### PR TITLE
fix(discovery): embed integrations in compiled runtime

### DIFF
--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -13,6 +13,7 @@ describe("discovery/import-rewriter", () => {
         'import { projectKnowledge } from "veryfront/knowledge";',
         'import { step, workflow } from "veryfront/workflow";',
         'import { evalAgent } from "veryfront/eval";',
+        'import { executeRemoteIntegrationTool } from "veryfront/integrations";',
       ].join("\n"),
       "/project/workflows",
     );
@@ -22,6 +23,7 @@ describe("discovery/import-rewriter", () => {
     assertStringIncludes(transformed, import.meta.resolve("veryfront/knowledge"));
     assertStringIncludes(transformed, import.meta.resolve("veryfront/workflow"));
     assertStringIncludes(transformed, import.meta.resolve("veryfront/eval"));
+    assertStringIncludes(transformed, import.meta.resolve("veryfront/integrations"));
     assertEquals(transformed.includes('from "veryfront/'), false);
   });
 
@@ -33,6 +35,7 @@ describe("discovery/import-rewriter", () => {
         'import { projectKnowledge } from "veryfront/knowledge";',
         'import { step, workflow } from "veryfront/workflow";',
         'import { evalAgent } from "veryfront/eval";',
+        'import { executeRemoteIntegrationTool } from "veryfront/integrations";',
       ].join("\n"),
       "/project/workflows",
       { compiled: true },
@@ -57,6 +60,10 @@ describe("discovery/import-rewriter", () => {
     assertStringIncludes(
       transformed,
       'const { evalAgent } = globalThis.__VERYFRONT_MODULES__["veryfront/eval"]',
+    );
+    assertStringIncludes(
+      transformed,
+      'const { executeRemoteIntegrationTool } = globalThis.__VERYFRONT_MODULES__["veryfront/integrations"]',
     );
     assertEquals(transformed.includes('from "veryfront/'), false);
   });

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -22,6 +22,7 @@ export const DISCOVERY_GLOBAL_VERYFRONT_MODULES = [
   "veryfront/eval",
   "veryfront/metrics",
   "veryfront/schemas",
+  "veryfront/integrations",
   // Server-side chat upload route handler (app/api/uploads/route.ts).
   "veryfront/chat/uploads",
 ] as const;

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -32,6 +32,7 @@ import * as workflowMod from "#veryfront/workflow";
 import * as evalMod from "#veryfront/eval";
 import * as metricsMod from "#veryfront/metrics";
 import * as schemasMod from "#veryfront/schemas";
+import * as integrationsMod from "#veryfront/integrations/index.ts";
 import * as chatUploadsMod from "#veryfront/chat/uploads";
 
 type TranspileCacheEntry = {
@@ -116,6 +117,7 @@ async function ensureVeryfrontGlobals(): Promise<void> {
     "veryfront/eval": evalMod,
     "veryfront/metrics": metricsMod,
     "veryfront/schemas": schemasMod,
+    "veryfront/integrations": integrationsMod,
     "veryfront/chat/uploads": chatUploadsMod,
   } satisfies Record<(typeof DISCOVERY_GLOBAL_VERYFRONT_MODULES)[number], unknown>;
 


### PR DESCRIPTION
## Summary

- add the documented `veryfront/integrations` entrypoint to the compiled discovery module registry
- statically embed the module so temporary project modules can resolve it inside the hosted binary
- cover normal and compiled import rewriting with a regression test

## Root cause

Hosted discovery bundles project-authored tools into temporary modules. A compiled binary cannot resolve framework source paths from those files, so supported public imports are bridged through an embedded global registry. `veryfront/integrations` was exported publicly but missing from that registry, which caused Jira and GitHub wrapper modules to fail discovery.

This keeps the fix in the framework. Projects do not need `service.ts`, manual registries, private imports, or shared-runtime-specific code.

## Validation

- `deno test --no-check --allow-all src/discovery/import-rewriter.test.ts src/discovery/import-rewriter.metrics.test.ts`
- `deno task verify:quick`
- `deno task test:unit` (20,257 steps)
- `deno task test:e2e:binary:fresh` (59 compiled-binary steps)
- independent code review: no findings

## Rollout

After merge and framework release, deploy the server staging image and verify that a synchronized project release discovers all Jira and GitHub tools with zero module-resolution errors on the shared runtime. Confirm dedicated-runtime parity before closing the tracking issue.

Related: veryfront/veryfront-issue-inbox#38
