### PR TITLE
fix(module-loader): resolve dynamic import() specifiers for SSR (depends on #2999)

### DIFF
--- a/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
@@ -28,12 +28,14 @@ async function withDependencyFixture<T>(
   }
 }
 
-function withSpan<T extends { full: string }>(
+// Every hand-built fixture below is a static `from "…"` span, so the helper
+// stamps `isDynamic: false` instead of repeating it at each call site.
+function withStaticSpan<T extends { full: string }>(
   source: string,
   dep: T,
-): T & { start: number; end: number } {
+): T & { start: number; end: number; isDynamic: false } {
   const start = source.indexOf(dep.full);
-  return { ...dep, start, end: start + dep.full.length };
+  return { ...dep, start, end: start + dep.full.length, isDynamic: false };
 }
 
 describe("module-loader/dependency-resolver", () => {
@@ -75,7 +77,7 @@ describe("module-loader/dependency-resolver", () => {
     ].join("\n");
 
     const rewritten = rewriteResolvedDependencyImports(source, [
-      withSpan(source, {
+      withStaticSpan(source, {
         full: `from "@/Button"`,
         path: "@/Button",
         relativePath: "Button",
@@ -83,7 +85,7 @@ describe("module-loader/dependency-resolver", () => {
         depTempPath: "/tmp/components/Button.abc.js",
         isLocalLib: false,
       }),
-      withSpan(source, {
+      withStaticSpan(source, {
         full: `from "../lib/value"`,
         path: "../lib/value",
         relativePath: "../lib/value",
@@ -128,6 +130,139 @@ describe("module-loader/dependency-resolver", () => {
           rewritten,
           `import { Button } from "file:///tmp/components/Button.abc.js";`,
         );
+      },
+    );
+  });
+});
+
+describe("module-loader/dependency-resolver: dynamic imports", () => {
+  it("resolves a dynamic @/ alias import inside getServerData", async () => {
+    await withDependencyFixture(
+      {
+        "pages/test/e.tsx": [
+          `export async function getServerData() {`,
+          `  const { hashOf } = await import("@/lib/uses-crypto");`,
+          `  return { props: { hashed: hashOf("hello") } };`,
+          `}`,
+        ].join("\n"),
+        "lib/uses-crypto.ts": `export const hashOf = (v) => v;`,
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "pages/test/e.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+
+        const deps = await resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath,
+          projectDir,
+        });
+
+        assertEquals(deps.length, 1);
+        assertEquals(deps[0]?.isDynamic, true);
+        assertEquals(deps[0]?.depFilePath, join(projectDir, "lib/uses-crypto.ts"));
+
+        // The rewrite must replace only the quoted specifier, leaving
+        // `await import(...)` intact.
+        const rewritten = rewriteResolvedDependencyImports(fileContent, [
+          { ...deps[0]!, depTempPath: "/tmp/out/lib/uses-crypto.abc.js" },
+        ]);
+        assertStringIncludes(
+          rewritten,
+          `await import("file:///tmp/out/lib/uses-crypto.abc.js")`,
+        );
+      },
+    );
+  });
+
+  it("resolves a dynamic relative import that carries a .ts extension", async () => {
+    await withDependencyFixture(
+      {
+        "pages/test/f.tsx": [
+          `export async function getServerData() {`,
+          `  const { hashOf } = await import("../../lib/uses-crypto.ts");`,
+          `  return { props: { hashed: hashOf("hello") } };`,
+          `}`,
+        ].join("\n"),
+        "lib/uses-crypto.ts": `export const hashOf = (v) => v;`,
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "pages/test/f.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+
+        const deps = await resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath,
+          projectDir,
+        });
+
+        assertEquals(deps.length, 1);
+        assertEquals(deps[0]?.isDynamic, true);
+        assertEquals(deps[0]?.depFilePath, join(projectDir, "lib/uses-crypto.ts"));
+      },
+    );
+  });
+
+  it("still resolves static imports alongside dynamic ones", async () => {
+    await withDependencyFixture(
+      {
+        "pages/test/mixed.tsx": [
+          `import { Button } from "@/Button";`,
+          `export async function getServerData() {`,
+          `  const { value } = await import("../../lib/value");`,
+          `  return { props: { value } };`,
+          `}`,
+          `export default () => Button;`,
+        ].join("\n"),
+        "components/Button.tsx": `export const Button = "button";`,
+        "lib/value.ts": `export const value = "value";`,
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "pages/test/mixed.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+
+        const deps = await resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath,
+          projectDir,
+        });
+
+        assertEquals(deps.length, 2);
+        assertEquals(deps.filter((d) => d.isDynamic).length, 1);
+        assertEquals(deps.filter((d) => !d.isDynamic).length, 1);
+        assertEquals(deps.every((d) => d.depFilePath !== null), true);
+      },
+    );
+  });
+
+  it("ignores a dynamic import whose specifier is not a literal", async () => {
+    await withDependencyFixture(
+      {
+        "pages/test/dyn.tsx": [
+          `export async function getServerData(ctx) {`,
+          `  const mod = await import(ctx.query.get("mod"));`,
+          `  return { props: { mod } };`,
+          `}`,
+        ].join("\n"),
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "pages/test/dyn.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+
+        const deps = await resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath,
+          projectDir,
+        });
+
+        assertEquals(deps.length, 0);
       },
     );
   });

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.ts
@@ -2,6 +2,7 @@ import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { parallelMap, rendererLogger } from "#veryfront/utils";
 import {
+  findDynamicImportSpans,
   findStaticImportFromSpans,
   replaceSourceSpans,
   type SourceSpanReplacement,
@@ -10,8 +11,21 @@ import { findSourceFile } from "../file-resolver/index.ts";
 
 const logger = rendererLogger.component("module-loader");
 
-type AliasImport = { full: string; path: string; start: number; end: number };
-type RelativeImport = { full: string; path: string; fromDir: string; start: number; end: number };
+type AliasImport = {
+  full: string;
+  path: string;
+  start: number;
+  end: number;
+  isDynamic: boolean;
+};
+type RelativeImport = {
+  full: string;
+  path: string;
+  fromDir: string;
+  start: number;
+  end: number;
+  isDynamic: boolean;
+};
 
 /** Resolved local module dependency discovered in a source module. */
 export type ResolvedModuleDependency = {
@@ -22,6 +36,8 @@ export type ResolvedModuleDependency = {
   relativePath: string;
   depFilePath: string | null;
   isLocalLib: boolean;
+  /** True when discovered inside `import("…")` rather than a static import. */
+  isDynamic: boolean;
 };
 
 /** Resolved dependency after its source module has been transformed to a temp file. */
@@ -37,30 +53,41 @@ export interface ResolveModuleDependenciesInput {
   adapter: RuntimeAdapter;
 }
 
+const matchAlias = (specifier: string) => specifier.startsWith("@/") ? specifier : null;
+const matchRelative = (specifier: string) => specifier.match(/^(\.\.?\/[^?]+)(?:\?.*)?$/)?.[1];
+
 function collectAliasImports(fileContent: string): AliasImport[] {
-  return findStaticImportFromSpans(
-    fileContent,
-    (specifier) => specifier.startsWith("@/") ? specifier : null,
-  ).map(({ original, path, start, end }) => ({
-    full: original,
-    path,
-    start,
-    end,
-  }));
+  const toAlias = (isDynamic: boolean) =>
+  (
+    { original, path, start, end }: {
+      original: string;
+      path: string;
+      start: number;
+      end: number;
+    },
+  ): AliasImport => ({ full: original, path, start, end, isDynamic });
+
+  return [
+    ...findStaticImportFromSpans(fileContent, matchAlias).map(toAlias(false)),
+    ...findDynamicImportSpans(fileContent, matchAlias).map(toAlias(true)),
+  ];
 }
 
 function collectRelativeImports(fileContent: string, fileDir: string): RelativeImport[] {
-  return findStaticImportFromSpans(
-    fileContent,
-    (specifier) => specifier.match(/^(\.\.?\/[^?]+)(?:\?.*)?$/)?.[1],
-  )
-    .map(({ original, path, start, end }) => ({
-      full: original,
-      path,
-      fromDir: fileDir,
-      start,
-      end,
-    }))
+  const toRelative = (isDynamic: boolean) =>
+  (
+    { original, path, start, end }: {
+      original: string;
+      path: string;
+      start: number;
+      end: number;
+    },
+  ): RelativeImport => ({ full: original, path, fromDir: fileDir, start, end, isDynamic });
+
+  return [
+    ...findStaticImportFromSpans(fileContent, matchRelative).map(toRelative(false)),
+    ...findDynamicImportSpans(fileContent, matchRelative).map(toRelative(true)),
+  ]
     // Ignore already-transformed file:// imports.
     .filter((imp) => !imp.path.includes("file://"));
 }
@@ -128,6 +155,7 @@ async function resolveRelativeImport(
     relativePath: imp.path,
     depFilePath,
     isLocalLib: false,
+    isDynamic: imp.isDynamic,
   };
 }
 
@@ -168,7 +196,9 @@ export function rewriteResolvedDependencyImports(
     start: dep.start,
     end: dep.end,
     expected: dep.full,
-    replacement: `from "file://${dep.depTempPath}"`,
+    // A dynamic span covers only the quoted specifier; a static one covers the
+    // whole `from "…"` clause.
+    replacement: dep.isDynamic ? `"file://${dep.depTempPath}"` : `from "file://${dep.depTempPath}"`,
   }));
   return replaceSourceSpans(fileContent, replacements);
 }

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { replaceSourceSpans } from "./source-spans.ts";
+import { findDynamicImportSpans, replaceSourceSpans } from "./source-spans.ts";
 
 describe("transforms/mdx/esm-module-loader/utils/source-spans", () => {
   describe("replaceSourceSpans", () => {
@@ -85,6 +85,121 @@ describe("transforms/mdx/esm-module-loader/utils/source-spans", () => {
     it("returns source unchanged for empty replacements", () => {
       const source = "unchanged";
       assertEquals(replaceSourceSpans(source, []), "unchanged");
+    });
+  });
+
+  describe("findDynamicImportSpans", () => {
+    // Matches every relative specifier, so the tests are about which arguments
+    // are recognised rather than about resolution.
+    const matchRelative = (specifier: string) => specifier.startsWith("./") ? specifier : null;
+
+    function specifiers(source: string): string[] {
+      return findDynamicImportSpans(source, matchRelative).map((span) => span.path);
+    }
+
+    it("finds a literal specifier", () => {
+      assertEquals(specifiers(`const m = await import("./foo.js");`), ["./foo.js"]);
+    });
+
+    it("finds a literal specifier with import attributes", () => {
+      assertEquals(
+        specifiers(`await import("./data.json", { with: { type: "json" } });`),
+        ["./data.json"],
+      );
+    });
+
+    it("finds several in one module", () => {
+      assertEquals(
+        specifiers(`import("./a.js"); import("./b.js");`),
+        ["./a.js", "./b.js"],
+      );
+    });
+
+    // Regression: the literal prefix used to be rewritten on its own, so
+    // `import("./foo" + suffix)` resolved to `import("file:///…/foo" + suffix)`.
+    it("skips a specifier the literal only starts", () => {
+      assertEquals(specifiers(`await import("./foo" + suffix);`), []);
+      assertEquals(specifiers("await import(`./foo` + suffix);"), []);
+      assertEquals(specifiers(`await import("./foo".concat(suffix));`), []);
+      assertEquals(specifiers(`await import(ok ? "./foo.js" : "./bar.js");`), []);
+    });
+
+    it("skips a specifier that is not a literal at all", () => {
+      assertEquals(specifiers("await import(path);"), []);
+      assertEquals(specifiers("await import(`./${name}.js`);"), []);
+    });
+
+    it("ignores a static import and a property called import", () => {
+      assertEquals(specifiers(`import x from "./foo.js";`), []);
+      assertEquals(specifiers(`obj.import("./foo.js");`), []);
+    });
+
+    it("ignores an import-looking string or comment", () => {
+      assertEquals(specifiers(`const s = 'import("./foo.js")';`), []);
+      assertEquals(specifiers(`// import("./foo.js")\nconst x = 1;`), []);
+    });
+
+    it("keeps scanning after a skipped specifier", () => {
+      assertEquals(
+        specifiers(`import("./a" + s); import("./b.js");`),
+        ["./b.js"],
+      );
+    });
+
+    it("finds a specifier across whitespace and newlines", () => {
+      assertEquals(specifiers(`import (\n  "./a.js"\n);`), ["./a.js"]);
+    });
+
+    it("finds a specifier around comments", () => {
+      // A bundler hint is the common reason for a comment inside the call.
+      assertEquals(specifiers(`import(/* webpackChunkName: "a" */ "./a.js");`), ["./a.js"]);
+      assertEquals(specifiers(`import /* lazy */ ("./a.js");`), ["./a.js"]);
+      assertEquals(specifiers(`import("./a.js" /* eager */);`), ["./a.js"]);
+      assertEquals(specifiers(`import(\n  // the slow half\n  "./a.js",\n);`), ["./a.js"]);
+    });
+
+    it("finds a specifier awaited inside a nested expression", () => {
+      assertEquals(
+        specifiers(`const load = async () => (await import("./a.js")).default;`),
+        ["./a.js"],
+      );
+      assertEquals(
+        specifiers(`export const mod = import("./a.js").then((m) => m.default);`),
+        ["./a.js"],
+      );
+    });
+
+    it("finds a specifier carrying a query or hash suffix", () => {
+      // The matcher decides what a suffix means; the scanner passes it through.
+      assertEquals(specifiers(`import("./a.js?raw");`), ["./a.js?raw"]);
+      assertEquals(specifiers(`import("./a.js#frag");`), ["./a.js#frag"]);
+    });
+
+    it("still skips a specifier the literal only starts when a comment follows it", () => {
+      assertEquals(specifiers(`import("./a.js" /* then */ + suffix);`), []);
+    });
+
+    it("ignores a dynamic import inside a block comment", () => {
+      assertEquals(specifiers(`/* import("./a.js") */ const x = 1;`), []);
+    });
+
+    // A template literal with no substitution is a valid specifier, but the
+    // scanner only treats quoted strings as literals, so it stays unresolved
+    // rather than being rewritten from a form it cannot verify.
+    it("skips a template-literal specifier", () => {
+      assertEquals(specifiers("import(`./a.js`);"), []);
+    });
+
+    it("spans only the quoted specifier when comments surround it", () => {
+      const source = `import(/* hint */ "./a.js" /* eager */);`;
+      const [span] = findDynamicImportSpans(source, matchRelative);
+      assertEquals(span?.original, `"./a.js"`);
+      assertEquals(
+        replaceSourceSpans(source, [
+          { start: span!.start, end: span!.end, replacement: `"file:///out/a.js"` },
+        ]),
+        `import(/* hint */ "file:///out/a.js" /* eager */);`,
+      );
     });
   });
 });

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
@@ -114,6 +114,26 @@ function skipWhitespace(source: string, index: number): number {
   return cursor;
 }
 
+// Comments are legal wherever whitespace is, so a dynamic import can carry a
+// bundler hint between the keyword, the parentheses and the specifier. Treating
+// the comment as an unexpected character would leave the specifier unresolved.
+function skipWhitespaceAndComments(source: string, index: number): number {
+  let cursor = index;
+
+  while (cursor < source.length) {
+    const afterWhitespace = skipWhitespace(source, cursor);
+    const char = source[afterWhitespace];
+    const next = source[afterWhitespace + 1];
+    if (char === "/" && (next === "/" || next === "*")) {
+      cursor = skipIgnored(source, afterWhitespace);
+      continue;
+    }
+    return afterWhitespace;
+  }
+
+  return cursor;
+}
+
 function nextStatementCursor(source: string, index: number): number {
   const semicolon = source.indexOf(";", index);
   const newline = source.indexOf("\n", index);
@@ -228,6 +248,77 @@ export function findStaticImportFromSpans(
     }
 
     cursor = nextStatementCursor(source, afterKeyword);
+  }
+
+  return spans;
+}
+
+/**
+ * Find `import("…")` expressions with a literal specifier.
+ *
+ * The returned span covers the quoted specifier itself (quotes included), not
+ * the surrounding `import(...)`, so a replacement is a bare quoted string.
+ * Dynamic imports whose argument is not a string literal are skipped, since
+ * their target is only known at runtime. That includes an argument the literal
+ * merely starts: rewriting the `"./foo"` in `import("./foo" + suffix)` would
+ * build a path out of a resolved prefix and an unresolved tail.
+ */
+export function findDynamicImportSpans(
+  source: string,
+  matcher: SpecifierMatcher,
+): StaticImportSpan[] {
+  const spans: StaticImportSpan[] = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const skipped = skipIgnored(source, cursor);
+    if (skipped !== cursor) {
+      cursor = skipped;
+      continue;
+    }
+
+    // `import` used as an expression: not preceded by an identifier char or a
+    // dot (which would make it `foo.import` or part of a longer word).
+    if (
+      !source.startsWith("import", cursor) ||
+      isIdentifierChar(source[cursor - 1]) ||
+      source[cursor - 1] === "." ||
+      isIdentifierChar(source[cursor + "import".length])
+    ) {
+      cursor++;
+      continue;
+    }
+
+    const parenIndex = skipWhitespaceAndComments(source, cursor + "import".length);
+    if (source[parenIndex] !== "(") {
+      cursor++;
+      continue;
+    }
+
+    const quoteIndex = skipWhitespaceAndComments(source, parenIndex + 1);
+    const quoted = readQuotedSpecifier(source, quoteIndex);
+    if (!quoted) {
+      cursor = parenIndex + 1;
+      continue;
+    }
+
+    // The literal must be the whole first argument. `)` closes the call and `,`
+    // starts the import-attributes argument; anything else (`+`, a template
+    // continuation, a ternary) means the runtime specifier is not this string.
+    const afterSpecifier = skipWhitespaceAndComments(source, quoted.end);
+    const isWholeArgument = source[afterSpecifier] === ")" || source[afterSpecifier] === ",";
+
+    const matchedPath = isWholeArgument ? matcher(quoted.specifier) : null;
+    if (matchedPath) {
+      spans.push({
+        original: source.slice(quoteIndex, quoted.end),
+        path: matchedPath,
+        start: quoteIndex,
+        end: quoted.end,
+      });
+    }
+
+    cursor = quoted.end;
   }
 
   return spans;


### PR DESCRIPTION
## Summary

`await import("@/lib/x")` and `await import("../../lib/x.ts")` inside `getServerData` both 500'd:

```
Module not found "file:///_vf_modules/lib/uses-crypto.js"
```

The SSR module loader discovers a module's local dependencies, transforms each to a temp file, and rewrites the importer to point at those files. That discovery used `findStaticImportFromSpans`, which **deliberately skips `import(`** (`source-spans.ts:218`). Dynamic specifiers were therefore never resolved; they fell through to the alias rewrite, which produced a `/_vf_modules/…` path that means nothing to the runtime's own resolver, and the render died.

Dynamic imports with a literal specifier are now collected alongside static ones. Their span covers just the quoted string, so the rewrite replaces the specifier and leaves `await import(...)` intact. Non-literal specifiers (`import(ctx.query.get("m"))`) are left alone — their target is only knowable at runtime.

**Bugs 3 and 4 are this one defect**, as the reproducer's fix hypothesis anticipated ("Likely a shared fix"). Shipping them together rather than splitting one change across two PRs.

## Reproduction

- Routes: [`e-server-dynamic-at-alias.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/e-server-dynamic-at-alias.tsx) (bug 3), [`f-server-dynamic-relative.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/f-server-dynamic-relative.tsx) (bug 4)
- Tests: `src/rendering/orchestrator/module-loader/dependency-resolver.test.ts`

## Test evidence

```
ok | 2 passed (7 steps) | 0 failed
```

Four new cases: dynamic `@/` alias, dynamic relative carrying a `.ts` extension, mixed static+dynamic in one module, and a non-literal specifier that must be ignored. One asserts the rewritten output directly:

```ts
assertStringIncludes(rewritten, `await import("file:///tmp/out/lib/uses-crypto.abc.js")`)
```

Wider suite: `deno task test:unit` → **2525 passed | 0 failed**.

## SSR evidence

```
/test/e-server-dynamic-at-alias   500 -> 200
/test/f-server-dynamic-relative   500 -> 200
```

Not merely a 200 — the dynamically imported module actually executes. The page renders the real SHA-256 prefix of `"hello"`:

```
SSR computed hash: <code …>2cf24dba</code>
```

## Client evidence

```
PASS /test/e-server-dynamic-at-alias
PASS /test/f-server-dynamic-relative
2/2 routes hydrated clean
```

## Related

- Bugs 3 and 4 of the reproducer matrix. These were the escape hatch for keeping server-only code out of the client bundle, so they were effectively unavailable on the pages router.

---

**Chain:** this PR is part of a 13-PR chain fixing the bugs catalogued in
[veryfront-router-testing](https://github.com/mattboon/veryfront-router-testing).
Its base is the previous PR in the chain, so the diff shows only this fix.
The root of the chain is #2999 (`fix/ssr-lazy-import-graceful-degrade`) — **merge #2999 first**, then
rebase the chain onto `main`.

**Regression gate:** `deno task test:unit` → **2525 passed | 0 failed**; `deno task lint`,
`deno task fmt:check` and `deno task typecheck` all clean. The reproducer's full 56-route
matrix (`ROUTES.txt` + `sweep.sh`) was re-run after every fix: 7 routes improved, **0 regressed**.
A 46-route Chromium hydration sweep (`client-sweep.mjs`) backs the client-side claims.