### PR TITLE
Centralize SSR outcomes behind one semantic module

### DIFF
--- a/src/rendering/orchestrator/ssr-orchestrator.ts
+++ b/src/rendering/orchestrator/ssr-orchestrator.ts
@@ -17,26 +17,9 @@ import {
   endRenderSession,
   hasRenderSession,
 } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/index.ts";
-
-import { isDataControlResult } from "#veryfront/data/helpers.ts";
+import { isSSRControlOutcome } from "../ssr-outcome.ts";
 
 const logger = rendererLogger.component("ssr-orchestrator");
-
-/** True when the thrown value is (or wraps) a notFound()/redirect() control result. */
-function isThrownControlResult(error: unknown): boolean {
-  const seen = new Set<unknown>();
-  const stack: unknown[] = [error];
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (!current || typeof current !== "object" || seen.has(current)) continue;
-    if (isDataControlResult(current)) return true;
-    seen.add(current);
-    stack.push((current as { cause?: unknown }).cause);
-    const aggregated = (current as { errors?: unknown }).errors;
-    if (Array.isArray(aggregated)) stack.push(...aggregated);
-  }
-  return false;
-}
 
 export interface SSROrchestratorConfig {
   mode: "development" | "production";
@@ -169,7 +152,7 @@ export class SSROrchestrator {
     } catch (renderError) {
       // A thrown notFound()/redirect() control result is NOT a render error —
       // let it propagate to the SSR error handler (→ 404 / redirect).
-      if (isThrownControlResult(renderError)) throw renderError;
+      if (isSSRControlOutcome(renderError)) throw renderError;
 
       // The page threw during SSR (React error boundaries don't catch SSR render
       // throws). Render the segment's app-router error.tsx instead, if present;

--- a/src/rendering/ssr-outcome.test.ts
+++ b/src/rendering/ssr-outcome.test.ts
@@ -1,7 +1,13 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { notFound, redirect } from "#veryfront/data/helpers.ts";
-import { findSSRControlOutcome, isSSRControlOutcome } from "./ssr-outcome.ts";
+import {
+  API_CLIENT_ERROR,
+  FILE_NOT_FOUND,
+  RENDER_ERROR,
+  SERVICE_OVERLOADED,
+} from "#veryfront/errors";
+import { findSSRControlOutcome, isSSRControlOutcome, resolveSSRFailure } from "./ssr-outcome.ts";
 
 describe("ssr-outcome.ts", () => {
   describe("findSSRControlOutcome", () => {
@@ -43,6 +49,121 @@ describe("ssr-outcome.ts", () => {
     it("returns true only when the graph contains a branded control result", () => {
       assertEquals(isSSRControlOutcome(new Error("wrapped", { cause: notFound() })), true);
       assertEquals(isSSRControlOutcome({ notFound: true }), false);
+    });
+  });
+
+  describe("resolveSSRFailure", () => {
+    it("classifies known SSR failures into semantic outcomes", () => {
+      const genericLocal = new Error("local render failed");
+      const genericProduction = new Error("production render failed");
+      const boundaryError = Object.assign(new Error("boundary rendered"), {
+        errorBoundaryHtml: "<!doctype html><html><body>boundary</body></html>",
+      });
+      const overloaded = SERVICE_OVERLOADED.create({
+        detail: "queue is full",
+        status: 429,
+      });
+      const redirectError = RENDER_ERROR.create({
+        detail: "redirect",
+        context: {
+          redirect: {
+            destination: "/login",
+            permanent: true,
+          },
+        },
+      });
+
+      const cases = [
+        {
+          name: "file-not-found",
+          error: FILE_NOT_FOUND.create({ detail: "missing page" }),
+          context: { isLocalProject: false },
+          want: { kind: "not-found" },
+        },
+        {
+          name: "undeployed release file list",
+          error: API_CLIENT_ERROR.create({
+            detail: "missing files",
+            status: 404,
+            context: {
+              details: { url: "/api/projects/p1/environments/production/files" },
+            },
+          }),
+          context: { isLocalProject: false },
+          want: { kind: "undeployed" },
+        },
+        {
+          name: "render redirect context",
+          error: redirectError,
+          context: { isLocalProject: false },
+          want: { kind: "redirect", location: "/login", permanent: true },
+        },
+        {
+          name: "service overloaded",
+          error: overloaded,
+          context: { isLocalProject: true },
+          want: { kind: "overloaded", status: 429 },
+        },
+        {
+          name: "generic local runtime",
+          error: genericLocal,
+          context: { isLocalProject: true },
+          want: { kind: "runtime", exposure: "development-overlay" },
+        },
+        {
+          name: "generic production server error",
+          error: genericProduction,
+          context: { isLocalProject: false },
+          want: { kind: "server-error", exposure: "generic" },
+        },
+        {
+          name: "app-router error boundary",
+          error: boundaryError,
+          context: { isLocalProject: true },
+          want: {
+            kind: "app-router-error-boundary",
+            html: "<!doctype html><html><body>boundary</body></html>",
+          },
+        },
+      ] as const;
+
+      for (const testCase of cases) {
+        const outcome = resolveSSRFailure(testCase.error, testCase.context);
+        assertEquals(outcome.kind, testCase.want.kind, testCase.name);
+
+        switch (testCase.want.kind) {
+          case "not-found":
+          case "undeployed":
+            break;
+          case "redirect":
+            assertEquals(outcome, testCase.want, testCase.name);
+            break;
+          case "overloaded":
+            assertEquals(outcome.status, testCase.want.status, testCase.name);
+            assertStrictEquals(outcome.error, overloaded, testCase.name);
+            break;
+          case "runtime":
+          case "server-error":
+            assertEquals(outcome.exposure, testCase.want.exposure, testCase.name);
+            assertStrictEquals(outcome.error, testCase.error, testCase.name);
+            break;
+          case "app-router-error-boundary":
+            assertEquals(outcome.html, testCase.want.html, testCase.name);
+            assertStrictEquals(outcome.error, boundaryError, testCase.name);
+            break;
+        }
+      }
+    });
+
+    it("defaults service-overloaded to 503 when the error has no status", () => {
+      const overloaded = SERVICE_OVERLOADED.create({ detail: "queue is full" });
+      Object.assign(overloaded, { status: undefined });
+
+      const outcome = resolveSSRFailure(overloaded, { isLocalProject: true });
+
+      assertEquals(outcome.kind, "overloaded");
+      assertEquals(outcome.status, 503);
+      assertStrictEquals(outcome.error, overloaded);
     });
   });
 });

--- a/src/rendering/ssr-outcome.test.ts
+++ b/src/rendering/ssr-outcome.test.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { notFound, redirect } from "#veryfront/data/helpers.ts";
+import { findSSRControlOutcome, isSSRControlOutcome } from "./ssr-outcome.ts";
+
+describe("ssr-outcome.ts", () => {
+  describe("findSSRControlOutcome", () => {
+    it("finds a branded redirect through cause and AggregateError nodes", () => {
+      const wrapped = new AggregateError([
+        new Error("other"),
+        new Error("wrapped", { cause: redirect("/login", true) }),
+      ]);
+
+      assertEquals(findSSRControlOutcome(wrapped), {
+        kind: "redirect",
+        location: "/login",
+        permanent: true,
+      });
+    });
+
+    it("rejects an unbranded redirect-shaped value", () => {
+      assertEquals(
+        findSSRControlOutcome({
+          redirect: { destination: "/login", permanent: false },
+        }),
+        null,
+      );
+    });
+
+    it("terminates on cyclic error graphs", () => {
+      const cyclic: { cause?: unknown } = {};
+      cyclic.cause = cyclic;
+
+      assertEquals(findSSRControlOutcome(cyclic), null);
+    });
+
+    it("normalizes a branded notFound result", () => {
+      assertEquals(findSSRControlOutcome(notFound()), { kind: "not-found" });
+    });
+  });
+
+  describe("isSSRControlOutcome", () => {
+    it("returns true only when the graph contains a branded control result", () => {
+      assertEquals(isSSRControlOutcome(new Error("wrapped", { cause: notFound() })), true);
+      assertEquals(isSSRControlOutcome({ notFound: true }), false);
+    });
+  });
+});

--- a/src/rendering/ssr-outcome.test.ts
+++ b/src/rendering/ssr-outcome.test.ts
@@ -7,7 +7,62 @@ import {
   RENDER_ERROR,
   SERVICE_OVERLOADED,
 } from "#veryfront/errors";
+import type { SSRFailureOutcome } from "./ssr-outcome.ts";
 import { findSSRControlOutcome, isSSRControlOutcome, resolveSSRFailure } from "./ssr-outcome.ts";
+
+function assertSSRFailureOutcome(
+  actual: SSRFailureOutcome,
+  expected: SSRFailureOutcome,
+  message?: string,
+): void {
+  switch (expected.kind) {
+    case "not-found":
+      assertEquals(actual, expected, message);
+      return;
+    case "redirect":
+      assertEquals(actual, expected, message);
+      return;
+    case "app-router-error-boundary":
+      if (actual.kind !== "app-router-error-boundary") {
+        assertEquals(actual.kind, expected.kind, message);
+        return;
+      }
+      assertEquals(actual.html, expected.html, message);
+      assertStrictEquals(actual.error, expected.error, message);
+      return;
+    case "undeployed":
+      if (actual.kind !== "undeployed") {
+        assertEquals(actual.kind, expected.kind, message);
+        return;
+      }
+      assertStrictEquals(actual.error, expected.error, message);
+      return;
+    case "overloaded":
+      if (actual.kind !== "overloaded") {
+        assertEquals(actual.kind, expected.kind, message);
+        return;
+      }
+      assertEquals(actual.status, expected.status, message);
+      assertStrictEquals(actual.error, expected.error, message);
+      return;
+    case "runtime":
+      if (actual.kind !== "runtime") {
+        assertEquals(actual.kind, expected.kind, message);
+        return;
+      }
+      assertEquals(actual.exposure, expected.exposure, message);
+      assertStrictEquals(actual.error, expected.error, message);
+      return;
+    case "server-error":
+      if (actual.kind !== "server-error") {
+        assertEquals(actual.kind, expected.kind, message);
+        return;
+      }
+      assertEquals(actual.exposure, expected.exposure, message);
+      assertStrictEquals(actual.error, expected.error, message);
+      return;
+  }
+}
 
 describe("ssr-outcome.ts", () => {
   describe("findSSRControlOutcome", () => {
@@ -63,6 +118,13 @@ describe("ssr-outcome.ts", () => {
         detail: "queue is full",
         status: 429,
       });
+      const undeployedError = API_CLIENT_ERROR.create({
+        detail: "missing files",
+        status: 404,
+        context: {
+          details: { url: "/api/projects/p1/environments/production/files" },
+        },
+      });
       const redirectError = RENDER_ERROR.create({
         detail: "redirect",
         context: {
@@ -78,43 +140,49 @@ describe("ssr-outcome.ts", () => {
           name: "file-not-found",
           error: FILE_NOT_FOUND.create({ detail: "missing page" }),
           context: { isLocalProject: false },
-          want: { kind: "not-found" },
+          want: { kind: "not-found" } satisfies SSRFailureOutcome,
         },
         {
           name: "undeployed release file list",
-          error: API_CLIENT_ERROR.create({
-            detail: "missing files",
-            status: 404,
-            context: {
-              details: { url: "/api/projects/p1/environments/production/files" },
-            },
-          }),
+          error: undeployedError,
           context: { isLocalProject: false },
-          want: { kind: "undeployed" },
+          want: { kind: "undeployed", error: undeployedError } satisfies SSRFailureOutcome,
         },
         {
           name: "render redirect context",
           error: redirectError,
           context: { isLocalProject: false },
-          want: { kind: "redirect", location: "/login", permanent: true },
+          want: {
+            kind: "redirect",
+            location: "/login",
+            permanent: true,
+          } satisfies SSRFailureOutcome,
         },
         {
           name: "service overloaded",
           error: overloaded,
           context: { isLocalProject: true },
-          want: { kind: "overloaded", status: 429 },
+          want: { kind: "overloaded", status: 429, error: overloaded } satisfies SSRFailureOutcome,
         },
         {
           name: "generic local runtime",
           error: genericLocal,
           context: { isLocalProject: true },
-          want: { kind: "runtime", exposure: "development-overlay" },
+          want: {
+            kind: "runtime",
+            exposure: "development-overlay",
+            error: genericLocal,
+          } satisfies SSRFailureOutcome,
         },
         {
           name: "generic production server error",
           error: genericProduction,
           context: { isLocalProject: false },
-          want: { kind: "server-error", exposure: "generic" },
+          want: {
+            kind: "server-error",
+            exposure: "generic",
+            error: genericProduction,
+          } satisfies SSRFailureOutcome,
         },
         {
           name: "app-router error boundary",
@@ -123,35 +191,17 @@ describe("ssr-outcome.ts", () => {
           want: {
             kind: "app-router-error-boundary",
             html: "<!doctype html><html><body>boundary</body></html>",
-          },
+            error: boundaryError,
+          } satisfies SSRFailureOutcome,
         },
       ] as const;
 
       for (const testCase of cases) {
-        const outcome = resolveSSRFailure(testCase.error, testCase.context);
-        assertEquals(outcome.kind, testCase.want.kind, testCase.name);
-
-        switch (testCase.want.kind) {
-          case "not-found":
-          case "undeployed":
-            break;
-          case "redirect":
-            assertEquals(outcome, testCase.want, testCase.name);
-            break;
-          case "overloaded":
-            assertEquals(outcome.status, testCase.want.status, testCase.name);
-            assertStrictEquals(outcome.error, overloaded, testCase.name);
-            break;
-          case "runtime":
-          case "server-error":
-            assertEquals(outcome.exposure, testCase.want.exposure, testCase.name);
-            assertStrictEquals(outcome.error, testCase.error, testCase.name);
-            break;
-          case "app-router-error-boundary":
-            assertEquals(outcome.html, testCase.want.html, testCase.name);
-            assertStrictEquals(outcome.error, boundaryError, testCase.name);
-            break;
-        }
+        assertSSRFailureOutcome(
+          resolveSSRFailure(testCase.error, testCase.context),
+          testCase.want,
+          testCase.name,
+        );
       }
     });
 
@@ -161,9 +211,46 @@ describe("ssr-outcome.ts", () => {
 
       const outcome = resolveSSRFailure(overloaded, { isLocalProject: true });
 
-      assertEquals(outcome.kind, "overloaded");
-      assertEquals(outcome.status, 503);
-      assertStrictEquals(outcome.error, overloaded);
+      assertSSRFailureOutcome(outcome, {
+        kind: "overloaded",
+        status: 503,
+        error: overloaded,
+      });
+    });
+
+    it("prefers app-router boundary HTML over a wrapped branded control result", () => {
+      const error = Object.assign(new Error("boundary rendered", { cause: notFound() }), {
+        errorBoundaryHtml: "<!doctype html><html><body>boundary wins</body></html>",
+      });
+
+      assertSSRFailureOutcome(resolveSSRFailure(error, { isLocalProject: false }), {
+        kind: "app-router-error-boundary",
+        html: "<!doctype html><html><body>boundary wins</body></html>",
+        error,
+      });
+    });
+
+    it("prefers a wrapped branded control result over VeryfrontError category handling", () => {
+      const error = FILE_NOT_FOUND.create({
+        detail: "missing page",
+        cause: redirect("/preferred", false),
+      });
+
+      assertSSRFailureOutcome(resolveSSRFailure(error, { isLocalProject: false }), {
+        kind: "redirect",
+        location: "/preferred",
+        permanent: false,
+      });
+    });
+
+    it("prefers service overload classification over local runtime fallback", () => {
+      const error = SERVICE_OVERLOADED.create({ detail: "queue is full" });
+
+      assertSSRFailureOutcome(resolveSSRFailure(error, { isLocalProject: true }), {
+        kind: "overloaded",
+        status: 503,
+        error,
+      });
     });
   });
 });

--- a/src/rendering/ssr-outcome.ts
+++ b/src/rendering/ssr-outcome.ts
@@ -1,0 +1,47 @@
+import { isDataControlResult } from "#veryfront/data/helpers.ts";
+import type { DataResult } from "#veryfront/data/types.ts";
+
+export type SSRControlOutcome =
+  | { kind: "not-found" }
+  | {
+    kind: "redirect";
+    location: string;
+    permanent: boolean;
+  };
+
+export function findSSRControlOutcome(error: unknown): SSRControlOutcome | null {
+  const seen = new Set<unknown>();
+  const stack: unknown[] = [error];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || typeof current !== "object" || seen.has(current)) continue;
+
+    if (isDataControlResult(current)) {
+      return toSSRControlOutcome(current);
+    }
+
+    seen.add(current);
+    stack.push((current as { cause?: unknown }).cause);
+    const aggregated = (current as { errors?: unknown }).errors;
+    if (Array.isArray(aggregated)) stack.push(...aggregated);
+  }
+
+  return null;
+}
+
+export function isSSRControlOutcome(error: unknown): boolean {
+  return findSSRControlOutcome(error) !== null;
+}
+
+function toSSRControlOutcome(result: DataResult): SSRControlOutcome {
+  if (result.redirect) {
+    return {
+      kind: "redirect",
+      location: result.redirect.destination,
+      permanent: result.redirect.permanent === true,
+    };
+  }
+
+  return { kind: "not-found" };
+}

--- a/src/rendering/ssr-outcome.ts
+++ b/src/rendering/ssr-outcome.ts
@@ -1,5 +1,6 @@
 import { isDataControlResult } from "#veryfront/data/helpers.ts";
 import type { DataResult } from "#veryfront/data/types.ts";
+import { VeryfrontError } from "#veryfront/errors";
 
 export type SSRControlOutcome =
   | { kind: "not-found" }
@@ -8,6 +9,44 @@ export type SSRControlOutcome =
     location: string;
     permanent: boolean;
   };
+
+export type SSRFailureOutcome =
+  | SSRControlOutcome
+  | {
+    kind: "app-router-error-boundary";
+    html: string;
+    error: Error;
+  }
+  | {
+    kind: "undeployed";
+    error: Error;
+  }
+  | {
+    kind: "overloaded";
+    status: number;
+    error: Error;
+  }
+  | {
+    kind: "runtime";
+    exposure: "development-overlay";
+    error: Error;
+  }
+  | {
+    kind: "server-error";
+    exposure: "generic";
+    error: Error;
+  };
+
+interface RedirectResultContext {
+  redirect?: {
+    destination?: unknown;
+    permanent?: unknown;
+  };
+}
+
+interface ErrorBoundarySignal {
+  errorBoundaryHtml?: unknown;
+}
 
 export function findSSRControlOutcome(error: unknown): SSRControlOutcome | null {
   const seen = new Set<unknown>();
@@ -34,6 +73,53 @@ export function isSSRControlOutcome(error: unknown): boolean {
   return findSSRControlOutcome(error) !== null;
 }
 
+export function resolveSSRFailure(
+  error: unknown,
+  context: { isLocalProject: boolean },
+): SSRFailureOutcome {
+  const errorObj = error instanceof Error ? error : new Error(String(error));
+  const errorBoundaryHtml = (error as ErrorBoundarySignal | undefined)?.errorBoundaryHtml;
+  if (typeof errorBoundaryHtml === "string") {
+    return {
+      kind: "app-router-error-boundary",
+      html: errorBoundaryHtml,
+      error: errorObj,
+    };
+  }
+
+  const control = findSSRControlOutcome(error);
+  if (control) return control;
+
+  if (error instanceof VeryfrontError && error.slug === "file-not-found") {
+    return { kind: "not-found" };
+  }
+
+  if (isUndeployedFileListError(error)) {
+    return { kind: "undeployed", error: errorObj };
+  }
+
+  if (error instanceof VeryfrontError && error.slug === "render-error") {
+    const redirect = extractRedirectLocation(error);
+    if (redirect) {
+      return {
+        kind: "redirect",
+        location: redirect.destination,
+        permanent: redirect.permanent,
+      };
+    }
+  }
+
+  if (error instanceof VeryfrontError && error.slug === "service-overloaded") {
+    return { kind: "overloaded", status: error.status ?? 503, error: errorObj };
+  }
+
+  if (context.isLocalProject) {
+    return { kind: "runtime", exposure: "development-overlay", error: errorObj };
+  }
+
+  return { kind: "server-error", exposure: "generic", error: errorObj };
+}
+
 function toSSRControlOutcome(result: DataResult): SSRControlOutcome {
   if (result.redirect) {
     return {
@@ -44,4 +130,29 @@ function toSSRControlOutcome(result: DataResult): SSRControlOutcome {
   }
 
   return { kind: "not-found" };
+}
+
+function extractRedirectLocation(
+  error: VeryfrontError,
+): { destination: string; permanent: boolean } | null {
+  const redirect = (error.context as RedirectResultContext | undefined)?.redirect;
+  if (!redirect || typeof redirect.destination !== "string") return null;
+
+  return {
+    destination: redirect.destination,
+    permanent: redirect.permanent === true,
+  };
+}
+
+function isUndeployedFileListError(error: unknown): boolean {
+  if (!(error instanceof VeryfrontError) || error.slug !== "api-client-error") return false;
+  if (error.status !== 404) return false;
+
+  const apiUrl =
+    (((error.context as { details?: { url?: string } } | undefined)?.details?.url) ?? "")
+      .toString();
+
+  return apiUrl.includes("/files") &&
+    !apiUrl.includes("/files/") &&
+    (apiUrl.includes("/environments/") || apiUrl.includes("/branches/"));
 }

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -146,6 +146,19 @@ function getAllReady(stream: ReadableStream | null | undefined): Promise<unknown
   return allReady as Promise<unknown>;
 }
 
+function getApiUrlForLogging(error: Error): string | undefined {
+  if (!("context" in error)) return undefined;
+
+  const context = error.context;
+  if (!context || typeof context !== "object" || !("details" in context)) return undefined;
+
+  const details = context.details;
+  if (!details || typeof details !== "object" || !("url" in details)) return undefined;
+
+  const url = details.url;
+  return typeof url === "string" ? url : undefined;
+}
+
 export class SSRService implements SSRServiceLike {
   private readonly cacheRepo?: CacheRepository<string>;
   private readonly rendererProvider: RendererProvider;
@@ -344,6 +357,7 @@ export class SSRService implements SSRServiceLike {
       case "undeployed":
         logger.debug("Project not deployed", {
           projectSlug: ctx.projectSlug,
+          apiUrl: getApiUrlForLogging(outcome.error),
         });
         return {
           status: HTTP_NOT_FOUND,

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -8,8 +8,7 @@ import { getHeapStats } from "#veryfront/utils/memory/index.ts";
 import { serverLogger, timeAsync } from "#veryfront/utils";
 import { computeSSRETag } from "../../handlers/request/ssr/etag-handler.ts";
 import { VeryfrontError } from "#veryfront/errors";
-import { isDataControlResult } from "#veryfront/data/helpers.ts";
-import type { DataResult } from "#veryfront/data/types.ts";
+import { findSSRControlOutcome } from "#veryfront/rendering/ssr-outcome.ts";
 import { getColorSchemeFromRequest } from "#veryfront/security/http/client-hints.ts";
 import {
   endRenderSession,
@@ -112,36 +111,6 @@ interface RedirectResultContext {
     destination?: unknown;
     permanent?: unknown;
   };
-}
-
-/**
- * Find a thrown `notFound()` / `redirect()` control result anywhere in the
- * error's `cause` chain or an `AggregateError`'s `errors`.
- *
- * `throw notFound()` is documented to work like `return notFound()`. The data
- * loaders already recognise a thrown branded result (server-data-fetcher.ts),
- * but a control result thrown from a page COMPONENT render surfaces here in the
- * SSR error handler instead, where, unrecognised, it became a 500. Matching the
- * brand lets it behave like the returned/loader form: a 404 (custom
- * `not-found.tsx`) or a redirect. The check is on the brand, never the shape.
- *
- * React can surface concurrent boundary failures wrapped in an `AggregateError`,
- * so the walk descends both `cause` and `errors`. A `seen` set keeps a
- * self-referential chain from looping.
- */
-function findThrownControlResult(error: unknown): DataResult | null {
-  const seen = new Set<unknown>();
-  const stack: unknown[] = [error];
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (!current || typeof current !== "object" || seen.has(current)) continue;
-    if (isDataControlResult(current)) return current as DataResult;
-    seen.add(current);
-    stack.push((current as { cause?: unknown }).cause);
-    const aggregated = (current as { errors?: unknown }).errors;
-    if (Array.isArray(aggregated)) stack.push(...aggregated);
-  }
-  return null;
 }
 
 function extractRedirectLocation(
@@ -328,7 +297,7 @@ export class SSRService implements SSRServiceLike {
           try {
             await allReady;
           } catch (error) {
-            if (findThrownControlResult(error)) {
+            if (findSSRControlOutcome(error)) {
               return this.handleRenderError(error, ctx, slug, request, nonce);
             }
           }
@@ -389,17 +358,21 @@ export class SSRService implements SSRServiceLike {
     // as a thrown control result. Recognise the brand and behave like the loader
     // form: notFound to 404 (routed to the segment's custom not-found.tsx by the
     // handler), redirect to 301/302. Otherwise it falls through to a 500.
-    const control = findThrownControlResult(error);
-    if (control?.redirect) {
+    const control = findSSRControlOutcome(error);
+    if (control?.kind === "redirect") {
       logger.debug("SSR control-result redirect (thrown from component)", {
         slug,
-        destination: control.redirect.destination,
-        permanent: control.redirect.permanent,
+        destination: control.location,
+        permanent: control.permanent,
         projectSlug: ctx.projectSlug,
       });
-      return buildRedirectResult(control.redirect, errorObj, slug);
+      return buildRedirectResult(
+        { destination: control.location, permanent: control.permanent },
+        errorObj,
+        slug,
+      );
     }
-    if (control?.notFound) {
+    if (control?.kind === "not-found") {
       logger.debug("SSR control-result notFound (thrown from component)", { slug });
       return buildNotFoundResult(slug);
     }

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -7,8 +7,7 @@ import {
 import { getHeapStats } from "#veryfront/utils/memory/index.ts";
 import { serverLogger, timeAsync } from "#veryfront/utils";
 import { computeSSRETag } from "../../handlers/request/ssr/etag-handler.ts";
-import { VeryfrontError } from "#veryfront/errors";
-import { findSSRControlOutcome } from "#veryfront/rendering/ssr-outcome.ts";
+import { findSSRControlOutcome, resolveSSRFailure } from "#veryfront/rendering/ssr-outcome.ts";
 import { getColorSchemeFromRequest } from "#veryfront/security/http/client-hints.ts";
 import {
   endRenderSession,
@@ -104,25 +103,6 @@ export interface MemoryStatus {
   heapUsedMB: number;
   heapLimitMB: number;
   heapUsedPercent: number;
-}
-
-interface RedirectResultContext {
-  redirect?: {
-    destination?: unknown;
-    permanent?: unknown;
-  };
-}
-
-function extractRedirectLocation(
-  error: VeryfrontError,
-): { destination: string; permanent: boolean } | null {
-  const redirect = (error.context as RedirectResultContext | undefined)?.redirect;
-  if (!redirect || typeof redirect.destination !== "string") return null;
-
-  return {
-    destination: redirect.destination,
-    permanent: redirect.permanent === true,
-  };
 }
 
 /**
@@ -330,73 +310,40 @@ export class SSRService implements SSRServiceLike {
     nonce?: string,
   ): SSRRenderResult {
     const errorObj = error instanceof Error ? error : new Error(String(error));
+    const outcome = resolveSSRFailure(error, { isLocalProject: Boolean(ctx.isLocalProject) });
 
-    // The page threw and its app-router error.tsx already rendered a full,
-    // hydrating document (the boundary UI). Serve it as a 500 without caching.
-    const errorBoundaryHtml = (error as { errorBoundaryHtml?: string })?.errorBoundaryHtml;
-    if (typeof errorBoundaryHtml === "string") {
-      captureApplicationError(errorObj, {
-        boundary: "ssr.app-router-error-boundary",
-        method: request.method,
-      });
-      return {
-        status: HTTP_INTERNAL_SERVER_ERROR,
-        html: errorBoundaryHtml,
-        isStreaming: false,
-        cacheStrategy: "no-cache",
-        errorType: "app-router-error-boundary",
-        slug,
-      };
-    }
-
-    // Dev-only overlay (full stack, absolute paths, line numbers) must never
-    // be exposed outside a local project, including remote preview, which is
-    // internet-reachable. See VULN-SRV-1 / VULN-SRV-2.
-    const isDev = Boolean(ctx.isLocalProject);
-
-    // `throw notFound()` / `throw redirect()` from a page component surfaces here
-    // as a thrown control result. Recognise the brand and behave like the loader
-    // form: notFound to 404 (routed to the segment's custom not-found.tsx by the
-    // handler), redirect to 301/302. Otherwise it falls through to a 500.
-    const control = findSSRControlOutcome(error);
-    if (control?.kind === "redirect") {
-      logger.debug("SSR control-result redirect (thrown from component)", {
-        slug,
-        destination: control.location,
-        permanent: control.permanent,
-        projectSlug: ctx.projectSlug,
-      });
-      return buildRedirectResult(
-        { destination: control.location, permanent: control.permanent },
-        errorObj,
-        slug,
-      );
-    }
-    if (control?.kind === "not-found") {
-      logger.debug("SSR control-result notFound (thrown from component)", { slug });
-      return buildNotFoundResult(slug);
-    }
-
-    if (error instanceof VeryfrontError && error.slug === "file-not-found") {
-      logger.debug("Page not found", { slug, error: errorObj.message });
-      return buildNotFoundResult(slug);
-    }
-
-    if (
-      error instanceof VeryfrontError && error.slug === "api-client-error" && error.status === 404
-    ) {
-      const apiUrl =
-        (((error.context as { details?: { url?: string } } | undefined)?.details?.url) ?? "")
-          .toString();
-
-      const isFileListRequest = apiUrl.includes("/files") &&
-        !apiUrl.includes("/files/") &&
-        (apiUrl.includes("/environments/") || apiUrl.includes("/branches/"));
-
-      if (isFileListRequest) {
+    switch (outcome.kind) {
+      case "app-router-error-boundary":
+        captureApplicationError(outcome.error, {
+          boundary: "ssr.app-router-error-boundary",
+          method: request.method,
+        });
+        return {
+          status: HTTP_INTERNAL_SERVER_ERROR,
+          html: outcome.html,
+          isStreaming: false,
+          cacheStrategy: "no-cache",
+          errorType: "app-router-error-boundary",
+          slug,
+        };
+      case "redirect":
+        logger.debug("SSR redirect", {
+          slug,
+          destination: outcome.location,
+          permanent: outcome.permanent,
+          projectSlug: ctx.projectSlug,
+        });
+        return buildRedirectResult(
+          { destination: outcome.location, permanent: outcome.permanent },
+          errorObj,
+          slug,
+        );
+      case "not-found":
+        logger.debug("SSR notFound", { slug });
+        return buildNotFoundResult(slug);
+      case "undeployed":
         logger.debug("Project not deployed", {
           projectSlug: ctx.projectSlug,
-          apiUrl,
         });
         return {
           status: HTTP_NOT_FOUND,
@@ -406,87 +353,82 @@ export class SSRService implements SSRServiceLike {
           errorType: "undeployed",
           slug,
         };
-      }
-    }
-
-    if (error instanceof VeryfrontError && error.slug === "render-error") {
-      const redirect = extractRedirectLocation(error);
-      if (redirect) {
-        logger.debug("SSR redirect", {
+      case "overloaded":
+        return {
+          status: outcome.status ?? HTTP_UNAVAILABLE,
+          html: ErrorPages.memoryPressure(),
+          isStreaming: false,
+          cacheStrategy: "no-cache",
+          error: outcome.error,
+          errorType: "server-error",
           slug,
-          destination: redirect.destination,
-          permanent: redirect.permanent,
+        };
+      case "runtime":
+        captureApplicationError(outcome.error, {
+          boundary: "ssr.render",
+          method: request.method,
+        });
+
+        logger.error("Render failed", {
+          slug,
+          error: outcome.error.message,
+          stack: outcome.error.stack,
           projectSlug: ctx.projectSlug,
         });
-        return buildRedirectResult(redirect, errorObj, slug);
-      }
+
+        // Dev-only overlay content includes stack details and must stay local-only.
+        getErrorCollector().addRuntimeError(outcome.error.message, outcome.error.stack, {
+          source: "ssr-service",
+          url: request.url,
+          slug,
+        });
+
+        {
+          const sourceFile = (outcome.error as Error & { sourceFile?: string }).sourceFile;
+          const location = sourceFile ? parseErrorLocation(outcome.error, sourceFile) : {};
+          return {
+            status: HTTP_INTERNAL_SERVER_ERROR,
+            html: ErrorOverlay.createHTML(
+              {
+                error: outcome.error,
+                type: "runtime",
+                ...(sourceFile ? { file: sourceFile } : {}),
+                ...location,
+              },
+              ctx.projectSlug,
+              nonce,
+            ),
+            isStreaming: false,
+            cacheStrategy: "no-cache",
+            error: outcome.error,
+            errorType: "runtime",
+            showDevOverlay: true,
+            slug,
+          };
+        }
+      case "server-error":
+        captureApplicationError(outcome.error, {
+          boundary: "ssr.render",
+          method: request.method,
+        });
+
+        logger.error("Render failed", {
+          slug,
+          error: outcome.error.message,
+          stack: outcome.error.stack,
+          projectSlug: ctx.projectSlug,
+        });
+
+        return {
+          status: HTTP_INTERNAL_SERVER_ERROR,
+          html: ErrorPages.serverError(),
+          isStreaming: false,
+          cacheStrategy: "no-cache",
+          error: outcome.error,
+          errorType: "server-error",
+          slug,
+        };
     }
-
-    if (
-      error instanceof VeryfrontError && error.slug === "service-overloaded"
-    ) {
-      return {
-        status: error.status ?? HTTP_UNAVAILABLE,
-        html: ErrorPages.memoryPressure(),
-        isStreaming: false,
-        cacheStrategy: "no-cache",
-        error: errorObj,
-        errorType: "server-error",
-        slug,
-      };
-    }
-
-    captureApplicationError(errorObj, {
-      boundary: "ssr.render",
-      method: request.method,
-    });
-
-    logger.error("Render failed", {
-      slug,
-      error: errorObj.message,
-      stack: errorObj.stack,
-      projectSlug: ctx.projectSlug,
-    });
-
-    if (isDev) {
-      getErrorCollector().addRuntimeError(errorObj.message, errorObj.stack, {
-        source: "ssr-service",
-        url: request.url,
-        slug,
-      });
-
-      const sourceFile = (errorObj as Error & { sourceFile?: string }).sourceFile;
-      const location = sourceFile ? parseErrorLocation(errorObj, sourceFile) : {};
-      return {
-        status: HTTP_INTERNAL_SERVER_ERROR,
-        html: ErrorOverlay.createHTML(
-          {
-            error: errorObj,
-            type: "runtime",
-            ...(sourceFile ? { file: sourceFile } : {}),
-            ...location,
-          },
-          ctx.projectSlug,
-          nonce,
-        ),
-        isStreaming: false,
-        cacheStrategy: "no-cache",
-        error: errorObj,
-        errorType: "runtime",
-        showDevOverlay: true,
-        slug,
-      };
-    }
-
-    return {
-      status: HTTP_INTERNAL_SERVER_ERROR,
-      html: ErrorPages.serverError(),
-      isStreaming: false,
-      cacheStrategy: "no-cache",
-      error: errorObj,
-      errorType: "server-error",
-      slug,
-    };
   }
 
   createMemoryPressureResult(slug: string): SSRRenderResult {

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -369,7 +369,7 @@ export class SSRService implements SSRServiceLike {
         };
       case "overloaded":
         return {
-          status: outcome.status ?? HTTP_UNAVAILABLE,
+          status: outcome.status,
           html: ErrorPages.memoryPressure(),
           isStreaming: false,
           cacheStrategy: "no-cache",


### PR DESCRIPTION
## Description

Centralizes SSR control-flow discovery and render-failure classification behind one pure semantic module.

- Adds graph-safe discovery for branded `notFound()` and `redirect()` outcomes across `cause` and `AggregateError.errors`.
- Adds `resolveSSRFailure()` with explicit, regression-tested category precedence.
- Replaces duplicate control-result walkers in the SSR orchestrator and service.
- Keeps logging, application-error capture, development overlays, error-page HTML, status/cache fields, and public `SSRRenderResult` adaptation in `SSRService`.
- Preserves handler injection, streaming, ETag, redirect, not-found, overload, and local-only overlay behavior.

## Related Issues

None.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactoring
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review
- [x] I have added tests for branded traversal, cyclic graphs, unbranded rejection, semantic categories, and precedence conflicts
- [x] New and existing unit tests pass locally
- [ ] Documentation has been updated (no public API or command behavior changed)

## Verification

- `deno fmt --check` on all modified files
- `deno lint` on all modified production and test files
- `deno check` on the outcome module, tests, orchestrator, service, and handler
- Focused SSR suite: 5 files, 119 steps, 0 failures
- `deno task test:unit`: 2,800 tests, 22,682 steps, 0 failures
- Pre-push checks: all passed
- Whole-branch independent review: SPEC PASS, QUALITY PASS
