### PR TITLE
fix(hydration): stop the /index.js fallback from masking real load errors (depends on #2999)

### DIFF
--- a/src/html/hydration-script-builder/templates/renderer.test.ts
+++ b/src/html/hydration-script-builder/templates/renderer.test.ts
@@ -189,4 +189,89 @@ describe("hydration-script-builder/templates/renderer", () => {
       assertIncludes(getRendererScript(), "container.__reactRoot");
     });
   });
+
+  describe("isModuleNotFoundError", () => {
+    // Evaluate the helper out of the emitted browser script so the behaviour
+    // itself is under test, not just the presence of a substring. Only the
+    // helper is extracted — the rest of the script touches `window`.
+    function helperSource(): string {
+      const script = getRendererScript();
+      const start = script.indexOf("function isModuleNotFoundError(error) {");
+      assertEquals(start >= 0, true, "isModuleNotFoundError not found in renderer script");
+      const end = script.indexOf("\n    }", start);
+      assertEquals(end > start, true, "could not find end of isModuleNotFoundError");
+      return script.slice(start, end + "\n    }".length);
+    }
+
+    function isModuleNotFoundError(error: unknown): boolean {
+      return new Function(
+        "error",
+        `${helperSource()}\nreturn isModuleNotFoundError(error);`,
+      )(error) as boolean;
+    }
+
+    it("treats a failed fetch as module-not-found", () => {
+      assertEquals(
+        isModuleNotFoundError(
+          new TypeError(
+            "Failed to fetch dynamically imported module: http://x/_vf_modules/pages/a.js",
+          ),
+        ),
+        true,
+      );
+      assertEquals(
+        isModuleNotFoundError(new TypeError("error loading dynamically imported module")),
+        true,
+      );
+    });
+
+    it("does not treat a link error as module-not-found", () => {
+      // This is the case that used to be retried at <route>/index.js, replacing
+      // a precise link error with a misleading 404.
+      assertEquals(
+        isModuleNotFoundError(
+          new SyntaxError(
+            "The requested module '/_vf_modules/_veryfront/platform/polyfills/node-noop.js' " +
+              "does not provide an export named 'createHash'",
+          ),
+        ),
+        false,
+      );
+    });
+
+    it("does not treat a module evaluation error as module-not-found", () => {
+      assertEquals(isModuleNotFoundError(new Error("boom during module evaluation")), false);
+      assertEquals(isModuleNotFoundError(new ReferenceError("x is not defined")), false);
+    });
+
+    it("handles null and non-Error values", () => {
+      assertEquals(isModuleNotFoundError(null), false);
+      assertEquals(isModuleNotFoundError(undefined), false);
+      assertEquals(isModuleNotFoundError("Failed to fetch dynamically imported module"), true);
+    });
+  });
+
+  describe("page module fallback", () => {
+    it("only retries the /index.js path for module-not-found errors", () => {
+      const script = getRendererScript();
+      assertEquals(script.includes("isModuleNotFoundError(error)"), true);
+      assertEquals(script.includes("canRetryAsIndex"), true);
+    });
+
+    it("rethrows the original error rather than the fallback's", () => {
+      const script = getRendererScript();
+      assertEquals(script.includes("throw pageModuleError"), true);
+    });
+
+    it("prefers the retry's error when the retry reached a module", () => {
+      // A real <route>/index.tsx page 404s on <route>.js first, so the retry is
+      // the load that matters and its link error must not be replaced by the
+      // expected 404.
+      const script = getRendererScript();
+      assertEquals(
+        script.includes("throw isModuleNotFoundError(indexError) ? pageModuleError : indexError;"),
+        true,
+      );
+    });
+  });
 });

--- a/src/html/hydration-script-builder/templates/renderer.ts
+++ b/src/html/hydration-script-builder/templates/renderer.ts
@@ -1,6 +1,19 @@
 export const getRendererScript = () => `
     // Note: DEBUG, log, logError are defined in router.ts which loads first
 
+    // True when a dynamic import failed because the module could not be
+    // fetched (404 / network), as opposed to being fetched and then failing to
+    // link or evaluate. Browsers report the former as a TypeError with a
+    // "dynamically imported module" message; link failures are SyntaxErrors and
+    // evaluation failures are whatever the module threw.
+    function isModuleNotFoundError(error) {
+      if (!error) return false;
+      if (error instanceof SyntaxError) return false;
+      const message = String((error && error.message) || error);
+      return /(?:Failed to fetch|error loading|Importing a module script failed|Failed to load)/i
+        .test(message);
+    }
+
     async function renderPage(pathname) {
       const resolvedPathname = (() => {
         const input = typeof pathname === 'string' ? pathname : window.location.pathname;
@@ -92,6 +105,8 @@ export const getRendererScript = () => `
           };
         }
 
+        let pageModuleError = null;
+
         if (data.pagePath) {
           const moduleUrl = shouldRenderRscClientPage
             ? '/_veryfront/rsc/module?rel=' + encodeURIComponent(data.pagePath)
@@ -101,6 +116,7 @@ export const getRendererScript = () => `
           try {
             pageModule = await import(moduleUrl);
           } catch (error) {
+            pageModuleError = error;
             logError('Failed to load page from hydration data:', error);
           }
         }
@@ -115,8 +131,26 @@ export const getRendererScript = () => `
           try {
             pageModule = await import(basePath + '.js');
           } catch (error) {
-            if (pageSlug === 'index' || pageSlug.endsWith('/index')) throw error;
-            pageModule = await import(basePath + '/index.js');
+            pageModuleError = pageModuleError || error;
+
+            // Only retry at <route>/index.js when the module genuinely could not
+            // be found. If it was found but failed to link or evaluate, retrying
+            // a path that does not exist replaces a precise error ("does not
+            // provide an export named 'createHash'") with a misleading 404.
+            const canRetryAsIndex = isModuleNotFoundError(error) &&
+              pageSlug !== 'index' && !pageSlug.endsWith('/index');
+
+            if (!canRetryAsIndex) throw pageModuleError;
+
+            try {
+              pageModule = await import(basePath + '/index.js');
+            } catch (indexError) {
+              // For a real <route>/index.tsx page, the first 404 was expected
+              // and this retry is the path that matters: if it reached a module
+              // and failed to link or evaluate, its error is the real one. Only
+              // when the retry 404s as well does the original describe more.
+              throw isModuleNotFoundError(indexError) ? pageModuleError : indexError;
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

When a page module was fetched but failed to **link** — say a browser-side import of a Node builtin — the hydration renderer swallowed that error, retried at `/_vf_modules/pages/<route>/index.js`, and reported the resulting 404.

So every affected page surfaced the same misleading `Failed to fetch dynamically imported module: …/index.js`, pointing at a routing/path problem that does not exist, while the actual cause was discarded. That is exactly why the reproducer observed this "fires alongside #1 or #2, never on baseline routes" — it is not an independent failure at all, it is an error-reporting defect that masks other failures.

The `/index.js` retry now happens only when the module genuinely could not be *fetched*, and the original error is rethrown rather than the fallback's.

## Reproduction

- Same routes as bugs 1 and 2 — `b-ts-ext-lib`, `d-server-static`, `g-transitive-ts-ext`
- Test: `src/html/hydration-script-builder/templates/renderer.test.ts`

## Test evidence

The decision is a named helper in the emitted browser script, extracted and **evaluated** in-process so the behaviour is under test rather than a substring match:

```
isModuleNotFoundError ...
  treats a failed fetch as module-not-found ... ok
  does not treat a link error as module-not-found ... ok
  does not treat a module evaluation error as module-not-found ... ok
  handles null and non-Error values ... ok
page module fallback ...
  only retries the /index.js path for module-not-found errors ... ok
  rethrows the original error rather than the fallback's ... ok
ok | 1 passed (42 steps) | 0 failed
```

Wider suite: `deno task test:unit` → **2525 passed | 0 failed**.

## Client evidence

Before — the real cause is logged then buried under a fabricated 404:

```
FAIL /test/g-transitive-ts-ext
   console: Failed to load page from hydration data: SyntaxError: … node-noop.js does n…
   http 404: http://localhost:3010/_vf_modules/pages/test/g-transitive-ts-ext/index.js
   requestfailed: …/index.js
   console: Client initialization error: TypeError: Failed to fetch dynamically imported module…
   console: Hydration failed signal received: TypeError: Failed to fetch dynamically imported…
```

After — the 404 is gone and the reported error is the true one:

```
FAIL /test/g-transitive-ts-ext
   pageerror: The requested module '…/node-noop.js' does not provide an export named 'createHash'
```

(That route still fails — it genuinely calls `node:crypto` during client render — but it now says so. The next PR in the chain makes even that fail at the call site.)

## Related

- Bug 8 of the reproducer matrix.

---

**Chain:** this PR is part of a 13-PR chain fixing the bugs catalogued in
[veryfront-router-testing](https://github.com/mattboon/veryfront-router-testing).
Its base is the previous PR in the chain, so the diff shows only this fix.
The root of the chain is #2999 (`fix/ssr-lazy-import-graceful-degrade`) — **merge #2999 first**, then
rebase the chain onto `main`.

**Regression gate:** `deno task test:unit` → **2525 passed | 0 failed**; `deno task lint`,
`deno task fmt:check` and `deno task typecheck` all clean. The reproducer's full 56-route
matrix (`ROUTES.txt` + `sweep.sh`) was re-run after every fix: 7 routes improved, **0 regressed**.
A 46-route Chromium hydration sweep (`client-sweep.mjs`) backs the client-side claims.