### PR TITLE
fix(deploy): wait for release source convergence

### DIFF
--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -227,9 +227,18 @@ it("uses canonical production read-back in human and JSON modes", async () => {
       using time = new FakeTime();
       resumeReleaseSourceRead();
       await time.tickAsync(0);
-      for (let attempt = 1; attempt < 20; attempt++) {
+      for (
+        let tick = 0;
+        releaseSourceReads < 20 && tick < 40;
+        tick++
+      ) {
         await time.tickAsync(500);
       }
+      assertEquals(
+        releaseSourceReads,
+        20,
+        "release-source polling did not exhaust its fixed read budget",
+      );
       await assertRejects(
         () => deployment,
         Error,

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -7,6 +7,7 @@ import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { computeSourceDigest, writePushReceipt } from "../../shared/deployment-provenance.ts";
 import { setJsonMode } from "../../shared/json-output.ts";
 import { deployCommand, type DeploymentRoutingConvergence } from "./command.ts";
+import { FakeTime } from "#std/testing/time";
 
 const PROJECT_ID = "550e8400-e29b-41d4-a716-446655440000";
 const ENVIRONMENT_ID = "660e8400-e29b-41d4-a716-446655440000";
@@ -73,7 +74,11 @@ it("uses canonical production read-back in human and JSON modes", async () => {
     Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
     _resetEnvironmentConfig();
 
-    let releaseSourceContent = "export const value = 1;\n";
+    const currentReleaseSource = "export const value = 1;\n";
+    let releaseSourceContents: string[] | null = null;
+    let releaseSourceReads = 0;
+    let releaseSourceReadGate: Promise<void> | null = null;
+    let notifyReleaseSourceRead: (() => void) | null = null;
     let routingConvergence: DeploymentRoutingConvergence = {
       status: "converged",
       acknowledged: 2,
@@ -137,10 +142,17 @@ it("uses canonical production read-back in human and JSON modes", async () => {
         request.method === "GET" &&
         url.pathname.endsWith(`/releases/${RELEASE_ID}/versions`)
       ) {
+        releaseSourceReads++;
+        notifyReleaseSourceRead?.();
+        notifyReleaseSourceRead = null;
+        if (releaseSourceReadGate) await releaseSourceReadGate;
         return Response.json({
           data: [{
             path: "app.ts",
-            data: JSON.stringify({ body: releaseSourceContent, path: "app.ts" }),
+            data: JSON.stringify({
+              body: releaseSourceContents?.shift() ?? currentReleaseSource,
+              path: "app.ts",
+            }),
           }],
           page_info: {},
         });
@@ -163,15 +175,19 @@ it("uses canonical production read-back in human and JSON modes", async () => {
       setJsonMode(jsonMode);
       requests.length = 0;
       environmentReads = 0;
+      releaseSourceReads = 0;
+      releaseSourceContents = ["export const value = 0;\n", currentReleaseSource];
 
       await withMockFetch(handleRequest, runDeploy);
 
       assertEquals(environmentReads, 2);
+      assertEquals(releaseSourceReads, 2);
       assertEquals(requests, [
         "GET /api/projects/my-project",
         `GET /api/projects/${PROJECT_ID}/environments`,
         `POST /api/projects/${PROJECT_ID}/releases`,
         `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}`,
+        `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}/versions`,
         `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}/versions`,
         `POST /api/projects/${PROJECT_ID}/deployments`,
         `GET /api/projects/${PROJECT_ID}/deployments/${DEPLOYMENT_ID}`,
@@ -183,28 +199,63 @@ it("uses canonical production read-back in human and JSON modes", async () => {
     routingConvergence = { status: "pending" };
     requests.length = 0;
     environmentReads = 0;
+    releaseSourceReads = 0;
+    releaseSourceContents = null;
 
     await withMockFetch(handleRequest, runDeploy);
     assertEquals(environmentReads, 2);
 
     setJsonMode(false);
-    releaseSourceContent = "export const value = 2;\n";
+    releaseSourceContents = Array.from(
+      { length: 20 },
+      () => "export const value = 2;\n",
+    );
     requests.length = 0;
     environmentReads = 0;
+    releaseSourceReads = 0;
 
-    await assertRejects(
-      () => withMockFetch(handleRequest, runDeploy),
-      Error,
-      "does not match pushed commit",
-    );
+    const firstReleaseSourceRead = new Promise<void>((resolve) => {
+      notifyReleaseSourceRead = resolve;
+    });
+    let resumeReleaseSourceRead!: () => void;
+    releaseSourceReadGate = new Promise<void>((resolve) => {
+      resumeReleaseSourceRead = resolve;
+    });
+    const deployment = withMockFetch(handleRequest, runDeploy);
+    await firstReleaseSourceRead;
+    {
+      using time = new FakeTime();
+      resumeReleaseSourceRead();
+      await time.tickAsync(0);
+      for (let attempt = 1; attempt < 20; attempt++) {
+        await time.tickAsync(500);
+      }
+      await assertRejects(
+        () => deployment,
+        Error,
+        "does not match pushed commit",
+      );
+    }
+    releaseSourceReadGate = null;
     assertEquals(environmentReads, 1);
-    assertEquals(requests, [
+    assertEquals(releaseSourceReads, 20);
+    assertEquals(requests.slice(0, 4), [
       "GET /api/projects/my-project",
       `GET /api/projects/${PROJECT_ID}/environments`,
       `POST /api/projects/${PROJECT_ID}/releases`,
       `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}`,
-      `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}/versions`,
     ]);
+    assertEquals(
+      requests.filter((request) =>
+        request ===
+          `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}/versions`
+      ).length,
+      20,
+    );
+    assertEquals(
+      requests.includes(`POST /api/projects/${PROJECT_ID}/deployments`),
+      false,
+    );
   } finally {
     envKeys.forEach((key, index) => {
       const value = savedEnv[index];

--- a/cli/commands/deploy/command.test.ts
+++ b/cli/commands/deploy/command.test.ts
@@ -531,10 +531,260 @@ describe("release source verification", () => {
           releaseId: "release-1",
           commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
           sourceDigest: expectedDigest,
-        }),
+        }, { attempts: 1, delayMs: 0 }),
       Error,
       "does not match pushed commit",
     );
+  });
+
+  it("waits for a well-formed release source digest to match the pushed commit", async () => {
+    const expectedDigest = await computeSourceDigest([
+      { path: "app.ts", content: "commit B\n" },
+    ]);
+    let sourceReads = 0;
+    const mockClient = createMockClient({
+      get: (path) => {
+        if (path.endsWith("/versions")) {
+          sourceReads++;
+          return Promise.resolve({
+            data: [{
+              path: "app.ts",
+              data: JSON.stringify({
+                body: sourceReads === 1 ? "commit A\n" : "commit B\n",
+                path: "app.ts",
+              }),
+            }],
+            page_info: {},
+          });
+        }
+        return Promise.resolve({
+          id: "release-1",
+          name: "github-main-90719c01",
+          version: "0.0.41",
+          project_id: "project-1",
+        });
+      },
+    });
+
+    const result = await verifyReleaseSource(mockClient, "project-1", {
+      projectId: "project-1",
+      releaseId: "release-1",
+      commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+      sourceDigest: expectedDigest,
+    }, { attempts: 2, delayMs: 0 });
+
+    assertEquals(result.sourceDigest, expectedDigest);
+    assertEquals(sourceReads, 2);
+  });
+
+  it("fails closed after exhausting well-formed release source digest mismatches", async () => {
+    const expectedDigest = await computeSourceDigest([
+      { path: "app.ts", content: "commit A\n" },
+    ]);
+    const staleDigest = await computeSourceDigest([
+      { path: "app.ts", content: "commit B\n" },
+    ]);
+    let sourceReads = 0;
+    const mockClient = createMockClient({
+      get: (path) => {
+        if (path.endsWith("/versions")) {
+          sourceReads++;
+          return Promise.resolve({
+            data: [{
+              path: "app.ts",
+              data: JSON.stringify({ body: "commit B\n", path: "app.ts" }),
+            }],
+            page_info: {},
+          });
+        }
+        return Promise.resolve({
+          id: "release-1",
+          name: "github-main-90719c01",
+          version: "0.0.41",
+          project_id: "project-1",
+        });
+      },
+    });
+
+    await assertRejects(
+      () =>
+        verifyReleaseSource(mockClient, "project-1", {
+          projectId: "project-1",
+          releaseId: "release-1",
+          commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+          sourceDigest: expectedDigest,
+        }, { attempts: 2, delayMs: 0 }),
+      Error,
+      `expected source digest ${expectedDigest}; last observed ${staleDigest}`,
+    );
+    assertEquals(sourceReads, 2);
+  });
+
+  it("caps release source verification at the fixed polling budget", async () => {
+    const expectedDigest = await computeSourceDigest([
+      { path: "app.ts", content: "commit A\n" },
+    ]);
+    let sourceReads = 0;
+    const mockClient = createMockClient({
+      get: (path) => {
+        if (path.endsWith("/versions")) {
+          sourceReads++;
+          return Promise.resolve({
+            data: [{
+              path: "app.ts",
+              data: JSON.stringify({ body: "commit B\n", path: "app.ts" }),
+            }],
+            page_info: {},
+          });
+        }
+        return Promise.resolve({
+          id: "release-1",
+          name: "github-main-90719c01",
+          version: "0.0.41",
+          project_id: "project-1",
+        });
+      },
+    });
+
+    await assertRejects(
+      () =>
+        verifyReleaseSource(mockClient, "project-1", {
+          projectId: "project-1",
+          releaseId: "release-1",
+          commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+          sourceDigest: expectedDigest,
+        }, { attempts: 21, delayMs: 0 }),
+      Error,
+      "does not match pushed commit",
+    );
+    assertEquals(sourceReads, 20);
+  });
+
+  it("does not retry malformed source data or API failures", async () => {
+    const expectedDigest = await computeSourceDigest([]);
+
+    for (
+      const testCase of [
+        {
+          name: "malformed source data",
+          error: "has invalid version data",
+          versions: () =>
+            Promise.resolve({
+              data: [{ path: "app.ts", data: "not-json" }],
+              page_info: {},
+            }),
+        },
+        {
+          name: "source API failure",
+          error: "release source unavailable",
+          versions: () => Promise.reject(new Error("release source unavailable")),
+        },
+      ]
+    ) {
+      let sourceReads = 0;
+      const mockClient = createMockClient({
+        get: (path) => {
+          if (path.endsWith("/versions")) {
+            sourceReads++;
+            return testCase.versions();
+          }
+          return Promise.resolve({
+            id: "release-1",
+            name: "github-main-90719c01",
+            version: "0.0.41",
+            project_id: "project-1",
+          });
+        },
+      });
+
+      await assertRejects(
+        () =>
+          verifyReleaseSource(mockClient, "project-1", {
+            projectId: "project-1",
+            releaseId: "release-1",
+            commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+            sourceDigest: expectedDigest,
+          }, { attempts: 20, delayMs: 0 }),
+        Error,
+        testCase.error,
+        testCase.name,
+      );
+      assertEquals(sourceReads, 1, testCase.name);
+    }
+  });
+
+  it("rejects invalid release metadata before reading source versions", async () => {
+    const expectedDigest = await computeSourceDigest([]);
+
+    for (
+      const testCase of [
+        {
+          name: "release identity",
+          release: {
+            id: "other-release",
+            name: "github-main-90719c01",
+            version: "0.0.41",
+            project_id: "project-1",
+          },
+          error: "expected release-1",
+        },
+        {
+          name: "project ownership",
+          release: {
+            id: "release-1",
+            name: "github-main-90719c01",
+            version: "0.0.41",
+            project_id: "other-project",
+          },
+          error: "does not belong to resolved project",
+        },
+        {
+          name: "release name",
+          release: {
+            id: "release-1",
+            name: "other-release-name",
+            version: "0.0.41",
+            project_id: "project-1",
+          },
+          error: "no longer matches the created release name",
+        },
+        {
+          name: "release version",
+          release: {
+            id: "release-1",
+            name: "github-main-90719c01",
+            project_id: "project-1",
+          },
+          error: "has no version",
+        },
+      ]
+    ) {
+      let sourceReads = 0;
+      const mockClient = createMockClient({
+        get: (path) => {
+          if (path.endsWith("/versions")) {
+            sourceReads++;
+            return Promise.resolve({ data: [], page_info: {} });
+          }
+          return Promise.resolve(testCase.release);
+        },
+      });
+
+      await assertRejects(
+        () =>
+          verifyReleaseSource(mockClient, "project-1", {
+            projectId: "project-1",
+            releaseId: "release-1",
+            releaseName: "github-main-90719c01",
+            commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+            sourceDigest: expectedDigest,
+          }, { attempts: 20, delayMs: 0 }),
+        Error,
+        testCase.error,
+        testCase.name,
+      );
+      assertEquals(sourceReads, 0, testCase.name);
+    }
   });
 });
 
@@ -755,9 +1005,82 @@ describe("deployment verification", () => {
           deploymentId,
           commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
           sourceDigest,
-        }, { attempts: 1, delayMs: 0 }),
+        }, {
+          attempts: 1,
+          delayMs: 0,
+          releaseSource: { attempts: 1, delayMs: 0 },
+        }),
       Error,
       "does not match pushed commit",
     );
+  });
+
+  it("keeps release-source convergence independent from environment convergence", async () => {
+    const sourceDigest = await computeSourceDigest([
+      { path: "app.ts", content: "commit B\n" },
+    ]);
+    let sourceReads = 0;
+    const mockClient = createMockClient({
+      get: (path) => {
+        if (path.endsWith(`/deployments/${deploymentId}`)) {
+          return Promise.resolve({
+            id: deploymentId,
+            release: { id: releaseId },
+            environment: { id: environmentId },
+          });
+        }
+        if (path.endsWith(`/releases/${releaseId}`)) {
+          return Promise.resolve({
+            id: releaseId,
+            name: "github-main-90719c01",
+            version: "0.0.41",
+            project: projectId,
+          });
+        }
+        if (path.endsWith(`/releases/${releaseId}/versions`)) {
+          sourceReads++;
+          return Promise.resolve({
+            data: [{
+              path: "app.ts",
+              data: JSON.stringify({
+                body: sourceReads === 1 ? "commit A\n" : "commit B\n",
+                path: "app.ts",
+              }),
+            }],
+            page_info: {},
+          });
+        }
+        return Promise.resolve({
+          data: [{
+            id: environmentId,
+            name: "production",
+            project_id: projectId,
+            protected: true,
+            deployment: {
+              id: deploymentId,
+              release: { id: releaseId, name: "github-main-90719c01" },
+            },
+          }],
+        });
+      },
+    });
+
+    const result = await verifyDeployment(mockClient, "my-project", {
+      projectId,
+      projectSlug: "my-project",
+      environmentId,
+      environmentName: "production",
+      releaseId,
+      deploymentId,
+      commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+      sourceDigest,
+    }, {
+      attempts: 1,
+      delayMs: 0,
+      releaseSource: { attempts: 2, delayMs: 0 },
+    });
+
+    assertEquals(result.sourceDigest, sourceDigest);
+    assertEquals(sourceReads, 2);
   });
 });

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -165,10 +165,42 @@ interface DeploymentExpectation {
   releaseName?: string;
 }
 
-interface DeploymentVerificationOptions {
+interface VerificationRetryOptions {
   attempts?: number;
   delayMs?: number;
+}
+
+interface DeploymentVerificationOptions extends VerificationRetryOptions {
+  releaseSource?: VerificationRetryOptions;
   verifiedRelease?: ReleaseSourceVerification;
+}
+
+const MAX_RELEASE_SOURCE_VERIFICATION_ATTEMPTS = 20;
+const MAX_RELEASE_SOURCE_VERIFICATION_DELAY_MS = 500;
+
+// Release creation can precede source-snapshot materialization. Only a
+// successfully read, well-formed digest mismatch enters this convergence loop;
+// validation and exhausted API-client transport errors still fail closed.
+function boundedReleaseSourceVerificationOptions(
+  options: VerificationRetryOptions,
+): Required<VerificationRetryOptions> {
+  const attempts = options.attempts === undefined
+    ? MAX_RELEASE_SOURCE_VERIFICATION_ATTEMPTS
+    : Number.isFinite(options.attempts)
+    ? Math.min(
+      MAX_RELEASE_SOURCE_VERIFICATION_ATTEMPTS,
+      Math.max(1, Math.trunc(options.attempts)),
+    )
+    : MAX_RELEASE_SOURCE_VERIFICATION_ATTEMPTS;
+  const delayMs = options.delayMs === undefined
+    ? MAX_RELEASE_SOURCE_VERIFICATION_DELAY_MS
+    : Number.isFinite(options.delayMs)
+    ? Math.min(
+      MAX_RELEASE_SOURCE_VERIFICATION_DELAY_MS,
+      Math.max(0, Math.trunc(options.delayMs)),
+    )
+    : MAX_RELEASE_SOURCE_VERIFICATION_DELAY_MS;
+  return { attempts, delayMs };
 }
 
 /**
@@ -406,6 +438,7 @@ export async function verifyReleaseSource(
   client: ApiClient,
   projectReference: string,
   expected: ReleaseSourceExpectation,
+  options: VerificationRetryOptions = {},
 ): Promise<ReleaseSourceVerification> {
   const release = await getRelease(client, projectReference, expected.releaseId);
   if (release.id !== expected.releaseId) {
@@ -419,20 +452,27 @@ export async function verifyReleaseSource(
     throw new Error(`Release ${expected.releaseId} has no version`);
   }
 
-  const sourceDigest = await getReleaseSourceDigest(client, projectReference, expected.releaseId);
-  if (sourceDigest !== expected.sourceDigest) {
-    throw new Error(
-      `Release ${expected.releaseId} source does not match pushed commit ${expected.commitSha}`,
-    );
+  const { attempts, delayMs } = boundedReleaseSourceVerificationOptions(options);
+  let sourceDigest = "";
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    sourceDigest = await getReleaseSourceDigest(client, projectReference, expected.releaseId);
+    if (sourceDigest === expected.sourceDigest) {
+      return {
+        projectId: expected.projectId,
+        releaseId: expected.releaseId,
+        releaseVersion: release.version,
+        commitSha: expected.commitSha,
+        sourceDigest,
+      };
+    }
+
+    if (attempt < attempts - 1 && delayMs > 0) await wait(delayMs);
   }
 
-  return {
-    projectId: expected.projectId,
-    releaseId: expected.releaseId,
-    releaseVersion: release.version,
-    commitSha: expected.commitSha,
-    sourceDigest,
-  };
+  throw new Error(
+    `Release ${expected.releaseId} source does not match pushed commit ${expected.commitSha}: expected source digest ${expected.sourceDigest}; last observed ${sourceDigest}`,
+  );
 }
 
 export async function verifyDeployment(
@@ -455,6 +495,7 @@ export async function verifyDeployment(
     client,
     projectReference,
     expected,
+    options.releaseSource,
   );
   if (
     verifiedRelease.projectId !== expected.projectId ||

--- a/cli/mcp/tools/deploy-tool.test.ts
+++ b/cli/mcp/tools/deploy-tool.test.ts
@@ -382,9 +382,18 @@ describe("mcp/tools/deploy-tool", () => {
           using time = new FakeTime();
           resumeReleaseSourceRead();
           await time.tickAsync(0);
-          for (let attempt = 1; attempt < 20; attempt++) {
+          for (
+            let tick = 0;
+            releaseSourceReads < 20 && tick < 40;
+            tick++
+          ) {
             await time.tickAsync(500);
           }
+          assertEquals(
+            releaseSourceReads,
+            20,
+            "release-source polling did not exhaust its fixed read budget",
+          );
           mismatchResult = await deployment;
         }
         releaseSourceReadGate = null;

--- a/cli/mcp/tools/deploy-tool.test.ts
+++ b/cli/mcp/tools/deploy-tool.test.ts
@@ -9,6 +9,7 @@ import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { computeSourceDigest, writePushReceipt } from "../../shared/deployment-provenance.ts";
 import { triggerDeploy, vfTriggerDeploy } from "./deploy-tool.ts";
+import { FakeTime } from "#std/testing/time";
 
 // ---------------------------------------------------------------------------
 // Tool definition (shape)
@@ -210,7 +211,11 @@ describe("mcp/tools/deploy-tool", () => {
 
         const capturedRequests: { method: string; url: string }[] = [];
         let environmentReads = 0;
-        let releaseFiles: Array<{ path: string; data: string }> = [];
+        const releaseFiles: Array<{ path: string; data: string }> = [];
+        let releaseFileResponses: Array<Array<{ path: string; data: string }>> | null = null;
+        let releaseSourceReads = 0;
+        let releaseSourceReadGate: Promise<void> | null = null;
+        let notifyReleaseSourceRead: (() => void) | null = null;
 
         const handleRequest = async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
@@ -267,7 +272,14 @@ describe("mcp/tools/deploy-tool", () => {
           }
 
           if (method === "GET" && pathname.endsWith("/releases/rel-42/versions")) {
-            return Response.json({ data: releaseFiles, page_info: {} });
+            releaseSourceReads++;
+            notifyReleaseSourceRead?.();
+            notifyReleaseSourceRead = null;
+            if (releaseSourceReadGate) await releaseSourceReadGate;
+            return Response.json({
+              data: releaseFileResponses?.shift() ?? releaseFiles,
+              page_info: {},
+            });
           }
 
           if (method === "GET" && pathname.endsWith("/releases/rel-42")) {
@@ -320,20 +332,19 @@ describe("mcp/tools/deploy-tool", () => {
           ],
         );
 
-        releaseFiles = [{
+        releaseFileResponses = [[{
           path: "app.ts",
-          data: JSON.stringify({ body: "changed after push\n", path: "app.ts" }),
-        }];
+          data: JSON.stringify({ body: "stale release source\n", path: "app.ts" }),
+        }], []];
         capturedRequests.length = 0;
         environmentReads = 0;
-        const mismatchResult = await withMockFetch(handleRequest, runDeploy);
+        releaseSourceReads = 0;
+        const staleThenCurrentResult = await withMockFetch(handleRequest, runDeploy);
 
-        assertEquals(mismatchResult.success, false);
-        assertEquals(
-          mismatchResult.error?.includes("does not match pushed commit"),
-          true,
-          mismatchResult.error,
-        );
+        assertEquals(staleThenCurrentResult.success, true, staleThenCurrentResult.error);
+        assertEquals(staleThenCurrentResult.deploymentId, "deploy-99");
+        assertEquals(staleThenCurrentResult.sourceDigest, sourceDigest);
+        assertEquals(releaseSourceReads, 2);
         assertEquals(
           capturedRequests.map(({ method, url }) => `${method} ${new URL(url).pathname}`),
           [
@@ -342,7 +353,50 @@ describe("mcp/tools/deploy-tool", () => {
             "POST /api/projects/project-1/releases",
             "GET /api/projects/project-1/releases/rel-42",
             "GET /api/projects/project-1/releases/rel-42/versions",
+            "GET /api/projects/project-1/releases/rel-42/versions",
+            "POST /api/projects/project-1/deployments",
+            "GET /api/projects/project-1/deployments/deploy-99",
+            "GET /api/projects/project-1/environments",
           ],
+        );
+
+        releaseFileResponses = Array.from({ length: 20 }, () => [{
+          path: "app.ts",
+          data: JSON.stringify({ body: "stale release source\n", path: "app.ts" }),
+        }]);
+        capturedRequests.length = 0;
+        environmentReads = 0;
+        releaseSourceReads = 0;
+
+        const firstReleaseSourceRead = new Promise<void>((resolve) => {
+          notifyReleaseSourceRead = resolve;
+        });
+        let resumeReleaseSourceRead!: () => void;
+        releaseSourceReadGate = new Promise<void>((resolve) => {
+          resumeReleaseSourceRead = resolve;
+        });
+        const deployment = withMockFetch(handleRequest, runDeploy);
+        await firstReleaseSourceRead;
+        let mismatchResult;
+        {
+          using time = new FakeTime();
+          resumeReleaseSourceRead();
+          await time.tickAsync(0);
+          for (let attempt = 1; attempt < 20; attempt++) {
+            await time.tickAsync(500);
+          }
+          mismatchResult = await deployment;
+        }
+        releaseSourceReadGate = null;
+
+        assertEquals(mismatchResult.success, false);
+        assertEquals(mismatchResult.error?.includes("does not match pushed commit"), true);
+        assertEquals(releaseSourceReads, 20);
+        assertEquals(
+          capturedRequests.some(({ method, url }) =>
+            method === "POST" && new URL(url).pathname.endsWith("/deployments")
+          ),
+          false,
         );
       } finally {
         if (originalToken !== undefined) {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1151",
+  "version": "0.1.1152",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1151";
+export const VERSION = "0.1.1152";


### PR DESCRIPTION
## Why

A release can be created before its immutable source snapshot is visible through the versions endpoint. The CLI currently performs one strict digest read, so CI can reject a correctly pushed commit during this short control-plane convergence window.

Observed in `agentic-job-submission-processing`: deployment failed with a release-source mismatch; the same release later returned the exact pushed digest with zero file differences.

## What changed

- poll only successfully parsed source-digest mismatches (20 reads, 500 ms maximum interval)
- keep release identity/ownership/name/version validation single-shot and fail closed
- preserve the existing independent deployment-environment convergence controls
- never create the deployment until exact source identity is proven
- cover human CLI, JSON CLI, and MCP deploy paths, including exhaustion/no-deploy evidence
- bump framework version to `0.1.1152`

The shared API client’s existing transient transport retry remains separate: exhausted request errors and malformed source data escape the convergence loop immediately.

## Verification

- `deno task verify:quick`
- focused deploy unit/integration/MCP suite: 16 tests / 75 steps / 0 failed
- `deno task test:integration:cli`: 20 files / 169 steps / 0 failed
- `deno.lock` unchanged

## Release impact

Publishing `v0.1.1152` lets the consumer app retry its currently failing staging deployment without weakening source-identity guarantees.