### PR TITLE
refactor(utils): canonical subscriber-set observable plus exact-dupe cleanups

### DIFF
--- a/src/html/styles-builder/plugin-loader.ts
+++ b/src/html/styles-builder/plugin-loader.ts
@@ -7,7 +7,7 @@
  * @module html/styles-builder/plugin-loader
  */
 
-import { encodeBase64, serverLogger } from "#veryfront/utils";
+import { encodeBase64Bytes, serverLogger } from "#veryfront/utils";
 import {
   type ErrorSlug,
   getErrorBySlug,
@@ -99,7 +99,11 @@ export function rewriteEsmShRootRelativeImports(code: string): string {
 
 async function importBundledModule(code: string): Promise<unknown> {
   if (!isDeno) {
-    const dataUrl = `data:text/javascript;base64,${encodeBase64(code)}`;
+    // Encode as UTF-8 bytes: the data: URL importer decodes UTF-8, and btoa on
+    // the raw string would emit Latin-1 bytes for chars in [0x80, 0xFF].
+    const dataUrl = `data:text/javascript;base64,${
+      encodeBase64Bytes(new TextEncoder().encode(code))
+    }`;
     return await import(dataUrl);
   }
 

--- a/src/modules/server/fs-probe.ts
+++ b/src/modules/server/fs-probe.ts
@@ -1,0 +1,25 @@
+/** Minimal stat surface shared by the secure and platform filesystems. */
+interface StatCapableFs {
+  stat(path: string): Promise<{ isFile: boolean }>;
+}
+
+/**
+ * Resolve the first path in `paths` order that exists as a file, or null.
+ * All candidates are stat-probed in parallel; order of `paths` decides the
+ * winner, not which probe resolves first.
+ */
+export async function findFirstExistingFile(
+  fs: StatCapableFs,
+  paths: string[],
+): Promise<string | null> {
+  const results = await Promise.all(paths.map(async (path) => {
+    try {
+      const stat = await fs.stat(path);
+      return stat.isFile ? path : null;
+    } catch {
+      return null;
+    }
+  }));
+
+  return results.find((path): path is string => path !== null) ?? null;
+}

--- a/src/modules/server/module-batch-handler.ts
+++ b/src/modules/server/module-batch-handler.ts
@@ -46,6 +46,7 @@ import {
   hasSourceMiss,
   rememberSourceMiss,
 } from "./module-source-resolution-cache.ts";
+import { findFirstExistingFile } from "./fs-probe.ts";
 
 const logger = serverLogger.component("module-batch");
 
@@ -82,38 +83,6 @@ const FRAMEWORK_EXTENSIONS = [
   ".jsx",
   ".js", // Regular sources for dev mode
 ] as const;
-
-async function findFirstSecureFile(
-  secureFs: ReturnType<typeof createSecureFs>,
-  paths: string[],
-): Promise<string | null> {
-  const results = await Promise.all(paths.map(async (path) => {
-    try {
-      const stat = await secureFs.stat(path);
-      return stat.isFile ? path : null;
-    } catch {
-      return null;
-    }
-  }));
-
-  return results.find((path): path is string => path !== null) ?? null;
-}
-
-async function findFirstPlatformFile(
-  platformFs: ReturnType<typeof createFileSystem>,
-  paths: string[],
-): Promise<string | null> {
-  const results = await Promise.all(paths.map(async (path) => {
-    try {
-      const stat = await platformFs.stat(path);
-      return stat.isFile ? path : null;
-    } catch {
-      return null;
-    }
-  }));
-
-  return results.find((path): path is string => path !== null) ?? null;
-}
 
 export interface BatchHandlerOptions {
   projectDir: string;
@@ -341,7 +310,7 @@ async function loadAndTransformModule(
   });
   if (hasSourceMiss(missCacheKey)) return null;
 
-  const sourcePath = await findFirstSecureFile(
+  const sourcePath = await findFirstExistingFile(
     secureFs,
     EXTENSIONS.map((ext) => join(projectDir, basePath + ext)),
   );
@@ -359,7 +328,7 @@ async function loadAndTransformModule(
 
   const platformFs = createFileSystem();
   for (const lookupDir of frameworkLookupDirs) {
-    const frameworkPath = await findFirstPlatformFile(
+    const frameworkPath = await findFirstExistingFile(
       platformFs,
       FRAMEWORK_EXTENSIONS.map((ext) => join(lookupDir, basePath + ext)),
     );

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -55,6 +55,7 @@ import {
   getReleaseModuleResponse,
   rememberReleaseModuleResponse,
 } from "./module-response-cache.ts";
+import { findFirstExistingFile } from "./fs-probe.ts";
 import { ensureFilenameDefaultExport } from "#veryfront/modules/loader-shared/filename-default-export.ts";
 
 const logger = serverLogger.component("module-server");
@@ -791,42 +792,10 @@ async function findFrameworkPackageAssetFile(
 ): Promise<string | null> {
   if (hasUnsafePackageAssetPath(basePathWithoutExt)) return null;
 
-  return await findFirstPlatformFile(
+  return await findFirstExistingFile(
     fs,
     extensions.map((ext) => join(FRAMEWORK_ROOT, basePathWithoutExt + ext)),
   );
-}
-
-async function findFirstPlatformFile(
-  fs: ReturnType<typeof createFileSystem>,
-  paths: string[],
-): Promise<string | null> {
-  const results = await Promise.all(paths.map(async (path) => {
-    try {
-      const stat = await fs.stat(path);
-      return stat.isFile ? path : null;
-    } catch {
-      return null;
-    }
-  }));
-
-  return results.find((path): path is string => path !== null) ?? null;
-}
-
-async function findFirstSecureFile(
-  secureFs: ReturnType<typeof createSecureFs>,
-  paths: string[],
-): Promise<string | null> {
-  const results = await Promise.all(paths.map(async (path) => {
-    try {
-      const stat = await secureFs.stat(path);
-      return stat.isFile ? path : null;
-    } catch {
-      return null;
-    }
-  }));
-
-  return results.find((path): path is string => path !== null) ?? null;
 }
 
 async function findSourceFile(
@@ -970,7 +939,7 @@ async function findSourceFile(
     : extensions;
 
   // Project file lookups (using secureFs which may go through FSAdapter in proxy mode)
-  const projectFilePath = await findFirstSecureFile(
+  const projectFilePath = await findFirstExistingFile(
     secureFs,
     projectLookupExtensions.map((ext) => join(projectDir, basePathWithoutExt + ext)),
   );
@@ -984,7 +953,7 @@ async function findSourceFile(
     if (!basePathWithoutExt.startsWith(prefix)) continue;
 
     const strippedPath = basePathWithoutExt.slice(prefix.length);
-    const strippedFilePath = await findFirstSecureFile(
+    const strippedFilePath = await findFirstExistingFile(
       secureFs,
       projectLookupExtensions.map((ext) => join(projectDir, strippedPath + ext)),
     );
@@ -998,7 +967,7 @@ async function findSourceFile(
     }
   }
 
-  const indexFilePath = await findFirstSecureFile(
+  const indexFilePath = await findFirstExistingFile(
     secureFs,
     projectLookupExtensions.map((ext) => join(projectDir, basePathWithoutExt, `index${ext}`)),
   );
@@ -1013,7 +982,7 @@ async function findSourceFile(
   // Try looking in common project directories
   const commonDirs = ["components", "app", "pages", "lib", "src"];
   for (const dir of commonDirs) {
-    const commonDirFilePath = await findFirstSecureFile(
+    const commonDirFilePath = await findFirstExistingFile(
       secureFs,
       projectLookupExtensions.map((ext) => join(projectDir, dir, basePathWithoutExt + ext)),
     );

--- a/src/observability/error-collector.ts
+++ b/src/observability/error-collector.ts
@@ -6,6 +6,7 @@
  **************************/
 
 import { type ErrorCategory, INVALID_ARGUMENT } from "#veryfront/errors";
+import { createSubscriberSet } from "#veryfront/utils/subscriber-set.ts";
 
 /** Public API contract for error type. */
 export type ErrorType = "compile" | "runtime" | "bundle" | "hmr" | "module";
@@ -65,7 +66,7 @@ export type ErrorSubscriber = (error: DevError) => void;
 /** Implement error collector. */
 export class ErrorCollector {
   private errors = new Map<string, DevError>();
-  private subscribers = new Set<ErrorSubscriber>();
+  private subscribers = createSubscriberSet<[DevError]>();
   private idCounter = 0;
   private maxErrors: number;
 
@@ -99,13 +100,7 @@ export class ErrorCollector {
 
     this.errors.set(fullError.id, fullError);
 
-    for (const subscriber of this.subscribers) {
-      try {
-        subscriber(fullError);
-      } catch (_) {
-        /* expected: subscriber errors must not break error collection */
-      }
-    }
+    this.subscribers.notify(fullError);
 
     return fullError;
   }
@@ -320,8 +315,7 @@ export class ErrorCollector {
   }
 
   subscribe(callback: ErrorSubscriber): () => void {
-    this.subscribers.add(callback);
-    return () => this.subscribers.delete(callback);
+    return this.subscribers.subscribe(callback);
   }
 
   toJSON(): DevError[] {

--- a/src/observability/log-buffer.ts
+++ b/src/observability/log-buffer.ts
@@ -1,4 +1,5 @@
 import { redactSensitive } from "#veryfront/utils/logger/redact.ts";
+import { createSubscriberSet } from "#veryfront/utils/subscriber-set.ts";
 
 /** Public API contract for log level. */
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -27,7 +28,7 @@ export type LogSubscriber = (entry: LogEntry) => void;
 /** Implement log buffer. */
 export class LogBuffer {
   private entries: LogEntry[] = [];
-  private subscribers = new Set<LogSubscriber>();
+  private subscribers = createSubscriberSet<[LogEntry]>();
   private idCounter = 0;
   private maxSize: number;
 
@@ -55,13 +56,7 @@ export class LogBuffer {
       this.entries.shift();
     }
 
-    for (const subscriber of this.subscribers) {
-      try {
-        subscriber(fullEntry);
-      } catch (_) {
-        /* expected: subscriber errors must not break log buffering */
-      }
-    }
+    this.subscribers.notify(fullEntry);
 
     return fullEntry;
   }
@@ -146,8 +141,7 @@ export class LogBuffer {
   }
 
   subscribe(callback: LogSubscriber): () => void {
-    this.subscribers.add(callback);
-    return () => this.subscribers.delete(callback);
+    return this.subscribers.subscribe(callback);
   }
 
   toJSON(): LogEntry[] {

--- a/src/observability/request-profiler.ts
+++ b/src/observability/request-profiler.ts
@@ -35,7 +35,8 @@ const records: RequestProfileRecord[] = [];
 const MAX_RECORDS = 200;
 let sequence = 0;
 
-function roundMs(value: number): number {
+/** Round to 2 decimal places (Server-Timing millisecond precision). */
+export function roundMs(value: number): number {
   return Math.round(value * 100) / 100;
 }
 
@@ -171,14 +172,25 @@ function formatDuration(value: number): string {
   return Math.max(0, roundMs(value)).toFixed(2);
 }
 
-export function buildServerTimingHeader(record: RequestProfileRecord): string {
-  const metrics = [`total;dur=${formatDuration(record.totalMs)}`];
-
-  for (const [name, duration] of Object.entries(record.phases).slice(0, 20)) {
+/** Build a Server-Timing header value from a total plus named phase durations. */
+export function buildServerTimingValue(
+  totalLabel: string,
+  totalMs: number,
+  phases: Iterable<[string, number]>,
+): string {
+  const metrics = [`${totalLabel};dur=${formatDuration(totalMs)}`];
+  for (const [name, duration] of phases) {
     metrics.push(`${sanitizeMetricName(name)};dur=${formatDuration(duration)}`);
   }
-
   return metrics.join(", ");
+}
+
+export function buildServerTimingHeader(record: RequestProfileRecord): string {
+  return buildServerTimingValue(
+    "total",
+    record.totalMs,
+    Object.entries(record.phases).slice(0, 20),
+  );
 }
 
 export function withServerTimingHeader(

--- a/src/observability/request-profiler.ts
+++ b/src/observability/request-profiler.ts
@@ -178,7 +178,7 @@ export function buildServerTimingValue(
   totalMs: number,
   phases: Iterable<[string, number]>,
 ): string {
-  const metrics = [`${totalLabel};dur=${formatDuration(totalMs)}`];
+  const metrics = [`${sanitizeMetricName(totalLabel)};dur=${formatDuration(totalMs)}`];
   for (const [name, duration] of phases) {
     metrics.push(`${sanitizeMetricName(name)};dur=${formatDuration(duration)}`);
   }

--- a/src/proxy/server-timing.ts
+++ b/src/proxy/server-timing.ts
@@ -1,21 +1,10 @@
 import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { buildServerTimingValue, roundMs } from "#veryfront/observability/request-profiler.ts";
 
 export interface ProxyServerTiming {
   enabled: boolean;
   startedAt: number;
   phases: Map<string, number>;
-}
-
-function roundMs(value: number): number {
-  return Math.round(value * 100) / 100;
-}
-
-function formatDuration(value: number): string {
-  return Math.max(0, roundMs(value)).toFixed(2);
-}
-
-function sanitizeMetricName(name: string): string {
-  return name.replace(/[^A-Za-z0-9!#$%&'*+\-.^_`|~]/g, "_");
 }
 
 export function shouldEnableProxyServerTiming(): boolean {
@@ -64,12 +53,7 @@ export function withProxyServerTimingHeader(
 ): Response {
   if (!timing.enabled) return response;
 
-  const metrics = [`proxy.total;dur=${formatDuration(totalMs)}`];
-  for (const [name, duration] of timing.phases.entries()) {
-    metrics.push(`${sanitizeMetricName(name)};dur=${formatDuration(duration)}`);
-  }
-
-  const value = metrics.join(", ");
+  const value = buildServerTimingValue("proxy.total", totalMs, timing.phases.entries());
 
   try {
     const existing = response.headers.get("Server-Timing");

--- a/src/server/reload-notifier.ts
+++ b/src/server/reload-notifier.ts
@@ -1,4 +1,5 @@
 import { serverLogger } from "#veryfront/utils";
+import { createSubscriberSet } from "#veryfront/utils/subscriber-set.ts";
 
 const logger = serverLogger.component("reload-notifier");
 
@@ -20,8 +21,12 @@ type ReloadProjectInput = ReloadProjectInfo | string | undefined;
 const DEBOUNCE_MS = 300;
 
 class ReloadNotifierImpl {
-  private listeners = new Set<ReloadListener>();
-  private invalidateListeners = new Set<InvalidateListener>();
+  private listeners = createSubscriberSet<[string[] | undefined, ReloadProjectInfo | undefined]>(
+    (error) => logger.error("Listener error:", error),
+  );
+  private invalidateListeners = createSubscriberSet(
+    (error) => logger.error("Invalidate listener error:", error),
+  );
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingChangedPaths = new Set<string>();
   private pendingProject?: ReloadProjectInfo;
@@ -32,13 +37,11 @@ class ReloadNotifierImpl {
   };
 
   subscribe(listener: ReloadListener): () => void {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
+    return this.listeners.subscribe(listener);
   }
 
   subscribeInvalidate(listener: InvalidateListener): () => void {
-    this.invalidateListeners.add(listener);
-    return () => this.invalidateListeners.delete(listener);
+    return this.invalidateListeners.subscribe(listener);
   }
 
   triggerReload(changedPaths?: string[], project?: ReloadProjectInput): void {
@@ -87,13 +90,7 @@ class ReloadNotifierImpl {
       count: this.invalidateListeners.size,
     });
 
-    for (const listener of this.invalidateListeners) {
-      try {
-        listener();
-      } catch (error) {
-        logger.error("Invalidate listener error:", error);
-      }
-    }
+    this.invalidateListeners.notify();
   }
 
   private notifyListeners(changedPaths?: string[], project?: ReloadProjectInfo): void {
@@ -105,21 +102,11 @@ class ReloadNotifierImpl {
       project,
     });
 
-    for (const listener of this.listeners) {
-      try {
-        listener(changedPaths, project);
-      } catch (error) {
-        logger.error("Listener error:", error);
-      }
-    }
+    this.listeners.notify(changedPaths, project);
   }
 
   getListenerCount(): number {
     return this.listeners.size;
-  }
-
-  getInvalidateListenerCount(): number {
-    return this.invalidateListeners.size;
   }
 
   getMetrics(): {

--- a/src/utils/base64url.ts
+++ b/src/utils/base64url.ts
@@ -14,11 +14,8 @@ export function encodeBase64(value: string): string {
     try {
       return globalThis.btoa(value);
     } catch (_) {
-      /* expected: non-Latin1 string — fall back to TextEncoder */
-      const bytes = new TextEncoder().encode(value);
-      let binary = "";
-      for (const byte of bytes) binary += String.fromCharCode(byte);
-      return globalThis.btoa(binary);
+      /* expected: non-Latin1 string — fall back to UTF-8 bytes */
+      return encodeBase64Bytes(new TextEncoder().encode(value));
     }
   }
 
@@ -29,6 +26,20 @@ export function encodeBase64(value: string): string {
   throw new Error("Base64 encoding is not supported in this runtime");
 }
 
+/** Encode raw bytes as standard base64. */
+export function encodeBase64Bytes(bytes: Uint8Array): string {
+  if (typeof globalThis.btoa === "function") {
+    let binary = "";
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return globalThis.btoa(binary);
+  }
+
+  const bufferCtor = (globalThis as { Buffer?: typeof Buffer }).Buffer;
+  if (bufferCtor) return bufferCtor.from(bytes).toString("base64");
+
+  throw new Error("Base64 encoding is not supported in this runtime");
+}
+
 /** Encode a string as unpadded base64url. */
 export function base64urlEncode(input: string): string {
   return toBase64Url(encodeBase64(input));
@@ -36,7 +47,5 @@ export function base64urlEncode(input: string): string {
 
 /** Encode raw bytes as unpadded base64url. */
 export function base64urlEncodeBytes(bytes: Uint8Array): string {
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return toBase64Url(btoa(binary));
+  return toBase64Url(encodeBase64Bytes(bytes));
 }

--- a/src/utils/base64url.ts
+++ b/src/utils/base64url.ts
@@ -28,14 +28,16 @@ export function encodeBase64(value: string): string {
 
 /** Encode raw bytes as standard base64. */
 export function encodeBase64Bytes(bytes: Uint8Array): string {
+  // Prefer Buffer where available (Node): avoids building a large intermediate
+  // binary string, which is slower and can hit maximum-string-size limits.
+  const bufferCtor = (globalThis as { Buffer?: typeof Buffer }).Buffer;
+  if (bufferCtor) return bufferCtor.from(bytes).toString("base64");
+
   if (typeof globalThis.btoa === "function") {
     let binary = "";
     for (const byte of bytes) binary += String.fromCharCode(byte);
     return globalThis.btoa(binary);
   }
-
-  const bufferCtor = (globalThis as { Buffer?: typeof Buffer }).Buffer;
-  if (bufferCtor) return bufferCtor.from(bytes).toString("base64");
 
   throw new Error("Base64 encoding is not supported in this runtime");
 }

--- a/src/utils/base64url.ts
+++ b/src/utils/base64url.ts
@@ -8,7 +8,13 @@ function toBase64Url(b64: string): string {
   return b64.replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
 }
 
-/** Encode a UTF-8 string as standard base64 (handles non-Latin1 input). */
+/**
+ * Encode a string as standard base64. Latin-1 input (all code points <= 0xFF)
+ * is encoded with btoa's binary-string semantics; input outside Latin-1 falls
+ * back to UTF-8 bytes. Callers that need guaranteed UTF-8 bytes regardless of
+ * input (e.g. data: URLs decoded as UTF-8) should use
+ * `encodeBase64Bytes(new TextEncoder().encode(value))` instead.
+ */
 export function encodeBase64(value: string): string {
   if (typeof globalThis.btoa === "function") {
     try {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -113,9 +113,16 @@ export {
   simpleHash,
 } from "./hash-utils.ts";
 
-export { base64urlEncode, base64urlEncodeBytes, encodeBase64 } from "./base64url.ts";
+export {
+  base64urlEncode,
+  base64urlEncodeBytes,
+  encodeBase64,
+  encodeBase64Bytes,
+} from "./base64url.ts";
 
 export { sleep } from "./sleep.ts";
+
+export { createSubscriberSet, type SubscriberSet } from "./subscriber-set.ts";
 
 export { MemoCache, memoize, memoizeAsync, simpleHash as memoizeHash } from "./memoize.ts";
 

--- a/src/utils/subscriber-set.test.ts
+++ b/src/utils/subscriber-set.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from "#veryfront/testing/bdd";
+import { assertEquals } from "#veryfront/testing/assert";
+import { createSubscriberSet } from "./subscriber-set.ts";
+
+describe("utils/subscriber-set", () => {
+  it("notifies all listeners with the given arguments", () => {
+    const set = createSubscriberSet<[string]>();
+    const seen: string[] = [];
+    set.subscribe((value) => seen.push(`a:${value}`));
+    set.subscribe((value) => seen.push(`b:${value}`));
+
+    set.notify("x");
+    assertEquals(seen, ["a:x", "b:x"]);
+  });
+
+  it("is safe for a listener to unsubscribe itself or others mid-notify", () => {
+    const set = createSubscriberSet();
+    const calls: string[] = [];
+    const unsubscribeB = set.subscribe(() => calls.push("b"));
+    set.subscribe(() => {
+      calls.push("a");
+      unsubscribeB();
+    });
+
+    // Insertion order: b first, then a. Removing b during a's run must not
+    // disturb the snapshot; on the next notify b is gone.
+    set.notify();
+    set.notify();
+    assertEquals(calls, ["b", "a", "a"]);
+  });
+
+  it("isolates a throwing listener so the rest still run", () => {
+    const set = createSubscriberSet();
+    const calls: string[] = [];
+    set.subscribe(() => {
+      throw new Error("bad listener");
+    });
+    set.subscribe(() => calls.push("survivor"));
+
+    set.notify();
+    assertEquals(calls, ["survivor"]);
+  });
+
+  it("routes listener errors to onListenerError", () => {
+    const errors: unknown[] = [];
+    const set = createSubscriberSet((error) => errors.push(error));
+    set.subscribe(() => {
+      throw new Error("routed");
+    });
+
+    set.notify();
+    assertEquals((errors[0] as Error).message, "routed");
+  });
+
+  it("survives a throwing onListenerError and keeps notifying", () => {
+    const calls: string[] = [];
+    const set = createSubscriberSet(() => {
+      throw new Error("bad error handler");
+    });
+    set.subscribe(() => {
+      throw new Error("boom");
+    });
+    set.subscribe(() => calls.push("survivor"));
+
+    set.notify();
+    assertEquals(calls, ["survivor"]);
+  });
+
+  it("tracks size, ignores double-unsubscribe, and clears", () => {
+    const set = createSubscriberSet();
+    const unsubscribe = set.subscribe(() => {});
+    set.subscribe(() => {});
+    assertEquals(set.size, 2);
+
+    unsubscribe();
+    unsubscribe();
+    assertEquals(set.size, 1);
+
+    set.clear();
+    assertEquals(set.size, 0);
+  });
+});

--- a/src/utils/subscriber-set.test.ts
+++ b/src/utils/subscriber-set.test.ts
@@ -13,20 +13,24 @@ describe("utils/subscriber-set", () => {
     assertEquals(seen, ["a:x", "b:x"]);
   });
 
-  it("is safe for a listener to unsubscribe itself or others mid-notify", () => {
+  it("still notifies a listener that was unsubscribed earlier in the same notify (snapshot)", () => {
     const set = createSubscriberSet();
     const calls: string[] = [];
-    const unsubscribeB = set.subscribe(() => calls.push("b"));
+    // Register the remover FIRST so it removes a listener that has not run
+    // yet. Live Set iteration would skip b; the snapshot must still call it.
+    let unsubscribeB = () => {};
     set.subscribe(() => {
       calls.push("a");
       unsubscribeB();
     });
+    unsubscribeB = set.subscribe(() => calls.push("b"));
 
-    // Insertion order: b first, then a. Removing b during a's run must not
-    // disturb the snapshot; on the next notify b is gone.
     set.notify();
+    assertEquals(calls, ["a", "b"]);
+
+    // The removal still takes effect for subsequent notifies.
     set.notify();
-    assertEquals(calls, ["b", "a", "a"]);
+    assertEquals(calls, ["a", "b", "a"]);
   });
 
   it("isolates a throwing listener so the rest still run", () => {

--- a/src/utils/subscriber-set.ts
+++ b/src/utils/subscriber-set.ts
@@ -1,0 +1,51 @@
+/** Listener registry returned by {@link createSubscriberSet}. */
+export interface SubscriberSet<Args extends unknown[] = []> {
+  /** Register a listener; returns its unsubscribe function. */
+  subscribe(listener: (...args: Args) => void): () => void;
+  /** Invoke every listener; a throwing listener never stops the others. */
+  notify(...args: Args): void;
+  /** Number of registered listeners. */
+  readonly size: number;
+  /** Remove all listeners. */
+  clear(): void;
+}
+
+/**
+ * Create a subscriber set — the canonical subscribe/notify observable used
+ * across modules. Notification iterates a snapshot, so a listener that
+ * unsubscribes (itself or others) mid-notify is safe, and listener errors are
+ * isolated (routed to `onListenerError` when provided, otherwise swallowed).
+ */
+export function createSubscriberSet<Args extends unknown[] = []>(
+  onListenerError?: (error: unknown) => void,
+): SubscriberSet<Args> {
+  const listeners = new Set<(...args: Args) => void>();
+
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    notify(...args) {
+      for (const listener of [...listeners]) {
+        try {
+          listener(...args);
+        } catch (error) {
+          try {
+            onListenerError?.(error);
+          } catch {
+            // A throwing error handler must not break notification either.
+          }
+        }
+      }
+    },
+    get size() {
+      return listeners.size;
+    },
+    clear() {
+      listeners.clear();
+    },
+  };
+}

--- a/src/utils/subscriber-set.ts
+++ b/src/utils/subscriber-set.ts
@@ -11,7 +11,7 @@ export interface SubscriberSet<Args extends unknown[] = []> {
 }
 
 /**
- * Create a subscriber set — the canonical subscribe/notify observable used
+ * Create a subscriber set: the canonical subscribe/notify observable used
  * across modules. Notification iterates a snapshot, so a listener that
  * unsubscribes (itself or others) mid-notify is safe, and listener errors are
  * isolated (routed to `onListenerError` when provided, otherwise swallowed).

--- a/src/workflow/claude-code/websocket-publisher.ts
+++ b/src/workflow/claude-code/websocket-publisher.ts
@@ -5,6 +5,7 @@
  */
 
 import { logger as baseLogger } from "#veryfront/utils";
+import { createSubscriberSet } from "#veryfront/utils/subscriber-set.ts";
 import type {
   BidirectionalPublisher,
   CancelledEvent,
@@ -55,7 +56,11 @@ export class WebSocketPublisher implements BidirectionalPublisher {
   private config: Required<Omit<WebSocketPublisherConfig, "socket">> & {
     socket: WebSocket;
   };
-  private commandHandlers = new Set<ClientCommandHandler>();
+  private commandHandlers = createSubscriberSet<[ClientCommand]>((error) => {
+    if (this.config.debug) {
+      logger.error("Handler error", error);
+    }
+  });
   private closed = false;
   private pingTimer: number | null = null;
 
@@ -114,15 +119,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
     }
 
     // Dispatch to handlers
-    for (const handler of this.commandHandlers) {
-      try {
-        handler(command);
-      } catch (error) {
-        if (this.config.debug) {
-          logger.error("Handler error", error);
-        }
-      }
-    }
+    this.commandHandlers.notify(command);
   }
 
   private sendPong(): void {
@@ -165,10 +162,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
    * Subscribe to client commands
    */
   onCommand(handler: ClientCommandHandler): () => void {
-    this.commandHandlers.add(handler);
-    return () => {
-      this.commandHandlers.delete(handler);
-    };
+    return this.commandHandlers.subscribe(handler);
   }
 
   /**

--- a/tests/integration/server/modules/reload-notifier.test.ts
+++ b/tests/integration/server/modules/reload-notifier.test.ts
@@ -24,7 +24,7 @@ describe("ReloadNotifier Tests", { sanitizeOps: false, sanitizeResources: false 
   describe("ReloadNotifier - Subscription Management", () => {
     it("starts with zero listeners", (): void => {
       assertEquals(ReloadNotifier.getListenerCount(), 0);
-      assertEquals(ReloadNotifier.getInvalidateListenerCount(), 0);
+      assertEquals(ReloadNotifier.getMetrics().activeInvalidateListeners, 0);
     });
 
     it("can subscribe and unsubscribe reload listeners", (): void => {
@@ -42,13 +42,13 @@ describe("ReloadNotifier Tests", { sanitizeOps: false, sanitizeResources: false 
     it("can subscribe and unsubscribe invalidate listeners", (): void => {
       const listener = (): void => {};
 
-      assertEquals(ReloadNotifier.getInvalidateListenerCount(), 0);
+      assertEquals(ReloadNotifier.getMetrics().activeInvalidateListeners, 0);
 
       const unsubscribe = ReloadNotifier.subscribeInvalidate(listener);
-      assertEquals(ReloadNotifier.getInvalidateListenerCount(), 1);
+      assertEquals(ReloadNotifier.getMetrics().activeInvalidateListeners, 1);
 
       unsubscribe();
-      assertEquals(ReloadNotifier.getInvalidateListenerCount(), 0);
+      assertEquals(ReloadNotifier.getMetrics().activeInvalidateListeners, 0);
     });
 
     it("supports multiple listeners", (): void => {


### PR DESCRIPTION
## Summary

Third PR in the code-reduction campaign (after #3045, #3046). Six modules hand-rolled the same Set-based subscribe/notify observable with inconsistent notify semantics; this adds one canonical `createSubscriberSet` to `#veryfront/utils` and migrates the accidental copies, plus two byte-identical dupe groups flagged by `deno task dupes`, plus fixes for two review findings against the already-merged #3045.

> **Note (force-pushed):** the original push accidentally contained only the 2 new files — a `git stash`/`stash pop` during verification unstaged the 9 migrated files before commit. The amended commit contains the full change set; the earlier bot comments about dead/unwired code are resolved.

**Net: −1 line (+163/−164, 13 files).** The raw counter is thin because ~40 lines are review-driven *additions* fixing #3045 fallout (see below); the consolidation itself removes ~120 lines of duplicated logic. 2634 unit tests pass.

### Changes

1. **`createSubscriberSet<Args>(onListenerError?)`** — subscribe→unsubscribe, snapshot-during-notify, isolated listener errors (including a throwing `onListenerError` itself), `size`/`clear`. Migrated: `observability/error-collector`, `observability/log-buffer`, `server/reload-notifier` (both listener sets, per-set error logs preserved; dead `getInvalidateListenerCount` removed), `workflow/claude-code/websocket-publisher`.
   Two of these sites previously iterated the **live** Set during notify — a listener unsubscribing mid-notify could skip listeners. Snapshot semantics closes that bug class.
2. **Server-Timing dedupe** — the metric-building loop plus `roundMs`/`formatDuration`/`sanitizeMetricName` were duplicated between `proxy/server-timing.ts` and `observability/request-profiler.ts`; proxy now uses the exported `buildServerTimingValue`/`roundMs` and the format helpers went back to private.
3. **`modules/server`** — four identical `findFirstSecureFile`/`findFirstPlatformFile` copies collapsed into one structurally-typed `findFirstExistingFile` (`fs-probe.ts`).
4. **#3045 review fixes** (Codex/Copilot findings on the merged PR):
   - *UTF-8 regression in `plugin-loader`*: `encodeBase64(code)` for `data:` URLs emits Latin-1 bytes for chars in `[0x80–0xFF]` via btoa, corrupting non-ASCII plugin source outside Deno. Now `encodeBase64Bytes(new TextEncoder().encode(code))`, restoring the pre-#3045 always-UTF-8 behavior.
   - *Bare `btoa` in `base64urlEncodeBytes`*: now routed through the new fallback-safe `encodeBase64Bytes` (btoa → Buffer → clear error), and `encodeBase64`'s non-Latin1 fallback reuses it.

### Deliberately left (documented in code or genuinely different)
- `rendering/client/navigation-store` + `react/runtime/core` mirror — documented cross-bundle contract; react runtime bundle intentionally imports nothing
- `workflow/claude-code/event-publisher` — throwing handlers intentionally propagate; converting would change behavior
- proxy Redis channel map — keyed pubsub with connection lifecycle, different abstraction

### Verification
- `deno task verify:quick` exit 0; `deno task test:unit` 2634 passed / 0 failed; affected suites (observability, proxy, modules/server, workflow, utils, html) pass unmodified; pre-push hook (fmt + full suite) passed on the amended commit