### PR TITLE
fix(ssr): preserve active transforms during dev cache clears

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1110",
+  "version": "0.1.1111",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/modules/react-loader/ssr-module-loader/cache/index.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/index.ts
@@ -19,6 +19,8 @@ export {
   tryAcquireTransformSlot,
 } from "./memory.ts";
 
+export type { ClearSSRModuleCacheForProjectOptions } from "./memory.ts";
+
 export {
   getFromRedis,
   initializeSSRDistributedCache,

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -18,6 +18,7 @@ import { verifiedHttpBundlePaths } from "../http-bundle-helpers.ts";
 import { getTransformPerProjectLimit } from "../constants.ts";
 import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import { getTmpDirCacheKey } from "../tmp-paths.ts";
 
 describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
   function resetState(): void {
@@ -267,6 +268,21 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
       globalInProgress.clear();
     });
 
+    it("should preserve in-progress entries for a specific project when requested", () => {
+      resetState();
+
+      const projectTransform = Promise.resolve();
+      globalInProgress.set("prefix:project-1:mod", projectTransform);
+      globalInProgress.set("prefix:project-2:mod", Promise.resolve());
+
+      clearSSRModuleCacheForProject("project-1", { preserveActiveTransforms: true });
+
+      assertEquals(globalInProgress.get("prefix:project-1:mod"), projectTransform);
+      assertEquals(globalInProgress.has("prefix:project-2:mod"), true);
+
+      globalInProgress.clear();
+    });
+
     it("should clear failed components for a specific project", () => {
       resetState();
 
@@ -285,13 +301,36 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
       resetState();
 
       const baseCacheDir = getMdxEsmCacheDir();
-      const key1 = `${baseCacheDir}|${hashCodeHex("project-1")}|${hashCodeHex("preview-main")}`;
-      const key2 = `${baseCacheDir}|${hashCodeHex("project-2")}|${hashCodeHex("preview-main")}`;
+      const key1 = getTmpDirCacheKey(baseCacheDir, "project-1", "preview-main");
+      const key2 = getTmpDirCacheKey(baseCacheDir, "project-2", "preview-main");
+      const legacyKey = `${baseCacheDir}|${hashCodeHex("project-1")}|${
+        hashCodeHex("preview-main")
+      }`;
+
+      globalTmpDirs.set(key1, "/tmp/proj1");
+      globalTmpDirs.set(key2, "/tmp/proj2");
+      globalTmpDirs.set(legacyKey, "/tmp/proj1-legacy");
+
+      clearSSRModuleCacheForProject("project-1");
+
+      assertEquals(globalTmpDirs.has(key1), false);
+      assertEquals(globalTmpDirs.has(key2), true);
+      assertEquals(globalTmpDirs.has(legacyKey), false);
+
+      globalTmpDirs.clear();
+    });
+
+    it("should clear project tmp dirs even when active transforms are preserved", () => {
+      resetState();
+
+      const baseCacheDir = getMdxEsmCacheDir();
+      const key1 = getTmpDirCacheKey(baseCacheDir, "project-1", "preview-main");
+      const key2 = getTmpDirCacheKey(baseCacheDir, "project-2", "preview-main");
 
       globalTmpDirs.set(key1, "/tmp/proj1");
       globalTmpDirs.set(key2, "/tmp/proj2");
 
-      clearSSRModuleCacheForProject("project-1");
+      clearSSRModuleCacheForProject("project-1", { preserveActiveTransforms: true });
 
       assertEquals(globalTmpDirs.has(key1), false);
       assertEquals(globalTmpDirs.has(key2), true);
@@ -314,6 +353,43 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
       }
 
       releaseTransformSlot("proj-other");
+    });
+
+    it("should reject project transform waiters by default", async () => {
+      resetState();
+      if (getTransformPerProjectLimit() <= 0) return;
+
+      const projectId = "proj-waiter-default-clear";
+      for (let i = 0; i < getTransformPerProjectLimit(); i++) {
+        assertEquals(acquireTransformSlot(projectId), true);
+      }
+
+      const waiter = tryAcquireTransformSlot(projectId, 10_000);
+      clearSSRModuleCacheForProject(projectId);
+
+      assertEquals(await waiter, false);
+      assertEquals(getTransformStats().activeProjects.has(projectId), false);
+    });
+
+    it("should preserve project transform slots and waiters when requested", async () => {
+      resetState();
+      if (getTransformPerProjectLimit() <= 0) return;
+
+      const projectId = "proj-waiter-preserved-clear";
+      for (let i = 0; i < getTransformPerProjectLimit(); i++) {
+        assertEquals(acquireTransformSlot(projectId), true);
+      }
+
+      const waiter = tryAcquireTransformSlot(projectId, 10_000);
+      clearSSRModuleCacheForProject(projectId, { preserveActiveTransforms: true });
+
+      assertEquals(getTransformStats().activeProjects.has(projectId), true);
+      releaseTransformSlot(projectId);
+      assertEquals(await waiter, true);
+
+      for (let i = 0; i < getTransformPerProjectLimit(); i++) {
+        releaseTransformSlot(projectId);
+      }
     });
 
     it("should clear verifiedHttpBundlePaths", () => {

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -50,6 +50,16 @@ export const globalTmpDirs = new LRUCache<string, string>({
 
 export const failedComponents = new Map<string, FailureRecord>();
 
+export interface ClearSSRModuleCacheForProjectOptions {
+  /**
+   * Preserve live transform ownership and per-project capacity waiters while
+   * clearing request-visible cache entries. Dev SSR request starts use this so
+   * concurrent cold requests do not delete another request's transform leader
+   * before it can publish its completed cache entry.
+   */
+  preserveActiveTransforms?: boolean;
+}
+
 let _transformSemaphore: Semaphore | undefined;
 export function getTransformSemaphore(): Semaphore {
   if (!_transformSemaphore) {
@@ -308,9 +318,13 @@ export function clearSSRModuleCache(): void {
   });
 }
 
-export function clearSSRModuleCacheForProject(projectId: string): void {
+export function clearSSRModuleCacheForProject(
+  projectId: string,
+  options: ClearSSRModuleCacheForProjectOptions = {},
+): void {
   let cleared = 0;
   const encodedProjectId = hashCodeHex(projectId);
+  const preserveActiveTransforms = options.preserveActiveTransforms === true;
 
   for (const key of globalModuleCache.keys()) {
     if (!isKeyForProject(key, projectId)) continue;
@@ -323,9 +337,11 @@ export function clearSSRModuleCacheForProject(projectId: string): void {
     globalCrossProjectCache.delete(key);
   }
 
-  for (const key of globalInProgress.keys()) {
-    if (!isKeyForProject(key, projectId)) continue;
-    globalInProgress.delete(key);
+  if (!preserveActiveTransforms) {
+    for (const key of globalInProgress.keys()) {
+      if (!isKeyForProject(key, projectId)) continue;
+      globalInProgress.delete(key);
+    }
   }
 
   for (const key of failedComponents.keys()) {
@@ -335,7 +351,7 @@ export function clearSSRModuleCacheForProject(projectId: string): void {
 
   for (const key of globalTmpDirs.keys()) {
     const parts = key.split("|");
-    if (parts.length >= 3 && parts[1] === encodedProjectId) {
+    if (parts[2] === encodedProjectId || parts[1] === encodedProjectId) {
       globalTmpDirs.delete(key);
       continue;
     }
@@ -346,8 +362,10 @@ export function clearSSRModuleCacheForProject(projectId: string): void {
     }
   }
 
-  projectTransformCounts.delete(projectId);
-  rejectProjectTransformWaiters(projectId);
+  if (!preserveActiveTransforms) {
+    projectTransformCounts.delete(projectId);
+    rejectProjectTransformWaiters(projectId);
+  }
 
   // Clear verified HTTP bundle paths — keys are tempPath:contentHash (not project-scoped),
   // so full clear is needed. This just forces re-verification on next access.
@@ -356,6 +374,7 @@ export function clearSSRModuleCacheForProject(projectId: string): void {
   logger.debug("✓ Project cache cleared", {
     projectId,
     entriesCleared: cleared,
+    activeTransformsPreserved: preserveActiveTransforms,
     remainingModules: globalModuleCache.size,
   });
 }

--- a/src/modules/react-loader/ssr-module-loader/index.ts
+++ b/src/modules/react-loader/ssr-module-loader/index.ts
@@ -32,6 +32,8 @@ export {
   isSSRDistributedCacheEnabled,
 } from "./cache/index.ts";
 
+export type { ClearSSRModuleCacheForProjectOptions } from "./cache/index.ts";
+
 export { Semaphore } from "./concurrency/index.ts";
 
 import { SSR_MODULE_CACHE_MAX_ENTRIES } from "./constants.ts";

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -18,6 +18,11 @@ import {
   resetRequestProfiles,
   runWithRequestProfiling,
 } from "#veryfront/observability/request-profiler.ts";
+import {
+  clearSSRModuleCache,
+  globalInProgress,
+  globalModuleCache,
+} from "#veryfront/modules/react-loader/ssr-module-loader/cache/index.ts";
 
 const RELEASE_CSS_HASH = "c".repeat(64);
 
@@ -201,6 +206,58 @@ describe("RenderPipeline behavior", () => {
 
     assertEquals(checks, [{ slug: "", cacheKey: "index" }]);
     assertEquals(persists, [{ slug: "", cacheKey: "index" }]);
+  });
+
+  it("renderPage preserves active SSR transforms during development cache freshness clears", async () => {
+    clearSSRModuleCache();
+    const projectId = "project-dev-render-active-transform";
+    const moduleKey = `prefix:${projectId}:module`;
+    const inProgressKey = `prefix:${projectId}:in-progress`;
+    const leader = Promise.resolve();
+    globalModuleCache.set(moduleKey, { tempPath: "/tmp/dev-render.mjs", contentHash: "a" });
+    globalInProgress.set(inProgressKey, leader);
+
+    const pipeline = createPipeline("/project/pages/dev-render.tsx", {
+      mode: "development",
+      projectId,
+    });
+
+    try {
+      await pipeline.renderPage("/dev-render", { delivery: "string" });
+
+      assertEquals(globalModuleCache.has(moduleKey), false);
+      assertEquals(globalInProgress.get(inProgressKey), leader);
+    } finally {
+      clearSSRModuleCache();
+    }
+  });
+
+  it("resolvePageData preserves active SSR transforms during development cache freshness clears", async () => {
+    clearSSRModuleCache();
+    const projectId = "project-dev-page-data-active-transform";
+    const moduleKey = `prefix:${projectId}:module`;
+    const inProgressKey = `prefix:${projectId}:in-progress`;
+    const leader = Promise.resolve();
+    globalModuleCache.set(moduleKey, { tempPath: "/tmp/dev-page-data.mjs", contentHash: "a" });
+    globalInProgress.set(inProgressKey, leader);
+
+    const pipeline = createPipeline("/project/pages/dev-page-data.tsx", {
+      mode: "development",
+      projectId,
+    });
+    (pipeline as any).loadModule = async () => ({});
+
+    try {
+      await pipeline.resolvePageData("/dev-page-data", {
+        request: new Request("http://localhost/dev-page-data"),
+        url: new URL("http://localhost/dev-page-data"),
+      });
+
+      assertEquals(globalModuleCache.has(moduleKey), false);
+      assertEquals(globalInProgress.get(inProgressKey), leader);
+    } finally {
+      clearSSRModuleCache();
+    }
   });
 
   it("renderPage forwards project-relative layout props to HTML hydration", async () => {

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -529,7 +529,7 @@ export class RenderPipeline {
     setupSSRGlobals();
 
     if (this.config.mode === "development") {
-      clearSSRModuleCacheForProject(projectId);
+      clearSSRModuleCacheForProject(projectId, { preserveActiveTransforms: true });
     }
 
     const renderOnce = () =>
@@ -823,7 +823,7 @@ export class RenderPipeline {
     const projectId = options?.projectId ?? this.config.projectId ?? this.config.projectDir;
 
     if (this.config.mode === "development") {
-      clearSSRModuleCacheForProject(projectId);
+      clearSSRModuleCacheForProject(projectId, { preserveActiveTransforms: true });
     }
 
     const pageInfo = await profilePhase(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1110";
+export const VERSION = "0.1.1111";


### PR DESCRIPTION
## Summary

- preserve active SSR singleflight leaders and project transform waiters during development request-start cache freshness clears
- keep the existing destructive behavior for explicit project invalidation and HMR callers
- fix project temp-directory invalidation for the current versioned cache-key shape while retaining legacy compatibility
- bump the framework/runtime version to `0.1.1111` so merge creates a new release

## Root cause

Both `renderPage()` and `resolvePageData()` clear the project SSR module cache at the start of every development request. That clear also removed `globalInProgress` entries. Under cold concurrent route prefetch, one request could remove another request transform leader; the leader then failed its identity check, skipped cache publication, and `loadRawModule()` threw `Failed to transform module` even though transformation completed.

This is a request-time SSR race, not an SSG problem. The consuming app must remain SSR-only.

## Fix

`clearSSRModuleCacheForProject()` now accepts an explicit `preserveActiveTransforms` mode. Dev request entrypoints use it to clear request-visible cached modules while preserving only live transform ownership, per-project slot counts, and waiters. All existing invalidation callers retain full-clear behavior by default.

## Verification

- full pre-push gate passed
  - format: 4,086 files
  - lint: 4,034 files
  - typecheck: passed
  - unit tests: 2,617 passed / 21,321 steps / 0 failed
- focused cache and render-pipeline tests: 57 steps passed
- locally built and linked `veryfront@0.1.1111` into [agentic-job-submission-processing PR #41](https://github.com/veryfront/agentic-job-submission-processing/pull/41)
- exact cold concurrent requests for `/`, `/review`, `/jobs`, and `/chat` returned 200 with no `cssError` and no transform failure
- cold browser load triggered all route page-data prefetches with HTTP 200, no browser errors, and no server-side CSS-generation or transform errors

## Before / after

Before (`0.1.1109`): reproducible `CSS generation failed` / `Failed to transform module` during cold concurrent page-data prefetch.

After (linked `0.1.1111`): the same concurrent SSR and browser-prefetch paths complete without errors.