### PR TITLE
Restore production project middleware across hosted runtimes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1057",
+  "version": "0.1.1058",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1058",
+  "version": "0.1.1059",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -157,6 +157,33 @@ const pipeline = new MiddlewarePipeline()
   .use(cors({ origin: "*" }));
 ```
 
+## Project-wide root middleware
+
+Add `middleware.ts`, `middleware.js`, or `middleware.mjs` at the project root to run middleware before every project route. Export one middleware function or an array of functions:
+
+```ts
+// middleware.ts
+import type { MiddlewareHandler } from "veryfront/middleware";
+
+const requireAccess: MiddlewareHandler = async (c, next) => {
+  if (!c.request.headers.has("authorization")) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const response = await next();
+  response?.headers.set("x-project-middleware", "applied");
+  return response;
+};
+
+export default requireAccess;
+```
+
+Root middleware has the same ordering and short-circuit contract in local development, dedicated production servers, and the shared hosted runtime. The shared runtime resolves and compiles the file only after it has authenticated the project and selected its release or preview branch. Middleware receives only that request's project environment through `c.env`.
+
+Production middleware is cached by project, environment, and immutable release or preview branch. Preview cache invalidation reloads the file after source changes, and the cache has a fixed entry limit. A missing file passes through normally.
+
+Production loading is fail-closed. If a declared middleware file cannot be read, compiled, or validated as a middleware export, a dedicated server does not start and a shared server returns an error only for the affected project request. Failed shared loads are not cached, so a corrected deployment can recover without restarting unrelated projects. Development loading remains nonfatal and reports the loading error in the server log.
+
 ## Verify it worked
 
 Hit a route with and without the headers the middleware expects:

--- a/src/server/context/cache-invalidation.ts
+++ b/src/server/context/cache-invalidation.ts
@@ -17,6 +17,7 @@ import {
 import { clearSnippetCacheForProject } from "#veryfront/rendering/snippet-renderer.ts";
 import { resetApiHandlerForProject } from "#veryfront/server/handlers/request/api/pages-api-handler.ts";
 import { clearSourceMissCache } from "#veryfront/modules/server/module-source-resolution-cache.ts";
+import { invalidateProjectMiddlewareCache } from "#veryfront/server/runtime-handler/project-middleware.ts";
 
 const logger = serverLogger.component("cache-invalidation");
 
@@ -61,6 +62,13 @@ export async function invalidateProjectCaches(
     clearModulePathCache();
   }
   clearSourceMissCache();
+
+  const middlewareEntries = invalidateProjectMiddlewareCache(projectSlug, projectId);
+  logger.debug("Clearing project middleware cache", {
+    projectSlug,
+    projectId,
+    entriesDeleted: middlewareEntries,
+  });
 
   logger.debug("Clearing SSR module cache", {
     projectSlug,

--- a/src/server/dev-server/middleware.test.ts
+++ b/src/server/dev-server/middleware.test.ts
@@ -1,0 +1,76 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { loadMiddlewareFile } from "./middleware.ts";
+
+function createVirtualAdapter(source: string): RuntimeAdapter {
+  const fs = {
+    getUnderlyingAdapter: () => fs,
+    getAdapterType: () => "MultiProjectFSAdapter",
+    isVeryfrontAdapter: () => true,
+    isMultiProjectMode: () => true,
+    exists: (path: string) => Promise.resolve(path.endsWith("/middleware.ts")),
+    readFile: () => Promise.resolve(source),
+  } as unknown as RuntimeAdapter["fs"];
+
+  return {
+    id: "test",
+    name: "test",
+    capabilities: {},
+    fs,
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      has: () => false,
+      toObject: () => ({}),
+    },
+    server: {} as RuntimeAdapter["server"],
+    serve: () => Promise.resolve({ close: () => Promise.resolve() }),
+  } as unknown as RuntimeAdapter;
+}
+
+describe("loadMiddlewareFile", () => {
+  afterAll(async () => {
+    const { stop } = await import("veryfront/extensions/bundler");
+    await stop();
+  });
+
+  it("fails closed for invalid production middleware", async () => {
+    const adapter = createVirtualAdapter("export default function broken( {");
+
+    await assertRejects(
+      () => loadMiddlewareFile("/app", adapter, { throwOnError: true }),
+      Error,
+    );
+  });
+
+  it("fails closed when production middleware has no valid default export", async () => {
+    const adapter = createVirtualAdapter("export const middleware = () => new Response('ok');");
+
+    await assertRejects(
+      () => loadMiddlewareFile("/app", adapter, { throwOnError: true }),
+      TypeError,
+      "Invalid middleware export",
+    );
+  });
+
+  it("fails closed when a production middleware array contains invalid entries", async () => {
+    const adapter = createVirtualAdapter(
+      "export default [() => new Response('ok'), 'invalid'];",
+    );
+
+    await assertRejects(
+      () => loadMiddlewareFile("/app", adapter, { throwOnError: true }),
+      TypeError,
+      "Invalid middleware export",
+    );
+  });
+
+  it("preserves nonfatal development loading for invalid middleware", async () => {
+    const adapter = createVirtualAdapter("export default function broken( {");
+
+    assertEquals(await loadMiddlewareFile("/app", adapter), []);
+  });
+});

--- a/src/server/dev-server/middleware.ts
+++ b/src/server/dev-server/middleware.ts
@@ -1,4 +1,5 @@
 import { MiddlewarePipeline } from "#veryfront/middleware/core/pipeline/index.ts";
+import type { MiddlewareHandler } from "#veryfront/middleware/core/types.ts";
 import { COMPILATION_ERROR } from "#veryfront/errors";
 import { isVirtualFilesystem } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -14,10 +15,11 @@ import {
 import { getEsbuildLoader } from "#veryfront/utils/path-utils.ts";
 import { generateRequestId } from "#veryfront/utils/request-id.ts";
 
-export type MiddlewareFunction = (
-  c: { req: Request; var: Record<string, unknown> },
-  next: () => Promise<Response | undefined> | Response,
-) => Promise<Response | undefined> | Response | undefined;
+export type MiddlewareFunction = MiddlewareHandler;
+
+interface MiddlewareLoadOptions {
+  throwOnError?: boolean;
+}
 
 const baseLogger = getBaseLogger("SERVER");
 
@@ -102,6 +104,7 @@ function createRequestLoggerMiddleware(): MiddlewareFunction {
 export async function loadMiddlewareFile(
   projectDir: string,
   adapter: RuntimeAdapter,
+  options: MiddlewareLoadOptions = {},
 ): Promise<MiddlewareFunction[]> {
   const middlewareFiles = ["middleware.ts", "middleware.js", "middleware.mjs"];
 
@@ -113,15 +116,20 @@ export async function loadMiddlewareFile(
       logger.debug(`Loading ${middlewareFile}`);
 
       if (isVirtualFilesystem(adapter.fs)) {
-        return await loadMiddlewareFromVirtualFS(middlewarePath, adapter);
+        return await loadMiddlewareFromVirtualFS(
+          middlewarePath,
+          adapter,
+          options.throwOnError === true,
+        );
       }
 
       const middlewareUrl = `file://${middlewarePath}?t=${Date.now()}-${crypto.randomUUID()}`;
       const middlewareModule = await import(middlewareUrl);
-      return normalizeMiddlewareExport(middlewareModule);
+      return normalizeMiddlewareExport(middlewareModule, options.throwOnError === true);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.warn(`Failed to load ${middlewareFile}: ${errorMessage}`);
+      if (options.throwOnError) throw error;
     }
   }
 
@@ -131,6 +139,7 @@ export async function loadMiddlewareFile(
 async function loadMiddlewareFromVirtualFS(
   middlewarePath: string,
   adapter: RuntimeAdapter,
+  strictExport: boolean,
 ): Promise<MiddlewareFunction[]> {
   const fs = createFileSystem();
 
@@ -166,28 +175,45 @@ async function loadMiddlewareFromVirtualFS(
   try {
     await fs.writeTextFile(tempFile, js);
     const middlewareModule = await import(`file://${tempFile}?v=${Date.now()}`);
-    return normalizeMiddlewareExport(middlewareModule);
+    return normalizeMiddlewareExport(middlewareModule, strictExport);
   } finally {
     await fs.remove(tempDir, { recursive: true });
   }
 }
 
-function normalizeMiddlewareExport(middlewareModule: unknown): MiddlewareFunction[] {
-  if (middlewareModule && typeof middlewareModule === "object" && "default" in middlewareModule) {
-    const exported = (middlewareModule as { default?: unknown }).default;
+function normalizeMiddlewareExport(
+  middlewareModule: unknown,
+  strict = false,
+): MiddlewareFunction[] {
+  const exported = middlewareModule && typeof middlewareModule === "object" &&
+      "default" in middlewareModule
+    ? (middlewareModule as { default?: unknown }).default
+    : middlewareModule;
 
-    if (Array.isArray(exported)) {
-      return exported.filter((m): m is MiddlewareFunction => typeof m === "function");
+  if (Array.isArray(exported)) {
+    if (
+      strict && (exported.length === 0 || exported.some((value) => typeof value !== "function"))
+    ) {
+      throw new TypeError(
+        "Invalid middleware export: expected a function or non-empty array of functions",
+      );
     }
-
-    return typeof exported === "function" ? [exported as MiddlewareFunction] : [];
+    return exported.filter((middleware): middleware is MiddlewareFunction =>
+      typeof middleware === "function"
+    );
   }
 
-  if (Array.isArray(middlewareModule)) {
-    return middlewareModule.filter((m): m is MiddlewareFunction => typeof m === "function");
+  if (typeof exported === "function") {
+    return [exported as MiddlewareFunction];
   }
 
-  return typeof middlewareModule === "function" ? [middlewareModule as MiddlewareFunction] : [];
+  if (strict) {
+    throw new TypeError(
+      "Invalid middleware export: expected a function or non-empty array of functions",
+    );
+  }
+
+  return [];
 }
 
 export async function setupMiddleware(

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -268,7 +268,9 @@ export function startProductionServer(
         // startup cannot discover a root middleware file. Standalone runtimes
         // load project middleware with the same semantics as the dev server.
         const isProxyMode = bootstrap.config.fs?.veryfront?.proxyMode === true;
-        const projectMiddleware = isProxyMode ? [] : await loadMiddlewareFile(projectDir, adapter);
+        const projectMiddleware = isProxyMode
+          ? []
+          : await loadMiddlewareFile(projectDir, adapter, { throwOnError: true });
         let coreHandler = baseHandler;
         if (projectMiddleware.length > 0) {
           const pipeline = new MiddlewarePipeline();

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -264,11 +264,11 @@ export function startProductionServer(
           localProjects,
         });
 
-        // Project middleware (root middleware.ts) runs in production with the
-        // same semantics as in dev: middleware executes before routing and can
-        // short-circuit by returning a Response. Requests keep their identity
-        // when middleware calls next(), so WebSocket upgrades stay intact.
-        const projectMiddleware = await loadMiddlewareFile(projectDir, adapter);
+        // Shared proxy filesystems need tenant context from the request, so
+        // startup cannot discover a root middleware file. Standalone runtimes
+        // load project middleware with the same semantics as the dev server.
+        const isProxyMode = bootstrap.config.fs?.veryfront?.proxyMode === true;
+        const projectMiddleware = isProxyMode ? [] : await loadMiddlewareFile(projectDir, adapter);
         let coreHandler = baseHandler;
         if (projectMiddleware.length > 0) {
           const pipeline = new MiddlewarePipeline();

--- a/src/server/project-env/index.ts
+++ b/src/server/project-env/index.ts
@@ -4,7 +4,12 @@
  * @module server/project-env
  */
 
-export { getProjectEnv, isProjectEnvActive, runWithProjectEnv } from "./storage.ts";
+export {
+  getProjectEnv,
+  getProjectEnvSnapshot,
+  isProjectEnvActive,
+  runWithProjectEnv,
+} from "./storage.ts";
 export { EnvironmentVariableCache } from "./cache.ts";
 export { filterRuntimeProjectEnv, filterSharedRuntimeProjectEnv } from "./reserved-env.ts";
 export { fetchProjectEnvVars } from "./fetcher.ts";

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -121,6 +121,7 @@ import {
 } from "../project-env/index.ts";
 import { SCANNER_PATH_PATTERN } from "#veryfront/utils/constants/security.ts";
 import { isProxyTrusted } from "../utils/proxy-trust.ts";
+import { projectMiddlewareRuntime } from "./project-middleware.ts";
 
 // Re-export from dedicated module for lightweight imports
 export { parseProxyEnvironment, type ProxyEnvironment } from "./proxy-environment.ts";
@@ -666,7 +667,13 @@ export function createVeryfrontHandler(
 
           await incrementRequestMetrics();
 
-          const executeRoute = () => registry.execute(req, ctx);
+          const executeRoute = () =>
+            projectMiddlewareRuntime.execute({
+              request: req,
+              handlerContext: ctx,
+              isSharedProxy: isProxyMode,
+              next: async () => (await registry.execute(req, ctx)) ?? undefined,
+            });
           // Only activate env isolation in proxy mode (multi-tenant).
           // reqCtx.token indicates the request came through the proxy with auth.
           // Without it (standalone / test), host env must remain accessible.

--- a/src/server/runtime-handler/project-middleware.test.ts
+++ b/src/server/runtime-handler/project-middleware.test.ts
@@ -1,0 +1,459 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { runWithProjectEnv } from "#veryfront/server/project-env";
+import {
+  ProjectMiddlewareRuntime,
+  type ProjectMiddlewareRuntimeContext,
+} from "./project-middleware.ts";
+
+interface ActiveFsContext {
+  projectSlug: string;
+  projectId?: string;
+  releaseId?: string | null;
+  branch?: string | null;
+}
+
+function createAdapter(
+  storage = new AsyncLocalStorage<ActiveFsContext>(),
+  middlewareSource?: string,
+): RuntimeAdapter {
+  const fs = {
+    getUnderlyingAdapter: () => fs,
+    getAdapterType: () => "MultiProjectFSAdapter",
+    isVeryfrontAdapter: () => true,
+    isMultiProjectMode: () => true,
+    isContextualMode: () => true,
+    exists: (path: string) =>
+      Promise.resolve(middlewareSource !== undefined && path.endsWith("/middleware.ts")),
+    readFile: () => Promise.resolve(middlewareSource ?? ""),
+    runWithContext: <T>(
+      projectSlug: string,
+      _token: string,
+      fn: () => Promise<T>,
+      projectId?: string,
+      options?: {
+        releaseId?: string | null;
+        branch?: string | null;
+      },
+    ) =>
+      storage.run(
+        {
+          projectSlug,
+          projectId,
+          releaseId: options?.releaseId,
+          branch: options?.branch,
+        },
+        fn,
+      ),
+  } as unknown as RuntimeAdapter["fs"];
+
+  return {
+    id: "test",
+    name: "test",
+    capabilities: {},
+    fs,
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      has: () => false,
+      toObject: () => ({ HOST_SECRET: "must-not-leak" }),
+    },
+    server: {} as RuntimeAdapter["server"],
+    serve: () => Promise.resolve({ close: () => Promise.resolve() }),
+  } as unknown as RuntimeAdapter;
+}
+
+function createContext(
+  adapter: RuntimeAdapter,
+  overrides: Partial<HandlerContext> = {},
+): HandlerContext {
+  return {
+    projectDir: "/app",
+    adapter,
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "trusted-project",
+    projectId: "project-a",
+    releaseId: "release-a",
+    proxyToken: "trusted-token",
+    environmentName: "Production",
+    resolvedEnvironment: "production",
+    requestContext: {
+      token: "trusted-token",
+      slug: "trusted-project",
+      branch: null,
+      mode: "production",
+    },
+    isLocalProject: false,
+    ...overrides,
+  };
+}
+
+function execute(
+  runtime: ProjectMiddlewareRuntime,
+  context: HandlerContext,
+  request = new Request("https://example.com/resource"),
+  next = () => Promise.resolve(new Response("route")),
+): Promise<Response | undefined> {
+  const runtimeContext: ProjectMiddlewareRuntimeContext = {
+    request,
+    handlerContext: context,
+    isSharedProxy: true,
+    next,
+  };
+  return runtime.execute(runtimeContext);
+}
+
+describe("ProjectMiddlewareRuntime", () => {
+  afterAll(async () => {
+    const { stop } = await import("veryfront/extensions/bundler");
+    await stop();
+  });
+
+  it("loads production middleware in trusted filesystem context and caches by release", async () => {
+    const storage = new AsyncLocalStorage<ActiveFsContext>();
+    const adapter = createAdapter(storage);
+    const loadedContexts: ActiveFsContext[] = [];
+    let loadCount = 0;
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => {
+        loadCount++;
+        loadedContexts.push(storage.getStore()!);
+        return Promise.resolve([
+          async (_c, next) => {
+            const response = await next();
+            response?.headers.set("x-project-middleware", "applied");
+            return response;
+          },
+        ]);
+      },
+    });
+    const context = createContext(adapter);
+    const spoofedRequest = new Request("https://example.com/resource", {
+      headers: { "x-project-slug": "spoofed-project" },
+    });
+
+    const first = await execute(runtime, context, spoofedRequest);
+    const second = await execute(runtime, context, spoofedRequest);
+
+    assertEquals(loadCount, 1);
+    assertEquals(first?.headers.get("x-project-middleware"), "applied");
+    assertEquals(second?.headers.get("x-project-middleware"), "applied");
+    assertEquals(loadedContexts, [{
+      projectSlug: "trusted-project",
+      projectId: "project-a",
+      releaseId: "release-a",
+      branch: null,
+    }]);
+  });
+
+  it("reloads middleware when the production release changes", async () => {
+    const adapter = createAdapter();
+    let loadCount = 0;
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => {
+        const version = ++loadCount;
+        return Promise.resolve([() => new Response(`middleware-${version}`)]);
+      },
+    });
+
+    const first = await execute(runtime, createContext(adapter));
+    const second = await execute(
+      runtime,
+      createContext(adapter, { releaseId: "release-b" }),
+    );
+
+    assertEquals(await first?.text(), "middleware-1");
+    assertEquals(await second?.text(), "middleware-2");
+    assertEquals(loadCount, 2);
+  });
+
+  it("scopes preview middleware by branch and supports explicit project invalidation", async () => {
+    const adapter = createAdapter();
+    let loadCount = 0;
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => {
+        loadCount++;
+        return Promise.resolve([]);
+      },
+    });
+    const previewContext = (branch: string): HandlerContext =>
+      createContext(adapter, {
+        releaseId: undefined,
+        resolvedEnvironment: "preview",
+        requestContext: {
+          token: "trusted-token",
+          slug: "trusted-project",
+          branch,
+          mode: "preview",
+        },
+      });
+
+    await execute(runtime, previewContext("feature-a"));
+    await execute(runtime, previewContext("feature-a"));
+    await execute(runtime, previewContext("feature-b"));
+    assertEquals(loadCount, 2);
+
+    assertEquals(runtime.invalidateProject("project-a"), 2);
+    await execute(runtime, previewContext("feature-b"));
+    assertEquals(loadCount, 3);
+  });
+
+  it("passes through when the project has no root middleware", async () => {
+    const adapter = createAdapter();
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => Promise.resolve([]),
+    });
+    let routeCalls = 0;
+
+    const response = await execute(
+      runtime,
+      createContext(adapter),
+      undefined,
+      () => {
+        routeCalls++;
+        return Promise.resolve(new Response("route"));
+      },
+    );
+
+    assertEquals(routeCalls, 1);
+    assertEquals(await response?.text(), "route");
+  });
+
+  it("preserves short-circuit and pass-through middleware ordering", async () => {
+    const adapter = createAdapter();
+    const calls: string[] = [];
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () =>
+        Promise.resolve([
+          async (c, next) => {
+            calls.push("first:before");
+            if (c.req.headers.get("x-block") === "1") {
+              return new Response("blocked", { status: 401 });
+            }
+            const response = await next();
+            calls.push("first:after");
+            return response;
+          },
+          async (_c, next) => {
+            calls.push("second:before");
+            const response = await next();
+            calls.push("second:after");
+            return response;
+          },
+        ]),
+    });
+    let routeCalls = 0;
+    const next = () => {
+      routeCalls++;
+      calls.push("route");
+      return Promise.resolve(new Response("route"));
+    };
+
+    const blocked = await execute(
+      runtime,
+      createContext(adapter),
+      new Request("https://example.com/resource", { headers: { "x-block": "1" } }),
+      next,
+    );
+    assertEquals(blocked?.status, 401);
+    assertEquals(routeCalls, 0);
+    assertEquals(calls, ["first:before"]);
+
+    calls.length = 0;
+    const allowed = await execute(runtime, createContext(adapter), undefined, next);
+    assertEquals(await allowed?.text(), "route");
+    assertEquals(routeCalls, 1);
+    assertEquals(calls, [
+      "first:before",
+      "second:before",
+      "route",
+      "second:after",
+      "first:after",
+    ]);
+  });
+
+  it("preserves request and response identity for WebSocket upgrade handling", async () => {
+    const adapter = createAdapter();
+    const request = new Request("https://example.com/_ws", {
+      headers: { upgrade: "websocket" },
+    });
+    const routeResponse = new Response("upgrade handoff");
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () =>
+        Promise.resolve([
+          async (c, next) => {
+            assertEquals(c.req === request, true);
+            return await next();
+          },
+        ]),
+    });
+
+    const response = await execute(
+      runtime,
+      createContext(adapter),
+      request,
+      () => Promise.resolve(routeResponse),
+    );
+
+    assertEquals(response === routeResponse, true);
+  });
+
+  it("isolates concurrent projects and ignores project selectors on the request", async () => {
+    const storage = new AsyncLocalStorage<ActiveFsContext>();
+    const adapter = createAdapter(storage);
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: async () => {
+        const before = storage.getStore()?.projectSlug;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        const after = storage.getStore()?.projectSlug;
+        assertEquals(after, before);
+        return [() => new Response(before)];
+      },
+    });
+    const request = new Request("https://example.com/resource", {
+      headers: { "x-project-slug": "untrusted-project" },
+    });
+
+    const [projectA, projectB] = await Promise.all([
+      execute(runtime, createContext(adapter), request),
+      execute(
+        runtime,
+        createContext(adapter, {
+          projectSlug: "trusted-project-b",
+          projectId: "project-b",
+          releaseId: "release-b",
+          requestContext: {
+            token: "trusted-token",
+            slug: "trusted-project-b",
+            branch: null,
+            mode: "production",
+          },
+        }),
+        request,
+      ),
+    ]);
+
+    assertEquals(await projectA?.text(), "trusted-project");
+    assertEquals(await projectB?.text(), "trusted-project-b");
+  });
+
+  it("evicts rejected loads so the affected project can recover", async () => {
+    const adapter = createAdapter();
+    let attempts = 0;
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => {
+        attempts++;
+        if (attempts === 1) return Promise.reject(new Error("compile failed"));
+        return Promise.resolve([() => new Response("recovered")]);
+      },
+    });
+
+    await assertRejects(
+      () => execute(runtime, createContext(adapter)),
+      Error,
+      "compile failed",
+    );
+    const response = await execute(runtime, createContext(adapter));
+
+    assertEquals(attempts, 2);
+    assertEquals(await response?.text(), "recovered");
+  });
+
+  it("rejects malformed shared production middleware before routing", async () => {
+    const adapter = createAdapter(
+      undefined,
+      "export const middleware = () => new Response('untrusted');",
+    );
+    const runtime = new ProjectMiddlewareRuntime();
+    let routeCalls = 0;
+
+    await assertRejects(
+      () =>
+        execute(runtime, createContext(adapter), undefined, () => {
+          routeCalls++;
+          return Promise.resolve(new Response("route"));
+        }),
+      TypeError,
+      "Invalid middleware export",
+    );
+
+    assertEquals(routeCalls, 0);
+  });
+
+  it("keeps the compiled middleware cache bounded", async () => {
+    const adapter = createAdapter();
+    let loads = 0;
+    const runtime = new ProjectMiddlewareRuntime({
+      maxEntries: 1,
+      loadMiddleware: () => {
+        loads++;
+        return Promise.resolve([]);
+      },
+    });
+
+    await execute(runtime, createContext(adapter));
+    await execute(
+      runtime,
+      createContext(adapter, {
+        projectSlug: "trusted-project-b",
+        projectId: "project-b",
+        releaseId: "release-b",
+      }),
+    );
+    await execute(runtime, createContext(adapter));
+
+    assertEquals(runtime.size, 1);
+    assertEquals(loads, 3);
+  });
+
+  it("exposes only the active project environment to middleware", async () => {
+    const adapter = createAdapter();
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () =>
+        Promise.resolve([
+          (c) => Response.json(c.env),
+        ]),
+    });
+
+    const response = await runWithProjectEnv(
+      { TENANT_VALUE: "project-only" },
+      () => execute(runtime, createContext(adapter)),
+    );
+
+    assertEquals(await response?.json(), { TENANT_VALUE: "project-only" });
+  });
+
+  it("does not load shared middleware for local, standalone, or unauthenticated context", async () => {
+    const adapter = createAdapter();
+    let loads = 0;
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => {
+        loads++;
+        return Promise.resolve([]);
+      },
+    });
+    let routeCalls = 0;
+    const next = () => {
+      routeCalls++;
+      return Promise.resolve(new Response("route"));
+    };
+
+    await runtime.execute({
+      request: new Request("https://example.com"),
+      handlerContext: createContext(adapter),
+      isSharedProxy: false,
+      next,
+    });
+    await execute(runtime, createContext(adapter, { isLocalProject: true }), undefined, next);
+    await execute(runtime, createContext(adapter, { proxyToken: undefined }), undefined, next);
+
+    assertEquals(loads, 0);
+    assertEquals(routeCalls, 3);
+  });
+});

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -1,0 +1,198 @@
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
+import { registerLRUCache } from "#veryfront/cache";
+import { MiddlewareContext } from "#veryfront/middleware/core/context.ts";
+import { MiddlewarePipeline } from "#veryfront/middleware/core/pipeline/index.ts";
+import { getProjectEnvSnapshot } from "#veryfront/server/project-env";
+import {
+  loadMiddlewareFile,
+  type MiddlewareFunction,
+} from "#veryfront/server/dev-server/middleware.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
+import { serverLogger } from "#veryfront/utils";
+
+const DEFAULT_MAX_ENTRIES = 100;
+const logger = serverLogger.component("project-middleware");
+
+type MiddlewareLoader = (
+  projectDir: string,
+  adapter: RuntimeAdapter,
+) => Promise<MiddlewareFunction[]>;
+
+interface ProjectMiddlewareRuntimeOptions {
+  maxEntries?: number;
+  loadMiddleware?: MiddlewareLoader;
+  registryName?: string;
+}
+
+export interface ProjectMiddlewareRuntimeContext {
+  request: Request;
+  handlerContext: HandlerContext;
+  isSharedProxy: boolean;
+  next: () => Promise<Response | undefined>;
+}
+
+function cacheSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function resolvedEnvironment(ctx: HandlerContext): "production" | "preview" {
+  return ctx.resolvedEnvironment ?? ctx.requestContext?.mode ?? "preview";
+}
+
+function resolvedBranch(ctx: HandlerContext): string | null {
+  return ctx.requestContext?.branch ?? ctx.parsedDomain?.branch ?? null;
+}
+
+/** Request-scoped root middleware loader for the shared multi-project runtime. */
+export class ProjectMiddlewareRuntime {
+  readonly #cache: LRUCache<string, Promise<readonly MiddlewareFunction[]>>;
+  readonly #loadMiddleware: MiddlewareLoader;
+
+  constructor(options: ProjectMiddlewareRuntimeOptions = {}) {
+    this.#cache = new LRUCache({
+      maxEntries: options.maxEntries ?? DEFAULT_MAX_ENTRIES,
+    });
+    this.#loadMiddleware = options.loadMiddleware ??
+      ((projectDir, adapter) => loadMiddlewareFile(projectDir, adapter, { throwOnError: true }));
+
+    if (options.registryName) {
+      registerLRUCache(options.registryName, this.#cache);
+    }
+  }
+
+  get size(): number {
+    return this.#cache.size;
+  }
+
+  invalidateProject(projectIdentity: string): number {
+    const expectedProject = cacheSegment(projectIdentity);
+    let deleted = 0;
+
+    for (const key of [...this.#cache.keys()]) {
+      if (key.split(":", 1)[0] !== expectedProject) continue;
+      if (this.#cache.delete(key)) deleted++;
+    }
+
+    return deleted;
+  }
+
+  clear(): void {
+    this.#cache.clear();
+  }
+
+  async execute(input: ProjectMiddlewareRuntimeContext): Promise<Response | undefined> {
+    const { handlerContext: ctx, isSharedProxy, next, request } = input;
+    const fs = ctx.adapter.fs;
+
+    if (
+      !isSharedProxy || ctx.isLocalProject || !ctx.projectSlug || !ctx.proxyToken ||
+      !isExtendedFSAdapter(fs) || !fs.isMultiProjectMode()
+    ) {
+      return next();
+    }
+
+    const environment = resolvedEnvironment(ctx);
+    const branch = resolvedBranch(ctx);
+
+    return fs.runWithContext(
+      ctx.projectSlug,
+      ctx.proxyToken,
+      async () => {
+        const middleware = await this.#getMiddleware(ctx, environment, branch);
+        if (middleware.length === 0) return next();
+
+        const pipeline = new MiddlewarePipeline();
+        for (const handler of middleware) pipeline.use(handler);
+
+        const composed = pipeline.compose();
+        const middlewareContext = new MiddlewareContext(
+          request,
+          getProjectEnvSnapshot() ?? {},
+        );
+        return await composed(middlewareContext, next);
+      },
+      ctx.projectId,
+      {
+        productionMode: environment === "production",
+        releaseId: ctx.releaseId ?? null,
+        branch,
+        environmentName: ctx.environmentName ?? null,
+      },
+    );
+  }
+
+  async #getMiddleware(
+    ctx: HandlerContext,
+    environment: "production" | "preview",
+    branch: string | null,
+  ): Promise<readonly MiddlewareFunction[]> {
+    const key = this.#buildCacheKey(ctx, environment, branch);
+    if (!key) return this.#load(ctx);
+
+    let pending = this.#cache.get(key);
+    if (!pending) {
+      pending = Promise.resolve().then(() => this.#load(ctx));
+      this.#cache.set(key, pending);
+    }
+
+    try {
+      return await pending;
+    } catch (error) {
+      if (this.#cache.get(key) === pending) this.#cache.delete(key);
+      throw error;
+    }
+  }
+
+  #buildCacheKey(
+    ctx: HandlerContext,
+    environment: "production" | "preview",
+    branch: string | null,
+  ): string | null {
+    const projectIdentity = ctx.projectId ?? ctx.projectSlug;
+    if (!projectIdentity) return null;
+
+    const sourceIdentity = environment === "production" ? ctx.releaseId : branch ?? "default";
+    if (!sourceIdentity) return null;
+
+    const environmentIdentity = ctx.environmentId ?? ctx.environmentName ?? "default";
+    return [
+      cacheSegment(projectIdentity),
+      environment,
+      cacheSegment(sourceIdentity),
+      cacheSegment(environmentIdentity),
+    ].join(":");
+  }
+
+  async #load(ctx: HandlerContext): Promise<readonly MiddlewareFunction[]> {
+    try {
+      return await this.#loadMiddleware(ctx.projectDir, ctx.adapter);
+    } catch (error) {
+      logger.error("Failed to load project middleware", {
+        projectSlug: ctx.projectSlug,
+        projectId: ctx.projectId,
+        releaseId: ctx.releaseId,
+        branch: resolvedBranch(ctx),
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+}
+
+export const projectMiddlewareRuntime = new ProjectMiddlewareRuntime({
+  registryName: "project-middleware-cache",
+});
+
+export function invalidateProjectMiddlewareCache(
+  projectSlug: string,
+  projectId?: string,
+): number {
+  const identities = new Set([projectSlug, projectId].filter((value): value is string => !!value));
+  let deleted = 0;
+  for (const identity of identities) {
+    deleted += projectMiddlewareRuntime.invalidateProject(identity);
+  }
+  return deleted;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1057";
+export const VERSION = "0.1.1058";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1058";
+export const VERSION = "0.1.1059";

--- a/tests/integration/server/production-server.test.ts
+++ b/tests/integration/server/production-server.test.ts
@@ -17,6 +17,12 @@ import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
 
 import { restoreLogs } from "../../_helpers/log-guard.ts";
 import { buildProduction } from "../../../src/build/production-build/index.ts";
+import { createMockAdapter } from "../../../src/platform/adapters/mock.ts";
+import { FSAdapterWrapper } from "../../../src/platform/adapters/fs/wrapper.ts";
+import { MultiProjectFSAdapter } from "../../../src/platform/adapters/fs/veryfront/multi-project-adapter.ts";
+import type { RuntimeAdapter } from "../../../src/platform/adapters/base.ts";
+import type { BootstrapResult } from "../../../src/server/bootstrap.ts";
+import { startProductionServer } from "../../../src/server/production-server.ts";
 import { TestDataFactory } from "../../fixtures/test-data-factory.ts";
 import { withTestContext } from "../../_helpers/context.ts";
 import { cleanupBundler } from "../../../src/rendering/cleanup.ts";
@@ -421,6 +427,64 @@ describe(
     describe(
       "Production Server - Project middleware",
       () => {
+        it("does not read project middleware before proxy request context exists", async () => {
+          const multiProjectFs = new MultiProjectFSAdapter({
+            veryfront: {
+              apiBaseUrl: "https://api.example.com",
+              proxyMode: true,
+              cache: { enabled: false },
+            },
+          });
+          const mockAdapter = createMockAdapter();
+          let serveCalled = false;
+
+          const proxyAdapter: RuntimeAdapter = {
+            ...mockAdapter,
+            fs: new FSAdapterWrapper(multiProjectFs),
+            serve: (_handler, options) => {
+              serveCalled = true;
+              const hostname = options.hostname ?? "127.0.0.1";
+              const port = options.port ?? 0;
+              options.onListen?.({ hostname, port });
+              return Promise.resolve({
+                stop: () => Promise.resolve(),
+                addr: { hostname, port },
+              });
+            },
+          };
+
+          let server: Awaited<ReturnType<typeof startProductionServer>> | undefined;
+          try {
+            server = await startProductionServer({
+              projectDir: "/app",
+              port: 0,
+              bindAddress: "127.0.0.1",
+              adapter: proxyAdapter,
+              bootstrapResult: {
+                adapter: proxyAdapter,
+                config: {
+                  fs: {
+                    type: "veryfront",
+                    veryfront: {
+                      apiBaseUrl: "https://api.example.com",
+                      proxyMode: true,
+                    },
+                  },
+                },
+                usingFSAdapter: true,
+                fsAdapterType: "MultiProjectFSAdapter",
+                extensionLoader: {} as BootstrapResult["extensionLoader"],
+              },
+            });
+            await server.ready;
+
+            assert(serveCalled, "Proxy production server must reach its listening state");
+          } finally {
+            await server?.stop();
+            multiProjectFs.dispose();
+          }
+        });
+
         it("applies root middleware.ts to requests", async () => {
           await withTestContext("prod-project-middleware", async (context) => {
             await writeTextFile(

--- a/tests/integration/server/production-server.test.ts
+++ b/tests/integration/server/production-server.test.ts
@@ -26,6 +26,7 @@ import { startProductionServer } from "../../../src/server/production-server.ts"
 import { TestDataFactory } from "../../fixtures/test-data-factory.ts";
 import { withTestContext } from "../../_helpers/context.ts";
 import { cleanupBundler } from "../../../src/rendering/cleanup.ts";
+import { invalidateProjectMiddlewareCache } from "../../../src/server/runtime-handler/project-middleware.ts";
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -481,6 +482,135 @@ describe(
             assert(serveCalled, "Proxy production server must reach its listening state");
           } finally {
             await server?.stop();
+            multiProjectFs.dispose();
+          }
+        });
+
+        it("loads shared proxy middleware after trusted request context is resolved", async () => {
+          const projectSlug = "shared-middleware-project";
+          const projectId = "shared-middleware-project-id";
+          const releaseId = "shared-middleware-release";
+          const middlewareSource = `export default function projectMiddleware() {
+            return new Response("shared middleware", {
+              status: 418,
+              headers: { "x-shared-middleware": "applied" },
+            });
+          }`;
+          const projectFs = {
+            exists: (path: string) => Promise.resolve(path === "/app/middleware.ts"),
+            readFile: () => Promise.resolve(middlewareSource),
+            readTextFile: () => Promise.resolve(middlewareSource),
+            readOptionalTextFile: () => Promise.resolve(middlewareSource),
+          };
+          const resolvedContexts: Array<{
+            projectSlug: string;
+            projectId?: string;
+            productionMode?: boolean;
+            releaseId?: string | null;
+          }> = [];
+          const multiProjectFs = new MultiProjectFSAdapter({
+            veryfront: {
+              apiBaseUrl: "https://api.example.com",
+              proxyMode: true,
+              cache: { enabled: false },
+            },
+          });
+          const originalManager = (multiProjectFs as any).manager;
+          (multiProjectFs as any).manager = {
+            getAdapter(
+              resolvedSlug: string,
+              _token: string,
+              resolvedProjectId?: string,
+              productionMode?: boolean,
+              resolvedReleaseId?: string | null,
+            ) {
+              resolvedContexts.push({
+                projectSlug: resolvedSlug,
+                projectId: resolvedProjectId,
+                productionMode,
+                releaseId: resolvedReleaseId,
+              });
+              return Promise.resolve(projectFs);
+            },
+            getStats: () => ({ adapters: 0, stats: [] }),
+            dispose: () => {},
+          };
+
+          const mockAdapter = createMockAdapter();
+          let servedHandler: ((request: Request) => Promise<Response> | Response) | undefined;
+          const proxyAdapter: RuntimeAdapter = {
+            ...mockAdapter,
+            fs: new FSAdapterWrapper(multiProjectFs),
+            serve: (handler, options) => {
+              servedHandler = handler;
+              const hostname = options.hostname ?? "127.0.0.1";
+              const port = options.port ?? 0;
+              options.onListen?.({ hostname, port });
+              return Promise.resolve({
+                stop: () => Promise.resolve(),
+                addr: { hostname, port },
+              });
+            },
+          };
+
+          let server: Awaited<ReturnType<typeof startProductionServer>> | undefined;
+          try {
+            server = await startProductionServer({
+              projectDir: "/app",
+              port: 0,
+              bindAddress: "127.0.0.1",
+              adapter: proxyAdapter,
+              bootstrapResult: {
+                adapter: proxyAdapter,
+                config: {
+                  fs: {
+                    type: "veryfront",
+                    veryfront: {
+                      apiBaseUrl: "https://api.example.com",
+                      proxyMode: true,
+                    },
+                  },
+                },
+                usingFSAdapter: true,
+                fsAdapterType: "MultiProjectFSAdapter",
+                extensionLoader: {} as BootstrapResult["extensionLoader"],
+              },
+            });
+            await server.ready;
+            assertExists(servedHandler);
+
+            const response = await servedHandler(
+              new Request(`https://${projectSlug}.production.veryfront.com/protected`, {
+                headers: {
+                  "x-project-slug": projectSlug,
+                  "x-project-id": projectId,
+                  "x-release-id": releaseId,
+                  "x-token": "request-token",
+                },
+              }),
+            );
+
+            assertEquals(response.status, 418);
+            assertEquals(await response.text(), "shared middleware");
+            assertEquals(response.headers.get("x-shared-middleware"), "applied");
+            assert(
+              resolvedContexts.length >= 1 &&
+                resolvedContexts.every((context) =>
+                  context.projectSlug === projectSlug &&
+                  context.projectId === projectId
+                ),
+              "Every filesystem lookup must use the resolved project context",
+            );
+            assert(
+              resolvedContexts.some((context) =>
+                context.productionMode === true && context.releaseId === releaseId
+              ),
+              "Middleware loading must use production release context",
+            );
+          } finally {
+            invalidateProjectMiddlewareCache(projectSlug, projectId);
+            await server?.stop();
+            (multiProjectFs as any).manager = originalManager;
             multiProjectFs.dispose();
           }
         });


### PR DESCRIPTION
## Problem

Framework 0.1.1057 added root project middleware to dedicated production servers, but shared proxy renderers cannot inspect tenant files at process startup because their multi-project filesystem requires authenticated request context. Startup failed before readiness, and simply skipping discovery would leave shared and dedicated runtimes with different security behavior.

## Change

- keep shared renderers bootable by skipping tenant filesystem discovery during process startup
- resolve shared project middleware only after trusted project, token, environment, release, and branch context exists
- cache compiled middleware by immutable source identity with bounded LRU storage and explicit project invalidation
- preserve middleware ordering, short-circuit behavior, request identity, WebSocket handoff, `handler.ready`, and project environment isolation
- fail closed in production for read, compile, import, and malformed-export failures
- preserve nonfatal development diagnostics
- publish the combined correction as `0.1.1059`

The implementation does not manufacture tenant context, choose projects from request selector headers, swallow production failures, or crash the shared process for one project.

## Verification

- `deno task verify:quick`
- full framework suite: 2,798 tests / 23,567 steps passed
- protected pre-push suite: 2,380 tests / 20,202 steps passed
- npm build and package policy tests
- shared production integration with the real multi-project filesystem
- concurrent project isolation, release/branch changes, invalidation, absence, malformed source/export, ordering, short-circuit, environment, request identity, and bounded-cache regressions
- independent code review: no remaining blockers

## Rollout

After merge and RC deployment, run a shared-runtime staging canary that exercises middleware on one project and confirms normal routing on an unrelated project.

Related: veryfront/veryfront-studio#5873, veryfront/veryfront-studio#5874, veryfront/veryfront-issue-inbox#41