### PR TITLE
feat(schedule): declare integration requirements in source

### DIFF
--- a/docs/api-reference/veryfront/schedule.md
+++ b/docs/api-reference/veryfront/schedule.md
@@ -23,6 +23,15 @@ export default schedule({
   timezone: "Europe/Stockholm",
   target: { kind: "workflow", id: "escalate-ticket" },
   input: { severity: "high" },
+  integrationRequirements: [
+    {
+      integration: "slack",
+      requiredScopes: ["chat:write"],
+      resources: [
+        { kind: "channel", id: "C012345", parent: { kind: "workspace", id: "T012345" } },
+      ],
+    },
+  ],
 });
 ```
 
@@ -30,18 +39,22 @@ export default schedule({
 
 ### Functions
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `discoverSchedules` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/discovery.ts#L17) |
-| `isScheduleDefinition` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L23) |
-| `schedule` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/factory.ts#L20) |
+| Name                   | Description | Source                                                                                        |
+| ---------------------- | ----------- | --------------------------------------------------------------------------------------------- |
+| `discoverSchedules`    |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/discovery.ts#L17) |
+| `isScheduleDefinition` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L37)     |
+| `schedule`             |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/factory.ts#L109)  |
 
 ### Types
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `ScheduleConcurrencyPolicy` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L2) |
-| `ScheduleConfig` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L18) |
-| `ScheduleDefinition` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L4) |
-| `ScheduleDiscoveryOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/discovery.ts#L8) |
-| `ScheduleDiscoveryResult` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/discovery.ts#L15) |
+| Name                                   | Description | Source                                                                                        |
+| -------------------------------------- | ----------- | --------------------------------------------------------------------------------------------- |
+| `ScheduleConcurrencyPolicy`            |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L3)      |
+| `ScheduleConfig`                       |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L32)     |
+| `ScheduleDefinition`                   |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L17)     |
+| `ScheduleDiscoveryOptions`             |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/discovery.ts#L8)  |
+| `ScheduleDiscoveryResult`              |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/discovery.ts#L15) |
+| `ScheduleIntegrationRequirement`       |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L11)     |
+| `ScheduleIntegrationRequirementConfig` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L17)     |
+| `ScheduleIntegrationResource`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L10)     |
+| `ScheduleIntegrationResourceIdentity`  |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L5)      |

--- a/src/schedule/factory.test.ts
+++ b/src/schedule/factory.test.ts
@@ -55,6 +55,68 @@ describe("schedule/factory", () => {
     assertEquals(isScheduleDefinition(definition), true);
   });
 
+  it("preserves integration requirements", () => {
+    const definition = schedule({
+      id: "slack-digest",
+      schedule: "0 9 * * 1-5",
+      target: { kind: "workflow", id: "post-slack-digest" },
+      integrationRequirements: [
+        {
+          integration: "slack",
+          requiredScopes: ["channels:read", "chat:write"],
+          resources: [
+            { kind: "workspace", id: "T012345" },
+            { kind: "channel", id: "C012345", parent: { kind: "workspace", id: "T012345" } },
+          ],
+        },
+        {
+          integration: "linear",
+          requiredScopes: ["read"],
+          resources: [{ kind: "workspace", id: "acme" }],
+        },
+      ],
+    });
+
+    assertEquals(definition.integrationRequirements, [
+      {
+        integration: "slack",
+        requiredScopes: ["channels:read", "chat:write"],
+        resources: [
+          { kind: "workspace", id: "T012345" },
+          { kind: "channel", id: "C012345", parent: { kind: "workspace", id: "T012345" } },
+        ],
+      },
+      {
+        integration: "linear",
+        requiredScopes: ["read"],
+        resources: [{ kind: "workspace", id: "acme" }],
+      },
+    ]);
+    assertEquals(isScheduleDefinition(definition), true);
+  });
+
+  it("allows empty required scopes and resources", () => {
+    const definition = schedule({
+      id: "empty-requirements",
+      schedule: "0 9 * * 1-5",
+      target: { kind: "workflow", id: "post-empty-digest" },
+      integrationRequirements: [
+        {
+          integration: "slack",
+        },
+      ],
+    });
+
+    assertEquals(definition.integrationRequirements, [
+      {
+        integration: "slack",
+        requiredScopes: [],
+        resources: [],
+      },
+    ]);
+    assertEquals(isScheduleDefinition(definition), true);
+  });
+
   it("rejects invalid ids and targets", () => {
     assertThrows(
       () =>
@@ -90,6 +152,203 @@ describe("schedule/factory", () => {
         }),
       Error,
       "Schedule input.now must be JSON-serializable.",
+    );
+  });
+
+  it("rejects malformed integration requirements", () => {
+    assertThrows(
+      () =>
+        schedule({
+          id: "slack-digest",
+          schedule: "0 9 * * 1-5",
+          target: { kind: "workflow", id: "post-slack-digest" },
+          integrationRequirements: [
+            {
+              integration: "slack",
+              requiredScopes: ["chat:write"],
+              resources: [{ kind: "channel", id: 123 }],
+            },
+          ] as never,
+        }),
+      Error,
+      "resources[0].id is required.",
+    );
+
+    assertThrows(
+      () =>
+        schedule({
+          id: "slack-digest",
+          schedule: "0 9 * * 1-5",
+          target: { kind: "workflow", id: "post-slack-digest" },
+          integrationRequirements: [
+            {
+              integration: "slack",
+              requiredScopes: ["chat:write"],
+              resources: [{ kind: "channel", id: "C012345", parent: "T012345" }],
+            },
+          ] as never,
+        }),
+      Error,
+      "resources[0].parent must be an object.",
+    );
+
+    assertThrows(
+      () =>
+        schedule({
+          id: "slack-digest",
+          schedule: "0 9 * * 1-5",
+          target: { kind: "workflow", id: "post-slack-digest" },
+          integrationRequirements: [
+            {
+              integration: "slack",
+              requiredScopes: ["chat:write"],
+              resources: [{ kind: "channel", id: "C012345", parent: { kind: "", id: "T012345" } }],
+            },
+          ],
+        }),
+      Error,
+      "resources[0].parent.kind is required.",
+    );
+
+    assertThrows(
+      () =>
+        schedule({
+          id: "slack-digest",
+          schedule: "0 9 * * 1-5",
+          target: { kind: "workflow", id: "post-slack-digest" },
+          integrationRequirements: [
+            {
+              integration: "slack",
+              requiredScopes: ["chat:write"],
+              resources: [{
+                kind: "channel",
+                id: "C012345",
+                parent: { kind: "workspace", id: "" },
+              }],
+            },
+          ],
+        }),
+      Error,
+      "resources[0].parent.id is required.",
+    );
+
+    assertThrows(
+      () =>
+        schedule({
+          id: "slack-digest",
+          schedule: "0 9 * * 1-5",
+          target: { kind: "workflow", id: "post-slack-digest" },
+          integrationRequirements: [
+            {
+              integration: "Slack",
+              requiredScopes: ["chat:write"],
+              resources: [{ kind: "channel", id: "C012345" }],
+            },
+          ],
+        }),
+      Error,
+      "integration must use a lowercase integration identifier",
+    );
+
+    assertThrows(
+      () =>
+        schedule({
+          id: "slack-digest",
+          schedule: "0 9 * * 1-5",
+          target: { kind: "workflow", id: "post-slack-digest" },
+          integrationRequirements: [
+            {
+              integration: "slack",
+              requiredScopes: ["chat:write"],
+              resources: [{ kind: "Channel", id: "C012345" }],
+            },
+          ],
+        }),
+      Error,
+      "resources[0].kind must use a lowercase resource kind",
+    );
+  });
+
+  it("rejects duplicate integration requirements", () => {
+    assertThrows(
+      () =>
+        schedule({
+          id: "slack-digest",
+          schedule: "0 9 * * 1-5",
+          target: { kind: "workflow", id: "post-slack-digest" },
+          integrationRequirements: [
+            {
+              integration: "slack",
+              requiredScopes: ["channels:read"],
+              resources: [{ kind: "workspace", id: "T012345" }],
+            },
+            {
+              integration: "slack",
+              requiredScopes: ["chat:write"],
+              resources: [{ kind: "channel", id: "C012345" }],
+            },
+          ],
+        }),
+      Error,
+      "duplicate integration slack",
+    );
+  });
+
+  it("rejects unknown integration requirement fields", () => {
+    assertThrows(
+      () =>
+        schedule({
+          id: "slack-digest",
+          schedule: "0 9 * * 1-5",
+          target: { kind: "workflow", id: "post-slack-digest" },
+          integrationRequirements: [{
+            integration: "slack",
+            requiredScopes: [],
+            resources: [],
+            tokenId: "must-not-be-source-owned",
+          }] as never,
+        }),
+      Error,
+      "integrationRequirements[0].tokenId is not supported",
+    );
+  });
+
+  it("does not treat malformed integration requirements as schedule definitions", () => {
+    assertEquals(
+      isScheduleDefinition({
+        id: "slack-digest",
+        schedule: "0 9 * * 1-5",
+        target: { kind: "workflow", id: "post-slack-digest" },
+        integrationRequirements: [
+          {
+            integration: "slack",
+            requiredScopes: ["channels:read"],
+            resources: [{ kind: "workspace", id: "T012345" }],
+          },
+          {
+            integration: "slack",
+            requiredScopes: ["chat:write"],
+            resources: [{ kind: "channel", id: "C012345" }],
+          },
+        ],
+      }),
+      false,
+    );
+
+    assertEquals(
+      isScheduleDefinition({
+        id: "slack-digest",
+        schedule: "0 9 * * 1-5",
+        target: { kind: "workflow", id: "post-slack-digest" },
+        integrationRequirements: [
+          {
+            integration: "slack",
+            requiredScopes: ["channels:read"],
+            resources: [{ kind: "channel", id: "C012345", parent: "T012345" }],
+          },
+        ],
+      }),
+      false,
     );
   });
 });

--- a/src/schedule/factory.ts
+++ b/src/schedule/factory.ts
@@ -1,8 +1,17 @@
 import { isTriggerTarget } from "#veryfront/trigger/target.ts";
 import { assertSerializable, validateTriggerId } from "#veryfront/trigger/validation.ts";
-import type { ScheduleConcurrencyPolicy, ScheduleConfig, ScheduleDefinition } from "./types.ts";
+import type {
+  ScheduleConcurrencyPolicy,
+  ScheduleConfig,
+  ScheduleDefinition,
+  ScheduleIntegrationRequirement,
+  ScheduleIntegrationResource,
+  ScheduleIntegrationResourceIdentity,
+} from "./types.ts";
 
 const CONCURRENCY_POLICIES = new Set<ScheduleConcurrencyPolicy>(["Allow", "Forbid", "Replace"]);
+const INTEGRATION_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+const REQUIREMENT_KIND_PATTERN = /^[a-z][a-z0-9_-]*$/;
 
 function requireString(value: unknown, label: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -16,6 +25,176 @@ function validatePositiveInteger(value: unknown, label: string): void {
   if (!Number.isInteger(value) || Number(value) <= 0) {
     throw new Error(`${label} must be a positive integer.`);
   }
+}
+
+function requireContractString(value: unknown, label: string, maxLength: number): string {
+  const normalized = requireString(value, label).trim();
+  if (normalized.length > maxLength) {
+    throw new Error(`${label} must be at most ${maxLength} characters.`);
+  }
+  return normalized;
+}
+
+function requireIntegrationName(value: unknown, label: string): string {
+  const normalized = requireContractString(value, label, 255);
+  if (!INTEGRATION_NAME_PATTERN.test(normalized)) {
+    throw new Error(`${label} must use a lowercase integration identifier.`);
+  }
+  return normalized;
+}
+
+function requireRequirementKind(value: unknown, label: string): string {
+  const normalized = requireContractString(value, label, 64);
+  if (!REQUIREMENT_KIND_PATTERN.test(normalized)) {
+    throw new Error(`${label} must use a lowercase resource kind.`);
+  }
+  return normalized;
+}
+
+function assertOnlyKeys(
+  record: Record<string, unknown>,
+  allowedKeys: string[],
+  label: string,
+): void {
+  const allowed = new Set(allowedKeys);
+  const unknownKey = Object.keys(record).find((key) => !allowed.has(key));
+  if (unknownKey) {
+    throw new Error(`${label}.${unknownKey} is not supported.`);
+  }
+}
+
+function normalizeIntegrationRequirements(
+  value: unknown,
+): ScheduleIntegrationRequirement[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error("Schedule integrationRequirements must be an array.");
+  }
+  if (value.length > 20) {
+    throw new Error("Schedule integrationRequirements must contain at most 20 entries.");
+  }
+
+  const integrations = new Set<string>();
+  return value.map((requirement, index) => {
+    if (!requirement || typeof requirement !== "object" || Array.isArray(requirement)) {
+      throw new Error(`Schedule integrationRequirements[${index}] must be an object.`);
+    }
+
+    const record = requirement as Record<string, unknown>;
+    const label = `Schedule integrationRequirements[${index}]`;
+    assertOnlyKeys(record, ["integration", "requiredScopes", "resources"], label);
+    const integration = requireIntegrationName(
+      record.integration,
+      `${label}.integration`,
+    );
+    const integrationKey = integration.toLowerCase();
+    if (integrations.has(integrationKey)) {
+      throw new Error(
+        `Schedule integrationRequirements contains duplicate integration ${integration}.`,
+      );
+    }
+    integrations.add(integrationKey);
+
+    const rawRequiredScopes = record.requiredScopes ?? [];
+    if (!Array.isArray(rawRequiredScopes)) {
+      throw new Error(
+        `${label}.requiredScopes must be an array.`,
+      );
+    }
+    if (rawRequiredScopes.length > 50) {
+      throw new Error(
+        `${label}.requiredScopes must contain at most 50 entries.`,
+      );
+    }
+    const requiredScopes = rawRequiredScopes.map((scope, scopeIndex) =>
+      requireContractString(
+        scope,
+        `${label}.requiredScopes[${scopeIndex}]`,
+        255,
+      )
+    );
+
+    const rawResources = record.resources ?? [];
+    if (!Array.isArray(rawResources)) {
+      throw new Error(`${label}.resources must be an array.`);
+    }
+    if (rawResources.length > 50) {
+      throw new Error(
+        `${label}.resources must contain at most 50 entries.`,
+      );
+    }
+    const resources = rawResources.map((resource, resourceIndex) =>
+      normalizeIntegrationResource(resource, index, resourceIndex)
+    );
+
+    return { integration, requiredScopes, resources };
+  });
+}
+
+function normalizeIntegrationResource(
+  resource: unknown,
+  requirementIndex: number,
+  resourceIndex: number,
+): ScheduleIntegrationResource {
+  if (!resource || typeof resource !== "object" || Array.isArray(resource)) {
+    throw new Error(
+      `Schedule integrationRequirements[${requirementIndex}].resources[${resourceIndex}] must be an object.`,
+    );
+  }
+
+  const record = resource as Record<string, unknown>;
+  const label = `Schedule integrationRequirements[${requirementIndex}].resources[${resourceIndex}]`;
+  assertOnlyKeys(record, ["kind", "id", "parent"], label);
+  const kind = requireRequirementKind(
+    record.kind,
+    `${label}.kind`,
+  );
+  const id = requireContractString(
+    record.id,
+    `${label}.id`,
+    512,
+  );
+  const parent = record.parent;
+  const normalizedParent = normalizeIntegrationResourceParent(
+    parent,
+    requirementIndex,
+    resourceIndex,
+  );
+
+  return {
+    kind,
+    id,
+    ...(normalizedParent === undefined ? {} : { parent: normalizedParent }),
+  };
+}
+
+function normalizeIntegrationResourceParent(
+  value: unknown,
+  requirementIndex: number,
+  resourceIndex: number,
+): ScheduleIntegrationResourceIdentity | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      `Schedule integrationRequirements[${requirementIndex}].resources[${resourceIndex}].parent must be an object.`,
+    );
+  }
+
+  const record = value as Record<string, unknown>;
+  const label =
+    `Schedule integrationRequirements[${requirementIndex}].resources[${resourceIndex}].parent`;
+  assertOnlyKeys(record, ["kind", "id"], label);
+  return {
+    kind: requireRequirementKind(
+      record.kind,
+      `${label}.kind`,
+    ),
+    id: requireContractString(
+      record.id,
+      `${label}.id`,
+      512,
+    ),
+  };
 }
 
 export function schedule(config: ScheduleConfig): ScheduleDefinition {
@@ -40,6 +219,7 @@ export function schedule(config: ScheduleConfig): ScheduleDefinition {
   validatePositiveInteger(config.backoffLimit, "Schedule backoffLimit");
   validatePositiveInteger(config.maxRuns, "Schedule maxRuns");
   assertSerializable(config.input, "Schedule input");
+  const integrationRequirements = normalizeIntegrationRequirements(config.integrationRequirements);
 
   return {
     id,
@@ -55,5 +235,6 @@ export function schedule(config: ScheduleConfig): ScheduleDefinition {
       ? {}
       : { concurrencyPolicy: config.concurrencyPolicy }),
     ...(config.maxRuns === undefined ? {} : { maxRuns: config.maxRuns }),
+    ...(integrationRequirements === undefined ? {} : { integrationRequirements }),
   };
 }

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -18,7 +18,15 @@
  */
 
 export { schedule } from "./factory.ts";
-export type { ScheduleConcurrencyPolicy, ScheduleConfig, ScheduleDefinition } from "./types.ts";
+export type {
+  ScheduleConcurrencyPolicy,
+  ScheduleConfig,
+  ScheduleDefinition,
+  ScheduleIntegrationRequirement,
+  ScheduleIntegrationRequirementConfig,
+  ScheduleIntegrationResource,
+  ScheduleIntegrationResourceIdentity,
+} from "./types.ts";
 export { isScheduleDefinition } from "./types.ts";
 export { discoverSchedules } from "./discovery.ts";
 export type { ScheduleDiscoveryOptions, ScheduleDiscoveryResult } from "./discovery.ts";

--- a/src/schedule/types.ts
+++ b/src/schedule/types.ts
@@ -2,6 +2,27 @@ import type { TriggerTarget } from "#veryfront/trigger/target.ts";
 
 export type ScheduleConcurrencyPolicy = "Allow" | "Forbid" | "Replace";
 
+export interface ScheduleIntegrationResourceIdentity {
+  kind: string;
+  id: string;
+}
+
+export interface ScheduleIntegrationResource extends ScheduleIntegrationResourceIdentity {
+  parent?: ScheduleIntegrationResourceIdentity;
+}
+
+export interface ScheduleIntegrationRequirement {
+  integration: string;
+  requiredScopes: string[];
+  resources: ScheduleIntegrationResource[];
+}
+
+export interface ScheduleIntegrationRequirementConfig {
+  integration: string;
+  requiredScopes?: string[];
+  resources?: ScheduleIntegrationResource[];
+}
+
 export interface ScheduleDefinition {
   id: string;
   name?: string;
@@ -14,11 +35,13 @@ export interface ScheduleDefinition {
   backoffLimit?: number;
   concurrencyPolicy?: ScheduleConcurrencyPolicy;
   maxRuns?: number;
+  integrationRequirements?: ScheduleIntegrationRequirement[];
 }
 
-export type ScheduleConfig = Omit<ScheduleDefinition, "schedule"> & {
+export type ScheduleConfig = Omit<ScheduleDefinition, "schedule" | "integrationRequirements"> & {
   cron?: string;
   schedule?: string;
+  integrationRequirements?: ScheduleIntegrationRequirementConfig[];
 };
 
 export function isScheduleDefinition(value: unknown): value is ScheduleDefinition {
@@ -28,6 +51,89 @@ export function isScheduleDefinition(value: unknown): value is ScheduleDefinitio
     typeof definition.id === "string" &&
     typeof definition.schedule === "string" &&
     definition.target !== null &&
-    typeof definition.target === "object"
+    typeof definition.target === "object" &&
+    isScheduleIntegrationRequirements(definition.integrationRequirements)
   );
+}
+
+function isScheduleIntegrationRequirements(
+  value: unknown,
+): value is ScheduleIntegrationRequirement[] {
+  if (value === undefined) return true;
+  if (!Array.isArray(value) || value.length > 20) return false;
+
+  const integrations = new Set<string>();
+  for (const requirement of value) {
+    if (!requirement || typeof requirement !== "object" || Array.isArray(requirement)) {
+      return false;
+    }
+
+    const record = requirement as Record<string, unknown>;
+    const integration = isIntegrationName(record.integration) ? record.integration : undefined;
+    if (
+      integration === undefined ||
+      !hasOnlyKeys(record, ["integration", "requiredScopes", "resources"]) ||
+      integrations.has(integration.toLowerCase()) ||
+      !isStringArray(record.requiredScopes) ||
+      !isScheduleIntegrationResources(record.resources)
+    ) {
+      return false;
+    }
+
+    integrations.add(integration.toLowerCase());
+  }
+
+  return true;
+}
+
+function isScheduleIntegrationResources(value: unknown): value is ScheduleIntegrationResource[] {
+  if (!Array.isArray(value) || value.length > 50) return false;
+
+  return value.every((resource) => {
+    if (!resource || typeof resource !== "object" || Array.isArray(resource)) return false;
+
+    const record = resource as Record<string, unknown>;
+    return (
+      hasOnlyKeys(record, ["kind", "id", "parent"]) &&
+      isRequirementKind(record.kind) &&
+      isBoundedString(record.id, 512) &&
+      (record.parent === undefined || isScheduleIntegrationResourceIdentity(record.parent))
+    );
+  });
+}
+
+function isScheduleIntegrationResourceIdentity(
+  value: unknown,
+): value is ScheduleIntegrationResourceIdentity {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+
+  const record = value as Record<string, unknown>;
+  return hasOnlyKeys(record, ["kind", "id"]) &&
+    isRequirementKind(record.kind) && isBoundedString(record.id, 512);
+}
+
+function hasOnlyKeys(record: Record<string, unknown>, allowedKeys: string[]): boolean {
+  const allowed = new Set(allowedKeys);
+  return Object.keys(record).every((key) => allowed.has(key));
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length <= 50 &&
+    value.every((item) => isBoundedString(item, 255));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isBoundedString(value: unknown, maxLength: number): value is string {
+  return isNonEmptyString(value) && value.trim().length <= maxLength;
+}
+
+function isIntegrationName(value: unknown): value is string {
+  return isBoundedString(value, 255) && /^[a-z0-9][a-z0-9_-]*$/.test(value.trim());
+}
+
+function isRequirementKind(value: unknown): value is string {
+  return isBoundedString(value, 64) && /^[a-z][a-z0-9_-]*$/.test(value.trim());
 }


### PR DESCRIPTION
## Summary

- add a typed `integrationRequirements` contract to source-defined schedules
- validate integration names, scopes, resources, parent resource identity, limits, and duplicate integrations
- preserve the declaration through the schedule factory and export the public types
- keep input arrays optional while returning canonical arrays for API compatibility
- document the source DSL shape

## Why

The platform cannot safely reconcile source schedules by inferring authorization from enabled tools or the user who deployed. Source declares the integration contract while actor, grant, token binding, and pause state remain runtime-owned.

## Verification

- `deno task verify:quick`
- pre-push suite: 2,382 tests / 20,255 steps passed
- focused schedule factory suite: 1 test / 10 steps passed
- `deno check`, `deno lint`, and `git diff --check`

API reconciliation: veryfront/veryfront-api#3940
Related: veryfront/veryfront-api#4026