### PR TITLE
fix(schedule): run local agent targets

### DIFF
--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -45,6 +45,37 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       throw new Error(`Schedule "${opts.id}" not found.`);
     }
 
+    const triggerInput = input ?? schedule.input ?? {};
+    const scheduleConfig =
+      triggerInput && typeof triggerInput === "object" && !Array.isArray(triggerInput)
+        ? triggerInput as Record<string, unknown>
+        : {};
+    const scheduleName = schedule.name ?? schedule.id;
+    const scheduleTarget = scheduleConfig._schedule_target;
+    const conversationMode = scheduleTarget && typeof scheduleTarget === "object" &&
+        !Array.isArray(scheduleTarget)
+      ? (scheduleTarget as Record<string, unknown>).conversationMode
+      : undefined;
+    if (schedule.target.kind === "agent" && conversationMode === "existing") {
+      throw new Error(
+        "Local scheduled agent runs cannot attach to an existing cloud conversation.",
+      );
+    }
+
+    const agentRunOptions = schedule.target.kind === "agent"
+      ? {
+        agentInput:
+          typeof scheduleConfig.prompt === "string" && scheduleConfig.prompt.trim().length > 0
+            ? scheduleConfig.prompt
+            : `Run scheduled agent ${schedule.target.id} for ${scheduleName}`,
+        agentContext: {
+          trigger: "schedule",
+          schedule: { id: schedule.id, name: scheduleName },
+          forwardedProps: scheduleConfig,
+        },
+      }
+      : {};
+
     const run = await runTriggerTarget({
       projectDir,
       adapter,
@@ -52,7 +83,8 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       cacheKey: configCacheKey,
       projectId,
       target: schedule.target,
-      input: input ?? schedule.input ?? {},
+      input: triggerInput,
+      ...agentRunOptions,
       debug: opts.debug,
     });
 

--- a/src/task/discovery.test.ts
+++ b/src/task/discovery.test.ts
@@ -450,4 +450,89 @@ describe("task/discovery", { sanitizeOps: false, sanitizeResources: false }, () 
     assertEquals(result.id, "probe-runtime");
     assertEquals(result.output, { hasRuntimeTool: true });
   });
+
+  it("runs agent targets after project runtime discovery", async () => {
+    const adapter = createRuntimeAdapter({
+      "/project/agents/scheduled-agent.ts": [
+        "export default {",
+        '  id: "scheduled-agent",',
+        '  config: { id: "scheduled-agent" },',
+        "  async generate({ input, context }) {",
+        '    return { text: `ran:${input}:${context.schedule_name}`, status: "completed", toolCalls: [] };',
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    });
+
+    const result = await runTriggerTarget({
+      projectDir: "/project",
+      adapter,
+      config: { fs: { type: "veryfront-api" } },
+      target: { kind: "agent", id: "scheduled-agent" },
+      agentInput: "Run the fixture.",
+      agentContext: { schedule_name: "Fixture schedule" },
+    });
+
+    assertEquals(result.kind, "agent");
+    assertEquals(result.id, "scheduled-agent");
+    assertEquals(result.output, {
+      text: "ran:Run the fixture.:Fixture schedule",
+      status: "completed",
+      toolCalls: 0,
+    });
+
+    await assertRejects(
+      () =>
+        runTriggerTarget({
+          projectDir: "/project",
+          adapter,
+          config: { fs: { type: "veryfront-api" } },
+          target: { kind: "agent", id: "scheduled-agent" },
+        }),
+      Error,
+      "Local agent trigger runs require an explicit agent input.",
+    );
+
+    await assertRejects(
+      () =>
+        runTriggerTarget({
+          projectDir: "/project",
+          adapter,
+          config: { fs: { type: "veryfront-api" } },
+          target: { kind: "agent", id: "missing-agent" },
+          agentInput: "Run the fixture.",
+        }),
+      Error,
+      'Agent target "missing-agent" not found.',
+    );
+  });
+
+  it("fails when an agent target returns an error status", async () => {
+    const adapter = createRuntimeAdapter({
+      "/project/agents/failing-agent.ts": [
+        "export default {",
+        '  id: "failing-agent",',
+        '  config: { id: "failing-agent" },',
+        "  async generate() {",
+        '    return { text: "failure", status: "error", toolCalls: [] };',
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    });
+
+    await assertRejects(
+      () =>
+        runTriggerTarget({
+          projectDir: "/project",
+          adapter,
+          config: { fs: { type: "veryfront-api" } },
+          target: { kind: "agent", id: "failing-agent" },
+          agentInput: "Run the fixture.",
+        }),
+      Error,
+      'Agent target "failing-agent" failed.',
+    );
+  });
 });

--- a/src/trigger/local-runner.ts
+++ b/src/trigger/local-runner.ts
@@ -24,6 +24,8 @@ export interface RunTriggerTargetOptions {
   projectId?: string;
   target: TriggerTarget;
   input?: unknown;
+  agentInput?: string;
+  agentContext?: Record<string, unknown>;
   debug?: boolean;
 }
 
@@ -131,6 +133,49 @@ async function runWorkflowTarget(
   });
 }
 
+async function runAgentTarget(options: RunTriggerTargetOptions): Promise<TriggerTargetRunResult> {
+  const agentInput = options.agentInput;
+  if (agentInput === undefined) {
+    throw TRIGGER_NOT_SUPPORTED.create({
+      detail: "Local agent trigger runs require an explicit agent input.",
+    });
+  }
+
+  const start = Date.now();
+  const discovery = await discoverRuntimeOrThrow(options);
+  const agent = agentRegistry.get(options.target.id);
+  if (!agent) {
+    throw TRIGGER_TARGET_NOT_FOUND.create({
+      detail: `Agent target "${options.target.id}" not found.`,
+      context: { targetId: options.target.id },
+    });
+  }
+
+  return await runWithProjectAgentRuntime(discovery, async () => {
+    const response = await agent.generate({
+      input: agentInput,
+      ...(options.agentContext === undefined ? {} : { context: options.agentContext }),
+    });
+    if (response.status === "error") {
+      throw TRIGGER_EXECUTION_FAILED.create({
+        detail: `Agent target "${options.target.id}" failed.`,
+        context: { targetId: options.target.id },
+      });
+    }
+
+    return {
+      kind: "agent",
+      id: options.target.id,
+      output: {
+        text: response.text,
+        status: response.status,
+        toolCalls: response.toolCalls.length,
+      },
+      durationMs: Date.now() - start,
+    };
+  });
+}
+
 export async function runTriggerTarget(
   options: RunTriggerTargetOptions,
 ): Promise<TriggerTargetRunResult> {
@@ -142,8 +187,5 @@ export async function runTriggerTarget(
     return await runWorkflowTarget(options);
   }
 
-  throw TRIGGER_NOT_SUPPORTED.create({
-    detail:
-      "Agent trigger targets are Cloud-only for this milestone. Use a workflow or task for local trigger runs.",
-  });
+  return await runAgentTarget(options);
 }


### PR DESCRIPTION
## Summary
- make `veryfront schedule run` execute source-defined agent targets locally
- preserve webhook behavior by requiring schedule handlers to supply an explicit agent prompt and schedule context
- return a safe agent summary and fail on a missing target or error response

## Verification
- `deno check src/trigger/local-runner.ts cli/commands/schedule/handler.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/task/discovery.test.ts`
- manual CLI smoke with a temporary source project: local agent schedule returned the expected prompt and schedule context