### PR TITLE
Restore compatible npm release after partial publish

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1163",
+  "version": "0.1.1164",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-observability-sentry/deno.json
+++ b/extensions/ext-observability-sentry/deno.json
@@ -6,7 +6,10 @@
     "extension": true,
     "capabilities": [
       { "type": "net:outbound", "hosts": ["*"] }
-    ]
+    ],
+    "npm": {
+      "publish": false
+    }
   },
   "imports": {
     "@sentry/deno": "npm:@sentry/deno@10.68.0",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1163";
+export const VERSION = "0.1.1164";


### PR DESCRIPTION
## Summary
- publish 0.1.1164 to restore one compatible version across the framework and established extension packages
- temporarily exclude `@veryfront/ext-observability-sentry` from npm publication until the package and trusted publisher are provisioned

## Root cause
Release 0.1.1163 published several extension packages before npm rejected the new Sentry package with E404. The root `veryfront` package therefore remained at 0.1.1162 while extension `latest` tags moved to 0.1.1163, causing fresh scaffolds to fail dependency resolution.

Failed release: https://github.com/veryfront/veryfront-code/actions/runs/30307704827

## Verification
- full pre-push gate: 2701 tests / 21934 steps passed
- `deno task build:npm`
- focused npm metadata and publication tests: 14 tests / 25 steps passed
- focused version/logger tests: 2 tests / 78 steps passed
- `deno task typecheck`
- `deno task lint`
- `deno fmt --check deno.json extensions/ext-observability-sentry/deno.json src/utils/version-constant.ts`
- computed publish set includes `veryfront` and excludes only the unprovisioned Sentry package
- `git diff --check`

## Follow-up
Provision `@veryfront/ext-observability-sentry` in npm and configure its trusted publisher, then remove `veryfront.npm.publish=false` in a later release.