### PR TITLE
Refresh incomplete proxy routing metadata

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -191,7 +191,11 @@ function createNotFoundResponse(): Response {
   return new Response("Not found", { status: 404 });
 }
 
-function createHandler(port: number, apiBasePath = "") {
+function createHandler(
+  port: number,
+  apiBasePath = "",
+  logger?: Parameters<typeof createProxyHandler>[0]["logger"],
+) {
   return createProxyHandler({
     config: {
       apiBaseUrl: `http://127.0.0.1:${port}${apiBasePath}`,
@@ -200,6 +204,7 @@ function createHandler(port: number, apiBasePath = "") {
       previewApiClientId: "test-client",
       previewApiClientSecret: "test-secret",
     },
+    logger,
   });
 }
 
@@ -498,6 +503,96 @@ describe("Proxy Handler", () => {
 
         await handler.close();
       } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("refreshes an in-flight routing result without an active release", async () => {
+      let routingLookups = 0;
+      let activeReleaseId: string | null = null;
+      let releaseFirstLookup: (() => void) | undefined;
+      let markFirstLookupStarted!: () => void;
+      let markLookupJoined!: () => void;
+      const firstLookupStarted = new Promise<void>((resolve) => {
+        markFirstLookupStarted = resolve;
+      });
+      const lookupJoined = new Promise<void>((resolve) => {
+        markLookupJoined = resolve;
+      });
+      const firstLookupRelease = new Promise<void>((resolve) => {
+        releaseFirstLookup = resolve;
+      });
+      const { logger } = createRecordingLogger();
+      const recordDebug = logger.debug;
+      logger.debug = (message, extra) => {
+        recordDebug(message, extra);
+        if (message === "Proxy routing metadata lookup joined in-flight request") {
+          markLookupJoined();
+        }
+      };
+
+      const { server, port } = createMockServer(async (req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/-/proxy-routing/")) {
+          routingLookups++;
+          const releaseIdAtLookupStart = activeReleaseId;
+          if (routingLookups === 1) {
+            markFirstLookupStarted();
+            await firstLookupRelease;
+          }
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            name: "My Project",
+            environments: [{
+              id: "env-1",
+              name: "staging",
+              active_release_id: releaseIdAtLookupStart,
+            }],
+          });
+        }
+
+        if (pathname.startsWith("/projects/-/proxy-access/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            environments: [{
+              id: "env-1",
+              name: "staging",
+              protected: false,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port, "", logger);
+        const req = () =>
+          new Request("http://my-project.staging.veryfront.com/page", {
+            headers: { host: "my-project.staging.veryfront.com" },
+          });
+
+        const beforeActivation = handler.processRequest(req());
+        await firstLookupStarted;
+        activeReleaseId = "rel-456";
+        const afterActivation = handler.processRequest(req());
+        await lookupJoined;
+        releaseFirstLookup();
+
+        assertEquals((await beforeActivation).error?.status, 404);
+        const afterActivationResult = await afterActivation;
+        assertEquals(afterActivationResult.error, undefined);
+        assertEquals(afterActivationResult.releaseId, "rel-456");
+        assertEquals(routingLookups, 2);
+
+        await handler.close();
+      } finally {
+        releaseFirstLookup?.();
         await server.shutdown();
       }
     });

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -443,6 +443,65 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("refreshes cached routing metadata without an active release", async () => {
+      let routingLookups = 0;
+      let activeReleaseId: string | null = null;
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/-/proxy-routing/")) {
+          routingLookups++;
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            name: "My Project",
+            environments: [{
+              id: "env-1",
+              name: "staging",
+              active_release_id: activeReleaseId,
+            }],
+          });
+        }
+
+        if (pathname.startsWith("/projects/-/proxy-access/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            environments: [{
+              id: "env-1",
+              name: "staging",
+              protected: false,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+        const req = () =>
+          new Request("http://my-project.staging.veryfront.com/page", {
+            headers: { host: "my-project.staging.veryfront.com" },
+          });
+
+        const beforeActivation = await handler.processRequest(req());
+        activeReleaseId = "rel-456";
+        const afterActivation = await handler.processRequest(req());
+
+        assertEquals(beforeActivation.error?.status, 404);
+        assertEquals(afterActivation.error, undefined);
+        assertEquals(afterActivation.releaseId, "rel-456");
+        assertEquals(routingLookups, 2);
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("invalidates routing metadata only for the targeted project", async () => {
       const routingLookups = new Map<string, number>();
       const { server, port } = createMockServer((req: Request) => {

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -697,6 +697,98 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("refreshes for a caller arriving after activation during an incomplete refresh", async () => {
+      let routingLookups = 0;
+      let activeReleaseId: string | null = null;
+      let releaseIncompleteRefresh!: () => void;
+      let markIncompleteRefreshStarted!: () => void;
+      let markLookupJoined!: () => void;
+      const incompleteRefreshStarted = new Promise<void>((resolve) => {
+        markIncompleteRefreshStarted = resolve;
+      });
+      const lookupJoined = new Promise<void>((resolve) => {
+        markLookupJoined = resolve;
+      });
+      const incompleteRefreshRelease = new Promise<void>((resolve) => {
+        releaseIncompleteRefresh = resolve;
+      });
+      const { logger } = createRecordingLogger();
+      const recordDebug = logger.debug;
+      logger.debug = (message, extra) => {
+        recordDebug(message, extra);
+        if (message === "Proxy routing metadata lookup joined in-flight request") {
+          markLookupJoined();
+        }
+      };
+
+      const { server, port } = createMockServer(async (req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/-/proxy-routing/")) {
+          routingLookups++;
+          const releaseIdAtLookupStart = activeReleaseId;
+          if (routingLookups === 2) {
+            markIncompleteRefreshStarted();
+            await incompleteRefreshRelease;
+          }
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            name: "My Project",
+            environments: [{
+              id: "env-1",
+              name: "staging",
+              active_release_id: releaseIdAtLookupStart,
+            }],
+          });
+        }
+
+        if (pathname.startsWith("/projects/-/proxy-access/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            environments: [{
+              id: "env-1",
+              name: "staging",
+              protected: false,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port, "", logger);
+        const req = () =>
+          new Request("http://my-project.staging.veryfront.com/page", {
+            headers: { host: "my-project.staging.veryfront.com" },
+          });
+
+        assertEquals((await handler.processRequest(req())).error?.status, 404);
+
+        const beforeActivation = handler.processRequest(req());
+        await incompleteRefreshStarted;
+        activeReleaseId = "rel-456";
+        const afterActivation = handler.processRequest(req());
+        await lookupJoined;
+        releaseIncompleteRefresh();
+
+        assertEquals((await beforeActivation).error?.status, 404);
+        const afterActivationResult = await afterActivation;
+        assertEquals(afterActivationResult.error, undefined);
+        assertEquals(afterActivationResult.releaseId, "rel-456");
+        assertEquals(routingLookups, 3);
+
+        await handler.close();
+      } finally {
+        releaseIncompleteRefresh();
+        await server.shutdown();
+      }
+    });
+
     it("invalidates routing metadata only for the targeted project", async () => {
       const routingLookups = new Map<string, number>();
       const { server, port } = createMockServer((req: Request) => {

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -507,17 +507,18 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("refreshes an in-flight routing result without an active release", async () => {
+    it("single-flights refreshes after an in-flight result without an active release", async () => {
       let routingLookups = 0;
       let activeReleaseId: string | null = null;
-      let releaseFirstLookup: (() => void) | undefined;
+      let releaseFirstLookup!: () => void;
       let markFirstLookupStarted!: () => void;
-      let markLookupJoined!: () => void;
+      let markLookupsJoined!: () => void;
+      let joinedLookups = 0;
       const firstLookupStarted = new Promise<void>((resolve) => {
         markFirstLookupStarted = resolve;
       });
-      const lookupJoined = new Promise<void>((resolve) => {
-        markLookupJoined = resolve;
+      const lookupsJoined = new Promise<void>((resolve) => {
+        markLookupsJoined = resolve;
       });
       const firstLookupRelease = new Promise<void>((resolve) => {
         releaseFirstLookup = resolve;
@@ -527,7 +528,8 @@ describe("Proxy Handler", () => {
       logger.debug = (message, extra) => {
         recordDebug(message, extra);
         if (message === "Proxy routing metadata lookup joined in-flight request") {
-          markLookupJoined();
+          joinedLookups++;
+          if (joinedLookups === 2) markLookupsJoined();
         }
       };
 
@@ -580,19 +582,29 @@ describe("Proxy Handler", () => {
         const beforeActivation = handler.processRequest(req());
         await firstLookupStarted;
         activeReleaseId = "rel-456";
-        const afterActivation = handler.processRequest(req());
-        await lookupJoined;
+        const afterActivationA = handler.processRequest(req());
+        const afterActivationB = handler.processRequest(req());
+        await lookupsJoined;
         releaseFirstLookup();
 
         assertEquals((await beforeActivation).error?.status, 404);
-        const afterActivationResult = await afterActivation;
-        assertEquals(afterActivationResult.error, undefined);
-        assertEquals(afterActivationResult.releaseId, "rel-456");
+        const [afterActivationResultA, afterActivationResultB] = await Promise.all([
+          afterActivationA,
+          afterActivationB,
+        ]);
+        assertEquals(afterActivationResultA.error, undefined);
+        assertEquals(afterActivationResultA.releaseId, "rel-456");
+        assertEquals(afterActivationResultB.error, undefined);
+        assertEquals(afterActivationResultB.releaseId, "rel-456");
+
+        const cachedResult = await handler.processRequest(req());
+        assertEquals(cachedResult.error, undefined);
+        assertEquals(cachedResult.releaseId, "rel-456");
         assertEquals(routingLookups, 2);
 
         await handler.close();
       } finally {
-        releaseFirstLookup?.();
+        releaseFirstLookup();
         await server.shutdown();
       }
     });

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -609,6 +609,94 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("bounds an in-flight refresh when no release becomes active", async () => {
+      let routingLookups = 0;
+      let releaseFirstLookup!: () => void;
+      let markFirstLookupStarted!: () => void;
+      let markLookupsJoined!: () => void;
+      let joinedLookups = 0;
+      const firstLookupStarted = new Promise<void>((resolve) => {
+        markFirstLookupStarted = resolve;
+      });
+      const lookupsJoined = new Promise<void>((resolve) => {
+        markLookupsJoined = resolve;
+      });
+      const firstLookupRelease = new Promise<void>((resolve) => {
+        releaseFirstLookup = resolve;
+      });
+      const { logger } = createRecordingLogger();
+      const recordDebug = logger.debug;
+      logger.debug = (message, extra) => {
+        recordDebug(message, extra);
+        if (message === "Proxy routing metadata lookup joined in-flight request") {
+          joinedLookups++;
+          if (joinedLookups === 2) markLookupsJoined();
+        }
+      };
+
+      const { server, port } = createMockServer(async (req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/-/proxy-routing/")) {
+          routingLookups++;
+          if (routingLookups === 1) {
+            markFirstLookupStarted();
+            await firstLookupRelease;
+          }
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            name: "My Project",
+            environments: [{
+              id: "env-1",
+              name: "staging",
+              active_release_id: null,
+            }],
+          });
+        }
+
+        if (pathname.startsWith("/projects/-/proxy-access/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            environments: [{
+              id: "env-1",
+              name: "staging",
+              protected: false,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port, "", logger);
+        const req = () =>
+          new Request("http://my-project.staging.veryfront.com/page", {
+            headers: { host: "my-project.staging.veryfront.com" },
+          });
+
+        const first = handler.processRequest(req());
+        await firstLookupStarted;
+        const second = handler.processRequest(req());
+        const third = handler.processRequest(req());
+        await lookupsJoined;
+        releaseFirstLookup();
+
+        const results = await Promise.all([first, second, third]);
+        assertEquals(results.map((result) => result.error?.status), [404, 404, 404]);
+        assertEquals(routingLookups, 2);
+
+        await handler.close();
+      } finally {
+        releaseFirstLookup();
+        await server.shutdown();
+      }
+    });
+
     it("invalidates routing metadata only for the targeted project", async () => {
       const routingLookups = new Map<string, number>();
       const { server, port } = createMockServer((req: Request) => {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -599,32 +599,39 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     lookupKey: string,
     token: string,
     timing?: ProxyServerTiming,
-    isCachedResultUsable?: (result: ProjectRoutingLookupResult) => boolean,
+    isResultUsable?: (result: ProjectRoutingLookupResult) => boolean,
   ): Promise<ProjectRoutingLookupResult | null> {
     const cacheKey = normalizeProjectLookupKey(lookupKey);
+    const canUseResult = (result: ProjectRoutingLookupResult | null): boolean =>
+      !result || !isResultUsable || isResultUsable(result);
+    const discardIncompleteResult = (): void => {
+      routingLookupCache.delete(cacheKey);
+      logger?.info("Refreshing incomplete proxy routing metadata", { lookupKey });
+    };
+
     return await profileProxyServerTimingPhase(
       timing ?? { enabled: false, startedAt: 0, phases: new Map() },
       "proxy.routing_lookup",
       async () => {
         const cached = getCachedRoutingLookup(cacheKey);
-        if (cached && (!isCachedResultUsable || isCachedResultUsable(cached))) {
+        if (cached && canUseResult(cached)) {
           logger?.debug("Proxy routing metadata cache hit", { lookupKey });
           return cached;
         }
-        if (cached) {
-          routingLookupCache.delete(cacheKey);
-          logger?.info("Refreshing incomplete proxy routing metadata", { lookupKey });
-        }
+        if (cached) discardIncompleteResult();
 
-        const existingLookup = routingLookupInflight.get(cacheKey);
-        if (existingLookup?.generation === routingLookupGeneration) {
+        while (true) {
+          const existingLookup = routingLookupInflight.get(cacheKey);
+          if (!existingLookup || existingLookup.generation !== routingLookupGeneration) break;
+
           logger?.debug("Proxy routing metadata lookup joined in-flight request", { lookupKey });
           const result = await existingLookup.promise;
-          if (!result || !isCachedResultUsable || isCachedResultUsable(result)) {
-            return result;
+          if (canUseResult(result)) return result;
+
+          discardIncompleteResult();
+          if (routingLookupInflight.get(cacheKey) === existingLookup) {
+            routingLookupInflight.delete(cacheKey);
           }
-          routingLookupCache.delete(cacheKey);
-          logger?.info("Refreshing incomplete proxy routing metadata", { lookupKey });
         }
 
         const lookupPromise = (async () => {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -619,7 +619,12 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         const existingLookup = routingLookupInflight.get(cacheKey);
         if (existingLookup?.generation === routingLookupGeneration) {
           logger?.debug("Proxy routing metadata lookup joined in-flight request", { lookupKey });
-          return await existingLookup.promise;
+          const result = await existingLookup.promise;
+          if (!result || !isCachedResultUsable || isCachedResultUsable(result)) {
+            return result;
+          }
+          routingLookupCache.delete(cacheKey);
+          logger?.info("Refreshing incomplete proxy routing metadata", { lookupKey });
         }
 
         const lookupPromise = (async () => {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -500,6 +500,13 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     });
   }
 
+  function hasActiveReleaseForMatchedEnvironment(
+    result: ProjectRoutingLookupResult,
+    envMatcher: (env: ProjectLookupEnvironment) => boolean,
+  ): boolean {
+    return result.environments?.some((env) => envMatcher(env) && !!env.active_release_id) ?? false;
+  }
+
   function pruneInvalidationGenerations(generations: Map<string, number>): void {
     const oldestActiveGeneration = activeRoutingLookupGenerations.size > 0
       ? Math.min(...activeRoutingLookupGenerations.keys())
@@ -592,6 +599,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     lookupKey: string,
     token: string,
     timing?: ProxyServerTiming,
+    isCachedResultUsable?: (result: ProjectRoutingLookupResult) => boolean,
   ): Promise<ProjectRoutingLookupResult | null> {
     const cacheKey = normalizeProjectLookupKey(lookupKey);
     return await profileProxyServerTimingPhase(
@@ -599,9 +607,13 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       "proxy.routing_lookup",
       async () => {
         const cached = getCachedRoutingLookup(cacheKey);
-        if (cached) {
+        if (cached && (!isCachedResultUsable || isCachedResultUsable(cached))) {
           logger?.debug("Proxy routing metadata cache hit", { lookupKey });
           return cached;
+        }
+        if (cached) {
+          routingLookupCache.delete(cacheKey);
+          logger?.info("Refreshing incomplete proxy routing metadata", { lookupKey });
         }
 
         const existingLookup = routingLookupInflight.get(cacheKey);
@@ -775,12 +787,20 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     timing: ProxyServerTiming | undefined,
     logContext: Record<string, unknown>,
     signedInternalControlPlaneRequest: boolean,
+    requireActiveRelease: boolean,
   ): Promise<ResolvedProjectMetadata> {
     return await profileProxyServerTimingPhase(
       timing ?? { enabled: false, startedAt: 0, phases: new Map() },
       "proxy.project_lookup",
       async () => {
-        const routingResult = await resolveProjectRoutingLookup(lookupKey, token, timing);
+        const routingResult = await resolveProjectRoutingLookup(
+          lookupKey,
+          token,
+          timing,
+          requireActiveRelease
+            ? (result) => hasActiveReleaseForMatchedEnvironment(result, envMatcher)
+            : undefined,
+        );
         if (!routingResult) {
           return await resolveFullProjectLookupAndProtection(
             req,
@@ -921,6 +941,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           timing,
           logContext,
           signedInternalControlPlaneRequest,
+          scope === "production",
         );
 
       try {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -83,6 +83,7 @@ interface ProjectRoutingCacheEntry {
 
 interface ProjectRoutingInflightEntry {
   generation: number;
+  isRefreshAfterIncompleteResult: boolean;
   promise: Promise<ProjectRoutingLookupResult | null>;
 }
 
@@ -608,6 +609,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       routingLookupCache.delete(cacheKey);
       logger?.info("Refreshing incomplete proxy routing metadata", { lookupKey });
     };
+    let refreshAfterIncompleteResult = false;
 
     return await profileProxyServerTimingPhase(
       timing ?? { enabled: false, startedAt: 0, phases: new Map() },
@@ -618,7 +620,10 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           logger?.debug("Proxy routing metadata cache hit", { lookupKey });
           return cached;
         }
-        if (cached) discardIncompleteResult();
+        if (cached) {
+          discardIncompleteResult();
+          refreshAfterIncompleteResult = true;
+        }
 
         while (true) {
           const existingLookup = routingLookupInflight.get(cacheKey);
@@ -626,9 +631,10 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
           logger?.debug("Proxy routing metadata lookup joined in-flight request", { lookupKey });
           const result = await existingLookup.promise;
-          if (canUseResult(result)) return result;
+          if (existingLookup.isRefreshAfterIncompleteResult || canUseResult(result)) return result;
 
           discardIncompleteResult();
+          refreshAfterIncompleteResult = true;
           if (routingLookupInflight.get(cacheKey) === existingLookup) {
             routingLookupInflight.delete(cacheKey);
           }
@@ -676,6 +682,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         })();
         const inflightEntry: ProjectRoutingInflightEntry = {
           generation: routingLookupGeneration,
+          isRefreshAfterIncompleteResult: refreshAfterIncompleteResult,
           promise: lookupPromise,
         };
         routingLookupInflight.set(cacheKey, inflightEntry);

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -83,7 +83,6 @@ interface ProjectRoutingCacheEntry {
 
 interface ProjectRoutingInflightEntry {
   generation: number;
-  isRefreshAfterIncompleteResult: boolean;
   promise: Promise<ProjectRoutingLookupResult | null>;
 }
 
@@ -609,7 +608,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       routingLookupCache.delete(cacheKey);
       logger?.info("Refreshing incomplete proxy routing metadata", { lookupKey });
     };
-    let refreshAfterIncompleteResult = false;
+    let hasRejectedIncompleteResult = false;
 
     return await profileProxyServerTimingPhase(
       timing ?? { enabled: false, startedAt: 0, phases: new Map() },
@@ -622,7 +621,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         }
         if (cached) {
           discardIncompleteResult();
-          refreshAfterIncompleteResult = true;
+          hasRejectedIncompleteResult = true;
         }
 
         while (true) {
@@ -631,10 +630,10 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
           logger?.debug("Proxy routing metadata lookup joined in-flight request", { lookupKey });
           const result = await existingLookup.promise;
-          if (existingLookup.isRefreshAfterIncompleteResult || canUseResult(result)) return result;
+          if (hasRejectedIncompleteResult || canUseResult(result)) return result;
 
           discardIncompleteResult();
-          refreshAfterIncompleteResult = true;
+          hasRejectedIncompleteResult = true;
           if (routingLookupInflight.get(cacheKey) === existingLookup) {
             routingLookupInflight.delete(cacheKey);
           }
@@ -682,7 +681,6 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         })();
         const inflightEntry: ProjectRoutingInflightEntry = {
           generation: routingLookupGeneration,
-          isRefreshAfterIncompleteResult: refreshAfterIncompleteResult,
           promise: lookupPromise,
         };
         routingLookupInflight.set(cacheKey, inflightEntry);


### PR DESCRIPTION
## Summary

- treat cached staging/production routing metadata without an active release as incomplete
- apply the same check when requests join an in-flight routing lookup
- keep the one-refresh retry budget caller-local so existing cohorts stay bounded without making later callers accept stale metadata
- preserve normal cache hits for active routes and leave the existing invalidation architecture unchanged

## Root cause

The proxy cached routing metadata while a new project had no active release. After publishing activated the release, the proxy could keep reusing that cached `active_release_id: null` result, so the deployment URL returned 404 until the cache expired. The same stale result could also be shared by in-flight lookups that started before activation.

## Validation

- serial regression: first request sees no active release, release becomes active, next request succeeds
- activation concurrency: two post-activation waiters reject one pre-activation result, share one refresh, then a following request hits the refreshed cache
- persistent-null concurrency: three requests return the expected 404 with exactly one initial lookup and one shared refresh
- temporal race: a caller arriving after activation during another caller’s incomplete refresh rejects the stale result and fetches the active release
- proxy handler suite: 59 checks passed
- concurrency stress: 20 repeated handler-suite runs passed
- strict test-typecheck baseline: 0 new failures
- full pre-push verification: format, lint, typecheck, and 2,687 tests passed
- architecture review: keep invalidation as-is; keep retry state at the request boundary rather than on shared cache state
- simplicity review: one caller-local boolean in the existing lookup loop; no new dependency or production-level abstraction

Closes veryfront/veryfront-issue-inbox#266