### PR TITLE
fix(cli): use listed content when pulling files

### DIFF
--- a/cli/commands/pull/command.test.ts
+++ b/cli/commands/pull/command.test.ts
@@ -42,6 +42,7 @@ function mockFilesResponse(paths: string[], next?: string): Promise<unknown> {
   return Promise.resolve({
     data: paths.map((path) => ({
       path,
+      content: `content for ${path}`,
       size: 100,
       type: "file",
       created_at: "",
@@ -427,6 +428,78 @@ describe("getFileContent", () => {
 });
 
 describe("pullCommand", () => {
+  it("writes listed content after every page loads without per-file requests", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+    let requestCount = 0;
+
+    try {
+      Deno.env.set("VERYFRONT_API_TOKEN", "token");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = new URL(String(input));
+        requestCount++;
+
+        assertEquals(url.pathname, "/projects/alpha/files");
+        assertEquals(await exists(join(tempDir, "app", "first.ts")), false);
+        assertEquals(await exists(join(tempDir, "app", "second.ts")), false);
+
+        if (requestCount === 1) {
+          assertEquals(url.searchParams.get("cursor"), null);
+          return Response.json({
+            data: [{
+              path: "app/first.ts",
+              content: "first page\n",
+              size: 11,
+              type: "file",
+              created_at: "",
+              updated_at: "",
+            }],
+            page_info: { next: "next-page" },
+          });
+        }
+
+        if (requestCount === 2) {
+          assertEquals(url.searchParams.get("cursor"), "next-page");
+          return Response.json({
+            data: [{
+              path: "app/second.ts",
+              content: "second page\n",
+              size: 12,
+              type: "file",
+              created_at: "",
+              updated_at: "",
+            }],
+            page_info: {},
+          });
+        }
+
+        throw new Error(`Pull made an unexpected per-file request: ${url}`);
+      }) as typeof fetch;
+
+      await pullCommand({
+        projectDir: tempDir,
+        projectSlug: "alpha",
+        force: true,
+        quiet: true,
+      });
+
+      assertEquals(requestCount, 2);
+      assertEquals(await Deno.readTextFile(join(tempDir, "app", "first.ts")), "first page\n");
+      assertEquals(
+        await Deno.readTextFile(join(tempDir, "app", "second.ts")),
+        "second page\n",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
   it("prunes managed local files missing from the selected Studio branch", async () => {
     const tempDir = await Deno.makeTempDir();
     const originalFetch = globalThis.fetch;
@@ -455,6 +528,7 @@ describe("pullCommand", () => {
               JSON.stringify({
                 data: [{
                   path: "app/keep.ts",
+                  content: "export default 1;",
                   size: 12,
                   type: "file",
                   created_at: "",
@@ -466,12 +540,7 @@ describe("pullCommand", () => {
             ),
           );
         }
-        return Promise.resolve(
-          new Response(JSON.stringify({ path: "app/keep.ts", content: "export default 1;" }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-        );
+        throw new Error(`Pruning pull made an unexpected per-file request: ${url}`);
       }) as typeof fetch;
 
       await pullCommand({
@@ -516,8 +585,8 @@ describe("pullCommand", () => {
           return Promise.resolve(
             Response.json({
               data: [
-                { path: "app/local-only.ts", size: 7, type: "file" },
-                { path: "assets/image.png", size: 7, type: "file" },
+                { path: "app/local-only.ts", content: "remote\n", size: 7, type: "file" },
+                { path: "assets/image.png", content: "binary", size: 7, type: "file" },
               ],
               page_info: {},
             }),
@@ -597,8 +666,8 @@ describe("pullCommand", () => {
         Promise.resolve(
           Response.json({
             data: [
-              { path: "app/page.ts", size: 7, type: "file" },
-              { path: "app/page.ts", size: 7, type: "file" },
+              { path: "app/page.ts", content: "first", size: 7, type: "file" },
+              { path: "app/page.ts", content: "second", size: 7, type: "file" },
             ],
             page_info: {},
           }),
@@ -684,6 +753,7 @@ describe("pullCommand", () => {
               JSON.stringify({
                 data: [{
                   path: "app/keep.ts",
+                  content: "new\n",
                   size: 12,
                   type: "file",
                   created_at: "",
@@ -753,7 +823,7 @@ describe("pullCommand", () => {
     }
   });
 
-  it("keeps prune candidates and fails when a remote file cannot be written", async () => {
+  it("leaves local files untouched when a later list page fails", async () => {
     const tempDir = await Deno.makeTempDir();
     const originalFetch = globalThis.fetch;
     const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
@@ -765,40 +835,30 @@ describe("pullCommand", () => {
       await initializeCleanTestGit(tempDir);
       Deno.env.set("VERYFRONT_API_TOKEN", "token");
       _resetEnvironmentConfig();
+      let requestCount = 0;
 
       globalThis.fetch = ((input: string | URL | Request) => {
         const url = String(input);
-        if (url.includes("/files?branch=studio-change")) {
+        requestCount++;
+        if (requestCount === 1) {
           return Promise.resolve(
             new Response(
               JSON.stringify({
-                data: [
-                  {
-                    path: "app/keep.ts",
-                    size: 12,
-                    type: "file",
-                    created_at: "",
-                    updated_at: "",
-                  },
-                  {
-                    path: "app/broken.ts",
-                    size: 12,
-                    type: "file",
-                    created_at: "",
-                    updated_at: "",
-                  },
-                ],
-                page_info: {},
+                data: [{
+                  path: "app/keep.ts",
+                  content: "new\n",
+                  size: 4,
+                  type: "file",
+                  created_at: "",
+                  updated_at: "",
+                }],
+                page_info: { next: "next-page" },
               }),
               { status: 200, headers: { "content-type": "application/json" } },
             ),
           );
         }
-        if (url.includes("app%2Fkeep.ts")) {
-          return Promise.resolve(
-            Response.json({ path: "app/keep.ts", content: "new\n" }),
-          );
-        }
+        assertStringIncludes(url, "cursor=next-page");
         return Promise.resolve(
           new Response(JSON.stringify({ error: "failed" }), {
             status: 500,
@@ -820,7 +880,8 @@ describe("pullCommand", () => {
         Error,
       );
 
-      assertStringIncludes(describeTestError(error), "Failed to pull");
+      assertEquals(requestCount, 2);
+      assertStringIncludes(describeTestError(error), "Failed to list files");
       assertEquals(await Deno.readTextFile(join(tempDir, "app", "keep.ts")), "old\n");
       assertEquals(await exists(join(tempDir, "app", "remove.ts")), true);
     } finally {
@@ -941,15 +1002,17 @@ describe("pullCommand", () => {
       globalThis.fetch = ((input: string | URL | Request) => {
         const url = String(input);
         const project = url.includes("/projects/alpha/") ? "alpha" : "beta";
-        if (!url.includes("app.ts")) {
-          return Promise.resolve(
-            Response.json({
-              data: [{ path: "app.ts", size: 10, type: "file" }],
-              page_info: {},
-            }),
-          );
-        }
-        return Promise.resolve(Response.json({ path: "app.ts", content: `${project} new\n` }));
+        return Promise.resolve(
+          Response.json({
+            data: [{
+              path: "app.ts",
+              content: `${project} new\n`,
+              size: 10,
+              type: "file",
+            }],
+            page_info: {},
+          }),
+        );
       }) as typeof fetch;
 
       await pullCommand({
@@ -987,6 +1050,7 @@ describe("pullCommand", () => {
             JSON.stringify({
               data: [{
                 path: "../outside.ts",
+                content: "outside",
                 size: 12,
                 type: "file",
                 created_at: "",
@@ -1040,6 +1104,7 @@ describe("pullCommand", () => {
               JSON.stringify({
                 data: [{
                   path: "app/page.tsx",
+                  content: "outside",
                   size: 12,
                   type: "file",
                   created_at: "",
@@ -1051,12 +1116,7 @@ describe("pullCommand", () => {
             ),
           );
         }
-        return Promise.resolve(
-          new Response(JSON.stringify({ path: "app/page.tsx", content: "outside" }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-        );
+        throw new Error(`Pull made an unexpected per-file request: ${url}`);
       }) as typeof fetch;
 
       const error = await assertRejects(
@@ -1100,6 +1160,7 @@ describe("pullCommand", () => {
               JSON.stringify({
                 data: [{
                   path: "app/page.tsx",
+                  content: "export default null;",
                   size: 10,
                   type: "file",
                   created_at: "",
@@ -1111,12 +1172,7 @@ describe("pullCommand", () => {
             ),
           );
         }
-        return Promise.resolve(
-          new Response(JSON.stringify({ path: "app/page.tsx", content: "export default null;" }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-        );
+        throw new Error(`Pull made an unexpected per-file request: ${url}`);
       }) as typeof fetch;
 
       const error = await assertRejects(
@@ -1202,6 +1258,7 @@ describe("pullCommand", () => {
               JSON.stringify({
                 data: [{
                   path: "app/page.tsx",
+                  content: "export default null;",
                   size: 12,
                   type: "file",
                   created_at: "2026-01-01T00:00:00Z",
@@ -1214,12 +1271,7 @@ describe("pullCommand", () => {
           );
         }
 
-        return Promise.resolve(
-          new Response(JSON.stringify({ path: "app/page.tsx", content: "export default null;" }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-        );
+        throw new Error(`Pull made an unexpected per-file request: ${url}`);
       }) as typeof fetch;
 
       const error = await assertRejects(

--- a/cli/commands/pull/command.ts
+++ b/cli/commands/pull/command.ts
@@ -122,6 +122,7 @@ export function resolvePullSource(options: PullOptions): PullSource {
 
 interface ProjectFile {
   path: string;
+  content: string;
   size: number;
   type: string;
   created_at: string;
@@ -136,9 +137,13 @@ interface ListFilesResponse {
   };
 }
 
-interface WriteOp {
+interface ValidatedFilePath {
   path: string;
   relativePath: string;
+}
+
+interface WriteOp extends ValidatedFilePath {
+  content: string;
 }
 
 interface DeleteOp {
@@ -183,7 +188,10 @@ export function validateRemoteFilePath(filePath: string): string {
 }
 
 /** Resolve a validated remote path and reject local symlink traversal. */
-async function validateFilePath(filePath: string, projectDir: string): Promise<WriteOp> {
+async function validateFilePath(
+  filePath: string,
+  projectDir: string,
+): Promise<ValidatedFilePath> {
   const canonicalPath = validateRemoteFilePath(filePath);
   const resolvedProjectDir = resolve(projectDir);
   const fullPath = resolve(resolvedProjectDir, canonicalPath);
@@ -313,31 +321,11 @@ export async function getFileContent(
   return response.content;
 }
 
-/** Concurrency limit for parallel file fetches */
+/** Concurrency limit for parallel file writes. */
 const CONCURRENCY = 20;
 
-interface PreparedWriteOp extends WriteOp {
-  content: string;
-}
-
-async function fetchFile(
+async function writeFile(
   op: WriteOp,
-  client: ReturnType<typeof createApiClient>,
-  projectSlug: string,
-  source: PullSource,
-): Promise<
-  { success: true; op: PreparedWriteOp } | { success: false; error: Error; path: string }
-> {
-  try {
-    const content = await getFileContent(client, projectSlug, op.relativePath, source);
-    return { success: true, op: { ...op, content } };
-  } catch (error) {
-    return { success: false, path: op.relativePath, error: error as Error };
-  }
-}
-
-async function writePreparedFile(
-  op: PreparedWriteOp,
   fs: ReturnType<typeof createFileSystem>,
 ): Promise<{ success: boolean; path: string; error?: Error }> {
   try {
@@ -351,9 +339,6 @@ async function writePreparedFile(
 
 async function writeFiles(
   ops: WriteOp[],
-  client: ReturnType<typeof createApiClient>,
-  projectSlug: string,
-  source: PullSource,
   dryRun: boolean,
 ): Promise<{ written: number; failed: number }> {
   if (dryRun) {
@@ -362,33 +347,13 @@ async function writeFiles(
   }
 
   const fs = createFileSystem();
-  const prepared: PreparedWriteOp[] = [];
   let failed = 0;
+  let written = 0;
 
   for (let i = 0; i < ops.length; i += CONCURRENCY) {
     const batch = ops.slice(i, i + CONCURRENCY);
     const results = await Promise.all(
-      batch.map((op) => fetchFile(op, client, projectSlug, source)),
-    );
-
-    for (const result of results) {
-      if (result.success) {
-        prepared.push(result.op);
-        continue;
-      }
-      cliLogger.error(`Failed to fetch ${result.path}:`, result.error);
-      failed++;
-    }
-  }
-
-  if (failed > 0) return { written: 0, failed };
-
-  let written = 0;
-
-  for (let i = 0; i < prepared.length; i += CONCURRENCY) {
-    const batch = prepared.slice(i, i + CONCURRENCY);
-    const results = await Promise.all(
-      batch.map((op) => writePreparedFile(op, fs)),
+      batch.map((op) => writeFile(op, fs)),
     );
 
     for (const result of results) {
@@ -655,21 +620,13 @@ async function pullSingleProject(
   const writeOps: WriteOp[] = [];
   const remotePaths = new Set<string>();
   for (const file of files) {
+    let op: ValidatedFilePath;
     try {
-      const op = await validateFilePath(file.path, projectDir);
+      op = await validateFilePath(file.path, projectDir);
       if (remotePaths.has(op.relativePath)) {
         throw new Error(`Duplicate remote file path: "${op.relativePath}"`);
       }
       remotePaths.add(op.relativePath);
-
-      if (
-        pruneIgnoreChecker &&
-        (pruneIgnoreChecker.isIgnored(op.relativePath) ||
-          !pruneIgnoreChecker.isSupportedExtension(op.relativePath))
-      ) {
-        continue;
-      }
-      writeOps.push(op);
     } catch (error) {
       throw INVALID_ARGUMENT.create({
         detail: `Veryfront returned an invalid file path "${file.path}": ${
@@ -678,6 +635,21 @@ async function pullSingleProject(
         cause: error,
       });
     }
+
+    if (
+      pruneIgnoreChecker &&
+      (pruneIgnoreChecker.isIgnored(op.relativePath) ||
+        !pruneIgnoreChecker.isSupportedExtension(op.relativePath))
+    ) {
+      continue;
+    }
+    if (typeof file.content !== "string") {
+      throw INVALID_ARGUMENT.create({
+        detail:
+          `Veryfront returned invalid content for file "${file.path}". No local files were changed.`,
+      });
+    }
+    writeOps.push({ ...op, content: file.content });
   }
 
   let deleteOps: DeleteOp[] = [];
@@ -711,7 +683,7 @@ async function pullSingleProject(
 
   spinner = quiet ? createNoopSpinner() : createSpinner(`Writing files to ${projectDir}...`);
 
-  const writeResult = await writeFiles(writeOps, client, projectSlug, source, dryRun);
+  const writeResult = await writeFiles(writeOps, dryRun);
 
   if (writeResult.failed > 0) {
     spinner.stop();

--- a/cli/commands/pull/pull.integration.test.ts
+++ b/cli/commands/pull/pull.integration.test.ts
@@ -36,6 +36,7 @@ describe("pull command integration", () => {
       if (!first) return;
 
       assertExists(first.path);
+      assertEquals(typeof first.content, "string");
       assertExists(first.size);
       assertExists(first.type);
     });

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1066",
+  "version": "0.1.1067",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1066";
+export const VERSION = "0.1.1067";


### PR DESCRIPTION
## Summary

- write file content already returned by paginated list endpoints
- remove redundant per-file GETs from `veryfront pull`
- preserve full pagination, path/content validation, write failure handling, and prune ordering
- add regression coverage for no N+1 requests and no writes when a later list page fails

## Why

A CI pull of an immutable 111-file release made two list requests and then 111 redundant content requests. The 20-request bursts raced the API-key verification limiter and produced intermittent `401 Unauthorized` failures. Using the list response is both the simpler contract and removes that failure mode.

## Validation

- focused pull unit and VCR integration tests
- version tests
- formatting, lint, CLI boundary, manifest checks, and full typecheck

Version: `0.1.1067`.