### PR TITLE
fix(transforms): make leaked node: named imports fail at the call site (depends on #2999)

### DIFF
--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -21,6 +21,7 @@ import type {
   TransformResult,
 } from "./types.ts";
 import {
+  browserNodeBuiltinImportsPlugin,
   browserServerExportsStripPlugin,
   compilePlugin,
   cssStripPlugin,
@@ -52,6 +53,7 @@ const BROWSER_PIPELINE: TransformPlugin[] = [
   compilePlugin,
   cssStripPlugin, // Strip CSS imports before they hit import resolution
   browserServerExportsStripPlugin, // Drop server-only hooks + their now-unused imports
+  browserNodeBuiltinImportsPlugin, // node:* named imports -> namespace + destructure
   resolveImportsPlugin, // Unified import resolution
   finalizePlugin,
 ];

--- a/src/transforms/pipeline/stages/browser-node-builtin-imports.test.ts
+++ b/src/transforms/pipeline/stages/browser-node-builtin-imports.test.ts
@@ -1,0 +1,198 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  browserNodeBuiltinImportsPlugin,
+  rewriteNodeBuiltinNamedImports,
+} from "./browser-node-builtin-imports.ts";
+import type { TransformContext } from "../types.ts";
+
+describe("browser-node-builtin-imports", () => {
+  it("converts a named import into a namespace import plus destructure", async () => {
+    const result = await rewriteNodeBuiltinNamedImports(
+      `import { createHash } from "node:crypto";\nexport const h = () => createHash("sha256");`,
+    );
+
+    // The named binding no longer has to exist on the polyfill at link time.
+    assertEquals(result.includes(`import { createHash } from "node:crypto"`), false);
+    assertStringIncludes(result, `import * as __vf_node_builtin_0 from "node:crypto";`);
+    assertStringIncludes(result, "const { createHash } = __vf_node_builtin_0;");
+    // The call site is untouched, so failure happens there.
+    assertStringIncludes(result, `createHash("sha256")`);
+  });
+
+  it("preserves aliases", async () => {
+    const result = await rewriteNodeBuiltinNamedImports(
+      `import { randomUUID as uuid } from "node:crypto";`,
+    );
+    assertStringIncludes(result, "const { randomUUID: uuid } = __vf_node_builtin_0;");
+  });
+
+  it("handles multiple bindings", async () => {
+    const result = await rewriteNodeBuiltinNamedImports(
+      `import { createHash, randomUUID } from "node:crypto";`,
+    );
+    assertStringIncludes(result, "const { createHash, randomUUID } = __vf_node_builtin_0;");
+  });
+
+  it("keeps a default binding alongside the namespace", async () => {
+    const result = await rewriteNodeBuiltinNamedImports(
+      `import crypto, { createHash } from "node:crypto";`,
+    );
+    assertStringIncludes(result, `import crypto from "node:crypto";`);
+    assertStringIncludes(result, "const { createHash } = __vf_node_builtin_0;");
+  });
+
+  it("leaves a default-only import alone", async () => {
+    const code = `import crypto from "node:crypto";\nexport const x = crypto;`;
+    assertEquals(await rewriteNodeBuiltinNamedImports(code), code);
+  });
+
+  it("leaves a namespace import alone", async () => {
+    const code = `import * as crypto from "node:crypto";`;
+    assertEquals(await rewriteNodeBuiltinNamedImports(code), code);
+  });
+
+  it("leaves a side-effect-only import alone", async () => {
+    const code = `import "node:crypto";`;
+    assertEquals(await rewriteNodeBuiltinNamedImports(code), code);
+  });
+
+  it("leaves non-node imports alone", async () => {
+    const code = `import { useState } from "react";`;
+    assertEquals(await rewriteNodeBuiltinNamedImports(code), code);
+  });
+
+  it("numbers each rewritten import uniquely", async () => {
+    const result = await rewriteNodeBuiltinNamedImports(
+      `import { createHash } from "node:crypto";\nimport { join } from "node:path";`,
+    );
+    assertStringIncludes(result, "__vf_node_builtin_0");
+    assertStringIncludes(result, "__vf_node_builtin_1");
+  });
+
+  // Regression: the stage used to look for " from ", which a production build
+  // never contains, so every non-dev build kept the link-time failure.
+  describe("minified input", () => {
+    it("rewrites a minified named import", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(
+        `import{createHash as h}from"node:crypto";export const x=()=>h("sha256");`,
+      );
+
+      assertStringIncludes(result, `import * as __vf_node_builtin_0 from "node:crypto";`);
+      assertStringIncludes(result, "const { createHash: h } = __vf_node_builtin_0;");
+      assertEquals(result.includes(`import{createHash as h}from"node:crypto"`), false);
+    });
+
+    it("rewrites a minified import with a default binding", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(
+        `import c,{createHash}from"node:crypto";export const x=c;`,
+      );
+
+      assertStringIncludes(result, `import c from "node:crypto";`);
+      assertStringIncludes(result, "const { createHash } = __vf_node_builtin_0;");
+    });
+
+    it("leaves a minified side-effect-only import alone", async () => {
+      const code = `import"node:crypto";`;
+      assertEquals(await rewriteNodeBuiltinNamedImports(code), code);
+    });
+
+    it("leaves a minified namespace import alone", async () => {
+      const code = `import*as c from"node:crypto";export const x=c;`;
+      assertEquals(await rewriteNodeBuiltinNamedImports(code), code);
+    });
+
+    it("rewrites both imports in a minified module", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(
+        `import{createHash}from"node:crypto";import{join}from"node:path";`,
+      );
+
+      // Statements are rewritten back to front, so the numbering runs the same
+      // way. Only uniqueness matters.
+      assertStringIncludes(result, "const { createHash } = __vf_node_builtin_1;");
+      assertStringIncludes(result, "const { join } = __vf_node_builtin_0;");
+      assertStringIncludes(result, `import * as __vf_node_builtin_1 from "node:crypto";`);
+      assertStringIncludes(result, `import * as __vf_node_builtin_0 from "node:path";`);
+    });
+
+    it("handles a single-quoted specifier", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(`import{createHash}from'node:crypto';`);
+      assertStringIncludes(result, `import * as __vf_node_builtin_0 from "node:crypto";`);
+      assertStringIncludes(result, "const { createHash } = __vf_node_builtin_0;");
+    });
+  });
+
+  // Regression: the namespace name used to be generated blind, so a module that
+  // already used it ended up with two bindings of the same name.
+  describe("name collisions", () => {
+    const declarationsOf = (code: string, name: string) =>
+      code.match(new RegExp(`(?:const|let|var|as)\\s+${name}\\b`, "g"))?.length ?? 0;
+
+    it("avoids a name the module already declares", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(
+        `const __vf_node_builtin_0 = 1;\nimport { createHash } from "node:crypto";`,
+      );
+
+      assertEquals(declarationsOf(result, "__vf_node_builtin_0"), 1);
+      assertStringIncludes(result, `import * as __vf_node_builtin__0 from "node:crypto";`);
+      assertStringIncludes(result, "const { createHash } = __vf_node_builtin__0;");
+      // The user's own binding survives untouched.
+      assertStringIncludes(result, "const __vf_node_builtin_0 = 1;");
+    });
+
+    it("avoids a name the module already imports", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(
+        `import { __vf_node_builtin_0 } from "./util.ts";\nimport { createHash } from "node:crypto";`,
+      );
+
+      assertStringIncludes(result, `import { __vf_node_builtin_0 } from "./util.ts";`);
+      assertStringIncludes(result, `import * as __vf_node_builtin__0 from "node:crypto";`);
+      assertStringIncludes(result, "const { createHash } = __vf_node_builtin__0;");
+    });
+
+    it("avoids a name aliased in by another import", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(
+        `import { x as __vf_node_builtin_0 } from "./util.ts";\nimport { join } from "node:path";`,
+      );
+
+      assertEquals(declarationsOf(result, "__vf_node_builtin_0"), 1);
+      assertStringIncludes(result, "const { join } = __vf_node_builtin__0;");
+    });
+
+    it("keeps stepping away until the name is free", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(
+        `const __vf_node_builtin_0 = 1;\nconst __vf_node_builtin__9 = 2;\n` +
+          `import { createHash } from "node:crypto";`,
+      );
+
+      assertStringIncludes(result, "const { createHash } = __vf_node_builtin___0;");
+    });
+
+    it("avoids a collision in minified source", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(
+        `import{createHash as h}from"node:crypto";const __vf_node_builtin_0=1;export const x=()=>h(__vf_node_builtin_0);`,
+      );
+
+      assertEquals(declarationsOf(result, "__vf_node_builtin_0"), 1);
+      assertStringIncludes(result, `import * as __vf_node_builtin__0 from "node:crypto";`);
+      assertStringIncludes(result, "const { createHash: h } = __vf_node_builtin__0;");
+    });
+
+    it("keeps the numbering unique across imports once renamed", async () => {
+      const result = await rewriteNodeBuiltinNamedImports(
+        `const __vf_node_builtin_0 = 1;\nimport { createHash } from "node:crypto";\n` +
+          `import { join } from "node:path";`,
+      );
+
+      assertStringIncludes(result, "const { join } = __vf_node_builtin__0;");
+      assertStringIncludes(result, "const { createHash } = __vf_node_builtin__1;");
+    });
+  });
+
+  it("only runs for the browser target", () => {
+    const ctx = (target: "browser" | "ssr") => ({ code: "", target }) as TransformContext;
+    assertEquals(browserNodeBuiltinImportsPlugin.condition?.(ctx("ssr")), false);
+    assertEquals(browserNodeBuiltinImportsPlugin.condition?.(ctx("browser")), true);
+  });
+});

--- a/src/transforms/pipeline/stages/browser-node-builtin-imports.ts
+++ b/src/transforms/pipeline/stages/browser-node-builtin-imports.ts
@@ -1,0 +1,129 @@
+/**
+ * Browser Node-Builtin Imports Stage — converts named imports of Node built-ins
+ * into namespace imports plus a destructure.
+ *
+ * Browser-bound imports of `node:*` are pointed at a noop polyfill whose whole
+ * job, per its own documentation, is that "the import succeeds, and any actual
+ * usage of the imported API fails at the call site, which surfaces the problem
+ * clearly instead of a cryptic module resolution error".
+ *
+ * That contract cannot hold for a *named* import. ESM resolves named imports at
+ * link time, so `import { createHash } from "node:crypto"` fails the whole
+ * module graph before a line of it runs:
+ *
+ *     SyntaxError: The requested module '.../node-noop.js' does not provide an
+ *     export named 'createHash'
+ *
+ * One leaked builtin therefore takes down hydration for the entire page, and the
+ * error names the polyfill rather than the offending import.
+ *
+ * Rewriting to a namespace import restores the intended behaviour: linking
+ * succeeds, the binding is `undefined`, and the failure happens where the API is
+ * actually called. It also makes the two node-noop variants (source and compiled
+ * binary, which export different names) behave identically.
+ */
+
+import type { TransformContext, TransformPlugin } from "../types.ts";
+import { TransformStage } from "../types.ts";
+import { rewriteImports } from "../../esm/lexer.ts";
+
+const NAMESPACE_PREFIX = "__vf_node_builtin_";
+
+/**
+ * Pick a namespace prefix the module has never used. A source file is free to
+ * declare or import `__vf_node_builtin_0` itself, and shadowing it would either
+ * duplicate the binding or silently redirect the user's own one.
+ *
+ * Substring containment is the right test even though it over-matches: every
+ * name we go on to generate starts with the prefix, so a module that never
+ * mentions the prefix cannot collide with any of them. That keeps this cheap on
+ * post-esbuild output, where parsing for real bindings is not an option.
+ */
+function pickNamespacePrefix(code: string): string {
+  let prefix = NAMESPACE_PREFIX;
+  while (code.includes(prefix)) prefix += "_";
+  return prefix;
+}
+
+/** Split a named-import clause into `local: imported` destructure pairs. */
+function toDestructurePairs(namedClause: string): string[] | null {
+  const pairs: string[] = [];
+
+  for (const rawPart of namedClause.split(",")) {
+    const part = rawPart.trim();
+    if (!part) continue;
+
+    const alias = part.match(/^([_$a-zA-Z][\w$]*)\s+as\s+([_$a-zA-Z][\w$]*)$/);
+    if (alias?.[1] && alias[2]) {
+      pairs.push(`${alias[1]}: ${alias[2]}`);
+      continue;
+    }
+
+    if (/^[_$a-zA-Z][\w$]*$/.test(part)) {
+      pairs.push(part);
+      continue;
+    }
+
+    return null; // Unrecognised clause — leave the statement alone.
+  }
+
+  return pairs.length > 0 ? pairs : null;
+}
+
+/**
+ * Rewrite `import { a, b as c } from "node:x"` to a namespace import plus a
+ * destructure. Default and namespace imports already link successfully and are
+ * left untouched.
+ */
+export async function rewriteNodeBuiltinNamedImports(code: string): Promise<string> {
+  if (!code.includes("node:")) return code;
+
+  let counter = 0;
+  const prefix = pickNamespacePrefix(code);
+
+  return await rewriteImports(code, (imp, statement) => {
+    if (!imp.n?.startsWith("node:")) return null;
+    if (imp.d > -1) return null; // dynamic import resolves lazily already
+    if (!statement.startsWith("import")) return null;
+
+    // The clause is everything between the `import` keyword and the specifier.
+    // Take it from the lexer's own offsets rather than by searching for
+    // " from ": esbuild emits `import{createHash as h}from"node:crypto";` when
+    // the build is minified, and there is no such substring in it.
+    const specifierStart = imp.s - imp.ss;
+    if (specifierStart <= "import".length || specifierStart > statement.length) return null;
+
+    const clause = statement
+      .slice("import".length, specifierStart - 1) // -1 for the opening quote
+      .replace(/\bfrom\s*$/, "")
+      .trim();
+
+    if (clause === "") return null; // side-effect-only import
+
+    const namedMatch = clause.match(/\{([^}]*)\}/);
+    if (!namedMatch?.[1]) return null; // no named bindings
+
+    const pairs = toDestructurePairs(namedMatch[1]);
+    if (!pairs) return null;
+
+    const namespace = `${prefix}${counter++}`;
+    const source = JSON.stringify(imp.n);
+
+    // Anything left of the named clause (a default binding) keeps its own import.
+    const leading = clause.replace(/\{[^}]*\}/, "").replace(/,\s*$/, "").replace(/^\s*,/, "")
+      .trim();
+
+    const defaultImport = leading ? `import ${leading} from ${source};` : "";
+
+    return `${defaultImport}import * as ${namespace} from ${source};` +
+      `const { ${pairs.join(", ")} } = ${namespace};`;
+  });
+}
+
+export const browserNodeBuiltinImportsPlugin: TransformPlugin = {
+  name: "browser-node-builtin-imports",
+  // Before import resolution, while the specifier is still `node:*`.
+  stage: TransformStage.COMPILE + 0.7,
+  condition: (ctx: TransformContext) => ctx.target === "browser",
+  transform: (ctx: TransformContext) => rewriteNodeBuiltinNamedImports(ctx.code),
+};

--- a/src/transforms/pipeline/stages/index.ts
+++ b/src/transforms/pipeline/stages/index.ts
@@ -8,6 +8,7 @@ export { parsePlugin } from "./parse.ts";
 export { compilePlugin } from "./compile.ts";
 export { cssStripPlugin } from "./ssr-css-strip.ts";
 export { browserServerExportsStripPlugin } from "./browser-server-exports-strip.ts";
+export { browserNodeBuiltinImportsPlugin } from "./browser-node-builtin-imports.ts";
 export { resolveImportsPlugin } from "./resolve-imports.ts";
 export { ssrVfModulesPlugin } from "./ssr-vf-modules.ts";
 export { ssrHttpStubPlugin } from "./ssr-http-stub.ts";


### PR DESCRIPTION
## Summary

> Found while fixing bug 2 — not in the reproducer's catalogue, but the same reported failure signature.

The browser noop polyfill for Node built-ins documents its own contract:

> If a server-only Node built-in leaks into a browser-served module, this prevents the import from crashing. Any actual usage of the imported API will fail at call-site, which surfaces the problem clearly instead of a cryptic module resolution error.

That contract cannot hold for a **named** import. ESM resolves named imports at link time, so `import { createHash } from "node:crypto"` in browser-bound code took down the entire module graph before a line of it ran — and the error named the polyfill rather than the offending import:

```
SyntaxError: The requested module '/_vf_modules/_veryfront/platform/polyfills/node-noop.js'
does not provide an export named 'createHash'
```

Named imports of `node:` builtins are now rewritten to a namespace import plus a destructure, so linking succeeds and the failure lands where the API is actually called.

This also resolves a real source/binary divergence: `src/platform/polyfills/node-noop.ts` exports `{ nodeNoop, default }` while the compiled-binary copy in `module-server.ts` exports only `default`, so identical source could link or fail depending on how the framework was served. Via a namespace import, both behave identically.

## Reproduction

- Routes: [`g-transitive-ts-ext.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/g-transitive-ts-ext.tsx), [`app/use-server/page.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/app/use-server/page.tsx) — components that call `node:crypto` at render time, rather than inside a data hook
- Test: `src/transforms/pipeline/stages/browser-node-builtin-imports.test.ts`

## Test evidence

```
ok | 23 passed (204 steps) | 0 failed      # src/transforms/pipeline/
```

Covers aliases, multiple bindings, a default binding alongside named ones, and the untouched cases (default-only, namespace, side-effect-only, non-node).

Wider suite: `deno task test:unit` → **2525 passed | 0 failed**.

## Client evidence

Before — one leaked builtin kills the whole page, blaming the polyfill:

```
FAIL /test/g-transitive-ts-ext
   pageerror: The requested module '…/node-noop.js' does not provide an export named 'createHash'
FAIL /use-server
FAIL /test-app/d-server-static
```

After — the module links, and the error names the real API at its real call site:

```
FAIL /test/g-transitive-ts-ext
   pageerror: createHash is not a function
FAIL /use-server
   pageerror: createHash is not a function
FAIL /test-app/d-server-static
   pageerror: createHash is not a function
```

These three routes **should** still fail: they genuinely invoke `node:crypto` during client render, which no polyfill can make work. The point is that the framework now says so precisely, exactly as the polyfill's documentation promises, instead of emitting a link error against a file the author never wrote.

## Related

- Discovered while fixing bug 2 (#3002); shares the reported signature of bugs 1/2/8.

---

**Chain:** this PR is part of a 13-PR chain fixing the bugs catalogued in
[veryfront-router-testing](https://github.com/mattboon/veryfront-router-testing).
Its base is the previous PR in the chain, so the diff shows only this fix.
The root of the chain is #2999 (`fix/ssr-lazy-import-graceful-degrade`) — **merge #2999 first**, then
rebase the chain onto `main`.

**Regression gate:** `deno task test:unit` → **2525 passed | 0 failed**; `deno task lint`,
`deno task fmt:check` and `deno task typecheck` all clean. The reproducer's full 56-route
matrix (`ROUTES.txt` + `sweep.sh`) was re-run after every fix: 7 routes improved, **0 regressed**.
A 46-route Chromium hydration sweep (`client-sweep.mjs`) backs the client-side claims.