### PR TITLE
Reserve framework release 0.1.1176 for lifecycle fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1175",
+  "version": "0.1.1176",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1175";
+export const VERSION = "0.1.1176";


### PR DESCRIPTION
## Summary
- Bumps the framework release version from 0.1.1175 to 0.1.1176 in `deno.json` and `src/utils/version-constant.ts` only.
- Publishes the Agent Sentry lifecycle correction merged by #3165.

## Release State
- Based directly on `main` after #3165 merged as `a226ff46455bc158f88f7d0de6385db9f571fa4b`.
- The release branch contains one commit above that base and no duplicated stacked-branch history.
- The PR is ready for the protected merge queue after required CI and review.

## Validation
- `npm view veryfront version` -> `0.1.1175`
- `npm view @veryfront/ext-observability-sentry version` -> `0.1.1175`
- npm versions checks confirm `0.1.1176` is unused for both packages.
- GitHub tag lookup and release lookup confirm `v0.1.1176` is unused.
- jq `deno.json` version check plus VERSION sync assertion -> pass.
- `deno fmt --check deno.json src/utils/version-constant.ts` -> pass.
- `deno check src/utils/version-constant.ts` -> pass.
- `bash scripts/ci/stable-release-requested.sh push 0.1.1176 origin/main` -> `true` as expected for the stable release bump.

## Known Local Validation Gap
- Local pre-commit `verify:quick` was attempted and is blocked by the existing `release-assets` docs/reference gap (`./release-assets` missing `@example` and `docs/api-reference/veryfront/release-assets.md`). This PR intentionally does not edit unrelated docs.
