### PR TITLE
Expose programmatic project runtime discovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1113",
+  "version": "0.1.1114",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/project/agent-runtime.test.ts
+++ b/src/agent/project/agent-runtime.test.ts
@@ -24,6 +24,7 @@ import {
 } from "#veryfront/integrations/source-policy.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { registerSkill, skillRegistry } from "#veryfront/skill/registry.ts";
+import { createLoadSkillTool } from "#veryfront/skill/tools.ts";
 import { getEffectiveAgentSystem } from "../runtime/effective-agent-system.ts";
 import { tool } from "#veryfront/tool";
 
@@ -238,6 +239,37 @@ Deno.test("discoverProjectAgentRuntime clears stale runtime registries before re
     assertEquals(getMCPRegistry().resources.has("stale-resource"), false);
     assertEquals(getMCPRegistry().prompts.has("stale-prompt"), false);
     assertEquals(workflowRegistry.has("stale-workflow"), false);
+  });
+});
+
+Deno.test("project runtime discovers local skills without an explicit adapter", async () => {
+  await withTempDir(async (rootDir) => {
+    const skillDir = resolve(rootDir, "skills", "extract-submission");
+    Deno.mkdirSync(skillDir, { recursive: true });
+    Deno.writeTextFileSync(
+      resolve(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: extract-submission",
+        "description: Extract one submission",
+        "---",
+        "",
+        "Parse the staged attachment and preserve field provenance.",
+        "",
+      ].join("\n"),
+    );
+
+    const discovery = await discoverProjectAgentRuntime({ projectDir: rootDir });
+
+    assertEquals([...discovery.skills.keys()], ["extract-submission"]);
+    const loaded = await createLoadSkillTool().execute({
+      skillId: "extract-submission",
+    }) as { skillId: string; instructions: string };
+    assertEquals(loaded.skillId, "extract-submission");
+    assertStringIncludes(
+      loaded.instructions,
+      "Parse the staged attachment and preserve field provenance.",
+    );
   });
 });
 

--- a/src/agent/project/agent-runtime.ts
+++ b/src/agent/project/agent-runtime.ts
@@ -6,6 +6,7 @@ import { clearTranspileCache } from "#veryfront/discovery/transpiler.ts";
 import { getConfig, type VeryfrontConfig } from "#veryfront/config";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
+import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
 import { clearMCPRegistry } from "#veryfront/mcp";
 import { workflowRegistry } from "#veryfront/workflow/registry.ts";
 import { agentRegistry } from "../composition/index.ts";
@@ -40,7 +41,7 @@ export type ProjectAgentRuntimeAgentIdCandidates = {
 /** Input payload for discover project agent runtime. */
 export type DiscoverProjectAgentRuntimeInput = {
   projectDir: string;
-  adapter: RuntimeAdapter;
+  adapter?: RuntimeAdapter;
   config?: VeryfrontConfig | null;
   fsAdapter?: FileSystemAdapter;
   cacheKey?: string;
@@ -127,7 +128,7 @@ export async function discoverProjectAgentRuntime(
       const config = input.config ??
         await getConfig(
           input.projectDir,
-          input.adapter,
+          input.adapter ?? await getLocalAdapter(),
           input.cacheKey ? { cacheKey: input.cacheKey } : undefined,
         );
       const discoveryOptions = createProjectDiscoveryConfig({

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -424,6 +424,264 @@ describe("discovery/import-rewriter", () => {
     }
   });
 
+  it("prefers project-local veryfront exports over runtime resolution in the Node discovery path", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    await Deno.mkdir(`${veryfrontDir}/local`, { recursive: true });
+    await Deno.writeTextFile(
+      `${veryfrontDir}/package.json`,
+      JSON.stringify({
+        name: "veryfront",
+        version: "0.0.0-project-local",
+        exports: {
+          "./schemas": "./local/schemas.js",
+          "./tool": "./local/tool.js",
+        },
+      }),
+    );
+    await Deno.writeTextFile(`${veryfrontDir}/local/schemas.js`, "");
+    await Deno.writeTextFile(`${veryfrontDir}/local/tool.js`, "");
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        [
+          'import { defineSchema } from "veryfront/schemas";',
+          'import { tool } from "veryfront/tool";',
+        ].join("\n"),
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertStringIncludes(transformed, `${projectDir}/node_modules/veryfront/local/schemas.js`);
+      assertStringIncludes(transformed, `${projectDir}/node_modules/veryfront/local/tool.js`);
+      assertEquals(transformed.includes(import.meta.resolve("veryfront/schemas")), false);
+      assertEquals(transformed.includes(import.meta.resolve("veryfront/tool")), false);
+      assertEquals(transformed.includes('from "veryfront/'), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("resolves project-local veryfront exports when projectDir is relative", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const originalCwd = Deno.cwd();
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    await Deno.mkdir(`${veryfrontDir}/local`, { recursive: true });
+    await Deno.writeTextFile(
+      `${veryfrontDir}/package.json`,
+      JSON.stringify({
+        name: "veryfront",
+        exports: {
+          "./schemas": "./local/schemas.js",
+        },
+      }),
+    );
+    await Deno.writeTextFile(`${veryfrontDir}/local/schemas.js`, "");
+
+    try {
+      Deno.chdir(projectDir);
+      const transformed = await rewriteDiscoveryImports(
+        'import { defineSchema } from "veryfront/schemas";',
+        ".",
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertStringIncludes(transformed, `${projectDir}/node_modules/veryfront/local/schemas.js`);
+      assertEquals(transformed.includes(import.meta.resolve("veryfront/schemas")), false);
+      assertEquals(transformed.includes('from "veryfront/schemas"'), false);
+    } finally {
+      Deno.chdir(originalCwd);
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not fall back to runtime veryfront resolution when local package directory has no package.json", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    await Deno.mkdir(veryfrontDir, { recursive: true });
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        'import { defineSchema } from "veryfront/schemas";',
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertEquals(transformed.includes(import.meta.resolve("veryfront/schemas")), false);
+      assertStringIncludes(transformed, 'from "veryfront/schemas"');
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not fall back to runtime veryfront resolution when local package.json cannot be read", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    const packageJsonPath = `${veryfrontDir}/package.json`;
+    await Deno.mkdir(veryfrontDir, { recursive: true });
+    await Deno.writeTextFile(
+      packageJsonPath,
+      JSON.stringify({
+        name: "veryfront",
+        exports: {
+          "./schemas": "./local/schemas.js",
+        },
+      }),
+    );
+
+    const unreadablePackageJsonFs = createFileSystem();
+    const readTextFile = unreadablePackageJsonFs.readTextFile.bind(unreadablePackageJsonFs);
+    unreadablePackageJsonFs.readTextFile = async (path: string): Promise<string> => {
+      if (path === packageJsonPath) {
+        throw new Error("forced package.json read failure");
+      }
+      return readTextFile(path);
+    };
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        'import { defineSchema } from "veryfront/schemas";',
+        projectDir,
+        unreadablePackageJsonFs,
+        `${projectDir}/app`,
+      );
+
+      assertEquals(transformed.includes(import.meta.resolve("veryfront/schemas")), false);
+      assertStringIncludes(transformed, 'from "veryfront/schemas"');
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not fall back to runtime veryfront resolution when local package stat fails for a non-not-found reason", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    await Deno.mkdir(veryfrontDir, { recursive: true });
+
+    const statFailureFs = createFileSystem();
+    const stat = statFailureFs.stat.bind(statFailureFs);
+    statFailureFs.stat = async (path: string) => {
+      if (path === veryfrontDir) {
+        throw Object.assign(new Error("forced stat permission failure"), { code: "EACCES" });
+      }
+      return stat(path);
+    };
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        'import { defineSchema } from "veryfront/schemas";',
+        projectDir,
+        statFailureFs,
+        `${projectDir}/app`,
+      );
+
+      assertEquals(transformed.includes(import.meta.resolve("veryfront/schemas")), false);
+      assertStringIncludes(transformed, 'from "veryfront/schemas"');
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("rejects project-local veryfront exports that escape the package directory", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    await Deno.mkdir(veryfrontDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${veryfrontDir}/package.json`,
+      JSON.stringify({
+        name: "veryfront",
+        exports: {
+          "./schemas": "../../outside.js",
+        },
+      }),
+    );
+    await Deno.writeTextFile(`${projectDir}/outside.js`, "");
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        'import { defineSchema } from "veryfront/schemas";',
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertEquals(transformed.includes("outside.js"), false);
+      assertEquals(transformed.includes(import.meta.resolve("veryfront/schemas")), false);
+      assertStringIncludes(transformed, 'from "veryfront/schemas"');
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("rejects unsupported project-local veryfront export entries without runtime fallback", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    await Deno.mkdir(veryfrontDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${veryfrontDir}/package.json`,
+      JSON.stringify({
+        name: "veryfront",
+        exports: {
+          "./schemas": { browser: "./browser-only.js" },
+        },
+      }),
+    );
+    await Deno.writeTextFile(`${veryfrontDir}/browser-only.js`, "");
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        'import { defineSchema } from "veryfront/schemas";',
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertEquals(transformed.includes("browser-only.js"), false);
+      assertEquals(transformed.includes(import.meta.resolve("veryfront/schemas")), false);
+      assertStringIncludes(transformed, 'from "veryfront/schemas"');
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not fall back to runtime veryfront resolution for missing project-local subpaths", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    await Deno.mkdir(`${veryfrontDir}/local`, { recursive: true });
+    await Deno.writeTextFile(
+      `${veryfrontDir}/package.json`,
+      JSON.stringify({
+        name: "veryfront",
+        exports: {
+          "./tool": "./local/tool.js",
+        },
+      }),
+    );
+    await Deno.writeTextFile(`${veryfrontDir}/local/tool.js`, "");
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        [
+          'import { defineSchema } from "veryfront/schemas";',
+          'import { tool } from "veryfront/tool";',
+        ].join("\n"),
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertStringIncludes(transformed, `${projectDir}/node_modules/veryfront/local/tool.js`);
+      assertEquals(transformed.includes(import.meta.resolve("veryfront/schemas")), false);
+      assertStringIncludes(transformed, 'from "veryfront/schemas"');
+      assertEquals(transformed.includes('from "veryfront/tool"'), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("resolves veryfront public imports for Node discovery modules without project-local dependencies", async () => {
     const transformed = await rewriteDiscoveryImports(
       [

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -119,6 +119,12 @@ function isUnprefixedNpmSpecifier(specifier: string): boolean {
 // by TypeScript and must not trigger filesystem resolution.
 const TYPE_ONLY_STATIC_RE = /(?:^|[\s;{}])(?:import|export)\s+type\b/;
 
+function isNotFoundError(error: unknown): boolean {
+  const DenoNotFound = globalThis.Deno?.errors?.NotFound;
+  if (DenoNotFound && error instanceof DenoNotFound) return true;
+  return (error as NodeJS.ErrnoException)?.code === "ENOENT";
+}
+
 function rewriteBareNpmImportsForDeno(code: string): string {
   return code
     // `import x from "spec"`, `export { x } from "spec"`, `export * from "spec"`.
@@ -282,6 +288,7 @@ export async function rewriteDiscoveryImports(
 
   try {
     const { pathToFileURL } = await import("node:url");
+    const projectRoot = pathHelper.resolve(projectDir);
 
     // Handle relative imports
     transformed = transformed.replace(
@@ -297,15 +304,15 @@ export async function rewriteDiscoveryImports(
     // so a subsequent `npm install` of the missing dep is picked up
     // without a process restart.
     const resolvePackageToFileUrl = async (specifier: string): Promise<string | null> => {
-      const cacheKey = `${projectDir}::${specifier}`;
+      const cacheKey = `${projectRoot}::${specifier}`;
       const cached = resolvedSpecifierCache.get(cacheKey);
       if (cached !== undefined) return cached;
 
       const { name: packageName, subpath } = splitPackageSubpath(specifier);
-      let searchDir = projectDir;
+      let searchDir = projectRoot;
 
       for (let i = 0; i < 10; i++) {
-        const packagePath = pathHelper.join(searchDir, "node_modules", packageName);
+        const packagePath = pathHelper.resolve(searchDir, "node_modules", packageName);
         const packageJsonPath = pathHelper.join(packagePath, "package.json");
 
         try {
@@ -447,39 +454,57 @@ export async function rewriteDiscoveryImports(
         );
     };
 
-    // Handle veryfront package imports
-    let vfPackagePath = pathHelper.join(projectDir, "node_modules", "veryfront");
-    let exportsMap: Record<string, string | { import?: string }> = {};
+    type VeryfrontExportSource =
+      | { kind: "absent" }
+      | { kind: "present"; packagePath: string; exportsMap: unknown };
 
-    try {
-      const vfPackageJsonPath = pathHelper.join(vfPackagePath, "package.json");
-      const pkgJson = JSON.parse(await fs.readTextFile(vfPackageJsonPath));
-      exportsMap = pkgJson.exports || {};
-    } catch (_) {
-      /* expected: veryfront package.json not found, fallback to deno.json search */
-      // Search for deno.json in parent directories
-      let searchDir = projectDir;
+    const findVeryfrontExportSource = async (): Promise<VeryfrontExportSource> => {
+      const nodePackagePath = pathHelper.resolve(projectRoot, "node_modules", "veryfront");
+      const vfPackageJsonPath = pathHelper.join(nodePackagePath, "package.json");
+      let hasNodePackagePath = false;
+      try {
+        await fs.stat(nodePackagePath);
+        hasNodePackagePath = true;
+      } catch (error) {
+        if (!isNotFoundError(error)) {
+          return { kind: "present", packagePath: nodePackagePath, exportsMap: undefined };
+        }
 
+        /* expected: veryfront directory absent, fallback to deno.json search */
+      }
+
+      if (hasNodePackagePath) {
+        try {
+          const packageJsonText = await fs.readTextFile(vfPackageJsonPath);
+          const pkgJson = JSON.parse(packageJsonText);
+          return { kind: "present", packagePath: nodePackagePath, exportsMap: pkgJson.exports };
+        } catch (_) {
+          return { kind: "present", packagePath: nodePackagePath, exportsMap: undefined };
+        }
+      }
+
+      // Search for deno.json in parent directories.
+      let searchDir = projectRoot;
       for (let i = 0; i < 5; i++) {
         try {
           const denoJsonPath = pathHelper.join(searchDir, "deno.json");
           const denoJson = JSON.parse(await fs.readTextFile(denoJsonPath));
-          if (denoJson.name === "veryfront" && denoJson.exports) {
-            exportsMap = denoJson.exports;
-            vfPackagePath = searchDir;
-            break;
+          if (denoJson.name === "veryfront" && "exports" in denoJson) {
+            return {
+              kind: "present",
+              packagePath: pathHelper.resolve(searchDir),
+              exportsMap: denoJson.exports,
+            };
           }
         } catch (_) {
           /* expected: deno.json not found at this level */
         }
-        searchDir = pathHelper.dirname(searchDir);
+        const parent = pathHelper.dirname(searchDir);
+        if (parent === searchDir) break;
+        searchDir = parent;
       }
-    }
 
-    const getExportPath = (entry: string | { import?: string } | undefined): string | null => {
-      if (!entry) return null;
-      if (typeof entry === "string") return entry;
-      return entry.import ?? null;
+      return { kind: "absent" };
     };
 
     const veryfrontSpecifiers = new Set<string>();
@@ -494,34 +519,45 @@ export async function rewriteDiscoveryImports(
       if (specifier) veryfrontSpecifiers.add(specifier);
     }
 
+    const veryfrontExportSource = await findVeryfrontExportSource();
+
+    const resolveVeryfrontExportToFileUrl = (
+      specifier: string,
+    ): { kind: "resolved"; url: string } | { kind: "rejected" } => {
+      if (veryfrontExportSource.kind === "absent") return { kind: "rejected" };
+
+      const subpath = specifier === "veryfront" ? "." : "./" + specifier.replace("veryfront/", "");
+      const exportPath = resolveExportPath(veryfrontExportSource.exportsMap, subpath);
+      if (!exportPath) return { kind: "rejected" };
+
+      const packagePath = veryfrontExportSource.packagePath;
+      const resolvedPath = pathHelper.resolve(packagePath, exportPath);
+      const packagePathPrefix = packagePath.endsWith(pathHelper.SEPARATOR)
+        ? packagePath
+        : packagePath + pathHelper.SEPARATOR;
+      if (resolvedPath !== packagePath && !resolvedPath.startsWith(packagePathPrefix)) {
+        return { kind: "rejected" };
+      }
+
+      return { kind: "resolved", url: pathToFileURL(resolvedPath).href };
+    };
+
     for (const specifier of veryfrontSpecifiers) {
-      const resolvedUrl = resolveRuntimeSpecifierToFileUrl(specifier);
-      if (resolvedUrl) {
-        transformed = rewriteResolvedSpecifierImports(transformed, specifier, resolvedUrl);
+      if (veryfrontExportSource.kind === "absent") continue;
+      const result = resolveVeryfrontExportToFileUrl(specifier);
+      if (result.kind === "resolved") {
+        transformed = rewriteResolvedSpecifierImports(transformed, specifier, result.url);
       }
     }
 
-    // Rewrite veryfront subpath imports
-    transformed = transformed.replace(
-      /from\s+["'](veryfront\/[^"']+)["']/g,
-      (match, fullSpecifier: string) => {
-        const subpath = "./" + fullSpecifier.replace("veryfront/", "");
-        const exportPath = getExportPath(exportsMap[subpath]);
-        if (!exportPath) return match;
-
-        const resolvedPath = pathHelper.join(vfPackagePath, exportPath);
-        return `from "${pathToFileURL(resolvedPath).href}"`;
-      },
-    );
-
-    // Rewrite bare veryfront import
-    transformed = transformed.replace(/from\s+["']veryfront["']/g, () => {
-      const exportPath = getExportPath(exportsMap["."]);
-      if (!exportPath) return 'from "veryfront"';
-
-      const resolvedPath = pathHelper.join(vfPackagePath, exportPath);
-      return `from "${pathToFileURL(resolvedPath).href}"`;
-    });
+    if (veryfrontExportSource.kind === "absent") {
+      for (const specifier of veryfrontSpecifiers) {
+        const resolvedUrl = resolveRuntimeSpecifierToFileUrl(specifier);
+        if (resolvedUrl) {
+          transformed = rewriteResolvedSpecifierImports(transformed, specifier, resolvedUrl);
+        }
+      }
+    }
   } catch (_) {
     /* expected: Node.js URL module unavailable in non-Node runtime */
     return transformed;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1113";
+export const VERSION = "0.1.1114";


### PR DESCRIPTION
## Summary

Depends on #3035 (`fix/sandbox-api-proxy-transport`) and is intentionally stacked on that branch. After #3035 merges, retarget this PR to `main` before merge.

This stack makes programmatic project-agent runtime discovery usable from consumer projects without requiring callers to provide a local framework adapter. That keeps local project runs aligned with the CLI/cloud discovery path: local project skills are discovered before `load_skill`, while the project framework instance remains the discovery boundary.

Release version: `0.1.1114` (`deno.json` and `src/utils/version-constant.ts`).

## Commits

- `703de47c1` Keep discovery bound to the project framework instance
- `9808b59d7` Let programmatic project runs discover local skills
- `2db776d47` Release programmatic project runtime discovery as v0.1.1114

## Validation

- `deno task generate && VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --parallel --allow-all --unstable-worker-options --unstable-net src/agent/project/agent-runtime.test.ts`
  - `10 passed | 0 failed`
- `deno task typecheck`
- `deno task fmt:check`
- `git diff --check`
- version parity assertion: `{"version":"0.1.1114","parity":true}`
- pre-push hook:
  - fmt, lint, typecheck
  - `deno task test:unit`: `2623 passed (21342 steps) | 0 failed | 0 ignored (5 steps)`

## Notes

No production bypasses, no admin merge, and no protection override. The branch was created in a clean worktree from exact #3035 head `7f0c6c122dcf736ea42ed04eaedadca2c0543463`.
