### PR TITLE
Fix hosted API dependency discovery for virtual projects

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1155",
+  "version": "0.1.1156",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/routing/api/module-loader/external-import-rewriter.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.ts
@@ -26,7 +26,7 @@ export const NODE_BUILTINS = ROUTE_NODE_BUILTINS;
 
 export async function readProjectDependencies(
   projectDir: string,
-  fs: FileSystem,
+  fs: Pick<FileSystem, "readTextFile">,
 ): Promise<Map<string, string>> {
   return await readProjectDependenciesForRoute(projectDir, fs);
 }

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -186,6 +186,52 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(typeof route?.GET, "function");
   });
 
+  it("resolves npm dependencies declared by adapter-backed virtual projects", async () => {
+    const realDir = await makeTempDir();
+    await fs.mkdir(join(realDir, "lib"), { recursive: true });
+    await fs.mkdir(join(realDir, "pages", "api"), { recursive: true });
+
+    await fs.writeTextFile(
+      join(realDir, "package.json"),
+      JSON.stringify({ dependencies: { zod: "4.3.6" } }),
+    );
+    await fs.writeTextFile(
+      join(realDir, "lib", "schema.ts"),
+      [
+        `import { z } from "zod";`,
+        `export const result = z.object({ ok: z.boolean() }).parse({ ok: true }).ok;`,
+      ].join("\n"),
+    );
+    await fs.writeTextFile(
+      join(realDir, "pages", "api", "activity.ts"),
+      [
+        `import { result } from "@/lib/schema.ts";`,
+        `export function GET() { return new Response(result ? "parsed" : "bad"); }`,
+      ].join("\n"),
+    );
+
+    const tempRoot = await makeTempDir();
+    const virtualBase = join(tempRoot, `vf-nonexistent-${Date.now()}`);
+    const toReal = (path: string): string => path.replace(virtualBase, realDir);
+    const virtualAdapter: RuntimeAdapter = {
+      ...adapter,
+      fs: {
+        ...adapter.fs,
+        readFile: (path: string) => fs.readTextFile(toReal(path)),
+        exists: (path: string) => fs.exists(toReal(path)),
+      },
+    };
+
+    const route = await loadHandlerModule({
+      projectDir: virtualBase,
+      modulePath: join(virtualBase, "pages", "api", "activity.ts"),
+      adapter: virtualAdapter,
+      config: undefined,
+    });
+
+    assertEquals(typeof route?.GET, "function");
+  });
+
   // Deno resolves the direct import itself and knows nothing about `@/`, so the
   // route only loads if the failed direct import falls back to bundling, where
   // the import map plugin resolves the alias.

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -430,11 +430,10 @@ function loadAndTranspileModule(
       const allowedHosts = await loadSecurityConfig(projectDir, adapter);
       validateHTTPImports(source, allowedHosts);
 
-      const projectSourceFs = {
-        ...fs,
+      const projectSourceReader = {
         readTextFile: (filePath: string) => adapter.fs.readFile(filePath),
       };
-      const allDeps = await readProjectDependencies(projectDir, projectSourceFs);
+      const allDeps = await readProjectDependencies(projectDir, projectSourceReader);
 
       // Filter out framework-managed packages from user deps. These are already
       // handled by the framework's own external/rewrite logic and should not be

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -430,7 +430,11 @@ function loadAndTranspileModule(
       const allowedHosts = await loadSecurityConfig(projectDir, adapter);
       validateHTTPImports(source, allowedHosts);
 
-      const allDeps = await readProjectDependencies(projectDir, fs);
+      const projectSourceFs = {
+        ...fs,
+        readTextFile: (filePath: string) => adapter.fs.readFile(filePath),
+      };
+      const allDeps = await readProjectDependencies(projectDir, projectSourceFs);
 
       // Filter out framework-managed packages from user deps. These are already
       // handled by the framework's own external/rewrite logic and should not be

--- a/src/transforms/import-rewriter/route-adapter.ts
+++ b/src/transforms/import-rewriter/route-adapter.ts
@@ -50,7 +50,7 @@ export const NODE_BUILTINS = [
 
 export async function readProjectDependenciesForRoute(
   projectDir: string,
-  fs: FileSystem,
+  fs: Pick<FileSystem, "readTextFile">,
 ): Promise<Map<string, string>> {
   try {
     const content = await fs.readTextFile(pathHelper.join(projectDir, "package.json"));

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1155";
+export const VERSION = "0.1.1156";


### PR DESCRIPTION
## Summary

- read API route project dependencies through the runtime adapter so hosted/preview virtual projects can discover their package.json dependencies
- keep temp handler filesystem behavior on the host filesystem
- add a regression test for a virtual adapter-backed API route importing zod through a project alias
- bump deno.json and the shared version constant to 0.1.1156 for the next release

## Root cause

Hosted API routes loaded source files through RuntimeAdapter.fs, but dependency discovery still read package.json through the host filesystem. For virtual project directories, package.json was invisible there, so userDeps was empty. The loader externalized zod without adding it to the import map, and Deno failed while loading the generated handler.mjs with `Import "zod" not a dependency and not in import map`.

## Testing

- deno test -A src/routing/api/module-loader/loader.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- deno test -A src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno task test:unit (2687 passed, 0 failed)
- pre-push hook (fmt, lint, typecheck, unit tests: 2687 passed, 0 failed)