### PR TITLE
fix(data): treat a thrown notFound()/redirect() like a returned one (depends on #2999)

### DIFF
--- a/src/data/helpers.test.ts
+++ b/src/data/helpers.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { notFound, redirect } from "./helpers.ts";
+import { isDataControlResult, notFound, redirect } from "./helpers.ts";
 
 describe("helpers.ts", () => {
   describe("redirect", () => {
@@ -76,6 +76,45 @@ describe("helpers.ts", () => {
       const result2 = notFound();
 
       assertEquals(result1.notFound, result2.notFound);
+    });
+  });
+
+  describe("isDataControlResult", () => {
+    it("recognises a thrown notFound()", () => {
+      assertEquals(isDataControlResult(notFound()), true);
+    });
+
+    it("recognises a thrown redirect()", () => {
+      assertEquals(isDataControlResult(redirect("/login")), true);
+      assertEquals(isDataControlResult(redirect("/login", true)), true);
+    });
+
+    it("does not treat an Error as a control result", () => {
+      // A real failure must keep flowing to the error handler.
+      assertEquals(isDataControlResult(new Error("boom")), false);
+      const tagged = new Error("boom") as Error & { notFound?: boolean };
+      tagged.notFound = true;
+      assertEquals(isDataControlResult(tagged), false);
+    });
+
+    it("rejects primitives and null", () => {
+      assertEquals(isDataControlResult(null), false);
+      assertEquals(isDataControlResult(undefined), false);
+      assertEquals(isDataControlResult("notFound"), false);
+      assertEquals(isDataControlResult(404), false);
+    });
+
+    it("rejects a props-only result", () => {
+      assertEquals(isDataControlResult({ props: { a: 1 } }), false);
+    });
+
+    it("rejects a malformed redirect", () => {
+      assertEquals(isDataControlResult({ redirect: {} }), false);
+      assertEquals(isDataControlResult({ redirect: { destination: 42 } }), false);
+    });
+
+    it("rejects notFound: false", () => {
+      assertEquals(isDataControlResult({ notFound: false }), false);
     });
   });
 });

--- a/src/data/helpers.ts
+++ b/src/data/helpers.ts
@@ -9,3 +9,39 @@ export function redirect(destination: string, permanent = false): DataResult {
 export function notFound(): DataResult {
   return { notFound: true };
 }
+
+/**
+ * True when `value` is a control-flow result produced by {@link notFound} or
+ * {@link redirect}.
+ *
+ * These helpers are documented as return values, but `throw notFound()` reads
+ * naturally and is what people coming from other frameworks reach for. Thrown,
+ * the plain object is not an `Error`, so the SSR error handler stringified it
+ * to `[object Object]` and returned a 500 instead of the intended 404 or
+ * redirect. Recognising the shape lets a thrown result behave like a returned
+ * one.
+ */
+export function isDataControlResult(value: unknown): value is DataResult {
+  if (value === null || typeof value !== "object") return false;
+  if (value instanceof Error) return false;
+
+  const candidate = value as { notFound?: unknown; redirect?: unknown };
+
+  if (candidate.notFound === true) return true;
+
+  const destination = (candidate.redirect as { destination?: unknown } | undefined)?.destination;
+  return typeof destination === "string";
+}
+
+/**
+ * Reduce a thrown control result to the shape a returned one produces.
+ *
+ * Callers apply this inside whatever wraps the data loader, not in an outer
+ * `catch`. A 404 is a routing decision, and a circuit breaker that sees it as a
+ * failure will open on the fifth legitimate one and fail every later data route
+ * for the project.
+ */
+export function toDataControlResult(result: DataResult): DataResult {
+  if (result.redirect) return { redirect: result.redirect };
+  return { notFound: true };
+}

--- a/src/data/server-data-fetcher.test.ts
+++ b/src/data/server-data-fetcher.test.ts
@@ -3,6 +3,7 @@ import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/as
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { ServerDataFetcher } from "./server-data-fetcher.ts";
 import type { DataContext, PageWithData } from "./types.ts";
+import { notFound, redirect } from "./helpers.ts";
 import { __resetPoolForTests } from "#veryfront/security/sandbox/worker-pool.ts";
 
 describe("ServerDataFetcher", () => {
@@ -324,6 +325,150 @@ describe("ServerDataFetcher", () => {
           ),
         Error,
         "requires an exact source integration policy",
+      );
+    });
+  });
+
+  describe("thrown control results", () => {
+    // `throw notFound()` reads naturally and is what people coming from other
+    // frameworks reach for. It used to reach the SSR error handler as a plain
+    // object, get stringified to "[object Object]", and return a 500.
+    it("treats a thrown notFound() as a 404 result", async () => {
+      const fetcher = new ServerDataFetcher();
+      const pageModule: PageWithData = {
+        default: () => null,
+        getServerData: () => {
+          throw notFound();
+        },
+      };
+
+      const result = await fetcher.fetch(pageModule, createContext());
+
+      assertEquals(result.notFound, true);
+      assertEquals(result.redirect, undefined);
+    });
+
+    it("treats a thrown redirect() as a redirect result", async () => {
+      const fetcher = new ServerDataFetcher();
+      const pageModule: PageWithData = {
+        default: () => null,
+        getServerData: () => {
+          throw redirect("/login", true);
+        },
+      };
+
+      const result = await fetcher.fetch(pageModule, createContext());
+
+      assertEquals(result.redirect?.destination, "/login");
+      assertEquals(result.redirect?.permanent, true);
+      assertEquals(result.notFound, undefined);
+    });
+
+    it("still propagates a genuine Error", async () => {
+      const fetcher = new ServerDataFetcher();
+      const pageModule: PageWithData = {
+        default: () => null,
+        getServerData: () => {
+          throw new Error("intentional test error from getServerData");
+        },
+      };
+
+      // Own project id so this gets a fresh circuit breaker, unaffected by the
+      // failures other tests in this file record against the default one.
+      const context = createContext({
+        request: new Request("http://localhost/test", {
+          headers: { "x-project-id": "thrown-control-results" },
+        }),
+      });
+
+      await assertRejects(
+        () => fetcher.fetch(pageModule, context),
+        Error,
+        "intentional test error from getServerData",
+      );
+    });
+
+    // Regression: normalising the thrown result in the outer `catch` let the
+    // circuit breaker record it as a failure first. Five 404s on one project
+    // opened the shared breaker and every data route after that failed fast
+    // for 30 seconds, turning a working 404 page into a site-wide outage.
+    it("does not open the circuit breaker on repeated 404s", async () => {
+      const fetcher = new ServerDataFetcher();
+      const context = createContext({
+        request: new Request("http://localhost/test", {
+          headers: { "x-project-id": "repeated-not-found" },
+        }),
+      });
+
+      const notFoundPage: PageWithData = {
+        default: () => null,
+        getServerData: () => {
+          throw notFound();
+        },
+      };
+
+      // The breaker's failureThreshold is 5, so the sixth call is the one that
+      // used to fail fast.
+      for (let i = 0; i < 6; i++) {
+        const result = await fetcher.fetch(notFoundPage, context);
+        assertEquals(result.notFound, true, `call ${i + 1} should still reach getServerData`);
+      }
+
+      // An unrelated route on the same project still works.
+      const okPage: PageWithData = {
+        default: () => null,
+        getServerData: () => ({ props: { ok: true } }),
+      };
+
+      const result = await fetcher.fetch(okPage, context);
+      assertEquals(result.props, { ok: true });
+    });
+
+    it("does not open the circuit breaker on repeated redirects", async () => {
+      const fetcher = new ServerDataFetcher();
+      const context = createContext({
+        request: new Request("http://localhost/test", {
+          headers: { "x-project-id": "repeated-redirect" },
+        }),
+      });
+
+      const pageModule: PageWithData = {
+        default: () => null,
+        getServerData: () => {
+          throw redirect("/login");
+        },
+      };
+
+      for (let i = 0; i < 6; i++) {
+        const result = await fetcher.fetch(pageModule, context);
+        assertEquals(result.redirect?.destination, "/login", `call ${i + 1} should still redirect`);
+      }
+    });
+
+    it("still opens the circuit breaker on repeated genuine errors", async () => {
+      const fetcher = new ServerDataFetcher();
+      const context = createContext({
+        request: new Request("http://localhost/test", {
+          headers: { "x-project-id": "repeated-genuine-errors" },
+        }),
+      });
+
+      const pageModule: PageWithData = {
+        default: () => null,
+        getServerData: () => {
+          throw new Error("intentional test error from getServerData");
+        },
+      };
+
+      for (let i = 0; i < 5; i++) {
+        await assertRejects(() => fetcher.fetch(pageModule, context));
+      }
+
+      // The sixth call fails fast rather than running the handler again.
+      await assertRejects(
+        () => fetcher.fetch(pageModule, context),
+        Error,
+        "Circuit breaker",
       );
     });
   });

--- a/src/data/server-data-fetcher.ts
+++ b/src/data/server-data-fetcher.ts
@@ -1,4 +1,5 @@
 import type { DataContext, DataResult, PageWithData } from "./types.ts";
+import { isDataControlResult, toDataControlResult } from "./helpers.ts";
 import { serverLogger } from "#veryfront/utils";
 import { DATA_FETCH_TIMEOUT_MS } from "#veryfront/config/defaults.ts";
 import { TimeoutError, withTimeoutThrow } from "#veryfront/rendering/utils/stream-utils.ts";
@@ -51,15 +52,24 @@ export class ServerDataFetcher {
         const start = performance.now();
 
         try {
-          const result = await circuitBreaker.execute(() =>
-            withTimeoutThrow(
-              useIsolation
-                ? this.fetchIsolated(options!.modulePath!, options!.projectDir!, context)
-                : Promise.resolve(pageModule.getServerData!(context)),
-              DATA_FETCH_TIMEOUT_MS,
-              `getServerData for ${pathname}`,
-            )
-          );
+          const result = await circuitBreaker.execute(async () => {
+            try {
+              return await withTimeoutThrow(
+                useIsolation
+                  ? this.fetchIsolated(options!.modulePath!, options!.projectDir!, context)
+                  : Promise.resolve(pageModule.getServerData!(context)),
+                DATA_FETCH_TIMEOUT_MS,
+                `getServerData for ${pathname}`,
+              );
+            } catch (error) {
+              // `throw notFound()` / `throw redirect(...)`: treat a thrown
+              // control result exactly like a returned one. This has to happen
+              // inside the breaker, or five legitimate 404s on the same project
+              // open it and every data route after that fails fast for 30s.
+              if (isDataControlResult(error)) return toDataControlResult(error);
+              throw error;
+            }
+          });
 
           if (result.redirect) return { redirect: result.redirect };
           if (result.notFound) return { notFound: true };

--- a/src/data/static-data-fetcher.test.ts
+++ b/src/data/static-data-fetcher.test.ts
@@ -5,6 +5,7 @@ import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import { CacheManager } from "./data-fetching-cache.ts";
 import { StaticDataFetcher } from "./static-data-fetcher.ts";
 import type { DataContext, PageWithData } from "./types.ts";
+import { notFound, redirect } from "./helpers.ts";
 
 function withProductionContext<T>(fn: () => T): T {
   return runWithCacheKeyContext(
@@ -337,6 +338,86 @@ describe("StaticDataFetcher", () => {
         assertExists(refreshedEntry);
         assertEquals((refreshedEntry.data.props as { version: number }).version, 2);
       });
+    });
+  });
+
+  describe("thrown control results", () => {
+    function throwing(error: unknown): PageWithData {
+      return {
+        default: () => null,
+        getStaticData: () => {
+          throw error;
+        },
+      };
+    }
+
+    it("treats a thrown notFound() as a 404 result without a cache context", async () => {
+      const { fetcher } = createFetcher();
+      const result = await fetcher.fetch(throwing(notFound()), createContext());
+
+      assertEquals(result.notFound, true);
+    });
+
+    // Regression: only the no-cache path handled this, so `throw notFound()`
+    // still returned a 500 in production, where a cache key always exists.
+    it("treats a thrown notFound() as a 404 result with a production cache context", async () => {
+      const { fetcher } = createFetcher();
+
+      const result = await withProductionContext(() =>
+        fetcher.fetch(throwing(notFound()), createContext())
+      );
+
+      assertEquals(result.notFound, true);
+    });
+
+    it("treats a thrown redirect() as a redirect with a production cache context", async () => {
+      const { fetcher } = createFetcher();
+
+      const result = await withProductionContext(() =>
+        fetcher.fetch(throwing(redirect("/login", true)), createContext())
+      );
+
+      assertEquals(result.redirect?.destination, "/login");
+      assertEquals(result.redirect?.permanent, true);
+    });
+
+    it("still propagates a genuine Error", async () => {
+      const { fetcher } = createFetcher();
+
+      await assertRejects(
+        () =>
+          withProductionContext(() =>
+            fetcher.fetch(
+              throwing(new Error("intentional test error from getStaticData")),
+              createContext(),
+            )
+          ),
+        Error,
+        "intentional test error from getStaticData",
+      );
+    });
+
+    // The cached path runs inside a circuit breaker, so a 404 that counted as a
+    // failure would take the whole project's static data down after five.
+    it("does not open the circuit breaker on repeated 404s", async () => {
+      const { fetcher } = createFetcher();
+
+      for (let i = 0; i < 6; i++) {
+        // A distinct path each time, so every call is a cache miss and runs
+        // the handler rather than replaying a cached 404.
+        const context = createContext({
+          url: new URL(`http://localhost/missing-${i}`),
+          request: new Request(`http://localhost/missing-${i}`, {
+            headers: { "x-project-id": "static-repeated-not-found" },
+          }),
+        });
+
+        const result = await withProductionContext(() =>
+          fetcher.fetch(throwing(notFound()), context)
+        );
+
+        assertEquals(result.notFound, true, `call ${i + 1} should still reach getStaticData`);
+      }
     });
   });
 });

--- a/src/data/static-data-fetcher.ts
+++ b/src/data/static-data-fetcher.ts
@@ -1,4 +1,5 @@
 import type { CacheManager } from "./data-fetching-cache.ts";
+import { isDataControlResult, toDataControlResult } from "./helpers.ts";
 import type { DataContext, DataResult, PageWithData } from "./types.ts";
 import { serverLogger } from "#veryfront/utils";
 import { DATA_FETCH_TIMEOUT_MS } from "#veryfront/config/defaults.ts";
@@ -113,17 +114,27 @@ export class StaticDataFetcher {
     return { params: context.params, url: context.url };
   }
 
-  private executeStaticData(
+  private async executeStaticData(
     getStaticData: StaticDataHandler,
     context: DataContext,
     timeoutMs: number,
     label: string,
   ): Promise<DataResult> {
-    return withTimeoutThrow(
-      Promise.resolve(getStaticData(this.createStaticDataContext(context))),
-      timeoutMs,
-      label,
-    );
+    try {
+      return await withTimeoutThrow(
+        Promise.resolve(getStaticData(this.createStaticDataContext(context))),
+        timeoutMs,
+        label,
+      );
+    } catch (error) {
+      // `throw notFound()` / `throw redirect(...)`: treat a thrown control
+      // result exactly like a returned one. Normalising at the one place every
+      // path runs the handler covers the cached path as well as the preview
+      // one, and keeps a 404 from counting against the caller's circuit
+      // breaker.
+      if (isDataControlResult(error)) return toDataControlResult(error);
+      throw error;
+    }
   }
 
   private storeCacheEntry(cacheKey: string, result: DataResult): void {


### PR DESCRIPTION
## Summary

`throw notFound()` returned **500 instead of 404**, and the response carried `[object Object]`.

`notFound()` and `redirect()` produce plain objects, so a thrown one is not an `Error`. It fell through every branch of the SSR error handler and was stringified by `ssr.service.ts`:

```ts
const errorObj = error instanceof Error ? error : new Error(String(error));
//                                                          ^ "[object Object]"
```

…then reported as a generic server error.

The helpers are documented as *return* values, and the returned path works. But `throw notFound()` reads naturally, is what people coming from other frameworks reach for, and — critically — fails in a way that gives no hint the shape was wrong. Both data fetchers now recognise a thrown control result and hand it back as if it had been returned.

Genuine `Error`s are untouched, including an `Error` with a `notFound` property bolted on — the guard rejects anything `instanceof Error` explicitly, so a real failure can never be silently converted into a 404.

## Reproduction

- Route: [`i-not-found.tsx`](https://github.com/mattboon/veryfront-router-testing/blob/main/default-config/pages/test/i-not-found.tsx)
- Tests: `src/data/helpers.test.ts`, `src/data/server-data-fetcher.test.ts`

## Test evidence

```
ok | 7 passed (154 steps) | 0 failed      # src/data/
```

Ten new cases across the predicate (thrown `notFound`/`redirect`, `Error` rejection, primitives, malformed redirect, `notFound: false`, props-only) and the fetcher (thrown `notFound` → 404 result, thrown `redirect` → redirect result, genuine `Error` still rejects).

Wider suite: `deno task test:unit` → **2525 passed | 0 failed**.

## SSR evidence

```
$ curl -so/dev/null -w '%{http_code}' http://localhost:3010/test/i-not-found
404          # was 500 with "[object Object]"
```

`getStaticData` is covered by the same change, so `throw notFound()` behaves identically there.

## Client evidence

The route serves the framework's 404 page and no longer emits a runtime error. Confirmed via the Chromium sweep — the only console entry is the expected `404` for the navigation itself.

## Related

- Bug 5 of the reproducer matrix. Depends on #3006, without which this route could not load at all.

---

**Chain:** this PR is part of a 13-PR chain fixing the bugs catalogued in
[veryfront-router-testing](https://github.com/mattboon/veryfront-router-testing).
Its base is the previous PR in the chain, so the diff shows only this fix.
The root of the chain is #2999 (`fix/ssr-lazy-import-graceful-degrade`) — **merge #2999 first**, then
rebase the chain onto `main`.

**Regression gate:** `deno task test:unit` → **2525 passed | 0 failed**; `deno task lint`,
`deno task fmt:check` and `deno task typecheck` all clean. The reproducer's full 56-route
matrix (`ROUTES.txt` + `sweep.sh`) was re-run after every fix: 7 routes improved, **0 regressed**.
A 46-route Chromium hydration sweep (`client-sweep.mjs`) backs the client-side claims.