### PR TITLE
Bump package version to 0.1.1077

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1076",
+  "version": "0.1.1077",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1076";
+export const VERSION = "0.1.1077";


### PR DESCRIPTION
Advances `deno.json` and `src/utils/version-constant.ts` (kept in lockstep; the drift-checked version test passes, 21 steps) past the `v0.1.1076` tag so the canonical integration scope work merged in #2954 can publish as `0.1.1077`.

Part of the veryfront-studio#5898 / #5934 rollout sequence.