### PR TITLE
Normalize knowledge lookup cursors at the boundary

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1148",
+  "version": "0.1.1149",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/knowledge/index.test.ts
+++ b/src/knowledge/index.test.ts
@@ -234,7 +234,6 @@ describe("projectKnowledge", () => {
           "Login content.",
         ].join("\n"),
       );
-
       const knowledge = projectKnowledge({ projectDir });
       const firstPage = await knowledge.lookup({ query: "zxqv yjkp", limit: 1 });
 
@@ -256,9 +255,56 @@ describe("projectKnowledge", () => {
     });
   });
 
+  it("normalizes blank and padded local lookup cursors", async () => {
+    await withTempDir(async (projectDir) => {
+      await mkdir(join(projectDir, "knowledge"), { recursive: true });
+      await writeTextFile(
+        join(projectDir, "knowledge", "billing.md"),
+        [
+          "---",
+          "type: runbook",
+          "title: Billing",
+          "---",
+          "",
+          "Billing content.",
+        ].join("\n"),
+      );
+      await writeTextFile(
+        join(projectDir, "knowledge", "login.md"),
+        [
+          "---",
+          "type: runbook",
+          "title: Login",
+          "---",
+          "",
+          "Login content.",
+        ].join("\n"),
+      );
+
+      const knowledge = projectKnowledge({ projectDir });
+      const firstPage = await knowledge.lookup({ query: "zxqv yjkp", limit: 1 });
+      const nextCursor = firstPage.page_info.next ?? "";
+
+      const blankCursorPage = await knowledge.lookup({
+        query: "zxqv yjkp",
+        cursor: " \n\t ",
+        limit: 1,
+      });
+      const paddedCursorPage = await knowledge.lookup({
+        query: "zxqv yjkp",
+        cursor: ` \n${nextCursor}\t `,
+      });
+
+      assertEquals(blankCursorPage.page_info.self, null);
+      assertEquals(blankCursorPage.data.map((item) => item.path), ["knowledge/billing.md"]);
+      assertEquals(paddedCursorPage.page_info.self, nextCursor);
+      assertEquals(paddedCursorPage.data.map((item) => item.path), ["knowledge/login.md"]);
+    });
+  });
+
   it("does not expose malformed cursor contents", async () => {
     const knowledge = projectKnowledge({ projectDir: "." });
-    const cursor = btoa("private cursor <TOKEN>");
+    const cursor = ` \n${btoa("private cursor <TOKEN>")}\t `;
 
     const error = await assertRejects(() => knowledge.lookup({ query: "billing", cursor }));
 
@@ -281,13 +327,34 @@ describe("projectKnowledge", () => {
           "Billing content.",
         ].join("\n"),
       );
+      await writeTextFile(
+        join(projectDir, "knowledge", "login.md"),
+        [
+          "---",
+          "type: runbook",
+          "title: Login",
+          "---",
+          "",
+          "Login content.",
+        ].join("\n"),
+      );
 
       const searchKnowledge = createSearchKnowledgeTool({ projectDir });
-      const result = await searchKnowledge.execute({ query: "billing" });
+      const firstPage = await searchKnowledge.execute({
+        query: "zxqv yjkp",
+        cursor: " \n\t ",
+        limit: 1,
+      });
+      const result = await searchKnowledge.execute({
+        query: "zxqv yjkp",
+        cursor: ` \n${firstPage.page_info.next ?? ""}\t `,
+      });
 
       assertEquals(searchKnowledge.id, "search_knowledge");
       assertEquals(searchKnowledge.inputSchemaJson?.properties?.query?.type, "string");
-      assertEquals(result.data.map((item) => item.path), ["knowledge/billing.md"]);
+      assertEquals(firstPage.data.map((item) => item.path), ["knowledge/billing.md"]);
+      assertEquals(result.page_info.self, firstPage.page_info.next);
+      assertEquals(result.data.map((item) => item.path), ["knowledge/login.md"]);
     });
   });
 

--- a/src/knowledge/index.test.ts
+++ b/src/knowledge/index.test.ts
@@ -10,7 +10,12 @@ import { exists, mkdir, withTempDir, writeTextFile } from "#veryfront/testing/de
 import { join } from "#veryfront/compat/path";
 import { clearEmbeddingProviders, registerEmbeddingProvider } from "#veryfront/embedding/index.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
-import { createSearchKnowledgeTool, formatKnowledgeContext, projectKnowledge } from "./index.ts";
+import {
+  createSearchKnowledgeTool,
+  formatKnowledgeContext,
+  projectKnowledge,
+  searchProjectKnowledge,
+} from "./index.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -311,6 +316,25 @@ describe("projectKnowledge", () => {
     assertInstanceOf(error, Error);
     assertEquals(error.message, "Invalid knowledge lookup cursor");
     assertEquals(error.cause, undefined);
+  });
+
+  it("does not expose type errors for non-string cursors", async () => {
+    const input = {
+      query: "billing",
+      cursor: 1 as unknown as string,
+    };
+    const lookupError = await assertRejects(() =>
+      projectKnowledge({ projectDir: "." }).lookup(input)
+    );
+    const searchError = await assertRejects(() =>
+      searchProjectKnowledge(input, { projectDir: "." })
+    );
+
+    for (const error of [lookupError, searchError]) {
+      assertInstanceOf(error, Error);
+      assertEquals(error.message, "Invalid knowledge lookup cursor");
+      assertEquals(error.cause, undefined);
+    }
   });
 
   it("creates a local search_knowledge tool for parity with hosted MCP", async () => {

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -515,8 +515,13 @@ function decodeCursor(cursor: string): ProjectKnowledgeLookupCursorState {
   }
 }
 
-function normalizeKnowledgeLookupCursor(cursor: string | undefined): string | undefined {
-  const normalizedCursor = cursor?.trim() ?? "";
+function normalizeKnowledgeLookupCursor(cursor: unknown): string | undefined {
+  if (cursor === undefined || cursor === null) return undefined;
+  if (typeof cursor !== "string") {
+    throw INPUT_VALIDATION_FAILED.create({ detail: "Invalid knowledge lookup cursor" });
+  }
+
+  const normalizedCursor = cursor.trim();
   return normalizedCursor.length > 0 ? normalizedCursor : undefined;
 }
 

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -515,6 +515,11 @@ function decodeCursor(cursor: string): ProjectKnowledgeLookupCursorState {
   }
 }
 
+function normalizeKnowledgeLookupCursor(cursor: string | undefined): string | undefined {
+  const normalizedCursor = cursor?.trim() ?? "";
+  return normalizedCursor.length > 0 ? normalizedCursor : undefined;
+}
+
 function scoreEntry(
   entry: SearchableProjectKnowledgeManifestEntry,
   query: string,
@@ -715,7 +720,8 @@ function lookupKnowledgeManifest(
   manifest: ProjectKnowledgeManifestEntry[],
   input: ProjectKnowledgeLookupInput,
 ): ProjectKnowledgeLookupOutput {
-  const cursorState = input.cursor ? decodeCursor(input.cursor) : null;
+  const normalizedCursor = normalizeKnowledgeLookupCursor(input.cursor);
+  const cursorState = normalizedCursor ? decodeCursor(normalizedCursor) : null;
   const providedQuery = input.query?.trim() ?? "";
   const resolvedQuery = (cursorState?.query ?? providedQuery).trim();
   const lookupTargetPath = cursorState ? null : getLookupTargetPath(input.lookup_target);
@@ -811,7 +817,7 @@ function lookupKnowledgeManifest(
     mode,
     data: pageEntries.map(({ entry, matchedFields }) => createLookupItem(entry, matchedFields)),
     page_info: {
-      self: input.cursor ?? null,
+      self: normalizedCursor ?? null,
       first: null,
       next: nextCursor,
       prev: null,
@@ -839,7 +845,9 @@ function coerceSearchKnowledgeInput(
       ? value.project_reference
       : undefined,
     query: typeof value.query === "string" ? value.query : undefined,
-    cursor: typeof value.cursor === "string" ? value.cursor : undefined,
+    cursor: typeof value.cursor === "string"
+      ? normalizeKnowledgeLookupCursor(value.cursor)
+      : undefined,
     lookup_target: value.lookup_target,
     limit: typeof value.limit === "number" ? value.limit : undefined,
     shard_count: typeof value.shard_count === "number" ? value.shard_count : undefined,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1148";
+export const VERSION = "0.1.1149";


### PR DESCRIPTION
## Summary
- trim knowledge lookup cursors once at the public lookup boundary
- treat whitespace-only cursors like an omitted first-page cursor
- accept valid cursors with incidental surrounding whitespace
- keep malformed non-empty cursor errors sanitized
- reuse normalization in the `search_knowledge` tool coercion path
- bump Veryfront to `0.1.1149`

## Verification
- focused knowledge suite: 1 test / 12 steps passed
- `deno task verify:quick`
- full pre-push after rebase: 2,683 tests / 21,800 steps, zero failures

## Integration
- #3109 merged as v0.1.1148
- rebased onto current `main` after the merge-queue rewrite
- current diff is one commit and exactly four files
- auto-merge remains disabled until current-head CI and re-approval complete