### PR TITLE
Make plain deploy promote the latest verified push

### DIFF
--- a/cli/commands/deploy/command-help.ts
+++ b/cli/commands/deploy/command-help.ts
@@ -8,7 +8,7 @@ export const deployHelp: CommandHelp = {
   options: [
     {
       flag: "-b, --branch <name>",
-      description: "Branch to release from (default: main)",
+      description: "Branch to release from (default: latest verified push, otherwise main)",
     },
     {
       flag: "-e, --env, --environment <name>",
@@ -37,8 +37,9 @@ export const deployHelp: CommandHelp = {
   notes: [
     "Requires VERYFRONT_API_TOKEN or an authenticated Veryfront login",
     "Creates or links a project when veryfront.json is not present",
-    "Pushes the selected branch before creating the release",
-    "Creates a new release from the specified branch",
+    "Promotes the latest verified push when --branch is omitted",
+    "Pushes main before the first deploy when no verified push exists",
+    "Creates a new release from the resolved branch",
     "Verifies the target environment points to the created deployment before succeeding",
   ],
 };

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -374,6 +374,104 @@ it("deploys production from the existing verified push without mutating source",
   }
 });
 
+it("promotes the latest verified push when no branch is specified", async () => {
+  for (const jsonMode of [false, true]) {
+    const projectDir = await Deno.makeTempDir();
+    await withDeployEnv(projectDir, async ({ commitSha, sourceDigest }) => {
+      await writePushReceipt(projectDir, {
+        controlPlane: "https://control.example.test/api",
+        projectId: PROJECT_ID,
+        projectSlug: "my-project",
+        branch: "feature-x",
+        commitSha,
+        sourceDigest,
+        clean: true,
+        pushedAt: "2026-07-10T09:20:00.000Z",
+      });
+
+      const requests: string[] = [];
+      const output: string[] = [];
+      const originalLog = console.log;
+      setJsonMode(jsonMode);
+      console.log = (...args: unknown[]) => {
+        output.push(args.map(String).join(" "));
+      };
+
+      try {
+        const result = await withMockFetch(
+          createDeployFetchHandler({ requests, sourceDigest }),
+          () =>
+            deployCommand({
+              projectDir,
+              env: "production",
+              dryRun: false,
+              force: false,
+              quiet: true,
+              environmentPollIntervalMs: 1,
+              environmentTimeoutMs: 1_000,
+            }),
+        );
+
+        if (jsonMode) {
+          const jsonResult = output.map((line) => JSON.parse(line)).at(-1);
+          assertEquals(jsonResult.data.branch, "feature-x");
+        } else {
+          assertEquals(result?.branch, "feature-x");
+        }
+      } finally {
+        console.log = originalLog;
+      }
+
+      assertEquals(
+        requests.includes(`POST /api/projects/${PROJECT_ID}/deployments`),
+        true,
+      );
+    });
+  }
+});
+
+it("keeps an explicitly selected deploy branch strict", async () => {
+  const projectDir = await Deno.makeTempDir();
+  await withDeployEnv(projectDir, async ({ commitSha, sourceDigest }) => {
+    await writePushReceipt(projectDir, {
+      controlPlane: "https://control.example.test/api",
+      projectId: PROJECT_ID,
+      projectSlug: "my-project",
+      branch: "feature-x",
+      commitSha,
+      sourceDigest,
+      clean: true,
+      pushedAt: "2026-07-10T09:20:00.000Z",
+    });
+
+    const requests: string[] = [];
+    await assertRejects(
+      () =>
+        withMockFetch(
+          createDeployFetchHandler({ requests, sourceDigest }),
+          () =>
+            deployCommand({
+              projectDir,
+              branch: "main",
+              env: "production",
+              dryRun: false,
+              force: false,
+              quiet: true,
+              environmentPollIntervalMs: 1,
+              environmentTimeoutMs: 1_000,
+            }),
+        ),
+      Error,
+      'The latest push is for branch "feature-x", but deploy targets "main".',
+    );
+
+    assertEquals(
+      requests.includes(`POST /api/projects/${PROJECT_ID}/releases`),
+      false,
+    );
+  });
+});
+
 it("fails inferred deploys with an orphaned receipt before creating remote or local state", async () => {
   for (const jsonMode of [false, true]) {
     for (const dryRun of [true, false]) {

--- a/cli/commands/deploy/command.test.ts
+++ b/cli/commands/deploy/command.test.ts
@@ -432,7 +432,7 @@ describe("DeployArgsSchema", () => {
     assertEquals(result.success, true);
     if (!result.success) return;
 
-    assertEquals(result.data.branch, "main");
+    assertEquals(result.data.branch, undefined);
     assertEquals(result.data.env, "production");
   });
 
@@ -461,7 +461,7 @@ describe("parseDeployArgs", () => {
     assertEquals(result.success, true);
     if (!result.success) return;
 
-    assertEquals(result.data.branch, "main");
+    assertEquals(result.data.branch, undefined);
     assertEquals(result.data.env, "production");
   });
 

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -1,8 +1,9 @@
 /**
  * Deploy command - Create a release and deploy to an environment
  *
- * Creates a new release from the specified branch (default: main)
- * and deploys it to the target environment (default: production).
+ * Creates a new release from the specified branch, the latest verified push,
+ * or main when the project has not been pushed yet, then deploys it to the
+ * target environment (default: production).
  *
  * @module cli/commands/deploy
  */
@@ -57,7 +58,7 @@ import { isWithinDirectory, normalizePath } from "veryfront/utils";
 export const getDeployArgsSchema = defineSchema((v) =>
   v.object({
     projectDir: v.string().optional(),
-    branch: v.string().min(1).default("main"),
+    branch: v.string().min(1).optional(),
     env: v.string().min(1).default("production"),
     releaseName: v.string().min(1).optional(),
     dryRun: v.boolean().default(false),
@@ -1200,7 +1201,7 @@ export async function waitForReleaseAssetManifest(
 export async function deployCommand(options: DeployOptions): Promise<DeployResult | null> {
   const {
     projectDir = cwd(),
-    branch,
+    branch: requestedBranch,
     env,
     releaseName,
     dryRun,
@@ -1237,6 +1238,7 @@ export async function deployCommand(options: DeployOptions): Promise<DeployResul
 
   const environmentConfig = await runWithProgress(getEnvironmentConfig);
   const receipt = await runWithProgress(() => readPushReceipt(projectDir));
+  const branch = requestedBranch ?? receipt?.branch ?? "main";
   const setup = await runWithProgress(() =>
     ensureProjectLinkedForDeploy(projectDir, environmentConfig, receipt, dryRun, quiet)
   );
@@ -1461,7 +1463,7 @@ export async function deployCommand(options: DeployOptions): Promise<DeployResul
 async function deployCommandJson(options: DeployOptions): Promise<DeployResult | null> {
   const {
     projectDir = cwd(),
-    branch,
+    branch: requestedBranch,
     env,
     releaseName,
     dryRun,
@@ -1476,6 +1478,7 @@ async function deployCommandJson(options: DeployOptions): Promise<DeployResult |
     streamJsonLine({ type: "step", name: "resolve-config", status: "started" });
     const environmentConfig = getEnvironmentConfig();
     const receipt = await readPushReceipt(projectDir);
+    const branch = requestedBranch ?? receipt?.branch ?? "main";
     const setup = await ensureProjectLinkedForDeploy(
       projectDir,
       environmentConfig,

--- a/cli/commands/deploy/handler.test.ts
+++ b/cli/commands/deploy/handler.test.ts
@@ -32,7 +32,7 @@ describe("Deploy Handler", () => {
     it("should use defaults when no flags provided", () => {
       const result = parseDeployArgs(createArgs());
       assertSuccess(result);
-      assertEquals(result.data.branch, "main");
+      assertEquals(result.data.branch, undefined);
       assertEquals(result.data.env, "production");
       assertEquals(result.data.dryRun, false);
       assertEquals(result.data.force, false);

--- a/cli/shared/deployment-provenance.test.ts
+++ b/cli/shared/deployment-provenance.test.ts
@@ -113,7 +113,9 @@ describe("validatePushReceipt", () => {
           })
         ),
       Error,
-      "different branch",
+      'The latest push is for branch "main", but deploy targets "feature-x". ' +
+        "Run veryfront deploy --branch main to deploy the latest push, " +
+        "or veryfront push --branch feature-x to preview feature-x first.",
     );
   });
 

--- a/cli/shared/deployment-provenance.ts
+++ b/cli/shared/deployment-provenance.ts
@@ -278,7 +278,11 @@ export function validatePushReceipt(
     throw new Error("The latest push targeted a different project. Run veryfront push again.");
   }
   if (receipt.branch !== expected.branch) {
-    throw new Error("The latest push targeted a different branch. Run veryfront push again.");
+    throw new Error(
+      `The latest push is for branch "${receipt.branch}", but deploy targets "${expected.branch}". ` +
+        `Run veryfront deploy --branch ${receipt.branch} to deploy the latest push, ` +
+        `or veryfront push --branch ${expected.branch} to preview ${expected.branch} first.`,
+    );
   }
   if (expected.commitSha && receipt.commitSha !== expected.commitSha.toLowerCase()) {
     throw new Error(

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1171",
+  "version": "0.1.1172",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1171";
+export const VERSION = "0.1.1172";


### PR DESCRIPTION
## Summary
- infer an omitted deploy branch from the latest verified push receipt
- keep explicit `--branch` selection strict with actionable mismatch recovery
- document first-deploy fallback to `main` and bump the release to `0.1.1172`

## Expected flow
```sh
veryfront push --branch feature-x
# inspect the Preview URL
veryfront deploy
# promotes that exact verified push to production
```

A project without a push receipt still uses the one-command first deploy flow and bootstraps `main`.

## Verification
- `deno task fmt:check`
- `deno task lint`
- `deno task typecheck`
- `deno task test:unit` — 2,714 passed, 22,069 steps
- `deno task test:integration:cli` — 36 passed, 181 steps
- focused deploy suite — 39 passed, 100 steps
- live `push --branch e2e-preview` followed by plain `deploy` — production release `0.0.3`
- agent-browser: full-height render, no failed requests, no console/page errors, `/api/ag-ui` 200, calculator response `16`