### PR TITLE
Bump veryfront to 0.1.1061

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1060",
+  "version": "0.1.1061",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1060";
+export const VERSION = "0.1.1061";


### PR DESCRIPTION
## Summary

- Bump Veryfront package version to `0.1.1061` so the merged MLflow eval exporter changes publish to npm.
- Keep the shared CLI version constant in sync with `deno.json`.

## Validation

- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version-constant.ts`
- pre-push hook: formatting, lint, typecheck, unit tests — `2380 passed / 20222 steps`
