### PR TITLE
Restore automated Sentry extension publication

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1164",
+  "version": "0.1.1165",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-observability-sentry/deno.json
+++ b/extensions/ext-observability-sentry/deno.json
@@ -6,10 +6,7 @@
     "extension": true,
     "capabilities": [
       { "type": "net:outbound", "hosts": ["*"] }
-    ],
-    "npm": {
-      "publish": false
-    }
+    ]
   },
   "imports": {
     "@sentry/deno": "npm:@sentry/deno@10.68.0",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1164";
+export const VERSION = "0.1.1165";


### PR DESCRIPTION
## Summary
- remove the temporary npm publication exclusion now that `@veryfront/ext-observability-sentry` exists publicly
- publish 0.1.1165 so the GitHub Actions trusted publisher is exercised for the new package
- keep framework and extension versions synchronized

## Context
The 0.1.1164 recovery intentionally skipped this package after npm rejected its first CI publication. The package has since been bootstrapped publicly and configured with a trusted publisher for `veryfront/veryfront-code`, workflow `cicd.yml`, environment `production`, and `npm publish` permission only.

## Verification
- full pre-push gate: 2701 tests / 21934 steps passed
- `deno task build:npm`, including `@veryfront/ext-observability-sentry`
- npm metadata and publication tests: 14 tests / 25 steps passed
- version/logger tests: 2 tests / 78 steps passed
- `deno task typecheck`
- `deno task lint`
- focused format check and `git diff --check`
- generated Sentry package is version 0.1.1165 with peer `veryfront ^0.1.1165`
- computed publish set includes `@veryfront/ext-observability-sentry`

## Release sequencing
Do not enqueue this PR until the 0.1.1164 recovery release has completed and registry versions are consistent. This avoids overlapping stable publications.