### PR TITLE
fix(ssr): scope layout routing to the resolved page

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1149",
+  "version": "0.1.1150",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/rendering/layouts/layout-applicator.test.ts
+++ b/src/rendering/layouts/layout-applicator.test.ts
@@ -11,12 +11,6 @@ import {
   resetReactCache,
 } from "#veryfront/react/compat/ssr-adapter/server-loader.ts";
 
-function isDotPath(pageFilePath: string): boolean {
-  return pageFilePath
-    .split("/")
-    .some((segment) => segment.startsWith(".") && segment !== "." && segment !== "..");
-}
-
 function buildSSRRouter(
   requestUrl: URL | undefined,
   pageFilePath: string,
@@ -87,30 +81,6 @@ describe("LayoutApplicator helpers", () => {
   afterEach(() => {
     resetReactCache();
     __setServerModuleLoaderForTests(null);
-  });
-
-  describe("isDotPath", () => {
-    it("should detect .veryfront paths", () => {
-      assertEquals(isDotPath("/project/.veryfront/chat/page.tsx"), true);
-    });
-
-    it("should detect hidden directory paths", () => {
-      assertEquals(isDotPath("/project/.hidden/page.tsx"), true);
-    });
-
-    it("should not flag normal paths", () => {
-      assertEquals(isDotPath("/project/pages/about.tsx"), false);
-      assertEquals(isDotPath("/project/app/blog/page.tsx"), false);
-    });
-
-    it("should not flag . or .. segments", () => {
-      assertEquals(isDotPath("./relative/path.tsx"), false);
-      assertEquals(isDotPath("../parent/path.tsx"), false);
-    });
-
-    it("should handle root-level dot paths", () => {
-      assertEquals(isDotPath(".config/page.tsx"), true);
-    });
   });
 
   describe("buildSSRRouter", () => {

--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -19,7 +19,7 @@ import {
   createErrorBoundary,
   tryLoadReservedInDirs,
 } from "../app-reserved.ts";
-import { detectAppRouter } from "../router-detection.ts";
+import { resolveRouterModeForPage } from "../router-detection.ts";
 import { getProjectReact } from "#veryfront/react";
 import { extract } from "#std/front-matter/yaml.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
@@ -151,16 +151,20 @@ export class LayoutApplicator {
           );
         }
 
-        const useAppRouter = await detectAppRouter(this.projectDir, this.config, this.adapter, {
-          projectId: this.projectId,
-        });
         const pageFilePath = pageInfo.entity.path;
+        const routerMode = await resolveRouterModeForPage(
+          this.projectDir,
+          pageFilePath,
+          this.config,
+          this.adapter,
+          { projectId: this.projectId },
+        );
 
         const isDotPath = pageFilePath
           .split("/")
           .some((s) => s.startsWith(".") && s !== "." && s !== "..");
 
-        if (useAppRouter) {
+        if (routerMode === "app") {
           wrappedElement = await this.wrapWithReservedComponents(wrappedElement, pageFilePath);
         } else if (isDotPath) {
           logger.debug("Skipping wrapWithAppComponent - dot-prefixed path");

--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -27,6 +27,7 @@ import { resolveFrameworkSourcePath } from "#veryfront/platform/compat/framework
 import { loadModuleFromSource } from "#veryfront/modules/react-loader/index.ts";
 import { resolveProjectReactVersion } from "#veryfront/transforms/esm/package-registry.ts";
 import { CLIENT_PAGE_ISLAND_ID } from "#veryfront/rendering/rsc/page-island.ts";
+import { isDotPath } from "../orchestrator/path-helpers.ts";
 
 const logger = rendererLogger.component("layout-applicator");
 
@@ -158,13 +159,15 @@ export class LayoutApplicator {
           this.config,
         );
 
-        const isDotPath = pageFilePath
-          .split("/")
-          .some((s) => s.startsWith(".") && s !== "." && s !== "..");
+        const dotPath = isDotPath({
+          slug: pageInfo.entity.slug ?? "",
+          filePath: pageFilePath,
+          projectDir: this.projectDir,
+        });
 
         if (routerMode === "app") {
           wrappedElement = await this.wrapWithReservedComponents(wrappedElement, pageFilePath);
-        } else if (isDotPath) {
+        } else if (dotPath) {
           logger.debug("Skipping wrapWithAppComponent - dot-prefixed path");
         } else {
           wrappedElement = await this.wrapWithAppComponent(wrappedElement);

--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -152,12 +152,10 @@ export class LayoutApplicator {
         }
 
         const pageFilePath = pageInfo.entity.path;
-        const routerMode = await resolveRouterModeForPage(
+        const routerMode = resolveRouterModeForPage(
           this.projectDir,
           pageFilePath,
           this.config,
-          this.adapter,
-          { projectId: this.projectId },
         );
 
         const isDotPath = pageFilePath

--- a/src/rendering/layouts/layout-collector.ts
+++ b/src/rendering/layouts/layout-collector.ts
@@ -1,11 +1,11 @@
-import { join } from "#veryfront/compat/path";
+import { isAbsolute, join, normalize } from "#veryfront/compat/path";
 import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { EntityInfo, LayoutItem, MdxBundle } from "#veryfront/types";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { getLayoutEntity } from "#veryfront/types/entities/getEntityInfo.ts";
 import { discoverNestedLayouts } from "./utils/discovery.ts";
-import { detectAppRouter } from "../router-detection.ts";
+import { resolveRouterModeForPage } from "../router-detection.ts";
 import { LAYOUT_EXTENSIONS, type LayoutExtension } from "./types.ts";
 import { SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
@@ -22,6 +22,12 @@ export function resolveLayoutRouterRootDir(
     ? config.directories?.app ?? "app"
     : config.directories?.pages ?? "pages";
   return join(projectDir, directory);
+}
+
+function resolvePagePath(pageFilePath: string, projectDir: string): string {
+  return normalize(
+    isAbsolute(pageFilePath) ? pageFilePath : join(projectDir, pageFilePath),
+  );
 }
 
 function getLayoutKind(path: string): "mdx" | "tsx" {
@@ -316,29 +322,29 @@ export class LayoutCollector {
   }
 
   private async collectNestedLayouts(pageInfo: EntityInfo): Promise<LayoutItem[]> {
-    const pageFilePath = pageInfo.entity.path;
-    const useAppRouter = await detectAppRouter(this.projectDir, this.config, this.adapter, {
-      projectId: this.projectId,
-    });
+    const pageFilePath = resolvePagePath(pageInfo.entity.path, this.projectDir);
+    const routerMode = await resolveRouterModeForPage(
+      this.projectDir,
+      pageInfo.entity.path,
+      this.config,
+      this.adapter,
+      { projectId: this.projectId },
+    );
+    const rootDir = resolveLayoutRouterRootDir(
+      this.projectDir,
+      routerMode === "app",
+      this.config,
+    );
 
-    // Unified path for ALL adapters - discoverNestedLayouts uses adapter.fs.stat()
-    // which works for both filesystem and API adapters
-    return this.collectLayoutsUnified(pageFilePath, useAppRouter);
+    return this.collectLayoutsUnified(pageFilePath, rootDir);
   }
 
   private async collectLayoutsUnified(
     pageFilePath: string,
-    useAppRouter: boolean,
+    rootDir: string,
   ): Promise<LayoutItem[]> {
-    const rootDir = resolveLayoutRouterRootDir(
-      this.projectDir,
-      useAppRouter,
-      this.config,
-    );
-
     logger.debug("collectLayoutsUnified", {
       pageFilePath,
-      useAppRouter,
       rootDir,
       projectDir: this.projectDir,
     });

--- a/src/rendering/layouts/layout-collector.ts
+++ b/src/rendering/layouts/layout-collector.ts
@@ -323,12 +323,10 @@ export class LayoutCollector {
 
   private async collectNestedLayouts(pageInfo: EntityInfo): Promise<LayoutItem[]> {
     const pageFilePath = resolvePagePath(pageInfo.entity.path, this.projectDir);
-    const routerMode = await resolveRouterModeForPage(
+    const routerMode = resolveRouterModeForPage(
       this.projectDir,
       pageInfo.entity.path,
       this.config,
-      this.adapter,
-      { projectId: this.projectId },
     );
     const rootDir = resolveLayoutRouterRootDir(
       this.projectDir,

--- a/src/rendering/orchestrator/path-helpers.test.ts
+++ b/src/rendering/orchestrator/path-helpers.test.ts
@@ -70,6 +70,17 @@ describe("path-helpers", () => {
       );
     });
 
+    it("ignores absolute file paths outside the project", () => {
+      assertEquals(
+        isDotPath({
+          slug: "chat",
+          filePath: "/repo/.worktrees/another-project/pages/chat/index.tsx",
+          projectDir: "/repo/project",
+        }),
+        false,
+      );
+    });
+
     it("returns false for paths with . or ..", () => {
       assertEquals(isDotPath({ slug: "./relative", projectDir: "/project" }), false);
       assertEquals(isDotPath({ slug: "../parent", projectDir: "/project" }), false);

--- a/src/rendering/orchestrator/path-helpers.test.ts
+++ b/src/rendering/orchestrator/path-helpers.test.ts
@@ -25,23 +25,54 @@ describe("path-helpers", () => {
 
   describe("isDotPath", () => {
     it("returns true for slugs with hidden segments", () => {
-      assertEquals(isDotPath(".veryfront/config"), true);
-      assertEquals(isDotPath("pages/.hidden/secret"), true);
+      assertEquals(isDotPath({ slug: ".veryfront/config", projectDir: "/project" }), true);
+      assertEquals(isDotPath({ slug: "pages/.hidden/secret", projectDir: "/project" }), true);
     });
 
     it("returns false for normal slugs", () => {
-      assertEquals(isDotPath("app/page"), false);
-      assertEquals(isDotPath("pages/index"), false);
+      assertEquals(isDotPath({ slug: "app/page", projectDir: "/project" }), false);
+      assertEquals(isDotPath({ slug: "pages/index", projectDir: "/project" }), false);
     });
 
     it("checks filePath when provided", () => {
-      assertEquals(isDotPath("normal", ".veryfront/cache/file.tsx"), true);
-      assertEquals(isDotPath("normal", "pages/index.tsx"), false);
+      assertEquals(
+        isDotPath({
+          slug: "normal",
+          filePath: ".veryfront/cache/file.tsx",
+          projectDir: "/project",
+        }),
+        true,
+      );
+      assertEquals(
+        isDotPath({ slug: "normal", filePath: "pages/index.tsx", projectDir: "/project" }),
+        false,
+      );
+    });
+
+    it("ignores hidden ancestors outside the project", () => {
+      const projectDir = "/repo/.worktrees/project";
+
+      assertEquals(
+        isDotPath({
+          slug: "chat",
+          filePath: `${projectDir}/pages/chat/index.tsx`,
+          projectDir,
+        }),
+        false,
+      );
+      assertEquals(
+        isDotPath({
+          slug: "hidden",
+          filePath: `${projectDir}/pages/.hidden/index.tsx`,
+          projectDir,
+        }),
+        true,
+      );
     });
 
     it("returns false for paths with . or ..", () => {
-      assertEquals(isDotPath("./relative"), false);
-      assertEquals(isDotPath("../parent"), false);
+      assertEquals(isDotPath({ slug: "./relative", projectDir: "/project" }), false);
+      assertEquals(isDotPath({ slug: "../parent", projectDir: "/project" }), false);
     });
   });
 

--- a/src/rendering/orchestrator/path-helpers.ts
+++ b/src/rendering/orchestrator/path-helpers.ts
@@ -7,16 +7,32 @@
  */
 
 import type { LayoutItem } from "#veryfront/types";
+import { isAbsolute, relative } from "#veryfront/compat/path";
 
 /** Check if a path segment is a hidden dot-directory (not . or ..) */
 export function isHiddenSegment(segment: string): boolean {
   return segment.startsWith(".") && segment !== "." && segment !== "..";
 }
 
-/** Check if a path contains dot-prefixed segments (e.g., .veryfront, .hidden) */
-export function isDotPath(slug: string, filePath?: string): boolean {
-  const hasDotSegment = (path: string) => path.split("/").some(isHiddenSegment);
-  return hasDotSegment(slug) || (filePath ? hasDotSegment(filePath) : false);
+/** Inputs used to determine whether a resolved route is hidden. */
+export interface DotPathOptions {
+  slug: string;
+  filePath?: string;
+  projectDir: string;
+}
+
+/**
+ * Check whether a route contains a dot-prefixed segment.
+ *
+ * Absolute filesystem ancestors are outside the route namespace and must not
+ * make a project hidden (for example, a project checked out under `.worktrees`).
+ */
+export function isDotPath({ slug, filePath, projectDir }: DotPathOptions): boolean {
+  const hasDotSegment = (path: string) =>
+    path.replaceAll("\\", "/").split("/").some(isHiddenSegment);
+  const projectPath = filePath && isAbsolute(filePath) ? relative(projectDir, filePath) : filePath;
+
+  return hasDotSegment(slug) || (projectPath ? hasDotSegment(projectPath) : false);
 }
 
 /** Empty layout result for dot-prefixed paths */

--- a/src/rendering/orchestrator/path-helpers.ts
+++ b/src/rendering/orchestrator/path-helpers.ts
@@ -21,6 +21,18 @@ export interface DotPathOptions {
   projectDir: string;
 }
 
+function getProjectPath(filePath: string | undefined, projectDir: string): string | undefined {
+  if (!filePath || !isAbsolute(filePath)) return filePath;
+
+  const projectPath = relative(projectDir, filePath);
+  const normalizedProjectPath = projectPath.replaceAll("\\", "/");
+  const isOutsideProject = normalizedProjectPath === ".." ||
+    normalizedProjectPath.startsWith("../") ||
+    isAbsolute(projectPath);
+
+  return isOutsideProject ? undefined : projectPath;
+}
+
 /**
  * Check whether a route contains a dot-prefixed segment.
  *
@@ -30,7 +42,7 @@ export interface DotPathOptions {
 export function isDotPath({ slug, filePath, projectDir }: DotPathOptions): boolean {
   const hasDotSegment = (path: string) =>
     path.replaceAll("\\", "/").split("/").some(isHiddenSegment);
-  const projectPath = filePath && isAbsolute(filePath) ? relative(projectDir, filePath) : filePath;
+  const projectPath = getProjectPath(filePath, projectDir);
 
   return hasDotSegment(slug) || (projectPath ? hasDotSegment(projectPath) : false);
 }

--- a/src/rendering/orchestrator/pipeline.test.ts
+++ b/src/rendering/orchestrator/pipeline.test.ts
@@ -90,28 +90,45 @@ describe("RenderPipeline helpers", () => {
 
   describe("isDotPath", () => {
     it("should detect dot-prefixed slug segments", () => {
-      assertEquals(isDotPath(".veryfront/chat"), true);
-      assertEquals(isDotPath("api/.hidden/route"), true);
+      assertEquals(isDotPath({ slug: ".veryfront/chat", projectDir: "/project" }), true);
+      assertEquals(isDotPath({ slug: "api/.hidden/route", projectDir: "/project" }), true);
     });
 
     it("should detect dot-prefixed filePath segments", () => {
-      assertEquals(isDotPath("normal-slug", "/project/.veryfront/pages/index.tsx"), true);
+      assertEquals(
+        isDotPath({
+          slug: "normal-slug",
+          filePath: "/project/.veryfront/pages/index.tsx",
+          projectDir: "/project",
+        }),
+        true,
+      );
     });
 
     it("should return false for normal paths", () => {
-      assertEquals(isDotPath("about"), false);
-      assertEquals(isDotPath("blog/post-1"), false);
-      assertEquals(isDotPath("normal", "/project/pages/index.tsx"), false);
+      assertEquals(isDotPath({ slug: "about", projectDir: "/project" }), false);
+      assertEquals(isDotPath({ slug: "blog/post-1", projectDir: "/project" }), false);
+      assertEquals(
+        isDotPath({
+          slug: "normal",
+          filePath: "/project/pages/index.tsx",
+          projectDir: "/project",
+        }),
+        false,
+      );
     });
 
     it("should handle missing filePath", () => {
-      assertEquals(isDotPath("normal-slug"), false);
-      assertEquals(isDotPath("normal-slug", undefined), false);
+      assertEquals(isDotPath({ slug: "normal-slug", projectDir: "/project" }), false);
+      assertEquals(
+        isDotPath({ slug: "normal-slug", filePath: undefined, projectDir: "/project" }),
+        false,
+      );
     });
 
     it("should handle '.' and '..' in paths without triggering", () => {
-      assertEquals(isDotPath("./relative"), false);
-      assertEquals(isDotPath("../parent"), false);
+      assertEquals(isDotPath({ slug: "./relative", projectDir: "/project" }), false);
+      assertEquals(isDotPath({ slug: "../parent", projectDir: "/project" }), false);
     });
   });
 

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -572,7 +572,11 @@ export class RenderPipeline {
             );
 
             try {
-              const skipLayouts = isDotPath(slug, pageInfo.entity.path);
+              const skipLayouts = isDotPath({
+                slug,
+                filePath: pageInfo.entity.path,
+                projectDir: this.config.projectDir,
+              });
 
               const layoutCollectStart = performance.now();
               const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await profilePhase(
@@ -862,7 +866,11 @@ export class RenderPipeline {
       () => this.config.pageResolver.resolvePage(slug),
     );
 
-    const skipLayouts = isDotPath(slug, pageInfo.entity.path);
+    const skipLayouts = isDotPath({
+      slug,
+      filePath: pageInfo.entity.path,
+      projectDir: this.config.projectDir,
+    });
     const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await profilePhase(
       "page_data.collect_layouts",
       () => this.config.layoutOrchestrator.collectLayouts(pageInfo),

--- a/src/rendering/router-detection.test.ts
+++ b/src/rendering/router-detection.test.ts
@@ -2,7 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
-import { detectAppRouter } from "./router-detection.ts";
+import { detectAppRouter, resolveRouterModeForPage } from "./router-detection.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { makeTempDir, mkdir, writeTextFile } from "#veryfront/testing/deno-compat.ts";
@@ -118,5 +118,36 @@ describe("detectAppRouter", () => {
     const result = await detectAppRouter(tmpDir, config, failingAdapter);
 
     assertEquals(result, true, "should detect app router using compat fs fallback");
+  });
+});
+
+describe("resolveRouterModeForPage", () => {
+  it("uses the most specific matching router root", () => {
+    const config = {
+      directories: {
+        app: "src",
+        pages: "src/pages",
+      },
+    } as VeryfrontConfig;
+
+    const result = resolveRouterModeForPage(
+      "/project",
+      "/project/src/pages/chat/index.tsx",
+      config,
+    );
+
+    assertEquals(result, "pages");
+  });
+
+  it("treats a resolved root-level page as a Pages route", () => {
+    const config = {} as VeryfrontConfig;
+
+    const result = resolveRouterModeForPage(
+      "/project",
+      "/project/index.mdx",
+      config,
+    );
+
+    assertEquals(result, "pages");
   });
 });

--- a/src/rendering/router-detection.ts
+++ b/src/rendering/router-detection.ts
@@ -79,14 +79,16 @@ function resolveProjectPath(projectDir: string, path: string): string {
  * Auto-detection decides which router to try first, but mixed projects can
  * legitimately fall back to the other router. Per-page rendering must follow
  * the route that actually resolved instead of the project-wide preference.
+ *
+ * Pages routes can also resolve from the project root. App routes cannot
+ * resolve outside their configured root, so an unmatched resolved path belongs
+ * to the Pages router.
  */
-export async function resolveRouterModeForPage(
+export function resolveRouterModeForPage(
   projectDir: string,
   pagePath: string,
   config: VeryfrontConfig,
-  adapter: RuntimeAdapter,
-  options?: DetectAppRouterOptions,
-): Promise<"app" | "pages"> {
+): "app" | "pages" {
   if (config.router === "app") return "app";
   if (config.router === "pages") return "pages";
 
@@ -100,10 +102,18 @@ export async function resolveRouterModeForPage(
     config.directories?.pages ?? "pages",
   );
 
-  if (isPathInside(resolvedPagePath, appRoot)) return "app";
-  if (isPathInside(resolvedPagePath, pagesRoot)) return "pages";
+  const isAppRoute = isPathInside(resolvedPagePath, appRoot);
+  const isPagesRoute = isPathInside(resolvedPagePath, pagesRoot);
 
-  return (await detectAppRouter(projectDir, config, adapter, options)) ? "app" : "pages";
+  if (isAppRoute && isPagesRoute) {
+    const appDistance = relative(appRoot, resolvedPagePath).split(/[\\/]/).filter(Boolean).length;
+    const pagesDistance =
+      relative(pagesRoot, resolvedPagePath).split(/[\\/]/).filter(Boolean).length;
+    return pagesDistance < appDistance ? "pages" : "app";
+  }
+
+  if (isAppRoute) return "app";
+  return "pages";
 }
 
 /**

--- a/src/rendering/router-detection.ts
+++ b/src/rendering/router-detection.ts
@@ -7,7 +7,7 @@
  * - Route file presence detection
  **************************/
 
-import { join } from "#veryfront/compat/path";
+import { isAbsolute, join, normalize, relative } from "#veryfront/compat/path";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -59,6 +59,51 @@ export function primeRouterDetectionCache(
 export interface DetectAppRouterOptions {
   /** Project ID for cache isolation in multi-tenant deployments */
   projectId?: string;
+}
+
+function isPathInside(path: string, directory: string): boolean {
+  const relativePath = relative(directory, path).replaceAll("\\", "/");
+  return relativePath === "" ||
+    (relativePath !== ".." &&
+      !relativePath.startsWith("../") &&
+      !isAbsolute(relativePath));
+}
+
+function resolveProjectPath(projectDir: string, path: string): string {
+  return normalize(isAbsolute(path) ? path : join(projectDir, path));
+}
+
+/**
+ * Resolve the router that owns an already-resolved page.
+ *
+ * Auto-detection decides which router to try first, but mixed projects can
+ * legitimately fall back to the other router. Per-page rendering must follow
+ * the route that actually resolved instead of the project-wide preference.
+ */
+export async function resolveRouterModeForPage(
+  projectDir: string,
+  pagePath: string,
+  config: VeryfrontConfig,
+  adapter: RuntimeAdapter,
+  options?: DetectAppRouterOptions,
+): Promise<"app" | "pages"> {
+  if (config.router === "app") return "app";
+  if (config.router === "pages") return "pages";
+
+  const resolvedPagePath = resolveProjectPath(projectDir, pagePath);
+  const appRoot = resolveProjectPath(
+    projectDir,
+    config.directories?.app ?? "app",
+  );
+  const pagesRoot = resolveProjectPath(
+    projectDir,
+    config.directories?.pages ?? "pages",
+  );
+
+  if (isPathInside(resolvedPagePath, appRoot)) return "app";
+  if (isPathInside(resolvedPagePath, pagesRoot)) return "pages";
+
+  return (await detectAppRouter(projectDir, config, adapter, options)) ? "app" : "pages";
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1149";
+export const VERSION = "0.1.1150";

--- a/tests/integration/renderer/layout-system/integration.test.ts
+++ b/tests/integration/renderer/layout-system/integration.test.ts
@@ -156,6 +156,72 @@ This is a test post.
     });
   });
 
+  it("preserves convention layouts when the project has a hidden ancestor", async () => {
+    await withTestContext("layout-mixed-router-pages-conventions", async (context) => {
+      const projectDir = join(context.projectDir, ".worktrees", "project");
+      await mkdir(join(projectDir, "app"), { recursive: true });
+      await mkdir(join(projectDir, "components"), { recursive: true });
+      await mkdir(join(projectDir, "pages/chat"), { recursive: true });
+
+      await writeTextFile(
+        join(projectDir, "app/layout.tsx"),
+        `export default function AppLayout({ children }) {
+  return <div id="app-layout">{children}</div>;
+}`,
+      );
+
+      await writeTextFile(
+        join(projectDir, "components/layout.tsx"),
+        `export default function DashboardLayout({ children }) {
+  return <aside id="dashboard-layout">{children}</aside>;
+}`,
+      );
+
+      await writeTextFile(
+        join(projectDir, "components/app.tsx"),
+        `export default function App({ children }) {
+  return <div id="pages-app-wrapper">{children}</div>;
+}`,
+      );
+
+      await writeTextFile(
+        join(projectDir, "pages/review.tsx"),
+        `export default function ReviewPage() {
+  return <div>Review page</div>;
+}`,
+      );
+
+      await writeTextFile(
+        join(projectDir, "pages/chat/layout.tsx"),
+        `export default function ChatLayout({ children }) {
+  return <main id="chat-route-layout">{children}</main>;
+}`,
+      );
+
+      await writeTextFile(
+        join(projectDir, "pages/chat/index.tsx"),
+        `export default function ChatPage() {
+  return <div>Chat page</div>;
+}`,
+      );
+
+      await withRenderer(projectDir, async (renderer) => {
+        const review = await renderer.renderPage("review");
+        assertExists(review.html);
+        assertStringIncludes(review.html, 'id="dashboard-layout"');
+        assertStringIncludes(review.html, 'id="pages-app-wrapper"');
+        assertEquals(review.html.includes('id="app-layout"'), false);
+
+        const chat = await renderer.renderPage("chat");
+        assertExists(chat.html);
+        assertStringIncludes(chat.html, 'id="chat-route-layout"');
+        assertStringIncludes(chat.html, 'id="pages-app-wrapper"');
+        assertEquals(chat.html.includes('id="dashboard-layout"'), false);
+        assertEquals(chat.html.includes('id="app-layout"'), false);
+      });
+    });
+  });
+
   it("named layout", async () => {
     await withTestContext("layout-named", async (context) => {
       await mkdir(join(context.projectDir, "layouts"), { recursive: true });

--- a/tests/integration/renderer/layout-system/integration.test.ts
+++ b/tests/integration/renderer/layout-system/integration.test.ts
@@ -6,7 +6,7 @@
 // Disable LRU intervals during testing to prevent resource leaks
 (globalThis as Record<string, unknown>).__vfDisableLruInterval = true;
 
-import { assertExists, assertStringIncludes } from "#veryfront/testing/assert";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert";
 import { join } from "#veryfront/compat/path";
 import { afterAll, describe, it } from "#veryfront/testing/bdd";
 import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
@@ -15,11 +15,14 @@ import { VeryfrontRenderer } from "../../../../src/rendering/orchestrator/ssr.ts
 import { cleanupBundler } from "../../../../src/rendering/cleanup.ts";
 import { withTestContext } from "../../../_helpers/context.ts";
 
-async function createRenderer(projectDir: string): Promise<VeryfrontRenderer> {
+async function createRenderer(
+  projectDir: string,
+  mode: "development" | "production" = "development",
+): Promise<VeryfrontRenderer> {
   const adapter = await getAdapter();
   const renderer = new VeryfrontRenderer({
     projectDir,
-    mode: "development",
+    mode,
     adapter,
   });
 
@@ -30,8 +33,9 @@ async function createRenderer(projectDir: string): Promise<VeryfrontRenderer> {
 async function withRenderer(
   projectDir: string,
   fn: (renderer: VeryfrontRenderer) => Promise<void>,
+  mode: "development" | "production" = "development",
 ): Promise<void> {
-  const renderer = await createRenderer(projectDir);
+  const renderer = await createRenderer(projectDir, mode);
   try {
     await fn(renderer);
   } finally {
@@ -86,6 +90,69 @@ This is a test post.
         assertExists(result.html);
         assertStringIncludes(result.html, "My Blog Post");
       });
+    });
+  });
+
+  it("uses the resolved Pages route layout in a mixed-router project", async () => {
+    await withTestContext("layout-mixed-router-pages-route", async (context) => {
+      await mkdir(join(context.projectDir, "app"), { recursive: true });
+      await mkdir(join(context.projectDir, "pages/chat"), { recursive: true });
+
+      await writeTextFile(
+        join(context.projectDir, "app/layout.tsx"),
+        `export default function AppLayout({ children }) {
+  return <div id="app-layout">{children}</div>;
+}`,
+      );
+
+      await writeTextFile(
+        join(context.projectDir, "pages/chat/layout.tsx"),
+        `export default function ChatLayout({ children }) {
+  return <main id="chat-route-layout">{children}</main>;
+}`,
+      );
+
+      await writeTextFile(
+        join(context.projectDir, "pages/chat/index.tsx"),
+        `export default function ChatPage() {
+  return <div>Chat page</div>;
+}`,
+      );
+
+      await writeTextFile(
+        join(context.projectDir, "components/layout.tsx"),
+        `export default function FallbackLayout({ children }) {
+  return <aside id="dashboard-fallback-layout">{children}</aside>;
+}`,
+      );
+
+      await writeTextFile(
+        join(context.projectDir, "components/app.tsx"),
+        `export default function App({ children }) {
+  return <div id="pages-app-wrapper">{children}</div>;
+}`,
+      );
+
+      await withRenderer(context.projectDir, async (renderer) => {
+        const result = await renderer.renderPage("chat");
+        assertExists(result.html);
+        assertStringIncludes(result.html, 'id="chat-route-layout"');
+        assertStringIncludes(result.html, 'id="pages-app-wrapper"');
+        assertEquals(result.html.includes('id="dashboard-fallback-layout"'), false);
+        const payload = result.html.match(
+          /<script id="veryfront-hydration-data" type="application\/json"[^>]*>([\s\S]*?)<\/script>/,
+        )?.[1];
+        assertExists(payload);
+        const hydrationData = JSON.parse(payload) as {
+          layouts?: Array<{ kind?: string; path?: string }>;
+          pagePath?: string;
+        };
+        assertEquals(hydrationData.pagePath, "pages/chat/index.tsx");
+        assertEquals(hydrationData.layouts, [{
+          kind: "tsx",
+          path: "pages/chat/layout.tsx",
+        }]);
+      }, "production");
     });
   });
 


### PR DESCRIPTION
## Summary

- derive per-page router ownership from the page path that actually resolved
- use that ownership for nested layout discovery and Pages/App wrapper selection
- scope hidden-route checks to the project instead of absolute filesystem ancestors
- cover mixed-router production SSR, hydration metadata, and hidden-parent worktrees
- bump the framework release to `0.1.1150`

## Root cause

Project-wide auto-detection correctly chooses which router to try first, but a mixed project can then resolve the route from the other router. Layout collection and application reused the project-wide preference, so a resolved `pages/chat/index.tsx` searched the App Router hierarchy and fell back to `components/layout.tsx`. The browser hydration payload preserved that wrong layout.

A second path-boundary issue appeared during exact consumer validation: absolute page paths beneath a hidden ancestor such as `.worktrees` were classified as hidden routes. That skipped both layout collection and the Pages app wrapper even though the hidden directory was outside the project. Hidden-route detection now evaluates the page path relative to the project root and is shared by both rendering paths.

The fix keeps initial route lookup unchanged and scopes only per-page rendering decisions to the router that owns the resolved page.

## Verification

- pre-push gate: 2,684 tests / 21,799 steps passed after rebasing on #3111
- `deno task verify:quick` passed after rebasing
- focused layout/path regression: 89 steps passed; hidden-ancestor integration failed before the fix and passes after it
- post-rebase independent verification: 102 targeted steps, including #3111 knowledge tests, passed
- exact packed-package consumer gate on the unchanged layout implementation: lint, typecheck, request-time SSR, discovery, and 173 tests passed
- packed consumer browser check from a `.worktrees` path: `/chat` is frameless and full-height with only `pages/chat/layout.tsx`; `/review` retains `components/layout.tsx`; browser errors clean
- two independent read-only reviews found no issues

## Release ordering

#3109 released as `v0.1.1148`. #3111 then merged first and reserved `v0.1.1149`. This branch is rebased on #3111 and now reserves `v0.1.1150`.