### PR TITLE
feat: normalize integration scopes to user and project

### DIFF
--- a/docs/api-reference/veryfront/integrations.md
+++ b/docs/api-reference/veryfront/integrations.md
@@ -59,7 +59,7 @@ const runtimeTools = await getRemoteIntegrationToolDefinitions();
 | `getRemoteIntegrationToolDefinitions` | Fetch integration tool definitions for the current request context. Returns ToolDefinition[] that the agent runtime merges into the model's available tools. Returns empty array if no API config or no tools. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/remote-tools.ts#L162) |
 | `isRemoteIntegrationTool` | Check if a tool name looks like a remote integration tool. Integration tools use "integration__tool_id" format (double underscore separator). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/remote-tools.ts#L190) |
 | `listConnectors` | List connectors. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/index.ts#L54) |
-| `syncIntegrationConfig` | Sync integration config from veryfront.config.ts to the API. This is a full-replace operation. Called by the MCP server path which has access to the config. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/remote-tools.ts#L226) |
+| `syncIntegrationConfig` | Sync integration config from veryfront.config.ts to the API. This is a full-replace operation. Called by the MCP server path which has access to the config. Legacy `endUser` scope input is accepted during migration but normalized to `user` before transmission. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/remote-tools.ts#L266) |
 
 ### Types
 
@@ -72,7 +72,7 @@ const runtimeTools = await getRemoteIntegrationToolDefinitions();
 | `IntegrationName` | Public API contract for integration name. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L479) |
 | `IntegrationPrompt` | Public API contract for integration prompt. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L493) |
 | `IntegrationRuntimeConfig` | Configuration used by integration runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L89) |
-| `IntegrationScope` | Public API contract for integration scope. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L86) |
+| `IntegrationScope` | Canonical user- or project-scoped integration connection. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L87) |
 | `IntegrationTool` | Public API contract for integration tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L65) |
 | `IntegrationToolMeta` | Public API contract for integration tool meta. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L487) |
 | `OAuthConfig` | Configuration used by oauth. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L485) |

--- a/docs/api-reference/veryfront/integrations.md
+++ b/docs/api-reference/veryfront/integrations.md
@@ -59,7 +59,7 @@ const runtimeTools = await getRemoteIntegrationToolDefinitions();
 | `getRemoteIntegrationToolDefinitions` | Fetch integration tool definitions for the current request context. Returns ToolDefinition[] that the agent runtime merges into the model's available tools. Returns empty array if no API config or no tools. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/remote-tools.ts#L162) |
 | `isRemoteIntegrationTool` | Check if a tool name looks like a remote integration tool. Integration tools use "integration__tool_id" format (double underscore separator). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/remote-tools.ts#L190) |
 | `listConnectors` | List connectors. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/index.ts#L54) |
-| `syncIntegrationConfig` | Sync integration config from veryfront.config.ts to the API. This is a full-replace operation. Called by the MCP server path which has access to the config. Legacy `endUser` scope input is accepted during migration but normalized to `user` before transmission. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/remote-tools.ts#L266) |
+| `syncIntegrationConfig` | Sync integration config from veryfront.config.ts to the API. This is a full-replace operation. Called by the MCP server path which has access to the validated, canonical config. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/remote-tools.ts#L265) |
 
 ### Types
 
@@ -71,8 +71,11 @@ const runtimeTools = await getRemoteIntegrationToolDefinitions();
 | `IntegrationEndpointHistoricalSummary` | Provider-declared summary contract for old tool outputs kept actionable across turns. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L489) |
 | `IntegrationName` | Public API contract for integration name. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L479) |
 | `IntegrationPrompt` | Public API contract for integration prompt. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L493) |
-| `IntegrationRuntimeConfig` | Configuration used by integration runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L89) |
+| `IntegrationRuntimeConfig` | Configuration used by integration runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L96) |
+| `IntegrationRuntimeConfigInput` | User-authored integration configuration accepted before validation. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L106) |
 | `IntegrationScope` | Canonical user- or project-scoped integration connection. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L87) |
+| `IntegrationScopeInput` | Integration scope accepted before configuration validation normalizes legacy input. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L93) |
+| `LegacyIntegrationScope` | Deprecated `endUser` configuration input. Use `user` instead. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L90) |
 | `IntegrationTool` | Public API contract for integration tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L65) |
 | `IntegrationToolMeta` | Public API contract for integration tool meta. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L487) |
 | `OAuthConfig` | Configuration used by oauth. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L485) |

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -45,6 +45,10 @@ Use `scope: "user"` for a private connection owned by the current user, or
 but Veryfront normalizes both to `user` and only syncs `user | project` to the
 API.
 
+Before deploying clients that write the canonical `user` scope, fully deploy
+the Phase 1 API compatibility release. During the migration, that API release
+must accept both canonical `user` writes and legacy `endUser` writes.
+
 ## Authentication flow
 
 When an agent calls an integration tool and no valid token exists:

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -31,13 +31,19 @@ export default defineConfig({
       tools: ["send-message", "list-channels"],
     },
 
-    // Per-user tokens (each end-user authenticates individually)
+    // Private user token (each user authenticates individually)
     linear: {
-      perUser: true,
+      scope: "user",
     },
   },
 });
 ```
+
+Use `scope: "user"` for a private connection owned by the current user, or
+`scope: "project"` for a connection shared with the project. The legacy
+`scope: "endUser"` value and `perUser: true` remain accepted during migration,
+but Veryfront normalizes both to `user` and only syncs `user | project` to the
+API.
 
 ## Authentication flow
 

--- a/src/config/define-config.test.ts
+++ b/src/config/define-config.test.ts
@@ -69,6 +69,23 @@ describe("define-config", () => {
         ),
       ).toEqual({ title: "Release", react: { version: "production" } });
     });
+
+    it("composes deprecated scope input before validation", () => {
+      const legacy = publicDefineConfig({
+        integrations: { linear: { scope: "endUser" } },
+      });
+      const merged = publicMergeConfigs(legacy);
+
+      expect(merged.integrations?.linear?.scope).toBe("endUser");
+    });
+
+    it("keeps canonical composition typed as validated config", () => {
+      const canonical: VeryfrontConfig = publicMergeConfigs(
+        publicDefineConfig({ integrations: { linear: { scope: "user" } } }),
+      );
+
+      expect(canonical.integrations?.linear?.scope).toBe("user");
+    });
   });
 
   describe("defineConfigWithEnv", () => {

--- a/src/config/define-config.test.ts
+++ b/src/config/define-config.test.ts
@@ -12,7 +12,7 @@ import {
   defineConfigWithEnv as publicDefineConfigWithEnv,
   mergeConfigs as publicMergeConfigs,
 } from "veryfront";
-import type { VeryfrontConfig } from "./schemas/index.ts";
+import type { VeryfrontConfig, VeryfrontConfigInput } from "./schemas/index.ts";
 import { createTestEnvironmentConfig } from "./environment-config.ts";
 
 describe("define-config", () => {
@@ -27,6 +27,15 @@ describe("define-config", () => {
     it("should work with minimal config", () => {
       const config: VeryfrontConfig = {};
       expect(defineConfig(config)).toEqual({});
+    });
+
+    it("accepts the deprecated endUser scope as configuration input", () => {
+      const config: VeryfrontConfigInput = {
+        integrations: { linear: { scope: "endUser" } },
+      };
+
+      expect(defineConfig(config)).toBe(config);
+      expect(config.integrations?.linear?.scope).toBe("endUser");
     });
 
     it("should preserve all config properties", () => {

--- a/src/config/define-config.ts
+++ b/src/config/define-config.ts
@@ -16,8 +16,12 @@ export function defineConfigWithEnv<const T extends VeryfrontConfigInput>(
 }
 
 /** Merge multiple partial Veryfront configuration objects into one config object. */
-export function mergeConfigs(...configs: Partial<VeryfrontConfig>[]): VeryfrontConfig {
-  return Object.assign({}, ...configs) as VeryfrontConfig;
+export function mergeConfigs(...configs: Partial<VeryfrontConfig>[]): VeryfrontConfig;
+export function mergeConfigs(...configs: Partial<VeryfrontConfigInput>[]): VeryfrontConfigInput;
+export function mergeConfigs(
+  ...configs: Partial<VeryfrontConfigInput>[]
+): VeryfrontConfigInput {
+  return Object.assign({}, ...configs);
 }
 
 export async function validateConfig(config: unknown): Promise<void> {

--- a/src/config/define-config.ts
+++ b/src/config/define-config.ts
@@ -1,17 +1,17 @@
-import type { VeryfrontConfig } from "./schemas/index.ts";
+import type { VeryfrontConfig, VeryfrontConfigInput } from "./schemas/index.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { type EnvironmentConfig, getEnvironmentConfig } from "./environment-config.ts";
 
 /** Define a Veryfront project configuration object. */
-export function defineConfig(config: VeryfrontConfig): VeryfrontConfig {
+export function defineConfig<const T extends VeryfrontConfigInput>(config: T): T {
   return config;
 }
 
 /** Define a Veryfront project configuration from the current environment name. */
-export function defineConfigWithEnv(
-  factory: (env: string) => VeryfrontConfig,
+export function defineConfigWithEnv<const T extends VeryfrontConfigInput>(
+  factory: (env: string) => T,
   envConfig: EnvironmentConfig = getEnvironmentConfig(),
-): VeryfrontConfig {
+): T {
   return factory(envConfig.nodeEnv);
 }
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -210,19 +210,22 @@ export default config as const;
 
     it("normalizes legacy integration scope while loading config", async () => {
       const adapter = setup();
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-config-integration-scope-" });
-      const configPath = `${projectDir}/veryfront.config.js`;
-      const source = 'export default { integrations: { linear: { scope: "endUser" } } };';
+      Object.assign(adapter.fs, {
+        getUnderlyingAdapter: () => adapter.fs,
+        isMultiProjectMode: () => false,
+        isVeryfrontAdapter: () => true,
+      });
+      const projectDir = "/typed-integration-config";
+      const configPath = "/veryfront.config.ts";
+      const source = [
+        'import { defineConfig } from "veryfront";',
+        'export default defineConfig({ integrations: { linear: { scope: "endUser" } } });',
+      ].join("\n");
 
-      try {
-        await Deno.writeTextFile(configPath, source);
-        adapter.fs.files.set(configPath, source);
+      adapter.fs.files.set(configPath, source);
 
-        const config = await getConfig(projectDir, adapter);
-        assertEquals(config.integrations?.linear?.scope, "user");
-      } finally {
-        await Deno.remove(projectDir, { recursive: true });
-      }
+      const config = await getConfig(projectDir, adapter);
+      assertEquals(config.integrations?.linear?.scope, "user");
     });
 
     it("should try multiple config file names", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -208,6 +208,23 @@ export default config as const;
       }
     });
 
+    it("normalizes legacy integration scope while loading config", async () => {
+      const adapter = setup();
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-config-integration-scope-" });
+      const configPath = `${projectDir}/veryfront.config.js`;
+      const source = 'export default { integrations: { linear: { scope: "endUser" } } };';
+
+      try {
+        await Deno.writeTextFile(configPath, source);
+        adapter.fs.files.set(configPath, source);
+
+        const config = await getConfig(projectDir, adapter);
+        assertEquals(config.integrations?.linear?.scope, "user");
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
     it("should try multiple config file names", async () => {
       const adapter = setup();
       const projectDir = await Deno.makeTempDir({ prefix: "vf-config-mjs-" });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -172,9 +172,9 @@ function validateCorsConfig(userConfig: unknown): void {
   });
 }
 
-function validateConfigShape(userConfig: unknown): void {
-  validateVeryfrontConfig(userConfig);
-  if (!userConfig || typeof userConfig !== "object") return;
+function validateConfigShape(userConfig: unknown): VeryfrontConfig {
+  const normalizedConfig = validateVeryfrontConfig(userConfig) as VeryfrontConfig;
+  if (!userConfig || typeof userConfig !== "object") return normalizedConfig;
 
   const unknown = findUnknownTopLevelKeys(userConfig as Record<string, unknown>);
   if (unknown.length > 0) {
@@ -182,6 +182,10 @@ function validateConfigShape(userConfig: unknown): void {
       detail: `Unknown config keys: ${unknown.join(", ")}. Check for typos in veryfront.config.`,
     });
   }
+  return {
+    ...(userConfig as VeryfrontConfig),
+    integrations: normalizedConfig.integrations,
+  };
 }
 
 /** @internal Exported for tests: merges user config over fresh defaults (deep for nested objects). */
@@ -282,9 +286,9 @@ function validateAndCacheConfig(userConfig: unknown, cacheKey: string): Veryfron
   }
 
   validateCorsConfig(userConfig);
-  validateConfigShape(userConfig);
+  const normalizedConfig = validateConfigShape(userConfig);
 
-  const merged = mergeConfigs(userConfig as Partial<VeryfrontConfig>);
+  const merged = mergeConfigs(normalizedConfig);
 
   if (merged.react?.version) {
     logger.debug("React version from config", { version: merged.react.version });

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -1,6 +1,7 @@
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferInput, InferSchema } from "#veryfront/extensions/schema/index.ts";
 import { type ConfigContext, createError, toError } from "#veryfront/errors/veryfront-error.ts";
+import type { IntegrationRuntimeConfigInput } from "#veryfront/integrations/types.ts";
 
 // Sub-schemas
 const getCorsSchema = defineSchema((v) =>
@@ -675,7 +676,14 @@ export const veryfrontConfigSchema = lazySchema(getVeryfrontConfigSchema);
 
 // Inferred types
 export type VeryfrontConfig = InferSchema<ReturnType<typeof getVeryfrontConfigSchema>>;
-export type VeryfrontConfigInput = InferInput<ReturnType<typeof getVeryfrontConfigSchema>>;
+type InferredVeryfrontConfigInput = InferInput<ReturnType<typeof getVeryfrontConfigSchema>>;
+/**
+ * User-authored configuration accepted before schema transforms run.
+ * `endUser` remains a deprecated integration scope input and normalizes to `user`.
+ */
+export type VeryfrontConfigInput = Omit<InferredVeryfrontConfigInput, "integrations"> & {
+  integrations?: Record<string, IntegrationRuntimeConfigInput | undefined>;
+};
 
 // Validation function
 export function validateVeryfrontConfig(input: unknown): VeryfrontConfig {

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -601,9 +601,12 @@ export const getVeryfrontConfigSchema = defineSchema((v) =>
           v.string(),
           v
             .object({
-              /** Token scope: "project" (shared) or "endUser" (per-end-user OAuth). */
-              scope: v.enum(["project", "endUser"]).optional(),
-              /** @deprecated Use `scope: "endUser"` instead. */
+              /** Token scope. Legacy "endUser" input is normalized to "user". */
+              scope: v
+                .enum(["user", "project", "endUser"])
+                .transform((scope): "user" | "project" => scope === "project" ? "project" : "user")
+                .optional(),
+              /** @deprecated Use `scope: "user"` instead. */
               perUser: v.boolean().optional(),
               /** Allowlist of tool IDs to expose. When set, only these tools are registered.
                * This keeps the MCP context narrow by excluding unused tools.

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -77,6 +77,9 @@ export {
 export type {
   IntegrationConnector,
   IntegrationRuntimeConfig,
+  IntegrationRuntimeConfigInput,
   IntegrationScope,
+  IntegrationScopeInput,
   IntegrationTool,
+  LegacyIntegrationScope,
 } from "./types.ts";

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -302,7 +302,7 @@ describe("integrations/remote-tools", () => {
         "sync-token",
         {
           github: { scope: "project", tools: ["list-repos"] },
-          slack: { scope: "endUser" },
+          slack: { scope: "user" },
         },
       ));
 

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -309,7 +309,7 @@ describe("integrations/remote-tools", () => {
     assertEquals(requestBody, {
       integrations: {
         github: { scope: "project", tools: ["list-repos"] },
-        slack: { scope: "endUser" },
+        slack: { scope: "user" },
       },
     });
   });

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -41,7 +41,7 @@ type RemoteIntegrationToolExecutionContext = {
 };
 
 type IntegrationConfigSyncInput = {
-  scope?: IntegrationScope | "endUser";
+  scope: IntegrationScope;
   tools?: string[];
 };
 
@@ -260,24 +260,13 @@ export async function executeRemoteIntegrationTool(
 /**
  * Sync integration config from veryfront.config.ts to the API.
  * This is a full-replace operation. Called by the MCP server path
- * which has access to the config. Legacy `endUser` scope input is accepted
- * during migration but normalized to `user` before transmission.
+ * which has access to the validated, canonical config.
  */
 export async function syncIntegrationConfig(
   apiBaseUrl: string,
   apiToken: string,
   integrations: Record<string, IntegrationConfigSyncInput>,
 ): Promise<void> {
-  const canonicalIntegrations = Object.fromEntries(
-    Object.entries(integrations).map(([name, config]) => [
-      name,
-      {
-        ...config,
-        scope: config.scope === "endUser" ? "user" : config.scope,
-      },
-    ]),
-  );
-
   try {
     const response = await fetch(`${apiBaseUrl}/integrations/config`, {
       method: "POST",
@@ -285,7 +274,7 @@ export async function syncIntegrationConfig(
         Authorization: `Bearer ${apiToken}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ integrations: canonicalIntegrations }),
+      body: JSON.stringify({ integrations }),
       signal: AbortSignal.timeout(INTEGRATION_REQUEST_TIMEOUT_MS),
     });
 

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -13,6 +13,7 @@ import { logger } from "#veryfront/utils";
 import { getApiBaseUrlEnv, getApiTokenEnv } from "#veryfront/config/env.ts";
 
 import type { ToolDefinition } from "#veryfront/tool";
+import type { IntegrationScope } from "./types.ts";
 
 /**
  * Default timeout for outbound integration API calls. Without it, a hung remote
@@ -37,6 +38,11 @@ interface CallToolTextContent {
 type RemoteIntegrationToolExecutionContext = {
   runId?: string;
   agentId?: string;
+};
+
+type IntegrationConfigSyncInput = {
+  scope?: IntegrationScope | "endUser";
+  tools?: string[];
 };
 
 // ---------------------------------------------------------------------------
@@ -254,13 +260,24 @@ export async function executeRemoteIntegrationTool(
 /**
  * Sync integration config from veryfront.config.ts to the API.
  * This is a full-replace operation. Called by the MCP server path
- * which has access to the config.
+ * which has access to the config. Legacy `endUser` scope input is accepted
+ * during migration but normalized to `user` before transmission.
  */
 export async function syncIntegrationConfig(
   apiBaseUrl: string,
   apiToken: string,
-  integrations: Record<string, { scope?: string; tools?: string[] }>,
+  integrations: Record<string, IntegrationConfigSyncInput>,
 ): Promise<void> {
+  const canonicalIntegrations = Object.fromEntries(
+    Object.entries(integrations).map(([name, config]) => [
+      name,
+      {
+        ...config,
+        scope: config.scope === "endUser" ? "user" : config.scope,
+      },
+    ]),
+  );
+
   try {
     const response = await fetch(`${apiBaseUrl}/integrations/config`, {
       method: "POST",
@@ -268,7 +285,7 @@ export async function syncIntegrationConfig(
         Authorization: `Bearer ${apiToken}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ integrations }),
+      body: JSON.stringify({ integrations: canonicalIntegrations }),
       signal: AbortSignal.timeout(INTEGRATION_REQUEST_TIMEOUT_MS),
     });
 

--- a/src/integrations/scope-contract.test.ts
+++ b/src/integrations/scope-contract.test.ts
@@ -1,0 +1,85 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { validateVeryfrontConfig } from "#veryfront/config/schemas/config.schema.ts";
+import { createMCPServer, type IntegrationLoaderConfig } from "#veryfront/mcp/server.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { IntegrationScope } from "./types.ts";
+
+const originalFetch = globalThis.fetch;
+
+function requireCanonicalScope(scope: IntegrationScope): "user" | "project" {
+  return scope;
+}
+
+describe("integration scope compatibility", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("exposes only canonical user and project scopes", () => {
+    const scopes: IntegrationScope[] = ["user", "project"];
+
+    assertEquals(scopes.map(requireCanonicalScope), ["user", "project"]);
+  });
+
+  it("accepts legacy endUser config and normalizes it to user", () => {
+    const config = validateVeryfrontConfig({
+      integrations: {
+        slack: { scope: "endUser", tools: ["search"] },
+      },
+    });
+
+    assertEquals(config.integrations, {
+      slack: { scope: "user", tools: ["search"] },
+    });
+    assertEquals(JSON.stringify(config.integrations).includes("endUser"), false);
+  });
+
+  it("accepts canonical user config without rewriting it", () => {
+    const config = validateVeryfrontConfig({
+      integrations: {
+        slack: { scope: "user", tools: ["search"] },
+      },
+    });
+
+    assertEquals(config.integrations, {
+      slack: { scope: "user", tools: ["search"] },
+    });
+  });
+
+  it("emits only canonical scopes during MCP config sync", async () => {
+    let requestBody: unknown;
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      requestBody = await request.json();
+      return Response.json({ synced: 4 });
+    };
+
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
+    server.setIntegrationLoader({
+      integrations: {
+        legacy: { scope: "endUser" },
+        canonical: { scope: "user" },
+        shared: { scope: "project" },
+        deprecatedPerUser: { perUser: true },
+      } as unknown as IntegrationLoaderConfig["integrations"],
+      apiBaseUrl: "https://api.example.com",
+      apiToken: "test-token",
+    });
+
+    await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+    assertEquals(requestBody, {
+      integrations: {
+        legacy: { scope: "user" },
+        canonical: { scope: "user" },
+        shared: { scope: "project" },
+        deprecatedPerUser: { scope: "user" },
+      },
+    });
+    assertEquals(JSON.stringify(requestBody).includes("endUser"), false);
+  });
+});

--- a/src/integrations/scope-contract.test.ts
+++ b/src/integrations/scope-contract.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { defineConfig } from "#veryfront/config/define-config.ts";
 import { validateVeryfrontConfig } from "#veryfront/config/schemas/config.schema.ts";
-import { createMCPServer, type IntegrationLoaderConfig } from "#veryfront/mcp/server.ts";
+import { createMCPServer } from "#veryfront/mcp/server.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { IntegrationScope } from "./types.ts";
@@ -59,13 +60,16 @@ describe("integration scope compatibility", () => {
       enabled: true,
       auth: { type: "none", allowUnauthenticated: true },
     });
-    server.setIntegrationLoader({
+    const config = validateVeryfrontConfig(defineConfig({
       integrations: {
         legacy: { scope: "endUser" },
         canonical: { scope: "user" },
         shared: { scope: "project" },
         deprecatedPerUser: { perUser: true },
-      } as unknown as IntegrationLoaderConfig["integrations"],
+      },
+    }));
+    server.setIntegrationLoader({
+      integrations: config.integrations ?? {},
       apiBaseUrl: "https://api.example.com",
       apiToken: "test-token",
     });

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -83,14 +83,14 @@ export interface IntegrationConnector {
   tools: IntegrationTool[];
 }
 
-/** Public API contract for integration scope. */
-export type IntegrationScope = "project" | "endUser";
+/** Canonical user- or project-scoped integration connection. */
+export type IntegrationScope = "user" | "project";
 
 /** Configuration used by integration runtime. */
 export interface IntegrationRuntimeConfig {
-  /** Token scope. "project" = shared project token, "endUser" = per-end-user token. */
+  /** Token scope. "project" = shared project token, "user" = private user token. */
   scope?: IntegrationScope;
-  /** @deprecated Use `scope: "endUser"` instead. */
+  /** @deprecated Use `scope: "user"` instead. */
   perUser?: boolean;
   /** Allowlist of tool IDs to expose. When set, only these tools are registered. */
   tools?: string[];

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -86,6 +86,12 @@ export interface IntegrationConnector {
 /** Canonical user- or project-scoped integration connection. */
 export type IntegrationScope = "user" | "project";
 
+/** @deprecated Use the canonical `"user"` scope. Accepted only in configuration input. */
+export type LegacyIntegrationScope = "endUser";
+
+/** Integration scope accepted before configuration validation normalizes legacy input. */
+export type IntegrationScopeInput = IntegrationScope | LegacyIntegrationScope;
+
 /** Configuration used by integration runtime. */
 export interface IntegrationRuntimeConfig {
   /** Token scope. "project" = shared project token, "user" = private user token. */
@@ -95,3 +101,8 @@ export interface IntegrationRuntimeConfig {
   /** Allowlist of tool IDs to expose. When set, only these tools are registered. */
   tools?: string[];
 }
+
+/** User-authored integration configuration accepted before validation. */
+export type IntegrationRuntimeConfigInput = Omit<IntegrationRuntimeConfig, "scope"> & {
+  scope?: IntegrationScopeInput;
+};

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -112,14 +112,10 @@ export interface IntegrationLoaderConfig {
   apiToken?: string;
 }
 
-type CompatibleIntegrationRuntimeConfig = Omit<IntegrationRuntimeConfig, "scope"> & {
-  scope?: IntegrationScope | "endUser";
-};
-
 function normalizeIntegrationScope(
-  config: CompatibleIntegrationRuntimeConfig | undefined,
+  config: IntegrationRuntimeConfig | undefined,
 ): IntegrationScope {
-  if (config?.scope === "user" || config?.scope === "endUser") return "user";
+  if (config?.scope === "user") return "user";
   if (config?.scope === "project") return "project";
   return config?.perUser ? "user" : "project";
 }
@@ -907,9 +903,8 @@ export class MCPServer {
       { scope: IntegrationScope; tools?: string[] }
     > = {};
     for (const [name, cfg] of Object.entries(config.integrations)) {
-      const compatibleConfig = cfg as CompatibleIntegrationRuntimeConfig | undefined;
       integrationConfigs[name] = {
-        scope: normalizeIntegrationScope(compatibleConfig),
+        scope: normalizeIntegrationScope(cfg),
         tools: cfg?.tools,
       };
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,7 +8,7 @@ import type { MCPServerConfig, ToolListEntry } from "./types.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
-import type { IntegrationRuntimeConfig } from "#veryfront/integrations/types.ts";
+import type { IntegrationRuntimeConfig, IntegrationScope } from "#veryfront/integrations/types.ts";
 import { logger as baseLogger } from "#veryfront/utils";
 import { createMCPHTTPHandler } from "./http-transport.ts";
 import { SessionManager } from "./session.ts";
@@ -110,6 +110,18 @@ export interface IntegrationLoaderConfig {
   integrations: Record<string, IntegrationRuntimeConfig | undefined>;
   apiBaseUrl: string;
   apiToken?: string;
+}
+
+type CompatibleIntegrationRuntimeConfig = Omit<IntegrationRuntimeConfig, "scope"> & {
+  scope?: IntegrationScope | "endUser";
+};
+
+function normalizeIntegrationScope(
+  config: CompatibleIntegrationRuntimeConfig | undefined,
+): IntegrationScope {
+  if (config?.scope === "user" || config?.scope === "endUser") return "user";
+  if (config?.scope === "project") return "project";
+  return config?.perUser ? "user" : "project";
 }
 
 const MCP_SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
@@ -890,10 +902,14 @@ export class MCPServer {
     // Sync config to API — this is the only responsibility of the MCP server path.
     // Actual tool discovery happens per-request in the agent runtime (getAvailableTools)
     // and the API's MCP tools/list handler.
-    const integrationConfigs: Record<string, { scope?: string; tools?: string[] }> = {};
+    const integrationConfigs: Record<
+      string,
+      { scope: IntegrationScope; tools?: string[] }
+    > = {};
     for (const [name, cfg] of Object.entries(config.integrations)) {
+      const compatibleConfig = cfg as CompatibleIntegrationRuntimeConfig | undefined;
       integrationConfigs[name] = {
-        scope: cfg?.scope ?? (cfg?.perUser ? "endUser" : "project"),
+        scope: normalizeIntegrationScope(compatibleConfig),
         tools: cfg?.tools,
       };
     }


### PR DESCRIPTION
## Summary

Aligns framework integration configuration with the project-scoped connection model.

- Canonical runtime and generated output scopes are `user | project`.
- Deprecated `endUser` is accepted only as configuration input during rollout.
- Loader, config composition, MCP sync, and direct sync normalize deprecated input to `user` before sending it to the API.
- Public integration documentation describes private project-user and shared project connections.

## Deployment order

Merge and deploy after Studio #5933 and API #3962. The API must already accept canonical `user` writes before this framework release is published.

## Verification

- All GitHub format, lint, typecheck, unit, integration, E2E, coverage, CodeQL, and install-smoke checks are green.
- Focused scope/config/MCP suites, docs generation, and build passed locally.

Independent review previously scored this PR 97/100; final merge remains gated on the complete Studio -> API -> Code rollout.