### PR TITLE
fix(api): ctx.text/ctx.json return 204/304 without a 500

### DIFF
--- a/src/routing/api/context-builder.test.ts
+++ b/src/routing/api/context-builder.test.ts
@@ -486,3 +486,44 @@ describe("createContext: ctx.json writes, ctx.body reads", () => {
     assertEquals(await read(), { isolated: true });
   });
 });
+
+describe("createContext: null-body statuses drop the body instead of throwing", () => {
+  function ctxFor(request: Request): APIContext {
+    return createContext(request, { params: {} } as RouteMatch, mockFs);
+  }
+
+  it("builds a 204 from ctx.text('', { status: 204 }) without throwing", async () => {
+    // `new Response("", { status: 204 })` throws — 204 is a null-body status and
+    // the empty string is still a (non-null) body. The helper must send `null`.
+    const ctx = ctxFor(new Request("http://localhost/api/text-204"));
+    const response = ctx.text("", { status: 204 });
+
+    assertEquals(response.status, 204);
+    assertEquals(response.body, null);
+    assertEquals(await response.text(), "");
+  });
+
+  it("builds a 204 from ctx.json(data, { status: 204 }) without throwing", () => {
+    const ctx = ctxFor(new Request("http://localhost/api/json-204"));
+    const response = ctx.json({ ignored: true }, { status: 204 });
+
+    assertEquals(response.status, 204);
+    assertEquals(response.body, null);
+  });
+
+  it("drops the body on a 304 too", () => {
+    const ctx = ctxFor(new Request("http://localhost/api/cached"));
+    const response = ctx.text("stale", { status: 304 });
+
+    assertEquals(response.status, 304);
+    assertEquals(response.body, null);
+  });
+
+  it("still returns the body for a normal 200 from ctx.text", async () => {
+    const ctx = ctxFor(new Request("http://localhost/api/hello"));
+    const response = ctx.text("hello", { status: 200 });
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.text(), "hello");
+  });
+});

--- a/src/routing/api/context-builder.ts
+++ b/src/routing/api/context-builder.ts
@@ -69,6 +69,16 @@ export function createJsonHelper(_request: Request): APIContext["json"] {
 }
 
 /**
+ * Build the `ctx.text` response helper.
+ *
+ * Exported for the isolation Worker so both execution modes share Fetch's
+ * null-body status handling instead of maintaining separate implementations.
+ */
+export function createTextHelper(): APIContext["text"] {
+  return (data: string, init?: ResponseInit): Response => createResponse(data, "text/plain", init);
+}
+
+/**
  * Build the `ctx.body` request-body reader.
  *
  * The parse is memoised on the first call, so a validation helper and a handler
@@ -107,9 +117,7 @@ export function createContext(
   const url = new URL(request.url);
   const json = createJsonHelper(request);
   const body = createBodyReader(request);
-
-  const text = (data: string, init?: ResponseInit): Response =>
-    createResponse(data, "text/plain", init);
+  const text = createTextHelper();
 
   return {
     request,

--- a/src/routing/api/context-builder.ts
+++ b/src/routing/api/context-builder.ts
@@ -33,12 +33,22 @@ export interface APIContext {
   fs: FileSystemAdapter;
 }
 
+/**
+ * Statuses that the Fetch spec forbids from carrying a body. Constructing
+ * `new Response(body, { status })` with a non-null `body` (an empty string
+ * still counts) throws `Response with null body status cannot have body`, so
+ * the helpers below must send `null` for these.
+ */
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
 function createResponse(
   body: BodyInit,
   contentType: string,
   init?: ResponseInit,
 ): Response {
-  return new Response(body, {
+  const status = init?.status;
+  const hasNullBodyStatus = status !== undefined && NULL_BODY_STATUSES.has(status);
+  return new Response(hasNullBodyStatus ? null : body, {
     ...init,
     headers: {
       "Content-Type": contentType,

--- a/src/routing/api/fixtures/null-body-pages-route.ts
+++ b/src/routing/api/fixtures/null-body-pages-route.ts
@@ -1,0 +1,7 @@
+type PagesContext = {
+  text(data: string, init?: ResponseInit): Response;
+};
+
+export function GET(ctx: PagesContext): Response {
+  return ctx.text("ignored", { status: 204 });
+}

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -944,4 +944,41 @@ describe("routing/api/route-executor", () => {
       assertEquals(await response.json(), policy);
     });
   });
+
+  describe("response helpers (isolated pages execution)", () => {
+    afterEach(() => {
+      Deno.env.delete("WORKER_ISOLATION_ENABLED");
+      Deno.env.delete("WORKER_ISOLATION_API");
+      __resetPoolForTests();
+    });
+
+    it("drops ctx.text bodies for null-body statuses", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      __resetPoolForTests();
+
+      const modulePath = new URL(
+        "./fixtures/null-body-pages-route.ts",
+        import.meta.url,
+      ).pathname;
+      const projectDir = new URL("../../../", import.meta.url).pathname;
+
+      const response = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          executePagesRoute(
+            { GET: () => new Response("unreachable") },
+            new Request("http://localhost/api/no-content", { method: "GET" }),
+            makeMatch("/api/no-content", modulePath),
+            "/api/no-content",
+            makeAdapter(),
+            undefined,
+            { modulePath, projectDir, isLocalProject: true },
+          ),
+      );
+
+      assertEquals(response.status, 204);
+      assertEquals(response.body, null);
+    });
+  });
 });

--- a/src/security/sandbox/worker-script.ts
+++ b/src/security/sandbox/worker-script.ts
@@ -34,7 +34,11 @@ import { isAbsolute, relative, resolve as resolvePath, sep as PATH_SEP } from "n
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import { isDataControlResult, toDataControlResult } from "#veryfront/data/helpers.ts";
 import { parseSourceIntegrationPolicyManifest } from "#veryfront/integrations/source-policy.ts";
-import { createBodyReader, createJsonHelper } from "#veryfront/routing/api/context-builder.ts";
+import {
+  createBodyReader,
+  createJsonHelper,
+  createTextHelper,
+} from "#veryfront/routing/api/context-builder.ts";
 
 // Module-level singletons to avoid per-call allocation churn
 const encoder = new TextEncoder();
@@ -482,11 +486,7 @@ async function handlePagesRoute(req: ExecutePagesRouteRequest): Promise<Serializ
           // the same whether or not isolation is enabled.
           json: createJsonHelper(request),
           body: createBodyReader(request),
-          text: (data: string, init?: ResponseInit): Response =>
-            new Response(data, {
-              ...init,
-              headers: { "Content-Type": "text/plain", ...init?.headers },
-            }),
+          text: createTextHelper(),
           fs: workerFs,
         };
 


### PR DESCRIPTION
## What

`ctx.text("", { status: 204 })` returned **500** (`application/problem+json`). An empty string is still a body and 204/304 are null-body statuses, so `new Response("", { status: 204 })` threw "Response with null body status cannot have body". The shared `createResponse` (behind both `ctx.text` and `ctx.json`) now sends a `null` body for null-body statuses (101/103/204/205/304), so the helpers return the status cleanly.

## How to test
1. Route: `export function GET(ctx){ return ctx.text("", { status: 204 }); }`
2. `curl -i .../api/text-204` → **204 No Content** (previously 500).
3. Sanity: `ctx.json(data, { status: 204 })` and a 304 also return cleanly; a normal 200 still carries its body.
4. `deno test src/routing/api/context-builder.test.ts` — new null-body-status cases (added red, now green).

Refs veryfront/veryfront-issue-inbox#200 (finding 2)