### PR TITLE
feat(schedule): add health configuration

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1091",
+  "version": "0.1.1092",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/api-reference/veryfront/schedule.md
+++ b/docs/api-reference/veryfront/schedule.md
@@ -23,6 +23,7 @@ export default schedule({
   timezone: "Europe/Stockholm",
   target: { kind: "workflow", id: "escalate-ticket" },
   input: { severity: "high" },
+  health: { maxStalenessSeconds: 1800 },
 });
 ```
 
@@ -33,19 +34,20 @@ export default schedule({
 | Name | Description | Source |
 |------|-------------|--------|
 | `discoverSchedules` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/discovery.ts#L18) |
-| `isScheduleDefinition` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L47) |
-| `schedule` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/factory.ts#L201) |
+| `isScheduleDefinition` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L53) |
+| `schedule` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/factory.ts#L223) |
 
 ### Types
 
 | Name | Description | Source |
 |------|-------------|--------|
 | `ScheduleConcurrencyPolicy` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L3) |
-| `ScheduleConfig` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L41) |
-| `ScheduleDefinition` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L26) |
+| `ScheduleConfig` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L47) |
+| `ScheduleDefinition` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L31) |
 | `ScheduleDiscoveryOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/discovery.ts#L9) |
 | `ScheduleDiscoveryResult` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/discovery.ts#L16) |
-| `ScheduleIntegrationRequirement` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L14) |
-| `ScheduleIntegrationRequirementConfig` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L20) |
-| `ScheduleIntegrationResource` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L10) |
-| `ScheduleIntegrationResourceIdentity` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L5) |
+| `ScheduleHealth` | Marks a schedule unhealthy when it has not succeeded within the given budget. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L6) |
+| `ScheduleIntegrationRequirement` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L19) |
+| `ScheduleIntegrationRequirementConfig` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L25) |
+| `ScheduleIntegrationResource` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L15) |
+| `ScheduleIntegrationResourceIdentity` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/schedule/types.ts#L10) |

--- a/docs/concepts/schedule.md
+++ b/docs/concepts/schedule.md
@@ -32,3 +32,23 @@ Do not put the work itself in the schedule definition. Use a one-time schedule
 for delayed one-off work and a cron-style schedule for recurring work.
 
 For implementation steps, see [Runs](../guides/runs.md).
+
+## Monitor a schedule
+
+Opt in to schedule health when a delayed or failed recurring job needs an
+operator alert. Set the longest acceptable time since a successful run:
+
+```ts
+import { schedule } from "veryfront/schedule";
+
+export default schedule({
+  id: "daily-support-triage",
+  schedule: "0 9 * * 1-5",
+  target: { kind: "workflow", id: "escalate-ticket" },
+  health: { maxStalenessSeconds: 1_800 },
+});
+```
+
+The platform reports the schedule as stale when it has not succeeded within
+that budget, and as failed after a newer terminal failure. Health settings are
+not sent to the target as run input.

--- a/src/schedule/factory.test.ts
+++ b/src/schedule/factory.test.ts
@@ -56,6 +56,40 @@ describe("schedule/factory", () => {
     assertEquals(isScheduleDefinition(definition), true);
   });
 
+  it("normalizes schedule health configuration", () => {
+    const definition = schedule({
+      id: "triage-sweep",
+      schedule: "0 */6 * * *",
+      target: { kind: "task", id: "run-triage-sweep" },
+      health: { maxStalenessSeconds: 1_800 },
+    });
+
+    assertEquals(definition.health, { maxStalenessSeconds: 1_800 });
+    assertEquals(isScheduleDefinition(definition), true);
+  });
+
+  it("rejects malformed schedule health configuration", () => {
+    for (
+      const health of [
+        {},
+        { maxStalenessSeconds: 0 },
+        { maxStalenessSeconds: 1.5 },
+        { maxStalenessSeconds: 60, unexpected: true },
+      ]
+    ) {
+      assertThrows(
+        () =>
+          schedule({
+            id: "triage-sweep",
+            schedule: "0 */6 * * *",
+            target: { kind: "task", id: "run-triage-sweep" },
+            health: health as never,
+          }),
+        Error,
+      );
+    }
+  });
+
   it("preserves integration requirements", () => {
     const definition = schedule({
       id: "slack-digest",
@@ -315,6 +349,16 @@ describe("schedule/factory", () => {
   });
 
   it("does not treat malformed integration requirements as schedule definitions", () => {
+    assertEquals(
+      isScheduleDefinition({
+        id: "triage-sweep",
+        schedule: "0 */6 * * *",
+        target: { kind: "task", id: "run-triage-sweep" },
+        health: { maxStalenessSeconds: 0 },
+      }),
+      false,
+    );
+
     assertEquals(
       isScheduleDefinition({
         id: "slack-digest",

--- a/src/schedule/factory.ts
+++ b/src/schedule/factory.ts
@@ -5,6 +5,7 @@ import type {
   ScheduleConcurrencyPolicy,
   ScheduleConfig,
   ScheduleDefinition,
+  ScheduleHealth,
   ScheduleIntegrationRequirement,
   ScheduleIntegrationResource,
   ScheduleIntegrationResourceIdentity,
@@ -23,9 +24,14 @@ function requireString(value: unknown, label: string): string {
 
 function validatePositiveInteger(value: unknown, label: string): void {
   if (value === undefined) return;
-  if (!Number.isInteger(value) || Number(value) <= 0) {
+  requirePositiveInteger(value, label);
+}
+
+function requirePositiveInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
     throw SCHEDULE_CONFIG_INVALID.create({ detail: `${label} must be a positive integer.` });
   }
+  return value;
 }
 
 function requireContractString(value: unknown, label: string, maxLength: number): string {
@@ -62,6 +68,22 @@ function assertOnlyKeys(
   if (unknownKey) {
     throw new Error(`${label}.${unknownKey} is not supported.`);
   }
+}
+
+function normalizeScheduleHealth(value: unknown): ScheduleHealth | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw SCHEDULE_CONFIG_INVALID.create({ detail: "Schedule health must be an object." });
+  }
+
+  const record = value as Record<string, unknown>;
+  assertOnlyKeys(record, ["maxStalenessSeconds"], "Schedule health");
+  return {
+    maxStalenessSeconds: requirePositiveInteger(
+      record.maxStalenessSeconds,
+      "Schedule health.maxStalenessSeconds",
+    ),
+  };
 }
 
 function normalizeIntegrationRequirements(
@@ -224,6 +246,7 @@ export function schedule(config: ScheduleConfig): ScheduleDefinition {
   validatePositiveInteger(config.backoffLimit, "Schedule backoffLimit");
   validatePositiveInteger(config.maxRuns, "Schedule maxRuns");
   assertSerializable(config.input, "Schedule input");
+  const health = normalizeScheduleHealth(config.health);
   const integrationRequirements = normalizeIntegrationRequirements(config.integrationRequirements);
 
   return {
@@ -240,6 +263,7 @@ export function schedule(config: ScheduleConfig): ScheduleDefinition {
       ? {}
       : { concurrencyPolicy: config.concurrencyPolicy }),
     ...(config.maxRuns === undefined ? {} : { maxRuns: config.maxRuns }),
+    ...(health === undefined ? {} : { health }),
     ...(integrationRequirements === undefined ? {} : { integrationRequirements }),
   };
 }

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -13,6 +13,7 @@
  *   timezone: "Europe/Stockholm",
  *   target: { kind: "workflow", id: "escalate-ticket" },
  *   input: { severity: "high" },
+ *   health: { maxStalenessSeconds: 1800 },
  * });
  * ```
  */
@@ -22,6 +23,7 @@ export type {
   ScheduleConcurrencyPolicy,
   ScheduleConfig,
   ScheduleDefinition,
+  ScheduleHealth,
   ScheduleIntegrationRequirement,
   ScheduleIntegrationRequirementConfig,
   ScheduleIntegrationResource,

--- a/src/schedule/types.ts
+++ b/src/schedule/types.ts
@@ -2,6 +2,11 @@ import type { TriggerTarget } from "#veryfront/trigger/target.ts";
 
 export type ScheduleConcurrencyPolicy = "Allow" | "Forbid" | "Replace";
 
+/** Marks a schedule unhealthy when it has not succeeded within the given budget. */
+export interface ScheduleHealth {
+  maxStalenessSeconds: number;
+}
+
 export interface ScheduleIntegrationResourceIdentity {
   kind: string;
   id: string;
@@ -35,6 +40,7 @@ export interface ScheduleDefinition {
   backoffLimit?: number;
   concurrencyPolicy?: ScheduleConcurrencyPolicy;
   maxRuns?: number;
+  health?: ScheduleHealth;
   integrationRequirements?: ScheduleIntegrationRequirement[];
 }
 
@@ -52,8 +58,20 @@ export function isScheduleDefinition(value: unknown): value is ScheduleDefinitio
     typeof definition.schedule === "string" &&
     definition.target !== null &&
     typeof definition.target === "object" &&
+    isScheduleHealth(definition.health) &&
     isScheduleIntegrationRequirements(definition.integrationRequirements)
   );
+}
+
+function isScheduleHealth(value: unknown): value is ScheduleHealth {
+  if (value === undefined) return true;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+
+  const record = value as Record<string, unknown>;
+  return hasOnlyKeys(record, ["maxStalenessSeconds"]) &&
+    typeof record.maxStalenessSeconds === "number" &&
+    Number.isInteger(record.maxStalenessSeconds) &&
+    record.maxStalenessSeconds > 0;
 }
 
 function isScheduleIntegrationRequirements(

--- a/src/skill/tools.test.ts
+++ b/src/skill/tools.test.ts
@@ -10,6 +10,7 @@ import {
 import type { Skill } from "./types.ts";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createSkillTestAdapter } from "./testing.ts";
+import { LocalScriptExecutor } from "./executor.ts";
 
 function createTestSkill(fsAdapter: FileSystemAdapter): Skill {
   return {
@@ -310,7 +311,9 @@ Do work.`,
         rootPath: skillRoot,
       });
 
-      const tool = createExecuteSkillScriptTool();
+      const tool = createExecuteSkillScriptTool({
+        executor: new LocalScriptExecutor(),
+      });
       const result = await tool.execute({
         skillId: "my-skill",
         script: "scripts/echo-style.sh",

--- a/src/skill/tools.ts
+++ b/src/skill/tools.ts
@@ -19,7 +19,7 @@ import { skillRegistry } from "./registry.ts";
 import { parseSkillFrontmatter } from "./parser.ts";
 import { listSkillSubdir, validateSkillPath } from "./path-safety.ts";
 import { getSkillScriptExecutor } from "./executor.ts";
-import type { Skill, SkillContent } from "./types.ts";
+import type { Skill, SkillContent, SkillScriptExecutor } from "./types.ts";
 import {
   SKILL_ASSETS_DIR,
   SKILL_MD_FILENAME,
@@ -255,7 +255,9 @@ export function createLoadSkillReferenceTool(): Tool {
  * Create the execute_skill_script tool.
  * Executes a script from a skill's scripts/ directory.
  */
-export function createExecuteSkillScriptTool(): Tool {
+export function createExecuteSkillScriptTool(
+  options: { executor?: SkillScriptExecutor } = {},
+): Tool {
   return tool({
     id: "execute_skill_script",
     description:
@@ -283,7 +285,7 @@ export function createExecuteSkillScriptTool(): Tool {
       );
 
       const scriptContent = await readSkillFile(skill, validatedPath);
-      const executor = getSkillScriptExecutor();
+      const executor = options.executor ?? getSkillScriptExecutor();
       return await executor.execute({
         scriptPath: validatedPath,
         scriptContent,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1091";
+export const VERSION = "0.1.1092";

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -45,6 +45,7 @@ import { Head } from "../../src/react/components/Head.tsx";
 import { PageContextProvider, usePageContext } from "../../src/react/context/index.tsx";
 import { Link, RouterProvider, useRouter } from "../../src/react/router/index.tsx";
 import { Sandbox } from "../../src/sandbox/index.ts";
+import { schedule } from "../../src/schedule/index.ts";
 import { isTaskDefinition } from "../../src/task/types.ts";
 import {
   getConnector,
@@ -102,6 +103,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "project-metrics.md",
   "quickstart.md",
   "sandbox.md",
+  "schedule.md",
   "skills.md",
   "storybook-ui-workbench.md",
   "tasks.md",
@@ -172,6 +174,19 @@ describe("Guide code example coverage", () => {
     const guideFiles = new Set(await guideFilesWithCodeFences());
     const stale = [...GUIDE_CODE_EXAMPLE_COVERAGE].filter((name) => !guideFiles.has(name));
     assertEquals(stale, []);
+  });
+});
+
+describe("Guide: concepts/schedule.md", () => {
+  it("defines the documented stale-run health budget", () => {
+    const definition = schedule({
+      id: "daily-support-triage",
+      schedule: "0 9 * * 1-5",
+      target: { kind: "workflow", id: "escalate-ticket" },
+      health: { maxStalenessSeconds: 1_800 },
+    });
+
+    assertEquals(definition.health, { maxStalenessSeconds: 1_800 });
   });
 });
 


### PR DESCRIPTION
## Summary
- Add the opt-in health.maxStalenessSeconds schedule contract.
- Validate it in the public factory and runtime discovery guard.
- Document and execute the public schedule-health example.

## Verification
- deno task test:unit
- deno task verify:quick

The Storybook-specific consumer typecheck cannot run in this clean worktree because its local TypeScript toolchain is absent; framework typechecking passed.