### PR TITLE
fix(binary): register veryfront/middleware for compiled-binary discovery (#217)

### DIFF
--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -28,6 +28,12 @@ export const DISCOVERY_GLOBAL_VERYFRONT_MODULES = [
   "veryfront/metrics",
   "veryfront/schemas",
   "veryfront/integrations",
+  // API-route middleware helpers (`import { MiddlewarePipeline, cors, … } from
+  // "veryfront/middleware"`). Without this, a compiled binary cannot register the
+  // module, so its per-subpath shim (`_vf_middleware.mjs`) is empty and any API
+  // route using the pipeline 500s with "does not provide an export named
+  // 'MiddlewarePipeline'". See veryfront-issue-inbox#217.
+  "veryfront/middleware",
   // Server-side chat upload route handler (app/api/uploads/route.ts).
   "veryfront/chat/uploads",
 ] as const;

--- a/src/discovery/runtime-modules-bootstrap.test.ts
+++ b/src/discovery/runtime-modules-bootstrap.test.ts
@@ -23,5 +23,13 @@ describe("compiled discovery runtime modules", () => {
         .createUploadHandler,
       "function",
     );
+    // veryfront-issue-inbox#217: API routes import the middleware pipeline from
+    // "veryfront/middleware"; a compiled binary must register it so the generated
+    // subpath shim re-exports MiddlewarePipeline instead of 500ing.
+    assertEquals(
+      typeof (modules["veryfront/middleware"] as { MiddlewarePipeline?: unknown })
+        .MiddlewarePipeline,
+      "function",
+    );
   });
 });

--- a/src/discovery/runtime-modules-bootstrap.ts
+++ b/src/discovery/runtime-modules-bootstrap.ts
@@ -10,6 +10,7 @@ import * as evalMod from "#veryfront/eval";
 import * as metricsMod from "#veryfront/metrics";
 import * as schemasMod from "#veryfront/schemas";
 import * as integrationsMod from "#veryfront/integrations/index.ts";
+import * as middlewareMod from "#veryfront/middleware";
 import * as chatUploadsMod from "#veryfront/chat/uploads";
 import { registerDiscoveryRuntimeModules } from "./runtime-modules.ts";
 
@@ -26,5 +27,6 @@ registerDiscoveryRuntimeModules({
   "veryfront/metrics": metricsMod,
   "veryfront/schemas": schemasMod,
   "veryfront/integrations": integrationsMod,
+  "veryfront/middleware": middlewareMod,
   "veryfront/chat/uploads": chatUploadsMod,
 });


### PR DESCRIPTION
## Problem

On a **compiled binary**, every API route that uses the middleware pipeline 500s:

```
SyntaxError: The requested module './_vf_middleware.mjs' does not provide an export named 'MiddlewarePipeline'
```

Affected: `/api/with-cors`, `/api/rewriting-cors`, `/api/mw-auth`, `/api/mw-timeout`, `/api/mw-usefor`, `/api/mw-execute`, `/api/mw-ratelimit`, `/api/mw-var`, `/api/mw-order`, `/api/mw-teardown`, `/api/imports/middleware` — 11 routes on the `default-config` gate.

## Root cause

For a compiled binary the API module-loader (`src/routing/api/module-loader/loader.ts`) writes a per-subpath ESM shim (`_vf_<subpath>.mjs`) next to the temp `handler.mjs`. `generateSubpathShim()` re-exports `Object.keys(globalThis.__vfModules[subpath])`, populated by `getDiscoveryRuntimeModules()`. `veryfront/middleware` was **not** in that registry (`DISCOVERY_GLOBAL_VERYFRONT_MODULES` + the bootstrap map), so its shim was empty → the static `import { MiddlewarePipeline }` failed.

Source-run is unaffected (it doesn't use shims), which is why this only showed on the binary.

## Fix

Register `veryfront/middleware` for compiled-binary discovery — add it to `DISCOVERY_GLOBAL_VERYFRONT_MODULES` and the `runtime-modules-bootstrap.ts` map. Two lines + a doc comment.

## Verification (per LOCALDEV.md)

Built the binary from this branch and ran the canonical `default-config` gate:

- **Before:** 124 routes, **12 SSR mismatches** (11 middleware/CORS + `/api/validated`).
- **After:** 124 routes, **1 SSR mismatch** — only `/api/validated`, which fails on bare-`zod` resolution in the binary (a separate, deeper issue tracked under #3105's binary follow-up), **not** the middleware shim.

The 11 middleware/CORS routes now return their correct codes (200 / 401 / 504), matching the source-run — binary and source are now at parity except `/api/validated`.

Added a regression assertion in `runtime-modules-bootstrap.test.ts` that `veryfront/middleware` registers `MiddlewarePipeline`.

Ref: veryfront-issue-inbox#217