### PR TITLE
fix(transforms/esm): never cache a degraded module artifact

### DIFF
--- a/src/transforms/esm/degraded-artifact.ts
+++ b/src/transforms/esm/degraded-artifact.ts
@@ -1,0 +1,24 @@
+/**
+ * Degradation marking for cached HTTP module artifacts.
+ *
+ * A module whose lazy dependency could not be prefetched is still usable for
+ * the render that produced it, but it must never be mistaken for a complete
+ * artifact on a later render. The marker travels with the code, so any reader
+ * of the on-disk cache can tell the two apart.
+ *
+ * @module transforms/esm/degraded-artifact
+ */
+
+/** Preserved comment format that survives minification */
+const VF_DEGRADED_MARKER = "\n/*! @vf-degraded */\n";
+
+/** Mark bundle code as produced from an incomplete dependency prefetch. */
+export function markDegradedArtifact(code: string): string {
+  if (isDegradedArtifact(code)) return code;
+  return `${code}${VF_DEGRADED_MARKER}`;
+}
+
+/** Return whether bundle code was produced from an incomplete prefetch. */
+export function isDegradedArtifact(code: string): boolean {
+  return code.endsWith(VF_DEGRADED_MARKER);
+}

--- a/src/transforms/esm/http-cache.test.ts
+++ b/src/transforms/esm/http-cache.test.ts
@@ -22,6 +22,7 @@ import {
   normalizeHttpUrl,
 } from "./http-cache.ts";
 import { __setDistributedCacheAccessorForTests } from "./http-cache-wrapper.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
 import { buildHttpCacheIdentity } from "./http-cache-helpers.ts";
 import { simpleHash } from "#veryfront/utils/hash-utils.ts";
 
@@ -38,6 +39,22 @@ function extractBundleHashes(code: string): string[] {
 
   BUNDLE_RE.lastIndex = 0;
   return hashes;
+}
+
+/** Minimal distributed cache backend backed by a map the test can inspect. */
+function createMemoryBackend(store: Map<string, string>): CacheBackend {
+  return {
+    type: "memory",
+    get: (key) => Promise.resolve(store.get(key) ?? null),
+    set: (key, value) => {
+      store.set(key, value);
+      return Promise.resolve();
+    },
+    del: (key) => {
+      store.delete(key);
+      return Promise.resolve();
+    },
+  };
 }
 
 describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, () => {
@@ -355,6 +372,103 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
       assertEquals(hasCalls, [expectedIdentity]);
       assertEquals(addCalls, [expectedIdentity]);
       assertEquals(deleteCalls, [expectedIdentity]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      __injectCachesForTests(null);
+      __setDistributedCacheAccessorForTests(null);
+      __clearInFlightHttpFetches();
+      await remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("does not persist a module whose lazy dependency failed to prefetch", async () => {
+    const tempDir = await makeTempDir({ prefix: "vf-degraded-artifact-" });
+    const originalFetch = globalThis.fetch;
+    const parentUrl = "https://modules.example.com/degraded-parent.js";
+    const childUrl = "https://modules.example.com/degraded-child.js";
+    const distributed = new Map<string, string>();
+    let parentFetches = 0;
+
+    __injectCachesForTests({
+      cachedPaths: new Map(),
+      processingStack: new Set(),
+      lastDistributedRefresh: new Map(),
+    });
+    __setDistributedCacheAccessorForTests(() => Promise.resolve(createMemoryBackend(distributed)));
+    globalThis.fetch = ((input: string | URL | Request) => {
+      if (String(input) === childUrl) {
+        return Promise.resolve(new Response("upstream failure", { status: 502 }));
+      }
+      parentFetches += 1;
+      return Promise.resolve(
+        new Response(`export const load = () => import("${childUrl}");`, {
+          headers: { "content-type": "application/javascript" },
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const source = `import { load } from "${parentUrl}"; export { load };`;
+      const options = { cacheDir: tempDir, importMap: { imports: {}, scopes: {} } };
+
+      const first = await cacheHttpImportsToLocal(source, options);
+      const firstPath = first.code.match(/file:\/\/([^"']+\.mjs)/)?.[1];
+      assert(firstPath, "Expected the render to keep working with a local parent module");
+      assertEquals(parentFetches, 1);
+      assertEquals(distributed.size, 0);
+
+      await cacheHttpImportsToLocal(source, options);
+      assertEquals(parentFetches, 2);
+      assertEquals(distributed.size, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      __injectCachesForTests(null);
+      __setDistributedCacheAccessorForTests(null);
+      __clearInFlightHttpFetches();
+      await remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("persists a module whose lazy dependency prefetched successfully", async () => {
+    const tempDir = await makeTempDir({ prefix: "vf-healthy-artifact-" });
+    const originalFetch = globalThis.fetch;
+    const parentUrl = "https://modules.example.com/healthy-parent.js";
+    const childUrl = "https://modules.example.com/healthy-child.js";
+    const distributed = new Map<string, string>();
+    let parentFetches = 0;
+
+    __injectCachesForTests({
+      cachedPaths: new Map(),
+      processingStack: new Set(),
+      lastDistributedRefresh: new Map(),
+    });
+    __setDistributedCacheAccessorForTests(() => Promise.resolve(createMemoryBackend(distributed)));
+    globalThis.fetch = ((input: string | URL | Request) => {
+      if (String(input) === childUrl) {
+        return Promise.resolve(
+          new Response("export const child = true;", {
+            headers: { "content-type": "application/javascript" },
+          }),
+        );
+      }
+      parentFetches += 1;
+      return Promise.resolve(
+        new Response(`export const load = () => import("${childUrl}");`, {
+          headers: { "content-type": "application/javascript" },
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const source = `import { load } from "${parentUrl}"; export { load };`;
+      const options = { cacheDir: tempDir, importMap: { imports: {}, scopes: {} } };
+
+      await cacheHttpImportsToLocal(source, options);
+      assertEquals(parentFetches, 1);
+      assert(distributed.size > 0, "Expected a healthy module to reach the distributed cache");
+
+      await cacheHttpImportsToLocal(source, options);
+      assertEquals(parentFetches, 1);
     } finally {
       globalThis.fetch = originalFetch;
       __injectCachesForTests(null);

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -31,6 +31,7 @@ import { looksLikeHtmlContent as looksLikeHtmlNotJs } from "./html-content.ts";
 
 // Extracted modules
 import { embedSourceUrl, extractSourceUrl } from "./source-url-embed.ts";
+import { isDegradedArtifact, markDegradedArtifact } from "./degraded-artifact.ts";
 import {
   buildHttpCacheIdentity,
   buildHttpCacheIdentityMetadata,
@@ -112,16 +113,39 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
 
   if (await exists(cachePath)) {
     const code = await fs.readTextFile(cachePath);
-    const deps = extractBundleDeps(code);
 
-    if (deps.length > 0) {
-      const depsValid = await validateBundleDepsExist(deps, cacheDir);
-      if (!depsValid) {
-        httpCacheLog.debug("Local cache has missing deps, will re-fetch", {
-          url: normalizedUrl,
-          hash,
-          missingDeps: deps.length,
-        });
+    if (isDegradedArtifact(code)) {
+      // The artifact on disk is the fallback a previous render wrote when a
+      // dependency could not be prefetched. Retry the prefetch instead of
+      // handing the degradation on.
+      httpCacheLog.debug("Local cache holds a degraded artifact, will re-fetch", {
+        url: normalizedUrl,
+        hash,
+      });
+    } else {
+      const deps = extractBundleDeps(code);
+
+      if (deps.length > 0) {
+        const depsValid = await validateBundleDepsExist(deps, cacheDir);
+        if (!depsValid) {
+          httpCacheLog.debug("Local cache has missing deps, will re-fetch", {
+            url: normalizedUrl,
+            hash,
+            missingDeps: deps.length,
+          });
+        } else {
+          getCachedPaths().set(cacheKey, cachePath);
+          refreshDistributedCacheAsync(
+            hash,
+            code,
+            cacheDir,
+            normalizedUrl,
+            identityMetadata,
+            getLastDistributedRefresh,
+          );
+          trackBundleAccumulator(hash, normalizedUrl, cachePath);
+          return cachePath;
+        }
       } else {
         getCachedPaths().set(cacheKey, cachePath);
         refreshDistributedCacheAsync(
@@ -135,18 +159,6 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
         trackBundleAccumulator(hash, normalizedUrl, cachePath);
         return cachePath;
       }
-    } else {
-      getCachedPaths().set(cacheKey, cachePath);
-      refreshDistributedCacheAsync(
-        hash,
-        code,
-        cacheDir,
-        normalizedUrl,
-        identityMetadata,
-        getLastDistributedRefresh,
-      );
-      trackBundleAccumulator(hash, normalizedUrl, cachePath);
-      return cachePath;
     }
   }
 
@@ -299,13 +311,22 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
     }
 
     processingStack.add(cacheIdentity);
+    let degraded: readonly string[] = [];
     try {
-      code = await rewriteModuleImports(code, normalizedUrl, options, cacheHttpModule);
+      const rewritten = await rewriteModuleImports(
+        code,
+        normalizedUrl,
+        options,
+        cacheHttpModule,
+      );
+      code = rewritten.code;
+      degraded = rewritten.degraded;
     } finally {
       processingStack.delete(cacheIdentity);
     }
 
     code = embedSourceUrl(code, normalizedUrl);
+    if (degraded.length > 0) code = markDegradedArtifact(code);
 
     await fs.mkdir(cacheDir, { recursive: true });
     await fs.writeTextFile(cachePath, code);
@@ -315,6 +336,20 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
         detail:
           `[HTTP-CACHE] INVARIANT VIOLATION: File write succeeded but file does not exist: ${cachePath}`,
       });
+    }
+
+    if (degraded.length > 0) {
+      // The file on disk carries this render through, but the artifact is not
+      // the one this URL is supposed to produce. Keeping it out of the
+      // distributed cache and the in-memory path map means the next render
+      // retries the prefetch instead of inheriting one upstream blip for the
+      // lifetime of the distributed entry.
+      httpCacheLog.warn("Not caching a module with unresolved dynamic imports", {
+        url: normalizedUrl,
+        hash,
+        degraded,
+      });
+      return cachePath;
     }
 
     try {
@@ -385,7 +420,7 @@ export function cacheHttpImportsToLocal(
 ): Promise<CacheHttpImportsResult> {
   const requestOptions = prepareHttpCacheRequestOptions(options);
   return bundleAccumulatorStorage.run([], async () => {
-    const replacements = await buildReplacements(
+    const { replacements } = await buildReplacements(
       code,
       undefined,
       requestOptions,

--- a/src/transforms/esm/specifier-resolver.test.ts
+++ b/src/transforms/esm/specifier-resolver.test.ts
@@ -16,19 +16,19 @@ describe("transforms/esm/specifier-resolver", () => {
   describe("buildReplacements", () => {
     it("returns empty map for code with no imports", async () => {
       const result = await buildReplacements("const x = 1;", undefined, defaultOptions, noopCache);
-      assertEquals(result.size, 0);
+      assertEquals(result.replacements.size, 0);
     });
 
     it("returns empty map for internal bare specifiers", async () => {
       const code = `import { foo } from "#veryfront/utils";`;
       const result = await buildReplacements(code, undefined, defaultOptions, noopCache);
-      assertEquals(result.size, 0);
+      assertEquals(result.replacements.size, 0);
     });
 
     it("returns empty map for node: scheme", async () => {
       const code = `import fs from "node:fs";`;
       const result = await buildReplacements(code, undefined, defaultOptions, noopCache);
-      assertEquals(result.size, 0);
+      assertEquals(result.replacements.size, 0);
     });
 
     it("does not rewrite private import-map aliases to esm.sh fragments", async () => {
@@ -44,7 +44,7 @@ describe("transforms/esm/specifier-resolver", () => {
         },
       );
 
-      assertEquals(result.size, 0);
+      assertEquals(result.replacements.size, 0);
       assertEquals(cacheCalls, []);
     });
 
@@ -68,36 +68,39 @@ describe("transforms/esm/specifier-resolver", () => {
         },
       );
 
-      assertEquals(result.get("#pkg"), "./http-pkg.mjs");
+      assertEquals(result.replacements.get("#pkg"), "./http-pkg.mjs");
       assertEquals(cacheCalls, ["https://cdn.example.com/pkg.js"]);
     });
 
     it("returns empty map for jsr: specifiers", async () => {
       const code = `import { load } from "jsr:@std/dotenv@0.225.6";`;
       const result = await buildReplacements(code, undefined, defaultOptions, noopCache);
-      assertEquals(result.size, 0);
+      assertEquals(result.replacements.size, 0);
     });
 
     it("rewrites npm: specifiers when cache returns a path", async () => {
       const code = `import React from "npm:react@18";`;
       const mockCache: CacheHttpModuleFn = async () => "/tmp/cache/http-12345.mjs";
       const result = await buildReplacements(code, undefined, defaultOptions, mockCache);
-      assertEquals(result.has("npm:react@18"), true);
-      assertEquals(result.get("npm:react@18"), "file:///tmp/cache/http-12345.mjs");
+      assertEquals(result.replacements.has("npm:react@18"), true);
+      assertEquals(result.replacements.get("npm:react@18"), "file:///tmp/cache/http-12345.mjs");
     });
 
     it("npm: specifier falls back to bare name when cache returns null", async () => {
       const code = `import React from "npm:react@18";`;
       const result = await buildReplacements(code, undefined, defaultOptions, noopCache);
-      assertEquals(result.get("npm:react@18"), "react@18");
+      assertEquals(result.replacements.get("npm:react@18"), "react@18");
     });
 
     it("rewrites http URL when cache returns a path", async () => {
       const code = `import lodash from "https://esm.sh/lodash@4";`;
       const mockCache: CacheHttpModuleFn = async () => "/tmp/cache/http-99999.mjs";
       const result = await buildReplacements(code, undefined, defaultOptions, mockCache);
-      assertEquals(result.has("https://esm.sh/lodash@4"), true);
-      assertEquals(result.get("https://esm.sh/lodash@4"), "file:///tmp/cache/http-99999.mjs");
+      assertEquals(result.replacements.has("https://esm.sh/lodash@4"), true);
+      assertEquals(
+        result.replacements.get("https://esm.sh/lodash@4"),
+        "file:///tmp/cache/http-99999.mjs",
+      );
     });
 
     it("rewrites mapped esm.sh veryfront URLs to local framework modules without caching", async () => {
@@ -123,7 +126,7 @@ describe("transforms/esm/specifier-resolver", () => {
       );
 
       assertEquals(
-        result.get(specifier),
+        result.replacements.get(specifier),
         "/_vf_modules/_veryfront/chat/index.js?ssr=true",
       );
       assertEquals(cacheCalls, []);
@@ -138,7 +141,7 @@ describe("transforms/esm/specifier-resolver", () => {
         defaultOptions,
         mockCache,
       );
-      assertEquals(result.get("https://esm.sh/lodash@4"), "./http-99999.mjs");
+      assertEquals(result.replacements.get("https://esm.sh/lodash@4"), "./http-99999.mjs");
     });
 
     it("resolves relative specifiers against HTTP base URL", async () => {
@@ -150,14 +153,14 @@ describe("transforms/esm/specifier-resolver", () => {
         defaultOptions,
         mockCache,
       );
-      assertEquals(result.has("./utils.js"), true);
-      assertEquals(result.get("./utils.js"), "./http-11111.mjs");
+      assertEquals(result.replacements.has("./utils.js"), true);
+      assertEquals(result.replacements.get("./utils.js"), "./http-11111.mjs");
     });
 
     it("ignores relative specifiers without HTTP base URL", async () => {
       const code = `import { foo } from "./utils.js";`;
       const result = await buildReplacements(code, undefined, defaultOptions, noopCache);
-      assertEquals(result.size, 0);
+      assertEquals(result.replacements.size, 0);
     });
 
     it("skips a dynamic specifier whose cache lookup throws instead of aborting", async () => {
@@ -174,7 +177,7 @@ describe("transforms/esm/specifier-resolver", () => {
           throw new Error("cache failed");
         },
       );
-      assertEquals(result.size, 0);
+      assertEquals(result.replacements.size, 0);
     });
 
     it("aborts when a static specifier's cache lookup throws", async () => {
@@ -205,6 +208,69 @@ describe("transforms/esm/specifier-resolver", () => {
       );
     });
 
+    it("reports a skipped dynamic absolute URL as degraded", async () => {
+      const code = `export const load = () => import("https://esm.sh/foo");`;
+      const result = await buildReplacements(
+        code,
+        undefined,
+        defaultOptions,
+        async () => {
+          throw new Error("cache failed");
+        },
+      );
+      assertEquals(result.degraded, ["https://esm.sh/foo"]);
+    });
+
+    it("reports nothing as degraded when every specifier resolves", async () => {
+      const code = `import ok from "https://esm.sh/ok";`;
+      const result = await buildReplacements(
+        code,
+        undefined,
+        defaultOptions,
+        async () => "/tmp/cache/http-ok.mjs",
+      );
+      assertEquals(result.degraded, []);
+    });
+
+    it("aborts when a dynamic relative specifier fails to resolve", async () => {
+      // A relative specifier inside an esm.sh bundle resolves at call time
+      // against the local bundle cache directory, where the chunk was never
+      // written. Leaving it in place would guarantee a runtime failure.
+      const code = `export const load = () => import("./chunk-abc.mjs");`;
+      await assertRejects(
+        () =>
+          buildReplacements(code, "https://esm.sh/parent@1/index.js", defaultOptions, async () => {
+            throw new Error("cache failed");
+          }),
+        Error,
+        "cache failed",
+      );
+    });
+
+    it("aborts when a dynamic npm: specifier fails to resolve", async () => {
+      const code = `export const load = () => import("npm:redis");`;
+      await assertRejects(
+        () =>
+          buildReplacements(code, "https://esm.sh/parent@1/index.js", defaultOptions, async () => {
+            throw new Error("cache failed");
+          }),
+        Error,
+        "cache failed",
+      );
+    });
+
+    it("aborts when a dynamic bare specifier fails to resolve", async () => {
+      const code = `export const load = () => import("some-package");`;
+      await assertRejects(
+        () =>
+          buildReplacements(code, "https://esm.sh/parent@1/index.js", defaultOptions, async () => {
+            throw new Error("cache failed");
+          }),
+        Error,
+        "cache failed",
+      );
+    });
+
     it("still resolves other specifiers when a dynamic one throws", async () => {
       const code = `import ok from "https://esm.sh/ok";\n` +
         `export const load = () => import("https://esm.sh/broken");`;
@@ -213,8 +279,8 @@ describe("transforms/esm/specifier-resolver", () => {
         return "/tmp/cache/http-ok.mjs";
       };
       const result = await buildReplacements(code, undefined, defaultOptions, cache);
-      assertEquals(result.get("https://esm.sh/ok"), "file:///tmp/cache/http-ok.mjs");
-      assertEquals(result.has("https://esm.sh/broken"), false);
+      assertEquals(result.replacements.get("https://esm.sh/ok"), "file:///tmp/cache/http-ok.mjs");
+      assertEquals(result.replacements.has("https://esm.sh/broken"), false);
     });
   });
 
@@ -222,15 +288,15 @@ describe("transforms/esm/specifier-resolver", () => {
     it("returns code unchanged when no replacements needed", async () => {
       const code = `import fs from "node:fs";`;
       const result = await rewriteModuleImports(code, "", defaultOptions, noopCache);
-      assertEquals(result, code);
+      assertEquals(result.code, code);
     });
 
     it("rewrites http import in code", async () => {
       const code = `import React from "https://esm.sh/react@18";`;
       const mockCache: CacheHttpModuleFn = async () => "/tmp/cache/http-12345.mjs";
       const result = await rewriteModuleImports(code, "", defaultOptions, mockCache);
-      assertEquals(result.includes("file:///tmp/cache/http-12345.mjs"), true);
-      assertEquals(result.includes("https://esm.sh/react@18"), false);
+      assertEquals(result.code.includes("file:///tmp/cache/http-12345.mjs"), true);
+      assertEquals(result.code.includes("https://esm.sh/react@18"), false);
     });
 
     it("leaves a dynamic specifier untouched when its cache lookup throws", async () => {
@@ -245,7 +311,20 @@ describe("transforms/esm/specifier-resolver", () => {
           throw new Error("cache failed");
         },
       );
-      assertEquals(result, original);
+      assertEquals(result.code, original);
+    });
+
+    it("reports the specifiers left in place as degraded", async () => {
+      const original = `export const load = () => import("https://esm.sh/foo");`;
+      const result = await rewriteModuleImports(
+        original,
+        "https://esm.sh/parent",
+        defaultOptions,
+        async () => {
+          throw new Error("cache failed");
+        },
+      );
+      assertEquals(result.degraded, ["https://esm.sh/foo"]);
     });
 
     it("aborts when a static specifier's cache lookup throws", async () => {

--- a/src/transforms/esm/specifier-resolver.ts
+++ b/src/transforms/esm/specifier-resolver.ts
@@ -106,21 +106,26 @@ async function resolveSpecifier(
 }
 
 /**
- * Specifiers this module only ever reaches through `import(...)`.
+ * Specifiers the runtime can still resolve on its own if prefetching fails.
  *
- * The distinction decides what a resolution failure means. A static import is
- * part of the emitted module's own import graph, so the artifact contract holds
- * for it: every static dependency resolves to a local path before the module is
- * handed to the runtime loader, and a failure to do that is fatal, exactly as
- * it was before graceful degradation existed.
+ * Two conditions must hold together. The specifier must be reached only
+ * through `import(...)`, because a static import is part of the emitted
+ * module's own import graph: every static dependency resolves to a local path
+ * before the module is handed to the runtime loader, and a failure to do that
+ * is fatal, exactly as it was before graceful degradation existed. A dynamic
+ * specifier is resolved by the runtime at call time and is routinely guarded by
+ * the caller (`platform/adapters/redis/modules.js` only calls
+ * `await import("redis")` when the redis adapter is actually used), so failing
+ * to prefetch it leaves the specifier in place rather than taking down a render
+ * that would never have imported it.
  *
- * A dynamic specifier is resolved by the runtime at call time and is routinely
- * guarded by the caller (`platform/adapters/redis/modules.js` only calls
- * `await import("redis")` when the redis adapter is actually used). Pre-fetching
- * it is an optimisation, so failing to pre-fetch it leaves the specifier in
- * place rather than taking down a render that would never have imported it.
+ * The specifier must also be an absolute http(s) URL, because that is the only
+ * form the runtime can resolve without the transform. A relative specifier left
+ * in place resolves against the local bundle cache directory, where the chunk
+ * was never written; `npm:` and bare specifiers need the import map the cached
+ * module no longer carries. Those failures stay fatal.
  */
-function isDynamicOnly(imports: readonly ImportSpecifier[]): Set<string> {
+function runtimeResolvableSpecifiers(imports: readonly ImportSpecifier[]): Set<string> {
   const dynamic = new Set<string>();
   const staticSpecifiers = new Set<string>();
 
@@ -130,24 +135,43 @@ function isDynamicOnly(imports: readonly ImportSpecifier[]): Set<string> {
   }
 
   for (const specifier of staticSpecifiers) dynamic.delete(specifier);
+  for (const specifier of [...dynamic]) {
+    if (!isHttpUrl(specifier)) dynamic.delete(specifier);
+  }
   return dynamic;
+}
+
+/** Specifier replacements plus the specifiers that were left unresolved. */
+export interface SpecifierReplacements {
+  readonly replacements: ReadonlyMap<string, string>;
+  /** Specifiers left in place because prefetching them failed. */
+  readonly degraded: readonly string[];
+}
+
+/** Rewritten module code plus the specifiers that were left unresolved. */
+export interface RewrittenModule {
+  readonly code: string;
+  /** Specifiers left in place because prefetching them failed. */
+  readonly degraded: readonly string[];
 }
 
 /**
  * Build a map of specifier replacements by resolving all imports in the code.
  *
- * Resolution failure is fatal for a static import and best-effort for a
- * specifier only ever used in `import(...)`. See {@link isDynamicOnly}.
+ * Resolution failure is fatal unless the runtime can resolve the specifier on
+ * its own. See {@link runtimeResolvableSpecifiers}. Every specifier left in
+ * place is reported as degraded so callers can decide whether the resulting
+ * code is fit to cache.
  */
 export async function buildReplacements(
   code: string,
   baseUrl: string | undefined,
   options: CacheOptions,
   cacheHttpModule: CacheHttpModuleFn,
-): Promise<Map<string, string>> {
+): Promise<SpecifierReplacements> {
   const imports = await parseImports(code);
   const uniqueSpecifiers = [...new Set(imports.map((imp) => imp.n).filter(Boolean))] as string[];
-  const dynamicOnly = isDynamicOnly(imports);
+  const runtimeResolvable = runtimeResolvableSpecifiers(imports);
 
   const settled = await Promise.allSettled(
     uniqueSpecifiers.map(async (specifier) => ({
@@ -157,6 +181,7 @@ export async function buildReplacements(
   );
 
   const replacements = new Map<string, string>();
+  const degraded: string[] = [];
   for (let i = 0; i < settled.length; i++) {
     const outcome = settled[i];
     const specifier = uniqueSpecifiers[i];
@@ -168,31 +193,44 @@ export async function buildReplacements(
       continue;
     }
 
-    // A static import must resolve. Leaving one unresolved would emit a module
-    // whose own import graph reaches outside the local cache, which is not what
-    // the runtime loader is handed anywhere else.
-    if (!dynamicOnly.has(specifier)) throw outcome.reason;
+    // Anything the runtime cannot resolve on its own must resolve here.
+    // Leaving one unresolved would emit a module whose own import graph reaches
+    // outside the local cache, which is not what the runtime loader is handed
+    // anywhere else.
+    if (!runtimeResolvable.has(specifier)) throw outcome.reason;
 
+    degraded.push(specifier);
     logger.warn("Leaving an unresolvable dynamic specifier for runtime resolution", {
       specifier,
       error: outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason),
     });
   }
 
-  return replacements;
+  return { replacements, degraded };
 }
 
 /**
  * Rewrite all HTTP/npm/bare import specifiers in module code to local cached paths.
+ *
+ * Reports any specifier left in place, so the caller can keep the resulting
+ * code out of the caches that outlive this render.
  */
 export async function rewriteModuleImports(
   code: string,
   moduleUrl: string,
   options: CacheOptions,
   cacheHttpModule: CacheHttpModuleFn,
-): Promise<string> {
-  const replacements = await buildReplacements(code, moduleUrl, options, cacheHttpModule);
-  if (replacements.size === 0) return code;
+): Promise<RewrittenModule> {
+  const { replacements, degraded } = await buildReplacements(
+    code,
+    moduleUrl,
+    options,
+    cacheHttpModule,
+  );
+  if (replacements.size === 0) return { code, degraded };
 
-  return replaceSpecifiers(code, (specifier) => replacements.get(specifier) ?? null);
+  return {
+    code: await replaceSpecifiers(code, (specifier) => replacements.get(specifier) ?? null),
+    degraded,
+  };
 }


### PR DESCRIPTION
## Why

Follow-up to #2999. That PR made nested esm.sh specifier resolution soft-fail instead of throwing, but a degraded artifact could then become indistinguishable from a complete artifact. A transient child-module fetch failure could be written locally, pushed to the distributed bundle cache, and memoized for later renders.

The previous runtime-resolution premise is also only safe for absolute `http(s)` dynamic imports. Relative dynamic imports inside an esm.sh bundle resolve against the local bundle-cache directory, and `npm:` or bare dynamic imports need resolver/import-map context that the cached module no longer has.

## What

- `buildReplacements` and `rewriteModuleImports` now return both replacements and a `degraded` signal.
- HTTP module caching marks degraded artifacts for the current render, but skips distributed cache writes and skips the in-memory path map so the next render retries.
- Local cache hits detect the degraded marker and refetch instead of reusing the incomplete artifact.
- Dynamic soft-fail is restricted to absolute `http(s)` specifiers; relative, `npm:`, and bare dynamic resolution failures are fatal again.

## Verification

- `deno test --allow-all src/transforms/esm/http-cache.test.ts src/transforms/esm/specifier-resolver.test.ts`
- `deno task lint:sanitizer-baseline`
- `deno task lint`
- `deno task typecheck`

## Review status

Score: 94/100. Recommended next step: merge after GitHub required checks finish green.

## Operational note

Already-written unmarked degraded artifacts cannot be distinguished in code. If the remaining 24-hour distributed cache window matters during rollout, flush the HTTP module cache prefix.