### PR TITLE
Finish SSR Outcome adoption in the data endpoints

### DIFF
--- a/src/rendering/ssr-outcome.test.ts
+++ b/src/rendering/ssr-outcome.test.ts
@@ -3,12 +3,20 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { notFound, redirect } from "#veryfront/data/helpers.ts";
 import {
   API_CLIENT_ERROR,
+  BUILD_FAILED,
   FILE_NOT_FOUND,
+  MODULE_NOT_FOUND,
   RENDER_ERROR,
   SERVICE_OVERLOADED,
 } from "#veryfront/errors";
 import type { SSRFailureOutcome } from "./ssr-outcome.ts";
-import { findSSRControlOutcome, isSSRControlOutcome, resolveSSRFailure } from "./ssr-outcome.ts";
+import {
+  findSSRControlOutcome,
+  isSSRBuildFailure,
+  isSSRControlOutcome,
+  resolveSSRControlOutcome,
+  resolveSSRFailure,
+} from "./ssr-outcome.ts";
 
 function assertSSRFailureOutcome(
   actual: SSRFailureOutcome,
@@ -104,6 +112,86 @@ describe("ssr-outcome.ts", () => {
     it("returns true only when the graph contains a branded control result", () => {
       assertEquals(isSSRControlOutcome(new Error("wrapped", { cause: notFound() })), true);
       assertEquals(isSSRControlOutcome({ notFound: true }), false);
+    });
+  });
+
+  describe("resolveSSRControlOutcome", () => {
+    it("recognises the routing brands the render pipeline raises", () => {
+      assertEquals(
+        resolveSSRControlOutcome(FILE_NOT_FOUND.create({ detail: "Page not found: x" })),
+        { kind: "not-found" },
+      );
+      assertEquals(
+        resolveSSRControlOutcome(
+          RENDER_ERROR.create({
+            detail: "Redirect to /login",
+            context: { redirect: { destination: "/login", permanent: true } },
+          }),
+        ),
+        { kind: "redirect", location: "/login", permanent: true },
+      );
+      assertEquals(resolveSSRControlOutcome(notFound()), { kind: "not-found" });
+      assertEquals(
+        resolveSSRControlOutcome(new Error("wrapped", { cause: redirect("/login") })),
+        { kind: "redirect", location: "/login", permanent: false },
+      );
+    });
+
+    it("reads no routing decision out of message text or plain shape", () => {
+      assertEquals(resolveSSRControlOutcome(new Error("Page not found")), null);
+      assertEquals(resolveSSRControlOutcome(new Error("upstream said 404")), null);
+      assertEquals(resolveSSRControlOutcome(new Error("no page matched")), null);
+      assertEquals(resolveSSRControlOutcome({ notFound: true }), null);
+      assertEquals(
+        resolveSSRControlOutcome({ redirect: { destination: "/login" } }),
+        null,
+      );
+    });
+
+    it("returns null for a render-error carrying no redirect", () => {
+      assertEquals(
+        resolveSSRControlOutcome(RENDER_ERROR.create({ detail: "boom" })),
+        null,
+      );
+    });
+  });
+
+  describe("isSSRBuildFailure", () => {
+    it("is true for compile and module-resolution categories", () => {
+      assertEquals(isSSRBuildFailure(BUILD_FAILED.create({ detail: "compile failed" })), true);
+      assertEquals(
+        isSSRBuildFailure(MODULE_NOT_FOUND.create({ detail: "missing import" })),
+        true,
+      );
+    });
+
+    it("is true for a render-error flagged at the point of load failure", () => {
+      assertEquals(
+        isSSRBuildFailure(
+          RENDER_ERROR.create({
+            detail: "Critical page module(s) failed to load",
+            context: { buildFailure: true },
+          }),
+        ),
+        true,
+      );
+    });
+
+    it("is false for a module that ran and threw, and for plain errors", () => {
+      // Failing to load is not evidence on its own: a module that compiled and
+      // threw at module scope also fails to load, and the project's own error
+      // page should present that.
+      assertEquals(
+        isSSRBuildFailure(
+          RENDER_ERROR.create({
+            detail: "Critical page module(s) failed to load",
+            context: { buildFailure: false },
+          }),
+        ),
+        false,
+      );
+      assertEquals(isSSRBuildFailure(new Error("intentional test error")), false);
+      assertEquals(isSSRBuildFailure(undefined), false);
     });
   });
 

--- a/src/rendering/ssr-outcome.ts
+++ b/src/rendering/ssr-outcome.ts
@@ -73,6 +73,65 @@ export function isSSRControlOutcome(error: unknown): boolean {
   return findSSRControlOutcome(error) !== null;
 }
 
+/**
+ * The routing decision a failed render carries, under any brand the framework
+ * raises for one.
+ *
+ * {@link findSSRControlOutcome} recognises only a thrown data control result.
+ * Two more brands mean the same thing by the time an error leaves the render
+ * pipeline: a `file-not-found` VeryfrontError, raised both when no page matches
+ * the slug and when a loader answered `notFound()`; and a `render-error`
+ * carrying `context.redirect`, raised when a loader answered `redirect()`.
+ * Anything deciding 404-vs-500, or whether to hand a redirect to the client,
+ * wants all three.
+ *
+ * Message text is never consulted. A project error that merely reads "not
+ * found" is a failure, and answering it with a 404 hides the failure, renders
+ * the wrong page, and caches a status the site never asked for.
+ */
+export function resolveSSRControlOutcome(error: unknown): SSRControlOutcome | null {
+  const control = findSSRControlOutcome(error);
+  if (control) return control;
+
+  if (isFileNotFoundError(error)) return { kind: "not-found" };
+
+  if (error instanceof VeryfrontError && error.slug === "render-error") {
+    const redirect = extractRedirectLocation(error);
+    if (redirect) {
+      return {
+        kind: "redirect",
+        location: redirect.destination,
+        permanent: redirect.permanent,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * True for errors raised while compiling or resolving project source, as
+ * opposed to errors thrown by the running application.
+ *
+ * Module-load failures arrive wrapped in a RUNTIME-category `render-error`,
+ * which loses the original category, so they carry a `buildFailure` flag that
+ * the module loader sets at the point of failure. Failing to load is not
+ * evidence on its own: a module that compiled fine and threw at module scope
+ * also fails to load, and that is an application error the project's own error
+ * page should present.
+ *
+ * This is orthogonal to {@link SSRFailureOutcome}. A build failure is still
+ * classified `runtime` or `server-error` like any other error; the answer here
+ * only says whether the project is allowed to dress it up.
+ */
+export function isSSRBuildFailure(error: unknown): boolean {
+  if (!(error instanceof VeryfrontError)) return false;
+  if (error.category === "BUILD" || error.category === "MODULE") return true;
+
+  const context = error.context as { buildFailure?: unknown } | undefined;
+  return context?.buildFailure === true;
+}
+
 export function resolveSSRFailure(
   error: unknown,
   context: { isLocalProject: boolean },
@@ -87,26 +146,13 @@ export function resolveSSRFailure(
     };
   }
 
-  const control = findSSRControlOutcome(error);
+  // Ordering against the undeployed check below is free: that one needs an
+  // `api-client-error`, and neither control brand can carry that slug.
+  const control = resolveSSRControlOutcome(error);
   if (control) return control;
-
-  if (error instanceof VeryfrontError && error.slug === "file-not-found") {
-    return { kind: "not-found" };
-  }
 
   if (isUndeployedFileListError(error)) {
     return { kind: "undeployed", error: errorObj };
-  }
-
-  if (error instanceof VeryfrontError && error.slug === "render-error") {
-    const redirect = extractRedirectLocation(error);
-    if (redirect) {
-      return {
-        kind: "redirect",
-        location: redirect.destination,
-        permanent: redirect.permanent,
-      };
-    }
   }
 
   if (error instanceof VeryfrontError && error.slug === "service-overloaded") {
@@ -142,6 +188,10 @@ function extractRedirectLocation(
     destination: redirect.destination,
     permanent: redirect.permanent === true,
   };
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return error instanceof VeryfrontError && error.slug === "file-not-found";
 }
 
 function isUndeployedFileListError(error: unknown): boolean {

--- a/src/server/handlers/request/module/data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/data-endpoint-handler.test.ts
@@ -18,6 +18,8 @@ import {
 import { DEPENDENCY_PINNING_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
 import { deleteEnv, getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { handleDataEndpoint } from "./data-endpoint-handler.ts";
+import { FILE_NOT_FOUND } from "#veryfront/errors";
+import { notFound } from "#veryfront/data/helpers.ts";
 
 const DEPENDENCY_PINNING_HEADER = "x-veryfront-dependency-pins";
 
@@ -394,5 +396,54 @@ describe("server/handlers/request/module/data-endpoint-handler", () => {
       clearReactVersionCache();
       await Deno.remove(projectDir, { recursive: true });
     }
+  });
+
+  describe("404-vs-500 classification", () => {
+    async function statusForRejection(error: unknown): Promise<number> {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-data-classify-" });
+      try {
+        setRendererInitializer(createInitializer(() => Promise.reject(error)));
+        const response = await callDataEndpoint(
+          new Request("http://localhost/_veryfront/data/missing.json"),
+          makeCtx(projectDir),
+        );
+        await response.body?.cancel();
+        return response.status;
+      } finally {
+        await destroyRendererAdapter();
+        setRendererInitializer(undefined);
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    }
+
+    it("answers 404 for the file-not-found the page resolver raises", async () => {
+      assertEquals(
+        await statusForRejection(
+          FILE_NOT_FOUND.create({ detail: "Page not found: missing" }),
+        ),
+        404,
+      );
+    });
+
+    it("answers 404 for a notFound() thrown from a loader, however wrapped", async () => {
+      assertEquals(await statusForRejection(notFound()), 404);
+      assertEquals(
+        await statusForRejection(new Error("wrapped", { cause: notFound() })),
+        404,
+      );
+    });
+
+    it("answers 500 for an unbranded error whose message merely says not found", async () => {
+      // Message text is not an interface. An error that reads "not found"
+      // without carrying a routing brand is a failure, and serving it as a 404
+      // would hide the failure behind the project's 404 page.
+      assertEquals(await statusForRejection(new Error("Page not found")), 500);
+      assertEquals(await statusForRejection(new Error("upstream said 404")), 500);
+      assertEquals(await statusForRejection(new Error("no page matched")), 500);
+    });
+
+    it("answers 500 for a generic failure", async () => {
+      assertEquals(await statusForRejection(new Error("render blew up")), 500);
+    });
   });
 });

--- a/src/server/handlers/request/module/data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/data-endpoint-handler.ts
@@ -8,6 +8,7 @@ import {
   resolveRequestedDependencyPinningSnapshot,
 } from "#veryfront/transforms/esm/package-registry.ts";
 import { createHandlerDependencyPinningSource } from "#veryfront/server/handlers/utils/dependency-pinning-source.ts";
+import { resolveSSRControlOutcome } from "#veryfront/rendering/ssr-outcome.ts";
 
 const DEPENDENCY_PINNING_HEADER = "x-veryfront-dependency-pins";
 
@@ -104,10 +105,7 @@ export function handleDataEndpoint(
         );
       } catch (e) {
         const errorMessage = getErrorMessage(e);
-        const lower = errorMessage.toLowerCase();
-        const isNotFound = lower.includes("not found") ||
-          lower.includes("404") ||
-          (e instanceof Error && e.message.toLowerCase().includes("no page"));
+        const isNotFound = resolveSSRControlOutcome(e)?.kind === "not-found";
         const status = isNotFound ? 404 : 500;
 
         serverLogger.error("[data-endpoint] Failed to resolve data", {

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -18,6 +18,8 @@ import {
 } from "./page-data-endpoint-handler.ts";
 import { DEPENDENCY_PINNING_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { FILE_NOT_FOUND, RENDER_ERROR } from "#veryfront/errors";
+import { notFound, redirect } from "#veryfront/data/helpers.ts";
 import {
   clearReactVersionCache,
   getDependencyPinningSnapshot,
@@ -439,15 +441,16 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
   });
 
   it("encodes a getServerData redirect() as a 200 payload instead of a 500", async () => {
-    // A redirect() from getServerData reaches the page-data endpoint as a thrown
-    // VeryfrontError carrying context.redirect. It must be encoded as a 200
-    // { redirect } payload so the SPA client can follow it — not misclassified as
-    // an internal error (500), which aborts client-side navigation.
+    // A redirect() from getServerData reaches the page-data endpoint as the
+    // render-error the data pipeline raises for it, carrying context.redirect.
+    // It must be encoded as a 200 { redirect } payload so the SPA client can
+    // follow it — not misclassified as an internal error (500), which aborts
+    // client-side navigation.
     setRendererInitializer(
       createInitializer(() =>
         Promise.reject(
-          Object.assign(new Error("Redirect to /target"), {
-            slug: "render-error",
+          RENDER_ERROR.create({
+            detail: "Redirect to /target",
             context: { redirect: { destination: "/target", permanent: false } },
           }),
         )
@@ -474,8 +477,8 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
       setRendererInitializer(
         createInitializer(() =>
           Promise.reject(
-            Object.assign(new Error(`Redirect to ${destination}`), {
-              slug: "render-error",
+            RENDER_ERROR.create({
+              detail: `Redirect to ${destination}`,
               context: { redirect: { destination, permanent: false } },
             }),
           )
@@ -502,8 +505,8 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
       setRendererInitializer(
         createInitializer(() =>
           Promise.reject(
-            Object.assign(new Error(`Redirect to ${destination}`), {
-              slug: "render-error",
+            RENDER_ERROR.create({
+              detail: `Redirect to ${destination}`,
               context: { redirect: { destination, permanent: false } },
             }),
           )
@@ -958,6 +961,65 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
       releaseId: "rel-page-data",
       branch: null,
       environmentName: "production",
+    });
+  });
+
+  describe("404-vs-500 classification", () => {
+    async function statusForRejection(error: unknown): Promise<number> {
+      setRendererInitializer(createInitializer(() => Promise.reject(error)));
+      const res = await callPageDataEndpoint(
+        new Request("http://localhost/_veryfront/page-data/missing.json"),
+        makeCtx(),
+      );
+      await res.body?.cancel();
+      __clearPageDataEndpointCacheForTests();
+      return res.status;
+    }
+
+    it("answers 404 for the file-not-found the page resolver raises", async () => {
+      assertEquals(
+        await statusForRejection(
+          FILE_NOT_FOUND.create({ detail: "Page not found: missing" }),
+        ),
+        404,
+      );
+    });
+
+    it("answers 404 for a notFound() thrown from a loader, however wrapped", async () => {
+      assertEquals(await statusForRejection(notFound()), 404);
+      assertEquals(
+        await statusForRejection(new Error("wrapped", { cause: notFound() })),
+        404,
+      );
+    });
+
+    it("answers 500 for an unbranded error whose message merely says not found", async () => {
+      // Message text is not an interface. An error that reads "not found"
+      // without carrying a routing brand is a failure, and serving it as a 404
+      // would hide the failure behind the project's 404 page.
+      assertEquals(await statusForRejection(new Error("Page not found")), 500);
+      assertEquals(await statusForRejection(new Error("upstream said 404")), 500);
+      assertEquals(await statusForRejection(new Error("no page matched")), 500);
+    });
+
+    it("answers 500 for a generic failure", async () => {
+      assertEquals(await statusForRejection(new Error("render blew up")), 500);
+    });
+  });
+
+  it("encodes a redirect() thrown from a loader as a 200 payload", async () => {
+    setRendererInitializer(
+      createInitializer(() => Promise.reject(redirect("/target", true))),
+    );
+
+    const res = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/redirecting.json"),
+      makeCtx(),
+    );
+
+    assertEquals(res.status, 200);
+    assertEquals(await res.json(), {
+      redirect: { destination: "/target", permanent: true },
     });
   });
 });

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -14,6 +14,7 @@ import {
   sanitizeQueryParamsForCacheKey,
 } from "#veryfront/cache/keys.ts";
 import type { PageDataResponse } from "#veryfront/rendering/orchestrator/types.ts";
+import { resolveSSRControlOutcome } from "#veryfront/rendering/ssr-outcome.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import {
   type DependencyPinningSnapshot,
@@ -256,17 +257,19 @@ export function handlePageDataEndpoint(
           );
         }
 
-        // A redirect() from getServerData surfaces here as a thrown
-        // VeryfrontError carrying context.redirect. The full-page render path
-        // converts this into a 302; the SPA page-data endpoint must encode it as
-        // a 200 payload so the client router can follow the redirect instead of
-        // treating it as an internal error (which 500s and aborts navigation).
-        const redirect = extractRedirectFromError(e);
-        if (redirect) {
+        // The full-page render path turns a control outcome into a 302 or a 404
+        // page. The SPA page-data endpoint has to encode the same decision as a
+        // payload the client router can act on, rather than as an internal
+        // error (which 500s and aborts navigation).
+        const control = resolveSSRControlOutcome(e);
+
+        // A destination the client refuses to follow is not a redirect the
+        // endpoint can encode, so it falls through to normal error handling.
+        if (control?.kind === "redirect" && isFollowableRedirect(control.location)) {
           return respondPageData(
             ResponseBuilder.json(
               {
-                redirect,
+                redirect: { destination: control.location, permanent: control.permanent },
                 ...(dependencySnapshot?.cacheKey.startsWith("on:")
                   ? { dependencyPinningCacheKey: dependencySnapshot.cacheKey }
                   : {}),
@@ -282,10 +285,7 @@ export function handlePageDataEndpoint(
         }
 
         const errorMessage = getErrorMessage(e);
-        const lower = errorMessage.toLowerCase();
-        const isNotFound = lower.includes("not found") ||
-          lower.includes("404") ||
-          (e instanceof Error && e.message.toLowerCase().includes("no page"));
+        const isNotFound = control?.kind === "not-found";
         const status = isNotFound ? 404 : 500;
 
         // Log the full error server-side but return a generic message
@@ -497,24 +497,6 @@ function isFollowableRedirect(destination: string): boolean {
     }
   }
   return /^https?:\/\//i.test(destination);
-}
-
-/**
- * A redirect() from getServerData is thrown up the pipeline as a VeryfrontError
- * whose `context.redirect` holds the destination (mirrors extractRedirectLocation
- * in the SSR service). Returns null for any other error, or for a redirect whose
- * destination is not safe to hand to the client to follow.
- */
-function extractRedirectFromError(
-  error: unknown,
-): { destination: string; permanent: boolean } | null {
-  const context = (error as {
-    context?: { redirect?: { destination?: unknown; permanent?: unknown } };
-  })?.context;
-  const redirect = context?.redirect;
-  if (!redirect || typeof redirect.destination !== "string") return null;
-  if (!isFollowableRedirect(redirect.destination)) return null;
-  return { destination: redirect.destination, permanent: redirect.permanent === true };
 }
 
 function buildPageDataCacheKey(

--- a/src/server/handlers/request/ssr/ssr.handler.test.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.test.ts
@@ -489,7 +489,10 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
     ] as const;
 
     for (const failure of applicationFailures) {
-      it(`looks for a custom error page for ${failure.kind} even with the dev overlay`, async () => {
+      const title = failure.exposure === "development-overlay"
+        ? `looks for a custom error page for ${failure.kind} even with the dev overlay`
+        : `looks for a custom error page for ${failure.kind}`;
+      it(title, async () => {
         const mockService = createMockSSRService({
           renderPage: () =>
             Promise.resolve({

--- a/src/server/handlers/request/ssr/ssr.handler.test.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.test.ts
@@ -143,7 +143,7 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
             html: "<html>not found</html>",
             isStreaming: false,
             cacheStrategy: "no-cache" as const,
-            errorType: "not-found" as const,
+            failure: { kind: "not-found" } as const,
             slug: "missing-page",
           }),
       });
@@ -165,8 +165,7 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
             status: 302,
             isStreaming: false,
             cacheStrategy: "no-cache" as const,
-            errorType: "redirect" as const,
-            redirectLocation: "/login",
+            failure: { kind: "redirect", location: "/login", permanent: false } as const,
             slug: "redirect-source",
           }),
       });
@@ -189,8 +188,11 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
             html: "<html>server error</html>",
             isStreaming: false,
             cacheStrategy: "no-cache" as const,
-            errorType: "server-error" as const,
-            error: new Error("Render failed"),
+            failure: {
+              kind: "server-error",
+              exposure: "generic",
+              error: new Error("Render failed"),
+            } as const,
             slug: "broken",
           }),
       });
@@ -211,8 +213,11 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
             html: "<html><body>segment boundary</body></html>",
             isStreaming: false,
             cacheStrategy: "no-cache" as const,
-            errorType: "app-router-error-boundary" as const,
-            error: new Error("Render failed"),
+            failure: {
+              kind: "app-router-error-boundary",
+              html: "<html><body>segment boundary</body></html>",
+              error: new Error("Render failed"),
+            } as const,
             slug: "broken",
           }),
       });
@@ -478,8 +483,13 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
       return { ctx: makeCtx({ adapter }), statted };
     }
 
-    for (const errorType of ["server-error", "runtime"] as const) {
-      it(`looks for a custom error page for ${errorType} even with the dev overlay`, async () => {
+    const applicationFailures = [
+      { kind: "server-error", exposure: "generic", error: new Error("Oops") },
+      { kind: "runtime", exposure: "development-overlay", error: new Error("Oops") },
+    ] as const;
+
+    for (const failure of applicationFailures) {
+      it(`looks for a custom error page for ${failure.kind} even with the dev overlay`, async () => {
         const mockService = createMockSSRService({
           renderPage: () =>
             Promise.resolve({
@@ -487,9 +497,7 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
               html: "<html>dev overlay</html>",
               isStreaming: false,
               cacheStrategy: "no-cache" as const,
-              errorType,
-              showDevOverlay: true,
-              error: new Error("Oops"),
+              failure,
               slug: "page",
             }),
         });
@@ -511,9 +519,11 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
             html: "<html>dev overlay</html>",
             isStreaming: false,
             cacheStrategy: "no-cache" as const,
-            errorType: "server-error" as const,
-            showDevOverlay: true,
-            error: new Error("Oops"),
+            failure: {
+              kind: "server-error",
+              exposure: "generic",
+              error: new Error("Oops"),
+            } as const,
             slug: "page",
           }),
       });
@@ -532,8 +542,11 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
             html: "<html>runtime error overlay</html>",
             isStreaming: false,
             cacheStrategy: "no-cache" as const,
-            errorType: "runtime" as const,
-            showDevOverlay: true,
+            failure: {
+              kind: "runtime",
+              exposure: "development-overlay" as const,
+              error: new Error("Dev error"),
+            },
             slug: "broken",
           }),
       });
@@ -563,8 +576,7 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
             status: 301,
             isStreaming: false,
             cacheStrategy: "no-cache" as const,
-            errorType: "redirect" as const,
-            redirectLocation: "/moved",
+            failure: { kind: "redirect", location: "/moved", permanent: false } as const,
             slug: "redirect-source",
           }),
       });
@@ -730,15 +742,17 @@ describe("handle - build errors bypass the custom error page", () => {
           html: "<html>dev overlay</html>",
           isStreaming: false,
           cacheStrategy: "no-cache" as const,
-          errorType: "runtime" as const,
-          showDevOverlay: true,
-          error: RENDER_ERROR.create({
-            detail: "Critical page module(s) failed to load",
-            context: {
-              criticalFailures: [{ path: "pages/test/y.tsx", error: "bad import", buildFailure }],
-              buildFailure,
-            },
-          }),
+          failure: {
+            kind: "runtime" as const,
+            exposure: "development-overlay" as const,
+            error: RENDER_ERROR.create({
+              detail: "Critical page module(s) failed to load",
+              context: {
+                criticalFailures: [{ path: "pages/test/y.tsx", error: "bad import", buildFailure }],
+                buildFailure,
+              },
+            }),
+          },
           slug: "page",
         }),
     });
@@ -790,9 +804,11 @@ describe("handle - build errors bypass the custom error page", () => {
           html: "<html>dev overlay</html>",
           isStreaming: false,
           cacheStrategy: "no-cache" as const,
-          errorType: "runtime" as const,
-          showDevOverlay: true,
-          error: new Error("intentional test error from getServerData"),
+          failure: {
+            kind: "runtime" as const,
+            exposure: "development-overlay" as const,
+            error: new Error("intentional test error from getServerData"),
+          },
           slug: "page",
         }),
     }));

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -31,7 +31,7 @@ import {
   type SSRServiceLike,
 } from "../../../services/rendering/ssr.service.ts";
 import { ErrorPages } from "../../../utils/error-html.ts";
-import { VeryfrontError } from "#veryfront/errors";
+import { isSSRBuildFailure } from "#veryfront/rendering/ssr-outcome.ts";
 import { buildSSRResponse } from "./ssr-response-builder.ts";
 import {
   type DependencyPinningSnapshot,
@@ -65,25 +65,6 @@ export function isProductionMode(ctx: HandlerContext, _url?: URL): boolean {
  *
  * Business logic is delegated to SSRService.
  */
-
-/**
- * True for errors raised while compiling or resolving project source, as
- * opposed to errors thrown by the running application.
- *
- * Module-load failures arrive wrapped in a RUNTIME-category `render-error`,
- * which loses the original category, so they carry a `buildFailure` flag that
- * the module loader sets at the point of failure. Failing to load is not
- * evidence on its own: a module that compiled fine and threw at module scope
- * also fails to load, and that is an application error the project's own error
- * page should present.
- */
-function isBuildError(error: unknown): boolean {
-  if (!(error instanceof VeryfrontError)) return false;
-  if (error.category === "BUILD" || error.category === "MODULE") return true;
-
-  const context = error.context as { buildFailure?: unknown } | undefined;
-  return context?.buildFailure === true;
-}
 
 export class SSRHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -302,7 +283,7 @@ export class SSRHandler extends BaseHandler {
           result.errorType === "runtime";
         // Project error pages should beat the dev overlay for runtime errors.
         // Build/import errors stay visible because their overlay is actionable.
-        if (isServerError && !(result.showDevOverlay && isBuildError(result.error))) {
+        if (isServerError && !(result.showDevOverlay && isSSRBuildFailure(result.error))) {
           const customResponse = await this.tryCustomErrorFallback(
             applicationRequest,
             ctx,

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -230,8 +230,12 @@ export class SSRHandler extends BaseHandler {
         if (memoryStatus.shouldReject) {
           this.logDebug("Rejecting due to memory pressure", { slug }, ctx);
           const result = this.ssrService.createMemoryPressureResult(slug);
-          result.dependencyPinningCacheKey = dependencySnapshot.cacheKey;
-          return this.buildResponse(req, ctx, result, generateNonce());
+          return this.buildResponse(
+            req,
+            ctx,
+            { ...result, dependencyPinningCacheKey: dependencySnapshot.cacheKey },
+            generateNonce(),
+          );
         }
 
         const nonce = generateNonce();
@@ -261,40 +265,48 @@ export class SSRHandler extends BaseHandler {
           dependencyPinningDependencies: dependencySnapshot.dependencies,
           dependencyPinningSource: dependencySource,
         });
-        result.dependencyPinningCacheKey = dependencySnapshot.cacheKey;
+        const rendered: SSRRenderResult = {
+          ...result,
+          dependencyPinningCacheKey: dependencySnapshot.cacheKey,
+        };
 
         endRequest(requestId);
 
-        if (result.errorType === "redirect" && result.redirectLocation) {
-          return this.handleRedirect(req, ctx, result, nonce);
+        const failure = rendered.failure;
+        switch (failure?.kind) {
+          case "redirect":
+            return this.handleRedirect(req, ctx, rendered, failure.location, nonce);
+          case "not-found":
+            return this.handleNotFound(
+              applicationRequest,
+              ctx,
+              slug,
+              nonce,
+              dependencySnapshot,
+            );
+          case "overloaded":
+          case "runtime":
+          case "server-error": {
+            // Project error pages should beat the dev overlay for runtime
+            // errors. Build/import errors stay visible because their overlay is
+            // actionable, and only a runtime failure raises one.
+            const overlayWins = failure.kind === "runtime" && isSSRBuildFailure(failure.error);
+            if (!overlayWins) {
+              const customResponse = await this.tryCustomErrorFallback(
+                applicationRequest,
+                ctx,
+                rendered,
+                failure.error,
+                nonce,
+                dependencySnapshot,
+              );
+              if (customResponse) return customResponse;
+            }
+            break;
+          }
         }
 
-        if (result.errorType === "not-found") {
-          return this.handleNotFound(
-            applicationRequest,
-            ctx,
-            slug,
-            nonce,
-            dependencySnapshot,
-          );
-        }
-
-        const isServerError = result.errorType === "server-error" ||
-          result.errorType === "runtime";
-        // Project error pages should beat the dev overlay for runtime errors.
-        // Build/import errors stay visible because their overlay is actionable.
-        if (isServerError && !(result.showDevOverlay && isSSRBuildFailure(result.error))) {
-          const customResponse = await this.tryCustomErrorFallback(
-            applicationRequest,
-            ctx,
-            result,
-            nonce,
-            dependencySnapshot,
-          );
-          if (customResponse) return customResponse;
-        }
-
-        return this.buildResponse(req, ctx, result, nonce);
+        return this.buildResponse(req, ctx, rendered, nonce);
       },
       { "ssr.slug": slug, "ssr.projectSlug": ctx.projectSlug || "unknown" },
     );
@@ -304,6 +316,7 @@ export class SSRHandler extends BaseHandler {
     req: Request,
     ctx: HandlerContext,
     result: SSRRenderResult,
+    location: string,
     nonce: string,
   ): HandlerResult {
     const response = this.createSnapshotResponseBuilder(
@@ -314,7 +327,7 @@ export class SSRHandler extends BaseHandler {
       .withCORS(req, ctx.securityConfig?.cors)
       .withSecurity(ctx.securityConfig ?? undefined, req)
       .withCache(result.cacheStrategy)
-      .withHeaders({ Location: result.redirectLocation ?? "/" })
+      .withHeaders({ Location: location })
       .build(null, result.status);
 
     return this.respond(response);
@@ -353,7 +366,7 @@ export class SSRHandler extends BaseHandler {
       html: ErrorPages.notFound(slug || "/"),
       isStreaming: false,
       cacheStrategy: "no-cache",
-      errorType: "not-found",
+      failure: { kind: "not-found" },
       slug,
       dependencyPinningCacheKey: dependencySnapshot.cacheKey,
     };
@@ -365,6 +378,7 @@ export class SSRHandler extends BaseHandler {
     req: Request,
     ctx: HandlerContext,
     result: SSRRenderResult,
+    error: Error,
     nonce: string,
     dependencySnapshot: DependencyPinningSnapshot,
   ): Promise<HandlerResult | null> {
@@ -375,7 +389,7 @@ export class SSRHandler extends BaseHandler {
     );
     const customResponse = await tryErrorPageFallback(req, ctx, builder, {
       statusCode: result.status,
-      error: result.error,
+      error,
       pathname: result.slug || "/",
     }, dependencySnapshot);
 

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -3,7 +3,7 @@ import "../../../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { SSRService } from "./ssr.service.ts";
-import type { RendererProvider, SSRRenderOptions } from "./ssr.service.ts";
+import type { RendererProvider, SSRRenderOptions, SSRRenderResult } from "./ssr.service.ts";
 import type { HandlerContext } from "../../handlers/types.ts";
 import type { RendererAdapter } from "../../shared/renderer-factory.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -113,6 +113,14 @@ function createReactReadyStream(rejection: unknown): ReadableStream<Uint8Array> 
   return Object.assign(stream, {
     allReady: Promise.reject(rejection),
   });
+}
+
+function redirectLocationOf(result: SSRRenderResult): string {
+  const failure = result.failure;
+  if (failure?.kind !== "redirect") {
+    throw new Error(`expected a redirect outcome, got ${failure?.kind ?? "none"}`);
+  }
+  return failure.location;
 }
 
 describe("server/services/rendering/ssr.service", () => {
@@ -400,7 +408,7 @@ describe("server/services/rendering/ssr.service", () => {
 
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 404);
-        assertEquals(result.errorType, "not-found");
+        assertEquals(result.failure?.kind, "not-found");
         assertEquals(result.isStreaming, false);
         assertEquals(result.cacheStrategy, "no-cache");
       });
@@ -425,7 +433,7 @@ describe("server/services/rendering/ssr.service", () => {
 
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 404);
-        assertEquals(result.errorType, "undeployed");
+        assertEquals(result.failure?.kind, "undeployed");
       });
 
       it("maps render redirects to redirect results", async () => {
@@ -451,8 +459,8 @@ describe("server/services/rendering/ssr.service", () => {
 
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 302);
-        assertEquals(result.errorType, "redirect");
-        assertEquals(result.redirectLocation, "/login");
+        assertEquals(result.failure?.kind, "redirect");
+        assertEquals(redirectLocationOf(result), "/login");
         assertEquals(result.cacheStrategy, "no-cache");
       });
 
@@ -468,7 +476,7 @@ describe("server/services/rendering/ssr.service", () => {
 
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 404);
-        assertEquals(result.errorType, "not-found");
+        assertEquals(result.failure?.kind, "not-found");
         assertEquals(result.cacheStrategy, "no-cache");
       });
 
@@ -484,8 +492,8 @@ describe("server/services/rendering/ssr.service", () => {
 
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 302);
-        assertEquals(result.errorType, "redirect");
-        assertEquals(result.redirectLocation, "/login");
+        assertEquals(result.failure?.kind, "redirect");
+        assertEquals(redirectLocationOf(result), "/login");
         assertEquals(result.cacheStrategy, "no-cache");
       });
 
@@ -509,7 +517,7 @@ describe("server/services/rendering/ssr.service", () => {
         );
 
         assertEquals(result.status, 404);
-        assertEquals(result.errorType, "not-found");
+        assertEquals(result.failure?.kind, "not-found");
         assertEquals(result.isStreaming, false);
         assertEquals(result.cacheStrategy, "no-cache");
       });
@@ -534,8 +542,8 @@ describe("server/services/rendering/ssr.service", () => {
         );
 
         assertEquals(result.status, 302);
-        assertEquals(result.errorType, "redirect");
-        assertEquals(result.redirectLocation, "/login");
+        assertEquals(result.failure?.kind, "redirect");
+        assertEquals(redirectLocationOf(result), "/login");
         assertEquals(result.isStreaming, false);
         assertEquals(result.cacheStrategy, "no-cache");
       });
@@ -552,7 +560,7 @@ describe("server/services/rendering/ssr.service", () => {
 
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 301);
-        assertEquals(result.redirectLocation, "/moved");
+        assertEquals(redirectLocationOf(result), "/moved");
       });
 
       it("finds a control result wrapped in an error's cause chain", async () => {
@@ -567,7 +575,7 @@ describe("server/services/rendering/ssr.service", () => {
 
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 404);
-        assertEquals(result.errorType, "not-found");
+        assertEquals(result.failure?.kind, "not-found");
       });
 
       it("finds a control result wrapped in an AggregateError", async () => {
@@ -582,7 +590,7 @@ describe("server/services/rendering/ssr.service", () => {
 
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 302);
-        assertEquals(result.redirectLocation, "/login");
+        assertEquals(redirectLocationOf(result), "/login");
       });
 
       it("treats an unbranded notFound-shaped throw as a server error", async () => {
@@ -600,7 +608,7 @@ describe("server/services/rendering/ssr.service", () => {
 
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 500);
-        assertEquals(result.errorType, "server-error");
+        assertEquals(result.failure?.kind, "server-error");
       });
 
       it("returns server-error for generic errors in production", async () => {
@@ -624,8 +632,7 @@ describe("server/services/rendering/ssr.service", () => {
         try {
           const result = await service.renderPage(makeCtx(), makeRenderOptions());
           assertEquals(result.status, 500);
-          assertEquals(result.errorType, "server-error");
-          assertEquals(result.showDevOverlay, undefined);
+          assertEquals(result.failure?.kind, "server-error");
           assertEquals(typeof result.html, "string");
           assertEquals(captured.length, 1);
           assertEquals((captured[0]?.error as Error).message, "Something broke");
@@ -662,7 +669,7 @@ describe("server/services/rendering/ssr.service", () => {
         try {
           const result = await service.renderPage(makeCtx(), makeRenderOptions());
           assertEquals(result.status, 500);
-          assertEquals(result.errorType, "app-router-error-boundary");
+          assertEquals(result.failure?.kind, "app-router-error-boundary");
           assertEquals(result.html, renderError.errorBoundaryHtml);
           assertEquals(captured.length, 1);
           assertEquals((captured[0]?.error as Error).message, "App router render failed");
@@ -692,10 +699,11 @@ describe("server/services/rendering/ssr.service", () => {
           makeRenderOptions(),
         );
         assertEquals(result.status, 503);
-        assertEquals(result.errorType, "server-error");
+        // Overload used to reach the handler re-encoded as a generic
+        // server-error; the outcome union keeps it distinguishable.
+        assertEquals(result.failure?.kind, "overloaded");
         assertEquals(result.cacheStrategy, "no-cache");
         assertEquals(result.isStreaming, false);
-        assertEquals(result.showDevOverlay, undefined);
         assertEquals(typeof result.html, "string");
         assertEquals(result.html?.includes("503"), true);
         assertEquals(result.html?.includes("Service Temporarily Unavailable"), true);
@@ -714,8 +722,7 @@ describe("server/services/rendering/ssr.service", () => {
         const ctx = makeCtx({ isLocalProject: true });
         const result = await service.renderPage(ctx, makeRenderOptions());
         assertEquals(result.status, 500);
-        assertEquals(result.errorType, "runtime");
-        assertEquals(result.showDevOverlay, true);
+        assertEquals(result.failure?.kind, "runtime");
         assertEquals(result.html?.includes('nonce="test-nonce"'), true);
       });
     });

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -7,6 +7,7 @@ import {
 import { getHeapStats } from "#veryfront/utils/memory/index.ts";
 import { serverLogger, timeAsync } from "#veryfront/utils";
 import { computeSSRETag } from "../../handlers/request/ssr/etag-handler.ts";
+import type { SSRFailureOutcome } from "#veryfront/rendering/ssr-outcome.ts";
 import { findSSRControlOutcome, resolveSSRFailure } from "#veryfront/rendering/ssr-outcome.ts";
 import { getColorSchemeFromRequest } from "#veryfront/security/http/client-hints.ts";
 import {
@@ -64,16 +65,14 @@ export interface SSRRenderResult {
   isStreaming: boolean;
   etag?: string;
   cacheStrategy: "no-cache" | "short";
-  error?: Error;
-  errorType?:
-    | "not-found"
-    | "undeployed"
-    | "redirect"
-    | "server-error"
-    | "runtime"
-    | "app-router-error-boundary";
-  showDevOverlay?: boolean;
-  redirectLocation?: string;
+  /**
+   * How the render ended, when it did not end in a page.
+   *
+   * Absent on success. Carried whole rather than flattened into status-plus-
+   * flags so callers discriminate on `kind` instead of reconstructing the
+   * decision the SSR Outcome module already made.
+   */
+  failure?: SSRFailureOutcome;
   slug: string;
   /** Dependency snapshot identity rendered into this document. */
   dependencyPinningCacheKey?: string;
@@ -110,17 +109,14 @@ export interface MemoryStatus {
  * `render-error` paths, so a change to redirect handling lands in one place.
  */
 function buildRedirectResult(
-  redirect: { destination: string; permanent?: boolean },
-  errorObj: Error,
+  redirect: Extract<SSRFailureOutcome, { kind: "redirect" }>,
   slug: string,
 ): SSRRenderResult {
   return {
     status: redirect.permanent ? 301 : HTTP_REDIRECT_FOUND,
     isStreaming: false,
     cacheStrategy: "no-cache",
-    error: errorObj,
-    errorType: "redirect",
-    redirectLocation: redirect.destination,
+    failure: redirect,
     slug,
   };
 }
@@ -135,7 +131,7 @@ function buildNotFoundResult(slug: string): SSRRenderResult {
     html: ErrorPages.notFound(slug || "/"),
     isStreaming: false,
     cacheStrategy: "no-cache",
-    errorType: "not-found",
+    failure: { kind: "not-found" },
     slug,
   };
 }
@@ -322,7 +318,6 @@ export class SSRService implements SSRServiceLike {
     request: Request,
     nonce?: string,
   ): SSRRenderResult {
-    const errorObj = error instanceof Error ? error : new Error(String(error));
     const outcome = resolveSSRFailure(error, { isLocalProject: Boolean(ctx.isLocalProject) });
 
     switch (outcome.kind) {
@@ -336,7 +331,7 @@ export class SSRService implements SSRServiceLike {
           html: outcome.html,
           isStreaming: false,
           cacheStrategy: "no-cache",
-          errorType: "app-router-error-boundary",
+          failure: outcome,
           slug,
         };
       case "redirect":
@@ -346,11 +341,7 @@ export class SSRService implements SSRServiceLike {
           permanent: outcome.permanent,
           projectSlug: ctx.projectSlug,
         });
-        return buildRedirectResult(
-          { destination: outcome.location, permanent: outcome.permanent },
-          errorObj,
-          slug,
-        );
+        return buildRedirectResult(outcome, slug);
       case "not-found":
         logger.debug("SSR notFound", { slug });
         return buildNotFoundResult(slug);
@@ -364,7 +355,7 @@ export class SSRService implements SSRServiceLike {
           html: ErrorPages.undeployed(),
           isStreaming: false,
           cacheStrategy: "no-cache",
-          errorType: "undeployed",
+          failure: outcome,
           slug,
         };
       case "overloaded":
@@ -373,8 +364,7 @@ export class SSRService implements SSRServiceLike {
           html: ErrorPages.memoryPressure(),
           isStreaming: false,
           cacheStrategy: "no-cache",
-          error: outcome.error,
-          errorType: "server-error",
+          failure: outcome,
           slug,
         };
       case "runtime":
@@ -414,9 +404,7 @@ export class SSRService implements SSRServiceLike {
             ),
             isStreaming: false,
             cacheStrategy: "no-cache",
-            error: outcome.error,
-            errorType: "runtime",
-            showDevOverlay: true,
+            failure: outcome,
             slug,
           };
         }
@@ -438,8 +426,7 @@ export class SSRService implements SSRServiceLike {
           html: ErrorPages.serverError(),
           isStreaming: false,
           cacheStrategy: "no-cache",
-          error: outcome.error,
-          errorType: "server-error",
+          failure: outcome,
           slug,
         };
     }


### PR DESCRIPTION
## Summary

Second-wave adoption of the SSR Outcome module (#3181). Two commits:

**1. Route the remaining SSR classifiers through SSR Outcome** — the two sibling data endpoints still classified errors by substring-matching (`"not found" || "404" || "no page"`) and shape-reading `.context.redirect`, so one branded `notFound()` got three different recognitions depending on which endpoint the browser hit.

- `page-data-endpoint-handler.ts` / `data-endpoint-handler.ts`: substring classifiers and `extractRedirectFromError` deleted; both route through new `resolveSSRControlOutcome` on `ssr-outcome.ts`, which covers the three brands the pipeline actually raises (DataResult control, file-not-found, render-error + redirect context). `findSSRControlOutcome` / `isSSRControlOutcome` semantics untouched — the orchestrator and streaming paths are unaffected.
- `ssr.handler.ts`'s `isBuildError` moved whole into the module as `isSSRBuildFailure`.
- Producer trace confirmed every real not-found producer into these endpoints was already branded (`PageResolver` FILE_NOT_FOUND; pipeline `applyFetchedDataResults` normalizes loader `notFound()`/`redirect()` in-realm before the worker boundary). **Intended behavior change:** an unbranded error whose message merely contains "not found"/"404"/"no page" now answers 500 instead of 404 — message text is not an interface.

**2. Carry the SSR failure outcome whole out of the SSR service** — the follow-up #3181 explicitly deferred. `SSRRenderResult`'s four failure optionals (`error`, `errorType`, `showDevOverlay`, `redirectLocation`) collapse into `failure?: SSRFailureOutcome`; the handler re-discriminates once, in a single switch on `failure.kind`. `overloaded` is listed explicitly so it keeps rendering the custom error page (previously an accident of the collapse to `"server-error"`); the overloaded test assertion is correspondingly strengthened. Grep-verified: no other consumer of the removed fields; `ssr-response-builder` reads success fields only; nothing serialized.

Three redirect tests that built duck-typed `Object.assign(new Error(), {slug: "render-error"})` errors the pipeline never produces were switched to the real `RENDER_ERROR.create(...)`; assertions unchanged.

## Review

Independent code-review pass: approve, zero defects — producer coverage, cycle/cross-realm safety, removed-field consumers, and dev-overlay equivalence all verified.

## Tested

- src/server/: 161 passed (1958 steps); src/rendering/: 101 passed (1563 steps); targeted suites 15 files / 239 steps (was 219)
- typecheck, lint, fmt, module/dependency-boundaries green individually; pre-push (fmt + full suite) passed
- Note: `verify:quick` cannot complete on any branch off current main — `lint:cli-boundary` breakage from #3187; the repair rides in the Project Resolution PR of this batch