### PR TITLE
Run project middleware in the production server

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1056",
+  "version": "0.1.1057",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/dev-server/middleware.ts
+++ b/src/server/dev-server/middleware.ts
@@ -14,7 +14,7 @@ import {
 import { getEsbuildLoader } from "#veryfront/utils/path-utils.ts";
 import { generateRequestId } from "#veryfront/utils/request-id.ts";
 
-type MiddlewareFunction = (
+export type MiddlewareFunction = (
   c: { req: Request; var: Record<string, unknown> },
   next: () => Promise<Response | undefined> | Response,
 ) => Promise<Response | undefined> | Response | undefined;
@@ -99,7 +99,7 @@ function createRequestLoggerMiddleware(): MiddlewareFunction {
   };
 }
 
-async function loadMiddlewareFile(
+export async function loadMiddlewareFile(
   projectDir: string,
   adapter: RuntimeAdapter,
 ): Promise<MiddlewareFunction[]> {

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -2,6 +2,8 @@ import { serverLogger as logger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { runtime } from "#veryfront/platform/adapters/detect.ts";
 import { createVeryfrontHandler } from "./runtime-handler/index.ts";
+import { loadMiddlewareFile } from "./dev-server/middleware.ts";
+import { MiddlewarePipeline } from "#veryfront/middleware/core/pipeline/index.ts";
 import { bootstrapProd, type BootstrapResult } from "./bootstrap.ts";
 import { cwd, onGlobalError, onSignal } from "#veryfront/platform/compat/process.ts";
 import { isDebugEnabled } from "#veryfront/utils/constants/env.ts";
@@ -262,6 +264,27 @@ export function startProductionServer(
           localProjects,
         });
 
+        // Project middleware (root middleware.ts) runs in production with the
+        // same semantics as in dev: middleware executes before routing and can
+        // short-circuit by returning a Response. Requests keep their identity
+        // when middleware calls next(), so WebSocket upgrades stay intact.
+        const projectMiddleware = await loadMiddlewareFile(projectDir, adapter);
+        let coreHandler = baseHandler;
+        if (projectMiddleware.length > 0) {
+          const pipeline = new MiddlewarePipeline();
+          for (const middleware of projectMiddleware) {
+            pipeline.use(middleware);
+          }
+          pipeline.use((c) => baseHandler(c.req));
+          coreHandler = Object.assign(
+            (req: Request) => pipeline.execute(req, adapter.env.toObject()),
+            { ready: baseHandler.ready },
+          );
+          logger.info("Registered project middleware", {
+            count: projectMiddleware.length,
+          });
+        }
+
         // Wrap handler with interceptor if provided (for combined mode)
         // WebSocket upgrade requests MUST NOT be intercepted because the interceptor
         // creates a new Request object, which breaks Deno.upgradeWebSocket()
@@ -269,12 +292,12 @@ export function startProductionServer(
           ? Object.assign(
             async (req: Request) => {
               const isWebSocketUpgrade = req.headers.get("upgrade")?.toLowerCase() === "websocket";
-              if (isWebSocketUpgrade) return baseHandler(req);
-              return baseHandler(await requestInterceptor(req));
+              if (isWebSocketUpgrade) return coreHandler(req);
+              return coreHandler(await requestInterceptor(req));
             },
-            { ready: baseHandler.ready },
+            { ready: coreHandler.ready },
           )
-          : baseHandler;
+          : coreHandler;
 
         let resolveListenReady: (() => void) | undefined;
         const listenReady = new Promise<void>((resolve) => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1056";
+export const VERSION = "0.1.1057";

--- a/tests/integration/server/production-server.test.ts
+++ b/tests/integration/server/production-server.test.ts
@@ -420,7 +420,6 @@ describe(
 
     describe(
       "Production Server - Project middleware",
-      { sanitizeResources: false, sanitizeOps: false },
       () => {
         it("applies root middleware.ts to requests", async () => {
           await withTestContext("prod-project-middleware", async (context) => {

--- a/tests/integration/server/production-server.test.ts
+++ b/tests/integration/server/production-server.test.ts
@@ -419,6 +419,61 @@ describe(
     );
 
     describe(
+      "Production Server - Project middleware",
+      { sanitizeResources: false, sanitizeOps: false },
+      () => {
+        it("applies root middleware.ts to requests", async () => {
+          await withTestContext("prod-project-middleware", async (context) => {
+            await writeTextFile(
+              join(context.projectDir, "public", "open.txt"),
+              "open content",
+            );
+            await writeTextFile(
+              join(context.projectDir, "middleware.ts"),
+              `export default async function gate(
+                c: { req: Request },
+                next: () => Promise<Response | undefined>,
+              ): Promise<Response | undefined> {
+                if (c.req.headers.get("x-gate") !== "open") {
+                  return new Response("blocked", { status: 401 });
+                }
+                const response = await next();
+                response?.headers.set("x-gate-passed", "1");
+                return response;
+              }
+              `,
+            );
+
+            const server = await context.createProductionServer();
+
+            const blocked = await fetch(`http://127.0.0.1:${server.port}/open.txt`);
+            assertEquals(
+              blocked.status,
+              401,
+              "Middleware must reject requests without the expected header",
+            );
+            assertEquals(await blocked.text(), "blocked");
+
+            const allowed = await fetch(`http://127.0.0.1:${server.port}/open.txt`, {
+              headers: { "x-gate": "open" },
+            });
+            assertEquals(
+              allowed.status,
+              200,
+              "Middleware must pass matching requests through to the handler",
+            );
+            assertEquals(await allowed.text(), "open content");
+            assertEquals(
+              allowed.headers.get("x-gate-passed"),
+              "1",
+              "Middleware must run around the handler response",
+            );
+          });
+        });
+      },
+    );
+
+    describe(
       "Production Server - Error Handling",
       { sanitizeResources: false, sanitizeOps: false },
       () => {


### PR DESCRIPTION
## Problem

The root `middleware.ts` convention is only honored by the dev server (`setupMiddleware` in `src/server/dev-server/middleware.ts`). `startProductionServer` builds `createVeryfrontHandler` directly, so project middleware (for example a basic auth gate) silently stops applying the moment a project runs under `veryfront serve` or the hosted runtime. Users get no error, just an unprotected site.

## Change

- Export `loadMiddlewareFile` and `MiddlewareFunction` from the dev server middleware module for reuse.
- In `startProductionServer`, load the project middleware file and, when present, execute it through `MiddlewarePipeline` around the runtime handler. Semantics match dev: middleware runs before routing and can short-circuit by returning a Response.
- The wrap preserves `handler.ready`, the `requestInterceptor` combined-mode path, and WebSocket upgrades (requests keep their identity when middleware calls `next()`).
- No-op when no middleware file exists: the handler is served unwrapped exactly as before.

## Testing

- New integration test in `tests/integration/server/production-server.test.ts`: a root `middleware.ts` rejects requests without a header (401) and passes matching requests through (200, with a middleware-set response header). Written first and confirmed failing (200 instead of 401) before the change.
- Full `production-server.test.ts` suite passes: 1 passed (22 steps), 0 failed.
- `deno check`, `deno fmt --check`, and `deno lint` clean on touched files.

## Follow-up

The public middleware guide (veryfront-docs) can now state that `middleware.ts` works identically in dev and production. Multi-project proxy mode still resolves middleware from the server's `projectDir` only; per-request project middleware resolution is out of scope here.