### PR TITLE
Restore configured sandbox tools for hosted root agents

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1073",
+  "version": "0.1.1074",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/default-chat-runtime.test.ts
+++ b/src/agent/hosted/default-chat-runtime.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import type {
   RemoteMCPToolSourceConfig,
   RemoteToolSource,
@@ -142,4 +142,102 @@ Deno.test("createDefaultHostedChatRuntime resolves configured owner tool selecto
 
   assertExists(capturedContext);
   assertEquals(capturedContext.availableToolNames, ["researcher--fetch-paper"]);
+});
+
+Deno.test("createDefaultHostedChatRuntime awaits per-run tool setup and exposes its cleanup", async () => {
+  let capturedContext: DefaultHostedChatRuntimeTaskContext | undefined;
+  let cleanupCalls = 0;
+
+  const runtime = await createDefaultHostedChatRuntime({
+    options: {
+      projectId: "project-1",
+      authToken: "token-1",
+      instructions: "Base instructions",
+      model: "openai/gpt-5.4-nano",
+      allowedTools: ["bash"],
+    },
+    config: {
+      apiUrl: "https://api.example.com",
+      apiMcpUrl: "https://api.example.com/mcp",
+    },
+    buildLocalTools: async (taskContext) => {
+      capturedContext = taskContext;
+      await Promise.resolve();
+      return { bash: localTool("Run shell commands") };
+    },
+    cleanup: () => {
+      cleanupCalls += 1;
+      return Promise.resolve();
+    },
+    createRemoteToolSource: emptyRemoteSource,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertExists(capturedContext);
+  assertEquals(capturedContext.availableToolNames, ["bash"]);
+  await runtime.cleanup();
+  assertEquals(cleanupCalls, 1);
+});
+
+Deno.test("createDefaultHostedChatRuntime cleans up after partial per-run tool setup failure", async () => {
+  let cleanupCalls = 0;
+
+  await assertRejects(
+    () =>
+      createDefaultHostedChatRuntime({
+        options: {
+          projectId: "project-1",
+          authToken: "token-1",
+          instructions: "Base instructions",
+          model: "openai/gpt-5.4-nano",
+          allowedTools: ["bash"],
+        },
+        config: {
+          apiUrl: "https://api.example.com",
+          apiMcpUrl: "https://api.example.com/mcp",
+        },
+        buildLocalTools: async () => {
+          await Promise.resolve();
+          throw new Error("sandbox tool setup failed");
+        },
+        cleanup: () => {
+          cleanupCalls += 1;
+          return Promise.resolve();
+        },
+        createRemoteToolSource: emptyRemoteSource,
+        preloadLatestConversationUserText: false,
+      }),
+    Error,
+    "sandbox tool setup failed",
+  );
+
+  assertEquals(cleanupCalls, 1);
+});
+
+Deno.test("createDefaultHostedChatRuntime preserves setup errors when cleanup also fails", async () => {
+  await assertRejects(
+    () =>
+      createDefaultHostedChatRuntime({
+        options: {
+          projectId: "project-1",
+          authToken: "token-1",
+          instructions: "Base instructions",
+          model: "openai/gpt-5.4-nano",
+          allowedTools: ["bash"],
+        },
+        config: {
+          apiUrl: "https://api.example.com",
+          apiMcpUrl: "https://api.example.com/mcp",
+        },
+        buildLocalTools: async () => {
+          await Promise.resolve();
+          throw new Error("sandbox tool setup failed");
+        },
+        cleanup: () => Promise.reject(new Error("sandbox cleanup failed")),
+        createRemoteToolSource: emptyRemoteSource,
+        preloadLatestConversationUserText: false,
+      }),
+    Error,
+    "sandbox tool setup failed",
+  );
 });

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -120,7 +120,10 @@ export type DefaultHostedChatRuntimeProjectSwitchInput = {
 export type CreateDefaultHostedChatRuntimeOptions = {
   options: DefaultHostedChatRuntimeCreationOptions;
   config: DefaultHostedChatRuntimeConfig;
-  buildLocalTools: (taskContext: DefaultHostedChatRuntimeTaskContext) => HostToolSet;
+  buildLocalTools: (
+    taskContext: DefaultHostedChatRuntimeTaskContext,
+  ) => HostToolSet | Promise<HostToolSet>;
+  cleanup?: () => Promise<void>;
   createTaskContext?: (
     input: CreateDefaultHostedChatRuntimeContextInput,
   ) => DefaultHostedChatRuntimeTaskContext;
@@ -177,7 +180,7 @@ async function buildToolAssembly(
   return prepareHostedChatRuntimeToolAssembly({
     taskContext: input.taskContext,
     instructions: input.options.instructions,
-    localTools: input.buildLocalTools(input.taskContext),
+    localTools: await input.buildLocalTools(input.taskContext),
     apiUrl: input.config.apiUrl,
     apiMcpUrl: input.config.apiMcpUrl,
     studioMcpUrl: input.config.studioMcpUrl,
@@ -323,7 +326,7 @@ export async function createDefaultHostedChatRuntime(
   const taskContext = input.createTaskContext
     ? input.createTaskContext({ options: input.options, modelId })
     : createDefaultTaskContext({ options: input.options, modelId });
-  const cleanup = () => Promise.resolve();
+  const cleanup = input.cleanup ?? (() => Promise.resolve());
 
   try {
     const toolAssembly = await buildToolAssembly({
@@ -368,7 +371,13 @@ export async function createDefaultHostedChatRuntime(
       }),
     };
   } catch (error) {
-    await cleanup();
+    try {
+      await cleanup();
+    } catch (cleanupError) {
+      input.logger?.warn("Hosted chat runtime cleanup failed after setup error", {
+        error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+      });
+    }
     throw error;
   }
 }

--- a/src/agent/hosted/root-sandbox-tool-source.test.ts
+++ b/src/agent/hosted/root-sandbox-tool-source.test.ts
@@ -1,0 +1,218 @@
+import "#veryfront/schemas/_test-setup.ts";
+import type { CreateSandboxBashTool } from "#veryfront/sandbox";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import type { HostToolSet } from "#veryfront/tool";
+import {
+  createHostedRootLocalToolRuntime,
+  prepareHostedRootSandboxToolSource,
+} from "./root-sandbox-tool-source.ts";
+import type { DefaultHostedChatRuntimeTaskContext } from "./default-chat-runtime.ts";
+
+const createBashTool: CreateSandboxBashTool = () => Promise.resolve({ tools: {} });
+
+function createSandboxTools(): HostToolSet {
+  return {
+    bash: {
+      description: "Run shell commands",
+      inputSchema: defineSchema((v) => v.object({ command: v.string() }))(),
+      execute: ({ command }) => ({ command }),
+    },
+    get_background_command: {
+      description: "Get a background command",
+      inputSchema: defineSchema((v) => v.object({ commandId: v.string() }))(),
+      execute: ({ commandId }) => ({ commandId }),
+    },
+  };
+}
+
+Deno.test("prepareHostedRootSandboxToolSource exposes the sandbox source when bash is selected", async () => {
+  const factoryInputs: Array<{ apiUrl?: string | URL; authToken?: string }> = [];
+  let closeCalls = 0;
+
+  const source = await prepareHostedRootSandboxToolSource({
+    allowedToolNames: ["bash"],
+    apiUrl: "https://api.example.com",
+    authToken: "token-1",
+    getProjectId: () => "project-1",
+    createBashTool,
+    createAgentServiceSandboxTools: (input) => {
+      factoryInputs.push(input);
+      return Promise.resolve({
+        tools: createSandboxTools(),
+        closeSandbox: () => {
+          closeCalls += 1;
+          return Promise.resolve();
+        },
+      });
+    },
+  });
+
+  assertEquals(Object.keys(source.tools).sort(), ["bash", "get_background_command"]);
+  assertEquals(factoryInputs.map((input) => [input.apiUrl, input.authToken]), [
+    ["https://api.example.com", "token-1"],
+  ]);
+  await source.closeRuntime?.();
+  assertEquals(closeCalls, 1);
+});
+
+Deno.test("prepareHostedRootSandboxToolSource treats unrestricted tools as a bash selection", async () => {
+  let factoryCalls = 0;
+
+  const source = await prepareHostedRootSandboxToolSource({
+    allowedToolNames: undefined,
+    apiUrl: "https://api.example.com",
+    authToken: "token-1",
+    getProjectId: () => "project-1",
+    createBashTool,
+    createAgentServiceSandboxTools: () => {
+      factoryCalls += 1;
+      return Promise.resolve({
+        tools: createSandboxTools(),
+        closeSandbox: () => Promise.resolve(),
+      });
+    },
+  });
+
+  assertEquals(factoryCalls, 1);
+  assertEquals("bash" in source.tools, true);
+});
+
+Deno.test("prepareHostedRootSandboxToolSource initializes for a bundled background command tool", async () => {
+  let factoryCalls = 0;
+
+  const source = await prepareHostedRootSandboxToolSource({
+    allowedToolNames: ["get_background_command"],
+    apiUrl: "https://api.example.com",
+    authToken: "token-1",
+    getProjectId: () => "project-1",
+    createBashTool,
+    createAgentServiceSandboxTools: () => {
+      factoryCalls += 1;
+      return Promise.resolve({
+        tools: createSandboxTools(),
+        closeSandbox: () => Promise.resolve(),
+      });
+    },
+  });
+
+  assertEquals(factoryCalls, 1);
+  assertEquals("get_background_command" in source.tools, true);
+});
+
+Deno.test("prepareHostedRootSandboxToolSource skips initialization when no sandbox tool is selected", async () => {
+  let factoryCalls = 0;
+
+  for (const allowedToolNames of [[], ["get_agent"]]) {
+    const source = await prepareHostedRootSandboxToolSource({
+      allowedToolNames,
+      apiUrl: "https://api.example.com",
+      authToken: "token-1",
+      getProjectId: () => "project-1",
+      createBashTool,
+      createAgentServiceSandboxTools: () => {
+        factoryCalls += 1;
+        return Promise.resolve({
+          tools: createSandboxTools(),
+          closeSandbox: () => Promise.resolve(),
+        });
+      },
+    });
+
+    assertEquals(source, { tools: {} });
+  }
+
+  assertEquals(factoryCalls, 0);
+});
+
+Deno.test("createHostedRootLocalToolRuntime merges sandbox tools and owns their cleanup", async () => {
+  let getProjectId: (() => string | null | undefined) | undefined;
+  let factoryCalls = 0;
+  let closeCalls = 0;
+  const taskContext: DefaultHostedChatRuntimeTaskContext = {
+    authToken: "token-1",
+    projectId: "project-1",
+    branchId: null,
+    model: "openai/gpt-5.4-nano",
+  };
+  const runtime = createHostedRootLocalToolRuntime({
+    allowedToolNames: ["bash"],
+    apiUrl: "https://api.example.com",
+    authToken: "token-1",
+    createBashTool,
+    buildBaseTools: () => ({ sleep: createSandboxTools().bash }),
+    createAgentServiceSandboxTools: (input) => {
+      factoryCalls += 1;
+      getProjectId = input.getProjectId;
+      return Promise.resolve({
+        tools: createSandboxTools(),
+        closeSandbox: () => {
+          closeCalls += 1;
+          return Promise.resolve();
+        },
+      });
+    },
+  });
+
+  assertEquals(Object.keys(await runtime.buildLocalTools(taskContext)).sort(), [
+    "bash",
+    "get_background_command",
+    "sleep",
+  ]);
+  assertEquals(Object.keys(await runtime.buildLocalTools(taskContext)).sort(), [
+    "bash",
+    "get_background_command",
+    "sleep",
+  ]);
+  assertEquals(factoryCalls, 1);
+  assertEquals(getProjectId?.(), "project-1");
+  taskContext.projectId = "project-2";
+  assertEquals(getProjectId?.(), "project-2");
+  await runtime.cleanup();
+  await runtime.cleanup();
+  assertEquals(closeCalls, 1);
+});
+
+Deno.test("createHostedRootLocalToolRuntime waits for in-flight setup before cleanup", async () => {
+  let resolveSandboxTools:
+    | ((value: {
+      tools: HostToolSet;
+      closeSandbox: () => Promise<void>;
+    }) => void)
+    | undefined;
+  let closeCalls = 0;
+  const sandboxTools = new Promise<{
+    tools: HostToolSet;
+    closeSandbox: () => Promise<void>;
+  }>((resolve) => {
+    resolveSandboxTools = resolve;
+  });
+  const taskContext: DefaultHostedChatRuntimeTaskContext = {
+    authToken: "token-1",
+    projectId: "project-1",
+    branchId: null,
+    model: "openai/gpt-5.4-nano",
+  };
+  const runtime = createHostedRootLocalToolRuntime({
+    allowedToolNames: ["bash"],
+    apiUrl: "https://api.example.com",
+    authToken: "token-1",
+    createBashTool,
+    buildBaseTools: () => ({}),
+    createAgentServiceSandboxTools: () => sandboxTools,
+  });
+
+  const buildPromise = runtime.buildLocalTools(taskContext);
+  const cleanupPromise = runtime.cleanup();
+  resolveSandboxTools?.({
+    tools: createSandboxTools(),
+    closeSandbox: () => {
+      closeCalls += 1;
+      return Promise.resolve();
+    },
+  });
+
+  await buildPromise;
+  await cleanupPromise;
+  assertEquals(closeCalls, 1);
+});

--- a/src/agent/hosted/root-sandbox-tool-source.ts
+++ b/src/agent/hosted/root-sandbox-tool-source.ts
@@ -1,0 +1,113 @@
+import {
+  type AgentServiceSandboxToolsOptions,
+  type AgentServiceSandboxToolsResult,
+  createAgentServiceSandboxTools,
+} from "#veryfront/sandbox";
+import type { HostToolSet } from "#veryfront/tool";
+import type { DefaultHostedChatRuntimeTaskContext } from "./default-chat-runtime.ts";
+
+const HOSTED_ROOT_SANDBOX_TOOL_NAMES = new Set([
+  "bash",
+  "sandbox_read_file",
+  "sandbox_write_file",
+  "start_background_command",
+  "get_background_command",
+  "get_background_command_output",
+  "cancel_background_command",
+]);
+
+type CreateAgentServiceSandboxTools = (
+  input: AgentServiceSandboxToolsOptions,
+) => Promise<Pick<AgentServiceSandboxToolsResult, "tools" | "closeSandbox">>;
+
+/** Input used to prepare the hosted root sandbox tool source. */
+export type PrepareHostedRootSandboxToolSourceInput = AgentServiceSandboxToolsOptions & {
+  allowedToolNames: readonly string[] | undefined;
+  createAgentServiceSandboxTools?: CreateAgentServiceSandboxTools;
+};
+
+/** Tool source and cleanup returned for a hosted root sandbox. */
+export type HostedRootSandboxToolSource = {
+  tools: HostToolSet;
+  closeRuntime?: () => Promise<void>;
+};
+
+/** Input used to create the hosted root local tool lifecycle. */
+export type CreateHostedRootLocalToolRuntimeInput =
+  & Omit<
+    PrepareHostedRootSandboxToolSourceInput,
+    "getProjectId"
+  >
+  & {
+    buildBaseTools: (taskContext: DefaultHostedChatRuntimeTaskContext) => HostToolSet;
+  };
+
+/** Hosted root local tool builder and runtime cleanup. */
+export type HostedRootLocalToolRuntime = {
+  buildLocalTools: (taskContext: DefaultHostedChatRuntimeTaskContext) => Promise<HostToolSet>;
+  cleanup: () => Promise<void>;
+};
+
+/** Prepare sandbox tools only when the effective root selection includes a sandbox tool. */
+export async function prepareHostedRootSandboxToolSource(
+  input: PrepareHostedRootSandboxToolSourceInput,
+): Promise<HostedRootSandboxToolSource> {
+  const {
+    allowedToolNames,
+    createAgentServiceSandboxTools: createSandboxToolsOverride,
+    ...sandboxInput
+  } = input;
+  if (
+    allowedToolNames !== undefined &&
+    !allowedToolNames.some((toolName) => HOSTED_ROOT_SANDBOX_TOOL_NAMES.has(toolName))
+  ) {
+    return { tools: {} };
+  }
+
+  const createSandboxTools = createSandboxToolsOverride ?? createAgentServiceSandboxTools;
+  const sandboxResult = await createSandboxTools(sandboxInput);
+  return {
+    tools: sandboxResult.tools,
+    closeRuntime: sandboxResult.closeSandbox,
+  };
+}
+
+/** Create the hosted root local tool builder with sandbox lifecycle ownership. */
+export function createHostedRootLocalToolRuntime(
+  input: CreateHostedRootLocalToolRuntimeInput,
+): HostedRootLocalToolRuntime {
+  let closeRuntime: (() => Promise<void>) | undefined;
+  let localToolsPromise: Promise<HostToolSet> | undefined;
+  let cleanupPromise: Promise<void> | undefined;
+  const { buildBaseTools, ...sandboxInput } = input;
+
+  return {
+    buildLocalTools(taskContext) {
+      localToolsPromise ??= (async () => {
+        const baseTools = buildBaseTools(taskContext);
+        const sandboxSource = await prepareHostedRootSandboxToolSource({
+          ...sandboxInput,
+          getProjectId: () => taskContext.projectId,
+        });
+        closeRuntime = sandboxSource.closeRuntime;
+        return {
+          ...baseTools,
+          ...sandboxSource.tools,
+        };
+      })();
+      return localToolsPromise;
+    },
+    cleanup() {
+      cleanupPromise ??= (async () => {
+        try {
+          await localToolsPromise;
+        } catch {
+          // Setup errors remain owned by the caller; cleanup only releases any
+          // handle that setup managed to establish before failing.
+        }
+        await closeRuntime?.();
+      })();
+      return cleanupPromise;
+    },
+  };
+}

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -70,6 +70,7 @@ import {
   type DefaultHostedChatRuntimeCreationOptions,
   type DefaultHostedChatRuntimeTaskContext,
 } from "./default-chat-runtime.ts";
+import { createHostedRootLocalToolRuntime } from "./root-sandbox-tool-source.ts";
 import { createVeryfrontCloudContextSummaryGenerator } from "./context-summary-generator.ts";
 import { createDefaultHostedInvokeAgentTool } from "./default-invoke-agent-tool.ts";
 import type { RuntimeClientProfile } from "../runtime/client-profile.ts";
@@ -774,6 +775,13 @@ function createAgentRuntime(
 ): Promise<HostedChatRuntimeCreationResult> {
   const config = context.infrastructure.getConfig();
   const refreshSystem = createProjectSteeringRefresh(context);
+  const localToolRuntime = createHostedRootLocalToolRuntime({
+    allowedToolNames: options.allowedTools,
+    apiUrl: config.VERYFRONT_API_URL,
+    authToken: options.authToken,
+    createBashTool: context.options.createBashTool,
+    buildBaseTools: (taskContext) => buildLocalTools(context, options, taskContext),
+  });
 
   return createDefaultHostedChatRuntime({
     options,
@@ -783,7 +791,8 @@ function createAgentRuntime(
       studioMcpUrl: config.VERYFRONT_STUDIO_MCP_URL,
       mcpServers: resolveMcpServers(context.options),
     },
-    buildLocalTools: (taskContext) => buildLocalTools(context, options, taskContext),
+    buildLocalTools: localToolRuntime.buildLocalTools,
+    cleanup: localToolRuntime.cleanup,
     refreshSystem,
     onSteeringMutation: async ({ mutation, taskContext }) => {
       if (mutation.skillsChanged) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1073";
+export const VERSION = "0.1.1074";


### PR DESCRIPTION
## Summary

- restore configured root-agent sandbox tools, including `bash`, through the existing agent-service sandbox seam
- await per-run local tool setup and attach idempotent sandbox cleanup to hosted runtime finalization
- preserve the original setup failure when cleanup also fails, and wait for in-flight setup before concurrent cleanup
- bump the framework release from `0.1.1073` to `0.1.1074`

This keeps the sandbox lazy: restricted runs that do not select a sandbox tool do not allocate one. The normal hosted tool assembly still applies the configured selector after sandbox tools are merged.

## Verification

- focused TDD cycles for async setup, setup failure, cleanup failure, selector behavior, background tools, project switching, repeated setup/cleanup, and concurrent cleanup
- `deno task fmt:check`
- `deno task lint`
- `deno task typecheck`
- hosted/sandbox suite: 290 passed, 159 steps, 0 failed
- full unit suite: 2,410 passed, 20,322 steps, 0 failed
- pre-push format, lint, typecheck, and full unit checks passed
- independent code review: CLEAR

## Remaining validation

- deploy the released framework through `veryfront-agent`
- replay the production Studio conversation and confirm the root model calls `update_agent`, then read the agent back

Closes #2952
Related: veryfront/veryfront-studio#5906
