### PR TITLE
fix(agent): persist explicit durable step telemetry

### DIFF
--- a/src/agent/conversation/durable-contracts.ts
+++ b/src/agent/conversation/durable-contracts.ts
@@ -406,6 +406,7 @@ export interface ConversationAgentRunUsage {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
+  usageCaptureStatus?: "complete" | "partial" | "missing";
 }
 
 /** Input payload for create conversation agent run. */

--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -1152,6 +1152,9 @@ export async function finalizeConversationAgentRun(
       model: input.model,
       inputTokens: input.usage?.inputTokens ?? 0,
       outputTokens: input.usage?.outputTokens ?? 0,
+      ...(input.usage?.usageCaptureStatus !== undefined
+        ? { usageCaptureStatus: input.usage.usageCaptureStatus }
+        : {}),
       finishReason: input.finishReason ?? "stop",
     }
     : null;

--- a/src/agent/conversation/hosted-terminal.test.ts
+++ b/src/agent/conversation/hosted-terminal.test.ts
@@ -58,8 +58,8 @@ describe("agent/conversation-hosted-terminal", () => {
               inputTokens: 1,
               outputTokens: 2,
               cachedInputTokens: 3,
-              usageCaptureStatus: "complete",
             },
+            usageCaptureStatus: "complete",
           },
         },
       }),
@@ -73,8 +73,8 @@ describe("agent/conversation-hosted-terminal", () => {
             inputTokens: 1,
             outputTokens: 2,
             cachedInputTokens: 3,
-            usageCaptureStatus: "complete",
           },
+          usageCaptureStatus: "complete",
         },
       },
     );
@@ -109,8 +109,8 @@ describe("agent/conversation-hosted-terminal", () => {
             inputTokens: 4,
             outputTokens: 6,
             cachedInputTokens: 2,
-            usageCaptureStatus: "complete",
           },
+          usageCaptureStatus: "complete",
         },
       });
 

--- a/src/agent/conversation/hosted-terminal.test.ts
+++ b/src/agent/conversation/hosted-terminal.test.ts
@@ -54,7 +54,12 @@ describe("agent/conversation-hosted-terminal", () => {
           terminalErrorCode: "ERR",
           terminalErrorMessage: "boom",
           metadata: {
-            usage: { inputTokens: 1, outputTokens: 2, cachedInputTokens: 3 },
+            usage: {
+              inputTokens: 1,
+              outputTokens: 2,
+              cachedInputTokens: 3,
+              usageCaptureStatus: "complete",
+            },
           },
         },
       }),
@@ -64,7 +69,12 @@ describe("agent/conversation-hosted-terminal", () => {
         terminalErrorMessage: "boom",
         metadata: {
           modelId: "fallback-model",
-          usage: { inputTokens: 1, outputTokens: 2, cachedInputTokens: 3 },
+          usage: {
+            inputTokens: 1,
+            outputTokens: 2,
+            cachedInputTokens: 3,
+            usageCaptureStatus: "complete",
+          },
         },
       },
     );
@@ -95,7 +105,12 @@ describe("agent/conversation-hosted-terminal", () => {
       await adapter.finalizeRun({
         status: "completed",
         metadata: {
-          usage: { inputTokens: 4, outputTokens: 6, cachedInputTokens: 2 },
+          usage: {
+            inputTokens: 4,
+            outputTokens: 6,
+            cachedInputTokens: 2,
+            usageCaptureStatus: "complete",
+          },
         },
       });
 
@@ -107,6 +122,7 @@ describe("agent/conversation-hosted-terminal", () => {
           model: "fallback-model",
           inputTokens: 4,
           outputTokens: 6,
+          usageCaptureStatus: "complete",
           finishReason: "stop",
         },
         terminal_error_code: null,

--- a/src/agent/conversation/hosted-terminal.test.ts
+++ b/src/agent/conversation/hosted-terminal.test.ts
@@ -133,6 +133,51 @@ describe("agent/conversation-hosted-terminal", () => {
     }
   });
 
+  it("preserves an explicit missing usage status without token metadata", async () => {
+    calls.length = 0;
+    const restoreFetch = installFetchMock();
+    try {
+      const adapter = createConversationHostedTerminalAdapter({
+        authToken: "tok",
+        apiUrl: "https://api.example.com",
+        run: {
+          conversationId: "conv-1",
+          runId: "run-1",
+          messageId: "msg-1",
+          latestEventId: 0,
+          latestExternalEventSequence: 0,
+          waitingToolCallId: null,
+          waitingToolName: null,
+          streamProtocolVersion: 2,
+          status: "running",
+        },
+        fallbackModelId: "fallback-model",
+        resolveProvider: (modelId) => `provider:${modelId}`,
+      });
+
+      await adapter.finalizeRun({
+        status: "completed",
+        metadata: { usageCaptureStatus: "missing" },
+      });
+
+      assertEquals(calls[0]?.body, {
+        status: "completed",
+        metadata: {
+          provider: "provider:fallback-model",
+          model: "fallback-model",
+          inputTokens: 0,
+          outputTokens: 0,
+          usageCaptureStatus: "missing",
+          finishReason: "stop",
+        },
+        terminal_error_code: null,
+        terminal_error_message: null,
+      });
+    } finally {
+      restoreFetch();
+    }
+  });
+
   it("dispatches terminal state observers even without a durable run", async () => {
     const seen: unknown[] = [];
     const adapter = createConversationHostedTerminalAdapter({

--- a/src/agent/conversation/hosted-terminal.ts
+++ b/src/agent/conversation/hosted-terminal.ts
@@ -143,6 +143,9 @@ function buildConversationHostedLifecycleUsage(
     ...(usage.cachedInputTokens !== undefined
       ? { cachedInputTokens: usage.cachedInputTokens }
       : {}),
+    ...(usage.usageCaptureStatus !== undefined
+      ? { usageCaptureStatus: usage.usageCaptureStatus }
+      : {}),
   };
 }
 
@@ -160,6 +163,9 @@ function buildConversationAgentRunUsage(
     inputTokens,
     outputTokens,
     totalTokens: inputTokens + outputTokens,
+    ...(usage.usageCaptureStatus !== undefined
+      ? { usageCaptureStatus: usage.usageCaptureStatus }
+      : {}),
   };
 }
 

--- a/src/agent/conversation/hosted-terminal.ts
+++ b/src/agent/conversation/hosted-terminal.ts
@@ -143,14 +143,12 @@ function buildConversationHostedLifecycleUsage(
     ...(usage.cachedInputTokens !== undefined
       ? { cachedInputTokens: usage.cachedInputTokens }
       : {}),
-    ...(usage.usageCaptureStatus !== undefined
-      ? { usageCaptureStatus: usage.usageCaptureStatus }
-      : {}),
   };
 }
 
 function buildConversationAgentRunUsage(
   usage: HostedLifecycleUsage | undefined,
+  usageCaptureStatus: NonNullable<HostedLifecycleTerminalState["metadata"]>["usageCaptureStatus"],
 ): ConversationAgentRunUsage | undefined {
   if (!usage) {
     return undefined;
@@ -163,9 +161,7 @@ function buildConversationAgentRunUsage(
     inputTokens,
     outputTokens,
     totalTokens: inputTokens + outputTokens,
-    ...(usage.usageCaptureStatus !== undefined
-      ? { usageCaptureStatus: usage.usageCaptureStatus }
-      : {}),
+    ...(usageCaptureStatus !== undefined ? { usageCaptureStatus } : {}),
   };
 }
 
@@ -176,14 +172,16 @@ export function toConversationHostedTerminalState(input: {
 }): HostedLifecycleTerminalState {
   const modelId = input.state.metadata?.modelId ?? input.fallbackModelId;
   const usage = buildConversationHostedLifecycleUsage(input.state.metadata?.usage);
+  const usageCaptureStatus = input.state.metadata?.usageCaptureStatus;
 
   return {
     status: input.state.status,
-    ...(modelId || usage
+    ...(modelId || usage || usageCaptureStatus
       ? {
         metadata: {
           ...(modelId ? { modelId } : {}),
           ...(usage ? { usage } : {}),
+          ...(usageCaptureStatus ? { usageCaptureStatus } : {}),
         },
       }
       : {}),
@@ -222,7 +220,10 @@ export function createConversationHostedTerminalAdapter(
         status,
         model: modelId,
         provider: options.resolveProvider(modelId),
-        usage: buildConversationAgentRunUsage(terminalState.metadata?.usage),
+        usage: buildConversationAgentRunUsage(
+          terminalState.metadata?.usage,
+          terminalState.metadata?.usageCaptureStatus,
+        ),
         terminalErrorCode: terminalState.terminalErrorCode,
         terminalErrorMessage: terminalState.terminalErrorMessage,
       });

--- a/src/agent/conversation/hosted-terminal.ts
+++ b/src/agent/conversation/hosted-terminal.ts
@@ -150,12 +150,12 @@ function buildConversationAgentRunUsage(
   usage: HostedLifecycleUsage | undefined,
   usageCaptureStatus: NonNullable<HostedLifecycleTerminalState["metadata"]>["usageCaptureStatus"],
 ): ConversationAgentRunUsage | undefined {
-  if (!usage) {
+  if (!usage && usageCaptureStatus === undefined) {
     return undefined;
   }
 
-  const inputTokens = usage.inputTokens ?? 0;
-  const outputTokens = usage.outputTokens ?? 0;
+  const inputTokens = usage?.inputTokens ?? 0;
+  const outputTokens = usage?.outputTokens ?? 0;
 
   return {
     inputTokens,

--- a/src/agent/conversation/run-events.test.ts
+++ b/src/agent/conversation/run-events.test.ts
@@ -49,9 +49,19 @@ describe("agent/conversation-run-events", () => {
 
     assertEquals(encoder.encode({ type: "start-step" }), [{
       type: conversationRunEventTypes.stepStarted,
+      stepName: "step-1",
     }]);
     assertEquals(encoder.encode({ type: "finish-step" }), [{
       type: conversationRunEventTypes.stepFinished,
+      stepName: "step-1",
+    }]);
+    assertEquals(encoder.encode({ type: "start-step" }), [{
+      type: conversationRunEventTypes.stepStarted,
+      stepName: "step-2",
+    }]);
+    assertEquals(encoder.encode({ type: "finish-step" }), [{
+      type: conversationRunEventTypes.stepFinished,
+      stepName: "step-2",
     }]);
   });
 

--- a/src/agent/conversation/run-events.test.ts
+++ b/src/agent/conversation/run-events.test.ts
@@ -44,6 +44,17 @@ describe("agent/conversation-run-events", () => {
     );
   });
 
+  it("encodes model step lifecycle events for durable replay", () => {
+    const encoder = new ConversationRunEventEncoder();
+
+    assertEquals(encoder.encode({ type: "start-step" }), [{
+      type: conversationRunEventTypes.stepStarted,
+    }]);
+    assertEquals(encoder.encode({ type: "finish-step" }), [{
+      type: conversationRunEventTypes.stepFinished,
+    }]);
+  });
+
   it("encodes text block ids as content ids when a durable message id is active", () => {
     const encoder = new ConversationRunEventEncoder();
     assertEquals(encoder.encode({ type: "start", messageId: "assistant-1" }), []);

--- a/src/agent/conversation/run-events.ts
+++ b/src/agent/conversation/run-events.ts
@@ -12,6 +12,8 @@ export const conversationRunEventTypes = {
   reasoningMessageStart: "REASONING_MESSAGE_START",
   reasoningMessageContent: "REASONING_MESSAGE_CONTENT",
   reasoningMessageEnd: "REASONING_MESSAGE_END",
+  stepStarted: "STEP_STARTED",
+  stepFinished: "STEP_FINISHED",
   toolCallStart: "TOOL_CALL_START",
   toolCallArgs: "TOOL_CALL_ARGS",
   toolCallEnd: "TOOL_CALL_END",
@@ -265,13 +267,17 @@ export class ConversationRunEventEncoder {
           value: chunk,
         }];
 
+      case "start-step":
+        return [{ type: conversationRunEventTypes.stepStarted }];
+
+      case "finish-step":
+        return [{ type: conversationRunEventTypes.stepFinished }];
+
       case "error":
       case "finish":
       case "abort":
       case "message-metadata":
       case "tool-approval-request":
-      case "start-step":
-      case "finish-step":
         return [];
 
       default:

--- a/src/agent/conversation/run-events.ts
+++ b/src/agent/conversation/run-events.ts
@@ -66,6 +66,20 @@ export class ConversationRunEventEncoder {
   private activeMessageId: string | null = null;
   private activeTextContentId: string | null = null;
   private textContentIndex = 0;
+  private activeStepName: string | null = null;
+  private stepCount = 0;
+
+  private nextStepName(): string {
+    this.stepCount += 1;
+    this.activeStepName = `step-${this.stepCount}`;
+    return this.activeStepName;
+  }
+
+  private finishStepName(): string {
+    const stepName = this.activeStepName ?? `step-${Math.max(this.stepCount, 1)}`;
+    this.activeStepName = null;
+    return stepName;
+  }
 
   private getToolResultMessageId(toolCallId: string) {
     return this.activeMessageId
@@ -268,10 +282,16 @@ export class ConversationRunEventEncoder {
         }];
 
       case "start-step":
-        return [{ type: conversationRunEventTypes.stepStarted }];
+        return [{
+          type: conversationRunEventTypes.stepStarted,
+          stepName: this.nextStepName(),
+        }];
 
       case "finish-step":
-        return [{ type: conversationRunEventTypes.stepFinished }];
+        return [{
+          type: conversationRunEventTypes.stepFinished,
+          stepName: this.finishStepName(),
+        }];
 
       case "error":
       case "finish":

--- a/src/agent/hosted/hosted-chat-finalization.test.ts
+++ b/src/agent/hosted/hosted-chat-finalization.test.ts
@@ -1,6 +1,8 @@
+import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ChatUiMessage, ChatUiMessageChunk, MessageMetadata } from "../../chat/types.ts";
+import { createConversationHostedTerminalAdapter } from "../conversation/hosted-terminal.ts";
 import type { ConversationRunChunkMirror } from "../conversation/run-chunk-mirror.ts";
 import { createMirroredToolChunkState } from "../streaming/mirrored-tool-chunk-state.ts";
 import type { HostedChatExecutionLifecycleAdapter } from "./chat-execution-lifecycle-types.ts";
@@ -210,6 +212,86 @@ describe("agent/hosted-chat-finalization", () => {
         },
       },
     ]);
+  });
+
+  it("posts canonical root usage capture status when finalizing a durable response", async () => {
+    const requestBodies: unknown[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit) => {
+      requestBodies.push(init?.body ? JSON.parse(String(init.body)) : null);
+      return new Response(
+        JSON.stringify({
+          completed: true,
+          run: { runId: "run-1", status: "completed" },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    };
+
+    try {
+      const terminal = createConversationHostedTerminalAdapter({
+        authToken: "token",
+        apiUrl: "https://api.example.com",
+        run: {
+          conversationId: "conversation-1",
+          runId: "run-1",
+          messageId: "assistant-message-1",
+          latestEventId: 0,
+          latestExternalEventSequence: 0,
+          waitingToolCallId: null,
+          waitingToolName: null,
+          streamProtocolVersion: 2,
+          status: "running",
+        },
+        fallbackModelId: "fallback-model",
+        resolveProvider: () => "test-provider",
+      });
+
+      await finalizeHostedChatRun({
+        kind: "response",
+        responseMessage: createResponseMessage({
+          parts: [{ type: "text", text: "done" }],
+          metadata: {
+            modelId: "test-model",
+            usage: { inputTokens: 2, outputTokens: 3 },
+            usageCaptureStatus: "complete",
+          },
+        }),
+        isAborted: false,
+        streamResult: createStreamResult({}),
+        lifecycleAdapter: {
+          durableRootRun: { runId: "run-1", messageId: "assistant-message-1" },
+          durableRunMirror: null,
+          terminal,
+        },
+        mirroredToolChunkState: createMirroredToolChunkState(),
+        capturedMessageId: "assistant-message-1",
+        incompleteToolCallsPartErrorText: "Tool call did not complete",
+        cleanup: async () => {},
+        streamError: null,
+      });
+
+      assertEquals(requestBodies, [
+        {
+          status: "completed",
+          metadata: {
+            provider: "test-provider",
+            model: "test-model",
+            inputTokens: 2,
+            outputTokens: 3,
+            usageCaptureStatus: "complete",
+            finishReason: "stop",
+          },
+          terminal_error_code: null,
+          terminal_error_message: null,
+        },
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("treats provider-owned input-available tool parts as completed", async () => {

--- a/src/agent/hosted/lifecycle.ts
+++ b/src/agent/hosted/lifecycle.ts
@@ -14,6 +14,7 @@ export interface HostedLifecycleTerminalState {
       cacheCreationInputTokens?: number;
       cacheReadInputTokens?: number;
       reasoningTokens?: number;
+      usageCaptureStatus?: "complete" | "partial" | "missing";
     };
   };
   terminalErrorCode?: string | null;

--- a/src/agent/hosted/lifecycle.ts
+++ b/src/agent/hosted/lifecycle.ts
@@ -14,8 +14,8 @@ export interface HostedLifecycleTerminalState {
       cacheCreationInputTokens?: number;
       cacheReadInputTokens?: number;
       reasoningTokens?: number;
-      usageCaptureStatus?: "complete" | "partial" | "missing";
     };
+    usageCaptureStatus?: "complete" | "partial" | "missing";
   };
   terminalErrorCode?: string | null;
   terminalErrorMessage?: string | null;


### PR DESCRIPTION
## Summary

- preserve start-step and finish-step as durable STEP_STARTED and STEP_FINISHED events
- emit stable non-empty paired stepName values for AG-UI schema compatibility
- preserve explicit usageCaptureStatus through hosted terminal normalization and canonical run completion metadata
- preserve status-only missing or partial telemetry with zero-token defaults
- add production-shaped regressions for all contracts

## Why

The durable staging proof for veryfront/veryfront-issue-inbox#353 must prove the exact hi prompt used one model step and complete usage capture. The framework previously dropped step lifecycle chunks from durable replay and stripped usageCaptureStatus before finalizing the canonical run, forcing consumers to infer telemetry. This change makes the existing runtime facts explicit and schema-valid at the durable public event boundary.

## Scope

This does not change model execution, tool exposure, CI, provider behavior, or authorization. It only preserves already-produced step and usage telemetry across the durable boundary.

## Review feedback addressed

- STEP_STARTED and STEP_FINISHED now include stable step-1, step-2, and subsequent names, with each finish reusing its matching start name.
- canonical root usageCaptureStatus reaches the exact durable completion POST
- status-only missing or partial values are retained even when token counters are unavailable

## Verification

- focused comment regression: 12/12 steps passed
- focused hosted/durable suite: 39/39 steps passed
- full pre-push suite: 2,870 tests / 22,836 steps passed
- format, lint, typecheck, and diff checks passed
- exact-head GitHub CI pending final completion

Dependent proof PR: veryfront/veryfront-agent#1757.