### PR TITLE
Keep preview promotion identity canonical

### DIFF
--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -276,7 +276,7 @@ async function withInferredDeployEnv<T>(
 }
 
 async function expectDeployReceiptError(
-  operation: () => Promise<void>,
+  operation: () => Promise<unknown>,
   jsonMode: boolean,
   output: string[],
   forbiddenText: string,
@@ -779,12 +779,18 @@ it("uses canonical production read-back in human and JSON modes", async () => {
         output.push(args.map(String).join(" "));
       };
 
+      let result;
       try {
-        await withMockFetch(handleRequest, () => runDeploy(jsonMode));
+        result = await withMockFetch(handleRequest, () => runDeploy(jsonMode));
       } finally {
         console.log = originalLog;
       }
 
+      assertEquals(result?.projectSlug, "my-project");
+      assertEquals(
+        result?.url,
+        "https://my-project.production.veryfront.com/dashboard",
+      );
       assertEquals(environmentReads, 2);
       assertEquals(environmentUrlReads, 2);
       assertEquals(releaseSourceReads, 2);

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -165,6 +165,64 @@ export interface DeploymentVerification {
   sourceDigest: string;
 }
 
+export interface DeployResult {
+  projectId: string;
+  projectSlug: string;
+  release: {
+    id: string;
+    name: string;
+    version: string;
+  };
+  environment: string;
+  environmentId: string;
+  deploymentId: string;
+  url: string;
+  protected: boolean;
+  routingConvergence: DeploymentRoutingConvergence | null;
+  commitSha: string | null;
+  sourceDigest: string;
+  controlPlane: string;
+  branch: string;
+}
+
+function createDeployResult({
+  verification,
+  release,
+  environment,
+  deployment,
+  environmentUrl,
+  config,
+  branch,
+}: {
+  verification: DeploymentVerification;
+  release: Release;
+  environment: Environment;
+  deployment: Deployment;
+  environmentUrl: string;
+  config: ResolvedConfig;
+  branch: string;
+}): DeployResult {
+  return {
+    projectId: verification.projectId,
+    projectSlug: verification.projectSlug,
+    release: {
+      id: verification.releaseId,
+      name: release.name,
+      version: verification.releaseVersion,
+    },
+    environment: verification.environmentName,
+    environmentId: verification.environmentId,
+    deploymentId: verification.deploymentId,
+    url: environmentUrl,
+    protected: environment.protected,
+    routingConvergence: deployment.routing_convergence ?? null,
+    commitSha: verification.commitSha,
+    sourceDigest: verification.sourceDigest,
+    controlPlane: normalizeControlPlane(config.apiUrl),
+    branch,
+  };
+}
+
 export interface ReleaseSourceVerification {
   projectId: string;
   releaseId: string;
@@ -1124,7 +1182,7 @@ export async function waitForReleaseAssetManifest(
 /**
  * Create a release and deploy to an environment
  */
-export async function deployCommand(options: DeployOptions): Promise<void> {
+export async function deployCommand(options: DeployOptions): Promise<DeployResult | null> {
   const {
     projectDir = cwd(),
     branch,
@@ -1178,7 +1236,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
         : `create release and deploy to "${env}"`;
       logInfo(`Would ${actions} for project ${setup.plannedProjectSlug}`);
     }
-    return;
+    return null;
   }
 
   if (bootstrapPush) {
@@ -1236,7 +1294,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
         : `create release and deploy to "${env}"`;
       logInfo(`Would ${actions}`);
     }
-    return;
+    return null;
   }
 
   updateProgress("Building release...", "Verifying pushed source...");
@@ -1323,7 +1381,17 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     throw error;
   }
 
-  if (quiet) return;
+  const result = createDeployResult({
+    verification,
+    release,
+    environment,
+    deployment,
+    environmentUrl,
+    config,
+    branch,
+  });
+
+  if (quiet) return result;
 
   logSuccess(
     `Deployed ${verification.projectSlug} to ${env} in ${formatDuration(Date.now() - startedAt)}`,
@@ -1367,9 +1435,11 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     const { getPostDeployTips } = await import("../../help/tips.ts");
     console.log(getPostDeployTips());
   }
+
+  return result;
 }
 
-async function deployCommandJson(options: DeployOptions): Promise<void> {
+async function deployCommandJson(options: DeployOptions): Promise<DeployResult | null> {
   const {
     projectDir = cwd(),
     branch,
@@ -1418,7 +1488,7 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
           ],
         },
       });
-      return;
+      return null;
     }
 
     if (bootstrapPush) {
@@ -1446,7 +1516,7 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
       });
       const { exit } = await import("veryfront/platform");
       exit(1);
-      return;
+      return null;
     }
     assertProjectOwnership("Environment", environment, project.id);
     streamJsonLine({ type: "step", name: "resolve-target", status: "completed" });
@@ -1479,7 +1549,7 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
           ],
         },
       });
-      return;
+      return null;
     }
 
     streamJsonLine({ type: "step", name: "verify-source", status: "started" });
@@ -1573,29 +1643,22 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
       });
     }
 
+    const result = createDeployResult({
+      verification,
+      release,
+      environment,
+      deployment,
+      environmentUrl,
+      config,
+      branch,
+    });
+
     streamJsonLine({
       type: "result",
       success: true,
-      data: {
-        projectId: verification.projectId,
-        projectSlug: verification.projectSlug,
-        release: {
-          id: verification.releaseId,
-          name: release.name,
-          version: verification.releaseVersion,
-        },
-        environment: env,
-        environmentId: verification.environmentId,
-        deploymentId: verification.deploymentId,
-        url: environmentUrl,
-        protected: environment.protected,
-        routingConvergence: deployment.routing_convergence ?? null,
-        commitSha: verification.commitSha,
-        sourceDigest: verification.sourceDigest,
-        controlPlane: normalizeControlPlane(config.apiUrl),
-        branch,
-      },
+      data: result,
     });
+    return result;
   } catch (error) {
     streamJsonLine({
       type: "result",
@@ -1604,5 +1667,6 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
     });
     const { exit } = await import("veryfront/platform");
     exit(1);
+    return null;
   }
 }

--- a/cli/commands/deploy/index.ts
+++ b/cli/commands/deploy/index.ts
@@ -26,6 +26,7 @@ export type {
   DeploymentRoutingConvergence,
   DeploymentVerification,
   DeployOptions,
+  DeployResult,
   EnvironmentReadinessOptions,
   EnvironmentReadinessTarget,
   ReleaseSourceVerification,

--- a/cli/commands/init/init-command.test.ts
+++ b/cli/commands/init/init-command.test.ts
@@ -10,7 +10,9 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { exists, makeTempDir, remove } from "#veryfront/testing/deno-compat.ts";
 import { cwd } from "veryfront/platform";
 import { join } from "veryfront/platform/path";
-import { initCommand } from "./init-command.ts";
+import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
+import { writeProjectLink } from "../../shared/project-link.ts";
+import { initCommand, resolveDeployedProjectSlug } from "./init-command.ts";
 import type { InitOptions, InitTemplate } from "./types.ts";
 
 describe("InitCommand Types", () => {
@@ -33,6 +35,33 @@ describe("InitCommand Types", () => {
   });
 
   describe("InitOptions", () => {
+    it("resolves the deployed slug from the local project link", async () => {
+      const projectDir = await makeTempDir({ prefix: "veryfront-init-deployed-slug-" });
+      const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL"];
+      const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+      try {
+        Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test/api");
+        _resetEnvironmentConfig();
+        await writeProjectLink(projectDir, {
+          controlPlane: "https://control.example.test/api",
+          projectId: "project-123",
+          projectSlug: "canonical-slug",
+        });
+
+        assertEquals(await resolveDeployedProjectSlug(projectDir), "canonical-slug");
+      } finally {
+        envKeys.forEach((key, index) => {
+          const value = savedEnv[index];
+          if (value === undefined) Deno.env.delete(key);
+          else Deno.env.set(key, value);
+        });
+        _resetEnvironmentConfig();
+        await remove(projectDir, { recursive: true });
+      }
+    });
+
     it("creates a named project beneath parentDir", async () => {
       const parentDir = await makeTempDir({ prefix: "veryfront-init-parent-" });
       const name = `parent-target-${crypto.randomUUID()}`;

--- a/cli/commands/init/init-command.test.ts
+++ b/cli/commands/init/init-command.test.ts
@@ -10,9 +10,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { exists, makeTempDir, remove } from "#veryfront/testing/deno-compat.ts";
 import { cwd } from "veryfront/platform";
 import { join } from "veryfront/platform/path";
-import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
-import { writeProjectLink } from "../../shared/project-link.ts";
-import { initCommand, resolveDeployedProjectSlug } from "./init-command.ts";
+import { initCommand } from "./init-command.ts";
 import type { InitOptions, InitTemplate } from "./types.ts";
 
 describe("InitCommand Types", () => {
@@ -35,33 +33,6 @@ describe("InitCommand Types", () => {
   });
 
   describe("InitOptions", () => {
-    it("resolves the deployed slug from the local project link", async () => {
-      const projectDir = await makeTempDir({ prefix: "veryfront-init-deployed-slug-" });
-      const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL"];
-      const savedEnv = envKeys.map((key) => Deno.env.get(key));
-
-      try {
-        Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
-        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test/api");
-        _resetEnvironmentConfig();
-        await writeProjectLink(projectDir, {
-          controlPlane: "https://control.example.test/api",
-          projectId: "project-123",
-          projectSlug: "canonical-slug",
-        });
-
-        assertEquals(await resolveDeployedProjectSlug(projectDir), "canonical-slug");
-      } finally {
-        envKeys.forEach((key, index) => {
-          const value = savedEnv[index];
-          if (value === undefined) Deno.env.delete(key);
-          else Deno.env.set(key, value);
-        });
-        _resetEnvironmentConfig();
-        await remove(projectDir, { recursive: true });
-      }
-    });
-
     it("creates a named project beneath parentDir", async () => {
       const parentDir = await makeTempDir({ prefix: "veryfront-init-parent-" });
       const name = `parent-target-${crypto.randomUUID()}`;

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -266,11 +266,6 @@ function renderProjectStructure(rootName: string, paths: string[], maxLines = 22
   return lines;
 }
 
-export async function resolveDeployedProjectSlug(projectDir: string): Promise<string> {
-  const { resolveConfigWithAuth } = await import("#cli/shared/config");
-  return (await resolveConfigWithAuth(projectDir)).projectSlug;
-}
-
 /**
  * Initializes a new Veryfront project with the specified template
  */
@@ -560,7 +555,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
   }
 
   // Deploy to cloud if --deploy flag is set
-  let deployedSlug: string | undefined;
+  let deployedUrl: string | undefined;
   const manualDeployCommand = `${getDlxCommand(pmPreference)} veryfront deploy`;
   if (options.deploy) {
     const { chdir } = await import("veryfront/platform");
@@ -581,7 +576,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
         try {
           chdir(projectDir);
 
-          await deployCommand({
+          const deployment = await deployCommand({
             projectDir,
             branch: "main",
             env: "production",
@@ -590,7 +585,10 @@ export async function initCommand(options: InitOptions): Promise<void> {
             quiet: true,
           });
 
-          deployedSlug = await resolveDeployedProjectSlug(projectDir);
+          if (!deployment) {
+            throw new Error("Deploy completed without a verified result.");
+          }
+          deployedUrl = deployment.url;
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           log(`\n  Deploy failed: ${message}`);
@@ -635,10 +633,10 @@ export async function initCommand(options: InitOptions): Promise<void> {
       console.log(`  ${step}`);
     }
 
-    if (deployedSlug) {
+    if (deployedUrl) {
       console.log("");
       console.log(
-        `  ${dim("Live:")} ${brand(`https://${deployedSlug}.production.veryfront.com`)}`,
+        `  ${dim("Live:")} ${brand(deployedUrl)}`,
       );
     } else {
       console.log("");

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -266,6 +266,11 @@ function renderProjectStructure(rootName: string, paths: string[], maxLines = 22
   return lines;
 }
 
+export async function resolveDeployedProjectSlug(projectDir: string): Promise<string> {
+  const { resolveConfigWithAuth } = await import("#cli/shared/config");
+  return (await resolveConfigWithAuth(projectDir)).projectSlug;
+}
+
 /**
  * Initializes a new Veryfront project with the specified template
  */
@@ -560,7 +565,6 @@ export async function initCommand(options: InitOptions): Promise<void> {
   if (options.deploy) {
     const { chdir } = await import("veryfront/platform");
     const { ensureAuthenticated, readToken } = await import("../../auth/index.ts");
-    const { readConfigFile } = await import("#cli/shared/config");
     const { deployCommand } = await import("../deploy/index.ts");
     const manualDeployHint = `Run ${brand(manualDeployCommand)} to deploy later.`;
 
@@ -586,8 +590,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
             quiet: true,
           });
 
-          const configFile = await readConfigFile(projectDir);
-          deployedSlug = configFile?.projectSlug;
+          deployedSlug = await resolveDeployedProjectSlug(projectDir);
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           log(`\n  Deploy failed: ${message}`);

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -202,6 +202,67 @@ describe("buildPushUrls", () => {
 });
 
 describe("push JSON output", () => {
+  it("uses the canonical project slug for project-ID targets", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalLog = console.log;
+    const envKeys = [
+      "VERYFRONT_API_TOKEN",
+      "VERYFRONT_API_URL",
+      "VERYFRONT_PROJECT_SLUG",
+      "TENANT_PROJECT_SLUG",
+      "VERYFRONT_PROJECT_ID",
+      "TENANT_PROJECT_ID",
+    ];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    try {
+      Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+      Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("TENANT_PROJECT_SLUG");
+      Deno.env.set("VERYFRONT_PROJECT_ID", "project-123");
+      Deno.env.delete("TENANT_PROJECT_ID");
+      _resetEnvironmentConfig();
+      setJsonMode(true);
+
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        if (request.method === "GET" && url.pathname === "/projects/project-123/files") {
+          return Response.json({ data: [], page_info: {} });
+        }
+        if (request.method === "GET" && url.pathname === "/projects/project-123") {
+          return Response.json({ id: "project-123", slug: "canonical-slug" });
+        }
+        throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+      }) as typeof fetch;
+
+      for (const dryRun of [true, false]) {
+        const projectDir = await Deno.makeTempDir();
+        const output: string[] = [];
+        console.log = (message?: unknown) => output.push(String(message));
+        try {
+          await pushCommand({ projectDir, dryRun });
+
+          const result = JSON.parse(output.at(-1)!);
+          assertEquals(result.data.projectSlug, "canonical-slug");
+          assertEquals(
+            result.data.previewUrl,
+            "https://canonical-slug.preview.veryfront.com",
+          );
+        } finally {
+          await Deno.remove(projectDir, { recursive: true });
+        }
+      }
+    } finally {
+      setJsonMode(false);
+      console.log = originalLog;
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
+  });
+
   it("keeps an up-to-date dry run on the dry-run schema", async () => {
     const originalFetch = globalThis.fetch;
     const originalLog = console.log;

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -1176,6 +1176,56 @@ describe("push receipt source snapshot", () => {
       _resetEnvironmentConfig();
     }
   });
+
+  it("fails closed when an explicit project ID is missing", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = [
+      "VERYFRONT_API_TOKEN",
+      "VERYFRONT_API_URL",
+      "VERYFRONT_PROJECT_SLUG",
+      "TENANT_PROJECT_SLUG",
+      "VERYFRONT_PROJECT_ID",
+      "TENANT_PROJECT_ID",
+    ];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+    const requests: string[] = [];
+
+    try {
+      Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+      Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("TENANT_PROJECT_SLUG");
+      Deno.env.set("VERYFRONT_PROJECT_ID", "missing-project-id");
+      Deno.env.delete("TENANT_PROJECT_ID");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        requests.push(`${request.method} ${url.pathname}`);
+        return Response.json({ error: "not found" }, { status: 404 });
+      }) as typeof fetch;
+
+      for (const dryRun of [true, false]) {
+        await withGitProject(async ({ projectDir }) => {
+          await assertRejects(
+            () => pushCommand({ projectDir, dryRun, quiet: true }),
+            Error,
+            'Project "missing-project-id" was not found',
+          );
+        });
+      }
+
+      assertEquals(requests, [
+        "GET /projects/missing-project-id/files",
+        "GET /projects/missing-project-id/files",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
+  });
 });
 
 describe("push dry-run project bootstrap", () => {

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -705,6 +705,11 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           }
         } catch (error) {
           if (getErrorStatus(error) !== 404) throw error;
+          if (config.projectId) {
+            throw new Error(
+              `Project "${config.projectId}" was not found. Check ${projectReferenceSource.name} or remove it to let Veryfront create a project for this directory.`,
+            );
+          }
           if (dryRun) planProjectCreation();
           else await createProject();
         }

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -697,11 +697,11 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       } else {
         try {
           mainFiles = await listAllFiles(client, projectApiReference(config), { type: "main" });
-          if (shouldPersistProjectLink(projectReferenceSource)) {
+          if (shouldPersistProjectLink(projectReferenceSource) || config.projectId) {
             const project = await getProjectTarget(client, projectApiReference(config));
-            config = dryRun
-              ? { ...config, projectId: project.id, projectSlug: project.slug }
-              : await persistProjectLink(projectDir, config, project);
+            config = !dryRun && shouldPersistProjectLink(projectReferenceSource)
+              ? await persistProjectLink(projectDir, config, project)
+              : { ...config, projectId: project.id, projectSlug: project.slug };
           }
         } catch (error) {
           if (getErrorStatus(error) !== 404) throw error;

--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -496,6 +496,7 @@ describe("resolveConfigWithAuth", () => {
       const config = await resolveConfigWithAuth("/tmp/test-dir", env);
 
       assertEquals(config.projectSlug, "tenant-project-id");
+      assertEquals(config.projectId, "tenant-project-id");
     } finally {
       if (previousTenantProjectSlug === undefined) {
         Deno.env.delete("TENANT_PROJECT_SLUG");

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -276,6 +276,12 @@ async function resolveConfigBase(
     const tenantReference = resolveEnvironmentProjectReference();
     if (tenantReference) {
       projectSlug = tenantReference.reference;
+      if (
+        tenantReference.name === "VERYFRONT_PROJECT_ID" ||
+        tenantReference.name === "TENANT_PROJECT_ID"
+      ) {
+        projectId = tenantReference.reference;
+      }
       projectReferenceSource = { kind: "tenant-environment", name: tenantReference.name };
     } else {
       const projectLink = await readProjectLinkForControlPlane(dir, apiUrl);

--- a/cli/shared/project-link.test.ts
+++ b/cli/shared/project-link.test.ts
@@ -88,6 +88,29 @@ describe("project link persistence", () => {
     });
   });
 
+  it("rejects empty identities and invalid control-plane URLs", async () => {
+    const invalidLinks = [
+      { ...LINK, controlPlane: "" },
+      { ...LINK, controlPlane: "not-a-url" },
+      { ...LINK, projectId: "" },
+      { ...LINK, projectId: "   " },
+      { ...LINK, projectSlug: "" },
+      { ...LINK, projectSlug: "   " },
+    ];
+
+    await withTempProject(async (projectDir) => {
+      for (const link of invalidLinks) {
+        await writeRawProjectLink(projectDir, { version: 1, ...link });
+
+        await assertRejects(
+          () => readProjectLink(projectDir),
+          Error,
+          "remove it and relink",
+        );
+      }
+    });
+  });
+
   it("rejects another control plane without exposing the project directory", async () => {
     await withTempProject(async (projectDir) => {
       await writeProjectLink(projectDir, LINK);

--- a/cli/shared/project-link.ts
+++ b/cli/shared/project-link.ts
@@ -68,6 +68,9 @@ async function inspectProjectLinkPath(
 
 function normalizeControlPlane(controlPlane: string): string {
   const url = new URL(controlPlane);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new TypeError("Veryfront control-plane URLs must use HTTP or HTTPS.");
+  }
   const pathname = url.pathname.replace(/\/+$/, "");
   return `${url.origin}${pathname}`;
 }
@@ -84,9 +87,23 @@ function isProjectLink(value: unknown): value is ProjectLink {
   if (!value || typeof value !== "object") return false;
   const link = value as Record<string, unknown>;
   return link.version === PROJECT_LINK_VERSION &&
-    typeof link.controlPlane === "string" &&
-    typeof link.projectId === "string" &&
-    typeof link.projectSlug === "string";
+    isNonEmptyTrimmedString(link.controlPlane) &&
+    isControlPlaneUrl(link.controlPlane) &&
+    isNonEmptyTrimmedString(link.projectId) &&
+    isNonEmptyTrimmedString(link.projectSlug);
+}
+
+function isNonEmptyTrimmedString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value === value.trim();
+}
+
+function isControlPlaneUrl(value: string): boolean {
+  try {
+    normalizeControlPlane(value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function readProjectLink(projectDir: string): Promise<ProjectLink | null> {

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -63,9 +63,10 @@ Both commands use the same `.vfignore` rules. Ignored files and unsupported
 extensions are not reconciled with Veryfront.
 
 If the project has a `.vfignore`, keep it as a regular file inside the project
-and commit it to Git. An untracked, Git-ignored, or symlinked `.vfignore` cannot
-provide clean production provenance, so Deploy will stop instead of treating
-the checkout as the reviewed commit.
+and commit it to Git so the managed source set is reproducible. Symlinked
+`.vfignore` files are rejected. Git cleanliness is recorded as provenance
+metadata; Deploy promotes the source digest recorded by Push rather than
+recomputing production bytes from the working tree.
 
 ## Preview the Push
 
@@ -90,11 +91,13 @@ veryfront deploy --branch main --env staging --yes
 
 Push records the checked-out commit and source digest in
 `.veryfront/push-receipt.json`. Deploy uses that last verified Push receipt,
-requires it to match the same project, branch, commit, and checkout, then
-verifies the release source digest before assigning it to the environment. If no
-receipt exists, Deploy bootstraps one with a quiet Push, but CI should keep the
-explicit Push step so review and production promotion remain separate. Do not
-split the two commands across CI jobs or clean the checkout between them.
+requires it to match the same project, branch, and Git commit, then verifies the
+release source digest before assigning it to the environment. Uncommitted edits
+made after Push are not promoted and do not invalidate that receipt; run Push
+again to update the preview before deploying those bytes. If no receipt exists,
+Deploy bootstraps one with a quiet Push, but CI should keep the explicit Push
+step so review and production promotion remain separate. Do not split the two
+commands across CI jobs or clean the checkout between them.
 
 Deploy creates an immutable release from the pushed source, then assigns that
 release to `staging`.
@@ -223,8 +226,8 @@ Deploy prints human-readable output by default. Add `--json` only when the CI
 system needs machine-readable audit evidence. JSON mode emits NDJSON records
 for each step and a final result.
 
-Write the audit file outside the Git checkout so it does not make the source
-dirty before Deploy verifies the Push receipt:
+Write the audit file outside the Git checkout so a later Push cannot include it
+in the managed source set:
 
 ```bash title="GitHub Actions deployment step"
 set -o pipefail

--- a/docs/superpowers/specs/2026-07-28-quickstart-deploy-experience-design.md
+++ b/docs/superpowers/specs/2026-07-28-quickstart-deploy-experience-design.md
@@ -126,7 +126,7 @@ Git commit and cleanliness remain visible provenance metadata. They do not rejec
 - non-Git projects;
 - CI deployments with commit metadata.
 
-Source mutations between push and deploy still fail because the digest or receipt no longer matches.
+Uncommitted source mutations after Push remain local and do not change the production candidate. Deploy promotes the exact remote digest recorded by the last verified Push; users run Push again when they want new local bytes to replace that candidate. A different checked-out Git commit still invalidates the receipt.
 
 ### Default log policy
 
@@ -247,7 +247,8 @@ Normal errors omit stack traces. `--verbose` includes diagnostic context.
 ### Provenance
 
 - dirty and non-Git source can produce a valid release when the source digest matches;
-- changed source, wrong project, wrong branch, wrong control plane, and wrong digest still fail;
+- uncommitted source changes after Push remain local and do not block promotion of the verified digest;
+- a different checked-out commit, wrong project, wrong branch, wrong control plane, and wrong digest still fail;
 - release and deployment verification require the pushed source digest.
 
 ### Logging


### PR DESCRIPTION
## Summary
- reject malformed local links and missing explicit project IDs instead of creating replacement projects
- keep dry-run identity resolution side-effect free while reporting canonical project URLs
- make preview promotion semantics explicit for local edits and later commits
- return the verified deployment result so `init --deploy` prints the canonical live URL

Follow-up hardening for #3143.

## Verification
- `deno test -A cli/shared/project-link.test.ts cli/shared/config.test.ts cli/commands/push/command.test.ts cli/commands/deploy/command.integration.test.ts cli/commands/init/init-command.test.ts` (32 passed, 119 steps)
- `deno task typecheck`
- changed-file `deno fmt --check` and `deno lint`
- pre-push gate: 2709 passed, 21990 steps
- independent code review: approved with no findings