### PR TITLE
Publish Sentry V2 framework release

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1174",
+  "version": "0.1.1175",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1174";
+export const VERSION = "0.1.1175";


### PR DESCRIPTION
## Summary

Release the first framework package version that includes PRs #3158, #3159, and #3160 for the Sentry V2 consolidation.

- Bumps `deno.json` to `0.1.1175`
- Bumps `src/utils/version-constant.ts` to `0.1.1175`
- Keeps the release surface narrow so CI/CD publishes the normal stable package set after merge

## Release Gate

- #3160 merged through the merge queue at `a5d509d2d930ea3cdb717402d174f62a166150a2`
- Main push workflows for `a5d509d2d930ea3cdb717402d174f62a166150a2` are green
- `0.1.1175` is unused on npm for `veryfront` and `@veryfront/ext-observability-sentry`
- No `v0.1.1175` source tag or GitHub release exists at PR creation time

## Local Validation

- `jq -e '.version == "0.1.1175"' deno.json`
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `bash scripts/ci/stable-release-requested.sh push 0.1.1175 origin/main` returned `true`

Known local gap: the pre-commit `verify:quick` hook fails on the existing `release-assets` API docs/reference gap after earlier format/lint checks pass. This PR intentionally does not widen the release bump to repair unrelated documentation.

## Next Step After Merge

Wait for the stable release job, then verify:

```bash
npm view veryfront@0.1.1175 version --json
npm view @veryfront/ext-observability-sentry@0.1.1175 version exports dependencies --json
```

Then run temporary consumer imports for `@veryfront/ext-observability-sentry/node` and `@veryfront/ext-observability-sentry/deno` before starting the Agent deletion PR.
