### PR TITLE
Publish skill-registry scope isolation in framework 0.1.1071

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1070",
+  "version": "0.1.1071",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1070";
+export const VERSION = "0.1.1071";


### PR DESCRIPTION
Advances the stable framework version `0.1.1070 → 0.1.1071` (synchronized `deno.json` + `src/utils/version-constant.ts`) so the fix merged in #2947 ships.

## Why 0.1.1071
`0.1.1070` was published by #2946 **before** #2947 merged, so it does not contain the skill-registry scope isolation fix.

## What 0.1.1071 delivers
- #2947 — per-project skill registry scopes for environment-source control-plane runs. Fixes veryfront/veryfront-api#3952 (project skills invisible to scheduled agent runs: all projects shared one `__default__` registry scope and wiped each other's skills during discovery).

## Verification
Version synchronization and stable release-intent tests: 2 files, 25 steps, 0 failed.

After this merges and publishes, the veryfront-ops-agent project will be redeployed and its `load_skill` verified end-to-end before unpausing the triage-sweep schedule.