### PR TITLE
Release Sentry V1 startup capture in v0.1.1169

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1168",
+  "version": "0.1.1169",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1168";
+export const VERSION = "0.1.1169";


### PR DESCRIPTION
## Summary

- bump the framework release from 0.1.1168 to 0.1.1169
- publish the production startup-failure boundary merged in #3140
- trigger the veryfront-server, veryfront-job-runner, and veryfront-sandbox release dispatches

0.1.1168 was published before #3140 merged, so reusing it would leave the immutable published package without the V1 startup fix.

## Validation

- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version-constant.ts`
- version consistency check
- `git diff --check`

The repository-wide pre-commit `verify:quick` currently stops on four CLI-boundary violations already present on `main`; this two-file release diff does not touch those imports.

Tracks veryfront/veryfront-issue-inbox#299.