### PR TITLE
fix(ssr): bound foreground admission and shed background work

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -345,6 +345,7 @@
     "#std/testing.ts": "jsr:@std/testing@1.0.17",
     "#std/testing/bdd": "jsr:@std/testing@1.0.17/bdd",
     "#std/testing/bdd.ts": "jsr:@std/testing@1.0.17/bdd",
+    "#std/testing/mock": "jsr:@std/testing@1.0.17/mock",
     "#std/testing/time": "jsr:@std/testing@1.0.17/time",
     "#std/testing/time.ts": "jsr:@std/testing@1.0.17/time",
     "#std/expect": "jsr:@std/expect@1.0.18",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1145",
+  "version": "0.1.1146",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { Semaphore } from "./semaphore.ts";
 
@@ -29,6 +29,72 @@ describe("modules/react-loader/ssr-module-loader/concurrency/semaphore", () => {
 
       const result = await sem.tryAcquire(10);
       assertEquals(result, false);
+    });
+
+    it("should fail immediately without queueing when waiting is disabled", async () => {
+      const sem = new Semaphore(1);
+
+      await sem.tryAcquire();
+      assertEquals(await sem.tryAcquire(0), false);
+      assertEquals(sem.waiting, 0);
+    });
+
+    it("should remove an aborted waiter without granting it later", async () => {
+      const sem = new Semaphore(1);
+      const controller = new AbortController();
+
+      await sem.tryAcquire();
+      const waiting = sem.tryAcquire(500, { signal: controller.signal });
+      assertEquals(sem.waiting, 1);
+
+      controller.abort(new DOMException("request cancelled", "AbortError"));
+      await assertRejects(
+        () => waiting,
+        DOMException,
+        "request cancelled",
+      );
+      assertEquals(sem.waiting, 0);
+
+      sem.release();
+      assertEquals(sem.available, 1);
+    });
+
+    it("should grant a released permit past an aborted head waiter", async () => {
+      const sem = new Semaphore(1);
+      const controller = new AbortController();
+
+      await sem.tryAcquire();
+      const abortedWaiter = sem.tryAcquire(500, { signal: controller.signal });
+      const nextWaiter = sem.tryAcquire(500);
+      assertEquals(sem.waiting, 2);
+
+      controller.abort(new DOMException("head waiter cancelled", "AbortError"));
+      await assertRejects(
+        () => abortedWaiter,
+        DOMException,
+        "head waiter cancelled",
+      );
+
+      sem.release();
+      assertEquals(await nextWaiter, true);
+      assertEquals(sem.waiting, 0);
+      assertEquals(sem.available, 0);
+
+      sem.release();
+      assertEquals(sem.available, 1);
+    });
+
+    it("should not consume a permit for an already-aborted acquire", async () => {
+      const sem = new Semaphore(1);
+      const controller = new AbortController();
+      controller.abort(new DOMException("request cancelled", "AbortError"));
+
+      await assertRejects(
+        () => sem.tryAcquire(500, { signal: controller.signal }),
+        DOMException,
+        "request cancelled",
+      );
+      assertEquals(sem.available, 1);
     });
 
     it("should release permits", async () => {

--- a/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.test.ts
@@ -3,6 +3,19 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { Semaphore } from "./semaphore.ts";
 
+function abortBeforeListenerRegistration(
+  controller: AbortController,
+  reason: DOMException,
+): AbortSignal {
+  return new Proxy(controller.signal, {
+    get(target, property) {
+      if (property === "addEventListener") controller.abort(reason);
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
 describe("modules/react-loader/ssr-module-loader/concurrency/semaphore", () => {
   describe("Semaphore", () => {
     it("should acquire immediately when permits available", async () => {
@@ -94,6 +107,26 @@ describe("modules/react-loader/ssr-module-loader/concurrency/semaphore", () => {
         DOMException,
         "request cancelled",
       );
+      assertEquals(sem.available, 1);
+    });
+
+    it("should reject an abort missed immediately before listener registration", async () => {
+      const sem = new Semaphore(1);
+      const controller = new AbortController();
+      const reason = new DOMException("registration race", "AbortError");
+
+      await sem.tryAcquire();
+      await assertRejects(
+        () =>
+          sem.tryAcquire(10, {
+            signal: abortBeforeListenerRegistration(controller, reason),
+          }),
+        DOMException,
+        "registration race",
+      );
+      assertEquals(sem.waiting, 0);
+
+      sem.release();
       assertEquals(sem.available, 1);
     });
 

--- a/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
@@ -1,54 +1,103 @@
 /** Default timeout for acquiring a semaphore permit (ms) */
 const DEFAULT_ACQUIRE_TIMEOUT_MS = 100;
 
+interface SemaphoreWaiter {
+  resolve: (acquired: boolean) => void;
+  reject: (reason?: unknown) => void;
+  settled: boolean;
+  timeoutId?: ReturnType<typeof setTimeout>;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
 export class Semaphore {
   private permits: number;
   private readonly maxQueueSize: number;
-  private waitQueue: Array<{ resolve: () => void; reject: (err: Error) => void }> = [];
+  private waitQueue: SemaphoreWaiter[] = [];
 
   constructor(permits: number, options?: { maxQueueSize?: number }) {
     this.permits = permits;
     this.maxQueueSize = options?.maxQueueSize ?? Infinity;
   }
 
-  tryAcquire(timeoutMs = DEFAULT_ACQUIRE_TIMEOUT_MS): Promise<boolean> {
+  tryAcquire(
+    timeoutMs = DEFAULT_ACQUIRE_TIMEOUT_MS,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<boolean> {
+    const { signal } = options;
+    if (signal?.aborted) {
+      return Promise.reject(
+        signal.reason ?? new DOMException("The operation was aborted", "AbortError"),
+      );
+    }
+
     if (this.permits > 0) {
       this.permits--;
       return Promise.resolve(true);
+    }
+
+    if (timeoutMs <= 0) {
+      return Promise.resolve(false);
     }
 
     if (this.waitQueue.length >= this.maxQueueSize) {
       return Promise.resolve(false);
     }
 
-    return new Promise<boolean>((resolve) => {
-      let settled = false;
-
-      const onAcquire = (): void => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timeoutId);
-        resolve(true);
+    return new Promise<boolean>((resolve, reject) => {
+      const waiter: SemaphoreWaiter = {
+        resolve,
+        reject,
+        settled: false,
+        signal,
       };
 
-      const timeoutId = setTimeout(() => {
-        if (settled) return;
-        settled = true;
-
-        const index = this.waitQueue.findIndex((w) => w.resolve === onAcquire);
+      const removeWaiter = (): void => {
+        const index = this.waitQueue.indexOf(waiter);
         if (index !== -1) this.waitQueue.splice(index, 1);
+      };
+      const cleanup = (): void => {
+        if (waiter.timeoutId !== undefined) clearTimeout(waiter.timeoutId);
+        if (waiter.signal && waiter.onAbort) {
+          waiter.signal.removeEventListener("abort", waiter.onAbort);
+        }
+      };
 
-        resolve(false);
-      }, timeoutMs);
+      waiter.onAbort = () => {
+        if (waiter.settled) return;
+        waiter.settled = true;
+        removeWaiter();
+        cleanup();
+        reject(
+          signal?.reason ?? new DOMException("The operation was aborted", "AbortError"),
+        );
+      };
+      signal?.addEventListener("abort", waiter.onAbort, { once: true });
 
-      this.waitQueue.push({ resolve: onAcquire, reject: onAcquire });
+      if (Number.isFinite(timeoutMs)) {
+        waiter.timeoutId = setTimeout(() => {
+          if (waiter.settled) return;
+          waiter.settled = true;
+          removeWaiter();
+          cleanup();
+          resolve(false);
+        }, timeoutMs);
+      }
+
+      this.waitQueue.push(waiter);
     });
   }
 
   release(): void {
-    const next = this.waitQueue.shift();
-    if (next) {
-      next.resolve();
+    let next: SemaphoreWaiter | undefined;
+    while ((next = this.waitQueue.shift())) {
+      if (next.settled) continue;
+      next.settled = true;
+      if (next.timeoutId !== undefined) clearTimeout(next.timeoutId);
+      if (next.signal && next.onAbort) {
+        next.signal.removeEventListener("abort", next.onAbort);
+      }
+      next.resolve(true);
       return;
     }
 

--- a/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
@@ -73,6 +73,10 @@ export class Semaphore {
         );
       };
       signal?.addEventListener("abort", waiter.onAbort, { once: true });
+      if (signal?.aborted) {
+        waiter.onAbort();
+        return;
+      }
 
       if (Number.isFinite(timeoutMs)) {
         waiter.timeoutId = setTimeout(() => {

--- a/src/rendering/renderer-concurrency.test.ts
+++ b/src/rendering/renderer-concurrency.test.ts
@@ -3,6 +3,19 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { Mutex } from "./renderer-concurrency.ts";
 
+function abortBeforeListenerRegistration(
+  controller: AbortController,
+  reason: DOMException,
+): AbortSignal {
+  return new Proxy(controller.signal, {
+    get(target, property) {
+      if (property === "addEventListener") controller.abort(reason);
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
 describe("Mutex", () => {
   it("acquires immediately when unlocked", async () => {
     const mutex = new Mutex();
@@ -255,6 +268,44 @@ describe("project render slots", () => {
         "request cancelled",
       );
       await concurrency.releaseProjectSlot(projectId);
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      await concurrency.releaseProjectSlot(projectId);
+    } finally {
+      if (previousLimit === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_LIMIT");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_LIMIT", previousLimit);
+      }
+    }
+  });
+
+  it("rejects an abort missed immediately before listener registration", async () => {
+    const previousLimit = Deno.env.get("RENDER_PER_PROJECT_LIMIT");
+    Deno.env.set("RENDER_PER_PROJECT_LIMIT", "1");
+    try {
+      const concurrency = await import(
+        `./renderer-concurrency.ts?abort-registration-slot=${crypto.randomUUID()}`
+      );
+      const projectId = `project-${crypto.randomUUID()}`;
+      const controller = new AbortController();
+      const reason = new DOMException("registration race", "AbortError");
+
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      try {
+        await assertRejects(
+          () =>
+            concurrency.acquireProjectSlot(projectId, {
+              wait: true,
+              timeoutMs: 10,
+              signal: abortBeforeListenerRegistration(controller, reason),
+            }),
+          DOMException,
+          "registration race",
+        );
+      } finally {
+        await concurrency.releaseProjectSlot(projectId);
+      }
+
       assertEquals(await concurrency.acquireProjectSlot(projectId), true);
       await concurrency.releaseProjectSlot(projectId);
     } finally {

--- a/src/rendering/renderer-concurrency.test.ts
+++ b/src/rendering/renderer-concurrency.test.ts
@@ -116,6 +116,247 @@ describe("Mutex", () => {
 });
 
 describe("project render slots", () => {
+  it("falls back to safe limits when concurrency env values are invalid", async () => {
+    const previousMax = Deno.env.get("RENDER_MAX_CONCURRENT");
+    const previousLimit = Deno.env.get("RENDER_PER_PROJECT_LIMIT");
+    const previousQueueSize = Deno.env.get("RENDER_PER_PROJECT_QUEUE_SIZE");
+    Deno.env.set("RENDER_MAX_CONCURRENT", "3");
+    Deno.env.set("RENDER_PER_PROJECT_LIMIT", "not-a-number");
+    Deno.env.set("RENDER_PER_PROJECT_QUEUE_SIZE", "not-a-number");
+    try {
+      const concurrency = await import(
+        `./renderer-concurrency.ts?invalid-limits=${crypto.randomUUID()}`
+      );
+      const projectId = `project-${crypto.randomUUID()}`;
+
+      assertEquals(concurrency.RENDER_MAX_CONCURRENT, 3);
+      assertEquals(concurrency.RENDER_PER_PROJECT_LIMIT, 1);
+      assertEquals(concurrency.RENDER_PER_PROJECT_QUEUE_SIZE, 1);
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      await concurrency.releaseProjectSlot(projectId);
+    } finally {
+      for (
+        const [name, previous] of [
+          ["RENDER_MAX_CONCURRENT", previousMax],
+          ["RENDER_PER_PROJECT_LIMIT", previousLimit],
+          ["RENDER_PER_PROJECT_QUEUE_SIZE", previousQueueSize],
+        ] as const
+      ) {
+        if (previous === undefined) {
+          Deno.env.delete(name);
+        } else {
+          Deno.env.set(name, previous);
+        }
+      }
+    }
+  });
+
+  it("queues foreground waiters in FIFO order", async () => {
+    const previousLimit = Deno.env.get("RENDER_PER_PROJECT_LIMIT");
+    const previousQueueSize = Deno.env.get("RENDER_PER_PROJECT_QUEUE_SIZE");
+    Deno.env.set("RENDER_PER_PROJECT_LIMIT", "1");
+    Deno.env.set("RENDER_PER_PROJECT_QUEUE_SIZE", "2");
+    try {
+      const concurrency = await import(
+        `./renderer-concurrency.ts?fifo-slots=${crypto.randomUUID()}`
+      );
+      const projectId = `project-${crypto.randomUUID()}`;
+      const order: number[] = [];
+
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      const second = concurrency.acquireProjectSlot(projectId, {
+        wait: true,
+        timeoutMs: 500,
+      }).then((acquired: boolean) => {
+        if (acquired) order.push(2);
+        return acquired;
+      });
+      const third = concurrency.acquireProjectSlot(projectId, {
+        wait: true,
+        timeoutMs: 500,
+      }).then((acquired: boolean) => {
+        if (acquired) order.push(3);
+        return acquired;
+      });
+
+      await concurrency.releaseProjectSlot(projectId);
+      assertEquals(await second, true);
+      assertEquals(order, [2]);
+
+      await concurrency.releaseProjectSlot(projectId);
+      assertEquals(await third, true);
+      assertEquals(order, [2, 3]);
+      await concurrency.releaseProjectSlot(projectId);
+    } finally {
+      if (previousLimit === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_LIMIT");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_LIMIT", previousLimit);
+      }
+      if (previousQueueSize === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_QUEUE_SIZE");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_QUEUE_SIZE", previousQueueSize);
+      }
+    }
+  });
+
+  it("times out and removes a queued foreground waiter", async () => {
+    const previousLimit = Deno.env.get("RENDER_PER_PROJECT_LIMIT");
+    Deno.env.set("RENDER_PER_PROJECT_LIMIT", "1");
+    try {
+      const concurrency = await import(
+        `./renderer-concurrency.ts?timeout-slot=${crypto.randomUUID()}`
+      );
+      const projectId = `project-${crypto.randomUUID()}`;
+
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      assertEquals(
+        await concurrency.acquireProjectSlot(projectId, {
+          wait: true,
+          timeoutMs: 5,
+        }),
+        false,
+      );
+
+      await concurrency.releaseProjectSlot(projectId);
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      await concurrency.releaseProjectSlot(projectId);
+    } finally {
+      if (previousLimit === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_LIMIT");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_LIMIT", previousLimit);
+      }
+    }
+  });
+
+  it("aborts and removes a queued foreground waiter", async () => {
+    const previousLimit = Deno.env.get("RENDER_PER_PROJECT_LIMIT");
+    Deno.env.set("RENDER_PER_PROJECT_LIMIT", "1");
+    try {
+      const concurrency = await import(
+        `./renderer-concurrency.ts?abort-slot=${crypto.randomUUID()}`
+      );
+      const projectId = `project-${crypto.randomUUID()}`;
+      const controller = new AbortController();
+
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      const waiting = concurrency.acquireProjectSlot(projectId, {
+        wait: true,
+        timeoutMs: 500,
+        signal: controller.signal,
+      });
+      controller.abort(new DOMException("request cancelled", "AbortError"));
+
+      await assertRejects(
+        () => waiting,
+        DOMException,
+        "request cancelled",
+      );
+      await concurrency.releaseProjectSlot(projectId);
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      await concurrency.releaseProjectSlot(projectId);
+    } finally {
+      if (previousLimit === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_LIMIT");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_LIMIT", previousLimit);
+      }
+    }
+  });
+
+  it("grants a released slot past an aborted head waiter", async () => {
+    const previousLimit = Deno.env.get("RENDER_PER_PROJECT_LIMIT");
+    const previousQueueSize = Deno.env.get("RENDER_PER_PROJECT_QUEUE_SIZE");
+    Deno.env.set("RENDER_PER_PROJECT_LIMIT", "1");
+    Deno.env.set("RENDER_PER_PROJECT_QUEUE_SIZE", "2");
+    try {
+      const concurrency = await import(
+        `./renderer-concurrency.ts?aborted-head-slot=${crypto.randomUUID()}`
+      );
+      const projectId = `project-${crypto.randomUUID()}`;
+      const controller = new AbortController();
+
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      const abortedWaiter = concurrency.acquireProjectSlot(projectId, {
+        wait: true,
+        timeoutMs: 500,
+        signal: controller.signal,
+      });
+      const nextWaiter = concurrency.acquireProjectSlot(projectId, {
+        wait: true,
+        timeoutMs: 500,
+      });
+
+      controller.abort(new DOMException("head waiter cancelled", "AbortError"));
+      await assertRejects(
+        () => abortedWaiter,
+        DOMException,
+        "head waiter cancelled",
+      );
+
+      await concurrency.releaseProjectSlot(projectId);
+      assertEquals(await nextWaiter, true);
+      await concurrency.releaseProjectSlot(projectId);
+
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      await concurrency.releaseProjectSlot(projectId);
+    } finally {
+      if (previousLimit === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_LIMIT");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_LIMIT", previousLimit);
+      }
+      if (previousQueueSize === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_QUEUE_SIZE");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_QUEUE_SIZE", previousQueueSize);
+      }
+    }
+  });
+
+  it("rejects immediately when the foreground queue is full", async () => {
+    const previousLimit = Deno.env.get("RENDER_PER_PROJECT_LIMIT");
+    const previousQueueSize = Deno.env.get("RENDER_PER_PROJECT_QUEUE_SIZE");
+    Deno.env.set("RENDER_PER_PROJECT_LIMIT", "1");
+    Deno.env.set("RENDER_PER_PROJECT_QUEUE_SIZE", "1");
+    try {
+      const concurrency = await import(
+        `./renderer-concurrency.ts?full-slot=${crypto.randomUUID()}`
+      );
+      const projectId = `project-${crypto.randomUUID()}`;
+
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+      const queued = concurrency.acquireProjectSlot(projectId, {
+        wait: true,
+        timeoutMs: 500,
+      });
+      assertEquals(
+        await concurrency.acquireProjectSlot(projectId, {
+          wait: true,
+          timeoutMs: 500,
+        }),
+        false,
+      );
+
+      await concurrency.releaseProjectSlot(projectId);
+      assertEquals(await queued, true);
+      await concurrency.releaseProjectSlot(projectId);
+    } finally {
+      if (previousLimit === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_LIMIT");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_LIMIT", previousLimit);
+      }
+      if (previousQueueSize === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_QUEUE_SIZE");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_QUEUE_SIZE", previousQueueSize);
+      }
+    }
+  });
+
   it("does not delete a held project mutex while waiters are queued", async () => {
     const previousLimit = Deno.env.get("RENDER_PER_PROJECT_LIMIT");
     Deno.env.set("RENDER_PER_PROJECT_LIMIT", "1");

--- a/src/rendering/renderer-concurrency.ts
+++ b/src/rendering/renderer-concurrency.ts
@@ -22,7 +22,7 @@ import { RENDER_ERROR } from "#veryfront/errors";
  * Configurable via RENDER_MAX_CONCURRENT env var.
  * Prevents one pod from being overwhelmed when multiple projects have issues.
  */
-export const RENDER_MAX_CONCURRENT = getEnvNumber("RENDER_MAX_CONCURRENT") ?? 30;
+export const RENDER_MAX_CONCURRENT = getEnvNumber("RENDER_MAX_CONCURRENT", 30);
 
 /**
  * Maximum concurrent renders per project (noisy-neighbor protection).
@@ -30,12 +30,28 @@ export const RENDER_MAX_CONCURRENT = getEnvNumber("RENDER_MAX_CONCURRENT") ?? 30
  * more than ~1/3 of pod capacity. Set to 0 to disable per-project limits.
  * Configurable via RENDER_PER_PROJECT_LIMIT env var.
  */
-export const RENDER_PER_PROJECT_LIMIT = getEnvNumber("RENDER_PER_PROJECT_LIMIT") ??
-  Math.ceil(RENDER_MAX_CONCURRENT / 3);
+export const RENDER_PER_PROJECT_LIMIT = getEnvNumber(
+  "RENDER_PER_PROJECT_LIMIT",
+  Math.ceil(RENDER_MAX_CONCURRENT / 3),
+);
+
+/**
+ * Maximum queued foreground renders per project.
+ * Defaults to one additional per-project concurrency window. Background work
+ * never enters this queue.
+ */
+export const RENDER_PER_PROJECT_QUEUE_SIZE = Math.max(
+  0,
+  getEnvNumber(
+    "RENDER_PER_PROJECT_QUEUE_SIZE",
+    Math.max(0, RENDER_PER_PROJECT_LIMIT),
+  ),
+);
 
 /**
  * Timeout for acquiring render permit (ms).
- * If semaphore cannot be acquired within this time, request fails fast with 503.
+ * This is the total foreground admission budget across project and global
+ * capacity gates. Background work does not wait.
  */
 export const RENDER_ACQUIRE_TIMEOUT_MS = 5_000;
 
@@ -127,6 +143,17 @@ export const projectRenderCounts = new Map<string, number>();
  */
 const projectMutexes = new Map<string, Mutex>();
 
+interface ProjectSlotWaiter {
+  resolve: (acquired: boolean) => void;
+  reject: (reason?: unknown) => void;
+  settled: boolean;
+  timeoutId?: ReturnType<typeof setTimeout>;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
+const projectSlotWaitQueues = new Map<string, ProjectSlotWaiter[]>();
+
 function getProjectMutex(projectId: string): Mutex {
   let mutex = projectMutexes.get(projectId);
   if (!mutex) {
@@ -134,6 +161,22 @@ function getProjectMutex(projectId: string): Mutex {
     projectMutexes.set(projectId, mutex);
   }
   return mutex;
+}
+
+function getProjectSlotWaitQueue(projectId: string): ProjectSlotWaiter[] {
+  let queue = projectSlotWaitQueues.get(projectId);
+  if (!queue) {
+    queue = [];
+    projectSlotWaitQueues.set(projectId, queue);
+  }
+  return queue;
+}
+
+function cleanupProjectSlotWaiter(waiter: ProjectSlotWaiter): void {
+  if (waiter.timeoutId !== undefined) clearTimeout(waiter.timeoutId);
+  if (waiter.signal && waiter.onAbort) {
+    waiter.signal.removeEventListener("abort", waiter.onAbort);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -150,21 +193,84 @@ function acquireProjectLock(
 }
 
 /**
- * Attempt to acquire a project render slot with proper locking.
- * Returns true if acquired, false if limit reached.
+ * Attempt to acquire a project render slot with proper locking. Foreground
+ * callers may opt into a bounded FIFO wait; background callers use the
+ * fail-fast default.
  */
 export async function acquireProjectSlot(
   projectId: string,
+  options: {
+    wait?: boolean;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  } = {},
 ): Promise<boolean> {
+  const { signal } = options;
+  if (signal?.aborted) {
+    throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+  }
+
   if (RENDER_PER_PROJECT_LIMIT <= 0) return true;
 
   const release = await acquireProjectLock(projectId);
   try {
-    const current = projectRenderCounts.get(projectId) ?? 0;
-    if (current >= RENDER_PER_PROJECT_LIMIT) return false;
+    if (signal?.aborted) {
+      throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+    }
 
-    projectRenderCounts.set(projectId, current + 1);
-    return true;
+    const current = projectRenderCounts.get(projectId) ?? 0;
+    if (current < RENDER_PER_PROJECT_LIMIT) {
+      projectRenderCounts.set(projectId, current + 1);
+      return true;
+    }
+
+    if (!options.wait || RENDER_PER_PROJECT_QUEUE_SIZE <= 0) return false;
+
+    const timeoutMs = options.timeoutMs ?? RENDER_ACQUIRE_TIMEOUT_MS;
+    if (timeoutMs <= 0) return false;
+
+    const queue = getProjectSlotWaitQueue(projectId);
+    if (queue.length >= RENDER_PER_PROJECT_QUEUE_SIZE) return false;
+
+    return new Promise<boolean>((resolve, reject) => {
+      const waiter: ProjectSlotWaiter = {
+        resolve,
+        reject,
+        settled: false,
+        signal,
+      };
+
+      const removeWaiter = (): void => {
+        const index = queue.indexOf(waiter);
+        if (index !== -1) queue.splice(index, 1);
+        if (queue.length === 0 && projectSlotWaitQueues.get(projectId) === queue) {
+          projectSlotWaitQueues.delete(projectId);
+        }
+      };
+      const settleWithoutSlot = (reason?: unknown): void => {
+        if (waiter.settled) return;
+        waiter.settled = true;
+        removeWaiter();
+        cleanupProjectSlotWaiter(waiter);
+        if (reason !== undefined) {
+          reject(reason);
+        } else {
+          resolve(false);
+        }
+      };
+
+      waiter.onAbort = () =>
+        settleWithoutSlot(
+          signal?.reason ?? new DOMException("The operation was aborted", "AbortError"),
+        );
+      signal?.addEventListener("abort", waiter.onAbort, { once: true });
+
+      if (Number.isFinite(timeoutMs)) {
+        waiter.timeoutId = setTimeout(() => settleWithoutSlot(), timeoutMs);
+      }
+
+      queue.push(waiter);
+    });
   } finally {
     release();
   }
@@ -183,9 +289,22 @@ export async function releaseProjectSlot(
   let deleteIdleMutex = false;
   try {
     const current = projectRenderCounts.get(projectId) ?? 0;
+    const queue = projectSlotWaitQueues.get(projectId);
+    let next: ProjectSlotWaiter | undefined;
+    while ((next = queue?.shift())) {
+      if (next.settled) continue;
+      next.settled = true;
+      cleanupProjectSlotWaiter(next);
+      if (queue?.length === 0) projectSlotWaitQueues.delete(projectId);
+      projectRenderCounts.set(projectId, Math.max(1, current));
+      next.resolve(true);
+      return;
+    }
+    if (queue?.length === 0) projectSlotWaitQueues.delete(projectId);
+
     if (current <= 1) {
       projectRenderCounts.delete(projectId);
-      deleteIdleMutex = mutex.waiting === 0;
+      deleteIdleMutex = mutex.waiting === 0 && !projectSlotWaitQueues.has(projectId);
       return;
     }
     projectRenderCounts.set(projectId, current - 1);

--- a/src/rendering/renderer-concurrency.ts
+++ b/src/rendering/renderer-concurrency.ts
@@ -264,6 +264,10 @@ export async function acquireProjectSlot(
           signal?.reason ?? new DOMException("The operation was aborted", "AbortError"),
         );
       signal?.addEventListener("abort", waiter.onAbort, { once: true });
+      if (signal?.aborted) {
+        waiter.onAbort();
+        return;
+      }
 
       if (Number.isFinite(timeoutMs)) {
         waiter.timeoutId = setTimeout(() => settleWithoutSlot(), timeoutMs);

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -9,7 +9,7 @@ import {
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
-import { stub } from "jsr:@std/testing@1.0.17/mock";
+import { stub } from "#std/testing/mock";
 import { FakeTime } from "#std/testing/time";
 import type { CachePayload, CacheStore } from "./cache/types.ts";
 import type { RenderContext } from "./context/render-context.ts";

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -9,11 +9,19 @@ import {
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { stub } from "jsr:@std/testing@1.0.17/mock";
 import { FakeTime } from "#std/testing/time";
 import type { CachePayload, CacheStore } from "./cache/types.ts";
 import type { RenderContext } from "./context/render-context.ts";
 import { destroyRenderer, getRenderer, initializeRenderer, Renderer } from "./renderer.ts";
-import { projectRenderCounts } from "./renderer-concurrency.ts";
+import {
+  acquireProjectSlot,
+  projectRenderCounts,
+  releaseProjectSlot,
+  RENDER_ACQUIRE_TIMEOUT_MS,
+  RENDER_PER_PROJECT_LIMIT,
+  renderSemaphore,
+} from "./renderer-concurrency.ts";
 
 function getEnv(name: string): string | undefined {
   // deno-lint-ignore no-explicit-any
@@ -442,6 +450,72 @@ describe("Renderer release asset cache isolation", () => {
     assertEquals(store.data.get(cacheKey)?.result.html, "<html>fresh render</html>");
   });
 
+  it("serves stale HTML without queueing a refresh at project capacity", async () => {
+    const projectId = `stale-capacity-project-${crypto.randomUUID()}`;
+    const store = createInMemoryStore();
+    const ctx = {
+      ...makeRenderContext(),
+      projectId,
+      projectSlug: projectId,
+      cachePrefix: buildRenderCachePrefix(projectId, "production", "rel-1"),
+      adapter: { fs: { exists: async () => true } },
+    } as unknown as RenderContext;
+    const cacheKey = `${ctx.cachePrefix}:page:/stale-at-capacity`;
+    store.data.set(cacheKey, {
+      result: {
+        html: "<html>stale at capacity</html>",
+        frontmatter: {},
+        headings: [],
+        stream: null,
+        ssrHash: "stale-at-capacity",
+      },
+      storedAt: Date.now() - 10_000,
+      expiresAt: Date.now() - 1,
+      staleUntil: Date.now() + 60_000,
+    });
+
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let renderCount = 0;
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: () => Promise<never>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: () => {
+          renderCount++;
+          return Promise.reject(new Error("refresh must not start"));
+        },
+      },
+    });
+
+    for (let index = 0; index < RENDER_PER_PROJECT_LIMIT; index++) {
+      assertEquals(await acquireProjectSlot(projectId), true);
+    }
+
+    try {
+      const result = await renderer.renderPage("/stale-at-capacity", ctx, {
+        environment: "production",
+        releaseId: "rel-1",
+      });
+      assertEquals(result.html, "<html>stale at capacity</html>");
+
+      await waitForProductionPrewarm(renderer).catch(() => {});
+      assertEquals(renderCount, 0);
+      assertEquals(
+        store.data.get(cacheKey)?.result.html,
+        "<html>stale at capacity</html>",
+      );
+    } finally {
+      while ((projectRenderCounts.get(projectId) ?? 0) > 0) {
+        await releaseProjectSlot(projectId);
+      }
+    }
+  });
+
   it("preserves request metadata while refreshing stale HTML after disconnect", async () => {
     const store = createInMemoryStore();
     const ctx = {
@@ -737,6 +811,10 @@ describe("Renderer release asset cache isolation", () => {
   it("prewarms sibling production routes after a cacheable render", async () => {
     const store = createInMemoryStore();
     const renderedSlugs: string[] = [];
+    const renderRequests = new Map<
+      string,
+      { request?: Request; url?: URL }
+    >();
     const stalePages = Array.from(
       { length: 14 },
       (_, index) => `aa-stale-${index.toString().padStart(2, "0")}`,
@@ -750,7 +828,12 @@ describe("Renderer release asset cache isolation", () => {
         pipeline: {
           renderPage: (
             slug: string,
-            options?: { nonce?: string; releaseAssetManifest?: ReleaseAssetManifest | null },
+            options?: {
+              nonce?: string;
+              releaseAssetManifest?: ReleaseAssetManifest | null;
+              request?: Request;
+              url?: URL;
+            },
           ) => Promise<{
             html: string;
             frontmatter: Record<string, unknown>;
@@ -769,7 +852,12 @@ describe("Renderer release asset cache isolation", () => {
         pipeline: {
           renderPage: (
             slug: string,
-            options?: { nonce?: string; releaseAssetManifest?: ReleaseAssetManifest | null },
+            options?: {
+              nonce?: string;
+              releaseAssetManifest?: ReleaseAssetManifest | null;
+              request?: Request;
+              url?: URL;
+            },
           ) => Promise<{
             html: string;
             frontmatter: Record<string, unknown>;
@@ -784,6 +872,10 @@ describe("Renderer release asset cache isolation", () => {
           assertEquals(options?.releaseAssetManifest, null);
           assertEquals(options?.nonce, slug === "/" ? "nonce-123" : undefined);
           renderedSlugs.push(slug);
+          renderRequests.set(slug, {
+            request: options?.request,
+            url: options?.url,
+          });
           return Promise.resolve({
             html: `<html>${slug}</html>`,
             frontmatter: {},
@@ -798,11 +890,19 @@ describe("Renderer release asset cache isolation", () => {
       ...makeRenderContext(),
       adapter: { fs: {} } as RenderContext["adapter"],
     };
+    const url = new URL("https://preview.example.test/?utm_source=smoke");
     const result = await renderer.renderPage("/", ctx, {
       environment: "production",
       releaseId: "rel-1",
       releaseAssetManifest: null,
       nonce: "nonce-123",
+      request: new Request(url, {
+        headers: {
+          accept: "text/html",
+          "x-preview-context": "source-request",
+        },
+      }),
+      url,
     });
     await waitForProductionPrewarm(renderer);
 
@@ -816,6 +916,17 @@ describe("Renderer release asset cache isolation", () => {
     assertEquals(store.data.has(`${prefix}:page:/blog`), true);
     assertEquals(store.data.has(`${prefix}:page:/about`), true);
     assertEquals(store.data.has(`${prefix}:page:about`), false);
+
+    for (const slug of ["/blog", "/about"]) {
+      const prewarm = renderRequests.get(slug);
+      assertEquals(prewarm?.url?.href, `https://preview.example.test${slug}`);
+      assertEquals(prewarm?.request?.url, `https://preview.example.test${slug}`);
+      assertEquals(prewarm?.request?.method, "GET");
+      assertEquals(prewarm?.request?.headers.get("accept"), "text/html");
+      assertEquals(prewarm?.request?.headers.has("authorization"), false);
+      assertEquals(prewarm?.request?.headers.has("cookie"), false);
+      assertEquals(prewarm?.request?.headers.has("x-preview-context"), false);
+    }
   });
 
   it("prioritizes route-family siblings when prewarming production routes", async () => {
@@ -952,6 +1063,340 @@ describe("Renderer release asset cache isolation", () => {
     assertEquals(renderedSlugs, ["/"]);
     assertEquals(getAllPagesCalls, 0);
     assertEquals(store.data.size, 0);
+  });
+
+  it("waits within the admission budget for a foreground project slot", async () => {
+    const projectId = `queued-project-${crypto.randomUUID()}`;
+    const ctx = {
+      ...makeRenderContext(),
+      projectId,
+      projectSlug: projectId,
+      cachePrefix: buildRenderCachePrefix(projectId, "production", "rel-1"),
+    };
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let pipelineStarted = false;
+    let renderSettled = false;
+
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (slug: string) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (slug) => {
+          pipelineStarted = true;
+          return Promise.resolve({
+            html: `<html>${slug}</html>`,
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    for (let index = 0; index < RENDER_PER_PROJECT_LIMIT; index++) {
+      assertEquals(await acquireProjectSlot(projectId), true);
+    }
+
+    const render = renderer.renderPage("/queued", ctx, {
+      environment: "production",
+      releaseAssetManifest: null,
+    }).finally(() => {
+      renderSettled = true;
+    });
+    void render.catch(() => {});
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assertEquals(renderSettled, false);
+      assertEquals(pipelineStarted, false);
+
+      await releaseProjectSlot(projectId);
+      const result = await render;
+      assertEquals(result.html, "<html>/queued</html>");
+      assertEquals(pipelineStarted, true);
+    } finally {
+      while ((projectRenderCounts.get(projectId) ?? 0) > 0) {
+        await releaseProjectSlot(projectId);
+      }
+      await render.catch(() => {});
+    }
+  });
+
+  it("shares one admission budget across project and global capacity", async () => {
+    using time = new FakeTime();
+    let admissionNow = 0;
+    using _performanceNow = stub(Performance.prototype, "now", () => admissionNow);
+    const projectId = `budgeted-project-${crypto.randomUUID()}`;
+    const ctx = {
+      ...makeRenderContext(),
+      projectId,
+      projectSlug: projectId,
+      cachePrefix: buildRenderCachePrefix(projectId, "production", "rel-1"),
+    };
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let pipelineStarted = false;
+    let renderSettled = false;
+
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: () => Promise<never>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: () => {
+          pipelineStarted = true;
+          return Promise.reject(new Error("pipeline must not start"));
+        },
+      },
+    });
+
+    for (let index = 0; index < RENDER_PER_PROJECT_LIMIT; index++) {
+      assertEquals(await acquireProjectSlot(projectId), true);
+    }
+    let acquiredPermits = 0;
+    while (renderSemaphore.available > 0) {
+      assertEquals(await renderSemaphore.tryAcquire(0), true);
+      acquiredPermits++;
+    }
+
+    const render = renderer.renderPage("/budgeted", ctx, {
+      environment: "production",
+      releaseAssetManifest: null,
+    }).finally(() => {
+      renderSettled = true;
+    });
+    const rejected = assertRejects(() => render, Error, "Service is overloaded");
+
+    try {
+      await time.tickAsync(0);
+      await time.tickAsync(3_000);
+      admissionNow = 3_000;
+      assertEquals(renderSettled, false);
+
+      await releaseProjectSlot(projectId);
+      await time.tickAsync(0);
+      assertEquals(renderSemaphore.waiting, 1);
+
+      await time.tickAsync(RENDER_ACQUIRE_TIMEOUT_MS - 3_001);
+      assertEquals(renderSettled, false);
+
+      await time.tickAsync(1);
+      await rejected;
+      assertEquals(renderSettled, true);
+      assertEquals(pipelineStarted, false);
+      assertEquals(renderSemaphore.waiting, 0);
+    } finally {
+      for (let index = 0; index < acquiredPermits; index++) {
+        renderSemaphore.release();
+      }
+      while ((projectRenderCounts.get(projectId) ?? 0) > 0) {
+        await releaseProjectSlot(projectId);
+      }
+      await render.catch(() => {});
+    }
+  });
+
+  it("does not queue sibling prewarm behind exhausted global capacity", async () => {
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let renderCalls = 0;
+
+    (renderer as unknown as {
+      getAllPages: () => Promise<string[]>;
+      pageExists: () => Promise<boolean>;
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: () => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).getAllPages = () => Promise.resolve(["/blog"]);
+    (renderer as unknown as { pageExists: () => Promise<boolean> }).pageExists = () =>
+      Promise.resolve(true);
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: () => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: () => {
+          renderCalls++;
+          return Promise.resolve({
+            html: "<html>/blog</html>",
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    let acquiredPermits = 0;
+    while (renderSemaphore.available > 0) {
+      assertEquals(await renderSemaphore.tryAcquire(0), true);
+      acquiredPermits++;
+    }
+
+    const ctx = {
+      ...makeRenderContext(),
+      adapter: { fs: {} } as RenderContext["adapter"],
+    };
+    const prewarm = (renderer as unknown as {
+      runProductionRenderPrewarm: (
+        slug: string,
+        ctx: RenderContext,
+        options: {
+          environment: "production";
+          releaseId: string;
+          releaseAssetManifest: null;
+          url: URL;
+        },
+      ) => Promise<void>;
+    }).runProductionRenderPrewarm("/", ctx, {
+      environment: "production",
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+      url: new URL("https://preview.example.test/"),
+    });
+
+    try {
+      for (let index = 0; index < 10 && renderSemaphore.waiting === 0; index++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      assertEquals(renderSemaphore.waiting, 0);
+      assertEquals(renderCalls, 0);
+    } finally {
+      for (let index = 0; index < acquiredPermits; index++) {
+        renderSemaphore.release();
+      }
+      await prewarm;
+    }
+  });
+
+  it("retries foreground admission after a shared background leader overloads", async () => {
+    const projectId = `priority-project-${crypto.randomUUID()}`;
+    const ctx = {
+      ...makeRenderContext(),
+      projectId,
+      projectSlug: projectId,
+      cachePrefix: buildRenderCachePrefix(projectId, "production", "rel-1"),
+    };
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let renderCalls = 0;
+
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (slug: string) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (slug) => {
+          renderCalls++;
+          return Promise.resolve({
+            html: `<html>${slug}</html>`,
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    const firstCapacityCheck = Promise.withResolvers<boolean>();
+    const originalTryAcquire = renderSemaphore.tryAcquire;
+    let capacityChecks = 0;
+    renderSemaphore.tryAcquire = function (
+      timeoutMs?: number,
+      options?: { signal?: AbortSignal },
+    ): Promise<boolean> {
+      capacityChecks++;
+      if (capacityChecks === 1) return firstCapacityCheck.promise;
+      return originalTryAcquire.call(this, timeoutMs, options);
+    };
+
+    const sharedOptions = {
+      cacheKey: "priority-render",
+      environment: "production" as const,
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+    };
+    const backgroundRender = (renderer as unknown as {
+      renderPageWithAdmission: (
+        slug: string,
+        ctx: RenderContext,
+        options: typeof sharedOptions,
+        admission: "background",
+      ) => Promise<unknown>;
+    }).renderPageWithAdmission("/priority", ctx, sharedOptions, "background");
+    const backgroundRejected = assertRejects(
+      () => backgroundRender,
+      Error,
+      "Service is overloaded",
+    );
+
+    let foregroundRender: ReturnType<Renderer["renderPage"]> | undefined;
+    try {
+      for (let index = 0; index < 10 && capacityChecks === 0; index++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      assertEquals(capacityChecks, 1);
+
+      foregroundRender = renderer.renderPage("/priority", ctx, sharedOptions);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      firstCapacityCheck.resolve(false);
+
+      await backgroundRejected;
+      const result = await foregroundRender;
+      assertEquals(result.html, "<html>/priority</html>");
+      assertEquals(renderCalls, 1);
+      assertEquals(capacityChecks, 2);
+      assertEquals(
+        (renderer as unknown as {
+          renderFlightAdmissions: Map<string, "foreground" | "background">;
+        }).renderFlightAdmissions.size,
+        0,
+      );
+    } finally {
+      renderSemaphore.tryAcquire = originalTryAcquire;
+      firstCapacityCheck.resolve(false);
+      await backgroundRender.catch(() => {});
+      await foregroundRender?.catch(() => {});
+      while ((projectRenderCounts.get(projectId) ?? 0) > 0) {
+        await releaseProjectSlot(projectId);
+      }
+    }
   });
 
   it("deduplicates identical cacheable render misses before taking project slots", async () => {
@@ -1091,6 +1536,176 @@ describe("Renderer release asset cache isolation", () => {
     const result = await followerRender;
     assertEquals(result.html, "<html>/shared</html>");
     assertEquals(renderCalls, 1);
+  });
+
+  it("keeps a cacheable leader queued after its first caller disconnects", async () => {
+    const projectId = `shared-queued-project-${crypto.randomUUID()}`;
+    const ctx = {
+      ...makeRenderContext(),
+      projectId,
+      projectSlug: projectId,
+      cachePrefix: buildRenderCachePrefix(projectId, "production", "rel-1"),
+    };
+    const store = createInMemoryStore();
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    const caller = new AbortController();
+    let renderCalls = 0;
+
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (slug: string) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (slug) => {
+          renderCalls++;
+          return Promise.resolve({
+            html: `<html>${slug}</html>`,
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    for (let index = 0; index < RENDER_PER_PROJECT_LIMIT; index++) {
+      assertEquals(await acquireProjectSlot(projectId), true);
+    }
+
+    const sharedOptions = {
+      cacheKey: "shared-queued-render",
+      environment: "production" as const,
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+    };
+    const cancelledRender = renderer.renderPage("/shared-queued", ctx, {
+      ...sharedOptions,
+      request: new Request("https://example.com/shared-queued", {
+        signal: caller.signal,
+      }),
+    });
+    const followerRender = renderer.renderPage("/shared-queued", ctx, sharedOptions);
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assertEquals(renderCalls, 0);
+
+      const reason = new Error("caller disconnected while queued");
+      caller.abort(reason);
+      await assertRejects(() => cancelledRender, Error, reason.message);
+      assertEquals(renderCalls, 0);
+
+      await releaseProjectSlot(projectId);
+      const result = await followerRender;
+      assertEquals(result.html, "<html>/shared-queued</html>");
+      assertEquals(renderCalls, 1);
+    } finally {
+      while ((projectRenderCounts.get(projectId) ?? 0) > 0) {
+        await releaseProjectSlot(projectId);
+      }
+      await cancelledRender.catch(() => {});
+      await followerRender.catch(() => {});
+    }
+  });
+
+  it("keeps a cacheable leader globally queued after its first caller disconnects", async () => {
+    const projectId = `shared-global-project-${crypto.randomUUID()}`;
+    const ctx = {
+      ...makeRenderContext(),
+      projectId,
+      projectSlug: projectId,
+      cachePrefix: buildRenderCachePrefix(projectId, "production", "rel-1"),
+    };
+    const store = createInMemoryStore();
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    const caller = new AbortController();
+    let renderCalls = 0;
+    let observedSignal: AbortSignal | undefined;
+
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (
+            slug: string,
+            options?: { abortSignal?: AbortSignal },
+          ) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (slug, options) => {
+          renderCalls++;
+          observedSignal = options?.abortSignal;
+          return Promise.resolve({
+            html: `<html>${slug}</html>`,
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    let acquiredPermits = 0;
+    let transferredPermit = false;
+    while (renderSemaphore.available > 0) {
+      assertEquals(await renderSemaphore.tryAcquire(0), true);
+      acquiredPermits++;
+    }
+
+    const sharedOptions = {
+      cacheKey: "shared-global-render",
+      environment: "production" as const,
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+    };
+    const cancelledRender = renderer.renderPage("/shared-global", ctx, {
+      ...sharedOptions,
+      request: new Request("https://example.com/shared-global", {
+        signal: caller.signal,
+      }),
+    });
+
+    try {
+      for (let index = 0; index < 10 && renderSemaphore.waiting === 0; index++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      assertEquals(renderSemaphore.waiting, 1);
+      assertEquals(renderCalls, 0);
+
+      const followerRender = renderer.renderPage("/shared-global", ctx, sharedOptions);
+      const reason = new Error("caller disconnected while globally queued");
+      caller.abort(reason);
+      await assertRejects(() => cancelledRender, Error, reason.message);
+
+      renderSemaphore.release();
+      transferredPermit = true;
+      const result = await followerRender;
+      assertEquals(result.html, "<html>/shared-global</html>");
+      assertEquals(renderCalls, 1);
+      assertEquals(observedSignal?.aborted, false);
+    } finally {
+      const heldPermits = acquiredPermits - (transferredPermit ? 1 : 0);
+      for (let index = 0; index < heldPermits; index++) {
+        renderSemaphore.release();
+      }
+      await cancelledRender.catch(() => {});
+    }
   });
 
   it("aborts underlying render work when the pipeline deadline expires", async () => {

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -32,7 +32,7 @@
 
 import { rendererLogger } from "#veryfront/utils";
 import { MDXCacheAdapter } from "#veryfront/transforms/mdx/index.ts";
-import { INITIALIZATION_ERROR, SERVICE_OVERLOADED } from "#veryfront/errors";
+import { INITIALIZATION_ERROR, SERVICE_OVERLOADED, VeryfrontError } from "#veryfront/errors";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import {
   buildQueryAwareCacheKey,
@@ -105,6 +105,8 @@ const DEFAULT_RENDER_PREWARM_MAX_ROUTES = 12;
 const DEFAULT_RENDER_PREWARM_CONCURRENCY = 1;
 /** Bound remembered release contexts so multi-tenant processes cannot grow without limit. */
 const RENDER_PREWARM_CONTEXT_MAX_ENTRIES = 500;
+
+type RenderAdmission = "foreground" | "background";
 
 const RENDER_PREWARM_MAX_ROUTES = getBoundedEnvNumber(
   "VERYFRONT_RENDER_PREWARM_MAX_ROUTES",
@@ -249,6 +251,8 @@ export class Renderer {
    * Key format: {cachePrefix}:{slug}:{colorScheme}
    */
   private renderFlight = new Singleflight<CachedRenderData>();
+  /** Lets foreground followers recover when a background leader fails fast at capacity. */
+  private renderFlightAdmissions = new Map<string, RenderAdmission>();
   private productionPrewarmContexts = new Map<string, Promise<void>>();
 
   constructor(options: RendererOptions = {}) {
@@ -276,6 +280,15 @@ export class Renderer {
   }
 
   renderPage(slug: string, ctx: RenderContext, options?: RenderOptions): Promise<RenderResult> {
+    return this.renderPageWithAdmission(slug, ctx, options, "foreground");
+  }
+
+  private renderPageWithAdmission(
+    slug: string,
+    ctx: RenderContext,
+    options: RenderOptions | undefined,
+    admission: RenderAdmission,
+  ): Promise<RenderResult> {
     return withSpan(
       "renderer.renderPage",
       async () => {
@@ -325,6 +338,7 @@ export class Renderer {
           startTime,
           cacheKey,
           effectiveOptions.abortSignal ?? effectiveOptions.request?.signal,
+          admission,
         );
         this.scheduleProductionRenderPrewarm(slug, effectiveCtx, effectiveOptions, cacheKey);
         return result;
@@ -480,6 +494,10 @@ export class Renderer {
     ctx: RenderContext,
     options?: RenderOptions,
   ): RenderOptions {
+    const sourceUrl = options?.url ??
+      (options?.request ? new URL(options.request.url) : undefined);
+    const canonicalUrl = sourceUrl ? new URL("/", sourceUrl) : undefined;
+
     return {
       environment: ctx.environment,
       projectId: ctx.projectId,
@@ -489,6 +507,24 @@ export class Renderer {
       releaseAssetManifest: options?.releaseAssetManifest ?? null,
       noHmr: options?.noHmr,
       forceProductionScripts: options?.forceProductionScripts,
+      url: canonicalUrl,
+    };
+  }
+
+  private buildRoutePrewarmOptions(
+    slug: string,
+    options: RenderOptions,
+  ): RenderOptions {
+    if (!options.url) return options;
+
+    const url = new URL(normalizeComparableSlug(slug), options.url);
+    return {
+      ...options,
+      url,
+      request: new Request(url, {
+        method: "GET",
+        headers: { accept: "text/html" },
+      }),
     };
   }
 
@@ -529,7 +565,15 @@ export class Renderer {
     this.rememberProductionPrewarm(refreshKey, promise);
 
     setTimeout(() => {
-      void this.doRenderPage(slug, ctx, refreshOptions, performance.now(), cacheKey, undefined)
+      void this.doRenderPage(
+        slug,
+        ctx,
+        refreshOptions,
+        performance.now(),
+        cacheKey,
+        undefined,
+        "background",
+      )
         .then(() => {
           this.scheduleProductionRenderPrewarm(slug, ctx, refreshOptions, cacheKey);
           resolvePromise();
@@ -539,6 +583,14 @@ export class Renderer {
     promise.finally(() => {
       this.productionPrewarmContexts.delete(refreshKey);
     }).catch((error) => {
+      if (error instanceof VeryfrontError && error.slug === "service-overloaded") {
+        logger.debug("Production stale render refresh skipped at capacity", {
+          slug,
+          projectId: ctx.projectId,
+          releaseId: ctx.releaseId,
+        });
+        return;
+      }
       logger.warn("Production stale render refresh failed", {
         slug,
         projectId: ctx.projectId,
@@ -582,8 +634,21 @@ export class Renderer {
 
         const slug = slugs[index]!;
         try {
-          await this.renderPage(slug, ctx, options);
+          await this.renderPageWithAdmission(
+            slug,
+            ctx,
+            this.buildRoutePrewarmOptions(slug, options),
+            "background",
+          );
         } catch (error) {
+          if (error instanceof VeryfrontError && error.slug === "service-overloaded") {
+            logger.debug("Production render prewarm route skipped at capacity", {
+              slug,
+              projectId: ctx.projectId,
+              releaseId: ctx.releaseId,
+            });
+            continue;
+          }
           logger.warn("Production render prewarm route failed", {
             slug,
             projectId: ctx.projectId,
@@ -610,12 +675,18 @@ export class Renderer {
     startTime: number,
     cacheKey: string | null,
     callerSignal: AbortSignal | undefined,
+    admission: RenderAdmission,
+    retryBackgroundOverload = true,
   ): Promise<RenderResult> {
     const effectiveKey = cacheKey ?? crypto.randomUUID();
     const flightKey = this.getSingleflightKey(effectiveKey, ctx, options?.colorScheme);
     const isFollower = cacheKey !== null ? this.renderFlight.has(flightKey) : false;
+    const leaderAdmission = isFollower ? this.renderFlightAdmissions.get(flightKey) : admission;
 
     const runRender = async () => {
+      if (cacheKey !== null) {
+        this.renderFlightAdmissions.set(flightKey, admission);
+      }
       try {
         return await this.runRenderWithCapacity(
           slug,
@@ -624,6 +695,7 @@ export class Renderer {
           startTime,
           cacheKey,
           callerSignal,
+          admission,
         );
       } catch (error) {
         if (error instanceof TimeoutError) {
@@ -634,15 +706,48 @@ export class Renderer {
           });
         }
         throw error;
+      } finally {
+        if (
+          cacheKey !== null &&
+          this.renderFlightAdmissions.get(flightKey) === admission
+        ) {
+          this.renderFlightAdmissions.delete(flightKey);
+        }
       }
     };
 
-    const cachedData = cacheKey !== null
-      ? await waitForSharedPromise(
-        this.renderFlight.do(flightKey, runRender),
-        callerSignal,
-      )
-      : await runRender();
+    let cachedData: CachedRenderData;
+    try {
+      cachedData = cacheKey !== null
+        ? await waitForSharedPromise(
+          this.renderFlight.do(flightKey, runRender),
+          callerSignal,
+        )
+        : await runRender();
+    } catch (error) {
+      if (
+        retryBackgroundOverload &&
+        admission === "foreground" &&
+        isFollower &&
+        leaderAdmission === "background" &&
+        error instanceof VeryfrontError &&
+        error.slug === "service-overloaded"
+      ) {
+        // Background leaders never wait for capacity. Give a foreground follower
+        // its own bounded admission attempt instead of inheriting that fail-fast result.
+        return await this.doRenderPage(
+          slug,
+          ctx,
+          options,
+          startTime,
+          cacheKey,
+          callerSignal,
+          admission,
+          false,
+        );
+      }
+      throw error;
+    }
 
     if (isFollower) {
       logger.debug("Render deduplicated (follower)", {
@@ -670,44 +775,68 @@ export class Renderer {
     startTime: number,
     cacheKey: string | null,
     callerSignal: AbortSignal | undefined,
+    admission: RenderAdmission,
   ): Promise<CachedRenderData> {
-    if (!(await acquireProjectSlot(ctx.projectId))) {
+    const admissionStartedAt = performance.now();
+    const admissionSignal = cacheKey === null ? callerSignal : undefined;
+    const waitForCapacity = admission === "foreground";
+    const projectAcquired = await acquireProjectSlot(ctx.projectId, {
+      wait: waitForCapacity,
+      timeoutMs: waitForCapacity ? RENDER_ACQUIRE_TIMEOUT_MS : 0,
+      ...(admissionSignal ? { signal: admissionSignal } : {}),
+    });
+
+    if (!projectAcquired) {
       const activeCount = projectRenderCounts.get(ctx.projectId) ?? 0;
-      logger.error("Per-project render limit reached", {
+      const context = {
         slug,
         projectId: ctx.projectId,
         activeRenders: activeCount,
         limit: RENDER_PER_PROJECT_LIMIT,
-      });
+        admission,
+      };
+      if (admission === "background") {
+        logger.debug("Background render skipped at per-project capacity", context);
+      } else {
+        logger.warn("Per-project render admission exhausted", context);
+      }
       throw SERVICE_OVERLOADED.create({
         detail:
-          `Per-project render limit reached (${activeCount}/${RENDER_PER_PROJECT_LIMIT} active). Try again shortly.`,
-        context: {
+          `Per-project render admission exhausted (${activeCount}/${RENDER_PER_PROJECT_LIMIT} active). Try again shortly.`,
+        context,
+      });
+    }
+
+    let globalAcquired = false;
+    try {
+      const elapsedAdmissionMs = performance.now() - admissionStartedAt;
+      const globalWaitMs = waitForCapacity
+        ? Math.max(0, RENDER_ACQUIRE_TIMEOUT_MS - elapsedAdmissionMs)
+        : 0;
+      globalAcquired = await renderSemaphore.tryAcquire(globalWaitMs, {
+        ...(admissionSignal ? { signal: admissionSignal } : {}),
+      });
+
+      if (!globalAcquired) {
+        const context = {
           slug,
           projectId: ctx.projectId,
-          activeRenders: activeCount,
-          limit: RENDER_PER_PROJECT_LIMIT,
-        },
-      });
-    }
+          waiting: renderSemaphore.waiting,
+          available: renderSemaphore.available,
+          admission,
+        };
+        if (admission === "background") {
+          logger.debug("Background render skipped at global capacity", context);
+        } else {
+          logger.warn("Global render admission exhausted", context);
+        }
+        throw SERVICE_OVERLOADED.create({
+          detail:
+            `Render admission exhausted (${renderSemaphore.waiting} waiting). Service is overloaded.`,
+          context,
+        });
+      }
 
-    const acquired = await renderSemaphore.tryAcquire(RENDER_ACQUIRE_TIMEOUT_MS);
-    if (!acquired) {
-      await releaseProjectSlot(ctx.projectId);
-      logger.error("Render capacity exceeded - service overloaded", {
-        slug,
-        projectId: ctx.projectId,
-        waiting: renderSemaphore.waiting,
-        available: renderSemaphore.available,
-      });
-      throw SERVICE_OVERLOADED.create({
-        detail:
-          `Render capacity exceeded (${renderSemaphore.waiting} waiting). Service is overloaded.`,
-        context: { slug, projectId: ctx.projectId, waiting: renderSemaphore.waiting },
-      });
-    }
-
-    try {
       const services = this.createServicesForContext(ctx, options?.colorScheme);
       const renderAbortController = new AbortController();
       const request = cacheKey !== null && options?.request
@@ -754,7 +883,7 @@ export class Renderer {
         pageModule: result.pageModule,
       };
     } finally {
-      renderSemaphore.release();
+      if (globalAcquired) renderSemaphore.release();
       await releaseProjectSlot(ctx.projectId);
     }
   }

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -7,7 +7,7 @@ import type { RendererProvider, SSRRenderOptions } from "./ssr.service.ts";
 import type { HandlerContext } from "../../handlers/types.ts";
 import type { RendererAdapter } from "../../shared/renderer-factory.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
-import { VeryfrontError } from "#veryfront/errors/index.ts";
+import { SERVICE_OVERLOADED, VeryfrontError } from "#veryfront/errors/index.ts";
 import { notFound, redirect } from "#veryfront/data/helpers.ts";
 
 function createMockAdapter(): RuntimeAdapter {
@@ -579,6 +579,30 @@ describe("server/services/rendering/ssr.service", () => {
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 500);
         assertEquals(result.errorType, "server-error");
+        assertEquals(result.showDevOverlay, undefined);
+        assertEquals(typeof result.html, "string");
+      });
+
+      it("returns 503 for service-overloaded errors", async () => {
+        const adapter = createMockRendererAdapter({
+          renderPage: () => {
+            throw SERVICE_OVERLOADED.create({
+              detail: "Per-project render queue is full",
+            });
+          },
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        const result = await service.renderPage(
+          makeCtx({ isLocalProject: true }),
+          makeRenderOptions(),
+        );
+        assertEquals(result.status, 503);
+        assertEquals(result.errorType, "server-error");
+        assertEquals(result.cacheStrategy, "no-cache");
+        assertEquals(result.isStreaming, false);
         assertEquals(result.showDevOverlay, undefined);
         assertEquals(typeof result.html, "string");
       });

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -605,6 +605,8 @@ describe("server/services/rendering/ssr.service", () => {
         assertEquals(result.isStreaming, false);
         assertEquals(result.showDevOverlay, undefined);
         assertEquals(typeof result.html, "string");
+        assertEquals(result.html?.includes("503"), true);
+        assertEquals(result.html?.includes("Service Temporarily Unavailable"), true);
       });
 
       it("returns runtime error overlay in dev mode", async () => {

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -430,6 +430,20 @@ export class SSRService implements SSRServiceLike {
       }
     }
 
+    if (
+      error instanceof VeryfrontError && error.slug === "service-overloaded"
+    ) {
+      return {
+        status: error.status ?? HTTP_UNAVAILABLE,
+        html: ErrorPages.serverError(),
+        isStreaming: false,
+        cacheStrategy: "no-cache",
+        error: errorObj,
+        errorType: "server-error",
+        slug,
+      };
+    }
+
     logger.error("Render failed", {
       slug,
       error: errorObj.message,

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -435,7 +435,7 @@ export class SSRService implements SSRServiceLike {
     ) {
       return {
         status: error.status ?? HTTP_UNAVAILABLE,
-        html: ErrorPages.serverError(),
+        html: ErrorPages.memoryPressure(),
         isStreaming: false,
         cacheStrategy: "no-cache",
         error: errorObj,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1145";
+export const VERSION = "0.1.1146";


### PR DESCRIPTION
## Why

Authenticated SSR could still take 30+ seconds or return a generic 500 under cold concurrent load. The remaining bottleneck was admission policy: foreground renders could fail immediately at the per-project gate, while stale refresh and sibling prewarm could wait and compete with user-facing work.

This fixes admission at the renderer boundary. It does not raise module-load deadlines or hide slow transforms.

## What changed

- Add a bounded FIFO per-project queue for foreground renders.
- Apply one five-second admission budget across both the per-project and global capacity gates.
- Make stale refresh and sibling prewarm background work fail fast instead of queueing.
- Add abort-aware queue cleanup to the shared semaphore and project admission gate, including the listener-registration boundary.
- Preserve cacheable singleflight ownership when the first caller aborts while a leader waits for capacity.
- Retry a foreground follower once when it joined a background leader that failed fast with `service-overloaded`.
- Build prewarm requests from a canonical anonymous route-specific `GET` request rather than forwarding caller credentials or headers.
- Return overload as an explicit non-cacheable `503` response with a matching 503 unavailable page.
- Add `RENDER_PER_PROJECT_QUEUE_SIZE`; invalid numeric env values fall back to safe defaults.

## Boundedness and invariants

- Foreground wait is bounded by one total admission deadline, not one deadline per gate.
- Background work never enters either wait queue.
- Queue size is finite and configurable; the default matches the per-project concurrency limit.
- Cancellation removes timers, listeners, and queued waiters without consuming a permit.
- The public renderer API and cache identity remain unchanged.

## Verification

- Mandatory pre-push gate: **2,680 tests / 21,782 steps passed**, 0 failed.
- Focused admission/renderer/service suites: **7 suites / 113 steps passed**, 0 failed.
- The overload-body regression was replayed red/green: the former generic server page fails the 503 body assertions; the unavailable page passes them.
- `deno task verify:quick` passed (format, lint, ratchets, docs, and typecheck).
- Frozen changed-file type checks and `git diff --check` passed.
- Production-source local consumer smoke on the built **0.1.1146** package: `npm run check` passed with **173/173 tests**, all six SSR route outcomes passed, `/chat` returned 200 at ~1.24s TTFB, and `/review` returned 200 at ~1.50s TTFB.
- Authenticated deployed baseline before consuming this release: `/review` took ~21.3s TTFB / ~23.5s FCP; a six-request concurrent batch returned 200s but still took 12.2–19.9s TTFB.
- Independent correctness and performance reviews found no blocking issue.

## Release

- Bumps framework version to **0.1.1146** in `deno.json` and the runtime version constant.
- `0.1.1145` is already owned by merged PR #3100; this branch is rebased on that release change.
- Also includes the cache-integrity foundation merged in #3099 (0.1.1144).

Deployed authenticated latency and concurrency will be re-measured after this release is consumed by the job-submission project.

