### PR TITLE
fix(agent): preserve scoped MCP sources for delegates

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1109",
+  "version": "0.1.1110",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/composition/composition.test.ts
+++ b/src/agent/composition/composition.test.ts
@@ -9,7 +9,7 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module agent/composition/composition.test
  */
 
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { Agent, AgentResponse, AgentStreamResult } from "../types.ts";
 
@@ -193,5 +193,26 @@ describe("agentAsTool", () => {
       toolCalls: 0,
       status: "completed",
     });
+  });
+
+  it("preserves the child stream error when no final response is produced", async () => {
+    const childAgent = createMinimalAgent("failing-child");
+    childAgent.stream = () =>
+      Promise.resolve({
+        toDataStreamResponse() {
+          return new Response(
+            'data: {"type":"error","error":"Veryfront API MCP is unavailable"}\n\n',
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        },
+      });
+
+    const tool = agentAsTool(childAgent, "Run failing child agent");
+
+    await assertRejects(
+      () => tool.execute({ input: "Process the inbox" }),
+      Error,
+      "Veryfront API MCP is unavailable",
+    );
   });
 });

--- a/src/agent/composition/composition.ts
+++ b/src/agent/composition/composition.ts
@@ -18,6 +18,7 @@ import { getAgentToolInputSchema } from "../schemas/index.ts";
 import { getRuntimeSourceIntegrationPolicyFromContext } from "../runtime/runtime-tool-config.ts";
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import type { SourceIntegrationPolicyManifest } from "#veryfront/integrations/source-policy.ts";
+import { streamDataStreamEvents } from "../streaming/data-stream.ts";
 
 /** Agent as tool helper. */
 async function runAgentAsStreamingTool(
@@ -33,11 +34,22 @@ async function runAgentAsStreamingTool(
         finalResponse = response;
       },
     });
-    await stream.toDataStreamResponse().arrayBuffer();
+    let streamError: string | undefined;
+    const response = stream.toDataStreamResponse();
+    if (response.body) {
+      for await (const event of streamDataStreamEvents(response.body)) {
+        if (event.type !== "error") continue;
+        streamError = typeof event.errorText === "string"
+          ? event.errorText
+          : typeof event.error === "string"
+          ? event.error
+          : "Child agent stream failed";
+      }
+    }
 
     if (!finalResponse) {
       throw AGENT_ERROR.create({
-        detail: `Agent "${agent.id}" stream completed without a final response.`,
+        detail: streamError ?? `Agent "${agent.id}" stream completed without a final response.`,
       });
     }
     return finalResponse;

--- a/src/agent/hosted/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.test.ts
@@ -158,9 +158,9 @@ Deno.test("hosted child project agents request only materialized skill and deleg
   );
 });
 
-Deno.test("hosted scoped delegate tools opt out of legacy invoke_agent", () => {
+Deno.test("hosted scoped delegate tools replace legacy invoke_agent", () => {
   assertEquals(
-    veryfrontCloudAgentServiceInternals.shouldExposeLegacyInvokeAgent({
+    veryfrontCloudAgentServiceInternals.resolveHostedDelegationBinding({
       id: "job-submission-orchestrator",
       name: "Job submission orchestrator",
       description: "Coordinate job submission specialists.",
@@ -174,10 +174,18 @@ Deno.test("hosted scoped delegate tools opt out of legacy invoke_agent", () => {
         "get_file",
       ],
     }),
-    false,
+    {
+      kind: "scoped",
+      delegateIds: [
+        "ingestion-agent",
+        "extraction-agent",
+        "enrichment-agent",
+        "submission-agent",
+      ],
+    },
   );
   assertEquals(
-    veryfrontCloudAgentServiceInternals.shouldExposeLegacyInvokeAgent({
+    veryfrontCloudAgentServiceInternals.resolveHostedDelegationBinding({
       id: "legacy-agent",
       name: "Legacy agent",
       description: "Uses legacy delegation.",
@@ -185,7 +193,17 @@ Deno.test("hosted scoped delegate tools opt out of legacy invoke_agent", () => {
       skills: ["legacy-workflow"],
       tools: ["get_file"],
     }),
-    true,
+    { kind: "legacy" },
+  );
+  assertEquals(
+    veryfrontCloudAgentServiceInternals.resolveHostedDelegationBinding({
+      id: "no-delegation-agent",
+      name: "No delegation agent",
+      description: "Cannot delegate.",
+      instructions: "Work directly.",
+      delegates: [],
+    }),
+    { kind: "scoped", delegateIds: [] },
   );
 });
 

--- a/src/agent/hosted/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.test.ts
@@ -158,6 +158,37 @@ Deno.test("hosted child project agents request only materialized skill and deleg
   );
 });
 
+Deno.test("hosted scoped delegate tools opt out of legacy invoke_agent", () => {
+  assertEquals(
+    veryfrontCloudAgentServiceInternals.shouldExposeLegacyInvokeAgent({
+      id: "job-submission-orchestrator",
+      name: "Job submission orchestrator",
+      description: "Coordinate job submission specialists.",
+      instructions: "Coordinate the workflow.",
+      skills: ["orchestrate-job-submission"],
+      tools: [
+        "agent_ingestion-agent",
+        "agent_extraction-agent",
+        "agent_enrichment-agent",
+        "agent_submission-agent",
+        "get_file",
+      ],
+    }),
+    false,
+  );
+  assertEquals(
+    veryfrontCloudAgentServiceInternals.shouldExposeLegacyInvokeAgent({
+      id: "legacy-agent",
+      name: "Legacy agent",
+      description: "Uses legacy delegation.",
+      instructions: "Delegate when useful.",
+      skills: ["legacy-workflow"],
+      tools: ["get_file"],
+    }),
+    true,
+  );
+});
+
 Deno.test("hosted nested delegates inherit child scope and durable lineage", () => {
   const context = veryfrontCloudAgentServiceInternals.buildHostedChildToolContext(
     {

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -99,6 +99,7 @@ import {
 } from "../runtime/skill-metadata.ts";
 import type { RuntimeAgentMarkdownDefinition } from "../runtime/agent-definition.ts";
 import { buildAgentDelegateTools } from "../runtime/agent-delegation.ts";
+import { AGENT_DELEGATE_TOOL_PREFIX } from "../runtime/agent-delegation-names.ts";
 import {
   createRuntimeAgentDefinitionFromAgent,
   describeProjectAgentRuntimeAgentIdCandidates,
@@ -879,6 +880,7 @@ export const veryfrontCloudAgentServiceInternals = {
   resolveHostedChildAgentExecutionConfig,
   resolveHostedChildToolNames,
   resolveMcpServers,
+  shouldExposeLegacyInvokeAgent,
 };
 
 async function resolveHostedChildAgentExecutionConfig(
@@ -1020,6 +1022,13 @@ function buildHostedDeclarativeDelegateTools(
   });
 }
 
+function shouldExposeLegacyInvokeAgent(
+  agentConfig: RuntimeAgentMarkdownDefinition | undefined,
+): boolean {
+  return agentConfig?.tools === true ||
+    !agentConfig?.tools?.some((toolName) => toolName.startsWith(AGENT_DELEGATE_TOOL_PREFIX));
+}
+
 function buildLocalTools(
   context: NodeVeryfrontCloudAgentServiceContext,
   options: DefaultHostedChatRuntimeCreationOptions,
@@ -1041,9 +1050,9 @@ function buildLocalTools(
         tools,
         buildHostedDeclarativeDelegateTools(context, agentConfig, taskContext),
       );
-    } else {
+    } else if (shouldExposeLegacyInvokeAgent(agentConfig)) {
       // Agents authored before declarative delegates retain the legacy hosted
-      // child-fork tool. An explicit empty list opts out.
+      // child-fork tool. An explicit empty list or scoped delegate binding opts out.
       tools.invoke_agent = createInvokeAgentTool(context, taskContext);
     }
   }

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -877,10 +877,10 @@ function buildHostedChildToolContext(
 /** Internal test seams for hosted project-agent materialization. */
 export const veryfrontCloudAgentServiceInternals = {
   buildHostedChildToolContext,
+  resolveHostedDelegationBinding,
   resolveHostedChildAgentExecutionConfig,
   resolveHostedChildToolNames,
   resolveMcpServers,
-  shouldExposeLegacyInvokeAgent,
 };
 
 async function resolveHostedChildAgentExecutionConfig(
@@ -1010,23 +1010,25 @@ function buildHostedDelegateTools(
   });
 }
 
-function buildHostedDeclarativeDelegateTools(
-  context: NodeVeryfrontCloudAgentServiceContext,
-  agentConfig: RuntimeAgentMarkdownDefinition,
-  taskContext: DefaultHostedChatRuntimeTaskContext,
-): HostToolSet {
-  return buildHostedDelegateTools(context, {
-    delegates: agentConfig.delegates ?? [],
-    selfId: agentConfig.id,
-    taskContext,
-  });
-}
+type HostedDelegationBinding =
+  | { kind: "scoped"; delegateIds: string[] }
+  | { kind: "legacy" };
 
-function shouldExposeLegacyInvokeAgent(
+function resolveHostedDelegationBinding(
   agentConfig: RuntimeAgentMarkdownDefinition | undefined,
-): boolean {
-  return agentConfig?.tools === true ||
-    !agentConfig?.tools?.some((toolName) => toolName.startsWith(AGENT_DELEGATE_TOOL_PREFIX));
+): HostedDelegationBinding {
+  if (agentConfig?.delegates !== undefined) {
+    return { kind: "scoped", delegateIds: agentConfig.delegates };
+  }
+  if (agentConfig?.tools !== true) {
+    const delegateIds = agentConfig?.tools
+      ?.filter((toolName) => toolName.startsWith(AGENT_DELEGATE_TOOL_PREFIX))
+      .map((toolName) => toolName.slice(AGENT_DELEGATE_TOOL_PREFIX.length));
+    if (delegateIds?.length) {
+      return { kind: "scoped", delegateIds };
+    }
+  }
+  return { kind: "legacy" };
 }
 
 function buildLocalTools(
@@ -1045,14 +1047,19 @@ function buildLocalTools(
 
   if (options.allowDelegation !== false) {
     const agentConfig = options.liveProjectSteering?.agent;
-    if (agentConfig?.delegates !== undefined) {
+    const binding = resolveHostedDelegationBinding(agentConfig);
+    if (binding.kind === "scoped") {
       Object.assign(
         tools,
-        buildHostedDeclarativeDelegateTools(context, agentConfig, taskContext),
+        buildHostedDelegateTools(context, {
+          delegates: binding.delegateIds,
+          selfId: agentConfig?.id ?? taskContext.agentId ?? "veryfront",
+          taskContext,
+        }),
       );
-    } else if (shouldExposeLegacyInvokeAgent(agentConfig)) {
+    } else {
       // Agents authored before declarative delegates retain the legacy hosted
-      // child-fork tool. An explicit empty list or scoped delegate binding opts out.
+      // child-fork tool. Explicit scoped delegate bindings opt out.
       tools.invoke_agent = createInvokeAgentTool(context, taskContext);
     }
   }

--- a/src/agent/runtime/delegate-remote-tool-context.test.ts
+++ b/src/agent/runtime/delegate-remote-tool-context.test.ts
@@ -1,0 +1,130 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import type { ModelRuntime } from "#veryfront/provider";
+import type { RemoteToolSource } from "#veryfront/tool";
+import { agent } from "../index.ts";
+import { agentRegistry } from "../composition/index.ts";
+import {
+  type RuntimeRemoteToolConfig,
+  VERYFRONT_STUDIO_MCP_SOURCE_ID,
+} from "./mcp-server-tool-sources.ts";
+
+function createRuntimeStream(parts: unknown[]) {
+  return new ReadableStream<unknown>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+}
+
+Deno.test("local delegates inherit the trusted request-scoped MCP source", async () => {
+  const childId = "request-scoped-mcp-child";
+  const rootId = "request-scoped-mcp-root";
+  let childModelCalls = 0;
+  let rootModelCalls = 0;
+  const listedBy: string[] = [];
+
+  const injectedStudioSource: RemoteToolSource = {
+    id: VERYFRONT_STUDIO_MCP_SOURCE_ID,
+    listTools(context) {
+      listedBy.push(context?.agentId ?? "unknown");
+      return Promise.resolve([{
+        name: "get_file",
+        description: "Read a project file",
+        parameters: { type: "object", properties: {} },
+      }]);
+    },
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+
+  const childModel: ModelRuntime = {
+    provider: "test",
+    modelId: "test/delegate-child",
+    doGenerate: () => Promise.reject(new Error("unused")),
+    doStream() {
+      childModelCalls++;
+      return Promise.resolve({
+        stream: createRuntimeStream([
+          { type: "text-delta", text: "child completed" },
+          {
+            type: "finish",
+            finishReason: "stop",
+            usage: { inputTokens: 1, outputTokens: 1 },
+          },
+        ]),
+      });
+    },
+  };
+  const rootModel: ModelRuntime = {
+    provider: "test",
+    modelId: "test/delegate-root",
+    doGenerate: () => Promise.reject(new Error("unused")),
+    doStream() {
+      rootModelCalls++;
+      return Promise.resolve({
+        stream: createRuntimeStream(
+          rootModelCalls === 1
+            ? [
+              {
+                type: "tool-call",
+                toolCallId: "delegate-call-1",
+                toolName: `agent_${childId}`,
+                input: { input: "Read the project file" },
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]
+            : [
+              { type: "text-delta", text: "root completed" },
+              {
+                type: "finish",
+                finishReason: "stop",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ],
+        ),
+      });
+    },
+  };
+
+  agent({
+    id: childId,
+    model: "test/delegate-child",
+    system: "Use the project tool.",
+    tools: { get_file: true },
+    mcpServers: [{
+      kind: "veryfront-studio",
+      toolPolicy: { allow: ["get_file"] },
+    }],
+    resolveModelTransport: () => ({ model: childModel }),
+  });
+  const root = agent(
+    {
+      id: rootId,
+      model: "test/delegate-root",
+      system: "Delegate the task.",
+      delegates: [childId],
+      resolveModelTransport: () => ({ model: rootModel }),
+      __vfRemoteToolSources: [injectedStudioSource],
+    } as Parameters<typeof agent>[0] & RuntimeRemoteToolConfig,
+  );
+
+  try {
+    const body = await (await root.stream({ input: "Run the child" }))
+      .toDataStreamResponse()
+      .text();
+
+    assertEquals(childModelCalls, 1);
+    assertEquals(rootModelCalls, 2);
+    assertEquals(listedBy.includes(childId), true);
+    assertEquals(body.includes("root completed"), true);
+    assertEquals(body.includes('"type":"error"'), false);
+  } finally {
+    agentRegistry.delete(childId);
+    agentRegistry.delete(rootId);
+  }
+});

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -41,6 +41,7 @@ import { setActiveSpanAttributes as setOtelActiveSpanAttributes } from "#veryfro
 import { convertToTextGenerationRuntimeRequestMessages } from "./text-generation-runtime-message-converter.ts";
 import { convertToolsToRuntimeTools } from "./model-tool-converter.ts";
 import { getRuntimeRemoteToolSources } from "./mcp-server-tool-sources.ts";
+import { runWithExactRuntimeRemoteToolSources } from "./remote-tool-source-context.ts";
 import {
   createStreamState,
   processStream,
@@ -380,15 +381,19 @@ async function traceConfiguredToolExecution(input: {
         }),
       );
       try {
-        const result = await executeConfiguredTool(
-          input.toolName,
-          input.args,
-          input.toolsConfig,
-          input.context,
-          input.allowedRemoteToolNames,
-          input.remoteToolSources,
-          input.sourceIntegrationPolicy,
-          { strictConfiguredToolsOnly: input.strictConfiguredToolsOnly },
+        const result = await runWithExactRuntimeRemoteToolSources(
+          input.remoteToolSources ?? [],
+          () =>
+            executeConfiguredTool(
+              input.toolName,
+              input.args,
+              input.toolsConfig,
+              input.context,
+              input.allowedRemoteToolNames,
+              input.remoteToolSources,
+              input.sourceIntegrationPolicy,
+              { strictConfiguredToolsOnly: input.strictConfiguredToolsOnly },
+            ),
         );
         const resultError = getToolResultError(result);
         if (resultError !== undefined) {

--- a/src/agent/runtime/mcp-server-tool-sources.test.ts
+++ b/src/agent/runtime/mcp-server-tool-sources.test.ts
@@ -12,6 +12,7 @@ import {
   VERYFRONT_STUDIO_MCP_SOURCE_ID,
 } from "./mcp-server-tool-sources.ts";
 import { VeryfrontError } from "#veryfront/errors";
+import { runWithExactRuntimeRemoteToolSources } from "./remote-tool-source-context.ts";
 
 Deno.test("getRequestedUnresolvedBooleanToolNames keeps legacy delegation local", () => {
   assertEquals(
@@ -354,6 +355,44 @@ Deno.test("getRuntimeRemoteToolSources does not leak injected sources after expl
       mcpServers: [],
       __vfRemoteToolSources: [injectedApiSource, injectedStudioSource],
     } as Parameters<typeof getRuntimeRemoteToolSources>[0],
+  );
+
+  assertEquals(sources, undefined);
+});
+
+Deno.test("getRuntimeRemoteToolSources does not leak inherited sources after explicit MCP opt-out", () => {
+  const injectedSource: RemoteToolSource = {
+    id: VERYFRONT_API_MCP_SOURCE_ID,
+    listTools: () => Promise.resolve([]),
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+
+  const sources = runWithExactRuntimeRemoteToolSources(
+    [injectedSource],
+    () =>
+      getRuntimeRemoteToolSources({
+        system: "No remote MCP tools.",
+        mcpServers: [],
+      }),
+  );
+
+  assertEquals(sources, undefined);
+});
+
+Deno.test("getRuntimeRemoteToolSources does not expose inherited sources to tools true", () => {
+  const inheritedSource: RemoteToolSource = {
+    id: VERYFRONT_API_MCP_SOURCE_ID,
+    listTools: () => Promise.resolve([]),
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+
+  const sources = runWithExactRuntimeRemoteToolSources(
+    [inheritedSource],
+    () =>
+      getRuntimeRemoteToolSources({
+        system: "Use only explicitly granted tools.",
+        tools: true,
+      }),
   );
 
   assertEquals(sources, undefined);

--- a/src/agent/runtime/mcp-server-tool-sources.ts
+++ b/src/agent/runtime/mcp-server-tool-sources.ts
@@ -21,6 +21,7 @@ import {
   type VeryfrontCloudBootstrap,
 } from "#veryfront/platform/cloud/resolver.ts";
 import { createAgentServiceRemoteMcpConfig } from "../service/mcp-server-config.ts";
+import { getActiveRuntimeRemoteToolSources } from "./remote-tool-source-context.ts";
 
 export type RuntimeRemoteToolConfig = {
   __vfRemoteToolSources?: RemoteToolSource[];
@@ -288,11 +289,17 @@ export function getRuntimeRemoteToolSources(
   agentId = config.id,
 ): RemoteToolSource[] | undefined {
   const runtimeConfig = config as AgentConfig & RuntimeRemoteToolConfig;
-  const injectedSources = runtimeConfig.__vfRemoteToolSources ?? [];
+  const configuredInjectedSources = Object.hasOwn(runtimeConfig, "__vfRemoteToolSources")
+    ? runtimeConfig.__vfRemoteToolSources ?? []
+    : undefined;
   const hasExplicitMcpServers = config.mcpServers !== undefined;
   const implicitToolNames = hasExplicitMcpServers
     ? []
     : getRequestedUnresolvedBooleanToolNames({ tools: config.tools, agentId });
+  const inheritedSources = hasExplicitMcpServers || implicitToolNames.length > 0
+    ? getActiveRuntimeRemoteToolSources() ?? []
+    : [];
+  const injectedSources = configuredInjectedSources ?? inheritedSources;
   const configuredServers: AgentMcpServerConfig[] = config.mcpServers ??
     (implicitToolNames.length > 0
       ? [{ kind: "veryfront-api", toolPolicy: { allow: implicitToolNames } }]

--- a/src/agent/runtime/remote-tool-source-context.ts
+++ b/src/agent/runtime/remote-tool-source-context.ts
@@ -1,0 +1,17 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { RemoteToolSource } from "#veryfront/tool";
+
+const remoteToolSourceStorage = new AsyncLocalStorage<RemoteToolSource[]>();
+
+/** Return the exact request-scoped remote tool sources active at this runtime boundary. */
+export function getActiveRuntimeRemoteToolSources(): RemoteToolSource[] | undefined {
+  return remoteToolSourceStorage.getStore();
+}
+
+/** Establish the exact remote tool sources available to nested local execution. */
+export function runWithExactRuntimeRemoteToolSources<T>(
+  sources: RemoteToolSource[],
+  fn: () => T,
+): T {
+  return remoteToolSourceStorage.run(sources, fn);
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1109";
+export const VERSION = "0.1.1110";


### PR DESCRIPTION
## Problem

Project-scoped agents can delegate locally, but the child runtime loses the trusted request-scoped Veryfront MCP source. Explicit first-party MCP declarations then fall back to host bootstrap credentials and fail before model execution. The agent-as-tool wrapper also hides the actual child SSE error behind `stream completed without a final response`.

## Solution

- carry the exact effective remote-tool source set through nested local tool execution with request-local async context
- let delegated runtimes reuse that trusted source only for explicit first-party MCP declarations or explicitly named unresolved remote tools
- preserve explicit MCP opt-out and prevent `tools: true` from inheriting remote sources
- surface the original child stream error
- publish framework `0.1.1110` so the fix reaches Veryfront Cloud

## Red / green evidence

- Red: root → local delegate → explicit first-party MCP failed before the child model ran; child SSE error was replaced by the generic no-final-response error
- Green: 33 focused tests pass, including propagation, explicit opt-out, `tools: true` least privilege, and error preservation
- Broader: 228 agent runtime/composition tests pass; lint and framework typecheck pass
- Pre-push: 2,616 tests / 21,315 steps pass, zero failures
- Repository verify reached consumer typecheck and stopped only because the isolated worktree lacks `storybook/node_modules/.bin/tsc` (`npm --prefix storybook ci`), which CI installs
