### PR TITLE
feat(cli): add safe Git handoff workflows

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -10,6 +10,7 @@ on:
       - "deno.json"
       - "docs/getting-started/**"
       - "docs/guides/**"
+      - "docs/concepts/**"
       - "docs/api-reference/**"
       - "docs/integrations.md"
   workflow_dispatch:

--- a/cli/STYLE_GUIDE.md
+++ b/cli/STYLE_GUIDE.md
@@ -194,13 +194,13 @@ Show when command is run without required arguments:
 ```
   veryfront deploy
 
-  Deploy your project to production.
+  Create a release from previously pushed source and deploy it to production.
 
   Usage: veryfront deploy [options]
 
   Examples:
-    $ veryfront deploy
-    $ veryfront deploy --env staging
+    $ veryfront push --branch main
+    $ veryfront deploy --branch main --env staging
 
   Run 'veryfront deploy --help' for all options.
 ```
@@ -209,18 +209,18 @@ Show when command is run without required arguments:
 
 ```
   veryfront deploy
-  Deploy your project to production.
+  Create a release from previously pushed source and deploy it to production.
 
   Usage: veryfront deploy [options]
   Options:
     -e, --env <name>      Environment (default: production)
     -b, --branch <name>   Branch to deploy
-    -f, --force           Skip confirmation
+    -y, --yes             Skip confirmation
     -n, --dry-run         Preview without deploying
 
   Examples:
-    $ veryfront deploy
-    $ veryfront deploy --env staging
+    $ veryfront push --branch main
+    $ veryfront deploy --branch main --env staging
     $ veryfront deploy --branch feature-x --dry-run
 
   Tips:
@@ -234,7 +234,8 @@ Show when command is run without required arguments:
 | --------------- | ----------------------- |
 | `-h, --help`    | Show help               |
 | `-v, --version` | Show version            |
-| `-f, --force`   | Skip confirmations      |
+| `-y, --yes`     | Skip confirmations      |
+| `-f, --force`   | Command-specific force  |
 | `-n, --dry-run` | Preview without action  |
 | `-q, --quiet`   | Minimal output          |
 | `--json`        | Machine-readable output |
@@ -334,7 +335,8 @@ tasks.start(deployIdx);
 **stdout** is for primary output (results, `--json` data). **stderr** is for human-facing side-effects (progress, spinners, errors). This ensures `--json` output stays parseable when piped:
 
 ```bash
-veryfront deploy --json 2>/dev/null | jq '.url'
+veryfront push --branch main --yes
+veryfront deploy --branch main --env production --yes --json | tail -n 1 | jq '.data.deploymentId'
 ```
 
 Progress indicators (`createSpinner`) already write to stdout with ANSI clear sequences, so they self-clean in TTY mode and are suppressed in non-TTY mode.

--- a/cli/commands/demo/demo.ts
+++ b/cli/commands/demo/demo.ts
@@ -619,7 +619,14 @@ export async function demoCommand(options: DemoOptions = {}): Promise<void> {
     console.log();
     console.log(`  ${dim("1.")} Edit your app in ${brand(`${projectName}/`)}`);
     console.log(`  ${dim("2.")} Run ${brand("veryfront dev")} to start developing`);
-    console.log(`  ${dim("3.")} Run ${brand("veryfront deploy")} to publish changes`);
+    console.log(
+      `  ${dim("3.")} Run ${brand("veryfront push --branch main")} to upload changes`,
+    );
+    console.log(
+      `  ${dim("4.")} Run ${
+        brand("veryfront deploy --branch main --env production")
+      } to create a release and deploy`,
+    );
     console.log();
     console.log(`  ${dim("Learn more at https://veryfront.com/docs")}`);
     console.log();

--- a/cli/commands/demo/steps.ts
+++ b/cli/commands/demo/steps.ts
@@ -49,12 +49,12 @@ export const DEMO_STEPS: DemoStep[] = [
   },
   {
     id: "deploy",
-    title: "Deploy to Production",
+    title: "Create a Release and Deploy",
     description: [
-      "Deploy your app to Veryfront's global edge network with a single command.",
-      "No build step required - we handle that for you.",
+      "The demo pushed your source to main when it created the project.",
+      "Now create a release from that source and deploy it to production.",
     ],
-    command: "veryfront deploy",
+    command: "veryfront deploy --branch main --env production",
     hasAction: true,
   },
   {

--- a/cli/commands/deploy/command-help.ts
+++ b/cli/commands/deploy/command-help.ts
@@ -20,11 +20,15 @@ export const deployHelp: CommandHelp = {
     },
     {
       flag: "-f, --force",
-      description: "Deploy without confirmation",
+      description: "Skip confirmation for compatibility (prefer global --yes)",
     },
     {
       flag: "--dry-run",
       description: "Preview without executing",
+    },
+    {
+      flag: "-q, --quiet",
+      description: "Suppress progress and summary output",
     },
   ],
   examples: [
@@ -32,6 +36,7 @@ export const deployHelp: CommandHelp = {
     "veryfront deploy --env staging",
     "veryfront deploy --branch feature-x --env preview",
     "veryfront deploy --release-name v1.2.0",
+    "veryfront deploy --branch main --env production --yes",
     "veryfront deploy --dry-run",
   ],
   notes: [

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -574,16 +574,17 @@ export async function initCommand(options: InitOptions): Promise<void> {
     const { writeProjectSlug } = await import("#cli/shared/config");
     const { pushCommand } = await import("../push/index.ts");
     const { deployCommand } = await import("../deploy/index.ts");
+    const manualDeployHint = `Run ${brand("veryfront push --branch main")}, then ${
+      brand("veryfront deploy --branch main --env production")
+    } to deploy later.`;
 
     const authResult = await ensureAuthenticated();
     if (!authResult) {
-      log(
-        `\n  Authentication required for --deploy. Run ${brand("veryfront push")} to deploy later.`,
-      );
+      log(`\n  Authentication required for --deploy. ${manualDeployHint}`);
     } else {
       const token = await readToken();
       if (!token) {
-        log(`\n  Could not read auth token. Run ${brand("veryfront push")} to deploy later.`);
+        log(`\n  Could not read auth token. ${manualDeployHint}`);
       } else {
         const slug = `${projectName ?? "my-app"}-${randomSuffix()}`;
 
@@ -621,9 +622,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           log(`\n  Deploy failed: ${message}`);
-          log(
-            `  Your project was created locally. Run ${brand("veryfront push")} to deploy later.`,
-          );
+          log(`  Your project was created locally. ${manualDeployHint}`);
         }
       }
     }
@@ -665,8 +664,10 @@ export async function initCommand(options: InitOptions): Promise<void> {
   if (!deployedSlug) {
     successContent.push(
       "",
-      `${brand("veryfront push")}   ${dim("→ share a preview")}`,
-      `${brand("veryfront deploy")} ${dim("→ go live")}`,
+      `${brand("veryfront push --branch main")} ${dim("→ upload source")}`,
+      `${brand("veryfront deploy --branch main --env production")} ${
+        dim("→ create a release and go live")
+      }`,
     );
   }
 

--- a/cli/commands/pull/command-help.ts
+++ b/cli/commands/pull/command-help.ts
@@ -32,11 +32,19 @@ export const pullHelp: CommandHelp = {
     },
     {
       flag: "-f, --force",
-      description: "Force overwrite without confirmation",
+      description: "Skip confirmation for compatibility (prefer global --yes)",
     },
     {
       flag: "--dry-run",
-      description: "Show what would be written without writing",
+      description: "Show what would be written or deleted without changing files",
+    },
+    {
+      flag: "--prune",
+      description: "Delete managed local files missing from the selected source",
+    },
+    {
+      flag: "-q, --quiet",
+      description: "Suppress progress and summary output",
     },
   ],
   examples: [
@@ -49,8 +57,10 @@ export const pullHelp: CommandHelp = {
     "veryfront pull --release v1.2.0",
     "veryfront pull --projects project-a,project-b,project-c",
     "veryfront pull --projects my-app --dir ./apps",
+    "veryfront pull --branch studio-change --prune --dry-run",
+    "veryfront pull --branch studio-change --prune --yes",
     "veryfront pull --dry-run",
-    "veryfront pull --force",
+    "veryfront pull --yes",
   ],
   notes: [
     "Requires VERYFRONT_API_TOKEN env var or veryfront.json config",
@@ -58,5 +68,7 @@ export const pullHelp: CommandHelp = {
     "With --projects, each project is pulled into a subdirectory named after the slug",
     'Projects list can also be specified in veryfront.json: { "projects": ["slug1", "slug2"] }',
     "Priority order: --env > --release > --branch > main",
+    "--prune requires a clean Git worktree; --prune --dry-run can preview anywhere",
+    "--prune never removes ignored or unsupported files",
   ],
 };

--- a/cli/commands/pull/command.test.ts
+++ b/cli/commands/pull/command.test.ts
@@ -4,7 +4,12 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module cli/commands/pull.test
  */
 
-import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import {
@@ -16,6 +21,7 @@ import {
   type PullOptions,
   type PullSource,
   resolvePullSource,
+  validateRemoteFilePath,
 } from "./command.ts";
 import type { ApiClient } from "#cli/shared/config";
 import { join } from "veryfront/platform/path";
@@ -61,6 +67,10 @@ function restoreEnv(name: string, value: string | undefined): void {
   Deno.env.set(name, value);
 }
 
+function describeTestError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 async function exists(path: string): Promise<boolean> {
   try {
     await Deno.stat(path);
@@ -69,6 +79,30 @@ async function exists(path: string): Promise<boolean> {
     if (error instanceof Deno.errors.NotFound) return false;
     throw error;
   }
+}
+
+async function runTestGit(projectDir: string, ...args: string[]): Promise<string> {
+  const result = await new Deno.Command("git", {
+    cwd: projectDir,
+    args,
+    clearEnv: true,
+    env: Object.fromEntries(
+      Object.entries(Deno.env.toObject()).filter(([key]) => !key.startsWith("GIT_")),
+    ),
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  const stderr = new TextDecoder().decode(result.stderr);
+  assertEquals(result.success, true, stderr);
+  return new TextDecoder().decode(result.stdout).trim();
+}
+
+async function initializeCleanTestGit(projectDir: string): Promise<void> {
+  await runTestGit(projectDir, "init", "--quiet");
+  await runTestGit(projectDir, "config", "user.email", "test@example.com");
+  await runTestGit(projectDir, "config", "user.name", "Test User");
+  await runTestGit(projectDir, "add", "--all");
+  await runTestGit(projectDir, "commit", "--quiet", "--allow-empty", "-m", "initial");
 }
 
 describe("resolvePullSource", () => {
@@ -115,6 +149,34 @@ describe("resolvePullSource", () => {
   it("should prioritize env over release and branch", () => {
     const options: PullOptions = { env: "staging", release: "v1.2.0", branch: "feature-x" };
     assertEquals(resolvePullSource(options), { type: "environment", name: "staging" });
+  });
+});
+
+describe("validateRemoteFilePath", () => {
+  it("accepts canonical relative POSIX paths", () => {
+    assertEquals(validateRemoteFilePath("app/components/page.tsx"), "app/components/page.tsx");
+  });
+
+  it("rejects non-canonical and absolute path spellings", () => {
+    for (
+      const path of [
+        "",
+        "./app.ts",
+        "dir/../app.ts",
+        "dir//app.ts",
+        "dir/app.ts/",
+        "../app.ts",
+        "/app.ts",
+        "C:/app.ts",
+        "C:\\app.ts",
+        "\\\\server\\share\\app.ts",
+        ".git/config.ts",
+        "src/.veryfront/cache.ts",
+        "SRC/.GIT/config.ts",
+      ]
+    ) {
+      assertThrows(() => validateRemoteFilePath(path), Error, "Invalid file path");
+    }
   });
 });
 
@@ -296,7 +358,7 @@ describe("getFileContent", () => {
     const content = await getFileContent(mockClient, "my-project", "pages/index.tsx", source);
 
     assertEquals(capturedUrl, expectedUrl);
-    assertEquals(content, "export default function Home() {}\n");
+    assertEquals(content, "export default function Home() {}");
   }
 
   it("should fetch file content from main", async () => {
@@ -327,7 +389,7 @@ describe("getFileContent", () => {
     );
   });
 
-  it("should add trailing newline if missing", async () => {
+  it("should preserve content without a trailing newline", async () => {
     const mockClient = createMockClient({
       get: () => mockFileContentResponse("export default function Home() {}"),
     });
@@ -335,7 +397,7 @@ describe("getFileContent", () => {
     const source: PullSource = { type: "main" };
     const content = await getFileContent(mockClient, "my-project", "pages/index.tsx", source);
 
-    assertEquals(content.endsWith("\n"), true);
+    assertEquals(content, "export default function Home() {}");
   });
 
   it("should not add extra newline if already present", async () => {
@@ -349,9 +411,676 @@ describe("getFileContent", () => {
     assertEquals(content, "export default function Home() {}\n");
     assertEquals(content.endsWith("\n\n"), false);
   });
+
+  it("should preserve empty, CRLF, and multiple trailing newlines exactly", async () => {
+    for (const expected of ["", "line one\r\nline two\r\n", "line\n\n"]) {
+      const mockClient = createMockClient({
+        get: () => mockFileContentResponse(expected),
+      });
+
+      const content = await getFileContent(mockClient, "my-project", "pages/index.tsx", {
+        type: "main",
+      });
+      assertEquals(content, expected);
+    }
+  });
 });
 
 describe("pullCommand", () => {
+  it("prunes managed local files missing from the selected Studio branch", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+    const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
+
+    try {
+      await Deno.mkdir(join(tempDir, "app"), { recursive: true });
+      await Deno.writeTextFile(join(tempDir, "app", "keep.ts"), "old\n");
+      await Deno.writeTextFile(join(tempDir, "app", "remove.ts"), "remove\n");
+      await Deno.writeTextFile(join(tempDir, "app", "asset.bin"), "keep binary\n");
+      await Deno.writeTextFile(join(tempDir, "app", "local-only.ts"), "keep ignored\n");
+      await Deno.writeTextFile(join(tempDir, ".env.local"), "keep secret\n");
+      await Deno.writeTextFile(join(tempDir, ".vfignore"), "app/local-only.ts\n");
+      await initializeCleanTestGit(tempDir);
+
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = ((input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/files?branch=studio-change")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: [{
+                  path: "app/keep.ts",
+                  size: 12,
+                  type: "file",
+                  created_at: "",
+                  updated_at: "",
+                }],
+                page_info: {},
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ path: "app/keep.ts", content: "export default 1;" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }) as typeof fetch;
+
+      await pullCommand({
+        projectDir: tempDir,
+        projectSlug: "alpha",
+        branch: "studio-change",
+        prune: true,
+        force: true,
+        quiet: true,
+      });
+
+      assertEquals(await Deno.readTextFile(join(tempDir, "app", "keep.ts")), "export default 1;");
+      assertEquals(await exists(join(tempDir, "app", "remove.ts")), false);
+      assertEquals(await exists(join(tempDir, "app", "asset.bin")), true);
+      assertEquals(await exists(join(tempDir, "app", "local-only.ts")), true);
+      assertEquals(await exists(join(tempDir, ".env.local")), true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      restoreEnv("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("does not overwrite files protected by .vfignore during a pruning pull", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await Deno.mkdir(join(tempDir, "app"), { recursive: true });
+      await Deno.writeTextFile(join(tempDir, "app", "local-only.ts"), "local\n");
+      await Deno.writeTextFile(join(tempDir, ".vfignore"), "app/local-only.ts\n");
+      await initializeCleanTestGit(tempDir);
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = ((input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/files?branch=studio-change")) {
+          return Promise.resolve(
+            Response.json({
+              data: [
+                { path: "app/local-only.ts", size: 7, type: "file" },
+                { path: "assets/image.png", size: 7, type: "file" },
+              ],
+              page_info: {},
+            }),
+          );
+        }
+        throw new Error(`Pruning pull fetched excluded content: ${url}`);
+      }) as typeof fetch;
+
+      await pullCommand({
+        projectDir: tempDir,
+        projectSlug: "alpha",
+        branch: "studio-change",
+        prune: true,
+        force: true,
+        quiet: true,
+      });
+
+      assertEquals(await Deno.readTextFile(join(tempDir, "app", "local-only.ts")), "local\n");
+      assertEquals(await exists(join(tempDir, "assets", "image.png")), false);
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("rejects supported local symlinks before pruning", async () => {
+    if (Deno.build.os === "windows") return;
+
+    const tempDir = await Deno.makeTempDir();
+    const externalFile = await Deno.makeTempFile({ suffix: ".ts" });
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await Deno.symlink(externalFile, join(tempDir, "linked.ts"));
+      await initializeCleanTestGit(tempDir);
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+      globalThis.fetch = (() =>
+        Promise.resolve(Response.json({ data: [], page_info: {} }))) as typeof fetch;
+
+      const error = await assertRejects(
+        () =>
+          pullCommand({
+            projectDir: tempDir,
+            projectSlug: "alpha",
+            branch: "studio-change",
+            prune: true,
+            force: true,
+            quiet: true,
+          }),
+        Error,
+      );
+
+      assertStringIncludes(describeTestError(error), "does not support symbolic links");
+      assertEquals((await Deno.lstat(join(tempDir, "linked.ts"))).isSymlink, true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+      await Deno.remove(externalFile);
+    }
+  });
+
+  it("rejects duplicate remote paths before writing files", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          Response.json({
+            data: [
+              { path: "app/page.ts", size: 7, type: "file" },
+              { path: "app/page.ts", size: 7, type: "file" },
+            ],
+            page_info: {},
+          }),
+        )) as typeof fetch;
+
+      const error = await assertRejects(
+        () =>
+          pullCommand({
+            projectDir: tempDir,
+            projectSlug: "alpha",
+            force: true,
+            quiet: true,
+          }),
+        Error,
+      );
+
+      assertStringIncludes(describeTestError(error), "Duplicate remote file path");
+      assertEquals(await exists(join(tempDir, "app", "page.ts")), false);
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("prunes managed local files when the selected Studio branch is empty", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await Deno.mkdir(join(tempDir, "app"), { recursive: true });
+      await Deno.writeTextFile(join(tempDir, "app", "keep.ts"), "old\n");
+      await Deno.writeTextFile(join(tempDir, "app", "remove.ts"), "remove\n");
+      await initializeCleanTestGit(tempDir);
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ data: [], page_info: {} }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        )) as typeof fetch;
+
+      await pullCommand({
+        projectDir: tempDir,
+        projectSlug: "alpha",
+        branch: "empty-branch",
+        prune: true,
+        force: true,
+        quiet: true,
+      });
+
+      assertEquals(await exists(join(tempDir, "app", "remove.ts")), false);
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("shows prune operations in dry-run without changing local files", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await Deno.mkdir(join(tempDir, "app"), { recursive: true });
+      await Deno.writeTextFile(join(tempDir, "app", "keep.ts"), "old\n");
+      await Deno.writeTextFile(join(tempDir, "app", "remove.ts"), "remove\n");
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = ((input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/files?branch=studio-change")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: [{
+                  path: "app/keep.ts",
+                  size: 12,
+                  type: "file",
+                  created_at: "",
+                  updated_at: "",
+                }],
+                page_info: {},
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
+        throw new Error(`Dry run fetched file content: ${url}`);
+      }) as typeof fetch;
+
+      await pullCommand({
+        projectDir: tempDir,
+        projectSlug: "alpha",
+        branch: "studio-change",
+        prune: true,
+        dryRun: true,
+        quiet: true,
+      });
+
+      assertEquals(await Deno.readTextFile(join(tempDir, "app", "keep.ts")), "old\n");
+      assertEquals(await Deno.readTextFile(join(tempDir, "app", "remove.ts")), "remove\n");
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("requires Git before a mutating pruning pull", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await Deno.writeTextFile(join(tempDir, "local.ts"), "unchanged\n");
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+      globalThis.fetch = (() => {
+        throw new Error("Non-Git prune should fail before network access");
+      }) as typeof fetch;
+
+      const error = await assertRejects(
+        () =>
+          pullCommand({
+            projectDir: tempDir,
+            projectSlug: "alpha",
+            branch: "studio-change",
+            prune: true,
+            force: true,
+            quiet: true,
+          }),
+        Error,
+      );
+
+      assertStringIncludes(describeTestError(error), "inside a Git worktree");
+      assertEquals(await Deno.readTextFile(join(tempDir, "local.ts")), "unchanged\n");
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("keeps prune candidates and fails when a remote file cannot be written", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await Deno.mkdir(join(tempDir, "app"), { recursive: true });
+      await Deno.writeTextFile(join(tempDir, "app", "keep.ts"), "old\n");
+      await Deno.writeTextFile(join(tempDir, "app", "remove.ts"), "remove\n");
+      await initializeCleanTestGit(tempDir);
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = ((input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/files?branch=studio-change")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: [
+                  {
+                    path: "app/keep.ts",
+                    size: 12,
+                    type: "file",
+                    created_at: "",
+                    updated_at: "",
+                  },
+                  {
+                    path: "app/broken.ts",
+                    size: 12,
+                    type: "file",
+                    created_at: "",
+                    updated_at: "",
+                  },
+                ],
+                page_info: {},
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
+        if (url.includes("app%2Fkeep.ts")) {
+          return Promise.resolve(
+            Response.json({ path: "app/keep.ts", content: "new\n" }),
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: "failed" }), {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }) as typeof fetch;
+
+      const error = await assertRejects(
+        () =>
+          pullCommand({
+            projectDir: tempDir,
+            projectSlug: "alpha",
+            branch: "studio-change",
+            prune: true,
+            force: true,
+            quiet: true,
+          }),
+        Error,
+      );
+
+      assertStringIncludes(describeTestError(error), "Failed to pull");
+      assertEquals(await Deno.readTextFile(join(tempDir, "app", "keep.ts")), "old\n");
+      assertEquals(await exists(join(tempDir, "app", "remove.ts")), true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("refuses a pruning pull into a dirty Git worktree", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await runTestGit(tempDir, "init");
+      await runTestGit(tempDir, "config", "user.email", "test@example.com");
+      await runTestGit(tempDir, "config", "user.name", "Test User");
+      await Deno.writeTextFile(join(tempDir, "app.ts"), "export default 1;\n");
+      await runTestGit(tempDir, "add", "app.ts");
+      await runTestGit(tempDir, "commit", "-m", "initial");
+      await Deno.writeTextFile(join(tempDir, "app.ts"), "export default 2;\n");
+
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+
+      const error = await assertRejects(
+        () =>
+          pullCommand({
+            projectDir: tempDir,
+            projectSlug: "alpha",
+            branch: "studio-change",
+            prune: true,
+            force: true,
+            quiet: true,
+          }),
+        Error,
+      );
+
+      assertStringIncludes(describeTestError(error), "clean Git worktree");
+      assertEquals(await Deno.readTextFile(join(tempDir, "app.ts")), "export default 2;\n");
+    } finally {
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("checks every nested Git repository before a multi-project prune", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const projectDir = join(tempDir, "alpha");
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await Deno.mkdir(projectDir);
+      await runTestGit(projectDir, "init", "--quiet");
+      await runTestGit(projectDir, "config", "user.email", "test@example.com");
+      await runTestGit(projectDir, "config", "user.name", "Test User");
+      await Deno.writeTextFile(join(projectDir, "app.ts"), "export default 1;\n");
+      await runTestGit(projectDir, "add", "app.ts");
+      await runTestGit(projectDir, "commit", "--quiet", "-m", "initial");
+      await Deno.writeTextFile(join(projectDir, "app.ts"), "export default 2;\n");
+
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+      globalThis.fetch = (() => {
+        throw new Error("Dirty worktree should be rejected before network access");
+      }) as typeof fetch;
+
+      const error = await assertRejects(
+        () =>
+          pullCommand({
+            projectDir: tempDir,
+            projects: ["alpha"],
+            branch: "studio-change",
+            prune: true,
+            force: true,
+            quiet: true,
+          }),
+        Error,
+      );
+
+      assertStringIncludes(describeTestError(error), "clean Git worktree");
+      assertEquals(await Deno.readTextFile(join(projectDir, "app.ts")), "export default 2;\n");
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("preflights a shared monorepo once and ignores nested push receipts", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      for (const project of ["alpha", "beta"]) {
+        await Deno.mkdir(join(tempDir, project, ".veryfront"), { recursive: true });
+        await Deno.writeTextFile(join(tempDir, project, "app.ts"), `${project} old\n`);
+      }
+      await runTestGit(tempDir, "init", "--quiet");
+      await runTestGit(tempDir, "config", "user.email", "test@example.com");
+      await runTestGit(tempDir, "config", "user.name", "Test User");
+      await runTestGit(tempDir, "add", "alpha/app.ts", "beta/app.ts");
+      await runTestGit(tempDir, "commit", "--quiet", "-m", "initial");
+      for (const project of ["alpha", "beta"]) {
+        await Deno.writeTextFile(
+          join(tempDir, project, ".veryfront", "push-receipt.json"),
+          "{}\n",
+        );
+      }
+
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+      globalThis.fetch = ((input: string | URL | Request) => {
+        const url = String(input);
+        const project = url.includes("/projects/alpha/") ? "alpha" : "beta";
+        if (!url.includes("app.ts")) {
+          return Promise.resolve(
+            Response.json({
+              data: [{ path: "app.ts", size: 10, type: "file" }],
+              page_info: {},
+            }),
+          );
+        }
+        return Promise.resolve(Response.json({ path: "app.ts", content: `${project} new\n` }));
+      }) as typeof fetch;
+
+      await pullCommand({
+        projectDir: tempDir,
+        projects: ["alpha", "beta"],
+        branch: "studio-change",
+        prune: true,
+        force: true,
+        quiet: true,
+      });
+
+      assertEquals(await Deno.readTextFile(join(tempDir, "alpha", "app.ts")), "alpha new\n");
+      assertEquals(await Deno.readTextFile(join(tempDir, "beta", "app.ts")), "beta new\n");
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("rejects an invalid remote path before changing local files", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await Deno.writeTextFile(join(tempDir, "keep.ts"), "unchanged\n");
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: [{
+                path: "../outside.ts",
+                size: 12,
+                type: "file",
+                created_at: "",
+                updated_at: "",
+              }],
+              page_info: {},
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        )) as typeof fetch;
+
+      const error = await assertRejects(
+        () =>
+          pullCommand({
+            projectDir: tempDir,
+            projectSlug: "alpha",
+            force: true,
+            quiet: true,
+          }),
+        Error,
+      );
+
+      assertStringIncludes(describeTestError(error), "invalid file path");
+      assertEquals(await Deno.readTextFile(join(tempDir, "keep.ts")), "unchanged\n");
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("rejects a remote write through a symlinked directory", async () => {
+    if (Deno.build.os === "windows") return;
+
+    const tempDir = await Deno.makeTempDir();
+    const externalDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      await Deno.symlink(externalDir, join(tempDir, "app"));
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = ((input: string | URL | Request) => {
+        const url = String(input);
+        if (!url.includes("app%2Fpage.tsx")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: [{
+                  path: "app/page.tsx",
+                  size: 12,
+                  type: "file",
+                  created_at: "",
+                  updated_at: "",
+                }],
+                page_info: {},
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ path: "app/page.tsx", content: "outside" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }) as typeof fetch;
+
+      const error = await assertRejects(
+        () =>
+          pullCommand({
+            projectDir: tempDir,
+            projectSlug: "alpha",
+            force: true,
+            quiet: true,
+          }),
+        Error,
+      );
+
+      assertStringIncludes(describeTestError(error), "symbolic link");
+      assertEquals(await exists(join(externalDir, "page.tsx")), false);
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+      await Deno.remove(externalDir, { recursive: true });
+    }
+  });
+
   it("fails with an actionable message instead of silently cancelling when confirmation cannot be shown", async () => {
     const tempDir = await Deno.makeTempDir();
     const originalFetch = globalThis.fetch;
@@ -401,7 +1130,7 @@ describe("pullCommand", () => {
       const message = error instanceof Error ? error.message : String(error);
       assertEquals((error as { slug?: string }).slug, "invalid-argument");
       assertStringIncludes(message, "requires confirmation");
-      assertStringIncludes(message, "--force");
+      assertStringIncludes(message, "--yes");
       assertEquals(await exists(join(tempDir, "app", "page.tsx")), false);
     } finally {
       globalThis.fetch = originalFetch;
@@ -504,7 +1233,7 @@ describe("pullCommand", () => {
       const message = error instanceof Error ? error.message : String(error);
       assertEquals((error as { slug?: string }).slug, "invalid-argument");
       assertStringIncludes(message, "requires confirmation");
-      assertStringIncludes(message, "--force");
+      assertStringIncludes(message, "--yes");
       assertEquals(await exists(join(tempDir, "alpha")), false);
     } finally {
       globalThis.fetch = originalFetch;

--- a/cli/commands/pull/command.ts
+++ b/cli/commands/pull/command.ts
@@ -9,11 +9,11 @@
 
 import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
-import { dirname, join, normalize, resolve } from "veryfront/platform/path";
+import { dirname, isAbsolute, join, relative, resolve } from "veryfront/platform/path";
+import { isNotFoundError, lstat } from "veryfront/fs";
 import { cliLogger } from "#cli/utils";
 import { resolveCliApiUrl } from "#cli/shared/constants";
-import { cwd } from "veryfront/platform";
-import { createFileSystem } from "veryfront/platform";
+import { createFileSystem, cwd, env, runCommand } from "veryfront/platform";
 import {
   createApiClient,
   readConfigFile,
@@ -34,6 +34,7 @@ import {
 } from "veryfront/errors";
 import { withSpan } from "veryfront/observability/otlp-setup";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
+import { createIgnoreChecker, loadIgnorePatterns } from "../../sync/ignore.ts";
 
 /**
  * Schema factory for pull command arguments
@@ -48,6 +49,7 @@ export const getPullArgsSchema = defineSchema((v) =>
     release: v.string().optional(),
     force: v.boolean().default(false),
     dryRun: v.boolean().default(false),
+    prune: v.boolean().default(false),
     quiet: v.boolean().default(false),
   })
 );
@@ -68,6 +70,7 @@ export const parsePullArgs = createArgParser(PullArgsSchema, {
   release: CommonArgs.release,
   force: CommonArgs.force,
   dryRun: CommonArgs.dryRun,
+  prune: { keys: ["prune"], type: "boolean" },
   quiet: CommonArgs.quiet,
 });
 
@@ -96,10 +99,12 @@ export interface PullOptions {
   env?: string;
   /** Release version to pull from (e.g., "v1.2.0") */
   release?: string;
-  /** Force overwrite without confirmation */
+  /** Skip confirmation without changing overwrite semantics */
   force?: boolean;
   /** Dry run - show what would be written without writing */
   dryRun?: boolean;
+  /** Delete managed local files that are absent from the selected source */
+  prune?: boolean;
   /** Quiet mode - suppress spinner/progress output */
   quiet?: boolean;
 }
@@ -136,9 +141,14 @@ interface WriteOp {
   relativePath: string;
 }
 
+interface DeleteOp {
+  path: string;
+  relativePath: string;
+}
+
 interface PullProjectResult {
   written: number;
-  skipped: number;
+  deleted: number;
   cancelled: boolean;
 }
 
@@ -150,32 +160,71 @@ interface FailedProject {
   error?: unknown;
 }
 
-/**
- * Validate and sanitize file path to prevent path traversal attacks.
- * Ensures the resolved path is within the project directory.
- *
- * @param filePath - The file path from API to validate
- * @param projectDir - The project directory base path
- * @returns Sanitized absolute path
- * @throws Error if path attempts to escape project directory
- */
-function validateFilePath(filePath: string, projectDir: string): string {
-  const normalizedPath = normalize(filePath);
-
-  if (normalizedPath.startsWith("/") || normalizedPath.startsWith("..")) {
-    throw new Error(
-      `Invalid file path: "${filePath}" - paths must be relative and cannot escape project directory`,
-    );
+/** Validate a remote file path as a canonical relative POSIX path. */
+export function validateRemoteFilePath(filePath: string): string {
+  if (
+    filePath.length === 0 ||
+    filePath.includes("\\") ||
+    filePath.includes("\0") ||
+    isAbsolute(filePath)
+  ) {
+    throw new Error(`Invalid file path: "${filePath}" - expected a relative POSIX path`);
   }
 
-  const fullPath = resolve(projectDir, normalizedPath);
-  const resolvedProjectDir = resolve(projectDir);
+  const segments = filePath.split("/");
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    throw new Error(`Invalid file path: "${filePath}" - path must be canonical`);
+  }
+  if (segments.some((segment) => [".git", ".veryfront"].includes(segment.toLowerCase()))) {
+    throw new Error(`Invalid file path: "${filePath}" - reserved local metadata path`);
+  }
 
-  if (!fullPath.startsWith(resolvedProjectDir + "/") && fullPath !== resolvedProjectDir) {
+  return filePath;
+}
+
+/** Resolve a validated remote path and reject local symlink traversal. */
+async function validateFilePath(filePath: string, projectDir: string): Promise<WriteOp> {
+  const canonicalPath = validateRemoteFilePath(filePath);
+  const resolvedProjectDir = resolve(projectDir);
+  const fullPath = resolve(resolvedProjectDir, canonicalPath);
+  const destinationRelativePath = relative(resolvedProjectDir, fullPath).replace(/\\/g, "/");
+
+  if (
+    destinationRelativePath === ".." ||
+    destinationRelativePath.startsWith("../") ||
+    isAbsolute(destinationRelativePath)
+  ) {
     throw new Error(`Invalid file path: "${filePath}" - resolved path escapes project directory`);
   }
 
-  return fullPath;
+  const segments = canonicalPath.split("/");
+  let currentPath = resolvedProjectDir;
+  for (const [index, segment] of segments.entries()) {
+    currentPath = join(currentPath, segment);
+    let info;
+    try {
+      info = await lstat(currentPath);
+    } catch (error) {
+      if (isNotFoundError(error)) break;
+      throw error;
+    }
+    if (info.isSymlink) {
+      throw new Error(
+        `Invalid file path: "${filePath}" - symbolic links are not allowed in pull destinations`,
+      );
+    }
+    const isFinal = index === segments.length - 1;
+    if (!isFinal && !info.isDirectory) {
+      throw new Error(
+        `Invalid file path: "${filePath}" - a parent path is not a directory`,
+      );
+    }
+    if (isFinal && info.isDirectory) {
+      throw new Error(`Invalid file path: "${filePath}" - destination is a directory`);
+    }
+  }
+
+  return { path: fullPath, relativePath: canonicalPath };
 }
 
 /**
@@ -261,26 +310,39 @@ export async function getFileContent(
   const url = buildFileContentUrl(projectSlug, path, source);
   const response = await client.get<{ path: string; content: string; size: number }>(url);
 
-  // Ensure text files end with a trailing newline (POSIX standard)
-  const content = response.content;
-  if (content && !content.endsWith("\n")) return content + "\n";
-  return content;
+  return response.content;
 }
 
 /** Concurrency limit for parallel file fetches */
 const CONCURRENCY = 20;
 
-async function processFile(
+interface PreparedWriteOp extends WriteOp {
+  content: string;
+}
+
+async function fetchFile(
   op: WriteOp,
   client: ReturnType<typeof createApiClient>,
   projectSlug: string,
   source: PullSource,
+): Promise<
+  { success: true; op: PreparedWriteOp } | { success: false; error: Error; path: string }
+> {
+  try {
+    const content = await getFileContent(client, projectSlug, op.relativePath, source);
+    return { success: true, op: { ...op, content } };
+  } catch (error) {
+    return { success: false, path: op.relativePath, error: error as Error };
+  }
+}
+
+async function writePreparedFile(
+  op: PreparedWriteOp,
   fs: ReturnType<typeof createFileSystem>,
 ): Promise<{ success: boolean; path: string; error?: Error }> {
   try {
-    const content = await getFileContent(client, projectSlug, op.relativePath, source);
     await fs.mkdir(dirname(op.path), { recursive: true });
-    await fs.writeTextFile(op.path, content);
+    await fs.writeTextFile(op.path, op.content);
     return { success: true, path: op.relativePath };
   } catch (error) {
     return { success: false, path: op.relativePath, error: error as Error };
@@ -293,20 +355,40 @@ async function writeFiles(
   projectSlug: string,
   source: PullSource,
   dryRun: boolean,
-): Promise<{ written: number; skipped: number }> {
+): Promise<{ written: number; failed: number }> {
   if (dryRun) {
     for (const op of ops) cliLogger.info(`  Would write: ${op.relativePath}`);
-    return { written: ops.length, skipped: 0 };
+    return { written: ops.length, failed: 0 };
   }
 
   const fs = createFileSystem();
-  let written = 0;
-  let skipped = 0;
+  const prepared: PreparedWriteOp[] = [];
+  let failed = 0;
 
   for (let i = 0; i < ops.length; i += CONCURRENCY) {
     const batch = ops.slice(i, i + CONCURRENCY);
     const results = await Promise.all(
-      batch.map((op) => processFile(op, client, projectSlug, source, fs)),
+      batch.map((op) => fetchFile(op, client, projectSlug, source)),
+    );
+
+    for (const result of results) {
+      if (result.success) {
+        prepared.push(result.op);
+        continue;
+      }
+      cliLogger.error(`Failed to fetch ${result.path}:`, result.error);
+      failed++;
+    }
+  }
+
+  if (failed > 0) return { written: 0, failed };
+
+  let written = 0;
+
+  for (let i = 0; i < prepared.length; i += CONCURRENCY) {
+    const batch = prepared.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(
+      batch.map((op) => writePreparedFile(op, fs)),
     );
 
     for (const result of results) {
@@ -315,11 +397,164 @@ async function writeFiles(
         continue;
       }
       cliLogger.error(`Failed to write ${result.path}:`, result.error);
-      skipped++;
+      failed++;
     }
   }
 
-  return { written, skipped };
+  return { written, failed };
+}
+
+async function listManagedLocalFiles(
+  projectDir: string,
+  ignoreChecker: ReturnType<typeof createIgnoreChecker>,
+): Promise<DeleteOp[]> {
+  const fs = createFileSystem();
+  if (!(await fs.exists(projectDir))) return [];
+
+  const files: DeleteOp[] = [];
+
+  async function walk(currentDir: string): Promise<void> {
+    const entries = await fs.readDir(currentDir);
+
+    for await (const entry of entries) {
+      const path = join(currentDir, entry.name);
+      const relativePath = relative(projectDir, path).replace(/\\/g, "/");
+
+      if (ignoreChecker.isIgnored(relativePath)) continue;
+      if (entry.isSymlink) {
+        if (ignoreChecker.isSupportedExtension(entry.name)) {
+          throw new Error(
+            `Veryfront pull with --prune does not support symbolic links: "${relativePath}". Remove the link and run veryfront pull again.`,
+          );
+        }
+        continue;
+      }
+      if (entry.isDirectory) {
+        await walk(path);
+        continue;
+      }
+      if (!ignoreChecker.isSupportedExtension(entry.name)) continue;
+      files.push({ path, relativePath });
+    }
+  }
+
+  await walk(projectDir);
+  return files;
+}
+
+async function deleteLocalFiles(
+  ops: DeleteOp[],
+  dryRun: boolean,
+): Promise<{ deleted: number; failed: number }> {
+  if (dryRun) {
+    for (const op of ops) cliLogger.info(`  Would delete: ${op.relativePath}`);
+    return { deleted: ops.length, failed: 0 };
+  }
+
+  const fs = createFileSystem();
+  let deleted = 0;
+  let failed = 0;
+  for (const op of ops) {
+    try {
+      await fs.remove(op.path);
+      deleted++;
+    } catch (error) {
+      cliLogger.error(`Failed to delete ${op.relativePath}:`, error);
+      failed++;
+    }
+  }
+  return { deleted, failed };
+}
+
+function cleanGitEnvironment(): Record<string, string> {
+  const gitEnv = env();
+  for (const key of Object.keys(gitEnv)) {
+    if (key.startsWith("GIT_")) delete gitEnv[key];
+  }
+  return gitEnv;
+}
+
+async function nearestExistingDirectory(path: string): Promise<string | null> {
+  let current = resolve(path);
+  while (true) {
+    try {
+      const info = await lstat(current);
+      if (info.isDirectory) return current;
+    } catch (error) {
+      if (!isNotFoundError(error)) throw error;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+async function findGitRoot(projectDir: string): Promise<string | null> {
+  const cwd = await nearestExistingDirectory(projectDir);
+  if (!cwd) return null;
+
+  try {
+    const repository = await runCommand("git", {
+      args: ["rev-parse", "--show-toplevel"],
+      cwd,
+      clearEnv: true,
+      env: cleanGitEnvironment(),
+      capture: true,
+      timeoutMs: 5_000,
+    });
+    const root = repository.stdout?.trim();
+    return repository.success && root ? resolve(root) : null;
+  } catch {
+    return null;
+  }
+}
+
+function isUntrackedPushReceipt(statusLine: string): boolean {
+  if (!statusLine.startsWith("?? ")) return false;
+  const path = statusLine.slice(3).replace(/\\/g, "/");
+  return path === ".veryfront/push-receipt.json" ||
+    path.endsWith("/.veryfront/push-receipt.json");
+}
+
+async function assertCleanGitWorktrees(projectDirs: readonly string[]): Promise<void> {
+  const gitRoots = new Set<string>();
+  for (const projectDir of projectDirs) {
+    const gitRoot = await findGitRoot(projectDir);
+    if (!gitRoot) {
+      throw INVALID_ARGUMENT.create({
+        detail:
+          `Pull with --prune requires ${projectDir} to be inside a Git worktree. Clone or initialize the repository, or use --dry-run to preview without deleting files.`,
+      });
+    }
+    gitRoots.add(gitRoot);
+  }
+
+  for (const gitRoot of gitRoots) {
+    const status = await runCommand("git", {
+      args: ["status", "--porcelain=v1", "--untracked-files=all"],
+      cwd: gitRoot,
+      clearEnv: true,
+      env: cleanGitEnvironment(),
+      capture: true,
+      timeoutMs: 5_000,
+    });
+    if (!status.success) {
+      throw INVALID_ARGUMENT.create({
+        detail: "Veryfront could not verify that the Git worktree is clean before pruning files.",
+      });
+    }
+
+    const dirty = (status.stdout ?? "").split("\n").some((line) =>
+      line !== "" && !isUntrackedPushReceipt(line)
+    );
+    if (dirty) {
+      throw INVALID_ARGUMENT.create({
+        detail:
+          `Pull with --prune requires a clean Git worktree at ${gitRoot}. Commit or stash local changes, then run the command again.`,
+      });
+    }
+  }
 }
 
 function formatPullSource(source: PullSource): string {
@@ -368,19 +603,24 @@ function pullProjectListError(projectSlug: string, sourceLabel: string, error: u
   return wrapped;
 }
 
-async function confirmPullWrite(projectDir: string): Promise<boolean> {
+async function confirmPullWrite(
+  projectDir: string,
+  writeCount: number,
+  deleteCount: number,
+): Promise<boolean> {
   if (isInteractive() && !isTTY()) {
     throw INVALID_ARGUMENT.create({
       detail:
         `Pull requires confirmation before writing files, but no interactive prompt is available. ` +
-        `Re-run with --force to write into ${projectDir} without prompting.`,
+        `Re-run with --yes to write into ${projectDir} without prompting.`,
     });
   }
 
-  return await confirmPrompt(
-    `This will overwrite local files in ${projectDir}. Continue?`,
-    false,
-  );
+  const actions: string[] = [];
+  if (writeCount > 0) actions.push(`overwrite ${writeCount} local files`);
+  if (deleteCount > 0) actions.push(`delete ${deleteCount} managed local files`);
+  const action = actions.join(" and ");
+  return await confirmPrompt(`This will ${action} in ${projectDir}. Continue?`, false);
 }
 
 async function pullSingleProject(
@@ -389,6 +629,7 @@ async function pullSingleProject(
   source: PullSource,
   force: boolean,
   dryRun: boolean,
+  prune: boolean,
   config: ResolvedConfig,
   quiet = false,
 ): Promise<PullProjectResult> {
@@ -408,50 +649,105 @@ async function pullSingleProject(
     spinner.stop();
   }
 
-  if (files.length === 0) {
-    if (!quiet) logInfo(`No files to pull from ${projectSlug}.`);
-    return { written: 0, skipped: 0, cancelled: false };
-  }
-
+  const pruneIgnoreChecker = prune
+    ? createIgnoreChecker(await loadIgnorePatterns(projectDir))
+    : null;
   const writeOps: WriteOp[] = [];
+  const remotePaths = new Set<string>();
   for (const file of files) {
     try {
-      writeOps.push({ path: validateFilePath(file.path, projectDir), relativePath: file.path });
+      const op = await validateFilePath(file.path, projectDir);
+      if (remotePaths.has(op.relativePath)) {
+        throw new Error(`Duplicate remote file path: "${op.relativePath}"`);
+      }
+      remotePaths.add(op.relativePath);
+
+      if (
+        pruneIgnoreChecker &&
+        (pruneIgnoreChecker.isIgnored(op.relativePath) ||
+          !pruneIgnoreChecker.isSupportedExtension(op.relativePath))
+      ) {
+        continue;
+      }
+      writeOps.push(op);
     } catch (error) {
-      if (!quiet) cliLogger.warn(`Skipping invalid file path: ${file.path}`, error);
+      throw INVALID_ARGUMENT.create({
+        detail: `Veryfront returned an invalid file path "${file.path}": ${
+          describeError(error)
+        }. No local files were changed.`,
+        cause: error,
+      });
     }
   }
 
+  let deleteOps: DeleteOp[] = [];
+  if (pruneIgnoreChecker) {
+    const managedRemotePaths = new Set(writeOps.map((op) => op.relativePath));
+    const localFiles = await listManagedLocalFiles(projectDir, pruneIgnoreChecker);
+    deleteOps = localFiles.filter((file) => !managedRemotePaths.has(file.relativePath));
+  }
+
+  if (writeOps.length === 0 && deleteOps.length === 0) {
+    if (!quiet) logInfo(`No files to pull from ${projectSlug}.`);
+    return { written: 0, deleted: 0, cancelled: false };
+  }
+
   if (!quiet) {
+    const deleteSummary = deleteOps.length > 0 ? ` and ${deleteOps.length} to delete` : "";
     cliLogger.info(
-      `\nFound ${files.length} files to ${dryRun ? "pull" : "write"} from ${projectSlug}.`,
+      `\nFound ${writeOps.length} files to ${
+        dryRun ? "pull" : "write"
+      }${deleteSummary} from ${projectSlug}.`,
     );
   }
 
   if (!force && !dryRun) {
-    const confirmed = await confirmPullWrite(projectDir);
+    const confirmed = await confirmPullWrite(projectDir, writeOps.length, deleteOps.length);
     if (!confirmed) {
       cliLogger.info("Pull cancelled.");
-      return { written: 0, skipped: 0, cancelled: true };
+      return { written: 0, deleted: 0, cancelled: true };
     }
   }
 
   spinner = quiet ? createNoopSpinner() : createSpinner(`Writing files to ${projectDir}...`);
 
-  const result = await writeFiles(writeOps, client, projectSlug, source, dryRun);
+  const writeResult = await writeFiles(writeOps, client, projectSlug, source, dryRun);
+
+  if (writeResult.failed > 0) {
+    spinner.stop();
+    throw new Error(
+      `Failed to pull ${writeResult.failed} file${
+        writeResult.failed === 1 ? "" : "s"
+      }. No local files were pruned. Review git status and restore a clean worktree before retrying if any files were written.`,
+    );
+  }
+
+  const deleteResult = await deleteLocalFiles(deleteOps, dryRun);
 
   spinner.stop();
 
+  if (deleteResult.failed > 0) {
+    throw new Error(
+      `Failed to prune ${deleteResult.failed} local file${
+        deleteResult.failed === 1 ? "" : "s"
+      }. Some files may have changed. Review git status and restore a clean worktree before retrying.`,
+    );
+  }
+
   if (!quiet) {
     if (dryRun) {
-      logInfo(`Dry run complete for ${projectSlug}. Would write ${result.written} files.`);
+      logInfo(
+        `Dry run complete for ${projectSlug}. Would write ${writeResult.written} and delete ${deleteResult.deleted} files.`,
+      );
     } else {
-      logSuccess(`Pulled ${result.written} files from ${projectSlug} (${sourceLabel}).`);
-      if (result.skipped > 0) logWarning(`Skipped ${result.skipped} files due to errors.`);
+      const deletion = deleteResult.deleted > 0 ? ` and deleted ${deleteResult.deleted}` : "";
+      logSuccess(
+        `Pulled ${writeResult.written} files${deletion} from ${projectSlug} (${sourceLabel}).`,
+      );
     }
   }
 
-  return { ...result, cancelled: false };
+  return { written: writeResult.written, deleted: deleteResult.deleted, cancelled: false };
 }
 
 function formatProjectCount(count: number): string {
@@ -496,6 +792,7 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
         projectDir = cwd(),
         force = false,
         dryRun = false,
+        prune = false,
         quiet = false,
       } = options;
 
@@ -529,6 +826,19 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
         };
       }
 
+      if (prune && !dryRun) {
+        spinner.update("Checking Git worktree...");
+        const targetDirs = projects?.length
+          ? projects.map((project) => join(projectDir, project))
+          : [projectDir];
+        try {
+          await assertCleanGitWorktrees(targetDirs);
+        } catch (error) {
+          spinner.stop();
+          throw error;
+        }
+      }
+
       spinner.stop();
 
       if (!projects?.length) {
@@ -538,6 +848,7 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
           source,
           force,
           dryRun,
+          prune,
           config,
           quiet,
         );
@@ -545,7 +856,7 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
       }
 
       let totalWritten = 0;
-      let totalSkippedFiles = 0;
+      let totalDeleted = 0;
       const failedProjects: FailedProject[] = [];
       const cancelledProjects: string[] = [];
 
@@ -561,11 +872,12 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
             source,
             force,
             dryRun,
+            prune,
             config,
             quiet,
           );
           totalWritten += result.written;
-          totalSkippedFiles += result.skipped;
+          totalDeleted += result.deleted;
           if (result.cancelled) cancelledProjects.push(project);
         } catch (error) {
           cliLogger.error(`Failed to pull ${project}: ${describeError(error)}`);
@@ -583,10 +895,15 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
         cliLogger.info("");
         if (dryRun) {
           logInfo(
-            `Dry run complete. Would write ${totalWritten} files total across ${projects.length} projects.`,
+            `Dry run complete. Would write ${totalWritten} and delete ${totalDeleted} files total across ${projects.length} projects.`,
           );
         } else if (totalWritten > 0) {
-          logSuccess(`Pulled ${totalWritten} files total across ${projects.length} projects.`);
+          const deletion = totalDeleted > 0 ? ` and deleted ${totalDeleted}` : "";
+          logSuccess(
+            `Pulled ${totalWritten} files${deletion} total across ${projects.length} projects.`,
+          );
+        } else if (totalDeleted > 0) {
+          logSuccess(`Deleted ${totalDeleted} files across ${projects.length} projects.`);
         } else {
           logInfo(`No files were pulled across ${projects.length} projects.`);
         }
@@ -605,9 +922,6 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
             }.`,
           );
         }
-        if (totalSkippedFiles > 0) {
-          logWarning(`Skipped ${totalSkippedFiles} files due to write errors.`);
-        }
       }
 
       if (failedProjects.length > 0) {
@@ -624,6 +938,10 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
         throw new Error(detail);
       }
     },
-    { "cli.dryRun": options.dryRun ?? false, "cli.source_type": source.type },
+    {
+      "cli.dryRun": options.dryRun ?? false,
+      "cli.prune": options.prune ?? false,
+      "cli.source_type": source.type,
+    },
   );
 }

--- a/cli/commands/pull/handler.test.ts
+++ b/cli/commands/pull/handler.test.ts
@@ -39,6 +39,7 @@ describe("Pull Handler", () => {
       assertEquals(result.data.release, undefined);
       assertEquals(result.data.force, false);
       assertEquals(result.data.dryRun, false);
+      assertEquals(result.data.prune, false);
       assertEquals(result.data.quiet, false);
     });
 
@@ -96,6 +97,12 @@ describe("Pull Handler", () => {
       assertEquals(result.data.dryRun, true);
     });
 
+    it("should parse --prune flag", () => {
+      const result = parsePullArgs(createArgs({ prune: true }));
+      assertSuccess(result);
+      assertEquals(result.data.prune, true);
+    });
+
     it("should parse --quiet flag", () => {
       const result = parsePullArgs(createArgs({ quiet: true }));
       assertSuccess(result);
@@ -144,6 +151,7 @@ describe("Pull Handler", () => {
         env: "preview",
         force: true,
         "dry-run": true,
+        prune: true,
         quiet: true,
       }));
       assertSuccess(result);
@@ -151,6 +159,7 @@ describe("Pull Handler", () => {
       assertEquals(result.data.env, "preview");
       assertEquals(result.data.force, true);
       assertEquals(result.data.dryRun, true);
+      assertEquals(result.data.prune, true);
       assertEquals(result.data.quiet, true);
     });
 

--- a/cli/commands/push/command-help.ts
+++ b/cli/commands/push/command-help.ts
@@ -3,7 +3,7 @@ import type { CommandHelp } from "../../help/types.ts";
 export const pushHelp: CommandHelp = {
   name: "push",
   category: "deploy",
-  description: "Create a branch and upload local files to Veryfront",
+  description: "Upload local source files to a Veryfront branch",
   usage: "veryfront push [options]",
   options: [
     {
@@ -20,11 +20,15 @@ export const pushHelp: CommandHelp = {
     },
     {
       flag: "-f, --force",
-      description: "Push without confirmation",
+      description: "Skip confirmation for compatibility (prefer global --yes)",
     },
     {
       flag: "--dry-run",
       description: "Show what would be uploaded without uploading",
+    },
+    {
+      flag: "-q, --quiet",
+      description: "Suppress progress and summary output",
     },
   ],
   examples: [
@@ -33,12 +37,14 @@ export const pushHelp: CommandHelp = {
     "veryfront push --dir ./my-project",
     "veryfront push --branch feature-header",
     "veryfront push --branch main             # Push directly to main",
+    "veryfront push --branch main --yes       # Non-interactive CI push",
     "veryfront push --dry-run",
   ],
   notes: [
     "Requires VERYFRONT_API_TOKEN env var or veryfront.json config",
-    "Creates a new branch for each push - merge in Studio",
-    "Use --branch=main to push directly without creating a branch",
-    "Uploads all files using their relative paths",
+    "Without --branch, creates a timestamped branch that you can review in Studio",
+    "Use --branch main to update the existing Veryfront main branch",
+    "Uploads supported text source files using their relative paths",
+    ".vfignore controls which supported files are excluded",
   ],
 };

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -24,8 +24,12 @@ import {
   type UploadOp,
 } from "./command.ts";
 import { type ApiClient, resolveConfig } from "#cli/shared/config";
-import { createDefaultIgnoreChecker } from "../../sync/ignore.ts";
-import { readPushReceipt } from "../../shared/deployment-provenance.ts";
+import {
+  createDefaultIgnoreChecker,
+  createIgnoreChecker,
+  loadIgnorePatterns,
+} from "../../sync/ignore.ts";
+import { readPushReceipt, writePushReceipt } from "../../shared/deployment-provenance.ts";
 
 type MockClientOverrides = Partial<{
   get: (path: string, params?: Record<string, string>) => Promise<unknown>;
@@ -477,6 +481,34 @@ describe("push receipt source snapshot", () => {
     });
   });
 
+  it("keeps a tracked .vfignore in the clean Git provenance", async () => {
+    await withGitProject(async ({ projectDir, runGit }) => {
+      await Deno.writeTextFile(`${projectDir}/.vfignore`, "generated.ts\n");
+      await runGit("add", ".vfignore");
+      await runGit("commit", "--quiet", "-m", "add Veryfront ignore rules");
+      const checker = createIgnoreChecker(await loadIgnorePatterns(projectDir));
+
+      const snapshot = await capturePushSourceSnapshot(projectDir, checker);
+
+      assertEquals(snapshot.gitSource.clean, true);
+    });
+  });
+
+  it("marks a Git-ignored .vfignore as unclean", async () => {
+    await withGitProject(async ({ projectDir, runGit }) => {
+      await Deno.writeTextFile(`${projectDir}/.gitignore`, ".vfignore\n");
+      await runGit("add", ".gitignore");
+      await runGit("commit", "--quiet", "-m", "ignore Veryfront rules");
+      await Deno.writeTextFile(`${projectDir}/.vfignore`, "generated.ts\n");
+      assertEquals(await runGit("status", "--porcelain=v1", "--untracked-files=all"), "");
+      const checker = createIgnoreChecker(await loadIgnorePatterns(projectDir));
+
+      const snapshot = await capturePushSourceSnapshot(projectDir, checker);
+
+      assertEquals(snapshot.gitSource.clean, false);
+    });
+  });
+
   it("recognizes tracked source paths containing newlines", async () => {
     if (Deno.build.os === "windows") return;
 
@@ -826,5 +858,85 @@ describe("uploadFiles", () => {
 
     assertEquals(result.uploaded, 0);
     assertEquals(result.failed, 0);
+  });
+});
+
+describe("push failure ordering", () => {
+  it("does not delete remote files after an upload fails", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    try {
+      await withGitProject(async ({ projectDir, runGit }) => {
+        await Deno.writeTextFile(`${projectDir}/second.ts`, "export const second = true;\n");
+        await runGit("add", "second.ts");
+        await runGit("commit", "--quiet", "-m", "add second source file");
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+        _resetEnvironmentConfig();
+        await writePushReceipt(projectDir, {
+          controlPlane: "https://control.example.test",
+          projectId: "project-old",
+          projectSlug: "my-project",
+          branch: "main",
+          commitSha: await runGit("rev-parse", "HEAD"),
+          sourceDigest: `sha256:${"0".repeat(64)}`,
+          clean: true,
+          pushedAt: new Date().toISOString(),
+        });
+        assertExists(await readPushReceipt(projectDir));
+
+        const requests: string[] = [];
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+          requests.push(`${request.method} ${url.pathname}`);
+
+          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+            return Response.json({
+              data: [{
+                path: "stale.ts",
+                size: 8,
+                type: "file",
+                created_at: "",
+                updated_at: "",
+              }],
+              page_info: {},
+            });
+          }
+          if (request.method === "PUT" && url.pathname.endsWith("/files/app.ts")) {
+            return Response.json({ error: "upload failed" }, { status: 500 });
+          }
+          if (request.method === "PUT" && url.pathname.endsWith("/files/second.ts")) {
+            return Response.json({});
+          }
+          if (request.method === "DELETE") {
+            return Response.json({});
+          }
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        }) as typeof fetch;
+
+        await assertRejects(
+          () =>
+            pushCommand({
+              projectDir,
+              branch: "main",
+              force: true,
+              quiet: true,
+            }),
+          Error,
+          "Remote files were not deleted",
+        );
+
+        assertEquals(requests.some((request) => request.startsWith("DELETE ")), false);
+        assertEquals(await readPushReceipt(projectDir), null);
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
   });
 });

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1,8 +1,8 @@
 /**
- * Push command - Upload local project files to a new Veryfront branch
+ * Push command - Upload local project files to a Veryfront branch
  *
  * Scans local files and uploads them to the API using relative paths.
- * Creates a new branch for the changes which can be merged in Studio.
+ * Creates a branch when the requested branch does not already exist.
  *
  * @module cli/commands/push
  */
@@ -28,6 +28,7 @@ import { withSpan } from "veryfront/observability/otlp-setup";
 import { createIgnoreChecker, type IgnoreChecker, loadIgnorePatterns } from "../../sync/ignore.ts";
 import { listAllFiles, type PullSource } from "../pull/index.ts";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
+import { isNotFoundError, lstat } from "veryfront/fs";
 import {
   areSourceFilesTracked,
   clearPushReceipt,
@@ -79,7 +80,7 @@ export interface PushOptions {
   projectDir?: string;
   /** Branch name to create (auto-generated if not provided) */
   branch?: string;
-  /** Force push without confirmation */
+  /** Skip confirmation without changing push semantics */
   force?: boolean;
   /** Dry run - show what would be uploaded without uploading */
   dryRun?: boolean;
@@ -214,15 +215,38 @@ function projectSlugConflictError(
   return new Error(`${error.message} ${action}, then run veryfront push again.`);
 }
 
+async function sourceFilesForGitTracking(
+  projectDir: string,
+  files: readonly UploadOp[],
+): Promise<readonly UploadOp[]> {
+  const ignorePath = join(projectDir, ".vfignore");
+  let ignoreInfo;
+  try {
+    ignoreInfo = await lstat(ignorePath);
+  } catch (error) {
+    if (isNotFoundError(error)) return files;
+    throw error;
+  }
+
+  if (ignoreInfo.isSymlink || !ignoreInfo.isFile) {
+    throw new Error(
+      ".vfignore must be a regular file inside the project and cannot be a symbolic link.",
+    );
+  }
+
+  return [...files, { path: ".vfignore", content: "" }];
+}
+
 export async function capturePushSourceSnapshot(
   projectDir: string,
   ignoreChecker: IgnoreChecker,
 ): Promise<PushSourceSnapshot> {
   const gitSourceBefore = await resolveGitSource(projectDir);
   const files = await scanLocalFiles(projectDir, ignoreChecker);
+  const trackedSourceFiles = await sourceFilesForGitTracking(projectDir, files);
   const [sourceDigest, filesTracked] = await Promise.all([
     computeSourceDigest(files),
-    areSourceFilesTracked(projectDir, files),
+    areSourceFilesTracked(projectDir, trackedSourceFiles),
   ]);
   const gitSource = await resolveGitSource(projectDir);
 
@@ -627,15 +651,27 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         uploadResult = await uploadFiles(client, config.projectSlug, branchId, ops, false);
       }
 
+      if (uploadResult.failed > 0) {
+        spinner.stop();
+        throw new Error(
+          `Push failed for ${uploadResult.failed} file${
+            uploadResult.failed === 1 ? "" : "s"
+          }. Remote files were not deleted.`,
+        );
+      }
+
       if (toDelete.length > 0) {
         spinner.update("Deleting removed files...");
         deleteResult = await deleteFiles(client, config.projectSlug, branchId, toDelete, false);
       }
 
-      const failedTotal = uploadResult.failed + deleteResult.failed;
-      if (failedTotal > 0) {
+      if (deleteResult.failed > 0) {
         spinner.stop();
-        throw new Error(`Push failed for ${failedTotal} file${failedTotal === 1 ? "" : "s"}`);
+        throw new Error(
+          `Push failed for ${deleteResult.failed} file${
+            deleteResult.failed === 1 ? "" : "s"
+          } during deletion`,
+        );
       }
 
       spinner.update("Verifying push target...");

--- a/cli/help/tips.ts
+++ b/cli/help/tips.ts
@@ -28,8 +28,13 @@ export function getInitTemplates(): string {
 
 export function getPostBuildTips(): string {
   return `\n  ${dim("Next steps:")}\n` +
-    `    ${dim("•")} ${cyan("veryfront serve")}     Preview locally\n` +
-    `    ${dim("•")} ${cyan("veryfront deploy")}    Deploy to production\n`;
+    `    ${dim("•")} ${
+      cyan("veryfront serve")
+    }                                  Preview locally\n` +
+    `    ${dim("•")} ${cyan("veryfront push --branch main")}                     Upload source\n` +
+    `    ${dim("•")} ${
+      cyan("veryfront deploy --branch main --env production")
+    } Create a release and deploy\n`;
 }
 
 export function getPostDeployTips(): string {

--- a/cli/mcp/skills/deploy-safely/SKILL.md
+++ b/cli/mcp/skills/deploy-safely/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: deploy-safely
-description: Build, test, deploy, and verify with rollback on failure.
+description: Build, test, push, deploy, and verify with rollback through Git on failure.
 metadata:
   version: "1.0.0"
 ---
 
 # Deploy Safely
 
-Build, test, deploy, and verify with rollback on failure.
+Build and test the reviewed Git source, then push it to Veryfront before creating a release and deployment. If verification fails, revert the Git commit and run the normal delivery sequence again.
 
 ## Steps
 
@@ -25,7 +25,7 @@ Build, test, deploy, and verify with rollback on failure.
 
 3. **Push**
    ```bash
-   veryfront push --branch <branch> --force
+   veryfront push --branch <branch> --yes
    ```
    Abort if any file fails to upload.
 
@@ -33,7 +33,7 @@ Build, test, deploy, and verify with rollback on failure.
    ```bash
    veryfront deploy --env <environment> --branch <branch> --yes --json
    ```
-   Record the project, environment, release, deployment, and commit IDs from the response.
+   Record the project, environment, release, deployment, and commit IDs from the final result record.
 
 5. **Verify health** (via MCP)
    Use `vf_get_errors` to check for runtime errors after deploy.
@@ -41,12 +41,17 @@ Build, test, deploy, and verify with rollback on failure.
 
 6. **Confirm or rollback**
    - If no errors: deployment is successful
-   - If errors detected: deploy the previous version
+   - If errors are detected, create and push a Git revert:
+     ```bash
+     git revert <bad-commit>
+     git push origin <branch>
+     ```
+   - Let CI run the normal Push and Deploy steps for the revert. Without CI, repeat steps 3 and 4 manually.
 
 ## Error Recovery
 
 - **Build fails**: Check `vf_get_errors` for compilation errors, fix and retry
-- **Tests fail**: Read failure details from JSON output, fix failing tests
-- **Push fails**: Fix failed uploads before retrying deploy
+- **Tests fail**: Read the JSON output and fix failing tests
+- **Push fails**: Fix the upload failure and rerun Push before Deploy
 - **Deploy fails**: Check environment name, auth token, branch existence
-- **Post-deploy errors**: Redeploy previous release with `--release-name <previous>`
+- **Post-deploy errors**: Revert the failing Git commit, push the revert, then run the normal Push and Deploy sequence

--- a/cli/router.test.ts
+++ b/cli/router.test.ts
@@ -6,6 +6,7 @@ import { parseLoginMethod } from "./auth/utils.ts";
 import { routeCommand } from "./router.ts";
 import { cliLogger, VERSION } from "./utils/index.ts";
 import { setJsonMode } from "./shared/json-output.ts";
+import { isInteractive, resetInteractiveMode } from "./shared/interactive.ts";
 import type { ParsedArgs } from "./shared/types.ts";
 
 /**
@@ -346,6 +347,7 @@ describe("cli/router helpers", () => {
       cliLogger.info = originalInfo;
       console.log = originalConsoleLog;
       setJsonMode(false);
+      resetInteractiveMode();
     }
 
     async function runAndCaptureExit(args: ParsedArgs): Promise<number> {
@@ -383,6 +385,18 @@ describe("cli/router helpers", () => {
       }
     });
 
+    it("--yes enables non-interactive confirmation before routing", async () => {
+      stubExit();
+      stubLogger();
+      try {
+        const code = await runAndCaptureExit({ version: true, yes: true, _: [] } as ParsedArgs);
+        assertEquals(code, 0);
+        assertEquals(isInteractive(), false);
+      } finally {
+        restoreAll();
+      }
+    });
+
     it("--version --verbose prints runtime and OS details", async () => {
       stubExit();
       stubLogger();
@@ -413,7 +427,7 @@ describe("cli/router helpers", () => {
         );
         assertEquals(code, 0);
         assertEquals(consoleOutput.length, 1);
-        const parsed = JSON.parse(consoleOutput[0]);
+        const parsed = JSON.parse(consoleOutput[0]!);
         assertEquals(parsed.success, true);
         assertEquals(parsed.command, "version");
         assertEquals(parsed.data.version, VERSION);
@@ -438,7 +452,7 @@ describe("cli/router helpers", () => {
         );
         assertEquals(code, 2);
         assertEquals(consoleOutput.length, 1);
-        const parsed = JSON.parse(consoleOutput[0]);
+        const parsed = JSON.parse(consoleOutput[0]!);
         assertEquals(parsed.success, false);
         assertEquals(parsed.command, "nosuch");
         assertEquals(parsed.error.code, "USAGE_ERROR");
@@ -459,7 +473,7 @@ describe("cli/router helpers", () => {
         );
         assertEquals(code, 2);
         assertEquals(consoleOutput.length, 1);
-        const parsed = JSON.parse(consoleOutput[0]);
+        const parsed = JSON.parse(consoleOutput[0]!);
         assertEquals(parsed.success, false);
         assertEquals(parsed.command, "serve");
         assertEquals(parsed.error.code, "USAGE_ERROR");

--- a/cli/skills/core-skills.ts
+++ b/cli/skills/core-skills.ts
@@ -76,30 +76,30 @@ Create a Veryfront app with AI capabilities.
   {
     metadata: {
       name: "deploy-safely",
-      description: "Build, test, deploy, and verify with rollback on failure",
+      description: "Build, test, push, deploy, and verify with rollback through Git on failure",
       metadata: { version: "1.0.0" },
     },
     skillMd: `# Deploy Safely
 
-Build, test, deploy, and verify with rollback on failure.
+Build and test the reviewed Git source, then push it to Veryfront before creating a release and deployment. If verification fails, revert the Git commit and run the normal delivery sequence again.
 
 ## Steps
 
-1. \`veryfront build --json\`, abort if success: false
+1. \`veryfront build --json\`, abort if success is false
 2. \`veryfront test --json\`, abort if any test fails
-3. \`veryfront push --branch <branch> --force\`, abort if any upload fails
+3. \`veryfront push --branch <branch> --yes\`, abort if any upload fails
 4. \`veryfront deploy --env <environment> --branch <branch> --yes --json\`
 5. Record the project, environment, release, deployment, and commit IDs
 6. Use vf_get_errors to verify no runtime errors after deploy
-7. If errors: redeploy previous version
+7. If errors: run \`git revert <bad-commit>\` and \`git push origin <branch>\`, then let CI run steps 3 and 4 or repeat them manually
 
 ## Error Recovery
 
 - **Build fails**: Check vf_get_errors, fix and retry
-- **Tests fail**: Read JSON output, fix failing tests
-- **Push fails**: Fix failed uploads before retrying deploy
+- **Tests fail**: Read the JSON output, fix failing tests
+- **Push fails**: Fix the upload failure and rerun Push before Deploy
 - **Deploy fails**: Check environment, auth, branch
-- **Post-deploy errors**: Redeploy previous release`,
+- **Post-deploy errors**: Revert the failing Git commit, push the revert, then run the normal Push and Deploy sequence`,
     directory: "core:deploy-safely",
   },
   {

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -1,9 +1,65 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createDefaultIgnoreChecker, createIgnoreChecker } from "./ignore.ts";
+import { createDefaultIgnoreChecker, createIgnoreChecker, loadIgnorePatterns } from "./ignore.ts";
 
 describe("cli/sync/ignore", () => {
+  describe("loadIgnorePatterns", () => {
+    it("uses default patterns when .vfignore is missing", async () => {
+      const projectDir = await Deno.makeTempDir();
+      try {
+        const patterns = await loadIgnorePatterns(projectDir);
+        assertEquals(patterns.includes("node_modules"), true);
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("loads patterns from a regular .vfignore file", async () => {
+      const projectDir = await Deno.makeTempDir();
+      try {
+        await Deno.writeTextFile(`${projectDir}/.vfignore`, "generated/**\n");
+        const patterns = await loadIgnorePatterns(projectDir);
+        assertEquals(patterns.includes("generated/**"), true);
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("rejects a non-file .vfignore", async () => {
+      const projectDir = await Deno.makeTempDir();
+      try {
+        await Deno.mkdir(`${projectDir}/.vfignore`);
+        await assertRejects(
+          () => loadIgnorePatterns(projectDir),
+          Error,
+          "must be a regular file",
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("rejects a symlinked .vfignore", async () => {
+      if (Deno.build.os === "windows") return;
+
+      const projectDir = await Deno.makeTempDir();
+      const externalFile = await Deno.makeTempFile();
+      try {
+        await Deno.writeTextFile(externalFile, "generated/**\n");
+        await Deno.symlink(externalFile, `${projectDir}/.vfignore`);
+        await assertRejects(
+          () => loadIgnorePatterns(projectDir),
+          Error,
+          "cannot be a symbolic link",
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+        await Deno.remove(externalFile);
+      }
+    });
+  });
+
   describe("createIgnoreChecker", () => {
     it("should ignore exact directory names", () => {
       const checker = createIgnoreChecker(["node_modules", ".git"]);

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -5,6 +5,7 @@
 import { join } from "veryfront/platform/path";
 import { createFileSystem } from "veryfront/platform";
 import { cliLogger } from "#cli/utils";
+import { isNotFoundError, lstat } from "veryfront/fs";
 
 /** Default patterns always ignored */
 const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
@@ -78,9 +79,24 @@ export async function loadIgnorePatterns(projectPath: string): Promise<string[]>
   const ignorePath = join(projectPath, ".vfignore");
   const patterns = [...DEFAULT_IGNORE_PATTERNS];
 
+  let ignoreInfo;
   try {
-    if (!(await fs.exists(ignorePath))) return patterns;
+    ignoreInfo = await lstat(ignorePath);
+  } catch (error) {
+    if (isNotFoundError(error)) return patterns;
+    cliLogger.debug("Failed to read .vfignore:", error);
+    throw new Error("Failed to read .vfignore. Fix the file permissions or path and try again.", {
+      cause: error,
+    });
+  }
 
+  if (ignoreInfo.isSymlink || !ignoreInfo.isFile) {
+    throw new Error(
+      ".vfignore must be a regular file inside the project and cannot be a symbolic link.",
+    );
+  }
+
+  try {
     const content = await fs.readTextFile(ignorePath);
     const customPatterns = content
       .split("\n")
@@ -90,6 +106,9 @@ export async function loadIgnorePatterns(projectPath: string): Promise<string[]>
     patterns.push(...customPatterns);
   } catch (error) {
     cliLogger.debug("Failed to read .vfignore:", error);
+    throw new Error("Failed to read .vfignore. Fix the file permissions or path and try again.", {
+      cause: error,
+    });
   }
 
   return patterns;

--- a/cli/utils/env-prompt.test.ts
+++ b/cli/utils/env-prompt.test.ts
@@ -30,11 +30,19 @@ describe("env-prompt", () => {
       assertStringIncludes(result, "# IDE");
     });
 
-    it("returns existing content unchanged if .env already present", () => {
-      const existing = "# My gitignore\n.env\nnode_modules/";
+    it("returns existing content unchanged when every required entry is present", () => {
+      const existing = "# My gitignore\n.env\n.env.local\n.env.*.local\n.veryfront/\nnode_modules/";
       const result = generateGitignoreContent(existing);
 
       assertEquals(result, existing);
+    });
+
+    it("adds .veryfront when existing content already ignores environment files", () => {
+      const existing = "# My gitignore\n.env\n.env.local\n.env.*.local\nnode_modules/";
+      const result = generateGitignoreContent(existing);
+
+      assertStringIncludes(result, ".veryfront/");
+      assertEquals(result.match(/^\.env$/gm)?.length, 1);
     });
 
     it("appends env entries to existing content without .env", () => {

--- a/cli/utils/env-prompt.ts
+++ b/cli/utils/env-prompt.ts
@@ -162,14 +162,16 @@ async function promptForSingleEnvVar(envVar: EnvVarConfig): Promise<string> {
  * Generates content for .gitignore to ensure .env is not committed
  */
 export function generateGitignoreContent(existingContent?: string): string {
-  const requiredEntries = ["# Environment files", ".env", ".env.local", ".env.*.local", ""];
+  const environmentEntries = [".env", ".env.local", ".env.*.local"];
 
   if (!existingContent) {
     return [
       "# Dependencies",
       "node_modules/",
       "",
-      ...requiredEntries,
+      "# Environment files",
+      ...environmentEntries,
+      "",
       "# Build output",
       "dist/",
       ".veryfront/",
@@ -184,7 +186,21 @@ export function generateGitignoreContent(existingContent?: string): string {
     ].join("\n");
   }
 
-  if (existingContent.includes(".env")) return existingContent;
+  const existingEntries = new Set(
+    existingContent.split(/\r?\n/).map((line) => line.trim()).filter(Boolean),
+  );
+  const additions: string[] = [];
+  const missingEnvironmentEntries = environmentEntries.filter((entry) =>
+    !existingEntries.has(entry)
+  );
+  if (missingEnvironmentEntries.length > 0) {
+    additions.push("# Environment files", ...missingEnvironmentEntries);
+  }
+  if (!existingEntries.has(".veryfront/") && !existingEntries.has(".veryfront")) {
+    if (additions.length > 0) additions.push("");
+    additions.push("# Veryfront local state", ".veryfront/");
+  }
 
-  return `${existingContent.trimEnd()}\n\n${requiredEntries.join("\n")}`;
+  if (additions.length === 0) return existingContent;
+  return `${existingContent.trimEnd()}\n\n${additions.join("\n")}\n`;
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1062",
+  "version": "0.1.1063",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/api-reference/veryfront/cli.md
+++ b/docs/api-reference/veryfront/cli.md
@@ -41,7 +41,7 @@ The CLI groups commands by category. Each command supports `--help` for its full
 | `veryfront lock` | Manage remote import lockfile for reproducible builds |
 | `veryfront merge` | Merge a branch into main (or another branch) |
 | `veryfront pull` | Download project files from Veryfront remote |
-| `veryfront push` | Create a branch and upload local files to Veryfront |
+| `veryfront push` | Upload local source files to a Veryfront branch |
 | `veryfront up` | Deploy your app with one command (login, create, push, deploy) |
 
 ### Project

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -37,15 +37,16 @@ endpoints work.
 
 ## Deploy to Veryfront Cloud
 
-```bash
-veryfront deploy
-```
-
-For a preview deployment per branch:
+Push the current checkout to Veryfront `main`, then create and deploy its
+release:
 
 ```bash
-veryfront deploy --branch feature-x
+veryfront push --branch main --yes
+veryfront deploy --branch main --env production --yes
 ```
+
+Run both commands from the same checkout. Deploy verifies the Push receipt,
+Git commit, and source digest before it creates the release.
 
 ## Deploy somewhere else
 
@@ -54,10 +55,13 @@ For a non-Cloud target, run `veryfront build` and ship the `dist/` output. See
 
 ## Verify it worked
 
-After `veryfront deploy`, run:
+After Deploy completes, run:
 
 ```bash
 veryfront open
 ```
 
 The deployed page and API routes respond.
+
+For an automated production workflow, see
+[Deploy from CI](../guides/deploy-from-ci.md).

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -270,6 +270,7 @@ After editing `veryfront.config.ts`, restart `veryfront dev`. The dev banner
 prints the resolved `title`, output directory, and router mode. Set a
 distinctive `title` and check that the document title in the browser matches.
 
-For environment variables, read them back from a temporary API route. For
-example, return `getEnv("VERYFRONT_API_TOKEN")` from a debug route and remove
-it once you have confirmed the value resolves.
+For environment variables, set a temporary non-secret value such as
+`VERYFRONT_CONFIG_CHECK=enabled` and read that value from a temporary API route.
+Never return API tokens, provider keys, or other secrets from a route. Remove
+the route and temporary value after confirming the configuration resolves.

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -1,0 +1,197 @@
+---
+title: "Deploy from CI"
+description: "Push a reviewed Git commit to Veryfront and deploy it from a serialized CI job."
+order: 44
+---
+
+Use this guide to make a reviewed Git commit the source of a Veryfront
+deployment. The CI job pushes the checked-out source, creates an immutable
+release, and deploys that release to an environment.
+
+## Understand the Phase 0 boundary
+
+This workflow is a CI-mediated bridge, not an enforced repository connection.
+Veryfront does not yet know which Git repository is canonical. Existing Studio
+permissions can still allow direct edits to Veryfront `main`, and a project API
+key can upload the source present in its checkout. Pull request creation and
+conflict resolution remain manual.
+
+Use one serialized CI writer for each Veryfront project, protect its API key,
+and use immutable releases for Studio-to-Git handoffs. The connected-repository
+phase adds exact-SHA server fetches, GitHub App verification, and automated pull
+requests.
+
+## Prerequisites
+
+- A Veryfront project with the `veryfront` package pinned in its lockfile.
+- A dedicated project API key stored in the CI secret manager.
+- The project slug stored as a CI variable.
+- A protected `production` environment in Veryfront.
+- A CI job that runs after changes merge to `main`.
+- `.veryfront/` in `.gitignore` so local Push receipts are never committed.
+
+See [Configuration](./configuration.md) for the Cloud bootstrap environment
+variables.
+
+## Define the managed source set
+
+Push and `pull --prune` use the same supported text-file extensions and
+`.vfignore` rules. Ignored and unsupported files are not reconciled with
+Veryfront.
+
+If the project has a `.vfignore`, keep it as a regular file inside the project
+and commit it to Git. An untracked, Git-ignored, or symlinked `.vfignore` cannot
+provide clean production provenance, so Deploy will stop instead of treating
+the checkout as the reviewed commit.
+
+## Push and deploy
+
+Run Push and Deploy from the same Git checkout and CI job:
+
+```bash title="Terminal"
+veryfront push --branch main --yes
+veryfront deploy --branch main --env production --yes
+```
+
+Push records the checked-out commit and source digest in
+`.veryfront/push-receipt.json`. Deploy requires that receipt to match the same
+project, branch, commit, and checkout. Do not split the two commands across CI
+jobs or clean the checkout between them.
+
+Deploy creates an immutable release from the pushed source, then assigns that
+release to `production`.
+
+The current directory is the Veryfront project directory. It maps to the Git
+repository root by default. For a monorepo, run both commands from the same
+project subdirectory so Deploy finds the config and Push receipt created there.
+For example, set the GitHub Actions job default:
+
+```yaml title="Monorepo job excerpt"
+defaults:
+  run:
+    working-directory: apps/storefront
+```
+
+## Add a GitHub Actions workflow
+
+Add a workflow that serializes production updates and keeps the API key scoped
+to the deployment step:
+
+```yaml title=".github/workflows/deploy-veryfront.yml"
+name: Deploy Veryfront
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: veryfront-production-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Check out the merged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install the locked dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test --if-present
+
+      - name: Push and deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERYFRONT_API_TOKEN: ${{ secrets.VERYFRONT_API_TOKEN }}
+          VERYFRONT_PROJECT_SLUG: ${{ vars.VERYFRONT_PROJECT_SLUG }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+          CURRENT_MAIN_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)"
+          if [ "$CURRENT_MAIN_SHA" != "$GITHUB_SHA" ]; then
+            echo "Skipping superseded main commit $GITHUB_SHA"
+            exit 0
+          fi
+
+          npx --no-install veryfront push --branch main --yes
+          npx --no-install veryfront deploy --branch main --env production --yes
+```
+
+`npm ci` and `npx --no-install` use the Veryfront version in the project
+lockfile. Replace the install and test steps when the project uses another
+package manager, but keep Push and Deploy together.
+
+The concurrency group prevents two jobs from changing Veryfront `main` at the
+same time. `cancel-in-progress: false` lets an active Push and Deploy sequence
+finish before the next run starts.
+
+The SHA check skips a queued workflow when a newer `main` commit already
+exists. It is a Phase 0 race reduction, not the exact-SHA enforcement provided
+by a connected repository.
+
+## Capture deployment evidence
+
+Deploy prints human-readable output by default. Add `--json` only when the CI
+system needs machine-readable audit evidence. JSON mode emits NDJSON records
+for each step and a final result.
+
+Write the audit file outside the Git checkout so it does not make the source
+dirty before the production check:
+
+```bash title="GitHub Actions deployment step"
+set -o pipefail
+veryfront deploy --branch main --env production --yes --json \
+  | tee "${RUNNER_TEMP}/veryfront-deploy.ndjson"
+```
+
+Store `${RUNNER_TEMP}/veryfront-deploy.ndjson` as a CI artifact. The final
+result includes the project, commit SHA, source digest, release, environment,
+and deployment identifiers.
+
+## Roll back
+
+Revert the faulty Git commit instead of changing Veryfront `main` directly:
+
+```bash title="Terminal"
+BAD_COMMIT_SHA="<BAD_COMMIT_SHA>"
+git revert "$BAD_COMMIT_SHA"
+git push origin main
+```
+
+The push to Git starts the same serialized CI workflow. It creates a new
+immutable release from the reverted source and deploys it to production.
+
+## Verify it worked
+
+1. Confirm the CI job reports successful Push and Deploy steps.
+2. Confirm the final deployment evidence names the merged commit.
+3. Open the production environment with `veryfront open`.
+4. Check the changed route or API behavior.
+
+## Next
+
+- [Move Studio changes into Git](./move-studio-changes-to-git.md): Turn an immutable Studio release into a reviewed pull request.
+- [Build and deploy](./deploying.md): Review local build and self-hosted deployment paths.
+
+## Related
+
+- [veryfront/cli](../api-reference/veryfront/cli.md): CLI command catalog
+- [Configuration](./configuration.md): Cloud bootstrap environment variables

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -66,16 +66,22 @@ and production responses with `curl`.
 
 ## Deploy to Veryfront Cloud
 
+Push the current checkout to Veryfront, then create and deploy an immutable
+release from that source:
+
 ```bash
-veryfront deploy
+veryfront push --branch main --yes
+veryfront deploy --branch main --env production --yes
 ```
 
-Deploys your project to Veryfront Cloud.
+Run both commands from the same checkout. Deploy verifies the Push receipt,
+Git commit, and source digest before creating the release.
 
-For preview deployments:
+For an existing nonproduction environment named `staging`:
 
 ```bash
-veryfront deploy --branch feature-x
+veryfront push --branch feature-x --yes
+veryfront deploy --branch feature-x --env staging --yes
 ```
 
 Use `veryfront open` after deployment to open the project. Use
@@ -130,10 +136,13 @@ After `veryfront deploy`:
 ## Next
 
 - [Configuration](./configuration.md): Configure build and environment behavior
+- [Deploy from CI](./deploy-from-ci.md): Push and deploy reviewed Git commits from CI
+- [Move Studio changes into Git](./move-studio-changes-to-git.md): Review a Studio release through a Git pull request
 - [Providers](./providers.md): Configure model provider defaults
 
 ## Related
 
 - [veryfront](../api-reference/veryfront/index.md): Framework entrypoint
+- [veryfront/cli](../api-reference/veryfront/cli.md): Pull, Push, and Deploy command catalog
 - [veryfront/server](../api-reference/veryfront/server.md): Server runtime APIs
 - [veryfront/observability](../api-reference/veryfront/observability.md): Runtime observability

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -72,10 +72,12 @@ details, see [API reference](../api-reference/index.md).
 
 ## Deploy and extend
 
-| Goal                                   | Guide                                                 |
-| -------------------------------------- | ----------------------------------------------------- |
-| Build and deploy a project             | [Build and deploy](./deploying.md)                    |
-| Review shipped UI components           | [Storybook UI workbench](./storybook-ui-workbench.md) |
-| Run agents as separate services        | [Agent service runtime](./agent-service-runtime.md)   |
-| Enable reusable runtime infrastructure | [Extensions](./extensions.md)                         |
-| Write, test, and package an extension  | [Author extensions](./extension-authoring.md)         |
+| Goal                                    | Guide                                                           |
+| --------------------------------------- | --------------------------------------------------------------- |
+| Build and deploy a project              | [Build and deploy](./deploying.md)                              |
+| Deploy a reviewed Git commit from CI    | [Deploy from CI](./deploy-from-ci.md)                           |
+| Move an immutable Studio release to Git | [Move Studio changes into Git](./move-studio-changes-to-git.md) |
+| Review shipped UI components            | [Storybook UI workbench](./storybook-ui-workbench.md)           |
+| Run agents as separate services         | [Agent service runtime](./agent-service-runtime.md)             |
+| Enable reusable runtime infrastructure  | [Extensions](./extensions.md)                                   |
+| Write, test, and package an extension   | [Author extensions](./extension-authoring.md)                   |

--- a/docs/guides/move-studio-changes-to-git.md
+++ b/docs/guides/move-studio-changes-to-git.md
@@ -1,0 +1,134 @@
+---
+title: "Move Studio changes into Git"
+description: "Pull an immutable Veryfront Studio release into a Git feature branch and open a reviewed pull request."
+order: 45
+---
+
+Use this guide to hand a Studio change to a professional developer for Git
+review. The Studio release is the immutable handoff, while Git remains the
+place where developers review and resolve conflicts.
+
+## Prerequisites
+
+- An immutable release created from the completed Studio change.
+- The release version supplied by the Studio editor.
+- A clean local clone of the Git repository.
+- A dedicated Veryfront API key and project slug in your environment.
+- Permission to push a Git feature branch and open a pull request.
+- `.veryfront/` in `.gitignore` so the local Push receipt cannot enter the pull request.
+
+## Create the Studio handoff
+
+When the Studio change is ready, publish it to a non-production environment,
+such as staging. Publish creates the immutable release used for the handoff and
+deploys it only to that selected environment.
+
+Open the Releases panel in Studio, open the new release, and copy its Version
+value. Give that version to the professional developer. You do not need to
+deploy the unreviewed change to production.
+
+## Create a Git feature branch
+
+Start from the latest reviewed `main` branch:
+
+```bash title="Terminal"
+git fetch origin main
+git switch --create veryfront/studio-release origin/main
+git status --short
+```
+
+`git status --short` must print no changes. Never pull a Studio release directly
+into the Git `main` branch.
+
+## Preview the release
+
+Set the immutable release version and preview the file reconciliation:
+
+```bash title="Terminal"
+VERYFRONT_RELEASE="<VERSION>"
+veryfront pull --release "$VERYFRONT_RELEASE" --prune --dry-run
+```
+
+`--prune` includes managed local files that exist in Git but not in the Studio
+release. It does not delete ignored files, unsupported files, or Git metadata.
+Push and pruning Pulls share the project `.vfignore` rules. Commit `.vfignore`
+as a regular file when the project uses one.
+
+Use a release version instead of a mutable Studio branch name. Repeating the
+Pull for the same release retrieves the same source snapshot.
+
+## Apply the release
+
+Apply the additions, updates, and deletions to the clean feature branch:
+
+```bash title="Terminal"
+veryfront pull --release "$VERYFRONT_RELEASE" --prune --yes
+```
+
+Pull fetches every managed remote file before it writes locally. A content
+download failure leaves the feature branch unchanged. A local write or delete
+failure can leave a partial Git diff. In that case, inspect `git status`, return
+the feature branch to a clean state with your normal Git recovery workflow, and
+then run Pull again. Do not discard unrelated local work.
+
+## Review and test
+
+Inspect every change before committing it:
+
+```bash title="Terminal"
+git status --short
+git diff --check
+git diff
+```
+
+Run the project's normal format, lint, test, and build commands. Treat the
+pulled release like any other proposed source change.
+
+## Commit and open a pull request
+
+Commit the reviewed snapshot and push the feature branch:
+
+```bash title="Terminal"
+git add --all
+git commit -m "Apply Veryfront Studio release"
+git push --set-upstream origin HEAD
+```
+
+Open a pull request against `main` in the Git provider. Include the Veryfront
+release version in the pull request description so reviewers can trace the
+handoff.
+
+## Resolve conflicts in Git
+
+If `main` changes before the pull request merges, update the feature branch in
+Git:
+
+```bash title="Terminal"
+git fetch origin main
+git merge origin/main
+git diff --name-only --diff-filter=U
+```
+
+Resolve each listed file, run `git add --all`, commit the merge, and push the
+feature branch again. Do not resolve Git conflicts by overwriting Git `main`
+from Studio.
+
+After the pull request merges, the normal CI workflow pushes the reviewed Git
+`main` source to Veryfront and creates the production release and deployment.
+
+## Verify it worked
+
+1. Confirm the pull request diff matches the immutable Studio release.
+2. Confirm required Git reviews and checks pass.
+3. Merge the pull request.
+4. Confirm the serialized CI job pushes and deploys the merged commit.
+
+## Next
+
+- [Deploy from CI](./deploy-from-ci.md): Push and deploy the merged Git commit.
+- [Build and deploy](./deploying.md): Review the full deployment workflow.
+
+## Related
+
+- [veryfront/cli](../api-reference/veryfront/cli.md): Pull, Push, and Deploy command catalog
+- [Configuration](./configuration.md): Veryfront authentication and project configuration

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1062";
+export const VERSION = "0.1.1063";

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -52,7 +52,11 @@ import {
   getRemoteIntegrationToolDefinitions,
   listConnectors,
 } from "../../src/integrations/index.ts";
+import { parseDeployArgs } from "../../cli/commands/deploy/command.ts";
 import { buildKnowledgeIngestRunResult } from "../../cli/commands/knowledge/result.ts";
+import { parsePullArgs } from "../../cli/commands/pull/command.ts";
+import { parsePushArgs } from "../../cli/commands/push/command.ts";
+import { parseCliArgs } from "../../cli/shared/args.ts";
 import { getTemplate } from "../../cli/templates/index.ts";
 
 const EXISTING_GUIDE_EXAMPLE_SUITE = [
@@ -79,6 +83,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "cli-knowledge-ingestion.md",
   "coding-agents.md",
   "create-agent.md",
+  "deploy-from-ci.md",
   "deploying.md",
   "evals.md",
   "extension-authoring.md",
@@ -91,6 +96,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "create-api.md",
   "deploy-project.md",
   "integrations.md",
+  "move-studio-changes-to-git.md",
   "pages-and-routing.md",
   "project-structure.md",
   "project-metrics.md",
@@ -413,13 +419,70 @@ describe("Guide: deploying.md", () => {
         "veryfront dev",
         "veryfront build",
         "veryfront serve",
-        "veryfront deploy",
+        "veryfront push --branch main --yes",
+        "veryfront deploy --branch main --env production --yes",
         "veryfront open",
       ]
     ) {
       assertStringIncludes(guide, command);
     }
     assertEquals(guide.includes("veryfront start"), false);
+  });
+});
+
+describe("Guide: deploy-from-ci.md", () => {
+  it("uses supported Push and Deploy arguments in the required order", async () => {
+    const guide = await readGuide("deploy-from-ci.md");
+    const pushCommand = "veryfront push --branch main --yes";
+    const deployCommand = "veryfront deploy --branch main --env production --yes";
+
+    const pushArgs = parseCliArgs(["push", "--branch", "main", "--yes"]);
+    const parsedPush = parsePushArgs(pushArgs);
+    assert(parsedPush.success);
+    assertEquals(parsedPush.data.branch, "main");
+    assertEquals(pushArgs.yes, true);
+
+    const deployArgs = parseCliArgs([
+      "deploy",
+      "--branch",
+      "main",
+      "--env",
+      "production",
+      "--yes",
+    ]);
+    const parsedDeploy = parseDeployArgs(deployArgs);
+    assert(parsedDeploy.success);
+    assertEquals(parsedDeploy.data.branch, "main");
+    assertEquals(parsedDeploy.data.env, "production");
+    assertEquals(deployArgs.yes, true);
+
+    assert(guide.indexOf(pushCommand) < guide.indexOf(deployCommand));
+    assertStringIncludes(guide, "cancel-in-progress: false");
+    assertStringIncludes(guide, "RUNNER_TEMP");
+  });
+});
+
+describe("Guide: move-studio-changes-to-git.md", () => {
+  it("uses the immutable release and pruning Pull arguments", async () => {
+    const guide = await readGuide("move-studio-changes-to-git.md");
+    const pullArgs = parseCliArgs([
+      "pull",
+      "--release",
+      "0.0.42",
+      "--prune",
+      "--yes",
+    ]);
+    const parsedPull = parsePullArgs(pullArgs);
+
+    assert(parsedPull.success);
+    assertEquals(parsedPull.data.release, "0.0.42");
+    assertEquals(parsedPull.data.prune, true);
+    assertEquals(pullArgs.yes, true);
+    assertStringIncludes(
+      guide,
+      'veryfront pull --release "$VERYFRONT_RELEASE" --prune --yes',
+    );
+    assertStringIncludes(guide, "git merge origin/main");
   });
 });
 
@@ -786,7 +849,8 @@ describe("Guide: deploy-project.md", () => {
       const command of [
         "veryfront build",
         "veryfront serve",
-        "veryfront deploy",
+        "veryfront push --branch main --yes",
+        "veryfront deploy --branch main --env production --yes",
         "veryfront open",
       ]
     ) {

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 
 describe("guide content contracts", () => {
@@ -72,6 +72,72 @@ describe("guide content contracts", () => {
       assertStringIncludes(text, "veryfront serve");
       assertEquals(text.includes("veryfront start"), false);
     }
+  });
+
+  it("documents Push before Deploy for every Veryfront Cloud path", async () => {
+    const docs = [
+      "docs/getting-started/deploy-project.md",
+      "docs/guides/deploying.md",
+      "docs/guides/deploy-from-ci.md",
+    ];
+    const push = "veryfront push --branch main --yes";
+    const deploy = "veryfront deploy --branch main --env production --yes";
+
+    for (const path of docs) {
+      const text = await Deno.readTextFile(path);
+      const pushIndex = text.indexOf(push);
+      const deployIndex = text.indexOf(deploy);
+
+      assert(pushIndex >= 0, `${path} must document the canonical Push command`);
+      assert(deployIndex > pushIndex, `${path} must document Deploy after Push`);
+    }
+  });
+
+  it("keeps the CI workflow serialized, auditable, and rollback-safe", async () => {
+    const guide = await Deno.readTextFile("docs/guides/deploy-from-ci.md");
+
+    assertStringIncludes(guide, "same Git checkout and CI job");
+    assertStringIncludes(guide, "cancel-in-progress: false");
+    assertStringIncludes(guide, "not an enforced repository connection");
+    assertStringIncludes(guide, "Skipping superseded main commit");
+    assertStringIncludes(guide, "working-directory: apps/storefront");
+    assertStringIncludes(guide, ".veryfront/` in `.gitignore");
+    assertStringIncludes(guide, "commit it to Git");
+    assertStringIncludes(guide, "RUNNER_TEMP");
+    assertStringIncludes(guide, "NDJSON records");
+    assertStringIncludes(guide, "git revert");
+    assertEquals(guide.includes("--quiet"), false);
+    assertEquals(guide.includes("--release-name <previous>"), false);
+  });
+
+  it("uses an immutable release for the Studio-to-Git handoff", async () => {
+    const guide = await Deno.readTextFile(
+      "docs/guides/move-studio-changes-to-git.md",
+    );
+
+    assertStringIncludes(guide, "immutable release");
+    assertStringIncludes(guide, "publish it to a non-production environment");
+    assertStringIncludes(guide, "Open the Releases panel in Studio");
+    assertStringIncludes(guide, ".veryfront/` in `.gitignore");
+    assertStringIncludes(
+      guide,
+      'veryfront pull --release "$VERYFRONT_RELEASE" --prune --dry-run',
+    );
+    assertStringIncludes(guide, "Resolve conflicts in Git");
+    assertStringIncludes(guide, "failure can leave a partial Git diff");
+    assertStringIncludes(guide, "git merge origin/main");
+    assertEquals(guide.includes("veryfront pull --branch"), false);
+  });
+
+  it("never recommends exposing a secret to verify environment config", async () => {
+    const guide = await Deno.readTextFile("docs/guides/configuration.md");
+
+    assertStringIncludes(guide, "VERYFRONT_CONFIG_CHECK=enabled");
+    assertStringIncludes(guide, "Never return API tokens");
+    assertEquals(
+      guide.includes('return `getEnv("VERYFRONT_API_TOKEN")`'),
+      false,
+    );
   });
 
   it("documents the MCP session header for post-init tool calls", async () => {

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -212,6 +212,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   "guides/deploying.md": {
     references: [
       "../api-reference/veryfront/index.md",
+      "../api-reference/veryfront/cli.md",
       "../api-reference/veryfront/server.md",
       "../api-reference/veryfront/observability.md",
       "../api-reference/veryfront/utils.md",
@@ -220,8 +221,25 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "Pick one production path",
       "veryfront build",
       "veryfront serve",
-      "veryfront deploy",
+      "veryfront push --branch main --yes",
+      "veryfront deploy --branch main --env production --yes",
       "veryfront open",
+    ],
+  },
+  "guides/deploy-from-ci.md": {
+    references: [
+      "../api-reference/veryfront/cli.md",
+      "./configuration.md",
+      "./deploying.md",
+    ],
+    snippets: [
+      "veryfront push --branch main --yes",
+      "veryfront deploy --branch main --env production --yes",
+      ".veryfront/push-receipt.json",
+      "cancel-in-progress: false",
+      "RUNNER_TEMP",
+      "NDJSON records",
+      "git revert",
     ],
   },
   "guides/extension-authoring.md": {
@@ -304,6 +322,8 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "Workflows",
       "Extensions",
       "Build and deploy",
+      "Deploy from CI",
+      "Move Studio changes into Git",
     ],
   },
   "concepts/index.md": {
@@ -616,8 +636,25 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     snippets: [
       "veryfront build",
       "veryfront serve",
-      "veryfront deploy",
+      "veryfront push --branch main --yes",
+      "veryfront deploy --branch main --env production --yes",
       "veryfront open",
+    ],
+  },
+  "guides/move-studio-changes-to-git.md": {
+    references: [
+      "../api-reference/veryfront/cli.md",
+      "./configuration.md",
+      "./deploy-from-ci.md",
+    ],
+    snippets: [
+      "immutable release",
+      "veryfront pull --release",
+      "--prune --dry-run",
+      "git switch --create",
+      "git merge origin/main",
+      "Resolve conflicts in Git",
+      "git push --set-upstream origin HEAD",
     ],
   },
   "guides/sandbox.md": {


### PR DESCRIPTION
## Summary

- add `veryfront pull --prune` for reconciling immutable Studio releases into clean Git feature branches
- protect pruning with clean-worktree checks, canonical path validation, symlink rejection, shared `.vfignore` rules, and dry-run support
- fetch all remote content before local writes and never prune after a fetch or write failure
- stop Push before remote deletions when an upload fails
- include `.vfignore` in Git provenance checks and keep `.veryfront/` out of generated Git commits
- document the Phase 0 CI Push to Deploy workflow and Studio release to Git pull-request workflow
- align CLI help, demos, tips, and deployment-agent guidance with Push before Deploy
- bump Veryfront from the latest `origin/main` version `0.1.1062` to `0.1.1063`

## Compatibility

No commands or flags are removed. `--force`, `--quiet`, and `--json` remain supported.

Behavior changes to release-note:

- Pull now fails on invalid remote paths and fetch or write failures instead of silently skipping them.
- Pull preserves exact remote bytes instead of adding a trailing newline.
- `.vfignore`, when present, must be a regular file. Clean deployment provenance also requires it to be Git-tracked.
- project initialization may add `.veryfront/` to an existing `.gitignore`.

## Validation

- full pre-push suite: 2,382 tests and 20,249 steps
- formatting, lint, and type-check passed
- focused CLI suite: 47 tests and 354 steps
- documentation validation: 108 files and 709 links