### PR TITLE
feat(eval): publish deterministic suite CI artifacts

### DIFF
--- a/cli/commands/eval/command-help.ts
+++ b/cli/commands/eval/command-help.ts
@@ -24,7 +24,7 @@ export const evalHelp: CommandHelp = {
     },
     {
       flag: "--junit <path>",
-      description: "Write a JUnit XML report to a file",
+      description: "Write an eval or suite JUnit XML report to a file",
     },
     {
       flag: "--baseline <path>",
@@ -91,6 +91,7 @@ export const evalHelp: CommandHelp = {
   examples: [
     "veryfront eval --list",
     "veryfront eval",
+    "veryfront eval --report-dir .veryfront/evals/suite --junit .veryfront/evals/suite/junit.xml",
     "veryfront eval deep-research",
     "veryfront eval eval:deep-research --report-dir .veryfront/evals/deep-research",
     "veryfront eval eval:deep-research --report .veryfront/evals/deep-research/report.json --junit .veryfront/evals/deep-research/junit.xml",

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -770,6 +770,7 @@ describe("eval CLI command helpers", () => {
           candidateModels: [],
           projectDir,
           reportDir: `${projectDir}/suite`,
+          junit: `${projectDir}/suite/junit.xml`,
         },
         { discoverProjectAgentRuntime: () => Promise.resolve(runtime) },
       );
@@ -801,6 +802,21 @@ describe("eval CLI command helpers", () => {
         "eval:alpha",
         "eval:beta",
       ]);
+      const results = (await Deno.readTextFile(`${projectDir}/suite/results.jsonl`))
+        .trim()
+        .split("\n")
+        .map((line) => {
+          const result = JSON.parse(line) as { id: string; status: string };
+          return { id: result.id, status: result.status };
+        });
+      assertEquals(results, [
+        { id: "eval:alpha", status: "passed" },
+        { id: "eval:beta", status: "failed" },
+      ]);
+      const junit = await Deno.readTextFile(`${projectDir}/suite/junit.xml`);
+      assertStringIncludes(junit, '<testsuites tests="2" failures="1" skipped="0">');
+      assertStringIncludes(junit, '<testcase classname="eval" name="eval:alpha" />');
+      assertStringIncludes(junit, '<testcase classname="eval" name="eval:beta">');
       assertEquals(
         await Deno.stat(`${projectDir}/suite/001-alpha/summary.json`).then(() => true),
         true,

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -31,6 +31,7 @@ import {
   createEvalModelArtifactPaths,
   createEvalModelComparisonArtifact,
   createEvalModelComparisonExitCode,
+  createEvalSuiteJunitXml,
   createJunitXml,
   createResolvedEvalModelComparisonConfig,
   createResultsJsonl,
@@ -814,9 +815,12 @@ describe("eval CLI command helpers", () => {
         { id: "eval:beta", status: "failed" },
       ]);
       const junit = await Deno.readTextFile(`${projectDir}/suite/junit.xml`);
-      assertStringIncludes(junit, '<testsuites tests="2" failures="1" skipped="0">');
-      assertStringIncludes(junit, '<testcase classname="eval" name="eval:alpha" />');
-      assertStringIncludes(junit, '<testcase classname="eval" name="eval:beta">');
+      assertStringIncludes(
+        junit,
+        '<testsuites tests="2" failures="1" skipped="0">\n  <testsuite name="veryfront eval suite" tests="2" failures="1" skipped="0">',
+      );
+      assertStringIncludes(junit, '    <testcase classname="eval" name="eval:alpha" />');
+      assertStringIncludes(junit, '    <testcase classname="eval" name="eval:beta">');
       assertEquals(
         await Deno.stat(`${projectDir}/suite/001-alpha/summary.json`).then(() => true),
         true,
@@ -1659,6 +1663,43 @@ describe("eval CLI command helpers", () => {
     assertStringIncludes(
       xml,
       '<failure message="answer.exactMatch failed">Expected Paris, got Lyon</failure>',
+    );
+  });
+
+  it("serializes required export failures as suite JUnit failures", () => {
+    const junit = createEvalSuiteJunitXml({
+      kind: "eval-suite-summary",
+      runId: "suite-1",
+      startedAt: "2026-07-19T00:00:00.000Z",
+      endedAt: "2026-07-19T00:00:01.000Z",
+      total: 1,
+      passed: 0,
+      failed: 1,
+      results: [{
+        id: "eval:metadata-export",
+        name: "metadata export",
+        target: "agent:fixture",
+        status: "failed",
+        summary: {
+          runId: "eval-1",
+          evalId: "eval:metadata-export",
+          target: "agent:fixture",
+          records: 1,
+          passed: 1,
+          failed: 0,
+          passRate: 1,
+          metrics: [],
+        },
+      }],
+    });
+
+    assertStringIncludes(
+      junit,
+      '<testsuites tests="1" failures="1" skipped="0">\n  <testsuite name="veryfront eval suite" tests="1" failures="1" skipped="0">',
+    );
+    assertStringIncludes(
+      junit,
+      '<failure message="A required eval export failed.">A required eval export failed.</failure>',
     );
   });
 

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -91,6 +91,7 @@ type EvalArtifactPaths = {
 type EvalSuiteArtifactPaths = {
   directory: string;
   summary: string;
+  results: string;
   reportMarkdown: string;
 };
 
@@ -245,6 +246,7 @@ function createEvalSuiteArtifactPaths(reportDir: string): EvalSuiteArtifactPaths
   return {
     directory: reportDir,
     summary: join(reportDir, "summary.json"),
+    results: join(reportDir, "results.jsonl"),
     reportMarkdown: join(reportDir, "report.md"),
   };
 }
@@ -980,6 +982,34 @@ export function createJunitXml(report: EvalReport): string {
   return `${lines.join("\n")}\n`;
 }
 
+function createEvalSuiteResultsJsonl(summary: EvalSuiteSummary): string {
+  return summary.results.map((result) => JSON.stringify(result)).join("\n") +
+    (summary.results.length > 0 ? "\n" : "");
+}
+
+function createEvalSuiteJunitXml(summary: EvalSuiteSummary): string {
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<testsuites tests="${summary.total}" failures="${summary.failed}" skipped="0">`,
+  ];
+
+  for (const result of summary.results) {
+    const attrs = `classname="eval" name="${xmlEscape(result.id)}"`;
+    if (result.status === "passed") {
+      lines.push(`  <testcase ${attrs} />`);
+      continue;
+    }
+
+    const message = result.error ?? `${result.summary?.failed ?? 0} record(s) failed`;
+    lines.push(`  <testcase ${attrs}>`);
+    lines.push(`    <failure message="${xmlEscape(message)}">${xmlEscape(message)}</failure>`);
+    lines.push("  </testcase>");
+  }
+
+  lines.push("</testsuites>");
+  return `${lines.join("\n")}\n`;
+}
+
 async function writeTextFileEnsuringDir(path: string, content: string): Promise<void> {
   const dir = dirname(path);
   if (dir && dir !== ".") await Deno.mkdir(dir, { recursive: true });
@@ -1205,7 +1235,6 @@ function listEvals(evals: DiscoveredEval[], projectDir: string) {
 function unsupportedEvalSuiteOption(options: EvalOptions): string | undefined {
   const flags = [
     options.report ? "--report" : undefined,
-    options.junit ? "--junit" : undefined,
     options.baseline ? "--baseline" : undefined,
     options.writeBaseline ? "--write-baseline" : undefined,
     options.baselinePassRateDropThreshold !== undefined
@@ -1276,6 +1305,7 @@ async function writeEvalSuiteArtifacts(
   artifacts: EvalSuiteArtifactPaths,
 ): Promise<void> {
   await writeTextFileEnsuringDir(artifacts.summary, JSON.stringify(summary, null, 2));
+  await writeTextFileEnsuringDir(artifacts.results, createEvalSuiteResultsJsonl(summary));
   await writeTextFileEnsuringDir(artifacts.reportMarkdown, createEvalSuiteMarkdown(summary));
 }
 
@@ -1793,6 +1823,9 @@ async function runEvalSuite(input: {
 
   const summary = createEvalSuiteSummary(runId, startedAt, results);
   await writeEvalSuiteArtifacts(summary, artifacts);
+  if (input.options.junit) {
+    await writeTextFileEnsuringDir(input.options.junit, createEvalSuiteJunitXml(summary));
+  }
 
   if (isJsonMode()) {
     await outputJson(createSuccessEnvelope("eval", { suite: summary, artifacts }));
@@ -1800,6 +1833,7 @@ async function runEvalSuite(input: {
     cliLogger.info(`Eval suite: ${summary.passed}/${summary.total} passed`);
     cliLogger.info(`Report directory: ${artifacts.directory}`);
     cliLogger.info(`Suite report: ${artifacts.reportMarkdown}`);
+    if (input.options.junit) cliLogger.info(`JUnit: ${input.options.junit}`);
   }
 
   return summary.failed === 0 ? 0 : 1;

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -987,25 +987,30 @@ function createEvalSuiteResultsJsonl(summary: EvalSuiteSummary): string {
     (summary.results.length > 0 ? "\n" : "");
 }
 
-function createEvalSuiteJunitXml(summary: EvalSuiteSummary): string {
+export function createEvalSuiteJunitXml(summary: EvalSuiteSummary): string {
   const lines = [
     '<?xml version="1.0" encoding="UTF-8"?>',
     `<testsuites tests="${summary.total}" failures="${summary.failed}" skipped="0">`,
+    `  <testsuite name="veryfront eval suite" tests="${summary.total}" failures="${summary.failed}" skipped="0">`,
   ];
 
   for (const result of summary.results) {
     const attrs = `classname="eval" name="${xmlEscape(result.id)}"`;
     if (result.status === "passed") {
-      lines.push(`  <testcase ${attrs} />`);
+      lines.push(`    <testcase ${attrs} />`);
       continue;
     }
 
-    const message = result.error ?? `${result.summary?.failed ?? 0} record(s) failed`;
-    lines.push(`  <testcase ${attrs}>`);
-    lines.push(`    <failure message="${xmlEscape(message)}">${xmlEscape(message)}</failure>`);
-    lines.push("  </testcase>");
+    const message = result.error ??
+      (result.summary?.failed
+        ? `${result.summary.failed} record(s) failed`
+        : "A required eval export failed.");
+    lines.push(`    <testcase ${attrs}>`);
+    lines.push(`      <failure message="${xmlEscape(message)}">${xmlEscape(message)}</failure>`);
+    lines.push("    </testcase>");
   }
 
+  lines.push("  </testsuite>");
   lines.push("</testsuites>");
   return `${lines.join("\n")}\n`;
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1089",
+  "version": "0.1.1090",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -66,22 +66,26 @@ Each run writes `summary.json` and `results.jsonl` to the report directory. If
 `.veryfront/evals/<run-id>/`. Use `--report` only when CI also needs the full
 raw report in one JSON file.
 
-An all-eval run creates one suite directory with a summary and one child
-directory per eval. Evals run sequentially, so a failing eval does not prevent
-the remaining discovered evals from running.
+An all-eval run creates one suite directory and one child directory per eval.
+The suite directory contains the summary, one JSONL result per eval, and the
+markdown report. Use `--junit` to add a suite-level JUnit report. Evals run
+sequentially, so a failing eval does not prevent the remaining discovered evals
+from running.
 
 ```text
 .veryfront/evals/<suite-run-id>/
   summary.json
+  results.jsonl
   report.md
+  junit.xml
   001-deep-research/
     summary.json
     results.jsonl
     report.md
 ```
 
-`--report`, `--junit`, baselines, model overrides, and model comparison are
-single-eval options. Name the eval when using them.
+`--report`, baselines, model overrides, and model comparison are single-eval
+options. Name the eval when using them.
 
 The report and summary artifacts include `schemaVersion`. New reports also
 include dataset metadata with the dataset kind, optional path, example count,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1089";
+export const VERSION = "0.1.1090";


### PR DESCRIPTION
## Summary
- write root suite summary, JSONL results, markdown, and optional JUnit artifacts
- preserve generic metadata-only MLflow export and required-export gates from #2988
- bump `veryfront` to 0.1.1090 for CI publication

## Validation
- `deno test --frozen --no-check --allow-all extensions/ext-eval-report-mlflow/src/index.test.ts cli/commands/eval/command.test.ts src/eval/runner.test.ts`
- `deno task lint`
- `deno task typecheck`
- `deno task docs:validate`
- version manifest and runtime constant consistency check