### PR TITLE
chore(release): bump version to 0.1.1068

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1067",
+  "version": "0.1.1068",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1067";
+export const VERSION = "0.1.1068";


### PR DESCRIPTION
## Summary

- release the merged shared-routing convergence fix from veryfront/veryfront-studio#2917
- release the merged hosted compiled integration discovery fix from veryfront/veryfront-studio#2929
- keep the runtime and package version constants synchronized at `0.1.1068`

## Validation

- `deno fmt --check deno.json src/utils/version-constant.ts`
- version synchronization and stable release-intent tests: 2 tests, 25 passing steps
- repository pre-push checks: formatting, lint, typecheck, and 2,386 tests with 20,283 passing steps
- `git diff --check`

## Rollout

After publication, update the server framework dependency and deploy it to staging. Verify shared and dedicated discovery plus routing convergence canaries before promoting the server release to production.

Related: veryfront/veryfront-issue-inbox#39
Related: veryfront/veryfront-issue-inbox#38