### PR TITLE
fix: keep signed run cancellation independent of project releases

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1078",
+  "version": "0.1.1079",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/runtime-handler/project-middleware.test.ts
+++ b/src/server/runtime-handler/project-middleware.test.ts
@@ -429,6 +429,76 @@ describe("ProjectMiddlewareRuntime", () => {
     assertEquals(await response?.json(), { TENANT_VALUE: "project-only" });
   });
 
+  it("bypasses project middleware for config-optional control-plane run routes", async () => {
+    const adapter = createAdapter();
+    let loads = 0;
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => {
+        loads++;
+        return Promise.resolve([
+          () => new Response("project-middleware", { status: 418 }),
+        ]);
+      },
+    });
+    const context = createContext(adapter, { releaseId: undefined });
+    let routeCalls = 0;
+    const next = () => {
+      routeCalls++;
+      return Promise.resolve(new Response("route"));
+    };
+    const requests = [
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+        method: "POST",
+      }),
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
+        method: "POST",
+      }),
+      new Request("https://example.com/api/control-plane/runs/run_1", {
+        method: "DELETE",
+      }),
+    ];
+
+    for (const request of requests) {
+      const response = await execute(runtime, context, request, next);
+      assertEquals(response?.status, 200);
+      assertEquals(await response?.text(), "route");
+    }
+
+    assertEquals(loads, 0);
+    assertEquals(routeCalls, 3);
+  });
+
+  it("keeps project middleware enabled for control-plane run execution", async () => {
+    const adapter = createAdapter();
+    let loads = 0;
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => {
+        loads++;
+        return Promise.resolve([
+          () => new Response("project-middleware", { status: 418 }),
+        ]);
+      },
+    });
+    let routeCalls = 0;
+
+    const response = await execute(
+      runtime,
+      createContext(adapter),
+      new Request("https://example.com/api/control-plane/runs/run_1/execute", {
+        method: "POST",
+      }),
+      () => {
+        routeCalls++;
+        return Promise.resolve(new Response("route"));
+      },
+    );
+
+    assertEquals(response?.status, 418);
+    assertEquals(await response?.text(), "project-middleware");
+    assertEquals(loads, 1);
+    assertEquals(routeCalls, 0);
+  });
+
   it("does not load shared middleware for local, standalone, or unauthenticated context", async () => {
     const adapter = createAdapter();
     let loads = 0;

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -1,6 +1,7 @@
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache";
+import { isConfigOptionalControlPlaneRunRequest } from "#veryfront/channels/control-plane.ts";
 import { MiddlewareContext } from "#veryfront/middleware/core/context.ts";
 import { MiddlewarePipeline } from "#veryfront/middleware/core/pipeline/index.ts";
 import { getProjectEnvSnapshot } from "#veryfront/server/project-env";
@@ -84,6 +85,16 @@ export class ProjectMiddlewareRuntime {
 
   async execute(input: ProjectMiddlewareRuntimeContext): Promise<Response | undefined> {
     const { handlerContext: ctx, isSharedProxy, next, request } = input;
+
+    if (
+      isConfigOptionalControlPlaneRunRequest(
+        request.method,
+        new URL(request.url).pathname,
+      )
+    ) {
+      return next();
+    }
+
     const fs = ctx.adapter.fs;
 
     if (

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1078";
+export const VERSION = "0.1.1079";


### PR DESCRIPTION
## Why

The post-#2964 staging log audit found that the API correctly completed Gmail runs with `integration_auth_required`, then its best-effort runtime DELETE returned 500 before reaching the cancel handler. Project middleware attempted production filesystem discovery even though signed stream/resume/cancel routes are explicitly config-optional and may not carry a release ID.

## What changed

- bypass project-authored middleware only for the existing exact config-optional control-plane classifier
- leave `/execute` and unrelated routes project-middleware/config strict
- preserve signed handler verification; missing or forged signatures still fail in the route handlers
- keep the release-qualified cache invariant unchanged
- release as `veryfront@0.1.1079` for staging verification

## Regression coverage

- RED before fix: config-optional route returned fixture middleware status 418 instead of reaching the route
- stream, resume, and DELETE cancel now bypass project middleware with no release
- `/execute` negative guard still applies project middleware
- focused control-plane suites: 41 steps, 0 failures
- full unit suite: 2,423 files / 20,427 steps / 0 failures
- repo-wide format, lint, typecheck, dependency boundaries, and architecture validation pass
- circular scan: same 14 pre-existing cycles; none involve this change

## Staging gate

After merge/release, repeat the Gmail auth-required run and require the runtime cancel DELETE to return 202/204 with no `Runtime cancel request failed` or missing-release 500 in gcx/kubectl logs.

Related: #2964
Related: veryfront/veryfront-api#3974