### PR TITLE
refactor(agent): one stream-outcome seam for runtime and hosted

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,5 +12,5 @@ from whatever a provider throws, recognizing the late "body read" failure
 (which counts as completion when output already streamed), classifying finish
 reasons as completed steps, and mapping thrown errors to known terminal
 provider errors. The agent **runtime** layer starts streams and the **hosted**
-layer finishes them — both consult this module rather than re-deriving the
+layer finishes them; both consult this module rather than re-deriving the
 interpretation, so provider behavior changes land in one file.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,16 @@
+# Domain Glossary
+
+Terms with a specific meaning in this codebase. Architecture reviews and
+refactors should use these names; sharpen or extend this file as concepts
+crystallize.
+
+## Stream Outcome
+
+How a provider stream ended, interpreted in exactly one place:
+`src/agent/streaming/stream-outcome.ts`. Covers extracting an error message
+from whatever a provider throws, recognizing the late "body read" failure
+(which counts as completion when output already streamed), classifying finish
+reasons as completed steps, and mapping thrown errors to known terminal
+provider errors. The agent **runtime** layer starts streams and the **hosted**
+layer finishes them — both consult this module rather than re-deriving the
+interpretation, so provider behavior changes land in one file.

--- a/src/agent/hosted/child-lifecycle.ts
+++ b/src/agent/hosted/child-lifecycle.ts
@@ -4,7 +4,7 @@ import {
   type ChildRunExecutionSnapshot,
   getChildRunSnapshotUsage,
 } from "../child-run/execution-snapshot.ts";
-import { parseProviderError } from "../../chat/provider-errors.ts";
+import { resolveKnownProviderTerminalError } from "../streaming/stream-outcome.ts";
 import { isChildRunAbortError } from "../child-run/execution-support.ts";
 import {
   HostedChildTerminalStateError,
@@ -127,24 +127,6 @@ class HostedChildExecutionFailure extends Error {
     super(message);
     this.name = "HostedChildExecutionFailure";
   }
-}
-
-function resolveKnownProviderTerminalError(error: unknown): {
-  code: string;
-  message: string;
-} | null {
-  const parsedError = parseProviderError(error);
-  if (
-    parsedError.code === "EXTERNAL_SERVICE_ERROR" &&
-    parsedError.message === "LLM provider service error"
-  ) {
-    return null;
-  }
-
-  return {
-    code: parsedError.code,
-    message: parsedError.message,
-  };
 }
 
 async function dispatchTerminalState(

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -2,7 +2,7 @@ import type {
   ChildRunExecutionResult,
   ChildRunExecutionSnapshot,
 } from "../child-run/execution-snapshot.ts";
-import { parseProviderError } from "../../chat/provider-errors.ts";
+import { resolveKnownProviderTerminalError } from "../streaming/stream-outcome.ts";
 import {
   buildChildRunResultSummary,
   type ChildRunResultMode,
@@ -194,24 +194,6 @@ export function buildHostedDurableChildInvokeTerminalFailureResult(
     childRunId: input.identifiers.childRunId,
     childMessageId: input.identifiers.childMessageId,
   });
-}
-
-function resolveKnownProviderTerminalError(error: unknown): {
-  code: string;
-  message: string;
-} | null {
-  const parsedError = parseProviderError(error);
-  if (
-    parsedError.code === "EXTERNAL_SERVICE_ERROR" &&
-    parsedError.message === "LLM provider service error"
-  ) {
-    return null;
-  }
-
-  return {
-    code: parsedError.code,
-    message: parsedError.message,
-  };
 }
 
 /** Result returned from build hosted durable child invoke success. */

--- a/src/agent/hosted/stream-finalization.ts
+++ b/src/agent/hosted/stream-finalization.ts
@@ -1,4 +1,8 @@
 import type { HostedLifecycleTerminalState } from "./lifecycle.ts";
+import {
+  hasCompletedStepSignal,
+  isLateProviderBodyReadError,
+} from "../streaming/stream-outcome.ts";
 
 /** Error shape for hosted terminal. */
 export interface HostedTerminalError {
@@ -81,29 +85,6 @@ async function cleanupAfterFinalization(cleanup: () => Promise<void> | void): Pr
   await cleanup();
 }
 
-function getStreamErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === "string") {
-    return error;
-  }
-
-  if (
-    typeof error === "object" && error !== null && "message" in error &&
-    typeof error.message === "string"
-  ) {
-    return error.message;
-  }
-
-  return String(error);
-}
-
-function isLateProviderBodyReadError(error: unknown): boolean {
-  return /error reading a body from connection/i.test(getStreamErrorMessage(error));
-}
-
 function hasFinalStepCompletionSignal(finalStep: unknown): boolean {
   if (
     typeof finalStep !== "object" || finalStep === null || !("finishReason" in finalStep) ||
@@ -112,16 +93,7 @@ function hasFinalStepCompletionSignal(finalStep: unknown): boolean {
     return false;
   }
 
-  switch (finalStep.finishReason) {
-    case "stop":
-    case "length":
-    case "tool-calls":
-    case "content-filter":
-    case "other":
-      return true;
-    default:
-      return false;
-  }
+  return hasCompletedStepSignal(finalStep.finishReason);
 }
 
 function shouldFailStreamError(input: {

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -17,6 +17,11 @@ import {
   stripLeadingEmptyObjectPlaceholder,
 } from "../streaming/data-stream.ts";
 import { isDynamicTool } from "./tool-helpers.ts";
+import {
+  getStreamErrorMessage,
+  hasCompletedStepSignal,
+  isLateProviderBodyReadError,
+} from "../streaming/stream-outcome.ts";
 import { serverLogger } from "#veryfront/utils";
 import { isAnyDebugEnabled } from "#veryfront/utils/constants/env.ts";
 import { setActiveSpanAttributes, SpanKind } from "#veryfront/observability";
@@ -231,42 +236,6 @@ function logProviderToolPart(
     error: summarizeProviderToolDebugValue(part.error),
     input: summarizeProviderToolDebugValue(part.input),
   });
-}
-
-function getStreamErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === "string") {
-    return error;
-  }
-
-  if (
-    typeof error === "object" && error !== null && "message" in error &&
-    typeof error.message === "string"
-  ) {
-    return error.message;
-  }
-
-  return String(error);
-}
-
-function isLateProviderBodyReadError(error: unknown): boolean {
-  return /error reading a body from connection/i.test(getStreamErrorMessage(error));
-}
-
-function hasCompletedStepSignal(finishReason: string | null): boolean {
-  switch (finishReason) {
-    case "stop":
-    case "length":
-    case "tool-calls":
-    case "content-filter":
-    case "other":
-      return true;
-    default:
-      return false;
-  }
 }
 
 function hasStreamOutput(state: ChatStreamState): boolean {

--- a/src/agent/streaming/stream-outcome.test.ts
+++ b/src/agent/streaming/stream-outcome.test.ts
@@ -1,0 +1,79 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  getStreamErrorMessage,
+  hasCompletedStepSignal,
+  isLateProviderBodyReadError,
+  resolveKnownProviderTerminalError,
+} from "./stream-outcome.ts";
+
+describe("agent/stream-outcome", () => {
+  describe("getStreamErrorMessage", () => {
+    it("returns the message from an Error", () => {
+      assertEquals(getStreamErrorMessage(new Error("boom")), "boom");
+    });
+
+    it("returns a string error as-is", () => {
+      assertEquals(getStreamErrorMessage("plain failure"), "plain failure");
+    });
+
+    it("reads message from a plain object", () => {
+      assertEquals(getStreamErrorMessage({ message: "object failure" }), "object failure");
+    });
+
+    it("stringifies anything else", () => {
+      assertEquals(getStreamErrorMessage(42), "42");
+      assertEquals(getStreamErrorMessage(null), "null");
+      assertEquals(getStreamErrorMessage({ message: 7 }), "[object Object]");
+    });
+  });
+
+  describe("isLateProviderBodyReadError", () => {
+    it("matches the late body-read failure regardless of case", () => {
+      assertEquals(
+        isLateProviderBodyReadError(new Error("Error reading a body from connection: reset")),
+        true,
+      );
+      assertEquals(
+        isLateProviderBodyReadError("error reading a body from connection"),
+        true,
+      );
+    });
+
+    it("rejects other errors", () => {
+      assertEquals(isLateProviderBodyReadError(new Error("connection refused")), false);
+      assertEquals(isLateProviderBodyReadError(undefined), false);
+    });
+  });
+
+  describe("hasCompletedStepSignal", () => {
+    it("accepts every completed finish reason", () => {
+      for (const reason of ["stop", "length", "tool-calls", "content-filter", "other"]) {
+        assertEquals(hasCompletedStepSignal(reason), true, reason);
+      }
+    });
+
+    it("rejects null, unknown, and error finish reasons", () => {
+      assertEquals(hasCompletedStepSignal(null), false);
+      assertEquals(hasCompletedStepSignal("error"), false);
+      assertEquals(hasCompletedStepSignal("unknown"), false);
+    });
+  });
+
+  describe("resolveKnownProviderTerminalError", () => {
+    it("returns null for the generic provider service error", () => {
+      assertEquals(resolveKnownProviderTerminalError(new Error("boom")), null);
+    });
+
+    it("returns code and message for a recognized terminal error", () => {
+      const error = Object.assign(new Error("schema"), {
+        responseBody: "Invalid Veryfront schema: defineSchema missing",
+      });
+
+      const resolved = resolveKnownProviderTerminalError(error);
+      assertEquals(resolved?.code, "PROJECT_SCHEMA_ERROR");
+      assertEquals(typeof resolved?.message, "string");
+    });
+  });
+});

--- a/src/agent/streaming/stream-outcome.ts
+++ b/src/agent/streaming/stream-outcome.ts
@@ -1,0 +1,78 @@
+/**
+ * Stream Outcome — the single place that interprets how a provider stream ended.
+ *
+ * Both the runtime layer (which starts streams) and the hosted layer (which
+ * finishes them) need to answer the same questions: what error message does a
+ * thrown value carry, was it the late body-read failure, did the final step
+ * complete, and does the error map to a known terminal provider error. Before
+ * this module those answers were byte-identical private copies on both sides
+ * of the runtime/hosted boundary with nothing keeping them in sync.
+ */
+
+import { parseProviderError } from "../../chat/provider-errors.ts";
+
+/** Extract a human-readable message from any value a provider stream can throw. */
+export function getStreamErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (
+    typeof error === "object" && error !== null && "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+/**
+ * True for the "error reading a body from connection" failure some providers
+ * raise after all output has already streamed — treated as a completed stream
+ * when output and a completion signal are present.
+ */
+export function isLateProviderBodyReadError(error: unknown): boolean {
+  return /error reading a body from connection/i.test(getStreamErrorMessage(error));
+}
+
+/** True when the provider finish reason marks a completed step. */
+export function hasCompletedStepSignal(finishReason: string | null): boolean {
+  switch (finishReason) {
+    case "stop":
+    case "length":
+    case "tool-calls":
+    case "content-filter":
+    case "other":
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Map a thrown provider error to a terminal `{code, message}` pair, or null
+ * for the generic "LLM provider service error" (which callers treat as
+ * unknown/retryable rather than terminal).
+ */
+export function resolveKnownProviderTerminalError(error: unknown): {
+  code: string;
+  message: string;
+} | null {
+  const parsedError = parseProviderError(error);
+  if (
+    parsedError.code === "EXTERNAL_SERVICE_ERROR" &&
+    parsedError.message === "LLM provider service error"
+  ) {
+    return null;
+  }
+
+  return {
+    code: parsedError.code,
+    message: parsedError.message,
+  };
+}

--- a/src/agent/streaming/stream-outcome.ts
+++ b/src/agent/streaming/stream-outcome.ts
@@ -1,5 +1,5 @@
 /**
- * Stream Outcome — the single place that interprets how a provider stream ended.
+ * Stream Outcome: the single place that interprets how a provider stream ended.
  *
  * Both the runtime layer (which starts streams) and the hosted layer (which
  * finishes them) need to answer the same questions: what error message does a
@@ -33,7 +33,7 @@ export function getStreamErrorMessage(error: unknown): string {
 
 /**
  * True for the "error reading a body from connection" failure some providers
- * raise after all output has already streamed — treated as a completed stream
+ * raise after all output has already streamed. Treated as a completed stream
  * when output and a completion signal are present.
  */
 export function isLateProviderBodyReadError(error: unknown): boolean {

--- a/src/agent/streaming/stream-outcome.ts
+++ b/src/agent/streaming/stream-outcome.ts
@@ -9,7 +9,7 @@
  * of the runtime/hosted boundary with nothing keeping them in sync.
  */
 
-import { parseProviderError } from "../../chat/provider-errors.ts";
+import { parseProviderError } from "#veryfront/chat/provider-errors.ts";
 
 /** Extract a human-readable message from any value a provider stream can throw. */
 export function getStreamErrorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary

First PR from the architecture review (deepening campaign). The agent **runtime** layer starts provider streams and the **hosted** layer finishes them — and both independently re-derived what "the stream ended" means, with byte-identical private copies on each side of the layer boundary that nothing kept in sync:

- `getStreamErrorMessage` — copied in `runtime/chat-stream-handler.ts` and `hosted/stream-finalization.ts`
- `isLateProviderBodyReadError` — same pair
- the completed-step finish-reason switch — twice under different names (`hasCompletedStepSignal` / `hasFinalStepCompletionSignal`)
- `resolveKnownProviderTerminalError` — copied byte-for-byte inside hosted (`child-lifecycle.ts`, `durable-child-fork-execution.ts`)

A provider adding a finish reason or changing an error shape could make the two paths silently disagree.

## Change

New deep module on the seam: **`src/agent/streaming/stream-outcome.ts`** — the single interpretation of how a provider stream ended (error-message extraction, late body-read detection, completed-step classification, terminal-error resolution). `streaming/` was chosen because both layers already import it and it already depends on `chat/provider-errors`. All call sites route through it; hosted keeps only its 3-line `finalStep` unwrapper. Function names are unchanged to keep call-site churn minimal.

Also adds **`CONTEXT.md`** with the *Stream Outcome* domain term (first entry — file created lazily per the architecture-review workflow).

## Accounting

Non-test src: **−17 lines** (module +78 incl. docs vs −107 of deleted copies + thin imports). New interface test suite: +79 (14 steps). `CONTEXT.md`: +16.

## Verification

- New `stream-outcome.test.ts` covers all four functions (error shapes, regex, full finish-reason switch, terminal-vs-generic resolution)
- All anchor suites pass **unmodified**: 353 tests across `agent/streaming/`, `runtime/chat-stream-handler.test.ts`, `agent/hosted/`
- `deno task verify:quick` exit 0 · `deno task test:unit` 2635 passed / 0 failed · pre-push (fmt + full suite) passed