### PR TITLE
fix(runtime): bound SSR prefetch and hosted sandbox work

### DIFF
--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -14,7 +14,6 @@ const RELEASE_ID = "770e8400-e29b-41d4-a716-446655440000";
 const DEPLOYMENT_ID = "880e8400-e29b-41d4-a716-446655440000";
 
 it("uses canonical production read-back in human and JSON modes", async () => {
-  const originalCwd = Deno.cwd();
   const projectDir = await Deno.makeTempDir();
   const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
   const savedEnv = envKeys.map((key) => Deno.env.get(key));
@@ -73,7 +72,6 @@ it("uses canonical production read-back in human and JSON modes", async () => {
     Deno.env.set("VERYFRONT_API_URL", "https://control.example.test/api");
     Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
     _resetEnvironmentConfig();
-    Deno.chdir(projectDir);
 
     let releaseSourceContent = "export const value = 1;\n";
     let routingConvergence: DeploymentRoutingConvergence = {
@@ -152,6 +150,7 @@ it("uses canonical production read-back in human and JSON modes", async () => {
 
     const runDeploy = () =>
       deployCommand({
+        projectDir,
         branch: "main",
         env: "production",
         releaseName: `github-main-${actualSha}`,
@@ -207,7 +206,6 @@ it("uses canonical production read-back in human and JSON modes", async () => {
       `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}/versions`,
     ]);
   } finally {
-    Deno.chdir(originalCwd);
     envKeys.forEach((key, index) => {
       const value = savedEnv[index];
       if (value === undefined) Deno.env.delete(key);

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -30,6 +30,7 @@ import {
  */
 export const getDeployArgsSchema = defineSchema((v) =>
   v.object({
+    projectDir: v.string().optional(),
     branch: v.string().min(1).default("main"),
     env: v.string().min(1).default("production"),
     releaseName: v.string().min(1).optional(),
@@ -51,6 +52,7 @@ export type DeployOptions = InferSchema<ReturnType<typeof getDeployArgsSchema>>;
  * Parse CLI arguments into validated DeployOptions
  */
 export const parseDeployArgs = createArgParser(DeployArgsSchema, {
+  projectDir: CommonArgs.projectDir,
   branch: CommonArgs.branch,
   env: CommonArgs.env,
   releaseName: CommonArgs.releaseName,
@@ -540,13 +542,12 @@ export async function resolvePushedSource(input: {
  * Create a release and deploy to an environment
  */
 export async function deployCommand(options: DeployOptions): Promise<void> {
-  const { branch, env, releaseName, dryRun, force, quiet } = options;
+  const { projectDir = cwd(), branch, env, releaseName, dryRun, force, quiet } = options;
 
   if (isJsonMode()) {
     return deployCommandJson(options);
   }
 
-  const projectDir = cwd();
   let spinner = quiet ? createNoopSpinner() : createSpinner("Resolving configuration...");
 
   const config = await resolveConfigWithAuth(projectDir);
@@ -666,7 +667,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 }
 
 async function deployCommandJson(options: DeployOptions): Promise<void> {
-  const { branch, env, releaseName, dryRun, force } = options;
+  const { projectDir = cwd(), branch, env, releaseName, dryRun, force } = options;
 
   try {
     // JSON mode requires --force or --yes to prevent accidental deploys
@@ -683,7 +684,6 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
     }
 
     streamJsonLine({ type: "step", name: "resolve-config", status: "started" });
-    const projectDir = cwd();
     const config = await resolveConfigWithAuth(projectDir);
     const client = createApiClient(config);
     streamJsonLine({ type: "step", name: "resolve-config", status: "completed" });

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -205,18 +205,23 @@ describe("collectKnowledgeSources", () => {
     });
   });
 
-  it("treats uploads/ paths as remote even if a local uploads folder exists", async () => {
-    const originalCwd = Deno.cwd();
-    const tempDir = await Deno.makeTempDir();
-    await Deno.mkdir(`${tempDir}/uploads/contracts`, { recursive: true });
-    await Deno.writeTextFile(`${tempDir}/uploads/contracts/q1.pdf`, "local shadow copy");
+  it("treats uploads/ paths as remote upload references", async () => {
+    const shadowDir = join("uploads", `veryfront-knowledge-shadow-${crypto.randomUUID()}`);
+    const shadowPath = join(shadowDir, "q1.pdf");
+    const remotePath = shadowPath.replaceAll("\\", "/");
+    const downloadedPath = `/workspace/${remotePath}`;
+    const hadUploadsDir = await Deno.stat("uploads").then((stat) => stat.isDirectory).catch(() =>
+      false
+    );
+    const calls: string[] = [];
 
     try {
-      Deno.chdir(tempDir);
-      const calls: string[] = [];
+      await Deno.mkdir(shadowDir, { recursive: true });
+      await Deno.writeTextFile(shadowPath, "local shadow");
+
       const collection = await collectKnowledgeSources(
         {
-          sources: ["uploads/contracts/q1.pdf"],
+          sources: [remotePath],
           path: undefined,
           all: false,
           recursive: false,
@@ -227,19 +232,26 @@ describe("collectKnowledgeSources", () => {
           downloadUploads: async (uploadPaths) => {
             calls.push(...uploadPaths);
             return [{
-              uploadPath: "uploads/contracts/q1.pdf",
-              localPath: "/workspace/uploads/contracts/q1.pdf",
+              uploadPath: remotePath,
+              localPath: downloadedPath,
             }];
           },
         },
       );
 
-      assertEquals(calls, ["uploads/contracts/q1.pdf"]);
+      assertEquals(calls, [remotePath]);
       assertEquals(collection.sources[0]?.kind, "upload");
+      assertEquals(
+        collection.sources[0]?.localPath,
+        downloadedPath,
+      );
       assertEquals(collection.skipped, []);
     } finally {
-      Deno.chdir(originalCwd);
-      await Deno.remove(tempDir, { recursive: true });
+      await Deno.remove(shadowPath).catch(() => undefined);
+      await Deno.remove(shadowDir).catch(() => undefined);
+      if (!hadUploadsDir) {
+        await Deno.remove("uploads").catch(() => undefined);
+      }
     }
   });
 

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -210,9 +210,6 @@ describe("collectKnowledgeSources", () => {
     const shadowPath = join(shadowDir, "q1.pdf");
     const remotePath = shadowPath.replaceAll("\\", "/");
     const downloadedPath = `/workspace/${remotePath}`;
-    const hadUploadsDir = await Deno.stat("uploads").then((stat) => stat.isDirectory).catch(() =>
-      false
-    );
     const calls: string[] = [];
 
     try {
@@ -247,11 +244,7 @@ describe("collectKnowledgeSources", () => {
       );
       assertEquals(collection.skipped, []);
     } finally {
-      await Deno.remove(shadowPath).catch(() => undefined);
-      await Deno.remove(shadowDir).catch(() => undefined);
-      if (!hadUploadsDir) {
-        await Deno.remove("uploads").catch(() => undefined);
-      }
+      await Deno.remove(shadowDir, { recursive: true }).catch(() => undefined);
     }
   });
 

--- a/cli/commands/up/command.test.ts
+++ b/cli/commands/up/command.test.ts
@@ -79,7 +79,6 @@ describe("Up Command", () => {
 
   describe("upCommand", () => {
     it("uses VERYFRONT_API_BASE_URL when creating a project", async () => {
-      const originalCwd = Deno.cwd();
       const originalFetch = globalThis.fetch;
       const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
       const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
@@ -89,7 +88,6 @@ describe("Up Command", () => {
 
       try {
         await Deno.writeTextFile(join(tempDir, "package.json"), "{}");
-        Deno.chdir(tempDir);
         Deno.env.set("VERYFRONT_API_TOKEN", "env-token");
         Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.from-env.test");
         Deno.env.delete("VERYFRONT_API_URL");
@@ -183,7 +181,7 @@ describe("Up Command", () => {
           );
         }) as typeof fetch;
 
-        await upCommand({ force: true, dryRun: false });
+        await upCommand({ projectDir: tempDir, force: true, dryRun: false });
 
         assertEquals(
           requestedUrls.some((url) => url.startsWith("https://api.from-env.test/projects")),
@@ -195,7 +193,6 @@ describe("Up Command", () => {
         );
       } finally {
         globalThis.fetch = originalFetch;
-        Deno.chdir(originalCwd);
         restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
         restoreEnv("VERYFRONT_API_BASE_URL", originalApiBaseUrl);
         restoreEnv("VERYFRONT_API_URL", originalApiUrl);

--- a/cli/commands/up/command.ts
+++ b/cli/commands/up/command.ts
@@ -17,6 +17,7 @@ import { deployCommand } from "../deploy/index.ts";
 
 export const getUpArgsSchema = defineSchema((v) =>
   v.object({
+    projectDir: v.string().optional(),
     force: v.boolean().default(false),
     dryRun: v.boolean().default(false),
   })
@@ -27,6 +28,7 @@ export const UpArgsSchema = lazySchema(getUpArgsSchema);
 export type UpOptions = InferSchema<ReturnType<typeof getUpArgsSchema>>;
 
 export const parseUpArgs = createArgParser(UpArgsSchema, {
+  projectDir: CommonArgs.projectDir,
   force: CommonArgs.force,
   dryRun: CommonArgs.dryRun,
 });
@@ -106,12 +108,10 @@ export async function upCommand(
   options: Partial<UpOptions> = {},
   env: EnvironmentConfig = getEnvironmentConfig(),
 ): Promise<void> {
-  const { force = false, dryRun = false } = options;
+  const { projectDir = cwd(), force = false, dryRun = false } = options;
 
   const useColor = shouldUseColor();
   const c = (fn: (s: string) => string, s: string): string => (useColor ? fn(s) : s);
-
-  const projectDir = cwd();
 
   const userInfo = await ensureAuthenticated(env);
   if (!userInfo) return;
@@ -200,6 +200,7 @@ export async function upCommand(
 
     try {
       await deployCommand({
+        projectDir,
         branch: "main",
         env: "preview",
         force: true,

--- a/cli/skills/loader.test.ts
+++ b/cli/skills/loader.test.ts
@@ -5,11 +5,10 @@ import { join } from "#std/path.ts";
 import { CORE_SKILLS } from "./core-skills.ts";
 import { listAllSkills, listCoreSkills, listLocalSkills, loadSkill } from "./loader.ts";
 
-async function withTempCwd(
+async function withTempDir(
   files: Record<string, string>,
   fn: (dir: string) => Promise<void>,
 ): Promise<void> {
-  const original = Deno.cwd();
   const dir = await Deno.makeTempDir({ prefix: "vf-skill-loader-" });
   try {
     for (const [path, content] of Object.entries(files)) {
@@ -17,10 +16,8 @@ async function withTempCwd(
       await Deno.mkdir(join(target, ".."), { recursive: true });
       await Deno.writeTextFile(target, content);
     }
-    Deno.chdir(dir);
     await fn(dir);
   } finally {
-    Deno.chdir(original);
     await Deno.remove(dir, { recursive: true });
   }
 }
@@ -60,7 +57,7 @@ describe("Core Skills Embedded Data", () => {
 
 describe("Skill Loader", () => {
   it("loads a skill from SKILL.md frontmatter", async () => {
-    await withTempCwd({ "skills/code-review/SKILL.md": PROJECT_SKILL }, async (dir) => {
+    await withTempDir({ "skills/code-review/SKILL.md": PROJECT_SKILL }, async (dir) => {
       const skill = await loadSkill(join(dir, "skills", "code-review"));
 
       assertEquals(skill?.metadata.name, "code-review");
@@ -72,8 +69,8 @@ describe("Skill Loader", () => {
   });
 
   it("lists project-local skills from skills/<id>/SKILL.md", async () => {
-    await withTempCwd({ "skills/code-review/SKILL.md": PROJECT_SKILL }, async () => {
-      const skills = await listLocalSkills();
+    await withTempDir({ "skills/code-review/SKILL.md": PROJECT_SKILL }, async (dir) => {
+      const skills = await listLocalSkills(dir);
 
       assertEquals(skills.map((skill) => skill.metadata.name), ["code-review"]);
     });
@@ -94,7 +91,7 @@ describe("Skill Loader", () => {
   });
 
   it("listAllSkills deduplicates by name with local skills overriding core", async () => {
-    await withTempCwd({
+    await withTempDir({
       "skills/deploy-safely/SKILL.md": `---
 name: deploy-safely
 description: Local deploy skill.
@@ -102,8 +99,8 @@ description: Local deploy skill.
 
 # Local Deploy
 `,
-    }, async () => {
-      const all = await listAllSkills();
+    }, async (dir) => {
+      const all = await listAllSkills(dir);
       const matches = all.filter((skill) => skill.metadata.name === "deploy-safely");
 
       assertEquals(matches.length, 1);

--- a/cli/skills/loader.ts
+++ b/cli/skills/loader.ts
@@ -48,7 +48,7 @@ export async function listCoreSkills(): Promise<LoadedSkill[]> {
 }
 
 /**
- * Scan the current working directory for local skill directories.
+ * Scan the provided project directory for local skill directories.
  * A local skill is any skills/<id>/ directory containing a SKILL.md file.
  */
 export async function listLocalSkills(baseDir: string = cwd()): Promise<LoadedSkill[]> {
@@ -70,7 +70,7 @@ export async function listLocalSkills(baseDir: string = cwd()): Promise<LoadedSk
 }
 
 /**
- * List all skills: core (built-in) + local (in cwd).
+ * List all skills: core (built-in) + local (under baseDir).
  */
 export async function listAllSkills(baseDir: string = cwd()): Promise<LoadedSkill[]> {
   const [core, local] = await Promise.all([

--- a/cli/skills/loader.ts
+++ b/cli/skills/loader.ts
@@ -51,10 +51,10 @@ export async function listCoreSkills(): Promise<LoadedSkill[]> {
  * Scan the current working directory for local skill directories.
  * A local skill is any skills/<id>/ directory containing a SKILL.md file.
  */
-export async function listLocalSkills(): Promise<LoadedSkill[]> {
+export async function listLocalSkills(baseDir: string = cwd()): Promise<LoadedSkill[]> {
   const fs = createFileSystem();
   const skills: LoadedSkill[] = [];
-  const skillsDir = `${cwd()}/skills`;
+  const skillsDir = `${baseDir}/skills`;
 
   try {
     for await (const entry of fs.readDir(skillsDir)) {
@@ -72,10 +72,10 @@ export async function listLocalSkills(): Promise<LoadedSkill[]> {
 /**
  * List all skills: core (built-in) + local (in cwd).
  */
-export async function listAllSkills(): Promise<LoadedSkill[]> {
+export async function listAllSkills(baseDir: string = cwd()): Promise<LoadedSkill[]> {
   const [core, local] = await Promise.all([
     listCoreSkills(),
-    listLocalSkills(),
+    listLocalSkills(baseDir),
   ]);
 
   // Deduplicate by name, local skills override core

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1114",
+  "version": "0.1.1115",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-document-kreuzberg/src/kreuzberg.integration.test.ts
+++ b/extensions/ext-document-kreuzberg/src/kreuzberg.integration.test.ts
@@ -13,6 +13,10 @@ import { loadUpload } from "veryfront/embedding";
 import { ExtensionLoader } from "../../../src/extensions/loader.ts";
 import { createBuiltinExtensions } from "../../../src/extensions/builtin-extensions.ts";
 import {
+  createEvalReportExporterRegistry,
+  EvalReportExporterRegistryName,
+} from "../../../src/extensions/eval/index.ts";
+import {
   createLLMProviderRegistry,
   LLMProviderRegistryName,
 } from "../../../src/extensions/llm/index.ts";
@@ -65,12 +69,16 @@ describe("ext-document-kreuzberg integration", () => {
   it("extracts uploads through the built-in DocumentExtractor registration", opts, async () => {
     const logs: string[] = [];
     const logger = {
+      debug: (...args: unknown[]) => logs.push(args.join(" ")),
       info: (...args: unknown[]) => logs.push(args.join(" ")),
       warn: (...args: unknown[]) => logs.push(args.join(" ")),
       error: (...args: unknown[]) => logs.push(args.join(" ")),
     };
     const loader = new ExtensionLoader(logger);
-    loader.primeContracts({ [LLMProviderRegistryName]: createLLMProviderRegistry() });
+    loader.primeContracts({
+      [LLMProviderRegistryName]: createLLMProviderRegistry(),
+      [EvalReportExporterRegistryName]: createEvalReportExporterRegistry(),
+    });
 
     try {
       await loader.setupAll(createBuiltinExtensions(), {});

--- a/scripts/lint/test-typecheck-baseline.json
+++ b/scripts/lint/test-typecheck-baseline.json
@@ -101,7 +101,6 @@
   "src/transforms/md/compiler/md-compiler.test.ts",
   "src/transforms/mdx/compiler/index.test.ts",
   "src/transforms/mdx/esm-module-loader/loader.test.ts",
-  "src/transforms/npm-import-rewrites.test.ts",
   "src/utils/cache/stores/memory/lru-list-manager.test.ts",
   "src/workflow/api/workflow-client.test.ts",
   "src/workflow/blob/gcs-storage.test.ts"

--- a/scripts/lint/test-typecheck-baseline.json
+++ b/scripts/lint/test-typecheck-baseline.json
@@ -22,7 +22,6 @@
   "src/agent/hosted/child-stream-watchdog.test.ts",
   "src/agent/hosted/form-input-tool.test.ts",
   "src/agent/hosted/response-stream.test.ts",
-  "src/agent/hosted/root-sandbox-tool-source.test.ts",
   "src/agent/memory/memory.test.ts",
   "src/agent/middleware/cost-tracking/tracker.test.ts",
   "src/agent/runtime/load-tools-tool.test.ts",

--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -94,16 +94,22 @@ Deno.test("hosted remote tool sources do not carry legacy end-user identity plum
     ["end", "user", "id"].join("_"),
   ];
   const productionFiles = [
-    "src/agent/hosted/project-remote-tool-source.ts",
-    "src/agent/hosted/chat-runtime-tool-assembly.ts",
+    {
+      label: "src/agent/hosted/project-remote-tool-source.ts",
+      url: new URL("./project-remote-tool-source.ts", import.meta.url),
+    },
+    {
+      label: "src/agent/hosted/chat-runtime-tool-assembly.ts",
+      url: new URL("./chat-runtime-tool-assembly.ts", import.meta.url),
+    },
   ];
   const offenders: string[] = [];
 
   for (const file of productionFiles) {
-    const source = await Deno.readTextFile(file);
+    const source = await Deno.readTextFile(file.url);
     for (const token of forbidden) {
       if (source.includes(token)) {
-        offenders.push(`${file}:${token}`);
+        offenders.push(`${file.label}:${token}`);
       }
     }
   }

--- a/src/agent/hosted/root-sandbox-tool-source.test.ts
+++ b/src/agent/hosted/root-sandbox-tool-source.test.ts
@@ -16,12 +16,16 @@ function createSandboxTools(): HostToolSet {
     bash: {
       description: "Run shell commands",
       inputSchema: defineSchema((v) => v.object({ command: v.string() }))(),
-      execute: ({ command }) => ({ command }),
+      execute: (input: unknown) => ({
+        command: (input as { command: string }).command,
+      }),
     },
     get_background_command: {
       description: "Get a background command",
       inputSchema: defineSchema((v) => v.object({ commandId: v.string() }))(),
-      execute: ({ commandId }) => ({ commandId }),
+      execute: (input: unknown) => ({
+        commandId: (input as { commandId: string }).commandId,
+      }),
     },
   };
 }
@@ -140,7 +144,11 @@ Deno.test("createHostedRootLocalToolRuntime merges sandbox tools and owns their 
     apiUrl: "https://api.example.com",
     authToken: "token-1",
     createBashTool,
-    buildBaseTools: () => ({ sleep: createSandboxTools().bash }),
+    buildBaseTools: () => {
+      const bash = createSandboxTools().bash;
+      if (!bash) throw new Error("Expected bash mock tool");
+      return { sleep: bash };
+    },
     createAgentServiceSandboxTools: (input) => {
       factoryCalls += 1;
       getProjectId = input.getProjectId;

--- a/src/agent/hosted/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.test.ts
@@ -525,29 +525,24 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime requires agentId for mult
   });
 });
 
-Deno.test("createNodeVeryfrontCloudAgentServiceRuntime defaults discovery to cwd", async () => {
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime accepts baseDir for discovery", async () => {
   await withTempDir(async (rootDir) => {
     writeMarkdownAgentDefinition(rootDir);
-    const previousCwd = Deno.cwd();
-    Deno.chdir(rootDir);
-    try {
-      const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
-        serviceName: "cwd-agent-test",
-        agentId: "veryfront",
-        signals: [],
-        env: {
-          NODE_ENV: "test",
-          VERYFRONT_API_URL: "https://api.example.com",
-          PORT: "3144",
-          ALLOWED_ORIGINS: "https://studio.example.com",
-        },
-      });
+    const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+      serviceName: "base-dir-agent-test",
+      agentId: "veryfront",
+      baseDir: rootDir,
+      signals: [],
+      env: {
+        NODE_ENV: "test",
+        VERYFRONT_API_URL: "https://api.example.com",
+        PORT: "3144",
+        ALLOWED_ORIGINS: "https://studio.example.com",
+      },
+    });
 
-      assertEquals(bundle.runtime.contract.defaultAgentId, "veryfront");
-      assertEquals(getRuntimeAgent(bundle, "veryfront").config.model, "openai/gpt-5.4");
-    } finally {
-      Deno.chdir(previousCwd);
-    }
+    assertEquals(bundle.runtime.contract.defaultAgentId, "veryfront");
+    assertEquals(getRuntimeAgent(bundle, "veryfront").config.model, "openai/gpt-5.4");
   });
 });
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1141,7 +1141,7 @@ export class AgentRuntime {
 
         this.status = "tool_execution";
         addSpanEvent(loopSpan, "tool_execution_start", { count: response.toolCalls.length });
-        let mustLoadSkillFirst = !activeSkillPolicy &&
+        const mustLoadSkillFirstForStep = !activeSkillPolicy &&
           response.toolCalls.some((tc) => tc.toolName === LOAD_SKILL_TOOL_ID);
 
         for (const tc of response.toolCalls) {
@@ -1225,7 +1225,7 @@ export class AgentRuntime {
             const policyCheck = enforceSkillPolicy(
               tc.toolName,
               activeSkillPolicy,
-              mustLoadSkillFirst,
+              mustLoadSkillFirstForStep,
               {
                 hasSubmittedFormInput: hasSubmittedFormInputInLoop,
                 skillToolAvailability: activeSkillToolAvailability,
@@ -1332,7 +1332,6 @@ export class AgentRuntime {
                   activeSkillToolAvailability = extractSkillToolAvailability(result) ??
                     INACTIVE_SKILL_TOOL_AVAILABILITY;
                   activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
-                  mustLoadSkillFirst = false;
                 }
                 activeSkillPolicy = removeFormInputAfterSubmission(
                   tc.toolName,
@@ -1646,7 +1645,7 @@ export class AgentRuntime {
 
       this.status = "tool_execution";
       const streamedToolCalls = Array.from(state.toolCalls.values());
-      let mustLoadSkillFirst = !activeSkillPolicy &&
+      const mustLoadSkillFirstForStep = !activeSkillPolicy &&
         streamedToolCalls.some((tc) => tc.name === LOAD_SKILL_TOOL_ID);
 
       for (const tc of streamedToolCalls) {
@@ -1716,7 +1715,6 @@ export class AgentRuntime {
               activeSkillDelegationOverrides = extractSkillDelegationOverrides(
                 matchingResult.output,
               );
-              mustLoadSkillFirst = false;
             }
             activeSkillPolicy = removeFormInputAfterSubmission(
               tc.name,
@@ -1750,7 +1748,6 @@ export class AgentRuntime {
               activeSkillDelegationOverrides = extractSkillDelegationOverrides(
                 persistedResult.result,
               );
-              mustLoadSkillFirst = false;
             }
             activeSkillPolicy = removeFormInputAfterSubmission(
               tc.name,
@@ -1812,7 +1809,7 @@ export class AgentRuntime {
         const policyCheck = enforceSkillPolicy(
           tc.name,
           activeSkillPolicy,
-          mustLoadSkillFirst,
+          mustLoadSkillFirstForStep,
           {
             hasSubmittedFormInput: hasSubmittedFormInputInLoop,
             skillToolAvailability: activeSkillToolAvailability,
@@ -1885,7 +1882,6 @@ export class AgentRuntime {
               activeSkillToolAvailability = extractSkillToolAvailability(result) ??
                 INACTIVE_SKILL_TOOL_AVAILABILITY;
               activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
-              mustLoadSkillFirst = false;
             }
             activeSkillPolicy = removeFormInputAfterSubmission(
               tc.name,

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -109,6 +109,12 @@ describe("agent runtime refresh hooks", () => {
                 toolName: "load_skill",
                 input: '{"skillId":"read-only-review"}',
               },
+              {
+                type: "tool-call",
+                toolCallId: "write-after-skill",
+                toolName: "write_report",
+                input: '{"path":"second-report.md"}',
+              },
             ],
             finishReason: "tool-calls",
             usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
@@ -137,14 +143,14 @@ describe("agent runtime refresh hooks", () => {
     try {
       await Deno.writeTextFile(
         `${rootPath}/SKILL.md`,
-        "---\nname: read-only-review\ndescription: Review without writes\nallowed-tools: []\n---\nReview the code without modifying files.\n",
+        "---\nname: review\ndescription: Review one report\nallowed-tools: [write_report]\n---\nRead the input before deciding whether to write the report.\n",
       );
       registerSkill("read-only-review", {
         id: "read-only-review",
         metadata: {
-          name: "read-only-review",
-          description: "Review without writes",
-          allowedTools: [],
+          name: "review",
+          description: "Review one report",
+          allowedTools: ["write_report"],
         },
         rootPath,
       });
@@ -161,8 +167,10 @@ describe("agent runtime refresh hooks", () => {
 
       assertEquals(writeExecutions, 0);
       assertEquals(
-        response.toolCalls.find((call) => call.name === "write_report")?.status,
-        "error",
+        response.toolCalls.filter((call) => call.name === "write_report").map((call) =>
+          call.status
+        ),
+        ["error", "error"],
       );
     } finally {
       skillRegistry.clearAll();

--- a/src/data/server-data-fetcher.test.ts
+++ b/src/data/server-data-fetcher.test.ts
@@ -447,6 +447,43 @@ describe("ServerDataFetcher", () => {
       }
     });
 
+    it("keeps marked prefetch failures out of the foreground circuit breaker", async () => {
+      const fetcher = new ServerDataFetcher();
+      const projectId = `prefetch-breaker-isolation-${crypto.randomUUID()}`;
+      const prefetchContext = createContext({
+        request: new Request("http://localhost/test", {
+          headers: {
+            "x-project-id": projectId,
+            "x-veryfront-prefetch": "1",
+          },
+        }),
+      });
+      const foregroundContext = createContext({
+        request: new Request("http://localhost/test", {
+          headers: { "x-project-id": projectId },
+        }),
+      });
+
+      const failingPage: PageWithData = {
+        default: () => null,
+        getServerData: () => {
+          throw new Error("intentional prefetch failure");
+        },
+      };
+
+      for (let i = 0; i < 5; i++) {
+        await assertRejects(() => fetcher.fetch(failingPage, prefetchContext));
+      }
+
+      const okPage: PageWithData = {
+        default: () => null,
+        getServerData: () => ({ props: { ok: true } }),
+      };
+
+      const result = await fetcher.fetch(okPage, foregroundContext);
+      assertEquals(result.props, { ok: true });
+    });
+
     // Worker isolation is the configuration operators are told to use for
     // untrusted project code, so the in-process path alone is not enough. A
     // control result thrown inside the worker is a plain object, and the worker

--- a/src/data/server-data-fetcher.ts
+++ b/src/data/server-data-fetcher.ts
@@ -34,8 +34,10 @@ export class ServerDataFetcher {
 
     const pathname = context.url?.pathname ?? "unknown";
     const projectId = context.request?.headers?.get("x-project-id") ?? "default";
+    const isPrefetch = context.request?.headers?.get("x-veryfront-prefetch") === "1";
+    const breakerNamespace = isPrefetch ? "data-prefetch" : "data-fetch";
 
-    const circuitBreaker = getCircuitBreaker(`data-fetch:${projectId}`, {
+    const circuitBreaker = getCircuitBreaker(`${breakerNamespace}:${projectId}`, {
       failureThreshold: 5,
       resetTimeoutMs: 30_000,
       successThreshold: 2,
@@ -82,6 +84,7 @@ export class ServerDataFetcher {
             serverLogger.warn("DATA_FETCH_CIRCUIT_OPEN circuit breaker open, failing fast", {
               pathname,
               projectId,
+              breakerNamespace,
               retryAfterMs: error.nextAttemptMs,
             });
             throw error;
@@ -109,6 +112,7 @@ export class ServerDataFetcher {
         "data.pathname": pathname,
         "data.timeout_ms": DATA_FETCH_TIMEOUT_MS,
         "data.project_id": projectId,
+        "data.prefetch": isPrefetch,
         "data.isolated": useIsolation,
       },
     );

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -1,5 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { relative } from "#veryfront/compat/path/index.ts";
 import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { rewriteDiscoveryImports, rewriteForDeno } from "./import-rewriter.ts";
@@ -465,7 +466,6 @@ describe("discovery/import-rewriter", () => {
 
   it("resolves project-local veryfront exports when projectDir is relative", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
-    const originalCwd = Deno.cwd();
     const veryfrontDir = `${projectDir}/node_modules/veryfront`;
     await Deno.mkdir(`${veryfrontDir}/local`, { recursive: true });
     await Deno.writeTextFile(
@@ -480,10 +480,9 @@ describe("discovery/import-rewriter", () => {
     await Deno.writeTextFile(`${veryfrontDir}/local/schemas.js`, "");
 
     try {
-      Deno.chdir(projectDir);
       const transformed = await rewriteDiscoveryImports(
         'import { defineSchema } from "veryfront/schemas";',
-        ".",
+        relative(Deno.cwd(), projectDir),
         createFileSystem(),
         `${projectDir}/app`,
       );
@@ -492,7 +491,6 @@ describe("discovery/import-rewriter", () => {
       assertEquals(transformed.includes(import.meta.resolve("veryfront/schemas")), false);
       assertEquals(transformed.includes('from "veryfront/schemas"'), false);
     } finally {
-      Deno.chdir(originalCwd);
       await Deno.remove(projectDir, { recursive: true });
     }
   });

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -77,7 +77,9 @@ describe("hydration-script-builder/templates/router", () => {
     it("should log non-blocking background page-data fetch failures", () => {
       const result = getRouterScript();
       assertIncludes(result, "function logBackgroundFetchFailure(reason, path, error)");
+      assertIncludes(result, "function isAbortError(error)");
       assertIncludes(result, "logBackgroundFetchFailure('Stale page data refresh', path, error)");
+      assertIncludes(result, "if (!isAbortError(error)) {");
       assertIncludes(result, "logBackgroundFetchFailure('Page data prefetch', path, error)");
     });
 
@@ -459,6 +461,7 @@ describe("hydration-script-builder/templates/router", () => {
       dispatchEvent(): boolean;
       scrollTo(): void;
       scrollY: number;
+      __VERYFRONT_DEBUG__?: boolean;
       __veryfrontRouter?: RuntimeRouter;
       __veryfrontHydrationComplete?: () => void;
     }
@@ -487,6 +490,7 @@ describe("hydration-script-builder/templates/router", () => {
           url: string,
           options: { headers?: Record<string, string>; signal?: AbortSignal },
         ) => Promise<unknown>;
+        debug?: boolean;
       } = {},
     ): RuntimeHandle {
       const hydrationJson = JSON.stringify({ params: opts.hydrationParams ?? {} });
@@ -540,6 +544,7 @@ describe("hydration-script-builder/templates/router", () => {
         },
         scrollTo() {},
         scrollY: 0,
+        __VERYFRONT_DEBUG__: opts.debug,
       };
 
       let nextPageData: unknown = { pagePath: "page", params: {} };
@@ -800,7 +805,18 @@ describe("hydration-script-builder/templates/router", () => {
 
     it("aborts active speculative prefetches and starts foreground navigation independently", async () => {
       const abortedPrefetches: string[] = [];
+      const debugLogs: unknown[][] = [];
+      const errorLogs: unknown[][] = [];
+      const originalConsoleLog = console.log;
+      const originalConsoleError = console.error;
+      console.log = (...args: unknown[]) => {
+        debugLogs.push(args);
+      };
+      console.error = (...args: unknown[]) => {
+        errorLogs.push(args);
+      };
       const runtime = evaluateRouterRuntime({
+        debug: true,
         fetchImpl: (url, options) => {
           if (options.headers?.["X-Veryfront-Prefetch"] === "1") {
             return new Promise((_, reject) => {
@@ -814,24 +830,34 @@ describe("hydration-script-builder/templates/router", () => {
           return Promise.resolve(pageDataResponse("target"));
         },
       });
-      runtime.win.__veryfrontHydrationComplete?.();
+      try {
+        runtime.win.__veryfrontHydrationComplete?.();
 
-      runtime.router.prefetch("/target");
-      runtime.router.prefetch("/other");
-      runtime.router.prefetch("/queued");
-      assertEquals(runtime.fetchCalls.length, 2);
+        runtime.router.prefetch("/target");
+        runtime.router.prefetch("/other");
+        runtime.router.prefetch("/queued");
+        assertEquals(runtime.fetchCalls.length, 2);
 
-      await runtime.navigateSPA("/target", true);
+        await runtime.navigateSPA("/target", true);
 
-      assertEquals(abortedPrefetches.sort(), [
-        "/_veryfront/page-data/other.json",
-        "/_veryfront/page-data/target.json",
-      ]);
-      const navigationCall = runtime.fetchCalls[2];
-      if (!navigationCall) throw new Error("foreground navigation fetch did not start");
-      assertEquals(navigationCall.url, "/_veryfront/page-data/target.json");
-      assertEquals(navigationCall.options.headers, { "X-Veryfront-Navigation": "spa" });
-      assertEquals(runtime.router.pathname, "/target");
+        assertEquals(abortedPrefetches.sort(), [
+          "/_veryfront/page-data/other.json",
+          "/_veryfront/page-data/target.json",
+        ]);
+        assertEquals(
+          debugLogs.some((args) => String(args.join(" ")).includes("Page data prefetch failed")),
+          false,
+        );
+        assertEquals(errorLogs, []);
+        const navigationCall = runtime.fetchCalls[2];
+        if (!navigationCall) throw new Error("foreground navigation fetch did not start");
+        assertEquals(navigationCall.url, "/_veryfront/page-data/target.json");
+        assertEquals(navigationCall.options.headers, { "X-Veryfront-Navigation": "spa" });
+        assertEquals(runtime.router.pathname, "/target");
+      } finally {
+        console.log = originalConsoleLog;
+        console.error = originalConsoleError;
+      }
     });
   });
 });

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -148,7 +148,7 @@ describe("hydration-script-builder/templates/router", () => {
     it("should skip page-data prefetches while navigation is active", () => {
       const result = getRouterScript();
       assertIncludes(result, "let isNavigating = false;");
-      assertIncludes(result, "function prefetchPage(href) {\n      if (isNavigating) return;");
+      assertIncludes(result, "if (isNavigating) return;");
     });
 
     it("should emit route transition timing events", () => {
@@ -305,6 +305,7 @@ describe("hydration-script-builder/templates/router", () => {
       assertIncludes(result, "IDLE_PREFETCH_DELAY_MS = 1200");
       assertIncludes(result, "IDLE_PREFETCH_MAX_LINKS = 4");
       assertIncludes(result, "VIEWPORT_PREFETCH_MAX_LINKS = 8");
+      assertIncludes(result, "PAGE_DATA_PREFETCH_CONCURRENCY = 2");
       assertIncludes(result, "VIEWPORT_PREFETCH_ROOT_MARGIN = '200px'");
       assertIncludes(result, "link.getAttribute('data-prefetch') === 'false'");
       assertIncludes(result, "document.querySelectorAll('a[href]')");
@@ -445,6 +446,11 @@ describe("hydration-script-builder/templates/router", () => {
       query: Record<string, string>;
       navigate(path: string): Promise<void>;
       push(path: string): void;
+      prefetch(path: string): void;
+    }
+    interface RuntimeFetchCall {
+      url: string;
+      options: { headers?: Record<string, string>; signal?: AbortSignal };
     }
     interface RuntimeWindow {
       location: RuntimeLocation;
@@ -462,6 +468,7 @@ describe("hydration-script-builder/templates/router", () => {
       win: RuntimeWindow;
       listeners: Record<string, Array<(e: unknown) => void>>;
       setNextPageData: (data: unknown) => void;
+      fetchCalls: RuntimeFetchCall[];
       // The router.params snapshot captured the moment renderPageFromData built
       // the RouterProvider element — i.e. what the new page renders with. This is
       // what the ordering bug (mutating params after render) would get wrong.
@@ -476,6 +483,10 @@ describe("hydration-script-builder/templates/router", () => {
         pathname?: string;
         search?: string;
         hydrationParams?: Record<string, string | string[]>;
+        fetchImpl?: (
+          url: string,
+          options: { headers?: Record<string, string>; signal?: AbortSignal },
+        ) => Promise<unknown>;
       } = {},
     ): RuntimeHandle {
       const hydrationJson = JSON.stringify({ params: opts.hydrationParams ?? {} });
@@ -532,14 +543,22 @@ describe("hydration-script-builder/templates/router", () => {
       };
 
       let nextPageData: unknown = { pagePath: "page", params: {} };
-      const fetchStub = () =>
-        Promise.resolve({
+      const fetchCalls: RuntimeFetchCall[] = [];
+      const fetchStub = (
+        url: string,
+        options: { headers?: Record<string, string>; signal?: AbortSignal },
+      ) => {
+        fetchCalls.push({ url, options });
+        if (opts.fetchImpl) return opts.fetchImpl(url, options);
+
+        return Promise.resolve({
           ok: true,
           status: 200,
           url: "/_veryfront/page-data/page.json",
           headers: { get: () => null },
           json: () => Promise.resolve(nextPageData),
         });
+      };
 
       const RouterProvider = () => ({});
       const PageContextProvider = () => ({});
@@ -598,9 +617,31 @@ describe("hydration-script-builder/templates/router", () => {
         setNextPageData: (data: unknown) => {
           nextPageData = data;
         },
+        fetchCalls,
         getRenderedParams: () => renderedRouterParams,
         getRenderedPageParams: () => renderedPageParams,
       };
+    }
+
+    function pageDataResponse(path = "page"): unknown {
+      return {
+        ok: true,
+        status: 200,
+        url: "/_veryfront/page-data/" + path + ".json",
+        headers: { get: () => null },
+        json: () => Promise.resolve({ pagePath: path, params: {} }),
+      };
+    }
+
+    function flushMicrotasks(): Promise<void> {
+      return Promise.resolve().then(() => {});
+    }
+
+    async function flushUntil(check: () => boolean): Promise<void> {
+      for (let i = 0; i < 10; i++) {
+        if (check()) return;
+        await flushMicrotasks();
+      }
     }
 
     it("seeds router params from hydration data, joining catch-all segments", () => {
@@ -672,6 +713,125 @@ describe("hydration-script-builder/templates/router", () => {
 
       assertEquals(runtime.router.params, { id: "7" });
       assertEquals(runtime.getRenderedParams(), { id: "7" });
+    });
+
+    it("limits generated page-data prefetches to two active requests", async () => {
+      const pendingResolvers: Array<(value: unknown) => void> = [];
+      const runtime = evaluateRouterRuntime({
+        fetchImpl: () =>
+          new Promise((resolve) => {
+            pendingResolvers.push(resolve);
+          }),
+      });
+
+      runtime.router.prefetch("/a");
+      runtime.router.prefetch("/b");
+      runtime.router.prefetch("/c");
+      runtime.router.prefetch("/d");
+
+      assertEquals(runtime.fetchCalls.map((call) => call.url), [
+        "/_veryfront/page-data/a.json",
+        "/_veryfront/page-data/b.json",
+      ]);
+
+      const resolveFirst = pendingResolvers[0];
+      if (!resolveFirst) throw new Error("first prefetch did not start");
+      resolveFirst(pageDataResponse("a"));
+      await flushUntil(() => runtime.fetchCalls.length === 3);
+
+      assertEquals(runtime.fetchCalls.map((call) => call.url), [
+        "/_veryfront/page-data/a.json",
+        "/_veryfront/page-data/b.json",
+        "/_veryfront/page-data/c.json",
+      ]);
+    });
+
+    it("marks speculative page-data prefetches and does not retry them", async () => {
+      const runtime = evaluateRouterRuntime({
+        fetchImpl: () =>
+          Promise.resolve({
+            ok: false,
+            status: 500,
+            url: "/_veryfront/page-data/fail.json",
+            headers: { get: () => null },
+            json: () => Promise.resolve({}),
+          }),
+      });
+
+      runtime.router.prefetch("/fail");
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      assertEquals(runtime.fetchCalls.length, 1);
+      const call = runtime.fetchCalls[0];
+      if (!call) throw new Error("prefetch fetch did not start");
+      assertEquals(call.options.headers, { "X-Veryfront-Prefetch": "1" });
+    });
+
+    it("allows a failed speculative prefetch to be requested again later", async () => {
+      const runtime = evaluateRouterRuntime({
+        fetchImpl: () => {
+          if (runtime.fetchCalls.length === 1) {
+            return Promise.resolve({
+              ok: false,
+              status: 500,
+              url: "/_veryfront/page-data/retry.json",
+              headers: { get: () => null },
+              json: () => Promise.resolve({}),
+            });
+          }
+
+          return Promise.resolve(pageDataResponse("retry"));
+        },
+      });
+
+      runtime.router.prefetch("/retry");
+
+      for (let i = 0; i < 10 && runtime.fetchCalls.length < 2; i++) {
+        await flushMicrotasks();
+        runtime.router.prefetch("/retry");
+      }
+
+      assertEquals(runtime.fetchCalls.map((call) => call.url), [
+        "/_veryfront/page-data/retry.json",
+        "/_veryfront/page-data/retry.json",
+      ]);
+    });
+
+    it("aborts active speculative prefetches and starts foreground navigation independently", async () => {
+      const abortedPrefetches: string[] = [];
+      const runtime = evaluateRouterRuntime({
+        fetchImpl: (url, options) => {
+          if (options.headers?.["X-Veryfront-Prefetch"] === "1") {
+            return new Promise((_, reject) => {
+              options.signal?.addEventListener("abort", () => {
+                abortedPrefetches.push(url);
+                reject(new DOMException("Aborted", "AbortError"));
+              });
+            });
+          }
+
+          return Promise.resolve(pageDataResponse("target"));
+        },
+      });
+      runtime.win.__veryfrontHydrationComplete?.();
+
+      runtime.router.prefetch("/target");
+      runtime.router.prefetch("/other");
+      runtime.router.prefetch("/queued");
+      assertEquals(runtime.fetchCalls.length, 2);
+
+      await runtime.navigateSPA("/target", true);
+
+      assertEquals(abortedPrefetches.sort(), [
+        "/_veryfront/page-data/other.json",
+        "/_veryfront/page-data/target.json",
+      ]);
+      const navigationCall = runtime.fetchCalls[2];
+      if (!navigationCall) throw new Error("foreground navigation fetch did not start");
+      assertEquals(navigationCall.url, "/_veryfront/page-data/target.json");
+      assertEquals(navigationCall.options.headers, { "X-Veryfront-Navigation": "spa" });
+      assertEquals(runtime.router.pathname, "/target");
     });
   });
 });

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -150,7 +150,7 @@ describe("hydration-script-builder/templates/router", () => {
     it("should skip page-data prefetches while navigation is active", () => {
       const result = getRouterScript();
       assertIncludes(result, "let isNavigating = false;");
-      assertIncludes(result, "if (isNavigating) return;");
+      assertIncludes(result, "function prefetchPage(href) {\n      if (isNavigating) return;");
     });
 
     it("should emit route transition timing events", () => {

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -55,6 +55,10 @@ export const getRouterScript = () => `
       log(reason + ' failed:', path, message);
     }
 
+    function isAbortError(error) {
+      return error?.name === 'AbortError';
+    }
+
     function getDocumentNonce() {
       const element = document.querySelector('script[nonce], style[nonce], link[nonce]');
       if (!element) return undefined;
@@ -572,7 +576,9 @@ export const getRouterScript = () => `
       return startPageDataFetch(path, signal, { prefetch: true, trackPending: false })
         .then((data) => preloadModulesForPageData(data, path))
         .catch((error) => {
-          logBackgroundFetchFailure('Page data prefetch', path, error);
+          if (!isAbortError(error)) {
+            logBackgroundFetchFailure('Page data prefetch', path, error);
+          }
           throw error;
         });
     }

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -39,6 +39,7 @@ export const getRouterScript = () => `
     const IDLE_PREFETCH_DELAY_MS = 1200;
     const IDLE_PREFETCH_MAX_LINKS = 4;
     const VIEWPORT_PREFETCH_MAX_LINKS = 8;
+    const PAGE_DATA_PREFETCH_CONCURRENCY = 2;
     const VIEWPORT_PREFETCH_ROOT_MARGIN = '200px';
     const MAX_ROUTE_TIMINGS = 100;
     const MAX_SERVER_TIMING_LENGTH = 1024;
@@ -407,11 +408,16 @@ export const getRouterScript = () => `
     async function fetchWithRetry(url, options, maxRetries = MAX_RETRIES) {
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
         const controller = new AbortController();
+        const callerSignal = options.signal;
+        const abortFromCaller = () => controller.abort();
+        if (callerSignal?.aborted) controller.abort();
+        callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
         const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
         try {
           const response = await fetch(url, { ...options, signal: controller.signal });
           clearTimeout(timeout);
+          callerSignal?.removeEventListener('abort', abortFromCaller);
 
           if (response.ok) return response;
 
@@ -424,8 +430,9 @@ export const getRouterScript = () => `
           return response;
         } catch (error) {
           clearTimeout(timeout);
+          callerSignal?.removeEventListener('abort', abortFromCaller);
 
-          if (error.name === 'AbortError' && options.signal?.aborted) throw error;
+          if (error.name === 'AbortError' && callerSignal?.aborted) throw error;
           if (attempt === maxRetries) throw error;
 
           log('Fetch failed, retrying...', error.message);
@@ -450,10 +457,13 @@ export const getRouterScript = () => `
       log('Fetching page data:', path);
       perfStart('fetch:' + path);
 
+      const headers = options.prefetch
+        ? { 'X-Veryfront-Prefetch': '1' }
+        : { 'X-Veryfront-Navigation': 'spa' };
       const response = await fetchWithRetry(endpoint, {
-        headers: { 'X-Veryfront-Navigation': 'spa' },
+        headers,
         signal
-      });
+      }, options.prefetch ? 0 : MAX_RETRIES);
 
       if (!response.ok) {
         perfEnd('fetch:' + path);
@@ -504,11 +514,13 @@ export const getRouterScript = () => `
 
     function startPageDataFetch(path, signal, options = {}) {
       const request = fetchPageDataFresh(path, signal, options).finally(() => {
-        if (pendingPageDataFetches.get(path) === request) {
+        if (options.trackPending !== false && pendingPageDataFetches.get(path) === request) {
           pendingPageDataFetches.delete(path);
         }
       });
-      pendingPageDataFetches.set(path, request);
+      if (options.trackPending !== false) {
+        pendingPageDataFetches.set(path, request);
+      }
       return request;
     }
 
@@ -555,12 +567,13 @@ export const getRouterScript = () => `
       });
     }
 
-    async function fetchPageDataForPrefetch(path) {
+    async function fetchPageDataForPrefetch(path, signal) {
       if (getCachedPageData(path)) return;
-      return fetchPageDataDeduped(path)
+      return startPageDataFetch(path, signal, { prefetch: true, trackPending: false })
         .then((data) => preloadModulesForPageData(data, path))
         .catch((error) => {
           logBackgroundFetchFailure('Page data prefetch', path, error);
+          throw error;
         });
     }
 
@@ -578,6 +591,9 @@ export const getRouterScript = () => `
 
       if (isNavigating) return;
       isNavigating = true;
+      const [navigationPath] = href.split('#');
+      removeQueuedPrefetch(navigationPath || href);
+      abortActiveSpeculativePrefetches();
 
       currentAbortController = new AbortController();
       const signal = currentAbortController.signal;
@@ -654,6 +670,7 @@ export const getRouterScript = () => `
       } finally {
         isNavigating = false;
         currentAbortController = null;
+        processPageDataPrefetchQueue();
       }
     }
 
@@ -810,6 +827,9 @@ export const getRouterScript = () => `
     const observedPrefetchLinks = new WeakSet();
     const prefetchedPaths = new Set();
     const inFlightPrefetches = new Set();
+    const queuedPrefetchPaths = new Set();
+    const pageDataPrefetchQueue = [];
+    const activePageDataPrefetchControllers = new Map();
 
     function cancelScheduledPrefetch() {
       if (prefetchTimeout) {
@@ -895,9 +915,58 @@ export const getRouterScript = () => `
       }
     }
 
+    function removeQueuedPrefetch(path) {
+      queuedPrefetchPaths.delete(path);
+      for (let i = pageDataPrefetchQueue.length - 1; i >= 0; i--) {
+        if (pageDataPrefetchQueue[i] === path) pageDataPrefetchQueue.splice(i, 1);
+      }
+    }
+
+    function abortActiveSpeculativePrefetches() {
+      for (const controller of activePageDataPrefetchControllers.values()) {
+        controller.abort();
+      }
+    }
+
+    function processPageDataPrefetchQueue() {
+      if (isNavigating) return;
+
+      while (
+        activePageDataPrefetchControllers.size < PAGE_DATA_PREFETCH_CONCURRENCY &&
+        pageDataPrefetchQueue.length > 0
+      ) {
+        const href = pageDataPrefetchQueue.shift();
+        queuedPrefetchPaths.delete(href);
+
+        if (prefetchedPaths.has(href) || inFlightPrefetches.has(href) || getCachedPageData(href)) {
+          continue;
+        }
+
+        if (prefetchedPaths.size >= MAX_PREFETCH_PATHS) {
+          const oldest = prefetchedPaths.values().next().value;
+          if (oldest) prefetchedPaths.delete(oldest);
+        }
+
+        const controller = new AbortController();
+        prefetchedPaths.add(href);
+        inFlightPrefetches.add(href);
+        activePageDataPrefetchControllers.set(href, controller);
+
+        fetchPageDataForPrefetch(href, controller.signal)
+          .catch(() => {
+            prefetchedPaths.delete(href);
+          })
+          .finally(() => {
+            inFlightPrefetches.delete(href);
+            activePageDataPrefetchControllers.delete(href);
+            processPageDataPrefetchQueue();
+          });
+      }
+    }
+
     function prefetchPage(href) {
       if (isNavigating) return;
-      if (prefetchedPaths.has(href) || inFlightPrefetches.has(href)) return;
+      if (prefetchedPaths.has(href) || inFlightPrefetches.has(href) || queuedPrefetchPaths.has(href)) return;
 
       const cachedPageData = getCachedPageData(href);
       if (cachedPageData) {
@@ -907,21 +976,9 @@ export const getRouterScript = () => `
         return;
       }
 
-      if (prefetchedPaths.size >= MAX_PREFETCH_PATHS) {
-        const oldest = prefetchedPaths.values().next().value;
-        if (oldest) prefetchedPaths.delete(oldest);
-      }
-
-      prefetchedPaths.add(href);
-      inFlightPrefetches.add(href);
-
-      fetchPageDataForPrefetch(href)
-        .catch(() => {
-          prefetchedPaths.delete(href);
-        })
-        .finally(() => {
-          inFlightPrefetches.delete(href);
-        });
+      queuedPrefetchPaths.add(href);
+      pageDataPrefetchQueue.push(href);
+      processPageDataPrefetchQueue();
     }
 
     function prefetchEligibleRouteLinks(limit) {

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { RenderPipeline, type RenderPipelineConfig } from "./pipeline.ts";
+import type { RenderOptions } from "./types.ts";
 import { markBuildFailure } from "./module-loader/build-failure.ts";
 import { cachePageCss, getPageCssCacheKey } from "./css-cache.ts";
 import { cacheCSSAsync } from "#veryfront/html/styles-builder/index.ts";
@@ -835,6 +836,115 @@ describe("RenderPipeline behavior", () => {
       },
       pageData.layoutProps,
     );
+  });
+
+  it("resolvePageData reuses resolved page and layout data for CSS SSR", async () => {
+    const slug = "/behavior-css-data-reuse";
+    const projectId = "proj-css-data-reuse";
+    const pagePath = "/project/pages/behavior-css-data-reuse.tsx";
+    const layoutPath = "/project/layouts/root.tsx";
+    const cssHash = "cssdata1";
+    const expectedCss = ".from-data{color:blue}";
+    let pageDataCalls = 0;
+    let layoutDataCalls = 0;
+    let ssrOptions: Record<string, unknown> | undefined;
+    let appliedLayoutProps: Map<string, Record<string, unknown>> | undefined;
+    const pipeline = createPipeline(pagePath, {
+      pageRenderer: {
+        preparePageBundles: async () => ({
+          pageElement: {},
+          pageBundle: {},
+        }),
+      } as any,
+      layoutOrchestrator: {
+        collectLayouts: async () => ({
+          layoutBundle: undefined,
+          nestedLayouts: [{ kind: "tsx", componentPath: layoutPath }],
+        }),
+        preloadLayoutModules: async () => ({
+          tsxTotal: 1,
+          tsxSuccess: 1,
+          tsxFailures: [],
+          mdxTotal: 0,
+          mdxSuccess: 0,
+          mdxFailures: [],
+          importMapSuccess: true,
+          durationMs: 0,
+          allSuccess: true,
+        }),
+        applyLayoutsAndWrappers: async (
+          element: unknown,
+          _pageInfo: unknown,
+          _layoutBundle: unknown,
+          _nestedLayouts: unknown,
+          layoutProps: Map<string, Record<string, unknown>>,
+        ) => {
+          appliedLayoutProps = layoutProps;
+          return element;
+        },
+      } as any,
+      ssrOrchestrator: {
+        performSSRRendering: async (
+          _element: unknown,
+          _context: unknown,
+          options: RenderOptions,
+        ) => {
+          ssrOptions = options as Record<string, unknown>;
+          return {
+            fullHtml:
+              `<!DOCTYPE html><html><head><link rel="stylesheet" href="/_vf/css/${cssHash}.css"></head><body><div class="from-data">ok</div></body></html>`,
+            finalStream: null,
+            ssrHash: "test-hash",
+          };
+        },
+      } as any,
+    });
+
+    await cacheCSSAsync(expectedCss, cssHash, {
+      candidates: ["from-data"],
+      stylesheet: '@import "tailwindcss";',
+    });
+
+    (pipeline as any).loadModule = async (path: string) => {
+      if (path === pagePath) {
+        return {
+          getServerData: () => {
+            pageDataCalls++;
+            return { props: { title: "from-page" } };
+          },
+        };
+      }
+      if (path === layoutPath) {
+        return {
+          getServerData: () => {
+            layoutDataCalls++;
+            return { props: { theme: "from-layout" } };
+          },
+        };
+      }
+      return {};
+    };
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+      environment: "production",
+    });
+
+    assertEquals(pageDataCalls, 1);
+    assertEquals(layoutDataCalls, 1);
+    assertEquals(pageData.props, { title: "from-page" });
+    assertEquals(pageData.layoutProps, {
+      "layouts/root.tsx": { theme: "from-layout" },
+    });
+    assertEquals(pageData.css, expectedCss);
+    assertEquals(ssrOptions?.props, { title: "from-page" });
+    assertEquals(ssrOptions?.layoutProps, {
+      "layouts/root.tsx": { theme: "from-layout" },
+    });
+    assertEquals(Object.getOwnPropertySymbols(ssrOptions ?? {}).length, 0);
+    assertEquals(appliedLayoutProps?.get(layoutPath), { theme: "from-layout" });
   });
 
   it("resolvePageData reuses the SSR hashed stylesheet for SPA CSS", async () => {

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -163,6 +163,17 @@ interface FetchedDataResult {
   error: Error | null;
 }
 
+const PRE_RESOLVED_DATA = Symbol("veryfront.preResolvedData");
+
+type InternalRenderOptions = RenderOptions & {
+  [PRE_RESOLVED_DATA]?: DataResolutionResult;
+};
+
+function stripInternalRenderOptions(options: InternalRenderOptions): RenderOptions {
+  const { [PRE_RESOLVED_DATA]: _preResolvedData, ...publicOptions } = options;
+  return publicOptions;
+}
+
 export class RenderPipeline {
   private config: RenderPipelineConfig;
   private dataFetcher: DataFetcher;
@@ -580,7 +591,19 @@ export class RenderPipeline {
               let layoutDataMap = new Map<string, Record<string, unknown>>();
 
               const dataFetchStart = performance.now();
-              if (options?.url && (options.request || options.staticDataOnly)) {
+              const internalPreResolvedData = (options as InternalRenderOptions | undefined)?.[
+                PRE_RESOLVED_DATA
+              ];
+              const renderInputOptions = internalPreResolvedData && options
+                ? stripInternalRenderOptions(options as InternalRenderOptions)
+                : options;
+              if (internalPreResolvedData) {
+                resolvedParams = internalPreResolvedData.params;
+                dataFetchingProps = Object.keys(internalPreResolvedData.pageProps).length > 0
+                  ? internalPreResolvedData.pageProps
+                  : undefined;
+                layoutDataMap = internalPreResolvedData.layoutProps;
+              } else if (options?.url && (options.request || options.staticDataOnly)) {
                 await profilePhase(
                   "render.data_fetching",
                   () =>
@@ -618,13 +641,13 @@ export class RenderPipeline {
               const hasResolvedParams = Object.keys(resolvedParams).length > 0;
               const mergedOptions = (dataFetchingProps || hasResolvedParams)
                 ? {
-                  ...options,
+                  ...renderInputOptions,
                   ...(hasResolvedParams ? { params: resolvedParams } : {}),
                   ...(dataFetchingProps
-                    ? { props: { ...options?.props, ...dataFetchingProps } }
+                    ? { props: { ...renderInputOptions?.props, ...dataFetchingProps } }
                     : {}),
                 }
-                : options;
+                : renderInputOptions;
 
               const bundlePrepStart = performance.now();
               const pageBundleResult = await profilePhase(
@@ -895,7 +918,7 @@ export class RenderPipeline {
 
     const { css, cssAction, cssError } = await profilePhase(
       "page_data.resolve_css",
-      () => this.resolvePageDataCss(slug, options, projectUpdatedAt),
+      () => this.resolvePageDataCss(slug, options, projectUpdatedAt, dataResolution),
     );
 
     resolvePageDataLog.debug("Resolved page data", {
@@ -1005,6 +1028,7 @@ export class RenderPipeline {
     slug: string,
     options: RenderOptions | undefined,
     projectUpdatedAt: string | undefined,
+    dataResolution: DataResolutionResult,
   ): Promise<PageCssResult> {
     if (this.hasReadyReleaseCss(options)) {
       return { css: undefined, cssAction: "clear", cssError: undefined };
@@ -1024,16 +1048,19 @@ export class RenderPipeline {
     }
 
     try {
+      const cssRenderOptions: InternalRenderOptions = {
+        ...options,
+        delivery: "string",
+        skipCacheCheck: true,
+        skipCachePersist: true,
+        [PRE_RESOLVED_DATA]: dataResolution,
+      };
+
       const renderResult = await profilePhase(
         "page_data.css.render_html",
         () =>
           withTimeout(
-            this.renderPage(slug, {
-              ...options,
-              delivery: "string",
-              skipCacheCheck: true,
-              skipCachePersist: true,
-            }),
+            this.renderPage(slug, cssRenderOptions),
             CSS_SSR_TIMEOUT_MS,
             `CSS SSR for ${slug}`,
           ),

--- a/src/rendering/script-page-handling.ts
+++ b/src/rendering/script-page-handling.ts
@@ -389,5 +389,5 @@ async function loadScriptModule(
   const transpiled = await transpileWithEsbuild(source, modulePath, resolveDir);
   logger.debug(`Transpiled ${modulePath}`);
 
-  return importFromTempFile(fs, rewriteNpmImports(transpiled));
+  return importFromTempFile(fs, rewriteNpmImports(transpiled, projectDir));
 }

--- a/src/routing/api/module-loader/external-import-rewriter.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.ts
@@ -564,7 +564,7 @@ export async function rewriteExternalImports(
   }
 
   if (isDeno) {
-    transformed = rewriteNpmImports(transformed);
+    transformed = rewriteNpmImports(transformed, projectDir);
     transformed = rewriteDenoNodeBuiltinImports(transformed);
 
     // Rewrite user-installed npm dependencies.

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -562,7 +562,9 @@ export class LazySandbox {
       ? session
       : await this.waitForReadySession(session.id);
 
-    await this.waitForRuntimeDataPlaneReady(readySession);
+    if (this.shouldUseInternalDataPlane(readySession.endpoint, readySession.id)) {
+      await this.waitForRuntimeDataPlaneReady(readySession);
+    }
     return readySession.endpoint;
   }
 
@@ -854,14 +856,23 @@ export class LazySandbox {
       resolveDefaultSandboxRuntimeEndpoint({ endpoint });
   }
 
+  private shouldUseInternalDataPlane(endpoint: string, sessionId: string): boolean {
+    if (!this.resolveRuntimeEndpointOption) {
+      return false;
+    }
+
+    const runtimeEndpoint = this.resolveRuntimeEndpointFor(endpoint, sessionId);
+    return normalizeDataPlaneBaseUrl(runtimeEndpoint) !== normalizeDataPlaneBaseUrl(endpoint);
+  }
+
   private resolveDataPlaneRoute(): DataPlaneRoute {
     const endpoint = this.requireEndpoint();
     const sessionId = this.requireSessionId();
-    const runtimeEndpoint = this.resolveRuntimeEndpointFor(endpoint, sessionId);
-    const normalizedEndpoint = normalizeDataPlaneBaseUrl(endpoint);
-    const normalizedRuntimeEndpoint = normalizeDataPlaneBaseUrl(runtimeEndpoint);
-    if (normalizedRuntimeEndpoint !== normalizedEndpoint) {
-      return { baseUrl: normalizedRuntimeEndpoint, kind: "internal" };
+    if (this.shouldUseInternalDataPlane(endpoint, sessionId)) {
+      return {
+        baseUrl: normalizeDataPlaneBaseUrl(this.resolveRuntimeEndpointFor(endpoint, sessionId)),
+        kind: "internal",
+      };
     }
 
     return {

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -868,9 +868,17 @@ export class LazySandbox {
   private resolveDataPlaneRoute(): DataPlaneRoute {
     const endpoint = this.requireEndpoint();
     const sessionId = this.requireSessionId();
-    if (this.shouldUseInternalDataPlane(endpoint, sessionId)) {
+    if (!this.resolveRuntimeEndpointOption) {
       return {
-        baseUrl: normalizeDataPlaneBaseUrl(this.resolveRuntimeEndpointFor(endpoint, sessionId)),
+        baseUrl: sandboxSessionRoute(this.apiUrl, sessionId),
+        kind: "proxy",
+      };
+    }
+
+    const runtimeEndpoint = this.resolveRuntimeEndpointFor(endpoint, sessionId);
+    if (normalizeDataPlaneBaseUrl(runtimeEndpoint) !== normalizeDataPlaneBaseUrl(endpoint)) {
+      return {
+        baseUrl: normalizeDataPlaneBaseUrl(runtimeEndpoint),
         kind: "internal",
       };
     }

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1313,7 +1313,45 @@ describe("Sandbox", () => {
       }
     });
 
-    it("waits for Kubernetes runtime endpoint readiness even when the session is already running", async () => {
+    it("uses API proxy routes for default Kubernetes data-plane calls", async () => {
+      setEnv("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc");
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://3912734599.sandbox.veryfront.org",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        ndjsonResponse([
+          { type: "stdout", data: "ok\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+      });
+
+      try {
+        assertEquals(await sandbox.executeCommand("echo ok"), {
+          stdout: "ok\n",
+          stderr: "",
+          exitCode: 0,
+        });
+
+        assertEquals(fetchCalls.map((call) => call.url), [
+          "https://api.test.com/sandbox-sessions",
+          "https://api.test.com/sandbox-sessions/sandbox-1/heartbeat",
+          "https://api.test.com/sandbox-sessions/sandbox-1/commands/stream",
+        ]);
+      } finally {
+        await sandbox.close();
+      }
+    });
+
+    it("waits for explicit runtime endpoint readiness even when the session is already running", async () => {
       setEnv("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc");
       mockTimers({ advanceTimeByMs: true });
       mockFetch([
@@ -1340,6 +1378,8 @@ describe("Sandbox", () => {
         authToken: "test-token",
         apiUrl: "https://api.test.com",
         execStartRetryDelayMs: 1,
+        resolveRuntimeEndpoint: ({ endpoint }) =>
+          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
       });
 
       try {
@@ -1361,7 +1401,7 @@ describe("Sandbox", () => {
       }
     });
 
-    it("reprovisions SDK-created Kubernetes sessions when the runtime endpoint never becomes ready", async () => {
+    it("reprovisions SDK-created sessions when the explicit runtime endpoint never becomes ready", async () => {
       setEnv("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc");
       mockTimers({ advanceTimeByMs: true });
       mockFetch([
@@ -1397,6 +1437,8 @@ describe("Sandbox", () => {
         startupTimeoutMs: 3,
         pollIntervalMs: 2,
         controlRequestTimeoutMs: 0,
+        resolveRuntimeEndpoint: ({ endpoint }) =>
+          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
       });
 
       try {
@@ -1530,6 +1572,8 @@ describe("Sandbox", () => {
       const sandbox = Sandbox.createLazy({
         authToken: "test-token",
         apiUrl: "https://api.test.com",
+        resolveRuntimeEndpoint: ({ endpoint }) =>
+          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
       });
 
       try {
@@ -1574,6 +1618,8 @@ describe("Sandbox", () => {
       const sandbox = Sandbox.createLazy({
         authToken: "test-token",
         apiUrl: "https://api.test.com",
+        resolveRuntimeEndpoint: ({ endpoint }) =>
+          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
       });
 
       try {
@@ -1723,6 +1769,8 @@ describe("Sandbox", () => {
       const sandbox = Sandbox.createLazy({
         authToken: "test-token",
         apiUrl: "https://api.test.com",
+        resolveRuntimeEndpoint: ({ endpoint }) =>
+          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
       });
 
       try {
@@ -1812,6 +1860,8 @@ describe("Sandbox", () => {
       const sandbox = Sandbox.createLazy({
         authToken: "test-token",
         apiUrl: "https://api.test.com",
+        resolveRuntimeEndpoint: ({ endpoint }) =>
+          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
       });
 
       try {
@@ -1882,6 +1932,8 @@ describe("Sandbox", () => {
       const sandbox = Sandbox.createLazy({
         authToken: "test-token",
         apiUrl: "https://api.test.com",
+        resolveRuntimeEndpoint: ({ endpoint }) =>
+          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
       });
 
       try {
@@ -1951,6 +2003,8 @@ describe("Sandbox", () => {
       const sandbox = Sandbox.createLazy({
         authToken: "test-token",
         apiUrl: "https://api.test.com",
+        resolveRuntimeEndpoint: ({ endpoint }) =>
+          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
       });
 
       try {
@@ -2152,6 +2206,8 @@ describe("Sandbox", () => {
       const sandbox = Sandbox.createLazy({
         authToken: "test-token",
         apiUrl: "https://api.test.com",
+        resolveRuntimeEndpoint: ({ endpoint }) =>
+          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
       });
 
       try {

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -2203,14 +2203,20 @@ describe("Sandbox", () => {
         jsonResponse({ ok: true }),
       ]);
 
+      let resolverCalls = 0;
       const sandbox = Sandbox.createLazy({
         authToken: "test-token",
         apiUrl: "https://api.test.com",
-        resolveRuntimeEndpoint: ({ endpoint }) =>
-          resolveDefaultSandboxRuntimeEndpoint({ endpoint }),
+        resolveRuntimeEndpoint: ({ endpoint }) => {
+          resolverCalls++;
+          return resolveDefaultSandboxRuntimeEndpoint({ endpoint });
+        },
       });
 
       try {
+        await sandbox.ensure();
+        resolverCalls = 0;
+
         assertEquals((await sandbox.getBackgroundCommand("command-1")).status, "running");
         assertEquals((await sandbox.getBackgroundCommandOutput("command-1")).stdout, "done\n");
         assertEquals((await sandbox.cancelBackgroundCommand("command-1")).status, "canceled");
@@ -2220,6 +2226,7 @@ describe("Sandbox", () => {
 
       const internalCommandsUrl =
         "http://sandbox.veryfront-sandbox-sandbox-1.svc.cluster.local/exec/commands";
+      assertEquals(resolverCalls, 2);
       assertEquals(fetchCalls.map((call) => [call.url, call.init?.method ?? "GET"]), [
         ["https://api.test.com/sandbox-sessions", "POST"],
         ["http://sandbox.veryfront-sandbox-sandbox-1.svc.cluster.local/readyz", "GET"],

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -212,6 +212,64 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
     assertEquals(await first.text(), await second.text());
   });
 
+  it("keeps speculative prefetch work and cache state out of foreground page data", async () => {
+    const producers: string[] = [];
+    const prefetchGate = Promise.withResolvers<void>();
+    const prefetchStarted = Promise.withResolvers<void>();
+
+    setRendererInitializer(
+      createInitializer(async (slug, _ctx, options) => {
+        const producer = options?.request?.headers.get("x-veryfront-prefetch") === "1"
+          ? "prefetch"
+          : "foreground";
+        producers.push(producer);
+        if (producers.length === 1) {
+          prefetchStarted.resolve();
+          await prefetchGate.promise;
+        }
+
+        return {
+          ...createPageData(slug, producers.length),
+          frontmatter: { producer },
+        };
+      }),
+    );
+
+    const ctx = makeCtx({
+      projectDir: "/tmp/prefetch-page-data",
+      projectSlug: "prefetch-page-data",
+      projectId: "proj-prefetch-page-data",
+      releaseId: "rel-prefetch-page-data",
+    });
+    const url = "http://localhost/_veryfront/page-data/index.json";
+    const prefetchResponsePromise = callPageDataEndpoint(
+      new Request(url, { headers: { "x-veryfront-prefetch": "1" } }),
+      ctx,
+    );
+    await prefetchStarted.promise;
+
+    const foregroundResponsePromise = callPageDataEndpoint(new Request(url), ctx);
+    prefetchGate.resolve();
+
+    const [prefetchResponse, foregroundResponse] = await Promise.all([
+      prefetchResponsePromise,
+      foregroundResponsePromise,
+    ]);
+    const cachedForegroundResponse = await callPageDataEndpoint(new Request(url), ctx);
+
+    assertEquals(producers, ["prefetch", "foreground"]);
+    assertEquals(JSON.parse(await prefetchResponse.text()).frontmatter.producer, "prefetch");
+    assertEquals(JSON.parse(await foregroundResponse.text()).frontmatter.producer, "foreground");
+    assertEquals(
+      JSON.parse(await cachedForegroundResponse.text()).frontmatter.producer,
+      "foreground",
+    );
+    assertEquals(
+      prefetchResponse.headers.get("cache-control"),
+      "no-cache, no-store, must-revalidate",
+    );
+  });
+
   it("shares page-data cache entries across tracking and cache-busting query params", async () => {
     let calls = 0;
     setRendererInitializer(

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -100,9 +100,12 @@ export function handlePageDataEndpoint(
 
         const url = new URL(req.url);
         const renderer = await getRendererForProject(ctx);
-        const cacheKey = !isPageDataCacheEnabled() || requestHasCacheSensitiveState(req)
-          ? null
-          : buildPageDataCacheKey(ctx, slug, url);
+        const isSpeculativePrefetch = req.headers.get("x-veryfront-prefetch") === "1";
+        // The request reaches server-data hooks, so prefetch work cannot safely
+        // populate or join the foreground response cache/singleflight.
+        const canUsePageDataCache = isPageDataCacheEnabled() &&
+          !requestHasCacheSensitiveState(req) && !isSpeculativePrefetch;
+        const cacheKey = canUsePageDataCache ? buildPageDataCacheKey(ctx, slug, url) : null;
         const cachePolicy = cacheKey ? getPageDataCachePolicy(ctx) : null;
 
         const payload = cacheKey

--- a/src/transforms/npm-import-rewrites.test.ts
+++ b/src/transforms/npm-import-rewrites.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert";
+import { assertEquals, assertNotStrictEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import {
   _resetCache,
@@ -54,25 +54,40 @@ describe("npm-import-rewrites", () => {
       const result = rewriteNpmImports(input);
       assertEquals(result, input);
     });
+
+    it("keeps cached rewrite rules isolated by canonical project directory", async () => {
+      const firstProject = await Deno.makeTempDir();
+      const secondProject = await Deno.makeTempDir();
+
+      try {
+        _resetCache();
+        const firstRules = getNpmRewriteRules(firstProject);
+        const secondRules = getNpmRewriteRules(secondProject);
+
+        assertNotStrictEquals(firstRules, secondRules);
+        assertEquals(getNpmRewriteRules(firstProject), firstRules);
+        assertEquals(getNpmRewriteRules(secondProject), secondRules);
+      } finally {
+        _resetCache();
+        await Deno.remove(firstProject, { recursive: true });
+        await Deno.remove(secondProject, { recursive: true });
+      }
+    });
   });
 
   describe("missing deno.json fallback", () => {
     it("returns no rules when deno.json is missing", () => {
-      const originalCwd = Deno.cwd();
       const tmpDir = Deno.makeTempDirSync();
       try {
-        // Move to a directory without deno.json
-        Deno.chdir(tmpDir);
         _resetCache();
 
-        const rules = getNpmRewriteRules();
+        const rules = getNpmRewriteRules(tmpDir);
         assertEquals(rules.length, 0);
 
         // rewriteNpmImports should be a no-op
         const input = 'import { z } from "zod"';
-        assertEquals(rewriteNpmImports(input), input);
+        assertEquals(rewriteNpmImports(input, tmpDir), input);
       } finally {
-        Deno.chdir(originalCwd);
         _resetCache();
         Deno.removeSync(tmpDir);
       }

--- a/src/transforms/npm-import-rewrites.test.ts
+++ b/src/transforms/npm-import-rewrites.test.ts
@@ -8,7 +8,7 @@ import {
   REWRITABLE_PACKAGES,
   rewriteNpmImports,
 } from "./npm-import-rewrites.ts";
-import { join } from "#veryfront/compat/path/index.ts";
+import { join, resolve } from "#veryfront/compat/path/index.ts";
 import { cwd } from "#veryfront/platform/compat/process.ts";
 
 describe("npm-import-rewrites", () => {
@@ -21,6 +21,9 @@ describe("npm-import-rewrites", () => {
       it(`"${pkg}" has a pinned npm: entry in deno.json`, () => {
         const value = importMap[pkg];
         assertEquals(typeof value, "string", `Missing import map entry for "${pkg}"`);
+        if (typeof value !== "string") {
+          throw new Error(`Missing import map entry for "${pkg}"`);
+        }
         assertEquals(
           value.startsWith("npm:"),
           true,
@@ -71,6 +74,36 @@ describe("npm-import-rewrites", () => {
         _resetCache();
         await Deno.remove(firstProject, { recursive: true });
         await Deno.remove(secondProject, { recursive: true });
+      }
+    });
+
+    it("loads deno.json from the same canonical directory used for relative baseDir caching", () => {
+      const relativeBaseDir = "relative-project";
+      const resolvedProjectDir = resolve(relativeBaseDir);
+      const canonicalProjectDir = "/canonical/project";
+      const originalRealPathSync = Deno.realPathSync;
+      const originalReadTextFileSync = Deno.readTextFileSync;
+      let readPath: string | undefined;
+
+      try {
+        _resetCache();
+        Deno.realPathSync = ((path: string | URL) => {
+          assertEquals(path, resolvedProjectDir);
+          return canonicalProjectDir;
+        }) as typeof Deno.realPathSync;
+        Deno.readTextFileSync = ((path: string | URL) => {
+          readPath = String(path);
+          return JSON.stringify({ imports: {} });
+        }) as typeof Deno.readTextFileSync;
+
+        const rules = getNpmRewriteRules(relativeBaseDir);
+
+        assertEquals(rules, []);
+        assertEquals(readPath, join(canonicalProjectDir, "deno.json"));
+      } finally {
+        Deno.realPathSync = originalRealPathSync;
+        Deno.readTextFileSync = originalReadTextFileSync;
+        _resetCache();
       }
     });
   });

--- a/src/transforms/npm-import-rewrites.test.ts
+++ b/src/transforms/npm-import-rewrites.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertNotStrictEquals } from "#veryfront/testing/assert";
+import { assertEquals, assertNotStrictEquals, assertStrictEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import {
   _resetCache,
@@ -65,8 +65,8 @@ describe("npm-import-rewrites", () => {
         const secondRules = getNpmRewriteRules(secondProject);
 
         assertNotStrictEquals(firstRules, secondRules);
-        assertEquals(getNpmRewriteRules(firstProject), firstRules);
-        assertEquals(getNpmRewriteRules(secondProject), secondRules);
+        assertStrictEquals(getNpmRewriteRules(firstProject), firstRules);
+        assertStrictEquals(getNpmRewriteRules(secondProject), secondRules);
       } finally {
         _resetCache();
         await Deno.remove(firstProject, { recursive: true });

--- a/src/transforms/npm-import-rewrites.ts
+++ b/src/transforms/npm-import-rewrites.ts
@@ -10,7 +10,7 @@
  */
 
 import { cwd } from "#veryfront/platform/compat/process.ts";
-import { join } from "#veryfront/compat/path/index.ts";
+import { join, resolve } from "#veryfront/compat/path/index.ts";
 
 /**
  * Bare specifiers that should be rewritten to their pinned npm: versions.
@@ -23,7 +23,7 @@ interface RewriteRule {
   replacement: string;
 }
 
-let cachedRules: RewriteRule[] | undefined;
+let cachedRules = new Map<string, RewriteRule[]>();
 
 function escapeForRegex(pkg: string): string {
   return pkg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -60,9 +60,9 @@ function buildRules(importMap: Record<string, string>): RewriteRule[] {
   return rules;
 }
 
-function loadImportMapSync(): Record<string, string> {
+function loadImportMapSync(baseDir: string = cwd()): Record<string, string> {
   try {
-    const denoJsonPath = join(cwd(), "deno.json");
+    const denoJsonPath = join(baseDir, "deno.json");
     const content = Deno.readTextFileSync(denoJsonPath);
     const config = JSON.parse(content);
     return config.imports ?? {};
@@ -72,15 +72,29 @@ function loadImportMapSync(): Record<string, string> {
   }
 }
 
+function resolveCacheKey(baseDir: string): string {
+  const resolvedBaseDir = resolve(baseDir);
+  let canonicalBaseDir = resolvedBaseDir;
+  try {
+    canonicalBaseDir = Deno.realPathSync(resolvedBaseDir);
+  } catch {
+    // expected: user projects may not exist yet in some compiled-binary paths
+  }
+  return canonicalBaseDir;
+}
+
 /**
  * Returns rewrite rules derived from deno.json's import map.
- * Rules are cached after first call.
+ * Rules are cached per resolved project directory.
  */
-export function getNpmRewriteRules(): RewriteRule[] {
-  if (cachedRules) return cachedRules;
-  const importMap = loadImportMapSync();
-  cachedRules = buildRules(importMap);
-  return cachedRules;
+export function getNpmRewriteRules(baseDir: string = cwd()): RewriteRule[] {
+  const cacheKey = resolveCacheKey(baseDir);
+  const cached = cachedRules.get(cacheKey);
+  if (cached) return cached;
+  const importMap = loadImportMapSync(baseDir);
+  const rules = buildRules(importMap);
+  cachedRules.set(cacheKey, rules);
+  return rules;
 }
 
 const isDeno = typeof (globalThis as { Deno?: unknown }).Deno !== "undefined";
@@ -90,10 +104,10 @@ const isDeno = typeof (globalThis as { Deno?: unknown }).Deno !== "undefined";
  * Rewrites bare specifiers to pinned npm: versions from deno.json.
  * No-op on Node.js where bare specifiers resolve via node_modules.
  */
-export function rewriteNpmImports(source: string): string {
+export function rewriteNpmImports(source: string, baseDir: string = cwd()): string {
   if (!isDeno) return source;
   let result = source;
-  for (const { pattern, replacement } of getNpmRewriteRules()) {
+  for (const { pattern, replacement } of getNpmRewriteRules(baseDir)) {
     result = result.replace(pattern, replacement);
   }
   return result;
@@ -104,5 +118,5 @@ export { buildRules, REWRITABLE_PACKAGES };
 
 /** @internal Reset cached rules — only for testing */
 export function _resetCache(): void {
-  cachedRules = undefined;
+  cachedRules = new Map();
 }

--- a/src/transforms/npm-import-rewrites.ts
+++ b/src/transforms/npm-import-rewrites.ts
@@ -118,5 +118,5 @@ export { buildRules, REWRITABLE_PACKAGES };
 
 /** @internal Reset cached rules — only for testing */
 export function _resetCache(): void {
-  cachedRules = new Map();
+  cachedRules = new Map<string, RewriteRule[]>();
 }

--- a/src/transforms/npm-import-rewrites.ts
+++ b/src/transforms/npm-import-rewrites.ts
@@ -72,7 +72,7 @@ function loadImportMapSync(baseDir: string = cwd()): Record<string, string> {
   }
 }
 
-function resolveCacheKey(baseDir: string): string {
+function resolveProjectDir(baseDir: string): string {
   const resolvedBaseDir = resolve(baseDir);
   let canonicalBaseDir = resolvedBaseDir;
   try {
@@ -88,10 +88,11 @@ function resolveCacheKey(baseDir: string): string {
  * Rules are cached per resolved project directory.
  */
 export function getNpmRewriteRules(baseDir: string = cwd()): RewriteRule[] {
-  const cacheKey = resolveCacheKey(baseDir);
+  const projectDir = resolveProjectDir(baseDir);
+  const cacheKey = projectDir;
   const cached = cachedRules.get(cacheKey);
   if (cached) return cached;
-  const importMap = loadImportMapSync(baseDir);
+  const importMap = loadImportMapSync(projectDir);
   const rules = buildRules(importMap);
   cachedRules.set(cacheKey, rules);
   return rules;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1114";
+export const VERSION = "0.1.1115";


### PR DESCRIPTION
## Description

Fixes the remaining framework boundaries uncovered while validating the job-submission workflow against staging:

- keeps speculative page-data prefetch separate from foreground navigation and reuses request-resolved data during SSR
- routes default LazySandbox data-plane operations through authenticated Veryfront API proxy endpoints; direct runtime routing now requires an explicit resolver
- blocks same-response sibling tools until the model has observed loaded skill instructions
- removes process-wide cwd coupling from parallel tests and keys npm rewrite state by canonical project root

The release sources are advanced together to `0.1.1115` so the consumer project can replace its local framework link with the exact verified package.

## Related Issue(s)

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [x] Test update

## Verification

- `DENO_TESTING=1 VF_DISABLE_LRU_INTERVAL=1 deno task test`: 3,055 passed, 0 failed
- pre-push gate: 2,625 unit tests passed, format/lint/typecheck passed
- `deno task lint:test-typecheck`: baseline holds with 0 new failures
- `deno task verify:quick`: passed
- independent security review: no blockers
- independent final code review: approve / merge ready

## Checklist

- [x] I have made corresponding changes to the documentation (not applicable; behavior is covered by API comments and tests)
- [x] I have added tests that prove my fix is effective or that my feature works

## Notes

The staging consumer smoke already exercised the authenticated upload and sandbox/Kreuzberg path with the linked package. Production was not touched.