### PR TITLE
fix(module-loader): recover from stale mkdir memo on cache write (depends on #2999)

### DIFF
--- a/src/rendering/orchestrator/module-loader/module-persistence.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.test.ts
@@ -47,4 +47,95 @@ describe("module-loader/module-persistence", () => {
       await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
     }
   });
+
+  it("recreates the output directory when it disappears after being cached", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const filePath = join(projectDir, "lib/uses-crypto.ts");
+    const moduleCache = new Map<string, string>();
+
+    try {
+      await Deno.mkdir(dirname(filePath), { recursive: true });
+
+      const first = await persistTransformedModule({
+        filePath,
+        projectDir,
+        tmpDir,
+        transformedCode: "export const a = 1;",
+        localAdapter,
+        moduleCache,
+        cacheKey: "first",
+      });
+      assertEquals(await Deno.readTextFile(first), "export const a = 1;");
+
+      // Something outside the loader wipes the cache dir (manual `rm -rf .cache`,
+      // a cache sweep, a container restart). The mkdir memo still claims it exists.
+      await Deno.remove(join(tmpDir, "lib"), { recursive: true });
+
+      const second = await persistTransformedModule({
+        filePath,
+        projectDir,
+        tmpDir,
+        transformedCode: "export const a = 2;",
+        localAdapter,
+        moduleCache,
+        cacheKey: "second",
+      });
+      assertEquals(await Deno.readTextFile(second), "export const a = 2;");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
+  it("does not cache a failed mkdir as a created directory", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const filePath = join(projectDir, "lib/transient.ts");
+    const moduleCache = new Map<string, string>();
+
+    // A transient mkdir failure (EMFILE under concurrent compilation) must not
+    // poison the memo — otherwise every later write to that directory ENOENTs.
+    let failNextMkdir = true;
+    const stubFs = Object.create(localAdapter.fs) as typeof localAdapter.fs;
+    stubFs.mkdir = (path: string, options?: { recursive?: boolean }) => {
+      if (failNextMkdir) {
+        failNextMkdir = false;
+        return Promise.reject(new Error("EMFILE: too many open files, mkdir"));
+      }
+      return localAdapter.fs.mkdir(path, options);
+    };
+    const stubAdapter = Object.create(localAdapter) as typeof localAdapter;
+    Object.defineProperty(stubAdapter, "fs", { value: stubFs });
+
+    try {
+      await Deno.mkdir(dirname(filePath), { recursive: true });
+
+      await persistTransformedModule({
+        filePath,
+        projectDir,
+        tmpDir,
+        transformedCode: "export const b = 1;",
+        localAdapter: stubAdapter,
+        moduleCache,
+        cacheKey: "transient",
+      }).catch(() => undefined);
+
+      const result = await persistTransformedModule({
+        filePath,
+        projectDir,
+        tmpDir,
+        transformedCode: "export const b = 2;",
+        localAdapter: stubAdapter,
+        moduleCache,
+        cacheKey: "transient-retry",
+      });
+      assertEquals(await Deno.readTextFile(result), "export const b = 2;");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
 });

--- a/src/rendering/orchestrator/module-loader/module-persistence.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.test.ts
@@ -138,4 +138,94 @@ describe("module-loader/module-persistence", () => {
       await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
     }
   });
+
+  it("retries the mkdir on a later write when an earlier mkdir failed", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const filePath = join(projectDir, "lib/transient.ts");
+    const moduleCache = new Map<string, string>();
+
+    // mkdir always rejects, and the writes are made to land anyway by creating
+    // the output directory out of band. This isolates the memo from the write
+    // retry: the question is only whether a failed mkdir is remembered as done.
+    let mkdirCalls = 0;
+    const stubFs = Object.create(localAdapter.fs) as typeof localAdapter.fs;
+    stubFs.mkdir = () => {
+      mkdirCalls++;
+      return Promise.reject(new Error("EMFILE: too many open files, mkdir"));
+    };
+    const stubAdapter = Object.create(localAdapter) as typeof localAdapter;
+    Object.defineProperty(stubAdapter, "fs", { value: stubFs });
+
+    try {
+      await Deno.mkdir(dirname(filePath), { recursive: true });
+      await Deno.mkdir(join(tmpDir, "lib"), { recursive: true });
+
+      const persist = (transformedCode: string, cacheKey: string) =>
+        persistTransformedModule({
+          filePath,
+          projectDir,
+          tmpDir,
+          transformedCode,
+          localAdapter: stubAdapter,
+          moduleCache,
+          cacheKey,
+        });
+
+      await persist("export const b = 1;", "one").catch(() => undefined);
+      const before = mkdirCalls;
+      await persist("export const b = 2;", "two").catch(() => undefined);
+
+      // A failed mkdir must not be remembered as a created directory: the second
+      // persist has to attempt the mkdir again rather than trust a poisoned memo.
+      assertEquals(mkdirCalls > before, true);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
+  it("rethrows a non-race write error without retrying the write", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const filePath = join(projectDir, "lib/denied.ts");
+    const moduleCache = new Map<string, string>();
+
+    // A permission error is not a vanished-directory race, so recreating the
+    // directory and writing again would just fail twice on an already-degraded
+    // filesystem. It must surface immediately.
+    let writeCalls = 0;
+    const stubFs = Object.create(localAdapter.fs) as typeof localAdapter.fs;
+    stubFs.writeFile = () => {
+      writeCalls++;
+      return Promise.reject(new Error("EACCES: permission denied, open"));
+    };
+    const stubAdapter = Object.create(localAdapter) as typeof localAdapter;
+    Object.defineProperty(stubAdapter, "fs", { value: stubFs });
+
+    try {
+      await Deno.mkdir(dirname(filePath), { recursive: true });
+
+      let rejected = false;
+      await persistTransformedModule({
+        filePath,
+        projectDir,
+        tmpDir,
+        transformedCode: "export const c = 1;",
+        localAdapter: stubAdapter,
+        moduleCache,
+        cacheKey: "denied",
+      }).catch(() => {
+        rejected = true;
+      });
+
+      assertEquals(rejected, true);
+      assertEquals(writeCalls, 1);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
 });

--- a/src/rendering/orchestrator/module-loader/module-persistence.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.ts
@@ -7,6 +7,7 @@
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { rendererLogger } from "#veryfront/utils";
+import { isCacheWriteRaceError } from "#veryfront/utils/cache-file-ops.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import {
   getModulePathCache,
@@ -36,17 +37,26 @@ function pruneCreatedDirs(): void {
   }
 }
 
-async function ensureDir(adapter: RuntimeAdapter, dir: string): Promise<void> {
-  if (createdDirs.has(dir)) return;
+async function ensureDir(
+  adapter: RuntimeAdapter,
+  dir: string,
+  force = false,
+): Promise<void> {
+  if (!force && createdDirs.has(dir)) return;
 
   try {
     await adapter.fs.mkdir(dir, { recursive: true });
-  } catch (_) {
-    /* expected: directory might already exist */
-  } finally {
-    createdDirs.add(dir);
-    pruneCreatedDirs();
+  } catch (error) {
+    // `recursive: true` is a no-op on an existing directory, so a rejection here
+    // means the directory may genuinely be absent (EMFILE, EACCES, a racing
+    // sweep). Drop the memo so the next attempt retries instead of assuming the
+    // directory is present forever after.
+    createdDirs.delete(dir);
+    throw error;
   }
+
+  createdDirs.add(dir);
+  pruneCreatedDirs();
 }
 
 export interface PersistTransformedModuleInput {
@@ -75,17 +85,37 @@ export async function persistTransformedModule(
   const tempFilePath = join(input.tmpDir, jsPath);
 
   const tempDir = tempFilePath.substring(0, tempFilePath.lastIndexOf("/"));
-  await ensureDir(input.localAdapter, tempDir);
+  await ensureDir(input.localAdapter, tempDir).catch(() => {
+    // Fall through to the write, which retries the mkdir on failure.
+  });
 
   try {
     await input.localAdapter.fs.writeFile(tempFilePath, input.transformedCode);
   } catch (error) {
-    logger.error("Failed to write module:", {
-      filePath: input.filePath,
-      tempFilePath,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
+    // The cache directory can vanish between mkdir and write — a manual
+    // `rm -rf .cache`, a cache sweep, or a mkdir that never actually landed.
+    // Force the directory back into existence and retry once before failing.
+    if (!isCacheWriteRaceError(error)) {
+      logger.error("Failed to write module:", {
+        filePath: input.filePath,
+        tempFilePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+
+    try {
+      await ensureDir(input.localAdapter, tempDir, true);
+      await input.localAdapter.fs.writeFile(tempFilePath, input.transformedCode);
+      logger.debug("Recreated module cache directory after failed write", { tempDir });
+    } catch (retryError) {
+      logger.error("Failed to write module:", {
+        filePath: input.filePath,
+        tempFilePath,
+        error: retryError instanceof Error ? retryError.message : String(retryError),
+      });
+      throw retryError;
+    }
   }
 
   if (input.contentSourceId) {


### PR DESCRIPTION
## Summary

The module loader memoised every directory it had `mkdir`'d in a process-wide `Set`, and added the directory to that `Set` in a `finally` block — so a `mkdir` that *failed* was recorded as having succeeded. From then on `ensureDir` was a no-op for that directory and **every subsequent write to it failed with ENOENT for the lifetime of the dev server**. The same permanent-failure state is reached whenever the cache directory disappears after being memoised (a manual `rm -rf .cache`, a cache sweep, a container restart).

This is what made the dev server unusable at scale: past ~30 compiled routes, every request 500s with `Failed to write module: … ENOENT`, including routes that rendered fine moments earlier.

A directory is now recorded as created only when `mkdir` actually succeeds, and the write retries once — forcing the `mkdir` past the memo — when it fails with a cache-write race error.

## Reproduction

- Reproducer: [`default-config/`](https://github.com/mattboon/veryfront-router-testing/tree/main/default-config) at scale — see [RESULTS.md § "framework instability at scale"](https://github.com/mattboon/veryfront-router-testing/blob/main/RESULTS.md)
- Test: `src/rendering/orchestrator/module-loader/module-persistence.test.ts`

## Test evidence

Before (both new cases red, with the exact production signature):

```
recreates the output directory when it disappears after being cached ... FAILED
  error: NotFound: No such file or directory (os error 2): writefile
         '/…/vf-module-persist-out-…/lib/uses-crypto.e1b64c.js'
    at persistTransformedModule (module-persistence.ts:81:33)
does not cache a failed mkdir as a created directory ... FAILED
FAILED | 0 passed (1 step) | 1 failed (2 steps)
```

After:

```
writes transformed code, registers MDX path-cache, and updates module cache ... ok
recreates the output directory when it disappears after being cached ... ok
does not cache a failed mkdir as a created directory ... ok
ok | 1 passed (3 steps) | 0 failed
```

Wider suite: `deno task test:unit` → **2525 passed | 0 failed**.

## SSR evidence

The ENOENT cascade is gone entirely. After a full 56-route sweep against a single dev-server instance:

```
$ grep -ci "Failed to write module\|ENOENT" /tmp/vf-dev.log
0
```

Previously this fired on virtually every request past warm-up. Routes RESULTS.md recorded as lost to the cascade (`/use-server`, `/test/bb-env-vars`, `/test-app/c-tsx-ext-component`) now return 200.

## Client evidence

`/use-server` and `/test-app/c-tsx-ext-component` previously rendered the framework's `Runtime Error` page instead of the intended page. Both now render and hydrate; the full sweep shows no cache-write failure of any kind.

## Related

- Bug 9 of the reproducer matrix — the one the reproducer calls "the single biggest impediment to a healthy dev experience".

---

**Chain:** this PR is part of a 13-PR chain fixing the bugs catalogued in
[veryfront-router-testing](https://github.com/mattboon/veryfront-router-testing).
Its base is the previous PR in the chain, so the diff shows only this fix.
The root of the chain is #2999 (`fix/ssr-lazy-import-graceful-degrade`) — **merge #2999 first**, then
rebase the chain onto `main`.

**Regression gate:** `deno task test:unit` → **2525 passed | 0 failed**; `deno task lint`,
`deno task fmt:check` and `deno task typecheck` all clean. The reproducer's full 56-route
matrix (`ROUTES.txt` + `sweep.sh`) was re-run after every fix: 7 routes improved, **0 regressed**.
A 46-route Chromium hydration sweep (`client-sweep.mjs`) backs the client-side claims.