### PR TITLE
Inject project and environment context into internal agent runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1101",
+  "version": "0.1.1102",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/factory.ts
+++ b/src/agent/factory.ts
@@ -28,6 +28,7 @@ import { createError, toError } from "#veryfront/errors";
 import { COMMON_BLOCKED_PATTERNS, securityMiddleware } from "./middleware/security/validator.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { resolveConfiguredAgentModel } from "./runtime/model-resolution.ts";
+import { setEffectiveAgentSystem } from "./runtime/effective-agent-system.ts";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { getMessageSchema } from "./schemas/agent.schema.ts";
 import {
@@ -305,6 +306,7 @@ export function agent(config: AgentConfig): Agent {
     },
   };
 
+  setEffectiveAgentSystem(agentInstance, augmentedSystem);
   agentRegistry.register(id, agentInstance);
 
   return agentInstance;

--- a/src/agent/hosted/cloud-runtime-system-messages.ts
+++ b/src/agent/hosted/cloud-runtime-system-messages.ts
@@ -24,7 +24,10 @@ function createProjectInstructionsBlock(instructions: string): string {
   });
 }
 
-function createProjectContextBlock(input: { projectId: string; branchId?: string | null }): string {
+/** Builds the shared project-context prompt block (project reference + branch). */
+export function buildProjectContextPromptBlock(
+  input: { projectId: string; branchId?: string | null },
+): string {
   const branchLine = input.branchId
     ? `branch_id: "${input.branchId}"`
     : "branch_id: main (no branch_id needed for file operations)";
@@ -52,7 +55,7 @@ export function createVeryfrontCloudRuntimeSystemMessages(
 
   if (input.projectId) {
     runtimeBlocks.push(
-      createProjectContextBlock({
+      buildProjectContextPromptBlock({
         projectId: input.projectId,
         branchId: input.branchId,
       }),

--- a/src/agent/runtime/agent-invocation-contract.test.ts
+++ b/src/agent/runtime/agent-invocation-contract.test.ts
@@ -250,6 +250,8 @@ describe("agent/runtime-agent-invocation-contract", () => {
         project: {
           projectId,
           projectSlug: "demo-project",
+          runtimeTargetKind: "preview_branch",
+          runtimeTargetBranchId: branchId,
         },
         parentRunId: "run_root_1",
       },
@@ -265,6 +267,7 @@ describe("agent/runtime-agent-invocation-contract", () => {
       messages: parsed.messages,
       tools: parsed.tools,
       context: parsed.context,
+      runtimeTargetBranchId: branchId,
       credentials: parsed.credentials,
       agentSource: parsed.agentSource,
       forwardedProps: parsed.forwardedProps,

--- a/src/agent/runtime/agent-invocation-contract.ts
+++ b/src/agent/runtime/agent-invocation-contract.ts
@@ -380,6 +380,7 @@ export type RuntimeAgentControlPlaneStreamRequest = {
   messages: RuntimeAgentRunInvocation["messages"];
   tools: RuntimeAgentRunInvocation["tools"];
   context: RuntimeAgentRunInvocation["context"];
+  runtimeTargetBranchId?: RuntimeAgentProjectContext["runtimeTargetBranchId"];
   credentials?: RuntimeAgentRunInvocation["credentials"];
   agentSource: RuntimeAgentRunInvocation["agentSource"];
   agentConfig?: RuntimeAgentRunInvocation["agentConfig"];
@@ -398,6 +399,7 @@ export function buildRuntimeAgentControlPlaneStreamRequestFromInvocation(
     messages: input.messages,
     tools: input.tools,
     context: input.context,
+    runtimeTargetBranchId: input.run.project.runtimeTargetBranchId ?? null,
     ...(input.credentials ? { credentials: input.credentials } : {}),
     agentSource: input.agentSource,
     ...(input.agentConfig ? { agentConfig: input.agentConfig } : {}),

--- a/src/agent/runtime/effective-agent-system.ts
+++ b/src/agent/runtime/effective-agent-system.ts
@@ -1,0 +1,21 @@
+import type { Agent } from "../types.ts";
+
+type AgentSystem = Agent["config"]["system"];
+
+const EFFECTIVE_AGENT_SYSTEM = Symbol("veryfront.effectiveAgentSystem");
+
+type EffectiveSystemAgent = Agent & {
+  config: Agent["config"] & {
+    [EFFECTIVE_AGENT_SYSTEM]?: AgentSystem;
+  };
+};
+
+/** Records the system resolver used by an agent's private runtime. */
+export function setEffectiveAgentSystem(agent: Agent, system: AgentSystem): void {
+  (agent as EffectiveSystemAgent).config[EFFECTIVE_AGENT_SYSTEM] = system;
+}
+
+/** Returns the effective runtime system resolver, including through config-preserving wrappers. */
+export function getEffectiveAgentSystem(agent: Agent): AgentSystem {
+  return (agent as EffectiveSystemAgent).config[EFFECTIVE_AGENT_SYSTEM] ?? agent.config.system;
+}

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -799,6 +799,7 @@ describe("internal-agents/run-stream", () => {
   it("does not treat forwarded integration defs as grants without allowedTools", async () => {
     const sessionManager = new AgentRunSessionManager();
     let capturedAllowedRemoteTools: string[] | undefined;
+    let runtimeSystem: unknown;
 
     const agent = {
       id: "ops-agent",
@@ -824,7 +825,6 @@ describe("internal-agents/run-stream", () => {
           // The caller forwarded a definition for gmail__list_emails, so the
           // runtime can render metadata if it is otherwise granted, but the
           // definition itself is not the grant channel.
-          toolAllowlist: ["gmail__list_emails"],
           integrationToolDefinitions: [
             {
               name: "gmail__list_emails",
@@ -842,6 +842,7 @@ describe("internal-agents/run-stream", () => {
       {
         sessionManager,
         createRuntime: (runtimeAgent) => {
+          runtimeSystem = runtimeAgent.config.system;
           capturedAllowedRemoteTools = (
             runtimeAgent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] }
           ).__vfAllowedRemoteTools;
@@ -857,12 +858,16 @@ describe("internal-agents/run-stream", () => {
       },
     );
 
-    assertEquals(capturedAllowedRemoteTools, []);
+    assertEquals(capturedAllowedRemoteTools, undefined);
+    assertEquals(typeof runtimeSystem, "function");
+    const prompt = await (runtimeSystem as () => Promise<string>)();
+    assertEquals(prompt.includes("- gmail__list_emails"), false);
   });
 
   it("keeps allowlisted forwarded integration tools granted by allowedTools", async () => {
     const sessionManager = new AgentRunSessionManager();
     let capturedAllowedRemoteTools: string[] | undefined;
+    let runtimeSystem: unknown;
 
     const agent = {
       id: "ops-agent",
@@ -893,6 +898,11 @@ describe("internal-agents/run-stream", () => {
               description: "List emails",
               parameters: { type: "object", properties: {} },
             },
+            {
+              name: "gmail__delete_email",
+              description: "Delete an email",
+              parameters: { type: "object", properties: {} },
+            },
           ],
         },
       },
@@ -904,6 +914,7 @@ describe("internal-agents/run-stream", () => {
       {
         sessionManager,
         createRuntime: (runtimeAgent) => {
+          runtimeSystem = runtimeAgent.config.system;
           capturedAllowedRemoteTools = (
             runtimeAgent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] }
           ).__vfAllowedRemoteTools;
@@ -920,6 +931,10 @@ describe("internal-agents/run-stream", () => {
     );
 
     assertEquals(capturedAllowedRemoteTools, ["gmail__list_emails"]);
+    assertEquals(typeof runtimeSystem, "function");
+    const prompt = await (runtimeSystem as () => Promise<string>)();
+    assertStringIncludes(prompt, "- gmail__list_emails");
+    assertEquals(prompt.includes("- gmail__delete_email"), false);
   });
 
   it("allows a toolAllowlist subset of declared remote-source tools named like integrations", async () => {
@@ -1081,6 +1096,50 @@ describe("internal-agents/run-stream", () => {
     );
 
     assertEquals(capturedProviderTools, []);
+  });
+
+  it("omits provider tools unsupported by the configured model from the inventory", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let runtimeSystem: unknown;
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "openai/gpt-5.4-nano",
+        system: "test",
+        providerTools: ["web_search"],
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(input, agent, {
+      sessionManager,
+      createRuntime: (runtimeAgent) => {
+        runtimeSystem = runtimeAgent.config.system;
+        return {
+          stream: async () =>
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            }),
+        };
+      },
+    });
+
+    assertEquals(typeof runtimeSystem, "function");
+    const prompt = await (runtimeSystem as () => Promise<string>)();
+    assertEquals(prompt.includes("- web_search"), false);
   });
 
   it("preserves invoke_agent delegation for skill-enabled agents under toolAllowlist", async () => {

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -195,7 +195,18 @@ describe("internal-agents/run-stream", () => {
           },
         },
       ],
-      forwardedProps: {},
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: ["outlook__send_email"],
+          integrationToolDefinitions: [
+            {
+              name: "outlook__send_email",
+              description: "Send an Outlook email",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+        },
+      },
     } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
 
     await createRuntimeAgentStreamResponse(input, agent, {
@@ -225,6 +236,7 @@ describe("internal-agents/run-stream", () => {
     assertStringIncludes(prompt, '<runtime_info>\nmodel: "openai/gpt-5.4-nano"\n</runtime_info>');
     assertStringIncludes(prompt, "Current run tool inventory:");
     assertStringIncludes(prompt, "- create_file");
+    assertStringIncludes(prompt, "- outlook__send_email");
   });
 
   it("filters unavailable boolean source tool declarations before constructing the runtime", async () => {

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -1142,6 +1142,59 @@ describe("internal-agents/run-stream", () => {
     assertEquals(prompt.includes("- web_search"), false);
   });
 
+  it("keeps local tools required without protecting remote placeholders from provider caps", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    const remoteToolNames = Array.from(
+      { length: 150 },
+      (_, index) => `remote_${String(index).padStart(3, "0")}`,
+    );
+    let runtimeSystem: unknown;
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "openai/gpt-5.4-nano",
+        system: "test",
+        tools: Object.fromEntries([
+          ...remoteToolNames.map((toolName) => [toolName, true] as const),
+          ["zzz_local", { description: "Keep this local tool available" }],
+        ]),
+        __vfAllowedRemoteTools: [...remoteToolNames, "zzz_local"],
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(input, agent, {
+      sessionManager,
+      createRuntime: (runtimeAgent) => {
+        runtimeSystem = runtimeAgent.config.system;
+        return {
+          stream: async () =>
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            }),
+        };
+      },
+    });
+
+    assertEquals(typeof runtimeSystem, "function");
+    const prompt = await (runtimeSystem as () => Promise<string>)();
+    assertStringIncludes(prompt, "- zzz_local");
+    assertEquals(prompt.includes("- remote_127"), false);
+  });
+
   it("preserves invoke_agent delegation for skill-enabled agents under toolAllowlist", async () => {
     const sessionManager = new AgentRunSessionManager();
     let capturedToolNames: string[] = [];

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -166,6 +166,67 @@ describe("internal-agents/run-stream", () => {
     assertEquals(capturedMaxOutputTokens, 1200);
   });
 
+  it("composes the runtime system prompt with project, environment, and tool context", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedAgent: Agent | undefined;
+    const agent = {
+      id: "custom",
+      config: {
+        id: "custom",
+        model: "openai/gpt-5.4-nano",
+        system: "You are Custom Agent.",
+        tools: { create_file: { id: "create_file", type: "function", execute: () => "" } },
+      },
+    } as unknown as Agent;
+    const input = {
+      agentId: "custom",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [
+        {
+          type: "json",
+          title: "studio_context",
+          data: {
+            projectId: "ignored-when-sandbox-set",
+            branchId: null,
+            environmentContext: "<layout_context>\nVisible panels: [chat]\n</layout_context>",
+          },
+        },
+      ],
+      forwardedProps: {},
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(input, agent, {
+      sessionManager,
+      projectAgentSandbox: { projectId: "project-1" },
+      createRuntime: (runtimeAgent) => {
+        capturedAgent = runtimeAgent;
+        return {
+          stream: async () =>
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            }),
+        };
+      },
+    });
+
+    const system = capturedAgent?.config.system;
+    assertEquals(typeof system, "function");
+    const prompt = await (system as () => Promise<string>)();
+    assertStringIncludes(prompt, "You are Custom Agent.");
+    assertStringIncludes(prompt, 'project_reference: "project-1"');
+    assertStringIncludes(prompt, "branch_id: main (no branch_id needed for file operations)");
+    assertStringIncludes(prompt, "<environment_context>");
+    assertStringIncludes(prompt, "Visible panels: [chat]");
+    assertStringIncludes(prompt, '<runtime_info>\nmodel: "openai/gpt-5.4-nano"\n</runtime_info>');
+    assertStringIncludes(prompt, "Current run tool inventory:");
+    assertStringIncludes(prompt, "- create_file");
+  });
+
   it("filters unavailable boolean source tool declarations before constructing the runtime", async () => {
     const sessionManager = new AgentRunSessionManager();
     let capturedToolNames: string[] = [];

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -11,6 +11,8 @@ import {
   type RuntimeRemoteToolConfig,
 } from "#veryfront/agent/runtime/mcp-server-tool-sources.ts";
 import { buildRuntimeUsageTraceAttributes } from "#veryfront/agent/runtime/trace-usage.ts";
+import { getProviderNativeToolNames } from "#veryfront/agent/runtime/provider-native-tool-inventory.ts";
+import { selectProviderCompatibleToolNames } from "#veryfront/agent/runtime/provider-tool-compat.ts";
 import {
   convertAgentRuntimeMessagesToProviderMessages,
   convertProviderMessagesToAgentRuntimeMessages,
@@ -95,6 +97,7 @@ export interface RuntimeAgentStreamExecutionDeps {
   projectAgentSandbox?: {
     apiUrl?: string;
     authToken?: string;
+    branchId?: string | null;
     projectId?: string | null;
     sandboxEndpoint?: string;
   };
@@ -677,19 +680,30 @@ export async function createRuntimeAgentStreamResponse(
         typeof toolName === "string"
       )
       : []);
-  // The prompt inventory must cover the full model-visible surface: merged
-  // local/injected tools, provider-native tools, capped remote-source grants,
-  // and request-scoped forwarded integration tools — the latter two are
-  // exposed via __vfAllowedRemoteTools/__vfForwardedIntegrationToolDefs
-  // rather than mergedTools.
-  const runtimeToolNames = [
-    ...new Set([
-      ...(mergedTools && mergedTools !== true ? Object.keys(mergedTools) : []),
-      ...effectiveProviderToolNames,
-      ...(allowedRemoteToolNames ?? []),
-      ...(forwardedIntegrationToolDefs?.map((def) => def.name) ?? []),
-    ]),
-  ].sort();
+  const modelSupportedProviderToolNames = new Set(
+    getProviderNativeToolNames({ model: agent.config.model }),
+  );
+  const providerToolNames = effectiveProviderToolNames.filter((toolName) =>
+    modelSupportedProviderToolNames.has(toolName)
+  );
+  const localToolNames = mergedTools && mergedTools !== true ? Object.keys(mergedTools) : [];
+  const allowedRemoteToolNameSet = new Set(allowedRemoteToolNames ?? []);
+  const forwardedToolNames = (forwardedIntegrationToolDefs?.map((def) => def.name) ?? [])
+    .filter((toolName) => allowedRemoteToolNameSet.has(toolName));
+  const compatibleToolNames = selectProviderCompatibleToolNames(
+    [
+      ...new Set([
+        ...localToolNames,
+        ...(allowedRemoteToolNames ?? []),
+        ...forwardedToolNames,
+      ]),
+    ].sort(),
+    {
+      model: agent.config.model,
+      requiredToolNames: localToolNames,
+    },
+  );
+  const runtimeToolNames = [...new Set([...compatibleToolNames, ...providerToolNames])].sort();
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,
     config: {
@@ -698,6 +712,7 @@ export async function createRuntimeAgentStreamResponse(
         agent,
         runInput: input,
         projectId: deps.projectAgentSandbox?.projectId ?? null,
+        branchId: deps.projectAgentSandbox?.branchId,
         toolNames: runtimeToolNames,
       }),
       tools: mergedTools,

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -677,10 +677,17 @@ export async function createRuntimeAgentStreamResponse(
         typeof toolName === "string"
       )
       : []);
+  // The prompt inventory must cover the full model-visible surface: merged
+  // local/injected tools, provider-native tools, capped remote-source grants,
+  // and request-scoped forwarded integration tools — the latter two are
+  // exposed via __vfAllowedRemoteTools/__vfForwardedIntegrationToolDefs
+  // rather than mergedTools.
   const runtimeToolNames = [
     ...new Set([
       ...(mergedTools && mergedTools !== true ? Object.keys(mergedTools) : []),
       ...effectiveProviderToolNames,
+      ...(allowedRemoteToolNames ?? []),
+      ...(forwardedIntegrationToolDefs?.map((def) => def.name) ?? []),
     ]),
   ].sort();
   const runtimeAgent: RuntimeFilteredAgent = {

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -50,6 +50,7 @@ import {
   parseSseJsonEvents,
 } from "./ag-ui-sse.ts";
 import { AgentRunCancelledError, type AgentRunSessionManager } from "./session-manager.ts";
+import { createInternalAgentRunSystemPromptResolver } from "./run-system-prompt.ts";
 import type { RuntimeRunAgentInput } from "./schema.ts";
 import { serverLogger } from "#veryfront/utils";
 
@@ -670,10 +671,28 @@ export async function createRuntimeAgentStreamResponse(
         (toolName) => typeof toolName === "string" && runtimeToolAllowlist.has(toolName),
       )
       : undefined;
+  const effectiveProviderToolNames = cappedProviderTools ??
+    (Array.isArray(agent.config.providerTools)
+      ? agent.config.providerTools.filter((toolName): toolName is string =>
+        typeof toolName === "string"
+      )
+      : []);
+  const runtimeToolNames = [
+    ...new Set([
+      ...(mergedTools && mergedTools !== true ? Object.keys(mergedTools) : []),
+      ...effectiveProviderToolNames,
+    ]),
+  ];
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,
     config: {
       ...agent.config,
+      system: createInternalAgentRunSystemPromptResolver({
+        agent,
+        runInput: input,
+        projectId: deps.projectAgentSandbox?.projectId ?? null,
+        toolNames: runtimeToolNames,
+      }),
       tools: mergedTools,
       ...(cappedProviderTools !== undefined ? { providerTools: cappedProviderTools } : {}),
       ...(allowedRemoteToolNames !== undefined

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -682,7 +682,7 @@ export async function createRuntimeAgentStreamResponse(
       ...(mergedTools && mergedTools !== true ? Object.keys(mergedTools) : []),
       ...effectiveProviderToolNames,
     ]),
-  ];
+  ].sort();
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,
     config: {

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -690,10 +690,11 @@ export async function createRuntimeAgentStreamResponse(
   const allowedRemoteToolNameSet = new Set(allowedRemoteToolNames ?? []);
   const forwardedToolNames = (forwardedIntegrationToolDefs?.map((def) => def.name) ?? [])
     .filter((toolName) => allowedRemoteToolNameSet.has(toolName));
-  const compatibleToolNames = selectProviderCompatibleToolNames(
+  const runtimeToolNames = selectProviderCompatibleToolNames(
     [
       ...new Set([
         ...localToolNames,
+        ...providerToolNames,
         ...(allowedRemoteToolNames ?? []),
         ...forwardedToolNames,
       ]),
@@ -703,7 +704,6 @@ export async function createRuntimeAgentStreamResponse(
       requiredToolNames: localToolNames,
     },
   );
-  const runtimeToolNames = [...new Set([...compatibleToolNames, ...providerToolNames])].sort();
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,
     config: {

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -486,6 +486,29 @@ function applyRuntimeToolAllowlist(
   );
 }
 
+function getRequiredLocalToolNames(input: {
+  mergedTools: Agent["config"]["tools"];
+  availableLocalTools: Record<string, Tool | boolean>;
+  agent: Agent;
+}): string[] {
+  if (!input.mergedTools || input.mergedTools === true) {
+    return [];
+  }
+
+  return Object.entries(input.mergedTools)
+    .filter(([toolName, entry]) => {
+      if (entry && typeof entry === "object") {
+        return true;
+      }
+      if (Object.hasOwn(input.availableLocalTools, toolName)) {
+        return true;
+      }
+      const registryTool = toolRegistry.get(toolName);
+      return Boolean(registryTool && isToolVisibleTo(registryTool, { agentId: input.agent.id }));
+    })
+    .map(([toolName]) => toolName);
+}
+
 function getServerResolvedProjectToolNames(
   forwardedProps: RuntimeRunAgentInput["forwardedProps"],
 ): Set<string> {
@@ -686,14 +709,19 @@ export async function createRuntimeAgentStreamResponse(
   const providerToolNames = effectiveProviderToolNames.filter((toolName) =>
     modelSupportedProviderToolNames.has(toolName)
   );
-  const localToolNames = mergedTools && mergedTools !== true ? Object.keys(mergedTools) : [];
+  const mergedToolNames = mergedTools && mergedTools !== true ? Object.keys(mergedTools) : [];
   const allowedRemoteToolNameSet = new Set(allowedRemoteToolNames ?? []);
   const forwardedToolNames = (forwardedIntegrationToolDefs?.map((def) => def.name) ?? [])
     .filter((toolName) => allowedRemoteToolNameSet.has(toolName));
+  const localToolNames = getRequiredLocalToolNames({
+    mergedTools,
+    availableLocalTools,
+    agent,
+  });
   const runtimeToolNames = selectProviderCompatibleToolNames(
     [
       ...new Set([
-        ...localToolNames,
+        ...mergedToolNames,
         ...providerToolNames,
         ...(allowedRemoteToolNames ?? []),
         ...forwardedToolNames,

--- a/src/internal-agents/run-system-prompt.test.ts
+++ b/src/internal-agents/run-system-prompt.test.ts
@@ -1,6 +1,9 @@
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { Agent } from "#veryfront/agent";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { type Agent, agent } from "#veryfront/agent";
+import { agentRegistry } from "#veryfront/agent/composition/index.ts";
+import { registerSkill, skillRegistry } from "#veryfront/skill/registry.ts";
+import { toolRegistry } from "#veryfront/tool";
 import {
   composeInternalAgentRunSystemPrompt,
   getInternalAgentStudioRunContext,
@@ -37,6 +40,12 @@ function createStudioContextItem(data: Record<string, unknown>): unknown {
 }
 
 describe("internal-agents/run-system-prompt", () => {
+  afterEach(() => {
+    agentRegistry.clearAll();
+    skillRegistry.clearAll();
+    toolRegistry.clearAll();
+  });
+
   describe("getInternalAgentStudioRunContext", () => {
     it("extracts environment context, project id, and branch id", () => {
       const result = getInternalAgentStudioRunContext(
@@ -119,6 +128,21 @@ describe("internal-agents/run-system-prompt", () => {
       assertStringIncludes(prompt, 'branch_id: "branch-9"');
     });
 
+    it("prefers a trusted main branch target over Studio context", async () => {
+      const prompt = await composeInternalAgentRunSystemPrompt({
+        agent: createAgent(),
+        runInput: createRunInput([
+          createStudioContextItem({ projectId: "studio-project", branchId: "branch-9" }),
+        ]),
+        projectId: "sandbox-project",
+        branchId: null,
+        toolNames: [],
+      });
+
+      assertStringIncludes(prompt, "branch_id: main (no branch_id needed for file operations)");
+      assertEquals(prompt.includes('branch_id: "branch-9"'), false);
+    });
+
     it("includes the requested model in runtime info", async () => {
       const prompt = await composeInternalAgentRunSystemPrompt({
         agent: createAgent({ model: "openai/gpt-5.4-nano" }),
@@ -140,6 +164,35 @@ describe("internal-agents/run-system-prompt", () => {
 
       assertStringIncludes(prompt, "Base instructions with skill manifest.");
       assertStringIncludes(prompt, "- load_skill");
+    });
+
+    it("preserves the factory-resolved skill manifest", async () => {
+      registerSkill("support-triage", {
+        id: "support-triage",
+        metadata: {
+          name: "Support triage",
+          description: "Triage incoming support requests",
+        },
+        rootPath: "/test/skills/support-triage",
+      });
+      const skillAgent = agent({
+        id: "skill-agent",
+        system: "You are a support agent.",
+        skills: ["support-triage"],
+      });
+      const wrappedSkillAgent = {
+        ...skillAgent,
+        config: { ...skillAgent.config },
+      };
+
+      const prompt = await composeInternalAgentRunSystemPrompt({
+        agent: wrappedSkillAgent,
+        runInput: createRunInput(),
+        toolNames: ["load_skill"],
+      });
+
+      assertStringIncludes(prompt, "## Available Skills");
+      assertStringIncludes(prompt, "**support-triage**: Triage incoming support requests");
     });
 
     it("omits project and environment blocks when the run has no context", async () => {

--- a/src/internal-agents/run-system-prompt.test.ts
+++ b/src/internal-agents/run-system-prompt.test.ts
@@ -1,0 +1,145 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { Agent } from "#veryfront/agent";
+import {
+  composeInternalAgentRunSystemPrompt,
+  getInternalAgentStudioRunContext,
+} from "./run-system-prompt.ts";
+import type { RuntimeRunAgentInput } from "./schema.ts";
+
+const ENVIRONMENT_CONTEXT =
+  "<date_time>\nCurrent ISO date: 2026-07-22\n</date_time>\n\n<layout_context>\nVisible panels: [chat]\n</layout_context>";
+
+function createAgent(config: Partial<Agent["config"]> = {}): Agent {
+  return {
+    id: "custom-agent",
+    config: {
+      system: "You are Custom Agent.",
+      ...config,
+    },
+  } as Agent;
+}
+
+function createRunInput(
+  context: unknown[] = [],
+): RuntimeRunAgentInput {
+  return {
+    threadId: "3f1d8a58-4f65-4b0e-9a51-0a1c8b7f8f30",
+    runId: "run_1",
+    messages: [],
+    tools: [],
+    context,
+  } as unknown as RuntimeRunAgentInput;
+}
+
+function createStudioContextItem(data: Record<string, unknown>): unknown {
+  return { type: "json", title: "studio_context", data };
+}
+
+describe("internal-agents/run-system-prompt", () => {
+  describe("getInternalAgentStudioRunContext", () => {
+    it("extracts environment context, project id, and branch id", () => {
+      const result = getInternalAgentStudioRunContext(
+        createRunInput([
+          createStudioContextItem({
+            environmentContext: ENVIRONMENT_CONTEXT,
+            projectId: "project-1",
+            branchId: null,
+          }),
+        ]).context,
+      );
+
+      assertEquals(result.environmentContext, ENVIRONMENT_CONTEXT);
+      assertEquals(result.projectId, "project-1");
+      assertEquals(result.branchId, null);
+    });
+
+    it("ignores non-studio and malformed context items", () => {
+      const result = getInternalAgentStudioRunContext(
+        createRunInput([
+          { description: "classic ag-ui item", value: "ignored" },
+          { type: "json", title: "veryfront_invocation_context", data: { root_run_id: "run_1" } },
+          { type: "json", title: "studio_context", data: { environmentContext: "   " } },
+        ]).context,
+      );
+
+      assertEquals(result, {});
+    });
+  });
+
+  describe("composeInternalAgentRunSystemPrompt", () => {
+    it("appends project context, environment context, and tool inventory", async () => {
+      const prompt = await composeInternalAgentRunSystemPrompt({
+        agent: createAgent(),
+        runInput: createRunInput([
+          createStudioContextItem({
+            environmentContext: ENVIRONMENT_CONTEXT,
+            projectId: "project-1",
+            branchId: null,
+          }),
+        ]),
+        projectId: null,
+        toolNames: ["create_file", "update_file"],
+      });
+
+      assertStringIncludes(prompt, "You are Custom Agent.");
+      assertStringIncludes(prompt, '<project_context>\nproject_reference: "project-1"');
+      assertStringIncludes(prompt, "branch_id: main (no branch_id needed for file operations)");
+      assertStringIncludes(prompt, "<environment_context>");
+      assertStringIncludes(prompt, "Visible panels: [chat]");
+      assertStringIncludes(prompt, "Current run tool inventory:");
+      assertStringIncludes(prompt, "- create_file");
+      assertStringIncludes(prompt, "- update_file");
+    });
+
+    it("prefers the sandbox project id and renders explicit branch ids", async () => {
+      const prompt = await composeInternalAgentRunSystemPrompt({
+        agent: createAgent(),
+        runInput: createRunInput([
+          createStudioContextItem({ projectId: "studio-project", branchId: "branch-9" }),
+        ]),
+        projectId: "sandbox-project",
+        toolNames: [],
+      });
+
+      assertStringIncludes(prompt, 'project_reference: "sandbox-project"');
+      assertStringIncludes(prompt, 'branch_id: "branch-9"');
+    });
+
+    it("includes the requested model in runtime info", async () => {
+      const prompt = await composeInternalAgentRunSystemPrompt({
+        agent: createAgent({ model: "openai/gpt-5.4-nano" }),
+        runInput: createRunInput(),
+        toolNames: [],
+      });
+
+      assertStringIncludes(prompt, '<runtime_info>\nmodel: "openai/gpt-5.4-nano"\n</runtime_info>');
+    });
+
+    it("resolves function-based system prompts before composing", async () => {
+      const prompt = await composeInternalAgentRunSystemPrompt({
+        agent: createAgent({
+          system: () => Promise.resolve("Base instructions with skill manifest."),
+        }),
+        runInput: createRunInput(),
+        toolNames: ["load_skill"],
+      });
+
+      assertStringIncludes(prompt, "Base instructions with skill manifest.");
+      assertStringIncludes(prompt, "- load_skill");
+    });
+
+    it("omits project and environment blocks when the run has no context", async () => {
+      const prompt = await composeInternalAgentRunSystemPrompt({
+        agent: createAgent(),
+        runInput: createRunInput(),
+        toolNames: [],
+      });
+
+      assertEquals(prompt.includes("<project_context>"), false);
+      assertEquals(prompt.includes("<environment_context>"), false);
+      assertStringIncludes(prompt, "You are Custom Agent.");
+      assertStringIncludes(prompt, "- none");
+    });
+  });
+});

--- a/src/internal-agents/run-system-prompt.test.ts
+++ b/src/internal-agents/run-system-prompt.test.ts
@@ -65,6 +65,19 @@ describe("internal-agents/run-system-prompt", () => {
 
       assertEquals(result, {});
     });
+
+    it("trims values and drops whitespace-only branch ids", () => {
+      const result = getInternalAgentStudioRunContext(
+        createRunInput([
+          createStudioContextItem({
+            projectId: "  project-1  ",
+            branchId: "   ",
+          }),
+        ]).context,
+      );
+
+      assertEquals(result, { projectId: "project-1" });
+    });
   });
 
   describe("composeInternalAgentRunSystemPrompt", () => {

--- a/src/internal-agents/run-system-prompt.ts
+++ b/src/internal-agents/run-system-prompt.ts
@@ -70,13 +70,12 @@ export function getInternalAgentStudioRunContext(
 
     const environmentContext = getNonEmptyString(data.environmentContext);
     const projectId = getNonEmptyString(data.projectId);
+    const branchId = data.branchId === null ? null : getNonEmptyString(data.branchId);
 
     return {
       ...(environmentContext ? { environmentContext } : {}),
       ...(projectId ? { projectId } : {}),
-      ...(typeof data.branchId === "string" || data.branchId === null
-        ? { branchId: data.branchId }
-        : {}),
+      ...(branchId !== undefined ? { branchId } : {}),
     };
   }
 

--- a/src/internal-agents/run-system-prompt.ts
+++ b/src/internal-agents/run-system-prompt.ts
@@ -44,7 +44,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function getNonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function getStudioContextData(item: unknown): Record<string, unknown> | undefined {

--- a/src/internal-agents/run-system-prompt.ts
+++ b/src/internal-agents/run-system-prompt.ts
@@ -21,6 +21,7 @@
 import type { Agent } from "#veryfront/agent";
 import { buildProjectContextPromptBlock } from "#veryfront/agent/hosted/cloud-runtime-system-messages.ts";
 import { createRuntimeAgentSystemMessages } from "#veryfront/agent/runtime/agent-definition.ts";
+import { getEffectiveAgentSystem } from "#veryfront/agent/runtime/effective-agent-system.ts";
 import { getRuntimeAgentMarkdownDefinition } from "#veryfront/agent/runtime/agent-markdown-adapter.ts";
 import { createRuntimePromptBlock } from "#veryfront/agent/runtime/prompt-block.ts";
 import {
@@ -97,6 +98,7 @@ export type ComposeInternalAgentRunSystemPromptInput = {
   agent: Agent;
   runInput: RuntimeRunAgentInput;
   projectId?: string | null;
+  branchId?: string | null;
   toolNames: readonly string[];
 };
 
@@ -104,7 +106,7 @@ export type ComposeInternalAgentRunSystemPromptInput = {
 export async function composeInternalAgentRunSystemPrompt(
   input: ComposeInternalAgentRunSystemPromptInput,
 ): Promise<string> {
-  const baseInstructions = await resolveBaseSystemPrompt(input.agent.config.system);
+  const baseInstructions = await resolveBaseSystemPrompt(getEffectiveAgentSystem(input.agent));
   const studioContext = getInternalAgentStudioRunContext(input.runInput.context);
   const projectId = input.projectId ?? studioContext.projectId;
 
@@ -113,7 +115,7 @@ export async function composeInternalAgentRunSystemPrompt(
     runtimeBlocks.push(
       buildProjectContextPromptBlock({
         projectId,
-        branchId: studioContext.branchId ?? null,
+        branchId: input.branchId !== undefined ? input.branchId : studioContext.branchId ?? null,
       }),
     );
   }

--- a/src/internal-agents/run-system-prompt.ts
+++ b/src/internal-agents/run-system-prompt.ts
@@ -1,0 +1,150 @@
+/**
+ * Internal Agent Run System Prompt
+ *
+ * Composes the system prompt for project-runtime agent runs, mirroring the
+ * hosted chat runtime's instruction assembly. Before this, internal runs used
+ * the agent's authored instructions verbatim, so request-scoped agents (e.g.
+ * Studio-created project agents) never learned the project reference, branch,
+ * Studio environment context, or effective tool surface of the run they were
+ * executing in and asked users for values the harness already knew.
+ *
+ * The composed prompt extends the agent's resolved base instructions (which
+ * already include the factory's skill manifest for skill-enabled agents) with:
+ * - the shared project-context block (project reference + branch)
+ * - the requested model
+ * - the caller-supplied environment context (`studio_context` context item)
+ * - the effective run tool inventory
+ *
+ * @module
+ */
+
+import type { Agent } from "#veryfront/agent";
+import { buildProjectContextPromptBlock } from "#veryfront/agent/hosted/cloud-runtime-system-messages.ts";
+import { createRuntimeAgentSystemMessages } from "#veryfront/agent/runtime/agent-definition.ts";
+import { getRuntimeAgentMarkdownDefinition } from "#veryfront/agent/runtime/agent-markdown-adapter.ts";
+import { createRuntimePromptBlock } from "#veryfront/agent/runtime/prompt-block.ts";
+import {
+  flattenSystemInstructions,
+  withRuntimeToolInventory,
+} from "#veryfront/agent/runtime/tool-inventory.ts";
+import type { RuntimeRunAgentInput } from "./schema.ts";
+
+const STUDIO_CONTEXT_ITEM_TITLE = "studio_context";
+const DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant.";
+
+/** Caller-supplied run context extracted from the `studio_context` item. */
+export type InternalAgentStudioRunContext = {
+  environmentContext?: string;
+  projectId?: string;
+  branchId?: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function getStudioContextData(item: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(item) || item.type !== "json" || item.title !== STUDIO_CONTEXT_ITEM_TITLE) {
+    return undefined;
+  }
+  return isRecord(item.data) ? item.data : undefined;
+}
+
+/** Extracts the Studio-supplied run context from run context items. */
+export function getInternalAgentStudioRunContext(
+  context: RuntimeRunAgentInput["context"],
+): InternalAgentStudioRunContext {
+  for (const item of context) {
+    const data = getStudioContextData(item);
+    if (!data) {
+      continue;
+    }
+
+    const environmentContext = getNonEmptyString(data.environmentContext);
+    const projectId = getNonEmptyString(data.projectId);
+
+    return {
+      ...(environmentContext ? { environmentContext } : {}),
+      ...(projectId ? { projectId } : {}),
+      ...(typeof data.branchId === "string" || data.branchId === null
+        ? { branchId: data.branchId }
+        : {}),
+    };
+  }
+
+  return {};
+}
+
+async function resolveBaseSystemPrompt(system: Agent["config"]["system"]): Promise<string> {
+  if (typeof system === "string") {
+    return system;
+  }
+  if (typeof system === "function") {
+    return await system();
+  }
+  return DEFAULT_SYSTEM_PROMPT;
+}
+
+/** Input payload for compose internal agent run system prompt. */
+export type ComposeInternalAgentRunSystemPromptInput = {
+  agent: Agent;
+  runInput: RuntimeRunAgentInput;
+  projectId?: string | null;
+  toolNames: readonly string[];
+};
+
+/** Composes the internal agent run system prompt. */
+export async function composeInternalAgentRunSystemPrompt(
+  input: ComposeInternalAgentRunSystemPromptInput,
+): Promise<string> {
+  const baseInstructions = await resolveBaseSystemPrompt(input.agent.config.system);
+  const studioContext = getInternalAgentStudioRunContext(input.runInput.context);
+  const projectId = input.projectId ?? studioContext.projectId;
+
+  const runtimeBlocks: string[] = [];
+  if (projectId) {
+    runtimeBlocks.push(
+      buildProjectContextPromptBlock({
+        projectId,
+        branchId: studioContext.branchId ?? null,
+      }),
+    );
+  }
+  if (input.agent.config.model) {
+    runtimeBlocks.push(
+      createRuntimePromptBlock({
+        name: "runtime_info",
+        content: `model: "${input.agent.config.model}"`,
+      }),
+    );
+  }
+
+  const definition = getRuntimeAgentMarkdownDefinition(input.agent);
+  const messages = createRuntimeAgentSystemMessages({
+    agent: {
+      ...(definition ?? {
+        id: input.agent.id,
+        name: input.agent.config.name ?? input.agent.id,
+        description: input.agent.config.description ?? "",
+      }),
+      instructions: baseInstructions,
+    },
+    runtimeBlocks,
+    ...(studioContext.environmentContext
+      ? { environmentContext: studioContext.environmentContext }
+      : {}),
+  });
+
+  return flattenSystemInstructions(withRuntimeToolInventory(messages, input.toolNames));
+}
+
+/** Creates a lazy system prompt resolver for an internal agent run. */
+export function createInternalAgentRunSystemPromptResolver(
+  input: ComposeInternalAgentRunSystemPromptInput,
+): () => Promise<string> {
+  return () => composeInternalAgentRunSystemPrompt(input);
+}

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -73,6 +73,7 @@ export const getInternalAgentControlPlaneStreamRequestSchema = defineSchema((v) 
       (value) => isWithinJsonSizeLimit(value, 65_536),
       { message: "context must be less than 64 KB total" },
     ),
+    runtimeTargetBranchId: v.string().uuid().nullable().optional(),
     agentSource: getRuntimeAgentSourceContextSchema(),
     agentConfig: getRuntimeAgentMarkdownDefinitionSchema().optional().refine(
       (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_AGENT_CONFIG_BYTES),

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -193,6 +193,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
   it("streams AG-UI events for the signed runtime agent invocation envelope", async () => {
     let discoveryCalls = 0;
     let streamContext: Record<string, unknown> | undefined;
+    let runtimeSystem: unknown;
     const handler = new AgentStreamHandler({
       ensureProjectDiscovery: async () => {
         discoveryCalls += 1;
@@ -200,8 +201,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
       getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
       getAllAgentIds: () => ["assistant-1"],
       sessionManager: new AgentRunSessionManager(),
-      createRuntime: () => ({
+      createRuntime: (runtimeAgent) => ({
         stream: async (_messages, context, callbacks) => {
+          runtimeSystem = runtimeAgent.config.system;
           streamContext = context;
           callbacks?.onFinish?.({
             text: "hello from runtime",
@@ -239,7 +241,13 @@ describe("server/handlers/request/agent-stream.handler", () => {
       }),
     });
 
-    const body = createRuntimeAgentRunInvocationBody();
+    const invocation = JSON.parse(createRuntimeAgentRunInvocationBody());
+    invocation.context = [{
+      type: "json",
+      title: "studio_context",
+      data: { branchId: null },
+    }];
+    const body = JSON.stringify(invocation);
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
@@ -259,6 +267,13 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(discoveryCalls, 1);
     assertEquals(streamContext?.runId, "run_1");
     assertEquals(streamContext?.threadId, "10000000-1000-4000-8000-100000000001");
+    assertEquals(typeof runtimeSystem, "function");
+    const prompt = await (runtimeSystem as () => Promise<string>)();
+    assertStringIncludes(
+      prompt,
+      'branch_id: "10000000-1000-4000-8000-100000000006"',
+    );
+    assertEquals(prompt.includes("branch_id: main"), false);
 
     const text = await result.response.text();
     assertStringIncludes(text, "event: RunStarted");

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -706,7 +706,10 @@ describe("server/handlers/request/agent-stream.handler", () => {
 
       assertExists(result.response);
       assertEquals(result.response.status, 200);
-      assertEquals(capturedSystem, "Use project-scoped instructions.");
+      const resolvedSystem = typeof capturedSystem === "function"
+        ? await (capturedSystem as () => Promise<string>)()
+        : capturedSystem;
+      assertStringIncludes(String(resolvedSystem), "Use project-scoped instructions.");
       assertEquals(capturedSkills, ["support-triage"]);
       assertEquals((capturedTools as Record<string, unknown>).search_knowledge, true);
       assertEquals((capturedTools as Record<string, unknown>).get_file, true);
@@ -1604,7 +1607,8 @@ describe("server/handlers/request/agent-stream.handler", () => {
       OTEL_EXPORTER_OTLP_ENDPOINT: undefined,
       OTEL_RESOURCE_ATTRIBUTES: undefined,
     });
-    assertEquals(capturedSystem, "project_reference=support-agent-fork");
+    assertStringIncludes(capturedSystem ?? "", "project_reference=support-agent-fork");
+    assertStringIncludes(capturedSystem ?? "", '<project_context>\nproject_reference: "proj-1"');
     assertEquals(capturedMcpRequest, {
       url: "https://api.veryfront.org/mcp",
       authorization: "Bearer request-scoped-user-token",
@@ -1770,7 +1774,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       VERYFRONT_PROJECT_SLUG: "base-url-agent-fork",
       CUSTOM_PROJECT_ENV: "project-value-from-base-url",
     });
-    assertEquals(capturedSystem, `api=${apiBaseUrl}`);
+    assertStringIncludes(capturedSystem ?? "", `api=${apiBaseUrl}`);
     assertEquals(fetchUrls, [
       `${apiBaseUrl}/mcp`,
       `${apiBaseUrl}/projects/base-url-agent-fork/environments`,

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -780,6 +780,7 @@ export class AgentStreamHandler extends BaseHandler {
                     projectAgentSandbox: {
                       apiUrl: resolveVeryfrontApiBaseUrlFromHostEnv(),
                       authToken: apiAuthToken || undefined,
+                      branchId: payload.runtimeTargetBranchId,
                       projectId: sourceScopedContext.projectId ?? null,
                     },
                   });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1101";
+export const VERSION = "0.1.1102";


### PR DESCRIPTION
Fixes veryfront/veryfront-issue-inbox#73

## Problem

Studio-created custom project agents ask the user for `project_reference` and `branch_id` before calling tools like `create_file`, while the built-in Veryfront agent calls them immediately with the correct values.

Root cause: the two agent kinds execute on divergent paths. The built-in agent runs on the hosted chat runtime, where `buildVeryfrontCloudRuntimeInstructions` composes the system prompt from the agent instructions plus `<project_context>`, `<environment_context>` (from the `studio_context` context item), the skills manifest, and the tool inventory. Custom agents are dispatched with a request-scoped `agentConfig` to the project runtime, where `createRuntimeAgentStreamResponse` used the authored instructions **verbatim** — the run's `studio_context` item (environmentContext, projectId, branchId) was threaded only into tool execution, never into the prompt. Full trace in the issue comment: https://github.com/veryfront/veryfront-issue-inbox/issues/73#issuecomment-5043985783

## Fix

New `src/internal-agents/run-system-prompt.ts` composes the internal run system prompt the same way the hosted path does. `createRuntimeAgentStreamResponse` installs it as a lazy `system` resolver on the runtime agent:

- resolved base instructions (this preserves the `agent()` factory's automatic skill manifest for skill-enabled agents)
- `<project_context>` block — same shared builder as the hosted path (`buildProjectContextPromptBlock`, now exported), using the sandbox project id with `studio_context` as fallback
- `<runtime_info>` with the requested model
- `<environment_context>` from the `studio_context` context item
- run tool inventory from the effective merged tool surface (local + remote + provider tools after allowlisting)

Also bumps the version to 0.1.1102 for release.

## Tests

- `src/internal-agents/run-system-prompt.test.ts` — unit coverage for context extraction and prompt composition (9 steps)
- `src/internal-agents/run-stream.test.ts` — wiring test proving the runtime agent receives the composed prompt
- `src/server/handlers/request/agent-stream.handler.test.ts` — three assertions updated from exact-equal on the old verbatim system strings to includes-checks that also verify the new blocks appear end-to-end through the handler

## Follow-ups

- Verify in staging that a Studio-created custom agent now calls `create_file` with the correct `project_reference` without asking (issue repro).
- Verify Studio-created agents' skills actually resolve from the project runtime's skill registry at run time; if DB-defined skills never reach the registry, the (pre-existing) manifest mechanism stays empty — separate bug if confirmed.
- After merge: tag `v0.1.1102` on main (CI handles npm publish + binary upload), then bump the `veryfront` pin in veryfront-agent and project runtimes so deployed custom agents pick up the fix.
