### PR TITLE
feat(observability): add shared Sentry enablement contract

### DIFF
--- a/docs/api-reference/veryfront/observability.md
+++ b/docs/api-reference/veryfront/observability.md
@@ -226,10 +226,10 @@ import { captureApplicationError, flushApplicationErrors, initializeSentry } fro
 | `captureApplicationError` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/application-errors.ts#L20) |
 | `flushApplicationErrors` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/application-errors.ts#L32) |
 | `initializeSentry` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L90) |
-| `initializeSentryFromEnv` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L83) |
-| `isSentryEnabled` | Resolve the compatibility-release Sentry flag. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L40) |
+| `initializeSentryFromEnv` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L81) |
+| `isSentryEnabled` | Resolve the compatibility-release Sentry flag. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L43) |
 | `resetSentryForTests` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L124) |
-| `resolveSentryConfigFromEnv` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L56) |
+| `resolveSentryConfigFromEnv` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L59) |
 
 #### Types
 
@@ -237,4 +237,4 @@ import { captureApplicationError, flushApplicationErrors, initializeSentry } fro
 |------|-------------|--------|
 | `ApplicationErrorContext` | Sanitized context attached when a runtime reports an application error. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/application-error-contract.ts#L5) |
 | `ApplicationErrorReporter` | Provider-neutral application error capture and flush interface. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/application-error-contract.ts#L23) |
-| `SentryConfig` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L16) |
+| `SentryConfig` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L18) |

--- a/docs/api-reference/veryfront/observability.md
+++ b/docs/api-reference/veryfront/observability.md
@@ -225,10 +225,11 @@ import { captureApplicationError, flushApplicationErrors, initializeSentry } fro
 |------|-------------|--------|
 | `captureApplicationError` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/application-errors.ts#L20) |
 | `flushApplicationErrors` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/application-errors.ts#L32) |
-| `initializeSentry` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L54) |
-| `initializeSentryFromEnv` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L47) |
-| `resetSentryForTests` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L75) |
-| `resolveSentryConfigFromEnv` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L31) |
+| `initializeSentry` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L90) |
+| `initializeSentryFromEnv` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L83) |
+| `isSentryEnabled` | Resolve the compatibility-release Sentry flag. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L40) |
+| `resetSentryForTests` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L124) |
+| `resolveSentryConfigFromEnv` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/sentry.ts#L56) |
 
 #### Types
 

--- a/extensions/ext-observability-sentry/README.md
+++ b/extensions/ext-observability-sentry/README.md
@@ -5,11 +5,18 @@ First-party Sentry application error reporter for Veryfront runtimes.
 Enable the adapter explicitly and provide its credential:
 
 ```sh
+SENTRY_ENABLED=true
 VERYFRONT_ERROR_REPORTER=sentry
 SENTRY_DSN=https://public@example.ingest.sentry.io/1
 ```
 
-`SENTRY_DSN` alone does not activate reporting. Official compiled Veryfront
+`SENTRY_ENABLED=false` always disables reporting, even when the adapter and a
+valid DSN are present. During the compatibility rollout, an unset flag keeps
+the existing adapter-selection behavior. `SENTRY_DSN` selects the event
+destination and may use a public HTTPS custom Sentry hostname; `SENTRY_URL` is
+release-tooling configuration and is not read by the runtime adapter.
+
+`SENTRY_DSN` alone does not activate the framework adapter. Official compiled Veryfront
 binaries include the dormant adapter; npm consumers install
 `@veryfront/ext-observability-sentry` separately. The adapter captures
 unexpected application failures, tags them by service and boundary, and keeps

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -176,6 +176,22 @@ it("policy redacts application error attribute keys and credential-shaped values
   );
 });
 
+it("policy redacts credentials from custom-host DSNs", () => {
+  const event = prepareSentryEvent(
+    {
+      message: "failed to send to https://public:private@errors.example.test/42",
+    },
+    "veryfront-server",
+  );
+
+  assertEquals(
+    event.message,
+    "failed to send to https://[REDACTED]@errors.example.test/42",
+  );
+  assertEquals(event.message?.includes("public"), false);
+  assertEquals(event.message?.includes("private"), false);
+});
+
 it("policy applies sanitized application error attributes to Sentry scope", () => {
   const { sdk, state } = createSentrySdk();
   const error = new Error("agent failed");

--- a/src/agent/service/node-sentry.test.ts
+++ b/src/agent/service/node-sentry.test.ts
@@ -80,14 +80,41 @@ describe("agent/service/node-sentry", () => {
       dsn,
     );
     assertStrictEquals(
-      resolveNodeAgentServiceSentryConfig({ SENTRY_ENABLED: "true" }),
-      undefined,
-    );
-    assertStrictEquals(
       resolveNodeAgentServiceSentryConfig({ SENTRY_ENABLED: "false", SENTRY_DSN: dsn }),
       undefined,
     );
     assertEquals(resolveNodeAgentServiceSentryConfig({ SENTRY_DSN: dsn })?.dsn, dsn);
+  });
+
+  it("warns once without exposing secrets when Sentry is explicitly enabled without a DSN", async () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    let loadCount = 0;
+    try {
+      console.warn = (...args: unknown[]) => warnings.push(args);
+
+      const lifecycle = await initializeNodeAgentServiceSentryApplicationErrors({
+        env: {
+          SENTRY_ENABLED: "true",
+          SENTRY_DSN: "   ",
+          SENTRY_AUTH_TOKEN: "super-secret-token",
+        },
+        loadExtension: () => {
+          loadCount += 1;
+          return Promise.resolve({
+            createNodeSentryApplicationErrorReporter: () => createReporter(),
+          });
+        },
+      });
+
+      assertEquals(lifecycle.enabled, false);
+      assertEquals(loadCount, 0);
+      assertEquals(warnings, [[
+        "Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.",
+      ]]);
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 
   it("does not load the Sentry SDK when explicitly disabled with a valid DSN", async () => {

--- a/src/agent/service/node-sentry.test.ts
+++ b/src/agent/service/node-sentry.test.ts
@@ -72,6 +72,43 @@ describe("agent/service/node-sentry", () => {
     assertStrictEquals(resolveNodeAgentServiceSentryConfig({}), undefined);
   });
 
+  it("honors explicit Sentry enablement while preserving the legacy DSN behavior when unset", () => {
+    const dsn = "https://public@errors.example.test/42";
+
+    assertEquals(
+      resolveNodeAgentServiceSentryConfig({ SENTRY_ENABLED: "true", SENTRY_DSN: dsn })?.dsn,
+      dsn,
+    );
+    assertStrictEquals(
+      resolveNodeAgentServiceSentryConfig({ SENTRY_ENABLED: "true" }),
+      undefined,
+    );
+    assertStrictEquals(
+      resolveNodeAgentServiceSentryConfig({ SENTRY_ENABLED: "false", SENTRY_DSN: dsn }),
+      undefined,
+    );
+    assertEquals(resolveNodeAgentServiceSentryConfig({ SENTRY_DSN: dsn })?.dsn, dsn);
+  });
+
+  it("does not load the Sentry SDK when explicitly disabled with a valid DSN", async () => {
+    let loadCount = 0;
+    const lifecycle = await initializeNodeAgentServiceSentryApplicationErrors({
+      env: {
+        SENTRY_ENABLED: "false",
+        SENTRY_DSN: "https://public@errors.example.test/42",
+      },
+      loadExtension: () => {
+        loadCount += 1;
+        return Promise.resolve({
+          createNodeSentryApplicationErrorReporter: () => createReporter(),
+        });
+      },
+    });
+
+    assertEquals(lifecycle.enabled, false);
+    assertEquals(loadCount, 0);
+  });
+
   it("converts unexpected Agent error logs into application errors with structured attributes", () => {
     const reporter = createReporter();
     const emitter = createNodeAgentServiceLogApplicationErrorEmitter();

--- a/src/agent/service/node-sentry.test.ts
+++ b/src/agent/service/node-sentry.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   createNodeAgentServiceLogApplicationErrorEmitter,
   initializeNodeAgentServiceSentryApplicationErrors,
+  resetNodeAgentServiceSentryForTests,
   resolveNodeAgentServiceSentryConfig,
 } from "./node-sentry.ts";
 
@@ -87,13 +88,14 @@ describe("agent/service/node-sentry", () => {
   });
 
   it("warns once without exposing secrets when Sentry is explicitly enabled without a DSN", async () => {
+    resetNodeAgentServiceSentryForTests();
     const originalWarn = console.warn;
     const warnings: unknown[][] = [];
     let loadCount = 0;
     try {
       console.warn = (...args: unknown[]) => warnings.push(args);
 
-      const lifecycle = await initializeNodeAgentServiceSentryApplicationErrors({
+      const options = {
         env: {
           SENTRY_ENABLED: "true",
           SENTRY_DSN: "   ",
@@ -105,13 +107,56 @@ describe("agent/service/node-sentry", () => {
             createNodeSentryApplicationErrorReporter: () => createReporter(),
           });
         },
-      });
+      };
 
-      assertEquals(lifecycle.enabled, false);
+      assertStrictEquals(resolveNodeAgentServiceSentryConfig(options.env), undefined);
+      assertStrictEquals(resolveNodeAgentServiceSentryConfig(options.env), undefined);
+      assertEquals(warnings, []);
+      const lifecycles = await Promise.all([
+        initializeNodeAgentServiceSentryApplicationErrors(options),
+        initializeNodeAgentServiceSentryApplicationErrors(options),
+        initializeNodeAgentServiceSentryApplicationErrors(options),
+      ]);
+      const repeated = await initializeNodeAgentServiceSentryApplicationErrors(options);
+
+      assertEquals(lifecycles.map((lifecycle) => lifecycle.enabled), [false, false, false]);
+      assertEquals(repeated.enabled, false);
       assertEquals(loadCount, 0);
       assertEquals(warnings, [[
         "Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.",
       ]]);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("does not warn or load the SDK when disabled or compatibility-unset without a DSN", async () => {
+    resetNodeAgentServiceSentryForTests();
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    let loadCount = 0;
+    const loadExtension = () => {
+      loadCount += 1;
+      return Promise.resolve({
+        createNodeSentryApplicationErrorReporter: () => createReporter(),
+      });
+    };
+    try {
+      console.warn = (...args: unknown[]) => warnings.push(args);
+
+      const disabled = await initializeNodeAgentServiceSentryApplicationErrors({
+        env: { SENTRY_ENABLED: "false", SENTRY_DSN: "   " },
+        loadExtension,
+      });
+      const compatibilityUnset = await initializeNodeAgentServiceSentryApplicationErrors({
+        env: { SENTRY_DSN: "   " },
+        loadExtension,
+      });
+
+      assertEquals(disabled.enabled, false);
+      assertEquals(compatibilityUnset.enabled, false);
+      assertEquals(warnings, []);
+      assertEquals(loadCount, 0);
     } finally {
       console.warn = originalWarn;
     }

--- a/src/agent/service/node-sentry.ts
+++ b/src/agent/service/node-sentry.ts
@@ -69,7 +69,13 @@ export function resolveNodeAgentServiceSentryConfig(
   defaultServiceName = DEFAULT_SERVICE_NAME,
 ): NodeAgentServiceSentryConfig | undefined {
   const dsn = readTrimmedEnv(env, "SENTRY_DSN");
-  if (!dsn || !isSentryEnabled(env.SENTRY_ENABLED, true)) return undefined;
+  if (!isSentryEnabled(env.SENTRY_ENABLED, true)) return undefined;
+  if (!dsn) {
+    if (isSentryEnabled(env.SENTRY_ENABLED, false)) {
+      console.warn("Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.");
+    }
+    return undefined;
+  }
 
   const serviceName = readTrimmedEnv(env, "SENTRY_SERVICE_NAME") ??
     readTrimmedEnv(env, "SENTRY_SERVICE") ??

--- a/src/agent/service/node-sentry.ts
+++ b/src/agent/service/node-sentry.ts
@@ -41,6 +41,8 @@ type SentryExtensionLoader = () => Promise<SentryExtensionModule>;
 const DEFAULT_SERVICE_NAME = "veryfront-agent";
 const DEFAULT_ENVIRONMENT = "production";
 const DEFAULT_FLUSH_TIMEOUT_MS = 2_000;
+const MISSING_DSN_WARNING =
+  "Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.";
 const EXPECTED_ERROR_CODES = new Set([
   "AUTHENTICATION_REQUIRED",
   "CONTROL_PLANE_RUN_ID_MISMATCH",
@@ -54,6 +56,7 @@ const EXPECTED_ERROR_CODES = new Set([
 let currentInitializationId = 0;
 let currentLifecycle: NodeAgentServiceApplicationErrorLifecycle | undefined;
 let currentLifecycleOwner: symbol | undefined;
+let missingDsnWarningEmitted = false;
 
 function readTrimmedEnv(
   env: NodeAgentServiceApplicationErrorEnv,
@@ -70,12 +73,7 @@ export function resolveNodeAgentServiceSentryConfig(
 ): NodeAgentServiceSentryConfig | undefined {
   const dsn = readTrimmedEnv(env, "SENTRY_DSN");
   if (!isSentryEnabled(env.SENTRY_ENABLED, true)) return undefined;
-  if (!dsn) {
-    if (isSentryEnabled(env.SENTRY_ENABLED, false)) {
-      console.warn("Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.");
-    }
-    return undefined;
-  }
+  if (!dsn) return undefined;
 
   const serviceName = readTrimmedEnv(env, "SENTRY_SERVICE_NAME") ??
     readTrimmedEnv(env, "SENTRY_SERVICE") ??
@@ -242,7 +240,15 @@ export async function initializeNodeAgentServiceSentryApplicationErrors(options:
   deactivateCurrentLifecycle();
 
   const config = resolveNodeAgentServiceSentryConfig(options.env, options.defaultServiceName);
-  if (!config) return defaultLifecycle();
+  if (!config) {
+    if (
+      isSentryEnabled(options.env.SENTRY_ENABLED, false) &&
+      !readTrimmedEnv(options.env, "SENTRY_DSN")
+    ) {
+      warnAboutMissingDsnOnce();
+    }
+    return defaultLifecycle();
+  }
 
   const extension = await (options.loadExtension ?? loadNodeSentryExtension)();
   if (initializationId !== currentInitializationId) return defaultLifecycle();
@@ -294,6 +300,19 @@ export async function initializeNodeAgentServiceSentryApplicationErrors(options:
   };
   currentLifecycle = lifecycle;
   return lifecycle;
+}
+
+/** Reset node agent service Sentry state for tests. */
+export function resetNodeAgentServiceSentryForTests(): void {
+  currentInitializationId += 1;
+  deactivateCurrentLifecycle();
+  missingDsnWarningEmitted = false;
+}
+
+function warnAboutMissingDsnOnce(): void {
+  if (missingDsnWarningEmitted) return;
+  missingDsnWarningEmitted = true;
+  console.warn(MISSING_DSN_WARNING);
 }
 
 async function loadNodeSentryExtension(): Promise<SentryExtensionModule> {

--- a/src/agent/service/node-sentry.ts
+++ b/src/agent/service/node-sentry.ts
@@ -6,6 +6,7 @@ import {
   flushApplicationErrors,
   setApplicationErrorReporter,
 } from "#veryfront/observability/application-errors.ts";
+import { isSentryEnabled } from "#veryfront/observability/sentry.ts";
 import type { LogEntry, LogRecordEmitter } from "#veryfront/utils/logger/index.ts";
 import { __subscribeLogRecordEmitter } from "#veryfront/utils/logger/index.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
@@ -68,7 +69,7 @@ export function resolveNodeAgentServiceSentryConfig(
   defaultServiceName = DEFAULT_SERVICE_NAME,
 ): NodeAgentServiceSentryConfig | undefined {
   const dsn = readTrimmedEnv(env, "SENTRY_DSN");
-  if (!dsn) return undefined;
+  if (!dsn || !isSentryEnabled(env.SENTRY_ENABLED, true)) return undefined;
 
   const serviceName = readTrimmedEnv(env, "SENTRY_SERVICE_NAME") ??
     readTrimmedEnv(env, "SENTRY_SERVICE") ??

--- a/src/observability/sentry.test.ts
+++ b/src/observability/sentry.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   type ApplicationErrorContext,
   type ApplicationErrorReporter,
@@ -7,6 +8,7 @@ import {
 } from "./application-errors.ts";
 import {
   initializeSentry,
+  initializeSentryFromEnv,
   isSentryEnabled,
   resetSentryForTests,
   resolveSentryConfigFromEnv,
@@ -39,195 +41,207 @@ function createSentryExtension() {
   };
 }
 
-Deno.test("Sentry stays disabled without a DSN", async () => {
-  resetSentryForTests();
-  const { load, state } = createSentryExtension();
+describe("observability/sentry", () => {
+  it("Sentry stays disabled without a DSN", async () => {
+    resetSentryForTests();
+    const { load, state } = createSentryExtension();
 
-  assertEquals(await initializeSentry({}, load), false);
-  assertEquals(state.config, undefined);
-});
+    assertEquals(await initializeSentry({}, load), false);
+    assertEquals(state.config, undefined);
+  });
 
-Deno.test("Sentry enablement preserves legacy behavior while explicit false always wins", () => {
-  assertEquals(isSentryEnabled("true", false), true);
-  assertEquals(isSentryEnabled("false", true), false);
-  assertEquals(isSentryEnabled("0", true), false);
-  assertEquals(isSentryEnabled(undefined, true), true);
-  assertEquals(isSentryEnabled(undefined, false), false);
-});
+  it("Sentry enablement preserves legacy behavior while explicit false always wins", () => {
+    assertEquals(isSentryEnabled("true", false), true);
+    assertEquals(isSentryEnabled("false", true), false);
+    assertEquals(isSentryEnabled("0", true), false);
+    assertEquals(isSentryEnabled(undefined, true), true);
+    assertEquals(isSentryEnabled(undefined, false), false);
+  });
 
-Deno.test("Sentry environment configuration requires a DSN when explicitly enabled", () => {
-  const previousEnabled = Deno.env.get("SENTRY_ENABLED");
-  const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
-  const previousDsn = Deno.env.get("SENTRY_DSN");
-  try {
-    Deno.env.set("SENTRY_ENABLED", "true");
-    Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
-    Deno.env.delete("SENTRY_DSN");
+  it("Sentry startup warns once without exposing secrets when explicitly enabled without a DSN", async () => {
+    const previousEnabled = Deno.env.get("SENTRY_ENABLED");
+    const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+    const previousDsn = Deno.env.get("SENTRY_DSN");
+    const previousAuthToken = Deno.env.get("SENTRY_AUTH_TOKEN");
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    try {
+      Deno.env.set("SENTRY_ENABLED", "true");
+      Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
+      Deno.env.set("SENTRY_DSN", "   ");
+      Deno.env.set("SENTRY_AUTH_TOKEN", "super-secret-token");
+      console.warn = (...args: unknown[]) => warnings.push(args);
 
-    assertEquals(resolveSentryConfigFromEnv(), undefined);
-  } finally {
-    restoreEnv("SENTRY_ENABLED", previousEnabled);
-    restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
-    restoreEnv("SENTRY_DSN", previousDsn);
-  }
-});
+      assertEquals(await initializeSentryFromEnv(), false);
+      assertEquals(warnings, [[
+        "Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.",
+      ]]);
+    } finally {
+      console.warn = originalWarn;
+      restoreEnv("SENTRY_ENABLED", previousEnabled);
+      restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+      restoreEnv("SENTRY_DSN", previousDsn);
+      restoreEnv("SENTRY_AUTH_TOKEN", previousAuthToken);
+    }
+  });
 
-Deno.test("Sentry environment configuration rejects explicit false even with a valid DSN", () => {
-  const previousEnabled = Deno.env.get("SENTRY_ENABLED");
-  const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
-  const previousDsn = Deno.env.get("SENTRY_DSN");
-  try {
-    Deno.env.set("SENTRY_ENABLED", "false");
-    Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
-    Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
+  it("Sentry environment configuration rejects explicit false even with a valid DSN", () => {
+    const previousEnabled = Deno.env.get("SENTRY_ENABLED");
+    const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+    const previousDsn = Deno.env.get("SENTRY_DSN");
+    try {
+      Deno.env.set("SENTRY_ENABLED", "false");
+      Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
+      Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
 
-    assertEquals(resolveSentryConfigFromEnv(), undefined);
-  } finally {
-    restoreEnv("SENTRY_ENABLED", previousEnabled);
-    restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
-    restoreEnv("SENTRY_DSN", previousDsn);
-  }
-});
+      assertEquals(resolveSentryConfigFromEnv(), undefined);
+    } finally {
+      restoreEnv("SENTRY_ENABLED", previousEnabled);
+      restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+      restoreEnv("SENTRY_DSN", previousDsn);
+    }
+  });
 
-Deno.test("Sentry environment configuration requires explicit provider opt-in", () => {
-  const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
-  const previousDsn = Deno.env.get("SENTRY_DSN");
-  try {
-    Deno.env.delete("VERYFRONT_ERROR_REPORTER");
-    Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
-    assertEquals(resolveSentryConfigFromEnv(), undefined);
-  } finally {
-    restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
-    restoreEnv("SENTRY_DSN", previousDsn);
-  }
-});
+  it("Sentry environment configuration requires explicit provider opt-in", () => {
+    const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+    const previousDsn = Deno.env.get("SENTRY_DSN");
+    try {
+      Deno.env.delete("VERYFRONT_ERROR_REPORTER");
+      Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
+      assertEquals(resolveSentryConfigFromEnv(), undefined);
+    } finally {
+      restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+      restoreEnv("SENTRY_DSN", previousDsn);
+    }
+  });
 
-Deno.test("Sentry environment configuration uses the entrypoint service fallback", () => {
-  const previousEnabled = Deno.env.get("SENTRY_ENABLED");
-  const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
-  const previousDsn = Deno.env.get("SENTRY_DSN");
-  const previousServiceName = Deno.env.get("SENTRY_SERVICE_NAME");
-  const previousOtelServiceName = Deno.env.get("OTEL_SERVICE_NAME");
-  try {
-    Deno.env.delete("SENTRY_ENABLED");
-    Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
-    Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
-    Deno.env.set("SENTRY_SERVICE_NAME", "   ");
-    Deno.env.delete("OTEL_SERVICE_NAME");
+  it("Sentry environment configuration uses the entrypoint service fallback", () => {
+    const previousEnabled = Deno.env.get("SENTRY_ENABLED");
+    const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+    const previousDsn = Deno.env.get("SENTRY_DSN");
+    const previousServiceName = Deno.env.get("SENTRY_SERVICE_NAME");
+    const previousOtelServiceName = Deno.env.get("OTEL_SERVICE_NAME");
+    try {
+      Deno.env.delete("SENTRY_ENABLED");
+      Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
+      Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
+      Deno.env.set("SENTRY_SERVICE_NAME", "   ");
+      Deno.env.delete("OTEL_SERVICE_NAME");
 
-    assertEquals(resolveSentryConfigFromEnv("veryfront-proxy"), {
+      assertEquals(resolveSentryConfigFromEnv("veryfront-proxy"), {
+        dsn: "https://public@example.ingest.sentry.io/1",
+        environment: undefined,
+        release: undefined,
+        serviceName: "veryfront-proxy",
+      });
+    } finally {
+      restoreEnv("SENTRY_ENABLED", previousEnabled);
+      restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+      restoreEnv("SENTRY_DSN", previousDsn);
+      restoreEnv("SENTRY_SERVICE_NAME", previousServiceName);
+      restoreEnv("OTEL_SERVICE_NAME", previousOtelServiceName);
+    }
+  });
+
+  it("Sentry accepts a public HTTPS custom-host DSN", () => {
+    const previousEnabled = Deno.env.get("SENTRY_ENABLED");
+    const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+    const previousDsn = Deno.env.get("SENTRY_DSN");
+    try {
+      Deno.env.set("SENTRY_ENABLED", "true");
+      Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
+      Deno.env.set("SENTRY_DSN", "https://public@errors.example.test/42");
+
+      assertEquals(resolveSentryConfigFromEnv()?.dsn, "https://public@errors.example.test/42");
+    } finally {
+      restoreEnv("SENTRY_ENABLED", previousEnabled);
+      restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+      restoreEnv("SENTRY_DSN", previousDsn);
+    }
+  });
+
+  it("Sentry loads the extension with normalized runtime configuration", async () => {
+    resetSentryForTests();
+    const { load, state } = createSentryExtension();
+
+    assertEquals(
+      await initializeSentry(
+        {
+          dsn: "https://public@example.ingest.sentry.io/1",
+          environment: " production ",
+          release: " release-1 ",
+          serviceName: " veryfront-server ",
+        },
+        load,
+      ),
+      true,
+    );
+
+    assertEquals(state.config, {
       dsn: "https://public@example.ingest.sentry.io/1",
-      environment: undefined,
-      release: undefined,
-      serviceName: "veryfront-proxy",
+      environment: "production",
+      release: "release-1",
+      serviceName: "veryfront-server",
     });
-  } finally {
-    restoreEnv("SENTRY_ENABLED", previousEnabled);
-    restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
-    restoreEnv("SENTRY_DSN", previousDsn);
-    restoreEnv("SENTRY_SERVICE_NAME", previousServiceName);
-    restoreEnv("OTEL_SERVICE_NAME", previousOtelServiceName);
-  }
-});
+  });
 
-Deno.test("Sentry accepts a public HTTPS custom-host DSN", () => {
-  const previousEnabled = Deno.env.get("SENTRY_ENABLED");
-  const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
-  const previousDsn = Deno.env.get("SENTRY_DSN");
-  try {
-    Deno.env.set("SENTRY_ENABLED", "true");
-    Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
-    Deno.env.set("SENTRY_DSN", "https://public@errors.example.test/42");
+  it("Sentry initialization is idempotent across concurrent callers", async () => {
+    resetSentryForTests();
+    const { load, state } = createSentryExtension();
+    let resolveLoad: (() => void) | undefined;
+    let loadCount = 0;
+    const delayedLoad = async () => {
+      loadCount += 1;
+      await new Promise<void>((resolve) => {
+        resolveLoad = resolve;
+      });
+      return await load();
+    };
+    const config = { dsn: "https://public@errors.example.test/42" };
 
-    assertEquals(resolveSentryConfigFromEnv()?.dsn, "https://public@errors.example.test/42");
-  } finally {
-    restoreEnv("SENTRY_ENABLED", previousEnabled);
-    restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
-    restoreEnv("SENTRY_DSN", previousDsn);
-  }
-});
+    const first = initializeSentry(config, delayedLoad);
+    const second = initializeSentry(config, delayedLoad);
+    resolveLoad?.();
 
-Deno.test("Sentry loads the extension with normalized runtime configuration", async () => {
-  resetSentryForTests();
-  const { load, state } = createSentryExtension();
+    assertEquals(await Promise.all([first, second]), [true, true]);
+    assertEquals(loadCount, 1);
+    assertEquals(state.config?.dsn, "https://public@errors.example.test/42");
+  });
 
-  assertEquals(
+  it("Sentry captures service and Grafana trace correlation", async () => {
+    resetSentryForTests();
+    const { load, state } = createSentryExtension();
     await initializeSentry(
       {
         dsn: "https://public@example.ingest.sentry.io/1",
-        environment: " production ",
-        release: " release-1 ",
-        serviceName: " veryfront-server ",
+        serviceName: "veryfront-proxy",
       },
       load,
-    ),
-    true,
-  );
+    );
 
-  assertEquals(state.config, {
-    dsn: "https://public@example.ingest.sentry.io/1",
-    environment: "production",
-    release: "release-1",
-    serviceName: "veryfront-server",
+    const error = new Error("proxy failed");
+    const context = {
+      boundary: "proxy.request",
+      method: "GET",
+      requestId: "request-1",
+      spanId: "span-1",
+      traceId: "trace-1",
+    };
+    assertEquals(
+      captureApplicationError(error, context),
+      "event-id",
+    );
+    assertEquals(state.captured, [{ error, context }]);
+
+    assertEquals(await flushApplicationErrors(1_500), true);
+    assertEquals(state.flushTimeouts, [1_500]);
   });
-});
 
-Deno.test("Sentry initialization is idempotent across concurrent callers", async () => {
-  resetSentryForTests();
-  const { load, state } = createSentryExtension();
-  let resolveLoad: (() => void) | undefined;
-  let loadCount = 0;
-  const delayedLoad = async () => {
-    loadCount += 1;
-    await new Promise<void>((resolve) => {
-      resolveLoad = resolve;
-    });
-    return await load();
-  };
-  const config = { dsn: "https://public@errors.example.test/42" };
-
-  const first = initializeSentry(config, delayedLoad);
-  const second = initializeSentry(config, delayedLoad);
-  resolveLoad?.();
-
-  assertEquals(await Promise.all([first, second]), [true, true]);
-  assertEquals(loadCount, 1);
-  assertEquals(state.config?.dsn, "https://public@errors.example.test/42");
-});
-
-Deno.test("Sentry captures service and Grafana trace correlation", async () => {
-  resetSentryForTests();
-  const { load, state } = createSentryExtension();
-  await initializeSentry(
-    {
-      dsn: "https://public@example.ingest.sentry.io/1",
-      serviceName: "veryfront-proxy",
-    },
-    load,
-  );
-
-  const error = new Error("proxy failed");
-  const context = {
-    boundary: "proxy.request",
-    method: "GET",
-    requestId: "request-1",
-    spanId: "span-1",
-    traceId: "trace-1",
-  };
-  assertEquals(
-    captureApplicationError(error, context),
-    "event-id",
-  );
-  assertEquals(state.captured, [{ error, context }]);
-
-  assertEquals(await flushApplicationErrors(1_500), true);
-  assertEquals(state.flushTimeouts, [1_500]);
-});
-
-function restoreEnv(name: string, value: string | undefined): void {
-  if (value === undefined) {
-    Deno.env.delete(name);
-  } else {
-    Deno.env.set(name, value);
+  function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) {
+      Deno.env.delete(name);
+    } else {
+      Deno.env.set(name, value);
+    }
   }
-}
+});

--- a/src/observability/sentry.test.ts
+++ b/src/observability/sentry.test.ts
@@ -5,7 +5,12 @@ import {
   captureApplicationError,
   flushApplicationErrors,
 } from "./application-errors.ts";
-import { initializeSentry, resetSentryForTests, resolveSentryConfigFromEnv } from "./sentry.ts";
+import {
+  initializeSentry,
+  isSentryEnabled,
+  resetSentryForTests,
+  resolveSentryConfigFromEnv,
+} from "./sentry.ts";
 
 function createSentryExtension() {
   const state = {
@@ -42,6 +47,48 @@ Deno.test("Sentry stays disabled without a DSN", async () => {
   assertEquals(state.config, undefined);
 });
 
+Deno.test("Sentry enablement preserves legacy behavior while explicit false always wins", () => {
+  assertEquals(isSentryEnabled("true", false), true);
+  assertEquals(isSentryEnabled("false", true), false);
+  assertEquals(isSentryEnabled("0", true), false);
+  assertEquals(isSentryEnabled(undefined, true), true);
+  assertEquals(isSentryEnabled(undefined, false), false);
+});
+
+Deno.test("Sentry environment configuration requires a DSN when explicitly enabled", () => {
+  const previousEnabled = Deno.env.get("SENTRY_ENABLED");
+  const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+  const previousDsn = Deno.env.get("SENTRY_DSN");
+  try {
+    Deno.env.set("SENTRY_ENABLED", "true");
+    Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
+    Deno.env.delete("SENTRY_DSN");
+
+    assertEquals(resolveSentryConfigFromEnv(), undefined);
+  } finally {
+    restoreEnv("SENTRY_ENABLED", previousEnabled);
+    restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+    restoreEnv("SENTRY_DSN", previousDsn);
+  }
+});
+
+Deno.test("Sentry environment configuration rejects explicit false even with a valid DSN", () => {
+  const previousEnabled = Deno.env.get("SENTRY_ENABLED");
+  const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+  const previousDsn = Deno.env.get("SENTRY_DSN");
+  try {
+    Deno.env.set("SENTRY_ENABLED", "false");
+    Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
+    Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
+
+    assertEquals(resolveSentryConfigFromEnv(), undefined);
+  } finally {
+    restoreEnv("SENTRY_ENABLED", previousEnabled);
+    restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+    restoreEnv("SENTRY_DSN", previousDsn);
+  }
+});
+
 Deno.test("Sentry environment configuration requires explicit provider opt-in", () => {
   const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
   const previousDsn = Deno.env.get("SENTRY_DSN");
@@ -56,11 +103,13 @@ Deno.test("Sentry environment configuration requires explicit provider opt-in", 
 });
 
 Deno.test("Sentry environment configuration uses the entrypoint service fallback", () => {
+  const previousEnabled = Deno.env.get("SENTRY_ENABLED");
   const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
   const previousDsn = Deno.env.get("SENTRY_DSN");
   const previousServiceName = Deno.env.get("SENTRY_SERVICE_NAME");
   const previousOtelServiceName = Deno.env.get("OTEL_SERVICE_NAME");
   try {
+    Deno.env.delete("SENTRY_ENABLED");
     Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
     Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
     Deno.env.set("SENTRY_SERVICE_NAME", "   ");
@@ -73,10 +122,28 @@ Deno.test("Sentry environment configuration uses the entrypoint service fallback
       serviceName: "veryfront-proxy",
     });
   } finally {
+    restoreEnv("SENTRY_ENABLED", previousEnabled);
     restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
     restoreEnv("SENTRY_DSN", previousDsn);
     restoreEnv("SENTRY_SERVICE_NAME", previousServiceName);
     restoreEnv("OTEL_SERVICE_NAME", previousOtelServiceName);
+  }
+});
+
+Deno.test("Sentry accepts a public HTTPS custom-host DSN", () => {
+  const previousEnabled = Deno.env.get("SENTRY_ENABLED");
+  const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+  const previousDsn = Deno.env.get("SENTRY_DSN");
+  try {
+    Deno.env.set("SENTRY_ENABLED", "true");
+    Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
+    Deno.env.set("SENTRY_DSN", "https://public@errors.example.test/42");
+
+    assertEquals(resolveSentryConfigFromEnv()?.dsn, "https://public@errors.example.test/42");
+  } finally {
+    restoreEnv("SENTRY_ENABLED", previousEnabled);
+    restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+    restoreEnv("SENTRY_DSN", previousDsn);
   }
 });
 
@@ -103,6 +170,29 @@ Deno.test("Sentry loads the extension with normalized runtime configuration", as
     release: "release-1",
     serviceName: "veryfront-server",
   });
+});
+
+Deno.test("Sentry initialization is idempotent across concurrent callers", async () => {
+  resetSentryForTests();
+  const { load, state } = createSentryExtension();
+  let resolveLoad: (() => void) | undefined;
+  let loadCount = 0;
+  const delayedLoad = async () => {
+    loadCount += 1;
+    await new Promise<void>((resolve) => {
+      resolveLoad = resolve;
+    });
+    return await load();
+  };
+  const config = { dsn: "https://public@errors.example.test/42" };
+
+  const first = initializeSentry(config, delayedLoad);
+  const second = initializeSentry(config, delayedLoad);
+  resolveLoad?.();
+
+  assertEquals(await Promise.all([first, second]), [true, true]);
+  assertEquals(loadCount, 1);
+  assertEquals(state.config?.dsn, "https://public@errors.example.test/42");
 });
 
 Deno.test("Sentry captures service and Grafana trace correlation", async () => {

--- a/src/observability/sentry.test.ts
+++ b/src/observability/sentry.test.ts
@@ -59,12 +59,18 @@ describe("observability/sentry", () => {
   });
 
   it("Sentry startup warns once without exposing secrets when explicitly enabled without a DSN", async () => {
+    resetSentryForTests();
     const previousEnabled = Deno.env.get("SENTRY_ENABLED");
     const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
     const previousDsn = Deno.env.get("SENTRY_DSN");
     const previousAuthToken = Deno.env.get("SENTRY_AUTH_TOKEN");
     const originalWarn = console.warn;
     const warnings: unknown[][] = [];
+    let loadCount = 0;
+    const load = () => {
+      loadCount += 1;
+      return createSentryExtension().load();
+    };
     try {
       Deno.env.set("SENTRY_ENABLED", "true");
       Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
@@ -72,7 +78,19 @@ describe("observability/sentry", () => {
       Deno.env.set("SENTRY_AUTH_TOKEN", "super-secret-token");
       console.warn = (...args: unknown[]) => warnings.push(args);
 
-      assertEquals(await initializeSentryFromEnv(), false);
+      assertEquals(resolveSentryConfigFromEnv(), undefined);
+      assertEquals(resolveSentryConfigFromEnv(), undefined);
+      assertEquals(warnings, []);
+      assertEquals(
+        await Promise.all([
+          initializeSentryFromEnv(undefined, load),
+          initializeSentryFromEnv(undefined, load),
+          initializeSentryFromEnv(undefined, load),
+        ]),
+        [false, false, false],
+      );
+      assertEquals(await initializeSentryFromEnv(undefined, load), false);
+      assertEquals(loadCount, 0);
       assertEquals(warnings, [[
         "Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.",
       ]]);
@@ -82,6 +100,38 @@ describe("observability/sentry", () => {
       restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
       restoreEnv("SENTRY_DSN", previousDsn);
       restoreEnv("SENTRY_AUTH_TOKEN", previousAuthToken);
+    }
+  });
+
+  it("Sentry startup does not warn or load the SDK when disabled or compatibility-unset without a DSN", async () => {
+    resetSentryForTests();
+    const previousEnabled = Deno.env.get("SENTRY_ENABLED");
+    const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+    const previousDsn = Deno.env.get("SENTRY_DSN");
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    let loadCount = 0;
+    const load = () => {
+      loadCount += 1;
+      return createSentryExtension().load();
+    };
+    try {
+      Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
+      Deno.env.set("SENTRY_DSN", "   ");
+      console.warn = (...args: unknown[]) => warnings.push(args);
+
+      Deno.env.set("SENTRY_ENABLED", "false");
+      assertEquals(await initializeSentryFromEnv(undefined, load), false);
+      Deno.env.delete("SENTRY_ENABLED");
+      assertEquals(await initializeSentryFromEnv(undefined, load), false);
+
+      assertEquals(warnings, []);
+      assertEquals(loadCount, 0);
+    } finally {
+      console.warn = originalWarn;
+      restoreEnv("SENTRY_ENABLED", previousEnabled);
+      restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+      restoreEnv("SENTRY_DSN", previousDsn);
     }
   });
 

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -58,12 +58,18 @@ export function resolveSentryConfigFromEnv(
 ): SentryConfig | undefined {
   const reporterSelected = getEnv("VERYFRONT_ERROR_REPORTER")?.trim().toLowerCase() ===
     SENTRY_ERROR_REPORTER;
-  if (!reporterSelected || !isSentryEnabled(getEnv("SENTRY_ENABLED"), reporterSelected)) {
+  const enabled = getEnv("SENTRY_ENABLED");
+  if (!reporterSelected || !isSentryEnabled(enabled, reporterSelected)) {
     return undefined;
   }
 
   const dsn = getEnv("SENTRY_DSN")?.trim();
-  if (!dsn) return undefined;
+  if (!dsn) {
+    if (isSentryEnabled(enabled, false)) {
+      console.warn("Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.");
+    }
+    return undefined;
+  }
 
   return {
     dsn,

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -27,16 +27,46 @@ type SentryExtensionModule = {
 type SentryExtensionLoader = () => Promise<SentryExtensionModule>;
 
 let initialized = false;
+let initializationGeneration = 0;
+let initializationPromise: Promise<boolean> | undefined;
+
+/**
+ * Resolve the compatibility-release Sentry flag.
+ *
+ * Explicit false always disables reporting. While the flag is unset (or is an
+ * unrecognized value), callers retain their pre-flag behavior until managed
+ * deployments have been migrated to explicit values.
+ */
+export function isSentryEnabled(
+  enabled: string | undefined,
+  legacyEnabled: boolean,
+): boolean {
+  switch (enabled?.trim().toLowerCase()) {
+    case "true":
+    case "1":
+      return true;
+    case "false":
+    case "0":
+      return false;
+    default:
+      return legacyEnabled;
+  }
+}
 
 export function resolveSentryConfigFromEnv(
   defaultServiceName = DEFAULT_SERVICE_NAME,
 ): SentryConfig | undefined {
-  if (getEnv("VERYFRONT_ERROR_REPORTER")?.trim().toLowerCase() !== SENTRY_ERROR_REPORTER) {
+  const reporterSelected = getEnv("VERYFRONT_ERROR_REPORTER")?.trim().toLowerCase() ===
+    SENTRY_ERROR_REPORTER;
+  if (!reporterSelected || !isSentryEnabled(getEnv("SENTRY_ENABLED"), reporterSelected)) {
     return undefined;
   }
 
+  const dsn = getEnv("SENTRY_DSN")?.trim();
+  if (!dsn) return undefined;
+
   return {
-    dsn: getEnv("SENTRY_DSN"),
+    dsn,
     environment: getEnv("SENTRY_ENVIRONMENT") ?? getEnv("OTEL_DEPLOYMENT_ENVIRONMENT"),
     release: getEnv("SENTRY_RELEASE") ?? getEnv("OTEL_SERVICE_VERSION"),
     serviceName: (getEnv("SENTRY_SERVICE_NAME") ?? getEnv("OTEL_SERVICE_NAME"))?.trim() ||
@@ -60,19 +90,34 @@ export async function initializeSentry(
   const dsn = config.dsn?.trim();
   if (!dsn) return false;
 
-  const extension = await loadExtension();
-  const reporter = extension.createSentryApplicationErrorReporter({
-    dsn,
-    environment: config.environment?.trim() ?? "",
-    release: config.release?.trim() ?? "",
-    serviceName: config.serviceName?.trim() || DEFAULT_SERVICE_NAME,
-  });
-  setApplicationErrorReporter(reporter);
-  initialized = true;
-  return true;
+  if (initializationPromise) return await initializationPromise;
+
+  const generation = initializationGeneration;
+  const pending = (async () => {
+    const extension = await loadExtension();
+    if (generation !== initializationGeneration) return false;
+
+    const reporter = extension.createSentryApplicationErrorReporter({
+      dsn,
+      environment: config.environment?.trim() ?? "",
+      release: config.release?.trim() ?? "",
+      serviceName: config.serviceName?.trim() || DEFAULT_SERVICE_NAME,
+    });
+    setApplicationErrorReporter(reporter);
+    initialized = true;
+    return true;
+  })();
+  initializationPromise = pending;
+  try {
+    return await pending;
+  } finally {
+    if (initializationPromise === pending) initializationPromise = undefined;
+  }
 }
 
 export function resetSentryForTests(): void {
+  initializationGeneration += 1;
+  initializationPromise = undefined;
   initialized = false;
   setApplicationErrorReporter(undefined);
 }

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -12,6 +12,8 @@ export type { ApplicationErrorContext, ApplicationErrorReporter } from "./applic
 
 const DEFAULT_SERVICE_NAME = "veryfront-server";
 const SENTRY_ERROR_REPORTER = "sentry";
+const MISSING_DSN_WARNING =
+  "Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.";
 
 export type SentryConfig = {
   dsn?: string;
@@ -29,6 +31,7 @@ type SentryExtensionLoader = () => Promise<SentryExtensionModule>;
 let initialized = false;
 let initializationGeneration = 0;
 let initializationPromise: Promise<boolean> | undefined;
+let missingDsnWarningEmitted = false;
 
 /**
  * Resolve the compatibility-release Sentry flag.
@@ -64,12 +67,7 @@ export function resolveSentryConfigFromEnv(
   }
 
   const dsn = getEnv("SENTRY_DSN")?.trim();
-  if (!dsn) {
-    if (isSentryEnabled(enabled, false)) {
-      console.warn("Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.");
-    }
-    return undefined;
-  }
+  if (!dsn) return undefined;
 
   return {
     dsn,
@@ -82,9 +80,11 @@ export function resolveSentryConfigFromEnv(
 
 export function initializeSentryFromEnv(
   defaultServiceName = DEFAULT_SERVICE_NAME,
+  loadExtension: SentryExtensionLoader = loadSentryExtension,
 ): Promise<boolean> {
   const config = resolveSentryConfigFromEnv(defaultServiceName);
-  return config ? initializeSentry(config) : Promise.resolve(false);
+  if (!config && shouldWarnAboutMissingDsn()) warnAboutMissingDsnOnce();
+  return config ? initializeSentry(config, loadExtension) : Promise.resolve(false);
 }
 
 export async function initializeSentry(
@@ -124,8 +124,22 @@ export async function initializeSentry(
 export function resetSentryForTests(): void {
   initializationGeneration += 1;
   initializationPromise = undefined;
+  missingDsnWarningEmitted = false;
   initialized = false;
   setApplicationErrorReporter(undefined);
+}
+
+function shouldWarnAboutMissingDsn(): boolean {
+  const reporterSelected = getEnv("VERYFRONT_ERROR_REPORTER")?.trim().toLowerCase() ===
+    SENTRY_ERROR_REPORTER;
+  return reporterSelected && isSentryEnabled(getEnv("SENTRY_ENABLED"), false) &&
+    !getEnv("SENTRY_DSN")?.trim();
+}
+
+function warnAboutMissingDsnOnce(): void {
+  if (missingDsnWarningEmitted) return;
+  missingDsnWarningEmitted = true;
+  console.warn(MISSING_DSN_WARNING);
 }
 
 function loadSentryExtension(): Promise<SentryExtensionModule> {


### PR DESCRIPTION
## Summary

- add the compatibility-release `SENTRY_ENABLED` contract to the public `veryfront/observability/sentry` entrypoint
- make explicit `false`/`0` override a valid DSN while preserving each caller's legacy behavior when the flag is unset
- apply the shared gate to the framework Server/Proxy path and the Node Agent service path
- emit one fixed, secret-free startup warning per process when Sentry is explicitly enabled without a DSN, even across repeated or concurrent initialization
- keep `VERYFRONT_ERROR_REPORTER=sentry` as the framework adapter selector
- accept public HTTPS custom-host DSNs without introducing a SaaS hostname restriction
- make framework SDK initialization idempotent for concurrent callers and retain the existing redaction policy

## Tests

- focused framework, Agent, and redaction tests: 11 test registrations and 23 BDD steps passed
- Sentry extension adapter suite: 20 passed
- isolated Node/Deno runtime package generation smoke: passed
- `deno task typecheck`: passed
- formatting, lint, typecheck, dependency boundaries, module boundaries, extension contracts/capabilities: passed
- isolated Sentry Node/Deno runtime package generation smoke: passed
- repository pre-push checks, including the full unit suite: passed
- `deno task verify:quick` reached docs validation; it is blocked by the pre-existing `./release-assets` missing-`@example` documentation error on unchanged `origin/main` code

## Rollout / dependencies

- Depends on evidence baseline: veryfront/veryfront-operations#8
- Blocks the compatibility consumers in API, Agent, Server, Sandbox, Job Runner, and Operator rollout PRs.
- This PR deliberately does **not** read or validate `SENTRY_URL`; that variable belongs to release/deployment tooling, while runtime ingestion is selected only by `SENTRY_DSN`.
- Unset behavior is compatibility-only. Managed deployments must move to explicit `SENTRY_ENABLED=true|false` before the later strict-unset rollout.

## Publishing

After merge, publish a fresh `veryfront` release and matching Sentry Node/Deno runtime packages, then update downstream consumers to that immutable version. Version metadata is intentionally left to the repository's normal release PR rather than mixing a release bump into this source PR.


