### PR TITLE
Release the completed first deploy experience

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1165",
+  "version": "0.1.1166",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1165";
+export const VERSION = "0.1.1166";


### PR DESCRIPTION
## Summary

- publish the merged default agent starter and first deploy improvements
- advance the root CLI and shared runtime version to `0.1.1166`
- keep the release diff limited to the canonical version sources

`veryfront@0.1.1165` was published from `81a0b56d`, before PR #3135 merged. npm versions are immutable, so a new patch release is required for the current `main` starter to reach `npm create veryfront@latest`.

## Verification

- `deno task build:npm`
- `deno test --config scripts/test.deno.json --allow-all scripts/build/npm-package-metadata.test.ts`
- `deno test --no-check --allow-all cli/commands/deploy/command.test.ts cli/commands/deploy/command.integration.test.ts`
- `deno task fmt:check`
- `deno task lint`
- `deno task typecheck`
- pre-push suite: 2,701 tests / 21,938 steps passed

## Post-release check

After publication, run the exact fresh `npm create veryfront@latest` to `npx veryfront deploy` flow and verify the protected production page, full-height layout, assets, console, and network requests with `agent-browser`.