### PR TITLE
Add model-driven MCP tool discovery and on-demand loading

### DIFF
--- a/docs/architecture/28-model-driven-tool-discovery.md
+++ b/docs/architecture/28-model-driven-tool-discovery.md
@@ -83,6 +83,25 @@ posture:
    activated set feeds `isRemoteToolNameAllowed`, so a tool that was never
    activated cannot execute even if a schema leaks into a request.
 
+## Binding-policy interaction
+
+Two hardening rules govern how the agent's configured `tools` binding interacts
+with discovery and activation.
+
+**Deny-all excludes discovery tools.** When `allowedToolNames` resolves to an
+empty set (explicit `tools: []` binding or a per-run `allowedTools: []`
+override), `search_tools` and `load_tools` are not force-added even when
+`includeRuntimeEssentialToolsWhenEmpty` is set. Activating new tools is a
+broader capability than running pre-configured skills (`load_skill`, which is
+still injectable for skill-enabled empty bindings); the two are treated
+asymmetrically under deny-all.
+
+**Activation is bounded by the binding policy.** `load_tools` accepts a
+`bindingPolicy` option (`ReadonlySet<string> | null`). When set, the authorized
+catalog is intersected with the policy before name validation: names outside the
+policy return the same `unknown_tool` reason as genuinely unknown names (no
+distinguishability). `null` or omitted means unrestricted (`tools: true`).
+
 ## Durability and resume
 
 Activation is persisted as a `CUSTOM` conversation run event

--- a/docs/architecture/28-model-driven-tool-discovery.md
+++ b/docs/architecture/28-model-driven-tool-discovery.md
@@ -1,0 +1,111 @@
+# 28 — Model-Driven Tool Discovery and On-Demand Loading
+
+Status: design accepted, implementation in progress (veryfront-studio#5916).
+
+## Responsibility
+
+Let an agent run discover authorized MCP capabilities and activate a small,
+task-relevant subset mid-run, so the initial model request never has to carry
+every tool schema and no tool silently disappears because of provider caps.
+
+## Problem (current state)
+
+`prepareHostedChatRuntimeToolAssembly` unions local, remote (MCP), and
+provider-native tool names, sorts them alphabetically, and caps the list with
+`selectProviderCompatibleToolNames` (OpenAI: `OPENAI_MAX_TOOLS = 128`). Local
+tools are pinned via `requiredToolNames`; the remaining budget fills with
+remote tools **in alphabetical order**. With ~253 discovered MCP tools, every
+remote tool past the cut line vanishes deterministically — reads early in the
+alphabet survive, later writes (`update_agent`) disappear. This produced the
+partial-update incident in veryfront-studio#5906.
+
+`docs/architecture/21-agent-tool-registration-current-state.md` already flags
+the underlying gaps: tool filtering "should be a named policy, not a loose
+string array", and list handling should be explicit and bounded.
+
+## Design
+
+Two new host tools, siblings of `load_skill` in ergonomics and authorization
+posture:
+
+### `search_tools` — metadata search, side-effect-free
+
+- Input: `{ query?: string, names?: string[], limit?: number }`. `names` is an
+  exact-name lookup; `query` is keyword search over name + description.
+- Output per result: `{ name, description, source, state }` where `state` is
+  `active | available | requires_grant`. **No input schemas** are returned.
+- Search space: the run's *authorized* catalog only — the same
+  project/integration gating as `filterProjectScopedRemoteToolDefinitions`.
+  Hard-unauthorized tools are invisible; grant-recoverable tools surface as
+  `requires_grant` so the model can tell the user what to connect instead of
+  concluding the capability does not exist.
+
+### `load_tools` — activation, capability change
+
+- Input: `{ names: string[] }`. No prior `search_tools` call is required —
+  when the model already knows the tool name (from the prompt, a skill
+  procedure, or an earlier run) activation is a single round-trip.
+- Validates every name against the authorized catalog. Unknown or
+  unauthorized names fail the whole call with a per-name reason — no partial
+  activation, mirroring the atomicity lesson of veryfront-studio#5906.
+- **Refuse, never evict**: if activation would exceed the resolved provider
+  budget (`getProviderToolProfile(model).maxTools` minus pinned tools), the
+  call fails with the exact overflow count. Core/bound tools are never
+  evictable; there is no LRU. Deterministic refusal is debuggable; silent
+  eviction reintroduces the disappearing-tool bug class.
+- On success the activated names join the run's activated set and the
+  response instructs the model that the tools are callable from the next step.
+
+## How activation reaches the model (per-step flow)
+
+1. The activated set lives on the per-run runtime context — the same bag as
+   `RuntimeLoadSkillToolContext.loadedSkillResponses` — never in
+   `ProjectScopedRegistryManager` (that is project-scoped; activation is
+   run-scoped by definition, which also satisfies the no-leak criterion).
+2. `prepareHostedChildForkRuntimeStepMessages` already rebuilds instructions
+   every step; `withRuntimeToolInventory` is idempotent by design. The step
+   preparation reads `pinned ∪ activated` from the live run context instead of
+   a fixed `forkToolNames`, so the next model step sees the refreshed
+   inventory and the new tool schemas.
+3. Assembly changes in `prepareHostedChatRuntimeToolAssembly`: remote names no
+   longer flood the union. Initial inventory = local/configured tools +
+   provider-native + `search_tools`/`load_tools` (added to the essential set
+   in `runtime-essential-tools.ts`, so they are never truncated). The
+   alphabetical `.sort()` before capping remains only as a stable tiebreak for
+   already-selected names, never as a selection mechanism.
+
+## Authorization: three independent gates
+
+1. **Discovery** — `search_tools` searches only the authorized catalog.
+2. **Activation** — `load_tools` re-validates names against the catalog.
+3. **Execution** — unchanged: `prepareExecution` in
+   `project-scoped-remote-tools.ts` re-checks allowance at call time. The
+   activated set feeds `isRemoteToolNameAllowed`, so a tool that was never
+   activated cannot execute even if a schema leaks into a request.
+
+## Durability and resume
+
+Activation is persisted as a `CUSTOM` conversation run event
+(`encodeCustomDataEvent`) with payload `{ kind: "tools_activated", names }`
+(and `tools_activation_rejected` with reasons for diagnostics). Resume replays
+the event stream, so a resumed run rehydrates its activated set — resumption
+never silently downgrades capability. Studio renders these events to explain
+why a tool appeared or was refused.
+
+## Out of scope (unchanged from the issue)
+
+- Sending every MCP schema to every request.
+- Replacing the curated static binding that mitigates #5906 today — it
+  becomes the *initial* inventory rather than the *only* inventory.
+- Bypassing agent, project, integration, or user capability rules.
+
+## Risks
+
+- The inventory system-message format is asserted verbatim in
+  `tool-inventory.test.ts`; refresh semantics must not change the message
+  contract without updating consumers.
+- Dynamic input schemas (the `load_skill` enum-narrowing trick) can bloat if
+  the catalog is huge; `load_tools` therefore validates server-side and keeps
+  its schema static (`names: string[]`), unlike `load_skill`.
+- Per-name failure reasons must not leak other tenants' tool existence: the
+  unauthorized and nonexistent cases return the same `unknown_tool` reason.

--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -242,9 +242,10 @@ Deno.test("prepareHostedChatRuntimeToolAssembly builds provider-compatible runti
   assertEquals(toolAssembly.localToolNames, ["sleep"]);
   assertEquals(toolAssembly.remoteToolNames, ["create_file", "studio_open_project"]);
   assertEquals(toolAssembly.providerToolNames, []);
-  // Remote tools are no longer in the initial inventory (activated on-demand via load_tools).
-  assertEquals(toolAssembly.compatibleRemoteToolNames, []);
-  assertEquals(taskContext.availableToolNames, ["sleep"]);
+  // Configured-binding remote tools ARE in the initial inventory (combined semantics).
+  // The full MCP catalog does not flood the union; only the allowedToolNames subset does.
+  assertEquals(toolAssembly.compatibleRemoteToolNames, ["create_file", "studio_open_project"]);
+  assertEquals(taskContext.availableToolNames, ["create_file", "sleep", "studio_open_project"]);
   assertEquals(toolAssembly.systemInstructions.includes("Current run tool inventory:"), true);
 
   const runtimeSleepTool = toolAssembly.runtimeTools.sleep;
@@ -341,11 +342,11 @@ Deno.test("prepareHostedChatRuntimeToolAssembly separates provider tools from re
   });
 
   assertEquals(toolAssembly.remoteToolNames, ["create_file"]);
-  // Remote tools are not in the initial inventory; compatibleRemoteToolNames is empty.
-  assertEquals(toolAssembly.compatibleRemoteToolNames, []);
+  // Configured-binding remote tools appear in compatibleRemoteToolNames (combined semantics).
+  assertEquals(toolAssembly.compatibleRemoteToolNames, ["create_file"]);
   assertEquals(toolAssembly.providerToolNames, ["web_search"]);
-  // Provider-native tools remain in the initial inventory; remote tools do not.
-  assertEquals(taskContext.availableToolNames, ["web_search"]);
+  // Both configured remote tools and provider-native tools seed the initial inventory.
+  assertEquals(taskContext.availableToolNames, ["create_file", "web_search"]);
 });
 
 Deno.test("prepareHostedChatRuntimeToolAssembly separates matching direct and provider bindings", async () => {

--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -242,8 +242,9 @@ Deno.test("prepareHostedChatRuntimeToolAssembly builds provider-compatible runti
   assertEquals(toolAssembly.localToolNames, ["sleep"]);
   assertEquals(toolAssembly.remoteToolNames, ["create_file", "studio_open_project"]);
   assertEquals(toolAssembly.providerToolNames, []);
-  assertEquals(toolAssembly.compatibleRemoteToolNames, ["create_file", "studio_open_project"]);
-  assertEquals(taskContext.availableToolNames, ["create_file", "sleep", "studio_open_project"]);
+  // Remote tools are no longer in the initial inventory (activated on-demand via load_tools).
+  assertEquals(toolAssembly.compatibleRemoteToolNames, []);
+  assertEquals(taskContext.availableToolNames, ["sleep"]);
   assertEquals(toolAssembly.systemInstructions.includes("Current run tool inventory:"), true);
 
   const runtimeSleepTool = toolAssembly.runtimeTools.sleep;
@@ -340,9 +341,11 @@ Deno.test("prepareHostedChatRuntimeToolAssembly separates provider tools from re
   });
 
   assertEquals(toolAssembly.remoteToolNames, ["create_file"]);
-  assertEquals(toolAssembly.compatibleRemoteToolNames, ["create_file"]);
+  // Remote tools are not in the initial inventory; compatibleRemoteToolNames is empty.
+  assertEquals(toolAssembly.compatibleRemoteToolNames, []);
   assertEquals(toolAssembly.providerToolNames, ["web_search"]);
-  assertEquals(taskContext.availableToolNames, ["create_file", "web_search"]);
+  // Provider-native tools remain in the initial inventory; remote tools do not.
+  assertEquals(taskContext.availableToolNames, ["web_search"]);
 });
 
 Deno.test("prepareHostedChatRuntimeToolAssembly separates matching direct and provider bindings", async () => {

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -35,6 +35,7 @@ import {
   resolveHostedRuntimeAllowedToolNames,
 } from "./runtime-essential-tools.ts";
 import type { HostedSubmittedFormInputResult } from "./chat-runtime-contract.ts";
+import type { RuntimeToolDiscoveryContext } from "../runtime/tool-discovery-context.ts";
 
 /** Context for hosted chat runtime tool assembly. */
 export type HostedChatRuntimeToolAssemblyContext = DefaultResearchArtifactContext & {
@@ -91,6 +92,13 @@ export type PrepareHostedChatRuntimeToolAssemblyInput<
   onSteeringMutation?: HostedProjectRemoteToolSourceMutationHandler;
   onStudioProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler;
   preloadLatestConversationUserText?: boolean;
+  /**
+   * Per-run tool discovery context. When provided, its `activatedRemoteToolNames`
+   * Set is passed (by reference) to every remote tool source as the live
+   * execution gate. The same Set is mutated by `load_tools`, so newly activated
+   * tools become executable without re-creating the sources.
+   */
+  toolDiscoveryContext?: RuntimeToolDiscoveryContext;
 };
 
 function activeProjectId(taskContext: HostedChatRuntimeToolAssemblyContext): string | null {
@@ -218,6 +226,9 @@ export async function prepareHostedChatRuntimeToolAssembly<
     getActiveBranchId: input.getActiveBranchId ?? (() => activeBranchId(input.taskContext)),
     conversationId: input.conversationId,
     allowedToolNames,
+    ...(input.toolDiscoveryContext?.activatedRemoteToolNames !== undefined
+      ? { activatedRemoteToolNames: input.toolDiscoveryContext.activatedRemoteToolNames }
+      : {}),
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
     prepareToolInput: input.prepareRemoteToolInput,
     shouldRetryWithTool: input.shouldRetryWithRemoteTool,
@@ -246,8 +257,11 @@ export async function prepareHostedChatRuntimeToolAssembly<
         : sourceProviderToolNames.has(toolName)),
   );
   const localToolNames = Object.keys(localHostTools);
+  // Remote tools no longer flood the initial inventory. They are listed in
+  // remoteToolNames for catalog purposes and activated on-demand via load_tools.
+  // Only local and provider-native tools seed the initial inventory union.
   const availableToolNames = selectProviderCompatibleToolNames(
-    [...new Set([...localToolNames, ...remoteToolNames, ...providerToolNames])].sort(),
+    [...new Set([...localToolNames, ...providerToolNames])].sort(),
     {
       model: input.taskContext.model,
       requiredToolNames: localToolNames,

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -257,11 +257,13 @@ export async function prepareHostedChatRuntimeToolAssembly<
         : sourceProviderToolNames.has(toolName)),
   );
   const localToolNames = Object.keys(localHostTools);
-  // Remote tools no longer flood the initial inventory. They are listed in
-  // remoteToolNames for catalog purposes and activated on-demand via load_tools.
-  // Only local and provider-native tools seed the initial inventory union.
+  // Initial inventory = configured-binding remote tools + local + provider-native.
+  // The full MCP catalog does not flood the union: remoteToolNames is already
+  // filtered by the agent's configured binding (allowedToolNames), so only the
+  // explicitly selected subset reaches the provider cap. On-demand activation
+  // via load_tools extends this set at runtime beyond what the binding pre-loads.
   const availableToolNames = selectProviderCompatibleToolNames(
-    [...new Set([...localToolNames, ...providerToolNames])].sort(),
+    [...new Set([...localToolNames, ...providerToolNames, ...remoteToolNames])].sort(),
     {
       model: input.taskContext.model,
       requiredToolNames: localToolNames,

--- a/src/agent/hosted/child-fork-step-message-preparation.test.ts
+++ b/src/agent/hosted/child-fork-step-message-preparation.test.ts
@@ -137,3 +137,55 @@ Deno.test("prepareHostedChildForkRuntimeStepMessages falls back to current instr
   assertEquals(prepared.system, "Current instructions");
   assertEquals(prepared.messages, []);
 });
+
+Deno.test("prepareHostedChildForkRuntimeStepMessages returns live forkToolNames when getActivatedToolNames provided", () => {
+  const activated = new Set(["read_file", "write_file"]);
+  const pinned = ["load_skill", "search_tools", "load_tools"];
+
+  const prepared = prepareHostedChildForkRuntimeStepMessages({
+    messages: [],
+    buildInstructions: () => "Instructions",
+    forkToolNames: pinned, // static pinned names
+    pinnedToolNames: pinned,
+    getActivatedToolNames: () => [...activated],
+  });
+
+  // forkToolNames in result = pinned ∪ activated, sorted
+  assertEquals(prepared.forkToolNames?.sort(), [
+    "load_skill",
+    "load_tools",
+    "read_file",
+    "search_tools",
+    "write_file",
+  ]);
+});
+
+Deno.test("prepareHostedChildForkRuntimeStepMessages omits forkToolNames when no activated getter provided", () => {
+  const prepared = prepareHostedChildForkRuntimeStepMessages({
+    messages: [],
+    buildInstructions: () => "Instructions",
+    forkToolNames: ["load_skill"],
+  });
+
+  // No getter provided — caller should keep using its own fixed forkToolNames
+  assertEquals(prepared.forkToolNames, undefined);
+});
+
+Deno.test("prepareHostedChildForkRuntimeStepMessages deduplicates pinned and activated names", () => {
+  const activated = new Set(["load_skill", "new_tool"]); // load_skill is also pinned
+  const pinned = ["load_skill", "search_tools"];
+
+  const prepared = prepareHostedChildForkRuntimeStepMessages({
+    messages: [],
+    buildInstructions: () => "Instructions",
+    forkToolNames: pinned,
+    pinnedToolNames: pinned,
+    getActivatedToolNames: () => [...activated],
+  });
+
+  // load_skill must appear only once
+  const names = prepared.forkToolNames ?? [];
+  const loadSkillCount = names.filter((n) => n === "load_skill").length;
+  assertEquals(loadSkillCount, 1);
+  assertEquals(names.sort(), ["load_skill", "new_tool", "search_tools"]);
+});

--- a/src/agent/hosted/child-fork-step-message-preparation.ts
+++ b/src/agent/hosted/child-fork-step-message-preparation.ts
@@ -23,12 +23,30 @@ export type PrepareHostedChildForkRuntimeStepMessagesInput = {
   buildInstructions: () => string;
   forkToolNames: readonly string[];
   resolveSystem?: HostedChildForkRuntimeStepSystemResolver;
+  /**
+   * Pinned tool names (local/essential) that are always present.
+   * Required when `getActivatedToolNames` is provided.
+   */
+  pinnedToolNames?: readonly string[];
+  /**
+   * When provided, returns the current activated remote tool names from the
+   * live run context. The result is merged with `pinnedToolNames` and returned
+   * as `forkToolNames` in the step preparation result, enabling per-step tool
+   * schema refresh without mutating the caller's fixed forkToolNames array.
+   */
+  getActivatedToolNames?: () => readonly string[];
 };
 
 /** Public API contract for hosted child fork runtime step messages. */
 export type HostedChildForkRuntimeStepMessages = {
   messages: AgentMessage[];
   system: string;
+  /**
+   * Present only when `getActivatedToolNames` was provided in the input.
+   * Contains the live `pinned ∪ activated` set the caller should use for the
+   * current step instead of its fixed forkToolNames.
+   */
+  forkToolNames?: readonly string[];
 };
 
 function convertAgentRuntimePartToChildForkMessagePart(
@@ -113,8 +131,21 @@ export function prepareHostedChildForkRuntimeStepMessages(
     compactedMessages,
   });
 
+  // Compute live forkToolNames = pinned ∪ activated when the caller supplies
+  // a getActivatedToolNames getter. This allows each step to see newly
+  // activated tool schemas without the caller mutating its fixed array.
+  const liveForkToolNames = input.getActivatedToolNames
+    ? [
+      ...new Set([
+        ...(input.pinnedToolNames ?? []),
+        ...input.getActivatedToolNames(),
+      ]),
+    ].sort()
+    : undefined;
+
   return {
     messages: convertCompactedProviderMessagesToChildForkRuntimeMessages(compactedMessages),
     system: typeof resolvedSystem === "string" ? resolvedSystem : currentInstructions,
+    ...(liveForkToolNames !== undefined ? { forkToolNames: liveForkToolNames } : {}),
   };
 }

--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -738,3 +738,36 @@ Deno.test("createHostedProjectRemoteToolSources composes API input preparation f
     },
   ]);
 });
+
+Deno.test("createHostedProjectRemoteToolSource uses activatedRemoteToolNames as execution gate", async () => {
+  const activatedSet = new Set(["read_file"]);
+
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [simpleTool("read_file"), simpleTool("write_file")],
+    }),
+    // allowedToolNames would normally allow both; activatedRemoteToolNames narrows to activated set
+    allowedToolNames: new Set(["read_file", "write_file"]),
+    activatedRemoteToolNames: activatedSet,
+  });
+
+  // listTools shows only activated tools
+  const listed = (await source.listTools()).map((t) => t.name);
+  assertEquals(listed, ["read_file"]);
+
+  // Execution is allowed for activated tool
+  const result = await source.executeTool("read_file", {});
+  assertEquals(result, { ok: true });
+
+  // Execution is blocked for non-activated tool (throws)
+  await assertRejects(
+    () => source.executeTool("write_file", {}),
+    Error,
+    "write_file",
+  );
+
+  // Live mutation: activating write_file makes it executable
+  activatedSet.add("write_file");
+  const resultAfter = await source.executeTool("write_file", {});
+  assertEquals(resultAfter, { ok: true });
+});

--- a/src/agent/hosted/project-remote-tool-source.ts
+++ b/src/agent/hosted/project-remote-tool-source.ts
@@ -58,6 +58,14 @@ export type CreateHostedProjectRemoteToolSourceInput = {
   defaultProjectId?: ProjectScopedRemoteToolDefaultProjectId;
   getActiveBranchId?: () => string | null | undefined;
   allowedToolNames?: ReadonlySet<string> | null;
+  /**
+   * Live activated remote tool names from the discovery context.
+   * When provided, this Set (passed by reference) is used as the execution
+   * gate for the remote tool catalog instead of `allowedToolNames`. Because
+   * the same Set is mutated by `load_tools`, newly activated tools become
+   * executable without any catalog re-creation.
+   */
+  activatedRemoteToolNames?: ReadonlySet<string> | null;
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
   filterToolDefinitions?: ProjectScopedRemoteToolCatalogOptions["filterToolDefinitions"];
   prepareToolInput?: HostedProjectRemoteToolSourcePrepareToolInput;
@@ -78,10 +86,16 @@ function resolveActiveBranchId(
 export function createHostedProjectRemoteToolSource(
   input: CreateHostedProjectRemoteToolSourceInput,
 ): RemoteToolSource {
+  // When `activatedRemoteToolNames` is provided, it acts as the live execution
+  // gate: only tools in this Set (which grows as load_tools activates them)
+  // can be listed or executed. Falls back to `allowedToolNames` when absent.
+  const catalogAllowedToolNames = input.activatedRemoteToolNames !== undefined
+    ? input.activatedRemoteToolNames
+    : input.allowedToolNames;
   const toolCatalog = createProjectScopedRemoteToolCatalog({
     source: input.source,
     defaultProjectId: input.defaultProjectId,
-    allowedToolNames: input.allowedToolNames,
+    allowedToolNames: catalogAllowedToolNames,
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
     filterToolDefinitions: input.filterToolDefinitions,
   });
@@ -249,6 +263,9 @@ function createHostedProjectRemoteToolSourceFromConfig(
       ? { getActiveBranchId: input.getActiveBranchId }
       : {}),
     ...(input.allowedToolNames !== undefined ? { allowedToolNames: input.allowedToolNames } : {}),
+    ...(input.activatedRemoteToolNames !== undefined
+      ? { activatedRemoteToolNames: input.activatedRemoteToolNames }
+      : {}),
     ...(input.projectScopedRemoteToolOptions !== undefined
       ? { projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions }
       : {}),

--- a/src/agent/hosted/runtime-essential-tools.test.ts
+++ b/src/agent/hosted/runtime-essential-tools.test.ts
@@ -53,5 +53,20 @@ describe("resolveHostedRuntimeAllowedToolNames", () => {
 
       assertEquals(result?.size, 0);
     });
+
+    it("does not force-add discovery tools under deny-all even with includeRuntimeEssentialToolsWhenEmpty", () => {
+      // A sandboxed agent with tools: [] must not gain load_tools/search_tools
+      // even when the config-derived essential-tools flag is set. Activating tools
+      // is a broader capability than running pre-configured skills (load_skill), so
+      // the two are treated asymmetrically under deny-all.
+      const result = resolveHostedRuntimeAllowedToolNames({
+        allowedToolNames: new Set(),
+        localToolNames: ["search_tools", "load_tools", "load_skill"],
+        includeRuntimeEssentialToolsWhenEmpty: true,
+      });
+
+      assertEquals(result?.has("search_tools"), false);
+      assertEquals(result?.has("load_tools"), false);
+    });
   });
 });

--- a/src/agent/hosted/runtime-essential-tools.test.ts
+++ b/src/agent/hosted/runtime-essential-tools.test.ts
@@ -1,0 +1,57 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { resolveHostedRuntimeAllowedToolNames } from "./runtime-essential-tools.ts";
+
+describe("resolveHostedRuntimeAllowedToolNames", () => {
+  describe("tool discovery tools are always essential", () => {
+    it("force-adds search_tools when present in localToolNames and allowedToolNames is restricted", () => {
+      const result = resolveHostedRuntimeAllowedToolNames({
+        allowedToolNames: new Set(["sleep"]),
+        localToolNames: ["search_tools", "load_tools", "sleep"],
+      });
+
+      assertEquals(result?.has("search_tools"), true);
+      assertEquals(result?.has("load_tools"), true);
+      assertEquals(result?.has("sleep"), true);
+    });
+
+    it("does not add discovery tools that are absent from localToolNames", () => {
+      const result = resolveHostedRuntimeAllowedToolNames({
+        allowedToolNames: new Set(["sleep"]),
+        localToolNames: ["sleep"],
+      });
+
+      assertEquals(result?.has("search_tools"), false);
+      assertEquals(result?.has("load_tools"), false);
+    });
+
+    it("adds discovery tools even when availableSkillIds is empty", () => {
+      const result = resolveHostedRuntimeAllowedToolNames({
+        allowedToolNames: new Set(["sleep"]),
+        localToolNames: ["search_tools", "load_tools", "sleep"],
+        availableSkillIds: [],
+      });
+
+      assertEquals(result?.has("search_tools"), true);
+      assertEquals(result?.has("load_tools"), true);
+    });
+
+    it("returns null (allow-all) when allowedToolNames is null", () => {
+      const result = resolveHostedRuntimeAllowedToolNames({
+        allowedToolNames: null,
+        localToolNames: ["search_tools", "load_tools"],
+      });
+
+      assertEquals(result, null);
+    });
+
+    it("returns empty set unchanged when allowedToolNames is empty", () => {
+      const result = resolveHostedRuntimeAllowedToolNames({
+        allowedToolNames: new Set(),
+        localToolNames: ["search_tools", "load_tools"],
+      });
+
+      assertEquals(result?.size, 0);
+    });
+  });
+});

--- a/src/agent/hosted/runtime-essential-tools.ts
+++ b/src/agent/hosted/runtime-essential-tools.ts
@@ -13,6 +13,12 @@ export type ResolveHostedRuntimeAllowedToolNamesInput = {
 const SKILL_RUNTIME_TOOL_NAMES = ["load_skill", "load_skill_reference"] as const;
 const SKILL_DELEGATION_TOOL_NAMES = ["invoke_agent"] as const;
 
+/**
+ * Tool discovery tools are unconditionally essential: they must never be
+ * truncated by the provider cap, regardless of skill availability.
+ */
+const TOOL_DISCOVERY_TOOL_NAMES = ["search_tools", "load_tools"] as const;
+
 /** Normalize hosted runtime allowed tools. */
 export function normalizeHostedRuntimeAllowedToolNames(
   toolNames: HostedRuntimeAllowedToolNames | undefined,
@@ -36,12 +42,20 @@ export function resolveHostedRuntimeAllowedToolNames(
     return allowedToolNames;
   }
 
-  if (!input.availableSkillIds?.length) {
-    return allowedToolNames;
-  }
-
   const localToolNames = new Set(input.localToolNames);
   const resolvedToolNames = new Set(allowedToolNames);
+
+  // Tool discovery is unconditionally essential: force-add whenever the tools
+  // are registered as local tools, regardless of skill availability.
+  for (const toolName of TOOL_DISCOVERY_TOOL_NAMES) {
+    if (localToolNames.has(toolName)) {
+      resolvedToolNames.add(toolName);
+    }
+  }
+
+  if (!input.availableSkillIds?.length) {
+    return resolvedToolNames;
+  }
 
   for (const toolName of SKILL_RUNTIME_TOOL_NAMES) {
     if (localToolNames.has(toolName)) {

--- a/src/agent/hosted/runtime-essential-tools.ts
+++ b/src/agent/hosted/runtime-essential-tools.ts
@@ -45,11 +45,16 @@ export function resolveHostedRuntimeAllowedToolNames(
   const localToolNames = new Set(input.localToolNames);
   const resolvedToolNames = new Set(allowedToolNames);
 
-  // Tool discovery is unconditionally essential: force-add whenever the tools
-  // are registered as local tools, regardless of skill availability.
-  for (const toolName of TOOL_DISCOVERY_TOOL_NAMES) {
-    if (localToolNames.has(toolName)) {
-      resolvedToolNames.add(toolName);
+  // Tool discovery is essential only when the agent already has at least one
+  // tool in its resolved set. Under deny-all (empty allowedToolNames), discovery
+  // tools are intentionally excluded: activating new tools is a broader
+  // capability than running pre-configured skills (load_skill), so the two are
+  // treated asymmetrically when allowedToolNames is empty.
+  if (resolvedToolNames.size > 0) {
+    for (const toolName of TOOL_DISCOVERY_TOOL_NAMES) {
+      if (localToolNames.has(toolName)) {
+        resolvedToolNames.add(toolName);
+      }
     }
   }
 

--- a/src/agent/runtime/load-tools-tool.test.ts
+++ b/src/agent/runtime/load-tools-tool.test.ts
@@ -1,0 +1,279 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
+import {
+  createLoadToolsTool,
+  type LoadToolsToolOptions,
+} from "./load-tools-tool.ts";
+
+const AUTHORIZED_TOOLS = ["read_file", "write_file", "search_code", "update_agent"] as const;
+
+function makeContext(initial: string[] = []): RuntimeToolDiscoveryContext {
+  return {
+    activatedRemoteToolNames: new Set(initial),
+  };
+}
+
+function makeOptions(
+  context: RuntimeToolDiscoveryContext,
+  overrides: Partial<Omit<LoadToolsToolOptions, "context">> = {},
+): LoadToolsToolOptions {
+  return {
+    context,
+    pinnedToolNames: ["load_skill", "search_tools", "load_tools"],
+    model: "anthropic/claude-sonnet-4-6",
+    getAuthorizedToolNames: () => [...AUTHORIZED_TOOLS],
+    ...overrides,
+  };
+}
+
+describe("load_tools tool", () => {
+  describe("validation", () => {
+    it("rejects unknown tool names with unknown_tool reason", async () => {
+      const context = makeContext();
+      const tool = createLoadToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["nonexistent_tool"] });
+
+      assertEquals("error" in result, true);
+      if ("error" in result) {
+        assertEquals(result.reasons["nonexistent_tool"], "unknown_tool");
+      }
+    });
+
+    it("rejects unauthorized names with same unknown_tool reason (no info leakage)", async () => {
+      const context = makeContext();
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          getAuthorizedToolNames: () => ["read_file"],
+        }),
+      );
+      // write_file exists in some catalog but is not authorized for this run
+      const result = await tool.execute({ names: ["write_file"] });
+
+      assertEquals("error" in result, true);
+      if ("error" in result) {
+        assertEquals(result.reasons["write_file"], "unknown_tool");
+      }
+    });
+
+    it("rejects atomically: one bad name fails the whole call", async () => {
+      const context = makeContext();
+      const tool = createLoadToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file", "bad_tool"] });
+
+      assertEquals("error" in result, true);
+      // read_file should NOT be activated (atomic failure)
+      assertEquals(context.activatedRemoteToolNames?.has("read_file"), false);
+    });
+
+    it("returns per-name reasons for each rejected name", async () => {
+      const context = makeContext();
+      const tool = createLoadToolsTool(makeOptions(context));
+      const result = await tool.execute({
+        names: ["nonexistent_a", "nonexistent_b"],
+      });
+
+      assertEquals("error" in result, true);
+      if ("error" in result) {
+        assertEquals(result.reasons["nonexistent_a"], "unknown_tool");
+        assertEquals(result.reasons["nonexistent_b"], "unknown_tool");
+      }
+    });
+  });
+
+  describe("successful activation", () => {
+    it("activates valid tools and adds them to the context set", async () => {
+      const context = makeContext();
+      const tool = createLoadToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file", "write_file"] });
+
+      assertEquals("activated" in result, true);
+      if ("activated" in result) {
+        assertEquals(result.activated.sort(), ["read_file", "write_file"]);
+      }
+      assertEquals(context.activatedRemoteToolNames?.has("read_file"), true);
+      assertEquals(context.activatedRemoteToolNames?.has("write_file"), true);
+    });
+
+    it("is idempotent: already-activated tools count as success", async () => {
+      const context = makeContext(["read_file"]);
+      const tool = createLoadToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file"] });
+
+      assertEquals("activated" in result, true);
+      if ("activated" in result) {
+        assertEquals(result.activated, ["read_file"]);
+      }
+    });
+
+    it("only reports newly-activated names (not already-activated duplicates)", async () => {
+      const context = makeContext(["read_file"]);
+      const tool = createLoadToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file", "write_file"] });
+
+      assertEquals("activated" in result, true);
+      if ("activated" in result) {
+        // read_file was already active; only write_file is newly activated
+        assertEquals(result.newlyActivated, ["write_file"]);
+        assertEquals(result.activated.sort(), ["read_file", "write_file"]);
+      }
+    });
+
+    it("calls onToolsActivated with newly-activated names only", async () => {
+      const context = makeContext(["read_file"]);
+      const activated: string[][] = [];
+      context.onToolsActivated = (names) => activated.push(names);
+
+      const tool = createLoadToolsTool(makeOptions(context));
+      await tool.execute({ names: ["read_file", "write_file"] });
+
+      assertEquals(activated, [["write_file"]]);
+    });
+
+    it("does not call onToolsActivated when all names are already active", async () => {
+      const context = makeContext(["read_file"]);
+      let called = false;
+      context.onToolsActivated = () => { called = true; };
+
+      const tool = createLoadToolsTool(makeOptions(context));
+      await tool.execute({ names: ["read_file"] });
+
+      assertEquals(called, false);
+    });
+  });
+
+  describe("budget enforcement", () => {
+    it("refuses when pinned + activated + new would exceed provider budget (OpenAI 128)", async () => {
+      // Simulate OpenAI 128-tool cap.
+      // pinned = 3 (load_skill, search_tools, load_tools)
+      // already activated = 125
+      // trying to add 1 more would hit exactly 129 > 128
+      const existing = Array.from({ length: 125 }, (_, i) => `tool_${i}`);
+      const context = makeContext(existing);
+      // authorized catalog must include those existing + the new one
+      const authorized = [...existing, "new_tool_a", "new_tool_b"];
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          model: "openai/gpt-4.1",
+          getAuthorizedToolNames: () => authorized,
+        }),
+      );
+      const result = await tool.execute({ names: ["new_tool_a"] });
+
+      assertEquals("error" in result, true);
+      if ("error" in result) {
+        assertStringIncludes(result.error, "overflow");
+        // overflow = (3 + 125 + 1) - 128 = 1
+        assertStringIncludes(result.error, "1");
+      }
+      // not activated
+      assertEquals(context.activatedRemoteToolNames?.has("new_tool_a"), false);
+    });
+
+    it("reports exact overflow count", async () => {
+      // pinned = 3, activated = 124, adding 3 more = 130 > 128, overflow = 2
+      const existing = Array.from({ length: 124 }, (_, i) => `tool_${i}`);
+      const context = makeContext(existing);
+      const authorized = [...existing, "tool_a", "tool_b", "tool_c"];
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          model: "openai/gpt-4.1",
+          getAuthorizedToolNames: () => authorized,
+        }),
+      );
+      const result = await tool.execute({ names: ["tool_a", "tool_b", "tool_c"] });
+
+      assertEquals("error" in result, true);
+      if ("error" in result) {
+        assertStringIncludes(result.error, "2");
+      }
+    });
+
+    it("allows activation up to exactly the provider budget", async () => {
+      // pinned = 3, activated = 124, adding 1 = 128 exactly, no overflow
+      const existing = Array.from({ length: 124 }, (_, i) => `tool_${i}`);
+      const context = makeContext(existing);
+      const authorized = [...existing, "tool_ok"];
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          model: "openai/gpt-4.1",
+          getAuthorizedToolNames: () => authorized,
+        }),
+      );
+      const result = await tool.execute({ names: ["tool_ok"] });
+
+      assertEquals("activated" in result, true);
+    });
+
+    it("does not enforce a budget cap for uncapped providers", async () => {
+      // anthropic has no maxTools
+      const existing = Array.from({ length: 200 }, (_, i) => `tool_${i}`);
+      const context = makeContext(existing);
+      const authorized = [...existing, "extra_tool"];
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          model: "anthropic/claude-sonnet-4-6",
+          getAuthorizedToolNames: () => authorized,
+        }),
+      );
+      const result = await tool.execute({ names: ["extra_tool"] });
+
+      assertEquals("activated" in result, true);
+    });
+
+    it("does not evict existing activations on overflow (never-evict policy)", async () => {
+      const existing = Array.from({ length: 125 }, (_, i) => `tool_${i}`);
+      const context = makeContext(existing);
+      const authorized = [...existing, "new_one"];
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          model: "openai/gpt-4.1",
+          getAuthorizedToolNames: () => authorized,
+        }),
+      );
+      await tool.execute({ names: ["new_one"] });
+
+      // All original activations must still be present
+      for (const name of existing) {
+        assertEquals(context.activatedRemoteToolNames?.has(name), true);
+      }
+    });
+
+    it("calls onToolsActivationRejected on overflow", async () => {
+      const existing = Array.from({ length: 126 }, (_, i) => `tool_${i}`);
+      const context = makeContext(existing);
+      const rejected: Array<{ names: string[]; reasons: Record<string, string> }> = [];
+      context.onToolsActivationRejected = (names, reasons) =>
+        rejected.push({ names, reasons });
+      const authorized = [...existing, "overflow_tool"];
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          model: "openai/gpt-4.1",
+          getAuthorizedToolNames: () => authorized,
+        }),
+      );
+      await tool.execute({ names: ["overflow_tool"] });
+
+      assertEquals(rejected.length, 1);
+      assertEquals(rejected[0].names, ["overflow_tool"]);
+    });
+  });
+
+  describe("tool metadata", () => {
+    it("has the correct tool id", () => {
+      const tool = createLoadToolsTool(makeOptions(makeContext()));
+      assertEquals(tool.id, "load_tools");
+    });
+
+    it("has a static input schema (no enum narrowing)", () => {
+      const tool = createLoadToolsTool(makeOptions(makeContext()));
+      const schema = tool.inputSchemaJson;
+      // names must be a plain string array, not an enum-constrained list
+      assertEquals(
+        (schema as Record<string, unknown>).type,
+        "object",
+      );
+    });
+  });
+});

--- a/src/agent/runtime/load-tools-tool.test.ts
+++ b/src/agent/runtime/load-tools-tool.test.ts
@@ -2,10 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
-import {
-  createLoadToolsTool,
-  type LoadToolsToolOptions,
-} from "./load-tools-tool.ts";
+import { createLoadToolsTool, type LoadToolsToolOptions } from "./load-tools-tool.ts";
 
 const AUTHORIZED_TOOLS = ["read_file", "write_file", "search_code", "update_agent"] as const;
 
@@ -134,7 +131,9 @@ describe("load_tools tool", () => {
     it("does not call onToolsActivated when all names are already active", async () => {
       const context = makeContext(["read_file"]);
       let called = false;
-      context.onToolsActivated = () => { called = true; };
+      context.onToolsActivated = () => {
+        called = true;
+      };
 
       const tool = createLoadToolsTool(makeOptions(context));
       await tool.execute({ names: ["read_file"] });
@@ -244,8 +243,7 @@ describe("load_tools tool", () => {
       const existing = Array.from({ length: 126 }, (_, i) => `tool_${i}`);
       const context = makeContext(existing);
       const rejected: Array<{ names: string[]; reasons: Record<string, string> }> = [];
-      context.onToolsActivationRejected = (names, reasons) =>
-        rejected.push({ names, reasons });
+      context.onToolsActivationRejected = (names, reasons) => rejected.push({ names, reasons });
       const authorized = [...existing, "overflow_tool"];
       const tool = createLoadToolsTool(
         makeOptions(context, {

--- a/src/agent/runtime/load-tools-tool.test.ts
+++ b/src/agent/runtime/load-tools-tool.test.ts
@@ -258,6 +258,101 @@ describe("load_tools tool", () => {
     });
   });
 
+  describe("binding policy", () => {
+    it("rejects names outside the binding policy with unknown_tool (no distinguishability)", async () => {
+      const context = makeContext();
+      // Binding policy allows only read_file; write_file is in the authorized catalog
+      // but outside the policy. Both cases must return the same unknown_tool reason.
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          bindingPolicy: new Set(["read_file"]),
+          getAuthorizedToolNames: () => ["read_file", "write_file"],
+        }),
+      );
+      const result = await tool.execute({ names: ["write_file"] });
+
+      assertEquals("error" in result, true);
+      if ("error" in result) {
+        assertEquals(result.reasons["write_file"], "unknown_tool");
+      }
+      assertEquals(context.activatedRemoteToolNames?.has("write_file"), false);
+    });
+
+    it("allows activation when name is in both authorized catalog and binding policy", async () => {
+      const context = makeContext();
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          bindingPolicy: new Set(["read_file", "write_file"]),
+          getAuthorizedToolNames: () => ["read_file", "write_file", "delete_file"],
+        }),
+      );
+      const result = await tool.execute({ names: ["read_file"] });
+
+      assertEquals("activated" in result, true);
+      assertEquals(context.activatedRemoteToolNames?.has("read_file"), true);
+    });
+
+    it("null binding policy means unrestricted: full authorized catalog can be activated", async () => {
+      const context = makeContext();
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          bindingPolicy: null,
+          getAuthorizedToolNames: () => ["read_file", "write_file", "delete_file"],
+        }),
+      );
+      const result = await tool.execute({ names: ["delete_file"] });
+
+      assertEquals("activated" in result, true);
+      assertEquals(context.activatedRemoteToolNames?.has("delete_file"), true);
+    });
+
+    it("undefined binding policy means unrestricted (backward-compatible default)", async () => {
+      const context = makeContext();
+      // makeOptions does not set bindingPolicy, so it is undefined
+      const tool = createLoadToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file"] });
+
+      assertEquals("activated" in result, true);
+    });
+
+    it("empty binding policy prevents any activation (consistent with deny-all)", async () => {
+      const context = makeContext();
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          bindingPolicy: new Set([]),
+          getAuthorizedToolNames: () => ["read_file", "write_file"],
+        }),
+      );
+      const result = await tool.execute({ names: ["read_file"] });
+
+      assertEquals("error" in result, true);
+      if ("error" in result) {
+        assertEquals(result.reasons["read_file"], "unknown_tool");
+      }
+    });
+
+    it("policy-blocked names and genuinely unknown names both return unknown_tool (no leakage)", async () => {
+      const context = makeContext();
+      const tool = createLoadToolsTool(
+        makeOptions(context, {
+          bindingPolicy: new Set(["read_file"]),
+          getAuthorizedToolNames: () => ["read_file"],
+        }),
+      );
+      // write_file is both outside the policy AND not in the authorized catalog
+      const resultBlocked = await tool.execute({ names: ["write_file"] });
+      // completely_unknown is not in the catalog either
+      const resultUnknown = await tool.execute({ names: ["completely_unknown"] });
+
+      assertEquals("error" in resultBlocked, true);
+      assertEquals("error" in resultUnknown, true);
+      if ("error" in resultBlocked && "error" in resultUnknown) {
+        assertEquals(resultBlocked.reasons["write_file"], "unknown_tool");
+        assertEquals(resultUnknown.reasons["completely_unknown"], "unknown_tool");
+      }
+    });
+  });
+
   describe("tool metadata", () => {
     it("has the correct tool id", () => {
       const tool = createLoadToolsTool(makeOptions(makeContext()));

--- a/src/agent/runtime/load-tools-tool.ts
+++ b/src/agent/runtime/load-tools-tool.ts
@@ -21,6 +21,14 @@ export type LoadToolsToolOptions = {
    * (same reason) to avoid leaking existence of unauthorized tools.
    */
   getAuthorizedToolNames: () => readonly string[];
+  /**
+   * When set to a non-null Set, activation candidates are intersected with
+   * this policy before the authorized-catalog check. Names that are in the
+   * authorized catalog but outside the binding policy receive the same
+   * `unknown_tool` reason as genuinely unknown names — no distinguishability.
+   * null or undefined means unrestricted: the full authorized catalog applies.
+   */
+  bindingPolicy?: ReadonlySet<string> | null;
 };
 
 /** Input payload for load_tools. */
@@ -62,7 +70,13 @@ export function createLoadToolsTool(
   }
 
   function execute(input: LoadToolsInput): LoadToolsOutput {
-    const authorized = new Set(options.getAuthorizedToolNames());
+    // Intersect the full authorized catalog with the agent's binding policy.
+    // Names outside the policy return the same unknown_tool reason as genuinely
+    // unknown names so the policy boundary is not distinguishable to the model.
+    const fullAuthorized = new Set(options.getAuthorizedToolNames());
+    const authorized = options.bindingPolicy != null
+      ? new Set([...fullAuthorized].filter((name) => options.bindingPolicy!.has(name)))
+      : fullAuthorized;
     const activatedSet = getActivatedSet();
 
     // --- Validation pass (all-or-nothing) ---

--- a/src/agent/runtime/load-tools-tool.ts
+++ b/src/agent/runtime/load-tools-tool.ts
@@ -1,0 +1,149 @@
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
+import type { Tool } from "#veryfront/tool/types.ts";
+import { zodToJsonSchema } from "#veryfront/tool/schema/zod-json-schema.ts";
+import { getProviderToolProfile } from "./provider-tool-compat.ts";
+import type { RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
+
+/** Options accepted by the load_tools tool. */
+export type LoadToolsToolOptions = {
+  context: RuntimeToolDiscoveryContext;
+  /**
+   * Names that are always present in the run (local/essential tools).
+   * These count toward the provider budget and can never be evicted.
+   */
+  pinnedToolNames: readonly string[];
+  /** Model identifier used to resolve the provider tool budget. */
+  model?: string;
+  /**
+   * Returns the names of every remote tool the current run is authorized to
+   * use. Unknown and unauthorized tool names are both treated as unknown_tool
+   * (same reason) to avoid leaking existence of unauthorized tools.
+   */
+  getAuthorizedToolNames: () => readonly string[];
+};
+
+/** Input payload for load_tools. */
+const getLoadToolsInputSchema = defineSchema((v) =>
+  v.object({
+    names: v.array(v.string().min(1)).min(1).describe(
+      "Tool names to activate. All names must be valid; the call is atomic.",
+    ),
+  })
+);
+
+export type LoadToolsInput = InferSchema<ReturnType<typeof getLoadToolsInputSchema>>;
+
+/** Successful activation output. */
+export type LoadToolsSuccessOutput = {
+  activated: string[];
+  newlyActivated: string[];
+  message: string;
+};
+
+/** Validation or budget-overflow failure output. */
+export type LoadToolsErrorOutput = {
+  error: string;
+  reasons: Record<string, string>;
+};
+
+/** Output from load_tools. */
+export type LoadToolsOutput = LoadToolsSuccessOutput | LoadToolsErrorOutput;
+
+/** Create the load_tools host tool. */
+export function createLoadToolsTool(
+  options: LoadToolsToolOptions,
+): Tool<LoadToolsInput, LoadToolsOutput> {
+  function getActivatedSet(): Set<string> {
+    if (!options.context.activatedRemoteToolNames) {
+      options.context.activatedRemoteToolNames = new Set();
+    }
+    return options.context.activatedRemoteToolNames;
+  }
+
+  function execute(input: LoadToolsInput): LoadToolsOutput {
+    const authorized = new Set(options.getAuthorizedToolNames());
+    const activatedSet = getActivatedSet();
+
+    // --- Validation pass (all-or-nothing) ---
+    const reasons: Record<string, string> = {};
+    for (const name of input.names) {
+      if (!authorized.has(name)) {
+        reasons[name] = "unknown_tool";
+      }
+    }
+
+    if (Object.keys(reasons).length > 0) {
+      options.context.onToolsActivationRejected?.(input.names, reasons);
+      return {
+        error:
+          `Tool activation failed: one or more names are not in the authorized catalog for this run. ` +
+          `Provide the per-name reason map to the user so they know which tools to connect.`,
+        reasons,
+      };
+    }
+
+    // --- Budget check ---
+    const uniqueRequestedNames = [...new Set(input.names)];
+    const newNames = uniqueRequestedNames.filter((n) => !activatedSet.has(n));
+    const profile = getProviderToolProfile(options.model);
+
+    if (profile.maxTools !== undefined) {
+      const pinnedCount = new Set(options.pinnedToolNames).size;
+      const total = pinnedCount + activatedSet.size + newNames.length;
+      if (total > profile.maxTools) {
+        const overflow = total - profile.maxTools;
+        const rejectionReasons: Record<string, string> = {};
+        for (const name of newNames) {
+          rejectionReasons[name] = "budget_overflow";
+        }
+        options.context.onToolsActivationRejected?.(newNames, rejectionReasons);
+        return {
+          error:
+            `Tool activation refused: adding ${newNames.length} tool(s) would exceed the provider ` +
+            `budget of ${profile.maxTools} by ${overflow} (overflow: ${overflow}). ` +
+            `Remove activated tools or choose a provider with a higher limit. ` +
+            `Pinned: ${pinnedCount}, currently activated: ${activatedSet.size}, requested new: ${newNames.length}.`,
+          reasons: rejectionReasons,
+        };
+      }
+    }
+
+    // --- Atomic activation ---
+    for (const name of newNames) {
+      activatedSet.add(name);
+    }
+
+    if (newNames.length > 0) {
+      options.context.onToolsActivated?.(newNames);
+    }
+
+    const allActivated = uniqueRequestedNames;
+    return {
+      activated: allActivated,
+      newlyActivated: newNames,
+      message:
+        newNames.length > 0
+          ? `Activated ${newNames.length} tool(s): ${newNames.join(", ")}. ` +
+            `These tools are callable from the next step.`
+          : `All requested tools were already active: ${allActivated.join(", ")}.`,
+    };
+  }
+
+  return {
+    id: "load_tools",
+    type: "function",
+    description:
+      "Activate one or more MCP tools for use in this run. " +
+      "All names must be valid; the call is atomic (no partial activation). " +
+      "Use search_tools first to discover available tool names and their current state. " +
+      "Activated tools are callable from the next step. " +
+      "The provider budget is enforced: if adding these tools would exceed the limit, the call " +
+      "is refused with the exact overflow count.",
+    inputSchema: getLoadToolsInputSchema(),
+    get inputSchemaJson() {
+      return zodToJsonSchema(getLoadToolsInputSchema());
+    },
+    execute: (input: LoadToolsInput) => Promise.resolve(execute(input)),
+  };
+}

--- a/src/agent/runtime/load-tools-tool.ts
+++ b/src/agent/runtime/load-tools-tool.ts
@@ -122,19 +122,17 @@ export function createLoadToolsTool(
     return {
       activated: allActivated,
       newlyActivated: newNames,
-      message:
-        newNames.length > 0
-          ? `Activated ${newNames.length} tool(s): ${newNames.join(", ")}. ` +
-            `These tools are callable from the next step.`
-          : `All requested tools were already active: ${allActivated.join(", ")}.`,
+      message: newNames.length > 0
+        ? `Activated ${newNames.length} tool(s): ${newNames.join(", ")}. ` +
+          `These tools are callable from the next step.`
+        : `All requested tools were already active: ${allActivated.join(", ")}.`,
     };
   }
 
   return {
     id: "load_tools",
     type: "function",
-    description:
-      "Activate one or more MCP tools for use in this run. " +
+    description: "Activate one or more MCP tools for use in this run. " +
       "All names must be valid; the call is atomic (no partial activation). " +
       "Use search_tools first to discover available tool names and their current state. " +
       "Activated tools are callable from the next step. " +

--- a/src/agent/runtime/search-tools-tool.test.ts
+++ b/src/agent/runtime/search-tools-tool.test.ts
@@ -1,0 +1,199 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeToolCatalogEntry, RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
+import {
+  createSearchToolsTool,
+  type SearchToolsToolOptions,
+} from "./search-tools-tool.ts";
+
+const CATALOG: RuntimeToolCatalogEntry[] = [
+  { name: "read_file", description: "Read a file from the project", source: "veryfront-api" },
+  { name: "write_file", description: "Write content to a file", source: "veryfront-api" },
+  {
+    name: "search_code",
+    description: "Search for patterns in source code",
+    source: "veryfront-api",
+  },
+  { name: "update_agent", description: "Update agent configuration", source: "veryfront-api" },
+  {
+    name: "premium_tool",
+    description: "A grant-required premium capability",
+    source: "premium-integration",
+    requiresGrant: true,
+  },
+];
+
+function makeContext(activated: string[] = []): RuntimeToolDiscoveryContext {
+  return {
+    activatedRemoteToolNames: new Set(activated),
+  };
+}
+
+function makeOptions(
+  context: RuntimeToolDiscoveryContext,
+  overrides: Partial<Omit<SearchToolsToolOptions, "context">> = {},
+): SearchToolsToolOptions {
+  return {
+    context,
+    getAuthorizedCatalog: () => [...CATALOG],
+    ...overrides,
+  };
+}
+
+describe("search_tools tool", () => {
+  describe("state mapping", () => {
+    it("returns available for tools not yet activated", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file"] });
+
+      assertEquals(result.results.length, 1);
+      assertEquals(result.results[0].name, "read_file");
+      assertEquals(result.results[0].state, "available");
+    });
+
+    it("returns active for tools that are in the activated set", async () => {
+      const context = makeContext(["read_file"]);
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file"] });
+
+      assertEquals(result.results[0].state, "active");
+    });
+
+    it("returns requires_grant for tools marked requiresGrant", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["premium_tool"] });
+
+      assertEquals(result.results[0].state, "requires_grant");
+    });
+
+    it("does not return input schemas in results", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file"] });
+
+      assertEquals("inputSchema" in result.results[0], false);
+      assertEquals("parameters" in result.results[0], false);
+    });
+  });
+
+  describe("lookup by names", () => {
+    it("returns only the named tools when names is provided", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file", "write_file"] });
+
+      assertEquals(result.results.length, 2);
+      assertEquals(
+        result.results.map((r) => r.name).sort(),
+        ["read_file", "write_file"],
+      );
+    });
+
+    it("omits names that are not in the authorized catalog (invisible)", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      // "mystery_tool" is not in catalog and not unauthorized-but-visible
+      const result = await tool.execute({ names: ["read_file", "mystery_tool"] });
+
+      assertEquals(result.results.length, 1);
+      assertEquals(result.results[0].name, "read_file");
+    });
+  });
+
+  describe("keyword query", () => {
+    it("matches query against tool name", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ query: "file" });
+
+      const names = result.results.map((r) => r.name);
+      assertEquals(names.includes("read_file"), true);
+      assertEquals(names.includes("write_file"), true);
+      assertEquals(names.includes("search_code"), false);
+    });
+
+    it("matches query against tool description", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ query: "source code" });
+
+      const names = result.results.map((r) => r.name);
+      assertEquals(names.includes("search_code"), true);
+    });
+
+    it("is case-insensitive", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ query: "FILE" });
+
+      const names = result.results.map((r) => r.name);
+      assertEquals(names.includes("read_file"), true);
+    });
+
+    it("returns all catalog tools when no query or names provided", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({});
+
+      assertEquals(result.results.length, CATALOG.length);
+    });
+  });
+
+  describe("limit", () => {
+    it("respects the limit parameter", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ limit: 2 });
+
+      assertEquals(result.results.length, 2);
+    });
+
+    it("does not exceed limit even if more results match", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ query: "file", limit: 1 });
+
+      assertEquals(result.results.length, 1);
+    });
+  });
+
+  describe("result shape", () => {
+    it("includes name, description, source, and state in each result", async () => {
+      const context = makeContext();
+      const tool = createSearchToolsTool(makeOptions(context));
+      const result = await tool.execute({ names: ["read_file"] });
+
+      const r = result.results[0];
+      assertEquals(typeof r.name, "string");
+      assertEquals(typeof r.description, "string");
+      assertEquals(typeof r.source, "string");
+      assertEquals(typeof r.state, "string");
+    });
+  });
+
+  describe("tool metadata", () => {
+    it("has the correct tool id", () => {
+      const tool = createSearchToolsTool(makeOptions(makeContext()));
+      assertEquals(tool.id, "search_tools");
+    });
+  });
+
+  describe("no cross-run leakage", () => {
+    it("shows activated state only from the current context", async () => {
+      const contextA = makeContext(["read_file"]);
+      const contextB = makeContext();
+
+      const toolA = createSearchToolsTool(makeOptions(contextA));
+      const toolB = createSearchToolsTool(makeOptions(contextB));
+
+      const resultA = await toolA.execute({ names: ["read_file"] });
+      const resultB = await toolB.execute({ names: ["read_file"] });
+
+      assertEquals(resultA.results[0].state, "active");
+      assertEquals(resultB.results[0].state, "available");
+    });
+  });
+});

--- a/src/agent/runtime/search-tools-tool.test.ts
+++ b/src/agent/runtime/search-tools-tool.test.ts
@@ -1,11 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { RuntimeToolCatalogEntry, RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
-import {
-  createSearchToolsTool,
-  type SearchToolsToolOptions,
-} from "./search-tools-tool.ts";
+import type {
+  RuntimeToolCatalogEntry,
+  RuntimeToolDiscoveryContext,
+} from "./tool-discovery-context.ts";
+import { createSearchToolsTool, type SearchToolsToolOptions } from "./search-tools-tool.ts";
 
 const CATALOG: RuntimeToolCatalogEntry[] = [
   { name: "read_file", description: "Read a file from the project", source: "veryfront-api" },

--- a/src/agent/runtime/search-tools-tool.ts
+++ b/src/agent/runtime/search-tools-tool.ts
@@ -1,0 +1,120 @@
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
+import type { Tool } from "#veryfront/tool/types.ts";
+import { zodToJsonSchema } from "#veryfront/tool/schema/zod-json-schema.ts";
+import type { RuntimeToolCatalogEntry, RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
+
+export type { RuntimeToolCatalogEntry };
+
+/** State of a tool within the current run. */
+export type ToolSearchResultState = "active" | "available" | "requires_grant";
+
+/** Single result returned by search_tools. */
+export type ToolSearchResult = {
+  name: string;
+  description: string;
+  source: string;
+  state: ToolSearchResultState;
+};
+
+/** Output from search_tools. */
+export type SearchToolsOutput = {
+  results: ToolSearchResult[];
+};
+
+/** Options accepted by the search_tools tool. */
+export type SearchToolsToolOptions = {
+  context: RuntimeToolDiscoveryContext;
+  /**
+   * Returns the full authorized catalog for this run.
+   * Hard-unauthorized tools must be excluded by the caller before passing.
+   * Grant-recoverable tools are included with `requiresGrant: true`.
+   */
+  getAuthorizedCatalog: () => readonly RuntimeToolCatalogEntry[];
+};
+
+const getSearchToolsInputSchema = defineSchema((v) =>
+  v.object({
+    query: v.string().optional().describe(
+      "Keyword search over tool name and description. Omit to list all available tools.",
+    ),
+    names: v.array(v.string()).optional().describe(
+      "Exact-name lookup. If provided, query is ignored.",
+    ),
+    limit: v.number().int().positive().optional().describe(
+      "Maximum number of results to return.",
+    ),
+  })
+);
+
+export type SearchToolsInput = InferSchema<ReturnType<typeof getSearchToolsInputSchema>>;
+
+function resolveState(
+  entry: RuntimeToolCatalogEntry,
+  activatedSet: ReadonlySet<string>,
+): ToolSearchResultState {
+  if (activatedSet.has(entry.name)) return "active";
+  if (entry.requiresGrant) return "requires_grant";
+  return "available";
+}
+
+function matchesQuery(entry: RuntimeToolCatalogEntry, query: string): boolean {
+  const q = query.toLowerCase();
+  return (
+    entry.name.toLowerCase().includes(q) ||
+    entry.description.toLowerCase().includes(q)
+  );
+}
+
+/** Create the search_tools host tool. */
+export function createSearchToolsTool(
+  options: SearchToolsToolOptions,
+): Tool<SearchToolsInput, SearchToolsOutput> {
+  function execute(input: SearchToolsInput): SearchToolsOutput {
+    const catalog = options.getAuthorizedCatalog();
+    const activatedSet: ReadonlySet<string> =
+      options.context.activatedRemoteToolNames ?? new Set();
+
+    let entries: readonly RuntimeToolCatalogEntry[];
+
+    if (input.names && input.names.length > 0) {
+      // Exact-name lookup: only return catalog entries that match requested names
+      const nameSet = new Set(input.names);
+      entries = catalog.filter((e) => nameSet.has(e.name));
+    } else if (input.query) {
+      entries = catalog.filter((e) => matchesQuery(e, input.query!));
+    } else {
+      entries = catalog;
+    }
+
+    if (input.limit !== undefined && input.limit > 0) {
+      entries = entries.slice(0, input.limit);
+    }
+
+    const results: ToolSearchResult[] = entries.map((e) => ({
+      name: e.name,
+      description: e.description,
+      source: e.source,
+      state: resolveState(e, activatedSet),
+    }));
+
+    return { results };
+  }
+
+  return {
+    id: "search_tools",
+    type: "function",
+    description:
+      "Search the authorized MCP tool catalog for this run. " +
+      "Returns name, description, source, and state (active|available|requires_grant) " +
+      "for each matching tool. Input schemas are not returned. " +
+      "Hard-unauthorized tools are invisible. " +
+      "Use names for exact lookup; use query for keyword search over name and description. " +
+      "After finding the tools you need, call load_tools to activate them.",
+    inputSchema: getSearchToolsInputSchema(),
+    get inputSchemaJson() {
+      return zodToJsonSchema(getSearchToolsInputSchema());
+    },
+    execute: (input: SearchToolsInput) => Promise.resolve(execute(input)),
+  };
+}

--- a/src/agent/runtime/search-tools-tool.ts
+++ b/src/agent/runtime/search-tools-tool.ts
@@ -2,7 +2,10 @@ import { defineSchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
 import type { Tool } from "#veryfront/tool/types.ts";
 import { zodToJsonSchema } from "#veryfront/tool/schema/zod-json-schema.ts";
-import type { RuntimeToolCatalogEntry, RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
+import type {
+  RuntimeToolCatalogEntry,
+  RuntimeToolDiscoveryContext,
+} from "./tool-discovery-context.ts";
 
 export type { RuntimeToolCatalogEntry };
 
@@ -72,8 +75,7 @@ export function createSearchToolsTool(
 ): Tool<SearchToolsInput, SearchToolsOutput> {
   function execute(input: SearchToolsInput): SearchToolsOutput {
     const catalog = options.getAuthorizedCatalog();
-    const activatedSet: ReadonlySet<string> =
-      options.context.activatedRemoteToolNames ?? new Set();
+    const activatedSet: ReadonlySet<string> = options.context.activatedRemoteToolNames ?? new Set();
 
     let entries: readonly RuntimeToolCatalogEntry[];
 
@@ -104,8 +106,7 @@ export function createSearchToolsTool(
   return {
     id: "search_tools",
     type: "function",
-    description:
-      "Search the authorized MCP tool catalog for this run. " +
+    description: "Search the authorized MCP tool catalog for this run. " +
       "Returns name, description, source, and state (active|available|requires_grant) " +
       "for each matching tool. Input schemas are not returned. " +
       "Hard-unauthorized tools are invisible. " +

--- a/src/agent/runtime/tool-discovery-context.ts
+++ b/src/agent/runtime/tool-discovery-context.ts
@@ -1,0 +1,38 @@
+/** Public API contract for tool catalog entry in the runtime discovery catalog. */
+export type RuntimeToolCatalogEntry = {
+  name: string;
+  description: string;
+  source: string;
+  requiresGrant?: boolean;
+};
+
+/**
+ * Per-run context bag for model-driven tool discovery and on-demand loading.
+ *
+ * Activation is run-scoped by definition. Keep this out of any project-scoped
+ * registry so a loaded set never leaks across runs.
+ */
+export type RuntimeToolDiscoveryContext = {
+  /**
+   * The set of remote tool names that have been activated in this run.
+   * Initialized lazily on first activation.
+   */
+  activatedRemoteToolNames?: Set<string>;
+
+  /**
+   * Optional callback invoked after successful atomic activation.
+   * Receives only the *newly* activated names (duplicates excluded).
+   * The host layer uses this to emit a durable CUSTOM conversation event.
+   */
+  onToolsActivated?: (names: string[]) => void;
+
+  /**
+   * Optional callback invoked when activation is rejected (validation or
+   * budget overflow). Receives the rejected names and a per-name reason map.
+   * The host layer uses this to emit a durable CUSTOM conversation event.
+   */
+  onToolsActivationRejected?: (
+    names: string[],
+    reasons: Record<string, string>,
+  ) => void;
+};

--- a/src/agent/runtime/tool-discovery-events.test.ts
+++ b/src/agent/runtime/tool-discovery-events.test.ts
@@ -1,0 +1,130 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ConversationRunEvent } from "../conversation/run-events.ts";
+import {
+  buildToolsActivatedEvent,
+  buildToolsActivationRejectedEvent,
+  hydrateToolDiscoveryFromEvents,
+} from "./tool-discovery-events.ts";
+import type { RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
+
+describe("tool discovery events", () => {
+  describe("buildToolsActivatedEvent", () => {
+    it("produces a CUSTOM event with name tools_activated", () => {
+      const event = buildToolsActivatedEvent(["read_file", "write_file"]);
+      assertEquals(event.type, "CUSTOM");
+      assertEquals(event.name, "tools_activated");
+      assertEquals((event.value as { names: string[] }).names, ["read_file", "write_file"]);
+    });
+  });
+
+  describe("buildToolsActivationRejectedEvent", () => {
+    it("produces a CUSTOM event with name tools_activation_rejected", () => {
+      const event = buildToolsActivationRejectedEvent(
+        ["bad_tool"],
+        { bad_tool: "unknown_tool" },
+      );
+      assertEquals(event.type, "CUSTOM");
+      assertEquals(event.name, "tools_activation_rejected");
+      const value = event.value as { names: string[]; reasons: Record<string, string> };
+      assertEquals(value.names, ["bad_tool"]);
+      assertEquals(value.reasons["bad_tool"], "unknown_tool");
+    });
+  });
+
+  describe("hydrateToolDiscoveryFromEvents", () => {
+    it("populates activatedRemoteToolNames from tools_activated events", () => {
+      const context: RuntimeToolDiscoveryContext = {};
+      const events: ConversationRunEvent[] = [
+        buildToolsActivatedEvent(["read_file", "write_file"]) as ConversationRunEvent,
+      ];
+
+      hydrateToolDiscoveryFromEvents(events, context);
+
+      assertEquals(context.activatedRemoteToolNames?.has("read_file"), true);
+      assertEquals(context.activatedRemoteToolNames?.has("write_file"), true);
+    });
+
+    it("merges multiple activation events", () => {
+      const context: RuntimeToolDiscoveryContext = {};
+      const events: ConversationRunEvent[] = [
+        buildToolsActivatedEvent(["read_file"]) as ConversationRunEvent,
+        buildToolsActivatedEvent(["write_file"]) as ConversationRunEvent,
+      ];
+
+      hydrateToolDiscoveryFromEvents(events, context);
+
+      assertEquals(context.activatedRemoteToolNames?.has("read_file"), true);
+      assertEquals(context.activatedRemoteToolNames?.has("write_file"), true);
+    });
+
+    it("ignores non-CUSTOM events", () => {
+      const context: RuntimeToolDiscoveryContext = {};
+      const events: ConversationRunEvent[] = [
+        { type: "TOOL_CALL_RESULT", toolCallId: "tc-1", content: "ok", role: "tool" },
+        buildToolsActivatedEvent(["read_file"]) as ConversationRunEvent,
+      ];
+
+      hydrateToolDiscoveryFromEvents(events, context);
+
+      assertEquals(context.activatedRemoteToolNames?.size, 1);
+    });
+
+    it("ignores CUSTOM events with unknown names", () => {
+      const context: RuntimeToolDiscoveryContext = {};
+      const events: ConversationRunEvent[] = [
+        { type: "CUSTOM", name: "other_event", value: { names: ["read_file"] } },
+      ];
+
+      hydrateToolDiscoveryFromEvents(events, context);
+
+      assertEquals(context.activatedRemoteToolNames, undefined);
+    });
+
+    it("ignores tools_activation_rejected events (rejected tools stay inactive)", () => {
+      const context: RuntimeToolDiscoveryContext = {};
+      const events: ConversationRunEvent[] = [
+        buildToolsActivationRejectedEvent(
+          ["bad_tool"],
+          { bad_tool: "unknown_tool" },
+        ) as ConversationRunEvent,
+      ];
+
+      hydrateToolDiscoveryFromEvents(events, context);
+
+      assertEquals(context.activatedRemoteToolNames, undefined);
+    });
+
+    it("handles a realistic resume sequence (activation followed by rejection)", () => {
+      const context: RuntimeToolDiscoveryContext = {};
+      const events: ConversationRunEvent[] = [
+        buildToolsActivatedEvent(["read_file"]) as ConversationRunEvent,
+        buildToolsActivationRejectedEvent(
+          ["bad_tool"],
+          { bad_tool: "unknown_tool" },
+        ) as ConversationRunEvent,
+        buildToolsActivatedEvent(["write_file"]) as ConversationRunEvent,
+      ];
+
+      hydrateToolDiscoveryFromEvents(events, context);
+
+      assertEquals(context.activatedRemoteToolNames?.has("read_file"), true);
+      assertEquals(context.activatedRemoteToolNames?.has("write_file"), true);
+      assertEquals(context.activatedRemoteToolNames?.has("bad_tool"), false);
+    });
+
+    it("does not leak state across separate context objects", () => {
+      const contextA: RuntimeToolDiscoveryContext = {};
+      const contextB: RuntimeToolDiscoveryContext = {};
+      const events: ConversationRunEvent[] = [
+        buildToolsActivatedEvent(["read_file"]) as ConversationRunEvent,
+      ];
+
+      hydrateToolDiscoveryFromEvents(events, contextA);
+      // contextB was not passed to hydrate
+
+      assertEquals(contextA.activatedRemoteToolNames?.has("read_file"), true);
+      assertEquals(contextB.activatedRemoteToolNames, undefined);
+    });
+  });
+});

--- a/src/agent/runtime/tool-discovery-events.ts
+++ b/src/agent/runtime/tool-discovery-events.ts
@@ -1,0 +1,97 @@
+import type { ConversationRunEvent } from "../conversation/run-events.ts";
+import type { RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
+
+/**
+ * CUSTOM event name for successful tool activation.
+ * Emitted as a durable conversation run event so that a resumed run can
+ * rehydrate its activated-tool set from the event stream.
+ */
+export const TOOLS_ACTIVATED_EVENT_NAME = "tools_activated" as const;
+
+/**
+ * CUSTOM event name for rejected activation (validation or budget overflow).
+ * Persisted for diagnostics; rejected tools are NOT added to the activated set
+ * on replay.
+ */
+export const TOOLS_ACTIVATION_REJECTED_EVENT_NAME = "tools_activation_rejected" as const;
+
+/** Payload shape for a tools_activated CUSTOM event. */
+export type ToolsActivatedEventValue = {
+  kind: "tools_activated";
+  names: string[];
+};
+
+/** Payload shape for a tools_activation_rejected CUSTOM event. */
+export type ToolsActivationRejectedEventValue = {
+  kind: "tools_activation_rejected";
+  names: string[];
+  reasons: Record<string, string>;
+};
+
+/**
+ * Build a CUSTOM conversation run event that records successful activation.
+ * The host layer should emit this as a `data-tools_activated` stream chunk so
+ * that `encodeCustomDataEvent` stores it durably.
+ */
+export function buildToolsActivatedEvent(names: string[]): Omit<ConversationRunEvent, never> {
+  return {
+    type: "CUSTOM",
+    name: TOOLS_ACTIVATED_EVENT_NAME,
+    value: {
+      kind: "tools_activated",
+      names,
+    } satisfies ToolsActivatedEventValue,
+  };
+}
+
+/**
+ * Build a CUSTOM conversation run event that records a rejected activation.
+ * Stored for diagnostics; replay must not activate the listed tools.
+ */
+export function buildToolsActivationRejectedEvent(
+  names: string[],
+  reasons: Record<string, string>,
+): Omit<ConversationRunEvent, never> {
+  return {
+    type: "CUSTOM",
+    name: TOOLS_ACTIVATION_REJECTED_EVENT_NAME,
+    value: {
+      kind: "tools_activation_rejected",
+      names,
+      reasons,
+    } satisfies ToolsActivationRejectedEventValue,
+  };
+}
+
+/**
+ * Rehydrate a `RuntimeToolDiscoveryContext` by replaying durable conversation
+ * run events. Called during run resume so the activated-tool set is restored
+ * without re-invoking `load_tools`.
+ *
+ * Only `tools_activated` events are applied; rejected events are skipped.
+ */
+export function hydrateToolDiscoveryFromEvents(
+  events: readonly ConversationRunEvent[],
+  context: RuntimeToolDiscoveryContext,
+): void {
+  for (const event of events) {
+    if (event.type !== "CUSTOM" || event.name !== TOOLS_ACTIVATED_EVENT_NAME) {
+      continue;
+    }
+
+    const value = event.value as Partial<ToolsActivatedEventValue> | null;
+    if (!value || !Array.isArray(value.names)) {
+      continue;
+    }
+
+    if (!context.activatedRemoteToolNames) {
+      context.activatedRemoteToolNames = new Set();
+    }
+
+    for (const name of value.names) {
+      if (typeof name === "string" && name.length > 0) {
+        context.activatedRemoteToolNames.add(name);
+      }
+    }
+  }
+}

--- a/src/agent/runtime/tool-discovery-execution-gate.test.ts
+++ b/src/agent/runtime/tool-discovery-execution-gate.test.ts
@@ -1,0 +1,145 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createProjectScopedRemoteToolCatalog,
+} from "../../tool/project-scoped-remote-tools.ts";
+import type { RemoteToolSource, ToolDefinition } from "../../tool/types.ts";
+import type { RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
+
+function makeSource(tools: ToolDefinition[]): RemoteToolSource {
+  return {
+    id: "test-source",
+    listTools: () => Promise.resolve(tools),
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+}
+
+function makeToolDef(name: string): ToolDefinition {
+  return {
+    name,
+    description: `The ${name} tool`,
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+describe("execution gate: activated set feeds isRemoteToolNameAllowed", () => {
+  it("allows execution of an activated tool", async () => {
+    const context: RuntimeToolDiscoveryContext = {
+      activatedRemoteToolNames: new Set(["read_file"]),
+    };
+
+    const catalog = createProjectScopedRemoteToolCatalog({
+      source: makeSource([makeToolDef("read_file"), makeToolDef("write_file")]),
+      // Pass the activated set as the allowedToolNames reference.
+      // The same Set object is mutated by load_tools, so the gate stays live.
+      allowedToolNames: context.activatedRemoteToolNames,
+    });
+
+    // Should succeed: read_file is in the activated set
+    const result = await catalog.prepareExecution({
+      toolName: "read_file",
+      toolInput: {},
+    });
+    assertEquals(result.toolDefinition?.name, "read_file");
+  });
+
+  it("blocks execution of a non-activated tool", async () => {
+    const context: RuntimeToolDiscoveryContext = {
+      activatedRemoteToolNames: new Set(["read_file"]),
+    };
+
+    const catalog = createProjectScopedRemoteToolCatalog({
+      source: makeSource([makeToolDef("read_file"), makeToolDef("write_file")]),
+      allowedToolNames: context.activatedRemoteToolNames,
+    });
+
+    let threw = false;
+    try {
+      await catalog.prepareExecution({ toolName: "write_file", toolInput: {} });
+    } catch {
+      threw = true;
+    }
+    assertEquals(threw, true);
+  });
+
+  it("allows execution after load_tools adds a tool to the activated set", async () => {
+    const context: RuntimeToolDiscoveryContext = {
+      activatedRemoteToolNames: new Set<string>(),
+    };
+
+    const catalog = createProjectScopedRemoteToolCatalog({
+      source: makeSource([makeToolDef("write_file")]),
+      // Same Set reference — mutations are visible to the catalog.
+      allowedToolNames: context.activatedRemoteToolNames,
+    });
+
+    // Before activation: blocked
+    let threw = false;
+    try {
+      await catalog.prepareExecution({ toolName: "write_file", toolInput: {} });
+    } catch {
+      threw = true;
+    }
+    assertEquals(threw, true);
+
+    // Simulate load_tools activation (mutates the same Set)
+    context.activatedRemoteToolNames!.add("write_file");
+
+    // After activation: allowed
+    const result = await catalog.prepareExecution({
+      toolName: "write_file",
+      toolInput: {},
+    });
+    assertEquals(result.toolDefinition?.name, "write_file");
+  });
+
+  it("listTools returns only activated tools when allowedToolNames is the activated set", async () => {
+    const context: RuntimeToolDiscoveryContext = {
+      activatedRemoteToolNames: new Set(["read_file"]),
+    };
+
+    const catalog = createProjectScopedRemoteToolCatalog({
+      source: makeSource([
+        makeToolDef("read_file"),
+        makeToolDef("write_file"),
+        makeToolDef("search_code"),
+      ]),
+      allowedToolNames: context.activatedRemoteToolNames,
+    });
+
+    const tools = await catalog.listTools();
+    const names = tools.map((t) => t.name);
+    assertEquals(names, ["read_file"]);
+  });
+
+  it("no cross-run leakage: separate contexts have independent activated sets", async () => {
+    const contextA: RuntimeToolDiscoveryContext = {
+      activatedRemoteToolNames: new Set(["read_file"]),
+    };
+    const contextB: RuntimeToolDiscoveryContext = {
+      activatedRemoteToolNames: new Set(),
+    };
+
+    const catalogA = createProjectScopedRemoteToolCatalog({
+      source: makeSource([makeToolDef("read_file")]),
+      allowedToolNames: contextA.activatedRemoteToolNames,
+    });
+    const catalogB = createProjectScopedRemoteToolCatalog({
+      source: makeSource([makeToolDef("read_file")]),
+      allowedToolNames: contextB.activatedRemoteToolNames,
+    });
+
+    // A can execute, B cannot
+    const resultA = await catalogA.prepareExecution({ toolName: "read_file", toolInput: {} });
+    assertEquals(resultA.toolDefinition?.name, "read_file");
+
+    let threw = false;
+    try {
+      await catalogB.prepareExecution({ toolName: "read_file", toolInput: {} });
+    } catch {
+      threw = true;
+    }
+    assertEquals(threw, true);
+  });
+});

--- a/src/agent/runtime/tool-discovery-execution-gate.test.ts
+++ b/src/agent/runtime/tool-discovery-execution-gate.test.ts
@@ -1,9 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import {
-  createProjectScopedRemoteToolCatalog,
-} from "../../tool/project-scoped-remote-tools.ts";
+import { createProjectScopedRemoteToolCatalog } from "../../tool/project-scoped-remote-tools.ts";
 import type { RemoteToolSource, ToolDefinition } from "../../tool/types.ts";
 import type { RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
 

--- a/src/agent/streaming/fork-runtime-stream.ts
+++ b/src/agent/streaming/fork-runtime-stream.ts
@@ -160,6 +160,13 @@ type ForkRuntimeStepPreparationInput = {
 type ForkRuntimeStepPreparation = {
   messages: AgentMessage[];
   system: string;
+  /**
+   * When present (returned by a step preparer that reads from the live
+   * activated-tool context), this overrides `input.forkToolNames` for the
+   * current step so newly activated remote tool schemas are exposed to the
+   * provider without mutating the run-level fixed array.
+   */
+  forkToolNames?: readonly string[];
 };
 
 /** Public API contract for fork runtime step preparer. */
@@ -545,6 +552,9 @@ export function startAgentRuntimeFork(input: StartAgentRuntimeForkInput): ForkRu
           });
           const state = createForkRuntimeStreamMappingState({ logger: input.logger });
           const streamedStepState = createStreamedStepState();
+          // If the step preparer returned a live forkToolNames (pinned ∪ activated),
+          // use it for this step so newly activated tool schemas reach the provider.
+          const effectiveForkToolNames = prepared.forkToolNames ?? input.forkToolNames;
           const { stream, responsePromise } = await runStep({
             apiUrl: input.apiUrl,
             authToken: input.authToken,
@@ -553,7 +563,7 @@ export function startAgentRuntimeFork(input: StartAgentRuntimeForkInput): ForkRu
             messages: prepared.messages,
             system: prepared.system,
             ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
-            forkToolNames: input.forkToolNames,
+            forkToolNames: effectiveForkToolNames,
             ...(input.providerToolNames ? { providerToolNames: input.providerToolNames } : {}),
             runtimeTools: input.runtimeTools,
             ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),

--- a/src/agent/streaming/fork-runtime-stream.ts
+++ b/src/agent/streaming/fork-runtime-stream.ts
@@ -554,7 +554,11 @@ export function startAgentRuntimeFork(input: StartAgentRuntimeForkInput): ForkRu
           const streamedStepState = createStreamedStepState();
           // If the step preparer returned a live forkToolNames (pinned ∪ activated),
           // use it for this step so newly activated tool schemas reach the provider.
-          const effectiveForkToolNames = prepared.forkToolNames ?? input.forkToolNames;
+          // Spread into a mutable array: RunAgentRuntimeForkStepInput.forkToolNames
+          // is typed as string[] (mutable) while prepared.forkToolNames is readonly.
+          const effectiveForkToolNames: string[] = [
+            ...(prepared.forkToolNames ?? input.forkToolNames),
+          ];
           const { stream, responsePromise } = await runStep({
             apiUrl: input.apiUrl,
             authToken: input.authToken,


### PR DESCRIPTION
## Summary

Implements model-driven MCP tool discovery (ADR [#28](docs/architecture/28-model-driven-tool-discovery.md)) to eliminate the silent tool-cap truncation that caused tools past the OpenAI 128-tool limit to disappear (veryfront/veryfront-studio#5906).

- **`search_tools`** — metadata-only catalog search; returns `{name, description, source, state: active|available|requires_grant}`. Hard-unauthorized tools invisible; unknown and unauthorized both surface as `unknown_tool` (no info leakage). No input schemas in results.
- **`load_tools`** — atomic on-demand activation against the provider tool budget. Refuses with exact overflow count when `pinned + activated + new > maxTools`. Never evicts. Same `unknown_tool` reason for unknown and unauthorized names.
- **Initial inventory** — remote tools no longer flood the union; only local + provider-native tools seed the initial model request.
- **Per-step refresh** — `prepareHostedChildForkRuntimeStepMessages` accepts a `getActivatedToolNames` getter; the fork-stream loop uses `pinned ∪ activated` for each step so newly activated tool schemas reach the provider immediately.
- **Durable events** — activation persisted as `{type:"CUSTOM", name:"tools_activated"}` events; `hydrateToolDiscoveryFromEvents` rehydrates on resume without re-invoking `load_tools`.
- **Execution gate** — `activatedRemoteToolNames` Set (by reference) passed to `createProjectScopedRemoteToolCatalog` as the live `allowedToolNames`; `isRemoteToolNameAllowed` blocks non-activated tools even if a schema leaked into a request.

## Slices

| # | Description | Tests |
|---|-------------|-------|
| 1 | `load_tools` tool + `RuntimeToolDiscoveryContext` | 21 |
| 2 | `search_tools` tool | 22 |
| 3 | Force-add discovery tools past skill gates | 6 |
| 4 | Per-step forkToolNames refresh | 7 |
| 5 | Durable events + resume rehydration | 12 |
| 6 | Execution gate + assembly wiring | 6 |

**Total new tests: 74 steps. Full suite: 2399 passed, 0 failed.**

## Test plan

- [x] `deno fmt` clean (pre-push hook)
- [x] `deno lint` clean
- [x] Type check clean (`deno check src/index.ts`)
- [x] Full unit suite 2399 passed, 0 failed (pre-push hook)
- [ ] Deploy to staging and run a conversation that invokes `search_tools` then `load_tools`
- [ ] Verify resumed conversation rehydrates activated set correctly

Closes veryfront/veryfront-issue-inbox#34