### PR TITLE
fix(server): drain active streams before production shutdown

### DIFF
--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -1,4 +1,5 @@
 import { cwd } from "veryfront/platform";
+import { gracefullyShutdownProductionServer } from "veryfront/server";
 import { cliLogger } from "#cli/utils";
 import { exitProcess, registerTerminationSignals, showLogo } from "#cli/utils";
 import { generateDefaultProjectId } from "../../utils/project.ts";
@@ -88,10 +89,13 @@ async function runProductionServer(options: ServeOptions): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
 
-    cliLogger.info(`Received ${signal}, shutting down production server...`);
     try {
-      shutdownController.abort();
-      await server.stop();
+      await gracefullyShutdownProductionServer({
+        signal,
+        abort: () => shutdownController.abort(),
+        stop: server.stop,
+        logger: cliLogger,
+      });
     } catch (error) {
       cliLogger.warn("Error while shutting down production server:", error);
     } finally {
@@ -99,9 +103,7 @@ async function runProductionServer(options: ServeOptions): Promise<void> {
     }
   };
 
-  registerTerminationSignals((signal) => {
-    void shutdown(signal);
-  });
+  registerTerminationSignals(shutdown);
 
   await new Promise(() => {});
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1054",
+  "version": "0.1.1055",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/api-reference/veryfront/server.md
+++ b/docs/api-reference/veryfront/server.md
@@ -10,6 +10,7 @@ order: 28
 import {
   createHandler,
   createVeryfrontServer,
+  gracefullyShutdownProductionServer,
   startDevServer,
   startNodeVeryfrontServer,
   startProductionServer,
@@ -48,6 +49,7 @@ await server.fetch(new Request("https://example.com/health"));
 |------|-------------|--------|
 | `createHandler` | Create a Veryfront request handler for development or production. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L191) |
 | `createVeryfrontServer` | Create veryfront server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L148) |
+| `gracefullyShutdownProductionServer` | Run the one-shot process shutdown lifecycle, draining tracked requests and SSE response bodies before bounded cleanup. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/graceful-shutdown.ts#L218) |
 | `startDevServer` | Starts dev server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/dev-server/index.ts#L14) |
 | `startNodeVeryfrontServer` | Starts node veryfront server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L558) |
 | `startProductionServer` | Starts production server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/production-server.ts#L166) |
@@ -71,6 +73,7 @@ await server.fetch(new Request("https://example.com/health"));
 | `DevServerOptions` | Options accepted by dev server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/dev-server/types.ts#L1) |
 | `DiscoveryOptions` | Configuration for AI primitives discovery during server startup | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/production-server.ts#L115) |
 | `FileWatcherMetrics` | Public API contract for file watcher metrics. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/dev-server/types.ts#L32) |
+| `GracefulProductionShutdownOptions` | Inputs required to drain and stop a production server process. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/graceful-shutdown.ts#L25) |
 | `NodeVeryfrontServiceServer` | Public API contract for node veryfront service server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L74) |
 | `RouteDirectory` | Public API contract for route directory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/dev-server/types.ts#L26) |
 | `ServerHandle` | Public API contract for server handle. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/production-server.ts#L152) |

--- a/src/server/graceful-shutdown.test.ts
+++ b/src/server/graceful-shutdown.test.ts
@@ -1,0 +1,158 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS,
+  gracefullyShutdownProductionServerWithDependencies,
+  parseShutdownDrainTimeoutMs,
+} from "./graceful-shutdown.ts";
+
+describe("server/graceful-shutdown", () => {
+  it("parses a configured drain timeout and rejects invalid values", () => {
+    assertEquals(parseShutdownDrainTimeoutMs("290000"), 290_000);
+    assertEquals(parseShutdownDrainTimeoutMs("0"), 0);
+    assertEquals(parseShutdownDrainTimeoutMs(""), DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS);
+    assertEquals(parseShutdownDrainTimeoutMs("   "), DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS);
+    assertEquals(parseShutdownDrainTimeoutMs("invalid"), DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS);
+    assertEquals(parseShutdownDrainTimeoutMs("-1"), DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS);
+  });
+
+  it("enters lame-duck mode and drains before stopping the server", async () => {
+    const events: string[] = [];
+
+    const drained = await gracefullyShutdownProductionServerWithDependencies({
+      signal: "SIGTERM",
+      drainTimeoutMs: 290_000,
+      abort: () => events.push("abort"),
+      dispose: () => {
+        events.push("dispose");
+      },
+      stop: () => {
+        events.push("stop");
+        return Promise.resolve();
+      },
+      logger: {
+        info: (message) => events.push(`info:${message}`),
+        warn: (message) => events.push(`warn:${message}`),
+      },
+    }, {
+      markServerShuttingDown: () => events.push("lame-duck"),
+      setServerInitialized: (ready) => events.push(`ready:${ready}`),
+      requestTracker: {
+        getInFlightCount: () => 1,
+        waitForDrain: (timeoutMs) => {
+          events.push(`drain:${timeoutMs}`);
+          return Promise.resolve(true);
+        },
+        shutdown: () => events.push("tracker-shutdown"),
+      },
+      shutdownTelemetry: () => {
+        events.push("telemetry-shutdown");
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(drained, true);
+    assertEquals(events, [
+      "info:Received SIGTERM, initiating graceful shutdown...",
+      "lame-duck",
+      "ready:false",
+      "info:Server marked as not ready, waiting for in-flight requests to drain...",
+      "drain:290000",
+      "tracker-shutdown",
+      "dispose",
+      "abort",
+      "stop",
+      "telemetry-shutdown",
+      "info:Graceful shutdown complete",
+    ]);
+  });
+
+  it("continues shutdown after the drain timeout", async () => {
+    const events: string[] = [];
+
+    const drained = await gracefullyShutdownProductionServerWithDependencies({
+      signal: "SIGTERM",
+      drainTimeoutMs: 25_000,
+      abort: () => events.push("abort"),
+      stop: () => {
+        events.push("stop");
+        return Promise.resolve();
+      },
+      logger: {
+        info: () => {},
+        warn: (message) => events.push(`warn:${message}`),
+      },
+    }, {
+      markServerShuttingDown: () => {},
+      setServerInitialized: () => {},
+      requestTracker: {
+        getInFlightCount: () => 2,
+        waitForDrain: () => Promise.resolve(false),
+        shutdown: () => events.push("tracker-shutdown"),
+      },
+      shutdownTelemetry: () => {
+        events.push("telemetry-shutdown");
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(drained, false);
+    assertEquals(events, [
+      "warn:Drain timeout exceeded, forcing shutdown",
+      "tracker-shutdown",
+      "abort",
+      "stop",
+      "telemetry-shutdown",
+    ]);
+  });
+
+  it("bounds cleanup and still invokes every cleanup action", async () => {
+    const events: string[] = [];
+    const warnings: string[] = [];
+    const startedAt = Date.now();
+
+    await gracefullyShutdownProductionServerWithDependencies({
+      signal: "SIGTERM",
+      drainTimeoutMs: 25_000,
+      cleanupTimeoutMs: 20,
+      abort: () => events.push("abort"),
+      dispose: () => {
+        events.push("dispose");
+        return new Promise<void>(() => {});
+      },
+      stop: () => {
+        events.push("stop");
+        return Promise.resolve();
+      },
+      logger: {
+        info: () => {},
+        warn: (message) => warnings.push(message),
+      },
+    }, {
+      markServerShuttingDown: () => {},
+      setServerInitialized: () => {},
+      requestTracker: {
+        getInFlightCount: () => 0,
+        waitForDrain: () => Promise.resolve(true),
+        shutdown: () => events.push("tracker-shutdown"),
+      },
+      shutdownTelemetry: () => {
+        events.push("telemetry-shutdown");
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(Date.now() - startedAt < 500, true);
+    assertEquals(events, [
+      "tracker-shutdown",
+      "dispose",
+      "abort",
+      "stop",
+      "telemetry-shutdown",
+    ]);
+    assertEquals(
+      warnings.includes("Graceful shutdown cleanup deadline exceeded"),
+      true,
+    );
+  });
+});

--- a/src/server/graceful-shutdown.ts
+++ b/src/server/graceful-shutdown.ts
@@ -1,0 +1,222 @@
+import { shutdownOTLP } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { setServerInitialized } from "./handlers/monitoring/health.handler.ts";
+import { requestTracker } from "./runtime-handler/request-tracker.ts";
+import { markServerShuttingDown } from "./shutdown-state.ts";
+
+/** Default drain timeout leaves headroom under Kubernetes' default 30 second grace period. */
+export const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
+/** Cleanup timeout keeps total shutdown below the default 30 second grace period. */
+export const DEFAULT_SHUTDOWN_CLEANUP_TIMEOUT_MS = 4_000;
+
+interface GracefulShutdownRequestTracker {
+  getInFlightCount(): number;
+  waitForDrain(timeoutMs: number): Promise<boolean>;
+  shutdown(): void;
+}
+
+/**
+ * Inputs required to drain and stop a production server process.
+ *
+ * This lifecycle mutates process-wide readiness, shutdown, and request-tracking
+ * state. Use it once from the process signal handler, not for individual server
+ * instances or requests.
+ */
+export interface GracefulProductionShutdownOptions {
+  /** Operating-system signal that initiated shutdown. */
+  signal: "SIGINT" | "SIGTERM";
+  /** Maximum drain time. Defaults to SHUTDOWN_DRAIN_TIMEOUT_MS or 25 seconds. */
+  drainTimeoutMs?: number;
+  /** Total time allowed for cleanup after draining. Defaults to 4 seconds. */
+  cleanupTimeoutMs?: number;
+  /** Stops signal-aware background work before the HTTP server closes. */
+  abort: () => void;
+  /** Stops the production HTTP server. */
+  stop: () => Promise<void>;
+  /** Releases optional bootstrap resources before the server closes. */
+  dispose?: () => void | Promise<void>;
+  /** Logger used for shutdown progress and failures. */
+  logger: {
+    info(message: string, context?: Record<string, unknown>): void;
+    warn(message: string, context?: unknown): void;
+  };
+}
+
+type GracefulShutdownLogger = GracefulProductionShutdownOptions["logger"];
+
+interface GracefulProductionShutdownDependencies {
+  markServerShuttingDown: () => void;
+  setServerInitialized: (ready: boolean) => void;
+  requestTracker: GracefulShutdownRequestTracker;
+  shutdownTelemetry: () => Promise<void>;
+}
+
+const defaultDependencies: GracefulProductionShutdownDependencies = {
+  markServerShuttingDown,
+  setServerInitialized,
+  requestTracker,
+  shutdownTelemetry: shutdownOTLP,
+};
+
+export function parseShutdownDrainTimeoutMs(raw: string | undefined): number {
+  return parseShutdownTimeoutMs(raw, DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS);
+}
+
+export function parseShutdownCleanupTimeoutMs(raw: string | undefined): number {
+  return parseShutdownTimeoutMs(raw, DEFAULT_SHUTDOWN_CLEANUP_TIMEOUT_MS);
+}
+
+function parseShutdownTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function normalizeShutdownTimeoutMs(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  return Number.isInteger(value) && value >= 0 ? value : fallback;
+}
+
+async function runCleanupStep(
+  description: string,
+  action: () => void | Promise<void>,
+  logger: GracefulShutdownLogger,
+  cleanupDeadlineMs: number,
+): Promise<void> {
+  let result: void | Promise<void>;
+  try {
+    result = action();
+  } catch (error) {
+    logger.warn(`Failed to ${description} during graceful shutdown`, { error });
+    return;
+  }
+
+  if (!result || typeof (result as PromiseLike<void>).then !== "function") return;
+
+  const actionPromise = Promise.resolve(result);
+  const remainingMs = Math.max(0, cleanupDeadlineMs - Date.now());
+  if (remainingMs === 0) {
+    logger.warn("Graceful shutdown cleanup deadline exceeded", { step: description });
+    void actionPromise.catch((error) => {
+      logger.warn(`Failed to ${description} after cleanup deadline exceeded`, { error });
+    });
+    return;
+  }
+
+  type CleanupOutcome =
+    | { status: "completed" }
+    | { status: "failed"; error: unknown }
+    | { status: "timeout" };
+
+  let timeoutId: number | undefined;
+  const outcome = await Promise.race<CleanupOutcome>([
+    actionPromise.then(
+      () => ({ status: "completed" }),
+      (error) => ({ status: "failed", error }),
+    ),
+    new Promise<CleanupOutcome>((resolve) => {
+      timeoutId = setTimeout(() => resolve({ status: "timeout" }), remainingMs);
+    }),
+  ]);
+  if (timeoutId !== undefined) clearTimeout(timeoutId);
+
+  if (outcome.status === "failed") {
+    logger.warn(`Failed to ${description} during graceful shutdown`, { error: outcome.error });
+  } else if (outcome.status === "timeout") {
+    logger.warn("Graceful shutdown cleanup deadline exceeded", { step: description });
+  }
+}
+
+/**
+ * Stops new agent work, drains tracked requests and SSE response bodies, and then
+ * releases server resources.
+ */
+export async function gracefullyShutdownProductionServerWithDependencies(
+  options: GracefulProductionShutdownOptions,
+  dependencies: GracefulProductionShutdownDependencies,
+): Promise<boolean> {
+  const { logger } = options;
+  const drainTimeoutMs = normalizeShutdownTimeoutMs(
+    options.drainTimeoutMs,
+    parseShutdownDrainTimeoutMs(getEnv("SHUTDOWN_DRAIN_TIMEOUT_MS")),
+  );
+  const cleanupTimeoutMs = normalizeShutdownTimeoutMs(
+    options.cleanupTimeoutMs,
+    parseShutdownCleanupTimeoutMs(getEnv("SHUTDOWN_CLEANUP_TIMEOUT_MS")),
+  );
+
+  logger.info(`Received ${options.signal}, initiating graceful shutdown...`, {
+    inFlightRequests: dependencies.requestTracker.getInFlightCount(),
+    drainTimeoutMs,
+    cleanupTimeoutMs,
+  });
+
+  dependencies.markServerShuttingDown();
+  dependencies.setServerInitialized(false);
+  logger.info("Server marked as not ready, waiting for in-flight requests to drain...");
+
+  let drained = false;
+  try {
+    drained = await dependencies.requestTracker.waitForDrain(drainTimeoutMs);
+  } catch (error) {
+    logger.warn("Failed while waiting for in-flight requests to drain", { error });
+  }
+
+  if (!drained) {
+    logger.warn("Drain timeout exceeded, forcing shutdown", {
+      remainingRequests: dependencies.requestTracker.getInFlightCount(),
+    });
+  }
+
+  const cleanupDeadlineMs = Date.now() + cleanupTimeoutMs;
+  await runCleanupStep(
+    "stop request tracking",
+    () => dependencies.requestTracker.shutdown(),
+    logger,
+    cleanupDeadlineMs,
+  );
+  if (options.dispose) {
+    await runCleanupStep(
+      "dispose the production bootstrap",
+      options.dispose,
+      logger,
+      cleanupDeadlineMs,
+    );
+  }
+  await runCleanupStep(
+    "abort the production server",
+    options.abort,
+    logger,
+    cleanupDeadlineMs,
+  );
+  await runCleanupStep(
+    "stop the production server",
+    options.stop,
+    logger,
+    cleanupDeadlineMs,
+  );
+  await runCleanupStep(
+    "shut down telemetry",
+    dependencies.shutdownTelemetry,
+    logger,
+    cleanupDeadlineMs,
+  );
+
+  logger.info("Graceful shutdown complete");
+  return drained;
+}
+
+/**
+ * Enter lame-duck mode, mark readiness false, drain tracked requests and SSE
+ * response bodies, and stop a production server process.
+ *
+ * This is a one-shot, process-level lifecycle. Call it once from a SIGINT or
+ * SIGTERM handler. The function returns `true` when every tracked request drains
+ * before the timeout and `false` when cleanup continues after the timeout.
+ */
+export function gracefullyShutdownProductionServer(
+  options: GracefulProductionShutdownOptions,
+): Promise<boolean> {
+  return gracefullyShutdownProductionServerWithDependencies(options, defaultDependencies);
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -48,6 +48,10 @@ const DEFAULT_SERVER_PORT = 3_000;
 
 export { DevServer, startDevServer, startProductionServer };
 export {
+  gracefullyShutdownProductionServer,
+  type GracefulProductionShutdownOptions,
+} from "./graceful-shutdown.ts";
+export {
   createVeryfrontServer,
   type CreateVeryfrontServerOptions,
   type NodeVeryfrontServiceServer,

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -2,15 +2,10 @@ import { serverLogger as logger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { runtime } from "#veryfront/platform/adapters/detect.ts";
 import { createVeryfrontHandler } from "./runtime-handler/index.ts";
-import { requestTracker } from "./runtime-handler/request-tracker.ts";
 import { bootstrapProd, type BootstrapResult } from "./bootstrap.ts";
 import { cwd, onGlobalError, onSignal } from "#veryfront/platform/compat/process.ts";
 import { isDebugEnabled } from "#veryfront/utils/constants/env.ts";
-import {
-  initializeOTLPWithApis,
-  shutdownOTLP,
-  withSpan,
-} from "#veryfront/observability/tracing/otlp-setup.ts";
+import { initializeOTLPWithApis, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import {
   startConfiguredMemoryMonitoring,
   stopMemoryMonitoring,
@@ -26,7 +21,10 @@ import {
 } from "#veryfront/html/styles-builder/css-pregeneration.ts";
 import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import { setServerInitialized } from "./handlers/monitoring/health.handler.ts";
-import { markServerShuttingDown } from "./shutdown-state.ts";
+import {
+  gracefullyShutdownProductionServer,
+  parseShutdownDrainTimeoutMs,
+} from "./graceful-shutdown.ts";
 import {
   enableSSRClientOnlyFetching,
   enableSSRFetchInterception,
@@ -36,10 +34,6 @@ import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 
 const serverLog = logger.component("server");
 const globalLog = logger.component("global");
-
-/** Default time to wait for in-flight requests to drain during shutdown.
- *  K8s default terminationGracePeriodSeconds is 30s, so 25s leaves headroom. */
-const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
 
 /** Default port when PORT / VERYFRONT_PORT env vars are not set */
 const DEFAULT_SERVER_PORT = 3_000;
@@ -411,9 +405,8 @@ if (import.meta.main) {
 
     // Graceful shutdown for direct CLI execution (e.g., deno run)
     // Default drain timeout: 25 seconds (K8s default terminationGracePeriodSeconds is 30)
-    const drainTimeoutMs = parseInt(
-      adapter.env.get("SHUTDOWN_DRAIN_TIMEOUT_MS") ?? String(DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS),
-      10,
+    const drainTimeoutMs = parseShutdownDrainTimeoutMs(
+      adapter.env.get("SHUTDOWN_DRAIN_TIMEOUT_MS"),
     );
 
     let shuttingDown = false;
@@ -421,40 +414,14 @@ if (import.meta.main) {
       if (shuttingDown) return;
       shuttingDown = true;
 
-      logger.info(`Received ${signal}, initiating graceful shutdown...`, {
-        inFlightRequests: requestTracker.getInFlightCount(),
+      await gracefullyShutdownProductionServer({
+        signal,
         drainTimeoutMs,
+        abort: () => shutdownController.abort(),
+        dispose: bootstrap.dispose,
+        stop: server.stop,
+        logger,
       });
-
-      // Phase 1: Enter lame-duck mode. markServerShuttingDown() makes the
-      // agent-work handlers reject NEW requests with 503 (before any side
-      // effects) so the API can retry against another instance, even while the
-      // pod IP is still directly reachable. setServerInitialized(false) flips
-      // /readyz to not-ready so K8s stops routing Service traffic.
-      markServerShuttingDown();
-      setServerInitialized(false);
-      logger.info("Server marked as not ready, waiting for in-flight requests to drain...");
-
-      try {
-        // Phase 2: Wait for in-flight requests to complete (graceful drain)
-        const drained = await requestTracker.waitForDrain(drainTimeoutMs);
-        if (!drained) {
-          logger.warn("Drain timeout exceeded, forcing shutdown", {
-            remainingRequests: requestTracker.getInFlightCount(),
-          });
-        }
-
-        // Phase 3: Stop accepting new connections and clean up
-        requestTracker.shutdown();
-        await bootstrap.dispose?.();
-        shutdownController.abort();
-        await server.stop();
-        await shutdownOTLP();
-
-        logger.info("Graceful shutdown complete");
-      } catch (error) {
-        logger.warn("Error while shutting down production server:", error);
-      }
     };
 
     const handleSignal = (signal: "SIGINT" | "SIGTERM"): void => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1054";
+export const VERSION = "0.1.1055";

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -587,6 +587,94 @@ export function GET() {
     });
   });
 
+  it("should drain an active SSE response before production serve exits on SIGTERM", async () => {
+    const projectDir = await createTestProject(
+      "sigterm-drain-test",
+      `
+export default function Home() {
+  return <div>Home Page</div>;
+}
+`,
+      {
+        "pages/api/events.ts": `
+const encoder = new TextEncoder();
+
+export function GET() {
+  return new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode("data: open\\n\\n"));
+      setTimeout(() => {
+        controller.enqueue(encoder.encode("data: complete\\n\\n"));
+        controller.close();
+      }, 1500);
+    },
+  }), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+`,
+      },
+    );
+
+    await withServer(projectDir, async (server) => {
+      const response = await fetch(`http://127.0.0.1:${server.port}/api/events`);
+      assertEquals(response.status, 200, "Should start the SSE response");
+
+      const reader = response.body?.getReader();
+      assert(reader, "Should expose the SSE response body");
+      const firstChunk = await reader.read();
+      assertEquals(firstChunk.done, false, "Should keep the SSE response open");
+
+      let processExited = false;
+      const statusPromise = server.process.status.then((status) => {
+        processExited = true;
+        return status;
+      });
+
+      server.process.kill("SIGTERM");
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      assertEquals(
+        processExited,
+        false,
+        `Production serve exited before the active SSE response drained:\n${server.logs.join("")}`,
+      );
+
+      while (!(await reader.read()).done) {
+        // Consume the body so request tracking can observe stream completion.
+      }
+
+      const status = await Promise.race([
+        statusPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Production serve did not exit after SSE drain")),
+            10_000,
+          )
+        ),
+      ]);
+      assertEquals(status.success, true, "Production serve should exit successfully after drain");
+
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (server.logs.join("").includes("Graceful shutdown complete")) break;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+
+      const logs = server.logs.join("");
+      const receivedSignalIndex = logs.indexOf(
+        "Received SIGTERM, initiating graceful shutdown...",
+      );
+      const drainedIndex = logs.indexOf("All requests drained successfully");
+      const shutdownCompleteIndex = logs.indexOf("Graceful shutdown complete");
+
+      assert(receivedSignalIndex >= 0, `Should log SIGTERM handling:\n${logs}`);
+      assert(drainedIndex > receivedSignalIndex, `Should drain after SIGTERM:\n${logs}`);
+      assert(
+        shutdownCompleteIndex > drainedIndex,
+        `Should complete shutdown after the SSE response drains:\n${logs}`,
+      );
+    });
+  });
+
   it("should handle nested API routes", async () => {
     const projectDir = await createTestProject(
       "api-nested-test",


### PR DESCRIPTION
## Description

Use one bounded production shutdown lifecycle from both the CLI serve path and direct server execution. The lifecycle enters lame-duck mode, marks readiness false, drains tracked requests and SSE response bodies, and bounds all cleanup work before exit.

The regression test compiles the real CLI binary, opens an SSE response, sends SIGTERM, and verifies the process exits only after the response drains.

## Related Issue(s)

Related to https://github.com/veryfront/veryfront-api/issues/4028

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- Focused lifecycle suite: 5 files, 76 steps passed
- Compiled binary E2E: 59 steps passed, including active SSE SIGTERM drain
- Full pre-push formatting, lint, typecheck, and unit test hook passed
- API docs validation: 38 references, 63 guides, 693 links passed
- npm build and package metadata tests passed