### PR TITLE
fix(orchestrator/file-resolver): resolve @/ imports that carry an explicit source extension

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1094",
+  "version": "0.1.1095",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/rendering/orchestrator/file-resolver/index.test.ts
+++ b/src/rendering/orchestrator/file-resolver/index.test.ts
@@ -5,6 +5,58 @@ import type { ResolveFileOptions, RuntimeAdapter } from "#veryfront/platform/ada
 import { findSourceFile } from "./index.ts";
 
 describe("rendering/orchestrator/file-resolver", () => {
+  it("resolves a specifier that already carries an explicit source extension", async () => {
+    // Repro for the SSR `@/` alias bug: when a user writes
+    //   import { Welcome } from "@/components/Welcome.tsx"
+    // the alias resolver strips `@/` and passes `components/Welcome.tsx` to
+    // findSourceFile. Historically the candidate builder only tried
+    // `${fileName}${ext}` and `${fileName}/index${ext}` variants, so the
+    // literal on-disk path was never a candidate and the file was reported
+    // missing even though it existed. This test locks in the fix.
+    const adapter = {
+      fs: {
+        stat: async (path: string) => {
+          if (path === "/project/components/Welcome.tsx") {
+            return {
+              isFile: true,
+              isDirectory: false,
+              isSymlink: false,
+              size: 1,
+              mtime: new Date(),
+            };
+          }
+          throw new Error("File not found");
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    const result = await findSourceFile("components/Welcome.tsx", "/project", adapter);
+
+    assertEquals(result, "/project/components/Welcome.tsx");
+  });
+
+  it("prefers the literal on-disk path over ext-appended candidates via resolveFile", async () => {
+    const resolveCalls: string[] = [];
+    const adapter = {
+      fs: {
+        resolveFile: async (basePath: string) => {
+          resolveCalls.push(basePath);
+          return basePath === "/project/components/Welcome.tsx"
+            ? "/project/components/Welcome.tsx"
+            : null;
+        },
+        stat: async () => {
+          throw new Error("stat should not be reached when resolveFile succeeds");
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    const result = await findSourceFile("components/Welcome.tsx", "/project", adapter);
+
+    assertEquals(result, "/project/components/Welcome.tsx");
+    assertEquals(resolveCalls[0], "/project/components/Welcome.tsx");
+  });
+
   it("does not resolve source imports through an implicit pages/ fallback", async () => {
     const resolveCalls: Array<{ basePath: string; allowPagesPrefix?: boolean }> = [];
 

--- a/src/rendering/orchestrator/file-resolver/index.ts
+++ b/src/rendering/orchestrator/file-resolver/index.ts
@@ -16,6 +16,13 @@ export { buildCandidatePaths, findFirstExisting } from "./candidates.ts";
 const SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mdx", ".md"];
 const COMPONENT_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"];
 
+function stripSourceExtension(path: string): { stem: string; hasExt: boolean } {
+  const matched = SOURCE_EXTENSIONS.find((ext) => path.endsWith(ext));
+  return matched
+    ? { stem: path.slice(0, -matched.length), hasExt: true }
+    : { stem: path, hasExt: false };
+}
+
 export function getLocalLibDir(): string {
   const currentFile = new URL(import.meta.url).pathname;
   const srcIndex = currentFile.indexOf("/src/");
@@ -49,11 +56,24 @@ export async function findSourceFile(
   projectDir: string,
   adapter: RuntimeAdapter,
 ): Promise<string | null> {
+  // When the specifier already carries an explicit source extension
+  // (e.g. `@/components/Welcome.tsx`), the literal on-disk path must be a
+  // candidate. `buildCandidatePaths` only produces `${fileName}${ext}` and
+  // `${fileName}/index${ext}` variants, so without stripping the extension
+  // here the file would never match.
+  const { stem, hasExt: hasExplicitExt } = stripSourceExtension(basePath);
+
   if (adapter.fs.resolveFile) {
-    const directBases = [join(projectDir, basePath)];
-    const withoutComponents = basePath.replace(/^components\//, "");
-    if (withoutComponents !== basePath) {
-      directBases.push(join(projectDir, withoutComponents));
+    const directBases: string[] = [];
+    if (hasExplicitExt) directBases.push(join(projectDir, basePath));
+    directBases.push(join(projectDir, stem));
+
+    const stemWithoutComponents = stem.replace(/^components\//, "");
+    if (stemWithoutComponents !== stem) {
+      if (hasExplicitExt) {
+        directBases.push(join(projectDir, basePath.replace(/^components\//, "")));
+      }
+      directBases.push(join(projectDir, stemWithoutComponents));
     }
 
     for (const candidateBase of directBases) {
@@ -67,11 +87,16 @@ export async function findSourceFile(
     }
   }
 
-  const candidates = buildCandidatePaths(projectDir, basePath, SOURCE_EXTENSIONS);
+  const candidates: string[] = [];
+  if (hasExplicitExt) candidates.push(join(projectDir, basePath));
+  candidates.push(...buildCandidatePaths(projectDir, stem, SOURCE_EXTENSIONS));
 
-  const withoutComponents = basePath.replace(/^components\//, "");
-  if (withoutComponents !== basePath) {
-    candidates.push(...buildCandidatePaths(projectDir, withoutComponents, SOURCE_EXTENSIONS));
+  const stemWithoutComponents = stem.replace(/^components\//, "");
+  if (stemWithoutComponents !== stem) {
+    if (hasExplicitExt) {
+      candidates.push(join(projectDir, basePath.replace(/^components\//, "")));
+    }
+    candidates.push(...buildCandidatePaths(projectDir, stemWithoutComponents, SOURCE_EXTENSIONS));
   }
 
   const result = await findFirstExisting(candidates, (p) => adapter.fs.stat(p));

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1094";
+export const VERSION = "0.1.1095";


### PR DESCRIPTION
## What

`findSourceFile` did not treat a specifier's explicit source extension as a hint. `buildCandidatePaths` only emits `${fileName}${ext}` and `${fileName}/index${ext}` variants, so a specifier like `@/components/Welcome.tsx` produced candidates such as `components/Welcome.tsx.tsx` and `components/Welcome.tsx.ts` — the literal `components/Welcome.tsx` on disk was never checked.

For extensionless specifiers (`@/components/Welcome`) resolution worked as before, so this only showed up when a user wrote the extension.

## Change

`findSourceFile` now:

- Detects a trailing source extension on the incoming specifier.
- If present, tries the literal `${projectDir}/${basePath}` first, both in the `adapter.fs.resolveFile` branch and in the `stat`-based fallback.
- Uses the extension-stripped stem for the subsequent extension-appended candidates, so the existing behavior for extensionless specifiers is unchanged.

The existing `components/`-prefix leniency (adding/stripping `components/`) is preserved so previously-working imports keep resolving. Whether that leniency should stay long-term is a separate conversation.

Refactored the shared list of source extensions into a single helper so the array and any extension check stay in sync.

## Tests

- New unit tests in `src/rendering/orchestrator/file-resolver/index.test.ts` cover both branches (with and without `adapter.fs.resolveFile`) for a specifier carrying an explicit `.tsx` extension.
- Existing `file-resolver` tests continue to pass.
- Wider smoke: `deno test src/rendering/ src/modules/ src/transforms/` — 238 files / 3283 steps, all green.

## Manual check

Reproduced with a `veryfront init --template minimal` scaffold plus a two-line `components/Welcome.tsx` imported from `app/page.tsx` as `@/components/Welcome.tsx`:

- Before: `GET /` returns HTTP 500 with `Cannot find module '/_vf_modules/components/Welcome.js'`.
- After: `GET /` returns HTTP 200 with the component rendered.

## Notes

Small change, intentionally narrow — happy to expand or split if a reviewer would prefer.