### PR TITLE
fix(rendering): reuse stable SSR module identities

### DIFF
--- a/src/rendering/orchestrator/module-loader/index.test.ts
+++ b/src/rendering/orchestrator/module-loader/index.test.ts
@@ -1,9 +1,22 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertNotStrictEquals,
+  assertStrictEquals,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
 import { dirname, join } from "#veryfront/compat/path/index.ts";
-import { isMissingModuleError, type ModuleLoaderConfig, transformModuleWithDeps } from "./index.ts";
+import { runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
+import {
+  isMissingModuleError,
+  loadModule,
+  type ModuleLoaderConfig,
+  transformModuleWithDeps,
+} from "./index.ts";
+import { getModuleCacheKey } from "./module-cache-lookup.ts";
 
 async function withModuleLoaderFixture<T>(
   files: Record<string, string>,
@@ -103,6 +116,67 @@ describe("module-loader/transformModuleWithDeps", () => {
 
         assertStringIncludes(transformedPath, "/app/page.json");
         assertEquals((await Deno.stat(depPath)).isFile, true);
+      },
+    );
+  });
+});
+
+describe("module-loader/loadModule", () => {
+  it("reuses the content-addressed module identity across repeated loads", async () => {
+    await withModuleLoaderFixture(
+      { "app/page.ts": `export const value = "stable";` },
+      async ({ projectDir, tmpDir, config }) => {
+        const filePath = join(projectDir, "app/page.ts");
+        const productionConfig = { ...config, mode: "production" as const };
+        const artifactPath = join(tmpDir, "page.stable.mjs");
+        await Deno.writeTextFile(artifactPath, `export const value = "stable";`);
+        productionConfig.moduleCache.set(
+          getModuleCacheKey(filePath, undefined, projectDir, undefined, undefined, "production"),
+          artifactPath,
+        );
+
+        await runWithCacheDir(tmpDir, async () => {
+          const first = await loadModule(filePath, productionConfig);
+          const loadedAt = Date.now();
+          while (Date.now() === loadedAt) {
+            await new Promise((resolve) => setTimeout(resolve, 1));
+          }
+          const second = await loadModule(filePath, productionConfig);
+
+          assertStrictEquals(second, first);
+        });
+      },
+    );
+  });
+
+  it("loads a new module identity when the cached content artifact changes", async () => {
+    await withModuleLoaderFixture(
+      { "app/page.ts": `export const value = "stable";` },
+      async ({ projectDir, tmpDir, config }) => {
+        const filePath = join(projectDir, "app/page.ts");
+        const productionConfig = { ...config, mode: "production" as const };
+        const cacheKey = getModuleCacheKey(
+          filePath,
+          undefined,
+          projectDir,
+          undefined,
+          undefined,
+          "production",
+        );
+        const stablePath = join(tmpDir, "page.stable.mjs");
+        await Deno.writeTextFile(stablePath, `export const value = "stable";`);
+        productionConfig.moduleCache.set(cacheKey, stablePath);
+
+        await runWithCacheDir(tmpDir, async () => {
+          const first = await loadModule(filePath, productionConfig);
+          const changedPath = join(tmpDir, "page.changed.mjs");
+          await Deno.writeTextFile(changedPath, `export const value = "changed";`);
+          productionConfig.moduleCache.set(cacheKey, changedPath);
+          const changed = await loadModule(filePath, productionConfig);
+
+          assertNotStrictEquals(changed, first);
+          assertEquals(changed.value, "changed");
+        });
       },
     );
   });

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -206,7 +206,7 @@ export async function loadModule(
   const localAdapter = await getLocalAdapter();
 
   const tempFilePath = await transformModuleWithDeps(filePath, tmpDir, localAdapter, config);
-  const moduleUrl = `file://${tempFilePath}?t=${Date.now()}`;
+  const moduleUrl = `file://${tempFilePath}`;
 
   try {
     return await import(moduleUrl);


### PR DESCRIPTION
## Description

Production SSR imported the same transformed module with a new wall-clock query suffix on every uncached render. Deno treats each distinct URL as a separate module identity and retains it for the isolate lifetime, allowing repeated renders to accumulate module graphs until V8 exits.

This PR:

- reuses the existing content-addressed artifact URL for successful imports
- preserves fresh identities for exceptional HTTP-bundle and missing-file recovery attempts
- adds regression coverage proving unchanged artifacts reuse one namespace while changed artifact paths receive a new namespace

## TDD evidence

RED:

- Added the repeated-load identity test first.
- Command: `deno test --no-check --allow-all src/rendering/orchestrator/module-loader/index.test.ts`
- Failure: `AssertionError: Values have the same structure but are not reference-equal.`

GREEN:

- Removed the per-request timestamp from the normal successful import URL.
- Focused test passed with the same namespace object reused.

## Related Issue(s)

Fixes veryfront/veryfront-server#251

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Verification

- Focused module-loader suite: 3 groups, 9 steps, 0 failures
- Rendering-orchestrator suite: 25 groups, 312 steps, 0 failures
- Full unit suite: 2,517 tests, 20,844 steps, 0 failures
- `deno task verify:quick`: passed
- Pre-push formatting, lint, typecheck, and unit gates: passed
- Independent code review: approved

## Rollout and follow-up

- No public API or documentation changes.
- Production soak requires a framework release and server artifact promotion.
- The existing 32-bit artifact filename hash is unchanged; moving it to a collision-resistant digest should be a separate cache-format change.

## Checklist

- [x] Documentation is not applicable because this changes internal runtime behavior only
- [x] I have added tests that prove the fix is effective