### PR TITLE
Bump framework release to 0.1.1178

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1177",
+  "version": "0.1.1178",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1177";
+export const VERSION = "0.1.1178";


### PR DESCRIPTION
Version bump for the first release carrying the merged July-30 set. Same shape as #3174: `deno.json` + `src/utils/version-constant.ts` together, publish gated on the tag.

## What ships in 0.1.1178 (vs published 0.1.1177)

| Change | Behavior at deploy |
|---|---|
| Stream lifecycle Gates 1-4 (#3072) | dormant — `VF_STREAM_LIFECYCLE_MODE` unset = legacy, byte-compatible; watchdog semantics also flag-gated |
| Dependency pinning Phase 0 (#3114) | dormant — `VERYFRONT_DEPENDENCY_PINNING` unset = identical to 0.1.1177 |
| esm.sh migration codemod (#3115) | inert — opt-in tooling |
| Chat API RFC (#2980) | docs only |
| **SSR side-effect/dynamic import rewriting (#3175)** | **active** — SSR now rewrites `import "..."` and `import("...")` forms |
| **Trigger-ref popper anchoring (#3176)** | **active** — Popover/DropdownMenu lose the wrapper `<span>` |

## Publish steps after merge

1. Tag the merge commit: `git tag v0.1.1178 <merge-sha> && git push origin v0.1.1178` — CI publishes npm + binaries.
2. This starts the production soak for #3175 and #3176 (the two active changes).
3. Stream-lifecycle shadow rollout can then follow per `docs/internal/stream-lifecycle-rollout.md`: consumers on 0.1.1178 → `VF_STREAM_LIFECYCLE_MODE=shadow` → 24h divergence watch → `active` at 1%.

Full pre-push suite passed on push. Version test suite (21 steps) green.