### PR TITLE
fix(runtime): keep HMR websockets out of root middleware

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1143",
+  "version": "0.1.1144",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1144",
+  "version": "0.1.1145",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/runtime-handler/project-middleware.test.ts
+++ b/src/server/runtime-handler/project-middleware.test.ts
@@ -499,7 +499,7 @@ describe("ProjectMiddlewareRuntime", () => {
       releaseId: undefined,
       resolvedEnvironment: "preview",
       requestContext: {
-        token: undefined,
+        token: "",
         slug: "trusted-project",
         branch: "main",
         mode: "preview",

--- a/src/server/runtime-handler/project-middleware.test.ts
+++ b/src/server/runtime-handler/project-middleware.test.ts
@@ -25,16 +25,27 @@ interface ActiveFsContext {
 function createAdapter(
   storage = new AsyncLocalStorage<ActiveFsContext>(),
   middlewareSource?: string,
+  options: { requireContextForFileAccess?: boolean } = {},
 ): RuntimeAdapter {
+  const assertContext = () => {
+    if (options.requireContextForFileAccess && !storage.getStore()) {
+      throw new Error("[test] No request context available");
+    }
+  };
   const fs = {
     getUnderlyingAdapter: () => fs,
     getAdapterType: () => "MultiProjectFSAdapter",
     isVeryfrontAdapter: () => true,
     isMultiProjectMode: () => true,
     isContextualMode: () => true,
-    exists: (path: string) =>
-      Promise.resolve(middlewareSource !== undefined && path.endsWith("/middleware.ts")),
-    readFile: () => Promise.resolve(middlewareSource ?? ""),
+    exists: (path: string) => {
+      assertContext();
+      return Promise.resolve(middlewareSource !== undefined && path.endsWith("/middleware.ts"));
+    },
+    readFile: () => {
+      assertContext();
+      return Promise.resolve(middlewareSource ?? "");
+    },
     runWithContext: <T>(
       projectSlug: string,
       _token: string,
@@ -283,17 +294,19 @@ describe("ProjectMiddlewareRuntime", () => {
     ]);
   });
 
-  it("preserves request and response identity for WebSocket upgrade handling", async () => {
+  it("preserves request and response identity for non-HMR WebSocket upgrade handling", async () => {
     const adapter = createAdapter();
-    const request = new Request("https://example.com/_ws", {
+    const request = new Request("https://example.com/socket", {
       headers: { upgrade: "websocket" },
     });
     const routeResponse = new Response("upgrade handoff");
+    let middlewareSawRequest = false;
     const runtime = new ProjectMiddlewareRuntime({
       loadMiddleware: () =>
         Promise.resolve([
           async (c, next) => {
             assertEquals(c.req === request, true);
+            middlewareSawRequest = true;
             return await next();
           },
         ]),
@@ -306,6 +319,7 @@ describe("ProjectMiddlewareRuntime", () => {
       () => Promise.resolve(routeResponse),
     );
 
+    assertEquals(middlewareSawRequest, true);
     assertEquals(response === routeResponse, true);
   });
 
@@ -471,6 +485,40 @@ describe("ProjectMiddlewareRuntime", () => {
 
     assertEquals(loads, 0);
     assertEquals(routeCalls, 3);
+  });
+
+  it("bypasses project middleware for proxy HMR websockets without request context", async () => {
+    const adapter = createAdapter(
+      undefined,
+      undefined,
+      { requireContextForFileAccess: true },
+    );
+    const runtime = new ProjectMiddlewareRuntime();
+    const context = createContext(adapter, {
+      proxyToken: undefined,
+      releaseId: undefined,
+      resolvedEnvironment: "preview",
+      requestContext: {
+        token: undefined,
+        slug: "trusted-project",
+        branch: "main",
+        mode: "preview",
+      },
+    });
+    let routeCalls = 0;
+
+    const response = await execute(
+      runtime,
+      context,
+      new Request("https://example.com/_ws?x-environment=preview&x-project-slug=trusted-project"),
+      () => {
+        routeCalls++;
+        return Promise.resolve(new Response("hmr"));
+      },
+    );
+
+    assertEquals(await response?.text(), "hmr");
+    assertEquals(routeCalls, 1);
   });
 
   it("keeps project middleware enabled for control-plane run execution", async () => {

--- a/src/server/runtime-handler/project-middleware.test.ts
+++ b/src/server/runtime-handler/project-middleware.test.ts
@@ -510,7 +510,9 @@ describe("ProjectMiddlewareRuntime", () => {
     const response = await execute(
       runtime,
       context,
-      new Request("https://example.com/_ws?x-environment=preview&x-project-slug=trusted-project"),
+      new Request("https://example.com/_ws?x-environment=preview&x-project-slug=trusted-project", {
+        headers: { upgrade: "websocket" },
+      }),
       () => {
         routeCalls++;
         return Promise.resolve(new Response("hmr"));

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -12,6 +12,7 @@ import {
 import type { HandlerContext } from "#veryfront/types";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { serverLogger } from "#veryfront/utils";
+import { isWebSocketPath } from "./request-utils.ts";
 
 const DEFAULT_MAX_ENTRIES = 100;
 const logger = serverLogger.component("project-middleware");
@@ -85,11 +86,16 @@ export class ProjectMiddlewareRuntime {
 
   async execute(input: ProjectMiddlewareRuntimeContext): Promise<Response | undefined> {
     const { handlerContext: ctx, isSharedProxy, next, request } = input;
+    const pathname = new URL(request.url).pathname;
+
+    if (isWebSocketPath(pathname)) {
+      return next();
+    }
 
     if (
       isConfigOptionalControlPlaneRunRequest(
         request.method,
-        new URL(request.url).pathname,
+        pathname,
       )
     ) {
       return next();

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -12,7 +12,7 @@ import {
 import type { HandlerContext } from "#veryfront/types";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { serverLogger } from "#veryfront/utils";
-import { isWebSocketPath } from "./request-utils.ts";
+import { isWebSocketPath } from "#veryfront/server/runtime-handler/request-utils.ts";
 
 const DEFAULT_MAX_ENTRIES = 100;
 const logger = serverLogger.component("project-middleware");

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1144";
+export const VERSION = "0.1.1145";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1143";
+export const VERSION = "0.1.1144";


### PR DESCRIPTION
## Summary
- bypass project root middleware for the internal `/_ws` HMR endpoint before middleware loading
- add a regression test that reproduces the tokenless proxy websocket path failing without a request-scoped filesystem context
- bump `veryfront-code` patch version to `0.1.1145`

## Root Cause
Staging `/_ws?x-project-slug=...&x-environment=preview` requests can arrive without an `x-token` header because browser WebSocket construction cannot attach proxy headers. `createProxyGuard` intentionally skips `/_ws`, but `ProjectMiddlewareRuntime.execute` still tried to load root middleware before the HMR handler ran. That load calls `adapter.fs.exists()` through `loadMiddlewareFile`, and `MultiProjectFSAdapter` requires `fs.runWithContext()` to resolve project files, so staging returned 500 with `No request context available`.

## Fix
Treat `/_ws` as internal HMR plumbing and pass it straight to the next handler before project middleware is loaded. Non-HMR WebSocket upgrade paths still execute project middleware; the existing identity test was tightened so that distinction is covered.

## Testing
- RED: new regression test failed before the production change with `[test] No request context available`
- `deno task test src/server/runtime-handler/project-middleware.test.ts src/server/runtime-handler/index.test.ts`
- `deno task verify:quick`
- `DENO_TESTING=1 VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --frozen --preload=src/schemas/_test-setup.ts --no-check --parallel --allow-all --ignore=tests/e2e,tests/integration/compiled-binary-e2e.test.ts --unstable-worker-options --unstable-net src/server/runtime-handler/project-middleware.test.ts src/server/runtime-handler/index.test.ts`
- pre-push hook: fmt, lint, typecheck, and unit tests passed (`2680 passed`, `21751 steps`, `0 failed`)

## Notes
No `deno.lock` changes are included; test-generated lockfile churn was intentionally reverted.

