### PR TITLE
refactor(core): land dependency-free runtime foundations

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -36,9 +36,10 @@ cli/
 ├── utils/               # General utilities
 ├── help/                # Command definitions, help formatting
 ├── discovery/           # User project file discovery (tools, agents)
-├── templates/           # Project and integration templates
-└── test-utils/          # VCR testing utilities
+└── templates/           # Project and integration templates
 ```
+
+CLI integration-test support lives outside the shipped package under `tests/support/`.
 
 ## Commands
 

--- a/cli/commands/deploy/deploy.integration.test.ts
+++ b/cli/commands/deploy/deploy.integration.test.ts
@@ -11,7 +11,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterAll, beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
-import { initVCRTest, isRecording, type VCRTestContext } from "../../test-utils/vcr.ts";
+import { initVCRTest, isRecording, type VCRTestContext } from "../../../tests/support/cli-vcr.ts";
 import {
   createHttpDeployControlPlane,
   type DeployControlPlane,

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -2,7 +2,7 @@
  * Eval command - Discover and run eval definitions from the evals/ directory.
  */
 
-import { dirname, isAbsolute, relative, resolve } from "@std/path";
+import { dirname, isAbsolute, relative, resolve } from "veryfront/platform/path";
 import type { Agent, AgentResponse } from "veryfront/agent";
 import type { VeryfrontConfig } from "veryfront/config";
 import {

--- a/cli/commands/generate/integration-generator.ts
+++ b/cli/commands/generate/integration-generator.ts
@@ -5,7 +5,7 @@
  * Creates connector.json, API client, OAuth routes, token store, and tool skeletons.
  */
 
-import { join } from "#std/path.ts";
+import { join } from "veryfront/platform/path";
 import { bold, brand, dim } from "#cli/ui";
 import { cliLogger } from "#cli/utils";
 import { createFileSystem, type FileSystem } from "veryfront/platform";

--- a/cli/commands/merge/merge.integration.test.ts
+++ b/cli/commands/merge/merge.integration.test.ts
@@ -11,7 +11,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterAll, beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
-import { initVCRTest, isRecording, type VCRTestContext } from "../../test-utils/vcr.ts";
+import { initVCRTest, isRecording, type VCRTestContext } from "../../../tests/support/cli-vcr.ts";
 import { getBranchByName } from "./index.ts";
 
 describe("merge command integration", () => {

--- a/cli/commands/pull/pull.integration.test.ts
+++ b/cli/commands/pull/pull.integration.test.ts
@@ -11,7 +11,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterAll, beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
-import { initVCRTest, type VCRTestContext } from "../../test-utils/vcr.ts";
+import { initVCRTest, type VCRTestContext } from "../../../tests/support/cli-vcr.ts";
 import { getFileContent, listAllFiles, type PullSource } from "./command.ts";
 
 describe("pull command integration", () => {

--- a/cli/commands/push/push.integration.test.ts
+++ b/cli/commands/push/push.integration.test.ts
@@ -11,7 +11,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertExists } from "#veryfront/testing/assert.ts";
 import { afterAll, beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
-import { initVCRTest, isRecording, type VCRTestContext } from "../../test-utils/vcr.ts";
+import { initVCRTest, isRecording, type VCRTestContext } from "../../../tests/support/cli-vcr.ts";
 import { createBranch } from "./command.ts";
 
 describe("push command integration", () => {

--- a/cli/commands/routes/command.ts
+++ b/cli/commands/routes/command.ts
@@ -1,4 +1,4 @@
-import { join, relative } from "#std/path.ts";
+import { join, relative } from "veryfront/platform/path";
 import { runtime } from "veryfront/platform";
 import { getConfig } from "veryfront/config";
 import { cliLogger } from "#cli/utils";

--- a/cli/commands/skills/create.ts
+++ b/cli/commands/skills/create.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ParsedArgs } from "#cli/shared/types";
-import { relative } from "#std/path.ts";
+import { relative } from "veryfront/platform/path";
 import { createSuccessEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
 import { exitProcess, logSuccess, logUsageError } from "#cli/utils";
 import { scaffoldProjectFile } from "../../scaffold/engine.ts";

--- a/cli/commands/skills/validate.ts
+++ b/cli/commands/skills/validate.ts
@@ -8,7 +8,7 @@ import type { ParsedArgs } from "#cli/shared/types";
 import { createSuccessEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
 import { exitProcess, logError, logSuccess, logWarning } from "#cli/utils";
 import { createFileSystem } from "veryfront/platform";
-import { basename, resolve } from "#std/path.ts";
+import { basename, resolve } from "veryfront/platform/path";
 import { parseSkillFrontmatter, SKILL_NAME_REGEX, validateSkillMetadata } from "veryfront/skill";
 
 interface ValidationIssue {

--- a/cli/scaffold/engine.ts
+++ b/cli/scaffold/engine.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from "#std/path.ts";
+import { dirname, join } from "veryfront/platform/path";
 import { createFileSystem } from "veryfront/platform";
 import { ensureDir, fileExists } from "../utils/fs.ts";
 import { toComponentName, toSlug } from "../utils/string.ts";

--- a/cli/skills/loader.ts
+++ b/cli/skills/loader.ts
@@ -1,6 +1,6 @@
 import { createFileSystem } from "veryfront/platform";
 import { cwd } from "veryfront/platform";
-import { basename } from "#std/path.ts";
+import { basename } from "veryfront/platform/path";
 import { parseSkillFrontmatter, validateSkillMetadata } from "veryfront/skill";
 import type { LoadedSkill } from "./types.ts";
 import { CORE_SKILLS } from "./core-skills.ts";

--- a/src/eval/datasets.ts
+++ b/src/eval/datasets.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, join } from "@std/path";
+import { isAbsolute, join } from "veryfront/platform/path";
 import type { EvalDataset, EvalExampleInput } from "./types.ts";
 import { createEvalValidationError, normalizeEvalExamples } from "./validation.ts";
 

--- a/src/eval/datasets.ts
+++ b/src/eval/datasets.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, join } from "veryfront/platform/path";
+import { isAbsolute, join } from "#veryfront/compat/path";
 import type { EvalDataset, EvalExampleInput } from "./types.ts";
 import { createEvalValidationError, normalizeEvalExamples } from "./validation.ts";
 

--- a/src/eval/discovery.ts
+++ b/src/eval/discovery.ts
@@ -2,7 +2,7 @@
  * Eval discovery for project-local eval definitions.
  */
 
-import { join } from "veryfront/platform/path";
+import { join } from "#veryfront/compat/path";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { RuntimeAdapter } from "#veryfront/platform";
 import { importDiscoveryModule } from "#veryfront/discovery/module-import.ts";

--- a/src/eval/discovery.ts
+++ b/src/eval/discovery.ts
@@ -2,7 +2,7 @@
  * Eval discovery for project-local eval definitions.
  */
 
-import { join } from "@std/path";
+import { join } from "veryfront/platform/path";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { RuntimeAdapter } from "#veryfront/platform";
 import { importDiscoveryModule } from "#veryfront/discovery/module-import.ts";

--- a/src/eval/provenance.ts
+++ b/src/eval/provenance.ts
@@ -1,4 +1,4 @@
-import { join } from "@std/path";
+import { join } from "veryfront/platform/path";
 import { computeHash, computeHashBytes } from "#veryfront/utils";
 import { VERSION } from "#veryfront/utils/version-constant.ts";
 import type { EvalRunProvenance } from "./types.ts";

--- a/src/eval/provenance.ts
+++ b/src/eval/provenance.ts
@@ -1,4 +1,4 @@
-import { join } from "veryfront/platform/path";
+import { join } from "#veryfront/compat/path";
 import { computeHash, computeHashBytes } from "#veryfront/utils";
 import { VERSION } from "#veryfront/utils/version-constant.ts";
 import type { EvalRunProvenance } from "./types.ts";

--- a/src/eval/run-report.ts
+++ b/src/eval/run-report.ts
@@ -1,4 +1,4 @@
-import { join, relative } from "veryfront/platform/path";
+import { join, relative } from "#veryfront/compat/path";
 import { compareEvalReports } from "./baseline.ts";
 import type { DiscoveredEval } from "./discovery.ts";
 import { compareEvalModelReports, createEvalModelComparisonMarkdown } from "./model-comparison.ts";

--- a/src/eval/run-report.ts
+++ b/src/eval/run-report.ts
@@ -1,4 +1,4 @@
-import { join, relative } from "@std/path";
+import { join, relative } from "veryfront/platform/path";
 import { compareEvalReports } from "./baseline.ts";
 import type { DiscoveredEval } from "./discovery.ts";
 import { compareEvalModelReports, createEvalModelComparisonMarkdown } from "./model-comparison.ts";

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -7,7 +7,7 @@
  * @module extensions/discovery
  */
 
-import { join } from "veryfront/platform/path";
+import { join } from "#veryfront/compat/path";
 import type { Capability, PackageContractMetadata, ResolvedExtension } from "./types.ts";
 
 /**

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -7,7 +7,7 @@
  * @module extensions/discovery
  */
 
-import { join } from "@std/path";
+import { join } from "veryfront/platform/path";
 import type { Capability, PackageContractMetadata, ResolvedExtension } from "./types.ts";
 
 /**

--- a/src/extensions/factory-loader.ts
+++ b/src/extensions/factory-loader.ts
@@ -7,7 +7,7 @@
  * @module extensions/factory-loader
  */
 
-import { isAbsolute, toFileUrl } from "veryfront/platform/path";
+import { isAbsolute, toFileUrl } from "#veryfront/compat/path";
 import { EXTENSION_VALIDATION_ERROR } from "./errors.ts";
 import type { Extension, ExtensionFactory, ExtensionSource, ResolvedExtension } from "./types.ts";
 

--- a/src/extensions/factory-loader.ts
+++ b/src/extensions/factory-loader.ts
@@ -7,7 +7,7 @@
  * @module extensions/factory-loader
  */
 
-import { isAbsolute, toFileUrl } from "@std/path";
+import { isAbsolute, toFileUrl } from "veryfront/platform/path";
 import { EXTENSION_VALIDATION_ERROR } from "./errors.ts";
 import type { Extension, ExtensionFactory, ExtensionSource, ResolvedExtension } from "./types.ts";
 

--- a/src/extensions/orchestrate.ts
+++ b/src/extensions/orchestrate.ts
@@ -8,7 +8,7 @@
  * @module extensions/orchestrate
  */
 
-import { basename, dirname } from "@std/path";
+import { basename, dirname } from "veryfront/platform/path";
 import * as defaultDiscovery from "./discovery.ts";
 import { loadExtensionFactory as defaultLoadFactory } from "./factory-loader.ts";
 import { ExtensionLoader } from "./loader.ts";

--- a/src/extensions/orchestrate.ts
+++ b/src/extensions/orchestrate.ts
@@ -8,7 +8,7 @@
  * @module extensions/orchestrate
  */
 
-import { basename, dirname } from "veryfront/platform/path";
+import { basename, dirname } from "#veryfront/compat/path";
 import * as defaultDiscovery from "./discovery.ts";
 import { loadExtensionFactory as defaultLoadFactory } from "./factory-loader.ts";
 import { ExtensionLoader } from "./loader.ts";

--- a/src/platform/compat/console/deno.ts
+++ b/src/platform/compat/console/deno.ts
@@ -1,20 +1,25 @@
-import {
-  blue,
-  bold,
-  cyan,
-  dim,
-  gray,
-  green,
-  italic,
-  magenta,
-  red,
-  reset,
-  strikethrough,
-  underline,
-  white,
-  yellow,
-} from "#std/fmt/colors.ts";
-import type { ConsoleStyler } from "./types.ts";
+import * as ansi from "../std/fmt-colors.ts";
+import { getDenoRuntime } from "../runtime.ts";
+import type { ColorFunction, ConsoleStyler } from "./types.ts";
+
+const identity: ColorFunction = (text) => text;
+const color = (style: ColorFunction): ColorFunction =>
+  getDenoRuntime()?.noColor === true ? identity : style;
+
+export const red = color(ansi.red);
+export const green = color(ansi.green);
+export const yellow = color(ansi.yellow);
+export const blue = color(ansi.blue);
+export const cyan = color(ansi.cyan);
+export const magenta = color(ansi.magenta);
+export const white = color(ansi.white);
+export const gray = color(ansi.gray);
+export const bold = color(ansi.bold);
+export const dim = color(ansi.dim);
+export const italic = color(ansi.italic);
+export const underline = color(ansi.underline);
+export const strikethrough = color(ansi.strikethrough);
+export const reset = color(ansi.reset);
 
 export const colors: ConsoleStyler = {
   red,
@@ -31,21 +36,4 @@ export const colors: ConsoleStyler = {
   underline,
   strikethrough,
   reset,
-};
-
-export {
-  blue,
-  bold,
-  cyan,
-  dim,
-  gray,
-  green,
-  italic,
-  magenta,
-  red,
-  reset,
-  strikethrough,
-  underline,
-  white,
-  yellow,
 };

--- a/src/platform/compat/console/index.ts
+++ b/src/platform/compat/console/index.ts
@@ -1,58 +1,22 @@
 /**
  * Cross-runtime console styling
  *
- * Provides terminal colors that work in Deno, Node.js, and Bun.
- * Falls back to no-op functions in environments without terminal support.
+ * Provides terminal colors in Deno. Node.js and Bun use identity styling
+ * because the logging layer owns color policy and TTY detection there.
  */
 
 import { isDeno } from "../runtime.ts";
+import { colors as denoColors } from "./deno.ts";
+import { colors as nodeColors } from "./node.ts";
 import type { ColorFunction, ConsoleStyler } from "./types.ts";
 
 export type { ColorFunction, ConsoleStyler } from "./types.ts";
 
-const noOp: ColorFunction = (text: string) => text;
-
-const fallbackColors: ConsoleStyler = {
-  red: noOp,
-  green: noOp,
-  yellow: noOp,
-  blue: noOp,
-  cyan: noOp,
-  magenta: noOp,
-  white: noOp,
-  gray: noOp,
-  bold: noOp,
-  dim: noOp,
-  italic: noOp,
-  underline: noOp,
-  strikethrough: noOp,
-  reset: noOp,
-};
-
-let _colors: ConsoleStyler | null = null;
-
-async function loadColors(): Promise<ConsoleStyler> {
-  if (_colors) return _colors;
-
-  try {
-    const mod = await (isDeno ? import("./deno.ts") : import("./node.ts"));
-    _colors = mod.colors;
-  } catch (_) {
-    /* expected: color module may not be available in all runtimes */
-    _colors = fallbackColors;
-  }
-
-  return _colors;
-}
-
-const colorsPromise = loadColors();
-
-function getColors(): ConsoleStyler {
-  return _colors ?? fallbackColors;
-}
+const runtimeColors: ConsoleStyler = isDeno ? denoColors : nodeColors;
+const colorsPromise = Promise.resolve(runtimeColors);
 
 function makeColor(getter: (c: ConsoleStyler) => ColorFunction): ColorFunction {
-  return (text: string) => getter(getColors())(text);
+  return (text: string) => getter(runtimeColors)(text);
 }
 
 export const red: ColorFunction = makeColor((c) => c.red);

--- a/src/platform/compat/console/node.test.ts
+++ b/src/platform/compat/console/node.test.ts
@@ -1,0 +1,13 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { colors } from "./node.ts";
+
+describe("platform/compat/console/node", () => {
+  it("keeps every style neutral", () => {
+    const input = "plain text";
+    for (const style of Object.values(colors)) {
+      assertEquals(style(input), input);
+    }
+  });
+});

--- a/src/platform/compat/console/node.ts
+++ b/src/platform/compat/console/node.ts
@@ -1,46 +1,29 @@
-import type { ConsoleStyler } from "./types.ts";
+import type { ColorFunction, ConsoleStyler } from "./types.ts";
 
-type PicoColors = {
-  red: (s: string) => string;
-  green: (s: string) => string;
-  yellow: (s: string) => string;
-  blue: (s: string) => string;
-  cyan: (s: string) => string;
-  magenta: (s: string) => string;
-  white: (s: string) => string;
-  gray: (s: string) => string;
-  bold: (s: string) => string;
-  dim: (s: string) => string;
-  italic: (s: string) => string;
-  underline: (s: string) => string;
-  strikethrough: (s: string) => string;
-  reset: (s: string) => string;
-};
-
-// NOTE: pc is null because lazy initialization was removed as dead code.
-// Colors on Node.js currently fall through to identity (no-op).
-// The console/index.ts fallback colors and ANSI module handle the actual coloring.
-const pc: PicoColors | null = null;
-
-function lazyColor(fn: keyof PicoColors): (s: string) => string {
-  return (s: string) => pc?.[fn]?.(s) ?? s;
-}
+/**
+ * Node styling is intentionally identity-only.
+ *
+ * Veryfront's logging layer owns color policy and TTY detection. Keeping this
+ * compatibility module neutral prevents escape codes from leaking into pipes,
+ * JSON logs, and test output.
+ */
+const identity: ColorFunction = (text: string) => text;
 
 export const colors: ConsoleStyler = {
-  red: lazyColor("red"),
-  green: lazyColor("green"),
-  yellow: lazyColor("yellow"),
-  blue: lazyColor("blue"),
-  cyan: lazyColor("cyan"),
-  magenta: lazyColor("magenta"),
-  white: lazyColor("white"),
-  gray: lazyColor("gray"),
-  bold: lazyColor("bold"),
-  dim: lazyColor("dim"),
-  italic: lazyColor("italic"),
-  underline: lazyColor("underline"),
-  strikethrough: lazyColor("strikethrough"),
-  reset: lazyColor("reset"),
+  red: identity,
+  green: identity,
+  yellow: identity,
+  blue: identity,
+  cyan: identity,
+  magenta: identity,
+  white: identity,
+  gray: identity,
+  bold: identity,
+  dim: identity,
+  italic: identity,
+  underline: identity,
+  strikethrough: identity,
+  reset: identity,
 };
 
 export const {

--- a/src/platform/compat/path/basic-operations.test.ts
+++ b/src/platform/compat/path/basic-operations.test.ts
@@ -17,6 +17,10 @@ describe("platform/compat/path/basic-operations", () => {
       assertEquals(join("a/", "/b"), "a/b");
     });
 
+    it("normalizes dot and parent segments", () => {
+      assertEquals(join("a", ".", "b", "..", "c"), "a/c");
+    });
+
     it("should skip empty strings", () => {
       assertEquals(join("a", "", "b"), "a/b");
     });
@@ -41,6 +45,10 @@ describe("platform/compat/path/basic-operations", () => {
 
     it("should handle Windows backslash paths", () => {
       assertEquals(dirname("D:\\a\\project\\src\\file.ts"), "D:/a/project/src");
+    });
+
+    it("preserves a Windows drive root", () => {
+      assertEquals(dirname("D:\\file.ts"), "D:/");
     });
   });
 

--- a/src/platform/compat/path/basic-operations.test.ts
+++ b/src/platform/compat/path/basic-operations.test.ts
@@ -25,6 +25,17 @@ describe("platform/compat/path/basic-operations", () => {
       assertEquals(join("a", "", "b"), "a/b");
     });
 
+    it("removes trailing separators from non-root paths", () => {
+      assertEquals(join("uploads/"), "uploads");
+      assertEquals(join("a", "b/"), "a/b");
+    });
+
+    it("preserves filesystem roots", () => {
+      assertEquals(join("/"), "/");
+      assertEquals(join("D:\\"), "D:/");
+      assertEquals(join("\\\\server\\share\\"), "//server/share/");
+    });
+
     it("should return / for no valid segments", () => {
       assertEquals(join(""), "/");
     });

--- a/src/platform/compat/path/basic-operations.ts
+++ b/src/platform/compat/path/basic-operations.ts
@@ -4,6 +4,7 @@ import {
   portableDirname,
   portableExtname,
   portableJoin,
+  removeTrailingSeparatorsExceptRoot,
   runtimeUsesWindowsPaths,
   toPortableSeparators,
 } from "./portable.ts";
@@ -18,7 +19,10 @@ export function join(...paths: string[]): string {
   if (paths.every((path) => path.length === 0)) return "/";
   const windows = usesWindowsFlavor(paths);
   const pathApi = getNativePathImplementation(windows);
-  return pathApi ? toPortableSeparators(pathApi.join(...paths)) : portableJoin(paths, windows);
+  const joined = pathApi
+    ? toPortableSeparators(pathApi.join(...paths))
+    : portableJoin(paths, windows);
+  return removeTrailingSeparatorsExceptRoot(joined, windows);
 }
 
 /** Return the parent directory path. */

--- a/src/platform/compat/path/basic-operations.ts
+++ b/src/platform/compat/path/basic-operations.ts
@@ -1,63 +1,44 @@
-import { isDeno, nodePath } from "./runtime.ts";
+import {
+  hasWindowsLikePath,
+  portableBasename,
+  portableDirname,
+  portableExtname,
+  portableJoin,
+  runtimeUsesWindowsPaths,
+  toPortableSeparators,
+} from "./portable.ts";
+import { getNativePathImplementation } from "./runtime.ts";
 
-function hasWindowsLikePath(path: string): boolean {
-  return path.includes("\\") || /^[A-Za-z]:/.test(path) || path.startsWith("\\\\");
+function usesWindowsFlavor(paths: readonly string[]): boolean {
+  return runtimeUsesWindowsPaths() || paths.some(hasWindowsLikePath);
 }
 
-/** Normalize backslashes to forward slashes (for Deno on Windows). */
-function normSep(p: string): string {
-  return p.includes("\\") ? p.replace(/\\/g, "/") : p;
-}
-
-/** Join path segments. */
+/** Join and normalize path segments using their detected path flavor. */
 export function join(...paths: string[]): string {
-  const joined = paths
-    .map(normSep)
-    .filter((p) => p.length > 0)
-    .join("/")
-    .replace(/\/+/g, "/")
-    .replace(/\/$/, "");
-
-  return joined || "/";
+  if (paths.every((path) => path.length === 0)) return "/";
+  const windows = usesWindowsFlavor(paths);
+  const pathApi = getNativePathImplementation(windows);
+  return pathApi ? toPortableSeparators(pathApi.join(...paths)) : portableJoin(paths, windows);
 }
 
 /** Return the parent directory path. */
 export function dirname(path: string): string {
-  if (!isDeno && nodePath && !hasWindowsLikePath(path)) return nodePath.dirname(path);
-
-  const p = normSep(path);
-  const lastSlash = p.lastIndexOf("/");
-  if (lastSlash === -1) return ".";
-  if (lastSlash === 0) return "/";
-  return p.slice(0, lastSlash);
+  const windows = usesWindowsFlavor([path]);
+  const pathApi = getNativePathImplementation(windows);
+  return pathApi ? toPortableSeparators(pathApi.dirname(path)) : portableDirname(path, windows);
 }
 
 /** Return the last path segment. */
 export function basename(path: string, ext?: string): string {
-  if (!isDeno && nodePath && !hasWindowsLikePath(path)) {
-    // Only pass ext if defined - Bun is strict about this parameter
-    return ext === undefined ? nodePath.basename(path) : nodePath.basename(path, ext);
-  }
-
-  let normalizedPath = normSep(path);
-  while (normalizedPath.length > 1 && normalizedPath.endsWith("/")) {
-    normalizedPath = normalizedPath.slice(0, -1);
-  }
-
-  const lastSlash = normalizedPath.lastIndexOf("/");
-  let base = lastSlash === -1 ? normalizedPath : normalizedPath.slice(lastSlash + 1);
-
-  if (ext && base.endsWith(ext)) base = base.slice(0, -ext.length);
-
-  return base;
+  const windows = usesWindowsFlavor([path]);
+  const pathApi = getNativePathImplementation(windows);
+  if (!pathApi) return portableBasename(path, ext, windows);
+  return ext === undefined ? pathApi.basename(path) : pathApi.basename(path, ext);
 }
 
 /** Return the file extension for a path. */
 export function extname(path: string): string {
-  if (!isDeno && nodePath && !hasWindowsLikePath(path)) return nodePath.extname(path);
-
-  const base = basename(path);
-  const lastDot = base.lastIndexOf(".");
-  if (lastDot <= 0) return "";
-  return base.slice(lastDot);
+  const windows = usesWindowsFlavor([path]);
+  const pathApi = getNativePathImplementation(windows);
+  return pathApi?.extname(path) ?? portableExtname(path, windows);
 }

--- a/src/platform/compat/path/index.test.ts
+++ b/src/platform/compat/path/index.test.ts
@@ -123,6 +123,10 @@ describe("compat/path/index.ts exports", () => {
       assertEquals(posix.relative("/project/src", "/project/src"), "");
       assertEquals(posix.relative("/project/src", "/project/tests/unit"), "../tests/unit");
       assertEquals(posix.dirname("//server/file.ts"), "//server");
+      assertEquals(posix.basename("/x.y", "x.y"), "x.y");
+      assertEquals(posix.basename("x.y", "x.y"), "");
+      assertEquals(posix.basename("x.y/", "x.y"), "x.y");
+      assertEquals(posix.basename("/", "."), "/");
       assertEquals(posix.extname(".env"), "");
       assertEquals(posix.extname("archive.tar.gz"), ".gz");
     });

--- a/src/platform/compat/path/index.test.ts
+++ b/src/platform/compat/path/index.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   basename,
@@ -15,6 +15,7 @@ import {
   nodePath,
   normalize,
   parse,
+  posix,
   relative,
   resolve,
   sep,
@@ -110,6 +111,38 @@ describe("compat/path/index.ts exports", () => {
     it("isAbsolute should detect absolute paths", () => {
       assertEquals(isAbsolute("/absolute/path"), true);
       assertEquals(isAbsolute("relative/path"), false);
+    });
+  });
+
+  describe("dependency-free POSIX operations", () => {
+    it("matches POSIX path edge semantics", () => {
+      assertEquals(posix.join(), ".");
+      assertEquals(posix.join("", ""), ".");
+      assertEquals(posix.normalize("/src//pages/../index.ts/"), "/src/index.ts/");
+      assertEquals(posix.normalize("../../src/./index.ts"), "../../src/index.ts");
+      assertEquals(posix.relative("/project/src", "/project/src"), "");
+      assertEquals(posix.relative("/project/src", "/project/tests/unit"), "../tests/unit");
+      assertEquals(posix.dirname("//server/file.ts"), "//server");
+      assertEquals(posix.extname(".env"), "");
+      assertEquals(posix.extname("archive.tar.gz"), ".gz");
+    });
+
+    it("treats backslashes as ordinary POSIX filename characters", () => {
+      assertEquals(
+        posix.basename(String.raw`C:\\project\\file.ts`),
+        String.raw`C:\\project\\file.ts`,
+      );
+      assertEquals(posix.isAbsolute(String.raw`C:\\project\\file.ts`), false);
+      assertEquals(
+        posix.normalize(String.raw`C:\\project\\file.ts`),
+        String.raw`C:\\project\\file.ts`,
+      );
+    });
+
+    it("rejects non-string runtime inputs", () => {
+      assertThrows(() => posix.normalize(null as unknown as string), TypeError);
+      assertThrows(() => posix.join("src", 1 as unknown as string), TypeError);
+      assertThrows(() => posix.basename("file.ts", 1 as unknown as string), TypeError);
     });
   });
 

--- a/src/platform/compat/path/index.ts
+++ b/src/platform/compat/path/index.ts
@@ -11,5 +11,6 @@ export { delimiter, hasNodePath, isDeno, nodePath, sep, sep as SEPARATOR } from 
 export { basename, dirname, extname, join } from "./basic-operations.ts";
 export { isAbsolute, normalize, relative, resolve } from "./resolution.ts";
 export { format, parse } from "./parse-format.ts";
+export { posix, type PosixPath } from "./posix.ts";
 export { fromFileUrl, toFileUrl } from "./url-conversion.ts";
 export { validatePathSecurity } from "./security.ts";

--- a/src/platform/compat/path/parse-format.test.ts
+++ b/src/platform/compat/path/parse-format.test.ts
@@ -103,5 +103,28 @@ describe("platform/compat/path/parse-format", () => {
       assertEquals(ext, ".txt");
       // dir is "." on Deno, "" on Node/Bun — both valid
     });
+
+    it("parses Windows paths into portable components", () => {
+      assertEquals(parse("D:\\workspace\\src\\file.ts"), {
+        root: "D:/",
+        dir: "D:/workspace/src",
+        base: "file.ts",
+        ext: ".ts",
+        name: "file",
+      });
+    });
+
+    it("formats Windows path objects with portable separators", () => {
+      assertEquals(
+        format({
+          root: "D:/",
+          dir: "D:/workspace/src",
+          base: "file.ts",
+          ext: ".ts",
+          name: "file",
+        }),
+        "D:/workspace/src/file.ts",
+      );
+    });
   });
 });

--- a/src/platform/compat/path/parse-format.ts
+++ b/src/platform/compat/path/parse-format.ts
@@ -1,33 +1,41 @@
-import { isDeno, nodePath } from "./runtime.ts";
-import { basename, dirname, extname, join } from "./basic-operations.ts";
-import { isAbsolute } from "./resolution.ts";
 import type { PathObject } from "./types.ts";
+import {
+  hasWindowsLikePath,
+  portableFormat,
+  portableParse,
+  runtimeUsesWindowsPaths,
+  toPortableSeparators,
+} from "./portable.ts";
+import { getNativePathImplementation } from "./runtime.ts";
 
 export function parse(path: string): PathObject {
-  if (!isDeno && nodePath) {
-    return nodePath.parse(path);
-  }
+  const windows = runtimeUsesWindowsPaths() || hasWindowsLikePath(path);
+  const pathApi = getNativePathImplementation(windows);
+  if (!pathApi) return portableParse(path, windows);
 
-  const dir = dirname(path);
-  const base = basename(path);
-  const ext = extname(path);
-
+  const parsed = pathApi.parse(path);
   return {
-    root: isAbsolute(path) ? "/" : "",
-    dir,
-    base,
-    ext,
-    name: base.slice(0, base.length - ext.length),
+    root: toPortableSeparators(parsed.root ?? ""),
+    dir: toPortableSeparators(parsed.dir ?? ""),
+    base: parsed.base ?? "",
+    ext: parsed.ext ?? "",
+    name: parsed.name ?? "",
   };
 }
 
 export function format(pathObject: PathObject): string {
-  if (!isDeno && nodePath) {
-    return nodePath.format(pathObject);
-  }
+  const windows = runtimeUsesWindowsPaths() ||
+    hasWindowsLikePath(pathObject.root ?? "") ||
+    hasWindowsLikePath(pathObject.dir ?? "");
+  const pathApi = getNativePathImplementation(windows);
+  if (!pathApi) return portableFormat(pathObject, windows);
 
-  const { dir = "", base = "", name = "", ext = "" } = pathObject;
-
-  const fileName = base || name + ext;
-  return dir ? join(dir, fileName) : fileName;
+  const formatted = pathApi.format({
+    root: pathObject.root ?? "",
+    dir: pathObject.dir ?? "",
+    base: pathObject.base ?? "",
+    ext: pathObject.ext ?? "",
+    name: pathObject.name ?? "",
+  });
+  return toPortableSeparators(formatted);
 }

--- a/src/platform/compat/path/portable.test.ts
+++ b/src/platform/compat/path/portable.test.ts
@@ -17,7 +17,8 @@ import {
 
 describe("platform/compat/path/portable", () => {
   it("distinguishes UNC paths from redundant POSIX roots", () => {
-    assertEquals(hasWindowsLikePath("//server/share/file.ts"), true);
+    assertEquals(hasWindowsLikePath("//server/share/file.ts"), false);
+    assertEquals(hasWindowsLikePath(String.raw`\\server\share\file.ts`), true);
     assertEquals(hasWindowsLikePath("///tmp/file.ts"), false);
     assertEquals(hasWindowsLikePath("////tmp/file.ts"), false);
     assertEquals(portableNormalize("///tmp/file.ts", true), "/tmp/file.ts");

--- a/src/platform/compat/path/portable.test.ts
+++ b/src/platform/compat/path/portable.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  hasWindowsLikePath,
   portableBasename,
   portableDirname,
   portableExtname,
@@ -15,6 +16,13 @@ import {
 } from "./portable.ts";
 
 describe("platform/compat/path/portable", () => {
+  it("distinguishes UNC paths from redundant POSIX roots", () => {
+    assertEquals(hasWindowsLikePath("//server/share/file.ts"), true);
+    assertEquals(hasWindowsLikePath("///tmp/file.ts"), false);
+    assertEquals(hasWindowsLikePath("////tmp/file.ts"), false);
+    assertEquals(portableNormalize("///tmp/file.ts", true), "/tmp/file.ts");
+  });
+
   it("normalizes POSIX joins without a native path module", () => {
     assertEquals(
       portableJoin(["/workspace", ".", "src", "..", "test"], false),

--- a/src/platform/compat/path/portable.test.ts
+++ b/src/platform/compat/path/portable.test.ts
@@ -1,0 +1,104 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  portableBasename,
+  portableDirname,
+  portableExtname,
+  portableFormat,
+  portableIsAbsolute,
+  portableJoin,
+  portableNormalize,
+  portableParse,
+  portableRelative,
+  portableResolve,
+} from "./portable.ts";
+
+describe("platform/compat/path/portable", () => {
+  it("normalizes POSIX joins without a native path module", () => {
+    assertEquals(
+      portableJoin(["/workspace", ".", "src", "..", "test"], false),
+      "/workspace/test",
+    );
+    assertEquals(portableJoin([""], false), "/");
+  });
+
+  it("preserves Windows drive and UNC roots", () => {
+    assertEquals(
+      portableNormalize("D:\\workspace\\src\\..\\test", true),
+      "D:/workspace/test",
+    );
+    assertEquals(
+      portableNormalize("\\\\server\\share\\project\\..\\src", true),
+      "//server/share/src",
+    );
+    assertEquals(portableDirname("D:\\file.ts", true), "D:/");
+  });
+
+  it("extracts portable path components", () => {
+    assertEquals(
+      portableBasename("D:\\workspace\\file.test.ts", ".ts", true),
+      "file.test",
+    );
+    assertEquals(
+      portableExtname("D:\\workspace\\file.test.ts", true),
+      ".ts",
+    );
+    assertEquals(portableExtname("/workspace/.gitignore", false), "");
+    assertEquals(portableBasename("/workspace/file.ts", "file.ts", false), "file.ts");
+    assertEquals(portableBasename("file.ts", "file.ts", false), "");
+    assertEquals(portableBasename("file.ts/", "file.ts", false), "file.ts");
+  });
+
+  it("resolves and relativizes absolute paths", () => {
+    assertEquals(
+      portableResolve(["/workspace/src", "..", "test"], false),
+      "/workspace/test",
+    );
+    assertEquals(
+      portableResolve(["//server/share/project", ".."], true),
+      "//server/share/",
+    );
+    assertEquals(
+      portableRelative("C:/workspace", "D:/project", true),
+      "D:/project",
+    );
+    assertEquals(
+      portableRelative("/workspace/src", "/workspace/test", false),
+      "../test",
+    );
+  });
+
+  it("recognizes portable absolute paths", () => {
+    assertEquals(portableIsAbsolute("/workspace", false), true);
+    assertEquals(portableIsAbsolute("D:/workspace", true), true);
+    assertEquals(portableIsAbsolute("//server/share", true), true);
+    assertEquals(portableIsAbsolute("workspace", false), false);
+  });
+
+  it("parses and formats Windows paths", () => {
+    const parsed = portableParse("D:\\workspace\\src\\file.ts", true);
+    assertEquals(parsed, {
+      root: "D:/",
+      dir: "D:/workspace/src",
+      base: "file.ts",
+      ext: ".ts",
+      name: "file",
+    });
+    assertEquals(portableFormat(parsed, true), "D:/workspace/src/file.ts");
+    assertEquals(
+      portableFormat(
+        { root: "", dir: "src", base: "", ext: ".js", name: "index" },
+        false,
+      ),
+      "src/index.js",
+    );
+    assertEquals(
+      portableFormat(
+        { root: "", dir: "src", base: "", ext: "js", name: "index" },
+        false,
+      ),
+      "src/index.js",
+    );
+  });
+});

--- a/src/platform/compat/path/portable.ts
+++ b/src/platform/compat/path/portable.ts
@@ -9,8 +9,7 @@ interface RootInfo {
 
 export function hasWindowsLikePath(path: string): boolean {
   return path.includes("\\") ||
-    /^[A-Za-z]:/.test(path) ||
-    /^\/\/[^/]+\/[^/]+(?:\/|$)/.test(path);
+    /^[A-Za-z]:/.test(path);
 }
 
 export function toPortableSeparators(path: string): string {

--- a/src/platform/compat/path/portable.ts
+++ b/src/platform/compat/path/portable.ts
@@ -97,6 +97,21 @@ function canonicalPath(path: string, windows: boolean): string {
   return windows ? toPortableSeparators(path) : path;
 }
 
+export function removeTrailingSeparatorsExceptRoot(
+  path: string,
+  windows: boolean,
+): string {
+  const root = analyzeRoot(path, windows);
+  let canonical = canonicalPath(path, windows);
+  while (
+    canonical.endsWith("/") &&
+    canonical.length > root.root.length
+  ) {
+    canonical = canonical.slice(0, -1);
+  }
+  return canonical;
+}
+
 function rootKey(root: RootInfo, windows: boolean): string {
   const value = root.device || root.root;
   return windows ? value.toLowerCase() : value;

--- a/src/platform/compat/path/portable.ts
+++ b/src/platform/compat/path/portable.ts
@@ -1,0 +1,369 @@
+import type { PathObject } from "./types.ts";
+
+interface RootInfo {
+  absolute: boolean;
+  device: string;
+  rest: string;
+  root: string;
+}
+
+export function hasWindowsLikePath(path: string): boolean {
+  return path.includes("\\") ||
+    /^[A-Za-z]:/.test(path) ||
+    path.startsWith("//");
+}
+
+export function toPortableSeparators(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function analyzeRoot(path: string, windows: boolean): RootInfo {
+  const portable = toPortableSeparators(path);
+
+  if (windows) {
+    const unc = portable.match(
+      /^\/\/+([^/]+)\/+([^/]+)(\/+(.*))?$/,
+    );
+    if (unc?.[1] && unc[2]) {
+      const device = `//${unc[1]}/${unc[2]}`;
+      return {
+        absolute: true,
+        device,
+        rest: unc[4] ?? "",
+        root: unc[3] === undefined ? device : `${device}/`,
+      };
+    }
+
+    const drive = portable.match(/^([A-Za-z]:)(\/+)?(.*)$/);
+    if (drive?.[1] !== undefined) {
+      const absolute = drive[2] !== undefined;
+      return {
+        absolute,
+        device: drive[1],
+        rest: drive[3] ?? "",
+        root: absolute ? `${drive[1]}/` : drive[1],
+      };
+    }
+  }
+
+  if (portable.startsWith("/")) {
+    return {
+      absolute: true,
+      device: "",
+      rest: portable.replace(/^\/+/, ""),
+      root: "/",
+    };
+  }
+
+  return {
+    absolute: false,
+    device: "",
+    rest: portable,
+    root: "",
+  };
+}
+
+function appendRoot(root: RootInfo, tail: string): string {
+  if (root.root === "") return tail || ".";
+  if (!root.absolute) return `${root.root}${tail || "."}`;
+  if (!tail) {
+    return root.device.startsWith("//") ? `${root.device}/` : root.root;
+  }
+  return root.root.endsWith("/") ? `${root.root}${tail}` : `${root.root}/${tail}`;
+}
+
+function normalizeTail(rest: string, absolute: boolean): string[] {
+  const normalized: string[] = [];
+
+  for (const segment of rest.split("/")) {
+    if (segment === "" || segment === ".") continue;
+
+    if (segment !== "..") {
+      normalized.push(segment);
+      continue;
+    }
+
+    const previous = normalized.at(-1);
+    if (previous !== undefined && previous !== "..") {
+      normalized.pop();
+    } else if (!absolute) {
+      normalized.push("..");
+    }
+  }
+
+  return normalized;
+}
+
+function canonicalPath(path: string, windows: boolean): string {
+  return windows ? toPortableSeparators(path) : path;
+}
+
+function rootKey(root: RootInfo, windows: boolean): string {
+  const value = root.device || root.root;
+  return windows ? value.toLowerCase() : value;
+}
+
+export function runtimeUsesWindowsPaths(): boolean {
+  const runtime = globalThis as typeof globalThis & {
+    Deno?: { build?: { os?: string } };
+    process?: { platform?: string };
+  };
+  if (typeof runtime.Deno?.build?.os === "string") {
+    return runtime.Deno.build.os === "windows";
+  }
+  return runtime.process?.platform === "win32";
+}
+
+function runtimeCwd(): string {
+  const deno = (globalThis as {
+    Deno?: { cwd?: () => string };
+  }).Deno;
+  try {
+    if (typeof deno?.cwd === "function") return deno.cwd();
+  } catch {
+    // Continue to the next runtime source.
+  }
+
+  const process = (globalThis as {
+    process?: { cwd?: () => string };
+  }).process;
+  try {
+    if (typeof process?.cwd === "function") return process.cwd();
+  } catch {
+    // Browsers do not expose a process working directory.
+  }
+
+  // Browser builds use a virtual root because no host working directory exists.
+  return "/";
+}
+
+export function portableNormalize(path: string, windows: boolean): string {
+  if (path === "") return ".";
+
+  const root = analyzeRoot(path, windows);
+  const tail = normalizeTail(root.rest, root.absolute).join("/");
+  let result = appendRoot(root, tail);
+
+  const hadTrailingSeparator = /[\\/]$/.test(path);
+  if (hadTrailingSeparator && result === ".") return "./";
+  if (
+    hadTrailingSeparator &&
+    result !== root.root &&
+    !result.endsWith("/")
+  ) {
+    result += "/";
+  }
+
+  return result;
+}
+
+export function portableJoin(paths: readonly string[], windows: boolean): string {
+  const nonempty = paths.filter((path) => path.length > 0);
+  if (nonempty.length === 0) return "/";
+  return portableNormalize(nonempty.join("/"), windows);
+}
+
+export function portableDirname(path: string, windows: boolean): string {
+  if (path.length === 0) return ".";
+
+  const root = analyzeRoot(path, windows);
+  let canonical = canonicalPath(path, windows);
+  while (
+    canonical.endsWith("/") &&
+    canonical.length > root.root.length
+  ) {
+    canonical = canonical.slice(0, -1);
+  }
+
+  if (canonical === root.root || canonical === root.device) {
+    return root.root || root.device || ".";
+  }
+
+  const lastSeparator = canonical.lastIndexOf("/");
+  if (lastSeparator === -1) return root.device || ".";
+  if (lastSeparator < root.root.length) return root.root || "/";
+  if (lastSeparator === 0) return "/";
+  return canonical.slice(0, lastSeparator);
+}
+
+export function portableBasename(
+  path: string,
+  ext: string | undefined,
+  windows: boolean,
+): string {
+  if (path.length === 0) return "";
+
+  const root = analyzeRoot(path, windows);
+  let canonical = canonicalPath(path, windows);
+  const originalPath = canonical;
+  if (ext !== undefined && ext !== "" && ext === originalPath) return "";
+  while (
+    canonical.endsWith("/") &&
+    canonical.length > root.root.length
+  ) {
+    canonical = canonical.slice(0, -1);
+  }
+
+  if (
+    windows &&
+    root.device.startsWith("//") &&
+    root.rest === ""
+  ) {
+    return root.device.slice(root.device.lastIndexOf("/") + 1);
+  }
+
+  if (canonical === root.root || canonical === root.device) return "";
+
+  const lastSeparator = canonical.lastIndexOf("/");
+  let base = canonical.slice(lastSeparator + 1);
+  if (
+    !root.absolute &&
+    root.device &&
+    lastSeparator === -1 &&
+    base.startsWith(root.device)
+  ) {
+    base = base.slice(root.device.length);
+  }
+
+  if (ext !== undefined && ext !== "" && base.endsWith(ext)) {
+    if (ext.length < base.length) return base.slice(0, -ext.length);
+  }
+  return base;
+}
+
+export function portableExtname(path: string, windows: boolean): string {
+  const base = portableBasename(path, undefined, windows);
+  const lastDot = base.lastIndexOf(".");
+  if (lastDot <= 0 || base === "." || base === "..") return "";
+  return base.slice(lastDot);
+}
+
+export function portableIsAbsolute(path: string, windows: boolean): boolean {
+  return analyzeRoot(path, windows).absolute;
+}
+
+export function portableResolve(
+  paths: readonly string[],
+  windows: boolean,
+): string {
+  let resolved = runtimeCwd();
+
+  for (const rawPath of paths) {
+    if (rawPath.length === 0) continue;
+
+    const path = toPortableSeparators(rawPath);
+    const incoming = analyzeRoot(path, windows);
+    const current = analyzeRoot(resolved, windows);
+
+    if (incoming.absolute && incoming.device) {
+      resolved = path;
+    } else if (incoming.absolute) {
+      resolved = windows && current.device ? `${current.device}/${incoming.rest}` : path;
+    } else if (incoming.device) {
+      resolved = rootKey(incoming, true) === rootKey(current, true)
+        ? `${current.root}${current.rest}/${incoming.rest}`
+        : `${incoming.device}/${incoming.rest}`;
+    } else {
+      resolved = `${resolved}/${path}`;
+    }
+  }
+
+  const normalized = portableNormalize(resolved, windows);
+  const root = analyzeRoot(normalized, windows);
+  if (
+    normalized.endsWith("/") &&
+    normalized !== root.root &&
+    normalized !== `${root.device}/`
+  ) {
+    return normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+export function portableRelative(
+  from: string,
+  to: string,
+  windows: boolean,
+): string {
+  const resolvedFrom = portableResolve([from], windows);
+  const resolvedTo = portableResolve([to], windows);
+  const fromRoot = analyzeRoot(resolvedFrom, windows);
+  const toRoot = analyzeRoot(resolvedTo, windows);
+
+  if (rootKey(fromRoot, windows) !== rootKey(toRoot, windows)) {
+    return resolvedTo;
+  }
+
+  const fromParts = normalizeTail(fromRoot.rest, true);
+  const toParts = normalizeTail(toRoot.rest, true);
+  let common = 0;
+
+  while (common < fromParts.length && common < toParts.length) {
+    const fromPart = fromParts[common]!;
+    const toPart = toParts[common]!;
+    const equal = windows ? fromPart.toLowerCase() === toPart.toLowerCase() : fromPart === toPart;
+    if (!equal) break;
+    common++;
+  }
+
+  const result = [
+    ...Array.from({ length: fromParts.length - common }, () => ".."),
+    ...toParts.slice(common),
+  ];
+  return result.join("/") || ".";
+}
+
+export function portableParse(path: string, windows: boolean): PathObject {
+  const root = analyzeRoot(path, windows);
+  let canonical = canonicalPath(path, windows);
+  while (
+    canonical.endsWith("/") &&
+    canonical.length > root.root.length
+  ) {
+    canonical = canonical.slice(0, -1);
+  }
+
+  const base = windows && root.device.startsWith("//") && root.rest === ""
+    ? ""
+    : portableBasename(canonical, undefined, windows);
+  const ext = portableExtname(base, windows);
+  const name = base.slice(0, base.length - ext.length);
+  let dir = "";
+
+  if (base === "") {
+    dir = root.root;
+  } else if (
+    canonical.includes("/") ||
+    (windows && root.device !== "")
+  ) {
+    dir = portableDirname(canonical, windows);
+  }
+
+  return {
+    root: root.root,
+    dir,
+    base,
+    ext,
+    name,
+  };
+}
+
+export function portableFormat(
+  pathObject: PathObject,
+  windows: boolean,
+): string {
+  const root = toPortableSeparators(pathObject.root ?? "");
+  const dir = toPortableSeparators(pathObject.dir ?? "");
+  const rawExt = pathObject.ext ?? "";
+  const ext = rawExt && !rawExt.startsWith(".") ? `.${rawExt}` : rawExt;
+  const base = pathObject.base ||
+    `${pathObject.name ?? ""}${ext}`;
+  const directory = dir || root;
+
+  if (!directory) return base;
+  if (!base) return directory;
+  if (directory.endsWith("/") || (windows && /^[A-Za-z]:$/.test(directory))) {
+    return `${directory}${base}`;
+  }
+  return `${directory}/${base}`;
+}

--- a/src/platform/compat/path/portable.ts
+++ b/src/platform/compat/path/portable.ts
@@ -10,7 +10,7 @@ interface RootInfo {
 export function hasWindowsLikePath(path: string): boolean {
   return path.includes("\\") ||
     /^[A-Za-z]:/.test(path) ||
-    path.startsWith("//");
+    /^\/\/[^/]+\/[^/]+(?:\/|$)/.test(path);
 }
 
 export function toPortableSeparators(path: string): string {
@@ -22,7 +22,7 @@ function analyzeRoot(path: string, windows: boolean): RootInfo {
 
   if (windows) {
     const unc = portable.match(
-      /^\/\/+([^/]+)\/+([^/]+)(\/+(.*))?$/,
+      /^\/\/([^/]+)\/+([^/]+)(\/+(.*))?$/,
     );
     if (unc?.[1] && unc[2]) {
       const device = `//${unc[1]}/${unc[2]}`;

--- a/src/platform/compat/path/posix.ts
+++ b/src/platform/compat/path/posix.ts
@@ -1,0 +1,193 @@
+/** Dependency-free POSIX path operations for every supported runtime. */
+
+export interface PosixPath {
+  join(...paths: string[]): string;
+  resolve(...paths: string[]): string;
+  normalize(path: string): string;
+  relative(from: string, to: string): string;
+  dirname(path: string): string;
+  basename(path: string, suffix?: string): string;
+  extname(path: string): string;
+  isAbsolute(path: string): boolean;
+  readonly sep: "/";
+  readonly delimiter: ":";
+}
+
+function assertPath(value: unknown): asserts value is string {
+  if (typeof value !== "string") {
+    throw new TypeError(`Path must be a string. Received ${typeof value}`);
+  }
+}
+
+function normalizeSegments(path: string, allowAboveRoot: boolean): string {
+  const segments: string[] = [];
+
+  for (const segment of path.split("/")) {
+    if (segment.length === 0 || segment === ".") continue;
+    if (segment !== "..") {
+      segments.push(segment);
+      continue;
+    }
+
+    const previous = segments.at(-1);
+    if (previous !== undefined && previous !== "..") {
+      segments.pop();
+    } else if (allowAboveRoot) {
+      segments.push("..");
+    }
+  }
+
+  return segments.join("/");
+}
+
+function runtimeWorkingDirectory(): string {
+  const runtime = globalThis as typeof globalThis & {
+    Deno?: { cwd?: () => string };
+    process?: { cwd?: () => string };
+  };
+
+  if (typeof runtime.Deno?.cwd === "function") {
+    const directory = runtime.Deno.cwd();
+    assertPath(directory);
+    return directory;
+  }
+  if (typeof runtime.process?.cwd === "function") {
+    const directory = runtime.process.cwd();
+    assertPath(directory);
+    return directory;
+  }
+
+  // Browser and worker runtimes resolve relative virtual paths from their root.
+  return "/";
+}
+
+function normalize(path: string): string {
+  assertPath(path);
+  if (path.length === 0) return ".";
+
+  const absolute = path.startsWith("/");
+  const trailingSeparator = path.endsWith("/");
+  let normalized = normalizeSegments(path, !absolute);
+
+  if (normalized.length > 0 && trailingSeparator) normalized += "/";
+  if (absolute) return normalized.length > 0 ? `/${normalized}` : "/";
+  if (normalized.length > 0) return normalized;
+  return trailingSeparator ? "./" : ".";
+}
+
+function join(...paths: string[]): string {
+  let joined = "";
+  for (const path of paths) {
+    assertPath(path);
+    if (path.length === 0) continue;
+    joined = joined.length === 0 ? path : `${joined}/${path}`;
+  }
+  return joined.length === 0 ? "." : normalize(joined);
+}
+
+function resolve(...paths: string[]): string {
+  let resolved = "";
+  let absolute = false;
+
+  for (let index = paths.length - 1; index >= -1 && !absolute; index--) {
+    const path = index >= 0 ? paths[index] : runtimeWorkingDirectory();
+    assertPath(path);
+    if (path.length === 0) continue;
+
+    resolved = `${path}/${resolved}`;
+    absolute = path.startsWith("/");
+  }
+
+  const normalized = normalizeSegments(resolved, !absolute);
+  if (absolute) return normalized.length > 0 ? `/${normalized}` : "/";
+  return normalized.length > 0 ? normalized : ".";
+}
+
+function relative(from: string, to: string): string {
+  assertPath(from);
+  assertPath(to);
+
+  const resolvedFrom = resolve(from);
+  const resolvedTo = resolve(to);
+  if (resolvedFrom === resolvedTo) return "";
+
+  const fromSegments = resolvedFrom.split("/").filter(Boolean);
+  const toSegments = resolvedTo.split("/").filter(Boolean);
+  let common = 0;
+  while (
+    common < fromSegments.length &&
+    common < toSegments.length &&
+    fromSegments[common] === toSegments[common]
+  ) {
+    common++;
+  }
+
+  return [
+    ...Array.from({ length: fromSegments.length - common }, () => ".."),
+    ...toSegments.slice(common),
+  ].join("/");
+}
+
+function dirname(path: string): string {
+  assertPath(path);
+  if (path.length === 0) return ".";
+
+  const hasRoot = path.startsWith("/");
+  let end = -1;
+  let matchedSeparator = true;
+  for (let index = path.length - 1; index >= 1; index--) {
+    if (path[index] === "/") {
+      if (!matchedSeparator) {
+        end = index;
+        break;
+      }
+    } else {
+      matchedSeparator = false;
+    }
+  }
+
+  if (end === -1) return hasRoot ? "/" : ".";
+  if (hasRoot && end === 1) return "//";
+  return path.slice(0, end);
+}
+
+function basename(path: string, suffix?: string): string {
+  assertPath(path);
+  if (suffix !== undefined) assertPath(suffix);
+
+  let end = path.length;
+  while (end > 0 && path[end - 1] === "/") end--;
+  if (end === 0) return "";
+
+  const start = path.lastIndexOf("/", end - 1) + 1;
+  const base = path.slice(start, end);
+  if (suffix && suffix.length <= base.length && base.endsWith(suffix)) {
+    return base.slice(0, -suffix.length);
+  }
+  return base;
+}
+
+function extname(path: string): string {
+  const base = basename(path);
+  if (base === "." || base === "..") return "";
+  const lastDot = base.lastIndexOf(".");
+  return lastDot <= 0 ? "" : base.slice(lastDot);
+}
+
+function isAbsolute(path: string): boolean {
+  assertPath(path);
+  return path.startsWith("/");
+}
+
+export const posix: Readonly<PosixPath> = Object.freeze({
+  join,
+  resolve,
+  normalize,
+  relative,
+  dirname,
+  basename,
+  extname,
+  isAbsolute,
+  sep: "/",
+  delimiter: ":",
+});

--- a/src/platform/compat/path/posix.ts
+++ b/src/platform/compat/path/posix.ts
@@ -155,16 +155,58 @@ function basename(path: string, suffix?: string): string {
   assertPath(path);
   if (suffix !== undefined) assertPath(suffix);
 
-  let end = path.length;
-  while (end > 0 && path[end - 1] === "/") end--;
-  if (end === 0) return "";
+  let start = 0;
+  let end = -1;
+  let matchedSeparator = true;
 
-  const start = path.lastIndexOf("/", end - 1) + 1;
-  const base = path.slice(start, end);
-  if (suffix && suffix.length <= base.length && base.endsWith(suffix)) {
-    return base.slice(0, -suffix.length);
+  if (suffix !== undefined && suffix.length > 0 && suffix.length <= path.length) {
+    if (suffix === path) return "";
+
+    let suffixIndex = suffix.length - 1;
+    let firstNonSeparatorEnd = -1;
+    for (let index = path.length - 1; index >= 0; index--) {
+      const character = path[index];
+      if (character === "/") {
+        if (!matchedSeparator) {
+          start = index + 1;
+          break;
+        }
+        continue;
+      }
+
+      if (firstNonSeparatorEnd === -1) {
+        matchedSeparator = false;
+        firstNonSeparatorEnd = index + 1;
+      }
+      if (suffixIndex < 0) continue;
+
+      if (character === suffix[suffixIndex]) {
+        suffixIndex--;
+        if (suffixIndex === -1) end = index;
+      } else {
+        suffixIndex = -1;
+        end = firstNonSeparatorEnd;
+      }
+    }
+
+    if (start === end) end = firstNonSeparatorEnd;
+    else if (end === -1) end = path.length;
+    return path.slice(start, end);
   }
-  return base;
+
+  for (let index = path.length - 1; index >= 0; index--) {
+    if (path[index] === "/") {
+      if (!matchedSeparator) {
+        start = index + 1;
+        break;
+      }
+    } else if (end === -1) {
+      matchedSeparator = false;
+      end = index + 1;
+    }
+  }
+
+  return end === -1 ? "" : path.slice(start, end);
 }
 
 function extname(path: string): string {

--- a/src/platform/compat/path/resolution.test.ts
+++ b/src/platform/compat/path/resolution.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { cwd } from "../process.ts";
 import { isAbsolute, normalize, relative, resolve } from "./resolution.ts";
 
 describe("platform/compat/path/resolution", () => {
@@ -22,10 +23,11 @@ describe("platform/compat/path/resolution", () => {
     });
 
     it("uses the runtime working directory for relative paths", () => {
-      assertEquals(resolve("."), Deno.cwd().replaceAll("\\", "/"));
+      const workingDirectory = cwd().replaceAll("\\", "/");
+      assertEquals(resolve("."), workingDirectory);
       assertEquals(
         resolve("relative", "file.ts"),
-        `${Deno.cwd().replaceAll("\\", "/")}/relative/file.ts`,
+        `${workingDirectory}/relative/file.ts`,
       );
     });
 

--- a/src/platform/compat/path/resolution.test.ts
+++ b/src/platform/compat/path/resolution.test.ts
@@ -21,6 +21,14 @@ describe("platform/compat/path/resolution", () => {
       assertEquals(resolve("/first", "/second"), "/second");
     });
 
+    it("uses the runtime working directory for relative paths", () => {
+      assertEquals(resolve("."), Deno.cwd().replaceAll("\\", "/"));
+      assertEquals(
+        resolve("relative", "file.ts"),
+        `${Deno.cwd().replaceAll("\\", "/")}/relative/file.ts`,
+      );
+    });
+
     it("should handle Windows drive-letter paths", () => {
       assertEquals(
         resolve("D:/a/project/src/build", "..", "..", ".."),
@@ -37,6 +45,10 @@ describe("platform/compat/path/resolution", () => {
 
     it("should preserve drive letter when resolving to root", () => {
       assertEquals(resolve("D:/a", ".."), "D:/");
+    });
+
+    it("preserves UNC roots", () => {
+      assertEquals(resolve("//server/share/project", ".."), "//server/share/");
     });
   });
 
@@ -104,6 +116,13 @@ describe("platform/compat/path/resolution", () => {
 
     it("should preserve Windows drive letter", () => {
       assertEquals(normalize("D:/"), "D:/");
+    });
+
+    it("preserves UNC roots while normalizing traversal", () => {
+      assertEquals(
+        normalize("\\\\server\\share\\project\\..\\src"),
+        "//server/share/src",
+      );
     });
   });
 });

--- a/src/platform/compat/path/resolution.test.ts
+++ b/src/platform/compat/path/resolution.test.ts
@@ -50,7 +50,10 @@ describe("platform/compat/path/resolution", () => {
     });
 
     it("preserves UNC roots", () => {
-      assertEquals(resolve("//server/share/project", ".."), "//server/share/");
+      assertEquals(
+        resolve(String.raw`\\server\share\project`, ".."),
+        "//server/share/",
+      );
     });
   });
 
@@ -101,6 +104,7 @@ describe("platform/compat/path/resolution", () => {
     });
 
     it("keeps redundant POSIX roots local", () => {
+      assertEquals(normalize("//tmp/file.ts"), "/tmp/file.ts");
       assertEquals(normalize("///tmp/file.ts"), "/tmp/file.ts");
       assertEquals(normalize("////tmp/file.ts"), "/tmp/file.ts");
     });

--- a/src/platform/compat/path/resolution.test.ts
+++ b/src/platform/compat/path/resolution.test.ts
@@ -100,12 +100,23 @@ describe("platform/compat/path/resolution", () => {
       assertEquals(normalize("/home//user"), "/home/user");
     });
 
+    it("keeps redundant POSIX roots local", () => {
+      assertEquals(normalize("///tmp/file.ts"), "/tmp/file.ts");
+      assertEquals(normalize("////tmp/file.ts"), "/tmp/file.ts");
+    });
+
     it("should return . for empty string", () => {
       assertEquals(normalize(""), ".");
     });
 
     it("should preserve absolute path root", () => {
       assertEquals(normalize("/"), "/");
+    });
+
+    it("should remove trailing separators from non-root paths", () => {
+      assertEquals(normalize("uploads/"), "uploads");
+      assertEquals(normalize("./"), ".");
+      assertEquals(normalize("D:/project/"), "D:/project");
     });
 
     it("should handle relative parent traversal", () => {
@@ -125,6 +136,7 @@ describe("platform/compat/path/resolution", () => {
         normalize("\\\\server\\share\\project\\..\\src"),
         "//server/share/src",
       );
+      assertEquals(normalize("\\\\server\\share\\"), "//server/share/");
     });
   });
 });

--- a/src/platform/compat/path/resolution.ts
+++ b/src/platform/compat/path/resolution.ts
@@ -40,5 +40,20 @@ export function relative(from: string, to: string): string {
 export function normalize(path: string): string {
   const windows = usesWindowsFlavor([path]);
   const pathApi = getNativePathImplementation(windows);
-  return pathApi ? toPortableSeparators(pathApi.normalize(path)) : portableNormalize(path, windows);
+  const normalized = pathApi
+    ? toPortableSeparators(pathApi.normalize(path))
+    : portableNormalize(path, windows);
+
+  // The established Veryfront facade contract returns canonical paths without
+  // a trailing separator, except for filesystem roots. Enforce that
+  // postcondition independently of whether the runtime supplies node:path.
+  if (
+    normalized === "/" ||
+    /^[A-Za-z]:\/$/.test(normalized) ||
+    /^\/\/[^/]+\/[^/]+\/$/.test(normalized)
+  ) {
+    return normalized;
+  }
+  if (normalized === "./") return ".";
+  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
 }

--- a/src/platform/compat/path/resolution.ts
+++ b/src/platform/compat/path/resolution.ts
@@ -4,6 +4,7 @@ import {
   portableNormalize,
   portableRelative,
   portableResolve,
+  removeTrailingSeparatorsExceptRoot,
   runtimeUsesWindowsPaths,
   toPortableSeparators,
 } from "./portable.ts";
@@ -47,13 +48,5 @@ export function normalize(path: string): string {
   // The established Veryfront facade contract returns canonical paths without
   // a trailing separator, except for filesystem roots. Enforce that
   // postcondition independently of whether the runtime supplies node:path.
-  if (
-    normalized === "/" ||
-    /^[A-Za-z]:\/$/.test(normalized) ||
-    /^\/\/[^/]+\/[^/]+\/$/.test(normalized)
-  ) {
-    return normalized;
-  }
-  if (normalized === "./") return ".";
-  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+  return removeTrailingSeparatorsExceptRoot(normalized, windows);
 }

--- a/src/platform/compat/path/resolution.ts
+++ b/src/platform/compat/path/resolution.ts
@@ -1,136 +1,44 @@
-import { isDeno, nodePath } from "./runtime.ts";
+import {
+  hasWindowsLikePath,
+  portableIsAbsolute,
+  portableNormalize,
+  portableRelative,
+  portableResolve,
+  runtimeUsesWindowsPaths,
+  toPortableSeparators,
+} from "./portable.ts";
+import { getNativePathImplementation } from "./runtime.ts";
 
-function hasWindowsLikePath(path: string): boolean {
-  return path.includes("\\") || /^[A-Za-z]:/.test(path) || path.startsWith("\\\\");
+function usesWindowsFlavor(paths: readonly string[]): boolean {
+  return runtimeUsesWindowsPaths() || paths.some(hasWindowsLikePath);
 }
 
-/** Normalize backslashes to forward slashes (for Deno on Windows). */
-function normSep(p: string): string {
-  return p.includes("\\") ? p.replace(/\\/g, "/") : p;
-}
-
-/** Match Windows drive letter prefix like "C:/" */
-const DRIVE_LETTER = /^[A-Za-z]:\//;
-
-/** Resolve path segments to an absolute path. */
+/** Resolve path segments to an absolute, normalized path. */
 export function resolve(...paths: string[]): string {
-  if (!isDeno && nodePath && !paths.some(hasWindowsLikePath)) return nodePath.resolve(...paths);
-
-  let resolvedPath = normSep(globalThis.Deno?.cwd?.() ?? "/");
-
-  for (const rawPath of paths) {
-    if (!rawPath) continue;
-    const path = normSep(rawPath);
-    if (path.startsWith("/") || DRIVE_LETTER.test(path)) {
-      resolvedPath = path;
-    } else {
-      resolvedPath = `${resolvedPath}/${path}`;
-    }
-  }
-
-  // Preserve drive letter prefix (e.g. "D:/") if present
-  let prefix = "/";
-  const driveMatch = resolvedPath.match(DRIVE_LETTER);
-  if (driveMatch) {
-    prefix = driveMatch[0]; // e.g. "D:/"
-    resolvedPath = resolvedPath.slice(prefix.length);
-  } else if (resolvedPath.startsWith("/")) {
-    resolvedPath = resolvedPath.slice(1);
-  }
-
-  const parts = resolvedPath.split("/").filter(Boolean);
-  const resolved: string[] = [];
-
-  for (const part of parts) {
-    if (part === "..") {
-      resolved.pop();
-      continue;
-    }
-    if (part !== ".") resolved.push(part);
-  }
-
-  return `${prefix}${resolved.join("/")}`;
+  const windows = usesWindowsFlavor(paths);
+  const pathApi = getNativePathImplementation(windows);
+  return pathApi
+    ? toPortableSeparators(pathApi.resolve(...paths))
+    : portableResolve(paths, windows);
 }
 
 export function isAbsolute(path: string): boolean {
-  if (!isDeno && nodePath && !hasWindowsLikePath(path) && nodePath.isAbsolute(path)) return true;
-  // Cross-platform fallback: Unix, Windows drive letters, and UNC paths
-  if (path.startsWith("/")) return true;
-  if (/^[A-Za-z]:[/\\]/.test(path)) return true;
-  return /^\\\\[^\\]+\\[^\\]+/.test(path);
+  const windows = usesWindowsFlavor([path]);
+  const pathApi = getNativePathImplementation(windows);
+  return pathApi?.isAbsolute(path) ?? portableIsAbsolute(path, windows);
 }
 
 export function relative(from: string, to: string): string {
-  if (!isDeno && nodePath && !hasWindowsLikePath(from) && !hasWindowsLikePath(to)) {
-    const relativePath = nodePath.relative(from, to);
-    return relativePath || ".";
-  }
-
-  const resolvedFrom = resolve(from);
-  const resolvedTo = resolve(to);
-
-  // Strip drive prefix for comparison (both will share the same drive after resolve)
-  const fromDrive = resolvedFrom.match(DRIVE_LETTER);
-  const fromBase = fromDrive ? resolvedFrom.slice(fromDrive[0].length) : resolvedFrom.slice(1);
-  const toDrive = resolvedTo.match(DRIVE_LETTER);
-  const toBase = toDrive ? resolvedTo.slice(toDrive[0].length) : resolvedTo.slice(1);
-
-  const fromParts = fromBase.split("/").filter(Boolean);
-  const toParts = toBase.split("/").filter(Boolean);
-
-  let common = 0;
-  const minLen = Math.min(fromParts.length, toParts.length);
-
-  for (let i = 0; i < minLen; i++) {
-    if (fromParts[i] !== toParts[i]) break;
-    common++;
-  }
-
-  const ups = fromParts.length - common;
-  const result = [...new Array(ups).fill(".."), ...toParts.slice(common)];
-
-  return result.join("/") || ".";
+  const windows = usesWindowsFlavor([from, to]);
+  const pathApi = getNativePathImplementation(windows);
+  const result = pathApi
+    ? toPortableSeparators(pathApi.relative(from, to))
+    : portableRelative(from, to, windows);
+  return result || ".";
 }
 
 export function normalize(path: string): string {
-  if (!isDeno && nodePath && !hasWindowsLikePath(path)) return nodePath.normalize(path);
-  if (path === "") return ".";
-
-  const p = normSep(path);
-  const abs = isAbsolute(p);
-
-  // Preserve drive letter prefix
-  let prefix = "";
-  const driveMatch = p.match(DRIVE_LETTER);
-  if (driveMatch) {
-    prefix = driveMatch[0];
-  } else if (abs) {
-    prefix = "/";
-  }
-
-  const pathWithoutPrefix = driveMatch ? p.slice(prefix.length) : abs ? p.slice(1) : p;
-  const parts = pathWithoutPrefix.split("/").filter((s) => s && s !== ".");
-
-  const normalized: string[] = [];
-
-  for (const part of parts) {
-    if (part !== "..") {
-      normalized.push(part);
-      continue;
-    }
-
-    const last = normalized[normalized.length - 1];
-    if (normalized.length > 0 && last !== "..") {
-      normalized.pop();
-      continue;
-    }
-
-    if (!abs) normalized.push("..");
-  }
-
-  const result = normalized.join("/");
-
-  if (abs) return result ? `${prefix}${result}` : prefix || "/";
-
-  return result || ".";
+  const windows = usesWindowsFlavor([path]);
+  const pathApi = getNativePathImplementation(windows);
+  return pathApi ? toPortableSeparators(pathApi.normalize(path)) : portableNormalize(path, windows);
 }

--- a/src/platform/compat/path/runtime.ts
+++ b/src/platform/compat/path/runtime.ts
@@ -1,4 +1,4 @@
-import type { NodePathModule } from "./types.ts";
+import type { NodePathModule, PathImplementation } from "./types.ts";
 
 const globalProcess = (globalThis as { process?: { versions?: { node?: string } } }).process;
 const hasNodeApis = !!globalProcess?.versions?.node || "Bun" in globalThis;
@@ -25,3 +25,10 @@ export { nodePath };
 export const sep = nodePath?.sep ?? "/";
 export const delimiter = nodePath?.delimiter ?? ":";
 export const hasNodePath = nodePath !== null;
+
+export function getNativePathImplementation(
+  windows: boolean,
+): PathImplementation | null {
+  if (!nodePath) return null;
+  return windows ? nodePath.win32 : nodePath.posix;
+}

--- a/src/platform/compat/path/types.ts
+++ b/src/platform/compat/path/types.ts
@@ -6,7 +6,7 @@ export interface PathObject {
   name?: string;
 }
 
-export interface NodePathModule {
+export interface PathImplementation {
   sep: string;
   delimiter: string;
   join(...paths: string[]): string;
@@ -19,4 +19,9 @@ export interface NodePathModule {
   normalize(path: string): string;
   parse(path: string): PathObject;
   format(pathObject: PathObject): string;
+}
+
+export interface NodePathModule extends PathImplementation {
+  posix: PathImplementation;
+  win32: PathImplementation;
 }

--- a/src/platform/compat/path/url-conversion.test.ts
+++ b/src/platform/compat/path/url-conversion.test.ts
@@ -92,6 +92,9 @@ describe("url-conversion", () => {
 
     it("keeps redundant POSIX root separators local", () => {
       assertEquals(toFileUrl("//").href, "file:///");
+      if (Deno.build.os !== "windows") {
+        assertEquals(toFileUrl("//tmp/file.ts").href, "file:///tmp/file.ts");
+      }
       assertEquals(toFileUrl("///tmp/file.ts").href, "file:///tmp/file.ts");
       assertEquals(toFileUrl("////tmp/file.ts").href, "file:///tmp/file.ts");
     });

--- a/src/platform/compat/path/url-conversion.test.ts
+++ b/src/platform/compat/path/url-conversion.test.ts
@@ -68,6 +68,14 @@ describe("url-conversion", () => {
       assertEquals(fromFileUrl(result), path);
     });
 
+    it("should preserve colons inside POSIX path segments", () => {
+      const path = "/srv/app/node_modules/example/C:/entry.mjs";
+      assertEquals(
+        toFileUrl(path).href,
+        "file:///srv/app/node_modules/example/C:/entry.mjs",
+      );
+    });
+
     it("should handle relative path by resolving", () => {
       const result = toFileUrl("relative/path.ts");
       assertEquals(result.protocol, "file:");

--- a/src/platform/compat/path/url-conversion.test.ts
+++ b/src/platform/compat/path/url-conversion.test.ts
@@ -71,6 +71,21 @@ describe("url-conversion", () => {
     it("should handle relative path by resolving", () => {
       const result = toFileUrl("relative/path.ts");
       assertEquals(result.protocol, "file:");
+      assertEquals(fromFileUrl(result), `${Deno.cwd()}/relative/path.ts`);
+    });
+
+    it("preserves UNC hosts instead of converting them to local-root paths", () => {
+      const result = toFileUrl(String.raw`\\server\share\extension.ts`);
+      assertEquals(result.href, "file://server/share/extension.ts");
+      if (Deno.build.os !== "windows") {
+        assertEquals(fromFileUrl(result), "//server/share/extension.ts");
+      }
+    });
+
+    it("preserves literal backslashes in POSIX paths", () => {
+      if (Deno.build.os === "windows") return;
+      const path = String.raw`/tmp/literal\backslash.ts`;
+      assertEquals(fromFileUrl(toFileUrl(path)), path);
     });
   });
 

--- a/src/platform/compat/path/url-conversion.test.ts
+++ b/src/platform/compat/path/url-conversion.test.ts
@@ -82,6 +82,12 @@ describe("url-conversion", () => {
       }
     });
 
+    it("keeps redundant POSIX root separators local", () => {
+      assertEquals(toFileUrl("//").href, "file:///");
+      assertEquals(toFileUrl("///tmp/file.ts").href, "file:///tmp/file.ts");
+      assertEquals(toFileUrl("////tmp/file.ts").href, "file:///tmp/file.ts");
+    });
+
     it("preserves literal backslashes in POSIX paths", () => {
       if (Deno.build.os === "windows") return;
       const path = String.raw`/tmp/literal\backslash.ts`;

--- a/src/platform/compat/path/url-conversion.test.ts
+++ b/src/platform/compat/path/url-conversion.test.ts
@@ -1,6 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { runtimeUsesWindowsPaths } from "./portable.ts";
+import { resolve } from "./resolution.ts";
 import { fromFileUrl, toFileUrl } from "./url-conversion.ts";
 
 describe("url-conversion", () => {
@@ -79,28 +81,48 @@ describe("url-conversion", () => {
     it("should handle relative path by resolving", () => {
       const result = toFileUrl("relative/path.ts");
       assertEquals(result.protocol, "file:");
-      assertEquals(fromFileUrl(result), `${Deno.cwd()}/relative/path.ts`);
+      const expected = resolve("relative/path.ts");
+      assertEquals(
+        fromFileUrl(result),
+        runtimeUsesWindowsPaths() ? expected.replaceAll("/", "\\") : expected,
+      );
     });
 
-    it("preserves UNC hosts instead of converting them to local-root paths", () => {
+    it("preserves explicit UNC hosts without inventing ambiguous POSIX paths", () => {
       const result = toFileUrl(String.raw`\\server\share\extension.ts`);
       assertEquals(result.href, "file://server/share/extension.ts");
-      if (Deno.build.os !== "windows") {
-        assertEquals(fromFileUrl(result), "//server/share/extension.ts");
+      if (runtimeUsesWindowsPaths()) {
+        assertEquals(fromFileUrl(result), String.raw`\\server\share\extension.ts`);
+      } else {
+        assertThrows(
+          () => fromFileUrl(result),
+          TypeError,
+          "File URL host must be empty or localhost on non-Windows runtimes",
+        );
+      }
+    });
+
+    it("treats localhost file URLs as local paths", () => {
+      if (!runtimeUsesWindowsPaths()) {
+        assertEquals(fromFileUrl("file://localhost/tmp/file.ts"), "/tmp/file.ts");
       }
     });
 
     it("keeps redundant POSIX root separators local", () => {
       assertEquals(toFileUrl("//").href, "file:///");
-      if (Deno.build.os !== "windows") {
+      if (!runtimeUsesWindowsPaths()) {
         assertEquals(toFileUrl("//tmp/file.ts").href, "file:///tmp/file.ts");
+        assertEquals(
+          toFileUrl("//server/share/file.ts").href,
+          "file:///server/share/file.ts",
+        );
       }
       assertEquals(toFileUrl("///tmp/file.ts").href, "file:///tmp/file.ts");
       assertEquals(toFileUrl("////tmp/file.ts").href, "file:///tmp/file.ts");
     });
 
     it("preserves literal backslashes in POSIX paths", () => {
-      if (Deno.build.os === "windows") return;
+      if (runtimeUsesWindowsPaths()) return;
       const path = String.raw`/tmp/literal\backslash.ts`;
       assertEquals(fromFileUrl(toFileUrl(path)), path);
     });

--- a/src/platform/compat/path/url-conversion.ts
+++ b/src/platform/compat/path/url-conversion.ts
@@ -28,6 +28,16 @@ function parseUncPath(path: string): { host: string; pathname: string } | null {
   return { host: match[1], pathname: match[2] };
 }
 
+/**
+ * Convert a file URL to a runtime-native filesystem path.
+ *
+ * Local and `localhost` URLs are supported on every runtime. A non-local host
+ * becomes a UNC path on Windows; other runtimes reject it because no
+ * unambiguous local path representation exists.
+ *
+ * @throws {TypeError} If the URL is not a file URL, contains an encoded path
+ * separator, or names a non-local host on a non-Windows runtime.
+ */
 export function fromFileUrl(url: string | URL): string {
   const parsedUrl = typeof url === "string" ? new URL(url) : url;
   if (parsedUrl.protocol !== "file:") {
@@ -35,11 +45,17 @@ export function fromFileUrl(url: string | URL): string {
   }
 
   const windows = runtimeUsesWindowsPaths();
-  const pathname = decodeFilePath(parsedUrl.pathname, windows);
   const host = parsedUrl.hostname;
 
+  if (host && host !== "localhost" && !windows) {
+    throw new TypeError(
+      "File URL host must be empty or localhost on non-Windows runtimes",
+    );
+  }
+
+  const pathname = decodeFilePath(parsedUrl.pathname, windows);
   if (host && host !== "localhost") {
-    return windows ? `\\\\${host}${pathname.replaceAll("/", "\\")}` : `//${host}${pathname}`;
+    return `\\\\${host}${pathname.replaceAll("/", "\\")}`;
   }
 
   if (!windows) return pathname;

--- a/src/platform/compat/path/url-conversion.ts
+++ b/src/platform/compat/path/url-conversion.ts
@@ -21,6 +21,7 @@ function encodePath(path: string): string {
 }
 
 function parseUncPath(path: string): { host: string; pathname: string } | null {
+  if (!runtimeUsesWindowsPaths() && !path.startsWith("\\\\")) return null;
   const portable = path.replaceAll("\\", "/");
   const match = portable.match(/^\/\/([^/]+)(\/.*)$/);
   if (!match?.[1] || !match[2]) return null;

--- a/src/platform/compat/path/url-conversion.ts
+++ b/src/platform/compat/path/url-conversion.ts
@@ -10,7 +10,14 @@ function decodeFilePath(pathname: string, windows: boolean): string {
 }
 
 function encodePath(path: string): string {
-  return path.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+  // Match filesystem URL encoding: protect characters that URL parsing would
+  // interpret structurally while leaving valid path characters such as a
+  // drive-like colon untouched when it appears inside a POSIX path segment.
+  return path
+    .replaceAll("%", "%25")
+    .replaceAll("\\", "%5C")
+    .replaceAll("#", "%23")
+    .replaceAll("?", "%3F");
 }
 
 function parseUncPath(path: string): { host: string; pathname: string } | null {

--- a/src/platform/compat/path/url-conversion.ts
+++ b/src/platform/compat/path/url-conversion.ts
@@ -15,7 +15,7 @@ function encodePath(path: string): string {
 
 function parseUncPath(path: string): { host: string; pathname: string } | null {
   const portable = path.replaceAll("\\", "/");
-  const match = portable.match(/^\/\/+([^/]+)(\/.*)$/);
+  const match = portable.match(/^\/\/([^/]+)(\/.*)$/);
   if (!match?.[1] || !match[2]) return null;
   return { host: match[1], pathname: match[2] };
 }

--- a/src/platform/compat/path/url-conversion.ts
+++ b/src/platform/compat/path/url-conversion.ts
@@ -1,29 +1,23 @@
-import { hasNodePath, isDeno } from "./runtime.ts";
-import { isAbsolute, resolve } from "./resolution.ts";
+import { posix } from "./posix.ts";
+import { resolve } from "./resolution.ts";
+import { runtimeUsesWindowsPaths } from "./portable.ts";
 
-type GlobalWithRequire = typeof globalThis & {
-  require?: (specifier: string) => { fileURLToPath?: (url: string | URL) => string };
-  Deno?: { cwd?: () => string; build?: { os?: string } };
-};
-
-let _fileURLToPath: ((url: string | URL) => string) | null = null;
-
-function getFileURLToPath(): ((url: string | URL) => string) | null {
-  if (_fileURLToPath) return _fileURLToPath;
-  if (!hasNodePath) return null;
-
-  try {
-    const nodeUrl = (globalThis as GlobalWithRequire).require?.("node:url");
-    const fileURLToPath = nodeUrl?.fileURLToPath;
-
-    if (!fileURLToPath) return null;
-
-    _fileURLToPath = fileURLToPath;
-    return _fileURLToPath;
-  } catch (_) {
-    /* expected: node:url require may fail in non-Node runtimes */
-    return null;
+function decodeFilePath(pathname: string, windows: boolean): string {
+  if (/%2f/i.test(pathname) || (windows && /%5c/i.test(pathname))) {
+    throw new TypeError("File URL path must not include encoded path separators");
   }
+  return decodeURIComponent(pathname);
+}
+
+function encodePath(path: string): string {
+  return path.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+}
+
+function parseUncPath(path: string): { host: string; pathname: string } | null {
+  const portable = path.replaceAll("\\", "/");
+  const match = portable.match(/^\/\/+([^/]+)(\/.*)$/);
+  if (!match?.[1] || !match[2]) return null;
+  return { host: match[1], pathname: match[2] };
 }
 
 export function fromFileUrl(url: string | URL): string {
@@ -32,33 +26,37 @@ export function fromFileUrl(url: string | URL): string {
     throw new TypeError("Must be a file URL");
   }
 
-  const fileURLToPath = getFileURLToPath();
-  if (fileURLToPath) return fileURLToPath(parsedUrl);
+  const windows = runtimeUsesWindowsPaths();
+  const pathname = decodeFilePath(parsedUrl.pathname, windows);
+  const host = parsedUrl.hostname;
 
-  if (isDeno) {
-    const g = globalThis as GlobalWithRequire;
-    const hasCwd = Boolean(g.Deno?.cwd);
-    const isWindows = g.Deno?.build?.os === "windows";
-
-    if (hasCwd && isWindows) {
-      return decodeURIComponent(parsedUrl.pathname)
-        .replace(/^\/([A-Za-z]:)/, "$1")
-        .replace(/\//g, "\\");
-    }
-
-    return decodeURIComponent(parsedUrl.pathname);
+  if (host && host !== "localhost") {
+    return windows ? `\\\\${host}${pathname.replaceAll("/", "\\")}` : `//${host}${pathname}`;
   }
 
-  return decodeURIComponent(parsedUrl.pathname);
+  if (!windows) return pathname;
+  return pathname
+    .replace(/^\/([A-Za-z]:)/, "$1")
+    .replaceAll("/", "\\");
 }
 
 export function toFileUrl(path: string): URL {
-  const absolute = hasNodePath ? path : isAbsolute(path) ? path : resolve(path);
-  // Preserve filesystem characters that URL parsing would otherwise decode or
-  // interpret as fragment/query delimiters.
-  const encodedPath = absolute
-    .replaceAll("%", "%25")
-    .replaceAll("#", "%23")
-    .replaceAll("?", "%3F");
-  return new URL(`file://${encodedPath}`);
+  if (typeof path !== "string") {
+    throw new TypeError(`Path must be a string. Received ${typeof path}`);
+  }
+
+  const unc = parseUncPath(path);
+  if (unc) {
+    return new URL(`file://${unc.host}${encodePath(unc.pathname)}`);
+  }
+
+  const portable = path.replaceAll("\\", "/");
+  const drive = portable.match(/^([A-Za-z]:)(\/.*)?$/);
+  if (drive?.[1]) {
+    const pathname = drive[2] ?? "/";
+    return new URL(`file:///${drive[1]}${encodePath(pathname)}`);
+  }
+
+  const absolute = runtimeUsesWindowsPaths() ? resolve(path) : posix.resolve(path);
+  return new URL(`file://${encodePath(absolute)}`);
 }

--- a/src/platform/compat/std/async.test.ts
+++ b/src/platform/compat/std/async.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { testDelay } from "#veryfront/testing/timing.ts";
+import { readTextFile } from "../fs.ts";
+import { fromFileUrl } from "../path/index.ts";
+import { deleteEnv, setEnv } from "../process.ts";
+import { delay } from "./async.ts";
+
+const TEST_TIME_SCALE_ENV = "VF_TEST_TIME_SCALE";
+
+function captureScheduledDelay(schedule: () => Promise<void>): {
+  delayMs: number;
+  pending: Promise<void>;
+} {
+  const originalSetTimeout = globalThis.setTimeout;
+  let delayMs: number | undefined;
+  let pending: Promise<void> | undefined;
+
+  try {
+    globalThis.setTimeout = ((
+      callback: (...args: unknown[]) => void,
+      ms?: number,
+      ...args: unknown[]
+    ) => {
+      delayMs = ms ?? 0;
+      queueMicrotask(() => callback(...args));
+      return 0;
+    }) as unknown as typeof globalThis.setTimeout;
+    pending = schedule();
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+
+  if (delayMs === undefined || pending === undefined) {
+    throw new Error("Expected delay to schedule a timer");
+  }
+  return { delayMs, pending };
+}
+
+describe("platform/compat/std/async", () => {
+  afterEach(() => deleteEnv(TEST_TIME_SCALE_ENV));
+
+  it("runtime and testing delays use the same current scale", async () => {
+    setEnv(TEST_TIME_SCALE_ENV, "0.25");
+    const runtimeDelay = captureScheduledDelay(() => delay(100));
+    const testingDelay = captureScheduledDelay(() => testDelay(100));
+
+    assertEquals(runtimeDelay.delayMs, 25);
+    assertEquals(testingDelay.delayMs, 25);
+    await Promise.all([runtimeDelay.pending, testingDelay.pending]);
+  });
+
+  it("keeps production runtime imports outside the testing module", async () => {
+    const source = await readTextFile(fromFileUrl(new URL("./async.ts", import.meta.url)));
+    const importSpecifiers = Array.from(
+      source.matchAll(/\bfrom\s+["']([^"']+)["']/g),
+      (match) => match[1],
+    );
+
+    assertEquals(
+      importSpecifiers.filter((specifier) => specifier?.includes("/testing/")),
+      [],
+    );
+  });
+});

--- a/src/platform/compat/std/async.ts
+++ b/src/platform/compat/std/async.ts
@@ -1,16 +1,6 @@
-import { isDeno } from "../runtime.ts";
-import { scaleMs } from "#veryfront/testing/timing.ts";
+import { scaleDuration } from "../time-scale.ts";
 
-// no cleanup needed: one-shot
-function nodeDelay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, scaleMs(ms)));
-}
-
-export let delay: (ms: number) => Promise<void>;
-
-if (!isDeno) {
-  delay = nodeDelay;
-} else {
-  const { delay: stdDelay } = await import("#std/async.ts");
-  delay = (ms: number) => stdDelay(scaleMs(ms));
+/** Resolve after the scaled duration using the host timer contract. */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, scaleDuration(ms)));
 }

--- a/src/platform/compat/std/fmt-colors.test.ts
+++ b/src/platform/compat/std/fmt-colors.test.ts
@@ -1,0 +1,16 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createColor } from "./fmt-colors.ts";
+
+describe("platform/compat/std/fmt-colors", () => {
+  it("reopens an outer ANSI style after a nested close sequence", () => {
+    const red = createColor(31, 39);
+    const blue = createColor(34, 39);
+
+    assertEquals(
+      red(`before ${blue("nested")} after`),
+      "\x1b[31mbefore \x1b[34mnested\x1b[31m after\x1b[39m",
+    );
+  });
+});

--- a/src/platform/compat/std/fmt-colors.ts
+++ b/src/platform/compat/std/fmt-colors.ts
@@ -1,21 +1,20 @@
 /**
- * Portable @std/fmt/colors shim for Node.js and Bun.
- *
- * In Deno: Uses @std/fmt/colors
- * In Node.js/Bun: Provides ANSI escape code implementations
+ * Dependency-free ANSI color functions for every supported runtime.
  *
  * @module
  */
 
-import { isDeno } from "../runtime.ts";
-
 type ColorFn = (str: string) => string;
 
-function createColor(open: number, close: number): ColorFn {
-  return (str: string) => `\x1b[${open}m${str}\x1b[${close}m`;
+/** @internal Builds one ANSI wrapper while preserving an outer nested style. */
+export function createColor(open: number, close: number): ColorFn {
+  const openSequence = `\x1b[${open}m`;
+  const closeSequence = `\x1b[${close}m`;
+  return (str: string) =>
+    openSequence + str.split(closeSequence).join(openSequence) + closeSequence;
 }
 
-const nodeColors = {
+const colors = {
   red: createColor(31, 39),
   green: createColor(32, 39),
   yellow: createColor(33, 39),
@@ -51,12 +50,8 @@ const nodeColors = {
   hidden: createColor(8, 28),
   strikethrough: createColor(9, 29),
 
-  reset: (str: string) => `\x1b[0m${str}\x1b[0m`,
+  reset: createColor(0, 0),
 } satisfies Record<string, ColorFn>;
-
-const colors: Record<string, ColorFn> = isDeno
-  ? ((await import("#std/fmt/colors.ts")) as unknown as Record<string, ColorFn>)
-  : nodeColors;
 
 export const {
   red,

--- a/src/platform/compat/std/path.ts
+++ b/src/platform/compat/std/path.ts
@@ -1,5 +1,3 @@
-import { isDeno } from "../runtime.ts";
-
 export {
   basename,
   delimiter,
@@ -17,20 +15,4 @@ export {
   SEPARATOR,
   toFileUrl,
 } from "../path/index.ts";
-
-interface PosixPath {
-  join(...paths: string[]): string;
-  resolve(...paths: string[]): string;
-  normalize(path: string): string;
-  relative(from: string, to: string): string;
-  dirname(path: string): string;
-  basename(path: string, ext?: string): string;
-  extname(path: string): string;
-  isAbsolute(path: string): boolean;
-  sep: string;
-  delimiter: string;
-}
-
-const { posix } = isDeno ? await import("#std/path.ts") : await import("node:path");
-
-export { posix };
+export { posix, type PosixPath } from "../path/posix.ts";

--- a/src/platform/compat/time-scale.ts
+++ b/src/platform/compat/time-scale.ts
@@ -1,0 +1,24 @@
+import { getEnv } from "./process/env.ts";
+
+const DEFAULT_TIME_SCALE = 1;
+const TIME_SCALE_ENV = "VF_TEST_TIME_SCALE";
+
+function readTimeScale(): number {
+  const raw = getEnv(TIME_SCALE_ENV);
+  if (!raw) return DEFAULT_TIME_SCALE;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TIME_SCALE;
+
+  return parsed;
+}
+
+/** Return the configured cross-runtime time scale. */
+export function getTimeScale(): number {
+  return readTimeScale();
+}
+
+/** Scale a duration for cross-runtime timers. */
+export function scaleDuration(ms: number, minMs = 1): number {
+  return Math.max(minMs, Math.round(ms * readTimeScale()));
+}

--- a/src/task/discovery.ts
+++ b/src/task/discovery.ts
@@ -20,7 +20,7 @@
  * ```
  */
 
-import { join } from "@std/path";
+import { join } from "veryfront/platform/path";
 import { logger as baseLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform";
 import type { VeryfrontConfig } from "#veryfront/config";

--- a/src/task/discovery.ts
+++ b/src/task/discovery.ts
@@ -20,7 +20,7 @@
  * ```
  */
 
-import { join } from "veryfront/platform/path";
+import { join } from "#veryfront/compat/path";
 import { logger as baseLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform";
 import type { VeryfrontConfig } from "#veryfront/config";

--- a/src/testing/timing.test.ts
+++ b/src/testing/timing.test.ts
@@ -1,0 +1,38 @@
+import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { assertEquals } from "./assert.ts";
+import { afterEach, describe, it } from "./bdd.ts";
+import { getTestTimeScale, scaleMs } from "./timing.ts";
+
+const TEST_TIME_SCALE_ENV = "VF_TEST_TIME_SCALE";
+
+describe("testing/timing", () => {
+  afterEach(() => deleteEnv(TEST_TIME_SCALE_ENV));
+
+  it("uses the default scale when the environment value is absent or invalid", () => {
+    deleteEnv(TEST_TIME_SCALE_ENV);
+    assertEquals(getTestTimeScale(), 1, "missing scale should use the default");
+
+    for (const value of ["", "0", "-1", "NaN", "Infinity"]) {
+      setEnv(TEST_TIME_SCALE_ENV, value);
+      assertEquals(getTestTimeScale(), 1, `${value || "empty"} should use the default`);
+    }
+  });
+
+  it("reads the current positive scale on every call", () => {
+    setEnv(TEST_TIME_SCALE_ENV, "0.25");
+    assertEquals(getTestTimeScale(), 0.25);
+    assertEquals(scaleMs(100), 25);
+
+    setEnv(TEST_TIME_SCALE_ENV, "2");
+    assertEquals(getTestTimeScale(), 2);
+    assertEquals(scaleMs(100), 200);
+  });
+
+  it("rounds scaled durations and enforces the requested minimum", () => {
+    setEnv(TEST_TIME_SCALE_ENV, "0.25");
+
+    assertEquals(scaleMs(10), 3, "scaled durations should use Math.round");
+    assertEquals(scaleMs(1), 1, "the default minimum should be one millisecond");
+    assertEquals(scaleMs(1, 5), 5, "the caller-provided minimum should be honored");
+  });
+});

--- a/src/testing/timing.ts
+++ b/src/testing/timing.ts
@@ -1,25 +1,13 @@
-import { getEnv } from "#veryfront/platform/compat/process.ts";
-
-const DEFAULT_SCALE = 1;
-
-function readScale(): number {
-  const raw = getEnv("VF_TEST_TIME_SCALE");
-  if (!raw) return DEFAULT_SCALE;
-
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SCALE;
-
-  return parsed;
-}
+import { getTimeScale, scaleDuration } from "#veryfront/platform/compat/time-scale.ts";
 
 /** Return test time scale. */
 export function getTestTimeScale(): number {
-  return readScale();
+  return getTimeScale();
 }
 
 /** Scale a duration for the current test runtime. */
 export function scaleMs(ms: number, minMs = 1): number {
-  return Math.max(minMs, Math.round(ms * readScale()));
+  return scaleDuration(ms, minMs);
 }
 
 // no cleanup needed: one-shot

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
@@ -17,6 +17,7 @@ import {
 import { FRAMEWORK_ROOT, HASH_SEED_FNV1A } from "../constants.ts";
 import { resolveVeryfrontModuleUrl } from "../../../veryfront-module-urls.ts";
 import { MDX_ESM_CACHE_NAMESPACE } from "../cache-format.ts";
+import { normalizePath } from "./module-cache.ts";
 
 function getTransformCacheKey(
   projectId: string,
@@ -37,26 +38,6 @@ function rewriteVeryfrontImports(code: string): string {
     const mapped = resolveVeryfrontModuleUrl(specifier);
     return `from "${mapped ?? specifier}"`;
   });
-}
-
-function normalizePath(modulePath: string, parentModulePath?: string): string {
-  const stripped = modulePath.replace(/^\//, "");
-  if (!parentModulePath) return stripped;
-
-  const isRelative = modulePath.startsWith("./") || modulePath.startsWith("../");
-  if (!isRelative) return stripped;
-
-  const parentDir = parentModulePath.replace(/\/[^/]+$/, "");
-  const parts = [...parentDir.split("/"), ...modulePath.split("/")];
-
-  const resolved: string[] = [];
-  for (const part of parts) {
-    if (part === "..") resolved.pop();
-    else if (part !== ".") resolved.push(part);
-  }
-
-  const joined = resolved.join("/");
-  return joined.startsWith("_vf_modules/") ? joined : `_vf_modules/${joined}`;
 }
 
 function findNestedImports(moduleCode: string): {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 /** @module transforms/mdx/esm-module-loader/module-fetcher/index.test */
 
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { makeTempDir, remove } from "#veryfront/testing/deno-compat.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -198,6 +198,37 @@ describe("module-fetcher", { sanitizeResources: false, sanitizeOps: false }, () 
     it("resolves ../ relative import against parent", () => {
       const result = normalizePath("../lib/helper.js", "_vf_modules/pages/index.js");
       assertEquals(result, "_vf_modules/lib/helper.js");
+    });
+
+    it("allows relative imports that reach but do not escape the virtual root", () => {
+      const result = normalizePath("../../shared.js", "_vf_modules/a/b/page.js");
+      assertEquals(result, "_vf_modules/shared.js");
+    });
+
+    it("rejects relative imports that escape the virtual root", () => {
+      assertThrows(
+        () => normalizePath("../../secret.js", "_vf_modules/pages/index.js"),
+        TypeError,
+        "project module root",
+      );
+      assertThrows(
+        () => normalizePath("../../../secret.js", "_vf_modules/pages/index.js"),
+        TypeError,
+        "project module root",
+      );
+    });
+
+    it("rejects pre-normalized paths that escape the virtual root", () => {
+      assertThrows(
+        () => normalizePath("_vf_modules/../secret.js"),
+        TypeError,
+        "project module root",
+      );
+      assertThrows(
+        () => normalizePath("../secret.js"),
+        TypeError,
+        "project module root",
+      );
     });
 
     it("adds _vf_modules/ prefix if missing after resolution", () => {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
@@ -18,23 +18,31 @@ import { hasUnresolvedImports } from "./nested-imports.ts";
 import { recordModuleToSession } from "./render-sessions.ts";
 import { ensureFilenameDefaultExport } from "#veryfront/modules/loader-shared/filename-default-export.ts";
 import { getMdxModuleCacheVariant } from "./cache-keys.ts";
+import { canonicalizeContainedModulePath, isVfModulePath } from "../resolution/module-path.ts";
+
+function invalidModulePath(): never {
+  throw new TypeError("Module path must remain within the project module root");
+}
 
 /**
  * Normalize a module path, resolving relative paths if a parent is provided.
  */
 export function normalizePath(modulePath: string, parentModulePath?: string): string {
-  // Strip query parameters (e.g., ?ssr=true) as they're not part of the file path
-  // and cause issues with cache key validation (? is not an allowed character)
-  let normalizedPath = modulePath.replace(/\?.*$/, "").replace(/^\//, "");
+  const relativeImport = modulePath.startsWith("./") || modulePath.startsWith("../");
+  if (!parentModulePath || !relativeImport) {
+    return canonicalizeContainedModulePath(modulePath) ?? invalidModulePath();
+  }
 
-  if (!parentModulePath) return normalizedPath;
-  if (!modulePath.startsWith("./") && !modulePath.startsWith("../")) return normalizedPath;
+  const normalizedParent = canonicalizeContainedModulePath(parentModulePath) ??
+    invalidModulePath();
+  const parentDir = posix.dirname(normalizedParent);
+  const resolvedPath = canonicalizeContainedModulePath(posix.join(parentDir, modulePath)) ??
+    invalidModulePath();
 
-  const parentDir = parentModulePath.replace(/\/[^/]+$/, "");
-  normalizedPath = posix.normalize(posix.join(parentDir, modulePath));
-
-  if (!normalizedPath.startsWith("_vf_modules/")) normalizedPath = `_vf_modules/${normalizedPath}`;
-  return normalizedPath;
+  if (isVfModulePath(normalizedParent) && !isVfModulePath(resolvedPath)) {
+    return invalidModulePath();
+  }
+  return isVfModulePath(resolvedPath) ? resolvedPath : `_vf_modules/${resolvedPath}`;
 }
 
 /**

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
@@ -7,8 +7,7 @@
  * @module transforms/mdx/esm-module-loader/module-fetcher/module-cache
  */
 
-import { join } from "#veryfront/compat/path";
-import * as posix from "#std/path/posix";
+import { join, posix } from "#veryfront/compat/path";
 import type { Logger } from "#veryfront/utils";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";

--- a/src/transforms/mdx/esm-module-loader/resolution/file-finder.test.ts
+++ b/src/transforms/mdx/esm-module-loader/resolution/file-finder.test.ts
@@ -92,6 +92,22 @@ describe("resolveModuleFile", () => {
     assertEquals(wasCalled(), true, "Should call adapter.fs.resolveFile for project paths");
   });
 
+  it("rejects traversal paths before consulting the filesystem adapter", async () => {
+    for (
+      const path of [
+        "_vf_modules/../secret.js",
+        "_vf_modules/../../secret.js",
+        "../secret.js",
+        "_vf_modules\\..\\secret.js",
+        "C:/secret.js",
+      ]
+    ) {
+      const { adapter, wasCalled } = createResolveFileTrackingAdapter();
+      assertEquals(await resolveModuleFile(path, adapter as any, "/project"), null);
+      assertEquals(wasCalled(), false);
+    }
+  });
+
   it("resolves framework react/* files", async () => {
     await assertResolvedModuleFile(
       "_vf_modules/_veryfront/react/router/index.js",

--- a/src/transforms/mdx/esm-module-loader/resolution/file-finder.ts
+++ b/src/transforms/mdx/esm-module-loader/resolution/file-finder.ts
@@ -8,6 +8,7 @@ import {
 } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { DIRECTORY_PREFIXES, LOG_PREFIX_MDX_LOADER, MODULE_EXTENSIONS } from "../constants.ts";
 import { getLocalFs } from "../cache/index.ts";
+import { canonicalizeContainedModulePath } from "./module-path.ts";
 
 const logger = rendererLogger.component("file-finder");
 
@@ -51,7 +52,11 @@ export async function resolveModuleFile(
   adapter: RuntimeAdapter,
   projectDir?: string,
 ): Promise<FileResolutionResult | null> {
-  const normalized = normalizedPath.replace(/^\/+/, "");
+  const normalized = canonicalizeContainedModulePath(normalizedPath);
+  if (!normalized) {
+    logger.warn(`${LOG_PREFIX_MDX_LOADER} Rejected module path outside project root`);
+    return null;
+  }
   const withoutVfModules = normalized.replace(/^_vf_modules\//, "");
   const isFramework = withoutVfModules.startsWith(FRAMEWORK_PREFIX);
   const rawPath = isFramework ? withoutVfModules.slice(FRAMEWORK_PREFIX.length) : withoutVfModules;

--- a/src/transforms/mdx/esm-module-loader/resolution/module-path.ts
+++ b/src/transforms/mdx/esm-module-loader/resolution/module-path.ts
@@ -1,0 +1,48 @@
+import { posix } from "#veryfront/compat/path";
+
+const VF_MODULE_ROOT = "_vf_modules";
+const VF_MODULE_PREFIX = `${VF_MODULE_ROOT}/`;
+
+/**
+ * Canonicalize a module path only when it remains project-relative and, when
+ * rooted in `_vf_modules`, remains below that virtual root.
+ */
+export function canonicalizeContainedModulePath(modulePath: string): string | null {
+  const candidate = modulePath
+    .replace(/\?.*$/, "")
+    .replace(/^\/+/, "");
+
+  if (
+    !candidate ||
+    candidate.includes("\\") ||
+    candidate.includes("\0") ||
+    /^[A-Za-z]:/.test(candidate)
+  ) {
+    return null;
+  }
+
+  const normalized = posix.normalize(candidate);
+  if (
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    posix.isAbsolute(normalized)
+  ) {
+    return null;
+  }
+
+  const wasVfModulePath = candidate === VF_MODULE_ROOT || candidate.startsWith(VF_MODULE_PREFIX);
+  if (
+    wasVfModulePath &&
+    normalized !== VF_MODULE_ROOT &&
+    !normalized.startsWith(VF_MODULE_PREFIX)
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function isVfModulePath(modulePath: string): boolean {
+  return modulePath === VF_MODULE_ROOT || modulePath.startsWith(VF_MODULE_PREFIX);
+}

--- a/src/trigger/discovery.ts
+++ b/src/trigger/discovery.ts
@@ -1,4 +1,4 @@
-import { join } from "@std/path";
+import { join } from "veryfront/platform/path";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { importDiscoveryModule } from "#veryfront/discovery/module-import.ts";
 import type { RuntimeAdapter } from "#veryfront/platform";

--- a/src/trigger/discovery.ts
+++ b/src/trigger/discovery.ts
@@ -1,4 +1,4 @@
-import { join } from "veryfront/platform/path";
+import { join } from "#veryfront/compat/path";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { importDiscoveryModule } from "#veryfront/discovery/module-import.ts";
 import type { RuntimeAdapter } from "#veryfront/platform";

--- a/src/workflow/claude-code/workspace-sync.test.ts
+++ b/src/workflow/claude-code/workspace-sync.test.ts
@@ -216,18 +216,27 @@ describe("WorkspaceSync symlink hardening (VULN-FS-4)", () => {
 
   it("rejects Windows-style drive-letter absolute paths", async () => {
     const { workspace } = await makeWorkspace(baseDir);
-    await assertRejects(
-      () => workspace.writeFile("C:\\Windows\\pwn.txt", "x"),
-      Error,
-    );
+    for (const path of ["C:\\Windows\\pwn.txt", "/D:/outside/pwn.txt"]) {
+      await assertRejects(
+        () => workspace.writeFile(path, "x"),
+        Error,
+      );
+    }
   });
 
-  it("rejects UNC-style double-slash paths", async () => {
+  it("rejects UNC-style paths with either separator", async () => {
     const { workspace } = await makeWorkspace(baseDir);
-    await assertRejects(
-      () => workspace.writeFile("//evil-host/share/pwn.txt", "x"),
-      Error,
-    );
+    for (
+      const path of [
+        "//evil-host/share/pwn.txt",
+        String.raw`\\evil-host\share\pwn.txt`,
+      ]
+    ) {
+      await assertRejects(
+        () => workspace.writeFile(path, "x"),
+        Error,
+      );
+    }
   });
 
   it("an absolute-looking Unix path does NOT escape the workspace", async () => {

--- a/src/workflow/claude-code/workspace-sync.test.ts
+++ b/src/workflow/claude-code/workspace-sync.test.ts
@@ -184,6 +184,19 @@ describe("WorkspaceSync symlink hardening (VULN-FS-4)", () => {
     assertEquals(info.isDirectory, true);
   });
 
+  it("rejects root-equivalent paths before the workspace exists", async () => {
+    const workspace = new WorkspaceSync({
+      baseDir,
+      runId: "pre-init-root-equivalent",
+      tenant: stubTenant(),
+    });
+
+    for (const path of [".", "segment/..", "segment/../."]) {
+      await assertRejects(() => workspace.writeFile(path, "x"), Error);
+    }
+    assertEquals(await exists(workspace.workspaceDir), false);
+  });
+
   it("rejects paths containing a NUL byte", async () => {
     const { workspace } = await makeWorkspace(baseDir);
     await assertRejects(

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -13,7 +13,7 @@
 import { computeHash, logger as baseLogger } from "#veryfront/utils";
 import { api } from "../api.ts";
 import type { CapturedTenantContext } from "../types.ts";
-import { dirname, join, relative, resolve } from "veryfront/platform/path";
+import { dirname, join, relative, resolve } from "#veryfront/compat/path";
 import { INITIALIZATION_ERROR, INVALID_ARGUMENT, SECURITY_VIOLATION } from "#veryfront/errors";
 import { isWithinDirectory } from "#veryfront/utils/path-utils.ts";
 

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -515,13 +515,19 @@ export class WorkspaceSync {
     // Resolve the full path lexically first (catches literal "..").
     const fullPath = resolve(join(this.workspaceDir, normalizedPath));
     const relativePath = relative(this.workspaceDir, fullPath);
-    if (!relativePath || relativePath.startsWith("..") || relativePath === "..") {
+    if (
+      !relativePath ||
+      relativePath === "." ||
+      relativePath === ".." ||
+      relativePath.startsWith("../") ||
+      relativePath.startsWith("..\\")
+    ) {
       throw SECURITY_VIOLATION.create({ detail: `Path traversal detected: ${path}` });
     }
 
     // Walk each segment and reject any existing symlink along the way.
     // A segment that does not yet exist is fine — it will be created later.
-    const relSegments = relativePath === "" ? [] : relativePath.split(/[\\/]/).filter(Boolean);
+    const relSegments = relativePath.split(/[\\/]/).filter(Boolean);
     let cursor = this.workspaceDir;
     for (const seg of relSegments) {
       cursor = join(cursor, seg);

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -13,7 +13,7 @@
 import { computeHash, logger as baseLogger } from "#veryfront/utils";
 import { api } from "../api.ts";
 import type { CapturedTenantContext } from "../types.ts";
-import { dirname, join, relative, resolve } from "#veryfront/compat/path";
+import { dirname, isAbsolute, join, relative, resolve } from "#veryfront/compat/path";
 import { INITIALIZATION_ERROR, INVALID_ARGUMENT, SECURITY_VIOLATION } from "#veryfront/errors";
 import { isWithinDirectory } from "#veryfront/utils/path-utils.ts";
 
@@ -499,7 +499,7 @@ export class WorkspaceSync {
     if (/^[A-Za-z]:[\\/]/.test(path)) {
       throw SECURITY_VIOLATION.create({ detail: `Absolute path not allowed: ${path}` });
     }
-    if (path.startsWith("//")) {
+    if (path.startsWith("//") || path.startsWith("\\\\")) {
       throw SECURITY_VIOLATION.create({ detail: `Absolute path not allowed: ${path}` });
     }
 
@@ -519,6 +519,7 @@ export class WorkspaceSync {
       !relativePath ||
       relativePath === "." ||
       relativePath === ".." ||
+      isAbsolute(relativePath) ||
       relativePath.startsWith("../") ||
       relativePath.startsWith("..\\")
     ) {

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -13,7 +13,7 @@
 import { computeHash, logger as baseLogger } from "#veryfront/utils";
 import { api } from "../api.ts";
 import type { CapturedTenantContext } from "../types.ts";
-import { dirname, join, relative, resolve } from "@std/path";
+import { dirname, join, relative, resolve } from "veryfront/platform/path";
 import { INITIALIZATION_ERROR, INVALID_ARGUMENT, SECURITY_VIOLATION } from "#veryfront/errors";
 import { isWithinDirectory } from "#veryfront/utils/path-utils.ts";
 

--- a/src/workflow/discovery/workflow-discovery.ts
+++ b/src/workflow/discovery/workflow-discovery.ts
@@ -22,7 +22,7 @@
  * ```
  */
 
-import { join } from "@std/path";
+import { join } from "veryfront/platform/path";
 import { logger as baseLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform";
 import type { VeryfrontConfig } from "#veryfront/config";

--- a/src/workflow/discovery/workflow-discovery.ts
+++ b/src/workflow/discovery/workflow-discovery.ts
@@ -22,7 +22,7 @@
  * ```
  */
 
-import { join } from "veryfront/platform/path";
+import { join } from "#veryfront/compat/path";
 import { logger as baseLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform";
 import type { VeryfrontConfig } from "#veryfront/config";

--- a/tests/bun/preload.ts
+++ b/tests/bun/preload.ts
@@ -15,6 +15,17 @@ import { fileURLToPath } from "url";
 
 const projectRoot = resolve(dirname(import.meta.dir), "../..");
 
+const denoConfig = JSON.parse(
+  readFileSync(resolve(projectRoot, "deno.json"), "utf-8"),
+) as { imports?: Record<string, unknown> };
+const localProjectImportMap = Object.fromEntries(
+  Object.entries(denoConfig.imports ?? {}).filter(
+    (entry): entry is [string, string] =>
+      typeof entry[1] === "string" &&
+      (entry[1].startsWith("./") || entry[1].startsWith("../")),
+  ),
+);
+
 const stdImportMap: Record<string, string> = {
   "#std/assert": "./src/testing/assert.ts",
   "#std/assert.ts": "./src/testing/assert.ts",
@@ -54,6 +65,7 @@ const reactImportMap: Record<string, string> = {
 
 const importMap: Record<string, string> = {
   "#deno-config": "./deno.json",
+  ...localProjectImportMap,
   ...stdImportMap,
   ...reactImportMap,
 };

--- a/tests/bun/preload.ts
+++ b/tests/bun/preload.ts
@@ -10,7 +10,7 @@
 
 import { plugin } from "bun";
 import { existsSync, readFileSync, statSync } from "fs";
-import { extname, resolve } from "path";
+import { dirname, extname, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const projectRoot = resolve(import.meta.dir, "../..");

--- a/tests/bun/preload.ts
+++ b/tests/bun/preload.ts
@@ -10,10 +10,10 @@
 
 import { plugin } from "bun";
 import { existsSync, readFileSync, statSync } from "fs";
-import { dirname, extname, resolve } from "path";
+import { extname, resolve } from "path";
 import { fileURLToPath } from "url";
 
-const projectRoot = resolve(dirname(import.meta.dir), "../..");
+const projectRoot = resolve(import.meta.dir, "../..");
 
 const denoConfig = JSON.parse(
   readFileSync(resolve(projectRoot, "deno.json"), "utf-8"),

--- a/tests/support/cli-vcr.ts
+++ b/tests/support/cli-vcr.ts
@@ -10,8 +10,8 @@
 
 import { load } from "#std/dotenv.ts";
 import { cliLogger } from "../../cli/utils/index.ts";
-import { cwd } from "veryfront/platform";
-import { createFileSystem } from "veryfront/platform";
+import { createFileSystem, cwd } from "veryfront/platform";
+import { fromFileUrl, join } from "veryfront/platform/path";
 import { type EnvironmentConfig, getEnvironmentConfig } from "veryfront/config";
 import type { ApiClient } from "../../cli/shared/config.ts";
 
@@ -72,8 +72,8 @@ export async function createVCRClient(
 ): Promise<{ client: ApiClient; save: () => Promise<void>; projectSlug: string }> {
   const fs = createFileSystem();
   const recording = env.vcr === "record";
-  const fixturesDir = new URL("../../cli/test-fixtures", import.meta.url).pathname;
-  const cassettePath = `${fixturesDir}/${cassetteName}.json`;
+  const fixturesDir = fromFileUrl(new URL("../../cli/test-fixtures/", import.meta.url));
+  const cassettePath = join(fixturesDir, `${cassetteName}.json`);
 
   let cassette: VCRCassette = {
     meta: { projectSlug: projectSlug ?? "", recordedAt: "" },

--- a/tests/support/cli-vcr.ts
+++ b/tests/support/cli-vcr.ts
@@ -5,15 +5,15 @@
  * Record:  deno task test:vcr:record
  * Replay:  deno task test:vcr (default)
  *
- * @module cli/test-utils/vcr
+ * @module tests/support/cli-vcr
  *************************/
 
 import { load } from "#std/dotenv.ts";
-import { cliLogger } from "#cli/utils";
+import { cliLogger } from "../../cli/utils/index.ts";
 import { cwd } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import { type EnvironmentConfig, getEnvironmentConfig } from "veryfront/config";
-import type { ApiClient } from "../shared/config.ts";
+import type { ApiClient } from "../../cli/shared/config.ts";
 
 // Load .env.local for credentials in record mode
 try {
@@ -72,7 +72,7 @@ export async function createVCRClient(
 ): Promise<{ client: ApiClient; save: () => Promise<void>; projectSlug: string }> {
   const fs = createFileSystem();
   const recording = env.vcr === "record";
-  const fixturesDir = new URL("../test-fixtures", import.meta.url).pathname;
+  const fixturesDir = new URL("../../cli/test-fixtures", import.meta.url).pathname;
   const cassettePath = `${fixturesDir}/${cassetteName}.json`;
 
   let cassette: VCRCassette = {
@@ -195,7 +195,7 @@ export async function initVCRTest(
   if (!env.projectSlug) throw new Error("VCR=record requires VERYFRONT_PROJECT_SLUG");
 
   // Dynamic import to avoid loading config module in playback mode
-  const { createApiClient, resolveConfig } = await import("../shared/config.ts");
+  const { createApiClient, resolveConfig } = await import("../../cli/shared/config.ts");
   const config = await resolveConfig(cwd());
   const realClient = createApiClient(config);
   const vcr = await createVCRClient(cassetteName, realClient, env.projectSlug, env);


### PR DESCRIPTION
## Description

First dependency-free core-runtime foundation from the recovered module-hardening work.

- Removes the production Platform -> Testing timer dependency and centralizes time scaling.
- Replaces external path/color runtime dependencies with local implementations.
- Hardens path behavior across Deno, Node ESM, Bun resolution, browser fallback, Windows drives, UNC paths, and redundant POSIX roots.
- Preserves the existing public path-facade semantics while migrating core source to the internal #veryfront/compat/path alias and CLI code to the public veryfront/platform/path export.
- Rejects non-local file URL hosts on non-Windows runtimes instead of silently mapping them to ambiguous local paths; Windows UNC conversion remains supported.
- Rejects root-equivalent, device-root, and UNC WorkspaceSync paths before filesystem access.
- Moves CLI VCR support out of shipped CLI sources and updates its documentation.

No third-party core dependency is introduced.

## Related Issue(s)

Module-hardening landing train; no standalone issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Verification

- Deno foundation suites: 13 passed / 216 steps
- Current Deno path portfolio: 7 passed / 147 steps
- Migrated-consumer suites: 24 passed / 241 steps
- CLI VCR playback: 4 passed / 21 steps
- Node focused suites: 121 tests passed; current URL-conversion contract is included in the Node path portfolio
- Bun 1.3.14 focused runtime: 22 tests passed across URL conversion and cache-busted file loading
- Workspace security regression suite: 21 steps passed
- Cross-runtime compatibility probe passed
- Deterministic path differential checks: 2.4 million operations, 0 mismatches
- Frozen typecheck, formatting, lint, diff check, core dependency, dependency boundary, module boundary, and CLI boundary gates passed
- Platform lint reports the same 45 pre-existing baseline violations; this PR adds none
- Independent semantic reviews found no remaining unresolved Critical or Important issue at the current head

## Compatibility note

Hosted file URLs are only representable as UNC filesystem paths on Windows. On non-Windows runtimes, fromFileUrl now throws TypeError for a host other than localhost instead of dropping or reinterpreting the authority as a local path. Local and localhost file URLs are unchanged, and forward-slash double-root paths retain POSIX-local semantics.

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
