### PR TITLE
fix(build): fail on empty builds and default veryfront build to SSG

### DIFF
--- a/cli/commands/build/command-help.ts
+++ b/cli/commands/build/command-help.ts
@@ -21,11 +21,11 @@ export const buildHelp: CommandHelp = {
     },
     {
       flag: "--ssg",
-      description: "Enable static generation",
+      description: "Enable static generation (default; also configurable via build.ssg)",
     },
     {
       flag: "--no-ssg",
-      description: "Disable static generation when another option enables it",
+      description: "Disable static generation (the build fails if it would emit no pages)",
     },
     {
       flag: "--include <paths>",

--- a/cli/commands/build/command.ts
+++ b/cli/commands/build/command.ts
@@ -54,7 +54,7 @@ export function buildCommand(options: BuildOptions): Promise<void> {
 
         const stats = await runWithBundlerShutdown(async () => {
           const adapter = await runtime.get();
-          await getConfig(options.projectDir, adapter);
+          const config = await getConfig(options.projectDir, adapter);
           await ensureBuiltinContentProcessor();
 
           if (isJsonMode()) {
@@ -70,7 +70,10 @@ export function buildCommand(options: BuildOptions): Promise<void> {
             enableSplitting: options.splitting ?? true,
             enableCompression: options.compress ?? true,
             enablePrefetch: options.prefetch ?? true,
-            ssg: options.ssg ?? false,
+            // Explicit CLI flag > build.ssg in veryfront.config.ts > enabled.
+            // A non-SSG build emits no pages at all, so SSG must be the
+            // default for `veryfront build` to produce a deployable artifact.
+            ssg: options.ssg ?? config.build?.ssg ?? true,
             include: options.include,
             exclude: options.exclude,
             dryRun,

--- a/cli/commands/build/command.ts
+++ b/cli/commands/build/command.ts
@@ -54,7 +54,7 @@ export function buildCommand(options: BuildOptions): Promise<void> {
 
         const stats = await runWithBundlerShutdown(async () => {
           const adapter = await runtime.get();
-          const config = await getConfig(options.projectDir, adapter);
+          await getConfig(options.projectDir, adapter);
           await ensureBuiltinContentProcessor();
 
           if (isJsonMode()) {
@@ -70,10 +70,9 @@ export function buildCommand(options: BuildOptions): Promise<void> {
             enableSplitting: options.splitting ?? true,
             enableCompression: options.compress ?? true,
             enablePrefetch: options.prefetch ?? true,
-            // Explicit CLI flag > build.ssg in veryfront.config.ts > enabled.
-            // A non-SSG build emits no pages at all, so SSG must be the
-            // default for `veryfront build` to produce a deployable artifact.
-            ssg: options.ssg ?? config.build?.ssg ?? true,
+            // Tri-state: buildProduction resolves an omitted flag against
+            // build.ssg in veryfront.config.ts, then defaults to enabled.
+            ssg: options.ssg,
             include: options.include,
             exclude: options.exclude,
             dryRun,

--- a/cli/commands/build/config-display.ts
+++ b/cli/commands/build/config-display.ts
@@ -9,7 +9,7 @@ export function displayBuildConfig(options: BuildOptions): void {
     splitting = true,
     compress = true,
     prefetch = true,
-    ssg = false,
+    ssg = true,
     include,
     exclude,
     dryRun = false,

--- a/cli/commands/build/handler.test.ts
+++ b/cli/commands/build/handler.test.ts
@@ -62,8 +62,17 @@ describe("commands/build/handler", () => {
         assertEquals(result.data.split, true);
         assertEquals(result.data.compress, true);
         assertEquals(result.data.prefetch, true);
-        assertEquals(result.data.ssg, false);
+        assertEquals(result.data.ssg, undefined);
       }
+    });
+
+    it("keeps an explicit --ssg=false distinct from an omitted flag", () => {
+      const result = parseBuildArgs({
+        _: ["build"],
+        ssg: false,
+      });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.ssg, false);
     });
 
     it("parses ssg flag for static generation", () => {

--- a/cli/commands/build/handler.ts
+++ b/cli/commands/build/handler.ts
@@ -22,7 +22,7 @@ export const getBuildArgsSchema = defineSchema((v) =>
     compress: v.boolean().default(true),
     noCompress: v.boolean().default(false),
     prefetch: v.boolean().default(true),
-    ssg: v.boolean().default(false),
+    ssg: v.boolean().optional(),
     noSsg: v.boolean().default(false),
     include: v.array(v.string()).optional(),
     exclude: v.array(v.string()).optional(),
@@ -75,10 +75,10 @@ export async function handleBuildCommand(args: ParsedArgs): Promise<void> {
     splitting: opts.split && !opts.noSplit,
     compress: opts.compress && !opts.noCompress,
     prefetch: opts.prefetch,
-    // Tri-state: explicit --no-ssg wins, explicit --ssg enables, otherwise
-    // leave undefined so the command can fall back to build.ssg from
-    // veryfront.config.ts (and its default).
-    ssg: opts.noSsg ? false : opts.ssg ? true : undefined,
+    // Tri-state: explicit --no-ssg wins, an explicit --ssg / --ssg=false is
+    // passed through, and an omitted flag stays undefined so the build can
+    // fall back to build.ssg from veryfront.config.ts (and its default).
+    ssg: opts.noSsg ? false : opts.ssg,
     include: opts.include,
     exclude: opts.exclude,
     dryRun: opts.dryRun,

--- a/cli/commands/build/handler.ts
+++ b/cli/commands/build/handler.ts
@@ -75,7 +75,10 @@ export async function handleBuildCommand(args: ParsedArgs): Promise<void> {
     splitting: opts.split && !opts.noSplit,
     compress: opts.compress && !opts.noCompress,
     prefetch: opts.prefetch,
-    ssg: opts.ssg && !opts.noSsg,
+    // Tri-state: explicit --no-ssg wins, explicit --ssg enables, otherwise
+    // leave undefined so the command can fall back to build.ssg from
+    // veryfront.config.ts (and its default).
+    ssg: opts.noSsg ? false : opts.ssg ? true : undefined,
     include: opts.include,
     exclude: opts.exclude,
     dryRun: opts.dryRun,

--- a/cli/mcp/tools/build-tool.test.ts
+++ b/cli/mcp/tools/build-tool.test.ts
@@ -55,7 +55,7 @@ describe("mcp/tools/build-tool", () => {
       const parsed = vfBuild.inputSchema.parse({});
       assertEquals(parsed.splitting, true);
       assertEquals(parsed.compress, true);
-      assertEquals(parsed.ssg, true);
+      assertEquals(parsed.ssg, undefined);
       assertEquals(parsed.dryRun, false);
       assertEquals(parsed.outputDir, undefined);
     });

--- a/cli/mcp/tools/build-tool.test.ts
+++ b/cli/mcp/tools/build-tool.test.ts
@@ -55,7 +55,7 @@ describe("mcp/tools/build-tool", () => {
       const parsed = vfBuild.inputSchema.parse({});
       assertEquals(parsed.splitting, true);
       assertEquals(parsed.compress, true);
-      assertEquals(parsed.ssg, false);
+      assertEquals(parsed.ssg, true);
       assertEquals(parsed.dryRun, false);
       assertEquals(parsed.outputDir, undefined);
     });

--- a/cli/mcp/tools/build-tool.ts
+++ b/cli/mcp/tools/build-tool.ts
@@ -33,8 +33,10 @@ const getBuildInput = defineSchema((v) =>
     ssg: v
       .boolean()
       .optional()
-      .default(false)
-      .describe("Enable static site generation. Defaults to false."),
+      .default(true)
+      .describe(
+        "Enable static site generation. Defaults to true; disabling it produces no pages.",
+      ),
     dryRun: v
       .boolean()
       .optional()

--- a/cli/mcp/tools/build-tool.ts
+++ b/cli/mcp/tools/build-tool.ts
@@ -33,9 +33,9 @@ const getBuildInput = defineSchema((v) =>
     ssg: v
       .boolean()
       .optional()
-      .default(true)
       .describe(
-        "Enable static site generation. Defaults to true; disabling it produces no pages.",
+        "Enable static site generation. Defaults to build.ssg from veryfront.config.ts, " +
+          "then true; disabling it produces no pages.",
       ),
     dryRun: v
       .boolean()

--- a/src/build/production-build/build/build-initializer.test.ts
+++ b/src/build/production-build/build/build-initializer.test.ts
@@ -38,14 +38,14 @@ describe("build/production-build/build/build-initializer", () => {
       assertEquals(result.enablePrefetch, true);
     });
 
-    it("should default ssg to false", () => {
+    it("should default ssg to true", () => {
       const result = normalizeBuildOptions({ projectDir: "/project" });
-      assertEquals(result.ssg, false);
+      assertEquals(result.ssg, true);
     });
 
-    it("should respect explicitly enabled ssg", () => {
-      const result = normalizeBuildOptions({ projectDir: "/project", ssg: true });
-      assertEquals(result.ssg, true);
+    it("should respect explicitly disabled ssg", () => {
+      const result = normalizeBuildOptions({ projectDir: "/project", ssg: false });
+      assertEquals(result.ssg, false);
     });
 
     it("should default dryRun to false", () => {

--- a/src/build/production-build/build/build-initializer.test.ts
+++ b/src/build/production-build/build/build-initializer.test.ts
@@ -38,9 +38,9 @@ describe("build/production-build/build/build-initializer", () => {
       assertEquals(result.enablePrefetch, true);
     });
 
-    it("should default ssg to true", () => {
+    it("should leave an omitted ssg undefined for config resolution", () => {
       const result = normalizeBuildOptions({ projectDir: "/project" });
-      assertEquals(result.ssg, true);
+      assertEquals(result.ssg, undefined);
     });
 
     it("should respect explicitly disabled ssg", () => {

--- a/src/build/production-build/build/build-initializer.ts
+++ b/src/build/production-build/build/build-initializer.ts
@@ -50,7 +50,9 @@ export function normalizeBuildOptions(options: BuildOptions): BuildOptions {
     enableSplitting: options.enableSplitting ?? true,
     enableCompression: options.enableCompression ?? true,
     enablePrefetch: options.enablePrefetch ?? true,
-    ssg: options.ssg ?? false,
+    // Default to SSG: a non-SSG build collects no routes and emits no pages,
+    // which is never a servable artifact.
+    ssg: options.ssg ?? true,
     include: options.include,
     exclude: options.exclude,
     dryRun: options.dryRun ?? false,

--- a/src/build/production-build/build/build-initializer.ts
+++ b/src/build/production-build/build/build-initializer.ts
@@ -50,9 +50,10 @@ export function normalizeBuildOptions(options: BuildOptions): BuildOptions {
     enableSplitting: options.enableSplitting ?? true,
     enableCompression: options.enableCompression ?? true,
     enablePrefetch: options.enablePrefetch ?? true,
-    // Default to SSG: a non-SSG build collects no routes and emits no pages,
-    // which is never a servable artifact.
-    ssg: options.ssg ?? true,
+    // Deliberately left undefined when the caller did not choose: the
+    // orchestrator resolves it against build.ssg from veryfront.config.ts
+    // (loaded in initializeBuildContext), then defaults to enabled.
+    ssg: options.ssg,
     include: options.include,
     exclude: options.exclude,
     dryRun: options.dryRun ?? false,

--- a/src/build/production-build/build/build-orchestrator.test.ts
+++ b/src/build/production-build/build/build-orchestrator.test.ts
@@ -2,11 +2,14 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  assertBuildProducedOutput,
   buildProduction,
   cleanupCaches,
   cleanupRenderer,
   logBuildCompletion,
 } from "./build-orchestrator.ts";
+import type { BuildStats } from "#veryfront/server/build-types.ts";
+import type { CollectedRoutes } from "./route-collector.ts";
 
 describe("build/production-build/build/build-orchestrator", () => {
   describe("re-exports", () => {
@@ -35,6 +38,78 @@ describe("build/production-build/build/build-orchestrator", () => {
 
     it("should be a function", () => {
       assertEquals(typeof buildProduction, "function");
+    });
+  });
+
+  describe("assertBuildProducedOutput", () => {
+    const emptyStats: BuildStats = {
+      pages: 0,
+      components: 0,
+      chunks: 0,
+      assets: 0,
+      totalSize: 0,
+      duration: 0,
+    };
+    const noRoutes: CollectedRoutes = { pages: [], app: [] };
+    const someRoutes: CollectedRoutes = {
+      pages: [{ path: "/", file: "pages/index.tsx", slug: "index" }],
+      app: [],
+    };
+
+    it("throws when SSG is disabled and nothing was built", () => {
+      let error: Error | undefined;
+      try {
+        assertBuildProducedOutput(emptyStats, noRoutes, false, false);
+      } catch (e) {
+        error = e as Error;
+      }
+      assertEquals(error !== undefined, true);
+      assertEquals(
+        error?.message.includes("static site generation is disabled"),
+        true,
+      );
+    });
+
+    it("throws when SSG is enabled but no routes were found", () => {
+      let error: Error | undefined;
+      try {
+        assertBuildProducedOutput(emptyStats, noRoutes, true, false);
+      } catch (e) {
+        error = e as Error;
+      }
+      assertEquals(error?.message.includes("no routes were found"), true);
+    });
+
+    it("throws when routes were collected but no pages were generated", () => {
+      let error: Error | undefined;
+      try {
+        assertBuildProducedOutput(emptyStats, someRoutes, true, false);
+      } catch (e) {
+        error = e as Error;
+      }
+      assertEquals(error?.message.includes("1 route(s) were collected"), true);
+    });
+
+    it("does not throw for dry runs", () => {
+      assertBuildProducedOutput(emptyStats, noRoutes, false, true);
+    });
+
+    it("does not throw when pages were built", () => {
+      assertBuildProducedOutput(
+        { ...emptyStats, pages: 2 },
+        someRoutes,
+        true,
+        false,
+      );
+    });
+
+    it("does not throw when chunks were built", () => {
+      assertBuildProducedOutput(
+        { ...emptyStats, chunks: 3 },
+        someRoutes,
+        true,
+        false,
+      );
     });
   });
 });

--- a/src/build/production-build/build/build-orchestrator.ts
+++ b/src/build/production-build/build/build-orchestrator.ts
@@ -52,9 +52,12 @@ export function buildProduction(options: BuildOptions): Promise<BuildStats> {
         const enableSplitting = normalizedOptions.enableSplitting ?? true;
         const enablePrefetch = normalizedOptions.enablePrefetch ?? true;
         const enableCompression = normalizedOptions.enableCompression ?? true;
-        // Default to SSG: a non-SSG build collects no routes and therefore
-        // emits no pages, which is never a servable artifact.
-        const ssg = normalizedOptions.ssg ?? true;
+        // Explicit caller option > build.ssg in veryfront.config.ts > enabled.
+        // Resolved here (after initializeBuildContext loads the config) so
+        // every entry point — CLI, MCP tool, direct API — honors the config.
+        // Default to SSG because a non-SSG build collects no routes and
+        // therefore emits no pages, which is never a servable artifact.
+        const ssg = normalizedOptions.ssg ?? context.config.build?.ssg ?? true;
 
         await withSpan(
           "build.setupDirectories",

--- a/src/build/production-build/build/build-orchestrator.ts
+++ b/src/build/production-build/build/build-orchestrator.ts
@@ -13,7 +13,7 @@ import { initializeBuildContext, normalizeBuildOptions } from "./build-initializ
 import { setupBuildDirectories } from "./build-setup.ts";
 import { runCodeSplitting } from "./code-splitter-orchestrator.ts";
 import { generateAllOutputs } from "./output-generator.ts";
-import { collectAllRoutes } from "./route-collector.ts";
+import { collectAllRoutes, type CollectedRoutes } from "./route-collector.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { generateLocalReleaseAssetManifest } from "../local-release-assets.ts";
 
@@ -52,7 +52,9 @@ export function buildProduction(options: BuildOptions): Promise<BuildStats> {
         const enableSplitting = normalizedOptions.enableSplitting ?? true;
         const enablePrefetch = normalizedOptions.enablePrefetch ?? true;
         const enableCompression = normalizedOptions.enableCompression ?? true;
-        const ssg = normalizedOptions.ssg ?? false;
+        // Default to SSG: a non-SSG build collects no routes and therefore
+        // emits no pages, which is never a servable artifact.
+        const ssg = normalizedOptions.ssg ?? true;
 
         await withSpan(
           "build.setupDirectories",
@@ -145,6 +147,9 @@ export function buildProduction(options: BuildOptions): Promise<BuildStats> {
         );
 
         context.stats.duration = Date.now() - startTime;
+
+        assertBuildProducedOutput(context.stats, routes, ssg, dryRun);
+
         logBuildCompletion(context.stats);
 
         return context.stats;
@@ -154,6 +159,33 @@ export function buildProduction(options: BuildOptions): Promise<BuildStats> {
     },
     { "build.projectDir": options.projectDir },
   );
+}
+
+/**
+ * A build that emits zero pages and zero chunks is not a deployable artifact,
+ * so reporting it as a success lets broken releases through (an empty dist/
+ * deployed behind a "Build completed successfully" message serves only 404s).
+ * Fail the build instead, with a message that points at the actual cause.
+ */
+export function assertBuildProducedOutput(
+  stats: BuildStats,
+  routes: CollectedRoutes,
+  ssg: boolean,
+  dryRun: boolean,
+): void {
+  if (dryRun || stats.pages > 0 || stats.chunks > 0) return;
+
+  const routeCount = routes.pages.length + routes.app.length;
+  const message = !ssg
+    ? "Build produced no pages because static site generation is disabled. " +
+      "Remove --no-ssg (or set `build: { ssg: true }` in veryfront.config.ts) and rebuild."
+    : routeCount === 0
+    ? "Build produced no pages: no routes were found. " +
+      "Add a page (e.g. pages/index.tsx or app/page.tsx), or loosen the --include/--exclude filters."
+    : `Build produced no pages even though ${routeCount} route(s) were collected. ` +
+      "Check the build log for per-route errors.";
+
+  throw toError(createError({ type: "build", message }));
 }
 
 export { cleanupCaches, cleanupRenderer, logBuildCompletion };

--- a/src/config/schemas/config.schema.test.ts
+++ b/src/config/schemas/config.schema.test.ts
@@ -14,6 +14,25 @@ describe("configSchema", () => {
     assertEquals(findUnknownTopLevelKeys({ foo: 1, router: "pages" }), ["foo"]);
   });
 
+  it("accepts build.ssg as a boolean", () => {
+    const enabled = validateVeryfrontConfig({ build: { ssg: true } });
+    assertEquals(enabled.build?.ssg, true);
+
+    const disabled = validateVeryfrontConfig({ build: { ssg: false } });
+    assertEquals(disabled.build?.ssg, false);
+
+    const omitted = validateVeryfrontConfig({ build: {} });
+    assertEquals(omitted.build?.ssg, undefined);
+  });
+
+  it("rejects non-boolean build.ssg", () => {
+    assertThrows(
+      () => validateVeryfrontConfig({ build: { ssg: "yes" } }),
+      Error,
+      "Invalid veryfront.config at build.ssg:",
+    );
+  });
+
   it("gives helpful error for invalid cors", () => {
     assertThrows(
       () => validateVeryfrontConfig({ security: { cors: { origin: 123 } } }),

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -76,6 +76,12 @@ export const getVeryfrontConfigSchema = defineSchema((v) =>
         .object({
           outDir: v.string().optional(),
           trailingSlash: v.boolean().optional(),
+          /**
+           * Generate static HTML for all routes during `veryfront build`.
+           * Defaults to true; disabling it produces no pages, so only turn it
+           * off for builds that intentionally skip static generation.
+           */
+          ssg: v.boolean().optional(),
           esbuild: v
             .object({
               wasmURL: v.string().url().optional(),

--- a/tests/integration/server/build/build.test.ts
+++ b/tests/integration/server/build/build.test.ts
@@ -142,6 +142,34 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
       });
     });
 
+    it("honors build.ssg from veryfront.config.ts when the caller omits ssg", async () => {
+      await withTestContext("build-config-ssg-off", async (context) => {
+        const outputDir = join(context.projectDir, "dist");
+
+        await removeAppDir(context.projectDir);
+
+        const pagesDir = await ensurePagesDir(context.projectDir);
+        await writeTextFile(join(pagesDir, "index.mdx"), "# Home Page");
+        await writeTextFile(
+          join(context.projectDir, "veryfront.config.js"),
+          `export default { build: { ssg: false } };`,
+        );
+
+        await assertRejects(
+          () =>
+            buildProduction({
+              projectDir: context.projectDir,
+              outputDir,
+              enableSplitting: false,
+              enableCompression: false,
+              enablePrefetch: false,
+            }),
+          Error,
+          "static site generation is disabled",
+        );
+      });
+    });
+
     it("fails for an empty project instead of emitting nothing", async () => {
       await withTestContext("build-empty", async (context) => {
         const outputDir = join(context.projectDir, "dist");

--- a/tests/integration/server/build/build.test.ts
+++ b/tests/integration/server/build/build.test.ts
@@ -13,7 +13,7 @@
 import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert";
 import { join } from "#veryfront/compat/path";
 import { afterAll, describe, it } from "#veryfront/testing/bdd";
-import { mkdir, readDir, remove, stat, writeTextFile } from "#veryfront/compat/fs.ts";
+import { mkdir, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { buildProduction } from "../../../../src/build/production-build/index.ts";
 import type { BuildStats } from "../../../../src/server/build-types.ts";
 import { withTestContext } from "../../../_helpers/context.ts";
@@ -27,15 +27,6 @@ async function ensurePagesDir(projectDir: string): Promise<string> {
   const pagesDir = join(projectDir, "pages");
   await mkdir(pagesDir, { recursive: true });
   return pagesDir;
-}
-
-async function dirExists(path: string): Promise<boolean> {
-  try {
-    await stat(path);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
@@ -75,7 +66,7 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
       });
     });
 
-    it("with --no-ssg produces no HTML", async () => {
+    it("with --no-ssg fails instead of reporting an empty build as success", async () => {
       await withTestContext("build-no-ssg", async (context) => {
         const outputDir = join(context.projectDir, "dist");
 
@@ -84,24 +75,19 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
         const pagesDir = await ensurePagesDir(context.projectDir);
         await writeTextFile(join(pagesDir, "index.mdx"), "# Home Page");
 
-        const stats = await buildProduction({
-          projectDir: context.projectDir,
-          outputDir,
-          enableSplitting: false,
-          enableCompression: false,
-          enablePrefetch: false,
-          ssg: false,
-        });
-
-        assertExists(stats);
-
-        if (!(await dirExists(outputDir))) return;
-
-        let htmlCount = 0;
-        for await (const e of readDir(outputDir)) {
-          if (e.isFile && e.name.endsWith(".html")) htmlCount++;
-        }
-        assertEquals(htmlCount, 0);
+        await assertRejects(
+          () =>
+            buildProduction({
+              projectDir: context.projectDir,
+              outputDir,
+              enableSplitting: false,
+              enableCompression: false,
+              enablePrefetch: false,
+              ssg: false,
+            }),
+          Error,
+          "static site generation is disabled",
+        );
       });
     });
 
@@ -156,24 +142,25 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
       });
     });
 
-    it("handles empty project", async () => {
+    it("fails for an empty project instead of emitting nothing", async () => {
       await withTestContext("build-empty", async (context) => {
         const outputDir = join(context.projectDir, "dist");
 
         await removeAppDir(context.projectDir);
         await remove(join(context.projectDir, "pages"), { recursive: true });
 
-        const stats = await buildProduction({
-          projectDir: context.projectDir,
-          outputDir,
-          enableSplitting: false,
-          enableCompression: false,
-          enablePrefetch: false,
-        });
-
-        assertExists(stats);
-        assertEquals(stats.pages, 0);
-        assertEquals(stats.assets, 0);
+        await assertRejects(
+          () =>
+            buildProduction({
+              projectDir: context.projectDir,
+              outputDir,
+              enableSplitting: false,
+              enableCompression: false,
+              enablePrefetch: false,
+            }),
+          Error,
+          "no routes were found",
+        );
       });
     });
 

--- a/tests/integration/server/production-server.test.ts
+++ b/tests/integration/server/production-server.test.ts
@@ -60,6 +60,13 @@ describe(
               join(context.projectDir, "public", "styles.css"),
               "body { margin: 0; }",
             );
+            // The build now fails when it produces zero pages, so the static
+            // asset fixture needs at least one route.
+            await mkdir(join(context.projectDir, "pages"), { recursive: true });
+            await writeTextFile(
+              join(context.projectDir, "pages", "index.mdx"),
+              "# Static Assets Fixture",
+            );
 
             await buildProduction({
               projectDir: context.projectDir,


### PR DESCRIPTION
## Summary

`veryfront build` defaulted `ssg` to `false`, so route collection was skipped entirely: the build emitted **zero pages, zero chunks**, exited 0, and printed "✨ Your site is ready for deployment!". Deploying that artifact serves only 404s — the silent-failure shape reported in veryfront/veryfront-issue-inbox#83 and root-caused in veryfront/veryfront-issue-inbox#89 (defect 1).

Three changes:

1. **SSG is now the default** — in the CLI (`--ssg`/`--no-ssg` flags remain, now tri-state), in `buildProduction` / `normalizeBuildOptions` (library default), and in the MCP `build` tool. A build that collects no routes is never a servable artifact, so opt-out is explicit.
2. **`build.ssg` is configurable in `veryfront.config.ts`** — previously the flag was CLI-only and unreachable for deployed projects. Precedence: explicit CLI flag > `config.build.ssg` > `true`.
3. **Empty builds fail loudly** — `assertBuildProducedOutput` rejects any non-dry-run build that produced zero pages and zero chunks, with a message that distinguishes the three causes (SSG disabled / no routes found / routes collected but nothing generated). Exit code 1 instead of "ready for deployment".

## Verification

Reproduced the original bug from CLI source (2-page project → 0 files, exit 0), then verified after the fix:

- default `veryfront build` → 2 static pages + chunks + data, exit 0
- `--no-ssg` → exit 1: *"Build produced no pages because static site generation is disabled…"*
- empty project → exit 1: *"…no routes were found. Add a page (e.g. pages/index.tsx or app/page.tsx)…"*
- `build: { ssg: false }` in config → respected (fails loudly); `--ssg` flag overrides config → succeeds

Tests: new unit tests for the guard, config schema, and initializer default; updated the integration tests that encoded the old empty-success contract. Affected set: 26 files / 233 steps green; full pre-push suite passed. Lint + typecheck clean.

## Out of scope

Defect 2 of veryfront/veryfront-issue-inbox#89 (`--ssg` fails with ~198 esbuild errors on projects whose pages reach the framework's server deps) is a separate fix in the code splitter externals — not addressed here. Also note `veryfront deploy` does not invoke this build (releases are created from pushed source; hosted serving is runtime SSR), so the hosted-404 investigation in issue #83 should additionally confirm the server-side path.

Fixes veryfront/veryfront-issue-inbox#89. Addresses the CLI portion of veryfront/veryfront-issue-inbox#83.