### PR TITLE
fix(api): resolve bare npm imports in API-route handlers on the Deno source-run

### DIFF
--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -5,6 +5,7 @@ import { join } from "#veryfront/compat/path";
 import {
   generateCompiledBinaryRequireShim,
   getNodeExternalPackagesToResolve,
+  getUserDependencies,
   isSpecifierResolutionError,
   loadHandlerModule,
   resolveEsmUserDependencies,
@@ -483,6 +484,25 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     );
 
     assertEquals(packages, ["zod", "pdf-parse", "another-lib"]);
+  });
+
+  it("keeps zod for Deno source runs but excludes it from compiled binaries", () => {
+    const dependencies = new Map([
+      ["zod", "^3.22.0"],
+      ["pdf-parse", "^1.1.1"],
+    ]);
+
+    assertEquals(
+      [...getUserDependencies(dependencies, { isDeno: true, isCompiledBinary: false })],
+      [
+        ["zod", "^3.22.0"],
+        ["pdf-parse", "^1.1.1"],
+      ],
+    );
+    assertEquals(
+      [...getUserDependencies(dependencies, { isDeno: true, isCompiledBinary: true })],
+      [["pdf-parse", "^1.1.1"]],
+    );
   });
 
   it("rewrites bare veryfront imports using the package export map", async () => {

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -435,7 +435,24 @@ function loadAndTranspileModule(
       // Filter out framework-managed packages from user deps. These are already
       // handled by the framework's own external/rewrite logic and should not be
       // treated as user npm packages.
-      const frameworkPackages = new Set(["zod", "veryfront", "react", "react-dom", "path"]);
+      //
+      // `zod` is kept as a user dep on Node and the Deno source-run so a
+      // handler's own `import { z } from "zod"` is rewritten to a resolvable
+      // specifier. Excluding it left a bare `import "zod"` in the temp handler
+      // that Deno cannot resolve → "not a dependency and not in import map" → 500.
+      // (The Node path already always-resolves zod via
+      // getNodeExternalPackagesToResolve, so only the Deno source-run was broken
+      // by the exclusion.) zod is still force-externalized below, never bundled.
+      //
+      // The compiled binary keeps zod excluded — this change is scoped to the
+      // runtimes where it is verified. The binary loads framework helpers
+      // (createValidatedHandler, MiddlewarePipeline, …) through per-subpath
+      // veryfront runtime shims written next to the temp handler, a separate and
+      // more constrained resolution path; wiring a user `zod` through it belongs
+      // in a dedicated change with its own binary coverage. Leaving the binary
+      // branch byte-identical to before keeps that path untouched here.
+      const frameworkPackages = new Set(["veryfront", "react", "react-dom", "path"]);
+      if (isDeno && isCompiledBinary()) frameworkPackages.add("zod");
       const frameworkPrefixes = ["@opentelemetry/", "node:", "veryfront/"];
       const userDeps = new Map<string, string>();
       for (const [name, version] of allDeps) {

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -451,15 +451,10 @@ function loadAndTranspileModule(
       // more constrained resolution path; wiring a user `zod` through it belongs
       // in a dedicated change with its own binary coverage. Leaving the binary
       // branch byte-identical to before keeps that path untouched here.
-      const frameworkPackages = new Set(["veryfront", "react", "react-dom", "path"]);
-      if (isDeno && isCompiledBinary()) frameworkPackages.add("zod");
-      const frameworkPrefixes = ["@opentelemetry/", "node:", "veryfront/"];
-      const userDeps = new Map<string, string>();
-      for (const [name, version] of allDeps) {
-        if (frameworkPackages.has(name)) continue;
-        if (frameworkPrefixes.some((p) => name.startsWith(p))) continue;
-        userDeps.set(name, version);
-      }
+      const userDeps = getUserDependencies(allDeps, {
+        isDeno,
+        isCompiledBinary: isDeno && isCompiledBinary(),
+      });
 
       // Always externalize user npm dependencies. The bundled handler is loaded
       // from a temp file and user deps are resolved at runtime:
@@ -578,6 +573,23 @@ async function readFileWithExtensions(
       message: `File not found: ${basePath}`,
     }),
   );
+}
+
+export function getUserDependencies(
+  allDeps: ReadonlyMap<string, string>,
+  runtime: { isDeno: boolean; isCompiledBinary: boolean },
+): Map<string, string> {
+  const frameworkPackages = new Set(["veryfront", "react", "react-dom", "path"]);
+  if (runtime.isDeno && runtime.isCompiledBinary) frameworkPackages.add("zod");
+
+  const frameworkPrefixes = ["@opentelemetry/", "node:", "veryfront/"];
+  const userDeps = new Map<string, string>();
+  for (const [name, version] of allDeps) {
+    if (frameworkPackages.has(name)) continue;
+    if (frameworkPrefixes.some((prefix) => name.startsWith(prefix))) continue;
+    userDeps.set(name, version);
+  }
+  return userDeps;
 }
 
 async function loadModuleFromCode(


### PR DESCRIPTION
## Problem

An API route that imports a bare npm dependency — e.g. `import { z } from "zod"` in a `createValidatedHandler` route — **500s under the Deno source-run** instead of running. The handler is bundled to a temp `handler.mjs` and dynamic-imported, but `zod` was hard-coded into the framework-managed exclusion set (`loader.ts`), so it was dropped from `userDeps`. The Deno import rewriters only rewrite specifiers present in `userDeps`, so a bare `import "zod"` reached Deno → `Import "zod" not a dependency and not in import map` → the handler failed to load before its method check could return (e.g. 405).

The **Node** path was unaffected because `getNodeExternalPackagesToResolve` already always-resolves zod — so this only bit the Deno source-run.

## Fix

Keep `zod` as a user dependency on **Node** and the **Deno source-run**, so a handler's own zod import is rewritten to a resolvable specifier like any other npm dep. zod is still force-externalized (never bundled inline).

```ts
const frameworkPackages = new Set(["veryfront", "react", "react-dom", "path"]);
if (isDeno && isCompiledBinary()) frameworkPackages.add("zod"); // binary path unchanged
```

## Scope / what this does NOT cover

Scoped to **Node + Deno source-run**, where it is verified. The **compiled binary** keeps zod excluded and its API-handler branch is left **byte-identical** — the binary resolves framework helpers (`createValidatedHandler`, `MiddlewarePipeline`) through a separate per-subpath veryfront runtime-shim path, and wiring a user `zod` through it needs its own change with binary coverage. (Filed separately.)

## Verification (veryfront-router-testing @ main)

- `default-config` source-run: `GET /api/validated` → **405** (was 500); 124-route SSR sweep **0 mismatches** (was 1); **110/110** programmatic specs.
- `lib-interop` backend sweep: **30/30** API routes importing common npm libs (jose, luxon, stripe, axios, drizzle-orm, jsonwebtoken, bcryptjs, cheerio, ajv, mathjs, pino, validator, …) return `{"ok":true}`; full interop sweep **60/60**.
- Module-loader unit tests (`loader`, `external-import-rewriter`) green; `deno fmt`/`deno lint` clean.

## How to test
1. `cd default-config && deno run --allow-all <this-branch>/cli/main.ts dev --port 3010`
2. `curl -o /dev/null -w '%{http_code}' localhost:3010/api/validated` → `405`
3. Run `lib-interop` the same way and `node interop-sweep.mjs http://localhost:<port> lib-interop` → 60/60.