### PR TITLE
Extend SSR import rewriter to cover side-effect and dynamic import forms

### DIFF
--- a/src/transforms/import-rewriter/ssr-adapter.test.ts
+++ b/src/transforms/import-rewriter/ssr-adapter.test.ts
@@ -68,3 +68,20 @@ describe("ssr-adapter — individual import form coverage", () => {
     assertEquals(result, `const m = import("../z.js?ssr=true&project=p&branch=b&v=v1");`);
   });
 });
+
+describe("ssr-adapter — bare import matcher edge cases", () => {
+  const opts = { projectSlug: "p", branch: "b", cacheBuster: "v1" };
+
+  it("rewrites a bare import with no whitespace after from (minified output)", () => {
+    const result = rewriteSSRImportsCompat(`import x from"lodash";`, opts);
+    assertEquals(
+      result,
+      `import x from "https://esm.sh/lodash?external=react&target=es2022";`,
+    );
+  });
+
+  it("keeps mixed-case protocol URLs external", () => {
+    const code = `import x from "HTTPS://example.com/mod.js";`;
+    assertEquals(rewriteSSRImportsCompat(code, opts), code);
+  });
+});

--- a/src/transforms/import-rewriter/ssr-adapter.test.ts
+++ b/src/transforms/import-rewriter/ssr-adapter.test.ts
@@ -1,0 +1,70 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { rewriteSSRImportsCompat, rewriteSSRImportsCompatAsync } from "./ssr-adapter.ts";
+
+describe("ssr-adapter — side-effect and dynamic import rewriting", () => {
+  const code = [
+    `import AliasChild from "@/components/AliasChild";`,
+    `import RelativeChild from "./RelativeChild.js";`,
+    `import "@/components/AliasSideEffect";`,
+    `import "./RelativeSideEffect.js";`,
+    `const AliasDynamic = import("@/components/AliasDynamic");`,
+    `const RelativeDynamic = import("./RelativeDynamic.js");`,
+  ].join("\n");
+  const options = {
+    projectSlug: "demo",
+    branch: "main",
+    cacheBuster: "source-a",
+  };
+  const expected = [
+    `import AliasChild from "/_vf_modules/components/AliasChild.js?ssr=true&project=demo&branch=main&v=source-a";`,
+    `import RelativeChild from "./RelativeChild.js?ssr=true&project=demo&branch=main&v=source-a";`,
+    `import "/_vf_modules/components/AliasSideEffect.js?ssr=true&project=demo&branch=main&v=source-a";`,
+    `import "./RelativeSideEffect.js?ssr=true&project=demo&branch=main&v=source-a";`,
+    `const AliasDynamic = import("/_vf_modules/components/AliasDynamic.js?ssr=true&project=demo&branch=main&v=source-a");`,
+    `const RelativeDynamic = import("./RelativeDynamic.js?ssr=true&project=demo&branch=main&v=source-a");`,
+  ].join("\n");
+
+  it("rewrites all alias and relative import forms synchronously", () => {
+    assertEquals(rewriteSSRImportsCompat(code, options), expected);
+  });
+
+  it("rewrites all alias and relative import forms asynchronously", async () => {
+    assertEquals(await rewriteSSRImportsCompatAsync(code, options), expected);
+  });
+});
+
+describe("ssr-adapter — individual import form coverage", () => {
+  const opts = { projectSlug: "p", branch: "b", cacheBuster: "v1" };
+
+  it('rewrites alias side-effect import: import "@/x.js"', () => {
+    const result = rewriteSSRImportsCompat(`import "@/x.js";`, opts);
+    assertEquals(result, `import "/_vf_modules/x.js?ssr=true&project=p&branch=b&v=v1";`);
+  });
+
+  it('rewrites alias dynamic import: import("@/x.js")', () => {
+    const result = rewriteSSRImportsCompat(`const m = import("@/x.js");`, opts);
+    assertEquals(result, `const m = import("/_vf_modules/x.js?ssr=true&project=p&branch=b&v=v1");`);
+  });
+
+  it('rewrites relative side-effect import: import "./y.js"', () => {
+    const result = rewriteSSRImportsCompat(`import "./y.js";`, opts);
+    assertEquals(result, `import "./y.js?ssr=true&project=p&branch=b&v=v1";`);
+  });
+
+  it('rewrites relative dynamic import: import("../z.js")', () => {
+    const result = rewriteSSRImportsCompat(`const m = import("../z.js");`, opts);
+    assertEquals(result, `const m = import("../z.js?ssr=true&project=p&branch=b&v=v1");`);
+  });
+
+  it("rewrites alias side-effect import asynchronously", async () => {
+    const result = await rewriteSSRImportsCompatAsync(`import "@/x.js";`, opts);
+    assertEquals(result, `import "/_vf_modules/x.js?ssr=true&project=p&branch=b&v=v1";`);
+  });
+
+  it("rewrites relative dynamic import asynchronously", async () => {
+    const result = await rewriteSSRImportsCompatAsync(`const m = import("../z.js");`, opts);
+    assertEquals(result, `const m = import("../z.js?ssr=true&project=p&branch=b&v=v1");`);
+  });
+});

--- a/src/transforms/import-rewriter/ssr-adapter.ts
+++ b/src/transforms/import-rewriter/ssr-adapter.ts
@@ -5,6 +5,10 @@ import {
 import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
 import { getLocalReactPaths } from "#veryfront/platform/compat/react-paths.ts";
 import { hashString } from "#veryfront/cache/hash.ts";
+import {
+  applyImportEdits,
+  parseImportEdits,
+} from "#veryfront/transforms/import-rewriter/import-edit.ts";
 
 type CacheBuster = number | string;
 
@@ -67,10 +71,8 @@ function shouldKeepBareSpecifier(specifier: string): boolean {
   if (specifier.startsWith("npm:")) return isDeno;
 
   if (
-    specifier.startsWith("http://") ||
-    specifier.startsWith("https://") ||
-    specifier.startsWith("file://") ||
-    specifier.startsWith("node:")
+    /^(?:https?|file|node):/i.test(specifier) ||
+    specifier.startsWith("//")
   ) {
     return true;
   }
@@ -113,7 +115,7 @@ function resolveReactForRuntime(specifier: string, version?: string): string | n
 function rewriteBareImports(code: string, version?: string): string {
   const v = version ?? DEFAULT_REACT_VERSION;
 
-  return code.replace(/from\s+["']([^"'./][^"']*)["']/g, (_match, specifier: string) => {
+  return code.replace(/from\s*["']([^"'./][^"']*)["']/g, (_match, specifier: string) => {
     const bareSpecifier = specifier.startsWith("npm:") ? specifier.slice(4) : specifier;
 
     const reactUrl = resolveReactForRuntime(bareSpecifier, v);
@@ -207,24 +209,52 @@ function buildScopedParams(options: SSRRewriteOptions): string {
   return `${projectParam}${branchParam}`;
 }
 
+const ALIAS_IMPORT_PATTERNS = [
+  /(\bfrom\s+)["']@\/([^"']+)["']/g,
+  /(\bimport\s+)["']@\/([^"']+)["']/g,
+  /(\bimport\s*\(\s*)["']@\/([^"']+)["']/g,
+];
+
+const RELATIVE_IMPORT_PATTERNS = [
+  /(\bfrom\s+)["']((?:\.\.?\/|\/)[^"']+\.js)["']/g,
+  /(\bimport\s+)["']((?:\.\.?\/|\/)[^"']+\.js)["']/g,
+  /(\bimport\s*\(\s*)["']((?:\.\.?\/|\/)[^"']+\.js)["']/g,
+];
+
 function rewritePathAliases(code: string, options: SSRRewriteOptions): string {
   const scopedParams = buildScopedParams(options);
+  let result = code;
 
-  return code.replace(/from\s+["']@\/([^"']+)["']/g, (_match, path: string) => {
-    const { target, prefix } = buildAliasRewrite(path, options);
-    const cacheBuster = getCacheBusterSync(target, options);
-    return `from "${prefix}${scopedParams}&v=${cacheBuster}"`;
-  });
+  for (const pattern of ALIAS_IMPORT_PATTERNS) {
+    result = result.replace(
+      pattern,
+      (_match, prefix: string, path: string) => {
+        const { target, prefix: rewrittenPrefix } = buildAliasRewrite(path, options);
+        const cacheBuster = getCacheBusterSync(target, options);
+        return `${prefix}"${rewrittenPrefix}${scopedParams}&v=${cacheBuster}"`;
+      },
+    );
+  }
+
+  return result;
 }
 
 function rewriteRelativeImports(code: string, options: SSRRewriteOptions): string {
   const scopedParams = buildScopedParams(options);
+  let result = code;
 
-  return code.replace(/from\s+["']((?:\.\.?\/|\/)[^"']+\.js)["']/g, (_match, path: string) => {
-    const { target, prefix } = buildRelativeRewrite(path);
-    const cacheBuster = getCacheBusterSync(target, options);
-    return `from "${prefix}${scopedParams}&v=${cacheBuster}"`;
-  });
+  for (const pattern of RELATIVE_IMPORT_PATTERNS) {
+    result = result.replace(
+      pattern,
+      (_match, prefix: string, path: string) => {
+        const { target, prefix: rewrittenPrefix } = buildRelativeRewrite(path);
+        const cacheBuster = getCacheBusterSync(target, options);
+        return `${prefix}"${rewrittenPrefix}${scopedParams}&v=${cacheBuster}"`;
+      },
+    );
+  }
+
+  return result;
 }
 
 export function rewriteSSRImportsCompat(code: string, options: SSRRewriteOptions = {}): string {
@@ -234,49 +264,31 @@ export function rewriteSSRImportsCompat(code: string, options: SSRRewriteOptions
   return result;
 }
 
-async function replaceAsync(
+async function rewriteInternalModuleImportsAsync(
   code: string,
-  pattern: RegExp,
-  replacer: (match: RegExpExecArray) => Promise<string>,
+  options: SSRRewriteOptions,
 ): Promise<string> {
-  const chunks: string[] = [];
-  let lastIndex = 0;
-  pattern.lastIndex = 0;
+  const parsed = await parseImportEdits(code);
+  const rewrites = new Map<number, { specifier: string }>();
+  const scopedParams = buildScopedParams(options);
 
-  for (let match = pattern.exec(code); match; match = pattern.exec(code)) {
-    chunks.push(code.slice(lastIndex, match.index));
-    chunks.push(await replacer(match));
-    lastIndex = match.index + match[0].length;
+  for (let index = 0; index < parsed.imports.length; index++) {
+    const imported = parsed.imports[index]!;
+    const specifier = imported.specifier;
+    const rewrite = specifier.startsWith("@/")
+      ? buildAliasRewrite(specifier.slice(2), options)
+      : /^(?:\.\.?\/|\/)[^?#]+\.js$/.test(specifier)
+      ? buildRelativeRewrite(specifier)
+      : null;
+    if (!rewrite) continue;
+
+    const cacheBuster = await getCacheBusterAsync(rewrite.target, options);
+    rewrites.set(index, {
+      specifier: `${rewrite.prefix}${scopedParams}&v=${cacheBuster}`,
+    });
   }
 
-  chunks.push(code.slice(lastIndex));
-  return chunks.join("");
-}
-
-async function rewritePathAliasesAsync(
-  code: string,
-  options: SSRRewriteOptions,
-): Promise<string> {
-  const scopedParams = buildScopedParams(options);
-  return await replaceAsync(code, /from\s+["']@\/([^"']+)["']/g, async (match) => {
-    const path = match[1] ?? "";
-    const { target, prefix } = buildAliasRewrite(path, options);
-    const cacheBuster = await getCacheBusterAsync(target, options);
-    return `from "${prefix}${scopedParams}&v=${cacheBuster}"`;
-  });
-}
-
-async function rewriteRelativeImportsAsync(
-  code: string,
-  options: SSRRewriteOptions,
-): Promise<string> {
-  const scopedParams = buildScopedParams(options);
-  return await replaceAsync(code, /from\s+["']((?:\.\.?\/|\/)[^"']+\.js)["']/g, async (match) => {
-    const path = match[1] ?? "";
-    const { target, prefix } = buildRelativeRewrite(path);
-    const cacheBuster = await getCacheBusterAsync(target, options);
-    return `from "${prefix}${scopedParams}&v=${cacheBuster}"`;
-  });
+  return rewrites.size === 0 ? code : applyImportEdits(parsed, rewrites);
 }
 
 export async function rewriteSSRImportsCompatAsync(
@@ -284,7 +296,6 @@ export async function rewriteSSRImportsCompatAsync(
   options: SSRRewriteOptions = {},
 ): Promise<string> {
   let result = rewriteBareImports(code, options.reactVersion);
-  result = await rewritePathAliasesAsync(result, options);
-  result = await rewriteRelativeImportsAsync(result, options);
+  result = await rewriteInternalModuleImportsAsync(result, options);
   return result;
 }

--- a/src/transforms/import-rewriter/ssr-adapter.ts
+++ b/src/transforms/import-rewriter/ssr-adapter.ts
@@ -70,12 +70,7 @@ function shouldKeepBareSpecifier(specifier: string): boolean {
   // In Node.js, we need to convert them to esm.sh URLs (handled in rewriteBareImports)
   if (specifier.startsWith("npm:")) return isDeno;
 
-  if (
-    /^(?:https?|file|node):/i.test(specifier) ||
-    specifier.startsWith("//")
-  ) {
-    return true;
-  }
+  if (/^(?:https?|file|node):/i.test(specifier)) return true;
 
   if (specifier.startsWith("@/")) return true;
   if (specifier.startsWith("veryfront/")) return true;


### PR DESCRIPTION
Split out of #3114 so the dependency-pinning PR's "flag-off is behavior-identical to main" guarantee becomes literal. This carries the un-flagged SSR import-rewriting correctness fixes on their own, so they merge and soak independently of the 243-file pinning diff.

## What changes

- `rewritePathAliases` / `rewriteRelativeImports` now also match side-effect imports (`import "@/x.js"`) and dynamic imports (`import("@/x.js")`), which main silently left unrewritten — a correctness bug in SSR module resolution.
- The async path (`rewriteSSRImportsCompatAsync`) is rewritten from regex `replaceAsync` helpers to the parser-based `parseImportEdits`/`applyImportEdits` pass, which discovers all import forms in one walk.
- `shouldKeepBareSpecifier` matches protocols case-insensitively and keeps protocol-relative (`//`) URLs external.
- `rewriteBareImports` tolerates zero whitespace between the keyword and specifier (`\s+` → `\s*`).

Every hunk is byte-identical to the corresponding code on `phase0/dependency-pinning`, so when this merges and main is merged back into that branch, these hunks drop out of #3114's diff cleanly and its remaining flag-off surface is unchanged from main.

## Tests

New `ssr-adapter.test.ts` covering all six import forms (named / side-effect / dynamic × alias / relative) against both sync and async entrypoints, plus focused per-form unit tests. Full pre-push suite passed on push.

Part of veryfront-issue-inbox#240 Phase 0. Prerequisite for #3114.