### PR TITLE
feat: declare delegated integration tool dependencies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1080",
+  "version": "0.1.1081",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -24,6 +24,18 @@ describe("tool factory", () => {
       assertEquals(t.description, "A test tool");
     });
 
+    it("should preserve delegated integration tool dependencies", () => {
+      const t = tool({
+        id: "github-list-issues",
+        description: "List GitHub issues through a bounded wrapper",
+        delegatedIntegrationTools: ["github__list_issues"],
+        inputSchema: defineSchema((v) => v.object({}))(),
+        execute: async () => [],
+      });
+
+      assertEquals(t.delegatedIntegrationTools, ["github__list_issues"]);
+    });
+
     it("should auto-generate id when not provided", () => {
       const t = tool({
         description: "auto-id",

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -137,6 +137,9 @@ export function tool<TInput = unknown, TOutput = unknown>(
     id,
     type: "function" as const,
     description: config.description,
+    ...(config.delegatedIntegrationTools
+      ? { delegatedIntegrationTools: [...config.delegatedIntegrationTools] }
+      : {}),
     inputSchema: config.inputSchema as Schema<TInput>,
     inputSchemaJson,
     outputSchema: config.outputSchema as Schema<TOutput> | undefined,

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -18,6 +18,13 @@ export interface ToolConfig<TInput = any, TOutput = any> {
   description: string;
 
   /**
+   * Native integration tools this local wrapper may call through the platform.
+   * Hosts use this metadata for connection binding and least-privilege runtime
+   * authorization. These dependencies are not exposed to the model as tools.
+   */
+  delegatedIntegrationTools?: readonly string[];
+
+  /**
    * Input schema produced via `defineSchema((v) => …)` (or any
    * `SchemaValidator`-backed builder), or a raw JSON Schema object for
    * dynamic/project-authored tools. Schema validators parse before `execute`;
@@ -153,6 +160,9 @@ export interface Tool<TInput = any, TOutput = any> {
 
   /** Tool description */
   description: string;
+
+  /** Native integration tools this local wrapper may call through the platform. */
+  delegatedIntegrationTools?: readonly string[];
 
   /** Input schema produced by `defineSchema` (or any SchemaValidator-backed builder). */
   inputSchema: Schema<TInput>;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1080";
+export const VERSION = "0.1.1081";


### PR DESCRIPTION
## Summary
- add optional delegated integration dependency metadata to local tools
- preserve the metadata through the tool factory
- keep delegated native tools separate from the model-visible tool surface
- bump the framework release to `0.1.1081`

## Verification
- `deno fmt --check src/tool/types.ts src/tool/factory.ts src/tool/factory.test.ts`
- `deno lint src/tool/types.ts src/tool/factory.ts src/tool/factory.test.ts`
- `deno check src/tool/factory.ts src/tool/types.ts`
- `deno test --no-check --allow-all src/tool/factory.test.ts`
- version constant verified against `deno.json`
- full pre-push suite: 2,423 tests passed

Tracks veryfront/veryfront-studio#5988.