### PR TITLE
refactor(utils): canonical safe JSON parse plus truncate and in-file slug dedupe

### DIFF
--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -19,6 +19,7 @@ import {
 } from "./types.ts";
 import { historicalToolSummaries } from "../integrations/_tool_summaries.ts";
 import type { IntegrationEndpointHistoricalSummary } from "../integrations/schema.ts";
+import { safeJsonParse } from "../utils/json.ts";
 
 /** Tunable limits used while preparing chat history for model context. */
 export type MessagePrepLimits = {
@@ -434,11 +435,8 @@ function stableHash(value: unknown): string {
 
 function tryParseJson(value: unknown): unknown {
   if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
+  const r = safeJsonParse(value);
+  return r.ok ? r.value : value;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -19,7 +19,7 @@ import {
 } from "./types.ts";
 import { historicalToolSummaries } from "../integrations/_tool_summaries.ts";
 import type { IntegrationEndpointHistoricalSummary } from "../integrations/schema.ts";
-import { safeJsonParse } from "../utils/json.ts";
+import { safeJsonParse } from "#veryfront/utils/json.ts";
 
 /** Tunable limits used while preparing chat history for model context. */
 export type MessagePrepLimits = {

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -40,17 +40,9 @@ function isErrorRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/** Result returned from safe JSON parse. */
-export type SafeJsonParseResult = { ok: true; value: unknown } | { ok: false; error: Error };
-
-/** Parse JSON safely without throwing. */
-export function safeJsonParse(value: string): SafeJsonParseResult {
-  try {
-    return { ok: true, value: JSON.parse(value) };
-  } catch (error) {
-    return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
-  }
-}
+import { safeJsonParse } from "../utils/json.ts";
+export { safeJsonParse };
+export type { SafeJsonParseResult } from "../utils/json.ts";
 
 function parseErrorJson(value: string): unknown | null {
   const parsed = safeJsonParse(value);

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -1,3 +1,7 @@
+import { safeJsonParse } from "#veryfront/utils/json.ts";
+export { safeJsonParse };
+export type { SafeJsonParseResult } from "#veryfront/utils/json.ts";
+
 /** Error shape for parsed provider. */
 export interface ParsedProviderError {
   code: string;
@@ -39,10 +43,6 @@ const AI_PROVIDER_BILLING_ERROR = {
 function isErrorRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-
-import { safeJsonParse } from "../utils/json.ts";
-export { safeJsonParse };
-export type { SafeJsonParseResult } from "../utils/json.ts";
 
 function parseErrorJson(value: string): unknown | null {
   const parsed = safeJsonParse(value);

--- a/src/embedding/veryfront-cloud/rag-store.ts
+++ b/src/embedding/veryfront-cloud/rag-store.ts
@@ -165,13 +165,17 @@ function normalizeEmbeddingModelDescriptor(model: string, dimension: SupportedDi
   };
 }
 
+function normalizeExtension(type: string | undefined): string | undefined {
+  return type?.trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
 function buildDocumentFilePath(documentId: string, type?: string): string {
-  const extension = type?.trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+  const extension = normalizeExtension(type);
   return `${DOCUMENTS_DIR}/${documentId}.${extension || "txt"}`;
 }
 
 function buildRefreshDocumentFilePath(documentId: string, type?: string): string {
-  const extension = type?.trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+  const extension = normalizeExtension(type);
   return `${DOCUMENTS_DIR}/${documentId}.refresh-${crypto.randomUUID()}.${extension || "txt"}`;
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -136,3 +136,5 @@ export {
 export { endRequest, isEnabled, startRequest, startTimer, timeAsync } from "./perf-timer.ts";
 
 export { parallelMap } from "./parallel.ts";
+
+export { safeJsonParse, type SafeJsonParseResult } from "./json.ts";

--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -1,0 +1,41 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertInstanceOf } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import { safeJsonParse } from "./json.ts";
+
+describe("safeJsonParse", () => {
+  it("parses a valid JSON string", () => {
+    const r = safeJsonParse('{"a":1}');
+    assertEquals(r.ok, true);
+    if (r.ok) assertEquals(r.value, { a: 1 });
+  });
+
+  it("parses a JSON number", () => {
+    const r = safeJsonParse("42");
+    assertEquals(r.ok, true);
+    if (r.ok) assertEquals(r.value, 42);
+  });
+
+  it("parses a JSON array", () => {
+    const r = safeJsonParse("[1,2,3]");
+    assertEquals(r.ok, true);
+    if (r.ok) assertEquals(r.value, [1, 2, 3]);
+  });
+
+  it("returns ok:false for invalid JSON", () => {
+    const r = safeJsonParse("not json");
+    assertEquals(r.ok, false);
+    if (!r.ok) assertInstanceOf(r.error, Error);
+  });
+
+  it("returns ok:false for an empty string", () => {
+    const r = safeJsonParse("");
+    assertEquals(r.ok, false);
+  });
+
+  it("accepts a type parameter for typed results", () => {
+    const r = safeJsonParse<{ name: string }>('{"name":"alice"}');
+    assertEquals(r.ok, true);
+    if (r.ok) assertEquals(r.value.name, "alice");
+  });
+});

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,22 @@
+/**
+ * Safe JSON parse utilities, dependency-free.
+ *
+ * @module utils/json
+ */
+
+/** Tagged-union result of {@link safeJsonParse}; narrow via the `ok` discriminant. */
+export type SafeJsonParseResult<T = unknown> =
+  | { ok: true; value: T }
+  | { ok: false; error: Error };
+
+/**
+ * Parse `value` as JSON without throwing; failures return `{ ok: false, error }`
+ * so callers handle them without a surrounding try/catch.
+ */
+export function safeJsonParse<T = unknown>(value: string): SafeJsonParseResult<T> {
+  try {
+    return { ok: true, value: JSON.parse(value) as T };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
+  }
+}

--- a/src/utils/logger/redact.ts
+++ b/src/utils/logger/redact.ts
@@ -204,6 +204,8 @@ const SENSITIVE_URL_PARAMS = [
   "auth",
 ] as const;
 
+const NORMALIZED_SENSITIVE_URL_PARAMS = new Set(SENSITIVE_URL_PARAMS.map(normalizeToAlphanumeric));
+
 const URL_USERINFO_RE = /(\b[a-z][a-z0-9+.-]*:\/\/)([^/?#@\s]+)@/gi;
 
 /**
@@ -239,8 +241,7 @@ export function sanitizeUrlCredentials(input: string): string {
   out = out.replace(
     /([?&;])([a-z0-9_.\-]+)=([^&#;\s]*)/gi,
     (match, sep: string, key: string, _val: string) => {
-      const normalized = normalizeToAlphanumeric(key);
-      const sensitive = SENSITIVE_URL_PARAMS.some((p) => normalized === normalizeToAlphanumeric(p));
+      const sensitive = NORMALIZED_SENSITIVE_URL_PARAMS.has(normalizeToAlphanumeric(key));
       return sensitive ? `${sep}${key}=${REDACTED}` : match;
     },
   );

--- a/src/utils/logger/redact.ts
+++ b/src/utils/logger/redact.ts
@@ -22,6 +22,11 @@ import { isRecord } from "./core.ts";
 /** Replacement value substituted for any sensitive field. */
 export const REDACTED = "[REDACTED]";
 
+/** Strip all non-alphanumeric characters and lowercase, used for key normalization. */
+function normalizeToAlphanumeric(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 /**
  * Normalized substrings that mark a key as sensitive. Matching is done against
  * a lowercased, non-alphanumeric-stripped form of the key, so `API-Key`,
@@ -78,7 +83,7 @@ export function isSensitiveKey(key: string): boolean {
   const cached = sensitiveKeyCache.get(key);
   if (cached !== undefined) return cached;
 
-  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const normalized = normalizeToAlphanumeric(key);
   const sensitive = SENSITIVE_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
 
   if (sensitiveKeyCache.size >= SENSITIVE_KEY_CACHE_MAX_SIZE) {
@@ -234,10 +239,8 @@ export function sanitizeUrlCredentials(input: string): string {
   out = out.replace(
     /([?&;])([a-z0-9_.\-]+)=([^&#;\s]*)/gi,
     (match, sep: string, key: string, _val: string) => {
-      const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
-      const sensitive = SENSITIVE_URL_PARAMS.some((p) =>
-        normalized === p.replace(/[^a-z0-9]/g, "")
-      );
+      const normalized = normalizeToAlphanumeric(key);
+      const sensitive = SENSITIVE_URL_PARAMS.some((p) => normalized === normalizeToAlphanumeric(p));
       return sensitive ? `${sep}${key}=${REDACTED}` : match;
     },
   );

--- a/src/workflow/backends/redis/index.ts
+++ b/src/workflow/backends/redis/index.ts
@@ -17,7 +17,7 @@ import type {
   WorkflowStatus,
 } from "../../types.ts";
 import { assertWorkflowRunUpdate, type WorkflowBackend, type WorkflowRunUpdate } from "../types.ts";
-import { agentLogger } from "#veryfront/utils";
+import { agentLogger, safeJsonParse } from "#veryfront/utils";
 import { requeueRun } from "../shared/requeue-run.ts";
 import { INITIALIZATION_ERROR, INVALID_ARGUMENT, RESOURCE_NOT_FOUND } from "#veryfront/errors";
 import { requireWorkflowSourceIntegrationPolicy } from "../../source-integration-policy.ts";
@@ -399,21 +399,17 @@ export class RedisBackend implements WorkflowBackend {
       });
     }
 
-    function parseJson<T>(
-      runId: string,
-      field: string,
-      value: string,
-    ): T {
-      try {
-        return JSON.parse(value) as T;
-      } catch (e) {
+    function parseJson<T>(runId: string, field: string, value: string): T {
+      const r = safeJsonParse<T>(value);
+      if (!r.ok) {
         throw INVALID_ARGUMENT.create({
           detail:
             `Invalid workflow run data for run "${runId}": failed to parse '${field}' as JSON. ` +
-            `Error: ${e instanceof Error ? e.message : String(e)}`,
-          cause: e instanceof Error ? e : undefined,
+            `Error: ${r.error.message}`,
+          cause: r.error,
         });
       }
+      return r.value;
     }
 
     function parseJsonOr<T>(


### PR DESCRIPTION
## Summary

Utility-survey follow-up sweep, scoped to identical-semantics-only unification.

- **`safeJsonParse`** — the three named parse-without-throwing impls (`chat/provider-errors.ts`, `chat/message-prep.ts` `tryParseJson`, `workflow/backends/redis` `parseJson<T>`) collapse onto one canonical tagged-union helper in `#veryfront/utils` (`src/utils/json.ts`), with a dedicated test suite.
- **In-file slug dedupe** — `logger/redact.ts` and `embedding/.../rag-store.ts` each defined the same normalize expression twice in-file; now one named helper per file (single point of change).
- **Truncate helpers: deliberately NOT unified** — verified every variant differs from the canonical `truncateText` in real ways (byte-based truncation, `\n[truncated]` markers, off-by-one ellipsis math). Forcing them together would change behavior.

## Accounting — flagged honestly

**Src +17** (+51/−34), tests +41. This misses the campaign's reduction rule: the three parsers were small and the canonical (with required barrel JSDoc) plus the two named helpers cost more than the copies saved. What it buys is one JSON-parse convention with its own tests instead of three, and slug normalization that can't drift within its files. If the line count outweighs that for you, closing this PR loses nothing else.

## Verification
- All touched-module suites pass unmodified (chat, workflow/backends, embedding, utils: 44 files / 314 steps)
- `deno task verify:quick` exit 0 · pre-push (fmt + full suite) passed