### PR TITLE
Preserve request context in relative-fs esbuild plugin callbacks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1055",
+  "version": "0.1.1056",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/dev/files/esbuild-plugins.test.ts
+++ b/src/server/handlers/dev/files/esbuild-plugins.test.ts
@@ -3,6 +3,7 @@ import "#veryfront/transforms/plugins/__tests__/code-parser-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { asyncLocalStorage } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import {
   createBareExternalPlugin,
   createHttpExternalPlugin,
@@ -393,6 +394,66 @@ describe(
         assertEquals(errors.some(({ text }) => text.includes("symbolic link")), true);
         assertEquals(output.includes(marker), false);
       }
+    });
+
+    it("resolves project files when esbuild callbacks fire outside the request context", async () => {
+      const esbuild = await import("veryfront/extensions/bundler");
+      // Root the esbuild service's message pump OUTSIDE any request context,
+      // as on a warm server pod whose first build served another request.
+      // Plugin callbacks of later builds run on this contextless pump, so an
+      // AsyncLocalStorage-dependent adapter loses its store unless the plugin
+      // re-enters it (the documented contract of wrapWithCurrentContext).
+      await esbuild.build({
+        bundle: false,
+        write: false,
+        stdin: { contents: "1;", loader: "js" },
+      });
+
+      const files: Record<string, string> = {
+        "/project/app/dep.js": "export const value = 42;",
+      };
+      // Like MultiProjectFSAdapter, refuse to operate without the store.
+      const contextBoundAdapter = {
+        fs: {
+          stat: (path: string) => {
+            if (!asyncLocalStorage.getStore()) {
+              return Promise.reject(new Error("No request context available"));
+            }
+            return files[path]
+              ? Promise.resolve({ isFile: true, isDirectory: false, isSymlink: false })
+              : Promise.reject(new Error("not found"));
+          },
+          readFile: (path: string) => {
+            if (!asyncLocalStorage.getStore()) {
+              return Promise.reject(new Error("No request context available"));
+            }
+            return files[path] !== undefined
+              ? Promise.resolve(files[path])
+              : Promise.reject(new Error("not found"));
+          },
+        },
+      } as unknown as ReturnType<typeof createMockAdapter>;
+
+      const result = await asyncLocalStorage.run(
+        {} as NonNullable<ReturnType<typeof asyncLocalStorage.getStore>>,
+        () =>
+          esbuild.build({
+            bundle: true,
+            write: false,
+            format: "esm",
+            platform: "browser",
+            target: "es2020",
+            stdin: {
+              contents: 'import { value } from "./dep.js"; console.log(value);',
+              loader: "js",
+              sourcefile: "/project/app/page.js",
+              resolveDir: "/project/app",
+            },
+            plugins: [createRelativeFsPlugin("/project", contextBoundAdapter)],
+          }),
+      );
+
+      assertEquals(result.outputFiles?.[0]?.text.includes("42"), true);
     });
   },
 );

--- a/src/server/handlers/dev/files/esbuild-plugins.ts
+++ b/src/server/handlers/dev/files/esbuild-plugins.ts
@@ -2,6 +2,7 @@ import type { OnLoadArgs, OnResolveArgs, Plugin, PluginBuild } from "veryfront/e
 import { NETWORK_ERROR } from "#veryfront/errors";
 // Direct import from base.ts to avoid circular dependency through barrel
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { wrapWithCurrentContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import {
   getDirectory,
   isWithinDirectory,
@@ -126,71 +127,78 @@ export function createRelativeFsPlugin(
   return {
     name: "veryfront-rel-fs",
     setup(build: PluginBuild) {
-      build.onResolve({ filter: /^(\.?\.?\/|\/)\/*/ }, async (args: OnResolveArgs) => {
-        // VULN-FS-6: NUL bytes are never legitimate in module paths.
-        if (args.path.includes("\0")) {
-          return {
-            errors: [{ text: `Import path contains NUL byte: ${args.path}`, location: null }],
-          };
-        }
+      // esbuild invokes plugin callbacks from its child-process message pump,
+      // which does not inherit the caller's AsyncLocalStorage store. Re-enter
+      // the request context captured at plugin setup so context-scoped
+      // adapters (MultiProjectFSAdapter) can resolve the project.
+      build.onResolve(
+        { filter: /^(\.?\.?\/|\/)\/*/ },
+        wrapWithCurrentContext(async (args: OnResolveArgs) => {
+          // VULN-FS-6: NUL bytes are never legitimate in module paths.
+          if (args.path.includes("\0")) {
+            return {
+              errors: [{ text: `Import path contains NUL byte: ${args.path}`, location: null }],
+            };
+          }
 
-        const basedir = args.resolveDir ||
-          (args.importer ? getDirectory(args.importer) : projectDir);
-        // normalizePath collapses `./` and `foo/../` segments produced by
-        // `joinPath` so downstream `adapter.fs.stat` lookups match the file
-        // system's canonical key. Still inside the containment check below.
-        const candidate = normalizePath(
-          args.path.startsWith("/")
-            ? joinPath(projectDir, args.path)
-            : joinPath(basedir, args.path),
-        );
+          const basedir = args.resolveDir ||
+            (args.importer ? getDirectory(args.importer) : projectDir);
+          // normalizePath collapses `./` and `foo/../` segments produced by
+          // `joinPath` so downstream `adapter.fs.stat` lookups match the file
+          // system's canonical key. Still inside the containment check below.
+          const candidate = normalizePath(
+            args.path.startsWith("/")
+              ? joinPath(projectDir, args.path)
+              : joinPath(basedir, args.path),
+          );
 
-        // VULN-FS-6: refuse anything that, after joining, escapes the project
-        // root. esbuild plugins fire per-import; an entry file with
-        // `import "../../../../etc/hostname"` would otherwise embed the file.
-        if (!isWithinDirectory(projectDir, candidate)) {
-          return {
-            errors: [{
-              text: `Import escapes project directory: ${args.path}`,
-              location: null,
-            }],
-          };
-        }
+          // VULN-FS-6: refuse anything that, after joining, escapes the project
+          // root. esbuild plugins fire per-import; an entry file with
+          // `import "../../../../etc/hostname"` would otherwise embed the file.
+          if (!isWithinDirectory(projectDir, candidate)) {
+            return {
+              errors: [{
+                text: `Import escapes project directory: ${args.path}`,
+                location: null,
+              }],
+            };
+          }
 
-        const candidates: string[] = [candidate];
-        for (const ext of SCRIPT_EXTENSIONS) candidates.push(candidate + ext);
-        for (const ext of SCRIPT_EXTENSIONS) {
-          candidates.push(joinPath(candidate, `index${ext}`));
-        }
+          const candidates: string[] = [candidate];
+          for (const ext of SCRIPT_EXTENSIONS) candidates.push(candidate + ext);
+          for (const ext of SCRIPT_EXTENSIONS) {
+            candidates.push(joinPath(candidate, `index${ext}`));
+          }
 
-        for (const f of candidates) {
-          // Defence in depth: each extension probe must also stay inside.
-          if (!isWithinDirectory(projectDir, f)) continue;
-          try {
-            const st = await adapter.fs.stat(f);
-            if (st.isFile) {
-              if (options.enforceBrowserBoundaries) {
-                const pathStatus = await inspectBrowserModulePath(projectDir, f, adapter);
-                if (pathStatus !== "trusted") {
+          for (const f of candidates) {
+            // Defence in depth: each extension probe must also stay inside.
+            if (!isWithinDirectory(projectDir, f)) continue;
+            try {
+              const st = await adapter.fs.stat(f);
+              if (st.isFile) {
+                if (options.enforceBrowserBoundaries) {
+                  const pathStatus = await inspectBrowserModulePath(projectDir, f, adapter);
+                  if (pathStatus !== "trusted") {
+                    return {
+                      errors: [{ text: dependencyPathError(pathStatus), location: null }],
+                    };
+                  }
                   return {
-                    errors: [{ text: dependencyPathError(pathStatus), location: null }],
+                    path: getProjectModuleIdentity(projectDir, f),
+                    namespace: PROJECT_FS_NAMESPACE,
+                    pluginData: { absolutePath: f } satisfies ProjectFsPluginData,
                   };
                 }
-                return {
-                  path: getProjectModuleIdentity(projectDir, f),
-                  namespace: PROJECT_FS_NAMESPACE,
-                  pluginData: { absolutePath: f } satisfies ProjectFsPluginData,
-                };
+                return { path: f };
               }
-              return { path: f };
+            } catch (_) {
+              // expected: candidate path doesn't exist, try next
             }
-          } catch (_) {
-            // expected: candidate path doesn't exist, try next
           }
-        }
 
-        return undefined;
-      });
+          return undefined;
+        }),
+      );
 
       async function loadModule(
         filePath: string,
@@ -265,13 +273,16 @@ export function createRelativeFsPlugin(
         }
       }
 
-      build.onLoad({ filter: SCRIPT_PATH_PATTERN, namespace: "file" }, (args: OnLoadArgs) => {
-        return loadModule(args.path, false);
-      });
+      build.onLoad(
+        { filter: SCRIPT_PATH_PATTERN, namespace: "file" },
+        wrapWithCurrentContext((args: OnLoadArgs) => {
+          return loadModule(args.path, false);
+        }),
+      );
 
       build.onLoad(
         { filter: SCRIPT_PATH_PATTERN, namespace: PROJECT_FS_NAMESPACE },
-        (args: OnLoadArgs) => {
+        wrapWithCurrentContext((args: OnLoadArgs) => {
           const absolutePath = getProjectFsPluginPath(args);
           if (!absolutePath) {
             return {
@@ -279,7 +290,7 @@ export function createRelativeFsPlugin(
             };
           }
           return loadModule(absolutePath, true);
-        },
+        }),
       );
     },
   };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1055";
+export const VERSION = "0.1.1056";


### PR DESCRIPTION
## Problem — production hydration outage for multi-file client pages

esbuild invokes plugin callbacks from its child-process message pump, which inherits the AsyncLocalStorage context from wherever the esbuild service was **first spawned on that pod** — not from the build's caller. `createRelativeFsPlugin` resolves and loads project files through the request-scoped adapter without re-entering the caller's context, so in proxy mode (`MultiProjectFSAdapter`) every relative import fails with `"No request context available"` on any pod whose first-ever build belonged to a different request.

**Observed live on production (runtime 0.1.1053):** after refactoring `veryfront-planning`'s page into `app/components/*`, every `/_veryfront/rsc/module?rel=app/page.tsx` request 500ed with esbuild `Could not resolve "./components/…"` / `"./pricing"` for **all** relative imports; SSR was fine, hydration dead. A freshly-started debug pod (whose first build was the affected page, rooting the pump inside that request's context) served the identical request with the identical token — 200 with all 12 files bundled. Pod-cycling made results flip pod-by-pod. Full evidence chain in the repro: priming the esbuild service outside any context makes the failure deterministic in a unit test.

## Fix

Wrap the plugin's `onResolve` and both `onLoad` callbacks with `wrapWithCurrentContext` — the exact treatment `routing/api/module-loader/loader.ts` and `discovery/transpiler.ts` already apply, per that helper's own doc comment describing this esbuild pump behavior.

Version bumped to 0.1.1056.

## Verification

- New test reproduces the bug faithfully: primes the esbuild service outside any ALS context, then bundles with a store-requiring adapter inside `asyncLocalStorage.run` — RED before the fix (callbacks fire from `readFromStdout`, contextless), GREEN after.
- Full unit suite: 2,378 passed, 0 failed.

## Rollout note

After promotion, affected pods recover immediately (no cache poisoning — the failure was per-callback). This also likely explains historical "hydration randomly broken in proxy mode" reports predating multi-file pages, since `./pricing`-style single-file-adjacent imports hit the same path.