### PR TITLE
Keep active SSE bodies in shutdown drain tracking

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1053",
+  "version": "0.1.1054",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/compat/http/response-lifecycle.ts
+++ b/src/platform/compat/http/response-lifecycle.ts
@@ -1,0 +1,67 @@
+/**
+ * Complete request lifecycle work when a response has actually finished.
+ * Non-streaming responses complete when their headers are ready, while SSE
+ * responses complete only after their body closes, errors, or is cancelled.
+ */
+
+export function isEventStreamResponse(response: Response): boolean {
+  if (!response.body) return false;
+
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  return contentType.split(";", 1)[0]?.trim() === "text/event-stream";
+}
+
+export function completeOnResponseBodySettlement(
+  response: Response,
+  onComplete: () => void,
+): Response {
+  if (!isEventStreamResponse(response)) {
+    onComplete();
+    return response;
+  }
+
+  let completed = false;
+  const complete = (): void => {
+    if (completed) return;
+    completed = true;
+    onComplete();
+  };
+
+  let reader: ReadableStreamDefaultReader<Uint8Array>;
+  try {
+    reader = response.body!.getReader();
+  } catch (error) {
+    complete();
+    throw error;
+  }
+
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          complete();
+          controller.close();
+          return;
+        }
+        controller.enqueue(result.value);
+      } catch (error) {
+        complete();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        complete();
+      }
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}

--- a/src/proxy/main.test.ts
+++ b/src/proxy/main.test.ts
@@ -15,4 +15,23 @@ describe("proxy main request URL parsing", () => {
     assertStringIncludes(source, "getReplayableRequestBodies(req, maxRetries)");
     assertStringIncludes(source, "body: upstreamBodies[attempt] ?? null");
   });
+
+  it("drains tracked responses before closing the proxy server", async () => {
+    const source = await Deno.readTextFile(new URL("./main.ts", import.meta.url));
+
+    assertStringIncludes(source, "if (shuttingDown) return createProxyDrainingResponse()");
+    assertStringIncludes(
+      source,
+      "proxyRequestDrainTracker.start(requestId, req.method, url.pathname)",
+    );
+    assertStringIncludes(
+      source,
+      "proxyRequestDrainTracker.completeOnResponseEnd(requestId, response)",
+    );
+
+    const drainIndex = source.indexOf("await proxyRequestDrainTracker.waitForDrain");
+    const closeIndex = source.indexOf("await closeProxyServerWithin");
+    assertEquals(drainIndex >= 0, true);
+    assertEquals(closeIndex > drainIndex, true);
+  });
 });

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -18,6 +18,7 @@
  * - VERYFRONT_API_INTERNAL_URL: API URL for internal endpoints (falls back to VERYFRONT_PROXY_API_BASE_URL)
  * - VERYFRONT_API_INTERNAL_USER: Basic auth user for internal API
  * - VERYFRONT_API_INTERNAL_PASS: Basic auth pass for internal API
+ * - SHUTDOWN_DRAIN_TIMEOUT_MS: Time to wait for active SSE responses during shutdown
  */
 
 import { createProxyHandler, INTERNAL_PROXY_HEADERS, type ProxyConfig } from "./handler.ts";
@@ -71,6 +72,12 @@ import {
   withProxyServerTimingHeader,
 } from "./server-timing.ts";
 import { removeStickyCookieFromPublicCacheableResponse } from "./response-headers.ts";
+import {
+  closeProxyServerWithin,
+  createProxyDrainingResponse,
+  parseProxyDrainTimeoutMs,
+  ProxyRequestDrainTracker,
+} from "./request-drain.ts";
 
 type AuthJwtExtensionModule = {
   createAuthProvider: (options?: Record<string, unknown>) => AuthProvider;
@@ -137,6 +144,8 @@ const { hostname: HOST, port: PORT } = resolveProxyBinding();
 const WS_CONNECT_TIMEOUT_MS = 30_000;
 // Timeout for forwarding requests to production server (SSR can take time on cold start)
 const DEFAULT_SERVER_REQUEST_TIMEOUT_MS = 90_000;
+const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
+const PROXY_SERVER_CLOSE_TIMEOUT_MS = 1_000;
 const VERYFRONT_SERVER_REQUEST_TIMEOUT_MS = parseInt(
   getEnv("VERYFRONT_SERVER_REQUEST_TIMEOUT_MS") || String(DEFAULT_SERVER_REQUEST_TIMEOUT_MS),
 );
@@ -149,6 +158,12 @@ const VERYFRONT_SERVER_RETRY_COUNT = parseInt(
 const VERYFRONT_SERVER_RETRY_DELAY_MS = parseInt(
   getEnv("VERYFRONT_SERVER_RETRY_DELAY_MS") || String(DEFAULT_SERVER_RETRY_DELAY_MS),
 );
+const SHUTDOWN_DRAIN_TIMEOUT_MS = parseProxyDrainTimeoutMs(
+  getEnv("SHUTDOWN_DRAIN_TIMEOUT_MS"),
+  DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS,
+);
+const proxyRequestDrainTracker = new ProxyRequestDrainTracker();
+let shuttingDown = false;
 
 const { createAuthProvider } = await importFirstPartyExtensionModule<AuthJwtExtensionModule>(
   "ext-auth-jwt",
@@ -645,49 +660,82 @@ async function handleApiProxy(req: Request, url: URL): Promise<Response> {
 /**
  * Main router.
  */
-function router(req: Request): Promise<Response> {
+async function router(req: Request): Promise<Response> {
   const url = new URL(req.url);
 
-  if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
-    return handleWebSocketUpgrade(req, url);
+  if (url.pathname === "/_proxy/health") {
+    return Response.json({ service: "veryfront-proxy", status: "ok" });
   }
+  if (shuttingDown) return createProxyDrainingResponse();
 
-  switch (url.pathname) {
-    case "/_proxy/stats":
-      if (Object.keys(proxyHandler.localProjects).length === 0) {
-        return Promise.resolve(new Response("Forbidden", { status: 403 }));
-      }
-      return handleStats();
-    case "/_proxy/health":
-      return Promise.resolve(
-        Response.json({ service: "veryfront-proxy", status: "ok" }),
-      );
+  const requestId = crypto.randomUUID();
+  proxyRequestDrainTracker.start(requestId, req.method, url.pathname);
+
+  try {
+    let response: Response;
+    if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+      response = await handleWebSocketUpgrade(req, url);
+    } else if (url.pathname === "/_proxy/stats") {
+      response = Object.keys(proxyHandler.localProjects).length === 0
+        ? new Response("Forbidden", { status: 403 })
+        : await handleStats();
+    } else if (url.pathname.startsWith("/_vf/api/")) {
+      response = await handleApiProxy(req, url);
+    } else if (isReleaseAssetPath(url.pathname)) {
+      response = await handleReleaseAssetRequest(url, { apiBaseUrl: config.apiBaseUrl }) ??
+        await forwardToServer(req, url);
+    } else {
+      response = await forwardToServer(req, url);
+    }
+
+    return proxyRequestDrainTracker.completeOnResponseEnd(requestId, response);
+  } catch (error) {
+    proxyRequestDrainTracker.complete(requestId);
+    throw error;
   }
-
-  if (url.pathname.startsWith("/_vf/api/")) return handleApiProxy(req, url);
-
-  if (isReleaseAssetPath(url.pathname)) {
-    return handleReleaseAssetRequest(url, { apiBaseUrl: config.apiBaseUrl }).then((res) =>
-      res ?? forwardToServer(req, url)
-    );
-  }
-
-  return forwardToServer(req, url);
 }
 
 // Create server before signal registration so early SIGTERM/SIGINT can close it safely.
 const server = createHttpServer();
 
 // Graceful shutdown
-let shuttingDown = false;
 async function shutdown(signal: "SIGINT" | "SIGTERM"): Promise<void> {
   if (shuttingDown) return;
   shuttingDown = true;
 
-  proxyLogger.info(`Received ${signal}, shutting down`);
+  proxyLogger.info(`Received ${signal}, initiating graceful shutdown`, {
+    inFlightRequests: proxyRequestDrainTracker.getInFlightCount(),
+    drainTimeoutMs: SHUTDOWN_DRAIN_TIMEOUT_MS,
+  });
 
   try {
-    await server.close();
+    const drained = await proxyRequestDrainTracker.waitForDrain(SHUTDOWN_DRAIN_TIMEOUT_MS);
+    if (!drained) {
+      const now = performance.now();
+      proxyLogger.warn("Proxy drain timeout exceeded, forcing shutdown", {
+        remainingRequests: proxyRequestDrainTracker.getInFlightRequests().slice(0, 10).map(
+          ({ requestId, method, path, startTime }) => ({
+            requestId,
+            method,
+            path,
+            elapsedMs: Math.round(now - startTime),
+          }),
+        ),
+      });
+    }
+
+    const closed = await closeProxyServerWithin(
+      () => server.close(),
+      PROXY_SERVER_CLOSE_TIMEOUT_MS,
+    );
+    if (!closed) {
+      proxyLogger.warn(
+        "Proxy server close timed out; process exit will close remaining connections",
+        {
+          closeTimeoutMs: PROXY_SERVER_CLOSE_TIMEOUT_MS,
+        },
+      );
+    }
     rendererRouter?.close();
     serverResolver.close();
     await proxyHandler.close();

--- a/src/proxy/request-drain.test.ts
+++ b/src/proxy/request-drain.test.ts
@@ -1,0 +1,122 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  closeProxyServerWithin,
+  createProxyDrainingResponse,
+  parseProxyDrainTimeoutMs,
+  ProxyRequestDrainTracker,
+} from "./request-drain.ts";
+
+describe("proxy request drain", () => {
+  it("completes non-streaming responses when headers are ready", () => {
+    const tracker = new ProxyRequestDrainTracker();
+    tracker.start("request-1", "GET", "/health");
+
+    const response = tracker.completeOnResponseEnd(
+      "request-1",
+      new Response("ok", { status: 200 }),
+    );
+
+    assertEquals(response.status, 200);
+    assertEquals(tracker.getInFlightCount(), 0);
+  });
+
+  it("keeps event streams in flight until the response body closes", async () => {
+    const tracker = new ProxyRequestDrainTracker();
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const source = new ReadableStream<Uint8Array>({
+      start(value) {
+        controller = value;
+      },
+    });
+
+    tracker.start("request-2", "POST", "/api/control-plane/runs/test/stream");
+    const response = tracker.completeOnResponseEnd(
+      "request-2",
+      new Response(source, {
+        status: 202,
+        statusText: "Streaming",
+        headers: {
+          "content-type": "text/event-stream; charset=utf-8",
+          "x-stream-id": "stream-1",
+        },
+      }),
+    );
+
+    assertEquals(tracker.getInFlightCount(), 1);
+    assertEquals(response.status, 202);
+    assertEquals(response.statusText, "Streaming");
+    assertEquals(response.headers.get("x-stream-id"), "stream-1");
+
+    const reader = response.body!.getReader();
+    const firstRead = reader.read();
+    controller!.enqueue(new TextEncoder().encode("data: ready\n\n"));
+    await firstRead;
+    assertEquals(tracker.getInFlightCount(), 1);
+
+    controller!.close();
+    await reader.read();
+    assertEquals(tracker.getInFlightCount(), 0);
+  });
+
+  it("waits for an active event stream to drain", async () => {
+    const tracker = new ProxyRequestDrainTracker();
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const source = new ReadableStream<Uint8Array>({
+      start(value) {
+        controller = value;
+      },
+    });
+
+    tracker.start("request-3", "POST", "/stream");
+    const response = tracker.completeOnResponseEnd(
+      "request-3",
+      new Response(source, { headers: { "content-type": "text/event-stream" } }),
+    );
+    const reader = response.body!.getReader();
+    const read = reader.read();
+    const drain = tracker.waitForDrain(250, 5);
+
+    setTimeout(() => controller!.close(), 10);
+
+    assertEquals((await read).done, true);
+    assertEquals(await drain, true);
+    assertEquals(tracker.getInFlightCount(), 0);
+  });
+
+  it("reports the requests that remain after the drain timeout", async () => {
+    const tracker = new ProxyRequestDrainTracker();
+    const source = new ReadableStream<Uint8Array>();
+
+    tracker.start("request-4", "POST", "/stream");
+    const response = tracker.completeOnResponseEnd(
+      "request-4",
+      new Response(source, { headers: { "content-type": "text/event-stream" } }),
+    );
+
+    assertEquals(await tracker.waitForDrain(10, 2), false);
+    assertEquals(tracker.getInFlightRequests().map(({ requestId }) => requestId), ["request-4"]);
+
+    await response.body!.cancel("test cleanup");
+    assertEquals(tracker.getInFlightCount(), 0);
+  });
+
+  it("uses a safe default for invalid drain timeout values", () => {
+    assertEquals(parseProxyDrainTimeoutMs("290000", 25_000), 290_000);
+    assertEquals(parseProxyDrainTimeoutMs("invalid", 25_000), 25_000);
+    assertEquals(parseProxyDrainTimeoutMs("-1", 25_000), 25_000);
+  });
+
+  it("returns a retryable connection-closing response while draining", () => {
+    const response = createProxyDrainingResponse();
+
+    assertEquals(response.status, 503);
+    assertEquals(response.headers.get("connection"), "close");
+    assertEquals(response.headers.get("retry-after"), "1");
+  });
+
+  it("bounds server close when an adapter keeps waiting on open connections", async () => {
+    assertEquals(await closeProxyServerWithin(() => new Promise(() => {}), 5), false);
+    assertEquals(await closeProxyServerWithin(() => Promise.resolve(), 50), true);
+  });
+});

--- a/src/proxy/request-drain.ts
+++ b/src/proxy/request-drain.ts
@@ -1,0 +1,87 @@
+import { completeOnResponseBodySettlement } from "#veryfront/platform/compat/http/response-lifecycle.ts";
+
+export interface TrackedProxyRequest {
+  requestId: string;
+  method: string;
+  path: string;
+  startTime: number;
+}
+
+export class ProxyRequestDrainTracker {
+  private readonly inFlight = new Map<string, TrackedProxyRequest>();
+
+  start(requestId: string, method: string, path: string): void {
+    this.inFlight.set(requestId, {
+      requestId,
+      method,
+      path,
+      startTime: performance.now(),
+    });
+  }
+
+  complete(requestId: string): void {
+    this.inFlight.delete(requestId);
+  }
+
+  completeOnResponseEnd(requestId: string, response: Response): Response {
+    return completeOnResponseBodySettlement(response, () => this.complete(requestId));
+  }
+
+  getInFlightCount(): number {
+    return this.inFlight.size;
+  }
+
+  getInFlightRequests(): TrackedProxyRequest[] {
+    return Array.from(this.inFlight.values(), (request) => ({ ...request }));
+  }
+
+  async waitForDrain(timeoutMs: number, pollIntervalMs = 100): Promise<boolean> {
+    if (this.inFlight.size === 0) return true;
+
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    const intervalMs = Math.max(1, pollIntervalMs);
+
+    while (this.inFlight.size > 0) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) return false;
+
+      await new Promise<void>((resolve) => setTimeout(resolve, Math.min(intervalMs, remainingMs)));
+    }
+
+    return true;
+  }
+}
+
+export function parseProxyDrainTimeoutMs(
+  rawValue: string | undefined,
+  defaultValue: number,
+): number {
+  const parsed = Number.parseInt(rawValue ?? "", 10);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : defaultValue;
+}
+
+export function createProxyDrainingResponse(): Response {
+  return new Response("Service Unavailable", {
+    status: 503,
+    headers: {
+      Connection: "close",
+      "Retry-After": "1",
+    },
+  });
+}
+
+export async function closeProxyServerWithin(
+  close: () => Promise<void>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<false>((resolve) => {
+    timeoutId = setTimeout(() => resolve(false), Math.max(0, timeoutMs));
+  });
+
+  try {
+    return await Promise.race([close().then(() => true as const), timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -84,6 +84,7 @@ import {
 } from "./tracing.ts";
 import {
   completeRequestTracking,
+  completeRequestTrackingOnResponseEnd,
   endContentMetrics,
   endRequestLifecycle,
   incrementRequestMetrics,
@@ -735,15 +736,14 @@ export function createVeryfrontHandler(
         });
 
         const isTimeout = response.status === HTTP_GATEWAY_TIMEOUT;
-        completeRequestTracking(
+        completeIsolatedRequest(headers.projectSlug, lifecycle.shouldCheckIsolation, isTimeout);
+
+        return completeRequestTrackingOnResponseEnd(
           lifecycle.requestId,
-          response.status,
+          withServerTimingHeader(response, requestProfileRecord),
           isTimeout,
           requestProfileRecord,
         );
-        completeIsolatedRequest(headers.projectSlug, lifecycle.shouldCheckIsolation, isTimeout);
-
-        return withServerTimingHeader(response, requestProfileRecord);
       } finally {
         endRequestLifecycle(lifecycle);
       }

--- a/src/server/runtime-handler/request-lifecycle.test.ts
+++ b/src/server/runtime-handler/request-lifecycle.test.ts
@@ -1,8 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   completeRequestTracking,
+  completeRequestTrackingOnResponseEnd,
   endContentMetrics,
   endRequestLifecycle,
   startContentMetrics,
@@ -74,6 +75,160 @@ describe("server/runtime-handler/request-lifecycle", () => {
     it("should handle timeout flag", () => {
       startRequestTracking("lifecycle-req-2", "slug", "/path", "GET", undefined, undefined);
       completeRequestTracking("lifecycle-req-2", 504, true);
+    });
+
+    it("should keep event streams in flight until their body closes", async () => {
+      const beforeCount = requestTracker.getInFlightCount();
+      let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const source = new ReadableStream<Uint8Array>({
+        start(value) {
+          controller = value;
+        },
+      });
+
+      startRequestTracking(
+        "lifecycle-stream-close",
+        "slug",
+        "/api/control-plane/runs/test/stream",
+        "POST",
+        "production",
+        "rel-1",
+      );
+      const response = completeRequestTrackingOnResponseEnd(
+        "lifecycle-stream-close",
+        new Response(source, {
+          status: 202,
+          statusText: "Streaming",
+          headers: {
+            "content-type": "text/event-stream",
+            "server-timing": "total;dur=12.00",
+            "x-stream-id": "stream-1",
+          },
+        }),
+        false,
+      );
+
+      assertEquals(requestTracker.getInFlightCount(), beforeCount + 1);
+      assertEquals(response.status, 202);
+      assertEquals(response.statusText, "Streaming");
+      assertEquals(response.headers.get("server-timing"), "total;dur=12.00");
+      assertEquals(response.headers.get("x-stream-id"), "stream-1");
+
+      const reader = response.body!.getReader();
+      const firstRead = reader.read();
+      controller!.enqueue(new TextEncoder().encode("data: test\n\n"));
+      await firstRead;
+      assertEquals(requestTracker.getInFlightCount(), beforeCount + 1);
+
+      controller!.close();
+      await reader.read();
+      assertEquals(requestTracker.getInFlightCount(), beforeCount);
+    });
+
+    it("should complete event stream tracking when the client cancels", async () => {
+      const beforeCount = requestTracker.getInFlightCount();
+      let sourceCancelled = false;
+      const source = new ReadableStream<Uint8Array>({
+        cancel() {
+          sourceCancelled = true;
+        },
+      });
+
+      startRequestTracking(
+        "lifecycle-stream-cancel",
+        "slug",
+        "/api/control-plane/runs/test/stream",
+        "POST",
+        "production",
+        "rel-1",
+      );
+      const response = completeRequestTrackingOnResponseEnd(
+        "lifecycle-stream-cancel",
+        new Response(source, { headers: { "content-type": "text/event-stream; charset=utf-8" } }),
+        false,
+      );
+
+      assertEquals(requestTracker.getInFlightCount(), beforeCount + 1);
+      await response.body!.cancel("client disconnected");
+      assertEquals(sourceCancelled, true);
+      assertEquals(requestTracker.getInFlightCount(), beforeCount);
+    });
+
+    it("should complete tracking once when cancellation races a pending read", async () => {
+      const beforeCount = requestTracker.getInFlightCount();
+      const beforeCompleted = requestTracker.getStats().completed;
+      const source = new ReadableStream<Uint8Array>();
+
+      startRequestTracking(
+        "lifecycle-stream-cancel-race",
+        "slug",
+        "/api/control-plane/runs/test/stream",
+        "POST",
+        "production",
+        "rel-1",
+      );
+      const response = completeRequestTrackingOnResponseEnd(
+        "lifecycle-stream-cancel-race",
+        new Response(source, { headers: { "content-type": "text/event-stream" } }),
+        false,
+      );
+
+      const reader = response.body!.getReader();
+      const pendingRead = reader.read();
+      await reader.cancel("client disconnected");
+      assertEquals((await pendingRead).done, true);
+      assertEquals(requestTracker.getInFlightCount(), beforeCount);
+      assertEquals(requestTracker.getStats().completed, beforeCompleted + 1);
+    });
+
+    it("should complete event stream tracking when the source errors", async () => {
+      const beforeCount = requestTracker.getInFlightCount();
+      let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const source = new ReadableStream<Uint8Array>({
+        start(value) {
+          controller = value;
+        },
+      });
+
+      startRequestTracking(
+        "lifecycle-stream-error",
+        "slug",
+        "/api/control-plane/runs/test/stream",
+        "POST",
+        "production",
+        "rel-1",
+      );
+      const response = completeRequestTrackingOnResponseEnd(
+        "lifecycle-stream-error",
+        new Response(source, { headers: { "content-type": "text/event-stream" } }),
+        false,
+      );
+
+      const read = response.body!.getReader().read();
+      controller!.error(new Error("stream failed"));
+      await assertRejects(() => read, Error, "stream failed");
+      assertEquals(requestTracker.getInFlightCount(), beforeCount);
+    });
+
+    it("should complete non-streaming responses immediately", () => {
+      const beforeCount = requestTracker.getInFlightCount();
+      startRequestTracking(
+        "lifecycle-response",
+        "slug",
+        "/api/health",
+        "GET",
+        "production",
+        "rel-1",
+      );
+
+      const response = completeRequestTrackingOnResponseEnd(
+        "lifecycle-response",
+        new Response("ok", { status: 200 }),
+        false,
+      );
+
+      assertEquals(response.status, 200);
+      assertEquals(requestTracker.getInFlightCount(), beforeCount);
     });
   });
 

--- a/src/server/runtime-handler/request-lifecycle.ts
+++ b/src/server/runtime-handler/request-lifecycle.ts
@@ -112,6 +112,69 @@ export function completeRequestTracking(
   requestTracker.complete(requestId, status, isTimeout, profile);
 }
 
+function isEventStreamResponse(response: Response): boolean {
+  if (!response.body) return false;
+
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  return contentType.split(";", 1)[0]?.trim() === "text/event-stream";
+}
+
+/**
+ * Keep streaming responses in the shutdown drain set until their body settles.
+ * Handler completion only means response headers are ready; an SSE body may
+ * continue producing events for several minutes after that point.
+ */
+export function completeRequestTrackingOnResponseEnd(
+  requestId: string,
+  response: Response,
+  isTimeout: boolean,
+  profile?: RequestProfileRecord | null,
+): Response {
+  if (!isEventStreamResponse(response)) {
+    completeRequestTracking(requestId, response.status, isTimeout, profile);
+    return response;
+  }
+
+  requestTracker.markLongLived(requestId);
+  const reader = response.body!.getReader();
+  let completed = false;
+  const complete = (): void => {
+    if (completed) return;
+    completed = true;
+    completeRequestTracking(requestId, response.status, isTimeout, profile);
+  };
+
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          complete();
+          controller.close();
+          return;
+        }
+        controller.enqueue(result.value);
+      } catch (error) {
+        complete();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        complete();
+      }
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 /**
  * End request lifecycle tracking.
  */

--- a/src/server/runtime-handler/request-lifecycle.ts
+++ b/src/server/runtime-handler/request-lifecycle.ts
@@ -22,6 +22,10 @@ import {
 import { requestTracker } from "./request-tracker.ts";
 import { generateRequestId } from "#veryfront/utils/request-id.ts";
 import type { RequestProfileRecord } from "#veryfront/observability/request-profiler.ts";
+import {
+  completeOnResponseBodySettlement,
+  isEventStreamResponse,
+} from "#veryfront/platform/compat/http/response-lifecycle.ts";
 
 interface RequestLifecycleContext {
   /** Request ID for tracking */
@@ -112,13 +116,6 @@ export function completeRequestTracking(
   requestTracker.complete(requestId, status, isTimeout, profile);
 }
 
-function isEventStreamResponse(response: Response): boolean {
-  if (!response.body) return false;
-
-  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-  return contentType.split(";", 1)[0]?.trim() === "text/event-stream";
-}
-
 /**
  * Keep streaming responses in the shutdown drain set until their body settles.
  * Handler completion only means response headers are ready; an SSE body may
@@ -136,42 +133,8 @@ export function completeRequestTrackingOnResponseEnd(
   }
 
   requestTracker.markLongLived(requestId);
-  const reader = response.body!.getReader();
-  let completed = false;
-  const complete = (): void => {
-    if (completed) return;
-    completed = true;
+  return completeOnResponseBodySettlement(response, () => {
     completeRequestTracking(requestId, response.status, isTimeout, profile);
-  };
-
-  const body = new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      try {
-        const result = await reader.read();
-        if (result.done) {
-          complete();
-          controller.close();
-          return;
-        }
-        controller.enqueue(result.value);
-      } catch (error) {
-        complete();
-        controller.error(error);
-      }
-    },
-    async cancel(reason) {
-      try {
-        await reader.cancel(reason);
-      } finally {
-        complete();
-      }
-    },
-  });
-
-  return new Response(body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
   });
 }
 

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -275,5 +275,26 @@ describe("server/runtime-handler/request-tracker", () => {
         globalThis.clearTimeout = originalClearTimeout;
       }
     });
+
+    it("should stop slow-request timers without completing a long-lived request", () => {
+      const clearedTimers: ReturnType<typeof setTimeout>[] = [];
+      const originalClearTimeout = globalThis.clearTimeout;
+      globalThis.clearTimeout = ((id?: ReturnType<typeof setTimeout>) => {
+        if (id !== undefined) clearedTimers.push(id);
+        originalClearTimeout(id);
+      }) as typeof clearTimeout;
+
+      try {
+        const beforeCount = requestTracker.getInFlightCount();
+        requestTracker.start("req-stream", "proj", "/stream", "POST");
+        requestTracker.markLongLived("req-stream");
+
+        assertEquals(clearedTimers.length, 1);
+        assertEquals(requestTracker.getInFlightCount(), beforeCount + 1);
+        requestTracker.complete("req-stream", 200);
+      } finally {
+        globalThis.clearTimeout = originalClearTimeout;
+      }
+    });
   });
 });

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -218,6 +218,20 @@ class RequestTracker {
     logger.info(`${tracked.method} ${tracked.path} ${statusCode}`, logContext);
   }
 
+  markLongLived(requestId: string): void {
+    const tracked = this.inFlight.get(requestId);
+    if (!tracked) return;
+
+    if (tracked.slowTimer) {
+      clearTimeout(tracked.slowTimer);
+      delete tracked.slowTimer;
+    }
+    if (tracked.verySlowTimer) {
+      clearTimeout(tracked.verySlowTimer);
+      delete tracked.verySlowTimer;
+    }
+  }
+
   getInFlightCount(): number {
     return this.inFlight.size;
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1053";
+export const VERSION = "0.1.1054";


### PR DESCRIPTION
## Summary

- keep SSE requests in the renderer shutdown drain set until body EOF, cancellation, or error
- make split proxy mode consume SHUTDOWN_DRAIN_TIMEOUT_MS and wait for active SSE bodies before exit
- reject new non-health proxy traffic with a retryable 503 while an instance drains
- preserve response status, status text, headers, and stream backpressure through a shared response-settlement helper
- bound HTTP adapter close so the configured drain remains a hard shutdown ceiling
- retain immediate completion behavior for non-streaming responses
- publish the immutable framework correction as 0.1.1054

## Root cause

The rollout acceptance run exposed three independent layers:

1. the proxy deployment had a 30-second termination window; fixed by veryfront/veryfront-server#240
2. the renderer request tracker completed when a handler returned response headers, not when an SSE body settled; fixed here
3. split proxy mode had its own shutdown path, did not read SHUTDOWN_DRAIN_TIMEOUT_MS, and exited without tracking proxied SSE bodies; fixed here

The merged server chart now provides a 290-second proxy and renderer drain inside a 300-second Kubernetes grace period. This framework change makes both processes consume that lifecycle correctly.

## Verification

- repository pre-push gate: passed
- full typecheck and generated-manifest checks: passed
- unit suite: 2,377 passed / 20,148 steps / 0 failed
- focused proxy and runtime lifecycle suites: 70 steps passed
- stream EOF, cancellation, error, cancellation race, timeout, response metadata, and bounded adapter-close cases: passed
- version parity and stable-release detection: passed
- 0.1.1054 registry slot: available
- format, lint, and diff checks: passed
- independent code review: approved with no remaining findings

## Rollout gate

After merge, verify the 0.1.1054 release and build one immutable server artifact containing this change plus server veryfront/veryfront-studio#240. Run an in-flight stream rollout test in staging before production promotion. Keep veryfront/veryfront-api#4028 open until the production acceptance run survives the rollout without a terminal stream error.

Related: veryfront/veryfront-api#4028