### PR TITLE
Preserve optional tool inputs in OpenAI Responses

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1122",
+  "version": "0.1.1123",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
@@ -146,6 +146,46 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
     assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
   });
 
+  it("keeps runtime function tools explicitly non-strict in Responses requests", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIResponsesRequest(
+      "gpt-5.4-nano",
+      "veryfront-cloud",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Search knowledge." }] }],
+        tools: [{
+          type: "function",
+          name: "search_knowledge",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+              cursor: { type: "string" },
+            },
+            required: ["query"],
+          },
+        }],
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.tools, [{
+      type: "function",
+      name: "search_knowledge",
+      strict: false,
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          cursor: { type: "string" },
+        },
+        required: ["query"],
+      },
+    }]);
+  });
+
   it("preserves Responses request shaping, provider option merge order, and warnings", () => {
     const prompt: RuntimePromptMessage[] = [
       { role: "system", content: "You are concise." },
@@ -301,6 +341,7 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
           type: "function",
           name: "lookup",
           description: "Look up a value",
+          strict: false,
           parameters: { type: "object", properties: { id: { type: "string" } } },
         },
         {

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
@@ -175,6 +175,11 @@ function toOpenAIResponsesTools(
         type: "function",
         name: tool.name,
         ...(typeof tool.description === "string" ? { description: tool.description } : {}),
+        // Responses otherwise attempts to normalize omitted strictness into
+        // strict mode, which turns every declared property into a required
+        // argument. Runtime and remote tool schemas use normal JSON Schema
+        // optional properties, so preserve that contract explicitly.
+        strict: false,
         parameters: unwrapToolInputSchema(tool.inputSchema),
       });
       continue;

--- a/src/provider/model-registry.test.ts
+++ b/src/provider/model-registry.test.ts
@@ -77,10 +77,11 @@ describe("provider/model-registry", () => {
     assertEquals(requestedBody?.model, "gpt-5.4-nano");
     assertEquals(requestedBody?.store, false);
     assertEquals(requestedBody?.reasoning, { effort: "medium" });
-    assertEquals(
-      (requestedBody?.tools as Array<{ name?: string }> | undefined)?.[0]?.name,
-      "lookup_order",
-    );
+    const requestedTool = (requestedBody?.tools as
+      | Array<Record<string, unknown>>
+      | undefined)?.[0];
+    assertEquals(requestedTool?.name, "lookup_order");
+    assertEquals(requestedTool?.strict, false);
     assertEquals(result.content, [{ type: "text", text: "Found order." }]);
   });
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1122";
+export const VERSION = "0.1.1123";


### PR DESCRIPTION
## Summary

- emit `strict: false` for OpenAI Responses function tools
- preserve optional JSON Schema properties such as knowledge cursor and lookup target
- add builder and provider-level regression coverage
- bump the patch version to 0.1.1123 for release

## Why

The Responses API normalizes function schemas to strict mode when `strict` is omitted. That makes every declared property required, so models invent values for optional fields. In staging this caused a Knowledge Q&A agent to repeatedly send invalid cursors and lookup targets until it exhausted all 12 steps.

Veryfront runtime tool definitions currently use standard JSON Schema semantics and do not expose provider-specific strict intent, so the request builder must explicitly opt out.

## Verification

- `deno task verify:quick`
- OpenAI extension tests
- model registry and Veryfront Cloud provider tests
- authenticated staging gateway A/B: omitted strict produced an empty cursor; `strict: false` produced query-only arguments

## Risk

This disables automatic strict normalization for all Responses function tools, matching the existing Veryfront tool contract. A future strict opt-in should add explicit intent to the runtime tool type rather than infer compatibility from arbitrary schemas.

## Staging follow-up

After merge, release, and deployment, rerun the Knowledge Q&A E2E on veryfront.org and verify successful `search_knowledge` plus `get_file` calls and a cited answer.