### PR TITLE
Stop advertising empty skill reference reloads

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1117",
+  "version": "0.1.1118",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.lock
+++ b/deno.lock
@@ -3,12 +3,8 @@
   "specifiers": {
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/assert@^1.0.17": "1.0.19",
-    "jsr:@std/assert@^1.0.19": "1.0.19",
-    "jsr:@std/async@^1.1.0": "1.2.0",
     "jsr:@std/cli@1.0.28": "1.0.28",
-    "jsr:@std/data-structures@^1.0.10": "1.0.11",
     "jsr:@std/dotenv@0.225.6": "0.225.6",
-    "jsr:@std/expect@1.0.18": "1.0.18",
     "jsr:@std/fmt@1.0.9": "1.0.9",
     "jsr:@std/fs@1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.14",
@@ -38,6 +34,7 @@
     "npm:@opentelemetry/sdk-logs@0.220.0": "0.220.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/sdk-metrics@2.9.0": "2.9.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/sdk-node@0.220.0": "0.220.0_@opentelemetry+api@1.9.1",
+    "npm:@opentelemetry/sdk-trace-base@2.8.0": "2.8.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/sdk-trace-base@2.9.0": "2.9.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/semantic-conventions@1.43.0": "1.43.0",
     "npm:@redis/client@1.5.8": "1.5.8",
@@ -46,7 +43,7 @@
     "npm:@types/mdast@4.0.3": "4.0.3",
     "npm:@types/node@*": "24.2.0",
     "npm:@types/unist@3.0.2": "3.0.2",
-    "npm:bash-tool@1.3.16": "1.3.16_ai@6.0.219__zod@3.25.76_just-bash@2.14.5",
+    "npm:bash-tool@1.3.16": "1.3.16_ai@6.0.232__zod@3.25.76_just-bash@2.14.5",
     "npm:better-sqlite3@9.6.0": "9.6.0",
     "npm:es-module-lexer@2.0.0": "2.0.0",
     "npm:esbuild@0.28.1": "0.28.1",
@@ -83,25 +80,11 @@
         "jsr:@std/internal"
       ]
     },
-    "@std/async@1.2.0": {
-      "integrity": "c059c6f6d95ca7cc012ae8e8d7164d1697113d54b0b679e4372b354b11c2dee5"
-    },
     "@std/cli@1.0.28": {
       "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a"
     },
-    "@std/data-structures@1.0.11": {
-      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
-    },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
-    },
-    "@std/expect@1.0.18": {
-      "integrity": "8566eab35200466f8609eb7e7aed062ed0db314e9a258d5d201b1b8997ce801a",
-      "dependencies": [
-        "jsr:@std/assert@^1.0.19",
-        "jsr:@std/internal",
-        "jsr:@std/path@^1.1.4"
-      ]
     },
     "@std/fmt@1.0.9": {
       "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
@@ -126,8 +109,6 @@
       "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
       "dependencies": [
         "jsr:@std/assert@^1.0.17",
-        "jsr:@std/async",
-        "jsr:@std/data-structures",
         "jsr:@std/internal"
       ]
     },
@@ -139,8 +120,8 @@
     "@acemir/cssom@0.9.31": {
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="
     },
-    "@ai-sdk/gateway@3.0.143_zod@3.25.76": {
-      "integrity": "sha512-RCH60KsUaNiZkI/fBuyau4yvYrVBIEgAcN+Ain94QpL1kVm28GduQzFKfGffAiJU2We0ZrmN4BHkoCZzACK96Q==",
+    "@ai-sdk/gateway@3.0.154_zod@3.25.76": {
+      "integrity": "sha512-pKJmMnTxdTOfo+iz7pCAgmnMt4uan2yIw8nChFVIk3yYBeX2A9p2MCGyP8jZ1zpqSYXBmczQZU7Pjvlj1aLbIQ==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -148,8 +129,8 @@
         "zod@3.25.76"
       ]
     },
-    "@ai-sdk/provider-utils@4.0.35_zod@3.25.76": {
-      "integrity": "sha512-bjYld/2KGPLt78kpqbya+fD4LYS7BqVQJyUjE3qAHrYB0FR2Q90BaWEVIBZaguTWXf/A8L6uG1zO1v9TxVlGWg==",
+    "@ai-sdk/provider-utils@4.0.40_zod@3.25.76": {
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
       "dependencies": [
         "@ai-sdk/provider",
         "@standard-schema/spec",
@@ -157,8 +138,8 @@
         "zod@3.25.76"
       ]
     },
-    "@ai-sdk/provider@3.0.13": {
-      "integrity": "sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==",
+    "@ai-sdk/provider@3.0.14": {
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
       "dependencies": [
         "json-schema"
       ]
@@ -778,8 +759,8 @@
       ],
       "scripts": true
     },
-    "@nodable/entities@2.2.0": {
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="
+    "@nodable/entities@3.0.0": {
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="
     },
     "@nodelib/fs.scandir@2.1.5": {
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
@@ -817,7 +798,7 @@
       "integrity": "sha512-xbfBSlToc6Svrl1rnFdqU990XeUWZJ2IfcCXMRzGtcWpy8h19NoO9EFpXn9lB3NWtJchPb7BVeEhY4+b+fUuFg==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/instrumentation-amqplib",
         "@opentelemetry/instrumentation-aws-lambda",
@@ -865,7 +846,7 @@
         "@opentelemetry/resource-detector-azure",
         "@opentelemetry/resource-detector-container",
         "@opentelemetry/resource-detector-gcp",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-node"
       ]
     },
@@ -873,7 +854,7 @@
       "integrity": "sha512-glfIVKnZevRin8fY/9uES/mhRtMT1lGINLHc9MIo5fTQZXswEEHamJtgjv4MTtzgnhHGC92mIS/0lzAUZMyE0w==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "yaml"
       ]
     },
@@ -881,6 +862,13 @@
       "integrity": "sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==",
       "dependencies": [
         "@opentelemetry/api"
+      ]
+    },
+    "@opentelemetry/core@2.8.0_@opentelemetry+api@1.9.1": {
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/semantic-conventions"
       ]
     },
     "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1": {
@@ -895,7 +883,7 @@
       "dependencies": [
         "@grpc/grpc-js",
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-grpc-exporter-base",
         "@opentelemetry/otlp-transformer",
@@ -907,7 +895,7 @@
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/api-logs@0.220.0",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-transformer",
         "@opentelemetry/sdk-logs"
@@ -927,12 +915,12 @@
       "dependencies": [
         "@grpc/grpc-js",
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/exporter-metrics-otlp-http",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-grpc-exporter-base",
         "@opentelemetry/otlp-transformer",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-metrics"
       ]
     },
@@ -940,10 +928,10 @@
       "integrity": "sha512-Yqt3RBw/bRVncaE9qIIhk4WfjbAQqXuP9FgAaU+IKPndnLEp/cUqZlSC324+bpmduRz7DoTjig8Ub0PeILWXUA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-transformer",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-metrics"
       ]
     },
@@ -951,11 +939,11 @@
       "integrity": "sha512-lyO+IQBdSvqHN/ZOW/OzrSWemtfD+HgWngn+HBNLhjy0YrCQQTz0OE/kSekH2Pl340dn9DWzhqHdz5Eftr+HLA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/exporter-metrics-otlp-http",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-transformer",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-metrics"
       ]
     },
@@ -963,8 +951,8 @@
       "integrity": "sha512-JZD5DL/NBpVd2BHefvYosm3G40UZ/KzExLv5tc0eZe0CtrsHHtcOk3YPUxR2EINmUeBf8+w5UReTV8fFPn95lA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-metrics",
         "@opentelemetry/semantic-conventions"
       ]
@@ -984,10 +972,10 @@
       "integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-transformer",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-trace"
       ]
     },
@@ -995,10 +983,10 @@
       "integrity": "sha512-voTAD8XgJxlK7zLkXh8EzMB09zrQr3tyY/BsnDTlDiQU/UdK58MZ63A3mUjdEDrxMjCVmBHU3WQJhRmQe+Dvzg==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-transformer",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-trace"
       ]
     },
@@ -1006,8 +994,8 @@
       "integrity": "sha512-RwINoce2BH8T4obT5pMcAla2sWma1YZvYuaktWmTluQ0PkQdvv5D060rWI1+kawX+J2qBRcMbwrZJJNcMJUauQ==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-trace",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1016,7 +1004,7 @@
       "integrity": "sha512-e67iWHIDEJ34eO8Dm11fZ8vhELWeLtW09ghV76dnFSN02QiuxjzP9PJO7+ZPnmqbVps7wxIwdEhQaf75wOR2kQ==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1035,7 +1023,7 @@
       "integrity": "sha512-RLosRcyIojBDzX6uPcooDlpJH5UFzbOZXwLp4NKl2FHy0UgmMfQU+mmul12wEohKTDiGumWouw43yRF69NAfbQ==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1062,7 +1050,7 @@
       "integrity": "sha512-Lg13vVEtZe2yvOyLr61qJHSiD1p0+CTMZhV7mlcRuVABPrfrWuqeEKamsZW0r04DP6LOoVZAvIb3iU7DV4/nEA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions",
         "@types/connect"
@@ -1094,7 +1082,7 @@
       "integrity": "sha512-3ffjIQUFNVP94lLLHlBEgNaomCoP0BLH36Gxmkk3/WKX+1530QKVAnZTleYdM3RVU2EeQFtWSmFMAyCLglqO3w==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1103,7 +1091,7 @@
       "integrity": "sha512-y7xVCHIy1xDIx5X3N1jr/JLHNw57aa3pLAWwmYbvyFJGtQeac/GP7ykwY10QwCFukXvrrxyOYPpMXeICduZzgw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation"
       ]
     },
@@ -1133,7 +1121,7 @@
       "integrity": "sha512-M3ZTzsFwPcb2mL+skodr94WJ0hMmpkqCb9k3kvZ2THzf+cxBsWYl/gjHZhjfuminKSh5x5gX2A+IeA3lJP4NVA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1150,7 +1138,7 @@
       "integrity": "sha512-Szt4dO2Boz2CDr38DaSw/lnqwhwKl+IAdgNGEGgSm2Anb+fwPtIAGmIwkhsLLN69QQZQE96JxjMKYY4rlRkYKw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions",
         "forwarded-parse"
@@ -1185,7 +1173,7 @@
       "integrity": "sha512-qem1LDEnrIq8BV+NwxTMy/AGZ4d4kT8Y5xQzJ56ogkhbChzdRKG+hof8taW7bOncNdbu26E17nh2RYuRvpI8sQ==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1218,7 +1206,7 @@
       "integrity": "sha512-CxzRijJCexHnucPDuKSz1PTJf6+t0VJxFDNQtoCwSPo8eGXKoEuJ/I4V2kMQjMbcY4qISN3Efa+7TL5Zy6zqTA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1279,7 +1267,7 @@
       "integrity": "sha512-p9xrFc/6R8t6Y293sTYLZ83LnzZo/qY0bBPA4xabdQt0Qjt8i1SlYFsIeGY2Jmf5WcESNUdjQB3NxWnt5Ox7zw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions",
         "@opentelemetry/sql-common",
@@ -1292,7 +1280,7 @@
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/api-logs@0.220.0",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1310,7 +1298,7 @@
       "integrity": "sha512-vdgtqK+uVf66FTjR6eVrveORtG7Jz5+Tlc4SvWCmtc1/2DYZ+IQuWQ9HPMJcFpcPkRXfiN1QNvZDPIe1Mlvopw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1328,7 +1316,7 @@
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/api-logs@0.220.0",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation"
       ]
     },
@@ -1352,7 +1340,7 @@
       "integrity": "sha512-VgxMzeR14uPEVqEC5b55m4KijEe+gQAgJ4jjWCE7h5i2Q76nS4y7OWDk8V+XkD4zK9bbJyWEK+a2DqtGP/fCuw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1378,7 +1366,7 @@
       "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/otlp-transformer"
       ]
     },
@@ -1387,7 +1375,7 @@
       "dependencies": [
         "@grpc/grpc-js",
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-transformer"
       ]
@@ -1397,8 +1385,8 @@
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/api-logs@0.220.0",
-        "@opentelemetry/core",
-        "@opentelemetry/resources",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-logs",
         "@opentelemetry/sdk-metrics",
         "@opentelemetry/sdk-trace"
@@ -1414,14 +1402,14 @@
       "integrity": "sha512-WrOT1WsOUG+B7hstD2RYoMPIOK76G8E9AQHhMjUvrQaGx/oA7rPWQvvr1Rqv7+yy4R0ZMVwWLC4vW2xnkgWPAQ==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core"
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1"
       ]
     },
     "@opentelemetry/propagator-jaeger@2.9.0_@opentelemetry+api@1.9.1": {
       "integrity": "sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core"
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1"
       ]
     },
     "@opentelemetry/redis-common@0.38.3": {
@@ -1431,16 +1419,16 @@
       "integrity": "sha512-IACBakM0z30CsASN6VSrpZi89+Ot4ZUerW8+6CdBFhdAZO+XGh0m4LigN6lh4yzUaqqva/SmH9yHeFfuctIY/A==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources"
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1"
       ]
     },
     "@opentelemetry/resource-detector-aws@2.20.0_@opentelemetry+api@1.9.1": {
       "integrity": "sha512-3ZkhvVHqJgJ75ObpZQwZIBySNfd4h772QRb2NBPU1A3lSUzDlRen9x5Kzv/K7HNkL/Azl8XEanykwa73YjWmQA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/semantic-conventions"
       ]
     },
@@ -1448,8 +1436,8 @@
       "integrity": "sha512-YMMgH/ZIiZgy2CHTHjOBNEYhcsi/l67Q272vAgwMqegRFIME4KljDhmTmjLGzjE3b0sErLtXBqF8Y/3bKn89+Q==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/semantic-conventions"
       ]
     },
@@ -1457,24 +1445,32 @@
       "integrity": "sha512-O7dMPH13+JZu+swtCsdq5702Fa2Q4MSHmwMoLxyqgWuPPtmDmao4s+V1ovfg225zW67quNDXFKdLf1q5/Elb9w==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources"
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1"
       ]
     },
     "@opentelemetry/resource-detector-gcp@0.55.0_@opentelemetry+api@1.9.1": {
       "integrity": "sha512-uWU27lJcTbeXDY+uWEapsIyMx8mKi14/IGvUY1DkmMmLQnKRibnbpZEsRVeWBPdjOWSjH9LfWTXp9yDcBHZOeg==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "gcp-metadata"
+      ]
+    },
+    "@opentelemetry/resources@2.8.0_@opentelemetry+api@1.9.1": {
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core@2.8.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/semantic-conventions"
       ]
     },
     "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1": {
       "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/semantic-conventions"
       ]
     },
@@ -1483,8 +1479,8 @@
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/api-logs@0.220.0",
-        "@opentelemetry/core",
-        "@opentelemetry/resources",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/semantic-conventions"
       ]
     },
@@ -1492,8 +1488,8 @@
       "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources"
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1"
       ]
     },
     "@opentelemetry/sdk-node@0.220.0_@opentelemetry+api@1.9.1": {
@@ -1503,7 +1499,7 @@
         "@opentelemetry/api-logs@0.220.0",
         "@opentelemetry/configuration",
         "@opentelemetry/context-async-hooks",
-        "@opentelemetry/core",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/exporter-logs-otlp-grpc",
         "@opentelemetry/exporter-logs-otlp-http",
         "@opentelemetry/exporter-logs-otlp-proto",
@@ -1520,12 +1516,21 @@
         "@opentelemetry/otlp-grpc-exporter-base",
         "@opentelemetry/propagator-b3",
         "@opentelemetry/propagator-jaeger",
-        "@opentelemetry/resources",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-logs",
         "@opentelemetry/sdk-metrics",
         "@opentelemetry/sdk-trace",
-        "@opentelemetry/sdk-trace-base",
+        "@opentelemetry/sdk-trace-base@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-trace-node",
+        "@opentelemetry/semantic-conventions"
+      ]
+    },
+    "@opentelemetry/sdk-trace-base@2.8.0_@opentelemetry+api@1.9.1": {
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core@2.8.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.8.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/semantic-conventions"
       ]
     },
@@ -1533,8 +1538,8 @@
       "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/sdk-trace",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1544,16 +1549,16 @@
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/context-async-hooks",
-        "@opentelemetry/core",
-        "@opentelemetry/sdk-trace-base"
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/sdk-trace-base@2.9.0_@opentelemetry+api@1.9.1"
       ]
     },
     "@opentelemetry/sdk-trace@2.9.0_@opentelemetry+api@1.9.1": {
       "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core",
-        "@opentelemetry/resources",
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
+        "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/semantic-conventions"
       ]
     },
@@ -1564,7 +1569,7 @@
       "integrity": "sha512-nwUwUU+8O8a4bnLqk6CodWeegGMEANgC94KTAhXcpGWLrW/2/hek/0ajNbjXnSOoNuCX+nteUPs46HFHhou9Xw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/core"
+        "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1"
       ]
     },
     "@pdf-lib/standard-fonts@1.0.0": {
@@ -1776,8 +1781,8 @@
     "@types/unist@3.0.2": {
       "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
     },
-    "@ungap/structured-clone@1.3.2": {
-      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="
+    "@ungap/structured-clone@1.3.3": {
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="
     },
     "@vercel/oidc@3.2.0": {
       "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="
@@ -1807,8 +1812,8 @@
     "agent-base@7.1.4": {
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
     },
-    "ai@6.0.219_zod@3.25.76": {
-      "integrity": "sha512-rtTDz99Rc9HsstSJ7YdO8DX7DQwS442N2vQ5jOopXDdo4qfkLrtIRpORdztFMOZxX/XjBzHRlvqF6eMg3cpyLA==",
+    "ai@6.0.232_zod@3.25.76": {
+      "integrity": "sha512-Ml5Kys8d6TqPq+5dxwGXJYQrW0/k9vzu9Z4Tr8NS0A7pzlJCKLpKMYIUHvCmG96GGrZ8zn9cxoFE29gPCU3cqQ==",
       "dependencies": [
         "@ai-sdk/gateway",
         "@ai-sdk/provider",
@@ -1851,7 +1856,7 @@
     "base64-js@1.5.1": {
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
-    "bash-tool@1.3.16_ai@6.0.219__zod@3.25.76_just-bash@2.14.5": {
+    "bash-tool@1.3.16_ai@6.0.232__zod@3.25.76_just-bash@2.14.5": {
       "integrity": "sha512-2xuprVBzUOYw4+QCpeSwvkuXuHkjKRtMzh+nTpEidROsNnglr5xRs3mdeOmwFVkjB4JhE/uZqIXE+tabbJI7QQ==",
       "dependencies": [
         "ai",
@@ -2236,15 +2241,15 @@
         "micromatch"
       ]
     },
-    "fast-xml-builder@1.2.1": {
-      "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
+    "fast-xml-builder@1.3.0": {
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "dependencies": [
         "path-expression-matcher",
         "xml-naming"
       ]
     },
-    "fast-xml-parser@5.9.3": {
-      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+    "fast-xml-parser@5.10.1": {
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
       "dependencies": [
         "@nodable/entities",
         "fast-xml-builder",
@@ -2592,8 +2597,8 @@
     "immediate@3.0.6": {
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
-    "import-in-the-middle@3.3.1": {
-      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+    "import-in-the-middle@3.3.2": {
+      "integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
       "dependencies": [
         "cjs-module-lexer",
         "es-module-lexer@2.3.1",
@@ -2652,8 +2657,8 @@
     "is-potential-custom-element-name@1.0.1": {
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
-    "is-unsafe@1.0.1": {
-      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA=="
+    "is-unsafe@2.0.0": {
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="
     },
     "isarray@1.0.0": {
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
@@ -3359,8 +3364,8 @@
     "mkdirp-classic@0.5.3": {
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
-    "modern-tar@0.7.6": {
-      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="
+    "modern-tar@0.7.7": {
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ=="
     },
     "module-details-from-path@1.0.4": {
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="
@@ -3474,8 +3479,8 @@
         "entities@8.0.0"
       ]
     },
-    "path-expression-matcher@1.6.1": {
-      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ=="
+    "path-expression-matcher@1.6.2": {
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="
     },
     "path-key@3.1.1": {
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
@@ -4041,8 +4046,8 @@
     "symbol-tree@3.2.4": {
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "systeminformation@5.32.0": {
-      "integrity": "sha512-7gfXs43T91miPxxTTtrYitotR/8MPsI2gy3XgUMs6kmOE/JCVqZp6nJpx4XkSutoSqDh6+Y2ovvb2A3RQCR+8w==",
+    "systeminformation@5.33.0": {
+      "integrity": "sha512-0LYSL01CCbjVeJG7iXI8fUCFU76zMjzbHd/EU3or4QpSFYCLMgslR11prwHuA3siz5jmOkqoLhjgOyDRmXBKmA==",
       "os": ["darwin", "linux", "win32", "freebsd", "openbsd", "netbsd", "sunos", "android"],
       "bin": true
     },
@@ -4296,8 +4301,8 @@
     "xml-name-validator@5.0.0": {
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
     },
-    "xml-naming@0.1.0": {
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="
+    "xml-naming@0.3.0": {
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="
     },
     "xmlchars@2.2.0": {
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -251,6 +251,7 @@ Deno.test("createRuntimeLoadSkillTool schema disallows body reloads for already-
         skillId: "veryfront",
         instructions: "# Veryfront",
         nextStep: "Continue.",
+        references: ["references/create-agent.md"],
       },
     },
   });
@@ -368,6 +369,7 @@ Deno.test("createRuntimeLoadSkillTool schema only permits reference loads when a
         skillId: "veryfront",
         instructions: "# Veryfront",
         nextStep: "Continue.",
+        references: ["references/create-agent.md"],
       },
     },
   });
@@ -395,6 +397,167 @@ Deno.test("createRuntimeLoadSkillTool schema only permits reference loads when a
     },
     required: ["skillId", "file"],
   });
+});
+
+Deno.test("createRuntimeLoadSkillTool exposes a no-file no-op schema after loading a skill without references", async () => {
+  const context = createProjectContext({
+    availableSkillIds: ["veryfront"],
+  });
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({
+      skills: new Map([
+        ["veryfront", {
+          skillId: "veryfront",
+          instructions: "# Veryfront",
+          references: [],
+        }],
+      ]),
+    }),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  await tool.execute({ skillId: "veryfront" });
+  const [loadedResponse] = Object.values(context.loadedSkillResponses ?? {});
+  if (loadedResponse) {
+    delete loadedResponse.references;
+  }
+
+  assertEquals(toolToProviderDefinition(tool).parameters, {
+    type: "object",
+    properties: {
+      skillId: {
+        type: "string",
+        enum: ["veryfront"],
+        description:
+          "Already-loaded skill ID with no advertised reference files. Calling load_skill again is a no-op. Loaded skill IDs: veryfront",
+      },
+    },
+    required: ["skillId"],
+  });
+
+  const reloadResult = expectLoadedSkillResponse(await tool.execute({ skillId: "veryfront" }));
+  assertStringIncludes(reloadResult.instructions, 'Skill "veryfront" is already loaded');
+});
+
+Deno.test("createRuntimeLoadSkillTool exposes only referenceable skills when every skill is loaded", async () => {
+  const context = createProjectContext({
+    availableSkillIds: ["plain", "with-reference"],
+  });
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({
+      skills: new Map([
+        ["plain", { instructions: "# Plain", references: [] }],
+        ["with-reference", {
+          instructions: "# With reference",
+          references: ["references/guide.md"],
+        }],
+      ]),
+    }),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  await tool.execute({ skillId: "plain" });
+  await tool.execute({ skillId: "with-reference" });
+
+  assertEquals(toolToProviderDefinition(tool).parameters, {
+    type: "object",
+    properties: {
+      skillId: {
+        type: "string",
+        enum: ["with-reference"],
+        description:
+          "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: with-reference",
+      },
+      file: {
+        type: "string",
+        description:
+          "Required reference file to load from an already-loaded skill. Do not call load_skill again for the skill body.",
+      },
+    },
+    required: ["skillId", "file"],
+  });
+});
+
+Deno.test("createRuntimeLoadSkillTool omits loaded skills without references from productive schema branches", async () => {
+  const context = createProjectContext({
+    availableSkillIds: ["create", "plain", "with-reference"],
+  });
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({
+      skills: new Map([
+        ["create", { instructions: "# Create", references: [] }],
+        ["plain", { instructions: "# Plain", references: [] }],
+        ["with-reference", {
+          instructions: "# With reference",
+          references: ["references/guide.md"],
+        }],
+      ]),
+      references: new Map([
+        ["with-reference/references/guide.md", "reference content"],
+      ]),
+    }),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  await tool.execute({ skillId: "plain" });
+  await tool.execute({ skillId: "with-reference" });
+
+  assertEquals(tool.inputSchemaJson, {
+    anyOf: [
+      {
+        type: "object",
+        properties: {
+          skillId: {
+            type: "string",
+            enum: ["create"],
+            description: "Unloaded skill ID to load. Available unloaded skill IDs: create",
+          },
+          file: {
+            type: "string",
+            description:
+              "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
+          },
+        },
+        required: ["skillId"],
+      },
+      {
+        type: "object",
+        properties: {
+          skillId: {
+            type: "string",
+            enum: ["with-reference"],
+            description:
+              "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: with-reference",
+          },
+          file: {
+            type: "string",
+            description:
+              "Required reference file to load from an already-loaded skill. Do not call load_skill again for the skill body.",
+          },
+        },
+        required: ["skillId", "file"],
+      },
+    ],
+  });
+
+  assertEquals(
+    await tool.execute({ skillId: "with-reference", file: "references/guide.md" }),
+    {
+      skillId: "with-reference",
+      file: "references/guide.md",
+      content: "reference content",
+    },
+  );
+  assertEquals(
+    expectLoadedSkillResponse(await tool.execute({ skillId: "create" })).instructions,
+    "# Create",
+  );
 });
 
 Deno.test("createRuntimeLoadSkillTool schema ignores stale loaded skills outside the current manifest", async () => {

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -327,7 +327,7 @@ Deno.test("createRuntimeLoadSkillTool refreshes its provider schema after a skil
       skillId: {
         type: "string",
         enum: ["veryfront"],
-        description: "The skill ID to load. Available skill IDs: veryfront",
+        description: "Unloaded skill ID to load. Available unloaded skill IDs: veryfront",
       },
       file: {
         type: "string",
@@ -426,6 +426,7 @@ Deno.test("createRuntimeLoadSkillTool exposes a no-file no-op schema after loadi
 
   assertEquals(toolToProviderDefinition(tool).parameters, {
     type: "object",
+    additionalProperties: false,
     properties: {
       skillId: {
         type: "string",
@@ -439,6 +440,14 @@ Deno.test("createRuntimeLoadSkillTool exposes a no-file no-op schema after loadi
 
   const reloadResult = expectLoadedSkillResponse(await tool.execute({ skillId: "veryfront" }));
   assertStringIncludes(reloadResult.instructions, 'Skill "veryfront" is already loaded');
+  let rejectedUnexpectedFile = false;
+  try {
+    await tool.execute({ skillId: "veryfront", file: "references/foo.md" });
+  } catch (error) {
+    rejectedUnexpectedFile = true;
+    assertStringIncludes(String(error), "input validation failed");
+  }
+  assertEquals(rejectedUnexpectedFile, true);
 });
 
 Deno.test("createRuntimeLoadSkillTool exposes only referenceable skills when every skill is loaded", async () => {
@@ -584,7 +593,7 @@ Deno.test("createRuntimeLoadSkillTool schema ignores stale loaded skills outside
       skillId: {
         type: "string",
         enum: ["veryfront"],
-        description: "The skill ID to load. Available skill IDs: veryfront",
+        description: "Unloaded skill ID to load. Available unloaded skill IDs: veryfront",
       },
       file: {
         type: "string",

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -374,7 +374,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
             loadedIds.join(", ")
           }`,
         ),
-      })
+      }).strict()
     )();
   }
 
@@ -429,7 +429,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
   return defineSchema((v) =>
     v.object({
       skillId: v.enum(enumValues).describe(
-        `The skill ID to load. Available skill IDs: ${unloadedIds.join(", ")}`,
+        `Unloaded skill ID to load. Available unloaded skill IDs: ${unloadedIds.join(", ")}`,
       ),
       file: v.string().optional().describe(
         "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
@@ -519,7 +519,9 @@ export function createRuntimeLoadSkillTool(
   async function execute({ skillId, file }: RuntimeLoadSkillToolInput) {
     let parsed: RuntimeLoadSkillToolInput;
     try {
-      parsed = buildRuntimeLoadSkillInputSchema(options).parse({ skillId, file });
+      parsed = buildRuntimeLoadSkillInputSchema(options).parse(
+        file === undefined ? { skillId } : { skillId, file },
+      );
     } catch (error) {
       throw INPUT_VALIDATION_FAILED.create({
         detail: `Tool "load_skill" input validation failed: ${

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -336,6 +336,19 @@ function getLoadedRuntimeSkillIds(options: RuntimeLoadSkillToolOptions): string[
   ].sort();
 }
 
+function getReferenceableLoadedRuntimeSkillIds(
+  options: RuntimeLoadSkillToolOptions,
+): string[] {
+  return [
+    ...new Set(
+      Object.values(options.context.loadedSkillResponses ?? {})
+        .filter((response) => (response.references?.length ?? 0) > 0)
+        .map((response) => response.skillId)
+        .filter((skillId): skillId is string => typeof skillId === "string" && skillId.length > 0),
+    ),
+  ].sort();
+}
+
 function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) {
   const knownIds = getKnownRuntimeSkillIds(options);
   if (!knownIds || knownIds.length === 0) {
@@ -345,16 +358,34 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
   const knownIdSet = new Set(knownIds);
   const loadedIds = getLoadedRuntimeSkillIds(options).filter((skillId) => knownIdSet.has(skillId));
   const loadedIdSet = new Set(loadedIds);
+  const referenceableLoadedIds = getReferenceableLoadedRuntimeSkillIds(options)
+    .filter((skillId) => knownIdSet.has(skillId));
   const unloadedIds = knownIds.filter((skillId) => !loadedIdSet.has(skillId));
 
-  if (loadedIds.length > 0 && unloadedIds.length === 0) {
+  if (
+    loadedIds.length > 0 && unloadedIds.length === 0 && referenceableLoadedIds.length === 0
+  ) {
     const [firstLoaded, ...restLoaded] = loadedIds as [string, ...string[]];
     const loadedEnumValues = [firstLoaded, ...restLoaded] as [string, ...string[]];
     return defineSchema((v) =>
       v.object({
         skillId: v.enum(loadedEnumValues).describe(
-          `Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: ${
+          `Already-loaded skill ID with no advertised reference files. Calling load_skill again is a no-op. Loaded skill IDs: ${
             loadedIds.join(", ")
+          }`,
+        ),
+      })
+    )();
+  }
+
+  if (referenceableLoadedIds.length > 0 && unloadedIds.length === 0) {
+    const [firstLoaded, ...restLoaded] = referenceableLoadedIds as [string, ...string[]];
+    const loadedEnumValues = [firstLoaded, ...restLoaded] as [string, ...string[]];
+    return defineSchema((v) =>
+      v.object({
+        skillId: v.enum(loadedEnumValues).describe(
+          `Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: ${
+            referenceableLoadedIds.join(", ")
           }`,
         ),
         file: v.string().describe(
@@ -364,10 +395,10 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
     )();
   }
 
-  if (loadedIds.length > 0) {
+  if (referenceableLoadedIds.length > 0) {
     const [firstUnloaded, ...restUnloaded] = unloadedIds as [string, ...string[]];
     const unloadedEnumValues = [firstUnloaded, ...restUnloaded] as [string, ...string[]];
-    const [firstLoaded, ...restLoaded] = loadedIds as [string, ...string[]];
+    const [firstLoaded, ...restLoaded] = referenceableLoadedIds as [string, ...string[]];
     const loadedEnumValues = [firstLoaded, ...restLoaded] as [string, ...string[]];
     return defineSchema((v) =>
       v.union([
@@ -382,7 +413,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
         v.object({
           skillId: v.enum(loadedEnumValues).describe(
             `Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: ${
-              loadedIds.join(", ")
+              referenceableLoadedIds.join(", ")
             }`,
           ),
           file: v.string().describe(
@@ -393,12 +424,12 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
     )();
   }
 
-  const [first, ...rest] = knownIds as [string, ...string[]];
+  const [first, ...rest] = unloadedIds as [string, ...string[]];
   const enumValues = [first, ...rest] as [string, ...string[]];
   return defineSchema((v) =>
     v.object({
       skillId: v.enum(enumValues).describe(
-        `The skill ID to load. Available skill IDs: ${knownIds.join(", ")}`,
+        `The skill ID to load. Available skill IDs: ${unloadedIds.join(", ")}`,
       ),
       file: v.string().optional().describe(
         "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1117";
+export const VERSION = "0.1.1118";


### PR DESCRIPTION
## Summary
- Hide already-loaded skills without advertised references from productive reference-load schema branches.
- Keep referenceable loaded skills available for required file loads.
- Preserve the 0.1.1118 version patch in deno.json and VERSION.

## Verification
- deno test src/agent/runtime/load-skill-tool.test.ts
- deno task verify:quick
- pre-push hook: formatting, lint, typecheck, and deno task test:unit (2,629 tests passed)
