### PR TITLE
Centralize the dependency-snapshot protocol behind one module

### DIFF
--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -11,11 +11,10 @@ import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-sc
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { VERYFRONT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import {
-  DEFAULT_REACT_VERSION,
   type DependencyPinningSourceInput,
-  esmShReact,
   resolveProjectPackageVersions,
 } from "#veryfront/transforms/esm/package-registry.ts";
+import { DEFAULT_REACT_VERSION, esmShReact } from "#veryfront/transforms/esm/react-cdn.ts";
 import {
   appendDependencyPinningKey,
   appendSameOriginDependencyPinningPathKey,

--- a/src/modules/import-map/default-import-map.ts
+++ b/src/modules/import-map/default-import-map.ts
@@ -1,5 +1,5 @@
 import type { ImportMapConfig } from "./types.ts";
-import { getReactImportMap } from "#veryfront/transforms/esm/package-registry.ts";
+import { getReactImportMap } from "#veryfront/transforms/esm/react-cdn.ts";
 
 /**
  * SSR import map for veryfront/* modules.

--- a/src/modules/import-map/loader.ts
+++ b/src/modules/import-map/loader.ts
@@ -7,7 +7,7 @@ import type { ImportMapConfig } from "./types.ts";
 import { getDefaultImportMap } from "./default-import-map.ts";
 import { mergeImportMaps } from "./merger.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
-import { getReactImportMap } from "#veryfront/transforms/esm/package-registry.ts";
+import { getReactImportMap } from "#veryfront/transforms/esm/react-cdn.ts";
 
 function normalizeImportMapForRuntime(importMap: ImportMapConfig): ImportMapConfig {
   const normalizeValue = (value: string): string => {

--- a/src/modules/react-loader/unified-loader.ts
+++ b/src/modules/react-loader/unified-loader.ts
@@ -6,11 +6,8 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { getProjectTmpDir } from "./temp-directory.ts";
 import type { ComponentMap, ComponentSource, LoadComponentOptions } from "./types.ts";
-import {
-  DEFAULT_REACT_VERSION,
-  getReactImportMap,
-  resolveDependencyPinningSnapshot,
-} from "#veryfront/transforms/esm/package-registry.ts";
+import { resolveDependencyPinningSnapshot } from "#veryfront/transforms/esm/package-registry.ts";
+import { DEFAULT_REACT_VERSION, getReactImportMap } from "#veryfront/transforms/esm/react-cdn.ts";
 
 type TransformedComponent = { name: string; code: string };
 type ComponentTransformer = typeof transformToESM;

--- a/src/react/compat/config-generator.ts
+++ b/src/react/compat/config-generator.ts
@@ -2,7 +2,7 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import { join } from "#veryfront/compat/path/index.ts";
 import { createError, toError } from "#veryfront/errors";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
-import { getReactUrls } from "#veryfront/transforms/esm/package-registry.ts";
+import { getReactUrls } from "#veryfront/transforms/esm/react-cdn.ts";
 import {
   REACT_VERSION_17,
   REACT_VERSION_18_2,

--- a/src/react/compat/ssr-adapter/server-loader.ts
+++ b/src/react/compat/ssr-adapter/server-loader.ts
@@ -2,10 +2,10 @@ import { INITIALIZATION_ERROR } from "#veryfront/errors";
 import { Singleflight } from "#veryfront/utils/singleflight.ts";
 import { cacheModuleToLocal } from "#veryfront/transforms/esm/http-cache.ts";
 import {
-  getReactUrls,
   normalizeReactVersion,
   stripSemverRange,
 } from "#veryfront/transforms/esm/package-registry.ts";
+import { getReactUrls } from "#veryfront/transforms/esm/react-cdn.ts";
 import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { rendererLogger } from "#veryfront/utils";
 

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -41,10 +41,10 @@ import {
   createDependencyPinningSource,
   type DependencyPinningSnapshot,
   type DependencyPinningSourceInput,
-  getReactUrls,
   resolveDependencyPinningSnapshot,
   resolveProjectReactVersion,
 } from "#veryfront/transforms/esm/package-registry.ts";
+import { getReactUrls } from "#veryfront/transforms/esm/react-cdn.ts";
 import { PLATFORM_UTILITIES } from "#veryfront/html/utils.ts";
 import { ensureDefaultBundlerContracts } from "../extensions/bundler/defaults.ts";
 import { register, tryResolve } from "../extensions/contracts.ts";

--- a/src/server/handlers/request/module/data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/data-endpoint-handler.test.ts
@@ -264,7 +264,9 @@ describe("server/handlers/request/module/data-endpoint-handler", () => {
         ),
         makeCtx(projectDir),
       );
-      const payload = await response.json();
+      // The conflict body is the one the client recovery matches on; see
+      // src/server/handlers/utils/dependency-snapshot-protocol.ts.
+      const payload = await response.text();
 
       assertEquals(response.status, 409);
       assertEquals(response.headers.get("cache-control"), "no-store");
@@ -274,10 +276,7 @@ describe("server/handlers/request/module/data-endpoint-handler", () => {
         ),
         true,
       );
-      assertEquals(payload, {
-        error: "Unknown dependency snapshot",
-        status: 409,
-      });
+      assertEquals(payload, "Unknown dependency snapshot");
       assertEquals(renderCalls, 0);
     } finally {
       restoreEnv(DEPENDENCY_PINNING_ENV_FLAG, originalFlag);

--- a/src/server/handlers/request/module/data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/data-endpoint-handler.ts
@@ -4,13 +4,15 @@ import { ResponseBuilder } from "#veryfront/security/index.ts";
 import { getRendererForProject } from "../../../shared/renderer-factory.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { serverLogger } from "#veryfront/utils";
-import {
-  resolveRequestedDependencyPinningSnapshot,
-} from "#veryfront/transforms/esm/package-registry.ts";
 import { createHandlerDependencyPinningSource } from "#veryfront/server/handlers/utils/dependency-pinning-source.ts";
+import {
+  applySnapshotResponseHeaders,
+  readSnapshotHeader,
+  resolveSnapshotForRequest,
+  snapshotConflictResponse,
+  stripSnapshotHeader,
+} from "#veryfront/server/handlers/utils/dependency-snapshot-protocol.ts";
 import { resolveSSRControlOutcome } from "#veryfront/rendering/ssr-outcome.ts";
-
-const DEPENDENCY_PINNING_HEADER = "x-veryfront-dependency-pins";
 
 export function handleDataEndpoint(
   req: Request,
@@ -27,35 +29,23 @@ export function handleDataEndpoint(
         const rawSlug = pathname.replace("/_veryfront/data/", "").replace(/\.json$/, "");
         const encSlug = rawSlug === "index" ? "" : rawSlug;
         const requestUrl = new URL(req.url);
-        const requestedPinKey = req.headers.get(DEPENDENCY_PINNING_HEADER);
         const dependencySource = createHandlerDependencyPinningSource(ctx);
-        const dependencySnapshot = requestedPinKey !== null &&
-            !requestedPinKey.startsWith("on:")
-          ? undefined
-          : await resolveRequestedDependencyPinningSnapshot(
-            dependencySource,
-            requestedPinKey,
-          );
-
-        const isMissingEnabledSnapshot = requestedPinKey === null &&
-          dependencySnapshot?.cacheKey.startsWith("on:");
-        if (!dependencySnapshot || isMissingEnabledSnapshot) {
-          const builder = createResponseBuilder(ctx)
-            .withCORS(req, ctx.securityConfig?.cors)
-            .withSecurity(ctx.securityConfig ?? undefined, req)
-            .withCache("no-store");
-          withDependencyPinningVary(builder);
+        const resolution = await resolveSnapshotForRequest(
+          dependencySource,
+          readSnapshotHeader(req.headers),
+        );
+        if (resolution.kind === "conflict") {
           return respond(
-            builder.json({ error: "Unknown dependency snapshot", status: 409 }, 409),
+            snapshotConflictResponse(createResponseBuilder(ctx), req, ctx.securityConfig),
           );
         }
+        const dependencySnapshot = resolution.snapshot;
 
         // The transport token must participate in framework caches without
         // leaking into application-visible request/query state.
         const applicationUrl = new URL(requestUrl);
         applicationUrl.pathname = encSlug ? `/${encSlug}` : "/";
-        const applicationHeaders = new Headers(req.headers);
-        applicationHeaders.delete(DEPENDENCY_PINNING_HEADER);
+        const applicationHeaders = stripSnapshotHeader(req.headers);
         const applicationRequest = new Request(applicationUrl, {
           method: req.method,
           headers: applicationHeaders,
@@ -85,12 +75,7 @@ export function handleDataEndpoint(
         const etag = computeEtag(body);
 
         const builder = createResponseBuilder(ctx).withCORS(req, ctx.securityConfig?.cors);
-        withDependencyPinningVary(builder);
-        if (dependencySnapshot.cacheKey.startsWith("on:")) {
-          builder.withHeaders({
-            [DEPENDENCY_PINNING_HEADER]: dependencySnapshot.cacheKey,
-          });
-        }
+        applySnapshotResponseHeaders(builder.headers, dependencySnapshot.cacheKey);
 
         if (hasMatchingEtag(req, etag)) {
           return respond(builder.notModified(etag));
@@ -117,7 +102,7 @@ export function handleDataEndpoint(
         const builder = createResponseBuilder(ctx)
           .withCORS(req, ctx.securityConfig?.cors)
           .withSecurity(ctx.securityConfig ?? undefined, req);
-        withDependencyPinningVary(builder);
+        applySnapshotResponseHeaders(builder.headers);
         return respond(
           builder.json(
             { error: isNotFound ? "Page not found" : "Internal server error", status },
@@ -131,13 +116,4 @@ export function handleDataEndpoint(
       "module.data.projectSlug": ctx.projectSlug || "unknown",
     },
   );
-}
-
-function withDependencyPinningVary(builder: ResponseBuilder): void {
-  const existing = builder.headers.get("vary");
-  const values = existing?.split(",").map((value) => value.trim().toLowerCase()) ?? [];
-  if (values.includes(DEPENDENCY_PINNING_HEADER)) return;
-  builder.withHeaders({
-    vary: existing ? `${existing}, ${DEPENDENCY_PINNING_HEADER}` : DEPENDENCY_PINNING_HEADER,
-  });
 }

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -388,6 +388,9 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
         );
         assertEquals(response.status, 409);
         assertEquals(response.headers.get("cache-control"), "no-store");
+        // The body the client recovery matches on; see
+        // src/server/handlers/utils/dependency-snapshot-protocol.ts.
+        assertEquals(await response.text(), "Unknown dependency snapshot");
         assertEquals(
           response.headers.get("vary")?.toLowerCase().includes(
             "x-veryfront-dependency-pins",

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -19,12 +19,17 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 import {
   type DependencyPinningSnapshot,
   type DependencyPinningSourceInput,
-  resolveRequestedDependencyPinningSnapshot,
 } from "#veryfront/transforms/esm/package-registry.ts";
 import { createHandlerDependencyPinningSource } from "#veryfront/server/handlers/utils/dependency-pinning-source.ts";
+import {
+  readSnapshotHeader,
+  resolveSnapshotForRequest,
+  snapshotConflictResponse,
+  stripSnapshotHeader,
+  withSnapshotResponseHeaders,
+} from "#veryfront/server/handlers/utils/dependency-snapshot-protocol.ts";
 
 const PAGE_DATA_TIMEOUT_MS = 25_000;
-const DEPENDENCY_PINNING_REQUEST_HEADER = "x-veryfront-dependency-pins";
 const PAGE_DATA_CACHE_TTL_MS = readPositiveIntegerEnv("VERYFRONT_PAGE_DATA_CACHE_TTL_MS", 60_000);
 const PAGE_DATA_CACHE_STALE_MS = readPositiveIntegerEnv(
   "VERYFRONT_PAGE_DATA_CACHE_STALE_MS",
@@ -139,37 +144,26 @@ export function handlePageDataEndpoint(
     async () => {
       let dependencySnapshot: DependencyPinningSnapshot | undefined;
       const respondPageData = (response: Response): HandlerResult =>
-        respond(withDependencySnapshotResponseHeaders(response, dependencySnapshot));
+        respond(withSnapshotResponseHeaders(response, dependencySnapshot?.cacheKey));
       try {
         const slug = pathname
           .replace("/_veryfront/page-data/", "")
           .replace(/\.json$/, "") || "";
 
-        const requestedPinKey = req.headers.get(DEPENDENCY_PINNING_REQUEST_HEADER);
-        if (requestedPinKey !== null && !requestedPinKey.startsWith("on:")) {
-          return respondPageData(
-            unknownDependencySnapshotResponse(req, ctx, createResponseBuilder),
-          );
-        }
-
+        const requested = readSnapshotHeader(req.headers);
         const dependencySource = createHandlerDependencyPinningSource(ctx);
-        const resolvedDependencySnapshot = await resolveRequestedDependencyPinningSnapshot(
-          dependencySource,
-          requestedPinKey,
-        );
-        if (
-          !resolvedDependencySnapshot ||
-          (requestedPinKey === null && resolvedDependencySnapshot.cacheKey !== "off")
-        ) {
+        const resolution = await resolveSnapshotForRequest(dependencySource, requested);
+        if (resolution.kind === "conflict") {
           return respondPageData(
-            unknownDependencySnapshotResponse(req, ctx, createResponseBuilder),
+            snapshotConflictResponse(createResponseBuilder(ctx), req, ctx.securityConfig),
           );
         }
+        const resolvedDependencySnapshot = resolution.snapshot;
         dependencySnapshot = resolvedDependencySnapshot;
 
         const url = new URL(req.url);
-        const applicationRequest = requestedPinKey === null ? req : new Request(req, {
-          headers: withoutHeader(req.headers, DEPENDENCY_PINNING_REQUEST_HEADER),
+        const applicationRequest = requested.kind === "absent" ? req : new Request(req, {
+          headers: stripSnapshotHeader(req.headers),
         });
         const renderer = await getRendererForProject(ctx);
         const isSpeculativePrefetch = req.headers.get("x-veryfront-prefetch") === "1";
@@ -314,51 +308,6 @@ export function handlePageDataEndpoint(
       "module.pageData.projectSlug": ctx.projectSlug || "unknown",
     },
   );
-}
-
-function withoutHeader(headers: Headers, name: string): Headers {
-  const sanitized = new Headers(headers);
-  sanitized.delete(name);
-  return sanitized;
-}
-
-function withDependencySnapshotResponseHeaders(
-  response: Response,
-  snapshot?: DependencyPinningSnapshot,
-): Response {
-  const headers = new Headers(response.headers);
-  const vary = headers.get("vary");
-  const varyValues = (vary ?? "")
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
-  if (
-    !varyValues.some((value) => value.toLowerCase() === DEPENDENCY_PINNING_REQUEST_HEADER)
-  ) {
-    varyValues.push(DEPENDENCY_PINNING_REQUEST_HEADER);
-  }
-  headers.set("vary", varyValues.join(", "));
-  if (snapshot?.cacheKey.startsWith("on:")) {
-    headers.set(DEPENDENCY_PINNING_REQUEST_HEADER, snapshot.cacheKey);
-  }
-
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-}
-
-function unknownDependencySnapshotResponse(
-  req: Request,
-  ctx: HandlerContext,
-  createResponseBuilder: (ctx: HandlerContext) => ResponseBuilder,
-): Response {
-  return createResponseBuilder(ctx)
-    .withCORS(req, ctx.securityConfig?.cors)
-    .withSecurity(ctx.securityConfig ?? undefined, req)
-    .withCache("no-store")
-    .json({ error: "Unknown dependency snapshot", status: 409 }, 409);
 }
 
 async function resolveCachedPageData(

--- a/src/server/handlers/request/module/page-module-handler.ts
+++ b/src/server/handlers/request/module/page-module-handler.ts
@@ -6,10 +6,13 @@ import { shouldUseNoCacheHeadersFromHandler } from "../../../context/enriched-co
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { serverLogger } from "#veryfront/utils";
 import { VeryfrontError } from "#veryfront/errors";
-import { resolveRequestedDependencyPinningSnapshot } from "#veryfront/transforms/esm/package-registry.ts";
 import { createHandlerDependencyPinningSource } from "#veryfront/server/handlers/utils/dependency-pinning-source.ts";
-
-const DEPENDENCY_PIN_PATTERN = /^on:[A-Za-z0-9._-]+$/;
+import {
+  readSnapshotQuery,
+  resolveSnapshotForRequest,
+  snapshotConflictResponse,
+  stripSnapshotQuery,
+} from "#veryfront/server/handlers/utils/dependency-snapshot-protocol.ts";
 
 function isPageModuleNotFound(error: unknown): boolean {
   return error instanceof VeryfrontError &&
@@ -35,31 +38,19 @@ export function handlePageModule(
         const slug = slugPath || "index";
 
         const requestUrl = new URL(req.url);
-        const requestedPinKeys = requestUrl.searchParams.getAll("pins");
-        const requestedPinKey = requestedPinKeys[0];
-        if (
-          requestedPinKeys.length > 1 ||
-          (requestedPinKey !== undefined &&
-            !DEPENDENCY_PIN_PATTERN.test(requestedPinKey))
-        ) {
-          return respondDependencyConflict(req, ctx, createResponseBuilder, respond);
-        }
-
         const dependencyPinningSource = createHandlerDependencyPinningSource(ctx);
-        const dependencySnapshot = await resolveRequestedDependencyPinningSnapshot(
+        const resolution = await resolveSnapshotForRequest(
           dependencyPinningSource,
-          requestedPinKey,
+          readSnapshotQuery(requestUrl),
         );
-        if (
-          !dependencySnapshot ||
-          (requestedPinKey === undefined &&
-            dependencySnapshot.cacheKey.startsWith("on:"))
-        ) {
-          return respondDependencyConflict(req, ctx, createResponseBuilder, respond);
+        if (resolution.kind === "conflict") {
+          return respond(
+            snapshotConflictResponse(createResponseBuilder(ctx), req, ctx.securityConfig),
+          );
         }
+        const dependencySnapshot = resolution.snapshot;
 
-        const applicationUrl = new URL(requestUrl);
-        if (requestedPinKey !== undefined) applicationUrl.searchParams.delete("pins");
+        const applicationUrl = stripSnapshotQuery(requestUrl);
         const renderer = await getRendererForProject(ctx);
         const { pageModule } = await renderer.renderPage(slug, {
           params: undefined,
@@ -128,20 +119,5 @@ export function handlePageModule(
       "module.page.pathname": pathname,
       "module.page.projectSlug": ctx.projectSlug || "unknown",
     },
-  );
-}
-
-function respondDependencyConflict(
-  req: Request,
-  ctx: HandlerContext,
-  createResponseBuilder: (ctx: HandlerContext) => ResponseBuilder,
-  respond: (response: Response) => HandlerResult,
-): HandlerResult {
-  return respond(
-    createResponseBuilder(ctx)
-      .withCORS(req, ctx.securityConfig?.cors)
-      .withSecurity(ctx.securityConfig ?? undefined, req)
-      .withCache("no-store")
-      .text("Unknown dependency snapshot", 409),
   );
 }

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -16,7 +16,6 @@ import type {
 } from "../../types.ts";
 import { PRIORITY_LOW } from "#veryfront/utils/constants/index.ts";
 import { generateNonce } from "#veryfront/security/http/response/security-handler.ts";
-import type { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { shouldUseNoCacheHeadersFromHandler } from "../../../context/enriched-context.ts";
@@ -33,14 +32,17 @@ import {
 import { ErrorPages } from "../../../utils/error-html.ts";
 import { isSSRBuildFailure } from "#veryfront/rendering/ssr-outcome.ts";
 import { buildSSRResponse } from "./ssr-response-builder.ts";
-import {
-  type DependencyPinningSnapshot,
-  resolveRequestedDependencyPinningSnapshot,
-} from "#veryfront/transforms/esm/package-registry.ts";
+import { type DependencyPinningSnapshot } from "#veryfront/transforms/esm/package-registry.ts";
 import { createHandlerDependencyPinningSource } from "#veryfront/server/handlers/utils/dependency-pinning-source.ts";
+import {
+  applySnapshotResponseHeaders,
+  readSnapshotHeader,
+  resolveSnapshotForRequest,
+  snapshotConflictResponse,
+  stripSnapshotHeader,
+} from "#veryfront/server/handlers/utils/dependency-snapshot-protocol.ts";
 
 const logger = serverLogger.component("ssr");
-const DEPENDENCY_PINNING_RESPONSE_HEADER = "x-veryfront-dependency-pins";
 
 /**
  * Determine if request should serve production (released) content.
@@ -203,23 +205,22 @@ export class SSRHandler extends BaseHandler {
     return withSpan(
       "ssr.handleWithContext",
       async () => {
-        const requestedPinKey = req.headers.get(DEPENDENCY_PINNING_RESPONSE_HEADER);
         const dependencySource = createHandlerDependencyPinningSource(ctx);
-        const dependencySnapshot = requestedPinKey !== null &&
-            !requestedPinKey.startsWith("on:")
-          ? undefined
-          : await resolveRequestedDependencyPinningSnapshot(
-            dependencySource,
-            requestedPinKey,
-          );
-        if (!dependencySnapshot) {
+        // The document request is where the client learns the current snapshot
+        // key, so an unpinned request adopts it instead of conflicting.
+        const resolution = await resolveSnapshotForRequest(
+          dependencySource,
+          readSnapshotHeader(req.headers),
+          { unpinnedRequest: "adopt" },
+        );
+        if (resolution.kind === "conflict") {
           endRequest(requestId);
           return this.handleDependencySnapshotConflict(req, ctx);
         }
+        const dependencySnapshot = resolution.snapshot;
 
         const applicationUrl = new URL(url);
-        const applicationHeaders = new Headers(req.headers);
-        applicationHeaders.delete(DEPENDENCY_PINNING_RESPONSE_HEADER);
+        const applicationHeaders = stripSnapshotHeader(req.headers);
         const applicationRequest = new Request(applicationUrl, {
           method: req.method,
           headers: applicationHeaders,
@@ -415,13 +416,13 @@ export class SSRHandler extends BaseHandler {
     req: Request,
     ctx: HandlerContext,
   ): HandlerResult {
-    const response = this.createResponseBuilder(ctx, generateNonce())
-      .withCORS(req, ctx.securityConfig?.cors)
-      .withSecurity(ctx.securityConfig ?? undefined, req)
-      .withCache("no-store");
-    withDependencyPinningVary(response);
-    const conflict = response.text("Unknown dependency snapshot", 409);
-    return this.respond(conflict);
+    return this.respond(
+      snapshotConflictResponse(
+        this.createResponseBuilder(ctx, generateNonce()),
+        req,
+        ctx.securityConfig,
+      ),
+    );
   }
 
   private createSnapshotResponseBuilder(
@@ -430,25 +431,7 @@ export class SSRHandler extends BaseHandler {
     dependencyPinningCacheKey?: string,
   ) {
     const builder = this.createResponseBuilder(ctx, nonce);
-    withDependencyPinningVary(builder);
-    if (dependencyPinningCacheKey?.startsWith("on:")) {
-      builder.withHeaders({
-        [DEPENDENCY_PINNING_RESPONSE_HEADER]: dependencyPinningCacheKey,
-      });
-    }
+    applySnapshotResponseHeaders(builder.headers, dependencyPinningCacheKey);
     return builder;
   }
-}
-
-function withDependencyPinningVary(
-  builder: ResponseBuilder,
-): void {
-  const existing = builder.headers.get("vary");
-  const values = existing?.split(",").map((value) => value.trim().toLowerCase()) ?? [];
-  if (values.includes(DEPENDENCY_PINNING_RESPONSE_HEADER)) return;
-  builder.withHeaders({
-    vary: existing
-      ? `${existing}, ${DEPENDENCY_PINNING_RESPONSE_HEADER}`
-      : DEPENDENCY_PINNING_RESPONSE_HEADER,
-  });
 }

--- a/src/server/handlers/utils/dependency-snapshot-protocol.test.ts
+++ b/src/server/handlers/utils/dependency-snapshot-protocol.test.ts
@@ -1,0 +1,251 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createResponseBuilder } from "#veryfront/security/index.ts";
+import {
+  clearReactVersionCache,
+  getDependencyPinningSnapshot,
+} from "#veryfront/transforms/esm/package-registry.ts";
+import { DEPENDENCY_PINNING_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
+import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import {
+  applySnapshotResponseHeaders,
+  DEPENDENCY_PINS_HEADER,
+  readSnapshotHeader,
+  readSnapshotQuery,
+  resolveSnapshotForRequest,
+  SNAPSHOT_CONFLICT_BODY,
+  snapshotConflictResponse,
+  stripSnapshotHeader,
+  stripSnapshotQuery,
+  withSnapshotResponseHeaders,
+} from "./dependency-snapshot-protocol.ts";
+
+const PINNED_KEY = "on:1a2b3c";
+
+function headers(init: Record<string, string> = {}): Headers {
+  return new Headers(init);
+}
+
+describe("server/handlers/utils/dependency-snapshot-protocol", () => {
+  describe("reading the requested snapshot", () => {
+    it("reports an absent header as unpinned", () => {
+      assertEquals(readSnapshotHeader(headers()), { kind: "absent" });
+    });
+
+    it("accepts a well-formed key from the header", () => {
+      assertEquals(
+        readSnapshotHeader(headers({ [DEPENDENCY_PINS_HEADER]: PINNED_KEY })),
+        { kind: "pinned", key: PINNED_KEY },
+      );
+    });
+
+    it("refuses header keys that are not snapshot keys", () => {
+      for (const raw of ["off", "on:", "on:first, on:second", "1a2b3c", "ON:1a2b3c"]) {
+        assertEquals(
+          readSnapshotHeader(headers({ [DEPENDENCY_PINS_HEADER]: raw })),
+          { kind: "unusable" },
+          `expected ${raw} to be refused`,
+        );
+      }
+    });
+
+    it("reads the same key from a module URL query parameter", () => {
+      assertEquals(
+        readSnapshotQuery(new URL(`http://localhost/m.js?pins=${PINNED_KEY}`)),
+        { kind: "pinned", key: PINNED_KEY },
+      );
+      assertEquals(readSnapshotQuery(new URL("http://localhost/m.js")), { kind: "absent" });
+    });
+
+    it("refuses a module URL asking for two snapshots at once", () => {
+      assertEquals(
+        readSnapshotQuery(new URL("http://localhost/m.js?pins=on:aaa&pins=on:bbb")),
+        { kind: "unusable" },
+      );
+    });
+  });
+
+  describe("forwarding to application code", () => {
+    it("removes the snapshot header without touching the rest", () => {
+      const forwarded = stripSnapshotHeader(
+        headers({ [DEPENDENCY_PINS_HEADER]: PINNED_KEY, "x-keep": "yes" }),
+      );
+
+      assertEquals(forwarded.get(DEPENDENCY_PINS_HEADER), null);
+      assertEquals(forwarded.get("x-keep"), "yes");
+    });
+
+    it("removes the snapshot query parameter without touching the rest", () => {
+      const forwarded = stripSnapshotQuery(
+        new URL(`http://localhost/m.js?rel=%2Fa&pins=${PINNED_KEY}`),
+      );
+
+      assertEquals(forwarded.searchParams.get("pins"), null);
+      assertEquals(forwarded.searchParams.get("rel"), "/a");
+    });
+
+    it("leaves the caller's headers unmodified", () => {
+      const original = headers({ [DEPENDENCY_PINS_HEADER]: PINNED_KEY });
+      stripSnapshotHeader(original);
+
+      assertEquals(original.get(DEPENDENCY_PINS_HEADER), PINNED_KEY);
+    });
+  });
+
+  describe("response headers", () => {
+    it("marks the response snapshot-dependent and echoes a pinned key", () => {
+      const responseHeaders = headers();
+      applySnapshotResponseHeaders(responseHeaders, PINNED_KEY);
+
+      assertEquals(responseHeaders.get("vary"), DEPENDENCY_PINS_HEADER);
+      assertEquals(responseHeaders.get(DEPENDENCY_PINS_HEADER), PINNED_KEY);
+    });
+
+    it("varies but echoes nothing when the project is not pinning", () => {
+      const responseHeaders = headers();
+      applySnapshotResponseHeaders(responseHeaders, "off");
+
+      assertEquals(responseHeaders.get("vary"), DEPENDENCY_PINS_HEADER);
+      assertEquals(responseHeaders.get(DEPENDENCY_PINS_HEADER), null);
+    });
+
+    it("appends to an existing vary rather than replacing it", () => {
+      const responseHeaders = headers({ vary: "Accept-Encoding" });
+      applySnapshotResponseHeaders(responseHeaders);
+
+      assertEquals(responseHeaders.get("vary"), `Accept-Encoding, ${DEPENDENCY_PINS_HEADER}`);
+    });
+
+    it("does not repeat an entry it already added", () => {
+      const responseHeaders = headers();
+      applySnapshotResponseHeaders(responseHeaders, PINNED_KEY);
+      applySnapshotResponseHeaders(responseHeaders, PINNED_KEY);
+
+      assertEquals(responseHeaders.get("vary"), DEPENDENCY_PINS_HEADER);
+    });
+
+    it("copies a response with the headers applied and the body intact", async () => {
+      const copied = withSnapshotResponseHeaders(
+        new Response("payload", { status: 404, headers: { "x-keep": "yes" } }),
+        PINNED_KEY,
+      );
+
+      assertEquals(copied.status, 404);
+      assertEquals(copied.headers.get("x-keep"), "yes");
+      assertEquals(copied.headers.get(DEPENDENCY_PINS_HEADER), PINNED_KEY);
+      assertEquals(await copied.text(), "payload");
+    });
+  });
+
+  describe("conflict response", () => {
+    it("answers 409 with the exact body the client recovery matches", async () => {
+      const response = snapshotConflictResponse(
+        createResponseBuilder(),
+        new Request("http://localhost/page"),
+        null,
+      );
+
+      assertEquals(response.status, 409);
+      assertEquals(await response.text(), SNAPSHOT_CONFLICT_BODY);
+      assertEquals(response.headers.get("cache-control"), "no-store");
+      assertEquals(
+        response.headers.get("vary")?.toLowerCase().includes(DEPENDENCY_PINS_HEADER),
+        true,
+      );
+    });
+
+    it("never echoes a snapshot key it could not resolve", () => {
+      const response = snapshotConflictResponse(
+        createResponseBuilder(),
+        new Request("http://localhost/page", {
+          headers: { [DEPENDENCY_PINS_HEADER]: PINNED_KEY },
+        }),
+        null,
+      );
+
+      assertEquals(response.headers.get(DEPENDENCY_PINS_HEADER), null);
+    });
+  });
+
+  describe("resolving a request against known snapshots", () => {
+    async function withPinnedProject(
+      run: (projectDir: string, currentKey: string) => Promise<void>,
+    ): Promise<void> {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-snapshot-protocol-" });
+      const originalFlag = getHostEnv(DEPENDENCY_PINNING_ENV_FLAG);
+      try {
+        setEnv(DEPENDENCY_PINNING_ENV_FLAG, "1");
+        clearReactVersionCache();
+        await Deno.writeTextFile(
+          `${projectDir}/package.json`,
+          JSON.stringify({ dependencies: { react: "18.3.1" } }),
+        );
+        const current = await getDependencyPinningSnapshot(projectDir);
+        await run(projectDir, current.cacheKey);
+      } finally {
+        setEnv(DEPENDENCY_PINNING_ENV_FLAG, originalFlag ?? "");
+        clearReactVersionCache();
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    }
+
+    it("resolves the key the caller asked for", async () => {
+      await withPinnedProject(async (projectDir, currentKey) => {
+        const resolution = await resolveSnapshotForRequest(projectDir, {
+          kind: "pinned",
+          key: currentKey,
+        });
+
+        assertEquals(resolution.kind, "ready");
+        assertEquals(
+          resolution.kind === "ready" ? resolution.snapshot.cacheKey : null,
+          currentKey,
+        );
+      });
+    });
+
+    it("conflicts on a key this server does not know", async () => {
+      await withPinnedProject(async (projectDir) => {
+        const resolution = await resolveSnapshotForRequest(projectDir, {
+          kind: "pinned",
+          key: "on:zzzzzz",
+        });
+
+        assertEquals(resolution.kind, "conflict");
+      });
+    });
+
+    it("conflicts without resolving anything when the request is unusable", async () => {
+      await withPinnedProject(async (projectDir) => {
+        assertEquals(
+          (await resolveSnapshotForRequest(projectDir, { kind: "unusable" })).kind,
+          "conflict",
+        );
+      });
+    });
+
+    it("conflicts on an unpinned request while the project is pinning", async () => {
+      await withPinnedProject(async (projectDir) => {
+        const resolution = await resolveSnapshotForRequest(projectDir, { kind: "absent" });
+
+        assertEquals(resolution.kind, "conflict");
+      });
+    });
+
+    it("lets the document request adopt the current snapshot instead", async () => {
+      await withPinnedProject(async (projectDir, currentKey) => {
+        const resolution = await resolveSnapshotForRequest(
+          projectDir,
+          { kind: "absent" },
+          { unpinnedRequest: "adopt" },
+        );
+
+        assertEquals(
+          resolution.kind === "ready" ? resolution.snapshot.cacheKey : null,
+          currentKey,
+        );
+      });
+    });
+  });
+});

--- a/src/server/handlers/utils/dependency-snapshot-protocol.ts
+++ b/src/server/handlers/utils/dependency-snapshot-protocol.ts
@@ -1,0 +1,196 @@
+/**
+ * The HTTP protocol that binds a request to one dependency snapshot.
+ *
+ * A page and every asset it pulls must be built from the same dependency set,
+ * so each request carries the snapshot key its document was built from. This
+ * module owns that wire contract end to end: the header and query parameter
+ * that carry the key, how a carried key is validated, how it is resolved into a
+ * snapshot, what a conflict looks like on the wire, and which response headers
+ * keep the answer cacheable.
+ *
+ * Handlers adapt their own transport to this module rather than restating the
+ * protocol. Document, page-data, and data requests carry the key in a header;
+ * module URLs carry it in a query parameter because the browser imports them
+ * and cannot attach headers.
+ */
+import type { HandlerContext } from "../types.ts";
+import type { ResponseBuilder } from "#veryfront/security/index.ts";
+import {
+  type DependencyPinningSnapshot,
+  type DependencyPinningSourceInput,
+  resolveRequestedDependencyPinningSnapshot,
+} from "#veryfront/transforms/esm/package-registry.ts";
+
+/** Request and response header carrying the dependency snapshot key. */
+export const DEPENDENCY_PINS_HEADER = "x-veryfront-dependency-pins";
+
+/** Query parameter carrying the snapshot key on browser-imported module URLs. */
+export const DEPENDENCY_PINS_QUERY_PARAM = "pins";
+
+/**
+ * Body of a snapshot-conflict response.
+ *
+ * The client recovers from a snapshot conflict by reloading the document, and
+ * it tells a conflict apart from any other 409 by matching this exact body. Any
+ * change here has to land in the client recovery paths first — see
+ * `src/rendering/rsc/dependency-snapshot-recovery.ts` and the router template
+ * in `src/html/hydration-script-builder/templates/`.
+ */
+export const SNAPSHOT_CONFLICT_BODY = "Unknown dependency snapshot";
+
+/**
+ * Canonical keys are `on:` plus a base36 hash. The pattern is deliberately
+ * wider than the canonical form so that resolution, not parsing, decides
+ * whether a well-formed key is one this server actually knows.
+ */
+const SNAPSHOT_KEY_PATTERN = /^on:[A-Za-z0-9._-]+$/;
+
+/** What a request carries, before it is resolved against known snapshots. */
+export type SnapshotRequest =
+  /** No key at all: an unpinned caller, or a first document request. */
+  | { readonly kind: "absent" }
+  /** A well-formed key the caller wants this response bound to. */
+  | { readonly kind: "pinned"; readonly key: string }
+  /** A key this server will not act on; always answered with a conflict. */
+  | { readonly kind: "unusable" };
+
+/** Outcome of pairing a carried key with the snapshots this server holds. */
+export type SnapshotResolution =
+  | { readonly kind: "ready"; readonly snapshot: DependencyPinningSnapshot }
+  | { readonly kind: "conflict" };
+
+export interface SnapshotResolutionOptions {
+  /**
+   * How to treat a request that carries no key while the project is pinning.
+   *
+   * `"conflict"` (the default) suits assets and data: the caller would receive
+   * content built from a snapshot it never asked for and cannot reconcile with
+   * the document it is rendering into. `"adopt"` suits the document request
+   * itself, which is where the client learns the current key in the first
+   * place.
+   */
+  readonly unpinnedRequest?: "adopt" | "conflict";
+}
+
+const ABSENT: SnapshotRequest = { kind: "absent" };
+const UNUSABLE: SnapshotRequest = { kind: "unusable" };
+const CONFLICT: SnapshotResolution = { kind: "conflict" };
+
+function classifyKey(key: string): SnapshotRequest {
+  return SNAPSHOT_KEY_PATTERN.test(key) ? { kind: "pinned", key } : UNUSABLE;
+}
+
+/** Read the snapshot key a header-carrying request asked for. */
+export function readSnapshotHeader(headers: Headers): SnapshotRequest {
+  const raw = headers.get(DEPENDENCY_PINS_HEADER);
+  return raw === null ? ABSENT : classifyKey(raw);
+}
+
+/**
+ * Read the snapshot key a module URL asked for.
+ *
+ * Two keys would ask one module to be built from two dependency sets at once,
+ * so the request is refused rather than resolved to whichever came first.
+ */
+export function readSnapshotQuery(url: URL): SnapshotRequest {
+  const keys = url.searchParams.getAll(DEPENDENCY_PINS_QUERY_PARAM);
+  const key = keys[0];
+  if (key === undefined) return ABSENT;
+  if (keys.length > 1) return UNUSABLE;
+  return classifyKey(key);
+}
+
+/**
+ * Copy headers for forwarding to application code with the snapshot key
+ * removed, so the transport token never reaches application-visible state.
+ */
+export function stripSnapshotHeader(headers: Headers): Headers {
+  const forwarded = new Headers(headers);
+  forwarded.delete(DEPENDENCY_PINS_HEADER);
+  return forwarded;
+}
+
+/** The same removal for module URLs, whose key rides in the query string. */
+export function stripSnapshotQuery(url: URL): URL {
+  const forwarded = new URL(url);
+  forwarded.searchParams.delete(DEPENDENCY_PINS_QUERY_PARAM);
+  return forwarded;
+}
+
+/**
+ * Mark a response as snapshot-dependent and, when the snapshot is pinned, tell
+ * the caller which one answered it.
+ *
+ * The `Vary` entry is what keeps a pinned answer from being served to a caller
+ * asking for a different snapshot, so it is applied to conflicts and errors too
+ * — not only to successful responses.
+ */
+export function applySnapshotResponseHeaders(
+  headers: Headers,
+  snapshotCacheKey?: string,
+): void {
+  const existing = headers.get("vary");
+  const values = existing?.split(",").map((value) => value.trim().toLowerCase()) ?? [];
+  if (!values.includes(DEPENDENCY_PINS_HEADER)) {
+    headers.set(
+      "vary",
+      existing ? `${existing}, ${DEPENDENCY_PINS_HEADER}` : DEPENDENCY_PINS_HEADER,
+    );
+  }
+  if (snapshotCacheKey?.startsWith("on:")) {
+    headers.set(DEPENDENCY_PINS_HEADER, snapshotCacheKey);
+  }
+}
+
+/** The one conflict response every snapshot-aware endpoint answers with. */
+export function snapshotConflictResponse(
+  builder: ResponseBuilder,
+  req: Request,
+  securityConfig: HandlerContext["securityConfig"],
+): Response {
+  const prepared = builder
+    .withCORS(req, securityConfig?.cors)
+    .withSecurity(securityConfig ?? undefined, req)
+    .withCache("no-store");
+  applySnapshotResponseHeaders(prepared.headers);
+  return prepared.text(SNAPSHOT_CONFLICT_BODY, 409);
+}
+
+/** Copy a response with the snapshot headers applied. */
+export function withSnapshotResponseHeaders(
+  response: Response,
+  snapshotCacheKey?: string,
+): Response {
+  const headers = new Headers(response.headers);
+  applySnapshotResponseHeaders(headers, snapshotCacheKey);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/** Pair a carried key with a snapshot this server can actually build from. */
+export async function resolveSnapshotForRequest(
+  source: DependencyPinningSourceInput,
+  requested: SnapshotRequest,
+  options: SnapshotResolutionOptions = {},
+): Promise<SnapshotResolution> {
+  if (requested.kind === "unusable") return CONFLICT;
+
+  const snapshot = await resolveRequestedDependencyPinningSnapshot(
+    source,
+    requested.kind === "pinned" ? requested.key : undefined,
+  );
+  if (!snapshot) return CONFLICT;
+
+  const adoptsCurrentSnapshot = (options.unpinnedRequest ?? "conflict") === "adopt";
+  if (
+    requested.kind === "absent" && !adoptsCurrentSnapshot &&
+    snapshot.cacheKey.startsWith("on:")
+  ) {
+    return CONFLICT;
+  }
+
+  return { kind: "ready", snapshot };
+}

--- a/src/server/handlers/utils/index.ts
+++ b/src/server/handlers/utils/index.ts
@@ -23,3 +23,19 @@ export {
   getHandlerDependencyPinningIdentity,
   type HandlerDependencyPinningIdentity,
 } from "./dependency-pinning-source.ts";
+export {
+  applySnapshotResponseHeaders,
+  DEPENDENCY_PINS_HEADER,
+  DEPENDENCY_PINS_QUERY_PARAM,
+  readSnapshotHeader,
+  readSnapshotQuery,
+  resolveSnapshotForRequest,
+  SNAPSHOT_CONFLICT_BODY,
+  snapshotConflictResponse,
+  type SnapshotRequest,
+  type SnapshotResolution,
+  type SnapshotResolutionOptions,
+  stripSnapshotHeader,
+  stripSnapshotQuery,
+  withSnapshotResponseHeaders,
+} from "./dependency-snapshot-protocol.ts";

--- a/src/server/services/rsc/orchestrators/handler.test.ts
+++ b/src/server/services/rsc/orchestrators/handler.test.ts
@@ -8,7 +8,7 @@ import { RSC_DEPENDENCY_PINNING_HEADER } from "#veryfront/rendering/rsc/constant
 import {
   clearReactVersionCache,
   getDependencyPinningSnapshot,
-  getDependencyPinningSnapshotSync,
+  resolveRequestedDependencyPinningSnapshot,
 } from "#veryfront/transforms/esm/package-registry.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 
@@ -143,7 +143,7 @@ describe(
             isLocalProject: false,
             mode: "production",
           });
-          const rememberedA = getDependencyPinningSnapshotSync(
+          const rememberedA = await resolveRequestedDependencyPinningSnapshot(
             projectDir,
             snapshotA.cacheKey,
           );

--- a/src/transforms/esm/http-bundler.ts
+++ b/src/transforms/esm/http-bundler.ts
@@ -8,7 +8,7 @@
 import { rendererLogger as logger } from "#veryfront/utils";
 import type { Plugin } from "veryfront/extensions/bundler";
 import { replaceSpecifiers } from "./lexer.ts";
-import { DEFAULT_REACT_VERSION, getReactUrls } from "./package-registry.ts";
+import { DEFAULT_REACT_VERSION, getReactUrls } from "./react-cdn.ts";
 import {
   type EnvironmentConfig,
   getEnvironmentConfig,

--- a/src/transforms/esm/http-cache-helpers.ts
+++ b/src/transforms/esm/http-cache-helpers.ts
@@ -11,7 +11,7 @@ import { resolveImport } from "#veryfront/modules/import-map/resolver.ts";
 import type { ImportMapConfig } from "#veryfront/modules/import-map/types.ts";
 import { buildEsmShUrl } from "../import-rewriter/url-builder.ts";
 import { parseBarePackageSpecifier } from "../shared/package-specifier.ts";
-import { DEFAULT_REACT_VERSION, getReactImportMap } from "./package-registry.ts";
+import { DEFAULT_REACT_VERSION, getReactImportMap } from "./react-cdn.ts";
 import { computeHash } from "#veryfront/utils/hash-utils.ts";
 
 const logger = rendererLogger.component("http-cache");

--- a/src/transforms/esm/import-rewriter.ts
+++ b/src/transforms/esm/import-rewriter.ts
@@ -1,5 +1,5 @@
 import { parseImports, replaceSpecifiers, rewriteImports } from "./lexer.ts";
-import { getReactImportMap } from "./package-registry.ts";
+import { getReactImportMap } from "./react-cdn.ts";
 import {
   DEFAULT_REACT_VERSION as REACT_DEFAULT_VERSION,
   TAILWIND_VERSION,

--- a/src/transforms/esm/package-registry.test.ts
+++ b/src/transforms/esm/package-registry.test.ts
@@ -15,7 +15,6 @@ import {
   _primeDependenciesCache,
   clearReactVersionCache,
   createDependencyPinningSource,
-  DEFAULT_REACT_VERSION,
   type DependencyPinningSource,
   ensureProjectDependenciesLoaded,
   getDependencyPinningCacheKey,
@@ -31,6 +30,7 @@ import {
   resolveRequestedDependencyPinningSnapshot,
   stripSemverRange,
 } from "./package-registry.ts";
+import { DEFAULT_REACT_VERSION } from "./react-cdn.ts";
 
 function cacheKeyForDependencies(
   dependencies: Readonly<Record<string, string>>,

--- a/src/transforms/esm/package-registry.ts
+++ b/src/transforms/esm/package-registry.ts
@@ -1,8 +1,7 @@
 /****
- * Central package version and URL registry.
+ * Central package version registry and dependency-pinning snapshot accessors.
  *
- * Re-exports from the unified import-rewriter module.
- * This file is kept for backward compatibility with existing imports.
+ * React CDN URL building lives in ./react-cdn.ts.
  */
 
 import { rendererLogger } from "#veryfront/utils";

--- a/src/transforms/esm/package-registry.ts
+++ b/src/transforms/esm/package-registry.ts
@@ -20,16 +20,7 @@ import type { VeryfrontConfig } from "#veryfront/config";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { DEPENDENCY_PINNING_ENV_FLAG } from "../../release-assets/constants.ts";
 import { isExactSemver } from "./npm-registry-client.ts";
-import {
-  buildReactUrl,
-  CSSTYPE_VERSION,
-  DEFAULT_REACT_VERSION,
-  getReactImportMap as getReactImportMapFromRewriter,
-  TAILWIND_VERSION,
-} from "../import-rewriter/url-builder.ts";
-
-// Re-export constants from unified source
-export { CSSTYPE_VERSION, DEFAULT_REACT_VERSION, TAILWIND_VERSION };
+import { DEFAULT_REACT_VERSION } from "../import-rewriter/url-builder.ts";
 
 interface CachedDependencyVersions {
   mtimeMs: number | null;
@@ -270,45 +261,6 @@ export function normalizeReactVersion(version: string | undefined): string {
 }
 
 /**
- * Build esm.sh URL with deps=csstype for React packages.
- */
-export function esmShReact(
-  pkg: string,
-  version: string,
-  path = "",
-  external = false,
-): string {
-  return buildReactUrl(
-    pkg as "react" | "react-dom",
-    version,
-    path || undefined,
-    external,
-  );
-}
-
-/**
- * Get React esm.sh URLs with consistent versioning.
- */
-export function getReactUrls(version?: string): Record<string, string> {
-  const v = version ?? DEFAULT_REACT_VERSION;
-  return {
-    react: buildReactUrl("react", v),
-    "react-dom": buildReactUrl("react-dom", v, undefined, true),
-    "react-dom/client": buildReactUrl("react-dom", v, "/client", true),
-    "react-dom/server": buildReactUrl("react-dom", v, "/server", true),
-    "react/jsx-runtime": buildReactUrl("react", v, "/jsx-runtime", true),
-    "react/jsx-dev-runtime": buildReactUrl("react", v, "/jsx-dev-runtime", true),
-  };
-}
-
-/**
- * Get complete React import map for esm.sh.
- */
-export function getReactImportMap(version?: string): Record<string, string> {
-  return getReactImportMapFromRewriter(version ?? DEFAULT_REACT_VERSION);
-}
-
-/**
  * Strip semver range prefixes (^, ~, >=, >, <=, <, =) from a version string.
  */
 export function stripSemverRange(version: string): string {
@@ -499,7 +451,7 @@ function rememberDependencyPinningSnapshot(
   return snapshot;
 }
 
-export function getDependencyPinningSnapshotSync(
+function getDependencyPinningSnapshotSync(
   source: DependencyPinningSourceInput,
   cacheKey: string,
 ): DependencyPinningSnapshot | undefined {

--- a/src/transforms/esm/react-cdn.ts
+++ b/src/transforms/esm/react-cdn.ts
@@ -1,0 +1,49 @@
+/**
+ * React CDN URL building.
+ *
+ * Everything that needs a React package served from esm.sh — import maps,
+ * bundlers, the SSR adapter, release-asset builds — asks here, so that one
+ * decision about how a React URL is spelled reaches all of them. The URLs
+ * themselves are built by the import rewriter's URL builder; this module is
+ * the React-shaped entry point onto it.
+ */
+import {
+  buildReactUrl,
+  DEFAULT_REACT_VERSION,
+  getReactImportMap as buildReactImportMap,
+} from "../import-rewriter/url-builder.ts";
+
+export { DEFAULT_REACT_VERSION };
+
+/** Build an esm.sh URL for one React package path. */
+export function esmShReact(
+  pkg: string,
+  version: string,
+  path = "",
+  external = false,
+): string {
+  return buildReactUrl(
+    pkg as "react" | "react-dom",
+    version,
+    path || undefined,
+    external,
+  );
+}
+
+/** Every React entry point a page can import, at one consistent version. */
+export function getReactUrls(version?: string): Record<string, string> {
+  const v = version ?? DEFAULT_REACT_VERSION;
+  return {
+    react: buildReactUrl("react", v),
+    "react-dom": buildReactUrl("react-dom", v, undefined, true),
+    "react-dom/client": buildReactUrl("react-dom", v, "/client", true),
+    "react-dom/server": buildReactUrl("react-dom", v, "/server", true),
+    "react/jsx-runtime": buildReactUrl("react", v, "/jsx-runtime", true),
+    "react/jsx-dev-runtime": buildReactUrl("react", v, "/jsx-dev-runtime", true),
+  };
+}
+
+/** The same entry points shaped as an import map. */
+export function getReactImportMap(version?: string): Record<string, string> {
+  return buildReactImportMap(version ?? DEFAULT_REACT_VERSION);
+}

--- a/src/transforms/esm/react-imports.ts
+++ b/src/transforms/esm/react-imports.ts
@@ -1,5 +1,5 @@
 import { replaceSpecifiers } from "./lexer.ts";
-import { DEFAULT_REACT_VERSION, getReactImportMap } from "./package-registry.ts";
+import { DEFAULT_REACT_VERSION, getReactImportMap } from "./react-cdn.ts";
 import { getLocalReactPaths } from "#veryfront/platform/compat/react-paths.ts";
 import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
 

--- a/src/transforms/import-rewriter/ssr-adapter.ts
+++ b/src/transforms/import-rewriter/ssr-adapter.ts
@@ -1,8 +1,5 @@
-import {
-  DEFAULT_REACT_VERSION,
-  type DependencyPinningSourceInput,
-  getReactImportMap,
-} from "#veryfront/transforms/esm/package-registry.ts";
+import { type DependencyPinningSourceInput } from "#veryfront/transforms/esm/package-registry.ts";
+import { DEFAULT_REACT_VERSION, getReactImportMap } from "#veryfront/transforms/esm/react-cdn.ts";
 import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
 import { getLocalReactPaths } from "#veryfront/platform/compat/react-paths.ts";
 import { hashString } from "#veryfront/cache/hash.ts";

--- a/src/transforms/pipeline/context.ts
+++ b/src/transforms/pipeline/context.ts
@@ -1,5 +1,5 @@
 import { computeShortContentHash } from "../esm/transform-utils.ts";
-import { DEFAULT_REACT_VERSION } from "../esm/package-registry.ts";
+import { DEFAULT_REACT_VERSION } from "../esm/react-cdn.ts";
 import type {
   TransformContext,
   TransformOptions,


### PR DESCRIPTION
## Summary

Stacked on #3189 (shares the four handler files). Two commits:

**1. Centralize the dependency-snapshot protocol behind one module** — the snapshot *identity* had a seam (`dependency-pinning-source.ts`); the HTTP *protocol* around it was re-implemented in four handlers with drift: three different constant names for the `x-veryfront-dependency-pins` literal, and a 409 body that was JSON in two handlers and text in two. New module `src/server/handlers/utils/dependency-snapshot-protocol.ts` owns validate (`^on:[A-Za-z0-9._-]+$`), strip-before-forward (header, or query-param twin for `import()` requests), echo+`Vary`, and **one** 409 shape: text `"Unknown dependency snapshot"`, `Cache-Control: no-store`. The four handlers become adapters (page-data −81, ssr −69, data −58, page-module −52). Two per-handler rules are now named, not duplicated: document requests **adopt** an unpinned request (the client learns the key); data/module requests **conflict**.

**The 409 unification fixes a live bug.** The client recognizers (`dependency-snapshot-recovery.ts`, hydration router template, both verified) match the *text* body — the JSON body page-data/data emitted **never matched**, so snapshot-conflict recovery was silently broken on exactly those endpoints. Rollout-compatible both directions: old HTML already recognizes the unified text; no recognizer was narrowed. Zero client-template lines touched.

**2. Split React CDN URL building out of the package registry** — `esmShReact` / `getReactUrls` / `getReactImportMap` (19 callers, unrelated concern) move to `src/transforms/esm/react-cdn.ts`; 14 call sites repointed, no re-export shim. Survey correction: `getDependencyPinningSnapshotSync` had four in-module callers (not zero) — made module-private instead of deleted; its one external test fixture now uses the public accessor.

## Future adoption (out of scope)

Five other handlers still emit the conflict string directly: `lib-modules.handler.ts:221`, `dev-file.handler.ts:140`, `action-handler.ts:230`, `endpoint-router.ts:320,386`.

## Review

Independent code-review pass: approve — all eight verification targets confirmed (dead JSON body, both rollout directions byte-compared, adopt/conflict assignment per handler, validation tightening unobservable against canonical `on:`+base36 keys, Vary appended not overwritten, boundary direction clean).

## Tested

- Protocol module: 25 steps; src/server + src/transforms + src/html: 342 passed (4699 steps); rsc/routing/modules: 64 passed (941 steps); post-split sweep: 468 passed (6316 steps) — 0 failed
- typecheck + 8 lint gates green individually; pre-push (fmt + full suite) passed