### PR TITLE
Dedup the skills block and fix call-context doc anchors

### DIFF
--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -256,7 +256,7 @@ Clear all stored messages from memory.
 | `DEFAULT_HOSTED_CHILD_SANDBOX_REQUIRED_CUE_PATTERN` | Default value for hosted child sandbox required cue pattern. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/child-requested-tools.ts#L53) |
 | `DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS` | Default value for hosted child status poll interval ms. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/child-fork-execution-runner.ts#L72) |
 | `DEFAULT_PROJECT_STEERING_PATHS` | Default value for project steering paths. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/project/steering-mutation.ts#L2) |
-| `DEFAULT_RUNTIME_AGENT_CONTEXT_MARKER` | Marker authored instructions use to place runtime blocks mid-prompt. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L37) |
+| `DEFAULT_RUNTIME_AGENT_CONTEXT_MARKER` | Marker authored instructions use to place runtime blocks mid-prompt. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L38) |
 | `DELEGATE_ONLY_WHEN_MATERIALLY_HELPFUL` | Shared delegate only when materially helpful value. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/delegation-policy.ts#L9) |
 | `ExternalAgentWorkerRequestSnapshotSchema` | Zod schema for external agent worker request snapshot. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/external-worker-client.ts#L117) |
 | `ExternalAgentWorkerRunSchema` | Zod schema for external agent worker run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/external-worker-client.ts#L166) |
@@ -324,7 +324,7 @@ Clear all stored messages from memory.
 | `bootstrapAgentService` | Bootstrap agent service helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/bootstrap.ts#L64) |
 | `bootstrapConversationAgentRun` | Bootstrap conversation agent run helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/bootstrap.ts#L319) |
 | `bootstrapHostedChildRun` | Bootstrap hosted child run helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/child-bootstrap.ts#L54) |
-| `buildAgentCallContext` | Builds the complete system-message set for one provider call. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L119) |
+| `buildAgentCallContext` | Builds the complete system-message set for one provider call. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L131) |
 | `buildAgentDelegateTools` | Builds the opt-in delegate tools for a coordinator agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/agent-delegation.ts#L84) |
 | `buildAgentRunTraceAttributes` | Builds agent run trace attributes. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/trace-attributes.ts#L181) |
 | `buildAgUiBrowserFinalizeResponse` | Response payload for build AG-UI browser finalize. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L364) |
@@ -371,8 +371,8 @@ Clear all stored messages from memory.
 | `buildParsedAgentServiceChatRequest` | Request payload for build parsed hosted chat. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/chat-request-parser.ts#L284) |
 | `buildParsedHostedAgUiRequest` | Request payload for build parsed hosted AG-UI. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/ag-ui-chat-request.ts#L178) |
 | `buildParsedHostedChatRequest` | Request payload for build parsed hosted chat. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/chat-request-parser.ts#L284) |
-| `buildProjectContextPromptBlock` | Builds the shared project-context prompt block (project reference + branch). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L70) |
-| `buildProjectInstructionsPromptBlock` | Builds the project-instructions prompt block. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L87) |
+| `buildProjectContextPromptBlock` | Builds the shared project-context prompt block (project reference + branch). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L72) |
+| `buildProjectInstructionsPromptBlock` | Builds the project-instructions prompt block. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L89) |
 | `buildProjectServiceTraceAttributes` | Builds Datadog unified service trace attributes for a hosted project run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/trace-attributes.ts#L93) |
 | `buildRecoveredStepParts` | Builds recovered step parts. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/streaming/fork-runtime-part-mapper.ts#L61) |
 | `buildRootOwnedChildResultHint` | Builds root owned child result hint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/delegation-policy.ts#L45) |
@@ -853,7 +853,7 @@ Clear all stored messages from memory.
 | `AbortRejectionProcessTarget` | Public API contract for abort rejection process target. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/abort-rejection-guard.ts#L7) |
 | `ActiveConversationRunStatus` | Public API contract for a conversation run status is active. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable-contracts.ts#L181) |
 | `Agent` | Public API contract for agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L367) |
-| `AgentCallProjectContext` | Project the call runs against, rendered as the `<project_context>` block. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L42) |
+| `AgentCallProjectContext` | Project the call runs against, rendered as the `<project_context>` block. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L44) |
 | `AgentCatalogAction` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L13) |
 | `AgentCatalogKind` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L6) |
 | `AgentConfig` | Configuration used by agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L142) |
@@ -1005,7 +1005,7 @@ Clear all stored messages from memory.
 | `BootstrapHostedChildRunInput` | Input payload for bootstrap hosted child run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/child-bootstrap.ts#L16) |
 | `BootstrapHostedChildRunResult` | Result returned from bootstrap hosted child run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/child-bootstrap.ts#L30) |
 | `BootstrappedHostedChatExecutionRuntime` | Public API contract for bootstrapped hosted chat execution runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/chat-execution-runtime.ts#L173) |
-| `BuildAgentCallContextInput` | Input payload for build agent call context. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L48) |
+| `BuildAgentCallContextInput` | Input payload for build agent call context. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/call-context.ts#L50) |
 | `BuildAgentDelegateToolsInput` | Input payload for build agent delegate tools. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/agent-delegation.ts#L22) |
 | `BuildChatStreamChunkMessageMetadataInput` | Input payload for build chat stream chunk message metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/chat-ui-message-helpers.ts#L9) |
 | `BuildDetachedFallbackChunksInput` | Input payload for build detached fallback chunks. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/finalized-message.ts#L60) |

--- a/src/agent/runtime/call-context.test.ts
+++ b/src/agent/runtime/call-context.test.ts
@@ -240,6 +240,30 @@ describe("agent/runtime/call-context", () => {
       assertEquals((messages[0]?.content ?? "").includes("Runtime facts"), false);
     });
 
+    it("skips the skills block when the instructions already carry one", () => {
+      const [message] = buildAgentCallContext({
+        instructions:
+          "Base\n\n<available_skills>\n- authored: An authored catalog\n</available_skills>",
+        skills: createSkills(),
+      });
+
+      assertEquals(
+        message?.content,
+        "Base\n\n<available_skills>\n- authored: An authored catalog\n</available_skills>",
+      );
+      assertEquals((message?.content ?? "").includes("Deployment guidance"), false);
+    });
+
+    it("still emits the skills block when the instructions only name the tag in prose", () => {
+      const [message] = buildAgentCallContext({
+        instructions: "Your catalog arrives in an <available_skills> block.",
+        skills: createSkills(),
+      });
+
+      assertStringIncludes(message?.content ?? "", "- review: Review guidance");
+      assertStringIncludes(message?.content ?? "", "</available_skills>");
+    });
+
     it("keeps untagged extra blocks that cannot be matched by tag", () => {
       const [message] = buildAgentCallContext({
         instructions: "Base",

--- a/src/agent/runtime/call-context.ts
+++ b/src/agent/runtime/call-context.ts
@@ -20,10 +20,11 @@
  * 2. An uncached `<environment_context>` message, when environment facts are
  *    supplied.
  *
- * Blocks whose tag already appears in the instructions are dropped. Callers
- * compose in layers — the factory renders a prompt that a project-runtime run
- * later re-composes — and dropping already-present tags keeps that idempotent
- * instead of emitting the same project reference twice.
+ * Every block — including the skills block — is dropped when the instructions
+ * already carry that tag as a complete element. Callers compose in layers: the
+ * factory renders a prompt that a project-runtime run later re-composes, and
+ * dropping already-present elements keeps that idempotent instead of emitting
+ * the same project reference or skill catalog twice.
  *
  * @module
  */
@@ -37,6 +38,7 @@ import type { RuntimeSkillDefinition } from "./skill-metadata.ts";
 export const DEFAULT_RUNTIME_AGENT_CONTEXT_MARKER = "<!-- veryfront-runtime-context -->";
 
 const ENVIRONMENT_CONTEXT_BLOCK_NAME = "environment_context";
+const AVAILABLE_SKILLS_BLOCK_NAME = "available_skills";
 
 /** Project the call runs against, rendered as the `<project_context>` block. */
 export type AgentCallProjectContext = {
@@ -163,7 +165,7 @@ export function buildAgentCallContext(input: BuildAgentCallContextInput): ChatSy
     staticParts.push(instructions.after);
   }
 
-  if (input.skills?.length) {
+  if (input.skills?.length && !hasBlock(input.instructions, AVAILABLE_SKILLS_BLOCK_NAME)) {
     staticParts.push(
       buildRuntimeAvailableSkillsPromptBlock(input.skills, {
         ...(input.availableToolNames === undefined

--- a/src/agent/runtime/call-context.ts
+++ b/src/agent/runtime/call-context.ts
@@ -17,14 +17,14 @@
  *    runtime-context marker, `<project_instructions>`, `<project_context>`,
  *    any caller-supplied extra blocks, the instructions after the marker, and
  *    `<available_skills>`.
- * 2. An uncached `<environment_context>` message, when environment facts are
- *    supplied.
+ * 2. An uncached `<environment_context>` message.
  *
- * Every block — including the skills block — is dropped when the instructions
- * already carry that tag as a complete element. Callers compose in layers: the
- * factory renders a prompt that a project-runtime run later re-composes, and
- * dropping already-present elements keeps that idempotent instead of emitting
- * the same project reference or skill catalog twice.
+ * Only the instructions are unconditional: each block appears only when the
+ * caller supplied its input and the instructions do not already carry that tag
+ * as a complete element, so message 2 can be absent and message 1 can be the
+ * instructions alone. Callers compose in layers — the factory's output is later
+ * re-composed by a project-runtime run — and skipping already-present elements
+ * keeps that idempotent instead of repeating a project reference or catalog.
  *
  * @module
  */


### PR DESCRIPTION
Lands the two Copilot review comments from #3188, which merged before they could be pushed (the branch was queued and protected against further updates).

## 1. Skills block bypassed the dedup rule

[Copilot comment](https://github.com/veryfront/veryfront-code/pull/3188#discussion_r3690176464) on `call-context.ts` — the module JSDoc promised that a block already present in the instructions is dropped, but the skills block never went through `hasBlock`: instructions carrying a complete `<available_skills>…</available_skills>` element still got a second catalog appended.

`buildAgentCallContext` now gates the skills block on `hasBlock` like every other block, so a prompt composed in layers cannot end up advertising two skill catalogs. The module JSDoc is corrected to match — it now says *every* block including skills, and "complete element" rather than "tag appears".

Hosted and internal-agents output is unaffected: neither carries an `available_skills` element in its instructions, and the pinned characterization tests from #3188 confirm the outputs stay byte-identical.

## 2. Drifted docs source anchors

[Copilot comment](https://github.com/veryfront/veryfront-code/pull/3188#discussion_r3690176497) on `agent.md` flagged `buildAgentCallContext` pointing at `call-context.ts#L119`. Auditing the rest of the file showed **all six** call-context anchors had drifted when the `hasBlock` hardening added JSDoc mid-review:

| Symbol | Was | Now |
|---|---|---|
| `buildAgentCallContext` | L119 | L131 |
| `DEFAULT_RUNTIME_AGENT_CONTEXT_MARKER` | L37 | L38 |
| `buildProjectContextPromptBlock` | L70 | L72 |
| `buildProjectInstructionsPromptBlock` | L87 | L89 |
| `AgentCallProjectContext` | L42 | L44 |
| `BuildAgentCallContextInput` | L48 | L50 |

The review comment observed L129 for `buildAgentCallContext`; the fix in section 1 adds two lines above it, so the anchor targets L131 — the line it will occupy once this merges. Every anchor was re-audited against the source *after* the cherry-pick onto merged main, since a rebase is exactly what silently invalidates line anchors.

`deno task docs` was deliberately not run: the generator rewrites all 39 reference files against anchors that have drifted repo-wide, which would bury three real fixes under ~3900 lines of unrelated churn.

## Tests

`call-context.test.ts` goes 22 → 24 steps. The two new cases mirror the existing dedup pair: instructions with a full `<available_skills>` element produce no second block (asserting the authored catalog survives verbatim and the injected skill text is absent), and a prose mention without a closing tag still emits the block.

- 825 passed / 0 failed across `src/agent`, `src/internal-agents`, `src/skill` (1932 steps)
- Full pre-push suite: 2806 passed / 0 failed (22736 steps)
- `deno task typecheck`, `deno lint`, `deno fmt --check`, docs coverage, `check-doc-links` — all clean