### PR TITLE
Bump framework release to 0.1.1177

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1176",
+  "version": "0.1.1177",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1176";
+export const VERSION = "0.1.1177";


### PR DESCRIPTION
## Summary

Bumps the framework release metadata from 0.1.1176 to 0.1.1177 for the structured-log redaction fix that merged in #3173.

This PR now sits directly on `main` at #3173's merge commit and remains draft until the release handoff is ready.

## Scope

- `deno.json` version -> `0.1.1177`
- `src/utils/version-constant.ts` VERSION -> `0.1.1177`

## Base / History

- #3173 merged as `15951b72c0eb6b8facf0096604fac44f016cf78f`
- This branch was rebased onto current `origin/main`
- The old stacked redaction-fix history was dropped
- Current diff is only the two release metadata lines

## Validation

- `npm view veryfront@0.1.1177 version` -> 404 / unused
- `npm view @veryfront/ext-observability-sentry@0.1.1177 version` -> 404 / unused
- `git ls-remote --tags origin v0.1.1177` -> no tag
- `deno task generate:manifests:check` -> passed
- `deno task fmt:check` -> passed
- `deno test --no-check --allow-read src/utils/version.test.ts` -> passed, including VERSION / deno.json sync
- `deno task typecheck` -> passed

## Notes

Pre-commit `verify:quick` was attempted before the rebase and failed on an existing docs/API-reference gap for `./release-assets`, not on this version bump. This PR stays scoped to release metadata only.