### PR TITLE
fix(api): make ctx.json() with no arguments read the request body (depends on #2999)

### DIFF
--- a/docs/guides/api-routes.md
+++ b/docs/guides/api-routes.md
@@ -25,7 +25,9 @@ export function GET() {
 }
 ```
 
-Use `pages/api/**` in the pages router. Export named HTTP method handlers or a `default` fallback handler. Each handler receives an `APIContext` as `ctx`; use `ctx.request` for the raw request, `ctx.params` for route params, `ctx.query` for query parameters, and `ctx.json()` or `Response.json()` to return JSON.
+Use `pages/api/**` in the pages router. Export named HTTP method handlers or a `default` fallback handler. Each handler receives an `APIContext` as `ctx`; use `ctx.request` for the raw request, `ctx.params` for route params, and `ctx.query` for query parameters.
+
+The `ctx.json` helper is intentionally overloaded by arity: `ctx.json()` reads the request body as JSON, while `ctx.json(data, init?)` returns a JSON `Response`. Use `ctx.request` directly when you need lower-level request APIs such as streaming, form data, or text parsing.
 
 ```ts
 // pages/api/hello.ts
@@ -65,7 +67,7 @@ Export any standard HTTP method:
 
 ```ts
 // app/api/users/route.ts
-const users = [{ id: "user_123", name: "Ada Lovelace" }];
+const users = [{ id: "user_123", name: "Test User" }];
 
 export async function GET() {
   return Response.json(users);
@@ -90,20 +92,20 @@ The same pages router route uses `ctx`:
 // pages/api/users.ts
 import type { APIContext } from "veryfront";
 
-const users = [{ id: "user_123", name: "Ada Lovelace" }];
+const users = [{ id: "user_123", name: "Test User" }];
 
 export async function GET(ctx: APIContext) {
   return ctx.json(users);
 }
 
 export async function POST(ctx: APIContext) {
-  const body = await ctx.request.json();
+  const body = await ctx.json();
   const user = { id: "user_456", ...body };
   return ctx.json(user, { status: 201 });
 }
 
 export async function DELETE(ctx: APIContext) {
-  const { id } = await ctx.request.json();
+  const { id } = await ctx.json() as { id?: string };
   if (!id) return ctx.json({ error: "Missing id" }, { status: 400 });
   return new Response(null, { status: 204 });
 }

--- a/src/routing/api/context-builder.test.ts
+++ b/src/routing/api/context-builder.test.ts
@@ -1,7 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createContext, normalizeParams, parseCookies } from "./context-builder.ts";
+import {
+  type APIContext,
+  createContext,
+  createJsonHelper,
+  normalizeParams,
+  parseCookies,
+} from "./context-builder.ts";
 import type { RouteMatch } from "./api-route-matcher.ts";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 
@@ -380,5 +386,96 @@ describe("API Context Builder", () => {
       assertEquals(body.name, "Test User");
       assertEquals(body.email, "test@example.com");
     });
+  });
+});
+
+describe("createContext: ctx.json arity", () => {
+  function ctxFor(request: Request): APIContext {
+    return createContext(request, { params: {} } as RouteMatch, mockFs);
+  }
+
+  it("parses the request body when called with no arguments", async () => {
+    // `await ctx.json()` used to stringify `undefined` into a Response, so the
+    // handler received an object that serialised back out as `{}`.
+    const ctx = ctxFor(
+      new Request("http://localhost/api/echo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ x: 1, nested: { y: "z" } }),
+      }),
+    );
+
+    assertEquals(await ctx.json(), { x: 1, nested: { y: "z" } });
+  });
+
+  it("still builds a JSON response when called with data", async () => {
+    const ctx = ctxFor(new Request("http://localhost/api/echo"));
+    const response = ctx.json({ received: true });
+
+    assertEquals(response instanceof Response, true);
+    assertEquals(response.headers.get("Content-Type"), "application/json");
+    assertEquals(await response.json(), { received: true });
+  });
+
+  it("honours a ResponseInit when building a response", async () => {
+    const ctx = ctxFor(new Request("http://localhost/api/echo"));
+    const response = ctx.json({ error: "nope" }, { status: 422 });
+
+    assertEquals(response.status, 422);
+    assertEquals(await response.json(), { error: "nope" });
+  });
+
+  // Regression: worker isolation built its own `ctx.json` as a response helper
+  // only, so `await ctx.json()` still returned a Response under
+  // WORKER_ISOLATION_API=1. Both contexts now build it from this one function,
+  // so a handler behaves the same whether or not isolation is enabled.
+  describe("createJsonHelper", () => {
+    it("reads the request body with no arguments", async () => {
+      const json = createJsonHelper(
+        new Request("http://localhost/api/echo", {
+          method: "POST",
+          body: JSON.stringify({ isolated: true }),
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      assertEquals(await json(), { isolated: true });
+    });
+
+    it("builds a response when given data", async () => {
+      const json = createJsonHelper(new Request("http://localhost/api/echo"));
+      const response = json({ ok: true }, { status: 201 });
+
+      assertEquals(response instanceof Response, true);
+      assertEquals(response.status, 201);
+      assertEquals(response.headers.get("Content-Type"), "application/json");
+      assertEquals(await response.json(), { ok: true });
+    });
+
+    it("is the same helper the request context exposes", async () => {
+      const request = new Request("http://localhost/api/echo", {
+        method: "POST",
+        body: JSON.stringify({ shared: true }),
+      });
+
+      const viaHelper = await createJsonHelper(request.clone())();
+      const viaContext = await ctxFor(request).json();
+
+      assertEquals(viaContext, viaHelper);
+    });
+  });
+
+  it("rejects when the body is not valid JSON", async () => {
+    const ctx = ctxFor(
+      new Request("http://localhost/api/echo", { method: "POST", body: "not json" }),
+    );
+
+    let threw = false;
+    try {
+      await ctx.json();
+    } catch (_) {
+      threw = true;
+    }
+    assertEquals(threw, true);
   });
 });

--- a/src/routing/api/context-builder.ts
+++ b/src/routing/api/context-builder.ts
@@ -14,7 +14,16 @@ export interface APIContext {
   cookies: Record<string, string>;
   headers: Headers;
   url: URL;
-  json: (data: unknown, init?: ResponseInit) => Response;
+  /**
+   * Read the request body as JSON, or build a JSON response.
+   *
+   * `ctx.json()` with no arguments parses and returns the request body.
+   * `ctx.json(data, init?)` returns a JSON `Response`.
+   */
+  json: {
+    (): Promise<unknown>;
+    (data: unknown, init?: ResponseInit): Response;
+  };
   text: (data: string, init?: ResponseInit) => Response;
   fs: FileSystemAdapter;
 }
@@ -33,14 +42,38 @@ function createResponse(
   });
 }
 
+/**
+ * Build the `ctx.json` helper for a request.
+ *
+ * Overloaded on arity. `ctx.json(data)` builds a response; `ctx.json()` reads
+ * the request body, which is what handlers reach for, and what the zero-arg
+ * form was previously misread as. It used to stringify `undefined` into a
+ * Response, so `await ctx.json()` yielded a Response object that serialised
+ * back out as `{}` and silently dropped every posted payload.
+ *
+ * Exported because the isolation Worker builds its own context and has to
+ * behave identically. Handlers must not care which one ran them.
+ */
+export function createJsonHelper(request: Request): APIContext["json"] {
+  function json(): Promise<unknown>;
+  function json(data: unknown, init?: ResponseInit): Response;
+  function json(...args: [] | [unknown, ResponseInit?]): Response | Promise<unknown> {
+    if (args.length === 0) return request.json();
+    const [data, init] = args;
+    return createResponse(JSON.stringify(data), "application/json", init);
+  }
+
+  return json;
+}
+
 export function createContext(
   request: Request,
   match: RouteMatch,
   fs: FileSystemAdapter,
 ): APIContext {
   const url = new URL(request.url);
-  const json = (data: unknown, init?: ResponseInit): Response =>
-    createResponse(JSON.stringify(data), "application/json", init);
+  const json = createJsonHelper(request);
+
   const text = (data: string, init?: ResponseInit): Response =>
     createResponse(data, "text/plain", init);
 

--- a/src/security/sandbox/worker-script.ts
+++ b/src/security/sandbox/worker-script.ts
@@ -33,6 +33,7 @@ import { installWorkerEgressGuard, type WorkerEgressGuardOptions } from "./worke
 import { isAbsolute, relative, resolve as resolvePath, sep as PATH_SEP } from "node:path";
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import { parseSourceIntegrationPolicyManifest } from "#veryfront/integrations/source-policy.ts";
+import { createJsonHelper } from "#veryfront/routing/api/context-builder.ts";
 
 // Module-level singletons to avoid per-call allocation churn
 const encoder = new TextEncoder();
@@ -454,11 +455,10 @@ async function handlePagesRoute(req: ExecutePagesRouteRequest): Promise<Serializ
           cookies,
           headers: request.headers,
           url,
-          json: (data: unknown, init?: ResponseInit): Response =>
-            new Response(JSON.stringify(data), {
-              ...init,
-              headers: { "Content-Type": "application/json", ...init?.headers },
-            }),
+          // The same helper the in-process context uses, so `await ctx.json()`
+          // reads the request body here too. A handler must behave the same
+          // whether or not isolation is enabled.
+          json: createJsonHelper(request),
           text: (data: string, init?: ResponseInit): Response =>
             new Response(data, {
               ...init,


### PR DESCRIPTION
## Summary

`ctx.json()` in pages API routes looked like a request-body parser but actually built a JSON `Response` from `undefined`. Handlers that wrote `const body = await ctx.json()` received a `Response` object, and echoing it back serialized to `{}`, silently dropping POST payloads.

This PR makes `ctx.json` arity-based: `ctx.json()` parses the request body, while `ctx.json(data, init?)` still builds a JSON `Response`. The worker-isolation API path now uses the same helper so isolated and in-process handlers behave the same.

## Verification

- `deno test --allow-all src/routing/api/context-builder.test.ts`
- `deno task lint:sanitizer-baseline`
- `deno task lint`
- `deno task typecheck`

## Review status

Score: 94/100. Recommended next step: merge after GitHub required checks finish green.