### PR TITLE
fix(pages): preserve layout and module variant parity

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1108",
+  "version": "0.1.1109",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/build-routes.test.ts
+++ b/src/server/build-routes.test.ts
@@ -207,6 +207,7 @@ describe("server/build-routes", () => {
       const adapter = createMockAdapter({
         "/project/pages/index.tsx": "export default () => <div />",
         "/project/pages/layout.tsx": "export default ({ children }) => children",
+        "/project/pages/admin/Layout.tsx": "export default ({ children }) => children",
         "/project/pages/chat/index.tsx": "export default () => <div />",
         "/project/pages/chat/layout.tsx": "export default ({ children }) => children",
         "/project/pages/docs/index.mdx": "# Docs",

--- a/src/server/build-routes.ts
+++ b/src/server/build-routes.ts
@@ -29,7 +29,7 @@ function isPagesApiDirectoryDescendant(relativePath: string): boolean {
 
 function isPagesLayoutFile(relativePath: string): boolean {
   const fileName = relativePath.replace(/\\/g, "/").split("/").pop();
-  return fileName !== undefined && PAGES_LAYOUT_CANDIDATES.has(fileName);
+  return fileName !== undefined && PAGES_LAYOUT_CANDIDATES.has(fileName.toLowerCase());
 }
 
 function shouldIncludeRoute(path: string, include?: string[], exclude?: string[]): boolean {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1108";
+export const VERSION = "0.1.1109";

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -163,12 +163,13 @@ async function assertBrowserSafeFrameworkGraph(port: number, entryPath: string):
 
     for (const specifier of specifiers) {
       const resolved = new URL(specifier, `http://127.0.0.1:${port}${modulePath}`);
+      const resolvedModulePath = `${resolved.pathname}${resolved.search}`;
       if (
         resolved.origin === `http://127.0.0.1:${port}` &&
         resolved.pathname.startsWith("/_vf_modules/_veryfront/") &&
-        !visited.has(resolved.pathname)
+        !visited.has(resolvedModulePath)
       ) {
-        pending.push(resolved.pathname);
+        pending.push(resolvedModulePath);
       }
     }
   }
@@ -481,6 +482,36 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
         await assertBrowserSafeFrameworkGraph(port, "/_vf_modules/_veryfront/chat/index.js");
         await stopServer(server);
       });
+    });
+
+    it("preserves query strings while walking browser framework module variants", async () => {
+      const requestedPaths: string[] = [];
+      const originalFetch = globalThis.fetch;
+
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = input instanceof Request ? new URL(input.url) : new URL(String(input));
+        const modulePath = `${url.pathname}${url.search}`;
+        requestedPaths.push(modulePath);
+
+        const body = modulePath === "/_vf_modules/_veryfront/entry.js"
+          ? 'import "/_vf_modules/_veryfront/child.js?v=browser";'
+          : "export const child = true;";
+        return new Response(body, { status: 200 });
+      }) as typeof fetch;
+
+      try {
+        await assertBrowserSafeFrameworkGraph(
+          4173,
+          "/_vf_modules/_veryfront/entry.js",
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      assertEquals(requestedPaths, [
+        "/_vf_modules/_veryfront/entry.js",
+        "/_vf_modules/_veryfront/child.js?v=browser",
+      ]);
     });
   });
 

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -106,8 +106,9 @@ const BROWSER_CSP_SAFE_MODULE_PATHS = [
 async function fetchServedFrameworkModule(
   port: number,
   modulePath: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<{ body: string; specifiers: string[] }> {
-  const response = await fetch(`http://127.0.0.1:${port}${modulePath}`);
+  const response = await fetchImpl(`http://127.0.0.1:${port}${modulePath}`);
   assertEquals(response.status, 200, `Expected ${modulePath} to be served`);
 
   const body = await response.text();
@@ -148,7 +149,11 @@ function assertBrowserSafeFrameworkModule(
   );
 }
 
-async function assertBrowserSafeFrameworkGraph(port: number, entryPath: string): Promise<void> {
+async function assertBrowserSafeFrameworkGraph(
+  port: number,
+  entryPath: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<void> {
   const pending = [entryPath];
   const visited = new Set<string>();
   let nextIndex = 0;
@@ -158,7 +163,7 @@ async function assertBrowserSafeFrameworkGraph(port: number, entryPath: string):
     if (!modulePath || visited.has(modulePath)) continue;
     visited.add(modulePath);
 
-    const { body, specifiers } = await fetchServedFrameworkModule(port, modulePath);
+    const { body, specifiers } = await fetchServedFrameworkModule(port, modulePath, fetchImpl);
     assertBrowserSafeFrameworkModule(modulePath, body, specifiers);
 
     for (const specifier of specifiers) {
@@ -486,9 +491,7 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
 
     it("preserves query strings while walking browser framework module variants", async () => {
       const requestedPaths: string[] = [];
-      const originalFetch = globalThis.fetch;
-
-      globalThis.fetch = (async (input: string | URL | Request) => {
+      const fetchModule = (async (input: string | URL | Request) => {
         const url = input instanceof Request ? new URL(input.url) : new URL(String(input));
         const modulePath = `${url.pathname}${url.search}`;
         requestedPaths.push(modulePath);
@@ -499,14 +502,11 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
         return new Response(body, { status: 200 });
       }) as typeof fetch;
 
-      try {
-        await assertBrowserSafeFrameworkGraph(
-          4173,
-          "/_vf_modules/_veryfront/entry.js",
-        );
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
+      await assertBrowserSafeFrameworkGraph(
+        4173,
+        "/_vf_modules/_veryfront/entry.js",
+        fetchModule,
+      );
 
       assertEquals(requestedPaths, [
         "/_vf_modules/_veryfront/entry.js",


### PR DESCRIPTION
## Summary

- match Pages Router layout-file detection to the runtime's case-insensitive entity detection
- preserve served-module query variants while walking the browser graph for CSP safety validation
- reserve framework version `0.1.1109` so merge produces a new release

This follows up on two review findings that arrived immediately before #3030 merged:

- https://github.com/veryfront/veryfront-code/pull/3030#discussion_r3634555980
- https://github.com/veryfront/veryfront-code/pull/3030#discussion_r3634556017

## Verification

- `deno fmt --check` on the five changed files
- `deno task typecheck`
- focused tests: 3 files, 98 steps, 0 failures
- full pre-push gate: 2,613 tests, 21,314 steps, 0 failures

## Release

- `deno.json`: `0.1.1108` → `0.1.1109`
- `src/utils/version-constant.ts`: `0.1.1108` → `0.1.1109`
