### PR TITLE
fix(rsc): fail closed on node: builtin imports in browser bundles

### DIFF
--- a/src/server/handlers/dev/files/esbuild-plugins.test.ts
+++ b/src/server/handlers/dev/files/esbuild-plugins.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "#veryfront/transforms/plugins/__tests__/code-parser-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { asyncLocalStorage } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
@@ -59,6 +59,30 @@ describe(
       );
 
       assertEquals(output.includes('from "https://esm.sh/react@19"'), true);
+    });
+
+    it("fails closed on a node: builtin import in a browser bundle", async () => {
+      // A server-only `node:*` import must never be silently rewritten to
+      // https://esm.sh/node:crypto (which 404s on esm.sh and throws
+      // `createHash is not a function` in the browser). The browser bundle must
+      // fail closed with a clear, actionable error instead.
+      const error = await assertRejects(() =>
+        bundleWithPlugin(
+          'import { createHash } from "node:crypto"; console.log(createHash);',
+          {},
+        )
+      );
+      const message = error instanceof Error ? error.message : String(error);
+      assertEquals(message.includes("node:crypto"), true);
+    });
+
+    it("still rewrites ordinary npm bare imports (the node: guard does not over-reject)", async () => {
+      const output = await bundleWithPlugin(
+        'import x from "lodash"; console.log(x);',
+        {},
+      );
+
+      assertEquals(output.includes("esm.sh/lodash"), true);
     });
   },
 );

--- a/src/server/handlers/dev/files/esbuild-plugins.ts
+++ b/src/server/handlers/dev/files/esbuild-plugins.ts
@@ -316,6 +316,14 @@ function isBareImport(path: string): boolean {
   );
 }
 
+/**
+ * A Node built-in module specifier (`node:crypto`, `node:fs`, …). These are
+ * server-only and must never be rewritten to an esm.sh URL for a browser bundle.
+ */
+function isNodeBuiltinSpecifier(path: string): boolean {
+  return path === "node" || path.startsWith("node:");
+}
+
 function toEsmUrl(path: string): string {
   return ESM_PACKAGE_MAP[path] ?? `https://esm.sh/${path}`;
 }
@@ -386,6 +394,22 @@ export function createBareExternalPlugin(
       build.onResolve({ filter: /.*/ }, (args: OnResolveArgs) => {
         if (!isBareImport(args.path)) return undefined;
         if (args.kind !== "import-statement" && args.kind !== "dynamic-import") return undefined;
+
+        // Fail closed on Node built-ins. This plugin only runs for browser
+        // bundles (platform: "browser"), where a server-only `node:*` import can
+        // never work: rewriting it to an esm.sh URL silently ships a module that
+        // 404s on esm.sh and throws (e.g. `createHash is not a function`) at
+        // hydration. Surface a clear build error instead of a broken rewrite.
+        if (isNodeBuiltinSpecifier(args.path)) {
+          return {
+            errors: [{
+              text: `Cannot bundle server-only import "${args.path}" for the browser. ` +
+                `Node built-in modules are not available on the client. Move it into a ` +
+                `server component, an API route, or middleware — or gate the code behind a ` +
+                `"use client" boundary that does not import it.`,
+            }],
+          };
+        }
 
         // Keep import-map-resolved specifiers as bare externals — the browser's
         // <script type="importmap"> resolves them to the correct CDN URL.


### PR DESCRIPTION
## What
Near-term safety net for the `experimental.rsc` `node:crypto` leak (issue #204 / #200 finding 6).

Under `experimental.rsc`, a directive-less **server** component that imports a `node:` builtin (e.g. `node:crypto`) is emitted into the **client** bundle. The browser bundler's bare-import resolver then rewrote `node:crypto` → `https://esm.sh/node:crypto`, which **404s** on esm.sh and throws `createHash is not a function` at hydration (server-side it rendered empty). 

This makes the browser bundler **fail closed**: the bare-external resolver now rejects `node:*` specifiers with a clear *"Cannot bundle server-only import … for the browser"* build error, instead of silently producing a broken bundle. A silent runtime break becomes an actionable build error.

**Scope:** near-term guard only. The deeper fix — never emitting a directive-less server component into the client graph under `experimental.rsc` — is tracked in the issue and not attempted here.

**Safety:** the plugin runs only for `platform: "browser"` bundles (single consumer: `browser-module-bundler.ts`), so server bundles that legitimately import `node:` builtins are unaffected. Verified a normal npm import (`lodash`) still resolves to esm.sh (the guard doesn't over-reject).

## How to test
`deno test src/server/handlers/dev/files/esbuild-plugins.test.ts`:
1. `fails closed on a node: builtin import in a browser bundle` — bundling `import { createHash } from "node:crypto"` now rejects with a build error naming `node:crypto` (added red, now green).
2. `still rewrites ordinary npm bare imports` — `lodash` still → esm.sh (guard doesn't over-reject).
Full `esbuild-plugins` + `browser-module-bundler` suites: 4 passed / 32 steps / 0 failed.

Refs veryfront/veryfront-issue-inbox#204 (finding 6 from #200)