### PR TITLE
Avoid allocating the full visible skill catalog for delegation checks

### DIFF
--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -466,12 +466,11 @@ function applyRuntimeToolAllowlist(
     // rather than silently skipping enforcement.
     return {};
   }
-  const visibleSkills = skillRegistry.resolveForAgent(true, { agentId: agent.id });
-  const availableSkillIds = visibleSkills.size > 0 ? [...visibleSkills.keys()] : undefined;
+  const hasVisibleSkills = skillRegistry.resolveForAgent(true, { agentId: agent.id }).size > 0;
   const allowedToolNames = resolveHostedRuntimeAllowedToolNames({
     allowedToolNames: toolAllowlist,
     localToolNames: Object.keys(mergedTools),
-    ...(availableSkillIds ? { availableSkillIds } : {}),
+    ...(hasVisibleSkills ? { availableSkillIds: ["*"] } : {}),
   });
   if (!allowedToolNames) {
     return mergedTools;

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -466,7 +466,7 @@ function applyRuntimeToolAllowlist(
     // rather than silently skipping enforcement.
     return {};
   }
-  const hasVisibleSkills = skillRegistry.resolveForAgent(true, { agentId: agent.id }).size > 0;
+  const hasVisibleSkills = skillRegistry.hasVisibleSkills({ agentId: agent.id });
   const allowedToolNames = resolveHostedRuntimeAllowedToolNames({
     allowedToolNames: toolAllowlist,
     localToolNames: Object.keys(mergedTools),

--- a/src/registry/project-scoped-registry-manager.test.ts
+++ b/src/registry/project-scoped-registry-manager.test.ts
@@ -194,6 +194,32 @@ describe("ProjectScopedRegistryManager", () => {
     });
   });
 
+  describe("some", () => {
+    it("short-circuits after the first matching effective item", () => {
+      const manager = createManager<string>("tool");
+      manager.register("first", "match");
+      manager.register("later", "skip");
+      const visited: string[] = [];
+
+      const matched = manager.some((item, id) => {
+        visited.push(id);
+        return item === "match";
+      });
+
+      assertEquals(matched, true);
+      assertEquals(visited, ["first"]);
+    });
+
+    it("tests project overrides instead of shadowed shared items", () => {
+      const manager = createManager<string>("tool");
+      manager.registerShared("tool-x", "shared");
+      manager.register("tool-x", "project");
+
+      assertEquals(manager.some((item) => item === "shared"), false);
+      assertEquals(manager.some((item) => item === "project"), true);
+    });
+  });
+
   describe("delete", () => {
     it("should delete a registered project item", () => {
       const manager = createManager<string>("tool");

--- a/src/registry/project-scoped-registry-manager.ts
+++ b/src/registry/project-scoped-registry-manager.ts
@@ -368,6 +368,29 @@ export class ProjectScopedRegistryManager<T> {
   }
 
   /**
+   * Test effective items without materializing the merged registry.
+   *
+   * Project items shadow shared items with the same id, matching `getAll()`.
+   * Iteration stops after the first match.
+   */
+  some(predicate: (item: T, id: string) => boolean): boolean {
+    const scopeId = this.getCurrentScopeId();
+    const projectRegistry = this.getActiveScopeRegistry(scopeId);
+
+    for (const [id, sharedItem] of this.sharedRegistry) {
+      const item = projectRegistry?.has(id) ? projectRegistry.get(id) as T : sharedItem;
+      if (predicate(item, id)) return true;
+    }
+
+    if (!projectRegistry) return false;
+    for (const [id, item] of projectRegistry) {
+      if (this.sharedRegistry.has(id)) continue;
+      if (predicate(item, id)) return true;
+    }
+    return false;
+  }
+
+  /**
    * Get all IDs for the current project (includes shared items).
    */
   getAllIds(): string[] {

--- a/src/skill/registry.ts
+++ b/src/skill/registry.ts
@@ -97,6 +97,11 @@ class SkillRegistryClass extends ScopedRegistryFacade<Skill> {
     }
     return ids;
   }
+
+  /** Whether at least one skill is visible without materializing a catalog. */
+  hasVisibleSkills(scope?: AgentCapabilityScope): boolean {
+    return this.manager.some((skill) => isSkillVisibleTo(skill, scope));
+  }
 }
 
 export const skillRegistry = new SkillRegistryClass(skillManager);

--- a/src/skill/skill-owner-scope.test.ts
+++ b/src/skill/skill-owner-scope.test.ts
@@ -106,6 +106,26 @@ Deno.test("getVisibleSkillIds excludes other agents' owned skills", () => {
   }
 });
 
+Deno.test("hasVisibleSkills applies owner scope without building a catalog", () => {
+  setupRegistry();
+  try {
+    assertEquals(skillRegistry.hasVisibleSkills({ agentId: "researcher" }), true);
+    assertEquals(skillRegistry.hasVisibleSkills({ agentId: "writer" }), true);
+
+    skillRegistry.clearAll();
+    registerSkill(
+      "researcher--cite",
+      makeSkill({ id: "researcher--cite", ownerAgentId: "researcher", shortName: "cite" }),
+    );
+
+    assertEquals(skillRegistry.hasVisibleSkills({ agentId: "researcher" }), true);
+    assertEquals(skillRegistry.hasVisibleSkills({ agentId: "writer" }), false);
+    assertEquals(skillRegistry.hasVisibleSkills(), false);
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
 Deno.test("load_skill rejects another agent's owned skill and enumerates only visible ids", async () => {
   setupRegistry();
   try {


### PR DESCRIPTION
## Summary

- preserve the owner-visible skill check used by restrictive runtime allowlists
- pass a one-element availability sentinel instead of materializing every visible skill ID
- add an allocation-free, short-circuiting scoped-registry predicate because `getAll()` also builds a merged `Map`
- preserve project-over-shared shadowing and owner visibility
- follow up on the final review comments from #3021 and #3022

This is behavior-neutral. The allowlist resolver only checks whether `availableSkillIds` is non-empty.

## Verification

- focused registry, skill ownership, run-stream, and allowlist tests: 16 passed, 85 steps, 0 failures
- `deno check` on all changed implementation files
- `deno fmt --check` on all changed files
- `deno lint` on all changed files
- full pre-push gate: 2,544 tests, 21,216 steps, 0 failures; format, lint, and typecheck passed
- independent code-review pass: no actionable findings

Related:
- https://github.com/veryfront/veryfront-code/pull/3021#discussion_r3630872007
- https://github.com/veryfront/veryfront-code/pull/3022#discussion_r3630952988