### PR TITLE
fix(api): resolve @/ imports in API routes, and report why loading failed (depends on #2999)

### DIFF
--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -3,7 +3,13 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { HTTP_OK } from "#veryfront/utils";
-import { __injectDepsForTests, APIRouteHandler } from "./handler.ts";
+import type { HandlerContext } from "#veryfront/types";
+import {
+  __injectDepsForTests,
+  type APIRoute,
+  APIRouteHandler,
+  sanitizeLoadErrorForResponse,
+} from "./handler.ts";
 
 const handlers: APIRouteHandler[] = [];
 
@@ -472,6 +478,142 @@ describe("APIRouteHandler", () => {
         const finalStatus = status ?? HTTP_OK;
         assertEquals(finalStatus, expected, `Status ${status} should result in ${expected}`);
       });
+    });
+  });
+
+  // A load failure belongs to the attempt that produced it. Held on the
+  // instance, it outlived the request and the next route to fail for its own
+  // reason reported someone else's error.
+  describe("load failure scoping", () => {
+    async function handlerWithTwoRoutes(
+      onLoad: (modulePath: string) => Promise<APIRoute | null>,
+    ): Promise<{ handler: APIRouteHandler; localCtx: HandlerContext }> {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/broken.ts",
+        "export function GET() { return new Response('broken'); }",
+      );
+      adapter.fs.files.set(
+        "/test/project/pages/api/empty.ts",
+        "export const notAMethod = 1;",
+      );
+
+      __injectDepsForTests({ loadHandlerModule: ({ modulePath }) => onLoad(modulePath) });
+
+      return {
+        handler: await createInitializedHandler("/test/project", adapter),
+        localCtx: {
+          projectDir: "/test/project",
+          adapter,
+          securityConfig: null,
+          cspUserHeader: null,
+          isLocalProject: true,
+        },
+      };
+    }
+
+    it("does not report one route's load error on another route", async () => {
+      const { handler, localCtx } = await handlerWithTwoRoutes((modulePath) => {
+        if (modulePath.includes("broken")) throw new Error("Unexpected token in broken.ts");
+        // A module with no HTTP exports: no error, just nothing to call.
+        return Promise.resolve({});
+      });
+
+      const broken = await handler.handle(new Request("http://localhost/api/broken"), localCtx);
+      assertEquals(broken?.status, 500);
+      assertEquals(await broken?.text(), "Unexpected token in broken.ts");
+
+      const empty = await handler.handle(new Request("http://localhost/api/empty"), localCtx);
+      assertEquals(empty?.status, 500);
+      assertEquals(await empty?.text(), "Handler not found");
+    });
+
+    it("classifies the allow-list block against the current attempt only", async () => {
+      const { handler } = await handlerWithTwoRoutes((modulePath) => {
+        if (modulePath.includes("broken")) {
+          throw new Error("Remote import blocked by allow-list: evil.example.com");
+        }
+        return Promise.resolve({});
+      });
+
+      const blocked = await handler.handle(new Request("http://localhost/api/broken"));
+      assertEquals(blocked?.status, 502);
+
+      const empty = await handler.handle(new Request("http://localhost/api/empty"));
+      assertEquals(empty?.status, 500, "a later route inherited the allow-list classification");
+    });
+  });
+
+  // AGENTS.md forbids local absolute paths, home directories, temp directories
+  // and full stack traces in user-facing output. A dev-mode 500 body is
+  // user-facing, and a raw module load error carries all four.
+  describe("sanitizeLoadErrorForResponse", () => {
+    const projectDir = "/PROJECT_ROOT/app";
+
+    it("keeps the actionable first line", () => {
+      const result = sanitizeLoadErrorForResponse(
+        'Expected ";" but found "}"\n    at file:///PROJECT_ROOT/app/api/users.ts:12:3',
+        projectDir,
+      );
+
+      assertEquals(result, 'Expected ";" but found "}"');
+    });
+
+    it("drops the stack trace", () => {
+      const result = sanitizeLoadErrorForResponse(
+        "Boom\n    at load (file:///PROJECT_ROOT/app/x.ts:1:1)\n    at run (x.ts:2:2)",
+        projectDir,
+      );
+
+      assertEquals(result.includes("    at "), false);
+    });
+
+    it("makes a path inside the project relative", () => {
+      const result = sanitizeLoadErrorForResponse(
+        "Module not found: file:///PROJECT_ROOT/app/api/users.ts",
+        projectDir,
+      );
+
+      assertEquals(result, "Module not found: api/users.ts");
+    });
+
+    it("redacts a temp directory the bundle was written to", () => {
+      const result = sanitizeLoadErrorForResponse(
+        "Could not resolve /var/folders/kx/T/vf-bundle-1234/route.js",
+        projectDir,
+      );
+
+      assertEquals(result.includes("/var/folders/"), false);
+      assertEquals(result.includes("<PATH>"), true);
+    });
+
+    it("redacts a home directory", () => {
+      for (const path of ["/Users/someone/code/x.ts", "/home/someone/code/x.ts"]) {
+        const result = sanitizeLoadErrorForResponse(`Cannot find module ${path}`, projectDir);
+
+        assertEquals(result.includes("someone"), false, `leaked a home directory: ${result}`);
+        assertEquals(result.includes("<PATH>"), true);
+      }
+    });
+
+    it("redacts a file:// URL outside the project", () => {
+      const result = sanitizeLoadErrorForResponse(
+        "Failed to load file:///tmp/vf-9f/route.js",
+        projectDir,
+      );
+
+      assertEquals(result.includes("file://"), false);
+    });
+
+    it("truncates a very long message", () => {
+      const result = sanitizeLoadErrorForResponse("x".repeat(1000), projectDir);
+      assertEquals(result.length <= 303, true);
+      assertEquals(result.endsWith("..."), true);
+    });
+
+    it("handles an empty message and a missing project directory", () => {
+      assertEquals(sanitizeLoadErrorForResponse(""), "");
+      assertEquals(sanitizeLoadErrorForResponse("Handler not found"), "Handler not found");
     });
   });
 });

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -21,6 +21,40 @@ const HANDLER_CACHE_MAX_ENTRIES = 256;
 
 export type { APIContext, APIRoute };
 
+/** Longest sanitised load error a response body carries. */
+const MAX_LOAD_ERROR_LENGTH = 300;
+
+/**
+ * Roots that only ever identify the machine running the server: home
+ * directories and the temp directories bundling writes to.
+ */
+const MACHINE_PATH_PATTERN =
+  /(?:file:\/\/)?\/(?:private\/)?(?:Users|home|root|var\/folders|var\/tmp|tmp)\/\S*/g;
+
+/**
+ * Reduce a module load error to something safe to put in a response body.
+ *
+ * The message is worth returning, since it usually names a syntax or import
+ * error the developer can act on. The rest of it is not: a raw load error
+ * carries the temp directory the bundle was written to, absolute paths into the
+ * framework install, and a full stack trace. A path inside the project survives
+ * as a project-relative one, because that is the part that identifies the file
+ * to fix.
+ */
+export function sanitizeLoadErrorForResponse(message: string, projectDir?: string): string {
+  // A stack trace is never the actionable part.
+  let text = (message.split("\n")[0] ?? "").trim();
+
+  if (projectDir) {
+    const root = projectDir.replace(/\/+$/, "");
+    text = text.replaceAll(`file://${root}/`, "").replaceAll(`${root}/`, "");
+  }
+
+  text = text.replace(MACHINE_PATH_PATTERN, "<PATH>");
+
+  return text.length > MAX_LOAD_ERROR_LENGTH ? `${text.slice(0, MAX_LOAD_ERROR_LENGTH)}...` : text;
+}
+
 /**
  * Injection interface for testing APIRouteHandler dependencies
  */
@@ -59,10 +93,18 @@ export interface APIResponse {
 /** Function signature for API route handlers. */
 export type APIHandler = (ctx: APIContext) => Promise<Response> | Response;
 
+/**
+ * Outcome of one load attempt. The failure travels with the attempt that
+ * produced it, so a later route can never report an earlier route's error.
+ */
+interface LoadAttempt {
+  handler: APIRoute | null;
+  errorMessage: string | null;
+}
+
 export class APIRouteHandler {
   private router = new ApiRouteMatcher();
   private routeCache = new LRUCache<string, APIRoute>({ maxEntries: HANDLER_CACHE_MAX_ENTRIES });
-  private lastErrorMessage: string | null = null;
   private activeRequests = 0;
   private destroyRequested = false;
   private destroyed = false;
@@ -176,17 +218,30 @@ export class APIRouteHandler {
           params: match.params,
         });
 
-        const handler = await this.loadHandler(match);
+        const { handler, errorMessage } = await this.loadHandler(match);
         if (!handler) {
+          const msg = errorMessage ?? "Handler not found";
+
           try {
-            logger.error(`handler module failed to load: ${match.route.page}`);
+            // The full detail, paths and all, belongs in the log.
+            logger.error(`handler module failed to load: ${match.route.page}`, { reason: msg });
           } catch (e) {
             logger.warn("API error log failed", e);
           }
 
-          const msg = this.lastErrorMessage ?? "Handler not found";
           if (msg.includes("Remote import blocked by allow-list")) return badGateway(msg);
-          return internalServerError("Handler not found");
+
+          // The reason the module failed to load is the only useful thing here.
+          // Reporting a flat "Handler not found" for what is usually a syntax or
+          // import error sends people hunting for a routing problem that does
+          // not exist. Local development only, and sanitised: a raw load error
+          // carries temp directories, absolute paths and a stack trace, none of
+          // which belong in a response body.
+          return internalServerError(
+            ctx?.isLocalProject
+              ? sanitizeLoadErrorForResponse(msg, this.projectDir)
+              : "Handler not found",
+          );
         }
 
         // App Router routes are always named route.ts/js/tsx/jsx
@@ -224,7 +279,7 @@ export class APIRouteHandler {
     ).finally(() => this.completeRequest());
   }
 
-  private loadHandler(match: RouteMatch): Promise<APIRoute | null> {
+  private loadHandler(match: RouteMatch): Promise<LoadAttempt> {
     const modulePath = match.route.page;
 
     return withSpan(
@@ -234,7 +289,7 @@ export class APIRouteHandler {
         await this.ensureConfig(adapter);
 
         const cached = this.routeCache.get(modulePath);
-        if (cached) return cached;
+        if (cached) return { handler: cached, errorMessage: null };
 
         try {
           const deps = getDeps();
@@ -248,15 +303,14 @@ export class APIRouteHandler {
           // Only cache handlers that export at least one HTTP method.
           // Empty objects ({}) from failed imports are truthy but useless —
           // caching them would prevent retry after the user fixes the import.
-          if (handler && Object.keys(handler).length > 0) {
-            this.routeCache.set(modulePath, handler);
-          }
-          return handler && Object.keys(handler).length > 0 ? handler : null;
+          const usable = handler && Object.keys(handler).length > 0 ? handler : null;
+          if (usable) this.routeCache.set(modulePath, usable);
+
+          return { handler: usable, errorMessage: null };
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
-          this.lastErrorMessage = msg;
           logger.error(`[API] Failed to load handler for ${modulePath}: ${msg}`);
-          return null;
+          return { handler: null, errorMessage: msg };
         }
       },
       { "api.modulePath": modulePath },

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -5,6 +5,7 @@ import { join } from "#veryfront/compat/path";
 import {
   generateCompiledBinaryRequireShim,
   getNodeExternalPackagesToResolve,
+  isSpecifierResolutionError,
   loadHandlerModule,
   resolveEsmUserDependencies,
   rewriteCompiledBinaryUserDependencyImports,
@@ -143,6 +144,75 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     });
 
     assertEquals(typeof route?.GET, "function");
+  });
+
+  // Deno resolves the direct import itself and knows nothing about `@/`, so the
+  // route only loads if the failed direct import falls back to bundling, where
+  // the import map plugin resolves the alias.
+  it("loads a local route that imports through the project's @/ alias", async () => {
+    const tmpDir = await makeTempDir();
+    await fs.mkdir(join(tmpDir, "lib"), { recursive: true });
+    await fs.mkdir(join(tmpDir, "pages", "api"), { recursive: true });
+
+    await fs.writeTextFile(
+      join(tmpDir, "lib", "greeting.ts"),
+      `export const greeting = "aliased";`,
+    );
+
+    const modulePath = join(tmpDir, "pages", "api", "aliased.ts");
+    await fs.writeTextFile(
+      modulePath,
+      [
+        `import { greeting } from "@/lib/greeting.ts";`,
+        `export function GET() { return new Response(greeting); }`,
+      ].join("\n"),
+    );
+
+    const config: VeryfrontConfig = {
+      resolve: { importMap: { imports: { "@/": "./" } } },
+    };
+
+    const route = await loadHandlerModule({ projectDir: tmpDir, modulePath, adapter, config });
+
+    assertEquals(typeof route?.GET, "function");
+  });
+
+  // Bundling reads the route through the adapter; a direct import does not. A
+  // module that threw while evaluating must surface its own error rather than
+  // be evaluated a second time under bundling semantics.
+  it("does not retry a module whose own error quotes a resolver phrase", async () => {
+    const tmpDir = await makeTempDir();
+    const modulePath = join(tmpDir, "handler.ts");
+
+    await fs.writeTextFile(
+      modulePath,
+      [
+        `throw new Error("Cannot find module 'config'");`,
+        `export function GET() { return new Response("ok"); }`,
+      ].join("\n"),
+    );
+
+    let readCount = 0;
+    const countingAdapter: RuntimeAdapter = {
+      ...adapter,
+      fs: {
+        ...adapter.fs,
+        readFile: (path: string) => {
+          readCount++;
+          return adapter.fs.readFile(path);
+        },
+      },
+    };
+
+    let caught = "";
+    try {
+      await loadHandlerModule({ projectDir: tmpDir, modulePath, adapter: countingAdapter });
+    } catch (error) {
+      caught = error instanceof Error ? error.message : String(error);
+    }
+
+    assertMatch(caught, /Cannot find module 'config'/);
+    assertEquals(readCount, 0, "the broken module was re-read for bundling");
   });
 
   it("throws on missing file", async () => {
@@ -1036,5 +1106,56 @@ describe("generateCompiledBinaryRequireShim - symlink resistance (VULN-FS-5)", {
     try {
       await fs.remove(realProject, { recursive: true });
     } catch (_) { /* best effort */ }
+  });
+});
+
+describe("isSpecifierResolutionError", () => {
+  // Direct import leaves specifier resolution to the runtime, which knows
+  // nothing about the project's `@/` alias — those routes used to 500 with a
+  // flat "Handler not found". Only resolution failures may fall back to
+  // bundling; a genuinely broken module must still surface its own error.
+  it("recognises an unresolved bare or aliased specifier", () => {
+    for (
+      const message of [
+        // Deno appends a hint on later lines; the specifier opens the message.
+        `Import "@/lib/uses-crypto" not a dependency\n  hint: try running \`deno add\``,
+        `Module not found "file:///p/lib/x.js".`,
+        `Relative import path "lib/x.ts" not prefixed with / or ./ or ../`,
+      ]
+    ) {
+      assertEquals(isSpecifierResolutionError(new TypeError(message)), true, message);
+    }
+  });
+
+  it("does not treat a genuine module error as a resolution failure", () => {
+    assertEquals(isSpecifierResolutionError(new SyntaxError("Unexpected token }")), false);
+    assertEquals(isSpecifierResolutionError(new TypeError("x is not a function")), false);
+    assertEquals(isSpecifierResolutionError(new Error("boom")), false);
+  });
+
+  // A route is free to throw whatever it likes. Matching those phrases anywhere
+  // in the message used to hand a broken module to the bundling loader, which
+  // evaluates it a second time under different semantics.
+  it("does not match a module's own error that quotes a resolver phrase", () => {
+    for (
+      const message of [
+        `Cannot find module 'config'`,
+        `Setup failed: Module not found "config"`,
+        `Import "x" not a dependency, said the module`,
+      ]
+    ) {
+      assertEquals(isSpecifierResolutionError(new Error(message)), false, message);
+    }
+
+    // Not even when the module throws the type Deno's resolver uses.
+    assertEquals(
+      isSpecifierResolutionError(new TypeError(`config error: Module not found "db"`)),
+      false,
+    );
+  });
+
+  it("ignores non-Error values", () => {
+    assertEquals(isSpecifierResolutionError(null), false);
+    assertEquals(isSpecifierResolutionError("not a dependency"), false);
   });
 });

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -84,7 +84,24 @@ async function loadModule(args: {
   }
 
   const fileExistsLocally = await fs.exists(modulePath);
-  if (fileExistsLocally) return loadTSModuleDirect(modulePath);
+  if (fileExistsLocally) {
+    try {
+      return await loadTSModuleDirect(modulePath);
+    } catch (error) {
+      // A direct import shares the dev server's runtime context, which is what
+      // makes auto-discovery (agentRegistry and friends) work — but it leaves
+      // specifier resolution to Deno, which knows nothing about the project's
+      // `@/` alias. Bundling can resolve that import map path, so fall back to
+      // it rather than reporting a routing-shaped 500.
+      if (!isSpecifierResolutionError(error)) throw error;
+
+      logger.debug("Direct import could not resolve a specifier, bundling instead", {
+        modulePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return loadAndTranspileModule(modulePath, projectDir, adapter, fs, config);
+    }
+  }
 
   logger.debug(`File not local, using adapter-based loading: ${modulePath}`);
   return loadAndTranspileModule(modulePath, projectDir, adapter, fs, config);
@@ -95,6 +112,27 @@ async function loadModule(args: {
  * This allows the module to share the same runtime context as the dev server,
  * enabling auto-discovery features like agentRegistry to work.
  */
+
+/**
+ * Deno's resolver reports an unresolvable import as a TypeError whose message
+ * opens by naming the specifier it could not resolve. Anchoring on that opening
+ * is what keeps a module's own error out: a route that throws
+ * `Error("Cannot find module x")` at evaluation time is broken, and re-running
+ * it under bundling would evaluate broken code a second time.
+ */
+const SPECIFIER_RESOLUTION_MESSAGE =
+  /^(?:Import "[^"]+" not a dependency|Module not found "[^"]+"|Relative import path "[^"]+" not prefixed)/;
+
+/**
+ * True when a module failed to load because Deno could not resolve one of its
+ * import specifiers, rather than because the module itself is broken.
+ */
+export function isSpecifierResolutionError(error: unknown): boolean {
+  // Every other error shape the direct import can produce belongs to the module.
+  if (!(error instanceof TypeError)) return false;
+  return SPECIFIER_RESOLUTION_MESSAGE.test(error.message.trimStart());
+}
+
 function loadTSModuleDirect(modulePath: string): Promise<APIRoute> {
   const cacheBuster = `?v=${Date.now()}`;
   const url = modulePath.startsWith("file://")


### PR DESCRIPTION
## Summary

Local API route modules are imported directly in dev so they share the dev server runtime. That path failed for routes importing through the project `@/` alias because Deno direct import does not know the project import map, and the API response collapsed to `Handler not found`.

This PR falls back to the bundling loader only when the direct import failure is shaped like a specifier-resolution error. Module syntax/runtime failures still surface as their own errors and are not retried under different loader semantics. Local development responses now return a sanitized load error instead of a flat routing-shaped message; production keeps the generic response.

Known remaining gap: bare npm specifiers in API routes are still separate work because temp-bundle external resolution cannot find project `node_modules`.

## Verification

- `deno test --allow-all src/routing/api/module-loader/loader.test.ts src/routing/api/handler.test.ts`
- `deno task lint:sanitizer-baseline`
- `deno task lint`
- `deno task typecheck`

## Review status

Score: 92/100. Recommended next step: merge after GitHub required checks finish green.