### PR TITLE
Harden registry isolation for unversioned environment contexts

### DIFF
--- a/src/cache/cache-key-builder.test.ts
+++ b/src/cache/cache-key-builder.test.ts
@@ -9,7 +9,10 @@ import {
   getProjectScopedKeyAlways,
   runWithCacheKeyContext,
   tryGetCacheKeyContext,
+  tryGetRegistryScopeContext,
+  tryGetRegistryScopeId,
 } from "./cache-key-builder.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 
 describe("cache-key-builder", () => {
   describe("getContentHashKey", () => {
@@ -77,6 +80,178 @@ describe("cache-key-builder", () => {
       const result = runWithCacheKeyContext(ctx, tryGetCacheKeyContext);
 
       assertEquals(result?.projectId, "test");
+    });
+  });
+
+  describe("tryGetRegistryScopeContext", () => {
+    it("returns null without project identity", async () => {
+      const result = await runWithRequestContext(
+        {
+          projectSlug: "",
+          token: "<TOKEN>",
+          productionMode: true,
+          environmentName: "Development",
+        },
+        async () => tryGetRegistryScopeContext(),
+      );
+
+      assertEquals(result, null);
+    });
+
+    it("uses immutable release and mutable branch scopes", async () => {
+      const release = await runWithRequestContext(
+        {
+          projectSlug: "project",
+          projectId: "project-id",
+          token: "<TOKEN>",
+          productionMode: true,
+          releaseId: "release-id",
+        },
+        async () => tryGetRegistryScopeContext(),
+      );
+      const branch = await runWithRequestContext(
+        {
+          projectSlug: "project",
+          projectId: "project-id",
+          token: "<TOKEN>",
+          productionMode: false,
+          branch: "feature",
+        },
+        async () => tryGetRegistryScopeContext(),
+      );
+
+      assertEquals(release, {
+        scopeId: "project-id:production:release-id",
+        immutable: true,
+      });
+      assertEquals(branch, {
+        scopeId: "project-id:preview:feature",
+        immutable: false,
+      });
+    });
+
+    it("isolates release-less environments for the same project", async () => {
+      const development = await runWithRequestContext(
+        {
+          projectSlug: "project",
+          projectId: "project-id",
+          token: "<TOKEN>",
+          productionMode: true,
+          releaseId: null,
+          environmentName: "Development",
+        },
+        async () => tryGetRegistryScopeContext(),
+      );
+      const production = await runWithRequestContext(
+        {
+          projectSlug: "project",
+          projectId: "project-id",
+          token: "<TOKEN>",
+          productionMode: true,
+          releaseId: null,
+          environmentName: "Production",
+        },
+        async () => tryGetRegistryScopeContext(),
+      );
+
+      assertEquals(development, {
+        scopeId: "project-id:production:environment:Development",
+        immutable: false,
+      });
+      assertEquals(production, {
+        scopeId: "project-id:production:environment:Production",
+        immutable: false,
+      });
+    });
+
+    it("uses the canonical production environment when its name is omitted", async () => {
+      const result = await runWithRequestContext(
+        {
+          projectSlug: "project",
+          projectId: "project-id",
+          token: "<TOKEN>",
+          productionMode: true,
+          releaseId: null,
+          environmentName: null,
+        },
+        async () => tryGetRegistryScopeContext(),
+      );
+
+      assertEquals(result, {
+        scopeId: "project-id:production:environment:production",
+        immutable: false,
+      });
+    });
+
+    it("keeps an explicit cache scope authoritative inside a filesystem source", async () => {
+      const result = await runWithRequestContext(
+        {
+          projectSlug: "project",
+          projectId: "filesystem-project",
+          token: "<TOKEN>",
+          productionMode: true,
+          releaseId: "filesystem-release",
+        },
+        async () =>
+          runWithCacheKeyContext(
+            {
+              projectId: "workflow-project",
+              mode: "production",
+              versionId: "workflow-release",
+            },
+            () => tryGetRegistryScopeContext(),
+          ),
+      );
+
+      assertEquals(result, {
+        scopeId: "workflow-project:production:workflow-release",
+        immutable: true,
+      });
+    });
+
+    it("keeps an outer explicit cache scope authoritative over nested filesystem work", async () => {
+      const result = await runWithCacheKeyContext(
+        {
+          projectId: "project-id",
+          mode: "production",
+          versionId: "outer-release",
+        },
+        () =>
+          runWithRequestContext(
+            {
+              projectSlug: "project",
+              projectId: "project-id",
+              token: "<TOKEN>",
+              productionMode: true,
+              releaseId: null,
+              environmentName: "Development",
+            },
+            async () => tryGetRegistryScopeContext(),
+          ),
+      );
+
+      assertEquals(result, {
+        scopeId: "project-id:production:outer-release",
+        immutable: true,
+      });
+    });
+
+    it("keeps explicit cache contexts available without a filesystem source", () => {
+      const scope = runWithCacheKeyContext(
+        { projectId: "project-id", mode: "production", versionId: "release-id" },
+        () => ({
+          context: tryGetRegistryScopeContext(),
+          id: tryGetRegistryScopeId(),
+        }),
+      );
+
+      assertEquals(scope, {
+        context: {
+          scopeId: "project-id:production:release-id",
+          immutable: true,
+        },
+        id: "project-id:production:release-id",
+      });
     });
   });
 

--- a/src/cache/cache-key-builder.ts
+++ b/src/cache/cache-key-builder.ts
@@ -18,7 +18,13 @@ let _getCurrentRequestContext: (() => MultiProjectRequestContextType | null) | n
 
 export type { CacheKeyContext };
 
-const cacheKeyContextStorage = new AsyncLocalStorage<CacheKeyContext>();
+export interface RegistryScopeContext {
+  scopeId: string;
+  /** Whether completed discovery is safe to retain for this immutable source. */
+  immutable: boolean;
+}
+
+const cacheKeyContextStorage = new AsyncLocalStorage<CacheKeyContext | null>();
 
 function validateCacheKeyContext(ctx: CacheKeyContext): CacheKeyContext {
   return CacheKeyContextSchema.parse(ctx);
@@ -35,6 +41,17 @@ export function getContentHashKey(
 
 export function runWithCacheKeyContext<T>(ctx: CacheKeyContext, fn: () => T): T {
   return cacheKeyContextStorage.run(validateCacheKeyContext(ctx), fn);
+}
+
+/**
+ * Suppress an inherited explicit cache scope for a callback. This is used when
+ * a restored tenant has a mutable source (for example, a production
+ * environment without a pinned release) that cannot safely use distributed
+ * caching. Ambient request context remains available for in-process registry
+ * isolation.
+ */
+export function runWithoutCacheKeyContext<T>(fn: () => T): T {
+  return cacheKeyContextStorage.run(null, fn);
 }
 
 export function getCurrentCacheKeyContext(): CacheKeyContext {
@@ -100,6 +117,67 @@ export function tryGetCacheKeyContext(): CacheKeyContext | null {
   if (!reqCtx) return null;
 
   return extractCacheKeyContextFromMultiProjectContext(reqCtx);
+}
+
+/**
+ * Returns a stable scope identifier for in-process registry isolation.
+ *
+ * Unlike tryGetCacheKeyContext(), this function does NOT return null when the
+ * request context lacks a field that would be required for a safe distributed
+ * cache key (e.g. productionMode=true without a releaseId). For in-process
+ * registries (ProjectScopedRegistryManager), project identity and the active
+ * content source still provide a safe process-local scope. Collapsing to
+ * "__default__" would let concurrent projects overwrite one another's
+ * registered skills, tools, and agents.
+ *
+ * Returns null only when no project identity is available at all (e.g. CLI /
+ * local dev without a multi-project context), in which case the caller should
+ * fall back to DEFAULT_SCOPE_ID.
+ */
+export function tryGetRegistryScopeContext(): RegistryScopeContext | null {
+  // Explicit contexts are authoritative for workflows and other callers that
+  // intentionally override ambient filesystem tenancy.
+  const cacheCtx = cacheKeyContextStorage.getStore();
+  if (cacheCtx) {
+    return {
+      scopeId: `${cacheCtx.projectId}:${cacheCtx.mode}:${cacheCtx.versionId}`,
+      immutable: cacheCtx.mode === "production",
+    };
+  }
+
+  const reqCtx = getRequestContextFn()?.();
+  if (reqCtx) {
+    const projectId = reqCtx.projectId || reqCtx.projectSlug;
+    if (!projectId) return null;
+
+    if (reqCtx.productionMode) {
+      if (reqCtx.releaseId) {
+        return {
+          scopeId: `${projectId}:production:${reqCtx.releaseId}`,
+          immutable: true,
+        };
+      }
+
+      // Match ProxyFSAdapterManager's canonical default so registry,
+      // discovery, and adapter caches all describe the same content source.
+      const environmentName = reqCtx.environmentName || "production";
+      return {
+        scopeId: `${projectId}:production:environment:${environmentName}`,
+        immutable: false,
+      };
+    }
+
+    return {
+      scopeId: `${projectId}:preview:${reqCtx.branch || "main"}`,
+      immutable: false,
+    };
+  }
+
+  return null;
+}
+
+export function tryGetRegistryScopeId(): string | null {
+  return tryGetRegistryScopeContext()?.scopeId ?? null;
 }
 
 function buildProjectScopedKey(prefix: string, resourceKey: string, ctx: CacheKeyContext): string {

--- a/src/cache/keys/builders/render.ts
+++ b/src/cache/keys/builders/render.ts
@@ -98,16 +98,20 @@ export function buildProxyManagerCacheKey(
   productionMode: boolean,
   releaseId: string | null,
   branch: string | null,
+  environmentName?: string | null,
 ): string {
   const mode = productionMode ? "production" : "preview";
 
   if (productionMode) {
-    if (!releaseId) {
+    if (releaseId) {
+      return `${CacheKeyPrefix.PROXY}:${projectSlug}:${mode}:${releaseId}`;
+    }
+    if (!environmentName) {
       throw CACHE_INVARIANT_VIOLATION.create({
-        detail: `Missing releaseId in production for ${projectSlug}`,
+        detail: `Missing releaseId or environmentName in production for ${projectSlug}`,
       });
     }
-    return `${CacheKeyPrefix.PROXY}:${projectSlug}:${mode}:${releaseId}`;
+    return `${CacheKeyPrefix.PROXY}:${projectSlug}:${mode}:environment:${environmentName}`;
   }
 
   return `${CacheKeyPrefix.PROXY}:${projectSlug}:${mode}:${branch ?? "main"}`;

--- a/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
@@ -215,6 +215,47 @@ describe("ProxyFSAdapterManager", () => {
       assertEquals(manager.hasAdapter("project", true, "rel-2"), false);
       manager.dispose();
     });
+
+    it("should differentiate release-less production adapters by environment", () => {
+      const manager = createManager();
+      const disposed: string[] = [];
+      const adapters = (manager as unknown as {
+        adapters: Map<
+          string,
+          { adapter: { dispose: () => void }; lastAccessed: number }
+        >;
+      }).adapters;
+      adapters.set("proxy:project:production:environment:production", {
+        adapter: { dispose: () => disposed.push("production") },
+        lastAccessed: Date.now(),
+      });
+      adapters.set("proxy:project:production:environment:Development", {
+        adapter: { dispose: () => disposed.push("Development") },
+        lastAccessed: Date.now(),
+      });
+
+      assertEquals(
+        manager.hasAdapter("project", true, null),
+        true,
+      );
+      assertEquals(
+        manager.hasAdapter("project", true, null, null, "Development"),
+        true,
+      );
+
+      manager.evictAdapter("project", true, null);
+      assertEquals(disposed, ["production"]);
+      assertEquals(manager.hasAdapter("project", true, null), false);
+      assertEquals(manager.hasAdapter("project", true, null, null, "Development"), true);
+
+      manager.evictAdapter("project", true, null, null, "Development");
+      assertEquals(disposed, ["production", "Development"]);
+      assertEquals(
+        manager.hasAdapter("project", true, null, null, "Development"),
+        false,
+      );
+      manager.dispose();
+    });
   });
 
   describe("getStats", () => {

--- a/src/platform/adapters/fs/veryfront/proxy-manager.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.ts
@@ -169,6 +169,7 @@ export class ProxyFSAdapterManager {
       effectiveProductionMode,
       effectiveReleaseId,
       effectiveBranch,
+      effectiveEnvironmentName,
     );
 
     logger.debug("getAdapter called", {
@@ -391,7 +392,7 @@ export class ProxyFSAdapterManager {
       invalidationCallbacks: createDefaultInvalidationCallbacks({
         ...this.baseConfig.invalidationCallbacks,
         evictCurrentAdapter: () =>
-          this.evictAdapter(projectSlug, productionMode, releaseId, branch),
+          this.evictAdapter(projectSlug, productionMode, releaseId, branch, environmentName),
       }),
     };
 
@@ -550,12 +551,17 @@ export class ProxyFSAdapterManager {
     productionMode?: boolean,
     releaseId?: string | null,
     branch?: string | null,
+    environmentName?: string | null,
   ): boolean {
+    const effectiveProductionMode = productionMode ?? false;
+    const effectiveEnvironmentName = environmentName ??
+      (effectiveProductionMode ? "production" : null);
     const cacheKey = buildProxyManagerCacheKey(
       projectSlug,
-      productionMode ?? false,
+      effectiveProductionMode,
       releaseId ?? null,
       branch ?? null,
+      effectiveEnvironmentName,
     );
     return this.adapters.has(cacheKey);
   }
@@ -565,12 +571,17 @@ export class ProxyFSAdapterManager {
     productionMode?: boolean,
     releaseId?: string | null,
     branch?: string | null,
+    environmentName?: string | null,
   ): void {
+    const effectiveProductionMode = productionMode ?? false;
+    const effectiveEnvironmentName = environmentName ??
+      (effectiveProductionMode ? "production" : null);
     const cacheKey = buildProxyManagerCacheKey(
       projectSlug,
-      productionMode ?? false,
+      effectiveProductionMode,
       releaseId ?? null,
       branch ?? null,
+      effectiveEnvironmentName,
     );
 
     const adapter = this.adapters.get(cacheKey);

--- a/src/registry/project-scoped-registry-manager.test.ts
+++ b/src/registry/project-scoped-registry-manager.test.ts
@@ -1,8 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd";
-import { assert, assertEquals } from "#veryfront/testing/assert";
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert";
 import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
-import { ProjectScopedRegistryManager } from "./project-scoped-registry-manager.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
+import {
+  ProjectScopedRegistryManager,
+  runWithRegistryTransaction,
+} from "./project-scoped-registry-manager.ts";
 
 describe("ProjectScopedRegistryManager", () => {
   function createManager<T>(name: string): ProjectScopedRegistryManager<T> {
@@ -240,5 +244,181 @@ describe("ProjectScopedRegistryManager", () => {
       assertEquals(manager.get("shared-a"), "value");
       assertEquals(manager.get("proj-a"), undefined);
     });
+  });
+});
+
+describe("ProjectScopedRegistryManager transactions", () => {
+  const scope = { projectId: "project-transaction", mode: "preview" as const, versionId: "main" };
+
+  it("keeps the live registry visible until a staged replacement commits", async () => {
+    const manager = new ProjectScopedRegistryManager<string>("skill");
+    runWithCacheKeyContext(scope, () => manager.register("old-skill", "old"));
+
+    const stageReady = Promise.withResolvers<void>();
+    const releaseStage = Promise.withResolvers<void>();
+    const transaction = runWithCacheKeyContext(
+      scope,
+      () =>
+        runWithRegistryTransaction(async () => {
+          manager.clear();
+          manager.register("new-skill", "new");
+          stageReady.resolve();
+          await releaseStage.promise;
+        }),
+    );
+
+    await stageReady.promise;
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.get("old-skill"), "old");
+      assertEquals(manager.get("new-skill"), undefined);
+    });
+
+    releaseStage.resolve();
+    await transaction;
+
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.get("old-skill"), undefined);
+      assertEquals(manager.get("new-skill"), "new");
+    });
+  });
+
+  it("discards staged mutations when the transaction fails", async () => {
+    const manager = new ProjectScopedRegistryManager<string>("skill");
+    runWithCacheKeyContext(scope, () => manager.register("stable-skill", "stable"));
+
+    await assertRejects(
+      () =>
+        runWithCacheKeyContext(
+          scope,
+          () =>
+            runWithRegistryTransaction(async () => {
+              manager.clear();
+              manager.register("partial-skill", "partial");
+              throw new Error("discovery failed");
+            }),
+        ),
+      Error,
+      "discovery failed",
+    );
+
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.get("stable-skill"), "stable");
+      assertEquals(manager.get("partial-skill"), undefined);
+    });
+  });
+
+  it("rejects registry access after a nested context changes tenant scope", async () => {
+    const manager = new ProjectScopedRegistryManager<string>("skill");
+
+    await assertRejects(
+      () =>
+        runWithCacheKeyContext(
+          scope,
+          () =>
+            runWithRegistryTransaction(async () => {
+              manager.register("project-skill", "stable");
+              await runWithCacheKeyContext(
+                { projectId: "other-project", mode: "preview", versionId: "main" },
+                async () => {
+                  manager.get("project-skill");
+                },
+              );
+            }),
+        ),
+      Error,
+      "Registry scope changed during transaction",
+    );
+
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.get("project-skill"), undefined);
+    });
+  });
+
+  it("routes async descendant writes to the live registry after commit", async () => {
+    const manager = new ProjectScopedRegistryManager<string>("skill");
+    const lateWrite = Promise.withResolvers<void>();
+
+    await runWithCacheKeyContext(
+      scope,
+      () =>
+        runWithRegistryTransaction(async () => {
+          manager.register("committed-skill", "committed");
+          setTimeout(() => {
+            try {
+              manager.clear();
+              manager.register("late-skill", "late");
+              lateWrite.resolve();
+            } catch (error) {
+              lateWrite.reject(error);
+            }
+          }, 0);
+        }),
+    );
+    await lateWrite.promise;
+
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.get("committed-skill"), undefined);
+      assertEquals(manager.get("late-skill"), "late");
+    });
+  });
+});
+
+// Hardening identified while investigating veryfront/veryfront-api#3952.
+// The issue itself had invalid skill metadata and release-pinned requests, so
+// this registry race was not its deterministic cause.
+// Control-plane runs with agentSource.type === "environment" and no releaseId
+// produce a request context with { productionMode: true, releaseId: null }.
+// tryGetCacheKeyContext() returns null for this context (no stable distributed
+// cache key without a releaseId), so buildRegistryScopeId() collapsed to
+// "__default__" — a single shared scope for every project. Concurrent
+// requests' skillRegistry.clear() calls stomped each other's skills, producing
+// "Skill not found. Available skills: none" when load_skill executed.
+describe("concurrent environment-source runs with no releaseId", () => {
+  it("skills registered by project-x must survive project-y discovery clear", async () => {
+    const manager = new ProjectScopedRegistryManager<string>("skill");
+
+    // Request A: project-x, environment source, no releaseId
+    // (mirrors withAgentSourceContext options for type === "environment")
+    await runWithRequestContext(
+      {
+        projectSlug: "project-x",
+        projectId: "proj-x",
+        token: "tok-a",
+        productionMode: true,
+        releaseId: null,
+        environmentName: "Development",
+      },
+      async () => {
+        manager.clear();
+        manager.register("oncall-triage", "skill-x");
+        assertEquals(
+          manager.getAll().size,
+          1,
+          "project-x skill must be registered in its own scope",
+        );
+
+        // Concurrent request B (different project) runs discovery — its clear()
+        // must not wipe project-x's scope.
+        await runWithRequestContext(
+          {
+            projectSlug: "project-y",
+            projectId: "proj-y",
+            token: "tok-b",
+            productionMode: true,
+            releaseId: null,
+            environmentName: "Production",
+          },
+          async () => {
+            manager.clear();
+          },
+        );
+
+        assertEquals(
+          manager.getAll().size,
+          1,
+          "project-x skill must survive project-y's discovery clear",
+        );
+      },
+    );
   });
 });

--- a/src/registry/project-scoped-registry-manager.ts
+++ b/src/registry/project-scoped-registry-manager.ts
@@ -23,18 +23,73 @@
  * @module
  */
 
-import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
+import { tryGetRegistryScopeId } from "#veryfront/cache/cache-key-builder.ts";
 import { agentLogger } from "#veryfront/utils/logger/logger.ts";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 const DEFAULT_SCOPE_ID = "__default__";
 
-function buildRegistryScopeId(): string {
-  const cacheContext = tryGetCacheKeyContext();
-  if (!cacheContext) {
-    return DEFAULT_SCOPE_ID;
-  }
+interface RegistryTransactionStage {
+  commit(): void;
+}
 
-  return `${cacheContext.projectId}:${cacheContext.mode}:${cacheContext.versionId}`;
+interface RegistryTransaction {
+  readonly targetScopeId: string;
+  readonly stages: Map<object, RegistryTransactionStage>;
+  state: "active" | "committed" | "aborted";
+}
+
+const registryTransactionStorage = new AsyncLocalStorage<RegistryTransaction>();
+
+function buildRegistryScopeId(): string {
+  // tryGetRegistryScopeId() returns a project-isolated key even when
+  // tryGetCacheKeyContext() would return null (e.g. control-plane runs for an
+  // environment source without a pinned releaseId). Without this, all such
+  // runs collapse to "__default__", so concurrent projects can overwrite one
+  // another's registered primitives.
+  return tryGetRegistryScopeId() ?? DEFAULT_SCOPE_ID;
+}
+
+/**
+ * Stage project-scoped registry mutations and publish them as one synchronous
+ * commit after the callback succeeds. Reads inside the callback see staged
+ * state; concurrent requests keep seeing the previous live state.
+ * The commit is an authoritative replacement, so it linearizes after and may
+ * supersede live writes made to the same scope while staging is in progress.
+ * Use this for complete discovery generations, not incremental updates.
+ *
+ * Nested calls participate in the existing transaction. If a nested tenant
+ * context changes the registry scope, the first registry access throws rather
+ * than committing data into the wrong tenant.
+ */
+export async function runWithRegistryTransaction<T>(fn: () => Promise<T>): Promise<T> {
+  const existing = registryTransactionStorage.getStore();
+  if (existing?.state === "active") return await fn();
+
+  const transaction: RegistryTransaction = {
+    targetScopeId: buildRegistryScopeId(),
+    stages: new Map(),
+    state: "active",
+  };
+
+  return await registryTransactionStorage.run(transaction, async () => {
+    try {
+      const result = await fn();
+
+      // Map replacement is synchronous. No other request can observe a partial
+      // commit between managers in this JavaScript turn.
+      for (const stage of transaction.stages.values()) {
+        stage.commit();
+      }
+      transaction.state = "committed";
+      transaction.stages.clear();
+      return result;
+    } catch (error) {
+      transaction.state = "aborted";
+      transaction.stages.clear();
+      throw error;
+    }
+  });
 }
 
 /**
@@ -56,10 +111,57 @@ export class ProjectScopedRegistryManager<T> {
     return buildRegistryScopeId();
   }
 
+  /** Return a transaction-local copy of the target registry when staging. */
+  private getTransactionRegistry(scopeId: string): Map<string, T> | undefined {
+    const transaction = registryTransactionStorage.getStore();
+    if (!transaction) return undefined;
+    if (transaction.state === "committed") return undefined;
+    if (transaction.state === "aborted") {
+      throw new Error(
+        `[${this.registryName}] Registry transaction already aborted for scope ` +
+          `"${transaction.targetScopeId}"`,
+      );
+    }
+
+    if (scopeId !== transaction.targetScopeId) {
+      throw new Error(
+        `[${this.registryName}] Registry scope changed during transaction: ` +
+          `expected "${transaction.targetScopeId}", got "${scopeId}"`,
+      );
+    }
+
+    const existing = transaction.stages.get(this) as
+      | (RegistryTransactionStage & { registry: Map<string, T> })
+      | undefined;
+    if (existing) return existing.registry;
+
+    const registry = new Map(this.registriesByScope.get(scopeId));
+    const stage: RegistryTransactionStage & { registry: Map<string, T> } = {
+      registry,
+      commit: () => {
+        if (registry.size === 0) {
+          this.registriesByScope.delete(scopeId);
+        } else {
+          this.registriesByScope.set(scopeId, registry);
+        }
+      },
+    };
+    transaction.stages.set(this, stage);
+    return registry;
+  }
+
+  /** Read the active registry, routing transaction access to its staged copy. */
+  private getActiveScopeRegistry(scopeId: string): Map<string, T> | undefined {
+    return this.getTransactionRegistry(scopeId) ?? this.registriesByScope.get(scopeId);
+  }
+
   /**
    * Get or create registry for a specific project.
    */
   private getScopeRegistry(scopeId: string): Map<string, T> {
+    const staged = this.getTransactionRegistry(scopeId);
+    if (staged) return staged;
+
     const existing = this.registriesByScope.get(scopeId);
     if (existing) return existing;
 
@@ -90,6 +192,9 @@ export class ProjectScopedRegistryManager<T> {
    * Use for framework-provided tools, not user-defined ones.
    */
   registerShared(id: string, item: T): void {
+    // Shared framework infrastructure is intentionally process-wide and is
+    // published immediately even inside a project transaction. Project
+    // discovery must never use this method for tenant-owned definitions.
     if (this.sharedRegistry.has(id)) {
       agentLogger.debug(`[${this.registryName}] Shared "${id}" already registered. Overwriting.`);
     }
@@ -104,7 +209,7 @@ export class ProjectScopedRegistryManager<T> {
    */
   get(id: string): T | undefined {
     const scopeId = this.getCurrentScopeId();
-    return this.registriesByScope.get(scopeId)?.get(id) ?? this.sharedRegistry.get(id);
+    return this.getActiveScopeRegistry(scopeId)?.get(id) ?? this.sharedRegistry.get(id);
   }
 
   /**
@@ -115,7 +220,7 @@ export class ProjectScopedRegistryManager<T> {
    */
   getOwn(id: string): T | undefined {
     const scopeId = this.getCurrentScopeId();
-    return this.registriesByScope.get(scopeId)?.get(id);
+    return this.getActiveScopeRegistry(scopeId)?.get(id);
   }
 
   /**
@@ -123,7 +228,7 @@ export class ProjectScopedRegistryManager<T> {
    */
   has(id: string): boolean {
     const scopeId = this.getCurrentScopeId();
-    return (this.registriesByScope.get(scopeId)?.has(id) ?? false) ||
+    return (this.getActiveScopeRegistry(scopeId)?.has(id) ?? false) ||
       this.sharedRegistry.has(id);
   }
 
@@ -132,7 +237,7 @@ export class ProjectScopedRegistryManager<T> {
    */
   getAllIds(): string[] {
     const scopeId = this.getCurrentScopeId();
-    const projectIds = this.registriesByScope.get(scopeId)?.keys() ?? [];
+    const projectIds = this.getActiveScopeRegistry(scopeId)?.keys() ?? [];
     const sharedIds = this.sharedRegistry.keys();
     return Array.from(new Set([...projectIds, ...sharedIds]));
   }
@@ -142,7 +247,7 @@ export class ProjectScopedRegistryManager<T> {
    */
   getAll(): Map<string, T> {
     const scopeId = this.getCurrentScopeId();
-    const projectRegistry = this.registriesByScope.get(scopeId);
+    const projectRegistry = this.getActiveScopeRegistry(scopeId);
     if (!projectRegistry) return new Map(this.sharedRegistry);
 
     const result = new Map<string, T>(this.sharedRegistry);
@@ -155,7 +260,7 @@ export class ProjectScopedRegistryManager<T> {
    */
   delete(id: string): boolean {
     const scopeId = this.getCurrentScopeId();
-    const registry = this.registriesByScope.get(scopeId);
+    const registry = this.getActiveScopeRegistry(scopeId);
     if (!registry?.has(id)) return false;
 
     registry.delete(id);
@@ -167,6 +272,11 @@ export class ProjectScopedRegistryManager<T> {
    * Clear all items for the current project.
    */
   clear(): void {
+    const staged = this.getTransactionRegistry(this.getCurrentScopeId());
+    if (staged) {
+      staged.clear();
+      return;
+    }
     this.clearProject(this.getCurrentScopeId());
   }
 
@@ -174,6 +284,13 @@ export class ProjectScopedRegistryManager<T> {
    * Clear a specific project's registry.
    */
   clearProject(projectId: string): void {
+    const transaction = registryTransactionStorage.getStore();
+    if (transaction && transaction.state !== "committed") {
+      throw new Error(
+        `[${this.registryName}] clearProject() is not supported during a registry transaction`,
+      );
+    }
+
     let cleared = false;
     for (const scopeId of Array.from(this.registriesByScope.keys())) {
       if (scopeId === projectId || scopeId.startsWith(`${projectId}:`)) {
@@ -191,6 +308,13 @@ export class ProjectScopedRegistryManager<T> {
    * Clear everything (for testing).
    */
   clearAll(): void {
+    const transaction = registryTransactionStorage.getStore();
+    if (transaction && transaction.state !== "committed") {
+      throw new Error(
+        `[${this.registryName}] clearAll() is not supported during a registry transaction`,
+      );
+    }
+
     this.registriesByScope.clear();
     this.sharedRegistry.clear();
     agentLogger.debug(`[${this.registryName}] Cleared all registries`);
@@ -216,7 +340,7 @@ export class ProjectScopedRegistryManager<T> {
       projectCount: this.registriesByScope.size,
       sharedCount: this.sharedRegistry.size,
       totalItems,
-      currentProjectItems: this.registriesByScope.get(scopeId)?.size ?? 0,
+      currentProjectItems: this.getActiveScopeRegistry(scopeId)?.size ?? 0,
     };
   }
 }

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -5,6 +5,7 @@ import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import type { HandlerContext } from "../../types.ts";
 import { ensureProjectDiscovery } from "./project-discovery.ts";
 import { agentRegistry } from "#veryfront/agent/composition/composition.ts";
@@ -54,6 +55,23 @@ async function writeAgentFile(
       `  id: "${agentId}",`,
       `  system: "${systemPrompt}",`,
       "});",
+      "",
+    ].join("\n"),
+  );
+}
+
+async function writeSkillFile(
+  ctx: HandlerContext,
+  skillId: string,
+): Promise<void> {
+  await ctx.adapter.fs.writeFile(
+    `${ctx.projectDir}/skills/${skillId}/SKILL.md`,
+    [
+      "---",
+      `name: ${skillId}`,
+      `description: ${skillId} fixture`,
+      "---",
+      `Use the ${skillId} fixture.`,
       "",
     ].join("\n"),
   );
@@ -140,6 +158,195 @@ describe(
       const updatedAgent = getAgent(agentId);
       assertExists(updatedAgent);
       assertEquals(updatedAgent.config.system, "SECOND");
+    });
+
+    it("keeps the live skill registry available until mutable rediscovery commits", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/atomic-discovery-project",
+        "atomic-discovery-project",
+        "production",
+      );
+      ctx.projectId = "atomic-discovery-project-id";
+      const requestContext = {
+        projectSlug: ctx.projectSlug!,
+        projectId: ctx.projectId,
+        token: "<TOKEN>",
+        productionMode: true,
+        releaseId: null,
+        environmentName: "Development",
+      };
+
+      await writeSkillFile(ctx, "old-skill");
+      await runWithRequestContext(requestContext, () => ensureProjectDiscovery(ctx));
+
+      await ctx.adapter.fs.remove(`${ctx.projectDir}/skills/old-skill`, { recursive: true });
+      await writeSkillFile(ctx, "new-skill");
+
+      const discoveryPaused = Promise.withResolvers<void>();
+      const resumeDiscovery = Promise.withResolvers<void>();
+      const originalExists = ctx.adapter.fs.exists.bind(ctx.adapter.fs);
+      let pauseSkillsRead = true;
+      ctx.adapter.fs.exists = async (path: string) => {
+        if (pauseSkillsRead && path === `${ctx.projectDir}/skills`) {
+          pauseSkillsRead = false;
+          discoveryPaused.resolve();
+          await resumeDiscovery.promise;
+        }
+        return originalExists(path);
+      };
+
+      const rediscovery = runWithRequestContext(
+        requestContext,
+        () => ensureProjectDiscovery(ctx),
+      );
+      await discoveryPaused.promise;
+
+      await runWithRequestContext(requestContext, async () => {
+        assertExists(skillRegistry.get("old-skill"));
+        assertEquals(skillRegistry.get("new-skill"), undefined);
+      });
+
+      resumeDiscovery.resolve();
+      await rediscovery;
+
+      await runWithRequestContext(requestContext, async () => {
+        assertEquals(skillRegistry.get("old-skill"), undefined);
+        assertExists(skillRegistry.get("new-skill"));
+      });
+    });
+
+    it("preserves the live skill registry when mutable rediscovery fails", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/failed-atomic-discovery-project",
+        "failed-atomic-discovery-project",
+        "production",
+      );
+      ctx.projectId = "failed-atomic-discovery-project-id";
+      const requestContext = {
+        projectSlug: ctx.projectSlug!,
+        projectId: ctx.projectId,
+        token: "<TOKEN>",
+        productionMode: true,
+        releaseId: null,
+        environmentName: "Development",
+      };
+
+      await writeSkillFile(ctx, "stable-skill");
+      await runWithRequestContext(requestContext, () => ensureProjectDiscovery(ctx));
+
+      const originalExists = ctx.adapter.fs.exists.bind(ctx.adapter.fs);
+      ctx.adapter.fs.exists = (path: string) => {
+        if (path === `${ctx.projectDir}/skills`) {
+          return Promise.reject(new Error("skill source unavailable"));
+        }
+        return originalExists(path);
+      };
+
+      await assertRejects(
+        () => runWithRequestContext(requestContext, () => ensureProjectDiscovery(ctx)),
+        Error,
+        "skill source unavailable",
+      );
+
+      await runWithRequestContext(requestContext, async () => {
+        assertExists(skillRegistry.get("stable-skill"));
+      });
+    });
+
+    it("does not deduplicate release-less discovery across environments", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const firstCtx = createHandlerContext(
+        "/shared-project-development",
+        "shared-project",
+        "production",
+      );
+      const secondCtx = createHandlerContext(
+        "/shared-project-production",
+        "shared-project",
+        "production",
+      );
+      firstCtx.projectId = "shared-project-id";
+      secondCtx.projectId = "shared-project-id";
+
+      await writeSkillFile(firstCtx, "development-skill");
+      await writeSkillFile(secondCtx, "production-skill");
+
+      let markFirstDiscoveryStarted!: () => void;
+      const firstDiscoveryStarted = new Promise<void>((resolve) => {
+        markFirstDiscoveryStarted = resolve;
+      });
+      let releaseFirstDiscovery!: () => void;
+      const holdFirstDiscovery = new Promise<void>((resolve) => {
+        releaseFirstDiscovery = resolve;
+      });
+      const firstExists = firstCtx.adapter.fs.exists.bind(firstCtx.adapter.fs);
+      let firstExistsCall = true;
+      firstCtx.adapter.fs.exists = async (path: string) => {
+        if (firstExistsCall) {
+          firstExistsCall = false;
+          markFirstDiscoveryStarted();
+          await holdFirstDiscovery;
+        }
+        return firstExists(path);
+      };
+
+      const firstDiscovery = runWithRequestContext(
+        {
+          projectSlug: "shared-project",
+          projectId: "shared-project-id",
+          token: "<TOKEN>",
+          productionMode: true,
+          releaseId: null,
+          environmentName: "Development",
+        },
+        () => ensureProjectDiscovery(firstCtx),
+      );
+      await firstDiscoveryStarted;
+
+      const secondDiscovery = runWithRequestContext(
+        {
+          projectSlug: "shared-project",
+          projectId: "shared-project-id",
+          token: "<TOKEN>",
+          productionMode: true,
+          releaseId: null,
+          environmentName: "Production",
+        },
+        () => ensureProjectDiscovery(secondCtx),
+      );
+      releaseFirstDiscovery();
+
+      const [firstResult, secondResult] = await Promise.all([
+        firstDiscovery,
+        secondDiscovery,
+      ]);
+      assertEquals(firstResult.skills.has("development-skill"), true);
+      assertEquals(secondResult.skills.has("production-skill"), true);
+
+      await runWithRequestContext(
+        {
+          projectSlug: "shared-project",
+          projectId: "shared-project-id",
+          token: "<TOKEN>",
+          productionMode: true,
+          releaseId: null,
+          environmentName: "Production",
+        },
+        async () => {
+          assertExists(skillRegistry.get("production-skill"));
+        },
+      );
     });
 
     it("uses cache-key context to isolate production discovery by release", async () => {

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -1,7 +1,8 @@
 import type { DiscoveryResult } from "#veryfront/discovery";
 import { serverLogger } from "#veryfront/utils";
 import { clearTrackedAgents, createProjectDiscoveryConfig } from "#veryfront/discovery";
-import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
+import { tryGetRegistryScopeContext } from "#veryfront/cache/cache-key-builder.ts";
+import { runWithRegistryTransaction } from "#veryfront/registry/project-scoped-registry-manager.ts";
 import { sanitizeUrlCredentials } from "#veryfront/utils/logger/redact.ts";
 import type { HandlerContext } from "../../types.ts";
 
@@ -95,9 +96,9 @@ function summarizeDiscoveryFailures(
 
 /** Build a discovery cache key that incorporates the release/version. */
 function discoveryKey(ctx: HandlerContext): string {
-  const cacheContext = tryGetCacheKeyContext();
-  if (cacheContext) {
-    return `${cacheContext.projectId}:${cacheContext.mode}:${cacheContext.versionId}`;
+  const registryScope = tryGetRegistryScopeContext();
+  if (registryScope) {
+    return registryScope.scopeId;
   }
 
   const slug = ctx.projectSlug ?? ctx.projectDir;
@@ -114,9 +115,9 @@ function discoveryKey(ctx: HandlerContext): string {
 }
 
 function shouldCacheCompletedDiscovery(ctx: HandlerContext): boolean {
-  const cacheContext = tryGetCacheKeyContext();
-  if (cacheContext) {
-    return cacheContext.mode === "production";
+  const registryScope = tryGetRegistryScopeContext();
+  if (registryScope) {
+    return registryScope.immutable;
   }
 
   const environment = ctx.enriched?.environment ?? ctx.resolvedEnvironment ??
@@ -145,45 +146,48 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<Disco
       );
       const { toolRegistry } = await import("#veryfront/tool/registry.ts");
 
-      // Clear stale entries for this project scope before re-discovery.
-      // This prevents agents/tools removed in a new release from lingering.
-      clearTrackedAgents();
-      clearTranspileCache();
-      agentRegistry.clear();
-      toolRegistry.clear();
+      return await runWithRegistryTransaction(async () => {
+        // Clear stale entries in a transaction-local copy. Concurrent runs keep
+        // using the prior live registry until discovery succeeds and the staged
+        // replacement is committed atomically.
+        clearTrackedAgents();
+        clearTranspileCache();
+        agentRegistry.clear();
+        toolRegistry.clear();
 
-      const discoveryOptions = createProjectDiscoveryConfig({
-        projectDir: ctx.projectDir,
-        config: ctx.config,
-        fsAdapter: ctx.adapter.fs,
-      });
-      const result = await discoverAll(discoveryOptions);
-      const shouldWarnOnEmptyAiDiscovery = discoveryOptions.toolDirs.length > 0 ||
-        discoveryOptions.agentDirs.length > 0;
-
-      const logData = {
-        projectSlug: ctx.projectSlug,
-        releaseId: ctx.releaseId,
-        agents: result.agents.size,
-        tools: result.tools.size,
-        errors: result.errors.length,
-      };
-
-      if (result.errors.length > 0) {
-        logger.warn("Primitive discovery completed with errors", {
-          ...logData,
-          failures: summarizeDiscoveryFailures(result.errors, ctx.projectDir),
-          omittedErrors: Math.max(0, result.errors.length - MAX_DISCOVERY_FAILURES_TO_LOG),
+        const discoveryOptions = createProjectDiscoveryConfig({
+          projectDir: ctx.projectDir,
+          config: ctx.config,
+          fsAdapter: ctx.adapter.fs,
         });
-      } else if (
-        result.agents.size === 0 && result.tools.size === 0 && shouldWarnOnEmptyAiDiscovery
-      ) {
-        logger.info("Primitive discovery found 0 agents and 0 tools", logData);
-      } else {
-        logger.info("Primitive discovery completed", logData);
-      }
+        const result = await discoverAll(discoveryOptions);
+        const shouldWarnOnEmptyAiDiscovery = discoveryOptions.toolDirs.length > 0 ||
+          discoveryOptions.agentDirs.length > 0;
 
-      return result;
+        const logData = {
+          projectSlug: ctx.projectSlug,
+          releaseId: ctx.releaseId,
+          agents: result.agents.size,
+          tools: result.tools.size,
+          errors: result.errors.length,
+        };
+
+        if (result.errors.length > 0) {
+          logger.warn("Primitive discovery completed with errors", {
+            ...logData,
+            failures: summarizeDiscoveryFailures(result.errors, ctx.projectDir),
+            omittedErrors: Math.max(0, result.errors.length - MAX_DISCOVERY_FAILURES_TO_LOG),
+          });
+        } else if (
+          result.agents.size === 0 && result.tools.size === 0 && shouldWarnOnEmptyAiDiscovery
+        ) {
+          logger.info("Primitive discovery found 0 agents and 0 tools", logData);
+        } else {
+          logger.info("Primitive discovery completed", logData);
+        }
+
+        return result;
+      });
     })(),
   };
 

--- a/src/workflow/executor/step-executor.test.ts
+++ b/src/workflow/executor/step-executor.test.ts
@@ -7,8 +7,19 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { step } from "../dsl/step.ts";
 import type { RetryConfig, WorkflowContext, WorkflowNode } from "../types.ts";
-import { StepExecutor } from "./step-executor.ts";
+import { runWithWorkflowTenant, StepExecutor } from "./step-executor.ts";
 import { TIMEOUT_ERROR } from "#veryfront/errors";
+import {
+  runWithCacheKeyContext,
+  tryGetCacheKeyContext,
+  tryGetRegistryScopeId,
+} from "#veryfront/cache/cache-key-builder.ts";
+import {
+  getCurrentRequestContext,
+  runWithRequestContext,
+} from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
+import { ProjectScopedRegistryManager } from "#veryfront/registry/project-scoped-registry-manager.ts";
+import type { CapturedTenantContext } from "../types.ts";
 
 /** A step whose tool throws `error`, counting how many times it is invoked. */
 function makeThrowingStepNode(
@@ -50,6 +61,38 @@ function makeStepNode(retry: RetryConfig): WorkflowNode {
     retry,
   });
 }
+
+describe("workflow tenant registry scoping", () => {
+  it("restores a release-less production environment without a synthetic cache scope", async () => {
+    const tenant: CapturedTenantContext = {
+      projectSlug: "workflow-environment-project",
+      projectId: "workflow-environment-project-id",
+      token: "<TOKEN>",
+      productionMode: true,
+      releaseId: null,
+      environmentName: "Development",
+    };
+    const manager = new ProjectScopedRegistryManager<string>("skill");
+
+    await runWithRequestContext(tenant, async () => {
+      manager.register("environment-skill", "available");
+    });
+
+    await runWithCacheKeyContext(
+      { projectId: "outer-project", mode: "production", versionId: "outer-release" },
+      () =>
+        runWithWorkflowTenant(tenant, async () => {
+          assertEquals(manager.get("environment-skill"), "available");
+          assertEquals(tryGetCacheKeyContext(), null);
+          assertEquals(
+            tryGetRegistryScopeId(),
+            "workflow-environment-project-id:production:environment:Development",
+          );
+          assertEquals(getCurrentRequestContext()?.environmentName, "Development");
+        }),
+    );
+  });
+});
 
 describe("StepExecutor retry validation", () => {
   it("rejects negative maxAttempts before executing the step", async () => {

--- a/src/workflow/executor/step-executor.ts
+++ b/src/workflow/executor/step-executor.ts
@@ -4,7 +4,9 @@ import type { Tool } from "#veryfront/tool/types.ts";
 import {
   type CacheKeyContext,
   runWithCacheKeyContext,
+  runWithoutCacheKeyContext,
 } from "#veryfront/cache/cache-key-builder.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { ensureError } from "#veryfront/errors/veryfront-error.ts";
 import { isVeryfrontError } from "#veryfront/errors/http-error.ts";
 import {
@@ -44,13 +46,21 @@ export function getWorkflowTenant(): CapturedTenantContext | undefined {
   return workflowTenantStorage.getStore();
 }
 
-function cacheKeyContextFromWorkflowTenant(tenant: CapturedTenantContext): CacheKeyContext {
+function cacheKeyContextFromWorkflowTenant(
+  tenant: CapturedTenantContext,
+): CacheKeyContext | null {
   const mode = tenant.productionMode ? "production" : "preview";
 
+  // Environment sources are mutable and have no immutable version segment.
+  // A synthetic "latest" distributed-cache bucket can mix different source
+  // snapshots, so these tenants use request context for registry isolation and
+  // deliberately skip distributed caching.
+  if (mode === "production" && !tenant.releaseId) return null;
+
   return {
-    projectId: tenant.projectId || tenant.projectSlug || "default",
+    projectId: tenant.projectId || tenant.projectSlug,
     mode,
-    versionId: mode === "production" ? (tenant.releaseId || "latest") : (tenant.branch || "main"),
+    versionId: mode === "production" ? tenant.releaseId! : (tenant.branch || "main"),
   };
 }
 
@@ -65,7 +75,24 @@ export function runWithWorkflowTenant<T>(
   if (!tenant) return fn();
   return workflowTenantStorage.run(
     tenant,
-    () => runWithCacheKeyContext(cacheKeyContextFromWorkflowTenant(tenant), fn),
+    () =>
+      runWithRequestContext(
+        {
+          projectSlug: tenant.projectSlug,
+          token: tenant.token,
+          projectId: tenant.projectId,
+          productionMode: tenant.productionMode,
+          releaseId: tenant.releaseId,
+          branch: tenant.branch,
+          environmentName: tenant.environmentName,
+        },
+        () => {
+          const cacheContext = cacheKeyContextFromWorkflowTenant(tenant);
+          return cacheContext
+            ? runWithCacheKeyContext(cacheContext, fn)
+            : runWithoutCacheKeyContext(fn);
+        },
+      ),
   );
 }
 

--- a/tests/integration/adapters/branch-cache-isolation.test.ts
+++ b/tests/integration/adapters/branch-cache-isolation.test.ts
@@ -57,12 +57,27 @@ describe("Branch Cache Isolation - Context Verification", () => {
       );
       assertEquals(releaseKey, "proxy:test-project:production:rel_123");
 
+      const environmentKey = buildProxyManagerCacheKey(
+        "test-project",
+        true,
+        null,
+        null,
+        "Development",
+      );
+      assertEquals(
+        environmentKey,
+        "proxy:test-project:production:environment:Development",
+      );
+
       let threw = false;
       try {
         buildProxyManagerCacheKey("test-project", true, null, null);
       } catch (e) {
         threw = true;
-        assertEquals((e as Error).message, "Missing releaseId in production for test-project");
+        assertEquals(
+          (e as Error).message,
+          "Missing releaseId or environmentName in production for test-project",
+        );
       }
       assertEquals(threw, true, "Expected error when releaseId is missing in production mode");
     });

--- a/tests/integration/adapters/proxy-fs-adapter-manager.test.ts
+++ b/tests/integration/adapters/proxy-fs-adapter-manager.test.ts
@@ -6,7 +6,7 @@
  */
 
 import "../../_helpers/contract-init.ts";
-import { assert, assertEquals } from "#veryfront/testing/assert";
+import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { ProxyFSAdapterManager } from "#veryfront/platform/adapters/fs/veryfront/proxy-manager.ts";
 
@@ -84,7 +84,7 @@ describe("ProxyFSAdapterManager - Cache Isolation", () => {
       assertEquals(manager.hasAdapter("my-project", true, "release-1"), false);
       assertEquals(manager.hasAdapter("my-project", true, "release-2"), false);
 
-      assertThrows(() => manager.hasAdapter("my-project", true, null));
+      assertEquals(manager.hasAdapter("my-project", true, null), false);
 
       assertEquals(
         manager.hasAdapter("my-project", false, null),
@@ -128,13 +128,3 @@ describe("ProxyFSAdapterManager - Cache Isolation", () => {
     }
   });
 });
-
-function assertThrows(fn: () => void): void {
-  let threw = false;
-  try {
-    fn();
-  } catch {
-    threw = true;
-  }
-  assert(threw, "Expected error when releaseId is missing in production mode");
-}


### PR DESCRIPTION
## Scope

This is cross-project isolation hardening discovered while investigating veryfront/veryfront-api#3952. It prevents project-scoped registries from collapsing into the shared `__default__` scope when an environment context has no pinned release ID.

## Important incident correction

This PR is **not** the causal fix for #3952. Production evidence later showed the affected requests already carried a release ID. The deterministic #3952 failure is invalid project skill metadata (`name: "On-Call Triage"` instead of lowercase kebab-case) in `veryfront-ops-agent`; that content patch, deployment, and replay are tracked separately.

## Failure mode this PR prevents

1. `tryGetCacheKeyContext()` correctly returns `null` when production has no stable release ID, because distributed caches must not share an unversioned key.
2. `ProjectScopedRegistryManager` used that cache result directly and fell back to `__default__`.
3. Concurrent unversioned environment requests from different projects could therefore share a registry scope.
4. One project's discovery clear could remove another project's in-flight entries.

## Fix

- Add `tryGetRegistryScopeId()`, which preserves project isolation using the environment, branch, or an `unversioned` sentinel even when distributed caching is intentionally disabled.
- Use it only for in-process registry scoping; distributed cache behavior remains unchanged.
- Add a concurrency regression proving one project's skill clear cannot wipe another project's skill.

## Verification

- `deno check src/cache/cache-key-builder.ts src/registry/project-scoped-registry-manager.ts`
- Full pre-push suite: 2,387 tests / 20,291 steps, zero failures
- GitHub format, lint, typecheck, unit, integration, coverage, browser/binary E2E, npm smoke, audit, and CodeQL checks are green