### PR TITLE
Add MLflow eval report exporter

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -16,6 +16,7 @@ import {
   applyGatewayBillingGroupFinalization,
   createDefaultEvalReportDir,
   createEvalArtifactPaths,
+  createEvalCliExportConfig,
   createEvalExitCode,
   createEvalMarkdownReport,
   createEvalModelArtifactPaths,
@@ -26,6 +27,7 @@ import {
   createResultsJsonl,
   createSummaryArtifact,
   createToolAdapter,
+  type EvalOptions,
   exportEvalReportForCli,
   finalizeGatewayBillingGroup,
   findEvalForCliId,
@@ -35,6 +37,8 @@ import {
   normalizeEvalInputForAgent,
   normalizeToolCalls,
   normalizeUsage,
+  resolveEvalExporterIds,
+  resolveEvalExportRedactionFromEnv,
   resolveToolTargetId,
   runEvalWithGatewayBillingGroup,
   summarizeReportForCli,
@@ -46,7 +50,21 @@ const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
 const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
 const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
 const originalXdgConfigHome = Deno.env.get("XDG_CONFIG_HOME");
+const originalEvalExport = Deno.env.get("VERYFRONT_EVAL_EXPORT");
+const originalEvalExporters = Deno.env.get("VERYFRONT_EVAL_EXPORTERS");
 const originalFetch = globalThis.fetch;
+const redactionEnvNames = [
+  "VERYFRONT_EVAL_EXPORT_INCLUDE_INPUTS",
+  "VERYFRONT_EVAL_EXPORT_INCLUDE_OUTPUTS",
+  "VERYFRONT_EVAL_EXPORT_INCLUDE_REFERENCES",
+  "VERYFRONT_EVAL_EXPORT_INCLUDE_TRACES",
+  "VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EVIDENCE",
+  "VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EXPLANATIONS",
+  "VERYFRONT_EVAL_EXPORT_METADATA_ALLOWLIST",
+] as const;
+const originalRedactionEnv = Object.fromEntries(
+  redactionEnvNames.map((name) => [name, Deno.env.get(name)]),
+) as Record<(typeof redactionEnvNames)[number], string | undefined>;
 
 function restoreEnv(): void {
   if (originalApiToken === undefined) {
@@ -71,6 +89,27 @@ function restoreEnv(): void {
     Deno.env.delete("XDG_CONFIG_HOME");
   } else {
     Deno.env.set("XDG_CONFIG_HOME", originalXdgConfigHome);
+  }
+
+  if (originalEvalExport === undefined) {
+    Deno.env.delete("VERYFRONT_EVAL_EXPORT");
+  } else {
+    Deno.env.set("VERYFRONT_EVAL_EXPORT", originalEvalExport);
+  }
+
+  if (originalEvalExporters === undefined) {
+    Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
+  } else {
+    Deno.env.set("VERYFRONT_EVAL_EXPORTERS", originalEvalExporters);
+  }
+
+  for (const name of redactionEnvNames) {
+    const original = originalRedactionEnv[name];
+    if (original === undefined) {
+      Deno.env.delete(name);
+    } else {
+      Deno.env.set(name, original);
+    }
   }
 
   globalThis.fetch = originalFetch;
@@ -232,6 +271,113 @@ describe("eval CLI command helpers", () => {
   it("normalizes eval ids without requiring users to type the namespace", () => {
     assertEquals(normalizeEvalCliId("deep-research"), "eval:deep-research");
     assertEquals(normalizeEvalCliId("eval:deep-research"), "eval:deep-research");
+  });
+
+  it("resolves eval exporters from CLI flags instead of environment defaults", () => {
+    Deno.env.set("VERYFRONT_EVAL_EXPORTERS", "mlflow,braintrust");
+    Deno.env.set("VERYFRONT_EVAL_EXPORT", "langfuse");
+
+    assertEquals(resolveEvalExporterIds({ exporters: ["custom"] }), ["custom"]);
+  });
+
+  it("resolves plural eval exporter env before the legacy env var", () => {
+    Deno.env.set("VERYFRONT_EVAL_EXPORTERS", "mlflow,braintrust");
+    Deno.env.set("VERYFRONT_EVAL_EXPORT", "langfuse");
+
+    assertEquals(resolveEvalExporterIds({ exporters: [] }), ["mlflow", "braintrust"]);
+  });
+
+  it("uses the legacy eval exporter env var only when the plural env var is unset", () => {
+    Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
+    Deno.env.set("VERYFRONT_EVAL_EXPORT", "langfuse");
+
+    assertEquals(resolveEvalExporterIds({ exporters: [] }), ["langfuse"]);
+  });
+
+  it("keeps eval export redaction safe by default", () => {
+    for (const name of redactionEnvNames) Deno.env.delete(name);
+
+    assertEquals(resolveEvalExportRedactionFromEnv(), {});
+  });
+
+  it("threads the runtime project slug into eval export context", () => {
+    const registry = createEvalReportExporterRegistry();
+    const config = createEvalCliExportConfig(
+      {
+        id: "eval:answers",
+        filePath: "/repo/evals/answers.eval.ts",
+        exportName: "default",
+        definition: {
+          id: "eval:answers",
+          target: "agent:assistant",
+          targetKind: "agent",
+          dataset: { kind: "inline", examples: [] },
+          metrics: [],
+        },
+      } as unknown as DiscoveredEval,
+      { exporters: ["mlflow"] } as EvalOptions,
+      "/repo",
+      createEvalArtifactPaths("/tmp/report"),
+      registry,
+      { projectSlug: "customer-support-agent" },
+    );
+
+    assertEquals(config?.context?.projectReference, "customer-support-agent");
+  });
+
+  it("lists evals without initializing selected exporter extensions", async () => {
+    const projectDir = await Deno.makeTempDir();
+    try {
+      const command = new Deno.Command(Deno.execPath(), {
+        args: [
+          "run",
+          "--allow-all",
+          new URL("../../main.ts", import.meta.url).pathname,
+          "eval",
+          "--list",
+          "--export",
+          "mlflow",
+        ],
+        cwd: projectDir,
+        clearEnv: true,
+        env: {
+          HOME: Deno.env.get("HOME") ?? projectDir,
+          PATH: Deno.env.get("PATH") ?? "",
+          NO_COLOR: "1",
+          MLFLOW_TRACKING_URI: "file:///tmp/mlruns",
+        },
+      });
+
+      const result = await command.output();
+      const output = `${new TextDecoder().decode(result.stdout)}${
+        new TextDecoder().decode(result.stderr)
+      }`;
+
+      assertEquals(result.code, 0, output);
+      assertStringIncludes(output, "No evals found.");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("resolves eval export redaction from exact global env toggles", () => {
+    Deno.env.set("VERYFRONT_EVAL_EXPORT_INCLUDE_INPUTS", "true");
+    Deno.env.set("VERYFRONT_EVAL_EXPORT_INCLUDE_OUTPUTS", "1");
+    Deno.env.set("VERYFRONT_EVAL_EXPORT_INCLUDE_REFERENCES", "yes");
+    Deno.env.set("VERYFRONT_EVAL_EXPORT_INCLUDE_TRACES", "on");
+    Deno.env.set("VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EVIDENCE", "true");
+    Deno.env.set("VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EXPLANATIONS", "true");
+    Deno.env.set("VERYFRONT_EVAL_EXPORT_METADATA_ALLOWLIST", "topic,tenantId topic");
+
+    assertEquals(resolveEvalExportRedactionFromEnv(), {
+      includeInputs: true,
+      includeOutputs: true,
+      includeReferences: true,
+      includeTraces: true,
+      includeMetricEvidence: true,
+      includeMetricExplanations: true,
+      metadataAllowlist: ["topic", "tenantId"],
+    });
   });
 
   it("finds explicit eval ids without forcing the namespace", () => {
@@ -871,6 +1017,21 @@ describe("eval CLI command helpers", () => {
     } finally {
       await Deno.remove(tempDir, { recursive: true });
     }
+  });
+
+  it("reports unknown CLI eval exporters as failed export results", async () => {
+    const exported = await exportEvalReportForCli(createReport(), {
+      registry: createEvalReportExporterRegistry(),
+      exporterIds: ["missing"],
+    });
+
+    assertEquals(exported.exports, [
+      {
+        exporterId: "missing",
+        ok: false,
+        error: 'No EvalReportExporter registered for "missing".',
+      },
+    ]);
   });
 
   it("renders a markdown eval report", () => {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -23,6 +23,14 @@ import type {
   EvalUsage,
 } from "veryfront/eval";
 import { createProjectDiscoveryConfig, discoverAll } from "veryfront/discovery";
+import { orchestrateExtensions } from "veryfront/extensions";
+import {
+  createEvalReportExporterRegistry,
+  type EvalReportExporterRegistry,
+  EvalReportExporterRegistryName,
+  type EvalReportExportRedaction,
+} from "veryfront/extensions/eval";
+import { createLLMProviderRegistry, LLMProviderRegistryName } from "veryfront/extensions/llm";
 import {
   compareEvalModelReports,
   compareEvalReports,
@@ -48,6 +56,7 @@ import {
   outputJson,
 } from "../../shared/json-output.ts";
 import { withProjectSourceContext } from "../../shared/project-source-context.ts";
+import { createEvalCliBuiltinExtensions } from "../../../src/extensions/builtin-extensions.ts";
 import type { EvalArgs } from "./handler.ts";
 
 export interface EvalOptions extends EvalArgs {}
@@ -120,6 +129,16 @@ type GatewayBillingFinalizeOptions = {
 type EvalModelComparisonPolicy = Omit<EvalModelComparisonOptions, "baselineModel">;
 
 const GATEWAY_BILLING_GROUP_USAGE_NOT_READY_CODE = "gateway_billing_group_usage_not_ready";
+const ENV_EVAL_EXPORTERS = "VERYFRONT_EVAL_EXPORTERS";
+const ENV_EVAL_EXPORT = "VERYFRONT_EVAL_EXPORT";
+const ENV_EVAL_EXPORT_INCLUDE_INPUTS = "VERYFRONT_EVAL_EXPORT_INCLUDE_INPUTS";
+const ENV_EVAL_EXPORT_INCLUDE_OUTPUTS = "VERYFRONT_EVAL_EXPORT_INCLUDE_OUTPUTS";
+const ENV_EVAL_EXPORT_INCLUDE_REFERENCES = "VERYFRONT_EVAL_EXPORT_INCLUDE_REFERENCES";
+const ENV_EVAL_EXPORT_INCLUDE_TRACES = "VERYFRONT_EVAL_EXPORT_INCLUDE_TRACES";
+const ENV_EVAL_EXPORT_INCLUDE_METRIC_EVIDENCE = "VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EVIDENCE";
+const ENV_EVAL_EXPORT_INCLUDE_METRIC_EXPLANATIONS =
+  "VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EXPLANATIONS";
+const ENV_EVAL_EXPORT_METADATA_ALLOWLIST = "VERYFRONT_EVAL_EXPORT_METADATA_ALLOWLIST";
 // Gateway usage capture is eventually consistent after model streams close.
 const DEFAULT_GATEWAY_BILLING_FINALIZE_RETRY_DELAYS_MS = [
   500,
@@ -1142,23 +1161,29 @@ function printReport(report: EvalReport, baseline?: EvalReportComparison): void 
   }
 }
 
-function createEvalCliExportConfig(
+export function createEvalCliExportConfig(
   evalItem: DiscoveredEval,
   options: EvalOptions,
   projectDir: string,
   artifactPaths: EvalArtifactPaths,
+  registry: EvalReportExporterRegistry,
+  config?: EvalRuntimeAuthConfig | null,
 ): EvalReportExportConfig | undefined {
-  if (options.exporters.length === 0) return undefined;
+  const exporterIds = resolveEvalExporterIds(options);
+  if (exporterIds.length === 0) return undefined;
+  const projectReference = resolveEvalRuntimeProjectSlug(config);
 
   return {
-    exporterIds: options.exporters,
+    registry,
+    exporterIds,
     context: {
       evalId: evalItem.definition.id,
+      ...(projectReference ? { projectReference } : {}),
       sourcePath: displaySourcePath(evalItem.filePath, projectDir),
       reportPath: options.report ?? artifactPaths.summary,
       tags: evalItem.definition.tags,
       metadata: evalItem.definition.metadata,
-      redaction: {},
+      redaction: resolveEvalExportRedactionFromEnv(),
     },
   };
 }
@@ -1177,6 +1202,117 @@ type ResolvedEvalModelComparisonConfig = {
 
 function uniqueValues(values: string[]): string[] {
   return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+function readEvalCliEnv(name: string): string | undefined {
+  try {
+    const value = Deno.env.get(name);
+    return value && value.trim().length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseEvalExporterList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(/[,\s]+/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export function resolveEvalExporterIds(options: Pick<EvalOptions, "exporters">): string[] {
+  if (options.exporters.length > 0) return uniqueValues(options.exporters);
+
+  const envExporters = parseEvalExporterList(readEvalCliEnv(ENV_EVAL_EXPORTERS));
+  if (envExporters.length > 0) return uniqueValues(envExporters);
+
+  return uniqueValues(parseEvalExporterList(readEvalCliEnv(ENV_EVAL_EXPORT)));
+}
+
+function parseEvalExportBooleanEnv(name: string): boolean | undefined {
+  const value = readEvalCliEnv(name)?.toLowerCase();
+  if (value === undefined) return undefined;
+  if (["1", "true", "yes", "on"].includes(value)) return true;
+  if (["0", "false", "no", "off"].includes(value)) return false;
+  return false;
+}
+
+function assignEvalExportBooleanEnv(
+  redaction: EvalReportExportRedaction,
+  key: keyof Pick<
+    EvalReportExportRedaction,
+    | "includeInputs"
+    | "includeOutputs"
+    | "includeReferences"
+    | "includeTraces"
+    | "includeMetricEvidence"
+    | "includeMetricExplanations"
+  >,
+  envName: string,
+): void {
+  const value = parseEvalExportBooleanEnv(envName);
+  if (value !== undefined) redaction[key] = value;
+}
+
+export function resolveEvalExportRedactionFromEnv(): EvalReportExportRedaction {
+  const redaction: EvalReportExportRedaction = {};
+  assignEvalExportBooleanEnv(redaction, "includeInputs", ENV_EVAL_EXPORT_INCLUDE_INPUTS);
+  assignEvalExportBooleanEnv(redaction, "includeOutputs", ENV_EVAL_EXPORT_INCLUDE_OUTPUTS);
+  assignEvalExportBooleanEnv(redaction, "includeReferences", ENV_EVAL_EXPORT_INCLUDE_REFERENCES);
+  assignEvalExportBooleanEnv(redaction, "includeTraces", ENV_EVAL_EXPORT_INCLUDE_TRACES);
+  assignEvalExportBooleanEnv(
+    redaction,
+    "includeMetricEvidence",
+    ENV_EVAL_EXPORT_INCLUDE_METRIC_EVIDENCE,
+  );
+  assignEvalExportBooleanEnv(
+    redaction,
+    "includeMetricExplanations",
+    ENV_EVAL_EXPORT_INCLUDE_METRIC_EXPLANATIONS,
+  );
+
+  const metadataAllowlist = parseEvalExporterList(
+    readEvalCliEnv(ENV_EVAL_EXPORT_METADATA_ALLOWLIST),
+  );
+  if (metadataAllowlist.length > 0) redaction.metadataAllowlist = uniqueValues(metadataAllowlist);
+
+  return redaction;
+}
+
+type EvalCliExtensionSetup = {
+  loader: Awaited<ReturnType<typeof orchestrateExtensions>>;
+  exporterRegistry: EvalReportExporterRegistry;
+};
+
+function createEvalCliPrimeContracts(): {
+  contracts: Record<string, unknown>;
+  exporterRegistry: EvalReportExporterRegistry;
+} {
+  const exporterRegistry = createEvalReportExporterRegistry();
+  return {
+    exporterRegistry,
+    contracts: {
+      [LLMProviderRegistryName]: createLLMProviderRegistry(),
+      [EvalReportExporterRegistryName]: exporterRegistry,
+    },
+  };
+}
+
+async function setupEvalCliExtensions(
+  projectDir: string,
+  config: VeryfrontConfig,
+  exporterIds: string[],
+): Promise<EvalCliExtensionSetup> {
+  const primeContracts = createEvalCliPrimeContracts();
+  const loader = await orchestrateExtensions({
+    projectDir,
+    config,
+    logger: cliLogger.component("eval-extensions"),
+    primeContracts: primeContracts.contracts,
+    builtinExtensions: createEvalCliBuiltinExtensions(exporterIds),
+  });
+  return { loader, exporterRegistry: primeContracts.exporterRegistry };
 }
 
 function resolveEvalModelComparisonConfig(
@@ -1236,7 +1372,9 @@ async function runEvalModelComparison(input: {
   projectDir: string;
   config: EvalModelComparisonConfig;
   policy: EvalModelComparisonPolicy;
-}): Promise<void> {
+  exporterRegistry: EvalReportExporterRegistry;
+  projectReference?: string;
+}): Promise<0 | 1> {
   const runId = createEvalRunId();
   const reportDir = input.options.reportDir ??
     createDefaultEvalReportDir(runId, input.evalItem.id);
@@ -1256,6 +1394,8 @@ async function runEvalModelComparison(input: {
       modelOptions,
       input.projectDir,
       modelPaths,
+      input.exporterRegistry,
+      input.projectReference ? { projectSlug: input.projectReference } : undefined,
     );
     const finalizedReport = await runEvalWithGatewayBillingGroup(
       modelRunId,
@@ -1314,10 +1454,10 @@ async function runEvalModelComparison(input: {
     if (input.options.report) cliLogger.info(`Report: ${input.options.report}`);
   }
 
-  exitProcess(createEvalModelComparisonExitCode(reports));
+  return createEvalModelComparisonExitCode(reports);
 }
 
-async function outputEvalNotFound(id: string, evals: DiscoveredEval[]): Promise<void> {
+async function outputEvalNotFound(id: string, evals: DiscoveredEval[]): Promise<1> {
   if (isJsonMode()) {
     await outputJson(createErrorEnvelope("eval", {
       code: "NOT_FOUND",
@@ -1334,10 +1474,10 @@ async function outputEvalNotFound(id: string, evals: DiscoveredEval[]): Promise<
       cliLogger.info("No evals found. Create an eval file in evals/.");
     }
   }
-  exitProcess(1);
+  return 1;
 }
 
-async function outputAgentNotFound(agentId: string): Promise<void> {
+async function outputAgentNotFound(agentId: string): Promise<1> {
   if (isJsonMode()) {
     await outputJson(createErrorEnvelope("eval", {
       code: "NOT_FOUND",
@@ -1347,10 +1487,10 @@ async function outputAgentNotFound(agentId: string): Promise<void> {
   } else {
     cliLogger.error(`Agent "${agentId}" not found for eval target.`);
   }
-  exitProcess(1);
+  return 1;
 }
 
-async function outputToolNotFound(toolId: string): Promise<void> {
+async function outputToolNotFound(toolId: string): Promise<1> {
   if (isJsonMode()) {
     await outputJson(createErrorEnvelope("eval", {
       code: "NOT_FOUND",
@@ -1360,10 +1500,10 @@ async function outputToolNotFound(toolId: string): Promise<void> {
   } else {
     cliLogger.error(`Tool "${toolId}" not found for eval target.`);
   }
-  exitProcess(1);
+  return 1;
 }
 
-async function outputEvalUsageError(message: string): Promise<void> {
+async function outputEvalUsageError(message: string): Promise<2> {
   if (isJsonMode()) {
     await outputJson(createErrorEnvelope("eval", {
       code: "USAGE_ERROR",
@@ -1373,13 +1513,13 @@ async function outputEvalUsageError(message: string): Promise<void> {
   } else {
     cliLogger.error(message);
   }
-  exitProcess(2);
+  return 2;
 }
 
 export async function evalCommand(options: EvalOptions): Promise<void> {
   const projectDir = Deno.cwd();
 
-  await withProjectSourceContext(projectDir, async ({ adapter, config }) => {
+  const exitCode = await withProjectSourceContext(projectDir, async ({ adapter, config }) => {
     await hydrateEvalRuntimeAuth(projectDir, config);
 
     const evalDiscovery = await discoverEvals({ projectDir, adapter, config });
@@ -1394,19 +1534,19 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
       const evals = listEvals(evalDiscovery.evals, projectDir);
       if (isJsonMode()) {
         await outputJson(createSuccessEnvelope("eval", { evals, errors: evalDiscovery.errors }));
-        return;
+        return undefined;
       }
 
       if (evals.length === 0) {
         cliLogger.info("No evals found.");
-        return;
+        return undefined;
       }
 
       cliLogger.info("Evals:");
       for (const item of evals) {
         cliLogger.info(`  - ${item.id} (${item.target})`);
       }
-      return;
+      return undefined;
     }
 
     if (!options.id) {
@@ -1419,139 +1559,153 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
       } else {
         cliLogger.error("Eval id is required. Usage: veryfront eval <eval-id>");
       }
-      exitProcess(2);
-      return;
+      return 2;
     }
 
     const evalId = normalizeEvalCliId(options.id);
     const evalItem = findEvalForCliId(evalDiscovery.evals, options.id);
     if (!evalItem) {
-      await outputEvalNotFound(evalId, evalDiscovery.evals);
-      return;
+      return await outputEvalNotFound(evalId, evalDiscovery.evals);
     }
 
     let modelComparisonConfig: ResolvedEvalModelComparisonConfig | undefined;
     try {
       modelComparisonConfig = await createResolvedEvalModelComparisonConfig(projectDir, options);
     } catch (error) {
-      await outputEvalUsageError(error instanceof Error ? error.message : String(error));
-      return;
+      return await outputEvalUsageError(error instanceof Error ? error.message : String(error));
     }
 
     if (evalItem.definition.targetKind !== "agent") {
       if (modelComparisonConfig) {
-        await outputEvalUsageError("Model comparison flags are only supported for agent evals.");
-        return;
+        return await outputEvalUsageError(
+          "Model comparison flags are only supported for agent evals.",
+        );
       }
       if (options.model || options.maxOutputTokens) {
-        await outputEvalUsageError(
+        return await outputEvalUsageError(
           "--model and --max-output-tokens are only supported for agent evals.",
         );
-        return;
       }
     }
 
-    const discoveryConfig = createProjectDiscoveryConfig({
-      projectDir,
-      config,
-      fsAdapter: adapter.fs,
-      verbose: options.debug,
-    });
-    const projectDiscovery = await discoverAll(discoveryConfig);
-    const agentId = evalItem.definition.targetKind === "agent"
-      ? resolveAgentTargetId(evalItem.definition.target)
-      : undefined;
-    const toolId = evalItem.definition.targetKind === "tool"
-      ? resolveToolTargetId(evalItem.definition.target)
-      : undefined;
-    const agent = agentId ? projectDiscovery.agents.get(agentId) : undefined;
-    const tool = toolId ? projectDiscovery.tools.get(toolId) : undefined;
+    const selectedExporterIds = resolveEvalExporterIds(options);
+    const extensionSetup = await setupEvalCliExtensions(projectDir, config, selectedExporterIds);
 
-    if (agentId && !agent) {
-      await outputAgentNotFound(agentId);
-      return;
-    }
-    if (toolId && !tool) {
-      await outputToolNotFound(toolId);
-      return;
-    }
+    try {
+      const discoveryConfig = createProjectDiscoveryConfig({
+        projectDir,
+        config,
+        fsAdapter: adapter.fs,
+        verbose: options.debug,
+      });
+      const projectDiscovery = await discoverAll(discoveryConfig);
+      const agentId = evalItem.definition.targetKind === "agent"
+        ? resolveAgentTargetId(evalItem.definition.target)
+        : undefined;
+      const toolId = evalItem.definition.targetKind === "tool"
+        ? resolveToolTargetId(evalItem.definition.target)
+        : undefined;
+      const agent = agentId ? projectDiscovery.agents.get(agentId) : undefined;
+      const tool = toolId ? projectDiscovery.tools.get(toolId) : undefined;
 
-    if (modelComparisonConfig) {
-      await runEvalModelComparison({
+      if (agentId && !agent) {
+        return await outputAgentNotFound(agentId);
+      }
+      if (toolId && !tool) {
+        return await outputToolNotFound(toolId);
+      }
+
+      if (modelComparisonConfig) {
+        return await runEvalModelComparison({
+          evalItem,
+          agent: agent!,
+          options,
+          projectDir,
+          config: modelComparisonConfig.config,
+          policy: modelComparisonConfig.policy,
+          exporterRegistry: extensionSetup.exporterRegistry,
+          projectReference: resolveEvalRuntimeProjectSlug(config),
+        });
+      }
+
+      const runId = createEvalRunId();
+      const artifactPaths = createEvalArtifactPaths(
+        options.reportDir ?? createDefaultEvalReportDir(runId, evalItem.id),
+      );
+      const provenance = await resolveEvalRunProvenance({
+        projectDir,
+        frameworkVersion: VERSION,
+      });
+      const billingGroupId = options.model
+        ? `${runId}_${sanitizeModelIdForPath(options.model)}`
+        : runId;
+      const exportConfig = createEvalCliExportConfig(
         evalItem,
-        agent: agent!,
         options,
         projectDir,
-        config: modelComparisonConfig.config,
-        policy: modelComparisonConfig.policy,
-      });
-      return;
-    }
+        artifactPaths,
+        extensionSetup.exporterRegistry,
+        config,
+      );
+      const finalizedReport = await runEvalWithGatewayBillingGroup(
+        billingGroupId,
+        () =>
+          runEval(evalItem.definition, {
+            baseDir: options.datasetBase ?? projectDir,
+            runId,
+            adapters: evalItem.definition.targetKind === "tool"
+              ? { tool: createToolAdapter(tool!, createEvalToolExecutionContext(config)) }
+              : { agent: createAgentAdapter(agent!, options) },
+            metadata: {
+              provenance,
+              ...(options.model ? { model: options.model } : {}),
+            },
+          }),
+      );
+      const report = await exportEvalReportForCli(finalizedReport, exportConfig);
 
-    const runId = createEvalRunId();
-    const artifactPaths = createEvalArtifactPaths(
-      options.reportDir ?? createDefaultEvalReportDir(runId, evalItem.id),
-    );
-    const provenance = await resolveEvalRunProvenance({
-      projectDir,
-      frameworkVersion: VERSION,
-    });
-    const billingGroupId = options.model
-      ? `${runId}_${sanitizeModelIdForPath(options.model)}`
-      : runId;
-    const exportConfig = createEvalCliExportConfig(evalItem, options, projectDir, artifactPaths);
-    const finalizedReport = await runEvalWithGatewayBillingGroup(
-      billingGroupId,
-      () =>
-        runEval(evalItem.definition, {
-          baseDir: options.datasetBase ?? projectDir,
-          runId,
-          adapters: evalItem.definition.targetKind === "tool"
-            ? { tool: createToolAdapter(tool!, createEvalToolExecutionContext(config)) }
-            : { agent: createAgentAdapter(agent!, options) },
-          metadata: {
-            provenance,
-            ...(options.model ? { model: options.model } : {}),
-          },
-        }),
-    );
-    const report = await exportEvalReportForCli(finalizedReport, exportConfig);
+      const baseline = options.baseline
+        ? compareEvalReports(
+          report,
+          await readEvalReport(options.baseline),
+          createEvalBaselineComparisonPolicy(options),
+        )
+        : undefined;
 
-    const baseline = options.baseline
-      ? compareEvalReports(
-        report,
-        await readEvalReport(options.baseline),
-        createEvalBaselineComparisonPolicy(options),
-      )
-      : undefined;
+      await writeEvalArtifacts(report, artifactPaths, baseline);
+      if (options.report) {
+        await writeTextFileEnsuringDir(options.report, JSON.stringify(report, null, 2));
+      }
+      if (options.junit) {
+        await writeTextFileEnsuringDir(options.junit, createJunitXml(report));
+      }
+      if (options.writeBaseline) {
+        await writeTextFileEnsuringDir(options.writeBaseline, JSON.stringify(report, null, 2));
+      }
 
-    await writeEvalArtifacts(report, artifactPaths, baseline);
-    if (options.report) {
-      await writeTextFileEnsuringDir(options.report, JSON.stringify(report, null, 2));
-    }
-    if (options.junit) {
-      await writeTextFileEnsuringDir(options.junit, createJunitXml(report));
-    }
-    if (options.writeBaseline) {
-      await writeTextFileEnsuringDir(options.writeBaseline, JSON.stringify(report, null, 2));
-    }
+      if (isJsonMode()) {
+        await outputJson(createSuccessEnvelope("eval", {
+          report,
+          summary: summarizeReportForCli(report),
+          baseline,
+          artifacts: artifactPaths,
+        }));
+      } else {
+        printReport(report, baseline);
+        cliLogger.info(`Report directory: ${artifactPaths.directory}`);
+        cliLogger.info(`Report markdown: ${artifactPaths.reportMarkdown}`);
+        if (options.report) cliLogger.info(`Report: ${options.report}`);
+        if (options.junit) cliLogger.info(`JUnit: ${options.junit}`);
+        if (options.writeBaseline) cliLogger.info(`Baseline written: ${options.writeBaseline}`);
+      }
 
-    if (isJsonMode()) {
-      await outputJson(createSuccessEnvelope("eval", {
-        report,
-        summary: summarizeReportForCli(report),
-        baseline,
-        artifacts: artifactPaths,
-      }));
-    } else {
-      printReport(report, baseline);
-      cliLogger.info(`Report directory: ${artifactPaths.directory}`);
-      cliLogger.info(`Report markdown: ${artifactPaths.reportMarkdown}`);
-      if (options.report) cliLogger.info(`Report: ${options.report}`);
-      if (options.junit) cliLogger.info(`JUnit: ${options.junit}`);
-      if (options.writeBaseline) cliLogger.info(`Baseline written: ${options.writeBaseline}`);
+      return createEvalExitCode(report, baseline);
+    } finally {
+      await extensionSetup.loader.teardownAll();
     }
-
-    exitProcess(createEvalExitCode(report, baseline));
   });
+
+  if (typeof exitCode === "number") {
+    exitProcess(exitCode);
+  }
 }

--- a/deno.json
+++ b/deno.json
@@ -51,6 +51,7 @@
     "./extensions/ext-parser-babel",
     "./extensions/ext-sandbox-shell-tools",
     "./extensions/ext-observability-opentelemetry",
+    "./extensions/ext-eval-report-mlflow",
     "./extensions/ext-eval-report-http",
     "./extensions/ext-content-mdx",
     "./extensions/ext-schema-zod"

--- a/deno.lock
+++ b/deno.lock
@@ -5230,6 +5230,12 @@
           "jsr:@std/testing@1.0.17"
         ]
       },
+      "extensions/ext-eval-report-mlflow": {
+        "dependencies": [
+          "jsr:@std/assert@1.0.19",
+          "jsr:@std/testing@1.0.17"
+        ]
+      },
       "extensions/ext-llm-anthropic": {
         "dependencies": [
           "jsr:@std/assert@1.0.19",

--- a/docs/concepts/framework-extensions.md
+++ b/docs/concepts/framework-extensions.md
@@ -42,6 +42,10 @@ Use `veryfront/extensions/eval` when a project needs to send completed
 `EvalReport` payloads to an eval platform such as Braintrust, Langfuse, or
 LangSmith. Use `@veryfront/ext-eval-report-http` for a generic HTTP transport
 when a project wants one gateway endpoint instead of vendor SDKs. Use
+`@veryfront/ext-eval-report-mlflow` when reports should be logged as MLflow
+Tracking runs. Select the exporter id from the eval CLI with `--export mlflow`
+or set `VERYFRONT_EVAL_EXPORTERS=mlflow` in CI; `MLFLOW_TRACKING_URI` activates
+the extension without a project config entry. Use
 `veryfront/extensions/observability` for runtime tracing, OpenTelemetry SDK
 setup, spans, and monitoring.
 
@@ -50,3 +54,17 @@ allow inputs, outputs, references, traces, metric evidence, metric explanations,
 or record metadata before those fields leave the process. When OpenTelemetry is
 active, `runEval` attaches the active `traceId` and `spanId` to export context
 unless the caller passes an explicit trace context.
+
+Exporter extensions should stay generic. Project-specific extraction, such as
+turning a product ticket or model response into a classification label, belongs
+in the eval adapter or metric. The MLflow exporter can aggregate classification
+metrics only from safe metric evidence fields, and that evidence requires an
+explicit redaction opt-in. Artifact transport is also part of the exporter
+boundary: v1 supports HTTP(S) artifact roots and HTTP(S) MLflow artifact proxy
+endpoints, not direct uploads to local filesystem roots or backend-specific
+schemes such as `dbfs://`, `gs://`, or `wasbs://`.
+
+Future vendor integrations should be sibling packages behind the same contract.
+For example, Braintrust should be added as a separate
+`@veryfront/ext-eval-report-*` exporter rather than as project-specific logic in
+the MLflow exporter.

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -629,6 +629,33 @@ Gateways should treat `context.trace` as correlation metadata. It is not span
 export, does not include logs or metric streams, and does not replace ambient
 OpenTelemetry export.
 
+Use `@veryfront/ext-eval-report-mlflow` when completed reports should become
+MLflow Tracking runs. The CLI path can be environment-only: set
+`MLFLOW_TRACKING_URI` to activate the extension, then select the fixed exporter
+id `mlflow` for the run.
+
+```bash
+MLFLOW_TRACKING_URI=http://localhost:5001 \
+veryfront eval deep-research --export mlflow
+```
+
+For authenticated MLflow Tracking servers, keep credentials out of
+`MLFLOW_TRACKING_URI`. Use `MLFLOW_TRACKING_TOKEN` for bearer auth or
+`MLFLOW_TRACKING_USERNAME` / `MLFLOW_TRACKING_PASSWORD` for basic auth.
+
+Use `VERYFRONT_EVAL_EXPORTERS=mlflow` when CI should select the same exporter
+for every eval command without repeating `--export`:
+
+```bash
+MLFLOW_TRACKING_URI=http://localhost:5001 \
+VERYFRONT_EVAL_EXPORTERS=mlflow \
+veryfront eval deep-research
+```
+
+`--export` wins over `VERYFRONT_EVAL_EXPORTERS` when both are set. The legacy
+singular `VERYFRONT_EVAL_EXPORT` is used only when
+`VERYFRONT_EVAL_EXPORTERS` is unset.
+
 From the CLI, pass comma-separated exporter ids. Export failures are reported in
 the JSON report and do not prevent local report or JUnit files from being
 written.
@@ -641,6 +668,61 @@ veryfront eval deep-research \
   --export braintrust,langfuse \
   --json
 ```
+
+MLflow artifact uploads support HTTP(S) run artifact roots directly. For
+proxied artifact roots such as `mlflow-artifacts:/...` or object-store-backed
+roots, configure an explicit HTTP(S) MLflow artifact server URI with
+`MLFLOW_ARTIFACTS_URI`. v1 does not upload directly to local filesystem roots or
+backend-specific schemes such as `dbfs://`, `gs://`, `wasbs://`, or similar
+URIs.
+
+The MLflow exporter logs generic aggregate metrics from the normalized
+`EvalReport`; it does not know project-specific label formats. If a project
+wants generic classification aggregates such as accuracy, macro precision,
+macro recall, macro F1, per-category counts, or confusion counts, extract safe
+labels inside the eval metric and place them in metric evidence:
+
+```ts
+{
+  name: "intent.classification",
+  pass: true,
+  evidence: {
+    expectedCategory: "billing",
+    predictedCategory: "billing",
+  },
+}
+```
+
+Metric evidence is redacted by default. Opt in only when the evidence contains
+safe aggregate labels rather than private prompts, outputs, customer records, or
+tool payloads:
+
+```bash
+MLFLOW_TRACKING_URI=http://localhost:5001 \
+VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EVIDENCE=true \
+veryfront eval deep-research --export mlflow
+```
+
+Programmatic eval runs can use the same redaction opt-in through export context:
+
+```ts
+const report = await runEval(definition, {
+  adapters,
+  export: {
+    exporterIds: ["mlflow"],
+    context: {
+      redaction: {
+        includeMetricEvidence: true,
+      },
+    },
+  },
+});
+```
+
+Braintrust should follow the same contract as a sibling
+`@veryfront/ext-eval-report-*` exporter, for example a future
+`@veryfront/ext-eval-report-braintrust`, instead of being special-cased in
+project eval definitions or the MLflow exporter.
 
 ## Discovery
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -58,9 +58,17 @@ Extension availability is separate from contract requirement:
 
 ### Eval export
 
-| Package                                                     | Contract                     | Description                                             |
-| ----------------------------------------------------------- | ---------------------------- | ------------------------------------------------------- |
-| [`@veryfront/ext-eval-report-http`](./ext-eval-report-http) | `EvalReportExporterRegistry` | Generic HTTP transport for redacted eval report exports |
+| Package                                                               | Contract                     | Description                                             |
+| --------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------- |
+| [`@veryfront/ext-eval-report-http`](./ext-eval-report-http)           | `EvalReportExporterRegistry` | Generic HTTP transport for redacted eval report exports |
+| [`@veryfront/ext-eval-report-mlflow`](./ext-eval-report-mlflow)       | `EvalReportExporterRegistry` | MLflow Tracking exporter for redacted eval reports      |
+
+Eval report exporters receive the generic, redacted `EvalReport` shape. Keep
+project-specific extraction in eval adapters or metrics, then select an exporter
+id such as `mlflow` from the CLI with `--export mlflow` or
+`VERYFRONT_EVAL_EXPORTERS=mlflow`. Future vendor integrations such as
+Braintrust should live as sibling `@veryfront/ext-eval-report-*` packages behind
+the same contract.
 
 ### Schema
 
@@ -125,6 +133,7 @@ to satisfy Veryfront runtime features.
 | SQLite-backed persistence                   | `@veryfront/ext-db-sqlite`                                                                                                     |
 | OpenTelemetry export or Node telemetry      | `@veryfront/ext-observability-opentelemetry`                                                                                   |
 | Local shell-tool agent runtime              | `@veryfront/ext-sandbox-shell-tools`                                                                                           |
+| Eval report export to MLflow                | `@veryfront/ext-eval-report-mlflow`                                                                                            |
 
 An agent runtime needs `@veryfront/ext-sandbox-shell-tools` only when it creates
 local bash or shell tools. MCP-only remote tool execution does not need that

--- a/extensions/ext-eval-report-mlflow/README.md
+++ b/extensions/ext-eval-report-mlflow/README.md
@@ -1,0 +1,169 @@
+# @veryfront/ext-eval-report-mlflow
+
+> **Category:** Eval export | **Requires:** `EvalReportExporterRegistry` | **Optional**
+
+Registers the `mlflow` eval report exporter. The exporter id is fixed to
+`mlflow`; it is not configurable by extension config or environment variable.
+Use this extension when completed Veryfront `EvalReport` payloads should be
+written to MLflow Tracking as one run per eval execution.
+
+The exporter is generic. It logs Veryfront report data such as pass/fail counts,
+metric pass rates, duration summaries, usage/tokens/cost fields, and redacted
+report artifacts. Project-specific extraction, such as reading a domain label
+from a ServiceNow ticket or support-agent response, must happen in the eval
+adapter or metric before export. The MLflow exporter only consumes the normalized
+`EvalReport` shape.
+
+## Environment-only usage
+
+No `veryfront.config.ts` entry is required for the common CLI path. Set
+`MLFLOW_TRACKING_URI` to activate the first-party extension, then select the
+`mlflow` exporter for the eval run.
+
+Select the exporter per command:
+
+```bash
+MLFLOW_TRACKING_URI=http://localhost:5001 \
+veryfront eval eval:service-now-classification --export mlflow
+```
+
+Or select it entirely from the environment:
+
+```bash
+MLFLOW_TRACKING_URI=http://localhost:5001 \
+VERYFRONT_EVAL_EXPORTERS=mlflow \
+veryfront eval eval:service-now-classification
+```
+
+`--export mlflow` is explicit for one CLI invocation. `VERYFRONT_EVAL_EXPORTERS`
+is useful in CI when every eval command in the job should export to the same
+backend. If both are set, the CLI flag wins. `VERYFRONT_EVAL_EXPORT` remains a
+legacy singular fallback when `VERYFRONT_EVAL_EXPORTERS` is unset.
+
+## Environment variables
+
+| Variable                                        | Required | Description                                                                                                                  |
+| ----------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `MLFLOW_TRACKING_URI`                           | Yes      | MLflow Tracking server URI. The exporter is not registered unless this is set.                                               |
+| `MLFLOW_EXPERIMENT_NAME`                        | No       | Experiment name. Defaults from project/eval context, then `veryfront-evals`.                                                 |
+| `MLFLOW_RUN_NAME`                               | No       | Run name. Defaults to `<eval-id>-<run-id>`.                                                                                  |
+| `MLFLOW_ARTIFACTS_URI`                          | No       | HTTP(S) MLflow artifact proxy endpoint used when the run artifact root is not directly writable as HTTP(S).                  |
+| `MLFLOW_TRACKING_TOKEN`                         | No       | Bearer token sent to MLflow Tracking REST endpoints. Prefer this over embedding credentials in `MLFLOW_TRACKING_URI`.        |
+| `MLFLOW_TRACKING_USERNAME`                      | No       | Username for basic auth to MLflow Tracking REST endpoints. Use with `MLFLOW_TRACKING_PASSWORD`.                              |
+| `MLFLOW_TRACKING_PASSWORD`                      | No       | Password for basic auth to MLflow Tracking REST endpoints. Use with `MLFLOW_TRACKING_USERNAME`.                              |
+| `VERYFRONT_EVAL_EXPORTERS`                      | No       | Comma- or whitespace-separated exporter ids selected by the CLI when `--export` is omitted. Use `mlflow` for this extension. |
+| `VERYFRONT_EVAL_EXPORT`                         | No       | Legacy singular exporter env var used only when `VERYFRONT_EVAL_EXPORTERS` is unset.                                         |
+| `VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EVIDENCE` | No       | CLI redaction opt-in for metric evidence. Leave unset or false unless evidence contains only safe labels or aggregates.      |
+
+`MLFLOW_TRACKING_URI` must be an HTTP(S) URI without embedded username/password
+credentials. Use `MLFLOW_TRACKING_TOKEN` or
+`MLFLOW_TRACKING_USERNAME`/`MLFLOW_TRACKING_PASSWORD` for authenticated tracking
+servers so credentials are not persisted in eval report export receipts.
+
+## Config usage
+
+Use config when a project wants to pin optional MLflow settings in code.
+Registration is still gated by `MLFLOW_TRACKING_URI` in v1, so set that
+environment variable even when config supplies other fields.
+
+```ts
+import extEvalReportMlflow from "@veryfront/ext-eval-report-mlflow";
+import { defineConfig } from "veryfront";
+
+export default defineConfig({
+  extensions: [
+    extEvalReportMlflow({
+      experimentName: "support-agent-classification",
+    }),
+  ],
+});
+```
+
+Then select the exporter when running the eval:
+
+```bash
+MLFLOW_TRACKING_URI=http://localhost:5001 \
+veryfront eval eval:service-now-classification --export mlflow
+```
+
+## Redaction and classification aggregates
+
+Eval exports are redacted by default before any exporter receives the report.
+Inputs, outputs, references, traces, tool-call payloads, metric evidence, metric
+explanations, and record metadata stay out of exported artifacts unless the eval
+export context explicitly allows them.
+
+The MLflow exporter can emit generic classification aggregate metrics when a
+metric or check result includes normalized category evidence:
+
+```ts
+{
+  name: "intent.classification",
+  pass: true,
+  evidence: {
+    expectedCategory: "billing",
+    predictedCategory: "billing",
+    confidence: 0.94,
+  },
+}
+```
+
+Supported evidence keys are `expectedCategory`, `expectedLabel`, or `expected`
+for the expected class, and `predictedCategory`, `predictedLabel`, or
+`predicted` for the predicted class. Because metric evidence is redacted by
+default, enable it only when those evidence fields are safe to export:
+
+```bash
+MLFLOW_TRACKING_URI=http://localhost:5001 \
+VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EVIDENCE=true \
+veryfront eval eval:service-now-classification --export mlflow
+```
+
+Programmatic eval runs can use the same redaction opt-in through export context:
+
+```ts
+await runEval(definition, {
+  adapters,
+  export: {
+    exporterIds: ["mlflow"],
+    context: {
+      redaction: {
+        includeMetricEvidence: true,
+      },
+    },
+  },
+});
+```
+
+Do not put private prompts, full model outputs, customer records, or vendor API
+payloads into metric evidence just to produce classification aggregates. Extract
+safe labels in the eval metric and export only those labels.
+
+## Artifacts
+
+The exporter uploads these artifacts under `veryfront-eval/`:
+
+- `report.json`
+- `summary.json`
+- `results.jsonl`
+
+v1 artifact transport supports:
+
+- Direct `PUT` uploads when the MLflow run artifact root is `http://` or
+  `https://`.
+- Uploads through an explicit HTTP(S) MLflow artifact proxy configured with
+  `MLFLOW_ARTIFACTS_URI` when the tracking server returns a proxied root such as
+  `mlflow-artifacts:/...` or an object-store-backed root.
+
+It does not upload directly to local filesystem artifact roots or vendor storage
+schemes such as `dbfs://`, `gs://`, `wasbs://`, or similar backend-specific
+URIs. For object storage, run an MLflow artifact proxy and point
+`MLFLOW_ARTIFACTS_URI` at that HTTP(S) endpoint.
+
+## Future vendor exporters
+
+MLflow is one eval-report exporter behind the shared
+`EvalReportExporterRegistry` contract. Braintrust, Langfuse, LangSmith, or other
+vendors should be implemented as sibling `@veryfront/ext-eval-report-*`
+extensions with their own exporter ids instead of adding project-specific logic
+to the MLflow exporter.

--- a/extensions/ext-eval-report-mlflow/deno.json
+++ b/extensions/ext-eval-report-mlflow/deno.json
@@ -1,0 +1,36 @@
+{
+  "name": "@veryfront/ext-eval-report-mlflow",
+  "version": "0.1.0",
+  "exports": "./src/index.ts",
+  "veryfront": {
+    "extension": true,
+    "contracts": {
+      "requires": ["EvalReportExporterRegistry"]
+    },
+    "capabilities": [
+      { "type": "net:outbound", "hosts": ["*"] },
+      {
+        "type": "env:read",
+        "keys": [
+          "MLFLOW_ARTIFACTS_URI",
+          "MLFLOW_EXPERIMENT_NAME",
+          "MLFLOW_RUN_NAME",
+          "MLFLOW_TRACKING_PASSWORD",
+          "MLFLOW_TRACKING_TOKEN",
+          "MLFLOW_TRACKING_URI",
+          "MLFLOW_TRACKING_USERNAME"
+        ]
+      }
+    ]
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1.0.19",
+    "@std/testing/bdd": "jsr:@std/testing@1.0.17/bdd",
+    "veryfront/eval": "../../src/eval/index.ts",
+    "veryfront/extensions": "../../src/extensions/index.ts",
+    "veryfront/extensions/eval": "../../src/extensions/eval/index.ts"
+  },
+  "tasks": {
+    "test": "deno test --no-check --allow-all src/"
+  }
+}

--- a/extensions/ext-eval-report-mlflow/src/index.test.ts
+++ b/extensions/ext-eval-report-mlflow/src/index.test.ts
@@ -1,0 +1,1054 @@
+/**
+ * ext-eval-report-mlflow extension tests.
+ *
+ * @module extensions/ext-eval-report-mlflow/test
+ */
+
+import { assertEquals, assertExists, assertRejects, assertThrows } from "@std/assert";
+import { afterEach, describe, it } from "@std/testing/bdd";
+import type { EvalReport } from "veryfront/eval";
+import type { ExtensionContext } from "veryfront/extensions";
+import {
+  createEvalReportExporterRegistry,
+  type EvalReportExporterRegistry,
+  EvalReportExporterRegistryName,
+} from "veryfront/extensions/eval";
+import factory, { createEvalReportMlflowExporter } from "./index.ts";
+
+const MLFLOW_ENV_KEYS = [
+  "MLFLOW_ARTIFACTS_URI",
+  "MLFLOW_EXPERIMENT_NAME",
+  "MLFLOW_RUN_NAME",
+  "MLFLOW_TRACKING_PASSWORD",
+  "MLFLOW_TRACKING_TOKEN",
+  "MLFLOW_TRACKING_URI",
+  "MLFLOW_TRACKING_USERNAME",
+] as const;
+
+const originalMlflowEnv = new Map(
+  MLFLOW_ENV_KEYS.map((key) => [key, Deno.env.get(key)]),
+);
+
+function createContext(registry: EvalReportExporterRegistry): ExtensionContext {
+  return {
+    get: <T>(name: string) => name === EvalReportExporterRegistryName ? registry as T : undefined,
+    require: <T>(name: string) => {
+      if (name === EvalReportExporterRegistryName) return registry as T;
+      throw new Error(`Missing contract ${name}`);
+    },
+    provide: () => undefined,
+    config: {},
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+  };
+}
+
+function restoreMlflowEnv(): void {
+  for (const key of MLFLOW_ENV_KEYS) {
+    const value = originalMlflowEnv.get(key);
+    if (value === undefined) {
+      Deno.env.delete(key);
+    } else {
+      Deno.env.set(key, value);
+    }
+  }
+}
+
+function clearMlflowEnv(): void {
+  for (const key of MLFLOW_ENV_KEYS) Deno.env.delete(key);
+}
+
+function createReport(): EvalReport {
+  return {
+    kind: "eval-report",
+    runId: "evalrun_1",
+    definitionId: "eval:smoke",
+    targetKind: "agent",
+    target: "agent:support",
+    startedAt: "2026-06-21T00:00:00.000Z",
+    endedAt: "2026-06-21T00:00:01.000Z",
+    summary: {
+      records: 1,
+      passed: 1,
+      failed: 0,
+      passRate: 1,
+      skippedResults: 0,
+      metrics: [
+        {
+          name: "answer.exactMatch",
+          family: "answer",
+          severity: "gate",
+          passed: 1,
+          failed: 0,
+          skipped: 0,
+          passRate: 1,
+        },
+      ],
+      duration: {
+        totalMs: 1000,
+        minMs: 1000,
+        maxMs: 1000,
+        meanMs: 1000,
+        p50Ms: 1000,
+        p95Ms: 1000,
+      },
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        costUsd: 0.01,
+      },
+    },
+    records: [
+      {
+        id: "q1:1",
+        evalId: "eval:smoke",
+        exampleId: "q1",
+        repetition: 1,
+        input: "question",
+        output: { text: "answer" },
+        reference: "answer",
+        metadata: {},
+        trace: { events: [], toolCalls: [] },
+        usage: { totalTokens: 15 },
+        durationMs: 1000,
+        completed: true,
+        metrics: [
+          {
+            name: "answer.exactMatch",
+            family: "answer",
+            severity: "gate",
+            score: 1,
+            pass: true,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function createSensitiveReport(): EvalReport {
+  return {
+    ...createReport(),
+    records: [
+      {
+        ...createReport().records[0]!,
+        input: { prompt: "private customer issue", apiKey: "<REDACTED>" },
+        output: { text: "private answer" },
+        reference: { text: "private reference" },
+        metadata: { tenantId: "tenant-secret", topic: "private" },
+        trace: {
+          events: [{ type: "message", content: "private model output" }],
+          toolCalls: [
+            {
+              id: "tool_1",
+              name: "lookup_customer",
+              status: "ok",
+              input: { customerId: "customer-secret" },
+              output: { result: "private result" },
+              metadata: { token: "<REDACTED>" },
+            },
+          ],
+        },
+        metrics: [
+          {
+            name: "answer.exactMatch",
+            family: "answer",
+            severity: "gate",
+            score: 1,
+            pass: true,
+            explanation: "Private explanation",
+            evidence: {
+              output: "private answer",
+              reference: "private reference",
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+interface RecordedMlflowRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+  body?: string;
+}
+
+function createMlflowFetchRecorder(options: {
+  experimentId?: string;
+  runId?: string;
+  artifactUri?: string;
+} = {}): {
+  requests: RecordedMlflowRequest[];
+  fetchImpl: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>;
+} {
+  const experimentId = options.experimentId ?? "exp-1";
+  const runId = options.runId ?? "run-1";
+  const artifactUri = options.artifactUri ?? "http://artifacts.test/root";
+  const requests: RecordedMlflowRequest[] = [];
+
+  const fetchImpl = (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = String(input);
+    requests.push({
+      url,
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === "string" ? init.body : undefined,
+    });
+
+    if (url.includes("/experiments/get-by-name")) {
+      return Promise.resolve(jsonResponse({
+        error_code: "RESOURCE_DOES_NOT_EXIST",
+        message: "not found",
+      }, 404));
+    }
+    if (url.endsWith("/api/2.0/mlflow/experiments/create")) {
+      return Promise.resolve(jsonResponse({ experiment_id: experimentId }));
+    }
+    if (url.endsWith("/api/2.0/mlflow/runs/create")) {
+      return Promise.resolve(jsonResponse({
+        run: {
+          info: {
+            run_id: runId,
+            artifact_uri: artifactUri,
+          },
+        },
+      }));
+    }
+    if (url.endsWith("/api/2.0/mlflow/runs/log-batch")) {
+      return Promise.resolve(jsonResponse({}));
+    }
+    if (url.endsWith("/api/2.0/mlflow/runs/update")) {
+      return Promise.resolve(jsonResponse({}));
+    }
+    if (init?.method === "PUT") {
+      return Promise.resolve(new Response("", { status: 200 }));
+    }
+    return Promise.resolve(jsonResponse({ message: `unexpected ${url}` }, 500));
+  };
+
+  return { requests, fetchImpl };
+}
+
+describe("ext-eval-report-mlflow", () => {
+  afterEach(() => {
+    restoreMlflowEnv();
+  });
+
+  it("declares the eval report exporter registry dependency", () => {
+    const extension = factory({ trackingUri: "http://mlflow.test" });
+
+    assertEquals(extension.name, "ext-eval-report-mlflow");
+    assertEquals(extension.contracts?.requires, [
+      EvalReportExporterRegistryName,
+    ]);
+    assertEquals(extension.capabilities, [
+      { type: "net:outbound", hosts: ["*"] },
+      {
+        type: "env:read",
+        keys: [
+          "MLFLOW_ARTIFACTS_URI",
+          "MLFLOW_EXPERIMENT_NAME",
+          "MLFLOW_RUN_NAME",
+          "MLFLOW_TRACKING_PASSWORD",
+          "MLFLOW_TRACKING_TOKEN",
+          "MLFLOW_TRACKING_URI",
+          "MLFLOW_TRACKING_USERNAME",
+        ],
+      },
+    ]);
+  });
+
+  it("registers an MLflow eval report exporter during setup when MLFLOW_TRACKING_URI is set", async () => {
+    clearMlflowEnv();
+    Deno.env.set("MLFLOW_TRACKING_URI", "http://mlflow.test");
+    const registry = createEvalReportExporterRegistry();
+    const { fetchImpl } = createMlflowFetchRecorder();
+    const extension = factory({ fetch: fetchImpl });
+
+    await extension.setup?.(createContext(registry));
+
+    assertExists(registry.get("mlflow"));
+  });
+
+  it("unregisters the MLflow eval report exporter during teardown", async () => {
+    clearMlflowEnv();
+    Deno.env.set("MLFLOW_TRACKING_URI", "http://mlflow.test");
+    const registry = createEvalReportExporterRegistry();
+    const { fetchImpl } = createMlflowFetchRecorder();
+    const extension = factory({ fetch: fetchImpl });
+
+    await extension.setup?.(createContext(registry));
+    assertExists(registry.get("mlflow"));
+
+    await extension.teardown?.();
+
+    assertEquals(registry.get("mlflow"), undefined);
+  });
+
+  it("skips exporter registration when no tracking URI is configured", async () => {
+    clearMlflowEnv();
+    const registry = createEvalReportExporterRegistry();
+    const { fetchImpl } = createMlflowFetchRecorder();
+    const extension = factory({ fetch: fetchImpl });
+
+    await extension.setup?.(createContext(registry));
+
+    assertEquals(registry.list(), []);
+  });
+
+  it("uses the fixed mlflow exporter id even when config includes an id field", async () => {
+    clearMlflowEnv();
+    Deno.env.set("MLFLOW_TRACKING_URI", "http://mlflow.test");
+    const registry = createEvalReportExporterRegistry();
+    const { fetchImpl } = createMlflowFetchRecorder();
+    const extension = factory({
+      id: "custom-config",
+      fetch: fetchImpl,
+    });
+
+    await extension.setup?.(createContext(registry));
+
+    assertEquals(registry.list().map((exporter) => exporter.id), ["mlflow"]);
+    assertExists(registry.get("mlflow"));
+    assertEquals(registry.get("custom-config"), undefined);
+  });
+
+  it("rejects non-HTTP tracking URIs before making MLflow REST calls", async () => {
+    assertThrows(
+      () =>
+        createEvalReportMlflowExporter({
+          trackingUri: "file:///tmp/mlruns",
+          experimentName: "support-agent-classification",
+        }),
+      Error,
+      "MLflow trackingUri must be an HTTP(S) URI: file:///tmp/mlruns",
+    );
+
+    clearMlflowEnv();
+    Deno.env.set("MLFLOW_TRACKING_URI", "ftp://mlflow.test");
+    const registry = createEvalReportExporterRegistry();
+    const { fetchImpl } = createMlflowFetchRecorder();
+    const extension = factory({ fetch: fetchImpl });
+
+    assertThrows(
+      () => extension.setup?.(createContext(registry)),
+      Error,
+      "MLflow trackingUri must be an HTTP(S) URI: ftp://mlflow.test",
+    );
+    assertEquals(registry.list(), []);
+  });
+
+  it("rejects credential-bearing tracking URIs and supports standard auth env headers", async () => {
+    assertThrows(
+      () =>
+        createEvalReportMlflowExporter({
+          trackingUri: "https://user:secret-token@mlflow.test",
+          experimentName: "support-agent-classification",
+        }),
+      Error,
+      "MLflow trackingUri must not include credentials",
+    );
+
+    clearMlflowEnv();
+    Deno.env.set("MLFLOW_TRACKING_URI", "https://mlflow.test");
+    Deno.env.set("MLFLOW_TRACKING_TOKEN", "secret-token");
+    const registry = createEvalReportExporterRegistry();
+    const { requests, fetchImpl } = createMlflowFetchRecorder();
+    const extension = factory({ fetch: fetchImpl });
+
+    await extension.setup?.(createContext(registry));
+    const results = await registry.export(createReport(), {
+      projectReference: "customer-support-agent",
+      sourcePath: "evals/service-now-classification.eval.ts",
+    });
+
+    assertEquals(results[0]?.ok, true);
+    const receipt = results[0]?.ok ? results[0].receipt : undefined;
+    assertEquals(receipt?.url, "https://mlflow.test/#/experiments/exp-1/runs/run-1");
+    assertEquals(JSON.stringify(results).includes("secret-token"), false);
+    assertEquals(
+      requests
+        .filter((request) => request.method !== "PUT")
+        .every((request) => request.headers.get("authorization") === "Bearer secret-token"),
+      true,
+    );
+    assertEquals(
+      requests
+        .filter((request) => request.method === "PUT")
+        .some((request) => request.headers.has("authorization")),
+      false,
+    );
+
+    const reportUpload = requests.find((request) =>
+      request.method === "PUT" &&
+      request.url.endsWith("/veryfront-eval/report.json")
+    );
+    assertExists(reportUpload);
+    assertEquals(String(reportUpload.body).includes("secret-token"), false);
+  });
+
+  it("logs a Veryfront eval report as an MLflow run", async () => {
+    const { requests, fetchImpl } = createMlflowFetchRecorder();
+    const exporter = createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test",
+      experimentName: "support-agent-classification",
+    }, fetchImpl);
+
+    const receipt = await exporter.export(createReport(), {
+      projectReference: "customer-support-agent",
+      sourcePath: "evals/service-now-classification.eval.ts",
+    });
+
+    assertEquals(receipt.externalRunId, "run-1");
+    assertEquals(
+      receipt.url,
+      "http://mlflow.test/#/experiments/exp-1/runs/run-1",
+    );
+    assertEquals(receipt.metadata?.artifacts, [
+      "veryfront-eval/report.json",
+      "veryfront-eval/summary.json",
+      "veryfront-eval/results.jsonl",
+    ]);
+
+    const createRun = requests.find((request) =>
+      request.url.endsWith("/api/2.0/mlflow/runs/create")
+    );
+    assertExists(createRun);
+    const createRunBody = JSON.parse(String(createRun.body));
+    assertEquals(createRunBody.experiment_id, "exp-1");
+    assertEquals(createRunBody.run_name, "eval:smoke-evalrun_1");
+    assertEquals(
+      createRunBody.tags.some((entry: { key: string; value: string }) =>
+        entry.key === "eval.source_path" &&
+        entry.value === "evals/service-now-classification.eval.ts"
+      ),
+      true,
+    );
+
+    const logBatch = requests.find((request) =>
+      request.url.endsWith("/api/2.0/mlflow/runs/log-batch")
+    );
+    assertExists(logBatch);
+    const logBatchBody = JSON.parse(String(logBatch.body));
+    const metricByKey = new Map(
+      logBatchBody.metrics.map((metric: { key: string; value: number }) => [
+        metric.key,
+        metric.value,
+      ]),
+    );
+    assertEquals(metricByKey.get("veryfront_pass_rate"), 1);
+    assertEquals(metricByKey.get("total_tokens"), 15);
+    assertEquals(
+      metricByKey.get("veryfront_metric.answer_exactmatch.pass_rate"),
+      1,
+    );
+    assertEquals(
+      metricByKey.get("veryfront_metric.answer_exactmatch.score_mean"),
+      1,
+    );
+
+    assertEquals(
+      requests.filter((request) => request.method === "PUT").map((request) => request.url),
+      [
+        "http://artifacts.test/root/veryfront-eval/report.json",
+        "http://artifacts.test/root/veryfront-eval/summary.json",
+        "http://artifacts.test/root/veryfront-eval/results.jsonl",
+      ],
+    );
+  });
+
+  it("maps MLflow REST and explicit artifact endpoints for mlflow-artifacts URIs", async () => {
+    const { requests, fetchImpl } = createMlflowFetchRecorder({
+      artifactUri: "mlflow-artifacts:/exp-1/run-1/artifacts",
+    });
+    const exporter = createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test:5001",
+      artifactsUri: "http://mlflow.test:5600",
+      experimentName: "support-agent-classification",
+    }, fetchImpl);
+
+    await exporter.export(createReport(), {
+      projectReference: "customer-support-agent",
+      sourcePath: "evals/service-now-classification.eval.ts",
+    });
+
+    assertEquals(
+      requests.filter((request) => request.method !== "PUT").map((request) => {
+        const url = new URL(request.url);
+        return {
+          method: request.method,
+          endpoint: `${url.origin}${url.pathname}${url.search}`,
+        };
+      }),
+      [
+        {
+          method: "GET",
+          endpoint:
+            "http://mlflow.test:5001/api/2.0/mlflow/experiments/get-by-name?experiment_name=support-agent-classification",
+        },
+        {
+          method: "POST",
+          endpoint: "http://mlflow.test:5001/api/2.0/mlflow/experiments/create",
+        },
+        {
+          method: "POST",
+          endpoint: "http://mlflow.test:5001/api/2.0/mlflow/runs/create",
+        },
+        {
+          method: "POST",
+          endpoint: "http://mlflow.test:5001/api/2.0/mlflow/runs/log-batch",
+        },
+        {
+          method: "POST",
+          endpoint: "http://mlflow.test:5001/api/2.0/mlflow/runs/log-batch",
+        },
+        {
+          method: "POST",
+          endpoint: "http://mlflow.test:5001/api/2.0/mlflow/runs/update",
+        },
+      ],
+    );
+    assertEquals(
+      requests.filter((request) => request.method === "PUT").map((request) => ({
+        url: request.url,
+        contentType: request.headers.get("content-type"),
+      })),
+      [
+        {
+          url:
+            "http://mlflow.test:5600/api/2.0/mlflow-artifacts/artifacts/exp-1/run-1/artifacts/veryfront-eval/report.json",
+          contentType: "application/json",
+        },
+        {
+          url:
+            "http://mlflow.test:5600/api/2.0/mlflow-artifacts/artifacts/exp-1/run-1/artifacts/veryfront-eval/summary.json",
+          contentType: "application/json",
+        },
+        {
+          url:
+            "http://mlflow.test:5600/api/2.0/mlflow-artifacts/artifacts/exp-1/run-1/artifacts/veryfront-eval/results.jsonl",
+          contentType: "application/x-ndjson",
+        },
+      ],
+    );
+  });
+
+  it("uses only sanitized classification evidence keys for classification metrics", async () => {
+    const { requests, fetchImpl } = createMlflowFetchRecorder();
+    const exporter = createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test",
+      experimentName: "support-agent-classification",
+    }, fetchImpl);
+    const baseRecord = createReport().records[0]!;
+    const report: EvalReport = {
+      ...createReport(),
+      summary: {
+        ...createReport().summary,
+        records: 4,
+        passed: 3,
+        failed: 1,
+        passRate: 3 / 4,
+        metrics: [
+          {
+            name: "intent.classification",
+            family: "answer",
+            severity: "gate",
+            passed: 2,
+            failed: 1,
+            skipped: 0,
+            passRate: 2 / 3,
+          },
+        ],
+      },
+      records: [
+        {
+          ...baseRecord,
+          id: "q1:1",
+          input: { expectedCategory: "billing", predictedCategory: "billing" },
+          output: { predictedCategory: "billing" },
+          reference: { expectedCategory: "billing" },
+          metrics: [
+            {
+              name: "intent.classification",
+              family: "answer",
+              severity: "gate",
+              score: 1,
+              pass: true,
+              evidence: {
+                expectedCategory: "billing",
+                predictedCategory: "billing",
+              },
+            },
+          ],
+        },
+        {
+          ...baseRecord,
+          id: "q2:1",
+          input: { expectedCategory: "support" },
+          output: { predictedCategory: "sales" },
+          reference: { expectedCategory: "support" },
+          metrics: [
+            {
+              name: "intent.classification",
+              family: "answer",
+              severity: "gate",
+              score: 0,
+              pass: false,
+              evidence: {
+                expected: "support",
+                predicted: "sales",
+              },
+            },
+          ],
+        },
+        {
+          ...baseRecord,
+          id: "q3:1",
+          input: { expectedCategory: "technical" },
+          output: { predictedCategory: "technical" },
+          reference: { expectedCategory: "technical" },
+          metrics: [
+            {
+              name: "intent.classification",
+              family: "answer",
+              severity: "gate",
+              score: 1,
+              pass: true,
+              evidence: {
+                expectedLabel: "technical",
+                predictedLabel: "technical",
+                confidence: 0.5,
+              },
+            },
+          ],
+        },
+        {
+          ...baseRecord,
+          id: "q4:1",
+          input: { expectedCategory: "ignored-input" },
+          output: { predictedCategory: "ignored-output" },
+          reference: { expectedCategory: "ignored-reference" },
+          metrics: [
+            {
+              name: "intent.classification",
+              family: "answer",
+              severity: "gate",
+              score: 1,
+              pass: true,
+            },
+          ],
+        },
+      ],
+    };
+
+    await exporter.export(report, {
+      projectReference: "customer-support-agent",
+      sourcePath: "evals/service-now-classification.eval.ts",
+    });
+
+    const logBatch = requests.find((request) =>
+      request.url.endsWith("/api/2.0/mlflow/runs/log-batch")
+    );
+    assertExists(logBatch);
+    const logBatchBody = JSON.parse(String(logBatch.body));
+    const metricByKey = new Map(
+      logBatchBody.metrics.map((metric: { key: string; value: number }) => [
+        metric.key,
+        metric.value,
+      ]),
+    );
+
+    assertEquals(metricByKey.get("evaluated_count"), 3);
+    assertEquals(metricByKey.get("correct_count"), 2);
+    assertEquals(metricByKey.get("failure_count"), 1);
+    assertEquals(metricByKey.get("confidence_mean"), 0.5);
+    assertEquals(
+      metricByKey.get("classification.intent_classification.evaluated_count"),
+      3,
+    );
+    assertEquals(
+      metricByKey.get("classification.intent_classification.confidence_mean"),
+      0.5,
+    );
+    assertEquals(
+      metricByKey.get(
+        "classification.intent_classification.category.billing.total",
+      ),
+      1,
+    );
+    assertEquals(
+      metricByKey.get(
+        "classification.intent_classification.category.support.total",
+      ),
+      1,
+    );
+    assertEquals(
+      metricByKey.get(
+        "classification.intent_classification.category.technical.total",
+      ),
+      1,
+    );
+    assertEquals(
+      metricByKey.get(
+        "classification.intent_classification.category.ignored_input.total",
+      ),
+      undefined,
+    );
+  });
+
+  it("marks MLflow runs FAILED when the eval report has failed records", async () => {
+    const { requests, fetchImpl } = createMlflowFetchRecorder();
+    const exporter = createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test",
+      experimentName: "support-agent-classification",
+    }, fetchImpl);
+    const report: EvalReport = {
+      ...createReport(),
+      summary: {
+        ...createReport().summary,
+        passed: 0,
+        failed: 1,
+        passRate: 0,
+      },
+    };
+
+    await exporter.export(report, {
+      projectReference: "customer-support-agent",
+      sourcePath: "evals/service-now-classification.eval.ts",
+    });
+
+    const updates = requests.filter((request) =>
+      request.url.endsWith("/api/2.0/mlflow/runs/update")
+    );
+    assertEquals(updates.length, 1);
+    assertEquals(JSON.parse(String(updates[0]!.body)).status, "FAILED");
+  });
+
+  it("fails clearly and marks the run FAILED when s3 artifacts lack an explicit artifactsUri", async () => {
+    const { requests, fetchImpl } = createMlflowFetchRecorder({
+      artifactUri: "s3://mlflow-bucket/exp-1/run-1/artifacts",
+    });
+    const exporter = createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test",
+      experimentName: "support-agent-classification",
+    }, fetchImpl);
+
+    const error = await assertRejects(
+      () =>
+        exporter.export(createReport(), {
+          projectReference: "customer-support-agent",
+          sourcePath: "evals/service-now-classification.eval.ts",
+        }),
+      Error,
+      "MLflow artifactsUri is required for non-HTTP artifact URI s3://mlflow-bucket/exp-1/run-1/artifacts",
+    );
+    assertEquals(
+      error.message,
+      "MLflow artifactsUri is required for non-HTTP artifact URI s3://mlflow-bucket/exp-1/run-1/artifacts. Configure MLFLOW_ARTIFACTS_URI or config.artifactsUri.",
+    );
+
+    const updates = requests.filter((request) =>
+      request.url.endsWith("/api/2.0/mlflow/runs/update")
+    );
+    assertEquals(updates.length, 1);
+    assertEquals(JSON.parse(String(updates[0]!.body)).status, "FAILED");
+  });
+
+  it("uploads s3 artifacts through an explicit artifactsUri", async () => {
+    const { requests, fetchImpl } = createMlflowFetchRecorder({
+      artifactUri: "s3://mlflow-bucket/exp-1/run-1/artifacts",
+    });
+    const exporter = createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test",
+      artifactsUri: "http://artifacts-proxy.test",
+      experimentName: "support-agent-classification",
+    }, fetchImpl);
+
+    const receipt = await exporter.export(createReport(), {
+      projectReference: "customer-support-agent",
+      sourcePath: "evals/service-now-classification.eval.ts",
+    });
+
+    assertEquals(receipt.externalRunId, "run-1");
+    assertEquals(
+      requests.filter((request) => request.method === "PUT").map((request) => request.url),
+      [
+        "http://artifacts-proxy.test/api/2.0/mlflow-artifacts/artifacts/exp-1/run-1/artifacts/veryfront-eval/report.json",
+        "http://artifacts-proxy.test/api/2.0/mlflow-artifacts/artifacts/exp-1/run-1/artifacts/veryfront-eval/summary.json",
+        "http://artifacts-proxy.test/api/2.0/mlflow-artifacts/artifacts/exp-1/run-1/artifacts/veryfront-eval/results.jsonl",
+      ],
+    );
+  });
+
+  it("rejects unsupported artifact roots even when artifactsUri is explicit", async () => {
+    const unsupportedArtifactUris = [
+      "gs://mlflow-bucket/exp-1/run-1/artifacts",
+      "dbfs://mlflow/exp-1/run-1/artifacts",
+      "wasbs://container@account.blob.core.windows.net/exp-1/run-1/artifacts",
+      "file:///tmp/mlruns/exp-1/run-1/artifacts",
+      "/tmp/mlruns/exp-1/run-1/artifacts",
+      "ftp://artifacts.test/exp-1/run-1/artifacts",
+    ];
+
+    for (const artifactUri of unsupportedArtifactUris) {
+      const { requests, fetchImpl } = createMlflowFetchRecorder({
+        artifactUri,
+      });
+      const exporter = createEvalReportMlflowExporter({
+        trackingUri: "http://mlflow.test",
+        artifactsUri: "http://artifacts-proxy.test",
+        experimentName: "support-agent-classification",
+      }, fetchImpl);
+
+      const error = await assertRejects(
+        () =>
+          exporter.export(createReport(), {
+            projectReference: "customer-support-agent",
+            sourcePath: "evals/service-now-classification.eval.ts",
+          }),
+        Error,
+        `Unsupported MLflow artifact URI: ${artifactUri}`,
+      );
+      assertEquals(
+        error.message,
+        `Unsupported MLflow artifact URI: ${artifactUri}. Supported proxied artifact roots: mlflow-artifacts:/, s3://`,
+      );
+      assertEquals(
+        requests.some((request) =>
+          request.method === "PUT" &&
+          new URL(request.url).origin === "http://artifacts-proxy.test"
+        ),
+        false,
+      );
+
+      const updates = requests.filter((request) =>
+        request.url.endsWith("/api/2.0/mlflow/runs/update")
+      );
+      assertEquals(updates.length, 1);
+      assertEquals(JSON.parse(String(updates[0]!.body)).status, "FAILED");
+    }
+  });
+
+  it("chunks MLflow log-batch requests above REST count limits", async () => {
+    const { requests, fetchImpl } = createMlflowFetchRecorder();
+    const exporter = createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test",
+      experimentName: "support-agent-classification",
+    }, fetchImpl);
+    const baseReport = createReport();
+    const report: EvalReport = {
+      ...baseReport,
+      summary: {
+        ...baseReport.summary,
+        metrics: Array.from({ length: 260 }, (_, index) => ({
+          name: `metric.${index}`,
+          family: "answer",
+          severity: "soft",
+          passed: 1,
+          failed: 0,
+          skipped: 0,
+          passRate: 1,
+        })),
+      },
+    };
+
+    await exporter.export(report, {
+      projectReference: "customer-support-agent",
+      sourcePath: "evals/service-now-classification.eval.ts",
+    });
+
+    const metricLogBatches = requests
+      .filter((request) => request.url.endsWith("/api/2.0/mlflow/runs/log-batch"))
+      .map((request) => JSON.parse(String(request.body)))
+      .filter((body) => body.metrics.length > 0);
+
+    assertEquals(metricLogBatches.length > 1, true);
+    assertEquals(
+      metricLogBatches.every((body) =>
+        body.metrics.length <= 1000 &&
+        body.params.length <= 100 &&
+        body.tags.length <= 100 &&
+        body.metrics.length + body.params.length + body.tags.length <= 1000
+      ),
+      true,
+    );
+    assertEquals(
+      metricLogBatches.reduce((sum, body) => sum + body.metrics.length, 0) >
+        1000,
+      true,
+    );
+  });
+
+  it("normalizes overlong MLflow keys and param/tag values before log-batch upload", async () => {
+    const { requests, fetchImpl } = createMlflowFetchRecorder();
+    const exporter = createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test",
+      experimentName: "support-agent-classification",
+    }, fetchImpl);
+    const longSegment = "verylongcategory".repeat(500);
+    const baseReport = createReport();
+    const report: EvalReport = {
+      ...baseReport,
+      metadata: { ...baseReport.metadata, model: `model-${longSegment}` },
+      summary: {
+        ...baseReport.summary,
+        metrics: [
+          ...baseReport.summary.metrics,
+          {
+            name: `classification.${longSegment}`,
+            family: "judge",
+            severity: "soft",
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            passRate: 1,
+          },
+        ],
+      },
+      records: baseReport.records.map((record) => ({
+        ...record,
+        metrics: [
+          ...(record.metrics ?? []),
+          {
+            name: `classification.${longSegment}`,
+            family: "judge",
+            severity: "soft",
+            pass: true,
+            score: 1,
+            evidence: {
+              expectedCategory: `expected-${longSegment}`,
+              predictedCategory: `predicted-${longSegment}`,
+              confidence: 0.9,
+            },
+          },
+        ],
+      })),
+    };
+
+    await exporter.export(report, {
+      projectReference: "customer-support-agent",
+      sourcePath: `evals/${longSegment}.eval.ts`,
+      tags: [`tag-${longSegment}`],
+    });
+
+    const logBatches = requests
+      .filter((request) => request.url.endsWith("/api/2.0/mlflow/runs/log-batch"))
+      .map((request) => JSON.parse(String(request.body)));
+    assertEquals(logBatches.length > 0, true);
+    const params = logBatches.flatMap((body) =>
+      body.params as Array<{ key: string; value: string }>
+    );
+    const createRun = requests.find((request) =>
+      request.url.endsWith("/api/2.0/mlflow/runs/create")
+    );
+    assertExists(createRun);
+    const tags = [
+      ...JSON.parse(String(createRun.body)).tags as Array<{ key: string; value: string }>,
+      ...logBatches.flatMap((body) => body.tags as Array<{ key: string; value: string }>),
+    ];
+    const metrics = logBatches.flatMap((body) => body.metrics as Array<{ key: string }>);
+
+    assertEquals(
+      params.every((entry) => entry.key.length <= 250 && entry.value.length <= 6_000),
+      true,
+    );
+    assertEquals(
+      tags.every((entry) => entry.key.length <= 250 && entry.value.length <= 5_000),
+      true,
+    );
+    assertEquals(metrics.every((entry) => entry.key.length <= 250), true);
+    assertEquals(
+      params.some((entry) => entry.value.length === 6_000 && /_[0-9a-f]{8}$/.test(entry.value)),
+      true,
+    );
+    assertEquals(
+      tags.some((entry) => entry.value.length === 5_000 && /_[0-9a-f]{8}$/.test(entry.value)),
+      true,
+    );
+    assertEquals(
+      metrics.some((entry) => entry.key.length === 250 && /_[0-9a-f]{8}/.test(entry.key)),
+      true,
+    );
+  });
+
+  it("fails clearly and marks the run FAILED for unsupported artifact roots", async () => {
+    const { requests, fetchImpl } = createMlflowFetchRecorder({
+      artifactUri: "file:///tmp/mlruns/exp-1/run-1/artifacts",
+    });
+    const exporter = createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test",
+      experimentName: "support-agent-classification",
+    }, fetchImpl);
+
+    const error = await assertRejects(
+      () =>
+        exporter.export(createReport(), {
+          projectReference: "customer-support-agent",
+          sourcePath: "evals/service-now-classification.eval.ts",
+        }),
+      Error,
+      "Unsupported MLflow artifact URI: file:///tmp/mlruns/exp-1/run-1/artifacts",
+    );
+    assertEquals(
+      error.message,
+      "Unsupported MLflow artifact URI: file:///tmp/mlruns/exp-1/run-1/artifacts. Supported proxied artifact roots: mlflow-artifacts:/, s3://",
+    );
+
+    const updates = requests.filter((request) =>
+      request.url.endsWith("/api/2.0/mlflow/runs/update")
+    );
+    assertEquals(updates.length, 1);
+    assertEquals(JSON.parse(String(updates[0]!.body)).status, "FAILED");
+  });
+
+  it("uses registry default redaction before uploading report artifacts", async () => {
+    const registry = createEvalReportExporterRegistry();
+    const { requests, fetchImpl } = createMlflowFetchRecorder();
+    registry.register(createEvalReportMlflowExporter({
+      trackingUri: "http://mlflow.test",
+      experimentName: "support-agent-classification",
+    }, fetchImpl));
+
+    const results = await registry.export(createSensitiveReport(), {
+      projectReference: "customer-support-agent",
+      sourcePath: "evals/service-now-classification.eval.ts",
+    });
+
+    assertEquals(results[0]?.ok, true);
+    const reportUpload = requests.find((request) =>
+      request.method === "PUT" &&
+      request.url.endsWith("/veryfront-eval/report.json")
+    );
+    assertExists(reportUpload);
+    const uploadedReport = JSON.parse(String(reportUpload.body)) as EvalReport;
+    const record = uploadedReport.records[0];
+    assertExists(record);
+    assertEquals(record.input, "[redacted]");
+    assertEquals(record.output, "[redacted]");
+    assertEquals(record.reference, "[redacted]");
+    assertEquals(record.metadata, {});
+    assertEquals(record.trace, { events: [], toolCalls: [] });
+    assertEquals(record.metrics?.[0]?.explanation, undefined);
+    assertEquals(record.metrics?.[0]?.evidence, undefined);
+  });
+});

--- a/extensions/ext-eval-report-mlflow/src/index.ts
+++ b/extensions/ext-eval-report-mlflow/src/index.ts
@@ -1,0 +1,1270 @@
+/**
+ * ext-eval-report-mlflow: MLflow Tracking transport for eval report exports.
+ *
+ * The extension resolves the core `EvalReportExporterRegistry` contract during
+ * setup and registers one `EvalReportExporter` that writes a completed
+ * Veryfront `EvalReport` to MLflow as a run.
+ *
+ * @module extensions/ext-eval-report-mlflow
+ */
+
+import type { EvalReport } from "veryfront/eval";
+import type { ExtensionFactory } from "veryfront/extensions";
+import {
+  type EvalReportExportContext,
+  type EvalReportExporter,
+  type EvalReportExporterRegistry,
+  EvalReportExporterRegistryName,
+  type EvalReportExportReceipt,
+} from "veryfront/extensions/eval";
+
+const DEFAULT_EXPORTER_ID = "mlflow";
+const ENV_TRACKING_URI = "MLFLOW_TRACKING_URI";
+const ENV_EXPERIMENT_NAME = "MLFLOW_EXPERIMENT_NAME";
+const ENV_RUN_NAME = "MLFLOW_RUN_NAME";
+const ENV_ARTIFACTS_URI = "MLFLOW_ARTIFACTS_URI";
+const ENV_TRACKING_TOKEN = "MLFLOW_TRACKING_TOKEN";
+const ENV_TRACKING_USERNAME = "MLFLOW_TRACKING_USERNAME";
+const ENV_TRACKING_PASSWORD = "MLFLOW_TRACKING_PASSWORD";
+
+const EXTENSION_METADATA = {
+  contracts: {
+    requires: ["EvalReportExporterRegistry"],
+  },
+  capabilities: [
+    { type: "net:outbound", hosts: ["*"] },
+    {
+      type: "env:read",
+      keys: [
+        "MLFLOW_ARTIFACTS_URI",
+        "MLFLOW_EXPERIMENT_NAME",
+        "MLFLOW_RUN_NAME",
+        "MLFLOW_TRACKING_PASSWORD",
+        "MLFLOW_TRACKING_TOKEN",
+        "MLFLOW_TRACKING_URI",
+        "MLFLOW_TRACKING_USERNAME",
+      ],
+    },
+  ],
+};
+
+type EvalReportMlflowFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+interface MlflowMetric {
+  key: string;
+  value: number;
+  timestamp: number;
+  step: number;
+}
+
+interface MlflowTag {
+  key: string;
+  value: string;
+}
+
+interface MlflowParam {
+  key: string;
+  value: string;
+}
+
+const MLFLOW_LOG_BATCH_MAX_TOTAL_ENTRIES = 1000;
+const MLFLOW_LOG_BATCH_MAX_METRICS = 1000;
+const MLFLOW_LOG_BATCH_MAX_PARAMS = 100;
+const MLFLOW_LOG_BATCH_MAX_TAGS = 100;
+const MLFLOW_LOG_BATCH_MAX_BYTES = 950_000;
+const LOG_BATCH_BODY_ENCODER = new TextEncoder();
+const MLFLOW_KEY_MAX_LENGTH = 250;
+const MLFLOW_PARAM_VALUE_MAX_LENGTH = 6_000;
+const MLFLOW_TAG_VALUE_MAX_LENGTH = 5_000;
+const SUPPORTED_MLFLOW_PROXY_ARTIFACT_URI_SCHEMES = [
+  "mlflow-artifacts:/",
+  "s3://",
+] as const;
+
+interface ClassificationRow {
+  expected: string;
+  predicted: string;
+  correct: boolean;
+  confidence?: number;
+}
+
+interface ClassificationMetricSet {
+  precision: number;
+  recall: number;
+  f1: number;
+}
+
+export interface EvalReportMlflowExtensionConfig {
+  trackingUri?: string;
+  artifactsUri?: string;
+  experimentName?: string;
+  runName?: string;
+  trackingToken?: string;
+  trackingUsername?: string;
+  trackingPassword?: string;
+  fetch?: EvalReportMlflowFetch;
+}
+
+export interface MlflowArtifactUploadResult {
+  artifactPath: string;
+  uploadUrl: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readEnv(name: string): string | undefined {
+  try {
+    const value = Deno.env.get(name);
+    return value && value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeConfig(config: unknown): EvalReportMlflowExtensionConfig {
+  if (!isRecord(config)) return {};
+  return {
+    ...(typeof config.trackingUri === "string" ? { trackingUri: config.trackingUri } : {}),
+    ...(typeof config.artifactsUri === "string" ? { artifactsUri: config.artifactsUri } : {}),
+    ...(typeof config.experimentName === "string" ? { experimentName: config.experimentName } : {}),
+    ...(typeof config.runName === "string" ? { runName: config.runName } : {}),
+    ...(typeof config.trackingToken === "string" ? { trackingToken: config.trackingToken } : {}),
+    ...(typeof config.trackingUsername === "string"
+      ? { trackingUsername: config.trackingUsername }
+      : {}),
+    ...(typeof config.trackingPassword === "string"
+      ? { trackingPassword: config.trackingPassword }
+      : {}),
+    ...(typeof config.fetch === "function" ? { fetch: config.fetch as EvalReportMlflowFetch } : {}),
+  };
+}
+
+function normalizeHttpUri(uri: string, label: string): string {
+  const trimmed = uri.trim().replace(/\/+$/, "");
+  try {
+    const url = new URL(trimmed);
+    if (url.username || url.password) {
+      throw new Error(
+        `MLflow ${label} must not include credentials. Use MLFLOW_TRACKING_TOKEN or MLFLOW_TRACKING_USERNAME/MLFLOW_TRACKING_PASSWORD instead.`,
+      );
+    }
+    if (url.protocol === "http:" || url.protocol === "https:") return trimmed;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("must not include credentials")) {
+      throw error;
+    }
+    // Use the consistent message below.
+  }
+  throw new Error(`MLflow ${label} must be an HTTP(S) URI: ${uri}`);
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+function truncateWithHash(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  const suffix = `_${stableHash(value)}`;
+  return `${value.slice(0, Math.max(0, maxLength - suffix.length))}${suffix}`;
+}
+
+function normalizeMlflowKey(key: string): string {
+  return truncateWithHash(key.trim() || "veryfront", MLFLOW_KEY_MAX_LENGTH);
+}
+
+function normalizeMlflowParamValue(value: string): string {
+  return truncateWithHash(value, MLFLOW_PARAM_VALUE_MAX_LENGTH);
+}
+
+function normalizeMlflowTagValue(value: string): string {
+  return truncateWithHash(value, MLFLOW_TAG_VALUE_MAX_LENGTH);
+}
+
+function createTrackingAuthHeaders(
+  config: Pick<
+    EvalReportMlflowExtensionConfig,
+    "trackingPassword" | "trackingToken" | "trackingUsername"
+  >,
+): Record<string, string> {
+  if (config.trackingToken) {
+    return { authorization: `Bearer ${config.trackingToken}` };
+  }
+  if (config.trackingUsername || config.trackingPassword) {
+    const credentials = btoa(`${config.trackingUsername ?? ""}:${config.trackingPassword ?? ""}`);
+    return { authorization: `Basic ${credentials}` };
+  }
+  return {};
+}
+
+function resolveExporterConfig(
+  config: EvalReportMlflowExtensionConfig,
+): EvalReportMlflowExtensionConfig & { id: string } {
+  return {
+    id: DEFAULT_EXPORTER_ID,
+    trackingUri: config.trackingUri ?? readEnv(ENV_TRACKING_URI),
+    artifactsUri: config.artifactsUri ?? readEnv(ENV_ARTIFACTS_URI),
+    experimentName: config.experimentName ?? readEnv(ENV_EXPERIMENT_NAME),
+    runName: config.runName ?? readEnv(ENV_RUN_NAME),
+    trackingToken: config.trackingToken ?? readEnv(ENV_TRACKING_TOKEN),
+    trackingUsername: config.trackingUsername ?? readEnv(ENV_TRACKING_USERNAME),
+    trackingPassword: config.trackingPassword ?? readEnv(ENV_TRACKING_PASSWORD),
+    ...(config.fetch ? { fetch: config.fetch } : {}),
+  };
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function tag(key: string, value: unknown): MlflowTag | undefined {
+  const next = stringValue(value);
+  return next === undefined
+    ? undefined
+    : { key: normalizeMlflowKey(key), value: normalizeMlflowTagValue(next) };
+}
+
+function param(key: string, value: unknown): MlflowParam | undefined {
+  const next = stringValue(value);
+  return next === undefined
+    ? undefined
+    : { key: normalizeMlflowKey(key), value: normalizeMlflowParamValue(next) };
+}
+
+function compact<T>(values: Array<T | undefined>): T[] {
+  return values.filter((value): value is T => value !== undefined);
+}
+
+function reportModel(report: EvalReport): string | undefined {
+  return typeof report.metadata?.model === "string" ? report.metadata.model : undefined;
+}
+
+function reportProvenanceGit(
+  report: EvalReport,
+): { sha?: string; branch?: string } {
+  const provenance = report.metadata?.provenance;
+  if (!provenance || typeof provenance !== "object") return {};
+  const git = (provenance as { git?: unknown }).git;
+  if (!isRecord(git)) return {};
+  return {
+    ...(typeof git.sha === "string" ? { sha: git.sha } : {}),
+    ...(typeof git.branch === "string" ? { branch: git.branch } : {}),
+  };
+}
+
+function experimentName(
+  config: EvalReportMlflowExtensionConfig,
+  report: EvalReport,
+  context: EvalReportExportContext,
+): string {
+  return config.experimentName ??
+    context.projectReference ??
+    context.projectId ??
+    report.definitionId ??
+    "veryfront-evals";
+}
+
+function runName(
+  config: EvalReportMlflowExtensionConfig,
+  report: EvalReport,
+): string {
+  return config.runName ?? `${report.definitionId}-${report.runId}`;
+}
+
+function createRunTags(
+  config: EvalReportMlflowExtensionConfig,
+  report: EvalReport,
+  context: EvalReportExportContext,
+): MlflowTag[] {
+  const git = reportProvenanceGit(report);
+  return compact([
+    tag("mlflow.runName", runName(config, report)),
+    tag("eval.framework", "veryfront"),
+    tag("eval.definition_id", report.definitionId),
+    tag("eval.target", report.target),
+    tag("eval.target_kind", report.targetKind),
+    tag("eval.run_id", report.runId),
+    tag("eval.status", report.summary.failed === 0 ? "passed" : "failed"),
+    tag("eval.source_path", context.sourcePath),
+    tag("eval.report_path", context.reportPath),
+    tag("eval.environment", context.environment),
+    tag("eval.branch", context.branch ?? git.branch),
+    tag("eval.commit_sha", context.commitSha ?? git.sha),
+    tag("eval.run_url", context.runUrl),
+    tag("eval.tags", context.tags?.join(",")),
+    tag("eval.model", reportModel(report)),
+    tag("trace.id", context.trace?.traceId),
+    tag("trace.span_id", context.trace?.spanId),
+  ]);
+}
+
+function createRunParams(
+  report: EvalReport,
+  context: EvalReportExportContext,
+): MlflowParam[] {
+  return compact([
+    param("framework_eval_id", report.definitionId),
+    param("framework_run_id", report.runId),
+    param("framework_target", report.target),
+    param("framework_target_kind", report.targetKind),
+    param("source_path", context.sourcePath),
+    param("report_path", context.reportPath),
+    param("model", reportModel(report)),
+  ]);
+}
+
+function mlflowMetric(
+  key: string,
+  value: number | undefined,
+  timestamp: number,
+): MlflowMetric | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return { key: normalizeMlflowKey(key), value, timestamp, step: 0 };
+}
+
+function durationMetrics(
+  duration: NonNullable<EvalReport["summary"]["duration"]> | undefined,
+  timestamp: number,
+): MlflowMetric[] {
+  if (!duration) return [];
+  return compact([
+    mlflowMetric("duration_ms_total", duration.totalMs, timestamp),
+    mlflowMetric("duration_ms_min", duration.minMs, timestamp),
+    mlflowMetric("duration_ms_max", duration.maxMs, timestamp),
+    mlflowMetric("duration_ms_mean", duration.meanMs, timestamp),
+    mlflowMetric("duration_ms_p50", duration.p50Ms, timestamp),
+    mlflowMetric("duration_ms_p95", duration.p95Ms, timestamp),
+    mlflowMetric("duration_seconds_total", duration.totalMs / 1000, timestamp),
+    mlflowMetric("duration_seconds_mean", duration.meanMs / 1000, timestamp),
+    mlflowMetric("duration_seconds_p95", duration.p95Ms / 1000, timestamp),
+  ]);
+}
+
+function usageMetrics(
+  usage: NonNullable<EvalReport["summary"]["usage"]> | undefined,
+  timestamp: number,
+): MlflowMetric[] {
+  if (!usage) return [];
+  return compact([
+    mlflowMetric("input_tokens", usage.inputTokens, timestamp),
+    mlflowMetric("output_tokens", usage.outputTokens, timestamp),
+    mlflowMetric("total_tokens", usage.totalTokens, timestamp),
+    mlflowMetric("billable_input_tokens", usage.billableInputTokens, timestamp),
+    mlflowMetric(
+      "billable_output_tokens",
+      usage.billableOutputTokens,
+      timestamp,
+    ),
+    mlflowMetric("cached_input_tokens", usage.cachedInputTokens, timestamp),
+    mlflowMetric(
+      "cache_creation_input_tokens",
+      usage.cacheCreationInputTokens,
+      timestamp,
+    ),
+    mlflowMetric(
+      "cache_read_input_tokens",
+      usage.cacheReadInputTokens,
+      timestamp,
+    ),
+    mlflowMetric("reasoning_tokens", usage.reasoningTokens, timestamp),
+    mlflowMetric("cost_usd", usage.costUsd, timestamp),
+    mlflowMetric(
+      "provider_input_cost_usd",
+      usage.providerInputCostUsd,
+      timestamp,
+    ),
+    mlflowMetric(
+      "provider_output_cost_usd",
+      usage.providerOutputCostUsd,
+      timestamp,
+    ),
+    mlflowMetric("provider_cost_usd", usage.providerCostUsd, timestamp),
+    mlflowMetric(
+      "veryfront_input_charge_usd",
+      usage.veryfrontInputChargeUsd,
+      timestamp,
+    ),
+    mlflowMetric(
+      "veryfront_output_charge_usd",
+      usage.veryfrontOutputChargeUsd,
+      timestamp,
+    ),
+    mlflowMetric("veryfront_charge_usd", usage.veryfrontChargeUsd, timestamp),
+    mlflowMetric("veryfront_billed_usd", usage.veryfrontBilledUsd, timestamp),
+    mlflowMetric("cost_credits", usage.costCredits, timestamp),
+  ]);
+}
+
+function toMetricKey(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "") || "metric";
+}
+
+function frameworkMetricSummaryMetrics(
+  report: EvalReport,
+  timestamp: number,
+): MlflowMetric[] {
+  return report.summary.metrics.flatMap((metric) => {
+    const key = `veryfront_metric.${toMetricKey(metric.name)}`;
+    return compact([
+      mlflowMetric(`${key}.pass_rate`, metric.passRate, timestamp),
+      mlflowMetric(`${key}.passed`, metric.passed, timestamp),
+      mlflowMetric(`${key}.failed`, metric.failed, timestamp),
+      mlflowMetric(`${key}.skipped`, metric.skipped, timestamp),
+    ]);
+  });
+}
+
+function recordScoreMetrics(
+  report: EvalReport,
+  timestamp: number,
+): MlflowMetric[] {
+  const scores = new Map<string, number[]>();
+  for (const record of report.records) {
+    for (
+      const result of [...(record.metrics ?? []), ...(record.checks ?? [])]
+    ) {
+      if (
+        typeof result.score !== "number" || !Number.isFinite(result.score)
+      ) continue;
+      const key = `veryfront_metric.${toMetricKey(result.name)}.score_mean`;
+      const values = scores.get(key) ?? [];
+      values.push(result.score);
+      scores.set(key, values);
+    }
+  }
+
+  return compact(
+    [...scores.entries()].map(([key, values]) => mlflowMetric(key, average(values), timestamp)),
+  );
+}
+
+function classificationValue(
+  value: unknown,
+  ...keys: string[]
+): string | undefined {
+  if (!isRecord(value)) return undefined;
+  for (const key of keys) {
+    const entry = value[key];
+    if (typeof entry === "string" && entry.trim().length > 0) return entry;
+  }
+  return undefined;
+}
+
+function classificationRowFromResult(
+  result: NonNullable<EvalReport["records"][number]["metrics"]>[number],
+): ClassificationRow | undefined {
+  const expected = classificationValue(
+    result.evidence,
+    "expectedCategory",
+    "expectedLabel",
+    "expected",
+  );
+  const predicted = classificationValue(
+    result.evidence,
+    "predictedCategory",
+    "predictedLabel",
+    "predicted",
+  );
+  if (!expected || !predicted) return undefined;
+  const confidence = isRecord(result.evidence) &&
+      typeof result.evidence.confidence === "number" &&
+      Number.isFinite(result.evidence.confidence)
+    ? result.evidence.confidence
+    : undefined;
+  return {
+    expected,
+    predicted,
+    correct: result.pass === true || expected === predicted,
+    ...(confidence === undefined ? {} : { confidence }),
+  };
+}
+
+function classificationRowsByMetric(
+  report: EvalReport,
+): Map<string, ClassificationRow[]> {
+  const rowsByMetric = new Map<string, ClassificationRow[]>();
+  for (const record of report.records) {
+    for (
+      const result of [...(record.metrics ?? []), ...(record.checks ?? [])]
+    ) {
+      const row = classificationRowFromResult(result);
+      if (!row) continue;
+      const rows = rowsByMetric.get(result.name) ?? [];
+      rows.push(row);
+      rowsByMetric.set(result.name, rows);
+    }
+  }
+  return rowsByMetric;
+}
+
+function buildPerCategory(
+  rows: ClassificationRow[],
+): Record<string, { total: number; correct: number; accuracy: number }> {
+  const result: Record<
+    string,
+    { total: number; correct: number; accuracy: number }
+  > = {};
+  for (const row of rows) {
+    const category = result[row.expected] ??= {
+      total: 0,
+      correct: 0,
+      accuracy: 0,
+    };
+    category.total += 1;
+    if (row.correct) category.correct += 1;
+  }
+  for (const value of Object.values(result)) {
+    value.accuracy = value.total === 0 ? 0 : value.correct / value.total;
+  }
+  return Object.fromEntries(
+    Object.entries(result).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function buildConfusion(
+  rows: ClassificationRow[],
+): Record<string, Record<string, number>> {
+  const confusion: Record<string, Record<string, number>> = {};
+  for (const row of rows) {
+    const predictions = confusion[row.expected] ??= {};
+    predictions[row.predicted] = (predictions[row.predicted] ?? 0) + 1;
+  }
+  return Object.fromEntries(
+    Object.entries(confusion).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function buildMacroMetrics(
+  confusion: Record<string, Record<string, number>>,
+): ClassificationMetricSet {
+  const labels = new Set<string>(Object.keys(confusion));
+  for (const predictions of Object.values(confusion)) {
+    for (const label of Object.keys(predictions)) labels.add(label);
+  }
+
+  const metricSets = Array.from(labels).map(
+    (label): ClassificationMetricSet => {
+      const truePositive = confusion[label]?.[label] ?? 0;
+      const actual = Object.values(confusion[label] ?? {}).reduce(
+        (sum, count) => sum + count,
+        0,
+      );
+      const predicted = Object.values(confusion).reduce(
+        (sum, predictions) => sum + (predictions[label] ?? 0),
+        0,
+      );
+      const precision = predicted === 0 ? 0 : truePositive / predicted;
+      const recall = actual === 0 ? 0 : truePositive / actual;
+      const f1 = precision + recall === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+      return { precision, recall, f1 };
+    },
+  );
+
+  if (metricSets.length === 0) return { precision: 0, recall: 0, f1: 0 };
+  return {
+    precision: average(metricSets.map((metric) => metric.precision)),
+    recall: average(metricSets.map((metric) => metric.recall)),
+    f1: average(metricSets.map((metric) => metric.f1)),
+  };
+}
+
+function classificationMetricNames(
+  metricName: string,
+  singleClassificationMetric: boolean,
+): string[] {
+  const metricKey = toMetricKey(metricName);
+  return singleClassificationMetric
+    ? ["", `classification.${metricKey}.`]
+    : [`classification.${metricKey}.`];
+}
+
+function classificationMetricsForRows(
+  metricName: string,
+  rows: ClassificationRow[],
+  timestamp: number,
+  singleClassificationMetric: boolean,
+): MlflowMetric[] {
+  const correct = rows.filter((row) => row.correct).length;
+  const failureCount = rows.length - correct;
+  const accuracy = rows.length === 0 ? 0 : correct / rows.length;
+  const perCategory = buildPerCategory(rows);
+  const confusion = buildConfusion(rows);
+  const macro = buildMacroMetrics(confusion);
+  const prefixes = classificationMetricNames(
+    metricName,
+    singleClassificationMetric,
+  );
+  const confidenceValues = rows
+    .map((row) => row.confidence)
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+  const metrics: MlflowMetric[] = [];
+
+  for (const prefix of prefixes) {
+    metrics.push(
+      mlflowMetric(`${prefix}accuracy`, accuracy, timestamp)!,
+      mlflowMetric(`${prefix}macro_precision`, macro.precision, timestamp)!,
+      mlflowMetric(`${prefix}macro_recall`, macro.recall, timestamp)!,
+      mlflowMetric(`${prefix}macro_f1`, macro.f1, timestamp)!,
+      mlflowMetric(`${prefix}evaluated_count`, rows.length, timestamp)!,
+      mlflowMetric(`${prefix}correct_count`, correct, timestamp)!,
+      mlflowMetric(`${prefix}failure_count`, failureCount, timestamp)!,
+    );
+
+    if (confidenceValues.length > 0) {
+      metrics.push(
+        mlflowMetric(
+          `${prefix}confidence_mean`,
+          average(confidenceValues),
+          timestamp,
+        )!,
+      );
+    }
+
+    for (const [category, value] of Object.entries(perCategory)) {
+      const key = `${prefix}category.${toMetricKey(category)}`;
+      metrics.push(
+        mlflowMetric(`${key}.accuracy`, value.accuracy, timestamp)!,
+        mlflowMetric(`${key}.correct`, value.correct, timestamp)!,
+        mlflowMetric(`${key}.total`, value.total, timestamp)!,
+      );
+    }
+
+    for (const [expected, predictions] of Object.entries(confusion)) {
+      for (const [predicted, count] of Object.entries(predictions)) {
+        metrics.push(
+          mlflowMetric(
+            `${prefix}confusion.${toMetricKey(expected)}.${toMetricKey(predicted)}`,
+            count,
+            timestamp,
+          )!,
+        );
+      }
+    }
+  }
+
+  return metrics;
+}
+
+function classificationMetrics(
+  report: EvalReport,
+  timestamp: number,
+): MlflowMetric[] {
+  const rowsByMetric = [...classificationRowsByMetric(report).entries()]
+    .filter(([, rows]) => rows.length > 0);
+  const singleClassificationMetric = rowsByMetric.length === 1;
+  return rowsByMetric.flatMap(([metricName, rows]) =>
+    classificationMetricsForRows(
+      metricName,
+      rows,
+      timestamp,
+      singleClassificationMetric,
+    )
+  );
+}
+
+function summaryMetrics(report: EvalReport, timestamp: number): MlflowMetric[] {
+  return compact([
+    mlflowMetric("veryfront_pass_rate", report.summary.passRate, timestamp),
+    mlflowMetric("veryfront_records", report.summary.records, timestamp),
+    mlflowMetric("veryfront_passed", report.summary.passed, timestamp),
+    mlflowMetric("veryfront_failed", report.summary.failed, timestamp),
+    mlflowMetric(
+      "veryfront_skipped_results",
+      report.summary.skippedResults,
+      timestamp,
+    ),
+    mlflowMetric(
+      "veryfront_gate_failures",
+      report.summary.gateFailures?.length,
+      timestamp,
+    ),
+    mlflowMetric(
+      "veryfront_failed_examples",
+      report.summary.failedExamples?.length,
+      timestamp,
+    ),
+    mlflowMetric(
+      "veryfront_flaky_examples",
+      report.summary.flakes?.flaky,
+      timestamp,
+    ),
+  ]);
+}
+
+function createMetrics(report: EvalReport, timestamp: number): MlflowMetric[] {
+  return [
+    ...summaryMetrics(report, timestamp),
+    ...durationMetrics(report.summary.duration, timestamp),
+    ...usageMetrics(report.summary.usage, timestamp),
+    ...frameworkMetricSummaryMetrics(report, timestamp),
+    ...recordScoreMetrics(report, timestamp),
+    ...classificationMetrics(report, timestamp),
+  ];
+}
+
+function average(values: number[]): number {
+  return values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function createResultsJsonl(report: EvalReport): string {
+  return report.records.length === 0
+    ? ""
+    : `${report.records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+}
+
+function safeArtifactPayload(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function normalizeArtifactPath(path: string): string {
+  const normalized = path
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .join("/");
+
+  if (
+    !normalized || normalized.startsWith("../") ||
+    normalized.includes("/../") ||
+    normalized === ".."
+  ) {
+    throw new Error(`Unsafe MLflow artifact path: ${path}`);
+  }
+
+  return normalized;
+}
+
+function normalizeMlflowArtifactsUri(uri: string): string {
+  const trimmed = normalizeHttpUri(uri, "artifactsUri");
+  if (trimmed.endsWith("/api/2.0/mlflow-artifacts/artifacts")) return trimmed;
+  return `${trimmed}/api/2.0/mlflow-artifacts/artifacts`;
+}
+
+function extractArtifactRootPath(runArtifactUri: string | undefined): string {
+  if (!runArtifactUri) {
+    throw new Error("MLflow run artifact URI is required for artifact uploads");
+  }
+
+  if (runArtifactUri.startsWith("mlflow-artifacts:/")) {
+    return normalizeArtifactPath(
+      runArtifactUri.replace(/^mlflow-artifacts:\/*/, ""),
+    );
+  }
+
+  if (runArtifactUri.startsWith("s3://")) {
+    const objectStoreMatch = /^s3:\/\/[^/]+\/(.+)$/i.exec(runArtifactUri);
+    if (objectStoreMatch) return normalizeArtifactPath(objectStoreMatch[1]!);
+  }
+
+  throw new Error(
+    `Unsupported MLflow artifact URI: ${runArtifactUri}. Supported proxied artifact roots: ${
+      SUPPORTED_MLFLOW_PROXY_ARTIFACT_URI_SCHEMES.join(", ")
+    }`,
+  );
+}
+
+function buildMlflowArtifactUploadUrl(input: {
+  runArtifactUri?: string;
+  artifactPath: string;
+  artifactsUri?: string;
+}): string {
+  if (
+    input.runArtifactUri?.startsWith("http://") ||
+    input.runArtifactUri?.startsWith("https://")
+  ) {
+    return `${normalizeHttpUri(input.runArtifactUri, "run artifact URI")}/${input.artifactPath}`;
+  }
+
+  const artifactRootPath = extractArtifactRootPath(input.runArtifactUri);
+  if (!input.artifactsUri) {
+    throw new Error(
+      `MLflow artifactsUri is required for non-HTTP artifact URI ${input.runArtifactUri}. Configure MLFLOW_ARTIFACTS_URI or config.artifactsUri.`,
+    );
+  }
+
+  const artifactServerUri = normalizeMlflowArtifactsUri(input.artifactsUri);
+
+  return `${artifactServerUri}/${artifactRootPath}/${input.artifactPath}`;
+}
+
+async function uploadMlflowArtifact(input: {
+  fetchImpl: EvalReportMlflowFetch;
+  runArtifactUri?: string;
+  artifactsUri?: string;
+  artifactPath: string;
+  content: string;
+  contentType: string;
+}): Promise<MlflowArtifactUploadResult> {
+  const artifactPath = normalizeArtifactPath(input.artifactPath);
+  const uploadUrl = buildMlflowArtifactUploadUrl({
+    runArtifactUri: input.runArtifactUri,
+    artifactsUri: input.artifactsUri,
+    artifactPath,
+  });
+  const response = await input.fetchImpl(uploadUrl, {
+    method: "PUT",
+    headers: { "content-type": input.contentType },
+    body: input.content,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `MLflow artifact upload failed (${response.status}): ${text || response.statusText}`,
+    );
+  }
+
+  return { artifactPath, uploadUrl };
+}
+
+async function uploadMlflowJsonArtifact(input: {
+  fetchImpl: EvalReportMlflowFetch;
+  runArtifactUri?: string;
+  artifactsUri?: string;
+  artifactPath: string;
+  value: unknown;
+}): Promise<MlflowArtifactUploadResult> {
+  return uploadMlflowArtifact({
+    ...input,
+    content: safeArtifactPayload(input.value),
+    contentType: "application/json",
+  });
+}
+
+class MlflowNotFoundError extends Error {}
+class MlflowAlreadyExistsError extends Error {}
+
+async function readMlflowResponse(response: Response): Promise<any> {
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : {};
+
+  if (response.ok) return payload;
+
+  const code = typeof payload.error_code === "string" ? payload.error_code : undefined;
+  const message = typeof payload.message === "string" ? payload.message : response.statusText;
+  if (response.status === 404 || code === "RESOURCE_DOES_NOT_EXIST") {
+    throw new MlflowNotFoundError(message);
+  }
+  if (code === "RESOURCE_ALREADY_EXISTS") {
+    throw new MlflowAlreadyExistsError(message);
+  }
+  throw new Error(
+    `MLflow request failed (${response.status} ${code ?? "unknown"}): ${message}`,
+  );
+}
+
+async function mlflowGet(
+  fetchImpl: EvalReportMlflowFetch,
+  trackingUri: string,
+  authHeaders: Record<string, string>,
+  endpoint: string,
+  query: Record<string, string>,
+): Promise<any> {
+  const url = new URL(`${trackingUri}/api/2.0/mlflow/${endpoint}`);
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.set(key, value);
+  }
+  return readMlflowResponse(await fetchImpl(url, { headers: authHeaders }));
+}
+
+async function mlflowPost(
+  fetchImpl: EvalReportMlflowFetch,
+  trackingUri: string,
+  authHeaders: Record<string, string>,
+  endpoint: string,
+  body: unknown,
+): Promise<any> {
+  return readMlflowResponse(
+    await fetchImpl(`${trackingUri}/api/2.0/mlflow/${endpoint}`, {
+      method: "POST",
+      headers: { ...authHeaders, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+interface MlflowLogBatchChunk {
+  params: MlflowParam[];
+  metrics: MlflowMetric[];
+  tags: MlflowTag[];
+}
+
+function logBatchEntryCount(chunk: MlflowLogBatchChunk): number {
+  return chunk.params.length + chunk.metrics.length + chunk.tags.length;
+}
+
+function logBatchBodySize(runId: string, chunk: MlflowLogBatchChunk): number {
+  const body = JSON.stringify({
+    run_id: runId,
+    params: chunk.params,
+    metrics: chunk.metrics,
+    tags: chunk.tags,
+  });
+  return LOG_BATCH_BODY_ENCODER.encode(body).length;
+}
+
+function canAddLogBatchEntry(
+  runId: string,
+  chunk: MlflowLogBatchChunk,
+  kind: keyof MlflowLogBatchChunk,
+  entry: MlflowLogBatchChunk[keyof MlflowLogBatchChunk][number],
+): boolean {
+  if (logBatchEntryCount(chunk) >= MLFLOW_LOG_BATCH_MAX_TOTAL_ENTRIES) {
+    return false;
+  }
+  if (
+    kind === "metrics" && chunk.metrics.length >= MLFLOW_LOG_BATCH_MAX_METRICS
+  ) return false;
+  if (kind === "params" && chunk.params.length >= MLFLOW_LOG_BATCH_MAX_PARAMS) {
+    return false;
+  }
+  if (kind === "tags" && chunk.tags.length >= MLFLOW_LOG_BATCH_MAX_TAGS) {
+    return false;
+  }
+
+  const nextChunk = {
+    params: kind === "params" ? [...chunk.params, entry as MlflowParam] : chunk.params,
+    metrics: kind === "metrics" ? [...chunk.metrics, entry as MlflowMetric] : chunk.metrics,
+    tags: kind === "tags" ? [...chunk.tags, entry as MlflowTag] : chunk.tags,
+  };
+  return logBatchBodySize(runId, nextChunk) <= MLFLOW_LOG_BATCH_MAX_BYTES;
+}
+
+function createLogBatchChunks(input: {
+  runId: string;
+  params?: MlflowParam[];
+  metrics?: MlflowMetric[];
+  tags?: MlflowTag[];
+}): MlflowLogBatchChunk[] {
+  const chunks: MlflowLogBatchChunk[] = [];
+  let current: MlflowLogBatchChunk = { params: [], metrics: [], tags: [] };
+
+  const flush = () => {
+    if (logBatchEntryCount(current) === 0) return;
+    chunks.push(current);
+    current = { params: [], metrics: [], tags: [] };
+  };
+
+  const add = <K extends keyof MlflowLogBatchChunk>(
+    kind: K,
+    entry: MlflowLogBatchChunk[K][number],
+  ) => {
+    if (!canAddLogBatchEntry(input.runId, current, kind, entry)) flush();
+    if (!canAddLogBatchEntry(input.runId, current, kind, entry)) {
+      throw new Error(
+        `MLflow log-batch ${kind} entry is too large to upload safely`,
+      );
+    }
+    current[kind].push(entry as never);
+  };
+
+  for (const param of input.params ?? []) add("params", param);
+  for (const tag of input.tags ?? []) add("tags", tag);
+  for (const metric of input.metrics ?? []) add("metrics", metric);
+  flush();
+
+  return chunks;
+}
+
+async function logMlflowBatch(
+  fetchImpl: EvalReportMlflowFetch,
+  trackingUri: string,
+  input: {
+    runId: string;
+    authHeaders: Record<string, string>;
+    params?: MlflowParam[];
+    metrics?: MlflowMetric[];
+    tags?: MlflowTag[];
+  },
+): Promise<void> {
+  for (const chunk of createLogBatchChunks(input)) {
+    await mlflowPost(
+      fetchImpl,
+      trackingUri,
+      input.authHeaders,
+      "runs/log-batch",
+      {
+        run_id: input.runId,
+        params: chunk.params,
+        metrics: chunk.metrics,
+        tags: chunk.tags,
+      },
+    );
+  }
+}
+
+async function getOrCreateMlflowExperiment(input: {
+  fetchImpl: EvalReportMlflowFetch;
+  trackingUri: string;
+  authHeaders: Record<string, string>;
+  experimentName: string;
+  report: EvalReport;
+  context: EvalReportExportContext;
+}): Promise<string> {
+  const existing = await mlflowGet(
+    input.fetchImpl,
+    input.trackingUri,
+    input.authHeaders,
+    "experiments/get-by-name",
+    {
+      experiment_name: input.experimentName,
+    },
+  ).catch((error) => {
+    if (error instanceof MlflowNotFoundError) return undefined;
+    throw error;
+  });
+
+  if (existing?.experiment?.experiment_id) {
+    return String(existing.experiment.experiment_id);
+  }
+
+  const created = await mlflowPost(
+    input.fetchImpl,
+    input.trackingUri,
+    input.authHeaders,
+    "experiments/create",
+    {
+      name: input.experimentName,
+      tags: compact([
+        tag("eval.framework", "veryfront"),
+        tag("eval.definition_id", input.report.definitionId),
+        tag("eval.project_reference", input.context.projectReference),
+      ]),
+    },
+  ).catch(async (error) => {
+    if (!(error instanceof MlflowAlreadyExistsError)) throw error;
+    const raceWinner = await mlflowGet(
+      input.fetchImpl,
+      input.trackingUri,
+      input.authHeaders,
+      "experiments/get-by-name",
+      {
+        experiment_name: input.experimentName,
+      },
+    );
+    return { experiment_id: raceWinner.experiment.experiment_id };
+  });
+
+  return String(created.experiment_id);
+}
+
+async function uploadReportArtifacts(input: {
+  fetchImpl: EvalReportMlflowFetch;
+  artifactsUri?: string;
+  runArtifactUri?: string;
+  report: EvalReport;
+}): Promise<string[]> {
+  const uploads = await Promise.all([
+    uploadMlflowJsonArtifact({
+      fetchImpl: input.fetchImpl,
+      runArtifactUri: input.runArtifactUri,
+      artifactsUri: input.artifactsUri,
+      artifactPath: "veryfront-eval/report.json",
+      value: input.report,
+    }),
+    uploadMlflowJsonArtifact({
+      fetchImpl: input.fetchImpl,
+      runArtifactUri: input.runArtifactUri,
+      artifactsUri: input.artifactsUri,
+      artifactPath: "veryfront-eval/summary.json",
+      value: input.report.summary,
+    }),
+    uploadMlflowArtifact({
+      fetchImpl: input.fetchImpl,
+      runArtifactUri: input.runArtifactUri,
+      artifactsUri: input.artifactsUri,
+      artifactPath: "veryfront-eval/results.jsonl",
+      content: createResultsJsonl(input.report),
+      contentType: "application/x-ndjson",
+    }),
+  ]);
+  return uploads.map((upload) => upload.artifactPath);
+}
+
+export class EvalReportMlflowExporter implements EvalReportExporter {
+  readonly id: string;
+  private readonly config: EvalReportMlflowExtensionConfig & {
+    trackingUri: string;
+  };
+  private readonly fetchImpl: EvalReportMlflowFetch;
+
+  constructor(
+    config: EvalReportMlflowExtensionConfig & {
+      id: string;
+      trackingUri: string;
+    },
+    fetchImpl: EvalReportMlflowFetch = fetch,
+  ) {
+    this.id = config.id;
+    this.config = {
+      ...config,
+      trackingUri: normalizeHttpUri(config.trackingUri, "trackingUri"),
+      ...(config.artifactsUri
+        ? { artifactsUri: normalizeHttpUri(config.artifactsUri, "artifactsUri") }
+        : {}),
+    };
+    this.fetchImpl = fetchImpl;
+  }
+
+  async export(
+    report: EvalReport,
+    context: EvalReportExportContext,
+  ): Promise<EvalReportExportReceipt> {
+    const trackingUri = this.config.trackingUri;
+    const authHeaders = createTrackingAuthHeaders(this.config);
+    const selectedExperimentName = experimentName(this.config, report, context);
+    const experimentId = await getOrCreateMlflowExperiment({
+      fetchImpl: this.fetchImpl,
+      trackingUri,
+      authHeaders,
+      experimentName: selectedExperimentName,
+      report,
+      context,
+    });
+    const startedAt = Date.parse(report.startedAt);
+    const createdRun = await mlflowPost(
+      this.fetchImpl,
+      trackingUri,
+      authHeaders,
+      "runs/create",
+      {
+        experiment_id: experimentId,
+        run_name: normalizeMlflowTagValue(runName(this.config, report)),
+        start_time: Number.isFinite(startedAt) ? startedAt : Date.now(),
+        tags: createRunTags(this.config, report, context),
+      },
+    );
+
+    const runId = String(
+      createdRun.run.info.run_id ?? createdRun.run.info.run_uuid,
+    );
+    const runArtifactUri = String(createdRun.run.info.artifact_uri ?? "");
+    try {
+      const now = Date.now();
+      await logMlflowBatch(this.fetchImpl, trackingUri, {
+        runId,
+        authHeaders,
+        params: createRunParams(report, context),
+        metrics: createMetrics(report, now),
+        tags: compact([
+          tag("veryfront.summary.failed", report.summary.failed),
+          tag("veryfront.summary.passed", report.summary.passed),
+        ]),
+      });
+
+      const artifacts = await uploadReportArtifacts({
+        fetchImpl: this.fetchImpl,
+        artifactsUri: this.config.artifactsUri,
+        runArtifactUri,
+        report,
+      });
+
+      await logMlflowBatch(this.fetchImpl, trackingUri, {
+        runId,
+        authHeaders,
+        tags: [
+          { key: "artifacts.logged", value: "true" },
+          { key: "artifacts.count", value: String(artifacts.length) },
+        ],
+      });
+
+      await mlflowPost(this.fetchImpl, trackingUri, authHeaders, "runs/update", {
+        run_id: runId,
+        status: report.summary.failed === 0 ? "FINISHED" : "FAILED",
+        end_time: Date.now(),
+      });
+
+      return {
+        externalRunId: runId,
+        url: `${trackingUri}/#/experiments/${experimentId}/runs/${runId}`,
+        metadata: {
+          experimentId,
+          experimentName: selectedExperimentName,
+          artifacts,
+        },
+      };
+    } catch (error) {
+      await mlflowPost(this.fetchImpl, trackingUri, authHeaders, "runs/update", {
+        run_id: runId,
+        status: "FAILED",
+        end_time: Date.now(),
+      }).catch(() => undefined);
+      throw error;
+    }
+  }
+}
+
+export function createEvalReportMlflowExporter(
+  config: EvalReportMlflowExtensionConfig & {
+    id?: string;
+    trackingUri: string;
+  },
+  fetchImpl?: EvalReportMlflowFetch,
+): EvalReportMlflowExporter {
+  return new EvalReportMlflowExporter(
+    { ...config, id: DEFAULT_EXPORTER_ID },
+    fetchImpl,
+  );
+}
+
+const extEvalReportMlflow: ExtensionFactory = (config?: unknown) => {
+  const factoryConfig = resolveExporterConfig(normalizeConfig(config));
+  let registry: EvalReportExporterRegistry | undefined;
+  let registeredId: string | undefined;
+
+  return {
+    name: "ext-eval-report-mlflow",
+    version: "0.1.0",
+    contracts: EXTENSION_METADATA.contracts,
+    capabilities: EXTENSION_METADATA.capabilities,
+    setup(ctx) {
+      registry = ctx.require<EvalReportExporterRegistry>(
+        EvalReportExporterRegistryName,
+      );
+      const activationTrackingUri = readEnv(ENV_TRACKING_URI);
+      if (!activationTrackingUri) {
+        ctx.logger.debug(
+          `[ext-eval-report-mlflow] Skipping EvalReportExporter "${factoryConfig.id}": no MLFLOW_TRACKING_URI configured`,
+        );
+        return;
+      }
+
+      registry.register(
+        new EvalReportMlflowExporter(
+          {
+            ...factoryConfig,
+            trackingUri: factoryConfig.trackingUri ?? activationTrackingUri,
+          },
+          factoryConfig.fetch,
+        ),
+      );
+      registeredId = factoryConfig.id;
+      ctx.logger.info(
+        `[ext-eval-report-mlflow] EvalReportExporter "${factoryConfig.id}" registered`,
+      );
+    },
+    teardown() {
+      if (registry && registeredId) registry.unregister(registeredId);
+      registry = undefined;
+      registeredId = undefined;
+    },
+  };
+};
+
+export default extEvalReportMlflow;

--- a/scripts/build/compile-binary.test.ts
+++ b/scripts/build/compile-binary.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from "#std/assert";
+import { DEFAULT_INCLUDES } from "./compile-binary.ts";
+
+Deno.test("compiled CLI embeds optional builtin extension source files", async () => {
+  const source = await Deno.readTextFile("src/extensions/builtin-extensions.ts");
+  const sourceDirectories = Array.from(
+    source.matchAll(/sourceDirectory:\s*"([^"]+)"/g),
+    (match) => match[1]!,
+  );
+
+  for (const sourceDirectory of sourceDirectories) {
+    assertEquals(
+      DEFAULT_INCLUDES.includes(`extensions/${sourceDirectory}/src/index.ts`),
+      true,
+      `compile-binary DEFAULT_INCLUDES must embed optional builtin ${sourceDirectory}`,
+    );
+  }
+});

--- a/scripts/build/compile-binary.ts
+++ b/scripts/build/compile-binary.ts
@@ -8,7 +8,7 @@ import { fromFileUrl, isAbsolute, join } from "#std/path.ts";
 import { getBinaryPluginBundleIncludes } from "../../src/build/binary-plugin-includes.ts";
 
 const PROJECT_ROOT = fromFileUrl(new URL("../..", import.meta.url));
-const DEFAULT_INCLUDES = [
+export const DEFAULT_INCLUDES = [
   "src/platform/polyfills",
   "src/proxy/main.ts",
   "src/security/sandbox/worker-script.ts",
@@ -20,6 +20,7 @@ const DEFAULT_INCLUDES = [
   "extensions/ext-db-sqlite/src/index.ts",
   "extensions/ext-document-kreuzberg/src/index.ts",
   "extensions/ext-eval-report-http/src/index.ts",
+  "extensions/ext-eval-report-mlflow/src/index.ts",
   "extensions/ext-observability-opentelemetry/src/index.ts",
   "extensions/ext-parser-babel/src/index.ts",
   "extensions/ext-sandbox-shell-tools/src/index.ts",

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -508,6 +508,7 @@ describe("npm supply-chain policy", () => {
       "ext-css-tailwind",
       "ext-db-sqlite",
       "ext-document-kreuzberg",
+      "ext-eval-report-mlflow",
       "ext-observability-opentelemetry",
       "ext-parser-babel",
       "ext-sandbox-shell-tools",

--- a/scripts/lint/audit-extension-capabilities.test.ts
+++ b/scripts/lint/audit-extension-capabilities.test.ts
@@ -66,6 +66,60 @@ describe("auditExtensionCapabilities", () => {
       'extensions/ext-cache-redis/deno.json sensitive extension "Redis token cache" is missing capability {"keys":["REDIS_PASSWORD","REDIS_PREFIX","REDIS_URL"],"type":"env:read"}',
     ]);
   });
+
+  it("requires MLflow export capabilities without the legacy exporter-id env key", () => {
+    const manifestPath = "extensions/ext-eval-report-mlflow/deno.json";
+    const allowedCapabilities = [
+      { type: "net:outbound", hosts: ["*"] },
+      {
+        type: "env:read",
+        keys: [
+          "MLFLOW_ARTIFACTS_URI",
+          "MLFLOW_EXPERIMENT_NAME",
+          "MLFLOW_RUN_NAME",
+          "MLFLOW_TRACKING_PASSWORD",
+          "MLFLOW_TRACKING_TOKEN",
+          "MLFLOW_TRACKING_URI",
+          "MLFLOW_TRACKING_USERNAME",
+        ],
+      },
+    ];
+
+    assertEquals(
+      auditExtensionCapabilities([
+        input({
+          manifestPath,
+          manifestCapabilities: allowedCapabilities,
+          factoryCapabilities: allowedCapabilities,
+        }),
+      ]),
+      [],
+    );
+
+    const forbiddenCapabilities = [
+      { type: "net:outbound", hosts: ["*"] },
+      {
+        type: "env:read",
+        keys: [
+          "MLFLOW_TRACKING_URI",
+          "VERYFRONT_EVAL_MLFLOW_EXPORTER_ID",
+        ],
+      },
+    ];
+    const issues = auditExtensionCapabilities([
+      input({
+        manifestPath,
+        manifestCapabilities: forbiddenCapabilities,
+        factoryCapabilities: forbiddenCapabilities,
+      }),
+    ]);
+
+    assertEquals(issues.map((issue) => issue.message), [
+      "extensions/ext-eval-report-mlflow/deno.json manifest capabilities must not register forbidden env key VERYFRONT_EVAL_MLFLOW_EXPORTER_ID",
+      "extensions/ext-eval-report-mlflow/deno.json factory capabilities must not register forbidden env key VERYFRONT_EVAL_MLFLOW_EXPORTER_ID",
+      'extensions/ext-eval-report-mlflow/deno.json sensitive extension "eval report MLflow export" is missing capability {"keys":["MLFLOW_ARTIFACTS_URI","MLFLOW_EXPERIMENT_NAME","MLFLOW_RUN_NAME","MLFLOW_TRACKING_PASSWORD","MLFLOW_TRACKING_TOKEN","MLFLOW_TRACKING_URI","MLFLOW_TRACKING_USERNAME"],"type":"env:read"}',
+    ]);
+  });
 });
 
 describe("extractExtensionSourceMetadata capabilities", () => {

--- a/scripts/lint/audit-extension-capabilities.ts
+++ b/scripts/lint/audit-extension-capabilities.ts
@@ -83,7 +83,33 @@ export const SENSITIVE_EXTENSION_CAPABILITY_POLICIES:
         },
       ],
     },
+    {
+      label: "eval report MLflow export",
+      manifestPath: "extensions/ext-eval-report-mlflow/deno.json",
+      requiredCapabilities: [
+        { type: "net:outbound", hosts: ["*"] },
+        {
+          type: "env:read",
+          keys: [
+            "MLFLOW_ARTIFACTS_URI",
+            "MLFLOW_EXPERIMENT_NAME",
+            "MLFLOW_RUN_NAME",
+            "MLFLOW_TRACKING_PASSWORD",
+            "MLFLOW_TRACKING_TOKEN",
+            "MLFLOW_TRACKING_URI",
+            "MLFLOW_TRACKING_USERNAME",
+          ],
+        },
+      ],
+    },
   ];
+
+const FORBIDDEN_ENV_READ_KEYS_BY_MANIFEST = new Map<string, string[]>([
+  [
+    "extensions/ext-eval-report-mlflow/deno.json",
+    ["VERYFRONT_EVAL_MLFLOW_EXPORTER_ID"],
+  ],
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -183,6 +209,32 @@ export function auditExtensionCapabilities(
             formatCapabilities(input.manifestCapabilities)
           }; factory ${formatCapabilities(input.factoryCapabilities)}`,
       });
+    }
+
+    const forbiddenEnvKeys = FORBIDDEN_ENV_READ_KEYS_BY_MANIFEST.get(
+      input.manifestPath,
+    ) ?? [];
+    for (const forbiddenKey of forbiddenEnvKeys) {
+      for (
+        const [label, capabilities] of [
+          ["manifest", input.manifestCapabilities],
+          ["factory", input.factoryCapabilities],
+        ] as const
+      ) {
+        if (
+          capabilities.some((capability) =>
+            capability.type === "env:read" &&
+            Array.isArray(capability.keys) &&
+            capability.keys.includes(forbiddenKey)
+          )
+        ) {
+          issues.push({
+            manifestPath: input.manifestPath,
+            message:
+              `${input.manifestPath} ${label} capabilities must not register forbidden env key ${forbiddenKey}`,
+          });
+        }
+      }
     }
 
     const policy = policyByManifest.get(input.manifestPath);

--- a/src/extensions/builtin-extensions.test.ts
+++ b/src/extensions/builtin-extensions.test.ts
@@ -6,9 +6,11 @@ import { EvalReportExporterRegistryName } from "./eval/index.ts";
 import type { SchemaValidator } from "./schema/index.ts";
 import {
   createBuiltinExtensions,
+  createEvalCliBuiltinExtensions,
   createOptionalBuiltinExtension,
   ensureBuiltinEvalReportExporterRegistry,
   ensureBuiltinSchemaValidator,
+  OPTIONAL_BUILTIN_EXTENSIONS,
 } from "./builtin-extensions.ts";
 import { createZodAdapter } from "../../extensions/ext-schema-zod/src/adapter.ts";
 
@@ -147,5 +149,29 @@ describe("createBuiltinExtensions", () => {
     });
 
     assertEquals(logs.some((message) => message.includes("ext-missing")), true);
+  });
+
+  it("declares explicit eval exporter ids for optional exporter builtins", () => {
+    const mlflow = OPTIONAL_BUILTIN_EXTENSIONS.find((definition) =>
+      definition.name === "ext-eval-report-mlflow"
+    );
+
+    assertEquals(mlflow?.evalExporterId, "mlflow");
+  });
+
+  it("builds a minimal eval CLI builtin set for selected eval exporters", () => {
+    const names = createEvalCliBuiltinExtensions(["mlflow"]).map((entry) => entry.extension.name);
+
+    assertEquals(names.includes("ext-schema-zod"), true);
+    assertEquals(names.includes("ext-eval-report-mlflow"), true);
+    assertEquals(names.includes("ext-auth-jwt"), false);
+    assertEquals(names.includes("ext-observability-opentelemetry"), false);
+  });
+
+  it("does not load optional eval exporter builtins when no exporters are selected", () => {
+    const names = createEvalCliBuiltinExtensions([]).map((entry) => entry.extension.name);
+
+    assertEquals(names.includes("ext-eval-report-mlflow"), false);
+    assertEquals(names.includes("ext-auth-jwt"), false);
   });
 });

--- a/src/extensions/builtin-extensions.ts
+++ b/src/extensions/builtin-extensions.ts
@@ -32,6 +32,7 @@ export type OptionalBuiltinExtensionDefinition = {
   origin: string;
   sourceDirectory: string;
   contracts?: ExtensionContractMetadata;
+  evalExporterId?: string;
   capabilities: Capability[];
 };
 
@@ -53,7 +54,7 @@ const BUILTIN_LLM_PROVIDERS: BuiltinLLMProviderDefinition[] = [
   },
 ];
 
-const OPTIONAL_BUILTIN_EXTENSIONS: OptionalBuiltinExtensionDefinition[] = [
+export const OPTIONAL_BUILTIN_EXTENSIONS: OptionalBuiltinExtensionDefinition[] = [
   {
     name: "ext-auth-jwt",
     origin: "veryfront/ext-auth-jwt",
@@ -159,6 +160,28 @@ const OPTIONAL_BUILTIN_EXTENSIONS: OptionalBuiltinExtensionDefinition[] = [
     contracts: { provides: ["SandboxShellToolsProvider"] },
     capabilities: [{ type: "sandbox:execute", tools: ["bash"] }],
   },
+  {
+    name: "ext-eval-report-mlflow",
+    origin: "veryfront/ext-eval-report-mlflow",
+    sourceDirectory: "ext-eval-report-mlflow",
+    contracts: { requires: ["EvalReportExporterRegistry"] },
+    evalExporterId: "mlflow",
+    capabilities: [
+      { type: "net:outbound", hosts: ["*"] },
+      {
+        type: "env:read",
+        keys: [
+          "MLFLOW_ARTIFACTS_URI",
+          "MLFLOW_EXPERIMENT_NAME",
+          "MLFLOW_RUN_NAME",
+          "MLFLOW_TRACKING_PASSWORD",
+          "MLFLOW_TRACKING_TOKEN",
+          "MLFLOW_TRACKING_URI",
+          "MLFLOW_TRACKING_USERNAME",
+        ],
+      },
+    ],
+  },
 ];
 
 function getOrCreateLLMProviderRegistry(): LLMProviderRegistry {
@@ -171,7 +194,9 @@ function getOrCreateLLMProviderRegistry(): LLMProviderRegistry {
 }
 
 export function ensureBuiltinEvalReportExporterRegistry(): EvalReportExporterRegistry {
-  const existing = tryResolve<EvalReportExporterRegistry>(EvalReportExporterRegistryName);
+  const existing = tryResolve<EvalReportExporterRegistry>(
+    EvalReportExporterRegistryName,
+  );
   if (existing) return existing;
 
   const registry = createEvalReportExporterRegistry();
@@ -219,15 +244,21 @@ function createBuiltinLLMProviderExtension(
       },
       capabilities: [],
       setup(ctx) {
-        const registry = ctx.require<LLMProviderRegistry>(LLMProviderRegistryName);
+        const registry = ctx.require<LLMProviderRegistry>(
+          LLMProviderRegistryName,
+        );
         didRegister = registerBuiltinLLMProvider(registry, provider);
         if (didRegister) {
-          ctx.logger.info(`[${definition.extensionName}] ${provider.id} provider registered`);
+          ctx.logger.info(
+            `[${definition.extensionName}] ${provider.id} provider registered`,
+          );
         }
       },
       teardown() {
         if (didRegister) {
-          const registry = tryResolve<LLMProviderRegistry>(LLMProviderRegistryName);
+          const registry = tryResolve<LLMProviderRegistry>(
+            LLMProviderRegistryName,
+          );
           registry?.unregister(provider.id);
           didRegister = false;
         }
@@ -254,7 +285,9 @@ export function createOptionalBuiltinExtension(
         if (!extension) return;
 
         loaded = extension;
-        for (const [contract, impl] of Object.entries(extension.provides ?? {})) {
+        for (
+          const [contract, impl] of Object.entries(extension.provides ?? {})
+        ) {
           ctx.provide(contract, impl);
         }
         await extension.setup?.(ctx);
@@ -298,7 +331,9 @@ async function importOptionalBuiltinFactory(
     default?: unknown;
   }>(sourceDirectory, packageName);
   if (typeof mod.default !== "function") {
-    throw new Error(`Builtin extension "${sourceDirectory}" has no default factory export`);
+    throw new Error(
+      `Builtin extension "${sourceDirectory}" has no default factory export`,
+    );
   }
   return mod.default as ExtensionFactory;
 }
@@ -313,7 +348,9 @@ function isMissingOptionalBuiltinImplementation(
   ]);
 }
 
-function getFirstPartyExtensionPackageName(definition: OptionalBuiltinExtensionDefinition): string {
+function getFirstPartyExtensionPackageName(
+  definition: OptionalBuiltinExtensionDefinition,
+): string {
   return definition.origin.replace("veryfront/", "@veryfront/");
 }
 
@@ -328,6 +365,27 @@ export function createBuiltinExtensions(): ResolvedExtension[] {
       extension: extZod(),
     },
     ...OPTIONAL_BUILTIN_EXTENSIONS.map(createOptionalBuiltinExtension),
+    ...BUILTIN_LLM_PROVIDERS.map(createBuiltinLLMProviderExtension),
+  ];
+}
+
+export function createEvalCliBuiltinExtensions(
+  selectedExporterIds: string[] = [],
+): ResolvedExtension[] {
+  const selected = new Set(selectedExporterIds);
+  const exporterExtensions = OPTIONAL_BUILTIN_EXTENSIONS.filter((definition) =>
+    definition.contracts?.requires?.includes(EvalReportExporterRegistryName) &&
+    definition.evalExporterId !== undefined &&
+    selected.has(definition.evalExporterId)
+  );
+
+  return [
+    {
+      source: "builtin",
+      origin: "veryfront/ext-schema-zod",
+      extension: extZod(),
+    },
+    ...exporterExtensions.map(createOptionalBuiltinExtension),
     ...BUILTIN_LLM_PROVIDERS.map(createBuiltinLLMProviderExtension),
   ];
 }


### PR DESCRIPTION
## Summary

Adds a first-party MLflow eval report exporter extension, wired into the built-in extension catalog and CLI eval export flow.

- adds `@veryfront/ext-eval-report-mlflow` with a fixed `mlflow` exporter id
- registers the exporter when `MLFLOW_TRACKING_URI` is configured
- supports safe-by-default eval report redaction through the shared export context
- uploads report/summary artifacts through MLflow REST APIs with explicit artifact endpoint handling
- adds CLI support for plural exporter selection via `--export`, `VERYFRONT_EVAL_EXPORTERS`, then legacy `VERYFRONT_EVAL_EXPORT`
- updates extension metadata audits, package metadata expectations, and docs

Closes #5876.

## Validation

- `deno fmt --check ...` on the changed MLflow/CLI/docs/audit files
- `git diff --cached --check`
- no conflict markers in changed conflict-resolution files
- no legacy `VERYFRONT_EVAL_MLFLOW_EXPORTER_ID` runtime/docs/metadata usage
- `deno test --no-check --allow-all extensions/ext-eval-report-mlflow/src/index.test.ts`
- `(cd extensions/ext-eval-report-mlflow && deno test --allow-all src/index.test.ts)`
- `deno task lint:extension-contracts`
- `deno task lint:extension-capabilities`
- `deno test --allow-all cli/commands/eval/command.test.ts`
- `deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/lint/audit-extension-capabilities.test.ts`
- `deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/lint/audit-extension-contracts.test.ts`
- `deno test --no-check --allow-all src/extensions/capabilities.test.ts src/extensions/builtin-extensions.test.ts src/extensions/eval/eval-report-exporter.test.ts src/eval/runner.test.ts src/eval/factory.test.ts src/eval/discovery.test.ts`
- pre-push hook: formatting, lint, typecheck, and unit tests (`2380 passed`, `20217 steps`)

## Notes

A targeted run of `scripts/build/npm-package-metadata.test.ts` passed the MLflow-related assertions but still hit an unrelated generated-artifact gap: missing `npm/esm/cli/commands/mcp/handler.js` in the checkout.
