### PR TITLE
Keep generated projects clean after dependency installation

### DIFF
--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -280,7 +280,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   let template: InitTemplate;
   let projectName = name;
-  let initGit = Boolean((options as InitOptions & { initGit?: boolean }).initGit);
+  let initGit = options.initGit ?? false;
 
   // Validate project name before doing anything else
   if (name) {

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -280,7 +280,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   let template: InitTemplate;
   let projectName = name;
-  let initGit = false;
+  let initGit = Boolean((options as InitOptions & { initGit?: boolean }).initGit);
 
   // Validate project name before doing anything else
   if (name) {
@@ -518,22 +518,6 @@ export async function initCommand(options: InitOptions): Promise<void> {
     throw err;
   }
 
-  // Initialize git if requested
-  if (initGit) {
-    const gitSpinner = quiet ? null : createSpinner("Initializing git repository...");
-    try {
-      const { initializeGitRepo } = await import("../../utils/git.ts");
-      const success = await initializeGitRepo(projectDir, projectName ?? "veryfront project");
-      if (success) {
-        gitSpinner?.success("Git repository initialized");
-      } else {
-        gitSpinner?.error("Git initialization failed");
-      }
-    } catch {
-      gitSpinner?.error("Git initialization failed");
-    }
-  }
-
   (options as InitOptions & { _featureTips?: string[] })._featureTips = featureTips;
 
   if (!options.skipInstall) {
@@ -551,6 +535,22 @@ export async function initCommand(options: InitOptions): Promise<void> {
       if (!quiet) {
         logger.warn(`Run '${getInstallCommand(pm)}' manually to install dependencies.`);
       }
+    }
+  }
+
+  // Initialize git if requested
+  if (initGit) {
+    const gitSpinner = quiet ? null : createSpinner("Initializing git repository...");
+    try {
+      const { initializeGitRepo } = await import("../../utils/git.ts");
+      const success = await initializeGitRepo(projectDir, projectName ?? "veryfront project");
+      if (success) {
+        gitSpinner?.success("Git repository initialized");
+      } else {
+        gitSpinner?.error("Git initialization failed");
+      }
+    } catch {
+      gitSpinner?.error("Git initialization failed");
     }
   }
 

--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -16,6 +16,7 @@ import { join } from "#veryfront/compat/path/index.ts";
 import { exists, makeTempDir, readTextFile, remove, stat } from "#veryfront/testing/deno-compat.ts";
 import { runCommand } from "#veryfront/compat/process.ts";
 import { STARTER_TEMPLATE_NAMES } from "../../templates/types.ts";
+import type { InitOptions } from "./types.ts";
 
 const TEST_DIR = await makeTempDir({ prefix: "veryfront-init-test-" });
 const EXPECTED_FAVICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
@@ -45,7 +46,7 @@ function runInitCommand(
 }
 
 function runQuietInitCommand(
-  options: Record<string, unknown>,
+  options: InitOptions,
   cwd = TEST_DIR,
   env?: Record<string, string>,
 ): Promise<{ code: number; stdout?: string; stderr?: string }> {
@@ -71,8 +72,21 @@ async function createFakeNpm(
 ): Promise<{ binDir: string; logPath: string }> {
   const binDir = await makeTempDir({ prefix: "veryfront-fake-npm-" });
   const logPath = join(binDir, "npm.log");
-  const npmPath = join(binDir, "npm");
-  const script = `#!/usr/bin/env sh
+  const isWindows = Deno.build.os === "windows";
+  const npmPath = join(binDir, isWindows ? "npm.cmd" : "npm");
+  const script = isWindows
+    ? [
+      "@echo off",
+      `>>"${logPath}" echo %CD% %*`,
+      ...(mode === "success"
+        ? [
+          `>package-lock.json echo {"lockfileVersion":3,"packages":{}}`,
+          "exit /b 0",
+        ]
+        : ["exit /b 42"]),
+      "",
+    ].join("\r\n")
+    : `#!/usr/bin/env sh
 printf '%s\\n' "$PWD $*" >> "${logPath}"
 if [ "${mode}" = "success" ]; then
   printf '%s\\n' '{"lockfileVersion":3,"packages":{}}' > package-lock.json
@@ -81,13 +95,16 @@ fi
 exit 42
 `;
   await Deno.writeTextFile(npmPath, script);
-  await Deno.chmod(npmPath, 0o755);
+  if (!isWindows) {
+    await Deno.chmod(npmPath, 0o755);
+  }
   return { binDir, logPath };
 }
 
 function withPath(binDir: string): Record<string, string> {
+  const delimiter = Deno.build.os === "windows" ? ";" : ":";
   return {
-    PATH: `${binDir}:${Deno.env.get("PATH") ?? ""}`,
+    PATH: `${binDir}${delimiter}${Deno.env.get("PATH") ?? ""}`,
     GIT_AUTHOR_NAME: "Veryfront Test",
     GIT_AUTHOR_EMAIL: "test@veryfront.local",
     GIT_COMMITTER_NAME: "Veryfront Test",
@@ -250,7 +267,7 @@ describe("init command integration", () => {
         assertEquals(result.code, 0, (result.stdout ?? "") + (result.stderr ?? ""));
         assertEquals(
           await readTextFile(join(dir, "package-lock.json")),
-          '{"lockfileVersion":3,"packages":{}}\n',
+          `{"lockfileVersion":3,"packages":{}}${Deno.build.os === "windows" ? "\r\n" : "\n"}`,
         );
         assertEquals(
           (await runGit(["ls-files", "package-lock.json"], dir)).trim(),

--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -47,6 +47,7 @@ function runInitCommand(
 function runQuietInitCommand(
   options: Record<string, unknown>,
   cwd = TEST_DIR,
+  env?: Record<string, string>,
 ): Promise<{ code: number; stdout?: string; stderr?: string }> {
   const initCommandUrl = new URL("./init-command.ts", import.meta.url).href;
   const configPath = new URL("../../../deno.json", import.meta.url).pathname;
@@ -61,7 +62,47 @@ function runQuietInitCommand(
     ],
     cwd,
     capture: true,
+    env,
   });
+}
+
+async function createFakeNpm(
+  mode: "success" | "failure",
+): Promise<{ binDir: string; logPath: string }> {
+  const binDir = await makeTempDir({ prefix: "veryfront-fake-npm-" });
+  const logPath = join(binDir, "npm.log");
+  const npmPath = join(binDir, "npm");
+  const script = `#!/usr/bin/env sh
+printf '%s\\n' "$PWD $*" >> "${logPath}"
+if [ "${mode}" = "success" ]; then
+  printf '%s\\n' '{"lockfileVersion":3,"packages":{}}' > package-lock.json
+  exit 0
+fi
+exit 42
+`;
+  await Deno.writeTextFile(npmPath, script);
+  await Deno.chmod(npmPath, 0o755);
+  return { binDir, logPath };
+}
+
+function withPath(binDir: string): Record<string, string> {
+  return {
+    PATH: `${binDir}:${Deno.env.get("PATH") ?? ""}`,
+    GIT_AUTHOR_NAME: "Veryfront Test",
+    GIT_AUTHOR_EMAIL: "test@veryfront.local",
+    GIT_COMMITTER_NAME: "Veryfront Test",
+    GIT_COMMITTER_EMAIL: "test@veryfront.local",
+  };
+}
+
+async function runGit(args: string[], cwd: string): Promise<string> {
+  const result = await runCommand("git", {
+    args,
+    cwd,
+    capture: true,
+  });
+  assertEquals(result.code, 0, (result.stdout ?? "") + (result.stderr ?? ""));
+  return result.stdout ?? "";
 }
 
 describe("init command integration", () => {
@@ -187,6 +228,107 @@ describe("init command integration", () => {
   });
 
   describe("file generation", () => {
+    it("commits the lockfile and leaves the scaffold clean after installing dependencies", async () => {
+      const name = `git-lock-${randomSuffix()}`;
+      const dir = join(TEST_DIR, name);
+      const fakeNpm = await createFakeNpm("success");
+
+      try {
+        const result = await runQuietInitCommand(
+          {
+            name,
+            template: "minimal",
+            runtime: "node",
+            initGit: true,
+            skipEnvPrompt: true,
+            quiet: true,
+          },
+          TEST_DIR,
+          withPath(fakeNpm.binDir),
+        );
+
+        assertEquals(result.code, 0, (result.stdout ?? "") + (result.stderr ?? ""));
+        assertEquals(
+          await readTextFile(join(dir, "package-lock.json")),
+          '{"lockfileVersion":3,"packages":{}}\n',
+        );
+        assertEquals(
+          (await runGit(["ls-files", "package-lock.json"], dir)).trim(),
+          "package-lock.json",
+        );
+        assertEquals(await runGit(["status", "--porcelain"], dir), "");
+      } finally {
+        await remove(dir, { recursive: true }).catch(() => {});
+        await remove(fakeNpm.binDir, { recursive: true }).catch(() => {});
+      }
+    });
+
+    it("does not invoke the package manager when install is skipped", async () => {
+      const name = `skip-install-${randomSuffix()}`;
+      const dir = join(TEST_DIR, name);
+      const fakeNpm = await createFakeNpm("success");
+
+      try {
+        const result = await runQuietInitCommand(
+          {
+            name,
+            template: "minimal",
+            runtime: "node",
+            initGit: true,
+            skipInstall: true,
+            skipEnvPrompt: true,
+            quiet: true,
+          },
+          TEST_DIR,
+          withPath(fakeNpm.binDir),
+        );
+
+        assertEquals(result.code, 0, (result.stdout ?? "") + (result.stderr ?? ""));
+        assertEquals(await exists(fakeNpm.logPath), false);
+        assertEquals(await exists(join(dir, "package-lock.json")), false);
+        assertEquals(await runGit(["status", "--porcelain"], dir), "");
+      } finally {
+        await remove(dir, { recursive: true }).catch(() => {});
+        await remove(fakeNpm.binDir, { recursive: true }).catch(() => {});
+      }
+    });
+
+    it("commits generated files and reports npm install recovery when dependency install fails", async () => {
+      const name = `failed-install-${randomSuffix()}`;
+      const dir = join(TEST_DIR, name);
+      const fakeNpm = await createFakeNpm("failure");
+
+      try {
+        const result = await runQuietInitCommand(
+          {
+            name,
+            template: "minimal",
+            runtime: "node",
+            initGit: true,
+            skipEnvPrompt: true,
+          },
+          TEST_DIR,
+          withPath(fakeNpm.binDir),
+        );
+        const output = (result.stdout ?? "") + (result.stderr ?? "");
+
+        assertEquals(result.code, 0, output);
+        assertEquals(output.includes("Run 'npm install' manually to install dependencies."), true);
+        assertEquals(await exists(join(dir, ".git")), true);
+        assertEquals(
+          (await runGit(["ls-files", "app/page.tsx", "package.json", ".gitignore"], dir))
+            .trim()
+            .split("\n")
+            .sort(),
+          [".gitignore", "app/page.tsx", "package.json"],
+        );
+        assertEquals(await runGit(["status", "--porcelain"], dir), "");
+      } finally {
+        await remove(dir, { recursive: true }).catch(() => {});
+        await remove(fakeNpm.binDir, { recursive: true }).catch(() => {});
+      }
+    });
+
     it("should create .env file when scaffolded integrations declare env vars", async () => {
       const result = await runInitCommand([
         projectName,

--- a/cli/commands/init/types.ts
+++ b/cli/commands/init/types.ts
@@ -31,4 +31,6 @@ export interface InitOptions {
   force?: boolean;
   /** Runtime for the scaffolded project. Defaults to "node". */
   runtime?: InitRuntime;
+  /** Initialize Git for programmatic calls; the CLI wizard controls this interactively. */
+  initGit?: boolean;
 }

--- a/src/platform/compat/process/command.test.ts
+++ b/src/platform/compat/process/command.test.ts
@@ -3,6 +3,10 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { deleteEnv, getEnv, runCommand, setEnv } from "../process.ts";
 
+function normalizeNewlines(output: string | undefined): string | undefined {
+  return output?.replaceAll("\r\n", "\n");
+}
+
 describe("runCommand", () => {
   it("runs shell command strings through the native shell", async () => {
     const result = await runCommand("echo shell-works && echo shell-stderr >&2", {
@@ -11,8 +15,8 @@ describe("runCommand", () => {
     });
 
     assertEquals(result.success, true);
-    assertEquals(result.stdout, "shell-works\n");
-    assertEquals(result.stderr, "shell-stderr\n");
+    assertEquals(normalizeNewlines(result.stdout), "shell-works\n");
+    assertEquals(normalizeNewlines(result.stderr), "shell-stderr\n");
   });
 
   it("preserves shell command arguments with spaces and metacharacters", async () => {

--- a/src/platform/compat/process/command.test.ts
+++ b/src/platform/compat/process/command.test.ts
@@ -4,6 +4,36 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { deleteEnv, getEnv, runCommand, setEnv } from "../process.ts";
 
 describe("runCommand", () => {
+  it("runs shell command strings through the native shell", async () => {
+    const result = await runCommand("echo shell-works && echo shell-stderr >&2", {
+      shell: true,
+      capture: true,
+    });
+
+    assertEquals(result.success, true);
+    assertEquals(result.stdout, "shell-works\n");
+    assertEquals(result.stderr, "shell-stderr\n");
+  });
+
+  it("preserves shell command arguments with spaces and metacharacters", async () => {
+    const result = await runCommand("deno", {
+      shell: true,
+      capture: true,
+      args: [
+        "eval",
+        "console.log(JSON.stringify(Deno.args))",
+        "value with spaces",
+        "literal ; & | $ * chars",
+      ],
+    });
+
+    assertEquals(result.success, true);
+    assertEquals(
+      result.stdout?.trim(),
+      JSON.stringify(["value with spaces", "literal ; & | $ * chars"]),
+    );
+  });
+
   it("clears inherited environment variables", async () => {
     const inheritedKey = "VERYFRONT_RUN_COMMAND_INHERITED";
     const explicitKey = "VERYFRONT_RUN_COMMAND_EXPLICIT";

--- a/src/platform/compat/process/command.ts
+++ b/src/platform/compat/process/command.ts
@@ -28,6 +28,18 @@ export interface CommandOptions {
 const COMMAND_TIMEOUT_EXIT_CODE = 124;
 const FORCE_KILL_GRACE_MS = 250;
 
+function createShellCommand(cmd: string, args: string[]): { cmd: string; args: string[] } {
+  if (isWindowsPlatform()) {
+    return { cmd: "cmd.exe", args: ["/d", "/s", "/c", cmd, ...args] };
+  }
+
+  if (args.length === 0) {
+    return { cmd: "sh", args: ["-c", cmd] };
+  }
+
+  return { cmd: "sh", args: ["-c", 'exec "$@"', "sh", cmd, ...args] };
+}
+
 function createTimeoutResult(
   timeoutMs: number,
   stdout?: string,
@@ -131,8 +143,9 @@ export async function runCommand(
 
   const deno = IS_DENO ? getDenoRuntime() : undefined;
   if (deno) {
-    const command = new deno.Command(cmd, {
-      args,
+    const denoCommand = shell ? createShellCommand(cmd, args) : { cmd, args };
+    const command = new deno.Command(denoCommand.cmd, {
+      args: denoCommand.args,
       cwd: cmdCwd,
       env: cmdEnv,
       clearEnv,
@@ -190,14 +203,8 @@ export async function runCommand(
 
     const bunStdio = inherit ? "inherit" : capture ? "pipe" : "ignore";
 
-    const isWindows = isWindowsPlatform();
-    const bunCmd = shell
-      ? args.length === 0
-        ? isWindows ? ["cmd", "/c", cmd] : ["sh", "-c", cmd]
-        : isWindows
-        ? ["cmd", "/c", cmd, ...args]
-        : ["sh", "-c", 'exec "$@"', "sh", cmd, ...args]
-      : [cmd, ...args];
+    const shellCommand = shell ? createShellCommand(cmd, args) : undefined;
+    const bunCmd = shellCommand ? [shellCommand.cmd, ...shellCommand.args] : [cmd, ...args];
 
     const proc = bunGlobal.Bun.spawn({
       cmd: bunCmd,


### PR DESCRIPTION
## Summary

- install dependencies before creating the optional initial Git commit
- track the generated package-manager lockfile and leave successful scaffolds clean
- preserve recoverable install-failure and `--skip-install` behavior
- honor native shell execution in the Deno process adapter so Windows `.cmd` package managers work

## Verification

- `deno test -A src/platform/compat/process/command.test.ts`
- `deno test -A cli/commands/init/init.integration.test.ts cli/commands/init/interactive-wizard.test.ts`
- `deno fmt --check cli/commands/init src/platform/compat/process`
- `deno lint cli/commands/init src/platform/compat/process`
- `deno task typecheck`
- `deno task build:npm`
- packed npm artifact, interactive AI Agent/Node/Git scaffold: `package-lock.json` tracked and `git status --porcelain` empty
- pre-push suite: 2706 tests, 21960 steps, 0 failures

## Integration note

The follow-up project-link/provenance change owns `init --deploy` link state and production source verification. The combined branch will be tested through scaffold, push, preview, and deploy before either change is marked release-ready.