### PR TITLE
Default new projects to the AI Agent starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It gives you agents, tools, workflows, and a complete React rendering stack in a
 Create a new Veryfront Code app:
 
 ```bash
-npm create veryfront
+npm create veryfront@latest my-agent
 ```
 
 <details>
@@ -34,7 +34,7 @@ deno init --npm veryfront
 
 </details>
 
-Start from a template directly:
+The default starter is `ai-agent`. Choose another template directly:
 
 ```bash
 npx veryfront init <PROJECT_NAME> --template <TEMPLATE>

--- a/cli/commands/init/catalog.test.ts
+++ b/cli/commands/init/catalog.test.ts
@@ -21,12 +21,16 @@ describe("catalog", () => {
   afterEach(() => Deno.env.delete(EXPERIMENTAL_INTEGRATIONS_ENV));
 
   describe("TEMPLATES", () => {
+    it("uses ai-agent as the default template", () => {
+      assertEquals(TEMPLATES[0]?.id, "ai-agent");
+    });
+
     it("contains expected templates", () => {
       assertEquals(TEMPLATES.length, 7);
       const ids = TEMPLATES.map((t) => t.id);
       assertEquals(ids, [
-        "minimal",
         "ai-agent",
+        "minimal",
         "docs-agent",
         "agentic-workflow",
         "multi-agent-system",

--- a/cli/commands/init/catalog.ts
+++ b/cli/commands/init/catalog.ts
@@ -21,9 +21,11 @@ export interface TemplateOption {
   description: string;
 }
 
+export const DEFAULT_TEMPLATE: InitTemplate = "ai-agent";
+
 export const TEMPLATES: readonly TemplateOption[] = [
+  { id: DEFAULT_TEMPLATE, label: "AI Agent", description: "Agent + chat UI + streaming" },
   { id: "minimal", label: "Minimal", description: "Blank canvas, no extras" },
-  { id: "ai-agent", label: "AI Agent", description: "Agent + chat UI + streaming" },
   {
     id: "docs-agent",
     label: "Docs Agent",

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -42,6 +42,7 @@ import {
   shouldRunWizard,
   validateProjectName,
 } from "./interactive-wizard.ts";
+import { DEFAULT_TEMPLATE } from "./catalog.ts";
 
 /**
  * Icon mapping for integrations based on category/name
@@ -316,7 +317,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
     initGit = wizardResult.initGit;
     wizardRuntime = wizardResult.runtime;
   } else {
-    template = options.template ?? "minimal";
+    template = options.template ?? DEFAULT_TEMPLATE;
   }
 
   const runtime: InitRuntime = options.runtime ?? wizardRuntime;

--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -457,12 +457,13 @@ describe("init command integration", () => {
   });
 
   describe("wizard behavior in non-TTY", () => {
-    it("should skip wizard and use minimal template when name is provided", async () => {
+    it("should skip wizard and use ai-agent template when name is provided", async () => {
       // When a name is provided, wizard should be skipped
       const result = await runInitCommand([projectName, "--skip-install"]);
 
       assertEquals(result.code, 0);
-      assertEquals(await exists(join(projectDir, "app")), true);
+      assertEquals(await exists(join(projectDir, "agents", "assistant.ts")), true);
+      assertEquals(await exists(join(projectDir, "tools", "calculator.ts")), true);
     });
   });
 

--- a/cli/commands/init/interactive-wizard.ts
+++ b/cli/commands/init/interactive-wizard.ts
@@ -3,7 +3,7 @@ import { getAgentFace } from "../../ui/dot-matrix.ts";
 import { isCiEnv, isDenoTestingEnv } from "veryfront/config";
 import { isInteractive as checkIsInteractive } from "veryfront/platform";
 import { select, textInput } from "../../utils/terminal-select.ts";
-import { getTemplateSelectOptions, TEMPLATES } from "./catalog.ts";
+import { DEFAULT_TEMPLATE, getTemplateSelectOptions, TEMPLATES } from "./catalog.ts";
 import type { InitRuntime, InitTemplate } from "./types.ts";
 
 /** Reject path separators and traversal so the name stays a single directory. */
@@ -33,7 +33,7 @@ export async function runInteractiveWizard(
   if (!canRunWizard()) {
     return {
       projectName: existingName ?? null,
-      template: "minimal",
+      template: DEFAULT_TEMPLATE,
       runtime: presetRuntime ?? "node",
       initGit: false,
       skipped: true,
@@ -74,7 +74,7 @@ export async function runInteractiveWizard(
       console.log(muted("\n  Cancelled.\n"));
       return {
         projectName: null,
-        template: "minimal",
+        template: DEFAULT_TEMPLATE,
         runtime: "node",
         initGit: false,
         skipped: false,
@@ -88,7 +88,7 @@ export async function runInteractiveWizard(
         console.log(muted("\n  Cancelled.\n"));
         return {
           projectName: null,
-          template: "minimal",
+          template: DEFAULT_TEMPLATE,
           runtime: "node",
           initGit: false,
           skipped: false,
@@ -101,7 +101,7 @@ export async function runInteractiveWizard(
         console.log(muted(`\n  ${nameError}\n`));
         return {
           projectName: null,
-          template: "minimal",
+          template: DEFAULT_TEMPLATE,
           runtime: "node",
           initGit: false,
           skipped: false,
@@ -123,7 +123,7 @@ export async function runInteractiveWizard(
     console.log(muted("\n  Cancelled.\n"));
     return {
       projectName: null,
-      template: "minimal",
+      template: DEFAULT_TEMPLATE,
       runtime: "node",
       initGit: false,
       skipped: false,
@@ -150,7 +150,7 @@ export async function runInteractiveWizard(
       console.log(muted("\n  Cancelled.\n"));
       return {
         projectName: null,
-        template: "minimal",
+        template: DEFAULT_TEMPLATE,
         runtime: "node",
         initGit: false,
         skipped: false,
@@ -175,7 +175,7 @@ export async function runInteractiveWizard(
     console.log(muted("\n  Cancelled.\n"));
     return {
       projectName: null,
-      template: "minimal",
+      template: DEFAULT_TEMPLATE,
       runtime: "node",
       initGit: false,
       skipped: false,

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1160",
+  "version": "0.1.1161",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -18,15 +18,14 @@ veryfront init test-app
 cd test-app
 ```
 
-The wizard asks which template to use.
+The wizard preselects the `ai-agent` template. Choose another template when you
+want a different starting point. In non-interactive environments, `ai-agent` is
+used automatically.
 
 Choose a starting point directly when you already know what you want to build,
 or when running the command from a non-interactive script:
 
 ```bash
-# Agent app with a chat UI, tool, and AG-UI route
-veryfront init support-agent --template ai-agent
-
 # Blank full-stack app with pages and routing
 veryfront init web-app --template minimal
 
@@ -62,7 +61,7 @@ Use these commands when you do not have the Veryfront CLI installed globally.
 <CodeGroup>
 
 ```bash npm
-npm create veryfront
+npm create veryfront@latest my-agent
 ```
 
 ```bash pnpm

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -14,13 +14,12 @@ globally, run them with `npx veryfront ...`.
 ## Create the app
 
 ```bash
-npm create veryfront@latest support-agent -- --template ai-agent
+npm create veryfront@latest support-agent
 cd support-agent
 ```
 
-The quickstart uses `--template ai-agent` so the command creates the exact app
-shown below. Omit `--template` when you want the interactive template picker
-instead.
+The `ai-agent` starter is the default. Pass `-- --template <template>` when you
+want a different starting point.
 
 The `ai-agent` template creates a runnable chat app:
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1160";
+export const VERSION = "0.1.1161";

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -189,7 +189,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "../api-reference/veryfront/chat.md",
     ],
     snippets: [
-      "npm create veryfront@latest support-agent -- --template ai-agent",
+      "npm create veryfront@latest support-agent",
       "npx veryfront deploy",
       "calculator.ts",
       "What is 128 divided by 8?",


### PR DESCRIPTION
## Summary

- make `ai-agent` the shared default for interactive and non-interactive project creation
- keep explicit `--template` selections unchanged
- document the no-flag quickstart command and bump the framework release to `0.1.1161`

`create-veryfront` already prepends `veryfront init` and forwards the project name and flags, so no wrapper change or wrapper release is required.

## Verification

- pre-push gate: formatting, lint, typecheck, and 2,693 tests / 21,929 steps passed
- focused init suite: 9 files / 141 steps passed
- docs contract and code-example tests: 127 steps passed
- version sync test passed
- independent code review: approved with no findings