### PR TITLE
refactor(build): replace external core glob matcher

### DIFF
--- a/src/build/asset-pipeline/css-optimizer/utils.test.ts
+++ b/src/build/asset-pipeline/css-optimizer/utils.test.ts
@@ -5,7 +5,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assert, assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { join } from "#veryfront/compat/path";
+import { join, resolve } from "#veryfront/compat/path";
 import { remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { ensureDir } from "#veryfront/compat/std/fs.ts";
 import {
@@ -64,6 +64,24 @@ describe("CSS Optimizer Utils", () => {
       assert(matchPattern("test.tsx", "*.{ts,tsx}"));
       assert(matchPattern("test.ts", "*.{ts,tsx}"));
       assert(!matchPattern("test.js", "*.{ts,tsx}"));
+    });
+
+    it("keeps wildcards inside segments unless globstar spans directories", () => {
+      assert(matchPattern("src/page.tsx", "src/*.tsx"));
+      assert(!matchPattern("src/nested/page.tsx", "src/*.tsx"));
+      assert(matchPattern("src/nested/page.tsx", "src/**/*.tsx"));
+      assert(matchPattern("src/page.tsx", "src/**/*.tsx"));
+    });
+
+    it("normalizes separators and supports literal glob characters", () => {
+      assert(matchPattern("src\\nested\\page.tsx", "src\\**\\*.tsx"));
+      assert(matchPattern("file?.tsx", "file[?].tsx"));
+      assert(!matchPattern("file1.tsx", "file[?].tsx"));
+    });
+
+    it("rejects invalid glob syntax", () => {
+      assertThrows(() => matchPattern("page.tsx", "*.{ts,tsx"), TypeError, "Invalid path glob");
+      assertThrows(() => matchPattern("page.tsx", "file[abc"), TypeError, "Invalid path glob");
     });
   });
 
@@ -171,6 +189,27 @@ describe("CSS Optimizer Utils", () => {
       assert(files.some((f) => f.includes("test.ts")));
 
       await cleanupTestDir();
+    });
+
+    it("uses the static prefix before an extended group as the scan root", async () => {
+      await cleanupTestDir();
+      try {
+        await ensureDir(join(TEST_DIR, "app"));
+        await ensureDir(join(TEST_DIR, "pages"));
+        await ensureDir(join(TEST_DIR, "components"));
+        await writeTextFile(join(TEST_DIR, "app", "page.tsx"), "content");
+        await writeTextFile(join(TEST_DIR, "pages", "page.tsx"), "content");
+        await writeTextFile(join(TEST_DIR, "components", "page.tsx"), "content");
+
+        const files = await globFiles(`${TEST_DIR}/@(app|pages)/**/*.tsx`);
+
+        assertEquals(files.map((file) => file.replaceAll("\\", "/")).sort(), [
+          resolve(TEST_DIR, "app", "page.tsx").replaceAll("\\", "/"),
+          resolve(TEST_DIR, "pages", "page.tsx").replaceAll("\\", "/"),
+        ]);
+      } finally {
+        await cleanupTestDir();
+      }
     });
 
     it("rejects patterns outside the project boundary", async () => {

--- a/src/build/asset-pipeline/css-optimizer/utils.ts
+++ b/src/build/asset-pipeline/css-optimizer/utils.ts
@@ -1,4 +1,3 @@
-import { globToRegExp } from "#std/path";
 import {
   basename,
   dirname,
@@ -8,6 +7,7 @@ import {
   relative,
   resolve,
 } from "#veryfront/compat/path/index.ts";
+import { compilePathGlob } from "#veryfront/build/utils/path-glob.ts";
 import { createFileSystem, isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import { cwd } from "#veryfront/platform/compat/process.ts";
 import { MAX_PATH_LENGTH_CHARS } from "#veryfront/utils/constants/limits.ts";
@@ -38,8 +38,6 @@ interface DiscoveryOptions {
 interface GlobOptions extends DiscoveryOptions {
   baseDir?: string;
 }
-
-const GLOB_MAGIC = /[*?{\[]/;
 
 function comparePaths(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
@@ -193,16 +191,11 @@ function compileProjectGlob(
     throw new TypeError(`Invalid CSS content pattern: ${JSON.stringify(pattern)}`);
   }
 
-  const segments = relativePattern.split("/");
-  const firstMagicSegment = segments.findIndex((segment) => GLOB_MAGIC.test(segment));
-  const staticSegments = firstMagicSegment === -1
-    ? segments.slice(0, -1)
-    : segments.slice(0, firstMagicSegment);
+  const expression = compilePathGlob(relativePattern);
+  const staticSegments = expression.staticPrefixSegments.length === expression.segmentCount
+    ? expression.staticPrefixSegments.slice(0, -1)
+    : expression.staticPrefixSegments;
   const rootDir = resolve(absoluteBase, ...staticSegments);
-  const expression = globToRegExp(relativePattern, {
-    extended: true,
-    globstar: true,
-  });
 
   return {
     rootDir,
@@ -233,10 +226,7 @@ export async function globFiles(
 export function matchPattern(path: string, pattern: string): boolean {
   requireSafePath(path, "CSS glob candidate");
   requireSafePath(pattern, "CSS glob pattern");
-  return globToRegExp(portablePath(pattern), {
-    extended: true,
-    globstar: true,
-  }).test(portablePath(path));
+  return compilePathGlob(portablePath(pattern)).test(portablePath(path));
 }
 
 export function getOutputPath(inputPath: string, outputDir: string): string {

--- a/src/build/utils/path-glob.test.ts
+++ b/src/build/utils/path-glob.test.ts
@@ -1,0 +1,152 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { compilePathGlob } from "./path-glob.ts";
+
+function assertMatches(pattern: string, matches: string[], rejects: string[]): void {
+  const matcher = compilePathGlob(pattern);
+  for (const path of matches) {
+    assertEquals(matcher.test(path), true, `${JSON.stringify(pattern)} should match ${path}`);
+  }
+  for (const path of rejects) {
+    assertEquals(matcher.test(path), false, `${JSON.stringify(pattern)} should not match ${path}`);
+  }
+}
+
+describe("build/utils/path-glob", () => {
+  it("anchors segment wildcards and single-character wildcards", () => {
+    assertMatches("*.ts", ["index.ts", ".ts"], ["index.tsx", "src/index.ts"]);
+    assertMatches("file?.ts", ["file1.ts", "filex.ts"], ["file.ts", "file10.ts"]);
+    assertMatches("a**b.ts", ["ab.ts", "anythingb.ts"], ["dir/ab.ts", "ab.tsx"]);
+  });
+
+  it("matches globstar only as a complete path segment", () => {
+    assertMatches(
+      "src/**/*.ts",
+      ["src/index.ts", "src/lib/index.ts", "src/lib/nested/index.ts"],
+      ["index.ts", "src/index.js", "other/index.ts"],
+    );
+    assertMatches("**/*.tsx", ["page.tsx", "app/page.tsx"], ["page.ts"]);
+    assertMatches("app/**/page.tsx", ["app/page.tsx", "app/a/b/page.tsx"], [
+      "page.tsx",
+      "apps/page.tsx",
+    ]);
+  });
+
+  it("supports brace alternatives and nested extended groups", () => {
+    assertMatches("*.{ts,tsx}", ["page.ts", "page.tsx"], ["page.js", "page.tsxx"]);
+    assertMatches("{app,@(pages|src)}/**/*.{ts,tsx}", [
+      "app/page.tsx",
+      "pages/about.ts",
+      "src/lib/value.ts",
+    ], ["components/page.tsx", "src/lib/value.js"]);
+    assertMatches("file{,.test}.ts", ["file.ts", "file.test.ts"], ["file.spec.ts"]);
+  });
+
+  it("treats route-group parentheses as literal path characters", () => {
+    assertMatches("app/(marketing)/**/*.tsx", [
+      "app/(marketing)/page.tsx",
+      "app/(marketing)/nested/page.tsx",
+    ], [
+      "app/marketing/page.tsx",
+      "app/(sales)/page.tsx",
+    ]);
+    assertMatches("page).tsx", ["page).tsx"], ["page.tsx"]);
+  });
+
+  it("supports each Bash-style extended group", () => {
+    assertMatches("@(page|layout).tsx", ["page.tsx", "layout.tsx"], [
+      "pagelayout.tsx",
+      "route.tsx",
+    ]);
+    assertMatches("?(pre)fix.ts", ["fix.ts", "prefix.ts"], ["preprefix.ts"]);
+    assertMatches("*(ab)c.ts", ["c.ts", "abc.ts", "ababc.ts"], ["ac.ts"]);
+    assertMatches("+(ab)c.ts", ["abc.ts", "ababc.ts"], ["c.ts", "ac.ts"]);
+    assertMatches("!(test).ts", ["page.ts", "contest.ts"], ["test.ts"]);
+  });
+
+  it("supports character ranges, negation, POSIX classes, and escapes", () => {
+    assertMatches("file[0-2].ts", ["file0.ts", "file2.ts"], ["file3.ts", "file10.ts"]);
+    assertMatches("file[!0-2].ts", ["file3.ts", "filex.ts"], ["file0.ts"]);
+    assertMatches("[[:digit:]][[:alpha:]].ts", ["1a.ts", "9Z.ts"], ["aa.ts"]);
+    assertMatches("file\\*.ts", ["file*.ts"], ["file1.ts"]);
+    assertMatches("file[?].ts", ["file?.ts"], ["file1.ts"]);
+  });
+
+  it("normalizes candidate separators while preserving absolute-path anchoring", () => {
+    assertMatches("src/**/*.ts", ["src\\index.ts", "src\\lib\\index.ts"], [
+      "other\\index.ts",
+    ]);
+    assertMatches("/project/**/*.ts", ["/project/index.ts", "\\project\\lib\\index.ts"], [
+      "project/index.ts",
+      "/other/index.ts",
+    ]);
+    assertMatches("src//*.ts/", ["src/index.ts", "src//index.ts/"], ["index.ts"]);
+  });
+
+  it("derives the static scan prefix from parsed segments", () => {
+    const literal = compilePathGlob("src/generated/file.ts");
+    assertEquals(literal.staticPrefixSegments, ["src", "generated", "file.ts"]);
+    assertEquals(literal.segmentCount, 3);
+
+    const extended = compilePathGlob("src/@(app|pages)/**/*.tsx");
+    assertEquals(extended.staticPrefixSegments, ["src"]);
+    assertEquals(extended.segmentCount, 4);
+
+    const escaped = compilePathGlob("src/file\\*.ts");
+    assertEquals(escaped.staticPrefixSegments, ["src", "file*.ts"]);
+  });
+
+  it("rejects malformed and structurally hostile patterns", () => {
+    for (
+      const pattern of [
+        "",
+        "file\\",
+        "file[abc.ts",
+        "file[z-a].ts",
+        "file[[:unknown:]].ts",
+        "{ts,tsx",
+        "@(page|layout",
+        "page}.tsx",
+        `safe${String.fromCharCode(0)}unsafe`,
+      ]
+    ) {
+      assertThrows(() => compilePathGlob(pattern), TypeError);
+    }
+
+    assertThrows(
+      () => compilePathGlob(`${"@(a|".repeat(17)}b${")".repeat(17)}`),
+      TypeError,
+      "nests groups",
+    );
+    assertThrows(
+      () => compilePathGlob(`{${Array.from({ length: 257 }, (_, index) => index).join(",")}}`),
+      TypeError,
+      "alternatives",
+    );
+    assertThrows(
+      () => compilePathGlob("*a".repeat(257)),
+      TypeError,
+      "matcher nodes",
+    );
+    assertThrows(
+      () => compilePathGlob("a".repeat(4_097)),
+      TypeError,
+      "at most 4096",
+    );
+
+    const expensiveMatcher = compilePathGlob("*a".repeat(256));
+    assertThrows(
+      () => expensiveMatcher.test("a".repeat(4_096)),
+      TypeError,
+      "bounded matching complexity",
+    );
+  });
+
+  it("rejects hostile candidates instead of treating them as non-matches", () => {
+    const matcher = compilePathGlob("**/*.ts");
+    assertThrows(() => matcher.test(""), TypeError);
+    assertThrows(() => matcher.test(`safe${String.fromCharCode(10)}unsafe.ts`), TypeError);
+    assertThrows(() => matcher.test("a".repeat(4_097)), TypeError);
+  });
+});

--- a/src/build/utils/path-glob.ts
+++ b/src/build/utils/path-glob.ts
@@ -1,0 +1,613 @@
+import { MAX_PATH_LENGTH_CHARS } from "#veryfront/utils/constants/limits.ts";
+import { hasControlCharacters } from "./string-validation.ts";
+
+const MAX_GLOB_NESTING = 16;
+const MAX_GLOB_NODES = 512;
+const MAX_GLOB_ALTERNATIVES = 256;
+const MAX_GLOB_MATCH_OPERATIONS = 250_000;
+
+interface GlobSequence {
+  nodes: GlobNode[];
+}
+
+type GlobNode =
+  | { kind: "literal"; value: string }
+  | { kind: "any-character" }
+  | { kind: "any-characters" }
+  | { kind: "character-class"; negated: boolean; atoms: CharacterClassAtom[] }
+  | { kind: "alternatives"; alternatives: GlobSequence[] }
+  | {
+    kind: "repeat";
+    alternatives: GlobSequence[];
+    minimum: 0 | 1;
+    maximum: 1 | "unbounded";
+  }
+  | { kind: "negative"; alternatives: GlobSequence[] };
+
+type CharacterClassAtom =
+  | { kind: "character"; value: string }
+  | { kind: "range"; start: number; end: number }
+  | { kind: "posix"; name: PosixCharacterClass };
+
+type PosixCharacterClass =
+  | "alnum"
+  | "alpha"
+  | "ascii"
+  | "blank"
+  | "cntrl"
+  | "digit"
+  | "graph"
+  | "lower"
+  | "print"
+  | "punct"
+  | "space"
+  | "upper"
+  | "word"
+  | "xdigit";
+
+interface CompiledSegment {
+  readonly literalValue?: string;
+  matches(value: string, budget: MatchBudget): boolean;
+}
+
+interface MatchBudget {
+  consume(count?: number): void;
+}
+
+type CompiledPathSegment = "globstar" | CompiledSegment;
+
+export interface PathGlobMatcher {
+  /** The portable, slash-separated pattern supplied at compilation time. */
+  readonly pattern: string;
+  /** Leading path segments that contain no glob syntax after parsing escapes. */
+  readonly staticPrefixSegments: readonly string[];
+  /** Number of path segments in the complete normalized pattern. */
+  readonly segmentCount: number;
+  /** Return whether the complete candidate path matches the complete pattern. */
+  test(path: string): boolean;
+}
+
+function requireSafeGlobText(value: unknown, label: string): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_PATH_LENGTH_CHARS ||
+    hasControlCharacters(value)
+  ) {
+    throw new TypeError(
+      `${label} must be a safe non-empty string of at most ${MAX_PATH_LENGTH_CHARS} characters`,
+    );
+  }
+}
+
+function invalidPattern(pattern: string, detail: string): TypeError {
+  return new TypeError(`Invalid path glob ${JSON.stringify(pattern)}: ${detail}`);
+}
+
+function createMatchBudget(pattern: string): MatchBudget {
+  let operations = 0;
+  return {
+    consume(count = 1): void {
+      operations += count;
+      if (operations > MAX_GLOB_MATCH_OPERATIONS) {
+        throw new TypeError(
+          `Path glob ${JSON.stringify(pattern)} exceeds the bounded matching complexity`,
+        );
+      }
+    },
+  };
+}
+
+class SegmentParser {
+  private index = 0;
+  private nodeCount = 0;
+  private alternativeCount = 0;
+
+  constructor(
+    private readonly segment: string,
+    private readonly fullPattern: string,
+  ) {}
+
+  parse(): GlobSequence {
+    const sequence = this.parseSequence(new Set(), 0);
+    if (this.index !== this.segment.length) {
+      throw invalidPattern(this.fullPattern, "contains an unmatched group delimiter");
+    }
+    return sequence;
+  }
+
+  private addNode<T extends GlobNode>(node: T): T {
+    this.nodeCount++;
+    if (this.nodeCount > MAX_GLOB_NODES) {
+      throw invalidPattern(
+        this.fullPattern,
+        `contains more than ${MAX_GLOB_NODES} matcher nodes`,
+      );
+    }
+    return node;
+  }
+
+  private parseSequence(stops: ReadonlySet<string>, depth: number): GlobSequence {
+    const nodes: GlobNode[] = [];
+    let literal = "";
+    const flushLiteral = (): void => {
+      if (literal.length === 0) return;
+      nodes.push(this.addNode({ kind: "literal", value: literal }));
+      literal = "";
+    };
+
+    while (this.index < this.segment.length) {
+      const character = this.segment[this.index]!;
+      if (stops.has(character)) break;
+
+      if (character === "\\") {
+        if (this.index + 1 >= this.segment.length) {
+          throw invalidPattern(this.fullPattern, "ends with an incomplete escape");
+        }
+        literal += this.segment[this.index + 1]!;
+        this.index += 2;
+        continue;
+      }
+
+      if (character === "[") {
+        flushLiteral();
+        nodes.push(this.parseCharacterClass());
+        continue;
+      }
+
+      if (character === "{") {
+        flushLiteral();
+        this.index++;
+        nodes.push(this.addNode({
+          kind: "alternatives",
+          alternatives: this.parseAlternatives("}", ",", depth + 1),
+        }));
+        continue;
+      }
+
+      const next = this.segment[this.index + 1];
+      if (
+        next === "(" &&
+        (character === "?" || character === "*" || character === "+" ||
+          character === "@" || character === "!")
+      ) {
+        flushLiteral();
+        this.index += 2;
+        const alternatives = this.parseAlternatives(")", "|", depth + 1);
+        if (character === "@") {
+          nodes.push(this.addNode({ kind: "alternatives", alternatives }));
+        } else if (character === "!") {
+          nodes.push(this.addNode({ kind: "negative", alternatives }));
+        } else {
+          nodes.push(this.addNode({
+            kind: "repeat",
+            alternatives,
+            minimum: character === "+" ? 1 : 0,
+            maximum: character === "?" ? 1 : "unbounded",
+          }));
+        }
+        continue;
+      }
+
+      if (character === "*") {
+        flushLiteral();
+        while (this.segment[this.index + 1] === "*") this.index++;
+        this.index++;
+        nodes.push(this.addNode({ kind: "any-characters" }));
+        continue;
+      }
+
+      if (character === "?") {
+        flushLiteral();
+        this.index++;
+        nodes.push(this.addNode({ kind: "any-character" }));
+        continue;
+      }
+
+      // Parentheses are ordinary path characters unless they close an
+      // extended group. This matters for framework route-group directories
+      // such as `app/(marketing)`. A closing brace remains invalid because an
+      // opening brace always starts a brace-alternative group in this grammar.
+      if (character === "}") {
+        throw invalidPattern(
+          this.fullPattern,
+          `contains an unmatched ${JSON.stringify(character)}`,
+        );
+      }
+
+      literal += character;
+      this.index++;
+    }
+
+    flushLiteral();
+    return { nodes };
+  }
+
+  private parseAlternatives(
+    closingCharacter: ")" | "}",
+    separator: "|" | ",",
+    depth: number,
+  ): GlobSequence[] {
+    if (depth > MAX_GLOB_NESTING) {
+      throw invalidPattern(
+        this.fullPattern,
+        `nests groups more than ${MAX_GLOB_NESTING} levels`,
+      );
+    }
+
+    const alternatives: GlobSequence[] = [];
+    const stops = new Set([separator, closingCharacter]);
+    while (true) {
+      alternatives.push(this.parseSequence(stops, depth));
+      this.alternativeCount++;
+      if (this.alternativeCount > MAX_GLOB_ALTERNATIVES) {
+        throw invalidPattern(
+          this.fullPattern,
+          `contains more than ${MAX_GLOB_ALTERNATIVES} alternatives`,
+        );
+      }
+
+      const character = this.segment[this.index];
+      if (character === closingCharacter) {
+        this.index++;
+        return alternatives;
+      }
+      if (character !== separator) {
+        throw invalidPattern(
+          this.fullPattern,
+          `contains an unclosed ${closingCharacter === ")" ? "extended group" : "brace group"}`,
+        );
+      }
+      this.index++;
+    }
+  }
+
+  private parseCharacterClass(): GlobNode {
+    this.index++;
+    let negated = false;
+    if (this.segment[this.index] === "!") {
+      negated = true;
+      this.index++;
+    }
+
+    const atoms: CharacterClassAtom[] = [];
+    while (this.index < this.segment.length && this.segment[this.index] !== "]") {
+      const atom = this.parseCharacterClassAtom();
+      if (
+        atom.kind === "character" &&
+        this.segment[this.index] === "-" &&
+        this.segment[this.index + 1] !== "]" &&
+        this.segment[this.index + 1] !== undefined
+      ) {
+        this.index++;
+        const end = this.parseCharacterClassAtom();
+        if (end.kind !== "character") {
+          throw invalidPattern(this.fullPattern, "uses a character class as a range endpoint");
+        }
+        const startCode = atom.value.charCodeAt(0);
+        const endCode = end.value.charCodeAt(0);
+        if (startCode > endCode) {
+          throw invalidPattern(this.fullPattern, "contains a descending character range");
+        }
+        atoms.push({ kind: "range", start: startCode, end: endCode });
+      } else {
+        atoms.push(atom);
+      }
+    }
+
+    if (this.segment[this.index] !== "]") {
+      throw invalidPattern(this.fullPattern, "contains an unclosed character class");
+    }
+    this.index++;
+    if (atoms.length === 0) {
+      throw invalidPattern(this.fullPattern, "contains an empty character class");
+    }
+    return this.addNode({ kind: "character-class", negated, atoms });
+  }
+
+  private parseCharacterClassAtom(): CharacterClassAtom {
+    if (
+      this.segment[this.index] === "[" &&
+      this.segment[this.index + 1] === ":"
+    ) {
+      const close = this.segment.indexOf(":]", this.index + 2);
+      if (close === -1) {
+        throw invalidPattern(this.fullPattern, "contains an unclosed POSIX character class");
+      }
+      const name = this.segment.slice(this.index + 2, close);
+      if (!isPosixCharacterClass(name)) {
+        throw invalidPattern(
+          this.fullPattern,
+          `contains unsupported POSIX character class ${JSON.stringify(name)}`,
+        );
+      }
+      this.index = close + 2;
+      return { kind: "posix", name };
+    }
+
+    let value = this.segment[this.index];
+    if (value === "\\") {
+      value = this.segment[this.index + 1];
+      if (value === undefined) {
+        throw invalidPattern(this.fullPattern, "ends with an incomplete character-class escape");
+      }
+      this.index += 2;
+    } else {
+      this.index++;
+    }
+    return { kind: "character", value: value! };
+  }
+}
+
+function isPosixCharacterClass(value: string): value is PosixCharacterClass {
+  return value === "alnum" || value === "alpha" || value === "ascii" ||
+    value === "blank" || value === "cntrl" || value === "digit" ||
+    value === "graph" || value === "lower" || value === "print" ||
+    value === "punct" || value === "space" || value === "upper" ||
+    value === "word" || value === "xdigit";
+}
+
+function matchesPosixClass(character: string, name: PosixCharacterClass): boolean {
+  const code = character.charCodeAt(0);
+  switch (name) {
+    case "alnum":
+      return code >= 0x30 && code <= 0x39 || code >= 0x41 && code <= 0x5a ||
+        code >= 0x61 && code <= 0x7a;
+    case "alpha":
+      return code >= 0x41 && code <= 0x5a || code >= 0x61 && code <= 0x7a;
+    case "ascii":
+      return code <= 0x7f;
+    case "blank":
+      return character === " " || character === "\t";
+    case "cntrl":
+      return code <= 0x1f || code === 0x7f;
+    case "digit":
+      return code >= 0x30 && code <= 0x39;
+    case "graph":
+      return code >= 0x21 && code <= 0x7e;
+    case "lower":
+      return code >= 0x61 && code <= 0x7a;
+    case "print":
+      return code >= 0x20 && code <= 0x7e;
+    case "punct":
+      return code >= 0x21 && code <= 0x2f || code >= 0x3a && code <= 0x40 ||
+        code >= 0x5b && code <= 0x60 || code >= 0x7b && code <= 0x7e;
+    case "space":
+      return character === " " || character === "\t" || character === "\n" ||
+        character === "\r" || character === "\v" || character === "\f";
+    case "upper":
+      return code >= 0x41 && code <= 0x5a;
+    case "word":
+      return code >= 0x30 && code <= 0x39 || code >= 0x41 && code <= 0x5a ||
+        code >= 0x61 && code <= 0x7a || character === "_";
+    case "xdigit":
+      return code >= 0x30 && code <= 0x39 || code >= 0x41 && code <= 0x46 ||
+        code >= 0x61 && code <= 0x66;
+  }
+}
+
+function compileSegment(segment: string, pattern: string): CompiledSegment {
+  const sequence = new SegmentParser(segment, pattern).parse();
+  const literalValue = sequence.nodes.every((node) => node.kind === "literal")
+    ? sequence.nodes.map((node) => node.value).join("")
+    : undefined;
+
+  return {
+    literalValue,
+    matches(value: string, budget: MatchBudget): boolean {
+      const sequenceMemo = new WeakMap<GlobSequence, Map<number, ReadonlySet<number>>>();
+      const nodeMemo = new WeakMap<GlobNode, Map<number, ReadonlySet<number>>>();
+
+      const evaluateAlternatives = (
+        alternatives: readonly GlobSequence[],
+        start: number,
+      ): Set<number> => {
+        const ends = new Set<number>();
+        for (const alternative of alternatives) {
+          budget.consume();
+          for (const end of evaluateSequence(alternative, start)) ends.add(end);
+        }
+        return ends;
+      };
+
+      const evaluateNode = (node: GlobNode, start: number): ReadonlySet<number> => {
+        budget.consume();
+        let starts = nodeMemo.get(node);
+        if (!starts) {
+          starts = new Map();
+          nodeMemo.set(node, starts);
+        }
+        const cached = starts.get(start);
+        if (cached) return cached;
+
+        const ends = new Set<number>();
+        switch (node.kind) {
+          case "literal":
+            if (value.startsWith(node.value, start)) ends.add(start + node.value.length);
+            break;
+          case "any-character":
+            if (start < value.length) ends.add(start + 1);
+            break;
+          case "any-characters":
+            budget.consume(value.length - start + 1);
+            for (let end = start; end <= value.length; end++) ends.add(end);
+            break;
+          case "character-class": {
+            if (start >= value.length) break;
+            const character = value[start]!;
+            const code = character.charCodeAt(0);
+            budget.consume(node.atoms.length);
+            const included = node.atoms.some((atom) => {
+              if (atom.kind === "character") return atom.value === character;
+              if (atom.kind === "range") return code >= atom.start && code <= atom.end;
+              return matchesPosixClass(character, atom.name);
+            });
+            if (included !== node.negated) ends.add(start + 1);
+            break;
+          }
+          case "alternatives":
+            for (const end of evaluateAlternatives(node.alternatives, start)) ends.add(end);
+            break;
+          case "negative": {
+            const excluded = evaluateAlternatives(node.alternatives, start);
+            budget.consume(value.length - start + 1);
+            for (let end = start; end <= value.length; end++) {
+              if (!excluded.has(end)) ends.add(end);
+            }
+            break;
+          }
+          case "repeat": {
+            if (node.maximum === 1) {
+              ends.add(start);
+              for (const end of evaluateAlternatives(node.alternatives, start)) ends.add(end);
+              break;
+            }
+
+            const pending: number[] = [];
+            if (node.minimum === 0) {
+              ends.add(start);
+              pending.push(start);
+            } else {
+              for (const end of evaluateAlternatives(node.alternatives, start)) {
+                budget.consume();
+                if (ends.has(end)) continue;
+                ends.add(end);
+                pending.push(end);
+              }
+            }
+            for (let index = 0; index < pending.length; index++) {
+              budget.consume();
+              for (const end of evaluateAlternatives(node.alternatives, pending[index]!)) {
+                if (ends.has(end)) continue;
+                ends.add(end);
+                pending.push(end);
+              }
+            }
+            break;
+          }
+        }
+
+        starts.set(start, ends);
+        return ends;
+      };
+
+      const evaluateSequence = (
+        current: GlobSequence,
+        start: number,
+      ): ReadonlySet<number> => {
+        budget.consume();
+        let starts = sequenceMemo.get(current);
+        if (!starts) {
+          starts = new Map();
+          sequenceMemo.set(current, starts);
+        }
+        const cached = starts.get(start);
+        if (cached) return cached;
+
+        let positions = new Set([start]);
+        for (const node of current.nodes) {
+          const nextPositions = new Set<number>();
+          for (const position of positions) {
+            budget.consume();
+            for (const end of evaluateNode(node, position)) nextPositions.add(end);
+          }
+          positions = nextPositions;
+          if (positions.size === 0) break;
+        }
+        starts.set(start, positions);
+        return positions;
+      };
+
+      return evaluateSequence(sequence, 0).has(value.length);
+    },
+  };
+}
+
+function normalizePattern(value: string): { absolute: boolean; segments: string[] } {
+  return {
+    absolute: value.startsWith("/"),
+    // Repeated and trailing separators have no matching significance.
+    segments: value.split("/").filter((segment) => segment.length > 0),
+  };
+}
+
+function normalizeCandidatePath(value: string): { absolute: boolean; segments: string[] } {
+  const portable = value.replaceAll("\\", "/");
+  return {
+    absolute: portable.startsWith("/"),
+    // Repeated and trailing separators have no matching significance.
+    segments: portable.split("/").filter((segment) => segment.length > 0),
+  };
+}
+
+/**
+ * Compile a bounded, dependency-free path glob.
+ *
+ * `*` and `?` stay within one path segment. A segment containing only `**`
+ * matches zero or more complete segments. Brace alternatives, character
+ * classes, POSIX character classes, and Bash-style extended groups are
+ * supported. Backslash escapes the following pattern character. Candidates
+ * accept either slash style and matching is always anchored to the full path.
+ */
+export function compilePathGlob(pattern: string): PathGlobMatcher {
+  requireSafeGlobText(pattern, "Path glob pattern");
+  const normalizedPattern = normalizePattern(pattern);
+  const compiledSegments: CompiledPathSegment[] = normalizedPattern.segments.map(
+    (segment) => segment === "**" ? "globstar" : compileSegment(segment, pattern),
+  );
+  const staticPrefixSegments: string[] = [];
+  for (const segment of compiledSegments) {
+    if (segment === "globstar" || segment.literalValue === undefined) break;
+    staticPrefixSegments.push(segment.literalValue);
+  }
+
+  const test = (path: string): boolean => {
+    requireSafeGlobText(path, "Path glob candidate");
+    const candidate = normalizeCandidatePath(path);
+    if (candidate.absolute !== normalizedPattern.absolute) return false;
+    const budget = createMatchBudget(pattern);
+    let reachablePathIndexes = new Set([0]);
+
+    for (const segment of compiledSegments) {
+      budget.consume();
+      if (segment === "globstar") {
+        let firstReachable = candidate.segments.length + 1;
+        for (const pathIndex of reachablePathIndexes) {
+          if (pathIndex < firstReachable) firstReachable = pathIndex;
+        }
+        reachablePathIndexes = new Set<number>();
+        budget.consume(candidate.segments.length - firstReachable + 1);
+        for (
+          let pathIndex = firstReachable;
+          pathIndex <= candidate.segments.length;
+          pathIndex++
+        ) {
+          reachablePathIndexes.add(pathIndex);
+        }
+        continue;
+      }
+
+      const nextReachablePathIndexes = new Set<number>();
+      for (const pathIndex of reachablePathIndexes) {
+        budget.consume();
+        if (
+          pathIndex < candidate.segments.length &&
+          segment.matches(candidate.segments[pathIndex]!, budget)
+        ) {
+          nextReachablePathIndexes.add(pathIndex + 1);
+        }
+      }
+      reachablePathIndexes = nextReachablePathIndexes;
+      if (reachablePathIndexes.size === 0) return false;
+    }
+
+    return reachablePathIndexes.has(candidate.segments.length);
+  };
+
+  return Object.freeze({
+    pattern,
+    staticPrefixSegments: Object.freeze(staticPrefixSegments),
+    segmentCount: compiledSegments.length,
+    test,
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the CSS discovery path matcher with a bounded dependency-free core glob compiler.

- supports braces, extglobs, character/POSIX classes, globstar, escapes, absolute paths, and platform separators
- derives static scan prefixes without widening filesystem traversal
- enforces parser, node, alternative, operation, and path-length budgets
- removes the core `@std/path` glob matcher dependency from CSS discovery

The incomplete cache-scope recovery was deliberately excluded because its invalidation consumer belongs with the registry extraction.

## Validation

- `deno task typecheck`
- focused format and lint
- module-boundary check
- focused glob/CSS tests: 38 steps
- full build/cache runtime tests: 180 suites / 1,371 steps
- zero third-party runtime dependencies
- `git diff --check`