### PR TITLE
Bump veryfront to 0.1.1064

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1063",
+  "version": "0.1.1064",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1063";
+export const VERSION = "0.1.1064";


### PR DESCRIPTION
## Summary

- bump the Veryfront package to `0.1.1064` so the merged source-schedule integration declarations publish
- keep the shared CLI version constant synchronized with `deno.json`

## Included framework change

- #2922 adds typed integration requirements to source-defined schedules and is already merged and green on `main`

## Validation

- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version-constant.ts`
- pre-push formatting, lint, typecheck, and unit suite: 2,382 passed / 20,255 steps

## Rollout

After release, verify the published tag/artifact and then confirm staging hosted runtimes adopt the new framework version before the schedule canary.