### PR TITLE
Keep skill capability coverage aligned with advertised assets

### DIFF
--- a/tests/e2e/features/skill-capabilities.test.ts
+++ b/tests/e2e/features/skill-capabilities.test.ts
@@ -264,7 +264,10 @@ export const POST = createAgUiHandler("researcher");
       assertEquals(loadSkillJson.toolId, "load_skill");
       assertStringIncludes(loadSkillJson.result.instructions, "crisp final draft");
       assertEquals(loadSkillJson.result.allowedTools, ["Read", "api:*"]);
-      assertEquals(loadSkillJson.result.references, ["references/style-guide.md"]);
+      assertEquals(loadSkillJson.result.references.toSorted(), [
+        "assets/voice.txt",
+        "references/style-guide.md",
+      ]);
       assertEquals(loadSkillJson.result.scripts, ["scripts/echo-style.sh"]);
 
       const { response: loadSkillReferenceResponse, json: loadSkillReferenceJson } = await postJson<


### PR DESCRIPTION
## Summary

- update the binary E2E expectation to include skill assets advertised by `load_skill`
- preserve the existing runtime contract, which already exposes assets through `load_skill_reference`

## Verification

- reproduced the stale assertion on a detached clean `origin/main` worktree with a separate freshly compiled binary
- `tests/e2e/features/skill-capabilities.test.ts`: 3 steps passed
- focused `deno fmt --check`
- `git diff --check`

This unblocks the binary-E2E baseline used by #3138.