### PR TITLE
fix(runtime): fetch project env from internal API

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1092",
+  "version": "0.1.1093",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/project-env/fetcher.test.ts
+++ b/src/server/project-env/fetcher.test.ts
@@ -1,8 +1,50 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { createMockServer } from "../../../tests/_helpers/utils.ts";
 import { fetchProjectEnvVars } from "./fetcher.ts";
+
+const INTERNAL_USER_ENV = "VERYFRONT_API_INTERNAL_USER";
+const INTERNAL_PASS_ENV = "VERYFRONT_API_INTERNAL_PASS";
+
+async function withInternalCredentials<T>(
+  username: string | undefined,
+  password: string | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previousUser = Deno.env.get(INTERNAL_USER_ENV);
+  const previousPass = Deno.env.get(INTERNAL_PASS_ENV);
+
+  try {
+    if (username === undefined) Deno.env.delete(INTERNAL_USER_ENV);
+    else Deno.env.set(INTERNAL_USER_ENV, username);
+    if (password === undefined) Deno.env.delete(INTERNAL_PASS_ENV);
+    else Deno.env.set(INTERNAL_PASS_ENV, password);
+    return await fn();
+  } finally {
+    if (previousUser === undefined) Deno.env.delete(INTERNAL_USER_ENV);
+    else Deno.env.set(INTERNAL_USER_ENV, previousUser);
+    if (previousPass === undefined) Deno.env.delete(INTERNAL_PASS_ENV);
+    else Deno.env.set(INTERNAL_PASS_ENV, previousPass);
+  }
+}
+
+function fetchFromMockApi(
+  port: number,
+  credentials?: { username: string; password: string },
+): Promise<Record<string, string>> {
+  return withInternalCredentials(
+    credentials?.username,
+    credentials?.password,
+    () =>
+      fetchProjectEnvVars(
+        `http://127.0.0.1:${port}`,
+        "my-project",
+        "env-123",
+        "test-token",
+      ),
+  );
+}
 
 describe("project-env/fetcher", () => {
   it("fetches and transforms env vars from API", async () => {
@@ -23,12 +65,7 @@ describe("project-env/fetcher", () => {
     });
 
     try {
-      const result = await fetchProjectEnvVars(
-        `http://127.0.0.1:${port}`,
-        "my-project",
-        "env-123",
-        "test-token",
-      );
+      const result = await fetchFromMockApi(port);
 
       assertEquals(result, {
         API_KEY: "sk-123",
@@ -45,12 +82,7 @@ describe("project-env/fetcher", () => {
     });
 
     try {
-      const result = await fetchProjectEnvVars(
-        `http://127.0.0.1:${port}`,
-        "my-project",
-        "env-123",
-        "test-token",
-      );
+      const result = await fetchFromMockApi(port);
 
       assertEquals(result, {});
     } finally {
@@ -64,12 +96,7 @@ describe("project-env/fetcher", () => {
     });
 
     try {
-      const result = await fetchProjectEnvVars(
-        `http://127.0.0.1:${port}`,
-        "my-project",
-        "env-123",
-        "test-token",
-      );
+      const result = await fetchFromMockApi(port);
 
       assertEquals(result, {});
     } finally {
@@ -83,18 +110,118 @@ describe("project-env/fetcher", () => {
     });
 
     try {
-      let threw = false;
-      try {
-        await fetchProjectEnvVars(
-          `http://127.0.0.1:${port}`,
-          "my-project",
-          "env-123",
-          "test-token",
+      await assertRejects(() => fetchFromMockApi(port));
+    } finally {
+      await server.shutdown();
+    }
+  });
+
+  it("uses the internal endpoint when Basic auth credentials are configured", async () => {
+    const { server, port } = createMockServer((req: Request) => {
+      const url = new URL(req.url);
+
+      assertEquals(url.pathname, "/internal/project-environment-variables");
+      assertEquals(url.searchParams.get("environment_id"), "env-123");
+      assertEquals(req.headers.get("authorization"), `Basic ${btoa("runtime-user:runtime-pass")}`);
+
+      return Response.json({ data: [{ key: "API_KEY", value: "plaintext-value" }] });
+    });
+
+    try {
+      const result = await fetchFromMockApi(port, {
+        username: "runtime-user",
+        password: "runtime-pass",
+      });
+
+      assertEquals(result, { API_KEY: "plaintext-value" });
+    } finally {
+      await server.shutdown();
+    }
+  });
+
+  it("falls back to the management endpoint when the internal endpoint is absent", async () => {
+    const paths: string[] = [];
+    const { server, port } = createMockServer((req: Request) => {
+      const url = new URL(req.url);
+      paths.push(url.pathname);
+
+      if (url.pathname === "/internal/project-environment-variables") {
+        assertEquals(
+          req.headers.get("authorization"),
+          `Basic ${btoa("runtime-user:runtime-pass")}`,
         );
-      } catch {
-        threw = true;
+        return new Response(null, { status: 404 });
       }
-      assertEquals(threw, true);
+
+      assertEquals(req.headers.get("authorization"), "Bearer test-token");
+      return Response.json({ data: [{ key: "API_KEY", value: "legacy-plaintext" }] });
+    });
+
+    try {
+      const result = await fetchFromMockApi(port, {
+        username: "runtime-user",
+        password: "runtime-pass",
+      });
+
+      assertEquals(paths, [
+        "/internal/project-environment-variables",
+        "/projects/my-project/environment-variables",
+      ]);
+      assertEquals(result, { API_KEY: "legacy-plaintext" });
+    } finally {
+      await server.shutdown();
+    }
+  });
+
+  it("does not fall back when the internal endpoint rejects the request", async () => {
+    let requestCount = 0;
+    const { server, port } = createMockServer((req: Request) => {
+      requestCount++;
+      assertEquals(new URL(req.url).pathname, "/internal/project-environment-variables");
+      assertEquals(
+        req.headers.get("authorization"),
+        `Basic ${btoa("runtime-user:runtime-pass")}`,
+      );
+      return new Response(null, { status: 401 });
+    });
+
+    try {
+      await assertRejects(() =>
+        fetchFromMockApi(port, {
+          username: "runtime-user",
+          password: "runtime-pass",
+        })
+      );
+      assertEquals(requestCount, 1);
+    } finally {
+      await server.shutdown();
+    }
+  });
+
+  it("rejects masked values returned by the internal endpoint", async () => {
+    const { server, port } = createMockServer(() => {
+      return Response.json({ data: [{ key: "API_KEY", value: "********" }] });
+    });
+
+    try {
+      await assertRejects(() =>
+        fetchFromMockApi(port, {
+          username: "runtime-user",
+          password: "runtime-pass",
+        })
+      );
+    } finally {
+      await server.shutdown();
+    }
+  });
+
+  it("rejects masked values returned by the management endpoint", async () => {
+    const { server, port } = createMockServer(() => {
+      return Response.json({ data: [{ key: "API_KEY", value: "********" }] });
+    });
+
+    try {
+      await assertRejects(() => fetchFromMockApi(port));
     } finally {
       await server.shutdown();
     }

--- a/src/server/project-env/fetcher.ts
+++ b/src/server/project-env/fetcher.ts
@@ -6,6 +6,7 @@
 
 import { getBaseLogger } from "#veryfront/utils";
 import { NETWORK_ERROR } from "#veryfront/errors";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 const baseLogger = getBaseLogger("PROJECT-ENV");
 
@@ -13,33 +14,29 @@ const logger = baseLogger.component("project-env");
 
 /** Max env vars per request. API enforces a hard cap of 100. */
 const ENV_VARS_FETCH_LIMIT = 100;
+const MASKED_ENV_VALUE = "********";
 
-/**
- * Fetch environment variables for a project from the Veryfront API.
- *
- * Calls: GET {apiBaseUrl}/projects/{projectSlug}/environment-variables?environment_id={environmentId}&limit=100
- * Response: { data: [{ key: string, value: string }] }
- */
-export async function fetchProjectEnvVars(
-  apiBaseUrl: string,
+type EnvironmentVariableResponse = {
+  data?: Array<{ key: string; value: string }>;
+};
+
+function getInternalAuthorization(): string | undefined {
+  const username = getHostEnv("VERYFRONT_API_INTERNAL_USER");
+  const password = getHostEnv("VERYFRONT_API_INTERNAL_PASS");
+  if (!username || !password) return undefined;
+  return `Basic ${globalThis.btoa(`${username}:${password}`)}`;
+}
+
+async function fetchEnvironmentVariables(
+  url: string,
+  authorization: string,
   projectSlug: string,
   environmentId: string,
-  token: string,
-): Promise<Record<string, string>> {
-  const url = `${apiBaseUrl}/projects/${
-    encodeURIComponent(projectSlug)
-  }/environment-variables?environment_id=${
-    encodeURIComponent(environmentId)
-  }&limit=${ENV_VARS_FETCH_LIMIT}`;
-
-  // Separate try-catch blocks eliminate the need to re-detect "our own" thrown errors
-  // by message string matching. Each catch handles a distinct failure mode.
-
-  let response: Response;
+): Promise<Response> {
   try {
-    response = await fetch(url, {
+    return await fetch(url, {
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: authorization,
         Accept: "application/json",
       },
     });
@@ -50,6 +47,54 @@ export async function fetchProjectEnvVars(
       error: error instanceof Error ? error.message : String(error),
     });
     throw error;
+  }
+}
+
+/**
+ * Fetch environment variables for a project from the Veryfront API.
+ *
+ * Hosted runtimes call the internal Basic-auth endpoint first. Older API deployments
+ * without that endpoint fall back to the bearer-auth management endpoint.
+ * Response: { data: [{ key: string, value: string }] }
+ */
+export async function fetchProjectEnvVars(
+  apiBaseUrl: string,
+  projectSlug: string,
+  environmentId: string,
+  token: string,
+): Promise<Record<string, string>> {
+  const managementUrl = `${apiBaseUrl}/projects/${
+    encodeURIComponent(projectSlug)
+  }/environment-variables?environment_id=${
+    encodeURIComponent(environmentId)
+  }&limit=${ENV_VARS_FETCH_LIMIT}`;
+  const internalUrl = `${apiBaseUrl}/internal/project-environment-variables?environment_id=${
+    encodeURIComponent(environmentId)
+  }`;
+
+  const internalAuthorization = getInternalAuthorization();
+  let response = internalAuthorization
+    ? await fetchEnvironmentVariables(
+      internalUrl,
+      internalAuthorization,
+      projectSlug,
+      environmentId,
+    )
+    : await fetchEnvironmentVariables(
+      managementUrl,
+      `Bearer ${token}`,
+      projectSlug,
+      environmentId,
+    );
+
+  if (internalAuthorization && response.status === 404) {
+    await response.body?.cancel();
+    response = await fetchEnvironmentVariables(
+      managementUrl,
+      `Bearer ${token}`,
+      projectSlug,
+      environmentId,
+    );
   }
 
   if (!response.ok) {
@@ -63,13 +108,16 @@ export async function fetchProjectEnvVars(
   }
 
   try {
-    const body = await response.json() as {
-      data?: Array<{ key: string; value: string }>;
-    };
+    const body = await response.json() as EnvironmentVariableResponse;
 
     const result: Record<string, string> = {};
     if (body.data) {
       for (const entry of body.data) {
+        if (entry.value === MASKED_ENV_VALUE) {
+          throw NETWORK_ERROR.create({
+            detail: "Refusing masked environment variable response",
+          });
+        }
         result[entry.key] = entry.value;
       }
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1092";
+export const VERSION = "0.1.1093";


### PR DESCRIPTION
## Summary
- prefer the Basic-authenticated `/internal/project-environment-variables` endpoint for hosted runtime environment injection
- retain a rollout-only fallback to the existing bearer route when credentials are unavailable or the internal endpoint returns exactly 404
- fail closed for other internal errors and reject the `********` management placeholder from either path
- bump the framework release from `0.1.1092` to `0.1.1093`

Companion to [veryfront-api#4024](https://github.com/veryfront/veryfront-api/issues/4024), [veryfront-api#4034](https://github.com/veryfront/veryfront-api/pull/4034), and [veryfront-studio#6063](https://github.com/veryfront/veryfront-studio/pull/6063). This runtime change must deploy before the API starts masking the public management route.

## TDD
- RED: added failing coverage for internal endpoint selection, Basic auth, 404-only fallback, non-404 failure, and masked-value rejection
- GREEN/refactor: centralized request handling and host credential lookup without changing the caller contract

## Verification
- focused fetcher tests: 9/9
- project-env suite: 46/46
- agent-stream caller suite: 32/32
- `deno check`, `deno lint`, and `deno fmt --check`
- release bump: `deno.json` parses and reports `0.1.1093`
- pre-push repository gate: formatting, lint, typecheck, 2,516 tests / 20,847 steps passed
- GitHub Actions: format, lint, typecheck, unit/integration, coverage, CodeQL, browser/binary E2E, and install smoke passed

## Rollout
Deploy this PR and [veryfront-studio#6063](https://github.com/veryfront/veryfront-studio/pull/6063) before [veryfront-api#4034](https://github.com/veryfront/veryfront-api/pull/4034). Existing deployments continue to use the legacy route until the internal endpoint is available.