### PR TITLE
fix(schemas): close post-merge review gaps

### DIFF
--- a/extensions/ext-schema-zod/src/adapter.ts
+++ b/extensions/ext-schema-zod/src/adapter.ts
@@ -485,6 +485,9 @@ function canonicalizeJsonValue(value: unknown): unknown {
 
 function snapshotJsonSchema(schema: JsonSchema): { key: string; schema: JsonSchema } {
   const canonical = canonicalizeJsonValue(schema);
+  if (canonical === null || typeof canonical !== "object" || Array.isArray(canonical)) {
+    throw new TypeError("JSON Schema root must be a plain object");
+  }
   const key = JSON.stringify(canonical);
   if (key === undefined) throw new TypeError("JSON Schema must be JSON serializable");
   return { key, schema: canonical as JsonSchema };

--- a/extensions/ext-schema-zod/src/json-schema-validation.test.ts
+++ b/extensions/ext-schema-zod/src/json-schema-validation.test.ts
@@ -140,6 +140,13 @@ describe("SchemaValidator.compileJsonSchema", () => {
       TypeError,
       "plain JSON objects",
     );
+    for (const schema of [null, false, [], "string"] as const) {
+      assertThrows(
+        () => compile(schema as never),
+        TypeError,
+        "JSON Schema root must be a plain object",
+      );
+    }
   });
 
   it("rejects sparse and extended arrays regardless of cache insertion order", () => {

--- a/src/schemas/lazy.test.ts
+++ b/src/schemas/lazy.test.ts
@@ -6,6 +6,18 @@ import { defineSchema } from "./define.ts";
 import { lazySchema } from "./lazy.ts";
 
 describe("lazySchema", () => {
+  it("does not materialize for inherited facade properties", () => {
+    let materializations = 0;
+    const getConcreteSchema = defineSchema((v) => v.string());
+    const schema = lazySchema(() => {
+      materializations += 1;
+      return getConcreteSchema();
+    });
+
+    assertEquals("toString" in schema, true);
+    assertEquals(materializations, 0);
+  });
+
   it("reflects non-configurable adapter metadata without violating proxy invariants", () => {
     let materializations = 0;
     const getConcreteSchema = defineSchema((v) => v.string());

--- a/src/schemas/lazy.ts
+++ b/src/schemas/lazy.ts
@@ -105,7 +105,7 @@ export function lazySchema<T>(getSchema: () => Schema<T>): Schema<T> {
       return Reflect.get(target, prop, receiver);
     },
     has(target, prop) {
-      return Object.hasOwn(target, prop) || prop in (schema() as object) || prop in target;
+      return prop in target || prop in (schema() as object);
     },
     ownKeys(target) {
       if (!Reflect.isExtensible(target)) return Reflect.ownKeys(target);


### PR DESCRIPTION
## Summary

Follow-up to #3226 addressing two late suppressed review observations that were not represented as unresolved threads before merge.

- keep inherited lazy-schema facade membership checks lazy
- reject non-object raw JSON Schema roots at the Zod extension boundary
- add regression coverage for both contracts

## Validation

- `deno task typecheck`
- `deno test -A --no-check src/schemas extensions/ext-schema-zod/src` (7 suites, 150 steps)
- `deno task lint:core-deps`
- `deno task lint:test-typecheck`
- focused format, lint, check, and tests
- `git diff --check`

Core remains free of third-party dependencies; Ajv remains isolated to the schema extension.