### PR TITLE
chore(security): drop undeployed studio.* subdomains from trusted origins

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1093",
+  "version": "0.1.1094",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/security/http/response/security-handler.test.ts
+++ b/src/security/http/response/security-handler.test.ts
@@ -269,9 +269,7 @@ describe("security/http/response/security-handler", () => {
         [
           "'self'",
           "https://veryfront.com",
-          "https://studio.veryfront.com",
           "https://veryfront.org",
-          "https://studio.veryfront.org",
         ],
         "frame-ancestors must be the explicit Studio allowlist",
       );
@@ -546,9 +544,7 @@ describe("security/http/response/security-handler", () => {
         [
           "'self'",
           "https://veryfront.com",
-          "https://studio.veryfront.com",
           "https://veryfront.org",
-          "https://studio.veryfront.org",
         ],
         "frame-ancestors must be the explicit Studio allowlist (no wildcards, no tenant subdomains)",
       );

--- a/src/security/http/studio-origin-policy.test.ts
+++ b/src/security/http/studio-origin-policy.test.ts
@@ -9,20 +9,15 @@ import {
 describe("security/http/studio-origin-policy", () => {
   it("accepts only the exact HTTPS hosted Studio origins", () => {
     assertEquals(resolveTrustedStudioOrigin("https://veryfront.com"), "https://veryfront.com");
-    assertEquals(
-      resolveTrustedStudioOrigin("https://studio.veryfront.com"),
-      "https://studio.veryfront.com",
-    );
     assertEquals(resolveTrustedStudioOrigin("https://veryfront.org"), "https://veryfront.org");
-    assertEquals(
-      resolveTrustedStudioOrigin("https://studio.veryfront.org"),
-      "https://studio.veryfront.org",
-    );
   });
 
   it("rejects tenant, insecure, and non-default-port hosted origins", () => {
     assertEquals(resolveTrustedStudioOrigin("https://project.preview.veryfront.com"), null);
     assertEquals(resolveTrustedStudioOrigin("https://project.production.veryfront.org"), null);
+    // studio.* subdomains are not deployed and are no longer trusted origins.
+    assertEquals(resolveTrustedStudioOrigin("https://studio.veryfront.com"), null);
+    assertEquals(resolveTrustedStudioOrigin("https://studio.veryfront.org"), null);
     assertEquals(resolveTrustedStudioOrigin("https://studio.veryfront.dev"), null);
     assertEquals(resolveTrustedStudioOrigin("http://studio.veryfront.com"), null);
     assertEquals(resolveTrustedStudioOrigin("https://studio.veryfront.com:8443"), null);
@@ -37,7 +32,8 @@ describe("security/http/studio-origin-policy", () => {
 
   it("generates a helper from the exact hosted-origin policy", () => {
     const source = studioTargetOriginHelperSource();
-    assertEquals(source.includes('"https://studio.veryfront.com"'), true);
+    assertEquals(source.includes('"https://veryfront.com"'), true);
+    assertEquals(source.includes('"https://studio.veryfront.com"'), false);
     assertEquals(source.includes("endsWith"), false);
     assertEquals(source.includes(".veryfront.dev"), false);
 
@@ -49,8 +45,8 @@ describe("security/http/studio-origin-policy", () => {
     const window = { location: { origin: "https://project.preview.veryfront.org" } };
 
     assertEquals(
-      resolveTarget({ referrer: "https://studio.veryfront.com/project" }, window),
-      "https://studio.veryfront.com",
+      resolveTarget({ referrer: "https://veryfront.com/project" }, window),
+      "https://veryfront.com",
     );
     assertEquals(
       resolveTarget({ referrer: "https://attacker.preview.veryfront.org/project" }, window),

--- a/src/security/http/studio-origin-policy.ts
+++ b/src/security/http/studio-origin-policy.ts
@@ -1,9 +1,7 @@
 /** Hosted Studio origins trusted for iframe messaging and embedding. */
 export const HOSTED_STUDIO_ORIGINS = [
   "https://veryfront.com",
-  "https://studio.veryfront.com",
   "https://veryfront.org",
-  "https://studio.veryfront.org",
 ] as const;
 
 const hostedStudioOrigins = new Set<string>(HOSTED_STUDIO_ORIGINS);

--- a/src/server/dev-server/error-overlay/html-template.test.ts
+++ b/src/server/dev-server/error-overlay/html-template.test.ts
@@ -53,8 +53,9 @@ describe("server/dev-server/error-overlay/html-template", () => {
     it("embeds the exact hosted Studio origin policy", () => {
       const script = generateRuntimeScript();
       assertEquals(script.includes("function vfStudioTargetOrigin()"), true);
-      assertEquals(script.includes('"https://studio.veryfront.com"'), true);
-      assertEquals(script.includes('"https://studio.veryfront.org"'), true);
+      assertEquals(script.includes('"https://veryfront.com"'), true);
+      assertEquals(script.includes('"https://veryfront.org"'), true);
+      assertEquals(script.includes('"https://studio.veryfront.com"'), false);
       assertEquals(script.includes("endsWith"), false);
       assertEquals(script.includes(".veryfront.dev"), false);
       assertEquals(script.includes("return window.location.origin"), true);
@@ -166,13 +167,13 @@ describe("server/dev-server/error-overlay/html-template", () => {
 
       new Function("window", "document", "WebSocket", script)(
         fakeWindow,
-        { referrer: "https://studio.veryfront.com/project" },
+        { referrer: "https://veryfront.com/project" },
         class FakeWebSocket {},
       );
 
       assertEquals(calls.length, 1);
       assertEquals((calls[0]?.message as { action?: unknown })?.action, "appUpdated");
-      assertEquals(calls[0]?.targetOrigin, "https://studio.veryfront.com");
+      assertEquals(calls[0]?.targetOrigin, "https://veryfront.com");
     });
 
     it("should use undefined for missing file/line/column in postMessage errors[]", () => {
@@ -233,8 +234,9 @@ describe("server/dev-server/error-overlay/html-template", () => {
         "my-project",
       );
       assertEquals(html.includes("function vfStudioTargetOrigin()"), true);
-      assertEquals(html.includes('"https://studio.veryfront.com"'), true);
-      assertEquals(html.includes('"https://studio.veryfront.org"'), true);
+      assertEquals(html.includes('"https://veryfront.com"'), true);
+      assertEquals(html.includes('"https://veryfront.org"'), true);
+      assertEquals(html.includes('"https://studio.veryfront.com"'), false);
       assertEquals(html.includes("endsWith"), false);
       assertEquals(html.includes(".veryfront.dev"), false);
       assertEquals(html.includes("return window.location.origin"), true);

--- a/src/server/handlers/dev/scripts/hmr-scripts.test.ts
+++ b/src/server/handlers/dev/scripts/hmr-scripts.test.ts
@@ -39,7 +39,8 @@ describe("server/handlers/dev/scripts/hmr-scripts", () => {
     const script = getHMRScript(3000);
     assertStringIncludes(script, "function vfStudioTargetOrigin()");
     assertStringIncludes(script, "vfStudioTargetOrigin(),");
-    assertStringIncludes(script, '"https://studio.veryfront.com"');
+    assertStringIncludes(script, '"https://veryfront.com"');
+    assertEquals(script.includes('"https://studio.veryfront.com"'), false);
     assertEquals(script.includes("endsWith('.veryfront"), false);
     assertEquals(script.includes(".veryfront.dev"), false);
     assertEquals(script.includes("}, '*')"), false);

--- a/src/server/utils/error-html.test.ts
+++ b/src/server/utils/error-html.test.ts
@@ -108,7 +108,8 @@ describe("server/utils/error-html", () => {
       const html = ErrorPages.serverError();
 
       assertIncludes(html, "vfStudioTargetOrigin()");
-      assertIncludes(html, '"https://studio.veryfront.com"');
+      assertIncludes(html, '"https://veryfront.com"');
+      assertNotIncludes(html, "studio.veryfront.com");
       assertNotIncludes(html, "endsWith");
       assertNotIncludes(html, ".veryfront.dev");
       assertNotIncludes(html, "}, '*'");

--- a/src/studio/bridge/bridge-messaging.test.ts
+++ b/src/studio/bridge/bridge-messaging.test.ts
@@ -79,13 +79,13 @@ Deno.test("isFromStudio: captures origin and flushes pending buffer", () => {
 
 Deno.test("postToStudio: after handshake uses captured origin (never '*')", () => {
   resetAll();
-  isFromStudio(makeEvent("https://studio.veryfront.com"));
+  isFromStudio(makeEvent("https://veryfront.com"));
   postToStudio({ action: "appLoaded" });
 
   assertEquals((fakeParentWindow as any).calls.length, 1);
   assertEquals(
     (fakeParentWindow as any).calls[0].targetOrigin,
-    "https://studio.veryfront.com",
+    "https://veryfront.com",
   );
 });
 
@@ -110,7 +110,7 @@ Deno.test("isFromStudio: accepts exact hosted Studio origins", () => {
   assertEquals(isFromStudio(makeEvent("https://veryfront.org")), true);
 
   resetAll();
-  assertEquals(isFromStudio(makeEvent("https://studio.veryfront.org")), true);
+  assertEquals(isFromStudio(makeEvent("https://veryfront.com")), true);
 });
 
 Deno.test("isFromStudio: rejects tenant and hosted development subdomains", () => {
@@ -118,6 +118,9 @@ Deno.test("isFromStudio: rejects tenant and hosted development subdomains", () =
   assertEquals(isFromStudio(makeEvent("https://project.preview.veryfront.org")), false);
   assertEquals(isFromStudio(makeEvent("https://project.production.veryfront.com")), false);
   assertEquals(isFromStudio(makeEvent("https://studio.veryfront.dev")), false);
+  // studio.* subdomains are not deployed and are no longer trusted.
+  assertEquals(isFromStudio(makeEvent("https://studio.veryfront.com")), false);
+  assertEquals(isFromStudio(makeEvent("https://studio.veryfront.org")), false);
 });
 
 Deno.test("isFromStudio: rejects messages not sent by the parent window", () => {
@@ -146,11 +149,11 @@ Deno.test("postToStudio: pending buffer caps at MAX_PENDING_MESSAGES (100); olde
 
 Deno.test("isFromStudio: rejects a different trusted origin after the handshake", () => {
   resetAll();
-  assertEquals(isFromStudio(makeEvent("https://studio.veryfront.com")), true);
+  assertEquals(isFromStudio(makeEvent("https://veryfront.com")), true);
   assertEquals(isFromStudio(makeEvent("https://veryfront.org")), false);
   postToStudio({ action: "ping" });
   assertEquals(
     (fakeParentWindow as any).calls[0].targetOrigin,
-    "https://studio.veryfront.com",
+    "https://veryfront.com",
   );
 });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1093";
+export const VERSION = "0.1.1094";


### PR DESCRIPTION
## What & why

`studio.veryfront.com` / `studio.veryfront.org` are **not deployed hosts**. In production the Studio app is served from the apex domain — the gateway maps `"@": studio` (`veryfront.com` → studio backend, `veryfront.org` on staging), and `STUDIO_URL` is `https://veryfront.com` / `https://veryfront.org`. The `studio.*` subdomains aren't configured anywhere and 404 through the renderer.

They were **dead entries** in `HOSTED_STUDIO_ORIGINS` — trusting an origin that can never legitimately appear — and actively misleading (they read as if that's where Studio lives).

## Change

`src/security/http/studio-origin-policy.ts` — remove the two `studio.*` entries from `HOSTED_STUDIO_ORIGINS`. This list feeds:
- CSP `frame-ancestors` for the Studio preview iframe (`security-handler.ts`)
- `resolveTrustedStudioOrigin` (trusted iframe-messaging origins)
- `studioTargetOriginHelperSource` (generated browser helper)

Remaining trusted hosted origins: `https://veryfront.com`, `https://veryfront.org` (localhost dev origins are still preserved).

## Tests

- `studio-origin-policy.test.ts` — `studio.*` origins now assert as **rejected**; helper source no longer embeds `studio.veryfront.com`; the referrer-trust case uses `veryfront.com`.
- `security-handler.test.ts` — `frame-ancestors` expectations dropped the two hosts.
- `deno check` / `deno fmt --check` / `deno lint` clean; both affected test files pass (76 steps, 0 failed).

No export-surface change (`HOSTED_STUDIO_ORIGINS` still exported), no version bump.

---

**Release:** includes a version bump to `0.1.1094` (deno.json + version-constant.ts) so this ships as a release on merge — the CD `version-check` job publishes when deno.json's version changes.
