### PR TITLE
fix: add local AG-UI agent fallback

### DIFF
--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -62,6 +62,67 @@ describe("APIRouteHandler", () => {
   });
 
   describe("request handling - unmatched routes", () => {
+    it("should let an optional route-miss handler serve unmatched API routes", async () => {
+      const adapter = createMockAdapter();
+      const handler = new APIRouteHandler("/test/project", adapter, {
+        onRouteMiss: ({ pathname }) =>
+          pathname === "/api/ag-ui" ? Response.json({ fallback: true }) : null,
+      });
+      handlers.push(handler);
+      await handler.initialize();
+
+      const response = await handler.handle(
+        new Request("http://localhost/api/ag-ui", { method: "POST" }),
+      );
+
+      assertEquals(response?.status, 200);
+      assertEquals(await response?.json(), { fallback: true });
+    });
+
+    it("should keep the normal 404 when the route-miss handler declines", async () => {
+      const adapter = createMockAdapter();
+      const handler = new APIRouteHandler("/test/project", adapter, {
+        onRouteMiss: () => null,
+      });
+      handlers.push(handler);
+      await handler.initialize();
+
+      const response = await handler.handle(new Request("http://localhost/api/notfound"));
+
+      assertEquals(response?.status, 404);
+    });
+
+    it("should not call the route-miss handler when a concrete API route matches", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/ag-ui.ts",
+        "export function POST() { return Response.json({ explicit: true }); }",
+      );
+      __injectDepsForTests({
+        loadHandlerModule: () =>
+          Promise.resolve({
+            POST: () => Response.json({ explicit: true }),
+          }),
+      });
+      let misses = 0;
+      const handler = new APIRouteHandler("/test/project", adapter, {
+        onRouteMiss: () => {
+          misses++;
+          return Response.json({ fallback: true });
+        },
+      });
+      handlers.push(handler);
+      await handler.initialize();
+
+      const response = await handler.handle(
+        new Request("http://localhost/api/ag-ui", { method: "POST" }),
+      );
+
+      assertEquals(response?.status, 200);
+      assertEquals(await response?.json(), { explicit: true });
+      assertEquals(misses, 0);
+    });
+
     it("should return null for non-API routes", async () => {
       const adapter = createMockAdapter();
       const handler = await createInitializedHandler("/test/project", adapter);

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -21,6 +21,21 @@ const HANDLER_CACHE_MAX_ENTRIES = 256;
 
 export type { APIContext, APIRoute };
 
+export interface ApiRouteMissInput {
+  request: Request;
+  ctx?: HandlerContext;
+  pathname: string;
+}
+
+export type ApiRouteMissHandler = (
+  input: ApiRouteMissInput,
+) => Response | null | Promise<Response | null>;
+
+export interface APIRouteHandlerOptions {
+  onRouteMiss?: ApiRouteMissHandler;
+  onDestroy?: () => void;
+}
+
 /** Longest sanitised load error a response body carries. */
 const MAX_LOAD_ERROR_LENGTH = 300;
 
@@ -122,6 +137,7 @@ export class APIRouteHandler {
   constructor(
     private projectDir: string,
     adapter?: RuntimeAdapter,
+    private options: APIRouteHandlerOptions = {},
   ) {
     this.adapter = adapter ?? null;
     this.adapterPromise = adapter ? Promise.resolve(adapter) : null;
@@ -206,6 +222,9 @@ export class APIRouteHandler {
             isApiPath: pathname.startsWith("/api/"),
             availableRoutes: this.router.listRoutes().map((r) => r.pattern),
           });
+
+          const routeMissResponse = await this.options.onRouteMiss?.({ request, ctx, pathname });
+          if (routeMissResponse) return routeMissResponse;
 
           if (pathname === "/api" || pathname.startsWith("/api/")) return notFound();
           return null;
@@ -344,6 +363,7 @@ export class APIRouteHandler {
     this.destroyed = true;
     this.routeCache.destroy();
     this.router.destroy();
+    this.options.onDestroy?.();
   }
 
   private async ensureAdapter(): Promise<RuntimeAdapter> {

--- a/src/routing/api/index.ts
+++ b/src/routing/api/index.ts
@@ -5,7 +5,15 @@
  */
 
 export { APIRouteHandler } from "./handler.ts";
-export type { APIContext, APIHandler, APIResponse, APIRoute } from "./handler.ts";
+export type {
+  APIContext,
+  APIHandler,
+  APIResponse,
+  APIRoute,
+  APIRouteHandlerOptions,
+  ApiRouteMissHandler,
+  ApiRouteMissInput,
+} from "./handler.ts";
 
 export { ApiRouteMatcher } from "./api-route-matcher.ts";
 export type { Route, RouteMatch } from "./api-route-matcher.ts";

--- a/src/server/handlers/request/api/dev-agent-ag-ui-fallback.test.ts
+++ b/src/server/handlers/request/api/dev-agent-ag-ui-fallback.test.ts
@@ -1,0 +1,173 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { CONFIG_INVALID } from "#veryfront/errors";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { DevAgentAgUiFallback } from "./dev-agent-ag-ui-fallback.ts";
+
+function createContext(
+  adapter: ReturnType<typeof createMockAdapter>,
+  isLocalProject = true,
+): HandlerContext {
+  return {
+    projectDir: "/test/project",
+    adapter,
+    securityConfig: null,
+    cspUserHeader: null,
+    isLocalProject,
+  };
+}
+
+function createMissInput(
+  input: {
+    adapter: ReturnType<typeof createMockAdapter>;
+    url?: string;
+    method?: string;
+    isLocalProject?: boolean;
+  },
+) {
+  const request = new Request(input.url ?? "http://localhost/api/ag-ui", {
+    method: input.method ?? "POST",
+  });
+  return {
+    request,
+    pathname: new URL(request.url).pathname,
+    ctx: createContext(input.adapter, input.isLocalProject ?? true),
+  };
+}
+
+describe("DevAgentAgUiFallback", () => {
+  it("delegates exact local POST /api/ag-ui misses to the hosted route set", async () => {
+    const adapter = createMockAdapter();
+    let createCalls = 0;
+    let handledUrl = "";
+    const fallback = new DevAgentAgUiFallback({
+      projectDir: "/test/project",
+      adapter,
+      createRuntime: (options) => {
+        createCalls++;
+        assertEquals(options.projectDir, "/test/project");
+        assertEquals(options.baseDir, "/test/project");
+        return Promise.resolve({
+          routeSet: {
+            handleAgUiRequest(request: Request) {
+              handledUrl = request.url;
+              return Response.json({ delegated: true });
+            },
+          },
+          lifecycle: { stop: () => Promise.resolve() },
+        } as never);
+      },
+    });
+
+    const response = await fallback.handle(createMissInput({ adapter }));
+
+    assertEquals(response?.status, 200);
+    assertEquals(await response?.json(), { delegated: true });
+    assertEquals(handledUrl, "http://localhost/api/ag-ui");
+    assertEquals(createCalls, 1);
+  });
+
+  it("declines non-local, non-POST, and non-exact AG-UI requests", async () => {
+    const adapter = createMockAdapter();
+    let createCalls = 0;
+    const fallback = new DevAgentAgUiFallback({
+      projectDir: "/test/project",
+      adapter,
+      createRuntime: () => {
+        createCalls++;
+        throw new Error("should not create runtime");
+      },
+    });
+
+    assertEquals(
+      await fallback.handle(createMissInput({ adapter, method: "GET" })),
+      null,
+    );
+    assertEquals(
+      await fallback.handle(createMissInput({ adapter, url: "http://localhost/api/ag-ui/resume" })),
+      null,
+    );
+    assertEquals(
+      await fallback.handle(createMissInput({ adapter, isLocalProject: false })),
+      null,
+    );
+    assertEquals(createCalls, 0);
+  });
+
+  it("returns a structured 400 when multiple project agents require selection", async () => {
+    const adapter = createMockAdapter();
+    const fallback = new DevAgentAgUiFallback({
+      projectDir: "/test/project",
+      adapter,
+      createRuntime: () =>
+        Promise.reject(
+          CONFIG_INVALID.create({
+            detail:
+              "agentId is required when agent discovery does not resolve to exactly one agent. Discovered agents: alpha, beta.",
+          }),
+        ),
+    });
+
+    const response = await fallback.handle(createMissInput({ adapter }));
+
+    assertEquals(response?.status, 400);
+    assertEquals(await response?.json(), {
+      error: "AGENT_SELECTION_REQUIRED",
+      errorCode: "AGENT_SELECTION_REQUIRED",
+      message: "Select an agent for /api/ag-ui when multiple project agents are discovered.",
+      agents: ["alpha", "beta"],
+    });
+  });
+
+  it("keeps zero-agent projects on the normal unmatched-route path", async () => {
+    const adapter = createMockAdapter();
+    const fallback = new DevAgentAgUiFallback({
+      projectDir: "/test/project",
+      adapter,
+      createRuntime: () =>
+        Promise.reject(
+          CONFIG_INVALID.create({
+            detail:
+              "agentId is required when agent discovery does not resolve to exactly one agent. Discovered agents: none.",
+          }),
+        ),
+    });
+
+    assertEquals(await fallback.handle(createMissInput({ adapter })), null);
+  });
+
+  it("invalidates the cached hosted runtime", async () => {
+    const adapter = createMockAdapter();
+    let createCalls = 0;
+    let stopCalls = 0;
+    const fallback = new DevAgentAgUiFallback({
+      projectDir: "/test/project",
+      adapter,
+      createRuntime: () => {
+        createCalls++;
+        return Promise.resolve({
+          routeSet: {
+            handleAgUiRequest: () => Response.json({ createCalls }),
+          },
+          lifecycle: {
+            stop: () => {
+              stopCalls++;
+              return Promise.resolve();
+            },
+          },
+        } as never);
+      },
+    });
+
+    const first = await fallback.handle(createMissInput({ adapter }));
+    fallback.invalidate();
+    await Promise.resolve();
+    const second = await fallback.handle(createMissInput({ adapter }));
+
+    assertEquals(await first?.json(), { createCalls: 1 });
+    assertEquals(await second?.json(), { createCalls: 2 });
+    assertEquals(stopCalls, 1);
+  });
+});

--- a/src/server/handlers/request/api/dev-agent-ag-ui-fallback.ts
+++ b/src/server/handlers/request/api/dev-agent-ag-ui-fallback.ts
@@ -1,0 +1,124 @@
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { ApiRouteMissInput } from "#veryfront/routing/api/handler.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import type { AgentServiceRuntimeBundle } from "#veryfront/agent/service/runtime.ts";
+import type {
+  NodeVeryfrontCloudAgentServiceOptions,
+  NodeVeryfrontCloudAgentServicePreparedExecution,
+} from "#veryfront/agent/hosted/veryfront-cloud-agent-service.ts";
+import { serverLogger } from "#veryfront/utils";
+
+const AG_UI_PATH = "/api/ag-ui";
+const AGENT_SELECTION_REQUIRED = "AGENT_SELECTION_REQUIRED";
+
+type DevAgentRuntimeBundle = Pick<
+  AgentServiceRuntimeBundle<NodeVeryfrontCloudAgentServicePreparedExecution>,
+  "routeSet" | "lifecycle"
+>;
+
+type DevAgentRuntimeFactory = (
+  options: NodeVeryfrontCloudAgentServiceOptions,
+) => Promise<DevAgentRuntimeBundle>;
+
+export interface DevAgentAgUiFallbackOptions {
+  projectDir: string;
+  adapter: RuntimeAdapter;
+  createRuntime?: DevAgentRuntimeFactory;
+}
+
+interface AgentSelectionFailure {
+  agents: string[];
+}
+
+const logger = serverLogger.component("dev-agent-ag-ui-fallback");
+
+async function createDefaultRuntime(
+  options: NodeVeryfrontCloudAgentServiceOptions,
+): Promise<DevAgentRuntimeBundle> {
+  const { createNodeVeryfrontCloudAgentServiceRuntime } = await import(
+    "#veryfront/agent/hosted/veryfront-cloud-agent-service.ts"
+  );
+  return createNodeVeryfrontCloudAgentServiceRuntime(options);
+}
+
+function parseAgentSelectionFailure(error: unknown): AgentSelectionFailure | null {
+  if (!(error instanceof VeryfrontError) || error.slug !== "config-invalid") {
+    return null;
+  }
+
+  const detail = error.detail ?? error.message;
+  const match = detail.match(/Discovered agents:\s*([^.]*)\./);
+  if (!match) return null;
+
+  const discovered = match[1]?.trim() ?? "";
+  if (!discovered || discovered === "none") {
+    return { agents: [] };
+  }
+
+  const agents = discovered.split(",").map((agent) => agent.trim()).filter(Boolean);
+  return agents.length > 1 ? { agents } : null;
+}
+
+function agentSelectionRequiredResponse(failure: AgentSelectionFailure): Response {
+  return Response.json(
+    {
+      error: AGENT_SELECTION_REQUIRED,
+      errorCode: AGENT_SELECTION_REQUIRED,
+      message: "Select an agent for /api/ag-ui when multiple project agents are discovered.",
+      agents: failure.agents,
+    },
+    { status: 400 },
+  );
+}
+
+export class DevAgentAgUiFallback {
+  private runtimePromise: Promise<DevAgentRuntimeBundle> | null = null;
+  private readonly createRuntime: DevAgentRuntimeFactory;
+
+  constructor(private readonly options: DevAgentAgUiFallbackOptions) {
+    this.createRuntime = options.createRuntime ?? createDefaultRuntime;
+  }
+
+  async handle(input: ApiRouteMissInput): Promise<Response | null> {
+    if (!this.shouldHandle(input)) return null;
+
+    try {
+      const runtime = await this.getRuntime();
+      return await runtime.routeSet.handleAgUiRequest(input.request);
+    } catch (error) {
+      const selectionFailure = parseAgentSelectionFailure(error);
+      if (!selectionFailure) throw error;
+      if (selectionFailure.agents.length === 0) return null;
+      return agentSelectionRequiredResponse(selectionFailure);
+    }
+  }
+
+  invalidate(): void {
+    const runtimePromise = this.runtimePromise;
+    this.runtimePromise = null;
+    if (!runtimePromise) return;
+
+    void runtimePromise
+      .then((runtime) => runtime.lifecycle.stop())
+      .catch((error) => {
+        logger.debug("Failed to stop dev AG-UI fallback runtime", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  }
+
+  private shouldHandle(input: ApiRouteMissInput): boolean {
+    return input.ctx?.isLocalProject === true &&
+      input.pathname === AG_UI_PATH &&
+      input.request.method.toUpperCase() === "POST";
+  }
+
+  private getRuntime(): Promise<DevAgentRuntimeBundle> {
+    this.runtimePromise ??= this.createRuntime({
+      projectDir: this.options.projectDir,
+      baseDir: this.options.projectDir,
+      env: this.options.adapter.env.toObject(),
+    });
+    return this.runtimePromise;
+  }
+}

--- a/src/server/handlers/request/api/pages-api-handler.ts
+++ b/src/server/handlers/request/api/pages-api-handler.ts
@@ -15,6 +15,7 @@ import {
   tryGetCacheKeyContext,
 } from "#veryfront/cache/cache-key-builder.ts";
 import type { HandlerContext } from "../../types.ts";
+import { DevAgentAgUiFallback } from "./dev-agent-ag-ui-fallback.ts";
 
 const logger = serverLogger.component("reset-api-handler");
 
@@ -137,7 +138,14 @@ async function refreshPreviewSourceSnapshot(ctx: HandlerContext): Promise<void> 
 async function createApiHandler(ctx: HandlerContext): Promise<APIRouteHandler> {
   await refreshPreviewSourceSnapshot(ctx);
 
-  const handler = new APIRouteHandler(ctx.projectDir, ctx.adapter);
+  const devAgentAgUiFallback = new DevAgentAgUiFallback({
+    projectDir: ctx.projectDir,
+    adapter: ctx.adapter,
+  });
+  const handler = new APIRouteHandler(ctx.projectDir, ctx.adapter, {
+    onRouteMiss: (input) => devAgentAgUiFallback.handle(input),
+    onDestroy: () => devAgentAgUiFallback.invalidate(),
+  });
   await handler.initialize();
   return handler;
 }


### PR DESCRIPTION
## Summary
- add an optional API route-miss hook that preserves normal route precedence
- delegate exact local `POST /api/ag-ui` misses to the existing hosted agent-service route set
- keep zero-agent projects on the normal 404 path and return `400 AGENT_SELECTION_REQUIRED` for multi-agent ambiguity

Closes veryfront/veryfront-issue-inbox#109

## Validation
- `deno test --allow-all src/routing/api/handler.test.ts src/server/handlers/request/api/dev-agent-ag-ui-fallback.test.ts src/server/handlers/request/api/pages-api-handler.test.ts`
- `deno fmt --check` on touched files
- `deno lint` on touched files
- `deno check src/routing/api/index.ts src/server/handlers/request/api/index.ts`
- `deno task typecheck`
- pre-commit `deno task verify:quick` passed

## Scope
No separate local agent-service process, no broad `/api/*` fallback, and no user-route behavior change when an explicit `/api/ag-ui` route exists.