### PR TITLE
fix(agent): preserve hosted integration project identity

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1115",
+  "version": "0.1.1116",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -335,6 +335,7 @@ export async function prepareHostedChatRuntimeCreationOptions<
   return {
     creationOptions: {
       projectId: input.projectId,
+      ...(input.request.projectSlug ? { projectSlug: input.request.projectSlug } : {}),
       authToken: input.authToken,
       instructions: agentInstructions,
       ...(input.branchId !== undefined ? { branchId: input.branchId } : {}),

--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -36,7 +36,7 @@ export type HostedChatProjectAccessError = {
 
 /** Result returned from hosted chat project access. */
 export type HostedChatProjectAccessResult =
-  | { success: true }
+  | { success: true; projectSlug?: string }
   | { success: false; error: HostedChatProjectAccessError };
 
 /** Request payload for parsed hosted chat. */
@@ -118,13 +118,23 @@ function getValidationErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "validation failed";
 }
 
+function normalizeProjectSlug(projectSlug: string | undefined): string | undefined {
+  const normalized = projectSlug?.trim();
+  return normalized || undefined;
+}
+
+function isBlankProjectSlug(projectSlug: string | undefined): boolean {
+  return projectSlug !== undefined && !normalizeProjectSlug(projectSlug);
+}
+
 async function verifyHostedChatProjectAccess(input: {
   projectId: string | null;
   authToken: string;
+  requestedProjectSlug?: string;
   verifyProjectAccess?: ParseHostedChatRequestOptions["verifyProjectAccess"];
-}): Promise<Response | undefined> {
+}): Promise<{ projectSlug?: string } | Response> {
   if (!input.projectId || !input.verifyProjectAccess) {
-    return undefined;
+    return { projectSlug: normalizeProjectSlug(input.requestedProjectSlug) };
   }
 
   const access = await input.verifyProjectAccess({
@@ -132,7 +142,22 @@ async function verifyHostedChatProjectAccess(input: {
     authToken: input.authToken,
   });
   if (access.success) {
-    return undefined;
+    const requestedProjectSlug = normalizeProjectSlug(input.requestedProjectSlug);
+    const verifiedProjectSlug = normalizeProjectSlug(access.projectSlug);
+    if (
+      requestedProjectSlug &&
+      verifiedProjectSlug &&
+      requestedProjectSlug !== verifiedProjectSlug
+    ) {
+      return Response.json(
+        {
+          errorCode: "FORBIDDEN",
+          message: "Project slug does not match verified project access",
+        },
+        { status: 403 },
+      );
+    }
+    return { projectSlug: verifiedProjectSlug };
   }
 
   return Response.json(
@@ -163,6 +188,20 @@ export async function buildParsedHostedChatRequest(input: {
   const projectSlug = chatContext.projectSlug;
   const conversationId = chatContext.conversationId;
 
+  if (isBlankProjectSlug(projectSlug)) {
+    return createValidationErrorResponse({
+      messagePrefix: "Invalid request",
+      validationMessage: "context.projectSlug cannot be blank",
+    });
+  }
+
+  if (input.verifyProjectAccess && !projectId && normalizeProjectSlug(projectSlug)) {
+    return createValidationErrorResponse({
+      messagePrefix: "Invalid request",
+      validationMessage: "context.projectSlug requires verified context.projectId",
+    });
+  }
+
   if (input.agentConfig && input.agentId && input.agentConfig.id !== input.agentId) {
     return createValidationErrorResponse({
       messagePrefix: "Invalid runtime agent invocation",
@@ -170,23 +209,29 @@ export async function buildParsedHostedChatRequest(input: {
     });
   }
 
-  const accessError = await verifyHostedChatProjectAccess({
+  const access = await verifyHostedChatProjectAccess({
     projectId,
     authToken: input.authToken,
+    requestedProjectSlug: projectSlug,
     verifyProjectAccess: input.verifyProjectAccess,
   });
-  if (accessError) {
-    return accessError;
+  if (access instanceof Response) {
+    return access;
   }
+  const verifiedProjectSlug = access.projectSlug;
+  const validatedContext: ChatRequestContext = {
+    ...chatContext,
+    projectSlug: verifiedProjectSlug,
+  };
 
   return {
     agentId: input.agentId,
     userId: input.userId,
     authToken: input.authToken,
     messages: messages as ChatUiMessage[],
-    validatedContext: chatContext,
+    validatedContext,
     projectId,
-    projectSlug,
+    projectSlug: verifiedProjectSlug,
     conversationId,
     parentRunId: durableRootRun?.runId,
     upstreamParentConversationId: durableRootRun?.parentConversationId,

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -306,7 +306,7 @@ describe("agent/hosted-chat-request", () => {
       }),
       {
         authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
-        verifyProjectAccess: () => Promise.resolve({ success: true }),
+        verifyProjectAccess: () => Promise.resolve({ success: true, projectSlug: "demo-project" }),
         runtimeSource,
       },
     );
@@ -318,6 +318,151 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(parsed.projectId, projectId);
     assertEquals(parsed.projectSlug, "demo-project");
     assertEquals(parsed.validatedContext.projectSlug, "demo-project");
+  });
+
+  it("does not trust a requested slug when project access omits a verified slug", async () => {
+    const parsed = await parseRuntimeAgentRunInvocationHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/runs", {
+        method: "POST",
+        body: JSON.stringify(createRuntimeInvocation()),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: () => Promise.resolve({ success: true }),
+        runtimeSource,
+      },
+    );
+
+    if (parsed instanceof Response) {
+      throw new Error("Expected parsed request");
+    }
+
+    assertEquals(parsed.projectSlug, undefined);
+    assertEquals(parsed.validatedContext.projectSlug, undefined);
+  });
+
+  it("rejects whitespace-only project slugs before project access", async () => {
+    let projectAccessChecks = 0;
+    const response = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+          context: {
+            conversationId,
+            projectId,
+            projectSlug: "   ",
+            branchId,
+          },
+        }),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: () => {
+          projectAccessChecks++;
+          return Promise.resolve({ success: true, projectSlug: "canonical-project" });
+        },
+      },
+    );
+
+    if (!(response instanceof Response)) {
+      throw new Error("Expected validation response");
+    }
+
+    assertEquals(response.status, 400);
+    assertEquals(projectAccessChecks, 0);
+    assertEquals(await response.json(), {
+      errorCode: "VALIDATION_ERROR",
+      message: "Invalid request: context.projectSlug cannot be blank",
+    });
+  });
+
+  it("rejects project slugs without project ids when project access is configured", async () => {
+    let projectAccessChecks = 0;
+    const response = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+          context: {
+            conversationId,
+            projectId: null,
+            projectSlug: "requested-project",
+            branchId,
+          },
+        }),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: () => {
+          projectAccessChecks++;
+          return Promise.resolve({ success: true, projectSlug: "requested-project" });
+        },
+      },
+    );
+
+    if (!(response instanceof Response)) {
+      throw new Error("Expected validation response");
+    }
+
+    assertEquals(response.status, 400);
+    assertEquals(projectAccessChecks, 0);
+    assertEquals(await response.json(), {
+      errorCode: "VALIDATION_ERROR",
+      message: "Invalid request: context.projectSlug requires verified context.projectId",
+    });
+  });
+
+  it("uses the verified project slug when the request omits a slug", async () => {
+    const parsed = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+          context: {
+            conversationId,
+            projectId,
+            branchId,
+          },
+        }),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: () =>
+          Promise.resolve({ success: true, projectSlug: "canonical-project" }),
+      },
+    );
+
+    if (parsed instanceof Response) {
+      throw new Error("Expected parsed request");
+    }
+
+    assertEquals(parsed.projectSlug, "canonical-project");
+    assertEquals(parsed.validatedContext.projectSlug, "canonical-project");
+  });
+
+  it("rejects runtime invocations whose requested slug does not match the verified slug", async () => {
+    const response = await parseRuntimeAgentRunInvocationHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/runs", {
+        method: "POST",
+        body: JSON.stringify(createRuntimeInvocation()),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: () => Promise.resolve({ success: true, projectSlug: "other-project" }),
+        runtimeSource,
+      },
+    );
+
+    if (!(response instanceof Response)) {
+      throw new Error("Expected validation response");
+    }
+
+    assertEquals(response.status, 403);
+    assertEquals(await response.json(), {
+      errorCode: "FORBIDDEN",
+      message: "Project slug does not match verified project access",
+    });
   });
 
   it("preserves request-scoped project agent config from runtime invocations", async () => {

--- a/src/agent/hosted/chat-runtime-contract.ts
+++ b/src/agent/hosted/chat-runtime-contract.ts
@@ -115,6 +115,7 @@ export type HostedChatRuntimeTargetKind = "main_branch" | "environment" | "previ
 /** Options accepted by hosted chat runtime creation. */
 export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingConfig> = {
   projectId: string | null;
+  projectSlug?: string;
   branchId?: string | null;
   runtimeTargetKind?: HostedChatRuntimeTargetKind | null;
   runtimeTargetEnvironmentId?: string | null;

--- a/src/agent/hosted/default-chat-runtime.test.ts
+++ b/src/agent/hosted/default-chat-runtime.test.ts
@@ -1,11 +1,15 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/compat/process.ts";
+import { refreshEnvironmentConfig } from "#veryfront/config/environment-config.ts";
+import { clearModelProviders, type ModelRuntime, registerModelProvider } from "#veryfront/provider";
 import type {
   RemoteMCPToolSourceConfig,
   RemoteToolSource,
   ToolExecutionContext,
 } from "#veryfront/tool";
 import { toolRegistry } from "#veryfront/tool";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { defineSchema } from "../../schemas/define.ts";
 import {
   createDefaultHostedChatRuntime,
@@ -32,6 +36,41 @@ function emptyRemoteSource(config: RemoteMCPToolSourceConfig): RemoteToolSource 
     executeTool: (_toolName: string, _args: unknown, _context?: ToolExecutionContext) =>
       Promise.resolve({ ok: true }),
   };
+}
+
+function createTextStream() {
+  return new ReadableStream<unknown>({
+    start(controller) {
+      controller.enqueue({ type: "text-delta", text: "done" });
+      controller.enqueue({ type: "finish", finishReason: "stop" });
+      controller.close();
+    },
+  });
+}
+
+function createMockModel(): ModelRuntime {
+  return {
+    provider: "anthropic",
+    modelId: "anthropic/claude-sonnet-4-6",
+    async doGenerate() {
+      return {
+        content: [{ type: "text", text: "done" }],
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      };
+    },
+    async doStream() {
+      return { stream: createTextStream() };
+    },
+  };
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    deleteEnv(key);
+    return;
+  }
+  setEnv(key, value);
 }
 
 Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime", async () => {
@@ -80,6 +119,85 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
     inputRequestId: "input-request-1",
   });
   assertEquals(capturedContext.availableToolNames, ["sleep"]);
+});
+
+Deno.test("createDefaultHostedChatRuntime forwards hosted project slug to integration discovery", async () => {
+  const previousApiBaseUrl = getEnv("VERYFRONT_API_BASE_URL");
+  const previousApiToken = getEnv("VERYFRONT_API_TOKEN");
+  const previousProjectSlug = getEnv("VERYFRONT_PROJECT_SLUG");
+  const previousProxyMode = getEnv("PROXY_MODE");
+
+  try {
+    setEnv("VERYFRONT_API_BASE_URL", "https://api.test");
+    setEnv("VERYFRONT_API_TOKEN", "environment-token");
+    deleteEnv("VERYFRONT_PROJECT_SLUG");
+    deleteEnv("PROXY_MODE");
+    refreshEnvironmentConfig();
+    clearModelProviders();
+    registerModelProvider("anthropic", () => createMockModel());
+
+    let authorizationHeader: string | null = null;
+    let projectSlugHeader: string | null = null;
+
+    const runtime = await createDefaultHostedChatRuntime({
+      sourceIntegrationPolicy: unrestrictedSourceIntegrationPolicy,
+      options: {
+        projectId: "11111111-1111-4111-8111-111111111111",
+        projectSlug: "authorized-project",
+        authToken: "user-scoped-token",
+        instructions: "Base instructions",
+        model: "sonnet",
+        allowedTools: ["github__list_repos"],
+        conversationId: "conversation-1",
+        userId: "user-1",
+      },
+      config: {
+        apiUrl: "https://api.example.com",
+        apiMcpUrl: "https://api.example.com/mcp",
+      },
+      buildLocalTools: () => ({}),
+      createRemoteToolSource: emptyRemoteSource,
+      preloadLatestConversationUserText: false,
+    });
+
+    await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (new URL(request.url).pathname === "/integrations/tools/list") {
+          authorizationHeader = request.headers.get("Authorization");
+          projectSlugHeader = request.headers.get("x-veryfront-project-slug");
+          return Response.json({
+            tools: [{
+              name: "github__list_repos",
+              description: "List repos",
+              inputSchema: { type: "object", properties: {} },
+            }],
+          });
+        }
+        return Response.json({ ok: true });
+      },
+      async () => {
+        const result = await runtime.agent.stream({
+          messages: [],
+          abortSignal: new AbortController().signal,
+        });
+        for await (const _chunk of result.toUIMessageStream()) {
+          // Consume the stream so runtime tool discovery executes.
+        }
+      },
+    );
+
+    assertEquals(authorizationHeader, "Bearer user-scoped-token");
+    assertEquals(projectSlugHeader, "authorized-project");
+  } finally {
+    await toolRegistry.clearAll();
+    clearModelProviders();
+    restoreEnv("VERYFRONT_API_BASE_URL", previousApiBaseUrl);
+    restoreEnv("VERYFRONT_API_TOKEN", previousApiToken);
+    restoreEnv("VERYFRONT_PROJECT_SLUG", previousProjectSlug);
+    restoreEnv("PROXY_MODE", previousProxyMode);
+    refreshEnvironmentConfig();
+  }
 });
 
 Deno.test("createDefaultHostedChatRuntime keeps per-run host tools out of the global registry", async () => {

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -4,6 +4,7 @@ import {
   type RemoteToolSource,
 } from "#veryfront/tool";
 import { runWithRequestContextAsync, serverLogger } from "#veryfront/utils";
+import { runWithRequestContext as runWithProjectRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import {
   resolveVeryfrontCloudModelId,
   resolveVeryfrontCloudModelThinking,
@@ -76,6 +77,7 @@ export type DefaultHostedChatRuntimeTaskContext = HostedRuntimeStateResolverCont
   runId?: string;
   agentId?: string;
   projectId: string;
+  projectSlug?: string;
   branchId: string | null;
   runtimeTargetKind?: DefaultHostedChatRuntimeCreationOptions["runtimeTargetKind"];
   runtimeTargetEnvironmentId?: string | null;
@@ -155,6 +157,7 @@ function createDefaultTaskContext(
     runId: input.options.runId,
     agentId: input.options.agentId,
     projectId: input.options.projectId ?? "",
+    projectSlug: input.options.projectSlug,
     branchId: input.options.branchId ?? null,
     runtimeTargetKind: input.options.runtimeTargetKind ?? null,
     runtimeTargetEnvironmentId: input.options.runtimeTargetEnvironmentId ?? null,
@@ -291,6 +294,7 @@ function createCloudContext(input: {
   return {
     apiBaseUrl: input.config.apiUrl,
     apiToken: input.options.authToken,
+    projectSlug: input.options.projectSlug,
     serviceLayer: "cloud",
   };
 }
@@ -310,13 +314,29 @@ function runWithDefaultHostedRequestContext<TResult>(
     }),
     requestId: crypto.randomUUID(),
     projectId: input.taskContext.projectId || undefined,
+    projectSlug: input.taskContext.projectSlug,
     userId: input.taskContext.userId,
     conversationId: input.taskContext.conversationId,
   };
 
   return runWithRequestContextAsync(
     requestContext,
-    () => runWithVeryfrontCloudContextAsync(input.cloudContext, input.operation),
+    () => {
+      const runWithCloudContext = () =>
+        runWithVeryfrontCloudContextAsync(input.cloudContext, input.operation);
+      if (!input.taskContext.projectSlug) {
+        return runWithCloudContext();
+      }
+      return runWithProjectRequestContext(
+        {
+          projectSlug: input.taskContext.projectSlug,
+          projectId: input.taskContext.projectId || undefined,
+          token: input.taskContext.authToken,
+          productionMode: false,
+        },
+        runWithCloudContext,
+      );
+    },
   );
 }
 

--- a/src/agent/service/auth.test.ts
+++ b/src/agent/service/auth.test.ts
@@ -431,7 +431,7 @@ describe("agent/agent-service-auth", () => {
   });
 
   it("checks project access against the configured API origin", async () => {
-    const fetchMock = createFetchMock(new Response("{}", { status: 200 }));
+    const fetchMock = createFetchMock(Response.json({ slug: "verified-project" }));
     const auth = createHostedServiceAuth({
       fetch: fetchMock.fetch,
       projectAccessTimeoutMs: 1_000,
@@ -446,6 +446,7 @@ describe("agent/agent-service-auth", () => {
     assertEquals(result.success, true);
     if (!result.success) throw new Error("Expected project access to succeed");
     assertEquals(result.projectId, "project-1");
+    assertEquals(result.projectSlug, "verified-project");
     const call = getOnlyFetchCall(fetchMock.calls);
     assertEquals(String(call.input), "https://api.example.test/projects/project-1");
     assertEquals(call.init?.method, "GET");

--- a/src/agent/service/auth.ts
+++ b/src/agent/service/auth.ts
@@ -61,7 +61,7 @@ export type HostedServiceProjectAccessError = {
 
 /** Result returned from hosted service project access. */
 export type HostedServiceProjectAccessResult =
-  | { success: true; projectId: string }
+  | { success: true; projectId: string; projectSlug?: string }
   | { success: false; error: HostedServiceProjectAccessError };
 
 /** Configuration used by hosted service auth. */
@@ -205,6 +205,17 @@ function decodeBase64Url(input: string): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readProjectSlugFromAccessResponse(response: Response): Promise<string | undefined> {
+  try {
+    const body: unknown = await response.json();
+    if (!isRecord(body)) return undefined;
+    const slug = typeof body.slug === "string" ? body.slug.trim() : "";
+    return slug || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function parseJsonObject(json: string): Record<string, unknown> | null {
@@ -431,9 +442,11 @@ export function createHostedServiceAuth(
           };
         }
 
+        const projectSlug = await readProjectSlugFromAccessResponse(response);
         return {
           success: true,
           projectId,
+          ...(projectSlug ? { projectSlug } : {}),
         };
       } catch (error) {
         options.logger?.error?.("Project access check failed", { error, projectId });

--- a/src/agent/service/routes.ts
+++ b/src/agent/service/routes.ts
@@ -94,6 +94,7 @@ export type HostedAgentServiceRouteSetOptions<TExecution extends object> = {
   verifyProjectAccess: (projectId: string, authToken: string) => Promise<
     {
       success: true;
+      projectSlug?: string;
     } | {
       success: false;
       error: { errorCode: string; message: string; statusCode: number };

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -276,6 +276,31 @@ describe("integrations/remote-tools", () => {
     assertEquals(definitions, []);
   });
 
+  it("does not fall back to the environment project slug when request context has an empty slug", async () => {
+    setRemoteToolEnv({
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+      VERYFRONT_PROJECT_SLUG: "environment-project",
+    });
+
+    let projectSlugHeader: string | null = "unexpected";
+    const definitions = await runWithRequestContext(
+      { projectSlug: "   ", token: "request-token" },
+      async () =>
+        await withMockFetch(
+          async (input: string | URL | Request, init?: RequestInit) => {
+            const request = input instanceof Request ? input : new Request(input, init);
+            projectSlugHeader = request.headers.get("x-veryfront-project-slug");
+            return Response.json({ tools: [] });
+          },
+          async () => await getRemoteIntegrationToolDefinitions(),
+        ),
+    );
+
+    assertEquals(projectSlugHeader, null);
+    assertEquals(definitions, []);
+  });
+
   it("omits the project slug header when no project context is configured", async () => {
     setRemoteToolEnv({
       VERYFRONT_API_BASE_URL: "https://api.test",

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -76,8 +76,11 @@ function normalizeProjectSlug(projectSlug: string | undefined): string | undefin
 }
 
 function resolveRequestProjectSlug(): string | undefined {
-  const requestProjectSlug = normalizeProjectSlug(getCurrentRequestContext()?.projectSlug);
-  return requestProjectSlug ?? normalizeProjectSlug(getEnvironmentConfig().projectSlug);
+  const requestContext = getCurrentRequestContext();
+  if (requestContext) {
+    return normalizeProjectSlug(requestContext.projectSlug);
+  }
+  return normalizeProjectSlug(getEnvironmentConfig().projectSlug);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1115";
+export const VERSION = "0.1.1116";


### PR DESCRIPTION
## Summary

- Preserves hosted integration project identity by deriving the canonical project slug from the authenticated project access check before remote integration discovery.
- Rejects mismatched ID/slug pairs, blank slug input, and projectless hosted calls that would otherwise inherit an ambient environment project slug.
- Installs request context around hosted streaming so `/integrations/tools/list` receives the verified user token and `x-veryfront-project-slug` header.
- Bumps `veryfront-code` to `0.1.1116` in `deno.json` and `src/utils/version-constant.ts` so this PR creates a release.

## Validation

- `deno test --allow-env --allow-read --allow-write --allow-net src/agent/service/auth.test.ts src/agent/hosted/chat-request.test.ts src/integrations/remote-tools.test.ts`
- `deno task verify:quick`
- Pre-push gate: format, lint, `deno check src/index.ts`, and full unit suite: `2626 passed / 0 failed`
- `deno run -A scripts/release.ts 0.1.1116 --dry-run --no-test --no-build --no-publish --yes`

## Notes

This addresses the review comments about raw request slug trust, whitespace slug normalization, and fallback to environment slug state.
