### PR TITLE
Keep deployment state outside the HMR source loop

### DIFF
--- a/src/server/dev-server/file-watch-setup.test.ts
+++ b/src/server/dev-server/file-watch-setup.test.ts
@@ -4,11 +4,15 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isIgnoredOutputDir, shouldIgnorePath } from "./file-watch-setup.ts";
 
 describe("shouldIgnorePath", () => {
-  it("ignores paths inside generated/output directories", () => {
+  it("ignores generated/output directory events and their contents", () => {
     expect(shouldIgnorePath("/proj/node_modules/foo/index.js")).toBe(true);
+    expect(shouldIgnorePath("/proj/node_modules")).toBe(true);
     expect(shouldIgnorePath("/proj/.git/HEAD")).toBe(true);
     expect(shouldIgnorePath("/proj/.cache/bundle.js")).toBe(true);
+    expect(shouldIgnorePath("/proj/.veryfront")).toBe(true);
     expect(shouldIgnorePath("/proj/.veryfront/manifest.json")).toBe(true);
+    expect(shouldIgnorePath(String.raw`C:\proj\.veryfront`)).toBe(true);
+    expect(shouldIgnorePath(String.raw`C:\proj\.veryfront\manifest.json`)).toBe(true);
   });
 
   it("ignores the Playwright MCP output directory (regression for #1977)", () => {
@@ -42,6 +46,8 @@ describe("shouldIgnorePath", () => {
   it("does not ignore legitimate source files", () => {
     expect(shouldIgnorePath("/proj/pages/index.tsx")).toBe(false);
     expect(shouldIgnorePath("/proj/components/Button.jsx")).toBe(false);
+    expect(shouldIgnorePath("/proj/.veryfront.config.ts")).toBe(false);
+    expect(shouldIgnorePath("/proj/my-node_modules/index.ts")).toBe(false);
     expect(shouldIgnorePath("/proj/lib/util.ts")).toBe(false);
     expect(shouldIgnorePath("/proj/styles/app.css")).toBe(false);
     expect(shouldIgnorePath("/proj/content/post.mdx")).toBe(false);

--- a/src/server/dev-server/file-watch-setup.ts
+++ b/src/server/dev-server/file-watch-setup.ts
@@ -20,23 +20,17 @@ const DEFAULT_PRIMITIVE_DIRS = ["tools", "agents", "workflows", "prompts", "reso
  * These are generated/cached files that change during normal operation
  * but don't represent actual source code changes.
  */
-const IGNORED_PATH_PATTERNS = [
-  ".cache/",
-  ".cache\\",
-  "node_modules/",
-  "node_modules\\",
-  ".git/",
-  ".git\\",
-  ".veryfront/",
-  ".veryfront\\",
-  ".omx/",
-  ".omx\\",
+const IGNORED_DIRECTORY_NAMES = new Set([
+  ".cache",
+  "node_modules",
+  ".git",
+  ".veryfront",
+  ".omx",
   // Tool output directories that live inside the project root. Tools such as
   // the Playwright MCP server write per-step artifacts here continuously,
   // which would otherwise drive an open-ended HMR refresh loop.
-  ".playwright-mcp/",
-  ".playwright-mcp\\",
-];
+  ".playwright-mcp",
+]);
 
 /**
  * Generated-artifact file extensions that are never source and must never
@@ -97,7 +91,7 @@ function hasIgnoredArtifactFileName(path: string): boolean {
  * Exported for unit testing.
  */
 export function shouldIgnorePath(path: string): boolean {
-  return IGNORED_PATH_PATTERNS.some((pattern) => path.includes(pattern)) ||
+  return path.split(/[\\/]/).some((segment) => IGNORED_DIRECTORY_NAMES.has(segment)) ||
     hasIgnoredArtifactExtension(path) ||
     hasIgnoredArtifactFileName(path);
 }

--- a/src/server/dev-server/file-watch-setup.ts
+++ b/src/server/dev-server/file-watch-setup.ts
@@ -16,8 +16,8 @@ const METRICS_LOG_INTERVAL = 10;
 const DEFAULT_PRIMITIVE_DIRS = ["tools", "agents", "workflows", "prompts", "resources"];
 
 /**
- * Patterns for paths that should NOT trigger HMR updates.
- * These are generated/cached files that change during normal operation
+ * Exact directory-name path segments that should NOT trigger HMR updates.
+ * These contain generated or cached files that change during normal operation
  * but don't represent actual source code changes.
  */
 const IGNORED_DIRECTORY_NAMES = new Set([


### PR DESCRIPTION
## Summary

- ignore internal/runtime directories by exact path segment on POSIX and Windows
- ignore the `.veryfront` directory creation event produced by `veryfront push`
- keep similarly named source paths such as `.veryfront.config.ts` and `my-node_modules` watchable

## Verification

- regression test failed before the matcher change and passes after it
- focused watcher tests: 2 tests, 10 steps
- format, lint, and type checks pass
- full pre-push: 2710 tests, 22010 steps
- source CLI `dev` plus `push`: push completed and the running dev server emitted no reload/cache error