### PR TITLE
Centralize project creation behind one reusable interface

### DIFF
--- a/cli/app/operations/project-creation.ts
+++ b/cli/app/operations/project-creation.ts
@@ -6,13 +6,14 @@
  */
 
 import { cwd } from "veryfront/platform";
+import { join } from "veryfront/platform/path";
 import type { AppState } from "../state.ts";
 import { addLog, setProjects, updateRemote } from "../state.ts";
 import { readToken } from "../../auth/token-store.ts";
 import { fetchRemoteProjects } from "../../sync/index.ts";
 import { getLocalProjectsFromState, normalizeSlug } from "../utils.ts";
 import { reserveProjectSlug } from "../../shared/reserve-slug.ts";
-import { initCommand } from "../../commands/init/init-command.ts";
+import { createProject as createSharedProject } from "../../shared/project-creation.ts";
 import type { InitTemplate } from "../../commands/init/types.ts";
 
 export interface ProjectCreationContext {
@@ -41,18 +42,23 @@ export async function createProject(
 
     const normalizedSlug = normalizeSlug(projectName);
     const { slug } = await reserveProjectSlug(normalizedSlug, token);
-    const projectPath = `${cwd()}/projects/${slug}`;
 
-    await initCommand({
-      name: `projects/${slug}`,
+    const creation = await createSharedProject({
+      name: slug,
+      parentDir: join(cwd(), "projects"),
       template,
-      skipInstall: true,
-      skipEnvPrompt: true,
-      quiet: true,
+      runtime: "node",
+      features: [],
+      integrations: [],
+      environmentValues: {},
+      conflictPolicy: "fail",
+      installDependencies: false,
+      initializeGit: false,
+      includePackageMetadata: false,
     });
 
     const currentProjects = getLocalProjectsFromState(state);
-    currentProjects.push({ slug, path: projectPath });
+    currentProjects.push({ slug, path: creation.projectDir });
     state = setProjects(currentProjects)(state);
 
     const result = await fetchRemoteProjects();

--- a/cli/commands/demo/demo.ts
+++ b/cli/commands/demo/demo.ts
@@ -6,7 +6,6 @@
 
 import { chdir, cwd, promptSync, writeStdout } from "veryfront/platform";
 import { getStdinReader, setRawMode } from "veryfront/platform";
-import { join } from "veryfront/platform/path";
 import {
   AnimatedDotMatrix,
   bold,
@@ -38,7 +37,7 @@ import {
   DEFAULT_LOGIN_TIMEOUT_MS,
   resolveCliApiUrl,
 } from "#cli/shared/constants";
-import { initCommand } from "../init/index.ts";
+import { createProject as createSharedProject } from "../../shared/project-creation.ts";
 import { writeProjectLink } from "../../shared/project-link.ts";
 import { randomSuffix } from "#cli/shared/slug";
 import { deployCommand } from "../deploy/index.ts";
@@ -353,16 +352,21 @@ async function executeStepAction(
     }
 
     case "create": {
-      await initCommand({
+      const creation = await createSharedProject({
         name: projectName,
+        parentDir: cwd(),
         template: "ai-agent",
-        quiet: true,
-        skipInstall: true,
-        skipEnvPrompt: true,
-        force: true,
+        runtime: "node",
+        features: [],
+        integrations: [],
+        environmentValues: {},
+        conflictPolicy: "overwrite",
+        installDependencies: false,
+        initializeGit: false,
+        includePackageMetadata: false,
       });
 
-      const projectDir = join(cwd(), projectName);
+      const projectDir = creation.projectDir;
       const slug = `${projectName}-${randomSuffix()}`;
       actualProjectSlug = slug;
 

--- a/cli/commands/init/init-command.test.ts
+++ b/cli/commands/init/init-command.test.ts
@@ -50,6 +50,7 @@ describe("InitCommand Types", () => {
         });
 
         assertEquals(await exists(join(parentDir, name, "app")), true);
+        assertEquals(await exists(join(parentDir, name, "package.json")), false);
         assertEquals(await exists(cwdTarget), false);
       } finally {
         await remove(parentDir, { recursive: true }).catch(() => {});
@@ -86,6 +87,7 @@ describe("InitCommand Types", () => {
 
         const expectedLiveLine = `  Live: ${deployedUrl}`;
         const liveLine = output.map(stripAnsi).find((line) => line === expectedLiveLine);
+        assertEquals(await exists(join(parentDir, name, "app")), true);
         assertEquals(liveLine, expectedLiveLine);
       } finally {
         console.log = originalLog;

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -6,173 +6,20 @@
 import { cliLogger as logger, isVerbose } from "#cli/utils";
 import { brand, dim, red } from "#cli/ui";
 import { createTransientSpinner } from "../../ui/progress.ts";
-import { ensureDir } from "#std/fs.ts";
 import { join } from "veryfront/platform/path";
-import { createPackageJson } from "./config-generator.ts";
-import { createDenoConfig } from "./deno-config-generator.ts";
 import { createError, toError } from "veryfront/errors";
 import type { InitOptions, InitRuntime, InitTemplate } from "./types.ts";
 import { cwd } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
-import {
-  detectPackageManager,
-  getDlxCommand,
-  getInstallCommand,
-  getRunCommand,
-  installDependencies,
-  type PackageManager,
-} from "../../utils/package-manager.ts";
-import { generateGitignoreContent, promptForEnvVars } from "../../utils/env-prompt.ts";
-import type { EnvVarConfig, ResolvedIntegration, TemplateFile } from "../../templates/types.ts";
-import {
-  loadFeature,
-  mergeFiles,
-  resolveFeatures,
-  validateFeatures,
-} from "../../templates/feature-loader.ts";
-import {
-  getIntegrationBaseFiles,
-  loadIntegrationBaseConfig,
-  loadIntegrationBaseFilesFromDirectory,
-  loadIntegrations,
-  validateIntegrations,
-} from "../../templates/integration-loader.ts";
+import { getDlxCommand, getInstallCommand, getRunCommand } from "../../utils/package-manager.ts";
+import { createProject, type ProjectCreationObserver } from "../../shared/project-creation.ts";
+import { promptForEnvVars } from "../../utils/env-prompt.ts";
 import {
   runInteractiveWizard,
   shouldRunWizard,
   validateProjectName,
 } from "./interactive-wizard.ts";
 import { DEFAULT_TEMPLATE } from "./catalog.ts";
-
-/**
- * Icon mapping for integrations based on category/name
- */
-const INTEGRATION_ICONS: Record<string, string> = {
-  gmail: "mail",
-  outlook: "mail",
-  slack: "slack",
-  teams: "teams",
-  calendar: "calendar",
-  github: "github",
-  gitlab: "gitlab",
-  bitbucket: "bitbucket",
-  jira: "jira",
-  confluence: "confluence",
-  notion: "notion",
-  linear: "linear",
-  asana: "asana",
-  trello: "trello",
-  monday: "monday",
-  clickup: "clickup",
-  figma: "figma",
-  drive: "drive",
-  onedrive: "onedrive",
-  sharepoint: "sharepoint",
-  box: "box",
-  sheets: "sheets",
-  airtable: "airtable",
-  supabase: "database",
-  neon: "database",
-  snowflake: "database",
-  salesforce: "salesforce",
-  pipedrive: "pipedrive",
-  zendesk: "zendesk",
-  intercom: "intercom",
-  freshdesk: "freshdesk",
-  servicenow: "servicenow",
-  stripe: "stripe",
-  quickbooks: "quickbooks",
-  xero: "xero",
-  shopify: "shopify",
-  mailchimp: "mailchimp",
-  twitter: "twitter",
-  zoom: "zoom",
-  webex: "webex",
-  twilio: "twilio",
-  sentry: "sentry",
-  posthog: "posthog",
-  mixpanel: "mixpanel",
-  anthropic: "ai",
-  aws: "cloud",
-};
-
-/**
- * Generate the integrations status route based on loaded integrations
- */
-function generateIntegrationsStatusRoute(integrations: ResolvedIntegration[]): string {
-  const integrationEntries = integrations
-    .map((integration) => {
-      const icon = INTEGRATION_ICONS[integration.config.name] ?? "default";
-      return `  { id: "${integration.config.name}", name: "${integration.config.displayName}", icon: "${icon}" },`;
-    })
-    .join("\n");
-
-  return `/**
- * Integration Status API
- *
- * Returns the connection status of all configured integrations.
- * Used by the setup guide to show which services are connected.
- *
- * This file is auto-generated based on the integrations you selected.
- */
-
-import { tokenStore } from "../../../../lib/token-store";
-
-// Integrations configured for this project
-const INTEGRATIONS = [
-${integrationEntries}
-];
-
-export async function GET(_req: Request) {
-  // Get actual user ID from session in production
-  const userId = "current-user";
-
-  const statuses = await Promise.all(
-    INTEGRATIONS.map(async (integration) => {
-      const connected = await tokenStore.isConnected(userId, integration.id);
-      return {
-        id: integration.id,
-        name: integration.name,
-        icon: integration.icon,
-        connected,
-        connectUrl: \`/api/auth/\${integration.id}\`,
-      };
-    }),
-  );
-
-  return Response.json({ integrations: statuses });
-}
-`;
-}
-
-function validateOrThrow<T extends string>(
-  kind: "features" | "integrations",
-  values: T[],
-  validate: (values: T[]) => { valid: boolean; errors: string[] },
-): void {
-  if (!values.length) return;
-
-  const validation = validate(values);
-  if (validation.valid) return;
-
-  for (const error of validation.errors) logger.error(error);
-
-  throw toError(
-    createError({
-      type: "config",
-      message: `Invalid ${kind} specified`,
-    }),
-  );
-}
-
-function dedupeEnvVars(envVars: EnvVarConfig[]): EnvVarConfig[] {
-  const seen = new Set<string>();
-  return envVars.filter(({ name }) => {
-    if (seen.has(name)) return false;
-    seen.add(name);
-    return true;
-  });
-}
 
 type StructureNode = {
   file: boolean;
@@ -328,238 +175,85 @@ export async function initCommand(
   }
 
   const runtime: InitRuntime = options.runtime ?? wizardRuntime;
-  // Map runtime to package-manager preference. "node" → "npm" so an explicit
-  // --runtime node always uses npm regardless of lockfiles or user agent;
-  // "bun"/"deno" force the matching pm.
-  const pmPreference: PackageManager = runtime === "node" ? "npm" : runtime;
-
   const projectDir = projectName ? join(parentDir, projectName) : parentDir;
-  const fs = createFileSystem();
-
-  validateOrThrow("features", features, validateFeatures);
-  validateOrThrow("integrations", integrations, validateIntegrations);
-
-  if (projectName && (await fs.exists(projectDir)) && !options.force) {
-    throw toError(
-      createError({
-        type: "config",
-        message:
-          `Directory "${projectName}" already exists. Choose a different name or use --force to overwrite.`,
-      }),
-    );
-  }
-
-  const { getAiRuleTemplate, getTemplate, getTemplateConfig } = await import(
-    "../../templates/index.ts"
-  );
-
-  let templateFiles = await getTemplate(template);
-  const templateConfig = getTemplateConfig(template);
-
-  if (!templateFiles) {
-    throw toError(
-      createError({
-        type: "config",
-        message: `Template ${template} not found`,
-      }),
-    );
-  }
-
-  const agentsGuide = getAiRuleTemplate("agents.md");
-  if (!agentsGuide) {
-    throw toError(
-      createError({
-        type: "config",
-        message: "Project agent guide template not found",
-      }),
-    );
-  }
-
-  if (!templateFiles.some((file) => file.path === "AGENTS.md")) {
-    templateFiles = mergeFiles(templateFiles, [
-      { path: "AGENTS.md", content: agentsGuide },
-    ]);
-  }
-
-  const allEnvVars: EnvVarConfig[] = templateConfig?.envVars ? [...templateConfig.envVars] : [];
-  const featureTips: string[] = [];
-  let loadedIntegrations: ResolvedIntegration[] = [];
-
-  if (features.length) {
-    const { ordered, errors } = await resolveFeatures(features);
-    if (errors.length) {
-      for (const error of errors) logger.error(error);
+  if (projectName && !options.force) {
+    const fs = createFileSystem();
+    if (await fs.exists(projectDir)) {
       throw toError(
         createError({
           type: "config",
-          message: "Failed to resolve features",
+          message:
+            `Directory "${projectName}" already exists. Choose a different name or use --force to overwrite.`,
         }),
       );
     }
+  }
 
-    logger.debug(`Resolved feature order: ${ordered.join(" -> ")}`);
-
-    for (const featureName of ordered) {
-      const feature = await loadFeature(featureName);
-      if (!feature) {
-        logger.warn(`Feature ${featureName} not found, skipping`);
-        continue;
+  let installSpinner: ReturnType<typeof createTransientSpinner> | null = null;
+  const installObserver: ProjectCreationObserver = {
+    onEvent(event) {
+      if (event.kind === "dependency-installation-started") {
+        installSpinner = quiet
+          ? null
+          : createTransientSpinner(`Installing dependencies with ${event.packageManager}...`);
+        return;
       }
 
-      logger.debug(`Loading feature: ${featureName} (${feature.files.length} files)`);
-      templateFiles = mergeFiles(templateFiles, feature.files);
+      if (event.status === "installed") {
+        installSpinner?.success("Dependencies installed");
+        return;
+      }
 
-      if (feature.config.envVars) allEnvVars.push(...feature.config.envVars);
-      if (feature.config.tips) featureTips.push(...feature.config.tips);
-    }
-  }
-
-  if (integrations.length) {
-    logger.debug(`Loading integrations: ${integrations.join(", ")}`);
-
-    templateFiles = mergeFiles(templateFiles, getIntegrationBaseFiles());
-    templateFiles = mergeFiles(templateFiles, await loadIntegrationBaseFilesFromDirectory());
-
-    const baseConfig = await loadIntegrationBaseConfig();
-    if (baseConfig?.envVars) allEnvVars.push(...baseConfig.envVars);
-
-    const {
-      integrations: resolvedIntegrations,
-      files: integrationFiles,
-      errors: integrationErrors,
-    } = await loadIntegrations(integrations);
-    loadedIntegrations = resolvedIntegrations;
-
-    if (integrationErrors.length) {
-      for (const error of integrationErrors) logger.warn(error);
-    }
-
-    templateFiles = mergeFiles(templateFiles, integrationFiles);
-
-    for (const integration of loadedIntegrations) {
-      if (integration.config.envVars) allEnvVars.push(...integration.config.envVars);
-    }
-
-    templateFiles = mergeFiles(templateFiles, [
-      {
-        path: "app/api/integrations/status/route.ts",
-        content: generateIntegrationsStatusRoute(loadedIntegrations),
-      },
-    ]);
-
-    logger.debug(
-      `Loaded ${loadedIntegrations.length} integrations with ${integrationFiles.length} files`,
-    );
-
-    featureTips.push(`Integrations loaded: ${integrations.join(", ")}`);
-    featureTips.push("Visit /setup for guided OAuth app setup");
-    featureTips.push("Connect services at /api/auth/<service>");
-  }
-
-  if (projectName) await ensureDir(projectDir);
-
-  const createdPaths: string[] = [];
-  for (const file of templateFiles as TemplateFile[]) {
-    if (file.path === ".env" || file.path === ".env.example") continue;
-
-    const filePath = join(projectDir, file.path);
-    const fileDir = join(projectDir, ...file.path.split("/").slice(0, -1));
-
-    if (fileDir !== projectDir) await ensureDir(fileDir);
-
-    await fs.writeTextFile(filePath, file.content);
-    createdPaths.push(file.path);
-    logger.debug(`Created file: ${file.path}`);
-  }
-
-  // Skip in quiet/TUI mode since local dev uses CDN and package.json can cause hydration issues
-  if (!options.quiet) {
-    await createPackageJson(projectDir, projectName, {
-      dependencies: templateConfig?.npmDependencies,
-      firstPartyExtensions: templateConfig?.firstPartyExtensions,
-      integrations: loadedIntegrations.map((integration) => ({
-        name: integration.config.name,
-        npmDependencies: integration.config.npmDependencies,
-      })),
-    });
-    createdPaths.push("package.json");
-    if (runtime === "deno") {
-      await createDenoConfig(projectDir);
-      createdPaths.push("deno.json");
-    }
-  }
-
-  if (allEnvVars.length) {
-    const envResult = await promptForEnvVars(dedupeEnvVars(allEnvVars), {
-      skipPrompt: options.skipEnvPrompt,
-      prefilledValues: options.env,
-    });
-
-    await fs.writeTextFile(join(projectDir, ".env"), envResult.envContent);
-    createdPaths.push(".env");
-    logger.debug("Created file: .env");
-
-    await fs.writeTextFile(join(projectDir, ".env.example"), envResult.envExampleContent);
-    createdPaths.push(".env.example");
-    logger.debug("Created file: .env.example");
-  }
-
-  const gitignorePath = join(projectDir, ".gitignore");
-  let existingGitignore: string | undefined;
-  try {
-    existingGitignore = await fs.readTextFile(gitignorePath);
-  } catch {
-    existingGitignore = undefined;
-  }
-
-  await fs.writeTextFile(gitignorePath, generateGitignoreContent(existingGitignore));
-  createdPaths.push(".gitignore");
-  logger.debug("Updated file: .gitignore");
-
-  (options as InitOptions & { _featureTips?: string[] })._featureTips = featureTips;
-
-  if (!options.skipInstall) {
-    const pm = await detectPackageManager(projectDir, pmPreference);
-    const installSpinner = quiet
-      ? null
-      : createTransientSpinner(`Installing dependencies with ${pm}...`);
-    const installSuccess = await installDependencies(projectDir, {
-      silent: true,
-      packageManager: pm,
-    });
-
-    if (installSuccess) {
-      installSpinner?.success("Dependencies installed");
-    } else {
       installSpinner?.error("Dependency installation failed");
       if (!quiet) {
-        logger.warn(`Run '${getInstallCommand(pm)}' manually to install dependencies.`);
+        logger.warn(
+          `Run '${getInstallCommand(event.packageManager)}' manually to install dependencies.`,
+        );
       }
-    }
+    },
+  };
+
+  const result = await createProject(
+    {
+      name: projectName,
+      parentDir,
+      template,
+      runtime,
+      features,
+      integrations,
+      environmentValues: options.env ?? {},
+      conflictPolicy: options.force ? "overwrite" : "fail",
+      installDependencies: !options.skipInstall,
+      initializeGit: initGit,
+      includePackageMetadata: !quiet,
+    },
+    {
+      observer: installObserver,
+      resolveEnvironmentFiles: (variables, values) =>
+        promptForEnvVars(variables, {
+          skipPrompt: options.skipEnvPrompt,
+          prefilledValues: values,
+        }),
+    },
+  );
+
+  if (result.gitInitialization === "failed" && !quiet) {
+    logger.warn("Git initialization failed");
   }
 
-  // Initialize git if requested
-  if (initGit) {
-    try {
-      const { initializeGitRepo } = await import("../../utils/git.ts");
-      const success = await initializeGitRepo(projectDir, projectName ?? "veryfront project");
-      if (!success && !quiet) logger.warn("Git initialization failed");
-    } catch {
-      if (!quiet) logger.warn("Git initialization failed");
-    }
-  }
+  const createdProjectDir = result.projectDir;
 
   // Deploy to cloud if --deploy flag is set
   let deployedUrl: string | undefined;
   const manualDeployCommand = quiet
-    ? `${getDlxCommand(pmPreference)} veryfront deploy`
-    : getRunCommand(pmPreference, "deploy");
+    ? `${getDlxCommand(result.packageManager)} veryfront deploy`
+    : getRunCommand(result.packageManager, "deploy");
   if (options.deploy) {
     const manualDeployHint = `Run ${brand(manualDeployCommand)} to deploy later.`;
 
     if (dependencies.deployProject) {
       try {
-        deployedUrl = await dependencies.deployProject(projectDir);
+        deployedUrl = await dependencies.deployProject(createdProjectDir);
         if (!deployedUrl) {
           throw new Error("Deploy completed without a verified result.");
         }
@@ -588,10 +282,10 @@ export async function initCommand(
           log(`  Deploying project...`);
 
           try {
-            chdir(projectDir);
+            chdir(createdProjectDir);
 
             const deployment = await deployCommand({
-              projectDir,
+              projectDir: createdProjectDir,
               branch: "main",
               env: "production",
               force: true,
@@ -615,7 +309,7 @@ export async function initCommand(
   }
 
   // Build success box with next steps
-  const pm = await detectPackageManager(projectDir, pmPreference);
+  const pm = result.packageManager;
   const devCommand = getRunCommand(pm, "dev");
 
   const localSteps: string[] = [];
@@ -629,7 +323,7 @@ export async function initCommand(
 
   const displayName = projectName ?? "Project";
   const structureRoot = projectName ?? ".";
-  const structureLines = renderProjectStructure(structureRoot, createdPaths);
+  const structureLines = renderProjectStructure(structureRoot, result.createdPaths);
   const deployCommandHint = getRunCommand(pm, "deploy");
 
   if (!quiet) {
@@ -658,9 +352,8 @@ export async function initCommand(
     }
 
     const tips: string[] = [];
-    const displayFeatureTips = (options as InitOptions & { _featureTips?: string[] })._featureTips;
-    if (displayFeatureTips?.length) {
-      for (const tip of displayFeatureTips) {
+    if (result.featureTips.length) {
+      for (const tip of result.featureTips) {
         tips.push(dim(tip));
       }
     }

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -13,12 +13,9 @@ import { cwd } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import { getDlxCommand, getInstallCommand, getRunCommand } from "../../utils/package-manager.ts";
 import { createProject, type ProjectCreationObserver } from "../../shared/project-creation.ts";
+import { validateProjectName } from "../../shared/project-name.ts";
 import { promptForEnvVars } from "../../utils/env-prompt.ts";
-import {
-  runInteractiveWizard,
-  shouldRunWizard,
-  validateProjectName,
-} from "./interactive-wizard.ts";
+import { runInteractiveWizard, shouldRunWizard } from "./interactive-wizard.ts";
 import { DEFAULT_TEMPLATE } from "./catalog.ts";
 
 type StructureNode = {

--- a/cli/commands/init/interactive-wizard.test.ts
+++ b/cli/commands/init/interactive-wizard.test.ts
@@ -6,12 +6,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import {
-  formatWizardIntro,
-  SETUP_COPY,
-  shouldRunWizard,
-  validateProjectName,
-} from "./interactive-wizard.ts";
+import { formatWizardIntro, SETUP_COPY, shouldRunWizard } from "./interactive-wizard.ts";
 
 describe("interactive-wizard", () => {
   it("starts directly with the setup task", () => {
@@ -23,32 +18,6 @@ describe("interactive-wizard", () => {
     assertEquals(SETUP_COPY.template, "Choose a starter template:");
     assertEquals(SETUP_COPY.runtime, "Select runtime:");
     assertEquals(SETUP_COPY.git, "Initialize Git?");
-  });
-
-  describe("validateProjectName", () => {
-    it("should accept a simple name", () => {
-      assertEquals(validateProjectName("my-app"), null);
-    });
-
-    it("should reject forward slashes", () => {
-      assertEquals(typeof validateProjectName("foo/bar"), "string");
-    });
-
-    it("should reject backslashes", () => {
-      assertEquals(typeof validateProjectName("foo\\bar"), "string");
-    });
-
-    it("should reject dot-dot", () => {
-      assertEquals(typeof validateProjectName(".."), "string");
-    });
-
-    it("should reject single dot", () => {
-      assertEquals(typeof validateProjectName("."), "string");
-    });
-
-    it("should accept dotfiles", () => {
-      assertEquals(validateProjectName(".my-app"), null);
-    });
   });
 
   describe("shouldRunWizard", () => {

--- a/cli/commands/init/interactive-wizard.ts
+++ b/cli/commands/init/interactive-wizard.ts
@@ -2,16 +2,12 @@ import { muted } from "#cli/ui";
 import { isCiEnv, isDenoTestingEnv } from "veryfront/config";
 import { isInteractive as checkIsInteractive } from "veryfront/platform";
 import { isInteractive as isCliInteractive } from "../../shared/interactive.ts";
+import { validateProjectName } from "../../shared/project-name.ts";
 import { select, textInput } from "../../utils/terminal-select.ts";
 import { DEFAULT_TEMPLATE, getTemplateSelectOptions } from "./catalog.ts";
 import type { InitRuntime, InitTemplate } from "./types.ts";
 
-/** Reject path separators and traversal so the name stays a single directory. */
-export function validateProjectName(name: string): string | null {
-  if (/[/\\]/.test(name)) return 'Project name cannot contain "/" or "\\"';
-  if (name === "." || name === "..") return 'Project name cannot be "." or ".."';
-  return null;
-}
+export { validateProjectName } from "../../shared/project-name.ts";
 
 export interface WizardResult {
   projectName: string | null; // null = use current directory

--- a/cli/commands/init/interactive-wizard.ts
+++ b/cli/commands/init/interactive-wizard.ts
@@ -7,7 +7,7 @@ import { select, textInput } from "../../utils/terminal-select.ts";
 import { DEFAULT_TEMPLATE, getTemplateSelectOptions } from "./catalog.ts";
 import type { InitRuntime, InitTemplate } from "./types.ts";
 
-export { validateProjectName } from "../../shared/project-name.ts";
+export { validateProjectName };
 
 export interface WizardResult {
   projectName: string | null; // null = use current directory

--- a/cli/mcp/tools/catalog-tools.test.ts
+++ b/cli/mcp/tools/catalog-tools.test.ts
@@ -245,5 +245,20 @@ describe("mcp/tools/catalog-tools", () => {
       assertEquals(result.projectDir, undefined);
       assertEquals(result.message.includes("cannot contain"), true);
     });
+
+    it("reports an empty project name before checking the parent directory", async () => {
+      const parentDir = await Deno.makeTempDir();
+      createdDirs.push(parentDir);
+
+      const result = await vfCreateProject.execute({
+        name: "",
+        template: "minimal",
+        directory: parentDir,
+      });
+
+      assertEquals(result.success, false);
+      assertEquals(result.projectDir, undefined);
+      assertEquals(result.message, "Failed to create project: Project name cannot be empty");
+    });
   });
 });

--- a/cli/mcp/tools/catalog-tools.test.ts
+++ b/cli/mcp/tools/catalog-tools.test.ts
@@ -5,6 +5,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "veryfront/platform/path";
 import { EXPERIMENTAL_INTEGRATIONS_ENV } from "../../../src/integrations/feature-flags.ts";
 import {
   resolveCreateProjectPaths,
@@ -14,6 +15,47 @@ import {
   vfListTemplates,
   vfListUsecases,
 } from "./catalog-tools.ts";
+
+async function createFakeNpm(): Promise<string> {
+  const binDir = await Deno.makeTempDir();
+  const logPath = join(binDir, "npm.log");
+  const isWindows = Deno.build.os === "windows";
+  const npmPath = join(binDir, isWindows ? "npm.cmd" : "npm");
+  const script = isWindows
+    ? [
+      "@echo off",
+      `>>"${logPath}" echo %CD% %*`,
+      `>package-lock.json echo {"lockfileVersion":3,"packages":{}}`,
+      "exit /b 0",
+      "",
+    ].join("\r\n")
+    : `#!/usr/bin/env sh
+printf '%s\\n' "$PWD $*" >> "${logPath}"
+printf '%s\\n' '{"lockfileVersion":3,"packages":{}}' > package-lock.json
+exit 0
+`;
+
+  await Deno.writeTextFile(npmPath, script);
+  if (!isWindows) await Deno.chmod(npmPath, 0o755);
+  return binDir;
+}
+
+async function withFakeNpm(action: () => Promise<void>): Promise<void> {
+  const binDir = await createFakeNpm();
+  const pathDelimiter = Deno.build.os === "windows" ? ";" : ":";
+  const originalDenoPath = Deno.env.get("PATH");
+  const nextPath = `${binDir}${pathDelimiter}${originalDenoPath ?? ""}`;
+
+  try {
+    Deno.env.set("PATH", nextPath);
+    await action();
+  } finally {
+    if (originalDenoPath === undefined) Deno.env.delete("PATH");
+    else Deno.env.set("PATH", originalDenoPath);
+
+    await Deno.remove(binDir, { recursive: true }).catch(() => {});
+  }
+}
 
 describe("mcp/tools/catalog-tools", () => {
   afterEach(() => Deno.env.delete(EXPERIMENTAL_INTEGRATIONS_ENV));
@@ -128,6 +170,14 @@ describe("mcp/tools/catalog-tools", () => {
   });
 
   describe("vfCreateProject", () => {
+    const createdDirs: string[] = [];
+
+    afterEach(async () => {
+      for (const dir of createdDirs.splice(0)) {
+        await Deno.remove(dir, { recursive: true }).catch(() => {});
+      }
+    });
+
     it("resolves the requested parent directory and slug once", () => {
       assertEquals(
         resolveCreateProjectPaths({ name: "Example App", directory: "projects" }),
@@ -149,6 +199,39 @@ describe("mcp/tools/catalog-tools", () => {
 
     it("has execute function", () => {
       assertEquals(typeof vfCreateProject.execute, "function");
+    });
+
+    it("returns the created project path and first next step", async () => {
+      const parentDir = await Deno.makeTempDir();
+      createdDirs.push(parentDir);
+
+      await withFakeNpm(async () => {
+        const result = await vfCreateProject.execute({
+          name: "Example App",
+          template: "minimal",
+          directory: parentDir,
+        });
+
+        assertEquals(result.success, true);
+        assertEquals(result.projectDir, join(parentDir, "example-app"));
+        assertEquals(result.nextSteps?.[0], `cd ${join(parentDir, "example-app")}`);
+      });
+    });
+
+    it("keeps the existing-directory failure response", async () => {
+      const parentDir = await Deno.makeTempDir();
+      createdDirs.push(parentDir);
+      const projectDir = join(parentDir, "example-app");
+      await Deno.mkdir(projectDir);
+
+      const result = await vfCreateProject.execute({
+        name: "Example App",
+        template: "minimal",
+        directory: parentDir,
+      });
+
+      assertEquals(result.success, false);
+      assertEquals(result.message, `Directory already exists: ${projectDir}`);
     });
 
     it("reports project-name validation failures", async () => {

--- a/cli/mcp/tools/catalog-tools.ts
+++ b/cli/mcp/tools/catalog-tools.ts
@@ -10,9 +10,11 @@ import { withSpan } from "veryfront/observability/otlp-setup";
 import { connectors } from "../../../src/integrations/_data.ts";
 import { filterVisibleIntegrations } from "../../../src/integrations/feature-flags.ts";
 import { INTEGRATION_CATEGORIES } from "../../commands/init/catalog.ts";
+import { createProject as createSharedProject } from "../../shared/project-creation.ts";
 import type { MCPTool } from "../tools.ts";
 import { directoryExists, formatError, toSlug } from "./helpers.ts";
 import type { InitTemplate } from "../../commands/init/types.ts";
+import type { IntegrationName } from "../../templates/types.ts";
 
 // ============================================================================
 // Static Data
@@ -388,33 +390,34 @@ export const vfCreateProject: MCPTool<CreateProjectInput, CreateProjectResult> =
       "cli.mcp.tool.vf_create_project",
       async () => {
         try {
-          const { initCommand } = await import("../../commands/init/index.ts");
-
           const { name, parentDir, projectDir } = resolveCreateProjectPaths(input);
 
           if (await directoryExists(projectDir)) {
             return { success: false, message: `Directory already exists: ${projectDir}` };
           }
 
-          await initCommand({
+          const creation = await createSharedProject({
             name,
             parentDir,
             template: input.template as InitTemplate,
-            integrations: input.integrations as
-              | import("../../templates/types.ts").IntegrationName[]
-              | undefined,
-            skipInstall: false,
-            skipEnvPrompt: true,
+            runtime: "node",
+            features: [],
+            integrations: (input.integrations ?? []) as IntegrationName[],
+            environmentValues: {},
+            conflictPolicy: "fail",
+            installDependencies: true,
+            initializeGit: false,
+            includePackageMetadata: true,
           });
 
-          const nextSteps = [`cd ${projectDir}`, "deno task dev"];
+          const nextSteps = [`cd ${creation.projectDir}`, "deno task dev"];
           if (input.integrations?.length) {
             nextSteps.push("Configure integration credentials in .env");
           }
 
           return {
             success: true,
-            projectDir,
+            projectDir: creation.projectDir,
             message: `Created project "${input.name}" with ${input.template} template`,
             nextSteps,
           };

--- a/cli/mcp/tools/catalog-tools.ts
+++ b/cli/mcp/tools/catalog-tools.ts
@@ -11,6 +11,7 @@ import { connectors } from "../../../src/integrations/_data.ts";
 import { filterVisibleIntegrations } from "../../../src/integrations/feature-flags.ts";
 import { INTEGRATION_CATEGORIES } from "../../commands/init/catalog.ts";
 import { createProject as createSharedProject } from "../../shared/project-creation.ts";
+import { validateProjectName } from "../../shared/project-name.ts";
 import type { MCPTool } from "../tools.ts";
 import { directoryExists, formatError, toSlug } from "./helpers.ts";
 import type { InitTemplate } from "../../commands/init/types.ts";
@@ -391,6 +392,10 @@ export const vfCreateProject: MCPTool<CreateProjectInput, CreateProjectResult> =
       async () => {
         try {
           const { name, parentDir, projectDir } = resolveCreateProjectPaths(input);
+          const nameError = validateProjectName(name);
+          if (nameError) {
+            return { success: false, message: `Failed to create project: ${nameError}` };
+          }
 
           if (await directoryExists(projectDir)) {
             return { success: false, message: `Directory already exists: ${projectDir}` };

--- a/cli/shared/project-creation.test.ts
+++ b/cli/shared/project-creation.test.ts
@@ -10,6 +10,46 @@ import {
   type ProjectCreationEvent,
 } from "./project-creation.ts";
 
+async function withGitIdentity(action: () => Promise<void>): Promise<void> {
+  const processEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env;
+  const keys = [
+    "GIT_AUTHOR_NAME",
+    "GIT_AUTHOR_EMAIL",
+    "GIT_COMMITTER_NAME",
+    "GIT_COMMITTER_EMAIL",
+  ];
+  const originalDenoEnv = new Map(keys.map((key) => [key, Deno.env.get(key)]));
+  const originalProcessEnv = new Map(keys.map((key) => [key, processEnv?.[key]]));
+
+  try {
+    const env = {
+      GIT_AUTHOR_NAME: "Veryfront Tests",
+      GIT_AUTHOR_EMAIL: "tests@example.invalid",
+      GIT_COMMITTER_NAME: "Veryfront Tests",
+      GIT_COMMITTER_EMAIL: "tests@example.invalid",
+    };
+    for (const [key, value] of Object.entries(env)) {
+      Deno.env.set(key, value);
+      if (processEnv) processEnv[key] = value;
+    }
+
+    await action();
+  } finally {
+    for (const key of keys) {
+      const denoValue = originalDenoEnv.get(key);
+      if (denoValue === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, denoValue);
+
+      if (processEnv) {
+        const processValue = originalProcessEnv.get(key);
+        if (processValue === undefined) delete processEnv[key];
+        else processEnv[key] = processValue;
+      }
+    }
+  }
+}
+
 function baseRequest(parentDir: string): CreateProjectRequest {
   return {
     name: "contract-project",
@@ -66,6 +106,58 @@ describe("createProject", () => {
       assertEquals(overwritten.projectDir, result.projectDir);
     } finally {
       await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("rejects invalid project names before writing inside or outside parentDir", async () => {
+    const cases = [
+      {
+        name: "nested/project",
+        message: 'Project name cannot contain "/" or "\\"',
+        forbiddenPath: ["parent", "nested"],
+      },
+      {
+        name: "nested\\project",
+        message: 'Project name cannot contain "/" or "\\"',
+        forbiddenPath: ["parent", "nested\\project"],
+      },
+      {
+        name: ".",
+        message: 'Project name cannot be "." or ".."',
+        forbiddenPath: ["parent", "app"],
+      },
+      {
+        name: "..",
+        message: 'Project name cannot be "." or ".."',
+        forbiddenPath: ["app"],
+      },
+      {
+        name: "../vf-escape-probe",
+        message: 'Project name cannot contain "/" or "\\"',
+        forbiddenPath: ["vf-escape-probe"],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const rootDir = await makeTempDir({ prefix: "veryfront-create-invalid-name-" });
+      const parentDir = join(rootDir, "parent");
+
+      try {
+        await assertRejects(
+          () =>
+            createProject({
+              ...baseRequest(parentDir),
+              name: testCase.name,
+              conflictPolicy: "overwrite",
+            }),
+          Error,
+          testCase.message,
+        );
+
+        assertEquals(await exists(join(rootDir, ...testCase.forbiddenPath)), false);
+      } finally {
+        await remove(rootDir, { recursive: true }).catch(() => {});
+      }
     }
   });
 
@@ -148,20 +240,19 @@ describe("createProject", () => {
 
   it("emits dependency installation observer events and installed status", async () => {
     const parentDir = await makeTempDir({ prefix: "veryfront-create-install-" });
-    const binDir = await makeTempDir({ prefix: "veryfront-create-bin-" });
-    const originalPath = Deno.env.get("PATH");
     const events: ProjectCreationEvent[] = [];
+    const projectDir = join(parentDir, "install-events");
 
     try {
-      const fakeNpm = join(binDir, "npm");
-      await Deno.writeTextFile(fakeNpm, "#!/bin/sh\nexit 0\n");
-      await Deno.chmod(fakeNpm, 0o755);
-      Deno.env.set("PATH", `${binDir}${originalPath ? `:${originalPath}` : ""}`);
+      await Deno.mkdir(projectDir, { recursive: true });
+      await Deno.writeTextFile(join(projectDir, "package.json"), "{}\n");
 
       const result = await createProject({
         ...baseRequest(parentDir),
         name: "install-events",
+        conflictPolicy: "overwrite",
         installDependencies: true,
+        includePackageMetadata: false,
       }, {
         observer: {
           onEvent(event) {
@@ -180,10 +271,118 @@ describe("createProject", () => {
         },
       ]);
     } finally {
-      if (originalPath === undefined) Deno.env.delete("PATH");
-      else Deno.env.set("PATH", originalPath);
       await remove(parentDir, { recursive: true }).catch(() => {});
-      await remove(binDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("emits dependency installation observer events and failed status", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-install-failed-" });
+    const events: ProjectCreationEvent[] = [];
+    const projectDir = join(parentDir, "install-failed");
+
+    try {
+      await Deno.mkdir(projectDir, { recursive: true });
+      await Deno.writeTextFile(join(projectDir, "package.json"), "{");
+
+      const result = await createProject({
+        ...baseRequest(parentDir),
+        name: "install-failed",
+        conflictPolicy: "overwrite",
+        installDependencies: true,
+        includePackageMetadata: false,
+      }, {
+        observer: {
+          onEvent(event) {
+            events.push(event);
+          },
+        },
+      });
+
+      assertEquals(result.dependencyInstallation, "failed");
+      assertEquals(events, [
+        { kind: "dependency-installation-started", packageManager: "npm" },
+        {
+          kind: "dependency-installation-finished",
+          packageManager: "npm",
+          status: "failed",
+        },
+      ]);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("returns initialized Git state when Git initialization succeeds", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-git-ok-" });
+
+    try {
+      await withGitIdentity(async () => {
+        const result = await createProject({
+          ...baseRequest(parentDir),
+          name: "git-initialized",
+          initializeGit: true,
+        });
+
+        assertEquals(result.gitInitialization, "initialized");
+        assertEquals(await exists(join(parentDir, "git-initialized", ".git")), true);
+      });
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("returns failed Git state when Git initialization fails", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-git-failed-" });
+    const projectDir = join(parentDir, "git-failed");
+
+    try {
+      await Deno.mkdir(projectDir, { recursive: true });
+      await Deno.writeTextFile(join(projectDir, ".git"), "not a git directory\n");
+
+      const result = await createProject({
+        ...baseRequest(parentDir),
+        name: "git-failed",
+        conflictPolicy: "overwrite",
+        initializeGit: true,
+      });
+
+      assertEquals(result.gitInitialization, "failed");
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("maps runtime to deterministic package manager preferences", async () => {
+    const cases: Array<{
+      runtime: CreateProjectRequest["runtime"];
+      packageManager: string;
+      createdPath: string;
+    }> = [
+      { runtime: "node", packageManager: "npm", createdPath: "package.json" },
+      { runtime: "bun", packageManager: "bun", createdPath: "package.json" },
+      { runtime: "deno", packageManager: "deno", createdPath: "deno.json" },
+    ];
+
+    for (const testCase of cases) {
+      const parentDir = await makeTempDir({
+        prefix: `veryfront-create-runtime-${testCase.runtime}-`,
+      });
+
+      try {
+        const result = await createProject({
+          ...baseRequest(parentDir),
+          name: `${testCase.runtime}-project`,
+          runtime: testCase.runtime,
+        });
+
+        assertEquals(result.packageManager, testCase.packageManager);
+        assertEquals(result.createdPaths.includes(testCase.createdPath), true);
+        if (testCase.runtime === "deno") {
+          assertEquals(await exists(join(parentDir, "deno-project", "deno.json")), true);
+        }
+      } finally {
+        await remove(parentDir, { recursive: true }).catch(() => {});
+      }
     }
   });
 });

--- a/cli/shared/project-creation.test.ts
+++ b/cli/shared/project-creation.test.ts
@@ -161,6 +161,28 @@ describe("createProject", () => {
     }
   });
 
+  it("rejects an unknown template without creating the target directory", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-invalid-template-" });
+    const projectDir = join(parentDir, "invalid-template");
+
+    try {
+      await assertRejects(
+        () =>
+          createProject({
+            ...baseRequest(parentDir),
+            name: "invalid-template",
+            template: "missing-template" as CreateProjectRequest["template"],
+          }),
+        Error,
+        "Template missing-template not found",
+      );
+
+      assertEquals(await exists(projectDir), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
   it("omits package metadata when package metadata is disabled", async () => {
     const parentDir = await makeTempDir({ prefix: "veryfront-create-metadata-" });
 

--- a/cli/shared/project-creation.test.ts
+++ b/cli/shared/project-creation.test.ts
@@ -112,6 +112,16 @@ describe("createProject", () => {
   it("rejects invalid project names before writing inside or outside parentDir", async () => {
     const cases = [
       {
+        name: "",
+        message: "Project name cannot be empty",
+        forbiddenPath: ["parent", "app"],
+      },
+      {
+        name: "   ",
+        message: "Project name cannot be empty",
+        forbiddenPath: ["parent", "   "],
+      },
+      {
         name: "nested/project",
         message: 'Project name cannot contain "/" or "\\"',
         forbiddenPath: ["parent", "nested"],

--- a/cli/shared/project-creation.test.ts
+++ b/cli/shared/project-creation.test.ts
@@ -1,0 +1,189 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { exists, makeTempDir, remove } from "#veryfront/testing/deno-compat.ts";
+import { join } from "veryfront/platform/path";
+import {
+  createProject,
+  type CreateProjectRequest,
+  type ProjectCreationEvent,
+} from "./project-creation.ts";
+
+function baseRequest(parentDir: string): CreateProjectRequest {
+  return {
+    name: "contract-project",
+    parentDir,
+    template: "minimal",
+    runtime: "node",
+    features: [],
+    integrations: [],
+    environmentValues: {},
+    conflictPolicy: "fail",
+    installDependencies: false,
+    initializeGit: false,
+    includePackageMetadata: true,
+  };
+}
+
+describe("createProject", () => {
+  it("returns the structured creation result for a minimal named project", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-contract-" });
+
+    try {
+      const result = await createProject(baseRequest(parentDir));
+
+      assertEquals(result.projectDir, join(parentDir, "contract-project"));
+      assertEquals(result.projectName, "contract-project");
+      assertEquals(result.packageManager, "npm");
+      assertEquals(result.dependencyInstallation, "skipped");
+      assertEquals(result.gitInitialization, "skipped");
+      assertEquals(result.createdPaths.includes("app/page.tsx"), true);
+      assertEquals(result.createdPaths.includes("package.json"), true);
+      assertEquals(result.createdPaths.includes(".gitignore"), true);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("fails or overwrites an existing project directory from the conflict policy", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-conflict-" });
+    const request = baseRequest(parentDir);
+
+    try {
+      const result = await createProject(request);
+
+      await assertRejects(
+        () => createProject({ ...request, conflictPolicy: "fail" }),
+        Error,
+        'Directory "contract-project" already exists',
+      );
+
+      const overwritten = await createProject({
+        ...request,
+        conflictPolicy: "overwrite",
+      });
+      assertEquals(overwritten.projectDir, result.projectDir);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("omits package metadata when package metadata is disabled", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-metadata-" });
+
+    try {
+      const metadataFree = await createProject({
+        ...baseRequest(parentDir),
+        name: "metadata-free",
+        includePackageMetadata: false,
+      });
+
+      assertEquals(metadataFree.createdPaths.includes("package.json"), false);
+      assertEquals(await exists(join(parentDir, "metadata-free", "package.json")), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("writes resolved environment files for integration environment variables", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-env-" });
+    const calls: string[][] = [];
+
+    try {
+      const result = await createProject({
+        ...baseRequest(parentDir),
+        name: "github-env",
+        integrations: ["github"],
+        environmentValues: {
+          GITHUB_CLIENT_ID: "client-id",
+          GITHUB_CLIENT_SECRET: "client-secret",
+        },
+      }, {
+        resolveEnvironmentFiles: (variables, values) => {
+          calls.push(variables.map((variable) => variable.name));
+          assertEquals(values.GITHUB_CLIENT_ID, "client-id");
+          assertEquals(values.GITHUB_CLIENT_SECRET, "client-secret");
+          return Promise.resolve({
+            envContent: "GITHUB_CLIENT_ID=client-id\nGITHUB_CLIENT_SECRET=client-secret\n",
+            envExampleContent:
+              "GITHUB_CLIENT_ID=your-client-id\nGITHUB_CLIENT_SECRET=your-secret\n",
+          });
+        },
+      });
+
+      assertEquals(calls, [["APP_URL", "GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET"]]);
+      assertEquals(result.createdPaths.includes(".env"), true);
+      assertEquals(result.createdPaths.includes(".env.example"), true);
+
+      const envContent = await Deno.readTextFile(join(parentDir, "github-env", ".env"));
+      const envExampleContent = await Deno.readTextFile(
+        join(parentDir, "github-env", ".env.example"),
+      );
+      assertStringIncludes(envContent, "GITHUB_CLIENT_ID=client-id");
+      assertStringIncludes(envExampleContent, "GITHUB_CLIENT_SECRET=your-secret");
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("returns feature tips assembled from selected features", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-tips-" });
+
+    try {
+      const result = await createProject({
+        ...baseRequest(parentDir),
+        name: "feature-tips",
+        features: ["ai"],
+      });
+
+      assertEquals(
+        result.featureTips.includes("The AG-UI endpoint is available at /api/ag-ui"),
+        true,
+      );
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("emits dependency installation observer events and installed status", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-install-" });
+    const binDir = await makeTempDir({ prefix: "veryfront-create-bin-" });
+    const originalPath = Deno.env.get("PATH");
+    const events: ProjectCreationEvent[] = [];
+
+    try {
+      const fakeNpm = join(binDir, "npm");
+      await Deno.writeTextFile(fakeNpm, "#!/bin/sh\nexit 0\n");
+      await Deno.chmod(fakeNpm, 0o755);
+      Deno.env.set("PATH", `${binDir}${originalPath ? `:${originalPath}` : ""}`);
+
+      const result = await createProject({
+        ...baseRequest(parentDir),
+        name: "install-events",
+        installDependencies: true,
+      }, {
+        observer: {
+          onEvent(event) {
+            events.push(event);
+          },
+        },
+      });
+
+      assertEquals(result.dependencyInstallation, "installed");
+      assertEquals(events, [
+        { kind: "dependency-installation-started", packageManager: "npm" },
+        {
+          kind: "dependency-installation-finished",
+          packageManager: "npm",
+          status: "installed",
+        },
+      ]);
+    } finally {
+      if (originalPath === undefined) Deno.env.delete("PATH");
+      else Deno.env.set("PATH", originalPath);
+      await remove(parentDir, { recursive: true }).catch(() => {});
+      await remove(binDir, { recursive: true }).catch(() => {});
+    }
+  });
+});

--- a/cli/shared/project-creation.ts
+++ b/cli/shared/project-creation.ts
@@ -5,7 +5,6 @@ import { join } from "veryfront/platform/path";
 import { ensureDir } from "#std/fs.ts";
 import { createDenoConfig } from "../commands/init/deno-config-generator.ts";
 import { createPackageJson } from "../commands/init/config-generator.ts";
-import { validateProjectName } from "../commands/init/interactive-wizard.ts";
 import type { InitRuntime, InitTemplate } from "../commands/init/types.ts";
 import {
   type EnvPromptResult,
@@ -37,6 +36,7 @@ import type {
   ResolvedIntegration,
   TemplateFile,
 } from "../templates/types.ts";
+import { validateProjectName } from "./project-name.ts";
 
 export interface CreateProjectRequest {
   name?: string;
@@ -462,8 +462,6 @@ export async function createProject(
     throw createConfigError(`Directory "${projectName}" already exists`);
   }
 
-  if (projectName) await ensureDir(projectDir);
-
   const template = await loadTemplateFiles(request.template);
   const allEnvVars = [...template.envVars];
 
@@ -477,6 +475,8 @@ export async function createProject(
     featureAssembly.files,
     allEnvVars,
   );
+
+  if (projectName) await ensureDir(projectDir);
 
   const createdPaths = await writeScaffoldFiles(projectDir, integrationAssembly.files);
   const featureTips = [...featureAssembly.tips, ...integrationAssembly.tips];

--- a/cli/shared/project-creation.ts
+++ b/cli/shared/project-creation.ts
@@ -1,4 +1,5 @@
 import { createError, toError } from "veryfront/errors";
+import { cliLogger as logger } from "#cli/utils";
 import { createFileSystem } from "veryfront/platform";
 import { join } from "veryfront/platform/path";
 import { ensureDir } from "#std/fs.ts";
@@ -190,6 +191,8 @@ function validateOrThrow<T extends string>(
   const validation = validate(values);
   if (validation.valid) return;
 
+  for (const error of validation.errors) logger.error(error);
+
   throw createConfigError(`Invalid ${kind} specified`);
 }
 
@@ -246,11 +249,21 @@ async function assembleFeatureFiles(
   if (!features.length) return { files, tips };
 
   const { ordered, errors } = await resolveFeatures(features);
-  if (errors.length) throw createConfigError("Failed to resolve features");
+  if (errors.length) {
+    for (const error of errors) logger.error(error);
+    throw createConfigError("Failed to resolve features");
+  }
+
+  logger.debug(`Resolved feature order: ${ordered.join(" -> ")}`);
 
   for (const featureName of ordered) {
     const feature = await loadFeature(featureName);
-    if (!feature) continue;
+    if (!feature) {
+      logger.warn(`Feature ${featureName} not found, skipping`);
+      continue;
+    }
+
+    logger.debug(`Loading feature: ${featureName} (${feature.files.length} files)`);
 
     files = mergeFiles(files, feature.files);
     if (feature.config.envVars) allEnvVars.push(...feature.config.envVars);
@@ -271,6 +284,8 @@ async function assembleIntegrationFiles(
 
   if (!integrations.length) return { files, loadedIntegrations, tips };
 
+  logger.debug(`Loading integrations: ${integrations.join(", ")}`);
+
   files = mergeFiles(files, getIntegrationBaseFiles());
   files = mergeFiles(files, await loadIntegrationBaseFilesFromDirectory());
 
@@ -280,8 +295,13 @@ async function assembleIntegrationFiles(
   const {
     integrations: resolvedIntegrations,
     files: integrationFiles,
+    errors: integrationErrors,
   } = await loadIntegrations(integrations);
   loadedIntegrations = resolvedIntegrations;
+
+  if (integrationErrors.length) {
+    for (const error of integrationErrors) logger.warn(error);
+  }
 
   files = mergeFiles(files, integrationFiles);
 
@@ -295,6 +315,10 @@ async function assembleIntegrationFiles(
       content: generateIntegrationsStatusRoute(loadedIntegrations),
     },
   ]);
+
+  logger.debug(
+    `Loaded ${loadedIntegrations.length} integrations with ${integrationFiles.length} files`,
+  );
 
   tips.push(`Integrations loaded: ${integrations.join(", ")}`);
   tips.push("Visit /setup for guided OAuth app setup");
@@ -320,6 +344,7 @@ async function writeScaffoldFiles(
 
     await fs.writeTextFile(filePath, file.content);
     createdPaths.push(file.path);
+    logger.debug(`Created file: ${file.path}`);
   }
 
   return createdPaths;
@@ -347,7 +372,9 @@ async function writeEnvFiles(
   );
 
   await fs.writeTextFile(join(projectDir, ".env"), envResult.envContent);
+  logger.debug("Created file: .env");
   await fs.writeTextFile(join(projectDir, ".env.example"), envResult.envExampleContent);
+  logger.debug("Created file: .env.example");
   return [".env", ".env.example"];
 }
 
@@ -362,6 +389,7 @@ async function writeGitignore(projectDir: string): Promise<void> {
   }
 
   await fs.writeTextFile(gitignorePath, generateGitignoreContent(existingGitignore));
+  logger.debug("Updated file: .gitignore");
 }
 
 function packageManagerPreference(runtime: InitRuntime): PackageManager {

--- a/cli/shared/project-creation.ts
+++ b/cli/shared/project-creation.ts
@@ -4,6 +4,7 @@ import { join } from "veryfront/platform/path";
 import { ensureDir } from "#std/fs.ts";
 import { createDenoConfig } from "../commands/init/deno-config-generator.ts";
 import { createPackageJson } from "../commands/init/config-generator.ts";
+import { validateProjectName } from "../commands/init/interactive-wizard.ts";
 import type { InitRuntime, InitTemplate } from "../commands/init/types.ts";
 import {
   type EnvPromptResult,
@@ -414,6 +415,11 @@ export async function createProject(
   dependencies: CreateProjectDependencies = {},
 ): Promise<CreateProjectResult> {
   const projectName = request.name;
+  if (projectName) {
+    const nameError = validateProjectName(projectName);
+    if (nameError) throw createConfigError(nameError);
+  }
+
   const projectDir = projectName ? join(request.parentDir, projectName) : request.parentDir;
   const fs = createFileSystem();
 

--- a/cli/shared/project-creation.ts
+++ b/cli/shared/project-creation.ts
@@ -1,0 +1,499 @@
+import { createError, toError } from "veryfront/errors";
+import { createFileSystem } from "veryfront/platform";
+import { join } from "veryfront/platform/path";
+import { ensureDir } from "#std/fs.ts";
+import { createDenoConfig } from "../commands/init/deno-config-generator.ts";
+import { createPackageJson } from "../commands/init/config-generator.ts";
+import type { InitRuntime, InitTemplate } from "../commands/init/types.ts";
+import {
+  type EnvPromptResult,
+  generateGitignoreContent,
+  promptForEnvVars,
+} from "../utils/env-prompt.ts";
+import {
+  detectPackageManager,
+  installDependencies,
+  type PackageManager,
+} from "../utils/package-manager.ts";
+import {
+  getIntegrationBaseFiles,
+  loadIntegrationBaseConfig,
+  loadIntegrationBaseFilesFromDirectory,
+  loadIntegrations,
+  validateIntegrations,
+} from "../templates/integration-loader.ts";
+import {
+  loadFeature,
+  mergeFiles,
+  resolveFeatures,
+  validateFeatures,
+} from "../templates/feature-loader.ts";
+import type {
+  EnvVarConfig,
+  FeatureName,
+  IntegrationName,
+  ResolvedIntegration,
+  TemplateFile,
+} from "../templates/types.ts";
+
+export interface CreateProjectRequest {
+  name?: string;
+  parentDir: string;
+  template: InitTemplate;
+  runtime: InitRuntime;
+  features: FeatureName[];
+  integrations: IntegrationName[];
+  environmentValues: Record<string, string>;
+  conflictPolicy: "fail" | "overwrite";
+  installDependencies: boolean;
+  initializeGit: boolean;
+  includePackageMetadata: boolean;
+}
+
+export interface CreateProjectResult {
+  projectDir: string;
+  projectName?: string;
+  createdPaths: string[];
+  packageManager: PackageManager;
+  dependencyInstallation: "installed" | "failed" | "skipped";
+  gitInitialization: "initialized" | "failed" | "skipped";
+  featureTips: string[];
+}
+
+export type ProjectCreationEvent =
+  | { kind: "dependency-installation-started"; packageManager: PackageManager }
+  | {
+    kind: "dependency-installation-finished";
+    packageManager: PackageManager;
+    status: "installed" | "failed";
+  };
+
+export interface ProjectCreationObserver {
+  onEvent(event: ProjectCreationEvent): void | Promise<void>;
+}
+
+export interface CreateProjectDependencies {
+  observer?: ProjectCreationObserver;
+  resolveEnvironmentFiles?: (
+    variables: EnvVarConfig[],
+    values: Record<string, string>,
+  ) => Promise<Pick<EnvPromptResult, "envContent" | "envExampleContent">>;
+}
+
+const INTEGRATION_ICONS: Record<string, string> = {
+  gmail: "mail",
+  outlook: "mail",
+  slack: "slack",
+  teams: "teams",
+  calendar: "calendar",
+  github: "github",
+  gitlab: "gitlab",
+  bitbucket: "bitbucket",
+  jira: "jira",
+  confluence: "confluence",
+  notion: "notion",
+  linear: "linear",
+  asana: "asana",
+  trello: "trello",
+  monday: "monday",
+  clickup: "clickup",
+  figma: "figma",
+  drive: "drive",
+  onedrive: "onedrive",
+  sharepoint: "sharepoint",
+  box: "box",
+  sheets: "sheets",
+  airtable: "airtable",
+  supabase: "database",
+  neon: "database",
+  snowflake: "database",
+  salesforce: "salesforce",
+  pipedrive: "pipedrive",
+  zendesk: "zendesk",
+  intercom: "intercom",
+  freshdesk: "freshdesk",
+  servicenow: "servicenow",
+  stripe: "stripe",
+  quickbooks: "quickbooks",
+  xero: "xero",
+  shopify: "shopify",
+  mailchimp: "mailchimp",
+  twitter: "twitter",
+  zoom: "zoom",
+  webex: "webex",
+  twilio: "twilio",
+  sentry: "sentry",
+  posthog: "posthog",
+  mixpanel: "mixpanel",
+  anthropic: "ai",
+  aws: "cloud",
+};
+
+function generateIntegrationsStatusRoute(integrations: ResolvedIntegration[]): string {
+  const integrationEntries = integrations
+    .map((integration) => {
+      const icon = INTEGRATION_ICONS[integration.config.name] ?? "default";
+      return `  { id: "${integration.config.name}", name: "${integration.config.displayName}", icon: "${icon}" },`;
+    })
+    .join("\n");
+
+  return `/**
+ * Integration Status API
+ *
+ * Returns the connection status of all configured integrations.
+ * Used by the setup guide to show which services are connected.
+ *
+ * This file is auto-generated based on the integrations you selected.
+ */
+
+import { tokenStore } from "../../../../lib/token-store";
+
+// Integrations configured for this project
+const INTEGRATIONS = [
+${integrationEntries}
+];
+
+export async function GET(_req: Request) {
+  // Get actual user ID from session in production
+  const userId = "current-user";
+
+  const statuses = await Promise.all(
+    INTEGRATIONS.map(async (integration) => {
+      const connected = await tokenStore.isConnected(userId, integration.id);
+      return {
+        id: integration.id,
+        name: integration.name,
+        icon: integration.icon,
+        connected,
+        connectUrl: \`/api/auth/\${integration.id}\`,
+      };
+    }),
+  );
+
+  return Response.json({ integrations: statuses });
+}
+`;
+}
+
+function createConfigError(message: string): Error {
+  return toError(createError({ type: "config", message }));
+}
+
+function validateOrThrow<T extends string>(
+  kind: "features" | "integrations",
+  values: T[],
+  validate: (values: T[]) => { valid: boolean; errors: string[] },
+): void {
+  if (!values.length) return;
+
+  const validation = validate(values);
+  if (validation.valid) return;
+
+  throw createConfigError(`Invalid ${kind} specified`);
+}
+
+function dedupeEnvVars(envVars: EnvVarConfig[]): EnvVarConfig[] {
+  const seen = new Set<string>();
+  return envVars.filter(({ name }) => {
+    if (seen.has(name)) return false;
+    seen.add(name);
+    return true;
+  });
+}
+
+async function loadTemplateFiles(
+  template: InitTemplate,
+): Promise<
+  {
+    files: TemplateFile[];
+    envVars: EnvVarConfig[];
+    dependencies?: Record<string, string>;
+    firstPartyExtensions?: string[];
+  }
+> {
+  const { getAiRuleTemplate, getTemplate, getTemplateConfig } = await import(
+    "../templates/index.ts"
+  );
+
+  let files = await getTemplate(template);
+  const templateConfig = getTemplateConfig(template);
+
+  if (!files) throw createConfigError(`Template ${template} not found`);
+
+  const agentsGuide = getAiRuleTemplate("agents.md");
+  if (!agentsGuide) throw createConfigError("Project agent guide template not found");
+
+  if (!files.some((file) => file.path === "AGENTS.md")) {
+    files = mergeFiles(files, [{ path: "AGENTS.md", content: agentsGuide }]);
+  }
+
+  return {
+    files,
+    envVars: templateConfig?.envVars ? [...templateConfig.envVars] : [],
+    dependencies: templateConfig?.npmDependencies,
+    firstPartyExtensions: templateConfig?.firstPartyExtensions,
+  };
+}
+
+async function assembleFeatureFiles(
+  features: FeatureName[],
+  templateFiles: TemplateFile[],
+  allEnvVars: EnvVarConfig[],
+): Promise<{ files: TemplateFile[]; tips: string[] }> {
+  let files = templateFiles;
+  const tips: string[] = [];
+  if (!features.length) return { files, tips };
+
+  const { ordered, errors } = await resolveFeatures(features);
+  if (errors.length) throw createConfigError("Failed to resolve features");
+
+  for (const featureName of ordered) {
+    const feature = await loadFeature(featureName);
+    if (!feature) continue;
+
+    files = mergeFiles(files, feature.files);
+    if (feature.config.envVars) allEnvVars.push(...feature.config.envVars);
+    if (feature.config.tips) tips.push(...feature.config.tips);
+  }
+
+  return { files, tips };
+}
+
+async function assembleIntegrationFiles(
+  integrations: IntegrationName[],
+  templateFiles: TemplateFile[],
+  allEnvVars: EnvVarConfig[],
+): Promise<{ files: TemplateFile[]; loadedIntegrations: ResolvedIntegration[]; tips: string[] }> {
+  let files = templateFiles;
+  const tips: string[] = [];
+  let loadedIntegrations: ResolvedIntegration[] = [];
+
+  if (!integrations.length) return { files, loadedIntegrations, tips };
+
+  files = mergeFiles(files, getIntegrationBaseFiles());
+  files = mergeFiles(files, await loadIntegrationBaseFilesFromDirectory());
+
+  const baseConfig = await loadIntegrationBaseConfig();
+  if (baseConfig?.envVars) allEnvVars.push(...baseConfig.envVars);
+
+  const {
+    integrations: resolvedIntegrations,
+    files: integrationFiles,
+  } = await loadIntegrations(integrations);
+  loadedIntegrations = resolvedIntegrations;
+
+  files = mergeFiles(files, integrationFiles);
+
+  for (const integration of loadedIntegrations) {
+    if (integration.config.envVars) allEnvVars.push(...integration.config.envVars);
+  }
+
+  files = mergeFiles(files, [
+    {
+      path: "app/api/integrations/status/route.ts",
+      content: generateIntegrationsStatusRoute(loadedIntegrations),
+    },
+  ]);
+
+  tips.push(`Integrations loaded: ${integrations.join(", ")}`);
+  tips.push("Visit /setup for guided OAuth app setup");
+  tips.push("Connect services at /api/auth/<service>");
+
+  return { files, loadedIntegrations, tips };
+}
+
+async function writeScaffoldFiles(
+  projectDir: string,
+  templateFiles: TemplateFile[],
+): Promise<string[]> {
+  const fs = createFileSystem();
+  const createdPaths: string[] = [];
+
+  for (const file of templateFiles) {
+    if (file.path === ".env" || file.path === ".env.example") continue;
+
+    const filePath = join(projectDir, file.path);
+    const fileDir = join(projectDir, ...file.path.split("/").slice(0, -1));
+
+    if (fileDir !== projectDir) await ensureDir(fileDir);
+
+    await fs.writeTextFile(filePath, file.content);
+    createdPaths.push(file.path);
+  }
+
+  return createdPaths;
+}
+
+async function writeEnvFiles(
+  projectDir: string,
+  envVars: EnvVarConfig[],
+  request: CreateProjectRequest,
+  dependencies: CreateProjectDependencies,
+): Promise<string[]> {
+  if (!envVars.length) return [];
+
+  const fs = createFileSystem();
+  const resolveEnvironmentFiles = dependencies.resolveEnvironmentFiles ??
+    ((variables, values) =>
+      promptForEnvVars(variables, {
+        skipPrompt: true,
+        prefilledValues: values,
+      }));
+
+  const envResult = await resolveEnvironmentFiles(
+    dedupeEnvVars(envVars),
+    request.environmentValues,
+  );
+
+  await fs.writeTextFile(join(projectDir, ".env"), envResult.envContent);
+  await fs.writeTextFile(join(projectDir, ".env.example"), envResult.envExampleContent);
+  return [".env", ".env.example"];
+}
+
+async function writeGitignore(projectDir: string): Promise<void> {
+  const fs = createFileSystem();
+  const gitignorePath = join(projectDir, ".gitignore");
+  let existingGitignore: string | undefined;
+  try {
+    existingGitignore = await fs.readTextFile(gitignorePath);
+  } catch {
+    existingGitignore = undefined;
+  }
+
+  await fs.writeTextFile(gitignorePath, generateGitignoreContent(existingGitignore));
+}
+
+function packageManagerPreference(runtime: InitRuntime): PackageManager {
+  return runtime === "node" ? "npm" : runtime;
+}
+
+async function initializeGit(
+  projectDir: string,
+  projectName: string | undefined,
+  enabled: boolean,
+): Promise<CreateProjectResult["gitInitialization"]> {
+  if (!enabled) return "skipped";
+
+  try {
+    const { initializeGitRepo } = await import("../utils/git.ts");
+    return await initializeGitRepo(projectDir, projectName ?? "veryfront project")
+      ? "initialized"
+      : "failed";
+  } catch {
+    return "failed";
+  }
+}
+
+async function installProjectDependencies(
+  projectDir: string,
+  packageManager: PackageManager,
+  enabled: boolean,
+  observer: ProjectCreationObserver | undefined,
+): Promise<CreateProjectResult["dependencyInstallation"]> {
+  if (!enabled) return "skipped";
+
+  await observer?.onEvent({
+    kind: "dependency-installation-started",
+    packageManager,
+  });
+  const installed = await installDependencies(projectDir, {
+    silent: true,
+    packageManager,
+  });
+  const status = installed ? "installed" : "failed";
+  await observer?.onEvent({
+    kind: "dependency-installation-finished",
+    packageManager,
+    status,
+  });
+  return status;
+}
+
+export async function createProject(
+  request: CreateProjectRequest,
+  dependencies: CreateProjectDependencies = {},
+): Promise<CreateProjectResult> {
+  const projectName = request.name;
+  const projectDir = projectName ? join(request.parentDir, projectName) : request.parentDir;
+  const fs = createFileSystem();
+
+  validateOrThrow("features", request.features, validateFeatures);
+  validateOrThrow("integrations", request.integrations, validateIntegrations);
+
+  if (
+    projectName &&
+    request.conflictPolicy === "fail" &&
+    await fs.exists(projectDir)
+  ) {
+    throw createConfigError(`Directory "${projectName}" already exists`);
+  }
+
+  if (projectName) await ensureDir(projectDir);
+
+  const template = await loadTemplateFiles(request.template);
+  const allEnvVars = [...template.envVars];
+
+  const featureAssembly = await assembleFeatureFiles(
+    request.features,
+    template.files,
+    allEnvVars,
+  );
+  const integrationAssembly = await assembleIntegrationFiles(
+    request.integrations,
+    featureAssembly.files,
+    allEnvVars,
+  );
+
+  const createdPaths = await writeScaffoldFiles(projectDir, integrationAssembly.files);
+  const featureTips = [...featureAssembly.tips, ...integrationAssembly.tips];
+
+  if (request.includePackageMetadata) {
+    await createPackageJson(projectDir, projectName, {
+      dependencies: template.dependencies,
+      firstPartyExtensions: template.firstPartyExtensions,
+      integrations: integrationAssembly.loadedIntegrations.map((integration) => ({
+        name: integration.config.name,
+        npmDependencies: integration.config.npmDependencies,
+      })),
+    });
+    createdPaths.push("package.json");
+
+    if (request.runtime === "deno") {
+      await createDenoConfig(projectDir);
+      createdPaths.push("deno.json");
+    }
+  }
+
+  createdPaths.push(
+    ...await writeEnvFiles(projectDir, allEnvVars, request, dependencies),
+  );
+
+  await writeGitignore(projectDir);
+  createdPaths.push(".gitignore");
+
+  const packageManager = await detectPackageManager(
+    projectDir,
+    packageManagerPreference(request.runtime),
+  );
+  const dependencyInstallation = await installProjectDependencies(
+    projectDir,
+    packageManager,
+    request.installDependencies,
+    dependencies.observer,
+  );
+  const gitInitialization = await initializeGit(
+    projectDir,
+    projectName,
+    request.initializeGit,
+  );
+
+  return {
+    projectDir,
+    projectName,
+    createdPaths,
+    packageManager,
+    dependencyInstallation,
+    gitInitialization,
+    featureTips,
+  };
+}

--- a/cli/shared/project-creation.ts
+++ b/cli/shared/project-creation.ts
@@ -443,19 +443,21 @@ export async function createProject(
   dependencies: CreateProjectDependencies = {},
 ): Promise<CreateProjectResult> {
   const projectName = request.name;
-  if (projectName) {
+  if (projectName !== undefined) {
     const nameError = validateProjectName(projectName);
     if (nameError) throw createConfigError(nameError);
   }
 
-  const projectDir = projectName ? join(request.parentDir, projectName) : request.parentDir;
+  const projectDir = projectName === undefined
+    ? request.parentDir
+    : join(request.parentDir, projectName);
   const fs = createFileSystem();
 
   validateOrThrow("features", request.features, validateFeatures);
   validateOrThrow("integrations", request.integrations, validateIntegrations);
 
   if (
-    projectName &&
+    projectName !== undefined &&
     request.conflictPolicy === "fail" &&
     await fs.exists(projectDir)
   ) {
@@ -476,7 +478,7 @@ export async function createProject(
     allEnvVars,
   );
 
-  if (projectName) await ensureDir(projectDir);
+  if (projectName !== undefined) await ensureDir(projectDir);
 
   const createdPaths = await writeScaffoldFiles(projectDir, integrationAssembly.files);
   const featureTips = [...featureAssembly.tips, ...integrationAssembly.tips];

--- a/cli/shared/project-name.test.ts
+++ b/cli/shared/project-name.test.ts
@@ -5,6 +5,11 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { validateProjectName } from "./project-name.ts";
 
 describe("validateProjectName", () => {
+  it("rejects empty and whitespace-only names", () => {
+    assertEquals(validateProjectName(""), "Project name cannot be empty");
+    assertEquals(validateProjectName("   "), "Project name cannot be empty");
+  });
+
   it("accepts a simple name", () => {
     assertEquals(validateProjectName("my-app"), null);
   });

--- a/cli/shared/project-name.test.ts
+++ b/cli/shared/project-name.test.ts
@@ -1,0 +1,31 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { validateProjectName } from "./project-name.ts";
+
+describe("validateProjectName", () => {
+  it("accepts a simple name", () => {
+    assertEquals(validateProjectName("my-app"), null);
+  });
+
+  it("rejects forward slashes", () => {
+    assertEquals(typeof validateProjectName("foo/bar"), "string");
+  });
+
+  it("rejects backslashes", () => {
+    assertEquals(typeof validateProjectName("foo\\bar"), "string");
+  });
+
+  it("rejects dot-dot", () => {
+    assertEquals(typeof validateProjectName(".."), "string");
+  });
+
+  it("rejects single dot", () => {
+    assertEquals(typeof validateProjectName("."), "string");
+  });
+
+  it("accepts dotfiles", () => {
+    assertEquals(validateProjectName(".my-app"), null);
+  });
+});

--- a/cli/shared/project-name.ts
+++ b/cli/shared/project-name.ts
@@ -1,5 +1,6 @@
 /** Reject path separators and traversal so the name stays a single directory. */
 export function validateProjectName(name: string): string | null {
+  if (!name.trim()) return "Project name cannot be empty";
   if (/[/\\]/.test(name)) return 'Project name cannot contain "/" or "\\"';
   if (name === "." || name === "..") return 'Project name cannot be "." or ".."';
   return null;

--- a/cli/shared/project-name.ts
+++ b/cli/shared/project-name.ts
@@ -1,0 +1,6 @@
+/** Reject path separators and traversal so the name stays a single directory. */
+export function validateProjectName(name: string): string | null {
+  if (/[/\\]/.test(name)) return 'Project name cannot contain "/" or "\\"';
+  if (name === "." || name === "..") return 'Project name cannot be "." or ".."';
+  return null;
+}

--- a/cli/utils/git.test.ts
+++ b/cli/utils/git.test.ts
@@ -1,0 +1,42 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { exists, makeTempDir, remove } from "#veryfront/testing/deno-compat.ts";
+import { join } from "veryfront/platform/path";
+
+describe("initializeGitRepo", () => {
+  it("initializes the requested directory when ambient Git targets another repository", async () => {
+    const projectDir = await makeTempDir({ prefix: "veryfront-git-isolation-" });
+    const moduleUrl = new URL("./git.ts", import.meta.url).href;
+    const ambientIndex = join(projectDir, "ambient-index");
+
+    try {
+      await Deno.writeTextFile(join(projectDir, "app.ts"), "export {};\n");
+      const code = `
+        import { initializeGitRepo } from ${JSON.stringify(moduleUrl)};
+        console.log(await initializeGitRepo(${JSON.stringify(projectDir)}, "isolated"));
+      `;
+      const output = await new Deno.Command(Deno.execPath(), {
+        args: ["eval", "--no-check", code],
+        env: {
+          GIT_AUTHOR_NAME: "Veryfront Tests",
+          GIT_AUTHOR_EMAIL: "tests@example.invalid",
+          GIT_COMMITTER_NAME: "Veryfront Tests",
+          GIT_COMMITTER_EMAIL: "tests@example.invalid",
+          GIT_DIR: join(projectDir, "missing-git-dir"),
+          GIT_INDEX_FILE: ambientIndex,
+        },
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      const stderr = new TextDecoder().decode(output.stderr);
+
+      assertEquals(output.success, true, stderr);
+      assertEquals(new TextDecoder().decode(output.stdout).trim(), "true");
+      assertEquals(await exists(join(projectDir, ".git")), true);
+      assertEquals(await exists(join(projectDir, ".git", "index")), true);
+      assertEquals(await exists(ambientIndex), false);
+    } finally {
+      await remove(projectDir, { recursive: true }).catch(() => {});
+    }
+  });
+});

--- a/cli/utils/git.ts
+++ b/cli/utils/git.ts
@@ -3,7 +3,7 @@
  * @module cli/utils/git
  */
 
-import { runCommand } from "veryfront/platform";
+import { env, runCommand } from "veryfront/platform";
 import { cliLogger as logger } from "#cli/utils";
 
 /**
@@ -14,10 +14,20 @@ export async function initializeGitRepo(
   projectName: string,
 ): Promise<boolean> {
   try {
+    const gitEnv = Object.fromEntries(
+      Object.entries(env()).filter(([key]) =>
+        !key.startsWith("GIT_") ||
+        key.startsWith("GIT_AUTHOR_") ||
+        key.startsWith("GIT_COMMITTER_")
+      ),
+    );
+
     // Initialize git
     const initResult = await runCommand("git", {
       args: ["init"],
       cwd: projectDir,
+      clearEnv: true,
+      env: gitEnv,
       capture: true,
     });
 
@@ -30,6 +40,8 @@ export async function initializeGitRepo(
     const addResult = await runCommand("git", {
       args: ["add", "-A"],
       cwd: projectDir,
+      clearEnv: true,
+      env: gitEnv,
       capture: true,
     });
 
@@ -42,6 +54,8 @@ export async function initializeGitRepo(
     const commitResult = await runCommand("git", {
       args: ["commit", "-m", `Initial commit: ${projectName}`, "--no-gpg-sign"],
       cwd: projectDir,
+      clearEnv: true,
+      env: gitEnv,
       capture: true,
     });
 

--- a/docs/superpowers/plans/2026-07-30-project-creation-module.md
+++ b/docs/superpowers/plans/2026-07-30-project-creation-module.md
@@ -43,6 +43,7 @@
 
 ```ts
 export interface CreateProjectRequest {
+  /** A single directory name. Path separators and traversal are rejected. */
   name?: string;
   parentDir: string;
   template: InitTemplate;
@@ -368,8 +369,8 @@ For App, use:
 
 ```ts
 const creation = await createProject({
-  name: `projects/${slug}`,
-  parentDir: cwd(),
+  name: slug,
+  parentDir: join(cwd(), "projects"),
   template,
   runtime: "node",
   features: [],

--- a/docs/superpowers/plans/2026-07-30-project-creation-module.md
+++ b/docs/superpowers/plans/2026-07-30-project-creation-module.md
@@ -1,0 +1,450 @@
+# Project Creation Module Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give CLI, App, MCP, and demo callers one deterministic project-creation interface with an observable result.
+
+**Architecture:** Add `cli/shared/project-creation.ts` as the deep local creation module. Keep `initCommand()` as the interactive and presentation compatibility adapter, then move deterministic App, MCP, and demo callers to the shared interface. The module returns non-fatal install and Git outcomes and accepts only one narrow environment-file interaction seam plus semantic install events.
+
+**Tech Stack:** Deno, TypeScript, existing Veryfront template loaders, filesystem adapter, package-manager utilities, Git utility, BDD test helpers.
+
+## Global Constraints
+
+- Preserve public CLI arguments, output wording, MCP schema, template identifiers, generated files, and non-fatal deploy behavior.
+- Preserve public API compatibility.
+- Use `veryfront/*` for public imports and `#cli/*` or relative imports for CLI internals.
+- Add no dependencies.
+- Keep prompts, terminal progress and result formatting, JSON and MCP formatting, remote registration, source push, and deployment outside the shared module.
+- Keep diffs small and do not refactor unrelated init behavior.
+
+---
+
+## File structure
+
+- Create `cli/shared/project-creation.ts`: deterministic creation request, result, semantic install events, template assembly, filesystem writes, install, and Git initialization.
+- Create `cli/shared/project-creation.test.ts`: interface-level result and filesystem behavior tests.
+- Modify `cli/commands/init/init-command.ts`: retain wizard, existing-directory preflight, environment prompting, spinner, warnings, optional deployment, and success output; delegate creation to the shared module.
+- Modify `cli/commands/init/init-command.test.ts`: characterize compatibility output and prove returned creation data drives presentation.
+- Modify `cli/app/operations/project-creation.ts`: use the shared result instead of rebuilding the project path.
+- Modify `cli/mcp/tools/catalog-tools.ts`: use the shared result while preserving the MCP response.
+- Modify `cli/mcp/tools/catalog-tools.test.ts`: prove MCP path and result compatibility.
+- Modify `cli/commands/demo/demo.ts`: use the shared result before existing registration and push behavior.
+
+### Task 1: Deterministic project creation contract
+
+**Files:**
+- Create: `cli/shared/project-creation.ts`
+- Create: `cli/shared/project-creation.test.ts`
+- Move implementation from: `cli/commands/init/init-command.ts`
+
+**Interfaces:**
+- Consumes: `InitTemplate`, `InitRuntime`, `FeatureName`, `IntegrationName`, `EnvVarConfig`, `EnvPromptResult`, and `PackageManager`.
+- Produces:
+
+```ts
+export interface CreateProjectRequest {
+  name?: string;
+  parentDir: string;
+  template: InitTemplate;
+  runtime: InitRuntime;
+  features: FeatureName[];
+  integrations: IntegrationName[];
+  environmentValues: Record<string, string>;
+  conflictPolicy: "fail" | "overwrite";
+  installDependencies: boolean;
+  initializeGit: boolean;
+  includePackageMetadata: boolean;
+}
+
+export interface CreateProjectResult {
+  projectDir: string;
+  projectName?: string;
+  createdPaths: string[];
+  packageManager: PackageManager;
+  dependencyInstallation: "installed" | "failed" | "skipped";
+  gitInitialization: "initialized" | "failed" | "skipped";
+  featureTips: string[];
+}
+
+export type ProjectCreationEvent =
+  | { kind: "dependency-installation-started"; packageManager: PackageManager }
+  | {
+      kind: "dependency-installation-finished";
+      packageManager: PackageManager;
+      status: "installed" | "failed";
+    };
+
+export interface ProjectCreationObserver {
+  onEvent(event: ProjectCreationEvent): void | Promise<void>;
+}
+
+export interface CreateProjectDependencies {
+  observer?: ProjectCreationObserver;
+  resolveEnvironmentFiles?: (
+    variables: EnvVarConfig[],
+    values: Record<string, string>,
+  ) => Promise<Pick<EnvPromptResult, "envContent" | "envExampleContent">>;
+}
+
+export function createProject(
+  request: CreateProjectRequest,
+  dependencies?: CreateProjectDependencies,
+): Promise<CreateProjectResult>;
+```
+
+- [ ] **Step 1: Write failing interface tests**
+
+Add tests that create a minimal project in a temporary parent directory and assert the structured result:
+
+```ts
+const result = await createProject({
+  name: "contract-project",
+  parentDir,
+  template: "minimal",
+  runtime: "node",
+  features: [],
+  integrations: [],
+  environmentValues: {},
+  conflictPolicy: "fail",
+  installDependencies: false,
+  initializeGit: false,
+  includePackageMetadata: true,
+});
+
+assertEquals(result.projectDir, join(parentDir, "contract-project"));
+assertEquals(result.projectName, "contract-project");
+assertEquals(result.packageManager, "npm");
+assertEquals(result.dependencyInstallation, "skipped");
+assertEquals(result.gitInitialization, "skipped");
+assertEquals(result.createdPaths.includes("app/page.tsx"), true);
+assertEquals(result.createdPaths.includes("package.json"), true);
+assertEquals(result.createdPaths.includes(".gitignore"), true);
+```
+
+Add separate tests for:
+
+```ts
+assertRejects(
+  () => createProject({ ...request, conflictPolicy: "fail" }),
+  Error,
+  'Directory "contract-project" already exists',
+);
+
+const overwritten = await createProject({
+  ...request,
+  conflictPolicy: "overwrite",
+});
+assertEquals(overwritten.projectDir, result.projectDir);
+
+const metadataFree = await createProject({
+  ...request,
+  name: "metadata-free",
+  includePackageMetadata: false,
+});
+assertEquals(metadataFree.createdPaths.includes("package.json"), false);
+```
+
+Also assert that an integration requiring environment variables calls the supplied `resolveEnvironmentFiles` once, writes `.env` and `.env.example`, and records both paths.
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run:
+
+```bash
+deno test --no-check --allow-all cli/shared/project-creation.test.ts
+```
+
+Expected: fail because `cli/shared/project-creation.ts` does not exist.
+
+- [ ] **Step 3: Implement the shared module**
+
+Move creation-only helpers and behavior from `init-command.ts`:
+
+- integration status route generation
+- feature and integration validation and assembly
+- environment requirement de-duplication
+- template and agent-guide loading
+- scaffold file writes and created-path tracking
+- package metadata generation
+- `.env`, `.env.example`, and `.gitignore` generation
+- package-manager selection and optional dependency installation
+- optional Git initialization
+
+Use the deterministic default environment resolver:
+
+```ts
+const resolveEnvironmentFiles = dependencies.resolveEnvironmentFiles ??
+  ((variables, values) =>
+    promptForEnvVars(variables, {
+      skipPrompt: true,
+      prefilledValues: values,
+    }));
+```
+
+Emit install events before and after `installDependencies()`. Return `"failed"` without throwing when installation fails. Catch Git initialization failures and return `"failed"` without throwing.
+
+Do not add deployment, remote project registration, source push, terminal spinners, or success copy.
+
+- [ ] **Step 4: Run focused GREEN and static checks**
+
+Run:
+
+```bash
+deno test --no-check --allow-all cli/shared/project-creation.test.ts
+deno fmt --check cli/shared/project-creation.ts cli/shared/project-creation.test.ts
+deno lint cli/shared/project-creation.ts cli/shared/project-creation.test.ts
+deno check cli/shared/project-creation.ts cli/shared/project-creation.test.ts
+git diff --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit Task 1**
+
+Commit the shared module and tests with a Lore message. Record the RED and GREEN commands in `Tested:` and the compatibility migration as `Not-tested:`.
+
+### Task 2: Init compatibility adapter
+
+**Files:**
+- Modify: `cli/commands/init/init-command.ts`
+- Modify: `cli/commands/init/init-command.test.ts`
+- Test: `cli/commands/init/init.integration.test.ts`
+- Test: `cli/commands/init/init-deploy.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `createProject(request, dependencies): Promise<CreateProjectResult>` from Task 1.
+- Produces: unchanged `initCommand(options, dependencies): Promise<void>`.
+
+- [ ] **Step 1: Add failing compatibility assertions**
+
+Extend `init-command.test.ts` so the compatibility facade proves:
+
+```ts
+await initCommand({
+  name,
+  parentDir,
+  template: "minimal",
+  skipInstall: true,
+  skipEnvPrompt: true,
+  quiet: true,
+});
+
+assertEquals(await exists(join(parentDir, name, "app")), true);
+assertEquals(await exists(join(parentDir, name, "package.json")), false);
+```
+
+Retain the existing deploy test and add an assertion that the verified deploy URL still prints after creation is delegated.
+
+Add focused assertions to the integration suite that a failing fake npm still prints:
+
+```text
+Run 'npm install' manually to install dependencies.
+```
+
+and that initialized Git remains clean.
+
+- [ ] **Step 2: Run the compatibility tests and verify the characterization**
+
+Run:
+
+```bash
+deno test --no-check --allow-all cli/commands/init/init-command.test.ts
+```
+
+Expected before adapter migration: pass, proving the existing behavior is locked.
+
+After replacing the creation body with an unimplemented shared call, rerun and verify it fails before completing the adapter.
+
+- [ ] **Step 3: Convert `initCommand()` into an adapter**
+
+Keep in `init-command.ts`:
+
+- initial existing-directory preflight and existing red error copy
+- interactive wizard and cancellation
+- request defaulting
+- `renderProjectStructure()`
+- dependency-install spinner presentation
+- install and Git failure warnings
+- optional authenticated deployment and its non-fatal messages
+- final structure, next steps, tips, and live/deploy output
+
+Build the shared request:
+
+```ts
+const result = await createProject(
+  {
+    name: projectName,
+    parentDir,
+    template,
+    runtime,
+    features,
+    integrations,
+    environmentValues: options.env ?? {},
+    conflictPolicy: options.force ? "overwrite" : "fail",
+    installDependencies: !options.skipInstall,
+    initializeGit: initGit,
+    includePackageMetadata: !quiet,
+  },
+  {
+    observer: installObserver,
+    resolveEnvironmentFiles: (variables, values) =>
+      promptForEnvVars(variables, {
+        skipPrompt: options.skipEnvPrompt,
+        prefilledValues: values,
+      }),
+  },
+);
+```
+
+Use `result.packageManager`, `result.createdPaths`, and `result.featureTips` for all subsequent presentation. Remove the `_featureTips` mutation and duplicated creation helpers from `init-command.ts`.
+
+- [ ] **Step 4: Run init regression coverage and static checks**
+
+Run:
+
+```bash
+VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all \
+  cli/shared/project-creation.test.ts \
+  cli/commands/init/init-command.test.ts \
+  cli/commands/init/init.integration.test.ts \
+  cli/commands/init/init-deploy.integration.test.ts
+deno fmt --check cli/shared/project-creation.ts cli/commands/init/init-command.ts \
+  cli/shared/project-creation.test.ts cli/commands/init/init-command.test.ts
+deno lint cli/shared/project-creation.ts cli/commands/init/init-command.ts \
+  cli/shared/project-creation.test.ts cli/commands/init/init-command.test.ts
+deno check cli/shared/project-creation.ts cli/commands/init/init-command.ts \
+  cli/shared/project-creation.test.ts cli/commands/init/init-command.test.ts
+git diff --check
+```
+
+Expected: all pass with existing output and generated-file behavior unchanged.
+
+- [ ] **Step 5: Commit Task 2**
+
+Commit the adapter conversion with a Lore message. Record the focused unit and integration suite in `Tested:`.
+
+### Task 3: Programmatic consumer migration
+
+**Files:**
+- Modify: `cli/app/operations/project-creation.ts`
+- Modify: `cli/mcp/tools/catalog-tools.ts`
+- Modify: `cli/mcp/tools/catalog-tools.test.ts`
+- Modify: `cli/commands/demo/demo.ts`
+
+**Interfaces:**
+- Consumes: `createProject(request): Promise<CreateProjectResult>` from Task 1.
+- Produces: unchanged App state transition, unchanged `vf_create_project` input and result schemas, and unchanged demo remote registration and push sequence.
+
+- [ ] **Step 1: Add failing consumer assertions**
+
+In `catalog-tools.test.ts`, retain path normalization assertions and add a successful tool execution assertion that checks:
+
+```ts
+assertEquals(result.success, true);
+assertEquals(result.projectDir, join(parentDir, "example-app"));
+assertEquals(result.nextSteps?.[0], `cd ${join(parentDir, "example-app")}`);
+```
+
+Add a conflict assertion proving the existing failure response remains:
+
+```ts
+assertEquals(result.success, false);
+assertEquals(result.message, `Directory already exists: ${projectDir}`);
+```
+
+- [ ] **Step 2: Run the MCP test and verify the characterization**
+
+Run:
+
+```bash
+deno test --no-check --allow-all cli/mcp/tools/catalog-tools.test.ts
+```
+
+Expected before migration: pass. Temporarily point the imports at the shared module and verify compilation fails until complete request objects are supplied.
+
+- [ ] **Step 3: Migrate deterministic consumers**
+
+For App, use:
+
+```ts
+const creation = await createProject({
+  name: `projects/${slug}`,
+  parentDir: cwd(),
+  template,
+  runtime: "node",
+  features: [],
+  integrations: [],
+  environmentValues: {},
+  conflictPolicy: "fail",
+  installDependencies: false,
+  initializeGit: false,
+  includePackageMetadata: false,
+});
+```
+
+Store `creation.projectDir` in App state.
+
+For MCP, use the resolved name and parent directory, include package metadata, install dependencies, skip Git, and build `projectDir` and next steps from the returned result.
+
+For demo, use overwrite conflict policy, omit package metadata, skip installation and Git, then use `creation.projectDir` for its unchanged registration, link, and push sequence.
+
+Do not move remote registration, auth, linking, push, or deploy into the shared module.
+
+- [ ] **Step 4: Run consumer and full verification**
+
+Run:
+
+```bash
+VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all \
+  cli/shared/project-creation.test.ts \
+  cli/commands/init/init-command.test.ts \
+  cli/mcp/tools/catalog-tools.test.ts
+deno fmt --check cli/shared/project-creation.ts cli/commands/init/init-command.ts \
+  cli/app/operations/project-creation.ts cli/mcp/tools/catalog-tools.ts \
+  cli/commands/demo/demo.ts
+deno lint cli/shared/project-creation.ts cli/commands/init/init-command.ts \
+  cli/app/operations/project-creation.ts cli/mcp/tools/catalog-tools.ts \
+  cli/commands/demo/demo.ts
+deno check cli/shared/project-creation.ts cli/commands/init/init-command.ts \
+  cli/app/operations/project-creation.ts cli/mcp/tools/catalog-tools.ts \
+  cli/commands/demo/demo.ts
+VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 \
+  REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text \
+  deno test --no-check --allow-all --parallel \
+  '--ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts'
+git diff --check origin/main...HEAD
+```
+
+Expected: all pass. If the test run regenerates unrelated tracked files, restore only the known generated drift with `apply_patch` and rerun `git diff --check`.
+
+- [ ] **Step 5: Commit Task 3**
+
+Commit the programmatic consumer migration with a Lore message. Record every completed verification command and any known untested interactive path.
+
+### Task 4: Independent final review and PR
+
+**Files:**
+- Review: `origin/main...HEAD`
+
+**Interfaces:**
+- Consumes: all completed tasks.
+- Produces: a review verdict, verification evidence, pushed branch, and PR URL.
+
+- [ ] **Step 1: Run an independent specification and quality review**
+
+Review for:
+
+- exact design-contract compliance
+- no presentation or remote behavior in `createProject()`
+- no regression in quiet package metadata behavior
+- non-fatal install, Git, and deploy behavior
+- stable MCP schema and response
+- no unsafe casts or leaked implementation flags
+
+- [ ] **Step 2: Resolve every actionable finding**
+
+Apply fixes test-first, rerun the narrowest failing checks, and request re-review until the verdict is `APPROVE`, `SPEC PASS`, and `QUALITY PASS`.
+
+- [ ] **Step 3: Push and create PR 3**
+
+Push `codex/project-creation-module`, create a PR against `main`, include the interface rationale, changed consumers, tests, and remaining risk, and record the PR URL before starting item 4.

--- a/docs/superpowers/specs/2026-07-30-project-creation-design.md
+++ b/docs/superpowers/specs/2026-07-30-project-creation-design.md
@@ -28,6 +28,7 @@ This could model every step as a port, but it would expose more implementation k
 
 ```ts
 export interface CreateProjectRequest {
+  /** A single directory name. Path separators and traversal are rejected. */
   name?: string;
   parentDir: string;
   template: InitTemplate;
@@ -97,7 +98,7 @@ The existing `initCommand()` remains the public CLI command surface. Its deploy 
 ## Consumer migration
 
 - CLI handler: continues to call `initCommand()`.
-- App: calls `createProject()` and uses `result.projectDir` instead of rebuilding the path.
+- App: passes `join(cwd(), "projects")` as `parentDir`, passes the reserved slug as the single-directory `name`, and uses `result.projectDir` instead of rebuilding the path.
 - MCP: calls `createProject()` and builds its public response from the result.
 - Demo: calls `createProject()`, then performs its existing registration, link, and push steps.
 

--- a/docs/superpowers/specs/2026-07-30-project-creation-design.md
+++ b/docs/superpowers/specs/2026-07-30-project-creation-design.md
@@ -1,0 +1,121 @@
+# Project creation module design
+
+## Goal
+
+Give CLI, App, MCP, and demo callers one deterministic project-creation interface with an observable result. Keep prompts, terminal formatting, JSON and MCP formatting, remote registration, source push, and optional deployment in their adapters.
+
+The refactor must preserve existing generated files, conflict handling, package-manager selection, dependency installation, Git initialization, non-fatal installation and Git failures, and non-fatal deployment behavior.
+
+## Approaches considered
+
+### Selected: deep local creation module with a compatibility adapter
+
+Add `cli/shared/project-creation.ts`. It owns validation, template and extension assembly, environment-file generation, filesystem writes, package metadata, dependency installation, and optional Git initialization. It returns a structured result and emits only semantic lifecycle events needed by adapters.
+
+Keep `initCommand()` as the interactive CLI compatibility adapter. It resolves wizard choices, supplies environment values, renders progress and results, and optionally deploys after local creation succeeds. App, MCP, and demo callers use the shared module directly once they already have deterministic inputs.
+
+This concentrates creation behavior without coupling the local module to a terminal or remote service.
+
+### Rejected: return a result from the existing `initCommand()`
+
+This is smaller, but the shared interface would still accept interaction and presentation flags such as `quiet`, `skipEnvPrompt`, and `deploy`. Programmatic callers would continue depending on CLI behavior.
+
+### Rejected: generic project-creation workflow or dependency-injection framework
+
+This could model every step as a port, but it would expose more implementation knowledge than callers need. Existing filesystem, template, package-manager, and Git utilities are sufficient.
+
+## Interface
+
+```ts
+export interface CreateProjectRequest {
+  name?: string;
+  parentDir: string;
+  template: InitTemplate;
+  runtime: InitRuntime;
+  features: FeatureName[];
+  integrations: IntegrationName[];
+  environmentValues: Record<string, string>;
+  conflictPolicy: "fail" | "overwrite";
+  installDependencies: boolean;
+  initializeGit: boolean;
+  includePackageMetadata: boolean;
+}
+
+export interface CreateProjectResult {
+  projectDir: string;
+  projectName?: string;
+  createdPaths: string[];
+  packageManager: PackageManager;
+  dependencyInstallation: "installed" | "failed" | "skipped";
+  gitInitialization: "initialized" | "failed" | "skipped";
+  featureTips: string[];
+}
+
+export type ProjectCreationEvent =
+  | { kind: "dependency-installation-started"; packageManager: PackageManager }
+  | {
+      kind: "dependency-installation-finished";
+      packageManager: PackageManager;
+      status: "installed" | "failed";
+    };
+
+export interface ProjectCreationObserver {
+  onEvent(event: ProjectCreationEvent): void | Promise<void>;
+}
+
+export interface CreateProjectDependencies {
+  observer?: ProjectCreationObserver;
+  resolveEnvironmentFiles?: (
+    variables: EnvVarConfig[],
+    values: Record<string, string>,
+  ) => Promise<Pick<EnvPromptResult, "envContent" | "envExampleContent">>;
+}
+
+export function createProject(
+  request: CreateProjectRequest,
+  dependencies?: CreateProjectDependencies,
+): Promise<CreateProjectResult>;
+```
+
+`includePackageMetadata` makes the existing quiet/TUI scaffold mode explicit. Presentation state must not implicitly change generated files inside the shared module.
+
+The observer is deliberately narrow. It preserves the current dependency-installation spinner without exposing filesystem steps or adding a generic event system.
+
+The optional environment-file resolver is the single interaction seam. Programmatic callers use the deterministic default, which applies supplied values and defaults without prompting. `initCommand()` supplies the existing prompt adapter so the shared module can discover template and integration requirements while terminal interaction remains outside it.
+
+## Data flow
+
+1. An adapter resolves interactive choices into a complete `CreateProjectRequest`.
+2. `createProject()` validates the name, feature list, and integration list before creating the target directory.
+3. The module assembles template, feature, integration, agent-guide, environment, package metadata, and ignore files.
+4. It writes the scaffold and records repo-relative created paths.
+5. It optionally installs dependencies and initializes Git. Both failures remain non-fatal and are represented in the result.
+6. The adapter renders warnings, next steps, and optional deployment using the returned result.
+
+The existing `initCommand()` remains the public CLI command surface. Its deploy dependency stays outside `createProject()` because a deploy failure must not invalidate successful local creation.
+
+## Consumer migration
+
+- CLI handler: continues to call `initCommand()`.
+- App: calls `createProject()` and uses `result.projectDir` instead of rebuilding the path.
+- MCP: calls `createProject()` and builds its public response from the result.
+- Demo: calls `createProject()`, then performs its existing registration, link, and push steps.
+
+No public CLI arguments, MCP schema, template identifiers, or output wording change in this PR.
+
+## Error handling
+
+Invalid names, features, integrations, templates, and target conflicts throw before scaffold writes where current behavior permits. File-write failures throw.
+
+Dependency installation and Git initialization failures do not throw. Their statuses are returned so `initCommand()` can preserve existing warnings. Optional deployment keeps its existing non-fatal handling in `initCommand()`.
+
+## Verification
+
+- Add focused contract tests for returned paths, package-manager selection, created-path reporting, feature tips, conflict policy, dependency-installation status, and Git status.
+- Preserve existing init integration tests as regression coverage for generated files and runtime variants.
+- Type-check the CLI, App, MCP, and demo consumers against the shared interface.
+- Run format, lint, targeted tests, and the repository unit suite before opening the PR.
+
+## Scope
+
+This PR does not change templates, add dependencies, redesign the init wizard, alter remote project registration, or combine project creation with deployment.

--- a/docs/superpowers/specs/2026-07-30-project-creation-design.md
+++ b/docs/superpowers/specs/2026-07-30-project-creation-design.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Give CLI, App, MCP, and demo callers one deterministic project-creation interface with an observable result. Keep prompts, terminal formatting, JSON and MCP formatting, remote registration, source push, and optional deployment in their adapters.
+Give CLI, App, MCP, and demo callers one deterministic project-creation interface with an observable result. Keep prompts, terminal progress and result formatting, JSON and MCP formatting, remote registration, source push, and optional deployment in their adapters. Existing diagnostic debug and validation messages may remain beside the creation rules that produce them.
 
 The refactor must preserve existing generated files, conflict handling, package-manager selection, dependency installation, Git initialization, non-fatal installation and Git failures, and non-fatal deployment behavior.
 


### PR DESCRIPTION
## Description

Centralizes deterministic local project creation behind one reusable interface.

- Adds `createProject()` with structured request, result, dependency-installation events, and explicit install and Git outcomes.
- Validates a project name as one directory component before path construction or filesystem writes.
- Keeps prompts, terminal progress, remote registration, push, and optional deployment in caller adapters.
- Converts `initCommand()` into a compatibility adapter over the shared creation module.
- Reuses the module from App, MCP, and demo flows without changing their public schemas or remote lifecycle behavior.
- Preserves generated files, package-manager selection, quiet-mode metadata behavior, non-fatal install and Git failures, and deploy fallback behavior.
- Keeps new-repository Git commands independent from an ambient `GIT_DIR`.

## Related Issues

None.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactoring
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review
- [x] I have added contract, compatibility, integration, and MCP regression coverage
- [x] New and existing unit tests pass locally
- [x] Architecture design and implementation plan are included

## Verification

- `deno fmt --check` on all modified TypeScript files
- `deno lint` on all modified TypeScript files
- `deno check` on the shared module and every migrated consumer
- Focused creation, init, and MCP suites: passed
- `deno task test:unit`: 2,801 tests, 22,683 steps, 0 failures
- Whole-branch independent review: SPEC PASS, QUALITY PASS

## Known baseline failures

Two script-only checks fail identically on this branch and a clean detached `origin/main` worktree:

- npm package metadata expects prebuilt `npm/esm/cli/commands/mcp/handler.js`
- generated API reference expects a missing `RuntimeMetadata` source anchor

Neither path is changed by this PR.
