### PR TITLE
fix(schemas): harden validation boundaries

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -57,6 +57,8 @@
     "npm:@types/unist@3.0.2": "3.0.2",
     "npm:@types/ws@8.18.1": "8.18.1",
     "npm:ai@7.0.41": "7.0.41_zod@4.3.6",
+    "npm:ajv-formats@3.0.1": "3.0.1_ajv@8.18.0",
+    "npm:ajv@8.18.0": "8.18.0",
     "npm:bash-tool@1.3.18": "1.3.18_ai@7.0.41__zod@3.25.76_just-bash@3.0.1",
     "npm:better-sqlite3@9.6.0": "9.6.0",
     "npm:brace-expansion@5.0.8": "5.0.8",
@@ -2859,6 +2861,24 @@
         "zod@4.3.6"
       ]
     },
+    "ajv-formats@3.0.1_ajv@8.18.0": {
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": [
+        "ajv"
+      ],
+      "optionalPeers": [
+        "ajv"
+      ]
+    },
+    "ajv@8.18.0": {
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
+      ]
+    },
     "ansi-regex@5.0.1": {
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
@@ -3282,6 +3302,9 @@
     "extend@3.0.2": {
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "fast-glob@3.3.3": {
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dependencies": [
@@ -3291,6 +3314,9 @@
         "merge2",
         "micromatch"
       ]
+    },
+    "fast-uri@3.1.4": {
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="
     },
     "fast-xml-builder@1.3.0": {
       "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
@@ -3736,6 +3762,9 @@
       "dependencies": [
         "bignumber.js"
       ]
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-schema@0.4.0": {
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
@@ -6479,6 +6508,8 @@
         "dependencies": [
           "jsr:@std/assert@1.0.19",
           "jsr:@std/testing@1.0.17",
+          "npm:ajv-formats@3.0.1",
+          "npm:ajv@8.18.0",
           "npm:zod@4.3.6"
         ]
       }

--- a/extensions/ext-schema-zod/deno.json
+++ b/extensions/ext-schema-zod/deno.json
@@ -10,6 +10,10 @@
     "capabilities": []
   },
   "imports": {
+    "ajv": "npm:ajv@8.18.0",
+    "ajv/dist/2019.js": "npm:ajv@8.18.0/dist/2019.js",
+    "ajv/dist/2020.js": "npm:ajv@8.18.0/dist/2020.js",
+    "ajv-formats": "npm:ajv-formats@3.0.1",
     "zod": "npm:zod@4.3.6",
     "@std/assert": "jsr:@std/assert@1.0.19",
     "@std/testing/bdd": "jsr:@std/testing@1.0.17/bdd",

--- a/extensions/ext-schema-zod/src/adapter.ts
+++ b/extensions/ext-schema-zod/src/adapter.ts
@@ -10,10 +10,18 @@
  * @module extensions/ext-schema-zod/adapter
  */
 
+import { Ajv as AjvDraft7, type AnySchema, type ErrorObject, type ValidateFunction } from "ajv";
+import { Ajv2019 } from "ajv/dist/2019.js";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormatsModule from "ajv-formats";
 import { z } from "zod";
 import type {
   InferShape,
   JsonSchema,
+  JsonSchemaValidationFailure,
+  JsonSchemaValidationFunction,
+  JsonSchemaValidationIssue,
+  JsonSchemaValidationSuccess,
   RefinementCtx,
   Schema,
   SchemaValidator,
@@ -21,7 +29,13 @@ import type {
   ValidationIssue,
   ValidationResult,
 } from "veryfront/extensions/schema";
-import { isOptionalSchema, zodToJsonSchema } from "./json-schema.ts";
+import { isOptionalSchema, recordStaticJsonSchemaDefault, zodToJsonSchema } from "./json-schema.ts";
+
+// Deno exposes the CommonJS default as a callable value at runtime while the
+// package declaration describes the imported value as a module namespace.
+const addFormats = addFormatsModule as unknown as (
+  compiler: JsonSchemaCompiler,
+) => JsonSchemaCompiler;
 
 // deno-lint-ignore no-explicit-any -- zod's chainable APIs return parametric types
 type AnyZodSchema = z.ZodType<any, any, any>;
@@ -43,8 +57,13 @@ function wrap<T>(zs: AnyZodSchema): Schema<T> {
     optional: () => wrap<T | undefined>(zs.optional()),
     nullable: () => wrap<T | null>(zs.nullable()),
     nullish: () => wrap<T | null | undefined>(zs.nullish()),
-    default: (value: Exclude<T, undefined> | (() => Exclude<T, undefined>)) =>
-      wrap<Exclude<T, undefined>>(anyZs.default(value)),
+    default: (value: Exclude<T, undefined> | (() => Exclude<T, undefined>)) => {
+      const defaulted = anyZs.default(value);
+      if (typeof value !== "function") {
+        recordStaticJsonSchemaDefault(defaulted, value);
+      }
+      return wrap<Exclude<T, undefined>>(defaulted);
+    },
     describe: (description: string) => wrap<T>(zs.describe(description)),
     refine: (
       check: (value: T) => boolean,
@@ -121,9 +140,24 @@ function toZodShape(
 ): Record<string, AnyZodSchema> {
   const out: Record<string, AnyZodSchema> = {};
   for (const [key, value] of Object.entries(shape)) {
-    out[key] = toZod(value);
+    defineOwnDataProperty(out, key, toZod(value));
   }
   return out;
+}
+
+function defineOwnDataProperty(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  // A data descriptor preserves keys such as `__proto__` as ordinary data
+  // without invoking inherited setters in runtimes that expose them.
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
 }
 
 const coerce: SchemaValidatorCoerce = {
@@ -133,15 +167,428 @@ const coerce: SchemaValidatorCoerce = {
   date: (): Schema<Date> => wrap(z.coerce.date()),
 };
 
+const JSON_SCHEMA_VALIDATOR_CACHE_SIZE = 128;
+
+// Raw schemas can originate in extensions and tool metadata, so snapshot them
+// through a deliberately bounded JSON boundary before handing them to Ajv.
+// These ceilings are comfortably above practical tool schemas while keeping a
+// single compilation from consuming unbounded stack, CPU, or memory.
+const JSON_SCHEMA_MAX_DEPTH = 128;
+const JSON_SCHEMA_MAX_NODES = 100_000;
+const JSON_SCHEMA_MAX_SERIALIZED_BYTES = 4 * 1024 * 1024;
+const JSON_SCHEMA_MAX_STRING_BYTES = 1024 * 1024;
+const JSON_SCHEMA_MAX_KEY_BYTES = 16 * 1024;
+const JSON_UTF8_ENCODER = new TextEncoder();
+
+type JsonSchemaCompiler = {
+  compile(schema: AnySchema): ValidateFunction<unknown>;
+};
+
+const JSON_SCHEMA_COMPILER_OPTIONS = {
+  strict: true,
+  allErrors: true,
+  addUsedSchema: false,
+  allowUnionTypes: true,
+  coerceTypes: false,
+  ownProperties: true,
+  useDefaults: false,
+  removeAdditional: false,
+} as const;
+
+const DRAFT_7_META_SCHEMA_URI = "https://json-schema.org/draft-07/schema";
+const AJV_DRAFT_7_META_SCHEMA_URI = "http://json-schema.org/draft-07/schema#";
+
+function normalizeMetaSchemaUri(uri: string): string {
+  return uri.trim().replace(/#$/, "").replace(/^http:/, "https:");
+}
+
+function createJsonSchemaCompiler(schema: JsonSchema): JsonSchemaCompiler {
+  const declaredDraft = typeof schema.$schema === "string"
+    ? normalizeMetaSchemaUri(schema.$schema)
+    : "https://json-schema.org/draft/2020-12/schema";
+  const compiler = declaredDraft === DRAFT_7_META_SCHEMA_URI
+    ? new AjvDraft7(JSON_SCHEMA_COMPILER_OPTIONS)
+    : declaredDraft === "https://json-schema.org/draft/2019-09/schema"
+    ? new Ajv2019(JSON_SCHEMA_COMPILER_OPTIONS)
+    : declaredDraft === "https://json-schema.org/draft/2020-12/schema"
+    ? new Ajv2020(JSON_SCHEMA_COMPILER_OPTIONS)
+    : undefined;
+
+  if (!compiler) {
+    throw new Error(`Unsupported JSON Schema draft: ${schema.$schema}`);
+  }
+  addFormats(compiler);
+  return compiler;
+}
+
+function schemaForCompilation(schema: JsonSchema): AnySchema {
+  if (
+    typeof schema.$schema !== "string" ||
+    normalizeMetaSchemaUri(schema.$schema) !== DRAFT_7_META_SCHEMA_URI
+  ) {
+    return schema as AnySchema;
+  }
+
+  // Ajv's Draft 7 compiler registers the canonical HTTP identifier. Compile
+  // an isolated root snapshot using that identifier while leaving the
+  // caller-owned and cache-key snapshots unchanged.
+  return {
+    ...schema,
+    $schema: AJV_DRAFT_7_META_SCHEMA_URI,
+  } as AnySchema;
+}
+
+type CanonicalJsonContainer = unknown[] | Record<string, unknown>;
+
+type CanonicalizationFrame =
+  | {
+    kind: "visit";
+    value: unknown;
+    depth: number;
+    parent?: CanonicalJsonContainer;
+    key?: string | number;
+  }
+  | { kind: "exit"; value: object };
+
+type CanonicalizationVisitFrame = Extract<CanonicalizationFrame, { kind: "visit" }>;
+
+function boundedUtf8Length(value: string, limit: number, label: "key" | "string"): number {
+  // Every UTF-16 code unit contributes at least one UTF-8 byte. This cheap
+  // guard avoids allocating an encoded copy once the value is already known
+  // to exceed the byte ceiling.
+  if (value.length > limit) {
+    throw new TypeError(`JSON Schema ${label} exceeds the ${limit}-byte limit`);
+  }
+  const byteLength = JSON_UTF8_ENCODER.encode(value).byteLength;
+  if (byteLength > limit) {
+    throw new TypeError(`JSON Schema ${label} exceeds the ${limit}-byte limit`);
+  }
+  return byteLength;
+}
+
+function serializedJsonTokenByteLength(value: string | number | boolean | null): number {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new TypeError("JSON Schema must contain only JSON values");
+  }
+  return JSON_UTF8_ENCODER.encode(serialized).byteLength;
+}
+
+class JsonSchemaCanonicalizer {
+  private readonly activeAncestors = new Set<object>();
+  private readonly stack: CanonicalizationFrame[] = [];
+  private canonicalRoot: unknown;
+  private rootAssigned = false;
+  private nodeCount = 0;
+  private serializedBytes = 0;
+
+  canonicalize(value: unknown): unknown {
+    this.stack.push({ kind: "visit", value, depth: 0 });
+    while (this.stack.length > 0) {
+      const frame = this.stack.pop();
+      if (!frame) break;
+      if (frame.kind === "exit") {
+        this.activeAncestors.delete(frame.value);
+      } else {
+        this.visit(frame);
+      }
+    }
+
+    if (!this.rootAssigned) {
+      throw new TypeError("JSON Schema must contain a JSON value");
+    }
+    return this.canonicalRoot;
+  }
+
+  private visit(frame: CanonicalizationVisitFrame): void {
+    this.consumeNode(frame.depth);
+    if (this.visitScalar(frame)) return;
+
+    const current = frame.value;
+    if (typeof current !== "object" || current === null) {
+      throw new TypeError("JSON Schema must contain only JSON values");
+    }
+    if (this.activeAncestors.has(current)) {
+      throw new TypeError("JSON Schema must not contain cycles");
+    }
+    if (Array.isArray(current)) {
+      this.visitArray(frame, current);
+    } else {
+      this.visitObject(frame, current);
+    }
+  }
+
+  private visitScalar(frame: CanonicalizationVisitFrame): boolean {
+    const current = frame.value;
+    if (current === null || typeof current === "boolean") {
+      this.assign(frame, current);
+      this.addSerializedBytes(serializedJsonTokenByteLength(current));
+      return true;
+    }
+    if (typeof current === "string") {
+      boundedUtf8Length(current, JSON_SCHEMA_MAX_STRING_BYTES, "string");
+      this.assign(frame, current);
+      this.addSerializedBytes(serializedJsonTokenByteLength(current));
+      return true;
+    }
+    if (typeof current === "number") {
+      if (!Number.isFinite(current)) {
+        throw new TypeError("JSON Schema numbers must be finite");
+      }
+      this.assign(frame, current);
+      this.addSerializedBytes(serializedJsonTokenByteLength(current));
+      return true;
+    }
+    if (typeof current !== "object") {
+      throw new TypeError("JSON Schema must contain only JSON values");
+    }
+    return false;
+  }
+
+  private visitArray(frame: CanonicalizationVisitFrame, current: unknown[]): void {
+    const lengthDescriptor = Reflect.getOwnPropertyDescriptor(current, "length");
+    const length = lengthDescriptor && "value" in lengthDescriptor
+      ? lengthDescriptor.value
+      : undefined;
+    if (
+      typeof length !== "number" ||
+      !Number.isSafeInteger(length) ||
+      length < 0
+    ) {
+      throw new TypeError("JSON Schema arrays must have a non-negative integer data length");
+    }
+    if (length > JSON_SCHEMA_MAX_NODES) {
+      throw new TypeError(`JSON Schema exceeds the maximum node count of ${JSON_SCHEMA_MAX_NODES}`);
+    }
+    const ownKeys = Reflect.ownKeys(current);
+    if (
+      ownKeys.some((key) => typeof key === "symbol") ||
+      ownKeys.length !== length + 1 ||
+      !ownKeys.includes("length")
+    ) {
+      throw new TypeError("JSON Schema arrays must be dense JSON arrays without extra properties");
+    }
+    this.addSerializedBytes(2 + Math.max(0, length - 1));
+
+    const descriptors: PropertyDescriptor[] = [];
+    for (let index = 0; index < length; index++) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(current, String(index));
+      if (!descriptor || !("value" in descriptor) || descriptor.enumerable !== true) {
+        throw new TypeError(
+          "JSON Schema arrays must be dense data-only JSON arrays without accessors",
+        );
+      }
+      descriptors.push(descriptor);
+    }
+
+    const canonical: unknown[] = new Array(length);
+    this.assign(frame, canonical);
+    this.activeAncestors.add(current);
+    this.stack.push({ kind: "exit", value: current });
+    for (let index = descriptors.length - 1; index >= 0; index--) {
+      const descriptor = descriptors[index];
+      if (!descriptor) {
+        throw new TypeError("JSON Schema array snapshot is internally inconsistent");
+      }
+      this.stack.push({
+        kind: "visit",
+        value: descriptor.value,
+        depth: frame.depth + 1,
+        parent: canonical,
+        key: index,
+      });
+    }
+  }
+
+  private visitObject(frame: CanonicalizationVisitFrame, current: object): void {
+    const prototype = Object.getPrototypeOf(current);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("JSON Schema objects must be plain JSON objects");
+    }
+    const ownKeys = Reflect.ownKeys(current);
+    if (ownKeys.length > JSON_SCHEMA_MAX_NODES) {
+      throw new TypeError(`JSON Schema exceeds the maximum node count of ${JSON_SCHEMA_MAX_NODES}`);
+    }
+    if (ownKeys.some((key) => typeof key === "symbol")) {
+      throw new TypeError("JSON Schema objects must not contain symbol keys");
+    }
+    this.addSerializedBytes(2 + Math.max(0, ownKeys.length - 1));
+
+    const entries = (ownKeys as string[]).map((key) => {
+      boundedUtf8Length(key, JSON_SCHEMA_MAX_KEY_BYTES, "key");
+      this.addSerializedBytes(serializedJsonTokenByteLength(key) + 1);
+      const descriptor = Object.getOwnPropertyDescriptor(current, key);
+      if (!descriptor || !("value" in descriptor)) {
+        throw new TypeError("JSON Schema objects must be data-only and must not contain accessors");
+      }
+      if (descriptor.enumerable !== true) {
+        throw new TypeError("JSON Schema objects must not contain non-enumerable properties");
+      }
+      return { key, value: descriptor.value };
+    }).sort((left, right) => left.key < right.key ? -1 : left.key > right.key ? 1 : 0);
+
+    const canonical: Record<string, unknown> = {};
+    this.assign(frame, canonical);
+    this.activeAncestors.add(current);
+    this.stack.push({ kind: "exit", value: current });
+    for (let index = entries.length - 1; index >= 0; index--) {
+      const entry = entries[index];
+      if (!entry) {
+        throw new TypeError("JSON Schema object snapshot is internally inconsistent");
+      }
+      this.stack.push({
+        kind: "visit",
+        value: entry.value,
+        depth: frame.depth + 1,
+        parent: canonical,
+        key: entry.key,
+      });
+    }
+  }
+
+  private consumeNode(depth: number): void {
+    if (depth > JSON_SCHEMA_MAX_DEPTH) {
+      throw new TypeError(`JSON Schema exceeds the maximum depth of ${JSON_SCHEMA_MAX_DEPTH}`);
+    }
+    this.nodeCount++;
+    if (this.nodeCount > JSON_SCHEMA_MAX_NODES) {
+      throw new TypeError(`JSON Schema exceeds the maximum node count of ${JSON_SCHEMA_MAX_NODES}`);
+    }
+  }
+
+  private addSerializedBytes(amount: number): void {
+    this.serializedBytes += amount;
+    if (this.serializedBytes > JSON_SCHEMA_MAX_SERIALIZED_BYTES) {
+      throw new TypeError(
+        `JSON Schema exceeds the ${JSON_SCHEMA_MAX_SERIALIZED_BYTES}-byte serialized limit`,
+      );
+    }
+  }
+
+  private assign(frame: CanonicalizationVisitFrame, canonical: unknown): void {
+    if (frame.parent === undefined) {
+      this.canonicalRoot = canonical;
+      this.rootAssigned = true;
+      return;
+    }
+    if (Array.isArray(frame.parent)) {
+      frame.parent[frame.key as number] = canonical;
+      return;
+    }
+    defineOwnDataProperty(frame.parent, frame.key as string, canonical);
+  }
+}
+
+function canonicalizeJsonValue(value: unknown): unknown {
+  return new JsonSchemaCanonicalizer().canonicalize(value);
+}
+
+function snapshotJsonSchema(schema: JsonSchema): { key: string; schema: JsonSchema } {
+  const canonical = canonicalizeJsonValue(schema);
+  const key = JSON.stringify(canonical);
+  if (key === undefined) throw new TypeError("JSON Schema must be JSON serializable");
+  return { key, schema: canonical as JsonSchema };
+}
+
+function copyValidationIssue(error: ErrorObject): JsonSchemaValidationIssue {
+  let params: Record<string, unknown>;
+  try {
+    params = structuredClone(error.params) as Record<string, unknown>;
+  } catch {
+    params = { ...error.params };
+  }
+
+  return {
+    instancePath: error.instancePath,
+    schemaPath: error.schemaPath,
+    keyword: error.keyword,
+    params,
+    ...(error.message === undefined ? {} : { message: error.message }),
+  };
+}
+
+function validationFailure(
+  errors: ErrorObject[] | null | undefined,
+): JsonSchemaValidationFailure {
+  return {
+    success: false,
+    errors: (errors ?? []).map(copyValidationIssue),
+  };
+}
+
+function validationSuccess<T>(input: unknown): JsonSchemaValidationSuccess<T> {
+  return { success: true, value: input as T };
+}
+
+function errorObjectsFromUnknown(error: unknown): ErrorObject[] | undefined {
+  if (!error || typeof error !== "object" || !("errors" in error)) {
+    return undefined;
+  }
+  return Array.isArray(error.errors) ? error.errors as ErrorObject[] : undefined;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return !!value &&
+    (typeof value === "object" || typeof value === "function") &&
+    "then" in value &&
+    typeof value.then === "function";
+}
+
+function compileJsonSchemaValidator<T>(schema: JsonSchema): JsonSchemaValidationFunction<T> {
+  const validate = createJsonSchemaCompiler(schema).compile(schemaForCompilation(schema));
+
+  return (input) => {
+    const outcome = validate(input);
+    if (isPromiseLike(outcome)) {
+      return Promise.resolve(outcome).then(
+        () => validationSuccess<T>(input),
+        (error: unknown) => {
+          const errors = errorObjectsFromUnknown(error);
+          if (errors) return validationFailure(errors);
+          throw error;
+        },
+      );
+    }
+
+    return outcome ? validationSuccess<T>(input) : validationFailure(validate.errors);
+  };
+}
+
+function createJsonSchemaCompilationCache(): SchemaValidator["compileJsonSchema"] {
+  const cache = new Map<string, JsonSchemaValidationFunction>();
+
+  return <T>(schema: JsonSchema): JsonSchemaValidationFunction<T> => {
+    const snapshot = snapshotJsonSchema(schema);
+    const cached = cache.get(snapshot.key);
+    if (cached) {
+      cache.delete(snapshot.key);
+      cache.set(snapshot.key, cached);
+      return cached as JsonSchemaValidationFunction<T>;
+    }
+
+    const compiled = compileJsonSchemaValidator<T>(snapshot.schema);
+    while (cache.size >= JSON_SCHEMA_VALIDATOR_CACHE_SIZE) {
+      const oldestKey = cache.keys().next().value;
+      if (oldestKey === undefined) break;
+      cache.delete(oldestKey);
+    }
+    cache.set(snapshot.key, compiled);
+    return compiled;
+  };
+}
+
 /**
  * Build a zod-backed `SchemaValidator` instance.
  *
- * Stateless — safe to call once at extension setup and pass the returned
- * value to `ctx.provide("SchemaValidator", …)`. Tests that need to register
- * the validator without going through full extension bootstrap can call this
- * factory directly.
+ * Adapter instances snapshot schemas into plain JSON and retain at most 128
+ * compiled validators in an LRU cache. Each unique validator owns an isolated
+ * Ajv compiler, so unrelated `$id` values cannot collide or accumulate in a
+ * process-wide registry. It is therefore safe to call this once at extension setup and pass the returned value to
+ * `ctx.provide("SchemaValidator", …)`. Tests that need to register the
+ * validator without full extension bootstrap can call this factory directly.
  */
 export function createZodAdapter(): SchemaValidator {
+  const compileJsonSchema = createJsonSchemaCompilationCache();
   return {
     string: (): Schema<string> => wrap(z.string()),
     number: (): Schema<number> => wrap(z.number()),
@@ -230,6 +677,8 @@ export function createZodAdapter(): SchemaValidator {
     coerce,
 
     validate: <T>(schema: Schema<T>, data: unknown): ValidationResult<T> => schema.safeParse(data),
+
+    compileJsonSchema,
 
     toJsonSchema: (schema: Schema<unknown>): JsonSchema => zodToJsonSchema(toZod(schema)),
 

--- a/extensions/ext-schema-zod/src/json-schema-validation.test.ts
+++ b/extensions/ext-schema-zod/src/json-schema-validation.test.ts
@@ -1,0 +1,507 @@
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import type {
+  JsonSchemaValidationFunction,
+  JsonSchemaValidationResult,
+} from "veryfront/extensions/schema";
+import { createZodAdapter } from "./adapter.ts";
+
+async function validate(
+  validator: JsonSchemaValidationFunction,
+  input: unknown,
+): Promise<JsonSchemaValidationResult> {
+  return await validator(input);
+}
+
+describe("SchemaValidator.compileJsonSchema", () => {
+  it("validates Draft 2020-12 schemas without mutating accepted input", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        count: { type: "integer" },
+        label: { type: "string", default: "generated" },
+      },
+      required: ["count"],
+      additionalProperties: false,
+    });
+    const input = { count: 2 };
+
+    const result = await validate(validator, input);
+
+    assertEquals(result, { success: true, value: input });
+    assertEquals(input, { count: 2 });
+  });
+
+  it("selects the compiler declared by Draft 7 and Draft 2019-09 schemas", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const draft7 = compile({
+      $schema: "http://json-schema.org/draft-07/schema#",
+      type: "object",
+      properties: { value: { type: "integer" } },
+      required: ["value"],
+    });
+    const draft7Https = compile({
+      $schema: "https://json-schema.org/draft-07/schema#",
+      type: "object",
+      properties: { value: { type: "integer" } },
+      required: ["value"],
+    });
+    const draft2019 = compile({
+      $schema: "https://json-schema.org/draft/2019-09/schema",
+      type: "array",
+      items: { type: "string" },
+    });
+
+    assertEquals((await validate(draft7, { value: 1 })).success, true);
+    assertEquals((await validate(draft7, { value: "1" })).success, false);
+    assertEquals((await validate(draft7Https, { value: 1 })).success, true);
+    assertEquals((await validate(draft7Https, { value: "1" })).success, false);
+    assertEquals((await validate(draft2019, ["one", "two"])).success, true);
+    assertEquals((await validate(draft2019, ["one", 2])).success, false);
+  });
+
+  it("supports JSON Schema union type arrays in strict mode", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      type: ["string", "null"],
+    } as never);
+
+    assertEquals((await validate(validator, "value")).success, true);
+    assertEquals((await validate(validator, null)).success, true);
+    assertEquals((await validate(validator, 1)).success, false);
+  });
+
+  it("reuses compiled schemas through a bounded adapter-local cache", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const first = compile({ type: "string", minLength: 1 });
+    const equivalent = compile({ minLength: 1, type: "string" });
+
+    assertEquals(equivalent === first, true);
+
+    for (let index = 0; index < 128; index++) {
+      compile({ type: "integer", minimum: index });
+    }
+
+    const recompiled = compile({ type: "string", minLength: 1 });
+    assertEquals(recompiled === first, false);
+  });
+
+  it("snapshots cached schemas so later caller mutation cannot change validation", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const schema = { type: "string" as const, minLength: 2 };
+    const validator = compile(schema);
+
+    (schema as { type: string }).type = "number";
+    schema.minLength = 100;
+
+    assertEquals((await validate(validator, "ok")).success, true);
+    assertEquals((await validate(validator, 42)).success, false);
+  });
+
+  it("snapshots proxied array lengths from their data descriptor", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    let lengthReads = 0;
+    const value = new Proxy([] as unknown[], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          lengthReads++;
+          return lengthReads === 5 ? 5 : 0;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const validator = compile({ enum: [value] });
+
+    assertEquals(lengthReads, 0);
+    assertEquals((await validate(validator, [])).success, true);
+    assertEquals((await validate(validator, [null, null, null, null, null])).success, false);
+  });
+
+  it("rejects non-JSON schema values before they can collide in the cache", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+
+    assertThrows(
+      () => compile({ type: "number", minimum: Number.NaN }),
+      TypeError,
+      "finite",
+    );
+    assertThrows(
+      () => compile({ type: "string", custom: new Date() } as never),
+      TypeError,
+      "plain JSON objects",
+    );
+  });
+
+  it("rejects sparse and extended arrays regardless of cache insertion order", () => {
+    const denseSchema = { enum: [[null]] } as never;
+    const sparseValue: unknown[] = [];
+    sparseValue.length = 1;
+    const sparseSchema = { enum: [sparseValue] } as never;
+    const extendedValue = [null] as unknown[] & { label?: string };
+    extendedValue.label = "not-json-array-data";
+    const extendedSchema = { enum: [extendedValue] } as never;
+
+    const denseFirstCompile = createZodAdapter().compileJsonSchema;
+    assert(denseFirstCompile);
+    denseFirstCompile(denseSchema);
+    assertThrows(() => denseFirstCompile(sparseSchema), TypeError, "dense JSON arrays");
+    assertThrows(() => denseFirstCompile(extendedSchema), TypeError, "dense JSON arrays");
+
+    const invalidFirstCompile = createZodAdapter().compileJsonSchema;
+    assert(invalidFirstCompile);
+    assertThrows(() => invalidFirstCompile(sparseSchema), TypeError, "dense JSON arrays");
+    assertThrows(() => invalidFirstCompile(extendedSchema), TypeError, "dense JSON arrays");
+    invalidFirstCompile(denseSchema);
+  });
+
+  it("rejects schema accessors without invoking them or poisoning the cache", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const cached = compile({ type: "string" });
+    let objectGetterCalls = 0;
+    let arrayGetterCalls = 0;
+    const objectAccessor = { type: "string" } as Record<string, unknown>;
+    Object.defineProperty(objectAccessor, "minLength", {
+      enumerable: true,
+      get() {
+        objectGetterCalls++;
+        return 2;
+      },
+    });
+    const arrayAccessor: unknown[] = [];
+    Object.defineProperty(arrayAccessor, "0", {
+      enumerable: true,
+      get() {
+        arrayGetterCalls++;
+        return "value";
+      },
+    });
+    arrayAccessor.length = 1;
+
+    assertThrows(
+      () => compile(objectAccessor as never),
+      TypeError,
+      "accessors",
+    );
+    assertThrows(
+      () => compile({ enum: [arrayAccessor] } as never),
+      TypeError,
+      "accessors",
+    );
+    assertEquals(objectGetterCalls, 0);
+    assertEquals(arrayGetterCalls, 0);
+    assertEquals(compile({ type: "string" }) === cached, true);
+  });
+
+  it("rejects hidden and symbol schema keys instead of aliasing cached schemas", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const cached = compile({ type: "string" });
+    const hidden = { type: "string" } as Record<string, unknown>;
+    Object.defineProperty(hidden, "minLength", {
+      enumerable: false,
+      value: 2,
+    });
+    const symbol = { type: "string" } as Record<PropertyKey, unknown>;
+    symbol[Symbol("constraint")] = { minLength: 2 };
+
+    assertThrows(
+      () => compile(hidden as never),
+      TypeError,
+      "non-enumerable",
+    );
+    assertThrows(
+      () => compile(symbol as never),
+      TypeError,
+      "symbol keys",
+    );
+    assertEquals(compile({ type: "string" }) === cached, true);
+  });
+
+  it("detects cycles while allowing repeated acyclic schema references", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const cyclic: Record<string, unknown> = { type: "object" };
+    cyclic.properties = { self: cyclic };
+
+    assertThrows(() => compile(cyclic as never), TypeError, "cycles");
+
+    const shared = { type: "string" as const, minLength: 1 };
+    const validator = compile({
+      type: "object",
+      properties: { left: shared, right: shared },
+      required: ["left", "right"],
+      additionalProperties: false,
+    });
+    assertEquals((await validate(validator, { left: "a", right: "b" })).success, true);
+  });
+
+  it("enforces explicit depth, node, string, key, and serialized-size bounds", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    let deeplyNested: unknown = { type: "string" };
+    for (let depth = 0; depth < 130; depth++) {
+      deeplyNested = { allOf: [deeplyNested] };
+    }
+    const tooManyNodes = new Array(100_001).fill(null);
+    const tooLongString = "x".repeat(1024 * 1024 + 1);
+    const tooLongKey = "k".repeat(16 * 1024 + 1);
+    const maximumString = "x".repeat(1024 * 1024);
+
+    assertThrows(
+      () => compile(deeplyNested as never),
+      TypeError,
+      "maximum depth",
+    );
+    assertThrows(
+      () => compile({ enum: [tooManyNodes] } as never),
+      TypeError,
+      "maximum node count",
+    );
+    assertThrows(
+      () => compile({ description: tooLongString } as never),
+      TypeError,
+      "string exceeds",
+    );
+    assertThrows(
+      () => compile({ [tooLongKey]: true } as never),
+      TypeError,
+      "key exceeds",
+    );
+    assertThrows(
+      () => compile({ enum: [maximumString, maximumString, maximumString, maximumString] }),
+      TypeError,
+      "serialized limit",
+    );
+  });
+
+  it("accepts null-prototype schemas and safely canonicalizes __proto__ data keys", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const properties = Object.create(null) as Record<string, unknown>;
+    properties.value = { type: "string" };
+    const schema = Object.assign(Object.create(null) as Record<string, unknown>, {
+      type: "object",
+      properties,
+      required: ["value"],
+      additionalProperties: false,
+    });
+    const input = Object.create(null) as Record<string, unknown>;
+    input.value = "safe";
+    const validator = compile(schema as never);
+
+    assertEquals((await validate(validator, input)).success, true);
+    assertEquals((await validate(validator, {})).success, false);
+
+    const constant = JSON.parse('{"__proto__":"safe"}') as Record<string, unknown>;
+    const constantValidator = compile({ const: constant } as never);
+    assertEquals(
+      (await validate(constantValidator, JSON.parse('{"__proto__":"safe"}'))).success,
+      true,
+    );
+    assertEquals(
+      (await validate(constantValidator, JSON.parse('{"__proto__":"wrong"}'))).success,
+      false,
+    );
+  });
+
+  it("does not coerce input or remove additional properties", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      type: "object",
+      properties: { count: { type: "integer" } },
+      required: ["count"],
+      additionalProperties: false,
+    });
+    const input = { count: "2", extra: true };
+
+    const result = await validate(validator, input);
+
+    assertEquals(result.success, false);
+    if (result.success) return;
+    assertEquals(result.errors.map((error) => error.keyword).sort(), [
+      "additionalProperties",
+      "type",
+    ]);
+    assertEquals(input, { count: "2", extra: true });
+  });
+
+  it("copies validation errors before a later validation can replace them", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+      additionalProperties: false,
+    });
+
+    const first = await validate(validator, {});
+    assertEquals(first.success, false);
+    if (first.success) return;
+    const snapshot = structuredClone(first.errors);
+
+    await validate(validator, { query: 42 });
+
+    assertEquals(first.errors, snapshot);
+  });
+
+  it("normalizes asynchronous Ajv validation failures", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      $async: true,
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+      additionalProperties: false,
+    });
+
+    const result = await validate(validator, { query: 42 });
+
+    assertEquals(result.success, false);
+    if (result.success) return;
+    assertEquals(result.errors.map((error) => error.keyword), ["type"]);
+  });
+
+  it("fails schema compilation for unsupported formats in strict mode", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+
+    assertThrows(
+      () => compile({ type: "string", format: "future-unknown-format" }),
+      Error,
+      "unknown format",
+    );
+  });
+
+  it("validates the standard email, uri, uuid, and date-time formats", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      type: "object",
+      properties: {
+        email: { type: "string", format: "email" },
+        uri: { type: "string", format: "uri" },
+        uuid: { type: "string", format: "uuid" },
+        timestamp: { type: "string", format: "date-time" },
+      },
+      required: ["email", "uri", "uuid", "timestamp"],
+      additionalProperties: false,
+    });
+
+    const valid = await validate(validator, {
+      email: "hello@veryfront.com",
+      uri: "https://veryfront.com/docs?section=schemas",
+      uuid: "123e4567-e89b-42d3-a456-426614174000",
+      timestamp: "2026-07-23T12:34:56Z",
+    });
+    assertEquals(valid.success, true);
+
+    const invalid = await validate(validator, {
+      email: "not-an-email",
+      uri: "not a uri",
+      uuid: "not-a-uuid",
+      timestamp: "not-a-date-time",
+    });
+    assertEquals(invalid.success, false);
+    if (invalid.success) return;
+    assertEquals(
+      invalid.errors.map(
+        (error): [string, string] => [error.instancePath, error.keyword],
+      ).sort(([left], [right]) => left.localeCompare(right)),
+      [
+        ["/email", "format"],
+        ["/timestamp", "format"],
+        ["/uri", "format"],
+        ["/uuid", "format"],
+      ],
+    );
+  });
+
+  it("compiles independent schemas that reuse the same $id", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const first = compile({
+      $id: "urn:veryfront:test:duplicate-id",
+      type: "string",
+      minLength: 3,
+    });
+    const second = compile({
+      $id: "urn:veryfront:test:duplicate-id",
+      type: "integer",
+      minimum: 1,
+    });
+
+    assertEquals((await validate(first, "abc")).success, true);
+    assertEquals((await validate(first, 2)).success, false);
+    assertEquals((await validate(second, 2)).success, true);
+    assertEquals((await validate(second, "abc")).success, false);
+  });
+
+  it("does not retain caller schemas in a shared compiler registry", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+
+    for (let index = 0; index < 128; index++) {
+      compile({
+        $id: `urn:veryfront:test:bounded-registry:${index}`,
+        type: "object",
+      });
+    }
+
+    assertThrows(
+      () => compile({ $ref: "urn:veryfront:test:bounded-registry:0" }),
+      Error,
+      "can't resolve reference",
+    );
+  });
+
+  it("does not satisfy required properties from an inherited prototype", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      type: "object",
+      properties: { ownValue: { type: "string" } },
+      required: ["ownValue"],
+      additionalProperties: false,
+    });
+    const input = Object.create({ ownValue: "inherited" }) as Record<string, unknown>;
+
+    const result = await validate(validator, input);
+
+    assertEquals(result.success, false);
+    if (result.success) return;
+    assertEquals(result.errors.map((error) => error.keyword), ["required"]);
+  });
+
+  it("ignores inherited keys when enforcing additionalProperties", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      type: "object",
+      properties: { ownValue: { type: "string" } },
+      required: ["ownValue"],
+      additionalProperties: false,
+    });
+    const input = Object.assign(
+      Object.create({ inheritedExtra: true }) as Record<string, unknown>,
+      { ownValue: "present" },
+    );
+
+    const result = await validate(validator, input);
+
+    assertEquals(result.success, true);
+  });
+});

--- a/extensions/ext-schema-zod/src/json-schema.test.ts
+++ b/extensions/ext-schema-zod/src/json-schema.test.ts
@@ -1,0 +1,238 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { z } from "zod";
+import { createZodAdapter } from "./adapter.ts";
+import { zodToJsonSchema } from "./json-schema.ts";
+
+describe("zodToJsonSchema", () => {
+  it("converts null and unconstrained values accurately", () => {
+    assertEquals(zodToJsonSchema(z.null()), { type: "null" });
+    assertEquals(zodToJsonSchema(z.literal(null)), { const: null, type: "null" });
+    assertEquals(zodToJsonSchema(z.unknown()), {});
+    assertEquals(zodToJsonSchema(z.any()), {});
+  });
+
+  it("converts the output of a custom validation guard", () => {
+    const guarded = z.custom<unknown>(() => true).pipe(z.string());
+
+    assertEquals(zodToJsonSchema(guarded), { type: "string" });
+  });
+
+  it("converts the output of a transformed custom validation pipeline", () => {
+    const guarded = z
+      .custom<unknown>(() => true)
+      .transform((value) => ({ success: true, value }))
+      .refine((result) => result.success)
+      .transform((result) => result.value)
+      .pipe(z.string());
+
+    assertEquals(zodToJsonSchema(guarded), { type: "string" });
+  });
+
+  it("preserves string length, pattern, and format constraints", () => {
+    assertEquals(
+      zodToJsonSchema(z.string().min(2).max(10).regex(/^[a-z]+$/)),
+      {
+        type: "string",
+        minLength: 2,
+        maxLength: 10,
+        pattern: "^[a-z]+$",
+      },
+    );
+    assertEquals(zodToJsonSchema(z.string().email()), {
+      type: "string",
+      format: "email",
+    });
+    assertEquals(zodToJsonSchema(z.string().url()), {
+      type: "string",
+      format: "uri",
+    });
+    assertEquals(zodToJsonSchema(z.string().uuid()), {
+      type: "string",
+      format: "uuid",
+    });
+    assertEquals(zodToJsonSchema(z.string().datetime()), {
+      type: "string",
+      format: "date-time",
+    });
+  });
+
+  it("preserves multiple regular-expression constraints without dropping any", () => {
+    assertEquals(zodToJsonSchema(z.string().regex(/[A-Z]/).regex(/[0-9]/)), {
+      type: "string",
+      allOf: [{ pattern: "[A-Z]" }, { pattern: "[0-9]" }],
+    });
+  });
+
+  it("does not guess at regular-expression flags JSON Schema cannot encode", () => {
+    assertEquals(zodToJsonSchema(z.string().regex(/value/i)), { type: "string" });
+  });
+
+  it("preserves integer and numeric range constraints", () => {
+    assertEquals(zodToJsonSchema(z.number().int().min(1).max(10)), {
+      type: "integer",
+      minimum: 1,
+      maximum: 10,
+    });
+    assertEquals(zodToJsonSchema(z.number().positive().lt(10)), {
+      type: "number",
+      exclusiveMinimum: 0,
+      exclusiveMaximum: 10,
+    });
+    assertEquals(zodToJsonSchema(z.number().int()), {
+      type: "integer",
+      minimum: -Number.MAX_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+  });
+
+  it("preserves array size constraints", () => {
+    assertEquals(zodToJsonSchema(z.array(z.string()).min(1).max(3)), {
+      type: "array",
+      items: { type: "string" },
+      minItems: 1,
+      maxItems: 3,
+    });
+  });
+
+  it("preserves finite record keys and their required-key semantics", async () => {
+    const adapter = createZodAdapter();
+    const schema = adapter.record(
+      adapter.enum(["first", "second"]),
+      adapter.string(),
+    );
+    const jsonSchema = adapter.toJsonSchema(schema);
+    const validate = adapter.compileJsonSchema?.(jsonSchema);
+    if (!validate) throw new Error("Expected the built-in adapter to compile JSON Schema");
+
+    assertEquals(jsonSchema, {
+      type: "object",
+      properties: {
+        first: { type: "string" },
+        second: { type: "string" },
+      },
+      required: ["first", "second"],
+      additionalProperties: false,
+    });
+    assertEquals(schema.safeParse({ first: "a", second: "b" }).success, true);
+    assertEquals((await validate({ first: "a", second: "b" })).success, true);
+    assertEquals(schema.safeParse({ first: "a" }).success, false);
+    assertEquals((await validate({ first: "a" })).success, false);
+    assertEquals(schema.safeParse({ first: "a", second: "b", third: "c" }).success, false);
+    assertEquals((await validate({ first: "a", second: "b", third: "c" })).success, false);
+  });
+
+  it("preserves defaults on union schemas", () => {
+    const adapter = createZodAdapter();
+    const schema = adapter.union([adapter.string(), adapter.number()]).default("fallback");
+
+    assertEquals(adapter.toJsonSchema(schema), {
+      anyOf: [{ type: "string" }, { type: "number" }],
+      default: "fallback",
+    });
+  });
+
+  it("preserves __proto__ as an ordinary object-schema property", () => {
+    const adapter = createZodAdapter();
+    const schema = adapter.object({
+      ["__proto__"]: adapter.string(),
+    });
+    const input = JSON.parse('{"__proto__":"data"}');
+
+    const parsed = schema.parse(input);
+    const jsonSchema = adapter.toJsonSchema(schema);
+
+    assertEquals(Object.hasOwn(parsed, "__proto__"), true);
+    assertEquals((parsed as Record<string, unknown>)["__proto__"], "data");
+    assertEquals(jsonSchema, {
+      type: "object",
+      properties: {
+        ["__proto__"]: { type: "string" },
+      },
+      required: ["__proto__"],
+    });
+    assertEquals(Object.getPrototypeOf(jsonSchema.properties), Object.prototype);
+  });
+
+  it("unwraps nullable schemas returned by lazy schemas", () => {
+    const schema = z.lazy(() => z.string().nullable());
+
+    assertEquals(zodToJsonSchema(schema), {
+      anyOf: [{ type: "string" }, { type: "null" }],
+    });
+  });
+
+  it("fails clearly before deep conversion can exhaust the call stack", () => {
+    let schema: z.ZodTypeAny = z.string();
+    for (let depth = 0; depth < 130; depth++) {
+      schema = z.array(schema);
+    }
+
+    assertThrows(
+      () => zodToJsonSchema(schema),
+      RangeError,
+      "maximum conversion depth",
+    );
+  });
+
+  it("bounds schema wrapper traversal by conversion depth", () => {
+    let schema: z.ZodTypeAny = z.string();
+    for (let depth = 0; depth < 130; depth++) {
+      schema = schema.optional();
+    }
+
+    assertThrows(
+      () => zodToJsonSchema(schema),
+      RangeError,
+      "maximum conversion depth",
+    );
+  });
+
+  it("bounds finite record-key discovery by conversion depth", () => {
+    let keySchema: z.ZodTypeAny = z.literal("key");
+    for (let depth = 0; depth < 130; depth++) {
+      keySchema = z.union([keySchema, z.literal("key")]);
+    }
+
+    assertThrows(
+      () => zodToJsonSchema(z.record(keySchema as never, z.string())),
+      RangeError,
+      "maximum conversion depth",
+    );
+  });
+
+  it("preflights finite record-key unions against the conversion node budget", () => {
+    const key = z.literal("key");
+    const options = new Array(100_000).fill(key) as [
+      typeof key,
+      typeof key,
+      ...(typeof key)[],
+    ];
+
+    assertThrows(
+      () => zodToJsonSchema(z.record(z.union(options), z.string())),
+      RangeError,
+      "maximum conversion node count",
+    );
+  });
+
+  it("counts abandoned finite-key probes against the conversion node budget", () => {
+    const key = z.literal("key");
+    const options: [
+      typeof key,
+      typeof key,
+      ...(typeof key | z.ZodString)[],
+    ] = [
+      key,
+      key,
+      ...new Array<typeof key>(49_998).fill(key),
+      z.string(),
+    ];
+
+    assertThrows(
+      () => zodToJsonSchema(z.record(z.union(options), z.string())),
+      RangeError,
+      "maximum conversion node count",
+    );
+  });
+});

--- a/extensions/ext-schema-zod/src/json-schema.ts
+++ b/extensions/ext-schema-zod/src/json-schema.ts
@@ -1,9 +1,9 @@
 /**
  * Zod-to-JSON-Schema converter used by the `SchemaValidator` adapter.
  *
- * Operates directly on zod's internal `_def` shape (covers both v3 and v4)
- * because zod ships no first-class JSON-Schema export. Confined to
- * `extensions/ext-schema-zod/` so the rest of the codebase never has to import zod
+ * Operates directly on zod's internal `_def` shape to preserve the adapter's
+ * stable v3 and v4 compatibility behavior. It is confined to
+ * `extensions/ext-schema-zod/` so the rest of the codebase never imports zod
  * to learn what a tool's input schema looks like.
  *
  * @module extensions/ext-schema-zod/json-schema
@@ -12,7 +12,7 @@
 import type { z } from "zod";
 import type { JsonSchema } from "veryfront/extensions/schema";
 
-/** Zod internal _def shape — covers fields from both v3 and v4. */
+/** Zod internal _def shape covering fields from both v3 and v4. */
 interface ZodDef {
   typeName?: string; // v3
   type?: string; // v4
@@ -24,18 +24,58 @@ interface ZodDef {
   element?: z.ZodTypeAny; // v4 array/record
   items?: z.ZodTypeAny[]; // tuple
   options?: z.ZodTypeAny[] | Map<string, z.ZodTypeAny>; // union
+  keyType?: z.ZodTypeAny; // record
   valueType?: z.ZodTypeAny; // record
   catchall?: z.ZodTypeAny; // object unknown-key policy / catchall
   unknownKeys?: "strip" | "passthrough" | "strict"; // v3 object unknown-key policy
   innerType?: z.ZodTypeAny; // optional/nullable/default (v3)
   schema?: z.ZodTypeAny; // effects/optional/nullable (v3/v4)
   in?: z.ZodTypeAny; // pipe input (v4)
+  out?: z.ZodTypeAny; // pipe output (v4)
   getter?: () => z.ZodTypeAny; // lazy
-  defaultValue?: (() => unknown) | unknown;
+  checks?: unknown[];
+  minLength?: number | { value?: number } | null; // array limits (v3)
+  maxLength?: number | { value?: number } | null; // array limits (v3)
 }
 
 interface ConversionContext {
   seen: WeakSet<object>;
+  depth: number;
+  nodeCount: number;
+}
+
+const MAX_CONVERSION_DEPTH = 128;
+const MAX_CONVERSION_NODES = 100_000;
+
+function assertConversionDepth(depth: number): void {
+  if (depth > MAX_CONVERSION_DEPTH) {
+    throw new RangeError(
+      `Zod schema exceeds the maximum conversion depth of ${MAX_CONVERSION_DEPTH}`,
+    );
+  }
+}
+
+interface ZodCheckDefinition {
+  check?: string;
+  kind?: string;
+  format?: string;
+  pattern?: RegExp;
+  regex?: RegExp;
+  minimum?: number;
+  maximum?: number;
+  value?: number;
+  inclusive?: boolean;
+}
+
+interface NumericBoundary {
+  value: number;
+  exclusive: boolean;
+}
+
+const STATIC_DEFAULT_VALUE = Symbol("veryfront.staticJsonSchemaDefault");
+
+interface StaticDefaultValue {
+  value: unknown;
 }
 
 const LITERAL_TYPE_MAP: Record<string, "string" | "number" | "boolean"> = {
@@ -44,8 +84,122 @@ const LITERAL_TYPE_MAP: Record<string, "string" | "number" | "boolean"> = {
   boolean: "boolean",
 };
 
-function getLiteralType(value: unknown): "string" | "number" | "boolean" | undefined {
+function getLiteralType(
+  value: unknown,
+): "string" | "number" | "boolean" | "null" | undefined {
+  if (value === null) return "null";
   return LITERAL_TYPE_MAP[typeof value];
+}
+
+type RecordKeyFrame =
+  | { kind: "visit"; schema: z.ZodTypeAny; depth: number }
+  | { kind: "exit"; schema: z.ZodTypeAny };
+
+function finiteStringRecordKeys(
+  schema: z.ZodTypeAny,
+  context: ConversionContext,
+): string[] | undefined {
+  const activeSchemas = new WeakSet<object>();
+  const keys: string[] = [];
+  const stack: RecordKeyFrame[] = [{
+    kind: "visit",
+    schema,
+    depth: context.depth,
+  }];
+  let pendingVisitCount = 1;
+  let visitedNodes = 0;
+  const finish = (result: string[] | undefined): string[] | undefined => {
+    context.nodeCount += visitedNodes;
+    return result;
+  };
+  const assertCapacity = (additionalNodes: number): void => {
+    if (
+      context.nodeCount +
+          visitedNodes +
+          pendingVisitCount +
+          additionalNodes >
+        MAX_CONVERSION_NODES
+    ) {
+      throw new RangeError(
+        `Zod schema exceeds the maximum conversion node count of ${MAX_CONVERSION_NODES}`,
+      );
+    }
+  };
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (!frame) break;
+    if (frame.kind === "exit") {
+      activeSchemas.delete(frame.schema);
+      continue;
+    }
+
+    pendingVisitCount--;
+    assertConversionDepth(frame.depth);
+    visitedNodes++;
+    if (context.nodeCount + visitedNodes > MAX_CONVERSION_NODES) {
+      throw new RangeError(
+        `Zod schema exceeds the maximum conversion node count of ${MAX_CONVERSION_NODES}`,
+      );
+    }
+    if (activeSchemas.has(frame.schema)) return finish(undefined);
+
+    const tag = getTypeTag(frame.schema);
+    const def = getDef(frame.schema);
+    if (tag === "ZodLiteral" || tag === "literal") {
+      const literal = def.value ?? (Array.isArray(def.values) ? def.values[0] : def.values);
+      if (typeof literal !== "string") return finish(undefined);
+      keys.push(literal);
+      continue;
+    }
+
+    if (tag === "ZodEnum" || tag === "enum") {
+      const rawValues = Array.isArray(def.values)
+        ? def.values
+        : def.entries
+        ? Object.values(def.entries)
+        : [];
+      assertCapacity(rawValues.length);
+      for (const value of rawValues) {
+        visitedNodes++;
+        if (typeof value !== "string") return finish(undefined);
+        keys.push(value);
+      }
+      continue;
+    }
+
+    if (
+      tag !== "ZodUnion" &&
+      tag !== "ZodDiscriminatedUnion" &&
+      tag !== "union"
+    ) {
+      return finish(undefined);
+    }
+
+    const options = def.options ?? [];
+    const optionCount = options instanceof Map ? options.size : options.length;
+    assertCapacity(optionCount);
+    if (optionCount > 0 && frame.depth + 1 > MAX_CONVERSION_DEPTH) {
+      throw new RangeError(
+        `Zod schema exceeds the maximum conversion depth of ${MAX_CONVERSION_DEPTH}`,
+      );
+    }
+    const optionArray = options instanceof Map ? Array.from(options.values()) : options;
+    activeSchemas.add(frame.schema);
+    stack.push({ kind: "exit", schema: frame.schema });
+    pendingVisitCount += optionCount;
+    for (let index = optionArray.length - 1; index >= 0; index--) {
+      const option = optionArray[index];
+      if (!option) return finish(undefined);
+      stack.push({
+        kind: "visit",
+        schema: option,
+        depth: frame.depth + 1,
+      });
+    }
+  }
+
+  return finish(Array.from(new Set(keys)));
 }
 
 function getDef(schema: z.ZodTypeAny): ZodDef {
@@ -58,8 +212,226 @@ function getTypeTag(schema: z.ZodTypeAny): string | undefined {
   return def.typeName ?? def.type;
 }
 
+function originatesFromCustomSchema(schema: z.ZodTypeAny): boolean {
+  const seen = new WeakSet<object>();
+  let current = schema;
+  let depth = 0;
+
+  while (!seen.has(current)) {
+    assertConversionDepth(depth);
+    seen.add(current);
+    const tag = getTypeTag(current);
+    if (tag === "custom" || tag === "ZodCustom") return true;
+    if (tag !== "pipe" && tag !== "ZodEffects") return false;
+
+    const def = getDef(current);
+    const input = def.schema ?? def.in;
+    if (!input || input === current) return false;
+    current = input;
+    depth++;
+  }
+
+  return false;
+}
+
+function representedPipeSchema(def: ZodDef): z.ZodTypeAny | undefined {
+  const input = def.schema ?? def.in;
+  return input && originatesFromCustomSchema(input) && def.out ? def.out : input;
+}
+
+/** Record a literal default without evaluating Zod's possibly dynamic getter. */
+export function recordStaticJsonSchemaDefault(schema: z.ZodTypeAny, value: unknown): void {
+  Object.defineProperty(getDef(schema), STATIC_DEFAULT_VALUE, {
+    configurable: true,
+    enumerable: true,
+    value: { value } satisfies StaticDefaultValue,
+    writable: false,
+  });
+}
+
+function getStaticJsonSchemaDefault(def: ZodDef): StaticDefaultValue | undefined {
+  const marked = (def as Record<PropertyKey, unknown>)[STATIC_DEFAULT_VALUE];
+  if (!marked || typeof marked !== "object" || !("value" in marked)) return undefined;
+  return marked as StaticDefaultValue;
+}
+
+function getCheckDefinitions(def: ZodDef): ZodCheckDefinition[] {
+  return (def.checks ?? []).flatMap((check): ZodCheckDefinition[] => {
+    if (!check || typeof check !== "object") return [];
+    const internal = (check as { _zod?: { def?: unknown } })._zod?.def;
+    const definition = internal ?? check;
+    return definition && typeof definition === "object" ? [definition as ZodCheckDefinition] : [];
+  });
+}
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function addConjunctiveConstraints(
+  json: JsonSchema,
+  keyword: "format" | "pattern",
+  values: string[],
+): void {
+  const uniqueValues = Array.from(new Set(values));
+  if (uniqueValues.length === 0) return;
+  if (uniqueValues.length === 1) {
+    json[keyword] = uniqueValues[0];
+    return;
+  }
+  json.allOf = [
+    ...(json.allOf ?? []),
+    ...uniqueValues.map((value) => ({ [keyword]: value })),
+  ];
+}
+
+const STRING_FORMAT_MAP: Readonly<Record<string, string>> = {
+  email: "email",
+  url: "uri",
+  uuid: "uuid",
+  datetime: "date-time",
+};
+
+function convertString(def: ZodDef): JsonSchema {
+  const json: JsonSchema = { type: "string" };
+  const patterns: string[] = [];
+  const formats: string[] = [];
+
+  for (const check of getCheckDefinitions(def)) {
+    if (check.check === "min_length" && finiteNumber(check.minimum)) {
+      json.minLength = Math.max(json.minLength ?? 0, check.minimum);
+      continue;
+    }
+    if (check.check === "max_length" && finiteNumber(check.maximum)) {
+      json.maxLength = Math.min(json.maxLength ?? Number.POSITIVE_INFINITY, check.maximum);
+      continue;
+    }
+
+    const format = check.check === "string_format" ? check.format : check.kind;
+    if (format === "min" && finiteNumber(check.value)) {
+      json.minLength = Math.max(json.minLength ?? 0, check.value);
+    } else if (format === "max" && finiteNumber(check.value)) {
+      json.maxLength = Math.min(json.maxLength ?? Number.POSITIVE_INFINITY, check.value);
+    } else if (format === "regex") {
+      const regex = check.pattern ?? check.regex;
+      if (regex && regex.flags.length === 0) patterns.push(regex.source);
+    } else if (format && STRING_FORMAT_MAP[format]) {
+      formats.push(STRING_FORMAT_MAP[format]);
+    }
+  }
+
+  addConjunctiveConstraints(json, "pattern", patterns);
+  addConjunctiveConstraints(json, "format", formats);
+  return json;
+}
+
+function tighterLowerBoundary(
+  current: NumericBoundary | undefined,
+  candidate: NumericBoundary,
+): NumericBoundary {
+  if (!current || candidate.value > current.value) return candidate;
+  if (candidate.value < current.value) return current;
+  return { value: current.value, exclusive: current.exclusive || candidate.exclusive };
+}
+
+function tighterUpperBoundary(
+  current: NumericBoundary | undefined,
+  candidate: NumericBoundary,
+): NumericBoundary {
+  if (!current || candidate.value < current.value) return candidate;
+  if (candidate.value > current.value) return current;
+  return { value: current.value, exclusive: current.exclusive || candidate.exclusive };
+}
+
+function convertNumber(def: ZodDef): JsonSchema {
+  let integer = false;
+  let lower: NumericBoundary | undefined;
+  let upper: NumericBoundary | undefined;
+
+  for (const check of getCheckDefinitions(def)) {
+    if (
+      (check.check === "number_format" && check.format === "safeint") ||
+      check.kind === "int"
+    ) {
+      integer = true;
+      lower = tighterLowerBoundary(lower, {
+        value: -Number.MAX_SAFE_INTEGER,
+        exclusive: false,
+      });
+      upper = tighterUpperBoundary(upper, {
+        value: Number.MAX_SAFE_INTEGER,
+        exclusive: false,
+      });
+      continue;
+    }
+
+    if (check.check === "greater_than" && finiteNumber(check.value)) {
+      lower = tighterLowerBoundary(lower, {
+        value: check.value,
+        exclusive: check.inclusive !== true,
+      });
+    } else if (check.check === "less_than" && finiteNumber(check.value)) {
+      upper = tighterUpperBoundary(upper, {
+        value: check.value,
+        exclusive: check.inclusive !== true,
+      });
+    } else if (check.kind === "min" && finiteNumber(check.value)) {
+      lower = tighterLowerBoundary(lower, {
+        value: check.value,
+        exclusive: check.inclusive === false,
+      });
+    } else if (check.kind === "max" && finiteNumber(check.value)) {
+      upper = tighterUpperBoundary(upper, {
+        value: check.value,
+        exclusive: check.inclusive === false,
+      });
+    }
+  }
+
+  const json: JsonSchema = { type: integer ? "integer" : "number" };
+  if (lower) {
+    if (lower.exclusive) json.exclusiveMinimum = lower.value;
+    else json.minimum = lower.value;
+  }
+  if (upper) {
+    if (upper.exclusive) json.exclusiveMaximum = upper.value;
+    else json.maximum = upper.value;
+  }
+  return json;
+}
+
+function arrayLimit(value: ZodDef["minLength"]): number | undefined {
+  if (finiteNumber(value)) return value;
+  if (value && typeof value === "object" && finiteNumber(value.value)) return value.value;
+  return undefined;
+}
+
+function applyArrayLimits(json: JsonSchema, def: ZodDef): void {
+  const minimums: number[] = [];
+  const maximums: number[] = [];
+  const legacyMinimum = arrayLimit(def.minLength);
+  const legacyMaximum = arrayLimit(def.maxLength);
+  if (legacyMinimum !== undefined) minimums.push(legacyMinimum);
+  if (legacyMaximum !== undefined) maximums.push(legacyMaximum);
+
+  for (const check of getCheckDefinitions(def)) {
+    if (check.check === "min_length" && finiteNumber(check.minimum)) {
+      minimums.push(check.minimum);
+    } else if (check.check === "max_length" && finiteNumber(check.maximum)) {
+      maximums.push(check.maximum);
+    }
+  }
+
+  if (minimums.length > 0) json.minItems = Math.max(...minimums);
+  if (maximums.length > 0) json.maxItems = Math.min(...maximums);
+}
+
 export function zodToJsonSchema(schema: z.ZodTypeAny): JsonSchema {
-  return convertSchema(schema, { seen: new WeakSet() });
+  return convertSchema(schema, {
+    seen: new WeakSet(),
+    depth: 0,
+    nodeCount: 0,
+  });
 }
 
 function convertSchema(schema: z.ZodTypeAny, context: ConversionContext): JsonSchema {
@@ -82,11 +454,21 @@ export function isOptionalSchema(schema: z.ZodTypeAny): boolean {
 
 function convert(schema: z.ZodTypeAny, context: ConversionContext): JsonSchema {
   if (context.seen.has(schema)) return {};
+  assertConversionDepth(context.depth);
+  context.nodeCount += 1;
+  if (context.nodeCount > MAX_CONVERSION_NODES) {
+    throw new RangeError(
+      `Zod schema exceeds the maximum conversion node count of ${MAX_CONVERSION_NODES}`,
+    );
+  }
+
   context.seen.add(schema);
+  context.depth += 1;
 
   try {
     return convertInner(schema, context);
   } finally {
+    context.depth -= 1;
     context.seen.delete(schema);
   }
 }
@@ -98,15 +480,27 @@ function convertInner(schema: z.ZodTypeAny, context: ConversionContext): JsonSch
   switch (tag) {
     case "ZodString":
     case "string":
-      return { type: "string" };
+      return convertString(def);
 
     case "ZodNumber":
     case "number":
-      return { type: "number" };
+      return convertNumber(def);
 
     case "ZodBoolean":
     case "boolean":
       return { type: "boolean" };
+
+    case "ZodNull":
+    case "null":
+      return { type: "null" };
+
+    case "ZodUnknown":
+    case "unknown":
+    case "ZodAny":
+    case "any":
+    case "ZodCustom":
+    case "custom":
+      return {};
 
     case "ZodBigInt":
     case "bigint":
@@ -141,7 +535,12 @@ function convertInner(schema: z.ZodTypeAny, context: ConversionContext): JsonSch
 
       for (const [key, value] of Object.entries(shape ?? {})) {
         const zodSchema = value as z.ZodTypeAny;
-        properties[key] = convertSchema(zodSchema, context);
+        Object.defineProperty(properties, key, {
+          configurable: true,
+          enumerable: true,
+          value: convertSchema(zodSchema, context),
+          writable: true,
+        });
         if (!isOptionalSchema(zodSchema)) required.push(key);
       }
 
@@ -157,8 +556,12 @@ function convertInner(schema: z.ZodTypeAny, context: ConversionContext): JsonSch
     case "array": {
       // v3: _def.type (item schema), v4: _def.element (item schema)
       const itemType = def.element ?? (def.type as unknown as z.ZodTypeAny | undefined);
-      if (!itemType || typeof itemType === "string") return { type: "array" };
-      return { type: "array", items: convertSchema(itemType, context) };
+      const json: JsonSchema = { type: "array" };
+      if (itemType && typeof itemType !== "string") {
+        json.items = convertSchema(itemType, context);
+      }
+      applyArrayLimits(json, def);
+      return json;
     }
 
     case "ZodTuple":
@@ -184,7 +587,40 @@ function convertInner(schema: z.ZodTypeAny, context: ConversionContext): JsonSch
     case "record": {
       const valueSchema = def.valueType ?? def.element;
       if (!valueSchema) return { type: "object" };
-      return { type: "object", additionalProperties: convertSchema(valueSchema, context) };
+      const valueJsonSchema = convertSchema(valueSchema, context);
+      const finiteKeys = def.keyType && finiteStringRecordKeys(def.keyType, context);
+      if (finiteKeys) {
+        const properties: Record<string, JsonSchema> = {};
+        for (const key of finiteKeys) {
+          Object.defineProperty(properties, key, {
+            configurable: true,
+            enumerable: true,
+            value: valueJsonSchema,
+            writable: true,
+          });
+        }
+        return {
+          type: "object",
+          properties,
+          required: finiteKeys,
+          additionalProperties: false,
+        };
+      }
+
+      const json: JsonSchema = {
+        type: "object",
+        additionalProperties: valueJsonSchema,
+      };
+      if (def.keyType) {
+        const propertyNames = convertSchema(def.keyType, context);
+        if (
+          Object.keys(propertyNames).length !== 1 ||
+          propertyNames.type !== "string"
+        ) {
+          json.propertyNames = propertyNames;
+        }
+      }
+      return json;
     }
 
     case "ZodDefault":
@@ -192,26 +628,21 @@ function convertInner(schema: z.ZodTypeAny, context: ConversionContext): JsonSch
       const innerType = def.innerType ?? def.schema;
       if (!innerType) return { type: "object" };
       const inner = convertSchema(innerType, context);
-      const defaultValue = typeof def.defaultValue === "function"
-        ? def.defaultValue()
-        : def.defaultValue;
-
-      if (typeof inner === "object" && !("anyOf" in inner) && defaultValue !== undefined) {
-        inner.default = defaultValue;
-      }
+      const staticDefault = getStaticJsonSchemaDefault(def);
+      if (staticDefault) inner.default = staticDefault.value;
 
       return inner;
     }
 
     case "ZodLazy":
     case "lazy":
-      return def.getter ? convert(def.getter(), context) : { type: "object" };
+      return def.getter ? convertSchema(def.getter(), context) : { type: "object" };
 
     case "ZodEffects":
     case "pipe": {
       // v3: ZodEffects wraps schema in _def.schema
       // v4: pipe wraps in _def.in (input schema)
-      const innerSchema = def.schema ?? def.in;
+      const innerSchema = representedPipeSchema(def);
       return innerSchema ? convert(innerSchema, context) : { type: "object" };
     }
 
@@ -239,11 +670,16 @@ function getObjectAdditionalProperties(
 function unwrapSchema(
   schema: z.ZodTypeAny,
 ): { schema: z.ZodTypeAny; nullable: boolean; optional: boolean } {
+  const seen = new WeakSet<object>();
   let current: z.ZodTypeAny = schema;
   let nullable = false;
   let optional = false;
+  let depth = 0;
 
   while (true) {
+    assertConversionDepth(depth);
+    if (seen.has(current)) return { schema: current, nullable, optional };
+    seen.add(current);
     const tag = getTypeTag(current);
     const def = getDef(current);
 
@@ -252,18 +688,21 @@ function unwrapSchema(
       case "nullable":
         nullable = true;
         current = (def.innerType ?? def.schema)!;
+        depth++;
         break;
 
       case "ZodOptional":
       case "optional":
         optional = true;
         current = (def.innerType ?? def.schema)!;
+        depth++;
         break;
 
       case "ZodEffects":
       case "pipe":
-        current = def.schema ?? def.in ?? current;
+        current = representedPipeSchema(def) ?? current;
         if (current === schema) return { schema: current, nullable, optional };
+        depth++;
         break;
 
       default:
@@ -273,9 +712,14 @@ function unwrapSchema(
 }
 
 function hasDefaultSchema(schema: z.ZodTypeAny): boolean {
+  const seen = new WeakSet<object>();
   let current: z.ZodTypeAny = schema;
+  let depth = 0;
 
   while (true) {
+    assertConversionDepth(depth);
+    if (seen.has(current)) return false;
+    seen.add(current);
     const tag = getTypeTag(current);
     const def = getDef(current);
 
@@ -293,6 +737,7 @@ function hasDefaultSchema(schema: z.ZodTypeAny): boolean {
         const inner = def.innerType ?? def.schema ?? def.in;
         if (!inner || inner === current) return false;
         current = inner;
+        depth++;
         break;
       }
 

--- a/scripts/lint/test-typecheck-baseline.json
+++ b/scripts/lint/test-typecheck-baseline.json
@@ -80,7 +80,6 @@
   "src/server/build-service-worker.test.ts",
   "src/server/handlers/response/cors.test.ts",
   "src/server/shared/renderer/adapter.test.ts",
-  "src/tool/factory.test.ts",
   "src/transforms/import-rewriter/strategies/import-map-strategy.test.ts",
   "src/transforms/md/compiler/md-compiler.test.ts",
   "src/transforms/mdx/compiler/index.test.ts",

--- a/src/extensions/schema/index.ts
+++ b/src/extensions/schema/index.ts
@@ -10,6 +10,8 @@ export type {
   InferSchema,
   InferShape,
   JsonSchema,
+  JsonSchemaValidationFunction,
+  JsonSchemaValidationResult,
   RefinementCtx,
   SchemaFactory,
   ValidationResult,
@@ -17,6 +19,9 @@ export type {
 
 // Interfaces
 export type {
+  JsonSchemaValidationFailure,
+  JsonSchemaValidationIssue,
+  JsonSchemaValidationSuccess,
   Schema,
   SchemaValidator,
   SchemaValidatorCoerce,

--- a/src/extensions/schema/json-schema.ts
+++ b/src/extensions/schema/json-schema.ts
@@ -6,18 +6,39 @@
  * @module extensions/schema/json-schema
  */
 
+export type JsonSchemaPrimitiveType =
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "object"
+  | "array"
+  | "null";
+
 export type JsonSchema = {
-  type?: "string" | "number" | "integer" | "boolean" | "object" | "array" | "null";
+  [keyword: string]: unknown;
+  $schema?: string;
+  type?: JsonSchemaPrimitiveType | readonly JsonSchemaPrimitiveType[];
   description?: string;
-  enum?: unknown[];
+  format?: string;
+  pattern?: string;
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  enum?: readonly unknown[];
   const?: unknown;
   default?: unknown;
   properties?: Record<string, JsonSchema>;
-  required?: string[];
+  required?: readonly string[];
+  propertyNames?: JsonSchema;
   items?: JsonSchema;
   additionalProperties?: boolean | JsonSchema;
-  anyOf?: JsonSchema[];
-  prefixItems?: JsonSchema[];
+  anyOf?: readonly JsonSchema[];
+  allOf?: readonly JsonSchema[];
+  prefixItems?: readonly JsonSchema[];
   minItems?: number;
   maxItems?: number;
 };

--- a/src/extensions/schema/schema-validator.ts
+++ b/src/extensions/schema/schema-validator.ts
@@ -148,6 +148,44 @@ export interface ValidationFailure {
 /** Discriminated union of validation outcomes. */
 export type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
 
+/** Stable validation issue copied from a JSON Schema validator result. */
+export interface JsonSchemaValidationIssue {
+  /** JSON Pointer to the invalid value. */
+  instancePath: string;
+  /** JSON Pointer to the failed schema keyword. */
+  schemaPath: string;
+  /** JSON Schema keyword that failed. */
+  keyword: string;
+  /** Keyword-specific diagnostic values. */
+  params: Readonly<Record<string, unknown>>;
+  /** Human-readable validator diagnostic, when available. */
+  message?: string;
+}
+
+/** Successful validation of an input against a compiled JSON Schema. */
+export interface JsonSchemaValidationSuccess<T = unknown> {
+  success: true;
+  /** The accepted input. Validators must not mutate this value. */
+  value: T;
+}
+
+/** Failed validation of an input against a compiled JSON Schema. */
+export interface JsonSchemaValidationFailure {
+  success: false;
+  /** Validator issues copied before a subsequent validation can replace them. */
+  errors: readonly JsonSchemaValidationIssue[];
+}
+
+/** Result returned by a compiled JSON Schema validator. */
+export type JsonSchemaValidationResult<T = unknown> =
+  | JsonSchemaValidationSuccess<T>
+  | JsonSchemaValidationFailure;
+
+/** Compiled, reusable JSON Schema validation function. */
+export type JsonSchemaValidationFunction<T = unknown> = (
+  input: unknown,
+) => JsonSchemaValidationResult<T> | PromiseLike<JsonSchemaValidationResult<T>>;
+
 /**
  * Namespace for `coerce.*` constructors — accepts input in any form and
  * coerces to the target type before validation.
@@ -230,6 +268,16 @@ export interface SchemaValidator {
    * earlier revisions of this contract.
    */
   validate<T>(schema: Schema<T>, data: unknown): ValidationResult<T>;
+
+  /**
+   * Compile a JSON Schema into a reusable, non-mutating validator.
+   *
+   * This capability is optional so existing third-party `SchemaValidator`
+   * implementations remain source-compatible. Framework features that accept
+   * raw JSON Schema fail clearly when the registered adapter does not provide
+   * it.
+   */
+  compileJsonSchema?<T = unknown>(schema: JsonSchema): JsonSchemaValidationFunction<T>;
 
   /**
    * Convert an opaque `Schema<T>` to a JSON Schema document.

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -1,4 +1,4 @@
-# Schemas Module
+# Schemas module
 
 This directory contains shared validation schemas used across multiple modules in the veryfront codebase.
 
@@ -11,7 +11,7 @@ The veryfront codebase follows a **schema-first approach** where:
 3. **Module-local schemas** live in `{module}/schemas/` directories
 4. **Shared schemas** (cross-module) live in `src/schemas/` (this directory)
 
-## Naming Conventions
+## Naming conventions
 
 - **Schema files**: `{name}.schema.ts` (e.g., `config.schema.ts`)
 - **Shared schema files**: `common.ts`, `primitives.ts` (no `.schema` suffix since they're collections)
@@ -19,14 +19,19 @@ The veryfront codebase follows a **schema-first approach** where:
 - **Schema exports**: Backward-compat constant (e.g., `export const UserSchema = getUserSchema()`)
 - **Type exports**: Infer types from schema getters (e.g., `type User = InferSchema<ReturnType<typeof getUserSchema>>`)
 
-## Directory Structure
+## Directory structure
 
 ```
 src/
 ├── schemas/                    # Shared schemas (cross-module)
 │   ├── index.ts                # Barrel export
 │   ├── common.ts               # Common validators (email, url, pagination, etc.)
-│   └── primitives.ts           # Primitive validators (non-empty string, positive int, etc.)
+│   ├── define.ts               # Lazy, memoized schema factories
+│   ├── json-schema.ts          # Adapter-neutral JSON Schema helpers
+│   ├── json-value.ts           # Defensive JSON value validation
+│   ├── lazy.ts                 # Import-safe schema facade
+│   ├── primitives.ts           # Primitive validators
+│   └── *.test.ts               # Colocated behavior and regression tests
 │
 ├── config/
 │   ├── schemas/                # Module-local schemas
@@ -37,9 +42,50 @@ src/
 └── [other modules follow same pattern]
 ```
 
-## When to Use Shared vs Module-Local Schemas
+## Shared schema constraints
 
-### Use `src/schemas/` (shared) for:
+| Schema        | Accepted input and limits                                                                                                                                                                                                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Email         | Valid email string, at most 255 characters                                                                                                                                                                                                                                                             |
+| Slug          | 1 to 100 lowercase ASCII letters, digits, or hyphens                                                                                                                                                                                                                                                   |
+| URL           | Valid URL string, at most 2,048 characters                                                                                                                                                                                                                                                             |
+| Phone number  | E.164 digits with an optional leading `+`                                                                                                                                                                                                                                                              |
+| Pagination    | `page` and `limit` accept numbers or decimal digit strings of at most 16 characters. `page` is a positive safe integer. `limit` is 1 to 100. Defaults are 1 and 10.                                                                                                                                    |
+| File path     | Non-empty, no null bytes, at most 4,096 characters                                                                                                                                                                                                                                                     |
+| Absolute path | Filesystem-rooted, no null bytes, at most 4,096 characters                                                                                                                                                                                                                                             |
+| JSON value    | Data-only JSON with at most 128 levels, 100,000 nodes, and 4 MiB serialized size. A string is at most 1 MiB and an object key is at most 16 KiB in UTF-8. Cycles, accessors, symbol keys, non-enumerable properties, and plain-object prototypes other than `Object.prototype` or `null` are rejected. |
+
+Raw JSON Schema compilation and adapter-generated JSON Schema documents use
+the same bounded, data-only snapshot. Only that canonical snapshot crosses the
+helper boundary, so later reads cannot observe different Proxy values. Invalid
+adapter results fail with a `TypeError`.
+
+## JSON Schema conversion
+
+The built-in adapter preserves these representable constraints:
+
+- Integer, inclusive range, and exclusive range checks
+- String and array length checks
+- Regular expressions without flags
+- Email, URI, UUID, and date-time formats
+- Literal defaults, including defaults on union schemas
+- Optional, nullable, object, array, tuple, record, enum, and union structure
+
+Dynamic default callbacks are not executed during conversion and do not appear
+in the generated document. Runtime transforms, arbitrary refinements, and
+regular-expression flags have no exact JSON Schema equivalent and are omitted.
+Recursive lazy cycles are cut off with an unconstrained schema instead of
+emitting `$ref`. JavaScript-only values such as `bigint`, `Date`, functions,
+and class instances also have no faithful JSON representation and should not
+be exposed as JSON tool inputs. Runtime validation remains authoritative for
+those constraints.
+Conversion stops with a clear error above 128 active schema levels or 100,000
+visited schema nodes instead of exhausting the call stack or allocating an
+unbounded document.
+
+## When to use shared vs module-local schemas
+
+### Use `src/schemas/` (shared) for
 
 - **Cross-cutting validators** used by 3+ modules
   - Examples: email, URL, UUID, slug validation
@@ -47,16 +93,16 @@ src/
   - Date/time schemas
   - Common primitive types
 
-### Use `{module}/schemas/` (module-local) for:
+### Use `{module}/schemas/` (module-local) for
 
 - **Domain-specific schemas** used primarily within one module
   - Examples: `AgentConfig`, `WorkflowStep`, `CacheKeyContext`
 - **Module business logic** types
 - **Module-specific enums** and discriminated unions
 
-## Schema Patterns
+## Schema patterns
 
-### 1. Basic Schema with Inferred Type
+### 1. Basic schema with inferred type
 
 ```typescript
 // schemas/user.schema.ts
@@ -77,7 +123,7 @@ export const UserSchema = getUserSchema();
 export type User = InferSchema<ReturnType<typeof getUserSchema>>;
 ```
 
-### 2. Discriminated Union (Event Types)
+### 2. Discriminated union (event types)
 
 ```typescript
 // schemas/events.schema.ts
@@ -102,7 +148,7 @@ export const EventSchema = getEventSchema();
 export type Event = InferSchema<ReturnType<typeof getEventSchema>>;
 ```
 
-### 3. Composing Schemas
+### 3. Composing schemas
 
 ```typescript
 // schemas/api.schema.ts
@@ -144,7 +190,7 @@ export const ApiResponseSchema = getApiResponseSchema();
 export type ApiResponse = InferSchema<ReturnType<typeof getApiResponseSchema>>;
 ```
 
-### 4. Recursive/Lazy Schemas
+### 4. Recursive and lazy schemas
 
 ```typescript
 // schemas/tree.schema.ts
@@ -165,7 +211,7 @@ export const TreeNodeSchema = getTreeNodeSchema();
 export type TreeNode = InferSchema<ReturnType<typeof getTreeNodeSchema>>;
 ```
 
-### 5. Using with Runtime Validation
+### 5. Runtime validation
 
 ```typescript
 import { getUserSchema } from "./schemas/user.schema.ts";
@@ -193,7 +239,7 @@ function createUserSafe(data: unknown) {
 }
 ```
 
-## Migration Guidelines
+## Migration guidelines
 
 When converting existing `types.ts` files to schemas:
 
@@ -204,7 +250,7 @@ When converting existing `types.ts` files to schemas:
 5. **Delete old `types.ts`** file (no legacy cruft)
 6. **Run `deno task verify`** to ensure everything works
 
-### Before (Old Pattern)
+### Before (old pattern)
 
 ```typescript
 // types.ts
@@ -215,7 +261,7 @@ export interface User {
 }
 ```
 
-### After (New Pattern)
+### After (new pattern)
 
 ```typescript
 // schemas/user.schema.ts
@@ -244,7 +290,7 @@ export type User = InferSchema<ReturnType<typeof getUserSchema>>;
 6. **Maintainability**: Change schema once, type updates automatically
 7. **Documentation**: Schemas serve as living documentation
 
-## Testing Schemas
+## Testing schemas
 
 ```typescript
 import "#veryfront/schemas/_test-setup.ts";

--- a/src/schemas/common.test.ts
+++ b/src/schemas/common.test.ts
@@ -121,8 +121,29 @@ describe("CommonSchemas", () => {
       assertEquals(result.data.limit, 20);
     });
 
+    it("should reject non-decimal numeric string spellings", () => {
+      for (const value of [" 3 ", "+3", "3.0", "1e2", "0x10"]) {
+        assertParseFailure(CommonSchemas.pagination.safeParse({ page: value }));
+        assertParseFailure(CommonSchemas.pagination.safeParse({ limit: value }));
+      }
+    });
+
+    it("should reject decimal digit strings longer than 16 characters", () => {
+      const overlong = "0".repeat(17);
+
+      assertParseFailure(CommonSchemas.pagination.safeParse({ page: overlong }));
+      assertParseFailure(CommonSchemas.pagination.safeParse({ limit: overlong }));
+    });
+
     it("should reject negative page numbers", () => {
       assertParseFailure(CommonSchemas.pagination.safeParse({ page: -1 }));
+    });
+
+    it("should reject page numbers above the maximum safe integer", () => {
+      const unsafePage = Number.MAX_SAFE_INTEGER + 1;
+
+      assertParseFailure(CommonSchemas.pagination.safeParse({ page: unsafePage }));
+      assertParseFailure(CommonSchemas.pagination.safeParse({ page: String(unsafePage) }));
     });
 
     it("should reject limit exceeding 100", () => {

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -9,32 +9,55 @@
  * @module schemas/common
  */
 
-import type { InferSchema, Schema } from "veryfront/extensions/schema";
+import type { InferSchema, Schema } from "#veryfront/extensions/schema/index.ts";
 import { MAX_URL_LENGTH_FOR_VALIDATION } from "#veryfront/utils/constants/index.ts";
 import { defineSchema } from "./define.ts";
 import { getTimestampSchema } from "./primitives.ts";
 
 const SLUG_PATTERN = /^[a-z0-9-]+$/;
 const E164_PHONE_NUMBER_PATTERN = /^\+?[1-9]\d{1,14}$/;
+const MAX_EMAIL_LENGTH = 255;
+const MAX_SLUG_LENGTH = 100;
+const DEFAULT_PAGE_NUMBER = 1;
+const DEFAULT_PAGE_LIMIT = 10;
+const MAX_PAGE_LIMIT = 100;
+const MAX_SAFE_INTEGER_DIGITS = String(Number.MAX_SAFE_INTEGER).length;
+const DECIMAL_INTEGER_PATTERN = /^\d+$/;
+const STRONG_PASSWORD_MIN_LENGTH = 8;
 
-export const getEmailSchema = defineSchema((v) => v.string().email().max(255));
+export const getEmailSchema = defineSchema((v) => v.string().max(MAX_EMAIL_LENGTH).email());
 export const getUuidSchema = defineSchema((v) => v.string().uuid());
-export const getSlugSchema = defineSchema((v) => v.string().regex(SLUG_PATTERN).min(1).max(100));
+export const getSlugSchema = defineSchema((v) =>
+  v.string().min(1).max(MAX_SLUG_LENGTH).regex(SLUG_PATTERN)
+);
 export const getUrlSchema = defineSchema((v) =>
-  v.string().url().max(MAX_URL_LENGTH_FOR_VALIDATION)
+  v.string().max(MAX_URL_LENGTH_FOR_VALIDATION).url()
 );
 export const getPhoneNumberSchema = defineSchema((v) =>
   v.string().regex(E164_PHONE_NUMBER_PATTERN)
 );
 
-export const getPaginationSchema = defineSchema((v) =>
-  v.object({
-    page: v.coerce.number().int().positive().default(1),
-    limit: v.coerce.number().int().positive().max(100).default(10),
+export const getPaginationSchema = defineSchema((v) => {
+  const numericQueryParameter = (numberSchema: Schema<number>) =>
+    v.union([
+      v
+        .string()
+        .max(MAX_SAFE_INTEGER_DIGITS)
+        .regex(DECIMAL_INTEGER_PATTERN)
+        .transform((value) => Number(value))
+        .pipe(numberSchema),
+      numberSchema,
+    ]);
+  const pageNumber = v.number().int().positive().max(Number.MAX_SAFE_INTEGER);
+  const pageLimit = v.number().int().positive().max(MAX_PAGE_LIMIT);
+
+  return v.object({
+    page: numericQueryParameter(pageNumber).default(DEFAULT_PAGE_NUMBER),
+    limit: numericQueryParameter(pageLimit).default(DEFAULT_PAGE_LIMIT),
     sort: v.string().optional(),
     order: v.enum(["asc", "desc"]).optional(),
-  })
-);
+  });
+});
 
 export const getDateRangeSchema = defineSchema((v) =>
   v
@@ -50,7 +73,10 @@ export const getDateRangeSchema = defineSchema((v) =>
 export const getStrongPasswordSchema = defineSchema((v) =>
   v
     .string()
-    .min(8, "Password must be at least 8 characters")
+    .min(
+      STRONG_PASSWORD_MIN_LENGTH,
+      `Password must be at least ${STRONG_PASSWORD_MIN_LENGTH} characters`,
+    )
     .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
     .regex(/[a-z]/, "Password must contain at least one lowercase letter")
     .regex(/[0-9]/, "Password must contain at least one number")

--- a/src/schemas/define.test.ts
+++ b/src/schemas/define.test.ts
@@ -2,8 +2,9 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { register, reset, tryResolve } from "#veryfront/extensions/contracts.ts";
-import type { SchemaValidator } from "#veryfront/extensions/schema/index.ts";
+import type { JsonSchema, Schema, SchemaValidator } from "#veryfront/extensions/schema/index.ts";
 import { defineSchema } from "./define.ts";
+import { compileJsonSchemaValidator, tryCompileJsonSchemaValidator } from "./json-schema.ts";
 import { lazySchema } from "./lazy.ts";
 import { createZodAdapter } from "../../extensions/ext-schema-zod/src/adapter.ts";
 
@@ -55,11 +56,33 @@ describe("defineSchema", () => {
     assertEquals(first === second, true);
   });
 
+  it("rejects malformed factory results at materialization", () => {
+    const getSchema = defineSchema(() => null as never);
+
+    assertThrows(
+      () => getSchema(),
+      TypeError,
+      "Schema factory must return a Schema",
+    );
+  });
+
+  it("fails clearly when a factory re-enters its own getter", () => {
+    const holder = {} as { getSchema: () => Schema<string> };
+    const getSchema = defineSchema(() => holder.getSchema());
+    holder.getSchema = getSchema;
+
+    assertThrows(
+      () => getSchema(),
+      Error,
+      "Schema factory recursively invoked its own getter",
+    );
+  });
+
   it("defers adapter resolution until first call", () => {
     reset();
     const getSchema = defineSchema((v) => v.boolean());
 
-    // No contract yet — construction alone must not throw.
+    // No contract yet. Construction alone must not throw.
     assertEquals(tryResolve<SchemaValidator>("SchemaValidator"), undefined);
 
     register<SchemaValidator>("SchemaValidator", createZodAdapter());
@@ -87,5 +110,132 @@ describe("defineSchema", () => {
     const getObjectSchema = defineSchema((v) => v.object({ name: nameSchema }));
 
     assertEquals(getObjectSchema().parse({ name: "Veryfront" }), { name: "Veryfront" });
+  });
+
+  it("fails clearly when the registered adapter cannot compile raw JSON Schema", () => {
+    reset();
+    const { compileJsonSchema: _unsupported, ...legacyAdapter } = createZodAdapter();
+    register<SchemaValidator>("SchemaValidator", legacyAdapter);
+
+    assertThrows(
+      () => compileJsonSchemaValidator({ type: "object" }),
+      Error,
+      "cannot compile JSON Schema",
+    );
+  });
+
+  it("rejects malformed compiled-validator results", () => {
+    reset();
+    register<SchemaValidator>("SchemaValidator", {
+      ...createZodAdapter(),
+      compileJsonSchema: () => null as never,
+    });
+
+    assertThrows(
+      () => compileJsonSchemaValidator({ type: "object" }),
+      TypeError,
+      "must return a validation function",
+    );
+    assertThrows(
+      () => tryCompileJsonSchemaValidator({ type: "object" }),
+      TypeError,
+      "must return a validation function",
+    );
+  });
+
+  it("reads the optional JSON Schema compiler capability once", () => {
+    reset();
+    const adapter = createZodAdapter();
+    let compilerReads = 0;
+    Object.defineProperty(adapter, "compileJsonSchema", {
+      configurable: true,
+      get() {
+        compilerReads += 1;
+        if (compilerReads > 1) return undefined;
+        return <T = unknown>() => (input: unknown) => ({
+          success: true as const,
+          value: input as T,
+        });
+      },
+    });
+    register<SchemaValidator>("SchemaValidator", adapter);
+
+    const compiled = compileJsonSchemaValidator({ type: "object" });
+
+    assertEquals(compiled({ name: "Veryfront" }), {
+      success: true,
+      value: { name: "Veryfront" },
+    });
+    assertEquals(compilerReads, 1);
+  });
+
+  it("rejects unsafe raw JSON Schema before invoking the adapter compiler", () => {
+    reset();
+    let compileCalls = 0;
+    let accessorReads = 0;
+    register<SchemaValidator>("SchemaValidator", {
+      ...createZodAdapter(),
+      compileJsonSchema: <T = unknown>() => {
+        compileCalls += 1;
+        return (input) => ({ success: true, value: input as T });
+      },
+    });
+    const unsafeSchema: Record<string, unknown> = {};
+    Object.defineProperty(unsafeSchema, "type", {
+      enumerable: true,
+      get() {
+        accessorReads += 1;
+        return "object";
+      },
+    });
+
+    assertThrows(
+      () => compileJsonSchemaValidator(unsafeSchema),
+      TypeError,
+      "must be a bounded JSON Schema object",
+    );
+    assertEquals(compileCalls, 0);
+    assertEquals(accessorReads, 0);
+  });
+
+  it("passes a data-only snapshot to a custom JSON Schema compiler", () => {
+    reset();
+    let compilerInput: unknown;
+    let descriptorReads = 0;
+    let valueReads = 0;
+    const target = { type: "object" as const };
+    const schema = new Proxy(target, {
+      getOwnPropertyDescriptor(_target, property) {
+        if (property !== "type") return undefined;
+        descriptorReads += 1;
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: "object",
+        };
+      },
+      get(_target, property, receiver) {
+        if (property === "type") {
+          valueReads += 1;
+          return () => "not-json";
+        }
+        return Reflect.get(_target, property, receiver);
+      },
+    });
+    register<SchemaValidator>("SchemaValidator", {
+      ...createZodAdapter(),
+      compileJsonSchema: <T = unknown>(input: JsonSchema) => {
+        compilerInput = input;
+        return (value) => ({ success: true, value: value as T });
+      },
+    });
+
+    compileJsonSchemaValidator(schema);
+
+    assertEquals(compilerInput, { type: "object" });
+    assertEquals(compilerInput === schema, false);
+    assertEquals(descriptorReads, 1);
+    assertEquals(valueReads, 0);
   });
 });

--- a/src/schemas/define.ts
+++ b/src/schemas/define.ts
@@ -4,7 +4,7 @@
  * `defineSchema(factory)` returns a memoized getter that resolves the
  * `SchemaValidator` extension contract on first call and materializes the
  * schema via the provided factory. This indirection lets core modules declare
- * schemas without importing zod directly — a real validator (typically
+ * schemas without importing zod directly. A real validator (typically
  * `@veryfront/ext-schema-zod`) must be registered in the contract registry before
  * the schema is first accessed.
  *
@@ -14,8 +14,53 @@
 import { resolve } from "#veryfront/extensions/contracts.ts";
 import type { Schema, SchemaFactory, SchemaValidator } from "#veryfront/extensions/schema/index.ts";
 
+const SCHEMA_METHOD_NAMES = [
+  "optional",
+  "nullable",
+  "nullish",
+  "default",
+  "describe",
+  "refine",
+  "superRefine",
+  "transform",
+  "strict",
+  "strip",
+  "passthrough",
+  "partial",
+  "extend",
+  "merge",
+  "omit",
+  "pick",
+  "min",
+  "max",
+  "int",
+  "positive",
+  "nonnegative",
+  "regex",
+  "email",
+  "url",
+  "uuid",
+  "datetime",
+  "pipe",
+  "parse",
+  "safeParse",
+] as const;
+
 export function resolveSchemaValidator(): SchemaValidator {
   return resolve<SchemaValidator>("SchemaValidator");
+}
+
+/** Assert the runtime surface promised by the opaque Schema contract. */
+export function assertSchemaContract<T>(
+  value: unknown,
+  message: string,
+): asserts value is Schema<T> {
+  const valid = !!value &&
+    (typeof value === "object" || typeof value === "function") &&
+    SCHEMA_METHOD_NAMES.every((method) =>
+      typeof (value as Record<string, unknown>)[method] === "function"
+    );
+  if (!valid) throw new TypeError(message);
 }
 
 /**
@@ -36,10 +81,27 @@ export function resolveSchemaValidator(): SchemaValidator {
  */
 export function defineSchema<T>(factory: SchemaFactory<T>): () => Schema<T> {
   let cached: Schema<T> | undefined;
+  let materializing = false;
+
   return () => {
-    if (cached) return cached;
-    const v = resolveSchemaValidator();
-    cached = factory(v);
-    return cached;
+    if (cached !== undefined) return cached;
+    if (materializing) {
+      throw new Error(
+        "Schema factory recursively invoked its own getter; use v.lazy() for recursion",
+      );
+    }
+
+    materializing = true;
+    try {
+      const schema = factory(resolveSchemaValidator());
+      assertSchemaContract<T>(
+        schema,
+        "Schema factory must return a Schema contract implementation",
+      );
+      cached = schema;
+      return schema;
+    } finally {
+      materializing = false;
+    }
   };
 }

--- a/src/schemas/json-schema.test.ts
+++ b/src/schemas/json-schema.test.ts
@@ -1,0 +1,193 @@
+import "./_test-setup.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { register, reset } from "#veryfront/extensions/contracts.ts";
+import type { SchemaValidator } from "#veryfront/extensions/schema/index.ts";
+import {
+  defineSchema,
+  getEmailSchema,
+  getJsonValueSchema,
+  getPaginationSchema,
+  getPortNumberSchema,
+  getStrongPasswordSchema,
+  lazySchema,
+  schemaIsOptional,
+  schemaToJsonSchema,
+} from "./index.ts";
+import { createZodAdapter } from "../../extensions/ext-schema-zod/src/adapter.ts";
+
+describe("JSON Schema helpers", () => {
+  afterEach(() => {
+    reset();
+    register<SchemaValidator>("SchemaValidator", createZodAdapter());
+  });
+
+  it("converts lazy contract schemas through the registered validator", () => {
+    const schema = lazySchema(
+      defineSchema((v) =>
+        v.object({
+          name: v.string(),
+          count: v.number().default(1),
+          note: v.string().optional(),
+        })
+      ),
+    );
+
+    assertEquals(schemaToJsonSchema(schema), {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        count: { type: "number", default: 1 },
+        note: { type: "string" },
+      },
+      required: ["name"],
+    });
+  });
+
+  it("reports optional and defaulted schemas consistently", () => {
+    const schema = lazySchema(defineSchema((v) => v.string()));
+
+    assertEquals(schemaIsOptional(schema), false);
+    assertEquals(schemaIsOptional(schema.optional()), true);
+    assertEquals(schemaIsOptional(schema.default("fallback")), true);
+  });
+
+  it("emits all JSON value primitive and container types", () => {
+    assertEquals(schemaToJsonSchema(getJsonValueSchema()), {
+      anyOf: [
+        { type: "string" },
+        { type: "number" },
+        { type: "boolean" },
+        { type: "null" },
+        { type: "array", items: {} },
+        { type: "object", properties: {}, additionalProperties: true },
+      ],
+    });
+  });
+
+  it("preserves shared schema constraints and defaults", () => {
+    assertEquals(schemaToJsonSchema(getEmailSchema()), {
+      type: "string",
+      maxLength: 255,
+      format: "email",
+    });
+    assertEquals(schemaToJsonSchema(getPortNumberSchema()), {
+      type: "integer",
+      minimum: 1,
+      maximum: 65_535,
+    });
+    assertEquals(schemaToJsonSchema(getStrongPasswordSchema()), {
+      type: "string",
+      minLength: 8,
+      allOf: [
+        { pattern: "[A-Z]" },
+        { pattern: "[a-z]" },
+        { pattern: "[0-9]" },
+        { pattern: "[^A-Za-z0-9]" },
+      ],
+    });
+
+    const pagination = schemaToJsonSchema(getPaginationSchema());
+    assertEquals(pagination.properties?.page, {
+      anyOf: [
+        { type: "string", maxLength: 16, pattern: "^\\d+$" },
+        {
+          type: "integer",
+          exclusiveMinimum: 0,
+          maximum: Number.MAX_SAFE_INTEGER,
+        },
+      ],
+      default: 1,
+    });
+    assertEquals(pagination.properties?.limit, {
+      anyOf: [
+        { type: "string", maxLength: 16, pattern: "^\\d+$" },
+        { type: "integer", exclusiveMinimum: 0, maximum: 100 },
+      ],
+      default: 10,
+    });
+  });
+
+  it("does not execute dynamic defaults during schema conversion", () => {
+    let defaultCalls = 0;
+    const schema = defineSchema((v) =>
+      v.string().default(() => {
+        defaultCalls += 1;
+        return "generated";
+      })
+    )();
+
+    assertEquals(schemaToJsonSchema(schema), { type: "string" });
+    assertEquals(defaultCalls, 0);
+    assertEquals(schema.parse(undefined), "generated");
+    assertEquals(defaultCalls, 1);
+  });
+
+  it("rejects malformed adapter conversion results", () => {
+    reset();
+    const adapter = createZodAdapter();
+    register<SchemaValidator>("SchemaValidator", {
+      ...adapter,
+      toJsonSchema: () => null as never,
+    });
+
+    assertThrows(
+      () => schemaToJsonSchema(adapter.string()),
+      TypeError,
+      "must return a bounded JSON Schema object",
+    );
+  });
+
+  it("returns a data-only snapshot of stateful adapter output", () => {
+    reset();
+    const adapter = createZodAdapter();
+    let descriptorReads = 0;
+    let valueReads = 0;
+    const target = { type: "string" as const };
+    const adapterOutput = new Proxy(target, {
+      getOwnPropertyDescriptor(_target, property) {
+        if (property !== "type") return undefined;
+        descriptorReads += 1;
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: "string",
+        };
+      },
+      get(_target, property, receiver) {
+        if (property === "type") {
+          valueReads += 1;
+          return () => "not-json";
+        }
+        return Reflect.get(_target, property, receiver);
+      },
+    });
+    register<SchemaValidator>("SchemaValidator", {
+      ...adapter,
+      toJsonSchema: () => adapterOutput,
+    });
+
+    const jsonSchema = schemaToJsonSchema(adapter.string());
+
+    assertEquals(jsonSchema, { type: "string" });
+    assertEquals(jsonSchema === adapterOutput, false);
+    assertEquals(descriptorReads, 1);
+    assertEquals(valueReads, 0);
+  });
+
+  it("rejects malformed adapter optionality results", () => {
+    reset();
+    const adapter = createZodAdapter();
+    register<SchemaValidator>("SchemaValidator", {
+      ...adapter,
+      isOptional: () => "yes" as never,
+    });
+
+    assertThrows(
+      () => schemaIsOptional(adapter.string()),
+      TypeError,
+      "must return a boolean",
+    );
+  });
+});

--- a/src/schemas/json-schema.ts
+++ b/src/schemas/json-schema.ts
@@ -6,8 +6,24 @@
  * @module schemas/json-schema
  */
 
-import type { JsonSchema, Schema } from "#veryfront/extensions/schema/index.ts";
+import type {
+  JsonSchema,
+  JsonSchemaValidationFunction,
+  Schema,
+  SchemaValidator,
+} from "#veryfront/extensions/schema/index.ts";
 import { resolveSchemaValidator } from "./define.ts";
+import { snapshotBoundedJsonValue } from "./json-value.ts";
+
+function snapshotBoundedJsonSchemaObject(value: unknown): JsonSchema | undefined {
+  const snapshot = snapshotBoundedJsonValue(value);
+  return snapshot.success &&
+      !!snapshot.value &&
+      typeof snapshot.value === "object" &&
+      !Array.isArray(snapshot.value)
+    ? snapshot.value
+    : undefined;
+}
 
 /**
  * Convert an opaque `Schema<T>` to a JSON Schema document.
@@ -17,7 +33,15 @@ import { resolveSchemaValidator } from "./define.ts";
  * by `defineSchema` or any other contract-aware builder.
  */
 export function schemaToJsonSchema(schema: Schema<unknown>): JsonSchema {
-  return resolveSchemaValidator().toJsonSchema(schema);
+  const jsonSchema = snapshotBoundedJsonSchemaObject(
+    resolveSchemaValidator().toJsonSchema(schema),
+  );
+  if (!jsonSchema) {
+    throw new TypeError(
+      "SchemaValidator.toJsonSchema() must return a bounded JSON Schema object",
+    );
+  }
+  return jsonSchema;
 }
 
 /**
@@ -27,7 +51,71 @@ export function schemaToJsonSchema(schema: Schema<unknown>): JsonSchema {
  * `isOptional` implementation.
  */
 export function isOptionalSchema(schema: Schema<unknown>): boolean {
-  return resolveSchemaValidator().isOptional(schema);
+  const optional = resolveSchemaValidator().isOptional(schema);
+  if (typeof optional !== "boolean") {
+    throw new TypeError("SchemaValidator.isOptional() must return a boolean");
+  }
+  return optional;
+}
+
+function compileWithValidator<T>(
+  validator: SchemaValidator,
+  compiler: NonNullable<SchemaValidator["compileJsonSchema"]>,
+  schema: JsonSchema,
+): JsonSchemaValidationFunction<T> {
+  const snapshot = snapshotBoundedJsonSchemaObject(schema);
+  if (!snapshot) {
+    throw new TypeError("JSON Schema must be a bounded JSON Schema object");
+  }
+
+  let compiled: JsonSchemaValidationFunction<T>;
+  try {
+    compiled = compiler.call(validator, snapshot) as JsonSchemaValidationFunction<T>;
+  } catch (cause) {
+    throw new Error("The registered SchemaValidator failed to compile JSON Schema", { cause });
+  }
+  if (typeof compiled !== "function") {
+    throw new TypeError("SchemaValidator.compileJsonSchema() must return a validation function");
+  }
+  return compiled;
+}
+
+/**
+ * Compile a raw JSON Schema through the registered validator extension.
+ *
+ * This helper is intentionally internal. Raw-schema consumers must fail
+ * during materialization when a custom validator adapter does not implement
+ * the optional compilation capability.
+ */
+export function compileJsonSchemaValidator<T = unknown>(
+  schema: JsonSchema,
+): JsonSchemaValidationFunction<T> {
+  const validator = resolveSchemaValidator();
+  const compiler = validator.compileJsonSchema;
+  if (!compiler) {
+    throw new Error(
+      "The registered SchemaValidator cannot compile JSON Schema. " +
+        "Use a validator extension that implements compileJsonSchema().",
+    );
+  }
+
+  return compileWithValidator<T>(validator, compiler, schema);
+}
+
+/**
+ * Compile a raw JSON Schema when the registered adapter supports it.
+ *
+ * Older third-party adapters predate this optional capability. Callers that
+ * only need to transmit a schema can remain compatible and defer the explicit
+ * capability error until local validation is actually requested.
+ */
+export function tryCompileJsonSchemaValidator<T = unknown>(
+  schema: JsonSchema,
+): JsonSchemaValidationFunction<T> | undefined {
+  const validator = resolveSchemaValidator();
+  const compiler = validator.compileJsonSchema;
+  if (!compiler) return undefined;
+  return compileWithValidator<T>(validator, compiler, schema);
 }
 
 export type { JsonSchema };

--- a/src/schemas/json-value.ts
+++ b/src/schemas/json-value.ts
@@ -1,0 +1,281 @@
+/**
+ * Defensive validation for data-only JSON values.
+ *
+ * Kept internal to the schemas module so runtime schemas and JSON Schema
+ * adapter boundaries share one set of resource and prototype-safety checks.
+ *
+ * @module schemas/json-value
+ */
+
+const JSON_VALUE_MAX_DEPTH = 128;
+const JSON_VALUE_MAX_NODES = 100_000;
+const JSON_VALUE_MAX_SERIALIZED_BYTES = 4 * 1024 * 1024;
+const JSON_VALUE_MAX_STRING_BYTES = 1024 * 1024;
+const JSON_VALUE_MAX_KEY_BYTES = 16 * 1024;
+const JSON_UTF8_ENCODER = new TextEncoder();
+
+export type BoundedJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | BoundedJsonValue[]
+  | { [key: string]: BoundedJsonValue };
+
+export type BoundedJsonSnapshot =
+  | { success: true; value: BoundedJsonValue }
+  | { success: false };
+
+type CanonicalJsonContainer =
+  | BoundedJsonValue[]
+  | { [key: string]: BoundedJsonValue };
+
+type SnapshotFrame =
+  | {
+    kind: "visit";
+    value: unknown;
+    depth: number;
+    parent?: CanonicalJsonContainer;
+    key?: string | number;
+  }
+  | { kind: "exit"; value: object };
+
+type SnapshotVisitFrame = Extract<SnapshotFrame, { kind: "visit" }>;
+
+const INVALID_JSON_SNAPSHOT: BoundedJsonSnapshot = Object.freeze({ success: false });
+
+function utf8LengthWithin(value: string, limit: number): number | undefined {
+  if (value.length > limit) return undefined;
+  const byteLength = JSON_UTF8_ENCODER.encode(value).byteLength;
+  return byteLength <= limit ? byteLength : undefined;
+}
+
+function serializedByteLength(value: string | number | boolean | null): number | undefined {
+  const serialized = JSON.stringify(value);
+  return serialized === undefined ? undefined : JSON_UTF8_ENCODER.encode(serialized).byteLength;
+}
+
+/**
+ * Creates a bounded, data-only snapshot of an unknown JSON value.
+ *
+ * The walk is iterative and rejects cycles, accessors, plain-object
+ * prototypes other than `Object.prototype` or `null`, non-JSON properties,
+ * and inputs above the documented depth, node, string, key, and
+ * serialized-size limits. Only property descriptor values captured during
+ * this walk are copied, so a stateful Proxy cannot change the value between
+ * validation and later consumption.
+ */
+export function snapshotBoundedJsonValue(value: unknown): BoundedJsonSnapshot {
+  try {
+    const activeAncestors = new Set<object>();
+    const stack: SnapshotFrame[] = [{ kind: "visit", value, depth: 0 }];
+    let nodeCount = 0;
+    let serializedBytes = 0;
+    let canonicalRoot: BoundedJsonValue | undefined;
+    let rootAssigned = false;
+
+    const addSerializedBytes = (amount: number): boolean => {
+      serializedBytes += amount;
+      return serializedBytes <= JSON_VALUE_MAX_SERIALIZED_BYTES;
+    };
+
+    const assign = (frame: SnapshotVisitFrame, canonical: BoundedJsonValue): void => {
+      if (frame.parent === undefined) {
+        canonicalRoot = canonical;
+        rootAssigned = true;
+        return;
+      }
+      if (Array.isArray(frame.parent)) {
+        frame.parent[frame.key as number] = canonical;
+        return;
+      }
+      defineOwnDataProperty(frame.parent, frame.key as string, canonical);
+    };
+
+    while (stack.length > 0) {
+      const frame = stack.pop();
+      if (!frame) break;
+      if (frame.kind === "exit") {
+        activeAncestors.delete(frame.value);
+        continue;
+      }
+
+      if (frame.depth > JSON_VALUE_MAX_DEPTH || ++nodeCount > JSON_VALUE_MAX_NODES) {
+        return INVALID_JSON_SNAPSHOT;
+      }
+
+      const current = frame.value;
+      if (current === null || typeof current === "boolean") {
+        const bytes = serializedByteLength(current);
+        if (bytes === undefined || !addSerializedBytes(bytes)) return INVALID_JSON_SNAPSHOT;
+        assign(frame, current);
+        continue;
+      }
+      if (typeof current === "string") {
+        if (utf8LengthWithin(current, JSON_VALUE_MAX_STRING_BYTES) === undefined) {
+          return INVALID_JSON_SNAPSHOT;
+        }
+        const bytes = serializedByteLength(current);
+        if (bytes === undefined || !addSerializedBytes(bytes)) return INVALID_JSON_SNAPSHOT;
+        assign(frame, current);
+        continue;
+      }
+      if (typeof current === "number") {
+        if (!Number.isFinite(current)) return INVALID_JSON_SNAPSHOT;
+        const bytes = serializedByteLength(current);
+        if (bytes === undefined || !addSerializedBytes(bytes)) return INVALID_JSON_SNAPSHOT;
+        assign(frame, current);
+        continue;
+      }
+      if (typeof current !== "object" || activeAncestors.has(current)) {
+        return INVALID_JSON_SNAPSHOT;
+      }
+
+      if (Array.isArray(current)) {
+        if (
+          !snapshotArray(
+            current,
+            frame,
+            stack,
+            activeAncestors,
+            addSerializedBytes,
+            assign,
+          )
+        ) {
+          return INVALID_JSON_SNAPSHOT;
+        }
+        continue;
+      }
+
+      if (
+        !snapshotObject(
+          current,
+          frame,
+          stack,
+          activeAncestors,
+          addSerializedBytes,
+          assign,
+        )
+      ) {
+        return INVALID_JSON_SNAPSHOT;
+      }
+    }
+
+    return rootAssigned
+      ? { success: true, value: canonicalRoot as BoundedJsonValue }
+      : INVALID_JSON_SNAPSHOT;
+  } catch {
+    // Proxy traps and reflective operations can throw. Such values are not
+    // data-only JSON inputs and must fail validation rather than escape it.
+    return INVALID_JSON_SNAPSHOT;
+  }
+}
+
+function snapshotArray(
+  value: unknown[],
+  frame: SnapshotVisitFrame,
+  stack: SnapshotFrame[],
+  activeAncestors: Set<object>,
+  addSerializedBytes: (amount: number) => boolean,
+  assign: (frame: SnapshotVisitFrame, canonical: BoundedJsonValue) => void,
+): boolean {
+  const ownKeys = Reflect.ownKeys(value);
+  const lengthDescriptor = Reflect.getOwnPropertyDescriptor(value, "length");
+  const length = lengthDescriptor && "value" in lengthDescriptor
+    ? lengthDescriptor.value
+    : undefined;
+  if (
+    typeof length !== "number" ||
+    !Number.isSafeInteger(length) ||
+    length < 0 ||
+    length > JSON_VALUE_MAX_NODES ||
+    ownKeys.some((key) => typeof key === "symbol") ||
+    ownKeys.length !== length + 1 ||
+    !ownKeys.includes("length") ||
+    !addSerializedBytes(2 + Math.max(0, length - 1))
+  ) {
+    return false;
+  }
+
+  const values: unknown[] = [];
+  for (let index = 0; index < length; index++) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor || !("value" in descriptor) || descriptor.enumerable !== true) return false;
+    values.push(descriptor.value);
+  }
+
+  const canonical: BoundedJsonValue[] = new Array(length);
+  assign(frame, canonical);
+  activeAncestors.add(value);
+  stack.push({ kind: "exit", value });
+  for (let index = values.length - 1; index >= 0; index--) {
+    stack.push({
+      kind: "visit",
+      value: values[index],
+      depth: frame.depth + 1,
+      parent: canonical,
+      key: index,
+    });
+  }
+  return true;
+}
+
+function snapshotObject(
+  value: object,
+  frame: SnapshotVisitFrame,
+  stack: SnapshotFrame[],
+  activeAncestors: Set<object>,
+  addSerializedBytes: (amount: number) => boolean,
+  assign: (frame: SnapshotVisitFrame, canonical: BoundedJsonValue) => void,
+): boolean {
+  const prototype = Reflect.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return false;
+
+  const ownKeys = Reflect.ownKeys(value);
+  if (
+    ownKeys.length > JSON_VALUE_MAX_NODES ||
+    ownKeys.some((key) => typeof key === "symbol") ||
+    !addSerializedBytes(2 + Math.max(0, ownKeys.length - 1))
+  ) {
+    return false;
+  }
+
+  const values: unknown[] = [];
+  for (const key of ownKeys as string[]) {
+    if (utf8LengthWithin(key, JSON_VALUE_MAX_KEY_BYTES) === undefined) return false;
+    const keyBytes = serializedByteLength(key);
+    if (keyBytes === undefined || !addSerializedBytes(keyBytes + 1)) return false;
+
+    const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !("value" in descriptor) || descriptor.enumerable !== true) return false;
+    values.push(descriptor.value);
+  }
+
+  const canonical: { [key: string]: BoundedJsonValue } = {};
+  assign(frame, canonical);
+  activeAncestors.add(value);
+  stack.push({ kind: "exit", value });
+  for (let index = values.length - 1; index >= 0; index--) {
+    stack.push({
+      kind: "visit",
+      value: values[index],
+      depth: frame.depth + 1,
+      parent: canonical,
+      key: ownKeys[index] as string,
+    });
+  }
+  return true;
+}
+
+function defineOwnDataProperty(
+  target: { [key: string]: BoundedJsonValue },
+  key: string,
+  value: BoundedJsonValue,
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}

--- a/src/schemas/lazy.test.ts
+++ b/src/schemas/lazy.test.ts
@@ -1,0 +1,90 @@
+import "./_test-setup.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { Schema } from "#veryfront/extensions/schema/index.ts";
+import { defineSchema } from "./define.ts";
+import { lazySchema } from "./lazy.ts";
+
+describe("lazySchema", () => {
+  it("reflects non-configurable adapter metadata without violating proxy invariants", () => {
+    let materializations = 0;
+    const getConcreteSchema = defineSchema((v) => v.string());
+    const schema = lazySchema(() => {
+      materializations += 1;
+      const concreteSchema = getConcreteSchema();
+      Object.defineProperty(concreteSchema, "adapterMetadata", {
+        configurable: false,
+        enumerable: true,
+        value: "test-adapter",
+      });
+      return concreteSchema;
+    });
+
+    assertEquals(materializations, 0);
+    assertEquals(
+      Object.getOwnPropertyDescriptor(schema, "adapterMetadata")?.value,
+      "test-adapter",
+    );
+    assertEquals(materializations, 1);
+  });
+
+  it("can be frozen without breaking reflection or validation", () => {
+    const schema = lazySchema(defineSchema((v) => v.string().min(1)));
+
+    Object.freeze(schema);
+
+    assertEquals(Object.isFrozen(schema), true);
+    assertEquals(schema.parse("Veryfront"), "Veryfront");
+  });
+
+  it("prefers concrete own metadata over inherited facade properties", () => {
+    const getConcreteSchema = defineSchema((v) => v.string());
+    const concreteSchema = getConcreteSchema();
+    Object.defineProperties(concreteSchema, {
+      toString: {
+        configurable: true,
+        enumerable: true,
+        value: "adapter-to-string",
+      },
+      receiverAwareMetadata: {
+        configurable: true,
+        enumerable: true,
+        get() {
+          return this === concreteSchema ? "concrete" : "wrong receiver";
+        },
+      },
+    });
+    const schema = lazySchema(() => concreteSchema);
+    const metadata = schema as unknown as Record<string, unknown>;
+
+    Object.freeze(schema);
+
+    assertEquals(Reflect.get(metadata, "toString"), "adapter-to-string");
+    assertEquals(metadata.receiverAwareMetadata, "concrete");
+  });
+
+  it("rejects malformed getter results at materialization", () => {
+    const schema = lazySchema(() => null as never);
+
+    assertThrows(
+      () => schema.parse("value"),
+      TypeError,
+      "lazySchema getter must return a Schema",
+    );
+  });
+
+  it("fails clearly when its getter re-enters the facade", () => {
+    const concreteSchema = defineSchema((v) => v.string())();
+    const holder = {} as { schema: Schema<string> };
+    holder.schema = lazySchema(() => {
+      holder.schema.parse("value");
+      return concreteSchema;
+    });
+
+    assertThrows(
+      () => holder.schema.parse("value"),
+      Error,
+      "lazySchema getter recursively invoked its own facade",
+    );
+  });
+});

--- a/src/schemas/lazy.ts
+++ b/src/schemas/lazy.ts
@@ -1,12 +1,63 @@
+/**
+ * Lazy schema facade with contract validation and metadata forwarding.
+ *
+ * @module schemas/lazy
+ */
+
 import type {
   RefinementCtx,
   Schema,
   ValidationResult,
 } from "#veryfront/extensions/schema/index.ts";
+import { assertSchemaContract } from "./define.ts";
+
+function configurableDescriptor(descriptor: PropertyDescriptor): PropertyDescriptor {
+  return { ...descriptor, configurable: true };
+}
+
+function copyOwnProperties(target: object, source: object): boolean {
+  for (const prop of Reflect.ownKeys(source)) {
+    if (Reflect.getOwnPropertyDescriptor(target, prop)) continue;
+    const descriptor = Reflect.getOwnPropertyDescriptor(source, prop);
+    const targetDescriptor = descriptor && !("value" in descriptor)
+      ? {
+        ...descriptor,
+        get: descriptor.get?.bind(source),
+        set: descriptor.set?.bind(source),
+      }
+      : descriptor;
+    if (
+      targetDescriptor &&
+      !Reflect.defineProperty(target, prop, configurableDescriptor(targetDescriptor))
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
 
 export function lazySchema<T>(getSchema: () => Schema<T>): Schema<T> {
   let cached: Schema<T> | undefined;
-  const schema = () => cached ??= getSchema();
+  let materializing = false;
+  const schema = (): Schema<T> => {
+    if (cached !== undefined) return cached;
+    if (materializing) {
+      throw new Error("lazySchema getter recursively invoked its own facade");
+    }
+
+    materializing = true;
+    try {
+      const concreteSchema = getSchema();
+      assertSchemaContract<T>(
+        concreteSchema,
+        "lazySchema getter must return a Schema contract implementation",
+      );
+      cached = concreteSchema;
+      return concreteSchema;
+    } finally {
+      materializing = false;
+    }
+  };
   const facade: Schema<T> = {
     _output: undefined as unknown as T,
     optional: () => schema().optional(),
@@ -44,22 +95,32 @@ export function lazySchema<T>(getSchema: () => Schema<T>): Schema<T> {
 
   return new Proxy(facade, {
     get(target, prop, receiver) {
-      if (prop in target) {
+      if (Object.hasOwn(target, prop)) {
         return Reflect.get(target, prop, receiver);
       }
-      return Reflect.get(schema() as object, prop, receiver);
+      const concreteSchema = schema() as object;
+      if (prop in concreteSchema) {
+        return Reflect.get(concreteSchema, prop, concreteSchema);
+      }
+      return Reflect.get(target, prop, receiver);
     },
     has(target, prop) {
-      return prop in target || prop in (schema() as object);
+      return Object.hasOwn(target, prop) || prop in (schema() as object) || prop in target;
     },
     ownKeys(target) {
+      if (!Reflect.isExtensible(target)) return Reflect.ownKeys(target);
       return Array.from(
         new Set([...Reflect.ownKeys(target), ...Reflect.ownKeys(schema() as object)]),
       );
     },
     getOwnPropertyDescriptor(target, prop) {
-      return Reflect.getOwnPropertyDescriptor(target, prop) ??
-        Reflect.getOwnPropertyDescriptor(schema() as object, prop);
+      const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+      if (targetDescriptor || !Reflect.isExtensible(target)) return targetDescriptor;
+      const schemaDescriptor = Reflect.getOwnPropertyDescriptor(schema() as object, prop);
+      return schemaDescriptor && configurableDescriptor(schemaDescriptor);
+    },
+    preventExtensions(target) {
+      return copyOwnProperties(target, schema() as object) && Reflect.preventExtensions(target);
     },
   });
 }

--- a/src/schemas/primitives.test.ts
+++ b/src/schemas/primitives.test.ts
@@ -13,6 +13,7 @@ import {
   getSemverSchema,
   getTimestampSchema,
 } from "./index.ts";
+import { MAX_PATH_LENGTH_CHARS } from "#veryfront/utils/constants/index.ts";
 
 function assertParseSuccess(result: { success: boolean }): void {
   assertEquals(result.success, true);
@@ -92,6 +93,102 @@ describe("primitive schemas", () => {
     it("rejects undefined values", () => {
       assertParseFailure(getJsonValueSchema().safeParse({ invalid: undefined }));
     });
+
+    it("rejects cyclic values without throwing", () => {
+      const cyclic: Record<string, unknown> = {};
+      cyclic.self = cyclic;
+
+      assertParseFailure(getJsonValueSchema().safeParse(cyclic));
+    });
+
+    it("rejects values deeper than the validation limit without throwing", () => {
+      let value: unknown = null;
+      for (let depth = 0; depth < 256; depth++) value = [value];
+
+      assertParseFailure(getJsonValueSchema().safeParse(value));
+    });
+
+    it("rejects oversized strings", () => {
+      assertParseFailure(getJsonValueSchema().safeParse("x".repeat(1_048_577)));
+    });
+
+    it("rejects accessors without invoking them", () => {
+      let reads = 0;
+      const value: Record<string, unknown> = {};
+      Object.defineProperty(value, "field", {
+        enumerable: true,
+        get() {
+          reads += 1;
+          return "value";
+        },
+      });
+
+      assertParseFailure(getJsonValueSchema().safeParse(value));
+      assertEquals(reads, 0);
+    });
+
+    it("consumes one data-only snapshot of a stateful Proxy", () => {
+      let descriptorReads = 0;
+      let valueReads = 0;
+      const target = { field: "target" };
+      const value = new Proxy(target, {
+        getOwnPropertyDescriptor(_target, property) {
+          if (property !== "field") return undefined;
+          descriptorReads += 1;
+          return {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: "snapshot",
+          };
+        },
+        get(_target, property, receiver) {
+          if (property === "field") {
+            valueReads += 1;
+            return () => "not-json";
+          }
+          return Reflect.get(_target, property, receiver);
+        },
+      });
+
+      const result = getJsonValueSchema().safeParse(value);
+
+      assertEquals(result.success, true);
+      if (!result.success) return;
+      assertEquals(result.data, { field: "snapshot" });
+      assertEquals(result.data === value, false);
+      assertEquals(descriptorReads, 1);
+      assertEquals(valueReads, 0);
+    });
+
+    it("rejects objects with custom prototypes or symbol keys", () => {
+      const inherited = Object.assign(Object.create({ inherited: true }), { own: true });
+      const symbolKeyed = { value: true, [Symbol("hidden")]: true };
+
+      assertParseFailure(getJsonValueSchema().safeParse(inherited));
+      assertParseFailure(getJsonValueSchema().safeParse(symbolKeyed));
+    });
+
+    it("preserves __proto__ as data without changing the output prototype", () => {
+      const value: Record<string, unknown> = {};
+      Object.defineProperty(value, "__proto__", {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: { polluted: true },
+      });
+
+      const result = getJsonValueSchema().safeParse(value);
+
+      assertEquals(result.success, true);
+      if (!result.success) return;
+      assertEquals(Object.hasOwn(result.data as object, "__proto__"), true);
+      assertEquals((result.data as Record<string, unknown>)["__proto__"], {
+        polluted: true,
+      });
+      assertEquals(Object.getPrototypeOf(result.data as object), Object.prototype);
+      assertEquals((result.data as { polluted?: unknown }).polluted, undefined);
+    });
   });
 
   describe("hexColor", () => {
@@ -127,16 +224,45 @@ describe("primitive schemas", () => {
     it("rejects empty file paths", () => {
       assertParseFailure(getFilePathSchema().safeParse(""));
     });
+
+    it("rejects file paths containing null bytes", () => {
+      assertParseFailure(getFilePathSchema().safeParse("src/main\0.ts"));
+    });
+
+    it("rejects file paths exceeding the shared path limit", () => {
+      assertParseSuccess(getFilePathSchema().safeParse("a".repeat(MAX_PATH_LENGTH_CHARS)));
+      assertParseFailure(getFilePathSchema().safeParse("a".repeat(MAX_PATH_LENGTH_CHARS + 1)));
+    });
   });
 
   describe("absolutePath", () => {
     it("accepts unix and windows absolute paths", () => {
       assertParseSuccess(getAbsolutePathSchema().safeParse("/usr/local/bin"));
       assertParseSuccess(getAbsolutePathSchema().safeParse(String.raw`C:\Projects\veryfront`));
+      assertParseSuccess(getAbsolutePathSchema().safeParse("C:/Projects/veryfront"));
+      assertParseSuccess(getAbsolutePathSchema().safeParse(String.raw`\Projects\veryfront`));
+      assertParseSuccess(
+        getAbsolutePathSchema().safeParse(String.raw`\\server\share\veryfront`),
+      );
     });
 
     it("rejects relative paths", () => {
       assertParseFailure(getAbsolutePathSchema().safeParse("relative/path"));
+      assertParseFailure(getAbsolutePathSchema().safeParse("C:relative\\path"));
+      assertParseFailure(getAbsolutePathSchema().safeParse(String.raw`\\server`));
+    });
+
+    it("rejects absolute paths containing null bytes", () => {
+      assertParseFailure(getAbsolutePathSchema().safeParse("/tmp/main\0.ts"));
+    });
+
+    it("rejects absolute paths exceeding the shared path limit", () => {
+      assertParseSuccess(
+        getAbsolutePathSchema().safeParse(`/${"a".repeat(MAX_PATH_LENGTH_CHARS - 1)}`),
+      );
+      assertParseFailure(
+        getAbsolutePathSchema().safeParse(`/${"a".repeat(MAX_PATH_LENGTH_CHARS)}`),
+      );
     });
   });
 });

--- a/src/schemas/primitives.ts
+++ b/src/schemas/primitives.ts
@@ -1,13 +1,20 @@
 /**
  * Reusable validation primitives, expressed against the `SchemaValidator`
- * contract via `defineSchema`. Each export is a lazy getter — calling it
+ * contract via `defineSchema`. Each export is a lazy getter. Calling it
  * materializes (and caches) the schema on first use.
  *
  * @module schemas/primitives
  */
 
-import type { InferSchema, Schema } from "veryfront/extensions/schema";
+import type { InferSchema, Schema } from "#veryfront/extensions/schema/index.ts";
+import { MAX_PATH_LENGTH_CHARS } from "#veryfront/utils/constants/index.ts";
 import { defineSchema } from "./define.ts";
+import { type BoundedJsonValue, snapshotBoundedJsonValue } from "./json-value.ts";
+
+const ABSOLUTE_PATH_PATTERN = /^(?:\/|\\(?!\\)|[A-Za-z]:[\\/]|\\\\[^\\/]+[\\/][^\\/]+)/;
+const MIN_PORT_NUMBER = 1;
+const MAX_PORT_NUMBER = 65_535;
+const isPathWithoutNullBytes = (path: string): boolean => !path.includes("\0");
 
 export const getNonEmptyStringSchema = defineSchema((v) =>
   v.string().min(1, "String cannot be empty")
@@ -25,7 +32,11 @@ export const getNonNegativeIntSchema = defineSchema((v) =>
 export type NonNegativeInt = InferSchema<ReturnType<typeof getNonNegativeIntSchema>>;
 
 export const getPortNumberSchema = defineSchema((v) =>
-  v.number().int().min(1).max(65535, "Port must be between 1 and 65535")
+  v
+    .number()
+    .int()
+    .min(MIN_PORT_NUMBER)
+    .max(MAX_PORT_NUMBER, `Port must be between ${MIN_PORT_NUMBER} and ${MAX_PORT_NUMBER}`)
 );
 export type PortNumber = InferSchema<ReturnType<typeof getPortNumberSchema>>;
 
@@ -33,29 +44,31 @@ export const getTimestampSchema = defineSchema((v) => v.string().datetime());
 export type Timestamp = InferSchema<ReturnType<typeof getTimestampSchema>>;
 
 /**
- * Recursive JSON value type — a string, number, boolean, null, array of
+ * Recursive JSON value type: a string, number, boolean, null, array of
  * JsonValue, or object with string keys and JsonValue values.
  */
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { [key: string]: JsonValue };
+export type JsonValue = BoundedJsonValue;
 
-export const getJsonValueSchema = defineSchema<JsonValue>((v): Schema<JsonValue> =>
-  v.lazy<JsonValue>(() =>
-    v.union([
-      v.string(),
-      v.number(),
-      v.boolean(),
-      v.null(),
-      v.array(getJsonValueSchema()),
-      v.record(v.string(), getJsonValueSchema()),
-    ]) as Schema<JsonValue>
-  )
-);
+export const getJsonValueSchema = defineSchema<JsonValue>((v): Schema<JsonValue> => {
+  const jsonValueShape = v.union([
+    v.string(),
+    v.number(),
+    v.boolean(),
+    v.null(),
+    v.array(v.unknown()),
+    v.object({}).passthrough(),
+  ]) as Schema<JsonValue>;
+
+  return v
+    .custom<unknown>(() => true)
+    .transform((value) => snapshotBoundedJsonValue(value))
+    .refine(
+      (snapshot) => snapshot.success,
+      "Expected an acyclic, bounded, data-only JSON value",
+    )
+    .transform((snapshot): JsonValue => snapshot.success ? snapshot.value : null)
+    .pipe(jsonValueShape);
+});
 
 export const getHexColorSchema = defineSchema((v) =>
   v.string().regex(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/, "Invalid hex color")
@@ -71,14 +84,22 @@ export const getSemverSchema = defineSchema((v) =>
 export type Semver = InferSchema<ReturnType<typeof getSemverSchema>>;
 
 export const getFilePathSchema = defineSchema((v) =>
-  v.string().min(1, "File path cannot be empty")
+  v
+    .string()
+    .min(1, "File path cannot be empty")
+    .max(MAX_PATH_LENGTH_CHARS, `File path cannot exceed ${MAX_PATH_LENGTH_CHARS} characters`)
+    .refine(isPathWithoutNullBytes, "File path cannot contain null bytes")
 );
 export type FilePath = InferSchema<ReturnType<typeof getFilePathSchema>>;
 
 export const getAbsolutePathSchema = defineSchema((v) =>
-  v.string().regex(
-    /^(?:\/|[A-Za-z]:\\)/,
-    "Path must be absolute (start with / or drive letter)",
-  )
+  v
+    .string()
+    .max(MAX_PATH_LENGTH_CHARS, `Path cannot exceed ${MAX_PATH_LENGTH_CHARS} characters`)
+    .regex(
+      ABSOLUTE_PATH_PATTERN,
+      "Path must start at a filesystem root, drive letter, or UNC share",
+    )
+    .refine(isPathWithoutNullBytes, "Path cannot contain null bytes")
 );
 export type AbsolutePath = InferSchema<ReturnType<typeof getAbsolutePathSchema>>;


### PR DESCRIPTION
## Summary

- add bounded, data-only JSON value and raw JSON Schema snapshots
- extend the validator contract with optional compiled JSON Schema validation
- implement strict, non-mutating AJV validation inside `@veryfront/ext-schema-zod` only
- bound schema conversion depth, node count, strings, keys, serialized size, and adapter-local compiled-validator caching
- harden lazy schema proxy invariants, schema factory contracts, pagination coercion, and path primitives

Core remains validator-library independent; AJV and Zod are confined to the schema extension.

## Validation

- `deno task typecheck`
- changed tests: 7 suites, 148 steps, 0 failures
- `deno lint extensions/ext-schema-zod/src src/extensions/schema src/schemas`
- `deno task lint:ban-zod`
- `deno task test:integration --no-lock`: 256 suites, 2,592 steps, 0 failures
- `git diff --check`

Repository-wide `lint:imports` still reports the existing 70 cross-boundary imports outside this diff; this PR introduces none.