### PR TITLE
Preserve structured credit errors from hosted providers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1123",
+  "version": "0.1.1124",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/provider/runtime-loader/provider-http.test.ts
+++ b/src/provider/runtime-loader/provider-http.test.ts
@@ -216,6 +216,67 @@ describe("provider-http", () => {
       });
     });
 
+    it("preserves structured Veryfront 402 problems for internal classification", async () => {
+      const responseBody = JSON.stringify({
+        slug: "insufficient-credits",
+        error: "AI credit limit exceeded",
+        balance: 0,
+        required: 4,
+      });
+      const err = await buildProviderError(
+        "openai",
+        jsonResponse(402, responseBody),
+      );
+
+      assertEquals(err.responseBody, responseBody);
+      assertEquals(Object.keys(err).includes("responseBody"), false);
+      assertEquals(JSON.stringify(err).includes("AI credit limit exceeded"), false);
+      assertEquals(err.message, "Provider request failed with status 402");
+      assertEquals(parseProviderError(err), {
+        code: "INSUFFICIENT_CREDITS",
+        message: "AI credit limit exceeded",
+        status: 402,
+      });
+    });
+
+    it("preserves structured Veryfront resource limit problems for classification", async () => {
+      const responseBody = JSON.stringify({
+        slug: "resource-limit-exceeded",
+        error: "Resource limit exceeded",
+        suggestion: "Reduce the request size and try again.",
+      });
+      const err = await buildProviderError(
+        "openai",
+        jsonResponse(402, responseBody),
+      );
+
+      assertEquals(err.responseBody, responseBody);
+      assertEquals(Object.keys(err).includes("responseBody"), false);
+      assertEquals(parseProviderError(err), {
+        code: "RESOURCE_LIMIT_EXCEEDED",
+        message: "Reduce the request size and try again.",
+        status: 402,
+      });
+    });
+
+    it("does not preserve arbitrary provider 402 response details", async () => {
+      const err = await buildProviderError(
+        "openai",
+        jsonResponse(402, {
+          error: {
+            message: "private provider payload <TOKEN>",
+          },
+        }),
+      );
+
+      assertEquals(err.responseBody, undefined);
+      assertEquals(JSON.stringify(err).includes("<TOKEN>"), false);
+      assertEquals(parseProviderError(err), {
+        code: "EXTERNAL_SERVICE_ERROR",
+        message: "LLM provider service error",
+      });
+    });
+
     it("does not preserve arbitrary provider api error messages", async () => {
       const err = await buildProviderError(
         "anthropic",

--- a/src/provider/runtime-loader/provider-http.ts
+++ b/src/provider/runtime-loader/provider-http.ts
@@ -238,8 +238,12 @@ export async function buildProviderError(
     errorType === "invalid_request_error" &&
     parsedBody !== undefined &&
     !truncated;
+  const problemSlug = typeof parsedBody?.slug === "string" ? parsedBody.slug : undefined;
+  const isStructuredVeryfrontCreditProblem = status === 402 &&
+    (problemSlug === "insufficient-credits" || problemSlug === "resource-limit-exceeded") &&
+    !truncated;
 
-  return isStructuredInvalidRequest
+  return isStructuredInvalidRequest || isStructuredVeryfrontCreditProblem
     ? preserveStructuredResponseBody(requestError, rawBody)
     : requestError;
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1123";
+export const VERSION = "0.1.1124";


### PR DESCRIPTION
## Summary

- preserve recognized Veryfront 402 credit problem bodies as bounded, non-enumerable classifier input
- keep arbitrary provider 402 payloads hidden from logs and JSON serialization
- classify exhausted platform credits as `INSUFFICIENT_CREDITS` instead of a generic provider outage
- bump the framework release version to `0.1.1124`

## Why

The provider transport reduced hosted gateway 402 responses to only `Provider request failed with status 402`. Without the structured `insufficient-credits` slug, the hosted runtime emitted a generic provider error and Studio displayed the provider-outage banner.

## Verification

- regression test demonstrated the failure before the implementation
- focused provider, error-parser, hosted terminal-error, version, and logger tests
- `deno task verify:quick`
- full pre-push gate: formatting, lint, typecheck, and 2,641 tests / 21,441 test steps