### PR TITLE
feat(eval): run all discovered evals

### DIFF
--- a/cli/commands/eval/command-help.ts
+++ b/cli/commands/eval/command-help.ts
@@ -3,12 +3,12 @@ import type { CommandHelp } from "../../help/types.ts";
 export const evalHelp: CommandHelp = {
   name: "eval",
   category: "ai",
-  description: "Discover and run eval definitions",
+  description: "List, run, and export discovered eval definitions",
   usage: "veryfront eval [eval-id] [options]",
   options: [
     {
       flag: "-l, --list",
-      description: "List discovered evals",
+      description: "List discovered evals without running them",
     },
     {
       flag: "--dataset-base <path>",
@@ -86,6 +86,7 @@ export const evalHelp: CommandHelp = {
   ],
   examples: [
     "veryfront eval --list",
+    "veryfront eval",
     "veryfront eval deep-research",
     "veryfront eval eval:deep-research --report-dir .veryfront/evals/deep-research",
     "veryfront eval eval:deep-research --report .veryfront/evals/deep-research/report.json --junit .veryfront/evals/deep-research/junit.xml",
@@ -93,6 +94,7 @@ export const evalHelp: CommandHelp = {
     "veryfront eval deep-research --baseline-model anthropic/claude-sonnet-4-6 --candidate-model moonshotai/kimi-k2.6",
     "veryfront eval deep-research --baseline-model anthropic/claude-sonnet-4-6 --candidate-model moonshotai/kimi-k2.6 --comparison-policy evals/model-comparison.policy.json",
     "veryfront eval deep-research --export braintrust,langfuse --json",
+    "MLFLOW_TRACKING_URI=https://mlflow.example.com veryfront eval",
     "veryfront eval deep-research --json",
   ],
 };

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -9,6 +9,7 @@ import {
   evalAgent,
   type EvalReport,
   evalTool,
+  metrics,
 } from "veryfront/eval";
 import { createEvalReportExporterRegistry } from "veryfront/extensions/eval";
 import { markCurrentVeryfrontCloudBillingGroupUsed } from "veryfront/provider";
@@ -61,6 +62,7 @@ const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
 const originalXdgConfigHome = Deno.env.get("XDG_CONFIG_HOME");
 const originalEvalExport = Deno.env.get("VERYFRONT_EVAL_EXPORT");
 const originalEvalExporters = Deno.env.get("VERYFRONT_EVAL_EXPORTERS");
+const originalMlflowTrackingUri = Deno.env.get("MLFLOW_TRACKING_URI");
 const originalFetch = globalThis.fetch;
 const redactionEnvNames = [
   "VERYFRONT_EVAL_EXPORT_INCLUDE_INPUTS",
@@ -110,6 +112,12 @@ function restoreEnv(): void {
     Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
   } else {
     Deno.env.set("VERYFRONT_EVAL_EXPORTERS", originalEvalExporters);
+  }
+
+  if (originalMlflowTrackingUri === undefined) {
+    Deno.env.delete("MLFLOW_TRACKING_URI");
+  } else {
+    Deno.env.set("MLFLOW_TRACKING_URI", originalMlflowTrackingUri);
   }
 
   for (const name of redactionEnvNames) {
@@ -320,6 +328,14 @@ describe("eval CLI command helpers", () => {
     Deno.env.set("VERYFRONT_EVAL_EXPORT", "langfuse");
 
     assertEquals(resolveEvalExporterIds({ exporters: [] }), ["langfuse"]);
+  });
+
+  it("exports to MLflow when its tracking URI is configured", () => {
+    Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
+    Deno.env.delete("VERYFRONT_EVAL_EXPORT");
+    Deno.env.set("MLFLOW_TRACKING_URI", "https://mlflow.example.com");
+
+    assertEquals(resolveEvalExporterIds({ exporters: [] }), ["mlflow"]);
   });
 
   it("keeps eval export redaction safe by default", () => {
@@ -670,6 +686,110 @@ describe("eval CLI command helpers", () => {
 
       assertEquals(exitCode, 0);
       assertEquals(observedPolicies, [sourceIntegrationPolicy]);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
+  });
+
+  it("runs every discovered eval sequentially and passes example metadata through agent context", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-eval-suite-" });
+    const configHome = await Deno.makeTempDir({ prefix: "vf-eval-suite-auth-" });
+    const contexts: unknown[] = [];
+    const fixtureAgent = {
+      id: "fixture",
+      config: {},
+      generate: async (input: { context?: unknown }) => {
+        contexts.push(input.context);
+        return {
+          text: "expected",
+          messages: [],
+          status: "completed",
+          toolCalls: [],
+        } satisfies AgentResponse;
+      },
+    } as unknown as Agent;
+    const alpha = evalAgent({
+      id: "eval:alpha",
+      target: "agent:fixture",
+      dataset: [{
+        id: "alpha-example",
+        input: "alpha",
+        metadata: { fixtureScenario: "alpha" },
+      }],
+      metrics: [metrics.answer.contains({ text: "expected" }).gate()],
+    });
+    const beta = evalAgent({
+      id: "eval:beta",
+      target: "agent:fixture",
+      dataset: [{
+        id: "beta-example",
+        input: "beta",
+        metadata: { fixtureScenario: "beta" },
+      }],
+      metrics: [metrics.answer.contains({ text: "missing" }).gate()],
+    });
+    alpha.source = { filePath: `${projectDir}/evals/alpha.eval.ts`, exportName: "default" };
+    beta.source = { filePath: `${projectDir}/evals/beta.eval.ts`, exportName: "default" };
+    const runtime = createProjectRuntimeDiscovery(normalizeSourceIntegrationPolicy({ allow: {} }));
+    runtime.agents.set(fixtureAgent.id, fixtureAgent);
+    runtime.evals.set(beta.id, beta);
+    runtime.evals.set(alpha.id, alpha);
+
+    try {
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORT");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+
+      const exitCode = await runEvalCommand(
+        {
+          list: false,
+          exporters: [],
+          debug: false,
+          candidateModels: [],
+          projectDir,
+          reportDir: `${projectDir}/suite`,
+        },
+        { discoverProjectAgentRuntime: () => Promise.resolve(runtime) },
+      );
+
+      assertEquals(exitCode, 1);
+      assertEquals(contexts, [
+        {
+          eval: {
+            definitionId: "eval:alpha",
+            exampleId: "alpha-example",
+            repetition: 1,
+            metadata: { fixtureScenario: "alpha" },
+          },
+        },
+        {
+          eval: {
+            definitionId: "eval:beta",
+            exampleId: "beta-example",
+            repetition: 1,
+            metadata: { fixtureScenario: "beta" },
+          },
+        },
+      ]);
+      const summary = JSON.parse(await Deno.readTextFile(`${projectDir}/suite/summary.json`));
+      assertEquals(summary.total, 2);
+      assertEquals(summary.passed, 1);
+      assertEquals(summary.failed, 1);
+      assertEquals(summary.results.map((result: { id: string }) => result.id), [
+        "eval:alpha",
+        "eval:beta",
+      ]);
+      assertEquals(
+        await Deno.stat(`${projectDir}/suite/001-alpha/summary.json`).then(() => true),
+        true,
+      );
+      assertEquals(
+        await Deno.stat(`${projectDir}/suite/002-beta/summary.json`).then(() => true),
+        true,
+      );
     } finally {
       await Deno.remove(projectDir, { recursive: true });
       await Deno.remove(configHome, { recursive: true });

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -88,6 +88,33 @@ type EvalArtifactPaths = {
   reportMarkdown: string;
 };
 
+type EvalSuiteArtifactPaths = {
+  directory: string;
+  summary: string;
+  reportMarkdown: string;
+};
+
+type EvalSuiteResult = {
+  id: string;
+  name: string;
+  target: string;
+  status: "passed" | "failed" | "error";
+  artifacts?: EvalArtifactPaths;
+  summary?: CliEvalSummary;
+  error?: string;
+};
+
+type EvalSuiteSummary = {
+  kind: "eval-suite-summary";
+  runId: string;
+  startedAt: string;
+  endedAt: string;
+  total: number;
+  passed: number;
+  failed: number;
+  results: EvalSuiteResult[];
+};
+
 type EvalModelArtifactPaths = EvalArtifactPaths & {
   junit: string;
 };
@@ -140,6 +167,7 @@ type EvalModelComparisonPolicy = Omit<EvalModelComparisonOptions, "baselineModel
 const GATEWAY_BILLING_GROUP_USAGE_NOT_READY_CODE = "gateway_billing_group_usage_not_ready";
 const ENV_EVAL_EXPORTERS = "VERYFRONT_EVAL_EXPORTERS";
 const ENV_EVAL_EXPORT = "VERYFRONT_EVAL_EXPORT";
+const ENV_MLFLOW_TRACKING_URI = "MLFLOW_TRACKING_URI";
 const ENV_EVAL_EXPORT_INCLUDE_INPUTS = "VERYFRONT_EVAL_EXPORT_INCLUDE_INPUTS";
 const ENV_EVAL_EXPORT_INCLUDE_OUTPUTS = "VERYFRONT_EVAL_EXPORT_INCLUDE_OUTPUTS";
 const ENV_EVAL_EXPORT_INCLUDE_REFERENCES = "VERYFRONT_EVAL_EXPORT_INCLUDE_REFERENCES";
@@ -210,6 +238,31 @@ export function createEvalArtifactPaths(reportDir: string): EvalArtifactPaths {
     results: join(reportDir, "results.jsonl"),
     reportMarkdown: join(reportDir, "report.md"),
   };
+}
+
+function createEvalSuiteArtifactPaths(reportDir: string): EvalSuiteArtifactPaths {
+  return {
+    directory: reportDir,
+    summary: join(reportDir, "summary.json"),
+    reportMarkdown: join(reportDir, "report.md"),
+  };
+}
+
+function sortEvals(evals: DiscoveredEval[]): DiscoveredEval[] {
+  return [...evals].sort((left, right) =>
+    left.id.localeCompare(right.id) || left.filePath.localeCompare(right.filePath)
+  );
+}
+
+function createEvalSuiteChildDirectory(
+  suiteDirectory: string,
+  index: number,
+  evalId: string,
+): string {
+  return join(
+    suiteDirectory,
+    `${String(index + 1).padStart(3, "0")}-${sanitizeEvalReportDirLabel(evalId)}`,
+  );
 }
 
 function sanitizeModelIdForPath(model: string): string {
@@ -1079,10 +1132,18 @@ function createEvalToolCallId(toolId: string, context: EvalToolAdapterContext): 
 }
 
 function createAgentAdapter(agent: Agent, options: EvalOptions) {
-  return async ({ example }: EvalAgentAdapterContext) => {
+  return async ({ definition, example, repetition }: EvalAgentAdapterContext) => {
     const started = Date.now();
     const response = await agent.generate({
       input: normalizeEvalInputForAgent(example.input),
+      context: {
+        eval: {
+          definitionId: definition.id,
+          exampleId: example.id,
+          repetition,
+          metadata: example.metadata ?? {},
+        },
+      },
       ...(options.model ? { model: options.model } : {}),
       ...(options.maxOutputTokens ? { maxOutputTokens: options.maxOutputTokens } : {}),
     });
@@ -1121,7 +1182,7 @@ export function createToolAdapter(tool: Tool, baseContext: ToolExecutionContext 
 }
 
 function listEvals(evals: DiscoveredEval[], projectDir: string) {
-  return evals.map((item) => ({
+  return sortEvals(evals).map((item) => ({
     id: item.id,
     name: item.name,
     target: item.definition.target,
@@ -1130,6 +1191,83 @@ function listEvals(evals: DiscoveredEval[], projectDir: string) {
       exportName: item.exportName,
     },
   }));
+}
+
+function unsupportedEvalSuiteOption(options: EvalOptions): string | undefined {
+  const flags = [
+    options.report ? "--report" : undefined,
+    options.junit ? "--junit" : undefined,
+    options.baseline ? "--baseline" : undefined,
+    options.writeBaseline ? "--write-baseline" : undefined,
+    options.baselinePassRateDropThreshold !== undefined
+      ? "--baseline-pass-rate-drop-threshold"
+      : undefined,
+    options.baselineMetricPassRateDropThreshold !== undefined
+      ? "--baseline-metric-pass-rate-drop-threshold"
+      : undefined,
+    options.baselineFailedDeltaThreshold !== undefined
+      ? "--baseline-failed-delta-threshold"
+      : undefined,
+    options.baselineUsageIncreaseThreshold !== undefined
+      ? "--baseline-usage-increase-threshold"
+      : undefined,
+    options.baselineLatencyIncreaseThreshold !== undefined
+      ? "--baseline-latency-increase-threshold"
+      : undefined,
+    options.model ? "--model" : undefined,
+    options.maxOutputTokens ? "--max-output-tokens" : undefined,
+    options.baselineModel ? "--baseline-model" : undefined,
+    options.candidateModels.length > 0 ? "--candidate-model" : undefined,
+    options.comparisonPolicy ? "--comparison-policy" : undefined,
+  ].filter((flag): flag is string => Boolean(flag));
+
+  if (flags.length === 0) return undefined;
+  return `${flags.join(", ")} require a named eval. Run \`veryfront eval <eval-id>\`.`;
+}
+
+function createEvalSuiteSummary(
+  runId: string,
+  startedAt: Date,
+  results: EvalSuiteResult[],
+): EvalSuiteSummary {
+  const passed = results.filter((result) => result.status === "passed").length;
+  return {
+    kind: "eval-suite-summary",
+    runId,
+    startedAt: startedAt.toISOString(),
+    endedAt: new Date().toISOString(),
+    total: results.length,
+    passed,
+    failed: results.length - passed,
+    results,
+  };
+}
+
+function createEvalSuiteMarkdown(summary: EvalSuiteSummary): string {
+  const rows = summary.results.map((result) =>
+    `| ${markdownCell(result.id)} | ${result.status} | ${
+      result.summary ? `${result.summary.passed}/${result.summary.records}` : "n/a"
+    } | ${result.error ? markdownCell(result.error) : ""} |`
+  );
+  return [
+    "# Eval suite report",
+    "",
+    `Run: \`${markdownCell(summary.runId)}\``,
+    `Result: \`${summary.passed}/${summary.total} passed\``,
+    "",
+    "| Eval | Status | Records | Error |",
+    "| --- | --- | --- | --- |",
+    ...rows,
+    "",
+  ].join("\n");
+}
+
+async function writeEvalSuiteArtifacts(
+  summary: EvalSuiteSummary,
+  artifacts: EvalSuiteArtifactPaths,
+): Promise<void> {
+  await writeTextFileEnsuringDir(artifacts.summary, JSON.stringify(summary, null, 2));
+  await writeTextFileEnsuringDir(artifacts.reportMarkdown, createEvalSuiteMarkdown(summary));
 }
 
 function getDiscoveredEvals(runtime: ProjectAgentRuntimeDiscovery): DiscoveredEval[] {
@@ -1252,7 +1390,10 @@ export function resolveEvalExporterIds(options: Pick<EvalOptions, "exporters">):
   const envExporters = parseEvalExporterList(readEvalCliEnv(ENV_EVAL_EXPORTERS));
   if (envExporters.length > 0) return uniqueValues(envExporters);
 
-  return uniqueValues(parseEvalExporterList(readEvalCliEnv(ENV_EVAL_EXPORT)));
+  const legacyExporters = parseEvalExporterList(readEvalCliEnv(ENV_EVAL_EXPORT));
+  if (legacyExporters.length > 0) return uniqueValues(legacyExporters);
+
+  return readEvalCliEnv(ENV_MLFLOW_TRACKING_URI) ? ["mlflow"] : [];
 }
 
 function parseEvalExportBooleanEnv(name: string): boolean | undefined {
@@ -1541,6 +1682,107 @@ async function outputEvalUsageError(message: string): Promise<2> {
   return 2;
 }
 
+async function runEvalSuite(input: {
+  evals: DiscoveredEval[];
+  options: EvalOptions;
+  projectDir: string;
+  projectRuntime: ProjectAgentRuntimeDiscovery;
+  config: VeryfrontConfig;
+  exporterRegistry: EvalReportExporterRegistry;
+}): Promise<0 | 1> {
+  const runId = createEvalRunId();
+  const startedAt = new Date();
+  const artifacts = createEvalSuiteArtifactPaths(
+    input.options.reportDir ?? createDefaultEvalReportDir(runId),
+  );
+  const provenance = await resolveEvalRunProvenance({
+    projectDir: input.projectDir,
+    frameworkVersion: VERSION,
+  });
+  const results: EvalSuiteResult[] = [];
+
+  for (const [index, evalItem] of sortEvals(input.evals).entries()) {
+    const evalArtifacts = createEvalArtifactPaths(
+      createEvalSuiteChildDirectory(artifacts.directory, index, evalItem.id),
+    );
+
+    try {
+      const agentId = evalItem.definition.targetKind === "agent"
+        ? resolveAgentTargetId(evalItem.definition.target)
+        : undefined;
+      const toolId = evalItem.definition.targetKind === "tool"
+        ? resolveToolTargetId(evalItem.definition.target)
+        : undefined;
+      const agent = agentId ? input.projectRuntime.agents.get(agentId) : undefined;
+      const tool = toolId ? input.projectRuntime.tools.get(toolId) : undefined;
+      if (agentId && !agent) throw new Error(`Agent "${agentId}" not found for eval target.`);
+      if (toolId && !tool) throw new Error(`Tool "${toolId}" not found for eval target.`);
+
+      const evalRunId = `${runId}_${String(index + 1).padStart(3, "0")}`;
+      const exportConfig = createEvalCliExportConfig(
+        evalItem,
+        input.options,
+        input.projectDir,
+        evalArtifacts,
+        input.exporterRegistry,
+        input.config,
+      );
+      const finalizedReport = await runEvalWithGatewayBillingGroup(
+        evalRunId,
+        () =>
+          runEval(evalItem.definition, {
+            baseDir: input.options.datasetBase ?? input.projectDir,
+            runId: evalRunId,
+            adapters: evalItem.definition.targetKind === "tool"
+              ? { tool: createToolAdapter(tool!, createEvalToolExecutionContext(input.config)) }
+              : { agent: createAgentAdapter(agent!, input.options) },
+            metadata: { provenance },
+          }),
+      );
+      const report = await exportEvalReportForCli(finalizedReport, exportConfig);
+      await writeEvalArtifacts(report, evalArtifacts);
+      const status = createEvalExitCode(report) === 0 ? "passed" : "failed";
+      results.push({
+        id: evalItem.id,
+        name: evalItem.name,
+        target: evalItem.definition.target,
+        status,
+        artifacts: evalArtifacts,
+        summary: summarizeReportForCli(report),
+      });
+
+      if (!isJsonMode()) {
+        printReport(report);
+        cliLogger.info(`Report directory: ${evalArtifacts.directory}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      results.push({
+        id: evalItem.id,
+        name: evalItem.name,
+        target: evalItem.definition.target,
+        status: "error",
+        artifacts: evalArtifacts,
+        error: message,
+      });
+      if (!isJsonMode()) cliLogger.error(`Eval ${evalItem.id}: ${message}`);
+    }
+  }
+
+  const summary = createEvalSuiteSummary(runId, startedAt, results);
+  await writeEvalSuiteArtifacts(summary, artifacts);
+
+  if (isJsonMode()) {
+    await outputJson(createSuccessEnvelope("eval", { suite: summary, artifacts }));
+  } else {
+    cliLogger.info(`Eval suite: ${summary.passed}/${summary.total} passed`);
+    cliLogger.info(`Report directory: ${artifacts.directory}`);
+    cliLogger.info(`Suite report: ${artifacts.reportMarkdown}`);
+  }
+
+  return summary.failed === 0 ? 0 : 1;
+}
+
 export async function runEvalCommand(
   options: EvalOptions,
   dependencies: EvalCommandDependencies = {},
@@ -1594,16 +1836,46 @@ export async function runEvalCommand(
     }
 
     if (!options.id) {
-      if (isJsonMode()) {
-        await outputJson(createErrorEnvelope("eval", {
-          code: "USAGE_ERROR",
-          slug: "eval-id-required",
-          message: "Eval id is required",
-        }));
-      } else {
-        cliLogger.error("Eval id is required. Usage: veryfront eval <eval-id>");
+      const invalidOption = unsupportedEvalSuiteOption(options);
+      if (invalidOption) return await outputEvalUsageError(invalidOption);
+
+      if (evals.length === 0) {
+        if (isJsonMode()) {
+          await outputJson(createSuccessEnvelope("eval", {
+            suite: null,
+            errors: projectRuntime.errors.map((error) => ({
+              filePath: error.file,
+              error: error.error.message,
+            })),
+          }));
+        } else {
+          cliLogger.info("No evals found.");
+        }
+        return 0;
       }
-      return 2;
+
+      const selectedExporterIds = resolveEvalExporterIds(options);
+      const extensionSetup = await setupEvalCliExtensions(
+        projectDir,
+        config,
+        selectedExporterIds,
+      );
+      try {
+        return await runWithProjectAgentRuntime(
+          projectRuntime,
+          () =>
+            runEvalSuite({
+              evals,
+              options,
+              projectDir,
+              projectRuntime,
+              config,
+              exporterRegistry: extensionSetup.exporterRegistry,
+            }),
+        );
+      } finally {
+        await extensionSetup.loader.teardownAll();
+      }
     }
 
     const evalId = normalizeEvalCliId(options.id);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1085",
+  "version": "0.1.1086",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -4,8 +4,8 @@ description: "Define and run quality checks for agents."
 order: 40
 ---
 
-Evals are project-defined quality checks in `evals/`. Run them locally with
-`veryfront eval <eval-id>` and store report artifacts in CI.
+Evals are project-defined quality checks in `evals/`. Use `veryfront eval` to
+run every discovered eval, or `veryfront eval <eval-id>` to run one.
 
 ## Prerequisites
 
@@ -40,7 +40,13 @@ export default evalAgent({
 });
 ```
 
-Run it:
+Run every discovered eval:
+
+```bash
+veryfront eval
+```
+
+Run one eval:
 
 ```bash
 veryfront eval deep-research
@@ -59,6 +65,23 @@ Each run writes `summary.json` and `results.jsonl` to the report directory. If
 `--report-dir` is omitted, Veryfront writes them under
 `.veryfront/evals/<run-id>/`. Use `--report` only when CI also needs the full
 raw report in one JSON file.
+
+An all-eval run creates one suite directory with a summary and one child
+directory per eval. Evals run sequentially, so a failing eval does not prevent
+the remaining discovered evals from running.
+
+```text
+.veryfront/evals/<suite-run-id>/
+  summary.json
+  report.md
+  001-deep-research/
+    summary.json
+    results.jsonl
+    report.md
+```
+
+`--report`, `--junit`, baselines, model overrides, and model comparison are
+single-eval options. Name the eval when using them.
 
 The report and summary artifacts include `schemaVersion`. New reports also
 include dataset metadata with the dataset kind, optional path, example count,
@@ -631,8 +654,8 @@ OpenTelemetry export.
 
 Use `@veryfront/ext-eval-report-mlflow` when completed reports should become
 MLflow Tracking runs. The CLI path can be environment-only: set
-`MLFLOW_TRACKING_URI` to activate the extension, then select the default
-exporter id `mlflow` for the run.
+`MLFLOW_TRACKING_URI` to activate the extension and select the default `mlflow`
+exporter for the run.
 
 ```bash
 MLFLOW_TRACKING_URI=http://localhost:5001 \
@@ -643,8 +666,9 @@ For authenticated MLflow Tracking servers, keep credentials out of
 `MLFLOW_TRACKING_URI`. Use `MLFLOW_TRACKING_TOKEN` for bearer auth or
 `MLFLOW_TRACKING_USERNAME` / `MLFLOW_TRACKING_PASSWORD` for basic auth.
 
-Use `VERYFRONT_EVAL_EXPORTERS=mlflow` when CI should select the same exporter
-for every eval command without repeating `--export`:
+When `MLFLOW_TRACKING_URI` is configured, `veryfront eval` automatically exports
+every completed eval report to MLflow. Set `VERYFRONT_EVAL_EXPORTERS=mlflow`
+explicitly when CI should make that selection visible in its environment:
 
 ```bash
 MLFLOW_TRACKING_URI=http://localhost:5001 \
@@ -654,9 +678,8 @@ veryfront eval deep-research
 
 `--export` wins over `VERYFRONT_EVAL_EXPORTERS` when both are set. The legacy
 singular `VERYFRONT_EVAL_EXPORT` is used only when
-`VERYFRONT_EVAL_EXPORTERS` is unset. The MLflow exporter always registers under
-the fixed id `mlflow`, so select it with `--export mlflow` or
-`VERYFRONT_EVAL_EXPORTERS=mlflow`.
+`VERYFRONT_EVAL_EXPORTERS` is unset. Without either selector,
+`MLFLOW_TRACKING_URI` selects the fixed `mlflow` exporter automatically.
 
 From the CLI, pass comma-separated exporter ids. Export failures are reported in
 the JSON report and do not prevent local report or JUnit files from being
@@ -770,7 +793,13 @@ List discovered evals:
 veryfront eval --list
 ```
 
-Run the eval locally:
+Run every discovered eval locally:
+
+```bash
+veryfront eval
+```
+
+Run one eval locally:
 
 ```bash
 veryfront eval deep-research

--- a/extensions/ext-eval-report-mlflow/README.md
+++ b/extensions/ext-eval-report-mlflow/README.md
@@ -2,13 +2,13 @@
 
 > **Category:** Eval export | **Requires:** `EvalReportExporterRegistry` | **Optional**
 
-Registers the `mlflow` eval report exporter. The exporter id is fixed to
-`mlflow` so CLI selection via `VERYFRONT_EVAL_EXPORTERS` / `--export` stays
-predictable. Use this extension when completed Veryfront `EvalReport` payloads
-should be written to MLflow Tracking as one run per eval execution.
+Registers the `mlflow` eval report exporter. Configure `MLFLOW_TRACKING_URI` to
+select it automatically for CLI evals. Use this extension when completed
+Veryfront `EvalReport` payloads should be written to MLflow Tracking as one run
+per eval execution.
 
 > **npm packaging note:** CLI usage is bundled into the root `veryfront`
-> package, so `veryfront eval --export mlflow` works without installing a
+> package, so `veryfront eval` works without installing a
 > separate package. The standalone `@veryfront/ext-eval-report-mlflow` package
 > is intentionally not published until npm trusted publishing is configured for
 > that new package.
@@ -23,28 +23,29 @@ adapter or metric before export. The MLflow exporter only consumes the normalize
 ## Environment-only usage
 
 No `veryfront.config.ts` entry is required for the common CLI path. Set
-`MLFLOW_TRACKING_URI` to activate the first-party extension, then select the
-`mlflow` exporter for the eval run.
+`MLFLOW_TRACKING_URI` and `veryfront eval` automatically exports every
+completed eval report to MLflow.
 
-Select the exporter per command:
+Run every discovered eval:
 
 ```bash
 MLFLOW_TRACKING_URI=http://localhost:5001 \
-veryfront eval eval:service-now-classification --export mlflow
+veryfront eval
 ```
 
-Or select it entirely from the environment:
+`--export mlflow` remains available when one command should explicitly select
+the exporter. `VERYFRONT_EVAL_EXPORTERS` is useful in CI when the job should
+make the selection visible or choose a different exporter. Either takes
+precedence over automatic MLflow selection. `VERYFRONT_EVAL_EXPORT` remains a
+legacy singular fallback when `VERYFRONT_EVAL_EXPORTERS` is unset.
+
+For example:
 
 ```bash
 MLFLOW_TRACKING_URI=http://localhost:5001 \
 VERYFRONT_EVAL_EXPORTERS=mlflow \
 veryfront eval eval:service-now-classification
 ```
-
-`--export mlflow` is explicit for one CLI invocation. `VERYFRONT_EVAL_EXPORTERS`
-is useful in CI when every eval command in the job should export to the same
-backend. If both are set, the CLI flag wins. `VERYFRONT_EVAL_EXPORT` remains a
-legacy singular fallback when `VERYFRONT_EVAL_EXPORTERS` is unset.
 
 ## Environment variables
 
@@ -58,8 +59,8 @@ legacy singular fallback when `VERYFRONT_EVAL_EXPORTERS` is unset.
 | `MLFLOW_TRACKING_TOKEN`                         | No       | Bearer token sent to MLflow Tracking REST endpoints. Prefer this over embedding credentials in `MLFLOW_TRACKING_URI`.         |
 | `MLFLOW_TRACKING_USERNAME`                      | No       | Username for basic auth to MLflow Tracking REST endpoints. Use with `MLFLOW_TRACKING_PASSWORD`.                               |
 | `MLFLOW_TRACKING_PASSWORD`                      | No       | Password for basic auth to MLflow Tracking REST endpoints. Use with `MLFLOW_TRACKING_USERNAME`.                               |
-| `VERYFRONT_EVAL_EXPORTERS`                      | No       | Comma- or whitespace-separated exporter ids selected by the CLI when `--export` is omitted. Use `mlflow` for this extension.  |
-| `VERYFRONT_EVAL_EXPORT`                         | No       | Legacy singular exporter env var used only when `VERYFRONT_EVAL_EXPORTERS` is unset.                                          |
+| `VERYFRONT_EVAL_EXPORTERS`                      | No       | Comma- or whitespace-separated exporter ids that override automatic MLflow selection. Use `mlflow` for this extension.        |
+| `VERYFRONT_EVAL_EXPORT`                         | No       | Legacy singular exporter override used only when `VERYFRONT_EVAL_EXPORTERS` is unset.                                         |
 | `VERYFRONT_EVAL_EXPORT_INCLUDE_METRIC_EVIDENCE` | No       | CLI redaction opt-in for metric evidence. Leave unset or false unless evidence contains only safe labels or aggregates.       |
 
 `MLFLOW_TRACKING_URI` must be an HTTP(S) URI without embedded username/password

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1085";
+export const VERSION = "0.1.1086";


### PR DESCRIPTION
## Summary
- make `veryfront eval` run every auto-discovered eval sequentially
- write one suite summary plus per-eval artifacts, and continue after a failing eval
- automatically export to MLflow when `MLFLOW_TRACKING_URI` is configured
- pass namespaced eval example metadata through agent context, so project middleware can select fixtures without a custom process runner
- bump the framework release version to `0.1.1086`, so a merge publishes this feature

## Usage
```sh
veryfront eval --list
veryfront eval
MLFLOW_TRACKING_URI=https://mlflow.example.com veryfront eval
veryfront eval <eval-id>
```

## Verification
- `deno test --allow-all cli/commands/eval/command.test.ts`
- `deno test --allow-all src/utils/version.test.ts`
- `deno task typecheck`
- `deno task lint`
- `deno task docs:validate`
- `deno task test:unit` (2,516 passing)
- repository pre-push gate (format, lint, typecheck, unit tests)
