### PR TITLE
fix(ssr): give documentElement/body the full element stub

### DIFF
--- a/src/rendering/ssr-globals/dom-stubs.test.ts
+++ b/src/rendering/ssr-globals/dom-stubs.test.ts
@@ -82,6 +82,23 @@ describe("rendering/ssr-globals/dom-stubs", () => {
       assertEquals(doc.getElementById(), null);
     });
 
+    // Regression: libraries (sonner, next-themes, focus/scroll-lock helpers)
+    // read attributes off documentElement/body during render. These must carry
+    // the full element-stub surface, not just { style, classList }, or SSR
+    // throws "document.documentElement.getAttribute is not a function".
+    it("documentElement and body expose the full element-stub attribute API", () => {
+      const doc = createDocumentStub();
+      for (const el of [doc.documentElement, doc.body]) {
+        assertEquals(typeof el.getAttribute, "function");
+        assertEquals(typeof el.setAttribute, "function");
+        assertEquals(typeof el.hasAttribute, "function");
+        assertEquals(typeof el.removeAttribute, "function");
+        assertEquals(el.getAttribute(), null);
+        assertEquals(el.hasAttribute(), false);
+        assertEquals(typeof el.classList.toggle, "function");
+      }
+    });
+
     it("should have complete readyState", () => {
       const doc = createDocumentStub();
       assertEquals(doc.readyState, "complete");

--- a/src/rendering/ssr-globals/dom-stubs.ts
+++ b/src/rendering/ssr-globals/dom-stubs.ts
@@ -133,15 +133,8 @@ export function createDocumentStub(): {
   getElementsByClassName: () => [];
   getElementsByTagName: () => [];
   getElementsByName: () => [];
-  documentElement: {
-    style: Record<string, unknown>;
-    classList: Omit<ReturnType<typeof createClassListStub>, "toggle">;
-  };
-  body: {
-    style: Record<string, unknown>;
-    classList: Omit<ReturnType<typeof createClassListStub>, "toggle">;
-    appendChild: () => void;
-  };
+  documentElement: ReturnType<typeof createElementStub>;
+  body: ReturnType<typeof createElementStub>;
   head: { appendChild: () => void; removeChild: () => void };
   readyState: "complete";
   cookie: string;
@@ -156,12 +149,6 @@ export function createDocumentStub(): {
   styleSheets: [];
   adoptedStyleSheets: [];
 } {
-  const classList = {
-    add: noop,
-    remove: noop,
-    contains: noopFalse,
-  };
-
   return {
     __veryfrontSSRStub: true,
     exitFullscreen: undefined,
@@ -183,8 +170,11 @@ export function createDocumentStub(): {
     getElementsByTagName: noopEmptyArray,
     getElementsByName: noopEmptyArray,
 
-    documentElement: { style: {}, classList },
-    body: { style: {}, classList, appendChild: noop },
+    // documentElement/body get the full element stub surface so libraries that
+    // read attributes during render (sonner, next-themes, focus/scroll-lock
+    // helpers) don't crash on a missing `getAttribute`/`setAttribute`.
+    documentElement: createElementStub(),
+    body: createElementStub(),
     head: { appendChild: noop, removeChild: noop },
     readyState: "complete",
     cookie: emptyString,


### PR DESCRIPTION
## Problem

The SSR DOM stub (`src/rendering/ssr-globals/dom-stubs.ts`) exposed `document.documentElement` and `document.body` as minimal `{ style, classList }` objects. They were missing `getAttribute` / `setAttribute` / `hasAttribute` / `removeAttribute` — which `createElementStub()` already provides for every other element.

Any library that reads an attribute off `documentElement`/`body` **during render** crashes SSR:

```
TypeError: document.documentElement.getAttribute is not a function
```

…which 500s the whole route. Hit in practice by **sonner** (`<Toaster>` reads `document.documentElement.getAttribute`), and latent for **next-themes** and focus/scroll-lock helpers.

## Fix

Point `documentElement` and `body` at `createElementStub()` so they carry the full element surface (attributes, classList with `toggle`, dataset, dimensions, …). Net removal of the ad-hoc partial objects.

## Test

Adds a regression test asserting `documentElement`/`body` expose `getAttribute`/`setAttribute`/`hasAttribute`/`removeAttribute`. `deno test src/rendering/ssr-globals/dom-stubs.test.ts` → 31 steps pass.

## Verification

Reproduced against a real app rendering sonner's `<Toaster>`: **500 pre-fix**, **200 + clean hydration + toast fires post-fix**. Part of a 19-component shadcn/ui interop sweep that goes green with this fix.