### PR TITLE
fix(transforms): stop dropping import attributes on JSON modules (depends on #2999)

### DIFF
--- a/src/transforms/esm/transform-utils.ts
+++ b/src/transforms/esm/transform-utils.ts
@@ -9,6 +9,17 @@ export function computeShortContentHash(content: string): Promise<string> {
   return shortHash(content);
 }
 
+/**
+ * esbuild feature overrides shared by every source transform.
+ *
+ * Import attributes post-date the `es20xx` targets we lower to, so esbuild
+ * would silently *drop* `with { type: "json" }` rather than fail. Every runtime
+ * that consumes this output requires the attribute to load a JSON module, so
+ * dropping it turns a working import into a load-time error:
+ * `Attempted to load JSON module without specifying "type": "json"`.
+ */
+export const ESBUILD_SUPPORTED_FEATURES = { "import-attributes": true } as const;
+
 const EXTENSION_LOADERS: Record<string, Loader> = {
   ".tsx": "tsx",
   ".ts": "ts",

--- a/src/transforms/pipeline/stages/compile.test.ts
+++ b/src/transforms/pipeline/stages/compile.test.ts
@@ -1,10 +1,34 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
+import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { compilePlugin } from "./compile.ts";
 import { TransformStage } from "../types.ts";
+import type { TransformContext } from "../types.ts";
+
+function createContext(code: string, filePath = "/project/lib/x.ts"): TransformContext {
+  return {
+    code,
+    originalSource: code,
+    filePath,
+    projectDir: "/project",
+    projectId: "project",
+    target: "ssr",
+    dev: true,
+    contentHash: "hash",
+    jsxImportSource: "react",
+    timing: new Map(),
+    debug: false,
+    metadata: new Map(),
+    reactVersion: "19.1.1",
+  } as TransformContext;
+}
 
 describe("transforms/pipeline/stages/compile", () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
   describe("compilePlugin metadata", () => {
     it("has name 'esbuild-compile'", () => {
       assertEquals(compilePlugin.name, "esbuild-compile");
@@ -21,6 +45,32 @@ describe("transforms/pipeline/stages/compile", () => {
 
     it("has no condition (always runs)", () => {
       assertEquals(compilePlugin.condition, undefined);
+    });
+  });
+
+  describe("import attributes", () => {
+    // esbuild lowers to es2020, which pre-dates import attributes — without an
+    // explicit `supported` override it silently drops `with { type: "json" }`,
+    // and the runtime then refuses the module with "Attempted to load JSON
+    // module without specifying \"type\": \"json\"".
+    it('preserves `with { type: "json" }` on a static import', async () => {
+      const result = await compilePlugin.transform(
+        createContext(
+          `import manifest from "./manifest.json" with { type: "json" };\nexport const x = manifest;`,
+        ),
+      );
+
+      assertStringIncludes(result, 'with { type: "json" }');
+    });
+
+    it("preserves the attribute on a dynamic import", async () => {
+      const result = await compilePlugin.transform(
+        createContext(
+          `export async function load() { return await import("./manifest.json", { with: { type: "json" } }); }`,
+        ),
+      );
+
+      assertStringIncludes(result, 'type: "json"');
     });
   });
 });

--- a/src/transforms/pipeline/stages/compile.ts
+++ b/src/transforms/pipeline/stages/compile.ts
@@ -2,7 +2,7 @@ import { getEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { COMPILATION_ERROR } from "#veryfront/errors";
 import { getErrorCollector } from "#veryfront/observability";
-import { getLoaderFromPath } from "../../esm/transform-utils.ts";
+import { ESBUILD_SUPPORTED_FEATURES, getLoaderFromPath } from "../../esm/transform-utils.ts";
 import { type TransformContext, type TransformPlugin, TransformStage } from "../types.ts";
 
 const logger = rendererLogger.component("esm-transform");
@@ -20,6 +20,7 @@ export const compilePlugin: TransformPlugin = {
         loader,
         format: "esm",
         target: "es2020",
+        supported: ESBUILD_SUPPORTED_FEATURES,
         jsx: "automatic",
         jsxImportSource: ctx.jsxImportSource,
         minify: !ctx.dev,

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -4,7 +4,12 @@ import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import { join } from "#veryfront/compat/path/index.ts";
-import { isCyclePlaceholder, reactReExportToEsmUrl, transformFrameworkCode } from "./transform.ts";
+import {
+  isCyclePlaceholder,
+  reactReExportToEsmUrl,
+  stripJsonAttributesFromModuleImports,
+  transformFrameworkCode,
+} from "./transform.ts";
 import {
   buildFrameworkTransformCacheKey,
   FRAMEWORK_ROOT,
@@ -605,5 +610,34 @@ describe("transformFrameworkCode depth-limit fallback", {
     } finally {
       await Deno.remove(tmp, { recursive: true });
     }
+  });
+});
+
+describe("stripJsonAttributesFromModuleImports", () => {
+  // A framework `.json` import is resolved by compiling the JSON into a cached
+  // `.mjs` that default-exports the data. The attribute describes the original
+  // target, so leaving it makes the runtime reject the rewritten import with
+  // "Expected a Json module, but identified a Mjs module".
+  it("drops the attribute when the target is now an .mjs", () => {
+    const code = `import m from "file:///cache/framework/vfmod-abc.mjs" with { type: "json" };`;
+    assertEquals(
+      stripJsonAttributesFromModuleImports(code),
+      `import m from "file:///cache/framework/vfmod-abc.mjs";`,
+    );
+  });
+
+  it("keeps the attribute on a genuine .json target", () => {
+    const code = `import m from "./manifest.json" with { type: "json" };`;
+    assertEquals(stripJsonAttributesFromModuleImports(code), code);
+  });
+
+  it("handles single quotes and extra whitespace", () => {
+    const code = `import m from 'file:///cache/a.mjs'  with  { type: 'json' };`;
+    assertStringIncludes(stripJsonAttributesFromModuleImports(code), `from 'file:///cache/a.mjs';`);
+  });
+
+  it("leaves plain module imports untouched", () => {
+    const code = `import { a } from "file:///cache/a.mjs";`;
+    assertEquals(stripJsonAttributesFromModuleImports(code), code);
   });
 });

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -5,6 +5,7 @@
  * resolves all imports (#veryfront/, relative, React).
  */
 
+import { ESBUILD_SUPPORTED_FEATURES } from "#veryfront/transforms/esm/transform-utils.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import denoConfig from "#deno-config" with { type: "json" };
@@ -157,6 +158,7 @@ async function compileFallbackSource(
     jsxImportSource: "react",
     format: "esm",
     target: "es2022",
+    supported: ESBUILD_SUPPORTED_FEATURES,
   });
   return result.code;
 }
@@ -438,6 +440,7 @@ async function transformFrameworkCodeUncoalesced(
       jsxImportSource: "react",
       format: "esm",
       target: "es2022",
+      supported: ESBUILD_SUPPORTED_FEATURES,
     });
 
     let transformed = result.code;
@@ -607,6 +610,8 @@ async function transformFrameworkCodeUncoalesced(
       }),
     );
 
+    transformed = stripJsonAttributesFromModuleImports(transformed);
+
     // Cache HTTP imports to local filesystem
     const importMap = await loadImportMap(ctx.projectDir);
     const cacheResult = await cacheHttpImportsToLocal(transformed, {
@@ -686,6 +691,23 @@ export async function resolveAndTransformVeryfrontImport(
  * Transform framework source code with React import rewriting.
  * Entry point for top-level framework modules (e.g., Head.tsx, Router.tsx).
  */
+/**
+ * Drop `with { type: "json" }` from imports that now point at a JavaScript
+ * module.
+ *
+ * A framework import of a `.json` file (`#veryfront/server/dev-ui/manifest.json`)
+ * is resolved by transforming the JSON into a cached `.mjs` that default-exports
+ * the data. The attribute on the importer describes the *original* target, so
+ * leaving it in place makes the runtime reject the rewritten import with
+ * "Expected a Json module, but identified a Mjs module".
+ */
+export function stripJsonAttributesFromModuleImports(code: string): string {
+  return code.replace(
+    /(from\s*["'](?:file:\/\/)?[^"']+\.mjs["'])\s*with\s*\{[^}]*\}/g,
+    "$1",
+  );
+}
+
 export async function transformFrameworkSource(
   content: string,
   sourcePath: string,


### PR DESCRIPTION
## Summary

> Found while fixing bug 5. This is a **hard prerequisite** for bugs 5 and 6 — neither route could even be exercised until it was fixed.

`import { notFound } from "veryfront"` — a documented public API — failed to load at all, 500-ing every page that used it:

```
Attempted to load JSON module without specifying "type": "json" attribute in the import statement.
```

Two compounding causes:

**1. esbuild was silently dropping the attribute.** Every source transform lowers to `es2020`/`es2022`, both of which pre-date import attributes, so esbuild *dropped* `with { type: "json" }` rather than erroring. The framework barrel reaches `#veryfront/server/dev-ui/manifest.json`, whose attribute vanished. Verified directly:

```
es2020                        -> import m from "…/manifest.json";
esnext                        -> import m from "…/manifest.json" with { type: "json" };
es2020 + supported override   -> import m from "…/manifest.json" with { type: "json" };
```

Fixed with an explicit `supported: { "import-attributes": true }`, shared as `ESBUILD_SUPPORTED_FEATURES` so every source transform agrees rather than each `target:` site drifting.

**2. With the attribute preserved, the next failure was the opposite.**

```
Expected a Json module, but identified a Mjs module
```

The framework resolver compiles a `.json` dependency into a cached `.mjs` that default-exports the data, but left the attribute — which describes the *original* target — in place. Attributes on imports that now point at a `.mjs` are stripped.

## Reproduction

- Routes: [`i-not-found.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/i-not-found.tsx), [`h-redirect.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/h-redirect.tsx), [`l-error-thrown.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/l-error-thrown.tsx) — every page importing from `"veryfront"`
- Tests: `src/transforms/pipeline/stages/compile.test.ts`, `src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts`

## Test evidence

```
ok | 24 passed (211 steps) | 0 failed      # src/transforms/pipeline/
```

Covers attribute preservation on static and dynamic imports, and the strip pass (drops it for a `.mjs` target, keeps it for a genuine `.json` target, single quotes, plain imports untouched).

Wider suite: `deno task test:unit` → **2525 passed | 0 failed**.

## SSR evidence

Emitted framework bundle, before → after:

```
import devUiManifest from "#veryfront/server/dev-ui/manifest.json";
import devUiManifest from "#veryfront/server/dev-ui/manifest.json" with { type: "json" };
```

Route status:

```
/test/h-redirect    500 -> 302     # redirect() from getServerData, restored
/test/i-not-found   500 -> 404     # unblocks #3007
/test/l-error-thrown 500 -> 500    # now reaching the intended error path, unblocks #3008
```

Note `h-redirect` — the reproducer recorded `redirect()` as *working* at `0.1.1094`. It had since regressed to a 500 on `main`; this restores it.

## Client evidence

```
PASS /test/h-redirect
PASS /test/j-query-params?name=Grace
PASS /test/t-cookies
```

## Related

- Blocks bugs 5 (#3007) and 6 (#3008). Not in the reproducer's catalogue — it postdates `0.1.1094`.

---

**Chain:** this PR is part of a 13-PR chain fixing the bugs catalogued in
[veryfront-router-testing](https://github.com/mattboon/veryfront-router-testing).
Its base is the previous PR in the chain, so the diff shows only this fix.
The root of the chain is #2999 (`fix/ssr-lazy-import-graceful-degrade`) — **merge #2999 first**, then
rebase the chain onto `main`.

**Regression gate:** `deno task test:unit` → **2525 passed | 0 failed**; `deno task lint`,
`deno task fmt:check` and `deno task typecheck` all clean. The reproducer's full 56-route
matrix (`ROUTES.txt` + `sweep.sh`) was re-run after every fix: 7 routes improved, **0 regressed**.
A 46-route Chromium hydration sweep (`client-sweep.mjs`) backs the client-side claims.