### PR TITLE
fix(hydration): align browser modules with rewritten targets

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1121",
+  "version": "0.1.1122",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -265,6 +265,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     const text = await response.text();
     assertEquals(text.includes("#deno-config"), false);
     assertEquals(text.includes("./version-constant.js"), true);
+    assertEquals(/with\s*\{\s*type\s*:\s*["']json["']\s*\}/.test(text), false);
   });
 
   it("should serve browser React shims imported by npm framework modules", async () => {

--- a/src/transforms/esm/transform-utils.test.ts
+++ b/src/transforms/esm/transform-utils.test.ts
@@ -8,6 +8,7 @@ describe("transforms/esm/transform-utils", () => {
     const cases: Array<[string, string]> = [
       ["pages/index.tsx", "tsx"],
       ["utils/helper.ts", "ts"],
+      ["schemas/lazy.ts.src", "ts"],
       ["components/Button.jsx", "jsx"],
       ["lib/main.js", "js"],
       ["posts/hello.mdx", "jsx"],

--- a/src/transforms/esm/transform-utils.ts
+++ b/src/transforms/esm/transform-utils.ts
@@ -42,7 +42,8 @@ const EXTENSION_LOADERS: Record<string, Loader> = {
 };
 
 export function getLoaderFromPath(filePath: string): Loader {
-  const ext = filePath.slice(filePath.lastIndexOf("."));
+  const sourcePath = filePath.endsWith(".src") ? filePath.slice(0, -4) : filePath;
+  const ext = sourcePath.slice(sourcePath.lastIndexOf("."));
   return EXTENSION_LOADERS[ext] ?? "tsx";
 }
 

--- a/src/transforms/pipeline/stages/resolve-imports.ts
+++ b/src/transforms/pipeline/stages/resolve-imports.ts
@@ -6,6 +6,7 @@
  */
 
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
+import { stripJsonImportAttributes } from "../../esm/import-attributes.ts";
 import { type RewriteContext, rewriteImports } from "../../import-rewriter/index.ts";
 import { type TransformContext, type TransformPlugin, TransformStage } from "../types.ts";
 
@@ -43,6 +44,10 @@ export const resolveImportsPlugin: TransformPlugin = {
 
   async transform(ctx: TransformContext): Promise<string> {
     const rewriteCtx = await buildRewriteContext(ctx);
-    return rewriteImports(ctx.code, rewriteCtx);
+    const code = await rewriteImports(ctx.code, rewriteCtx);
+    return stripJsonImportAttributes(
+      code,
+      (specifier) => specifier === "/_vf_modules/_veryfront/_deno-config.js",
+    );
   },
 };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1121";
+export const VERSION = "0.1.1122";


### PR DESCRIPTION
## Outcome

Restores client hydration for framework modules served through /_vf_modules without app-level import workarounds.

This PR is intentionally stacked on #3049 so its diff contains only the hydration fix. After #3049 merges, this branch should be rebased onto main and the PR retargeted to main.

## Root cause

- The browser rewrite changed #deno-config from a JSON import to the JavaScript _deno-config.js stub but retained with { type: "json" }, so the browser rejected the module.
- Framework source files resolved as names such as lazy.ts.src fell through to the TSX loader, so TypeScript generic-arrow syntax could be parsed as JSX and fail.

## Fix

- Strip the JSON import attribute only for the rewritten /_vf_modules/_veryfront/_deno-config.js target. Real JSON imports keep their attributes.
- Select the loader from the effective extension before a trailing .src suffix. Unknown extensions retain the existing TSX fallback.
- Add focused regressions for both cloud failures.
- Bump the framework release version to 0.1.1122.

## Verification

- Regression tests were first observed failing against the previous behavior.
- Focused module-server, loader, import-attribute, and import-rewriter tests pass.
- deno task verify:quick passes.
- Full unit suite: 2,634 passed, 0 failed.
- Repository pre-push gate passes.
- A linked consumer app loaded /chat locally through the framework source with no dynamic-module errors; the chat input became interactive, proving hydration completed.
- Direct module checks confirm the version module has no stale JSON attribute and lazy.ts.src compiles without a transform error.

## Release follow-up

After merge and release of 0.1.1122, agentic-job-submission-processing will be upgraded, pushed to Veryfront Cloud main, deployed to staging, and re-verified through the strict attachment workflow and browser hydration path.