### PR TITLE
fix(integrations): forward project context to remote tools

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1090",
+  "version": "0.1.1091",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -17,6 +17,7 @@ const ENV_KEYS = [
   "PROXY_MODE",
   "VERYFRONT_API_BASE_URL",
   "VERYFRONT_API_TOKEN",
+  "VERYFRONT_PROJECT_SLUG",
 ] as const;
 
 const originalEnv = new Map(ENV_KEYS.map((key) => [key, getEnv(key)]));
@@ -80,9 +81,11 @@ describe("integrations/remote-tools", () => {
       PROXY_MODE: "1",
       VERYFRONT_API_BASE_URL: "https://api.test",
       VERYFRONT_API_TOKEN: "env-token",
+      VERYFRONT_PROJECT_SLUG: "environment-project",
     });
 
     let authorizationHeader: string | null = null;
+    let projectSlugHeader: string | null = null;
 
     const definitions = await runWithRequestContext(
       {
@@ -95,6 +98,7 @@ describe("integrations/remote-tools", () => {
           async (input: string | URL | Request, init?: RequestInit) => {
             const request = input instanceof Request ? input : new Request(input, init);
             authorizationHeader = request.headers.get("Authorization");
+            projectSlugHeader = request.headers.get("x-veryfront-project-slug");
 
             return Response.json({
               tools: [
@@ -119,6 +123,7 @@ describe("integrations/remote-tools", () => {
     );
 
     assertEquals(authorizationHeader, "Bearer request-token");
+    assertEquals(projectSlugHeader, "request-project");
     assertEquals(definitions, [
       {
         name: "github__list_repos",
@@ -248,6 +253,46 @@ describe("integrations/remote-tools", () => {
 
     assertEquals(authorizationHeader, "Bearer env-token");
     assertEquals(definitions, []);
+  });
+
+  it("uses the environment project slug when no request context is active", async () => {
+    setRemoteToolEnv({
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+      VERYFRONT_PROJECT_SLUG: "environment-project",
+    });
+
+    let projectSlugHeader: string | null = null;
+    const definitions = await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        projectSlugHeader = request.headers.get("x-veryfront-project-slug");
+        return Response.json({ tools: [] });
+      },
+      async () => await getRemoteIntegrationToolDefinitions(),
+    );
+
+    assertEquals(projectSlugHeader, "environment-project");
+    assertEquals(definitions, []);
+  });
+
+  it("omits the project slug header when no project context is configured", async () => {
+    setRemoteToolEnv({
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+    });
+
+    let projectSlugHeader: string | null = "unexpected";
+    await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        projectSlugHeader = request.headers.get("x-veryfront-project-slug");
+        return Response.json({ tools: [] });
+      },
+      async () => await getRemoteIntegrationToolDefinitions(),
+    );
+
+    assertEquals(projectSlugHeader, null);
   });
 
   it("fails closed when the API lists a legacy integration tool alias", async () => {
@@ -392,6 +437,36 @@ describe("integrations/remote-tools", () => {
       error: "authentication_required",
       connectUrl: "/api/auth/github",
     });
+  });
+
+  it("forwards the request project slug when executing a remote integration tool", async () => {
+    setRemoteToolEnv({
+      PROXY_MODE: "1",
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+      VERYFRONT_PROJECT_SLUG: "environment-project",
+    });
+
+    let projectSlugHeader: string | null = null;
+    const result = await runWithRequestContext(
+      {
+        projectSlug: "request-project",
+        token: "request-token",
+        productionMode: false,
+      },
+      async () =>
+        await withMockFetch(
+          async (input: string | URL | Request, init?: RequestInit) => {
+            const request = input instanceof Request ? input : new Request(input, init);
+            projectSlugHeader = request.headers.get("x-veryfront-project-slug");
+            return Response.json({ content: [], structuredContent: { ok: true } });
+          },
+          async () => await executeRemoteIntegrationTool("github__list_repos", {}),
+        ),
+    );
+
+    assertEquals(projectSlugHeader, "request-project");
+    assertEquals(result, { ok: true });
   });
 
   it("forwards run and agent context without caller-supplied end-user identity", async () => {

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -70,6 +70,16 @@ function resolveRequestToken(): string | undefined {
   return isValidApiToken(environmentToken) ? environmentToken : undefined;
 }
 
+function normalizeProjectSlug(projectSlug: string | undefined): string | undefined {
+  const normalized = projectSlug?.trim();
+  return normalized || undefined;
+}
+
+function resolveRequestProjectSlug(): string | undefined {
+  const requestProjectSlug = normalizeProjectSlug(getCurrentRequestContext()?.projectSlug);
+  return requestProjectSlug ?? normalizeProjectSlug(getEnvironmentConfig().projectSlug);
+}
+
 // ---------------------------------------------------------------------------
 // API communication
 // ---------------------------------------------------------------------------
@@ -121,11 +131,14 @@ async function postIntegrationApi(
   token: string,
   body?: unknown,
 ): Promise<Response> {
+  const projectSlug = resolveRequestProjectSlug();
+
   return await fetch(`${baseUrl}${path}`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
+      ...(projectSlug ? { "x-veryfront-project-slug": projectSlug } : {}),
     },
     ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     signal: AbortSignal.timeout(INTEGRATION_REQUEST_TIMEOUT_MS),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1090";
+export const VERSION = "0.1.1091";


### PR DESCRIPTION
## Summary
- forwards the existing request project slug to the normal remote integration API helper
- falls back to `VERYFRONT_PROJECT_SLUG` for single-project local/CI runs
- keeps the header absent without project context and leaves tool endpoints, payloads, schemas, providers, and dependencies unchanged

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 deno test --frozen --no-check --allow-all src/integrations/remote-tools.test.ts`
- `deno task lint`
- `deno task typecheck`
- `deno task test:unit` (2,516 passed; 20,838 steps)

Dependent on #2989; will rebase onto `main` after it merges.