### PR TITLE
Silence expected optional-path misses in dev logs

### DIFF
--- a/src/platform/adapters/fs/github/adapter.test.ts
+++ b/src/platform/adapters/fs/github/adapter.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import { GitHubFSAdapter } from "./adapter.ts";
 import { createGitHubConfig } from "./types.ts";
 
@@ -171,8 +172,14 @@ describe("GitHubFSAdapter", () => {
       assertEquals(content, "hello world");
     });
 
-    it("should throw on nonexistent file", async () => {
-      await assertRejects(() => adapter.stat("nonexistent.ts"), Error, "not found");
+    it("should throw a recognized not-found error for a nonexistent file", async () => {
+      const error = await assertRejects(
+        () => adapter.stat("nonexistent.ts"),
+        Error,
+        "not found",
+      );
+
+      assertEquals(isNotFoundError(error), true);
     });
   });
 

--- a/src/platform/adapters/fs/github/stat-operations.ts
+++ b/src/platform/adapters/fs/github/stat-operations.ts
@@ -1,4 +1,4 @@
-import { createError, toError } from "#veryfront/errors";
+import { FILE_NOT_FOUND } from "#veryfront/errors";
 import { logger } from "#veryfront/utils";
 import {
   buildGitHubResolveCacheKey,
@@ -158,13 +158,10 @@ export class GitHubStatOperations {
       indexSize: this.fileIndex.size,
     });
 
-    throw toError(
-      createError({
-        type: "file",
-        message: `File not found: ${normalizedPath}`,
-        context: { path: normalizedPath, operation: "read" },
-      }),
-    );
+    throw FILE_NOT_FOUND.create({
+      detail: `File not found: ${normalizedPath}`,
+      context: { path: normalizedPath, operation: "read" },
+    });
   }
 
   async exists(path: string): Promise<boolean> {

--- a/src/platform/adapters/fs/veryfront/stat-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import type { ProjectFile, VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
 import type { ContentContextProvider } from "./file-list-access.ts";
@@ -145,7 +146,7 @@ describe("StatOperations", () => {
       assertEquals(info.size, 0);
     });
 
-    it("should throw for non-existent path", async () => {
+    it("should throw a recognized not-found error for a non-existent path", async () => {
       const statOps = createStatOps(
         createMockClient(),
         new PathNormalizer(),
@@ -157,6 +158,7 @@ describe("StatOperations", () => {
         assertEquals(true, false, "Should have thrown");
       } catch (e) {
         assertExists(e);
+        assertEquals(isNotFoundError(e), true);
       }
     });
 

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -3,7 +3,7 @@ import { isFrameworkSourcePath } from "#veryfront/utils/path-utils.ts";
 import type { FileInfo, ResolveFileOptions } from "../../base.ts";
 import type { ProjectFile } from "../../veryfront-api-client/index.ts";
 import { VeryfrontOperationsBase } from "./base-operations.ts";
-import { createError, fromError, toError, VeryfrontError } from "#veryfront/errors";
+import { createError, FILE_NOT_FOUND, fromError, toError, VeryfrontError } from "#veryfront/errors";
 import { buildStatCacheKeyPrefix } from "./cache-keys.ts";
 import { STAT_OPERATION_EXTENSION_PRIORITY as EXTENSION_PRIORITY } from "./extension-priority.ts";
 import {
@@ -153,12 +153,10 @@ export class StatOperations extends VeryfrontOperationsBase {
       normalizedPath,
       indexSize: fileIdx.size,
     });
-    throw toError(
-      createError({
-        type: "file",
-        message: `File not found: ${normalizedPath}`,
-      }),
-    );
+    throw FILE_NOT_FOUND.create({
+      detail: `File not found: ${normalizedPath}`,
+      context: { path: normalizedPath },
+    });
   }
 
   private async ensureIndexBuilt(): Promise<void> {

--- a/src/platform/adapters/runtime/node/filesystem-adapter.test.ts
+++ b/src/platform/adapters/runtime/node/filesystem-adapter.test.ts
@@ -1,0 +1,78 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  __registerLogRecordEmitter,
+  __resetLoggerConfigForTests,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+} from "#veryfront/utils/logger/logger.ts";
+import { NodeFileSystemAdapter } from "./filesystem-adapter.ts";
+
+function captureDebugLogs(): { entries: LogEntry[]; restore: () => void } {
+  const originalLogLevel = Deno.env.get("LOG_LEVEL");
+  const originalConsole = {
+    debug: console.debug,
+    error: console.error,
+    log: console.log,
+    warn: console.warn,
+  };
+  const entries: LogEntry[] = [];
+
+  console.debug =
+    console.error =
+    console.log =
+    console.warn =
+      () => {};
+  Deno.env.set("LOG_LEVEL", "DEBUG");
+  __resetLoggerConfigForTests();
+  __registerLogRecordEmitter((entry) => entries.push(entry));
+
+  return {
+    entries,
+    restore: () => {
+      __resetLogRecordEmitterForTests();
+      console.debug = originalConsole.debug;
+      console.error = originalConsole.error;
+      console.log = originalConsole.log;
+      console.warn = originalConsole.warn;
+      if (originalLogLevel === undefined) Deno.env.delete("LOG_LEVEL");
+      else Deno.env.set("LOG_LEVEL", originalLogLevel);
+      __resetLoggerConfigForTests();
+    },
+  };
+}
+
+describe("NodeFileSystemAdapter", () => {
+  it("does not log an expected missing path as an access failure", async () => {
+    const adapter = new NodeFileSystemAdapter();
+    const tempDir = await adapter.makeTempDir("vf-node-fs-exists-");
+    const logs = captureDebugLogs();
+
+    try {
+      assertEquals(await adapter.exists(`${tempDir}/missing`), false);
+      assertEquals(
+        logs.entries.some((entry) => entry.message.includes("File access check failed")),
+        false,
+      );
+    } finally {
+      logs.restore();
+      await adapter.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("keeps unexpected access failures visible in debug logs", async () => {
+    const adapter = new NodeFileSystemAdapter();
+    const logs = captureDebugLogs();
+
+    try {
+      assertEquals(await adapter.exists("\0"), false);
+      assertEquals(
+        logs.entries.some((entry) => entry.message.includes("File access check failed")),
+        true,
+      );
+    } finally {
+      logs.restore();
+    }
+  });
+});

--- a/src/platform/adapters/runtime/node/filesystem-adapter.ts
+++ b/src/platform/adapters/runtime/node/filesystem-adapter.ts
@@ -11,6 +11,7 @@ import {
   createWatcherIterator,
   setupNodeFsWatcher,
 } from "../shared/shared-watcher.ts";
+import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import { makeNodeTempDir } from "../shared/temp-dir.ts";
 import { serverLogger } from "#veryfront/utils";
 
@@ -38,7 +39,9 @@ export class NodeFileSystemAdapter implements FileSystemAdapter {
       await fs.access(path);
       return true;
     } catch (error) {
-      serverLogger.debug(`File access check failed for ${path}:`, error);
+      if (!isNotFoundError(error)) {
+        serverLogger.debug(`File access check failed for ${path}:`, error);
+      }
       return false;
     }
   }

--- a/src/server/dev-server/route-discovery.test.ts
+++ b/src/server/dev-server/route-discovery.test.ts
@@ -3,7 +3,47 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { ApiRouteMatcher } from "#veryfront/routing/api/api-route-matcher.ts";
+import {
+  __registerLogRecordEmitter,
+  __resetLoggerConfigForTests,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+} from "#veryfront/utils/logger/logger.ts";
 import { RouteDiscovery } from "./route-discovery.ts";
+
+function captureDebugLogs(): { entries: LogEntry[]; restore: () => void } {
+  const originalLogLevel = Deno.env.get("LOG_LEVEL");
+  const originalConsole = {
+    debug: console.debug,
+    error: console.error,
+    log: console.log,
+    warn: console.warn,
+  };
+  const entries: LogEntry[] = [];
+
+  console.debug =
+    console.error =
+    console.log =
+    console.warn =
+      () => {};
+  Deno.env.set("LOG_LEVEL", "DEBUG");
+  __resetLoggerConfigForTests();
+  __registerLogRecordEmitter((entry) => entries.push(entry));
+
+  return {
+    entries,
+    restore: () => {
+      __resetLogRecordEmitterForTests();
+      console.debug = originalConsole.debug;
+      console.error = originalConsole.error;
+      console.log = originalConsole.log;
+      console.warn = originalConsole.warn;
+      if (originalLogLevel === undefined) Deno.env.delete("LOG_LEVEL");
+      else Deno.env.set("LOG_LEVEL", originalLogLevel);
+      __resetLoggerConfigForTests();
+    },
+  };
+}
 
 describe("server/dev-server/route-discovery", () => {
   it("discovers routes from configured app and pages directories", async () => {
@@ -36,5 +76,46 @@ describe("server/dev-server/route-discovery", () => {
     await discovery.discoverRoutes();
 
     assertEquals(router.match("/")?.route.page, "src/app/page.tsx");
+  });
+
+  it("does not log expected missing route directories as failures", async () => {
+    const adapter = createMockAdapter();
+    const router = new ApiRouteMatcher();
+    const discovery = new RouteDiscovery("/project", adapter, router);
+    const logs = captureDebugLogs();
+
+    try {
+      await discovery.discoverRoutes();
+
+      assertEquals(router.listRoutes(), []);
+      assertEquals(
+        logs.entries.some((entry) => entry.message === "Directory check failed"),
+        false,
+      );
+    } finally {
+      logs.restore();
+    }
+  });
+
+  it("keeps unexpected route directory failures visible in debug logs", async () => {
+    const adapter = createMockAdapter();
+    adapter.fs.stat = () =>
+      Promise.reject(Object.assign(new Error("permission denied"), { code: "EACCES" }));
+    const router = new ApiRouteMatcher();
+    const discovery = new RouteDiscovery("/project", adapter, router, {
+      fs: { type: "github" },
+    });
+    const logs = captureDebugLogs();
+
+    try {
+      await discovery.discoverRoutes();
+
+      assertEquals(
+        logs.entries.some((entry) => entry.message === "Directory check failed"),
+        true,
+      );
+    } finally {
+      logs.restore();
+    }
   });
 });

--- a/src/server/dev-server/route-discovery.ts
+++ b/src/server/dev-server/route-discovery.ts
@@ -5,7 +5,7 @@ import type { ApiRouteMatcher } from "#veryfront/routing/api/index.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { RouteDirectory } from "./types.ts";
 import { withFallback } from "#veryfront/platform/adapters/fallback-wrapper.ts";
-import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { createFileSystem, isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 
 const logger = serverLogger.component("server");
 
@@ -155,17 +155,11 @@ export class RouteDiscovery {
       logger.debug("Directory stat result", { path, isDirectory: stat.isDirectory });
       return stat.isDirectory;
     } catch (error) {
-      // A missing directory is the expected "no routes here" case and by far the
-      // common one (e.g. a project with no `.veryfront` dir yet). Returning false
-      // is correct for both a genuine absence and a transient adapter error, so
-      // this stays at debug: escalating to warn here fires on the ordinary
-      // missing-dir path (the not-found is wrapped by the fallback-wrapper, so it
-      // is not recognizable as ENOENT) and floods normal dev startup. Surfacing a
-      // genuine adapter failure distinctly needs not-found detection that sees
-      // through the fallback wrapper — tracked as a follow-up.
-      logger.debug("Directory check failed", {
-        errorName: error instanceof Error ? error.name : typeof error,
-      });
+      if (!isNotFoundError(error)) {
+        logger.debug("Directory check failed", {
+          errorName: error instanceof Error ? error.name : typeof error,
+        });
+      }
       return false;
     }
   }


### PR DESCRIPTION
## Description

Verbose development logs treated expected missing optional files and route directories as failures even though the probes correctly returned false and requests completed successfully.

This change:

- suppresses debug failure records for recognized not-found errors in the Node filesystem adapter
- suppresses the same expected misses during route-directory discovery
- preserves diagnostics for unexpected failures such as permission or malformed-path errors
- adds regression coverage for both the silent not-found path and retained unexpected-error path

The implementation reuses the existing `isNotFoundError` classifier and does not change filesystem return semantics or public APIs.

## Related Issue(s)

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Verification

- `deno fmt --check` on all four changed files
- `deno lint` on all four changed files
- `deno check` on all four changed files
- affected-area test run: 17 suites, 186 steps, 0 failures
- repository pre-push gate: 2,807 tests, 22,721 steps, 0 failures
- `git diff --check`

An additional repository-root discovery run included two script tests outside the pre-push unit selection. Both failures reproduced unchanged on the clean base revision: a missing generated npm MCP handler artifact and an API-reference source-anchor assertion.

## Checklist

- [x] Documentation is not required because this changes internal diagnostic behavior without changing a public API or contract
- [x] I have added tests that prove my fix is effective or that my feature works
