### PR TITLE
fix: preserve replayed message attachments

### DIFF
--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -649,7 +649,7 @@ Clear all stored messages from memory.
 | `mirrorDefaultResearchRunArtifact` | Mirror default research run artifact helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/artifacts/default-research-artifact-support.ts#L299) |
 | `monitorConversationRunStatus` | Monitor conversation run status helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable.ts#L929) |
 | `monitorHostedChildRunStatus` | Monitor hosted child run status helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/child-status.ts#L149) |
-| `normalizeAgUiBrowserRuntimeRequest` | Request payload for normalize AG-UI browser runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L199) |
+| `normalizeAgUiBrowserRuntimeRequest` | Request payload for normalize AG-UI browser runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L215) |
 | `normalizeAgUiMessages` | Normalizes AG-UI messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/host-support.ts#L384) |
 | `normalizeAgUiRuntimeMessages` | Normalizes AG-UI runtime messages. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-support.ts#L18) |
 | `normalizeChatMessageMetadata` | Normalizes chat message metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/chat-ui-message-helpers.ts#L192) |
@@ -672,8 +672,8 @@ Clear all stored messages from memory.
 | `parseAgUiContextString` | Parses AG-UI context string. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/forwarded-context.ts#L40) |
 | `parseAgUiRequest` | Request payload for parse AG-UI. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/host-support.ts#L369) |
 | `parseAgUiRequestOrError` | Error shape for parse AG-UI request or. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/host-support.ts#L374) |
-| `parseAgUiRuntimeRequest` | Request payload for parse AG-UI runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L223) |
-| `parseAgUiRuntimeRequestOrError` | Error shape for parse AG-UI runtime request or. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L228) |
+| `parseAgUiRuntimeRequest` | Request payload for parse AG-UI runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L239) |
+| `parseAgUiRuntimeRequestOrError` | Error shape for parse AG-UI runtime request or. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L244) |
 | `parseAgUiSseResponse` | Parse an AG-UI SSE `Response` into normalized events, text, tool starts, and terminal error state. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/sse-parser.ts#L258) |
 | `parseAppendConversationRunEventsErrorBody` | Parses append conversation run events error body. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable-append-errors.ts#L22) |
 | `parseDataStreamSseEvents` | Parses data stream sse events. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/streaming/data-stream.ts#L14) |
@@ -979,17 +979,17 @@ Clear all stored messages from memory.
 | `AgUiResumeValue` | Public API contract for AG-UI resume value. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/tool-shared.ts#L11) |
 | `AgUiRuntimeChatStreamEncoder` | Public API contract for AG-UI runtime chat stream encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-chat-stream-encoder.ts#L48) |
 | `AgUiRuntimeChatStreamEncoderState` | State for AG-UI runtime chat stream encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-chat-stream-encoder.ts#L41) |
-| `AgUiRuntimeContextItem` | Public API contract for AG-UI runtime context item. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L190) |
+| `AgUiRuntimeContextItem` | Public API contract for AG-UI runtime context item. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L206) |
 | `AgUiRuntimeEventEncoder` | Public API contract for AG-UI runtime event encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-event-encoder.ts#L13) |
 | `AgUiRuntimeHandlerConfig` | Configuration used by AG-UI runtime handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L397) |
 | `AgUiRuntimeHandlerConfigWithAgent` | Public API contract for AG-UI runtime handler config with agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L392) |
 | `AgUiRuntimeHandlerExecute` | Public API contract for AG-UI runtime handler execute. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L356) |
 | `AgUiRuntimeHandlerExecuteInput` | Input payload for AG-UI runtime handler execute. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L348) |
 | `AgUiRuntimeHandlerOptions` | Options accepted by AG-UI runtime handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L378) |
-| `AgUiRuntimeInjectedTool` | Public API contract for AG-UI runtime injected tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L186) |
+| `AgUiRuntimeInjectedTool` | Public API contract for AG-UI runtime injected tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L202) |
 | `AgUiRuntimeLifecycleContext` | Context for AG-UI runtime lifecycle. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L34) |
-| `AgUiRuntimeMessage` | Message shape for AG-UI runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L194) |
-| `AgUiRuntimeRequest` | Request payload for AG-UI runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L196) |
+| `AgUiRuntimeMessage` | Message shape for AG-UI runtime, including optional user-message attachments. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L210) |
+| `AgUiRuntimeRequest` | Request payload for AG-UI runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L212) |
 | `AgUiRuntimeStreamEvent` | Event emitted for AG-UI runtime stream. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L4) |
 | `AgUiSseEvent` | Event emitted for AG-UI sse. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/host-support.ts#L18) |
 | `AgUiSseEventType` | Normalized AG-UI runtime event type value. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/sse-parser.ts#L27) |
@@ -1620,8 +1620,8 @@ Clear all stored messages from memory.
 | `defaultHostedInvokeAgentSelectionSchema` | Schema for default hosted invoke agent selection. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/default-invoke-agent-tool.ts#L214) |
 | `getAgUiRuntimeContextItemSchema` | Zod schema for get AG-UI runtime context item. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L60) |
 | `getAgUiRuntimeInjectedToolSchema` | Zod schema for get AG-UI runtime injected tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L46) |
-| `getAgUiRuntimeMessageSchema` | Zod schema for get AG-UI runtime message. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L146) |
-| `getAgUiRuntimeRequestSchema` | Zod schema for get AG-UI runtime request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L166) |
+| `getAgUiRuntimeMessageSchema` | Zod schema for AG-UI runtime messages, including optional user-message attachments. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L162) |
+| `getAgUiRuntimeRequestSchema` | Zod schema for get AG-UI runtime request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L182) |
 | `getCreateInputRequestRequestSchema` | Zod schema for get create input request request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/input/request-protocol.ts#L24) |
 | `getCreateInputRequestResponseSchema` | Zod schema for get create input request response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/input/request-protocol.ts#L158) |
 | `getFormInputToolInputSchema` | Zod schema for get form input tool input. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/input/request-protocol.ts#L11) |

--- a/src/agent/ag-ui/runtime-support.test.ts
+++ b/src/agent/ag-ui/runtime-support.test.ts
@@ -4,6 +4,40 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { normalizeAgUiRuntimeMessages } from "./runtime-support.ts";
 
 describe("agent/ag-ui-runtime-support", () => {
+  it("canonicalizes legacy upload metadata on user attachments", () => {
+    const messages = normalizeAgUiRuntimeMessages([
+      {
+        id: "user-1",
+        role: "user",
+        content: "Review this screenshot",
+        attachments: [{
+          type: "file",
+          url: "https://uploads.example.com/screenshot.png",
+          mediaType: "image/png",
+          upload_id: "upload-image-1",
+          upload_path: "_chat/user/upload-image-1-screenshot.png",
+          filename: "screenshot.png",
+        }],
+      },
+    ]);
+
+    assertEquals(messages, [{
+      id: "user-1",
+      role: "user",
+      parts: [
+        { type: "text", text: "Review this screenshot" },
+        {
+          type: "file",
+          url: "https://uploads.example.com/screenshot.png",
+          mediaType: "image/png",
+          uploadId: "upload-image-1",
+          uploadPath: "_chat/user/upload-image-1-screenshot.png",
+          filename: "screenshot.png",
+        },
+      ],
+    }]);
+  });
+
   it("infers tool message names from preceding assistant runtime tool calls", () => {
     const messages = normalizeAgUiRuntimeMessages([
       {

--- a/src/agent/ag-ui/runtime-support.ts
+++ b/src/agent/ag-ui/runtime-support.ts
@@ -25,9 +25,15 @@ export function normalizeAgUiRuntimeMessages(
 
     switch (message.role) {
       case "system":
-      case "user":
         toolNamesById.clear();
         parts.push({ type: "text", text: message.content });
+        break;
+      case "user":
+        toolNamesById.clear();
+        if (message.content.length > 0) {
+          parts.push({ type: "text", text: message.content });
+        }
+        parts.push(...message.attachments ?? []);
         break;
       case "assistant":
         if (typeof message.content === "string" && message.content.length > 0) {

--- a/src/agent/ag-ui/runtime-support.ts
+++ b/src/agent/ag-ui/runtime-support.ts
@@ -14,6 +14,32 @@ function parseToolArguments(serializedArguments: string): Record<string, unknown
   }
 }
 
+type AgUiRuntimeUserMessage = Extract<
+  AgUiRuntimeRequest["messages"][number],
+  { role: "user" }
+>;
+type AgUiRuntimeAttachment = NonNullable<
+  AgUiRuntimeUserMessage["attachments"]
+>[number];
+
+function normalizeRuntimeAttachment(
+  attachment: AgUiRuntimeAttachment,
+): Message["parts"][number] {
+  const {
+    upload_id: legacyUploadId,
+    upload_path: legacyUploadPath,
+    ...canonicalAttachment
+  } = attachment;
+  const uploadId = canonicalAttachment.uploadId ?? legacyUploadId;
+  const uploadPath = canonicalAttachment.uploadPath ?? legacyUploadPath;
+
+  return {
+    ...canonicalAttachment,
+    ...(uploadId ? { uploadId } : {}),
+    ...(uploadPath ? { uploadPath } : {}),
+  };
+}
+
 /** Normalizes AG-UI runtime messages. */
 export function normalizeAgUiRuntimeMessages(
   messages: AgUiRuntimeRequest["messages"],
@@ -33,7 +59,7 @@ export function normalizeAgUiRuntimeMessages(
         if (message.content.length > 0) {
           parts.push({ type: "text", text: message.content });
         }
-        parts.push(...message.attachments ?? []);
+        parts.push(...(message.attachments ?? []).map(normalizeRuntimeAttachment));
         break;
       case "assistant":
         if (typeof message.content === "string" && message.content.length > 0) {

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1452,6 +1452,10 @@ describe("agent/hosted-chat-request", () => {
           role: "user",
           parts: [
             {
+              type: "text",
+              text: "Review these attachments.",
+            },
+            {
               type: "image",
               upload_id: "upload-image-1",
               media_type: "image/png",
@@ -1470,6 +1474,10 @@ describe("agent/hosted-chat-request", () => {
     });
 
     const expectedParts = [
+      {
+        type: "text",
+        text: "Review these attachments.",
+      },
       {
         type: "file",
         uploadId: "upload-image-1",

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1443,6 +1443,68 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(request.messages[0]?.parts as unknown, rawReplayParts);
   });
 
+  it("normalizes persisted uploaded file parts from runtime invocations", async () => {
+    const invocation = RuntimeAgentRunInvocationSchema.parse({
+      ...createRuntimeInvocation(),
+      messages: [
+        {
+          id: "user-message-1",
+          role: "user",
+          parts: [
+            {
+              type: "image",
+              upload_id: "upload-image-1",
+              media_type: "image/png",
+              url: "https://uploads.example.com/screenshot.png",
+            },
+            {
+              type: "file",
+              upload_id: "upload-file-1",
+              media_type: "application/pdf",
+              url: "https://uploads.example.com/report.pdf",
+              filename: "report.pdf",
+            },
+          ],
+        },
+      ],
+    });
+
+    const expectedParts = [
+      {
+        type: "file",
+        uploadId: "upload-image-1",
+        mediaType: "image/png",
+        url: "https://uploads.example.com/screenshot.png",
+      },
+      {
+        type: "file",
+        uploadId: "upload-file-1",
+        mediaType: "application/pdf",
+        url: "https://uploads.example.com/report.pdf",
+        filename: "report.pdf",
+      },
+    ];
+    const request = buildHostedChatRequestFromRuntimeAgentInvocation(invocation);
+    const parsed = await parseRuntimeAgentRunInvocationHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/control-plane/runs/run_1/stream", {
+        method: "POST",
+        body: JSON.stringify(invocation),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: () => Promise.resolve({ success: true }),
+        runtimeSource,
+      },
+    );
+
+    if (parsed instanceof Response) {
+      throw new Error("Expected parsed runtime invocation");
+    }
+
+    assertEquals(request.messages[0]?.parts as unknown, expectedParts);
+    assertEquals(parsed.messages[0]?.parts as unknown, expectedParts);
+  });
+
   it("carries environment runtime target metadata from runtime invocations", () => {
     const baseInvocation = createRuntimeInvocation();
     const invocation = RuntimeAgentRunInvocationSchema.parse({

--- a/src/agent/hosted/chat-request.ts
+++ b/src/agent/hosted/chat-request.ts
@@ -481,6 +481,57 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function getNonEmptyStringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function normalizeHostedRuntimeInvocationMessagePart(part: unknown): unknown {
+  if (!isRecord(part) || (part.type !== "file" && part.type !== "image")) {
+    return part;
+  }
+
+  const mediaType = getNonEmptyStringField(part, "mediaType") ??
+    getNonEmptyStringField(part, "media_type");
+  const url = getNonEmptyStringField(part, "url");
+  if (!mediaType || !url) {
+    return part;
+  }
+
+  const uploadId = getNonEmptyStringField(part, "uploadId") ??
+    getNonEmptyStringField(part, "upload_id");
+  const uploadPath = getNonEmptyStringField(part, "uploadPath") ??
+    getNonEmptyStringField(part, "upload_path");
+  const filename = getNonEmptyStringField(part, "filename");
+
+  return {
+    type: "file",
+    mediaType,
+    url,
+    ...(filename ? { filename } : {}),
+    ...(uploadId ? { uploadId } : {}),
+    ...(uploadPath ? { uploadPath } : {}),
+  };
+}
+
+function normalizeHostedRuntimeInvocationMessages(
+  messages: RuntimeAgentRunInvocation["messages"],
+): RuntimeAgentRunInvocation["messages"] {
+  return messages.map((message) => {
+    if (!isRecord(message) || !Array.isArray(message.parts)) {
+      return message;
+    }
+
+    return {
+      ...message,
+      parts: message.parts.map(normalizeHostedRuntimeInvocationMessagePart),
+    };
+  });
+}
+
 function getStudioRuntimeEnvironmentContext(input: RuntimeAgentRunInvocation): string | undefined {
   for (const item of input.context) {
     if (item.type !== "json" || item.title !== "studio_context") continue;
@@ -529,7 +580,7 @@ export function buildHostedChatRequestInputFromRuntimeAgentInvocation(
   const runtimeTargetKind = getRuntimeTargetKind(input.run.project.runtimeTargetKind);
 
   return {
-    messages: input.messages,
+    messages: normalizeHostedRuntimeInvocationMessages(input.messages),
     context: {
       conversationId: input.run.conversationId,
       projectId: input.run.project.projectId,

--- a/src/agent/runtime/ag-ui-contract.ts
+++ b/src/agent/runtime/ag-ui-contract.ts
@@ -118,11 +118,21 @@ export const getAgUiRuntimeAttachmentSchema = defineSchema((v) =>
       type: v.literal("image"),
       url: v.string().min(1),
       mediaType: v.string().min(1),
+      uploadId: v.string().min(1).optional(),
+      upload_id: v.string().min(1).optional(),
+      uploadPath: v.string().min(1).optional(),
+      upload_path: v.string().min(1).optional(),
+      filename: v.string().min(1).optional(),
     }).strict(),
     v.object({
       type: v.literal("file"),
       url: v.string().min(1),
       mediaType: v.string().min(1),
+      uploadId: v.string().min(1).optional(),
+      upload_id: v.string().min(1).optional(),
+      uploadPath: v.string().min(1).optional(),
+      upload_path: v.string().min(1).optional(),
+      filename: v.string().min(1).optional(),
     }).strict(),
   ])
 );

--- a/src/agent/runtime/ag-ui-contract.ts
+++ b/src/agent/runtime/ag-ui-contract.ts
@@ -112,11 +112,27 @@ export const getAgUiRuntimeSystemMessageSchema = defineSchema((v) =>
   }).strict()
 );
 
+export const getAgUiRuntimeAttachmentSchema = defineSchema((v) =>
+  v.discriminatedUnion("type", [
+    v.object({
+      type: v.literal("image"),
+      url: v.string().min(1),
+      mediaType: v.string().min(1),
+    }).strict(),
+    v.object({
+      type: v.literal("file"),
+      url: v.string().min(1),
+      mediaType: v.string().min(1),
+    }).strict(),
+  ])
+);
+
 export const getAgUiRuntimeUserMessageSchema = defineSchema((v) =>
   v.object({
     id: v.string().min(1),
     role: v.literal("user"),
     content: v.string(),
+    attachments: v.array(getAgUiRuntimeAttachmentSchema()).optional(),
     ...runtimeMessageExtensionFields(v),
   }).strict()
 );

--- a/src/agent/runtime/message-adapter.ts
+++ b/src/agent/runtime/message-adapter.ts
@@ -15,6 +15,23 @@ type StructuredProviderPart = Exclude<ProviderModelMessage["content"], string>[n
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
+type RuntimeAttachmentFields = {
+  url: string;
+  mediaType: string;
+  filename?: string;
+  uploadId?: string;
+  uploadPath?: string;
+};
+
+type RuntimeAttachmentPart =
+  | ({ type: "image" } & RuntimeAttachmentFields)
+  | ({ type: "file" } & RuntimeAttachmentFields);
+
+type RuntimeAttachmentLikePart = RuntimeAttachmentPart & {
+  upload_id?: string;
+  upload_path?: string;
+};
+
 type AgentRuntimeMessageLikePart =
   | { type: "text"; text: string }
   | { type: "reasoning"; text?: string; signature?: string; redactedData?: string }
@@ -62,8 +79,7 @@ type AgentRuntimeMessageLikePart =
     result?: unknown;
     output?: unknown;
   }
-  | { type: "image"; url: string; mediaType: string }
-  | { type: "file"; url: string; mediaType: string }
+  | RuntimeAttachmentLikePart
   | ChatSourceUrlUiPart
   | ChatSourceDocumentUiPart;
 
@@ -83,8 +99,7 @@ export type AgentRuntimeMessagePart =
     toolName: string;
     result: unknown;
   }
-  | { type: "image"; url: string; mediaType: string }
-  | { type: "file"; url: string; mediaType: string }
+  | RuntimeAttachmentPart
   | ChatSourceUrlUiPart
   | ChatSourceDocumentUiPart;
 
@@ -151,11 +166,7 @@ function createTextAgentRuntimePart(text: string): AgentRuntimeMessagePart | nul
 function toNativeFilePart(
   type: "image" | "file",
   part: unknown,
-): { type: "image"; url: string; mediaType: string } | {
-  type: "file";
-  url: string;
-  mediaType: string;
-} | null {
+): RuntimeAttachmentPart | null {
   const url = getOptionalStringField(part, "url");
   const mediaType = getOptionalStringField(part, "mediaType");
   // `data:` URLs (inline base64) are kept: guest / no-project attachments ride
@@ -163,9 +174,23 @@ function toNativeFilePart(
   if (!url || !mediaType) {
     return null;
   }
+
+  const filename = getOptionalStringField(part, "filename");
+  const uploadId = getOptionalStringField(part, "uploadId") ??
+    getOptionalStringField(part, "upload_id");
+  const uploadPath = getOptionalStringField(part, "uploadPath") ??
+    getOptionalStringField(part, "upload_path");
+  const sharedFields = {
+    url,
+    mediaType,
+    ...(filename ? { filename } : {}),
+    ...(uploadId ? { uploadId } : {}),
+    ...(uploadPath ? { uploadPath } : {}),
+  };
+
   return type === "file"
-    ? { type: "file" as const, url, mediaType }
-    : { type: "image" as const, url, mediaType };
+    ? { type: "file" as const, ...sharedFields }
+    : { type: "image" as const, ...sharedFields };
 }
 
 function convertStructuredPart(part: StructuredProviderPart): AgentRuntimeMessagePart | null {
@@ -213,8 +238,10 @@ function convertStructuredPart(part: StructuredProviderPart): AgentRuntimeMessag
 function createAttachmentReference(part: StructuredProviderPart): UploadedFileReference | null {
   const filename = getOptionalStringField(part, "filename");
   const mediaType = getOptionalStringField(part, "mediaType");
-  const uploadId = getOptionalStringField(part, "uploadId");
-  const uploadPath = getOptionalStringField(part, "uploadPath");
+  const uploadId = getOptionalStringField(part, "uploadId") ??
+    getOptionalStringField(part, "upload_id");
+  const uploadPath = getOptionalStringField(part, "uploadPath") ??
+    getOptionalStringField(part, "upload_path");
   const url = getOptionalStringField(part, "url");
 
   if (!mediaType) {

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -779,6 +779,7 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages preserves persisted uploade
       type: "image",
       url: "https://signed.example.com/web-app-screenshot.jpg",
       mediaType: "image/jpeg",
+      uploadId: "upload-image-1",
     },
     {
       type: "text",

--- a/src/agent/schemas/agent.schema.ts
+++ b/src/agent/schemas/agent.schema.ts
@@ -113,6 +113,14 @@ const sourceDocumentPartShape = (v: SchemaValidator) =>
     filename: v.string().optional(),
   });
 
+const attachmentMetadataFields = (v: SchemaValidator) => ({
+  filename: v.string().optional(),
+  uploadId: v.string().optional(),
+  upload_id: v.string().optional(),
+  uploadPath: v.string().optional(),
+  upload_path: v.string().optional(),
+});
+
 export const getMessagePartSchema = defineSchema((v) =>
   v.union([
     v.object({
@@ -134,11 +142,13 @@ export const getMessagePartSchema = defineSchema((v) =>
       type: v.literal("image"),
       url: v.string(),
       mediaType: v.string(),
+      ...attachmentMetadataFields(v),
     }),
     v.object({
       type: v.literal("file"),
       url: v.string(),
       mediaType: v.string(),
+      ...attachmentMetadataFields(v),
     }),
   ])
 );

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -224,6 +224,40 @@ describe("internal-agents/schema", () => {
     assertEquals(parsed.context, [{ description: "Current file", value: "src/main.ts" }]);
   });
 
+  it("accepts upload metadata on AG-UI runtime attachments", () => {
+    const parsed = getRuntimeRunAgentInputSchema().parse({
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [{
+        id: "user_1",
+        role: "user",
+        content: "Review this screenshot",
+        attachments: [{
+          type: "file",
+          url: "https://uploads.example.com/screenshot.png",
+          mediaType: "image/png",
+          uploadId: "upload-image-1",
+          uploadPath: "_chat/user/upload-image-1-screenshot.png",
+          filename: "screenshot.png",
+        }],
+      }],
+    });
+
+    assertEquals(parsed.messages[0], {
+      id: "user_1",
+      role: "user",
+      content: "Review this screenshot",
+      attachments: [{
+        type: "file",
+        url: "https://uploads.example.com/screenshot.png",
+        mediaType: "image/png",
+        uploadId: "upload-image-1",
+        uploadPath: "_chat/user/upload-image-1-screenshot.png",
+        filename: "screenshot.png",
+      }],
+    });
+  });
+
   it("does not dual-read the runtime invocation transport as an internal request", () => {
     assertThrows(() =>
       getInternalAgentStreamRequestSchema().parse({
@@ -323,6 +357,50 @@ describe("internal-agents/schema", () => {
       tools: [],
       context: [{ type: "text", text: "Current file: src/main.ts" }],
     });
+  });
+
+  it("preserves upload metadata while normalizing compatibility attachment parts", () => {
+    const internalRequest = getInternalAgentStreamRequestSchema().parse({
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      agentSource: { type: "branch", branch: "main" },
+      messages: [
+        {
+          id: "user_1",
+          role: "user",
+          parts: [
+            { type: "text", text: "Review this screenshot" },
+            {
+              type: "file",
+              url: "https://uploads.example.com/screenshot.png",
+              mediaType: "image/png",
+              upload_id: "upload-image-1",
+              upload_path: "_chat/user/upload-image-1-screenshot.png",
+              filename: "screenshot.png",
+            },
+          ],
+        },
+      ],
+      context: [],
+    });
+
+    assertEquals(
+      (toRuntimeRunAgentInput(internalRequest) as unknown as { messages: unknown }).messages,
+      [{
+        id: "user_1",
+        role: "user",
+        content: "Review this screenshot",
+        attachments: [{
+          type: "file",
+          url: "https://uploads.example.com/screenshot.png",
+          mediaType: "image/png",
+          uploadId: "upload-image-1",
+          uploadPath: "_chat/user/upload-image-1-screenshot.png",
+          filename: "screenshot.png",
+        }],
+      }],
+    );
   });
 
   it("rejects legacy endUserId on internal stream payloads", () => {

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -223,6 +223,23 @@ function stringifyToolResult(result: unknown): string {
   }
 }
 
+function getRuntimeAttachment(
+  part: Record<string, unknown>,
+): { type: "image" | "file"; url: string; mediaType: string } | null {
+  const type = getPartString(part, "type");
+  if (type !== "image" && type !== "file") {
+    return null;
+  }
+
+  const url = getPartString(part, "url");
+  const mediaType = getPartString(part, "mediaType", "media_type");
+  if (!url || !mediaType) {
+    return null;
+  }
+
+  return { type, url, mediaType };
+}
+
 function toRuntimeMessage(
   message: RuntimeMessage | InternalAgentCompatibilityMessage,
 ): RuntimeMessage {
@@ -238,6 +255,11 @@ function toRuntimeMessage(
     .filter((part) => part.type === "text" && typeof part.text === "string")
     .map((part) => part.text as string)
     .join("\n");
+  const attachments = (message.parts as ReadonlyArray<Record<string, unknown>>)
+    .flatMap((part) => {
+      const attachment = getRuntimeAttachment(part);
+      return attachment ? [attachment] : [];
+    });
 
   // Use the conditional-spread pattern (omitting keys entirely when not
   // present) to preserve the pre-migration runtime semantics. Cast the
@@ -261,6 +283,7 @@ function toRuntimeMessage(
         id: message.id,
         role: "user",
         content: textContent,
+        ...(attachments.length ? { attachments } : {}),
         ...sharedFields,
       } as RuntimeMessage;
     case "assistant": {

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -101,6 +101,14 @@ type RuntimeMessage = AgUiRuntimeMessage;
 type InternalAgentCompatibilityMessage = InferSchema<
   ReturnType<typeof getInternalAgentCompatibilityMessageSchema>
 >;
+type RuntimeAttachment = {
+  type: "image" | "file";
+  url: string;
+  mediaType: string;
+  uploadId?: string;
+  uploadPath?: string;
+  filename?: string;
+};
 
 function isRecordObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -225,7 +233,7 @@ function stringifyToolResult(result: unknown): string {
 
 function getRuntimeAttachment(
   part: Record<string, unknown>,
-): { type: "image" | "file"; url: string; mediaType: string } | null {
+): RuntimeAttachment | null {
   const type = getPartString(part, "type");
   if (type !== "image" && type !== "file") {
     return null;
@@ -237,7 +245,18 @@ function getRuntimeAttachment(
     return null;
   }
 
-  return { type, url, mediaType };
+  const uploadId = getPartString(part, "uploadId", "upload_id");
+  const uploadPath = getPartString(part, "uploadPath", "upload_path");
+  const filename = getPartString(part, "filename");
+
+  return {
+    type,
+    url,
+    mediaType,
+    ...(uploadId ? { uploadId } : {}),
+    ...(uploadPath ? { uploadPath } : {}),
+    ...(filename ? { filename } : {}),
+  };
 }
 
 function toRuntimeMessage(

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -278,12 +278,23 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(streamContext?.threadId, "10000000-1000-4000-8000-100000000001");
     assertEquals(typeof runtimeSystem, "function");
     assertEquals(
-      runtimeMessages?.[0]?.parts.find((part) => part.type === "image"),
-      {
-        type: "image",
-        mediaType: "image/png",
-        url: "https://uploads.example.com/screenshot.png",
-      },
+      runtimeMessages?.[0]?.parts,
+      [
+        { type: "text", text: "Hello" },
+        {
+          type: "image",
+          mediaType: "image/png",
+          url: "https://uploads.example.com/screenshot.png",
+        },
+        {
+          type: "text",
+          text: "Attached files from earlier conversation context:\n\n" +
+            "<uploaded_files>\n" +
+            '<file name="image" url="https://uploads.example.com/screenshot.png" ' +
+            'type="image/png" />\n' +
+            "</uploaded_files>",
+        },
+      ],
     );
     const prompt = await (runtimeSystem as () => Promise<string>)();
     assertStringIncludes(

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import type { AgentMessage } from "#veryfront/agent";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
 import type { RuntimeRemoteToolConfig } from "#veryfront/agent/runtime/mcp-server-tool-sources.ts";
 import { getRuntimeSourceIntegrationPolicy } from "#veryfront/agent/runtime/runtime-tool-config.ts";
@@ -194,6 +195,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     let discoveryCalls = 0;
     let streamContext: Record<string, unknown> | undefined;
     let runtimeSystem: unknown;
+    let runtimeMessages: AgentMessage[] | undefined;
     const handler = new AgentStreamHandler({
       ensureProjectDiscovery: async () => {
         discoveryCalls += 1;
@@ -202,8 +204,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
       getAllAgentIds: () => ["assistant-1"],
       sessionManager: new AgentRunSessionManager(),
       createRuntime: (runtimeAgent) => ({
-        stream: async (_messages, context, callbacks) => {
+        stream: async (messages, context, callbacks) => {
           runtimeSystem = runtimeAgent.config.system;
+          runtimeMessages = messages;
           streamContext = context;
           callbacks?.onFinish?.({
             text: "hello from runtime",
@@ -247,6 +250,12 @@ describe("server/handlers/request/agent-stream.handler", () => {
       title: "studio_context",
       data: { branchId: null },
     }];
+    invocation.messages[0].parts.push({
+      type: "image",
+      upload_id: "20000000-2000-4000-8000-200000000001",
+      media_type: "image/png",
+      url: "https://uploads.example.com/screenshot.png",
+    });
     const body = JSON.stringify(invocation);
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
@@ -268,6 +277,14 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(streamContext?.runId, "run_1");
     assertEquals(streamContext?.threadId, "10000000-1000-4000-8000-100000000001");
     assertEquals(typeof runtimeSystem, "function");
+    assertEquals(
+      runtimeMessages?.[0]?.parts.find((part) => part.type === "image"),
+      {
+        type: "image",
+        mediaType: "image/png",
+        url: "https://uploads.example.com/screenshot.png",
+      },
+    );
     const prompt = await (runtimeSystem as () => Promise<string>)();
     assertStringIncludes(
       prompt,

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -251,10 +251,12 @@ describe("server/handlers/request/agent-stream.handler", () => {
       data: { branchId: null },
     }];
     invocation.messages[0].parts.push({
-      type: "image",
-      upload_id: "20000000-2000-4000-8000-200000000001",
-      media_type: "image/png",
+      type: "file",
+      uploadId: "20000000-2000-4000-8000-200000000001",
+      uploadPath: "_chat/user/screenshot.png",
+      mediaType: "image/png",
       url: "https://uploads.example.com/screenshot.png",
+      filename: "screenshot.png",
     });
     const body = JSON.stringify(invocation);
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
@@ -278,19 +280,23 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(streamContext?.threadId, "10000000-1000-4000-8000-100000000001");
     assertEquals(typeof runtimeSystem, "function");
     assertEquals(
-      runtimeMessages?.[0]?.parts,
+      runtimeMessages?.[0]?.parts as unknown,
       [
         { type: "text", text: "Hello" },
         {
-          type: "image",
+          type: "file",
           mediaType: "image/png",
           url: "https://uploads.example.com/screenshot.png",
+          filename: "screenshot.png",
+          uploadId: "20000000-2000-4000-8000-200000000001",
+          uploadPath: "_chat/user/screenshot.png",
         },
         {
           type: "text",
           text: "Attached files from earlier conversation context:\n\n" +
             "<uploaded_files>\n" +
-            '<file name="image" url="https://uploads.example.com/screenshot.png" ' +
+            '<file name="screenshot.png" upload_id="20000000-2000-4000-8000-200000000001" ' +
+            'path="_chat/user/screenshot.png" url="https://uploads.example.com/screenshot.png" ' +
             'type="image/png" />\n' +
             "</uploaded_files>",
         },


### PR DESCRIPTION
## Summary
- normalize persisted snake_case image and file parts at the hosted runtime boundary
- preserve image/file attachments and upload metadata through the custom-agent control-plane AG-UI compatibility bridge
- rebuild native runtime message parts without adding empty text parts to attachment-only messages
- update the generated public agent API reference for runtime attachments

## Root cause
There were two loss points. Hosted runtime invocations could receive persisted upload parts as `image/file + upload_id + media_type`, while hosted validation expects canonical camelCase file parts. Separately, custom project-agent requests are compatibility messages with `parts`; `toRuntimeMessage()` flattened those messages into AG-UI `content` text and discarded every image/file part before `AgentRuntime.stream()`. The first bridge repair also needed to preserve canonical upload metadata, not only the fetchable URL.

## Message shape
```
persisted/API
{ type: "image", upload_id, media_type }

signed runtime invocation
{ type: "file", uploadId, uploadPath?, filename?, mediaType, url }

internal AG-UI bridge
{ role: "user", content, attachments: [{ type: "file", uploadId, uploadPath?, filename?, mediaType, url }] }

provider/runtime message
{ role: "user", parts: [{ type: "text", text }, { type: "file", uploadId, uploadPath?, filename?, mediaType, url }, { type: "text", text: "<uploaded_files>…" }] }
```

The bridge accepts both `image` and `file`, camelCase and legacy snake_case upload metadata, so persisted compatibility input and canonical API input converge on native runtime parts.

## Red / green evidence
- Initial red: hosted parser received persisted snake_case attachment parts
- Control-plane red: the public handler delivered text but no image to the runtime
- Final review red: canonical upload metadata was absent from the runtime-bound part
- Green: route-level canonical file regression plus hosted/internal/AG-UI/adapter/preparation suites pass
- Final focused review: 26 suites / 142 steps passed; Deno check, fmt, lint, and diff hygiene passed
- Final pre-push full unit suite: 2,706 passed, 0 failed
- Generated agent API reference validation passed

## Independent review
- Standards: 98/100
- Spec: 96/100

Companion producer PR: https://github.com/veryfront/veryfront-api/pull/4196
Progress: https://github.com/veryfront/veryfront-issue-inbox/issues/303
