### PR TITLE
fix(hosted-agent): honor configured tool bindings before provider limits

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1072",
+  "version": "0.1.1073",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -188,6 +188,7 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
       model: "configured-model",
       thinking: { enabled: true, budgetTokens: 1000 },
       maxSteps: 50,
+      tools: ["get_agent", "load_skill", "update_agent"],
     },
     projectId: "project-1",
     authToken: "token-1",
@@ -255,6 +256,8 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
     thinking: { enabled: false },
     maxSteps: 7,
     allowedTools: ["load_skill"],
+    allowedProviderTools: ["load_skill"],
+    includeRuntimeEssentialToolsWhenEmpty: false,
     allowDelegation: false,
     conversationId: "conversation-1",
     runId: "run-1",
@@ -270,6 +273,7 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
         model: "configured-model",
         thinking: { enabled: true, budgetTokens: 1000 },
         maxSteps: 50,
+        tools: ["get_agent", "load_skill", "update_agent"],
       },
       environmentContext: "Browser workspace",
       initialProjectInstructions: "Project instructions",
@@ -279,6 +283,31 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
 
   await result.creationOptions.publishParentRunEvents?.([{ type: "state_delta" }]);
   assertEquals(parentEvents, [{ type: "state_delta" }]);
+});
+
+Deno.test("prepareHostedChatRuntimeCreationOptions uses configured agent tools by default", async () => {
+  const result = await prepareHostedChatRuntimeCreationOptions({
+    request: createParsedHostedChatRequest(),
+    agentConfig: {
+      id: "agent-1",
+      model: "openai/gpt-5.4-nano",
+      tools: ["get_agent", "get_agent_source", "update_agent"],
+      providerTools: ["web_search"],
+    },
+    projectId: "project-1",
+    authToken: "token-1",
+    resolveModelId: (modelId) => modelId,
+    fetchSteering: () => Promise.resolve({ instructions: "", skills: [] }),
+    buildInstructions: () => "Agent instructions",
+  });
+
+  assertEquals(result.creationOptions.allowedTools, [
+    "get_agent",
+    "get_agent_source",
+    "update_agent",
+  ]);
+  assertEquals(result.creationOptions.allowedProviderTools, ["web_search"]);
+  assertEquals(result.creationOptions.includeRuntimeEssentialToolsWhenEmpty, true);
 });
 
 Deno.test("prepareHostedChatExecution prepares root run, runtime, and final messages", async () => {
@@ -347,6 +376,95 @@ Deno.test("prepareHostedChatExecution prepares root run, runtime, and final mess
       content: "agent-1:Project instructions",
     },
   ]);
+});
+
+Deno.test("prepareHostedChatExecution strips provider history enabled by a runtime override", async () => {
+  const messages: ChatUiMessage[] = [
+    {
+      id: "user-1",
+      role: "user",
+      parts: [{ type: "text", text: "Search the web." }],
+    },
+    {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "web_search",
+          toolCallId: "toolu_web_search",
+          input: { query: "Veryfront" },
+          state: "output-available",
+          providerExecuted: true,
+          output: null,
+        },
+        { type: "text", text: "I found the official site." },
+      ],
+    },
+    {
+      id: "tool-1",
+      role: "tool",
+      parts: [{
+        type: "tool-web_search",
+        toolCallId: "toolu_web_search",
+        toolName: "web_search",
+        input: { query: "Veryfront" },
+        state: "output-available",
+        output: null,
+      }],
+    },
+    {
+      id: "user-2",
+      role: "user",
+      parts: [{ type: "text", text: "Continue." }],
+    },
+  ];
+
+  const result = await prepareHostedChatExecution({
+    request: createParsedHostedChatRequest({
+      messages,
+      model: "anthropic/claude-sonnet-4-6",
+      runtimeOverrides: { allowedTools: ["web_search"] },
+      durableRootRun: {
+        runId: "run-1",
+        messageId: "message-1",
+        latestEventId: 3,
+        latestExternalEventSequence: 2,
+      },
+    }),
+    agentConfig: {
+      id: "agent-1",
+      model: "anthropic/claude-sonnet-4-6",
+    },
+    apiUrl: "https://api.example.com",
+    abortSignal: new AbortController().signal,
+    resolveModelId: (modelId) => modelId,
+    fetchSteering: () => Promise.resolve({ instructions: "", skills: [] }),
+    buildInstructions: () => "Agent instructions",
+    createRuntime: (options) =>
+      Promise.resolve({
+        runtimeKind: "framework",
+        modelId: options.model ?? "anthropic/claude-sonnet-4-6",
+        cleanup: () => Promise.resolve(),
+        agent: {
+          stream: () =>
+            Promise.resolve({
+              steps: Promise.resolve([]),
+              toUIMessageStream: async function* () {},
+            }),
+        },
+      }),
+  });
+
+  assertEquals(result.finalMessages.map((message) => message.role), [
+    "user",
+    "assistant",
+    "user",
+  ]);
+  assertEquals(result.finalMessages[1]?.parts, [{
+    type: "text",
+    text: "I found the official site.",
+  }]);
 });
 
 Deno.test("prepareHostedChatExecution does not carry old submitted form input into a new user turn", async () => {

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -27,6 +27,7 @@ import {
   resolveHostedRuntimeRequestConfig,
 } from "./runtime-request-config.ts";
 import { getRuntimeUploadUrl } from "../runtime/upload-url-client.ts";
+import { getProviderNativeToolNames } from "../runtime/provider-native-tool-inventory.ts";
 import { isRuntimeSkillVisibleTo, type RuntimeSkillDefinition } from "../runtime/skill-metadata.ts";
 import {
   applyContextBudget,
@@ -92,7 +93,8 @@ export type HostedChatRuntimeCreationPreparationInput<TRuntimeAgentDefinition> =
     thinking?: RuntimeAgentThinkingConfig;
     maxSteps?: number;
     allowedRemoteTools?: unknown;
-    providerTools?: unknown;
+    providerTools?: string[];
+    tools?: true | string[];
   };
   projectId: string | null;
   authToken: string;
@@ -134,6 +136,25 @@ function getProviderToolNames(agentConfig: { providerTools?: unknown }): string[
       typeof toolName === "string" && toolName.length > 0
     )
     : [];
+}
+
+function getProviderOwnedToolNames(input: {
+  agentConfig: { providerTools?: unknown };
+  runtimeConfig: ResolvedHostedRuntimeRequestConfig;
+}): string[] {
+  const providerNativeToolNames = new Set(
+    getProviderNativeToolNames({ model: input.runtimeConfig.requestedModel }),
+  );
+  const requestedProviderToolNames = input.runtimeConfig.requestedAllowedProviderTools.filter(
+    (toolName) => providerNativeToolNames.has(toolName),
+  );
+
+  return [
+    ...new Set([
+      ...getProviderToolNames(input.agentConfig),
+      ...requestedProviderToolNames,
+    ]),
+  ];
 }
 
 async function flushRequiredContextCompactionEvent(
@@ -185,7 +206,8 @@ export type HostedChatExecutionPreparationInput<
     thinking?: RuntimeAgentThinkingConfig;
     maxSteps?: number;
     allowedRemoteTools?: unknown;
-    providerTools?: unknown;
+    providerTools?: string[];
+    tools?: true | string[];
   },
   TRuntimeResult extends HostedChatRuntimeCreationResult,
 > = {
@@ -319,9 +341,11 @@ export async function prepareHostedChatRuntimeCreationOptions<
       ...(runtimeConfig.requestedMaxSteps !== undefined
         ? { maxSteps: runtimeConfig.requestedMaxSteps }
         : {}),
-      ...(runtimeConfig.effectiveRuntimeOverrides?.allowedTools
-        ? { allowedTools: runtimeConfig.effectiveRuntimeOverrides.allowedTools }
+      ...(runtimeConfig.requestedAllowedTools !== undefined
+        ? { allowedTools: runtimeConfig.requestedAllowedTools }
         : {}),
+      allowedProviderTools: runtimeConfig.requestedAllowedProviderTools,
+      includeRuntimeEssentialToolsWhenEmpty: runtimeConfig.includeRuntimeEssentialToolsWhenEmpty,
       ...(input.request.allowDelegation !== undefined
         ? { allowDelegation: input.request.allowDelegation }
         : {}),
@@ -374,7 +398,8 @@ export async function prepareHostedChatExecution<
     thinking?: RuntimeAgentThinkingConfig;
     maxSteps?: number;
     allowedRemoteTools?: unknown;
-    providerTools?: unknown;
+    providerTools?: string[];
+    tools?: true | string[];
   },
   TRuntimeResult extends HostedChatRuntimeCreationResult,
 >(
@@ -427,7 +452,10 @@ export async function prepareHostedChatExecution<
       authToken: input.request.authToken,
       apiUrl: input.apiUrl,
       projectId: input.request.projectId,
-      providerOwnedToolNames: getProviderToolNames(input.agentConfig),
+      providerOwnedToolNames: getProviderOwnedToolNames({
+        agentConfig: input.agentConfig,
+        runtimeConfig: runtimePreparation.runtimeConfig,
+      }),
       abortSignal: input.abortSignal,
       historicalToolInputRetention: {
         diagnostics: historicalToolInputCompactions,

--- a/src/agent/hosted/chat-runtime-contract.ts
+++ b/src/agent/hosted/chat-runtime-contract.ts
@@ -126,6 +126,10 @@ export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingC
   temperature?: number;
   maxSteps?: number;
   allowedTools?: string[];
+  /** Provider-native selection kept separate from local and MCP tool bindings. */
+  allowedProviderTools?: string[];
+  /** Preserve skill runtime infrastructure for a config-derived empty tool selector. */
+  includeRuntimeEssentialToolsWhenEmpty?: boolean;
   allowDelegation?: boolean;
   thinking?: TThinkingConfig;
   conversationId?: string;

--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -142,7 +142,35 @@ Deno.test("prepareHostedChatRuntimeToolAssembly keeps empty allowed tools as exp
   assertEquals(taskContext.availableToolNames, []);
 });
 
-Deno.test("prepareHostedChatRuntimeToolAssembly does not add skill tools when no skills are active", async () => {
+Deno.test("prepareHostedChatRuntimeToolAssembly keeps skill infrastructure for config-derived empty tools", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+    availableSkillIds: ["plan"],
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      invoke_agent: localTool("Invoke agent"),
+      load_skill: localTool("Load skill"),
+      sleep: localTool("Sleep"),
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: [],
+    includeRuntimeEssentialToolsWhenEmpty: true,
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, ["invoke_agent", "load_skill"]);
+  assertEquals(taskContext.availableToolNames, ["invoke_agent", "load_skill"]);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly keeps config-derived empty non-skill runs narrowed", async () => {
   const taskContext: HostedChatRuntimeToolAssemblyContext = {
     authToken: "token",
     projectId: "project-1",
@@ -160,13 +188,14 @@ Deno.test("prepareHostedChatRuntimeToolAssembly does not add skill tools when no
     },
     apiUrl: "https://api.example.com",
     apiMcpUrl: "https://api.example.com/mcp",
-    allowedToolNames: ["sleep"],
+    allowedToolNames: [],
+    includeRuntimeEssentialToolsWhenEmpty: true,
     createRemoteToolSource: remoteSourceFromConfig,
     preloadLatestConversationUserText: false,
   });
 
-  assertEquals(toolAssembly.localToolNames, ["sleep"]);
-  assertEquals(taskContext.availableToolNames, ["sleep"]);
+  assertEquals(toolAssembly.localToolNames, []);
+  assertEquals(taskContext.availableToolNames, []);
 });
 
 Deno.test("prepareHostedChatRuntimeToolAssembly builds provider-compatible runtime inventory", async () => {
@@ -223,6 +252,73 @@ Deno.test("prepareHostedChatRuntimeToolAssembly builds provider-compatible runti
   assertEquals(traceSpans, ["tool.sleep"]);
 });
 
+Deno.test("prepareHostedChatRuntimeToolAssembly applies configured tools before the OpenAI cap", async () => {
+  const availableConfiguredToolNames = ["get_agent", "get_agent_source", "update_agent"];
+  const configuredToolNames = ["bash", ...availableConfiguredToolNames];
+  const remoteTools = [
+    ...Array.from(
+      { length: 250 },
+      (_, index) => remoteTool(`catalog_tool_${String(index).padStart(3, "0")}`, "Catalog tool"),
+    ),
+    ...availableConfiguredToolNames.map((name) => remoteTool(name, `Tool ${name}`)),
+  ];
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "openai/gpt-5.4-nano",
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {},
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: configuredToolNames,
+    createRemoteToolSource: (config) => ({
+      id: config.id ?? "api-mcp",
+      listTools: () => Promise.resolve(remoteTools),
+      executeTool: () => Promise.resolve({ ok: true }),
+    }),
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.remoteToolNames, availableConfiguredToolNames);
+  assertEquals(toolAssembly.compatibleRemoteToolNames, availableConfiguredToolNames);
+  assertEquals(taskContext.availableToolNames, availableConfiguredToolNames);
+  assertEquals(taskContext.availableToolNames?.includes("catalog_tool_000"), false);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly resolves an owner's configured short tool name", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    agentId: "researcher",
+    projectId: "project-1",
+    model: "openai/gpt-5.4-nano",
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      "researcher--fetch-paper": {
+        ...localTool("Fetch a paper"),
+        id: "researcher--fetch-paper",
+        ownerAgentId: "researcher",
+        shortName: "fetch-paper",
+      },
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: ["fetch-paper"],
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, ["researcher--fetch-paper"]);
+  assertEquals(taskContext.availableToolNames, ["researcher--fetch-paper"]);
+});
+
 Deno.test("prepareHostedChatRuntimeToolAssembly separates provider tools from remote MCP tools", async () => {
   const taskContext: HostedChatRuntimeToolAssemblyContext = {
     authToken: "token",
@@ -237,7 +333,8 @@ Deno.test("prepareHostedChatRuntimeToolAssembly separates provider tools from re
     apiUrl: "https://api.example.com",
     apiMcpUrl: "https://api.example.com/mcp",
     mcpServers: [{ kind: "veryfront-api" }],
-    allowedToolNames: ["create_file", "web_search"],
+    allowedToolNames: ["create_file"],
+    allowedProviderToolNames: ["web_search"],
     createRemoteToolSource: remoteSourceFromConfig,
     preloadLatestConversationUserText: false,
   });
@@ -246,6 +343,77 @@ Deno.test("prepareHostedChatRuntimeToolAssembly separates provider tools from re
   assertEquals(toolAssembly.compatibleRemoteToolNames, ["create_file"]);
   assertEquals(toolAssembly.providerToolNames, ["web_search"]);
   assertEquals(taskContext.availableToolNames, ["create_file", "web_search"]);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly separates matching direct and provider bindings", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    agentId: "researcher",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      "researcher--web_search": {
+        ...localTool("Search a private corpus"),
+        id: "researcher--web_search",
+        ownerAgentId: "researcher",
+        shortName: "web_search",
+      },
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: ["web_search"],
+    allowedProviderToolNames: ["web_search"],
+    sourceProviderToolNames: ["web_search"],
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, ["researcher--web_search"]);
+  assertEquals(toolAssembly.providerToolNames, ["web_search"]);
+  assertEquals(taskContext.availableToolNames, ["researcher--web_search", "web_search"]);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly does not let provider bindings authorize direct tools", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    agentId: "researcher",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      "researcher--web_search": {
+        ...localTool("Search a private corpus"),
+        id: "researcher--web_search",
+        ownerAgentId: "researcher",
+        shortName: "web_search",
+      },
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: [],
+    allowedProviderToolNames: ["web_search"],
+    sourceProviderToolNames: ["web_search"],
+    createRemoteToolSource: (config) => ({
+      id: config.id ?? "api-mcp",
+      listTools: () => Promise.resolve([remoteTool("web_search", "Remote search")]),
+      executeTool: () => Promise.resolve({ ok: true }),
+    }),
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, []);
+  assertEquals(toolAssembly.remoteToolNames, []);
+  assertEquals(toolAssembly.providerToolNames, ["web_search"]);
+  assertEquals(taskContext.availableToolNames, ["web_search"]);
 });
 
 Deno.test("prepareHostedChatRuntimeToolAssembly keeps source provider tools inside forwarded allowed tools", async () => {

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -39,6 +39,7 @@ import type { HostedSubmittedFormInputResult } from "./chat-runtime-contract.ts"
 /** Context for hosted chat runtime tool assembly. */
 export type HostedChatRuntimeToolAssemblyContext = DefaultResearchArtifactContext & {
   authToken: string;
+  agentId?: string;
   projectId?: string | null;
   branchId?: string | null;
   model?: string;
@@ -77,6 +78,8 @@ export type PrepareHostedChatRuntimeToolAssemblyInput<
   mcpServers?: readonly AgentServiceMcpServerConfig[];
   conversationId?: string;
   allowedToolNames?: HostedChatRuntimeAllowedToolNames;
+  allowedProviderToolNames?: HostedChatRuntimeAllowedToolNames;
+  includeRuntimeEssentialToolsWhenEmpty?: boolean;
   sourceProviderToolNames?: readonly string[];
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
   createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
@@ -118,6 +121,51 @@ function filterPostFormInputLocalTools(
   );
 }
 
+function resolveOwnerScopedToolName(input: {
+  toolName: string;
+  agentId?: string;
+  localTools: HostToolSet;
+}): string {
+  if (input.agentId === undefined) {
+    return input.toolName;
+  }
+
+  for (const [registeredName, tool] of Object.entries(input.localTools)) {
+    if (
+      tool.ownerAgentId === input.agentId &&
+      tool.shortName === input.toolName
+    ) {
+      return registeredName;
+    }
+  }
+
+  return input.toolName;
+}
+
+function resolveOwnerScopedToolNames(input: {
+  toolNames: HostedChatRuntimeAllowedToolNames | undefined;
+  agentId?: string;
+  localTools: HostToolSet;
+}): HostedChatRuntimeAllowedToolNames | undefined {
+  const toolNames = normalizeHostedRuntimeAllowedToolNames(input.toolNames);
+  if (toolNames === null) {
+    return input.toolNames;
+  }
+
+  const resolvedToolNames = new Set<string>();
+  for (const toolName of toolNames) {
+    resolvedToolNames.add(
+      resolveOwnerScopedToolName({
+        toolName,
+        agentId: input.agentId,
+        localTools: input.localTools,
+      }),
+    );
+  }
+
+  return resolvedToolNames;
+}
+
 /** Filter hosted chat runtime local tools. */
 export function filterHostedChatRuntimeLocalTools(input: {
   tools: HostToolSet;
@@ -138,10 +186,16 @@ export async function prepareHostedChatRuntimeToolAssembly<
 >(
   input: PrepareHostedChatRuntimeToolAssemblyInput<TTraceAttributes>,
 ): Promise<HostedChatRuntimeToolAssemblyResult> {
+  const ownerScopedAllowedToolNames = resolveOwnerScopedToolNames({
+    toolNames: input.allowedToolNames,
+    agentId: input.taskContext.agentId,
+    localTools: input.localTools,
+  });
   const allowedToolNames = resolveHostedRuntimeAllowedToolNames({
-    allowedToolNames: input.allowedToolNames,
+    allowedToolNames: ownerScopedAllowedToolNames,
     localToolNames: Object.keys(input.localTools),
     availableSkillIds: input.taskContext.availableSkillIds,
+    includeRuntimeEssentialToolsWhenEmpty: input.includeRuntimeEssentialToolsWhenEmpty,
   });
   const sortedLocalTools = filterHostedChatRuntimeLocalTools({
     tools: filterPostFormInputLocalTools(input.localTools, input.taskContext),
@@ -175,13 +229,21 @@ export async function prepareHostedChatRuntimeToolAssembly<
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
   });
   const sourceProviderToolNames = new Set(input.sourceProviderToolNames ?? []);
-  const localProviderToolNames = new Set(
-    Object.keys(sortedLocalTools).filter((toolName) => sourceProviderToolNames.has(toolName)),
+  const allowedProviderToolNames = normalizeHostedRuntimeAllowedToolNames(
+    input.allowedProviderToolNames,
   );
-  const providerToolNames = getProviderNativeToolNames({ model: input.taskContext.model }).filter(
+  const providerNativeToolNames = getProviderNativeToolNames({ model: input.taskContext.model });
+  const localProviderToolNames = new Set(
+    Object.keys(sortedLocalTools).filter((toolName) => providerNativeToolNames.includes(toolName)),
+  );
+  const providerToolNames = providerNativeToolNames.filter(
     (toolName) =>
       !localProviderToolNames.has(toolName) &&
-      (allowedToolNames ? allowedToolNames.has(toolName) : sourceProviderToolNames.has(toolName)),
+      (allowedProviderToolNames
+        ? allowedProviderToolNames.has(toolName)
+        : allowedToolNames
+        ? allowedToolNames.has(toolName)
+        : sourceProviderToolNames.has(toolName)),
   );
   const localToolNames = Object.keys(localHostTools);
   const availableToolNames = selectProviderCompatibleToolNames(

--- a/src/agent/hosted/default-chat-runtime.test.ts
+++ b/src/agent/hosted/default-chat-runtime.test.ts
@@ -108,3 +108,38 @@ Deno.test("createDefaultHostedChatRuntime keeps per-run host tools out of the gl
     toolRegistry.clearAll();
   }
 });
+
+Deno.test("createDefaultHostedChatRuntime resolves configured owner tool selectors", async () => {
+  let capturedContext: DefaultHostedChatRuntimeTaskContext | undefined;
+
+  await createDefaultHostedChatRuntime({
+    options: {
+      projectId: "project-1",
+      authToken: "token-1",
+      instructions: "Base instructions",
+      model: "openai/gpt-5.4-nano",
+      agentId: "researcher",
+      allowedTools: ["fetch-paper"],
+    },
+    config: {
+      apiUrl: "https://api.example.com",
+      apiMcpUrl: "https://api.example.com/mcp",
+    },
+    buildLocalTools: (taskContext) => {
+      capturedContext = taskContext;
+      return {
+        "researcher--fetch-paper": {
+          ...localTool("Fetch a paper"),
+          id: "researcher--fetch-paper",
+          ownerAgentId: "researcher",
+          shortName: "fetch-paper",
+        },
+      };
+    },
+    createRemoteToolSource: emptyRemoteSource,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertExists(capturedContext);
+  assertEquals(capturedContext.availableToolNames, ["researcher--fetch-paper"]);
+});

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -184,6 +184,8 @@ async function buildToolAssembly(
     mcpServers: input.config.mcpServers,
     conversationId: input.options.conversationId,
     allowedToolNames: input.options.allowedTools ?? null,
+    allowedProviderToolNames: input.options.allowedProviderTools,
+    includeRuntimeEssentialToolsWhenEmpty: input.options.includeRuntimeEssentialToolsWhenEmpty,
     sourceProviderToolNames: input.options.liveProjectSteering?.agent.providerTools,
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
     createRemoteToolSource: input.createRemoteToolSource,

--- a/src/agent/hosted/runtime-essential-tools.ts
+++ b/src/agent/hosted/runtime-essential-tools.ts
@@ -6,6 +6,8 @@ export type ResolveHostedRuntimeAllowedToolNamesInput = {
   allowedToolNames?: HostedRuntimeAllowedToolNames;
   localToolNames: Iterable<string>;
   availableSkillIds?: readonly string[];
+  /** Let the existing skill-enabled essential-tool policy handle an empty configured selector. */
+  includeRuntimeEssentialToolsWhenEmpty?: boolean;
 };
 
 const SKILL_RUNTIME_TOOL_NAMES = ["load_skill", "load_skill_reference"] as const;
@@ -27,7 +29,10 @@ export function resolveHostedRuntimeAllowedToolNames(
   input: ResolveHostedRuntimeAllowedToolNamesInput,
 ): ReadonlySet<string> | null {
   const allowedToolNames = normalizeHostedRuntimeAllowedToolNames(input.allowedToolNames);
-  if (!allowedToolNames || allowedToolNames.size === 0) {
+  if (
+    !allowedToolNames ||
+    (allowedToolNames.size === 0 && !input.includeRuntimeEssentialToolsWhenEmpty)
+  ) {
     return allowedToolNames;
   }
 

--- a/src/agent/hosted/runtime-request-config.test.ts
+++ b/src/agent/hosted/runtime-request-config.test.ts
@@ -140,3 +140,79 @@ Deno.test("resolveHostedRuntimeRequestConfig uses forwarded overrides when reque
   assertEquals(result.effectiveRuntimeOverrides, { allowedTools: ["read_file"], maxSteps: 8 });
   assertEquals(result.requestedMaxSteps, 8);
 });
+
+Deno.test("resolveHostedRuntimeRequestConfig defaults to configured agent tools", () => {
+  const result = resolveHostedRuntimeRequestConfig({
+    request: {},
+    agentConfig: createAgentConfig({
+      tools: ["get_agent", "get_agent_source", "update_agent"],
+      providerTools: ["web_search"],
+    }),
+    resolveModelId: (model) => model,
+  });
+
+  assertEquals(result.requestedAllowedTools, [
+    "get_agent",
+    "get_agent_source",
+    "update_agent",
+  ]);
+  assertEquals(result.requestedAllowedProviderTools, ["web_search"]);
+  assertEquals(result.includeRuntimeEssentialToolsWhenEmpty, true);
+});
+
+Deno.test("resolveHostedRuntimeRequestConfig keeps explicit tool overrides ahead of configured tools", () => {
+  const resolve = (allowedTools: string[]) => {
+    const result = resolveHostedRuntimeRequestConfig({
+      request: { runtimeOverrides: { allowedTools } },
+      agentConfig: createAgentConfig({
+        tools: ["get_agent", "update_agent"],
+        providerTools: ["web_search"],
+      }),
+      resolveModelId: (model) => model,
+    });
+    assertEquals(result.requestedAllowedProviderTools, allowedTools);
+    assertEquals(result.includeRuntimeEssentialToolsWhenEmpty, false);
+    return result.requestedAllowedTools;
+  };
+
+  assertEquals(resolve(["unbound_tool", "update_agent", "web_search"]), [
+    "unbound_tool",
+    "update_agent",
+    "web_search",
+  ]);
+  assertEquals(resolve([]), []);
+});
+
+Deno.test("resolveHostedRuntimeRequestConfig distinguishes unrestricted and omitted agent tools", () => {
+  const resolve = (
+    tools: RuntimeAgentMarkdownDefinition["tools"],
+    providerTools?: string[],
+  ) => {
+    const result = resolveHostedRuntimeRequestConfig({
+      request: {},
+      agentConfig: createAgentConfig({ tools, providerTools }),
+      resolveModelId: (model) => model,
+    });
+    return {
+      tools: result.requestedAllowedTools,
+      providerTools: result.requestedAllowedProviderTools,
+      includeRuntimeEssentialToolsWhenEmpty: result.includeRuntimeEssentialToolsWhenEmpty,
+    };
+  };
+
+  assertEquals(resolve(true), {
+    tools: undefined,
+    providerTools: [],
+    includeRuntimeEssentialToolsWhenEmpty: true,
+  });
+  assertEquals(resolve(undefined), {
+    tools: [],
+    providerTools: [],
+    includeRuntimeEssentialToolsWhenEmpty: true,
+  });
+  assertEquals(resolve(undefined, ["web_search"]), {
+    tools: [],
+    providerTools: ["web_search"],
+    includeRuntimeEssentialToolsWhenEmpty: true,
+  });
+});

--- a/src/agent/hosted/runtime-request-config.ts
+++ b/src/agent/hosted/runtime-request-config.ts
@@ -18,7 +18,7 @@ export type HostedRuntimeRequestConfigRequest = Pick<
 /** Public API contract for hosted runtime request config agent. */
 export type HostedRuntimeRequestConfigAgent = Pick<
   RuntimeAgentMarkdownDefinition,
-  "model" | "thinking" | "temperature" | "maxSteps"
+  "model" | "thinking" | "temperature" | "maxSteps" | "tools" | "providerTools"
 >;
 
 /** Input payload for resolve hosted runtime request config. */
@@ -39,6 +39,9 @@ export type ResolvedHostedRuntimeRequestConfig = {
   requestedThinking: RuntimeAgentThinkingConfig | undefined;
   requestedTemperature: number | undefined;
   requestedMaxSteps: number | undefined;
+  requestedAllowedTools: string[] | undefined;
+  requestedAllowedProviderTools: string[];
+  includeRuntimeEssentialToolsWhenEmpty: boolean;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -95,6 +98,32 @@ export function resolveHostedRuntimeThinkingOverride(input: {
   };
 }
 
+/** Resolve the explicit request tool selector or fall back to configured agent bindings. */
+export function resolveHostedRuntimeAllowedTools(input: {
+  configuredTools: RuntimeAgentMarkdownDefinition["tools"];
+  requestedTools: string[] | undefined;
+}): string[] | undefined {
+  if (input.requestedTools !== undefined) {
+    return [...new Set(input.requestedTools)];
+  }
+
+  if (input.configuredTools === true) {
+    return undefined;
+  }
+
+  return [...new Set(input.configuredTools ?? [])];
+}
+
+/** Resolve provider-native tool bindings without widening direct tool access. */
+export function resolveHostedRuntimeAllowedProviderTools(input: {
+  configuredProviderTools: RuntimeAgentMarkdownDefinition["providerTools"];
+  requestedTools: string[] | undefined;
+}): string[] {
+  return [
+    ...new Set(input.requestedTools ?? input.configuredProviderTools ?? []),
+  ];
+}
+
 /** Configuration used by resolve hosted runtime request. */
 export function resolveHostedRuntimeRequestConfig(
   input: ResolveHostedRuntimeRequestConfigInput,
@@ -118,5 +147,14 @@ export function resolveHostedRuntimeRequestConfig(
     requestedTemperature: input.agentConfig.temperature,
     requestedMaxSteps: effectiveRuntimeOverrides?.maxSteps ??
       input.agentConfig.maxSteps,
+    requestedAllowedTools: resolveHostedRuntimeAllowedTools({
+      configuredTools: input.agentConfig.tools,
+      requestedTools: effectiveRuntimeOverrides?.allowedTools,
+    }),
+    requestedAllowedProviderTools: resolveHostedRuntimeAllowedProviderTools({
+      configuredProviderTools: input.agentConfig.providerTools,
+      requestedTools: effectiveRuntimeOverrides?.allowedTools,
+    }),
+    includeRuntimeEssentialToolsWhenEmpty: effectiveRuntimeOverrides?.allowedTools === undefined,
   };
 }

--- a/src/tool/host-tools.ts
+++ b/src/tool/host-tools.ts
@@ -11,6 +11,10 @@ type HostToolExecute = {
 export type HostToolDefinition = {
   id?: string;
   type?: Tool["type"];
+  /** Owning agent id retained for owner-aware hosted tool selection. */
+  ownerAgentId?: string;
+  /** Short selector accepted by the owning agent's `tools:` configuration. */
+  shortName?: string;
   title?: string;
   description?: string;
   inputSchema?: unknown;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1072";
+export const VERSION = "0.1.1073";


### PR DESCRIPTION
## Description

Hosted agent requests were assembling the entire Veryfront MCP catalog instead of honoring the markdown agent's configured tool bindings. Production currently exposes 253 MCP tools; OpenAI accepts at most 128, so the provider compatibility cap discarded alphabetically later configured tools such as `update_agent`.

This change:

- derives direct local/MCP selection from the agent's `tools` binding unless an explicit per-run override is present;
- keeps provider-native selection separate so provider bindings cannot authorize same-name local or MCP tools;
- resolves owner-scoped short tool names for the active agent;
- preserves explicit `allowedTools: []` as deny-all, `tools: true` as unrestricted, existing skill-runtime essentials, and the legacy provider fallback;
- filters the 253-tool catalog before provider compatibility selection;
- strips provider-owned history for provider tools enabled by a runtime override;
- bumps the framework version from 0.1.1072 to 0.1.1073 for publication.

Configured selectors missing from the current context-scoped catalog remain unavailable without aborting the run. This is intentional because capabilities such as `bash` are created by a different runtime context.

## Related Issue(s)

Related to veryfront/veryfront-studio#5906.
Related architectural follow-up: veryfront/veryfront-issue-inbox#34.

The Studio issue should remain open until the published framework is deployed and a production replay confirms an actual `update_agent` call plus readback.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Verification

- `deno task fmt:check`
- `deno task lint`
- `deno task typecheck`
- `deno test --no-check --allow-all src/agent/hosted/` — 281 passed
- `deno task test:unit` — 2,401 passed / 20,322 steps
- independent code and architecture review — no blocking findings
- pre-push hook repeated format, lint, typecheck, and all unit tests successfully

## Checklist

- [x] I have made corresponding changes to the documentation (not applicable; internal hosted-runtime contract)
- [x] I have added tests that prove my fix is effective or that my feature works
