### PR TITLE
fix(modules): resolve project-local .mjs in the dev module server (#219)

### DIFF
--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -331,6 +331,31 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     }
   });
 
+  it("serves a project-local generated .mjs module (Panda styled-system) — #219", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-mjs-module-" });
+    try {
+      await Deno.mkdir(`${projectDir}/styled-system/css`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/styled-system/css/index.mjs`,
+        `export function css() { return "panda-class"; }\n`,
+      );
+
+      // A page's relative import `../../styled-system/css/index.mjs` resolves in
+      // the browser to this /_vf_modules/ URL. Before #219 the resolver stripped
+      // the .mjs and never probed it back, so this 404'd and hydration failed.
+      const response = await serve(
+        new Request("http://localhost:3000/_vf_modules/styled-system/css/index.mjs"),
+        projectDir,
+      );
+
+      assertEquals(response.status, 200);
+      const text = await response.text();
+      assertStringIncludes(text, "css");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("should prefer project deno.js over the dnt-relative deno fallback", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-project-deno-module-" });
     try {

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -356,6 +356,53 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     }
   });
 
+  it("honors an explicit .mjs request before same-stem fallbacks", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-mjs-collision-" });
+    try {
+      await Deno.mkdir(`${projectDir}/styled-system/css`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/styled-system/css/index.js`,
+        `export const source = "js-fallback";\n`,
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/styled-system/css/index.mjs`,
+        `export const source = "mjs-explicit";\n`,
+      );
+
+      const response = await serve(
+        new Request("http://localhost:3000/_vf_modules/styled-system/css/index.mjs"),
+        projectDir,
+      );
+
+      assertEquals(response.status, 200);
+      const text = await response.text();
+      assertStringIncludes(text, "mjs-explicit");
+      assertEquals(text.includes("js-fallback"), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not serve CommonJS sources without browser conversion", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-cjs-module-" });
+    try {
+      await Deno.writeTextFile(
+        `${projectDir}/legacy.cjs`,
+        `module.exports = { source: "commonjs" };\n`,
+      );
+
+      const response = await serve(
+        new Request("http://localhost:3000/_vf_modules/legacy.cjs"),
+        projectDir,
+      );
+
+      assertEquals(response.status, 404);
+      assertEquals(await response.text(), "Module not found");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("should prefer project deno.js over the dnt-relative deno fallback", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-project-deno-module-" });
     try {

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -820,22 +820,21 @@ async function findSourceFile(
     ".ts",
     ".jsx",
     ".js",
-    ".mjs",
-    ".cjs", // Already-compiled ESM/CJS (e.g. Panda's generated styled-system/*.mjs)
+    ".mjs", // Already-compiled ESM (e.g. Panda's generated styled-system/*.mjs)
     ".mdx",
     ".md", // Regular sources
   ];
 
   logger.debug("findSourceFile called", { projectDir, basePath });
 
-  const knownExtMatch = basePath.match(/\.(json|tsx|ts|jsx|js|mjs|cjs|mdx|md)(\.src)?$/);
+  const knownExtMatch = basePath.match(/\.(json|tsx|ts|jsx|js|mjs|mdx|md)(\.src)?$/);
   const requestedExtMatch = requestedModulePath.match(
-    /\.(json|tsx|ts|jsx|js|mjs|cjs|mdx|md)(\.src)?$/,
+    /\.(json|tsx|ts|jsx|js|mjs|mdx|md)(\.src)?$/,
   );
   const hasKnownExt = knownExtMatch !== null;
   const requestedExt = requestedExtMatch?.[1] ?? knownExtMatch?.[1] ?? null;
   const rawBasePathWithoutExt = hasKnownExt
-    ? basePath.replace(/\.(json|tsx|ts|jsx|js|mjs|cjs|mdx|md)(\.src)?$/, "")
+    ? basePath.replace(/\.(json|tsx|ts|jsx|js|mjs|mdx|md)(\.src)?$/, "")
     : basePath;
   let basePathWithoutExt = rawBasePathWithoutExt.replace(/^\/+/, "");
   if (basePathWithoutExt.startsWith("_vf_modules/")) {
@@ -939,9 +938,12 @@ async function findSourceFile(
     }
   }
 
-  const projectLookupExtensions = requestedExt !== null && requestedExt !== "json"
+  const fallbackExtensions = requestedExt !== null && requestedExt !== "json"
     ? extensions.filter((ext) => ext !== ".json")
     : extensions;
+  const projectLookupExtensions = requestedExt === "mjs"
+    ? [".mjs", ...fallbackExtensions.filter((ext) => ext !== ".mjs")]
+    : fallbackExtensions;
 
   // Project file lookups (using secureFs which may go through FSAdapter in proxy mode)
   const projectFilePath = await findFirstExistingFile(

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -820,18 +820,22 @@ async function findSourceFile(
     ".ts",
     ".jsx",
     ".js",
+    ".mjs",
+    ".cjs", // Already-compiled ESM/CJS (e.g. Panda's generated styled-system/*.mjs)
     ".mdx",
     ".md", // Regular sources
   ];
 
   logger.debug("findSourceFile called", { projectDir, basePath });
 
-  const knownExtMatch = basePath.match(/\.(json|tsx|ts|jsx|js|mdx|md)(\.src)?$/);
-  const requestedExtMatch = requestedModulePath.match(/\.(json|tsx|ts|jsx|js|mdx|md)(\.src)?$/);
+  const knownExtMatch = basePath.match(/\.(json|tsx|ts|jsx|js|mjs|cjs|mdx|md)(\.src)?$/);
+  const requestedExtMatch = requestedModulePath.match(
+    /\.(json|tsx|ts|jsx|js|mjs|cjs|mdx|md)(\.src)?$/,
+  );
   const hasKnownExt = knownExtMatch !== null;
   const requestedExt = requestedExtMatch?.[1] ?? knownExtMatch?.[1] ?? null;
   const rawBasePathWithoutExt = hasKnownExt
-    ? basePath.replace(/\.(json|tsx|ts|jsx|js|mdx|md)(\.src)?$/, "")
+    ? basePath.replace(/\.(json|tsx|ts|jsx|js|mjs|cjs|mdx|md)(\.src)?$/, "")
     : basePath;
   let basePathWithoutExt = rawBasePathWithoutExt.replace(/^\/+/, "");
   if (basePathWithoutExt.startsWith("_vf_modules/")) {


### PR DESCRIPTION
## Problem

A page that imports a generated local ESM file by relative path, such as `../../styled-system/css/index.mjs`, renders on the server but fails to hydrate. The browser requests `/_vf_modules/styled-system/css/index.mjs`, and the dev module server returns 404.

## Root cause

`findSourceFile` strips the requested extension and probes a fallback list. That list did not contain `.mjs`. Adding `.mjs` only as a fallback was also insufficient because a same-stem `.js` or `.ts` file could win before the explicitly requested `.mjs` file.

The browser transform path does not convert CommonJS to ESM, so serving `.cjs` from this path would expose CommonJS syntax to the browser.

## Fix

- Resolve project-local `.mjs` files.
- Prioritize `.mjs` when the request explicitly ends in `.mjs`.
- Keep `.cjs` outside this browser module path until a CommonJS-to-ESM conversion exists.

## Verification

- Added a same-stem `.js` and `.mjs` collision regression. An explicit `.mjs` request returns the `.mjs` source.
- Added a CommonJS regression using `module.exports`. A `.cjs` request returns 404 instead of serving unconverted CommonJS.
- Focused module server tests: 3 passed, 56 steps, 0 failed.
- Full pre-push gate: 2,680 passed, 21,765 steps, 0 failed.

Ref: veryfront-issue-inbox#219