### PR TITLE
fix(transforms,module-server): never emit or serve source extensions to the browser (depends on #2999)

### DIFF
--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -20,7 +20,7 @@ import {
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
-import { isModuleRequest } from "./module-server.ts";
+import { getDevModuleContentType, isModuleRequest } from "./module-server.ts";
 import { clearReleaseModuleResponseCache } from "./module-response-cache.ts";
 import { clearSourceMissCache } from "./module-source-resolution-cache.ts";
 import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
@@ -1066,5 +1066,28 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       await Deno.remove(projectDir, { recursive: true });
       await Deno.remove(cacheDir, { recursive: true });
     }
+  });
+});
+
+describe("getDevModuleContentType", () => {
+  // The module server compiles TS/JSX/MDX sources to JavaScript before serving
+  // them. Typing the response from the requested source extension yields
+  // `application/typescript`, which browsers refuse to execute as a module.
+  for (const path of ["lib/constants.ts", "components/Badge.tsx", "a.jsx", "post.mdx", "a.md"]) {
+    it(`serves ${path} as JavaScript`, () => {
+      assertEquals(getDevModuleContentType(path), "application/javascript; charset=utf-8");
+    });
+  }
+
+  it("still serves .css as CSS", () => {
+    assertEquals(getDevModuleContentType("styles/globals.css"), "text/css; charset=utf-8");
+  });
+
+  it("still serves source maps as JSON", () => {
+    assertEquals(getDevModuleContentType("pages/index.js.map"), "application/json; charset=utf-8");
+  });
+
+  it("serves extensionless paths as JavaScript", () => {
+    assertEquals(getDevModuleContentType("pages/index"), "application/javascript; charset=utf-8");
   });
 });

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -1064,7 +1064,15 @@ function getModuleHeaders(
   };
 }
 
-function getDevModuleContentType(modulePath: string): string {
+/** Source extensions the module server compiles to JavaScript before serving. */
+const COMPILED_TO_JS_EXTENSIONS = /\.(?:tsx?|jsx|mdx|md)$/;
+
+/**
+ * Content type for a dev module response.
+ *
+ * Exported for testing.
+ */
+export function getDevModuleContentType(modulePath: string): string {
   const normalizedPath = modulePath.toLowerCase();
 
   if (normalizedPath.endsWith(".map") || normalizedPath.endsWith(".json")) {
@@ -1073,6 +1081,14 @@ function getDevModuleContentType(modulePath: string): string {
 
   if (normalizedPath.endsWith(".css")) {
     return "text/css; charset=utf-8";
+  }
+
+  // The request path carries the *source* extension, but the body we serve is
+  // always the compiled JavaScript. Typing the response from the source
+  // extension yields `application/typescript`, which browsers refuse to execute
+  // as a module under strict MIME checking.
+  if (COMPILED_TO_JS_EXTENSIONS.test(normalizedPath)) {
+    return "application/javascript; charset=utf-8";
   }
 
   const detected = getContentTypeForPath(normalizedPath);

--- a/src/transforms/import-rewriter/strategies/alias-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/alias-strategy.test.ts
@@ -190,6 +190,50 @@ describe("AliasStrategy", () => {
         // This is "correct" given the input, but may not match the expected module structure
         assertEquals(result.specifier, "../lib/utils.js");
       });
+
+      it("should rewrite an explicit .ts extension to .js", () => {
+        // A browser cannot execute a module served as application/typescript, so
+        // source extensions must never survive into an emitted specifier.
+        const result = aliasStrategy.rewrite(
+          makeInfo("@/lib/constants.ts"),
+          makeCtx({ filePath: "/project/pages/test/b-ts-ext-lib.tsx" }),
+        );
+        assertEquals(result.specifier, "../../lib/constants.js");
+      });
+
+      it("should rewrite an explicit .tsx extension to .js", () => {
+        const result = aliasStrategy.rewrite(
+          makeInfo("@/components/Badge.tsx"),
+          makeCtx({ filePath: "/project/pages/test/c-tsx-ext-component.tsx" }),
+        );
+        assertEquals(result.specifier, "../../components/Badge.js");
+      });
+
+      it("should not double-append .js to an explicit .js extension", () => {
+        const result = aliasStrategy.rewrite(
+          makeInfo("@/lib/legacy.js"),
+          makeCtx({ filePath: "/project/pages/index.tsx" }),
+        );
+        assertEquals(result.specifier, "../lib/legacy.js");
+      });
+    });
+
+    describe("source extensions in moduleServerUrl and ssr targets", () => {
+      it("should rewrite .ts to .js with moduleServerUrl", () => {
+        const result = aliasStrategy.rewrite(
+          makeInfo("@/lib/constants.ts"),
+          makeCtx({ moduleServerUrl: "/_vf_modules" }),
+        );
+        assertEquals(result.specifier, "/_vf_modules/lib/constants.js");
+      });
+
+      it("should rewrite .tsx to .js for ssr", () => {
+        const result = aliasStrategy.rewrite(
+          makeInfo("@/components/Badge.tsx"),
+          makeCtx({ target: "ssr" }),
+        );
+        assertEquals(result.specifier, "/_vf_modules/components/Badge.js");
+      });
     });
   });
 });

--- a/src/transforms/import-rewriter/strategies/alias-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/alias-strategy.ts
@@ -45,9 +45,10 @@ export class AliasStrategy implements ImportRewriteStrategy {
     const fileDir = relativeFilePath.substring(0, relativeFilePath.lastIndexOf("/"));
     const depth = fileDir.split("/").filter(Boolean).length;
 
-    let relativePath = depth === 0 ? `./${path}` : `${"../".repeat(depth)}${path}`;
+    const prefix = depth === 0 ? "./" : "../".repeat(depth);
+    let relativePath = normalizeExtension(`${prefix}${path}`);
 
-    if (!/\.(tsx?|jsx?|mjs|cjs|mdx|css)$/.test(relativePath)) {
+    if (!/\.(tsx?|jsx?|mjs|cjs|mdx|css|js)$/.test(relativePath)) {
       relativePath = `${relativePath}.js`;
     }
 


### PR DESCRIPTION
## Summary

A page importing `@/lib/constants.ts` rendered on the server but never hydrated, dying with a strict-MIME rejection. Two independent defects produced it:

**1. The emitter kept the source extension.** `AliasStrategy`'s relative-fallback branch (used when no `moduleServerUrl` is configured) built the specifier by hand and never called `normalizeExtension`, so an explicit `.ts`/`.tsx`/`.jsx`/`.mdx` survived into the emitted browser import. Its guard regex also omitted `js`, so an explicit `.js` specifier became `.js.js`. The other two branches already normalize; this one now matches them.

**2. The server typed the response from the wrong thing.** The dev module server derived `Content-Type` from the *requested* path, so `/_vf_modules/lib/constants.ts` was served as `application/typescript` — even though the body is compiled JavaScript. With `x-content-type-options: nosniff`, browsers refuse to execute that as a module.

Either fix alone would close the reported route; both are wrong independently, so both are fixed.

## Reproduction

- Routes: [`b-ts-ext-lib.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/b-ts-ext-lib.tsx), [`c-tsx-ext-component.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/c-tsx-ext-component.tsx), [`g-transitive-ts-ext.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/g-transitive-ts-ext.tsx)
- Tests: `src/transforms/import-rewriter/strategies/alias-strategy.test.ts`, `src/modules/server/module-server.test.ts`

## Test evidence

Before — red isolated exactly to the fallback branch (the `moduleServerUrl` and `ssr` branches already passed, which is why this only ever bit projects on the fallback path):

```
relative path fallback (no moduleServerUrl) ... FAILED (due to 2 failed steps)
FAILED | 0 passed (24 steps) | 1 failed (4 steps)
```

After:

```
ok | 17 passed (285 steps) | 0 failed
```

Wider suite: `deno task test:unit` → **2525 passed | 0 failed**.

## SSR evidence

The emitted client bundle no longer carries the source extension:

```
$ curl -s http://localhost:3010/_vf_modules/pages/test/b-ts-ext-lib.js | grep '^import'
import { COLORS } from "../../lib/constants.js"      # was "../../lib/constants.ts"
```

And a `.ts` URL is served as JavaScript regardless:

```
$ curl -sD- -o/dev/null http://localhost:3010/_vf_modules/lib/constants.ts | grep -i content-type
content-type: application/javascript; charset=utf-8   # was application/typescript; charset=utf-8
```

## Client evidence

Chromium sweep (`client-sweep.mjs`), console + network errors:

```
PASS /test/a-no-ext-no-server
PASS /test/b-ts-ext-lib          # was: MIME type application/typescript
PASS /test/c-tsx-ext-component   # was: MIME type application/typescript
```

The adjacent-route sweep is what caught that `g-transitive-ts-ext` shares the *symptom* but not this cause — it reaches `node:crypto` at render time, handled in the later PRs of this chain.

## Related

- Bug 1 of the reproducer matrix; [veryfront-issue-inbox#82](https://github.com/veryfront/veryfront-issue-inbox/issues/82)

---

**Chain:** this PR is part of a 13-PR chain fixing the bugs catalogued in
[veryfront-router-testing](https://github.com/mattboon/veryfront-router-testing).
Its base is the previous PR in the chain, so the diff shows only this fix.
The root of the chain is #2999 (`fix/ssr-lazy-import-graceful-degrade`) — **merge #2999 first**, then
rebase the chain onto `main`.

**Regression gate:** `deno task test:unit` → **2525 passed | 0 failed**; `deno task lint`,
`deno task fmt:check` and `deno task typecheck` all clean. The reproducer's full 56-route
matrix (`ROUTES.txt` + `sweep.sh`) was re-run after every fix: 7 routes improved, **0 regressed**.
A 46-route Chromium hydration sweep (`client-sweep.mjs`) backs the client-side claims.