### PR TITLE
fix(agent): preserve deferred catalogs beyond provider limits

### DIFF
--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -173,6 +173,44 @@ Deno.test("prepareHostedChatRuntimeToolAssembly defers an unrestricted tools tru
   assertEquals(taskContext.availableToolNames, ["tool_search"]);
 });
 
+Deno.test("prepareHostedChatRuntimeToolAssembly preserves the full deferred OpenAI catalog", async () => {
+  const remoteTools = [
+    ...Array.from(
+      { length: 132 },
+      (_, index) => remoteTool(`catalog_tool_${String(index).padStart(3, "0")}`, "Catalog tool"),
+    ),
+    remoteTool("write_sandbox_files", "Write sandbox files"),
+  ];
+  const remoteToolNames = remoteTools.map((tool) => tool.name);
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "openai/gpt-5.5",
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    sourceIntegrationPolicy: unrestrictedSourceIntegrationPolicy,
+    taskContext,
+    instructions: "Base instructions",
+    localTools: { load_skill: localTool("Load skill") },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: null,
+    createRemoteToolSource: (config) => ({
+      id: config.id ?? "api-mcp",
+      listTools: () => Promise.resolve(remoteTools),
+      executeTool: () => Promise.resolve({ ok: true }),
+    }),
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.toolLoadingMode, "deferred");
+  assertEquals(toolAssembly.remoteToolNames, remoteToolNames);
+  assertEquals(toolAssembly.compatibleRemoteToolNames, remoteToolNames);
+  assertEquals(toolAssembly.availableToolNames, ["load_skill", ...remoteToolNames].sort());
+  assertEquals(taskContext.availableToolNames, ["load_skill", "tool_search"]);
+});
+
 Deno.test("prepareHostedChatRuntimeToolAssembly enforces the host authorization ceiling before discovery", async () => {
   const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
     sourceIntegrationPolicy: unrestrictedSourceIntegrationPolicy,

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -355,25 +355,25 @@ export async function prepareHostedChatRuntimeToolAssembly<
     input.sourceIntegrationPolicy,
   );
   const localToolNames = Object.keys(localHostTools);
-  // Initial inventory = configured-binding remote tools + local + provider-native.
-  // The full MCP catalog does not flood the union: remoteToolNames is already
-  // filtered by the agent's configured binding (allowedToolNames), so only the
-  // explicitly selected subset reaches the provider cap. On-demand activation
-  // via load_tools extends this set at runtime beyond what the binding pre-loads.
-  const availableToolNames = selectProviderCompatibleToolNames(
-    [...new Set([...localToolNames, ...providerToolNames, ...remoteToolNames])].sort(),
-    {
-      model: input.taskContext.model,
-      requiredToolNames: localToolNames,
-    },
-  );
-  const compatibleToolNames = new Set(availableToolNames);
-  const compatibleRemoteToolNames = remoteToolNames.filter((toolName) =>
-    compatibleToolNames.has(toolName)
-  );
   const toolLoadingMode: RuntimeToolLoadingMode = input.allowedToolNames === null
     ? "deferred"
     : "eager";
+  const authorizedToolNames = [
+    ...new Set([...localToolNames, ...providerToolNames, ...remoteToolNames]),
+  ].sort();
+  // Deferred mode sends only bootstrap/search plus explicitly loaded schemas to
+  // the model, so the provider schema limit must not truncate its searchable or
+  // executable authorization catalog. Eager mode still needs an up-front cap.
+  const availableToolNames = toolLoadingMode === "deferred"
+    ? authorizedToolNames
+    : selectProviderCompatibleToolNames(authorizedToolNames, {
+      model: input.taskContext.model,
+      requiredToolNames: localToolNames,
+    });
+  const compatibleToolNames = new Set(availableToolNames);
+  const compatibleRemoteToolNames = toolLoadingMode === "deferred"
+    ? remoteToolNames
+    : remoteToolNames.filter((toolName) => compatibleToolNames.has(toolName));
   const bootstrapToolNames = availableToolNames.filter((toolName) =>
     toolName === "form_input" || toolName === "load_skill"
   );

--- a/src/agent/hosted/runtime-request-config.test.ts
+++ b/src/agent/hosted/runtime-request-config.test.ts
@@ -27,6 +27,18 @@ it("server-resolved tool exposure checkpoint parses strictly and fails closed", 
         version: 2,
       },
     }, true),
+    {
+      version: 2,
+      loadedToolNames: ["get_release"],
+    },
+  );
+  assertEquals(
+    getServerResolvedToolExposureCheckpoint({
+      serverResolvedToolExposureCheckpoint: {
+        ...checkpoint,
+        version: 3,
+      },
+    }, true),
     undefined,
   );
   assertEquals(

--- a/src/agent/hosted/runtime-request-config.ts
+++ b/src/agent/hosted/runtime-request-config.ts
@@ -9,7 +9,10 @@ import {
   type RuntimeClientProfile,
 } from "../runtime/client-profile.ts";
 import { AGENT_DELEGATE_TOOL_PREFIX } from "../runtime/agent-delegation-names.ts";
-import type { ToolExposureCheckpoint } from "../runtime/tool-exposure.ts";
+import {
+  isSupportedToolExposureCheckpointVersion,
+  type ToolExposureCheckpoint,
+} from "../runtime/tool-exposure.ts";
 
 /** Request payload for hosted runtime request config. */
 export type HostedRuntimeRequestConfigRequest = Pick<
@@ -66,7 +69,7 @@ export function getServerResolvedToolExposureCheckpoint(
   const value = forwardedProps?.serverResolvedToolExposureCheckpoint;
   if (
     !isRecord(value) ||
-    value.version !== 1 ||
+    !isSupportedToolExposureCheckpointVersion(value.version) ||
     !Array.isArray(value.loadedToolNames) ||
     !value.loadedToolNames.every((name) => typeof name === "string" && name.length > 0) ||
     new Set(value.loadedToolNames).size !== value.loadedToolNames.length
@@ -74,7 +77,7 @@ export function getServerResolvedToolExposureCheckpoint(
     return undefined;
   }
   return {
-    version: 1,
+    version: value.version,
     loadedToolNames: [...value.loadedToolNames],
   };
 }

--- a/src/agent/runtime/agent-runtime-step.ts
+++ b/src/agent/runtime/agent-runtime-step.ts
@@ -61,6 +61,7 @@ export interface PrepareAgentRuntimeStepInput {
   allowedRemoteToolNames: string[] | undefined;
   config: AgentConfig;
   effectiveModel?: string;
+  excludedToolNames?: ReadonlySet<string>;
   forwardedRemoteToolDefinitions: ToolDefinition[] | undefined;
   getAvailableTools: RuntimeStepToolLoader;
   isLocalModel: boolean;
@@ -149,6 +150,10 @@ export async function prepareAgentRuntimeStep(
     );
   }
   tools = filterToolsAfterSubmittedFormInput(tools, input.messages, runtimeState.context);
+  const excludedToolNames = input.excludedToolNames;
+  if (excludedToolNames !== undefined) {
+    tools = tools.filter((tool) => !excludedToolNames.has(tool.name));
+  }
   const toolExposureState = input.toolExposureState ?? createToolExposureState();
   if (input.toolExposureCheckpoint) {
     const restoredState = restoreToolExposureState(input.toolExposureCheckpoint, tools);

--- a/src/agent/runtime/agent-runtime-step.ts
+++ b/src/agent/runtime/agent-runtime-step.ts
@@ -21,6 +21,7 @@ import {
   hasRuntimeToolInventory,
   withRuntimeToolInventory,
 } from "./tool-inventory.ts";
+import { getProviderToolProfile } from "./provider-tool-compat.ts";
 
 export type AgentRuntimeStepMode = "generate" | "stream";
 
@@ -59,6 +60,7 @@ export interface PrepareAgentRuntimeStepInput {
   activeSkillToolAvailability: SkillToolAvailability | undefined;
   allowedRemoteToolNames: string[] | undefined;
   config: AgentConfig;
+  effectiveModel?: string;
   forwardedRemoteToolDefinitions: ToolDefinition[] | undefined;
   getAvailableTools: RuntimeStepToolLoader;
   isLocalModel: boolean;
@@ -159,6 +161,7 @@ export async function prepareAgentRuntimeStep(
     authorized: tools,
     mode: resolveRuntimeToolLoading(input.config).mode,
     state: toolExposureState,
+    maxVisibleTools: getProviderToolProfile(input.effectiveModel ?? input.config.model).maxTools,
   });
   const systemPrompt = hasRuntimeToolInventory(runtimeState.systemPrompt)
     ? flattenSystemInstructions(

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -259,26 +259,14 @@ function executeFrameworkToolSearch(input: {
   if (!query) {
     throw new Error('tool_search requires a non-empty "query" string');
   }
-  const alreadyVisible = input.plan.visible.find((tool) =>
-    tool.name === query && tool.name !== TOOL_SEARCH_TOOL_NAME
-  );
-  const result: ToolSearchResult = alreadyVisible
-    ? {
-      matches: [{
-        name: alreadyVisible.name,
-        description: alreadyVisible.description,
-        status: "available",
-      }],
-      resultCount: 1,
-      loadedCount: 0,
-      miss: false,
-    }
-    : searchToolExposure({
-      query,
-      authorized: input.plan.deferred,
-      state: input.state,
-      maxLoadedTools: input.plan.maxLoadedTools,
-    });
+  const result: ToolSearchResult = searchToolExposure({
+    query,
+    authorized: input.plan.deferred,
+    available: input.plan.visible.filter((tool) => tool.name !== TOOL_SEARCH_TOOL_NAME),
+    state: input.state,
+    maxLoadedTools: input.plan.maxLoadedTools,
+  });
+  const alreadyVisible = result.matches.find((match) => match.status === "available");
   return {
     result: {
       ...result,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -387,6 +387,11 @@ function shouldHideProjectToolAfterAgentWriteSuccess(toolName: string): boolean 
 
 function applyAgentWriteFinalResponseGuard(plan: ToolExposurePlan): ToolExposurePlan {
   const keep = (tool: { name: string }) => !shouldHideProjectToolAfterAgentWriteSuccess(tool.name);
+  for (const toolName of plan.loadedToolNames) {
+    if (shouldHideProjectToolAfterAgentWriteSuccess(toolName)) {
+      plan.loadedToolNames.delete(toolName);
+    }
+  }
   return {
     ...plan,
     authorized: plan.authorized.filter(keep),

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -371,14 +371,14 @@ function getResponseFinishReason(response: AgentResponse): string | undefined {
   return typeof finishReason === "string" && finishReason.length > 0 ? finishReason : undefined;
 }
 
-function shouldHideProjectToolAfterAgentWriteSuccess(toolName: string): boolean {
-  return toolName === "create_agent" || toolName === "update_agent";
-}
-
 const AGENT_WRITE_FINAL_RESPONSE_EXCLUDED_TOOL_NAMES = new Set([
   "create_agent",
   "update_agent",
 ]);
+
+function shouldHideProjectToolAfterAgentWriteSuccess(toolName: string): boolean {
+  return AGENT_WRITE_FINAL_RESPONSE_EXCLUDED_TOOL_NAMES.has(toolName);
+}
 
 function applyAgentWriteFinalResponseGuard(plan: ToolExposurePlan): ToolExposurePlan {
   const keep = (tool: { name: string }) => !shouldHideProjectToolAfterAgentWriteSuccess(tool.name);

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -260,7 +260,7 @@ function executeFrameworkToolSearch(input: {
   }
   const result = searchToolExposure({
     query,
-    authorized: input.plan.authorized,
+    authorized: input.plan.deferred,
     state: input.state,
     maxLoadedTools: input.plan.maxLoadedTools,
   });

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -375,6 +375,11 @@ function shouldHideProjectToolAfterAgentWriteSuccess(toolName: string): boolean 
   return toolName === "create_agent" || toolName === "update_agent";
 }
 
+const AGENT_WRITE_FINAL_RESPONSE_EXCLUDED_TOOL_NAMES = new Set([
+  "create_agent",
+  "update_agent",
+]);
+
 function applyAgentWriteFinalResponseGuard(plan: ToolExposurePlan): ToolExposurePlan {
   const keep = (tool: { name: string }) => !shouldHideProjectToolAfterAgentWriteSuccess(tool.name);
   return {
@@ -1114,6 +1119,9 @@ export class AgentRuntime {
           allowedRemoteToolNames,
           config: runtimeStepConfig,
           effectiveModel,
+          excludedToolNames: agentWriteFinalResponseToolGuardEnabled
+            ? AGENT_WRITE_FINAL_RESPONSE_EXCLUDED_TOOL_NAMES
+            : undefined,
           forwardedRemoteToolDefinitions,
           getAvailableTools,
           isLocalModel: isLocal,
@@ -1708,6 +1716,9 @@ export class AgentRuntime {
         allowedRemoteToolNames,
         config: runtimeStepConfig,
         effectiveModel,
+        excludedToolNames: agentWriteFinalResponseToolGuardEnabled
+          ? AGENT_WRITE_FINAL_RESPONSE_EXCLUDED_TOOL_NAMES
+          : undefined,
         forwardedRemoteToolDefinitions,
         getAvailableTools,
         isLocalModel: isLocalStreaming,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -262,6 +262,7 @@ function executeFrameworkToolSearch(input: {
     query,
     authorized: input.plan.authorized,
     state: input.state,
+    maxLoadedTools: input.plan.maxLoadedTools,
   });
   return {
     result: {
@@ -1112,6 +1113,7 @@ export class AgentRuntime {
             : activeSkillToolAvailability,
           allowedRemoteToolNames,
           config: runtimeStepConfig,
+          effectiveModel,
           forwardedRemoteToolDefinitions,
           getAvailableTools,
           isLocalModel: isLocal,
@@ -1705,6 +1707,7 @@ export class AgentRuntime {
         activeSkillToolAvailability,
         allowedRemoteToolNames,
         config: runtimeStepConfig,
+        effectiveModel,
         forwardedRemoteToolDefinitions,
         getAvailableTools,
         isLocalModel: isLocalStreaming,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -220,6 +220,7 @@ import {
   type ToolExposureCheckpoint,
   type ToolExposurePlan,
   type ToolExposureState,
+  type ToolSearchResult,
 } from "./tool-exposure.ts";
 
 const logger = serverLogger.component("agent");
@@ -258,16 +259,32 @@ function executeFrameworkToolSearch(input: {
   if (!query) {
     throw new Error('tool_search requires a non-empty "query" string');
   }
-  const result = searchToolExposure({
-    query,
-    authorized: input.plan.deferred,
-    state: input.state,
-    maxLoadedTools: input.plan.maxLoadedTools,
-  });
+  const alreadyVisible = input.plan.visible.find((tool) =>
+    tool.name === query && tool.name !== TOOL_SEARCH_TOOL_NAME
+  );
+  const result: ToolSearchResult = alreadyVisible
+    ? {
+      matches: [{
+        name: alreadyVisible.name,
+        description: alreadyVisible.description,
+        status: "available",
+      }],
+      resultCount: 1,
+      loadedCount: 0,
+      miss: false,
+    }
+    : searchToolExposure({
+      query,
+      authorized: input.plan.deferred,
+      state: input.state,
+      maxLoadedTools: input.plan.maxLoadedTools,
+    });
   return {
     result: {
       ...result,
-      nextStep: result.loadedCount > 0
+      nextStep: alreadyVisible
+        ? `The matching tool "${alreadyVisible.name}" is already available. Call it directly.`
+        : result.loadedCount > 0
         ? "Continue to the next model step. Loaded tool schemas will be available then."
         : "Continue with the available tools or answer without a tool.",
     },

--- a/src/agent/runtime/runtime-tool-config.test.ts
+++ b/src/agent/runtime/runtime-tool-config.test.ts
@@ -80,6 +80,18 @@ describe("agent/runtime-tool-config", () => {
           loadedToolNames: ["get_release"],
         },
       })),
+      {
+        version: 2,
+        loadedToolNames: ["get_release"],
+      },
+    );
+    assertEquals(
+      getRuntimeToolExposureCheckpoint(runtimeConfig({
+        __vfToolExposureCheckpoint: {
+          version: 3,
+          loadedToolNames: ["get_release"],
+        },
+      })),
       undefined,
     );
   });

--- a/src/agent/runtime/runtime-tool-config.ts
+++ b/src/agent/runtime/runtime-tool-config.ts
@@ -3,7 +3,11 @@ import type { AgentConfig } from "../types.ts";
 import type { RuntimeRemoteToolConfig } from "./mcp-server-tool-sources.ts";
 import { resolveEffectiveSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import { type SourceIntegrationPolicyManifest } from "#veryfront/integrations/source-policy.ts";
-import { isValidToolExposureCheckpointName, type ToolExposureCheckpoint } from "./tool-exposure.ts";
+import {
+  isSupportedToolExposureCheckpointVersion,
+  isValidToolExposureCheckpointName,
+  type ToolExposureCheckpoint,
+} from "./tool-exposure.ts";
 
 /** Internal schema-loading mode derived from the authored tools selector. */
 export type RuntimeToolLoadingMode = "eager" | "deferred";
@@ -98,7 +102,7 @@ export function getRuntimeToolExposureCheckpoint(
 ): ToolExposureCheckpoint | undefined {
   const value = (config as RuntimeToolFilterConfig).__vfToolExposureCheckpoint;
   if (
-    value?.version !== 1 ||
+    !isSupportedToolExposureCheckpointVersion(value?.version) ||
     !Array.isArray(value.loadedToolNames) ||
     !value.loadedToolNames.every(isValidToolExposureCheckpointName)
   ) {

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { it } from "#veryfront/testing/bdd.ts";
 import type { ModelRuntime } from "#veryfront/provider";
 import { defineSchema } from "#veryfront/schemas";
-import { tool } from "#veryfront/tool";
+import { type RemoteToolSource, tool, type ToolDefinition } from "#veryfront/tool";
 import { toolRegistry } from "#veryfront/tool/registry.ts";
 import { agent } from "../index.ts";
 import type { AgentConfig, Message } from "../types.ts";
@@ -868,6 +868,180 @@ it("veryfront-cloud Anthropic and OpenAI transports default to framework fallbac
     await assistant.generate({ input: "hi" });
 
     assertEquals(observedTools, ["tool_search"]);
+  }
+});
+
+it("deferred OpenAI searches, exposes, and executes a remote tool beyond 128 authorized tools", async () => {
+  const lateToolName = "write_sandbox_files";
+  const remoteTools: ToolDefinition[] = [
+    ...Array.from(
+      { length: 132 },
+      (_, index): ToolDefinition => ({
+        name: `catalog_tool_${String(index).padStart(3, "0")}`,
+        description: "Catalog tool",
+        parameters: { type: "object", properties: {} },
+      }),
+    ),
+    {
+      name: lateToolName,
+      description: "Write sandbox files",
+      parameters: { type: "object", properties: {} },
+    },
+  ];
+  const allowedRemoteToolNames = remoteTools.map((tool) => tool.name);
+  const observedTools: string[][] = [];
+  let step = 0;
+  let executionCount = 0;
+  const remoteSource: RemoteToolSource = {
+    id: "veryfront-platform-mcp",
+    listTools: () => Promise.resolve(remoteTools),
+    executeTool: (toolName) => {
+      assertEquals(toolName, lateToolName);
+      executionCount++;
+      return Promise.resolve({ written: true });
+    },
+  };
+  const model: ModelRuntime = {
+    provider: "openai",
+    modelId: "gpt-5.5",
+    async doGenerate(options: unknown) {
+      observedTools.push(toolNames(options));
+      step++;
+      if (step === 1) {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: "search-1",
+            toolName: "tool_search",
+            input: JSON.stringify({ query: lateToolName }),
+          }],
+          finishReason: "tool-calls",
+        };
+      }
+      if (step === 2) {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: "write-1",
+            toolName: lateToolName,
+            input: "{}",
+          }],
+          finishReason: "tool-calls",
+        };
+      }
+      return {
+        content: [{ type: "text", text: "done" }],
+        finishReason: "stop",
+      };
+    },
+    async doStream() {
+      return { stream: new ReadableStream() };
+    },
+  };
+  const assistant = agent(
+    {
+      id: "openai-large-deferred-catalog",
+      model: "openai/gpt-5.5",
+      system: "Use tools when needed.",
+      skills: false,
+      tools: true,
+      maxSteps: 4,
+      resolveModelTransport: () => ({ model }),
+      __vfToolLoadingMode: "deferred",
+      __vfRemoteToolSources: [remoteSource],
+      __vfAllowedRemoteTools: allowedRemoteToolNames,
+    } as AgentConfig & RuntimeToolFilterConfig,
+  );
+
+  const response = await assistant.generate({ input: "Write the sandbox files" });
+
+  assertEquals(observedTools.every((names) => names.length <= 128), true);
+  assertEquals(observedTools[0]?.includes("tool_search"), true);
+  assertEquals(observedTools[0]?.includes(lateToolName), false);
+  assertEquals(observedTools[1]?.includes(lateToolName), true);
+  assertEquals(executionCount, 1);
+  assertEquals(response.text, "done");
+});
+
+it("generate and stream budget restored exposure against an OpenAI request override", async () => {
+  const remoteTools: ToolDefinition[] = Array.from(
+    { length: 130 },
+    (_, index): ToolDefinition => ({
+      name: `catalog_tool_${String(index).padStart(3, "0")}`,
+      description: "Catalog tool",
+      parameters: { type: "object", properties: {} },
+    }),
+  );
+  const allowedRemoteToolNames = remoteTools.map((tool) => tool.name);
+  const observedGenerateTools: string[][] = [];
+  const observedStreamTools: string[][] = [];
+  const remoteSource: RemoteToolSource = {
+    id: "veryfront-platform-mcp",
+    listTools: () => Promise.resolve(remoteTools),
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+  const model: ModelRuntime = {
+    provider: "openai",
+    modelId: "gpt-5.5",
+    async doGenerate(options: unknown) {
+      observedGenerateTools.push(toolNames(options));
+      return {
+        content: [{ type: "text", text: "done" }],
+        finishReason: "stop",
+      };
+    },
+    async doStream(options: unknown) {
+      observedStreamTools.push(toolNames(options));
+      return {
+        stream: createRuntimeStream([
+          { type: "text-delta", text: "done" },
+          { type: "finish", finishReason: "stop" },
+        ]),
+      };
+    },
+  };
+  const assistant = agent(
+    {
+      id: "request-model-override-budget",
+      model: "anthropic/claude-opus-4-6",
+      system: "Use tools when needed.",
+      skills: true,
+      tools: {
+        form_input: tool({
+          id: "form_input",
+          description: "Collect input",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+        load_skill: tool({
+          id: "load_skill",
+          description: "Load a skill",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+      },
+      maxSteps: 1,
+      resolveModelTransport: () => ({ model }),
+      __vfToolLoadingMode: "deferred",
+      __vfRemoteToolSources: [remoteSource],
+      __vfAllowedRemoteTools: allowedRemoteToolNames,
+      __vfToolExposureCheckpoint: {
+        version: 1,
+        loadedToolNames: allowedRemoteToolNames,
+      },
+    } as AgentConfig & RuntimeToolFilterConfig,
+  );
+
+  await assistant.generate({ input: "hi", model: "openai/gpt-5.5" });
+  await (await assistant.stream({ input: "hi", model: "openai/gpt-5.5" }))
+    .toDataStreamResponse().text();
+
+  for (const observedTools of [observedGenerateTools[0], observedStreamTools[0]]) {
+    assertEquals(observedTools?.length, 128);
+    assertEquals(observedTools?.includes("form_input"), true);
+    assertEquals(observedTools?.includes("load_skill"), true);
+    assertEquals(observedTools?.includes("tool_search"), true);
+    assertEquals(observedTools?.includes("catalog_tool_129"), true);
   }
 });
 

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -1069,7 +1069,7 @@ it("deferred search cannot spend provider capacity on an already-visible bootstr
             type: "tool-call",
             toolCallId: "search-bootstrap",
             toolName: "tool_search",
-            input: JSON.stringify({ query: "form_input" }),
+            input: JSON.stringify({ query: "collect input" }),
           }],
           finishReason: "tool-calls",
         };

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -1133,6 +1133,121 @@ it("deferred search cannot spend provider capacity on an already-visible bootstr
   assertEquals(response.text, "done");
 });
 
+it("deferred final-response guard frees loaded capacity before a later search", async () => {
+  const catalogTools: ToolDefinition[] = Array.from(
+    { length: 126 },
+    (_, index): ToolDefinition => ({
+      name: `catalog_tool_${String(index).padStart(3, "0")}`,
+      description: "Catalog tool",
+      parameters: { type: "object", properties: {} },
+    }),
+  );
+  const remoteTools: ToolDefinition[] = [
+    ...catalogTools,
+    {
+      name: "create_agent",
+      description: "Create an agent",
+      parameters: { type: "object", properties: {} },
+    },
+  ];
+  const allowedRemoteToolNames = remoteTools.map((tool) => tool.name);
+  const observedTools: string[][] = [];
+  let step = 0;
+  let createAgentExecutions = 0;
+  const model: ModelRuntime = {
+    provider: "openai",
+    modelId: "gpt-5.5",
+    async doGenerate(options: unknown) {
+      observedTools.push(toolNames(options));
+      step++;
+      if (step === 1) {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: "create-agent-1",
+            toolName: "create_agent",
+            input: "{}",
+          }],
+          finishReason: "tool-calls",
+        };
+      }
+      if (step === 2) {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: "search-catalog-124",
+            toolName: "tool_search",
+            input: JSON.stringify({ query: "catalog_tool_124" }),
+          }],
+          finishReason: "tool-calls",
+        };
+      }
+      return {
+        content: [{ type: "text", text: "done" }],
+        finishReason: "stop",
+      };
+    },
+    async doStream() {
+      return { stream: new ReadableStream() };
+    },
+  };
+  const remoteSource: RemoteToolSource = {
+    id: "veryfront-platform-mcp",
+    listTools: () => Promise.resolve(remoteTools),
+    executeTool: (toolName) => {
+      assertEquals(toolName, "create_agent");
+      createAgentExecutions++;
+      return Promise.resolve({ id: "created-agent" });
+    },
+  };
+  const assistant = agent(
+    {
+      id: "deferred-final-response-guard-budget",
+      model: "openai/gpt-5.5",
+      system: "Create the agent, then finish.",
+      skills: true,
+      tools: {
+        form_input: tool({
+          id: "form_input",
+          description: "Collect input",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+        load_skill: tool({
+          id: "load_skill",
+          description: "Load a skill",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+      },
+      maxSteps: 3,
+      resolveModelTransport: () => ({ model }),
+      __vfToolLoadingMode: "deferred",
+      __vfRemoteToolSources: [remoteSource],
+      __vfAllowedRemoteTools: allowedRemoteToolNames,
+      __vfToolExposureCheckpoint: {
+        version: 1,
+        loadedToolNames: [
+          ...catalogTools.slice(0, 124).map((tool) => tool.name),
+          "create_agent",
+        ],
+      },
+    } as AgentConfig & RuntimeToolFilterConfig,
+  );
+
+  const response = await assistant.generate({ input: "Create an agent" });
+
+  assertEquals(observedTools.length, 3);
+  assertEquals(observedTools[0]?.includes("create_agent"), true);
+  assertEquals(observedTools[2]?.length, 128);
+  assertEquals(observedTools[2]?.includes("create_agent"), false);
+  assertEquals(observedTools[2]?.includes("catalog_tool_000"), true);
+  assertEquals(observedTools[2]?.includes("catalog_tool_124"), true);
+  assertEquals(observedTools[2]?.includes("tool_search"), true);
+  assertEquals(createAgentExecutions, 1);
+  assertEquals(response.text, "done");
+});
+
 it(
   "framework fallback preserves configured provider tools for generate, stream, and respond",
   async () => {

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -1045,6 +1045,94 @@ it("generate and stream budget restored exposure against an OpenAI request overr
   }
 });
 
+it("deferred search cannot spend provider capacity on an already-visible bootstrap tool", async () => {
+  const remoteTools: ToolDefinition[] = Array.from(
+    { length: 127 },
+    (_, index): ToolDefinition => ({
+      name: `catalog_tool_${String(index).padStart(3, "0")}`,
+      description: "Catalog tool",
+      parameters: { type: "object", properties: {} },
+    }),
+  );
+  const allowedRemoteToolNames = remoteTools.map((tool) => tool.name);
+  const observedTools: string[][] = [];
+  let step = 0;
+  const model: ModelRuntime = {
+    provider: "openai",
+    modelId: "gpt-5.5",
+    async doGenerate(options: unknown) {
+      observedTools.push(toolNames(options));
+      step++;
+      if (step === 1) {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: "search-bootstrap",
+            toolName: "tool_search",
+            input: JSON.stringify({ query: "form_input" }),
+          }],
+          finishReason: "tool-calls",
+        };
+      }
+      return {
+        content: [{ type: "text", text: "done" }],
+        finishReason: "stop",
+      };
+    },
+    async doStream() {
+      return { stream: new ReadableStream() };
+    },
+  };
+  const remoteSource: RemoteToolSource = {
+    id: "veryfront-platform-mcp",
+    listTools: () => Promise.resolve(remoteTools),
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+  const assistant = agent(
+    {
+      id: "bootstrap-search-capacity",
+      model: "openai/gpt-5.5",
+      system: "Use tools when needed.",
+      skills: true,
+      tools: {
+        form_input: tool({
+          id: "form_input",
+          description: "Collect input",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+        load_skill: tool({
+          id: "load_skill",
+          description: "Load a skill",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+      },
+      maxSteps: 2,
+      resolveModelTransport: () => ({ model }),
+      __vfToolLoadingMode: "deferred",
+      __vfRemoteToolSources: [remoteSource],
+      __vfAllowedRemoteTools: allowedRemoteToolNames,
+      __vfToolExposureCheckpoint: {
+        version: 1,
+        loadedToolNames: allowedRemoteToolNames.slice(0, 125),
+      },
+    } as AgentConfig & RuntimeToolFilterConfig,
+  );
+
+  const response = await assistant.generate({ input: "Collect structured input" });
+
+  assertEquals(observedTools.length, 2);
+  for (const names of observedTools) {
+    assertEquals(names.length, 128);
+    assertEquals(names.includes("catalog_tool_000"), true);
+    assertEquals(names.includes("form_input"), true);
+    assertEquals(names.includes("load_skill"), true);
+    assertEquals(names.includes("tool_search"), true);
+  }
+  assertEquals(response.text, "done");
+});
+
 it(
   "framework fallback preserves configured provider tools for generate, stream, and respond",
   async () => {

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -1130,6 +1130,17 @@ it("deferred search cannot spend provider capacity on an already-visible bootstr
     assertEquals(names.includes("load_skill"), true);
     assertEquals(names.includes("tool_search"), true);
   }
+  assertEquals(response.toolCalls[0]?.result, {
+    matches: [{
+      name: "form_input",
+      description: "Collect input",
+      status: "available",
+    }],
+    resultCount: 1,
+    loadedCount: 0,
+    miss: false,
+    nextStep: 'The matching tool "form_input" is already available. Call it directly.',
+  });
   assertEquals(response.text, "done");
 });
 

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -1259,6 +1259,125 @@ it("deferred final-response guard frees loaded capacity before a later search", 
   assertEquals(response.text, "done");
 });
 
+it("final-response guard releases a loaded schema slot before deferred search", async () => {
+  const retainedToolName = "catalog_tool_retained";
+  const searchedToolName = "catalog_tool_searched";
+  const fillerToolNames = Array.from(
+    { length: 123 },
+    (_, index) => `catalog_tool_${String(index).padStart(3, "0")}`,
+  );
+  const remoteTools: ToolDefinition[] = [
+    retainedToolName,
+    ...fillerToolNames,
+    searchedToolName,
+    "catalog_tool_still_deferred",
+  ].map((name) => ({
+    name,
+    description: `Deferred schema for ${name}`,
+    parameters: { type: "object", properties: {} },
+  }));
+  const allowedRemoteToolNames = remoteTools.map((tool) => tool.name);
+  const initiallyLoadedToolNames = [
+    retainedToolName,
+    ...fillerToolNames,
+    "create_agent",
+  ];
+  const observedTools: string[][] = [];
+  let step = 0;
+  const model: ModelRuntime = {
+    provider: "openai",
+    modelId: "gpt-5.5",
+    async doGenerate(options: unknown) {
+      observedTools.push(toolNames(options));
+      step++;
+      if (step === 1) {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: "create-agent-before-search",
+            toolName: "create_agent",
+            input: JSON.stringify({ id: "capacity-agent" }),
+          }],
+          finishReason: "tool-calls",
+        };
+      }
+      if (step === 2) {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: "search-after-create-agent",
+            toolName: "tool_search",
+            input: JSON.stringify({ query: searchedToolName }),
+          }],
+          finishReason: "tool-calls",
+        };
+      }
+      return {
+        content: [{ type: "text", text: "done" }],
+        finishReason: "stop",
+      };
+    },
+    async doStream() {
+      return { stream: new ReadableStream() };
+    },
+  };
+  const remoteSource: RemoteToolSource = {
+    id: "veryfront-platform-mcp",
+    listTools: () => Promise.resolve(remoteTools),
+    executeTool: () => Promise.resolve({ ok: true }),
+  };
+  const assistant = agent(
+    {
+      id: "guarded-schema-capacity",
+      model: "openai/gpt-5.5",
+      system: "Create the agent, then search the deferred catalog.",
+      skills: true,
+      tools: {
+        form_input: tool({
+          id: "form_input",
+          description: "Collect input",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+        load_skill: tool({
+          id: "load_skill",
+          description: "Load a skill",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+        create_agent: tool({
+          id: "create_agent",
+          description: "Create a Studio project agent",
+          inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+          execute: ({ id }) => ({ id, name: "Capacity Agent" }),
+        }),
+      },
+      maxSteps: 3,
+      resolveModelTransport: () => ({ model }),
+      __vfToolLoadingMode: "deferred",
+      __vfRemoteToolSources: [remoteSource],
+      __vfAllowedRemoteTools: allowedRemoteToolNames,
+      __vfToolExposureCheckpoint: {
+        version: 1,
+        loadedToolNames: initiallyLoadedToolNames,
+      },
+    } as AgentConfig & RuntimeToolFilterConfig,
+  );
+
+  const response = await assistant.generate({ input: "Create the capacity agent" });
+
+  assertEquals(observedTools.length, 3);
+  assertEquals(observedTools[0]?.length, 128);
+  assertEquals(observedTools[0]?.includes("create_agent"), true);
+  assertEquals(observedTools[1]?.includes("create_agent"), false);
+  assertEquals(observedTools[1]?.includes("tool_search"), true);
+  assertEquals(observedTools[2]?.length, 128);
+  assertEquals(observedTools[2]?.includes(retainedToolName), true);
+  assertEquals(observedTools[2]?.includes(searchedToolName), true);
+  assertEquals(observedTools[2]?.includes("create_agent"), false);
+  assertEquals(response.text, "done");
+});
+
 it(
   "framework fallback preserves configured provider tools for generate, stream, and respond",
   async () => {

--- a/src/agent/runtime/tool-exposure.test.ts
+++ b/src/agent/runtime/tool-exposure.test.ts
@@ -228,6 +228,64 @@ it("authorized search matches load for the next step", () => {
   );
 });
 
+it("deferred exposure reserves bootstrap and search inside the provider tool budget", () => {
+  const remoteCatalog = Array.from(
+    { length: 130 },
+    (_, index) => definition(`catalog_tool_${String(index).padStart(3, "0")}`, "Catalog tool"),
+  );
+  const authorized = [
+    definition("form_input", "Ask the user for structured input"),
+    definition("load_skill", "Load a configured skill"),
+    ...remoteCatalog,
+  ];
+  const state = restoreToolExposureState({
+    version: 1,
+    loadedToolNames: remoteCatalog.map((tool) => tool.name),
+  }, authorized);
+  const plan = createToolExposurePlan({
+    authorized,
+    mode: "deferred",
+    state,
+    maxVisibleTools: 128,
+  });
+
+  assertEquals(plan.visible.length, 128);
+  assertEquals(plan.visible.some((tool) => tool.name === "form_input"), true);
+  assertEquals(plan.visible.some((tool) => tool.name === "load_skill"), true);
+  assertEquals(plan.visible.some((tool) => tool.name === TOOL_SEARCH_TOOL_NAME), true);
+  assertEquals(plan.maxLoadedTools, 125);
+  assertEquals(state.loadedToolNames.size, 125);
+  assertEquals(state.loadedToolNames.has("catalog_tool_000"), false);
+  assertEquals(state.loadedToolNames.has("catalog_tool_129"), true);
+});
+
+it("tool search evicts the oldest loaded schema before activating a new match at capacity", () => {
+  const remoteCatalog = Array.from(
+    { length: 130 },
+    (_, index) => definition(`catalog_tool_${String(index).padStart(3, "0")}`, "Catalog tool"),
+  );
+  const state = createToolExposureState();
+  for (const tool of remoteCatalog.slice(0, 125)) {
+    searchToolExposure({
+      query: tool.name,
+      authorized: remoteCatalog,
+      state,
+      maxLoadedTools: 125,
+    });
+  }
+  const result = searchToolExposure({
+    query: "catalog_tool_129",
+    authorized: remoteCatalog,
+    state,
+    maxLoadedTools: 125,
+  });
+
+  assertEquals(result.matches.map((match) => match.name), ["catalog_tool_129"]);
+  assertEquals(state.loadedToolNames.size, 125);
+  assertEquals(state.loadedToolNames.has("catalog_tool_000"), false);
+  assertEquals(state.loadedToolNames.has("catalog_tool_129"), true);
+});
+
 it("tool search never returns tools outside the currently authorized executable catalog", () => {
   assertEquals(
     searchToolExposure({

--- a/src/agent/runtime/tool-exposure.test.ts
+++ b/src/agent/runtime/tool-exposure.test.ts
@@ -117,6 +117,45 @@ it("tool search ranks exact name, description, and parameter matches", () => {
   assertEquals(parameter.matches[0]?.name, "get_release");
 });
 
+it("tool search reports a capability-matched visible tool without loading deferred schemas", () => {
+  const state = createToolExposureState();
+  const result = searchToolExposure({
+    query: "structured input",
+    authorized: [definition("create_form", "Create a reusable form")],
+    available: [definition("form_input", "Collect structured input")],
+    state,
+  });
+
+  assertEquals(result, {
+    matches: [{
+      name: "form_input",
+      description: "Collect structured input",
+      status: "available",
+    }],
+    resultCount: 1,
+    loadedCount: 0,
+    miss: false,
+  });
+  assertEquals([...state.loadedToolNames], []);
+});
+
+it("tool search loads a deferred exact-name match ahead of a visible capability match", () => {
+  const state = createToolExposureState();
+  const result = searchToolExposure({
+    query: "release",
+    authorized: [definition("release", "Publish the release")],
+    available: [definition("get_status", "Read release status")],
+    state,
+  });
+
+  assertEquals(result.matches, [{
+    name: "release",
+    description: "Publish the release",
+    status: "loaded",
+  }]);
+  assertEquals([...state.loadedToolNames], ["release"]);
+});
+
 it("tool search orders all four match ranks before name tie-breaking", () => {
   const rankedCatalog = [
     definition("a_parameter", "Other capability", "Release value"),

--- a/src/agent/runtime/tool-exposure.test.ts
+++ b/src/agent/runtime/tool-exposure.test.ts
@@ -259,6 +259,60 @@ it("deferred exposure reserves bootstrap and search inside the provider tool bud
   assertEquals(state.loadedToolNames.has("catalog_tool_129"), true);
 });
 
+it("deferred exposure uses the full provider budget once the exact-fit catalog is loaded", () => {
+  const remoteCatalog = Array.from(
+    { length: 126 },
+    (_, index) => definition(`catalog_tool_${String(index).padStart(3, "0")}`, "Catalog tool"),
+  );
+  const authorized = [
+    definition("form_input", "Ask the user for structured input"),
+    definition("load_skill", "Load a configured skill"),
+    ...remoteCatalog,
+  ];
+  const state = createToolExposureState(remoteCatalog.map((tool) => tool.name));
+
+  const plan = createToolExposurePlan({
+    authorized,
+    mode: "deferred",
+    state,
+    maxVisibleTools: 128,
+  });
+
+  assertEquals(plan.visible.length, 128);
+  assertEquals(plan.visible.some((tool) => tool.name === TOOL_SEARCH_TOOL_NAME), false);
+  assertEquals(plan.deferred, []);
+  assertEquals(plan.maxLoadedTools, 126);
+  assertEquals(state.loadedToolNames.size, 126);
+});
+
+it("deferred exposure prunes revoked and bootstrap names before budget eviction", () => {
+  const retained = definition("retained_tool", "Retained deferred tool");
+  const authorized = [
+    definition("form_input", "Ask the user for structured input"),
+    definition("load_skill", "Load a configured skill"),
+    retained,
+    definition("other_tool", "Other deferred tool"),
+  ];
+  const state = createToolExposureState([
+    retained.name,
+    "revoked_tool",
+    "form_input",
+  ]);
+
+  const plan = createToolExposurePlan({
+    authorized,
+    mode: "deferred",
+    state,
+    maxVisibleTools: 4,
+  });
+
+  assertEquals([...state.loadedToolNames], [retained.name]);
+  assertEquals(
+    plan.visible.map((tool) => tool.name),
+    ["form_input", "load_skill", retained.name, TOOL_SEARCH_TOOL_NAME],
+  );
+});
+
 it("tool search evicts the oldest loaded schema before activating a new match at capacity", () => {
   const remoteCatalog = Array.from(
     { length: 130 },
@@ -297,12 +351,12 @@ it("tool search never returns tools outside the currently authorized executable 
   );
 });
 
-it("tool exposure checkpoints are private, sorted, and restore only currently authorized tools", () => {
+it("tool exposure checkpoints are private, ordered, and restore only currently authorized tools", () => {
   const authorized = catalog.slice(0, 3);
   const state = createToolExposureState(["get_release", "create_release", "get_release"]);
   const checkpoint = createToolExposureCheckpoint(authorized, state);
   assertEquals(checkpoint.version, 1);
-  assertEquals(checkpoint.loadedToolNames, ["create_release", "get_release"]);
+  assertEquals(checkpoint.loadedToolNames, ["get_release", "create_release"]);
 
   assertEquals(
     [...restoreToolExposureState(checkpoint, authorized).loadedToolNames].sort(),
@@ -316,6 +370,29 @@ it("tool exposure checkpoints are private, sorted, and restore only currently au
     [...restoreToolExposureState({ ...checkpoint, version: 2 }, authorized).loadedToolNames],
     [],
   );
+});
+
+it("tool exposure checkpoints preserve eviction recency across restoration", () => {
+  const authorized = [
+    definition("z_oldest", "Oldest loaded tool"),
+    definition("a_newer", "Newer loaded tool"),
+    definition("m_next", "Next loaded tool"),
+  ];
+  const checkpoint = createToolExposureCheckpoint(
+    authorized,
+    createToolExposureState(["z_oldest", "a_newer"]),
+  );
+  const restored = restoreToolExposureState(checkpoint, authorized);
+
+  searchToolExposure({
+    query: "m_next",
+    authorized,
+    state: restored,
+    maxLoadedTools: 2,
+  });
+
+  assertEquals(checkpoint.loadedToolNames, ["z_oldest", "a_newer"]);
+  assertEquals([...restored.loadedToolNames], ["a_newer", "m_next"]);
 });
 
 it("tool exposure checkpoints canonicalize authorized loaded names", () => {
@@ -332,7 +409,7 @@ it("tool exposure checkpoints canonicalize authorized loaded names", () => {
 
   assertEquals(createToolExposureCheckpoint(authorized, state), {
     version: 1,
-    loadedToolNames: ["get_release", "list_projects"],
+    loadedToolNames: ["list_projects", "get_release"],
   });
 });
 

--- a/src/agent/runtime/tool-exposure.test.ts
+++ b/src/agent/runtime/tool-exposure.test.ts
@@ -302,6 +302,48 @@ it("deferred exposure uses the full provider budget once the exact-fit catalog i
   assertEquals(state.loadedToolNames.size, 126);
 });
 
+it("exact-fit deferred exposure loads the final schema without exceeding the provider budget", () => {
+  const remoteCatalog = Array.from(
+    { length: 126 },
+    (_, index) => definition(`catalog_tool_${String(index).padStart(3, "0")}`, "Catalog tool"),
+  );
+  const authorized = [
+    definition("form_input", "Ask the user for structured input"),
+    definition("load_skill", "Load a configured skill"),
+    ...remoteCatalog,
+  ];
+  const state = createToolExposureState(remoteCatalog.slice(0, 125).map((tool) => tool.name));
+
+  const searchStep = createToolExposurePlan({
+    authorized,
+    mode: "deferred",
+    state,
+    maxVisibleTools: 128,
+  });
+  assertEquals(searchStep.visible.length, 128);
+  assertEquals(searchStep.deferred.map((tool) => tool.name), ["catalog_tool_125"]);
+  assertEquals(searchStep.maxLoadedTools, 126);
+
+  const search = searchToolExposure({
+    query: "catalog_tool_125",
+    authorized: searchStep.deferred,
+    state,
+    maxLoadedTools: searchStep.maxLoadedTools,
+  });
+  assertEquals(search.loadedCount, 1);
+  assertEquals(state.loadedToolNames.size, 126);
+
+  const loadedStep = createToolExposurePlan({
+    authorized,
+    mode: "deferred",
+    state,
+    maxVisibleTools: 128,
+  });
+  assertEquals(loadedStep.visible.length, 128);
+  assertEquals(loadedStep.deferred, []);
+  assertEquals(loadedStep.visible.some((tool) => tool.name === TOOL_SEARCH_TOOL_NAME), false);
+});
+
 it("deferred exposure prunes revoked and bootstrap names before budget eviction", () => {
   const retained = definition("retained_tool", "Retained deferred tool");
   const authorized = [

--- a/src/agent/runtime/tool-exposure.test.ts
+++ b/src/agent/runtime/tool-exposure.test.ts
@@ -453,7 +453,7 @@ it("tool exposure checkpoints are private, ordered, and restore only currently a
   const authorized = catalog.slice(0, 3);
   const state = createToolExposureState(["get_release", "create_release", "get_release"]);
   const checkpoint = createToolExposureCheckpoint(authorized, state);
-  assertEquals(checkpoint.version, 1);
+  assertEquals(checkpoint.version, 2);
   assertEquals(checkpoint.loadedToolNames, ["get_release", "create_release"]);
 
   assertEquals(
@@ -465,8 +465,25 @@ it("tool exposure checkpoints are private, ordered, and restore only currently a
     ["get_release"],
   );
   assertEquals(
-    [...restoreToolExposureState({ ...checkpoint, version: 2 }, authorized).loadedToolNames],
+    [...restoreToolExposureState({ ...checkpoint, version: 3 }, authorized).loadedToolNames],
     [],
+  );
+});
+
+it("tool exposure checkpoint restoration upgrades legacy v1 order deterministically", () => {
+  const authorized = [
+    definition("a_legacy_oldest", "Legacy sorted first"),
+    definition("z_legacy_newer", "Legacy sorted last"),
+  ];
+
+  assertEquals(
+    [
+      ...restoreToolExposureState({
+        version: 1,
+        loadedToolNames: ["z_legacy_newer", "a_legacy_oldest"],
+      }, authorized).loadedToolNames,
+    ],
+    ["a_legacy_oldest", "z_legacy_newer"],
   );
 });
 
@@ -506,7 +523,7 @@ it("tool exposure checkpoints canonicalize authorized loaded names", () => {
   ]);
 
   assertEquals(createToolExposureCheckpoint(authorized, state), {
-    version: 1,
+    version: 2,
     loadedToolNames: ["list_projects", "get_release"],
   });
 });
@@ -537,7 +554,7 @@ it("tool exposure checkpoint restoration fails closed and reauthorizes names", (
 
   assertEquals(
     restore({
-      version: 2,
+      version: 3,
       loadedToolNames: ["still_authorized"],
     }),
     [],

--- a/src/agent/runtime/tool-exposure.test.ts
+++ b/src/agent/runtime/tool-exposure.test.ts
@@ -77,6 +77,23 @@ it("deferred exposure omits tool_search when only bootstrap tools are authorized
   assertEquals(deferred.deferred, []);
 });
 
+it("deferred exposure keeps injected tool_search in visible ASCII order", () => {
+  const deferred = createToolExposurePlan({
+    authorized: [
+      definition("z_bootstrap", "Always visible"),
+      definition("a_deferred", "Searchable later"),
+    ],
+    bootstrapToolNames: new Set(["z_bootstrap"]),
+    mode: "deferred",
+    state: createToolExposureState(),
+  });
+
+  assertEquals(
+    deferred.visible.map((tool) => tool.name),
+    [TOOL_SEARCH_TOOL_NAME, "z_bootstrap"],
+  );
+});
+
 it("tool search ranks exact name, description, and parameter matches", () => {
   const state = createToolExposureState();
   const exact = searchToolExposure({ query: "get_release", authorized: catalog, state });

--- a/src/agent/runtime/tool-exposure.ts
+++ b/src/agent/runtime/tool-exposure.ts
@@ -23,7 +23,8 @@ export type ToolExposurePlan = {
 
 /** Private versioned state persisted by the framework between resumed steps. */
 export type ToolExposureCheckpoint = {
-  version: 1;
+  /** v1 names were lexicographically sorted; v2 preserves oldest-to-newest recency. */
+  version: 1 | 2;
   loadedToolNames: string[];
 };
 
@@ -68,6 +69,13 @@ function compareAscii(left: string, right: string): number {
 /** Return whether a persisted name matches the existing non-empty tool id contract. */
 export function isValidToolExposureCheckpointName(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
+}
+
+/** Return whether a checkpoint version can be restored by this runtime. */
+export function isSupportedToolExposureCheckpointVersion(
+  value: unknown,
+): value is ToolExposureCheckpoint["version"] {
+  return value === 1 || value === 2;
 }
 
 function collectSchemaDescriptions(value: unknown, output: string[]): void {
@@ -327,7 +335,7 @@ export function createToolExposureCheckpoint(
 ): ToolExposureCheckpoint {
   const authorizedNames = new Set(authorized.map((tool) => tool.name));
   return {
-    version: 1,
+    version: 2,
     loadedToolNames: [...state.loadedToolNames]
       .filter((name) => authorizedNames.has(name)),
   };
@@ -355,7 +363,7 @@ export function restoreToolExposureState(
   authorized: readonly ToolDefinition[],
 ): ToolExposureState {
   if (
-    checkpoint?.version !== 1 ||
+    !isSupportedToolExposureCheckpointVersion(checkpoint?.version) ||
     !Array.isArray(checkpoint.loadedToolNames) ||
     !checkpoint.loadedToolNames.every(isValidToolExposureCheckpointName)
   ) {
@@ -363,7 +371,7 @@ export function restoreToolExposureState(
   }
 
   const authorizedNames = new Set(authorized.map((tool) => tool.name));
-  return createToolExposureState(
-    checkpoint.loadedToolNames.filter((name) => authorizedNames.has(name)),
-  );
+  const loadedToolNames = checkpoint.loadedToolNames.filter((name) => authorizedNames.has(name));
+  if (checkpoint.version === 1) loadedToolNames.sort(compareAscii);
+  return createToolExposureState(loadedToolNames);
 }

--- a/src/agent/runtime/tool-exposure.ts
+++ b/src/agent/runtime/tool-exposure.ts
@@ -50,6 +50,12 @@ export type ToolSearchResult = {
   miss: boolean;
 };
 
+type RankedToolSearchMatch = {
+  rank: number;
+  matchCount: number;
+  match: ToolSearchMatch;
+};
+
 function normalizeSearchText(value: string): string {
   return value.replace(/[A-Z]/g, (character) => String.fromCharCode(character.charCodeAt(0) + 32))
     .replaceAll("_", " ").trim().replace(/\s+/g, " ");
@@ -119,6 +125,50 @@ function getTermFallbackScore(input: {
     return rank === null ? [] : [rank];
   });
   return ranks.length > 0 ? { rank: Math.min(...ranks), matchCount: ranks.length } : null;
+}
+
+function rankToolExposureMatches(
+  query: string,
+  candidates: readonly { tool: ToolDefinition; status: ToolSearchMatch["status"] }[],
+): RankedToolSearchMatch[] {
+  const ranked: RankedToolSearchMatch[] = [];
+
+  for (const { tool, status } of candidates) {
+    const rank = getMatchRank({
+      query,
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    });
+    if (rank === null) continue;
+    ranked.push({
+      rank,
+      matchCount: 1,
+      match: { name: tool.name, description: tool.description, status },
+    });
+  }
+
+  if (ranked.length === 0) {
+    for (const { tool, status } of candidates) {
+      const score = getTermFallbackScore({
+        query,
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      });
+      if (!score) continue;
+      ranked.push({
+        ...score,
+        match: { name: tool.name, description: tool.description, status },
+      });
+    }
+  }
+
+  return ranked.sort((left, right) =>
+    left.rank - right.rank || right.matchCount - left.matchCount ||
+    (left.match.status === right.match.status ? 0 : left.match.status === "available" ? -1 : 1) ||
+    compareAscii(left.match.name, right.match.name)
+  );
 }
 
 /** Create fresh run-local tool exposure state. */
@@ -224,47 +274,29 @@ export function createToolExposurePlan(input: {
 export function searchToolExposure(input: {
   query: string;
   authorized: readonly ToolDefinition[];
+  available?: readonly ToolDefinition[];
   state: ToolExposureState;
   maxLoadedTools?: number;
 }): ToolSearchResult {
-  const ranked: Array<{ rank: number; matchCount: number; match: ToolSearchMatch }> = [];
-
-  for (const tool of input.authorized) {
-    const rank = getMatchRank({
-      query: input.query,
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.parameters,
-    });
-    if (rank === null) continue;
-    ranked.push({
-      rank,
-      matchCount: 1,
-      match: { name: tool.name, description: tool.description, status: "loaded" },
-    });
-  }
-
-  if (ranked.length === 0) {
-    for (const tool of input.authorized) {
-      const score = getTermFallbackScore({
-        query: input.query,
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.parameters,
-      });
-      if (!score) continue;
-      ranked.push({
-        ...score,
-        match: { name: tool.name, description: tool.description, status: "loaded" },
-      });
-    }
+  const ranked = rankToolExposureMatches(input.query, [
+    ...(input.available ?? []).map((tool) => ({ tool, status: "available" as const })),
+    ...input.authorized.map((tool) => ({ tool, status: "loaded" as const })),
+  ]);
+  if (ranked[0]?.match.status === "available") {
+    const matches = ranked
+      .filter(({ match }) => match.status === "available")
+      .slice(0, TOOL_SEARCH_RESULT_LIMIT)
+      .map(({ match }) => match);
+    return {
+      matches,
+      resultCount: matches.length,
+      loadedCount: 0,
+      miss: false,
+    };
   }
 
   const matches = ranked
-    .sort((left, right) =>
-      left.rank - right.rank || right.matchCount - left.matchCount ||
-      compareAscii(left.match.name, right.match.name)
-    )
+    .filter(({ match }) => match.status === "loaded")
     .slice(
       0,
       input.maxLoadedTools === undefined

--- a/src/agent/runtime/tool-exposure.ts
+++ b/src/agent/runtime/tool-exposure.ts
@@ -18,6 +18,7 @@ export type ToolExposurePlan = {
   visible: ToolDefinition[];
   deferred: ToolDefinition[];
   loadedToolNames: Set<string>;
+  maxLoadedTools?: number;
 };
 
 /** Private versioned state persisted by the framework between resumed steps. */
@@ -123,6 +124,15 @@ export function createToolExposureState(
   return { loadedToolNames: new Set(loadedToolNames) };
 }
 
+function retainNewestLoadedToolNames(state: ToolExposureState, limit: number | undefined): void {
+  if (limit === undefined) return;
+  while (state.loadedToolNames.size > limit) {
+    const oldest = state.loadedToolNames.values().next().value;
+    if (oldest === undefined) return;
+    state.loadedToolNames.delete(oldest);
+  }
+}
+
 /** Create the framework fallback tool definition without exposing catalog schemas. */
 export function createToolSearchDefinition(): ToolDefinition {
   return {
@@ -150,6 +160,7 @@ export function createToolExposurePlan(input: {
   mode: RuntimeToolLoadingMode;
   state: ToolExposureState;
   bootstrapToolNames?: ReadonlySet<string>;
+  maxVisibleTools?: number;
 }): ToolExposurePlan {
   const authorized = [...input.authorized];
   if (input.mode === "eager") {
@@ -165,6 +176,12 @@ export function createToolExposurePlan(input: {
   }
 
   const bootstrap = input.bootstrapToolNames ?? DEFAULT_BOOTSTRAP_TOOL_NAMES;
+  const bootstrapCount = authorized.filter((tool) => bootstrap.has(tool.name)).length;
+  const hasSearchableTools = authorized.some((tool) => !bootstrap.has(tool.name));
+  const maxLoadedTools = input.maxVisibleTools === undefined
+    ? undefined
+    : Math.max(0, input.maxVisibleTools - bootstrapCount - (hasSearchableTools ? 1 : 0));
+  retainNewestLoadedToolNames(input.state, maxLoadedTools);
   const visible = authorized
     .filter((tool) => bootstrap.has(tool.name) || input.state.loadedToolNames.has(tool.name))
     .sort((left, right) => compareAscii(left.name, right.name));
@@ -181,6 +198,7 @@ export function createToolExposurePlan(input: {
     visible,
     deferred,
     loadedToolNames: input.state.loadedToolNames,
+    ...(maxLoadedTools === undefined ? {} : { maxLoadedTools }),
   };
 }
 
@@ -189,6 +207,7 @@ export function searchToolExposure(input: {
   query: string;
   authorized: readonly ToolDefinition[];
   state: ToolExposureState;
+  maxLoadedTools?: number;
 }): ToolSearchResult {
   const ranked: Array<{ rank: number; matchCount: number; match: ToolSearchMatch }> = [];
 
@@ -228,16 +247,26 @@ export function searchToolExposure(input: {
       left.rank - right.rank || right.matchCount - left.matchCount ||
       compareAscii(left.match.name, right.match.name)
     )
-    .slice(0, TOOL_SEARCH_RESULT_LIMIT)
+    .slice(
+      0,
+      input.maxLoadedTools === undefined
+        ? TOOL_SEARCH_RESULT_LIMIT
+        : Math.min(TOOL_SEARCH_RESULT_LIMIT, input.maxLoadedTools),
+    )
     .map(({ match }) => match);
 
-  for (const match of matches) input.state.loadedToolNames.add(match.name);
+  for (const match of matches) {
+    input.state.loadedToolNames.delete(match.name);
+    input.state.loadedToolNames.add(match.name);
+  }
+  retainNewestLoadedToolNames(input.state, input.maxLoadedTools);
+  const loadedMatches = matches.filter((match) => input.state.loadedToolNames.has(match.name));
 
   return {
-    matches,
-    resultCount: matches.length,
-    loadedCount: matches.length,
-    miss: matches.length === 0,
+    matches: loadedMatches,
+    resultCount: loadedMatches.length,
+    loadedCount: loadedMatches.length,
+    miss: loadedMatches.length === 0,
   };
 }
 

--- a/src/agent/runtime/tool-exposure.ts
+++ b/src/agent/runtime/tool-exposure.ts
@@ -197,8 +197,7 @@ export function createToolExposurePlan(input: {
   pruneLoadedToolNames(input.state, loadableNames);
   retainNewestLoadedToolNames(input.state, maxLoadedTools);
   const visible = authorized
-    .filter((tool) => bootstrap.has(tool.name) || input.state.loadedToolNames.has(tool.name))
-    .sort((left, right) => compareAscii(left.name, right.name));
+    .filter((tool) => bootstrap.has(tool.name) || input.state.loadedToolNames.has(tool.name));
   const visibleNames = new Set(visible.map((tool) => tool.name));
   const deferred = loadable
     .filter((tool) => !visibleNames.has(tool.name))
@@ -206,6 +205,7 @@ export function createToolExposurePlan(input: {
   if (deferred.length > 0) {
     visible.push(createToolSearchDefinition());
   }
+  visible.sort((left, right) => compareAscii(left.name, right.name));
 
   return {
     authorized,

--- a/src/agent/runtime/tool-exposure.ts
+++ b/src/agent/runtime/tool-exposure.ts
@@ -133,6 +133,15 @@ function retainNewestLoadedToolNames(state: ToolExposureState, limit: number | u
   }
 }
 
+function pruneLoadedToolNames(
+  state: ToolExposureState,
+  loadableToolNames: ReadonlySet<string>,
+): void {
+  for (const name of state.loadedToolNames) {
+    if (!loadableToolNames.has(name)) state.loadedToolNames.delete(name);
+  }
+}
+
 /** Create the framework fallback tool definition without exposing catalog schemas. */
 export function createToolSearchDefinition(): ToolDefinition {
   return {
@@ -177,16 +186,21 @@ export function createToolExposurePlan(input: {
 
   const bootstrap = input.bootstrapToolNames ?? DEFAULT_BOOTSTRAP_TOOL_NAMES;
   const bootstrapCount = authorized.filter((tool) => bootstrap.has(tool.name)).length;
-  const hasSearchableTools = authorized.some((tool) => !bootstrap.has(tool.name));
-  const maxLoadedTools = input.maxVisibleTools === undefined
+  const loadable = authorized.filter((tool) => !bootstrap.has(tool.name));
+  const loadableNames = new Set(loadable.map((tool) => tool.name));
+  const loadedCapacity = input.maxVisibleTools === undefined
     ? undefined
-    : Math.max(0, input.maxVisibleTools - bootstrapCount - (hasSearchableTools ? 1 : 0));
+    : Math.max(0, input.maxVisibleTools - bootstrapCount);
+  const maxLoadedTools = loadedCapacity === undefined
+    ? undefined
+    : Math.max(0, loadedCapacity - (loadable.length > loadedCapacity ? 1 : 0));
+  pruneLoadedToolNames(input.state, loadableNames);
   retainNewestLoadedToolNames(input.state, maxLoadedTools);
   const visible = authorized
     .filter((tool) => bootstrap.has(tool.name) || input.state.loadedToolNames.has(tool.name))
     .sort((left, right) => compareAscii(left.name, right.name));
   const visibleNames = new Set(visible.map((tool) => tool.name));
-  const deferred = authorized
+  const deferred = loadable
     .filter((tool) => !visibleNames.has(tool.name))
     .sort((left, right) => compareAscii(left.name, right.name));
   if (deferred.length > 0) {
@@ -279,8 +293,7 @@ export function createToolExposureCheckpoint(
   return {
     version: 1,
     loadedToolNames: [...state.loadedToolNames]
-      .filter((name) => authorizedNames.has(name))
-      .sort(),
+      .filter((name) => authorizedNames.has(name)),
   };
 }
 

--- a/src/agent/runtime/tool-exposure.ts
+++ b/src/agent/runtime/tool-exposure.ts
@@ -36,7 +36,11 @@ export type ToolExposureCheckpointEvent = ToolExposureCheckpoint & {
 };
 
 /** Schema-free model-visible search result. */
-export type ToolSearchMatch = { name: string; description: string; status: "loaded" };
+export type ToolSearchMatch = {
+  name: string;
+  description: string;
+  status: "available" | "loaded";
+};
 
 /** Search output plus bounded observability counters. */
 export type ToolSearchResult = {


### PR DESCRIPTION
## Summary

- preserve the full authorized remote-tool catalog when hosted agents use deferred tool loading
- apply provider tool-count limits only to eager assembly and each model-visible schema set
- reserve provider capacity for bootstrap tools and `tool_search` across repeated searches and restored checkpoints
- derive that budget from the effective request model, including generate and stream model overrides
- deterministically evict the oldest loaded schema before activating a new match at capacity
- version ordered-recency checkpoints as v2 while retaining deterministic v1 restore compatibility
- prove an OpenAI run can search, load, and execute an alphabetically late tool from a 133-tool catalog while every provider step stays at or below 128 schemas

## Why

Hosted assembly previously applied the OpenAI 128-tool limit to the authorization catalog itself. Tools removed there were absent from both `tool_search` and execution, so deferred discovery could not recover them.

The exposure state also needs a provider-aware budget: without it, repeated searches, restored checkpoints, or an OpenAI per-request override could report schemas as loaded and later have the converter silently truncate them. The runtime now budgets against the effective model, reserves bootstrap/search capacity, and keeps the mutable loaded set within the remaining budget.

## Dependency and rollout

Blocked on veryfront/veryfront-api#4234 merging and deploying first. Framework emits ordered checkpoint v2; API #4234 adds N/N-1 support for sorted v1 plus ordered v2, preserves v2 recency through authenticated persistence/reload, and rejects duplicates/unknown versions.

Required order:

1. merge and deploy API #4234;
2. merge and publish this Framework PR;
3. update Agent #1758 to consume the immutable Framework release;
4. rerun Agent CI and durable staging discovery/execution proof before marking Agent ready.

## Validation

- 85 focused hosted, exposure, runtime-step, durability, and checkpoint tests passed
- generate and stream model-override regressions pass
- cumulative activation, exact-fit capacity, over-budget restore, visible capability search, and v1/v2 checkpoint regressions pass
- full pre-push: 2,891 tests + 22,884 nested steps, zero failures
- all GitHub formatting, lint, typecheck, unit, integration, coverage, smoke, browser/binary E2E, package, and CodeQL checks are green
- `git diff --check` passes
- authorization/security review found no policy widening

Tracks veryfront/veryfront-issue-inbox#353.
