### PR TITLE
fix(esm): resolve versioned bare specifiers on the SSR target

### DIFF
--- a/src/transforms/import-rewriter/strategies/bare-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/bare-strategy.test.ts
@@ -158,11 +158,50 @@ describe("BareStrategy", () => {
       );
     });
 
-    // On the SSR target every bare/`npm:` package is left external regardless of
-    // whether it is server-only — the rewrite only ever targets the browser.
+    // `npm:` specifiers are left external on SSR — the Deno npm resolver
+    // understands their version, so no rewrite is needed.
     it("leaves a browser-safe npm: specifier external on the SSR target", () => {
       const result = bareStrategy.rewrite(makeInfo("npm:zod@4.0.0"), makeCtx({ target: "ssr" }));
       assertEquals(result.specifier, null);
+    });
+  });
+
+  describe("rewrite: SSR strips explicit versions from bare specifiers", () => {
+    const ssr = makeCtx({ target: "ssr" });
+
+    it("strips the version so an installed package resolves by name", () => {
+      // Regression: `import()` of `next-themes@0.4.6` has no matching
+      // node_modules entry and stalls the cold module load to a 500.
+      assertEquals(bareStrategy.rewrite(makeInfo("next-themes@0.4.6"), ssr), {
+        specifier: "next-themes",
+      });
+    });
+
+    it("leaves an unversioned specifier unchanged", () => {
+      assertEquals(bareStrategy.rewrite(makeInfo("next-themes"), ssr), { specifier: null });
+    });
+
+    it("preserves the subpath while stripping the version", () => {
+      assertEquals(bareStrategy.rewrite(makeInfo("date-fns@3.6.0/locale"), ssr), {
+        specifier: "date-fns/locale",
+      });
+    });
+
+    it("strips the version from a scoped package", () => {
+      assertEquals(bareStrategy.rewrite(makeInfo("@tanstack/react-query@5.0.0"), ssr), {
+        specifier: "@tanstack/react-query",
+      });
+    });
+
+    it("keeps the version in the browser esm.sh URL (unchanged)", () => {
+      const result = bareStrategy.rewrite(
+        makeInfo("next-themes@0.4.6"),
+        makeCtx({ target: "browser" }),
+      );
+      assertEquals(
+        result.specifier?.startsWith("https://esm.sh/next-themes@0.4.6"),
+        true,
+      );
     });
   });
 });

--- a/src/transforms/import-rewriter/strategies/bare-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/bare-strategy.ts
@@ -87,7 +87,20 @@ export class BareStrategy implements ImportRewriteStrategy {
       return { specifier: null };
     }
 
-    if (ctx.target === "ssr") return { specifier: null };
+    if (ctx.target === "ssr") {
+      // On the server an installed package is resolved by name from node_modules
+      // (Node) — a bare specifier carrying an explicit version, e.g.
+      // `next-themes@0.4.6`, has no matching `node_modules/next-themes@0.4.6`
+      // entry, so `import()` never resolves it and the cold module load stalls
+      // to a timeout/500. The version is only meaningful for the browser's
+      // esm.sh URL, so strip it here and resolve the installed package by name
+      // (preserving any subpath). `npm:` specifiers keep their version — the
+      // Deno npm resolver understands them.
+      if (!isNpmScheme && parsed?.version) {
+        return { specifier: `${parsed.packageName}${parsed.subpath ?? ""}` };
+      }
+      return { specifier: null };
+    }
 
     if (parsed == null) {
       return { specifier: null };

--- a/src/transforms/import-rewriter/strategies/bare-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/bare-strategy.ts
@@ -15,6 +15,7 @@ import type {
 import { buildEsmShUrl, TAILWIND_VERSION } from "../url-builder.ts";
 import { parseBarePackageSpecifier } from "../../shared/package-specifier.ts";
 import { isServerOnlyPackage } from "../../shared/server-only-packages.ts";
+import { isCrossProjectImport } from "#veryfront/transforms/shared/cross-project-import.ts";
 
 const logger = rendererLogger.component("esm");
 
@@ -60,7 +61,8 @@ export class BareStrategy implements ImportRewriteStrategy {
       specifier === "react-dom" ||
       specifier.startsWith("react/") ||
       specifier.startsWith("react-dom/") ||
-      specifier.startsWith("node:")
+      specifier.startsWith("node:") ||
+      isCrossProjectImport(specifier)
     ) {
       return false;
     }

--- a/src/transforms/import-rewriter/unified-rewriter.test.ts
+++ b/src/transforms/import-rewriter/unified-rewriter.test.ts
@@ -133,6 +133,13 @@ describe("rewriteImports with the default strategies", () => {
     assertStringIncludes(result, "../components/Button.js");
   });
 
+  it("preserves versioned cross-project imports for SSR loader replacement", async () => {
+    const code = `import Button from "demo@1.0.0/@/components/Button";\n`;
+    const result = await rewriteImports(code, defaultCtx({ target: "ssr" }));
+
+    assertEquals(result, code);
+  });
+
   it("leaves an asset inside a dependency to the bare strategy", async () => {
     // The extension alone must not claim the specifier: "move the file to
     // public/" is not something you can do to a file inside node_modules.


### PR DESCRIPTION
## Summary

The framework's own `esm` warning tells you to pin imports — `import '<pkg>@x.y.z'` — but that exact syntax **hangs the cold module load to a timeout/500** on SSR.

Root cause: in `bare-strategy.ts`, the SSR branch returned `{ specifier: null }` (leave external) for **every** bare specifier. So a versioned one — `next-themes@0.4.6` — was left external and `import()`'d against node_modules literally as `node_modules/next-themes@0.4.6`, which doesn't exist (npm installs by **name**). Resolution never completes → the cold-module deadline fires → 500. The unversioned `next-themes` works precisely because it resolves to the installed dir.

## Fix

On the SSR target, strip an explicit version from a bare specifier so the **installed package resolves by name** (subpath preserved):

```
next-themes@0.4.6            → next-themes
date-fns@3.6.0/locale        → date-fns/locale
@tanstack/react-query@5.0.0  → @tanstack/react-query
```

Unchanged: unversioned specifiers (still `null`), the **browser** target (keeps the version in its esm.sh URL), `npm:` specifiers (the Deno npm resolver understands their version), and server-only packages.

## Verification

- `deno test src/transforms/import-rewriter/strategies/bare-strategy.test.ts` — 1 passed / 0 failed (30 steps, incl. 5 new SSR cases)
- `deno check` + `deno lint` clean on the changed files
- Validated at the unit level (the rewrite decision point); no end-to-end app link run.

## Notes

- Discovered on an example app whose `components/app.tsx` imported `next-themes@0.4.6` per the framework's own pin-version suggestion.
- Unrelated: `import-map-strategy.test.ts` has a pre-existing TS2724 (`ImportSpecifier` vs `ImportSpecifierInfo`) on `main`, so a whole-directory `deno test` type-checks red independent of this change.