### PR TITLE
Release MCP tool-error recovery in Veryfront 0.1.1069

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1068",
+  "version": "0.1.1069",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1068";
+export const VERSION = "0.1.1069";


### PR DESCRIPTION
## Release trigger

- advance the stable framework version from `0.1.1068` to `0.1.1069`
- keep `deno.json` and `src/utils/version-constant.ts` synchronized
- trigger the collision-checked stable publication path after merge so the runtime recovery fix is available in a tagged release

## Testing

- version synchronization and stable release-intent tests: 2 tests / 25 steps passed
- JSON parse and version assertion passed
- focused formatting and `git diff --check` passed
- normal pre-push hook passed: global format (3,976 files), lint (3,924 files), `deno check src/index.ts`, and full unit suite (2,386 tests / 20,290 steps)

Merged companion: veryfront/veryfront-code#2942

Addresses veryfront/veryfront-studio#5906