### PR TITLE
refactor(security): remove dormant SSR worker protocol

### DIFF
--- a/src/rendering/orchestrator/ssr-orchestrator.ts
+++ b/src/rendering/orchestrator/ssr-orchestrator.ts
@@ -10,9 +10,6 @@ import type { HTMLGenerationContext, HTMLGenerator } from "./html.ts";
 import type { LayoutOrchestrator } from "./layout.ts";
 import type { RenderOptions } from "./types.ts";
 import { runWithHeadCollector } from "#veryfront/react/head-collector.ts";
-import { getWorkerPool, isSSRIsolationEnabled } from "#veryfront/security/sandbox/worker-pool.ts";
-import type { WorkerResponse } from "#veryfront/security/sandbox/worker-types.ts";
-import { requireActiveSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import {
   endRenderSession,
   hasRenderSession,
@@ -34,24 +31,6 @@ export interface SSRRenderingResult {
   fullHtml: string;
   finalStream: ReadableStream | null;
   ssrHash: string;
-}
-
-/**
- * Options for isolated SSR rendering through the Worker pool.
- * When provided and SSR isolation is enabled, the rendering happens
- * in a per-project Worker instead of the main process.
- */
-export interface SSRIsolationOptions {
-  /** Temp file path for the page component module */
-  pageModulePath: string;
-  /** Ordered layout module temp paths (innermost to outermost) */
-  layoutModulePaths: string[];
-  /** Page component props */
-  pageProps: Record<string, unknown>;
-  /** Layout props (one entry per layout, matching layoutModulePaths order) */
-  layoutProps: Record<string, unknown>[];
-  /** Project directory for worker scoping */
-  projectDir: string;
 }
 
 function getElementTypeName(el: React.ReactElement | null | undefined): string {
@@ -93,21 +72,7 @@ export class SSROrchestrator {
     pageElement: React.ReactElement,
     generationContext: Omit<HTMLGenerationContext, "html" | "ssrHash">,
     options?: RenderOptions,
-    isolationOptions?: SSRIsolationOptions,
   ): Promise<SSRRenderingResult> {
-    // Isolated SSR path: render in per-project Worker
-    if (
-      isSSRIsolationEnabled() &&
-      isolationOptions?.pageModulePath &&
-      isolationOptions?.projectDir
-    ) {
-      // NOTE: the app-router error.tsx catch below is scoped to the main-process
-      // render path. Under SSR isolation (per-project Worker) a page throw is not
-      // yet routed to error.tsx — a follow-up, isolation being off by default.
-      return this.performIsolatedSSR(generationContext, options, isolationOptions);
-    }
-
-    // Default path: render in main process
     logger.debug("performSSRRendering called", {
       elementType: getElementTypeName(pageElement),
       hasChildren: !!(pageElement.props as Record<string, unknown>)?.children,
@@ -297,96 +262,6 @@ export class SSROrchestrator {
       error: err.message,
     });
     return { result: rendered.result, head: rendered.head, errorPath: errorInfo.path };
-  }
-
-  /**
-   * Perform SSR rendering in an isolated per-project Worker.
-   *
-   * The Worker imports user modules from their temp file paths,
-   * constructs the React element tree, and renders to HTML.
-   * For streaming, the Worker sends chunks via postMessage.
-   */
-  private async performIsolatedSSR(
-    generationContext: Omit<HTMLGenerationContext, "html" | "ssrHash">,
-    options: RenderOptions | undefined,
-    isolation: SSRIsolationOptions,
-  ): Promise<SSRRenderingResult> {
-    const wantsStream = options?.delivery === "stream";
-    const pool = getWorkerPool();
-    const requestId = crypto.randomUUID();
-
-    return withSpan(
-      "ssr.isolated_render",
-      async () => {
-        const worker = pool.getOrCreateWorker(isolation.projectDir, [isolation.projectDir]);
-
-        if (wantsStream) {
-          // Streaming mode: get a ReadableStream of chunks from the Worker
-          const stream = worker.executeStream({
-            type: "render-ssr",
-            id: requestId,
-            pageModulePath: isolation.pageModulePath,
-            layoutModulePaths: isolation.layoutModulePaths,
-            pageProps: isolation.pageProps,
-            layoutProps: isolation.layoutProps,
-            delivery: "stream",
-            sourceIntegrationPolicy: requireActiveSourceIntegrationPolicy(),
-          });
-
-          const ssrHash = `stream-isolated-${Date.now()}`;
-
-          // Generate HTML stream using the framework's HTML generator
-          const finalStream = await this.config.htmlGenerator.generateHTMLStream(stream, {
-            ...generationContext,
-            ssrHash,
-            options: { ...generationContext.options, ...options },
-            collectedHead: undefined,
-          });
-
-          return { fullHtml: "", finalStream, ssrHash };
-        }
-
-        // String mode: render to HTML in Worker, get result back
-        const workerResponse: WorkerResponse = await worker.execute({
-          type: "render-ssr",
-          id: requestId,
-          pageModulePath: isolation.pageModulePath,
-          layoutModulePaths: isolation.layoutModulePaths,
-          pageProps: isolation.pageProps,
-          layoutProps: isolation.layoutProps,
-          delivery: "string",
-          sourceIntegrationPolicy: requireActiveSourceIntegrationPolicy(),
-        });
-
-        if (workerResponse.type === "error") {
-          const err = new Error(workerResponse.error.message);
-          err.name = workerResponse.error.name;
-          throw err;
-        }
-
-        if (workerResponse.type !== "ssr-result") {
-          throw new Error(`Unexpected worker response type: ${workerResponse.type}`);
-        }
-
-        const html = workerResponse.html;
-        const ssrHash = await computeHash(html);
-
-        const fullHtml = await this.config.htmlGenerator.generateFullHTML({
-          ...generationContext,
-          html,
-          ssrHash,
-          options: { ...generationContext.options, ...options },
-          collectedHead: undefined,
-        });
-
-        return { fullHtml, finalStream: null, ssrHash };
-      },
-      {
-        "ssr.isolated": true,
-        "ssr.wants_stream": wantsStream,
-        "ssr.project_dir": isolation.projectDir,
-      },
-    );
   }
 
   private createStream(html: string): ReadableStream | null {

--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -39,7 +39,6 @@ const TEST_WORKER_SCRIPT_URL = `data:application/typescript,${
         return;
       }
       if (msg.type === "clear-cache") return;
-      if (msg.type === "render-ssr") return;
       self.postMessage({
         type: "error",
         id: msg.id,
@@ -431,15 +430,6 @@ testSuite("ProjectWorker - real worker request isolation", () => {
           request: serializedRequest,
           url: serializedRequest.url,
         },
-      },
-      {
-        type: "render-ssr",
-        id: "ssr",
-        pageModulePath: modulePath,
-        layoutModulePaths: [],
-        pageProps: {},
-        layoutProps: [],
-        delivery: "string",
       },
     ];
 
@@ -1351,50 +1341,6 @@ testSuite("ProjectWorker - real worker request isolation", () => {
         Deno.env.set(WORKER_INTERNAL_EGRESS_OVERRIDE_ENV, previousOverride);
       }
       await Deno.remove(projectDir, { recursive: true });
-    }
-  });
-});
-
-testSuite("ProjectWorker - executeStream", () => {
-  it("throws when worker is not started", () => {
-    const worker = createTestWorker("test-stream");
-    let threw = false;
-    try {
-      worker.executeStream({
-        type: "render-ssr",
-        id: "test-id",
-        pageModulePath: "/nonexistent.ts",
-        layoutModulePaths: [],
-        pageProps: {},
-        layoutProps: [],
-        delivery: "stream",
-        sourceIntegrationPolicy: TEST_SOURCE_INTEGRATION_POLICY,
-      });
-    } catch {
-      threw = true;
-    }
-    assert(threw, "should throw when worker is not available");
-  });
-
-  it("returns a ReadableStream when worker is started", () => {
-    const worker = createTestWorker("test-stream");
-    worker.start();
-    try {
-      const stream = worker.executeStream({
-        type: "render-ssr",
-        id: "test-id",
-        pageModulePath: "/nonexistent.ts",
-        layoutModulePaths: [],
-        pageProps: {},
-        layoutProps: [],
-        delivery: "stream",
-        sourceIntegrationPolicy: TEST_SOURCE_INTEGRATION_POLICY,
-      });
-      assert(stream instanceof ReadableStream, "should return a ReadableStream");
-      // Cancel the stream to clean up
-      stream.cancel();
-    } finally {
-      worker.terminate();
     }
   });
 });

--- a/src/security/sandbox/project-worker.ts
+++ b/src/security/sandbox/project-worker.ts
@@ -21,15 +21,9 @@ import {
   type WorkerEgressBroker,
 } from "./worker-egress-guard.ts";
 import type { WorkerPermissions } from "./worker-permissions.ts";
-import type {
-  WorkerRequest,
-  WorkerResponse,
-  WorkerStreamChunk,
-  WorkerStreamEnd,
-} from "./worker-types.ts";
+import type { WorkerRequest, WorkerResponse } from "./worker-types.ts";
 
 const logger = serverLogger.component("project-worker");
-const textEncoder = new TextEncoder();
 
 // Intersection with the DOM `WorkerOptions` so the value is assignable to the
 // `Worker` constructor without suppression — Deno reads the extra `deno` field
@@ -56,12 +50,6 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
-interface StreamHandler {
-  onChunk: (chunk: Uint8Array) => void;
-  onEnd: () => void;
-  onError: (error: Error) => void;
-}
-
 /**
  * Status of a project worker.
  */
@@ -72,7 +60,6 @@ export class ProjectWorker {
 
   private worker: Worker | null = null;
   private pending = new Map<string, PendingRequest>();
-  private streamHandlers = new Map<string, StreamHandler>();
   private requestTimeoutMs: number;
   private permissions: WorkerPermissions;
   private workerScriptUrl?: string;
@@ -225,109 +212,6 @@ export class ProjectWorker {
   }
 
   /**
-   * Execute a streaming request. Returns a ReadableStream that yields
-   * chunks as they arrive from the Worker via postMessage.
-   *
-   * Used for streaming SSR where the Worker sends chunks progressively.
-   * Falls back to a single-chunk stream if the Worker returns a non-streaming
-   * response (ssr-result with full HTML).
-   */
-  executeStream(request: WorkerRequest): ReadableStream<Uint8Array> {
-    if (!this.worker || this._status === "crashed" || this._status === "terminated") {
-      throw UNKNOWN_ERROR.create({ detail: `Worker not available (status: ${this._status})` });
-    }
-
-    this._requestCount++;
-    this._lastActivityAt = Date.now();
-    this._status = "busy";
-
-    const requestId = request.id;
-
-    return new ReadableStream<Uint8Array>({
-      start: (controller) => {
-        let timer = setTimeout(() => {
-          this.streamHandlers.delete(requestId);
-          this.pending.delete(requestId);
-          this.updateIdleStatus();
-          controller.error(
-            TIMEOUT_ERROR.create({
-              detail: `Worker stream timed out after ${this.requestTimeoutMs}ms`,
-            }),
-          );
-        }, this.requestTimeoutMs);
-
-        const resetTimer = () => {
-          clearTimeout(timer);
-          timer = setTimeout(() => {
-            this.streamHandlers.delete(requestId);
-            this.pending.delete(requestId);
-            this.updateIdleStatus();
-            controller.error(
-              TIMEOUT_ERROR.create({
-                detail: `Worker stream timed out after ${this.requestTimeoutMs}ms`,
-              }),
-            );
-          }, this.requestTimeoutMs);
-        };
-
-        // Register a stream handler for this request
-        this.streamHandlers.set(requestId, {
-          onChunk: (chunk: Uint8Array) => {
-            resetTimer();
-            controller.enqueue(chunk);
-          },
-          onEnd: () => {
-            clearTimeout(timer);
-            this.streamHandlers.delete(requestId);
-            this.pending.delete(requestId);
-            this.updateIdleStatus();
-            controller.close();
-          },
-          onError: (error: Error) => {
-            clearTimeout(timer);
-            this.streamHandlers.delete(requestId);
-            this.pending.delete(requestId);
-            this.updateIdleStatus();
-            controller.error(error);
-          },
-        });
-
-        // Also register in pending for non-streaming responses (fallback)
-        this.pending.set(requestId, {
-          resolve: (response) => {
-            clearTimeout(timer);
-            this.streamHandlers.delete(requestId);
-            this.pending.delete(requestId);
-            this.updateIdleStatus();
-
-            // If we get an ssr-result, emit it as a single chunk
-            if (response.type === "ssr-result") {
-              controller.enqueue(textEncoder.encode(response.html));
-              controller.close();
-            } else if (response.type === "error") {
-              const err = new Error(response.error.message);
-              err.name = response.error.name;
-              controller.error(err);
-            } else {
-              controller.close();
-            }
-          },
-          reject: (error) => {
-            clearTimeout(timer);
-            this.streamHandlers.delete(requestId);
-            this.pending.delete(requestId);
-            this.updateIdleStatus();
-            controller.error(error);
-          },
-          timer,
-        });
-
-        this.worker!.postMessage(request);
-      },
-    });
-  }
-
-  /**
    * Health check — send a ping and wait for pong.
    */
   async isHealthy(timeoutMs = 5_000): Promise<boolean> {
@@ -416,8 +300,6 @@ export class ProjectWorker {
   private handleMessage(
     data:
       | WorkerResponse
-      | WorkerStreamChunk
-      | WorkerStreamEnd
       | { type: "worker-exit" }
       | { type: "pong"; id: string },
   ): void {
@@ -433,19 +315,6 @@ export class ProjectWorker {
         pending.resolve(data as unknown as WorkerResponse);
         this.pending.delete((data as { id: string }).id);
       }
-      return;
-    }
-
-    // Handle streaming SSR chunks
-    if (data.type === "stream-chunk") {
-      const handler = this.streamHandlers.get(data.id);
-      if (handler) handler.onChunk(data.chunk);
-      return;
-    }
-
-    if (data.type === "stream-end") {
-      const handler = this.streamHandlers.get(data.id);
-      if (handler) handler.onEnd();
       return;
     }
 
@@ -477,12 +346,6 @@ export class ProjectWorker {
       clearTimeout(pending.timer);
       pending.reject(UNKNOWN_ERROR.create({ detail: reason }));
       this.pending.delete(id);
-    }
-
-    // Clean up stream handlers
-    for (const [id, handler] of this.streamHandlers) {
-      handler.onError(UNKNOWN_ERROR.create({ detail: reason }));
-      this.streamHandlers.delete(id);
     }
   }
 }

--- a/src/security/sandbox/worker-pool.test.ts
+++ b/src/security/sandbox/worker-pool.test.ts
@@ -1,12 +1,17 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { VeryfrontError } from "#veryfront/errors/types.ts";
 import {
   __resetPoolForTests,
   isDataIsolationEnabled,
-  isSSRIsolationEnabled,
   isWorkerIsolationEnabled,
   WorkerPool,
 } from "./worker-pool.ts";
@@ -356,7 +361,6 @@ describe("Feature flag caching", () => {
     __resetPoolForTests();
     assertEquals(isWorkerIsolationEnabled(), false);
     assertEquals(isDataIsolationEnabled(), false);
-    assertEquals(isSSRIsolationEnabled(), false);
   });
 
   it("returns true for API isolation when both flags set", () => {
@@ -373,11 +377,15 @@ describe("Feature flag caching", () => {
     assertEquals(isDataIsolationEnabled(), true);
   });
 
-  it("returns true for SSR isolation when both flags set", () => {
+  it("fails closed when the removed SSR isolation flag is enabled", () => {
     __resetPoolForTests();
     Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
     Deno.env.set("WORKER_ISOLATION_SSR", "1");
-    assertEquals(isSSRIsolationEnabled(), true);
+    assertThrows(
+      () => isWorkerIsolationEnabled(),
+      Error,
+      "WORKER_ISOLATION_SSR is unsupported",
+    );
   });
 
   it("caches flag results across calls", () => {

--- a/src/security/sandbox/worker-pool.ts
+++ b/src/security/sandbox/worker-pool.ts
@@ -11,7 +11,7 @@
 import { serverLogger } from "#veryfront/utils";
 import { getEnvBoolean, getEnvNumber, unrefTimer } from "#veryfront/platform/compat/process.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
-import { SECURITY_VIOLATION } from "#veryfront/errors";
+import { NOT_SUPPORTED, SECURITY_VIOLATION } from "#veryfront/errors";
 import { ProjectWorker } from "./project-worker.ts";
 import { buildWorkerEnvAllowlist, buildWorkerPermissions } from "./worker-permissions.ts";
 import type { WorkerPoolConfig, WorkerRequest, WorkerResponse } from "./worker-types.ts";
@@ -424,14 +424,17 @@ export class WorkerPool {
 let _flagsResolved = false;
 let _apiIsolation = false;
 let _dataIsolation = false;
-let _ssrIsolation = false;
 
 function resolveFlags(): void {
   if (_flagsResolved) return;
   const master = getEnvBoolean("WORKER_ISOLATION_ENABLED", false);
+  if (master && getEnvBoolean("WORKER_ISOLATION_SSR", false)) {
+    throw NOT_SUPPORTED.create({
+      detail: "WORKER_ISOLATION_SSR is unsupported; SSR uses the bounded main-process renderer",
+    });
+  }
   _apiIsolation = master && getEnvBoolean("WORKER_ISOLATION_API", false);
   _dataIsolation = master && getEnvBoolean("WORKER_ISOLATION_DATA", false);
-  _ssrIsolation = master && getEnvBoolean("WORKER_ISOLATION_SSR", false);
   _flagsResolved = true;
 }
 
@@ -451,15 +454,6 @@ export function isWorkerIsolationEnabled(): boolean {
 export function isDataIsolationEnabled(): boolean {
   resolveFlags();
   return _dataIsolation;
-}
-
-/**
- * Whether worker isolation is enabled for SSR rendering.
- * Controlled by WORKER_ISOLATION_SSR=1 (requires WORKER_ISOLATION_ENABLED=1).
- */
-export function isSSRIsolationEnabled(): boolean {
-  resolveFlags();
-  return _ssrIsolation;
 }
 
 /** Lazy singleton — created on first use when isolation is enabled */
@@ -491,5 +485,4 @@ export function __resetPoolForTests(): void {
   _flagsResolved = false;
   _apiIsolation = false;
   _dataIsolation = false;
-  _ssrIsolation = false;
 }

--- a/src/security/sandbox/worker-script.ts
+++ b/src/security/sandbox/worker-script.ts
@@ -14,7 +14,6 @@ import type {
   ExecuteAppRouteRequest,
   ExecutePagesRouteRequest,
   FetchDataRequest,
-  RenderSSRRequest,
   SerializedDataContext,
   SerializedDataResult,
   SerializedError,
@@ -25,9 +24,6 @@ import type {
   WorkerErrorResponse,
   WorkerRequest,
   WorkerResultResponse,
-  WorkerSSRResultResponse,
-  WorkerStreamChunk,
-  WorkerStreamEnd,
 } from "./worker-types.ts";
 import { installWorkerEgressGuard, type WorkerEgressGuardOptions } from "./worker-egress-guard.ts";
 import { isAbsolute, relative, resolve as resolvePath, sep as PATH_SEP } from "node:path";
@@ -137,26 +133,6 @@ export function makeProjectPathGuard(projectDir: string): (path: string) => Prom
 
     return realResolved ?? resolved;
   };
-}
-
-// Load React lazily for SSR requests. API-only workers and health checks should
-// start without resolving React, and the runtime caches dynamic imports after
-// the first SSR request.
-let _React: typeof import("react") | null = null;
-let _ReactDOMServer: typeof import("react-dom/server") | null = null;
-let _reactReady: Promise<void> | null = null;
-
-function ensureReactReady(): Promise<void> {
-  _reactReady ??= (async () => {
-    try {
-      _React = await import("react");
-      _ReactDOMServer = await import("react-dom/server");
-    } catch {
-      // React may not be available in all worker contexts (e.g., API-only workers).
-      // SSR handler will throw a clear error if React is needed but not loaded.
-    }
-  })();
-  return _reactReady;
 }
 
 // ---------------------------------------------------------------------------
@@ -508,114 +484,6 @@ async function handlePagesRoute(req: ExecutePagesRouteRequest): Promise<Serializ
 }
 
 // ---------------------------------------------------------------------------
-// SSR Rendering Handler
-// ---------------------------------------------------------------------------
-
-/**
- * Handle SSR rendering in the isolated Worker.
- *
- * Imports the page + layout components from their temp file paths,
- * constructs a React element tree (layouts wrapping page), and renders
- * to HTML string. For streaming, sends chunks via postMessage.
- *
- * The Worker gets its own React instance — safe because SSR is
- * self-contained (no hydration mismatch concern).
- */
-async function handleRenderSSR(
-  req: RenderSSRRequest,
-): Promise<{ html: string } | "streaming"> {
-  return await runWithWorkerSourceIntegrationPolicy(
-    req.sourceIntegrationPolicy,
-    async () => await renderSSR(req),
-  );
-}
-
-async function renderSSR(
-  req: RenderSSRRequest,
-): Promise<{ html: string } | "streaming"> {
-  // Load React only for SSR workers. API-only workers and health checks should
-  // not pay the React import cost or contend on it under parallel worker tests.
-  await ensureReactReady();
-
-  if (!_React || !_ReactDOMServer) {
-    throw new Error("React modules not available in this worker");
-  }
-
-  const React = _React;
-  const { renderToString } = _ReactDOMServer;
-
-  // Import the page component
-  const pageMod = await loadModule(req.pageModulePath);
-  const PageComponent = (pageMod.default ?? pageMod) as React.ComponentType<
-    Record<string, unknown>
-  >;
-
-  // Import layout components (innermost → outermost order)
-  const layoutComponents: React.ComponentType<Record<string, unknown>>[] = [];
-  for (const layoutPath of req.layoutModulePaths) {
-    const layoutMod = await loadModule(layoutPath);
-    layoutComponents.push(
-      (layoutMod.default ?? layoutMod) as React.ComponentType<
-        Record<string, unknown>
-      >,
-    );
-  }
-
-  // Build element tree: page is innermost, layouts wrap outward
-  const createElement = React.createElement as (
-    type: unknown,
-    props: Record<string, unknown> | null,
-    ...children: unknown[]
-  ) => React.ReactElement;
-
-  let element: React.ReactElement = createElement(PageComponent, req.pageProps);
-
-  for (let i = 0; i < layoutComponents.length; i++) {
-    const Layout = layoutComponents[i];
-    const layoutProps = req.layoutProps[i] ?? {};
-    element = createElement(Layout, layoutProps, element);
-  }
-
-  // Streaming mode: send chunks via postMessage
-  if (req.delivery === "stream") {
-    // Use renderToReadableStream if available (React 18+)
-    const serverModule = _ReactDOMServer as unknown as Record<string, unknown>;
-    const renderToReadableStream = serverModule.renderToReadableStream as
-      | ((element: React.ReactElement) => Promise<ReadableStream<Uint8Array>>)
-      | undefined;
-
-    if (renderToReadableStream) {
-      const stream = await renderToReadableStream(element);
-      const reader = stream.getReader();
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          const endMsg: WorkerStreamEnd = { type: "stream-end", id: req.id };
-          self.postMessage(endMsg);
-          break;
-        }
-        const chunkMsg: WorkerStreamChunk = {
-          type: "stream-chunk",
-          id: req.id,
-          chunk: value,
-        };
-        // Transfer the Uint8Array for zero-copy
-        self.postMessage(chunkMsg, { transfer: [value.buffer] });
-      }
-
-      return "streaming";
-    }
-
-    // Fallback: render to string if streaming not available
-  }
-
-  // String mode (or streaming fallback): render to string
-  const html = renderToString(element);
-  return { html };
-}
-
-// ---------------------------------------------------------------------------
 // Message Handler
 // ---------------------------------------------------------------------------
 
@@ -634,22 +502,6 @@ async function processWorkerRequest(request: WorkerRequest): Promise<void> {
         result: dataResult,
       };
       self.postMessage(response);
-      return;
-    }
-
-    // SSR rendering — may stream chunks or return HTML string
-    if (request.type === "render-ssr") {
-      const ssrResult = await handleRenderSSR(request);
-
-      // If streaming, chunks were already sent via postMessage
-      if (ssrResult === "streaming") return;
-
-      const ssrResponse: WorkerSSRResultResponse = {
-        type: "ssr-result",
-        id: request.id,
-        html: ssrResult.html,
-      };
-      self.postMessage(ssrResponse);
       return;
     }
 

--- a/src/security/sandbox/worker-types.ts
+++ b/src/security/sandbox/worker-types.ts
@@ -86,8 +86,7 @@ export interface SerializedDataResult {
 export type WorkerRequest =
   | ExecuteAppRouteRequest
   | ExecutePagesRouteRequest
-  | FetchDataRequest
-  | RenderSSRRequest;
+  | FetchDataRequest;
 
 export interface ExecuteAppRouteRequest {
   type: "execute-app-route";
@@ -125,49 +124,10 @@ export interface FetchDataRequest {
   sourceIntegrationPolicy: SourceIntegrationPolicyManifest;
 }
 
-export interface RenderSSRRequest {
-  type: "render-ssr";
-  id: string;
-  /** Temp file path for the page component module */
-  pageModulePath: string;
-  /** Ordered layout module temp paths (innermost → outermost) */
-  layoutModulePaths: string[];
-  /** Page component props (JSON-serializable) */
-  pageProps: Record<string, unknown>;
-  /** Layout props keyed by layout index (matching layoutModulePaths order) */
-  layoutProps: Record<string, unknown>[];
-  /** Rendering delivery mode */
-  delivery: "string" | "stream";
-  /** Exact source-owned integration policy for this project execution. */
-  sourceIntegrationPolicy: SourceIntegrationPolicyManifest;
-}
-
-// ---------------------------------------------------------------------------
-// Streaming SSR Protocol
-// ---------------------------------------------------------------------------
-
-export interface WorkerStreamChunk {
-  type: "stream-chunk";
-  id: string;
-  chunk: Uint8Array;
-}
-
-export interface WorkerStreamEnd {
-  type: "stream-end";
-  id: string;
-}
-
 export type WorkerResponse =
   | WorkerResultResponse
   | WorkerDataResultResponse
-  | WorkerSSRResultResponse
   | WorkerErrorResponse;
-
-export interface WorkerSSRResultResponse {
-  type: "ssr-result";
-  id: string;
-  html: string;
-}
 
 export interface WorkerResultResponse {
   type: "result";


### PR DESCRIPTION
## Summary
- remove the unwired worker SSR request/response and streaming protocol
- remove worker-local React loading and the incomplete isolated rendering path
- preserve API route and data-fetch worker isolation unchanged
- fail closed with `NOT_SUPPORTED` when the removed `WORKER_ISOLATION_SSR` flag is enabled

The rendering pipeline never supplied the former isolation options, and that path bypassed the production Head, error-boundary, cancellation, and SSR resource contracts.

## Validation
- `deno task fmt:check`
- `deno task lint`
- `deno task lint:core-deps`
- `deno task typecheck`
- worker pool, project worker, and SSR orchestrator suites: 10 suites / 62 checks

## Stack
Depends on #3219.