### PR TITLE
Phase 1: establish a fail-closed dependency artifact rollout seam

### DIFF
--- a/src/release-assets/dependency-artifact-mode.test.ts
+++ b/src/release-assets/dependency-artifact-mode.test.ts
@@ -1,0 +1,116 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { deleteEnv, getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import {
+  DEPENDENCY_ARTIFACT_MODE_ENV,
+  DEPENDENCY_ARTIFACT_PROJECTS_ENV,
+  DEPENDENCY_ARTIFACT_ROLLOUT_PERCENT_ENV,
+  getDependencyArtifactModeForProject,
+  parseDependencyArtifactRolloutConfig,
+  resolveDependencyArtifactMode,
+} from "./dependency-artifact-mode.ts";
+
+const ROLLOUT_ENV_KEYS = [
+  DEPENDENCY_ARTIFACT_MODE_ENV,
+  DEPENDENCY_ARTIFACT_ROLLOUT_PERCENT_ENV,
+  DEPENDENCY_ARTIFACT_PROJECTS_ENV,
+] as const;
+
+function restoreEnv(values: ReadonlyMap<string, string | undefined>): void {
+  for (const key of ROLLOUT_ENV_KEYS) {
+    const value = values.get(key);
+    if (value === undefined) deleteEnv(key);
+    else setEnv(key, value);
+  }
+}
+
+describe("dependency artifact rollout mode", () => {
+  it("defaults to off when rollout configuration is absent or invalid", () => {
+    assertEquals(parseDependencyArtifactRolloutConfig({}), {
+      mode: "off",
+      rolloutBasisPoints: 0,
+      projectAllowlist: [],
+    });
+    assertEquals(parseDependencyArtifactRolloutConfig({ mode: "enabled" }), {
+      mode: "off",
+      rolloutBasisPoints: 0,
+      projectAllowlist: [],
+    });
+  });
+
+  it("keeps the host-configured interface off when no rollout env is set", () => {
+    const original = new Map(ROLLOUT_ENV_KEYS.map((key) => [key, getHostEnv(key)]));
+    try {
+      for (const key of ROLLOUT_ENV_KEYS) deleteEnv(key);
+      assertEquals(getDependencyArtifactModeForProject("project-alpha"), "off");
+    } finally {
+      restoreEnv(original);
+    }
+  });
+
+  it("accepts only the four rollout modes", () => {
+    for (const mode of ["off", "shadow", "prefer", "require"] as const) {
+      assertEquals(
+        parseDependencyArtifactRolloutConfig({ mode, rolloutPercent: "100" }).mode,
+        mode,
+      );
+    }
+  });
+
+  it("keeps off authoritative over percentage and allowlist selection", () => {
+    const config = parseDependencyArtifactRolloutConfig({
+      mode: "off",
+      rolloutPercent: "100",
+      projectAllowlist: "project-alpha",
+    });
+
+    assertEquals(resolveDependencyArtifactMode("project-alpha", config), "off");
+  });
+
+  it("selects explicit projects and deduplicates allowlist entries", () => {
+    const config = parseDependencyArtifactRolloutConfig({
+      mode: "shadow",
+      rolloutPercent: "0",
+      projectAllowlist: " project-alpha,project-beta,project-alpha ",
+    });
+
+    assertEquals(config.projectAllowlist, ["project-alpha", "project-beta"]);
+    assertEquals(resolveDependencyArtifactMode("project-alpha", config), "shadow");
+    assertEquals(resolveDependencyArtifactMode("project-gamma", config), "off");
+  });
+
+  it("supports hundredth-percent cohorts with strict bounds", () => {
+    const selected = parseDependencyArtifactRolloutConfig({
+      mode: "prefer",
+      rolloutPercent: "45.04",
+    });
+    const notSelected = parseDependencyArtifactRolloutConfig({
+      mode: "prefer",
+      rolloutPercent: "45.03",
+    });
+
+    assertEquals(selected.rolloutBasisPoints, 4504);
+    assertEquals(resolveDependencyArtifactMode("project-alpha", selected), "prefer");
+    assertEquals(resolveDependencyArtifactMode("project-alpha", selected), "prefer");
+    assertEquals(resolveDependencyArtifactMode("project-alpha", notSelected), "off");
+
+    for (const rolloutPercent of ["-1", "100.01", "1.234", "1e2", "NaN"]) {
+      assertEquals(
+        parseDependencyArtifactRolloutConfig({ mode: "require", rolloutPercent })
+          .rolloutBasisPoints,
+        0,
+      );
+    }
+  });
+
+  it("never selects a request without a project identity", () => {
+    const config = parseDependencyArtifactRolloutConfig({
+      mode: "require",
+      rolloutPercent: "100",
+    });
+
+    assertEquals(resolveDependencyArtifactMode(undefined, config), "off");
+    assertEquals(resolveDependencyArtifactMode(null, config), "off");
+    assertEquals(resolveDependencyArtifactMode("", config), "off");
+  });
+});

--- a/src/release-assets/dependency-artifact-mode.ts
+++ b/src/release-assets/dependency-artifact-mode.ts
@@ -1,0 +1,114 @@
+import { hashString } from "#veryfront/cache/hash.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+
+export const DEPENDENCY_ARTIFACT_MODE_ENV = "VERYFRONT_DEPENDENCY_ARTIFACT_MODE";
+export const DEPENDENCY_ARTIFACT_ROLLOUT_PERCENT_ENV =
+  "VERYFRONT_DEPENDENCY_ARTIFACT_ROLLOUT_PERCENT";
+export const DEPENDENCY_ARTIFACT_PROJECTS_ENV = "VERYFRONT_DEPENDENCY_ARTIFACT_PROJECTS";
+
+export type DependencyArtifactMode = "off" | "shadow" | "prefer" | "require";
+
+export interface DependencyArtifactRolloutInput {
+  readonly mode?: string;
+  readonly rolloutPercent?: string;
+  readonly projectAllowlist?: string;
+}
+
+export interface DependencyArtifactRolloutConfig {
+  readonly mode: DependencyArtifactMode;
+  readonly rolloutBasisPoints: number;
+  readonly projectAllowlist: readonly string[];
+}
+
+const VALID_MODES = new Set<DependencyArtifactMode>([
+  "off",
+  "shadow",
+  "prefer",
+  "require",
+]);
+const ROLLOUT_BUCKETS = 10_000;
+const PERCENT_RE = /^(?:100(?:\.0{1,2})?|(?:0|[1-9]\d?)(?:\.\d{1,2})?)$/;
+
+function parseMode(value: string | undefined): DependencyArtifactMode {
+  const normalized = value?.trim().toLowerCase();
+  return normalized && VALID_MODES.has(normalized as DependencyArtifactMode)
+    ? normalized as DependencyArtifactMode
+    : "off";
+}
+
+function parseRolloutBasisPoints(value: string | undefined): number {
+  const normalized = value?.trim();
+  if (!normalized || !PERCENT_RE.test(normalized)) return 0;
+  return Math.round(Number(normalized) * 100);
+}
+
+function parseProjectAllowlist(value: string | undefined): readonly string[] {
+  if (!value) return [];
+  return [...new Set(value.split(",").map((projectId) => projectId.trim()).filter(Boolean))];
+}
+
+function base36ToBigInt(value: string): bigint {
+  let result = 0n;
+  for (const character of value) {
+    result = result * 36n + BigInt(Number.parseInt(character, 36));
+  }
+  return result;
+}
+
+/**
+ * Parse rollout settings without activating behavior. Invalid or absent modes
+ * collapse to an empty, off configuration so later callers cannot accidentally
+ * select a cohort from stale percentage or allowlist values.
+ */
+export function parseDependencyArtifactRolloutConfig(
+  input: DependencyArtifactRolloutInput,
+): DependencyArtifactRolloutConfig {
+  const mode = parseMode(input.mode);
+  if (mode === "off") {
+    return { mode, rolloutBasisPoints: 0, projectAllowlist: [] };
+  }
+
+  return {
+    mode,
+    rolloutBasisPoints: parseRolloutBasisPoints(input.rolloutPercent),
+    projectAllowlist: parseProjectAllowlist(input.projectAllowlist),
+  };
+}
+
+/** Stable 0..9999 cohort bucket. The domain prefix isolates this rollout. */
+function dependencyArtifactProjectBucket(projectId: string): number {
+  const hash = hashString(`dependency-artifact-rollout:${projectId}`);
+  return Number(base36ToBigInt(hash) % BigInt(ROLLOUT_BUCKETS));
+}
+
+/**
+ * Resolve the effective mode for a project. Explicit project selection and the
+ * deterministic percentage cohort form a union. Missing project identity fails
+ * closed so global or framework-only requests cannot enter a rollout.
+ */
+export function resolveDependencyArtifactMode(
+  projectId: string | null | undefined,
+  config: DependencyArtifactRolloutConfig,
+): DependencyArtifactMode {
+  if (config.mode === "off" || !projectId) return "off";
+  if (config.projectAllowlist.includes(projectId)) return config.mode;
+  return dependencyArtifactProjectBucket(projectId) < config.rolloutBasisPoints
+    ? config.mode
+    : "off";
+}
+
+/** Read host-owned rollout configuration once at the future request setup seam. */
+export function readDependencyArtifactRolloutConfig(): DependencyArtifactRolloutConfig {
+  return parseDependencyArtifactRolloutConfig({
+    mode: getHostEnv(DEPENDENCY_ARTIFACT_MODE_ENV),
+    rolloutPercent: getHostEnv(DEPENDENCY_ARTIFACT_ROLLOUT_PERCENT_ENV),
+    projectAllowlist: getHostEnv(DEPENDENCY_ARTIFACT_PROJECTS_ENV),
+  });
+}
+
+/** Small external interface for callers that do not need the parsed config. */
+export function getDependencyArtifactModeForProject(
+  projectId: string | null | undefined,
+): DependencyArtifactMode {
+  return resolveDependencyArtifactMode(projectId, readDependencyArtifactRolloutConfig());
+}

--- a/src/transforms/import-rewriter/strategies/bare-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/bare-strategy.test.ts
@@ -266,6 +266,31 @@ describe("BareStrategy", () => {
       assertEquals(after.specifier, before.specifier);
     });
 
+    it("keeps an unchanged draft byte-identical with exact dependency pins", async () => {
+      const context = makeCtx({
+        target: "browser",
+        dependencyPinningCacheKey: "on:snapshot-exact",
+        dependencyPinningDependencies: { lodash: "4.17.21" },
+      });
+      const source = [
+        `import lodash from "lodash";`,
+        `import debounce from "lodash/debounce";`,
+      ].join("\n");
+
+      const first = await rewriteImports(source, context);
+      const second = await rewriteImports(source, context);
+
+      assertEquals(second, first);
+      assertEquals(
+        first,
+        [
+          `import lodash from "https://esm.sh/lodash@4.17.21?external=react,react-dom&target=es2022";`,
+          `import debounce from "https://esm.sh/lodash@4.17.21/debounce?external=react,react-dom&target=es2022";`,
+        ].join("\n"),
+      );
+      assertEquals(first.includes("https://esm.sh/lodash?"), false);
+    });
+
     it("falls back to unversioned URL when both caches are cold", async () => {
       // No package.json cache, no npm registry cache — must behave like flag-off.
       const result = bareStrategy.rewrite(makeInfo("lodash"), makeCtx({ target: "browser" }));


### PR DESCRIPTION
## Description

Release 0 establishes the internal rollout policy needed before dependency artifacts can affect serving.

- Parse `off`, `shadow`, `prefer`, and `require` in one internal module.
- Default invalid or absent configuration to `off`.
- Select projects through an explicit allowlist or a deterministic basis-point cohort.
- Fail closed when project identity is missing.
- Keep the raw bucket calculation private so callers depend only on policy.
- Lock unchanged-draft exact-pin output as byte-identical across repeated rewrites.

This slice is intentionally inert. It does not change serving, enqueue work, fetch dependencies, or perform network I/O. Future HTTP handlers remain adapters over durable coordination; dependency fetching and graph building stay in the worker plane.

## Related Issue(s)

Related to https://github.com/veryfront/veryfront-issue-inbox/issues/240

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Verification

- `deno test --no-check --allow-all src/release-assets/dependency-artifact-mode.test.ts src/transforms/import-rewriter/strategies/bare-strategy.test.ts`: 56 steps passed.
- Focused rendering and snapshot matrix: 204 steps passed.
- `deno check`, `deno fmt --check`, `deno lint`, `git diff --check`: passed.
- Barrel JSDoc, wildcard export, module boundary, dependency boundary, and generated-manifest checks: passed.
- The aggregate pre-push suite reported 2,858 passing tests and 13 unrelated shared auth/env/fetch-state failures. All affected files pass when isolated: 31 suites, 284 steps, zero failures. The hook left no generated diff.

## Checklist

- [x] Documentation is not applicable because the module is internal and serving remains unchanged.
- [x] I have added tests that prove the rollout defaults fail closed and current exact-pin output remains stable.