### PR TITLE
ci: run required checks on merge_group for merge-queue support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
   # Required for merge-queue entries: queued runs report checks via merge_group.
   merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
+  # Required for merge-queue entries: queued runs report checks via merge_group.
+  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required for merge-queue entries: queued runs report checks via merge_group.
+  merge_group:
   schedule:
     - cron: "0 6 * * 1" # Weekly Monday 6am UTC
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   # Required for merge-queue entries: queued runs report checks via merge_group.
   merge_group:
+    types: [checks_requested]
   schedule:
     - cron: "0 6 * * 1" # Weekly Monday 6am UTC
 


### PR DESCRIPTION
## Summary

Prerequisite for enabling a merge queue on `main`. Queue entries fire `merge_group` events; without this trigger, queued runs never report their required checks and every entry times out.

### Changes
- `cicd.yml` + `codeql.yml`: add `merge_group:` to `on:`. No job changes needed — the existing `if:` guards (`event_name != 'pull_request' || same-repo`) already pass for merge_group events, and the sha-suffixed concurrency group prevents queue entries from cancelling each other.

### Deliberately untouched
- `security-audit.yml` — path-filtered; `merge_group` doesn't support path filters, and running it unconditionally on every queue entry would defeat the filter. It isn't a required check, so it doesn't gate the queue.
- `cla.yml` — `pull_request_target`; the CLA is verified on the PR before it can be queued.

### Flipping the queue on (after this merges)
1. Repo Settings → Rules (or classic branch protection) for `main` → enable **merge queue**; merge method **squash** (matches history style); build concurrency ~4 is plenty at current volume.
2. Optionally remove the strict "require branches to be up to date" requirement — the queue supersedes it (every entry is tested against the exact main it will land on).
3. From then on: "Merge when ready" instead of update-branch + wait cycles.