### PR TITLE
Fix preview discovery module leak

### DIFF
--- a/src/discovery/discovery-engine.ts
+++ b/src/discovery/discovery-engine.ts
@@ -190,6 +190,7 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
   const context: FileDiscoveryContext = {
     platform: detectPlatform(),
     fsAdapter: config.fsAdapter,
+    cacheNamespace: config.cacheNamespace,
     baseDir,
   };
 

--- a/src/discovery/project-discovery-config.ts
+++ b/src/discovery/project-discovery-config.ts
@@ -22,6 +22,7 @@ type DiscoverySettings = {
 
 type ProjectDiscoveryConfigInput = {
   projectDir: string;
+  cacheNamespace?: string;
   config?: VeryfrontConfig | null;
   fsAdapter?: FileSystemAdapter;
   verbose?: boolean;
@@ -69,6 +70,7 @@ export function createProjectDiscoveryConfig(
 
   return {
     baseDir: resolveProjectDiscoveryBaseDir(input.projectDir, input.config),
+    cacheNamespace: input.cacheNamespace,
     toolDirs: resolveDiscoveryPaths(
       aiConfig?.tools?.discovery,
       DEFAULT_PROJECT_DISCOVERY_DIRS.toolDirs,

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -195,14 +195,13 @@ export async function importModule(
     });
   }
 
-  // The cache key must include the source content: a shared hosted runtime
-  // process serves many projects and releases, and the same relative path
-  // (e.g. "tools/foo.ts") recurs across them. A path-only key keeps serving
-  // the stale module after a deploy and can hand one project's module to
-  // another project's discovery. The entry hash alone is still not enough —
-  // bundled relative imports are inlined into the module — so cached entries
-  // are only served after their recorded dependency contents re-verify.
-  const cacheKey = `${file} ${await computeHash(source)}`;
+  // A shared hosted runtime serves many projects and source generations, so
+  // namespace identical relative paths before considering entry contents.
+  // The entry hash alone is still not enough: bundled relative imports are
+  // inlined, so cached entries are only served after their recorded dependency
+  // contents re-verify.
+  const cacheNamespace = context.cacheNamespace ?? context.baseDir ?? "";
+  const cacheKey = JSON.stringify([cacheNamespace, file, await computeHash(source)]);
   const cachedEntries = transpileCache.get(cacheKey);
   if (cachedEntries) {
     const cached = await findCachedModuleWithFreshDeps(cachedEntries, context);

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -23,6 +23,8 @@ import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 export interface FileDiscoveryContext {
   platform: Platform;
   fsAdapter?: FileSystemAdapter;
+  /** Stable project or source-snapshot identity for transpiled module reuse. */
+  cacheNamespace?: string;
   nodeDeps?: {
     fs: typeof import("node:fs");
     path: typeof import("node:path");
@@ -35,6 +37,8 @@ export interface FileDiscoveryContext {
  */
 export interface DiscoveryConfig {
   baseDir: string;
+  /** Stable project or source-snapshot identity for transpiled module reuse. */
+  cacheNamespace?: string;
   toolDirs?: string[];
   agentDirs?: string[];
   skillDirs?: string[];

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -110,6 +110,50 @@ describe(
       assertEquals(updatedAgent.config.system, "SECOND");
     });
 
+    it("reuses unchanged preview primitive modules across requests", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/preview-module-cache-project",
+        "preview-module-cache-project",
+        "preview",
+      );
+      const counterKey = "__veryfrontPreviewDiscoveryImportCount";
+      const globals = globalThis as typeof globalThis & Record<string, unknown>;
+      delete globals[counterKey];
+
+      await ctx.adapter.fs.writeFile(
+        `${ctx.projectDir}/tools/counter.ts`,
+        [
+          'import { defineSchema } from "veryfront/schemas";',
+          'import { tool } from "veryfront/tool";',
+          "",
+          `const counterKey = "${counterKey}";`,
+          "const globals = globalThis as typeof globalThis & Record<string, unknown>;",
+          "globals[counterKey] = Number(globals[counterKey] ?? 0) + 1;",
+          "",
+          "export default tool({",
+          '  id: "counter",',
+          '  description: "Count module evaluations.",',
+          "  inputSchema: defineSchema((v) => v.object({}))(),",
+          "  execute: async () => ({ count: globals[counterKey] }),",
+          "});",
+          "",
+        ].join("\n"),
+      );
+
+      try {
+        await ensureProjectDiscovery(ctx);
+        await ensureProjectDiscovery(ctx);
+
+        assertEquals(globals[counterKey], 1);
+      } finally {
+        delete globals[counterKey];
+      }
+    });
+
     it("reuses preview discovery for one source snapshot generation", async () => {
       agentRegistry.clearAll();
       toolRegistry.clearAll();

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -154,6 +154,105 @@ describe(
       }
     });
 
+    it("does not reuse API-backed modules across projects", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const firstCtx = createHandlerContext("/runtime/first", "first-project", "preview");
+      const secondCtx = createHandlerContext("/runtime/second", "second-project", "preview");
+      firstCtx.projectId = "first-project-id";
+      secondCtx.projectId = "second-project-id";
+      firstCtx.config = { fs: { type: "veryfront-api" } } as HandlerContext["config"];
+      secondCtx.config = { fs: { type: "veryfront-api" } } as HandlerContext["config"];
+
+      const counterKey = "__veryfrontCrossProjectDiscoveryImportCount";
+      const globals = globalThis as typeof globalThis & Record<string, unknown>;
+      delete globals[counterKey];
+      const toolSource = [
+        'import { defineSchema } from "veryfront/schemas";',
+        'import { tool } from "veryfront/tool";',
+        "",
+        `const counterKey = "${counterKey}";`,
+        "const globals = globalThis as typeof globalThis & Record<string, unknown>;",
+        "globals[counterKey] = Number(globals[counterKey] ?? 0) + 1;",
+        "",
+        "export default tool({",
+        '  id: "counter",',
+        '  description: "Count module evaluations.",',
+        "  inputSchema: defineSchema((v) => v.object({}))(),",
+        "  execute: async () => ({ count: globals[counterKey] }),",
+        "});",
+        "",
+      ].join("\n");
+
+      await firstCtx.adapter.fs.writeFile("tools/counter.ts", toolSource);
+      await secondCtx.adapter.fs.writeFile("tools/counter.ts", toolSource);
+
+      try {
+        await ensureProjectDiscovery(firstCtx);
+        await ensureProjectDiscovery(secondCtx);
+
+        assertEquals(globals[counterKey], 2);
+      } finally {
+        delete globals[counterKey];
+      }
+    });
+
+    it("invalidates extensionless import resolution after a source snapshot change", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/runtime/resolution",
+        "resolution-project",
+        "preview",
+      );
+      ctx.projectId = "resolution-project-id";
+      ctx.config = { fs: { type: "veryfront-api" } } as HandlerContext["config"];
+      let sourceSnapshotVersion = 1;
+      (
+        ctx.adapter.fs as typeof ctx.adapter.fs & {
+          getSourceSnapshotVersion: () => number;
+        }
+      ).getSourceSnapshotVersion = () => sourceSnapshotVersion;
+      const resolvedConfigBase = `${Deno.cwd()}/tools/config`;
+
+      await ctx.adapter.fs.writeFile(
+        "tools/resolution.ts",
+        [
+          'import { tool } from "veryfront/tool";',
+          'import { defineSchema } from "veryfront/schemas";',
+          'import { description } from "./config";',
+          "",
+          "export default tool({",
+          '  id: "resolution_tool",',
+          "  description,",
+          "  inputSchema: defineSchema((v) => v.object({}))(),",
+          "  execute: async () => ({}),",
+          "});",
+          "",
+        ].join("\n"),
+      );
+      await ctx.adapter.fs.writeFile(
+        `${resolvedConfigBase}.tsx`,
+        'export const description = "TSX candidate";\n',
+      );
+
+      const first = await ensureProjectDiscovery(ctx);
+      assertEquals(first.tools.get("resolution_tool")?.description, "TSX candidate");
+
+      await ctx.adapter.fs.writeFile(
+        `${resolvedConfigBase}.ts`,
+        'export const description = "TypeScript candidate";\n',
+      );
+      sourceSnapshotVersion++;
+
+      const second = await ensureProjectDiscovery(ctx);
+      assertEquals(second.tools.get("resolution_tool")?.description, "TypeScript candidate");
+    });
+
     it("reuses preview discovery for one source snapshot generation", async () => {
       agentRegistry.clearAll();
       toolRegistry.clearAll();

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -174,6 +174,9 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<Disco
 
         const discoveryOptions = createProjectDiscoveryConfig({
           projectDir: ctx.projectDir,
+          cacheNamespace: sourceSnapshotVersion === undefined
+            ? key
+            : `${key}:snapshot:${sourceSnapshotVersion}`,
           config: ctx.config,
           fsAdapter: ctx.adapter.fs,
         });

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -156,7 +156,7 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<Disco
     sourceSnapshotVersion,
     promise: (async () => {
       return await runWithRegistryTransaction(async () => {
-        const { clearTranspileCache, discoverAll } = await import("#veryfront/discovery");
+        const { discoverAll } = await import("#veryfront/discovery");
         const { agentRegistry } = await import(
           "#veryfront/agent/composition/composition.ts"
         );
@@ -165,8 +165,10 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<Disco
         // Clear stale entries in a transaction-local copy. Concurrent runs keep
         // using the prior live registry until discovery succeeds and the staged
         // replacement is committed atomically.
+        // Keep the content-aware transpile cache: preview discovery runs on every
+        // API request, and clearing it would import unchanged modules under new
+        // temporary URLs that the runtime's ESM module map cannot unload.
         clearTrackedAgents();
-        clearTranspileCache();
         agentRegistry.clear();
         toolRegistry.clear();
 


### PR DESCRIPTION
## Summary

Preview API requests rerun project primitive discovery. The request path previously cleared the content-aware transpile cache on every request, which imported unchanged tools and agents under fresh temporary module URLs that remain in the runtime ESM module map. This eventually exhausted the Node heap.

This change keeps the transpile cache across request-time discovery while continuing to refresh transaction-local registries. Cache identity now includes the API-backed project scope, and source snapshot identity invalidates extensionless resolution when the remote file set changes.

## Replacement context

This PR replaces #3125 to resolve a branch-protection review deadlock. Kentaro authored #3125, and Koji pushed its latest review-fix commit, so neither could provide the required approval from someone other than the PR author and latest pusher. This replacement is authored by Koji from a new branch at the exact reviewed head of #3125: 142bac960f2c27c24a79eb7b7151f5741e5086a5.

## Review fixes

- Isolate evaluated preview modules across API-backed projects.
- Invalidate extensionless import resolution after a source snapshot change, including when a new higher-priority .ts candidate appears above an existing .tsx candidate.
- Preserve unchanged module reuse within the same project and source generation.

## Verification

- Focused discovery and transpiler tests: 4 passed, 38 steps.
- Full pre-push gate: 2,687 tests, 21,885 steps, zero failures.
- Previous GitHub CI on the identical commit was fully green.
- The two review threads on #3125 were replied to and resolved.

Relates to veryfront/veryfront-issue-inbox#263.