### PR TITLE
fix(cache): sanitize invalid cache-key characters at the API backend boundary

### DIFF
--- a/src/cache/backend.test.ts
+++ b/src/cache/backend.test.ts
@@ -9,7 +9,7 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module cache/backend.test
  */
 
-import { assertEquals, assertExists, assertRejects } from "#std/assert";
+import { assertEquals, assertExists, assertMatch, assertRejects } from "#std/assert";
 import {
   _resetShimForTests,
   type AttributeValue,
@@ -24,6 +24,10 @@ import {
   createCtx,
 } from "#veryfront/server/handlers/request/internal-agent-run.test-helpers.ts";
 import { runWithVerifiedCacheApiCredential } from "./verified-api-credential-context.ts";
+import { isValidCacheKey } from "./keys.ts";
+
+const API_CACHE_KEY_MAX_LENGTH = 512;
+const API_CACHE_KEY_PATTERN = /^[a-zA-Z0-9_:.\-/]+$/;
 
 type RecordedSpan = {
   name: string;
@@ -555,6 +559,151 @@ Deno.test("ApiCacheBackend uses custom keyPrefix", async () => {
   const cache = new ApiCacheBackend({ keyPrefix: "custom-prefix" });
   assertExists(cache);
   assertEquals(cache.type, "api");
+});
+
+Deno.test("ApiCacheBackend sends malformed keys as valid concrete API keys", async () => {
+  const { ApiCacheBackend } = await importBackend();
+  const globals = globalThis as Record<string, unknown>;
+  const originalAdapter = globals.__vf_multi_project_adapter;
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ url: string; body: Record<string, unknown> | null }> = [];
+
+  globals.__vf_multi_project_adapter = {
+    getCurrentRequestContext: () => ({
+      token: "request-token",
+      projectSlug: "project-slug",
+    }),
+  };
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    requests.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    const response = url.includes("/get-batch")
+      ? { values: {} }
+      : url.includes("/get?")
+      ? { value: null }
+      : {};
+    return Promise.resolve(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+
+  try {
+    const cache = new ApiCacheBackend({
+      apiBaseUrl: "https://api.example.test",
+      keyPrefix: "prefix",
+      circuitBreakerName: "api-cache-malformed-key-test",
+    });
+    const rawKey = "reset/token/secret123?ref=x&access_token=secret value";
+
+    await cache.get(rawKey);
+    await cache.getBatch([rawKey]);
+    await cache.set(rawKey, "value");
+    await cache.setBatch([{ key: rawKey, value: "value" }]);
+    await cache.del(rawKey);
+
+    const [getRequest, getBatchRequest, setRequest, setBatchRequest, delRequest] = requests;
+    assertExists(getRequest);
+    assertExists(getBatchRequest);
+    assertExists(setRequest);
+    assertExists(setBatchRequest);
+    assertExists(delRequest);
+    const getBatchKeys = getBatchRequest.body?.keys as string[];
+    const setBatchEntries = setBatchRequest.body?.entries as Array<{ key: string }>;
+    assertExists(getBatchKeys[0]);
+    assertExists(setBatchEntries[0]);
+    const outboundKeys = [
+      new URL(getRequest.url).searchParams.get("key"),
+      getBatchKeys[0],
+      setRequest.body?.key,
+      setBatchEntries[0].key,
+      delRequest.body?.key,
+    ];
+    assertEquals(outboundKeys.length, 5);
+    for (const key of outboundKeys) {
+      assertEquals(typeof key, "string");
+      assertEquals(isValidCacheKey(key as string), true);
+      assertMatch(key as string, API_CACHE_KEY_PATTERN);
+      assertEquals((key as string).length <= API_CACHE_KEY_MAX_LENGTH, true);
+      assertEquals((key as string).includes("access_token"), false);
+      assertEquals((key as string).includes("secret123"), false);
+      assertEquals((key as string).startsWith("prefix:vf-sanitized:"), true);
+    }
+    assertEquals(new Set(outboundKeys).size, 1);
+  } finally {
+    if (originalAdapter === undefined) {
+      delete globals.__vf_multi_project_adapter;
+    } else {
+      globals.__vf_multi_project_adapter = originalAdapter;
+    }
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("ApiCacheBackend bounds long keys and refuses malformed delete patterns", async () => {
+  const { ApiCacheBackend } = await importBackend();
+  const globals = globalThis as Record<string, unknown>;
+  const originalAdapter = globals.__vf_multi_project_adapter;
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ url: string; body: Record<string, unknown> | null }> = [];
+
+  globals.__vf_multi_project_adapter = {
+    getCurrentRequestContext: () => ({
+      token: "request-token",
+      projectSlug: "project-slug",
+    }),
+  };
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    requests.push({
+      url: String(input),
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    return Promise.resolve(
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+
+  try {
+    const cache = new ApiCacheBackend({
+      apiBaseUrl: "https://api.example.test",
+      keyPrefix: "prefix",
+      circuitBreakerName: "api-cache-long-key-test",
+    });
+
+    const overlongKey = `secret-path-token-${"a".repeat(API_CACHE_KEY_MAX_LENGTH)}`;
+    await cache.set(overlongKey, "value");
+    assertEquals(requests.length, 1);
+    const setRequest = requests[0];
+    assertExists(setRequest);
+    const outboundKey = setRequest.body?.key as string;
+    assertEquals(isValidCacheKey(outboundKey), true);
+    assertMatch(outboundKey, API_CACHE_KEY_PATTERN);
+    assertEquals(outboundKey.length <= API_CACHE_KEY_MAX_LENGTH, true);
+    assertEquals(outboundKey.includes("secret-path-token"), false);
+
+    const deleted = await cache.delByPattern("render:bad pattern:*");
+    assertEquals(deleted, 0);
+    assertEquals(requests.length, 1);
+
+    const overlongPattern = `render:${"*".repeat(API_CACHE_KEY_MAX_LENGTH)}`;
+    assertEquals(await cache.delByPattern(overlongPattern), 0);
+    assertEquals(requests.length, 1);
+  } finally {
+    if (originalAdapter === undefined) {
+      delete globals.__vf_multi_project_adapter;
+    } else {
+      globals.__vf_multi_project_adapter = originalAdapter;
+    }
+    globalThis.fetch = originalFetch;
+  }
 });
 
 Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from span URLs", async () => {

--- a/src/cache/backend.test.ts
+++ b/src/cache/backend.test.ts
@@ -24,7 +24,7 @@ import {
   createCtx,
 } from "#veryfront/server/handlers/request/internal-agent-run.test-helpers.ts";
 import { runWithVerifiedCacheApiCredential } from "./verified-api-credential-context.ts";
-import { isValidCacheKey } from "./keys.ts";
+import { buildQueryAwareCacheKey, isValidCacheKey } from "./keys.ts";
 
 const API_CACHE_KEY_MAX_LENGTH = 512;
 const API_CACHE_KEY_PATTERN = /^[a-zA-Z0-9_:.\-/]+$/;
@@ -561,18 +561,23 @@ Deno.test("ApiCacheBackend uses custom keyPrefix", async () => {
   assertEquals(cache.type, "api");
 });
 
-Deno.test("ApiCacheBackend sends malformed keys as valid concrete API keys", async () => {
+Deno.test("ApiCacheBackend safely maps query-aware keys without logging key-derived data", async () => {
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
   const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
   const requests: Array<{ url: string; body: Record<string, unknown> | null }> = [];
+  const warnings: string[] = [];
 
   globals.__vf_multi_project_adapter = {
     getCurrentRequestContext: () => ({
       token: "request-token",
       projectSlug: "project-slug",
     }),
+  };
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
   };
   globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -599,7 +604,14 @@ Deno.test("ApiCacheBackend sends malformed keys as valid concrete API keys", asy
       keyPrefix: "prefix",
       circuitBreakerName: "api-cache-malformed-key-test",
     });
-    const rawKey = "reset/token/secret123?ref=x&access_token=secret value";
+    const rawKey = buildQueryAwareCacheKey(
+      "/reset/token/secret123",
+      new URL(
+        "https://example.test/reset/token/secret123?access_token=secret%20value",
+      ),
+      { policy: "include-all" },
+    );
+    assertEquals(rawKey.includes("*"), true);
 
     await cache.get(rawKey);
     await cache.getBatch([rawKey]);
@@ -635,6 +647,11 @@ Deno.test("ApiCacheBackend sends malformed keys as valid concrete API keys", asy
       assertEquals((key as string).startsWith("prefix:vf-sanitized:"), true);
     }
     assertEquals(new Set(outboundKeys).size, 1);
+    const warningOutput = warnings.join("\n");
+    assertEquals(warningOutput.includes("originalLength"), true);
+    assertEquals(warningOutput.includes("keyHash"), false);
+    assertEquals(warningOutput.includes("access_token"), false);
+    assertEquals(warningOutput.includes("secret123"), false);
   } finally {
     if (originalAdapter === undefined) {
       delete globals.__vf_multi_project_adapter;
@@ -642,6 +659,7 @@ Deno.test("ApiCacheBackend sends malformed keys as valid concrete API keys", asy
       globals.__vf_multi_project_adapter = originalAdapter;
     }
     globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
   }
 });
 

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -2,7 +2,12 @@ import { logger as baseLogger, sanitizeUrlForSpan } from "#veryfront/utils";
 import { SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { tryGetCacheKeyContext } from "../cache-key-builder.ts";
-import { isValidCacheKey, sanitizeCacheKey } from "../keys/index.ts";
+import {
+  digestCacheKey,
+  isValidCacheKey,
+  isValidCachePattern,
+  sanitizeCacheKey,
+} from "../keys/index.ts";
 import { CircuitBreakerOpen, getCircuitBreaker } from "#veryfront/utils/circuit-breaker.ts";
 import type { CacheBackend } from "../types.ts";
 import { getEnvValue } from "./helpers.ts";
@@ -100,10 +105,11 @@ export class ApiCacheBackend implements CacheBackend {
     // invalid characters`, and on the control-plane /execute path that 400
     // loops until the request is flagged stuck (issues #162 / #175). Sanitize
     // so the request succeeds, and warn so the upstream generation bug stays
-    // visible rather than being silently masked.
+    // visible rather than being silently masked. Log a hash, not the key: a
+    // leaked raw URL can carry credentials (`?access_token=...`).
     const sanitized = sanitizeCacheKey(prefixed);
     logger.warn("Cache key contained invalid characters; sanitized before request", {
-      sanitizedKey: sanitized.slice(0, 200),
+      keyHash: digestCacheKey(prefixed),
       originalLength: prefixed.length,
     });
     return sanitized;
@@ -280,8 +286,26 @@ export class ApiCacheBackend implements CacheBackend {
   }
 
   async delByPattern(pattern: string): Promise<number> {
+    const prefixed = this.keyPrefix ? `${this.keyPrefix}:${pattern}` : pattern;
+
+    // A pattern is a glob: `*` is a wildcard, not a literal. We must NOT escape
+    // invalid characters here — the `*HH` escape would inject wildcards into the
+    // glob and over-delete. Fail closed instead: refuse a malformed pattern
+    // (leaving the entries to expire on TTL) rather than risk deleting keys the
+    // caller never targeted.
+    if (!isValidCachePattern(prefixed)) {
+      logger.warn(
+        "Refusing del-pattern with invalid characters (would inject glob wildcards); skipping",
+        {
+          patternHash: digestCacheKey(prefixed),
+          originalLength: prefixed.length,
+        },
+      );
+      return 0;
+    }
+
     const result = await this.request<{ deleted: number }>("POST", "/del-pattern", {
-      pattern: this.prefixKey(pattern),
+      pattern: prefixed,
     }, { failOnError: true });
     return result?.deleted ?? 0;
   }

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -2,12 +2,7 @@ import { logger as baseLogger, sanitizeUrlForSpan } from "#veryfront/utils";
 import { SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { tryGetCacheKeyContext } from "../cache-key-builder.ts";
-import {
-  digestCacheKey,
-  isValidCacheKey,
-  isValidCachePattern,
-  sanitizeCacheKey,
-} from "../keys/index.ts";
+import { digestCacheKey, isValidCachePattern, sanitizeCacheKey } from "../keys/index.ts";
 import { CircuitBreakerOpen, getCircuitBreaker } from "#veryfront/utils/circuit-breaker.ts";
 import type { CacheBackend } from "../types.ts";
 import { getEnvValue } from "./helpers.ts";
@@ -96,9 +91,10 @@ export class ApiCacheBackend implements CacheBackend {
     });
   }
 
-  private prefixKey(key: string): string {
+  private async prefixKey(key: string): Promise<string> {
     const prefixed = this.keyPrefix ? `${this.keyPrefix}:${key}` : key;
-    if (isValidCacheKey(prefixed)) return prefixed;
+    const sanitized = await sanitizeCacheKey(prefixed, this.keyPrefix);
+    if (sanitized === prefixed) return prefixed;
 
     // Defence in depth: a key that leaked raw URL/query/undefined tokens would
     // otherwise be rejected by the API with `HTTP 400: Cache key contains
@@ -107,8 +103,7 @@ export class ApiCacheBackend implements CacheBackend {
     // so the request succeeds, and warn so the upstream generation bug stays
     // visible rather than being silently masked. Log a hash, not the key: a
     // leaked raw URL can carry credentials (`?access_token=...`).
-    const sanitized = sanitizeCacheKey(prefixed);
-    logger.warn("Cache key contained invalid characters; sanitized before request", {
+    logger.warn("Cache key was not API-safe; sanitized before request", {
       keyHash: digestCacheKey(prefixed),
       originalLength: prefixed.length,
     });
@@ -226,9 +221,10 @@ export class ApiCacheBackend implements CacheBackend {
   }
 
   async get(key: string): Promise<string | null> {
+    const prefixedKey = await this.prefixKey(key);
     const result = await this.request<{ value: string | null }>(
       "GET",
-      `/get?key=${encodeURIComponent(this.prefixKey(key))}`,
+      `/get?key=${encodeURIComponent(prefixedKey)}`,
     );
     return result?.value ?? null;
   }
@@ -236,7 +232,9 @@ export class ApiCacheBackend implements CacheBackend {
   async getBatch(keys: string[]): Promise<Map<string, string | null>> {
     if (keys.length === 0) return new Map<string, string | null>();
 
-    const prefixedByKey = new Map(keys.map((k) => [k, this.prefixKey(k)] as const));
+    const prefixedByKey = new Map(
+      await Promise.all(keys.map(async (key) => [key, await this.prefixKey(key)] as const)),
+    );
     const response = await this.request<{ values: Record<string, string | null> }>(
       "POST",
       "/get-batch",
@@ -263,7 +261,7 @@ export class ApiCacheBackend implements CacheBackend {
 
   async set(key: string, value: string, ttlSeconds = 300): Promise<void> {
     await this.request("POST", "/set", {
-      key: this.prefixKey(key),
+      key: await this.prefixKey(key),
       value,
       ttl: ttlSeconds,
     });
@@ -272,35 +270,38 @@ export class ApiCacheBackend implements CacheBackend {
   async setBatch(entries: Array<{ key: string; value: string; ttl?: number }>): Promise<void> {
     if (entries.length === 0) return;
 
-    const prefixedEntries = entries.map(({ key, value, ttl }) => ({
-      key: this.prefixKey(key),
-      value,
-      ttl,
-    }));
+    const prefixedEntries = await Promise.all(
+      entries.map(async ({ key, value, ttl }) => ({
+        key: await this.prefixKey(key),
+        value,
+        ttl,
+      })),
+    );
 
     await this.request("POST", "/set-batch", { entries: prefixedEntries });
   }
 
   async del(key: string): Promise<void> {
-    await this.request("POST", "/del", { key: this.prefixKey(key) }, { failOnError: true });
+    await this.request(
+      "POST",
+      "/del",
+      { key: await this.prefixKey(key) },
+      { failOnError: true },
+    );
   }
 
   async delByPattern(pattern: string): Promise<number> {
     const prefixed = this.keyPrefix ? `${this.keyPrefix}:${pattern}` : pattern;
 
     // A pattern is a glob: `*` is a wildcard, not a literal. We must NOT escape
-    // invalid characters here — the `*HH` escape would inject wildcards into the
-    // glob and over-delete. Fail closed instead: refuse a malformed pattern
-    // (leaving the entries to expire on TTL) rather than risk deleting keys the
-    // caller never targeted.
+    // invalid characters here because rewriting a glob could broaden its
+    // deletion scope. Fail closed instead: refuse a malformed pattern (leaving
+    // the entries to expire on TTL) rather than risk deleting unrelated keys.
     if (!isValidCachePattern(prefixed)) {
-      logger.warn(
-        "Refusing del-pattern with invalid characters (would inject glob wildcards); skipping",
-        {
-          patternHash: digestCacheKey(prefixed),
-          originalLength: prefixed.length,
-        },
-      );
+      logger.warn("Refusing unsafe del-pattern; skipping", {
+        patternHash: digestCacheKey(prefixed),
+        originalLength: prefixed.length,
+      });
       return 0;
     }
 

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -2,7 +2,7 @@ import { logger as baseLogger, sanitizeUrlForSpan } from "#veryfront/utils";
 import { SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { tryGetCacheKeyContext } from "../cache-key-builder.ts";
-import { digestCacheKey, isValidCachePattern, sanitizeCacheKey } from "../keys/index.ts";
+import { isValidCachePattern, sanitizeCacheKey } from "../keys/index.ts";
 import { CircuitBreakerOpen, getCircuitBreaker } from "#veryfront/utils/circuit-breaker.ts";
 import type { CacheBackend } from "../types.ts";
 import { getEnvValue } from "./helpers.ts";
@@ -101,10 +101,9 @@ export class ApiCacheBackend implements CacheBackend {
     // invalid characters`, and on the control-plane /execute path that 400
     // loops until the request is flagged stuck (issues #162 / #175). Sanitize
     // so the request succeeds, and warn so the upstream generation bug stays
-    // visible rather than being silently masked. Log a hash, not the key: a
-    // leaked raw URL can carry credentials (`?access_token=...`).
+    // visible rather than being silently masked. Do not log any key-derived
+    // value because a leaked raw URL can carry credentials.
     logger.warn("Cache key was not API-safe; sanitized before request", {
-      keyHash: digestCacheKey(prefixed),
       originalLength: prefixed.length,
     });
     return sanitized;
@@ -299,7 +298,6 @@ export class ApiCacheBackend implements CacheBackend {
     // the entries to expire on TTL) rather than risk deleting unrelated keys.
     if (!isValidCachePattern(prefixed)) {
       logger.warn("Refusing unsafe del-pattern; skipping", {
-        patternHash: digestCacheKey(prefixed),
         originalLength: prefixed.length,
       });
       return 0;

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -2,6 +2,7 @@ import { logger as baseLogger, sanitizeUrlForSpan } from "#veryfront/utils";
 import { SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { tryGetCacheKeyContext } from "../cache-key-builder.ts";
+import { isValidCacheKey, sanitizeCacheKey } from "../keys/index.ts";
 import { CircuitBreakerOpen, getCircuitBreaker } from "#veryfront/utils/circuit-breaker.ts";
 import type { CacheBackend } from "../types.ts";
 import { getEnvValue } from "./helpers.ts";
@@ -91,7 +92,21 @@ export class ApiCacheBackend implements CacheBackend {
   }
 
   private prefixKey(key: string): string {
-    return this.keyPrefix ? `${this.keyPrefix}:${key}` : key;
+    const prefixed = this.keyPrefix ? `${this.keyPrefix}:${key}` : key;
+    if (isValidCacheKey(prefixed)) return prefixed;
+
+    // Defence in depth: a key that leaked raw URL/query/undefined tokens would
+    // otherwise be rejected by the API with `HTTP 400: Cache key contains
+    // invalid characters`, and on the control-plane /execute path that 400
+    // loops until the request is flagged stuck (issues #162 / #175). Sanitize
+    // so the request succeeds, and warn so the upstream generation bug stays
+    // visible rather than being silently masked.
+    const sanitized = sanitizeCacheKey(prefixed);
+    logger.warn("Cache key contained invalid characters; sanitized before request", {
+      sanitizedKey: sanitized.slice(0, 200),
+      originalLength: prefixed.length,
+    });
+    return sanitized;
   }
 
   private async request<T>(

--- a/src/cache/keys.test.ts
+++ b/src/cache/keys.test.ts
@@ -12,7 +12,6 @@ import {
   buildQueryAwareCacheKey,
   buildRenderCacheKey,
   buildRenderCachePrefix,
-  CACHE_PATTERN_ALLOWED_PATTERN,
   CacheKeyPrefix,
   computeContentSourceId,
   DEFAULT_EXCLUDED_QUERY_PARAMS,
@@ -29,6 +28,9 @@ import {
   getReadyManifestForRender,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
+
+const API_CACHE_KEY_MAX_LENGTH = 512;
+const API_CACHE_KEY_PATTERN = /^[a-zA-Z0-9_:.\-/]+$/;
 
 describe("cache/keys", () => {
   describe("CacheKeyPrefix", () => {
@@ -516,15 +518,20 @@ describe("cache/keys", () => {
       assertEquals(isValidCacheKey(""), false);
     });
 
+    it("rejects keys and patterns longer than the API limit", () => {
+      assertEquals(isValidCacheKey("a".repeat(API_CACHE_KEY_MAX_LENGTH + 1)), false);
+      assertEquals(isValidCachePattern(`prefix:${"*".repeat(API_CACHE_KEY_MAX_LENGTH)}`), false);
+    });
+
     it("flags keys containing characters outside the allowed set", () => {
       assertEquals(isValidCacheKey("render:proj:/blog?ref=x&y=1"), false);
       assertEquals(isValidCacheKey("render:proj: has space"), false);
       assertEquals(isValidCacheKey("render:café"), false);
     });
 
-    it("returns well-formed keys unchanged (no cache churn)", () => {
+    it("returns well-formed keys unchanged (no cache churn)", async () => {
       const key = "veryfront:ssr-module:proj_123:production:rel-abc:components/Button.tsx";
-      assertEquals(sanitizeCacheKey(key), key);
+      assertEquals(await sanitizeCacheKey(key), key);
     });
 
     it("treats `*` as a wildcard for patterns but not as a valid key character", () => {
@@ -545,35 +552,43 @@ describe("cache/keys", () => {
       assertEquals(isValidCachePattern("render:proj bad:*"), false);
     });
 
-    it("escapes a literal `*` in a key so the encoding stays collision-free", () => {
-      // `*` is the escape marker, so a literal `*` is itself escaped (`*2A`).
-      const sanitized = sanitizeCacheKey("render:proj:a*b");
-      assertMatch(sanitized, CACHE_PATTERN_ALLOWED_PATTERN);
-      assertEquals(sanitized, "render:proj:a*2Ab");
+    it("maps a literal `*` to a valid concrete API key", async () => {
+      const sanitized = await sanitizeCacheKey("render:proj:a*b");
+      assertEquals(isValidCacheKey(sanitized), true);
+      assertMatch(sanitized, API_CACHE_KEY_PATTERN);
+      assertEquals(sanitized.includes("render:proj:a"), false);
     });
 
-    it("does not collide a literal `*HH`-looking key with an escaped character", () => {
-      // "a b" (space) and "a*20b" (literal star) must not map to the same key.
-      assertNotEquals(sanitizeCacheKey("a b"), sanitizeCacheKey("a*20b"));
+    it("does not collide a malformed key with a marker-looking valid key", async () => {
+      assertNotEquals(await sanitizeCacheKey("a b"), await sanitizeCacheKey("a*20b"));
     });
 
-    it("escapes query-string characters that leak into a key", () => {
-      // ? = & are the classic offenders from a raw request URL.
-      const sanitized = sanitizeCacheKey("render:proj:/blog?ref=x&y=1");
-      assertMatch(sanitized, CACHE_PATTERN_ALLOWED_PATTERN);
-      assertEquals(sanitized, "render:proj:/blog*3Fref*3Dx*26y*3D1");
+    it("maps leaked query-string characters to a valid concrete API key", async () => {
+      const sanitized = await sanitizeCacheKey("render:proj:/blog?ref=x&y=1");
+      assertEquals(isValidCacheKey(sanitized), true);
+      assertMatch(sanitized, API_CACHE_KEY_PATTERN);
+      assertEquals(sanitized.includes("render:proj:/blog"), false);
     });
 
-    it("escapes whitespace and non-ASCII characters", () => {
-      const sanitized = sanitizeCacheKey("render:café page");
-      assertMatch(sanitized, CACHE_PATTERN_ALLOWED_PATTERN);
-      // é is two UTF-8 bytes, space is one.
-      assertEquals(sanitized, "render:caf*C3*A9*20page");
+    it("does not retain secret-bearing path prefixes from malformed URLs", async () => {
+      const sanitized = await sanitizeCacheKey(
+        "https://example.com/reset/token/secret123?next=/account",
+      );
+      assertEquals(sanitized.includes("secret123"), false);
+      assertEquals(isValidCacheKey(sanitized), true);
     });
 
-    it("is always valid after sanitizing arbitrary input", () => {
+    it("maps whitespace and non-ASCII characters to a valid concrete API key", async () => {
+      const sanitized = await sanitizeCacheKey("render:café page");
+      assertEquals(isValidCacheKey(sanitized), true);
+      assertMatch(sanitized, API_CACHE_KEY_PATTERN);
+      assertEquals(sanitized.includes("render:caf"), false);
+    });
+
+    it("always returns a valid, length-bounded concrete key", async () => {
       for (
         const input of [
+          "",
           "a?b=c",
           "spaces here",
           "emoji-🚀-key",
@@ -581,15 +596,24 @@ describe("cache/keys", () => {
           "percent%20already",
           "back\\slash",
           'quote"key',
+          "a".repeat(API_CACHE_KEY_MAX_LENGTH + 1),
         ]
       ) {
-        assertMatch(sanitizeCacheKey(input), CACHE_PATTERN_ALLOWED_PATTERN);
+        const sanitized = await sanitizeCacheKey(input);
+        assertEquals(isValidCacheKey(sanitized), true);
+        assertMatch(sanitized, API_CACHE_KEY_PATTERN);
+        assertEquals(sanitized.length <= API_CACHE_KEY_MAX_LENGTH, true);
       }
     });
 
-    it("is deterministic so a get derives the same key as its set", () => {
+    it("keeps the reserved fallback namespace distinct from raw valid keys", async () => {
+      const sanitized = await sanitizeCacheKey("a b");
+      assertNotEquals(await sanitizeCacheKey(sanitized), sanitized);
+    });
+
+    it("is deterministic so a get derives the same key as its set", async () => {
       const raw = "render:proj:/blog?ref=x";
-      assertEquals(sanitizeCacheKey(raw), sanitizeCacheKey(raw));
+      assertEquals(await sanitizeCacheKey(raw), await sanitizeCacheKey(raw));
     });
   });
 });

--- a/src/cache/keys.test.ts
+++ b/src/cache/keys.test.ts
@@ -12,12 +12,13 @@ import {
   buildQueryAwareCacheKey,
   buildRenderCacheKey,
   buildRenderCachePrefix,
-  CACHE_KEY_ALLOWED_PATTERN,
+  CACHE_PATTERN_ALLOWED_PATTERN,
   CacheKeyPrefix,
   computeContentSourceId,
   DEFAULT_EXCLUDED_QUERY_PARAMS,
   filterQueryParams,
   isValidCacheKey,
+  isValidCachePattern,
   parseRenderCacheKey,
   sanitizeCacheKey,
   sanitizeQueryParamsForCacheKey,
@@ -526,22 +527,46 @@ describe("cache/keys", () => {
       assertEquals(sanitizeCacheKey(key), key);
     });
 
-    it("preserves the glob wildcard and separators used by del-pattern", () => {
+    it("treats `*` as a wildcard for patterns but not as a valid key character", () => {
       const pattern = "render:proj_123:production:rel-abc:*";
-      assertEquals(sanitizeCacheKey(pattern), pattern);
-      assertEquals(isValidCacheKey(pattern), true);
+      // `*` is only valid in a del-pattern, never in a concrete key.
+      assertEquals(isValidCachePattern(pattern), true);
+      assertEquals(isValidCacheKey(pattern), false);
+    });
+
+    it("leaves a clean del-pattern (prefix + wildcard) unchanged", () => {
+      const pattern = "render:proj_123:production:rel-abc:*";
+      assertEquals(isValidCachePattern(pattern), true);
+    });
+
+    it("flags a del-pattern whose literal segment has invalid characters", () => {
+      // A space in the literal prefix — escaping this would inject `*` wildcards
+      // into the glob, so the backend must refuse it rather than sanitize.
+      assertEquals(isValidCachePattern("render:proj bad:*"), false);
+    });
+
+    it("escapes a literal `*` in a key so the encoding stays collision-free", () => {
+      // `*` is the escape marker, so a literal `*` is itself escaped (`*2A`).
+      const sanitized = sanitizeCacheKey("render:proj:a*b");
+      assertMatch(sanitized, CACHE_PATTERN_ALLOWED_PATTERN);
+      assertEquals(sanitized, "render:proj:a*2Ab");
+    });
+
+    it("does not collide a literal `*HH`-looking key with an escaped character", () => {
+      // "a b" (space) and "a*20b" (literal star) must not map to the same key.
+      assertNotEquals(sanitizeCacheKey("a b"), sanitizeCacheKey("a*20b"));
     });
 
     it("escapes query-string characters that leak into a key", () => {
       // ? = & are the classic offenders from a raw request URL.
       const sanitized = sanitizeCacheKey("render:proj:/blog?ref=x&y=1");
-      assertMatch(sanitized, CACHE_KEY_ALLOWED_PATTERN);
+      assertMatch(sanitized, CACHE_PATTERN_ALLOWED_PATTERN);
       assertEquals(sanitized, "render:proj:/blog*3Fref*3Dx*26y*3D1");
     });
 
     it("escapes whitespace and non-ASCII characters", () => {
       const sanitized = sanitizeCacheKey("render:café page");
-      assertMatch(sanitized, CACHE_KEY_ALLOWED_PATTERN);
+      assertMatch(sanitized, CACHE_PATTERN_ALLOWED_PATTERN);
       // é is two UTF-8 bytes, space is one.
       assertEquals(sanitized, "render:caf*C3*A9*20page");
     });
@@ -558,7 +583,7 @@ describe("cache/keys", () => {
           'quote"key',
         ]
       ) {
-        assertMatch(sanitizeCacheKey(input), CACHE_KEY_ALLOWED_PATTERN);
+        assertMatch(sanitizeCacheKey(input), CACHE_PATTERN_ALLOWED_PATTERN);
       }
     });
 

--- a/src/cache/keys.test.ts
+++ b/src/cache/keys.test.ts
@@ -12,11 +12,14 @@ import {
   buildQueryAwareCacheKey,
   buildRenderCacheKey,
   buildRenderCachePrefix,
+  CACHE_KEY_ALLOWED_PATTERN,
   CacheKeyPrefix,
   computeContentSourceId,
   DEFAULT_EXCLUDED_QUERY_PARAMS,
   filterQueryParams,
+  isValidCacheKey,
   parseRenderCacheKey,
+  sanitizeCacheKey,
   sanitizeQueryParamsForCacheKey,
 } from "./keys.ts";
 import {
@@ -499,6 +502,69 @@ describe("cache/keys", () => {
     it("should include HubSpot tracking params", () => {
       assertEquals(DEFAULT_EXCLUDED_QUERY_PARAMS.includes("_hsenc"), true);
       assertEquals(DEFAULT_EXCLUDED_QUERY_PARAMS.includes("_hsmi"), true);
+    });
+  });
+
+  describe("sanitizeCacheKey / isValidCacheKey", () => {
+    it("recognises a well-formed structural key as valid", () => {
+      const key = "veryfront:ssr-module:proj_123:production:rel-abc:components/Button.tsx";
+      assertEquals(isValidCacheKey(key), true);
+    });
+
+    it("treats the empty string as invalid", () => {
+      assertEquals(isValidCacheKey(""), false);
+    });
+
+    it("flags keys containing characters outside the allowed set", () => {
+      assertEquals(isValidCacheKey("render:proj:/blog?ref=x&y=1"), false);
+      assertEquals(isValidCacheKey("render:proj: has space"), false);
+      assertEquals(isValidCacheKey("render:café"), false);
+    });
+
+    it("returns well-formed keys unchanged (no cache churn)", () => {
+      const key = "veryfront:ssr-module:proj_123:production:rel-abc:components/Button.tsx";
+      assertEquals(sanitizeCacheKey(key), key);
+    });
+
+    it("preserves the glob wildcard and separators used by del-pattern", () => {
+      const pattern = "render:proj_123:production:rel-abc:*";
+      assertEquals(sanitizeCacheKey(pattern), pattern);
+      assertEquals(isValidCacheKey(pattern), true);
+    });
+
+    it("escapes query-string characters that leak into a key", () => {
+      // ? = & are the classic offenders from a raw request URL.
+      const sanitized = sanitizeCacheKey("render:proj:/blog?ref=x&y=1");
+      assertMatch(sanitized, CACHE_KEY_ALLOWED_PATTERN);
+      assertEquals(sanitized, "render:proj:/blog*3Fref*3Dx*26y*3D1");
+    });
+
+    it("escapes whitespace and non-ASCII characters", () => {
+      const sanitized = sanitizeCacheKey("render:café page");
+      assertMatch(sanitized, CACHE_KEY_ALLOWED_PATTERN);
+      // é is two UTF-8 bytes, space is one.
+      assertEquals(sanitized, "render:caf*C3*A9*20page");
+    });
+
+    it("is always valid after sanitizing arbitrary input", () => {
+      for (
+        const input of [
+          "a?b=c",
+          "spaces here",
+          "emoji-🚀-key",
+          "tab\tchar",
+          "percent%20already",
+          "back\\slash",
+          'quote"key',
+        ]
+      ) {
+        assertMatch(sanitizeCacheKey(input), CACHE_KEY_ALLOWED_PATTERN);
+      }
+    });
+
+    it("is deterministic so a get derives the same key as its set", () => {
+      const raw = "render:proj:/blog?ref=x";
+      assertEquals(sanitizeCacheKey(raw), sanitizeCacheKey(raw));
     });
   });
 });

--- a/src/cache/keys.test.ts
+++ b/src/cache/keys.test.ts
@@ -547,8 +547,8 @@ describe("cache/keys", () => {
     });
 
     it("flags a del-pattern whose literal segment has invalid characters", () => {
-      // A space in the literal prefix — escaping this would inject `*` wildcards
-      // into the glob, so the backend must refuse it rather than sanitize.
+      // Escaping a space in the literal prefix would inject `*` wildcards into
+      // the glob, so the backend must refuse it rather than sanitize.
       assertEquals(isValidCachePattern("render:proj bad:*"), false);
     });
 

--- a/src/cache/keys/builders/render.ts
+++ b/src/cache/keys/builders/render.ts
@@ -120,7 +120,9 @@ export function buildProxyManagerCacheKey(
 }
 
 /**
- * Build a query-aware cache key that is safe for multi-tenant caching.
+ * Build a query-aware key that preserves query semantics for multi-tenant
+ * caching. The result can contain internal `*HH` byte escapes; ApiCacheBackend
+ * maps completed concrete keys to the API cache schema at its boundary.
  *
  * @param slug - Base page slug
  * @param url - Optional URL with query params

--- a/src/cache/keys/index.ts
+++ b/src/cache/keys/index.ts
@@ -36,14 +36,17 @@ export {
 // Utilities: parsing, filtering, normalization
 export {
   CACHE_KEY_ALLOWED_PATTERN,
+  CACHE_PATTERN_ALLOWED_PATTERN,
   createCacheKeyFilter,
   deleteAllKeysForProject,
   deleteAllKeysForProjectAsync,
+  digestCacheKey,
   filterQueryParams,
   getAllKeysForProject,
   getAllKeysForProjectAsync,
   getCacheKeyVersion,
   isValidCacheKey,
+  isValidCachePattern,
   normalizeFilePath,
   parseRenderCacheKey,
   sanitizeCacheKey,

--- a/src/cache/keys/index.ts
+++ b/src/cache/keys/index.ts
@@ -40,7 +40,6 @@ export {
   createCacheKeyFilter,
   deleteAllKeysForProject,
   deleteAllKeysForProjectAsync,
-  digestCacheKey,
   filterQueryParams,
   getAllKeysForProject,
   getAllKeysForProjectAsync,

--- a/src/cache/keys/index.ts
+++ b/src/cache/keys/index.ts
@@ -35,6 +35,7 @@ export {
 
 // Utilities: parsing, filtering, normalization
 export {
+  CACHE_KEY_ALLOWED_PATTERN,
   createCacheKeyFilter,
   deleteAllKeysForProject,
   deleteAllKeysForProjectAsync,
@@ -42,8 +43,10 @@ export {
   getAllKeysForProject,
   getAllKeysForProjectAsync,
   getCacheKeyVersion,
+  isValidCacheKey,
   normalizeFilePath,
   parseRenderCacheKey,
+  sanitizeCacheKey,
   sanitizeQueryParamsForCacheKey,
 } from "./utils.ts";
 

--- a/src/cache/keys/utils.ts
+++ b/src/cache/keys/utils.ts
@@ -148,14 +148,15 @@ function normalizeQueryParamName(param: string): string {
 }
 
 /**
- * Sanitize query params for use in cache keys.
- * Converts query params to a format safe for API cache key validation.
+ * Encode query params for use in internal cache-key construction.
  *
- * API cache key validation only allows: a-z A-Z 0-9 _ : . * - /
+ * This encoding uses `*HH` byte escapes to avoid collisions between query
+ * values. A key containing these escapes is not a valid concrete API cache key;
+ * ApiCacheBackend maps the completed key to the API schema at its boundary.
  *
  * @param url - URL or URLSearchParams to extract query params from
  * @param options - Query param handling options
- * @returns Sanitized query string safe for cache keys, or empty string
+ * @returns Encoded query string for cache-key construction, or an empty string
  */
 export function sanitizeQueryParamsForCacheKey(
   url: URL | URLSearchParams,
@@ -226,7 +227,7 @@ export const CACHE_PATTERN_ALLOWED_PATTERN = /^[a-zA-Z0-9_:.*/-]+$/;
 
 /**
  * True when a concrete cache key is valid for the API cache backend (non-empty
- * and within the key character set — no `*`).
+ * and within the key character set, with no `*`).
  */
 export function isValidCacheKey(key: string): boolean {
   return key.length > 0 &&
@@ -245,19 +246,10 @@ export function isValidCachePattern(pattern: string): boolean {
 }
 
 /**
- * Non-reversible digest of a key, for logs. Cache keys can inadvertently carry
- * secrets (e.g. a raw request URL with an `?access_token=` that leaked into key
- * generation), so we log this hash instead of the key itself.
- */
-export function digestCacheKey(key: string): string {
-  return strongPathHash(key);
-}
-
-/**
  * Guarantee a concrete cache key only contains characters the API cache backend
  * accepts, so a malformed key can never reach the backend and trigger an
  * `HTTP 400: Cache key contains invalid characters` (which, on the control-plane
- * `/execute` path, loops until the request is flagged stuck — see veryfront
+ * `/execute` path, loops until the request is flagged stuck; see veryfront
  * issues #162 / #175).
  *
  * Ordinary valid keys are returned unchanged. Malformed, empty, overlong, and

--- a/src/cache/keys/utils.ts
+++ b/src/cache/keys/utils.ts
@@ -212,24 +212,46 @@ function encodeCacheKeySegment(value: string): string {
   }).join("");
 }
 
-// Characters the API cache backend accepts in a whole key/pattern. This is the
-// structural charset (segment separators `:` and `/`, the glob wildcard `*`,
-// plus `.` `-` `_` and alphanumerics) — a superset of the per-segment set used
-// by encodeCacheKeySegment, which additionally escapes `:` `/` `*`.
+// Characters the API cache backend accepts. Two related sets:
+//
+// - A concrete KEY (get/set/del) may contain segment separators `:` and `/`,
+//   plus `.` `-` `_` and alphanumerics. It deliberately EXCLUDES `*`: a key is
+//   never a glob, and `*` is reserved as the escape marker below — excluding it
+//   from the passthrough set is what makes sanitizeCacheKey injective (no two
+//   inputs collide onto one key).
+// - A del-pattern additionally allows `*` as the glob wildcard.
 const cacheKeyEscapeEncoder = new TextEncoder();
-const CACHE_KEY_ALLOWED_CHAR = /^[a-zA-Z0-9_:.*/-]$/;
-export const CACHE_KEY_ALLOWED_PATTERN = /^[a-zA-Z0-9_:.*/-]+$/;
+const CACHE_KEY_ALLOWED_CHAR = /^[a-zA-Z0-9_:./-]$/;
+export const CACHE_KEY_ALLOWED_PATTERN = /^[a-zA-Z0-9_:./-]+$/;
+export const CACHE_PATTERN_ALLOWED_PATTERN = /^[a-zA-Z0-9_:.*/-]+$/;
 
 /**
- * True when a key/pattern is already valid for the API cache backend
- * (non-empty and within the allowed character set).
+ * True when a concrete cache key is valid for the API cache backend (non-empty
+ * and within the key character set — no `*`).
  */
 export function isValidCacheKey(key: string): boolean {
   return key.length > 0 && CACHE_KEY_ALLOWED_PATTERN.test(key);
 }
 
 /**
- * Guarantee a cache key/pattern only contains characters the API cache backend
+ * True when a del-pattern is valid for the API cache backend (non-empty and
+ * within the key character set plus the `*` glob wildcard).
+ */
+export function isValidCachePattern(pattern: string): boolean {
+  return pattern.length > 0 && CACHE_PATTERN_ALLOWED_PATTERN.test(pattern);
+}
+
+/**
+ * Non-reversible digest of a key, for logs. Cache keys can inadvertently carry
+ * secrets (e.g. a raw request URL with an `?access_token=` that leaked into key
+ * generation), so we log this hash instead of the key itself.
+ */
+export function digestCacheKey(key: string): string {
+  return strongPathHash(key);
+}
+
+/**
+ * Guarantee a concrete cache key only contains characters the API cache backend
  * accepts, so a malformed key can never reach the backend and trigger an
  * `HTTP 400: Cache key contains invalid characters` (which, on the control-plane
  * `/execute` path, loops until the request is flagged stuck — see veryfront
@@ -237,12 +259,18 @@ export function isValidCacheKey(key: string): boolean {
  *
  * Keys already within the allowed set are returned unchanged — the common case,
  * so no existing well-formed key is rewritten and no cache entry is orphaned.
- * Any out-of-set character (e.g. `?`, `=`, `&`, `%`, whitespace, or non-ASCII
- * that leaked in from a raw request URL, query string, or an `undefined` token
- * during key generation) is escaped as `*HH` byte sequences — the same escape
- * convention encodeCacheKeySegment uses for query params. Escaping is
- * deterministic, so a `get` and the `set` that produced the value derive the
- * identical key.
+ * Any out-of-set character (e.g. `?`, `=`, `&`, `%`, whitespace, `*`, or
+ * non-ASCII that leaked in from a raw request URL, query string, or an
+ * `undefined` token during key generation) is escaped as `*HH` byte sequences —
+ * the same escape convention encodeCacheKeySegment uses for query params.
+ *
+ * Because `*` is never a passthrough character, every `*` in the output is an
+ * escape marker: the encoding is injective (no collisions) and deterministic,
+ * so a `get` and the `set` that produced the value derive the identical key.
+ *
+ * NOTE: intended for concrete keys, not del-patterns. The `*HH` output contains
+ * `*`, which a glob context would read as a wildcard, so a pattern must never be
+ * routed through here — see isValidCachePattern and ApiCacheBackend.delByPattern.
  */
 export function sanitizeCacheKey(key: string): string {
   if (CACHE_KEY_ALLOWED_PATTERN.test(key)) return key;

--- a/src/cache/keys/utils.ts
+++ b/src/cache/keys/utils.ts
@@ -7,6 +7,7 @@
  ********************************************************************************/
 
 import { VERSION } from "#veryfront/utils/version.ts";
+import { computeHash } from "#veryfront/utils";
 import { type Span, SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 
@@ -212,16 +213,14 @@ function encodeCacheKeySegment(value: string): string {
   }).join("");
 }
 
-// Characters the API cache backend accepts. Two related sets:
-//
-// - A concrete KEY (get/set/del) may contain segment separators `:` and `/`,
-//   plus `.` `-` `_` and alphanumerics. It deliberately EXCLUDES `*`: a key is
-//   never a glob, and `*` is reserved as the escape marker below — excluding it
-//   from the passthrough set is what makes sanitizeCacheKey injective (no two
-//   inputs collide onto one key).
-// - A del-pattern additionally allows `*` as the glob wildcard.
-const cacheKeyEscapeEncoder = new TextEncoder();
-const CACHE_KEY_ALLOWED_CHAR = /^[a-zA-Z0-9_:./-]$/;
+// Keep these constraints aligned with veryfront-api's shared cache schemas.
+const CACHE_KEY_MAX_LENGTH = 512;
+const SANITIZED_CACHE_KEY_MARKER = "vf-sanitized:";
+const SHA256_HEX_LENGTH = 64;
+const MAX_TRUSTED_PREFIX_LENGTH = CACHE_KEY_MAX_LENGTH -
+  1 -
+  SANITIZED_CACHE_KEY_MARKER.length -
+  SHA256_HEX_LENGTH;
 export const CACHE_KEY_ALLOWED_PATTERN = /^[a-zA-Z0-9_:./-]+$/;
 export const CACHE_PATTERN_ALLOWED_PATTERN = /^[a-zA-Z0-9_:.*/-]+$/;
 
@@ -230,7 +229,9 @@ export const CACHE_PATTERN_ALLOWED_PATTERN = /^[a-zA-Z0-9_:.*/-]+$/;
  * and within the key character set — no `*`).
  */
 export function isValidCacheKey(key: string): boolean {
-  return key.length > 0 && CACHE_KEY_ALLOWED_PATTERN.test(key);
+  return key.length > 0 &&
+    key.length <= CACHE_KEY_MAX_LENGTH &&
+    CACHE_KEY_ALLOWED_PATTERN.test(key);
 }
 
 /**
@@ -238,7 +239,9 @@ export function isValidCacheKey(key: string): boolean {
  * within the key character set plus the `*` glob wildcard).
  */
 export function isValidCachePattern(pattern: string): boolean {
-  return pattern.length > 0 && CACHE_PATTERN_ALLOWED_PATTERN.test(pattern);
+  return pattern.length > 0 &&
+    pattern.length <= CACHE_KEY_MAX_LENGTH &&
+    CACHE_PATTERN_ALLOWED_PATTERN.test(pattern);
 }
 
 /**
@@ -257,32 +260,25 @@ export function digestCacheKey(key: string): string {
  * `/execute` path, loops until the request is flagged stuck — see veryfront
  * issues #162 / #175).
  *
- * Keys already within the allowed set are returned unchanged — the common case,
- * so no existing well-formed key is rewritten and no cache entry is orphaned.
- * Any out-of-set character (e.g. `?`, `=`, `&`, `%`, whitespace, `*`, or
- * non-ASCII that leaked in from a raw request URL, query string, or an
- * `undefined` token during key generation) is escaped as `*HH` byte sequences —
- * the same escape convention encodeCacheKeySegment uses for query params.
+ * Ordinary valid keys are returned unchanged. Malformed, empty, overlong, and
+ * reserved-namespace keys become a deterministic SHA-256 fallback. No part of
+ * the unsafe key is retained because it may contain a credential or other
+ * sensitive path data. A separately supplied trusted backend prefix can be
+ * retained so prefix-based invalidation still reaches the fallback entry.
+ * Reserving the namespace prevents a valid raw key from being mistaken for a
+ * generated fallback key.
  *
- * Because `*` is never a passthrough character, every `*` in the output is an
- * escape marker: the encoding is injective (no collisions) and deterministic,
- * so a `get` and the `set` that produced the value derive the identical key.
- *
- * NOTE: intended for concrete keys, not del-patterns. The `*HH` output contains
- * `*`, which a glob context would read as a wildcard, so a pattern must never be
- * routed through here — see isValidCachePattern and ApiCacheBackend.delByPattern.
+ * Intended for concrete keys only. Delete patterns are validated and rejected
+ * separately because rewriting a glob could broaden its deletion scope.
  */
-export function sanitizeCacheKey(key: string): string {
-  if (CACHE_KEY_ALLOWED_PATTERN.test(key)) return key;
+export async function sanitizeCacheKey(key: string, trustedPrefix = ""): Promise<string> {
+  if (isValidCacheKey(key) && !key.includes(SANITIZED_CACHE_KEY_MARKER)) return key;
 
-  return Array.from(key, (char) => {
-    if (CACHE_KEY_ALLOWED_CHAR.test(char)) return char;
-
-    return Array.from(
-      cacheKeyEscapeEncoder.encode(char),
-      (byte) => `*${byte.toString(16).toUpperCase().padStart(2, "0")}`,
-    ).join("");
-  }).join("");
+  const safePrefix = CACHE_KEY_ALLOWED_PATTERN.test(trustedPrefix) &&
+      !trustedPrefix.includes(SANITIZED_CACHE_KEY_MARKER)
+    ? `${trustedPrefix.slice(0, MAX_TRUSTED_PREFIX_LENGTH)}:`
+    : "";
+  return `${safePrefix}${SANITIZED_CACHE_KEY_MARKER}${await computeHash(key)}`;
 }
 
 export function createCacheKeyFilter(options: {

--- a/src/cache/keys/utils.ts
+++ b/src/cache/keys/utils.ts
@@ -212,6 +212,51 @@ function encodeCacheKeySegment(value: string): string {
   }).join("");
 }
 
+// Characters the API cache backend accepts in a whole key/pattern. This is the
+// structural charset (segment separators `:` and `/`, the glob wildcard `*`,
+// plus `.` `-` `_` and alphanumerics) — a superset of the per-segment set used
+// by encodeCacheKeySegment, which additionally escapes `:` `/` `*`.
+const cacheKeyEscapeEncoder = new TextEncoder();
+const CACHE_KEY_ALLOWED_CHAR = /^[a-zA-Z0-9_:.*/-]$/;
+export const CACHE_KEY_ALLOWED_PATTERN = /^[a-zA-Z0-9_:.*/-]+$/;
+
+/**
+ * True when a key/pattern is already valid for the API cache backend
+ * (non-empty and within the allowed character set).
+ */
+export function isValidCacheKey(key: string): boolean {
+  return key.length > 0 && CACHE_KEY_ALLOWED_PATTERN.test(key);
+}
+
+/**
+ * Guarantee a cache key/pattern only contains characters the API cache backend
+ * accepts, so a malformed key can never reach the backend and trigger an
+ * `HTTP 400: Cache key contains invalid characters` (which, on the control-plane
+ * `/execute` path, loops until the request is flagged stuck — see veryfront
+ * issues #162 / #175).
+ *
+ * Keys already within the allowed set are returned unchanged — the common case,
+ * so no existing well-formed key is rewritten and no cache entry is orphaned.
+ * Any out-of-set character (e.g. `?`, `=`, `&`, `%`, whitespace, or non-ASCII
+ * that leaked in from a raw request URL, query string, or an `undefined` token
+ * during key generation) is escaped as `*HH` byte sequences — the same escape
+ * convention encodeCacheKeySegment uses for query params. Escaping is
+ * deterministic, so a `get` and the `set` that produced the value derive the
+ * identical key.
+ */
+export function sanitizeCacheKey(key: string): string {
+  if (CACHE_KEY_ALLOWED_PATTERN.test(key)) return key;
+
+  return Array.from(key, (char) => {
+    if (CACHE_KEY_ALLOWED_CHAR.test(char)) return char;
+
+    return Array.from(
+      cacheKeyEscapeEncoder.encode(char),
+      (byte) => `*${byte.toString(16).toUpperCase().padStart(2, "0")}`,
+    ).join("");
+  }).join("");
+}
+
 export function createCacheKeyFilter(options: {
   projectId?: string;
   environment?: "production" | "preview";


### PR DESCRIPTION
## What and why

Malformed concrete cache keys were reaching the API cache backend. The API rejects keys outside its exact schema with HTTP 400; on the control-plane `/execute` path that failure can repeat until the request is marked stuck and consume a server worker slot.

This addresses the cache-boundary failure mode reported in veryfront-issue-inbox #162 and #175.

## Root cause

Veryfront's query-aware key builder uses collision-free internal `*HH` byte escapes for special query characters. Concrete API cache keys deliberately reject `*` because it is reserved for delete-pattern glob matching. `ApiCacheBackend` previously forwarded the internal key representation without adapting it to the API contract.

## The fix

`ApiCacheBackend` is the schema boundary shared by concrete get, batch get, set, batch set, and delete operations.

- Valid concrete keys pass through byte-for-byte unchanged.
- Malformed, empty, overlong, or reserved-namespace keys map deterministically to `vf-sanitized:<sha256>`, optionally retaining only the explicitly configured trusted backend prefix.
- Fallback keys match the API regex, contain no `*`, and remain within the 512-character limit.
- Warnings contain only the original length. No raw key, query/path value, or stable key-derived identifier is logged.
- Delete patterns are validated separately. Unsafe or overlong patterns fail closed without issuing an API request.
- Key-builder documentation now distinguishes internal `*HH` query encoding from concrete API key validity.

## Tests

The request-boundary regression starts with a real `buildQueryAwareCacheKey` output containing an internal `*HH` escape, passes it through `ApiCacheBackend`, and verifies:

1. `get`, `getBatch`, `set`, `setBatch`, and `del` derive one identical API-safe key.
2. The outbound key matches the API regex and 512-character limit.
3. Unsafe path/query material is absent from the outbound key.
4. Warnings contain no raw secret material and no key-derived hash.
5. Unsafe and overlong delete patterns issue no request.
6. Valid keys remain unchanged and fallback generation is deterministic and collision-resistant.

## Verification

- Focused cache suite: **63 tests / 82 steps**, 0 failures.
- Repository unit gate: **2,708 tests / 21,975 steps**, 0 failures.
- Format, lint, typecheck, documentation validation, barrel checks, and `git diff --check`: passed.
- `verify:quick` reaches pre-existing CLI-boundary violations in unrelated deploy/serve files; this PR does not modify those files.
- Hosted checks are the final merge gate for the updated head.
