### PR TITLE
fix(agent): honor scheduled output-token limits

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1084",
+  "version": "0.1.1085",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.lock
+++ b/deno.lock
@@ -3,7 +3,9 @@
   "specifiers": {
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/assert@^1.0.17": "1.0.19",
+    "jsr:@std/async@^1.1.0": "1.2.0",
     "jsr:@std/cli@1.0.28": "1.0.28",
+    "jsr:@std/data-structures@^1.0.10": "1.0.11",
     "jsr:@std/dotenv@0.225.6": "0.225.6",
     "jsr:@std/fmt@1.0.9": "1.0.9",
     "jsr:@std/fs@1.0.23": "1.0.23",
@@ -79,8 +81,14 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/async@1.2.0": {
+      "integrity": "c059c6f6d95ca7cc012ae8e8d7164d1697113d54b0b679e4372b354b11c2dee5"
+    },
     "@std/cli@1.0.28": {
       "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a"
+    },
+    "@std/data-structures@1.0.11": {
+      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
     },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
@@ -108,6 +116,8 @@
       "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
       "dependencies": [
         "jsr:@std/assert@^1.0.17",
+        "jsr:@std/async@^1.1.0",
+        "jsr:@std/data-structures@^1.0.10",
         "jsr:@std/internal"
       ]
     },

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -128,6 +128,44 @@ describe("internal-agents/run-stream", () => {
     _resetShimForTests();
   });
 
+  it("forwards the scheduled output-token cap to the internal runtime", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedMaxOutputTokens: number | undefined;
+    const agent = {
+      id: "test",
+      config: {
+        id: "test",
+        model: "anthropic/claude-sonnet-4-6",
+        system: "test",
+      },
+    } as unknown as Agent;
+    const input = {
+      agentId: "test",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: { maxOutputTokens: 1200 },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(input, agent, {
+      sessionManager,
+      createRuntime: () => ({
+        stream: async (_messages, _context, _callbacks, _modelOverride, maxOutputTokens) => {
+          capturedMaxOutputTokens = maxOutputTokens;
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          });
+        },
+      }),
+    });
+
+    assertEquals(capturedMaxOutputTokens, 1200);
+  });
+
   it("filters unavailable boolean source tool declarations before constructing the runtime", async () => {
     const sessionManager = new AgentRunSessionManager();
     let capturedToolNames: string[] = [];

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -397,6 +397,13 @@ function getAllowedRemoteToolNames(
   return allowedTools.every((toolName) => typeof toolName === "string") ? allowedTools : [];
 }
 
+function getForwardedMaxOutputTokens(
+  forwardedProps: RuntimeRunAgentInput["forwardedProps"],
+): number | undefined {
+  const value = forwardedProps?.maxOutputTokens;
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
 /**
  * Reads the restrictive `runtimeOverrides.toolAllowlist` override.
  *
@@ -680,6 +687,7 @@ export async function createRuntimeAgentStreamResponse(
     normalizeAgUiRuntimeMessages(input.messages),
     mergedTools,
   );
+  const maxOutputTokens = getForwardedMaxOutputTokens(input.forwardedProps);
   let runtimeStream: ReadableStream<Uint8Array>;
   let clientAttached = true;
   try {
@@ -702,7 +710,7 @@ export async function createRuntimeAgentStreamResponse(
         },
       },
       undefined,
-      undefined,
+      maxOutputTokens,
       abortSignal,
     );
     logger.info("Internal agent runtime stream attached", {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1084";
+export const VERSION = "0.1.1085";


### PR DESCRIPTION
Fixes #2982

## Root cause
Project-owned scheduled agents use `src/internal-agents/run-stream.ts`, which called `AgentRuntime.stream` without forwarding the persisted `forwardedProps.maxOutputTokens` cap. The provider gateway therefore reserved against the model maximum and rejected an otherwise affordable staging run before its first tool call.

## Change
Pass a valid positive scheduled cap to the existing `maxOutputTokensOverride` runtime argument.

## Verification
- Regression test: scheduled cap `1200` reaches the internal runtime
- `deno test --frozen -A src/internal-agents/run-stream.test.ts`
- `deno task fmt:check`
- `deno task lint`
- `deno task typecheck`
- Pre-push full unit suite: 2,516 tests / 20,830 steps

Release version: `veryfront@0.1.1085`.