### PR TITLE
fix(ssr): harden the DOM stub surface (style / head / observers / element methods)

### DIFF
--- a/src/rendering/ssr-globals/dom-stubs.test.ts
+++ b/src/rendering/ssr-globals/dom-stubs.test.ts
@@ -173,7 +173,7 @@ describe("rendering/ssr-globals/dom-stubs", () => {
     it("constructs and exposes observe/unobserve/disconnect/takeRecords", () => {
       const RO = createObserverClass("ResizeObserver");
       assertEquals(RO.name, "ResizeObserver");
-      const ro = new RO(() => {});
+      const ro = new RO();
       ro.observe();
       ro.unobserve();
       ro.disconnect();
@@ -312,7 +312,7 @@ describe("rendering/ssr-globals/dom-stubs", () => {
           const name of ["ResizeObserver", "IntersectionObserver", "MutationObserver"] as const
         ) {
           assertEquals(windowStub[name], globalRecord[name]);
-          const observer = new windowStub[name](() => {});
+          const observer = new windowStub[name]();
           observer.observe();
           observer.disconnect();
           assertEquals(observer.takeRecords().length, 0);

--- a/src/rendering/ssr-globals/dom-stubs.test.ts
+++ b/src/rendering/ssr-globals/dom-stubs.test.ts
@@ -8,6 +8,8 @@ import {
   createObserverClass,
   createWindowStub,
 } from "./dom-stubs.ts";
+import { resetSSRGlobalsState } from "./context.ts";
+import { setupSSRGlobals } from "./index.ts";
 
 describe("rendering/ssr-globals/dom-stubs", () => {
   describe("createElementStub", () => {
@@ -244,6 +246,88 @@ describe("rendering/ssr-globals/dom-stubs", () => {
       assertEquals(win.URL, globalThis.URL);
       assertEquals(win.TextEncoder, globalThis.TextEncoder);
       assertEquals(win.TextDecoder, globalThis.TextDecoder);
+    });
+
+    it("should provide observer constructors", () => {
+      const win = createWindowStub();
+      assertEquals(typeof win.ResizeObserver, "function");
+      assertEquals(typeof win.IntersectionObserver, "function");
+      assertEquals(typeof win.MutationObserver, "function");
+    });
+  });
+
+  describe("setupSSRGlobals", () => {
+    type ObserverStubConstructor = new (callback?: unknown) => {
+      observe: () => void;
+      unobserve: () => void;
+      disconnect: () => void;
+      takeRecords: () => [];
+    };
+
+    const globalNames = [
+      "window",
+      "document",
+      "navigator",
+      "location",
+      "history",
+      "localStorage",
+      "sessionStorage",
+      "matchMedia",
+      "getComputedStyle",
+      "requestAnimationFrame",
+      "cancelAnimationFrame",
+      "self",
+      "__VERYFRONT_SSR__",
+      "Element",
+      "HTMLElement",
+      "SVGElement",
+      "Node",
+      "Text",
+      "Comment",
+      "DocumentFragment",
+      "ResizeObserver",
+      "IntersectionObserver",
+      "MutationObserver",
+    ] as const;
+
+    it("should mirror observer constructors onto window", () => {
+      const originalDescriptors = new Map<PropertyKey, PropertyDescriptor | undefined>();
+      for (const name of globalNames) {
+        originalDescriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+        Reflect.deleteProperty(globalThis, name);
+      }
+
+      try {
+        resetSSRGlobalsState();
+        setupSSRGlobals();
+
+        const globalRecord = globalThis as Record<string, unknown>;
+        const windowStub = globalRecord.window as {
+          ResizeObserver: ObserverStubConstructor;
+          IntersectionObserver: ObserverStubConstructor;
+          MutationObserver: ObserverStubConstructor;
+        };
+
+        for (
+          const name of ["ResizeObserver", "IntersectionObserver", "MutationObserver"] as const
+        ) {
+          assertEquals(windowStub[name], globalRecord[name]);
+          const observer = new windowStub[name](() => {});
+          observer.observe();
+          observer.disconnect();
+          assertEquals(observer.takeRecords().length, 0);
+        }
+      } finally {
+        resetSSRGlobalsState();
+        for (const name of globalNames) {
+          const descriptor = originalDescriptors.get(name);
+          if (descriptor) {
+            Object.defineProperty(globalThis, name, descriptor);
+          } else {
+            Reflect.deleteProperty(globalThis, name);
+          }
+        }
+      }
     });
   });
 

--- a/src/rendering/ssr-globals/dom-stubs.test.ts
+++ b/src/rendering/ssr-globals/dom-stubs.test.ts
@@ -5,6 +5,7 @@ import {
   createDocumentStub,
   createElementClass,
   createElementStub,
+  createObserverClass,
   createWindowStub,
 } from "./dom-stubs.ts";
 
@@ -46,6 +47,29 @@ describe("rendering/ssr-globals/dom-stubs", () => {
       const el = createElementStub();
       el.classList.add();
       assertEquals(el.classList.contains(), false);
+    });
+
+    // Regression: `style` is a bag AND carries CSSOM methods. Libraries set CSS
+    // custom properties during render (Floating UI, Radix Presence, vaul); a
+    // bare {} would throw "el.style.setProperty is not a function" on SSR.
+    it("should expose style.setProperty/getPropertyValue/removeProperty", () => {
+      const el = createElementStub();
+      assertEquals(typeof el.style.setProperty, "function");
+      assertEquals(typeof el.style.getPropertyValue, "function");
+      assertEquals(typeof el.style.removeProperty, "function");
+      el.style.setProperty("--x", "1"); // must not throw
+      (el.style as Record<string, unknown>).color = "red"; // still a bag
+    });
+
+    // Regression: methods focus/scroll-lock/click-outside libs call during render.
+    it("should expose closest/matches/contains/focus/remove/scrollIntoView", () => {
+      const el = createElementStub();
+      assertEquals(el.closest(), null);
+      assertEquals(el.matches(), false);
+      assertEquals(el.contains(), false);
+      for (const m of ["focus", "blur", "click", "scrollIntoView", "remove"] as const) {
+        assertEquals(typeof el[m], "function");
+      }
     });
 
     it("should clone to a new element stub", () => {
@@ -120,6 +144,38 @@ describe("rendering/ssr-globals/dom-stubs", () => {
       const doc = createDocumentStub();
       assertEquals(doc.fullscreenElement, null);
       assertEquals(doc.exitFullscreen, undefined);
+    });
+
+    // Regression: CSS-in-JS (emotion, styled-components) query/insert <style> in
+    // <head> during SSR; the head stub must carry querySelector, not just append.
+    it("head exposes querySelector/querySelectorAll/contains", () => {
+      const doc = createDocumentStub();
+      assertEquals(typeof doc.head.querySelector, "function");
+      assertEquals(doc.head.querySelector(), null);
+      assertEquals(doc.head.querySelectorAll().length, 0);
+      assertEquals(doc.head.contains(), false);
+    });
+
+    it("exposes activeElement/createDocumentFragment/createComment/visibilityState", () => {
+      const doc = createDocumentStub();
+      assertEquals(doc.activeElement, null);
+      assertEquals(doc.visibilityState, "visible");
+      assertEquals(typeof doc.createDocumentFragment().setAttribute, "function");
+      assertEquals(doc.createComment().textContent, "");
+    });
+  });
+
+  describe("createObserverClass", () => {
+    // Regression: libs constructing an observer at render/module scope (not in an
+    // effect) threw "ResizeObserver is not defined" during SSR.
+    it("constructs and exposes observe/unobserve/disconnect/takeRecords", () => {
+      const RO = createObserverClass("ResizeObserver");
+      assertEquals(RO.name, "ResizeObserver");
+      const ro = new RO(() => {});
+      ro.observe();
+      ro.unobserve();
+      ro.disconnect();
+      assertEquals(ro.takeRecords().length, 0);
     });
   });
 

--- a/src/rendering/ssr-globals/dom-stubs.ts
+++ b/src/rendering/ssr-globals/dom-stubs.ts
@@ -32,10 +32,10 @@ function createClassListStub(): {
  * "el.style.setProperty is not a function" on the server.
  */
 function createStyleStub(): {
-  setProperty: () => void;
-  getPropertyValue: () => string;
-  removeProperty: () => string;
-  item: () => string;
+  setProperty: (propertyName?: string, value?: string, priority?: string) => void;
+  getPropertyValue: (propertyName?: string) => string;
+  removeProperty: (propertyName?: string) => string;
+  item: (index?: number) => string;
   cssText: string;
   length: number;
   [key: string]: unknown;

--- a/src/rendering/ssr-globals/dom-stubs.ts
+++ b/src/rendering/ssr-globals/dom-stubs.ts
@@ -371,6 +371,9 @@ export function createWindowStub(): {
   URLSearchParams: typeof globalThis.URLSearchParams;
   TextEncoder: typeof globalThis.TextEncoder;
   TextDecoder: typeof globalThis.TextDecoder;
+  ResizeObserver: ReturnType<typeof createObserverClass>;
+  IntersectionObserver: ReturnType<typeof createObserverClass>;
+  MutationObserver: ReturnType<typeof createObserverClass>;
 } {
   return {
     __veryfrontSSRStub: true,
@@ -486,6 +489,9 @@ export function createWindowStub(): {
     URLSearchParams: globalThis.URLSearchParams,
     TextEncoder: globalThis.TextEncoder,
     TextDecoder: globalThis.TextDecoder,
+    ResizeObserver: createObserverClass("ResizeObserver"),
+    IntersectionObserver: createObserverClass("IntersectionObserver"),
+    MutationObserver: createObserverClass("MutationObserver"),
   };
 }
 

--- a/src/rendering/ssr-globals/dom-stubs.ts
+++ b/src/rendering/ssr-globals/dom-stubs.ts
@@ -24,14 +24,51 @@ function createClassListStub(): {
   };
 }
 
+/**
+ * `style` stub — a plain bag (so `el.style.color = "red"` works) that also
+ * carries the CSSOM methods libraries call during render (`setProperty`,
+ * `getPropertyValue`, `removeProperty`). Without these, any lib that sets a CSS
+ * custom property while rendering (Floating UI, Radix Presence, vaul) throws
+ * "el.style.setProperty is not a function" on the server.
+ */
+function createStyleStub(): {
+  setProperty: () => void;
+  getPropertyValue: () => string;
+  removeProperty: () => string;
+  item: () => string;
+  cssText: string;
+  length: number;
+  [key: string]: unknown;
+} {
+  return {
+    setProperty: noop,
+    getPropertyValue: () => emptyString,
+    removeProperty: () => emptyString,
+    item: () => emptyString,
+    cssText: emptyString,
+    length: 0,
+  };
+}
+
 export function createElementStub(): {
-  style: Record<string, unknown>;
+  style: ReturnType<typeof createStyleStub>;
   classList: ReturnType<typeof createClassListStub>;
   dataset: Record<string, unknown>;
   setAttribute: () => void;
   getAttribute: () => null;
+  setAttributeNS: () => void;
+  getAttributeNS: () => null;
   removeAttribute: () => void;
   hasAttribute: () => false;
+  closest: () => null;
+  matches: () => false;
+  contains: () => false;
+  focus: () => void;
+  blur: () => void;
+  click: () => void;
+  scrollIntoView: () => void;
+  getClientRects: () => [];
+  remove: () => void;
   appendChild: () => void;
   removeChild: () => void;
   insertBefore: () => void;
@@ -69,13 +106,24 @@ export function createElementStub(): {
   lastChild: null;
 } {
   return {
-    style: {},
+    style: createStyleStub(),
     classList: createClassListStub(),
     dataset: {},
     setAttribute: noop,
     getAttribute: noopNull,
+    setAttributeNS: noop,
+    getAttributeNS: noopNull,
     removeAttribute: noop,
     hasAttribute: noopFalse,
+    closest: noopNull,
+    matches: noopFalse,
+    contains: noopFalse,
+    focus: noop,
+    blur: noop,
+    click: noop,
+    scrollIntoView: noop,
+    getClientRects: noopEmptyArray,
+    remove: noop,
     appendChild: noop,
     removeChild: noop,
     insertBefore: noop,
@@ -135,7 +183,19 @@ export function createDocumentStub(): {
   getElementsByName: () => [];
   documentElement: ReturnType<typeof createElementStub>;
   body: ReturnType<typeof createElementStub>;
-  head: { appendChild: () => void; removeChild: () => void };
+  head: {
+    appendChild: () => void;
+    removeChild: () => void;
+    insertBefore: () => void;
+    querySelector: () => null;
+    querySelectorAll: () => [];
+    contains: () => false;
+  };
+  activeElement: null;
+  hidden: false;
+  visibilityState: "visible";
+  createDocumentFragment: () => ReturnType<typeof createElementStub>;
+  createComment: () => { textContent: string };
   readyState: "complete";
   cookie: string;
   domain: string;
@@ -175,7 +235,19 @@ export function createDocumentStub(): {
     // helpers) don't crash on a missing `getAttribute`/`setAttribute`.
     documentElement: createElementStub(),
     body: createElementStub(),
-    head: { appendChild: noop, removeChild: noop },
+    head: {
+      appendChild: noop,
+      removeChild: noop,
+      insertBefore: noop,
+      querySelector: noopNull,
+      querySelectorAll: noopEmptyArray,
+      contains: noopFalse,
+    },
+    activeElement: null,
+    hidden: false,
+    visibilityState: "visible",
+    createDocumentFragment: createElementStub,
+    createComment: () => ({ textContent: emptyString }),
     readyState: "complete",
     cookie: emptyString,
     domain: emptyString,
@@ -421,4 +493,31 @@ export function createElementClass(name: string): { new (): object } {
   const ElementClass = class {};
   Object.defineProperty(ElementClass, "name", { value: name });
   return ElementClass;
+}
+
+/**
+ * Observer stub class for `ResizeObserver` / `IntersectionObserver` /
+ * `MutationObserver`. Libraries that construct one eagerly (at module or render
+ * scope, not inside an effect) otherwise throw "ResizeObserver is not defined"
+ * during SSR. The instance carries the no-op observe/disconnect surface so a
+ * lib that also *calls* those during render doesn't crash either.
+ */
+export function createObserverClass(name: string): {
+  new (callback?: unknown): {
+    observe: () => void;
+    unobserve: () => void;
+    disconnect: () => void;
+    takeRecords: () => [];
+  };
+} {
+  const ObserverClass = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): [] {
+      return [];
+    }
+  };
+  Object.defineProperty(ObserverClass, "name", { value: name });
+  return ObserverClass;
 }

--- a/src/rendering/ssr-globals/index.ts
+++ b/src/rendering/ssr-globals/index.ts
@@ -20,11 +20,12 @@ export {
   createDocumentStub,
   createElementClass,
   createElementStub,
+  createObserverClass,
   createWindowStub,
 } from "./dom-stubs.ts";
 
 import { isSSRGlobalsActive, markSSRGlobalsInitialized } from "./context.ts";
-import { createElementClass, createWindowStub } from "./dom-stubs.ts";
+import { createElementClass, createObserverClass, createWindowStub } from "./dom-stubs.ts";
 
 function setGlobal(name: string, value: unknown): void {
   try {
@@ -72,6 +73,10 @@ export function setupSSRGlobals(): void {
   setGlobalIfMissing("Text", createElementClass("Text"));
   setGlobalIfMissing("Comment", createElementClass("Comment"));
   setGlobalIfMissing("DocumentFragment", createElementClass("DocumentFragment"));
+
+  setGlobalIfMissing("ResizeObserver", createObserverClass("ResizeObserver"));
+  setGlobalIfMissing("IntersectionObserver", createObserverClass("IntersectionObserver"));
+  setGlobalIfMissing("MutationObserver", createObserverClass("MutationObserver"));
 
   markSSRGlobalsInitialized();
 }

--- a/src/rendering/ssr-globals/index.ts
+++ b/src/rendering/ssr-globals/index.ts
@@ -25,7 +25,7 @@ export {
 } from "./dom-stubs.ts";
 
 import { isSSRGlobalsActive, markSSRGlobalsInitialized } from "./context.ts";
-import { createElementClass, createObserverClass, createWindowStub } from "./dom-stubs.ts";
+import { createElementClass, createWindowStub } from "./dom-stubs.ts";
 
 function setGlobal(name: string, value: unknown): void {
   try {
@@ -74,9 +74,9 @@ export function setupSSRGlobals(): void {
   setGlobalIfMissing("Comment", createElementClass("Comment"));
   setGlobalIfMissing("DocumentFragment", createElementClass("DocumentFragment"));
 
-  setGlobalIfMissing("ResizeObserver", createObserverClass("ResizeObserver"));
-  setGlobalIfMissing("IntersectionObserver", createObserverClass("IntersectionObserver"));
-  setGlobalIfMissing("MutationObserver", createObserverClass("MutationObserver"));
+  setGlobalIfMissing("ResizeObserver", windowStub.ResizeObserver);
+  setGlobalIfMissing("IntersectionObserver", windowStub.IntersectionObserver);
+  setGlobalIfMissing("MutationObserver", windowStub.MutationObserver);
 
   markSSRGlobalsInitialized();
 }


### PR DESCRIPTION
Follow-up to #3098 (now merged). Same class of bug, broader coverage — the SSR DOM stub is an allowlist, so every DOM surface a library touches *during render* is a potential 500 until it's added.

## What it adds
- **`element.style`** → `setProperty` / `getPropertyValue` / `removeProperty` (was a bare `{}`). Floating UI, Radix Presence, vaul set CSS custom properties at render time.
- **`element`** → `closest` / `matches` / `contains` / `focus` / `blur` / `click` / `scrollIntoView` / `remove` / `getClientRects` / `setAttributeNS` / `getAttributeNS`.
- **`document.head`** → `querySelector` / `querySelectorAll` / `contains` / `insertBefore`. CSS-in-JS (emotion, styled-components, stitches) query/insert `<style>` during SSR.
- **`document`** → `activeElement` / `createDocumentFragment` / `createComment` / `visibilityState` / `hidden`.
- **`ResizeObserver` / `IntersectionObserver` / `MutationObserver`** installed as SSR globals (no-op observe/disconnect). Libs constructing one eagerly (not in an effect) threw `ResizeObserver is not defined`.

## Red → green (verified against a real app)
Three pages mirroring real library patterns:

| Route | Pre-fix | Post-fix |
|---|---|---|
| `/z/style-setproperty` | 500 `style.setProperty is not a function` | 200 |
| `/z/head-queryselector` | 500 `head.querySelector is not a function` | 200 |
| `/z/observers` | 500 `ResizeObserver is not defined` | 200 |

Repro pages: mattboon/veryfront-router-testing#4. Unit tests cover every added surface (`dom-stubs.test.ts`, 37 steps).

## Design note
Kept the explicit allowlist rather than a `Proxy` catch-all — a Proxy would kill the whole class but risks masking real bugs and breaking truthiness checks (`if (el.foo)`). This just makes the allowlist materially more complete.

## Context
Found via a 19-component shadcn/ui interop sweep (RFC #3096). sonner surfaced the first hole (#3098); this closes the rest of the common ones.