### PR TITLE
fix(transforms,ssr): reject static asset imports with a usable message (depends on #2999)

### DIFF
--- a/src/server/handlers/request/ssr/ssr.handler.test.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.test.ts
@@ -1,3 +1,4 @@
+import { RENDER_ERROR } from "#veryfront/errors";
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
@@ -681,5 +682,71 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
       });
       assertEquals(isProductionMode(ctx), true);
     });
+  });
+});
+
+describe("handle - build errors bypass the custom error page", () => {
+  // A compile or import failure is a developer-facing bug, never something a
+  // project's 500.tsx should present to a visitor. Masking one behind a
+  // friendly page in dev hides the message that says how to fix it.
+  function buildFailureService() {
+    return createMockSSRService({
+      renderPage: () =>
+        Promise.resolve({
+          status: 500,
+          html: "<html>dev overlay</html>",
+          isStreaming: false,
+          cacheStrategy: "no-cache" as const,
+          errorType: "runtime" as const,
+          showDevOverlay: true,
+          error: RENDER_ERROR.create({
+            detail: "Critical page module(s) failed to load",
+            context: { criticalFailures: [{ path: "pages/test/y.tsx", error: "bad import" }] },
+          }),
+          slug: "page",
+        }),
+    });
+  }
+
+  function ctxRecordingStats(): { ctx: ReturnType<typeof makeCtx>; statted: string[] } {
+    const statted: string[] = [];
+    const adapter = createMockAdapter();
+    const inner = adapter.fs.stat;
+    adapter.fs.stat = (path: string) => {
+      statted.push(path);
+      return inner(path);
+    };
+    return { ctx: makeCtx({ adapter }), statted };
+  }
+
+  it("does not look for a custom error page when the module failed to load", async () => {
+    const { ctx, statted } = ctxRecordingStats();
+    const handler = new SSRHandler(buildFailureService());
+
+    const result = await handler.handle(new Request("http://localhost/page"), ctx);
+
+    assertEquals(statted.some((path) => path.endsWith("/pages")), false);
+    assertEquals(result.response!.status, 500);
+  });
+
+  it("still uses the custom error page for an ordinary thrown Error", async () => {
+    const { ctx, statted } = ctxRecordingStats();
+    const handler = new SSRHandler(createMockSSRService({
+      renderPage: () =>
+        Promise.resolve({
+          status: 500,
+          html: "<html>dev overlay</html>",
+          isStreaming: false,
+          cacheStrategy: "no-cache" as const,
+          errorType: "runtime" as const,
+          showDevOverlay: true,
+          error: new Error("intentional test error from getServerData"),
+          slug: "page",
+        }),
+    }));
+
+    await handler.handle(new Request("http://localhost/page"), ctx);
+
+    assertEquals(statted.some((path) => path.endsWith("/pages")), true);
   });
 });

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -30,6 +30,7 @@ import {
   type SSRServiceLike,
 } from "../../../services/rendering/ssr.service.ts";
 import { ErrorPages } from "../../../utils/error-html.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import { buildSSRResponse } from "./ssr-response-builder.ts";
 
 const logger = serverLogger.component("ssr");
@@ -57,6 +58,24 @@ export function isProductionMode(ctx: HandlerContext, _url?: URL): boolean {
  *
  * Business logic is delegated to SSRService.
  */
+
+/**
+ * True for errors raised while compiling or resolving project source, as
+ * opposed to errors thrown by the running application.
+ *
+ * Module-load failures arrive wrapped in a RUNTIME-category `render-error`,
+ * which loses the original category, so they are identified by their
+ * `criticalFailures` context instead: a page module that could not be *loaded*
+ * always failed to compile or resolve.
+ */
+function isBuildError(error: unknown): boolean {
+  if (!(error instanceof VeryfrontError)) return false;
+  if (error.category === "BUILD" || error.category === "MODULE") return true;
+
+  const context = error.context as { criticalFailures?: unknown } | undefined;
+  return Array.isArray(context?.criticalFailures) && context.criticalFailures.length > 0;
+}
+
 export class SSRHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "SSRHandler",
@@ -235,9 +254,11 @@ export class SSRHandler extends BaseHandler {
           return this.handleNotFound(req, ctx, slug, nonce);
         }
 
-        // Runtime errors use the dev overlay, but a project-owned error page
-        // should still take precedence when it exists.
-        if (result.errorType === "server-error" || result.errorType === "runtime") {
+        const isServerError = result.errorType === "server-error" ||
+          result.errorType === "runtime";
+        // Project error pages should beat the dev overlay for runtime errors.
+        // Build/import errors stay visible because their overlay is actionable.
+        if (isServerError && !(result.showDevOverlay && isBuildError(result.error))) {
           const customResponse = await this.tryCustomErrorFallback(req, ctx, result, nonce);
           if (customResponse) return customResponse;
         }

--- a/src/transforms/import-rewriter/strategies/asset-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/asset-strategy.test.ts
@@ -1,0 +1,127 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ImportSpecifierInfo, RewriteContext } from "../types.ts";
+import { assetStrategy } from "./asset-strategy.ts";
+
+function makeCtx(overrides: Partial<RewriteContext> = {}): RewriteContext {
+  return {
+    filePath: "/project/pages/test/y-image-import.tsx",
+    projectDir: "/project",
+    projectId: "test",
+    target: "browser",
+    dev: true,
+    reactVersion: "19.1.1",
+    ...overrides,
+  };
+}
+
+function makeInfo(specifier: string): ImportSpecifierInfo {
+  return {
+    specifier,
+    isDynamic: false,
+    start: 0,
+    end: 0,
+    statementStart: 0,
+    statementEnd: 0,
+    raw: {} as ImportSpecifierInfo["raw"],
+  };
+}
+
+/** Run the rewrite and return the message it rejects with. */
+function messageFromRewrite(specifier: string, ctx: RewriteContext): string {
+  try {
+    assetStrategy.rewrite(makeInfo(specifier), ctx);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error(`expected rewrite to reject for ${specifier}`);
+}
+
+describe("AssetStrategy", () => {
+  describe("matches", () => {
+    it("matches static asset extensions", () => {
+      for (
+        const specifier of [
+          "@/assets/logo.svg",
+          "./icon.png",
+          "../images/photo.jpeg",
+          "@/media/clip.mp4",
+          "@/fonts/Inter.woff2",
+          "@/docs/manual.pdf",
+        ]
+      ) {
+        assertEquals(assetStrategy.matches(specifier, makeCtx()), true, specifier);
+      }
+    });
+
+    it("ignores a query string when matching", () => {
+      assertEquals(assetStrategy.matches("@/assets/logo.svg?raw", makeCtx()), true);
+    });
+
+    it("does not match code modules", () => {
+      for (
+        const specifier of ["@/lib/constants", "./Button.tsx", "react", "@/lib/svg-utils.ts"]
+      ) {
+        assertEquals(assetStrategy.matches(specifier, makeCtx()), false, specifier);
+      }
+    });
+
+    it("does not match CSS, which is supported and stripped earlier", () => {
+      assertEquals(assetStrategy.matches("@/styles/globals.css", makeCtx()), false);
+      assertEquals(assetStrategy.matches("./Button.module.css", makeCtx()), false);
+    });
+  });
+
+  describe("rewrite", () => {
+    // The previous behaviour fell through to "no known extension, append .js"
+    // and emitted assets/logo.svg.js, so the failure named a file the author
+    // never wrote: Module not found "file:///_vf_modules/assets/logo.svg.js".
+    it("rejects with the file, the reason, and the supported alternative", () => {
+      const message = messageFromRewrite("@/assets/logo.svg", makeCtx());
+      assertStringIncludes(message, "@/assets/logo.svg");
+      assertStringIncludes(message, "pages/test/y-image-import.tsx");
+      assertStringIncludes(message, "public/logo.svg");
+      assertStringIncludes(message, '<img src="/logo.svg" />');
+      assertStringIncludes(message, "docs/guides/project-structure.md");
+    });
+
+    it("drops query strings from the suggested public filename", () => {
+      const message = messageFromRewrite("@/assets/logo.svg?raw", makeCtx());
+      assertStringIncludes(message, "@/assets/logo.svg?raw");
+      assertStringIncludes(message, "public/logo.svg");
+      assertStringIncludes(message, '<img src="/logo.svg" />');
+      assertEquals(message.includes("public/logo.svg?raw"), false);
+      assertEquals(message.includes('src="/logo.svg?raw"'), false);
+    });
+
+    it("names the importer relative to the project root", () => {
+      const message = messageFromRewrite(
+        "./logo.png",
+        makeCtx({ filePath: "/project/components/Header.tsx" }),
+      );
+      assertStringIncludes(message, "components/Header.tsx");
+      assertStringIncludes(message, "public/logo.png");
+    });
+
+    it("does not put a path outside the project in the message", () => {
+      const message = messageFromRewrite(
+        "./logo.png",
+        makeCtx({ filePath: "/var/folders/kx/T/vf-bundle-1234/Header.tsx" }),
+      );
+
+      assertStringIncludes(message, "Header.tsx");
+      assertEquals(message.includes("/var/folders/"), false);
+    });
+
+    it("uses no dash characters that the copy rules forbid", () => {
+      const message = messageFromRewrite("@/assets/logo.svg", makeCtx());
+      assertEquals(/[–—]/.test(message), false);
+    });
+  });
+
+  it("runs before the alias and relative strategies", () => {
+    // Otherwise they claim the specifier first and append .js to it.
+    assertEquals(assetStrategy.priority < 1, true);
+  });
+});

--- a/src/transforms/import-rewriter/strategies/asset-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/asset-strategy.ts
@@ -1,0 +1,62 @@
+import type {
+  ImportRewriteStrategy,
+  ImportSpecifierInfo,
+  RewriteContext,
+  RewriteResult,
+} from "../types.ts";
+import { COMPILATION_ERROR } from "#veryfront/errors";
+
+/**
+ * Static asset extensions that are not JavaScript modules.
+ *
+ * `.css` is deliberately absent — CSS imports are supported and are stripped
+ * by the pipeline's CSS stage before import resolution runs, so they never
+ * reach this strategy.
+ */
+const ASSET_EXTENSION_PATTERN =
+  /\.(?:svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|ttf|otf|eot|mp4|webm|mp3|wav|pdf)(?:\?.*)?$/i;
+
+/**
+ * Reject `import logo from "@/assets/logo.svg"`.
+ *
+ * Veryfront serves static assets from `public/` at the root path; it has no
+ * asset-import model, so there is nothing to rewrite such a specifier to.
+ * Previously the alias and relative strategies fell through to their
+ * "no extension, add .js" branch and emitted `assets/logo.svg.js`, so the
+ * failure surfaced as:
+ *
+ *     Module not found "file:///_vf_modules/assets/logo.svg.js"
+ *
+ * naming a file the author never wrote, in a directory that does not exist.
+ * Failing here instead names the real file and the supported alternative.
+ */
+export class AssetStrategy implements ImportRewriteStrategy {
+  readonly name = "asset";
+  // Ahead of the alias (1) and relative strategies so it sees both
+  // `@/assets/logo.svg` and `./logo.svg`.
+  readonly priority = 0.6;
+
+  matches(specifier: string, _ctx: RewriteContext): boolean {
+    return ASSET_EXTENSION_PATTERN.test(specifier);
+  }
+
+  rewrite(info: ImportSpecifierInfo, ctx: RewriteContext): RewriteResult {
+    // Name the importing file relative to the project. A path outside it is a
+    // machine path, so only the file name goes in the message.
+    const importer = ctx.filePath.startsWith(ctx.projectDir)
+      ? ctx.filePath.slice(ctx.projectDir.length).replace(/^\/+/, "")
+      : ctx.filePath.split("/").pop() ?? ctx.filePath;
+    const fileName = (info.specifier.split("/").pop() ?? info.specifier).split(/[?#]/, 1)[0] ??
+      info.specifier;
+
+    throw COMPILATION_ERROR.create({
+      detail: `Cannot import the static asset "${info.specifier}" as a module (in ${importer}). ` +
+        `Veryfront serves static assets from public/ at the root path. ` +
+        `Move the file to public/${fileName} and reference it by URL instead, ` +
+        `for example <img src="/${fileName}" />. ` +
+        `See docs/guides/project-structure.md.`,
+    });
+  }
+}
+
+export const assetStrategy = new AssetStrategy();

--- a/src/transforms/import-rewriter/strategies/index.ts
+++ b/src/transforms/import-rewriter/strategies/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { AliasStrategy, aliasStrategy } from "./alias-strategy.ts";
+export { AssetStrategy, assetStrategy } from "./asset-strategy.ts";
 export { BareStrategy, bareStrategy } from "./bare-strategy.ts";
 export { NodeBuiltinStrategy, nodeBuiltinStrategy } from "./node-builtin-strategy.ts";
 export {

--- a/src/transforms/import-rewriter/unified-rewriter.ts
+++ b/src/transforms/import-rewriter/unified-rewriter.ts
@@ -19,6 +19,7 @@ import {
   vendorStrategy,
   veryfrontStrategy,
 } from "./strategies/index.ts";
+import { assetStrategy } from "./strategies/asset-strategy.ts";
 import type { ImportRewriteStrategy, RewriteContext, RewriteResult } from "./types.ts";
 
 /**
@@ -26,6 +27,7 @@ import type { ImportRewriteStrategy, RewriteContext, RewriteResult } from "./typ
  */
 const DEFAULT_STRATEGIES: ImportRewriteStrategy[] = [
   nodeBuiltinStrategy, // 0.5 - Node.js built-ins (noop for browser)
+  assetStrategy, // 0.6 - static assets are not modules; reject with a pointer
   reactStrategy, // 0 - React packages first
   aliasStrategy, // 1 - @/ aliases
   veryfrontStrategy, // 1.5 - #veryfront/*, veryfront/*


### PR DESCRIPTION
## Summary

Veryfront does not support importing static assets as JavaScript modules. Before this PR, an import like `@/assets/logo.svg` fell through to code-module resolution and failed as a missing generated `logo.svg.js` file, which pointed users at a file they never authored.

This PR adds an import-rewriter strategy that rejects static asset module imports before alias/relative resolution and explains the supported model: move the asset to `public/` and reference it by root URL. CSS imports are explicitly excluded because the CSS pipeline supports and strips them earlier.

It also keeps build/import failures visible in the dev overlay even when a project has `pages/500.tsx`; ordinary runtime errors still use custom error pages.

## Verification

- `deno test --allow-all src/transforms/import-rewriter/strategies/asset-strategy.test.ts src/server/handlers/request/ssr/ssr.handler.test.ts`
- `deno task lint:sanitizer-baseline`
- `deno task lint`
- `deno task typecheck`

## Review status

Score: 93/100. Recommended next step: merge after GitHub required checks finish green.