### PR TITLE
Accept safe .md aliases when loading skills

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1147",
+  "version": "0.1.1148",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -205,6 +205,10 @@ Deno.test("createRuntimeLoadSkillTool normalizes .md aliases without a known ski
     builtinStore: createBuiltinStore({}),
   });
 
+  assertStringIncludes(
+    JSON.stringify(tool.inputSchemaJson),
+    'A lowercase \\".md\\" suffix is accepted',
+  );
   const result = expectLoadedSkillResponse(await tool.execute({ skillId: "plan.md" }));
   const reload = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
 

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -135,6 +135,58 @@ Deno.test("createRuntimeLoadSkillTool accepts a lowercase .md skill alias at the
   assertStringIncludes(reload.instructions, 'Skill "plan" is already loaded');
 });
 
+Deno.test("createRuntimeLoadSkillTool preserves canonical .md skill IDs", async () => {
+  const loaderCalls: string[] = [];
+  const tool = createRuntimeLoadSkillTool({
+    context: createProjectContext({
+      availableSkillIds: ["plan", "plan.md"],
+    }),
+    skillsDir: "/skills",
+    projectSkillLoader: {
+      listProjectSkillReferences: () => Promise.resolve([]),
+      loadProjectSkill: (_context, skillId) => {
+        loaderCalls.push(skillId);
+        return Promise.resolve({
+          skillId,
+          instructions: `# ${skillId}`,
+          references: [],
+        });
+      },
+      loadProjectSkillReference: () => Promise.resolve(null),
+    },
+    builtinStore: createBuiltinStore({}),
+  });
+
+  assertEquals(tool.inputSchemaJson, {
+    type: "object",
+    properties: {
+      skillId: {
+        type: "string",
+        enum: ["plan", "plan.md"],
+        description: "Unloaded skill ID to load. Available unloaded skill IDs: plan, plan.md",
+      },
+      file: {
+        type: "string",
+        description:
+          "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
+      },
+    },
+    required: ["skillId"],
+  });
+
+  const markdownNamed = expectLoadedSkillResponse(await tool.execute({ skillId: "plan.md" }));
+  const extensionless = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
+
+  assertEquals(markdownNamed.skillId, "plan.md");
+  assertEquals(extensionless.skillId, "plan");
+  assertEquals(loaderCalls, ["plan.md", "plan"]);
+  await assertRejects(
+    () => tool.execute({ skillId: "plan.md.md" }),
+    Error,
+    "input validation failed",
+  );
+});
+
 Deno.test("createRuntimeLoadSkillTool normalizes .md aliases without a known skill manifest", async () => {
   const loaderCalls: string[] = [];
   const tool = createRuntimeLoadSkillTool({

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -394,7 +394,7 @@ Deno.test("createRuntimeLoadSkillTool schema disallows body reloads for already-
           skillId: {
             type: "string",
             enum: ["plan", "plan.md"],
-            description: "Unloaded skill ID to load. Available unloaded skill IDs: plan",
+            description: "Unloaded skill ID to load. Available unloaded skill IDs: plan, plan.md",
           },
           file: {
             type: "string",
@@ -411,7 +411,7 @@ Deno.test("createRuntimeLoadSkillTool schema disallows body reloads for already-
             type: "string",
             enum: ["veryfront", "veryfront.md"],
             description:
-              "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront",
+              "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront, veryfront.md",
           },
           file: {
             type: "string",
@@ -451,7 +451,8 @@ Deno.test("createRuntimeLoadSkillTool refreshes its provider schema after a skil
       skillId: {
         type: "string",
         enum: ["veryfront", "veryfront.md"],
-        description: "Unloaded skill ID to load. Available unloaded skill IDs: veryfront",
+        description:
+          "Unloaded skill ID to load. Available unloaded skill IDs: veryfront, veryfront.md",
       },
       file: {
         type: "string",
@@ -472,7 +473,7 @@ Deno.test("createRuntimeLoadSkillTool refreshes its provider schema after a skil
         type: "string",
         enum: ["veryfront", "veryfront.md"],
         description:
-          "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront",
+          "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront, veryfront.md",
       },
       file: {
         type: "string",
@@ -511,7 +512,7 @@ Deno.test("createRuntimeLoadSkillTool schema only permits reference loads when a
         type: "string",
         enum: ["veryfront", "veryfront.md"],
         description:
-          "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront",
+          "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront, veryfront.md",
       },
       file: {
         type: "string",
@@ -556,7 +557,7 @@ Deno.test("createRuntimeLoadSkillTool exposes a no-file no-op schema after loadi
         type: "string",
         enum: ["veryfront", "veryfront.md"],
         description:
-          "Already-loaded skill ID with no advertised reference files. Calling load_skill again is a no-op. Loaded skill IDs: veryfront",
+          "Already-loaded skill ID with no advertised reference files. Calling load_skill again is a no-op. Loaded skill IDs: veryfront, veryfront.md",
       },
     },
     required: ["skillId"],
@@ -603,7 +604,7 @@ Deno.test("createRuntimeLoadSkillTool exposes only referenceable skills when eve
         type: "string",
         enum: ["with-reference", "with-reference.md"],
         description:
-          "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: with-reference",
+          "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: with-reference, with-reference.md",
       },
       file: {
         type: "string",
@@ -649,7 +650,8 @@ Deno.test("createRuntimeLoadSkillTool omits loaded skills without references fro
           skillId: {
             type: "string",
             enum: ["create", "create.md"],
-            description: "Unloaded skill ID to load. Available unloaded skill IDs: create",
+            description:
+              "Unloaded skill ID to load. Available unloaded skill IDs: create, create.md",
           },
           file: {
             type: "string",
@@ -666,7 +668,7 @@ Deno.test("createRuntimeLoadSkillTool omits loaded skills without references fro
             type: "string",
             enum: ["with-reference", "with-reference.md"],
             description:
-              "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: with-reference",
+              "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: with-reference, with-reference.md",
           },
           file: {
             type: "string",
@@ -717,7 +719,8 @@ Deno.test("createRuntimeLoadSkillTool schema ignores stale loaded skills outside
       skillId: {
         type: "string",
         enum: ["veryfront", "veryfront.md"],
-        description: "Unloaded skill ID to load. Available unloaded skill IDs: veryfront",
+        description:
+          "Unloaded skill ID to load. Available unloaded skill IDs: veryfront, veryfront.md",
       },
       file: {
         type: "string",

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -135,6 +135,39 @@ Deno.test("createRuntimeLoadSkillTool accepts a lowercase .md skill alias at the
   assertStringIncludes(reload.instructions, 'Skill "plan" is already loaded');
 });
 
+Deno.test("createRuntimeLoadSkillTool normalizes .md aliases without a known skill manifest", async () => {
+  const loaderCalls: string[] = [];
+  const tool = createRuntimeLoadSkillTool({
+    context: createProjectContext(),
+    skillsDir: "/skills",
+    projectSkillLoader: {
+      listProjectSkillReferences: () => Promise.resolve([]),
+      loadProjectSkill: (_context, skillId) => {
+        loaderCalls.push(skillId);
+        return Promise.resolve(
+          skillId === "plan" ? { instructions: "# Project plan", references: [] } : null,
+        );
+      },
+      loadProjectSkillReference: () => Promise.resolve(null),
+    },
+    builtinStore: createBuiltinStore({}),
+  });
+
+  const result = expectLoadedSkillResponse(await tool.execute({ skillId: "plan.md" }));
+  const reload = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
+
+  assertEquals(result.skillId, "plan");
+  assertEquals(loaderCalls, ["plan"]);
+  assertStringIncludes(reload.instructions, 'Skill "plan" is already loaded');
+  for (const invalidSkillId of ["plan.md.md", "plan.MD", "bad/path.md"]) {
+    await assertRejects(
+      () => tool.execute({ skillId: invalidSkillId }),
+      Error,
+      "input validation failed",
+    );
+  }
+});
+
 Deno.test("createRuntimeLoadSkillTool falls back to builtin skills and filters allowed tools", async () => {
   const tool = createRuntimeLoadSkillTool({
     context: createProjectContext({

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -100,6 +100,41 @@ Deno.test("createRuntimeLoadSkillTool loads project skills before builtin skills
   });
 });
 
+Deno.test("createRuntimeLoadSkillTool accepts a lowercase .md skill alias at the boundary", async () => {
+  const loaderCalls: string[] = [];
+  const context = createProjectContext({
+    availableSkillIds: ["plan"],
+  });
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: {
+      listProjectSkillReferences: (_context, skillId) =>
+        Promise.resolve(
+          skillId === "plan" ? ["references/project.md"] : [],
+        ),
+      loadProjectSkill: (_context, skillId) => {
+        loaderCalls.push(skillId);
+        return Promise.resolve(
+          skillId === "plan"
+            ? { skillId: "plan", instructions: "# Project plan", references: [] }
+            : null,
+        );
+      },
+      loadProjectSkillReference: (_context, skillId, normalizedFile) =>
+        Promise.resolve(`${skillId}/${normalizedFile}`),
+    },
+    builtinStore: createBuiltinStore({}),
+  });
+
+  const result = expectLoadedSkillResponse(await tool.execute({ skillId: "plan.md" }));
+  const reload = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
+
+  assertEquals(result.skillId, "plan");
+  assertEquals(loaderCalls, ["plan"]);
+  assertStringIncludes(reload.instructions, 'Skill "plan" is already loaded');
+});
+
 Deno.test("createRuntimeLoadSkillTool falls back to builtin skills and filters allowed tools", async () => {
   const tool = createRuntimeLoadSkillTool({
     context: createProjectContext({
@@ -269,7 +304,7 @@ Deno.test("createRuntimeLoadSkillTool schema disallows body reloads for already-
         properties: {
           skillId: {
             type: "string",
-            enum: ["plan"],
+            enum: ["plan", "plan.md"],
             description: "Unloaded skill ID to load. Available unloaded skill IDs: plan",
           },
           file: {
@@ -285,7 +320,7 @@ Deno.test("createRuntimeLoadSkillTool schema disallows body reloads for already-
         properties: {
           skillId: {
             type: "string",
-            enum: ["veryfront"],
+            enum: ["veryfront", "veryfront.md"],
             description:
               "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront",
           },
@@ -326,7 +361,7 @@ Deno.test("createRuntimeLoadSkillTool refreshes its provider schema after a skil
     properties: {
       skillId: {
         type: "string",
-        enum: ["veryfront"],
+        enum: ["veryfront", "veryfront.md"],
         description: "Unloaded skill ID to load. Available unloaded skill IDs: veryfront",
       },
       file: {
@@ -346,7 +381,7 @@ Deno.test("createRuntimeLoadSkillTool refreshes its provider schema after a skil
     properties: {
       skillId: {
         type: "string",
-        enum: ["veryfront"],
+        enum: ["veryfront", "veryfront.md"],
         description:
           "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront",
       },
@@ -385,7 +420,7 @@ Deno.test("createRuntimeLoadSkillTool schema only permits reference loads when a
     properties: {
       skillId: {
         type: "string",
-        enum: ["veryfront"],
+        enum: ["veryfront", "veryfront.md"],
         description:
           "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront",
       },
@@ -430,7 +465,7 @@ Deno.test("createRuntimeLoadSkillTool exposes a no-file no-op schema after loadi
     properties: {
       skillId: {
         type: "string",
-        enum: ["veryfront"],
+        enum: ["veryfront", "veryfront.md"],
         description:
           "Already-loaded skill ID with no advertised reference files. Calling load_skill again is a no-op. Loaded skill IDs: veryfront",
       },
@@ -477,7 +512,7 @@ Deno.test("createRuntimeLoadSkillTool exposes only referenceable skills when eve
     properties: {
       skillId: {
         type: "string",
-        enum: ["with-reference"],
+        enum: ["with-reference", "with-reference.md"],
         description:
           "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: with-reference",
       },
@@ -524,7 +559,7 @@ Deno.test("createRuntimeLoadSkillTool omits loaded skills without references fro
         properties: {
           skillId: {
             type: "string",
-            enum: ["create"],
+            enum: ["create", "create.md"],
             description: "Unloaded skill ID to load. Available unloaded skill IDs: create",
           },
           file: {
@@ -540,7 +575,7 @@ Deno.test("createRuntimeLoadSkillTool omits loaded skills without references fro
         properties: {
           skillId: {
             type: "string",
-            enum: ["with-reference"],
+            enum: ["with-reference", "with-reference.md"],
             description:
               "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: with-reference",
           },
@@ -592,7 +627,7 @@ Deno.test("createRuntimeLoadSkillTool schema ignores stale loaded skills outside
     properties: {
       skillId: {
         type: "string",
-        enum: ["veryfront"],
+        enum: ["veryfront", "veryfront.md"],
         description: "Unloaded skill ID to load. Available unloaded skill IDs: veryfront",
       },
       file: {
@@ -890,6 +925,21 @@ Deno.test("createRuntimeLoadSkillTool rejects unsafe and unknown manifest skill 
     Error,
     "input validation failed",
   );
+  for (
+    const invalidSkillId of [
+      "plan.md.md",
+      "bad/path.md",
+      "..",
+      "plan.mdx",
+      "plan.MD",
+    ]
+  ) {
+    await assertRejects(
+      () => tool.execute({ skillId: invalidSkillId }),
+      Error,
+      "input validation failed",
+    );
+  }
 });
 
 Deno.test("createRuntimeLoadSkillTool advertises the runtime skill manifest instead of inviting invented skill IDs", () => {

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -144,7 +144,9 @@ export const getRuntimeLoadSkillToolInputSchema = defineSchema((v) =>
         /^[a-zA-Z0-9_-]+(?:\.md)?$/,
         'skillId must contain only letters, numbers, "_" or "-", with an optional lowercase ".md" suffix',
       )
-      .describe('The skill ID to load (e.g., "react-components", "api-design")'),
+      .describe(
+        'The skill ID to load. A lowercase ".md" suffix is accepted when it is the canonical ID or an unambiguous alias (e.g., "react-components" or "react-components.md").',
+      ),
     file: v.string().optional().describe(
       "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
     ),
@@ -353,7 +355,7 @@ function getReferenceableLoadedRuntimeSkillIds(
 }
 
 function getRuntimeSkillIdInputValues(
-  skillIds: readonly string[],
+  skillIds: readonly [string, ...string[]],
   knownSkillIds: readonly string[],
 ): [string, ...string[]] {
   const knownSkillIdSet = new Set(knownSkillIds);

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -352,13 +352,33 @@ function getReferenceableLoadedRuntimeSkillIds(
   ].sort();
 }
 
-function getRuntimeSkillIdInputValues(skillIds: readonly string[]): [string, ...string[]] {
-  const values = skillIds.flatMap((skillId) => [skillId, `${skillId}.md`]);
+function getRuntimeSkillIdInputValues(
+  skillIds: readonly string[],
+  knownSkillIds: readonly string[],
+): [string, ...string[]] {
+  const knownSkillIdSet = new Set(knownSkillIds);
+  const values = skillIds.flatMap((skillId) => {
+    const alias = `${skillId}.md`;
+    return skillId.endsWith(".md") || knownSkillIdSet.has(alias) ? [skillId] : [skillId, alias];
+  });
   return values as [string, ...string[]];
 }
 
-function normalizeRuntimeLoadSkillInputSkillId(skillId: string): string {
-  return skillId.endsWith(".md") ? skillId.slice(0, -3) : skillId;
+function normalizeRuntimeLoadSkillInputSkillId(
+  options: RuntimeLoadSkillToolOptions,
+  skillId: string,
+): string {
+  const knownSkillIds = getKnownRuntimeSkillIds(options);
+  if (knownSkillIds?.includes(skillId)) {
+    return skillId;
+  }
+
+  const aliasTarget = skillId.endsWith(".md") ? skillId.slice(0, -3) : null;
+  if (aliasTarget && (!knownSkillIds || knownSkillIds.includes(aliasTarget))) {
+    return aliasTarget;
+  }
+
+  return skillId;
 }
 
 function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) {
@@ -378,7 +398,10 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
     loadedIds.length > 0 && unloadedIds.length === 0 && referenceableLoadedIds.length === 0
   ) {
     const [firstLoaded, ...restLoaded] = loadedIds as [string, ...string[]];
-    const loadedEnumValues = getRuntimeSkillIdInputValues([firstLoaded, ...restLoaded]);
+    const loadedEnumValues = getRuntimeSkillIdInputValues(
+      [firstLoaded, ...restLoaded],
+      knownIds,
+    );
     return defineSchema((v) =>
       v.object({
         skillId: v.enum(loadedEnumValues).describe(
@@ -392,7 +415,10 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
 
   if (referenceableLoadedIds.length > 0 && unloadedIds.length === 0) {
     const [firstLoaded, ...restLoaded] = referenceableLoadedIds as [string, ...string[]];
-    const loadedEnumValues = getRuntimeSkillIdInputValues([firstLoaded, ...restLoaded]);
+    const loadedEnumValues = getRuntimeSkillIdInputValues(
+      [firstLoaded, ...restLoaded],
+      knownIds,
+    );
     return defineSchema((v) =>
       v.object({
         skillId: v.enum(loadedEnumValues).describe(
@@ -409,9 +435,15 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
 
   if (referenceableLoadedIds.length > 0) {
     const [firstUnloaded, ...restUnloaded] = unloadedIds as [string, ...string[]];
-    const unloadedEnumValues = getRuntimeSkillIdInputValues([firstUnloaded, ...restUnloaded]);
+    const unloadedEnumValues = getRuntimeSkillIdInputValues(
+      [firstUnloaded, ...restUnloaded],
+      knownIds,
+    );
     const [firstLoaded, ...restLoaded] = referenceableLoadedIds as [string, ...string[]];
-    const loadedEnumValues = getRuntimeSkillIdInputValues([firstLoaded, ...restLoaded]);
+    const loadedEnumValues = getRuntimeSkillIdInputValues(
+      [firstLoaded, ...restLoaded],
+      knownIds,
+    );
     return defineSchema((v) =>
       v.union([
         v.object({
@@ -437,7 +469,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
   }
 
   const [first, ...rest] = unloadedIds as [string, ...string[]];
-  const enumValues = getRuntimeSkillIdInputValues([first, ...rest]);
+  const enumValues = getRuntimeSkillIdInputValues([first, ...rest], knownIds);
   return defineSchema((v) =>
     v.object({
       skillId: v.enum(enumValues).describe(
@@ -541,7 +573,7 @@ export function createRuntimeLoadSkillTool(
         }`,
       });
     }
-    skillId = normalizeRuntimeLoadSkillInputSkillId(parsed.skillId);
+    skillId = normalizeRuntimeLoadSkillInputSkillId(options, parsed.skillId);
     file = parsed.file;
 
     if (file) {

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -408,7 +408,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
       v.object({
         skillId: v.enum(loadedEnumValues).describe(
           `Already-loaded skill ID with no advertised reference files. Calling load_skill again is a no-op. Loaded skill IDs: ${
-            loadedIds.join(", ")
+            loadedEnumValues.join(", ")
           }`,
         ),
       }).strict()
@@ -425,7 +425,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
       v.object({
         skillId: v.enum(loadedEnumValues).describe(
           `Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: ${
-            referenceableLoadedIds.join(", ")
+            loadedEnumValues.join(", ")
           }`,
         ),
         file: v.string().describe(
@@ -450,7 +450,9 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
       v.union([
         v.object({
           skillId: v.enum(unloadedEnumValues).describe(
-            `Unloaded skill ID to load. Available unloaded skill IDs: ${unloadedIds.join(", ")}`,
+            `Unloaded skill ID to load. Available unloaded skill IDs: ${
+              unloadedEnumValues.join(", ")
+            }`,
           ),
           file: v.string().optional().describe(
             "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
@@ -459,7 +461,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
         v.object({
           skillId: v.enum(loadedEnumValues).describe(
             `Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: ${
-              referenceableLoadedIds.join(", ")
+              loadedEnumValues.join(", ")
             }`,
           ),
           file: v.string().describe(
@@ -475,7 +477,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
   return defineSchema((v) =>
     v.object({
       skillId: v.enum(enumValues).describe(
-        `Unloaded skill ID to load. Available unloaded skill IDs: ${unloadedIds.join(", ")}`,
+        `Unloaded skill ID to load. Available unloaded skill IDs: ${enumValues.join(", ")}`,
       ),
       file: v.string().optional().describe(
         "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -140,7 +140,10 @@ export type RuntimeLoadSkillToolOptions = {
 export const getRuntimeLoadSkillToolInputSchema = defineSchema((v) =>
   v.object({
     skillId: v.string()
-      .regex(/^[a-zA-Z0-9_-]+$/, 'skillId must contain only letters, numbers, "_" or "-"')
+      .regex(
+        /^[a-zA-Z0-9_-]+(?:\.md)?$/,
+        'skillId must contain only letters, numbers, "_" or "-", with an optional lowercase ".md" suffix',
+      )
       .describe('The skill ID to load (e.g., "react-components", "api-design")'),
     file: v.string().optional().describe(
       "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
@@ -349,6 +352,15 @@ function getReferenceableLoadedRuntimeSkillIds(
   ].sort();
 }
 
+function getRuntimeSkillIdInputValues(skillIds: readonly string[]): [string, ...string[]] {
+  const values = skillIds.flatMap((skillId) => [skillId, `${skillId}.md`]);
+  return values as [string, ...string[]];
+}
+
+function normalizeRuntimeLoadSkillInputSkillId(skillId: string): string {
+  return skillId.endsWith(".md") ? skillId.slice(0, -3) : skillId;
+}
+
 function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) {
   const knownIds = getKnownRuntimeSkillIds(options);
   if (!knownIds || knownIds.length === 0) {
@@ -366,7 +378,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
     loadedIds.length > 0 && unloadedIds.length === 0 && referenceableLoadedIds.length === 0
   ) {
     const [firstLoaded, ...restLoaded] = loadedIds as [string, ...string[]];
-    const loadedEnumValues = [firstLoaded, ...restLoaded] as [string, ...string[]];
+    const loadedEnumValues = getRuntimeSkillIdInputValues([firstLoaded, ...restLoaded]);
     return defineSchema((v) =>
       v.object({
         skillId: v.enum(loadedEnumValues).describe(
@@ -380,7 +392,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
 
   if (referenceableLoadedIds.length > 0 && unloadedIds.length === 0) {
     const [firstLoaded, ...restLoaded] = referenceableLoadedIds as [string, ...string[]];
-    const loadedEnumValues = [firstLoaded, ...restLoaded] as [string, ...string[]];
+    const loadedEnumValues = getRuntimeSkillIdInputValues([firstLoaded, ...restLoaded]);
     return defineSchema((v) =>
       v.object({
         skillId: v.enum(loadedEnumValues).describe(
@@ -397,9 +409,9 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
 
   if (referenceableLoadedIds.length > 0) {
     const [firstUnloaded, ...restUnloaded] = unloadedIds as [string, ...string[]];
-    const unloadedEnumValues = [firstUnloaded, ...restUnloaded] as [string, ...string[]];
+    const unloadedEnumValues = getRuntimeSkillIdInputValues([firstUnloaded, ...restUnloaded]);
     const [firstLoaded, ...restLoaded] = referenceableLoadedIds as [string, ...string[]];
-    const loadedEnumValues = [firstLoaded, ...restLoaded] as [string, ...string[]];
+    const loadedEnumValues = getRuntimeSkillIdInputValues([firstLoaded, ...restLoaded]);
     return defineSchema((v) =>
       v.union([
         v.object({
@@ -425,7 +437,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
   }
 
   const [first, ...rest] = unloadedIds as [string, ...string[]];
-  const enumValues = [first, ...rest] as [string, ...string[]];
+  const enumValues = getRuntimeSkillIdInputValues([first, ...rest]);
   return defineSchema((v) =>
     v.object({
       skillId: v.enum(enumValues).describe(
@@ -529,7 +541,7 @@ export function createRuntimeLoadSkillTool(
         }`,
       });
     }
-    skillId = parsed.skillId;
+    skillId = normalizeRuntimeLoadSkillInputSkillId(parsed.skillId);
     file = parsed.file;
 
     if (file) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1147";
+export const VERSION = "0.1.1148";


### PR DESCRIPTION
## Summary
- accept exactly one lowercase `.md` suffix at the `load_skill` boundary
- preserve canonical IDs that already end in `.md` and suppress ambiguous aliases
- advertise canonical IDs and safe `.md` aliases in dynamic provider schemas
- derive provider descriptions from the same accepted enum values used for validation
- validate raw input before normalization and reject repeated suffixes, paths, `.mdx`, and uppercase `.MD`
- bump Veryfront to `0.1.1148`

## Verification
- `deno test -A src/agent/runtime/load-skill-tool.test.ts` (27 passed)
- `deno task verify:quick`
- full pre-push: 2,683 tests / 21,796 steps, zero failures

This fixes model calls such as `load_skill({ skillId: "create-agent.md" })` while keeping canonical skill identity unambiguous.