### PR TITLE
Release attachment replay support in v0.1.1167

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1166",
+  "version": "0.1.1167",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1166";
+export const VERSION = "0.1.1167";


### PR DESCRIPTION
## Why

The latest published package is still `veryfront@0.1.1166`, whose npm `gitHead` predates the merged attachment replay fix in #3141. Because `main` kept the same version, the stable release workflow correctly skipped publication and no downstream runtime deployment started.

This PR advances the framework version so the merged custom-agent attachment fix can be published and deployed.

Tracking: veryfront/veryfront-issue-inbox#303
Related API fix: veryfront/veryfront-api#4196

## What changed

- Bump `deno.json` from `0.1.1166` to `0.1.1167`.
- Keep the shared runtime `VERSION` constant synchronized at `0.1.1167`.

## Impact

After merge, the stable release workflow can publish `veryfront@0.1.1167` from a commit containing #3141 and dispatch the downstream server, job-runner, and sandbox deployments. Issue 303 will remain the progress tracker through deployment and browser retesting of both `/chat` and workspace chat.

## Verification

- `deno fmt --check deno.json src/utils/version-constant.ts src/utils/version.ts src/utils/logger/logger.ts`
- `deno lint deno.json src/utils/version-constant.ts src/utils/version.ts src/utils/logger/logger.ts`
- `deno check src/utils/version-constant.ts src/utils/version.ts src/utils/logger/logger.ts`
- Version/logger tests: 2 passed / 78 steps
- npm package metadata tests: 11 passed / 25 steps
- `deno task build:npm`
- `VERSION=0.1.1167 GITHUB_SHA=$(git rev-parse HEAD) scripts/ci/publish-npm-packages.sh preflight`
- `git diff --check`

The local pre-push unit suite was run twice. Both runs passed 2,708 tests and hit the same unrelated parallel timing assertion in `cli/mcp/tools/deploy-tool.test.ts` (14/20 reads, then 19/20 reads). That test passes alone (1 test / 27 steps). The branch was pushed with the local hook bypassed after recording this evidence; GitHub CI remains the independent merge gate.