### PR TITLE
Centralize project resolution behind one module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,6 +39,20 @@ deploy tool are presentation adapters over this module; the control plane
 deployment is verified **and** ready; no adapter skips or re-implements
 verification, polling, or readiness waits.
 
+## Project Resolution
+
+The single owner of "which project does this directory target, and does it
+exist on the control plane?": `cli/shared/project-resolution.ts`
+(`resolveOrCreateProject`). One request carries the project directory, the
+resolved config, the reference source, and whether the run may create or only
+plan; it settles into one typed outcome — existing, created, or
+planned-create. Push, deploy, up, demo, and the TUI are presentation adapters
+over this module: they own their wording, spinners, and typed-error phrasing,
+never the decision. There is exactly one persisted link format
+(`.veryfront/project.json`), written only for references a directory owns
+(inferred or local-link) and never on a dry run. The project client
+(control plane over HTTP, CLI API client, fake in tests) is its one seam.
+
 ## Stream Delivery
 
 The separate agent-loop fan-out boundary that will route lifecycle frames to

--- a/cli/app/operations/project-creation.test.ts
+++ b/cli/app/operations/project-creation.test.ts
@@ -1,0 +1,91 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
+import { join } from "veryfront/platform/path";
+import { createProject } from "./project-creation.ts";
+import { createInitialState } from "../state.ts";
+
+const API_URL = "https://control.example.test";
+const TOKEN = "vf_test_token";
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    Deno.env.delete(name);
+    return;
+  }
+  Deno.env.set(name, value);
+}
+
+describe("TUI project creation", () => {
+  it("links the created project when the reservation omits the id", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalCwd = Deno.cwd();
+    const envKeys = ["VERYFRONT_API_URL", "VERYFRONT_API_BASE_URL", "XDG_CONFIG_HOME"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+    const workDir = await Deno.makeTempDir();
+    const configHome = await Deno.makeTempDir();
+    const requests: string[] = [];
+
+    try {
+      await Deno.mkdir(join(configHome, "veryfront"), { recursive: true });
+      await Deno.writeTextFile(join(configHome, "veryfront", "token"), TOKEN);
+      Deno.env.set("VERYFRONT_API_URL", API_URL);
+      Deno.env.delete("VERYFRONT_API_BASE_URL");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+      _resetEnvironmentConfig();
+      Deno.chdir(workDir);
+
+      globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        requests.push(`${request.method} ${url.pathname}`);
+
+        // The reservation succeeds but the response carries no id, which is
+        // what reserveProjectSlug normalizes to an empty projectId.
+        if (request.method === "POST" && url.pathname === "/projects") {
+          return Promise.resolve(Response.json({}));
+        }
+        if (request.method === "GET" && url.pathname === "/projects/my-app") {
+          return Promise.resolve(Response.json({ id: "proj_canonical", slug: "my-app" }));
+        }
+        if (request.method === "GET" && url.pathname === "/projects") {
+          return Promise.resolve(Response.json({ data: [], page_info: {} }));
+        }
+
+        throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+      }) as typeof fetch;
+
+      const state = await createProject(
+        { state: createInitialState(), render: () => {} },
+        "My App",
+        "minimal",
+      );
+
+      const link = JSON.parse(
+        await Deno.readTextFile(
+          join(workDir, "projects", "my-app", ".veryfront", "project.json"),
+        ),
+      );
+      assertEquals(link, {
+        version: 1,
+        controlPlane: API_URL,
+        projectId: "proj_canonical",
+        projectSlug: "my-app",
+      });
+      assertEquals(requests.includes("GET /projects/my-app"), true);
+      assertEquals(
+        state.logs.some((entry) => entry.message.includes("Created my-app")),
+        true,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      Deno.chdir(originalCwd);
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+      await Deno.remove(workDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
+  });
+});

--- a/cli/app/operations/project-creation.ts
+++ b/cli/app/operations/project-creation.ts
@@ -14,7 +14,9 @@ import { fetchRemoteProjects } from "../../sync/index.ts";
 import { getLocalProjectsFromState } from "../utils.ts";
 import { reserveProjectSlug } from "../../shared/reserve-slug.ts";
 import { normalizeProjectSlug } from "../../shared/slug.ts";
-import { persistProjectLink } from "../../shared/project-resolution.ts";
+import { resolveOrCreateProject } from "../../shared/project-resolution.ts";
+import { createApiClient, type ResolvedConfig } from "../../shared/config.ts";
+import { getProjectTarget } from "../../shared/deployment-provenance.ts";
 import { resolveCliApiUrl } from "../../shared/constants.ts";
 import { createProject as createSharedProject } from "../../shared/project-creation.ts";
 import type { InitTemplate } from "../../commands/init/types.ts";
@@ -61,15 +63,26 @@ export async function createProject(
       includePackageMetadata: false,
     });
 
-    // A project the TUI just reserved is this directory's project: record the
-    // canonical link so every later command resolves it without inference.
-    if (reserved.projectId) {
-      await persistProjectLink(
-        creation.projectDir,
-        { apiUrl: resolveCliApiUrl(), apiToken: token, projectSlug: slug },
-        { id: reserved.projectId, slug },
-      );
-    }
+    // A project the TUI just reserved is this directory's project, so it
+    // resolves through the same owner as every other create: reservation
+    // responses that omit the id still settle on the canonical one, and the
+    // link is always written.
+    const config: ResolvedConfig = {
+      apiUrl: resolveCliApiUrl(),
+      apiToken: token,
+      projectSlug: slug,
+    };
+    await resolveOrCreateProject({
+      projectDir: creation.projectDir,
+      config,
+      source: { kind: "inferred", name: "project files" },
+      client: {
+        getProject: (reference) => getProjectTarget(createApiClient(config), reference),
+        // The slug is reserved before scaffolding so the directory can take
+        // its name; hand that reservation over rather than taking a second.
+        reserveSlug: () => Promise.resolve(reserved),
+      },
+    });
 
     const currentProjects = getLocalProjectsFromState(state);
     currentProjects.push({ slug, path: creation.projectDir });

--- a/cli/app/operations/project-creation.ts
+++ b/cli/app/operations/project-creation.ts
@@ -11,8 +11,11 @@ import type { AppState } from "../state.ts";
 import { addLog, setProjects, updateRemote } from "../state.ts";
 import { readToken } from "../../auth/token-store.ts";
 import { fetchRemoteProjects } from "../../sync/index.ts";
-import { getLocalProjectsFromState, normalizeSlug } from "../utils.ts";
+import { getLocalProjectsFromState } from "../utils.ts";
 import { reserveProjectSlug } from "../../shared/reserve-slug.ts";
+import { normalizeProjectSlug } from "../../shared/slug.ts";
+import { persistProjectLink } from "../../shared/project-resolution.ts";
+import { resolveCliApiUrl } from "../../shared/constants.ts";
 import { createProject as createSharedProject } from "../../shared/project-creation.ts";
 import type { InitTemplate } from "../../commands/init/types.ts";
 
@@ -40,8 +43,9 @@ export async function createProject(
       return addLog("error", "Not authenticated. Press 'a' to login.")(state);
     }
 
-    const normalizedSlug = normalizeSlug(projectName);
-    const { slug } = await reserveProjectSlug(normalizedSlug, token);
+    const normalizedSlug = normalizeProjectSlug(projectName);
+    const reserved = await reserveProjectSlug(normalizedSlug, token);
+    const slug = reserved.slug;
 
     const creation = await createSharedProject({
       name: slug,
@@ -56,6 +60,16 @@ export async function createProject(
       initializeGit: false,
       includePackageMetadata: false,
     });
+
+    // A project the TUI just reserved is this directory's project: record the
+    // canonical link so every later command resolves it without inference.
+    if (reserved.projectId) {
+      await persistProjectLink(
+        creation.projectDir,
+        { apiUrl: resolveCliApiUrl(), apiToken: token, projectSlug: slug },
+        { id: reserved.projectId, slug },
+      );
+    }
 
     const currentProjects = getLocalProjectsFromState(state);
     currentProjects.push({ slug, path: creation.projectDir });

--- a/cli/app/utils.ts
+++ b/cli/app/utils.ts
@@ -17,10 +17,6 @@ export function generateRandomSlug(): string {
   return `${adj}-${noun}`;
 }
 
-export function normalizeSlug(projectName: string): string {
-  return projectName.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
-}
-
 export function getLocalProjectsFromState(
   appState: AppState,
 ): Array<{ slug: string; path: string }> {

--- a/cli/commands/demo/demo.test.ts
+++ b/cli/commands/demo/demo.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { type DemoOptions, resolveDemoReservedProject } from "./demo.ts";
+import type { DemoOptions } from "./demo.ts";
 import { DEMO_STEPS } from "./steps.ts";
 
 const LOGIN_METHODS = ["google", "github", "microsoft", "token"] as const;
@@ -101,26 +101,5 @@ describe("Demo auto mode configuration", () => {
       projectName: "auto-test-project",
     };
     assertEquals(options.projectName, "auto-test-project");
-  });
-});
-
-describe("demo project registration", () => {
-  it("looks up the canonical project id when slug reservation omits it", async () => {
-    const result = await resolveDemoReservedProject(
-      { slug: "demo-canonical", projectId: "", created: true },
-      "token",
-      {
-        get: <T>(path: string): Promise<T> => {
-          assertEquals(path, "/projects/demo-canonical");
-          return Promise.resolve({ id: "proj_canonical", slug: "demo-canonical" } as T);
-        },
-        post: () => Promise.reject(new Error("unexpected post")),
-        put: () => Promise.reject(new Error("unexpected put")),
-        patch: () => Promise.reject(new Error("unexpected patch")),
-        delete: () => Promise.reject(new Error("unexpected delete")),
-      },
-    );
-
-    assertEquals(result, { id: "proj_canonical", slug: "demo-canonical" });
   });
 });

--- a/cli/commands/demo/demo.ts
+++ b/cli/commands/demo/demo.ts
@@ -38,14 +38,14 @@ import {
   resolveCliApiUrl,
 } from "#cli/shared/constants";
 import { createProject as createSharedProject } from "../../shared/project-creation.ts";
-import { writeProjectLink } from "../../shared/project-link.ts";
 import { randomSuffix } from "#cli/shared/slug";
 import { deployCommand } from "../deploy/index.ts";
 import { pushCommand } from "../push/index.ts";
 import { devCommand } from "../dev/index.ts";
-import { type ApiClient, createApiClient } from "#cli/shared/config";
-import { getProjectTarget, type ProjectTarget } from "../../shared/deployment-provenance.ts";
-import { reserveProjectSlug, type ReserveResult } from "#cli/shared/reserve-slug";
+import { createApiClient, type ResolvedConfig } from "#cli/shared/config";
+import { resolveOrCreateProject } from "#cli/shared/project-resolution";
+import { getProjectTarget } from "../../shared/deployment-provenance.ts";
+import { reserveProjectSlug } from "#cli/shared/reserve-slug";
 import { DEMO_STEPS, type DemoStep } from "./steps.ts";
 
 // ANSI escape codes
@@ -69,22 +69,6 @@ const AUTH_OPTIONS: { id: AuthMethod; label: string }[] = [
   { id: "microsoft", label: "Microsoft" },
   { id: "token", label: "API Token" },
 ];
-
-export async function resolveDemoReservedProject(
-  reserveResult: ReserveResult,
-  token: string,
-  client: ApiClient = createApiClient({
-    apiUrl: resolveCliApiUrl(),
-    apiToken: token,
-    projectSlug: reserveResult.slug,
-  }),
-): Promise<ProjectTarget> {
-  if (reserveResult.projectId) {
-    return { id: reserveResult.projectId, slug: reserveResult.slug };
-  }
-
-  return getProjectTarget(client, reserveResult.slug);
-}
 
 function clearCountdownLine(): void {
   write(`\r  ${" ".repeat(30)}\r`);
@@ -377,14 +361,32 @@ async function executeStepAction(
       console.log(`  ${dim("Registering project...")}`);
 
       try {
-        const reserveResult = await reserveProjectSlug(slug, token);
-        const project = await resolveDemoReservedProject(reserveResult, token);
-        await writeProjectLink(projectDir, {
-          controlPlane: resolveCliApiUrl(),
-          projectId: project.id,
-          projectSlug: project.slug,
+        const demoConfig: ResolvedConfig = {
+          apiUrl: resolveCliApiUrl(),
+          apiToken: token,
+          projectSlug: slug,
+        };
+        const outcome = await resolveOrCreateProject({
+          projectDir,
+          config: demoConfig,
+          source: { kind: "inferred", name: "project files" },
+          client: {
+            getProject: (reference) => getProjectTarget(createApiClient(demoConfig), reference),
+            reserveSlug: async (reserveSlug, options) => {
+              const reserved = await reserveProjectSlug(
+                reserveSlug,
+                token,
+                undefined,
+                undefined,
+                options,
+              );
+              return { slug: reserved.slug, projectId: reserved.projectId };
+            },
+          },
         });
-        actualProjectSlug = project.slug;
+        actualProjectSlug = outcome.kind === "planned-create"
+          ? outcome.plannedSlug
+          : outcome.project.slug;
         console.log("  ✓ Project registered");
 
         console.log(`  ${dim("Pushing code...")}`);

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -130,7 +130,11 @@ async function assertMissingProjectDryRunDoesNotMutate(branch: string): Promise<
         const url = new URL(request.url);
         requests.push(`${request.method} ${url.pathname}`);
 
-        if (request.method === "GET" && url.pathname === "/projects/missing-project/files") {
+        if (
+          request.method === "GET" &&
+          (url.pathname === "/projects/missing-project" ||
+            url.pathname === "/projects/missing-project/files")
+        ) {
           return Response.json({ error: "not found" }, { status: 404 });
         }
         if (request.method === "POST" && url.pathname === "/projects") {
@@ -153,7 +157,7 @@ async function assertMissingProjectDryRunDoesNotMutate(branch: string): Promise<
         quiet: true,
       });
 
-      assertEquals(requests, ["GET /projects/missing-project/files"]);
+      assertEquals(requests, ["GET /projects/missing-project"]);
       assertEquals(await readPushReceipt(projectDir), null);
     });
   } finally {
@@ -311,6 +315,9 @@ describe("push JSON output", () => {
       globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
         const request = input instanceof Request ? input : new Request(input, init);
         const url = new URL(request.url);
+        if (request.method === "GET" && url.pathname === "/projects/json-project") {
+          return Response.json({ id: "proj_json", slug: "json-project" });
+        }
         if (request.method === "GET" && url.pathname === "/projects/json-project/files") {
           return Response.json({ data: [], page_info: {} });
         }
@@ -363,6 +370,9 @@ describe("push JSON output", () => {
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
+          if (request.method === "GET" && url.pathname === "/projects/json-project") {
+            return Response.json({ id: "proj_json", slug: "json-project" });
+          }
           if (request.method === "GET" && url.pathname === "/projects/json-project/files") {
             return Response.json({ data: [], page_info: {} });
           }
@@ -415,6 +425,9 @@ describe("push JSON output", () => {
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
+          if (request.method === "GET" && url.pathname === "/projects/json-project") {
+            return Response.json({ id: "proj_json", slug: "json-project" });
+          }
           if (request.method === "GET" && url.pathname === "/projects/json-project/files") {
             return Response.json({ data: [], page_info: {} });
           }
@@ -469,6 +482,9 @@ describe("push JSON output", () => {
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
+          if (request.method === "GET" && url.pathname === "/projects/json-project") {
+            return Response.json({ id: "proj_json", slug: "json-project" });
+          }
           if (request.method === "GET" && url.pathname === "/projects/json-project/files") {
             return Response.json({
               data: [
@@ -1191,7 +1207,11 @@ describe("push receipt source snapshot", () => {
       globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
         const request = input instanceof Request ? input : new Request(input, init);
         const url = new URL(request.url);
-        if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+        if (
+          request.method === "GET" &&
+          (url.pathname === "/projects/my-project" ||
+            url.pathname === "/projects/my-project/files")
+        ) {
           return Response.json({ error: "not found" }, { status: 404 });
         }
         if (request.method === "POST" && url.pathname === "/projects") {
@@ -1300,8 +1320,8 @@ describe("push receipt source snapshot", () => {
       }
 
       assertEquals(requests, [
-        "GET /projects/missing-project-id/files",
-        "GET /projects/missing-project-id/files",
+        "GET /projects/missing-project-id",
+        "GET /projects/missing-project-id",
       ]);
     } finally {
       globalThis.fetch = originalFetch;
@@ -1559,6 +1579,9 @@ describe("push failure ordering", () => {
           const url = new URL(request.url);
           requests.push(`${request.method} ${url.pathname}`);
 
+          if (request.method === "GET" && url.pathname === "/projects/my-project") {
+            return Response.json({ id: "project-old", slug: "my-project" });
+          }
           if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
             return Response.json({
               data: [{

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -20,7 +20,17 @@ import {
   resolveConfigWithAuthDetails,
   type ResolvedConfig,
 } from "#cli/shared/config";
-import { writeProjectLink } from "../../shared/project-link.ts";
+import {
+  canPersistAlternativeSlug,
+  getErrorStatus,
+  projectApiReference,
+  ProjectReferenceNotFoundError,
+  type ProjectResolutionClient,
+  type ProjectResolutionOutcome,
+  resolveOrCreateProject,
+  shouldPersistProjectLink,
+  slugConflictAction,
+} from "#cli/shared/project-resolution";
 import { ProjectSlugConflictError, reserveProjectSlug } from "#cli/shared/reserve-slug";
 import { isVerbose, logInfo, logSuccess } from "#cli/utils";
 import { INVALID_ARGUMENT, PREVIEW_HOSTNAME_TOO_LONG } from "veryfront/errors";
@@ -214,58 +224,13 @@ function sourceChangedError(): Error {
   return new Error("Local source changed during push. Run veryfront push again.");
 }
 
-function canPersistAlternativeSlug(source: ProjectReferenceSource): boolean {
-  return source.kind === "inferred";
-}
-
-function shouldPersistProjectLink(source: ProjectReferenceSource): boolean {
-  return source.kind === "inferred" || source.kind === "local-link";
-}
-
-function projectApiReference(config: ResolvedConfig): string {
-  return config.projectId ?? config.projectSlug;
-}
-
-async function persistProjectLink(
-  projectDir: string,
-  config: ResolvedConfig,
-  project: { id: string; slug: string },
-): Promise<ResolvedConfig> {
-  await writeProjectLink(projectDir, {
-    controlPlane: config.apiUrl,
-    projectId: project.id,
-    projectSlug: project.slug,
-  });
-  return { ...config, projectId: project.id, projectSlug: project.slug };
-}
-
 function projectSlugConflictError(
   error: ProjectSlugConflictError,
   source: ProjectReferenceSource,
 ): Error {
-  let action: string;
-  switch (source.kind) {
-    case "argument":
-      action = "Use a different --project value";
-      break;
-    case "environment":
-      action = "Update or remove VERYFRONT_PROJECT_SLUG";
-      break;
-    case "module-config":
-      action = `Update projectSlug in ${source.name}`;
-      break;
-    case "tenant-environment":
-      action = `Update or remove ${source.name}`;
-      break;
-    case "json-config":
-    case "inferred":
-      action = "Choose a different project slug";
-      break;
-    case "local-link":
-      action = "Relink this project";
-      break;
-  }
-  return new Error(`${error.message} ${action}, then run veryfront push again.`);
+  return new Error(
+    `${error.message} ${slugConflictAction(source)}, then run veryfront push again.`,
+  );
 }
 
 async function sourceFilesForGitTracking(
@@ -425,12 +390,6 @@ export function createBranch(
   return client.post<BranchResponse>(`/projects/${encodeURIComponent(projectSlug)}/branches`, {
     name: branchName,
   });
-}
-
-function getErrorStatus(error: unknown): number | undefined {
-  if (typeof error !== "object" || error === null) return undefined;
-  const status = (error as { status?: unknown }).status;
-  return typeof status === "number" ? status : undefined;
 }
 
 async function getBranchByName(
@@ -667,50 +626,6 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       let mainFiles: RemoteFile[] = [];
       let projectExists = true;
 
-      const createProject = async (): Promise<void> => {
-        spinner.update("Creating project...");
-        let reserveResult: Awaited<ReturnType<typeof reserveProjectSlug>>;
-        try {
-          reserveResult = await reserveProjectSlug(
-            config.projectSlug,
-            config.apiToken,
-            undefined,
-            config.apiUrl,
-            { allowAlternativeSlug: canPersistAlternativeSlug(projectReferenceSource) },
-          );
-        } catch (reserveError) {
-          spinner.stop();
-          if (reserveError instanceof ProjectSlugConflictError) {
-            throw projectSlugConflictError(reserveError, projectReferenceSource);
-          }
-          throw reserveError;
-        }
-        let project = reserveResult.projectId
-          ? { id: reserveResult.projectId, slug: reserveResult.slug }
-          : null;
-        const reservedSlugChanged = reserveResult.slug !== config.projectSlug;
-        const configWithReservedSlug = { ...config, projectSlug: reserveResult.slug };
-        if (!project) {
-          project = await getProjectTarget(client, reserveResult.slug);
-        }
-        if (shouldPersistProjectLink(projectReferenceSource)) {
-          config = await persistProjectLink(projectDir, configWithReservedSlug, project);
-          if (
-            reservedSlugChanged &&
-            !quiet && !jsonOutput
-          ) {
-            logInfo(`Project slug: ${reserveResult.slug}`);
-          }
-        } else {
-          config = configWithReservedSlug;
-        }
-        try {
-          mainFiles = await listAllFiles(client, projectApiReference(config), { type: "main" });
-        } catch {
-          mainFiles = [];
-        }
-      };
-
       const planProjectCreation = (): void => {
         projectExists = false;
         if (!quiet && !jsonOutput) {
@@ -718,27 +633,68 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         }
       };
 
-      if (projectReferenceSource.kind === "inferred") {
-        if (dryRun) planProjectCreation();
-        else await createProject();
+      const resolutionClient: ProjectResolutionClient = {
+        getProject: (reference) => getProjectTarget(client, reference),
+        reserveSlug: async (slug, options) => {
+          spinner.update("Creating project...");
+          const reserved = await reserveProjectSlug(
+            slug,
+            config.apiToken,
+            undefined,
+            config.apiUrl,
+            options,
+          );
+          return { slug: reserved.slug, projectId: reserved.projectId };
+        },
+      };
+
+      let outcome: ProjectResolutionOutcome;
+      try {
+        outcome = await resolveOrCreateProject({
+          projectDir,
+          config,
+          source: projectReferenceSource,
+          client: resolutionClient,
+          createMissingReference: true,
+          allowAlternativeSlug: canPersistAlternativeSlug(projectReferenceSource),
+          dryRun,
+        });
+      } catch (error) {
+        spinner.stop();
+        if (error instanceof ProjectSlugConflictError) {
+          throw projectSlugConflictError(error, projectReferenceSource);
+        }
+        if (error instanceof ProjectReferenceNotFoundError && error.byId) {
+          throw new Error(
+            `Project "${error.reference}" was not found. Check ${projectReferenceSource.name} or remove it to let Veryfront create a project for this directory.`,
+          );
+        }
+        throw error;
+      }
+
+      if (outcome.kind === "planned-create") {
+        planProjectCreation();
       } else {
-        try {
+        if (outcome.kind === "created") {
+          if (outcome.persisted && outcome.project.slug !== outcome.requestedSlug) {
+            if (!quiet && !jsonOutput) logInfo(`Project slug: ${outcome.project.slug}`);
+          }
+          config = outcome.config;
+          // A just-created project has no files yet; a listing failure here is
+          // not a reason to fail the push.
+          try {
+            mainFiles = await listAllFiles(client, projectApiReference(config), { type: "main" });
+          } catch {
+            mainFiles = [];
+          }
+        } else {
+          // An existing project only adopts the resolved identity when the
+          // reference is one this directory owns, or was already an id.
+          config = outcome.persisted || shouldPersistProjectLink(projectReferenceSource) ||
+              config.projectId
+            ? outcome.config
+            : config;
           mainFiles = await listAllFiles(client, projectApiReference(config), { type: "main" });
-          if (shouldPersistProjectLink(projectReferenceSource) || config.projectId) {
-            const project = await getProjectTarget(client, projectApiReference(config));
-            config = !dryRun && shouldPersistProjectLink(projectReferenceSource)
-              ? await persistProjectLink(projectDir, config, project)
-              : { ...config, projectId: project.id, projectSlug: project.slug };
-          }
-        } catch (error) {
-          if (getErrorStatus(error) !== 404) throw error;
-          if (config.projectId) {
-            throw new Error(
-              `Project "${config.projectId}" was not found. Check ${projectReferenceSource.name} or remove it to let Veryfront create a project for this directory.`,
-            );
-          }
-          if (dryRun) planProjectCreation();
-          else await createProject();
         }
       }
 

--- a/cli/commands/up/command.test.ts
+++ b/cli/commands/up/command.test.ts
@@ -235,7 +235,7 @@ describe("Up Command", () => {
           }
 
           if (
-            url.endsWith(`/projects/${expectedSlug}`) &&
+            (url.endsWith(`/projects/${expectedSlug}`) || url.endsWith("/projects/project-1")) &&
             method === "GET"
           ) {
             return Promise.resolve(
@@ -244,7 +244,8 @@ describe("Up Command", () => {
           }
 
           if (
-            url.includes(`/projects/${expectedSlug}/files/`) &&
+            (url.includes(`/projects/${expectedSlug}/files/`) ||
+              url.includes("/projects/project-1/files/")) &&
             method === "PUT"
           ) {
             const path = decodeURIComponent(new URL(url).pathname.split("/files/")[1] ?? "");
@@ -395,6 +396,24 @@ describe("Up Command", () => {
         );
         const expectedName = capitalizeSeparatedWords(expectedSlug, "-", " ");
         assertEquals(projectCreateBody, { slug: expectedSlug, name: expectedName });
+
+        assertEquals(
+          JSON.parse(await Deno.readTextFile(join(tempDir, ".veryfront", "project.json"))),
+          {
+            version: 1,
+            controlPlane: "https://api.from-env.test",
+            projectId: "project-1",
+            projectSlug: expectedSlug,
+          },
+        );
+        let veryfrontJsonExists = true;
+        try {
+          await Deno.stat(join(tempDir, "veryfront.json"));
+        } catch {
+          veryfrontJsonExists = false;
+        }
+        assertEquals(veryfrontJsonExists, false);
+
         const humanOutput = output.join("\n");
         assertEquals(humanOutput.includes("Studio:"), true);
         assertEquals(humanOutput.includes("Preview:"), true);
@@ -441,6 +460,9 @@ describe("Up Command", () => {
 
           if (request.method === "GET" && url.pathname === "/me") {
             return Response.json({ id: "user-1", email: "dev@example.com" });
+          }
+          if (request.method === "GET" && url.pathname === "/projects/json-up") {
+            return Response.json({ id: "project-1", slug: "json-up" });
           }
           if (request.method === "GET" && url.pathname === "/projects/json-up/files") {
             return Response.json({ data: [], page_info: {} });

--- a/cli/commands/up/command.ts
+++ b/cli/commands/up/command.ts
@@ -2,7 +2,6 @@ import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
 import { cliLogger, exitProcess } from "#cli/utils";
 import { cwd } from "veryfront/platform";
-import { join } from "veryfront/platform/path";
 import { createFileSystem } from "veryfront/platform";
 import { brand, createNoopSpinner, dim } from "#cli/ui";
 import { ensureAuthenticated } from "../../auth/index.ts";
@@ -12,12 +11,17 @@ import { isTTY, promptUser } from "#cli/utils";
 import { logSuccess, logWarning } from "#cli/utils";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
 import {
+  createApiClient,
   resolveConfigWithAuthDetails,
   type ResolvedConfig,
-  type VeryfrontConfig,
 } from "#cli/shared/config";
 import { reserveProjectSlug } from "#cli/shared/reserve-slug";
 import { normalizeProjectSlug } from "#cli/shared/slug";
+import {
+  inferProjectSlugFromDirectory,
+  resolveOrCreateProject,
+} from "#cli/shared/project-resolution";
+import { getProjectTarget } from "../../shared/deployment-provenance.ts";
 import { pushCommand } from "../push/index.ts";
 import { deployCommand } from "../deploy/index.ts";
 import { buildPushUrls } from "../push/command.ts";
@@ -82,25 +86,11 @@ async function analyzeDirectory(
 
   if (!hasCode) return { type: "empty" };
 
-  let suggestedSlug = normalizeProjectSlug(projectDir.split(/[/\\]/).pop() || "my-app");
-  const packagePath = join(projectDir, "package.json");
-  try {
-    if (await fs.exists(packagePath)) {
-      const pkg = JSON.parse(await fs.readTextFile(packagePath)) as { name?: string };
-      if (pkg.name) suggestedSlug = normalizeProjectSlug(pkg.name);
-    }
-  } catch (error) {
-    cliLogger.debug("Failed to read package.json for project slug:", error);
-  }
-  return { type: "has-code", config: resolved.config, suggestedSlug };
-}
-
-async function saveConfig(projectDir: string, config: VeryfrontConfig): Promise<void> {
-  const fs = createFileSystem();
-  await fs.writeTextFile(
-    join(projectDir, "veryfront.json"),
-    `${JSON.stringify(config, null, 2)}\n`,
-  );
+  return {
+    type: "has-code",
+    config: resolved.config,
+    suggestedSlug: await inferProjectSlugFromDirectory(projectDir),
+  };
 }
 
 export async function upCommand(
@@ -171,37 +161,53 @@ export async function upCommand(
       if (trimmed) slug = normalizeProjectSlug(trimmed);
     }
 
-    if (dryRun) {
-      if (!jsonOutput) cliLogger.info(dim(`Would create project: ${slug}`));
-    } else {
-      const projectSpinner = jsonOutput
-        ? createNoopSpinner()
-        : createSpinner(`Creating project "${slug}"...`);
+    const projectSpinner = dryRun || jsonOutput
+      ? createNoopSpinner()
+      : createSpinner(`Creating project "${slug}"...`);
 
-      try {
-        if (!context.config.apiToken) {
-          projectSpinner.stop();
-          throw new Error("Not authenticated");
-        }
-
-        const reserved = await reserveProjectSlug(
-          slug,
-          context.config.apiToken,
-          env,
-          context.config.apiUrl,
-          { allowAlternativeSlug: false },
-        );
-        slug = reserved.slug;
+    try {
+      if (!dryRun && !context.config.apiToken) {
         projectSpinner.stop();
-
-        await saveConfig(projectDir, { projectSlug: slug });
-
-        if (!jsonOutput) logSuccess(`Created project ${slug}`);
-      } catch (error) {
-        projectSpinner.stop();
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Project creation failed: ${message}`, { cause: error });
+        throw new Error("Not authenticated");
       }
+
+      const outcome = await resolveOrCreateProject({
+        projectDir,
+        config: { ...context.config, projectSlug: slug },
+        source: { kind: "inferred", name: "project files" },
+        client: {
+          getProject: (reference) =>
+            getProjectTarget(
+              createApiClient({ ...context.config, projectSlug: slug }),
+              reference,
+            ),
+          reserveSlug: async (reserveSlug, options) => {
+            const reserved = await reserveProjectSlug(
+              reserveSlug,
+              context.config.apiToken,
+              env,
+              context.config.apiUrl,
+              options,
+            );
+            return { slug: reserved.slug, projectId: reserved.projectId };
+          },
+        },
+        allowAlternativeSlug: false,
+        dryRun,
+      });
+      projectSpinner.stop();
+
+      if (outcome.kind === "planned-create") {
+        if (!jsonOutput) cliLogger.info(dim(`Would create project: ${outcome.plannedSlug}`));
+        slug = outcome.plannedSlug;
+      } else {
+        slug = outcome.project.slug;
+        if (!jsonOutput) logSuccess(`Created project ${slug}`);
+      }
+    } catch (error) {
+      projectSpinner.stop();
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Project creation failed: ${message}`, { cause: error });
     }
 
     projectSlug = slug;

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -14,6 +14,7 @@
     "#cli/shared/project-source-context": "./shared/project-source-context.ts",
     "#cli/shared/slug": "./shared/slug.ts",
     "#cli/shared/reserve-slug": "./shared/reserve-slug.ts",
+    "#cli/shared/project-resolution": "./shared/project-resolution.ts",
     "#cli/shared/runtime-auth": "./shared/runtime-auth.ts",
     "#cli/shared/server-startup": "./shared/server-startup.ts",
     "#cli/ui": "./ui/index.ts",

--- a/cli/mcp/tools/deploy-tool.test.ts
+++ b/cli/mcp/tools/deploy-tool.test.ts
@@ -13,7 +13,7 @@ import {
   PROJECT_SLUG,
   withDeployEnv,
   withFetchStub,
-} from "../../shared/deployment/_deploy-test-support.ts";
+} from "../../test-utils/deploy-test-support.ts";
 
 function toolDeployProject(controlPlane: InMemoryDeployControlPlane): DeployProject {
   return createDeployProject({

--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -42,7 +42,7 @@ import {
   readyManifest,
   withDeployEnv,
   withFetchStub,
-} from "./_deploy-test-support.ts";
+} from "../../test-utils/deploy-test-support.ts";
 
 async function expectDeployError(
   fn: () => Promise<unknown>,

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -20,9 +20,17 @@ import {
   resolveGitSource,
   validatePushReceipt,
 } from "../deployment-provenance.ts";
-import { writeProjectLink } from "../project-link.ts";
 import { normalizeProjectSlug } from "../slug.ts";
 import { reserveProjectSlug } from "../reserve-slug.ts";
+import {
+  inferProjectSlugFromDirectory,
+  projectApiReference,
+  ProjectReferenceNotFoundError,
+  type ProjectResolutionClient,
+  type ProjectResolutionOutcome,
+  resolveOrCreateProject,
+  shouldPersistProjectLink,
+} from "../project-resolution.ts";
 import {
   type ProjectReferenceSource,
   resolveConfigWithAuth,
@@ -190,50 +198,6 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function getErrorStatus(error: unknown): number | undefined {
-  if (typeof error !== "object" || error === null) return undefined;
-  const status = (error as { status?: unknown }).status;
-  return typeof status === "number" ? status : undefined;
-}
-
-function projectApiReference(config: ResolvedConfig): string {
-  return config.projectId ?? config.projectSlug;
-}
-
-function shouldPersistProjectLink(source: ProjectReferenceSource): boolean {
-  return source.kind === "inferred" || source.kind === "local-link";
-}
-
-async function inferDeployProjectSlug(projectDir: string): Promise<string> {
-  const fs = createFileSystem();
-  const packagePath = join(projectDir, "package.json");
-
-  try {
-    if (await fs.exists(packagePath)) {
-      const pkg = JSON.parse(await fs.readTextFile(packagePath)) as { name?: string };
-      if (pkg.name) return normalizeProjectSlug(pkg.name);
-    }
-  } catch {
-    // Fall back to the directory name below.
-  }
-
-  const dirName = projectDir.split(/[/\\]/).filter(Boolean).pop() ?? "my-app";
-  return normalizeProjectSlug(dirName);
-}
-
-async function persistProjectLink(
-  projectDir: string,
-  config: ResolvedConfig,
-  project: ProjectTarget,
-): Promise<ResolvedConfig> {
-  await writeProjectLink(projectDir, {
-    controlPlane: config.apiUrl,
-    projectId: project.id,
-    projectSlug: project.slug,
-  });
-  return { ...config, projectId: project.id, projectSlug: project.slug };
-}
-
 async function ensureProjectLinkedForDeploy(
   projectDir: string,
   env: EnvironmentConfig,
@@ -256,77 +220,78 @@ async function ensureProjectLinkedForDeploy(
   const isInferredReference = projectReferenceSource.kind === "inferred";
   const projectReference = requestReference ??
     (isInferredReference
-      ? normalizeProjectSlug(initial.projectSlug || await inferDeployProjectSlug(projectDir))
+      ? normalizeProjectSlug(initial.projectSlug || await inferProjectSlugFromDirectory(projectDir))
       : initial.projectSlug);
   const config = requestReference
     ? { ...initial, projectId: undefined, projectSlug: requestReference }
     : { ...initial, projectSlug: projectReference };
   const controlPlane = controlPlaneFactory(config);
 
-  if (!isInferredReference) {
-    try {
-      const project = await controlPlane.getProject(projectApiReference(config));
-      const resolvedConfig = shouldPersistProjectLink(projectReferenceSource)
-        ? mode === "dry-run"
-          ? { ...config, projectId: project.id, projectSlug: project.slug }
-          : await persistProjectLink(projectDir, config, project)
-        : { ...config, projectSlug: project.slug };
-      return {
-        config: resolvedConfig,
-        controlPlane: controlPlaneFactory(resolvedConfig),
-        project,
-        plannedProjectSlug: project.slug,
-      };
-    } catch (error) {
-      if (error instanceof VeryfrontError) throw error;
-      if (getErrorStatus(error) !== 404) {
-        throw new Error(
-          `Could not check project "${projectReference}": ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
-    }
-
-    throw new Error(
-      `Project "${projectReference}" was not found. Check the project reference or remove it to let deploy create a project for this directory.`,
-    );
-  }
-
   const suggestedSlug = normalizeProjectSlug(projectReference);
-  if (receipt) {
+  if (isInferredReference && receipt) {
     throw new Error(
       `The local push receipt is orphaned: ${PUSH_RECEIPT_RELATIVE_PATH} targets project "${receipt.projectSlug}", but deploy inferred "${suggestedSlug}" because there is no explicit config or local project link. Remove the receipt and run veryfront push again, or relink this project before deploying.`,
     );
   }
 
-  if (mode === "dry-run") {
-    const dryRunConfig = { ...initial, projectSlug: suggestedSlug };
+  const resolutionClient: ProjectResolutionClient = {
+    getProject: (reference) => controlPlane.getProject(reference),
+    reserveSlug: async (slug, options) => {
+      const reserved = await reserveProjectSlug(
+        slug,
+        initial.apiToken,
+        env,
+        initial.apiUrl,
+        options,
+      );
+      return { slug: reserved.slug, projectId: reserved.projectId };
+    },
+  };
+
+  let outcome: ProjectResolutionOutcome;
+  try {
+    outcome = await resolveOrCreateProject({
+      projectDir,
+      config,
+      source: projectReferenceSource,
+      client: resolutionClient,
+      createMissingReference: false,
+      dryRun: mode === "dry-run",
+    });
+  } catch (error) {
+    if (error instanceof ProjectReferenceNotFoundError) {
+      throw new Error(
+        `Project "${projectReference}" was not found. Check the project reference or remove it to let deploy create a project for this directory.`,
+      );
+    }
+    if (isInferredReference || error instanceof VeryfrontError) throw error;
+    throw new Error(
+      `Could not check project "${projectReference}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (outcome.kind === "planned-create") {
+    const dryRunConfig = { ...initial, projectSlug: outcome.plannedSlug };
     return {
       config: dryRunConfig,
       controlPlane: controlPlaneFactory(dryRunConfig),
       project: null,
-      plannedProjectSlug: suggestedSlug,
+      plannedProjectSlug: outcome.plannedSlug,
     };
   }
 
-  const created = await reserveProjectSlug(
-    suggestedSlug,
-    initial.apiToken,
-    env,
-    initial.apiUrl,
-  );
-  const createdConfig = { ...initial, projectSlug: created.slug };
-  const createdControlPlane = controlPlaneFactory(createdConfig);
-  const project = created.projectId
-    ? { id: created.projectId, slug: created.slug }
-    : await createdControlPlane.getProject(created.slug);
-  const linkedConfig = await persistProjectLink(projectDir, createdConfig, project);
+  // A source that never owns the local link keeps its own reference: only the
+  // slug is refreshed from the control plane, never the id.
+  const resolvedConfig = shouldPersistProjectLink(projectReferenceSource)
+    ? outcome.config
+    : { ...config, projectSlug: outcome.project.slug };
   return {
-    config: linkedConfig,
-    controlPlane: controlPlaneFactory(linkedConfig),
-    project,
-    plannedProjectSlug: created.slug,
+    config: resolvedConfig,
+    controlPlane: controlPlaneFactory(resolvedConfig),
+    project: outcome.project,
+    plannedProjectSlug: outcome.project.slug,
   };
 }
 

--- a/cli/shared/project-resolution.test.ts
+++ b/cli/shared/project-resolution.test.ts
@@ -352,6 +352,14 @@ describe("resolveOrCreateProject", () => {
         if (outcome.kind !== "created") throw new Error("unreachable");
         assertEquals(calls.getProject, ["my-app"]);
         assertEquals(outcome.project, { id: "proj_canonical", slug: "my-app" });
+        // An empty reservation id must never leave the project unlinked.
+        assertEquals(outcome.persisted, true);
+        assertEquals(await readLink(dir), {
+          version: 1,
+          controlPlane: CONTROL_PLANE,
+          projectId: "proj_canonical",
+          projectSlug: "my-app",
+        });
       });
     });
 

--- a/cli/shared/project-resolution.test.ts
+++ b/cli/shared/project-resolution.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertInstanceOf, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "veryfront/platform/path";
 import type { ProjectReferenceSource, ResolvedConfig } from "./config.ts";
@@ -219,6 +219,7 @@ describe("resolveOrCreateProject", () => {
           ProjectReferenceNotFoundError,
         );
 
+        assertInstanceOf(error, ProjectReferenceNotFoundError);
         assertEquals(error.reference, "proj_gone");
         assertEquals(error.byId, true);
         assertEquals(error.source, LOCAL_LINK);
@@ -240,6 +241,7 @@ describe("resolveOrCreateProject", () => {
           ProjectReferenceNotFoundError,
         );
 
+        assertInstanceOf(error, ProjectReferenceNotFoundError);
         assertEquals(error.reference, "my-app");
         assertEquals(error.byId, false);
         assertEquals(calls.reserveSlug, []);
@@ -425,6 +427,7 @@ describe("resolveOrCreateProject", () => {
           ProjectSlugConflictError,
         );
 
+        assertInstanceOf(error, ProjectSlugConflictError);
         assertEquals(error.slug, "my-app");
         assertEquals(error.message, 'Project slug "my-app" is already in use.');
       });

--- a/cli/shared/project-resolution.test.ts
+++ b/cli/shared/project-resolution.test.ts
@@ -1,0 +1,425 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "veryfront/platform/path";
+import type { ProjectReferenceSource, ResolvedConfig } from "./config.ts";
+import { PROJECT_LINK_RELATIVE_PATH } from "./project-link.ts";
+import {
+  canPersistAlternativeSlug,
+  getErrorStatus,
+  projectApiReference,
+  ProjectReferenceNotFoundError,
+  type ProjectResolutionClient,
+  resolveOrCreateProject,
+  shouldPersistProjectLink,
+  slugConflictAction,
+} from "./project-resolution.ts";
+import { ProjectSlugConflictError } from "./reserve-slug.ts";
+
+const CONTROL_PLANE = "https://control.example.test/api";
+
+function config(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    apiUrl: CONTROL_PLANE,
+    apiToken: "token",
+    projectSlug: "my-app",
+    ...overrides,
+  } as ResolvedConfig;
+}
+
+const INFERRED: ProjectReferenceSource = { kind: "inferred", name: "project files" };
+const LOCAL_LINK: ProjectReferenceSource = { kind: "local-link", name: ".veryfront/project.json" };
+const JSON_CONFIG: ProjectReferenceSource = { kind: "json-config", name: "veryfront.json" };
+const ARGUMENT: ProjectReferenceSource = { kind: "argument", name: "--project" };
+
+interface FakeCalls {
+  getProject: string[];
+  reserveSlug: Array<{ slug: string; allowAlternativeSlug: boolean }>;
+}
+
+function notFound(): Error {
+  const error = new Error("API request failed: 404 Not Found") as Error & { status: number };
+  error.status = 404;
+  return error;
+}
+
+function serverError(): Error {
+  const error = new Error("API request failed: 500 Server Error") as Error & { status: number };
+  error.status = 500;
+  return error;
+}
+
+function fakeClient(behaviour: {
+  project?: { id: string; slug: string };
+  getProjectError?: () => Error;
+  reserve?: { slug: string; projectId: string };
+  reserveError?: () => Error;
+}): { client: ProjectResolutionClient; calls: FakeCalls } {
+  const calls: FakeCalls = { getProject: [], reserveSlug: [] };
+  const client: ProjectResolutionClient = {
+    getProject: (reference) => {
+      calls.getProject.push(reference);
+      if (behaviour.getProjectError) return Promise.reject(behaviour.getProjectError());
+      return Promise.resolve(behaviour.project ?? { id: "proj_1", slug: reference });
+    },
+    reserveSlug: (slug, options) => {
+      calls.reserveSlug.push({ slug, allowAlternativeSlug: options.allowAlternativeSlug });
+      if (behaviour.reserveError) return Promise.reject(behaviour.reserveError());
+      return Promise.resolve(behaviour.reserve ?? { slug, projectId: "proj_1" });
+    },
+  };
+  return { client, calls };
+}
+
+async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await run(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function readLink(projectDir: string): Promise<unknown> {
+  return JSON.parse(await Deno.readTextFile(join(projectDir, PROJECT_LINK_RELATIVE_PATH)));
+}
+
+async function linkExists(projectDir: string): Promise<boolean> {
+  try {
+    await Deno.stat(join(projectDir, PROJECT_LINK_RELATIVE_PATH));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("project reference helpers", () => {
+  it("prefers the project id over the slug as the API reference", () => {
+    assertEquals(projectApiReference(config({ projectId: "proj_1" })), "proj_1");
+    assertEquals(projectApiReference(config()), "my-app");
+  });
+
+  it("persists a link only for references this directory owns", () => {
+    assertEquals(shouldPersistProjectLink(INFERRED), true);
+    assertEquals(shouldPersistProjectLink(LOCAL_LINK), true);
+    assertEquals(shouldPersistProjectLink(JSON_CONFIG), false);
+    assertEquals(shouldPersistProjectLink(ARGUMENT), false);
+  });
+
+  it("allows an alternative slug only for an inferred reference", () => {
+    assertEquals(canPersistAlternativeSlug(INFERRED), true);
+    assertEquals(canPersistAlternativeSlug(LOCAL_LINK), false);
+  });
+
+  it("reads a numeric status off an error and ignores everything else", () => {
+    assertEquals(getErrorStatus(notFound()), 404);
+    assertEquals(getErrorStatus(new Error("no status")), undefined);
+    assertEquals(getErrorStatus("not an object"), undefined);
+    assertEquals(getErrorStatus(null), undefined);
+  });
+
+  it("phrases the slug conflict remedy against the reference source", () => {
+    assertEquals(slugConflictAction(ARGUMENT), "Use a different --project value");
+    assertEquals(
+      slugConflictAction({ kind: "environment", name: "environment configuration" }),
+      "Update or remove VERYFRONT_PROJECT_SLUG",
+    );
+    assertEquals(
+      slugConflictAction({ kind: "module-config", name: "veryfront.config.ts" }),
+      "Update projectSlug in veryfront.config.ts",
+    );
+    assertEquals(
+      slugConflictAction({ kind: "tenant-environment", name: "TENANT_PROJECT_SLUG" }),
+      "Update or remove TENANT_PROJECT_SLUG",
+    );
+    assertEquals(slugConflictAction(JSON_CONFIG), "Choose a different project slug");
+    assertEquals(slugConflictAction(LOCAL_LINK), "Relink this project");
+  });
+});
+
+describe("resolveOrCreateProject", () => {
+  describe("an existing named project", () => {
+    it("persists the link for a local-link reference", async () => {
+      await withTempDir(async (dir) => {
+        const { client, calls } = fakeClient({ project: { id: "proj_1", slug: "my-app" } });
+        const outcome = await resolveOrCreateProject({
+          projectDir: dir,
+          config: config({ projectId: "proj_1" }),
+          source: LOCAL_LINK,
+          client,
+        });
+
+        assertEquals(outcome.kind, "existing");
+        assertEquals(calls.getProject, ["proj_1"]);
+        if (outcome.kind !== "existing") throw new Error("unreachable");
+        assertEquals(outcome.persisted, true);
+        assertEquals(outcome.config.projectId, "proj_1");
+        assertEquals(outcome.config.projectSlug, "my-app");
+        assertEquals(await readLink(dir), {
+          version: 1,
+          controlPlane: CONTROL_PLANE,
+          projectId: "proj_1",
+          projectSlug: "my-app",
+        });
+      });
+    });
+
+    it("does not persist a link for a json-config reference", async () => {
+      await withTempDir(async (dir) => {
+        const { client, calls } = fakeClient({ project: { id: "proj_1", slug: "my-app" } });
+        const outcome = await resolveOrCreateProject({
+          projectDir: dir,
+          config: config(),
+          source: JSON_CONFIG,
+          client,
+        });
+
+        assertEquals(outcome.kind, "existing");
+        assertEquals(calls.getProject, ["my-app"]);
+        if (outcome.kind !== "existing") throw new Error("unreachable");
+        assertEquals(outcome.persisted, false);
+        assertEquals(await linkExists(dir), false);
+      });
+    });
+
+    it("plans without persisting when the run is a dry run", async () => {
+      await withTempDir(async (dir) => {
+        const { client, calls } = fakeClient({ project: { id: "proj_1", slug: "my-app" } });
+        const outcome = await resolveOrCreateProject({
+          projectDir: dir,
+          config: config({ projectId: "proj_1" }),
+          source: LOCAL_LINK,
+          client,
+          dryRun: true,
+        });
+
+        if (outcome.kind !== "existing") throw new Error("unreachable");
+        assertEquals(outcome.persisted, false);
+        assertEquals(outcome.config.projectId, "proj_1");
+        assertEquals(calls.reserveSlug, []);
+        assertEquals(await linkExists(dir), false);
+      });
+    });
+  });
+
+  describe("a named project that is gone", () => {
+    it("reports a reference held by id", async () => {
+      await withTempDir(async (dir) => {
+        const { client } = fakeClient({ getProjectError: notFound });
+        const error = await assertRejects(
+          () =>
+            resolveOrCreateProject({
+              projectDir: dir,
+              config: config({ projectId: "proj_gone" }),
+              source: LOCAL_LINK,
+              client,
+              createMissingReference: true,
+            }),
+          ProjectReferenceNotFoundError,
+        );
+
+        assertEquals(error.reference, "proj_gone");
+        assertEquals(error.byId, true);
+        assertEquals(error.source, LOCAL_LINK);
+      });
+    });
+
+    it("reports a named slug when the caller does not create missing projects", async () => {
+      await withTempDir(async (dir) => {
+        const { client, calls } = fakeClient({ getProjectError: notFound });
+        const error = await assertRejects(
+          () =>
+            resolveOrCreateProject({
+              projectDir: dir,
+              config: config(),
+              source: JSON_CONFIG,
+              client,
+              createMissingReference: false,
+            }),
+          ProjectReferenceNotFoundError,
+        );
+
+        assertEquals(error.reference, "my-app");
+        assertEquals(error.byId, false);
+        assertEquals(calls.reserveSlug, []);
+      });
+    });
+
+    it("creates the project when the caller opts in", async () => {
+      await withTempDir(async (dir) => {
+        const { client, calls } = fakeClient({
+          getProjectError: notFound,
+          reserve: { slug: "my-app", projectId: "proj_new" },
+        });
+        const outcome = await resolveOrCreateProject({
+          projectDir: dir,
+          config: config(),
+          source: JSON_CONFIG,
+          client,
+          createMissingReference: true,
+        });
+
+        assertEquals(outcome.kind, "created");
+        if (outcome.kind !== "created") throw new Error("unreachable");
+        assertEquals(outcome.project, { id: "proj_new", slug: "my-app" });
+        assertEquals(outcome.requestedSlug, "my-app");
+        assertEquals(outcome.persisted, false);
+        assertEquals(calls.reserveSlug, [{ slug: "my-app", allowAlternativeSlug: false }]);
+        assertEquals(await linkExists(dir), false);
+      });
+    });
+
+    it("only plans the create on a dry run, never reserving the slug", async () => {
+      await withTempDir(async (dir) => {
+        const { client, calls } = fakeClient({ getProjectError: notFound });
+        const outcome = await resolveOrCreateProject({
+          projectDir: dir,
+          config: config(),
+          source: JSON_CONFIG,
+          client,
+          createMissingReference: true,
+          dryRun: true,
+        });
+
+        assertEquals(outcome.kind, "planned-create");
+        if (outcome.kind !== "planned-create") throw new Error("unreachable");
+        assertEquals(outcome.plannedSlug, "my-app");
+        assertEquals(calls.reserveSlug, []);
+        assertEquals(await linkExists(dir), false);
+      });
+    });
+
+    it("rethrows a non-404 lookup failure unchanged", async () => {
+      await withTempDir(async (dir) => {
+        const raised = serverError();
+        const { client } = fakeClient({ getProjectError: () => raised });
+        const error = await assertRejects(() =>
+          resolveOrCreateProject({
+            projectDir: dir,
+            config: config(),
+            source: JSON_CONFIG,
+            client,
+            createMissingReference: true,
+          })
+        );
+
+        assertEquals(error, raised);
+      });
+    });
+  });
+
+  describe("an inferred reference", () => {
+    it("creates the project and writes the canonical link", async () => {
+      await withTempDir(async (dir) => {
+        const { client, calls } = fakeClient({
+          reserve: { slug: "my-app", projectId: "proj_new" },
+        });
+        const outcome = await resolveOrCreateProject({
+          projectDir: dir,
+          config: config(),
+          source: INFERRED,
+          client,
+        });
+
+        assertEquals(outcome.kind, "created");
+        if (outcome.kind !== "created") throw new Error("unreachable");
+        assertEquals(outcome.persisted, true);
+        assertEquals(calls.getProject, []);
+        assertEquals(calls.reserveSlug, [{ slug: "my-app", allowAlternativeSlug: true }]);
+        assertEquals(await readLink(dir), {
+          version: 1,
+          controlPlane: CONTROL_PLANE,
+          projectId: "proj_new",
+          projectSlug: "my-app",
+        });
+      });
+    });
+
+    it("looks up the canonical id when the reservation omits it", async () => {
+      await withTempDir(async (dir) => {
+        const { client, calls } = fakeClient({
+          reserve: { slug: "my-app", projectId: "" },
+          project: { id: "proj_canonical", slug: "my-app" },
+        });
+        const outcome = await resolveOrCreateProject({
+          projectDir: dir,
+          config: config(),
+          source: INFERRED,
+          client,
+        });
+
+        if (outcome.kind !== "created") throw new Error("unreachable");
+        assertEquals(calls.getProject, ["my-app"]);
+        assertEquals(outcome.project, { id: "proj_canonical", slug: "my-app" });
+      });
+    });
+
+    it("reports the alternative slug the control plane handed back", async () => {
+      await withTempDir(async (dir) => {
+        const { client } = fakeClient({
+          reserve: { slug: "my-app-x1y2z3", projectId: "proj_alt" },
+        });
+        const outcome = await resolveOrCreateProject({
+          projectDir: dir,
+          config: config(),
+          source: INFERRED,
+          client,
+        });
+
+        if (outcome.kind !== "created") throw new Error("unreachable");
+        assertEquals(outcome.requestedSlug, "my-app");
+        assertEquals(outcome.project.slug, "my-app-x1y2z3");
+        assertEquals(outcome.config.projectSlug, "my-app-x1y2z3");
+        assertEquals(await readLink(dir), {
+          version: 1,
+          controlPlane: CONTROL_PLANE,
+          projectId: "proj_alt",
+          projectSlug: "my-app-x1y2z3",
+        });
+      });
+    });
+
+    it("plans the create without reserving or persisting on a dry run", async () => {
+      await withTempDir(async (dir) => {
+        const { client, calls } = fakeClient({});
+        const outcome = await resolveOrCreateProject({
+          projectDir: dir,
+          config: config(),
+          source: INFERRED,
+          client,
+          dryRun: true,
+        });
+
+        assertEquals(outcome.kind, "planned-create");
+        if (outcome.kind !== "planned-create") throw new Error("unreachable");
+        assertEquals(outcome.plannedSlug, "my-app");
+        assertEquals(calls.reserveSlug, []);
+        assertEquals(calls.getProject, []);
+        assertEquals(await linkExists(dir), false);
+      });
+    });
+
+    it("propagates a slug conflict for adapters to phrase", async () => {
+      await withTempDir(async (dir) => {
+        const { client } = fakeClient({
+          reserveError: () => new ProjectSlugConflictError("my-app"),
+        });
+        const error = await assertRejects(
+          () =>
+            resolveOrCreateProject({
+              projectDir: dir,
+              config: config(),
+              source: INFERRED,
+              client,
+              allowAlternativeSlug: false,
+            }),
+          ProjectSlugConflictError,
+        );
+
+        assertEquals(error.slug, "my-app");
+        assertEquals(error.message, 'Project slug "my-app" is already in use.');
+      });
+    });
+  });
+});

--- a/cli/shared/project-resolution.ts
+++ b/cli/shared/project-resolution.ts
@@ -1,0 +1,245 @@
+/**
+ * Project Resolution
+ *
+ * The single owner of "which project does this directory target, and does it
+ * exist on the control plane?". One request carries the project directory, the
+ * resolved config, where the project reference came from, and a client seam;
+ * it settles into one typed outcome (existing, created, or planned-create).
+ * Callers are presentation adapters: they own their own message wording and
+ * spinners, this module owns the decision and the one persisted link format
+ * (`.veryfront/project.json`).
+ *
+ * @module cli/shared/project-resolution
+ */
+
+import { createFileSystem } from "veryfront/platform";
+import { join } from "veryfront/platform/path";
+import { VeryfrontError } from "veryfront/errors";
+import type { ProjectReferenceSource, ResolvedConfig } from "./config.ts";
+import { writeProjectLink } from "./project-link.ts";
+import { normalizeProjectSlug } from "./slug.ts";
+
+/** A project as the control plane identifies it. */
+export interface ProjectTargetRef {
+  id: string;
+  slug: string;
+}
+
+/**
+ * The one seam between resolution and the control plane. Adapters wire this
+ * over whichever transport they already hold (deploy control plane, CLI API
+ * client, demo token); tests wire an in-memory fake.
+ */
+export interface ProjectResolutionClient {
+  getProject(reference: string): Promise<ProjectTargetRef>;
+  reserveSlug(
+    slug: string,
+    options: { allowAlternativeSlug: boolean },
+  ): Promise<{ slug: string; projectId: string }>;
+}
+
+export interface ProjectResolutionRequest {
+  projectDir: string;
+  config: ResolvedConfig;
+  source: ProjectReferenceSource;
+  client: ProjectResolutionClient;
+  /** Plan only: never reserve a slug, never write a project link. */
+  dryRun?: boolean;
+  /**
+   * What to do when a named (non-inferred) reference is not found remotely:
+   * create the project (push) or report it (deploy). Defaults to reporting.
+   */
+  createMissingReference?: boolean;
+  /** Defaults to true only for inferred references. */
+  allowAlternativeSlug?: boolean;
+}
+
+export type ProjectResolutionOutcome =
+  | {
+    kind: "existing";
+    config: ResolvedConfig;
+    project: ProjectTargetRef;
+    persisted: boolean;
+  }
+  | {
+    kind: "created";
+    config: ResolvedConfig;
+    project: ProjectTargetRef;
+    requestedSlug: string;
+    persisted: boolean;
+  }
+  | { kind: "planned-create"; config: ResolvedConfig; plannedSlug: string };
+
+/**
+ * A named project reference did not resolve remotely. Adapters translate this
+ * into their own wording; the module never phrases user-facing guidance.
+ */
+export class ProjectReferenceNotFoundError extends Error {
+  constructor(
+    readonly reference: string,
+    readonly source: ProjectReferenceSource,
+    readonly byId: boolean,
+  ) {
+    super(`Project "${reference}" was not found.`);
+    this.name = "ProjectReferenceNotFoundError";
+  }
+}
+
+/** The reference to look a project up by: its id when known, else its slug. */
+export function projectApiReference(config: ResolvedConfig): string {
+  return config.projectId ?? config.projectSlug;
+}
+
+/** Only directory-owned references earn a persisted local project link. */
+export function shouldPersistProjectLink(source: ProjectReferenceSource): boolean {
+  return source.kind === "inferred" || source.kind === "local-link";
+}
+
+/** Only an inferred slug may be silently replaced by an available alternative. */
+export function canPersistAlternativeSlug(source: ProjectReferenceSource): boolean {
+  return source.kind === "inferred";
+}
+
+export function getErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" ? status : undefined;
+}
+
+/** Write `.veryfront/project.json` and fold the resolved identity into config. */
+export async function persistProjectLink<T extends { apiUrl: string }>(
+  projectDir: string,
+  config: T,
+  project: ProjectTargetRef,
+): Promise<T & { projectId: string; projectSlug: string }> {
+  await writeProjectLink(projectDir, {
+    controlPlane: config.apiUrl,
+    projectId: project.id,
+    projectSlug: project.slug,
+  });
+  return { ...config, projectId: project.id, projectSlug: project.slug };
+}
+
+/** The slug a directory suggests: its package name, else its own name. */
+export async function inferProjectSlugFromDirectory(projectDir: string): Promise<string> {
+  const fs = createFileSystem();
+  const packagePath = join(projectDir, "package.json");
+
+  try {
+    if (await fs.exists(packagePath)) {
+      const pkg = JSON.parse(await fs.readTextFile(packagePath)) as { name?: string };
+      if (pkg.name) return normalizeProjectSlug(pkg.name);
+    }
+  } catch {
+    // Fall back to the directory name below.
+  }
+
+  const dirName = projectDir.split(/[/\\]/).filter(Boolean).pop() ?? "my-app";
+  return normalizeProjectSlug(dirName);
+}
+
+/**
+ * What a user can do about a slug that is already taken, phrased against the
+ * place the slug came from.
+ */
+export function slugConflictAction(source: ProjectReferenceSource): string {
+  switch (source.kind) {
+    case "argument":
+      return "Use a different --project value";
+    case "environment":
+      return "Update or remove VERYFRONT_PROJECT_SLUG";
+    case "module-config":
+      return `Update projectSlug in ${source.name}`;
+    case "tenant-environment":
+      return `Update or remove ${source.name}`;
+    case "json-config":
+    case "inferred":
+      return "Choose a different project slug";
+    case "local-link":
+      return "Relink this project";
+  }
+}
+
+async function createProject(
+  request: ProjectResolutionRequest,
+  allowAlternativeSlug: boolean,
+): Promise<ProjectResolutionOutcome> {
+  const { projectDir, config, source, client, dryRun = false } = request;
+  const requestedSlug = config.projectSlug;
+  const reserved = await client.reserveSlug(requestedSlug, { allowAlternativeSlug });
+  const reservedConfig = { ...config, projectSlug: reserved.slug };
+  const project = reserved.projectId
+    ? { id: reserved.projectId, slug: reserved.slug }
+    : await client.getProject(reserved.slug);
+
+  const persisted = shouldPersistProjectLink(source) && !dryRun;
+  return {
+    kind: "created",
+    config: persisted ? await persistProjectLink(projectDir, reservedConfig, project) : {
+      ...reservedConfig,
+      projectId: project.id,
+      projectSlug: project.slug,
+    },
+    project,
+    requestedSlug,
+    persisted,
+  };
+}
+
+/**
+ * Resolve the project this directory targets, creating it when the reference
+ * is the directory's own inference (or when the caller opts in for a named
+ * reference that no longer exists).
+ */
+export async function resolveOrCreateProject(
+  request: ProjectResolutionRequest,
+): Promise<ProjectResolutionOutcome> {
+  const {
+    projectDir,
+    config,
+    source,
+    client,
+    dryRun = false,
+    createMissingReference = false,
+  } = request;
+  const allowAlternativeSlug = request.allowAlternativeSlug ?? canPersistAlternativeSlug(source);
+
+  const plannedCreate: ProjectResolutionOutcome = {
+    kind: "planned-create",
+    config,
+    plannedSlug: config.projectSlug,
+  };
+
+  if (source.kind === "inferred") {
+    // A dry run never reserves a slug, so the create can only be planned.
+    return dryRun ? plannedCreate : createProject(request, allowAlternativeSlug);
+  }
+
+  const reference = projectApiReference(config);
+  let project: ProjectTargetRef;
+  try {
+    project = await client.getProject(reference);
+  } catch (error) {
+    if (error instanceof VeryfrontError) throw error;
+    if (getErrorStatus(error) !== 404) throw error;
+    if (config.projectId) {
+      throw new ProjectReferenceNotFoundError(reference, source, true);
+    }
+    if (!createMissingReference) {
+      throw new ProjectReferenceNotFoundError(reference, source, false);
+    }
+    return dryRun ? plannedCreate : createProject(request, allowAlternativeSlug);
+  }
+
+  const persisted = shouldPersistProjectLink(source) && !dryRun;
+  return {
+    kind: "existing",
+    config: persisted ? await persistProjectLink(projectDir, config, project) : {
+      ...config,
+      projectId: project.id,
+      projectSlug: project.slug,
+    },
+    project,
+    persisted,
+  };
+}

--- a/cli/test-utils/deploy-test-support.ts
+++ b/cli/test-utils/deploy-test-support.ts
@@ -3,12 +3,14 @@
  *
  * Used by deploy-project.test.ts and the MCP deploy-tool tests so both drive
  * the real DeployProject module over the same fake control plane.
+ *
+ * @module cli/test-utils/deploy-test-support
  */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "veryfront/testing/assert";
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import type { ReleaseAssetManifestResponse } from "veryfront/release-assets";
-import { computeSourceDigest, writePushReceipt } from "../deployment-provenance.ts";
+import { computeSourceDigest, writePushReceipt } from "../shared/deployment-provenance.ts";
 import type {
   DeployControlPlane,
   DeployDeployment,
@@ -16,7 +18,7 @@ import type {
   DeployProjectRecord,
   DeployRelease,
   DeployReleaseFile,
-} from "./control-plane.ts";
+} from "../shared/deployment/control-plane.ts";
 
 export const CONTROL_PLANE = "https://control.example.test/api";
 export const PROJECT_ID = "project-1";


### PR DESCRIPTION
## Summary

Extracts **Project Resolution** — `cli/shared/project-resolution.ts`, `resolveOrCreateProject(request)` over a two-method client seam (`getProject`, `reserveSlug`) — as the single owner of "resolve-or-create the remote project for this directory," settling one typed outcome (`existing | created | planned-create`). Six sites become adapters: `deploy-project.ts`, `push`, `up`, `demo`, the TUI project-creation operation (pull's bootstrap was already link-shaped and is untouched). Seven formerly char-identical helper copies (`projectApiReference`, `shouldPersistProjectLink`, `canPersistAlternativeSlug`, `getErrorStatus`, `persistProjectLink`, `inferProjectSlugFromDirectory`, `slugConflictAction`) now have one canonical home. Error cases cross the seam as typed errors (`ProjectReferenceNotFoundError`, propagated `ProjectSlugConflictError`), so each adapter keeps its exact user-facing message texts. CONTEXT.md gains the Project Resolution entry.

## Behavior changes (intended)

1. **`veryfront up` persists `.veryfront/project.json`** via the module and no longer writes `veryfront.json`. Previously up-created projects were classified `json-config` forever — never re-linked, no cached projectId, resolved by slug on every subsequent command. User-visible fix.
2. **Push resolves the project before listing files** (one extra `GET /projects/{ref}` per non-inferred source). Two request-sequence test assertions retargeted; their guarantees (fail-closed on missing explicit id; no `POST /projects` on dry run) are unchanged.
3. **Dry runs never mutate the control plane.** The originally spec'd algorithm would have let a dry run against a missing named reference reserve a slug; the module returns `planned-create` before reaching the create path, with a regression test.
4. TUI slug normalization now uses the canonical `normalizeProjectSlug` (the old variant could emit `--my--app-`).

## Also in this PR

- **Repairs `lint:cli-boundary` on main** (broken by #3187): `_deploy-test-support.ts` deep-imported `#veryfront/**` paths; the assert import moves to the public `veryfront/testing/assert`, and the `_resetEnvironmentConfig` helper moves to `cli/test-utils/deploy-test-support.ts` (already in the rule's skip list) rather than pushing an internal test hook into the public config API.
- Verdicts recorded: MCP `toSlug` and `remote-file-tools.createProjectWithRetry` deliberately left alone (route-name preservation; different endpoint semantics + `templateSlug`/`isPublic` body fields).

## Review

Independent code-review pass: approve. Adapter fidelity verified branch-by-branch (including deploy's three-way config-merge nuance and exact error texts); two non-blocking nits noted (a dead `!dryRun` guard in `createProject`, one ternary's formatting) — left as-is since a stacked PR builds on this SHA.

## Tested

- 84 tests / 838 steps, 0 failed across the new module suite + deployment + deploy/push/up/demo + cli/app + cli/mcp
- `lint:cli-boundary` passes (failed on base); typecheck, lint, fmt green; pre-push (fmt + full suite) passed
- Known-broken on base, untouched: `docs:validate` @example gap on `src/release-assets/index.ts` (separate follow-up)