### PR TITLE
docs: present the CI-controlled Git delivery workflow

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1065",
+  "version": "0.1.1066",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -8,22 +8,20 @@ Use this guide to make a reviewed Git commit the source of a Veryfront
 deployment. The CI job pushes the checked-out source, creates an immutable
 release, and deploys that release to an environment.
 
-## Understand the Phase 0 boundary
+## Understand the trust boundary
 
-This workflow is a CI-mediated bridge, not an enforced repository connection.
-Veryfront does not yet know which Git repository is canonical. Existing Studio
-permissions can still allow direct edits to Veryfront `main`, and a project API
-key can upload the source present in its checkout. Veryfront does not open Git
-pull requests in this phase. A developer or repository-owned CI workflow can
-run the documented handoff commands, while review and conflict resolution stay
-in Git.
+This workflow uses CI as the bridge between Git and Veryfront. It is
+not an enforced repository connection, so Veryfront cannot verify which Git
+repository is canonical. Existing Studio permissions can still allow direct
+edits to Veryfront `main`, and a project API key can upload the source present
+in its checkout. Veryfront does not create Git pull requests as part of this
+workflow. A developer or repository-owned CI workflow runs the handoff
+commands, while review and conflict resolution stay in Git.
 
 Use one serialized CI writer for each Veryfront project, protect its API key,
-and use immutable releases for Studio-to-Git handoffs. The connected-repository
-phase adds exact-SHA server fetches, GitHub App verification, and automated pull
-requests.
+and use immutable releases for Studio-to-Git handoffs.
 
-Phase 0 depends on operating rules that Veryfront cannot enforce yet:
+This workflow depends on operating rules that Veryfront does not enforce:
 
 - Treat Git `main` as the canonical source.
 - Do not edit or publish directly from Studio `main`. Make citizen-developer
@@ -31,7 +29,7 @@ Phase 0 depends on operating rules that Veryfront cannot enforce yet:
   release.
 - After every Git merge, wait for CI to push the new `main` source into
   Veryfront before anyone starts new Studio work.
-- Start the pilot in staging. Enable production only after an Admin or Owner
+- Start with staging. Enable production only after an Admin or Owner
   approves the staging evidence described below.
 
 ## Prerequisites
@@ -39,7 +37,7 @@ Phase 0 depends on operating rules that Veryfront cannot enforce yet:
 - A Veryfront project with the `veryfront` package pinned in its lockfile.
 - A dedicated project API key stored in the CI secret manager.
 - The project slug stored as a CI variable.
-- A protected `staging` environment in Veryfront for the pilot.
+- A protected `staging` environment in Veryfront.
 - A protected `production` environment in Veryfront before promotion.
 - A CI job that runs after changes merge to `main`.
 - `.veryfront/` in `.gitignore` so local Push receipts are never committed.
@@ -65,7 +63,7 @@ the checkout as the reviewed commit.
 
 ## Preview the Push
 
-Preview the source reconciliation before the pilot changes Veryfront:
+Preview the source reconciliation before it changes Veryfront:
 
 ```bash title="Terminal"
 veryfront push --branch main --dry-run
@@ -106,7 +104,8 @@ defaults:
 ## Add a GitHub Actions workflow
 
 Add a workflow that serializes main updates and keeps the API key scoped to the
-deployment step. Keep this staging target while the pilot is under review:
+deployment step. Keep this staging target until production delivery is
+approved:
 
 ```yaml title=".github/workflows/deploy-veryfront.yml"
 name: Deploy Veryfront
@@ -175,15 +174,15 @@ same time. `cancel-in-progress: false` lets an active Push and Deploy sequence
 finish before the next run starts.
 
 The SHA check skips a queued workflow when a newer `main` commit already
-exists. It is a Phase 0 race reduction, not the exact-SHA enforcement provided
-by a connected repository.
+exists. This reduces races between queued CI runs, but it does not provide
+server-side exact-SHA enforcement.
 
 Do not start a new Studio change until this job has pushed the latest Git
 `main` source successfully. A Studio release created from an older baseline is
-a stale full snapshot, and the Phase 0 handoff does not auto-merge it with
-newer Git changes.
+a stale full snapshot, and the CLI handoff does not auto-merge it with newer
+Git changes.
 
-## Promote the pilot to production
+## Promote to production
 
 Before production promotion, require an Admin or Owner to verify and record all
 of these staging results in the team's normal change-management system:
@@ -195,7 +194,7 @@ of these staging results in the team's normal change-management system:
 - A smoke test passed against the staging deployment.
 - The team successfully rehearsed rollback by reverting a Git change and
   allowing the same CI workflow to deploy the resulting commit.
-- If Studio-to-Git handoff is in scope for the pilot, one immutable Studio
+- If Studio-to-Git handoff is in scope, one immutable Studio
   release completed the reviewed pull-request flow in
   [Move Studio changes into Git](./move-studio-changes-to-git.md).
 

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -8,20 +8,18 @@ Use this guide to make a reviewed Git commit the source of a Veryfront
 deployment. The CI job pushes the checked-out source, creates an immutable
 release, and deploys that release to an environment.
 
-## Understand the trust boundary
+## How the CI workflow works
 
-This workflow uses CI as the bridge between Git and Veryfront. It is
-not an enforced repository connection, so Veryfront cannot verify which Git
-repository is canonical. Existing Studio permissions can still allow direct
-edits to Veryfront `main`, and a project API key can upload the source present
-in its checkout. Veryfront does not create Git pull requests as part of this
-workflow. A developer or repository-owned CI workflow runs the handoff
-commands, while review and conflict resolution stay in Git.
+This workflow keeps repository access and deployment credentials inside
+repository-owned CI/CD. The trusted runner checks out the reviewed Git commit,
+tests it, pushes the source to Veryfront, and deploys an immutable release.
+Repository and protected-environment access remain with the trusted runner.
 
-Use one serialized CI writer for each Veryfront project, protect its API key,
-and use immutable releases for Studio-to-Git handoffs.
+Git `main` acts as the desired source state, similar to a GitOps workflow. Use
+one serialized CI writer for each Veryfront project, protect its API key, and
+use immutable releases for Studio-to-Git handoffs.
 
-This workflow depends on operating rules that Veryfront does not enforce:
+Use these operating controls:
 
 - Treat Git `main` as the canonical source.
 - Do not edit or publish directly from Studio `main`. Make citizen-developer
@@ -174,13 +172,11 @@ same time. `cancel-in-progress: false` lets an active Push and Deploy sequence
 finish before the next run starts.
 
 The SHA check skips a queued workflow when a newer `main` commit already
-exists. This reduces races between queued CI runs, but it does not provide
-server-side exact-SHA enforcement.
+exists. This prevents a queued job from reconciling superseded source.
 
 Do not start a new Studio change until this job has pushed the latest Git
 `main` source successfully. A Studio release created from an older baseline is
-a stale full snapshot, and the CLI handoff does not auto-merge it with newer
-Git changes.
+a stale full snapshot that requires a full Git diff and conflict review.
 
 ## Promote to production
 

--- a/docs/guides/move-studio-changes-to-git.md
+++ b/docs/guides/move-studio-changes-to-git.md
@@ -24,8 +24,8 @@ into Veryfront and deploy it to staging. Record that successful job's Git SHA.
 Do not start a new Studio change before this Push finishes.
 
 Create a non-main Studio branch for the citizen-developer change. Do not edit
-or publish directly from Studio `main`. Phase 0 cannot enforce this rule, so the
-team must apply it as part of the pilot operating procedure.
+or publish directly from Studio `main`. This CLI workflow cannot enforce the
+rule, so the team must apply it as part of its source-control policy.
 
 ## Create the Studio handoff
 
@@ -65,7 +65,7 @@ if [ "$CURRENT_MAIN_SHA" != "$BASE_GIT_SHA" ]; then
 fi
 ```
 
-For the safest pilot path, stop when these SHAs differ. Push the latest Git
+For the safest workflow, stop when these SHAs differ. Push the latest Git
 `main` source into Veryfront, recreate the Studio change, and publish a new
 release. If the professional developer deliberately continues, they own the
 full Git diff and every conflict resolution.
@@ -153,8 +153,8 @@ You can put the same Pull, test, commit, and `gh pr create` sequence in a
 repository-owned CI workflow. Require the release version and Studio base Git
 SHA as inputs, write both values into the pull request, and label a mismatch
 between the base SHA and current `main` as a stale full snapshot. Veryfront does
-not hold the Git credential or create the pull request in Phase 0; the
-repository workflow does.
+not hold the Git credential or create the pull request in this workflow; the
+repository-owned workflow does.
 
 ## Resolve conflicts in Git
 
@@ -173,8 +173,8 @@ from Studio.
 
 After the pull request merges, the normal CI workflow pushes the reviewed Git
 `main` source to Veryfront and creates the staging release and deployment
-during the pilot. The approved production workflow uses the same sequence.
-Wait for that Push before anyone starts another Studio change.
+when staging is configured. The approved production workflow uses the same
+sequence. Wait for that Push before anyone starts another Studio change.
 
 ## Verify it worked
 

--- a/docs/guides/move-studio-changes-to-git.md
+++ b/docs/guides/move-studio-changes-to-git.md
@@ -24,8 +24,8 @@ into Veryfront and deploy it to staging. Record that successful job's Git SHA.
 Do not start a new Studio change before this Push finishes.
 
 Create a non-main Studio branch for the citizen-developer change. Do not edit
-or publish directly from Studio `main`. This CLI workflow cannot enforce the
-rule, so the team must apply it as part of its source-control policy.
+or publish directly from Studio `main`. Apply this rule through the team's
+source-control policy and CI ownership.
 
 ## Create the Studio handoff
 
@@ -150,11 +150,10 @@ Studio base Git SHA. Reviewers can use those values to trace the handoff and
 identify a stale snapshot.
 
 You can put the same Pull, test, commit, and `gh pr create` sequence in a
-repository-owned CI workflow. Require the release version and Studio base Git
-SHA as inputs, write both values into the pull request, and label a mismatch
-between the base SHA and current `main` as a stale full snapshot. Veryfront does
-not hold the Git credential or create the pull request in this workflow; the
-repository-owned workflow does.
+repository-owned CI workflow. Keep the Git credential and pull request creation
+in that workflow. Require the release version and Studio base Git SHA as inputs,
+write both values into the pull request, and label a mismatch between the base
+SHA and current `main` as a stale full snapshot.
 
 ## Resolve conflicts in Git
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1065";
+export const VERSION = "0.1.1066";

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -98,7 +98,11 @@ describe("guide content contracts", () => {
 
     assertStringIncludes(guide, "same Git checkout and CI job");
     assertStringIncludes(guide, "cancel-in-progress: false");
-    assertStringIncludes(guide, "not an enforced repository connection");
+    assertStringIncludes(
+      guide,
+      "repository access and deployment credentials inside",
+    );
+    assertStringIncludes(guide, "similar to a GitOps workflow");
     assertStringIncludes(guide, "Skipping superseded main commit");
     assertStringIncludes(guide, "working-directory: apps/storefront");
     assertStringIncludes(guide, ".veryfront/` in `.gitignore");

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -106,7 +106,7 @@ describe("guide content contracts", () => {
     assertStringIncludes(guide, "RUNNER_TEMP");
     assertStringIncludes(guide, "NDJSON records");
     assertStringIncludes(guide, "git revert");
-    assertStringIncludes(guide, "Start the pilot in staging");
+    assertStringIncludes(guide, "Start with staging");
     assertStringIncludes(guide, "veryfront push --branch main --dry-run");
     assertStringIncludes(guide, "does not create a missing project or branch");
     assertStringIncludes(guide, "veryfront deploy --branch main --env staging --yes");
@@ -149,7 +149,7 @@ describe("guide content contracts", () => {
     assertEquals(guide.includes("veryfront pull --branch"), false);
   });
 
-  it("keeps the Phase 0 Pull safety contract in command help", async () => {
+  it("keeps the Pull safety contract in command help", async () => {
     const help = await Deno.readTextFile("cli/commands/pull/command-help.ts");
 
     assertStringIncludes(help, "full managed-source snapshot");


### PR DESCRIPTION
## Summary

- describe the existing Push and Deploy workflow as repository-owned CI/CD with a GitOps-style desired-source model
- keep GitHub repository access, protected-environment approval, and Git credentials inside the trusted CI runner
- replace rollout-stage terminology in the CI deployment and Studio-to-Git handoff guides with durable workflow language
- update the documentation contract names and bump the package patch version from `0.1.1065` to `0.1.1066`

## Validation

- `deno fmt --check` for all changed source and documentation files
- 33 documentation tests with 119 passing steps
- version synchronization tests with 21 passing steps
- repository pre-push checks: formatting, lint, type check, and 2,383 unit tests with 20,257 passing steps
- `git diff --check`

## Publication

`veryfront-code` remains the source of truth. The matching public guide update is tracked in veryfront/veryfront-docs#334.
