### PR TITLE
Release the web-fetch fallback as v0.1.1120

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1119",
+  "version": "0.1.1120",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1119";
+export const VERSION = "0.1.1120";


### PR DESCRIPTION
## Why

`v0.1.1119` was published from commit `7ed1dd22a804d84d9dfd365f36c7e2c0fd73c1e6` before #3043 merged. That immutable release therefore does not contain the cross-provider `web_fetch` fallback from merge commit `bfa8e2555fc85f2727fe0521927747c83d937fb2`.

## Change

- Bump `deno.json` from `0.1.1119` to `0.1.1120`.
- Keep `src/utils/version-constant.ts` synchronized.
- Trigger a fresh stable release from current main so downstream staging images include #3043.

## Verification

- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version-constant.ts`
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-read --allow-env src/security/repository-hardening.test.ts`
- Normal pre-push gate: 2,634 tests / 21,369 steps, zero failures
- Confirmed npm and Git tag `0.1.1120` are unused

## Risk

Narrow metadata-only release correction. Runtime code is unchanged from the already-green #3043 merge.