### PR TITLE
Use preview request auth for dependency pin writeback

### DIFF
--- a/src/server/handlers/utils/dependency-pinning-source.test.ts
+++ b/src/server/handlers/utils/dependency-pinning-source.test.ts
@@ -89,6 +89,7 @@ describe("server/handlers/utils/dependency-pinning-source", () => {
     const source = createHandlerDependencyPinningSource(
       makeCtx({
         isLocalProject: false,
+        proxyToken: "request-scoped-token",
         requestContext: {
           token: "",
           slug: "project",
@@ -105,6 +106,7 @@ describe("server/handlers/utils/dependency-pinning-source", () => {
 
     assertEquals(source.contentSourceId, "preview-main-source");
     assertEquals(source.dependencyWritebackTarget, { kind: "main" });
+    assertEquals(source.dependencyWritebackToken, "request-scoped-token");
   });
 
   it("targets preview branches and denies release, production, or unproven sources", () => {

--- a/src/server/handlers/utils/dependency-pinning-source.ts
+++ b/src/server/handlers/utils/dependency-pinning-source.ts
@@ -52,5 +52,6 @@ export function createHandlerDependencyPinningSource(
     config: ctx.config,
     ...identity,
     dependencyWritebackTarget,
+    dependencyWritebackToken: dependencyWritebackTarget ? ctx.proxyToken : undefined,
   });
 }

--- a/src/transforms/esm/npm-registry-client.test.ts
+++ b/src/transforms/esm/npm-registry-client.test.ts
@@ -105,6 +105,41 @@ describe("npm-registry-client dependency contracts", () => {
     }
   });
 
+  it("uses request-scoped authorization when the runtime has no API token", async () => {
+    const originalBaseUrl = getHostEnv("VERYFRONT_API_BASE_URL");
+    const originalToken = getHostEnv("VERYFRONT_API_TOKEN");
+    const originalFetch = globalThis.fetch;
+    setEnv("VERYFRONT_API_BASE_URL", "https://api.example.test");
+    setEnv("VERYFRONT_API_TOKEN", "");
+    refreshEnvironmentConfig();
+
+    let authorization = "";
+    globalThis.fetch = (_input, init) => {
+      authorization = new Headers(init?.headers).get("authorization") ?? "";
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    };
+
+    try {
+      schedulePlatformDependencyResolution(
+        "project-ref",
+        "zod",
+        "^3",
+        {
+          target: { kind: "main" },
+          authToken: "request-scoped-token",
+        },
+      );
+      await _pendingResolutions();
+
+      assertEquals(authorization, "Bearer request-scoped-token");
+    } finally {
+      globalThis.fetch = originalFetch;
+      setEnv("VERYFRONT_API_BASE_URL", originalBaseUrl ?? "");
+      setEnv("VERYFRONT_API_TOKEN", originalToken ?? "");
+      refreshEnvironmentConfig();
+    }
+  });
+
   it("posts branch and caller-observed declarations, including absence", async () => {
     const originalBaseUrl = getHostEnv("VERYFRONT_API_BASE_URL");
     const originalToken = getHostEnv("VERYFRONT_API_TOKEN");

--- a/src/transforms/esm/npm-registry-client.ts
+++ b/src/transforms/esm/npm-registry-client.ts
@@ -32,6 +32,7 @@ const pendingPlatformResolutionPromises = new Set<Promise<void>>();
 export type DependencyResolutionEligibility = () => boolean;
 export interface DependencyResolutionScheduleOptions {
   target: DependencyWritebackTarget;
+  authToken?: string;
   isEligible?: DependencyResolutionEligibility;
 }
 interface QueuedPlatformResolution {
@@ -44,6 +45,7 @@ interface QueuedPlatformResolution {
 interface QueuedPlatformResolutionBatch {
   projectId: string;
   target: DependencyWritebackTarget;
+  authToken?: string;
   resolutions: Map<string, QueuedPlatformResolution>;
 }
 const queuedPlatformResolutions = new Map<string, QueuedPlatformResolutionBatch>();
@@ -58,6 +60,7 @@ type DependencyResolutionPoster = (
   specifiers: string[],
   target: DependencyWritebackTarget,
   expectedDeclarations: Readonly<Record<string, string | null>>,
+  authToken?: string,
 ) => Promise<void>;
 let postDependencyResolutionImpl: DependencyResolutionPoster = postDependencyResolution;
 const ALWAYS_ELIGIBLE: DependencyResolutionEligibility = () => true;
@@ -247,9 +250,12 @@ export function schedulePlatformDependencyResolution(
     queuedBatch = {
       projectId,
       target,
+      authToken: options.authToken,
       resolutions: new Map(),
     };
     queuedPlatformResolutions.set(queueKey, queuedBatch);
+  } else if (options.authToken) {
+    queuedBatch.authToken = options.authToken;
   }
   queuedBatch.resolutions.set(packageName, {
     packageName,
@@ -324,6 +330,7 @@ function schedulePlatformResolutionFlush(queueKey: string): void {
                     resolution.expectedDeclaration,
                   ]),
                 ),
+                queued.authToken,
               );
             },
           );
@@ -375,12 +382,14 @@ export function _setDependencyResolutionPosterForTest(
  *                     "pkg", "pkg@^1", "pkg@next", or "pkg@1.2.3"
  * @param expectedDeclarations - package declarations observed in the immutable
  *                               caller snapshot; null means the package was absent
+ * @param authToken - request-scoped bearer token; the runtime token remains the fallback
  */
 export async function postDependencyResolution(
   projectId: string,
   specifiers: string[],
   target: DependencyWritebackTarget,
   expectedDeclarations: Readonly<Record<string, string | null>>,
+  authToken?: string,
 ): Promise<void> {
   if (!isCanonicalDependencyWritebackTarget(target)) return;
 
@@ -389,7 +398,7 @@ export async function postDependencyResolution(
   );
   const config = getEnvironmentConfig();
   const apiBaseUrl = config.apiBaseUrl;
-  const apiToken = config.apiToken;
+  const apiToken = authToken || config.apiToken;
 
   if (!apiBaseUrl || !apiToken) {
     logger.debug("Skipping dependency resolution write-back: no API config", { projectId });

--- a/src/transforms/esm/package-registry.ts
+++ b/src/transforms/esm/package-registry.ts
@@ -171,6 +171,8 @@ export interface DependencyPinningSource {
   readonly branch?: string | null;
   /** Explicit writable platform target; absent for release/production sources. */
   readonly dependencyWritebackTarget?: DependencyWritebackTarget;
+  /** Request-scoped bearer token used only by the platform write-back transport. */
+  readonly dependencyWritebackToken?: string;
 }
 
 export type DependencyPinningSourceInput =
@@ -190,6 +192,7 @@ export interface CreateDependencyPinningSourceOptions {
   isLocalProject?: boolean;
   config?: VeryfrontConfig | null;
   dependencyWritebackTarget?: DependencyWritebackTarget;
+  dependencyWritebackToken?: string;
 }
 
 /**
@@ -225,6 +228,7 @@ export function createDependencyPinningSource(
     dependencyWritebackTarget: options.dependencyWritebackTarget
       ? Object.freeze({ ...options.dependencyWritebackTarget })
       : undefined,
+    dependencyWritebackToken: options.dependencyWritebackToken,
     ...(adapterFs
       ? {
         fs: adapterFs,

--- a/src/transforms/import-rewriter/dependency-resolution.test.ts
+++ b/src/transforms/import-rewriter/dependency-resolution.test.ts
@@ -29,6 +29,7 @@ function memorySource(
     | "branch"
     | "contentSourceId"
     | "dependencyWritebackTarget"
+    | "dependencyWritebackToken"
     | "releaseId"
   > = {},
 ): DependencyPinningSource {
@@ -232,6 +233,37 @@ describe("dependency resolution write-back authority", () => {
       { specifiers: ["zod@^4"], target: "branch:feature" },
       { specifiers: ["zod@^4"], target: "main" },
     ]);
+  });
+
+  it("forwards request-scoped authorization from the current source", async () => {
+    const state: MemoryPackageState = {
+      content: JSON.stringify({ dependencies: { zod: "^3" } }),
+      mtime: new Date(1_000),
+    };
+    const source = memorySource('["project-a","branch-feature"]', state, {
+      branch: "feature",
+      dependencyWritebackTarget: { kind: "branch", branch: "feature" },
+      dependencyWritebackToken: "request-scoped-token",
+    });
+    let requestToken: string | undefined;
+    _setDependencyResolutionPosterForTest(
+      (_projectId, _specifiers, _target, _expected, token) => {
+        requestToken = token;
+        return Promise.resolve();
+      },
+    );
+    const snapshot = await getDependencyPinningSnapshot(source);
+
+    resolveDependencyPinForImport("zod", {
+      projectDir: source.projectDir,
+      projectId: "project-a",
+      dependencyPinningSource: source,
+      dependencyPinningCacheKey: snapshot.cacheKey,
+      dependencyPinningDependencies: snapshot.dependencies,
+    });
+    await _pendingResolutions();
+
+    assertEquals(requestToken, "request-scoped-token");
   });
 
   it("resolves an own constructor declaration without prototype interference", async () => {

--- a/src/transforms/import-rewriter/dependency-resolution.ts
+++ b/src/transforms/import-rewriter/dependency-resolution.ts
@@ -129,12 +129,17 @@ export function resolveDependencyPinForImport(
       writebackSource !== null
     ? writebackSource.dependencyWritebackTarget
     : undefined;
+  const writebackToken = typeof writebackSource === "object" &&
+      writebackSource !== null
+    ? writebackSource.dependencyWritebackToken
+    : undefined;
   const writebackAuthorization = writebackSource &&
       writebackTarget &&
       cacheKey?.startsWith("on:") &&
       cacheKey !== "on:unknown"
     ? {
       target: writebackTarget,
+      authToken: writebackToken,
       isEligible: () => isCurrentDependencyPinningSnapshot(writebackSource, cacheKey),
     }
     : undefined;


### PR DESCRIPTION
## Description

- pass the existing project-scoped preview credential through the dependency pinning source and batched writeback scheduler
- prefer request-scoped authorization for the resolution API while retaining the runtime credential as a fallback
- keep credentials out of dependency snapshot identities, cache keys, and logs
- add regression coverage at the handler-context, scheduler, and HTTP transport boundaries

## Staging finding

After #3200 deployed, the baseline preview and ranged dependency render returned 200, but the renderer emitted an unversioned dependency URL and the branch declaration remained ranged. Both staging server replicas had the API base URL configured but no global runtime credential, so the best-effort writeback returned before making the resolution request.

Preview requests already carry a project-scoped credential for remote project access. Reusing that credential keeps authorization scoped to the active project and avoids adding ambient deployment authority.

## Related issue(s)

Related: veryfront/veryfront-issue-inbox#240
Follows: #3198 and #3200

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Verification

- red-before-fix regression: 3 failing assertions at context, scheduler, and transport seams
- focused regression suite: 3 passed, 29 steps, 0 failed
- affected transform/module sweep: 74 passed, 1,313 steps, 0 failed
- serial rerun of broad-run timeout/failure files: 4 passed, 39 steps, 0 failed
- canonical unit suite: 2,856 passed and 14 parallel shared-environment/fetch-leak failures; all affected files rerun with isolated environment state: 32 passed, 287 steps, 0 failed
- full repository format and lint checks passed in the pre-push hook
- type checks passed for the public entry point and all changed source/test files
- git diff check, debug-instrumentation scan, and secret-safety scan passed

## Rollout gate

After merge and staging deployment, rerun the clean ranged-dependency canary without calling the resolution API manually. The gate is exact 3.x package writeback followed by a transformed module that emits the exact version. Then run concurrent cold requests, cache-hit verification, and the staging soak. The live flag-off toggle remains a separate shared-staging authorization gate.

## Checklist

- [x] I have made corresponding changes to the documentation (not applicable, internal transport behavior only)
- [x] I have added tests that prove my fix is effective or that my feature works