### PR TITLE
feat(chat): Message.Text / .Reasoning / .Source typed part-leaf sugar (#2935)

### DIFF
--- a/src/react/components/chat/chat/components/sources.tsx
+++ b/src/react/components/chat/chat/components/sources.tsx
@@ -38,6 +38,15 @@ export function useSources(): SourcesContextValue {
   return ctx;
 }
 
+/**
+ * Read the enclosing `Sources` state if present, or `null` outside one. Lets a
+ * leaf like `Message.Source` opt into the row's `onSourceClick` without failing
+ * when rendered standalone.
+ */
+export function useSourcesOptional(): SourcesContextValue | null {
+  return React.useContext(SourcesContext);
+}
+
 /** Props accepted by `Sources` / `Sources.Root`. */
 export interface SourcesProps {
   sources: Source[];

--- a/src/react/components/chat/chat/composition/message-body.tsx
+++ b/src/react/components/chat/chat/composition/message-body.tsx
@@ -1,0 +1,182 @@
+/**
+ * Message body renderers — the grouped-part anatomy shared by the default
+ * `Message.Content` loop and the composed `Message.Part` / typed-leaf sub-parts.
+ * Kept in one module so the composed path never drifts from the preset.
+ *
+ * @module react/components/chat/composition/message-body
+ */
+
+import * as React from "react";
+import type { CodeBlockProps, Components } from "../../markdown.tsx";
+import { Markdown } from "../../markdown.tsx";
+import type { PartGroup } from "../utils/message-parts.ts";
+import { useMessageContext } from "../contexts/message-context.tsx";
+import { Reasoning } from "../components/reasoning.tsx";
+import { ToolCall } from "../components/tool-ui.tsx";
+import { StepIndicator } from "../components/step-indicator.tsx";
+import { AttachmentPill } from "../components/attachment-pill.tsx";
+import { SourcePill, useSourcesOptional } from "../components/sources.tsx";
+import type { Source } from "../components/sources.tsx";
+
+/** Options shared by the default part renderer and `Message.Part`. */
+interface RenderPartOptions {
+  stepCount: number;
+  /** Forwarded to the answer `Markdown` — swap the code block. */
+  codeBlock?: (props: CodeBlockProps) => React.ReactNode;
+  /** Forwarded to the answer `Markdown` — override element renderers. */
+  markdownComponents?: Components;
+}
+
+/**
+ * Render one grouped assistant part with the default anatomy. Extracted so both
+ * the default `Message.Content` loop and the `Message.Part` sub-part share one
+ * source of truth — the composed path never drifts from the preset.
+ */
+export function renderAnswerPart(
+  group: PartGroup,
+  opts: RenderPartOptions,
+): React.ReactNode {
+  if (group.type === "text") {
+    // `my-2` gives the answer text extra breathing room from an adjacent tool
+    // card. In the flex-col container the gap doesn't collapse with margins, so
+    // this widens text↔tool boundaries while tool↔tool stays at the base gap.
+    return (
+      <Markdown
+        className="my-2 text-[15px] leading-7"
+        renderCodeBlock={opts.codeBlock}
+        components={opts.markdownComponents}
+      >
+        {group.content}
+      </Markdown>
+    );
+  }
+  if (group.type === "reasoning") {
+    return <Reasoning text={group.text} isStreaming={group.isStreaming} />;
+  }
+  if (group.type === "step") {
+    return opts.stepCount > 1
+      ? (
+        <StepIndicator
+          stepIndex={group.stepIndex}
+          isComplete={group.isComplete}
+        />
+      )
+      : null;
+  }
+  if (group.type === "file") {
+    const isImage = group.file.mediaType.startsWith("image/");
+    return (
+      <div className="my-1.5">
+        <AttachmentPill
+          className="w-[200px]"
+          attachment={{
+            id: "file",
+            name: group.file.filename ?? "Attachment",
+            type: group.file.mediaType,
+            url: group.file.url,
+            // No lifecycle `state`: this is a sent, read-only attachment, so
+            // the pill shows the file type/size rather than an "Uploaded" badge.
+            ...(group.file.size != null ? { size: group.file.size } : {}),
+            preview: isImage ? group.file.url : undefined,
+          }}
+        />
+      </div>
+    );
+  }
+  // ToolCall renders the compact skill row for skill tools and the full
+  // params/result card for everything else — one component either way.
+  return <ToolCall tool={group.tool} />;
+}
+
+// ---------------------------------------------------------------------------
+// Message.Part — the body sub-part used inside a composed `Message.Content`.
+// Renders any grouped part with the default anatomy (so composition never drifts
+// from the preset); special-case a part by checking `part.type` and rendering
+// your own node instead.
+// ---------------------------------------------------------------------------
+
+/** Props for `Message.Part`. */
+export interface MessagePartProps {
+  part: PartGroup;
+  codeBlock?: (props: CodeBlockProps) => React.ReactNode;
+  markdownComponents?: Components;
+}
+
+/** Render a single grouped part with the default `Message.Content` anatomy. */
+export function MessagePart({
+  part,
+  codeBlock,
+  markdownComponents,
+}: MessagePartProps): React.ReactElement {
+  const { parts } = useMessageContext();
+  const stepCount = parts.filter((g) => g.type === "step").length;
+  return (
+    <>
+      {renderAnswerPart(part, {
+        stepCount,
+        codeBlock,
+        markdownComponents,
+      })}
+    </>
+  );
+}
+MessagePart.displayName = "Message.Part";
+
+// ---------------------------------------------------------------------------
+// Message.Text / .Reasoning / .Source — typed part-leaf sugar.
+//
+// Thin, typed wrappers so a consumer composing `Message.Content`'s function-child
+// can write `<Message.Text part={p} />` on a narrowed part instead of switching
+// on `part.type` themselves. `Text`/`Reasoning` delegate to `Message.Part` (one
+// source of truth for the anatomy); `Source` renders a single citation pill.
+// ---------------------------------------------------------------------------
+
+/** Props for `Message.Text` — a `text` group from `Message.Content`. */
+export interface MessageTextProps {
+  part: Extract<PartGroup, { type: "text" }>;
+  codeBlock?: (props: CodeBlockProps) => React.ReactNode;
+  markdownComponents?: Components;
+}
+
+/** Render a text part with the default answer anatomy (typed sugar over `Message.Part`). */
+export function MessageText(
+  { part, codeBlock, markdownComponents }: MessageTextProps,
+): React.ReactElement {
+  return <MessagePart part={part} codeBlock={codeBlock} markdownComponents={markdownComponents} />;
+}
+MessageText.displayName = "Message.Text";
+
+/** Props for `Message.Reasoning` — a `reasoning` group from `Message.Content`. */
+export interface MessageReasoningProps {
+  part: Extract<PartGroup, { type: "reasoning" }>;
+}
+
+/** Render a reasoning part with the default anatomy (typed sugar over `Message.Part`). */
+export function MessageReasoning({ part }: MessageReasoningProps): React.ReactElement {
+  return <MessagePart part={part} />;
+}
+MessageReasoning.displayName = "Message.Reasoning";
+
+/** Props for `Message.Source` — a single citation from `Message.Sources`. */
+export interface MessageSourceProps {
+  source: Source;
+  index: number;
+  /** Override the click handler; falls back to the enclosing `Message.Sources`. */
+  onClick?: () => void;
+  className?: string;
+}
+
+/**
+ * Render a single citation pill. Inside a `Message.Sources` function-child it
+ * inherits the row's `onSourceClick`; pass `onClick` to override, or use it
+ * standalone with no handler.
+ */
+export function MessageSource(
+  { source, index, onClick, className }: MessageSourceProps,
+): React.ReactElement {
+  const sources = useSourcesOptional();
+  const handleClick = onClick ??
+    (sources?.onSourceClick ? () => sources.onSourceClick?.(source, index) : undefined);
+  return <SourcePill source={source} index={index} onClick={handleClick} className={className} />;
+}
+MessageSource.displayName = "Message.Source";

--- a/src/react/components/chat/chat/composition/message.test.tsx
+++ b/src/react/components/chat/chat/composition/message.test.tsx
@@ -122,6 +122,55 @@ describe("Message.Content — composability contract", () => {
     assertStringIncludes(html, "Runs guide");
   });
 
+  it("Message.Text / .Reasoning render narrowed parts via the typed sugar leaves", () => {
+    const reasoning: ChatMessage = {
+      ...assistantMessage,
+      parts: [
+        { type: "reasoning", text: "Thinking about persistence.", state: "done" },
+        { type: "text", text: "Answer body." },
+      ],
+    };
+    const html = renderToString(
+      <Message.Root message={reasoning}>
+        <Message.Content>
+          {(part: PartGroup, i: number) => {
+            if (part.type === "text") return <Message.Text key={i} part={part} />;
+            if (part.type === "reasoning") return <Message.Reasoning key={i} part={part} />;
+            return <Message.Part key={i} part={part} />;
+          }}
+        </Message.Content>
+      </Message.Root>,
+    );
+    assertStringIncludes(html, "Answer body.");
+    // The reasoning leaf renders the collapsible `Reasoning` anatomy (its text is
+    // behind the "Thought process" toggle, collapsed by default in SSR).
+    assertStringIncludes(html, "Thought process");
+  });
+
+  it("Message.Source renders a citation and inherits the row click handler", () => {
+    const withSources: ChatMessage = {
+      ...assistantMessage,
+      parts: [
+        { type: "text", text: "See sources." },
+        {
+          type: "tool-result",
+          toolCallId: "tool-search-docs",
+          // deno-lint-ignore no-explicit-any
+          result: { documents: [{ title: "Runs guide", url: "/runs" }] } as any,
+          // deno-lint-ignore no-explicit-any
+        } as any,
+      ],
+    };
+    const html = renderToString(
+      <Message.Root message={withSources}>
+        <Message.Sources>
+          {(source, index) => <Message.Source key={index} source={source} index={index} />}
+        </Message.Sources>
+      </Message.Root>,
+    );
+    assertStringIncludes(html, "Runs guide");
+  });
+
   it("does not auto-append sources when the body is composed", () => {
     // In compose mode the caller owns sources — nothing is appended implicitly.
     const withSources: ChatMessage = {

--- a/src/react/components/chat/chat/composition/message.tsx
+++ b/src/react/components/chat/chat/composition/message.tsx
@@ -21,7 +21,6 @@
 import * as React from "react";
 import type { BranchInfo, ChatMessage } from "#veryfront/agent/react";
 import { cn, defaultChatTheme } from "../../theme.ts";
-import { Markdown } from "../../markdown.tsx";
 import type { CodeBlockProps, Components } from "../../markdown.tsx";
 import type { PartGroup } from "../utils/message-parts.ts";
 import { MessageItem } from "#veryfront/react/primitives/index.ts";
@@ -34,16 +33,26 @@ import { Slot } from "../../../ui/slot.tsx";
 import { CheckIcon, CopyIcon, PencilIcon, RefreshCwIcon } from "../../../ui/icons/index.ts";
 import { MessageFeedback as FeedbackImpl } from "../components/message-feedback.tsx";
 import { BranchPicker as BranchPickerImpl } from "../components/branch-picker.tsx";
-import { Reasoning } from "../components/reasoning.tsx";
 import { Shimmer } from "../../../ui/shimmer.tsx";
-import { ToolCall } from "../components/tool-ui.tsx";
-import { StepIndicator } from "../components/step-indicator.tsx";
 import { AttachmentPill } from "../components/attachment-pill.tsx";
 import type { Source } from "../components/sources.tsx";
 import { AgentAvatar as AvatarImpl } from "./agent-avatar.tsx";
 import { Popover, PopoverContent, PopoverTrigger } from "../../../ui/popover.tsx";
 import { MessageSources } from "./message-sources.tsx";
 export type { MessageSourcesProps } from "./message-sources.tsx";
+import {
+  MessagePart,
+  MessageReasoning,
+  MessageSource,
+  MessageText,
+  renderAnswerPart,
+} from "./message-body.tsx";
+export type {
+  MessagePartProps,
+  MessageReasoningProps,
+  MessageSourceProps,
+  MessageTextProps,
+} from "./message-body.tsx";
 import {
   getAnswerPartsForRendering,
   getTextContentFromParts,
@@ -374,76 +383,6 @@ function groupKey(group: PartGroup, index: number): string {
   }
 }
 
-/** Options shared by the default part renderer and `Message.Part`. */
-interface RenderPartOptions {
-  stepCount: number;
-  /** Forwarded to the answer `Markdown` — swap the code block. */
-  codeBlock?: (props: CodeBlockProps) => React.ReactNode;
-  /** Forwarded to the answer `Markdown` — override element renderers. */
-  markdownComponents?: Components;
-}
-
-/**
- * Render one grouped assistant part with the default anatomy. Extracted so both
- * the default `Message.Content` loop and the `Message.Part` sub-part share one
- * source of truth — the composed path never drifts from the preset.
- */
-function renderAnswerPart(
-  group: PartGroup,
-  opts: RenderPartOptions,
-): React.ReactNode {
-  if (group.type === "text") {
-    // `my-2` gives the answer text extra breathing room from an adjacent tool
-    // card. In the flex-col container the gap doesn't collapse with margins, so
-    // this widens text↔tool boundaries while tool↔tool stays at the base gap.
-    return (
-      <Markdown
-        className="my-2 text-[15px] leading-7"
-        renderCodeBlock={opts.codeBlock}
-        components={opts.markdownComponents}
-      >
-        {group.content}
-      </Markdown>
-    );
-  }
-  if (group.type === "reasoning") {
-    return <Reasoning text={group.text} isStreaming={group.isStreaming} />;
-  }
-  if (group.type === "step") {
-    return opts.stepCount > 1
-      ? (
-        <StepIndicator
-          stepIndex={group.stepIndex}
-          isComplete={group.isComplete}
-        />
-      )
-      : null;
-  }
-  if (group.type === "file") {
-    const isImage = group.file.mediaType.startsWith("image/");
-    return (
-      <div className="my-1.5">
-        <AttachmentPill
-          className="w-[200px]"
-          attachment={{
-            id: "file",
-            name: group.file.filename ?? "Attachment",
-            type: group.file.mediaType,
-            url: group.file.url,
-            // No lifecycle `state`: this is a sent, read-only attachment, so
-            // the pill shows the file type/size rather than an "Uploaded" badge.
-            ...(group.file.size != null ? { size: group.file.size } : {}),
-            preview: isImage ? group.file.url : undefined,
-          }}
-        />
-      </div>
-    );
-  }
-  // ToolCall renders the compact skill row for skill tools and the full
-  // params/result card for everything else — one component either way.
-  return <ToolCall tool={group.tool} />;
-}
-
 export interface MessageContentProps {
   className?: string;
   /** Swap the code block used in the answer markdown (forwarded to `Markdown`). */
@@ -536,40 +475,6 @@ function MessageContent({
   );
 }
 MessageContent.displayName = "Message.Content";
-
-// ---------------------------------------------------------------------------
-// Message.Part / Message.Sources — the body sub-parts used inside a composed
-// `Message.Content`. `Message.Part` renders any grouped part with the default
-// anatomy (so composition never drifts from the preset); special-case a part by
-// checking `part.type` and rendering your own node instead.
-// ---------------------------------------------------------------------------
-
-/** Props for `Message.Part`. */
-export interface MessagePartProps {
-  part: PartGroup;
-  codeBlock?: (props: CodeBlockProps) => React.ReactNode;
-  markdownComponents?: Components;
-}
-
-/** Render a single grouped part with the default `Message.Content` anatomy. */
-function MessagePart({
-  part,
-  codeBlock,
-  markdownComponents,
-}: MessagePartProps): React.ReactElement {
-  const { parts } = useMessageContext();
-  const stepCount = parts.filter((g) => g.type === "step").length;
-  return (
-    <>
-      {renderAnswerPart(part, {
-        stepCount,
-        codeBlock,
-        markdownComponents,
-      })}
-    </>
-  );
-}
-MessagePart.displayName = "Message.Part";
 
 // ---------------------------------------------------------------------------
 // Message.Actions — the reference render-or-compose pattern.
@@ -974,6 +879,9 @@ export const Message = Object.assign(MessageComponent, {
   Header: MessageHeaderCompound,
   Content: MessageContent,
   Part: MessagePart,
+  Text: MessageText,
+  Reasoning: MessageReasoning,
+  Source: MessageSource,
   Sources: MessageSources,
   Actions: MessageActionsWrapper,
   CopyAction: MessageCopyAction,

--- a/storybook/stories/chat/Message.stories.tsx
+++ b/storybook/stories/chat/Message.stories.tsx
@@ -19,7 +19,10 @@ Message.Root  <- or compose it: context (message, branch state)
   +-- Message.Header  <- agent avatar + name + timestamp (assistant)
   +-- Message.Content  <- body; no children = default loop, or a function child
   |     +-- Message.Part  <- default rendering for one grouped part
+  |     +-- Message.Text  <- typed sugar: render a text part
+  |     +-- Message.Reasoning  <- typed sugar: render a reasoning part
   |     +-- Message.Sources  <- inline citation sources
+  |     |     +-- Message.Source  <- typed sugar: render a single citation
   +-- Message.Continuing  <- "Continuing…" shimmer while streaming
   +-- Message.Actions  <- copy / regenerate
   +-- Message.Tokens  <- token-usage popover (Model / Input / Output / Total)
@@ -218,6 +221,52 @@ export const CompoundAssistant: Story = {
           <Message.Actions />
           <Message.Tokens />
         </div>
+      </Message.Root>
+    </StoryFrame>
+  ),
+};
+
+export const TypedPartLeaves: Story = {
+  name: "Typed part leaves (Text / Reasoning / Source)",
+  tags: ["!dev"],
+  parameters: {
+    docs: {
+      source: {
+        code: `import { Message } from "veryfront/chat";
+
+// Compose the body from typed sugar leaves instead of switching on part.type:
+// Message.Text / .Reasoning render a narrowed part; Message.Source renders one
+// citation and inherits the row's onSourceClick.
+<Message.Root message={assistantMessage}>
+  <Message.Header />
+  <Message.Content>
+    {(part) => {
+      if (part.type === "text") return <Message.Text part={part} />;
+      if (part.type === "reasoning") return <Message.Reasoning part={part} />;
+      return <Message.Part part={part} />;
+    }}
+  </Message.Content>
+  <Message.Sources>
+    {(source, index) => <Message.Source source={source} index={index} />}
+  </Message.Sources>
+</Message.Root>`,
+      },
+    },
+  },
+  render: () => (
+    <StoryFrame maxWidth="760px">
+      <Message.Root message={chatMessages[1]}>
+        <Message.Header />
+        <Message.Content>
+          {(part) => {
+            if (part.type === "text") return <Message.Text part={part} />;
+            if (part.type === "reasoning") return <Message.Reasoning part={part} />;
+            return <Message.Part part={part} />;
+          }}
+        </Message.Content>
+        <Message.Sources>
+          {(source, index) => <Message.Source source={source} index={index} />}
+        </Message.Sources>
       </Message.Root>
     </StoryFrame>
   ),


### PR DESCRIPTION
## Summary

Closes **#2935** — the optional typed **part-leaf sugar** that the composition overhaul (#2851) deferred. First of the post-#2941 follow-ups.

Lets a consumer composing `Message.Content`'s function-child render a narrowed part directly instead of switching on `part.type`:

```tsx
<Message.Content>
  {(part) => {
    if (part.type === "text") return <Message.Text part={part} />;
    if (part.type === "reasoning") return <Message.Reasoning part={part} />;
    return <Message.Part part={part} />;
  }}
</Message.Content>
<Message.Sources>
  {(source, index) => <Message.Source source={source} index={index} />}
</Message.Sources>
```

## What's in it

| Leaf | Behaviour |
|------|-----------|
| `Message.Text` | Renders a `text` group via `Message.Part` (one source of truth for the anatomy). |
| `Message.Reasoning` | Renders a `reasoning` group via `Message.Part`. |
| `Message.Source` | Renders a single citation pill; inside a `Message.Sources` function-child it inherits the row's `onSourceClick` (new `useSourcesOptional` reader), or takes an explicit `onClick`. |

Each is a dumb consumer of the message context / its `part` prop, hung off the `Message` compound.

## Notes

- **Additive** — no breaking changes. `Message.Part` + the `part.type` switch keep working.
- Extracted the shared part-body renderers (`renderAnswerPart`, `Message.Part`, and the new leaves) into `message-body.tsx` so `message.tsx` stays under its LOC ratchet ceiling — no ceiling was raised.

## Tests / gates

- New composability-contract cases: `Message.Text`/`.Reasoning` render narrowed parts; `Message.Source` renders + inherits the row click handler.
- New Storybook story: **Typed part leaves (Text / Reasoning / Source)**; composition tree updated (audit: all trees honest).
- Green: chat component suite (45 files / 206 steps, 0 failed), chat ratchets, `chat-barrels` typecheck, storybook workbench, fmt + lint.