### PR TITLE
fix(binary): resolve a handler's bare zod import on the compiled binary (#217)

### DIFF
--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -486,12 +486,13 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(packages, ["zod", "pdf-parse", "another-lib"]);
   });
 
-  it("keeps zod for Deno source runs but excludes it from compiled binaries", () => {
+  it("keeps zod as a user dep on every runtime, incl. the compiled binary (#217)", () => {
     const dependencies = new Map([
       ["zod", "^3.22.0"],
       ["pdf-parse", "^1.1.1"],
     ]);
 
+    // Deno source-run keeps zod (#3105) ...
     assertEquals(
       [...getUserDependencies(dependencies, { isDeno: true, isCompiledBinary: false })],
       [
@@ -499,9 +500,14 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
         ["pdf-parse", "^1.1.1"],
       ],
     );
+    // ... and so does the compiled binary now, so a handler's `import { z } from
+    // "zod"` is rewritten to resolve from node_modules instead of 500ing (#217).
     assertEquals(
       [...getUserDependencies(dependencies, { isDeno: true, isCompiledBinary: true })],
-      [["pdf-parse", "^1.1.1"]],
+      [
+        ["zod", "^3.22.0"],
+        ["pdf-parse", "^1.1.1"],
+      ],
     );
   });
 

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -486,24 +486,16 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(packages, ["zod", "pdf-parse", "another-lib"]);
   });
 
-  it("keeps zod as a user dep on every runtime, incl. the compiled binary (#217)", () => {
+  it("keeps zod as a user dependency for compiled binary resolution (#217)", () => {
     const dependencies = new Map([
       ["zod", "^3.22.0"],
       ["pdf-parse", "^1.1.1"],
     ]);
 
-    // Deno source-run keeps zod (#3105) ...
-    assertEquals(
-      [...getUserDependencies(dependencies, { isDeno: true, isCompiledBinary: false })],
-      [
-        ["zod", "^3.22.0"],
-        ["pdf-parse", "^1.1.1"],
-      ],
-    );
-    // ... and so does the compiled binary now, so a handler's `import { z } from
+    // A compiled binary needs zod in this list so a handler's `import { z } from
     // "zod"` is rewritten to resolve from node_modules instead of 500ing (#217).
     assertEquals(
-      [...getUserDependencies(dependencies, { isDeno: true, isCompiledBinary: true })],
+      [...getUserDependencies(dependencies)],
       [
         ["zod", "^3.22.0"],
         ["pdf-parse", "^1.1.1"],

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -446,10 +446,7 @@ function loadAndTranspileModule(
       // any other npm package, so its import resolves from the project's
       // node_modules via the createRequire shim. zod is still force-externalized
       // below, never bundled inline. See veryfront-issue-inbox#217.
-      const userDeps = getUserDependencies(allDeps, {
-        isDeno,
-        isCompiledBinary: isDeno && isCompiledBinary(),
-      });
+      const userDeps = getUserDependencies(allDeps);
 
       // Always externalize user npm dependencies. The bundled handler is loaded
       // from a temp file and user deps are resolved at runtime:
@@ -572,7 +569,6 @@ async function readFileWithExtensions(
 
 export function getUserDependencies(
   allDeps: ReadonlyMap<string, string>,
-  runtime: { isDeno: boolean; isCompiledBinary: boolean },
 ): Map<string, string> {
   const frameworkPackages = new Set(["veryfront", "react", "react-dom", "path"]);
 

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -436,21 +436,16 @@ function loadAndTranspileModule(
       // handled by the framework's own external/rewrite logic and should not be
       // treated as user npm packages.
       //
-      // `zod` is kept as a user dep on Node and the Deno source-run so a
-      // handler's own `import { z } from "zod"` is rewritten to a resolvable
-      // specifier. Excluding it left a bare `import "zod"` in the temp handler
-      // that Deno cannot resolve → "not a dependency and not in import map" → 500.
-      // (The Node path already always-resolves zod via
-      // getNodeExternalPackagesToResolve, so only the Deno source-run was broken
-      // by the exclusion.) zod is still force-externalized below, never bundled.
-      //
-      // The compiled binary keeps zod excluded — this change is scoped to the
-      // runtimes where it is verified. The binary loads framework helpers
-      // (createValidatedHandler, MiddlewarePipeline, …) through per-subpath
-      // veryfront runtime shims written next to the temp handler, a separate and
-      // more constrained resolution path; wiring a user `zod` through it belongs
-      // in a dedicated change with its own binary coverage. Leaving the binary
-      // branch byte-identical to before keeps that path untouched here.
+      // `zod` is kept as a user dep on every runtime — Node, the Deno source-run,
+      // AND the compiled binary — so a handler's own `import { z } from "zod"` is
+      // rewritten to a resolvable specifier. Excluding it left a bare `import "zod"`
+      // in the temp handler that Deno cannot resolve → "not a dependency and not in
+      // import map" → 500. (The Node path already always-resolves zod via
+      // getNodeExternalPackagesToResolve.) On the compiled binary, keeping zod in
+      // userDeps routes it through rewriteCompiledBinaryUserDependencyImports like
+      // any other npm package, so its import resolves from the project's
+      // node_modules via the createRequire shim. zod is still force-externalized
+      // below, never bundled inline. See veryfront-issue-inbox#217.
       const userDeps = getUserDependencies(allDeps, {
         isDeno,
         isCompiledBinary: isDeno && isCompiledBinary(),
@@ -580,7 +575,6 @@ export function getUserDependencies(
   runtime: { isDeno: boolean; isCompiledBinary: boolean },
 ): Map<string, string> {
   const frameworkPackages = new Set(["veryfront", "react", "react-dom", "path"]);
-  if (runtime.isDeno && runtime.isCompiledBinary) frameworkPackages.add("zod");
 
   const frameworkPrefixes = ["@opentelemetry/", "node:", "veryfront/"];
   const userDeps = new Map<string, string>();


### PR DESCRIPTION
## Problem

An API route with `import { z } from "zod"` **500s on the compiled binary**:

```
Import "zod" not a dependency and not in import map
```

This is the binary half of veryfront-issue-inbox#217 that veryfront-code#3105 explicitly deferred ("The compiled binary keeps zod excluded … tracked separately").

## Root cause

`getUserDependencies()` force-excluded `zod` from `userDeps` **only on the binary** (`if (isDeno && isCompiledBinary) frameworkPackages.add("zod")`). On the binary, `rewriteCompiledBinaryUserDependencyImports` only rewrites specifiers present in `userDeps` — so the excluded `import "zod"` was left bare and reached Deno, which can't resolve it.

#3105 already keeps zod as a user dep on Node and the Deno source-run. This drops the binary-only exclusion so zod is treated like any other npm package and rewritten through the `createRequire` shim to resolve from the project's `node_modules`. zod stays force-externalized (esbuild `external`) — never bundled inline.

## Verification (per LOCALDEV.md)

Built a fresh binary and ran it against `veryfront-router-testing/default-config`:
- A route importing `zod` and calling `z.object().safeParse(...)` → **200** (was 500).
- Middleware/CORS routes unaffected (still 200/401/504).
- `deno task test:unit`: **2680 passed, 0 failed**. Updated the paired `getUserDependencies` regression test to expect zod on the binary too.

## Scope note

`/api/validated` in that repro *additionally* imports `createValidatedHandler` from the **root** `veryfront`, which the hand-written root runtime shim omits — a **separate** root-shim-completeness gap filed as veryfront-issue-inbox#231. That is not addressed here; this PR is strictly the bare-npm-dep (zod) resolution.

Ref: veryfront-issue-inbox#217