### PR TITLE
fix(router): useRouter().push/replace/navigate do SPA navigation (no full reload)

### DIFF
--- a/src/html/hydration-script-builder/dev-client-renderer.ts
+++ b/src/html/hydration-script-builder/dev-client-renderer.ts
@@ -8,7 +8,7 @@ export function generateDevClientRendererScript(nonce?: string): string {
   <script type="module"${nonceAttr}>
     import * as React from 'react';
     import { createRoot } from 'react-dom/client';
-    import { RouterProvider, useRouter as useRouterFromModule } from 'veryfront/router';
+    import { RouterProvider, useRouter as useRouterFromModule, getNavigationStore } from 'veryfront/router';
     import { PageContextProvider } from 'veryfront/context';
 
     ${getRouterScript()}

--- a/src/html/hydration-script-builder/prod-scripts.ts
+++ b/src/html/hydration-script-builder/prod-scripts.ts
@@ -12,7 +12,7 @@ export function generateProdHydrationModule(): string {
   return [
     `import * as React from 'react';`,
     `import { createRoot } from 'react-dom/client';`,
-    `import { RouterProvider, useRouter as useRouterFromModule } from 'veryfront/router';`,
+    `import { RouterProvider, useRouter as useRouterFromModule, getNavigationStore } from 'veryfront/router';`,
     `import { PageContextProvider } from 'veryfront/context';`,
     getRouterScript().trim(),
     getLoaderScript().trim(),

--- a/src/html/hydration-script-builder/templates/router-push-spa.test.ts
+++ b/src/html/hydration-script-builder/templates/router-push-spa.test.ts
@@ -1,0 +1,203 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getRouterScript } from "./router.ts";
+
+// Finding #7: useRouter().push()/replace() must perform SPA navigation, not a
+// full document reload. `useRouter()` (from `veryfront/router` = react runtime
+// core) routes push/replace/navigate through the shared navigation store's
+// `navigate`, which delegates to whatever navigator has been registered via
+// `setNavigator` — or falls back to `location.assign` (a full reload) when none
+// is. The dev hydration runtime owns the real SPA navigator (`navigateSPA`, the
+// same one that intercepts <Link> clicks), so it must register that navigator
+// against the shared store. These tests evaluate the generated runtime with a
+// stub store and assert the registration + SPA routing actually happen.
+
+interface RuntimeLocation {
+  origin: string;
+  pathname: string;
+  search: string;
+  readonly href: string;
+}
+interface RuntimeRouter {
+  pathname: string;
+  push(path: string): void;
+  replace(path: string): void;
+}
+interface FakeStore {
+  navigator: ((href: string, options?: { history?: string }) => Promise<void>) | null;
+  assignFallbackCount: number;
+  navigate(href: string, options?: { history?: string }): Promise<void>;
+  setNavigator(next: (href: string, options?: { history?: string }) => Promise<void>): void;
+}
+
+interface RuntimeHandle {
+  router: RuntimeRouter;
+  navigateSPA: (href: string, pushState?: boolean, restoreScroll?: boolean) => Promise<void>;
+  store: FakeStore;
+  win: { __veryfrontHydrationComplete?: () => void };
+  setNextPageData: (data: unknown) => void;
+}
+
+function evaluateRouterRuntimeWithStore(): RuntimeHandle {
+  const listeners: Record<string, Array<(e: unknown) => void>> = {};
+  const addEventListener = (type: string, fn: (e: unknown) => void) => {
+    (listeners[type] ??= []).push(fn);
+  };
+
+  const makeEl = () => ({
+    style: {} as Record<string, unknown>,
+    id: "",
+    textContent: "",
+    setAttribute() {},
+    getAttribute() {
+      return null;
+    },
+    prepend() {},
+    remove() {},
+    appendChild() {},
+  });
+
+  const rootEl = { __reactRoot: { render() {} } };
+  const hydrationJson = JSON.stringify({ params: {} });
+  const doc = {
+    readyState: "complete",
+    body: { prepend() {}, setAttribute() {}, removeAttribute() {}, appendChild() {} },
+    head: { appendChild() {} },
+    createElement: () => makeEl(),
+    querySelector: () => null,
+    querySelectorAll: () => [] as unknown[],
+    getElementById: (id: string) => {
+      if (id === "veryfront-hydration-data") return { textContent: hydrationJson };
+      if (id === "root") return rootEl;
+      return null;
+    },
+    addEventListener,
+  };
+
+  const win = {
+    location: {
+      origin: "https://veryfront.test",
+      pathname: "/",
+      search: "",
+      get href() {
+        return "https://veryfront.test" + this.pathname + this.search;
+      },
+    } as RuntimeLocation,
+    history: { pushState() {}, replaceState() {}, back() {}, forward() {} },
+    addEventListener,
+    dispatchEvent() {
+      return true;
+    },
+    scrollTo() {},
+    scrollY: 0,
+    __veryfrontRouter: undefined as RuntimeRouter | undefined,
+    __veryfrontHydrationComplete: undefined as (() => void) | undefined,
+  };
+
+  let nextPageData: unknown = { pagePath: "page", params: {} };
+  const fetchStub = () =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      url: "/_veryfront/page-data/page.json",
+      headers: { get: () => null },
+      json: () => Promise.resolve(nextPageData),
+    });
+
+  const RouterProvider = () => ({});
+  const PageContextProvider = () => ({});
+  const React = { createElement: () => ({}) };
+  const loadComponent = () => Promise.resolve(() => null);
+
+  // Faithful stand-in for the cross-bundle navigation store the react runtime's
+  // RouterProvider reads. `navigate` delegates to the registered navigator, or
+  // records a full-reload fallback when none is registered — exactly the real
+  // store's `navigate(href) { if (navigator) return navigator(...); location.assign(...) }`.
+  const store: FakeStore = {
+    navigator: null,
+    assignFallbackCount: 0,
+    navigate(href, options) {
+      if (store.navigator) return store.navigator(href, options);
+      store.assignFallbackCount++;
+      return Promise.resolve();
+    },
+    setNavigator(next) {
+      store.navigator = next;
+    },
+  };
+  const getNavigationStore = () => store;
+
+  const factory = new Function(
+    "window",
+    "document",
+    "fetch",
+    "React",
+    "RouterProvider",
+    "PageContextProvider",
+    "loadComponent",
+    "setTimeout",
+    "clearTimeout",
+    "getNavigationStore",
+    getRouterScript() + "\nreturn { router, navigateSPA };",
+  );
+
+  const handle = factory(
+    win,
+    doc,
+    fetchStub,
+    React,
+    RouterProvider,
+    PageContextProvider,
+    loadComponent,
+    () => 0,
+    () => {},
+    getNavigationStore,
+  ) as { router: RuntimeRouter; navigateSPA: RuntimeHandle["navigateSPA"] };
+
+  return {
+    router: handle.router,
+    navigateSPA: handle.navigateSPA,
+    store,
+    win,
+    setNextPageData: (data: unknown) => {
+      nextPageData = data;
+    },
+  };
+}
+
+describe("hydration-script-builder/templates/router — push SPA navigator (finding #7)", () => {
+  it("registers the SPA navigator against the shared navigation store", () => {
+    const runtime = evaluateRouterRuntimeWithStore();
+    // Without a registered navigator, useRouter().push() falls back to a full
+    // document reload (location.assign). The runtime must register navigateSPA.
+    assertEquals(typeof runtime.store.navigator, "function");
+  });
+
+  it("routes store.navigate({history:'push'}) through SPA navigation, not a full reload", async () => {
+    const runtime = evaluateRouterRuntimeWithStore();
+    runtime.win.__veryfrontHydrationComplete?.();
+    runtime.setNextPageData({ pagePath: "page", params: {} });
+    runtime.win.location.pathname = "/next";
+
+    // This is exactly what useRouter().push('/next') does in the react runtime.
+    await runtime.store.navigate("/next", { history: "push" });
+
+    // SPA navigation ran (router snapshot moved) and the store never fell back
+    // to the full-reload path.
+    assertEquals(runtime.store.assignFallbackCount, 0);
+    assertEquals(runtime.router.pathname, "/next");
+  });
+
+  it("routes store.navigate({history:'replace'}) through SPA navigation, not a full reload", async () => {
+    const runtime = evaluateRouterRuntimeWithStore();
+    runtime.win.__veryfrontHydrationComplete?.();
+    runtime.setNextPageData({ pagePath: "page", params: {} });
+    runtime.win.location.pathname = "/replaced";
+
+    await runtime.store.navigate("/replaced", { history: "replace" });
+
+    assertEquals(runtime.store.assignFallbackCount, 0);
+    assertEquals(runtime.router.pathname, "/replaced");
+  });
+});

--- a/src/html/hydration-script-builder/templates/router-push-spa.test.ts
+++ b/src/html/hydration-script-builder/templates/router-push-spa.test.ts
@@ -33,8 +33,13 @@ interface FakeStore {
 
 interface RuntimeHandle {
   router: RuntimeRouter;
-  navigateSPA: (href: string, pushState?: boolean, restoreScroll?: boolean) => Promise<void>;
+  navigateSPA: (
+    href: string,
+    historyMode?: "push" | "replace" | "none",
+    restoreScroll?: boolean,
+  ) => Promise<void>;
   store: FakeStore;
+  historyCalls: Array<{ method: "push" | "replace"; href: string }>;
   win: { location: RuntimeLocation; __veryfrontHydrationComplete?: () => void };
   setNextPageData: (data: unknown) => void;
 }
@@ -75,6 +80,7 @@ function evaluateRouterRuntimeWithStore(): RuntimeHandle {
     addEventListener,
   };
 
+  const historyCalls: RuntimeHandle["historyCalls"] = [];
   const win = {
     location: {
       origin: "https://veryfront.test",
@@ -84,7 +90,16 @@ function evaluateRouterRuntimeWithStore(): RuntimeHandle {
         return "https://veryfront.test" + this.pathname + this.search;
       },
     } as RuntimeLocation,
-    history: { pushState() {}, replaceState() {}, back() {}, forward() {} },
+    history: {
+      pushState(_state: unknown, _unused: string, href: string) {
+        historyCalls.push({ method: "push", href });
+      },
+      replaceState(_state: unknown, _unused: string, href: string) {
+        historyCalls.push({ method: "replace", href });
+      },
+      back() {},
+      forward() {},
+    },
     addEventListener,
     dispatchEvent() {
       return true;
@@ -159,6 +174,7 @@ function evaluateRouterRuntimeWithStore(): RuntimeHandle {
     router: handle.router,
     navigateSPA: handle.navigateSPA,
     store,
+    historyCalls,
     win,
     setNextPageData: (data: unknown) => {
       nextPageData = data;
@@ -199,5 +215,6 @@ describe("hydration-script-builder/templates/router — push SPA navigator (find
 
     assertEquals(runtime.store.assignFallbackCount, 0);
     assertEquals(runtime.router.pathname, "/replaced");
+    assertEquals(runtime.historyCalls, [{ method: "replace", href: "/replaced" }]);
   });
 });

--- a/src/html/hydration-script-builder/templates/router-push-spa.test.ts
+++ b/src/html/hydration-script-builder/templates/router-push-spa.test.ts
@@ -35,7 +35,7 @@ interface RuntimeHandle {
   router: RuntimeRouter;
   navigateSPA: (href: string, pushState?: boolean, restoreScroll?: boolean) => Promise<void>;
   store: FakeStore;
-  win: { __veryfrontHydrationComplete?: () => void };
+  win: { location: RuntimeLocation; __veryfrontHydrationComplete?: () => void };
   setNextPageData: (data: unknown) => void;
 }
 

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -144,7 +144,7 @@ describe("hydration-script-builder/templates/router", () => {
     it("should cancel hover prefetch before click navigation", () => {
       const result = getRouterScript();
       assertIncludes(result, "function cancelScheduledPrefetch()");
-      assertIncludes(result, "cancelScheduledPrefetch();\n      void navigateSPA(href, true);");
+      assertIncludes(result, "cancelScheduledPrefetch();\n      void navigateSPA(href, 'push');");
     });
 
     it("should skip page-data prefetches while navigation is active", () => {
@@ -233,7 +233,7 @@ describe("hydration-script-builder/templates/router", () => {
     });
 
     it("should define navigateSPA function", () => {
-      assertIncludes(getRouterScript(), "async function navigateSPA(href, pushState");
+      assertIncludes(getRouterScript(), "async function navigateSPA(href, historyMode");
     });
 
     it("should define renderPageFromData function", () => {

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -599,6 +599,7 @@ describe("hydration-script-builder/templates/router", () => {
         "loadComponent",
         "setTimeout",
         "clearTimeout",
+        "getNavigationStore",
         getRouterScript() + "\nreturn { router, navigateSPA };",
       );
 
@@ -612,6 +613,7 @@ describe("hydration-script-builder/templates/router", () => {
         loadComponent,
         () => 0,
         () => {},
+        () => ({ setNavigator() {} }),
       ) as { router: RuntimeRouter; navigateSPA: RuntimeHandle["navigateSPA"] };
 
       return {

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -1111,6 +1111,15 @@ export const getRouterScript = () => `
 
     window.__veryfrontRouter = router;
 
+    // Route useRouter().push/replace/navigate (from veryfront/router) through the
+    // same SPA navigator that intercepts <Link> clicks. Without this the shared
+    // navigation store has no navigator registered and its navigate() falls back
+    // to a full-page location.assign (finding #7: push() full-reloads).
+    getNavigationStore().setNavigator((href, options) => {
+      const mode = options && options.history;
+      return navigateSPA(href, mode !== 'replace' && mode !== 'none');
+    });
+
     // ============================================
     // Event handlers
     // ============================================

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -592,7 +592,7 @@ export const getRouterScript = () => `
     // ============================================
     // SPA navigation handler
     // ============================================
-    async function navigateSPA(href, pushState = true, restoreScroll = false) {
+    async function navigateSPA(href, historyMode = 'push', restoreScroll = false) {
       currentAbortController?.abort();
 
       if (isNavigating) return;
@@ -632,8 +632,10 @@ export const getRouterScript = () => `
           return;
         }
 
-        if (pushState) {
+        if (historyMode === 'push') {
           window.history.pushState({ pageData, scrollY: 0 }, '', href);
+        } else if (historyMode === 'replace') {
+          window.history.replaceState({ pageData, scrollY: 0 }, '', href);
         }
 
         // Update the shared router snapshot BEFORE rendering. RouterProvider
@@ -666,7 +668,11 @@ export const getRouterScript = () => `
 
         hideNavigationProgress();
         perfEnd('nav:total:' + href);
-        emitRouteTiming('total', targetPath, navigationStartedAt, { href, pushState, restoreScroll });
+        emitRouteTiming('total', targetPath, navigationStartedAt, {
+          href,
+          historyMode,
+          restoreScroll
+        });
         log('SPA navigation complete');
       } catch (error) {
         hideNavigationProgress();
@@ -1076,10 +1082,10 @@ export const getRouterScript = () => `
       domain: window.location.origin,
       path: window.location.pathname,
       push: (path) => {
-        void navigateSPA(path, true);
+        void navigateSPA(path, 'push');
       },
       replace: (path) => {
-        void navigateSPA(path, false);
+        void navigateSPA(path, 'replace');
       },
       back: () => {
         window.history.back();
@@ -1105,7 +1111,7 @@ export const getRouterScript = () => `
       })(),
       isPreview: false,
       isMounted: true,
-      navigate: (path) => navigateSPA(path, true),
+      navigate: (path) => navigateSPA(path, 'push'),
       reload: () => window.location.reload()
     };
 
@@ -1117,7 +1123,8 @@ export const getRouterScript = () => `
     // to a full-page location.assign (finding #7: push() full-reloads).
     getNavigationStore().setNavigator((href, options) => {
       const mode = options && options.history;
-      return navigateSPA(href, mode !== 'replace' && mode !== 'none');
+      const historyMode = mode === 'replace' ? 'replace' : mode === 'none' ? 'none' : 'push';
+      return navigateSPA(href, historyMode);
     });
 
     // ============================================
@@ -1130,7 +1137,7 @@ export const getRouterScript = () => `
       saveScrollPosition(currentPath);
 
       if (!e.state?.pageData) {
-        await navigateSPA(path, false, true);
+        await navigateSPA(path, 'none', true);
         return;
       }
 
@@ -1186,7 +1193,7 @@ export const getRouterScript = () => `
 
       e.preventDefault();
       cancelScheduledPrefetch();
-      void navigateSPA(href, true);
+      void navigateSPA(href, 'push');
     });
 
     document.addEventListener(

--- a/src/react/runtime/core.ts
+++ b/src/react/runtime/core.ts
@@ -185,7 +185,7 @@ interface NavigationStore {
 
 const NAVIGATION_STORE_KEY = Symbol.for("veryfront.navigation.store.v1");
 
-function getNavigationStore(): NavigationStore {
+export function getNavigationStore(): NavigationStore {
   const holder = globalThis as Record<symbol, unknown>;
   const existing = holder[NAVIGATION_STORE_KEY] as NavigationStore | undefined;
   if (existing) return existing;


### PR DESCRIPTION
## What

`useRouter().push()` / `replace()` / `navigate()` triggered a **full document reload** (destroying the JS realm) in both the app-router and pages-router, while `<Link>` correctly stayed SPA.

The hydration runtime wires `<Link>` clicks to its `navigateSPA`, but never registered a navigator against the shared navigation store that `RouterProvider` reads — so the store's `navigate` fell back to `location.assign(href)`. This registers `navigateSPA` as the store's navigator (mapping `history: 'push' | 'replace'`), so programmatic navigation is SPA too. `getNavigationStore` is exported from the react runtime and imported by both the dev (`dev-client-renderer`) and prod (`prod-scripts`) hydration-module builders so the generated runtime can reach it.

## How to test
1. Load a page that stamps a marker on mount (e.g. `window.__spa = Date.now()`), then trigger `useRouter().push('/other')`.
2. Expect: the marker **survives**, URL + content update, no document reload — in **both** app and pages routers (previously the marker was wiped by a full reload).
3. `<Link>` navigation is unchanged (still SPA).
4. `deno test src/html/hydration-script-builder/` — new `router-push-spa.test.ts` (red→green); all 12 files green.

Refs veryfront/veryfront-issue-inbox#200 (finding 7)