### PR TITLE
fix(ssr): coalesce cold component transforms

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1150",
+  "version": "0.1.1151",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/cache/config-hash.test.ts
+++ b/src/cache/config-hash.test.ts
@@ -35,6 +35,20 @@ describe("cache/config-hash", () => {
       const h2 = await computeConfigHash({ studioEmbed: true });
       assertNotEquals(h1, h2);
     });
+
+    for (
+      const [field, baseValue, changedValue] of [
+        ["moduleServerUrl", "https://modules-a.example.test", "https://modules-b.example.test"],
+        ["vendorBundleHash", "vendor-a", "vendor-b"],
+        ["apiBaseUrl", "https://api-a.example.test", "https://api-b.example.test"],
+      ] as const
+    ) {
+      it(`should differ when ${field} changes`, async () => {
+        const h1 = await computeConfigHash({ [field]: baseValue });
+        const h2 = await computeConfigHash({ [field]: changedValue });
+        assertNotEquals(h1, h2);
+      });
+    }
   });
 
   describe("computeConfigHashSync", () => {
@@ -61,5 +75,19 @@ describe("cache/config-hash", () => {
       const hash = computeConfigHashSync({});
       assertEquals(hash.startsWith("v"), true);
     });
+
+    for (
+      const [field, baseValue, changedValue] of [
+        ["moduleServerUrl", "https://modules-a.example.test", "https://modules-b.example.test"],
+        ["vendorBundleHash", "vendor-a", "vendor-b"],
+        ["apiBaseUrl", "https://api-a.example.test", "https://api-b.example.test"],
+      ] as const
+    ) {
+      it(`should differ when ${field} changes`, () => {
+        const h1 = computeConfigHashSync({ [field]: baseValue });
+        const h2 = computeConfigHashSync({ [field]: changedValue });
+        assertNotEquals(h1, h2);
+      });
+    }
   });
 });

--- a/src/cache/config-hash.ts
+++ b/src/cache/config-hash.ts
@@ -21,6 +21,12 @@ interface TransformConfig {
   reactVersion?: string;
   /** JSX import source */
   jsxImportSource?: string;
+  /** Module server URL for rewritten browser imports */
+  moduleServerUrl?: string;
+  /** Vendor bundle hash for rewritten vendor imports */
+  vendorBundleHash?: string;
+  /** API base URL for rewritten cross-project imports */
+  apiBaseUrl?: string;
   /** Enable Studio Navigator embed */
   studioEmbed?: boolean;
   /** Development mode */
@@ -37,6 +43,9 @@ export function computeConfigHash(config: TransformConfig): Promise<string> {
     transformVersion: VERSION,
     reactVersion: config.reactVersion ?? DEFAULT_REACT_VERSION,
     jsxImportSource: config.jsxImportSource ?? "react",
+    moduleServerUrl: config.moduleServerUrl ?? null,
+    vendorBundleHash: config.vendorBundleHash ?? null,
+    apiBaseUrl: config.apiBaseUrl ?? null,
     studioEmbed: config.studioEmbed ?? false,
     dev: config.dev ?? false,
     csstype: CSSTYPE_VERSION,
@@ -56,9 +65,17 @@ export function computeConfigHashSync(config: TransformConfig): string {
     `v${VERSION}`,
     config.reactVersion ?? DEFAULT_REACT_VERSION,
     config.jsxImportSource ?? "react",
+    encodeConfigPart("modules", config.moduleServerUrl),
+    encodeConfigPart("vendor", config.vendorBundleHash),
+    encodeConfigPart("api", config.apiBaseUrl),
     config.studioEmbed ? "studio" : "",
     config.dev ? "dev" : "",
   ].filter(Boolean);
 
   return parts.join(":");
+}
+
+function encodeConfigPart(label: string, value: string | undefined): string {
+  if (!value) return "";
+  return `${label}:${value.length}:${value}`;
 }

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
@@ -5,7 +5,10 @@ import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts"
 import type { FileSystem } from "#veryfront/platform/compat/fs.ts";
 import type { CrossProjectImport } from "#veryfront/transforms/esm/import-parser.ts";
 import { globalCrossProjectCache } from "./cache/index.ts";
-import { transformCrossProjectImportFlow } from "./cross-project-import-loader.ts";
+import {
+  buildCrossProjectImportCacheKey,
+  transformCrossProjectImportFlow,
+} from "./cross-project-import-loader.ts";
 
 function createMockCacheFs(overrides: Partial<FileSystem> = {}): FileSystem {
   return {
@@ -41,7 +44,11 @@ const crossProjectImport: CrossProjectImport = {
 describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", () => {
   it("returns cached temp path without fetching", async () => {
     globalCrossProjectCache.clear();
-    const cacheKey = `${crossProjectImport.specifier}:project-a:default`;
+    const cacheKey = buildCrossProjectImportCacheKey({
+      specifier: crossProjectImport.specifier,
+      projectId: "project-a",
+      registryBaseUrl: "https://registry.example.com",
+    });
     globalCrossProjectCache.set(cacheKey, {
       tempPath: "/tmp/cached-cross-project.mjs",
       contentHash: "cafe1234",
@@ -56,6 +63,7 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
         projectId: "project-a",
         projectDir: "/project",
         dev: true,
+        apiBaseUrl: "https://registry.example.com/api",
         adapter: denoAdapter,
       },
       cache: {
@@ -151,7 +159,12 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
 
     const expectedRegistryUrl =
       "https://registry.example.com/acme-ui@1.2.3/@/components/Button.tsx";
-    const expectedCacheKey = `${crossProjectImport.specifier}:project-a:19.1.1`;
+    const expectedCacheKey = buildCrossProjectImportCacheKey({
+      specifier: crossProjectImport.specifier,
+      projectId: "project-a",
+      reactVersion: "19.1.1",
+      registryBaseUrl: "https://registry.example.com",
+    });
 
     assertEquals(result, "/tmp/cross-project-transformed.mjs");
     assertEquals(fetchedUrl, expectedRegistryUrl);
@@ -170,6 +183,65 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
     assertEquals(cached?.contentHash, "1234abcd");
     assertEquals(debugLogs.includes("[SSR-MODULE-LOADER] Fetching cross-project import"), true);
     assertEquals(debugLogs.includes("[SSR-MODULE-LOADER] Cross-project import transformed"), true);
+  });
+
+  it("separates cross-project cache entries by API base URL", async () => {
+    globalCrossProjectCache.clear();
+
+    const fetchedUrls: string[] = [];
+    let writeCount = 0;
+
+    const createFlowOptions = (apiBaseUrl: string) => ({
+      crossProjectImport,
+      options: {
+        projectId: "project-a",
+        projectDir: "/project",
+        dev: true,
+        apiBaseUrl,
+        reactVersion: "19.1.1",
+        adapter: denoAdapter,
+      },
+      cache: {
+        hashContentAsync: async (content: string) =>
+          content.includes("registry-a") ? "hash-registry-a" : "hash-registry-b",
+        getTempPath: async (_filePath: string, contentHash?: string) =>
+          `/tmp/${contentHash ?? "missing"}.mjs`,
+        getFs: () =>
+          createMockCacheFs({
+            writeTextFile: async () => {
+              writeCount++;
+            },
+          }),
+      },
+      withTransformCapacity: async <T>(_syntheticFilePath: string, operation: () => Promise<T>) =>
+        await operation(),
+      fetchImpl: async (input: URL | RequestInfo) => {
+        const url = String(input);
+        fetchedUrls.push(url);
+        const source = url.includes("registry-a")
+          ? "export const registry = 'registry-a';"
+          : "export const registry = 'registry-b';";
+        return new Response(source, { status: 200 });
+      },
+      transformToESMImpl: async (source: string) => source,
+      loggerImpl: { debug: () => {}, error: () => {} },
+    });
+
+    const registryAPath = await transformCrossProjectImportFlow(
+      createFlowOptions("https://registry-a.example.com/api"),
+    );
+    const registryBPath = await transformCrossProjectImportFlow(
+      createFlowOptions("https://registry-b.example.com/api"),
+    );
+
+    assertEquals(registryAPath, "/tmp/hash-registry-a.mjs");
+    assertEquals(registryBPath, "/tmp/hash-registry-b.mjs");
+    assertEquals(fetchedUrls, [
+      "https://registry-a.example.com/acme-ui@1.2.3/@/components/Button.tsx",
+      "https://registry-b.example.com/acme-ui@1.2.3/@/components/Button.tsx",
+    ]);
+    assertEquals(writeCount, 2);
+    assertEquals(globalCrossProjectCache.size, 2);
   });
 
   it("rejects source bodies whose UTF-8 byte size exceeds the fallback limit before transform", async () => {

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
@@ -11,6 +11,7 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import { globalCrossProjectCache } from "./cache/index.ts";
 import type { SSRModuleLoaderOptions } from "./types.ts";
 import { readLimitedCrossProjectSource } from "#veryfront/modules/server/cross-project-source-limit.ts";
+import { base64urlEncode } from "#veryfront/utils/base64url.ts";
 
 interface CrossProjectImportCache {
   hashContentAsync(content: string): Promise<string>;
@@ -41,6 +42,21 @@ function getRegistryBaseUrl(apiBaseUrl?: string): string {
   return resolvedApiBaseUrl.replace(/\/api\/?$/, "");
 }
 
+interface CrossProjectImportCacheKeyOptions {
+  specifier: string;
+  projectId: string;
+  reactVersion?: string;
+  registryBaseUrl: string;
+}
+
+export function buildCrossProjectImportCacheKey(
+  options: CrossProjectImportCacheKeyOptions,
+): string {
+  const reactVersion = options.reactVersion ?? "default";
+  const registryKey = base64urlEncode(options.registryBaseUrl);
+  return `${options.specifier}:${options.projectId}:${reactVersion}:registry:${registryKey}`;
+}
+
 export async function transformCrossProjectImportFlow(
   flowOptions: TransformCrossProjectImportFlowOptions,
 ): Promise<string> {
@@ -57,13 +73,17 @@ export async function transformCrossProjectImportFlow(
   } = flowOptions;
 
   const { specifier, projectSlug, version, path } = crossProjectImport;
-  const reactVersion = options.reactVersion ?? "default";
-  const cacheKey = `${specifier}:${options.projectId}:${reactVersion}`;
+  const registryBaseUrl = getRegistryBaseUrl(options.apiBaseUrl);
+  const cacheKey = buildCrossProjectImportCacheKey({
+    specifier,
+    projectId: options.projectId,
+    reactVersion: options.reactVersion,
+    registryBaseUrl,
+  });
 
   const cachedEntry = globalCrossProjectCache.get(cacheKey);
   if (cachedEntry) return cachedEntry.tempPath;
 
-  const registryBaseUrl = getRegistryBaseUrl(options.apiBaseUrl);
   const projectRef = `${projectSlug}@${version}`;
   const registryUrl = `${registryBaseUrl}/${projectRef}/@/${path}`;
 

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
@@ -37,6 +37,37 @@ class FakeDistributedCache implements CacheBackend {
 }
 
 describe("SSRCacheManager", { sanitizeResources: false, sanitizeOps: false }, () => {
+  it("separates SSR module cache identity by API base URL", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-cache-manager-" });
+    const baseOptions = {
+      projectDir,
+      projectId: "project-a",
+      contentSourceId: "preview-main",
+      adapter: denoAdapter,
+      dev: true,
+      reactVersion: "19.1.1",
+    };
+
+    try {
+      const registryA = new SSRCacheManager({
+        ...baseOptions,
+        apiBaseUrl: "https://registry-a.example.com/api",
+      });
+      const registryB = new SSRCacheManager({
+        ...baseOptions,
+        apiBaseUrl: "https://registry-b.example.com/api",
+      });
+
+      assertNotEquals(registryA.getConfigHash(), registryB.getConfigHash());
+      assertNotEquals(
+        registryA.getCacheKey("/project/pages/index.tsx"),
+        registryB.getCacheKey("/project/pages/index.tsx"),
+      );
+    } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
   it("recovers missing vfmod dependencies for redis cache entries", async () => {
     const projectDir = await makeTempDir({ prefix: "vf-ssr-cache-manager-" });
     const distributedCache = new FakeDistributedCache();

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
@@ -52,6 +52,7 @@ export class SSRCacheManager {
       this.cachedConfigHash = computeConfigHashSync({
         reactVersion: this.options.reactVersion,
         dev: this.options.dev,
+        apiBaseUrl: this.options.apiBaseUrl,
       });
     }
     return this.cachedConfigHash;

--- a/src/rendering/component-handling.test.ts
+++ b/src/rendering/component-handling.test.ts
@@ -1,0 +1,295 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { DEFAULT_REACT_VERSION } from "#veryfront/transforms/import-rewriter/url-builder.ts";
+import { bundleComponentForClient } from "./component-handling.ts";
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("Timed out waiting for condition");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("rendering/component-handling", () => {
+  it("shares one client bundle transform for concurrent cold misses", async () => {
+    let transformCalls = 0;
+    const transform = Promise.withResolvers<string>();
+
+    const first = bundleComponentForClient(
+      "export default function Page() { return null; }",
+      "/project/app/page.tsx",
+      "/project",
+      {} as RuntimeAdapter,
+      undefined,
+      "project-1",
+      "19.1.0",
+      {
+        transformToESM: () => {
+          transformCalls++;
+          return transform.promise;
+        },
+      },
+    );
+    const second = bundleComponentForClient(
+      "export default function Page() { return null; }",
+      "/project/app/page.tsx",
+      "/project",
+      {} as RuntimeAdapter,
+      undefined,
+      "project-1",
+      "19.1.0",
+      {
+        transformToESM: () => {
+          transformCalls++;
+          return transform.promise;
+        },
+      },
+    );
+
+    await waitFor(() => transformCalls > 0);
+    assertEquals(transformCalls, 1);
+
+    transform.resolve("export default function Page() { return null; }");
+
+    assertEquals(await Promise.all([first, second]), [
+      "export default function Page() { return null; }",
+      "export default function Page() { return null; }",
+    ]);
+    assertEquals(transformCalls, 1);
+  });
+
+  it("retries after a failed client bundle transform", async () => {
+    let transformCalls = 0;
+    const failedTransform = Promise.withResolvers<string>();
+    const deps = {
+      transformToESM: () => {
+        transformCalls++;
+        return transformCalls === 1
+          ? failedTransform.promise
+          : Promise.resolve("export default function Page() { return null; }");
+      },
+    };
+
+    const first = bundleComponentForClient(
+      "export default function Page() { return null; }",
+      "/project/app/retry.tsx",
+      "/project",
+      {} as RuntimeAdapter,
+      undefined,
+      "project-1",
+      "19.1.0",
+      deps,
+    );
+    await waitFor(() => transformCalls > 0);
+    const rejected = assertRejects(
+      () => first,
+      Error,
+      "Component transformation failed",
+    );
+    failedTransform.reject(new Error("boom"));
+    await rejected;
+
+    assertEquals(
+      await bundleComponentForClient(
+        "export default function Page() { return null; }",
+        "/project/app/retry.tsx",
+        "/project",
+        {} as RuntimeAdapter,
+        undefined,
+        "project-1",
+        "19.1.0",
+        deps,
+      ),
+      "export default function Page() { return null; }",
+    );
+    assertEquals(transformCalls, 2);
+  });
+
+  it("caches client bundle transforms separately by module server URL and React version", async () => {
+    const source = "export default function Page() { return null; }";
+    const filePath = "/project/app/transform-identity.tsx";
+    const projectDir = "/project";
+    const projectId = "project-transform-identity";
+    const transformed: string[] = [];
+
+    const deps = {
+      transformToESM: (
+        _source: string,
+        _filePath: string,
+        _projectDir: string,
+        _adapter: RuntimeAdapter,
+        options: { moduleServerUrl?: string; reactVersion?: string },
+      ) => {
+        const result = `${options.moduleServerUrl}:${options.reactVersion}`;
+        transformed.push(result);
+        return Promise.resolve(result);
+      },
+    };
+
+    const bundle = (moduleServerUrl: string, reactVersion: string) =>
+      bundleComponentForClient(
+        source,
+        filePath,
+        projectDir,
+        {} as RuntimeAdapter,
+        moduleServerUrl,
+        projectId,
+        reactVersion,
+        deps,
+      );
+
+    assertEquals(
+      await bundle("https://modules-a.example.test", "19.1.0"),
+      "https://modules-a.example.test:19.1.0",
+    );
+    assertEquals(
+      await bundle("https://modules-b.example.test", "19.1.0"),
+      "https://modules-b.example.test:19.1.0",
+    );
+    assertEquals(
+      await bundle("https://modules-a.example.test", "19.2.0"),
+      "https://modules-a.example.test:19.2.0",
+    );
+    assertEquals(transformed, [
+      "https://modules-a.example.test:19.1.0",
+      "https://modules-b.example.test:19.1.0",
+      "https://modules-a.example.test:19.2.0",
+    ]);
+  });
+
+  it("uses the default React version for missing completed-cache identity", async () => {
+    const source = "export default function Page() { return null; }";
+    const filePath = "/project/app/default-react-identity.tsx";
+    const projectDir = "/project";
+    const projectId = "project-default-react-identity";
+    let transformCalls = 0;
+
+    const deps = {
+      transformToESM: () => {
+        transformCalls++;
+        return Promise.resolve("default-react-bundle");
+      },
+    };
+
+    const bundle = (reactVersion?: string) =>
+      bundleComponentForClient(
+        source,
+        filePath,
+        projectDir,
+        {} as RuntimeAdapter,
+        "https://modules-a.example.test",
+        projectId,
+        reactVersion,
+        deps,
+      );
+
+    assertEquals(await bundle(undefined), "default-react-bundle");
+    assertEquals(await bundle(DEFAULT_REACT_VERSION), "default-react-bundle");
+    assertEquals(transformCalls, 1);
+  });
+
+  it("does not share in-flight client bundle transforms across module server URL and React version", async () => {
+    const source = "export default function Page() { return null; }";
+    const filePath = "/project/app/transform-flight-identity.tsx";
+    const projectDir = "/project";
+    const projectId = "project-transform-flight-identity";
+    const transforms = new Map<
+      string,
+      ReturnType<typeof Promise.withResolvers<string>>
+    >();
+
+    const deps = {
+      transformToESM: (
+        _source: string,
+        _filePath: string,
+        _projectDir: string,
+        _adapter: RuntimeAdapter,
+        options: { moduleServerUrl?: string; reactVersion?: string },
+      ) => {
+        const key = `${options.moduleServerUrl}:${options.reactVersion}`;
+        const transform = Promise.withResolvers<string>();
+        transforms.set(key, transform);
+        return transform.promise;
+      },
+    };
+
+    const bundle = (moduleServerUrl: string, reactVersion: string) =>
+      bundleComponentForClient(
+        source,
+        filePath,
+        projectDir,
+        {} as RuntimeAdapter,
+        moduleServerUrl,
+        projectId,
+        reactVersion,
+        deps,
+      );
+
+    const baseline = bundle("https://modules-a.example.test", "19.1.0");
+    const moduleServerChanged = bundle("https://modules-b.example.test", "19.1.0");
+    const reactChanged = bundle("https://modules-a.example.test", "19.2.0");
+
+    await waitFor(() => transforms.size === 3);
+    transforms.get("https://modules-a.example.test:19.1.0")?.resolve("bundle-a");
+    transforms.get("https://modules-b.example.test:19.1.0")?.resolve("bundle-b");
+    transforms.get("https://modules-a.example.test:19.2.0")?.resolve("bundle-c");
+
+    assertEquals(await Promise.all([baseline, moduleServerChanged, reactChanged]), [
+      "bundle-a",
+      "bundle-b",
+      "bundle-c",
+    ]);
+  });
+
+  it("does not let a stale transform overwrite its replacement cache entry", async () => {
+    using time = new FakeTime();
+    const staleTransform = Promise.withResolvers<string>();
+    const transformStarted = Promise.withResolvers<void>();
+    let transformCalls = 0;
+    const source = "export default function Page() { return null; }";
+    const args = [
+      source,
+      "/project/app/stale.tsx",
+      "/project",
+      {} as RuntimeAdapter,
+      undefined,
+      "project-1",
+      "19.1.0",
+    ] as const;
+
+    const stale = bundleComponentForClient(...args, {
+      transformToESM: () => {
+        transformCalls++;
+        transformStarted.resolve(undefined);
+        return staleTransform.promise;
+      },
+    });
+    await transformStarted.promise;
+
+    await time.tickAsync(5 * 60_000);
+    const replacement = await bundleComponentForClient(...args, {
+      transformToESM: () => {
+        transformCalls++;
+        return Promise.resolve("replacement-code");
+      },
+    });
+    assertEquals(replacement, "replacement-code");
+
+    staleTransform.resolve("stale-code");
+    assertEquals(await stale, "stale-code");
+    assertEquals(
+      await bundleComponentForClient(...args, {
+        transformToESM: () => {
+          transformCalls++;
+          return Promise.resolve("unexpected-code");
+        },
+      }),
+      "replacement-code",
+    );
+    assertEquals(transformCalls, 2);
+  });
+});

--- a/src/rendering/component-handling.ts
+++ b/src/rendering/component-handling.ts
@@ -11,6 +11,8 @@ import { getProjectReact } from "#veryfront/react";
 import { buildComponentCacheKey } from "#veryfront/cache/keys.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache";
+import { Singleflight } from "#veryfront/utils/singleflight.ts";
+import { DEFAULT_REACT_VERSION } from "#veryfront/transforms/import-rewriter/url-builder.ts";
 
 interface ComponentPageResult {
   pageElement: BundledReact.ReactElement;
@@ -19,17 +21,55 @@ interface ComponentPageResult {
 
 /**
  * Cache for transformed component hydration bundles.
- * Keys are content-addressed: `component:${projectId}:${filePath}:${sha256(source)}`.
- * Safe for multi-tenant use (project-scoped + content-hashed).
+ * Keys are content-addressed and scoped to transform-affecting inputs.
+ * Safe for multi-tenant use (project-scoped + content/transform-hashed).
  * Evicted when exceeding MAX_COMPONENT_CACHE_SIZE to prevent unbounded memory growth.
  */
 const MAX_COMPONENT_CACHE_SIZE = 5_000;
 const componentHydrationCache = new LRUCache<string, string>({
   maxEntries: MAX_COMPONENT_CACHE_SIZE,
 });
+const componentHydrationFlights = new Singleflight<string>();
+const COMPONENT_HYDRATION_FLIGHT_STALE_EVICTION_MS = 5 * 60_000;
+
+interface BundleComponentForClientDeps {
+  transformToESM: (
+    source: string,
+    filePath: string,
+    projectDir: string,
+    adapter: RuntimeAdapter,
+    options: {
+      projectId: string;
+      dev: boolean;
+      jsxImportSource: string;
+      moduleServerUrl?: string;
+      reactVersion?: string;
+    },
+  ) => Promise<string>;
+}
+
+async function getBundleComponentForClientDeps(): Promise<BundleComponentForClientDeps> {
+  const { transformToESM } = await import("#veryfront/transforms/esm-transform.ts");
+  return { transformToESM };
+}
 
 // Register cache for monitoring
 registerLRUCache("component-hydration-cache", componentHydrationCache);
+
+async function buildComponentHydrationCacheHash(
+  source: string,
+  moduleServerUrl?: string,
+  reactVersion?: string,
+): Promise<string> {
+  const sourceHash = await computeHash(source);
+  const effectiveReactVersion = reactVersion ?? DEFAULT_REACT_VERSION;
+  const cacheIdentity = JSON.stringify([
+    sourceHash,
+    moduleServerUrl ?? null,
+    effectiveReactVersion,
+  ]);
+  return (await computeHash(cacheIdentity)).slice(0, 16);
+}
 
 /**
  * Load and render a TSX/JSX component page
@@ -129,7 +169,7 @@ export async function handleComponentPage(
   }
 }
 
-async function bundleComponentForClient(
+export async function bundleComponentForClient(
   source: string,
   filePath: string,
   projectDir: string,
@@ -137,23 +177,46 @@ async function bundleComponentForClient(
   moduleServerUrl?: string,
   projectId?: string,
   reactVersion?: string,
-): Promise<string | null> {
+  injectedDeps?: BundleComponentForClientDeps,
+): Promise<string> {
   try {
-    const contentHash = (await computeHash(source)).slice(0, 16);
-    const cacheKey = buildComponentCacheKey(projectId ?? projectDir, filePath, contentHash);
+    const cacheHash = await buildComponentHydrationCacheHash(
+      source,
+      moduleServerUrl,
+      reactVersion,
+    );
+    const cacheKey = buildComponentCacheKey(projectId ?? projectDir, filePath, cacheHash);
     const cached = componentHydrationCache.get(cacheKey);
     if (cached) return cached;
 
-    const { transformToESM } = await import("#veryfront/transforms/esm-transform.ts");
-    const transformed = await transformToESM(source, filePath, projectDir, adapter, {
-      projectId: projectId ?? projectDir,
-      dev: true,
-      jsxImportSource: "react",
-      moduleServerUrl,
-      reactVersion,
-    });
+    const transformed = await componentHydrationFlights.do(
+      cacheKey,
+      async (control) => {
+        const cachedDuringFlight = componentHydrationCache.get(cacheKey);
+        if (cachedDuringFlight) return cachedDuringFlight;
 
-    componentHydrationCache.set(cacheKey, transformed);
+        const { transformToESM } = injectedDeps ?? await getBundleComponentForClientDeps();
+        const transformed = await transformToESM(source, filePath, projectDir, adapter, {
+          projectId: projectId ?? projectDir,
+          dev: true,
+          jsxImportSource: "react",
+          moduleServerUrl,
+          reactVersion,
+        });
+
+        if (control.isCurrent()) {
+          componentHydrationCache.set(cacheKey, transformed);
+        }
+        return transformed;
+      },
+      {
+        staleAfterMs: COMPONENT_HYDRATION_FLIGHT_STALE_EVICTION_MS,
+        onStaleEvicted: () => {
+          logger.warn("Evicted stale component hydration transform flight", { filePath });
+        },
+      },
+    );
+
     return transformed;
   } catch (error) {
     const errorMessage = getErrorMessage(error);

--- a/src/rendering/layouts/utils/component-loader.test.ts
+++ b/src/rendering/layouts/utils/component-loader.test.ts
@@ -1,16 +1,34 @@
 import "#veryfront/schemas/_test-setup.ts";
 import * as React from "react";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
 import {
   createLayoutComponentCache,
   loadMDXLayout,
+  loadTSXComponent,
   shouldUnwrapAppRouterDocumentLayout,
   unwrapAppRouterDocumentLayout,
 } from "./component-loader.ts";
 import { mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
 import type { MdxBundle } from "#veryfront/types";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("Timed out waiting for condition");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+function layoutAdapter(source: string): RuntimeAdapter {
+  return {
+    fs: {
+      readFile: () => Promise.resolve(source),
+    },
+  } as unknown as RuntimeAdapter;
+}
 
 describe("rendering/layouts/utils/component-loader", () => {
   describe("createLayoutComponentCache", () => {
@@ -289,6 +307,165 @@ describe("rendering/layouts/utils/component-loader", () => {
       assertEquals(result.type, "main");
       const child = React.Children.only(result.props.children) as React.ReactElement;
       assertEquals(child.type, "button");
+    });
+  });
+
+  describe("loadTSXComponent", () => {
+    it("shares one component load for concurrent cold misses", async () => {
+      const cache = createLayoutComponentCache();
+      const loaded = Promise.withResolvers<React.ComponentType>();
+      let loadCalls = 0;
+      function Layout() {
+        return null;
+      }
+
+      const first = loadTSXComponent(
+        "/project/app/layout.tsx",
+        "/project",
+        cache,
+        layoutAdapter("export default function Layout() { return null; }"),
+        "project-1",
+        "project-slug",
+        "release-1",
+        "19.1.0",
+        {
+          loadComponentFromSource: () => {
+            loadCalls++;
+            return loaded.promise;
+          },
+        },
+      );
+      const second = loadTSXComponent(
+        "/project/app/layout.tsx",
+        "/project",
+        cache,
+        layoutAdapter("export default function Layout() { return null; }"),
+        "project-1",
+        "project-slug",
+        "release-1",
+        "19.1.0",
+        {
+          loadComponentFromSource: () => {
+            loadCalls++;
+            return loaded.promise;
+          },
+        },
+      );
+
+      await waitFor(() => loadCalls > 0);
+      assertEquals(loadCalls, 1);
+
+      loaded.resolve(Layout);
+
+      assertEquals(await Promise.all([first, second]), [Layout, Layout]);
+      assertEquals(loadCalls, 1);
+    });
+
+    it("retries after a failed component load", async () => {
+      const cache = createLayoutComponentCache();
+      const failedLoad = Promise.withResolvers<React.ComponentType>();
+      let loadCalls = 0;
+      function Layout() {
+        return null;
+      }
+      const deps = {
+        loadComponentFromSource: () => {
+          loadCalls++;
+          return loadCalls === 1 ? failedLoad.promise : Promise.resolve(Layout);
+        },
+      };
+
+      const first = loadTSXComponent(
+        "/project/app/retry-layout.tsx",
+        "/project",
+        cache,
+        layoutAdapter("export default function Layout() { return null; }"),
+        "project-1",
+        "project-slug",
+        "release-1",
+        "19.1.0",
+        deps,
+      );
+      await waitFor(() => loadCalls > 0);
+      const rejected = assertRejects(() => first, Error, "load failed");
+      failedLoad.reject(new Error("load failed"));
+      await rejected;
+
+      assertEquals(
+        await loadTSXComponent(
+          "/project/app/retry-layout.tsx",
+          "/project",
+          cache,
+          layoutAdapter("export default function Layout() { return null; }"),
+          "project-1",
+          "project-slug",
+          "release-1",
+          "19.1.0",
+          deps,
+        ),
+        Layout,
+      );
+      assertEquals(loadCalls, 2);
+    });
+
+    it("does not let a stale load overwrite its replacement cache entry", async () => {
+      using time = new FakeTime();
+      const cache = createLayoutComponentCache();
+      const staleLoad = Promise.withResolvers<React.ComponentType>();
+      const loadStarted = Promise.withResolvers<void>();
+      let loadCalls = 0;
+      function StaleLayout() {
+        return null;
+      }
+      function ReplacementLayout() {
+        return null;
+      }
+      function UnexpectedLayout() {
+        return null;
+      }
+      const args = [
+        "/project/app/stale-layout.tsx",
+        "/project",
+        cache,
+        layoutAdapter("export default function Layout() { return null; }"),
+        "project-1",
+        "project-slug",
+        "release-1",
+        "19.1.0",
+      ] as const;
+
+      const stale = loadTSXComponent(...args, {
+        loadComponentFromSource: () => {
+          loadCalls++;
+          loadStarted.resolve(undefined);
+          return staleLoad.promise;
+        },
+      });
+      await loadStarted.promise;
+
+      await time.tickAsync(5 * 60_000);
+      assertEquals(
+        await loadTSXComponent(...args, {
+          loadComponentFromSource: () => {
+            loadCalls++;
+            return Promise.resolve(ReplacementLayout);
+          },
+        }),
+        ReplacementLayout,
+      );
+
+      staleLoad.resolve(StaleLayout);
+      assertEquals(await stale, StaleLayout);
+      assertEquals(
+        await loadTSXComponent(...args, {
+          loadComponentFromSource: () => {
+            loadCalls++;
+            return Promise.resolve(UnexpectedLayout);
+          },
+        }),
+        ReplacementLayout,
+      );
+      assertEquals(loadCalls, 2);
     });
   });
 

--- a/src/rendering/layouts/utils/component-loader.ts
+++ b/src/rendering/layouts/utils/component-loader.ts
@@ -19,6 +19,7 @@ import { getProjectReact } from "#veryfront/react";
 import { ensureValidChild } from "./ensure-valid-child.ts";
 import { buildLayoutComponentCacheKey, CacheKeyPrefix } from "#veryfront/cache/keys.ts";
 import { LAYOUT_EXTENSIONS } from "#veryfront/rendering/layouts/types.ts";
+import { Singleflight } from "#veryfront/utils/singleflight.ts";
 
 const loadMdxLayoutLog = logger.component("load-mdx-layout");
 const applyTsxLayoutLog = logger.component("apply-tsx-layout");
@@ -26,6 +27,7 @@ const applyMdxLayoutLog = logger.component("apply-mdx-layout");
 const APP_ROUTER_SCRIPT_LAYOUT_EXTENSIONS = LAYOUT_EXTENSIONS.filter((extension) =>
   extension !== "md" && extension !== "mdx"
 );
+const TSX_COMPONENT_FLIGHT_STALE_EVICTION_MS = 5 * 60_000;
 
 type AppRouterDocumentLayoutFunction = (
   props: { children?: BundledReact.ReactNode },
@@ -37,6 +39,26 @@ export interface LayoutComponentCache {
   delete(key: string): void;
   clear(): void;
   clearForProject?(projectId: string): void;
+}
+
+interface LoadTSXComponentDeps {
+  loadComponentFromSource: typeof loadComponentFromSource;
+}
+
+const tsxComponentFlights = new WeakMap<
+  LayoutComponentCache,
+  Singleflight<BundledReact.ComponentType>
+>();
+
+function getTSXComponentFlights(
+  cache: LayoutComponentCache,
+): Singleflight<BundledReact.ComponentType> {
+  let flights = tsxComponentFlights.get(cache);
+  if (!flights) {
+    flights = new Singleflight<BundledReact.ComponentType>();
+    tsxComponentFlights.set(cache, flights);
+  }
+  return flights;
 }
 
 class InMemoryLayoutComponentCache implements LayoutComponentCache {
@@ -229,6 +251,7 @@ export async function loadTSXComponent(
   projectSlug: string,
   contentSourceId: string,
   reactVersion?: string,
+  deps: LoadTSXComponentDeps = { loadComponentFromSource },
 ): Promise<BundledReact.ComponentType> {
   const source = await adapter.fs.readFile(componentPath);
   const hash = await computeHash(source);
@@ -238,25 +261,50 @@ export async function loadTSXComponent(
   const cached = cache.get(cacheKey);
   if (cached) return cached;
 
-  const loaded = await loadComponentFromSource(source, componentPath, projectDir, adapter, {
-    dev: true,
-    projectId,
-    projectSlug,
-    ssr: true,
-    contentSourceId,
-    reactVersion,
-  });
+  const loaded = await getTSXComponentFlights(cache).do(
+    cacheKey,
+    async (control) => {
+      const cachedDuringFlight = cache.get(cacheKey);
+      if (cachedDuringFlight) return cachedDuringFlight;
 
-  if (!loaded) {
-    throw toError(
-      createError({
-        type: "render",
-        message: "Component loading failed",
-      }),
-    );
-  }
+      const loaded = await deps.loadComponentFromSource(
+        source,
+        componentPath,
+        projectDir,
+        adapter,
+        {
+          dev: true,
+          projectId,
+          projectSlug,
+          ssr: true,
+          contentSourceId,
+          reactVersion,
+        },
+      );
 
-  cache.set(cacheKey, loaded);
+      if (!loaded) {
+        throw toError(
+          createError({
+            type: "render",
+            message: "Component loading failed",
+          }),
+        );
+      }
+
+      if (control.isCurrent()) {
+        cache.set(cacheKey, loaded);
+      }
+      return loaded;
+    },
+    {
+      staleAfterMs: TSX_COMPONENT_FLIGHT_STALE_EVICTION_MS,
+      onStaleEvicted: () => {
+        applyTsxLayoutLog.warn("Evicted stale TSX layout component load flight", {
+          componentPath,
+        });
+      },
+    },
+  );
   return loaded;
 }
 

--- a/src/transforms/pipeline/index.test.ts
+++ b/src/transforms/pipeline/index.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 /** @module transforms/pipeline/index.test */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   makeTempDir,
@@ -59,6 +59,45 @@ export default function App() { return dep; }`;
       } finally {
         await remove(projectDir, { recursive: true });
         await remove(externalDir, { recursive: true });
+      }
+    });
+
+    it("keeps browser transform cache entries separate by moduleServerUrl", async () => {
+      const projectDir = await makeTempDir({ prefix: "vf-pipeline-cache-proj-" });
+      const mainFile = join(projectDir, "main.tsx");
+      const depFile = join(projectDir, "dep.ts");
+
+      try {
+        const mainSource = `import { dep } from "./dep";
+export default function App() { return dep; }`;
+
+        await writeTextFile(mainFile, mainSource);
+        await writeTextFile(depFile, "export const dep = 1;");
+
+        const adapter = {
+          fs: {
+            readFile: (path: string): Promise<string> => readTextFile(path),
+          },
+        };
+
+        const firstCode = await transformToESM(mainSource, mainFile, projectDir, adapter, {
+          ssr: false,
+          dev: true,
+          projectId: "test-project",
+          moduleServerUrl: "https://modules-a.example.test/_vf_modules",
+        });
+
+        const secondCode = await transformToESM(mainSource, mainFile, projectDir, adapter, {
+          ssr: false,
+          dev: true,
+          projectId: "test-project",
+          moduleServerUrl: "https://modules-b.example.test/_vf_modules",
+        });
+
+        assertStringIncludes(firstCode, "https://modules-a.example.test/_vf_modules");
+        assertStringIncludes(secondCode, "https://modules-b.example.test/_vf_modules");
+      } finally {
+        await remove(projectDir, { recursive: true });
       }
     });
   },

--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -156,6 +156,9 @@ export function runPipeline(
       const configHash = await computeConfigHash({
         reactVersion: ctx.reactVersion,
         jsxImportSource: ctx.jsxImportSource,
+        moduleServerUrl: ctx.moduleServerUrl,
+        vendorBundleHash: ctx.vendorBundleHash,
+        apiBaseUrl: ctx.apiBaseUrl,
         studioEmbed: ctx.studioEmbed,
         dev: ctx.dev,
       });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1150";
+export const VERSION = "0.1.1151";


### PR DESCRIPTION
## Why

Authenticated Pages SSR can issue concurrent requests while client hydration and TSX layout caches are still cold. Those caches stored only completed values, so every concurrent miss repeated the same expensive transform or load. Deployed /review traffic reached multi-second render.prepare_bundles work and intermittent 5xx responses.

## What

- coalesce same-key client hydration transforms at the completed-cache owner
- coalesce TSX layout loads per LayoutComponentCache instance
- recheck completed caches inside each Singleflight leader
- publish completed values only after success and only from the current leader
- evict never-settling flights after five minutes without allowing stale leaders to overwrite replacements
- keep transform sharing correct across runtime configurations by including module server, React, vendor bundle, API registry, and cross-project registry inputs in the cache identities that can bypass transforms
- use collision-safe identity encoding and preserve the raw project owner boundary
- add regressions for concurrency, failure and retry, stale replacement, completed-cache separation, in-flight separation, and full transformToESM cache separation
- bump the framework version from 0.1.1150 to 0.1.1151

## Verification

- 75 focused cache, pipeline, Singleflight, component, layout, SSR manager, and cross-project steps: green
- review cleanup suite: 35 steps green, plus deno check and formatting
- deno task verify:quick: green
- final pre-push gate: 2,685 tests / 21,818 steps green
- independent architecture and performance reviews: CLEAR; comprehensive review: APPROVE

## Deployment verification after release

The consumer project will pin 0.1.1151, deploy it, then remeasure authenticated /review and /chat including concurrent cold requests and rerun the end-to-end attachment workflow.