### PR TITLE
fix(agent): materialize project sandbox tools

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1099",
+  "version": "0.1.1100",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -1134,10 +1134,19 @@ describe("internal-agents/run-stream", () => {
     assertStringIncludes(JSON.stringify(capturedMessages), "Continue and finish the diagram.");
   });
 
-  it("materializes explicitly configured sandbox bash before constructing the runtime", async () => {
+  it("materializes explicitly configured sandbox tools before constructing the runtime", async () => {
     const sessionManager = new AgentRunSessionManager();
     const sandboxInputs: AgentServiceSandboxToolsOptions[] = [];
     let capturedToolNames: string[] = [];
+    let capturedTools: Agent["config"]["tools"];
+    const parserInputSchema = {
+      parse: (input: unknown) => input,
+    };
+    const inputSchemaJson = {
+      type: "object" as const,
+      properties: {},
+      additionalProperties: true,
+    };
 
     const agent = {
       id: "builder-agent",
@@ -1147,6 +1156,8 @@ describe("internal-agents/run-stream", () => {
         system: "test",
         tools: {
           bash: true,
+          sandbox_read_file: true,
+          sandbox_write_file: true,
           missing_tool: true,
         },
         sandbox: {
@@ -1182,11 +1193,21 @@ describe("internal-agents/run-stream", () => {
             tools: {
               bash: {
                 description: "Run bash",
+                inputSchema: parserInputSchema,
+                inputSchemaJson,
                 execute: async () => ({ stdout: "ok", stderr: "", exitCode: 0 }),
               },
               sandbox_read_file: {
                 description: "Read sandbox file",
+                inputSchema: parserInputSchema,
+                inputSchemaJson,
                 execute: async () => "",
+              },
+              sandbox_write_file: {
+                description: "Write sandbox file",
+                inputSchema: parserInputSchema,
+                inputSchemaJson,
+                execute: async () => undefined,
               },
             },
             sandbox: {} as AgentServiceSandboxToolsResult["sandbox"],
@@ -1194,6 +1215,7 @@ describe("internal-agents/run-stream", () => {
           });
         },
         createRuntime: (_agent, mergedTools) => {
+          capturedTools = mergedTools;
           capturedToolNames = Object.keys(mergedTools ?? {}).sort();
           return {
             stream: async () =>
@@ -1207,7 +1229,26 @@ describe("internal-agents/run-stream", () => {
       },
     );
 
-    assertEquals(capturedToolNames, ["bash"]);
+    assertEquals(capturedToolNames, ["bash", "sandbox_read_file", "sandbox_write_file"]);
+    if (!capturedTools || capturedTools === true) {
+      throw new Error("Expected materialized sandbox tools");
+    }
+    for (const toolName of ["bash", "sandbox_read_file", "sandbox_write_file"]) {
+      const runtimeTool = capturedTools[toolName];
+      if (!runtimeTool || runtimeTool === true) {
+        throw new Error(`Expected materialized ${toolName}`);
+      }
+      assertEquals(runtimeTool.type, "dynamic");
+    }
+    const bash = capturedTools.bash;
+    if (!bash || bash === true || !bash.execute) {
+      throw new Error("Expected executable bash tool");
+    }
+    assertEquals(await bash.execute({}, { toolCallId: "bash-call" }), {
+      stdout: "ok",
+      stderr: "",
+      exitCode: 0,
+    });
     assertEquals(
       sandboxInputs.map((sandboxInput) => ({
         apiUrl: sandboxInput.apiUrl,

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -1139,9 +1139,6 @@ describe("internal-agents/run-stream", () => {
     const sandboxInputs: AgentServiceSandboxToolsOptions[] = [];
     let capturedToolNames: string[] = [];
     let capturedTools: Agent["config"]["tools"];
-    const parserInputSchema = {
-      parse: (input: unknown) => input,
-    };
     const inputSchemaJson = {
       type: "object" as const,
       properties: {},
@@ -1193,19 +1190,16 @@ describe("internal-agents/run-stream", () => {
             tools: {
               bash: {
                 description: "Run bash",
-                inputSchema: parserInputSchema,
                 inputSchemaJson,
                 execute: async () => ({ stdout: "ok", stderr: "", exitCode: 0 }),
               },
               sandbox_read_file: {
                 description: "Read sandbox file",
-                inputSchema: parserInputSchema,
                 inputSchemaJson,
                 execute: async () => "",
               },
               sandbox_write_file: {
                 description: "Write sandbox file",
-                inputSchema: parserInputSchema,
                 inputSchemaJson,
                 execute: async () => undefined,
               },

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -29,6 +29,7 @@ import {
 import { resolveHostedRuntimeAllowedToolNames } from "#veryfront/agent/hosted/runtime-essential-tools.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import {
+  createToolsFromHostDefinitions,
   isToolVisibleTo,
   type Tool,
   type ToolExecutionContext,
@@ -363,16 +364,20 @@ async function buildProjectAgentSandboxTools(input: {
     getProjectId: () => sandboxConfig.projectId ?? input.deps.projectAgentSandbox?.projectId,
   });
 
-  const bash = sandboxResult.tools[PROJECT_AGENT_SANDBOX_BASH_TOOL_NAME];
-  if (!bash) {
+  const declaredTools = input.agent.config.tools;
+  const materializedTools = createToolsFromHostDefinitions(sandboxResult.tools);
+  const configuredTools = isRecord(declaredTools)
+    ? Object.fromEntries(
+      Object.entries(materializedTools).filter(([toolName]) => declaredTools[toolName] === true),
+    )
+    : {};
+  if (!configuredTools[PROJECT_AGENT_SANDBOX_BASH_TOOL_NAME]) {
     await sandboxResult.closeSandbox();
     return {};
   }
 
   return {
-    tools: {
-      [PROJECT_AGENT_SANDBOX_BASH_TOOL_NAME]: bash as Tool,
-    },
+    tools: configuredTools,
     closeSandbox: sandboxResult.closeSandbox,
   };
 }

--- a/src/tool/host-tools.test.ts
+++ b/src/tool/host-tools.test.ts
@@ -124,6 +124,29 @@ describe("tool/host-tools", () => {
     assertEquals(executeCalls, 1);
   });
 
+  it("materializes JSON-schema-only host tool definitions", async () => {
+    const inputSchemaJson: JsonSchema = {
+      type: "object",
+      properties: { command: { type: "string" } },
+      required: ["command"],
+    };
+
+    const tools = createToolsFromHostDefinitions({
+      bash: {
+        description: "Run a sandbox command",
+        inputSchemaJson,
+        execute: (input: unknown) => input,
+      },
+    });
+
+    const bash = tools.bash;
+    if (!bash) throw new Error("bash tool was not materialized");
+    assertEquals(bash.type, "dynamic");
+    assertEquals(bash.inputSchemaJson, inputSchemaJson);
+    assertEquals(await bash.execute({ command: "true" }), { command: "true" });
+    await assertRejects(() => bash.execute("true"), Error, "input must be a non-null object");
+  });
+
   it("skips non-runnable host definitions", () => {
     const tools = createToolsFromHostDefinitions({
       missingExecute: {

--- a/src/tool/host-tools.ts
+++ b/src/tool/host-tools.ts
@@ -30,7 +30,6 @@ export type HostToolSet = Record<string, HostToolDefinition>;
 
 type RunnableHostToolDefinition = HostToolDefinition & {
   description: string;
-  inputSchema: unknown;
   execute: HostToolExecute;
 };
 
@@ -68,7 +67,11 @@ function isHostToolDefinition(value: unknown): value is RunnableHostToolDefiniti
   return (
     isRecord(value) &&
     typeof value.description === "string" &&
-    (isSchemaLike(value.inputSchema) || isParserBackedPrecomputedSchema(value)) &&
+    (
+      isSchemaLike(value.inputSchema) ||
+      isParserBackedPrecomputedSchema(value) ||
+      (value.inputSchema === undefined && isRecord(value.inputSchemaJson))
+    ) &&
     typeof value.execute === "function"
   );
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1099";
+export const VERSION = "0.1.1100";


### PR DESCRIPTION
## Summary
- materialize configured sandbox host tools in the managed project-agent runtime
- expose only sandbox tools explicitly declared by the source agent
- preserve the existing fail-closed bash requirement and sandbox cleanup
- release as Veryfront 0.1.1100

## Root cause
The managed internal agent path converted the sandbox provider result by retaining only `bash`. Project agents that explicitly configured `sandbox_write_file` and `sandbox_read_file` therefore advertised no executors for those aliases. The extraction agent could not stage its Kreuzberg request or read the result.

Staging red evidence:
- root run: `run_sched_797cbb84e90f440b8f5586482980d0e4`
- conversation: `26508295-3b74-532b-b451-29bdf55fd54a`
- extraction child: `1d5c736a-bee2-4e59-b020-248f01f568de`
- error: `Tool executor not found for bash` after the configured sandbox aliases were omitted

## Red / green / refactor
- **Red:** strengthened `internal-agents/run-stream` coverage to require `bash`, `sandbox_read_file`, and `sandbox_write_file`; before the fix it received only `bash`.
- **Green:** materialize the provider definitions through the shared host-tool adapter.
- **Refactor:** filter the materialized map back to the source agent's explicit tool IDs so no undeclared sandbox capability is exposed.

## Verification
- `deno test -A src/internal-agents/run-stream.test.ts --filter 'internal-agents/run-stream'`
- `deno fmt --check`
- `deno lint`
- `deno check`
- `deno task verify:quick`
- pre-push full formatting, lint, typecheck, and unit checks

Closes veryfront/veryfront-issue-inbox#90.