### PR TITLE
Fix sandbox AI peer resolution in security audit

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -60,6 +60,7 @@
     "npm:@types/mdast@4.0.3": "4.0.3",
     "npm:@types/node@*": "24.2.0",
     "npm:@types/unist@3.0.2": "3.0.2",
+    "npm:ai@6.0.235": "6.0.235_zod@4.3.6",
     "npm:bash-tool@1.3.16": "1.3.16_ai@6.0.235__zod@3.25.76_just-bash@2.14.5",
     "npm:better-sqlite3@9.6.0": "9.6.0",
     "npm:brace-expansion@5.0.8": "5.0.8",
@@ -205,9 +206,18 @@
       "integrity": "sha512-jO0LUsIQC+FeJRQI1KFiNcfTGp6a0lXrymekaXfBIvhVEOyt0NUyc9wiVi/dYGHQmWFXUo8QgmghgGAGLOPTAA==",
       "dependencies": [
         "@ai-sdk/provider",
-        "@ai-sdk/provider-utils",
+        "@ai-sdk/provider-utils@4.0.40_zod@3.25.76",
         "@vercel/oidc",
         "zod@3.25.76"
+      ]
+    },
+    "@ai-sdk/gateway@3.0.157_zod@4.3.6": {
+      "integrity": "sha512-jO0LUsIQC+FeJRQI1KFiNcfTGp6a0lXrymekaXfBIvhVEOyt0NUyc9wiVi/dYGHQmWFXUo8QgmghgGAGLOPTAA==",
+      "dependencies": [
+        "@ai-sdk/provider",
+        "@ai-sdk/provider-utils@4.0.40_zod@4.3.6",
+        "@vercel/oidc",
+        "zod@4.3.6"
       ]
     },
     "@ai-sdk/provider-utils@4.0.40_zod@3.25.76": {
@@ -217,6 +227,15 @@
         "@standard-schema/spec",
         "eventsource-parser",
         "zod@3.25.76"
+      ]
+    },
+    "@ai-sdk/provider-utils@4.0.40_zod@4.3.6": {
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+      "dependencies": [
+        "@ai-sdk/provider",
+        "@standard-schema/spec",
+        "eventsource-parser",
+        "zod@4.3.6"
       ]
     },
     "@ai-sdk/provider@3.0.14": {
@@ -1980,11 +1999,21 @@
     "ai@6.0.235_zod@3.25.76": {
       "integrity": "sha512-Uyeuvowo20XChpFC0lUaQq8xf0Kg7OElA56fEjUYoeWMJIzqshDTz4S57KXobcJ4m+iDQxMeJoUj06CIxSLx7A==",
       "dependencies": [
-        "@ai-sdk/gateway",
+        "@ai-sdk/gateway@3.0.157_zod@3.25.76",
         "@ai-sdk/provider",
-        "@ai-sdk/provider-utils",
+        "@ai-sdk/provider-utils@4.0.40_zod@3.25.76",
         "@opentelemetry/api",
         "zod@3.25.76"
+      ]
+    },
+    "ai@6.0.235_zod@4.3.6": {
+      "integrity": "sha512-Uyeuvowo20XChpFC0lUaQq8xf0Kg7OElA56fEjUYoeWMJIzqshDTz4S57KXobcJ4m+iDQxMeJoUj06CIxSLx7A==",
+      "dependencies": [
+        "@ai-sdk/gateway@3.0.157_zod@4.3.6",
+        "@ai-sdk/provider",
+        "@ai-sdk/provider-utils@4.0.40_zod@4.3.6",
+        "@opentelemetry/api",
+        "zod@4.3.6"
       ]
     },
     "ansi-regex@5.0.1": {
@@ -2015,7 +2044,7 @@
     "bash-tool@1.3.16_ai@6.0.235__zod@3.25.76_just-bash@2.14.5": {
       "integrity": "sha512-2xuprVBzUOYw4+QCpeSwvkuXuHkjKRtMzh+nTpEidROsNnglr5xRs3mdeOmwFVkjB4JhE/uZqIXE+tabbJI7QQ==",
       "dependencies": [
-        "ai",
+        "ai@6.0.235_zod@3.25.76",
         "fast-glob",
         "just-bash",
         "yaml",
@@ -5326,6 +5355,7 @@
         "dependencies": [
           "jsr:@std/assert@1.0.19",
           "jsr:@std/testing@1.0.17",
+          "npm:ai@6.0.235",
           "npm:bash-tool@1.3.16",
           "npm:brace-expansion@5.0.8",
           "npm:just-bash@2.14.5"

--- a/extensions/ext-sandbox-shell-tools/deno.json
+++ b/extensions/ext-sandbox-shell-tools/deno.json
@@ -12,6 +12,7 @@
     ]
   },
   "imports": {
+    "ai": "npm:ai@6.0.235",
     "bash-tool": "npm:bash-tool@1.3.16",
     "brace-expansion": "npm:brace-expansion@5.0.8",
     "just-bash": "npm:just-bash@2.14.5",

--- a/scripts/build/npm-extension-package-metadata.test.ts
+++ b/scripts/build/npm-extension-package-metadata.test.ts
@@ -38,6 +38,16 @@ describe("firstPartyExtensionManifestPaths", () => {
 });
 
 describe("manifestDependencies", () => {
+  it("pins bash-tool's required AI SDK peer in the sandbox extension", async () => {
+    const manifest = JSON.parse(
+      await Deno.readTextFile(
+        "extensions/ext-sandbox-shell-tools/deno.json",
+      ),
+    ) as ExtensionManifest;
+
+    assertEquals(manifestDependencies(manifest).ai, "6.0.235");
+  });
+
   it("derives npm dependencies from extension imports", () => {
     const manifest: ExtensionManifest = {
       name: "@veryfront/ext-sandbox-shell-tools",

--- a/scripts/build/npm-package-metadata.ts
+++ b/scripts/build/npm-package-metadata.ts
@@ -56,6 +56,7 @@ export const EXTENSION_OWNED_DEPENDENCIES = [
 	"@opentelemetry/semantic-conventions",
 	"@sentry/deno",
 	"@sentry/node",
+	"ai",
 	"bash-tool",
 	"brace-expansion",
 	"es-module-lexer",
@@ -87,10 +88,6 @@ export const EXTENSION_OWNED_DEPENDENCIES = [
 	"vfile",
 ] as const;
 
-const STALE_DIRECT_DEPENDENCIES = [
-	"ai",
-] as const;
-
 const STALE_DEV_DEPENDENCIES = [
 	"@types/better-sqlite3",
 	"@types/mime-types",
@@ -111,11 +108,6 @@ export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
 	}
 
 	for (const name of EXTENSION_OWNED_DEPENDENCIES) {
-		delete pkg.dependencies?.[name];
-		delete pkg.optionalDependencies?.[name];
-	}
-
-	for (const name of STALE_DIRECT_DEPENDENCIES) {
 		delete pkg.dependencies?.[name];
 		delete pkg.optionalDependencies?.[name];
 	}


### PR DESCRIPTION
## Summary

- Pin the AI SDK version required by `bash-tool` in the sandbox shell-tools extension.
- Keep that extension-owned dependency out of the root `veryfront` npm package.
- Add a regression test so the required peer cannot become implicit again.
- Refresh `deno.lock` for the explicit workspace dependency.

## Root cause

The security audit rebuilds an npm dependency graph from workspace manifests. `bash-tool@1.3.16` declares `ai@^6.0.0` as a required peer, but the extension did not declare that peer itself. npm therefore floated the audit graph to a newer AI SDK chain that installed vulnerable `undici@5.29.0`, while the Deno lockfile still used the safe `ai@6.0.235` chain.

Failed job: https://github.com/veryfront/veryfront-code/actions/runs/30486981051/job/90695009402

## Verification

- `deno task audit` (59 dependencies, no vulnerabilities)
- dependency, core dependency, boundary, extension contract, and extension capability lints
- package metadata and audit regression tests
- sandbox shell-tools extension tests
- changed TypeScript typecheck
- separated SBOM generation
- repository pre-push format, lint, typecheck, and unit-test gate