### PR TITLE
Keep local project identity explicit and restore pull prompts

### DIFF
--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -448,7 +448,7 @@ it("models an inferred missing project during dry-run deploy", async () => {
         quiet: true,
       }));
 
-    assertEquals(requests, ["GET /api/projects/missing-app"]);
+    assertEquals(requests, []);
   } finally {
     envKeys.forEach((key, index) => {
       const value = savedEnv[index];
@@ -526,6 +526,7 @@ it("uses an alternative slug when inferred first deploy project creation conflic
   const savedEnv = envKeys.map((key) => Deno.env.get(key));
   const createSlugs: string[] = [];
   let environmentUrlReads = 0;
+  let inferredProjectLookups = 0;
 
   try {
     await Deno.writeTextFile(`${projectDir}/.gitignore`, ".veryfront/\n");
@@ -554,6 +555,7 @@ it("uses an alternative slug when inferred first deploy project creation conflic
         return new Response("ready");
       }
       if (request.method === "GET" && url.pathname === "/api/projects/taken-app") {
+        inferredProjectLookups++;
         return Response.json({ message: "not found" }, { status: 404 });
       }
       if (request.method === "POST" && url.pathname === "/api/projects") {
@@ -562,7 +564,7 @@ it("uses an alternative slug when inferred first deploy project creation conflic
         if (body.slug === "taken-app") {
           return Response.json({ error: "taken" }, { status: 409 });
         }
-        assertEquals(/^taken-app-[a-z0-9]+$/.test(body.slug), true);
+        assertEquals(/^taken-app-[a-z0-9]{6}$/.test(body.slug), true);
         await writePushReceipt(projectDir, {
           controlPlane: "https://control.example.test/api",
           projectId: PROJECT_ID,
@@ -671,9 +673,10 @@ it("uses an alternative slug when inferred first deploy project creation conflic
       }));
 
     assertEquals(createSlugs.length, 2);
+    assertEquals(inferredProjectLookups, 0);
     assertEquals(environmentUrlReads, 0);
     assertEquals(createSlugs[0], "taken-app");
-    assertEquals(/^taken-app-[a-z0-9]+$/.test(createSlugs[1] ?? ""), true);
+    assertEquals(/^taken-app-[a-z0-9]{6}$/.test(createSlugs[1] ?? ""), true);
     const linkedConfig = JSON.parse(await Deno.readTextFile(`${projectDir}/veryfront.json`)) as {
       projectSlug?: string;
     };

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -15,7 +15,6 @@ import { type EnvironmentConfig, getConfig, getEnvironmentConfig } from "veryfro
 import {
   type ApiClient,
   createApiClient,
-  readConfigFile,
   resolveConfigWithAuth,
   resolveConfigWithAuthDetails,
   type ResolvedConfig,
@@ -864,8 +863,6 @@ async function ensureProjectLinkedForDeploy(
 }> {
   const details = await resolveConfigWithAuthDetails(projectDir, env);
   const initial = details.config;
-  const configFile = await readConfigFile(projectDir);
-  const hasPersistedSlug = Boolean(configFile?.projectSlug);
   const isInferredReference = details.projectReferenceSource.kind === "inferred";
   const projectReference = isInferredReference
     ? normalizeProjectSlug(initial.projectSlug || await inferDeployProjectSlug(projectDir))
@@ -873,29 +870,25 @@ async function ensureProjectLinkedForDeploy(
   const config = { ...initial, projectSlug: projectReference };
   const client = createApiClient(config);
 
-  try {
-    const project = await getProject(client, projectReference);
-    if (isInferredReference && !hasPersistedSlug && !dryRun) {
-      await writeProjectSlug(projectDir, project.slug);
-      if (!quiet && isVerbose()) logInfo(`Linked project ${project.slug}`);
-    }
-    return {
-      config: { ...config, projectSlug: project.slug },
-      client,
-      project,
-      plannedProjectSlug: project.slug,
-    };
-  } catch (error) {
-    if (getErrorStatus(error) !== 404) {
-      throw new Error(
-        `Could not check project "${projectReference}": ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
-  }
-
   if (!isInferredReference) {
+    try {
+      const project = await getProject(client, projectReference);
+      return {
+        config: { ...config, projectSlug: project.slug },
+        client,
+        project,
+        plannedProjectSlug: project.slug,
+      };
+    } catch (error) {
+      if (getErrorStatus(error) !== 404) {
+        throw new Error(
+          `Could not check project "${projectReference}": ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+
     throw new Error(
       `Project "${projectReference}" was not found. Check the project reference or remove it to let deploy create a project for this directory.`,
     );

--- a/cli/commands/dev/command.ts
+++ b/cli/commands/dev/command.ts
@@ -13,7 +13,7 @@ import { validateProviderConfig } from "veryfront/discovery";
 import { yellow } from "#cli/ui";
 import { exitProcess, registerTerminationSignals } from "#cli/utils";
 import { brand, dim, error as errorColor, success } from "#cli/ui";
-import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
+import { applyRuntimeAuthContext, resolveLinkedProjectSlug } from "#cli/shared/runtime-auth";
 import { createKeyboardHandler, type KeyboardHandler } from "../../ui/keyboard.ts";
 import { openBrowser } from "../../auth/browser.ts";
 import { createMCPServer, type MCPDevServer } from "../../mcp/server.ts";
@@ -96,9 +96,12 @@ export function devCommand(options: DevOptions): Promise<DevCommandResult> {
 
       const env = getEnvironmentConfig();
       const isProxyMode = config?.fs?.veryfront?.proxyMode === true;
-      const runtimeAuth = await applyRuntimeAuthContext({
+      const linkedProjectSlug = await resolveLinkedProjectSlug(
         projectDir,
-        projectSlug: config?.fs?.veryfront?.projectSlug ?? env.projectSlug,
+        config?.projectSlug ?? config?.fs?.veryfront?.projectSlug ?? env.projectSlug,
+      );
+      const runtimeAuth = await applyRuntimeAuthContext({
+        linkedProjectSlug,
       });
       // Validate provider config and print warnings (framework returns plain text, CLI adds colors)
       const aiValidation = validateProviderConfig(config);

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -52,6 +52,7 @@ import { parseEvalArgs } from "./handler.ts";
 const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
 const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
 const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
+const originalServiceLayer = Deno.env.get("VERYFRONT_SERVICE_LAYER");
 const originalXdgConfigHome = Deno.env.get("XDG_CONFIG_HOME");
 const originalEvalExport = Deno.env.get("VERYFRONT_EVAL_EXPORT");
 const originalEvalExporters = Deno.env.get("VERYFRONT_EVAL_EXPORTERS");
@@ -82,6 +83,12 @@ function restoreEnv(): void {
     Deno.env.delete("VERYFRONT_PROJECT_SLUG");
   } else {
     Deno.env.set("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
+  }
+
+  if (originalServiceLayer === undefined) {
+    Deno.env.delete("VERYFRONT_SERVICE_LAYER");
+  } else {
+    Deno.env.set("VERYFRONT_SERVICE_LAYER", originalServiceLayer);
   }
 
   if (originalApiBaseUrl === undefined) {
@@ -1511,6 +1518,7 @@ describe("eval CLI command helpers", () => {
     try {
       Deno.env.delete("VERYFRONT_API_TOKEN");
       Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_SERVICE_LAYER");
       Deno.env.set("XDG_CONFIG_HOME", configHome);
       await saveToken("stored-token");
 
@@ -1520,6 +1528,7 @@ describe("eval CLI command helpers", () => {
 
       assertEquals(Deno.env.get("VERYFRONT_API_TOKEN"), "stored-token");
       assertEquals(Deno.env.get("VERYFRONT_PROJECT_SLUG"), "configured-eval-project");
+      assertEquals(Deno.env.get("VERYFRONT_SERVICE_LAYER"), "cloud");
     } finally {
       await Deno.remove(projectDir, { recursive: true });
       await Deno.remove(configHome, { recursive: true });

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -38,7 +38,7 @@ import {
   getVeryfrontCloudBootstrap,
   runWithVeryfrontCloudContextAsync,
 } from "veryfront/provider";
-import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
+import { applyRuntimeAuthContext, resolveLinkedProjectSlug } from "#cli/shared/runtime-auth";
 import { cliLogger, exitProcess, VERSION } from "#cli/utils";
 import {
   discoverProjectAgentRuntime,
@@ -567,8 +567,10 @@ export async function hydrateEvalRuntimeAuth(
   config: EvalRuntimeAuthConfig | null | undefined,
 ) {
   return await applyRuntimeAuthContext({
-    projectDir,
-    projectSlug: resolveEvalRuntimeProjectSlug(config),
+    linkedProjectSlug: await resolveLinkedProjectSlug(
+      projectDir,
+      resolveEvalRuntimeProjectSlug(config),
+    ),
   });
 }
 

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -860,7 +860,7 @@ describe("push receipt source snapshot", () => {
     });
   });
 
-  it("persists an inferred existing-project slug before uploading files", async () => {
+  it("creates a new project instead of linking an inferred existing-project slug", async () => {
     const originalFetch = globalThis.fetch;
     const envKeys = [
       "VERYFRONT_API_TOKEN",
@@ -874,6 +874,9 @@ describe("push receipt source snapshot", () => {
     const savedEnv = envKeys.map((key) => Deno.env.get(key));
 
     await withGitProject(async ({ projectDir }) => {
+      const createSlugs: string[] = [];
+      let reservedSlug = "";
+
       try {
         Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
         Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
@@ -889,12 +892,24 @@ describe("push receipt source snapshot", () => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
 
-          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+          if (request.method === "POST" && url.pathname === "/projects") {
+            const body = await request.json() as { slug: string };
+            createSlugs.push(body.slug);
+            if (body.slug === "my-project") {
+              return Response.json({ error: "slug taken" }, { status: 409 });
+            }
+            reservedSlug = body.slug;
+            return Response.json({ id: "project-123" }, { status: 201 });
+          }
+          if (
+            request.method === "GET" &&
+            url.pathname === `/projects/${reservedSlug}/files`
+          ) {
             return Response.json({ data: [], page_info: {} });
           }
           if (
             request.method === "PUT" &&
-            url.pathname.startsWith("/projects/my-project/files/")
+            url.pathname.startsWith(`/projects/${reservedSlug}/files/`)
           ) {
             return Response.json({ error: "upload failed" }, { status: 500 });
           }
@@ -909,7 +924,10 @@ describe("push receipt source snapshot", () => {
         );
 
         const config = JSON.parse(await Deno.readTextFile(`${projectDir}/veryfront.json`));
-        assertEquals(config.projectSlug, "my-project");
+        assertEquals(createSlugs[0], "my-project");
+        assertEquals(createSlugs.length, 2);
+        assertEquals(/^my-project-[a-z0-9]{6}$/.test(reservedSlug), true);
+        assertEquals(config.projectSlug, reservedSlug);
       } finally {
         globalThis.fetch = originalFetch;
         envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -860,6 +860,126 @@ describe("push receipt source snapshot", () => {
     });
   });
 
+  it("persists an inferred existing-project slug before uploading files", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = [
+      "VERYFRONT_API_TOKEN",
+      "VERYFRONT_API_URL",
+      "VERYFRONT_API_BASE_URL",
+      "VERYFRONT_PROJECT_SLUG",
+      "TENANT_PROJECT_SLUG",
+      "VERYFRONT_PROJECT_ID",
+      "TENANT_PROJECT_ID",
+    ];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    await withGitProject(async ({ projectDir }) => {
+      try {
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.delete("VERYFRONT_API_BASE_URL");
+        for (const key of envKeys.slice(3)) Deno.env.delete(key);
+        await Deno.writeTextFile(
+          `${projectDir}/package.json`,
+          `${JSON.stringify({ name: "my-project" }, null, 2)}\n`,
+        );
+        _resetEnvironmentConfig();
+
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+
+          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+            return Response.json({ data: [], page_info: {} });
+          }
+          if (
+            request.method === "PUT" &&
+            url.pathname.startsWith("/projects/my-project/files/")
+          ) {
+            return Response.json({ error: "upload failed" }, { status: 500 });
+          }
+
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        }) as typeof fetch;
+
+        await assertRejects(
+          () => pushCommand({ projectDir, quiet: true }),
+          Error,
+          "failed",
+        );
+
+        const config = JSON.parse(await Deno.readTextFile(`${projectDir}/veryfront.json`));
+        assertEquals(config.projectSlug, "my-project");
+      } finally {
+        globalThis.fetch = originalFetch;
+        envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+        _resetEnvironmentConfig();
+      }
+    });
+  });
+
+  it("persists an accepted inferred slug before uploading project files", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = [
+      "VERYFRONT_API_TOKEN",
+      "VERYFRONT_API_URL",
+      "VERYFRONT_API_BASE_URL",
+      "VERYFRONT_PROJECT_SLUG",
+      "TENANT_PROJECT_SLUG",
+      "VERYFRONT_PROJECT_ID",
+      "TENANT_PROJECT_ID",
+    ];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    await withGitProject(async ({ projectDir }) => {
+      try {
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.delete("VERYFRONT_API_BASE_URL");
+        for (const key of envKeys.slice(3)) Deno.env.delete(key);
+        await Deno.writeTextFile(
+          `${projectDir}/package.json`,
+          `${JSON.stringify({ name: "my-project" }, null, 2)}\n`,
+        );
+        _resetEnvironmentConfig();
+
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+
+          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+            return Response.json({ error: "not found" }, { status: 404 });
+          }
+          if (request.method === "POST" && url.pathname === "/projects") {
+            assertEquals((await request.json() as { slug: string }).slug, "my-project");
+            return Response.json({ id: "project-123" }, { status: 201 });
+          }
+          if (
+            request.method === "PUT" &&
+            url.pathname.startsWith("/projects/my-project/files/")
+          ) {
+            return Response.json({ error: "upload failed" }, { status: 500 });
+          }
+
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        }) as typeof fetch;
+
+        await assertRejects(
+          () => pushCommand({ projectDir, quiet: true }),
+          Error,
+          "failed",
+        );
+
+        const config = JSON.parse(await Deno.readTextFile(`${projectDir}/veryfront.json`));
+        assertEquals(config.projectSlug, "my-project");
+      } finally {
+        globalThis.fetch = originalFetch;
+        envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+        _resetEnvironmentConfig();
+      }
+    });
+  });
+
   it("does not reserve alternative projects for explicit slug sources", async () => {
     const originalFetch = globalThis.fetch;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -618,6 +618,9 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       let projectExists = true;
       try {
         mainFiles = await listAllFiles(client, config.projectSlug, { type: "main" });
+        if (!dryRun && projectReferenceSource.kind === "inferred") {
+          await writeProjectSlug(projectDir, config.projectSlug);
+        }
       } catch (error) {
         // Project doesn't exist yet - create it on first push
         if (getErrorStatus(error) === 404) {
@@ -646,9 +649,17 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               }
               throw reserveError;
             }
-            if (reserveResult.slug !== config.projectSlug) {
+            if (
+              projectReferenceSource.kind === "inferred" ||
+              reserveResult.slug !== config.projectSlug
+            ) {
               await writeProjectSlug(projectDir, reserveResult.slug);
-              if (!quiet && !jsonOutput) logInfo(`Project slug: ${reserveResult.slug}`);
+              if (
+                reserveResult.slug !== config.projectSlug &&
+                !quiet && !jsonOutput
+              ) {
+                logInfo(`Project slug: ${reserveResult.slug}`);
+              }
             }
             config = { ...config, projectSlug: reserveResult.slug };
             // Now try to get files again (should be empty for new project)

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -613,65 +613,64 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       const branchName = branch;
       const isMainBranch = branchName === "main";
 
-      // First-push: If project doesn't exist on server yet, create it unless this is a dry run.
       let mainFiles: RemoteFile[] = [];
       let projectExists = true;
-      try {
-        mainFiles = await listAllFiles(client, config.projectSlug, { type: "main" });
-        if (!dryRun && projectReferenceSource.kind === "inferred") {
-          await writeProjectSlug(projectDir, config.projectSlug);
-        }
-      } catch (error) {
-        // Project doesn't exist yet - create it on first push
-        if (getErrorStatus(error) === 404) {
-          if (dryRun) {
-            projectExists = false;
-            if (!quiet && !jsonOutput) {
-              logInfo(
-                `Project "${config.projectSlug}" does not exist. Dry run will not create it.`,
-              );
-            }
-          } else {
-            spinner.update("Creating project...");
-            let reserveResult: Awaited<ReturnType<typeof reserveProjectSlug>>;
-            try {
-              reserveResult = await reserveProjectSlug(
-                config.projectSlug,
-                config.apiToken,
-                undefined,
-                config.apiUrl,
-                { allowAlternativeSlug: canPersistAlternativeSlug(projectReferenceSource) },
-              );
-            } catch (reserveError) {
-              spinner.stop();
-              if (reserveError instanceof ProjectSlugConflictError) {
-                throw projectSlugConflictError(reserveError, projectReferenceSource);
-              }
-              throw reserveError;
-            }
-            if (
-              projectReferenceSource.kind === "inferred" ||
-              reserveResult.slug !== config.projectSlug
-            ) {
-              await writeProjectSlug(projectDir, reserveResult.slug);
-              if (
-                reserveResult.slug !== config.projectSlug &&
-                !quiet && !jsonOutput
-              ) {
-                logInfo(`Project slug: ${reserveResult.slug}`);
-              }
-            }
-            config = { ...config, projectSlug: reserveResult.slug };
-            // Now try to get files again (should be empty for new project)
-            try {
-              mainFiles = await listAllFiles(client, config.projectSlug, { type: "main" });
-            } catch {
-              // Project just created, no files yet
-              mainFiles = [];
-            }
+
+      const createProject = async (): Promise<void> => {
+        spinner.update("Creating project...");
+        let reserveResult: Awaited<ReturnType<typeof reserveProjectSlug>>;
+        try {
+          reserveResult = await reserveProjectSlug(
+            config.projectSlug,
+            config.apiToken,
+            undefined,
+            config.apiUrl,
+            { allowAlternativeSlug: canPersistAlternativeSlug(projectReferenceSource) },
+          );
+        } catch (reserveError) {
+          spinner.stop();
+          if (reserveError instanceof ProjectSlugConflictError) {
+            throw projectSlugConflictError(reserveError, projectReferenceSource);
           }
-        } else {
-          throw error;
+          throw reserveError;
+        }
+        if (
+          projectReferenceSource.kind === "inferred" ||
+          reserveResult.slug !== config.projectSlug
+        ) {
+          await writeProjectSlug(projectDir, reserveResult.slug);
+          if (
+            reserveResult.slug !== config.projectSlug &&
+            !quiet && !jsonOutput
+          ) {
+            logInfo(`Project slug: ${reserveResult.slug}`);
+          }
+        }
+        config = { ...config, projectSlug: reserveResult.slug };
+        try {
+          mainFiles = await listAllFiles(client, config.projectSlug, { type: "main" });
+        } catch {
+          mainFiles = [];
+        }
+      };
+
+      const planProjectCreation = (): void => {
+        projectExists = false;
+        if (!quiet && !jsonOutput) {
+          logInfo(`Project "${config.projectSlug}" will be created on push.`);
+        }
+      };
+
+      if (projectReferenceSource.kind === "inferred") {
+        if (dryRun) planProjectCreation();
+        else await createProject();
+      } else {
+        try {
+          mainFiles = await listAllFiles(client, config.projectSlug, { type: "main" });
+        } catch (error) {
+          if (getErrorStatus(error) !== 404) throw error;
+          if (dryRun) planProjectCreation();
+          else await createProject();
         }
       }
 

--- a/cli/commands/start/command.test.ts
+++ b/cli/commands/start/command.test.ts
@@ -1,12 +1,41 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { readTextFile } from "veryfront/platform";
-import { selectStartProject, shouldSkipProjectDirectory, startCommand } from "./command.ts";
+import { saveToken } from "../../auth/token-store.ts";
+import {
+  hydrateStartRuntimeAuth,
+  selectStartProject,
+  shouldSkipProjectDirectory,
+  startCommand,
+} from "./command.ts";
 import { startHelp } from "./command-help.ts";
 import type { StartOptions } from "./command.ts";
 
+const ENV_KEYS = [
+  "VERYFRONT_API_TOKEN",
+  "VERYFRONT_PROJECT_SLUG",
+  "VERYFRONT_SERVICE_LAYER",
+  "XDG_CONFIG_HOME",
+] as const;
+const originalEnv = new Map(ENV_KEYS.map((key) => [key, Deno.env.get(key)]));
+let tempDirs: string[] = [];
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, value);
+  }
+}
+
 describe("commands/start/command", () => {
+  afterEach(async () => {
+    restoreEnv();
+    await Promise.all(tempDirs.map((dir) => Deno.remove(dir, { recursive: true })));
+    tempDirs = [];
+  });
+
   describe("startCommand", () => {
     it("is exported as a function", () => {
       assertExists(startCommand);
@@ -121,6 +150,48 @@ describe("commands/start/command", () => {
         projectDir: "/repo",
         projectSlug: undefined,
       });
+    });
+  });
+
+  describe("hydrateStartRuntimeAuth", () => {
+    async function setupProject(): Promise<string> {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-start-project-" });
+      const configHome = await Deno.makeTempDir({ prefix: "vf-start-config-" });
+      tempDirs.push(projectDir, configHome);
+      for (const key of ENV_KEYS) Deno.env.delete(key);
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+      await saveToken("stored-token");
+      return projectDir;
+    }
+
+    it("does not turn a discovered directory slug into cloud authorization scope", async () => {
+      const projectDir = await setupProject();
+
+      const linkedProjectSlug = await hydrateStartRuntimeAuth({
+        projectDir,
+        projectSlug: "directory-slug",
+      });
+
+      assertEquals(linkedProjectSlug, undefined);
+      assertEquals(Deno.env.get("VERYFRONT_API_TOKEN"), "stored-token");
+      assertEquals(Deno.env.get("VERYFRONT_PROJECT_SLUG"), undefined);
+      assertEquals(Deno.env.get("VERYFRONT_SERVICE_LAYER"), "cloud");
+    });
+
+    it("uses a persisted project link for cloud authorization scope", async () => {
+      const projectDir = await setupProject();
+      await Deno.writeTextFile(
+        `${projectDir}/veryfront.json`,
+        JSON.stringify({ projectSlug: "linked-project" }),
+      );
+
+      const linkedProjectSlug = await hydrateStartRuntimeAuth({
+        projectDir,
+        projectSlug: "directory-slug",
+      });
+
+      assertEquals(linkedProjectSlug, "linked-project");
+      assertEquals(Deno.env.get("VERYFRONT_PROJECT_SLUG"), "linked-project");
     });
   });
 

--- a/cli/commands/start/command.ts
+++ b/cli/commands/start/command.ts
@@ -250,7 +250,6 @@ export async function startCommand(options: StartOptions): Promise<void> {
       projectDir,
       signal: shutdownController.signal,
       requestInterceptor,
-      defaultProjectSlug: linkedProjectSlug,
       defaultProjectId,
       linkedProjectSlug,
     });

--- a/cli/commands/start/command.ts
+++ b/cli/commands/start/command.ts
@@ -6,7 +6,7 @@ import { exitProcess, registerTerminationSignals } from "#cli/utils";
 import { generateDefaultProjectId } from "../../utils/project.ts";
 import { clearAllLocalCaches } from "veryfront/transforms/mdx-cache";
 import { startCliDevServer, startCliProxyModeServer } from "#cli/shared/server-startup";
-import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
+import { applyRuntimeAuthContext, resolveLinkedProjectSlug } from "#cli/shared/runtime-auth";
 
 const logger = cliLogger.component("global");
 
@@ -127,6 +127,14 @@ export function selectStartProject(
   return { projectDir: fallbackDir, projectSlug: undefined };
 }
 
+export async function hydrateStartRuntimeAuth(
+  selectedProject: StartProjectSelection,
+): Promise<string | undefined> {
+  const linkedProjectSlug = await resolveLinkedProjectSlug(selectedProject.projectDir);
+  await applyRuntimeAuthContext({ linkedProjectSlug });
+  return linkedProjectSlug;
+}
+
 async function trySetupProxy(localProjects: Map<string, string>): Promise<ProxySetup> {
   try {
     // Proxy is only available in local dev, not in the npm package
@@ -224,11 +232,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   const selectedProject = selectStartProject(discovered, cwd());
   const projectDir = selectedProject.projectDir;
-  const runtimeAuth = await applyRuntimeAuthContext({
-    projectDir,
-    projectSlug: selectedProject.projectSlug,
-  });
-  const fallbackProjectSlug = runtimeAuth.projectSlug;
+  const linkedProjectSlug = await hydrateStartRuntimeAuth(selectedProject);
 
   const allProjects = new Map([...discovered.projects, ...discovered.examples]);
   const proxy = await trySetupProxy(allProjects);
@@ -246,9 +250,9 @@ export async function startCommand(options: StartOptions): Promise<void> {
       projectDir,
       signal: shutdownController.signal,
       requestInterceptor,
-      defaultProjectSlug: defaultProjectId,
+      defaultProjectSlug: linkedProjectSlug,
       defaultProjectId,
-      fallbackProjectSlug,
+      linkedProjectSlug,
     });
   } else {
     server = await startCliDevServer({

--- a/cli/shared/project-source-context.test.ts
+++ b/cli/shared/project-source-context.test.ts
@@ -12,6 +12,7 @@ import {
 const ENV_KEYS = [
   "VERYFRONT_PROJECT_SLUG",
   "VERYFRONT_API_TOKEN",
+  "VERYFRONT_SERVICE_LAYER",
   "VERYFRONT_PROJECT_ID",
   "VERYFRONT_BRANCH_REF",
   "TENANT_BRANCH_ID",
@@ -77,6 +78,7 @@ describe("project source runtime auth", () => {
     try {
       Deno.env.delete("VERYFRONT_API_TOKEN");
       Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_SERVICE_LAYER");
       Deno.env.set("XDG_CONFIG_HOME", configHome);
       await saveToken("stored-token");
 
@@ -88,6 +90,7 @@ describe("project source runtime auth", () => {
 
       assertEquals(Deno.env.get("VERYFRONT_API_TOKEN"), "stored-token");
       assertEquals(Deno.env.get("VERYFRONT_PROJECT_SLUG"), "configured-fs-project");
+      assertEquals(Deno.env.get("VERYFRONT_SERVICE_LAYER"), "cloud");
     } finally {
       await Deno.remove(projectDir, { recursive: true });
       await Deno.remove(configHome, { recursive: true });
@@ -101,6 +104,7 @@ describe("project source runtime auth", () => {
     try {
       Deno.env.delete("VERYFRONT_API_TOKEN");
       Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_SERVICE_LAYER");
       Deno.env.set("XDG_CONFIG_HOME", configHome);
       await saveToken("stored-token");
       await Deno.writeTextFile(

--- a/cli/shared/project-source-context.ts
+++ b/cli/shared/project-source-context.ts
@@ -6,7 +6,7 @@ import {
   runtime,
   type RuntimeAdapter,
 } from "veryfront/platform";
-import { applyRuntimeAuthContext } from "./runtime-auth.ts";
+import { applyRuntimeAuthContext, resolveLinkedProjectSlug } from "./runtime-auth.ts";
 
 interface ProxyProjectSourceContext {
   projectSlug: string;
@@ -64,8 +64,10 @@ export async function applyProjectSourceRuntimeAuth(
   config: VeryfrontConfig,
 ) {
   return await applyRuntimeAuthContext({
-    projectDir,
-    projectSlug: config.projectSlug ?? config.fs?.veryfront?.projectSlug,
+    linkedProjectSlug: await resolveLinkedProjectSlug(
+      projectDir,
+      config.projectSlug ?? config.fs?.veryfront?.projectSlug,
+    ),
   });
 }
 

--- a/cli/shared/runtime-auth.test.ts
+++ b/cli/shared/runtime-auth.test.ts
@@ -1,14 +1,20 @@
+import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { deleteEnv, getEnv, setEnv } from "#veryfront/compat/process.ts";
 import { saveToken } from "../auth/token-store.ts";
 import {
   applyRuntimeAuthContext,
-  inferRuntimeProjectSlug,
+  resolveLinkedProjectSlug,
   resolveRuntimeAuthContext,
 } from "./runtime-auth.ts";
 
-const ENV_KEYS = ["VERYFRONT_API_TOKEN", "VERYFRONT_PROJECT_SLUG", "XDG_CONFIG_HOME"] as const;
+const ENV_KEYS = [
+  "VERYFRONT_API_TOKEN",
+  "VERYFRONT_PROJECT_SLUG",
+  "VERYFRONT_SERVICE_LAYER",
+  "XDG_CONFIG_HOME",
+] as const;
 let tempDirs: string[] = [];
 
 function clearEnv(): void {
@@ -41,52 +47,76 @@ describe("cli/shared/runtime-auth", () => {
     tempDirs = [];
   });
 
-  it("infers a project slug from the project directory", () => {
-    assertEquals(inferRuntimeProjectSlug("/workspace/My Test"), "my-test");
-  });
-
   it("prefers explicit environment auth over the token store", async () => {
     await useTempConfigHome();
     await saveToken("stored-token");
     setEnv("VERYFRONT_API_TOKEN", "env-token");
     setEnv("VERYFRONT_PROJECT_SLUG", "env-project");
+    setEnv("VERYFRONT_SERVICE_LAYER", "local");
 
     const context = await resolveRuntimeAuthContext({
-      projectDir: "/workspace/my-test",
-      projectSlug: "config-project",
+      linkedProjectSlug: "config-project",
     });
 
     assertEquals(context, {
       apiToken: "env-token",
       projectSlug: "env-project",
+      serviceLayer: "local",
     });
   });
 
-  it("uses the stored login token when runtime env auth is absent", async () => {
+  it("uses stored login auth without claiming an unlinked project", async () => {
+    await useTempConfigHome();
+    await saveToken("stored-token");
+
+    const context = await applyRuntimeAuthContext({});
+
+    assertEquals(context, {
+      apiToken: "stored-token",
+      serviceLayer: "cloud",
+    });
+    assertEquals(getEnv("VERYFRONT_API_TOKEN"), "stored-token");
+    assertEquals(getEnv("VERYFRONT_PROJECT_SLUG"), undefined);
+    assertEquals(getEnv("VERYFRONT_SERVICE_LAYER"), "cloud");
+  });
+
+  it("keeps an explicitly linked project scoped to cloud requests", async () => {
     await useTempConfigHome();
     await saveToken("stored-token");
 
     const context = await applyRuntimeAuthContext({
-      projectDir: "/workspace/My Test",
+      linkedProjectSlug: "linked-project",
     });
 
     assertEquals(context, {
       apiToken: "stored-token",
-      projectSlug: "my-test",
+      projectSlug: "linked-project",
+      serviceLayer: "cloud",
     });
-    assertEquals(getEnv("VERYFRONT_API_TOKEN"), "stored-token");
-    assertEquals(getEnv("VERYFRONT_PROJECT_SLUG"), "my-test");
+    assertEquals(getEnv("VERYFRONT_PROJECT_SLUG"), "linked-project");
   });
 
-  it("does not inject an inferred project slug without a token", async () => {
+  it("reads the persisted project link without inferring from the directory name", async () => {
+    const linkedDir = await Deno.makeTempDir({ prefix: "vf-linked-project-" });
+    const unlinkedDir = await Deno.makeTempDir({ prefix: "vf-unlinked-project-" });
+    tempDirs.push(linkedDir, unlinkedDir);
+    await Deno.writeTextFile(
+      `${linkedDir}/veryfront.json`,
+      JSON.stringify({ projectSlug: "persisted-project" }),
+    );
+
+    assertEquals(await resolveLinkedProjectSlug(linkedDir), "persisted-project");
+    assertEquals(await resolveLinkedProjectSlug(unlinkedDir), undefined);
+  });
+
+  it("does not inject project or service-layer auth without a token", async () => {
     await useTempConfigHome();
 
-    const context = await applyRuntimeAuthContext({
-      projectDir: "/workspace/my-test",
-    });
+    const context = await applyRuntimeAuthContext({});
 
-    assertEquals(context, { projectSlug: "my-test" });
+    assertEquals(context, {});
     assertEquals(getEnv("VERYFRONT_API_TOKEN"), undefined);
     assertEquals(getEnv("VERYFRONT_PROJECT_SLUG"), undefined);
+    assertEquals(getEnv("VERYFRONT_SERVICE_LAYER"), undefined);
   });
 });

--- a/cli/shared/runtime-auth.ts
+++ b/cli/shared/runtime-auth.ts
@@ -1,15 +1,15 @@
 import { getEnv, setEnv } from "veryfront/platform";
-import { basename } from "veryfront/platform/path";
 import { readToken } from "../auth/token-store.ts";
+import { readConfigFile } from "./config.ts";
 
 export interface RuntimeAuthOptions {
-  projectDir: string;
-  projectSlug?: string;
+  linkedProjectSlug?: string;
 }
 
 export interface RuntimeAuthContext {
   apiToken?: string;
   projectSlug?: string;
+  serviceLayer?: string;
 }
 
 function normalizeEnvValue(value: string | undefined): string | undefined {
@@ -17,10 +17,14 @@ function normalizeEnvValue(value: string | undefined): string | undefined {
   return normalized ? normalized : undefined;
 }
 
-export function inferRuntimeProjectSlug(projectDir: string): string | undefined {
-  const dirName = basename(projectDir).replace(/^@[^/]+[/\\]/, "");
-  const slug = dirName.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
-  return slug || undefined;
+export async function resolveLinkedProjectSlug(
+  projectDir: string,
+  configuredProjectSlug?: string,
+): Promise<string | undefined> {
+  const configured = normalizeEnvValue(configuredProjectSlug);
+  if (configured) return configured;
+
+  return normalizeEnvValue((await readConfigFile(projectDir))?.projectSlug);
 }
 
 export async function resolveRuntimeAuthContext(
@@ -31,12 +35,14 @@ export async function resolveRuntimeAuthContext(
   const apiToken = envToken ?? storedToken;
 
   const envProjectSlug = normalizeEnvValue(getEnv("VERYFRONT_PROJECT_SLUG"));
-  const projectSlug = envProjectSlug ?? normalizeEnvValue(options.projectSlug) ??
-    inferRuntimeProjectSlug(options.projectDir);
+  const projectSlug = envProjectSlug ?? normalizeEnvValue(options.linkedProjectSlug);
+  const envServiceLayer = normalizeEnvValue(getEnv("VERYFRONT_SERVICE_LAYER"));
+  const serviceLayer = envServiceLayer ?? (apiToken ? "cloud" : undefined);
 
   return {
     ...(apiToken ? { apiToken } : {}),
     ...(projectSlug ? { projectSlug } : {}),
+    ...(serviceLayer ? { serviceLayer } : {}),
   };
 }
 
@@ -53,6 +59,13 @@ export async function applyRuntimeAuthContext(
     context.apiToken && context.projectSlug && !normalizeEnvValue(getEnv("VERYFRONT_PROJECT_SLUG"))
   ) {
     setEnv("VERYFRONT_PROJECT_SLUG", context.projectSlug);
+  }
+
+  if (
+    context.apiToken && context.serviceLayer &&
+    !normalizeEnvValue(getEnv("VERYFRONT_SERVICE_LAYER"))
+  ) {
+    setEnv("VERYFRONT_SERVICE_LAYER", context.serviceLayer);
   }
 
   return context;

--- a/cli/shared/server-startup.test.ts
+++ b/cli/shared/server-startup.test.ts
@@ -1,0 +1,60 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { buildDiscoveryConfig } from "./server-startup.ts";
+
+const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
+
+function restoreEnv(): void {
+  if (originalApiToken === undefined) {
+    Deno.env.delete("VERYFRONT_API_TOKEN");
+  } else {
+    Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+  }
+
+  if (originalProjectSlug === undefined) {
+    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+  } else {
+    Deno.env.set("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
+  }
+}
+
+describe("buildDiscoveryConfig", () => {
+  afterEach(restoreEnv);
+
+  it("does not scope an unlinked local project to its directory slug", () => {
+    Deno.env.set("VERYFRONT_API_TOKEN", "stored-token");
+    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+
+    const config = buildDiscoveryConfig({
+      port: 3000,
+      projectDir: "/tmp/my-agent",
+      signal: new AbortController().signal,
+      requestInterceptor: (request: Request) => request,
+      defaultProjectSlug: undefined,
+      defaultProjectId: "local-my-agent",
+      linkedProjectSlug: undefined,
+    });
+
+    assertEquals(config.projectSlug, undefined);
+    assertEquals(config.apiToken, "stored-token");
+  });
+
+  it("uses a persisted project link for cloud discovery", () => {
+    Deno.env.set("VERYFRONT_API_TOKEN", "stored-token");
+    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+
+    const config = buildDiscoveryConfig({
+      port: 3000,
+      projectDir: "/tmp/my-agent",
+      signal: new AbortController().signal,
+      requestInterceptor: (request: Request) => request,
+      defaultProjectSlug: "linked-project",
+      defaultProjectId: "local-my-agent",
+      linkedProjectSlug: "linked-project",
+    });
+
+    assertEquals(config.projectSlug, "linked-project");
+  });
+});

--- a/cli/shared/server-startup.test.ts
+++ b/cli/shared/server-startup.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { buildDiscoveryConfig } from "./server-startup.ts";
+import { buildDiscoveryConfig, buildProxyRuntimeProjectIdentity } from "./server-startup.ts";
 
 const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
 const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
@@ -32,7 +32,6 @@ describe("buildDiscoveryConfig", () => {
       projectDir: "/tmp/my-agent",
       signal: new AbortController().signal,
       requestInterceptor: (request: Request) => request,
-      defaultProjectSlug: undefined,
       defaultProjectId: "local-my-agent",
       linkedProjectSlug: undefined,
     });
@@ -50,11 +49,25 @@ describe("buildDiscoveryConfig", () => {
       projectDir: "/tmp/my-agent",
       signal: new AbortController().signal,
       requestInterceptor: (request: Request) => request,
-      defaultProjectSlug: "linked-project",
       defaultProjectId: "local-my-agent",
       linkedProjectSlug: "linked-project",
     });
 
     assertEquals(config.projectSlug, "linked-project");
+  });
+});
+
+describe("buildProxyRuntimeProjectIdentity", () => {
+  it("keeps the standalone slug paired with its local project id", () => {
+    assertEquals(
+      buildProxyRuntimeProjectIdentity({
+        defaultProjectId: "local-my-agent",
+        linkedProjectSlug: "linked-project",
+      }),
+      {
+        defaultProjectSlug: "local-my-agent",
+        defaultProjectId: "local-my-agent",
+      },
+    );
   });
 });

--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -24,14 +24,14 @@ export interface StartCliProxyModeServerOptions {
   projectDir: string;
   signal: AbortSignal;
   requestInterceptor: (req: Request) => Request | Promise<Request>;
-  defaultProjectSlug: string;
+  defaultProjectSlug?: string;
   defaultProjectId: string;
-  fallbackProjectSlug?: string;
+  linkedProjectSlug?: string;
 }
 
-function buildDiscoveryConfig(options: StartCliProxyModeServerOptions): DiscoveryOptions {
+export function buildDiscoveryConfig(options: StartCliProxyModeServerOptions): DiscoveryOptions {
   const token = getEnv("VERYFRONT_API_TOKEN") ?? "";
-  const slug = getEnv("VERYFRONT_PROJECT_SLUG") ?? options.fallbackProjectSlug ?? "";
+  const slug = getEnv("VERYFRONT_PROJECT_SLUG") ?? options.linkedProjectSlug ?? "";
 
   return {
     baseDir: options.projectDir,

--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -24,9 +24,17 @@ export interface StartCliProxyModeServerOptions {
   projectDir: string;
   signal: AbortSignal;
   requestInterceptor: (req: Request) => Request | Promise<Request>;
-  defaultProjectSlug?: string;
   defaultProjectId: string;
   linkedProjectSlug?: string;
+}
+
+export function buildProxyRuntimeProjectIdentity(
+  options: Pick<StartCliProxyModeServerOptions, "defaultProjectId" | "linkedProjectSlug">,
+): Pick<StartProductionServerOptions, "defaultProjectSlug" | "defaultProjectId"> {
+  return {
+    defaultProjectSlug: options.defaultProjectId,
+    defaultProjectId: options.defaultProjectId,
+  };
 }
 
 export function buildDiscoveryConfig(options: StartCliProxyModeServerOptions): DiscoveryOptions {
@@ -60,8 +68,7 @@ export async function startCliProxyModeServer(
     projectDir: options.projectDir,
     signal: options.signal,
     requestInterceptor: options.requestInterceptor,
-    defaultProjectSlug: options.defaultProjectSlug,
-    defaultProjectId: options.defaultProjectId,
+    ...buildProxyRuntimeProjectIdentity(options),
     discoveryConfig: buildDiscoveryConfig(options),
   });
   await ensureBuiltinContentProcessor();

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -7,6 +7,7 @@ import {
   onSignal,
   promptSync,
   readStdinByteSync,
+  readStdinLine,
   setRawMode,
   writeStdout,
 } from "veryfront/platform";
@@ -156,8 +157,12 @@ export async function promptUser(message: string): Promise<string> {
     });
   }
 
-  const input = promptSync(message);
-  return input?.trim() ?? "";
+  if (typeof globalThis.prompt === "function") {
+    return promptSync(message)?.trim() ?? "";
+  }
+
+  writeStdout(message);
+  return (await readStdinLine())?.trim() ?? "";
 }
 
 const CTRL_C = 0x03;

--- a/src/platform/compat/stdin.test.ts
+++ b/src/platform/compat/stdin.test.ts
@@ -1,7 +1,14 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createEscapeBuffer } from "./stdin.ts";
+import {
+  createEscapeBuffer,
+  createNodeStdinReader,
+  readStdinLine,
+  setNodeRawMode,
+  type StdinReader,
+  waitForNodeKeypress,
+} from "./stdin.ts";
 
 function createTestBuffer(timeouts: string[]): ReturnType<typeof createEscapeBuffer> {
   return createEscapeBuffer((key) => timeouts.push(key));
@@ -64,5 +71,191 @@ describe("createEscapeBuffer", () => {
 
     assertEquals(buffer.push("a"), "a");
     assertEquals(timeouts, []);
+  });
+});
+
+describe("readStdinLine", () => {
+  it("reads a line split across Node-style stdin chunks", async () => {
+    const encoder = new TextEncoder();
+    const chunks = [encoder.encode("y"), encoder.encode("es\r\nignored")];
+    let released = false;
+    const reader: StdinReader = {
+      read: () => {
+        const value = chunks.shift();
+        return Promise.resolve({ value, done: value === undefined });
+      },
+      releaseLock: () => {
+        released = true;
+      },
+    };
+
+    assertEquals(await readStdinLine(reader), "yes");
+    assertEquals(released, true);
+  });
+
+  it("returns null when stdin closes before receiving input", async () => {
+    let released = false;
+    const reader: StdinReader = {
+      read: () => Promise.resolve({ value: undefined, done: true }),
+      releaseLock: () => {
+        released = true;
+      },
+    };
+
+    assertEquals(await readStdinLine(reader), null);
+    assertEquals(released, true);
+  });
+
+  it("decodes the final value returned with EOF", async () => {
+    const reader: StdinReader = {
+      read: () =>
+        Promise.resolve({
+          value: new TextEncoder().encode("yes\n"),
+          done: true,
+        }),
+      releaseLock: () => {},
+    };
+
+    assertEquals(await readStdinLine(reader), "yes");
+  });
+});
+
+describe("createNodeStdinReader", () => {
+  it("attaches reader listeners before resuming raw-mode Node stdin", () => {
+    const events: string[] = [];
+    const listeners = new Map<string, (data: Uint8Array) => void>();
+    const stdin = {
+      on: (event: string, listener: (data: Uint8Array) => void) => {
+        events.push(`on:${event}`);
+        listeners.set(event, listener);
+      },
+      off: (event: string) => {
+        listeners.delete(event);
+      },
+      pause: () => {},
+      resume: () => {
+        events.push("resume");
+      },
+      setRawMode: (enabled: boolean) => {
+        events.push(`raw:${enabled}`);
+      },
+    };
+
+    setNodeRawMode(stdin, true);
+    const reader = createNodeStdinReader(stdin);
+
+    assertEquals(events, ["raw:true", "on:data", "on:end", "resume"]);
+    reader.releaseLock();
+  });
+
+  it("resumes stdin while reading and pauses it when released", async () => {
+    const listeners = new Map<string, (data: Uint8Array) => void>();
+    let resumedAfterListenersAttached = false;
+    let paused = false;
+    const reader = createNodeStdinReader({
+      on: (event, listener) => {
+        listeners.set(event, listener);
+      },
+      off: (event) => {
+        listeners.delete(event);
+      },
+      pause: () => {
+        paused = true;
+      },
+      resume: () => {
+        resumedAfterListenersAttached = listeners.has("data") && listeners.has("end");
+      },
+    });
+
+    assertEquals(resumedAfterListenersAttached, true);
+    const read = reader.read();
+    listeners.get("data")?.(new TextEncoder().encode("yes\n"));
+
+    assertEquals(await read, {
+      value: new TextEncoder().encode("yes\n"),
+      done: false,
+    });
+    reader.releaseLock();
+    assertEquals(paused, true);
+    assertEquals(listeners.size, 0);
+  });
+
+  it("reports EOF after draining a buffered partial line", async () => {
+    const listeners = new Map<string, (data: Uint8Array) => void>();
+    const reader = createNodeStdinReader({
+      on: (event, listener) => {
+        listeners.set(event, listener);
+      },
+      off: (event) => {
+        listeners.delete(event);
+      },
+      pause: () => {},
+      resume: () => {},
+    });
+
+    const firstRead = reader.read();
+    listeners.get("data")?.(new TextEncoder().encode("partial"));
+    assertEquals(await firstRead, {
+      value: new TextEncoder().encode("partial"),
+      done: false,
+    });
+    listeners.get("end")?.(new Uint8Array());
+
+    assertEquals(await reader.read(), { value: undefined, done: true });
+    reader.releaseLock();
+  });
+
+  it("settles a pending read as EOF when released", async () => {
+    const listeners = new Map<string, (data: Uint8Array) => void>();
+    const reader = createNodeStdinReader({
+      on: (event, listener) => {
+        listeners.set(event, listener);
+      },
+      off: (event) => {
+        listeners.delete(event);
+      },
+      pause: () => {},
+      resume: () => {},
+    });
+
+    const pendingRead = reader.read();
+    reader.releaseLock();
+
+    let timeoutId: number | undefined;
+    const result = await Promise.race([
+      pendingRead,
+      new Promise<"timeout">((resolve) => {
+        timeoutId = setTimeout(() => resolve("timeout"), 20);
+      }),
+    ]);
+    clearTimeout(timeoutId);
+    assertEquals(result, { value: undefined, done: true });
+  });
+});
+
+describe("waitForNodeKeypress", () => {
+  it("attaches the data listener before resuming stdin", async () => {
+    const events: string[] = [];
+    let onData: ((data: Uint8Array) => void) | undefined;
+    const wait = waitForNodeKeypress({
+      once: (event, listener) => {
+        events.push(`once:${event}`);
+        onData = listener;
+      },
+      pause: () => {
+        events.push("pause");
+      },
+      resume: () => {
+        events.push("resume");
+      },
+      setRawMode: (enabled) => {
+        events.push(`raw:${enabled}`);
+      },
+    });
+
+    assertEquals(events, ["once:data", "raw:true", "resume"]);
+    onData?.(new Uint8Array([0x0a]));
+    await wait;
+    assertEquals(events, ["once:data", "raw:true", "resume", "raw:false", "pause"]);
   });
 });

--- a/src/platform/compat/stdin.ts
+++ b/src/platform/compat/stdin.ts
@@ -20,6 +20,20 @@ declare const process:
   }
   | undefined;
 
+export interface NodeRawStdinLike {
+  setRawMode?(enabled: boolean): void;
+}
+
+export interface NodeKeypressStdinLike extends NodeRawStdinLike {
+  pause(): void;
+  resume(): void;
+  once(event: string, listener: (data: Uint8Array) => void): void;
+}
+
+export function setNodeRawMode(stdin: NodeRawStdinLike, enabled: boolean): void {
+  stdin.setRawMode?.(enabled);
+}
+
 /**
  * Set raw mode on stdin (enables character-by-character input)
  */
@@ -33,8 +47,7 @@ export function setRawMode(enabled: boolean): void {
   const stdin = process?.stdin;
   if (!stdin?.setRawMode) return;
 
-  stdin.setRawMode(enabled);
-  if (enabled) stdin.resume();
+  setNodeRawMode(stdin, enabled);
 }
 
 /**
@@ -43,6 +56,61 @@ export function setRawMode(enabled: boolean): void {
 export interface StdinReader {
   read(): Promise<{ value: Uint8Array | undefined; done: boolean }>;
   releaseLock(): void;
+}
+
+export interface NodeStdinLike {
+  pause(): void;
+  resume(): void;
+  on(event: string, listener: (data: Uint8Array) => void): void;
+  off(event: string, listener: (data: Uint8Array) => void): void;
+}
+
+/** Create a chunk reader over Node's event-based stdin stream. */
+export function createNodeStdinReader(stdin: NodeStdinLike): StdinReader {
+  let buffer: Uint8Array[] = [];
+  let ended = false;
+  let resolveRead: ((result: { value: Uint8Array | undefined; done: boolean }) => void) | null =
+    null;
+
+  function onData(data: Uint8Array): void {
+    const chunk = new Uint8Array(data);
+    if (resolveRead) {
+      resolveRead({ value: chunk, done: false });
+      resolveRead = null;
+      return;
+    }
+    buffer.push(chunk);
+  }
+
+  function settleEnd(): void {
+    ended = true;
+    if (!resolveRead) return;
+    resolveRead({ value: undefined, done: true });
+    resolveRead = null;
+  }
+
+  stdin.on("data", onData);
+  stdin.on("end", settleEnd);
+  stdin.resume();
+
+  return {
+    read(): Promise<{ value: Uint8Array | undefined; done: boolean }> {
+      const value = buffer.shift();
+      if (value) return Promise.resolve({ value, done: false });
+      if (ended) return Promise.resolve({ value: undefined, done: true });
+
+      return new Promise((resolve) => {
+        resolveRead = resolve;
+      });
+    },
+    releaseLock(): void {
+      stdin.off("data", onData);
+      stdin.off("end", settleEnd);
+      stdin.pause();
+      buffer = [];
+      settleEnd();
+    },
+  };
 }
 
 /**
@@ -70,51 +138,49 @@ export function getStdinReader(): StdinReader {
     };
   }
 
-  let buffer: Uint8Array[] = [];
-  let resolveRead: ((result: { value: Uint8Array | undefined; done: boolean }) => void) | null =
-    null;
+  return createNodeStdinReader(stdin);
+}
 
-  function onData(data: Uint8Array): void {
-    const chunk = new Uint8Array(data);
-    if (resolveRead) {
-      resolveRead({ value: chunk, done: false });
-      resolveRead = null;
-      return;
+/** Read one line from stdin and release the reader when complete. */
+export async function readStdinLine(
+  reader: StdinReader = getStdinReader(),
+): Promise<string | null> {
+  const decoder = new TextDecoder();
+  let input = "";
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (value) {
+        input += decoder.decode(value, { stream: !done });
+      } else if (done) {
+        input += decoder.decode();
+      }
+      const lineEnd = input.search(/[\r\n]/);
+      if (lineEnd !== -1) return input.slice(0, lineEnd);
+      if (done) return input || null;
     }
-    buffer.push(chunk);
+  } finally {
+    reader.releaseLock();
   }
-
-  function onEnd(): void {
-    if (!resolveRead) return;
-    resolveRead({ value: undefined, done: true });
-    resolveRead = null;
-  }
-
-  stdin.on("data", onData);
-  stdin.on("end", onEnd);
-
-  return {
-    read(): Promise<{ value: Uint8Array | undefined; done: boolean }> {
-      const value = buffer.shift();
-      if (value) return Promise.resolve({ value, done: false });
-
-      return new Promise((resolve) => {
-        resolveRead = resolve;
-      });
-    },
-    releaseLock(): void {
-      stdin.off("data", onData);
-      stdin.off("end", onEnd);
-      buffer = [];
-      resolveRead = null;
-    },
-  };
 }
 
 /**
  * Wait for a single keypress from stdin.
  * Works in both Deno and Node.js.
  */
+export function waitForNodeKeypress(stdin: NodeKeypressStdinLike): Promise<void> {
+  return new Promise((resolve) => {
+    stdin.once("data", () => {
+      setNodeRawMode(stdin, false);
+      stdin.pause();
+      resolve();
+    });
+    setNodeRawMode(stdin, true);
+    stdin.resume();
+  });
+}
+
 export function waitForKeypress(): Promise<void> {
   const deno = isDeno ? getDenoRuntime() : undefined;
   if (deno) {
@@ -130,21 +196,8 @@ export function waitForKeypress(): Promise<void> {
     })();
   }
 
-  return new Promise((resolve) => {
-    const stdin = process?.stdin;
-    if (!stdin) {
-      resolve();
-      return;
-    }
-
-    stdin.setRawMode?.(true);
-    stdin.resume();
-    stdin.once("data", () => {
-      stdin.setRawMode?.(false);
-      stdin.pause();
-      resolve();
-    });
-  });
+  const stdin = process?.stdin;
+  return stdin ? waitForNodeKeypress(stdin) : Promise.resolve();
 }
 
 // Key codes for raw mode

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -53,6 +53,7 @@ export {
 export {
   createEscapeBuffer,
   getStdinReader,
+  readStdinLine,
   setRawMode,
   type StdinReader,
 } from "./compat/stdin.ts";


### PR DESCRIPTION
## Summary

- keep unlinked local development account-scoped instead of treating the folder name as remote project authorization
- treat an inferred project name only as a fresh-project slug candidate; never use it to select an existing remote project
- retry first-create slug conflicts with the canonical random suffix flow and persist the accepted slug in `veryfront.json` before source mutation
- restore interactive Node fallback prompts so the generated npm CLI waits for `veryfront pull` confirmation
- keep standalone local runtime IDs paired with local slugs while using persisted cloud links only for authenticated discovery

## Verification

- focused push/deploy/auth/start/runtime suite: 44 tests, 202 steps passed
- full local pre-push gate: format 4,148 files; lint 4,094 files; typecheck; 2,706 tests / 21,958 steps passed
- GitHub CI: format, lint, typecheck, unit, integration, npm install smoke, RSC browser E2E, binary E2E, all coverage shards/gate, and CodeQL passed
- generated npm CLI sequential TTY prompts: yes, then no
- real generated npm `pull`: confirmation waited, 13 files pulled
- agent-browser local AG-UI: response `pong`, POST 200, no console errors, full-height root

The complete repository run exposed one stale, unrelated skill-assets E2E expectation already present on `origin/main`. #3139 updates that assertion to match the existing runtime contract and now has a fully green GitHub matrix.

Closes veryfront/veryfront-issue-inbox#283
