### PR TITLE
Close quickstart deploy review gaps

### DIFF
--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -362,6 +362,61 @@ it("models an inferred missing project during dry-run deploy", async () => {
   }
 });
 
+it("does not claim dry-run deploy would push source when source push is skipped", async () => {
+  const projectDir = await Deno.makeTempDir();
+  const envKeys = [
+    "VERYFRONT_API_TOKEN",
+    "VERYFRONT_API_URL",
+    "VERYFRONT_PROJECT_SLUG",
+    "VERYFRONT_PROJECT_ID",
+  ];
+  const savedEnv = envKeys.map((key) => Deno.env.get(key));
+  const logs: string[] = [];
+  const originalLog = console.log;
+
+  try {
+    await Deno.writeTextFile(`${projectDir}/package.json`, '{"name":"missing-app"}\n');
+    Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+    Deno.env.set("VERYFRONT_API_URL", "https://control.example.test/api");
+    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+    Deno.env.delete("VERYFRONT_PROJECT_ID");
+    _resetEnvironmentConfig();
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+
+    await withMockFetch(
+      (_input: string | URL | Request, _init?: RequestInit) =>
+        Promise.resolve(Response.json({ message: "not found" }, { status: 404 })),
+      () =>
+        deployCommand({
+          projectDir,
+          branch: "main",
+          env: "production",
+          dryRun: true,
+          force: true,
+          quiet: false,
+          skipSourcePush: true,
+        }),
+    );
+
+    assertEquals(
+      logs.some((line) => line.includes('Would create release and deploy to "production"')),
+      true,
+    );
+    assertEquals(logs.some((line) => line.includes("push source")), false);
+  } finally {
+    console.log = originalLog;
+    envKeys.forEach((key, index) => {
+      const value = savedEnv[index];
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    });
+    _resetEnvironmentConfig();
+    await Deno.remove(projectDir, { recursive: true });
+  }
+});
+
 it("uses an alternative slug when inferred first deploy project creation conflicts", async () => {
   const projectDir = await Deno.makeTempDir();
   const envKeys = [
@@ -527,7 +582,7 @@ it("uses an alternative slug when inferred first deploy project creation conflic
   }
 });
 
-it("collects page routes when projectDir has a trailing slash", async () => {
+it("collects configured app and pages routes when projectDir has a trailing slash", async () => {
   const projectDir = await Deno.makeTempDir();
   const envKeys = [
     "VERYFRONT_API_TOKEN",
@@ -538,18 +593,30 @@ it("collects page routes when projectDir has a trailing slash", async () => {
   const savedEnv = envKeys.map((key) => Deno.env.get(key));
 
   try {
-    await Deno.mkdir(`${projectDir}/app`, { recursive: true });
+    await Deno.mkdir(`${projectDir}/src/site`, { recursive: true });
+    await Deno.mkdir(`${projectDir}/src/pages`, { recursive: true });
     await Deno.writeTextFile(`${projectDir}/.gitignore`, ".veryfront/\n");
-    await Deno.writeTextFile(`${projectDir}/veryfront.json`, '{"projectSlug":"my-project"}\n');
     await Deno.writeTextFile(
-      `${projectDir}/app/page.tsx`,
+      `${projectDir}/veryfront.config.ts`,
+      'export default { projectSlug: "my-project", directories: { app: "src/site", pages: "src/pages" } };\n',
+    );
+    await Deno.writeTextFile(
+      `${projectDir}/src/site/page.tsx`,
       "export default function Page() { return null; }\n",
+    );
+    await Deno.writeTextFile(
+      `${projectDir}/src/pages/about.tsx`,
+      "export default function About() { return null; }\n",
     );
     const actualSha = await commitProject(projectDir);
     const sourceDigest = await computeSourceDigest([
       {
-        path: "app/page.tsx",
+        path: "src/site/page.tsx",
         content: "export default function Page() { return null; }\n",
+      },
+      {
+        path: "src/pages/about.tsx",
+        content: "export default function About() { return null; }\n",
       },
     ]);
     await writePushReceipt(projectDir, {
@@ -609,10 +676,16 @@ it("collects page routes when projectDir has a trailing slash", async () => {
       ) {
         return Promise.resolve(Response.json({
           data: [{
-            path: "app/page.tsx",
+            path: "src/site/page.tsx",
             data: JSON.stringify({
               body: "export default function Page() { return null; }\n",
-              path: "app/page.tsx",
+              path: "src/site/page.tsx",
+            }),
+          }, {
+            path: "src/pages/about.tsx",
+            data: JSON.stringify({
+              body: "export default function About() { return null; }\n",
+              path: "src/pages/about.tsx",
             }),
           }],
           page_info: {},
@@ -658,7 +731,7 @@ it("collects page routes when projectDir has a trailing slash", async () => {
             skipSourcePush: true,
           }),
         Error,
-        "Missing routes: /",
+        "Missing routes: /, /about",
       ));
   } finally {
     envKeys.forEach((key, index) => {

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -598,7 +598,7 @@ it("collects configured app and pages routes when projectDir has a trailing slas
     await Deno.writeTextFile(`${projectDir}/.gitignore`, ".veryfront/\n");
     await Deno.writeTextFile(
       `${projectDir}/veryfront.config.ts`,
-      'export default { projectSlug: "my-project", directories: { app: "src/site", pages: "src/pages" } };\n',
+      'export default { projectSlug: "my-project", directories: { app: "src\\\\site", pages: "src\\\\pages" } };\n',
     );
     await Deno.writeTextFile(
       `${projectDir}/src/site/page.tsx`,
@@ -741,6 +741,265 @@ it("collects configured app and pages routes when projectDir has a trailing slas
     });
     _resetEnvironmentConfig();
     await Deno.remove(projectDir, { recursive: true });
+  }
+});
+
+it("rejects configured route directories outside projectDir before walking", async () => {
+  const projectDir = await Deno.makeTempDir();
+  const envKeys = [
+    "VERYFRONT_API_TOKEN",
+    "VERYFRONT_API_URL",
+    "VERYFRONT_PROJECT_SLUG",
+    "VERYFRONT_PROJECT_ID",
+  ];
+  const savedEnv = envKeys.map((key) => Deno.env.get(key));
+  const requests: string[] = [];
+  const releaseSource = "export const value = 1;\n";
+
+  try {
+    await Deno.writeTextFile(`${projectDir}/.gitignore`, ".veryfront/\n");
+    await Deno.writeTextFile(
+      `${projectDir}/veryfront.config.ts`,
+      'export default { projectSlug: "my-project", directories: { app: "../outside", pages: "src/pages" } };\n',
+    );
+    await Deno.writeTextFile(`${projectDir}/app.ts`, releaseSource);
+    const actualSha = await commitProject(projectDir);
+    const sourceDigest = await computeSourceDigest([
+      { path: "app.ts", content: releaseSource },
+    ]);
+    await writePushReceipt(projectDir, {
+      controlPlane: "https://control.example.test/api",
+      projectId: PROJECT_ID,
+      projectSlug: "my-project",
+      branch: "main",
+      commitSha: actualSha,
+      sourceDigest,
+      clean: true,
+      pushedAt: "2026-07-10T09:20:00.000Z",
+    });
+
+    Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+    Deno.env.set("VERYFRONT_API_URL", "https://control.example.test/api");
+    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+    Deno.env.delete("VERYFRONT_PROJECT_ID");
+    _resetEnvironmentConfig();
+
+    await withMockFetch((input: string | URL | Request, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      const url = new URL(request.url);
+      requests.push(`${request.method} ${url.pathname}`);
+
+      if (request.method === "GET" && url.pathname === "/api/projects/my-project") {
+        return Promise.resolve(Response.json({ id: PROJECT_ID, slug: "my-project" }));
+      }
+      if (request.method === "GET" && url.pathname.endsWith("/environments")) {
+        return Promise.resolve(Response.json({
+          data: [{
+            id: ENVIRONMENT_ID,
+            name: "production",
+            project_id: PROJECT_ID,
+            protected: false,
+            deployment: null,
+          }],
+        }));
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/releases")) {
+        return Promise.resolve(Response.json({
+          id: RELEASE_ID,
+          name: `github-main-${actualSha}`,
+          version: "0.0.41",
+          project_id: PROJECT_ID,
+        }, { status: 201 }));
+      }
+      if (request.method === "GET" && url.pathname.endsWith(`/releases/${RELEASE_ID}`)) {
+        return Promise.resolve(Response.json({
+          id: RELEASE_ID,
+          name: `github-main-${actualSha}`,
+          version: "0.0.41",
+          project_id: PROJECT_ID,
+        }));
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname.endsWith(`/releases/${RELEASE_ID}/versions`)
+      ) {
+        return Promise.resolve(Response.json({
+          data: [{
+            path: "app.ts",
+            data: JSON.stringify({ body: releaseSource, path: "app.ts" }),
+          }],
+          page_info: {},
+        }));
+      }
+      return Promise.resolve(Response.json({ message: "not found" }, { status: 404 }));
+    }, () =>
+      assertRejects(
+        () =>
+          deployCommand({
+            projectDir,
+            branch: "main",
+            env: "production",
+            releaseName: `github-main-${actualSha}`,
+            dryRun: false,
+            force: true,
+            quiet: true,
+            skipSourcePush: true,
+          }),
+        Error,
+        'Configured app directory "../outside" resolves outside the project directory',
+      ));
+
+    assertEquals(
+      requests.some((request) => request.endsWith(`/releases/${RELEASE_ID}/asset-manifest`)),
+      false,
+    );
+  } finally {
+    envKeys.forEach((key, index) => {
+      const value = savedEnv[index];
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    });
+    _resetEnvironmentConfig();
+    await Deno.remove(projectDir, { recursive: true });
+  }
+});
+
+it("rejects absolute configured route directories before walking", async () => {
+  const cases = [
+    {
+      app: "/project/src/site",
+      message: 'Configured app directory "/project/src/site" must be project-relative',
+    },
+    {
+      app: "C:/project/src/site",
+      message: 'Configured app directory "C:/project/src/site" must be project-relative',
+    },
+    {
+      app: "\\\\server\\share\\site",
+      message: 'Configured app directory "//server/share/site" must be project-relative',
+    },
+  ];
+
+  for (const testCase of cases) {
+    const projectDir = await Deno.makeTempDir();
+    const envKeys = [
+      "VERYFRONT_API_TOKEN",
+      "VERYFRONT_API_URL",
+      "VERYFRONT_PROJECT_SLUG",
+      "VERYFRONT_PROJECT_ID",
+    ];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+    const requests: string[] = [];
+    const releaseSource = "export const value = 1;\n";
+
+    try {
+      await Deno.writeTextFile(`${projectDir}/.gitignore`, ".veryfront/\n");
+      await Deno.writeTextFile(
+        `${projectDir}/veryfront.config.ts`,
+        `export default { projectSlug: "my-project", directories: { app: ${
+          JSON.stringify(testCase.app)
+        }, pages: "src/pages" } };\n`,
+      );
+      await Deno.writeTextFile(`${projectDir}/app.ts`, releaseSource);
+      const actualSha = await commitProject(projectDir);
+      const sourceDigest = await computeSourceDigest([
+        { path: "app.ts", content: releaseSource },
+      ]);
+      await writePushReceipt(projectDir, {
+        controlPlane: "https://control.example.test/api",
+        projectId: PROJECT_ID,
+        projectSlug: "my-project",
+        branch: "main",
+        commitSha: actualSha,
+        sourceDigest,
+        clean: true,
+        pushedAt: "2026-07-10T09:20:00.000Z",
+      });
+
+      Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+      Deno.env.set("VERYFRONT_API_URL", "https://control.example.test/api");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_PROJECT_ID");
+      _resetEnvironmentConfig();
+
+      await withMockFetch((input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        requests.push(`${request.method} ${url.pathname}`);
+
+        if (request.method === "GET" && url.pathname === "/api/projects/my-project") {
+          return Promise.resolve(Response.json({ id: PROJECT_ID, slug: "my-project" }));
+        }
+        if (request.method === "GET" && url.pathname.endsWith("/environments")) {
+          return Promise.resolve(Response.json({
+            data: [{
+              id: ENVIRONMENT_ID,
+              name: "production",
+              project_id: PROJECT_ID,
+              protected: false,
+              deployment: null,
+            }],
+          }));
+        }
+        if (request.method === "POST" && url.pathname.endsWith("/releases")) {
+          return Promise.resolve(Response.json({
+            id: RELEASE_ID,
+            name: `github-main-${actualSha}`,
+            version: "0.0.41",
+            project_id: PROJECT_ID,
+          }, { status: 201 }));
+        }
+        if (request.method === "GET" && url.pathname.endsWith(`/releases/${RELEASE_ID}`)) {
+          return Promise.resolve(Response.json({
+            id: RELEASE_ID,
+            name: `github-main-${actualSha}`,
+            version: "0.0.41",
+            project_id: PROJECT_ID,
+          }));
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname.endsWith(`/releases/${RELEASE_ID}/versions`)
+        ) {
+          return Promise.resolve(Response.json({
+            data: [{
+              path: "app.ts",
+              data: JSON.stringify({ body: releaseSource, path: "app.ts" }),
+            }],
+            page_info: {},
+          }));
+        }
+        return Promise.resolve(Response.json({ message: "not found" }, { status: 404 }));
+      }, () =>
+        assertRejects(
+          () =>
+            deployCommand({
+              projectDir,
+              branch: "main",
+              env: "production",
+              releaseName: `github-main-${actualSha}`,
+              dryRun: false,
+              force: true,
+              quiet: true,
+              skipSourcePush: true,
+            }),
+          Error,
+          testCase.message,
+        ));
+
+      assertEquals(
+        requests.some((request) => request.endsWith(`/releases/${RELEASE_ID}/asset-manifest`)),
+        false,
+      );
+    } finally {
+      envKeys.forEach((key, index) => {
+        const value = savedEnv[index];
+        if (value === undefined) Deno.env.delete(key);
+        else Deno.env.set(key, value);
+      });
+      _resetEnvironmentConfig();
+      await Deno.remove(projectDir, { recursive: true });
+    }
   }
 });
 

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -10,7 +10,7 @@
 import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
 import { createFileSystem, cwd, runtime } from "veryfront/platform";
-import { join, relative } from "veryfront/platform/path";
+import { join, relative, resolve } from "veryfront/platform/path";
 import { type EnvironmentConfig, getConfig, getEnvironmentConfig } from "veryfront/config";
 import {
   type ApiClient,
@@ -40,6 +40,7 @@ import {
 } from "../../shared/deployment-provenance.ts";
 import type { ReleaseAssetManifestResponse } from "#veryfront/release-assets/manifest-schema.ts";
 import { routeForPage } from "#veryfront/release-assets/route-path.ts";
+import { isWithinDirectory, normalizePath } from "#veryfront/utils/path-utils.ts";
 
 /**
  * Schema factory for deploy command arguments
@@ -730,9 +731,38 @@ async function getProjectRouteDirectories(
   const adapter = await runtime.get();
   const config = await getConfig(projectDir, adapter);
   return {
-    app: config.directories?.app ?? "app",
-    pages: config.directories?.pages ?? "pages",
+    app: normalizeConfiguredRouteDirectory(config.directories?.app ?? "app"),
+    pages: normalizeConfiguredRouteDirectory(config.directories?.pages ?? "pages"),
   };
+}
+
+function normalizeConfiguredRouteDirectory(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function isAbsoluteConfiguredRouteDirectory(path: string): boolean {
+  return path.startsWith("/") || /^[A-Za-z]:\//.test(path);
+}
+
+function resolveProjectRouteDirectory(
+  projectDir: string,
+  directory: string,
+  name: "app" | "pages",
+): string {
+  if (isAbsoluteConfiguredRouteDirectory(directory)) {
+    throw new Error(
+      `Configured ${name} directory "${directory}" must be project-relative. Set directories.${name} to a path inside the project, for example "${name}" or "src/${name}".`,
+    );
+  }
+
+  const projectRoot = normalizePath(projectDir);
+  const routeRoot = normalizePath(resolve(projectRoot, directory));
+  if (!isWithinDirectory(projectRoot, routeRoot)) {
+    throw new Error(
+      `Configured ${name} directory "${directory}" resolves outside the project directory. Set directories.${name} to a project-relative path inside the project.`,
+    );
+  }
+  return routeRoot;
 }
 
 async function collectProjectPageRoutes(projectDir: string): Promise<string[]> {
@@ -766,8 +796,8 @@ async function collectProjectPageRoutes(projectDir: string): Promise<string[]> {
     }
   }
 
-  const appDir = join(projectDir, directories.app);
-  const pagesDir = join(projectDir, directories.pages);
+  const appDir = resolveProjectRouteDirectory(projectDir, directories.app, "app");
+  const pagesDir = resolveProjectRouteDirectory(projectDir, directories.pages, "pages");
   await Promise.all([
     walk(appDir, appDir, "app"),
     walk(pagesDir, pagesDir, "pages"),

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -9,9 +9,9 @@
 
 import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
-import { createFileSystem, cwd } from "veryfront/platform";
+import { createFileSystem, cwd, runtime } from "veryfront/platform";
 import { join, relative } from "veryfront/platform/path";
-import { type EnvironmentConfig, getEnvironmentConfig } from "veryfront/config";
+import { type EnvironmentConfig, getConfig, getEnvironmentConfig } from "veryfront/config";
 import {
   type ApiClient,
   createApiClient,
@@ -724,11 +724,23 @@ async function ensureProjectLinkedForDeploy(
   };
 }
 
+async function getProjectRouteDirectories(
+  projectDir: string,
+): Promise<{ app: string; pages: string }> {
+  const adapter = await runtime.get();
+  const config = await getConfig(projectDir, adapter);
+  return {
+    app: config.directories?.app ?? "app",
+    pages: config.directories?.pages ?? "pages",
+  };
+}
+
 async function collectProjectPageRoutes(projectDir: string): Promise<string[]> {
   const fs = createFileSystem();
+  const directories = await getProjectRouteDirectories(projectDir);
   const routes = new Set<string>();
 
-  async function walk(dir: string): Promise<void> {
+  async function walk(rootDir: string, dir: string, routeRoot: "app" | "pages"): Promise<void> {
     let entries;
     try {
       if (!(await fs.exists(dir))) return;
@@ -740,23 +752,25 @@ async function collectProjectPageRoutes(projectDir: string): Promise<string[]> {
     for await (const entry of entries) {
       const path = join(dir, entry.name);
       if (entry.isDirectory) {
-        await walk(path);
+        await walk(rootDir, path, routeRoot);
         continue;
       }
       if (!/\.(tsx|ts|jsx|mdx|js)$/.test(entry.name)) continue;
 
-      const relativePath = relative(projectDir, path).replace(/\\/g, "/");
+      const relativePath = relative(rootDir, path).replace(/\\/g, "/");
       if (relativePath === "." || relativePath === ".." || relativePath.startsWith("../")) {
         continue;
       }
-      const route = routeForPage(relativePath);
+      const route = routeForPage(`${routeRoot}/${relativePath}`);
       if (route) routes.add(route);
     }
   }
 
+  const appDir = join(projectDir, directories.app);
+  const pagesDir = join(projectDir, directories.pages);
   await Promise.all([
-    walk(join(projectDir, "app")),
-    walk(join(projectDir, "pages")),
+    walk(appDir, appDir, "app"),
+    walk(pagesDir, pagesDir, "pages"),
   ]);
 
   return [...routes].sort();
@@ -860,14 +874,14 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
   const environmentConfig = getEnvironmentConfig();
   const setup = await ensureProjectLinkedForDeploy(projectDir, environmentConfig, dryRun, quiet);
   let { config, client, project } = setup;
-  const expectedPageRoutes = await collectProjectPageRoutes(projectDir);
 
   if (dryRun && !project) {
     spinner.stop();
     if (!quiet) {
-      logInfo(
-        `Would push source to "${branch}", create release, and deploy to "${env}" for project ${setup.plannedProjectSlug}`,
-      );
+      const actions = skipSourcePush
+        ? `create release and deploy to "${env}"`
+        : `push source to "${branch}", create release, and deploy to "${env}"`;
+      logInfo(`Would ${actions} for project ${setup.plannedProjectSlug}`);
     }
     return;
   }
@@ -971,6 +985,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     });
 
     spinner.update(`Waiting for release assets for ${release.version}...`);
+    const expectedPageRoutes = await collectProjectPageRoutes(projectDir);
     await waitForReleaseAssetManifest(client, project.slug, release.id, {
       expectedRoutes: expectedPageRoutes,
       pollIntervalMs: assetManifestPollIntervalMs,
@@ -1059,7 +1074,6 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
     const environmentConfig = getEnvironmentConfig();
     const setup = await ensureProjectLinkedForDeploy(projectDir, environmentConfig, dryRun, true);
     let { config, client, project } = setup;
-    const expectedPageRoutes = await collectProjectPageRoutes(projectDir);
     streamJsonLine({ type: "step", name: "resolve-config", status: "completed" });
 
     if (dryRun && !project) {
@@ -1162,6 +1176,7 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
     streamJsonLine({ type: "step", name: "verify-release-source", status: "completed" });
 
     streamJsonLine({ type: "step", name: "wait-release-assets", status: "started" });
+    const expectedPageRoutes = await collectProjectPageRoutes(projectDir);
     await waitForReleaseAssetManifest(client, project.slug, release.id, {
       expectedRoutes: expectedPageRoutes,
       pollIntervalMs: assetManifestPollIntervalMs,

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1158",
+  "version": "0.1.1159",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-injection.test.ts
+++ b/src/html/html-injection.test.ts
@@ -11,6 +11,8 @@ const baseTemplate = `<!DOCTYPE html>
 
 const minMeta: HTMLMetadata = { title: "Test", description: "Desc" };
 const PAGE_HASH = "a".repeat(64);
+const UNUSED_HASH = "b".repeat(64);
+const ABOUT_HASH = "c".repeat(64);
 
 function releaseManifest(): ReleaseAssetManifest {
   return {
@@ -25,11 +27,34 @@ function releaseManifest(): ReleaseAssetManifest {
     assetBasePath: "/_vf/assets",
     modules: {
       "app/page.tsx": { contentHash: PAGE_HASH, size: 1, contentType: "text/javascript" },
+      "components/Unused.tsx": {
+        contentHash: UNUSED_HASH,
+        size: 1,
+        contentType: "text/javascript",
+      },
     },
     css: [],
     routes: { "/": { modules: ["app/page.tsx"], css: [] } },
     dependencies: {},
     fallback: { mode: "jit", gaps: [] },
+  };
+}
+
+function customDirectoryReleaseManifest(): ReleaseAssetManifest {
+  return {
+    ...releaseManifest(),
+    modules: {
+      "src/site/page.tsx": { contentHash: PAGE_HASH, size: 1, contentType: "text/javascript" },
+      "src/pages/about.tsx": {
+        contentHash: ABOUT_HASH,
+        size: 1,
+        contentType: "text/javascript",
+      },
+    },
+    routes: {
+      "/": { modules: ["src/site/page.tsx"], css: [] },
+      "/about": { modules: ["src/pages/about.tsx"], css: [] },
+    },
   };
 }
 
@@ -152,7 +177,7 @@ describe("html/html-injection", () => {
       assertEquals(hydrationData.clientModuleStrategy, "rsc-module");
     });
 
-    it("injects release asset modules into full-document client page hydration data", () => {
+    it("injects route-scoped release asset modules into full-document client page hydration data", () => {
       const html = injectHTMLContent(
         baseTemplate,
         "<p>content</p>",
@@ -170,6 +195,28 @@ describe("html/html-injection", () => {
       const hydrationData = extractHydrationData(html);
       assertEquals(hydrationData.releaseAssetModules, {
         "app/page.tsx": `/_vf/assets/${PAGE_HASH}.js`,
+      });
+    });
+
+    it("uses configured route directories for route-scoped release asset modules", () => {
+      const html = injectHTMLContent(
+        baseTemplate,
+        "<p>content</p>",
+        minMeta,
+        {
+          mode: "production",
+          slug: "about",
+          pagePath: "/project/src/pages/about.tsx",
+          projectDir: "/project",
+          isClientPage: true,
+          directories: { app: "src/site", pages: "src/pages" },
+          releaseAssetManifest: customDirectoryReleaseManifest(),
+        },
+      );
+
+      const hydrationData = extractHydrationData(html);
+      assertEquals(hydrationData.releaseAssetModules, {
+        "src/pages/about.tsx": `/_vf/assets/${ABOUT_HASH}.js`,
       });
     });
 

--- a/src/html/html-injection.ts
+++ b/src/html/html-injection.ts
@@ -20,7 +20,13 @@ import {
   getStudioScripts,
 } from "./dev-scripts.ts";
 import { buildReleaseAssetModules } from "#veryfront/release-assets/client-module-map.ts";
+import { routeForPage } from "#veryfront/release-assets/route-path.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
+
+interface RouteDirectories {
+  app?: string;
+  pages?: string;
+}
 
 export interface InjectHTMLContentOptions {
   mode: string;
@@ -61,6 +67,8 @@ export interface InjectHTMLContentOptions {
   projectStylesheetHref?: string;
   /** Ready release asset manifest used to hydrate full HTML client pages */
   releaseAssetManifest?: ReleaseAssetManifest | null;
+  /** Configured route directories used to map physical page paths to route keys */
+  directories?: RouteDirectories;
 }
 
 function toProjectRelativePath(absolutePath: string, projectDir?: string): string {
@@ -75,6 +83,41 @@ function hasProjectStylesheet(html: string): boolean {
   return /id=["']vf-tailwind-css["']/i.test(html) ||
     /href=["'][^"']*\/_vf_styles\/styles\.css(?:\?[^"']*)?["']/i.test(html) ||
     /href=["'][^"']*\/_vf\/css\/[^"']+\.css["']/i.test(html);
+}
+
+function normalizeLogicalPath(path: string): string {
+  const parts: string[] = [];
+  for (const part of path.replace(/\\/g, "/").split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return parts.join("/");
+}
+
+function pathBelowRoot(path: string, root: string): string | null {
+  const normalizedPath = normalizeLogicalPath(path);
+  const normalizedRoot = normalizeLogicalPath(root);
+  if (normalizedRoot === "") return normalizedPath;
+  if (normalizedPath === normalizedRoot) return "";
+  const prefix = `${normalizedRoot}/`;
+  return normalizedPath.startsWith(prefix) ? normalizedPath.slice(prefix.length) : null;
+}
+
+function routeForConfiguredPage(path: string, directories?: RouteDirectories): string | null {
+  const appRelativePath = pathBelowRoot(path, directories?.app ?? "app");
+  if (appRelativePath !== null) {
+    const route = routeForPage(`app/${appRelativePath}`);
+    if (route !== null) return route;
+  }
+
+  const pagesRelativePath = pathBelowRoot(path, directories?.pages ?? "pages");
+  if (pagesRelativePath !== null) return routeForPage(`pages/${pagesRelativePath}`);
+
+  return null;
 }
 
 export function injectHTMLContent(
@@ -133,12 +176,13 @@ export function injectHTMLContent(
 
   // Inject hydration data for 'use client' pages (before scripts, so client.js can find it)
   if (options.pagePath && options.isClientPage && hasBodyClose) {
+    const pagePath = toProjectRelativePath(options.pagePath, options.projectDir);
     // Serialize with jsonForInlineScript, not raw JSON.stringify: route params
     // (and slug) are URL-derived and decoded, so a segment like `%3C/script%3E`
     // would otherwise break out of the <script> tag (reflected XSS). This escapes
     // `<`, `>`, `&`, and line separators, matching the main shell hydration path.
     const hydrationData = jsonForInlineScript({
-      pagePath: toProjectRelativePath(options.pagePath, options.projectDir),
+      pagePath,
       slug: options.slug,
       isClientPage: true,
       params: options.params ?? {},
@@ -146,7 +190,9 @@ export function injectHTMLContent(
         isLocalProject: options.isLocalProject ?? options.mode === "development",
         environment: options.environment,
       }),
-      releaseAssetModules: buildReleaseAssetModules(options.releaseAssetManifest),
+      releaseAssetModules: buildReleaseAssetModules(options.releaseAssetManifest, {
+        route: routeForConfiguredPage(pagePath, options.directories),
+      }),
     });
     const nonceAttr = buildNonceAttribute(options.nonce);
     const hydrationScript =

--- a/src/html/html-injection.ts
+++ b/src/html/html-injection.ts
@@ -20,13 +20,11 @@ import {
   getStudioScripts,
 } from "./dev-scripts.ts";
 import { buildReleaseAssetModules } from "#veryfront/release-assets/client-module-map.ts";
-import { routeForPage } from "#veryfront/release-assets/route-path.ts";
+import {
+  type ConfiguredRouteDirectories,
+  routeForConfiguredPage,
+} from "#veryfront/release-assets/route-path.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
-
-interface RouteDirectories {
-  app?: string;
-  pages?: string;
-}
 
 export interface InjectHTMLContentOptions {
   mode: string;
@@ -68,7 +66,7 @@ export interface InjectHTMLContentOptions {
   /** Ready release asset manifest used to hydrate full HTML client pages */
   releaseAssetManifest?: ReleaseAssetManifest | null;
   /** Configured route directories used to map physical page paths to route keys */
-  directories?: RouteDirectories;
+  directories?: ConfiguredRouteDirectories;
 }
 
 function toProjectRelativePath(absolutePath: string, projectDir?: string): string {
@@ -83,41 +81,6 @@ function hasProjectStylesheet(html: string): boolean {
   return /id=["']vf-tailwind-css["']/i.test(html) ||
     /href=["'][^"']*\/_vf_styles\/styles\.css(?:\?[^"']*)?["']/i.test(html) ||
     /href=["'][^"']*\/_vf\/css\/[^"']+\.css["']/i.test(html);
-}
-
-function normalizeLogicalPath(path: string): string {
-  const parts: string[] = [];
-  for (const part of path.replace(/\\/g, "/").split("/")) {
-    if (!part || part === ".") continue;
-    if (part === "..") {
-      parts.pop();
-      continue;
-    }
-    parts.push(part);
-  }
-  return parts.join("/");
-}
-
-function pathBelowRoot(path: string, root: string): string | null {
-  const normalizedPath = normalizeLogicalPath(path);
-  const normalizedRoot = normalizeLogicalPath(root);
-  if (normalizedRoot === "") return normalizedPath;
-  if (normalizedPath === normalizedRoot) return "";
-  const prefix = `${normalizedRoot}/`;
-  return normalizedPath.startsWith(prefix) ? normalizedPath.slice(prefix.length) : null;
-}
-
-function routeForConfiguredPage(path: string, directories?: RouteDirectories): string | null {
-  const appRelativePath = pathBelowRoot(path, directories?.app ?? "app");
-  if (appRelativePath !== null) {
-    const route = routeForPage(`app/${appRelativePath}`);
-    if (route !== null) return route;
-  }
-
-  const pagesRelativePath = pathBelowRoot(path, directories?.pages ?? "pages");
-  if (pagesRelativePath !== null) return routeForPage(`pages/${pagesRelativePath}`);
-
-  return null;
 }
 
 export function injectHTMLContent(

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -1854,6 +1854,42 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     assert(routeModules.includes("lib/utils.ts"), "extensionless transitive import in closure");
   });
 
+  it("derives manifest routes from configured app and pages directories", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "veryfront.config.ts",
+        content: 'export default { directories: { app: "src\\\\site", pages: "src\\\\pages" } };',
+      },
+      {
+        path: "src/site/layout.tsx",
+        content: "export default function Layout({ children }) { return children; }",
+      },
+      {
+        path: "src/site/page.tsx",
+        content: "export default function Home() { return null; }",
+      },
+      {
+        path: "src/pages/about.tsx",
+        content: "export default function About() { return null; }",
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (s: string) => Promise.resolve(s);
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+
+    assertEquals(Object.keys(manifest.routes).sort(), ["/", "/about"]);
+    assertEquals(manifest.routes["/"]?.modules, [
+      "src/site/page.tsx",
+      "src/site/layout.tsx",
+    ]);
+    assertEquals(manifest.routes["/about"]?.modules, ["src/pages/about.tsx"]);
+  });
+
   // H1: non-transform failures (e.g., listAllReleaseFiles throws) report failed.
   it("reports failed on non-transform build failure (H1)", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -1862,15 +1862,15 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
         content: 'export default { directories: { app: "src\\\\site", pages: "src\\\\pages" } };',
       },
       {
-        path: "src/site/layout.tsx",
+        path: "src\\site\\layout.tsx",
         content: "export default function Layout({ children }) { return children; }",
       },
       {
-        path: "src/site/page.tsx",
+        path: "src\\site\\page.tsx",
         content: "export default function Home() { return null; }",
       },
       {
-        path: "src/pages/about.tsx",
+        path: "src\\pages\\about.tsx",
         content: "export default function About() { return null; }",
       },
     ];
@@ -1967,31 +1967,6 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     assertEquals(Object.keys(manifest.modules).length, 0);
     // Gap is recorded.
     assert(result.gaps.some((g) => g.startsWith("oversized:")));
-  });
-
-  // L3: nested index route derivation.
-  it("routeForPage derives nested index routes correctly (L3)", () => {
-    assertEquals(routeForPage("pages/index.tsx"), "/");
-    assertEquals(routeForPage("pages/about.tsx"), "/about");
-    assertEquals(routeForPage("pages/blog/index.tsx"), "/blog");
-    assertEquals(routeForPage("pages/blog/post.tsx"), "/blog/post");
-    assertEquals(routeForPage("pages/a/b/index.tsx"), "/a/b");
-    assertEquals(routeForPage("pages/api/hello.ts"), null);
-    assertEquals(routeForPage("pages/api/users/[id].ts"), null);
-    assertEquals(routeForPage("pages/index.d.ts"), null);
-    assertEquals(routeForPage("pages/blog/post.d.ts"), null);
-    assertEquals(routeForPage("pages/index.css"), null);
-    assertEquals(routeForPage("pages/_app.tsx"), null);
-    assertEquals(routeForPage("pages/_document.tsx"), null);
-    assertEquals(routeForPage("pages/blog/_draft.tsx"), null);
-    assertEquals(routeForPage("app/page.tsx"), "/");
-    assertEquals(routeForPage("app/(marketing)/page.tsx"), "/");
-    assertEquals(routeForPage("app/(marketing)/blog/page.tsx"), "/blog");
-    assertEquals(routeForPage("app/page.d.ts"), null);
-    assertEquals(routeForPage("app/page.css"), null);
-    assertEquals(routeForPage("app/@modal/page.tsx"), null);
-    assertEquals(routeForPage("app/_components/page.tsx"), null);
-    assertEquals(routeForPage("components/Button.tsx"), null);
   });
 });
 

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -62,7 +62,12 @@ import {
   RELEASE_ASSET_UPLOAD_CONCURRENCY,
   releaseAssetUrl,
 } from "./constants.ts";
-import { routeForPage } from "./route-path.ts";
+import {
+  configuredRoutePath,
+  normalizeLogicalPath,
+  routeForConfiguredPage,
+  routeForPage,
+} from "./route-path.ts";
 export { routeForPage } from "./route-path.ts";
 import type {
   ReleaseAssetCssEntry,
@@ -294,40 +299,6 @@ function isBrowserModule(path: string, directories: ReleaseRouterDirectories): b
     BROWSER_MODULE_DIRS.some((dir) => path.startsWith(dir));
 }
 
-function configuredRoutePath(
-  path: string,
-  directories: ReleaseRouterDirectories,
-  routeRoot: "app" | "pages",
-): string | null {
-  const relativePath = pathBelowRoot(path, directories[routeRoot]);
-  return relativePath === null ? null : `${routeRoot}/${relativePath}`;
-}
-
-function pathBelowRoot(path: string, root: string): string | null {
-  const normalizedPath = normalizeLogicalPath(path);
-  const normalizedRoot = normalizeLogicalPath(root);
-  if (normalizedRoot === "") return normalizedPath;
-  if (normalizedPath === normalizedRoot) return "";
-  const prefix = `${normalizedRoot}/`;
-  return normalizedPath.startsWith(prefix) ? normalizedPath.slice(prefix.length) : null;
-}
-
-function routeForConfiguredPage(
-  path: string,
-  directories: ReleaseRouterDirectories,
-): string | null {
-  const appPath = configuredRoutePath(path, directories, "app");
-  if (appPath) {
-    const route = routeForPage(appPath);
-    if (route !== null) return route;
-  }
-
-  const pagesPath = configuredRoutePath(path, directories, "pages");
-  if (pagesPath) return routeForPage(pagesPath);
-
-  return null;
-}
-
 function isConfiguredAppRouterLayout(path: string, directories: ReleaseRouterDirectories): boolean {
   const appPath = configuredRoutePath(path, directories, "app");
   if (!appPath?.startsWith("app/")) return false;
@@ -389,19 +360,6 @@ function resolveKnownModulePath(path: string, knownPaths: Set<string>): string |
   }
 
   return null;
-}
-
-function normalizeLogicalPath(path: string): string {
-  const parts: string[] = [];
-  for (const part of path.replace(/\\/g, "/").split("/")) {
-    if (!part || part === ".") continue;
-    if (part === "..") {
-      parts.pop();
-      continue;
-    }
-    parts.push(part);
-  }
-  return parts.join("/");
 }
 
 function normalizeProjectSpecifier(specifier: string, logicalPath: string): string | null {
@@ -1603,8 +1561,9 @@ async function runBuildInner(
 
   for (const file of files) {
     if (typeof file.content !== "string") continue;
-    const abs = resolveMaterializedReleasePath(tempDir, file.path);
-    sourceByPath.set(file.path, file.content);
+    const logicalPath = file.path.replace(/\\/g, "/");
+    const abs = resolveMaterializedReleasePath(tempDir, logicalPath);
+    sourceByPath.set(normalizeLogicalPath(logicalPath), file.content);
     await fs.mkdir(dirname(abs), { recursive: true });
     await fs.writeTextFile(abs, file.content);
   }

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -237,6 +237,11 @@ interface FinalizedDependencyModules {
   fallbackUrls: Map<string, string>;
 }
 
+interface ReleaseRouterDirectories {
+  app: string;
+  pages: string;
+}
+
 function frameworkModuleUrlToSourceKey(moduleUrl: string): string | null {
   if (!moduleUrl.startsWith(FRAMEWORK_MODULE_URL_PREFIX)) return null;
   return moduleUrl
@@ -282,32 +287,74 @@ function isTransformableBrowserModule(path: string): boolean {
 }
 
 /** True when a logical path should seed the browser module graph. */
-function isBrowserModule(path: string): boolean {
+function isBrowserModule(path: string, directories: ReleaseRouterDirectories): boolean {
   if (!isTransformableBrowserModule(path)) return false;
-  if (routeForPage(path) !== null) return true;
-  return isAppRouterLayout(path) || BROWSER_MODULE_DIRS.some((dir) => path.startsWith(dir));
+  if (routeForConfiguredPage(path, directories) !== null) return true;
+  return isConfiguredAppRouterLayout(path, directories) ||
+    BROWSER_MODULE_DIRS.some((dir) => path.startsWith(dir));
 }
 
-function isAppRouterLayout(path: string): boolean {
-  if (!path.startsWith("app/")) return false;
-  const withoutPrefix = path.slice("app/".length);
+function configuredRoutePath(
+  path: string,
+  directories: ReleaseRouterDirectories,
+  routeRoot: "app" | "pages",
+): string | null {
+  const relativePath = pathBelowRoot(path, directories[routeRoot]);
+  return relativePath === null ? null : `${routeRoot}/${relativePath}`;
+}
+
+function pathBelowRoot(path: string, root: string): string | null {
+  const normalizedPath = normalizeLogicalPath(path);
+  const normalizedRoot = normalizeLogicalPath(root);
+  if (normalizedRoot === "") return normalizedPath;
+  if (normalizedPath === normalizedRoot) return "";
+  const prefix = `${normalizedRoot}/`;
+  return normalizedPath.startsWith(prefix) ? normalizedPath.slice(prefix.length) : null;
+}
+
+function routeForConfiguredPage(
+  path: string,
+  directories: ReleaseRouterDirectories,
+): string | null {
+  const appPath = configuredRoutePath(path, directories, "app");
+  if (appPath) {
+    const route = routeForPage(appPath);
+    if (route !== null) return route;
+  }
+
+  const pagesPath = configuredRoutePath(path, directories, "pages");
+  if (pagesPath) return routeForPage(pagesPath);
+
+  return null;
+}
+
+function isConfiguredAppRouterLayout(path: string, directories: ReleaseRouterDirectories): boolean {
+  const appPath = configuredRoutePath(path, directories, "app");
+  if (!appPath?.startsWith("app/")) return false;
+  const withoutPrefix = appPath.slice("app/".length);
   const segments = withoutPrefix.split("/");
   const fileName = segments.pop();
   if (!fileName || !/^layout\.(tsx|ts|jsx|mdx|js)$/.test(fileName)) return false;
   return !segments.some((segment) => segment.startsWith("@") || segment.startsWith("_"));
 }
 
-function collectAppRouterLayoutsForPage(logicalPath: string, knownPaths: Set<string>): string[] {
-  if (!logicalPath.startsWith("app/") || routeForPage(logicalPath) === null) return [];
+function collectConfiguredAppRouterLayoutsForPage(
+  logicalPath: string,
+  directories: ReleaseRouterDirectories,
+  knownPaths: Set<string>,
+): string[] {
+  const appPath = configuredRoutePath(logicalPath, directories, "app");
+  if (!appPath || routeForPage(appPath) === null) return [];
 
   const segments = logicalPath.split("/");
   segments.pop();
+  const appRootDepth = normalizeLogicalPath(directories.app).split("/").filter(Boolean).length;
 
   const layouts: string[] = [];
-  for (let depth = 1; depth <= segments.length; depth++) {
+  for (let depth = appRootDepth; depth <= segments.length; depth++) {
     const dir = segments.slice(0, depth).join("/");
     for (const ext of BROWSER_MODULE_EXTENSIONS) {
-      const candidate = `${dir}/layout${ext}`;
+      const candidate = dir ? `${dir}/layout${ext}` : `layout${ext}`;
       if (knownPaths.has(candidate)) {
         layouts.push(candidate);
         break;
@@ -315,6 +362,13 @@ function collectAppRouterLayoutsForPage(logicalPath: string, knownPaths: Set<str
     }
   }
   return layouts;
+}
+
+function releaseRouterDirectories(config: VeryfrontConfig): ReleaseRouterDirectories {
+  return {
+    app: config.directories?.app ?? "app",
+    pages: config.directories?.pages ?? "pages",
+  };
 }
 
 function resolveKnownModulePath(path: string, knownPaths: Set<string>): string | null {
@@ -339,7 +393,7 @@ function resolveKnownModulePath(path: string, knownPaths: Set<string>): string |
 
 function normalizeLogicalPath(path: string): string {
   const parts: string[] = [];
-  for (const part of path.split("/")) {
+  for (const part of path.replace(/\\/g, "/").split("/")) {
     if (!part || part === ".") continue;
     if (part === "..") {
       parts.pop();
@@ -1567,6 +1621,7 @@ async function runBuildInner(
   const vendorHttpImports = input.vendorHttpImports ?? vendorHttpImportsWithCache;
   const vendorDependencies = isDependencyImportMapEnabled();
   const releaseConfig = await resolveReleaseConfigFromSourceFiles(sourceByPath, input, tempDir);
+  const routeDirectories = releaseRouterDirectories(releaseConfig);
   const releaseReactVersion = await resolveReleaseReactVersion(
     sourceByPath,
     releaseConfig,
@@ -1656,7 +1711,7 @@ async function runBuildInner(
   }
 
   for (const logicalPath of sourceByPath.keys()) {
-    if (!isBrowserModule(logicalPath)) continue;
+    if (!isBrowserModule(logicalPath, routeDirectories)) continue;
 
     const failure = await transformProjectModule(logicalPath);
     if (failure) return failure;
@@ -1805,15 +1860,17 @@ async function runBuildInner(
   // B2. Routes: walk the transformed browser import closure from each page entrypoint.
   // Modules missing from transformedModules are recorded as closure gaps.
   const routes: Record<string, ReleaseAssetRouteEntry> = {};
-  const pageModules = Object.keys(modules).filter((p) => routeForPage(p) !== null);
+  const pageModules = Object.keys(modules).filter((p) =>
+    routeForConfiguredPage(p, routeDirectories) !== null
+  );
 
   for (const logicalPath of pageModules) {
-    const route = routeForPage(logicalPath);
+    const route = routeForConfiguredPage(logicalPath, routeDirectories);
     if (!route) continue;
 
     const entryModules = [
       logicalPath,
-      ...collectAppRouterLayoutsForPage(logicalPath, knownPaths),
+      ...collectConfiguredAppRouterLayoutsForPage(logicalPath, routeDirectories, knownPaths),
     ];
     const { modules: closureModules, gaps: closureGaps } = await collectRouteClosure(
       entryModules,

--- a/src/release-assets/client-module-map.test.ts
+++ b/src/release-assets/client-module-map.test.ts
@@ -1,0 +1,80 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ReleaseAssetManifest } from "./manifest-schema.ts";
+import { buildReleaseAssetModules } from "./client-module-map.ts";
+
+const PAGE_HASH = "a".repeat(64);
+const FALLBACK_HASH = "b".repeat(64);
+
+function manifest(): ReleaseAssetManifest {
+  return {
+    schemaVersion: 1,
+    projectId: "project-id",
+    releaseId: "release-id",
+    releaseVersion: 1,
+    manifestVersion: 1,
+    builderVersion: "0.1.765",
+    sourceContentHash: "",
+    createdAt: "2026-07-27T00:00:00.000Z",
+    assetBasePath: "/_vf/assets",
+    modules: {
+      "app/page.tsx": { contentHash: PAGE_HASH, size: 1, contentType: "text/javascript" },
+      "components/Fallback.tsx": {
+        contentHash: FALLBACK_HASH,
+        size: 1,
+        contentType: "text/javascript",
+      },
+    },
+    css: [],
+    routes: {
+      "/": { modules: ["app/page.tsx"], css: [] },
+      "/empty": { modules: [], css: [] },
+      "/partial-stale": { modules: ["app/page.tsx", "src/site/page.tsx"], css: [] },
+      "/stale": { modules: ["src/site/page.tsx"], css: [] },
+    },
+    dependencies: {},
+    fallback: { mode: "jit", gaps: [] },
+  };
+}
+
+describe("release asset client module map", () => {
+  it("uses route-scoped modules when route entries match manifest modules", () => {
+    assertEquals(buildReleaseAssetModules(manifest(), { route: "/" }), {
+      "app/page.tsx": `/_vf/assets/${PAGE_HASH}.js`,
+    });
+  });
+
+  it("does not materialize the full fallback map when route entries match manifest modules", () => {
+    const releaseManifest = manifest();
+    Object.defineProperty(releaseManifest.modules["components/Fallback.tsx"], "contentHash", {
+      get() {
+        throw new Error("fallback module was materialized");
+      },
+    });
+
+    assertEquals(buildReleaseAssetModules(releaseManifest, { route: "/" }), {
+      "app/page.tsx": `/_vf/assets/${PAGE_HASH}.js`,
+    });
+  });
+
+  it("falls back to the full manifest when a route has no matching module keys", () => {
+    assertEquals(buildReleaseAssetModules(manifest(), { route: "/stale" }), {
+      "app/page.tsx": `/_vf/assets/${PAGE_HASH}.js`,
+      "components/Fallback.tsx": `/_vf/assets/${FALLBACK_HASH}.js`,
+    });
+  });
+
+  it("falls back to the full manifest when a route has stale module keys", () => {
+    assertEquals(buildReleaseAssetModules(manifest(), { route: "/partial-stale" }), {
+      "app/page.tsx": `/_vf/assets/${PAGE_HASH}.js`,
+      "components/Fallback.tsx": `/_vf/assets/${FALLBACK_HASH}.js`,
+    });
+  });
+
+  it("falls back to the full manifest when a route has an empty module list", () => {
+    assertEquals(buildReleaseAssetModules(manifest(), { route: "/empty" }), {
+      "app/page.tsx": `/_vf/assets/${PAGE_HASH}.js`,
+      "components/Fallback.tsx": `/_vf/assets/${FALLBACK_HASH}.js`,
+    });
+  });
+});

--- a/src/release-assets/client-module-map.ts
+++ b/src/release-assets/client-module-map.ts
@@ -3,13 +3,28 @@ import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 
 export function buildReleaseAssetModules(
   manifest?: ReleaseAssetManifest | null,
+  options: { route?: string | null } = {},
 ): Record<string, string> | undefined {
   if (!manifest) return undefined;
 
+  const routeModules = options.route ? manifest.routes[options.route]?.modules : undefined;
+  const buildFallback = (): Record<string, string> | undefined => {
+    const fallbackModules: Record<string, string> = {};
+    for (const [path, entry] of Object.entries(manifest.modules)) {
+      fallbackModules[path] = releaseAssetUrl(entry.contentHash, "js");
+    }
+    return Object.keys(fallbackModules).length > 0 ? fallbackModules : undefined;
+  };
+
+  if (!routeModules) return buildFallback();
+  if (routeModules.length === 0) return buildFallback();
+
   const modules: Record<string, string> = {};
-  for (const [path, entry] of Object.entries(manifest.modules)) {
+  for (const path of routeModules) {
+    const entry = manifest.modules[path];
+    if (!entry) return buildFallback();
     modules[path] = releaseAssetUrl(entry.contentHash, "js");
   }
 
-  return Object.keys(modules).length > 0 ? modules : undefined;
+  return modules;
 }

--- a/src/release-assets/route-path.test.ts
+++ b/src/release-assets/route-path.test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  configuredRoutePath,
+  normalizeLogicalPath,
+  pathBelowRoot,
+  routeForConfiguredPage,
+  routeForPage,
+} from "./route-path.ts";
+
+describe("release-assets/route-path", () => {
+  it("derives nested index routes correctly", () => {
+    assertEquals(routeForPage("pages/index.tsx"), "/");
+    assertEquals(routeForPage("pages/about.tsx"), "/about");
+    assertEquals(routeForPage("pages/blog/index.tsx"), "/blog");
+    assertEquals(routeForPage("pages/blog/post.tsx"), "/blog/post");
+    assertEquals(routeForPage("pages/a/b/index.tsx"), "/a/b");
+    assertEquals(routeForPage("pages/api/hello.ts"), null);
+    assertEquals(routeForPage("pages/api/users/[id].ts"), null);
+    assertEquals(routeForPage("pages/index.d.ts"), null);
+    assertEquals(routeForPage("pages/blog/post.d.ts"), null);
+    assertEquals(routeForPage("pages/index.css"), null);
+    assertEquals(routeForPage("pages/_app.tsx"), null);
+    assertEquals(routeForPage("pages/_document.tsx"), null);
+    assertEquals(routeForPage("pages/blog/_draft.tsx"), null);
+    assertEquals(routeForPage("app/page.tsx"), "/");
+    assertEquals(routeForPage("app/(marketing)/page.tsx"), "/");
+    assertEquals(routeForPage("app/(marketing)/blog/page.tsx"), "/blog");
+    assertEquals(routeForPage("app/page.d.ts"), null);
+    assertEquals(routeForPage("app/page.css"), null);
+    assertEquals(routeForPage("app/@modal/page.tsx"), null);
+    assertEquals(routeForPage("app/_components/page.tsx"), null);
+    assertEquals(routeForPage("components/Button.tsx"), null);
+  });
+
+  it("normalizes logical paths before matching configured route roots", () => {
+    const directories = { app: "src\\site", pages: "src/pages" };
+
+    assertEquals(normalizeLogicalPath("src\\site/./blog/../page.tsx"), "src/site/page.tsx");
+    assertEquals(pathBelowRoot("src\\pages\\about.tsx", "src/pages"), "about.tsx");
+    assertEquals(configuredRoutePath("src\\site\\page.tsx", directories, "app"), "app/page.tsx");
+    assertEquals(routeForConfiguredPage("src\\pages\\about.tsx", directories), "/about");
+  });
+});

--- a/src/release-assets/route-path.ts
+++ b/src/release-assets/route-path.ts
@@ -1,10 +1,46 @@
 const PAGE_MODULE_EXTENSION = /\.(tsx|ts|jsx|mdx|js)$/;
 const DECLARATION_MODULE_EXTENSION = /\.d\.(tsx|ts)$/;
 
+export interface ConfiguredRouteDirectories {
+  app?: string;
+  pages?: string;
+}
+
 function stripPageModuleExtension(logicalPath: string): string | null {
   if (DECLARATION_MODULE_EXTENSION.test(logicalPath)) return null;
   if (!PAGE_MODULE_EXTENSION.test(logicalPath)) return null;
   return logicalPath.replace(PAGE_MODULE_EXTENSION, "");
+}
+
+export function normalizeLogicalPath(path: string): string {
+  const parts: string[] = [];
+  for (const part of path.replace(/\\/g, "/").split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return parts.join("/");
+}
+
+export function pathBelowRoot(path: string, root: string): string | null {
+  const normalizedPath = normalizeLogicalPath(path);
+  const normalizedRoot = normalizeLogicalPath(root);
+  if (normalizedRoot === "") return normalizedPath;
+  if (normalizedPath === normalizedRoot) return "";
+  const prefix = `${normalizedRoot}/`;
+  return normalizedPath.startsWith(prefix) ? normalizedPath.slice(prefix.length) : null;
+}
+
+export function configuredRoutePath(
+  path: string,
+  directories: ConfiguredRouteDirectories | undefined,
+  routeRoot: "app" | "pages",
+): string | null {
+  const relativePath = pathBelowRoot(path, directories?.[routeRoot] ?? routeRoot);
+  return relativePath === null ? null : `${routeRoot}/${relativePath}`;
 }
 
 /** Derive a route path from a page module logical path. */
@@ -45,6 +81,22 @@ export function routeForPage(logicalPath: string): string | null {
       .join("/");
     return `/${route}`.replace(/\/+/g, "/").replace(/\/$/, "") || "/";
   }
+
+  return null;
+}
+
+export function routeForConfiguredPage(
+  path: string,
+  directories?: ConfiguredRouteDirectories,
+): string | null {
+  const appPath = configuredRoutePath(path, directories, "app");
+  if (appPath) {
+    const route = routeForPage(appPath);
+    if (route !== null) return route;
+  }
+
+  const pagesPath = configuredRoutePath(path, directories, "pages");
+  if (pagesPath) return routeForPage(pagesPath);
 
   return null;
 }

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -312,6 +312,7 @@ export class HTMLGenerator {
       importMapJson,
       projectStylesheetHref,
       releaseAssetManifest,
+      directories: this.config.config.directories,
     });
 
     if (injectedHtml.trimStart().toLowerCase().startsWith("<!doctype")) return injectedHtml;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1158";
+export const VERSION = "0.1.1159";


### PR DESCRIPTION
## Summary
- make deploy dry-run output respect `skipSourcePush`
- collect deploy route coverage from configured `directories.app` / `directories.pages`
- scope full-document client hydration release asset module maps to the current route when route coverage exists

## Review threads addressed
- veryfront-code#3126 comment 3658449804
- veryfront-code#3126 comment 3658449847
- veryfront-code#3126 comment 3658449871

## Tests
- `deno fmt --check cli/commands/deploy/command.ts cli/commands/deploy/command.integration.test.ts src/html/html-injection.ts src/html/html-injection.test.ts src/release-assets/client-module-map.ts`
- `deno lint cli/commands/deploy/command.ts cli/commands/deploy/command.integration.test.ts src/html/html-injection.ts src/html/html-injection.test.ts src/release-assets/client-module-map.ts`
- `deno check cli/commands/deploy/command.ts src/html/html-injection.ts src/release-assets/client-module-map.ts src/html/hydration-script-builder/hydration-data-generator.ts`
- `deno test --no-check --allow-all cli/commands/deploy/command.integration.test.ts src/html/html-injection.test.ts src/html/hydration-script-builder/hydration-data-generator.test.ts`
- repository pre-push hook completed during branch push