### PR TITLE
fix(agent): honor scheduled output token limits

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1083",
+  "version": "0.1.1084",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -181,6 +181,7 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
         allowedTools: ["load_skill"],
         thinking: false,
         maxSteps: 7,
+        maxOutputTokens: 1200,
       },
     }),
     agentConfig: {
@@ -255,6 +256,7 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
     model: "resolved:requested-model",
     thinking: { enabled: false },
     maxSteps: 7,
+    maxOutputTokens: 1200,
     allowedTools: ["load_skill"],
     allowedProviderTools: ["load_skill"],
     includeRuntimeEssentialToolsWhenEmpty: false,

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -341,6 +341,9 @@ export async function prepareHostedChatRuntimeCreationOptions<
       ...(runtimeConfig.requestedMaxSteps !== undefined
         ? { maxSteps: runtimeConfig.requestedMaxSteps }
         : {}),
+      ...(runtimeConfig.requestedMaxOutputTokens !== undefined
+        ? { maxOutputTokens: runtimeConfig.requestedMaxOutputTokens }
+        : {}),
       ...(runtimeConfig.requestedAllowedTools !== undefined
         ? { allowedTools: runtimeConfig.requestedAllowedTools }
         : {}),

--- a/src/agent/hosted/chat-request.ts
+++ b/src/agent/hosted/chat-request.ts
@@ -36,6 +36,7 @@ export const getHostedChatRuntimeOverridesSchema = defineSchema((v) =>
     allowedTools: v.array(v.string().min(1)).max(100).optional(),
     thinking: v.union([v.literal(false), v.number().int().positive()]).optional(),
     maxSteps: v.number().int().positive().optional(),
+    maxOutputTokens: v.number().int().positive().optional(),
   }).strip()
 );
 

--- a/src/agent/hosted/chat-runtime-agent-adapter.test.ts
+++ b/src/agent/hosted/chat-runtime-agent-adapter.test.ts
@@ -123,6 +123,7 @@ describe("createHostedChatRuntimeAgentAdapter", () => {
       runId: "run-1",
       conversationId: "conversation-1",
       authToken: "run-token-1",
+      maxOutputTokens: 1200,
       runStream: async (operation) => {
         runnerCalled = true;
         return await operation();
@@ -152,6 +153,7 @@ describe("createHostedChatRuntimeAgentAdapter", () => {
     assertEquals(capturedInput?.context?.runId, "run-1");
     assertEquals(capturedInput?.context?.conversationId, "conversation-1");
     assertEquals(capturedInput?.context?.authToken, "run-token-1");
+    assertEquals(capturedInput?.maxOutputTokens, 1200);
     const expectedChunks = [
       { type: "start", messageId: "assistant-message" },
       { type: "start-step" },

--- a/src/agent/hosted/chat-runtime-agent-adapter.ts
+++ b/src/agent/hosted/chat-runtime-agent-adapter.ts
@@ -29,6 +29,7 @@ export type HostedChatRuntimeAgentAdapterInput = {
   agentId?: string;
   conversationId?: string;
   authToken?: string;
+  maxOutputTokens?: number;
   runStream?: HostedChatRuntimeAgentAdapterRunner;
   warnOrphanedToolInput?: (
     message: string,
@@ -55,6 +56,9 @@ export function createHostedChatRuntimeAgentAdapter(
           async () => {
             const response = await input.runtimeAgent.stream({
               messages: streamInput.messages,
+              ...(input.maxOutputTokens !== undefined
+                ? { maxOutputTokens: input.maxOutputTokens }
+                : {}),
               context: {
                 ...(input.runId ? { runId: input.runId } : {}),
                 ...(input.agentId ? { agentId: input.agentId } : {}),

--- a/src/agent/hosted/chat-runtime-contract.ts
+++ b/src/agent/hosted/chat-runtime-contract.ts
@@ -125,6 +125,7 @@ export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingC
   model?: string;
   temperature?: number;
   maxSteps?: number;
+  maxOutputTokens?: number;
   allowedTools?: string[];
   /** Provider-native selection kept separate from local and MCP tool bindings. */
   allowedProviderTools?: string[];

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -366,6 +366,7 @@ export async function createDefaultHostedChatRuntime(
             agentId: taskContext.agentId,
             conversationId: taskContext.conversationId,
             authToken: taskContext.authToken,
+            maxOutputTokens: input.options.maxOutputTokens,
             runStream: (operation) =>
               runWithDefaultHostedRequestContext({
                 taskContext,

--- a/src/agent/hosted/runtime-request-config.test.ts
+++ b/src/agent/hosted/runtime-request-config.test.ts
@@ -39,6 +39,9 @@ Deno.test("getForwardedHostedRuntimeOverrides parses non-empty forwarded runtime
   assertEquals(getForwardedHostedRuntimeOverrides({ runtimeOverrides: { thinking: 1000 } }), {
     thinking: 1000,
   });
+  assertEquals(getForwardedHostedRuntimeOverrides({ maxOutputTokens: 1200 }), {
+    maxOutputTokens: 1200,
+  });
 });
 
 Deno.test("resolveHostedRuntimeThinkingOverride applies optional thinking override", () => {
@@ -131,14 +134,20 @@ Deno.test("resolveHostedRuntimeRequestConfig uses forwarded overrides when reque
           allowedTools: ["read_file"],
           maxSteps: 8,
         },
+        maxOutputTokens: 1200,
       },
     },
     agentConfig: createAgentConfig({ maxSteps: 12 }),
     resolveModelId: (model) => model ? `veryfront-cloud/${model}` : undefined,
   });
 
-  assertEquals(result.effectiveRuntimeOverrides, { allowedTools: ["read_file"], maxSteps: 8 });
+  assertEquals(result.effectiveRuntimeOverrides, {
+    allowedTools: ["read_file"],
+    maxSteps: 8,
+    maxOutputTokens: 1200,
+  });
   assertEquals(result.requestedMaxSteps, 8);
+  assertEquals(result.requestedMaxOutputTokens, 1200);
 });
 
 Deno.test("resolveHostedRuntimeRequestConfig defaults to configured agent tools", () => {

--- a/src/agent/hosted/runtime-request-config.ts
+++ b/src/agent/hosted/runtime-request-config.ts
@@ -39,6 +39,7 @@ export type ResolvedHostedRuntimeRequestConfig = {
   requestedThinking: RuntimeAgentThinkingConfig | undefined;
   requestedTemperature: number | undefined;
   requestedMaxSteps: number | undefined;
+  requestedMaxOutputTokens: number | undefined;
   requestedAllowedTools: string[] | undefined;
   requestedAllowedProviderTools: string[];
   includeRuntimeEssentialToolsWhenEmpty: boolean;
@@ -63,20 +64,27 @@ export function getForwardedHostedRuntimeOverrides(
   forwardedProps: Record<string, unknown> | undefined,
 ): ChatRuntimeOverrides | undefined {
   const runtimeOverrides = forwardedProps?.runtimeOverrides;
-  if (!isRecord(runtimeOverrides)) {
-    return undefined;
-  }
-
-  const parsedRuntimeOverrides = hostedChatRuntimeOverridesSchema.safeParse(
-    runtimeOverrides,
-  );
-  if (!parsedRuntimeOverrides.success) {
-    return undefined;
-  }
-
-  return Object.keys(parsedRuntimeOverrides.data).length > 0
-    ? parsedRuntimeOverrides.data
+  const parsedRuntimeOverrides = isRecord(runtimeOverrides)
+    ? hostedChatRuntimeOverridesSchema.safeParse(runtimeOverrides)
     : undefined;
+  if (parsedRuntimeOverrides && !parsedRuntimeOverrides.success) {
+    return undefined;
+  }
+
+  const maxOutputTokens = forwardedProps?.maxOutputTokens;
+  const forwardedMaxOutputTokens = typeof maxOutputTokens === "number" &&
+      Number.isSafeInteger(maxOutputTokens) && maxOutputTokens > 0
+    ? maxOutputTokens
+    : undefined;
+  const overrides = {
+    ...(parsedRuntimeOverrides?.success ? parsedRuntimeOverrides.data : {}),
+    ...(forwardedMaxOutputTokens !== undefined &&
+        parsedRuntimeOverrides?.data.maxOutputTokens === undefined
+      ? { maxOutputTokens: forwardedMaxOutputTokens }
+      : {}),
+  };
+
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
 /** Resolves hosted runtime thinking override. */
@@ -147,6 +155,7 @@ export function resolveHostedRuntimeRequestConfig(
     requestedTemperature: input.agentConfig.temperature,
     requestedMaxSteps: effectiveRuntimeOverrides?.maxSteps ??
       input.agentConfig.maxSteps,
+    requestedMaxOutputTokens: effectiveRuntimeOverrides?.maxOutputTokens,
     requestedAllowedTools: resolveHostedRuntimeAllowedTools({
       configuredTools: input.agentConfig.tools,
       requestedTools: effectiveRuntimeOverrides?.allowedTools,

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -302,6 +302,7 @@ export interface ChatRuntimeOverrides {
   allowedTools?: string[];
   thinking?: false | number;
   maxSteps?: number;
+  maxOutputTokens?: number;
 }
 
 /** Public API contract for project file. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1083";
+export const VERSION = "0.1.1084";


### PR DESCRIPTION
Fixes #2982

Scheduled runs already forward `config.maxOutputTokens`; hosted chat discarded it before calling the framework agent. This wires the positive limit through hosted request parsing, creation, and adapter streaming, so the provider receives the configured 1,200-token cap instead of reserving Sonnet’s 64k maximum.

Validation:
- Red: added assertions for forwarded schedule props, runtime creation, and adapter stream input (failed before implementation).
- Green: 28 targeted hosted-agent tests passed.
- `deno check` for changed modules, `deno task typecheck`, `deno task lint`, and `deno task fmt:check` passed.

Release: `veryfront@0.1.1084`.