### PR TITLE
fix(ssr): keep compiled framework cache graphs reusable

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1153",
+  "version": "0.1.1154",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/cache/dependency-graph.ts
+++ b/src/cache/dependency-graph.ts
@@ -211,7 +211,7 @@ export function normalizeSpecifierToPath(
   projectDir: string,
 ): string {
   if (specifier.startsWith("@/")) {
-    return normalizeExtension(`${projectDir}/${specifier.slice(2)}`);
+    return normalizeDependencyPath(`${projectDir}/${specifier.slice(2)}`, fromFile);
   }
 
   if (specifier.startsWith("./") || specifier.startsWith("../")) {
@@ -223,14 +223,26 @@ export function normalizeSpecifierToPath(
       else if (part !== ".") parts.push(part);
     }
 
-    return normalizeExtension(`/${parts.join("/")}`);
+    return normalizeDependencyPath(`/${parts.join("/")}`, fromFile);
   }
 
   if (specifier.startsWith("file://")) {
-    return normalizeExtension(specifier.slice(7));
+    return normalizeDependencyPath(specifier.slice(7), fromFile);
   }
 
   return specifier;
+}
+
+function normalizeDependencyPath(path: string, fromFile: string): string {
+  if (
+    fromFile.endsWith(".src") &&
+    !path.endsWith(".src") &&
+    /\.(?:[cm]?[jt]sx?|mdx?)$/.test(path)
+  ) {
+    return `${path}.src`;
+  }
+
+  return normalizeExtension(path);
 }
 
 function normalizeExtension(path: string): string {

--- a/src/cache/dependency-tracking.test.ts
+++ b/src/cache/dependency-tracking.test.ts
@@ -103,6 +103,35 @@ describe("Dependency tracking cache invalidation", () => {
       expect(hash1).not.toBe(hash2);
     });
 
+    it("should hash dependencies stored as compiled framework .src files", async () => {
+      const entryPath = "/framework/dist/framework-src/react/context/index.tsx.src";
+      const dependencyPath = "/framework/dist/framework-src/react/runtime/core.ts.src";
+      const entryCode =
+        `import { core } from "../runtime/core.ts";\nexport const context = core;\n`;
+
+      const filesV1 = new Map<string, string>([
+        [entryPath, entryCode],
+        [dependencyPath, `export const core = "v1";\n`],
+      ]);
+      const filesV2 = new Map<string, string>([
+        [entryPath, entryCode],
+        [dependencyPath, `export const core = "v2";\n`],
+      ]);
+
+      const hash1 = await computeDepsHash(
+        entryPath,
+        createGetContent(filesV1),
+        "/project",
+      );
+      const hash2 = await computeDepsHash(
+        entryPath,
+        createGetContent(filesV2),
+        "/project",
+      );
+
+      expect(hash1).not.toBe(hash2);
+    });
+
     it("should reuse cached content for overlapping dependency graphs", async () => {
       const files = new Map<string, string>([
         [

--- a/src/modules/react-loader/ssr-module-loader/http-bundle-helpers.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/http-bundle-helpers.test.ts
@@ -144,6 +144,33 @@ describe("extractAllFilePaths", () => {
     assertEquals(extractAllFilePaths(code), ["/app/.cache/markdown.tsx"]);
   });
 
+  it("preserves compiled framework .src cache paths", () => {
+    const code = [
+      `import context from "file:///tmp/deno-compile-veryfront/dist/framework-src/react/context/index.tsx.src";`,
+      `import core from "file:///tmp/deno-compile-veryfront/dist/framework-src/react/runtime/core.ts.src?v=42";`,
+    ].join("\n");
+
+    assertEquals(extractAllFilePaths(code), [
+      "/tmp/deno-compile-veryfront/dist/framework-src/react/context/index.tsx.src",
+      "/tmp/deno-compile-veryfront/dist/framework-src/react/runtime/core.ts.src",
+    ]);
+  });
+
+  it("does not truncate unsupported file URL suffixes into valid-looking paths", () => {
+    const code = [
+      `import source from "file:///tmp/project/Button.ts.source";`,
+      `import sourceMap from "file:///tmp/project/Button.js.map";`,
+    ].join("\n");
+
+    assertEquals(extractAllFilePaths(code), []);
+  });
+
+  it("ignores file URLs with a host component", () => {
+    const code = `import remote from "file://cache-host/tmp/project/Button.js";`;
+
+    assertEquals(extractAllFilePaths(code), []);
+  });
+
   it("strips query parameters from extracted paths", () => {
     const code = `import a from "file:///tmp/project/Button.tsx?v=123";`;
     assertEquals(extractAllFilePaths(code), ["/tmp/project/Button.tsx"]);

--- a/src/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts
+++ b/src/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts
@@ -142,16 +142,17 @@ export function extractHttpBundlePaths(code: string): Array<{ path: string; hash
  */
 export function extractAllFilePaths(code: string): string[] {
   // Create regex per call to avoid shared lastIndex state across concurrent calls.
-  const allFilePathsPattern = /file:\/\/([^"'\s]+\.(?:mjs|js|tsx|ts|jsx)(?:\?[^"'\s]*)?)/gi;
+  const allFilePathsPattern = /file:\/\/(\/[^"'\s]+)/gi;
+  const supportedPathPattern = /\.(?:mjs|js|tsx|ts|jsx)(?:\.src)?$/i;
 
   const paths: string[] = [];
   const seen = new Set<string>();
 
   let match: RegExpExecArray | null;
   while ((match = allFilePathsPattern.exec(code)) !== null) {
-    const path = match[1]?.replace(/\?.*$/, "");
+    const path = match[1]?.replace(/[?#].*$/, "");
 
-    if (!path || seen.has(path)) continue;
+    if (!path || !supportedPathPattern.test(path) || seen.has(path)) continue;
 
     seen.add(path);
     paths.push(path);

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { join } from "#veryfront/compat/path/index.ts";
+import { join, toFileUrl } from "#veryfront/compat/path/index.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 import {
   makeTempDir,
@@ -152,6 +152,47 @@ describe("SSRCacheManager", { sanitizeResources: false, sanitizeOps: false }, ()
       );
 
       assertEquals(isValid, false);
+    } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("accepts cache entries that reference existing compiled framework sources", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-cache-manager-" });
+    const embeddedSourcePath = join(
+      projectDir,
+      "dist",
+      "framework-src",
+      "react",
+      "runtime",
+      "core.ts.src",
+    );
+
+    try {
+      await mkdir(join(projectDir, "dist", "framework-src", "react", "runtime"), {
+        recursive: true,
+      });
+      await writeTextFile(embeddedSourcePath, `export const core = "compiled";`);
+
+      const cacheManager = new SSRCacheManager({
+        projectDir,
+        projectId: `project-${crypto.randomUUID()}`,
+        contentSourceId: `preview-${crypto.randomUUID()}`,
+        adapter: denoAdapter,
+        dev: true,
+      });
+
+      const isValid = await cacheManager.validateCachedCode(
+        `import { core } from "${toFileUrl(embeddedSourcePath).href}"; export default core;`,
+        join(projectDir, "pages", "index.tsx"),
+        "memory-cache",
+        {
+          checkLocalPaths: true,
+          checkInvalidEsmShPath: false,
+        },
+      );
+
+      assertEquals(isValid, true);
     } finally {
       await remove(projectDir, { recursive: true });
     }

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
@@ -62,6 +62,21 @@ describe("modules/react-loader/ssr-module-loader/tmp-paths", () => {
     );
   });
 
+  it("builds hashed JavaScript paths for compiled framework .src files", () => {
+    const tempPath = buildTempModulePath(
+      "/cache/mdx/v0-1-1154/project/source",
+      "/tmp/deno-compile-veryfront/dist/framework-src/react/runtime/core.ts.src",
+      "/project",
+      "0.1.1154",
+      "deadbeefcafebabe",
+    );
+
+    assertEquals(
+      tempPath,
+      "/cache/mdx/v0-1-1154/project/source/tmp/deno-compile-veryfront/dist/framework-src/react/runtime/core.v0-1-1154.deadbeef.js",
+    );
+  });
+
   it("keeps absolute path structure when file is outside project dir", () => {
     const projectHash = hashCodeHex("my/project");
     const tempPath = buildTempModulePath(

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.ts
@@ -47,6 +47,6 @@ export function buildTempModulePath(
   const hashSuffix = contentHash
     ? `.v${versionPrefix}.${contentHash.slice(0, 8)}`
     : `.v${versionPrefix}`;
-  const jsPath = relativePath.replace(/\.(tsx?|jsx|mdx)$/, `${hashSuffix}.js`);
+  const jsPath = relativePath.replace(/\.(tsx?|jsx|mdx)(?:\.src)?$/, `${hashSuffix}.js`);
   return join(tmpDir, jsPath);
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1153";
+export const VERSION = "0.1.1154";


### PR DESCRIPTION
## Problem

Compiled framework modules use physical paths ending in .ts.src or .tsx.src. Three cache-path mismatches made valid entries look stale during concurrent preview SSR:

- file URL extraction truncated the terminal .src suffix
- dependency hashing rewrote embedded physical imports to .js
- temporary module paths did not content-address compiled .src inputs

The result was repeated context/router re-transforms, invalid-local-path warnings, and elevated 500/503 latency under cold concurrency.

## Fix

- validate complete file URLs and preserve supported .src paths
- hash the physical embedded dependency graph for compiled framework sources
- emit content-addressed .js artifacts for terminal .ts.src/.tsx.src inputs
- add regressions at URL extraction, dependency hashing, cache validation, and temp-path boundaries

This deliberately does not increase timeouts or bypass cache validation.

## Verification

- deno task verify:quick
- focused cache/path suite: 80 steps passed
- fresh compiled-binary E2E: 62/62 passed in 3m17s
- full framework suite: 3,113 tests / 25,292 steps passed; two unrelated baseline packaging checks fail on origin/main as well (existing gaxios ownership metadata and absent generated npm MCP handler output)
- git diff --check

## Release

Bumps framework version to 0.1.1154.