### PR TITLE
refactor(react): one useDisclosure and shared Modal/Anchored surfaces for overlays

### DIFF
--- a/src/react/components/ui/anchored-surface.tsx
+++ b/src/react/components/ui/anchored-surface.tsx
@@ -1,7 +1,7 @@
 /**
  * Shared behavioral machinery for Popover and DropdownMenu.
  * TODO(a11y): focus trap, portal + collision-aware positioning (flip/shift),
- * aria-controls/aria-expanded, side/align offsets.
+ * aria-controls, side/align offsets.
  * DropdownMenu: roving focus, typeahead, Tab, aria-activedescendant, sub menus.
  * @module react/components/ui/anchored-surface
  */

--- a/src/react/components/ui/anchored-surface.tsx
+++ b/src/react/components/ui/anchored-surface.tsx
@@ -1,0 +1,105 @@
+/**
+ * Shared behavioral machinery for Popover and DropdownMenu.
+ * TODO(a11y): focus trap, portal + collision-aware positioning (flip/shift),
+ * aria-controls/aria-expanded, side/align offsets.
+ * DropdownMenu: roving focus, typeahead, Tab, aria-activedescendant, sub menus.
+ * @module react/components/ui/anchored-surface
+ */
+import * as React from "react";
+import { cx as cn } from "./cva.ts";
+import { Slot } from "./slot.tsx";
+import { Floating } from "./floating.tsx";
+import { type DisclosureOptions, useDisclosure } from "./disclosure.ts";
+
+/** Context value shared between an anchored skin's Root and its parts. */
+export interface AnchoredState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  anchorRef: React.RefObject<HTMLElement | null>;
+}
+
+/** Context for Popover and DropdownMenu skins. */
+export const AnchoredContext = React.createContext<AnchoredState | null>(null);
+
+/**
+ * Anchor `<span>` + disclosure state + context provider.
+ * Both `<Popover>` and `<DropdownMenu>` delegate here — the span is the
+ * positioning anchor for `Floating`.
+ */
+export function AnchoredRoot(
+  { children, open, defaultOpen, onOpenChange }: DisclosureOptions & { children: React.ReactNode },
+): React.ReactElement {
+  const { open: isOpen, setOpen } = useDisclosure({ open, defaultOpen, onOpenChange });
+  const anchorRef = React.useRef<HTMLElement | null>(null);
+  const ctx = React.useMemo(() => ({ open: isOpen, setOpen, anchorRef }), [isOpen, setOpen]);
+  return (
+    <span ref={anchorRef} className="relative inline-block">
+      <AnchoredContext.Provider value={ctx}>
+        {children}
+      </AnchoredContext.Provider>
+    </span>
+  );
+}
+
+/** Props for `AnchoredTrigger`. */
+export interface AnchoredTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+  /** `aria-haspopup` value — `"dialog"` for Popover, `"menu"` for DropdownMenu. */
+  haspopup: NonNullable<React.AriaAttributes["aria-haspopup"]>;
+}
+
+/**
+ * Toggle trigger for anchored surfaces. Sets `aria-haspopup`/`aria-expanded`;
+ * skins differ only in the `haspopup` value they pass.
+ */
+export function AnchoredTrigger(
+  { children, asChild, onClick, haspopup, ...props }: AnchoredTriggerProps,
+): React.ReactElement {
+  const ctx = React.useContext(AnchoredContext);
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      {...(asChild ? {} : { type: "button" as const })}
+      aria-haspopup={haspopup}
+      aria-expanded={ctx?.open}
+      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+        onClick?.(e);
+        ctx?.setOpen(!ctx.open);
+      }}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+}
+
+/** Props for `AnchoredContent`. */
+export interface AnchoredContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  align?: "start" | "end";
+}
+
+/**
+ * `Floating` wrapper with base anchored-surface classes.
+ * Skins extend via `className` (min-width, padding) and `role`.
+ */
+export function AnchoredContent(
+  { children, className, align, ...props }: AnchoredContentProps,
+): React.ReactElement | null {
+  const ctx = React.useContext(AnchoredContext);
+  if (!ctx) return null;
+  return (
+    <Floating
+      anchorRef={ctx.anchorRef}
+      open={ctx.open}
+      align={align}
+      onDismiss={() => ctx.setOpen(false)}
+      className={cn(
+        "z-50 overflow-hidden rounded-lg bg-[var(--popover)] text-[var(--foreground)] shadow-sm outline-none",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Floating>
+  );
+}

--- a/src/react/components/ui/anchored-surface.tsx
+++ b/src/react/components/ui/anchored-surface.tsx
@@ -18,88 +18,100 @@ export interface AnchoredState {
   anchorRef: React.RefObject<HTMLElement | null>;
 }
 
-/** Context for Popover and DropdownMenu skins. */
-export const AnchoredContext = React.createContext<AnchoredState | null>(null);
-
-/**
- * Anchor `<span>` + disclosure state + context provider.
- * Both `<Popover>` and `<DropdownMenu>` delegate here — the span is the
- * positioning anchor for `Floating`.
- */
-export function AnchoredRoot(
-  { children, open, defaultOpen, onOpenChange }: DisclosureOptions & { children: React.ReactNode },
-): React.ReactElement {
-  const { open: isOpen, setOpen } = useDisclosure({ open, defaultOpen, onOpenChange });
-  const anchorRef = React.useRef<HTMLElement | null>(null);
-  const ctx = React.useMemo(() => ({ open: isOpen, setOpen, anchorRef }), [isOpen, setOpen]);
-  return (
-    <span ref={anchorRef} className="relative inline-block">
-      <AnchoredContext.Provider value={ctx}>
-        {children}
-      </AnchoredContext.Provider>
-    </span>
-  );
-}
-
-/** Props for `AnchoredTrigger`. */
+/** Props for `AnchoredTrigger` (returned by the factory). */
 export interface AnchoredTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean;
-  /** `aria-haspopup` value — `"dialog"` for Popover, `"menu"` for DropdownMenu. */
+  /** `aria-haspopup` value -- `"dialog"` for Popover, `"menu"` for DropdownMenu. */
   haspopup: NonNullable<React.AriaAttributes["aria-haspopup"]>;
 }
 
-/**
- * Toggle trigger for anchored surfaces. Sets `aria-haspopup`/`aria-expanded`;
- * skins differ only in the `haspopup` value they pass.
- */
-export function AnchoredTrigger(
-  { children, asChild, onClick, haspopup, ...props }: AnchoredTriggerProps,
-): React.ReactElement {
-  const ctx = React.useContext(AnchoredContext);
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      {...(asChild ? {} : { type: "button" as const })}
-      aria-haspopup={haspopup}
-      aria-expanded={ctx?.open}
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        ctx?.setOpen(!ctx.open);
-      }}
-      {...props}
-    >
-      {children}
-    </Comp>
-  );
-}
-
-/** Props for `AnchoredContent`. */
+/** Props for `AnchoredContent` (returned by the factory). */
 export interface AnchoredContentProps extends React.HTMLAttributes<HTMLDivElement> {
   align?: "start" | "end";
 }
 
 /**
- * `Floating` wrapper with base anchored-surface classes.
- * Skins extend via `className` (min-width, padding) and `role`.
+ * Creates a fresh context instance plus the AnchoredRoot, AnchoredTrigger, and
+ * AnchoredContent parts -- all bound to that context.
+ *
+ * Each skin (Popover, DropdownMenu) calls this ONCE at module scope so their
+ * contexts are distinct objects. This prevents cross-binding when one skin is
+ * nested inside the other or inside a modal skin: a DropdownMenuItem close
+ * call only affects the DropdownMenu whose context is in scope, never a
+ * Popover above it in the tree.
  */
-export function AnchoredContent(
-  { children, className, align, ...props }: AnchoredContentProps,
-): React.ReactElement | null {
-  const ctx = React.useContext(AnchoredContext);
-  if (!ctx) return null;
-  return (
-    <Floating
-      anchorRef={ctx.anchorRef}
-      open={ctx.open}
-      align={align}
-      onDismiss={() => ctx.setOpen(false)}
-      className={cn(
-        "z-50 overflow-hidden rounded-lg bg-[var(--popover)] text-[var(--foreground)] shadow-sm outline-none",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </Floating>
-  );
+export function createAnchoredSurfaceParts() {
+  const Context = React.createContext<AnchoredState | null>(null);
+
+  /**
+   * Anchor `<span>` + disclosure state + context provider.
+   * The span is the positioning anchor for `Floating`.
+   */
+  function AnchoredRoot(
+    { children, open, defaultOpen, onOpenChange }: DisclosureOptions & {
+      children: React.ReactNode;
+    },
+  ): React.ReactElement {
+    const { open: isOpen, setOpen } = useDisclosure({ open, defaultOpen, onOpenChange });
+    const anchorRef = React.useRef<HTMLElement | null>(null);
+    const ctx = React.useMemo(() => ({ open: isOpen, setOpen, anchorRef }), [isOpen, setOpen]);
+    return (
+      <span ref={anchorRef} className="relative inline-block">
+        <Context.Provider value={ctx}>
+          {children}
+        </Context.Provider>
+      </span>
+    );
+  }
+
+  /**
+   * Toggle trigger. Sets `aria-haspopup` and `aria-expanded`; toggles open on
+   * click. Skins differ only in the `haspopup` value they supply.
+   */
+  function AnchoredTrigger(
+    { children, asChild, onClick, haspopup, ...props }: AnchoredTriggerProps,
+  ): React.ReactElement {
+    const ctx = React.useContext(Context);
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        {...(asChild ? {} : { type: "button" as const })}
+        aria-haspopup={haspopup}
+        aria-expanded={ctx?.open}
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          onClick?.(e);
+          // Guard ctx before reading ctx.open (trigger may render outside a Root).
+          if (ctx) ctx.setOpen(!ctx.open);
+        }}
+        {...props}
+      >
+        {children}
+      </Comp>
+    );
+  }
+
+  /** `Floating` wrapper with base classes. Skins extend via `className` and `role`. */
+  function AnchoredContent(
+    { children, className, align, ...props }: AnchoredContentProps,
+  ): React.ReactElement | null {
+    const ctx = React.useContext(Context);
+    if (!ctx) return null;
+    return (
+      <Floating
+        anchorRef={ctx.anchorRef}
+        open={ctx.open}
+        align={align}
+        onDismiss={() => ctx.setOpen(false)}
+        className={cn(
+          "z-50 overflow-hidden rounded-lg bg-[var(--popover)] text-[var(--foreground)] shadow-sm outline-none",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </Floating>
+    );
+  }
+
+  return { Context, AnchoredRoot, AnchoredTrigger, AnchoredContent };
 }

--- a/src/react/components/ui/collapsible.tsx
+++ b/src/react/components/ui/collapsible.tsx
@@ -11,6 +11,7 @@
  */
 import * as React from "react";
 import { Slot } from "./slot.tsx";
+import { useDisclosure } from "./disclosure.ts";
 
 const CollapsibleContext = React.createContext<
   { open: boolean; toggle: () => void; disabled?: boolean } | null
@@ -33,14 +34,8 @@ export function Collapsible({
   children,
   ...props
 }: CollapsibleProps): React.ReactElement {
-  const [internal, setInternal] = React.useState(defaultOpen ?? false);
-  const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : internal;
-  const toggle = React.useCallback(() => {
-    const next = !isOpen;
-    if (!isControlled) setInternal(next);
-    onOpenChange?.(next);
-  }, [isOpen, isControlled, onOpenChange]);
+  const { open: isOpen, setOpen } = useDisclosure({ open, defaultOpen, onOpenChange });
+  const toggle = React.useCallback(() => setOpen(!isOpen), [isOpen, setOpen]);
   return (
     <div data-state={isOpen ? "open" : "closed"} {...props}>
       <CollapsibleContext.Provider value={{ open: isOpen, toggle, disabled }}>

--- a/src/react/components/ui/dialog.tsx
+++ b/src/react/components/ui/dialog.tsx
@@ -3,28 +3,22 @@
  * Trigger / Content + Header / Title / Description / Body / Footer / Action /
  * Cancel / Close / Form). Classes ported 1:1 from Studio's `Dialog` (tokens
  * remapped; `Heading` level 2 + `Text` inlined). Modal overlay + centered panel;
- * dismisses on `Escape` and overlay click.
- *
- * TODO(a11y): focus trap + restore, `aria-labelledby`/`aria-describedby` wiring,
- * scroll-lock, portal, enter/exit animation. Private to the chat module.
+ * dismisses on `Escape` and overlay click. A11y work tracked in modal-surface.tsx.
  *
  * @module react/components/ui/dialog
  */
 import * as React from "react";
 import { cx as cn } from "./cva.ts";
-import { Slot } from "./slot.tsx";
 import { ScrollFade } from "./scroll-fade.tsx";
 import { Button, type ButtonProps, LoadingButton } from "./button.tsx";
-
-const DialogContext = React.createContext<
-  { open: boolean; setOpen: (open: boolean) => void } | null
->(null);
-
-function useDialog() {
-  const ctx = React.useContext(DialogContext);
-  if (!ctx) throw new Error("Dialog parts must be used within <Dialog>");
-  return ctx;
-}
+import { useDisclosure } from "./disclosure.ts";
+import {
+  ModalClose,
+  ModalContent,
+  ModalContext,
+  ModalTrigger,
+  useModal,
+} from "./modal-surface.tsx";
 
 /** Props accepted by `<Dialog>`. */
 export interface DialogProps {
@@ -41,41 +35,20 @@ export function Dialog({
   defaultOpen,
   onOpenChange,
 }: DialogProps): React.ReactElement {
-  const [internal, setInternal] = React.useState(defaultOpen ?? false);
-  const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : internal;
-  const setOpen = React.useCallback((next: boolean) => {
-    if (!isControlled) setInternal(next);
-    onOpenChange?.(next);
-  }, [isControlled, onOpenChange]);
+  const { open: isOpen, setOpen } = useDisclosure({ open, defaultOpen, onOpenChange });
+  const ctx = React.useMemo(() => ({ open: isOpen, setOpen }), [isOpen, setOpen]);
   return (
-    <DialogContext.Provider value={{ open: isOpen, setOpen }}>
+    <ModalContext.Provider value={ctx}>
       {children}
-    </DialogContext.Provider>
+    </ModalContext.Provider>
   );
 }
 
 /** Trigger — opens the dialog. `asChild` merges onto the child element. */
-export function DialogTrigger({
-  children,
-  asChild,
-  onClick,
-  ...props
-}: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }): React.ReactElement {
-  const ctx = useDialog();
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      {...(asChild ? {} : { type: "button" as const })}
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        ctx.setOpen(true);
-      }}
-      {...props}
-    >
-      {children}
-    </Comp>
-  );
+export function DialogTrigger(
+  props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
+): React.ReactElement {
+  return <ModalTrigger {...props} />;
 }
 
 /** Modal surface — overlay + centered panel, rendered while open. */
@@ -84,47 +57,17 @@ export function DialogContent({
   children,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>): React.ReactElement | null {
-  const ctx = useDialog();
-  const panelRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    if (!ctx.open) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") ctx.setOpen(false);
-    };
-    document.addEventListener("keydown", onKeyDown);
-    // Focus the first focusable descendant on open (radix-like) — e.g. a
-    // CommandInput — falling back to the panel itself. Full focus-trap is TODO.
-    const panel = panelRef.current;
-    const focusable = panel?.querySelector<HTMLElement>(
-      'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
-    );
-    (focusable ?? panel)?.focus();
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [ctx.open]);
-
-  if (!ctx.open) return null;
   return (
-    <div className="fixed inset-0 z-50">
-      <div
-        className="fixed inset-0 bg-[var(--overlay)]"
-        onClick={() => ctx.setOpen(false)}
-      />
-      <div
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        tabIndex={-1}
-        className={cn(
-          "fixed left-1/2 top-1/2 z-50 w-[calc(100%-3rem)] max-w-xl max-h-[85vh] -translate-x-1/2 -translate-y-1/2",
-          "rounded-xl bg-[var(--dialog)] text-[var(--foreground)] shadow-lg outline-none overflow-hidden flex flex-col",
-          className,
-        )}
-        {...props}
-      >
-        {children}
-      </div>
-    </div>
+    <ModalContent
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 w-[calc(100%-3rem)] max-w-xl max-h-[85vh] -translate-x-1/2 -translate-y-1/2",
+        "rounded-xl bg-[var(--dialog)] text-[var(--foreground)] shadow-lg outline-none overflow-hidden flex flex-col",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ModalContent>
   );
 }
 
@@ -231,7 +174,7 @@ export function DialogCancel({
   onClick,
   ...props
 }: ButtonProps): React.ReactElement {
-  const ctx = useDialog();
+  const ctx = useModal("Dialog");
   return (
     <Button
       variant={variant}
@@ -247,24 +190,8 @@ export function DialogCancel({
 }
 
 /** Closes the dialog. `asChild` merges onto the child element. */
-export function DialogClose({
-  children,
-  asChild,
-  onClick,
-  ...props
-}: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }): React.ReactElement {
-  const ctx = useDialog();
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      {...(asChild ? {} : { type: "button" as const })}
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        ctx.setOpen(false);
-      }}
-      {...props}
-    >
-      {children}
-    </Comp>
-  );
+export function DialogClose(
+  props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
+): React.ReactElement {
+  return <ModalClose {...props} />;
 }

--- a/src/react/components/ui/dialog.tsx
+++ b/src/react/components/ui/dialog.tsx
@@ -11,14 +11,17 @@ import * as React from "react";
 import { cx as cn } from "./cva.ts";
 import { ScrollFade } from "./scroll-fade.tsx";
 import { Button, type ButtonProps, LoadingButton } from "./button.tsx";
-import { useDisclosure } from "./disclosure.ts";
-import {
-  ModalClose,
-  ModalContent,
-  ModalContext,
-  ModalTrigger,
-  useModal,
-} from "./modal-surface.tsx";
+import { createModalSurfaceParts } from "./modal-surface.tsx";
+
+// Per-skin context + machinery -- distinct from Drawer's instance so a
+// DrawerClose nested inside a Dialog cannot accidentally close the Dialog.
+const {
+  ModalRoot: _Root,
+  useModal: _hook,
+  ModalTrigger: _Trigger,
+  ModalClose: _Close,
+  ModalContent: _Content,
+} = createModalSurfaceParts("Dialog");
 
 /** Props accepted by `<Dialog>`. */
 export interface DialogProps {
@@ -29,26 +32,15 @@ export interface DialogProps {
 }
 
 /** Dialog root — owns open state. */
-export function Dialog({
-  children,
-  open,
-  defaultOpen,
-  onOpenChange,
-}: DialogProps): React.ReactElement {
-  const { open: isOpen, setOpen } = useDisclosure({ open, defaultOpen, onOpenChange });
-  const ctx = React.useMemo(() => ({ open: isOpen, setOpen }), [isOpen, setOpen]);
-  return (
-    <ModalContext.Provider value={ctx}>
-      {children}
-    </ModalContext.Provider>
-  );
+export function Dialog(props: DialogProps): React.ReactElement {
+  return <_Root {...props} />;
 }
 
 /** Trigger — opens the dialog. `asChild` merges onto the child element. */
 export function DialogTrigger(
   props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
 ): React.ReactElement {
-  return <ModalTrigger {...props} />;
+  return <_Trigger {...props} />;
 }
 
 /** Modal surface — overlay + centered panel, rendered while open. */
@@ -58,7 +50,7 @@ export function DialogContent({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>): React.ReactElement | null {
   return (
-    <ModalContent
+    <_Content
       className={cn(
         "fixed left-1/2 top-1/2 z-50 w-[calc(100%-3rem)] max-w-xl max-h-[85vh] -translate-x-1/2 -translate-y-1/2",
         "rounded-xl bg-[var(--dialog)] text-[var(--foreground)] shadow-lg outline-none overflow-hidden flex flex-col",
@@ -67,7 +59,7 @@ export function DialogContent({
       {...props}
     >
       {children}
-    </ModalContent>
+    </_Content>
   );
 }
 
@@ -174,7 +166,7 @@ export function DialogCancel({
   onClick,
   ...props
 }: ButtonProps): React.ReactElement {
-  const ctx = useModal("Dialog");
+  const ctx = _hook();
   return (
     <Button
       variant={variant}
@@ -193,5 +185,5 @@ export function DialogCancel({
 export function DialogClose(
   props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
 ): React.ReactElement {
-  return <ModalClose {...props} />;
+  return <_Close {...props} />;
 }

--- a/src/react/components/ui/disclosure.ts
+++ b/src/react/components/ui/disclosure.ts
@@ -1,0 +1,27 @@
+/**
+ * useDisclosure — shared controlled/uncontrolled open state for overlay surfaces.
+ * @module react/components/ui/disclosure
+ */
+import * as React from "react";
+
+/** Options accepted by `useDisclosure`. */
+export interface DisclosureOptions {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+/** Returns `{ open, setOpen }`, handling controlled and uncontrolled usage. */
+export function useDisclosure({ open, defaultOpen, onOpenChange }: DisclosureOptions) {
+  const [internal, setInternal] = React.useState(defaultOpen ?? false);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : internal;
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternal(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+  return { open: isOpen, setOpen };
+}

--- a/src/react/components/ui/disclosure.ts
+++ b/src/react/components/ui/disclosure.ts
@@ -1,5 +1,5 @@
 /**
- * useDisclosure — shared controlled/uncontrolled open state for overlay surfaces.
+ * useDisclosure: shared controlled/uncontrolled open state for overlay surfaces.
  * @module react/components/ui/disclosure
  */
 import * as React from "react";
@@ -15,13 +15,18 @@ export interface DisclosureOptions {
 export function useDisclosure({ open, defaultOpen, onOpenChange }: DisclosureOptions) {
   const [internal, setInternal] = React.useState(defaultOpen ?? false);
   const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : internal;
+  const isOpen: boolean = open ?? internal;
+  // Latest-ref pattern: setOpen keeps a stable identity across parent renders
+  // (so effect consumers do not re-register listeners) while always invoking
+  // the caller's current onOpenChange.
+  const onOpenChangeRef = React.useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
   const setOpen = React.useCallback(
     (next: boolean) => {
       if (!isControlled) setInternal(next);
-      onOpenChange?.(next);
+      onOpenChangeRef.current?.(next);
     },
-    [isControlled, onOpenChange],
+    [isControlled],
   );
   return { open: isOpen, setOpen };
 }

--- a/src/react/components/ui/drawer.tsx
+++ b/src/react/components/ui/drawer.tsx
@@ -10,8 +10,12 @@
  */
 import * as React from "react";
 import { cx as cn } from "./cva.ts";
-import { useDisclosure } from "./disclosure.ts";
-import { ModalClose, ModalContent, ModalContext, ModalTrigger } from "./modal-surface.tsx";
+import { createModalSurfaceParts } from "./modal-surface.tsx";
+
+// Per-skin context + machinery -- distinct from Dialog's instance so a
+// DialogClose nested inside a Drawer cannot accidentally close the Drawer.
+const { ModalRoot: _Root, ModalTrigger: _Trigger, ModalClose: _Close, ModalContent: _Content } =
+  createModalSurfaceParts("Drawer");
 
 /** Props accepted by `<Drawer>`. */
 export interface DrawerProps {
@@ -22,26 +26,15 @@ export interface DrawerProps {
 }
 
 /** Drawer root — owns open state. */
-export function Drawer({
-  children,
-  open,
-  defaultOpen,
-  onOpenChange,
-}: DrawerProps): React.ReactElement {
-  const { open: isOpen, setOpen } = useDisclosure({ open, defaultOpen, onOpenChange });
-  const ctx = React.useMemo(() => ({ open: isOpen, setOpen }), [isOpen, setOpen]);
-  return (
-    <ModalContext.Provider value={ctx}>
-      {children}
-    </ModalContext.Provider>
-  );
+export function Drawer(props: DrawerProps): React.ReactElement {
+  return <_Root {...props} />;
 }
 
 /** Trigger — opens the drawer. `asChild` merges onto the child element. */
 export function DrawerTrigger(
   props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
 ): React.ReactElement {
-  return <ModalTrigger {...props} />;
+  return <_Trigger {...props} />;
 }
 
 /** Bottom sheet — overlay + sliding surface with a drag handle. */
@@ -51,7 +44,7 @@ export function DrawerContent({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>): React.ReactElement | null {
   return (
-    <ModalContent
+    <_Content
       className={cn(
         "fixed inset-x-0 bottom-0 z-50 flex flex-col max-h-[85vh] w-full rounded-t-xl bg-[var(--drawer)] text-[var(--foreground)] outline-none",
         className,
@@ -65,7 +58,7 @@ export function DrawerContent({
       {...props}
     >
       {children}
-    </ModalContent>
+    </_Content>
   );
 }
 
@@ -120,5 +113,5 @@ export function DrawerFooter(
 export function DrawerClose(
   props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
 ): React.ReactElement {
-  return <ModalClose {...props} />;
+  return <_Close {...props} />;
 }

--- a/src/react/components/ui/drawer.tsx
+++ b/src/react/components/ui/drawer.tsx
@@ -3,26 +3,15 @@
  * Vaul-style component). Same API shape for the parts we need: Root / Trigger /
  * Content (overlay + sheet + drag handle) / Title / Header / Body / Footer /
  * Close. Surface classes ported 1:1 from Studio (tokens remapped). Slides up
- * from the bottom; dismisses on `Escape` and overlay click.
- *
- * TODO(a11y): focus trap + restore, drag-to-dismiss / snap points, scroll-lock,
- * portal, enter/exit animation. Private to the chat module.
+ * from the bottom; dismisses on `Escape` and overlay click. A11y work tracked
+ * in modal-surface.tsx.
  *
  * @module react/components/ui/drawer
  */
 import * as React from "react";
 import { cx as cn } from "./cva.ts";
-import { Slot } from "./slot.tsx";
-
-const DrawerContext = React.createContext<
-  { open: boolean; setOpen: (open: boolean) => void } | null
->(null);
-
-function useDrawer() {
-  const ctx = React.useContext(DrawerContext);
-  if (!ctx) throw new Error("Drawer parts must be used within <Drawer>");
-  return ctx;
-}
+import { useDisclosure } from "./disclosure.ts";
+import { ModalClose, ModalContent, ModalContext, ModalTrigger } from "./modal-surface.tsx";
 
 /** Props accepted by `<Drawer>`. */
 export interface DrawerProps {
@@ -39,41 +28,20 @@ export function Drawer({
   defaultOpen,
   onOpenChange,
 }: DrawerProps): React.ReactElement {
-  const [internal, setInternal] = React.useState(defaultOpen ?? false);
-  const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : internal;
-  const setOpen = React.useCallback((next: boolean) => {
-    if (!isControlled) setInternal(next);
-    onOpenChange?.(next);
-  }, [isControlled, onOpenChange]);
+  const { open: isOpen, setOpen } = useDisclosure({ open, defaultOpen, onOpenChange });
+  const ctx = React.useMemo(() => ({ open: isOpen, setOpen }), [isOpen, setOpen]);
   return (
-    <DrawerContext.Provider value={{ open: isOpen, setOpen }}>
+    <ModalContext.Provider value={ctx}>
       {children}
-    </DrawerContext.Provider>
+    </ModalContext.Provider>
   );
 }
 
 /** Trigger — opens the drawer. `asChild` merges onto the child element. */
-export function DrawerTrigger({
-  children,
-  asChild,
-  onClick,
-  ...props
-}: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }): React.ReactElement {
-  const ctx = useDrawer();
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      {...(asChild ? {} : { type: "button" as const })}
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        ctx.setOpen(true);
-      }}
-      {...props}
-    >
-      {children}
-    </Comp>
-  );
+export function DrawerTrigger(
+  props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
+): React.ReactElement {
+  return <ModalTrigger {...props} />;
 }
 
 /** Bottom sheet — overlay + sliding surface with a drag handle. */
@@ -82,47 +50,22 @@ export function DrawerContent({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>): React.ReactElement | null {
-  const ctx = useDrawer();
-  const sheetRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    if (!ctx.open) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") ctx.setOpen(false);
-    };
-    document.addEventListener("keydown", onKeyDown);
-    const focusable = sheetRef.current?.querySelector<HTMLElement>(
-      'input:not([disabled]), textarea:not([disabled]), button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
-    );
-    (focusable ?? sheetRef.current)?.focus();
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [ctx.open]);
-
-  if (!ctx.open) return null;
   return (
-    <div className="fixed inset-0 z-50">
-      <div
-        className="fixed inset-0 bg-[var(--overlay)]"
-        onClick={() => ctx.setOpen(false)}
-      />
-      <div
-        ref={sheetRef}
-        role="dialog"
-        aria-modal="true"
-        tabIndex={-1}
-        className={cn(
-          "fixed inset-x-0 bottom-0 z-50 flex flex-col max-h-[85vh] w-full rounded-t-xl bg-[var(--drawer)] text-[var(--foreground)] outline-none",
-          className,
-        )}
-        {...props}
-      >
+    <ModalContent
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 flex flex-col max-h-[85vh] w-full rounded-t-xl bg-[var(--drawer)] text-[var(--foreground)] outline-none",
+        className,
+      )}
+      lead={
         <div
           aria-hidden="true"
           className="mx-auto mt-3 h-[3px] w-[30px] shrink-0 rounded-full bg-[var(--outline-border)]"
         />
-        {children}
-      </div>
-    </div>
+      }
+      {...props}
+    >
+      {children}
+    </ModalContent>
   );
 }
 
@@ -174,24 +117,8 @@ export function DrawerFooter(
 }
 
 /** Closes the drawer. `asChild` merges onto the child element. */
-export function DrawerClose({
-  children,
-  asChild,
-  onClick,
-  ...props
-}: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }): React.ReactElement {
-  const ctx = useDrawer();
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      {...(asChild ? {} : { type: "button" as const })}
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        ctx.setOpen(false);
-      }}
-      {...props}
-    >
-      {children}
-    </Comp>
-  );
+export function DrawerClose(
+  props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
+): React.ReactElement {
+  return <ModalClose {...props} />;
 }

--- a/src/react/components/ui/dropdown-menu.tsx
+++ b/src/react/components/ui/dropdown-menu.tsx
@@ -11,12 +11,12 @@
 import * as React from "react";
 import { cx as cn } from "./cva.ts";
 import { Slot } from "./slot.tsx";
-import {
-  AnchoredContent,
-  AnchoredContext,
-  AnchoredRoot,
-  AnchoredTrigger,
-} from "./anchored-surface.tsx";
+import { createAnchoredSurfaceParts } from "./anchored-surface.tsx";
+
+// Per-skin context + machinery -- distinct from Popover's instance so a
+// Popover nested inside a DropdownMenu cannot accidentally close the menu.
+const { Context: _ctx, AnchoredRoot: _Root, AnchoredTrigger: _Trigger, AnchoredContent: _Content } =
+  createAnchoredSurfaceParts();
 
 /** Props accepted by `<DropdownMenu>`. */
 export interface DropdownMenuProps {
@@ -28,14 +28,14 @@ export interface DropdownMenuProps {
 
 /** DropdownMenu root — owns open state and the positioning anchor. */
 export function DropdownMenu(props: DropdownMenuProps): React.ReactElement {
-  return <AnchoredRoot {...props} />;
+  return <_Root {...props} />;
 }
 
 /** Trigger — toggles the menu. `asChild` merges onto the child element. */
 export function DropdownMenuTrigger(
   props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
 ): React.ReactElement {
-  return <AnchoredTrigger {...props} haspopup="menu" />;
+  return <_Trigger {...props} haspopup="menu" />;
 }
 
 /** Props accepted by `<DropdownMenuContent>`. */
@@ -52,14 +52,14 @@ export function DropdownMenuContent({
   ...props
 }: DropdownMenuContentProps): React.ReactElement | null {
   return (
-    <AnchoredContent
+    <_Content
       role="menu"
       align={align}
       className={cn("min-w-[260px] p-2.5", className)}
       {...props}
     >
       {children}
-    </AnchoredContent>
+    </_Content>
   );
 }
 
@@ -92,7 +92,7 @@ export function DropdownMenuItem({
   asChild,
   ...props
 }: DropdownMenuItemProps): React.ReactElement {
-  const ctx = React.useContext(AnchoredContext);
+  const ctx = React.useContext(_ctx);
   const Comp = asChild ? Slot : "button";
   return (
     <Comp

--- a/src/react/components/ui/dropdown-menu.tsx
+++ b/src/react/components/ui/dropdown-menu.tsx
@@ -3,26 +3,20 @@
  * shape (Root / Trigger / Content / Group / Item / ItemMeta / Separator /
  * Label). Classes are ported 1:1 from Studio's `DropdownMenu` (token names
  * remapped to veryfront's `[var(--token)]` vocabulary). Opens below the
- * trigger; dismisses on outside-click, `Escape`, and item select.
- *
- * TODO(a11y): roving focus + arrow-key navigation, typeahead, `Tab` handling,
- * portal + collision-aware positioning (flip/shift), `aria-activedescendant`,
- * RadioItem/CheckboxItem/Sub menus. Private to the chat module.
+ * trigger; dismisses on outside-click, `Escape`, and item select. A11y work
+ * tracked in anchored-surface.tsx.
  *
  * @module react/components/ui/dropdown-menu
  */
 import * as React from "react";
 import { cx as cn } from "./cva.ts";
 import { Slot } from "./slot.tsx";
-import { Floating } from "./floating.tsx";
-
-const MenuContext = React.createContext<
-  {
-    open: boolean;
-    setOpen: (open: boolean) => void;
-    anchorRef: React.RefObject<HTMLElement | null>;
-  } | null
->(null);
+import {
+  AnchoredContent,
+  AnchoredContext,
+  AnchoredRoot,
+  AnchoredTrigger,
+} from "./anchored-surface.tsx";
 
 /** Props accepted by `<DropdownMenu>`. */
 export interface DropdownMenuProps {
@@ -33,52 +27,15 @@ export interface DropdownMenuProps {
 }
 
 /** DropdownMenu root — owns open state and the positioning anchor. */
-export function DropdownMenu({
-  children,
-  open,
-  defaultOpen,
-  onOpenChange,
-}: DropdownMenuProps): React.ReactElement {
-  const [internal, setInternal] = React.useState(defaultOpen ?? false);
-  const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : internal;
-  const setOpen = React.useCallback((next: boolean) => {
-    if (!isControlled) setInternal(next);
-    onOpenChange?.(next);
-  }, [isControlled, onOpenChange]);
-  const anchorRef = React.useRef<HTMLElement | null>(null);
-  return (
-    <span ref={anchorRef} className="relative inline-block">
-      <MenuContext.Provider value={{ open: isOpen, setOpen, anchorRef }}>
-        {children}
-      </MenuContext.Provider>
-    </span>
-  );
+export function DropdownMenu(props: DropdownMenuProps): React.ReactElement {
+  return <AnchoredRoot {...props} />;
 }
 
 /** Trigger — toggles the menu. `asChild` merges onto the child element. */
-export function DropdownMenuTrigger({
-  children,
-  asChild,
-  onClick,
-  ...props
-}: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }): React.ReactElement {
-  const ctx = React.useContext(MenuContext);
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      {...(asChild ? {} : { type: "button" as const })}
-      aria-haspopup="menu"
-      aria-expanded={ctx?.open}
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        ctx?.setOpen(!ctx.open);
-      }}
-      {...props}
-    >
-      {children}
-    </Comp>
-  );
+export function DropdownMenuTrigger(
+  props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
+): React.ReactElement {
+  return <AnchoredTrigger {...props} haspopup="menu" />;
 }
 
 /** Props accepted by `<DropdownMenuContent>`. */
@@ -94,23 +51,15 @@ export function DropdownMenuContent({
   align = "start",
   ...props
 }: DropdownMenuContentProps): React.ReactElement | null {
-  const ctx = React.useContext(MenuContext);
-  if (!ctx) return null;
   return (
-    <Floating
-      anchorRef={ctx.anchorRef}
-      open={ctx.open}
-      align={align}
-      onDismiss={() => ctx.setOpen(false)}
+    <AnchoredContent
       role="menu"
-      className={cn(
-        "z-50 min-w-[260px] overflow-hidden rounded-lg bg-[var(--popover)] p-2.5 shadow-sm outline-none",
-        className,
-      )}
+      align={align}
+      className={cn("min-w-[260px] p-2.5", className)}
       {...props}
     >
       {children}
-    </Floating>
+    </AnchoredContent>
   );
 }
 
@@ -143,7 +92,7 @@ export function DropdownMenuItem({
   asChild,
   ...props
 }: DropdownMenuItemProps): React.ReactElement {
-  const ctx = React.useContext(MenuContext);
+  const ctx = React.useContext(AnchoredContext);
   const Comp = asChild ? Slot : "button";
   return (
     <Comp

--- a/src/react/components/ui/modal-surface.tsx
+++ b/src/react/components/ui/modal-surface.tsx
@@ -1,0 +1,122 @@
+/**
+ * Shared behavioral machinery for Dialog and Drawer.
+ * TODO(a11y): focus trap, aria-labelledby, scroll-lock, portal, animation.
+ * Drawer: drag-to-dismiss / snap points.
+ * @module react/components/ui/modal-surface
+ */
+import * as React from "react";
+import { Slot } from "./slot.tsx";
+
+/** Open/close state shared between a modal skin's Root and its parts. */
+export interface ModalState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+/** Context for Dialog and Drawer skins. */
+export const ModalContext = React.createContext<ModalState | null>(null);
+
+/** Reads the nearest ModalContext; throws if called outside a skin root. */
+export function useModal(name = "Modal"): ModalState {
+  const ctx = React.useContext(ModalContext);
+  if (!ctx) throw new Error(`${name} parts must be used within <${name}>`);
+  return ctx;
+}
+
+const FOCUSABLE =
+  'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+
+/** Attaches Escape-dismiss and focus-first-focusable behaviour to a modal panel. */
+export function useModalContentEffect(
+  open: boolean,
+  setOpen: (open: boolean) => void,
+  ref: React.RefObject<HTMLElement | null>,
+): void {
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const focusable = ref.current?.querySelector<HTMLElement>(FOCUSABLE);
+    (focusable ?? ref.current)?.focus();
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]); // setOpen is stable (useCallback); ref object is stable
+}
+
+type ModalBtnProps = React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean };
+
+/** Opens the modal on click. `asChild` merges onto the child element. */
+export function ModalTrigger(
+  { children, asChild, onClick, ...props }: ModalBtnProps,
+): React.ReactElement {
+  const ctx = useModal();
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      {...(asChild ? {} : { type: "button" as const })}
+      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+        onClick?.(e);
+        ctx.setOpen(true);
+      }}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+}
+
+/** Closes the modal on click. `asChild` merges onto the child element. */
+export function ModalClose(
+  { children, asChild, onClick, ...props }: ModalBtnProps,
+): React.ReactElement {
+  const ctx = useModal();
+  const Comp = asChild ? Slot : "button";
+  return (
+    <Comp
+      {...(asChild ? {} : { type: "button" as const })}
+      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+        onClick?.(e);
+        ctx.setOpen(false);
+      }}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+}
+
+/** Props for `ModalContent`. */
+export interface ModalContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Extra node rendered before `children` — used by Drawer for the drag handle. */
+  lead?: React.ReactNode;
+}
+
+/** Fixed overlay + panel shell. Skins supply panel layout via `className`. */
+export function ModalContent(
+  { className, children, lead, ...props }: ModalContentProps,
+): React.ReactElement | null {
+  const ctx = useModal();
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  useModalContentEffect(ctx.open, ctx.setOpen, panelRef);
+  if (!ctx.open) return null;
+  return (
+    <div className="fixed inset-0 z-50">
+      <div
+        className="fixed inset-0 bg-[var(--overlay)]"
+        onClick={() => ctx.setOpen(false)}
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        className={className}
+        {...props}
+      >
+        {lead}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/react/components/ui/modal-surface.tsx
+++ b/src/react/components/ui/modal-surface.tsx
@@ -6,6 +6,7 @@
  */
 import * as React from "react";
 import { Slot } from "./slot.tsx";
+import { type DisclosureOptions, useDisclosure } from "./disclosure.ts";
 
 /** Open/close state shared between a modal skin's Root and its parts. */
 export interface ModalState {
@@ -13,21 +14,18 @@ export interface ModalState {
   setOpen: (open: boolean) => void;
 }
 
-/** Context for Dialog and Drawer skins. */
-export const ModalContext = React.createContext<ModalState | null>(null);
-
-/** Reads the nearest ModalContext; throws if called outside a skin root. */
-export function useModal(name = "Modal"): ModalState {
-  const ctx = React.useContext(ModalContext);
-  if (!ctx) throw new Error(`${name} parts must be used within <${name}>`);
-  return ctx;
+/** Props for the shared modal content shell. */
+export interface ModalContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Extra node rendered before `children` -- used by Drawer for the drag handle. */
+  lead?: React.ReactNode;
 }
+
+type ModalBtnProps = React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean };
 
 const FOCUSABLE =
   'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
 
-/** Attaches Escape-dismiss and focus-first-focusable behaviour to a modal panel. */
-export function useModalContentEffect(
+function useModalContentEffect(
   open: boolean,
   setOpen: (open: boolean) => void,
   ref: React.RefObject<HTMLElement | null>,
@@ -41,82 +39,109 @@ export function useModalContentEffect(
     const focusable = ref.current?.querySelector<HTMLElement>(FOCUSABLE);
     (focusable ?? ref.current)?.focus();
     return () => document.removeEventListener("keydown", onKey);
-  }, [open]); // setOpen is stable (useCallback); ref object is stable
+  }, [open, setOpen]); // include setOpen: the controlled path can replace it
 }
 
-type ModalBtnProps = React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean };
+/**
+ * Creates a fresh context instance plus the Root, useModal, ModalTrigger,
+ * ModalClose, and ModalContent parts -- all bound to that context.
+ *
+ * Each skin (Dialog, Drawer) calls this ONCE at module scope so their contexts
+ * are distinct objects. This prevents cross-binding when one skin is nested
+ * inside the other: a DrawerClose inside a Dialog will only close the Drawer,
+ * never the Dialog, because the two contexts cannot overlap.
+ *
+ * @param name - Component name used in the thrown error (e.g. "Dialog").
+ */
+export function createModalSurfaceParts(name: string) {
+  const Context = React.createContext<ModalState | null>(null);
 
-/** Opens the modal on click. `asChild` merges onto the child element. */
-export function ModalTrigger(
-  { children, asChild, onClick, ...props }: ModalBtnProps,
-): React.ReactElement {
-  const ctx = useModal();
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      {...(asChild ? {} : { type: "button" as const })}
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        ctx.setOpen(true);
-      }}
-      {...props}
-    >
-      {children}
-    </Comp>
-  );
-}
+  /** Provides open state to all parts in a modal skin. */
+  function ModalRoot(
+    { children, open, defaultOpen, onOpenChange }: DisclosureOptions & {
+      children: React.ReactNode;
+    },
+  ): React.ReactElement {
+    const { open: isOpen, setOpen } = useDisclosure({ open, defaultOpen, onOpenChange });
+    const value = React.useMemo(() => ({ open: isOpen, setOpen }), [isOpen, setOpen]);
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+  }
 
-/** Closes the modal on click. `asChild` merges onto the child element. */
-export function ModalClose(
-  { children, asChild, onClick, ...props }: ModalBtnProps,
-): React.ReactElement {
-  const ctx = useModal();
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      {...(asChild ? {} : { type: "button" as const })}
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        ctx.setOpen(false);
-      }}
-      {...props}
-    >
-      {children}
-    </Comp>
-  );
-}
+  /** Reads the skin's context; throws if called outside the skin's root. */
+  function useModal(): ModalState {
+    const ctx = React.useContext(Context);
+    if (!ctx) throw new Error(`${name} parts must be used within <${name}>`);
+    return ctx;
+  }
 
-/** Props for `ModalContent`. */
-export interface ModalContentProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Extra node rendered before `children` — used by Drawer for the drag handle. */
-  lead?: React.ReactNode;
-}
-
-/** Fixed overlay + panel shell. Skins supply panel layout via `className`. */
-export function ModalContent(
-  { className, children, lead, ...props }: ModalContentProps,
-): React.ReactElement | null {
-  const ctx = useModal();
-  const panelRef = React.useRef<HTMLDivElement>(null);
-  useModalContentEffect(ctx.open, ctx.setOpen, panelRef);
-  if (!ctx.open) return null;
-  return (
-    <div className="fixed inset-0 z-50">
-      <div
-        className="fixed inset-0 bg-[var(--overlay)]"
-        onClick={() => ctx.setOpen(false)}
-      />
-      <div
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        tabIndex={-1}
-        className={className}
+  /** Opens the modal on click. `asChild` merges onto the child element. */
+  function ModalTrigger(
+    { children, asChild, onClick, ...props }: ModalBtnProps,
+  ): React.ReactElement {
+    const ctx = useModal();
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        {...(asChild ? {} : { type: "button" as const })}
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          onClick?.(e);
+          ctx.setOpen(true);
+        }}
         {...props}
       >
-        {lead}
         {children}
+      </Comp>
+    );
+  }
+
+  /** Closes the modal on click. `asChild` merges onto the child element. */
+  function ModalClose(
+    { children, asChild, onClick, ...props }: ModalBtnProps,
+  ): React.ReactElement {
+    const ctx = useModal();
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        {...(asChild ? {} : { type: "button" as const })}
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          onClick?.(e);
+          ctx.setOpen(false);
+        }}
+        {...props}
+      >
+        {children}
+      </Comp>
+    );
+  }
+
+  /** Fixed overlay + panel shell. Skins supply panel layout via `className`. */
+  function ModalContent(
+    { className, children, lead, ...props }: ModalContentProps,
+  ): React.ReactElement | null {
+    const ctx = useModal();
+    const panelRef = React.useRef<HTMLDivElement>(null);
+    useModalContentEffect(ctx.open, ctx.setOpen, panelRef);
+    if (!ctx.open) return null;
+    return (
+      <div className="fixed inset-0 z-50">
+        <div
+          className="fixed inset-0 bg-[var(--overlay)]"
+          onClick={() => ctx.setOpen(false)}
+        />
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          tabIndex={-1}
+          className={className}
+          {...props}
+        >
+          {lead}
+          {children}
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
+
+  return { ModalRoot, useModal, ModalTrigger, ModalClose, ModalContent };
 }

--- a/src/react/components/ui/popover.tsx
+++ b/src/react/components/ui/popover.tsx
@@ -3,26 +3,14 @@
  * (Root / Trigger / Content + Title / Body / Footer / Actions section parts).
  * Classes are ported 1:1 from Studio's `Popover` (tokens remapped to
  * veryfront's `[var(--token)]` vocabulary). Anchored below the trigger;
- * dismisses on outside-click and `Escape`.
- *
- * TODO(a11y): focus trap + restore, portal + collision-aware positioning
- * (flip/shift), `aria-controls`/`aria-expanded` wiring on the trigger,
- * `side`/`align` offset variants. Private to the chat module.
+ * dismisses on outside-click and `Escape`. A11y work tracked in
+ * anchored-surface.tsx.
  *
  * @module react/components/ui/popover
  */
 import * as React from "react";
 import { cx as cn } from "./cva.ts";
-import { Slot } from "./slot.tsx";
-import { Floating } from "./floating.tsx";
-
-const PopoverContext = React.createContext<
-  {
-    open: boolean;
-    setOpen: (open: boolean) => void;
-    anchorRef: React.RefObject<HTMLElement | null>;
-  } | null
->(null);
+import { AnchoredContent, AnchoredRoot, AnchoredTrigger } from "./anchored-surface.tsx";
 
 /** Props accepted by `<Popover>`. */
 export interface PopoverProps {
@@ -33,52 +21,15 @@ export interface PopoverProps {
 }
 
 /** Popover root — owns open state and the positioning anchor. */
-export function Popover({
-  children,
-  open,
-  defaultOpen,
-  onOpenChange,
-}: PopoverProps): React.ReactElement {
-  const [internal, setInternal] = React.useState(defaultOpen ?? false);
-  const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : internal;
-  const setOpen = React.useCallback((next: boolean) => {
-    if (!isControlled) setInternal(next);
-    onOpenChange?.(next);
-  }, [isControlled, onOpenChange]);
-  const anchorRef = React.useRef<HTMLElement | null>(null);
-  return (
-    <span ref={anchorRef} className="relative inline-block">
-      <PopoverContext.Provider value={{ open: isOpen, setOpen, anchorRef }}>
-        {children}
-      </PopoverContext.Provider>
-    </span>
-  );
+export function Popover(props: PopoverProps): React.ReactElement {
+  return <AnchoredRoot {...props} />;
 }
 
 /** Trigger — toggles the popover. `asChild` merges onto the child element. */
-export function PopoverTrigger({
-  children,
-  asChild,
-  onClick,
-  ...props
-}: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }): React.ReactElement {
-  const ctx = React.useContext(PopoverContext);
-  const Comp = asChild ? Slot : "button";
-  return (
-    <Comp
-      {...(asChild ? {} : { type: "button" as const })}
-      aria-haspopup="dialog"
-      aria-expanded={ctx?.open}
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        onClick?.(e);
-        ctx?.setOpen(!ctx.open);
-      }}
-      {...props}
-    >
-      {children}
-    </Comp>
-  );
+export function PopoverTrigger(
+  props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
+): React.ReactElement {
+  return <AnchoredTrigger {...props} haspopup="dialog" />;
 }
 
 /** Props accepted by `<PopoverContent>`. */
@@ -94,23 +45,15 @@ export function PopoverContent({
   align = "end",
   ...props
 }: PopoverContentProps): React.ReactElement | null {
-  const ctx = React.useContext(PopoverContext);
-  if (!ctx) return null;
   return (
-    <Floating
-      anchorRef={ctx.anchorRef}
-      open={ctx.open}
-      align={align}
-      onDismiss={() => ctx.setOpen(false)}
+    <AnchoredContent
       role="dialog"
-      className={cn(
-        "z-50 min-w-[220px] overflow-hidden rounded-lg bg-[var(--popover)] text-[var(--foreground)] shadow-sm outline-none",
-        className,
-      )}
+      align={align}
+      className={cn("min-w-[220px]", className)}
       {...props}
     >
       {children}
-    </Floating>
+    </AnchoredContent>
   );
 }
 

--- a/src/react/components/ui/popover.tsx
+++ b/src/react/components/ui/popover.tsx
@@ -10,7 +10,12 @@
  */
 import * as React from "react";
 import { cx as cn } from "./cva.ts";
-import { AnchoredContent, AnchoredRoot, AnchoredTrigger } from "./anchored-surface.tsx";
+import { createAnchoredSurfaceParts } from "./anchored-surface.tsx";
+
+// Per-skin context + machinery -- distinct from DropdownMenu's instance so
+// a DropdownMenu nested inside a Popover cannot accidentally close the Popover.
+const { AnchoredRoot: _Root, AnchoredTrigger: _Trigger, AnchoredContent: _Content } =
+  createAnchoredSurfaceParts();
 
 /** Props accepted by `<Popover>`. */
 export interface PopoverProps {
@@ -22,14 +27,14 @@ export interface PopoverProps {
 
 /** Popover root — owns open state and the positioning anchor. */
 export function Popover(props: PopoverProps): React.ReactElement {
-  return <AnchoredRoot {...props} />;
+  return <_Root {...props} />;
 }
 
 /** Trigger — toggles the popover. `asChild` merges onto the child element. */
 export function PopoverTrigger(
   props: React.ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean },
 ): React.ReactElement {
-  return <AnchoredTrigger {...props} haspopup="dialog" />;
+  return <_Trigger {...props} haspopup="dialog" />;
 }
 
 /** Props accepted by `<PopoverContent>`. */
@@ -46,14 +51,14 @@ export function PopoverContent({
   ...props
 }: PopoverContentProps): React.ReactElement | null {
   return (
-    <AnchoredContent
+    <_Content
       role="dialog"
       align={align}
       className={cn("min-w-[220px]", className)}
       {...props}
     >
       {children}
-    </AnchoredContent>
+    </_Content>
   );
 }
 


### PR DESCRIPTION
## Summary

Candidate #3 from the architecture review. Five overlay primitives (`dialog`, `drawer`, `popover`, `dropdown-menu`, `collapsible` — 976 LOC) shared byte-identical behavioral machinery: the controlled/uncontrolled open-state block appeared in all five, Popover and DropdownMenu were byte-identical through Root+Trigger, Dialog and Drawer shared Trigger/Close and the Escape/focus/overlay effect, and a `TODO(a11y)` block was copy-pasted 4×.

### Changes
- **`ui/disclosure.ts`** — one `useDisclosure({open, defaultOpen, onOpenChange})` hook (the previously ×5 block)
- **`ui/modal-surface.tsx`** — shared Modal surface; Dialog and Drawer are now skins (panel classes, overlay tokens, Drawer's drag handle stay skin-specific)
- **`ui/anchored-surface.tsx`** — shared Anchored surface; Popover and DropdownMenu are skins (`haspopup` dialog-vs-menu, min-width, padding, alignment, `role` all passed per-skin)
- The pending **a11y work (focus trap, portal, scroll-lock, collision) is now single-site** — one TODO in the surfaces instead of four copies

### Accounting
Net **−5** (976→971): skins shed 259 lines, the shared surfaces cost 254. The review's −150 estimate assumed the shared behavior was negligible; it isn't — but the leverage goal (a11y implemented once, one open-state machine, one test surface) is fully delivered, at no size cost.

### Verification
- Public component APIs unchanged; every skin difference explicitly parameterized (documented in the surfaces)
- React suite: 131 test files, 0 failed, unmodified · `lint:chat-ratchets` 0 violations · `lint:chat-composability` 22 compounds honest
- `deno task verify:quick` exit 0 · pre-push (fmt + full suite) passed

Implemented by a worktree executor from the review spec; verified on review.