### PR TITLE
Lock quickstart URL handoffs to canonical deployment results

### DIFF
--- a/cli/commands/init/init-command.test.ts
+++ b/cli/commands/init/init-command.test.ts
@@ -56,6 +56,41 @@ describe("InitCommand Types", () => {
       }
     });
 
+    it("prints the verified URL returned by the composed deployment", async () => {
+      const parentDir = await makeTempDir({ prefix: "veryfront-init-deploy-" });
+      const name = `deployed-target-${crypto.randomUUID()}`;
+      const deployedUrl = "https://verified.example.test/app/dashboard";
+      const output: string[] = [];
+      const originalLog = console.log;
+
+      try {
+        console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
+
+        await initCommand(
+          {
+            name,
+            parentDir,
+            template: "minimal",
+            skipInstall: true,
+            skipEnvPrompt: true,
+            deploy: true,
+          },
+          {
+            deployProject: async (projectDir) => {
+              assertEquals(projectDir, join(parentDir, name));
+              return deployedUrl;
+            },
+          },
+        );
+
+        const liveLine = output.find((line) => line.includes("Live:"));
+        assertEquals(liveLine?.includes(deployedUrl), true);
+      } finally {
+        console.log = originalLog;
+        await remove(parentDir, { recursive: true }).catch(() => {});
+      }
+    });
+
     it("should allow empty options", () => {
       const options: InitOptions = {};
       assertExists(options);

--- a/cli/commands/init/init-command.test.ts
+++ b/cli/commands/init/init-command.test.ts
@@ -10,6 +10,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { exists, makeTempDir, remove } from "#veryfront/testing/deno-compat.ts";
 import { cwd } from "veryfront/platform";
 import { join } from "veryfront/platform/path";
+import { stripAnsi } from "../../ui/ansi.ts";
 import { initCommand } from "./init-command.ts";
 import type { InitOptions, InitTemplate } from "./types.ts";
 
@@ -84,7 +85,7 @@ describe("InitCommand Types", () => {
         );
 
         const liveLine = output.find((line) => line.includes("Live:"));
-        assertEquals(liveLine?.includes(deployedUrl), true);
+        assertEquals(stripAnsi(liveLine ?? ""), `  Live: ${deployedUrl}`);
       } finally {
         console.log = originalLog;
         await remove(parentDir, { recursive: true }).catch(() => {});

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -180,7 +180,7 @@ type StructureNode = {
 };
 
 interface InitCommandDependencies {
-  deployProject?: (projectDir: string) => Promise<string | undefined>;
+  deployProject?: (projectDir: string) => Promise<string>;
 }
 
 const STRUCTURE_ORDER = [

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -179,6 +179,10 @@ type StructureNode = {
   children: Map<string, StructureNode>;
 };
 
+interface InitCommandDependencies {
+  deployProject?: (projectDir: string) => Promise<string | undefined>;
+}
+
 const STRUCTURE_ORDER = [
   "app",
   "pages",
@@ -269,7 +273,10 @@ function renderProjectStructure(rootName: string, paths: string[], maxLines = 22
 /**
  * Initializes a new Veryfront project with the specified template
  */
-export async function initCommand(options: InitOptions): Promise<void> {
+export async function initCommand(
+  options: InitOptions,
+  dependencies: InitCommandDependencies = {},
+): Promise<void> {
   const { name, features = [], quiet = false } = options;
   const { integrations = [] } = options;
   const parentDir = options.parentDir ?? cwd();
@@ -558,41 +565,55 @@ export async function initCommand(options: InitOptions): Promise<void> {
   let deployedUrl: string | undefined;
   const manualDeployCommand = `${getDlxCommand(pmPreference)} veryfront deploy`;
   if (options.deploy) {
-    const { chdir } = await import("veryfront/platform");
-    const { ensureAuthenticated, readToken } = await import("../../auth/index.ts");
-    const { deployCommand } = await import("../deploy/index.ts");
     const manualDeployHint = `Run ${brand(manualDeployCommand)} to deploy later.`;
 
-    const authResult = await ensureAuthenticated();
-    if (!authResult) {
-      log(`\n  Authentication required for --deploy. ${manualDeployHint}`);
+    if (dependencies.deployProject) {
+      try {
+        deployedUrl = await dependencies.deployProject(projectDir);
+        if (!deployedUrl) {
+          throw new Error("Deploy completed without a verified result.");
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log(`\n  Deploy failed: ${message}`);
+        log(`  Your project was created locally. ${manualDeployHint}`);
+      }
     } else {
-      const token = await readToken();
-      if (!token) {
-        log(`\n  Could not read auth token. ${manualDeployHint}`);
+      const { chdir } = await import("veryfront/platform");
+      const { ensureAuthenticated, readToken } = await import("../../auth/index.ts");
+      const { deployCommand } = await import("../deploy/index.ts");
+      const authResult = await ensureAuthenticated();
+
+      if (!authResult) {
+        log(`\n  Authentication required for --deploy. ${manualDeployHint}`);
       } else {
-        log(`\n  Deploying project...`);
+        const token = await readToken();
+        if (!token) {
+          log(`\n  Could not read auth token. ${manualDeployHint}`);
+        } else {
+          log(`\n  Deploying project...`);
 
-        try {
-          chdir(projectDir);
+          try {
+            chdir(projectDir);
 
-          const deployment = await deployCommand({
-            projectDir,
-            branch: "main",
-            env: "production",
-            force: true,
-            dryRun: false,
-            quiet: true,
-          });
+            const deployment = await deployCommand({
+              projectDir,
+              branch: "main",
+              env: "production",
+              force: true,
+              dryRun: false,
+              quiet: true,
+            });
 
-          if (!deployment) {
-            throw new Error("Deploy completed without a verified result.");
+            if (!deployment) {
+              throw new Error("Deploy completed without a verified result.");
+            }
+            deployedUrl = deployment.url;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            log(`\n  Deploy failed: ${message}`);
+            log(`  Your project was created locally. ${manualDeployHint}`);
           }
-          deployedUrl = deployment.url;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          log(`\n  Deploy failed: ${message}`);
-          log(`  Your project was created locally. ${manualDeployHint}`);
         }
       }
     }

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -36,6 +36,7 @@ import {
 } from "../../shared/deployment-provenance.ts";
 import { setJsonMode } from "../../shared/json-output.ts";
 import { readProjectLink, writeProjectLink } from "../../shared/project-link.ts";
+import { stripAnsi } from "../../ui/ansi.ts";
 
 type MockClientOverrides = Partial<{
   get: (path: string, params?: Record<string, string>) => Promise<unknown>;
@@ -266,17 +267,16 @@ describe("push JSON output", () => {
       try {
         await pushCommand({ projectDir, dryRun: false });
 
+        const humanOutput = output.map(stripAnsi);
         assertEquals(
-          output.some((line) =>
-            line.includes("Studio:") &&
-            line.includes("https://veryfront.com/projects/canonical-slug?branch=main")
+          humanOutput.includes(
+            "  Studio:  https://veryfront.com/projects/canonical-slug?branch=main",
           ),
           true,
         );
         assertEquals(
-          output.some((line) =>
-            line.includes("Preview:") &&
-            line.includes("https://canonical-slug.preview.veryfront.com")
+          humanOutput.includes(
+            "  Preview: https://canonical-slug.preview.veryfront.com",
           ),
           true,
         );

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -107,6 +107,10 @@ function restoreEnv(key: string, value: string | undefined): void {
   else Deno.env.set(key, value);
 }
 
+function captureConsoleLog(output: string[]): (...args: unknown[]) => void {
+  return (...args: unknown[]) => output.push(args.map(String).join(" "));
+}
+
 async function assertMissingProjectDryRunDoesNotMutate(branch: string): Promise<void> {
   const originalFetch = globalThis.fetch;
   const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
@@ -240,7 +244,7 @@ describe("push JSON output", () => {
       for (const dryRun of [true, false]) {
         const projectDir = await Deno.makeTempDir();
         const output: string[] = [];
-        console.log = (message?: unknown) => output.push(String(message));
+        console.log = captureConsoleLog(output);
         try {
           await pushCommand({ projectDir, dryRun });
 
@@ -258,7 +262,7 @@ describe("push JSON output", () => {
       setJsonMode(false);
       const projectDir = await Deno.makeTempDir();
       const output: string[] = [];
-      console.log = (message?: unknown) => output.push(String(message));
+      console.log = captureConsoleLog(output);
       try {
         await pushCommand({ projectDir, dryRun: false });
 
@@ -302,7 +306,7 @@ describe("push JSON output", () => {
       Deno.env.set("VERYFRONT_PROJECT_SLUG", "json-project");
       _resetEnvironmentConfig();
       setJsonMode(true);
-      console.log = (message?: unknown) => output.push(String(message));
+      console.log = captureConsoleLog(output);
 
       globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
         const request = input instanceof Request ? input : new Request(input, init);
@@ -354,7 +358,7 @@ describe("push JSON output", () => {
         Deno.env.set("VERYFRONT_PROJECT_SLUG", "json-project");
         _resetEnvironmentConfig();
         setJsonMode(true);
-        console.log = (message?: unknown) => output.push(String(message));
+        console.log = captureConsoleLog(output);
 
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
@@ -406,7 +410,7 @@ describe("push JSON output", () => {
         Deno.env.set("VERYFRONT_PROJECT_SLUG", "json-project");
         _resetEnvironmentConfig();
         setJsonMode(true);
-        console.log = (message?: unknown) => output.push(String(message));
+        console.log = captureConsoleLog(output);
 
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -254,6 +254,31 @@ describe("push JSON output", () => {
           await Deno.remove(projectDir, { recursive: true });
         }
       }
+
+      setJsonMode(false);
+      const projectDir = await Deno.makeTempDir();
+      const output: string[] = [];
+      console.log = (message?: unknown) => output.push(String(message));
+      try {
+        await pushCommand({ projectDir, dryRun: false });
+
+        assertEquals(
+          output.some((line) =>
+            line.includes("Studio:") &&
+            line.includes("https://veryfront.com/projects/canonical-slug?branch=main")
+          ),
+          true,
+        );
+        assertEquals(
+          output.some((line) =>
+            line.includes("Preview:") &&
+            line.includes("https://canonical-slug.preview.veryfront.com")
+          ),
+          true,
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
     } finally {
       setJsonMode(false);
       console.log = originalLog;


### PR DESCRIPTION
## Summary
- verify `init --deploy` prints the exact URL returned by the composed deployment
- verify explicit project-ID pushes print Studio and Preview links with the canonical project slug
- add a narrow internal deployment dependency boundary so the init flow can be tested without authentication or production side effects

## Verification
- focused init and push tests
- `deno fmt --check`
- `deno lint`
- `deno check`
- full pre-push gate: 2709 tests / 21995 steps, 0 failures

Follow-up regression coverage for #3144.