### PR TITLE
Fix MLflow release publish path

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1061",
+  "version": "0.1.1062",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-eval-report-mlflow/README.md
+++ b/extensions/ext-eval-report-mlflow/README.md
@@ -7,6 +7,12 @@ Registers the `mlflow` eval report exporter. The exporter id is fixed to
 Use this extension when completed Veryfront `EvalReport` payloads should be
 written to MLflow Tracking as one run per eval execution.
 
+> **npm packaging note:** CLI usage is bundled into the root `veryfront`
+> package, so `veryfront eval --export mlflow` works without installing a
+> separate package. The standalone `@veryfront/ext-eval-report-mlflow` package
+> is intentionally not published until npm trusted publishing is configured for
+> that new package.
+
 The exporter is generic. It logs Veryfront report data such as pass/fail counts,
 metric pass rates, duration summaries, usage/tokens/cost fields, and redacted
 report artifacts. Project-specific extraction, such as reading a domain label

--- a/extensions/ext-eval-report-mlflow/deno.json
+++ b/extensions/ext-eval-report-mlflow/deno.json
@@ -5,10 +5,17 @@
   "veryfront": {
     "extension": true,
     "contracts": {
-      "requires": ["EvalReportExporterRegistry"]
+      "requires": [
+        "EvalReportExporterRegistry"
+      ]
     },
     "capabilities": [
-      { "type": "net:outbound", "hosts": ["*"] },
+      {
+        "type": "net:outbound",
+        "hosts": [
+          "*"
+        ]
+      },
       {
         "type": "env:read",
         "keys": [
@@ -21,7 +28,10 @@
           "MLFLOW_TRACKING_USERNAME"
         ]
       }
-    ]
+    ],
+    "npm": {
+      "publish": false
+    }
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.19",

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -181,6 +181,93 @@ Deno.test("npm publish orders extensions before the root package", async () => {
   }
 });
 
+Deno.test("npm publish skips extension packages marked publish false", async () => {
+  const packageRoot = await Deno.makeTempDir();
+
+  try {
+    await Deno.mkdir(`${packageRoot}/extensions/ext-alpha`, {
+      recursive: true,
+    });
+    await Deno.mkdir(`${packageRoot}/extensions/ext-private`, {
+      recursive: true,
+    });
+    await Deno.mkdir(`${packageRoot}/npm/extensions/ext-alpha`, {
+      recursive: true,
+    });
+    await Deno.mkdir(`${packageRoot}/npm/extensions/ext-private`, {
+      recursive: true,
+    });
+
+    await Deno.writeTextFile(
+      `${packageRoot}/deno.json`,
+      JSON.stringify({
+        workspace: [
+          "./extensions/ext-alpha",
+          "./extensions/ext-private",
+        ],
+      }),
+    );
+    await Deno.writeTextFile(
+      `${packageRoot}/extensions/ext-alpha/deno.json`,
+      JSON.stringify({
+        name: "@veryfront/ext-alpha",
+        veryfront: { extension: true },
+      }),
+    );
+    await Deno.writeTextFile(
+      `${packageRoot}/extensions/ext-private/deno.json`,
+      JSON.stringify({
+        name: "@veryfront/ext-private",
+        veryfront: { extension: true, npm: { publish: false } },
+      }),
+    );
+    await Deno.writeTextFile(
+      `${packageRoot}/npm/extensions/ext-alpha/package.json`,
+      JSON.stringify({
+        name: "@veryfront/ext-alpha",
+        veryfront: { extension: true },
+      }),
+    );
+    await Deno.writeTextFile(
+      `${packageRoot}/npm/extensions/ext-private/package.json`,
+      JSON.stringify({
+        name: "@veryfront/ext-private",
+        veryfront: { extension: true, npm: { publish: false } },
+      }),
+    );
+
+    const output = await new Deno.Command("bash", {
+      args: [
+        "-c",
+        'source "$SCRIPT_PATH"\npackage_names_from_workspace\npackage_dirs',
+      ],
+      cwd: packageRoot,
+      env: {
+        SCRIPT_PATH: `${Deno.cwd()}/scripts/ci/publish-npm-packages.sh`,
+      },
+      stderr: "piped",
+      stdout: "piped",
+    }).output();
+
+    assertEquals(output.code, 0, new TextDecoder().decode(output.stderr));
+    assertEquals(
+      new TextDecoder().decode(output.stdout).trim().split("\n"),
+      [
+        "veryfront",
+        "@veryfront/ext-alpha",
+        "npm/extensions/ext-alpha",
+        "npm",
+      ],
+    );
+    assertStringIncludes(
+      new TextDecoder().decode(output.stderr),
+      "@veryfront/ext-private is marked veryfront.npm.publish=false",
+    );
+  } finally {
+    await Deno.remove(packageRoot, { recursive: true });
+  }
+});
+
 // Extensions whose implementations are statically imported by
 // src/extensions/builtin-extensions.ts and therefore ship inside the root
 // npm package. Their dependencies must stay in root; every other workspace
@@ -190,6 +277,7 @@ const ROOT_BUNDLED_EXTENSIONS = new Set([
   "ext-llm-openai",
   "ext-llm-anthropic",
   "ext-llm-google",
+  "ext-eval-report-mlflow",
 ]);
 
 Deno.test("EXTENSION_OWNED_DEPENDENCIES stays in sync with extension manifests", async () => {

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -38,7 +38,14 @@ require_env() {
 # Package directories in dependency order for publish modes. The root package
 # pins auto-loaded extensions to the same version, so publish it last.
 package_dirs() {
-  find npm/extensions -mindepth 1 -maxdepth 1 -type d | sort
+  find npm/extensions -mindepth 1 -maxdepth 1 -type d | sort | while read -r PACKAGE_DIR; do
+    if [ "$(jq -r '.veryfront.npm.publish == false' "${PACKAGE_DIR}/package.json")" = "true" ]; then
+      PACKAGE_NAME="$(jq -r '.name' "${PACKAGE_DIR}/package.json")"
+      echo "::notice::${PACKAGE_NAME} is marked veryfront.npm.publish=false; skipping npm publish" >&2
+      continue
+    fi
+    printf '%s\n' "${PACKAGE_DIR}"
+  done
   printf '%s\n' npm
 }
 
@@ -48,6 +55,9 @@ package_names_from_workspace() {
   printf '%s\n' veryfront
   jq -r '.workspace[] | select(startswith("./extensions/")) | .[2:] + "/deno.json"' deno.json \
     | while read -r MANIFEST_PATH; do
+      if [ "$(jq -r '.veryfront.npm.publish == false' "${MANIFEST_PATH}")" = "true" ]; then
+        continue
+      fi
       jq -r '.name' "${MANIFEST_PATH}"
     done \
     | sort

--- a/src/extensions/builtin-extensions.ts
+++ b/src/extensions/builtin-extensions.ts
@@ -18,6 +18,7 @@ import { createLLMProviderRegistry, LLMProviderRegistryName } from "./llm/index.
 import { OpenAIProvider } from "../../extensions/ext-llm-openai/src/index.ts";
 import { AnthropicProvider } from "../../extensions/ext-llm-anthropic/src/index.ts";
 import { GoogleProvider } from "../../extensions/ext-llm-google/src/index.ts";
+import extEvalReportMlflow from "../../extensions/ext-eval-report-mlflow/src/index.ts";
 import extZod from "../../extensions/ext-schema-zod/src/index.ts";
 import { createZodAdapter } from "../../extensions/ext-schema-zod/src/adapter.ts";
 
@@ -34,6 +35,7 @@ export type OptionalBuiltinExtensionDefinition = {
   contracts?: ExtensionContractMetadata;
   evalExporterId?: string;
   capabilities: Capability[];
+  factory?: ExtensionFactory;
 };
 
 const BUILTIN_LLM_PROVIDERS: BuiltinLLMProviderDefinition[] = [
@@ -166,6 +168,7 @@ export const OPTIONAL_BUILTIN_EXTENSIONS: OptionalBuiltinExtensionDefinition[] =
     sourceDirectory: "ext-eval-report-mlflow",
     contracts: { requires: ["EvalReportExporterRegistry"] },
     evalExporterId: "mlflow",
+    factory: extEvalReportMlflow,
     capabilities: [
       { type: "net:outbound", hosts: ["*"] },
       {
@@ -305,7 +308,7 @@ async function loadOptionalBuiltinExtension(
   ctx: ExtensionContext,
 ): Promise<Extension | undefined> {
   try {
-    const factory = await importOptionalBuiltinFactory(
+    const factory = definition.factory ?? await importOptionalBuiltinFactory(
       definition.sourceDirectory,
       getFirstPartyExtensionPackageName(definition),
     );

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1061";
+export const VERSION = "0.1.1062";


### PR DESCRIPTION
## Summary
- bump release metadata to `0.1.1062` after the partial `0.1.1061` publish
- bundle the MLflow eval exporter into the root `veryfront` package so `veryfront eval --export mlflow` still works
- mark standalone `@veryfront/ext-eval-report-mlflow` as non-published until npm trusted publishing is configured
- teach npm release package discovery to skip generated packages/manifests with `veryfront.npm.publish=false`

## Root cause
The main release for `0.1.1061` failed when CI tried to publish the new standalone `@veryfront/ext-eval-report-mlflow` package. npm returned `404` for the publish request, which is consistent with the package not being pre-created/trusted-publishing configured yet. That left dependent packages partially published and blocked downstream support-agent integration.

## Verification
- `deno check src/extensions/builtin-extensions.ts`
- `deno task build:npm`
- `deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/build/npm-package-metadata.test.ts scripts/build/compile-binary.test.ts scripts/lint/audit-extension-capabilities.test.ts`
- `deno test --no-check --allow-read src/extensions/builtin-extensions.test.ts`
- full pre-push checks: formatting, lint, typecheck, unit tests (`2380 passed / 20222 steps`)
- generated publish list excludes `@veryfront/ext-eval-report-mlflow` while retaining the root npm package
