### PR TITLE
Run pushed schedules through cloud runs

### DIFF
--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -297,10 +297,14 @@ export async function login(
 export async function ensureAuthenticated(
   env: EnvironmentConfig = getEnvironmentConfig(),
 ): Promise<AuthIdentity | null> {
+  const humanOutput = !isJsonMode();
+
   if (env.apiToken) {
     const credential = await validateCredential(env.apiToken, env);
     if (credential) return credential;
-    console.log("  " + warning("Warning: VERYFRONT_API_TOKEN is invalid"));
+    if (humanOutput) {
+      console.log("  " + warning("Warning: VERYFRONT_API_TOKEN is invalid"));
+    }
   }
 
   const storedToken = await readToken(env);
@@ -308,8 +312,12 @@ export async function ensureAuthenticated(
     const credential = await validateCredential(storedToken, env);
     if (credential) return credential;
     await deleteToken(env);
-    console.log("  " + warning("Session expired. Please log in again."));
+    if (humanOutput) {
+      console.log("  " + warning("Session expired. Please log in again."));
+    }
   }
+
+  if (!humanOutput) return null;
 
   if (!isTTY()) {
     cliLogger.error("Not logged in. Set VERYFRONT_API_TOKEN or run in interactive mode.");

--- a/cli/commands/schedule/command-help.ts
+++ b/cli/commands/schedule/command-help.ts
@@ -3,7 +3,7 @@ import type { CommandHelp } from "../../help/types.ts";
 export const scheduleHelp: CommandHelp = {
   name: "schedule",
   category: "ai",
-  description: "Run a source-defined schedule locally",
+  description: "Run a source-defined schedule locally or in the Veryfront cloud",
   usage: "veryfront schedule run <id> [options]",
   options: [
     {
@@ -12,7 +12,8 @@ export const scheduleHelp: CommandHelp = {
     },
     {
       flag: "--remote",
-      description: "Run the pushed source schedule in the Veryfront cloud runtime",
+      description:
+        "Run the pushed source schedule in the Veryfront cloud runtime; cannot be combined with --input",
     },
     {
       flag: "--json",

--- a/cli/commands/schedule/command-help.ts
+++ b/cli/commands/schedule/command-help.ts
@@ -11,6 +11,10 @@ export const scheduleHelp: CommandHelp = {
       description: "JSON input file to override the schedule input",
     },
     {
+      flag: "--remote",
+      description: "Run the pushed source schedule in the Veryfront cloud runtime",
+    },
+    {
       flag: "--json",
       description: "Output the run result as JSON",
     },
@@ -22,5 +26,6 @@ export const scheduleHelp: CommandHelp = {
   examples: [
     "veryfront schedule run daily-triage",
     "veryfront schedule run daily-triage --input fixtures/priority-queue.json --json",
+    "veryfront schedule run daily-triage --remote --json",
   ],
 };

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { clearProjectAgentRuntimeRegistries } from "../../../src/agent/project/agent-runtime.ts";
+import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import type { CreateScheduleRunFromSourceResult, Run, VeryfrontRunsClient } from "veryfront/runs";
 import { setJsonMode } from "../../shared/json-output.ts";
@@ -21,6 +22,7 @@ const environmentNames = [
   "VERYFRONT_API_URL",
   "VERYFRONT_API_TOKEN",
   "VERYFRONT_PROJECT_SLUG",
+  "XDG_CONFIG_HOME",
 ] as const;
 const originalEnvironment = Object.fromEntries(
   environmentNames.map((name) => [name, Deno.env.get(name)]),
@@ -121,11 +123,13 @@ describe("schedule command", () => {
     console.log = originalConsoleLog;
     setJsonMode(false);
     restoreEnvironment();
+    _resetEnvironmentConfig();
     clearProjectAgentRuntimeRegistries();
   });
 
   it("runs a pushed schedule without importing broken local schedule files", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-schedule-remote-" });
+    const configHome = await Deno.makeTempDir({ prefix: "vf-schedule-remote-config-home-" });
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     const responses = [
       jsonResponse({
@@ -159,13 +163,23 @@ describe("schedule command", () => {
         'export default { projectSlug: "dreamy-haven", fs: { type: "local" } };\n',
       );
       await Deno.writeTextFile(
+        `${projectDir}/veryfront.json`,
+        JSON.stringify({
+          apiUrl: "https://api.from-config.test",
+          apiToken: "config-token",
+          projectSlug: "json-only-project",
+        }) + "\n",
+      );
+      await Deno.writeTextFile(
         `${projectDir}/schedules/unrelated-broken.ts`,
         "export default nope(",
       );
 
-      Deno.env.set("VERYFRONT_API_URL", "https://api.test.com");
-      Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
-      Deno.env.set("VERYFRONT_PROJECT_SLUG", "dreamy-haven");
+      Deno.env.delete("VERYFRONT_API_URL");
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+      _resetEnvironmentConfig();
       Deno.chdir(projectDir);
       setJsonMode(true);
       console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
@@ -202,10 +216,18 @@ describe("schedule command", () => {
 
       assertEquals(exitCode, 0);
       assertEquals(requests.map((request) => request.url), [
-        "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=process-job-submissions",
-        `https://api.test.com/projects/dreamy-haven/schedules/${scheduleId}/runs`,
-        `https://api.test.com/runs/${encodeURIComponent(runId)}`,
+        "https://api.from-config.test/projects/dreamy-haven/schedules?status=active&source_trigger_id=process-job-submissions",
+        `https://api.from-config.test/projects/dreamy-haven/schedules/${scheduleId}/runs`,
+        `https://api.from-config.test/runs/${encodeURIComponent(runId)}`,
       ]);
+      assertEquals(
+        requests.map((request) => new Headers(request.init?.headers).get("Authorization")),
+        [
+          "Bearer config-token",
+          "Bearer config-token",
+          "Bearer config-token",
+        ],
+      );
       const createRunBody = JSON.parse(String(requests[1]?.init?.body));
       assertEquals(createRunBody.run_name, "Process job submissions");
       assertEquals(typeof createRunBody.idempotency_key, "string");
@@ -231,6 +253,7 @@ describe("schedule command", () => {
     } finally {
       await stopEsbuild();
       await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
     }
   });
 

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -127,7 +127,7 @@ describe("schedule command", () => {
     clearProjectAgentRuntimeRegistries();
   });
 
-  it("runs a pushed schedule without importing broken local schedule files", async () => {
+  it("runs a pushed schedule without importing local runtime source", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-schedule-remote-" });
     const configHome = await Deno.makeTempDir({ prefix: "vf-schedule-remote-config-home-" });
     const requests: Array<{ url: string; init?: RequestInit }> = [];
@@ -160,7 +160,7 @@ describe("schedule command", () => {
       await Deno.mkdir(`${projectDir}/schedules`, { recursive: true });
       await Deno.writeTextFile(
         `${projectDir}/veryfront.config.ts`,
-        'export default { projectSlug: "dreamy-haven", fs: { type: "local" } };\n',
+        'throw new Error("remote schedules must not import local runtime config");\n',
       );
       await Deno.writeTextFile(
         `${projectDir}/veryfront.json`,
@@ -216,8 +216,8 @@ describe("schedule command", () => {
 
       assertEquals(exitCode, 0);
       assertEquals(requests.map((request) => request.url), [
-        "https://api.from-config.test/projects/dreamy-haven/schedules?status=active&source_trigger_id=process-job-submissions",
-        `https://api.from-config.test/projects/dreamy-haven/schedules/${scheduleId}/runs`,
+        "https://api.from-config.test/projects/json-only-project/schedules?status=active&source_trigger_id=process-job-submissions",
+        `https://api.from-config.test/projects/json-only-project/schedules/${scheduleId}/runs`,
         `https://api.from-config.test/runs/${encodeURIComponent(runId)}`,
       ]);
       assertEquals(

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -242,7 +242,7 @@ describe("schedule command", () => {
           input: "missing.json",
         } as ParsedArgs),
       Error,
-      "Remote schedule runs use the source already pushed to Veryfront and do not accept --input.",
+      "Invalid schedule arguments: remote runs use the source already pushed to Veryfront and do not accept --input.",
     );
   });
 });

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -3,7 +3,7 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { clearProjectAgentRuntimeRegistries } from "../../../src/agent/project/agent-runtime.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
-import type { Run, VeryfrontRunsClient } from "veryfront/runs";
+import type { CreateScheduleRunFromSourceResult, Run, VeryfrontRunsClient } from "veryfront/runs";
 import { setJsonMode } from "../../shared/json-output.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 import { handleScheduleCommand, waitForRemoteScheduleRun } from "./handler.ts";
@@ -81,6 +81,17 @@ function makeRun(overrides: Partial<Run> = {}): Run {
   };
 }
 
+function makeAcceptedScheduleRun(timeoutSeconds = 5): CreateScheduleRunFromSourceResult {
+  return {
+    scheduleRun: {
+      run_id: runId,
+      run_execution_id: runId,
+      schedule_id: scheduleId,
+    },
+    timeoutSeconds,
+  };
+}
+
 function restoreEnvironment(): void {
   for (const name of environmentNames) {
     const value = originalEnvironment[name];
@@ -114,6 +125,7 @@ describe("schedule command", () => {
           status: "active",
           definition_source: "source",
           source_trigger_id: "process-job-submissions",
+          timeout_seconds: 1800,
         }],
         source_schedules: [],
       }),
@@ -143,6 +155,7 @@ describe("schedule command", () => {
           '  timezone: "Europe/Berlin",',
           '  target: { kind: "agent", id: "job-submission-orchestrator" },',
           '  input: { prompt: "Process job submissions." },',
+          "  timeoutSeconds: 5,",
           "});",
           "",
         ].join("\n"),
@@ -231,6 +244,44 @@ describe("schedule command", () => {
 });
 
 describe("remote schedule polling", () => {
+  it("uses the accepted cloud schedule timeout instead of the local definition", async () => {
+    const runs = [
+      makeRun({ status: "pending", output: null, completed_at: null }),
+      makeRun({ status: "running", output: null, completed_at: null }),
+      makeRun(),
+    ];
+    const client = {
+      get: (requestedRunId: string) => {
+        assertEquals(requestedRunId, runId);
+        const run = runs.shift();
+        if (!run) throw new Error("Unexpected poll");
+        return Promise.resolve(run);
+      },
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+    let now = 0;
+
+    const run = await waitForRemoteScheduleRun(
+      client,
+      {
+        scheduleRun: {
+          run_id: runId,
+          run_execution_id: runId,
+          schedule_id: scheduleId,
+        },
+        timeoutSeconds: 1800,
+      },
+      {
+        now: () => now,
+        sleep: () => {
+          now += 36_000;
+          return Promise.resolve();
+        },
+      },
+    );
+
+    assertEquals(run.status, "completed");
+  });
+
   it("polls pending and running states until the run completes", async () => {
     const runs = [
       makeRun({ status: "pending", output: null, completed_at: null }),
@@ -246,7 +297,7 @@ describe("remote schedule polling", () => {
     } satisfies Pick<VeryfrontRunsClient, "get">;
     let now = 0;
 
-    const run = await waitForRemoteScheduleRun(client, runId, 5_000, {
+    const run = await waitForRemoteScheduleRun(client, makeAcceptedScheduleRun(), {
       now: () => now,
       sleep: (delayMs) => {
         now += delayMs;
@@ -274,7 +325,7 @@ describe("remote schedule polling", () => {
         ),
     } satisfies Pick<VeryfrontRunsClient, "get">;
 
-    const run = await waitForRemoteScheduleRun(client, runId, 5_000);
+    const run = await waitForRemoteScheduleRun(client, makeAcceptedScheduleRun());
 
     assertEquals(run.status, "waiting");
     assertEquals(run.waiting_reason, "awaiting_human");
@@ -292,7 +343,7 @@ describe("remote schedule polling", () => {
     } satisfies Pick<VeryfrontRunsClient, "get">;
 
     await assertRejects(
-      () => waitForRemoteScheduleRun(client, runId, 5_000),
+      () => waitForRemoteScheduleRun(client, makeAcceptedScheduleRun()),
       Error,
       "Hosted agent execution failed",
     );
@@ -304,7 +355,7 @@ describe("remote schedule polling", () => {
     } satisfies Pick<VeryfrontRunsClient, "get">;
 
     await assertRejects(
-      () => waitForRemoteScheduleRun(client, runId, 5_000),
+      () => waitForRemoteScheduleRun(client, makeAcceptedScheduleRun()),
       Error,
       `Scheduled run was cancelled: ${runId}`,
     );
@@ -318,7 +369,7 @@ describe("remote schedule polling", () => {
 
     await assertRejects(
       () =>
-        waitForRemoteScheduleRun(client, runId, 1_500, {
+        waitForRemoteScheduleRun(client, makeAcceptedScheduleRun(1), {
           now: () => now,
           sleep: (delayMs) => {
             now += delayMs;

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -202,7 +202,7 @@ describe("schedule command", () => {
 
       assertEquals(exitCode, 0);
       assertEquals(requests.map((request) => request.url), [
-        "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=process-job-submissions&limit=1",
+        "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=process-job-submissions",
         `https://api.test.com/projects/dreamy-haven/schedules/${scheduleId}/runs`,
         `https://api.test.com/runs/${encodeURIComponent(runId)}`,
       ]);

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -1,0 +1,332 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { clearProjectAgentRuntimeRegistries } from "../../../src/agent/project/agent-runtime.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import type { Run, VeryfrontRunsClient } from "veryfront/runs";
+import { setJsonMode } from "../../shared/json-output.ts";
+import type { ParsedArgs } from "../../shared/types.ts";
+import { handleScheduleCommand, waitForRemoteScheduleRun } from "./handler.ts";
+
+const originalCwd = Deno.cwd();
+const originalExit = Deno.exit;
+const originalFetch = globalThis.fetch;
+const originalConsoleLog = console.log;
+const environmentNames = [
+  "VERYFRONT_API_URL",
+  "VERYFRONT_API_TOKEN",
+  "VERYFRONT_PROJECT_SLUG",
+] as const;
+const originalEnvironment = Object.fromEntries(
+  environmentNames.map((name) => [name, Deno.env.get(name)]),
+) as Record<(typeof environmentNames)[number], string | undefined>;
+
+const projectId = "22222222-2222-4222-8222-222222222222";
+const scheduleId = "33333333-3333-4333-8333-333333333333";
+const runId = "run_11111111-1111-4111-8111-111111111111";
+
+class ExitSentinel extends Error {
+  constructor(readonly code: number) {
+    super(`exit:${code}`);
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    run_id: runId,
+    kind: "agent",
+    status: "completed",
+    owner: { kind: "project", id: projectId },
+    parent_run_id: null,
+    root_run_id: runId,
+    waiting_reason: null,
+    metadata: null,
+    target: "agent:job-submission-orchestrator",
+    workflow_id: null,
+    schedule_id: scheduleId,
+    batch_id: null,
+    runtime_target_kind: "main_branch",
+    runtime_target_environment_id: null,
+    runtime_target_branch_id: null,
+    input: null,
+    config: null,
+    output: {
+      scanned: 1,
+      succeeded: 1,
+      failed: 0,
+    },
+    error: null,
+    logs: null,
+    artifacts: [],
+    duration_ms: 12_345,
+    exit_code: 0,
+    start_mode: null,
+    timeout_seconds: 1800,
+    backoff_limit: 1,
+    trigger_kind: "schedule",
+    trigger_id: scheduleId,
+    created_by: null,
+    updated_at: "2026-07-26T12:00:12.345Z",
+    created_at: "2026-07-26T12:00:00.000Z",
+    started_at: "2026-07-26T12:00:00.100Z",
+    completed_at: "2026-07-26T12:00:12.345Z",
+    ...overrides,
+  };
+}
+
+function restoreEnvironment(): void {
+  for (const name of environmentNames) {
+    const value = originalEnvironment[name];
+    if (value === undefined) {
+      Deno.env.delete(name);
+    } else {
+      Deno.env.set(name, value);
+    }
+  }
+}
+
+describe("schedule command", () => {
+  afterEach(() => {
+    Deno.chdir(originalCwd);
+    // deno-lint-ignore no-explicit-any
+    (Deno as any).exit = originalExit;
+    globalThis.fetch = originalFetch;
+    console.log = originalConsoleLog;
+    setJsonMode(false);
+    restoreEnvironment();
+    clearProjectAgentRuntimeRegistries();
+  });
+
+  it("runs a source-defined schedule in the canonical cloud runtime", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-schedule-remote-" });
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const responses = [
+      jsonResponse({
+        schedules: [{
+          id: scheduleId,
+          status: "active",
+          definition_source: "source",
+          source_trigger_id: "process-job-submissions",
+        }],
+        source_schedules: [],
+      }),
+      jsonResponse({
+        run_id: runId,
+        run_execution_id: runId,
+        schedule_id: scheduleId,
+      }, 201),
+      jsonResponse(makeRun()),
+    ];
+    const output: string[] = [];
+
+    try {
+      await Deno.mkdir(`${projectDir}/schedules`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/veryfront.config.ts`,
+        'export default { projectSlug: "dreamy-haven", fs: { type: "local" } };\n',
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/schedules/process-job-submissions.ts`,
+        [
+          'import { schedule } from "veryfront/schedule";',
+          "export default schedule({",
+          '  id: "process-job-submissions",',
+          '  name: "Process job submissions",',
+          '  schedule: "0 * * * *",',
+          '  timezone: "Europe/Berlin",',
+          '  target: { kind: "agent", id: "job-submission-orchestrator" },',
+          '  input: { prompt: "Process job submissions." },',
+          "});",
+          "",
+        ].join("\n"),
+      );
+
+      Deno.env.set("VERYFRONT_API_URL", "https://api.test.com");
+      Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+      Deno.env.set("VERYFRONT_PROJECT_SLUG", "dreamy-haven");
+      Deno.chdir(projectDir);
+      setJsonMode(true);
+      console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
+      globalThis.fetch = (async (
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.toString()
+          : input.url;
+        requests.push({ url, init });
+        const response = responses.shift();
+        if (!response) throw new Error(`Unexpected request: ${url}`);
+        return response;
+      }) as typeof fetch;
+      // deno-lint-ignore no-explicit-any
+      (Deno as any).exit = (code = 0) => {
+        throw new ExitSentinel(code);
+      };
+
+      let exitCode: number | undefined;
+      try {
+        await handleScheduleCommand({
+          _: ["schedule", "run", "process-job-submissions"],
+          remote: true,
+          json: true,
+        } as ParsedArgs);
+      } catch (error) {
+        if (!(error instanceof ExitSentinel)) throw error;
+        exitCode = error.code;
+      }
+
+      assertEquals(exitCode, 0);
+      assertEquals(requests.map((request) => request.url), [
+        "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=process-job-submissions&limit=1",
+        `https://api.test.com/projects/dreamy-haven/schedules/${scheduleId}/runs`,
+        `https://api.test.com/runs/${encodeURIComponent(runId)}`,
+      ]);
+      assertEquals(JSON.parse(output.at(-1) ?? "{}"), {
+        success: true,
+        command: "schedule",
+        data: {
+          command: "schedule",
+          triggerId: "process-job-submissions",
+          target: { kind: "agent", id: "job-submission-orchestrator" },
+          output: {
+            runId,
+            status: "completed",
+            result: {
+              scanned: 1,
+              succeeded: 1,
+              failed: 0,
+            },
+          },
+          durationMs: 12_345,
+        },
+      });
+    } finally {
+      await stopEsbuild();
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("rejects local input overrides before starting a remote run", async () => {
+    await assertRejects(
+      () =>
+        handleScheduleCommand({
+          _: ["schedule", "run", "process-job-submissions"],
+          remote: true,
+          input: "missing.json",
+        } as ParsedArgs),
+      Error,
+      "Remote schedule runs use the source already pushed to Veryfront and do not accept --input.",
+    );
+  });
+});
+
+describe("remote schedule polling", () => {
+  it("polls pending and running states until the run completes", async () => {
+    const runs = [
+      makeRun({ status: "pending", output: null, completed_at: null }),
+      makeRun({ status: "running", output: null, completed_at: null }),
+      makeRun(),
+    ];
+    const client = {
+      get: () => {
+        const run = runs.shift();
+        if (!run) throw new Error("Unexpected poll");
+        return Promise.resolve(run);
+      },
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+    let now = 0;
+
+    const run = await waitForRemoteScheduleRun(client, runId, 5_000, {
+      now: () => now,
+      sleep: (delayMs) => {
+        now += delayMs;
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(run.status, "completed");
+    assertEquals(run.output, {
+      scanned: 1,
+      succeeded: 1,
+      failed: 0,
+    });
+  });
+
+  it("returns waiting runs for caller-visible human action", async () => {
+    const client = {
+      get: () =>
+        Promise.resolve(
+          makeRun({
+            status: "waiting",
+            waiting_reason: "awaiting_human",
+            completed_at: null,
+          }),
+        ),
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+
+    const run = await waitForRemoteScheduleRun(client, runId, 5_000);
+
+    assertEquals(run.status, "waiting");
+    assertEquals(run.waiting_reason, "awaiting_human");
+  });
+
+  it("surfaces the recorded error from failed runs", async () => {
+    const client = {
+      get: () =>
+        Promise.resolve(
+          makeRun({
+            status: "failed",
+            error: { message: "Hosted agent execution failed" },
+          }),
+        ),
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+
+    await assertRejects(
+      () => waitForRemoteScheduleRun(client, runId, 5_000),
+      Error,
+      "Hosted agent execution failed",
+    );
+  });
+
+  it("reports cancelled runs as failures", async () => {
+    const client = {
+      get: () => Promise.resolve(makeRun({ status: "cancelled" })),
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+
+    await assertRejects(
+      () => waitForRemoteScheduleRun(client, runId, 5_000),
+      Error,
+      `Scheduled run was cancelled: ${runId}`,
+    );
+  });
+
+  it("stops polling at the remote schedule deadline", async () => {
+    const client = {
+      get: () => Promise.resolve(makeRun({ status: "running", completed_at: null })),
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+    let now = 0;
+
+    await assertRejects(
+      () =>
+        waitForRemoteScheduleRun(client, runId, 1_500, {
+          now: () => now,
+          sleep: (delayMs) => {
+            now += delayMs;
+            return Promise.resolve();
+          },
+        }),
+      Error,
+      `Timed out waiting for scheduled run: ${runId}`,
+    );
+  });
+});

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -6,7 +6,11 @@ import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import type { CreateScheduleRunFromSourceResult, Run, VeryfrontRunsClient } from "veryfront/runs";
 import { setJsonMode } from "../../shared/json-output.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
-import { handleScheduleCommand, waitForRemoteScheduleRun } from "./handler.ts";
+import {
+  formatRemoteScheduleRunOutput,
+  handleScheduleCommand,
+  waitForRemoteScheduleRun,
+} from "./handler.ts";
 
 const originalCwd = Deno.cwd();
 const originalExit = Deno.exit;
@@ -244,6 +248,25 @@ describe("schedule command", () => {
 });
 
 describe("remote schedule polling", () => {
+  it("preserves the waiting reason in caller-visible output", () => {
+    assertEquals(
+      formatRemoteScheduleRunOutput(
+        makeRun({
+          status: "waiting",
+          waiting_reason: "awaiting_human",
+          output: null,
+          completed_at: null,
+        }),
+      ),
+      {
+        runId,
+        status: "waiting",
+        waitingReason: "awaiting_human",
+        result: null,
+      },
+    );
+  });
+
   it("uses the accepted cloud schedule timeout instead of the local definition", async () => {
     const runs = [
       makeRun({ status: "pending", output: null, completed_at: null }),

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -94,6 +94,10 @@ function makeAcceptedScheduleRun(timeoutSeconds = 5): CreateScheduleRunFromSourc
       schedule_id: scheduleId,
     },
     timeoutSeconds,
+    target: {
+      kind: "agent",
+      id: "job-submission-orchestrator",
+    },
   };
 }
 
@@ -120,14 +124,19 @@ describe("schedule command", () => {
     clearProjectAgentRuntimeRegistries();
   });
 
-  it("runs a source-defined schedule in the canonical cloud runtime", async () => {
+  it("runs a pushed schedule without importing broken local schedule files", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-schedule-remote-" });
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     const responses = [
       jsonResponse({
         schedules: [{
           id: scheduleId,
+          name: "Process job submissions",
           status: "active",
+          target: {
+            kind: "agent",
+            id: "job-submission-orchestrator",
+          },
           definition_source: "source",
           source_trigger_id: "process-job-submissions",
           timeout_seconds: 1800,
@@ -139,7 +148,7 @@ describe("schedule command", () => {
         run_execution_id: runId,
         schedule_id: scheduleId,
       }, 201),
-      jsonResponse(makeRun()),
+      jsonResponse(makeRun({ target: null })),
     ];
     const output: string[] = [];
 
@@ -150,20 +159,8 @@ describe("schedule command", () => {
         'export default { projectSlug: "dreamy-haven", fs: { type: "local" } };\n',
       );
       await Deno.writeTextFile(
-        `${projectDir}/schedules/process-job-submissions.ts`,
-        [
-          'import { schedule } from "veryfront/schedule";',
-          "export default schedule({",
-          '  id: "process-job-submissions",',
-          '  name: "Process job submissions",',
-          '  schedule: "0 * * * *",',
-          '  timezone: "Europe/Berlin",',
-          '  target: { kind: "agent", id: "local-unpushed-orchestrator" },',
-          '  input: { prompt: "Process job submissions." },',
-          "  timeoutSeconds: 5,",
-          "});",
-          "",
-        ].join("\n"),
+        `${projectDir}/schedules/unrelated-broken.ts`,
+        "export default nope(",
       );
 
       Deno.env.set("VERYFRONT_API_URL", "https://api.test.com");
@@ -209,6 +206,9 @@ describe("schedule command", () => {
         `https://api.test.com/projects/dreamy-haven/schedules/${scheduleId}/runs`,
         `https://api.test.com/runs/${encodeURIComponent(runId)}`,
       ]);
+      const createRunBody = JSON.parse(String(requests[1]?.init?.body));
+      assertEquals(createRunBody.run_name, "Process job submissions");
+      assertEquals(typeof createRunBody.idempotency_key, "string");
       assertEquals(JSON.parse(output.at(-1) ?? "{}"), {
         success: true,
         command: "schedule",
@@ -249,8 +249,8 @@ describe("schedule command", () => {
 });
 
 describe("remote schedule polling", () => {
-  it("falls back to the local target when the cloud run target is unavailable", () => {
-    const fallback = { kind: "agent" as const, id: "local-orchestrator" };
+  it("falls back to the pushed schedule target when the run target is unavailable", () => {
+    const fallback = { kind: "agent" as const, id: "pushed-orchestrator" };
     assertEquals(resolveRemoteScheduleTarget(makeRun({ target: null }), fallback), fallback);
     assertEquals(
       resolveRemoteScheduleTarget(makeRun({ target: "eval:unsupported" }), fallback),
@@ -279,9 +279,19 @@ describe("remote schedule polling", () => {
 
   it("uses the accepted cloud schedule timeout instead of the local definition", async () => {
     const runs = [
-      makeRun({ status: "pending", output: null, completed_at: null }),
-      makeRun({ status: "running", output: null, completed_at: null }),
-      makeRun(),
+      makeRun({
+        status: "pending",
+        output: null,
+        completed_at: null,
+        timeout_seconds: null,
+      }),
+      makeRun({
+        status: "running",
+        output: null,
+        completed_at: null,
+        timeout_seconds: null,
+      }),
+      makeRun({ timeout_seconds: null }),
     ];
     const client = {
       get: (requestedRunId: string) => {
@@ -295,14 +305,7 @@ describe("remote schedule polling", () => {
 
     const run = await waitForRemoteScheduleRun(
       client,
-      {
-        scheduleRun: {
-          run_id: runId,
-          run_execution_id: runId,
-          schedule_id: scheduleId,
-        },
-        timeoutSeconds: 1800,
-      },
+      makeAcceptedScheduleRun(1800),
       {
         now: () => now,
         sleep: () => {
@@ -311,6 +314,42 @@ describe("remote schedule polling", () => {
         },
       },
     );
+
+    assertEquals(run.status, "completed");
+  });
+
+  it("does not spend the execution timeout while the remote run is queued", async () => {
+    const runs = [
+      makeRun({ status: "pending", output: null, completed_at: null, started_at: null }),
+      makeRun({ status: "pending", output: null, completed_at: null, started_at: null }),
+      makeRun({
+        status: "running",
+        output: null,
+        completed_at: null,
+        started_at: "1970-01-01T00:02:00.000Z",
+      }),
+      makeRun({
+        started_at: "1970-01-01T00:02:00.000Z",
+        completed_at: "1970-01-01T00:02:00.500Z",
+      }),
+    ];
+    const client = {
+      get: (requestedRunId: string) => {
+        assertEquals(requestedRunId, runId);
+        const run = runs.shift();
+        if (!run) throw new Error("Unexpected poll");
+        return Promise.resolve(run);
+      },
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+    let now = 0;
+
+    const run = await waitForRemoteScheduleRun(client, makeAcceptedScheduleRun(1), {
+      now: () => now,
+      sleep: () => {
+        now += 60_000;
+        return Promise.resolve();
+      },
+    });
 
     assertEquals(run.status, "completed");
   });
@@ -396,7 +435,15 @@ describe("remote schedule polling", () => {
 
   it("stops polling at the remote schedule deadline", async () => {
     const client = {
-      get: () => Promise.resolve(makeRun({ status: "running", completed_at: null })),
+      get: () =>
+        Promise.resolve(
+          makeRun({
+            status: "running",
+            completed_at: null,
+            timeout_seconds: null,
+            started_at: "1970-01-01T00:00:00.000Z",
+          }),
+        ),
     } satisfies Pick<VeryfrontRunsClient, "get">;
     let now = 0;
 
@@ -411,6 +458,57 @@ describe("remote schedule polling", () => {
         }),
       Error,
       `Timed out waiting for scheduled run: ${runId}`,
+    );
+  });
+
+  it("uses the timeout recorded on the cloud run once execution starts", async () => {
+    const client = {
+      get: () =>
+        Promise.resolve(
+          makeRun({
+            status: "running",
+            completed_at: null,
+            timeout_seconds: 1,
+            started_at: "1970-01-01T00:00:00.000Z",
+          }),
+        ),
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+    let now = 0;
+
+    await assertRejects(
+      () =>
+        waitForRemoteScheduleRun(client, makeAcceptedScheduleRun(1800), {
+          now: () => now,
+          sleep: () => {
+            now += 32_000;
+            return Promise.resolve();
+          },
+        }),
+      Error,
+      `Timed out waiting for scheduled run: ${runId}`,
+    );
+  });
+
+  it("stops polling when a remote run never leaves the queue", async () => {
+    const client = {
+      get: () =>
+        Promise.resolve(
+          makeRun({ status: "pending", output: null, completed_at: null, started_at: null }),
+        ),
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+    let now = 0;
+
+    await assertRejects(
+      () =>
+        waitForRemoteScheduleRun(client, makeAcceptedScheduleRun(1), {
+          now: () => now,
+          sleep: () => {
+            now += 60_000;
+            return Promise.resolve();
+          },
+        }),
+      Error,
+      `Timed out waiting for scheduled run to start: ${runId}`,
     );
   });
 });

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -9,6 +9,7 @@ import type { ParsedArgs } from "../../shared/types.ts";
 import {
   formatRemoteScheduleRunOutput,
   handleScheduleCommand,
+  resolveRemoteScheduleTarget,
   waitForRemoteScheduleRun,
 } from "./handler.ts";
 
@@ -157,7 +158,7 @@ describe("schedule command", () => {
           '  name: "Process job submissions",',
           '  schedule: "0 * * * *",',
           '  timezone: "Europe/Berlin",',
-          '  target: { kind: "agent", id: "job-submission-orchestrator" },',
+          '  target: { kind: "agent", id: "local-unpushed-orchestrator" },',
           '  input: { prompt: "Process job submissions." },',
           "  timeoutSeconds: 5,",
           "});",
@@ -248,6 +249,15 @@ describe("schedule command", () => {
 });
 
 describe("remote schedule polling", () => {
+  it("falls back to the local target when the cloud run target is unavailable", () => {
+    const fallback = { kind: "agent" as const, id: "local-orchestrator" };
+    assertEquals(resolveRemoteScheduleTarget(makeRun({ target: null }), fallback), fallback);
+    assertEquals(
+      resolveRemoteScheduleTarget(makeRun({ target: "eval:unsupported" }), fallback),
+      fallback,
+    );
+  });
+
   it("preserves the waiting reason in caller-visible output", () => {
     assertEquals(
       formatRemoteScheduleRunOutput(

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -1,4 +1,5 @@
 import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
+import { resolveConfigWithAuth } from "#cli/shared/config";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
 import type { ParsedArgs } from "#cli/shared/types";
 import { exitProcess } from "#cli/utils";
@@ -129,8 +130,11 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
     const { adapter, config, configCacheKey, projectId } = context;
     if (opts.remote) {
       const startedAt = Date.now();
+      const cliConfig = await resolveConfigWithAuth(projectDir);
       const client = createRunsClient({
-        projectReference: config.projectSlug,
+        apiUrl: cliConfig.apiUrl,
+        authToken: cliConfig.apiToken,
+        projectReference: cliConfig.projectSlug,
       });
       const accepted = await client.createScheduleRunFromSource({
         sourceTriggerId: opts.id,

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -4,15 +4,20 @@ import type { ParsedArgs } from "#cli/shared/types";
 import { exitProcess } from "#cli/utils";
 import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
+import { createRunsClient, type Run, type VeryfrontRunsClient } from "veryfront/runs";
 import { discoverSchedules } from "veryfront/schedule";
 import { runTriggerTarget } from "veryfront/trigger";
 import { outputTriggerRun, readJsonFile } from "../trigger-utils.ts";
+
+const REMOTE_SCHEDULE_POLL_INTERVAL_MS = 1_000;
+const REMOTE_SCHEDULE_TIMEOUT_GRACE_MS = 30_000;
 
 const getScheduleArgsSchema = defineSchema((v) =>
   v.object({
     action: v.literal("run"),
     id: v.string(),
     input: v.string().optional(),
+    remote: v.boolean().default(false),
     debug: v.boolean().default(false),
   })
 );
@@ -25,12 +30,51 @@ const parseScheduleArgs = createArgParser(ScheduleArgsSchema, {
   action: { keys: ["action"], type: "string", positional: 0 },
   id: { keys: ["id"], type: "string", positional: 1 },
   input: { keys: ["input"], type: "string" },
+  remote: { keys: ["remote"], type: "boolean" },
   debug: { keys: ["debug"], type: "boolean" },
 });
+
+interface RemoteSchedulePollOptions {
+  now?: () => number;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+export async function waitForRemoteScheduleRun(
+  client: Pick<VeryfrontRunsClient, "get">,
+  runId: string,
+  timeoutMs: number,
+  options: RemoteSchedulePollOptions = {},
+): Promise<Run> {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ??
+    ((delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+  const deadline = now() + timeoutMs;
+  while (true) {
+    const run = await client.get(runId);
+    if (run.status === "completed" || run.status === "waiting") {
+      return run;
+    }
+    if (run.status === "failed") {
+      throw new Error(run.error?.message ?? `Scheduled run failed: ${runId}`);
+    }
+    if (run.status === "cancelled") {
+      throw new Error(`Scheduled run was cancelled: ${runId}`);
+    }
+    if (now() >= deadline) {
+      throw new Error(`Timed out waiting for scheduled run: ${runId}`);
+    }
+    await sleep(REMOTE_SCHEDULE_POLL_INTERVAL_MS);
+  }
+}
 
 export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
   const opts: ScheduleArgs = parseArgsOrThrow(parseScheduleArgs, "schedule", args);
   const projectDir = Deno.cwd();
+  if (opts.remote && opts.input) {
+    throw new Error(
+      "Remote schedule runs use the source already pushed to Veryfront and do not accept --input.",
+    );
+  }
   const input = opts.input ? await readJsonFile(opts.input, "--input JSON file") : undefined;
 
   await withProjectSourceContext(projectDir, async (context) => {
@@ -43,6 +87,35 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
     const schedule = result.items.find((candidate) => candidate.id === opts.id);
     if (!schedule) {
       throw new Error(`Schedule "${opts.id}" not found.`);
+    }
+
+    if (opts.remote) {
+      const startedAt = Date.now();
+      const client = createRunsClient({
+        projectReference: config.projectSlug,
+      });
+      const accepted = await client.createScheduleRunFromSource({
+        sourceTriggerId: schedule.id,
+        runName: schedule.name ?? schedule.id,
+        idempotencyKey: `schedule-cli:${crypto.randomUUID()}`,
+      });
+      const remoteRun = await waitForRemoteScheduleRun(
+        client,
+        accepted.run_id,
+        (schedule.timeoutSeconds ?? 300) * 1_000 + REMOTE_SCHEDULE_TIMEOUT_GRACE_MS,
+      );
+      await outputTriggerRun({
+        command: "schedule",
+        triggerId: schedule.id,
+        target: schedule.target,
+        output: {
+          runId: remoteRun.run_id,
+          status: remoteRun.status,
+          result: remoteRun.output,
+        },
+        durationMs: remoteRun.duration_ms ?? Date.now() - startedAt,
+      });
+      return;
     }
 
     const triggerInput = input ?? schedule.input ?? {};

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -16,6 +16,9 @@ import { outputTriggerRun, readJsonFile } from "../trigger-utils.ts";
 
 const REMOTE_SCHEDULE_POLL_INTERVAL_MS = 1_000;
 const REMOTE_SCHEDULE_TIMEOUT_GRACE_MS = 30_000;
+// Bound how long the CLI waits for dispatch without consuming the cloud run's
+// execution budget. The run remains durable in Veryfront if this wait expires.
+const REMOTE_SCHEDULE_QUEUE_WAIT_TIMEOUT_MS = 5 * 60_000;
 
 const getScheduleArgsSchema = defineSchema((v) =>
   v.object({
@@ -53,11 +56,18 @@ export async function waitForRemoteScheduleRun(
   const sleep = options.sleep ??
     ((delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs)));
   const runId = accepted.scheduleRun.run_id;
-  const deadline = now() +
-    accepted.timeoutSeconds * 1_000 +
-    REMOTE_SCHEDULE_TIMEOUT_GRACE_MS;
+  const acceptedAt = now();
+  const queueDeadline = acceptedAt + REMOTE_SCHEDULE_QUEUE_WAIT_TIMEOUT_MS;
+  let executionStartedAtMs: number | undefined;
   while (true) {
     const run = await client.get(runId);
+    const observedAt = now();
+    const parsedStartedAt = run.started_at ? Date.parse(run.started_at) : NaN;
+    if (executionStartedAtMs === undefined && Number.isFinite(parsedStartedAt)) {
+      executionStartedAtMs = Math.min(parsedStartedAt, observedAt);
+    } else if (run.status !== "pending" && executionStartedAtMs === undefined) {
+      executionStartedAtMs = observedAt;
+    }
     if (run.status === "completed" || run.status === "waiting") {
       return run;
     }
@@ -67,8 +77,20 @@ export async function waitForRemoteScheduleRun(
     if (run.status === "cancelled") {
       throw new Error(`Scheduled run was cancelled: ${runId}`);
     }
-    if (now() >= deadline) {
+    const recordedTimeoutSeconds = run.timeout_seconds;
+    const executionTimeoutSeconds = recordedTimeoutSeconds !== null &&
+        recordedTimeoutSeconds > 0
+      ? recordedTimeoutSeconds
+      : accepted.timeoutSeconds;
+    const executionDeadline = executionStartedAtMs === undefined
+      ? undefined
+      : executionStartedAtMs + executionTimeoutSeconds * 1_000 +
+        REMOTE_SCHEDULE_TIMEOUT_GRACE_MS;
+    if (executionDeadline !== undefined && observedAt >= executionDeadline) {
       throw new Error(`Timed out waiting for scheduled run: ${runId}`);
+    }
+    if (executionStartedAtMs === undefined && observedAt >= queueDeadline) {
+      throw new Error(`Timed out waiting for scheduled run to start: ${runId}`);
     }
     await sleep(REMOTE_SCHEDULE_POLL_INTERVAL_MS);
   }
@@ -103,28 +125,15 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       "Invalid schedule arguments: remote runs use the source already pushed to Veryfront and do not accept --input.",
     );
   }
-  const input = opts.input ? await readJsonFile(opts.input, "--input JSON file") : undefined;
-
   await withProjectSourceContext(projectDir, async (context) => {
     const { adapter, config, configCacheKey, projectId } = context;
-    const result = await discoverSchedules({ projectDir, adapter, config });
-    if (result.errors.length > 0) {
-      throw new Error(`Schedule discovery failed: ${result.errors[0]?.message}`);
-    }
-
-    const schedule = result.items.find((candidate) => candidate.id === opts.id);
-    if (!schedule) {
-      throw new Error(`Schedule "${opts.id}" not found.`);
-    }
-
     if (opts.remote) {
       const startedAt = Date.now();
       const client = createRunsClient({
         projectReference: config.projectSlug,
       });
       const accepted = await client.createScheduleRunFromSource({
-        sourceTriggerId: schedule.id,
-        runName: schedule.name ?? schedule.id,
+        sourceTriggerId: opts.id,
         idempotencyKey: `schedule-cli:${crypto.randomUUID()}`,
       });
       const remoteRun = await waitForRemoteScheduleRun(
@@ -133,12 +142,23 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       );
       await outputTriggerRun({
         command: "schedule",
-        triggerId: schedule.id,
-        target: resolveRemoteScheduleTarget(remoteRun, schedule.target),
+        triggerId: opts.id,
+        target: resolveRemoteScheduleTarget(remoteRun, accepted.target),
         output: formatRemoteScheduleRunOutput(remoteRun),
         durationMs: remoteRun.duration_ms ?? Date.now() - startedAt,
       });
       return;
+    }
+
+    const input = opts.input ? await readJsonFile(opts.input, "--input JSON file") : undefined;
+    const result = await discoverSchedules({ projectDir, adapter, config });
+    if (result.errors.length > 0) {
+      throw new Error(`Schedule discovery failed: ${result.errors[0]?.message}`);
+    }
+
+    const schedule = result.items.find((candidate) => candidate.id === opts.id);
+    if (!schedule) {
+      throw new Error(`Schedule "${opts.id}" not found.`);
     }
 
     const triggerInput = input ?? schedule.input ?? {};

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -118,6 +118,31 @@ export function resolveRemoteScheduleTarget(run: Run, fallback: TriggerTarget): 
   return { kind, id };
 }
 
+async function runRemoteSchedule(projectDir: string, opts: ScheduleArgs): Promise<void> {
+  const startedAt = Date.now();
+  const cliConfig = await resolveConfigWithAuth(projectDir);
+  const client = createRunsClient({
+    apiUrl: cliConfig.apiUrl,
+    authToken: cliConfig.apiToken,
+    projectReference: cliConfig.projectSlug,
+  });
+  const accepted = await client.createScheduleRunFromSource({
+    sourceTriggerId: opts.id,
+    idempotencyKey: `schedule-cli:${crypto.randomUUID()}`,
+  });
+  const remoteRun = await waitForRemoteScheduleRun(
+    client,
+    accepted,
+  );
+  await outputTriggerRun({
+    command: "schedule",
+    triggerId: opts.id,
+    target: resolveRemoteScheduleTarget(remoteRun, accepted.target),
+    output: formatRemoteScheduleRunOutput(remoteRun),
+    durationMs: remoteRun.duration_ms ?? Date.now() - startedAt,
+  });
+}
+
 export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
   const opts: ScheduleArgs = parseArgsOrThrow(parseScheduleArgs, "schedule", args);
   const projectDir = Deno.cwd();
@@ -126,34 +151,14 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       "Invalid schedule arguments: remote runs use the source already pushed to Veryfront and do not accept --input.",
     );
   }
+  if (opts.remote) {
+    await runRemoteSchedule(projectDir, opts);
+    exitProcess(0);
+    return;
+  }
+
   await withProjectSourceContext(projectDir, async (context) => {
     const { adapter, config, configCacheKey, projectId } = context;
-    if (opts.remote) {
-      const startedAt = Date.now();
-      const cliConfig = await resolveConfigWithAuth(projectDir);
-      const client = createRunsClient({
-        apiUrl: cliConfig.apiUrl,
-        authToken: cliConfig.apiToken,
-        projectReference: cliConfig.projectSlug,
-      });
-      const accepted = await client.createScheduleRunFromSource({
-        sourceTriggerId: opts.id,
-        idempotencyKey: `schedule-cli:${crypto.randomUUID()}`,
-      });
-      const remoteRun = await waitForRemoteScheduleRun(
-        client,
-        accepted,
-      );
-      await outputTriggerRun({
-        command: "schedule",
-        triggerId: opts.id,
-        target: resolveRemoteScheduleTarget(remoteRun, accepted.target),
-        output: formatRemoteScheduleRunOutput(remoteRun),
-        durationMs: remoteRun.duration_ms ?? Date.now() - startedAt,
-      });
-      return;
-    }
-
     const input = opts.input ? await readJsonFile(opts.input, "--input JSON file") : undefined;
     const result = await discoverSchedules({ projectDir, adapter, config });
     if (result.errors.length > 0) {

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -11,7 +11,7 @@ import {
   type VeryfrontRunsClient,
 } from "veryfront/runs";
 import { discoverSchedules } from "veryfront/schedule";
-import { runTriggerTarget } from "veryfront/trigger";
+import { runTriggerTarget, type TriggerTarget } from "veryfront/trigger";
 import { outputTriggerRun, readJsonFile } from "../trigger-utils.ts";
 
 const REMOTE_SCHEDULE_POLL_INTERVAL_MS = 1_000;
@@ -83,6 +83,18 @@ export function formatRemoteScheduleRunOutput(run: Run): Record<string, unknown>
   };
 }
 
+export function resolveRemoteScheduleTarget(run: Run, fallback: TriggerTarget): TriggerTarget {
+  if (!run.target) return fallback;
+  const separator = run.target.indexOf(":");
+  if (separator < 1) return fallback;
+  const kind = run.target.slice(0, separator);
+  const id = run.target.slice(separator + 1).trim();
+  if ((kind !== "agent" && kind !== "task" && kind !== "workflow") || id.length === 0) {
+    return fallback;
+  }
+  return { kind, id };
+}
+
 export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
   const opts: ScheduleArgs = parseArgsOrThrow(parseScheduleArgs, "schedule", args);
   const projectDir = Deno.cwd();
@@ -122,7 +134,7 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       await outputTriggerRun({
         command: "schedule",
         triggerId: schedule.id,
-        target: schedule.target,
+        target: resolveRemoteScheduleTarget(remoteRun, schedule.target),
         output: formatRemoteScheduleRunOutput(remoteRun),
         durationMs: remoteRun.duration_ms ?? Date.now() - startedAt,
       });

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -74,6 +74,15 @@ export async function waitForRemoteScheduleRun(
   }
 }
 
+export function formatRemoteScheduleRunOutput(run: Run): Record<string, unknown> {
+  return {
+    runId: run.run_id,
+    status: run.status,
+    ...(run.waiting_reason ? { waitingReason: run.waiting_reason } : {}),
+    result: run.output,
+  };
+}
+
 export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
   const opts: ScheduleArgs = parseArgsOrThrow(parseScheduleArgs, "schedule", args);
   const projectDir = Deno.cwd();
@@ -114,11 +123,7 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
         command: "schedule",
         triggerId: schedule.id,
         target: schedule.target,
-        output: {
-          runId: remoteRun.run_id,
-          status: remoteRun.status,
-          result: remoteRun.output,
-        },
+        output: formatRemoteScheduleRunOutput(remoteRun),
         durationMs: remoteRun.duration_ms ?? Date.now() - startedAt,
       });
       return;

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -4,7 +4,12 @@ import type { ParsedArgs } from "#cli/shared/types";
 import { exitProcess } from "#cli/utils";
 import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
-import { createRunsClient, type Run, type VeryfrontRunsClient } from "veryfront/runs";
+import {
+  createRunsClient,
+  type CreateScheduleRunFromSourceResult,
+  type Run,
+  type VeryfrontRunsClient,
+} from "veryfront/runs";
 import { discoverSchedules } from "veryfront/schedule";
 import { runTriggerTarget } from "veryfront/trigger";
 import { outputTriggerRun, readJsonFile } from "../trigger-utils.ts";
@@ -41,14 +46,16 @@ interface RemoteSchedulePollOptions {
 
 export async function waitForRemoteScheduleRun(
   client: Pick<VeryfrontRunsClient, "get">,
-  runId: string,
-  timeoutMs: number,
+  accepted: CreateScheduleRunFromSourceResult,
   options: RemoteSchedulePollOptions = {},
 ): Promise<Run> {
   const now = options.now ?? Date.now;
   const sleep = options.sleep ??
     ((delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs)));
-  const deadline = now() + timeoutMs;
+  const runId = accepted.scheduleRun.run_id;
+  const deadline = now() +
+    accepted.timeoutSeconds * 1_000 +
+    REMOTE_SCHEDULE_TIMEOUT_GRACE_MS;
   while (true) {
     const run = await client.get(runId);
     if (run.status === "completed" || run.status === "waiting") {
@@ -101,8 +108,7 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       });
       const remoteRun = await waitForRemoteScheduleRun(
         client,
-        accepted.run_id,
-        (schedule.timeoutSeconds ?? 300) * 1_000 + REMOTE_SCHEDULE_TIMEOUT_GRACE_MS,
+        accepted,
       );
       await outputTriggerRun({
         command: "schedule",

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -88,7 +88,7 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
   const projectDir = Deno.cwd();
   if (opts.remote && opts.input) {
     throw new Error(
-      "Remote schedule runs use the source already pushed to Veryfront and do not accept --input.",
+      "Invalid schedule arguments: remote runs use the source already pushed to Veryfront and do not accept --input.",
     );
   }
   const input = opts.input ? await readJsonFile(opts.input, "--input JSON file") : undefined;

--- a/cli/router.test.ts
+++ b/cli/router.test.ts
@@ -482,6 +482,29 @@ describe("cli/router helpers", () => {
         restoreAll();
       }
     });
+
+    it("reports incompatible remote schedule input as a usage error", async () => {
+      stubExit();
+      stubConsole();
+      setJsonMode(true);
+      try {
+        const code = await runAndCaptureExit({
+          _: ["schedule", "run", "process-job-submissions"],
+          remote: true,
+          input: "input.json",
+          json: true,
+        } as ParsedArgs);
+        assertEquals(code, 2);
+        assertEquals(consoleOutput.length, 1);
+        const parsed = JSON.parse(consoleOutput[0]!);
+        assertEquals(parsed.success, false);
+        assertEquals(parsed.command, "schedule");
+        assertEquals(parsed.error.code, "USAGE_ERROR");
+        assertEquals(parsed.error.slug, "invalid-arguments");
+      } finally {
+        restoreAll();
+      }
+    });
   });
 
   describe("command extraction from args", () => {

--- a/cli/router.test.ts
+++ b/cli/router.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { COMMANDS } from "./help/command-definitions.ts";
@@ -317,8 +318,10 @@ describe("cli/router helpers", () => {
     const originalExit = Deno.exit;
     const originalInfo = cliLogger.info;
     const originalConsoleLog = console.log;
+    const originalConsoleError = console.error;
     let infoMessages: string[];
     let consoleOutput: string[];
+    let consoleErrorOutput: string[];
 
     function stubExit() {
       // deno-lint-ignore no-explicit-any
@@ -336,8 +339,12 @@ describe("cli/router helpers", () => {
 
     function stubConsole() {
       consoleOutput = [];
+      consoleErrorOutput = [];
       console.log = (...args: unknown[]) => {
         consoleOutput.push(args.map(String).join(" "));
+      };
+      console.error = (...args: unknown[]) => {
+        consoleErrorOutput.push(args.map(String).join(" "));
       };
     }
 
@@ -346,6 +353,7 @@ describe("cli/router helpers", () => {
       (Deno as any).exit = originalExit;
       cliLogger.info = originalInfo;
       console.log = originalConsoleLog;
+      console.error = originalConsoleError;
       setJsonMode(false);
       resetInteractiveMode();
     }
@@ -503,6 +511,63 @@ describe("cli/router helpers", () => {
         assertEquals(parsed.error.slug, "invalid-arguments");
       } finally {
         restoreAll();
+      }
+    });
+
+    it("reports missing credentials for schedule remote JSON runs as JSON command failure", async () => {
+      const originalCwd = Deno.cwd();
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-schedule-json-auth-" });
+      const configHome = await Deno.makeTempDir({ prefix: "vf-schedule-json-auth-config-" });
+      const environmentNames = [
+        "VERYFRONT_API_URL",
+        "VERYFRONT_API_TOKEN",
+        "VERYFRONT_PROJECT_SLUG",
+        "XDG_CONFIG_HOME",
+      ] as const;
+      const originalEnvironment = Object.fromEntries(
+        environmentNames.map((name) => [name, Deno.env.get(name)]),
+      ) as Record<(typeof environmentNames)[number], string | undefined>;
+
+      stubExit();
+      stubConsole();
+      setJsonMode(true);
+      try {
+        await Deno.writeTextFile(
+          `${projectDir}/veryfront.json`,
+          JSON.stringify({ projectSlug: "json-auth-project" }),
+        );
+        Deno.chdir(projectDir);
+        Deno.env.delete("VERYFRONT_API_URL");
+        Deno.env.delete("VERYFRONT_API_TOKEN");
+        Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+        Deno.env.set("XDG_CONFIG_HOME", configHome);
+        _resetEnvironmentConfig();
+
+        const code = await runAndCaptureExit({
+          _: ["schedule", "run", "process-job-submissions"],
+          remote: true,
+          json: true,
+        } as ParsedArgs);
+        assertEquals(code, 1);
+        assertEquals(consoleOutput.length, 1);
+        const parsed = JSON.parse(consoleOutput[0] ?? "{}");
+        assertEquals(parsed.success, false);
+        assertEquals(parsed.command, "schedule");
+        assertEquals(parsed.error.code, "RUNTIME_ERROR");
+        assertEquals(parsed.error.slug, "command-failed");
+        assertEquals(parsed.error.message, "Authentication required for this operation.");
+        assertEquals(consoleErrorOutput, []);
+      } finally {
+        Deno.chdir(originalCwd);
+        for (const name of environmentNames) {
+          const value = originalEnvironment[name];
+          if (value === undefined) Deno.env.delete(name);
+          else Deno.env.set(name, value);
+        }
+        _resetEnvironmentConfig();
+        restoreAll();
+        await Deno.remove(projectDir, { recursive: true });
+        await Deno.remove(configHome, { recursive: true });
       }
     });
   });

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1154",
+  "version": "0.1.1155",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.lock
+++ b/deno.lock
@@ -3,8 +3,13 @@
   "specifiers": {
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/assert@^1.0.17": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@1.2.0": "1.2.0",
+    "jsr:@std/async@^1.1.0": "1.4.0",
     "jsr:@std/cli@1.0.28": "1.0.28",
+    "jsr:@std/data-structures@^1.0.10": "1.0.11",
     "jsr:@std/dotenv@0.225.6": "0.225.6",
+    "jsr:@std/expect@1.0.18": "1.0.18",
     "jsr:@std/fmt@1.0.9": "1.0.9",
     "jsr:@std/fs@1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.14",
@@ -20,7 +25,7 @@
     "npm:@kreuzberg/node@4.4.2": "4.4.2",
     "npm:@kreuzberg/wasm@4.5.2": "4.5.2",
     "npm:@mdx-js/mdx@3.1.1": "3.1.1",
-    "npm:@mdx-js/react@3.1.1": "3.1.1_@types+react@19.2.17_react@19.2.8",
+    "npm:@mdx-js/react@3.1.1": "3.1.1_@types+react@19.2.17_react@19.2.7",
     "npm:@opentelemetry/api-logs@0.208.0": "0.208.0",
     "npm:@opentelemetry/api-logs@0.220.0": "0.220.0",
     "npm:@opentelemetry/api@1.9.1": "1.9.1",
@@ -43,7 +48,7 @@
     "npm:@types/mdast@4.0.3": "4.0.3",
     "npm:@types/node@*": "24.2.0",
     "npm:@types/unist@3.0.2": "3.0.2",
-    "npm:bash-tool@1.3.16": "1.3.16_ai@6.0.235__zod@3.25.76_just-bash@2.14.5",
+    "npm:bash-tool@1.3.16": "1.3.16_ai@6.0.232__zod@3.25.76_just-bash@2.14.5",
     "npm:better-sqlite3@9.6.0": "9.6.0",
     "npm:brace-expansion@5.0.8": "5.0.8",
     "npm:es-module-lexer@2.0.0": "2.0.0",
@@ -84,11 +89,28 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/async@1.2.0": {
+      "integrity": "c059c6f6d95ca7cc012ae8e8d7164d1697113d54b0b679e4372b354b11c2dee5"
+    },
+    "@std/async@1.4.0": {
+      "integrity": "4d70b008634f571cff9b554090d628c76141c32613aae0ff283fd5fa23d0c379"
+    },
     "@std/cli@1.0.28": {
       "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a"
     },
+    "@std/data-structures@1.0.11": {
+      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
+    },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
+    },
+    "@std/expect@1.0.18": {
+      "integrity": "8566eab35200466f8609eb7e7aed062ed0db314e9a258d5d201b1b8997ce801a",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.4"
+      ]
     },
     "@std/fmt@1.0.9": {
       "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
@@ -113,6 +135,8 @@
       "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
       "dependencies": [
         "jsr:@std/assert@^1.0.17",
+        "jsr:@std/async@^1.1.0",
+        "jsr:@std/data-structures",
         "jsr:@std/internal"
       ]
     },
@@ -124,8 +148,8 @@
     "@acemir/cssom@0.9.31": {
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="
     },
-    "@ai-sdk/gateway@3.0.157_zod@3.25.76": {
-      "integrity": "sha512-jO0LUsIQC+FeJRQI1KFiNcfTGp6a0lXrymekaXfBIvhVEOyt0NUyc9wiVi/dYGHQmWFXUo8QgmghgGAGLOPTAA==",
+    "@ai-sdk/gateway@3.0.154_zod@3.25.76": {
+      "integrity": "sha512-pKJmMnTxdTOfo+iz7pCAgmnMt4uan2yIw8nChFVIk3yYBeX2A9p2MCGyP8jZ1zpqSYXBmczQZU7Pjvlj1aLbIQ==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -733,7 +757,7 @@
         "vfile"
       ]
     },
-    "@mdx-js/react@3.1.1_@types+react@19.2.17_react@19.2.8": {
+    "@mdx-js/react@3.1.1_@types+react@19.2.17_react@19.2.7": {
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "dependencies": [
         "@types/mdx",
@@ -1416,8 +1440,8 @@
         "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1"
       ]
     },
-    "@opentelemetry/resource-detector-aws@2.21.0_@opentelemetry+api@1.9.1": {
-      "integrity": "sha512-Veavy+khoywR+Hv065SU5jucFTGTiW1KXo39CsJ+8wqdYYz8jiRJPnQ20Kd+X9HbV2+Abb0l5CrJIdxK1ZOqBg==",
+    "@opentelemetry/resource-detector-aws@2.20.0_@opentelemetry+api@1.9.1": {
+      "integrity": "sha512-3ZkhvVHqJgJ75ObpZQwZIBySNfd4h772QRb2NBPU1A3lSUzDlRen9x5Kzv/K7HNkL/Azl8XEanykwa73YjWmQA==",
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
@@ -1434,8 +1458,8 @@
         "@opentelemetry/semantic-conventions"
       ]
     },
-    "@opentelemetry/resource-detector-container@0.8.12_@opentelemetry+api@1.9.1": {
-      "integrity": "sha512-EJRFfIY26whY0w5RDxMRXlfBDgDS001JYMHuOVuDBBsRrV4MBqoVajR9B0L9Vy728+w/HNVnSQkpJFacFr+klg==",
+    "@opentelemetry/resource-detector-container@0.8.11_@opentelemetry+api@1.9.1": {
+      "integrity": "sha512-O7dMPH13+JZu+swtCsdq5702Fa2Q4MSHmwMoLxyqgWuPPtmDmao4s+V1ovfg225zW67quNDXFKdLf1q5/Elb9w==",
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
@@ -1799,8 +1823,8 @@
     "agent-base@7.1.4": {
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
     },
-    "ai@6.0.235_zod@3.25.76": {
-      "integrity": "sha512-Uyeuvowo20XChpFC0lUaQq8xf0Kg7OElA56fEjUYoeWMJIzqshDTz4S57KXobcJ4m+iDQxMeJoUj06CIxSLx7A==",
+    "ai@6.0.232_zod@3.25.76": {
+      "integrity": "sha512-Ml5Kys8d6TqPq+5dxwGXJYQrW0/k9vzu9Z4Tr8NS0A7pzlJCKLpKMYIUHvCmG96GGrZ8zn9cxoFE29gPCU3cqQ==",
       "dependencies": [
         "@ai-sdk/gateway",
         "@ai-sdk/provider",
@@ -1834,7 +1858,7 @@
     "base64-js@1.5.1": {
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
-    "bash-tool@1.3.16_ai@6.0.235__zod@3.25.76_just-bash@2.14.5": {
+    "bash-tool@1.3.16_ai@6.0.232__zod@3.25.76_just-bash@2.14.5": {
       "integrity": "sha512-2xuprVBzUOYw4+QCpeSwvkuXuHkjKRtMzh+nTpEidROsNnglr5xRs3mdeOmwFVkjB4JhE/uZqIXE+tabbJI7QQ==",
       "dependencies": [
         "ai",
@@ -2330,8 +2354,8 @@
         "gopd"
       ]
     },
-    "google-logging-utils@1.2.0": {
-      "integrity": "sha512-WE9av4wKDZgRjBwgVUabocx8T6/7o3Ca1Fat46FXDhXVAFibzNadedcOXrdgd1Kzmk8tsk/9ZH89Wyf/SqeZ3A=="
+    "google-logging-utils@1.1.3": {
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="
     },
     "gopd@1.2.0": {
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
@@ -3540,8 +3564,8 @@
       "integrity": "sha512-KTOIcZTSOpOxbu3i0+T6mFQ6tkxXKlTxfcMFs1trQbsMnG84qNq+DjXr8Afu+FEFjvF1NNlldpC7roPyazFI8g==",
       "deprecated": true
     },
-    "react@19.2.8": {
-      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="
+    "react@19.2.7": {
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="
     },
     "readable-stream@2.3.8": {
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
@@ -3912,8 +3936,8 @@
     "symbol-tree@3.2.4": {
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "systeminformation@5.33.1": {
-      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
+    "systeminformation@5.33.0": {
+      "integrity": "sha512-0LYSL01CCbjVeJG7iXI8fUCFU76zMjzbHd/EU3or4QpSFYCLMgslR11prwHuA3siz5jmOkqoLhjgOyDRmXBKmA==",
       "os": ["darwin", "linux", "win32", "freebsd", "openbsd", "netbsd", "sunos", "android"],
       "bin": true
     },

--- a/deno.lock
+++ b/deno.lock
@@ -3,13 +3,8 @@
   "specifiers": {
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/assert@^1.0.17": "1.0.19",
-    "jsr:@std/assert@^1.0.19": "1.0.19",
-    "jsr:@std/async@1.2.0": "1.2.0",
-    "jsr:@std/async@^1.1.0": "1.4.0",
     "jsr:@std/cli@1.0.28": "1.0.28",
-    "jsr:@std/data-structures@^1.0.10": "1.0.11",
     "jsr:@std/dotenv@0.225.6": "0.225.6",
-    "jsr:@std/expect@1.0.18": "1.0.18",
     "jsr:@std/fmt@1.0.9": "1.0.9",
     "jsr:@std/fs@1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.14",
@@ -25,7 +20,7 @@
     "npm:@kreuzberg/node@4.4.2": "4.4.2",
     "npm:@kreuzberg/wasm@4.5.2": "4.5.2",
     "npm:@mdx-js/mdx@3.1.1": "3.1.1",
-    "npm:@mdx-js/react@3.1.1": "3.1.1_@types+react@19.2.17_react@19.2.7",
+    "npm:@mdx-js/react@3.1.1": "3.1.1_@types+react@19.2.17_react@19.2.8",
     "npm:@opentelemetry/api-logs@0.208.0": "0.208.0",
     "npm:@opentelemetry/api-logs@0.220.0": "0.220.0",
     "npm:@opentelemetry/api@1.9.1": "1.9.1",
@@ -48,7 +43,7 @@
     "npm:@types/mdast@4.0.3": "4.0.3",
     "npm:@types/node@*": "24.2.0",
     "npm:@types/unist@3.0.2": "3.0.2",
-    "npm:bash-tool@1.3.16": "1.3.16_ai@6.0.232__zod@3.25.76_just-bash@2.14.5",
+    "npm:bash-tool@1.3.16": "1.3.16_ai@6.0.235__zod@3.25.76_just-bash@2.14.5",
     "npm:better-sqlite3@9.6.0": "9.6.0",
     "npm:brace-expansion@5.0.8": "5.0.8",
     "npm:es-module-lexer@2.0.0": "2.0.0",
@@ -89,28 +84,11 @@
         "jsr:@std/internal"
       ]
     },
-    "@std/async@1.2.0": {
-      "integrity": "c059c6f6d95ca7cc012ae8e8d7164d1697113d54b0b679e4372b354b11c2dee5"
-    },
-    "@std/async@1.4.0": {
-      "integrity": "4d70b008634f571cff9b554090d628c76141c32613aae0ff283fd5fa23d0c379"
-    },
     "@std/cli@1.0.28": {
       "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a"
     },
-    "@std/data-structures@1.0.11": {
-      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
-    },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
-    },
-    "@std/expect@1.0.18": {
-      "integrity": "8566eab35200466f8609eb7e7aed062ed0db314e9a258d5d201b1b8997ce801a",
-      "dependencies": [
-        "jsr:@std/assert@^1.0.19",
-        "jsr:@std/internal",
-        "jsr:@std/path@^1.1.4"
-      ]
     },
     "@std/fmt@1.0.9": {
       "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
@@ -135,8 +113,6 @@
       "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
       "dependencies": [
         "jsr:@std/assert@^1.0.17",
-        "jsr:@std/async@^1.1.0",
-        "jsr:@std/data-structures",
         "jsr:@std/internal"
       ]
     },
@@ -148,8 +124,8 @@
     "@acemir/cssom@0.9.31": {
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="
     },
-    "@ai-sdk/gateway@3.0.154_zod@3.25.76": {
-      "integrity": "sha512-pKJmMnTxdTOfo+iz7pCAgmnMt4uan2yIw8nChFVIk3yYBeX2A9p2MCGyP8jZ1zpqSYXBmczQZU7Pjvlj1aLbIQ==",
+    "@ai-sdk/gateway@3.0.157_zod@3.25.76": {
+      "integrity": "sha512-jO0LUsIQC+FeJRQI1KFiNcfTGp6a0lXrymekaXfBIvhVEOyt0NUyc9wiVi/dYGHQmWFXUo8QgmghgGAGLOPTAA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -757,7 +733,7 @@
         "vfile"
       ]
     },
-    "@mdx-js/react@3.1.1_@types+react@19.2.17_react@19.2.7": {
+    "@mdx-js/react@3.1.1_@types+react@19.2.17_react@19.2.8": {
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "dependencies": [
         "@types/mdx",
@@ -1440,8 +1416,8 @@
         "@opentelemetry/resources@2.9.0_@opentelemetry+api@1.9.1"
       ]
     },
-    "@opentelemetry/resource-detector-aws@2.20.0_@opentelemetry+api@1.9.1": {
-      "integrity": "sha512-3ZkhvVHqJgJ75ObpZQwZIBySNfd4h772QRb2NBPU1A3lSUzDlRen9x5Kzv/K7HNkL/Azl8XEanykwa73YjWmQA==",
+    "@opentelemetry/resource-detector-aws@2.21.0_@opentelemetry+api@1.9.1": {
+      "integrity": "sha512-Veavy+khoywR+Hv065SU5jucFTGTiW1KXo39CsJ+8wqdYYz8jiRJPnQ20Kd+X9HbV2+Abb0l5CrJIdxK1ZOqBg==",
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
@@ -1458,8 +1434,8 @@
         "@opentelemetry/semantic-conventions"
       ]
     },
-    "@opentelemetry/resource-detector-container@0.8.11_@opentelemetry+api@1.9.1": {
-      "integrity": "sha512-O7dMPH13+JZu+swtCsdq5702Fa2Q4MSHmwMoLxyqgWuPPtmDmao4s+V1ovfg225zW67quNDXFKdLf1q5/Elb9w==",
+    "@opentelemetry/resource-detector-container@0.8.12_@opentelemetry+api@1.9.1": {
+      "integrity": "sha512-EJRFfIY26whY0w5RDxMRXlfBDgDS001JYMHuOVuDBBsRrV4MBqoVajR9B0L9Vy728+w/HNVnSQkpJFacFr+klg==",
       "dependencies": [
         "@opentelemetry/api",
         "@opentelemetry/core@2.9.0_@opentelemetry+api@1.9.1",
@@ -1823,8 +1799,8 @@
     "agent-base@7.1.4": {
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
     },
-    "ai@6.0.232_zod@3.25.76": {
-      "integrity": "sha512-Ml5Kys8d6TqPq+5dxwGXJYQrW0/k9vzu9Z4Tr8NS0A7pzlJCKLpKMYIUHvCmG96GGrZ8zn9cxoFE29gPCU3cqQ==",
+    "ai@6.0.235_zod@3.25.76": {
+      "integrity": "sha512-Uyeuvowo20XChpFC0lUaQq8xf0Kg7OElA56fEjUYoeWMJIzqshDTz4S57KXobcJ4m+iDQxMeJoUj06CIxSLx7A==",
       "dependencies": [
         "@ai-sdk/gateway",
         "@ai-sdk/provider",
@@ -1858,7 +1834,7 @@
     "base64-js@1.5.1": {
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
-    "bash-tool@1.3.16_ai@6.0.232__zod@3.25.76_just-bash@2.14.5": {
+    "bash-tool@1.3.16_ai@6.0.235__zod@3.25.76_just-bash@2.14.5": {
       "integrity": "sha512-2xuprVBzUOYw4+QCpeSwvkuXuHkjKRtMzh+nTpEidROsNnglr5xRs3mdeOmwFVkjB4JhE/uZqIXE+tabbJI7QQ==",
       "dependencies": [
         "ai",
@@ -2354,8 +2330,8 @@
         "gopd"
       ]
     },
-    "google-logging-utils@1.1.3": {
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="
+    "google-logging-utils@1.2.0": {
+      "integrity": "sha512-WE9av4wKDZgRjBwgVUabocx8T6/7o3Ca1Fat46FXDhXVAFibzNadedcOXrdgd1Kzmk8tsk/9ZH89Wyf/SqeZ3A=="
     },
     "gopd@1.2.0": {
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
@@ -3564,8 +3540,8 @@
       "integrity": "sha512-KTOIcZTSOpOxbu3i0+T6mFQ6tkxXKlTxfcMFs1trQbsMnG84qNq+DjXr8Afu+FEFjvF1NNlldpC7roPyazFI8g==",
       "deprecated": true
     },
-    "react@19.2.7": {
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="
+    "react@19.2.8": {
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="
     },
     "readable-stream@2.3.8": {
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
@@ -3936,8 +3912,8 @@
     "symbol-tree@3.2.4": {
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "systeminformation@5.33.0": {
-      "integrity": "sha512-0LYSL01CCbjVeJG7iXI8fUCFU76zMjzbHd/EU3or4QpSFYCLMgslR11prwHuA3siz5jmOkqoLhjgOyDRmXBKmA==",
+    "systeminformation@5.33.1": {
+      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
       "os": ["darwin", "linux", "win32", "freebsd", "openbsd", "netbsd", "sunos", "android"],
       "bin": true
     },

--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -199,7 +199,7 @@ Run the agent and stream the response. Returns a result with `.toDataStreamRespo
 
 ### `agent.respond(request)`
 
-Convert an HTTP request into an AG-UI streaming response for route handlers.
+Handle an incoming HTTP request and return a streaming `Response`. Reads messages from the request body.
 
 **Returns:** <code>Promise&lt;Response&gt;</code>
 
@@ -501,7 +501,7 @@ Clear all stored messages from memory.
 | `createRuntimeAgentDefinitionFromAgent` | Create runtime agent definition from agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/project/agent-runtime.ts#L169) |
 | `createRuntimeAgentFromMarkdownDefinition` | Definition for create runtime agent from markdown. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/agent-markdown-adapter.ts#L8) |
 | `createRuntimeAgentSystemMessages` | Create runtime agent system messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/agent-definition.ts#L256) |
-| `createRuntimeLoadSkillTool` | Create runtime load skill tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L514) |
+| `createRuntimeLoadSkillTool` | Create runtime load skill tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L562) |
 | `createRuntimeProjectFilesClient` | Create runtime project files client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/project-files-client.ts#L104) |
 | `createRuntimeProjectSkillLoader` | Create runtime project skill loader. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/project-skill-loader.ts#L327) |
 | `createRuntimePromptBlock` | Create runtime prompt block. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/prompt-block.ts#L9) |
@@ -1537,13 +1537,13 @@ Clear all stored messages from memory.
 | `RuntimeLoadedSkillResponse` | Response payload for runtime loaded skill. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/skill-metadata.ts#L149) |
 | `RuntimeLoadedSkillResponseMessages` | Public API contract for runtime loaded skill response messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/skill-metadata.ts#L140) |
 | `RuntimeLoadSkillBuiltinStore` | Public API contract for runtime load skill builtin store. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L118) |
-| `RuntimeLoadSkillErrorOutput` | Output from runtime load skill error. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L167) |
-| `RuntimeLoadSkillReferenceFileOutput` | Output from runtime load skill reference file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L160) |
+| `RuntimeLoadSkillErrorOutput` | Output from runtime load skill error. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L172) |
+| `RuntimeLoadSkillReferenceFileOutput` | Output from runtime load skill reference file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L165) |
 | `RuntimeLoadSkillToolContext` | Context for runtime load skill tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L108) |
-| `RuntimeLoadSkillToolInput` | Input payload for runtime load skill tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L155) |
+| `RuntimeLoadSkillToolInput` | Input payload for runtime load skill tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L160) |
 | `RuntimeLoadSkillToolMessages` | Public API contract for runtime load skill tool messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L125) |
 | `RuntimeLoadSkillToolOptions` | Options accepted by runtime load skill tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L128) |
-| `RuntimeLoadSkillToolOutput` | Output from runtime load skill tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L172) |
+| `RuntimeLoadSkillToolOutput` | Output from runtime load skill tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/load-skill-tool.ts#L177) |
 | `RuntimeProjectFile` | Public API contract for runtime project file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/project-files-client.ts#L48) |
 | `RuntimeProjectFileListItem` | Public API contract for runtime project file list item. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/project-files-client.ts#L50) |
 | `RuntimeProjectFilesApiOptions` | Options accepted by runtime project files API. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/project-files-client.ts#L55) |

--- a/docs/api-reference/veryfront/chat.md
+++ b/docs/api-reference/veryfront/chat.md
@@ -537,25 +537,25 @@ import { compactForStep, compactHistoricalUiMessageToolInputs, compactOldToolInp
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `compactForStep` | Compact for step. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1796) |
-| `compactHistoricalUiMessageToolInputs` | Compact large historical UI-message tool inputs after matching results are available. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1518) |
-| `compactOldToolInputs` | Compact large historical tool-call inputs after matching results are available. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1431) |
+| `compactForStep` | Compact for step. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1794) |
+| `compactHistoricalUiMessageToolInputs` | Compact large historical UI-message tool inputs after matching results are available. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1516) |
+| `compactOldToolInputs` | Compact large historical tool-call inputs after matching results are available. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1429) |
 | `compressTurn` | Compress turn. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L228) |
-| `dedupeToolHistory` | Dedupe tool history. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1820) |
-| `enforceTokenBudget` | Enforce token budget. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1887) |
+| `dedupeToolHistory` | Dedupe tool history. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1818) |
+| `enforceTokenBudget` | Enforce token budget. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1885) |
 | `enforceTokenBudgetWithTurnCompression` | Enforce token budget with turn compression. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L303) |
-| `ensureToolCallInputs` | Ensure tool call inputs helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1765) |
+| `ensureToolCallInputs` | Ensure tool call inputs helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1763) |
 | `estimateMessageTokenBreakdown` | Estimate token categories for provider, UI, or runtime messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L181) |
-| `estimateOverhead` | Estimate overhead. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1759) |
+| `estimateOverhead` | Estimate overhead. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1757) |
 | `estimateTokens` | Estimate tokens. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L99) |
 | `isModelSupportedFileMediaType` | Check whether the model supports the file media type. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L659) |
-| `maskOldToolOutputs` | Mask old tool outputs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1333) |
+| `maskOldToolOutputs` | Mask old tool outputs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1331) |
 | `normalizeMessageFilePartMediaTypes` | Normalizes message file part media types. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L665) |
-| `prepareProviderModelMessagesFromUiMessages` | Prepare provider model messages from UI messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1032) |
-| `repairToolPairs` | Repair tool pairs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1616) |
+| `prepareProviderModelMessagesFromUiMessages` | Prepare provider model messages from UI messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1030) |
+| `repairToolPairs` | Repair tool pairs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L1614) |
 | `rewriteUnsupportedFilePartsAsAnnotations` | Rewrite unsupported file parts as annotations. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L692) |
-| `sanitizeProviderModelMessages` | Sanitize provider model messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L923) |
-| `stripPendingToolParts` | Strip pending tool parts. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L796) |
+| `sanitizeProviderModelMessages` | Sanitize provider model messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L921) |
+| `stripPendingToolParts` | Strip pending tool parts. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/message-prep.ts#L794) |
 
 #### Types
 

--- a/docs/api-reference/veryfront/cli.md
+++ b/docs/api-reference/veryfront/cli.md
@@ -72,7 +72,7 @@ The CLI groups commands by category. Each command supports `--help` for its full
 | `veryfront eval` | List, run, and export discovered eval definitions |
 | `veryfront issues` | File-based issue tracking (SDLC conventions) |
 | `veryfront mcp` | Start MCP server for coding agents |
-| `veryfront schedule` | Run a source-defined schedule locally |
+| `veryfront schedule` | Run a source-defined schedule locally or in the Veryfront cloud |
 | `veryfront schedules` | List source-defined schedules |
 | `veryfront skills` | List and inspect available agent skills |
 | `veryfront task` | Run a task from the tasks/ directory |

--- a/docs/api-reference/veryfront/knowledge.md
+++ b/docs/api-reference/veryfront/knowledge.md
@@ -32,11 +32,11 @@ const result = await knowledge.retrieve("SSO login failure");
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `createSearchKnowledgeTool` | Create a local tool with the same id and response shape as hosted `search_knowledge`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L879) |
-| `formatKnowledgeContext` | Format search results into a deterministic prompt context block. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L859) |
-| `normalizeKnowledgeQuery` | Normalize a knowledge query before retrieval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L851) |
-| `projectKnowledge` | Create a project knowledge helper backed by the configured RAG store. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L895) |
-| `searchProjectKnowledge` | Search the local OKF knowledge manifest with the same input/output shape as Veryfront Cloud's `search_knowledge` MCP tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L869) |
+| `createSearchKnowledgeTool` | Create a local tool with the same id and response shape as hosted `search_knowledge`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L892) |
+| `formatKnowledgeContext` | Format search results into a deterministic prompt context block. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L872) |
+| `normalizeKnowledgeQuery` | Normalize a knowledge query before retrieval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L864) |
+| `projectKnowledge` | Create a project knowledge helper backed by the configured RAG store. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L908) |
+| `searchProjectKnowledge` | Search the local OKF knowledge manifest with the same input/output shape as Veryfront Cloud's `search_knowledge` MCP tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L882) |
 
 ### Types
 

--- a/docs/api-reference/veryfront/runs.md
+++ b/docs/api-reference/veryfront/runs.md
@@ -42,53 +42,53 @@ const events = await runs.events(accepted.run.run_id);
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `CancelRunResponseSchema` | Zod schema for a cancel-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L151) |
-| `CreateRunResponseSchema` | Zod schema for a create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L145) |
-| `RunEventListSchema` | Zod schema for a paginated run-event response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L155) |
-| `RunEventSchema` | Zod schema for a run event. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L153) |
-| `RunListSchema` | Zod schema for a paginated project-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L157) |
-| `RunSchema` | Zod schema for a canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L143) |
-| `ScheduleRunCreateResponseSchema` | Zod schema for a schedule-triggered create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L147) |
+| `CancelRunResponseSchema` | Zod schema for a cancel-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L156) |
+| `CreateRunResponseSchema` | Zod schema for a create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L150) |
+| `RunEventListSchema` | Zod schema for a paginated run-event response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L160) |
+| `RunEventSchema` | Zod schema for a run event. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L158) |
+| `RunListSchema` | Zod schema for a paginated project-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L162) |
+| `RunSchema` | Zod schema for a canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L148) |
+| `ScheduleRunCreateResponseSchema` | Zod schema for a schedule-triggered create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L152) |
 
 ### Functions
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L467) |
+| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L475) |
 
 ### Classes
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `VeryfrontRunsClient` | Public client for canonical durable runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L156) |
+| `VeryfrontRunsClient` | Public client for canonical durable runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L161) |
 
 ### Types
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `CancelRunResponse` | Response returned when a run is cancelled. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L180) |
-| `CreateEvalRunInput` | Input payload for creating an eval run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L75) |
-| `CreateRunResponse` | Response returned when a run is accepted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L174) |
-| `CreateScheduleRunFromSourceInput` | Input for resolving and triggering one pushed source-defined schedule. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L90) |
-| `CreateScheduleRunFromSourceResult` | Cloud schedule metadata returned with an accepted source-triggered run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L97) |
-| `CreateScheduleRunInput` | Input for triggering one persisted schedule by its canonical UUID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L83) |
-| `CreateTaskRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L58) |
-| `CreateWorkflowRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L67) |
-| `KnowledgeIngestByUploadIdsInput` | Input payload for knowledge ingest by upload IDs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L103) |
-| `KnowledgeIngestByUploadPathsInput` | Input payload for knowledge ingest by upload paths. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L109) |
-| `KnowledgeIngestByUploadPrefixInput` | Input payload for knowledge ingest by upload prefix. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L115) |
-| `ListRunEventsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L125) |
-| `ListRunsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L120) |
-| `ProjectScopedOptions` | Options accepted by project-scoped run requests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L38) |
-| `Run` | Canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L172) |
-| `RunEvent` | Event emitted by a run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L182) |
-| `RunExecutionError` | Error payload recorded for failed task and workflow runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L170) |
-| `RunKind` | Canonical durable run kind. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L160) |
-| `RunList` | Paginated project run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L186) |
-| `RunOwner` | Canonical durable run owner. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L164) |
-| `RunRuntimeTargetKind` | Runtime target for a task, workflow, or eval run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L43) |
-| `RunRuntimeTargetOptions` | Runtime target fields accepted by run creation APIs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L46) |
-| `RunStatus` | Canonical durable run status. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L162) |
-| `RunTriggerKind` | Trigger kind recorded on scheduled or externally-started runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L168) |
-| `ScheduleRunCreateResponse` | Response returned when a schedule-triggered run is accepted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L176) |
-| `VeryfrontRunsClientConfig` | Configuration used by the Veryfront runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L30) |
+| `CancelRunResponse` | Response returned when a run is cancelled. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L185) |
+| `CreateEvalRunInput` | Input payload for creating an eval run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L76) |
+| `CreateRunResponse` | Response returned when a run is accepted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L179) |
+| `CreateScheduleRunFromSourceInput` | Input for resolving and triggering one pushed source-defined schedule. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L91) |
+| `CreateScheduleRunFromSourceResult` | Cloud schedule metadata returned with an accepted source-triggered run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L98) |
+| `CreateScheduleRunInput` | Input for triggering one persisted schedule by its canonical UUID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L84) |
+| `CreateTaskRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L59) |
+| `CreateWorkflowRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L68) |
+| `KnowledgeIngestByUploadIdsInput` | Input payload for knowledge ingest by upload IDs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L108) |
+| `KnowledgeIngestByUploadPathsInput` | Input payload for knowledge ingest by upload paths. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L114) |
+| `KnowledgeIngestByUploadPrefixInput` | Input payload for knowledge ingest by upload prefix. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L120) |
+| `ListRunEventsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L130) |
+| `ListRunsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L125) |
+| `ProjectScopedOptions` | Options accepted by project-scoped run requests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L39) |
+| `Run` | Canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L177) |
+| `RunEvent` | Event emitted by a run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L187) |
+| `RunExecutionError` | Error payload recorded for failed task and workflow runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L175) |
+| `RunKind` | Canonical durable run kind. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L165) |
+| `RunList` | Paginated project run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L191) |
+| `RunOwner` | Canonical durable run owner. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L169) |
+| `RunRuntimeTargetKind` | Runtime target for a task, workflow, or eval run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L44) |
+| `RunRuntimeTargetOptions` | Runtime target fields accepted by run creation APIs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L47) |
+| `RunStatus` | Canonical durable run status. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L167) |
+| `RunTriggerKind` | Trigger kind recorded on scheduled or externally-started runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L173) |
+| `ScheduleRunCreateResponse` | Response returned when a schedule-triggered run is accepted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L181) |
+| `VeryfrontRunsClientConfig` | Configuration used by the Veryfront runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L31) |

--- a/docs/api-reference/veryfront/runs.md
+++ b/docs/api-reference/veryfront/runs.md
@@ -8,9 +8,9 @@ order: 26
 
 ```ts
 import {
-  createRunsClient,
   CancelRunResponseSchema,
   CreateRunResponseSchema,
+  createRunsClient,
   RunEventListSchema,
   RunEventSchema,
   RunListSchema,
@@ -40,50 +40,54 @@ const events = await runs.events(accepted.run.run_id);
 
 ### Components
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `CancelRunResponseSchema` | Zod schema for a cancel-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L125) |
-| `CreateRunResponseSchema` | Zod schema for a create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L123) |
-| `RunEventListSchema` | Zod schema for a paginated run-event response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L129) |
-| `RunEventSchema` | Zod schema for a run event. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L127) |
-| `RunListSchema` | Zod schema for a paginated project-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L131) |
-| `RunSchema` | Zod schema for a canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L121) |
+| Name                              | Description                                              | Source                                                                                   |
+| --------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `CancelRunResponseSchema`         | Zod schema for a cancel-run response.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L150) |
+| `CreateRunResponseSchema`         | Zod schema for a create-run response.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L144) |
+| `RunEventListSchema`              | Zod schema for a paginated run-event response.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L154) |
+| `RunEventSchema`                  | Zod schema for a run event.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L152) |
+| `RunListSchema`                   | Zod schema for a paginated project-run response.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L156) |
+| `RunSchema`                       | Zod schema for a canonical durable run.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L142) |
+| `ScheduleRunCreateResponseSchema` | Zod schema for a schedule-triggered create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L146) |
 
 ### Functions
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L389) |
+| Name               | Description           | Source                                                                                       |
+| ------------------ | --------------------- | -------------------------------------------------------------------------------------------- |
+| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L455) |
 
 ### Classes
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `VeryfrontRunsClient` | Public client for canonical durable runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L133) |
+| Name                  | Description                               | Source                                                                                       |
+| --------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `VeryfrontRunsClient` | Public client for canonical durable runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L148) |
 
 ### Types
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `CancelRunResponse` | Response returned when a run is cancelled. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L150) |
-| `CreateEvalRunInput` | Input payload for creating an eval run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L72) |
-| `CreateRunResponse` | Response returned when a run is accepted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L148) |
-| `CreateTaskRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L55) |
-| `CreateWorkflowRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L64) |
-| `KnowledgeIngestByUploadIdsInput` | Input payload for knowledge ingest by upload IDs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L80) |
-| `KnowledgeIngestByUploadPathsInput` | Input payload for knowledge ingest by upload paths. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L86) |
-| `KnowledgeIngestByUploadPrefixInput` | Input payload for knowledge ingest by upload prefix. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L92) |
-| `ListRunEventsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L102) |
-| `ListRunsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L97) |
-| `ProjectScopedOptions` | Options accepted by project-scoped run requests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L35) |
-| `Run` | Canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L146) |
-| `RunEvent` | Event emitted by a run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L152) |
-| `RunExecutionError` | Error payload recorded for failed task and workflow runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L144) |
-| `RunKind` | Canonical durable run kind. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L134) |
-| `RunList` | Paginated project run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L156) |
-| `RunOwner` | Canonical durable run owner. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L138) |
-| `RunRuntimeTargetKind` | Runtime target for a task, workflow, or eval run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L40) |
-| `RunRuntimeTargetOptions` | Runtime target fields accepted by run creation APIs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L43) |
-| `RunStatus` | Canonical durable run status. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L136) |
-| `RunTriggerKind` | Trigger kind recorded on scheduled or externally-started runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L142) |
-| `VeryfrontRunsClientConfig` | Configuration used by the Veryfront runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L27) |
+| Name                                 | Description                                                            | Source                                                                                       |
+| ------------------------------------ | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `CancelRunResponse`                  | Response returned when a run is cancelled.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L179)     |
+| `CreateEvalRunInput`                 | Input payload for creating an eval run.                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L75)  |
+| `CreateRunResponse`                  | Response returned when a run is accepted.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L173)     |
+| `CreateScheduleRunFromSourceInput`   | Input for resolving and triggering one pushed source-defined schedule. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L88)  |
+| `CreateScheduleRunInput`             | Input for triggering one persisted schedule by its canonical UUID.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L82)  |
+| `CreateTaskRunInput`                 |                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L58)  |
+| `CreateWorkflowRunInput`             |                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L67)  |
+| `KnowledgeIngestByUploadIdsInput`    | Input payload for knowledge ingest by upload IDs.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L95)  |
+| `KnowledgeIngestByUploadPathsInput`  | Input payload for knowledge ingest by upload paths.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L101) |
+| `KnowledgeIngestByUploadPrefixInput` | Input payload for knowledge ingest by upload prefix.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L107) |
+| `ListRunEventsOptions`               |                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L117) |
+| `ListRunsOptions`                    |                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L112) |
+| `ProjectScopedOptions`               | Options accepted by project-scoped run requests.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L38)  |
+| `Run`                                | Canonical durable run.                                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L171)     |
+| `RunEvent`                           | Event emitted by a run.                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L181)     |
+| `RunExecutionError`                  | Error payload recorded for failed task and workflow runs.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L169)     |
+| `RunKind`                            | Canonical durable run kind.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L159)     |
+| `RunList`                            | Paginated project run response.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L185)     |
+| `RunOwner`                           | Canonical durable run owner.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L163)     |
+| `RunRuntimeTargetKind`               | Runtime target for a task, workflow, or eval run.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L43)  |
+| `RunRuntimeTargetOptions`            | Runtime target fields accepted by run creation APIs.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L46)  |
+| `RunStatus`                          | Canonical durable run status.                                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L161)     |
+| `RunTriggerKind`                     | Trigger kind recorded on scheduled or externally-started runs.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L167)     |
+| `ScheduleRunCreateResponse`          | Response returned when a schedule-triggered run is accepted.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L175)     |
+| `VeryfrontRunsClientConfig`          | Configuration used by the Veryfront runs client.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L30)  |

--- a/docs/api-reference/veryfront/runs.md
+++ b/docs/api-reference/veryfront/runs.md
@@ -1,6 +1,6 @@
 ---
 title: "veryfront/runs"
-description: "Canonical durable runs for task, workflow, and eval execution."
+description: "Canonical durable runs for task, workflow, eval, and schedule-triggered execution."
 order: 26
 ---
 
@@ -8,9 +8,9 @@ order: 26
 
 ```ts
 import {
+  createRunsClient,
   CancelRunResponseSchema,
   CreateRunResponseSchema,
-  createRunsClient,
   RunEventListSchema,
   RunEventSchema,
   RunListSchema,
@@ -40,54 +40,55 @@ const events = await runs.events(accepted.run.run_id);
 
 ### Components
 
-| Name                              | Description                                              | Source                                                                                   |
-| --------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `CancelRunResponseSchema`         | Zod schema for a cancel-run response.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L150) |
-| `CreateRunResponseSchema`         | Zod schema for a create-run response.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L144) |
-| `RunEventListSchema`              | Zod schema for a paginated run-event response.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L154) |
-| `RunEventSchema`                  | Zod schema for a run event.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L152) |
-| `RunListSchema`                   | Zod schema for a paginated project-run response.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L156) |
-| `RunSchema`                       | Zod schema for a canonical durable run.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L142) |
-| `ScheduleRunCreateResponseSchema` | Zod schema for a schedule-triggered create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L146) |
+| Name | Description | Source |
+|------|-------------|--------|
+| `CancelRunResponseSchema` | Zod schema for a cancel-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L151) |
+| `CreateRunResponseSchema` | Zod schema for a create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L145) |
+| `RunEventListSchema` | Zod schema for a paginated run-event response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L155) |
+| `RunEventSchema` | Zod schema for a run event. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L153) |
+| `RunListSchema` | Zod schema for a paginated project-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L157) |
+| `RunSchema` | Zod schema for a canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L143) |
+| `ScheduleRunCreateResponseSchema` | Zod schema for a schedule-triggered create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L147) |
 
 ### Functions
 
-| Name               | Description           | Source                                                                                       |
-| ------------------ | --------------------- | -------------------------------------------------------------------------------------------- |
-| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L455) |
+| Name | Description | Source |
+|------|-------------|--------|
+| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L467) |
 
 ### Classes
 
-| Name                  | Description                               | Source                                                                                       |
-| --------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `VeryfrontRunsClient` | Public client for canonical durable runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L148) |
+| Name | Description | Source |
+|------|-------------|--------|
+| `VeryfrontRunsClient` | Public client for canonical durable runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L156) |
 
 ### Types
 
-| Name                                 | Description                                                            | Source                                                                                       |
-| ------------------------------------ | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `CancelRunResponse`                  | Response returned when a run is cancelled.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L179)     |
-| `CreateEvalRunInput`                 | Input payload for creating an eval run.                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L75)  |
-| `CreateRunResponse`                  | Response returned when a run is accepted.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L173)     |
-| `CreateScheduleRunFromSourceInput`   | Input for resolving and triggering one pushed source-defined schedule. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L88)  |
-| `CreateScheduleRunInput`             | Input for triggering one persisted schedule by its canonical UUID.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L82)  |
-| `CreateTaskRunInput`                 |                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L58)  |
-| `CreateWorkflowRunInput`             |                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L67)  |
-| `KnowledgeIngestByUploadIdsInput`    | Input payload for knowledge ingest by upload IDs.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L95)  |
-| `KnowledgeIngestByUploadPathsInput`  | Input payload for knowledge ingest by upload paths.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L101) |
-| `KnowledgeIngestByUploadPrefixInput` | Input payload for knowledge ingest by upload prefix.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L107) |
-| `ListRunEventsOptions`               |                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L117) |
-| `ListRunsOptions`                    |                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L112) |
-| `ProjectScopedOptions`               | Options accepted by project-scoped run requests.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L38)  |
-| `Run`                                | Canonical durable run.                                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L171)     |
-| `RunEvent`                           | Event emitted by a run.                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L181)     |
-| `RunExecutionError`                  | Error payload recorded for failed task and workflow runs.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L169)     |
-| `RunKind`                            | Canonical durable run kind.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L159)     |
-| `RunList`                            | Paginated project run response.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L185)     |
-| `RunOwner`                           | Canonical durable run owner.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L163)     |
-| `RunRuntimeTargetKind`               | Runtime target for a task, workflow, or eval run.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L43)  |
-| `RunRuntimeTargetOptions`            | Runtime target fields accepted by run creation APIs.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L46)  |
-| `RunStatus`                          | Canonical durable run status.                                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L161)     |
-| `RunTriggerKind`                     | Trigger kind recorded on scheduled or externally-started runs.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L167)     |
-| `ScheduleRunCreateResponse`          | Response returned when a schedule-triggered run is accepted.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L175)     |
-| `VeryfrontRunsClientConfig`          | Configuration used by the Veryfront runs client.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L30)  |
+| Name | Description | Source |
+|------|-------------|--------|
+| `CancelRunResponse` | Response returned when a run is cancelled. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L180) |
+| `CreateEvalRunInput` | Input payload for creating an eval run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L75) |
+| `CreateRunResponse` | Response returned when a run is accepted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L174) |
+| `CreateScheduleRunFromSourceInput` | Input for resolving and triggering one pushed source-defined schedule. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L90) |
+| `CreateScheduleRunFromSourceResult` | Cloud schedule metadata returned with an accepted source-triggered run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L97) |
+| `CreateScheduleRunInput` | Input for triggering one persisted schedule by its canonical UUID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L83) |
+| `CreateTaskRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L58) |
+| `CreateWorkflowRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L67) |
+| `KnowledgeIngestByUploadIdsInput` | Input payload for knowledge ingest by upload IDs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L103) |
+| `KnowledgeIngestByUploadPathsInput` | Input payload for knowledge ingest by upload paths. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L109) |
+| `KnowledgeIngestByUploadPrefixInput` | Input payload for knowledge ingest by upload prefix. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L115) |
+| `ListRunEventsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L125) |
+| `ListRunsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L120) |
+| `ProjectScopedOptions` | Options accepted by project-scoped run requests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L38) |
+| `Run` | Canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L172) |
+| `RunEvent` | Event emitted by a run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L182) |
+| `RunExecutionError` | Error payload recorded for failed task and workflow runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L170) |
+| `RunKind` | Canonical durable run kind. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L160) |
+| `RunList` | Paginated project run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L186) |
+| `RunOwner` | Canonical durable run owner. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L164) |
+| `RunRuntimeTargetKind` | Runtime target for a task, workflow, or eval run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L43) |
+| `RunRuntimeTargetOptions` | Runtime target fields accepted by run creation APIs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L46) |
+| `RunStatus` | Canonical durable run status. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L162) |
+| `RunTriggerKind` | Trigger kind recorded on scheduled or externally-started runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L168) |
+| `ScheduleRunCreateResponse` | Response returned when a schedule-triggered run is accepted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L176) |
+| `VeryfrontRunsClientConfig` | Configuration used by the Veryfront runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L30) |

--- a/docs/api-reference/veryfront/sandbox.md
+++ b/docs/api-reference/veryfront/sandbox.md
@@ -62,13 +62,13 @@ Create a lazily-provisioned sandbox session with automatic heartbeats.
 
 ### `sandbox.executeCommand(command, options)`
 
-Execute a command and return buffered stdout/stderr + exit code.
+Execute a bash command in the sandbox and return buffered stdout/stderr plus the exit code.
 
 **Returns:** <code>Promise&lt;ExecResult&gt;</code>
 
 ### `sandbox.executeStream(command, options)`
 
-Execute a command and stream output events as they arrive.
+Execute a bash command and stream newline-delimited JSON (NDJSON) output events as they arrive.
 
 **Returns:** <code>AsyncGenerator&lt;ExecStreamEvent&gt;</code>
 

--- a/docs/api-reference/veryfront/sandbox.md
+++ b/docs/api-reference/veryfront/sandbox.md
@@ -62,13 +62,13 @@ Create a lazily-provisioned sandbox session with automatic heartbeats.
 
 ### `sandbox.executeCommand(command, options)`
 
-Execute a bash command in the sandbox and return buffered result.
+Execute a command and return buffered stdout/stderr + exit code.
 
 **Returns:** <code>Promise&lt;ExecResult&gt;</code>
 
 ### `sandbox.executeStream(command, options)`
 
-Execute a bash command with streaming output (NDJSON).
+Execute a command and stream output events as they arrive.
 
 **Returns:** <code>AsyncGenerator&lt;ExecStreamEvent&gt;</code>
 
@@ -80,7 +80,7 @@ Read a file from the sandbox workspace.
 
 ### `sandbox.writeFiles(files)`
 
-Write files to the sandbox workspace.
+Write one or more files to the sandbox workspace.
 
 **Returns:** <code>Promise&lt;void&gt;</code>
 
@@ -116,13 +116,13 @@ Cancel an async background command.
 
 ### `sandbox.heartbeat()`
 
-Send a heartbeat to prevent idle timeout.
+Send a heartbeat to keep the sandbox session alive.
 
 **Returns:** <code>Promise&lt;void&gt;</code>
 
 ### `sandbox.close()`
 
-Close the sandbox session and mark for deletion.
+Close the sandbox session and mark it for deletion.
 
 **Returns:** <code>Promise&lt;void&gt;</code>
 

--- a/docs/api-reference/veryfront/sandbox.md
+++ b/docs/api-reference/veryfront/sandbox.md
@@ -68,7 +68,7 @@ Execute a bash command in the sandbox and return buffered stdout/stderr plus the
 
 ### `sandbox.executeStream(command, options)`
 
-Execute a bash command and stream newline-delimited JSON (NDJSON) output events as they arrive.
+Execute a bash command in the sandbox and stream newline-delimited JSON (NDJSON) output events as they arrive.
 
 **Returns:** <code>AsyncGenerator&lt;ExecStreamEvent&gt;</code>
 

--- a/docs/concepts/schedule.md
+++ b/docs/concepts/schedule.md
@@ -52,3 +52,16 @@ export default schedule({
 The platform reports the schedule as stale when it has not succeeded within
 that budget, and as failed after a newer terminal failure. Health settings are
 not sent to the target as run input.
+
+## Run a pushed schedule on demand
+
+Use remote mode when the schedule needs the same hosted tools, integrations,
+delegation, and durable run context as its cloud recurrence:
+
+```sh
+veryfront schedule run daily-support-triage --remote --json
+```
+
+Push the source schedule first. Remote runs use the pushed definition and do
+not accept `--input`; omit `--remote` when you intentionally want the existing
+local execution path.

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -1772,11 +1772,13 @@ const METHOD_DESCRIPTIONS: Record<
       },
     },
     executeCommand: {
-      desc: "Execute a command and return buffered stdout/stderr + exit code.",
+      desc:
+        "Execute a bash command in the sandbox and return buffered stdout/stderr plus the exit code.",
       params: { command: "Bash command string to execute in the sandbox." },
     },
     executeStream: {
-      desc: "Execute a command and stream output events as they arrive.",
+      desc:
+        "Execute a bash command and stream newline-delimited JSON (NDJSON) output events as they arrive.",
       params: { command: "Bash command string to execute in the sandbox." },
     },
     readFile: {

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -1778,7 +1778,7 @@ const METHOD_DESCRIPTIONS: Record<
     },
     executeStream: {
       desc:
-        "Execute a bash command and stream newline-delimited JSON (NDJSON) output events as they arrive.",
+        "Execute a bash command in the sandbox and stream newline-delimited JSON (NDJSON) output events as they arrive.",
       params: { command: "Bash command string to execute in the sandbox." },
     },
     readFile: {

--- a/src/README.md
+++ b/src/README.md
@@ -604,7 +604,7 @@ See [`transforms/import-rewriter/README.md`](./transforms/import-rewriter/README
 
 **Exports**: `veryfront/runs`
 
-- `VeryfrontRunsClient` for task, workflow, and eval run management
+- `VeryfrontRunsClient` for task, workflow, eval, and source-defined schedule run management
 - Canonical run creation and event reading
 - Runtime environment helpers
 

--- a/src/runs/index.ts
+++ b/src/runs/index.ts
@@ -1,5 +1,5 @@
 /**
- * Canonical durable runs for task, workflow, and eval execution.
+ * Canonical durable runs for task, workflow, eval, and schedule-triggered execution.
  *
  * @module
  *
@@ -25,6 +25,8 @@
 export {
   type CreateEvalRunInput,
   createRunsClient,
+  type CreateScheduleRunFromSourceInput,
+  type CreateScheduleRunInput,
   type CreateTaskRunInput,
   type CreateWorkflowRunInput,
   type KnowledgeIngestByUploadIdsInput,
@@ -55,4 +57,6 @@ export {
   RunSchema,
   type RunStatus,
   type RunTriggerKind,
+  type ScheduleRunCreateResponse,
+  ScheduleRunCreateResponseSchema,
 } from "./schemas.ts";

--- a/src/runs/index.ts
+++ b/src/runs/index.ts
@@ -26,6 +26,7 @@ export {
   type CreateEvalRunInput,
   createRunsClient,
   type CreateScheduleRunFromSourceInput,
+  type CreateScheduleRunFromSourceResult,
   type CreateScheduleRunInput,
   type CreateTaskRunInput,
   type CreateWorkflowRunInput,

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -325,6 +325,10 @@ describe("VeryfrontRunsClient", () => {
         schedule_id: scheduleId,
       },
       timeoutSeconds: 1800,
+      target: {
+        kind: "agent",
+        id: "job-submission-orchestrator",
+      },
     });
     assertEquals(
       call(0).url,
@@ -369,6 +373,41 @@ describe("VeryfrontRunsClient", () => {
       call(0).url,
       "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=missing-schedule&limit=1",
     );
+  });
+
+  it("does not trust a non-active schedule returned by the active filter", async () => {
+    mockFetch([
+      jsonResponse({
+        schedules: [{
+          id: scheduleId,
+          name: "Process job submissions",
+          status: "paused",
+          target: {
+            kind: "agent",
+            id: "job-submission-orchestrator",
+          },
+          definition_source: "source",
+          source_trigger_id: "process-job-submissions",
+          timeout_seconds: 1800,
+        }],
+      }),
+    ]);
+    const client = new VeryfrontRunsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    await assertRejects(
+      () =>
+        client.createScheduleRunFromSource({
+          sourceTriggerId: "process-job-submissions",
+        }),
+      Error,
+      'Active source schedule "process-job-submissions" not found in project "dreamy-haven".',
+    );
+
+    assertEquals(fetchCalls.length, 1);
   });
 
   it("creates knowledge ingest task runs", async () => {

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -346,6 +346,34 @@ describe("VeryfrontRunsClient", () => {
     });
   });
 
+  it("generates an idempotency key for direct schedule run creation", async () => {
+    mockFetch([
+      jsonResponse({
+        run_id: "run_11111111-1111-4111-8111-111111111111",
+        run_execution_id: "run_11111111-1111-4111-8111-111111111111",
+        schedule_id: scheduleId,
+      }, 201),
+    ]);
+    const client = new VeryfrontRunsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    await client.createScheduleRun({
+      scheduleId,
+      runName: "Manual schedule retry guard",
+    });
+
+    const body = jsonBody(0) as { run_name: string; idempotency_key: string };
+    assertEquals(call(0).init?.method, "POST");
+    assertEquals(body, {
+      run_name: "Manual schedule retry guard",
+      idempotency_key: body.idempotency_key,
+    });
+    assertStringIncludes(body.idempotency_key, "schedule-run:");
+  });
+
   it("does not create a run when the pushed source schedule is missing", async () => {
     mockFetch([
       jsonResponse({

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -319,9 +319,12 @@ describe("VeryfrontRunsClient", () => {
     });
 
     assertEquals(response, {
-      run_id: "run_11111111-1111-4111-8111-111111111111",
-      run_execution_id: "run_11111111-1111-4111-8111-111111111111",
-      schedule_id: scheduleId,
+      scheduleRun: {
+        run_id: "run_11111111-1111-4111-8111-111111111111",
+        run_execution_id: "run_11111111-1111-4111-8111-111111111111",
+        schedule_id: scheduleId,
+      },
+      timeoutSeconds: 1800,
     });
     assertEquals(
       call(0).url,

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -14,6 +14,7 @@ let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
 let fetchResponses: Array<Response | (() => Response)> = [];
 
 const projectId = "22222222-2222-4222-8222-222222222222";
+const scheduleId = "33333333-3333-4333-8333-333333333333";
 
 function mockFetch(responses: Array<Response | (() => Response)>): void {
   fetchCalls = [];
@@ -249,6 +250,122 @@ describe("VeryfrontRunsClient", () => {
         start_mode: "manual",
       },
     });
+  });
+
+  it("creates schedule runs by resolving the source trigger id", async () => {
+    mockFetch([
+      jsonResponse({
+        schedules: [{
+          id: scheduleId,
+          project_id: projectId,
+          name: "Process job submissions",
+          status: "active",
+          target: {
+            kind: "agent",
+            id: "job-submission-orchestrator",
+            conversation_mode: "create_new",
+          },
+          schedule: "0 * * * *",
+          timezone: "Europe/Berlin",
+          runtime_target_kind: "main_branch",
+          runtime_target_environment_id: null,
+          runtime_target_branch_id: null,
+          config: {
+            prompt: "Process job submissions.",
+          },
+          timeout_seconds: 1800,
+          backoff_limit: 1,
+          concurrency_policy: "Forbid",
+          definition_source: "source",
+          source_trigger_id: "process-job-submissions",
+          source_path: "schedules/process-job-submissions.ts",
+          source_hash: "source-hash",
+          last_scheduled_at: null,
+          last_successful_at: null,
+          health: null,
+          max_runs: null,
+          run_count: 0,
+          completed_at: null,
+          paused_reason: null,
+          paused_at: null,
+          last_failure_at: null,
+          last_failure_code: null,
+          last_failure_message: null,
+          last_failure_run_id: null,
+          created_by: null,
+          integration_requirements: [],
+          created_at: "2026-07-26T12:00:00.000Z",
+          updated_at: "2026-07-26T12:00:00.000Z",
+        }],
+        source_schedules: [],
+      }),
+      jsonResponse({
+        run_id: "run_11111111-1111-4111-8111-111111111111",
+        run_execution_id: "run_11111111-1111-4111-8111-111111111111",
+        schedule_id: scheduleId,
+      }, 201),
+    ]);
+
+    const client = new VeryfrontRunsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    const response = await client.createScheduleRunFromSource({
+      sourceTriggerId: "process-job-submissions",
+      runName: "Local CLI verification",
+      idempotencyKey: "schedule-cli-test",
+    });
+
+    assertEquals(response, {
+      run_id: "run_11111111-1111-4111-8111-111111111111",
+      run_execution_id: "run_11111111-1111-4111-8111-111111111111",
+      schedule_id: scheduleId,
+    });
+    assertEquals(
+      call(0).url,
+      "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=process-job-submissions&limit=1",
+    );
+    assertEquals(
+      call(1).url,
+      `https://api.test.com/projects/dreamy-haven/schedules/${scheduleId}/runs`,
+    );
+    assertEquals(call(1).init?.method, "POST");
+    assertEquals(headerValue(1, "Authorization"), "Bearer test-token");
+    assertEquals(jsonBody(1), {
+      run_name: "Local CLI verification",
+      idempotency_key: "schedule-cli-test",
+    });
+  });
+
+  it("does not create a run when the pushed source schedule is missing", async () => {
+    mockFetch([
+      jsonResponse({
+        schedules: [],
+        source_schedules: [],
+      }),
+    ]);
+    const client = new VeryfrontRunsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    await assertRejects(
+      () =>
+        client.createScheduleRunFromSource({
+          sourceTriggerId: "missing-schedule",
+        }),
+      Error,
+      'Active source schedule "missing-schedule" not found in project "dreamy-haven".',
+    );
+
+    assertEquals(fetchCalls.length, 1);
+    assertEquals(
+      call(0).url,
+      "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=missing-schedule&limit=1",
+    );
   });
 
   it("creates knowledge ingest task runs", async () => {

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -346,8 +346,9 @@ describe("VeryfrontRunsClient", () => {
     });
   });
 
-  it("generates an idempotency key for direct schedule run creation", async () => {
+  it("reuses a generated idempotency key when direct schedule creation retries", async () => {
     mockFetch([
+      jsonResponse({ error: "temporary upstream failure" }, 500),
       jsonResponse({
         run_id: "run_11111111-1111-4111-8111-111111111111",
         run_execution_id: "run_11111111-1111-4111-8111-111111111111",
@@ -358,6 +359,11 @@ describe("VeryfrontRunsClient", () => {
       apiUrl: "https://api.test.com",
       authToken: "test-token",
       projectReference: "dreamy-haven",
+      retry: {
+        maxRetries: 1,
+        initialDelay: 1,
+        maxDelay: 1,
+      },
     });
 
     await client.createScheduleRun({
@@ -365,13 +371,17 @@ describe("VeryfrontRunsClient", () => {
       runName: "Manual schedule retry guard",
     });
 
-    const body = jsonBody(0) as { run_name: string; idempotency_key: string };
+    const firstBody = jsonBody(0) as { run_name: string; idempotency_key: string };
+    const retryBody = jsonBody(1) as { run_name: string; idempotency_key: string };
+    assertEquals(fetchCalls.length, 2);
     assertEquals(call(0).init?.method, "POST");
-    assertEquals(body, {
+    assertEquals(call(1).init?.method, "POST");
+    assertEquals(firstBody, {
       run_name: "Manual schedule retry guard",
-      idempotency_key: body.idempotency_key,
+      idempotency_key: firstBody.idempotency_key,
     });
-    assertStringIncludes(body.idempotency_key, "schedule-run:");
+    assertStringIncludes(firstBody.idempotency_key, "schedule-run:");
+    assertEquals(retryBody, firstBody);
   });
 
   it("does not create a run when the pushed source schedule is missing", async () => {

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -332,7 +332,7 @@ describe("VeryfrontRunsClient", () => {
     });
     assertEquals(
       call(0).url,
-      "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=process-job-submissions&limit=1",
+      "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=process-job-submissions",
     );
     assertEquals(
       call(1).url,
@@ -371,7 +371,61 @@ describe("VeryfrontRunsClient", () => {
     assertEquals(fetchCalls.length, 1);
     assertEquals(
       call(0).url,
-      "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=missing-schedule&limit=1",
+      "https://api.test.com/projects/dreamy-haven/schedules?status=active&source_trigger_id=missing-schedule",
+    );
+  });
+
+  it("creates the matching source schedule when it is not the first listed schedule", async () => {
+    const matchingScheduleId = "44444444-4444-4444-8444-444444444444";
+    mockFetch([
+      jsonResponse({
+        schedules: [
+          {
+            id: "99999999-9999-4999-8999-999999999999",
+            name: "Another active schedule",
+            status: "active",
+            target: {
+              kind: "agent",
+              id: "other-agent",
+            },
+            definition_source: "source",
+            source_trigger_id: "other-source-schedule",
+            timeout_seconds: 300,
+          },
+          {
+            id: matchingScheduleId,
+            name: "Process job submissions",
+            status: "active",
+            target: {
+              kind: "agent",
+              id: "job-submission-orchestrator",
+            },
+            definition_source: "source",
+            source_trigger_id: "process-job-submissions",
+            timeout_seconds: 1800,
+          },
+        ],
+      }),
+      jsonResponse({
+        run_id: "run_11111111-1111-4111-8111-111111111111",
+        run_execution_id: "run_11111111-1111-4111-8111-111111111111",
+        schedule_id: matchingScheduleId,
+      }, 201),
+    ]);
+    const client = new VeryfrontRunsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    const response = await client.createScheduleRunFromSource({
+      sourceTriggerId: "process-job-submissions",
+    });
+
+    assertEquals(response.scheduleRun.schedule_id, matchingScheduleId);
+    assertEquals(
+      call(1).url,
+      `https://api.test.com/projects/dreamy-haven/schedules/${matchingScheduleId}/runs`,
     );
   });
 

--- a/src/runs/runs-client.ts
+++ b/src/runs/runs-client.ts
@@ -97,6 +97,10 @@ export interface CreateScheduleRunFromSourceInput extends ProjectScopedOptions {
 export interface CreateScheduleRunFromSourceResult {
   scheduleRun: ScheduleRunCreateResponse;
   timeoutSeconds: number;
+  target: {
+    kind: "task" | "workflow" | "agent";
+    id: string;
+  };
 }
 
 /** Input payload for knowledge ingest by upload IDs. */
@@ -320,6 +324,7 @@ export class VeryfrontRunsClient {
       ScheduleReferenceListSchema,
     );
     const schedule = listed.schedules.find((candidate) =>
+      candidate.status === "active" &&
       candidate.definition_source === "source" &&
       candidate.source_trigger_id === input.sourceTriggerId
     );
@@ -334,12 +339,13 @@ export class VeryfrontRunsClient {
     const scheduleRun = await this.createScheduleRun({
       scheduleId: schedule.id,
       projectReference,
-      runName: input.runName,
+      runName: input.runName ?? schedule.name,
       idempotencyKey: input.idempotencyKey,
     });
     return {
       scheduleRun,
       timeoutSeconds: schedule.timeout_seconds,
+      target: schedule.target,
     };
   }
 

--- a/src/runs/runs-client.ts
+++ b/src/runs/runs-client.ts
@@ -93,6 +93,12 @@ export interface CreateScheduleRunFromSourceInput extends ProjectScopedOptions {
   idempotencyKey?: string;
 }
 
+/** Cloud schedule metadata returned with an accepted source-triggered run. */
+export interface CreateScheduleRunFromSourceResult {
+  scheduleRun: ScheduleRunCreateResponse;
+  timeoutSeconds: number;
+}
+
 /** Input payload for knowledge ingest by upload IDs. */
 export interface KnowledgeIngestByUploadIdsInput
   extends Omit<CreateTaskRunInput, "target" | "config"> {
@@ -300,7 +306,7 @@ export class VeryfrontRunsClient {
 
   async createScheduleRunFromSource(
     input: CreateScheduleRunFromSourceInput,
-  ): Promise<ScheduleRunCreateResponse> {
+  ): Promise<CreateScheduleRunFromSourceResult> {
     const projectReference = this.resolveProjectReference(input.projectReference);
     const listed = await this.requestJson(
       withQuery(
@@ -325,12 +331,16 @@ export class VeryfrontRunsClient {
       });
     }
 
-    return await this.createScheduleRun({
+    const scheduleRun = await this.createScheduleRun({
       scheduleId: schedule.id,
       projectReference,
       runName: input.runName,
       idempotencyKey: input.idempotencyKey,
     });
+    return {
+      scheduleRun,
+      timeoutSeconds: schedule.timeout_seconds,
+    };
   }
 
   async list(options: ListRunsOptions = {}): Promise<RunList> {

--- a/src/runs/runs-client.ts
+++ b/src/runs/runs-client.ts
@@ -16,6 +16,9 @@ import {
   type RunList,
   RunListSchema,
   RunSchema,
+  ScheduleReferenceListSchema,
+  type ScheduleRunCreateResponse,
+  ScheduleRunCreateResponseSchema,
 } from "./schemas.ts";
 
 const DEFAULT_MAX_RETRIES = 3;
@@ -74,6 +77,20 @@ export interface CreateEvalRunInput extends RunCreateBaseInput, RunRuntimeTarget
   input?: Record<string, unknown>;
   config?: Record<string, unknown>;
   startMode?: string;
+}
+
+/** Input for triggering one persisted schedule by its canonical UUID. */
+export interface CreateScheduleRunInput extends ProjectScopedOptions {
+  scheduleId: string;
+  runName?: string;
+  idempotencyKey?: string;
+}
+
+/** Input for resolving and triggering one pushed source-defined schedule. */
+export interface CreateScheduleRunFromSourceInput extends ProjectScopedOptions {
+  sourceTriggerId: string;
+  runName?: string;
+  idempotencyKey?: string;
 }
 
 /** Input payload for knowledge ingest by upload IDs. */
@@ -262,6 +279,57 @@ export class VeryfrontRunsClient {
           start_mode: startMode,
         },
       },
+    });
+  }
+
+  createScheduleRun(input: CreateScheduleRunInput): Promise<ScheduleRunCreateResponse> {
+    const { scheduleId, projectReference, runName, idempotencyKey } = input;
+    const project = this.resolveProjectReference(projectReference);
+    return this.requestJson(
+      `/projects/${encodeURIComponent(project)}/schedules/${encodeURIComponent(scheduleId)}/runs`,
+      ScheduleRunCreateResponseSchema,
+      {
+        method: "POST",
+        body: {
+          run_name: runName,
+          idempotency_key: idempotencyKey,
+        },
+      },
+    );
+  }
+
+  async createScheduleRunFromSource(
+    input: CreateScheduleRunFromSourceInput,
+  ): Promise<ScheduleRunCreateResponse> {
+    const projectReference = this.resolveProjectReference(input.projectReference);
+    const listed = await this.requestJson(
+      withQuery(
+        `/projects/${encodeURIComponent(projectReference)}/schedules`,
+        toQueryParams({
+          status: "active",
+          source_trigger_id: input.sourceTriggerId,
+          limit: 1,
+        }),
+      ),
+      ScheduleReferenceListSchema,
+    );
+    const schedule = listed.schedules.find((candidate) =>
+      candidate.definition_source === "source" &&
+      candidate.source_trigger_id === input.sourceTriggerId
+    );
+    if (!schedule) {
+      throw API_CLIENT_ERROR.create({
+        detail:
+          `Active source schedule "${input.sourceTriggerId}" not found in project "${projectReference}". Push the source schedule before running it remotely.`,
+        status: 404,
+      });
+    }
+
+    return await this.createScheduleRun({
+      scheduleId: schedule.id,
+      projectReference,
+      runName: input.runName,
+      idempotencyKey: input.idempotencyKey,
     });
   }
 

--- a/src/runs/runs-client.ts
+++ b/src/runs/runs-client.ts
@@ -318,7 +318,6 @@ export class VeryfrontRunsClient {
         toQueryParams({
           status: "active",
           source_trigger_id: input.sourceTriggerId,
-          limit: 1,
         }),
       ),
       ScheduleReferenceListSchema,

--- a/src/runs/runs-client.ts
+++ b/src/runs/runs-client.ts
@@ -25,6 +25,7 @@ const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000;
 const DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
 const DEFAULT_KNOWLEDGE_INGEST_RUN_NAME = "Ingest knowledge";
+const GENERATED_SCHEDULE_RUN_IDEMPOTENCY_PREFIX = "schedule-run";
 
 /** Configuration used by the Veryfront runs client. */
 export interface VeryfrontRunsClientConfig {
@@ -295,6 +296,8 @@ export class VeryfrontRunsClient {
   createScheduleRun(input: CreateScheduleRunInput): Promise<ScheduleRunCreateResponse> {
     const { scheduleId, projectReference, runName, idempotencyKey } = input;
     const project = this.resolveProjectReference(projectReference);
+    const resolvedIdempotencyKey = idempotencyKey ??
+      `${GENERATED_SCHEDULE_RUN_IDEMPOTENCY_PREFIX}:${crypto.randomUUID()}`;
     return this.requestJson(
       `/projects/${encodeURIComponent(project)}/schedules/${encodeURIComponent(scheduleId)}/runs`,
       ScheduleRunCreateResponseSchema,
@@ -302,7 +305,7 @@ export class VeryfrontRunsClient {
         method: "POST",
         body: {
           run_name: runName,
-          idempotency_key: idempotencyKey,
+          idempotency_key: resolvedIdempotencyKey,
         },
       },
     );

--- a/src/runs/schemas.ts
+++ b/src/runs/schemas.ts
@@ -91,7 +91,12 @@ export const getScheduleReferenceListSchema = defineSchema((v) =>
     schedules: v.array(
       v.object({
         id: v.string(),
+        name: v.string(),
         status: v.enum(["active", "paused", "deleting"] as const),
+        target: v.object({
+          kind: v.enum(["task", "workflow", "agent"] as const),
+          id: v.string(),
+        }),
         definition_source: v.enum(["manual", "source"] as const),
         source_trigger_id: v.string().nullable(),
         timeout_seconds: v.number().int(),

--- a/src/runs/schemas.ts
+++ b/src/runs/schemas.ts
@@ -94,6 +94,7 @@ export const getScheduleReferenceListSchema = defineSchema((v) =>
         status: v.enum(["active", "paused", "deleting"] as const),
         definition_source: v.enum(["manual", "source"] as const),
         source_trigger_id: v.string().nullable(),
+        timeout_seconds: v.number().int(),
       }),
     ),
   })

--- a/src/runs/schemas.ts
+++ b/src/runs/schemas.ts
@@ -78,6 +78,27 @@ export const getCreateRunResponseSchema = defineSchema((v) =>
   })
 );
 
+export const getScheduleRunCreateResponseSchema = defineSchema((v) =>
+  v.object({
+    run_id: v.string(),
+    run_execution_id: v.string(),
+    schedule_id: v.string(),
+  })
+);
+
+export const getScheduleReferenceListSchema = defineSchema((v) =>
+  v.object({
+    schedules: v.array(
+      v.object({
+        id: v.string(),
+        status: v.enum(["active", "paused", "deleting"] as const),
+        definition_source: v.enum(["manual", "source"] as const),
+        source_trigger_id: v.string().nullable(),
+      }),
+    ),
+  })
+);
+
 export const getCancelRunResponseSchema = defineSchema((v) =>
   v.object({
     cancelled: v.boolean(),
@@ -121,6 +142,10 @@ export const getRunListSchema = defineSchema((v) =>
 export const RunSchema = lazySchema(getRunSchema);
 /** Zod schema for a create-run response. */
 export const CreateRunResponseSchema = lazySchema(getCreateRunResponseSchema);
+/** Zod schema for a schedule-triggered create-run response. */
+export const ScheduleRunCreateResponseSchema = lazySchema(getScheduleRunCreateResponseSchema);
+/** Zod schema for the schedule references needed to trigger source schedules. */
+export const ScheduleReferenceListSchema = lazySchema(getScheduleReferenceListSchema);
 /** Zod schema for a cancel-run response. */
 export const CancelRunResponseSchema = lazySchema(getCancelRunResponseSchema);
 /** Zod schema for a run event. */
@@ -146,6 +171,10 @@ export type RunExecutionError = InferSchema<ReturnType<typeof getRunExecutionErr
 export type Run = InferSchema<ReturnType<typeof getRunSchema>>;
 /** Response returned when a run is accepted. */
 export type CreateRunResponse = InferSchema<ReturnType<typeof getCreateRunResponseSchema>>;
+/** Response returned when a schedule-triggered run is accepted. */
+export type ScheduleRunCreateResponse = InferSchema<
+  ReturnType<typeof getScheduleRunCreateResponseSchema>
+>;
 /** Response returned when a run is cancelled. */
 export type CancelRunResponse = InferSchema<ReturnType<typeof getCancelRunResponseSchema>>;
 /** Event emitted by a run. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1154";
+export const VERSION = "0.1.1155";


### PR DESCRIPTION
## Summary
- add `veryfront schedule run <id> --remote` to invoke the pushed source-defined schedule through canonical cloud schedule runs
- add runs-client helpers for schedule run creation and source-trigger resolution
- document remote schedule execution and regenerate the runs API reference
- bump `deno.json` and `src/utils/version-constant.ts` to `0.1.1155` for release automation

## Verification
- `deno task verify:quick`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/runs/runs-client.test.ts cli/commands/schedule/handler.test.ts`
- `DENO_TESTING=1 VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net cli/commands/push/command.test.ts`

## Full test note
`deno task test` currently fails on two npm metadata baseline checks that reproduce on a clean `origin/main` worktree: `EXTENSION_OWNED_DEPENDENCIES` missing `gaxios`, and missing generated `npm/esm/cli/commands/mcp/handler.js`. The earlier push snapshot failure did not reproduce under the repo test setup.

## Dependency
- Requires veryfront-api PR #4114 for `source_trigger_id` schedule filtering in staging/cloud.