### PR TITLE
fix(cli): retry idempotent file uploads

### DIFF
--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -495,6 +495,55 @@ describe("createApiClient", () => {
         globalThis.fetch = originalFetch;
       }
     });
+
+    it("retries PUT after a nested ECONNRESET and preserves the request body", async () => {
+      let callCount = 0;
+      const requestBodies: string[] = [];
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, init?: RequestInit) => {
+        callCount++;
+        requestBodies.push(String(init?.body));
+        if (callCount === 1) {
+          const cause = Object.assign(new Error("read failed"), { code: "ECONNRESET" });
+          return Promise.reject(new TypeError("fetch failed", { cause }));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ updated: true }), { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        const result = await client.put<{ updated: boolean }>("/test", { content: "same" });
+        assertEquals(result.updated, true);
+        assertEquals(callCount, 2);
+        assertEquals(requestBodies, [
+          JSON.stringify({ content: "same" }),
+          JSON.stringify({ content: "same" }),
+        ]);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("retries PUT on 502 and succeeds on the second attempt", async () => {
+      let callCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(new Response("bad gateway", { status: 502 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ updated: true }), { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        const result = await client.put<{ updated: boolean }>("/test", { content: "same" });
+        assertEquals(result.updated, true);
+        assertEquals(callCount, 2);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
   });
 
   describe("retry behavior for non-idempotent requests", () => {
@@ -554,6 +603,28 @@ describe("createApiClient", () => {
           () => client.post("/test", {}),
           Error,
           "connection reset",
+        );
+        assertEquals(callCount, 1);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("does NOT retry POST when fetch wraps ECONNRESET in a cause", async () => {
+      let callCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+        callCount++;
+        const cause = Object.assign(new Error("read failed"), { code: "ECONNRESET" });
+        return Promise.reject(new TypeError("fetch failed", { cause }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        await assertRejects(
+          () => client.post("/test", {}),
+          TypeError,
+          "fetch failed",
         );
         assertEquals(callCount, 1);
       } finally {

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -15,7 +15,7 @@ import { cliLogger, VERSION } from "#cli/utils";
 import { readToken } from "../auth/token-store.ts";
 import { ensureAuthenticated } from "../auth/login.ts";
 import { resolveCliApiUrl } from "./constants.ts";
-import { isRetryableConnectionError } from "../../src/proxy/retry.ts";
+import { isConnectionRefusedError, isRetryableConnectionError } from "../../src/proxy/retry.ts";
 
 // Delays for exponential backoff with jitter: attempt 1 = ~300ms, 2 = ~1s, 3 = ~3s
 const API_RETRY_DELAYS_MS = [300, 1000, 3000] as const;
@@ -24,13 +24,6 @@ const API_MAX_RETRIES = 3;
 /** Returns true for HTTP status codes that indicate a transient gateway failure. */
 function isTransientStatus(status: number): boolean {
   return status === 502 || status === 503 || status === 504;
-}
-
-/** Returns true when the connection error is a refused connection (request never reached server). */
-function isConnectionRefused(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const msg = error.message.toLowerCase();
-  return msg.includes("connection refused") || msg.includes("os error 111");
 }
 
 /** Sleep for `ms` milliseconds plus a random jitter up to 20% of `ms`. */
@@ -392,7 +385,7 @@ export function createApiClient(config: ResolvedConfig): ApiClient {
 
   /** Returns true for request methods that are safe to retry on any transient failure. */
   function isIdempotent(method: string): boolean {
-    return method === "GET" || method === "HEAD";
+    return method === "GET" || method === "HEAD" || method === "PUT";
   }
 
   async function request<T>(
@@ -420,7 +413,7 @@ export function createApiClient(config: ResolvedConfig): ApiClient {
         const isTransient = status !== undefined
           ? isTransientStatus(status)
           : isRetryableConnectionError(error);
-        const isRefused = isConnectionRefused(error);
+        const isRefused = isConnectionRefusedError(error);
 
         // Idempotent: retry on transient HTTP status or any retryable connection error.
         // Non-idempotent: retry only on connection-refused (request never reached server).

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1067",
+  "version": "0.1.1068",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/proxy/retry.test.ts
+++ b/src/proxy/retry.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts
 import {
   getReplayableRequestBodies,
   getUpstreamRetryCount,
+  isConnectionRefusedError,
   isRetryableConnectionError,
   shouldRetryUpstreamRequest,
 } from "./retry.ts";
@@ -52,7 +53,7 @@ describe("isRetryableConnectionError", () => {
     assertEquals(isRetryableConnectionError(new Error("os error 111")), true);
   });
 
-  it("returns false for timeout errors", () => {
+  it("does not infer retryability from generic timeout messages", () => {
     assertEquals(isRetryableConnectionError(new Error("Request timeout")), false);
     assertEquals(isRetryableConnectionError(new Error("Gateway timeout")), false);
   });
@@ -91,6 +92,25 @@ describe("isRetryableConnectionError", () => {
       ),
       true,
     );
+  });
+
+  it("recognizes retryable codes in nested fetch causes", () => {
+    const cause = Object.assign(new Error("read failed"), { code: "ECONNRESET" });
+    const error = new TypeError("fetch failed", { cause });
+    const timeout = Object.assign(new Error("request failed"), { code: "ETIMEDOUT" });
+    const refused = Object.assign(new Error("connect failed"), { code: "ECONNREFUSED" });
+
+    assertEquals(isRetryableConnectionError(error), true);
+    assertEquals(isRetryableConnectionError(timeout), true);
+    assertEquals(isConnectionRefusedError(new TypeError("fetch failed", { cause: refused })), true);
+  });
+
+  it("handles cyclic cause chains", () => {
+    const error = new Error("fetch failed");
+    Object.defineProperty(error, "cause", { value: error });
+
+    assertEquals(isRetryableConnectionError(error), false);
+    assertEquals(isConnectionRefusedError(error), false);
   });
 });
 

--- a/src/proxy/retry.ts
+++ b/src/proxy/retry.ts
@@ -5,29 +5,67 @@
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 
 const CONTROL_PLANE_RUN_STREAM_PATH = /^\/api\/control-plane\/runs\/[^/]+\/stream$/;
+const MAX_ERROR_CAUSE_DEPTH = 8;
+const RETRYABLE_CONNECTION_CODES = new Set(["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT"]);
+const CONNECTION_REFUSED_CODES = new Set(["ECONNREFUSED"]);
 
 type RequestBodyReplayKind = "bodyless" | "bounded" | "unsupported";
+
+interface ErrorDetails {
+  message?: unknown;
+  code?: unknown;
+  cause?: unknown;
+}
+
+function errorChainMatches(
+  error: unknown,
+  predicate: (message: string, code: string) => boolean,
+): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const seen = new Set<object>();
+  let current: unknown = error;
+
+  for (let depth = 0; depth < MAX_ERROR_CAUSE_DEPTH; depth++) {
+    if (typeof current !== "object" || current === null || seen.has(current)) return false;
+    seen.add(current);
+
+    const details = current as ErrorDetails;
+    const message = typeof details.message === "string" ? details.message.toLowerCase() : "";
+    const code = typeof details.code === "string" ? details.code.toUpperCase() : "";
+    if (predicate(message, code)) return true;
+
+    current = details.cause;
+  }
+
+  return false;
+}
 
 /**
  * Check if a fetch error is a transient connection error worth retrying.
  * These occur when renderer pods are being recycled or temporarily unavailable.
  */
 export function isRetryableConnectionError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const msg = error.message.toLowerCase();
-  return (
-    msg.includes("connection reset") ||
-    msg.includes("connection closed") ||
-    msg.includes("connection refused") ||
-    msg.includes("os error 104") || // ECONNRESET
-    msg.includes("os error 111") // ECONNREFUSED
+  return errorChainMatches(
+    error,
+    (message, code) =>
+      RETRYABLE_CONNECTION_CODES.has(code) ||
+      message.includes("connection reset") ||
+      message.includes("connection closed") ||
+      message.includes("connection refused") ||
+      message.includes("os error 104") || // ECONNRESET
+      message.includes("os error 111"), // ECONNREFUSED
   );
 }
 
-function isConnectionRefusedError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const message = error.message.toLowerCase();
-  return message.includes("connection refused") || message.includes("os error 111");
+export function isConnectionRefusedError(error: unknown): boolean {
+  return errorChainMatches(
+    error,
+    (message, code) =>
+      CONNECTION_REFUSED_CODES.has(code) ||
+      message.includes("connection refused") ||
+      message.includes("os error 111"),
+  );
 }
 
 function isIdempotentMethod(method: string): boolean {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1067";
+export const VERSION = "0.1.1068";


### PR DESCRIPTION
## Summary

- classify transient connection failures through bounded, cycle-safe error cause chains and standard network error codes
- retry idempotent CLI `PUT` requests with the existing bounded backoff, including Node fetch errors that wrap `ECONNRESET`
- keep non-idempotent `POST` requests single-shot after connection resets
- bump Veryfront from `0.1.1067` to `0.1.1068`

## Context

A Veryfront Cloud push failed after 110 successful file uploads because Node fetch reported `TypeError: fetch failed` with nested `ECONNRESET`. Version `0.1.1067` neither recognized the nested cause nor retried file `PUT` requests.

Failed job: https://github.com/veryfront/veryfront-ops-agent/actions/runs/29328179660/job/87069567891

## Validation

- `VF_DISABLE_LRU_INTERVAL=1 deno test --frozen --no-check --allow-all src/proxy/retry.test.ts cli/shared/config.test.ts` (8 suites, 52 steps)
- `deno check --frozen cli/shared/config.ts src/proxy/retry.ts`
- `deno task verify:quick`
- pre-push suite (2,386 tests, 20,288 steps)