### PR TITLE
Honor standalone production security intent

### DIFF
--- a/src/security/http/config.test.ts
+++ b/src/security/http/config.test.ts
@@ -126,6 +126,22 @@ describe("security/http/config", () => {
     assertEquals(loader.getSecurityConfig()?.csrf, true);
   });
 
+  it("honors standalone production intent when process env is development", async () => {
+    Deno.env.set("NODE_ENV", "development");
+    const loader = new SecurityConfigLoader(
+      "/project",
+      createMockAdapter(),
+      {
+        security: {},
+      },
+      true,
+    );
+
+    await loader.ensureLoaded();
+
+    assertEquals(loader.getSecurityConfig()?.csrf, true);
+  });
+
   it("does not warn that CSRF is unconfigured when production defaults enable it", async () => {
     Deno.env.set("NODE_ENV", "production");
     const { getOutput, restore } = captureConsoleLog();

--- a/src/security/http/config.ts
+++ b/src/security/http/config.ts
@@ -18,6 +18,7 @@ export class SecurityConfigLoader {
     private projectDir: string,
     private adapter: RuntimeAdapter,
     private configOverride?: VeryfrontConfig,
+    private productionRuntime = false,
   ) {}
 
   async ensureLoaded(): Promise<void> {
@@ -45,7 +46,7 @@ export class SecurityConfigLoader {
 
   private applyConfig(cfg?: VeryfrontConfig): void {
     const security: SecurityConfig = cfg?.security ? { ...cfg.security } as SecurityConfig : {};
-    const production = isProduction();
+    const production = this.productionRuntime || isProduction();
 
     if (security.headers) security.headers = { ...security.headers };
 

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -112,6 +112,37 @@ describe("server/runtime-handler/index", () => {
     assertEquals(securityGuidance.length, 0);
   });
 
+  it("keeps explicit security warnings visible for standalone production", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const adapter = new DenoAdapter();
+    const { lines, restore } = captureConsoleOutput();
+    const originalVeryfrontEnv = Deno.env.get("VERYFRONT_ENV");
+    Deno.env.set("VERYFRONT_ENV", "development");
+
+    try {
+      const handler = createVeryfrontHandler(projectDir, adapter, {
+        projectDir,
+        config: {
+          security: { csrf: false },
+        } as any,
+        defaultEnvironment: "production",
+      });
+      await handler.ready;
+      await handler(new Request("http://localhost/healthz"));
+    } finally {
+      restore();
+      if (originalVeryfrontEnv === undefined) Deno.env.delete("VERYFRONT_ENV");
+      else Deno.env.set("VERYFRONT_ENV", originalVeryfrontEnv);
+      HMRHandler.shutdown();
+      await Deno.remove(projectDir, { recursive: true });
+    }
+
+    assertEquals(
+      lines.some((line) => line.includes("Neither CORS nor CSRF protection is configured")),
+      true,
+    );
+  });
+
   it("returns 502 when x-token is missing in proxy mode", async () => {
     const handler = createProxyModeHandler();
 

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -312,7 +312,12 @@ export function createVeryfrontHandler(
     });
   }
 
-  const securityLoader = new SecurityConfigLoader(projectDir, adapter, opts.config);
+  const securityLoader = new SecurityConfigLoader(
+    projectDir,
+    adapter,
+    opts.config,
+    opts.defaultEnvironment === "production",
+  );
 
   // Per-project environment variable cache (fetches from API, caches with 60s TTL)
   const apiBaseUrl = adapter.env.get("VERYFRONT_API_BASE_URL") ?? "https://api.veryfront.com/api";


### PR DESCRIPTION
## Summary

- carry standalone production intent into the security config loader
- default CSRF on for `veryfront serve` even when ambient process env is development
- retain the warning when standalone production explicitly disables both CORS and CSRF

## Verification

- both regression tests failed before the implementation and pass after it
- focused security/runtime-handler tests: 18 steps
- format, lint, and type checks pass
- full pre-push: 2710 tests, 22012 steps

Related: https://github.com/veryfront/veryfront-code/pull/3146#discussion_r3666516214