### PR TITLE
Preserve registry invariants during concurrent discovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1071",
+  "version": "0.1.1072",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/registry/project-scoped-registry-manager.test.ts
+++ b/src/registry/project-scoped-registry-manager.test.ts
@@ -282,6 +282,132 @@ describe("ProjectScopedRegistryManager transactions", () => {
     });
   });
 
+  it("preserves a live registration that arrives while replacement is staged", async () => {
+    const manager = new ProjectScopedRegistryManager<string>("agent");
+    runWithCacheKeyContext(scope, () => manager.register("old-agent", "old"));
+
+    const stageReady = Promise.withResolvers<void>();
+    const releaseStage = Promise.withResolvers<void>();
+    const transaction = runWithCacheKeyContext(
+      scope,
+      () =>
+        runWithRegistryTransaction(async () => {
+          manager.clear();
+          manager.register("discovered-agent", "discovered");
+          stageReady.resolve();
+          await releaseStage.promise;
+        }),
+    );
+
+    await stageReady.promise;
+    runWithCacheKeyContext(scope, () => manager.register("route-agent", "route"));
+
+    releaseStage.resolve();
+    await transaction;
+
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.get("old-agent"), undefined);
+      assertEquals(manager.get("discovered-agent"), "discovered");
+      assertEquals(manager.get("route-agent"), "route");
+    });
+  });
+
+  it("preserves a live deletion that arrives while mutations are staged", async () => {
+    const manager = new ProjectScopedRegistryManager<string>("agent");
+    runWithCacheKeyContext(scope, () => {
+      manager.register("deleted-agent", "old");
+      manager.register("stable-agent", "stable");
+    });
+
+    const stageReady = Promise.withResolvers<void>();
+    const releaseStage = Promise.withResolvers<void>();
+    const transaction = runWithCacheKeyContext(
+      scope,
+      () =>
+        runWithRegistryTransaction(async () => {
+          manager.register("discovered-agent", "discovered");
+          stageReady.resolve();
+          await releaseStage.promise;
+        }),
+    );
+
+    await stageReady.promise;
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.delete("deleted-agent"), true);
+    });
+
+    releaseStage.resolve();
+    await transaction;
+
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.get("deleted-agent"), undefined);
+      assertEquals(manager.get("stable-agent"), "stable");
+      assertEquals(manager.get("discovered-agent"), "discovered");
+    });
+  });
+
+  it("honors a live clear after a transaction stages the first item", async () => {
+    const manager = new ProjectScopedRegistryManager<string>("agent");
+    const stageReady = Promise.withResolvers<void>();
+    const releaseStage = Promise.withResolvers<void>();
+    const transaction = runWithCacheKeyContext(
+      scope,
+      () =>
+        runWithRegistryTransaction(async () => {
+          manager.register("staged-agent", "staged");
+          stageReady.resolve();
+          await releaseStage.promise;
+        }),
+    );
+
+    await stageReady.promise;
+    runWithCacheKeyContext(scope, () => manager.clear());
+
+    releaseStage.resolve();
+    await transaction;
+
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.get("staged-agent"), undefined);
+    });
+  });
+
+  it("serializes concurrent transactions for the same registry scope", async () => {
+    const manager = new ProjectScopedRegistryManager<string>("agent");
+    const firstStarted = Promise.withResolvers<void>();
+    const releaseFirst = Promise.withResolvers<void>();
+    let secondStarted = false;
+
+    const first = runWithCacheKeyContext(
+      scope,
+      () =>
+        runWithRegistryTransaction(async () => {
+          manager.register("first-agent", "first");
+          firstStarted.resolve();
+          await releaseFirst.promise;
+        }),
+    );
+    await firstStarted.promise;
+
+    const second = runWithCacheKeyContext(
+      scope,
+      () =>
+        runWithRegistryTransaction(async () => {
+          secondStarted = true;
+          manager.register("second-agent", "second");
+        }),
+    );
+    await Promise.resolve();
+    assertEquals(secondStarted, false);
+
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+
+    runWithCacheKeyContext(scope, () => {
+      assertEquals(manager.get("first-agent"), "first");
+      assertEquals(manager.get("second-agent"), "second");
+    });
+  });
+
   it("discards staged mutations when the transaction fails", async () => {
     const manager = new ProjectScopedRegistryManager<string>("skill");
     runWithCacheKeyContext(scope, () => manager.register("stable-skill", "stable"));

--- a/src/registry/project-scoped-registry-manager.ts
+++ b/src/registry/project-scoped-registry-manager.ts
@@ -29,8 +29,29 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 const DEFAULT_SCOPE_ID = "__default__";
 
+type RegistryMutation<T> =
+  | { readonly type: "clear" }
+  | { readonly type: "delete"; readonly id: string }
+  | { readonly type: "set"; readonly id: string; readonly item: T };
+
+interface RegistryTransactionPublication {
+  publish(): void;
+}
+
 interface RegistryTransactionStage {
-  commit(): void;
+  prepare(): RegistryTransactionPublication;
+  abort(): void;
+}
+
+interface ManagedRegistryTransactionStage<T> extends RegistryTransactionStage {
+  readonly registry: Map<string, T>;
+  validateRegistration(id: string, incoming: T): void;
+  record(mutation: RegistryMutation<T>): void;
+}
+
+interface ProjectScopedRegistryManagerOptions<T> {
+  /** Must be side-effect free; transaction preparation may invoke it again. */
+  validateRegistration?(id: string, existing: T, incoming: T): void;
 }
 
 interface RegistryTransaction {
@@ -40,6 +61,25 @@ interface RegistryTransaction {
 }
 
 const registryTransactionStorage = new AsyncLocalStorage<RegistryTransaction>();
+const registryTransactionLocks = new Map<string, Promise<void>>();
+
+async function acquireRegistryTransactionLock(scopeId: string): Promise<() => void> {
+  const previous = registryTransactionLocks.get(scopeId) ?? Promise.resolve();
+  const gate = Promise.withResolvers<void>();
+  const current = previous.then(() => gate.promise);
+  registryTransactionLocks.set(scopeId, current);
+  await previous;
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    gate.resolve();
+    if (registryTransactionLocks.get(scopeId) === current) {
+      registryTransactionLocks.delete(scopeId);
+    }
+  };
+}
 
 function buildRegistryScopeId(): string {
   // tryGetRegistryScopeId() returns a project-isolated key even when
@@ -54,8 +94,10 @@ function buildRegistryScopeId(): string {
  * Stage project-scoped registry mutations and publish them as one synchronous
  * commit after the callback succeeds. Reads inside the callback see staged
  * state; concurrent requests keep seeing the previous live state.
- * The commit is an authoritative replacement, so it linearizes after and may
- * supersede live writes made to the same scope while staging is in progress.
+ * Transactions for the same scope are serialized. Live writes made outside
+ * the transaction while discovery is in flight are journaled alongside staged
+ * mutations and replayed in call order, preserving the previous immediate-
+ * mutation semantics without exposing a partially discovered generation.
  * Use this for complete discovery generations, not incremental updates.
  *
  * Nested calls participate in the existing transaction. If a nested tenant
@@ -66,30 +108,43 @@ export async function runWithRegistryTransaction<T>(fn: () => Promise<T>): Promi
   const existing = registryTransactionStorage.getStore();
   if (existing?.state === "active") return await fn();
 
+  const targetScopeId = buildRegistryScopeId();
+  const releaseLock = await acquireRegistryTransactionLock(targetScopeId);
   const transaction: RegistryTransaction = {
-    targetScopeId: buildRegistryScopeId(),
+    targetScopeId,
     stages: new Map(),
     state: "active",
   };
 
-  return await registryTransactionStorage.run(transaction, async () => {
-    try {
-      const result = await fn();
+  try {
+    return await registryTransactionStorage.run(transaction, async () => {
+      try {
+        const result = await fn();
 
-      // Map replacement is synchronous. No other request can observe a partial
-      // commit between managers in this JavaScript turn.
-      for (const stage of transaction.stages.values()) {
-        stage.commit();
+        // Prepare every manager before publishing any of them. Publication is
+        // synchronous, so no request can observe a partial generation.
+        const publications = Array.from(
+          transaction.stages.values(),
+          (stage) => stage.prepare(),
+        );
+        for (const publication of publications) {
+          publication.publish();
+        }
+        transaction.state = "committed";
+        transaction.stages.clear();
+        return result;
+      } catch (error) {
+        transaction.state = "aborted";
+        for (const stage of transaction.stages.values()) {
+          stage.abort();
+        }
+        transaction.stages.clear();
+        throw error;
       }
-      transaction.state = "committed";
-      transaction.stages.clear();
-      return result;
-    } catch (error) {
-      transaction.state = "aborted";
-      transaction.stages.clear();
-      throw error;
-    }
-  });
+    });
+  } finally {
+    releaseLock();
+  }
 }
 
 /**
@@ -100,8 +155,42 @@ export async function runWithRegistryTransaction<T>(fn: () => Promise<T>): Promi
 export class ProjectScopedRegistryManager<T> {
   private registriesByScope = new Map<string, Map<string, T>>();
   private sharedRegistry = new Map<string, T>();
+  private activeStagesByScope = new Map<string, Set<ManagedRegistryTransactionStage<T>>>();
 
-  constructor(private registryName: string) {}
+  constructor(
+    private registryName: string,
+    private options: ProjectScopedRegistryManagerOptions<T> = {},
+  ) {}
+
+  private validateRegistration(
+    registry: Map<string, T>,
+    id: string,
+    incoming: T,
+  ): void {
+    if (!registry.has(id)) return;
+    this.options.validateRegistration?.(id, registry.get(id) as T, incoming);
+  }
+
+  private applyMutation(
+    registry: Map<string, T>,
+    mutation: RegistryMutation<T>,
+    validateRegistration = false,
+  ): void {
+    switch (mutation.type) {
+      case "clear":
+        registry.clear();
+        break;
+      case "delete":
+        registry.delete(mutation.id);
+        break;
+      case "set":
+        if (validateRegistration) {
+          this.validateRegistration(registry, mutation.id, mutation.item);
+        }
+        registry.set(mutation.id, mutation.item);
+        break;
+    }
+  }
 
   /**
    * Get the current project ID from AsyncLocalStorage context.
@@ -111,8 +200,10 @@ export class ProjectScopedRegistryManager<T> {
     return buildRegistryScopeId();
   }
 
-  /** Return a transaction-local copy of the target registry when staging. */
-  private getTransactionRegistry(scopeId: string): Map<string, T> | undefined {
+  /** Return the transaction-local stage for this manager and scope. */
+  private getTransactionStage(
+    scopeId: string,
+  ): ManagedRegistryTransactionStage<T> | undefined {
     const transaction = registryTransactionStorage.getStore();
     if (!transaction) return undefined;
     if (transaction.state === "committed") return undefined;
@@ -131,37 +222,75 @@ export class ProjectScopedRegistryManager<T> {
     }
 
     const existing = transaction.stages.get(this) as
-      | (RegistryTransactionStage & { registry: Map<string, T> })
+      | ManagedRegistryTransactionStage<T>
       | undefined;
-    if (existing) return existing.registry;
+    if (existing) return existing;
 
-    const registry = new Map(this.registriesByScope.get(scopeId));
-    const stage: RegistryTransactionStage & { registry: Map<string, T> } = {
+    const baseRegistry = new Map(this.registriesByScope.get(scopeId));
+    const registry = new Map(baseRegistry);
+    const validationRegistry = new Map(baseRegistry);
+    const mutations: RegistryMutation<T>[] = [];
+    let closed = false;
+
+    const close = () => {
+      if (closed) return;
+      closed = true;
+      const activeStages = this.activeStagesByScope.get(scopeId);
+      activeStages?.delete(stage);
+      if (activeStages?.size === 0) this.activeStagesByScope.delete(scopeId);
+    };
+
+    const stage: ManagedRegistryTransactionStage<T> = {
       registry,
-      commit: () => {
-        if (registry.size === 0) {
-          this.registriesByScope.delete(scopeId);
-        } else {
-          this.registriesByScope.set(scopeId, registry);
-        }
+      validateRegistration: (id, incoming) => {
+        this.validateRegistration(validationRegistry, id, incoming);
       },
+      record: (mutation) => {
+        mutations.push(mutation);
+        this.applyMutation(validationRegistry, mutation);
+      },
+      prepare: () => {
+        const replacement = new Map(baseRegistry);
+        for (const mutation of mutations) {
+          this.applyMutation(replacement, mutation, true);
+        }
+
+        return {
+          publish: () => {
+            close();
+            if (replacement.size === 0) {
+              this.registriesByScope.delete(scopeId);
+            } else {
+              this.registriesByScope.set(scopeId, replacement);
+            }
+          },
+        };
+      },
+      abort: close,
     };
     transaction.stages.set(this, stage);
-    return registry;
+    const activeStages = this.activeStagesByScope.get(scopeId) ?? new Set();
+    activeStages.add(stage);
+    this.activeStagesByScope.set(scopeId, activeStages);
+    return stage;
+  }
+
+  /** Record a live mutation in any in-flight transaction for this scope. */
+  private recordLiveMutation(scopeId: string, mutation: RegistryMutation<T>): void {
+    for (const stage of this.activeStagesByScope.get(scopeId) ?? []) {
+      stage.record(mutation);
+    }
   }
 
   /** Read the active registry, routing transaction access to its staged copy. */
   private getActiveScopeRegistry(scopeId: string): Map<string, T> | undefined {
-    return this.getTransactionRegistry(scopeId) ?? this.registriesByScope.get(scopeId);
+    return this.getTransactionStage(scopeId)?.registry ?? this.registriesByScope.get(scopeId);
   }
 
   /**
    * Get or create registry for a specific project.
    */
   private getScopeRegistry(scopeId: string): Map<string, T> {
-    const staged = this.getTransactionRegistry(scopeId);
-    if (staged) return staged;
-
     const existing = this.registriesByScope.get(scopeId);
     if (existing) return existing;
 
@@ -175,8 +304,11 @@ export class ProjectScopedRegistryManager<T> {
    */
   register(id: string, item: T): void {
     const scopeId = this.getCurrentScopeId();
-    const registry = this.getScopeRegistry(scopeId);
+    const stage = this.getTransactionStage(scopeId);
+    const registry = stage?.registry ?? this.getScopeRegistry(scopeId);
 
+    if (stage) stage.validateRegistration(id, item);
+    else this.validateRegistration(registry, id, item);
     if (registry.has(id)) {
       agentLogger.debug(
         `[${this.registryName}] "${id}" already registered for scope ${scopeId}. Overwriting.`,
@@ -184,6 +316,9 @@ export class ProjectScopedRegistryManager<T> {
     }
 
     registry.set(id, item);
+    const mutation: RegistryMutation<T> = { type: "set", id, item };
+    if (stage) stage.record(mutation);
+    else this.recordLiveMutation(scopeId, mutation);
     agentLogger.debug(`[${this.registryName}] Registered "${id}" for scope ${scopeId}`);
   }
 
@@ -260,24 +395,31 @@ export class ProjectScopedRegistryManager<T> {
    */
   delete(id: string): boolean {
     const scopeId = this.getCurrentScopeId();
-    const registry = this.getActiveScopeRegistry(scopeId);
-    if (!registry?.has(id)) return false;
+    const stage = this.getTransactionStage(scopeId);
+    const registry = stage?.registry ?? this.registriesByScope.get(scopeId);
+    const existed = registry?.has(id) ?? false;
+    if (!existed && !stage && !this.activeStagesByScope.has(scopeId)) return false;
 
-    registry.delete(id);
+    registry?.delete(id);
+    const mutation: RegistryMutation<T> = { type: "delete", id };
+    if (stage) stage.record(mutation);
+    else this.recordLiveMutation(scopeId, mutation);
     agentLogger.debug(`[${this.registryName}] Deleted "${id}" from scope ${scopeId}`);
-    return true;
+    return existed;
   }
 
   /**
    * Clear all items for the current project.
    */
   clear(): void {
-    const staged = this.getTransactionRegistry(this.getCurrentScopeId());
-    if (staged) {
-      staged.clear();
+    const scopeId = this.getCurrentScopeId();
+    const stage = this.getTransactionStage(scopeId);
+    if (stage) {
+      stage.registry.clear();
+      stage.record({ type: "clear" });
       return;
     }
-    this.clearProject(this.getCurrentScopeId());
+    this.clearProject(scopeId);
   }
 
   /**
@@ -292,10 +434,14 @@ export class ProjectScopedRegistryManager<T> {
     }
 
     let cleared = false;
-    for (const scopeId of Array.from(this.registriesByScope.keys())) {
+    const scopeIds = new Set([
+      ...this.registriesByScope.keys(),
+      ...this.activeStagesByScope.keys(),
+    ]);
+    for (const scopeId of scopeIds) {
       if (scopeId === projectId || scopeId.startsWith(`${projectId}:`)) {
-        this.registriesByScope.delete(scopeId);
-        cleared = true;
+        cleared = this.registriesByScope.delete(scopeId) || cleared;
+        this.recordLiveMutation(scopeId, { type: "clear" });
       }
     }
 
@@ -315,6 +461,13 @@ export class ProjectScopedRegistryManager<T> {
       );
     }
 
+    const scopeIds = new Set([
+      ...this.registriesByScope.keys(),
+      ...this.activeStagesByScope.keys(),
+    ]);
+    for (const scopeId of scopeIds) {
+      this.recordLiveMutation(scopeId, { type: "clear" });
+    }
     this.registriesByScope.clear();
     this.sharedRegistry.clear();
     agentLogger.debug(`[${this.registryName}] Cleared all registries`);

--- a/src/tool/registry.test.ts
+++ b/src/tool/registry.test.ts
@@ -1,11 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd";
-import { assertEquals, assertThrows } from "#veryfront/testing/assert";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { tool } from "./factory.ts";
 import { toolRegistry, toolToProviderDefinition } from "./registry.ts";
 import type { Tool } from "./types.ts";
 import { VeryfrontError } from "#veryfront/errors/types.ts";
+import { runWithRegistryTransaction } from "#veryfront/registry/project-scoped-registry-manager.ts";
 
 describe("tool registry", () => {
   afterEach(() => {
@@ -216,6 +217,103 @@ describe("tool registry", () => {
       // The losing registration must have thrown a VeryfrontError
       assertEquals(errorFromB instanceof VeryfrontError, true);
       assertEquals((errorFromB as VeryfrontError).slug, "tool-id-conflict");
+    });
+
+    it("rejects a live conflict that arrives after a staged registration", async () => {
+      const schema = defineSchema((v) => v.object({}))();
+      const staged = tool({
+        id: "interleaved-tool",
+        description: "discovery version",
+        inputSchema: schema,
+        execute: async () => "discovery",
+      });
+      const live = tool({
+        id: "interleaved-tool",
+        description: "route version",
+        inputSchema: schema,
+        execute: async () => "route",
+      });
+      const stageReady = Promise.withResolvers<void>();
+      const releaseStage = Promise.withResolvers<void>();
+
+      const transaction = runWithRegistryTransaction(async () => {
+        toolRegistry.clear();
+        toolRegistry.register("interleaved-tool", staged);
+        stageReady.resolve();
+        await releaseStage.promise;
+      });
+
+      await stageReady.promise;
+      toolRegistry.register("interleaved-tool", live);
+      releaseStage.resolve();
+
+      await assertRejects(() => transaction, VeryfrontError, "interleaved-tool");
+      assertEquals(toolRegistry.get("interleaved-tool"), live);
+    });
+
+    it("rejects a staged conflict that follows a live registration", async () => {
+      const schema = defineSchema((v) => v.object({}))();
+      const live = tool({
+        id: "reverse-interleaved-tool",
+        description: "route version",
+        inputSchema: schema,
+        execute: async () => "route",
+      });
+      const staged = tool({
+        id: "reverse-interleaved-tool",
+        description: "discovery version",
+        inputSchema: schema,
+        execute: async () => "discovery",
+      });
+      const stageReady = Promise.withResolvers<void>();
+      const releaseStage = Promise.withResolvers<void>();
+
+      const transaction = runWithRegistryTransaction(async () => {
+        toolRegistry.clear();
+        stageReady.resolve();
+        await releaseStage.promise;
+        toolRegistry.register("reverse-interleaved-tool", staged);
+      });
+
+      await stageReady.promise;
+      toolRegistry.register("reverse-interleaved-tool", live);
+      releaseStage.resolve();
+
+      await assertRejects(() => transaction, VeryfrontError, "reverse-interleaved-tool");
+      assertEquals(toolRegistry.get("reverse-interleaved-tool"), live);
+    });
+
+    it("allows a staged replacement after an interleaved live clear", async () => {
+      const schema = defineSchema((v) => v.object({}))();
+      const first = tool({
+        id: "cleared-interleaved-tool",
+        description: "first discovery version",
+        inputSchema: schema,
+        execute: async () => "first",
+      });
+      const replacement = tool({
+        id: "cleared-interleaved-tool",
+        description: "replacement discovery version",
+        inputSchema: schema,
+        execute: async () => "replacement",
+      });
+      const firstStaged = Promise.withResolvers<void>();
+      const stageReplacement = Promise.withResolvers<void>();
+
+      const transaction = runWithRegistryTransaction(async () => {
+        toolRegistry.clear();
+        toolRegistry.register("cleared-interleaved-tool", first);
+        firstStaged.resolve();
+        await stageReplacement.promise;
+        toolRegistry.register("cleared-interleaved-tool", replacement);
+      });
+
+      await firstStaged.promise;
+      toolRegistry.clear();
+      stageReplacement.resolve();
+      await transaction;
+
+      assertEquals(toolRegistry.get("cleared-interleaved-tool"), replacement);
     });
   });
 });

--- a/src/tool/registry.ts
+++ b/src/tool/registry.ts
@@ -5,8 +5,6 @@ import { ScopedRegistryFacade } from "#veryfront/registry/scoped-registry-facade
 import { ProjectScopedRegistryManager } from "#veryfront/registry/project-scoped-registry-manager.ts";
 import { TOOL_ID_CONFLICT } from "#veryfront/errors/error-registry/agent.ts";
 
-const toolManager = new ProjectScopedRegistryManager<Tool>("tool");
-
 /**
  * Returns true when `incoming` is considered the same definition as `existing`:
  * same object reference, or matching id + description. Equivalent definitions
@@ -18,18 +16,25 @@ function isSameToolDefinition(existing: Tool, incoming: Tool): boolean {
     (existing.id === incoming.id && existing.description === incoming.description);
 }
 
+function validateToolRegistration(id: string, existing: Tool, incoming: Tool): void {
+  if (isSameToolDefinition(existing, incoming)) return;
+  throw TOOL_ID_CONFLICT.create({
+    detail:
+      `Tool "${id}" is already registered with a different definition. Use a unique tool ID or rename one of the conflicting tools.`,
+  });
+}
+
+const toolManager = new ProjectScopedRegistryManager<Tool>("tool", {
+  validateRegistration: validateToolRegistration,
+});
+
 class ToolRegistryClass extends ScopedRegistryFacade<Tool> {
   override register(id: string, item: Tool): void {
-    // Conflict-check against the project's own scope only: a project tool is
-    // allowed to shadow a shared/framework tool with the same ID.
+    // Equivalent-registration diagnostics inspect the project scope only;
+    // the manager enforces conflicts here and again against journaled order.
+    // Shared/framework tools remain intentionally shadowable.
     const existing = this.getOwn(id);
-    if (existing !== undefined && !isSameToolDefinition(existing, item)) {
-      throw TOOL_ID_CONFLICT.create({
-        detail:
-          `Tool "${id}" is already registered with a different definition. Use a unique tool ID or rename one of the conflicting tools.`,
-      });
-    }
-    if (existing !== undefined && existing !== item) {
+    if (existing !== undefined && existing !== item && isSameToolDefinition(existing, item)) {
       agentLogger.debug(`[tool] "${id}" re-registered with equivalent definition; replacing.`);
     }
     super.register(id, item);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1071";
+export const VERSION = "0.1.1072";


### PR DESCRIPTION
## Summary

- Follow up #2947 after final concurrency review exposed mutation loss during project-scoped discovery.
- Serialize same-scope transaction generations and journal staged plus live mutations in exact call order.
- Preserve TOOL_ID_CONFLICT validation with a combined-order shadow while allowing replacements after clear or delete.
- Prepare every registry before synchronous publication so validation failures abort all staged state without discarding live winners.
- Advance deno.json and the shared version constant to 0.1.1072 so downstream runtimes can consume the corrected implementation.

## Regression evidence

The new tests fail against the blind replacement behavior by demonstrating dropped live registrations, resurrected deletions, overlapping same-scope transactions, and stale-view tool conflicts. They pass with ordered replay and validation-shadow handling, including staged A → live clear → staged B.

## Validation

- Affected registry and discovery suites: 166 steps passed
- deno task verify:quick
- Full pre-push suite: 2,390 tests / 20,322 steps, 0 failed
- Independent post-fix review: no P0–P2 blockers
- git diff --check
- npm and GitHub collision checks: 0.1.1072 is unpublished

## Release context

0.1.1071 published the project-scope isolation from #2947 but does not contain this ordered-replay fix. Publishing this PR as 0.1.1072 prevents the exact agent-service upgrade needed by #5906 from adopting the known concurrency race.

Related: #2947, #2948