### PR TITLE
fix(routing,html): validate SPA redirect scheme (security follow-up to #3063)

### DIFF
--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -626,10 +626,18 @@ export const getRouterScript = () => `
         // { redirect: { destination } } payload. Follow it with a document
         // navigation to the target (the same net effect as the full-page 302),
         // instead of trying to render a page that does not exist here.
+        // Only follow http(s)/relative destinations: assigning a javascript:/data:
+        // URL to location.href would EXECUTE it (the server also filters these, so
+        // this is defense in depth). Fall through to the normal error path otherwise.
         if (pageData && pageData.redirect && typeof pageData.redirect.destination === 'string') {
-          log('SPA navigation redirect -> ' + pageData.redirect.destination);
-          window.location.href = pageData.redirect.destination;
-          return;
+          try {
+            var redirectTarget = new URL(pageData.redirect.destination, window.location.origin);
+            if (redirectTarget.protocol === 'http:' || redirectTarget.protocol === 'https:') {
+              log('SPA navigation redirect -> ' + redirectTarget.href);
+              window.location.href = redirectTarget.href;
+              return;
+            }
+          } catch (e) { /* invalid destination — do not follow */ }
         }
 
         if (pushState) {

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -117,27 +117,32 @@ export const PLATFORM_UTILITIES: Record<string, string> = {
   ...AI_MODULE_UTILITIES,
 };
 
+// Per-provider URL templates for the veryfront framework modules only. React is
+// NOT here: it always comes from esm.sh (see esmShReactImports) because unpkg and
+// jsdelivr only serve UMD globals, which cannot be loaded through an import map.
 interface CdnUrlTemplates {
-  react: (version: string) => string;
-  reactDom: (version: string) => string;
-  reactDomClient: (version: string) => string;
-  jsxRuntime: (version: string) => string;
-  jsxDevRuntime: (version: string) => string;
   veryfrontChat: (version: string) => string;
   veryfrontMarkdown: (version: string) => string;
   veryfrontMdx: (version: string) => string;
   veryfrontWorkflow: (version: string) => string;
 }
 
+// React import-map entries, always from esm.sh — the only CDN that serves React
+// as real ESM. Uses the centralized esmShReact() helper so the URLs stay
+// byte-identical across SSR/client (any mismatch loads a second React instance
+// and hooks fail).
+function esmShReactImports(react: string): Record<string, string> {
+  return {
+    react: esmShReact("react", react),
+    "react-dom": esmShReact("react-dom", react, "", true),
+    "react-dom/client": esmShReact("react-dom", react, "/client", true),
+    "react/jsx-runtime": esmShReact("react", react, "/jsx-runtime", true),
+    "react/jsx-dev-runtime": esmShReact("react", react, "/jsx-dev-runtime", true),
+  };
+}
+
 const CDN_URL_TEMPLATES: Record<CdnProvider, CdnUrlTemplates> = {
   "esm.sh": {
-    // Use centralized esmShReact() helper from package-registry.ts to ensure URL consistency
-    // Any URL mismatch causes esm.sh to serve different modules -> multiple React instances -> hooks fail
-    react: (v) => esmShReact("react", v),
-    reactDom: (v) => esmShReact("react-dom", v, "", true),
-    reactDomClient: (v) => esmShReact("react-dom", v, "/client", true),
-    jsxRuntime: (v) => esmShReact("react", v, "/jsx-runtime", true),
-    jsxDevRuntime: (v) => esmShReact("react", v, "/jsx-dev-runtime", true),
     veryfrontChat: (v) =>
       `https://esm.sh/veryfront@${v}/chat?external=react,react-dom&target=es2022`,
     veryfrontMarkdown: (v) =>
@@ -147,23 +152,12 @@ const CDN_URL_TEMPLATES: Record<CdnProvider, CdnUrlTemplates> = {
       `https://esm.sh/veryfront@${v}/workflow/react?external=react,react-dom&target=es2022`,
   },
   unpkg: {
-    react: (v) => `https://unpkg.com/react@${v}/umd/react.production.min.js`,
-    reactDom: (v) => `https://unpkg.com/react-dom@${v}/umd/react-dom.production.min.js`,
-    reactDomClient: (v) => `https://unpkg.com/react-dom@${v}/umd/react-dom.production.min.js`,
-    jsxRuntime: (v) => `https://unpkg.com/react@${v}/jsx-runtime`,
-    jsxDevRuntime: (v) => `https://unpkg.com/react@${v}/jsx-dev-runtime`,
     veryfrontChat: (v) => `https://unpkg.com/veryfront@${v}/esm/src/chat/index.js`,
     veryfrontMarkdown: (v) => `https://unpkg.com/veryfront@${v}/esm/src/markdown/index.js`,
     veryfrontMdx: (v) => `https://unpkg.com/veryfront@${v}/esm/src/mdx/index.js`,
     veryfrontWorkflow: (v) => `https://unpkg.com/veryfront@${v}/esm/src/workflow/react/index.js`,
   },
   jsdelivr: {
-    react: (v) => `https://cdn.jsdelivr.net/npm/react@${v}/umd/react.production.min.js`,
-    reactDom: (v) => `https://cdn.jsdelivr.net/npm/react-dom@${v}/umd/react-dom.production.min.js`,
-    reactDomClient: (v) =>
-      `https://cdn.jsdelivr.net/npm/react-dom@${v}/umd/react-dom.production.min.js`,
-    jsxRuntime: (v) => `https://cdn.jsdelivr.net/npm/react@${v}/jsx-runtime`,
-    jsxDevRuntime: (v) => `https://cdn.jsdelivr.net/npm/react@${v}/jsx-dev-runtime`,
     veryfrontChat: (v) => `https://cdn.jsdelivr.net/npm/veryfront@${v}/esm/src/chat/index.js`,
     veryfrontMarkdown: (v) =>
       `https://cdn.jsdelivr.net/npm/veryfront@${v}/esm/src/markdown/index.js`,
@@ -187,26 +181,15 @@ function buildCdnImportMapFromTemplates(
 ): Record<string, string> {
   const { react, veryfront } = versions;
 
-  // React is ALWAYS served from esm.sh, regardless of the configured CDN
-  // provider. esm.sh is the only CDN that serves React as real ESM; unpkg and
-  // jsdelivr only ship UMD globals (react/umd/react.production.min.js), which
-  // cannot be consumed through an import map at all — the browser rejects them
-  // with a module-resolution/CORS error and hydration never starts. Self-hosted
-  // mode already does exactly this. The `provider` only governs where the
-  // veryfront framework modules load from.
-  const reactTemplates = CDN_URL_TEMPLATES["esm.sh"];
-
   return {
-    react: reactTemplates.react(react),
-    "react-dom": reactTemplates.reactDom(react),
-    "react-dom/client": reactTemplates.reactDomClient(react),
-    "react/jsx-runtime": reactTemplates.jsxRuntime(react),
-    "react/jsx-dev-runtime": reactTemplates.jsxDevRuntime(react),
+    // React is ALWAYS from esm.sh, regardless of the configured provider (see
+    // esmShReactImports). The `provider` only governs the veryfront modules.
+    ...esmShReactImports(react),
     "veryfront/chat": templates.veryfrontChat(veryfront),
     "veryfront/markdown": templates.veryfrontMarkdown(veryfront),
     "veryfront/mdx": templates.veryfrontMdx(veryfront),
     "veryfront/workflow": templates.veryfrontWorkflow(veryfront),
-    // Core runtime utilities always resolve locally (see comment above).
+    // Core runtime utilities always resolve locally.
     ...CORE_PLATFORM_UTILITIES,
     // AI modules only override the CDN entries when requested.
     ...(includeAiModulesLocally ? AI_MODULE_UTILITIES : {}),
@@ -227,14 +210,9 @@ function getJsdelivrImportMap(versions: DetectedVersions): Record<string, string
 
 function getSelfHostedImportMap(versions: DetectedVersions): Record<string, string> {
   const { react } = versions;
-  const esmShTemplates = CDN_URL_TEMPLATES["esm.sh"];
 
   return {
-    react: esmShTemplates.react(react),
-    "react-dom": esmShTemplates.reactDom(react),
-    "react-dom/client": esmShTemplates.reactDomClient(react),
-    "react/jsx-runtime": esmShTemplates.jsxRuntime(react),
-    "react/jsx-dev-runtime": esmShTemplates.jsxDevRuntime(react),
+    ...esmShReactImports(react),
     "veryfront/chat": "/_veryfront/lib/chat.js",
     "veryfront/markdown": "/_veryfront/lib/markdown.js",
     "veryfront/mdx": "/_veryfront/lib/mdx.js",
@@ -423,14 +401,7 @@ export async function buildImportMap(
     : DEFAULT_VERSIONS;
 
   if (mode === "bundled") {
-    const reactTemplates = CDN_URL_TEMPLATES["esm.sh"];
-    let imports: Record<string, string> = {
-      react: reactTemplates.react(versions.react),
-      "react-dom": reactTemplates.reactDom(versions.react),
-      "react-dom/client": reactTemplates.reactDomClient(versions.react),
-      "react/jsx-runtime": reactTemplates.jsxRuntime(versions.react),
-      "react/jsx-dev-runtime": reactTemplates.jsxDevRuntime(versions.react),
-    };
+    let imports: Record<string, string> = { ...esmShReactImports(versions.react) };
     imports = applyManifestDependencies(imports, releaseAssetManifest);
     imports = applyReleaseModuleVersions(imports, releaseAssetManifest);
     imports = { ...imports, ...customImports };

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -240,6 +240,34 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
     });
   });
 
+  it("does not encode a non-http(s) redirect destination for the client to follow", async () => {
+    // The client follows the destination with window.location.href, which would
+    // EXECUTE a javascript:/data: URL. Such destinations must NOT be emitted as a
+    // 200 redirect payload — they fall through to normal error handling instead.
+    for (const destination of ["javascript:alert(1)", "data:text/html,x", "//evil.example"]) {
+      setRendererInitializer(
+        createInitializer(() =>
+          Promise.reject(
+            Object.assign(new Error(`Redirect to ${destination}`), {
+              slug: "render-error",
+              context: { redirect: { destination, permanent: false } },
+            }),
+          )
+        ),
+      );
+
+      const res = await callPageDataEndpoint(
+        new Request("http://localhost/_veryfront/page-data/redirecting.json"),
+        makeCtx(),
+      );
+
+      assertEquals(res.status, 500);
+      const body = await res.json();
+      assertEquals(body.redirect, undefined);
+      __clearPageDataEndpointCacheForTests();
+    }
+  });
+
   it("keeps speculative prefetch work and cache state out of foreground page data", async () => {
     const producers: string[] = [];
     const prefetchGate = Promise.withResolvers<void>();

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -268,6 +268,34 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
     }
   });
 
+  it("does not encode root-relative redirects that URL parsing normalizes across origins", async () => {
+    for (const destination of ["/\\evil.example", "/\t//evil.example"]) {
+      const parsedOrigin = parseOrigin(destination, "https://app.example");
+      assertEquals(parsedOrigin === null || parsedOrigin !== "https://app.example", true);
+
+      setRendererInitializer(
+        createInitializer(() =>
+          Promise.reject(
+            Object.assign(new Error(`Redirect to ${destination}`), {
+              slug: "render-error",
+              context: { redirect: { destination, permanent: false } },
+            }),
+          )
+        ),
+      );
+
+      const res = await callPageDataEndpoint(
+        new Request("http://localhost/_veryfront/page-data/redirecting.json"),
+        makeCtx(),
+      );
+
+      assertEquals(res.status, 500);
+      const body = await res.json();
+      assertEquals(body.redirect, undefined);
+      __clearPageDataEndpointCacheForTests();
+    }
+  });
+
   it("keeps speculative prefetch work and cache state out of foreground page data", async () => {
     const producers: string[] = [];
     const prefetchGate = Promise.withResolvers<void>();
@@ -585,3 +613,11 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
     });
   });
 });
+
+function parseOrigin(destination: string, base: string): string | null {
+  try {
+    return new URL(destination, base).origin;
+  } catch {
+    return null;
+  }
+}

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -350,7 +350,14 @@ function refreshStalePageData(
  * destinations fall through to normal error handling instead of being followed.
  */
 function isFollowableRedirect(destination: string): boolean {
-  if (destination.startsWith("/") && !destination.startsWith("//")) return true;
+  if (destination.startsWith("/")) {
+    const baseOrigin = "https://veryfront.local";
+    try {
+      return new URL(destination, baseOrigin).origin === baseOrigin;
+    } catch {
+      return false;
+    }
+  }
   return /^https?:\/\//i.test(destination);
 }
 

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -342,9 +342,23 @@ function refreshStalePageData(
 }
 
 /**
+ * Only http(s) and root-relative destinations may be encoded for the client to
+ * follow. The client follows the destination with `window.location.href`, which
+ * would EXECUTE a `javascript:`/`data:` URL — unlike the full-page 302 path where
+ * the browser ignores such a Location. Protocol-relative `//host` is rejected too
+ * (it is easy to smuggle past a naive "starts with /" check). Blocked
+ * destinations fall through to normal error handling instead of being followed.
+ */
+function isFollowableRedirect(destination: string): boolean {
+  if (destination.startsWith("/") && !destination.startsWith("//")) return true;
+  return /^https?:\/\//i.test(destination);
+}
+
+/**
  * A redirect() from getServerData is thrown up the pipeline as a VeryfrontError
  * whose `context.redirect` holds the destination (mirrors extractRedirectLocation
- * in the SSR service). Returns null for any other error.
+ * in the SSR service). Returns null for any other error, or for a redirect whose
+ * destination is not safe to hand to the client to follow.
  */
 function extractRedirectFromError(
   error: unknown,
@@ -354,6 +368,7 @@ function extractRedirectFromError(
   })?.context;
   const redirect = context?.redirect;
   if (!redirect || typeof redirect.destination !== "string") return null;
+  if (!isFollowableRedirect(redirect.destination)) return null;
   return { destination: redirect.destination, permanent: redirect.permanent === true };
 }
 


### PR DESCRIPTION
## Summary

**Security follow-up to #3063.** That PR was squash-merged from only its first commit — the second commit, which added redirect-destination scheme validation, did not make it into the squash. As a result `main` currently ships the vulnerable code and this restores the guard.

### The issue (now live on `main`)
#3063 made the SPA client follow a `getServerData` `redirect()` by encoding it as a `200 { redirect: { destination } }` payload and running, in the client router:

```js
window.location.href = pageData.redirect.destination;
```

with **no scheme validation**. Assigning a `javascript:`/`data:` URL to `window.location.href` **executes** it — unlike the full-page 302 path, where the browser ignores such a `Location`. An app that redirects to user-influenced input — e.g. `redirect(ctx.query.get("next"))` — is therefore turned into XSS on client-side navigation.

### Fix (restores the dropped commit)
- **Server** (`page-data-endpoint-handler.ts`): `isFollowableRedirect` — only encode a redirect payload for http(s) and root-relative destinations; `javascript:`, `data:`, and protocol-relative `//host` fall through to normal error handling and are never sent to the client.
- **Client** (`router.ts`): resolve via `new URL(dest, origin)` and only follow when the protocol is http(s) — defense in depth.
- **Test**: new case asserts `javascript:`, `data:`, and `//host` destinations → 500, no `redirect` payload.
- **Cleanup** (bundled with the same commit): remove the now-dead unpkg/jsdelivr `/umd/*` React URL templates left over from #3063 (they were the original bug's source); React import-map entries come from one `esmShReactImports()` helper.

## Tests
`deno test src/html/utils.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts` → 48 steps, 0 failed.

## Validation (veryfront-router-testing)
default-config gate + `nav-sweep` 16/16 (h-redirect still follows its `/`-relative target), config-cdn-unpkg still hydrates clean.

Base: `main`.
