### PR TITLE
Preserve exact Knowledge Q&A source citations

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1124",
+  "version": "0.1.1125",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/ag-ui/browser-encoder.ts
+++ b/src/agent/ag-ui/browser-encoder.ts
@@ -638,6 +638,10 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
   }
 
   switch (event.type) {
+    case "source-document":
+      state.sawVisibleOutput = true;
+      return [createCustomDataEvent("source-document", event)];
+
     case "message-start":
       getMessageId(state, event);
       return [];

--- a/src/agent/ag-ui/chat-ui-chunk-browser-encoder.test.ts
+++ b/src/agent/ag-ui/chat-ui-chunk-browser-encoder.test.ts
@@ -210,6 +210,25 @@ describe("agent/ag-ui-chat-ui-chunk-browser-encoder", () => {
     );
   });
 
+  it("encodes source documents as renderable custom events", () => {
+    const encoder = createAgUiChatUiChunkBrowserEncoder();
+    const sourceDocument: ChatUiMessageChunk = {
+      type: "source-document",
+      sourceId: "knowledge/knowledge-ingest-20260723131451088-source.md",
+      mediaType: "text/markdown",
+      title: "knowledge/knowledge-ingest-20260723131451088-source.md",
+      filename: "knowledge/knowledge-ingest-20260723131451088-source.md",
+    };
+
+    assertEquals(encoder.encode(sourceDocument), [{
+      event: "Custom",
+      payload: {
+        name: "source-document",
+        value: sourceDocument,
+      },
+    }]);
+  });
+
   it("creates a tracked browser response for chat UI chunks", async () => {
     const response = createAgUiChatUiTrackedBrowserResponse({
       agUiInput: {

--- a/src/agent/conversation/run-events.test.ts
+++ b/src/agent/conversation/run-events.test.ts
@@ -130,6 +130,32 @@ describe("agent/conversation-run-events", () => {
     );
   });
 
+  it("encodes source documents as durable custom events", () => {
+    const encoder = new ConversationRunEventEncoder();
+    const path = "knowledge/knowledge-ingest-20260723131451088-source.md";
+
+    assertEquals(
+      encoder.encode({
+        type: "source-document",
+        sourceId: path,
+        mediaType: "text/markdown",
+        title: path,
+        filename: path,
+      }),
+      [{
+        type: conversationRunEventTypes.custom,
+        name: "source-document",
+        value: {
+          type: "source-document",
+          sourceId: path,
+          mediaType: "text/markdown",
+          title: path,
+          filename: path,
+        },
+      }],
+    );
+  });
+
   it("encodes and normalizes whole event lists", () => {
     const events = [
       { type: "text-start", id: "msg-1" },

--- a/src/agent/conversation/run-events.ts
+++ b/src/agent/conversation/run-events.ts
@@ -256,12 +256,18 @@ export class ConversationRunEventEncoder {
         return events;
       }
 
+      case "source-document":
+        return [{
+          type: conversationRunEventTypes.custom,
+          name: "source-document",
+          value: chunk,
+        }];
+
       case "error":
       case "finish":
       case "abort":
       case "message-metadata":
       case "source-url":
-      case "source-document":
       case "file":
       case "tool-approval-request":
       case "start-step":

--- a/src/agent/streaming/knowledge-source-document.test.ts
+++ b/src/agent/streaming/knowledge-source-document.test.ts
@@ -1,0 +1,56 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { deriveKnowledgeSourceDocumentChunk } from "./knowledge-source-document.ts";
+
+const KNOWLEDGE_PATH =
+  "knowledge/knowledge-ingest-20260723131451088-6d16440c-veryfront-equity-story-13july26.md";
+
+describe("agent/streaming/knowledge-source-document", () => {
+  it("preserves a canonical get_file knowledge path character-for-character", () => {
+    assertEquals(
+      deriveKnowledgeSourceDocumentChunk({
+        toolName: "get_file",
+        output: { path: KNOWLEDGE_PATH, content: "# Equity story" },
+      }),
+      {
+        type: "source-document",
+        sourceId: KNOWLEDGE_PATH,
+        mediaType: "text/markdown",
+        title: KNOWLEDGE_PATH,
+        filename: KNOWLEDGE_PATH,
+      },
+    );
+  });
+
+  it("supports wrapped MCP structured output", () => {
+    assertEquals(
+      deriveKnowledgeSourceDocumentChunk({
+        toolName: "get_file",
+        output: { structuredContent: { path: KNOWLEDGE_PATH } },
+      })?.sourceId,
+      KNOWLEDGE_PATH,
+    );
+  });
+
+  it("does not cite search results, source files, or malformed outputs", () => {
+    assertEquals(
+      deriveKnowledgeSourceDocumentChunk({
+        toolName: "search_knowledge",
+        output: { path: KNOWLEDGE_PATH },
+      }),
+      null,
+    );
+    assertEquals(
+      deriveKnowledgeSourceDocumentChunk({
+        toolName: "get_file",
+        output: { path: "agents/support.ts" },
+      }),
+      null,
+    );
+    assertEquals(
+      deriveKnowledgeSourceDocumentChunk({ toolName: "get_file", output: {} }),
+      null,
+    );
+  });
+});

--- a/src/agent/streaming/knowledge-source-document.ts
+++ b/src/agent/streaming/knowledge-source-document.ts
@@ -1,0 +1,58 @@
+import type { ChatMessageMetadata, ChatUiMessageChunk } from "#veryfront/chat/protocol.ts";
+import { lookup as lookupMediaType } from "#veryfront/platform/compat/media-types.ts";
+
+const GET_FILE_TOOL_NAME = "get_file";
+const KNOWLEDGE_PATH_PREFIX = "knowledge/";
+
+type SourceDocumentChunk = Extract<
+  ChatUiMessageChunk<ChatMessageMetadata>,
+  { type: "source-document" }
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveStructuredOutput(output: unknown): Record<string, unknown> | null {
+  if (!isRecord(output)) {
+    return null;
+  }
+
+  if (isRecord(output.structuredContent)) {
+    return output.structuredContent;
+  }
+
+  if (isRecord(output.structured_content)) {
+    return output.structured_content;
+  }
+
+  return output;
+}
+
+/** Derive an exact structured citation from a successful project knowledge file read. */
+export function deriveKnowledgeSourceDocumentChunk(input: {
+  toolName: string | undefined;
+  output: unknown;
+}): SourceDocumentChunk | null {
+  if (input.toolName !== GET_FILE_TOOL_NAME) {
+    return null;
+  }
+
+  const output = resolveStructuredOutput(input.output);
+  const path = output?.path;
+  if (
+    typeof path !== "string" ||
+    path.length === 0 ||
+    !path.startsWith(KNOWLEDGE_PATH_PREFIX)
+  ) {
+    return null;
+  }
+
+  return {
+    type: "source-document",
+    sourceId: path,
+    mediaType: lookupMediaType(path) ?? "text/plain",
+    title: path,
+    filename: path,
+  };
+}

--- a/src/agent/streaming/mirrored-tool-chunk-state.test.ts
+++ b/src/agent/streaming/mirrored-tool-chunk-state.test.ts
@@ -318,6 +318,58 @@ describe("mirrored-tool-chunk-state", () => {
     assertEquals(mirroredOutput, true);
   });
 
+  it("emits one exact source document for repeated successful knowledge file reads", async () => {
+    const path =
+      "knowledge/knowledge-ingest-20260723131451088-6d16440c-veryfront-equity-story-13july26.md";
+    const sourceChunks: Chunk[] = [
+      {
+        type: "tool-input-available",
+        toolCallId: "tc-1",
+        toolName: "get_file",
+        input: { path },
+      },
+      { type: "tool-output-available", toolCallId: "tc-1", output: { path } },
+      {
+        type: "tool-input-available",
+        toolCallId: "tc-2",
+        toolName: "get_file",
+        input: { path },
+      },
+      { type: "tool-output-available", toolCallId: "tc-2", output: { path } },
+    ];
+    const appendedChunks: Chunk[] = [];
+
+    const outputChunks = await collectChunks(
+      createHostedMirroredUiStream({
+        sourceStream: streamChunks(sourceChunks),
+        rootStreamWatchdog: {
+          observe: () => undefined,
+          dispose: () => undefined,
+        },
+        mirroredToolChunkState: createMirroredToolChunkState(),
+        appendChunk: (chunk) => {
+          appendedChunks.push(chunk);
+        },
+      }),
+    );
+    const expectedSource: Chunk = {
+      type: "source-document",
+      sourceId: path,
+      mediaType: "text/markdown",
+      title: path,
+      filename: path,
+    };
+
+    assertEquals(outputChunks, [
+      sourceChunks[0],
+      sourceChunks[1],
+      expectedSource,
+      sourceChunks[2],
+      sourceChunks[3],
+    ]);
+    assertEquals(appendedChunks, outputChunks);
+  });
+
   it("closes open mirrored tool calls when the source stream aborts", async () => {
     const sourceChunks: Chunk[] = [
       { type: "tool-input-available", toolCallId: "tc-1", toolName: "edit_file", input: {} },

--- a/src/agent/streaming/mirrored-tool-chunk-state.ts
+++ b/src/agent/streaming/mirrored-tool-chunk-state.ts
@@ -1,4 +1,5 @@
 import type { ChatMessageMetadata, ChatUiMessageChunk } from "#veryfront/chat/protocol.ts";
+import { deriveKnowledgeSourceDocumentChunk } from "./knowledge-source-document.ts";
 
 /** Check whether a durable chunk mirrors tool output. */
 export function isDurableMirroredOutputChunk(
@@ -250,23 +251,38 @@ export async function* createHostedMirroredUiStream(
   input: CreateHostedMirroredUiStreamInput,
 ): AsyncIterable<ChatUiMessageChunk<ChatMessageMetadata>> {
   let streamError: unknown = null;
+  const emittedKnowledgeSourceIds = new Set<string>();
 
   try {
-    for await (const chunk of input.sourceStream) {
-      input.rootStreamWatchdog.observe(chunk);
-      if (isDurableMirroredOutputChunk(chunk)) {
-        input.setMirroredOutput?.(true);
+    for await (const sourceChunk of input.sourceStream) {
+      const derivedSource = sourceChunk.type === "tool-output-available"
+        ? deriveKnowledgeSourceDocumentChunk({
+          toolName: input.mirroredToolChunkState.toolCallNames.get(sourceChunk.toolCallId),
+          output: sourceChunk.output,
+        })
+        : null;
+      const chunks = [sourceChunk];
+      if (derivedSource && !emittedKnowledgeSourceIds.has(derivedSource.sourceId)) {
+        emittedKnowledgeSourceIds.add(derivedSource.sourceId);
+        chunks.push(derivedSource);
       }
-      recordMirroredToolChunkState(input.mirroredToolChunkState, chunk);
-      if (input.appendChunk) {
-        await Promise.resolve(input.appendChunk(chunk)).catch((error: unknown) => {
-          input.logger?.error("Durable run mirror failed to handle chunk", {
-            chunkType: chunk.type,
-            error: error instanceof Error ? error.message : String(error),
+
+      for (const chunk of chunks) {
+        input.rootStreamWatchdog.observe(chunk);
+        if (isDurableMirroredOutputChunk(chunk)) {
+          input.setMirroredOutput?.(true);
+        }
+        recordMirroredToolChunkState(input.mirroredToolChunkState, chunk);
+        if (input.appendChunk) {
+          await Promise.resolve(input.appendChunk(chunk)).catch((error: unknown) => {
+            input.logger?.error("Durable run mirror failed to handle chunk", {
+              chunkType: chunk.type,
+              error: error instanceof Error ? error.message : String(error),
+            });
           });
-        });
+        }
+        yield chunk;
       }
-      yield chunk;
     }
   } catch (error) {
     streamError = error;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1124";
+export const VERSION = "0.1.1125";


### PR DESCRIPTION
## Summary
- derive source-document chunks from successful project get_file outputs under knowledge/
- stream the exact path to the browser and persist it in durable conversation events
- deduplicate repeated reads without rewriting assistant prose
- publish as 0.1.1125

## Why
Opaque ingest paths can lose characters when a model manually retypes them. The platform tool result is the canonical source identity.

## Test plan
- pre-push: format, lint, typecheck, 2,642 unit suites / 21,446 steps
- 26 focused citation steps
- deno task verify:quick
- consumer package typecheck
- compiled-binary VFS E2E
- load-sensitive sandbox, SSR, and starter-template cases rerun green in isolation

## Staging
After release and deployment, create a fresh Knowledge Q&A agent, regenerate answers, reload the conversation, and verify the source chip retains the exact get_file path.