### PR TITLE
Redact credential text in lifted logger fields

### DIFF
--- a/src/utils/logger/logger.test.ts
+++ b/src/utils/logger/logger.test.ts
@@ -474,6 +474,26 @@ describe("logger", () => {
         restore();
       }
     });
+
+    it("scrubs credential-shaped text from string-valued lifted fields (#341)", () => {
+      const { getOutput, restore } = captureConsoleLog();
+
+      try {
+        withJsonLogFormat(() => {
+          serverLogger.info("Tool event", {
+            tool_name: "browser_fetch?access_token=synthetic-probe-secret&page=2",
+          });
+
+          const line = getOutput();
+          const entry = JSON.parse(line) as LogEntry;
+          assertEquals(line.includes("synthetic-probe-secret"), false);
+          assertEquals(entry.tool_name, "browser_fetch?access_token=[REDACTED]&page=2");
+          assertEquals(entry.context, undefined);
+        });
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe("text output format", () => {
@@ -518,6 +538,52 @@ describe("logger", () => {
         const output = getOutput();
         assertEquals(output.includes("p4ss"), false);
         assertEquals(output.includes("[REDACTED]"), true);
+      } finally {
+        restore();
+        Deno.env.delete("LOG_FORMAT");
+        Deno.env.delete("NO_COLOR");
+        __resetLoggerConfigForTests();
+      }
+    });
+
+    it("scrubs credential-shaped text from rendered context values (#341)", () => {
+      Deno.env.set("LOG_FORMAT", "text");
+      Deno.env.set("NO_COLOR", "1");
+      __resetLoggerConfigForTests();
+
+      const { getOutput, restore } = captureConsoleLog();
+
+      try {
+        serverLogger.info("Tool event", {
+          toolName: "browser_fetch",
+          callback: "https://api.example.com/cb?access_token=synthetic-text-secret&page=2",
+          nested: {
+            link: "https://api.example.com/cb?access_token=synthetic-nested-secret&page=2",
+          },
+          urlObject: new URL(
+            "https://api.example.com/cb?access_token=synthetic-url-object-secret&page=2",
+          ),
+          attempt: 2,
+        });
+
+        const output = getOutput();
+        assertEquals(output.includes("synthetic-text-secret"), false);
+        assertEquals(output.includes("synthetic-nested-secret"), false);
+        assertEquals(output.includes("synthetic-url-object-secret"), false);
+        assertEquals(output.includes("toolName=browser_fetch"), true);
+        assertEquals(
+          output.includes("callback=https://api.example.com/cb?access_token=[REDACTED]&page=2"),
+          true,
+        );
+        assertEquals(
+          output.includes('"link":"https://api.example.com/cb?access_token=[REDACTED]&page=2"'),
+          true,
+        );
+        assertEquals(
+          output.includes("urlObject=https://api.example.com/cb?access_token=[REDACTED]&page=2"),
+          true,
+        );
+        assertEquals(output.includes("attempt=2"), true);
       } finally {
         restore();
         Deno.env.delete("LOG_FORMAT");

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -335,6 +335,10 @@ function extractAliasToEntryField(
   delete context[sourceKey];
 }
 
+function sanitizeStringFieldValue(value: unknown): string {
+  return sanitizeUrlCredentials(String(value));
+}
+
 class ConsoleLogger implements Logger {
   private boundContext: Record<string, unknown>;
   private componentName?: string;
@@ -377,10 +381,10 @@ class ConsoleLogger implements Logger {
     if (this.componentName) entry.component = this.componentName;
 
     // Extract known fields to top level for easier Grafana filtering
-    extractToEntryField(entry, mergedContext, "requestId", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "traceId", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "spanId", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "projectSlug", (v) => String(v));
+    extractToEntryField(entry, mergedContext, "requestId", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "traceId", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "spanId", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "projectSlug", sanitizeStringFieldValue);
     extractToEntryField(entry, mergedContext, "durationMs", (v) => Number(v));
 
     // Auto-inject trace context from OTel when not already set
@@ -393,57 +397,75 @@ class ConsoleLogger implements Logger {
     }
 
     // Extract standard snake_case fields for Loki filtering
-    extractToEntryField(entry, mergedContext, "request_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "trace_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "span_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "project_slug", (v) => String(v));
-    // request_url / domain are URL-shaped and lifted out of mergedContext
-    // *before* redactSensitive runs, so they bypass the key-based redactor.
-    // Scrub embedded credentials (userinfo, ?access_token=, …) here (#1989).
-    extractToEntryField(
-      entry,
-      mergedContext,
-      "request_url",
-      (v) => sanitizeUrlCredentials(String(v)),
-    );
-    extractToEntryField(entry, mergedContext, "domain", (v) => sanitizeUrlCredentials(String(v)));
-    extractToEntryField(entry, mergedContext, "project_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "release_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "branch_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "branch_name", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "run_execution_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "run_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "agent_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "thread_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "schedule_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "schedule_name", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "tool_name", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "tool_call_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "batch_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "run_target", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "task", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "event_kind", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "user_visible", (v) => String(v));
+    extractToEntryField(entry, mergedContext, "request_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "trace_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "span_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "project_slug", sanitizeStringFieldValue);
+    // Lifted string fields are removed from mergedContext before redactSensitive
+    // runs, so scrub credential-shaped text while preserving the field value.
+    extractToEntryField(entry, mergedContext, "request_url", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "domain", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "project_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "release_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "branch_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "branch_name", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "run_execution_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "run_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "agent_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "thread_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "schedule_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "schedule_name", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "tool_name", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "tool_call_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "batch_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "run_target", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "task", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "event_kind", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "user_visible", sanitizeStringFieldValue);
     extractToEntryField(entry, mergedContext, "duration_ms", (v) => Number(v));
-    extractToEntryField(entry, mergedContext, "user_id", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "conversation_id", (v) => String(v));
+    extractToEntryField(entry, mergedContext, "user_id", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "conversation_id", sanitizeStringFieldValue);
 
     // Also extract camelCase variants so callers can use either convention
-    extractToEntryField(entry, mergedContext, "userId", (v) => String(v));
-    extractToEntryField(entry, mergedContext, "conversationId", (v) => String(v));
-    extractAliasToEntryField(entry, mergedContext, "runId", "run_id", (v) => String(v));
-    extractAliasToEntryField(entry, mergedContext, "agentId", "agent_id", (v) => String(v));
-    extractAliasToEntryField(entry, mergedContext, "threadId", "thread_id", (v) => String(v));
-    extractAliasToEntryField(entry, mergedContext, "scheduleId", "schedule_id", (v) => String(v));
+    extractToEntryField(entry, mergedContext, "userId", sanitizeStringFieldValue);
+    extractToEntryField(entry, mergedContext, "conversationId", sanitizeStringFieldValue);
+    extractAliasToEntryField(entry, mergedContext, "runId", "run_id", sanitizeStringFieldValue);
+    extractAliasToEntryField(entry, mergedContext, "agentId", "agent_id", sanitizeStringFieldValue);
+    extractAliasToEntryField(
+      entry,
+      mergedContext,
+      "threadId",
+      "thread_id",
+      sanitizeStringFieldValue,
+    );
+    extractAliasToEntryField(
+      entry,
+      mergedContext,
+      "scheduleId",
+      "schedule_id",
+      sanitizeStringFieldValue,
+    );
     extractAliasToEntryField(
       entry,
       mergedContext,
       "scheduleName",
       "schedule_name",
-      (v) => String(v),
+      sanitizeStringFieldValue,
     );
-    extractAliasToEntryField(entry, mergedContext, "toolName", "tool_name", (v) => String(v));
-    extractAliasToEntryField(entry, mergedContext, "toolCallId", "tool_call_id", (v) => String(v));
+    extractAliasToEntryField(
+      entry,
+      mergedContext,
+      "toolName",
+      "tool_name",
+      sanitizeStringFieldValue,
+    );
+    extractAliasToEntryField(
+      entry,
+      mergedContext,
+      "toolCallId",
+      "tool_call_id",
+      sanitizeStringFieldValue,
+    );
 
     // Emit snake_case aliases for camelCase fields (transition period)
     if (entry.requestId && !entry.request_id) entry.request_id = entry.requestId;

--- a/src/utils/logger/redact.test.ts
+++ b/src/utils/logger/redact.test.ts
@@ -144,6 +144,32 @@ describe("logger/redact", () => {
       assertEquals(result.nil, null);
     });
 
+    it("scrubs credential-shaped text from URL objects", () => {
+      const result = redactSensitive({
+        callback: new URL("https://api.example.com/cb?access_token=synthetic-url-secret&page=2"),
+      }) as Record<string, unknown>;
+
+      assertEquals(
+        result.callback,
+        `https://api.example.com/cb?access_token=${REDACTED}&page=2`,
+      );
+    });
+
+    it("scrubs credential-shaped text from scalar toJSON strings", () => {
+      const sensitive = {
+        toJSON: () => "https://api.example.com/cb?access_token=synthetic-to-json-secret&page=2",
+      };
+      const benign = { toJSON: () => "https://api.example.com/cb?page=2" };
+
+      const result = redactSensitive({ sensitive, benign }) as Record<string, unknown>;
+
+      assertEquals(
+        result.sensitive,
+        `https://api.example.com/cb?access_token=${REDACTED}&page=2`,
+      );
+      assertEquals(result.benign, benign);
+    });
+
     it("fails closed on cyclic references (no unredacted back-reference)", () => {
       const cyclic: Record<string, unknown> = { token: "t", keep: 1 };
       cyclic.self = cyclic;

--- a/src/utils/logger/redact.ts
+++ b/src/utils/logger/redact.ts
@@ -109,6 +109,8 @@ function hasToJson(value: object): value is { toJSON: () => unknown } {
 }
 
 function redactValue(value: unknown, depth: number, seen: Set<object>): unknown {
+  if (typeof value === "string") return sanitizeUrlCredentials(value);
+
   if (Array.isArray(value)) {
     if (depth >= MAX_DEPTH || seen.has(value)) return REDACTED;
     seen.add(value);
@@ -135,6 +137,10 @@ function redactValue(value: unknown, depth: number, seen: Set<object>): unknown 
       const serialized = value.toJSON();
       if (isRecord(serialized) || Array.isArray(serialized)) {
         return redactValue(serialized, depth + 1, seen);
+      }
+      if (typeof serialized === "string") {
+        const sanitized = sanitizeUrlCredentials(serialized);
+        return sanitized === serialized ? value : sanitized;
       }
       // Scalar result (string/number/…): the object serializes safely as-is.
       return value;
@@ -166,7 +172,8 @@ function redactValue(value: unknown, depth: number, seen: Set<object>): unknown 
   }
 
   // Primitives and scalar-serializing objects (Date, URL, …) are returned
-  // untouched: they are not key/value bags we can safely rewrite.
+  // untouched: except for string values above, they are not key/value bags we
+  // can safely rewrite.
   return value;
 }
 


### PR DESCRIPTION
## Summary

Fixes veryfront/veryfront-issue-inbox#341.

- routes known string-valued structured logger fields through the existing URL credential sanitizer before they are lifted out of context
- centralizes URL credential sanitization for string values inside `redactSensitive`, so text output and nested structured context use the same privacy boundary
- sanitizes scalar string `toJSON` results before returning original objects, so URL objects and custom serializers cannot leak credential-shaped URL text
- keeps structured field names and value types stable, and preserves non-sensitive scalar serializer identity/type behavior
- adds regressions proving `tool_name`, rendered text context, URL objects, and scalar `toJSON` strings no longer retain credential-shaped query values

## Root cause

`ConsoleLogger.createEntry` lifted known fields such as `tool_name` before `redactSensitive(mergedContext)` ran. Only `request_url` and `domain` received value-level credential scrubbing, so other string fields could preserve `?access_token=...` text at top level.

A review WATCH also found that text output rendered raw string context values through `formatTextLine -> redactSensitive -> formatContextText`, because `redactSensitive` masked sensitive keys but left non-sensitive string values untouched.

The follow-up HIGH found the same class of leak in the `toJSON` branch: scalar string serializers, including `URL` objects and custom `toJSON` values, returned the original object even when the scalar string contained credential-shaped URL text.

## Red / green evidence

RED:
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/utils/logger/logger.test.ts` failed on `scrubs credential-shaped text from string-valued lifted fields (#341)` because the serialized log line still contained `synthetic-probe-secret`.
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/utils/logger/logger.test.ts` failed on `scrubs credential-shaped text from rendered context values (#341)` because the text output still contained `synthetic-text-secret`.
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/utils/logger/redact.test.ts` failed on `scrubs credential-shaped text from URL objects` because the original URL object still contained `synthetic-url-secret`.

GREEN:
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/utils/logger/logger.test.ts` -> 1 passed, 62 steps
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/utils/logger/redact.test.ts` -> 1 passed, 30 steps
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/utils/logger` -> 2 passed, 92 steps
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all tests/integration/shared/logger.test.ts` -> 1 passed, 20 steps
- `deno fmt --check src/utils/logger/logger.ts src/utils/logger/logger.test.ts src/utils/logger/redact.ts src/utils/logger/redact.test.ts` -> checked 4 files
- `deno task fmt:check` -> passed
- `deno check src/utils/logger/logger.ts src/utils/logger/logger.test.ts src/utils/logger/redact.ts src/utils/logger/redact.test.ts` -> passed
- `deno task typecheck` -> passed
- `deno lint src/utils/logger/logger.ts src/utils/logger/logger.test.ts src/utils/logger/redact.ts src/utils/logger/redact.test.ts` -> checked 4 files
- `deno task lint` -> passed

## Known validation gap

`deno task verify:quick` does not complete on current `origin/main` because `docs:validate` fails for unrelated `./release-assets` API docs: missing `@example` in `src/release-assets/index.ts` and missing `docs/api-reference/veryfront/release-assets.md`. I reran `deno task docs:validate` directly and saw the same unrelated failure.

## Follow-up

After this lands and releases, repeat the Agent staging synthetic proof and confirm both Sentry and Loki contain only redacted values.
