### PR TITLE
fix: preserve exact control plane source context

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1087",
+  "version": "0.1.1088",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -879,7 +879,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
 
     assertExists(result.response);
     assertEquals(result.response.status, 200);
-    assertEquals(contextCalls, ["main", "restrict-gmail"]);
+    assertEquals(contextCalls, ["restrict-gmail"]);
     assertEquals(configReads, ["restrict-gmail"]);
     assertEquals(discoveryConfig?.integrations, {
       allow: { gmail: { allowedTools: ["list_emails"] } },
@@ -1968,7 +1968,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertStringIncludes(text, "event: RunFinished");
   });
 
-  it("uses the verified request credential for proxy and explicit agent source contexts", async () => {
+  it("uses the verified request credential for the exact agent source context", async () => {
     let observedCacheCredential:
       | ReturnType<typeof getVerifiedCacheApiCredential>
       | undefined;
@@ -2026,26 +2026,15 @@ describe("server/handlers/request/agent-stream.handler", () => {
     });
 
     const body = createAgentStreamRequestBody({
-      agentSource: { type: "branch", branch: "main" },
+      agentSource: {
+        type: "environment",
+        environmentName: "staging",
+        releaseId: "10000000-1000-4000-8000-100000000099",
+      },
       credentials: { authToken: "request-scoped-user-token" },
     });
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
     const ctx = createCtx(publicKeyPem);
-    ctx.parsedDomain = {
-      slug: "demo-project",
-      branch: "feature-a",
-      environment: "preview",
-      isVeryfrontDomain: true,
-      isDraft: true,
-      allowIframeEmbed: true,
-    };
-    ctx.resolvedEnvironment = "preview";
-    ctx.requestContext = {
-      slug: "demo-project",
-      branch: "feature-a",
-      mode: "preview",
-      token: "",
-    };
     ctx.adapter = {
       ...ctx.adapter,
       env: createNoopEnvAdapter(publicKeyPem),
@@ -2079,12 +2068,11 @@ describe("server/handlers/request/agent-stream.handler", () => {
 
     assertExists(result.response);
     assertEquals(result.response.status, 200);
-    assertEquals(runWithContextCalls.length, 2);
+    assertEquals(runWithContextCalls.length, 1);
     assertEquals(runWithContextCalls[0]?.token, "request-scoped-user-token");
-    assertEquals(runWithContextCalls[0]?.branch, "feature-a");
-    assertEquals(runWithContextCalls[1]?.token, "request-scoped-user-token");
-    assertEquals(runWithContextCalls[1]?.branch, "main");
-    assertEquals(runWithContextCalls[1]?.productionMode, false);
+    assertEquals(runWithContextCalls[0]?.environmentName, "staging");
+    assertEquals(runWithContextCalls[0]?.releaseId, "10000000-1000-4000-8000-100000000099");
+    assertEquals(runWithContextCalls[0]?.productionMode, true);
     assertEquals(observedCacheCredential, {
       token: "request-scoped-user-token",
       projectId: "proj-1",

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -8,6 +8,7 @@ import {
 import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
 import { type RuntimeAgentDiscoveryDeps } from "#veryfront/channels/control-plane.ts";
 import { getDiscoveredHostTools } from "#veryfront/agent/hosted/veryfront-cloud-agent-service.ts";
+import { runWithVerifiedCacheApiCredential } from "#veryfront/cache/verified-api-credential-context.ts";
 import {
   createRuntimeAgentStreamResponse,
   type RuntimeAgentStreamExecutionDeps,
@@ -689,7 +690,7 @@ export class AgentStreamHandler extends BaseHandler {
         hasAgentConfig: Boolean(payload.agentConfig),
       });
 
-      return await this.withProxyContext(requestScopedContext, () =>
+      const runWithAgentSourceContext = () =>
         this.withAgentSourceContext(
           requestScopedContext,
           payload.agentSource,
@@ -813,7 +814,11 @@ export class AgentStreamHandler extends BaseHandler {
               },
             );
           },
-        ), { verifiedControlPlaneClaims: verifiedClaims });
+        );
+      return await runWithVerifiedCacheApiCredential(
+        verifiedClaims,
+        runWithAgentSourceContext,
+      );
     } catch (error) {
       if (error instanceof InternalAgentRequestBodyTooLargeError) {
         return this.respond(builder.json({ error: error.message }, error.status));

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1087";
+export const VERSION = "0.1.1088";


### PR DESCRIPTION
## Summary
- execute scheduled control-plane agent runs in exactly their requested source context
- keep the signed cache credential in its own async scope instead of creating an extra filesystem context
- lock the regression with environment/release context assertions
- release the framework fix as `0.1.1088`

## Verification
- `deno task test src/utils/logger/logger.test.ts src/platform/compat/process.test.ts src/internal-agents/control-plane-auth.test.ts src/server/handlers/request/agent-stream.handler.test.ts`
- `deno task coverage:ci:shard -- --shard=6/8` (244 tests, 2,468 steps)
- `deno fmt --check ...`
- `deno task typecheck`
- real local scheduled service-identity run completed with native GitHub and Jira tools
- fresh staging deploy and scheduled service-identity smoke completed

Part of veryfront/veryfront-studio#6013.