### PR TITLE
fix(eval): compare strict JSON agent answers semantically

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1118",
+  "version": "0.1.1119",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -282,6 +282,8 @@ metrics.answer.regex({ pattern: "Paris|paris" }).gate();
 metrics.answer.jsonMatch({ expected: { city: "Paris" } }).gate();
 ```
 
+`jsonMatch` compares JSON values, so object key order and insignificant whitespace do not affect the result. Agent text outputs and their string references are parsed only when the entire string is valid JSON; Markdown fences and surrounding prose are not accepted. Direct tool outputs are already values and are compared without reparsing.
+
 Use agent and operational metrics for tool and budget quality:
 
 ```ts

--- a/src/eval/metrics.test.ts
+++ b/src/eval/metrics.test.ts
@@ -43,6 +43,117 @@ describe("eval/metrics", () => {
     );
   });
 
+  it("matches strict JSON emitted as agent text", async () => {
+    const jsonMatch = metrics.answer.jsonMatch().gate();
+    const reference = {
+      claimed_elsewhere: 2,
+      failed: 0,
+      succeeded: 1,
+    };
+
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: {
+          text: '{"succeeded":1,"claimed_elsewhere":2,"failed":0}',
+        },
+        reference,
+      }))).pass,
+      true,
+    );
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: { text: JSON.stringify(reference, null, 2) },
+        reference,
+      }))).pass,
+      true,
+    );
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: {
+          text: '{"succeeded":1,"claimed_elsewhere":2,"failed":0}',
+        },
+        reference: JSON.stringify(reference),
+      }))).pass,
+      true,
+    );
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: { text: '"not-json"' },
+        reference: "not-json",
+      }))).pass,
+      true,
+    );
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: {
+          text: '```json\n{"succeeded":1,"claimed_elsewhere":2,"failed":0}\n```',
+        },
+        reference,
+      }))).pass,
+      false,
+    );
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: {
+          text: 'Result: {"succeeded":1,"claimed_elsewhere":2,"failed":0}',
+        },
+        reference,
+      }))).pass,
+      false,
+    );
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: { text: "not-json" },
+        reference: "not-json",
+      }))).pass,
+      false,
+    );
+
+    const explicitString = metrics.answer.jsonMatch({ expected: "null" }).gate();
+    assertEquals(
+      (await explicitString.evaluate(createRecord({ output: { json: "null" } }))).pass,
+      true,
+    );
+
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: "not-json",
+        reference: "not-json",
+      }))).pass,
+      true,
+    );
+  });
+
+  it("ignores inherited json adapter values", async () => {
+    const jsonMatch = metrics.answer.jsonMatch({ expected: { status: "ok" } }).gate();
+    const output = Object.assign(
+      Object.create({ json: { status: "ok" } }) as Record<string, unknown>,
+      { text: "not-json" },
+    );
+
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({ output }))).pass,
+      false,
+    );
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: Object.create({ text: '{"status":"ok"}' }) as Record<string, unknown>,
+      }))).pass,
+      false,
+    );
+  });
+
+  it("preserves __proto__ keys during JSON comparison", async () => {
+    const jsonMatch = metrics.answer.jsonMatch({ expected: {} }).gate();
+
+    assertEquals(
+      (await jsonMatch.evaluate(createRecord({
+        output: { text: '{"__proto__":{"polluted":true}}' },
+      }))).pass,
+      false,
+    );
+  });
+
   it("evaluates agent and operations metrics", async () => {
     const noFailedTools = metrics.agent.noFailedTools().gate();
     const latency = metrics.ops.latency({ maxMs: 100 }).budget();

--- a/src/eval/metrics.ts
+++ b/src/eval/metrics.ts
@@ -120,11 +120,25 @@ function getOutputText(output: unknown): string {
   return stableStringify(output);
 }
 
-function getOutputJson(output: unknown): unknown {
-  if (output && typeof output === "object" && "json" in output) {
-    return (output as { json: unknown }).json;
+const INVALID_JSON_TEXT = Symbol("invalid-json-text");
+
+function getOutputJson(output: unknown): { fromText: boolean; value: unknown } {
+  if (output && typeof output === "object") {
+    const record = output as Record<string, unknown>;
+    if (Object.hasOwn(record, "json")) return { fromText: false, value: record.json };
+    if (Object.hasOwn(record, "text") && typeof record.text === "string") {
+      return { fromText: true, value: parseJsonText(record.text) };
+    }
   }
-  return output;
+  return { fromText: false, value: output };
+}
+
+function parseJsonText(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return INVALID_JSON_TEXT;
+  }
 }
 
 function stableStringify(value: unknown): string {
@@ -134,7 +148,7 @@ function stableStringify(value: unknown): string {
 function sortJsonValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(sortJsonValue);
   if (!value || typeof value !== "object") return value;
-  const sorted: Record<string, unknown> = {};
+  const sorted = Object.create(null) as Record<string, unknown>;
   for (const key of Object.keys(value).sort()) {
     sorted[key] = sortJsonValue((value as Record<string, unknown>)[key]);
   }
@@ -720,11 +734,18 @@ export const metrics = {
       }, options);
     },
 
-    jsonMatch(options: { expected?: unknown }): EvalMetric {
+    jsonMatch(options: { expected?: unknown } = {}): EvalMetric {
       return createMetric("answer.jsonMatch", "answer", (record) => {
-        const expected = Object.hasOwn(options, "expected") ? options.expected : record.reference;
+        const hasExpectedOption = Object.hasOwn(options, "expected");
+        const expectedInput = hasExpectedOption ? options.expected : record.reference;
         const actual = getOutputJson(record.output);
-        const pass = stableStringify(actual) === stableStringify(expected);
+        let expected = expectedInput;
+        if (actual.fromText && !hasExpectedOption && typeof expectedInput === "string") {
+          const parsedReference = parseJsonText(expectedInput);
+          if (parsedReference !== INVALID_JSON_TEXT) expected = parsedReference;
+        }
+        const pass = actual.value !== INVALID_JSON_TEXT && expected !== INVALID_JSON_TEXT &&
+          stableStringify(actual.value) === stableStringify(expected);
         return scoreResult("answer.jsonMatch", "answer", "gate", pass);
       }, options as Record<string, unknown>);
     },

--- a/src/eval/runner.test.ts
+++ b/src/eval/runner.test.ts
@@ -66,6 +66,31 @@ describe("eval/runner", () => {
     ]);
   });
 
+  it("matches an agent's strict JSON text as structured output", async () => {
+    const definition = evalAgent({
+      id: "eval:structured-answer",
+      target: "agent:orchestrator",
+      dataset: datasets.inline([{
+        id: "run-1",
+        input: "Report terminal counts",
+        reference: { claimed_elsewhere: 2, failed: 0, succeeded: 1 },
+      }]),
+      metrics: [metrics.answer.jsonMatch().gate()],
+    });
+
+    const report = await runEval(definition, {
+      adapters: {
+        agent: async () => ({
+          text: '{"succeeded":1,"claimed_elsewhere":2,"failed":0}',
+        }),
+      },
+    });
+
+    assertEquals(report.summary.passed, 1);
+    assertEquals(report.summary.failed, 0);
+    assertEquals(report.summary.metrics[0]?.name, "answer.jsonMatch");
+  });
+
   it("records check assertions alongside metric results", async () => {
     const definition = evalAgent({
       id: "eval:check-api",
@@ -330,6 +355,28 @@ describe("eval/runner", () => {
         metadata: { durationMs: 12 },
       },
     ]);
+  });
+
+  it("keeps direct tool string outputs as JSON string values", async () => {
+    const definition = evalTool({
+      id: "eval:string-tool",
+      target: "tool:string_value",
+      dataset: datasets.inline([{
+        id: "string-1",
+        input: null,
+        reference: "not-json",
+      }]),
+      metrics: [metrics.answer.jsonMatch().gate()],
+    });
+
+    const report = await runEval(definition, {
+      adapters: {
+        tool: async () => ({ output: "not-json" }),
+      },
+    });
+
+    assertEquals(report.summary.passed, 1);
+    assertEquals(report.summary.failed, 0);
   });
 
   it("preserves mapped undefined tool input in direct tool traces", async () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1118";
+export const VERSION = "0.1.1119";


### PR DESCRIPTION
## Summary

- make `metrics.answer.jsonMatch()` work with its documented no-argument form
- parse agent `text` answers and valid JSON string references only when the whole value is valid JSON
- retain ordinary string references when they are not JSON values
- compare parsed values structurally while rejecting markdown fences, surrounding prose, and invalid agent JSON
- preserve direct tool outputs as already-structured values, including legitimate string values
- ignore inherited adapter properties so prototype state cannot influence comparisons
- preserve JSON keys such as `__proto__` during stable structural comparison
- document the contract and bump the framework release to `0.1.1119`

## Why

The job-submission consumer eval completed successfully and passed every tool-behavior gate, but `answer.exactMatch` failed because equivalent JSON used different key ordering/formatting. Normalizing this in the consumer would duplicate framework adapter semantics and leave `jsonMatch()` broken for every other agent eval.

Motivating consumer run: https://github.com/veryfront/agentic-job-submission-processing/actions/runs/30009246768

## Verification

- pre-push gate after rebasing onto current `main`: 2,629 tests / 21,366 steps, all passing
- focused eval + version suite: 49 steps, all passing
- focused typecheck and lint for changed framework files
- exact `0.1.1119` npm core and extension tarballs built, packed, and installed into the consumer app
- packed consumer gate: lint, TypeScript, 6 request-time SSR outcomes, discovery, and all 163 tests pass; npm audit reports zero vulnerabilities
- strictness coverage proves reordered keys and pretty-printed JSON pass while fenced, prose-wrapped, and invalid agent JSON fail
- compatibility coverage proves direct tool string outputs and ordinary string references remain values
- regression coverage proves inherited `json`/`text` properties are ignored and `__proto__` keys survive canonicalization

## Scope

No model-output cleanup is added. Agent responses still have to be complete raw JSON values.
