### PR TITLE
Rebuild up as a Deploy Execution adapter

### DIFF
--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -8,10 +8,21 @@ import { computeSourceDigest, writePushReceipt } from "../../shared/deployment-p
 import { setJsonMode } from "../../shared/json-output.ts";
 import { readProjectLink, writeProjectLink } from "../../shared/project-link.ts";
 import { deployCommand } from "./command.ts";
+import { createDeployProject, type DeployProject } from "../../shared/deployment/deploy-project.ts";
 import type { DeploymentRoutingConvergence } from "../../shared/deployment/control-plane.ts";
 import { FakeTime } from "#std/testing/time";
 import { stripAnsi } from "../../ui/ansi.ts";
 import { setVerboseMode } from "../../utils/index.ts";
+
+/**
+ * The real Deploy Execution module with test-bounded polling: these suites
+ * drive deploy end to end over a fetch stub, they never fake the module.
+ */
+function boundedDeployProject(): DeployProject {
+  return createDeployProject({
+    polling: { environmentPollIntervalMs: 1, environmentTimeoutMs: 1_000 },
+  });
+}
 
 const PROJECT_ID = "550e8400-e29b-41d4-a716-446655440000";
 const ENVIRONMENT_ID = "660e8400-e29b-41d4-a716-446655440000";
@@ -347,8 +358,7 @@ it("deploys production from the existing verified push without mutating source",
               dryRun: false,
               force: false,
               quiet: true,
-              environmentPollIntervalMs: 1,
-              environmentTimeoutMs: 1_000,
+              deployProject: boundedDeployProject(),
             }),
         );
       } finally {
@@ -416,8 +426,7 @@ it("defaults omitted deploy branch to main instead of promoting a feature push r
                       dryRun: false,
                       force: false,
                       quiet: true,
-                      environmentPollIntervalMs: 1,
-                      environmentTimeoutMs: 1_000,
+                      deployProject: boundedDeployProject(),
                     }),
                 ),
               Error,
@@ -446,8 +455,7 @@ it("defaults omitted deploy branch to main instead of promoting a feature push r
                     dryRun: false,
                     force: false,
                     quiet: true,
-                    environmentPollIntervalMs: 1,
-                    environmentTimeoutMs: 1_000,
+                    deployProject: boundedDeployProject(),
                   }),
               ),
             Error,
@@ -493,8 +501,7 @@ it("keeps an explicitly selected deploy branch strict", async () => {
               dryRun: false,
               force: false,
               quiet: true,
-              environmentPollIntervalMs: 1,
-              environmentTimeoutMs: 1_000,
+              deployProject: boundedDeployProject(),
             }),
         ),
       Error,
@@ -581,8 +588,7 @@ it("bootstraps exactly one quiet push when no verified push receipt exists", asy
           dryRun: false,
           force: false,
           quiet: true,
-          environmentPollIntervalMs: 1,
-          environmentTimeoutMs: 1_000,
+          deployProject: boundedDeployProject(),
         }),
     );
 
@@ -891,8 +897,7 @@ it("uses canonical production read-back in human and JSON modes", async () => {
         force: false,
         quiet,
         skipSourcePush: true,
-        environmentPollIntervalMs: 1,
-        environmentTimeoutMs: 1_000,
+        deployProject: boundedDeployProject(),
       });
 
     const outputModes = [
@@ -1259,8 +1264,7 @@ it("deploys production from a dirty worktree when the pushed digest matches the 
         force: false,
         quiet: true,
         skipSourcePush: true,
-        environmentPollIntervalMs: 1,
-        environmentTimeoutMs: 1_000,
+        deployProject: boundedDeployProject(),
       }));
 
     assertEquals(

--- a/cli/commands/deploy/command.test.ts
+++ b/cli/commands/deploy/command.test.ts
@@ -16,7 +16,7 @@ import type {
 import type { DeployResult } from "../../shared/deployment/result.ts";
 import { stripAnsi } from "../../ui/ansi.ts";
 import { DeployArgsSchema, parseDeployArgs } from "./index.ts";
-import { deployCommandWithProjectForTesting } from "./command.ts";
+import { deployCommand } from "./command.ts";
 import type { ParsedArgs } from "#cli/shared/types";
 
 async function captureConsole<T>(fn: () => Promise<T>): Promise<{ result: T; output: string[] }> {
@@ -86,20 +86,14 @@ describe("deploy command adapters", () => {
       force: false,
       quiet: false,
       skipSourcePush: true,
-      environmentPollIntervalMs: 1,
-      environmentTimeoutMs: 1,
+      deployProject: createFakeDeployment(),
     };
 
     const human = await withMockFetch(
       () => {
         throw new Error("adapter performed fetch orchestration");
       },
-      () =>
-        captureConsole(() =>
-          deployCommandWithProjectForTesting(options, {
-            createDeployProject: createFakeDeployment,
-          })
-        ),
+      () => captureConsole(() => deployCommand(options)),
     );
 
     let json: { result: DeployResult | null; output: string[] };
@@ -109,12 +103,7 @@ describe("deploy command adapters", () => {
         () => {
           throw new Error("adapter performed fetch orchestration");
         },
-        () =>
-          captureConsole(() =>
-            deployCommandWithProjectForTesting(options, {
-              createDeployProject: createFakeDeployment,
-            })
-          ),
+        () => captureConsole(() => deployCommand(options)),
       );
     } finally {
       setJsonMode(false);

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -52,12 +52,8 @@ export const DeployArgsSchema = lazySchema(getDeployArgsSchema);
 type ParsedDeployOptions = InferSchema<ReturnType<typeof getDeployArgsSchema>>;
 export type DeployOptions = Omit<ParsedDeployOptions, "skipSourcePush"> & {
   skipSourcePush?: boolean;
-  /** Internal composition control for parent commands that own the JSON result. */
-  suppressJsonOutput?: boolean;
-  assetManifestPollIntervalMs?: number;
-  assetManifestTimeoutMs?: number;
-  environmentPollIntervalMs?: number;
-  environmentTimeoutMs?: number;
+  /** Deploy Execution override for tests; production uses createDeployProject(). */
+  deployProject?: DeployProject;
 };
 
 /**
@@ -82,36 +78,12 @@ export type { DeployResult };
  * Create a release and deploy to an environment
  */
 export async function deployCommand(options: DeployOptions): Promise<DeployResult | null> {
-  return deployCommandWithProjectForTesting(options);
+  if (isJsonMode()) return deployCommandJson(options);
+  return deployCommandHuman(options);
 }
 
-export interface DeployCommandTestingSeams {
-  createDeployProject?: (options: DeployOptions) => DeployProject;
-}
-
-export async function deployCommandWithProjectForTesting(
-  options: DeployOptions,
-  seams: DeployCommandTestingSeams = {},
-): Promise<DeployResult | null> {
-  if (isJsonMode() && !options.suppressJsonOutput) {
-    return deployCommandJson(options, seams);
-  }
-
-  return deployCommandHuman(options, seams);
-}
-
-function createDeployRunner(options: DeployOptions, seams: DeployCommandTestingSeams) {
-  const fakeProject = seams.createDeployProject?.(options);
-  if (fakeProject) return fakeProject;
-
-  return createDeployProject({
-    polling: {
-      assetManifestPollIntervalMs: options.assetManifestPollIntervalMs,
-      assetManifestTimeoutMs: options.assetManifestTimeoutMs,
-      environmentPollIntervalMs: options.environmentPollIntervalMs,
-      environmentTimeoutMs: options.environmentTimeoutMs,
-    },
-  });
+function deployRunner(options: DeployOptions): DeployProject {
+  return options.deployProject ?? createDeployProject();
 }
 
 function toDeployRequest(options: DeployOptions) {
@@ -143,10 +115,7 @@ function commandStepName(stepName: DeployStepName): string {
   return stepName === "create-deployment" ? "deploy" : stepName;
 }
 
-async function deployCommandHuman(
-  options: DeployOptions,
-  seams: DeployCommandTestingSeams,
-): Promise<DeployResult | null> {
+async function deployCommandHuman(options: DeployOptions): Promise<DeployResult | null> {
   const { env, quiet = false } = options;
   const startedAt = Date.now();
   const verbose = isVerbose();
@@ -161,7 +130,7 @@ async function deployCommandHuman(
   let warning: string | null = null;
   let outcome: DeployProjectOutcome;
   try {
-    outcome = await createDeployRunner(options, seams).execute(toDeployRequest(options), {
+    outcome = await deployRunner(options).execute(toDeployRequest(options), {
       onEvent(event) {
         if (event.kind === "warning") {
           warning = event.message;
@@ -230,12 +199,9 @@ async function deployCommandHuman(
   return result;
 }
 
-async function deployCommandJson(
-  options: DeployOptions,
-  seams: DeployCommandTestingSeams,
-): Promise<DeployResult | null> {
+async function deployCommandJson(options: DeployOptions): Promise<DeployResult | null> {
   try {
-    const outcome = await createDeployRunner(options, seams).execute(toDeployRequest(options), {
+    const outcome = await deployRunner(options).execute(toDeployRequest(options), {
       onEvent(event) {
         if (event.kind === "warning") {
           streamJsonLine({

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -17,12 +17,12 @@ import { brand, createNoopSpinner, createSpinner, dim, formatDuration } from "#c
 import { createStreamErrorResult, isJsonMode, streamJsonLine } from "../../shared/json-output.ts";
 import {
   createDeployProject,
-  type DeployEvent,
   type DeployPlan,
   type DeployProject,
   type DeployProjectOutcome,
   type DeployStepName,
 } from "../../shared/deployment/deploy-project.ts";
+import { deployProgressText, initialDeployProgressText } from "../../shared/deployment/progress.ts";
 import type { DeployResult } from "../../shared/deployment/result.ts";
 
 /**
@@ -143,49 +143,6 @@ function commandStepName(stepName: DeployStepName): string {
   return stepName === "create-deployment" ? "deploy" : stepName;
 }
 
-function progressForEvent(
-  event: Extract<DeployEvent, { kind: "step" }>,
-  env: string,
-  verbose: boolean,
-): string | null {
-  if (event.phase !== "started") return null;
-  switch (event.step) {
-    case "resolve-config":
-      return verbose ? "Resolving configuration..." : "Linking project...";
-    case "push-source":
-      return verbose ? "Pushing source..." : "Uploading source...";
-    case "resolve-target":
-    case "verify-source":
-    case "create-release":
-    case "verify-release-source":
-    case "wait-release-assets":
-      return verbose ? progressDetailForBuildStep(event.step, env) : "Building release...";
-    case "create-deployment":
-      return `Deploying to ${env}...`;
-    case "verify-deployment":
-      return verbose ? `Verifying ${env} deployment...` : `Deploying to ${env}...`;
-    case "wait-environment-url":
-      return verbose ? `Waiting for ${env} URL...` : `Verifying ${env} URL...`;
-  }
-}
-
-function progressDetailForBuildStep(stepName: DeployStepName, env: string): string {
-  switch (stepName) {
-    case "resolve-target":
-      return `Looking up environment "${env}"...`;
-    case "verify-source":
-      return "Verifying pushed source...";
-    case "create-release":
-      return "Creating release...";
-    case "verify-release-source":
-      return "Verifying release source...";
-    case "wait-release-assets":
-      return "Waiting for release assets...";
-    default:
-      return "Building release...";
-  }
-}
-
 async function deployCommandHuman(
   options: DeployOptions,
   seams: DeployCommandTestingSeams,
@@ -193,7 +150,7 @@ async function deployCommandHuman(
   const { env, quiet = false } = options;
   const startedAt = Date.now();
   const verbose = isVerbose();
-  let progressText = verbose ? "Resolving configuration..." : "Linking project...";
+  let progressText = initialDeployProgressText(verbose);
   const spinner = quiet ? createNoopSpinner() : createSpinner(progressText);
   const updateProgress = (next: string | null): void => {
     if (!next) return;
@@ -210,7 +167,7 @@ async function deployCommandHuman(
           warning = event.message;
           return;
         }
-        updateProgress(progressForEvent(event, env, verbose));
+        updateProgress(deployProgressText(event, env, verbose));
       },
     });
   } catch (error) {

--- a/cli/commands/up/command.test.ts
+++ b/cli/commands/up/command.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   _resetEnvironmentConfig,
   createTestEnvironmentConfig,
@@ -12,6 +13,14 @@ import { normalizeProjectSlug } from "#cli/shared/slug";
 import { capitalizeSeparatedWords } from "veryfront/utils/case-utils";
 import { resetInteractiveMode, setNonInteractive } from "../../shared/interactive.ts";
 import { setJsonMode } from "../../shared/json-output.ts";
+import { stripAnsi } from "../../ui/ansi.ts";
+import type {
+  DeployPlan,
+  DeployProject,
+  DeployProjectOutcome,
+  DeployProjectRequest,
+} from "../../shared/deployment/deploy-project.ts";
+import type { DeployResult } from "../../shared/deployment/result.ts";
 
 function createArgs(flags: Record<string, unknown> = {}): ParsedArgs {
   return { _: ["up"], ...flags };
@@ -54,6 +63,96 @@ async function captureExit(run: () => Promise<void>): Promise<number> {
     // deno-lint-ignore no-explicit-any
     (Deno as any).exit = originalExit;
   }
+}
+
+async function captureLog<T>(run: () => Promise<T>): Promise<{ result: T; output: string[] }> {
+  const output: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => {
+    output.push(args.map(String).join(" "));
+  };
+  try {
+    return { result: await run(), output };
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+/** Deploy Execution recorded, never executed: what did `up` ask deploy to do? */
+function recordingDeployProject(
+  outcome: DeployProjectOutcome,
+): { deployProject: DeployProject; requests: DeployProjectRequest[] } {
+  const requests: DeployProjectRequest[] = [];
+  return {
+    requests,
+    deployProject: {
+      execute(request) {
+        requests.push(request);
+        return Promise.resolve(outcome);
+      },
+    },
+  };
+}
+
+/**
+ * A verified deployment whose URL shares no pattern with the preview hostname
+ * `up` used to rebuild locally, so tests can tell the two apart.
+ */
+const VERIFIED_RESULT: DeployResult = {
+  projectId: "project-verified",
+  projectSlug: "verified-slug",
+  release: { id: "release-1", name: "main", version: "2026.07.31-1" },
+  environment: "preview",
+  environmentId: "environment-1",
+  deploymentId: "deployment-1",
+  url: "https://verified.example.test/dashboard",
+  protected: false,
+  routingConvergence: null,
+  commitSha: "a".repeat(40),
+  sourceDigest: "sha256:verified",
+  controlPlane: "https://control.example.test/api",
+  branch: "main",
+};
+
+const VERIFIED_OUTCOME: DeployProjectOutcome = { kind: "deployed", result: VERIFIED_RESULT };
+
+function dryRunOutcome(overrides: Partial<DeployPlan> = {}): DeployProjectOutcome {
+  return {
+    kind: "dry-run",
+    plan: {
+      branch: "main",
+      projectId: "project-verified",
+      projectSlug: "verified-slug",
+      environment: "preview",
+      environmentId: "environment-1",
+      controlPlane: "https://control.example.test/api",
+      plannedActions: ["push-source", "create-release", "deploy"],
+      ...overrides,
+    },
+  };
+}
+
+function identityResponse(): Response {
+  return Response.json({ id: "user-1", email: "dev@example.com" });
+}
+
+async function createLinkedProjectDir(): Promise<string> {
+  const projectDir = await Deno.makeTempDir();
+  await Deno.writeTextFile(join(projectDir, "package.json"), "{}");
+  await Deno.writeTextFile(
+    join(projectDir, "veryfront.json"),
+    `${JSON.stringify({ projectSlug: "linked-up" }, null, 2)}\n`,
+  );
+  return projectDir;
+}
+
+function authenticatedEnv(homeDir: string) {
+  return createTestEnvironmentConfig({
+    apiBaseUrl: "https://auth.example.test",
+    apiToken: "session-token",
+    homeDir,
+    xdgConfigHome: homeDir,
+  });
 }
 
 describe("Up Command", () => {
@@ -111,20 +210,19 @@ describe("Up Command", () => {
 
   describe("upCommand", () => {
     it("exits nonzero after an unauthenticated JSON result", async () => {
-      const originalConsoleLog = console.log;
       const tempDir = await Deno.makeTempDir();
-      const output: string[] = [];
 
       try {
         setJsonMode(true);
-        console.log = (message?: unknown) => output.push(String(message));
         const env = createTestEnvironmentConfig({
           apiToken: undefined,
           homeDir: tempDir,
           xdgConfigHome: tempDir,
         });
 
-        const exitCode = await captureExit(() => upCommand({ projectDir: tempDir }, env));
+        const { result: exitCode, output } = await captureLog(() =>
+          captureExit(() => upCommand({ projectDir: tempDir }, env))
+        );
 
         assertEquals(exitCode, 1);
         assertEquals(output.length, 1);
@@ -139,35 +237,28 @@ describe("Up Command", () => {
           },
         });
       } finally {
-        console.log = originalConsoleLog;
         setJsonMode(false);
         await Deno.remove(tempDir, { recursive: true });
       }
     });
 
     it("exits nonzero after an empty-folder JSON result", async () => {
-      const originalFetch = globalThis.fetch;
-      const originalConsoleLog = console.log;
       const tempDir = await Deno.makeTempDir();
-      const output: string[] = [];
+      const { deployProject, requests } = recordingDeployProject(VERIFIED_OUTCOME);
 
       try {
         setJsonMode(true);
-        console.log = (message?: unknown) => output.push(String(message));
-        globalThis.fetch = (() =>
-          Promise.resolve(
-            Response.json({ id: "user-1", email: "dev@example.com" }),
-          )) as typeof fetch;
-        const env = createTestEnvironmentConfig({
-          apiBaseUrl: "https://auth.example.test",
-          apiToken: "session-token",
-          homeDir: tempDir,
-          xdgConfigHome: tempDir,
-        });
+        const env = authenticatedEnv(tempDir);
 
-        const exitCode = await captureExit(() => upCommand({ projectDir: tempDir }, env));
+        const { result: exitCode, output } = await captureLog(() =>
+          withMockFetch(
+            () => Promise.resolve(identityResponse()),
+            () => captureExit(() => upCommand({ projectDir: tempDir }, env, { deployProject })),
+          )
+        );
 
         assertEquals(exitCode, 1);
+        assertEquals(requests, []);
         assertEquals(output.length, 1);
         assertEquals(JSON.parse(output[0]!), {
           type: "result",
@@ -180,211 +271,195 @@ describe("Up Command", () => {
           },
         });
       } finally {
-        globalThis.fetch = originalFetch;
-        console.log = originalConsoleLog;
         setJsonMode(false);
         await Deno.remove(tempDir, { recursive: true });
       }
     });
 
-    it("uses VERYFRONT_API_BASE_URL when creating a project", async () => {
-      const originalFetch = globalThis.fetch;
+    it("asks Deploy Execution for one verified preview of main", async () => {
+      const projectDir = await createLinkedProjectDir();
+      const { deployProject, requests } = recordingDeployProject(VERIFIED_OUTCOME);
+
+      try {
+        setNonInteractive(true);
+        const { output } = await captureLog(() =>
+          withMockFetch(
+            () => Promise.resolve(identityResponse()),
+            () => upCommand({ projectDir }, authenticatedEnv(projectDir), { deployProject }),
+          )
+        );
+
+        assertEquals(requests, [{
+          projectDir,
+          branch: "main",
+          environment: "preview",
+          mode: "apply",
+          source: { kind: "ensure-pushed" },
+        }]);
+
+        const lines = output.map(stripAnsi);
+        assertEquals(lines.includes("  Preview: https://verified.example.test/dashboard"), true);
+        assertEquals(
+          lines.includes("  Studio:  https://veryfront.com/projects/verified-slug?branch=main"),
+          true,
+        );
+        assertEquals(lines.includes("  Deploy:  veryfront deploy"), true);
+        assertEquals(lines.includes("  ✓ verified-slug is ready"), true);
+        // The printed preview URL is the deployment that was verified, never a
+        // hostname rebuilt from the local slug.
+        assertEquals(lines.some((line) => line.includes("preview.veryfront.com")), false);
+      } finally {
+        resetInteractiveMode();
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("reports the verified deployment URL as the single JSON result", async () => {
+      const projectDir = await createLinkedProjectDir();
+      const { deployProject, requests } = recordingDeployProject(VERIFIED_OUTCOME);
+
+      try {
+        setJsonMode(true);
+        setNonInteractive(true);
+        const { output } = await captureLog(() =>
+          withMockFetch(
+            () => Promise.resolve(identityResponse()),
+            () => upCommand({ projectDir }, authenticatedEnv(projectDir), { deployProject }),
+          )
+        );
+
+        assertEquals(requests.length, 1);
+        assertEquals(output.length, 1);
+        assertEquals(JSON.parse(output[0]!), {
+          type: "result",
+          success: true,
+          data: {
+            projectSlug: "verified-slug",
+            dryRun: false,
+            studioUrl: "https://veryfront.com/projects/verified-slug?branch=main",
+            previewUrl: VERIFIED_RESULT.url,
+            nextCommand: "veryfront deploy",
+          },
+        });
+      } finally {
+        setJsonMode(false);
+        resetInteractiveMode();
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("owns one JSON result for a dry run planned by Deploy Execution", async () => {
+      const projectDir = await createLinkedProjectDir();
+      const { deployProject, requests } = recordingDeployProject(dryRunOutcome());
+
+      try {
+        setJsonMode(true);
+        setNonInteractive(true);
+        const { output } = await captureLog(() =>
+          withMockFetch(
+            () => Promise.resolve(identityResponse()),
+            () =>
+              upCommand({ projectDir, dryRun: true }, authenticatedEnv(projectDir), {
+                deployProject,
+              }),
+          )
+        );
+
+        assertEquals(requests[0]?.mode, "dry-run");
+        assertEquals(output.length, 1);
+        assertEquals(JSON.parse(output[0]!), {
+          type: "result",
+          success: true,
+          data: {
+            projectSlug: "linked-up",
+            dryRun: true,
+            plannedActions: ["push-source", "deploy-preview"],
+          },
+        });
+      } finally {
+        setJsonMode(false);
+        resetInteractiveMode();
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("reports a planned project creation from the dry-run plan", async () => {
+      const projectDir = await Deno.makeTempDir();
+      const expectedSlug = normalizeProjectSlug(projectDir.split(/[/\\]/).pop() ?? "");
+      const { deployProject } = recordingDeployProject(
+        dryRunOutcome({
+          projectId: null,
+          environmentId: null,
+          plannedActions: ["create-project", "push-source", "create-release", "deploy"],
+        }),
+      );
+
+      try {
+        await Deno.writeTextFile(join(projectDir, "package.json"), "{}");
+        setJsonMode(true);
+        setNonInteractive(true);
+        const { output } = await captureLog(() =>
+          withMockFetch(
+            () => Promise.resolve(identityResponse()),
+            () =>
+              upCommand({ projectDir, dryRun: true }, authenticatedEnv(projectDir), {
+                deployProject,
+              }),
+          )
+        );
+
+        assertEquals(output.length, 1);
+        assertEquals(JSON.parse(output[0]!), {
+          type: "result",
+          success: true,
+          data: {
+            projectSlug: expectedSlug,
+            dryRun: true,
+            plannedActions: ["create-project", "push-source", "deploy-preview"],
+          },
+        });
+      } finally {
+        setJsonMode(false);
+        resetInteractiveMode();
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("creates the project against VERYFRONT_API_BASE_URL before deploying", async () => {
       const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
       const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
       const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
-      const tempDir = await Deno.makeTempDir();
-      const expectedSlug = normalizeProjectSlug(tempDir.split(/[/\\]/).pop() ?? "");
+      const projectDir = await Deno.makeTempDir();
+      const expectedSlug = normalizeProjectSlug(projectDir.split(/[/\\]/).pop() ?? "");
       const requestedUrls: string[] = [];
       let projectCreateBody: unknown;
-      const uploadedFiles = new Map<string, string>();
-      let deploymentCreated = false;
-      const output: string[] = [];
-      const originalConsoleLog = console.log;
+      const { deployProject, requests } = recordingDeployProject(VERIFIED_OUTCOME);
 
       try {
-        console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
-        await Deno.writeTextFile(join(tempDir, "package.json"), "{}");
+        await Deno.writeTextFile(join(projectDir, "package.json"), "{}");
         Deno.env.set("VERYFRONT_API_TOKEN", "env-token");
         Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.from-env.test");
         Deno.env.delete("VERYFRONT_API_URL");
         _resetEnvironmentConfig();
-
-        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-          const request = input instanceof Request ? input : new Request(input, init);
-          const url = request.url;
-          const method = request.method;
-          requestedUrls.push(url);
-
-          if (url.endsWith("/me")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ id: "user-1", email: "dev@example.com" }), {
-                status: 200,
-                headers: { "content-type": "application/json" },
-              }),
-            );
-          }
-
-          if (url.endsWith("/projects") && method === "POST") {
-            projectCreateBody = await request.clone().json();
-            return Promise.resolve(
-              new Response(JSON.stringify({ id: "project-1", slug: expectedSlug }), {
-                status: 200,
-                headers: { "content-type": "application/json" },
-              }),
-            );
-          }
-
-          if (
-            (url.endsWith(`/projects/${expectedSlug}`) || url.endsWith("/projects/project-1")) &&
-            method === "GET"
-          ) {
-            return Promise.resolve(
-              Response.json({ id: "project-1", slug: expectedSlug }),
-            );
-          }
-
-          if (
-            (url.includes(`/projects/${expectedSlug}/files/`) ||
-              url.includes("/projects/project-1/files/")) &&
-            method === "PUT"
-          ) {
-            const path = decodeURIComponent(new URL(url).pathname.split("/files/")[1] ?? "");
-            const body = await request.clone().json() as { content: string };
-            uploadedFiles.set(path, body.content);
-            return Promise.resolve(Response.json({}));
-          }
-
-          if (url.endsWith("/branches") && method === "POST") {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({ id: "branch-1", name: "main", projectId: "project-1" }),
-                {
-                  status: 200,
-                  headers: { "content-type": "application/json" },
-                },
-              ),
-            );
-          }
-
-          if (url.includes("/environments")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  data: [{
-                    id: "env-1",
-                    name: "preview",
-                    protected: false,
-                    project_id: "project-1",
-                    deployment: deploymentCreated
-                      ? {
-                        id: "deployment-1",
-                        release: { id: "release-1", name: "Preview" },
-                      }
-                      : null,
-                  }],
-                  page_info: {},
-                }),
-                {
-                  status: 200,
-                  headers: { "content-type": "application/json" },
-                },
-              ),
-            );
-          }
-
-          if (url.endsWith("/releases") && method === "POST") {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  id: "release-1",
-                  name: "Preview",
-                  version: "v1",
-                  export_status: "complete",
-                  build_status: "complete",
-                  deploy_status: "pending",
-                }),
-                {
-                  status: 200,
-                  headers: { "content-type": "application/json" },
-                },
-              ),
-            );
-          }
-
-          if (url.endsWith("/deployments") && method === "POST") {
-            deploymentCreated = true;
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({ id: "deployment-1", release: "release-1", environment: "env-1" }),
-                {
-                  status: 200,
-                  headers: { "content-type": "application/json" },
-                },
-              ),
-            );
-          }
-
-          if (url.endsWith("/releases/release-1") && method === "GET") {
-            return Promise.resolve(
-              Response.json({
-                id: "release-1",
-                name: "Preview",
-                version: "v1",
-                project_id: "project-1",
-                export_status: "complete",
-                build_status: "complete",
-                deploy_status: "pending",
-              }),
-            );
-          }
-
-          if (new URL(url).pathname.endsWith("/releases/release-1/versions")) {
-            return Promise.resolve(
-              Response.json({
-                data: [...uploadedFiles].map(([path, content]) => ({
-                  path,
-                  data: JSON.stringify({ body: content, path }),
-                })),
-                page_info: {},
-              }),
-            );
-          }
-
-          if (url.endsWith("/releases/release-1/asset-manifest")) {
-            return Promise.resolve(
-              Response.json({
-                state: "ready",
-                manifest: {
-                  modules: {},
-                  css: [],
-                  routes: {},
-                  dependencies: {},
-                  fallback: { mode: "jit", gaps: [] },
-                },
-              }),
-            );
-          }
-
-          if (url.endsWith("/deployments/deployment-1")) {
-            return Promise.resolve(
-              Response.json({
-                id: "deployment-1",
-                release_id: "release-1",
-                environment_id: "env-1",
-              }),
-            );
-          }
-
-          return Promise.resolve(
-            new Response(JSON.stringify({ data: [], page_info: {} }), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        }) as typeof fetch;
-
         setNonInteractive(true);
-        await upCommand({ projectDir: tempDir, force: false, dryRun: false });
+
+        await captureLog(() =>
+          withMockFetch(async (input: string | URL | Request, init?: RequestInit) => {
+            const request = input instanceof Request ? input : new Request(input, init);
+            const url = new URL(request.url);
+            requestedUrls.push(request.url);
+
+            if (url.pathname === "/me") return identityResponse();
+            if (request.method === "POST" && url.pathname === "/projects") {
+              projectCreateBody = await request.clone().json();
+              return Response.json({ id: "project-1", slug: expectedSlug });
+            }
+            throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+          }, () =>
+            upCommand({ projectDir, force: false, dryRun: false }, undefined, {
+              deployProject,
+            }))
+        );
 
         assertEquals(
           requestedUrls.some((url) => url.startsWith("https://api.from-env.test/projects")),
@@ -394,11 +469,14 @@ describe("Up Command", () => {
           requestedUrls.some((url) => url.startsWith("https://api.veryfront.com/projects")),
           false,
         );
-        const expectedName = capitalizeSeparatedWords(expectedSlug, "-", " ");
-        assertEquals(projectCreateBody, { slug: expectedSlug, name: expectedName });
+        assertEquals(projectCreateBody, {
+          slug: expectedSlug,
+          name: capitalizeSeparatedWords(expectedSlug, "-", " "),
+        });
+        assertEquals(requests.length, 1);
 
         assertEquals(
-          JSON.parse(await Deno.readTextFile(join(tempDir, ".veryfront", "project.json"))),
+          JSON.parse(await Deno.readTextFile(join(projectDir, ".veryfront", "project.json"))),
           {
             version: 1,
             controlPlane: "https://api.from-env.test",
@@ -406,115 +484,34 @@ describe("Up Command", () => {
             projectSlug: expectedSlug,
           },
         );
-        let veryfrontJsonExists = true;
-        try {
-          await Deno.stat(join(tempDir, "veryfront.json"));
-        } catch {
-          veryfrontJsonExists = false;
-        }
-        assertEquals(veryfrontJsonExists, false);
-
-        const humanOutput = output.join("\n");
-        assertEquals(humanOutput.includes("Studio:"), true);
-        assertEquals(humanOutput.includes("Preview:"), true);
-        assertEquals(humanOutput.includes("Deploy:"), true);
+        assertEquals(await exists(join(projectDir, "veryfront.json")), false);
       } finally {
-        console.log = originalConsoleLog;
-        globalThis.fetch = originalFetch;
         restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
         restoreEnv("VERYFRONT_API_BASE_URL", originalApiBaseUrl);
         restoreEnv("VERYFRONT_API_URL", originalApiUrl);
         resetInteractiveMode();
         _resetEnvironmentConfig();
-        await Deno.remove(tempDir, { recursive: true });
+        await Deno.remove(projectDir, { recursive: true });
       }
     });
 
-    it("owns one JSON result while nested dry-run commands stay quiet", async () => {
-      const originalFetch = globalThis.fetch;
-      const originalConsoleLog = console.log;
+    it("deploys a pulled local project link without creating a project", async () => {
       const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
       const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
       const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
       const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
-      const tempDir = await Deno.makeTempDir();
-      const output: string[] = [];
+      const projectDir = await Deno.makeTempDir();
+      const projectPosts: string[] = [];
+      const { deployProject, requests } = recordingDeployProject({
+        kind: "deployed",
+        result: { ...VERIFIED_RESULT, projectSlug: "pulled-up" },
+      });
 
       try {
-        await Deno.writeTextFile(join(tempDir, "package.json"), "{}");
+        await Deno.mkdir(join(projectDir, ".veryfront"), { recursive: true });
+        await Deno.writeTextFile(join(projectDir, "package.json"), "{}");
         await Deno.writeTextFile(
-          join(tempDir, "veryfront.json"),
-          `${JSON.stringify({ projectSlug: "json-up" }, null, 2)}\n`,
-        );
-        Deno.env.set("VERYFRONT_API_TOKEN", "env-token");
-        Deno.env.set("VERYFRONT_API_URL", "https://api.from-env.test");
-        Deno.env.delete("VERYFRONT_API_BASE_URL");
-        Deno.env.delete("VERYFRONT_PROJECT_SLUG");
-        _resetEnvironmentConfig();
-        setJsonMode(true);
-        console.log = (message?: unknown) => output.push(String(message));
-
-        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-          const request = input instanceof Request ? input : new Request(input, init);
-          const url = new URL(request.url);
-
-          if (request.method === "GET" && url.pathname === "/me") {
-            return Response.json({ id: "user-1", email: "dev@example.com" });
-          }
-          if (request.method === "GET" && url.pathname === "/projects/json-up") {
-            return Response.json({ id: "project-1", slug: "json-up" });
-          }
-          if (request.method === "GET" && url.pathname === "/projects/json-up/files") {
-            return Response.json({ data: [], page_info: {} });
-          }
-
-          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
-        }) as typeof fetch;
-
-        await upCommand({ projectDir: tempDir, dryRun: true });
-
-        assertEquals(output.length, 1);
-        assertEquals(JSON.parse(output[0]!), {
-          type: "result",
-          success: true,
-          data: {
-            projectSlug: "json-up",
-            dryRun: true,
-            plannedActions: ["push-source", "deploy-preview"],
-          },
-        });
-      } finally {
-        console.log = originalConsoleLog;
-        setJsonMode(false);
-        globalThis.fetch = originalFetch;
-        restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
-        restoreEnv("VERYFRONT_API_BASE_URL", originalApiBaseUrl);
-        restoreEnv("VERYFRONT_API_URL", originalApiUrl);
-        restoreEnv("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
-        _resetEnvironmentConfig();
-        await Deno.remove(tempDir, { recursive: true });
-      }
-    });
-
-    it("uses a pulled local project link without creating veryfront.json", async () => {
-      const originalFetch = globalThis.fetch;
-      const originalConsoleLog = console.log;
-      const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
-      const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
-      const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
-      const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
-      const tempDir = await Deno.makeTempDir();
-      const output: string[] = [];
-      const requested: Array<{ method: string; pathname: string }> = [];
-      const uploadedFiles = new Map<string, string>();
-      let projectPostCount = 0;
-      let deploymentCreated = false;
-
-      try {
-        await Deno.mkdir(join(tempDir, ".veryfront"), { recursive: true });
-        await Deno.writeTextFile(join(tempDir, "package.json"), "{}");
-        await Deno.writeTextFile(
-          join(tempDir, ".veryfront", "project.json"),
+          join(projectDir, ".veryfront", "project.json"),
           `${
             JSON.stringify(
               {
@@ -533,190 +530,79 @@ describe("Up Command", () => {
         Deno.env.delete("VERYFRONT_API_BASE_URL");
         Deno.env.delete("VERYFRONT_PROJECT_SLUG");
         _resetEnvironmentConfig();
-        console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
-
-        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-          const request = input instanceof Request ? input : new Request(input, init);
-          const url = new URL(request.url);
-          requested.push({ method: request.method, pathname: url.pathname });
-
-          if (request.method === "GET" && url.pathname === "/me") {
-            return Response.json({ id: "user-1", email: "dev@example.com" });
-          }
-
-          if (request.method === "POST" && url.pathname === "/projects") {
-            projectPostCount++;
-            return Response.json({ id: "unexpected-project", slug: "unexpected" });
-          }
-
-          if (request.method === "GET" && url.pathname === "/projects/project-linked") {
-            return Response.json({ id: "project-linked", slug: "pulled-up" });
-          }
-
-          if (request.method === "GET" && url.pathname === "/projects/project-linked/files") {
-            return Response.json({ data: [], page_info: {} });
-          }
-
-          if (
-            request.method === "PUT" &&
-            url.pathname.startsWith("/projects/project-linked/files/")
-          ) {
-            const path = decodeURIComponent(url.pathname.split("/files/")[1] ?? "");
-            const body = await request.clone().json() as { content: string };
-            uploadedFiles.set(path, body.content);
-            return Response.json({});
-          }
-
-          if (request.method === "POST" && url.pathname === "/projects/project-linked/branches") {
-            return Response.json({ id: "branch-1", name: "main", projectId: "project-linked" });
-          }
-
-          if (
-            request.method === "GET" && url.pathname === "/projects/project-linked/environments"
-          ) {
-            return Response.json({
-              data: [{
-                id: "env-1",
-                name: "preview",
-                protected: false,
-                project_id: "project-linked",
-                deployment: deploymentCreated
-                  ? { id: "deployment-1", release: { id: "release-1", name: "Preview" } }
-                  : null,
-              }],
-              page_info: {},
-            });
-          }
-
-          if (request.method === "POST" && url.pathname === "/projects/project-linked/releases") {
-            return Response.json({
-              id: "release-1",
-              name: "Preview",
-              version: "v1",
-              export_status: "complete",
-              build_status: "complete",
-              deploy_status: "pending",
-            });
-          }
-
-          if (
-            request.method === "POST" && url.pathname === "/projects/project-linked/deployments"
-          ) {
-            deploymentCreated = true;
-            return Response.json({
-              id: "deployment-1",
-              release: "release-1",
-              environment: "env-1",
-            });
-          }
-
-          if (
-            request.method === "GET" &&
-            [
-              "/projects/project-linked/releases/release-1",
-              "/projects/pulled-up/releases/release-1",
-            ]
-              .includes(url.pathname)
-          ) {
-            return Response.json({
-              id: "release-1",
-              name: "Preview",
-              version: "v1",
-              project_id: "project-linked",
-              export_status: "complete",
-              build_status: "complete",
-              deploy_status: "pending",
-            });
-          }
-
-          if (
-            request.method === "GET" &&
-            [
-              "/projects/project-linked/releases/release-1/versions",
-              "/projects/pulled-up/releases/release-1/versions",
-            ].includes(url.pathname)
-          ) {
-            return Response.json({
-              data: [...uploadedFiles].map(([path, content]) => ({
-                path,
-                data: JSON.stringify({ body: content, path }),
-              })),
-              page_info: {},
-            });
-          }
-
-          if (
-            request.method === "GET" &&
-            [
-              "/projects/project-linked/releases/release-1/asset-manifest",
-              "/projects/pulled-up/releases/release-1/asset-manifest",
-            ].includes(url.pathname)
-          ) {
-            return Response.json({
-              state: "ready",
-              manifest: {
-                modules: {},
-                css: [],
-                routes: {},
-                dependencies: {},
-                fallback: { mode: "jit", gaps: [] },
-              },
-            });
-          }
-
-          if (
-            request.method === "GET" &&
-            [
-              "/projects/project-linked/deployments/deployment-1",
-              "/projects/pulled-up/deployments/deployment-1",
-            ].includes(url.pathname)
-          ) {
-            return Response.json({
-              id: "deployment-1",
-              release_id: "release-1",
-              environment_id: "env-1",
-            });
-          }
-
-          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
-        }) as typeof fetch;
-
         setNonInteractive(true);
-        await upCommand({ projectDir: tempDir, force: false, dryRun: false });
 
-        assertEquals(projectPostCount, 0);
-        assertEquals(
-          requested.some((request) =>
-            request.method === "GET" && request.pathname === "/projects/project-linked/files"
-          ),
-          true,
-        );
-        assertEquals(
-          requested.some((request) =>
-            request.method === "POST" && request.pathname === "/projects/project-linked/deployments"
-          ),
-          true,
+        const { output } = await captureLog(() =>
+          withMockFetch((input: string | URL | Request, init?: RequestInit) => {
+            const request = input instanceof Request ? input : new Request(input, init);
+            const url = new URL(request.url);
+            if (request.method === "POST" && url.pathname === "/projects") {
+              projectPosts.push(request.url);
+              return Promise.resolve(Response.json({ id: "unexpected", slug: "unexpected" }));
+            }
+            if (url.pathname === "/me") return Promise.resolve(identityResponse());
+            throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+          }, () =>
+            upCommand({ projectDir, force: false, dryRun: false }, undefined, {
+              deployProject,
+            }))
         );
 
-        let veryfrontJsonExists = true;
-        try {
-          await Deno.stat(join(tempDir, "veryfront.json"));
-        } catch {
-          veryfrontJsonExists = false;
-        }
-        assertEquals(veryfrontJsonExists, false);
-        assertEquals(output.join("\n").includes("pulled-up"), true);
+        assertEquals(projectPosts, []);
+        assertEquals(requests.length, 1);
+        assertEquals(requests[0]?.source, { kind: "ensure-pushed" });
+        assertEquals(await exists(join(projectDir, "veryfront.json")), false);
+        assertEquals(output.map(stripAnsi).includes("  ✓ pulled-up is ready"), true);
       } finally {
-        console.log = originalConsoleLog;
-        globalThis.fetch = originalFetch;
         restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
         restoreEnv("VERYFRONT_API_BASE_URL", originalApiBaseUrl);
         restoreEnv("VERYFRONT_API_URL", originalApiUrl);
         restoreEnv("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
         resetInteractiveMode();
         _resetEnvironmentConfig();
-        await Deno.remove(tempDir, { recursive: true });
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("reports a failed deployment as a preview deployment failure", async () => {
+      const projectDir = await createLinkedProjectDir();
+      const deployProject: DeployProject = {
+        execute() {
+          return Promise.reject(new Error("environment URL did not become ready"));
+        },
+      };
+
+      try {
+        setNonInteractive(true);
+        let message = "";
+        await captureLog(async () => {
+          try {
+            await withMockFetch(
+              () => Promise.resolve(identityResponse()),
+              () => upCommand({ projectDir }, authenticatedEnv(projectDir), { deployProject }),
+            );
+          } catch (error) {
+            message = error instanceof Error ? error.message : String(error);
+          }
+        });
+
+        assertEquals(
+          message,
+          "Preview deployment failed: environment URL did not become ready",
+        );
+      } finally {
+        resetInteractiveMode();
+        await Deno.remove(projectDir, { recursive: true });
       }
     });
   });
 });
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/cli/commands/up/command.test.ts
+++ b/cli/commands/up/command.test.ts
@@ -136,6 +136,24 @@ function identityResponse(): Response {
   return Response.json({ id: "user-1", email: "dev@example.com" });
 }
 
+/**
+ * Fetch stub for the cases whose only legitimate call is the auth check.
+ *
+ * Everything else rejects: with Deploy Execution injected, up should reach the
+ * network for nothing but `GET /me`, and a stub that answers anything would
+ * hide the day up starts calling the control plane again.
+ */
+function authCheckOnlyFetch(): typeof fetch {
+  return ((input: string | URL | Request, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const url = new URL(request.url);
+    if (request.method === "GET" && url.pathname === "/me") {
+      return Promise.resolve(identityResponse());
+    }
+    throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+  }) as typeof fetch;
+}
+
 async function createLinkedProjectDir(): Promise<string> {
   const projectDir = await Deno.makeTempDir();
   await Deno.writeTextFile(join(projectDir, "package.json"), "{}");
@@ -252,7 +270,7 @@ describe("Up Command", () => {
 
         const { result: exitCode, output } = await captureLog(() =>
           withMockFetch(
-            () => Promise.resolve(identityResponse()),
+            authCheckOnlyFetch(),
             () => captureExit(() => upCommand({ projectDir: tempDir }, env, { deployProject })),
           )
         );
@@ -284,7 +302,7 @@ describe("Up Command", () => {
         setNonInteractive(true);
         const { output } = await captureLog(() =>
           withMockFetch(
-            () => Promise.resolve(identityResponse()),
+            authCheckOnlyFetch(),
             () => upCommand({ projectDir }, authenticatedEnv(projectDir), { deployProject }),
           )
         );
@@ -323,7 +341,7 @@ describe("Up Command", () => {
         setNonInteractive(true);
         const { output } = await captureLog(() =>
           withMockFetch(
-            () => Promise.resolve(identityResponse()),
+            authCheckOnlyFetch(),
             () => upCommand({ projectDir }, authenticatedEnv(projectDir), { deployProject }),
           )
         );
@@ -357,7 +375,7 @@ describe("Up Command", () => {
         setNonInteractive(true);
         const { output } = await captureLog(() =>
           withMockFetch(
-            () => Promise.resolve(identityResponse()),
+            authCheckOnlyFetch(),
             () =>
               upCommand({ projectDir, dryRun: true }, authenticatedEnv(projectDir), {
                 deployProject,
@@ -400,7 +418,7 @@ describe("Up Command", () => {
         setNonInteractive(true);
         const { output } = await captureLog(() =>
           withMockFetch(
-            () => Promise.resolve(identityResponse()),
+            authCheckOnlyFetch(),
             () =>
               upCommand({ projectDir, dryRun: true }, authenticatedEnv(projectDir), {
                 deployProject,
@@ -578,7 +596,7 @@ describe("Up Command", () => {
         await captureLog(async () => {
           try {
             await withMockFetch(
-              () => Promise.resolve(identityResponse()),
+              authCheckOnlyFetch(),
               () => upCommand({ projectDir }, authenticatedEnv(projectDir), { deployProject }),
             );
           } catch (error) {

--- a/cli/commands/up/command.ts
+++ b/cli/commands/up/command.ts
@@ -1,6 +1,6 @@
 import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
-import { cliLogger, exitProcess } from "#cli/utils";
+import { cliLogger, exitProcess, isVerbose } from "#cli/utils";
 import { cwd } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import { brand, createNoopSpinner, dim } from "#cli/ui";
@@ -22,9 +22,14 @@ import {
   resolveOrCreateProject,
 } from "#cli/shared/project-resolution";
 import { getProjectTarget } from "../../shared/deployment-provenance.ts";
-import { pushCommand } from "../push/index.ts";
-import { deployCommand } from "../deploy/index.ts";
-import { buildPushUrls } from "../push/command.ts";
+import {
+  createDeployProject,
+  type DeployPlan,
+  type DeployProject,
+  type DeployProjectOutcome,
+} from "../../shared/deployment/deploy-project.ts";
+import { deployProgressText, initialDeployProgressText } from "../../shared/deployment/progress.ts";
+import { buildStudioUrl } from "../studio/command.ts";
 import { isInteractive } from "../../shared/interactive.ts";
 import { createStreamErrorResult, isJsonMode, streamJsonLine } from "../../shared/json-output.ts";
 import { AUTHENTICATION_REQUIRED, PROJECT_SOURCE_EMPTY } from "veryfront/errors";
@@ -93,9 +98,29 @@ async function analyzeDirectory(
   };
 }
 
+export interface UpDependencies {
+  /** Deploy Execution override for tests; production uses createDeployProject(). */
+  deployProject?: DeployProject;
+}
+
+/**
+ * Actions `up` reports for a dry run, derived from the Deploy Execution plan.
+ *
+ * Release creation and deployment are one user-visible step for `up`, which
+ * only ever targets the preview environment.
+ */
+function plannedUpActions(plan: DeployPlan): string[] {
+  return [
+    ...(plan.plannedActions.includes("create-project") ? ["create-project"] : []),
+    ...(plan.plannedActions.includes("push-source") ? ["push-source"] : []),
+    "deploy-preview",
+  ];
+}
+
 export async function upCommand(
   options: Partial<UpOptions> = {},
   env: EnvironmentConfig = getEnvironmentConfig(),
+  dependencies: UpDependencies = {},
 ): Promise<void> {
   const { projectDir = cwd(), force = false, dryRun = false } = options;
   const jsonOutput = isJsonMode();
@@ -215,20 +240,37 @@ export async function upCommand(
 
   if (!jsonOutput) cliLogger.info("");
 
+  // Deploy Execution owns the rest: the bootstrap push, the release, the
+  // deployment, and the readiness probe behind the URL printed below.
+  const verbose = isVerbose();
+  let progressText = initialDeployProgressText(verbose);
+  const deploySpinner = jsonOutput ? createNoopSpinner() : createSpinner(progressText);
+  let outcome: DeployProjectOutcome;
+
   try {
-    await pushCommand({
+    outcome = await (dependencies.deployProject ?? createDeployProject()).execute({
       projectDir,
       branch: "main",
-      force: true,
-      dryRun,
-      quiet: true,
+      environment: "preview",
+      mode: dryRun ? "dry-run" : "apply",
+      source: { kind: "ensure-pushed" },
+    }, {
+      onEvent(event) {
+        if (event.kind !== "step") return;
+        const next = deployProgressText(event, "preview", verbose);
+        if (!next || next === progressText) return;
+        progressText = next;
+        deploySpinner.update(next);
+      },
     });
   } catch (error) {
+    deploySpinner.stop();
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Push failed: ${message}`, { cause: error });
+    throw new Error(`Preview deployment failed: ${message}`, { cause: error });
   }
+  deploySpinner.stop();
 
-  if (dryRun) {
+  if (outcome.kind === "dry-run") {
     if (jsonOutput) {
       streamJsonLine({
         type: "result",
@@ -236,11 +278,7 @@ export async function upCommand(
         data: {
           projectSlug,
           dryRun: true,
-          plannedActions: [
-            ...(context.type === "has-project" ? [] : ["create-project"]),
-            "push-source",
-            "deploy-preview",
-          ],
+          plannedActions: plannedUpActions(outcome.plan),
         },
       });
     } else {
@@ -249,42 +287,28 @@ export async function upCommand(
     return;
   }
 
-  try {
-    await deployCommand({
-      projectDir,
-      branch: "main",
-      env: "preview",
-      force: true,
-      dryRun,
-      quiet: true,
-      skipSourcePush: true,
-      suppressJsonOutput: true,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Preview deployment failed: ${message}`, { cause: error });
-  }
+  const result = outcome.result;
+  const studioUrl = buildStudioUrl(result.projectSlug, { branch: result.branch });
 
-  const urls = buildPushUrls(projectSlug, "main");
   if (jsonOutput) {
     streamJsonLine({
       type: "result",
       success: true,
       data: {
-        projectSlug,
+        projectSlug: result.projectSlug,
         dryRun: false,
-        studioUrl: urls.studio,
-        previewUrl: urls.preview,
+        studioUrl,
+        previewUrl: result.url,
         nextCommand: "veryfront deploy",
       },
     });
     return;
   }
 
-  logSuccess(`${projectSlug} is ready`);
+  logSuccess(`${result.projectSlug} is ready`);
   console.log();
-  console.log(`  Studio:  ${brand(urls.studio)}`);
-  console.log(`  Preview: ${brand(urls.preview)}`);
+  console.log(`  Studio:  ${brand(studioUrl)}`);
+  console.log(`  Preview: ${brand(result.url)}`);
   console.log();
   console.log(`  Deploy:  ${brand("veryfront deploy")}`);
   console.log();

--- a/cli/commands/up/up.integration.test.ts
+++ b/cli/commands/up/up.integration.test.ts
@@ -11,6 +11,24 @@ import {
   remove,
   writeTextFile,
 } from "#veryfront/compat/fs.ts";
+import { upCommand } from "./index.ts";
+import { createDeployProject } from "../../shared/deployment/deploy-project.ts";
+import type { DeployEnvironment } from "../../shared/deployment/control-plane.ts";
+import {
+  commitProject,
+  CONTROL_PLANE,
+  ENVIRONMENT_ID,
+  InMemoryDeployControlPlane,
+  PROJECT_ID,
+  PROJECT_SLUG,
+  withDeployEnv,
+  withFetchStub,
+} from "../../test-utils/deploy-test-support.ts";
+import { computeSourceDigest, writePushReceipt } from "../../shared/deployment-provenance.ts";
+import { writeProjectLink } from "../../shared/project-link.ts";
+import { resetInteractiveMode, setNonInteractive } from "../../shared/interactive.ts";
+import { setJsonMode } from "../../shared/json-output.ts";
+import { stripAnsi } from "../../ui/ansi.ts";
 
 function getSlug(dirName: string): string {
   return dirName.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
@@ -150,5 +168,242 @@ describe("Up Command Integration", { sanitizeOps: false, sanitizeResources: fals
 
       assertEquals(parsed.projectSlug, "existing-project");
     });
+  });
+});
+
+const PREVIEW_DOMAIN = "https://preview.example.test";
+const APP_PAGE = "export default function Page() { return <main>Hello</main>; }\n";
+
+/**
+ * The in-memory control plane with a preview environment that carries its own
+ * domain, and whose release mirrors whatever the bootstrap push uploaded.
+ */
+class PreviewControlPlane extends InMemoryDeployControlPlane {
+  constructor(private readonly pushedFiles: Map<string, string>) {
+    super();
+  }
+
+  override async getEnvironment(
+    reference: string,
+    name: string,
+  ): Promise<DeployEnvironment | null> {
+    const environment = await super.getEnvironment(reference, name);
+    return environment ? { ...environment, domains: [PREVIEW_DOMAIN] } : environment;
+  }
+
+  override async *listReleaseFiles() {
+    for (const [path, content] of this.pushedFiles) yield { path, content };
+  }
+}
+
+interface UpRun {
+  output: string[];
+  controlPlane: PreviewControlPlane;
+  projectCreates: number;
+  uploadedPaths: string[];
+  /** The message up rejected with, or null when the command completed. */
+  failure: string | null;
+}
+
+interface UpRunOptions {
+  dryRun?: boolean;
+  jsonMode?: boolean;
+  /**
+   * Seed a linked project plus a push receipt for this branch, so the deploy
+   * meets a receipt that does not describe the branch up targets.
+   */
+  receiptBranch?: string;
+}
+
+/**
+ * Runs upCommand against the real Deploy Execution module: project creation,
+ * the bootstrap push, and the readiness probe go over a fetch stub, releases
+ * and deployments go through the in-memory control plane.
+ */
+async function runUp(options: UpRunOptions = {}): Promise<UpRun> {
+  const { dryRun = false, jsonMode = false, receiptBranch } = options;
+  const projectDir = await makeTempDir({ prefix: "vf-up-e2e-" });
+  const pushedFiles = new Map<string, string>();
+  const controlPlane = new PreviewControlPlane(pushedFiles);
+  const uploadedPaths: string[] = [];
+  const output: string[] = [];
+  const originalLog = console.log;
+  let projectCreates = 0;
+  let failure: string | null = null;
+
+  try {
+    await writeTextFile(join(projectDir, ".gitignore"), ".veryfront/\n");
+    await writeTextFile(join(projectDir, "package.json"), `{"name":"${PROJECT_SLUG}"}\n`);
+    await mkdir(join(projectDir, "app"));
+    await writeTextFile(join(projectDir, "app", "page.tsx"), APP_PAGE);
+    const commitSha = await commitProject(projectDir);
+
+    if (receiptBranch) {
+      await writeProjectLink(projectDir, {
+        controlPlane: CONTROL_PLANE,
+        projectId: PROJECT_ID,
+        projectSlug: PROJECT_SLUG,
+      });
+      await writePushReceipt(projectDir, {
+        controlPlane: CONTROL_PLANE,
+        projectId: PROJECT_ID,
+        projectSlug: PROJECT_SLUG,
+        branch: receiptBranch,
+        commitSha,
+        // Well-formed but not this tree's pushed digest: the branch check
+        // fires first, which is what this receipt is here to prove.
+        sourceDigest: await computeSourceDigest([{ path: "app/page.tsx", content: APP_PAGE }]),
+        clean: true,
+      });
+    }
+
+    console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
+    setNonInteractive(true);
+    setJsonMode(jsonMode);
+
+    const run = () =>
+      withFetchStub(async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+
+        if (url.origin === PREVIEW_DOMAIN) return new Response("ready");
+        if (url.pathname.endsWith("/me")) {
+          return Response.json({ id: "user-1", email: "dev@example.com" });
+        }
+        if (request.method === "POST" && url.pathname === "/api/projects") {
+          projectCreates++;
+          return Response.json({ id: PROJECT_ID, slug: PROJECT_SLUG });
+        }
+        if (
+          request.method === "GET" &&
+          (url.pathname === `/api/projects/${PROJECT_ID}` ||
+            url.pathname === `/api/projects/${PROJECT_SLUG}`)
+        ) {
+          return Response.json({ id: PROJECT_ID, slug: PROJECT_SLUG });
+        }
+        if (request.method === "GET" && url.pathname.endsWith("/files")) {
+          return Response.json({ data: [], page_info: {} });
+        }
+        if (request.method === "PUT" && url.pathname.includes("/files/")) {
+          const path = decodeURIComponent(url.pathname.split("/files/")[1] ?? "");
+          const body = await request.clone().json() as { content: string };
+          pushedFiles.set(path, body.content);
+          uploadedPaths.push(path);
+          return Response.json({});
+        }
+        if (url.pathname.endsWith("/branches")) {
+          return request.method === "POST"
+            ? Response.json({ id: "branch-1", name: "main", projectId: PROJECT_ID })
+            : Response.json({ data: [], page_info: {} });
+        }
+        return Response.json(
+          { message: `unstubbed ${request.method} ${url.pathname}` },
+          { status: 404 },
+        );
+      }, () =>
+        upCommand({ projectDir, dryRun }, undefined, {
+          deployProject: createDeployProject({
+            polling: {
+              assetManifestPollIntervalMs: 1,
+              assetManifestTimeoutMs: 100,
+              environmentPollIntervalMs: 1,
+              environmentTimeoutMs: 1_000,
+            },
+            controlPlaneFactory: () => controlPlane,
+          }),
+        }));
+
+    try {
+      await withDeployEnv(run);
+    } catch (error) {
+      failure = error instanceof Error ? error.message : String(error);
+    }
+
+    return { output, controlPlane, projectCreates, uploadedPaths, failure };
+  } finally {
+    console.log = originalLog;
+    setJsonMode(false);
+    resetInteractiveMode();
+    await remove(projectDir, { recursive: true });
+  }
+}
+
+describe("up end to end", { sanitizeOps: false, sanitizeResources: false }, () => {
+  it("creates the project, pushes source, and prints the verified preview URL", async () => {
+    const run = await runUp();
+
+    assertEquals(run.failure, null);
+    assertEquals(run.projectCreates, 1);
+    assertEquals(run.uploadedPaths.includes("app/page.tsx"), true);
+    assertEquals(run.controlPlane.createdReleases.length, 1);
+    assertEquals(run.controlPlane.createdDeployments.length, 1);
+    assertEquals(run.controlPlane.createdDeployments[0]?.environmentId, ENVIRONMENT_ID);
+
+    const lines = run.output.map(stripAnsi);
+    assertEquals(lines.includes(`  ✓ ${PROJECT_SLUG} is ready`), true);
+    // The URL printed is the environment domain the control plane returned and
+    // the deploy probed, not a hostname rebuilt from the local slug.
+    assertEquals(lines.includes(`  Preview: ${PREVIEW_DOMAIN}`), true);
+    assertEquals(lines.some((line) => line.includes("preview.veryfront.com")), false);
+  });
+
+  it("reports the same verified URL as the single JSON result", async () => {
+    const run = await runUp({ jsonMode: true });
+
+    assertEquals(run.failure, null);
+    assertEquals(run.output.length, 1);
+    assertEquals(JSON.parse(run.output[0]!), {
+      type: "result",
+      success: true,
+      data: {
+        projectSlug: PROJECT_SLUG,
+        dryRun: false,
+        studioUrl: `https://veryfront.com/projects/${PROJECT_SLUG}?branch=main`,
+        previewUrl: PREVIEW_DOMAIN,
+        nextCommand: "veryfront deploy",
+      },
+    });
+  });
+
+  it("plans a dry run without mutating the control plane", async () => {
+    const run = await runUp({ dryRun: true, jsonMode: true });
+
+    assertEquals(run.failure, null);
+    assertEquals(run.projectCreates, 0);
+    assertEquals(run.uploadedPaths, []);
+    assertEquals(run.controlPlane.createdReleases, []);
+    assertEquals(run.controlPlane.createdDeployments, []);
+    assertEquals(run.controlPlane.projectLookups, []);
+
+    assertEquals(run.output.length, 1);
+    assertEquals(JSON.parse(run.output[0]!), {
+      type: "result",
+      success: true,
+      data: {
+        projectSlug: PROJECT_SLUG,
+        dryRun: true,
+        plannedActions: ["create-project", "push-source", "deploy-preview"],
+      },
+    });
+  });
+
+  it("fails a dry run whose push receipt describes another branch", async () => {
+    const run = await runUp({ dryRun: true, receiptBranch: "feature-x" });
+
+    // up targets main, the receipt is for feature-x: the deploy it plans could
+    // not run, so the plan is refused instead of printed. Before up delegated
+    // to Deploy Execution its dry run returned before anything read the
+    // receipt, and reported a push it would not have made.
+    assertEquals(
+      run.failure,
+      'Preview deployment failed: The latest push is for branch "feature-x", but deploy targets ' +
+        '"main". Run veryfront deploy --branch feature-x to deploy the latest push, or veryfront ' +
+        "push --branch main to preview main first.",
+    );
+    assertEquals(run.projectCreates, 0);
+    assertEquals(run.uploadedPaths, []);
+    assertEquals(run.controlPlane.createdReleases, []);
+    assertEquals(run.controlPlane.createdDeployments, []);
+    assertEquals(run.output.some((line) => line.includes("is ready")), false);
   });
 });

--- a/cli/commands/up/up.integration.test.ts
+++ b/cli/commands/up/up.integration.test.ts
@@ -50,7 +50,7 @@ async function listDirNames(
   return entries;
 }
 
-describe("Up Command Integration", { sanitizeOps: false, sanitizeResources: false }, () => {
+describe("Up Command Integration", () => {
   let testDir: string;
 
   beforeEach(async () => {
@@ -328,7 +328,7 @@ async function runUp(options: UpRunOptions = {}): Promise<UpRun> {
   }
 }
 
-describe("up end to end", { sanitizeOps: false, sanitizeResources: false }, () => {
+describe("up end to end", () => {
   it("creates the project, pushes source, and prints the verified preview URL", async () => {
     const run = await runUp();
 

--- a/cli/commands/up/up.integration.test.ts
+++ b/cli/commands/up/up.integration.test.ts
@@ -13,7 +13,10 @@ import {
 } from "#veryfront/compat/fs.ts";
 import { upCommand } from "./index.ts";
 import { createDeployProject } from "../../shared/deployment/deploy-project.ts";
-import type { DeployEnvironment } from "../../shared/deployment/control-plane.ts";
+import type {
+  DeployEnvironment,
+  DeployReleaseFile,
+} from "../../shared/deployment/control-plane.ts";
 import {
   commitProject,
   CONTROL_PLANE,
@@ -191,7 +194,10 @@ class PreviewControlPlane extends InMemoryDeployControlPlane {
     return environment ? { ...environment, domains: [PREVIEW_DOMAIN] } : environment;
   }
 
-  override async *listReleaseFiles() {
+  override async *listReleaseFiles(
+    _reference: string,
+    _releaseId: string,
+  ): AsyncIterable<DeployReleaseFile> {
     for (const [path, content] of this.pushedFiles) yield { path, content };
   }
 }
@@ -296,10 +302,10 @@ async function runUp(options: UpRunOptions = {}): Promise<UpRun> {
             ? Response.json({ id: "branch-1", name: "main", projectId: PROJECT_ID })
             : Response.json({ data: [], page_info: {} });
         }
-        return Response.json(
-          { message: `unstubbed ${request.method} ${url.pathname}` },
-          { status: 404 },
-        );
+        // Fail closed: a 404 here would be read as a transient status and
+        // retried until the readiness deadline, turning an unexpected call
+        // into a timeout instead of naming it.
+        throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
       }, () =>
         upCommand({ projectDir, dryRun }, undefined, {
           deployProject: createDeployProject({

--- a/cli/shared/deployment/progress.ts
+++ b/cli/shared/deployment/progress.ts
@@ -1,0 +1,60 @@
+/**
+ * Human progress text for Deploy Execution step events.
+ *
+ * Shared by every presentation adapter that renders `DeployProject.execute`
+ * progress (the deploy command, `veryfront up`) so the same step always reads
+ * the same way.
+ *
+ * @module cli/shared/deployment/progress
+ */
+
+import type { DeployEvent, DeployStepName } from "./deploy-project.ts";
+
+/** Text a spinner should show for a step event, or null when nothing changes. */
+export function deployProgressText(
+  event: Extract<DeployEvent, { kind: "step" }>,
+  environment: string,
+  verbose: boolean,
+): string | null {
+  if (event.phase !== "started") return null;
+  switch (event.step) {
+    case "resolve-config":
+      return verbose ? "Resolving configuration..." : "Linking project...";
+    case "push-source":
+      return verbose ? "Pushing source..." : "Uploading source...";
+    case "resolve-target":
+    case "verify-source":
+    case "create-release":
+    case "verify-release-source":
+    case "wait-release-assets":
+      return verbose ? buildStepDetail(event.step, environment) : "Building release...";
+    case "create-deployment":
+      return `Deploying to ${environment}...`;
+    case "verify-deployment":
+      return verbose ? `Verifying ${environment} deployment...` : `Deploying to ${environment}...`;
+    case "wait-environment-url":
+      return verbose ? `Waiting for ${environment} URL...` : `Verifying ${environment} URL...`;
+  }
+}
+
+/** First line a spinner shows before Deploy Execution emits its first step. */
+export function initialDeployProgressText(verbose: boolean): string {
+  return verbose ? "Resolving configuration..." : "Linking project...";
+}
+
+function buildStepDetail(stepName: DeployStepName, environment: string): string {
+  switch (stepName) {
+    case "resolve-target":
+      return `Looking up environment "${environment}"...`;
+    case "verify-source":
+      return "Verifying pushed source...";
+    case "create-release":
+      return "Creating release...";
+    case "verify-release-source":
+      return "Verifying release source...";
+    case "wait-release-assets":
+      return "Waiting for release assets...";
+    default:
+      return "Building release...";
+  }
+}

--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -22,9 +22,9 @@ const SCAN_ROOTS = [
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-// 408 after restoring resource and operation sanitizers for the VirtualModuleSystem
-// smoke suite.
-export const SANITIZER_OPT_OUT_BASELINE = 408;
+// 406 after restoring both sanitizers for the up command integration suite, which
+// leaked nothing and never needed them.
+export const SANITIZER_OPT_OUT_BASELINE = 406;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 


### PR DESCRIPTION
## Summary

Stacked on #3190 (consumes the Project Resolution module). Two commits:

**1. Rebuild `up` as a Deploy Execution adapter** — `veryfront up` previously composed `pushCommand` + `deployCommand({skipSourcePush})` around what `DeployProject.execute` already owns end-to-end, then **discarded the verified deployment URL** and printed one rebuilt via `buildPushUrls` on the `{slug}.preview.veryfront.com` pattern. Those coincide only for a domain-less preview environment on an app with no static page route — with a configured domain or a probed route path, the old output handed users a hostname nobody had checked. Now: one `DeployProject.execute` call (source `ensure-pushed`, branch `main`, env `preview`), and the printed/JSON `previewUrl` is the outcome's verified URL. Injection unified on the MCP style (`dependencies: { deployProject? }`). Progress text shared via `cli/shared/deployment/progress.ts` (moved verbatim). JSON field names and dry-run `plannedActions` shape unchanged.

Deliberate behavior changes (commit body): dry-run with a valid main receipt omits `push-source` from the plan (deploy wouldn't push); dry-run with a receipt for **another branch** now surfaces the mismatch error instead of silently planning — pinned by an exact-message integration test that also asserts zero control-plane mutations.

**2. Retire the deploy command's bespoke testing seams** — `deployCommandWithProjectForTesting` + `DeployCommandTestingSeams` deleted; `suppressJsonOutput` and the four never-parseable polling knobs dropped from `DeployOptions` (polling now reaches the module via `createDeployProject({ polling })`); `skipSourcePush` kept as the only command-boundary expression of source `already-pushed` (eight integration assertions ride it), flagged for removal once a user-facing flag exists.

**Tests:** the `up` suite no longer monkey-patches `globalThis.fetch` (was 6×) — it injects a fake DeployProject and finally asserts *what deploy was asked to do*, plus a new end-to-end suite over the real module with `InMemoryDeployControlPlane` (verified-URL provenance: output must carry the control plane's domain and must NOT contain the rebuilt pattern).

## Review

Independent code-review pass: approve, no blocking issues. Its one Low item (no pinning test for the stale-receipt dry-run change) is closed by the exact-message test above — which also corrected the review's own guess at the error (it's the `validatePushReceipt` branch-check error, not `SOURCE_DIGEST_MISMATCH`).

## Tested

- Targeted: 52 passed / 250 steps, 0 failed; typecheck, lint, fmt, cli-boundary, module-boundaries green; test-typecheck baseline holds (92 grandfathered, 0 new)
- Pre-push full suite: 2806 passed / 22,739 steps, 0 failed