### PR TITLE
fix(agent): classify returned MCP errors before success guards

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -376,6 +376,7 @@ async function traceConfiguredToolExecution(input: {
           input.allowedRemoteToolNames,
           input.remoteToolSources,
         );
+        const resultError = getToolResultError(result);
         setOtelActiveSpanAttributes(
           buildRuntimeToolTraceAttributes({
             mode: input.mode,
@@ -383,10 +384,12 @@ async function traceConfiguredToolExecution(input: {
             toolName: input.toolName,
             toolCallId: input.toolCallId,
             context: input.context,
-            status: "completed",
+            status: resultError === undefined ? "completed" : "failed",
             providerExecuted: false,
             inputSizeBytes,
             outputSizeBytes: estimateSerializedSizeBytes(result),
+            errorType: resultError === undefined ? undefined : "ToolResultError",
+            errorMessage: resultError,
           }),
         );
         return result;
@@ -1137,36 +1140,47 @@ export class AgentRuntime {
                 context: executionContext,
               });
 
-              toolCall.status = "completed";
+              const resultError = getToolResultError(result);
+              toolCall.status = resultError === undefined ? "completed" : "error";
               toolCall.result = result;
+              toolCall.error = resultError;
               toolCall.executionTime = Date.now() - startTime;
               setSpanAttributes(
                 toolSpan,
                 compactRuntimeTraceAttributes({
-                  "tool.status": "completed",
+                  "tool.status": resultError === undefined ? "completed" : "failed",
                   "tool.provider_executed": false,
                   "tool.output.size_bytes": estimateSerializedSizeBytes(result),
+                  ...(resultError === undefined ? {} : {
+                    error: true,
+                    "error.type": "ToolResultError",
+                    "error.message": resultError,
+                  }),
                 }),
               );
 
-              // Track skill policy from load_skill results
-              if (tc.toolName === LOAD_SKILL_TOOL_ID) {
-                activeSkillId = extractSkillId(result);
-                activeSkillPolicy = extractSkillPolicy(result);
-                activeSkillToolAvailability = extractSkillToolAvailability(result) ??
-                  INACTIVE_SKILL_TOOL_AVAILABILITY;
-                activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
-                mustLoadSkillFirst = false;
-              }
-              activeSkillPolicy = removeFormInputAfterSubmission(
-                tc.toolName,
-                result,
-                activeSkillId,
-                activeSkillPolicy,
-              );
-              if (isSubmittedFormInputExecutionResult(tc.toolName, result)) {
-                hasSubmittedFormInputInLoop = true;
-                currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
+              if (resultError === undefined) {
+                // Track skill policy from successful load_skill results
+                if (tc.toolName === LOAD_SKILL_TOOL_ID) {
+                  activeSkillId = extractSkillId(result);
+                  activeSkillPolicy = extractSkillPolicy(result);
+                  activeSkillToolAvailability = extractSkillToolAvailability(result) ??
+                    INACTIVE_SKILL_TOOL_AVAILABILITY;
+                  activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
+                  mustLoadSkillFirst = false;
+                }
+                activeSkillPolicy = removeFormInputAfterSubmission(
+                  tc.toolName,
+                  result,
+                  activeSkillId,
+                  activeSkillPolicy,
+                );
+                if (isSubmittedFormInputExecutionResult(tc.toolName, result)) {
+                  hasSubmittedFormInputInLoop = true;
+                  currentRuntimeContext = markSubmittedFormInputRuntimeContext(
+                    currentRuntimeContext,
+                  );
+                }
               }
 
               const toolResultMessage = createToolResultMessage(
@@ -1683,41 +1697,54 @@ export class AgentRuntime {
             context: executionContext,
           });
 
-          toolCall.status = "completed";
+          const resultError = getToolResultError(result);
+          toolCall.status = resultError === undefined ? "completed" : "error";
           toolCall.result = result;
+          toolCall.error = resultError;
           toolCall.executionTime = Date.now() - startTime;
           toolCalls.push(toolCall);
 
-          // Track skill policy from load_skill results
-          if (tc.name === LOAD_SKILL_TOOL_ID) {
-            activeSkillId = extractSkillId(result);
-            activeSkillPolicy = extractSkillPolicy(result);
-            activeSkillToolAvailability = extractSkillToolAvailability(result) ??
-              INACTIVE_SKILL_TOOL_AVAILABILITY;
-            activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
-            mustLoadSkillFirst = false;
-          }
-          activeSkillPolicy = removeFormInputAfterSubmission(
-            tc.name,
-            result,
-            activeSkillId,
-            activeSkillPolicy,
-          );
-          if (isSubmittedFormInputExecutionResult(tc.name, result)) {
-            hasSubmittedFormInputInLoop = true;
-            currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
-          }
-          if (shouldHideProjectToolAfterAgentWriteSuccess(tc.name)) {
-            agentWriteFinalResponseToolGuardEnabled = true;
+          if (resultError === undefined) {
+            // Track skill policy from successful load_skill results
+            if (tc.name === LOAD_SKILL_TOOL_ID) {
+              activeSkillId = extractSkillId(result);
+              activeSkillPolicy = extractSkillPolicy(result);
+              activeSkillToolAvailability = extractSkillToolAvailability(result) ??
+                INACTIVE_SKILL_TOOL_AVAILABILITY;
+              activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
+              mustLoadSkillFirst = false;
+            }
+            activeSkillPolicy = removeFormInputAfterSubmission(
+              tc.name,
+              result,
+              activeSkillId,
+              activeSkillPolicy,
+            );
+            if (isSubmittedFormInputExecutionResult(tc.name, result)) {
+              hasSubmittedFormInputInLoop = true;
+              currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
+            }
+            if (shouldHideProjectToolAfterAgentWriteSuccess(tc.name)) {
+              agentWriteFinalResponseToolGuardEnabled = true;
+            }
           }
 
           const dynamic = isDynamicTool(tc.name);
-          sendSSE(controller, encoder, {
-            type: "tool-output-available",
-            toolCallId: toolCall.id,
-            output: result,
-            ...(dynamic ? { dynamic: true } : {}),
-          });
+          if (resultError === undefined) {
+            sendSSE(controller, encoder, {
+              type: "tool-output-available",
+              toolCallId: toolCall.id,
+              output: result,
+              ...(dynamic ? { dynamic: true } : {}),
+            });
+          } else {
+            sendSSE(controller, encoder, {
+              type: "tool-output-error",
+              toolCallId: toolCall.id,
+              errorText: resultError,
+              ...(dynamic ? { dynamic: true } : {}),
+            });
+          }
 
           const toolResultMessage = createToolResultMessage(tc.id, tc.name, result);
           if (!currentStepToolResults.has(tc.id)) {

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -5,7 +5,12 @@ import { type ModelRuntime } from "#veryfront/provider";
 import { tool } from "#veryfront/tool";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { agent } from "../index.ts";
-import type { Message, RuntimeStateRequest, ToolExecutionResultRequest } from "../types.ts";
+import type {
+  AgentResponse,
+  Message,
+  RuntimeStateRequest,
+  ToolExecutionResultRequest,
+} from "../types.ts";
 
 function createRuntimeStream(parts: unknown[]) {
   return new ReadableStream<unknown>({
@@ -205,6 +210,82 @@ describe("agent runtime refresh hooks", () => {
       projectId: "project-generate",
     });
     assertEquals(toolResults[0]?.context?.projectId, "project-generate");
+  });
+
+  it("classifies structured errors returned during generate()", async () => {
+    const toolNamesByStep: string[][] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      async doGenerate(options) {
+        const rawTools = (options as { tools?: unknown }).tools;
+        const toolNames = Array.isArray(rawTools)
+          ? rawTools.map((entry) =>
+            (entry as { name?: string; id?: string }).name ??
+              (entry as { name?: string; id?: string }).id ?? ""
+          )
+          : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
+        toolNamesByStep.push(toolNames);
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            content: [{
+              type: "tool-call",
+              toolCallId: "update-agent-generate-error-1",
+              toolName: "update_agent",
+              input: '{"id":"jira-agent"}',
+            }],
+            finishReason: "tool-calls",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          };
+        }
+
+        return {
+          content: [{ type: "text", text: "I can retry with the required input." }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        return {
+          stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]),
+        };
+      },
+    };
+
+    const updateError = {
+      error: "tool_error",
+      message: "Invalid input - system: system or system_prompt is required",
+    };
+    const updateAgent = tool({
+      id: "update_agent",
+      description: "Update a Studio project agent",
+      inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+      execute: () => updateError,
+    });
+
+    const assistant = agent({
+      model: "anthropic/claude-sonnet-4-6",
+      system: "Update agents and recover from failed tool calls.",
+      tools: { update_agent: updateAgent },
+      providerTools: ["web_search", "web_fetch"],
+      maxSteps: 3,
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    const response = await assistant.generate({
+      input: "Attach the project skill to my Jira agent",
+    });
+
+    assertEquals(toolNamesByStep.length, 2);
+    assertEquals(toolNamesByStep[1]?.includes("update_agent"), true);
+    assertEquals(toolNamesByStep[1]?.includes("web_search"), true);
+    assertEquals(toolNamesByStep[1]?.includes("web_fetch"), true);
+    assertEquals(response.toolCalls[0]?.status, "error");
+    assertEquals(response.toolCalls[0]?.error, updateError.message);
+    assertEquals(response.toolCalls[0]?.result, updateError);
   });
 
   it("removes provider-native tools from the forced final response after create_agent", async () => {
@@ -534,6 +615,104 @@ describe("agent runtime refresh hooks", () => {
     assertEquals(toolNamesByStep[1]?.includes("create_agent"), true);
     assertEquals(toolNamesByStep[1]?.includes("web_search"), true);
     assertEquals(toolNamesByStep[1]?.includes("web_fetch"), true);
+  });
+
+  it("keeps tools available after update_agent returns a structured error", async () => {
+    const toolNamesByStep: string[][] = [];
+    let callCount = 0;
+    let finishedResponse: AgentResponse | undefined;
+    const model: ModelRuntime = {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream(options) {
+        const rawTools = (options as { tools?: unknown }).tools;
+        const toolNames = Array.isArray(rawTools)
+          ? rawTools.map((entry) =>
+            (entry as { name?: string; id?: string }).name ??
+              (entry as { name?: string; id?: string }).id ?? ""
+          )
+          : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
+        toolNamesByStep.push(toolNames);
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            stream: createRuntimeStream([
+              {
+                type: "tool-call",
+                toolCallId: "update-agent-error-1",
+                toolName: "update_agent",
+                input: '{"id":"jira-agent"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "I can retry with the required input." },
+            {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1 },
+            },
+          ]),
+        };
+      },
+    };
+
+    const updateError = {
+      error: "tool_error",
+      message: "Invalid input - system: system or system_prompt is required",
+    };
+    const updateAgent = tool({
+      id: "update_agent",
+      description: "Update a Studio project agent",
+      inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+      execute: () => updateError,
+    });
+
+    const assistant = agent({
+      model: "anthropic/claude-sonnet-4-6",
+      system: "Update agents and recover from failed tool calls.",
+      tools: { update_agent: updateAgent },
+      providerTools: ["web_search", "web_fetch"],
+      maxSteps: 3,
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    const response = (await assistant.stream({
+      input: "Attach the project skill to my Jira agent",
+      onFinish: (result) => {
+        finishedResponse = result;
+      },
+    })).toDataStreamResponse();
+
+    const streamBody = await response.text();
+    assertEquals(toolNamesByStep.length, 2);
+    assertEquals(toolNamesByStep[0]?.includes("update_agent"), true);
+    assertEquals(toolNamesByStep[1]?.includes("update_agent"), true);
+    assertEquals(toolNamesByStep[1]?.includes("web_search"), true);
+    assertEquals(toolNamesByStep[1]?.includes("web_fetch"), true);
+    assertEquals(streamBody.includes('"type":"tool-output-error"'), true);
+    assertEquals(streamBody.includes('"type":"tool-output-available"'), false);
+    assertEquals(streamBody.includes(updateError.message), true);
+    assertExists(finishedResponse);
+    assertEquals(finishedResponse.toolCalls[0]?.status, "error");
+    assertEquals(finishedResponse.toolCalls[0]?.error, updateError.message);
+    assertEquals(finishedResponse.toolCalls[0]?.result, updateError);
   });
 
   it("keeps skill file tools hidden after a failed load_skill attempt", async () => {


### PR DESCRIPTION
## Summary

- Classify normalized MCP `{ error, message }` return values before success-only runtime state changes.
- Emit `tool-output-error` while preserving the structured result for model recovery.
- Keep agent-write and provider retry tools available after returned failures.

## Testing

- Runtime unit suite: 179 files / 421 steps.
- `deno check src/index.ts`.
- `deno fmt --check`.
- `deno lint`.
- Repository pre-push hook, including the full unit suite.

## Residual risk

- Deployed Studio replay remains pending.
- Standard OpenTelemetry span status for non-throwing tool failures is pre-existing debt; this change records failed tool attributes but does not change the tracing-helper contract.

Companion: veryfront/veryfront-api#3951

Addresses veryfront/veryfront-studio#5906