### PR TITLE
Preserve server layouts during production hydration

### DIFF
--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -263,7 +263,12 @@ it("uses canonical production read-back in human and JSON modes", async () => {
       ]);
       if (jsonMode) {
         const events = output.map((line) =>
-          JSON.parse(line) as { type: string; name?: string; status?: string }
+          JSON.parse(line) as {
+            type: string;
+            name?: string;
+            status?: string;
+            data?: { url?: string };
+          }
         );
         assertEquals(
           events.slice(-4).map((event) =>
@@ -275,6 +280,10 @@ it("uses canonical production read-back in human and JSON modes", async () => {
             "wait-environment-url:completed",
             "result",
           ],
+        );
+        assertEquals(
+          events.at(-1)?.data?.url,
+          "https://my-project.production.veryfront.com/dashboard",
         );
       }
     }

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -700,6 +700,10 @@ function buildEnvironmentProbeUrl(baseUrl: string, route: string): string {
   return route === "/" ? probeUrl.origin : probeUrl.href;
 }
 
+function buildReadyEnvironmentUrl(baseUrl: string, route: string | null): string {
+  return route ? buildEnvironmentProbeUrl(baseUrl, route) : baseUrl;
+}
+
 function secureEnvironmentProbeUrl(url: string): string {
   const secureUrl = new URL(url);
   secureUrl.protocol = "https:";
@@ -1247,14 +1251,18 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       sourceDigest: source.sourceDigest,
     }, { verifiedRelease });
 
-    environmentUrl = buildEnvironmentUrl(verification.projectSlug, environment);
+    const readinessRoute = expectedPageRoutes.find((route) => !route.includes("[")) ?? null;
+    environmentUrl = buildReadyEnvironmentUrl(
+      buildEnvironmentUrl(verification.projectSlug, environment),
+      readinessRoute,
+    );
     spinner.update(`Waiting for ${env} URL...`);
     await waitForEnvironmentReady(
       {
         projectSlug: verification.projectSlug,
         environmentName: environment.name,
         url: environmentUrl,
-        route: expectedPageRoutes.find((route) => !route.includes("[")) ?? null,
+        route: readinessRoute,
         protected: environment.protected,
         apiToken: config.apiToken,
       },
@@ -1465,14 +1473,18 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
     }, { verifiedRelease });
     streamJsonLine({ type: "step", name: "verify-deployment", status: "completed" });
 
-    const environmentUrl = buildEnvironmentUrl(verification.projectSlug, environment);
+    const readinessRoute = expectedPageRoutes.find((route) => !route.includes("[")) ?? null;
+    const environmentUrl = buildReadyEnvironmentUrl(
+      buildEnvironmentUrl(verification.projectSlug, environment),
+      readinessRoute,
+    );
     streamJsonLine({ type: "step", name: "wait-environment-url", status: "started" });
     await waitForEnvironmentReady(
       {
         projectSlug: verification.projectSlug,
         environmentName: environment.name,
         url: environmentUrl,
-        route: expectedPageRoutes.find((route) => !route.includes("[")) ?? null,
+        route: readinessRoute,
         protected: environment.protected,
         apiToken: config.apiToken,
       },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1161",
+  "version": "0.1.1162",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {
@@ -472,7 +472,7 @@
     "test:all-runtimes": "deno task test:unit && deno task test:node && deno task test:bun",
     "test:e2e": "deno task test:e2e:playwright",
     "test:e2e:playwright": "PW_DISABLE_TS_ESM=1 npx playwright test --config=tests/e2e/playwright.config.cjs",
-    "test:e2e:rsc-browser": "deno task generate && VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all tests/e2e/regressions/rsc-proxy-hydration.test.ts tests/e2e/regressions/2026-07-27-legacy-router-hydration.test.ts --unstable-worker-options --unstable-net",
+    "test:e2e:rsc-browser": "deno task generate && VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all tests/e2e/regressions/rsc-proxy-hydration.test.ts tests/e2e/regressions/2026-07-27-legacy-router-hydration.test.ts tests/e2e/regressions/2026-07-27-release-asset-page-island-hydration.test.ts --unstable-worker-options --unstable-net",
     "test:e2e:binary": "deno task generate && deno test --allow-all tests/integration/compiled-binary-e2e.test.ts",
     "test:e2e:binary:fresh": "deno task generate && VERYFRONT_BINARY_FRESH=1 deno test --allow-all tests/integration/compiled-binary-e2e.test.ts",
     "test:e2e:templates": "deno run --allow-all scripts/test/template-runtime-e2e.ts",

--- a/src/html/hydration-script-builder/templates/renderer.ts
+++ b/src/html/hydration-script-builder/templates/renderer.ts
@@ -122,8 +122,7 @@ export const getRendererScript = () => `
           data.clientModuleStrategy === 'rsc-module' &&
           !hasReleaseAssetModules &&
           isAppRouterPath(normalizedPagePath);
-        const isolatedClientPage =
-          shouldRenderRscClientPage && data.isolatedClientPage === true;
+        const isolatedClientPage = data.isolatedClientPage === true;
 
         async function loadHydrationComponent(path, preferRscModule) {
           const normalizedPath = typeof path === 'string' ? path.replace(/^\\/+/, '') : '';

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1161";
+export const VERSION = "0.1.1162";

--- a/tests/e2e/regressions/2026-07-27-release-asset-page-island-hydration.test.ts
+++ b/tests/e2e/regressions/2026-07-27-release-asset-page-island-hydration.test.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env -S deno test --allow-all
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  captureBrowserDiagnostics,
+  closeChromium,
+  getBrowserDiagnosticMessages,
+  launchChromium,
+} from "../../_helpers/playwright.ts";
+import { generateProdHydrationModule } from "../../../src/html/hydration-script-builder/prod-scripts.ts";
+
+const HTML = `<!doctype html>
+<html>
+  <head>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "/react.js",
+          "react-dom/client": "/react-dom-client.js",
+          "veryfront/router": "/router.js",
+          "veryfront/context": "/context.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <div id="root">
+      <main id="server-layout">
+        <div id="veryfront-page-island">Server page</div>
+      </main>
+    </div>
+    <script id="veryfront-hydration-data" type="application/json">
+      {
+        "pagePath": "app/page.tsx",
+        "appRouterRoot": "app",
+        "clientModuleStrategy": "rsc-module",
+        "isolatedClientPage": true,
+        "releaseAssetModules": {
+          "app/page.tsx": "/page.js"
+        },
+        "layouts": [],
+        "params": {},
+        "props": {}
+      }
+    </script>
+    <script type="module" src="/hydration-runtime.js"></script>
+  </body>
+</html>`;
+
+const REACT_MODULE = `
+export function createElement(type, props, ...children) {
+  return { type, props: props || {}, children };
+}
+export const Children = { toArray(value) { return Array.isArray(value) ? value : [value]; } };
+export function isValidElement(value) { return Boolean(value && value.type); }
+export class Component {}
+`;
+
+const REACT_DOM_CLIENT_MODULE = `
+function mount(container) {
+  document.documentElement.dataset.hydratedRoot = container.id;
+  container.innerHTML = '<div id="client-page">Client page</div>';
+  return { render() { mount(container); } };
+}
+export function createRoot(container) {
+  return { render() { mount(container); } };
+}
+export function hydrateRoot(container) {
+  return mount(container);
+}
+`;
+
+const ROUTER_MODULE = `
+const store = {
+  subscribe() { return () => {}; },
+  getHref() { return location.pathname + location.search + location.hash; },
+  notify() {},
+  navigate() { return Promise.resolve(); },
+  setNavigator() {}
+};
+export function RouterProvider({ children }) { return children; }
+export function useRouter() { return {}; }
+export function getNavigationStore() { return store; }
+`;
+
+const PAGE_CONTEXT_MODULE = `
+export function PageContextProvider({ children }) { return children; }
+`;
+
+const PAGE_MODULE = `
+export default function Page() { return null; }
+`;
+
+function javascript(source: string): Response {
+  return new Response(source, {
+    headers: { "content-type": "application/javascript; charset=utf-8" },
+  });
+}
+
+describe("Regression: release asset hydration preserves server layouts", () => {
+  it("mounts an isolated client page inside the server-owned page island", async () => {
+    const hydrationModule = generateProdHydrationModule();
+    const server = Deno.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      onListen() {},
+    }, (request) => {
+      const pathname = new URL(request.url).pathname;
+
+      if (pathname === "/") {
+        return new Response(HTML, {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        });
+      }
+      if (pathname === "/hydration-runtime.js") return javascript(hydrationModule);
+      if (pathname === "/react.js") return javascript(REACT_MODULE);
+      if (pathname === "/react-dom-client.js") return javascript(REACT_DOM_CLIENT_MODULE);
+      if (pathname === "/router.js") return javascript(ROUTER_MODULE);
+      if (pathname === "/context.js") return javascript(PAGE_CONTEXT_MODULE);
+      if (pathname === "/page.js") return javascript(PAGE_MODULE);
+
+      return new Response("Not found", { status: 404 });
+    });
+    const browser = await launchChromium();
+
+    try {
+      if (!browser) return;
+
+      const page = await browser.newPage();
+      const diagnostics = captureBrowserDiagnostics(page);
+      const { port } = server.addr as Deno.NetAddr;
+      const response = await page.goto(`http://127.0.0.1:${port}/`);
+
+      assertEquals(response?.status(), 200);
+      await page.waitForFunction(
+        () => document.documentElement.dataset.hydratedRoot !== undefined,
+        undefined,
+        { timeout: 5_000 },
+      );
+
+      assertEquals(
+        await page.evaluate(() => document.documentElement.dataset.hydratedRoot),
+        "veryfront-page-island",
+      );
+      assertEquals(await page.locator("#server-layout").count(), 1);
+      assertEquals(await page.locator("#client-page").textContent(), "Client page");
+      assertEquals(getBrowserDiagnosticMessages(diagnostics), []);
+    } finally {
+      await closeChromium(browser);
+      await server.shutdown();
+      await server.finished;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- hydrate isolated release-asset pages inside the server-owned page island
- return the concrete page URL that deployment readiness actually verifies
- add the release-asset browser regression to the required RSC browser task
- prepare framework release 0.1.1162

## Root cause
Release-asset modules bypass the RSC-module branch, but `isolatedClientPage` was incorrectly gated by that branch. Hydration therefore mounted at `#root` and replaced the server-rendered layout, including its full-height wrapper.

## Validation
- `deno task test:e2e:rsc-browser` (3 tests, 6 steps)
- deploy unit/integration tests (24 tests, 65 steps)
- proxy handler tests (59 steps)
- `deno task typecheck`
- `deno task lint`
- `deno task fmt:check`
- npm package build and supply-chain policy tests
- pre-push checks (2,693 tests, 21,933 steps)
- independent code review: no findings

The broad parallel test task completed 3,130 tests and encountered one unrelated temporary-working-directory race in the demo integration suite; that failed 13-step test passed immediately in isolation.