### PR TITLE
docs(middleware): fix execute() example (use handle()) + document dev-vs-prod module state

### DIFF
--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -88,21 +88,20 @@ const pipeline = new MiddlewarePipeline()
   .useFor(/^\/api\/chat\//, timeout({ timeoutMs: 120_000 }));
 ```
 
-### Execute the pipeline
+### Run the pipeline
+
+Use `handle()` to run the middleware chain and then your route handler. If a middleware short-circuits (returns a `Response` — e.g. a rate-limit rejection), `handle()` returns that response and your handler never runs; otherwise your handler runs as the terminal step:
 
 ```ts
 // app/api/users/route.ts
 const users = [{ id: "user_123", name: "Ada Lovelace" }];
 
-export async function GET(request: Request) {
-  const result = await pipeline.execute(request);
-  if (result) return result; // Middleware returned a response (e.g., rate limit exceeded)
-
-  return Response.json(users);
+export function GET(request: Request) {
+  return pipeline.handle(request, () => Response.json(users));
 }
 ```
 
-The same pipeline can run in a pages router handler by passing `ctx.request`:
+The same pipeline runs in a pages router handler via `ctx.request`:
 
 ```ts
 // pages/api/users.ts
@@ -110,11 +109,8 @@ import type { APIContext } from "veryfront";
 
 const users = [{ id: "user_123", name: "Ada Lovelace" }];
 
-export async function GET(ctx: APIContext) {
-  const result = await pipeline.execute(ctx.request);
-  if (result) return result; // Middleware returned a response (e.g., rate limit exceeded)
-
-  return ctx.json(users);
+export function GET(ctx: APIContext) {
+  return pipeline.handle(ctx.request, () => ctx.json(users));
 }
 ```
 
@@ -124,7 +120,18 @@ Try it with the dev server running:
 curl -i http://localhost:3000/api/users
 ```
 
-The response should include any headers added by the middleware that matched the request. If a middleware returns a `Response`, the route handler stops there and returns that response.
+The response includes any headers added by the middleware that matched the request.
+
+> **`handle()` vs `execute()`.** `execute()` is a lower-level variant with **no terminal handler**: it returns the short-circuiting middleware's `Response`, or a synthesized **404 Not Found** when the chain passes through. It always resolves to a `Response` (never `undefined`), so `if (await pipeline.execute(req))` is always truthy — use `execute()` only when a middleware is always expected to produce the response. For the common "middleware, then my route handler" case, prefer `handle()`.
+
+### In-memory state across requests
+
+Middleware and route handlers created at module scope — for example a `rateLimit()` store, or a module-level counter — behave differently by environment:
+
+- **In development**, the dev server re-evaluates each route module on every request so edits hot-reload. A fresh module scope means module-level variables and default in-memory stores are re-created per request: a counter always reads back its initial value, and the default in-memory rate-limit store never accumulates across requests. To exercise threshold behavior in dev, drive the pipeline multiple times within a single request, or use an external store.
+- **In production**, the compiled route module is cached per release, so module-scoped state persists across requests **within one server process and one release**. It is still **not** shared across multiple instances, and it resets on every redeploy (and under memory-pressure eviction).
+
+For anything that must be correct across requests, instances, and deploys — rate limiting, counters, sessions — use an external store (see the `RateLimitStore` interface and the Redis example in the rate-limit reference) rather than module-scoped memory.
 
 ### Cleanup callbacks
 


### PR DESCRIPTION
## What
Two documentation fixes to the middleware guide (both by-design behaviors that the docs taught/omitted incorrectly).

**1. The "Execute the pipeline" example was dead code.** It used `const result = await pipeline.execute(request); if (result) return result;` then a fallthrough `return Response.json(users)`. But `execute()` **always** resolves to a `Response` (a synthesized 404 when the chain passes through — it has no terminal handler), so the fallthrough is unreachable and `GET /api/users` would return 404, never the JSON. Rewritten to use `handle()` (the primitive that runs middleware **then** your route handler), plus a `handle()` vs `execute()` note.

**2. Dev-vs-prod module state was undocumented.** Added an "In-memory state across requests" section: in dev the route module is re-evaluated per request (hot-reload), so module-scoped state (a counter, the default in-memory `rateLimit` store) resets each request; in prod the module is cached per-process/per-release so it persists (but still isn't shared across instances / survives redeploys). Points real use-cases at an external store.

Docs-only — no code change.

## How to test
- `docs/guides/middleware.md` — "Run the pipeline" now uses `pipeline.handle(request, () => …)`; new "In-memory state across requests" section.
- Behaviors verified against source at 0.1.1126 (`executor.ts:26-35`, `pipeline.ts:35-77`, loader cache-bust `loader.ts:137/576`, prod handler cache `pages-api-handler.ts:121-126`).

Closes veryfront/veryfront-issue-inbox#203 (findings 4 & 5 from #200)