### PR TITLE
fix(agent): propagate conversation context to hosted tools

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1082",
+  "version": "0.1.1083",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/chat-runtime-agent-adapter.test.ts
+++ b/src/agent/hosted/chat-runtime-agent-adapter.test.ts
@@ -121,6 +121,7 @@ describe("createHostedChatRuntimeAgentAdapter", () => {
       sourceIntegrationPolicy: unrestrictedSourceIntegrationPolicy,
       agentId: "agent-1",
       runId: "run-1",
+      conversationId: "conversation-1",
       authToken: "run-token-1",
       runStream: async (operation) => {
         runnerCalled = true;
@@ -149,6 +150,7 @@ describe("createHostedChatRuntimeAgentAdapter", () => {
     assertEquals(capturedInput?.context?.abortSignal, abortController.signal);
     assertEquals(capturedInput?.context?.agentId, "agent-1");
     assertEquals(capturedInput?.context?.runId, "run-1");
+    assertEquals(capturedInput?.context?.conversationId, "conversation-1");
     assertEquals(capturedInput?.context?.authToken, "run-token-1");
     const expectedChunks = [
       { type: "start", messageId: "assistant-message" },

--- a/src/agent/hosted/chat-runtime-agent-adapter.ts
+++ b/src/agent/hosted/chat-runtime-agent-adapter.ts
@@ -27,6 +27,7 @@ export type HostedChatRuntimeAgentAdapterInput = {
   sourceIntegrationPolicy: SourceIntegrationPolicyManifest;
   runId?: string;
   agentId?: string;
+  conversationId?: string;
   authToken?: string;
   runStream?: HostedChatRuntimeAgentAdapterRunner;
   warnOrphanedToolInput?: (
@@ -57,6 +58,7 @@ export function createHostedChatRuntimeAgentAdapter(
               context: {
                 ...(input.runId ? { runId: input.runId } : {}),
                 ...(input.agentId ? { agentId: input.agentId } : {}),
+                ...(input.conversationId ? { conversationId: input.conversationId } : {}),
                 ...(input.authToken ? { authToken: input.authToken } : {}),
                 abortSignal: streamInput.abortSignal,
                 publishDataEvent: (event: ToolExecutionDataEvent) => publishDataEvent(event),

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -364,6 +364,7 @@ export async function createDefaultHostedChatRuntime(
             sourceIntegrationPolicy: input.sourceIntegrationPolicy,
             runId: taskContext.runId,
             agentId: taskContext.agentId,
+            conversationId: taskContext.conversationId,
             authToken: taskContext.authToken,
             runStream: (operation) =>
               runWithDefaultHostedRequestContext({

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1082";
+export const VERSION = "0.1.1083";


### PR DESCRIPTION
## Summary
- propagate the durable conversation ID through the hosted runtime adapter
- make it available to local tools such as the Jira issue wrapper
- bump the framework package to 0.1.1082

## Verification
- red: `chat-runtime-agent-adapter.test.ts` failed because `conversationId` was undefined
- green: targeted hosted runtime tests pass
- `deno check` passes for the changed modules