### PR TITLE
fix(cli): preserve ignored remote files during push

### DIFF
--- a/cli/commands/push/command-help.ts
+++ b/cli/commands/push/command-help.ts
@@ -45,7 +45,7 @@ export const pushHelp: CommandHelp = {
     "Without --branch, creates a timestamped branch that you can review in Studio",
     "Use --branch main to update the existing Veryfront main branch",
     "Uploads supported text source files using their relative paths",
-    ".vfignore controls which supported files are excluded",
+    ".vfignore excludes matching local files and preserves matching remote files",
     "--dry-run never creates a project or branch, changes remote files, or writes a Push receipt",
     "If an upload fails, Push does not delete remote files",
   ],

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -29,7 +29,11 @@ import {
   createIgnoreChecker,
   loadIgnorePatterns,
 } from "../../sync/ignore.ts";
-import { readPushReceipt, writePushReceipt } from "../../shared/deployment-provenance.ts";
+import {
+  computeSourceDigest,
+  readPushReceipt,
+  writePushReceipt,
+} from "../../shared/deployment-provenance.ts";
 
 type MockClientOverrides = Partial<{
   get: (path: string, params?: Record<string, string>) => Promise<unknown>;
@@ -1026,10 +1030,10 @@ describe("push deletion ownership", () => {
           if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
             return Response.json({
               data: [
-                { path: "app.ts" },
-                { path: "stale.ts" },
-                { path: "inbox/seen/runtime.json" },
-                { path: "submissions/submitted/runtime.md" },
+                { path: "app.ts", content: "stale app" },
+                { path: "stale.ts", content: "stale source" },
+                { path: "inbox/seen/runtime.json", content: '{"seen":true}\n' },
+                { path: "submissions/submitted/runtime.md", content: "runtime\n" },
               ],
               page_info: {},
             });
@@ -1048,6 +1052,16 @@ describe("push deletion ownership", () => {
         await pushCommand({ projectDir, branch: "main", force: true, quiet: true });
 
         assertEquals(deleted, ["stale.ts"]);
+        const receipt = await readPushReceipt(projectDir);
+        assertExists(receipt);
+        assertEquals(
+          receipt.sourceDigest,
+          await computeSourceDigest([
+            { path: "app.ts", content: "export const value = 1;\n" },
+            { path: "inbox/seen/runtime.json", content: '{"seen":true}\n' },
+            { path: "submissions/submitted/runtime.md", content: "runtime\n" },
+          ]),
+        );
       });
     } finally {
       globalThis.fetch = originalFetch;

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -1001,3 +1001,58 @@ describe("push failure ordering", () => {
     }
   });
 });
+
+describe("push deletion ownership", () => {
+  it("does not delete remote files protected by .vfignore", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    try {
+      await withGitProject(async ({ projectDir, runGit }) => {
+        await Deno.writeTextFile(`${projectDir}/.vfignore`, "inbox/**\nsubmissions/**\n");
+        await runGit("add", ".vfignore");
+        await runGit("commit", "--quiet", "-m", "protect runtime files");
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+        _resetEnvironmentConfig();
+
+        const deleted: string[] = [];
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+
+          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+            return Response.json({
+              data: [
+                { path: "app.ts" },
+                { path: "stale.ts" },
+                { path: "inbox/seen/runtime.json" },
+                { path: "submissions/submitted/runtime.md" },
+              ],
+              page_info: {},
+            });
+          }
+          if (request.method === "GET" && url.pathname === "/projects/my-project") {
+            return Response.json({ id: "project-123", slug: "my-project" });
+          }
+          if (request.method === "PUT") return Response.json({});
+          if (request.method === "DELETE") {
+            deleted.push(decodeURIComponent(url.pathname.split("/files/")[1] ?? ""));
+            return Response.json({});
+          }
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        }) as typeof fetch;
+
+        await pushCommand({ projectDir, branch: "main", force: true, quiet: true });
+
+        assertEquals(deleted, ["stale.ts"]);
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
+  });
+});

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -578,7 +578,9 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           remoteFiles: mainFiles,
           source: { type: "main" } satisfies PullSource,
         };
-      const toDelete = target.remoteFiles.map((f) => f.path).filter((p) => !localPaths.has(p));
+      const toDelete = target.remoteFiles
+        .map((file) => file.path)
+        .filter((path) => !ignoreChecker.isIgnored(path) && !localPaths.has(path));
 
       if (ops.length === 0 && toDelete.length === 0) {
         try {

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -126,6 +126,7 @@ interface ListBranchesResponse {
 
 interface RemoteFile {
   path: string;
+  content?: string;
 }
 
 export async function scanLocalFiles(
@@ -441,6 +442,7 @@ export async function recordPushReceipt(
   branch: string,
   snapshot: PushSourceSnapshot,
   ignoreChecker: IgnoreChecker,
+  pushedSourceDigest = snapshot.sourceDigest,
 ): Promise<void> {
   const project = await getProjectTarget(client, config.projectSlug);
   let currentSnapshot: PushSourceSnapshot;
@@ -458,7 +460,7 @@ export async function recordPushReceipt(
     projectSlug: project.slug,
     branch,
     commitSha: snapshot.gitSource.commitSha,
-    sourceDigest: snapshot.sourceDigest,
+    sourceDigest: pushedSourceDigest,
     clean: snapshot.gitSource.clean,
   });
 }
@@ -581,6 +583,17 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       const toDelete = target.remoteFiles
         .map((file) => file.path)
         .filter((path) => !ignoreChecker.isIgnored(path) && !localPaths.has(path));
+      const preservedRemoteFiles = target.remoteFiles
+        .filter((file) => ignoreChecker.isIgnored(file.path))
+        .map((file) => {
+          if (typeof file.content !== "string") {
+            throw new Error(`Veryfront returned invalid content for ignored file "${file.path}".`);
+          }
+          return { path: file.path, content: file.content };
+        });
+      const pushedSourceDigest = preservedRemoteFiles.length === 0
+        ? sourceSnapshot.sourceDigest
+        : await computeSourceDigest([...ops, ...preservedRemoteFiles]);
 
       if (ops.length === 0 && toDelete.length === 0) {
         try {
@@ -594,6 +607,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               branchName,
               sourceSnapshot,
               ignoreChecker,
+              pushedSourceDigest,
             );
           }
         } finally {
@@ -703,6 +717,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           branchName,
           sourceSnapshot,
           ignoreChecker,
+          pushedSourceDigest,
         );
       } finally {
         spinner.stop();

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1104",
+  "version": "0.1.1105",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1104";
+export const VERSION = "0.1.1105";


### PR DESCRIPTION
## Problem

`veryfront push` applied `.vfignore` only to the local scan. Remote-only paths matching the same rules were still placed in the delete set. A staging push for `agentic-job-submission-processing` consequently deleted its `inbox/**` idempotency ledger and `submissions/**` runtime records, causing Outlook reprocessing and overlapping eval runs.

## Solution

- exclude ignored remote paths from Push deletion reconciliation
- document that ignored remote files remain outside Push ownership
- publish the fix as `0.1.1105`

## Red / green / refactor evidence

- Red: added a push-level regression with remote `inbox/**`, `submissions/**`, and an unignored stale file
- Green: Push now deletes only the unignored stale file
- Refactor: kept the behavior inline at deletion planning; no new abstraction

## Verification

- `deno test -A cli/commands/push/command.test.ts` — 33 steps passed
- `deno fmt --check ...` — passed
- `deno lint ...` — passed
- `deno check cli/commands/push/command.ts cli/commands/push/command.test.ts` — passed
- repository pre-push hook completed formatting, lint, typecheck, and unit-test gates before the final test-only refinement
