### PR TITLE
fix: preserve structured tool auth errors across the errorText channel

### DIFF
--- a/src/agent/ag-ui/browser-encoder.test.ts
+++ b/src/agent/ag-ui/browser-encoder.test.ts
@@ -176,6 +176,73 @@ describe("agent/ag-ui-browser-encoder", () => {
     );
   });
 
+  it("restores structured auth payloads from JSON tool-output-error text", () => {
+    const state = createAgUiBrowserEncoderState();
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-output-error",
+        toolCallId: "tool-1",
+        errorText: JSON.stringify({
+          error: "authentication_required",
+          integration: "gmail",
+          connectUrl: "https://veryfront.org/connect/gmail",
+          message: "Authentication required for Gmail.",
+        }),
+      }),
+      [{
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: "tool-1",
+          result: {
+            error: "authentication_required",
+            integration: "gmail",
+            connectUrl: "https://veryfront.org/connect/gmail",
+            message: "Authentication required for Gmail.",
+          },
+          isError: true,
+        },
+      }],
+    );
+  });
+
+  it("keeps plain and non-auth JSON tool-output-error text as opaque error strings", () => {
+    const state = createAgUiBrowserEncoderState();
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-output-error",
+        toolCallId: "tool-1",
+        errorText: "Tool execution failed",
+      }),
+      [{
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: "tool-1",
+          result: { error: "Tool execution failed" },
+          isError: true,
+        },
+      }],
+    );
+
+    const nonAuthJson = JSON.stringify({ error: "rate_limited", message: "Too many requests." });
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-output-error",
+        toolCallId: "tool-2",
+        errorText: nonAuthJson,
+      }),
+      [{
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: "tool-2",
+          result: { error: nonAuthJson },
+          isError: true,
+        },
+      }],
+    );
+  });
+
   it("marks provider-executed tools complete when the provider owns execution", () => {
     const state = createAgUiBrowserEncoderState();
 

--- a/src/agent/ag-ui/browser-encoder.ts
+++ b/src/agent/ag-ui/browser-encoder.ts
@@ -521,6 +521,29 @@ function completeToolInput(
   return events;
 }
 
+const STRUCTURED_TOOL_ERROR_CODES = new Set(["authentication_required", "reconnect_required"]);
+
+function parseStructuredToolErrorText(errorText: unknown): Record<string, unknown> | undefined {
+  if (typeof errorText !== "string" || !errorText.startsWith("{")) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(errorText);
+    if (
+      parsed && typeof parsed === "object" && !Array.isArray(parsed) &&
+      typeof (parsed as Record<string, unknown>).error === "string" &&
+      STRUCTURED_TOOL_ERROR_CODES.has((parsed as Record<string, unknown>).error as string)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Not JSON — treat as plain error text.
+  }
+
+  return undefined;
+}
+
 function createToolResultEvent(
   toolCallId: unknown,
   result: Record<string, unknown> | unknown,
@@ -799,7 +822,15 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
       return [
         ...closeOpenTextEvent(state),
         ...closeOpenReasoningEvent(state),
-        createToolResultEvent(event.toolCallId, { error: event.errorText }, true),
+        createToolResultEvent(
+          event.toolCallId,
+          // Structured tool errors (authentication_required / reconnect_required
+          // with a connectUrl) travel JSON-serialized through the string-typed
+          // errorText channel; restore them so the platform executor and the
+          // Studio Connect card see the machine code, not prose.
+          parseStructuredToolErrorText(event.errorText) ?? { error: event.errorText },
+          true,
+        ),
       ];
 
     case "tool-output-denied":

--- a/src/agent/runtime/tool-result-continuation.test.ts
+++ b/src/agent/runtime/tool-result-continuation.test.ts
@@ -321,6 +321,51 @@ describe("agent runtime streamed tool result collection", () => {
     );
   });
 
+  it("serializes structured auth errors so the machine code survives the errorText channel", () => {
+    const serialized = getToolResultError({
+      error: "authentication_required",
+      integration: "gmail",
+      connectUrl: "https://veryfront.org/connect/gmail",
+      message: "Authentication required for Gmail.",
+      isError: true,
+    });
+
+    assertEquals(
+      serialized === undefined ? undefined : JSON.parse(serialized),
+      {
+        error: "authentication_required",
+        integration: "gmail",
+        connectUrl: "https://veryfront.org/connect/gmail",
+        message: "Authentication required for Gmail.",
+      },
+    );
+
+    const reconnect = getToolResultError({
+      error: "reconnect_required",
+      integration: "gmail",
+      message: "Reconnect Gmail.",
+    });
+    assertEquals(
+      reconnect === undefined ? undefined : JSON.parse(reconnect),
+      {
+        error: "reconnect_required",
+        integration: "gmail",
+        message: "Reconnect Gmail.",
+      },
+    );
+  });
+
+  it("keeps flattening non-auth structured errors to their human message", () => {
+    assertEquals(
+      getToolResultError({
+        error: "rate_limited",
+        message: "Too many requests.",
+        isError: true,
+      }),
+      "Too many requests.",
+    );
+  });
+
   it("classifies only canonical returned tool error markers", () => {
     assertEquals(getToolResultError({ error: null }), undefined);
     assertEquals(getToolResultError({ error: false }), undefined);

--- a/src/agent/runtime/tool-result-continuation.ts
+++ b/src/agent/runtime/tool-result-continuation.ts
@@ -27,9 +27,36 @@ function getMcpToolErrorMessage(result: unknown): string | undefined {
   return record.error;
 }
 
+const STRUCTURED_TOOL_AUTH_ERRORS = new Set(["authentication_required", "reconnect_required"]);
+
+/**
+ * Structured auth payloads must survive the string-typed errorText channel:
+ * the platform executor and the Studio Connect card key on the machine code
+ * and connectUrl, not the human message. Serialize the payload as JSON; the
+ * AG-UI encoder parses JSON errorText back into a structured tool result.
+ */
+function serializeStructuredToolAuthError(result: unknown): string | undefined {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return undefined;
+  }
+
+  const record = result as Record<string, unknown>;
+  if (typeof record.error !== "string" || !STRUCTURED_TOOL_AUTH_ERRORS.has(record.error)) {
+    return undefined;
+  }
+
+  const { isError: _isError, ...payload } = record;
+  return JSON.stringify(payload);
+}
+
 export function getToolResultError(result: unknown): string | undefined {
   if (!hasToolExecutionErrorMarker(result)) {
     return undefined;
+  }
+
+  const structuredAuthError = serializeStructuredToolAuthError(result);
+  if (structuredAuthError !== undefined) {
+    return structuredAuthError;
   }
 
   const mcpToolErrorMessage = getMcpToolErrorMessage(result);


### PR DESCRIPTION
## Problem

When an integration tool fails with `authentication_required` / `reconnect_required`, the platform returns a structured payload (`error` code, `integration`, `connectUrl`, `message`). The runtime's `getToolResultError` flattened it to the human-readable message before emitting the `tool-output-error` event, so the AG-UI browser encoder produced `{ error: "Authentication required for Gmail." }`.

The platform executor's `getIntegrationAuthRequiredResult` matches `result.error` against `INTEGRATION_AUTH_REQUIRED_ERRORS` (the machine codes) — so it never matched, the run never completed with reason `integration_auth_required`, and Studio never rendered the Connect card. Verified on staging (rc.85): persisted tool result was `{"error":"Authentication required for Gmail."}` and zero `integration_auth_required` completions in logs.

## Fix

- `getToolResultError` now JSON-serializes the structured payload for the two auth error codes so it survives the string-typed `errorText` channel. All other errors keep the existing human-message flattening.
- The AG-UI browser encoder parses JSON `errorText` back into the structured tool result (only for the two auth codes); plain and non-auth JSON error text stays an opaque `{ error: string }` as before.

## Testing

- New unit tests for both helpers (round-trip of `authentication_required` / `reconnect_required`, non-auth errors unchanged, plain text unchanged).
- `deno task test:unit`: 2423 passed, 0 failed.
- `deno lint` + `deno check` clean on changed files.

Part of the interactive integration Connect-card chain (platform PRs #3963 / #3967 / #3970 / #3974).