### PR TITLE
fix(provider): preserve validation context without exposing bodies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1116",
+  "version": "0.1.1117",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/provider/runtime-loader/provider-http.test.ts
+++ b/src/provider/runtime-loader/provider-http.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "#std/assert";
 import { describe, it } from "#std/testing/bdd";
+import { parseProviderError } from "../../chat/provider-errors.ts";
 import {
   buildProviderError,
   parseRetryAfterMs,
@@ -168,6 +169,71 @@ describe("provider-http", () => {
       );
       assertEquals(err.message, "Provider request failed with status 500");
       assertEquals(err.message.includes("<TOKEN>"), false);
+    });
+
+    it("preserves structured 400 details for internal classification without enumerating them", async () => {
+      const responseBody = JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message: "This model does not support assistant message prefill.",
+        },
+      });
+      const err = await buildProviderError(
+        "anthropic",
+        jsonResponse(400, responseBody),
+      );
+
+      assertEquals(err.responseBody, responseBody);
+      assertEquals(Object.keys(err).includes("responseBody"), false);
+      assertEquals(JSON.stringify(err).includes("assistant message prefill"), false);
+      assertEquals(err.message, "Provider request failed with status 400");
+      assertEquals(parseProviderError(err), {
+        code: "MODEL_UNSUPPORTED_ASSISTANT_PREFILL",
+        message:
+          "The selected model does not support assistant-message prefill. Start a new user message or choose a compatible model.",
+      });
+    });
+
+    it("preserves invalid-request details when a provider also supplies a specific code", async () => {
+      const responseBody = JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          code: "context_length_exceeded",
+          message: "The prompt is too long for this model.",
+        },
+      });
+      const err = await buildProviderError(
+        "openai",
+        jsonResponse(400, responseBody),
+      );
+
+      assertEquals(err.responseBody, responseBody);
+      assertEquals(parseProviderError(err), {
+        code: "CONTEXT_LENGTH_EXCEEDED",
+        message: "Conversation is too long",
+      });
+    });
+
+    it("does not preserve arbitrary provider api error messages", async () => {
+      const err = await buildProviderError(
+        "anthropic",
+        jsonResponse(400, {
+          type: "error",
+          error: {
+            type: "api_error",
+            message: "private provider payload <TOKEN>",
+          },
+        }),
+      );
+
+      assertEquals(err.responseBody, undefined);
+      assertEquals(parseProviderError(err), {
+        code: "EXTERNAL_SERVICE_ERROR",
+        message: "LLM provider service error",
+      });
+      assertEquals(JSON.stringify(err).includes("<TOKEN>"), false);
     });
 
     it("uses the response status when the body is empty", async () => {

--- a/src/provider/runtime-loader/provider-http.ts
+++ b/src/provider/runtime-loader/provider-http.ts
@@ -23,6 +23,11 @@ export class ProviderError extends Error {
   readonly status: number;
   readonly retryable: boolean;
   readonly retryAfterMs?: number;
+  /**
+   * Bounded structured provider response used by the internal error classifier.
+   * Kept non-enumerable so logs and JSON serialization retain the generic error.
+   */
+  declare readonly responseBody?: string;
 
   constructor(options: {
     provider: ProviderKind;
@@ -53,6 +58,19 @@ export class ProviderQuotaError extends ProviderError {}
 
 /** Non-retryable 4xx/5xx that doesn't fit another bucket. */
 export class ProviderRequestError extends ProviderError {}
+
+function preserveStructuredResponseBody<T extends ProviderError>(
+  error: T,
+  responseBody: string,
+): T {
+  Object.defineProperty(error, "responseBody", {
+    value: responseBody,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return error;
+}
 
 /** Parses retry after ms. */
 export function parseRetryAfterMs(header: string | null): number | undefined {
@@ -96,10 +114,11 @@ export async function buildProviderError(
     }
   })();
   const errorRecord = readRecord(parsedBody?.error);
+  const errorType = typeof errorRecord?.type === "string" ? errorRecord.type : undefined;
   const errorCode = typeof errorRecord?.code === "string"
     ? errorRecord.code
-    : typeof errorRecord?.type === "string"
-    ? errorRecord.type
+    : errorType !== undefined
+    ? errorType
     : typeof errorRecord?.status === "string"
     ? errorRecord.status
     : undefined;
@@ -208,12 +227,21 @@ export async function buildProviderError(
     });
   }
 
-  return new ProviderRequestError({
+  const requestError = new ProviderRequestError({
     provider,
     status,
     message,
     retryable: false,
   });
+
+  const isStructuredInvalidRequest = status === 400 &&
+    errorType === "invalid_request_error" &&
+    parsedBody !== undefined &&
+    !truncated;
+
+  return isStructuredInvalidRequest
+    ? preserveStructuredResponseBody(requestError, rawBody)
+    : requestError;
 }
 
 /** Request and parse a JSON response. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1116";
+export const VERSION = "0.1.1117";


### PR DESCRIPTION
## Summary

- Preserves provider validation context for bounded, non-truncated 400 `invalid_request_error` response bodies without exposing arbitrary provider payloads through enumerable errors or logs.
- Keeps `responseBody` non-enumerable and fails closed for truncated or provider-generic payloads.
- Fixes the review regression where a specific nested `error.code` such as `context_length_exceeded` could mask `error.type = invalid_request_error` and prevent validation context preservation.
- Bumps `veryfront-code` to `0.1.1117` in `deno.json` and `src/utils/version-constant.ts` so this PR creates its own release after #3039.

## Base / Merge Order

#3039 has merged to `main` at `79db333a4` and released `0.1.1116`. #3040 now targets `main` directly and carries only the provider-error fix plus the `0.1.1117` version bump.

Current PR diff against `main` is limited to:
- `deno.json`
- `src/provider/runtime-loader/provider-http.ts`
- `src/provider/runtime-loader/provider-http.test.ts`
- `src/utils/version-constant.ts`

## Validation

- Focused provider/chat/version tests, including the `error.code` masking regression: `34` focused steps passed
- `deno test --no-check --allow-all src/chat/provider-errors.test.ts src/provider/runtime-loader/provider-http.test.ts src/provider/runtime-loader/stream-terminal-error.test.ts src/utils/version.test.ts`
- `deno task verify:quick`
- Pre-push gate after rebasing onto `main`: format, lint, type check, and full unit suite: `2626 passed / 0 failed`
- `deno run -A scripts/release.ts 0.1.1117 --dry-run --no-test --no-build --no-publish --yes`