### PR TITLE
Keep local serve CSS links tied to component imports

### DIFF
--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -13,6 +13,7 @@ import {
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { FSAdapterWrapper } from "#veryfront/platform/adapters/fs/wrapper.ts";
+import { clearCSSCache, getCSSByHash } from "#veryfront/html/styles-builder/index.ts";
 import { HTMLGenerator, type HTMLGeneratorConfig } from "./html.ts";
 import { buildHeadElements, mergeFrontmatter } from "./html-head.ts";
 import { mergeImportedCSS } from "./html-imported-css.ts";
@@ -66,6 +67,7 @@ describe("HTMLGenerator helpers", () => {
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, originalDependencyFlag ?? "");
     configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
+    clearCSSCache();
   });
 
   describe("buildHeadElements", () => {
@@ -827,6 +829,50 @@ describe("HTMLGenerator helpers", () => {
       assertEquals(html.includes("/_veryfront/rsc/client.js"), true);
       assertEquals(html.includes("/_veryfront/hydration-runtime.js"), false);
       assertEquals(html.includes("/_veryfront/hydrate.js"), false);
+    });
+
+    it("rebuilds streamed full-document CSS after an initial empty import snapshot", async () => {
+      const mockAdapter = createMockAdapter(async (path: string) => {
+        if (path === "/project/globals.css") return '@import "tailwindcss";';
+        if (path === "/project/components/hero.css") {
+          return ".hero-banner { color: rgb(12 34 56); }";
+        }
+        return "";
+      });
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: mockAdapter as any,
+        config: {} as any,
+        mode: "production",
+      });
+      const context = createHTMLContext({
+        options: {
+          environment: "production",
+          projectSlug: "streamed-full-doc-css-import-test",
+        },
+      });
+      let cssImportReads = 0;
+      Object.defineProperty(context, "cssImports", {
+        configurable: true,
+        enumerable: true,
+        get() {
+          cssImportReads += 1;
+          return cssImportReads === 1 ? undefined : ["/project/components/hero.css"];
+        },
+      });
+      const stream = createSingleChunkStream(
+        '<!DOCTYPE html><html><head><title>Imported CSS</title></head><body><div class="hero-banner">Hero</div></body></html>',
+      );
+
+      const responseStream = await generator.generateHTMLStream(stream, context);
+      const html = await new Response(responseStream).text();
+
+      const cssHash = html.match(/\/_vf\/css\/([^"/]+)\.css/)?.[1];
+      assertExists(cssHash);
+      const css = getCSSByHash(cssHash);
+      assertExists(css);
+      assertStringIncludes(css, ".hero-banner");
+      assertStringIncludes(css, "rgb(12 34 56)");
     });
   });
 

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -174,17 +174,7 @@ export class HTMLGenerator {
   async generateFullHTML(context: HTMLGenerationContext): Promise<string> {
     let html: string;
     if (isFullHTMLDocument(context.html)) {
-      let projectCSSPromise: Promise<ProjectCSSResult> | undefined;
-      if (this.config.mode === "production" && context.options?.environment === "production") {
-        const mergedFrontmatter = mergeCollectedFrontmatter(context);
-        const htmlOptions = await profilePhase(
-          "html.build_options",
-          () => this.buildHTMLOptions(context, mergedFrontmatter),
-        );
-        projectCSSPromise = startProjectCSSPreparation(context, htmlOptions);
-      }
-
-      html = await this.handleFullHTMLDocument(context, projectCSSPromise);
+      html = await this.handleFullHTMLDocument(context);
     } else {
       html = await this.wrapHTMLFragment(context);
     }
@@ -207,9 +197,6 @@ export class HTMLGenerator {
       "html.build_options",
       () => this.buildHTMLOptions(fullContext, mergedFrontmatter),
     );
-    const projectCSSPromise = startProjectCSSPreparation(fullContext, htmlOptions);
-    startPreparedCSSWarmup(this.config, fullContext, htmlOptions);
-
     let reactContent: string;
     try {
       reactContent = (await streamToString(reactStream)).trim();
@@ -225,13 +212,10 @@ export class HTMLGenerator {
     if (isFullHTMLDocument(reactContent)) {
       const encoder = new TextEncoder();
       const fullHtml = addNonceToHtmlTags(
-        await this.handleFullHTMLDocument(
-          {
-            ...fullContext,
-            html: reactContent,
-          },
-          projectCSSPromise,
-        ),
+        await this.handleFullHTMLDocument({
+          ...fullContext,
+          html: reactContent,
+        }),
         context.options?.nonce,
       );
 
@@ -242,6 +226,9 @@ export class HTMLGenerator {
         },
       });
     }
+
+    const projectCSSPromise = startProjectCSSPreparation(fullContext, htmlOptions);
+    startPreparedCSSWarmup(this.config, fullContext, htmlOptions);
 
     const { start, end } = await profilePhase(
       "html.generate_shell_parts",
@@ -271,8 +258,13 @@ export class HTMLGenerator {
 
   private async handleFullHTMLDocument(
     context: HTMLGenerationContext,
-    projectCSSPromise?: Promise<ProjectCSSResult>,
   ): Promise<string> {
+    const mergedFrontmatter = mergeCollectedFrontmatter(context);
+    const htmlOptions = await profilePhase(
+      "html.build_options",
+      () => this.buildHTMLOptions(context, mergedFrontmatter),
+    );
+    const projectCSSPromise = startProjectCSSPreparation(context, htmlOptions);
     const metadata = extractHTMLMetadata(
       (context.pageInfo.entity.frontmatter || {}) as MDXFrontmatter,
       (context.layoutBundle?.frontmatter || {}) as MDXFrontmatter,


### PR DESCRIPTION
## Summary
- Fixes full-document production CSS preparation so it starts after imported component CSS is merged into HTML options.
- Prevents `veryfront serve` / production-local full documents from linking a Tailwind-only hash when component `cssImports` are present.
- Adds a regression test that extracts the emitted `/_vf/css/<hash>.css` link and proves the cached CSS includes imported component rules.

## Reproduction / root cause
Issue #2893 reported a local `veryfront serve` session degrading from a full compiled CSS asset to a Tailwind-only CSS hash mid-run.

Root cause found in the HTML orchestrator: full-document paths could start project CSS preparation before `buildHTMLOptions()` merged `context.cssImports`. The streaming path also started the stale project CSS promise before knowing whether streamed output was a full HTML document. That allowed a valid production link to be generated from global stylesheet content only, omitting component imports.

## Fix
- `generateFullHTML()` now lets the full-document handler own CSS preparation.
- `handleFullHTMLDocument()` builds merged HTML options first, then starts project CSS preparation from those merged options.
- `generateHTMLStream()` defers project CSS preparation/warmup until after full-document detection, so full-document streams also use merged imports.

Fixes #2893

## Verification
- `deno test --frozen -A src/rendering/orchestrator/html.test.ts` → `1 passed (44 steps) | 0 failed`
- `deno task --frozen verify:quick` → exit 0; manifests, formatting, lint/style/custom audits, docs validation, and typecheck passed
- pre-commit `deno task verify:quick` → passed
