### PR TITLE
fix(runtime): preserve terminal diagnostics and browser hydration

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1120",
+  "version": "0.1.1121",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1121",
+  "version": "0.1.1122",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1136,6 +1136,7 @@ export class AgentRuntime {
             toolCalls,
             status: this.status,
             usage: totalUsage,
+            metadata: response.finishReason ? { finishReason: response.finishReason } : undefined,
           };
         }
 

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -308,6 +308,63 @@ describe("agent runtime refresh hooks", () => {
     assertEquals(toolResults[0]?.context?.projectId, "project-generate");
   });
 
+  it("preserves the finish reason when generate() stops without final text", async () => {
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/empty-final-text",
+      async doGenerate() {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            content: [{
+              type: "tool-call",
+              toolCallId: "write-1",
+              toolName: "write_report",
+              input: '{"path":"research/report.md"}',
+            }],
+            finishReason: "tool-calls",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          };
+        }
+
+        return {
+          content: [],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 },
+        };
+      },
+      async doStream() {
+        return {
+          stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]),
+        };
+      },
+    };
+
+    const writeReport = tool({
+      id: "write_report",
+      description: "Write a report",
+      inputSchema: defineSchema((v) => v.object({ path: v.string() }))(),
+      execute: ({ path }) => ({ path, created: true }),
+    });
+
+    const assistant = agent({
+      model: "hosted/empty-final-text",
+      system: "Write the report and summarize the result.",
+      tools: { write_report: writeReport },
+      maxSteps: 3,
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    const response = await assistant.generate({ input: "Write a report" });
+
+    assertEquals(callCount, 2);
+    assertEquals(response.status, "completed");
+    assertEquals(response.text, "");
+    assertEquals(response.metadata?.finishReason, "stop");
+    assertEquals(response.toolCalls[0]?.status, "completed");
+  });
+
   it("classifies structured errors returned during generate()", async () => {
     const toolNamesByStep: string[][] = [];
     let callCount = 0;

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -265,6 +265,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     const text = await response.text();
     assertEquals(text.includes("#deno-config"), false);
     assertEquals(text.includes("./version-constant.js"), true);
+    assertEquals(/with\s*\{\s*type\s*:\s*["']json["']\s*\}/.test(text), false);
   });
 
   it("should serve browser React shims imported by npm framework modules", async () => {

--- a/src/transforms/esm/transform-utils.test.ts
+++ b/src/transforms/esm/transform-utils.test.ts
@@ -8,6 +8,7 @@ describe("transforms/esm/transform-utils", () => {
     const cases: Array<[string, string]> = [
       ["pages/index.tsx", "tsx"],
       ["utils/helper.ts", "ts"],
+      ["schemas/lazy.ts.src", "ts"],
       ["components/Button.jsx", "jsx"],
       ["lib/main.js", "js"],
       ["posts/hello.mdx", "jsx"],

--- a/src/transforms/esm/transform-utils.ts
+++ b/src/transforms/esm/transform-utils.ts
@@ -42,7 +42,8 @@ const EXTENSION_LOADERS: Record<string, Loader> = {
 };
 
 export function getLoaderFromPath(filePath: string): Loader {
-  const ext = filePath.slice(filePath.lastIndexOf("."));
+  const sourcePath = filePath.endsWith(".src") ? filePath.slice(0, -4) : filePath;
+  const ext = sourcePath.slice(sourcePath.lastIndexOf("."));
   return EXTENSION_LOADERS[ext] ?? "tsx";
 }
 

--- a/src/transforms/pipeline/stages/resolve-imports.ts
+++ b/src/transforms/pipeline/stages/resolve-imports.ts
@@ -6,6 +6,7 @@
  */
 
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
+import { stripJsonImportAttributes } from "../../esm/import-attributes.ts";
 import { type RewriteContext, rewriteImports } from "../../import-rewriter/index.ts";
 import { type TransformContext, type TransformPlugin, TransformStage } from "../types.ts";
 
@@ -43,6 +44,10 @@ export const resolveImportsPlugin: TransformPlugin = {
 
   async transform(ctx: TransformContext): Promise<string> {
     const rewriteCtx = await buildRewriteContext(ctx);
-    return rewriteImports(ctx.code, rewriteCtx);
+    const code = await rewriteImports(ctx.code, rewriteCtx);
+    return stripJsonImportAttributes(
+      code,
+      (specifier) => specifier === "/_vf_modules/_veryfront/_deno-config.js",
+    );
   },
 };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1120";
+export const VERSION = "0.1.1121";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1121";
+export const VERSION = "0.1.1122";


### PR DESCRIPTION
## Summary

This PR now contains two narrow runtime fixes. The browser hydration fix from #3051 was merged into this branch before #3049 landed, so the combined release is version 0.1.1122.

### Agent completion diagnostics

- preserve provider finishReason in normal non-streaming Agent.generate() responses
- align non-streaming diagnostics with the existing streaming response metadata
- keep empty terminal output runtime-completed and avoid retrying tool side effects

### Browser module hydration

- remove the JSON import attribute only after #deno-config is rewritten to the JavaScript /_vf_modules/_veryfront/_deno-config.js stub
- retain JSON import attributes for real JSON modules
- select the underlying TypeScript or JavaScript loader for paths ending in .ts.src, .tsx.src, and equivalent preserved-source names
- retain the existing TSX fallback for genuinely unknown extensions

### Release

- bump deno.json and the runtime version constant to 0.1.1122

## Why

Veryfront Cloud can complete a final model step without visible assistant text. The provider finish reason reached the runtime bridge but the non-streaming agent path discarded it, preventing consumers from distinguishing a clean stop from output-length exhaustion.

Separately, browser module rewriting could point a JSON-annotated import at a JavaScript stub, and preserved .ts.src module paths could fall through to the TSX loader. Those mismatches caused browser hydration failures in a linked consumer application.

## Verification

- 2,634 unit tests passed with 0 failures
- deno task verify:quick passed
- focused refresh, runtime bridge, provider transport, module-server, loader, import-attribute, and import-rewriter tests passed
- repository pre-push format, lint, typecheck, and unit gates passed
- linked consumer /chat loaded from framework source without dynamic-module errors and became interactive, proving hydration completed
- direct module checks confirmed no stale JSON attribute on the JavaScript config stub and no transform error for lazy.ts.src
- fresh CI is running after updating the branch from main

## Release follow-up

After 0.1.1122 is published, the consumer project will upgrade and repeat its strict staging attachment workflow plus cloud browser hydration verification. Production remains untouched until those staging checks pass.