### PR TITLE
Report partial runtime discovery failures

### DIFF
--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -10,6 +10,11 @@ import { ensureProjectDiscovery } from "./project-discovery.ts";
 import { agentRegistry } from "#veryfront/agent/composition/composition.ts";
 import { skillRegistry } from "#veryfront/skill/registry.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import {
+  __registerLogRecordEmitter,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+} from "#veryfront/utils/logger/logger.ts";
 
 function createHandlerContext(
   projectDir: string,
@@ -282,6 +287,61 @@ describe(
 
       assertEquals(discovery.tools.has("relative_tool"), true);
       assertEquals(toolRegistry.has("relative_tool"), true);
+    });
+
+    it("warns with safe diagnostics when primitive discovery succeeds partially", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/partial-discovery-project",
+        "partial-discovery-project",
+        "preview",
+      );
+
+      await ctx.adapter.fs.writeFile(
+        `${ctx.projectDir}/tools/healthy-tool.ts`,
+        [
+          'import { tool } from "veryfront/tool";',
+          'import { defineSchema } from "veryfront/schemas";',
+          "",
+          "export default tool({",
+          '  id: "healthy_tool",',
+          '  description: "Returns a healthy result",',
+          "  inputSchema: defineSchema((v) => v.object({}))(),",
+          "  execute: async () => ({ ok: true }),",
+          "});",
+          "",
+        ].join("\n"),
+      );
+      await ctx.adapter.fs.writeFile(
+        `${ctx.projectDir}/tools/broken-tool.ts`,
+        'throw new Error("broken discovery fixture");\n',
+      );
+
+      const logEntries: LogEntry[] = [];
+      __registerLogRecordEmitter((entry) => logEntries.push(entry));
+
+      try {
+        const discovery = await ensureProjectDiscovery(ctx);
+        assertEquals(discovery.tools.has("healthy_tool"), true);
+        assertEquals(discovery.errors.length, 1);
+      } finally {
+        __resetLogRecordEmitterForTests();
+      }
+
+      const partialWarning = logEntries.find((entry) =>
+        entry.message === "Primitive discovery completed with errors"
+      );
+      assertExists(partialWarning);
+      assertEquals(partialWarning.level, "warn");
+      assertEquals(partialWarning.context?.failures, [{
+        file: "tools/broken-tool.ts",
+        sourceKind: "tool",
+        message: "broken discovery fixture",
+      }]);
+      assertEquals(JSON.stringify(partialWarning).includes(ctx.projectDir), false);
     });
 
     it("rethrows hard primitive discovery failures instead of returning an empty result", async () => {

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -2,6 +2,7 @@ import type { DiscoveryResult } from "#veryfront/discovery";
 import { serverLogger } from "#veryfront/utils";
 import { clearTrackedAgents, createProjectDiscoveryConfig } from "#veryfront/discovery";
 import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
+import { sanitizeUrlCredentials } from "#veryfront/utils/logger/redact.ts";
 import type { HandlerContext } from "../../types.ts";
 
 const logger = serverLogger.component("api-wrapper");
@@ -20,6 +21,77 @@ interface DiscoveryRecord {
 }
 
 const discoveredProjects = new Map<string, DiscoveryRecord>();
+const MAX_DISCOVERY_FAILURES_TO_LOG = 5;
+const MAX_DISCOVERY_ERROR_MESSAGE_LENGTH = 500;
+
+const DISCOVERY_SOURCE_KINDS: Readonly<Record<string, string>> = {
+  agents: "agent",
+  evals: "eval",
+  prompts: "prompt",
+  resources: "resource",
+  schedules: "schedule",
+  skills: "skill",
+  tasks: "task",
+  tools: "tool",
+  webhooks: "webhook",
+  workflows: "workflow",
+};
+
+function withoutFileProtocol(path: string): string {
+  return path.replace(/^file:\/\//, "").replaceAll("\\", "/");
+}
+
+function projectRelativeDiscoveryFile(file: string, projectDir: string): string {
+  const normalizedFile = withoutFileProtocol(file);
+  const normalizedProjectDir = withoutFileProtocol(projectDir).replace(/\/$/, "");
+
+  if (normalizedProjectDir && normalizedFile.startsWith(`${normalizedProjectDir}/`)) {
+    return normalizedFile.slice(normalizedProjectDir.length + 1);
+  }
+  if (!normalizedFile.startsWith("/") && !/^[A-Za-z]:\//.test(normalizedFile)) {
+    return normalizedFile.replace(/^\.\//, "");
+  }
+
+  const segments = normalizedFile.split("/").filter(Boolean);
+  return segments.slice(-2).join("/") || "unknown";
+}
+
+function sanitizeDiscoveryErrorMessage(
+  message: string,
+  file: string,
+  projectDir: string,
+  relativeFile: string,
+): string {
+  let sanitized = sanitizeUrlCredentials(message);
+  const normalizedFile = withoutFileProtocol(file);
+  const normalizedProjectDir = withoutFileProtocol(projectDir).replace(/\/$/, "");
+
+  for (const path of [file, normalizedFile]) {
+    if (path) sanitized = sanitized.replaceAll(path, relativeFile);
+  }
+  if (normalizedProjectDir) {
+    sanitized = sanitized.replaceAll(normalizedProjectDir, "<project>");
+  }
+
+  return sanitized.length <= MAX_DISCOVERY_ERROR_MESSAGE_LENGTH
+    ? sanitized
+    : `${sanitized.slice(0, MAX_DISCOVERY_ERROR_MESSAGE_LENGTH - 3)}...`;
+}
+
+function summarizeDiscoveryFailures(
+  errors: DiscoveryResult["errors"],
+  projectDir: string,
+): Array<{ file: string; sourceKind: string; message: string }> {
+  return errors.slice(0, MAX_DISCOVERY_FAILURES_TO_LOG).map(({ file, error }) => {
+    const relativeFile = projectRelativeDiscoveryFile(file, projectDir);
+    const topLevelDir = relativeFile.split("/", 1)[0] ?? "";
+    return {
+      file: relativeFile,
+      sourceKind: DISCOVERY_SOURCE_KINDS[topLevelDir] ?? "unknown",
+      message: sanitizeDiscoveryErrorMessage(error.message, file, projectDir, relativeFile),
+    };
+  });
+}
 
 /** Build a discovery cache key that incorporates the release/version. */
 function discoveryKey(ctx: HandlerContext): string {
@@ -97,14 +169,16 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<Disco
         errors: result.errors.length,
       };
 
-      if (
+      if (result.errors.length > 0) {
+        logger.warn("Primitive discovery completed with errors", {
+          ...logData,
+          failures: summarizeDiscoveryFailures(result.errors, ctx.projectDir),
+          omittedErrors: Math.max(0, result.errors.length - MAX_DISCOVERY_FAILURES_TO_LOG),
+        });
+      } else if (
         result.agents.size === 0 && result.tools.size === 0 && shouldWarnOnEmptyAiDiscovery
       ) {
-        logger.info("Primitive discovery found 0 agents and 0 tools", {
-          ...logData,
-          errorMessages: result.errors.map((e) => e.error.message).slice(0, 5),
-          baseDir: ctx.projectDir,
-        });
+        logger.info("Primitive discovery found 0 agents and 0 tools", logData);
       } else {
         logger.info("Primitive discovery completed", logData);
       }


### PR DESCRIPTION
## Summary
- emit a bounded warning when runtime discovery partially succeeds
- preserve healthy agents and tools while surfacing failed primitive modules
- sanitize diagnostics to project-relative paths and capped messages

## Why
Production discovery reported a non-zero error count while suppressing every failure detail because other primitives loaded successfully. That made a mixed-success runtime indistinguishable from a healthy one and blocked evidence-based diagnosis.

## Verification
- regression test covers one healthy tool plus one failed module
- targeted project-discovery tests pass with the frozen lockfile
- `deno task verify:quick` passes
- formatting and lint checks pass

Refs veryfront/veryfront-issue-inbox#41