### PR TITLE
fix(pages): keep chat layouts and server graphs out of browser builds

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1107",
+  "version": "0.1.1108",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -77,6 +77,9 @@ app/
 
 `/dashboard/settings` renders inside both the root layout and the dashboard layout.
 
+`layout.tsx` and the other supported `layout.*` extensions are reserved layout metadata at every
+directory level in both routers. They wrap descendant pages and never create a `/layout` route.
+
 ## Dynamic routes
 
 Use brackets for dynamic segments:

--- a/src/agent/streaming/tool-input.ts
+++ b/src/agent/streaming/tool-input.ts
@@ -1,4 +1,4 @@
-import { serverLogger } from "#veryfront/utils";
+import { serverLogger } from "#veryfront/utils/logger/logger.ts";
 
 const logger = serverLogger.component("agent-tool-input");
 

--- a/src/chat/client-import-boundary.test.ts
+++ b/src/chat/client-import-boundary.test.ts
@@ -2,10 +2,12 @@ import { assert } from "#std/assert";
 
 const browserReachableModules = [
   {
+    label: "src/agent/streaming/tool-input.ts",
     path: new URL("../agent/streaming/tool-input.ts", import.meta.url),
     required: ["#veryfront/utils/logger/logger.ts"],
   },
   {
+    label: "src/utils/logger/logger.ts",
     path: new URL("../utils/logger/logger.ts", import.meta.url),
     required: [
       "#veryfront/platform/compat/process/env.ts",
@@ -13,21 +15,22 @@ const browserReachableModules = [
     ],
   },
   {
+    label: "src/utils/version.ts",
     path: new URL("../utils/version.ts", import.meta.url),
     required: ["#veryfront/platform/compat/process/env.ts"],
   },
 ];
 
 Deno.test("chat client modules use leaf imports for server-capable dependencies", async () => {
-  for (const { path, required } of browserReachableModules) {
+  for (const { label, path, required } of browserReachableModules) {
     const source = await Deno.readTextFile(path);
     assert(
       !source.includes("#veryfront/platform/compat/process.ts") &&
         !source.includes('from "#veryfront/utils"'),
-      `${path.pathname} must not pull a server-capable barrel into the chat browser graph`,
+      `${label} must not pull a server-capable barrel into the chat browser graph`,
     );
     for (const specifier of required) {
-      assert(source.includes(specifier), `${path.pathname} must import ${specifier}`);
+      assert(source.includes(specifier), `${label} must import ${specifier}`);
     }
   }
 });

--- a/src/chat/client-import-boundary.test.ts
+++ b/src/chat/client-import-boundary.test.ts
@@ -1,0 +1,33 @@
+import { assert } from "#std/assert";
+
+const browserReachableModules = [
+  {
+    path: new URL("../agent/streaming/tool-input.ts", import.meta.url),
+    required: ["#veryfront/utils/logger/logger.ts"],
+  },
+  {
+    path: new URL("../utils/logger/logger.ts", import.meta.url),
+    required: [
+      "#veryfront/platform/compat/process/env.ts",
+      "#veryfront/platform/compat/process/lifecycle.ts",
+    ],
+  },
+  {
+    path: new URL("../utils/version.ts", import.meta.url),
+    required: ["#veryfront/platform/compat/process/env.ts"],
+  },
+];
+
+Deno.test("chat client modules use leaf imports for server-capable dependencies", async () => {
+  for (const { path, required } of browserReachableModules) {
+    const source = await Deno.readTextFile(path);
+    assert(
+      !source.includes("#veryfront/platform/compat/process.ts") &&
+        !source.includes('from "#veryfront/utils"'),
+      `${path.pathname} must not pull a server-capable barrel into the chat browser graph`,
+    );
+    for (const specifier of required) {
+      assert(source.includes(specifier), `${path.pathname} must import ${specifier}`);
+    }
+  }
+});

--- a/src/server/build-routes.test.ts
+++ b/src/server/build-routes.test.ts
@@ -203,6 +203,21 @@ describe("server/build-routes", () => {
       assertEquals(paths, ["/about", "/api"]);
     });
 
+    it("excludes Pages Router layout files from static page routes", async () => {
+      const adapter = createMockAdapter({
+        "/project/pages/index.tsx": "export default () => <div />",
+        "/project/pages/layout.tsx": "export default ({ children }) => children",
+        "/project/pages/chat/index.tsx": "export default () => <div />",
+        "/project/pages/chat/layout.tsx": "export default ({ children }) => children",
+        "/project/pages/docs/index.mdx": "# Docs",
+        "/project/pages/docs/layout.mdx": "# Docs layout",
+      });
+
+      const routes = await collectPagesRoutes(adapter, "/project");
+
+      assertEquals(routes.map((route) => route.path).sort(), ["/", "/chat", "/docs"]);
+    });
+
     it("excludes dynamic Pages Router routes from static generation", async () => {
       const adapter = createMockAdapter({
         "/project/pages/index.tsx": "export default () => <div />",

--- a/src/server/build-routes.ts
+++ b/src/server/build-routes.ts
@@ -12,6 +12,7 @@ import { isDynamicRoute, isDynamicSegment } from "#veryfront/utils/route-path-ut
 
 const PAGE_EXTENSIONS = [".mdx", ".md", ".tsx", ".jsx", ".ts", ".js"];
 const PAGE_CANDIDATES = ["page.mdx", "page.md", "page.tsx", "page.jsx", "page.ts", "page.js"];
+const PAGES_LAYOUT_CANDIDATES = new Set(PAGE_EXTENSIONS.map((extension) => `layout${extension}`));
 
 function convertToSlug(relativePath: string): string {
   return (
@@ -24,6 +25,11 @@ function convertToSlug(relativePath: string): string {
 
 function isPagesApiDirectoryDescendant(relativePath: string): boolean {
   return relativePath.replace(/\\/g, "/").startsWith("api/");
+}
+
+function isPagesLayoutFile(relativePath: string): boolean {
+  const fileName = relativePath.replace(/\\/g, "/").split("/").pop();
+  return fileName !== undefined && PAGES_LAYOUT_CANDIDATES.has(fileName);
 }
 
 function shouldIncludeRoute(path: string, include?: string[], exclude?: string[]): boolean {
@@ -53,7 +59,7 @@ export async function collectPagesRoutes(
     const file of discoverFiles({ baseDir: pagesDir, extensions: PAGE_EXTENSIONS, adapter })
   ) {
     const relativePath = relative(pagesDir, file.path);
-    if (isPagesApiDirectoryDescendant(relativePath)) continue;
+    if (isPagesApiDirectoryDescendant(relativePath) || isPagesLayoutFile(relativePath)) continue;
 
     const slug = convertToSlug(relativePath);
     const pathForRoute = `/${slug === "index" ? "" : slug}`;

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -682,6 +682,49 @@ describe("browser-server-exports-strip", () => {
       assertStringIncludes(strippedShared, "function fmt");
     });
 
+    // Production release modules have already passed through esbuild with
+    // `keepNames`, which emits a top-level name-registration call for every
+    // function. That compiler metadata must not turn a hook-only helper into a
+    // browser reference and keep its server import graph alive.
+    it("prunes hook-only helpers from compiled keepNames output", async () => {
+      const code = [
+        `var defineName = Object.defineProperty;`,
+        `var setName = (target, value) => defineName(target, "name", { value, configurable: true });`,
+        `import { getActivity } from "../lib/api.js";`,
+        `async function loadReview() { return getActivity(); }`,
+        `setName(loadReview, "getReviewProps");`,
+        `function loadStatic() { return loadReview(); }`,
+        `setName(loadStatic, "getStaticData");`,
+        `function loadServer() { return loadReview(); }`,
+        `setName(loadServer, "getServerData");`,
+        `function Page() { return null; }`,
+        `setName(Page, "Page");`,
+        `export { Page as default, loadServer as getServerData, loadStatic as getStaticData };`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code);
+
+      assertNotIncludes(result, "../lib/api.js");
+      assertEquals(occurrences(result, "getActivity"), 0);
+      assertEquals(occurrences(result, "loadReview"), 0);
+      assertStringIncludes(result, `setName(Page, "Page")`);
+    });
+
+    it("keeps helpers consumed by ordinary top-level registration", async () => {
+      const code = [
+        `import { getActivity } from "../lib/api.js";`,
+        `async function loadReview() { return getActivity(); }`,
+        `registerClientHandler(loadReview, "review-loader");`,
+        `function loadServer() { return loadReview(); }`,
+        `export { loadServer as getServerData };`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code);
+
+      assertStringIncludes(result, "../lib/api.js");
+      assertStringIncludes(result, "registerClientHandler(loadReview");
+    });
+
     // A chain member the client also reads is kept even though a later link in
     // the chain (used only by the hook) is dropped.
     it("keeps a chain member the client reads while dropping the hook-only tail", async () => {

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.ts
@@ -728,6 +728,139 @@ function hookReferencedIdentifiers(body: Node[], targets: Set<string>): Set<stri
   return referenced;
 }
 
+function literalText(node: Node | undefined): string | null {
+  if (!node) return null;
+  return typeof node.value === "string" ? node.value : nodeName(node);
+}
+
+function stringLiteralText(node: Node | undefined): string | null {
+  return node && typeof node.value === "string" ? node.value : null;
+}
+
+function isObjectDefineProperty(node: Node | undefined): boolean {
+  if (!node || node.type !== "MemberExpression") return false;
+  return nodeName(node.object) === "Object" &&
+    literalText(isNode(node.property) ? node.property : undefined) === "defineProperty";
+}
+
+function returnedCall(node: Node): Node | null {
+  const body = node.body;
+  if (!isNode(body)) return null;
+  if (body.type === "CallExpression") return body;
+  if (body.type !== "BlockStatement" || !Array.isArray(body.body) || body.body.length !== 1) {
+    return null;
+  }
+
+  const statement = body.body[0];
+  if (!isNode(statement) || statement.type !== "ReturnStatement" || !isNode(statement.argument)) {
+    return null;
+  }
+  return statement.argument.type === "CallExpression" ? statement.argument : null;
+}
+
+function isTrueExpression(node: Node | undefined): boolean {
+  if (!node) return false;
+  if (node.value === true) return true;
+  return node.type === "UnaryExpression" && node.operator === "!" &&
+    isNode(node.argument) && node.argument.value === 0;
+}
+
+function isNameDescriptor(node: Node | undefined, valueParam: string): boolean {
+  if (!node || node.type !== "ObjectExpression") return false;
+
+  let hasValue = false;
+  let configurable = false;
+  for (const property of Array.isArray(node.properties) ? node.properties : []) {
+    if (!isNode(property) || property.type !== "ObjectProperty") continue;
+    const key = literalText(isNode(property.key) ? property.key : undefined);
+    const value = isNode(property.value) ? property.value : undefined;
+    if (key === "value" && nodeName(value) === valueParam) hasValue = true;
+    if (key === "configurable" && isTrueExpression(value)) configurable = true;
+  }
+
+  return hasValue && configurable;
+}
+
+/**
+ * Bindings for esbuild's `keepNames` helper. Release modules are compiled
+ * before the browser transform, so their declarations are followed by calls
+ * like `__name(loadPage, "loadPage")`. Recognise the helper by its exact
+ * `Object.defineProperty(target, "name", …)` semantics rather than by its
+ * minified binding name.
+ */
+function compilerNameHelperBindings(body: Node[]): Set<string> {
+  const initializers = new Map<string, Node>();
+  for (const statement of body) {
+    if (statement.type !== "VariableDeclaration") continue;
+    for (const declarator of Array.isArray(statement.declarations) ? statement.declarations : []) {
+      if (!isNode(declarator) || !isNode(declarator.init)) continue;
+      const name = nodeName(declarator.id);
+      if (name) initializers.set(name, declarator.init);
+    }
+  }
+
+  const definePropertyBindings = new Set<string>();
+  for (const [name, init] of initializers) {
+    if (isObjectDefineProperty(init)) definePropertyBindings.add(name);
+  }
+
+  const helpers = new Set<string>();
+  for (const [name, init] of initializers) {
+    if (init.type !== "ArrowFunctionExpression" && init.type !== "FunctionExpression") continue;
+    const params = Array.isArray(init.params) ? init.params.filter(isNode) : [];
+    if (params.length !== 2) continue;
+    const targetParam = nodeName(params[0]);
+    const valueParam = nodeName(params[1]);
+    if (!targetParam || !valueParam) continue;
+
+    const call = returnedCall(init);
+    if (!call) continue;
+    const callee = isNode(call.callee) ? call.callee : undefined;
+    const callsDefineProperty = isObjectDefineProperty(callee) ||
+      (callee?.type === "Identifier" && definePropertyBindings.has(nodeName(callee) ?? ""));
+    if (!callsDefineProperty) continue;
+
+    const args = Array.isArray(call.arguments) ? call.arguments.filter(isNode) : [];
+    if (
+      args.length === 3 && nodeName(args[0]) === targetParam &&
+      stringLiteralText(args[1]) === "name" && isNameDescriptor(args[2], valueParam)
+    ) {
+      helpers.add(name);
+    }
+  }
+
+  return helpers;
+}
+
+interface CompilerNameRegistration {
+  statement: Node;
+  target: Node;
+  targetName: string;
+}
+
+function compilerNameRegistrations(body: Node[]): CompilerNameRegistration[] {
+  const helpers = compilerNameHelperBindings(body);
+  if (helpers.size === 0) return [];
+
+  const registrations: CompilerNameRegistration[] = [];
+  for (const statement of body) {
+    if (statement.type !== "ExpressionStatement" || !isNode(statement.expression)) continue;
+    const expression = statement.expression;
+    if (expression.type !== "CallExpression" || !isNode(expression.callee)) continue;
+    if (!helpers.has(nodeName(expression.callee) ?? "")) continue;
+
+    const args = Array.isArray(expression.arguments) ? expression.arguments.filter(isNode) : [];
+    const target = args[0];
+    const targetName = nodeName(target);
+    if (!target || args.length !== 2 || !targetName || stringLiteralText(args[1]) === null) {
+      continue;
+    }
+    registrations.push({ statement, target, targetName });
+  }
+
+  return registrations;
+}
+
 /**
  * Drop the top-level declarations the emptied server-only hooks closed over.
  *
@@ -752,6 +885,13 @@ function dropUnusedModuleScopeBindings(body: Node[], hookClosure: Set<string>): 
     const excluded = new WeakSet<Node>();
     for (const decl of decls) for (const id of decl.bindingIds) excluded.add(id);
 
+    // Esbuild's generated name-registration call is metadata for a declaration,
+    // not an independent browser consumer of it. Ignore that target reference
+    // when deciding liveness, and remove the call together with a declaration
+    // that proves hook-only.
+    const nameRegistrations = compilerNameRegistrations(current);
+    for (const registration of nameRegistrations) excluded.add(registration.target);
+
     const referenced = referencedIdentifiers(current, excluded);
 
     const removableStatements = new Set<Node>();
@@ -763,6 +903,11 @@ function dropUnusedModuleScopeBindings(body: Node[], hookClosure: Set<string>): 
       if (!inClosure || !unused) continue;
 
       removedDecls.push(decl);
+      for (const registration of nameRegistrations) {
+        if (decl.names.includes(registration.targetName)) {
+          removableStatements.add(registration.statement);
+        }
+      }
       if (!decl.declarator) {
         removableStatements.add(decl.statement);
         continue;

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -1,4 +1,5 @@
-import { getEnv, getHostEnv, isStdoutTTY } from "#veryfront/platform/compat/process.ts";
+import { getEnv, getHostEnv } from "#veryfront/platform/compat/process/env.ts";
+import { isStdoutTTY } from "#veryfront/platform/compat/process/lifecycle.ts";
 import { RUNTIME_VERSION } from "../version.ts";
 import {
   ANSI,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1107";
+export const VERSION = "0.1.1108";

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,5 +1,5 @@
 import denoConfig from "#deno-config" with { type: "json" };
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getEnv } from "#veryfront/platform/compat/process/env.ts";
 import { VERSION } from "./version-constant.ts";
 export { VERSION } from "./version-constant.ts";
 

--- a/tests/integration/core/getEntityInfo.test.ts
+++ b/tests/integration/core/getEntityInfo.test.ts
@@ -273,6 +273,10 @@ describe("getEntityBySlug", () => {
         join(pagesDir, "Layout.tsx"),
         `export default function Layout() { /* empty */ }`,
       );
+      await createTestFile(
+        join(pagesDir, "chat", "layout.tsx"),
+        `export default function ChatLayout() { /* empty */ }`,
+      );
 
       await createTestFile(
         join(pagesDir, "page.tsx"),
@@ -281,6 +285,9 @@ describe("getEntityBySlug", () => {
 
       const layoutInfo = await getEntityBySlug(context.projectDir, "Layout");
       assertEquals(layoutInfo, null);
+
+      const nestedLayoutInfo = await getEntityBySlug(context.projectDir, "chat/layout");
+      assertEquals(nestedLayoutInfo, null);
 
       const pageInfo = await getEntityBySlug(context.projectDir, "page");
       assertExists(pageInfo);

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -151,9 +151,10 @@ function assertBrowserSafeFrameworkModule(
 async function assertBrowserSafeFrameworkGraph(port: number, entryPath: string): Promise<void> {
   const pending = [entryPath];
   const visited = new Set<string>();
+  let nextIndex = 0;
 
-  while (pending.length > 0) {
-    const modulePath = pending.shift();
+  while (nextIndex < pending.length) {
+    const modulePath = pending[nextIndex++];
     if (!modulePath || visited.has(modulePath)) continue;
     visited.add(modulePath);
 

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -99,6 +99,8 @@ const BROWSER_CSP_SAFE_MODULE_PATHS = [
   "/_vf_modules/_veryfront/rendering/rsc/client-dom.js",
   "/_vf_modules/_veryfront/routing/client/page-loader.js",
   "/_vf_modules/_veryfront/client/spa/ClientApp.js",
+  "/_vf_modules/_veryfront/utils/logger/logger.js",
+  "/_vf_modules/_veryfront/utils/version.js",
 ];
 
 async function fetchServedFrameworkModule(
@@ -119,7 +121,8 @@ function assertBrowserSafeFrameworkModule(
   body: string,
   specifiers: string[],
 ): void {
-  const errorSpecifiers = specifiers.filter((specifier) =>
+  const specifierPaths = specifiers.map((specifier) => specifier.replace(/[?#].*$/, ""));
+  const errorSpecifiers = specifierPaths.filter((specifier) =>
     specifier.startsWith("/_vf_modules/_veryfront/errors/")
   );
 
@@ -128,21 +131,46 @@ function assertBrowserSafeFrameworkModule(
     `${modulePath} should not use unsafe-eval`,
   );
   assert(
-    !specifiers.includes("/_vf_modules/_veryfront/errors/index.js"),
+    !specifierPaths.includes("/_vf_modules/_veryfront/errors/index.js"),
     `${modulePath} should not import the heavyweight errors barrel`,
   );
   assert(
-    !specifiers.includes("/_vf_modules/_veryfront/platform/compat/process.js"),
+    !specifierPaths.includes("/_vf_modules/_veryfront/platform/compat/process.js"),
     `${modulePath} should not import process compat`,
   );
   assert(
-    !specifiers.includes("/_vf_modules/_veryfront/platform/compat/dynamic-import.js"),
+    !specifierPaths.includes("/_vf_modules/_veryfront/platform/compat/dynamic-import.js"),
     `${modulePath} should not import dynamic-import compat`,
   );
   assert(
     errorSpecifiers.every((specifier) => BROWSER_SAFE_ERROR_MODULES.has(specifier)),
     `${modulePath} should only import narrow browser-safe error modules`,
   );
+}
+
+async function assertBrowserSafeFrameworkGraph(port: number, entryPath: string): Promise<void> {
+  const pending = [entryPath];
+  const visited = new Set<string>();
+
+  while (pending.length > 0) {
+    const modulePath = pending.shift();
+    if (!modulePath || visited.has(modulePath)) continue;
+    visited.add(modulePath);
+
+    const { body, specifiers } = await fetchServedFrameworkModule(port, modulePath);
+    assertBrowserSafeFrameworkModule(modulePath, body, specifiers);
+
+    for (const specifier of specifiers) {
+      const resolved = new URL(specifier, `http://127.0.0.1:${port}${modulePath}`);
+      if (
+        resolved.origin === `http://127.0.0.1:${port}` &&
+        resolved.pathname.startsWith("/_vf_modules/_veryfront/") &&
+        !visited.has(resolved.pathname)
+      ) {
+        pending.push(resolved.pathname);
+      }
+    }
+  }
 }
 
 describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
@@ -442,6 +470,14 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
           assertBrowserSafeFrameworkModule(modulePath, body, specifiers);
         }
 
+        await stopServer(server);
+      });
+    });
+
+    it("serves the complete chat module graph without unsafe-eval dependencies", async () => {
+      await withTestContext("dev-server-framework-chat-graph-csp", async (context) => {
+        const { server, port } = await createTestDevServer(context);
+        await assertBrowserSafeFrameworkGraph(port, "/_vf_modules/_veryfront/chat/index.js");
         await stopServer(server);
       });
     });


### PR DESCRIPTION
## Summary

- recognize esbuild keepNames metadata so hook-only helpers and their server imports are removed from Pages browser artifacts
- keep chat-reachable logging and version modules on browser-safe leaf imports, with a recursive strict-CSP graph regression
- treat pages/**/layout files as reserved route metadata in static collection and request-time resolution
- document nested layout routing semantics
- set this PR release version to 0.1.1108 after #3029 releases 0.1.1107

## Why

The consumer chat route exposed two related production boundaries: compiled keepNames metadata kept a server-only import graph alive under strict CSP, and nested Pages layout modules were collected as independent pages. Both are framework concerns, so the app no longer needs a pathname branch or CSP exception.

## Merge order

PR #3029 must merge first so the release sequence remains monotonic: 0.1.1107, then this PR as 0.1.1108.

## Verification

- repository pre-push gate: 2,610 tests / 21,296 steps passed
- focused review regressions: 80 steps passed
- framework typecheck passed
- consumer production build: 4 pages and 8 browser chunks built successfully
- browser walkthrough at veryfront.me:3000: full-width /chat, dashboard shell retained on /review, no console errors, and no unsafe-eval dependency in the chat graph