### PR TITLE
fix delegated remote tool namespace handling

### DIFF
--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -2,7 +2,13 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { defineSchema } from "#veryfront/schemas/index.ts";
-import { createRemoteMCPToolSource, tool, toolRegistry } from "#veryfront/tool";
+import {
+  createRemoteMCPToolSource,
+  createToolsFromRemoteDefinitions,
+  type RemoteToolSource,
+  tool,
+  toolRegistry,
+} from "#veryfront/tool";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   executeConfiguredTool,
@@ -253,6 +259,128 @@ describe("tool-helpers", () => {
       );
     });
 
+    it("does not execute a materialized remote tool excluded by the runtime allowlist", async () => {
+      const executedToolNames: string[] = [];
+      const source: RemoteToolSource = {
+        id: "veryfront-api",
+        listTools: async () => [],
+        executeTool: async (toolName) => {
+          executedToolNames.push(toolName);
+          return { ok: true };
+        },
+      };
+      const configuredTools = createToolsFromRemoteDefinitions(source, [
+        {
+          name: "gmail__list_emails",
+          description: "List emails",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          name: "gmail__delete_email",
+          description: "Delete an email",
+          parameters: { type: "object", properties: {} },
+        },
+      ]);
+
+      await assertRejects(
+        () =>
+          executeConfiguredTool(
+            "gmail__delete_email",
+            {},
+            configuredTools,
+            { toolCallId: "tool-remote-denied" },
+            ["gmail__list_emails"],
+          ),
+        Error,
+        'Tool "gmail__delete_email" is not allowed for this run',
+      );
+      assertEquals(executedToolNames, []);
+    });
+
+    it("does not let an allowed alias execute a denied canonical remote tool", async () => {
+      const executedToolNames: string[] = [];
+      const source: RemoteToolSource = {
+        id: "veryfront-api",
+        listTools: async () => [],
+        executeTool: async (toolName) => {
+          executedToolNames.push(toolName);
+          return { ok: true };
+        },
+      };
+      const configuredTools = createToolsFromRemoteDefinitions(
+        source,
+        [{
+          name: "gmail__delete_email",
+          description: "Delete an email",
+          parameters: { type: "object", properties: {} },
+        }],
+        {
+          toolNameAliases: {
+            gmail__delete_email: "delete_email",
+          },
+        },
+      );
+
+      await assertRejects(
+        () =>
+          executeConfiguredTool(
+            "delete_email",
+            {},
+            configuredTools,
+            { toolCallId: "tool-remote-alias-denied" },
+            ["delete_email"],
+          ),
+        Error,
+        'Tool "gmail__delete_email" is not allowed for this run',
+      );
+      assertEquals(executedToolNames, []);
+    });
+
+    it("applies source integration policy to an aliased remote tool's canonical name", async () => {
+      const executedToolNames: string[] = [];
+      const source: RemoteToolSource = {
+        id: "veryfront-api",
+        listTools: async () => [],
+        executeTool: async (toolName) => {
+          executedToolNames.push(toolName);
+          return { ok: true };
+        },
+      };
+      const configuredTools = createToolsFromRemoteDefinitions(
+        source,
+        [{
+          name: "gmail__delete_email",
+          description: "Delete an email",
+          parameters: { type: "object", properties: {} },
+        }],
+        {
+          toolNameAliases: {
+            gmail__delete_email: "delete_email",
+          },
+        },
+      );
+
+      await assertRejects(
+        () =>
+          executeConfiguredTool(
+            "delete_email",
+            {},
+            configuredTools,
+            { toolCallId: "tool-remote-alias-policy-denied" },
+            ["gmail__delete_email"],
+            undefined,
+            {
+              schemaVersion: 1,
+              mode: "allowlist",
+              integrations: { gmail: { allowedToolIds: ["list_emails"] } },
+            },
+          ),
+        Error,
+        'Tool "gmail__delete_email" is not allowed by the source integration policy',
+      );
+      assertEquals(executedToolNames, []);
+    });
+
     it("enforces source integration policy before inline or fallback execution", async () => {
       let executed = false;
       const deniedTool = tool({
@@ -425,6 +553,120 @@ describe("tool-helpers", () => {
       } finally {
         toolRegistry.clearAll();
       }
+    });
+
+    it("does not advertise materialized remote tools excluded by the runtime allowlist", async () => {
+      const source: RemoteToolSource = {
+        id: "veryfront-api",
+        listTools: async () => [],
+        executeTool: async () => ({ ok: true }),
+      };
+      const configuredTools = createToolsFromRemoteDefinitions(source, [
+        {
+          name: "gmail__list_emails",
+          description: "List emails",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          name: "gmail__delete_email",
+          description: "Delete an email",
+          parameters: { type: "object", properties: {} },
+        },
+      ]);
+
+      const defs = await getAvailableTools(configuredTools, {
+        includeIntegrationTools: false,
+        allowedRemoteToolNames: ["gmail__list_emails"],
+      });
+
+      assertEquals(defs.map((def) => def.name), ["gmail__list_emails"]);
+    });
+
+    it("does not advertise an alias for a denied canonical remote tool", async () => {
+      const source: RemoteToolSource = {
+        id: "veryfront-api",
+        listTools: async () => [],
+        executeTool: async () => ({ ok: true }),
+      };
+      const configuredTools = createToolsFromRemoteDefinitions(
+        source,
+        [{
+          name: "gmail__delete_email",
+          description: "Delete an email",
+          parameters: { type: "object", properties: {} },
+        }],
+        {
+          toolNameAliases: {
+            gmail__delete_email: "delete_email",
+          },
+        },
+      );
+
+      const allowlistFiltered = await getAvailableTools(configuredTools, {
+        includeIntegrationTools: false,
+        allowedRemoteToolNames: ["delete_email"],
+      });
+      const policyFiltered = await getAvailableTools(configuredTools, {
+        includeIntegrationTools: false,
+        allowedRemoteToolNames: ["gmail__delete_email"],
+        sourceIntegrationPolicy: {
+          schemaVersion: 1,
+          mode: "allowlist",
+          integrations: { gmail: { allowedToolIds: ["list_emails"] } },
+        },
+      });
+
+      assertEquals(allowlistFiltered, []);
+      assertEquals(policyFiltered, []);
+    });
+
+    it("advertises and executes an allowed canonical remote tool through an integration-style alias", async () => {
+      const executedToolNames: string[] = [];
+      const source: RemoteToolSource = {
+        id: "veryfront-api",
+        listTools: async () => [],
+        executeTool: async (toolName) => {
+          executedToolNames.push(toolName);
+          return { ok: true };
+        },
+      };
+      const configuredTools = createToolsFromRemoteDefinitions(
+        source,
+        [{
+          name: "gmail__list_emails",
+          description: "List emails",
+          parameters: { type: "object", properties: {} },
+        }],
+        {
+          toolNameAliases: {
+            gmail__list_emails: "mail__list",
+          },
+        },
+      );
+      const sourceIntegrationPolicy = {
+        schemaVersion: 1 as const,
+        mode: "allowlist" as const,
+        integrations: { gmail: { allowedToolIds: ["list_emails"] } },
+      };
+
+      const definitions = await getAvailableTools(configuredTools, {
+        includeIntegrationTools: false,
+        allowedRemoteToolNames: ["gmail__list_emails"],
+        sourceIntegrationPolicy,
+      });
+      const result = await executeConfiguredTool(
+        "mail__list",
+        {},
+        configuredTools,
+        { toolCallId: "tool-remote-integration-alias-allowed" },
+        ["gmail__list_emails"],
+        undefined,
+        sourceIntegrationPolicy,
+      );
+
+      assertEquals(definitions.map((definition) => definition.name), ["mail__list"]);
+      assertEquals(result, { ok: true });
+      assertEquals(executedToolNames, ["gmail__list_emails"]);
     });
 
     it("enforces source integration policy for tools true and unknown connector versions", async () => {

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -9,6 +9,7 @@
 import type { RemoteToolSource, Tool, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
 import { executeTool, isToolVisibleTo, toolRegistry } from "#veryfront/tool";
 import { assertLocalToolId, toolToProviderDefinition } from "#veryfront/tool/registry.ts";
+import { getRemoteToolProvenance } from "#veryfront/tool/remote-tool-provenance.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { serverLogger } from "#veryfront/utils";
 import { createError, PERMISSION_DENIED, toError } from "#veryfront/errors";
@@ -98,6 +99,26 @@ export function isDynamicTool(name: string): boolean {
  */
 // deno-lint-ignore no-explicit-any -- generic erasure: accepts Tool with any input/output types
 export type ToolConfigEntry = Tool<any, any> | boolean;
+
+function getConfiguredRemoteToolName(
+  entry: ToolConfigEntry | undefined,
+): string | undefined {
+  return typeof entry === "object" ? getRemoteToolProvenance(entry) : undefined;
+}
+
+function getConfiguredToolAuthorizationName(
+  toolName: string,
+  entry: ToolConfigEntry | undefined,
+): string {
+  return getConfiguredRemoteToolName(entry) ?? toolName;
+}
+
+function isRemoteToolAllowed(
+  toolName: string,
+  allowedRemoteToolNames: readonly string[] | undefined,
+): boolean {
+  return allowedRemoteToolNames === undefined || allowedRemoteToolNames.includes(toolName);
+}
 
 /**
  * Resolve a configured tool name for a caller: the caller's own tool by short
@@ -263,7 +284,10 @@ export function resolveConfiguredTool(
   }
 
   if (configuredEntry && typeof configuredEntry === "object") {
-    if (options?.allowIntegrationStyleConcreteTools !== true) {
+    if (
+      options?.allowIntegrationStyleConcreteTools !== true &&
+      getConfiguredRemoteToolName(configuredEntry) === undefined
+    ) {
       assertLocalToolId(toolName);
       assertLocalToolId(configuredEntry.id);
     }
@@ -285,11 +309,26 @@ export async function executeConfiguredTool(
     strictConfiguredToolsOnly?: boolean;
   },
 ): Promise<unknown> {
+  const configuredEntry = toolsConfig === true ? undefined : toolsConfig?.[toolName];
+  const configuredRemoteToolName = getConfiguredRemoteToolName(configuredEntry);
+  const authorizationToolName = getConfiguredToolAuthorizationName(toolName, configuredEntry);
+
   if (
     sourceIntegrationPolicy &&
-    !isIntegrationToolAllowedBySourcePolicy(toolName, sourceIntegrationPolicy)
+    !isIntegrationToolAllowedBySourcePolicy(authorizationToolName, sourceIntegrationPolicy)
   ) {
-    throw new Error(`Tool "${toolName}" is not allowed by the source integration policy`);
+    throw new Error(
+      `Tool "${authorizationToolName}" is not allowed by the source integration policy`,
+    );
+  }
+
+  if (
+    configuredRemoteToolName !== undefined &&
+    !isRemoteToolAllowed(configuredRemoteToolName, allowedRemoteToolNames)
+  ) {
+    throw PERMISSION_DENIED.create({
+      detail: `Tool "${configuredRemoteToolName}" is not allowed for this run`,
+    });
   }
 
   const configuredTool = resolveConfiguredTool(toolsConfig, toolName, context, {
@@ -449,11 +488,14 @@ export async function getAvailableTools(
   const remoteToolNames = new Set(remoteDefs.map((def) => def.name));
   const explicitlyRequestedRemoteToolNames = new Set<string>();
   const unresolvedConfiguredToolNames: string[] = [];
+  const configuredAuthorizationToolNames = new Map<string, string>();
 
   for (const [name, entry] of Object.entries(toolsConfig)) {
+    const configuredRemoteToolName = getConfiguredRemoteToolName(entry);
+    const authorizationToolName = getConfiguredToolAuthorizationName(name, entry);
     if (
       sourceIntegrationPolicy &&
-      !isIntegrationToolAllowedBySourcePolicy(name, sourceIntegrationPolicy)
+      !isIntegrationToolAllowedBySourcePolicy(authorizationToolName, sourceIntegrationPolicy)
     ) {
       continue;
     }
@@ -484,10 +526,17 @@ export async function getAvailableTools(
     }
 
     if (entry && typeof entry === "object") {
-      if (!strictConfiguredToolsOnly) {
+      if (
+        configuredRemoteToolName !== undefined &&
+        !isRemoteToolAllowed(configuredRemoteToolName, options?.allowedRemoteToolNames)
+      ) {
+        continue;
+      }
+      if (!strictConfiguredToolsOnly && configuredRemoteToolName === undefined) {
         assertLocalToolId(name);
         assertLocalToolId(entry.id);
       }
+      configuredAuthorizationToolNames.set(name, authorizationToolName);
       addToolDefinition(tools, name, entry);
     }
   }
@@ -522,7 +571,10 @@ export async function getAvailableTools(
 
   return sourceIntegrationPolicy
     ? tools.filter((definition) =>
-      isIntegrationToolAllowedBySourcePolicy(definition.name, sourceIntegrationPolicy)
+      isIntegrationToolAllowedBySourcePolicy(
+        configuredAuthorizationToolNames.get(definition.name) ?? definition.name,
+        sourceIntegrationPolicy,
+      )
     )
     : tools;
 }

--- a/src/agent/streaming/fork-runtime-part-mapper.test.ts
+++ b/src/agent/streaming/fork-runtime-part-mapper.test.ts
@@ -183,4 +183,26 @@ describe("agent/fork-runtime-part-mapper", () => {
       },
     ]);
   });
+
+  it("preserves the concrete upstream error when errorText is absent", () => {
+    const state = createForkRuntimeStreamMappingState();
+
+    const parts = mapAgUiRuntimeEventToForkParts(
+      {
+        type: "error",
+        error: 'Tool "gmail__upload_attachment" is not registered',
+      },
+      state,
+    );
+
+    assertEquals(parts.length, 1);
+    assertEquals(parts[0]?.type, "error");
+    if (parts[0]?.type !== "error") {
+      throw new Error("Expected an error part");
+    }
+    assertEquals(
+      parts[0].error.message,
+      'Tool "gmail__upload_attachment" is not registered',
+    );
+  });
 });

--- a/src/agent/streaming/fork-runtime-part-mapper.ts
+++ b/src/agent/streaming/fork-runtime-part-mapper.ts
@@ -382,6 +382,8 @@ export function mapAgUiRuntimeEventToForkParts(
     case "error": {
       const errorText = typeof event.errorText === "string"
         ? event.errorText
+        : typeof event.error === "string"
+        ? event.error
         : "Framework stream failed";
       return [{ type: "error", error: new Error(errorText) }];
     }

--- a/src/agent/streaming/fork-runtime-stream.test.ts
+++ b/src/agent/streaming/fork-runtime-stream.test.ts
@@ -2,6 +2,8 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { defineSchema } from "#veryfront/schemas/index.ts";
+import { type ModelRuntime, registerModelProvider } from "#veryfront/provider";
+import { createToolsFromRemoteDefinitions, type RemoteToolSource } from "#veryfront/tool";
 import type { AgentResponse, Message as AgentMessage } from "../schemas/index.ts";
 import {
   applyPartToStreamedStepState,
@@ -478,6 +480,141 @@ describe("agent/fork-runtime-stream", () => {
     assertEquals(traceCalls, ["tool.create_file"]);
     assertEquals(attributes, [{ toolName: "create_file", toolCallId: "tool-call-1" }]);
     assertEquals(parts, [{ type: "text-delta", text: "Done." }]);
+  });
+
+  it("preserves and executes an authorized remote alias across repeated child runtimes", async () => {
+    const providerId = "child-remote-tool-regression";
+    let streamCalls = 0;
+    let providerToolNames: string[] = [];
+    const remoteExecutions: Array<{
+      toolName: string;
+      args: Record<string, unknown>;
+      toolCallId: string | undefined;
+    }> = [];
+    const model: ModelRuntime = {
+      provider: providerId,
+      modelId: `${providerId}/demo`,
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "Done." }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream(options: unknown) {
+        streamCalls++;
+        const childOrdinal = Math.ceil(streamCalls / 2);
+        const tools = (options as { tools?: Array<{ name?: string }> }).tools ?? [];
+        providerToolNames = tools.flatMap((tool) =>
+          typeof tool.name === "string" ? [tool.name] : []
+        );
+        return {
+          stream: new ReadableStream<unknown>({
+            start(controller) {
+              if (streamCalls % 2 === 1) {
+                controller.enqueue({
+                  type: "tool-call",
+                  toolCallId: `upload-call-${childOrdinal}`,
+                  toolName: "upload_attachment",
+                  input: { attachmentId: `attachment-${childOrdinal}` },
+                });
+                controller.enqueue({ type: "finish", finishReason: "tool-calls" });
+              } else {
+                controller.enqueue({ type: "text-delta", text: "Done." });
+                controller.enqueue({ type: "finish", finishReason: "stop" });
+              }
+              controller.close();
+            },
+          }),
+        };
+      },
+    };
+    registerModelProvider(providerId, () => model);
+
+    const source: RemoteToolSource = {
+      id: "veryfront-api",
+      listTools: async () => [],
+      executeTool: async (toolName, args, context) => {
+        remoteExecutions.push({
+          toolName,
+          args,
+          toolCallId: context?.toolCallId,
+        });
+        return { uploaded: true };
+      },
+    };
+    const remoteTools = createToolsFromRemoteDefinitions(source, [{
+      name: "gmail__upload_attachment",
+      description: "Upload an attachment to Gmail.",
+      parameters: {
+        type: "object",
+        properties: {
+          attachmentId: { type: "string" },
+        },
+        required: ["attachmentId"],
+      },
+    }]);
+    const uploadAttachment = remoteTools.gmail__upload_attachment;
+    assertExists(uploadAttachment);
+    const forkTools = { upload_attachment: uploadAttachment };
+
+    const childParts: ForkPart[][] = [];
+    for (const childOrdinal of [1, 2]) {
+      const { streamResult, forkToolNames } = startAgentRuntimeForkWithHostTools({
+        apiUrl: "https://api.example.com",
+        authToken: "auth-token",
+        projectId: "project-1",
+        provider: providerId,
+        forkModel: `${providerId}/demo`,
+        maxSteps: 2,
+        prompt: `Inspect attachment ${childOrdinal}.`,
+        forkTools,
+        buildInstructions: () => "Base instructions.",
+        traceTools: {
+          trace: (_spanName, operation) => operation(),
+        },
+      });
+      assertEquals(forkToolNames, ["upload_attachment"]);
+
+      const parts: ForkPart[] = [];
+      for await (const part of streamResult.fullStream) {
+        parts.push(part);
+      }
+      childParts.push(parts);
+    }
+
+    assertEquals(providerToolNames, ["upload_attachment"]);
+    assertEquals(streamCalls, 4);
+    assertEquals(remoteExecutions, [
+      {
+        toolName: "gmail__upload_attachment",
+        args: { attachmentId: "attachment-1" },
+        toolCallId: "upload-call-1",
+      },
+      {
+        toolName: "gmail__upload_attachment",
+        args: { attachmentId: "attachment-2" },
+        toolCallId: "upload-call-2",
+      },
+    ]);
+    for (const parts of childParts) {
+      assertEquals(
+        parts.some((part) =>
+          part.type === "tool-call" &&
+          part.toolName === "upload_attachment"
+        ),
+        true,
+      );
+      assertEquals(
+        parts.some((part) =>
+          part.type === "tool-result" &&
+          part.toolName === "upload_attachment" &&
+          (part.output as { uploaded?: boolean }).uploaded === true
+        ),
+        true,
+      );
+      assertEquals(parts.at(-1), { type: "text-delta", text: "Done." });
+    }
   });
 
   it("keeps denied integration tools out of child runtime requests", async () => {

--- a/src/agent/streaming/fork-runtime-stream.ts
+++ b/src/agent/streaming/fork-runtime-stream.ts
@@ -6,6 +6,7 @@ import {
   traceHostTools,
   type TraceHostToolsOptions,
 } from "#veryfront/tool";
+import { getRemoteToolProvenance } from "#veryfront/tool/remote-tool-provenance.ts";
 import { runWithVeryfrontCloudContextAsync } from "#veryfront/provider/veryfront-cloud/context.ts";
 import { streamDataStreamEvents } from "./data-stream.ts";
 import {
@@ -278,6 +279,18 @@ export type RunFrameworkForkStepInput = Omit<RunAgentRuntimeForkStepInput, "runt
   frameworkTools: Record<string, Tool | boolean>;
 };
 
+function getForkRuntimeAuthorizationToolNames(
+  toolNames: readonly string[],
+  runtimeTools: Record<string, Tool | boolean>,
+): string[] {
+  return toolNames.map((toolName) => {
+    const runtimeTool = runtimeTools[toolName];
+    return runtimeTool && typeof runtimeTool === "object"
+      ? getRemoteToolProvenance(runtimeTool) ?? toolName
+      : toolName;
+  });
+}
+
 /** Run agent runtime fork step. */
 export async function runAgentRuntimeForkStep(input: RunAgentRuntimeForkStepInput): Promise<{
   stream: ReadableStream<Uint8Array>;
@@ -319,7 +332,10 @@ export async function runAgentRuntimeForkStep(input: RunAgentRuntimeForkStepInpu
         }),
       }
       : {}),
-    __vfAllowedRemoteTools: input.forkToolNames,
+    __vfAllowedRemoteTools: getForkRuntimeAuthorizationToolNames(
+      input.forkToolNames,
+      input.runtimeTools,
+    ),
     ...(input.sourceIntegrationPolicy
       ? { __vfSourceIntegrationPolicy: input.sourceIntegrationPolicy }
       : {}),

--- a/src/tool/host-tools.test.ts
+++ b/src/tool/host-tools.test.ts
@@ -4,7 +4,9 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { JsonSchema } from "#veryfront/extensions/schema/index.ts";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { createToolsFromHostDefinitions, type HostToolSet } from "./host-tools.ts";
-import type { ToolExecutionContext, ToolSet } from "./types.ts";
+import { createToolsFromRemoteDefinitions } from "./remote-source-tools.ts";
+import { getRemoteToolProvenance } from "./remote-tool-provenance.ts";
+import type { RemoteToolSource, ToolExecutionContext, ToolSet } from "./types.ts";
 
 const emptyJsonSchema = { type: "object" as const, properties: {} };
 
@@ -79,6 +81,37 @@ describe("tool/host-tools", () => {
       title: "Search documentation",
       annotations: { readOnlyHint: true },
     });
+  });
+
+  it("preserves canonical remote provenance through host materialization", async () => {
+    let executedToolName = "";
+    const source: RemoteToolSource = {
+      id: "veryfront-api",
+      listTools: async () => [],
+      executeTool: async (toolName) => {
+        executedToolName = toolName;
+        return { ok: true };
+      },
+    };
+    const remoteTools = createToolsFromRemoteDefinitions(
+      source,
+      [{
+        name: "gmail__delete_email",
+        description: "Delete an email",
+        parameters: emptyJsonSchema,
+      }],
+      {
+        toolNameAliases: {
+          gmail__delete_email: "delete_email",
+        },
+      },
+    );
+
+    const tools = createToolsFromHostDefinitions(remoteTools);
+
+    assertEquals(getRemoteToolProvenance(tools.delete_email), "gmail__delete_email");
+    assertEquals(await tools.delete_email?.execute({}), { ok: true });
+    assertEquals(executedToolName, "gmail__delete_email");
   });
 
   it("materializes precomputed schemas from external host tool providers", async () => {

--- a/src/tool/host-tools.ts
+++ b/src/tool/host-tools.ts
@@ -2,6 +2,7 @@ import { dynamicTool, tool } from "./factory.ts";
 import { agentLogger } from "#veryfront/utils";
 import type { JsonSchema, Schema } from "#veryfront/extensions/schema/index.ts";
 import type { Tool, ToolConfig, ToolExecutionContext, ToolSet } from "./types.ts";
+import { getRemoteToolProvenance, markRemoteToolProvenance } from "./remote-tool-provenance.ts";
 
 type HostToolExecute = {
   bivarianceHack: (input: unknown, options?: ToolExecutionContext) => Promise<unknown> | unknown;
@@ -119,8 +120,9 @@ export function createToolsFromHostDefinitions(
       await definition.execute(input, normalizeExecutionContext(toolName, context, options));
 
     try {
+      let materializedTool: Tool | undefined;
       if (definition.inputSchemaJson) {
-        tools[toolName] = dynamicTool({
+        materializedTool = dynamicTool({
           id: toolName,
           description: definition.description,
           inputSchema: definition.inputSchema,
@@ -129,13 +131,19 @@ export function createToolsFromHostDefinitions(
           mcp: definition.mcp,
         });
       } else if (isSchemaLike(definition.inputSchema)) {
-        tools[toolName] = tool({
+        materializedTool = tool({
           id: toolName,
           description: definition.description,
           inputSchema: definition.inputSchema,
           execute,
           mcp: definition.mcp,
         });
+      }
+      if (materializedTool) {
+        const canonicalRemoteToolName = getRemoteToolProvenance(definition);
+        tools[toolName] = canonicalRemoteToolName
+          ? markRemoteToolProvenance(materializedTool, canonicalRemoteToolName)
+          : materializedTool;
       }
     } catch (error) {
       agentLogger.warn("Skipping host tool: schema conversion failed", {

--- a/src/tool/remote-source-tools.test.ts
+++ b/src/tool/remote-source-tools.test.ts
@@ -6,6 +6,7 @@ import {
   createToolsFromRemoteDefinitions,
   loadRemoteToolsFromSource,
 } from "./remote-source-tools.ts";
+import { getRemoteToolProvenance } from "./remote-tool-provenance.ts";
 
 describe("tool/remote-source-tools", () => {
   it("materializes runtime tools from remote definitions while preserving remote schemas", async () => {
@@ -52,6 +53,7 @@ describe("tool/remote-source-tools", () => {
 
     assertEquals(Object.keys(tools), ["docs_search"]);
     assertEquals(tools.docs_search?.id, "docs_search");
+    assertEquals(getRemoteToolProvenance(tools.docs_search), "search_docs");
     assertEquals(tools.docs_search?.inputSchemaJson, {
       type: "object",
       properties: {

--- a/src/tool/remote-source-tools.ts
+++ b/src/tool/remote-source-tools.ts
@@ -1,5 +1,6 @@
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { dynamicTool } from "./factory.ts";
+import { markRemoteToolProvenance } from "./remote-tool-provenance.ts";
 import type { RemoteToolSource, Tool, ToolDefinition, ToolExecutionContext } from "./types.ts";
 
 /** Options accepted by remote tool materialization. */
@@ -33,9 +34,7 @@ export function createToolsFromRemoteDefinitions(
   return Object.fromEntries(
     definitions.map((definition) => {
       const toolName = options.toolNameAliases?.[definition.name] ?? definition.name;
-
-      return [
-        toolName,
+      const remoteTool = markRemoteToolProvenance(
         dynamicTool({
           id: toolName,
           description: definition.description,
@@ -48,6 +47,12 @@ export function createToolsFromRemoteDefinitions(
           execute: async (input, context) =>
             await source.executeTool(definition.name, toToolInputRecord(input), context),
         }),
+        definition.name,
+      );
+
+      return [
+        toolName,
+        remoteTool,
       ];
     }),
   );

--- a/src/tool/remote-tool-provenance.ts
+++ b/src/tool/remote-tool-provenance.ts
@@ -1,0 +1,29 @@
+const REMOTE_TOOL_PROVENANCE = Symbol("veryfront.remote-tool-provenance");
+
+type RemoteToolProvenance = {
+  [REMOTE_TOOL_PROVENANCE]?: string;
+};
+
+/** Mark a runtime tool as materialized from a trusted remote tool source. */
+export function markRemoteToolProvenance<T extends object>(
+  tool: T,
+  canonicalToolName: string,
+): T {
+  Object.defineProperty(tool, REMOTE_TOOL_PROVENANCE, {
+    value: canonicalToolName,
+    enumerable: true,
+  });
+  return tool;
+}
+
+/** Return the canonical remote tool name carried by trusted provenance. */
+export function getRemoteToolProvenance(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+
+  const canonicalToolName = (value as RemoteToolProvenance)[REMOTE_TOOL_PROVENANCE];
+  return typeof canonicalToolName === "string" && canonicalToolName.length > 0
+    ? canonicalToolName
+    : undefined;
+}


### PR DESCRIPTION
## Description

Preserve the canonical identity of remote MCP tools when they are materialized, traced, aliased, and rematerialized for delegated child runtimes.

A remote tool such as `gmail__upload_attachment` was converted into a concrete runtime tool before a child fork started. The runtime then treated that concrete object as a local tool and rejected its integration-style ID with the reserved-namespace guard, surfacing as `Framework stream failed` / `INVOKE_AGENT_FAILED`.

Remote provenance records the canonical remote tool name on an internal symbol. Runtime assembly uses that canonical identity for both:

- bypassing the namespace assertion that applies only to local inline tools; and
- enforcing `allowedRemoteToolNames` and source-integration policy, including when a denied remote tool is exposed through an allowed-looking alias.

Provider-facing aliases remain unchanged. At the child-runtime boundary, selected aliases are mapped back to canonical provenance only for the internal authorization list. During listing, the provider alias remains associated with that canonical authorization identity through the final source-policy filter. This allows authorized aliases, including integration-style aliases, to advertise and execute without making the alias itself an authorization credential.

Ordinary inline local tools using `__` remain rejected. A remote tool cannot use provenance or aliasing to bypass the existing authorization policy.

The fork-stream error mapper also preserves the concrete upstream error string when `errorText` is absent instead of replacing it with the generic `Framework stream failed` message.

## Related Issue(s)

- https://github.com/veryfront/veryfront-api/issues/4150

## Acceptance criteria

- [x] A canonical remote tool ID containing `__` remains valid after remote-to-host materialization.
- [x] Two delegated child runtimes can each advertise and execute the materialized remote tool.
- [x] An authorized canonical remote tool can be advertised and executed through a provider-facing alias.
- [x] Listing and execution apply source policy to the same canonical identity, including for integration-style aliases.
- [x] Local inline tools still cannot use the reserved integration namespace.
- [x] `allowedRemoteToolNames` is enforced against the canonical remote name during both advertisement and execution.
- [x] Source-integration policy is enforced against the canonical remote name during both advertisement and execution.
- [x] Aliasing cannot disguise a denied canonical remote tool as an allowed tool.
- [x] A concrete upstream fork error is preserved when `errorText` is absent.
- [ ] The exact `veryfront-api` request-construction-to-framework boundary is covered cross-repository. This remains tracked in veryfront-api#4150; this PR changes no API code.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test update

## Test evidence

Red before implementation:

```text
Local tool "gmail__upload_attachment" cannot use the reserved integration tool namespace "integration__tool".
Error: Framework stream failed
Authorized alias: forkToolNames=["upload_attachment"], advertised=[]
Source-policy parity: canonical gmail__list_emails executed, alias mail__list advertised=[]
```

The authorization regression tests also failed before hardening: denied canonical tools were advertised/executed when provenance or an allowed-looking alias was present.

Green after implementation:

```text
Focused review suite:
23 passed (78 steps), 0 failed

Full frozen-lock unit suite:
2687 passed (21891 steps), 0 failed, 0 ignored (5 steps)
```

Additional verification:

- `deno task verify:quick`
- CI test-typecheck baseline, format, lint, and source typecheck passed
- independent security/architecture review approved the final listing/execution parity fix with no findings

## Checklist

- [x] Documentation impact reviewed; no public API documentation change is required
- [x] Tests prove the fix and the authorization boundary
- [x] Private symbol follows the repository constant convention
- [x] Unused provenance predicate export removed
