### PR TITLE
fix(routing,html): follow SPA redirects and resolve framework+React under CDN mode

### DIFF
--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -622,6 +622,16 @@ export const getRouterScript = () => `
 
         if (signal.aborted) return;
 
+        // getServerData redirect(): the page-data endpoint encodes it as a 200
+        // { redirect: { destination } } payload. Follow it with a document
+        // navigation to the target (the same net effect as the full-page 302),
+        // instead of trying to render a page that does not exist here.
+        if (pageData && pageData.redirect && typeof pageData.redirect.destination === 'string') {
+          log('SPA navigation redirect -> ' + pageData.redirect.destination);
+          window.location.href = pageData.redirect.destination;
+          return;
+        }
+
         if (pushState) {
           window.history.pushState({ pageData, scrollY: 0 }, '', href);
         }

--- a/src/html/utils.test.ts
+++ b/src/html/utils.test.ts
@@ -172,6 +172,22 @@ describe("html-generation/utils", () => {
       assertStringIncludes(imports["veryfront/markdown"]!, "/esm/src/markdown/index.js");
       assertStringIncludes(imports["veryfront/mdx"]!, "/esm/src/mdx/index.js");
       assertStringIncludes(imports["veryfront/workflow"]!, "/esm/src/workflow/react/index.js");
+
+      // Core runtime utilities must ALWAYS resolve locally, even under a
+      // non-default CDN provider — they must share the same React context module
+      // instance as SSR, otherwise the browser cannot resolve `veryfront/router`
+      // and hydration fails. CDN is only for third-party deps + the AI modules.
+      assertEquals(imports["veryfront/router"], "/_vf_modules/_veryfront/react/runtime/core.js");
+      assertEquals(imports["veryfront/head"], "/_vf_modules/_veryfront/react/runtime/core.js");
+      assertEquals(imports["veryfront/context"], "/_vf_modules/_veryfront/react/runtime/core.js");
+      assertEquals(imports["veryfront/fonts"], "/_vf_modules/_veryfront/react/fonts/index.js");
+
+      // React must come from esm.sh even under unpkg — unpkg only ships UMD
+      // globals, which cannot be loaded through an import map, so hydration would
+      // never start. (The `provider` only governs the veryfront framework modules.)
+      assertStringIncludes(imports["react"]!, "esm.sh");
+      assertStringIncludes(imports["react-dom"]!, "esm.sh");
+      assertStringIncludes(imports["react-dom/client"]!, "esm.sh");
     });
 
     it("should format JSON with proper indentation", async () => {

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -176,21 +176,40 @@ const CDN_URL_TEMPLATES: Record<CdnProvider, CdnUrlTemplates> = {
 function buildCdnImportMapFromTemplates(
   versions: DetectedVersions,
   templates: CdnUrlTemplates,
-  includePlatformUtilities: boolean,
+  // Whether the AI/chat modules (chat/markdown/mdx/workflow) are also served
+  // locally instead of from the CDN. The CORE platform utilities
+  // (router/head/context/fonts) are ALWAYS served locally regardless of
+  // provider — they must share the same React context module instance as SSR,
+  // otherwise usePageContext() returns undefined and the browser fails to even
+  // resolve `veryfront/router`. CDN is for third-party deps (react) and,
+  // optionally, the AI modules — never the core runtime.
+  includeAiModulesLocally: boolean,
 ): Record<string, string> {
   const { react, veryfront } = versions;
 
+  // React is ALWAYS served from esm.sh, regardless of the configured CDN
+  // provider. esm.sh is the only CDN that serves React as real ESM; unpkg and
+  // jsdelivr only ship UMD globals (react/umd/react.production.min.js), which
+  // cannot be consumed through an import map at all — the browser rejects them
+  // with a module-resolution/CORS error and hydration never starts. Self-hosted
+  // mode already does exactly this. The `provider` only governs where the
+  // veryfront framework modules load from.
+  const reactTemplates = CDN_URL_TEMPLATES["esm.sh"];
+
   return {
-    react: templates.react(react),
-    "react-dom": templates.reactDom(react),
-    "react-dom/client": templates.reactDomClient(react),
-    "react/jsx-runtime": templates.jsxRuntime(react),
-    "react/jsx-dev-runtime": templates.jsxDevRuntime(react),
+    react: reactTemplates.react(react),
+    "react-dom": reactTemplates.reactDom(react),
+    "react-dom/client": reactTemplates.reactDomClient(react),
+    "react/jsx-runtime": reactTemplates.jsxRuntime(react),
+    "react/jsx-dev-runtime": reactTemplates.jsxDevRuntime(react),
     "veryfront/chat": templates.veryfrontChat(veryfront),
     "veryfront/markdown": templates.veryfrontMarkdown(veryfront),
     "veryfront/mdx": templates.veryfrontMdx(veryfront),
     "veryfront/workflow": templates.veryfrontWorkflow(veryfront),
-    ...(includePlatformUtilities ? PLATFORM_UTILITIES : {}),
+    // Core runtime utilities always resolve locally (see comment above).
+    ...CORE_PLATFORM_UTILITIES,
+    // AI modules only override the CDN entries when requested.
+    ...(includeAiModulesLocally ? AI_MODULE_UTILITIES : {}),
   };
 }
 

--- a/src/routing/client/types.ts
+++ b/src/routing/client/types.ts
@@ -36,4 +36,10 @@ export interface SpaPageData {
   props: Record<string, unknown>;
   params: Record<string, string | string[]>;
   layoutProps: Record<string, Record<string, unknown>>;
+  /**
+   * Set when the route's getServerData called redirect(): the page-data endpoint
+   * returns a 200 with this instead of page props, and the client router follows
+   * it with a document navigation to `destination`.
+   */
+  redirect?: { destination: string; permanent?: boolean };
 }

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -212,6 +212,34 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
     assertEquals(await first.text(), await second.text());
   });
 
+  it("encodes a getServerData redirect() as a 200 payload instead of a 500", async () => {
+    // A redirect() from getServerData reaches the page-data endpoint as a thrown
+    // VeryfrontError carrying context.redirect. It must be encoded as a 200
+    // { redirect } payload so the SPA client can follow it — not misclassified as
+    // an internal error (500), which aborts client-side navigation.
+    setRendererInitializer(
+      createInitializer(() =>
+        Promise.reject(
+          Object.assign(new Error("Redirect to /target"), {
+            slug: "render-error",
+            context: { redirect: { destination: "/target", permanent: false } },
+          }),
+        )
+      ),
+    );
+
+    const ctx = makeCtx();
+    const res = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/redirecting.json"),
+      ctx,
+    );
+
+    assertEquals(res.status, 200);
+    assertEquals(await res.json(), {
+      redirect: { destination: "/target", permanent: false },
+    });
+  });
+
   it("keeps speculative prefetch work and cache state out of foreground page data", async () => {
     const producers: string[] = [];
     const prefetchGate = Promise.withResolvers<void>();

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -168,6 +168,26 @@ export function handlePageDataEndpoint(
           );
         }
 
+        // A redirect() from getServerData surfaces here as a thrown
+        // VeryfrontError carrying context.redirect. The full-page render path
+        // converts this into a 302; the SPA page-data endpoint must encode it as
+        // a 200 payload so the client router can follow the redirect instead of
+        // treating it as an internal error (which 500s and aborts navigation).
+        const redirect = extractRedirectFromError(e);
+        if (redirect) {
+          return respond(
+            ResponseBuilder.json(
+              { redirect },
+              req,
+              {
+                securityConfig: ctx.securityConfig,
+                corsConfig: ctx.securityConfig?.cors,
+                status: 200,
+              },
+            ),
+          );
+        }
+
         const errorMessage = getErrorMessage(e);
         const lower = errorMessage.toLowerCase();
         const isNotFound = lower.includes("not found") ||
@@ -319,6 +339,22 @@ function refreshStalePageData(
       }
     },
   );
+}
+
+/**
+ * A redirect() from getServerData is thrown up the pipeline as a VeryfrontError
+ * whose `context.redirect` holds the destination (mirrors extractRedirectLocation
+ * in the SSR service). Returns null for any other error.
+ */
+function extractRedirectFromError(
+  error: unknown,
+): { destination: string; permanent: boolean } | null {
+  const context = (error as {
+    context?: { redirect?: { destination?: unknown; permanent?: unknown } };
+  })?.context;
+  const redirect = context?.redirect;
+  if (!redirect || typeof redirect.destination !== "string") return null;
+  return { destination: redirect.destination, permanent: redirect.permanent === true };
 }
 
 function buildPageDataCacheKey(ctx: HandlerContext, slug: string, url: URL): string {


### PR DESCRIPTION
## Summary

Three client-navigation / hydration fixes, all surfaced by the
[`veryfront-router-testing`](https://github.com/mattboon/veryfront-router-testing)
reproducers. Each is invisible to a fresh full-page load and only appears during
in-app `<Link>` (SPA) navigation or under a non-default CDN provider.

### 1. `<Link>` navigation to a `redirect()` route returned 500
A `getServerData` `redirect()` throws a `RENDER_ERROR` (carrying `context.redirect`)
up the pipeline. The full-page render path converts it to a 302, but the SPA
**page-data endpoint**'s catch string-matched the error message and fell through to
`500 {"error":"Internal server error"}`. The client logged `[Veryfront] SPA
navigation failed: Failed to fetch page data: 500` and hard-reloaded.

**Fix:** the page-data endpoint now detects the redirect error and returns
`200 { redirect: { destination, permanent } }`; the client router follows it with a
document navigation to the destination.
`src/server/handlers/request/module/page-data-endpoint-handler.ts`,
`src/html/hydration-script-builder/templates/router.ts`,
`src/routing/client/types.ts`.

### 2. CDN mode dropped `veryfront/router` from the client import map
Under `moduleResolution: "cdn"` with `provider: "unpkg"` / `"jsdelivr"`, the core
platform utilities (`veryfront/router|head|context|fonts`) were omitted, so the
browser threw `Failed to resolve module specifier "veryfront/router"` and hydration
never started (SSR was 200). These must always resolve locally — they share the SSR
React context module instance. **Fix:** `buildCdnImportMapFromTemplates` always
spreads `CORE_PLATFORM_UTILITIES`; the provider flag now governs only the AI
modules. `src/html/utils.ts`.

### 3. CDN unpkg/jsdelivr served React as UMD
The unpkg/jsdelivr templates pointed React at `/umd/react.production.min.js` — a
browser global that cannot be loaded through an import map at all. **Fix:** React is
always resolved from esm.sh (the only CDN that serves ESM React, and what
`getSelfHostedImportMap` already does); the provider now only governs the veryfront
framework modules. `src/html/utils.ts`.

## Tests

- New: page-data endpoint "encodes a getServerData redirect() as a 200 payload
  instead of a 500".
- Extended: CDN import-map test asserts core utilities stay local and React comes
  from esm.sh under `unpkg`.
- `deno test src/html/utils.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts` → all pass.

## Reproducer validation (veryfront-router-testing)

Run against this branch from source and as a packed npm build:

- `default-config` canonical gate: **59 routes, 0 SSR / 0 client mismatches**
- `nav-sweep.mjs`: **16/16** — `/test/h-redirect` now `PASS (redirect -> /test/a-no-ext-no-server, 0 errors)`
- `config-cdn-unpkg`: hydrates **clean** (was: `veryfront/router` resolve failure)
- esm.sh default import map is unchanged → no regression to the default path

## Notes

- Base: `main`.
- Full `deno task test:unit` / lint were **not** run in this session — targeted tests
  above pass and the changed files are `deno fmt`-clean. Please let CI run the full
  suite.
