### PR TITLE
Capture production serve startup failures

### DIFF
--- a/cli/commands/serve/command.test.ts
+++ b/cli/commands/serve/command.test.ts
@@ -17,7 +17,17 @@ type RunWithStartupErrorReporting = <T>(
       context: { boundary: string },
     ) => string | undefined;
     flushApplicationErrors: (timeoutMs?: number) => Promise<boolean>;
+    onReportingError?: (
+      operation: "capture" | "flush",
+      error: unknown,
+    ) => void;
   },
+) => Promise<T>;
+
+type RunProductionStartupWithErrorReporting = <T>(
+  startup: () => Promise<T>,
+  reporter: Parameters<RunWithStartupErrorReporting>[1],
+  ensureBundlerContracts: () => Promise<void>,
 ) => Promise<T>;
 
 describe("commands/serve/command", () => {
@@ -187,5 +197,79 @@ describe("commands/serve/command", () => {
     );
 
     assertStrictEquals(thrown, startupError);
+  });
+
+  it("captures bundler contract failures before production startup", async () => {
+    const commandModule = await import("./command.ts") as {
+      runProductionStartupWithErrorReporting?: RunProductionStartupWithErrorReporting;
+    };
+    const runProductionStartupWithErrorReporting =
+      commandModule.runProductionStartupWithErrorReporting;
+    assertExists(runProductionStartupWithErrorReporting);
+
+    const bundlerError = new Error("bundler contracts failed");
+    const captures: Array<{ error: unknown; boundary: string }> = [];
+    let startupCalled = false;
+
+    const thrown = await assertRejects(() =>
+      runProductionStartupWithErrorReporting(
+        () => {
+          startupCalled = true;
+          return Promise.resolve();
+        },
+        {
+          captureApplicationError: (error, context) => {
+            captures.push({ error, boundary: context.boundary });
+            return "event-id";
+          },
+          flushApplicationErrors: () => Promise.resolve(true),
+        },
+        () => Promise.reject(bundlerError),
+      )
+    );
+
+    assertStrictEquals(thrown, bundlerError);
+    assertEquals(startupCalled, false);
+    assertEquals(captures, [{
+      error: bundlerError,
+      boundary: "process.startup",
+    }]);
+  });
+
+  it("reports reporter failures without replacing the startup failure", async () => {
+    const commandModule = await import("./command.ts") as {
+      runWithStartupErrorReporting?: RunWithStartupErrorReporting;
+    };
+    const runWithStartupErrorReporting = commandModule.runWithStartupErrorReporting;
+    assertExists(runWithStartupErrorReporting);
+
+    const startupError = new Error("startup failed");
+    const captureError = new Error("capture failed");
+    const flushError = new Error("flush failed");
+    const reporterFailures: Array<{
+      operation: "capture" | "flush";
+      error: unknown;
+    }> = [];
+
+    const thrown = await assertRejects(() =>
+      runWithStartupErrorReporting(
+        () => Promise.reject(startupError),
+        {
+          captureApplicationError: () => {
+            throw captureError;
+          },
+          flushApplicationErrors: () => Promise.reject(flushError),
+          onReportingError: (operation, error) => {
+            reporterFailures.push({ operation, error });
+          },
+        },
+      )
+    );
+
+    assertStrictEquals(thrown, startupError);
+    assertEquals(reporterFailures, [
+      { operation: "capture", error: captureError },
+      { operation: "flush", error: flushError },
+    ]);
   });
 });

--- a/cli/commands/serve/command.test.ts
+++ b/cli/commands/serve/command.test.ts
@@ -1,8 +1,24 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { serveCommand } from "./command.ts";
 import type { ServeOptions } from "./command.ts";
+
+type RunWithStartupErrorReporting = <T>(
+  startup: () => Promise<T>,
+  reporter: {
+    captureApplicationError: (
+      error: unknown,
+      context: { boundary: string },
+    ) => string | undefined;
+    flushApplicationErrors: (timeoutMs?: number) => Promise<boolean>;
+  },
+) => Promise<T>;
 
 describe("commands/serve/command", () => {
   describe("serveCommand", () => {
@@ -113,5 +129,63 @@ describe("commands/serve/command", () => {
       };
       assertEquals(Object.keys(options).length, 7);
     });
+  });
+
+  it("captures, flushes, and rethrows production startup failures exactly once", async () => {
+    const commandModule = await import("./command.ts") as {
+      runWithStartupErrorReporting?: RunWithStartupErrorReporting;
+    };
+    const runWithStartupErrorReporting = commandModule.runWithStartupErrorReporting;
+    assertExists(runWithStartupErrorReporting);
+
+    const startupError = new Error("startup failed");
+    const captures: Array<{ error: unknown; boundary: string }> = [];
+    const flushTimeouts: Array<number | undefined> = [];
+
+    const thrown = await assertRejects(() =>
+      runWithStartupErrorReporting(
+        () => Promise.reject(startupError),
+        {
+          captureApplicationError: (error, context) => {
+            captures.push({ error, boundary: context.boundary });
+            return "event-id";
+          },
+          flushApplicationErrors: (timeoutMs) => {
+            flushTimeouts.push(timeoutMs);
+            return Promise.resolve(true);
+          },
+        },
+      )
+    );
+
+    assertStrictEquals(thrown, startupError);
+    assertEquals(captures, [{
+      error: startupError,
+      boundary: "process.startup",
+    }]);
+    assertEquals(flushTimeouts, [2_000]);
+  });
+
+  it("preserves the startup failure when flushing the reporter fails", async () => {
+    const commandModule = await import("./command.ts") as {
+      runWithStartupErrorReporting?: RunWithStartupErrorReporting;
+    };
+    const runWithStartupErrorReporting = commandModule.runWithStartupErrorReporting;
+    assertExists(runWithStartupErrorReporting);
+
+    const startupError = new Error("startup failed");
+    const flushError = new Error("flush failed");
+
+    const thrown = await assertRejects(() =>
+      runWithStartupErrorReporting(
+        () => Promise.reject(startupError),
+        {
+          captureApplicationError: () => "event-id",
+          flushApplicationErrors: () => Promise.reject(flushError),
+        },
+      )
+    );
+
+    assertStrictEquals(thrown, startupError);
   });
 });

--- a/cli/commands/serve/command.test.ts
+++ b/cli/commands/serve/command.test.ts
@@ -176,7 +176,9 @@ describe("commands/serve/command", () => {
       error: startupError,
       boundary: "process.startup",
     }]);
-    assertEquals(flushTimeouts, [2_000]);
+    assertEquals(flushTimeouts.length, 1);
+    assertEquals((flushTimeouts[0] ?? Infinity) <= 2_000, true);
+    assertEquals((flushTimeouts[0] ?? 0) > 0, true);
   });
 
   it("preserves the startup failure when flushing the reporter fails", async () => {
@@ -425,6 +427,7 @@ describe("commands/serve/command", () => {
         dependencies: {
           ensureBundlerContracts: () => Promise<void>;
           initializeErrorReporting: () => Promise<unknown>;
+          loadSentryModule?: () => Promise<unknown>;
           reporter: Parameters<RunWithStartupErrorReporting>[1];
         },
       ) => Promise<void>;
@@ -474,7 +477,70 @@ describe("commands/serve/command", () => {
       error: bootstrapError,
       boundary: "process.startup",
     }]);
-    assertEquals(flushTimeouts, [2_000]);
+    assertEquals(flushTimeouts.length, 1);
+    assertEquals((flushTimeouts[0] ?? Infinity) <= 2_000, true);
+    assertEquals((flushTimeouts[0] ?? 0) > 0, true);
+  });
+
+  it("keeps Sentry module loading inside the real production server boundary", async () => {
+    const commandModule = await import("./command.ts") as {
+      runProductionServer?: (
+        options: ServeOptions,
+        dependencies: {
+          ensureBundlerContracts: () => Promise<void>;
+          loadSentryModule: () => Promise<never>;
+          reporter: Parameters<RunWithStartupErrorReporting>[1];
+        },
+      ) => Promise<void>;
+    };
+    const runProductionServer = commandModule.runProductionServer;
+    assertExists(runProductionServer);
+
+    const loadError = new Error("Sentry module failed to load");
+    const captures: Array<{ error: unknown; boundary: string }> = [];
+    const flushTimeouts: Array<number | undefined> = [];
+    let bundlerCalled = false;
+
+    const thrown = await assertRejects(() =>
+      runProductionServer(
+        {
+          mode: "production",
+          port: 3000,
+          bindAddress: "127.0.0.1",
+          splitMode: false,
+          useBinary: false,
+          binaryPath: "./bin/veryfront",
+          debug: false,
+        },
+        {
+          loadSentryModule: () => Promise.reject(loadError),
+          ensureBundlerContracts: () => {
+            bundlerCalled = true;
+            return Promise.reject(new Error("bundler should not run"));
+          },
+          reporter: {
+            captureApplicationError: (error, context) => {
+              captures.push({ error, boundary: context.boundary });
+              return "event-id";
+            },
+            flushApplicationErrors: (timeoutMs) => {
+              flushTimeouts.push(timeoutMs);
+              return Promise.resolve(true);
+            },
+          },
+        },
+      )
+    );
+
+    assertStrictEquals(thrown, loadError);
+    assertEquals(bundlerCalled, false);
+    assertEquals(captures, [{
+      error: loadError,
+      boundary: "process.startup",
+    }]);
+    assertEquals(flushTimeouts.length, 1);
+    assertEquals((flushTimeouts[0] ?? Infinity) <= 2_000, true);
+    assertEquals((flushTimeouts[0] ?? 0) > 0, true);
   });
 
   for (const mode of ["production", "combined"] as const) {

--- a/cli/commands/serve/command.test.ts
+++ b/cli/commands/serve/command.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { FakeTime } from "#std/testing/time";
 import {
   assertEquals,
   assertExists,
@@ -22,12 +23,14 @@ type RunWithStartupErrorReporting = <T>(
       error: unknown,
     ) => void;
   },
+  options?: { flushTimeoutMs?: number },
 ) => Promise<T>;
 
 type RunProductionStartupWithErrorReporting = <T>(
   startup: () => Promise<T>,
   reporter: Parameters<RunWithStartupErrorReporting>[1],
   ensureBundlerContracts: () => Promise<void>,
+  initializeObservability?: () => Promise<unknown>,
 ) => Promise<T>;
 
 describe("commands/serve/command", () => {
@@ -272,4 +275,229 @@ describe("commands/serve/command", () => {
       { operation: "flush", error: flushError },
     ]);
   });
+
+  it("preserves the startup failure when the reporting callback throws", async () => {
+    const commandModule = await import("./command.ts") as {
+      runWithStartupErrorReporting?: RunWithStartupErrorReporting;
+    };
+    const runWithStartupErrorReporting = commandModule.runWithStartupErrorReporting;
+    assertExists(runWithStartupErrorReporting);
+
+    const startupError = new Error("startup failed");
+    const callbackError = new Error("diagnostic callback failed");
+
+    const thrown = await assertRejects(() =>
+      runWithStartupErrorReporting(
+        () => Promise.reject(startupError),
+        {
+          captureApplicationError: () => {
+            throw new Error("capture failed");
+          },
+          flushApplicationErrors: () => Promise.reject(new Error("flush failed")),
+          onReportingError: () => {
+            throw callbackError;
+          },
+        },
+      )
+    );
+
+    assertStrictEquals(thrown, startupError);
+  });
+
+  it("bounds reporter flush by wall-clock timeout", async () => {
+    using time = new FakeTime();
+    const commandModule = await import("./command.ts") as {
+      runWithStartupErrorReporting?: RunWithStartupErrorReporting;
+    };
+    const runWithStartupErrorReporting = commandModule.runWithStartupErrorReporting;
+    assertExists(runWithStartupErrorReporting);
+
+    const startupError = new Error("startup failed");
+    const result = runWithStartupErrorReporting(
+      () => Promise.reject(startupError),
+      {
+        captureApplicationError: () => "event-id",
+        flushApplicationErrors: () => new Promise<boolean>(() => {}),
+      },
+      { flushTimeoutMs: 2_000 },
+    ).then(
+      (value: never) => ({ value }),
+      (error: unknown) => ({ error }),
+    );
+
+    let settled = false;
+    void result.then(() => settled = true);
+    await time.tickAsync(1_999);
+    assertEquals(settled, false);
+
+    await time.tickAsync(1);
+    const outcome = await result;
+    assertEquals("value" in outcome, false);
+    if ("error" in outcome) assertStrictEquals(outcome.error, startupError);
+  });
+
+  it("absorbs a flush rejection that arrives after the deadline", async () => {
+    using time = new FakeTime();
+    const commandModule = await import("./command.ts") as {
+      runWithStartupErrorReporting?: RunWithStartupErrorReporting;
+    };
+    const runWithStartupErrorReporting = commandModule.runWithStartupErrorReporting;
+    assertExists(runWithStartupErrorReporting);
+
+    const startupError = new Error("startup failed");
+    const flushError = new Error("flush failed late");
+    let rejectFlush!: (error: unknown) => void;
+    const reportingErrors: unknown[] = [];
+    const flush = new Promise<boolean>((_resolve, reject) => rejectFlush = reject);
+
+    const result = runWithStartupErrorReporting(
+      () => Promise.reject(startupError),
+      {
+        captureApplicationError: () => "event-id",
+        flushApplicationErrors: () => flush,
+        onReportingError: (_operation: "capture" | "flush", error: unknown) => {
+          reportingErrors.push(error);
+        },
+      },
+      { flushTimeoutMs: 25 },
+    ).then(
+      (value: never) => ({ value }),
+      (error: unknown) => ({ error }),
+    );
+
+    await time.tickAsync(25);
+    const outcome = await result;
+    assertEquals("value" in outcome, false);
+    if ("error" in outcome) assertStrictEquals(outcome.error, startupError);
+
+    rejectFlush(flushError);
+    await time.tickAsync(0);
+    assertEquals(reportingErrors, [flushError]);
+  });
+
+  it("captures Sentry bootstrap failures before production startup", async () => {
+    const commandModule = await import("./command.ts") as {
+      runProductionStartupWithErrorReporting?: RunProductionStartupWithErrorReporting;
+    };
+    const runProductionStartupWithErrorReporting =
+      commandModule.runProductionStartupWithErrorReporting;
+    assertExists(runProductionStartupWithErrorReporting);
+
+    const bootstrapError = new Error("Sentry bootstrap failed");
+    const captures: Array<{ error: unknown; boundary: string }> = [];
+    let bundlerContractsChecked = false;
+    let startupCalled = false;
+
+    const thrown = await assertRejects(() =>
+      runProductionStartupWithErrorReporting(
+        () => {
+          startupCalled = true;
+          return Promise.resolve();
+        },
+        {
+          captureApplicationError: (error, context) => {
+            captures.push({ error, boundary: context.boundary });
+            return "event-id";
+          },
+          flushApplicationErrors: () => Promise.resolve(true),
+        },
+        () => {
+          bundlerContractsChecked = true;
+          return Promise.resolve();
+        },
+        () => Promise.reject(bootstrapError),
+      )
+    );
+
+    assertStrictEquals(thrown, bootstrapError);
+    assertEquals(bundlerContractsChecked, false);
+    assertEquals(startupCalled, false);
+    assertEquals(captures, [{
+      error: bootstrapError,
+      boundary: "process.startup",
+    }]);
+  });
+
+  it("keeps Sentry bootstrap inside the real production server boundary", async () => {
+    const commandModule = await import("./command.ts") as {
+      runProductionServer?: (
+        options: ServeOptions,
+        dependencies: {
+          ensureBundlerContracts: () => Promise<void>;
+          initializeErrorReporting: () => Promise<unknown>;
+          reporter: Parameters<RunWithStartupErrorReporting>[1];
+        },
+      ) => Promise<void>;
+    };
+    const runProductionServer = commandModule.runProductionServer;
+    assertExists(runProductionServer);
+
+    const bootstrapError = new Error("Sentry bootstrap failed");
+    const captures: Array<{ error: unknown; boundary: string }> = [];
+    const flushTimeouts: Array<number | undefined> = [];
+    let bundlerCalled = false;
+
+    const thrown = await assertRejects(() =>
+      runProductionServer(
+        {
+          mode: "production",
+          port: 3000,
+          bindAddress: "127.0.0.1",
+          splitMode: false,
+          useBinary: false,
+          binaryPath: "./bin/veryfront",
+          debug: false,
+        },
+        {
+          initializeErrorReporting: () => Promise.reject(bootstrapError),
+          ensureBundlerContracts: () => {
+            bundlerCalled = true;
+            return Promise.resolve();
+          },
+          reporter: {
+            captureApplicationError: (error, context) => {
+              captures.push({ error, boundary: context.boundary });
+              return "event-id";
+            },
+            flushApplicationErrors: (timeoutMs) => {
+              flushTimeouts.push(timeoutMs);
+              return Promise.resolve(true);
+            },
+          },
+        },
+      )
+    );
+
+    assertStrictEquals(thrown, bootstrapError);
+    assertEquals(bundlerCalled, false);
+    assertEquals(captures, [{
+      error: bootstrapError,
+      boundary: "process.startup",
+    }]);
+    assertEquals(flushTimeouts, [2_000]);
+  });
+
+  for (const mode of ["production", "combined"] as const) {
+    it(`routes ${mode} mode through the production server boundary`, async () => {
+      const calls: ServeOptions[] = [];
+      const options: ServeOptions = {
+        mode,
+        port: 3000,
+        bindAddress: "127.0.0.1",
+        splitMode: false,
+        useBinary: false,
+        binaryPath: "./bin/veryfront",
+        debug: false,
+      };
+
+      await serveCommand(options, {
+        runProductionServer: (received) => {
+          calls.push(received);
+          return Promise.resolve();
+        },
+      });
+
+      assertEquals(calls, [options]);
+    });
+  }
 });

--- a/cli/commands/serve/command.test.ts
+++ b/cli/commands/serve/command.test.ts
@@ -543,6 +543,56 @@ describe("commands/serve/command", () => {
     assertEquals((flushTimeouts[0] ?? 0) > 0, true);
   });
 
+  it("preserves default reporter acquisition failures without remote capture", async () => {
+    const commandModule = await import("./command.ts") as {
+      runProductionServer?: (
+        options: ServeOptions,
+        dependencies: {
+          ensureBundlerContracts: () => Promise<void>;
+          loadSentryModule: () => Promise<never>;
+        },
+      ) => Promise<void>;
+    };
+    const runProductionServer = commandModule.runProductionServer;
+    assertExists(runProductionServer);
+
+    const loadError = new Error("Sentry module failed to load");
+    let bundlerCalled = false;
+    const result = runProductionServer(
+      {
+        mode: "production",
+        port: 3000,
+        bindAddress: "127.0.0.1",
+        splitMode: false,
+        useBinary: false,
+        binaryPath: "./bin/veryfront",
+        debug: false,
+      },
+      {
+        loadSentryModule: () => Promise.reject(loadError),
+        ensureBundlerContracts: () => {
+          bundlerCalled = true;
+          return Promise.resolve();
+        },
+      },
+    ).then(
+      (value: void) => ({ value }),
+      (error: unknown) => ({ error }),
+    );
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<{ timedOut: true }>((resolve) => {
+      timeoutId = setTimeout(() => resolve({ timedOut: true }), 250);
+    });
+    const outcome = await Promise.race([result, timeout]);
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+
+    assertEquals("timedOut" in outcome, false);
+    assertEquals("value" in outcome, false);
+    if ("error" in outcome) assertStrictEquals(outcome.error, loadError);
+    assertEquals(bundlerCalled, false);
+  });
+
   for (const mode of ["production", "combined"] as const) {
     it(`routes ${mode} mode through the production server boundary`, async () => {
       const calls: ServeOptions[] = [];

--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -4,6 +4,7 @@ import { cliLogger } from "#cli/utils";
 import { exitProcess, registerTerminationSignals, showLogo } from "#cli/utils";
 import { generateDefaultProjectId } from "../../utils/project.ts";
 import { startCliProductionServer } from "#cli/shared/server-startup";
+import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
 
 const STARTUP_ERROR_FLUSH_TIMEOUT_MS = 2_000;
 
@@ -50,6 +51,17 @@ export async function runWithStartupErrorReporting<T>(
   }
 }
 
+export async function runProductionStartupWithErrorReporting<T>(
+  startup: () => Promise<T>,
+  reporter: StartupErrorReporter,
+  ensureBundlerContracts: () => Promise<void> = ensureCliBundlerContracts,
+): Promise<T> {
+  return await runWithStartupErrorReporting(async () => {
+    await ensureBundlerContracts();
+    return await startup();
+  }, reporter);
+}
+
 async function runSplit(options: ServeOptions): Promise<void> {
   showLogo();
   const { runSplitMode } = await import("./split-mode.ts");
@@ -91,7 +103,7 @@ async function runProductionServer(options: ServeOptions): Promise<void> {
   } = await import("veryfront/observability/sentry");
   await initializeSentryFromEnv();
 
-  const { server, shutdownController } = await runWithStartupErrorReporting(
+  const { server, shutdownController } = await runProductionStartupWithErrorReporting(
     async () => {
       const { clearAllLocalCaches } = await import(
         "veryfront/transforms/mdx-cache"
@@ -132,11 +144,15 @@ async function runProductionServer(options: ServeOptions): Promise<void> {
     {
       captureApplicationError,
       flushApplicationErrors,
-      onReportingError: (operation, error) =>
+      onReportingError: (operation, error) => {
         cliLogger.warn(
-          `Error reporter failed to ${operation} production startup failure:`,
+          `Error reporter failed to ${operation} production startup failure.`,
+        );
+        cliLogger.debug(
+          `Error reporter ${operation} failure details:`,
           error,
-        ),
+        );
+      },
     },
   );
 

--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -27,6 +27,7 @@ type StartupErrorReportingOptions = {
 type ProductionServerDependencies = {
   ensureBundlerContracts?: () => Promise<void>;
   initializeErrorReporting?: () => Promise<unknown>;
+  loadSentryModule?: () => Promise<ProductionSentryModule>;
   reporter?: StartupErrorReporter;
 };
 
@@ -155,22 +156,36 @@ async function runProxy(options: ServeOptions): Promise<void> {
   await new Promise(() => {});
 }
 
-function createProductionStartupErrorReporter(
-  sentryModule: ProductionSentryModule,
-): StartupErrorReporter {
+function createDeferredProductionStartupErrorReporter(): {
+  reporter: StartupErrorReporter;
+  setSentryModule: (sentryModule: ProductionSentryModule) => void;
+} {
+  let sentryModule: ProductionSentryModule | undefined;
+
   return {
-    captureApplicationError: sentryModule.captureApplicationError,
-    flushApplicationErrors: sentryModule.flushApplicationErrors,
-    onReportingError: (operation, error) => {
-      cliLogger.warn(
-        `Error reporter failed to ${operation} production startup failure.`,
-      );
-      cliLogger.debug(
-        `Error reporter ${operation} failure details:`,
-        error,
-      );
+    reporter: {
+      captureApplicationError: (error, context) =>
+        sentryModule?.captureApplicationError(error, context),
+      flushApplicationErrors: (timeoutMs) =>
+        sentryModule?.flushApplicationErrors(timeoutMs) ?? Promise.resolve(true),
+      onReportingError: (operation, error) => {
+        cliLogger.warn(
+          `Error reporter failed to ${operation} production startup failure.`,
+        );
+        cliLogger.debug(
+          `Error reporter ${operation} failure details:`,
+          error,
+        );
+      },
+    },
+    setSentryModule: (loadedSentryModule) => {
+      sentryModule = loadedSentryModule;
     },
   };
+}
+
+function loadProductionSentryModule(): Promise<ProductionSentryModule> {
+  return import("veryfront/observability/sentry");
 }
 
 export async function runProductionServer(
@@ -178,9 +193,16 @@ export async function runProductionServer(
   dependencies: ProductionServerDependencies = {},
 ): Promise<void> {
   showLogo();
-  const sentryModule = await import("veryfront/observability/sentry");
-  const reporter = dependencies.reporter ??
-    createProductionStartupErrorReporter(sentryModule);
+  const deferredReporter = createDeferredProductionStartupErrorReporter();
+  const reporter = dependencies.reporter ?? deferredReporter.reporter;
+  const initializeErrorReporting = dependencies.initializeErrorReporting ??
+    (async () => {
+      const sentryModule = await (
+        dependencies.loadSentryModule ?? loadProductionSentryModule
+      )();
+      deferredReporter.setSentryModule(sentryModule);
+      await sentryModule.initializeSentryFromEnv();
+    });
 
   const { server, shutdownController } = await runProductionStartupWithErrorReporting(
     async () => {
@@ -222,8 +244,7 @@ export async function runProductionServer(
     },
     reporter,
     dependencies.ensureBundlerContracts ?? ensureCliBundlerContracts,
-    dependencies.initializeErrorReporting ??
-      (() => sentryModule.initializeSentryFromEnv()),
+    initializeErrorReporting,
   );
 
   let shuttingDown = false;

--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -5,6 +5,20 @@ import { exitProcess, registerTerminationSignals, showLogo } from "#cli/utils";
 import { generateDefaultProjectId } from "../../utils/project.ts";
 import { startCliProductionServer } from "#cli/shared/server-startup";
 
+const STARTUP_ERROR_FLUSH_TIMEOUT_MS = 2_000;
+
+type StartupErrorReporter = {
+  captureApplicationError: (
+    error: unknown,
+    context: { boundary: string },
+  ) => string | undefined;
+  flushApplicationErrors: (timeoutMs?: number) => Promise<boolean>;
+  onReportingError?: (
+    operation: "capture" | "flush",
+    error: unknown,
+  ) => void;
+};
+
 export interface ServeOptions {
   mode: "combined" | "proxy" | "production";
   port: number;
@@ -13,6 +27,27 @@ export interface ServeOptions {
   useBinary: boolean;
   binaryPath: string;
   debug: boolean;
+}
+
+export async function runWithStartupErrorReporting<T>(
+  startup: () => Promise<T>,
+  reporter: StartupErrorReporter,
+): Promise<T> {
+  try {
+    return await startup();
+  } catch (error) {
+    try {
+      reporter.captureApplicationError(error, { boundary: "process.startup" });
+    } catch (reportingError) {
+      reporter.onReportingError?.("capture", reportingError);
+    }
+    try {
+      await reporter.flushApplicationErrors(STARTUP_ERROR_FLUSH_TIMEOUT_MS);
+    } catch (reportingError) {
+      reporter.onReportingError?.("flush", reportingError);
+    }
+    throw error;
+  }
 }
 
 async function runSplit(options: ServeOptions): Promise<void> {
@@ -56,40 +91,54 @@ async function runProductionServer(options: ServeOptions): Promise<void> {
   } = await import("veryfront/observability/sentry");
   await initializeSentryFromEnv();
 
-  const { clearAllLocalCaches } = await import(
-    "veryfront/transforms/mdx-cache"
-  );
-  await clearAllLocalCaches();
+  const { server, shutdownController } = await runWithStartupErrorReporting(
+    async () => {
+      const { clearAllLocalCaches } = await import(
+        "veryfront/transforms/mdx-cache"
+      );
+      await clearAllLocalCaches();
 
-  const { initializeOTLPWithApis } = await import(
-    "veryfront/observability/otlp-setup"
-  );
-  const { initializeDistributedCaches } = await import(
-    "veryfront/cache"
-  );
-  const { defaultDistributedCacheInitializers } = await import(
-    "veryfront/server"
-  );
-  await Promise.allSettled([
-    initializeOTLPWithApis(),
-    initializeDistributedCaches(defaultDistributedCacheInitializers),
-  ]);
+      const { initializeOTLPWithApis } = await import(
+        "veryfront/observability/otlp-setup"
+      );
+      const { initializeDistributedCaches } = await import(
+        "veryfront/cache"
+      );
+      const { defaultDistributedCacheInitializers } = await import(
+        "veryfront/server"
+      );
+      await Promise.allSettled([
+        initializeOTLPWithApis(),
+        initializeDistributedCaches(defaultDistributedCacheInitializers),
+      ]);
 
-  const projectDir = cwd();
-  const shutdownController = new AbortController();
+      const projectDir = cwd();
+      const shutdownController = new AbortController();
+      const defaultProjectId = generateDefaultProjectId(projectDir);
 
-  const defaultProjectId = generateDefaultProjectId(projectDir);
+      const server = await startCliProductionServer({
+        projectDir,
+        port: options.port,
+        bindAddress: options.bindAddress,
+        debug: options.debug,
+        signal: shutdownController.signal,
+        defaultProjectSlug: defaultProjectId,
+        defaultProjectId,
+      });
+      await server.ready;
 
-  const server = await startCliProductionServer({
-    projectDir,
-    port: options.port,
-    bindAddress: options.bindAddress,
-    debug: options.debug,
-    signal: shutdownController.signal,
-    defaultProjectSlug: defaultProjectId,
-    defaultProjectId,
-  });
-  await server.ready;
+      return { server, shutdownController };
+    },
+    {
+      captureApplicationError,
+      flushApplicationErrors,
+      onReportingError: (operation, error) =>
+        cliLogger.warn(
+          `Error reporter failed to ${operation} production startup failure:`,
+          error,
+        ),
+    },
+  );
 
   let shuttingDown = false;
   const shutdown = async (signal: "SIGINT" | "SIGTERM"): Promise<void> => {

--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -20,6 +20,26 @@ type StartupErrorReporter = {
   ) => void;
 };
 
+type StartupErrorReportingOptions = {
+  flushTimeoutMs?: number;
+};
+
+type ProductionServerDependencies = {
+  ensureBundlerContracts?: () => Promise<void>;
+  initializeErrorReporting?: () => Promise<unknown>;
+  reporter?: StartupErrorReporter;
+};
+
+type ServeCommandDependencies = {
+  runProductionServer?: (options: ServeOptions) => Promise<void>;
+};
+
+type ProductionSentryModule = {
+  captureApplicationError: StartupErrorReporter["captureApplicationError"];
+  flushApplicationErrors: StartupErrorReporter["flushApplicationErrors"];
+  initializeSentryFromEnv: () => Promise<unknown>;
+};
+
 export interface ServeOptions {
   mode: "combined" | "proxy" | "production";
   port: number;
@@ -33,21 +53,61 @@ export interface ServeOptions {
 export async function runWithStartupErrorReporting<T>(
   startup: () => Promise<T>,
   reporter: StartupErrorReporter,
+  options: StartupErrorReportingOptions = {},
 ): Promise<T> {
+  const flushTimeoutMs = options.flushTimeoutMs ?? STARTUP_ERROR_FLUSH_TIMEOUT_MS;
   try {
     return await startup();
   } catch (error) {
+    const reportingDeadline = Date.now() + flushTimeoutMs;
     try {
       reporter.captureApplicationError(error, { boundary: "process.startup" });
     } catch (reportingError) {
-      reporter.onReportingError?.("capture", reportingError);
+      notifyReportingError(reporter, "capture", reportingError);
     }
     try {
-      await reporter.flushApplicationErrors(STARTUP_ERROR_FLUSH_TIMEOUT_MS);
+      await flushReporterWithDeadline(
+        reporter,
+        Math.max(0, reportingDeadline - Date.now()),
+      );
     } catch (reportingError) {
-      reporter.onReportingError?.("flush", reportingError);
+      notifyReportingError(reporter, "flush", reportingError);
     }
     throw error;
+  }
+}
+
+function notifyReportingError(
+  reporter: StartupErrorReporter,
+  operation: "capture" | "flush",
+  error: unknown,
+): void {
+  try {
+    reporter.onReportingError?.(operation, error);
+  } catch {
+    // Diagnostics must never replace the startup failure being reported.
+  }
+}
+
+async function flushReporterWithDeadline(
+  reporter: StartupErrorReporter,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const flush = Promise.resolve()
+    .then(() => reporter.flushApplicationErrors(timeoutMs))
+    .catch((error) => {
+      notifyReportingError(reporter, "flush", error);
+      return false;
+    });
+  const deadline = new Promise<boolean>((resolve) => {
+    timeoutId = setTimeout(() => resolve(false), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([flush, deadline]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
   }
 }
 
@@ -55,8 +115,10 @@ export async function runProductionStartupWithErrorReporting<T>(
   startup: () => Promise<T>,
   reporter: StartupErrorReporter,
   ensureBundlerContracts: () => Promise<void> = ensureCliBundlerContracts,
+  initializeObservability: () => Promise<unknown> = () => Promise.resolve(),
 ): Promise<T> {
   return await runWithStartupErrorReporting(async () => {
+    await initializeObservability();
     await ensureBundlerContracts();
     return await startup();
   }, reporter);
@@ -93,15 +155,32 @@ async function runProxy(options: ServeOptions): Promise<void> {
   await new Promise(() => {});
 }
 
-async function runProductionServer(options: ServeOptions): Promise<void> {
-  showLogo();
+function createProductionStartupErrorReporter(
+  sentryModule: ProductionSentryModule,
+): StartupErrorReporter {
+  return {
+    captureApplicationError: sentryModule.captureApplicationError,
+    flushApplicationErrors: sentryModule.flushApplicationErrors,
+    onReportingError: (operation, error) => {
+      cliLogger.warn(
+        `Error reporter failed to ${operation} production startup failure.`,
+      );
+      cliLogger.debug(
+        `Error reporter ${operation} failure details:`,
+        error,
+      );
+    },
+  };
+}
 
-  const {
-    captureApplicationError,
-    flushApplicationErrors,
-    initializeSentryFromEnv,
-  } = await import("veryfront/observability/sentry");
-  await initializeSentryFromEnv();
+export async function runProductionServer(
+  options: ServeOptions,
+  dependencies: ProductionServerDependencies = {},
+): Promise<void> {
+  showLogo();
+  const sentryModule = await import("veryfront/observability/sentry");
+  const reporter = dependencies.reporter ??
+    createProductionStartupErrorReporter(sentryModule);
 
   const { server, shutdownController } = await runProductionStartupWithErrorReporting(
     async () => {
@@ -141,19 +220,10 @@ async function runProductionServer(options: ServeOptions): Promise<void> {
 
       return { server, shutdownController };
     },
-    {
-      captureApplicationError,
-      flushApplicationErrors,
-      onReportingError: (operation, error) => {
-        cliLogger.warn(
-          `Error reporter failed to ${operation} production startup failure.`,
-        );
-        cliLogger.debug(
-          `Error reporter ${operation} failure details:`,
-          error,
-        );
-      },
-    },
+    reporter,
+    dependencies.ensureBundlerContracts ?? ensureCliBundlerContracts,
+    dependencies.initializeErrorReporting ??
+      (() => sentryModule.initializeSentryFromEnv()),
   );
 
   let shuttingDown = false;
@@ -169,10 +239,10 @@ async function runProductionServer(options: ServeOptions): Promise<void> {
         logger: cliLogger,
       });
     } catch (error) {
-      captureApplicationError(error, { boundary: "process.shutdown" });
+      reporter.captureApplicationError(error, { boundary: "process.shutdown" });
       cliLogger.warn("Error while shutting down production server:", error);
     } finally {
-      await flushApplicationErrors();
+      await reporter.flushApplicationErrors();
       exitProcess(0);
     }
   };
@@ -182,7 +252,10 @@ async function runProductionServer(options: ServeOptions): Promise<void> {
   await new Promise(() => {});
 }
 
-export async function serveCommand(options: ServeOptions): Promise<void> {
+export async function serveCommand(
+  options: ServeOptions,
+  dependencies: ServeCommandDependencies = {},
+): Promise<void> {
   if (options.splitMode) {
     await runSplit(options);
     return;
@@ -194,6 +267,6 @@ export async function serveCommand(options: ServeOptions): Promise<void> {
   }
 
   if (options.mode === "production" || options.mode === "combined") {
-    await runProductionServer(options);
+    await (dependencies.runProductionServer ?? runProductionServer)(options);
   }
 }

--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -164,6 +164,9 @@ function createDeferredProductionStartupErrorReporter(): {
 
   return {
     reporter: {
+      // If Sentry module acquisition fails, no remote transport exists yet.
+      // Preserve the acquisition failure and bound flush instead of adding a
+      // fallback reporter inside the startup path.
       captureApplicationError: (error, context) =>
         sentryModule?.captureApplicationError(error, context),
       flushApplicationErrors: (timeoutMs) =>

--- a/cli/commands/serve/handler.ts
+++ b/cli/commands/serve/handler.ts
@@ -1,14 +1,21 @@
 import { defineSchema, lazySchema } from "veryfront/schemas";
-import { getEnv, getEnvNumber } from "#veryfront/compat/process.ts";
+import { getEnv } from "veryfront/platform";
 import { DEFAULT_DEV_SERVER_PORT } from "#cli/utils";
 import { ServerModeSchema } from "#cli/shared/types";
 import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
 import type { ParsedArgs } from "#cli/shared/types";
 
+function readPortEnv(name: string, fallback: number): number {
+  const value = getEnv(name);
+  if (value === undefined) return fallback;
+  const port = Number.parseInt(value, 10);
+  return Number.isNaN(port) ? fallback : port;
+}
+
 function getDefaultServePort(): number {
-  const veryfrontPort = getEnvNumber("VERYFRONT_PORT", DEFAULT_DEV_SERVER_PORT);
-  return getEnvNumber("PORT", veryfrontPort);
+  const veryfrontPort = readPortEnv("VERYFRONT_PORT", DEFAULT_DEV_SERVER_PORT);
+  return readPortEnv("PORT", veryfrontPort);
 }
 
 function getDefaultBindAddress(): string {
@@ -59,7 +66,9 @@ export const parseServeArgs: typeof parseServeArgsBase = (args) => {
 
 export async function handleServeCommand(args: ParsedArgs): Promise<void> {
   const opts = parseArgsOrThrow(parseServeArgs, "serve", args);
-  await ensureCliBundlerContracts();
+  if (opts.split || opts.mode === "proxy") {
+    await ensureCliBundlerContracts();
+  }
   const { serveCommand } = await import("./command.ts");
   await serveCommand({
     mode: opts.mode as "production" | "proxy" | "combined",


### PR DESCRIPTION
## Summary

- report `veryfront serve` production startup failures to the framework Sentry client
- flush for at most two seconds before preserving the existing non-zero failure path
- keep the original startup error even if capture or flush reporting fails

## Root cause

The production request/shutdown boundaries only become active after server construction. Failures while clearing caches, initializing dependencies, constructing the production server, or waiting for readiness therefore bypassed Sentry.

## Validation

- `deno fmt --check cli/commands/serve/command.ts cli/commands/serve/command.test.ts`
- `deno check cli/commands/serve/command.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/commands/serve/` — 3 modules, 52 steps, 0 failures
- regression proves one `process.startup` capture, one 2,000 ms flush, and exact original-error identity

The repository-wide pre-commit `verify:quick` currently stops on five CLI-boundary violations already present on `main` and outside this diff.

## Rollout verification

After deployment, trigger the approved synthetic production-startup failure and confirm the event is retrievable in Sentry before closing the tracking issue.

Related: veryfront/veryfront-issue-inbox#299
