### PR TITLE
fix(runtime): keep page routing on a current source snapshot

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1152",
+  "version": "0.1.1153",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/base.ts
+++ b/src/platform/adapters/base.ts
@@ -176,6 +176,16 @@ export interface FileSystemAdapter {
   resolveFile?(basePath: string, options?: ResolveFileOptions): Promise<string | null>;
   /** Refresh remote source snapshots when a preview render detects stale cached content. */
   refreshSourceSnapshot?(reason?: string): Promise<void>;
+  /**
+   * Confirm that a mutable remote source snapshot is within its freshness
+   * lease, coalescing the network check across concurrent requests.
+   */
+  ensureSourceSnapshotFresh?(reason?: string): Promise<void>;
+  /**
+   * Monotonic generation for the active source snapshot. Consumers can retain
+   * derived state while this value is unchanged.
+   */
+  getSourceSnapshotVersion?(): number | undefined | Promise<number | undefined>;
 }
 
 export interface ResolveFileOptions {

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -108,6 +108,8 @@ describe("VeryfrontFSAdapter", () => {
       "getPokeMetrics",
       "getClient",
       "refreshSourceSnapshot",
+      "ensureSourceSnapshotFresh",
+      "getSourceSnapshotVersion",
     ] as const;
 
     for (const method of methods) {
@@ -789,6 +791,130 @@ describe("VeryfrontFSAdapter", () => {
       });
     });
 
+    it("does not reuse a freshness lease after the request branch changes", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          getContext: () => { type: string; name?: string };
+          listAllFiles: () => Promise<
+            Array<{ path: string; version_id: string; content: string }>
+          >;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+
+      let listAllFilesCalls = 0;
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        const branch = client.getContext().name ?? "main";
+        return Promise.resolve([{
+          path: "pages/index.tsx",
+          version_id: branch,
+          content: branch,
+        }]);
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+      assertEquals(await adapter.readTextFile("pages/index.tsx"), "main");
+
+      adapter.setRequestBranch("draft");
+      await adapter.ensureSourceSnapshotFresh("draft-request");
+
+      assertEquals(listAllFilesCalls, 2);
+      assertEquals(await adapter.readTextFile("pages/index.tsx"), "draft");
+
+      adapter.clearRequestBranch();
+      await adapter.ensureSourceSnapshotFresh("main-request");
+
+      assertEquals(listAllFilesCalls, 3);
+      assertEquals(await adapter.readTextFile("pages/index.tsx"), "main");
+    });
+
+    it("discards an in-flight refresh when the request branch changes", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          getContext: () => { type: string; name?: string };
+          listAllFiles: () => Promise<
+            Array<{ path: string; version_id: string; content: string }>
+          >;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+
+      let listAllFilesCalls = 0;
+      let finishMainRefresh: (() => void) | undefined;
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        const branch = client.getContext().name ?? "main";
+        const files = [{
+          path: "pages/index.tsx",
+          version_id: branch,
+          content: branch,
+        }];
+
+        if (listAllFilesCalls !== 2) return Promise.resolve(files);
+        return new Promise((resolve) => {
+          finishMainRefresh = () => resolve(files);
+        });
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+      (adapter as unknown as { sourceSnapshotCheckedAt: number }).sourceSnapshotCheckedAt = 0;
+
+      const mainRefresh = adapter.ensureSourceSnapshotFresh("main-request");
+      await waitFor(async () => finishMainRefresh !== undefined);
+
+      adapter.setRequestBranch("draft");
+      const draftRefresh = adapter.ensureSourceSnapshotFresh("draft-request");
+      finishMainRefresh?.();
+
+      await Promise.all([mainRefresh, draftRefresh]);
+
+      assertEquals(listAllFilesCalls, 3);
+      assertEquals(await adapter.readTextFile("pages/index.tsx"), "draft");
+    });
+
     it("refreshes a stale branch snapshot once when a pushed file is missing", async () => {
       const adapter = createAdapter({
         veryfront: {
@@ -857,6 +983,284 @@ describe("VeryfrontFSAdapter", () => {
 
       assertEquals(secondContent, "export const second = true;");
       assertEquals(listAllFilesCalls, 3);
+    });
+
+    it("leases an unchanged branch snapshot without relying on the file-list cache", async () => {
+      let routerInvalidations = 0;
+      let ssrInvalidations = 0;
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: false },
+        },
+        invalidationCallbacks: {
+          clearRouterDetectionCacheForProject: () => {
+            routerInvalidations++;
+          },
+          clearSSRModuleCacheForProject: () => {
+            ssrInvalidations++;
+          },
+        },
+      });
+
+      const firstFiles = [{
+        path: "pages/review.tsx",
+        version_id: "version-1",
+        content: "export default function Review() { return null; }",
+      }];
+      const changedFiles = [{
+        path: "app/review/page.tsx",
+        version_id: "version-2",
+        content: "export default function Review() { return null; }",
+      }];
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<
+            Array<{ path: string; version_id?: string; content?: string }>
+          >;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = async () => {
+        listAllFilesCalls++;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return listAllFilesCalls < 3 ? firstFiles : changedFiles;
+      };
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+
+      const initialSnapshotVersion = adapter.getSourceSnapshotVersion();
+      assertEquals(initialSnapshotVersion > 0, true);
+      assertEquals(listAllFilesCalls, 1);
+
+      (adapter as unknown as { sourceSnapshotCheckedAt: number }).sourceSnapshotCheckedAt = 0;
+      await Promise.all([
+        adapter.ensureSourceSnapshotFresh("first-concurrent-check"),
+        adapter.ensureSourceSnapshotFresh("second-concurrent-check"),
+        adapter.ensureSourceSnapshotFresh("third-concurrent-check"),
+      ]);
+
+      assertEquals(listAllFilesCalls, 2);
+      assertEquals(adapter.getSourceSnapshotVersion(), initialSnapshotVersion);
+      assertEquals(routerInvalidations, 0);
+      assertEquals(ssrInvalidations, 0);
+
+      (adapter as unknown as { sourceSnapshotCheckedAt: number }).sourceSnapshotCheckedAt = 0;
+      await adapter.ensureSourceSnapshotFresh("changed-source-check");
+
+      assertEquals(listAllFilesCalls, 3);
+      assertEquals(adapter.getSourceSnapshotVersion() > initialSnapshotVersion, true);
+      assertEquals(routerInvalidations, 1);
+      assertEquals(ssrInvalidations, 1);
+    });
+
+    it("keeps freshness followers attached until SSR invalidation completes", async () => {
+      const invalidationStarted = Promise.withResolvers<void>();
+      const releaseInvalidation = Promise.withResolvers<void>();
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: false },
+        },
+        invalidationCallbacks: {
+          clearSSRModuleCacheForProject: async () => {
+            invalidationStarted.resolve();
+            await releaseInvalidation.promise;
+          },
+        },
+      });
+
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<
+            Array<{ path: string; version_id: string; content: string }>
+          >;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        return Promise.resolve([{
+          path: "pages/review.tsx",
+          version_id: `version-${listAllFilesCalls}`,
+          content: `export const version = ${listAllFilesCalls};`,
+        }]);
+      };
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+      (adapter as unknown as { sourceSnapshotCheckedAt: number }).sourceSnapshotCheckedAt = 0;
+
+      const leader = adapter.ensureSourceSnapshotFresh("leader");
+      await invalidationStarted.promise;
+
+      let followerFinished = false;
+      const follower = adapter.ensureSourceSnapshotFresh("follower").then(() => {
+        followerFinished = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assertEquals(followerFinished, false);
+
+      releaseInvalidation.resolve();
+      await Promise.all([leader, follower]);
+      assertEquals(followerFinished, true);
+      assertEquals(listAllFilesCalls, 2);
+    });
+
+    it("does not let an older refresh overwrite a pushed source snapshot", async () => {
+      const refreshStarted = Promise.withResolvers<void>();
+      const releaseRefresh = Promise.withResolvers<
+        Array<{ path: string; version_id: string; content: string }>
+      >();
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+
+      const initialFiles = [{
+        path: "pages/review.tsx",
+        version_id: "version-1",
+        content: "export const version = 1;",
+      }];
+      const pushedFiles = [{
+        path: "pages/review.tsx",
+        version_id: "version-2",
+        content: "export const version = 2;",
+      }];
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<
+            Array<{ path: string; version_id: string; content: string }>
+          >;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        if (listAllFilesCalls === 1) return Promise.resolve(initialFiles);
+        refreshStarted.resolve();
+        return releaseRefresh.promise;
+      };
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+      const context = adapter.getContentContext();
+      assertExists(context);
+
+      const staleRefresh = adapter.refreshSourceSnapshot("poll");
+      await refreshStarted.promise;
+
+      await (adapter as unknown as {
+        replaceSourceSnapshot: (
+          cacheKey: string,
+          files: typeof pushedFiles,
+        ) => Promise<void>;
+      }).replaceSourceSnapshot(buildFileListCacheKey(context), pushedFiles);
+      const pushedVersion = adapter.getSourceSnapshotVersion();
+
+      releaseRefresh.resolve(initialFiles);
+      await staleRefresh;
+
+      assertEquals(adapter.getSourceSnapshotVersion(), pushedVersion);
+      assertEquals(await adapter.getAllSourceFiles(), pushedFiles);
+    });
+
+    it("does not reuse source snapshot generations across adapter instances", async () => {
+      async function initializeAdapter(
+        projectSlug: string,
+        projectId: string,
+      ): Promise<VeryfrontFSAdapter> {
+        const adapter = createAdapter({
+          veryfront: {
+            apiBaseUrl: "https://api.example.com",
+            apiToken: "test-token",
+            projectSlug,
+            contentSource: { type: "branch", branch: "main" },
+            cache: { enabled: true },
+          },
+        });
+        const client = (adapter as unknown as {
+          client: {
+            initialize: () => Promise<void>;
+            getProjectSlug: () => string;
+            getProjectId: () => string;
+            getCachedProject: () => { provider: string; layout: string };
+            listAllFiles: () => Promise<
+              Array<{ path: string; version_id?: string; content?: string }>
+            >;
+          };
+        }).client;
+
+        client.initialize = () => Promise.resolve();
+        client.getProjectSlug = () => projectSlug;
+        client.getProjectId = () => projectId;
+        client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+        client.listAllFiles = () =>
+          Promise.resolve([{
+            path: "agents/support.ts",
+            version_id: "version-1",
+            content: "export default {};",
+          }]);
+        (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+          .connect = () => {};
+
+        await adapter.initialize();
+        return adapter;
+      }
+
+      const first = await initializeAdapter("first-project", "project-1");
+      const second = await initializeAdapter("second-project", "project-2");
+
+      assertEquals(
+        first.getSourceSnapshotVersion() === second.getSourceSnapshotVersion(),
+        false,
+      );
+
+      first.dispose();
+      second.dispose();
     });
 
     it("refreshes a stale branch snapshot when resolveFile returns a cached miss", async () => {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -50,6 +50,44 @@ import { parseReleaseAssetManifest } from "#veryfront/release-assets/manifest-sc
 
 const logger = baseLogger.component("veryfront-fs-adapter");
 const BRANCH_MISS_RECOVERY_FAILURE_TTL_MS = 5_000;
+const BRANCH_SOURCE_SNAPSHOT_FRESHNESS_MS = 30_000;
+// Process-wide uniqueness prevents a recreated adapter from matching stale
+// derived-state generations left behind by its predecessor.
+let sourceSnapshotGeneration = 0;
+
+function nextSourceSnapshotGeneration(): number {
+  sourceSnapshotGeneration++;
+  return sourceSnapshotGeneration;
+}
+
+interface SourceSnapshotFile {
+  path: string;
+  id?: string;
+  version_id?: string;
+  content?: string;
+  type?: string;
+  size?: number;
+  updated_at?: string;
+}
+
+function sourceSnapshotsEqual(
+  previous: SourceSnapshotFile[] | undefined,
+  next: SourceSnapshotFile[],
+): boolean {
+  if (!previous || previous.length !== next.length) return false;
+
+  const previousByPath = new Map(previous.map((file) => [file.path, file]));
+  return next.every((file) => {
+    const prior = previousByPath.get(file.path);
+    return prior !== undefined &&
+      prior.id === file.id &&
+      prior.version_id === file.version_id &&
+      prior.content === file.content &&
+      prior.type === file.type &&
+      prior.size === file.size &&
+      prior.updated_at === file.updated_at;
+  });
+}
 
 interface BranchSnapshotRecoveryOptions<T> {
   isRecoverableMissResult?: (result: T) => boolean;
@@ -95,6 +133,13 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private branchMissRecoveryPromise: Promise<void> | null = null;
   private branchMissRecoveryGeneration = 0;
   private readonly branchMissRecoveryFailures = new Map<string, number>();
+  /** Last successful source check and generation of the materialized snapshot. */
+  private sourceSnapshotCheckedAt = 0;
+  private sourceSnapshotVersion = 0;
+  private sourceSnapshotIdentity: string | undefined;
+  private sourceSnapshotFiles: SourceSnapshotFile[] | undefined;
+  private sourceSnapshotRefreshPromise: Promise<void> | null = null;
+  private sourceSnapshotMutationTail: Promise<void> = Promise.resolve();
 
   private projectData?: Project;
   private apiBaseUrl: string;
@@ -116,6 +161,22 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   private getCurrentFileListCacheKey(): string | undefined {
     return this.contentContext ? buildFileListCacheKey(this.contentContext) : undefined;
+  }
+
+  private getCurrentSourceSnapshotIdentity(): string | undefined {
+    const context = this.contentContext;
+    if (!context) return undefined;
+
+    switch (context.sourceType) {
+      case "branch":
+        return `branch:${context.projectSlug}:${this.requestBranch ?? context.branch ?? "main"}`;
+      case "environment":
+        return `environment:${context.projectSlug}:${context.environmentName ?? ""}:${
+          context.releaseId ?? ""
+        }`;
+      case "release":
+        return `release:${context.projectSlug}:${context.releaseId ?? ""}`;
+    }
   }
 
   private syncClientContext(): void {
@@ -283,8 +344,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
         this.statOps.clearIndex();
         this.dirOps.clearTree();
       },
-      clearFileListIndex: () => this.readOps.clearFileListIndex(),
-      setFileListCache: (cacheKey, files) => this.cache.setAsync(cacheKey, files),
+      replaceSourceSnapshot: (cacheKey, files) => this.replaceSourceSnapshot(cacheKey, files),
       pregenerateStyles: (files) => this.triggerCSSPregeneration(files),
     });
 
@@ -389,6 +449,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       const fileSummary = summarizeFileList(files);
 
       await this.cache.setAsync(cacheKey, files);
+      this.markSourceSnapshotChanged(files);
 
       this.fileListReadyResolve?.();
       this.fileListReadyResolve = null;
@@ -655,7 +716,79 @@ export class VeryfrontFSAdapter implements FSAdapter {
     this.readOps.setFileListReadyPromise(warmupPromise);
   }
 
-  async refreshSourceSnapshot(reason = "manual-refresh"): Promise<void> {
+  private markSourceSnapshotChanged(
+    files: SourceSnapshotFile[],
+    identity = this.getCurrentSourceSnapshotIdentity(),
+  ): void {
+    this.sourceSnapshotFiles = files;
+    this.sourceSnapshotIdentity = identity;
+    this.sourceSnapshotVersion = nextSourceSnapshotGeneration();
+    this.sourceSnapshotCheckedAt = Date.now();
+  }
+
+  private runSourceSnapshotMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const mutation = this.sourceSnapshotMutationTail
+      .catch(() => undefined)
+      .then(operation);
+    this.sourceSnapshotMutationTail = mutation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return mutation;
+  }
+
+  private replaceSourceSnapshot(
+    cacheKey: string,
+    files: SourceSnapshotFile[],
+  ): Promise<void> {
+    return this.runSourceSnapshotMutation(async () => {
+      const context = this.contentContext;
+      if (!context || buildFileListCacheKey(context) !== cacheKey) {
+        logger.debug("Discarding source snapshot for superseded content context", {
+          cacheKey,
+          projectSlug: this.projectSlug,
+        });
+        return;
+      }
+
+      await this.cache.setAsync(cacheKey, files);
+      this.readOps.clearFileListIndex();
+      this.markSourceSnapshotChanged(files);
+    });
+  }
+
+  private async invalidateDerivedSourceCaches(): Promise<void> {
+    const projectId = this.client.getProjectId();
+    const invalidations: Array<void | Promise<void>> = [];
+
+    if (projectId) {
+      invalidations.push(
+        this.invalidationCallbacks.clearSSRModuleCacheForProject?.(projectId),
+        this.invalidationCallbacks.clearRouterDetectionCacheForProject?.(projectId),
+        this.invalidationCallbacks.clearProjectDiscoveryCacheForProject?.(projectId),
+        this.invalidationCallbacks.clearRendererCacheForProject?.(projectId),
+      );
+    } else {
+      invalidations.push(this.invalidationCallbacks.clearSSRModuleCache?.());
+    }
+
+    invalidations.push(this.invalidationCallbacks.clearModulePathCache?.());
+    if (this.projectSlug) {
+      invalidations.push(
+        this.invalidationCallbacks.clearSnippetCacheForProject?.(this.projectSlug),
+        this.invalidationCallbacks.clearProjectCSSCache?.(this.projectSlug),
+      );
+    }
+
+    const pendingInvalidations = invalidations.filter(
+      (invalidation): invalidation is Promise<void> => invalidation !== undefined,
+    );
+    if (pendingInvalidations.length > 0) {
+      await Promise.all(pendingInvalidations);
+    }
+  }
+
+  private async performSourceSnapshotRefresh(reason: string): Promise<void> {
     await this.ensureInitialized();
 
     if (!this.contentContext) {
@@ -668,26 +801,69 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
     const cacheKey = buildFileListCacheKey(this.contentContext);
     const refreshContext = this.contentContext;
-
-    this.fileListWarmupPromise = null;
-    this.fileListWarmupKey = null;
-    this.readOps.clearFileListIndex();
-    this.statOps.clearIndex();
-    this.dirOps.clearTree();
-
-    await Promise.all([
-      this.cache.deleteByPrefixAsync(buildFileCacheKeyPrefix(refreshContext)),
-      this.cache.deleteByPrefixAsync(buildStatCacheKeyPrefix(refreshContext)),
-      this.cache.deleteByPrefixAsync(buildDirCacheKeyPrefix(refreshContext)),
-      this.cache.deleteAsync(cacheKey),
-    ]);
-
+    const refreshIdentity = this.getCurrentSourceSnapshotIdentity();
+    const previousFiles = this.sourceSnapshotFiles;
+    const previousVersion = this.sourceSnapshotVersion;
     const files = await fetchFileListForContext(this.client, refreshContext);
-    await this.cache.setAsync(cacheKey, files);
-    const fileSummary = summarizeFileList(files);
-    this.branchMissRecoveryFailures.clear();
+    const result = await this.runSourceSnapshotMutation(async () => {
+      if (
+        this.contentContext !== refreshContext ||
+        this.getCurrentSourceSnapshotIdentity() !== refreshIdentity ||
+        this.sourceSnapshotVersion !== previousVersion
+      ) {
+        return { applied: false, sourceChanged: false };
+      }
 
-    if (fileSummary.sourceFilesWithContent > 0 && this.shouldBackgroundPregenerateStyles()) {
+      const sourceChanged = !sourceSnapshotsEqual(previousFiles, files);
+      if (sourceChanged) {
+        this.fileListWarmupPromise = null;
+        this.fileListWarmupKey = null;
+        this.readOps.clearFileListIndex();
+        this.statOps.clearIndex();
+        this.dirOps.clearTree();
+
+        await Promise.all([
+          this.cache.deleteByPrefixAsync(buildFileCacheKeyPrefix(refreshContext)),
+          this.cache.deleteByPrefixAsync(buildStatCacheKeyPrefix(refreshContext)),
+          this.cache.deleteByPrefixAsync(buildDirCacheKeyPrefix(refreshContext)),
+          this.cache.deleteAsync(cacheKey),
+        ]);
+      }
+
+      await this.cache.setAsync(cacheKey, files);
+      this.branchMissRecoveryFailures.clear();
+
+      if (sourceChanged) {
+        await this.invalidateDerivedSourceCaches();
+        // Publish freshness only after every cache derived from the previous
+        // snapshot has been invalidated. Concurrent followers remain attached
+        // to the refresh singleflight until this point.
+        this.markSourceSnapshotChanged(files, refreshIdentity);
+      } else {
+        this.sourceSnapshotFiles = files;
+        this.sourceSnapshotIdentity = refreshIdentity;
+        this.sourceSnapshotCheckedAt = Date.now();
+      }
+
+      return { applied: true, sourceChanged };
+    });
+
+    if (!result.applied) {
+      logger.debug("Discarding stale source snapshot refresh", {
+        reason,
+        cacheKey,
+        projectSlug: this.projectSlug,
+      });
+      return;
+    }
+
+    const fileSummary = summarizeFileList(files);
+
+    if (
+      result.sourceChanged &&
+      fileSummary.sourceFilesWithContent > 0 &&
+      this.shouldBackgroundPregenerateStyles()
+    ) {
       this.triggerCSSPregeneration(files).catch(() => {
         // Error already logged in triggerCSSPregeneration
       });
@@ -703,7 +879,50 @@ export class VeryfrontFSAdapter implements FSAdapter {
       releaseId: refreshContext.releaseId,
       totalFiles: fileSummary.totalFiles,
       filesWithContent: fileSummary.filesWithContent,
+      sourceChanged: result.sourceChanged,
+      sourceSnapshotVersion: this.sourceSnapshotVersion,
     });
+  }
+
+  async refreshSourceSnapshot(reason = "manual-refresh"): Promise<void> {
+    await this.ensureInitialized();
+
+    while (true) {
+      this.sourceSnapshotRefreshPromise ??= this.performSourceSnapshotRefresh(reason);
+      const refresh = this.sourceSnapshotRefreshPromise;
+
+      try {
+        await refresh;
+      } finally {
+        if (this.sourceSnapshotRefreshPromise === refresh) {
+          this.sourceSnapshotRefreshPromise = null;
+        }
+      }
+
+      const currentIdentity = this.getCurrentSourceSnapshotIdentity();
+      if (
+        currentIdentity === undefined ||
+        this.sourceSnapshotIdentity === currentIdentity
+      ) return;
+    }
+  }
+
+  async ensureSourceSnapshotFresh(reason = "freshness-check"): Promise<void> {
+    await this.ensureInitialized();
+    if (this.contentContext?.sourceType !== "branch") return;
+
+    if (
+      this.sourceSnapshotIdentity === this.getCurrentSourceSnapshotIdentity() &&
+      Date.now() - this.sourceSnapshotCheckedAt < BRANCH_SOURCE_SNAPSHOT_FRESHNESS_MS
+    ) {
+      return;
+    }
+
+    await this.refreshSourceSnapshot(reason);
+  }
+
+  getSourceSnapshotVersion(): number {
+    return this.sourceSnapshotVersion;
   }
 
   getPokeMetrics(): {
@@ -949,6 +1168,11 @@ export class VeryfrontFSAdapter implements FSAdapter {
       this.branchMissRecoveryPromise = null;
       this.branchMissRecoveryGeneration++;
       this.branchMissRecoveryFailures.clear();
+      this.sourceSnapshotCheckedAt = 0;
+      this.sourceSnapshotVersion = 0;
+      this.sourceSnapshotIdentity = undefined;
+      this.sourceSnapshotFiles = undefined;
+      this.sourceSnapshotRefreshPromise = null;
       logger.debug("Cleared index and dirTree due to context change", {
         oldContext,
         newContext: context,

--- a/src/platform/adapters/fs/veryfront/default-invalidation-callbacks.ts
+++ b/src/platform/adapters/fs/veryfront/default-invalidation-callbacks.ts
@@ -9,32 +9,43 @@ export function createDefaultInvalidationCallbacks(
 ): InvalidationCallbacks {
   return {
     clearSSRModuleCache: () => {
-      void loadModule<{ clearSSRModuleCache: () => void }>(
+      return loadModule<{ clearSSRModuleCache: () => void }>(
         "#veryfront/modules/react-loader/ssr-module-loader/cache/index.ts",
       ).then((m) => m.clearSSRModuleCache());
     },
     clearModulePathCache: () => {
-      void loadModule<{ clearModulePathCache: () => void }>(
+      return loadModule<{ clearModulePathCache: () => void }>(
         "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts",
       ).then((m) => m.clearModulePathCache());
     },
     invalidateModulePaths: (changedPaths: string[]) => {
-      void loadModule<{ invalidateModulePaths: (changedPaths: string[]) => void }>(
+      return loadModule<{ invalidateModulePaths: (changedPaths: string[]) => void }>(
         "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts",
       ).then((m) => m.invalidateModulePaths(changedPaths));
     },
     clearSSRModuleCacheForProject: (projectId: string) => {
-      void loadModule<{ clearSSRModuleCacheForProject: (projectId: string) => void }>(
+      return loadModule<{ clearSSRModuleCacheForProject: (projectId: string) => void }>(
         "#veryfront/modules/react-loader/ssr-module-loader/cache/index.ts",
       ).then((m) => m.clearSSRModuleCacheForProject(projectId));
     },
-    clearRouterDetectionCacheForProject: (projectId: string) => {
-      void loadModule<{ clearRouterDetectionCacheForProject: (projectId: string) => void }>(
+    clearRouterDetectionCacheForProject: async (projectId: string) => {
+      const module = await loadModule<{
+        clearRouterDetectionCacheForProject: (projectId: string) => void;
+      }>(
         "#veryfront/rendering/router-detection.ts",
-      ).then((m) => m.clearRouterDetectionCacheForProject(projectId));
+      );
+      module.clearRouterDetectionCacheForProject(projectId);
+    },
+    clearProjectDiscoveryCacheForProject: async (projectId: string) => {
+      const module = await loadModule<{
+        clearProjectDiscoveryCacheForProject: (projectId: string) => void;
+      }>(
+        "#veryfront/server/handlers/request/api/project-discovery.ts",
+      );
+      module.clearProjectDiscoveryCacheForProject(projectId);
     },
     clearSnippetCacheForProject: (projectSlug: string) => {
-      void loadModule<{ clearSnippetCacheForProject: (projectSlug: string) => void }>(
+      return loadModule<{ clearSnippetCacheForProject: (projectSlug: string) => void }>(
         "#veryfront/rendering/snippet-renderer.ts",
       ).then((m) => m.clearSnippetCacheForProject(projectSlug));
     },

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -112,6 +112,13 @@ describe("MultiProjectFSAdapter", () => {
       withAdapter((adapter) => assertMethod(adapter, "refreshSourceSnapshot"));
     });
 
+    it("should expose source snapshot freshness methods", () => {
+      withAdapter((adapter) => {
+        assertMethod(adapter, "ensureSourceSnapshotFresh");
+        assertMethod(adapter, "getSourceSnapshotVersion");
+      });
+    });
+
     it("should have getManagerStats method", () => {
       withAdapter((adapter) => assertMethod(adapter, "getManagerStats"));
     });
@@ -186,6 +193,83 @@ describe("MultiProjectFSAdapter", () => {
         assertEquals(capturedBranch, "main");
         assertEquals(cachedBeforeRefresh, "stale-content");
         assertEquals(cachedAfterRefresh, undefined);
+      });
+    });
+
+    it("clears request-scoped files only when a freshness check advances the snapshot", async () => {
+      await withAdapterAsync(async (adapter) => {
+        const originalManager = (adapter as any).manager;
+        let freshnessReason: string | undefined;
+        let sourceSnapshotVersion = 6;
+        let freshnessChecks = 0;
+
+        (adapter as any).manager = {
+          getAdapter() {
+            return Promise.resolve({
+              ensureSourceSnapshotFresh(reason?: string) {
+                freshnessReason = reason;
+                freshnessChecks++;
+                if (freshnessChecks === 1) sourceSnapshotVersion++;
+                return Promise.resolve();
+              },
+              getSourceSnapshotVersion() {
+                return sourceSnapshotVersion;
+              },
+            });
+          },
+          getStats: () => ({ adapters: 0, stats: [] }),
+          dispose: () => {},
+        };
+
+        try {
+          await adapter.runWithContext(
+            "project-a",
+            "test-token",
+            async () => {
+              setRequestScopedFile("file:pages/index.mdx", "stale-content");
+              await adapter.ensureSourceSnapshotFresh("page-routing");
+              assertEquals(getRequestScopedFile("file:pages/index.mdx"), undefined);
+              assertEquals(await adapter.getSourceSnapshotVersion(), 7);
+
+              setRequestScopedFile("file:pages/index.mdx", "current-content");
+              await adapter.ensureSourceSnapshotFresh("page-routing");
+              assertEquals(getRequestScopedFile("file:pages/index.mdx"), "current-content");
+            },
+            "project-id-a",
+            { branch: "main" },
+          );
+        } finally {
+          (adapter as any).manager = originalManager;
+        }
+
+        assertEquals(freshnessReason, "page-routing");
+      });
+    });
+
+    it("preserves optional snapshot capabilities for legacy project adapters", async () => {
+      await withAdapterAsync(async (adapter) => {
+        const originalManager = (adapter as any).manager;
+
+        (adapter as any).manager = {
+          getAdapter: () => Promise.resolve({}),
+          getStats: () => ({ adapters: 0, stats: [] }),
+          dispose: () => {},
+        };
+
+        try {
+          await adapter.runWithContext(
+            "project-a",
+            "test-token",
+            async () => {
+              await adapter.ensureSourceSnapshotFresh("config-load");
+              assertEquals(await adapter.getSourceSnapshotVersion(), undefined);
+            },
+            "project-id-a",
+            { branch: "main" },
+          );
+        } finally {
+          (adapter as any).manager = originalManager;
+        }
       });
     });
 

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -236,6 +236,36 @@ export class MultiProjectFSAdapter implements FSAdapter {
     }
   }
 
+  async ensureSourceSnapshotFresh(reason?: string): Promise<void> {
+    const adapter = await this.getAdapter();
+    if (typeof adapter.ensureSourceSnapshotFresh !== "function") return;
+
+    const previousVersion = await adapter.getSourceSnapshotVersion?.();
+    await adapter.ensureSourceSnapshotFresh(reason);
+    const currentVersion = await adapter.getSourceSnapshotVersion?.();
+    const sourceMayHaveChanged = previousVersion === undefined ||
+      currentVersion === undefined ||
+      previousVersion !== currentVersion;
+    if (!sourceMayHaveChanged) return;
+
+    const cleared = clearRequestScopedFileCache();
+    if (cleared > 0) {
+      logger.debug("Cleared request-scoped file cache after source freshness changed", {
+        reason,
+        cleared,
+        previousVersion,
+        currentVersion,
+      });
+    }
+  }
+
+  async getSourceSnapshotVersion(): Promise<number | undefined> {
+    const adapter = await this.getAdapter();
+    return typeof adapter.getSourceSnapshotVersion === "function"
+      ? await adapter.getSourceSnapshotVersion()
+      : undefined;
+  }
+
   dispose(): void {
     this.manager.dispose();
     this.defaultAdapter?.dispose();

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -30,6 +30,8 @@ export interface FSAdapter {
 
   resolveFile?(basePath: string, options?: ResolveFileOptions): Promise<string | null>;
   refreshSourceSnapshot?(reason?: string): Promise<void>;
+  ensureSourceSnapshotFresh?(reason?: string): Promise<void>;
+  getSourceSnapshotVersion?(): number | undefined | Promise<number | undefined>;
 }
 
 export interface ContextualFSAdapter extends FSAdapter {
@@ -151,16 +153,17 @@ export interface InvalidationProjectContext {
 }
 
 export interface InvalidationCallbacks {
-  clearSSRModuleCache?: () => void;
-  clearSSRModuleCacheForProject?: (projectId: string) => void;
-  clearRouterDetectionCacheForProject?: (projectId: string) => void;
-  clearModulePathCache?: () => void;
-  invalidateModulePaths?: (changedPaths: string[]) => void;
-  clearSnippetCacheForProject?: (projectSlug: string) => void;
+  clearSSRModuleCache?: () => void | Promise<void>;
+  clearSSRModuleCacheForProject?: (projectId: string) => void | Promise<void>;
+  clearRouterDetectionCacheForProject?: (projectId: string) => void | Promise<void>;
+  clearProjectDiscoveryCacheForProject?: (projectId: string) => void | Promise<void>;
+  clearModulePathCache?: () => void | Promise<void>;
+  invalidateModulePaths?: (changedPaths: string[]) => void | Promise<void>;
+  clearSnippetCacheForProject?: (projectSlug: string) => void | Promise<void>;
   triggerReload?: (changedPaths?: string[], project?: InvalidationProjectContext) => void;
   clearRendererCacheForProject?: (projectId: string) => void | Promise<void>;
   /** Invalidate project-level CSS cache when source files change */
-  clearProjectCSSCache?: (projectSlug: string) => void;
+  clearProjectCSSCache?: (projectSlug: string) => void | Promise<void>;
   /** Clear domain lookup cache to refresh release IDs after publishing */
   clearDomainCache?: () => void;
   /** Evict the current shared proxy adapter after successful invalidation */

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -124,8 +124,7 @@ function createWebSocketManager(options: {
     getContentSource: () => ({ type: "branch", branch: "main" }),
     getProjectDir: () => undefined,
     clearMemoryCaches: () => {},
-    clearFileListIndex: () => {},
-    setFileListCache: async () => {},
+    replaceSourceSnapshot: async () => {},
     pregenerateStyles: options.pregenerateStyles,
   });
 }
@@ -589,8 +588,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      clearFileListIndex: () => {},
-      setFileListCache: async () => {},
+      replaceSourceSnapshot: async () => {},
     });
 
     manager.connect("project-1");
@@ -652,8 +650,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      clearFileListIndex: () => {},
-      setFileListCache: async () => {},
+      replaceSourceSnapshot: async () => {},
     });
 
     manager.connect("project-1");
@@ -692,8 +689,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      clearFileListIndex: () => {},
-      setFileListCache: async () => {},
+      replaceSourceSnapshot: async () => {},
     });
 
     manager.connect("project-1");
@@ -732,8 +728,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      clearFileListIndex: () => {},
-      setFileListCache: async () => {},
+      replaceSourceSnapshot: async () => {},
     });
 
     manager.connect("project-1");
@@ -772,8 +767,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      clearFileListIndex: () => {},
-      setFileListCache: async () => {},
+      replaceSourceSnapshot: async () => {},
     });
 
     manager.connect("project-1");

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -1,7 +1,7 @@
 import { getBaseLogger } from "#veryfront/utils/logger/logger.ts";
 import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
 import type { FileCache } from "../cache/file-cache.ts";
-import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
+import type { ProjectFile, VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import type {
   ContentSource,
   InvalidationCallbacks,
@@ -60,13 +60,12 @@ interface WebSocketDeps {
   getContentSource: () => ContentSource;
   getProjectDir: () => string | undefined;
   clearMemoryCaches: () => void;
-  clearFileListIndex: () => void;
-  setFileListCache: (
+  replaceSourceSnapshot: (
     cacheKey: string,
-    files: Array<{ path: string; content?: string }>,
+    files: ProjectFile[],
   ) => Promise<void>;
   pregenerateStyles?: (
-    files: Array<{ path: string; content?: string }>,
+    files: ProjectFile[],
   ) => Promise<PreviewStyleArtifactInfo | undefined>;
 }
 
@@ -688,9 +687,10 @@ export class WebSocketManager {
         prefixes: ["file:", "stat:", "dir:"],
       });
 
-      this.deps.invalidationCallbacks.invalidateModulePaths?.(changedPaths);
-
       const projectId = this.deps.client.getProjectId();
+      const invalidations: Array<void | Promise<void>> = [
+        this.deps.invalidationCallbacks.invalidateModulePaths?.(changedPaths),
+      ];
       logger.debug("Clearing SSR module cache for HMR", {
         changedPaths,
         projectId,
@@ -698,17 +698,42 @@ export class WebSocketManager {
       });
 
       if (this.deps.invalidationCallbacks.clearSSRModuleCacheForProject && projectId) {
-        this.deps.invalidationCallbacks.clearSSRModuleCacheForProject(projectId);
+        invalidations.push(
+          this.deps.invalidationCallbacks.clearSSRModuleCacheForProject(projectId),
+        );
       } else {
-        this.deps.invalidationCallbacks.clearSSRModuleCache?.();
+        invalidations.push(this.deps.invalidationCallbacks.clearSSRModuleCache?.());
+      }
+      if (projectId) {
+        if (this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject) {
+          invalidations.push(
+            this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject(projectId),
+          );
+        }
+        if (this.deps.invalidationCallbacks.clearProjectDiscoveryCacheForProject) {
+          invalidations.push(
+            this.deps.invalidationCallbacks.clearProjectDiscoveryCacheForProject(projectId),
+          );
+        }
       }
 
       if (this.deps.invalidationCallbacks.clearRendererCacheForProject && projectId) {
-        await this.deps.invalidationCallbacks.clearRendererCacheForProject(projectId);
+        invalidations.push(
+          this.deps.invalidationCallbacks.clearRendererCacheForProject(projectId),
+        );
       }
 
       if (this.deps.invalidationCallbacks.clearProjectCSSCache && this.deps.projectSlug) {
-        this.deps.invalidationCallbacks.clearProjectCSSCache(this.deps.projectSlug);
+        invalidations.push(
+          this.deps.invalidationCallbacks.clearProjectCSSCache(this.deps.projectSlug),
+        );
+      }
+
+      const pendingInvalidations = invalidations.filter(
+        (invalidation): invalidation is Promise<void> => invalidation !== undefined,
+      );
+      if (pendingInvalidations.length > 0) {
+        await Promise.all(pendingInvalidations);
       }
 
       if (contentContext?.sourceType === "branch") {
@@ -716,8 +741,7 @@ export class WebSocketManager {
         try {
           const files = await this.deps.client.listAllFiles();
           const cacheKey = buildFileListCacheKey(contentContext);
-          await this.deps.setFileListCache(cacheKey, files);
-          this.deps.clearFileListIndex();
+          await this.deps.replaceSourceSnapshot(cacheKey, files);
           preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
 
           logger.debug("Fresh files cached (memory + Redis)", {
@@ -817,29 +841,54 @@ export class WebSocketManager {
       this.deps.invalidationCallbacks.clearDomainCache?.();
 
       const projectId = this.deps.client.getProjectId();
+      const invalidations: Array<void | Promise<void>> = [];
 
       if (this.deps.invalidationCallbacks.clearSSRModuleCacheForProject && projectId) {
-        this.deps.invalidationCallbacks.clearSSRModuleCacheForProject(projectId);
+        invalidations.push(
+          this.deps.invalidationCallbacks.clearSSRModuleCacheForProject(projectId),
+        );
       } else {
-        this.deps.invalidationCallbacks.clearSSRModuleCache?.();
+        invalidations.push(this.deps.invalidationCallbacks.clearSSRModuleCache?.());
       }
 
-      if (this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject && projectId) {
-        this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject(projectId);
+      if (projectId) {
+        if (this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject) {
+          invalidations.push(
+            this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject(projectId),
+          );
+        }
+        if (this.deps.invalidationCallbacks.clearProjectDiscoveryCacheForProject) {
+          invalidations.push(
+            this.deps.invalidationCallbacks.clearProjectDiscoveryCacheForProject(projectId),
+          );
+        }
       }
 
-      this.deps.invalidationCallbacks.clearModulePathCache?.();
+      invalidations.push(this.deps.invalidationCallbacks.clearModulePathCache?.());
 
       if (this.deps.invalidationCallbacks.clearSnippetCacheForProject && this.deps.projectSlug) {
-        this.deps.invalidationCallbacks.clearSnippetCacheForProject(this.deps.projectSlug);
+        invalidations.push(
+          this.deps.invalidationCallbacks.clearSnippetCacheForProject(this.deps.projectSlug),
+        );
       }
 
       if (this.deps.invalidationCallbacks.clearRendererCacheForProject && projectId) {
-        await this.deps.invalidationCallbacks.clearRendererCacheForProject(projectId);
+        invalidations.push(
+          this.deps.invalidationCallbacks.clearRendererCacheForProject(projectId),
+        );
       }
 
       if (this.deps.invalidationCallbacks.clearProjectCSSCache && this.deps.projectSlug) {
-        this.deps.invalidationCallbacks.clearProjectCSSCache(this.deps.projectSlug);
+        invalidations.push(
+          this.deps.invalidationCallbacks.clearProjectCSSCache(this.deps.projectSlug),
+        );
+      }
+
+      const pendingInvalidations = invalidations.filter(
+        (invalidation): invalidation is Promise<void> => invalidation !== undefined,
+      );
+      if (pendingInvalidations.length > 0) {
+        await Promise.all(pendingInvalidations);
       }
 
       const totalFileCount = fileBranchCount + fileReleaseCount + fileEnvCount;
@@ -858,8 +907,7 @@ export class WebSocketManager {
         try {
           const files = await this.deps.client.listAllFiles();
           const cacheKey = buildFileListCacheKey(contentContext);
-          await this.deps.setFileListCache(cacheKey, files);
-          this.deps.clearFileListIndex();
+          await this.deps.replaceSourceSnapshot(cacheKey, files);
           preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
 
           logger.debug("FRESH FILES FETCHED", {

--- a/src/platform/adapters/fs/wrapper.test.ts
+++ b/src/platform/adapters/fs/wrapper.test.ts
@@ -209,6 +209,35 @@ describe("FSAdapterWrapper", () => {
     });
   });
 
+  describe("source snapshot freshness", () => {
+    it("should delegate freshness checks and snapshot versions", async () => {
+      let reason: string | undefined;
+      const fsAdapter = {
+        ...createMockFSAdapter(),
+        ensureSourceSnapshotFresh(value?: string) {
+          reason = value;
+          return Promise.resolve();
+        },
+        getSourceSnapshotVersion() {
+          return 11;
+        },
+      };
+      const wrapper = new FSAdapterWrapper(fsAdapter);
+
+      await wrapper.ensureSourceSnapshotFresh?.("page-routing");
+
+      assertEquals(reason, "page-routing");
+      assertEquals(await wrapper.getSourceSnapshotVersion?.(), 11);
+    });
+
+    it("should omit freshness methods when the adapter does not support them", () => {
+      const wrapper = new FSAdapterWrapper(createMockFSAdapter());
+
+      assertEquals(wrapper.ensureSourceSnapshotFresh, undefined);
+      assertEquals(wrapper.getSourceSnapshotVersion, undefined);
+    });
+  });
+
   describe("readFile", () => {
     it("should read file using readTextFile if available", async () => {
       const fsAdapter = createMockFSAdapter({

--- a/src/platform/adapters/fs/wrapper.ts
+++ b/src/platform/adapters/fs/wrapper.ts
@@ -81,12 +81,21 @@ function isContextualAdapter(adapter: FSAdapter): adapter is ContextualFSAdapter
 export class FSAdapterWrapper implements ExtendedFileSystemAdapter {
   private readonly _fsAdapter: FSAdapter;
   readonly refreshSourceSnapshot?: (reason?: string) => Promise<void>;
+  readonly ensureSourceSnapshotFresh?: (reason?: string) => Promise<void>;
+  readonly getSourceSnapshotVersion?: () => number | undefined | Promise<number | undefined>;
 
   constructor(fsAdapter: FSAdapter) {
     this._fsAdapter = fsAdapter;
     if (typeof fsAdapter.refreshSourceSnapshot === "function") {
       this.refreshSourceSnapshot = (reason?: string) =>
         fsAdapter.refreshSourceSnapshot!.call(fsAdapter, reason);
+    }
+    if (typeof fsAdapter.ensureSourceSnapshotFresh === "function") {
+      this.ensureSourceSnapshotFresh = (reason?: string) =>
+        fsAdapter.ensureSourceSnapshotFresh!.call(fsAdapter, reason);
+    }
+    if (typeof fsAdapter.getSourceSnapshotVersion === "function") {
+      this.getSourceSnapshotVersion = () => fsAdapter.getSourceSnapshotVersion!.call(fsAdapter);
     }
   }
 

--- a/src/rendering/app-route-resolver.ts
+++ b/src/rendering/app-route-resolver.ts
@@ -9,7 +9,7 @@
 
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { EntityInfo, Frontmatter } from "#veryfront/types";
-import { isDynamicSegment } from "#veryfront/utils/route-path-utils.ts";
+import { isCatchAllSegment, isDynamicSegment } from "#veryfront/utils/route-path-utils.ts";
 import { join } from "#veryfront/compat/path";
 import { extract } from "#std/front-matter/yaml.ts";
 
@@ -77,23 +77,11 @@ async function tryDynamicMatch(
   let currentDir = join(projectDir, appDirName);
 
   for (const segment of segments) {
-    const exactPath = join(currentDir, segment);
+    const routeDirectory = await findRouteDirectory(currentDir, segment, adapter);
+    if (!routeDirectory) return null;
 
-    try {
-      const stat = await adapter.fs.stat(exactPath);
-      if (stat.isDirectory) {
-        currentDir = exactPath;
-        continue;
-      }
-    } catch (_) {
-      /* expected: exact path may not exist, try dynamic segments */
-    }
-
-    const dynamic = await findDynamicDir(currentDir, adapter);
-    if (!dynamic) return null;
-
-    currentDir = join(currentDir, dynamic.name);
-    if (dynamic.isCatchAll) break;
+    currentDir = join(currentDir, routeDirectory.name);
+    if (routeDirectory.isCatchAll) break;
   }
 
   for (const ext of [".mdx", ".md", ".tsx", ".jsx", ".ts", ".js"]) {
@@ -105,16 +93,27 @@ async function tryDynamicMatch(
   return null;
 }
 
-async function findDynamicDir(
+async function findRouteDirectory(
   dir: string,
+  segment: string,
   adapter: RuntimeAdapter,
 ): Promise<{ name: string; isCatchAll: boolean } | null> {
   try {
     const entries = await adapter.fs.readDir(dir);
+    let dynamic: { name: string; isCatchAll: boolean } | null = null;
+
     for await (const entry of entries) {
-      if (!entry.isDirectory || !isDynamicSegment(entry.name)) continue;
-      return { name: entry.name, isCatchAll: entry.name.startsWith("[...") };
+      if (!entry.isDirectory && !entry.isSymlink) continue;
+      if (entry.name === segment) return { name: entry.name, isCatchAll: false };
+      if (!dynamic && isDynamicSegment(entry.name)) {
+        dynamic = {
+          name: entry.name,
+          isCatchAll: isCatchAllSegment(entry.name),
+        };
+      }
     }
+
+    return dynamic;
   } catch (_) {
     /* expected: adapter.fs.readDir may fail for npm compatibility */
   }

--- a/src/rendering/page-resolution/page-resolver.test.ts
+++ b/src/rendering/page-resolution/page-resolver.test.ts
@@ -122,6 +122,74 @@ describe("rendering/page-resolution/page-resolver", () => {
       assertEquals(dynamic.entity.slug, "article");
     });
 
+    it("resolves dynamic App Router pages without remote stat misses", async () => {
+      let statCalls = 0;
+      const adapter = {
+        fs: {
+          readFile: async (path: string) => {
+            if (path === "/project/app/[slug]/page.tsx") {
+              return "export default function Page() { return null; }";
+            }
+            throw new Error("File not found");
+          },
+          resolveFile: async () => null,
+          stat: async () => {
+            statCalls++;
+            throw new Error("File not found");
+          },
+          readDir: async function* (path: string) {
+            if (path === "/project/app") {
+              yield { name: "[slug]", isFile: false, isDirectory: true };
+            }
+          },
+          writeFile: async () => {},
+          mkdir: async () => {},
+        },
+        env: { get: () => undefined },
+      } as unknown as RuntimeAdapter;
+      const resolver = new PageResolver({
+        projectDir: "/project",
+        config: createMockConfig({ router: "app" }),
+        adapter,
+      });
+
+      const page = await resolver.resolvePage("article");
+
+      assertEquals(page.entity.path, "/project/app/[slug]/page.tsx");
+      assertEquals(statCalls, 0);
+    });
+
+    it("resolves optional catch-all App Router pages across remaining segments", async () => {
+      const adapter = {
+        fs: {
+          readFile: async (path: string) => {
+            if (path === "/project/app/[[...slug]]/page.tsx") {
+              return "export default function Page() { return null; }";
+            }
+            throw new Error("File not found");
+          },
+          resolveFile: async () => null,
+          readDir: async function* (path: string) {
+            if (path === "/project/app") {
+              yield { name: "[[...slug]]", isFile: false, isDirectory: true };
+            }
+          },
+          writeFile: async () => {},
+          mkdir: async () => {},
+        },
+        env: { get: () => undefined },
+      } as unknown as RuntimeAdapter;
+      const resolver = new PageResolver({
+        projectDir: "/project",
+        config: createMockConfig({ router: "app" }),
+        adapter,
+      });
+
+      const page = await resolver.resolvePage("guides/platform/agents");
+
+      assertEquals(page.entity.path, "/project/app/[[...slug]]/page.tsx");
+    });
+
     it("keeps auto router detection aligned with the structural app router", async () => {
       const adapter = {
         fs: {
@@ -215,7 +283,9 @@ describe("rendering/page-resolution/page-resolver", () => {
           },
           exists: async (path: string) => path === "/project/pages",
           readDir: async function* (path: string) {
-            if (path === "/project/pages") {
+            if (path === "/project") {
+              yield { name: "pages", isFile: false, isDirectory: true };
+            } else if (path === "/project/pages") {
               yield { name: "index.tsx", isFile: true, isDirectory: false };
             }
           },

--- a/src/rendering/router-detection.test.ts
+++ b/src/rendering/router-detection.test.ts
@@ -119,6 +119,186 @@ describe("detectAppRouter", () => {
 
     assertEquals(result, true, "should detect app router using compat fs fallback");
   });
+
+  it("detects a Pages Router project without statting the missing app directory", async () => {
+    let statCalls = 0;
+    const adapter = {
+      ...failingAdapter,
+      fs: {
+        ...failingAdapter.fs,
+        stat: (path: string) => {
+          statCalls++;
+          if (path === "/project/pages") {
+            return Promise.resolve({
+              isFile: false,
+              isDirectory: true,
+              isSymlink: false,
+            });
+          }
+          return Promise.reject(new Error("File not found"));
+        },
+        readDir: async function* (path: string) {
+          if (path === "/project") {
+            yield { name: "pages", isFile: false, isDirectory: true, isSymlink: false };
+          } else if (path === "/project/pages") {
+            yield { name: "index.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          }
+        },
+      },
+    } as RuntimeAdapter;
+
+    const result = await detectAppRouter("/project", {} as VeryfrontConfig, adapter, {
+      projectId: "stat-free-pages-project",
+    });
+
+    assertEquals(result, false);
+    assertEquals(statCalls, 0);
+  });
+
+  it("recognizes the project root as a configured App Router directory", async () => {
+    const adapter = {
+      ...failingAdapter,
+      fs: {
+        ...failingAdapter.fs,
+        readDir: async function* (path: string) {
+          if (path === "/project") {
+            yield { name: "page.tsx", isFile: true, isDirectory: false, isSymlink: false };
+            yield { name: "pages", isFile: false, isDirectory: true, isSymlink: false };
+          } else if (path === "/project/pages") {
+            yield { name: "index.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          }
+        },
+      },
+    } as RuntimeAdapter;
+
+    const result = await detectAppRouter(
+      "/project",
+      { directories: { app: ".", pages: "pages" } } as VeryfrontConfig,
+      adapter,
+      { projectId: "root-app-project" },
+    );
+
+    assertEquals(result, true);
+  });
+
+  it("detects a Pages Router project whose parent listing omits implicit directories", async () => {
+    const adapter = {
+      ...failingAdapter,
+      id: "cloudflare",
+      fs: {
+        ...failingAdapter.fs,
+        stat: (path: string) => {
+          if (path === "/project/pages") {
+            return Promise.resolve({
+              isFile: false,
+              isDirectory: true,
+              isSymlink: false,
+            });
+          }
+          return Promise.reject(new Error("File not found"));
+        },
+        readDir: async function* (path: string) {
+          if (path === "/project/pages") {
+            yield { name: "index.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          }
+        },
+      },
+    } as RuntimeAdapter;
+
+    const result = await detectAppRouter("/project", {} as VeryfrontConfig, adapter, {
+      projectId: "implicit-kv-pages-project",
+    });
+
+    assertEquals(result, false);
+  });
+
+  it("recognizes a symlinked route directory without statting it", async () => {
+    let statCalls = 0;
+    const adapter = {
+      ...failingAdapter,
+      fs: {
+        ...failingAdapter.fs,
+        stat: () => {
+          statCalls++;
+          return Promise.reject(new Error("stat should not be called"));
+        },
+        readDir: async function* (path: string) {
+          if (path === "/project") {
+            yield { name: "pages", isFile: false, isDirectory: false, isSymlink: true };
+          } else if (path === "/project/pages") {
+            yield { name: "index.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          }
+        },
+      },
+    } as RuntimeAdapter;
+
+    const result = await detectAppRouter("/project", {} as VeryfrontConfig, adapter, {
+      projectId: "symlinked-pages-project",
+    });
+
+    assertEquals(result, false);
+    assertEquals(statCalls, 0);
+  });
+
+  it("traverses symlinked subdirectories when detecting App Router routes", async () => {
+    const adapter = {
+      ...failingAdapter,
+      fs: {
+        ...failingAdapter.fs,
+        realPath: (path: string) =>
+          Promise.resolve(path === "/project/app/docs" ? "/shared/docs" : path),
+        readDir: async function* (path: string) {
+          if (path === "/project") {
+            yield { name: "app", isFile: false, isDirectory: true, isSymlink: false };
+            yield { name: "pages", isFile: false, isDirectory: true, isSymlink: false };
+          } else if (path === "/project/app") {
+            yield { name: "docs", isFile: false, isDirectory: false, isSymlink: true };
+          } else if (path === "/project/app/docs") {
+            yield { name: "page.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          } else if (path === "/project/pages") {
+            yield { name: "index.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          }
+        },
+      },
+    } as RuntimeAdapter;
+
+    const result = await detectAppRouter("/project", {} as VeryfrontConfig, adapter, {
+      projectId: "nested-symlink-app-project",
+    });
+
+    assertEquals(result, true);
+  });
+
+  it("does not revisit a route directory through a symlink cycle", async () => {
+    let followedCycle = false;
+    const adapter = {
+      ...failingAdapter,
+      fs: {
+        ...failingAdapter.fs,
+        realPath: (path: string) =>
+          Promise.resolve(path === "/project/app/loop" ? "/project/app" : path),
+        readDir: async function* (path: string) {
+          if (path === "/project") {
+            yield { name: "app", isFile: false, isDirectory: true, isSymlink: false };
+            yield { name: "pages", isFile: false, isDirectory: true, isSymlink: false };
+          } else if (path === "/project/app") {
+            yield { name: "loop", isFile: false, isDirectory: false, isSymlink: true };
+          } else if (path === "/project/app/loop") {
+            followedCycle = true;
+          } else if (path === "/project/pages") {
+            yield { name: "index.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          }
+        },
+      },
+    } as RuntimeAdapter;
+
+    const result = await detectAppRouter("/project", {} as VeryfrontConfig, adapter, {
+      projectId: "symlink-cycle-project",
+    });
+
+    assertEquals(result, false);
+    assertEquals(followedCycle, false);
+  });
 });
 
 describe("resolveRouterModeForPage", () => {

--- a/src/rendering/router-detection.ts
+++ b/src/rendering/router-detection.ts
@@ -7,7 +7,7 @@
  * - Route file presence detection
  **************************/
 
-import { isAbsolute, join, normalize, relative } from "#veryfront/compat/path";
+import { basename, dirname, isAbsolute, join, normalize, relative } from "#veryfront/compat/path";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -166,16 +166,13 @@ async function detectAppRouterImpl(
   const appDirName = config?.directories?.app ?? "app";
   const pagesDirName = config?.directories?.pages ?? "pages";
 
-  const appDir = join(projectDir, appDirName);
-  const pagesDir = join(projectDir, pagesDirName);
+  const appDir = normalize(join(projectDir, appDirName));
+  const pagesDir = normalize(join(projectDir, pagesDirName));
 
-  const [appStat, pagesStat] = await Promise.all([
-    statWithFallback(appDir, adapter),
-    statWithFallback(pagesDir, adapter),
+  const [hasAppDir, hasPagesDir] = await Promise.all([
+    directoryExists(appDir, projectDir, adapter),
+    directoryExists(pagesDir, projectDir, adapter),
   ]);
-
-  const hasAppDir = Boolean(appStat?.isDirectory);
-  const hasPagesDir = Boolean(pagesStat?.isDirectory);
 
   if (hasAppDir && (await hasRouteFiles(appDir, adapter))) return true;
   if (hasPagesDir && (await hasRouteFiles(pagesDir, adapter))) return false;
@@ -187,7 +184,33 @@ async function detectAppRouterImpl(
 const ROUTE_EXTENSIONS = new Set([".mdx", ".md", ".tsx", ".jsx", ".ts", ".js"]);
 const ROUTE_PATTERNS = ["page", "layout", "error", "loading", "not-found", "index"];
 
-async function hasRouteFiles(dir: string, adapter: RuntimeAdapter): Promise<boolean> {
+async function resolveTraversalKey(
+  dir: string,
+  adapter: RuntimeAdapter,
+  requireCanonicalPath: boolean,
+): Promise<string | null> {
+  if (!adapter.fs.realPath) {
+    return requireCanonicalPath ? null : normalize(dir);
+  }
+
+  try {
+    return normalize(await adapter.fs.realPath(dir));
+  } catch (_) {
+    /* expected: virtual adapters may not resolve physical paths */
+    return requireCanonicalPath ? null : normalize(dir);
+  }
+}
+
+async function hasRouteFiles(
+  dir: string,
+  adapter: RuntimeAdapter,
+  visited = new Set<string>(),
+  requireCanonicalPath = false,
+): Promise<boolean> {
+  const traversalKey = await resolveTraversalKey(dir, adapter, requireCanonicalPath);
+  if (traversalKey === null || visited.has(traversalKey)) return false;
+  visited.add(traversalKey);
+
   const entries = await readDirWithFallback(dir, adapter);
 
   for (const entry of entries) {
@@ -203,7 +226,17 @@ async function hasRouteFiles(dir: string, adapter: RuntimeAdapter): Promise<bool
       continue;
     }
 
-    if (entry.isDirectory && (await hasRouteFiles(join(dir, entry.name), adapter))) {
+    if (
+      entry.isDirectory &&
+      (await hasRouteFiles(join(dir, entry.name), adapter, visited))
+    ) {
+      return true;
+    }
+
+    if (
+      entry.isSymlink &&
+      (await hasRouteFiles(join(dir, entry.name), adapter, visited, true))
+    ) {
       return true;
     }
   }
@@ -211,19 +244,19 @@ async function hasRouteFiles(dir: string, adapter: RuntimeAdapter): Promise<bool
   return false;
 }
 
+type NormalizedDirEntry = {
+  name: string;
+  isFile: boolean;
+  isDirectory: boolean;
+  isSymlink: boolean;
+};
+
 type NormalizedStat = {
   size?: number;
   isFile: boolean;
   isDirectory: boolean;
   isSymlink: boolean;
   mtime?: Date | null;
-};
-
-type NormalizedDirEntry = {
-  name: string;
-  isFile: boolean;
-  isDirectory: boolean;
-  isSymlink: boolean;
 };
 
 async function withAdapterFallback<T>(
@@ -242,6 +275,25 @@ async function withAdapterFallback<T>(
       return defaultValue;
     }
   }
+}
+
+async function directoryExists(
+  path: string,
+  projectDir: string,
+  adapter: RuntimeAdapter,
+): Promise<boolean> {
+  if (normalize(path) === normalize(projectDir)) return true;
+
+  const parentEntries = await readDirWithFallback(dirname(path), adapter);
+  const directoryName = basename(path);
+  const listed = parentEntries.some((entry) =>
+    entry.name === directoryName && (entry.isDirectory || entry.isSymlink)
+  );
+  if (listed || adapter.id !== "cloudflare") return listed;
+
+  // Cloudflare KV represents directories only as key prefixes, so its parent
+  // listing can omit a directory that stat can still resolve.
+  return Boolean((await statWithFallback(path, adapter))?.isDirectory);
 }
 
 async function statWithFallback(

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -842,13 +842,18 @@ describe("server/handlers/request/agent-stream.handler", () => {
 
     const contextCalls: string[] = [];
     const configReads: string[] = [];
+    const sourceEvents: string[] = [];
     const fs = createNoopFsAdapter([]);
     Object.assign(fs, {
       getUnderlyingAdapter: () => fs,
       isVeryfrontAdapter: () => true,
+      ensureSourceSnapshotFresh: async () => {
+        sourceEvents.push("source-fresh");
+      },
       exists: async (path: string) => path === "/veryfront.config.ts",
       readFile: async () => {
         const branch = getCurrentRequestContext()?.branch ?? "main";
+        sourceEvents.push("config-read");
         configReads.push(branch);
         return branch === "restrict-gmail"
           ? 'export default { integrations: { allow: { gmail: { allowedTools: ["list_emails"] } } } };'
@@ -899,6 +904,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(result.response.status, 200);
     assertEquals(contextCalls, ["restrict-gmail"]);
     assertEquals(configReads, ["restrict-gmail"]);
+    assertEquals(sourceEvents.slice(0, 2), ["source-fresh", "config-read"]);
     assertEquals(discoveryConfig?.integrations, {
       allow: { gmail: { allowedTools: ["list_emails"] } },
     });

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -360,6 +360,7 @@ async function resolveAgentSourceConfig(
   if (!cacheKey) {
     throw new Error("Explicit agent source requires a project identity");
   }
+  await ctx.adapter.fs.ensureSourceSnapshotFresh?.("agent-source-config");
   return await getConfig(ctx.projectDir, ctx.adapter, {
     cacheKey,
     sourceContext: buildAgentSourceRunOptions(sourceContext),

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -10,6 +10,8 @@ function createCtx(captured: { options?: Record<string, unknown> }): HandlerCont
     adapter: {
       fs: {
         isMultiProjectMode: () => true,
+        isVeryfrontAdapter: () => true,
+        getUnderlyingAdapter: () => ({}),
         runWithContext: async (
           _slug: string,
           _token: string,
@@ -39,6 +41,205 @@ function createCtx(captured: { options?: Record<string, unknown> }): HandlerCont
 }
 
 describe("ApiHandlerWrapper", () => {
+  it("routes known pages without remote stat misses or full API discovery", async () => {
+    let enteredProjectContext = false;
+    let remoteStatMisses = 0;
+    let primitiveDiscoveryChecks = 0;
+    let apiRouteChecks = 0;
+    let sourceSnapshotRefreshes = 0;
+    let pageReads = 0;
+    const ctx = createCtx({});
+    const fs = ctx.adapter.fs as unknown as {
+      runWithContext: (
+        slug: string,
+        token: string,
+        fn: () => Promise<unknown>,
+      ) => Promise<unknown>;
+      exists: (path: string) => Promise<boolean>;
+      stat: (path: string) => Promise<unknown>;
+      readDir: (path: string) => AsyncIterable<{
+        name: string;
+        isFile: boolean;
+        isDirectory: boolean;
+        isSymlink: boolean;
+      }>;
+      resolveFile: (path: string) => Promise<string | null>;
+      readFile: (path: string) => Promise<string>;
+      refreshSourceSnapshot: (reason?: string) => Promise<void>;
+    };
+    fs.runWithContext = async (_slug, _token, fn) => {
+      enteredProjectContext = true;
+      return await fn();
+    };
+    fs.exists = (path) => {
+      if (path.endsWith("/pages/api") || path.endsWith("/app")) {
+        apiRouteChecks++;
+      } else {
+        primitiveDiscoveryChecks++;
+      }
+      return Promise.resolve(false);
+    };
+    fs.stat = () => {
+      remoteStatMisses++;
+      return Promise.reject(new Error("File not found"));
+    };
+    fs.readDir = async function* (path) {
+      if (path === "/tmp/project") {
+        yield { name: "pages", isFile: false, isDirectory: true, isSymlink: false };
+      } else if (path === "/tmp/project/pages") {
+        yield { name: "index.tsx", isFile: true, isDirectory: false, isSymlink: false };
+        yield { name: "review.tsx", isFile: true, isDirectory: false, isSymlink: false };
+      }
+    };
+    fs.resolveFile = (path) =>
+      Promise.resolve(
+        path === "/tmp/project/pages/review" ? "/tmp/project/pages/review.tsx" : null,
+      );
+    fs.readFile = (path) => {
+      if (path === "/tmp/project/pages/review.tsx" || path === "pages/review.tsx") {
+        pageReads++;
+        return Promise.resolve("export default function Review() { return null; }");
+      }
+      return Promise.reject(new Error("File not found"));
+    };
+    fs.refreshSourceSnapshot = () => {
+      sourceSnapshotRefreshes++;
+      return Promise.resolve();
+    };
+    const handler = new ApiHandlerWrapper("/tmp/project", ctx.adapter);
+
+    const result = await handler.handle(new Request("http://localhost/review"), ctx);
+
+    assertEquals(result, { continue: true });
+    assertEquals(enteredProjectContext, true);
+    assertEquals(remoteStatMisses, 0);
+    assertEquals(pageReads, 1);
+    assertEquals(primitiveDiscoveryChecks, 0);
+    assertEquals(apiRouteChecks, 0);
+    assertEquals(sourceSnapshotRefreshes, 0);
+  });
+
+  it("checks preview source freshness before resolving page ownership", async () => {
+    const events: string[] = [];
+    const ctx = createCtx({});
+    ctx.requestContext!.mode = "preview";
+    ctx.releaseId = undefined;
+    ctx.config = { router: "pages" };
+    const fs = ctx.adapter.fs as unknown as {
+      runWithContext: (
+        slug: string,
+        token: string,
+        fn: () => Promise<unknown>,
+      ) => Promise<unknown>;
+      ensureSourceSnapshotFresh: (reason?: string) => Promise<void>;
+      exists: (path: string) => Promise<boolean>;
+      readDir: (path: string) => AsyncIterable<never>;
+      resolveFile: (path: string) => Promise<string | null>;
+      readFile: (path: string) => Promise<string>;
+      refreshSourceSnapshot: (reason?: string) => Promise<void>;
+    };
+    fs.runWithContext = async (_slug, _token, fn) => await fn();
+    fs.ensureSourceSnapshotFresh = () => {
+      events.push("source-fresh");
+      return Promise.resolve();
+    };
+    fs.exists = () => Promise.resolve(false);
+    fs.readDir = async function* () {};
+    fs.resolveFile = (path) => {
+      events.push("resolve-page");
+      return Promise.resolve(
+        path === "/tmp/project/pages/review" ? "/tmp/project/pages/review.tsx" : null,
+      );
+    };
+    fs.readFile = (path) => {
+      if (path === "pages/review.tsx" || path === "/tmp/project/pages/review.tsx") {
+        return Promise.resolve("export default function Review() { return null; }");
+      }
+      return Promise.reject(new Error("File not found"));
+    };
+    fs.refreshSourceSnapshot = () => {
+      events.push("full-refresh");
+      return Promise.resolve();
+    };
+    const handler = new ApiHandlerWrapper("/tmp/project", ctx.adapter);
+
+    const result = await handler.handle(new Request("http://localhost/review"), ctx);
+
+    assertEquals(result, { continue: true });
+    assertEquals(events.slice(0, 2), ["source-fresh", "resolve-page"]);
+    assertEquals(events.includes("full-refresh"), false);
+  });
+
+  it("preserves fresh API discovery when no page owns a non-API path", async () => {
+    let sourceSnapshotRefreshes = 0;
+    const ctx = createCtx({});
+    ctx.projectSlug = "unmatched-preview-project";
+    ctx.config = { router: "pages" };
+    ctx.requestContext!.mode = "preview";
+    ctx.releaseId = undefined;
+    const fs = ctx.adapter.fs as unknown as {
+      runWithContext: (
+        slug: string,
+        token: string,
+        fn: () => Promise<unknown>,
+      ) => Promise<unknown>;
+      exists: (path: string) => Promise<boolean>;
+      readDir: (path: string) => AsyncIterable<never>;
+      resolveFile: (path: string) => Promise<string | null>;
+      readFile: (path: string) => Promise<string>;
+      refreshSourceSnapshot: (reason?: string) => Promise<void>;
+    };
+    fs.runWithContext = async (_slug, _token, fn) => await fn();
+    fs.exists = () => Promise.resolve(false);
+    fs.readDir = async function* () {};
+    fs.resolveFile = () => Promise.resolve(null);
+    fs.readFile = () => Promise.reject(new Error("File not found"));
+    fs.refreshSourceSnapshot = () => {
+      sourceSnapshotRefreshes++;
+      return Promise.resolve();
+    };
+    const handler = new ApiHandlerWrapper("/tmp/project", ctx.adapter);
+
+    const result = await handler.handle(new Request("http://localhost/new-webhook"), ctx);
+
+    assertEquals(result, { continue: true });
+    assertEquals(sourceSnapshotRefreshes, 1);
+  });
+
+  it("keeps the exact /api path in the API handler flow", async () => {
+    let sourceSnapshotRefreshes = 0;
+    const ctx = createCtx({});
+    ctx.projectSlug = "exact-api-preview-project";
+    ctx.config = { router: "pages" };
+    ctx.requestContext!.mode = "preview";
+    ctx.releaseId = undefined;
+    const fs = ctx.adapter.fs as unknown as {
+      runWithContext: (
+        slug: string,
+        token: string,
+        fn: () => Promise<unknown>,
+      ) => Promise<unknown>;
+      exists: (path: string) => Promise<boolean>;
+      readDir: (path: string) => AsyncIterable<never>;
+      readFile: (path: string) => Promise<string>;
+      refreshSourceSnapshot: (reason?: string) => Promise<void>;
+    };
+    fs.runWithContext = async (_slug, _token, fn) => await fn();
+    fs.exists = () => Promise.resolve(false);
+    fs.readDir = async function* () {};
+    fs.readFile = () => Promise.reject(new Error("File not found"));
+    fs.refreshSourceSnapshot = () => {
+      sourceSnapshotRefreshes++;
+      return Promise.resolve();
+    };
+    const handler = new ApiHandlerWrapper("/tmp/project", ctx.adapter);
+
+    const result = await handler.handle(new Request("http://localhost/api"), ctx);
+
+    assertEquals(result.response?.status, 404);
+    assertEquals(sourceSnapshotRefreshes, 1);
+  });
+
   it("forwards environmentName into multi-project request context", async () => {
     const captured: { options?: Record<string, unknown> } = {};
     const handler = new ApiHandlerWrapper("/tmp/project", createCtx(captured).adapter);

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -5,10 +5,15 @@ import type {
   HandlerPriority,
   HandlerResult,
 } from "../../types.ts";
-import { getApiHandler, withApiHandler } from "./pages-api-handler.ts";
+import {
+  ensurePreviewSourceSnapshotFresh,
+  getApiHandler,
+  withApiHandler,
+} from "./pages-api-handler.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { ensureProjectDiscovery } from "./project-discovery.ts";
+import { PageResolver } from "#veryfront/rendering/page-resolution/page-resolver.ts";
 
 type FsWrapper = {
   isMultiProjectMode?: () => boolean;
@@ -107,7 +112,7 @@ export class ApiHandlerWrapper extends BaseHandler {
     );
   }
 
-  private handleWithContext(
+  private async handleWithContext(
     req: Request,
     ctx: HandlerContext,
     pathname: string,
@@ -116,11 +121,33 @@ export class ApiHandlerWrapper extends BaseHandler {
       "api.handleWithContext",
       async () => {
         try {
+          // WebSocket pokes update mutable previews immediately. This bounded,
+          // coalesced check is the fallback for missed pokes and establishes
+          // one source snapshot for route and primitive discovery.
+          await ensurePreviewSourceSnapshotFresh(ctx);
+
+          const canResolveAsPage = pathname !== "/api" &&
+            !pathname.startsWith("/api/") &&
+            (req.method === "GET" || req.method === "HEAD");
+
+          let isPageRequest = false;
+          if (canResolveAsPage) {
+            isPageRequest = await this.isPageRequest(pathname, ctx);
+          }
+
+          if (isPageRequest) {
+            return this.continue();
+          }
+
           // Lazy per-project primitive discovery (agents, tools) on first access.
           // Must run within runWithContext so VFS and registry scope are correct.
           await ensureProjectDiscovery(ctx);
 
-          const apiRes = await withApiHandler(ctx, (api) => api.handle(req, ctx));
+          const apiRes = await withApiHandler(
+            ctx,
+            (api) => api.handle(req, ctx),
+            { sourceSnapshotReady: true },
+          );
 
           if (!apiRes) {
             this.logDebug(
@@ -165,5 +192,29 @@ export class ApiHandlerWrapper extends BaseHandler {
         "api.projectSlug": ctx.projectSlug ?? "unknown",
       },
     );
+  }
+
+  private async isPageRequest(pathname: string, ctx: HandlerContext): Promise<boolean> {
+    const slug = pathname === "/" ? "" : pathname.replace(/^\/+|\/+$/g, "");
+    const pageResolver = new PageResolver({
+      projectDir: ctx.projectDir,
+      projectId: ctx.projectId,
+      config: ctx.config ?? {},
+      adapter: ctx.adapter,
+    });
+
+    try {
+      return await pageResolver.pageExists(slug);
+    } catch (error) {
+      this.logDebug(
+        "[API-Wrapper] Page ownership is indeterminate; preserving API discovery",
+        {
+          pathname,
+          error: this.getErrorMessage(error),
+        },
+        ctx,
+      );
+      return false;
+    }
   }
 }

--- a/src/server/handlers/request/api/pages-api-handler.ts
+++ b/src/server/handlers/request/api/pages-api-handler.ts
@@ -125,17 +125,41 @@ function shouldCacheApiHandler(ctx: HandlerContext): boolean {
   return getApiHandlerCacheContext(ctx)?.mode === "production";
 }
 
-async function refreshPreviewSourceSnapshot(ctx: HandlerContext): Promise<void> {
-  if (!ctx.projectSlug) return;
+function hasMutablePreviewSource(ctx: HandlerContext): boolean {
+  if (!ctx.projectSlug) return false;
   const cacheContext = getApiHandlerCacheContext(ctx);
   // Skip when production, or when the context is indeterminate.
-  if (!cacheContext || cacheContext.mode === "production") return;
+  return !!cacheContext && cacheContext.mode !== "production";
+}
 
+export async function ensurePreviewSourceSnapshotFresh(ctx: HandlerContext): Promise<void> {
+  if (!hasMutablePreviewSource(ctx)) return;
+  if (ctx.adapter.fs.ensureSourceSnapshotFresh) {
+    await ctx.adapter.fs.ensureSourceSnapshotFresh("preview-request-routing");
+    return;
+  }
+
+  // Backward compatibility for custom remote adapters that only implement the
+  // original unconditional refresh contract.
+  await refreshPreviewSourceSnapshot(ctx);
+}
+
+export async function refreshPreviewSourceSnapshot(ctx: HandlerContext): Promise<void> {
+  if (!hasMutablePreviewSource(ctx)) return;
   await ctx.adapter.fs.refreshSourceSnapshot?.("preview-api-route-discovery");
 }
 
-async function createApiHandler(ctx: HandlerContext): Promise<APIRouteHandler> {
-  await refreshPreviewSourceSnapshot(ctx);
+interface ApiHandlerOptions {
+  sourceSnapshotReady?: boolean;
+}
+
+async function createApiHandler(
+  ctx: HandlerContext,
+  options: ApiHandlerOptions = {},
+): Promise<APIRouteHandler> {
+  if (!options.sourceSnapshotReady) {
+    await ensurePreviewSourceSnapshotFresh(ctx);
+  }
 
   const handler = new APIRouteHandler(ctx.projectDir, ctx.adapter);
   await handler.initialize();
@@ -198,9 +222,10 @@ function retainHandler(promise: Promise<APIRouteHandler>): () => Promise<void> {
 
 function getApiHandlerPromise(
   ctx: HandlerContext,
+  options: ApiHandlerOptions = {},
 ): { promise: Promise<APIRouteHandler>; cached: boolean } {
   if (!shouldCacheApiHandler(ctx)) {
-    return { promise: createApiHandler(ctx), cached: false };
+    return { promise: createApiHandler(ctx, options), cached: false };
   }
 
   const cache = getCache();
@@ -208,7 +233,7 @@ function getApiHandlerPromise(
 
   let promise = cache.get(key);
   if (!promise) {
-    promise = createApiHandler(ctx);
+    promise = createApiHandler(ctx, options);
     cache.set(key, promise);
   }
 
@@ -227,8 +252,9 @@ export async function getApiHandler(ctx: HandlerContext): Promise<APIRouteHandle
 export async function withApiHandler<T>(
   ctx: HandlerContext,
   use: (handler: APIRouteHandler) => T | Promise<T>,
+  options: ApiHandlerOptions = {},
 ): Promise<T> {
-  const { promise, cached } = getApiHandlerPromise(ctx);
+  const { promise, cached } = getApiHandlerPromise(ctx, options);
   const release = retainHandler(promise);
 
   try {

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -7,7 +7,10 @@ import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import type { HandlerContext } from "../../types.ts";
-import { ensureProjectDiscovery } from "./project-discovery.ts";
+import {
+  clearProjectDiscoveryCacheForProject,
+  ensureProjectDiscovery,
+} from "./project-discovery.ts";
 import { agentRegistry } from "#veryfront/agent/composition/composition.ts";
 import { skillRegistry } from "#veryfront/skill/registry.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
@@ -107,6 +110,99 @@ describe(
       assertEquals(updatedAgent.config.system, "SECOND");
     });
 
+    it("reuses preview discovery for one source snapshot generation", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/versioned-preview-project",
+        "versioned-preview-project",
+        "preview",
+      );
+      const agentId = "versioned-preview-agent";
+      let sourceSnapshotVersion = 1;
+      (
+        ctx.adapter.fs as typeof ctx.adapter.fs & {
+          getSourceSnapshotVersion: () => number;
+        }
+      ).getSourceSnapshotVersion = () => sourceSnapshotVersion;
+
+      await writeAgentFile(ctx, agentId, "FIRST");
+      await ensureProjectDiscovery(ctx);
+
+      await writeAgentFile(ctx, agentId, "SECOND");
+      await ensureProjectDiscovery(ctx);
+
+      const cachedAgent = getAgent(agentId);
+      assertExists(cachedAgent);
+      assertEquals(cachedAgent.config.system, "FIRST");
+
+      sourceSnapshotVersion++;
+      await ensureProjectDiscovery(ctx);
+
+      const updatedAgent = getAgent(agentId);
+      assertExists(updatedAgent);
+      assertEquals(updatedAgent.config.system, "SECOND");
+    });
+
+    it("keeps a newer source generation cached when an older discovery fails", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/overlapping-preview-project",
+        "overlapping-preview-project",
+        "preview",
+      );
+      const agentId = "overlapping-preview-agent";
+      let sourceSnapshotVersion = 1;
+      (
+        ctx.adapter.fs as typeof ctx.adapter.fs & {
+          getSourceSnapshotVersion: () => number;
+        }
+      ).getSourceSnapshotVersion = () => sourceSnapshotVersion;
+
+      await writeAgentFile(ctx, agentId, "FIRST");
+
+      const staleDiscoveryPaused = Promise.withResolvers<void>();
+      const resumeStaleDiscovery = Promise.withResolvers<void>();
+      const originalExists = ctx.adapter.fs.exists.bind(ctx.adapter.fs);
+      let failFirstSkillsRead = true;
+      ctx.adapter.fs.exists = async (path: string) => {
+        if (failFirstSkillsRead && path === `${ctx.projectDir}/skills`) {
+          failFirstSkillsRead = false;
+          staleDiscoveryPaused.resolve();
+          await resumeStaleDiscovery.promise;
+          throw new Error("old snapshot unavailable");
+        }
+        return originalExists(path);
+      };
+
+      const staleDiscovery = ensureProjectDiscovery(ctx);
+      await staleDiscoveryPaused.promise;
+
+      sourceSnapshotVersion++;
+      const currentDiscovery = ensureProjectDiscovery(ctx);
+      // Let the newer generation publish its cache record before the older
+      // transaction is released and rejects.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      resumeStaleDiscovery.resolve();
+
+      await assertRejects(
+        () => staleDiscovery,
+        Error,
+        "old snapshot unavailable",
+      );
+      await currentDiscovery;
+
+      await writeAgentFile(ctx, agentId, "SECOND");
+      await ensureProjectDiscovery(ctx);
+
+      const cachedAgent = getAgent(agentId);
+      assertExists(cachedAgent);
+      assertEquals(cachedAgent.config.system, "FIRST");
+    });
+
     it("keeps production discovery cached for the same release", async () => {
       agentRegistry.clearAll();
       toolRegistry.clearAll();
@@ -132,6 +228,37 @@ describe(
       const cachedAgent = getAgent(agentId);
       assertExists(cachedAgent);
       assertEquals(cachedAgent.config.system, "FIRST");
+    });
+
+    it("invalidates fallback discovery by canonical project id", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/project-id-invalidation",
+        "project-id-invalidation-slug",
+        "production",
+        "release-123",
+      );
+      ctx.projectId = "project-id-invalidation-id";
+      const agentId = "project-id-invalidation-agent";
+
+      await writeAgentFile(ctx, agentId, "FIRST");
+      await ensureProjectDiscovery(ctx);
+
+      await writeAgentFile(ctx, agentId, "SECOND");
+      await ensureProjectDiscovery(ctx);
+
+      const cachedAgent = getAgent(agentId);
+      assertExists(cachedAgent);
+      assertEquals(cachedAgent.config.system, "FIRST");
+
+      clearProjectDiscoveryCacheForProject(ctx.projectId);
+      await ensureProjectDiscovery(ctx);
+
+      const updatedAgent = getAgent(agentId);
+      assertExists(updatedAgent);
+      assertEquals(updatedAgent.config.system, "SECOND");
     });
 
     it("does not cache completed production discovery without a release id", async () => {
@@ -549,6 +676,52 @@ describe(
         message: "broken discovery fixture",
       }]);
       assertEquals(JSON.stringify(partialWarning).includes(ctx.projectDir), false);
+    });
+
+    it("retries partial discovery within the same source snapshot", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/partial-discovery-retry-project",
+        "partial-discovery-retry-project",
+        "preview",
+      );
+      (
+        ctx.adapter.fs as typeof ctx.adapter.fs & {
+          getSourceSnapshotVersion: () => number;
+        }
+      ).getSourceSnapshotVersion = () => 1;
+
+      const toolPath = `${ctx.projectDir}/tools/recovered-tool.ts`;
+      await ctx.adapter.fs.writeFile(
+        toolPath,
+        'throw new Error("temporary discovery failure");\n',
+      );
+
+      const partial = await ensureProjectDiscovery(ctx);
+      assertEquals(partial.errors.length, 1);
+
+      await ctx.adapter.fs.writeFile(
+        toolPath,
+        [
+          'import { tool } from "veryfront/tool";',
+          'import { defineSchema } from "veryfront/schemas";',
+          "",
+          "export default tool({",
+          '  id: "recovered_tool",',
+          '  description: "Recovers after a transient discovery failure",',
+          "  inputSchema: defineSchema((v) => v.object({}))(),",
+          "  execute: async () => ({ ok: true }),",
+          "});",
+          "",
+        ].join("\n"),
+      );
+
+      const recovered = await ensureProjectDiscovery(ctx);
+      assertEquals(recovered.errors.length, 0);
+      assertEquals(recovered.tools.has("recovered_tool"), true);
     });
 
     it("rethrows hard primitive discovery failures instead of returning an empty result", async () => {

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -21,6 +21,7 @@ const logger = serverLogger.component("api-wrapper");
  */
 interface DiscoveryRecord {
   promise: Promise<DiscoveryResult>;
+  sourceSnapshotVersion?: number;
 }
 
 const discoveredProjects = new LRUCacheAdapter({ maxEntries: 1000 });
@@ -103,17 +104,19 @@ function discoveryKey(ctx: HandlerContext): string {
     return registryScope.scopeId;
   }
 
-  const slug = ctx.projectSlug ?? ctx.projectDir;
+  const projectIdentity = ctx.projectId ?? ctx.projectSlug ?? ctx.projectDir;
   const environment = ctx.enriched?.environment ?? ctx.resolvedEnvironment ??
     (ctx.releaseId ? "production" : "preview");
 
   if (environment === "production") {
-    return ctx.releaseId ? `${slug}:release:${ctx.releaseId}` : `${slug}:production:unreleased`;
+    return ctx.releaseId
+      ? `${projectIdentity}:release:${ctx.releaseId}`
+      : `${projectIdentity}:production:unreleased`;
   }
 
   const branch = ctx.requestContext?.branch ?? ctx.enriched?.branch ?? ctx.parsedDomain?.branch ??
     "main";
-  return `${slug}:preview:${branch}`;
+  return `${projectIdentity}:preview:${branch}`;
 }
 
 function shouldCacheCompletedDiscovery(ctx: HandlerContext): boolean {
@@ -134,21 +137,31 @@ function shouldCacheCompletedDiscovery(ctx: HandlerContext): boolean {
  * correct project scope.
  */
 export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<DiscoveryResult> {
+  await ctx.adapter.fs.ensureSourceSnapshotFresh?.("primitive-discovery");
   const key = discoveryKey(ctx);
-  const cacheCompletedDiscovery = shouldCacheCompletedDiscovery(ctx);
+  const sourceSnapshotVersion = await ctx.adapter.fs.getSourceSnapshotVersion?.();
+  const cacheCompletedDiscovery = shouldCacheCompletedDiscovery(ctx) ||
+    sourceSnapshotVersion !== undefined;
 
   const existing = discoveredProjects.get<DiscoveryRecord>(key);
-  if (existing) return existing.promise;
+  if (
+    existing &&
+    (sourceSnapshotVersion === undefined ||
+      existing.sourceSnapshotVersion === sourceSnapshotVersion)
+  ) {
+    return existing.promise;
+  }
 
   const discovery = {
+    sourceSnapshotVersion,
     promise: (async () => {
-      const { clearTranspileCache, discoverAll } = await import("#veryfront/discovery");
-      const { agentRegistry } = await import(
-        "#veryfront/agent/composition/composition.ts"
-      );
-      const { toolRegistry } = await import("#veryfront/tool/registry.ts");
-
       return await runWithRegistryTransaction(async () => {
+        const { clearTranspileCache, discoverAll } = await import("#veryfront/discovery");
+        const { agentRegistry } = await import(
+          "#veryfront/agent/composition/composition.ts"
+        );
+        const { toolRegistry } = await import("#veryfront/tool/registry.ts");
+
         // Clear stale entries in a transaction-local copy. Concurrent runs keep
         // using the prior live registry until discovery succeeds and the staged
         // replacement is committed atomically.
@@ -196,10 +209,21 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<Disco
   discoveredProjects.set(key, discovery);
 
   try {
-    return await discovery.promise;
+    const result = await discovery.promise;
+    if (result.errors.length > 0) {
+      const current = discoveredProjects.get<DiscoveryRecord>(key);
+      if (current === discovery) {
+        discoveredProjects.delete(key);
+      }
+    }
+    return result;
   } catch (error) {
-    // Allow retry on next request
-    discoveredProjects.delete(key);
+    // A superseded generation may already own this key. Delete only our own
+    // record so the newer discovery remains reusable after it completes.
+    const current = discoveredProjects.get<DiscoveryRecord>(key);
+    if (current === discovery) {
+      discoveredProjects.delete(key);
+    }
     logger.warn("Primitive discovery failed (will retry)", {
       projectSlug: ctx.projectSlug,
       error: error instanceof Error ? error.message : String(error),
@@ -215,6 +239,19 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<Disco
       if (current === discovery) {
         discoveredProjects.delete(key);
       }
+    }
+  }
+}
+
+/**
+ * Drop completed and in-flight discovery records for every source scope owned
+ * by a project. The next scoped request rebuilds registries transactionally
+ * from its current source snapshot.
+ */
+export function clearProjectDiscoveryCacheForProject(projectId: string): void {
+  for (const key of discoveredProjects.keys()) {
+    if (key === projectId || key.startsWith(`${projectId}:`)) {
+      discoveredProjects.delete(key);
     }
   }
 }

--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -677,6 +677,63 @@ describe("adapter-factory", () => {
       assertEquals(calls.runWithContext !== undefined || threw, true);
     });
 
+    it("refreshes mutable source before loading proxy config", async () => {
+      let sourceFresh = false;
+      const base = createMockAdapter({
+        "/veryfront.config.ts": { isDirectory: false, isFile: true },
+      });
+      const extendedFs = {
+        ...base.fs,
+        isVeryfrontAdapter: () => true,
+        getUnderlyingAdapter: () => ({}),
+        isMultiProjectMode: () => false,
+        runWithContext: (
+          _slug: string,
+          _token: string,
+          fn: () => Promise<unknown>,
+        ) => fn(),
+        ensureSourceSnapshotFresh: () => {
+          sourceFresh = true;
+          return Promise.resolve();
+        },
+        readFile: (path: string) => {
+          if (path !== "/veryfront.config.ts") {
+            return Promise.reject(new Error(`Not found: ${path}`));
+          }
+          return Promise.resolve(
+            `export default { router: "${sourceFresh ? "pages" : "app"}" };`,
+          );
+        },
+      };
+      const adapter = { ...base, fs: extendedFs } as unknown as RuntimeAdapter;
+
+      const result = await resolveAdapter({
+        projectDir: "/base/project",
+        adapter,
+        config: undefined,
+        projectSlug: "mutable-config-project",
+        projectId: "proj_mutable_config",
+        proxyToken: "tok-123",
+        releaseId: undefined,
+        proxyEnv: "preview",
+        branch: "main",
+        environmentName: undefined,
+        parsedDomain: {
+          slug: null,
+          branch: null,
+          environment: null,
+          isVeryfrontDomain: false,
+          isDraft: false,
+          allowIframeEmbed: false,
+        },
+        req: await makeReq(),
+        isProxyMode: true,
+      });
+
+      assertEquals(sourceFresh, true);
+      assertEquals(result.config?.router, "pages");
+    });
+
     it("re-throws config loading errors in proxy mode", async () => {
       // Use an extended adapter whose runWithContext throws
       const base = createMockAdapter({});

--- a/src/server/runtime-handler/adapter-factory.ts
+++ b/src/server/runtime-handler/adapter-factory.ts
@@ -182,15 +182,20 @@ export async function resolveAdapter(
     // because proceeding without config causes silent 404s for valid projects.
     try {
       effectiveConfig = await timeAsync("config:load-proxy-project", () => {
+        const loadCurrentConfig = async (): Promise<VeryfrontConfig> => {
+          // Config controls route and primitive discovery, so it must be read
+          // from the same current snapshot that those consumers will retain.
+          await effectiveAdapter.fs.ensureSourceSnapshotFresh?.("config-load");
+          return await getConfig(effectiveProjectDir, effectiveAdapter, {
+            cacheKey: opts.projectId ?? opts.projectSlug,
+          });
+        };
+
         if (isExtendedFSAdapter(effectiveAdapter.fs) && effectiveAdapter.fs.runWithContext) {
           return effectiveAdapter.fs.runWithContext(
             opts.projectSlug!,
             opts.proxyToken!,
-            async () => {
-              return await getConfig(effectiveProjectDir, effectiveAdapter, {
-                cacheKey: opts.projectId ?? opts.projectSlug,
-              });
-            },
+            loadCurrentConfig,
             opts.projectId,
             {
               productionMode: opts.proxyEnv === "production",
@@ -201,9 +206,7 @@ export async function resolveAdapter(
           );
         }
 
-        return getConfig(effectiveProjectDir, effectiveAdapter, {
-          cacheKey: opts.projectId ?? opts.projectSlug,
-        });
+        return loadCurrentConfig();
       });
 
       logger.debug("Loaded config in proxy mode", {

--- a/src/types/entities/getEntityInfo.ts
+++ b/src/types/entities/getEntityInfo.ts
@@ -405,9 +405,6 @@ async function findDynamicPageEntity(
       : pathHelper.join(projectDir, pagesDirectory);
 
     try {
-      const canReadDirectory = await pagesDirectoryExists(pagesDir, adapter);
-      if (!canReadDirectory) continue;
-
       const entries = await readDirectoryEntries(pagesDir, adapter);
       const dynamicEntries = entries.filter(
         (entry) =>
@@ -439,25 +436,6 @@ function withResolvedSlug(info: EntityInfo, normalizedSlug: string): EntityInfo 
       slug: normalizedSlug === "index" ? "" : normalizedSlug,
     },
   };
-}
-
-async function pagesDirectoryExists(
-  pagesDir: string,
-  adapter?: RuntimeAdapter,
-): Promise<boolean> {
-  if (!adapter) return await fs.exists(pagesDir);
-
-  try {
-    const stat = await withFallback(
-      () => adapter.fs.stat(pagesDir),
-      () => fs.stat(pagesDir),
-      { operationName: "stat:getEntityBySlug", logError: false },
-    );
-    return stat.isDirectory;
-  } catch (_) {
-    /* expected: stat may fail for non-existent directories */
-    return false;
-  }
 }
 
 async function readDirectoryEntries(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1152";
+export const VERSION = "0.1.1153";

--- a/tests/integration/server/production/api.test.ts
+++ b/tests/integration/server/production/api.test.ts
@@ -117,6 +117,12 @@ describe(
           await withTestContext(
             "production-server-app-route-methods",
             async (context: TestContext) => {
+              await mkdir(join(context.projectDir, "app"), { recursive: true });
+              await writeTextFile(
+                join(context.projectDir, "app", "page.tsx"),
+                `export default function Page(){ return 'home'; }`,
+              );
+
               const postDir = join(context.projectDir, "app", "post", "[slug]");
               await mkdir(postDir, { recursive: true });
               await writeTextFile(


### PR DESCRIPTION
## Description

Authenticated hosted preview requests spent most of their server time refreshing and rediscovering the remote source before SSR. A measured `/review` request took 8.53 seconds server-side while rendering itself took 1.84 seconds, with repeated page/API discovery producing 1,954 log entries. Under a 20-request cold burst, 6 requests reached the admission deadline and returned 503.

The first implementation gated discovery by the `/api` namespace. Review correctly showed that this would hide supported App Router `route.ts` handlers outside `/api`. This revision fixes the request/source boundary instead:

- remote config, page ownership, API discovery, and agent-source reads share a bounded current source snapshot;
- only positively resolved `GET`/`HEAD` page requests bypass API primitive discovery;
- unresolved paths retain complete route discovery, including exact `/api`, dynamic and optional-catch-all APIs, and non-`/api` App Router handlers;
- snapshot leases are isolated by branch, environment, and release, so stale in-flight work cannot publish over a newer request source;
- derived cache invalidations settle before a new source generation is published;
- fallback discovery records use the canonical project ID, matching adapter and websocket invalidation;
- request-scoped file caches turn over only when the remote version advances;
- custom project-root router directories, Cloudflare directory semantics, symlinked routes, and cyclic symlinks remain supported.

No timeout, concurrency, or admission limit is raised. The release version is advanced to `0.1.1153`.

## Related Issue(s)

Authenticated hosted SSR performance investigation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Verification

- `deno task verify:quick`: passed
- `deno task test:unit`: 2,685 tests / 21,855 steps passed
- `deno task test:integration`: 242 tests / 2,588 steps passed
- Pre-push format, lint, typecheck, and full unit suite: passed
- Focused regressions cover branch switching, stale in-flight refreshes, async invalidation ordering, project-root routers, non-`/api` handlers, exact `/api`, optional adapters, cyclic symlinks, and project-ID discovery invalidation
- Linked framework source against the consumer app: `/review` and `/chat` rendered; `/api/nonexistent` returned 404
- Cold local 20-request `/review` burst: 20/20 status 200, p95 3.99 seconds, no 503
- Authenticated hosted v0.1.1152 baseline: 14/20 status 200, 6/20 status 503, p95 about 20.1 seconds
- Authenticated hosted v0.1.1153 measurement will be recorded after this release is deployed

## Checklist

- [x] No public API documentation change is required
- [x] Tests prove the route and source-snapshot behavior
- [x] `deno.json` and the runtime version constant are bumped together

