### PR TITLE
fix(agent): preserve nested MCP capability boundaries

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1110",
+  "version": "0.1.1111",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1111",
+  "version": "0.1.1112",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.test.ts
@@ -158,7 +158,7 @@ Deno.test("hosted child project agents request only materialized skill and deleg
   );
 });
 
-Deno.test("hosted scoped delegate tools replace legacy invoke_agent", () => {
+Deno.test("hosted generic invocation is only replaced by explicit delegates", () => {
   assertEquals(
     veryfrontCloudAgentServiceInternals.resolveHostedDelegationBinding({
       id: "job-submission-orchestrator",
@@ -167,6 +167,7 @@ Deno.test("hosted scoped delegate tools replace legacy invoke_agent", () => {
       instructions: "Coordinate the workflow.",
       skills: ["orchestrate-job-submission"],
       tools: [
+        "invoke_agent",
         "agent_ingestion-agent",
         "agent_extraction-agent",
         "agent_enrichment-agent",
@@ -174,15 +175,7 @@ Deno.test("hosted scoped delegate tools replace legacy invoke_agent", () => {
         "get_file",
       ],
     }),
-    {
-      kind: "scoped",
-      delegateIds: [
-        "ingestion-agent",
-        "extraction-agent",
-        "enrichment-agent",
-        "submission-agent",
-      ],
-    },
+    { kind: "legacy" },
   );
   assertEquals(
     veryfrontCloudAgentServiceInternals.resolveHostedDelegationBinding({
@@ -194,6 +187,16 @@ Deno.test("hosted scoped delegate tools replace legacy invoke_agent", () => {
       tools: ["get_file"],
     }),
     { kind: "legacy" },
+  );
+  assertEquals(
+    veryfrontCloudAgentServiceInternals.resolveHostedDelegationBinding({
+      id: "scoped-agent",
+      name: "Scoped agent",
+      description: "Uses explicit delegates.",
+      instructions: "Delegate only to the specialist.",
+      delegates: ["specialist-agent"],
+    }),
+    { kind: "scoped", delegateIds: ["specialist-agent"] },
   );
   assertEquals(
     veryfrontCloudAgentServiceInternals.resolveHostedDelegationBinding({

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -99,7 +99,6 @@ import {
 } from "../runtime/skill-metadata.ts";
 import type { RuntimeAgentMarkdownDefinition } from "../runtime/agent-definition.ts";
 import { buildAgentDelegateTools } from "../runtime/agent-delegation.ts";
-import { AGENT_DELEGATE_TOOL_PREFIX } from "../runtime/agent-delegation-names.ts";
 import {
   createRuntimeAgentDefinitionFromAgent,
   describeProjectAgentRuntimeAgentIdCandidates,
@@ -1019,14 +1018,6 @@ function resolveHostedDelegationBinding(
 ): HostedDelegationBinding {
   if (agentConfig?.delegates !== undefined) {
     return { kind: "scoped", delegateIds: agentConfig.delegates };
-  }
-  if (agentConfig?.tools !== true) {
-    const delegateIds = agentConfig?.tools
-      ?.filter((toolName) => toolName.startsWith(AGENT_DELEGATE_TOOL_PREFIX))
-      .map((toolName) => toolName.slice(AGENT_DELEGATE_TOOL_PREFIX.length));
-    if (delegateIds?.length) {
-      return { kind: "scoped", delegateIds };
-    }
   }
   return { kind: "legacy" };
 }

--- a/src/agent/runtime/delegate-remote-tool-context.test.ts
+++ b/src/agent/runtime/delegate-remote-tool-context.test.ts
@@ -18,22 +18,40 @@ function createRuntimeStream(parts: unknown[]) {
   });
 }
 
+function getRuntimeToolNames(options: unknown): string[] {
+  const tools = (options as { tools?: unknown }).tools;
+  return Array.isArray(tools)
+    ? tools.map((entry) =>
+      (entry as { name?: string; id?: string }).name ??
+        (entry as { name?: string; id?: string }).id ?? ""
+    )
+    : Object.keys((tools as Record<string, unknown> | undefined) ?? {});
+}
+
 Deno.test("local delegates inherit the trusted request-scoped MCP source", async () => {
   const childId = "request-scoped-mcp-child";
   const rootId = "request-scoped-mcp-root";
   let childModelCalls = 0;
   let rootModelCalls = 0;
   const listedBy: string[] = [];
+  let childRuntimeToolNames: string[] = [];
 
   const injectedStudioSource: RemoteToolSource = {
     id: VERYFRONT_STUDIO_MCP_SOURCE_ID,
     listTools(context) {
       listedBy.push(context?.agentId ?? "unknown");
-      return Promise.resolve([{
-        name: "get_file",
-        description: "Read a project file",
-        parameters: { type: "object", properties: {} },
-      }]);
+      return Promise.resolve([
+        {
+          name: "get_file",
+          description: "Read a project file",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          name: "delete_file",
+          description: "Delete a project file",
+          parameters: { type: "object", properties: {} },
+        },
+      ]);
     },
     executeTool: () => Promise.resolve({ ok: true }),
   };
@@ -42,8 +60,9 @@ Deno.test("local delegates inherit the trusted request-scoped MCP source", async
     provider: "test",
     modelId: "test/delegate-child",
     doGenerate: () => Promise.reject(new Error("unused")),
-    doStream() {
+    doStream(options) {
       childModelCalls++;
+      childRuntimeToolNames = getRuntimeToolNames(options);
       return Promise.resolve({
         stream: createRuntimeStream([
           { type: "text-delta", text: "child completed" },
@@ -95,11 +114,8 @@ Deno.test("local delegates inherit the trusted request-scoped MCP source", async
     id: childId,
     model: "test/delegate-child",
     system: "Use the project tool.",
-    tools: { get_file: true },
-    mcpServers: [{
-      kind: "veryfront-studio",
-      toolPolicy: { allow: ["get_file"] },
-    }],
+    tools: true,
+    mcpServers: [{ kind: "veryfront-studio" }],
     resolveModelTransport: () => ({ model: childModel }),
   });
   const root = agent(
@@ -109,6 +125,7 @@ Deno.test("local delegates inherit the trusted request-scoped MCP source", async
       system: "Delegate the task.",
       delegates: [childId],
       resolveModelTransport: () => ({ model: rootModel }),
+      __vfAllowedRemoteTools: ["get_file"],
       __vfRemoteToolSources: [injectedStudioSource],
     } as Parameters<typeof agent>[0] & RuntimeRemoteToolConfig,
   );
@@ -121,9 +138,167 @@ Deno.test("local delegates inherit the trusted request-scoped MCP source", async
     assertEquals(childModelCalls, 1);
     assertEquals(rootModelCalls, 2);
     assertEquals(listedBy.includes(childId), true);
+    assertEquals(childRuntimeToolNames.includes("get_file"), true);
+    assertEquals(childRuntimeToolNames.includes("delete_file"), false);
     assertEquals(body.includes("root completed"), true);
     assertEquals(body.includes('"type":"error"'), false);
   } finally {
+    agentRegistry.delete(childId);
+    agentRegistry.delete(rootId);
+  }
+});
+
+Deno.test("local-only delegates preserve the trusted MCP source for a grandchild", async () => {
+  const grandchildId = "request-scoped-mcp-grandchild";
+  const childId = "request-scoped-local-child";
+  const rootId = "request-scoped-mcp-nested-root";
+  let grandchildModelCalls = 0;
+  let childModelCalls = 0;
+  let rootModelCalls = 0;
+  const listedBy: string[] = [];
+
+  const injectedStudioSource: RemoteToolSource = {
+    id: VERYFRONT_STUDIO_MCP_SOURCE_ID,
+    listTools(context) {
+      listedBy.push(context?.agentId ?? "unknown");
+      return Promise.resolve([{
+        name: "get_file",
+        description: "Read a project file",
+        parameters: { type: "object", properties: {} },
+      }]);
+    },
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+
+  const grandchildModel: ModelRuntime = {
+    provider: "test",
+    modelId: "test/delegate-grandchild",
+    doGenerate: () => Promise.reject(new Error("unused")),
+    doStream() {
+      grandchildModelCalls++;
+      return Promise.resolve({
+        stream: createRuntimeStream([
+          { type: "text-delta", text: "grandchild completed" },
+          {
+            type: "finish",
+            finishReason: "stop",
+            usage: { inputTokens: 1, outputTokens: 1 },
+          },
+        ]),
+      });
+    },
+  };
+  const childModel: ModelRuntime = {
+    provider: "test",
+    modelId: "test/delegate-intermediate",
+    doGenerate: () => Promise.reject(new Error("unused")),
+    doStream() {
+      childModelCalls++;
+      return Promise.resolve({
+        stream: createRuntimeStream(
+          childModelCalls === 1
+            ? [
+              {
+                type: "tool-call",
+                toolCallId: "grandchild-call-1",
+                toolName: `agent_${grandchildId}`,
+                input: { input: "Read the project file" },
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]
+            : [
+              { type: "text-delta", text: "child completed" },
+              {
+                type: "finish",
+                finishReason: "stop",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ],
+        ),
+      });
+    },
+  };
+  const rootModel: ModelRuntime = {
+    provider: "test",
+    modelId: "test/delegate-nested-root",
+    doGenerate: () => Promise.reject(new Error("unused")),
+    doStream() {
+      rootModelCalls++;
+      return Promise.resolve({
+        stream: createRuntimeStream(
+          rootModelCalls === 1
+            ? [
+              {
+                type: "tool-call",
+                toolCallId: "child-call-1",
+                toolName: `agent_${childId}`,
+                input: { input: "Delegate to the grandchild" },
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]
+            : [
+              { type: "text-delta", text: "root completed" },
+              {
+                type: "finish",
+                finishReason: "stop",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ],
+        ),
+      });
+    },
+  };
+
+  agent({
+    id: grandchildId,
+    model: "test/delegate-grandchild",
+    system: "Use the project tool.",
+    tools: { get_file: true },
+    mcpServers: [{
+      kind: "veryfront-studio",
+      toolPolicy: { allow: ["get_file"] },
+    }],
+    resolveModelTransport: () => ({ model: grandchildModel }),
+  });
+  agent({
+    id: childId,
+    model: "test/delegate-intermediate",
+    system: "Delegate once.",
+    delegates: [grandchildId],
+    resolveModelTransport: () => ({ model: childModel }),
+  });
+  const root = agent(
+    {
+      id: rootId,
+      model: "test/delegate-nested-root",
+      system: "Delegate the task.",
+      delegates: [childId],
+      resolveModelTransport: () => ({ model: rootModel }),
+      __vfRemoteToolSources: [injectedStudioSource],
+    } as Parameters<typeof agent>[0] & RuntimeRemoteToolConfig,
+  );
+
+  try {
+    const body = await (await root.stream({ input: "Run the nested child" }))
+      .toDataStreamResponse()
+      .text();
+
+    assertEquals(grandchildModelCalls, 1);
+    assertEquals(childModelCalls, 2);
+    assertEquals(rootModelCalls, 2);
+    assertEquals(listedBy.includes(grandchildId), true);
+    assertEquals(body.includes("root completed"), true);
+    assertEquals(body.includes('"type":"error"'), false);
+  } finally {
+    agentRegistry.delete(grandchildId);
     agentRegistry.delete(childId);
     agentRegistry.delete(rootId);
   }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -40,8 +40,11 @@ import {
 import { setActiveSpanAttributes as setOtelActiveSpanAttributes } from "#veryfront/observability";
 import { convertToTextGenerationRuntimeRequestMessages } from "./text-generation-runtime-message-converter.ts";
 import { convertToolsToRuntimeTools } from "./model-tool-converter.ts";
-import { getRuntimeRemoteToolSources } from "./mcp-server-tool-sources.ts";
-import { runWithExactRuntimeRemoteToolSources } from "./remote-tool-source-context.ts";
+import {
+  constrainRuntimeRemoteToolSources,
+  getRuntimeRemoteToolSources,
+} from "./mcp-server-tool-sources.ts";
+import { runWithRuntimeRemoteToolSources } from "./remote-tool-source-context.ts";
 import {
   createStreamState,
   processStream,
@@ -381,8 +384,12 @@ async function traceConfiguredToolExecution(input: {
         }),
       );
       try {
-        const result = await runWithExactRuntimeRemoteToolSources(
-          input.remoteToolSources ?? [],
+        const inheritedRemoteToolSources = constrainRuntimeRemoteToolSources(
+          input.remoteToolSources,
+          input.allowedRemoteToolNames,
+        );
+        const result = await runWithRuntimeRemoteToolSources(
+          inheritedRemoteToolSources,
           () =>
             executeConfiguredTool(
               input.toolName,

--- a/src/agent/runtime/mcp-server-tool-sources.test.ts
+++ b/src/agent/runtime/mcp-server-tool-sources.test.ts
@@ -335,7 +335,7 @@ Deno.test("getRuntimeRemoteToolSources preserves explicit MCP opt-out", () => {
     },
   );
 
-  assertEquals(sources, undefined);
+  assertEquals(sources, []);
 });
 
 Deno.test("getRuntimeRemoteToolSources does not leak injected sources after explicit MCP opt-out", () => {
@@ -357,7 +357,7 @@ Deno.test("getRuntimeRemoteToolSources does not leak injected sources after expl
     } as Parameters<typeof getRuntimeRemoteToolSources>[0],
   );
 
-  assertEquals(sources, undefined);
+  assertEquals(sources, []);
 });
 
 Deno.test("getRuntimeRemoteToolSources does not leak inherited sources after explicit MCP opt-out", () => {
@@ -376,7 +376,7 @@ Deno.test("getRuntimeRemoteToolSources does not leak inherited sources after exp
       }),
   );
 
-  assertEquals(sources, undefined);
+  assertEquals(sources, []);
 });
 
 Deno.test("getRuntimeRemoteToolSources does not expose inherited sources to tools true", () => {
@@ -396,6 +396,49 @@ Deno.test("getRuntimeRemoteToolSources does not expose inherited sources to tool
   );
 
   assertEquals(sources, undefined);
+});
+
+Deno.test("getRuntimeRemoteToolSources constrains inherited sources to implicit named tools", async () => {
+  const executedToolNames: string[] = [];
+  const inheritedSource: RemoteToolSource = {
+    id: VERYFRONT_STUDIO_MCP_SOURCE_ID,
+    listTools: () =>
+      Promise.resolve([
+        {
+          name: "get_file",
+          description: "Read a project file",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          name: "delete_file",
+          description: "Delete a project file",
+          parameters: { type: "object", properties: {} },
+        },
+      ]),
+    executeTool(toolName) {
+      executedToolNames.push(toolName);
+      return Promise.resolve({ ok: true });
+    },
+  };
+
+  const sources = runWithExactRuntimeRemoteToolSources(
+    [inheritedSource],
+    () =>
+      getRuntimeRemoteToolSources({
+        id: "implicit-project-tool-agent",
+        system: "Read project files.",
+        tools: { get_file: true },
+      }),
+  );
+
+  assertEquals((await sources?.[0]?.listTools())?.map((tool) => tool.name), ["get_file"]);
+  await sources?.[0]?.executeTool("get_file", {});
+  assertThrows(
+    () => sources![0]!.executeTool("delete_file", {}),
+    Error,
+    'Tool "delete_file" is not allowed for MCP server "studio-mcp"',
+  );
+  assertEquals(executedToolNames, ["get_file"]);
 });
 
 Deno.test("getRuntimeRemoteToolSources skips the implicit source without server identity", () => {

--- a/src/agent/runtime/mcp-server-tool-sources.test.ts
+++ b/src/agent/runtime/mcp-server-tool-sources.test.ts
@@ -6,6 +6,7 @@ import type {
   ToolExecutionContext,
 } from "#veryfront/tool";
 import {
+  constrainRuntimeRemoteToolSources,
   getRequestedUnresolvedBooleanToolNames,
   getRuntimeRemoteToolSources,
   VERYFRONT_API_MCP_SOURCE_ID,
@@ -338,6 +339,32 @@ Deno.test("getRuntimeRemoteToolSources preserves explicit MCP opt-out", () => {
   assertEquals(sources, []);
 });
 
+Deno.test("getRuntimeRemoteToolSources preserves an explicit empty injected-source boundary", () => {
+  let bootstrapCalls = 0;
+  const sources = getRuntimeRemoteToolSources(
+    {
+      system: "Use only injected project tools.",
+      tools: { get_file: true },
+      __vfRemoteToolSources: [],
+    } as Parameters<typeof getRuntimeRemoteToolSources>[0],
+    {
+      getVeryfrontBootstrap() {
+        bootstrapCalls++;
+        return {
+          apiBaseUrl: "https://api.example/",
+          apiToken: "server-token",
+          projectSlug: "server-project",
+          hasRequestContext: false,
+          usesVeryfrontFs: false,
+        };
+      },
+    },
+  );
+
+  assertEquals(sources, []);
+  assertEquals(bootstrapCalls, 0);
+});
+
 Deno.test("getRuntimeRemoteToolSources does not leak injected sources after explicit MCP opt-out", () => {
   const injectedApiSource: RemoteToolSource = {
     id: VERYFRONT_API_MCP_SOURCE_ID,
@@ -439,6 +466,65 @@ Deno.test("getRuntimeRemoteToolSources constrains inherited sources to implicit 
     'Tool "delete_file" is not allowed for MCP server "studio-mcp"',
   );
   assertEquals(executedToolNames, ["get_file"]);
+});
+
+Deno.test("constrainRuntimeRemoteToolSources applies an explicit empty cap to active sources", async () => {
+  const activeSource: RemoteToolSource = {
+    id: VERYFRONT_STUDIO_MCP_SOURCE_ID,
+    listTools: () =>
+      Promise.resolve([{
+        name: "get_file",
+        description: "Read a project file",
+        parameters: { type: "object", properties: {} },
+      }]),
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+
+  assertEquals(constrainRuntimeRemoteToolSources(undefined, []), []);
+
+  const sources = runWithExactRuntimeRemoteToolSources(
+    [activeSource],
+    () => constrainRuntimeRemoteToolSources(undefined, []),
+  );
+
+  assertEquals(await sources?.[0]?.listTools(), []);
+  assertThrows(
+    () => sources![0]!.executeTool("get_file", {}),
+    Error,
+    'Tool "get_file" is not allowed for MCP server "studio-mcp"',
+  );
+});
+
+Deno.test("constrainRuntimeRemoteToolSources applies a narrower cap to active sources", async () => {
+  const activeSource: RemoteToolSource = {
+    id: VERYFRONT_STUDIO_MCP_SOURCE_ID,
+    listTools: () =>
+      Promise.resolve([
+        {
+          name: "get_file",
+          description: "Read a project file",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          name: "delete_file",
+          description: "Delete a project file",
+          parameters: { type: "object", properties: {} },
+        },
+      ]),
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+
+  const sources = runWithExactRuntimeRemoteToolSources(
+    [activeSource],
+    () => constrainRuntimeRemoteToolSources(undefined, ["get_file"]),
+  );
+
+  assertEquals((await sources?.[0]?.listTools())?.map((tool) => tool.name), ["get_file"]);
+  assertThrows(
+    () => sources![0]!.executeTool("delete_file", {}),
+    Error,
+    'Tool "delete_file" is not allowed for MCP server "studio-mcp"',
+  );
 });
 
 Deno.test("getRuntimeRemoteToolSources skips the implicit source without server identity", () => {

--- a/src/agent/runtime/mcp-server-tool-sources.ts
+++ b/src/agent/runtime/mcp-server-tool-sources.ts
@@ -166,17 +166,18 @@ function createMcpToolPolicySource(
   };
 }
 
-/** Carry a runtime's remote-tool ceiling with sources inherited by nested agents. */
+/** Carry an explicit remote-tool ceiling into nested execution. */
 export function constrainRuntimeRemoteToolSources(
   sources: RemoteToolSource[] | undefined,
   allowedToolNames: string[] | undefined,
 ): RemoteToolSource[] | undefined {
-  if (sources === undefined || allowedToolNames === undefined) {
+  if (allowedToolNames === undefined) {
     return sources;
   }
 
   const policy = { allow: [...new Set(allowedToolNames)] };
-  return sources.map((source) => createMcpToolPolicySource(source, policy));
+  const sourcesToConstrain = sources ?? getActiveRuntimeRemoteToolSources() ?? [];
+  return sourcesToConstrain.map((source) => createMcpToolPolicySource(source, policy));
 }
 
 export type RuntimeMcpServerToolSourceDependencies = {
@@ -314,7 +315,7 @@ export function getRuntimeRemoteToolSources(
     : [];
   const injectedSources = configuredInjectedSources ?? inheritedSources;
   const configuredServers: AgentMcpServerConfig[] = config.mcpServers ??
-    (implicitToolNames.length > 0
+    (implicitToolNames.length > 0 && configuredInjectedSources === undefined
       ? [{ kind: "veryfront-api", toolPolicy: { allow: implicitToolNames } }]
       : []);
   const configuredFirstPartyServersBySourceId = new Map<string, AgentVeryfrontMcpServerConfig>();

--- a/src/agent/runtime/mcp-server-tool-sources.ts
+++ b/src/agent/runtime/mcp-server-tool-sources.ts
@@ -166,6 +166,19 @@ function createMcpToolPolicySource(
   };
 }
 
+/** Carry a runtime's remote-tool ceiling with sources inherited by nested agents. */
+export function constrainRuntimeRemoteToolSources(
+  sources: RemoteToolSource[] | undefined,
+  allowedToolNames: string[] | undefined,
+): RemoteToolSource[] | undefined {
+  if (sources === undefined || allowedToolNames === undefined) {
+    return sources;
+  }
+
+  const policy = { allow: [...new Set(allowedToolNames)] };
+  return sources.map((source) => createMcpToolPolicySource(source, policy));
+}
+
 export type RuntimeMcpServerToolSourceDependencies = {
   createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
   getVeryfrontBootstrap?: () => VeryfrontCloudBootstrap;
@@ -315,7 +328,9 @@ export function getRuntimeRemoteToolSources(
     : injectedSources;
   const policyWrappedInjectedSources = selectedInjectedSources.map((source) => {
     const server = configuredFirstPartyServersBySourceId.get(source.id);
-    return server ? createMcpToolPolicySource(source, server.toolPolicy) : source;
+    const policy = server?.toolPolicy ??
+      (implicitToolNames.length > 0 ? { allow: implicitToolNames } : undefined);
+    return createMcpToolPolicySource(source, policy);
   });
   const configuredSources = configuredServers.flatMap((server) => {
     if (isHttpMcpServerConfig(server)) {
@@ -345,5 +360,9 @@ export function getRuntimeRemoteToolSources(
     ...configuredSources,
   ];
 
-  return remoteToolSources.length > 0 ? remoteToolSources : undefined;
+  if (remoteToolSources.length > 0) {
+    return remoteToolSources;
+  }
+
+  return configuredInjectedSources !== undefined || hasExplicitMcpServers ? [] : undefined;
 }

--- a/src/agent/runtime/remote-tool-source-context.ts
+++ b/src/agent/runtime/remote-tool-source-context.ts
@@ -15,3 +15,11 @@ export function runWithExactRuntimeRemoteToolSources<T>(
 ): T {
   return remoteToolSourceStorage.run(sources, fn);
 }
+
+/** Preserve the active source boundary when this runtime has no boundary of its own. */
+export function runWithRuntimeRemoteToolSources<T>(
+  sources: RemoteToolSource[] | undefined,
+  fn: () => T,
+): T {
+  return sources === undefined ? fn() : remoteToolSourceStorage.run(sources, fn);
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1110";
+export const VERSION = "0.1.1111";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1111";
+export const VERSION = "0.1.1112";


### PR DESCRIPTION
## Problem

Follow-up to merged PR #3032. The immediate local-delegate MCP failure is fixed, but four capability-boundary gaps remained:

- serialized `agent_*` inventory was treated as delegation authority and replaced an explicitly configured generic `invoke_agent` surface;
- a local-only intermediate agent cleared the trusted MCP source before an MCP-using grandchild ran;
- the parent's request-level `__vfAllowedRemoteTools` ceiling did not travel with inherited sources;
- implicit unresolved remote tools filtered discovery but did not independently block execution of other tools exposed by the inherited source.

## Solution

- only an explicit `delegates` field creates hosted fixed-target delegate tools; otherwise the hosted runtime retains the generic `invoke_agent` path;
- preserve the active remote-source context when an intermediate runtime has no source boundary of its own;
- keep explicit injected-source and `mcpServers` opt-outs as an exact empty boundary;
- attach the current request-level allowlist to sources published for nested execution;
- wrap implicit inherited sources with an execution-time allow policy for exactly the requested tool names.

This intentionally does not translate serialized `agent_*` names into generic `invoke_agent`, because that would widen fixed target authority. Agents that want generic invocation must explicitly include `invoke_agent`. Explicit `delegates`, including `delegates: []`, remain supported.

## Red / green evidence

- Red: root -> local-only child -> MCP grandchild never reached the grandchild model.
- Red: a broad child MCP declaration could see a tool outside the parent's request cap.
- Red: an implicit inherited source executed a tool that was not declared.
- Red: serialized `agent_*` entries forced a scoped hosted binding despite generic invocation being configured.
- Green: 52 focused runtime, composition, MCP-policy, and hosted tests pass.
- Green: `deno task verify:quick` passes (format, lint/ratchets, docs validation, and repository typecheck).
- Green: the pre-push gate passes with 2,619 tests / 21,315 steps and zero failures.

## Tracking

- Follow-up to #3032
- Tracks veryfront/veryfront-issue-inbox#147
