### PR TITLE
Keep local development output focused

### DIFF
--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -1,0 +1,312 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path";
+import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
+import { delay } from "#std/async";
+import { TEST_TIMEOUTS } from "../../../tests/_helpers/constants.ts";
+import { withTestContext } from "../../../tests/_helpers/context.ts";
+import { pollHttpReadyByTimeout } from "../../../tests/_helpers/http-polling.ts";
+
+const NOISY_DEFAULT_FRAGMENTS = [
+  "declares capabilities",
+  "loaded from",
+  "Pre-converted schema",
+  "Using pre-converted schema",
+  "Pod-level module cache initialized",
+  "Pod-level ESM cache initialized",
+  "Initialized with gateway",
+  "Subscribing to ReloadNotifier",
+  "Primitive discovery completed",
+  "Using import map",
+  "built handler",
+  "Using runtime model",
+  "GET / 200",
+] as const;
+
+const DEBUG_EXTENSION_DIAGNOSTICS = [
+  "declares capabilities",
+  "loaded from",
+] as const;
+
+const DEBUG_REQUEST_DIAGNOSTICS = [
+  "GET / 200",
+] as const;
+
+const DEBUG_API_BUILD_DIAGNOSTICS = [
+  "Using import map",
+  "built handler",
+] as const;
+
+interface CliRun {
+  output: () => string;
+  stop: () => Promise<void>;
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function assertIncludesAny(
+  output: string,
+  candidates: readonly string[],
+  message: string,
+): void {
+  assert(
+    candidates.some((fragment) => output.includes(fragment)),
+    `${message}\nExpected one of: ${candidates.join(", ")}\nOutput:\n${output}`,
+  );
+}
+
+async function scaffoldMinimalProject(projectDir: string): Promise<void> {
+  await writeTextFile(
+    join(projectDir, "veryfront.config.js"),
+    `export default {
+  title: "Quiet Dev Logs Contract",
+  dev: {
+    host: "127.0.0.1"
+  },
+  resolve: {
+    importMap: {
+      imports: {
+        "@/": "./"
+      }
+    }
+  }
+};
+`,
+  );
+
+  await mkdir(join(projectDir, "app", "api", "ping"), { recursive: true });
+  await mkdir(join(projectDir, "lib"), { recursive: true });
+  await writeTextFile(
+    join(projectDir, "app", "page.tsx"),
+    `export default function Page() {
+  return <main>quiet dev logs page</main>;
+}
+`,
+  );
+  await writeTextFile(
+    join(projectDir, "lib", "ping.ts"),
+    `export const pingPayload = { ok: true };
+`,
+  );
+  await writeTextFile(
+    join(projectDir, "app", "api", "ping", "route.ts"),
+    `import { pingPayload } from "@/lib/ping.ts";
+
+export function GET() {
+  return Response.json(pingPayload);
+}
+`,
+  );
+}
+
+function makeChildEnv(
+  projectDir: string,
+  debugEnv: Record<string, string> = {},
+): Record<string, string> {
+  const env: Record<string, string> = {
+    PATH: Deno.env.get("PATH") ?? "",
+    HOME: projectDir,
+    TMPDIR: Deno.env.get("TMPDIR") ?? "/tmp",
+    CI: "1",
+    DENO_TESTING: "1",
+    NO_COLOR: "1",
+    NODE_ENV: "development",
+    LOG_FORMAT: "text",
+    LOG_LEVEL: "INFO",
+    VERYFRONT_API_TOKEN: "",
+    VERYFRONT_DEBUG: "",
+    VERYFRONT_NO_UPDATE_CHECK: "1",
+    VF_DISABLE_LRU_INTERVAL: "1",
+    SSR_TRANSFORM_PER_PROJECT_LIMIT: "0",
+    REVALIDATION_PER_PROJECT_LIMIT: "0",
+    ...debugEnv,
+  };
+
+  const denoDir = Deno.env.get("DENO_DIR");
+  const homeDir = Deno.env.get("HOME");
+  if (denoDir) {
+    env.DENO_DIR = denoDir;
+  } else if (homeDir) {
+    env.DENO_DIR = join(homeDir, "Library", "Caches", "deno");
+  }
+
+  return env;
+}
+
+function startVeryfrontDev(
+  projectDir: string,
+  port: number,
+  args: string[] = [],
+  env: Record<string, string> = {},
+): CliRun {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "-A",
+      "--unstable-worker-options",
+      "--unstable-net",
+      "cli/main.ts",
+      "dev",
+      "--project",
+      projectDir,
+      "--port",
+      String(port),
+      "--no-hmr",
+      ...args,
+    ],
+    cwd: Deno.cwd(),
+    clearEnv: true,
+    env: makeChildEnv(projectDir, env),
+    stdin: "null",
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const child = command.spawn();
+  const decoder = new TextDecoder();
+  let captured = "";
+
+  const drain = async (stream: ReadableStream<Uint8Array> | null): Promise<void> => {
+    if (!stream) return;
+    const reader = stream.getReader();
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        captured += decoder.decode(value, { stream: true });
+      }
+      captured += decoder.decode();
+    } finally {
+      reader.releaseLock();
+    }
+  };
+
+  const stdoutDone = drain(child.stdout);
+  const stderrDone = drain(child.stderr);
+
+  return {
+    output: () => stripAnsi(captured),
+    stop: async () => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Process may already have exited.
+      }
+
+      const status = await Promise.race([
+        child.status,
+        delay(2_000).then(() => undefined),
+      ]);
+
+      if (status === undefined) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Process may already have exited.
+        }
+        await child.status;
+      }
+
+      await Promise.race([
+        Promise.all([stdoutDone, stderrDone]),
+        delay(1_000),
+      ]);
+    },
+  };
+}
+
+async function requestPageAndApi(port: number): Promise<void> {
+  const pageResponse = await fetch(`http://127.0.0.1:${port}/`);
+  try {
+    assertEquals(pageResponse.status, 200);
+    assertStringIncludes(await pageResponse.text(), "quiet dev logs page");
+  } finally {
+    await pageResponse.body?.cancel().catch(() => {});
+  }
+
+  const apiResponse = await fetch(`http://127.0.0.1:${port}/api/ping`);
+  try {
+    assertEquals(apiResponse.status, 200);
+    assertEquals(await apiResponse.json(), { ok: true });
+  } finally {
+    await apiResponse.body?.cancel().catch(() => {});
+  }
+}
+
+describe(
+  "veryfront dev output",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("keeps default dev output focused on readiness and hides routine diagnostics", async () => {
+      await withTestContext("quiet-dev-output-default", async (context) => {
+        await scaffoldMinimalProject(context.projectDir);
+        const port = await context.allocatePort();
+        const run = startVeryfrontDev(context.projectDir, port);
+        context.addCleanup(run.stop);
+
+        const ready = await pollHttpReadyByTimeout(`http://127.0.0.1:${port}/`, {
+          timeoutMs: TEST_TIMEOUTS.SERVER_STARTUP,
+          requestTimeoutMs: 1_000,
+          verifyWithSecondRequest: false,
+        });
+        assert(ready.ready, `dev server did not become ready:\n${run.output()}`);
+
+        await requestPageAndApi(port);
+        await delay(300);
+
+        const output = run.output();
+        assertStringIncludes(output, "Server ready at");
+
+        for (const fragment of NOISY_DEFAULT_FRAGMENTS) {
+          assert(
+            !output.includes(fragment),
+            `default dev output should not include "${fragment}"\nOutput:\n${output}`,
+          );
+        }
+      });
+    });
+
+    it("keeps representative diagnostics visible with --debug", async () => {
+      await withTestContext("quiet-dev-output-debug", async (context) => {
+        await scaffoldMinimalProject(context.projectDir);
+        const port = await context.allocatePort();
+        const run = startVeryfrontDev(context.projectDir, port, ["--debug"], {
+          LOG_LEVEL: "DEBUG",
+        });
+        context.addCleanup(run.stop);
+
+        const ready = await pollHttpReadyByTimeout(`http://127.0.0.1:${port}/`, {
+          timeoutMs: TEST_TIMEOUTS.SERVER_STARTUP,
+          requestTimeoutMs: 1_000,
+          verifyWithSecondRequest: false,
+        });
+        assert(ready.ready, `debug dev server did not become ready:\n${run.output()}`);
+
+        await requestPageAndApi(port);
+        await delay(300);
+
+        const output = run.output();
+        assertStringIncludes(output, "Server ready at");
+        assertIncludesAny(
+          output,
+          DEBUG_EXTENSION_DIAGNOSTICS,
+          "--debug should expose extension diagnostics",
+        );
+        assertIncludesAny(
+          output,
+          DEBUG_REQUEST_DIAGNOSTICS,
+          "--debug should expose request diagnostics",
+        );
+        assertIncludesAny(
+          output,
+          DEBUG_API_BUILD_DIAGNOSTICS,
+          "--debug should expose API build diagnostics",
+        );
+      });
+    });
+  },
+);

--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -4,7 +4,6 @@ import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/a
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
-import { delay } from "#std/async";
 import { TEST_TIMEOUTS } from "../../../tests/_helpers/constants.ts";
 import { withTestContext } from "../../../tests/_helpers/context.ts";
 import {
@@ -261,7 +260,7 @@ describe(
           assert(ready.ready, `dev server did not become ready:\n${run.output()}`);
 
           await requestPageAndApi(port);
-          await delay(300);
+          await run.stop();
 
           const output = run.output();
           assertStringIncludes(output, "Server ready at");
@@ -294,7 +293,7 @@ describe(
           assert(ready.ready, `debug dev server did not become ready:\n${run.output()}`);
 
           await requestPageAndApi(port);
-          await delay(300);
+          await run.stop();
 
           const output = run.output();
           assertStringIncludes(output, "Server ready at");

--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -7,7 +7,11 @@ import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
 import { delay } from "#std/async";
 import { TEST_TIMEOUTS } from "../../../tests/_helpers/constants.ts";
 import { withTestContext } from "../../../tests/_helpers/context.ts";
-import { fetchWithTimeout, pollHttpReadyByTimeout } from "../../../tests/_helpers/http-polling.ts";
+import {
+  fetchWithTimeout,
+  pollHttpReadyByTimeout,
+  waitForPromiseWithTimeout,
+} from "../../../tests/_helpers/http-polling.ts";
 
 const NOISY_DEFAULT_FRAGMENTS = [
   "declares capabilities",
@@ -23,6 +27,8 @@ const NOISY_DEFAULT_FRAGMENTS = [
   "built handler",
   "Using runtime model",
   "GET / 200",
+  "GET /_ws 101",
+  "Neither CORS nor CSRF protection is configured",
 ] as const;
 
 const DEBUG_EXTENSION_DIAGNOSTICS = [
@@ -169,6 +175,7 @@ function startVeryfrontDev(
   });
 
   const child = command.spawn();
+  const status = child.status;
   const decoder = new TextDecoder();
   let captured = "";
 
@@ -199,24 +206,18 @@ function startVeryfrontDev(
         // Process may already have exited.
       }
 
-      const status = await Promise.race([
-        child.status,
-        delay(2_000).then(() => undefined),
-      ]);
-
-      if (status === undefined) {
+      try {
+        await waitForPromiseWithTimeout(status, 2_000, "dev server did not stop after SIGTERM");
+      } catch {
         try {
           child.kill("SIGKILL");
         } catch {
           // Process may already have exited.
         }
-        await child.status;
+        await status;
       }
 
-      await Promise.race([
-        Promise.all([stdoutDone, stderrDone]),
-        delay(1_000),
-      ]);
+      await Promise.all([stdoutDone, stderrDone]);
     },
   };
 }
@@ -241,7 +242,6 @@ async function requestPageAndApi(port: number): Promise<void> {
 
 describe(
   "veryfront dev output",
-  { sanitizeOps: false, sanitizeResources: false },
   () => {
     it(
       "keeps default dev output focused on readiness and hides routine diagnostics",

--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -7,7 +7,7 @@ import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
 import { delay } from "#std/async";
 import { TEST_TIMEOUTS } from "../../../tests/_helpers/constants.ts";
 import { withTestContext } from "../../../tests/_helpers/context.ts";
-import { pollHttpReadyByTimeout } from "../../../tests/_helpers/http-polling.ts";
+import { fetchWithTimeout, pollHttpReadyByTimeout } from "../../../tests/_helpers/http-polling.ts";
 
 const NOISY_DEFAULT_FRAGMENTS = [
   "declares capabilities",
@@ -39,13 +39,15 @@ const DEBUG_API_BUILD_DIAGNOSTICS = [
   "built handler",
 ] as const;
 
+const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
+
 interface CliRun {
   output: () => string;
   stop: () => Promise<void>;
 }
 
 function stripAnsi(value: string): string {
-  return value.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+  return value.replace(ANSI_ESCAPE_PATTERN, "");
 }
 
 function assertIncludesAny(
@@ -220,7 +222,7 @@ function startVeryfrontDev(
 }
 
 async function requestPageAndApi(port: number): Promise<void> {
-  const pageResponse = await fetch(`http://127.0.0.1:${port}/`);
+  const pageResponse = await fetchWithTimeout(`http://127.0.0.1:${port}/`);
   try {
     assertEquals(pageResponse.status, 200);
     assertStringIncludes(await pageResponse.text(), "quiet dev logs page");
@@ -228,7 +230,7 @@ async function requestPageAndApi(port: number): Promise<void> {
     await pageResponse.body?.cancel().catch(() => {});
   }
 
-  const apiResponse = await fetch(`http://127.0.0.1:${port}/api/ping`);
+  const apiResponse = await fetchWithTimeout(`http://127.0.0.1:${port}/api/ping`);
   try {
     assertEquals(apiResponse.status, 200);
     assertEquals(await apiResponse.json(), { ok: true });
@@ -241,72 +243,78 @@ describe(
   "veryfront dev output",
   { sanitizeOps: false, sanitizeResources: false },
   () => {
-    it("keeps default dev output focused on readiness and hides routine diagnostics", async () => {
-      await withTestContext("quiet-dev-output-default", async (context) => {
-        await scaffoldMinimalProject(context.projectDir);
-        const port = await context.allocatePort();
-        const run = startVeryfrontDev(context.projectDir, port);
-        context.addCleanup(run.stop);
+    it(
+      "keeps default dev output focused on readiness and hides routine diagnostics",
+      { timeout: TEST_TIMEOUTS.INTEGRATION },
+      async () => {
+        await withTestContext("quiet-dev-output-default", async (context) => {
+          await scaffoldMinimalProject(context.projectDir);
+          const port = await context.allocatePort();
+          const run = startVeryfrontDev(context.projectDir, port);
+          context.addCleanup(run.stop);
 
-        const ready = await pollHttpReadyByTimeout(`http://127.0.0.1:${port}/`, {
-          timeoutMs: TEST_TIMEOUTS.SERVER_STARTUP,
-          requestTimeoutMs: 1_000,
-          verifyWithSecondRequest: false,
+          const ready = await pollHttpReadyByTimeout(`http://127.0.0.1:${port}/`, {
+            timeoutMs: TEST_TIMEOUTS.SERVER_STARTUP,
+            requestTimeoutMs: 1_000,
+            verifyWithSecondRequest: false,
+          });
+          assert(ready.ready, `dev server did not become ready:\n${run.output()}`);
+
+          await requestPageAndApi(port);
+          await delay(300);
+
+          const output = run.output();
+          assertStringIncludes(output, "Server ready at");
+
+          for (const fragment of NOISY_DEFAULT_FRAGMENTS) {
+            assert(
+              !output.includes(fragment),
+              `default dev output should not include "${fragment}"\nOutput:\n${output}`,
+            );
+          }
         });
-        assert(ready.ready, `dev server did not become ready:\n${run.output()}`);
+      },
+    );
 
-        await requestPageAndApi(port);
-        await delay(300);
+    it(
+      "keeps representative diagnostics visible with --debug",
+      { timeout: TEST_TIMEOUTS.INTEGRATION },
+      async () => {
+        await withTestContext("quiet-dev-output-debug", async (context) => {
+          await scaffoldMinimalProject(context.projectDir);
+          const port = await context.allocatePort();
+          const run = startVeryfrontDev(context.projectDir, port, ["--debug"]);
+          context.addCleanup(run.stop);
 
-        const output = run.output();
-        assertStringIncludes(output, "Server ready at");
+          const ready = await pollHttpReadyByTimeout(`http://127.0.0.1:${port}/`, {
+            timeoutMs: TEST_TIMEOUTS.SERVER_STARTUP,
+            requestTimeoutMs: 1_000,
+            verifyWithSecondRequest: false,
+          });
+          assert(ready.ready, `debug dev server did not become ready:\n${run.output()}`);
 
-        for (const fragment of NOISY_DEFAULT_FRAGMENTS) {
-          assert(
-            !output.includes(fragment),
-            `default dev output should not include "${fragment}"\nOutput:\n${output}`,
+          await requestPageAndApi(port);
+          await delay(300);
+
+          const output = run.output();
+          assertStringIncludes(output, "Server ready at");
+          assertIncludesAny(
+            output,
+            DEBUG_EXTENSION_DIAGNOSTICS,
+            "--debug should expose extension diagnostics",
           );
-        }
-      });
-    });
-
-    it("keeps representative diagnostics visible with --debug", async () => {
-      await withTestContext("quiet-dev-output-debug", async (context) => {
-        await scaffoldMinimalProject(context.projectDir);
-        const port = await context.allocatePort();
-        const run = startVeryfrontDev(context.projectDir, port, ["--debug"], {
-          LOG_LEVEL: "DEBUG",
+          assertIncludesAny(
+            output,
+            DEBUG_REQUEST_DIAGNOSTICS,
+            "--debug should expose request diagnostics",
+          );
+          assertIncludesAny(
+            output,
+            DEBUG_API_BUILD_DIAGNOSTICS,
+            "--debug should expose API build diagnostics",
+          );
         });
-        context.addCleanup(run.stop);
-
-        const ready = await pollHttpReadyByTimeout(`http://127.0.0.1:${port}/`, {
-          timeoutMs: TEST_TIMEOUTS.SERVER_STARTUP,
-          requestTimeoutMs: 1_000,
-          verifyWithSecondRequest: false,
-        });
-        assert(ready.ready, `debug dev server did not become ready:\n${run.output()}`);
-
-        await requestPageAndApi(port);
-        await delay(300);
-
-        const output = run.output();
-        assertStringIncludes(output, "Server ready at");
-        assertIncludesAny(
-          output,
-          DEBUG_EXTENSION_DIAGNOSTICS,
-          "--debug should expose extension diagnostics",
-        );
-        assertIncludesAny(
-          output,
-          DEBUG_REQUEST_DIAGNOSTICS,
-          "--debug should expose request diagnostics",
-        );
-        assertIncludesAny(
-          output,
-          DEBUG_API_BUILD_DIAGNOSTICS,
-          "--debug should expose API build diagnostics",
-        );
-      });
-    });
+      },
+    );
   },
 );

--- a/cli/commands/dev/handler.ts
+++ b/cli/commands/dev/handler.ts
@@ -7,6 +7,7 @@ import { isAbsolute, join } from "veryfront/platform/path";
 import { cwd, setEnv } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import { cliLogger, DEFAULT_DEV_SERVER_PORT } from "#cli/utils";
+import { refreshLoggerConfig } from "veryfront/utils";
 import { clearAllLocalCaches } from "veryfront/transforms/mdx-cache";
 import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
@@ -64,6 +65,7 @@ export async function handleDevCommand(args: ParsedArgs): Promise<void> {
   // Enable verbose logging when --debug flag is passed
   if (opts.debug) {
     setEnv("LOG_LEVEL", "DEBUG");
+    refreshLoggerConfig();
   }
 
   // Clear stale ESM caches to prevent module resolution issues from previous runs

--- a/extensions/ext-bundler-esbuild/src/index.ts
+++ b/extensions/ext-bundler-esbuild/src/index.ts
@@ -34,7 +34,7 @@ const extEsbuild: ExtensionFactory = () => {
       if (!ctx.get("ModuleLexer")) {
         ctx.provide("ModuleLexer", lexer);
       }
-      ctx.logger.info("[ext-bundler-esbuild] Bundler + ModuleLexer registered");
+      ctx.logger.debug("[ext-bundler-esbuild] Bundler + ModuleLexer registered");
     },
     async teardown() {
       await bundler.stop?.();

--- a/extensions/ext-content-mdx/src/index.ts
+++ b/extensions/ext-content-mdx/src/index.ts
@@ -54,7 +54,7 @@ const extMdx: ExtensionFactory = () => {
     capabilities: [],
     setup(ctx) {
       ctx.provide("ContentProcessor", impl);
-      ctx.logger.info("[ext-content-mdx] ContentProcessor registered");
+      ctx.logger.debug("[ext-content-mdx] ContentProcessor registered");
     },
     teardown() {
       // No resources to release.

--- a/extensions/ext-css-tailwind/src/index.ts
+++ b/extensions/ext-css-tailwind/src/index.ts
@@ -66,7 +66,7 @@ const extTailwind: ExtensionFactory = () => {
     setup(ctx) {
       installTailwindPluginShims();
       ctx.provide("CSSProcessor", impl);
-      ctx.logger.info("[ext-css-tailwind] CSSProcessor registered");
+      ctx.logger.debug("[ext-css-tailwind] CSSProcessor registered");
     },
     teardown() {
       // Shims stay installed — removing them could break in-flight plugin

--- a/extensions/ext-db-sqlite/src/index.ts
+++ b/extensions/ext-db-sqlite/src/index.ts
@@ -39,7 +39,7 @@ const extDbSqlite: ExtensionFactory = () => {
 
     setup(ctx) {
       ctx.provide("SqliteStore", store);
-      ctx.logger.info("[ext-db-sqlite] SQLite store registered");
+      ctx.logger.debug("[ext-db-sqlite] SQLite store registered");
     },
   };
 };

--- a/extensions/ext-document-kreuzberg/src/index.ts
+++ b/extensions/ext-document-kreuzberg/src/index.ts
@@ -284,7 +284,7 @@ const extDocumentKreuzberg: ExtensionFactory = () => {
     setup(ctx) {
       const extractor = new KreuzbergDocumentExtractor({ logger: ctx.logger });
       ctx.provide("DocumentExtractor", extractor);
-      ctx.logger.info("[ext-document-kreuzberg] document extraction registered");
+      ctx.logger.debug("[ext-document-kreuzberg] document extraction registered");
     },
   };
 };

--- a/extensions/ext-eval-report-http/src/index.ts
+++ b/extensions/ext-eval-report-http/src/index.ts
@@ -271,7 +271,7 @@ const extEvalReportHttp: ExtensionFactory = (config?: unknown) => {
           ),
         );
         registeredIds.add(definition.id);
-        ctx.logger.info(`[ext-eval-report-http] EvalReportExporter "${definition.id}" registered`);
+        ctx.logger.debug(`[ext-eval-report-http] EvalReportExporter "${definition.id}" registered`);
       }
     },
     teardown() {

--- a/extensions/ext-eval-report-mlflow/src/index.ts
+++ b/extensions/ext-eval-report-mlflow/src/index.ts
@@ -1837,7 +1837,7 @@ const extEvalReportMlflow: ExtensionFactory = (config?: unknown) => {
         ),
       );
       registeredId = factoryConfig.id;
-      ctx.logger.info(
+      ctx.logger.debug(
         `[ext-eval-report-mlflow] EvalReportExporter "${factoryConfig.id}" registered`,
       );
     },

--- a/extensions/ext-llm-anthropic/src/index.ts
+++ b/extensions/ext-llm-anthropic/src/index.ts
@@ -25,7 +25,7 @@ const extAnthropic: ExtensionFactory = () => {
       const registry = ctx.require<LLMProviderRegistry>(LLMProviderRegistryName);
       registry.register(provider);
       registryRef = registry;
-      ctx.logger.info("[ext-llm-anthropic] Anthropic provider registered");
+      ctx.logger.debug("[ext-llm-anthropic] Anthropic provider registered");
     },
     teardown() {
       registryRef?.unregister(provider.id);

--- a/extensions/ext-llm-google/src/index.ts
+++ b/extensions/ext-llm-google/src/index.ts
@@ -23,7 +23,7 @@ const extGoogle: ExtensionFactory = () => {
     setup(ctx) {
       const registry = ctx.require<LLMProviderRegistry>(LLMProviderRegistryName);
       registry.register(provider);
-      ctx.logger.info("[ext-llm-google] Google provider registered");
+      ctx.logger.debug("[ext-llm-google] Google provider registered");
     },
     teardown() {
       // No resources to release.

--- a/extensions/ext-llm-openai/src/index.ts
+++ b/extensions/ext-llm-openai/src/index.ts
@@ -24,7 +24,7 @@ const extOpenAI: ExtensionFactory = () => {
     setup(ctx) {
       registry = ctx.require<LLMProviderRegistry>(LLMProviderRegistryName);
       registry.register(provider);
-      ctx.logger.info("[ext-llm-openai] OpenAI provider registered");
+      ctx.logger.debug("[ext-llm-openai] OpenAI provider registered");
     },
     teardown() {
       registry?.unregister(provider.id);

--- a/extensions/ext-observability-opentelemetry/src/index.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.ts
@@ -1251,7 +1251,7 @@ const extOpenTelemetry: ExtensionFactory = () => {
       await exporterImpl.start(ctx.config);
       ctx.provide("TracingExporter", exporterImpl);
       ctx.provide("NodeTelemetryProvider", nodeTelemetryProvider);
-      ctx.logger.info("[ext-observability-opentelemetry] TracingExporter registered");
+      ctx.logger.debug("[ext-observability-opentelemetry] TracingExporter registered");
     },
     async teardown() {
       await nodeTelemetryProvider.shutdown();

--- a/extensions/ext-parser-babel/src/index.ts
+++ b/extensions/ext-parser-babel/src/index.ts
@@ -150,7 +150,7 @@ const extBabel: ExtensionFactory = () => {
     capabilities: [],
     setup(ctx) {
       ctx.provide("CodeParser", impl);
-      ctx.logger.info("[ext-parser-babel] CodeParser registered");
+      ctx.logger.debug("[ext-parser-babel] CodeParser registered");
     },
     teardown() {
       // No resources to release.

--- a/extensions/ext-sandbox-shell-tools/src/index.ts
+++ b/extensions/ext-sandbox-shell-tools/src/index.ts
@@ -37,7 +37,7 @@ const extSandboxShellTools: ExtensionFactory = () => ({
   ],
   setup(ctx) {
     ctx.provide(SandboxShellToolsProviderName, provider);
-    ctx.logger.info("[ext-sandbox-shell-tools] Sandbox shell tools provider registered");
+    ctx.logger.debug("[ext-sandbox-shell-tools] Sandbox shell tools provider registered");
   },
 });
 

--- a/extensions/ext-schema-zod/src/index.ts
+++ b/extensions/ext-schema-zod/src/index.ts
@@ -27,7 +27,7 @@ const extZod: ExtensionFactory = () => {
     capabilities: [],
     setup(ctx) {
       ctx.provide("SchemaValidator", impl);
-      ctx.logger.info("[ext-schema-zod] SchemaValidator registered");
+      ctx.logger.debug("[ext-schema-zod] SchemaValidator registered");
     },
     teardown() {
       // No resources to release.

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -526,6 +526,14 @@ function warnLocalToolSkipping(agentId: string, modelId: string): void {
   );
 }
 
+function debugRuntimeModelRemap(requestedModel: string, resolvedModelString: string): void {
+  if (resolvedModelString === requestedModel) return;
+
+  logger.debug(
+    `⚡ Using runtime model "${resolvedModelString}" instead of "${requestedModel}".`,
+  );
+}
+
 type RuntimeStepState = {
   systemPrompt: string;
   context?: Record<string, unknown>;
@@ -652,11 +660,7 @@ export class AgentRuntime {
     const transport = await this.resolveModelTransport(context, modelOverride, "generate");
     const requestedModel = transport.requestedModel;
     const resolvedModelString = transport.resolvedModelString;
-    if (resolvedModelString !== requestedModel) {
-      logger.info(
-        `⚡ Using runtime model "${resolvedModelString}" instead of "${requestedModel}".`,
-      );
-    }
+    debugRuntimeModelRemap(requestedModel, resolvedModelString);
 
     return withSpan("agent.generate", async (span) => {
       setSpanAttributes(span, {
@@ -725,11 +729,7 @@ export class AgentRuntime {
     const transport = await this.resolveModelTransport(context, modelOverride, "stream");
     const requestedModel = transport.requestedModel;
     const resolvedModelString = transport.resolvedModelString;
-    if (resolvedModelString !== requestedModel) {
-      logger.info(
-        `⚡ Using runtime model "${resolvedModelString}" instead of "${requestedModel}".`,
-      );
-    }
+    debugRuntimeModelRemap(requestedModel, resolvedModelString);
 
     const memoryMessages = await this.prepareTurnMessages(messages);
 

--- a/src/agent/runtime/provider-transport.test.ts
+++ b/src/agent/runtime/provider-transport.test.ts
@@ -1,9 +1,25 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { type ModelRuntime, registerModelProvider } from "#veryfront/provider";
 import { agent } from "../factory.ts";
 import type { ModelTransportRequest } from "../types.ts";
+import {
+  __registerLogRecordEmitter,
+  __resetLoggerConfigForTests,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+} from "#veryfront/utils/logger/logger.ts";
+
+const originalLogLevel = Deno.env.get("LOG_LEVEL");
+
+function captureLogs(): LogEntry[] {
+  const entries: LogEntry[] = [];
+  Deno.env.set("LOG_LEVEL", "DEBUG");
+  __resetLoggerConfigForTests();
+  __registerLogRecordEmitter((entry) => entries.push(entry));
+  return entries;
+}
 
 function createTextStream(
   parts: Array<
@@ -22,6 +38,13 @@ function createTextStream(
 }
 
 describe("agent provider transport hooks", () => {
+  afterEach(() => {
+    if (originalLogLevel === undefined) Deno.env.delete("LOG_LEVEL");
+    else Deno.env.set("LOG_LEVEL", originalLogLevel);
+    __resetLoggerConfigForTests();
+    __resetLogRecordEmitterForTests();
+  });
+
   it("lets hosts override the model runtime and transport options for generate()", async () => {
     const captured: {
       request?: ModelTransportRequest;
@@ -84,6 +107,37 @@ describe("agent provider transport hooks", () => {
     assertEquals(captured.generateOptions.providerOptions, {
       veryfront: { projectSlug: "demo-project" },
     });
+  });
+
+  it("logs generate model remap diagnostics at debug level", async () => {
+    const entries = captureLogs();
+    registerModelProvider("google", (modelId) => ({
+      provider: "google",
+      modelId: `google/${modelId}`,
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "remapped generate" }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        return { stream: createTextStream([{ type: "finish" }]) };
+      },
+    }));
+
+    const assistant = agent({
+      model: "google-ai-studio/gemini-3.1-pro-preview",
+      system: "You are a helpful assistant.",
+    });
+
+    await assistant.generate({ input: "Hello" });
+
+    const entry = entries.find((candidate) =>
+      candidate.message ===
+        '⚡ Using runtime model "google/gemini-3.1-pro-preview" instead of "google-ai-studio/gemini-3.1-pro-preview".'
+    );
+    assertEquals(entry?.level, "debug");
   });
 
   it("uses the agent-configured temperature for generate()", async () => {
@@ -460,5 +514,42 @@ describe("agent provider transport hooks", () => {
     assertEquals(captured.streamOptions.providerOptions, {
       gateway: { branchId: "branch_123" },
     });
+  });
+
+  it("logs stream model remap diagnostics at debug level", async () => {
+    const entries = captureLogs();
+    registerModelProvider("google", (modelId) => ({
+      provider: "google",
+      modelId: `google/${modelId}`,
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream() {
+        return {
+          stream: createTextStream([
+            { type: "text-delta", text: "remapped stream" },
+            { type: "finish" },
+          ]),
+        };
+      },
+    }));
+
+    const assistant = agent({
+      model: "google-ai-studio/gemini-3.1-pro-preview",
+      system: "You are a helpful assistant.",
+    });
+
+    const response = (await assistant.stream({ input: "Hello" })).toDataStreamResponse();
+    await response.text();
+
+    const entry = entries.find((candidate) =>
+      candidate.message ===
+        '⚡ Using runtime model "google/gemini-3.1-pro-preview" instead of "google-ai-studio/gemini-3.1-pro-preview".'
+    );
+    assertEquals(entry?.level, "debug");
   });
 });

--- a/src/agent/runtime/provider-transport.test.ts
+++ b/src/agent/runtime/provider-transport.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { type ModelRuntime, registerModelProvider } from "#veryfront/provider";
+import { clearModelProviders, type ModelRuntime, registerModelProvider } from "#veryfront/provider";
 import { agent } from "../factory.ts";
 import type { ModelTransportRequest } from "../types.ts";
 import {
@@ -43,6 +43,7 @@ describe("agent provider transport hooks", () => {
     else Deno.env.set("LOG_LEVEL", originalLogLevel);
     __resetLoggerConfigForTests();
     __resetLogRecordEmitterForTests();
+    clearModelProviders();
   });
 
   it("lets hosts override the model runtime and transport options for generate()", async () => {

--- a/src/cache/module-cache.ts
+++ b/src/cache/module-cache.ts
@@ -56,7 +56,7 @@ function getOrInitPodCache(options: PodCacheOptions): LRUCache<string, string> {
   options.assign(cache);
   registerLRUCache(options.registryName, cache);
 
-  logger.info(options.logMessage, {
+  logger.debug(options.logMessage, {
     maxEntries: options.maxEntries,
     ttlMs: options.ttlMs,
   });

--- a/src/extensions/builtin-extensions.ts
+++ b/src/extensions/builtin-extensions.ts
@@ -255,7 +255,7 @@ function createBuiltinLLMProviderExtension(
         );
         didRegister = registerBuiltinLLMProvider(registry, provider);
         if (didRegister) {
-          ctx.logger.info(
+          ctx.logger.debug(
             `[${definition.extensionName}] ${provider.id} provider registered`,
           );
         }

--- a/src/extensions/capabilities.ts
+++ b/src/extensions/capabilities.ts
@@ -89,5 +89,5 @@ export function auditCapabilities(
   if (capabilities.length === 0) return;
 
   const lines = formatCapabilities(capabilities);
-  logger.info(`Extension "${extensionName}" declares capabilities:`, ...lines);
+  logger.debug(`Extension "${extensionName}" declares capabilities:`, ...lines);
 }

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -285,7 +285,7 @@ export class ExtensionLoader {
       }
 
       this.setupOrder.push(resolved);
-      this.logger.info(`Extension "${ext.name}" v${ext.version} loaded from ${resolved.source}`);
+      this.logger.debug(`Extension "${ext.name}" v${ext.version} loaded from ${resolved.source}`);
     }
   }
 

--- a/src/observability/production-log-noise.test.ts
+++ b/src/observability/production-log-noise.test.ts
@@ -25,6 +25,25 @@ const recoverableWarnSites = [
   },
 ];
 
+const hostedProductionRequestObservabilitySites = [
+  {
+    path: "src/server/runtime-handler/request-tracker.ts",
+    snippet: 'logger.warn("Slow request detected"',
+  },
+  {
+    path: "src/server/runtime-handler/request-tracker.ts",
+    snippet: 'logger.error("Very slow request - likely stuck"',
+  },
+  {
+    path: "src/server/runtime-handler/timeout-manager.ts",
+    snippet: 'logger.warn("Request timed out"',
+  },
+  {
+    path: "src/server/runtime-handler/timeout-manager.ts",
+    snippet: 'logger.error("Unhandled error in request handler"',
+  },
+];
+
 Deno.test("recoverable render cache events do not emit production warning logs", async () => {
   for (const site of recoverableWarnSites) {
     const source = await Deno.readTextFile(site.path);
@@ -32,6 +51,17 @@ Deno.test("recoverable render cache events do not emit production warning logs",
       source.includes(site.snippet),
       false,
       `${site.path} should not warn for recoverable/no-op production events`,
+    );
+  }
+});
+
+Deno.test("hosted production request failures and slow requests keep warning/error observability", async () => {
+  for (const site of hostedProductionRequestObservabilitySites) {
+    const source = await Deno.readTextFile(site.path);
+    assertEquals(
+      source.includes(site.snippet),
+      true,
+      `${site.path} must retain warning/error logging for failed or slow hosted requests`,
     );
   }
 });

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -157,7 +157,7 @@ function createImportMapPlugin(
 
   if (importMapEntries.length === 0) return { name: "import-map", setup() {} };
 
-  logger.info(`Using import map with ${importMapEntries.length} entries`);
+  logger.debug(`Using import map with ${importMapEntries.length} entries`);
 
   return {
     name: "import-map",
@@ -521,7 +521,7 @@ function loadAndTranspileModule(
         );
       }
 
-      logger.info(`built handler ${resolvedPath}`);
+      logger.debug(`built handler ${resolvedPath}`);
       const js = result.outputFiles?.[0]?.text ?? "export {}";
       logger.debug(`transpiled size ${js.length} bytes`);
 

--- a/src/security/http/config.test.ts
+++ b/src/security/http/config.test.ts
@@ -146,6 +146,24 @@ describe("security/http/config", () => {
     assertEquals(getOutput().includes("Neither CORS nor CSRF protection is configured"), false);
   });
 
+  it("does not warn for the same-origin development default", async () => {
+    Deno.env.set("NODE_ENV", "development");
+    const { getOutput, restore } = captureConsoleLog();
+    const loader = new SecurityConfigLoader(
+      "/project",
+      createMockAdapter(),
+      { security: {} },
+    );
+
+    try {
+      await loader.ensureLoaded();
+    } finally {
+      restore();
+    }
+
+    assertEquals(getOutput().includes("Neither CORS nor CSRF protection is configured"), false);
+  });
+
   it("honors explicit CSRF disablement in production", async () => {
     Deno.env.set("NODE_ENV", "production");
     const { getOutput, restore } = captureConsoleLog();

--- a/src/security/http/config.test.ts
+++ b/src/security/http/config.test.ts
@@ -148,6 +148,7 @@ describe("security/http/config", () => {
 
   it("honors explicit CSRF disablement in production", async () => {
     Deno.env.set("NODE_ENV", "production");
+    const { getOutput, restore } = captureConsoleLog();
     const loader = new SecurityConfigLoader(
       "/project",
       createMockAdapter(),
@@ -156,9 +157,14 @@ describe("security/http/config", () => {
       },
     );
 
-    await loader.ensureLoaded();
+    try {
+      await loader.ensureLoaded();
+    } finally {
+      restore();
+    }
 
     assertEquals(loader.getSecurityConfig()?.csrf, false);
+    assertEquals(getOutput().includes("Neither CORS nor CSRF protection is configured"), true);
   });
 
   it("rejects a failed load for the current caller and retries on the next call", async () => {

--- a/src/security/http/config.ts
+++ b/src/security/http/config.ts
@@ -45,15 +45,16 @@ export class SecurityConfigLoader {
 
   private applyConfig(cfg?: VeryfrontConfig): void {
     const security: SecurityConfig = cfg?.security ? { ...cfg.security } as SecurityConfig : {};
+    const production = isProduction();
 
     if (security.headers) security.headers = { ...security.headers };
 
     security.cors ??= false;
-    if (security.csrf === undefined && isProduction()) {
+    if (security.csrf === undefined && production) {
       security.csrf = true;
     }
 
-    if (!security.cors && !security.csrf) {
+    if (production && !security.cors && !security.csrf) {
       logger.warn(
         "Neither CORS nor CSRF protection is configured. " +
           "CORS is disabled by default (same-origin only). " +

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -57,7 +57,7 @@ export class HMRHandler extends BaseHandler {
     if (HMRHandler.initialized) return;
     HMRHandler.initialized = true;
 
-    logger.info("Subscribing to ReloadNotifier");
+    logger.debug("Subscribing to ReloadNotifier");
 
     HMRHandler.reloadUnsubscribe = ReloadNotifier.subscribe((changedPaths, project) => {
       logger.debug("ReloadNotifier callback triggered", {
@@ -261,7 +261,7 @@ export class HMRHandler extends BaseHandler {
         proxyToken,
         async () => {
           await fs.exists("veryfront.config.ts");
-          logger.info("Adapter initialized for poke reception", {
+          logger.debug("Adapter initialized for poke reception", {
             projectSlug,
           });
         },

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -196,9 +196,9 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<Disco
         } else if (
           result.agents.size === 0 && result.tools.size === 0 && shouldWarnOnEmptyAiDiscovery
         ) {
-          logger.info("Primitive discovery found 0 agents and 0 tools", logData);
+          logger.debug("Primitive discovery found 0 agents and 0 tools", logData);
         } else {
-          logger.info("Primitive discovery completed", logData);
+          logger.debug("Primitive discovery completed", logData);
         }
 
         return result;

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -6,6 +6,7 @@ import { DenoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts"
 import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
 import { createVeryfrontHandler } from "./index.ts";
 import { __injectDepsForTests as injectIsolationDepsForTests } from "./isolation.ts";
+import { requestTracker } from "./request-tracker.ts";
 
 function createMockAdapter(): RuntimeAdapter {
   return {
@@ -42,10 +43,27 @@ function createProxyModeHandler() {
   });
 }
 
+function captureConsoleOutput(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const capture = (...args: unknown[]) => lines.push(args.map(String).join(" "));
+  console.log = capture;
+  console.warn = capture;
+  return {
+    lines,
+    restore: () => {
+      console.log = originalLog;
+      console.warn = originalWarn;
+    },
+  };
+}
+
 describe("server/runtime-handler/index", () => {
   afterEach(() => {
     injectIsolationDepsForTests(null);
     HMRHandler.shutdown();
+    requestTracker.shutdown();
   });
 
   it("returns 502 when x-project-slug is missing in proxy mode", async () => {
@@ -63,6 +81,35 @@ describe("server/runtime-handler/index", () => {
       error: "Missing project context",
       detail: "x-project-slug header is required in proxy mode",
     });
+  });
+
+  it("emits one security configuration warning for the default development config", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const adapter = new DenoAdapter();
+    const { lines, restore } = captureConsoleOutput();
+
+    try {
+      const handler = createVeryfrontHandler(projectDir, adapter, {
+        projectDir,
+        config: {} as any,
+      });
+      await handler.ready;
+      await handler(new Request("http://localhost/healthz"));
+    } finally {
+      restore();
+      HMRHandler.shutdown();
+      await Deno.remove(projectDir, { recursive: true });
+    }
+
+    const securityGuidance = lines.filter((line) =>
+      line.includes("CSRF protection is not configured") ||
+      line.includes("Neither CORS nor CSRF protection is configured")
+    );
+    assertEquals(securityGuidance.length, 1);
+    assertEquals(
+      securityGuidance[0]?.includes("Neither CORS nor CSRF protection is configured"),
+      true,
+    );
   });
 
   it("returns 502 when x-token is missing in proxy mode", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -87,6 +87,8 @@ describe("server/runtime-handler/index", () => {
     const projectDir = await Deno.makeTempDir();
     const adapter = new DenoAdapter();
     const { lines, restore } = captureConsoleOutput();
+    const originalVeryfrontEnv = Deno.env.get("VERYFRONT_ENV");
+    Deno.env.set("VERYFRONT_ENV", "development");
 
     try {
       const handler = createVeryfrontHandler(projectDir, adapter, {
@@ -97,6 +99,8 @@ describe("server/runtime-handler/index", () => {
       await handler(new Request("http://localhost/healthz"));
     } finally {
       restore();
+      if (originalVeryfrontEnv === undefined) Deno.env.delete("VERYFRONT_ENV");
+      else Deno.env.set("VERYFRONT_ENV", originalVeryfrontEnv);
       HMRHandler.shutdown();
       await Deno.remove(projectDir, { recursive: true });
     }

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -83,7 +83,7 @@ describe("server/runtime-handler/index", () => {
     });
   });
 
-  it("emits one security configuration warning for the default development config", async () => {
+  it("does not emit security guidance for the safe development defaults", async () => {
     const projectDir = await Deno.makeTempDir();
     const adapter = new DenoAdapter();
     const { lines, restore } = captureConsoleOutput();
@@ -109,11 +109,7 @@ describe("server/runtime-handler/index", () => {
       line.includes("CSRF protection is not configured") ||
       line.includes("Neither CORS nor CSRF protection is configured")
     );
-    assertEquals(securityGuidance.length, 1);
-    assertEquals(
-      securityGuidance[0]?.includes("Neither CORS nor CSRF protection is configured"),
-      true,
-    );
+    assertEquals(securityGuidance.length, 0);
   });
 
   it("returns 502 when x-token is missing in proxy mode", async () => {

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -325,11 +325,6 @@ export function createVeryfrontHandler(
   const configPromise = (async () => {
     const c = opts.config ? opts.config : await getConfig(projectDir, adapter);
     config = c;
-    if (c?.security?.csrf === undefined) {
-      logger.info(
-        "CSRF protection is not configured. Add `security: { csrf: true }` to veryfront.config.ts to enable.",
-      );
-    }
     return c;
   })();
 

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -410,6 +410,7 @@ export function createVeryfrontHandler(
         preparedRequest.trackingFacts.method,
         preparedRequest.trackingFacts.environment,
         preparedRequest.trackingFacts.releaseId,
+        opts.defaultEnvironment === "production",
       );
 
       startContentMetrics();

--- a/src/server/runtime-handler/request-lifecycle.test.ts
+++ b/src/server/runtime-handler/request-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   completeRequestTracking,
   completeRequestTrackingOnResponseEnd,
@@ -13,6 +13,13 @@ import {
 import { requestTracker } from "./request-tracker.ts";
 
 describe("server/runtime-handler/request-lifecycle", () => {
+  afterEach(() => {
+    for (const tracked of requestTracker.getInFlightRequests()) {
+      requestTracker.complete(tracked.requestId, 200);
+    }
+    requestTracker.shutdown();
+  });
+
   describe("startRequestLifecycle", () => {
     it("should return context with requestId", () => {
       const req = new Request("http://localhost/test");

--- a/src/server/runtime-handler/request-lifecycle.ts
+++ b/src/server/runtime-handler/request-lifecycle.ts
@@ -75,6 +75,7 @@ export function startRequestTracking(
   method: string,
   environment: string | undefined,
   releaseId: string | undefined,
+  productionRuntime = false,
 ): void {
   requestTracker.start(
     requestId,
@@ -83,6 +84,7 @@ export function startRequestTracking(
     method,
     environment,
     releaseId,
+    productionRuntime,
   );
 }
 

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -3,18 +3,36 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   __registerLogRecordEmitter,
+  __resetLoggerConfigForTests,
   __resetLogRecordEmitterForTests,
   type LogEntry,
 } from "#veryfront/utils/logger/logger.ts";
 import { requestTracker } from "./request-tracker.ts";
 
-describe("server/runtime-handler/request-tracker", () => {
+const originalLogLevel = Deno.env.get("LOG_LEVEL");
+
+function captureLogs(): LogEntry[] {
+  const entries: LogEntry[] = [];
+  Deno.env.set("LOG_LEVEL", "DEBUG");
+  __resetLoggerConfigForTests();
+  __registerLogRecordEmitter((entry) => entries.push(entry));
+  return entries;
+}
+
+describe({
+  name: "server/runtime-handler/request-tracker",
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, () => {
   afterEach(() => {
     // Clean up any tracked requests
     for (const tracked of requestTracker.getInFlightRequests()) {
       requestTracker.complete(tracked.requestId, 200);
     }
     Deno.env.delete("VERYFRONT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS");
+    if (originalLogLevel === undefined) Deno.env.delete("LOG_LEVEL");
+    else Deno.env.set("LOG_LEVEL", originalLogLevel);
+    __resetLoggerConfigForTests();
     __resetLogRecordEmitterForTests();
   });
 
@@ -184,6 +202,82 @@ describe("server/runtime-handler/request-tracker", () => {
   });
 
   describe("complete logging behavior", () => {
+    it("logs successful request completions at debug level", () => {
+      const entries = captureLogs();
+
+      requestTracker.start("ok-req", "proj", "/ok", "GET");
+      requestTracker.complete("ok-req", 200);
+
+      const entry = entries.find((candidate) => candidate.message === "GET /ok 200");
+      assertEquals(entry?.level, "debug");
+      assertEquals(entry?.context?.statusCode, 200);
+    });
+
+    it("logs redirect request completions at debug level", () => {
+      const entries = captureLogs();
+
+      requestTracker.start("redirect-req", "proj", "/moved", "GET");
+      requestTracker.complete("redirect-req", 302);
+
+      const entry = entries.find((candidate) => candidate.message === "GET /moved 302");
+      assertEquals(entry?.level, "debug");
+      assertEquals(entry?.context?.statusCode, 302);
+    });
+
+    it("logs client error request completions at warn level", () => {
+      const entries = captureLogs();
+
+      requestTracker.start("not-found", "proj", "/missing", "GET");
+      requestTracker.complete("not-found", 404);
+
+      const entry = entries.find((candidate) => candidate.message === "GET /missing 404");
+      assertEquals(entry?.level, "warn");
+      assertEquals(entry?.context?.statusCode, 404);
+    });
+
+    it("logs server error request completions at error level", () => {
+      const entries = captureLogs();
+
+      requestTracker.start("error-req", "proj", "/broken", "GET");
+      requestTracker.complete("error-req", 500);
+
+      const entry = entries.find((candidate) => candidate.message === "GET /broken 500");
+      assertEquals(entry?.level, "error");
+      assertEquals(entry?.context?.statusCode, 500);
+    });
+
+    it("keeps slow and very slow timer diagnostics visible", () => {
+      const entries = captureLogs();
+      const originalSetTimeout = globalThis.setTimeout;
+
+      globalThis.setTimeout = ((callback: TimerHandler, delay?: number, ...args: unknown[]) => {
+        if (delay === 10_000) {
+          if (typeof callback === "function") callback(...args);
+          return 1 as unknown as ReturnType<typeof setTimeout>;
+        }
+        if (delay === 15_000) {
+          if (typeof callback === "function") callback(...args);
+          return 2 as unknown as ReturnType<typeof setTimeout>;
+        }
+        return originalSetTimeout(callback, delay, ...args);
+      }) as typeof setTimeout;
+
+      try {
+        requestTracker.start("slow-req", "proj", "/slow", "GET");
+        requestTracker.complete("slow-req", 200);
+      } finally {
+        globalThis.setTimeout = originalSetTimeout;
+      }
+
+      const slowEntry = entries.find((candidate) => candidate.message === "Slow request detected");
+      const verySlowEntry = entries.find((candidate) =>
+        candidate.message === "Very slow request - likely stuck"
+      );
+
+      assertEquals(slowEntry?.level, "warn");
+      assertEquals(verySlowEntry?.level, "error");
+    });
+
     it("handles module request with short duration (no debug log)", () => {
       requestTracker.start("fast-mod", "proj", "/_vf_modules/fast.js", "GET");
       requestTracker.complete("fast-mod", 200);
@@ -197,8 +291,7 @@ describe("server/runtime-handler/request-tracker", () => {
     });
 
     it("attaches request profile details to slow completion logs", () => {
-      const entries: LogEntry[] = [];
-      __registerLogRecordEmitter((entry) => entries.push(entry));
+      const entries = captureLogs();
       Deno.env.set("VERYFRONT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS", "0");
 
       requestTracker.start("profiled-req", "proj", "/", "GET", "production", "rel-1");
@@ -236,13 +329,13 @@ describe("server/runtime-handler/request-tracker", () => {
     });
 
     it("handles 404 status completion", () => {
-      requestTracker.start("not-found", "proj", "/missing", "GET");
-      requestTracker.complete("not-found", 404);
+      requestTracker.start("not-found-legacy", "proj", "/missing", "GET");
+      requestTracker.complete("not-found-legacy", 404);
     });
 
     it("handles 500 status completion", () => {
-      requestTracker.start("error-req", "proj", "/broken", "GET");
-      requestTracker.complete("error-req", 500);
+      requestTracker.start("error-req-legacy", "proj", "/broken", "GET");
+      requestTracker.complete("error-req-legacy", 500);
     });
   });
 

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   __registerLogRecordEmitter,
   __resetLoggerConfigForTests,
@@ -10,6 +10,7 @@ import {
 import { requestTracker } from "./request-tracker.ts";
 
 const originalLogLevel = Deno.env.get("LOG_LEVEL");
+const originalVeryfrontEnv = Deno.env.get("VERYFRONT_ENV");
 
 function captureLogs(): LogEntry[] {
   const entries: LogEntry[] = [];
@@ -20,6 +21,10 @@ function captureLogs(): LogEntry[] {
 }
 
 describe("server/runtime-handler/request-tracker", () => {
+  beforeEach(() => {
+    Deno.env.set("VERYFRONT_ENV", "development");
+  });
+
   afterEach(() => {
     // Clean up any tracked requests
     for (const tracked of requestTracker.getInFlightRequests()) {
@@ -29,6 +34,8 @@ describe("server/runtime-handler/request-tracker", () => {
     Deno.env.delete("VERYFRONT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS");
     if (originalLogLevel === undefined) Deno.env.delete("LOG_LEVEL");
     else Deno.env.set("LOG_LEVEL", originalLogLevel);
+    if (originalVeryfrontEnv === undefined) Deno.env.delete("VERYFRONT_ENV");
+    else Deno.env.set("VERYFRONT_ENV", originalVeryfrontEnv);
     __resetLoggerConfigForTests();
     __resetLogRecordEmitterForTests();
   });
@@ -252,6 +259,42 @@ describe("server/runtime-handler/request-tracker", () => {
       const entry = entries.find((candidate) => candidate.message === "GET /broken 500");
       assertEquals(entry?.level, "debug");
       assertEquals(entry?.context?.statusCode, 500);
+    });
+
+    it("elevates hosted client and server error completions", () => {
+      Deno.env.set("VERYFRONT_ENV", "production");
+      const entries = captureLogs();
+
+      requestTracker.start("hosted-not-found", "proj", "/missing", "GET");
+      requestTracker.complete("hosted-not-found", 404);
+      requestTracker.start("hosted-error", "proj", "/broken", "POST");
+      requestTracker.complete("hosted-error", 500);
+
+      const notFound = entries.find((candidate) => candidate.message === "GET /missing 404");
+      const serverError = entries.find((candidate) => candidate.message === "POST /broken 500");
+      assertEquals(notFound?.level, "warn");
+      assertEquals(serverError?.level, "error");
+    });
+
+    it("does not let a hosted logging sink failure alter request completion", () => {
+      Deno.env.set("VERYFRONT_ENV", "production");
+      const entries = captureLogs();
+      const originalError = console.error;
+
+      try {
+        console.error = () => {
+          throw new Error("error sink unavailable");
+        };
+
+        requestTracker.start("hosted-sink-error", "proj", "/broken", "GET");
+        requestTracker.complete("hosted-sink-error", 500);
+      } finally {
+        console.error = originalError;
+      }
+
+      const entry = entries.find((candidate) => candidate.message === "GET /broken 500");
+      assertEquals(entry?.level, "error");
+      assertEquals(requestTracker.getInFlightCount(), 0);
     });
 
     it("keeps slow and very slow timer diagnostics visible", () => {

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -336,15 +336,21 @@ describe("server/runtime-handler/request-tracker", () => {
     it("keeps slow and very slow timer diagnostics visible", () => {
       const entries = captureLogs();
       const originalSetTimeout = globalThis.setTimeout;
+      const originalClearTimeout = globalThis.clearTimeout;
+      const createInertTimerHandle = () => {
+        const handle = originalSetTimeout(() => {}, 0);
+        originalClearTimeout(handle);
+        return handle;
+      };
 
       globalThis.setTimeout = ((callback: TimerHandler, delay?: number, ...args: unknown[]) => {
         if (delay === 10_000) {
           if (typeof callback === "function") callback(...args);
-          return 1 as unknown as ReturnType<typeof setTimeout>;
+          return createInertTimerHandle();
         }
         if (delay === 15_000) {
           if (typeof callback === "function") callback(...args);
-          return 2 as unknown as ReturnType<typeof setTimeout>;
+          return createInertTimerHandle();
         }
         return originalSetTimeout(callback, delay, ...args);
       }) as typeof setTimeout;

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -276,6 +276,42 @@ describe("server/runtime-handler/request-tracker", () => {
       assertEquals(serverError?.level, "error");
     });
 
+    it("elevates standalone production failures when process env is development", () => {
+      const entries = captureLogs();
+
+      requestTracker.start(
+        "standalone-error",
+        "proj",
+        "/broken",
+        "GET",
+        undefined,
+        undefined,
+        true,
+      );
+      requestTracker.complete("standalone-error", 500);
+
+      const entry = entries.find((candidate) => candidate.message === "GET /broken 500");
+      assertEquals(entry?.level, "error");
+    });
+
+    it("keeps local project failures quiet when process env is development", () => {
+      const entries = captureLogs();
+
+      requestTracker.start(
+        "local-error",
+        "proj",
+        "/broken",
+        "GET",
+        "production",
+        undefined,
+        false,
+      );
+      requestTracker.complete("local-error", 500);
+
+      const entry = entries.find((candidate) => candidate.message === "GET /broken 500");
+      assertEquals(entry?.level, "debug");
+    });
+
     it("does not let a hosted logging sink failure alter request completion", () => {
       Deno.env.set("VERYFRONT_ENV", "production");
       const entries = captureLogs();

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -19,16 +19,13 @@ function captureLogs(): LogEntry[] {
   return entries;
 }
 
-describe({
-  name: "server/runtime-handler/request-tracker",
-  sanitizeOps: false,
-  sanitizeResources: false,
-}, () => {
+describe("server/runtime-handler/request-tracker", () => {
   afterEach(() => {
     // Clean up any tracked requests
     for (const tracked of requestTracker.getInFlightRequests()) {
       requestTracker.complete(tracked.requestId, 200);
     }
+    requestTracker.shutdown();
     Deno.env.delete("VERYFRONT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS");
     if (originalLogLevel === undefined) Deno.env.delete("LOG_LEVEL");
     else Deno.env.set("LOG_LEVEL", originalLogLevel);

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -221,25 +221,36 @@ describe("server/runtime-handler/request-tracker", () => {
       assertEquals(entry?.context?.statusCode, 302);
     });
 
-    it("logs client error request completions at warn level", () => {
+    it("logs websocket upgrade completions at debug level", () => {
+      const entries = captureLogs();
+
+      requestTracker.start("upgrade-req", "proj", "/_ws", "GET");
+      requestTracker.complete("upgrade-req", 101);
+
+      const entry = entries.find((candidate) => candidate.message === "GET /_ws 101");
+      assertEquals(entry?.level, "debug");
+      assertEquals(entry?.context?.statusCode, 101);
+    });
+
+    it("logs client error request completions at debug level", () => {
       const entries = captureLogs();
 
       requestTracker.start("not-found", "proj", "/missing", "GET");
       requestTracker.complete("not-found", 404);
 
       const entry = entries.find((candidate) => candidate.message === "GET /missing 404");
-      assertEquals(entry?.level, "warn");
+      assertEquals(entry?.level, "debug");
       assertEquals(entry?.context?.statusCode, 404);
     });
 
-    it("logs server error request completions at error level", () => {
+    it("logs server error request completions at debug level", () => {
       const entries = captureLogs();
 
       requestTracker.start("error-req", "proj", "/broken", "GET");
       requestTracker.complete("error-req", 500);
 
       const entry = entries.find((candidate) => candidate.message === "GET /broken 500");
-      assertEquals(entry?.level, "error");
+      assertEquals(entry?.level, "debug");
       assertEquals(entry?.context?.statusCode, 500);
     });
 
@@ -346,6 +357,34 @@ describe("server/runtime-handler/request-tracker", () => {
   });
 
   describe("timer cleanup", () => {
+    it("stops status logging after the final request completes", () => {
+      const clearedIntervals: ReturnType<typeof setInterval>[] = [];
+      const originalSetInterval = globalThis.setInterval;
+      const originalClearInterval = globalThis.clearInterval;
+      let statusInterval: ReturnType<typeof setInterval> | undefined;
+
+      globalThis.setInterval = ((...args: Parameters<typeof setInterval>) => {
+        statusInterval = originalSetInterval(...args);
+        return statusInterval;
+      }) as typeof setInterval;
+      globalThis.clearInterval = ((id?: ReturnType<typeof setInterval>) => {
+        if (id !== undefined) clearedIntervals.push(id);
+        originalClearInterval(id);
+      }) as typeof clearInterval;
+
+      try {
+        requestTracker.start("status-interval", "proj", "/_ws", "GET");
+        requestTracker.complete("status-interval", 101);
+
+        assertEquals(statusInterval !== undefined, true);
+        assertEquals(clearedIntervals.includes(statusInterval!), true);
+      } finally {
+        requestTracker.shutdown();
+        globalThis.setInterval = originalSetInterval;
+        globalThis.clearInterval = originalClearInterval;
+      }
+    });
+
     it("should clear both slow and very slow timers on completion", () => {
       const clearedTimers: ReturnType<typeof setTimeout>[] = [];
       const originalClearTimeout = globalThis.clearTimeout;

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -22,6 +22,7 @@ interface TrackedRequest {
   startTime: number;
   env?: string;
   releaseId?: string;
+  productionRuntime: boolean;
   slowTimer?: ReturnType<typeof setTimeout>;
   verySlowTimer?: ReturnType<typeof setTimeout>;
 }
@@ -79,8 +80,9 @@ function logRequestCompletion(
   message: string,
   statusCode: number,
   context: Record<string, unknown>,
+  productionRuntime: boolean,
 ): void {
-  if (!isProduction() || statusCode < 400) {
+  if ((!isProduction() && !productionRuntime) || statusCode < 400) {
     logger.debug(message, context);
     return;
   }
@@ -143,6 +145,7 @@ class RequestTracker {
     method: string,
     env?: string,
     releaseId?: string,
+    productionRuntime = false,
   ): void {
     this.startStatusLogging();
 
@@ -157,6 +160,7 @@ class RequestTracker {
       startTime,
       env,
       releaseId,
+      productionRuntime,
     };
 
     // WebSocket connections are long-lived by design and lightweight internal
@@ -241,7 +245,12 @@ class RequestTracker {
       logContext.request_profile = buildRequestProfileLogContext(profile);
     }
 
-    logRequestCompletion(`${tracked.method} ${tracked.path} ${statusCode}`, statusCode, logContext);
+    logRequestCompletion(
+      `${tracked.method} ${tracked.path} ${statusCode}`,
+      statusCode,
+      logContext,
+      tracked.productionRuntime,
+    );
   }
 
   markLongLived(requestId: string): void {

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -97,11 +97,9 @@ class RequestTracker {
   private totalCompleted = 0;
   private totalTimedOut = 0;
 
-  constructor() {
-    this.startStatusLogging();
-  }
-
   private startStatusLogging(): void {
+    if (this.statusInterval) return;
+
     this.statusInterval = setInterval(() => {
       if (this.inFlight.size === 0) return;
 
@@ -137,6 +135,8 @@ class RequestTracker {
     env?: string,
     releaseId?: string,
   ): void {
+    this.startStatusLogging();
+
     const startTime = performance.now();
     this.totalRequests++;
 
@@ -320,7 +320,10 @@ class RequestTracker {
   }
 
   shutdown(): void {
-    if (this.statusInterval) clearInterval(this.statusInterval);
+    if (this.statusInterval) {
+      clearInterval(this.statusInterval);
+      this.statusInterval = undefined;
+    }
 
     for (const tracked of this.inFlight.values()) {
       if (tracked.slowTimer) clearTimeout(tracked.slowTimer);

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -10,6 +10,7 @@ import { unrefTimer } from "#veryfront/compat/process.ts";
 import { isLightweightPath, isWebSocketPath } from "./request-utils.ts";
 import type { RequestProfileRecord } from "#veryfront/observability";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { isProduction } from "#veryfront/platform/environment.ts";
 
 const logger = serverLogger.component("request-tracker");
 
@@ -72,6 +73,24 @@ function buildRequestProfileLogContext(record: RequestProfileRecord): Record<str
     phases: record.phases,
     slowestPhases,
   };
+}
+
+function logRequestCompletion(
+  message: string,
+  statusCode: number,
+  context: Record<string, unknown>,
+): void {
+  if (!isProduction() || statusCode < 400) {
+    logger.debug(message, context);
+    return;
+  }
+
+  try {
+    if (statusCode >= 500) logger.error(message, context);
+    else logger.warn(message, context);
+  } catch {
+    // Completion observability must not change an already-produced response.
+  }
 }
 
 class RequestTracker {
@@ -222,7 +241,7 @@ class RequestTracker {
       logContext.request_profile = buildRequestProfileLogContext(profile);
     }
 
-    logger.debug(`${tracked.method} ${tracked.path} ${statusCode}`, logContext);
+    logRequestCompletion(`${tracked.method} ${tracked.path} ${statusCode}`, statusCode, logContext);
   }
 
   markLongLived(requestId: string): void {

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -74,22 +74,6 @@ function buildRequestProfileLogContext(record: RequestProfileRecord): Record<str
   };
 }
 
-function logRequestCompletion(
-  message: string,
-  statusCode: number,
-  context: Record<string, unknown>,
-): void {
-  if (statusCode >= 500) {
-    logger.error(message, context);
-  } else if (statusCode >= 400) {
-    logger.warn(message, context);
-  } else if (statusCode >= 200 && statusCode < 400) {
-    logger.debug(message, context);
-  } else {
-    logger.info(message, context);
-  }
-}
-
 class RequestTracker {
   private inFlight = new Map<string, TrackedRequest>();
   private statusInterval: ReturnType<typeof setInterval> | undefined;
@@ -125,6 +109,12 @@ class RequestTracker {
 
     // Global singleton status logging should not keep short-lived CLI processes alive.
     if (this.statusInterval) unrefTimer(this.statusInterval);
+  }
+
+  private stopStatusLogging(): void {
+    if (!this.statusInterval) return;
+    clearInterval(this.statusInterval);
+    this.statusInterval = undefined;
   }
 
   start(
@@ -204,6 +194,7 @@ class RequestTracker {
     if (tracked.verySlowTimer) clearTimeout(tracked.verySlowTimer);
 
     this.inFlight.delete(requestId);
+    if (this.inFlight.size === 0) this.stopStatusLogging();
 
     const durationMs = Math.round(performance.now() - tracked.startTime);
 
@@ -231,7 +222,7 @@ class RequestTracker {
       logContext.request_profile = buildRequestProfileLogContext(profile);
     }
 
-    logRequestCompletion(`${tracked.method} ${tracked.path} ${statusCode}`, statusCode, logContext);
+    logger.debug(`${tracked.method} ${tracked.path} ${statusCode}`, logContext);
   }
 
   markLongLived(requestId: string): void {
@@ -320,10 +311,7 @@ class RequestTracker {
   }
 
   shutdown(): void {
-    if (this.statusInterval) {
-      clearInterval(this.statusInterval);
-      this.statusInterval = undefined;
-    }
+    this.stopStatusLogging();
 
     for (const tracked of this.inFlight.values()) {
       if (tracked.slowTimer) clearTimeout(tracked.slowTimer);

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -74,6 +74,22 @@ function buildRequestProfileLogContext(record: RequestProfileRecord): Record<str
   };
 }
 
+function logRequestCompletion(
+  message: string,
+  statusCode: number,
+  context: Record<string, unknown>,
+): void {
+  if (statusCode >= 500) {
+    logger.error(message, context);
+  } else if (statusCode >= 400) {
+    logger.warn(message, context);
+  } else if (statusCode >= 200 && statusCode < 400) {
+    logger.debug(message, context);
+  } else {
+    logger.info(message, context);
+  }
+}
+
 class RequestTracker {
   private inFlight = new Map<string, TrackedRequest>();
   private statusInterval: ReturnType<typeof setInterval> | undefined;
@@ -215,7 +231,7 @@ class RequestTracker {
       logContext.request_profile = buildRequestProfileLogContext(profile);
     }
 
-    logger.info(`${tracked.method} ${tracked.path} ${statusCode}`, logContext);
+    logRequestCompletion(`${tracked.method} ${tracked.path} ${statusCode}`, statusCode, logContext);
   }
 
   markLongLived(requestId: string): void {

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -59,7 +59,7 @@ function tryConvert(
 }
 
 function logSchemaResult(logPrefix: string, toolId: string, method: string, schema: JsonSchema) {
-  agentLogger.info(
+  agentLogger.debug(
     `[${logPrefix}] ${method} schema for "${toolId}": ${
       Object.keys(schema.properties || {}).length
     } properties`,

--- a/src/tool/registry.ts
+++ b/src/tool/registry.ts
@@ -70,7 +70,7 @@ export function toolToProviderDefinition(tool: Tool): ToolDefinition {
   const hasPreConvertedSchema = tool.inputSchemaJson != null;
   const jsonSchema = tool.inputSchemaJson ?? zodToJsonSchema(tool.inputSchema);
 
-  agentLogger.info(
+  agentLogger.debug(
     `[TOOL] Using ${
       hasPreConvertedSchema ? "pre-converted" : "runtime-converted"
     } schema for "${tool.id}"`,

--- a/src/transforms/esm/transform-cache.ts
+++ b/src/transforms/esm/transform-cache.ts
@@ -243,7 +243,7 @@ export async function initializeTransformCache(): Promise<boolean> {
     try {
       // Use TokenizingCacheGateway for consistent interface and isDistributed() checks
       cacheGateway = await CacheBackends.codeStore("TRANSFORM-CACHE", { keyPrefix: "transform" });
-      logger.info("Initialized with gateway", { backend: cacheGateway.type });
+      logger.debug("Initialized with gateway", { backend: cacheGateway.type });
     } catch (error) {
       logger.warn("Backend init failed, using memory", { error });
       // Fallback to memory backend wrapped in gateway for consistent interface


### PR DESCRIPTION
## Summary

- keep routine bootstrap, model remap, tool-schema, and successful request diagnostics behind `--debug`
- retain startup readiness, actionable warnings, client errors, server errors, and slow-request diagnostics in default output
- emit one security-configuration warning and clean up request-tracker timers deterministically
- make the development warning regression test independent of the release runner's production environment

## Developer experience

Default `veryfront dev` output now communicates the outcome developers need: where the app is running, whether Studio/MCP are ready, and any actionable problem. `veryfront dev --debug` preserves the detailed runtime trace for diagnosis.

## Verification

- `NODE_ENV=production deno test -A src/server/runtime-handler/index.test.ts src/security/http/config.test.ts`
- `deno test -A cli/commands/dev/dev-output.integration.test.ts src/server/runtime-handler src/security/http/config.test.ts src/agent/runtime/provider-transport.test.ts`
- `deno fmt --check src/server/runtime-handler/index.test.ts`
- `deno lint src/server/runtime-handler/index.test.ts`
- `deno task typecheck`
- full pre-push hook: 2,710 passed, 21,995 steps, 0 failed
