### PR TITLE
fix(modules): bound module fetch and transform admission

### DIFF
--- a/src/modules/LOADER_GUIDE.md
+++ b/src/modules/LOADER_GUIDE.md
@@ -1,149 +1,181 @@
-# Module Loader Selection Guide
+# Choose a module loader
 
-This guide helps you choose the right module loader for your use case.
+Veryfront has several module loaders because they admit different inputs and
+produce different outputs. Choose the loader by boundary; they are not
+interchangeable convenience wrappers.
 
-## Quick Reference
+## Quick reference
 
-| Loader              | Location                                  | Use Case                                 |
-| ------------------- | ----------------------------------------- | ---------------------------------------- |
-| esm-module-loader   | `transforms/mdx/esm-module-loader/`       | MDX content, frontmatter, JSX transforms |
-| ssr-module-loader   | `modules/react-loader/ssr-module-loader/` | React SSR, distributed caching           |
-| orchestrator loader | `rendering/orchestrator/module-loader/`   | Render pipeline, ESM rewriting           |
-| API loader          | `routing/api/module-loader/`              | API routes, HTTP imports, security       |
+| Input and desired result                         | Entry point               | Location                                   |
+| ------------------------------------------------ | ------------------------- | ------------------------------------------ |
+| One source string to a React component           | `loadComponentFromSource` | `modules/react-loader/component-loader.ts` |
+| One source string to its complete module exports | `loadModuleFromSource`    | `modules/react-loader/component-loader.ts` |
+| A bounded batch of named component sources       | `loadComponentsUnified`   | `modules/react-loader/unified-loader.ts`   |
+| A project file/source graph for SSR              | `SSRModuleLoader`         | `modules/react-loader/ssr-module-loader/`  |
+| A compiled MDX program                           | `loadModuleESM`           | `transforms/mdx/esm-module-loader/`        |
+| A render-orchestrator file and dependency graph  | `loadModule`              | `rendering/orchestrator/module-loader/`    |
+| An API route handler file                        | `loadHandlerModule`       | `routing/api/module-loader/`               |
+| An HTTP request for `/_vf_modules/*`             | `serveModule`             | `modules/server/`                          |
 
-## Decision Tree
+## Decision guide
 
-```
-Loading MDX content?
-├─ Yes → esm-module-loader
-│   - Handles frontmatter extraction
-│   - JSX runtime loading
-│   - Component resolution
-│
-└─ No
-   ├─ React SSR with caching?
-   │  └─ Yes → ssr-module-loader
-   │      - Multi-layer caching (memory + disk)
-   │      - Import rewriting for cross-project
-   │      - Environment-specific strategies
-   │
-   ├─ In render pipeline?
-   │  └─ Yes → orchestrator/module-loader
-   │      - ESM rewriting for external modules
-   │      - Render context integration
-   │
-   └─ API route handlers?
-      └─ Yes → routing/api/module-loader
-          - Direct import strategy
-          - Transpilation fallback
-          - HTTP import security
-```
+1. If the input is an HTTP request for a browser or SSR module URL, use
+   `serveModule`. It owns request classification, containment, response
+   headers, and module transformation.
+2. If the input is an API route file, use `loadHandlerModule`. It owns API
+   handler extraction, HTTP-import policy, external dependency preparation,
+   and direct host-process loading. The higher-level API request handler uses
+   the separate preparation path when worker isolation is available.
+3. If the input is compiled MDX program text, use `loadModuleESM`. It owns MDX
+   metadata/component wiring and the MDX ESM cache.
+4. If rendering needs to load a project file and recursively transform its
+   dependencies, use the render orchestrator's `loadModule`.
+5. If application code already has a source string:
+   - use `loadComponentFromSource` when only the React component is needed;
+   - use `loadModuleFromSource` when named exports are also needed;
+   - use `loadComponentsUnified` for a bounded collection that should be
+     transformed and imported together.
+6. Use `SSRModuleLoader` directly only when the caller owns the SSR project,
+   content-source, adapter, and import-map identities. Most hosted request
+   paths reach it through a higher-level loader.
 
-## Shared Patterns
+## Loader contracts
 
-Import from `#veryfront/modules/loader-shared/patterns.ts`:
+### Source component loaders
 
 ```typescript
 import {
-  MODULE_EXTENSIONS, // [".tsx", ".ts", ".jsx", ".js", ".mdx"]
-  PROJECT_ALIAS_IMPORT_PATTERN, // @/ alias imports
-  REACT_IMPORT_PATTERN, // React detection
-  RELATIVE_IMPORT_PATTERN, // ./path imports
-  VF_MODULE_IMPORT_PATTERN, // /_vf_modules/ imports
-} from "#veryfront/modules/loader-shared/patterns.ts";
+  loadComponentFromSource,
+  loadModuleFromSource,
+} from "#veryfront/modules/react-loader/index.ts";
 ```
 
-## Loader Details
+Both functions require source code, its logical file path, the project root,
+and a `RuntimeAdapter`. `loadComponentFromSource` validates and returns a React
+component export; `loadModuleFromSource` returns the module namespace.
 
-### esm-module-loader
+Set `ssr: true` for server execution. In hosted code, also pass stable
+`projectId`, `contentSourceId`, React version, and the request-bound import map
+when it is already available.
 
-**Location:** `src/transforms/mdx/esm-module-loader/`
+`loadComponentsUnified` is for an in-memory batch. It validates the batch,
+bounds aggregate input/output, limits transform and write concurrency,
+materializes a temporary entry module, imports it, and cleans up its owned
+temporary directory.
 
-**Purpose:** Primary loader for MDX content with ESM module support.
-
-**Key Features:**
-
-- Module caching with multi-layer validation
-- Alias import transformation (@/ → absolute paths)
-- JSX file import handling
-- Stub module generation for missing dependencies
-- Framework bundle loading
-
-**Entry Point:** `loadModuleESM()`
-
-**Sub-modules:**
-
-- `metadata/` - Frontmatter and metadata extraction
-- `components/` - Component import resolution
-- `jsx/` - JSX runtime loading
-- `cache/` - Multi-layer caching
-- `transforms/` - Import transformations
-- `resolution/` - File finding utilities
-
-### ssr-module-loader
-
-**Location:** `src/modules/react-loader/ssr-module-loader/`
-
-**Purpose:** React SSR with distributed caching support.
-
-**Key Features:**
-
-- Memory + disk caching layers
-- Cross-project import rewriting
-- Environment-specific loading strategies (Deno vs Node)
-- Lockfile integrity verification
-
-**Entry Point:** `SSRModuleLoader` class
-
-### orchestrator/module-loader
-
-**Location:** `src/rendering/orchestrator/module-loader/`
-
-**Purpose:** Render pipeline integration.
-
-**Key Features:**
-
-- ESM rewriting for external modules
-- CDN URL resolution
-- Render context integration
-
-**Entry Point:** `ESMRewriter` class
-
-### API module-loader
-
-**Location:** `src/routing/api/module-loader/`
-
-**Purpose:** API route handler loading.
-
-**Key Features:**
-
-- Direct import strategy (fastest)
-- Transpilation fallback
-- HTTP import security controls
-
-**Entry Point:** `loadModule()`
-
-## Migration Notes
-
-Legacy helper files under `module-loader/` were removed.
-Use `esm-module-loader/` imports directly.
-
-### Removed Legacy Paths
-
-The following old imports were removed and must be replaced:
-
-| Function                  | Old Location                          | New Location                                  |
-| ------------------------- | ------------------------------------- | --------------------------------------------- |
-| `extractFrontmatter`      | `module-loader/metadata-extractor.ts` | `esm-module-loader/metadata/extractor.ts`     |
-| `extractMetadata`         | `module-loader/metadata-extractor.ts` | `esm-module-loader/metadata/extractor.ts`     |
-| `mergeFrontmatter`        | `module-loader/metadata-extractor.ts` | `esm-module-loader/metadata/extractor.ts`     |
-| `extractBalancedBlock`    | `module-loader/string-parser.ts`      | `esm-module-loader/metadata/string-parser.ts` |
-| `cleanModuleCode`         | `module-loader/string-parser.ts`      | `esm-module-loader/metadata/string-parser.ts` |
-| `parseJsonish`            | `module-loader/string-parser.ts`      | `esm-module-loader/metadata/string-parser.ts` |
-| `extractComponentImports` | `module-loader/component-resolver.ts` | `esm-module-loader/components/resolver.ts`    |
-| `resolveComponents`       | `module-loader/component-resolver.ts` | `esm-module-loader/components/resolver.ts`    |
-| `loadJSXRuntime`          | `module-loader/jsx-runtime-loader.ts` | `esm-module-loader/jsx/runtime-loader.ts`     |
+### SSR module loader
 
 ```typescript
-import { extractFrontmatter } from "./esm-module-loader/metadata/index.ts";
+import {
+  createSSRImportMapIdentity,
+  SSRModuleLoader,
+} from "#veryfront/modules/react-loader/ssr-module-loader/index.ts";
 ```
+
+`SSRModuleLoader` transforms local and cross-project dependency graphs for
+server execution. Its reusable caches include:
+
+- bounded process memory;
+- content-hashed files under project/content-source cache directories;
+- an optional distributed cache when explicitly initialized.
+
+For hosted work, construct `importMapIdentity` from the immutable map resolved
+for that exact project and content source. Omitting it is reserved for
+standalone callers that intentionally accept ambient import-map resolution.
+
+The loader fails when a required static dependency, transform, cache
+validation, or capacity acquisition fails. Dynamic dependencies may be left
+for runtime resolution when they are not required by the current execution
+path.
+
+### MDX ESM loader
+
+```typescript
+import {
+  type ESMLoaderContext,
+  loadModuleESM,
+} from "#veryfront/transforms/mdx/esm-module-loader/index.ts";
+```
+
+Use this after MDX has been compiled to an ESM program. The loader resolves MDX
+component imports, prepares the JSX runtime, materializes module dependencies,
+and returns an `MDXModule`.
+
+`strictMissingModules` defaults to `true`. Setting it to `false` enables the
+legacy missing-module/stub behavior and should only be done by a trusted caller
+that deliberately accepts incomplete output; it is not a generic recovery
+mode.
+
+### Render-orchestrator loader
+
+```typescript
+import {
+  loadModule,
+  type ModuleLoaderConfig,
+} from "#veryfront/rendering/orchestrator/module-loader/index.ts";
+```
+
+This loader recursively transforms a render dependency graph, persists
+content-addressed artifacts, and imports the resulting root module. The caller
+provides request-scoped caches, adapter, project root, mode, and optional
+cooperative cancellation/progress hooks.
+
+Do not call it for API handlers or raw browser module requests. Those
+boundaries have different security and response contracts.
+
+### API route loader
+
+```typescript
+import {
+  loadHandlerModule,
+  type LoadModuleOptions,
+} from "#veryfront/routing/api/module-loader/index.ts";
+```
+
+This loader validates that the route module stays inside the project, prepares
+its dependency graph for the active runtime, enforces configured remote-import
+hosts, imports it in the host process, and returns the supported HTTP method
+handlers. A loaded module with no supported handler exports returns `null`;
+missing files and build, validation, or execution failures are surfaced as API
+errors. Hosted request handling may instead prepare the route for worker
+execution; do not infer worker isolation from a direct `loadHandlerModule`
+call.
+
+### HTTP module server
+
+```typescript
+import { type ModuleServerOptions, serveModule } from "#veryfront/modules/server/index.ts";
+```
+
+`serveModule` handles canonical and legacy module URL prefixes, snippet
+modules, cross-project modules, SSR query identities, release-aware response
+caching, and HEAD response semantics. Hosted callers should supply a validated
+request-bound `importMapIdentity` and the project/source identities used by
+their filesystem adapter.
+
+## Shared patterns
+
+`#veryfront/modules/loader-shared/index.ts` exports path-validation helpers and
+legacy import regexes. The regexes are suitable only for their documented,
+bounded compatibility call sites. They do not parse JavaScript and must not be
+used for new general source rewriting.
+
+Use the module lexer/import-rewriter primitives under `transforms/` when an edit
+must distinguish real imports and exports from comments, strings, templates,
+or regular expressions.
+
+## Migration reference
+
+The former `module-loader/` MDX helper paths were consolidated under
+`transforms/mdx/esm-module-loader/`:
+
+| API                                                         | Current location                              |
+| ----------------------------------------------------------- | --------------------------------------------- |
+| `extractFrontmatter`, `extractMetadata`, `mergeFrontmatter` | `esm-module-loader/metadata/index.ts`         |
+| `extractBalancedBlock`, `cleanModuleCode`, `parseJsonish`   | `esm-module-loader/metadata/string-parser.ts` |
+| `extractComponentImports`, `resolveComponents`              | `esm-module-loader/components/resolver.ts`    |
+| `loadJSXRuntime`                                            | `esm-module-loader/jsx/runtime-loader.ts`     |
+
+Import these APIs through
+`#veryfront/transforms/mdx/esm-module-loader/index.ts` where they are exported,
+rather than recreating the removed legacy path.

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -1,372 +1,211 @@
-# Modules System
+# Modules
 
-## Purpose
+`src/modules` owns Veryfront's project-module boundary: component source
+discovery, import-map resolution, source-to-module loading, SSR module caching,
+browser module serving, and route module manifests.
 
-The modules system handles dynamic module loading, resolution, and React component discovery in Veryfront. It provides import map management, component registry, and module transformation for seamless integration of user code with the framework.
-
-## Scope
-
-### What this module does:
-
-- Load and resolve React components dynamically
-- Manage import map configuration
-- Register and track loaded components
-- Transform module paths for different environments
-- Handle JSX/TSX compilation on-the-fly
-- Resolve npm packages via CDN (esm.sh)
-- Support both file-based and in-memory modules
-
-### What this module does NOT do:
-
-- Build-time bundling (see `build/`)
-- Static analysis (see `rendering/`)
-- HTTP serving (see `server/`)
+It does not own the complete transform pipeline, MDX compilation, render
+orchestration, API-route execution, or production bundling. Those concerns live
+under `transforms/`, `rendering/`, `routing/`, and `build/`.
 
 ## Architecture
 
-```
-modules/
-├── index.ts                # Public API exports
-├── module-resolver.ts      # Main module resolution logic
-├── component-registry/     # Component tracking
-│   ├── index.ts
-│   ├── registry.ts         # Component registration
-│   └── types.ts
-├── import-map/             # Import map management
-│   ├── index.ts
-│   ├── loader.ts           # Load import maps
-│   ├── merger.ts           # Merge multiple maps
-│   ├── resolver.ts         # Resolve imports
-│   ├── transformer.ts      # Transform paths
-│   ├── default-import-map.ts
-│   └── types.ts
-└── react-loader/           # React component loading
-    ├── index.ts
-    ├── unified-loader.ts   # Main component loader
-    ├── component-loader.ts # Load individual components
-    ├── path-resolver.ts    # Resolve component paths
-    ├── temp-directory.ts   # Temp file handling
-    └── types.ts
-```
+| Area                              | Responsibility                                                                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `component-registry/`             | Discover `.tsx` and `.jsx` component sources, retain immutable metadata, and load source text through a runtime adapter. |
+| `import-map/`                     | Load, validate, merge, snapshot, resolve, and apply project import maps.                                                 |
+| `module-resolver.ts`              | Resolve virtual, local, external, and npm module identities while containing filesystem access to a project root.        |
+| `react-loader/`                   | Transform source strings into executable React modules or materialize a bounded batch of components.                     |
+| `react-loader/ssr-module-loader/` | Transform dependency graphs for SSR and manage memory, disk, and optional distributed caches.                            |
+| `server/`                         | Classify and serve browser/SSR module requests, data requests, and WebSocket traffic.                                    |
+| `manifest/`                       | Track bounded route dependency graphs and generate escaped module-preload hints.                                         |
+| `loader-shared/`                  | Shared path validation and narrow compatibility patterns used by loader implementations.                                 |
 
-## Key Exports
+The normal hosted flow resolves an import-map snapshot for the authenticated
+project and content source, binds that snapshot to a cache identity, transforms
+the requested graph, and only then publishes reusable cache entries. Standalone
+callers may omit an identity where the relevant option explicitly permits
+ambient import-map resolution, but hosted request paths should not.
 
-### Module Resolution
+## Entry points
 
-- `ModuleResolver` - Main resolver class
-- `resolveModule(specifier, options)` - Resolve module path
+### Root API
 
-### Component Registry
+`#veryfront/modules` exports the stable, general-purpose surface:
 
-- `ComponentRegistry` - Track loaded components
-- `registerComponent(path, component)` - Register component
-- `getComponent(path)` - Retrieve component
-- `clearRegistry()` - Clear all components
+| Export                                                                         | Contract                                                                                                                             |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `ComponentRegistry`                                                            | Discovers and reads component source metadata. It does not compile discovered files or populate React exports automatically.         |
+| `ModuleResolver`                                                               | Resolves one specifier to a contained file, virtual module, external URL, or esm.sh npm URL. Missing or blocked paths return `null`. |
+| `loadImportMap`, `mergeImportMaps`, `resolveImport`, `transformImportsWithMap` | Import-map loading and resolution.                                                                                                   |
+| `loadComponentFromSource`                                                      | Transforms and imports one source string, returning its React component export.                                                      |
+| `loadComponentsUnified`                                                        | Transforms and imports a bounded batch of named component sources.                                                                   |
+| `clearSSRModuleCache`, `clearSSRModuleCacheForProject`                         | Explicit SSR cache invalidation.                                                                                                     |
+| Path and temp-directory helpers                                                | Module-path normalization and project-scoped materialization support.                                                                |
 
-### Import Map
+Consult [`index.ts`](./index.ts) for the exact root exports. The following
+specialized entry points are intentionally separate:
 
-- `loadImportMap(projectDir)` - Load import map config
-- `mergeImportMaps(maps)` - Merge multiple maps
-- `resolveImport(specifier, map)` - Resolve import specifier
-- `transformModulePath(path, options)` - Transform path
+| Entry point                                                  | Primary exports                                                                     |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `#veryfront/modules/import-map/index.ts`                     | Import-map identity creation and validation in addition to the root import-map API. |
+| `#veryfront/modules/react-loader/index.ts`                   | `loadModuleFromSource` and the React loader surface.                                |
+| `#veryfront/modules/react-loader/ssr-module-loader/index.ts` | `SSRModuleLoader`, SSR import-map identities, cache controls, and cache statistics. |
+| `#veryfront/modules/server/index.ts`                         | `serveModule`, `APIServer`, `RateLimiter`, and WebSocket lifecycle functions.       |
+| `#veryfront/modules/manifest/index.ts`                       | Route module collection, lookup, invalidation, and preload hints.                   |
+| `#veryfront/modules/loader-shared/index.ts`                  | Cross-project request validation and low-level compatibility patterns.              |
 
-### React Loader
+## Examples
 
-- `loadComponent(path, options)` - Load React component
-- `UnifiedComponentLoader` - Unified loading interface
-- `resolveComponentPath(path)` - Resolve component location
+### Resolve a project module
 
-## Dependencies
-
-### Internal
-
-- `core/utils` - Path utilities, logging
-- `core/config` - Configuration loading
-- `platform/` - File system adapters
-
-### External
-
-- `esbuild` - JSX/TSX compilation
-- `react` - React component loading
-
-## Usage Examples
-
-### Load React Component
+Every filesystem-facing API requires a runtime adapter. The caller owns the
+adapter and project identity.
 
 ```typescript
-import { loadComponent } from "#veryfront/modules";
+import { ModuleResolver } from "#veryfront/modules";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
-// Load a page component
-const PageComponent = await loadComponent("/pages/index.tsx", {
-  projectDir: "/path/to/project",
-  mode: "development",
-});
-
-// Load with custom import map
-const Component = await loadComponent("/components/Button.tsx", {
-  projectDir: "/path/to/project",
-  importMap: {
-    imports: {
-      "react": "https://esm.sh/react@18.3.1",
+export async function resolveButton(adapter: RuntimeAdapter) {
+  const resolver = new ModuleResolver({
+    projectDir: "/workspace/site",
+    adapter,
+    importMap: {
+      "analytics": "https://esm.sh/@example/analytics@1.2.3",
     },
-  },
-});
+  });
+
+  return await resolver.resolve(
+    "./Button",
+    "components/index.ts",
+  );
+}
 ```
 
-### Component Registry
+Relative and absolute project paths are checked lexically and, when the adapter
+supports `realPath`, canonically. A path that escapes the project through `..`
+or a symlink resolves to `null`.
+
+### Discover and read component source
 
 ```typescript
 import { ComponentRegistry } from "#veryfront/modules";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
-const registry = new ComponentRegistry();
+export async function readButtonSource(adapter: RuntimeAdapter) {
+  const registry = new ComponentRegistry({
+    projectDir: "/workspace/site",
+    adapter,
+    componentDirs: ["components", "islands"],
+  });
 
-// Register component
-await registry.registerComponent("/pages/index.tsx", IndexPage);
-
-// Retrieve component
-const Component = registry.getComponent("/pages/index.tsx");
-
-// Check if exists
-if (registry.has("/pages/about.tsx")) {
-  const AboutPage = registry.getComponent("/pages/about.tsx");
+  await registry.discover();
+  const button = await registry.loadComponent("Button");
+  return button?.content;
 }
-
-// Clear registry (useful for HMR)
-registry.clearRegistry();
 ```
 
-### Import Map Management
+Discovery ignores test/spec files, `node_modules`, directory indexes, and
+non-JSX/TSX files. Duplicate basenames are rejected because the registry key is
+the basename, not the relative path.
+
+### Load a component from source
+
+```typescript
+import { loadComponentFromSource } from "#veryfront/modules";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+export async function loadPage(
+  source: string,
+  adapter: RuntimeAdapter,
+) {
+  return await loadComponentFromSource(
+    source,
+    "/workspace/site/pages/index.tsx",
+    "/workspace/site",
+    adapter,
+    {
+      projectId: "project-uuid",
+      contentSourceId: "preview-main",
+      reactVersion: "19.1.1",
+      ssr: true,
+    },
+  );
+}
+```
+
+SSR loading resolves or accepts an import-map snapshot for the complete
+dependency graph. Browser loading transforms and materializes a content-hashed
+module before importing it.
+
+### Merge and resolve import maps
 
 ```typescript
 import { loadImportMap, mergeImportMaps, resolveImport } from "#veryfront/modules";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
-// Load project import map
-const projectMap = await loadImportMap("/path/to/project");
+export async function resolveReact(
+  adapter: RuntimeAdapter,
+) {
+  const projectMap = await loadImportMap("/workspace/site", adapter);
+  const overrides = {
+    imports: {
+      "@app/": "/_vf_modules/app/",
+    },
+  };
+  const importMap = mergeImportMaps(projectMap, overrides);
 
-// Merge with framework defaults
-const defaultMap = {
-  imports: {
-    "react": "https://esm.sh/react@18.3.1",
-    "react-dom": "https://esm.sh/react-dom@18.3.1",
-  },
-};
-const merged = mergeImportMaps([defaultMap, projectMap]);
-
-// Resolve import specifier
-const resolved = resolveImport("react", merged);
-// Result: 'https://esm.sh/react@18.3.1'
-
-const aliased = resolveImport("@/components/Button", merged);
-// Result: '/src/components/Button.tsx'
-```
-
-### Module Resolver
-
-```typescript
-import { ModuleResolver } from "#veryfront/modules";
-
-const resolver = new ModuleResolver({
-  projectDir: "/path/to/project",
-  importMap: customImportMap,
-});
-
-// Resolve relative import
-const resolved = await resolver.resolve("./Button", "/components/index.tsx");
-// Result: '/components/Button.tsx'
-
-// Resolve npm package
-const pkg = await resolver.resolve("lodash", "/pages/index.tsx");
-// Result: 'https://esm.sh/lodash@4.17.21'
-
-// Resolve with alias
-const aliased = await resolver.resolve("@/utils/helpers", "/pages/index.tsx");
-// Result: '/src/utils/helpers.ts'
-```
-
-### Transform Module Path
-
-```typescript
-import { transformModulePath } from "#veryfront/modules";
-
-// Transform for browser
-const browserPath = transformModulePath("/src/components/Button.tsx", {
-  mode: "browser",
-  baseUrl: "http://localhost:3000",
-});
-// Result: 'http://localhost:3000/src/components/Button.tsx'
-
-// Transform for build
-const buildPath = transformModulePath("/src/components/Button.tsx", {
-  mode: "build",
-  outDir: "./dist",
-});
-// Result: './dist/_veryfront/components/Button.js'
-```
-
-## Import Map Configuration
-
-### deno.json / import_map.json
-
-```json
-{
-  "imports": {
-    // Path aliases
-    "@/": "./src/",
-    "@components/": "./src/components/",
-    "@utils/": "./src/utils/",
-
-    // npm packages (via CDN)
-    "react": "https://esm.sh/react@18.3.1",
-    "react-dom": "https://esm.sh/react-dom@18.3.1",
-    "lodash": "https://esm.sh/lodash@4.17.21",
-
-    // Local packages
-    "~lib/": "./lib/",
-
-    // Specific remapping
-    "old-package": "./node_modules/new-package/index.js"
-  },
-  "scopes": {
-    "https://esm.sh/": {
-      "react": "https://esm.sh/react@18.3.1"
-    }
-  }
+  return resolveImport("@app/page.js", importMap);
 }
 ```
 
-## Module Resolution Algorithm
+`mergeImportMaps` accepts maps as separate arguments. Later maps win for exact
+keys, while scoped maps are merged per scope. `loadImportMap` applies framework
+defaults, project `deno.json`, and Veryfront configuration in that order and
+then enforces the framework React mappings.
 
-1. **Check Import Map Imports**
-   - Exact match in `imports`
-   - Prefix match for paths ending with `/`
+## Operational contracts
 
-2. **Check Import Map Scopes**
-   - Match based on parent URL
-   - Apply scoped imports
+- Project and cross-project paths are bounded and must remain inside their
+  admitted roots. Encoded separators, traversal, and canonical symlink escapes
+  are rejected at their respective request boundaries.
+- Hosted module requests should carry the request-bound import-map identity.
+  Cache entries are scoped by the identities that can change transformed
+  output.
+- Component, manifest, lookup, response, and transform caches are bounded.
+  Use the exported project-specific invalidation functions when project content
+  changes.
+- Missing project files generally return `null` or a not-found response.
+  Malformed identities, unsafe paths, invalid source, and operational adapter
+  failures are not converted into alternate dependency graphs.
+- The regex constants in `loader-shared/patterns.ts` exist for narrow legacy
+  consumers. New source rewrites should use the module lexer/import-rewriter
+  primitives so comments and strings cannot be mistaken for imports.
 
-3. **Relative Path Resolution**
-   - Resolve `./` and `../` relative to parent
-   - Add file extensions if missing
+For guidance on selecting between the source, SSR, MDX, render, API, and HTTP
+loaders, see [`LOADER_GUIDE.md`](./LOADER_GUIDE.md).
 
-4. **Bare Specifier Resolution**
-   - Check node_modules (Node.js)
-   - Check npm: URLs (Deno)
-   - Fallback to esm.sh CDN
+## Verification
 
-5. **File System Check**
-   - Try with extensions: `.ts`, `.tsx`, `.js`, `.jsx`
-   - Try index files: `index.ts`, `index.tsx`
-
-## Performance
-
-### Component Loading
-
-- First load: ~10-20ms (includes compilation)
-- Cached load: ~1-2ms (from registry)
-- Memory usage: ~50KB per component
-
-### Import Map Resolution
-
-- Resolution: <1ms (hash map lookup)
-- Merge: ~2ms per map
-- Transform: ~0.5ms per path
-
-### Registry
-
-- Registration: O(1)
-- Lookup: O(1)
-- Memory: ~10KB overhead + components
-
-## Testing
+The repository's canonical tasks are:
 
 ```bash
-# Run all module tests
-deno task test src/modules/
-
-# Test component registry
-deno task test src/modules/component-registry/
-
-# Test import maps
-deno task test src/modules/import-map/
-
-# Test React loader
-deno task test src/modules/react-loader/
+deno task test:unit
+deno task lint
+deno task fmt:check
+deno task lint:module-boundaries
 ```
 
-## Related Modules
+During focused development, run the relevant files under `src/modules` with
+the same preload, environment, and permissions used by the `test` task. Do not
+omit the broader unit gate before merging a loader or cache change.
 
-- [`rendering/`](../rendering/README.md) - Uses modules for component loading
-- [`build/`](../build/README.md) - Bundles modules for production
-- [`platform/`](../platform/README.md) - File system access
-- [`config/`](../config/README.md) - Configuration management
+## Related areas
 
-## Troubleshooting
-
-### Module Not Found
-
-```typescript
-// Enable verbose logging
-import { ModuleResolver } from "#veryfront/modules";
-import { logger } from "#veryfront/utils";
-
-logger.level = "debug";
-
-const resolver = new ModuleResolver({ projectDir });
-try {
-  const resolved = await resolver.resolve("./Button", parent);
-} catch (error) {
-  console.error("Resolution failed:", error);
-  console.error("Search paths:", resolver.getSearchPaths());
-}
-```
-
-### Import Map Not Applied
-
-```typescript
-// Verify import map loaded correctly
-import { loadImportMap } from "#veryfront/modules";
-
-const map = await loadImportMap(projectDir);
-console.log("Loaded import map:", map);
-
-// Check for syntax errors in import_map.json
-```
-
-### Component Registry Stale
-
-```typescript
-// Clear registry on file changes (HMR)
-import { ComponentRegistry } from "#veryfront/modules";
-
-const registry = ComponentRegistry.getInstance();
-
-// On file change
-registry.remove("/components/Button.tsx");
-// Or clear all
-registry.clearRegistry();
-```
-
-### JSX Compilation Errors
-
-```typescript
-// Check esbuild configuration
-import { loadComponent } from "#veryfront/modules";
-
-try {
-  const Component = await loadComponent(path, {
-    projectDir,
-    jsx: "react-jsx", // or 'react' for classic runtime
-    jsxImportSource: "react",
-  });
-} catch (error) {
-  console.error("Compilation failed:", error);
-}
-```
-
-## Maintainer Notes
-
-**Team:** Core Infrastructure Team
-**Stability:** Stable (v0.1.0+)
-**Performance Critical:** Yes (runs on every page render)
-
-This module is critical for dynamic loading - optimize for speed and caching.
+- [`build/`](../build/README.md) — production compilation and artifacts
+- [`config/`](../config/README.md) — project configuration
+- [`platform/`](../platform/README.md) — runtime adapters and filesystem
+  contracts
+- [`rendering/`](../rendering/README.md) — render orchestration
+- [`routing/`](../routing/README.md) — API and application routes
+- [`transforms/`](../transforms/README.md) — source transformation pipelines

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -202,10 +202,10 @@ omit the broader unit gate before merging a loader or cache change.
 
 ## Related areas
 
-- [`build/`](../build/README.md) — production compilation and artifacts
-- [`config/`](../config/README.md) — project configuration
-- [`platform/`](../platform/README.md) — runtime adapters and filesystem
+- [`build/`](../build/README.md): production compilation and artifacts
+- [`config/`](../config/README.md): project configuration
+- [`platform/`](../platform/README.md): runtime adapters and filesystem
   contracts
-- [`rendering/`](../rendering/README.md) — render orchestration
-- [`routing/`](../routing/README.md) — API and application routes
-- [`transforms/`](../transforms/README.md) — source transformation pipelines
+- [`rendering/`](../rendering/README.md): render orchestration
+- [`routing/`](../routing/README.md): API and application routes
+- [`transforms/`](../transforms/README.md): source transformation pipelines

--- a/src/modules/server/classify.test.ts
+++ b/src/modules/server/classify.test.ts
@@ -55,10 +55,24 @@ describe("classifyModuleRequest", () => {
       }
     });
 
-    it("does NOT classify _snippets path without .js extension as snippet", () => {
-      // Falls through to dev-module since DEV_MODULE_PREFIX matches
-      const result = classifyModuleRequest(url("/_vf_modules/_snippets/abc123.ts"));
-      assertEquals(result.kind, "dev-module");
+    it("rejects a reserved snippet path without a .js extension", () => {
+      for (
+        const pathname of [
+          "/_vf_modules/_snippets",
+          "/_vf_modules/_snippets/abc123.ts",
+        ]
+      ) {
+        assertEquals(classifyModuleRequest(url(pathname)), {
+          kind: "invalid-module",
+          namespace: "snippet",
+        });
+      }
+    });
+    it("rejects trailing content after the snippet module", () => {
+      const result = classifyModuleRequest(
+        url("/_vf_modules/_snippets/abc123.js/extra"),
+      );
+      assertEquals(result, { kind: "invalid-module", namespace: "snippet" });
     });
   });
 
@@ -115,6 +129,22 @@ describe("classifyModuleRequest", () => {
       assertEquals(result.kind, "cross-project-latest");
       if (result.kind === "cross-project-latest") {
         assertEquals(result.path, "a/b/c/deep.js");
+      }
+    });
+
+    it("rejects malformed requests in the reserved cross-project namespace", () => {
+      for (
+        const pathname of [
+          "/_vf_modules/_cross",
+          "/_vf_modules/_cross/demo_project/@/index.js",
+          "/_vf_modules/_cross/demo@not-semver/@/index.js",
+          "/_vf_modules/_cross/demo/@/",
+        ]
+      ) {
+        assertEquals(classifyModuleRequest(url(pathname)), {
+          kind: "invalid-module",
+          namespace: "cross-project",
+        });
       }
     });
   });

--- a/src/modules/server/classify.ts
+++ b/src/modules/server/classify.ts
@@ -10,15 +10,28 @@
 
 /** Prefix for dev-module URLs; exported for path stripping in module-server. */
 export const DEV_MODULE_PREFIX = /^\/(?:_vf_modules|_veryfront\/modules)\//;
-const SNIPPET_MODULE_PREFIX = /^\/_vf_modules\/_snippets\/([a-f0-9]+)\.js/;
+const SNIPPET_MODULE_PREFIX = /^\/_vf_modules\/_snippets\/([a-f0-9]{1,128})\.js$/;
 // Cross-project import patterns: /_vf_modules/_cross/<slug>[@<version>]/@/<path>
 const CROSS_PROJECT_VERSIONED_PREFIX =
-  /^\/_vf_modules\/_cross\/([a-z0-9-]+)@([\d^~x][\d.x^~-]*)\/\@\/(.+)$/;
-const CROSS_PROJECT_LATEST_PREFIX = /^\/_vf_modules\/_cross\/([a-z0-9-]+)\/\@\/(.+)$/;
+  /^\/_vf_modules\/_cross\/([a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?)@([\d^~x][\d.x^~-]{0,127})\/\@\/(.+)$/;
+const CROSS_PROJECT_LATEST_PREFIX =
+  /^\/_vf_modules\/_cross\/([a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?)\/\@\/(.+)$/;
+const RESERVED_SNIPPET_NAMESPACE = "/_vf_modules/_snippets";
+const RESERVED_CROSS_PROJECT_NAMESPACE = "/_vf_modules/_cross";
+
+function isInNamespace(pathname: string, namespace: string): boolean {
+  return pathname === namespace || pathname.startsWith(`${namespace}/`);
+}
 
 /** URL does not start with any module prefix — not a module request. */
 export interface NotModuleKind {
   kind: "not-module";
+}
+
+/** A request entered a framework-owned namespace but did not match its grammar. */
+export interface InvalidModuleKind {
+  kind: "invalid-module";
+  namespace: "cross-project" | "snippet";
 }
 
 /** A compiled snippet module identified by its content hash. */
@@ -55,6 +68,7 @@ export interface DevModuleKind {
  */
 export type ModuleRequestKind =
   | NotModuleKind
+  | InvalidModuleKind
   | SnippetKind
   | CrossProjectVersionedKind
   | CrossProjectLatestKind
@@ -95,6 +109,13 @@ export function classifyModuleRequest(url: URL): ModuleRequestKind {
       slug: latestMatch[1] ?? "",
       path: latestMatch[2] ?? "",
     };
+  }
+
+  if (isInNamespace(url.pathname, RESERVED_SNIPPET_NAMESPACE)) {
+    return { kind: "invalid-module", namespace: "snippet" };
+  }
+  if (isInNamespace(url.pathname, RESERVED_CROSS_PROJECT_NAMESPACE)) {
+    return { kind: "invalid-module", namespace: "cross-project" };
   }
 
   return { kind: "dev-module" };

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -212,10 +212,11 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(await malformedCrossProject.text(), "Invalid module path");
   });
 
-  it("should return 404 for invalid cross-project import path", async () => {
+  it("returns 400 for an invalid path in the reserved cross-project namespace", async () => {
     const response = await serve(new Request("http://localhost:3000/_vf_modules/_cross//@/"));
 
-    assertEquals(response.status === 404 || response.status === 500, true);
+    assertEquals(response.status, 400);
+    assertEquals(await response.text(), "Invalid module path");
   });
 
   it("redacts internal module failures outside development", async () => {

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -218,6 +218,45 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(response.status === 404 || response.status === 500, true);
   });
 
+  it("redacts internal module failures outside development", async () => {
+    const { serveModule } = await import("./module-server.ts");
+    const projectDir = "/module-error-redaction";
+    const sourcePath = `${projectDir}/page.ts`;
+    const secret = "sensitive adapter failure";
+    const adapter = createMockAdapter();
+    adapter.fs.files.set(sourcePath, "export const page = true;");
+    const originalReadFile = adapter.fs.readFile.bind(adapter.fs);
+    adapter.fs.readFile = (path) => {
+      if (path === sourcePath) return Promise.reject(new Error(secret));
+      return originalReadFile(path);
+    };
+    const request = new Request("http://localhost:3000/_vf_modules/page.js");
+    const options = {
+      projectId: "module-error-redaction",
+      projectDir,
+      adapter,
+    };
+
+    const productionResponse = await serveModule(request, {
+      ...options,
+      dev: false,
+    });
+    assertEquals(productionResponse.status, 500);
+    const productionBody = await productionResponse.text();
+    assertEquals(
+      productionBody,
+      `// Transform Error\nthrow new Error("Module transformation failed");`,
+    );
+    assertEquals(productionBody.includes(secret), false);
+
+    const developmentResponse = await serveModule(request, {
+      ...options,
+      dev: true,
+    });
+    assertEquals(developmentResponse.status, 500);
+    assertStringIncludes(await developmentResponse.text(), secret);
+  });
+
   it("should serve _dnt.shims.js with _veryfront/ prefix", async () => {
     const response = await serve(
       new Request("http://localhost:3000/_vf_modules/_veryfront/_dnt.shims.js"),

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -197,10 +197,19 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(response.status, 404);
   });
 
-  it("should return 404 for snippet with missing hash", async () => {
+  it("rejects malformed paths in framework-owned module namespaces", async () => {
     const response = await serve(new Request("http://localhost:3000/_vf_modules/_snippets/.js"));
 
-    assertEquals(response.status === 404 || response.status === 500, true);
+    assertEquals(response.status, 400);
+    assertEquals(await response.text(), "Invalid module path");
+
+    const malformedCrossProject = await serve(
+      new Request(
+        "http://localhost:3000/_vf_modules/_cross/demo_project/@/index.js",
+      ),
+    );
+    assertEquals(malformedCrossProject.status, 400);
+    assertEquals(await malformedCrossProject.text(), "Invalid module path");
   });
 
   it("should return 404 for invalid cross-project import path", async () => {

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -5,7 +5,7 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import type { TransformOptions } from "#veryfront/transforms/esm-transform.ts";
 import { serverLogger, VERSION } from "#veryfront/utils";
-import { HTTP_NOT_FOUND, HTTP_OK, HTTP_SERVER_ERROR } from "#veryfront/utils";
+import { HTTP_BAD_REQUEST, HTTP_NOT_FOUND, HTTP_OK, HTTP_SERVER_ERROR } from "#veryfront/utils";
 import { getContentTypeForPath } from "#veryfront/server/handlers/utils/content-types.ts";
 import { createSecureFs } from "#veryfront/security";
 import { getErrorMessage } from "#veryfront/errors";

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -358,6 +358,17 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         });
       }
 
+      if (kind.kind === "invalid-module") {
+        logger.warn("Rejected malformed reserved module request", {
+          namespace: kind.namespace,
+          path: url.pathname,
+        });
+        return createModuleResponse(method, "Invalid module path", HTTP_BAD_REQUEST, {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Cache-Control": "no-cache",
+        });
+      }
+
       if (kind.kind === "snippet") {
         const { hash } = kind;
         if (!hash) {

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -460,9 +460,10 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         } catch (error) {
           const errorMsg = getErrorMessage(error);
           logger.error("Snippet transform error", { hash, error: errorMsg });
+          const clientError = getClientModuleError(dev, errorMsg);
           return createModuleResponse(
             method,
-            `// Transform Error\nthrow new Error(${JSON.stringify(errorMsg)});`,
+            `// Transform Error\nthrow new Error(${JSON.stringify(clientError)});`,
             HTTP_SERVER_ERROR,
             {
               "Content-Type": "application/javascript; charset=utf-8",
@@ -559,11 +560,18 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
             "Cache-Control": "no-cache",
           });
         } catch (error) {
-          logger.error("Cross-project error", { projectRef, error: String(error) });
-          return createModuleResponse(method, `// Error: ${String(error)}`, HTTP_SERVER_ERROR, {
-            "Content-Type": "application/javascript; charset=utf-8",
-            "Cache-Control": "no-cache",
-          });
+          const errorMsg = getErrorMessage(error);
+          logger.error("Cross-project error", { projectRef, error: errorMsg });
+          const clientError = getClientModuleError(dev, errorMsg);
+          return createModuleResponse(
+            method,
+            `// Transform Error\nthrow new Error(${JSON.stringify(clientError)});`,
+            HTTP_SERVER_ERROR,
+            {
+              "Content-Type": "application/javascript; charset=utf-8",
+              "Cache-Control": "no-cache",
+            },
+          );
         }
       }
 
@@ -815,7 +823,10 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         logger.error("Module transform error", { modulePath, error: errorMsg });
 
         const headers = getModuleHeaders(modulePath);
-        const errorBody = createDevModuleErrorBody(modulePath, errorMsg);
+        const errorBody = createModuleErrorBody(
+          modulePath,
+          getClientModuleError(dev, errorMsg),
+        );
 
         return createModuleResponse(method, errorBody, HTTP_SERVER_ERROR, headers);
       }
@@ -1219,7 +1230,13 @@ export function getDevModuleContentType(modulePath: string): string {
   return detected ?? "application/javascript; charset=utf-8";
 }
 
-function createDevModuleErrorBody(modulePath: string, errorMessage: string): string {
+const PRODUCTION_MODULE_ERROR = "Module transformation failed";
+
+function getClientModuleError(dev: boolean, errorMessage: string): string {
+  return dev ? errorMessage : PRODUCTION_MODULE_ERROR;
+}
+
+function createModuleErrorBody(modulePath: string, errorMessage: string): string {
   const normalizedPath = modulePath.toLowerCase();
 
   if (normalizedPath.endsWith(".css")) {

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { dirname, join } from "#veryfront/compat/path/index.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
@@ -39,6 +39,26 @@ function withStaticSpan<T extends { full: string }>(
 }
 
 describe("module-loader/dependency-resolver", () => {
+  it("fails closed when static import collection exceeds its bound", async () => {
+    const adapter = await getLocalAdapter();
+    const fileContent = Array.from(
+      { length: 501 },
+      (_, index) => `import value${index} from "@/value-${index}";`,
+    ).join("\n");
+
+    await assertRejects(
+      () =>
+        resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath: "/project/page.tsx",
+          projectDir: "/project",
+        }),
+      RangeError,
+      "more than 500 static alias imports",
+    );
+  });
+
   it("resolves alias and relative imports while ignoring already transformed file imports", async () => {
     await withDependencyFixture(
       {

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
@@ -59,6 +59,49 @@ describe("module-loader/dependency-resolver", () => {
     );
   });
 
+  // Bounding only the static scan would leave the same allocation reachable
+  // through the dynamic-import form, since both kinds are collected and
+  // rewritten together.
+  it("fails closed when dynamic import collection exceeds its bound", async () => {
+    const adapter = await getLocalAdapter();
+    const fileContent = Array.from(
+      { length: 501 },
+      (_, index) => `const value${index} = await import("@/value-${index}");`,
+    ).join("\n");
+
+    await assertRejects(
+      () =>
+        resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath: "/project/page.tsx",
+          projectDir: "/project",
+        }),
+      RangeError,
+      "more than 500 dynamic alias imports",
+    );
+  });
+
+  it("fails closed when dynamic relative import collection exceeds its bound", async () => {
+    const adapter = await getLocalAdapter();
+    const fileContent = Array.from(
+      { length: 501 },
+      (_, index) => `const value${index} = await import("./value-${index}");`,
+    ).join("\n");
+
+    await assertRejects(
+      () =>
+        resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath: "/project/page.tsx",
+          projectDir: "/project",
+        }),
+      RangeError,
+      "more than 500 dynamic relative imports",
+    );
+  });
+
   it("resolves alias and relative imports while ignoring already transformed file imports", async () => {
     await withDependencyFixture(
       {

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.ts
@@ -10,6 +10,7 @@ import {
 import { findSourceFile } from "../file-resolver/index.ts";
 
 const logger = rendererLogger.component("module-loader");
+const MAX_STATIC_IMPORTS_PER_KIND = 500;
 
 type AliasImport = {
   full: string;
@@ -67,8 +68,19 @@ function collectAliasImports(fileContent: string): AliasImport[] {
     },
   ): AliasImport => ({ full: original, path, start, end, isDynamic });
 
+  const staticImports = findStaticImportFromSpans(
+    fileContent,
+    matchAlias,
+    MAX_STATIC_IMPORTS_PER_KIND + 1,
+  );
+  if (staticImports.length > MAX_STATIC_IMPORTS_PER_KIND) {
+    throw new RangeError(
+      `Module contains more than ${MAX_STATIC_IMPORTS_PER_KIND} static alias imports`,
+    );
+  }
+
   return [
-    ...findStaticImportFromSpans(fileContent, matchAlias).map(toAlias(false)),
+    ...staticImports.map(toAlias(false)),
     ...findDynamicImportSpans(fileContent, matchAlias).map(toAlias(true)),
   ];
 }
@@ -84,8 +96,19 @@ function collectRelativeImports(fileContent: string, fileDir: string): RelativeI
     },
   ): RelativeImport => ({ full: original, path, fromDir: fileDir, start, end, isDynamic });
 
+  const staticImports = findStaticImportFromSpans(
+    fileContent,
+    matchRelative,
+    MAX_STATIC_IMPORTS_PER_KIND + 1,
+  );
+  if (staticImports.length > MAX_STATIC_IMPORTS_PER_KIND) {
+    throw new RangeError(
+      `Module contains more than ${MAX_STATIC_IMPORTS_PER_KIND} static relative imports`,
+    );
+  }
+
   return [
-    ...findStaticImportFromSpans(fileContent, matchRelative).map(toRelative(false)),
+    ...staticImports.map(toRelative(false)),
     ...findDynamicImportSpans(fileContent, matchRelative).map(toRelative(true)),
   ]
     // Ignore already-transformed file:// imports.

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.ts
@@ -6,11 +6,33 @@ import {
   findStaticImportFromSpans,
   replaceSourceSpans,
   type SourceSpanReplacement,
+  type StaticImportSpan,
 } from "#veryfront/transforms/mdx/esm-module-loader/utils/source-spans.ts";
 import { findSourceFile } from "../file-resolver/index.ts";
 
 const logger = rendererLogger.component("module-loader");
-const MAX_STATIC_IMPORTS_PER_KIND = 500;
+const MAX_IMPORTS_PER_KIND = 500;
+
+/**
+ * Collect one kind of import span, failing closed past the per-kind bound.
+ *
+ * The scanner is asked for one span more than the bound so that an over-budget
+ * module is rejected rather than resolved from a truncated prefix: every span
+ * collected here is rewritten to a temp-file URL later, so dropping the tail
+ * would leave those imports pointing at specifiers that no longer resolve.
+ */
+function collectBoundedSpans(
+  scan: (maxMatches: number) => StaticImportSpan[],
+  kind: string,
+): StaticImportSpan[] {
+  const spans = scan(MAX_IMPORTS_PER_KIND + 1);
+  if (spans.length > MAX_IMPORTS_PER_KIND) {
+    throw new RangeError(
+      `Module contains more than ${MAX_IMPORTS_PER_KIND} ${kind} imports`,
+    );
+  }
+  return spans;
+}
 
 type AliasImport = {
   full: string;
@@ -68,20 +90,15 @@ function collectAliasImports(fileContent: string): AliasImport[] {
     },
   ): AliasImport => ({ full: original, path, start, end, isDynamic });
 
-  const staticImports = findStaticImportFromSpans(
-    fileContent,
-    matchAlias,
-    MAX_STATIC_IMPORTS_PER_KIND + 1,
-  );
-  if (staticImports.length > MAX_STATIC_IMPORTS_PER_KIND) {
-    throw new RangeError(
-      `Module contains more than ${MAX_STATIC_IMPORTS_PER_KIND} static alias imports`,
-    );
-  }
-
   return [
-    ...staticImports.map(toAlias(false)),
-    ...findDynamicImportSpans(fileContent, matchAlias).map(toAlias(true)),
+    ...collectBoundedSpans(
+      (maxMatches) => findStaticImportFromSpans(fileContent, matchAlias, maxMatches),
+      "static alias",
+    ).map(toAlias(false)),
+    ...collectBoundedSpans(
+      (maxMatches) => findDynamicImportSpans(fileContent, matchAlias, maxMatches),
+      "dynamic alias",
+    ).map(toAlias(true)),
   ];
 }
 
@@ -96,20 +113,15 @@ function collectRelativeImports(fileContent: string, fileDir: string): RelativeI
     },
   ): RelativeImport => ({ full: original, path, fromDir: fileDir, start, end, isDynamic });
 
-  const staticImports = findStaticImportFromSpans(
-    fileContent,
-    matchRelative,
-    MAX_STATIC_IMPORTS_PER_KIND + 1,
-  );
-  if (staticImports.length > MAX_STATIC_IMPORTS_PER_KIND) {
-    throw new RangeError(
-      `Module contains more than ${MAX_STATIC_IMPORTS_PER_KIND} static relative imports`,
-    );
-  }
-
   return [
-    ...staticImports.map(toRelative(false)),
-    ...findDynamicImportSpans(fileContent, matchRelative).map(toRelative(true)),
+    ...collectBoundedSpans(
+      (maxMatches) => findStaticImportFromSpans(fileContent, matchRelative, maxMatches),
+      "static relative",
+    ).map(toRelative(false)),
+    ...collectBoundedSpans(
+      (maxMatches) => findDynamicImportSpans(fileContent, matchRelative, maxMatches),
+      "dynamic relative",
+    ).map(toRelative(true)),
   ]
     // Ignore already-transformed file:// imports.
     .filter((imp) => !imp.path.includes("file://"));

--- a/src/transforms/css-modules/naming.test.ts
+++ b/src/transforms/css-modules/naming.test.ts
@@ -1,10 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   normalizeCssModuleKey,
   resolveCssModuleKey,
   rewriteCssModuleContent,
+  rewriteCssModuleContentWithinLimit,
+  toProjectRelativeCssModuleKey,
   toScopedCssModuleClass,
 } from "./naming.ts";
 
@@ -60,5 +62,111 @@ describe("css-modules/naming", () => {
     // Original unsoped class names should not remain
     assertEquals(rewritten.includes(".container"), false);
     assertEquals(rewritten.includes(".active {"), false);
+  });
+
+  it("enforces the exact rewritten UTF-8 byte boundary", () => {
+    const admitted = rewriteCssModuleContentWithinLimit(
+      ".aé\ud800",
+      "/m.module.css",
+      17,
+    );
+
+    assertEquals(admitted, {
+      content: ".m_a__gqlim6é\ud800",
+      byteLength: 17,
+    });
+    assertThrows(
+      () => rewriteCssModuleContentWithinLimit(".aé\ud800", "/m.module.css", 16),
+      TypeError,
+      "16 bytes",
+    );
+  });
+
+  it("rejects repeated-selector expansion before emitting an oversized result", () => {
+    const content = ".a".repeat(512 * 1024);
+
+    assertThrows(
+      () => rewriteCssModuleContentWithinLimit(content, "/m.module.css", 1024 * 1024),
+      TypeError,
+      "1048576 bytes",
+    );
+  });
+
+  it("preserves comments, strings, authored mask-like text, and flat globals", () => {
+    const content = '__VF_CSS_GLOBAL_0__{/* .comment */content:".string"}:global(.prose) .local{}';
+    const expected =
+      '__VF_CSS_GLOBAL_0__{/* .comment */content:".string"}:global(.prose) .m_local__gqlim6{}';
+
+    assertEquals(rewriteCssModuleContent(content, "/m.module.css"), expected);
+    assertEquals(
+      rewriteCssModuleContentWithinLimit(content, "/m.module.css", 1_000),
+      { content: expected, byteLength: 86 },
+    );
+  });
+
+  it("ignores quoted closing parentheses while finding a flat :global span", () => {
+    assertEquals(
+      rewriteCssModuleContent(
+        ':global([data-x=")"]) .local { color:red }',
+        "/m.module.css",
+      ),
+      ':global([data-x=")"]) .m_local__gqlim6 { color:red }',
+    );
+  });
+
+  it("ignores commented closing parentheses while finding a flat :global span", () => {
+    assertEquals(
+      rewriteCssModuleContent(
+        ":global(.external/* ) */ .also-external) .local {}",
+        "/m.module.css",
+      ),
+      ":global(.external/* ) */ .also-external) .m_local__gqlim6 {}",
+    );
+  });
+
+  it("rejects unsafe output byte limits", () => {
+    for (const maximumBytes of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      assertThrows(
+        () => rewriteCssModuleContentWithinLimit("", "/m.module.css", maximumBytes),
+        RangeError,
+        "non-negative safe integer",
+      );
+    }
+  });
+
+  it("admits empty output at a zero-byte budget without allocating output code units", () => {
+    const NativeUint16Array = globalThis.Uint16Array;
+    let outputBufferCodeUnits = 0;
+    class RecordingUint16Array extends NativeUint16Array {
+      constructor(length: number) {
+        outputBufferCodeUnits += length;
+        super(length);
+      }
+    }
+    Object.defineProperty(globalThis, "Uint16Array", {
+      configurable: true,
+      value: RecordingUint16Array,
+      writable: true,
+    });
+
+    try {
+      assertThrows(
+        () => rewriteCssModuleContentWithinLimit(".a", "/m.module.css", 0),
+        TypeError,
+        "0 bytes",
+      );
+      assertEquals(outputBufferCodeUnits, 0);
+      assertEquals(
+        rewriteCssModuleContentWithinLimit("", "/m.module.css", 0),
+        { content: "", byteLength: 0 },
+      );
+      assertEquals(outputBufferCodeUnits, 0);
+    } finally {
+      Object.defineProperty(globalThis, "Uint16Array", {
+        configurable: true,
+        value: NativeUint16Array,
+        writable: true,
+      });
+    }
   });
 });

--- a/src/transforms/css-modules/naming.test.ts
+++ b/src/transforms/css-modules/naming.test.ts
@@ -6,7 +6,6 @@ import {
   resolveCssModuleKey,
   rewriteCssModuleContent,
   rewriteCssModuleContentWithinLimit,
-  toProjectRelativeCssModuleKey,
   toScopedCssModuleClass,
 } from "./naming.ts";
 

--- a/src/transforms/css-modules/naming.ts
+++ b/src/transforms/css-modules/naming.ts
@@ -113,24 +113,302 @@ export function toScopedCssModuleClass(moduleKey: string, localName: string): st
   return `${base}_${normalizedLocal}__${hash}`;
 }
 
-function maskGlobalSelectors(css: string): { masked: string; restore: (input: string) => string } {
-  const segments: string[] = [];
-  const masked = css.replace(/:global\(([^()]*)\)/g, (match) => {
-    const token = `__VF_CSS_GLOBAL_${segments.length}__`;
-    segments.push(match);
-    return token;
-  });
+const CSS_REWRITE_BUILD_CHUNK_CODE_UNITS = 8 * 1024;
 
-  return {
-    masked,
-    restore: (input: string) => {
-      let result = input;
-      for (const [i, segment] of segments.entries()) {
-        result = result.replaceAll(`__VF_CSS_GLOBAL_${i}__`, segment);
+interface CssModuleRewriteSink {
+  copySource(start: number, end: number): void;
+  writeScopedClass(start: number, end: number): void;
+}
+
+export interface RewrittenCssModuleContent {
+  content: string;
+  byteLength: number;
+}
+
+function addSafeInteger(current: number, increment: number, label: string): number {
+  if (
+    !Number.isSafeInteger(increment) ||
+    increment < 0 ||
+    current > Number.MAX_SAFE_INTEGER - increment
+  ) {
+    throw new RangeError(`${label} exceeds the safe-integer range`);
+  }
+  return current + increment;
+}
+
+function assertCssRewriteByteLimit(maximumBytes: number): number {
+  if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 0) {
+    throw new RangeError(
+      "CSS module output byte limit must be a non-negative safe integer",
+    );
+  }
+  return maximumBytes;
+}
+
+function isClassStart(codeUnit: number): boolean {
+  return codeUnit === 0x5f ||
+    codeUnit >= 0x41 && codeUnit <= 0x5a ||
+    codeUnit >= 0x61 && codeUnit <= 0x7a;
+}
+
+function isClassContinuation(codeUnit: number): boolean {
+  return isClassStart(codeUnit) || codeUnit === 0x2d ||
+    codeUnit >= 0x30 && codeUnit <= 0x39;
+}
+
+function skipCssComment(content: string, start: number): number {
+  let cursor = start + 2;
+  while (cursor < content.length - 1) {
+    if (content.charCodeAt(cursor) === 0x2a && content.charCodeAt(cursor + 1) === 0x2f) {
+      return cursor + 2;
+    }
+    cursor++;
+  }
+  return content.length;
+}
+
+function skipCssString(content: string, start: number, quote: number): number {
+  let cursor = start + 1;
+  while (cursor < content.length) {
+    const codeUnit = content.charCodeAt(cursor);
+    if (codeUnit === 0x5c) {
+      cursor = Math.min(content.length, cursor + 2);
+      continue;
+    }
+    cursor++;
+    if (codeUnit === quote) return cursor;
+  }
+  return content.length;
+}
+
+function startsFlatGlobal(content: string, start: number): boolean {
+  return content.startsWith(":global(", start);
+}
+
+function findFlatGlobalEnd(content: string, start: number): number {
+  let cursor = start + ":global(".length;
+  while (cursor < content.length) {
+    const codeUnit = content.charCodeAt(cursor);
+    if (codeUnit === 0x2f && content.charCodeAt(cursor + 1) === 0x2a) {
+      cursor = skipCssComment(content, cursor);
+      continue;
+    }
+    if (codeUnit === 0x22 || codeUnit === 0x27) {
+      cursor = skipCssString(content, cursor, codeUnit);
+      continue;
+    }
+    if (codeUnit === 0x28) return -1;
+    if (codeUnit === 0x29) return cursor + 1;
+    cursor++;
+  }
+  return -1;
+}
+
+/**
+ * Visit authored and rewritten spans in output order. Both the measurement
+ * and emission passes use this scanner so admission cannot disagree with the
+ * bytes that are ultimately built.
+ */
+function scanCssModuleRewrite(content: string, sink: CssModuleRewriteSink): void {
+  let cursor = 0;
+  let sourceStart = 0;
+
+  while (cursor < content.length) {
+    const codeUnit = content.charCodeAt(cursor);
+    if (codeUnit === 0x2f && content.charCodeAt(cursor + 1) === 0x2a) {
+      cursor = skipCssComment(content, cursor);
+      continue;
+    }
+    if (codeUnit === 0x22 || codeUnit === 0x27) {
+      cursor = skipCssString(content, cursor, codeUnit);
+      continue;
+    }
+    if (codeUnit === 0x3a && startsFlatGlobal(content, cursor)) {
+      const globalEnd = findFlatGlobalEnd(content, cursor);
+      if (globalEnd >= 0) {
+        cursor = globalEnd;
+        continue;
       }
-      return result;
-    },
-  };
+    }
+    if (codeUnit === 0x2e && isClassStart(content.charCodeAt(cursor + 1))) {
+      sink.copySource(sourceStart, cursor);
+      let classEnd = cursor + 2;
+      while (
+        classEnd < content.length &&
+        isClassContinuation(content.charCodeAt(classEnd))
+      ) {
+        classEnd++;
+      }
+      sink.writeScopedClass(cursor + 1, classEnd);
+      cursor = classEnd;
+      sourceStart = classEnd;
+      continue;
+    }
+    cursor++;
+  }
+
+  sink.copySource(sourceStart, content.length);
+}
+
+class CssModuleRewriteMeter implements CssModuleRewriteSink {
+  byteLength = 0;
+  codeUnits = 0;
+
+  constructor(
+    private readonly content: string,
+    private readonly scopedPrefix: string,
+    private readonly scopedSuffix: string,
+    private readonly maximumBytes: number,
+    private readonly label: string,
+  ) {}
+
+  copySource(start: number, end: number): void {
+    this.codeUnits = addSafeInteger(
+      this.codeUnits,
+      end - start,
+      "Rewritten CSS module length",
+    );
+    for (let cursor = start; cursor < end; cursor++) {
+      const codeUnit = this.content.charCodeAt(cursor);
+      if (
+        codeUnit >= 0xd800 && codeUnit <= 0xdbff && cursor + 1 < end
+      ) {
+        const low = this.content.charCodeAt(cursor + 1);
+        if (low >= 0xdc00 && low <= 0xdfff) {
+          this.addBytes(4);
+          cursor++;
+          continue;
+        }
+      }
+      this.addBytes(
+        codeUnit <= 0x7f ? 1 : codeUnit <= 0x7ff ? 2 : 3,
+      );
+    }
+  }
+
+  writeScopedClass(start: number, end: number): void {
+    const replacementCodeUnits = addSafeInteger(
+      addSafeInteger(
+        this.scopedPrefix.length,
+        end - start,
+        "Scoped CSS class length",
+      ),
+      this.scopedSuffix.length,
+      "Scoped CSS class length",
+    );
+    this.codeUnits = addSafeInteger(
+      this.codeUnits,
+      replacementCodeUnits,
+      "Rewritten CSS module length",
+    );
+    // Prefix, local class, and suffix are all restricted to ASCII.
+    this.addBytes(replacementCodeUnits);
+  }
+
+  private addBytes(increment: number): void {
+    if (increment > this.maximumBytes - this.byteLength) {
+      throw new TypeError(`${this.label} exceeds ${this.maximumBytes} bytes`);
+    }
+    this.byteLength = addSafeInteger(
+      this.byteLength,
+      increment,
+      "Rewritten CSS module byte length",
+    );
+  }
+}
+
+class CssModuleRewriteBuilder implements CssModuleRewriteSink {
+  private readonly buffer: Uint16Array;
+  private readonly chunks: string[] = [];
+  private bufferLength = 0;
+  private writtenCodeUnits = 0;
+
+  constructor(
+    private readonly content: string,
+    private readonly scopedPrefix: string,
+    private readonly scopedSuffix: string,
+    private readonly expectedCodeUnits: number,
+  ) {
+    this.buffer = new Uint16Array(
+      Math.min(expectedCodeUnits, CSS_REWRITE_BUILD_CHUNK_CODE_UNITS),
+    );
+  }
+
+  copySource(start: number, end: number): void {
+    for (let cursor = start; cursor < end; cursor++) {
+      this.writeCodeUnit(this.content.charCodeAt(cursor));
+    }
+  }
+
+  writeScopedClass(start: number, end: number): void {
+    this.writeString(this.scopedPrefix);
+    for (let cursor = start; cursor < end; cursor++) {
+      this.writeCodeUnit(this.content.charCodeAt(cursor));
+    }
+    this.writeString(this.scopedSuffix);
+  }
+
+  finish(): string {
+    this.flush();
+    if (this.writtenCodeUnits !== this.expectedCodeUnits) {
+      throw new Error("CSS module rewrite measurement disagreed with emission");
+    }
+    return this.chunks.join("");
+  }
+
+  private writeString(value: string): void {
+    for (let index = 0; index < value.length; index++) {
+      this.writeCodeUnit(value.charCodeAt(index));
+    }
+  }
+
+  private writeCodeUnit(codeUnit: number): void {
+    this.buffer[this.bufferLength++] = codeUnit;
+    this.writtenCodeUnits++;
+    if (this.bufferLength === this.buffer.length) this.flush();
+  }
+
+  private flush(): void {
+    if (this.bufferLength === 0) return;
+    this.chunks.push(
+      String.fromCharCode(...this.buffer.subarray(0, this.bufferLength)),
+    );
+    this.bufferLength = 0;
+  }
+}
+
+/**
+ * Rewrite a CSS Module only after its exact emitted UTF-8 size fits the
+ * supplied byte budget. The first pass retains no rewrite spans or output
+ * chunks; the second pass stores at most the admitted output.
+ */
+export function rewriteCssModuleContentWithinLimit(
+  content: string,
+  moduleKey: string,
+  maximumBytes: number,
+  label = "Rewritten CSS module",
+): RewrittenCssModuleContent {
+  const admittedMaximum = assertCssRewriteByteLimit(maximumBytes);
+  const { base, hash } = getCssModuleScope(moduleKey);
+  const scopedPrefix = `.${base}_`;
+  const scopedSuffix = `__${hash}`;
+  const meter = new CssModuleRewriteMeter(
+    content,
+    scopedPrefix,
+    scopedSuffix,
+    admittedMaximum,
+    label,
+  );
+  scanCssModuleRewrite(content, meter);
+
+  const builder = new CssModuleRewriteBuilder(
+    content,
+    scopedPrefix,
+    scopedSuffix,
+    meter.codeUnits,
+  );
+  scanCssModuleRewrite(content, builder);
+  return { content: builder.finish(), byteLength: meter.byteLength };
 }
 
 /**
@@ -138,15 +416,9 @@ function maskGlobalSelectors(css: string): { masked: string; restore: (input: st
  * Keeps `:global(...)` segments untouched.
  */
 export function rewriteCssModuleContent(content: string, moduleKey: string): string {
-  const { masked, restore } = maskGlobalSelectors(content);
-  // After :global() masking, every `.identifier` in the CSS is a local class
-  // selector. No lookbehind needed — numeric decimals like `0.5em` won't
-  // match because digits aren't in [_a-zA-Z].
-  const rewritten = masked.replace(
-    /\.([_a-zA-Z][_a-zA-Z0-9-]*)/g,
-    (_match, className: string) => {
-      return `.${toScopedCssModuleClass(moduleKey, className)}`;
-    },
-  );
-  return restore(rewritten);
+  return rewriteCssModuleContentWithinLimit(
+    content,
+    moduleKey,
+    Number.MAX_SAFE_INTEGER,
+  ).content;
 }

--- a/src/transforms/esm/bundle-accumulator.ts
+++ b/src/transforms/esm/bundle-accumulator.ts
@@ -1,0 +1,146 @@
+/**
+ * Request-scoped HTTP bundle manifest accumulation.
+ *
+ * @module transforms/esm/bundle-accumulator
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { join } from "#veryfront/compat/path/index.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import type { BundleEntry } from "./bundle-manifest-types.ts";
+import { extractBundleDeps } from "./bundle-deps-validator.ts";
+import { isDegradedArtifact } from "./degraded-artifact.ts";
+import {
+  isValidHttpBundleHash,
+  MAX_HTTP_BUNDLE_GRAPH_ENTRIES,
+  readCachedHttpBundleFile,
+} from "./http-bundle-file.ts";
+import { extractSourceUrl } from "./source-url-embed.ts";
+
+export interface BundleAccumulator {
+  readonly bundles: Map<string, BundleEntry>;
+  complete: boolean;
+}
+
+/** Per-request accumulator used by cacheHttpImportsToLocal. */
+export const bundleAccumulatorStorage = new AsyncLocalStorage<BundleAccumulator>();
+
+export function createBundleAccumulator(): BundleAccumulator {
+  return { bundles: new Map(), complete: true };
+}
+
+/** Prevent a partial bundle set from being published as an atomic manifest. */
+export function markBundleAccumulatorIncomplete(): void {
+  const accumulator = bundleAccumulatorStorage.getStore();
+  if (accumulator) accumulator.complete = false;
+}
+
+function recordBundle(entry: BundleEntry): void {
+  const accumulator = bundleAccumulatorStorage.getStore();
+  if (!accumulator) return;
+
+  if (!isValidHttpBundleHash(entry.hash)) {
+    accumulator.complete = false;
+    return;
+  }
+  if (
+    !accumulator.bundles.has(entry.hash) &&
+    accumulator.bundles.size >= MAX_HTTP_BUNDLE_GRAPH_ENTRIES
+  ) {
+    accumulator.complete = false;
+    return;
+  }
+
+  accumulator.bundles.set(entry.hash, entry);
+}
+
+/**
+ * Record one freshly written bundle. Recursive network fetches record their own
+ * artifacts, so this avoids trying to read a circular ancestor before its write
+ * has completed.
+ */
+export async function trackWrittenBundle(
+  hash: string,
+  normalizedUrl: string,
+  cachePath: string,
+): Promise<boolean> {
+  const accumulator = bundleAccumulatorStorage.getStore();
+  if (!accumulator) return true;
+
+  const bundle = await readCachedHttpBundleFile(createFileSystem(), cachePath);
+  if (!bundle) {
+    accumulator.complete = false;
+    return false;
+  }
+  if (isDegradedArtifact(bundle.code)) {
+    accumulator.complete = false;
+    return true;
+  }
+
+  recordBundle({
+    hash,
+    url: normalizedUrl,
+    sizeBytes: bundle.sizeBytes,
+  });
+  return true;
+}
+
+/**
+ * Record a complete, already-materialized bundle graph for memory, disk,
+ * distributed-cache, and in-flight cache hits.
+ */
+export async function trackCachedBundleGraph(
+  rootHash: string,
+  rootUrl: string,
+  rootPath: string,
+  cacheDir: string,
+): Promise<boolean> {
+  const accumulator = bundleAccumulatorStorage.getStore();
+  if (!accumulator) return true;
+
+  const fs = createFileSystem();
+  const pending = [{ hash: rootHash, path: rootPath, fallbackUrl: rootUrl }];
+  const seen = new Set<string>();
+
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (seen.has(current.hash)) continue;
+    if (
+      !isValidHttpBundleHash(current.hash) ||
+      seen.size >= MAX_HTTP_BUNDLE_GRAPH_ENTRIES
+    ) {
+      accumulator.complete = false;
+      return true;
+    }
+    seen.add(current.hash);
+
+    const bundle = await readCachedHttpBundleFile(fs, current.path);
+    if (!bundle) return false;
+    if (isDegradedArtifact(bundle.code)) {
+      accumulator.complete = false;
+      return true;
+    }
+
+    recordBundle({
+      hash: current.hash,
+      url: extractSourceUrl(bundle.code) ?? current.fallbackUrl,
+      sizeBytes: bundle.sizeBytes,
+    });
+
+    const deps = extractBundleDeps(bundle.code);
+    if (seen.size + deps.length > MAX_HTTP_BUNDLE_GRAPH_ENTRIES) {
+      accumulator.complete = false;
+      return true;
+    }
+    for (const dep of deps) {
+      if (seen.has(dep.hash)) continue;
+      pending.push({
+        hash: dep.hash,
+        path: join(cacheDir, `http-${dep.hash}.mjs`),
+        fallbackUrl: "",
+      });
+    }
+  }
+
+  return true;
+}

--- a/src/transforms/esm/bundle-deps-validator.ts
+++ b/src/transforms/esm/bundle-deps-validator.ts
@@ -7,13 +7,20 @@
  * @module transforms/esm/bundle-deps-validator
  */
 
-import { createFileSystem, exists } from "#veryfront/platform/compat/fs.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { httpBundleCache } from "./http-cache-wrapper.ts";
 import { unbrand } from "./http-cache-types.ts";
 import { extractSourceUrl } from "./source-url-embed.ts";
 import { ensureAbsoluteDir, hasIncompatibleFilePaths } from "./http-cache-helpers.ts";
+import {
+  isHttpBundleCodeWithinLimit,
+  isValidHttpBundleHash,
+  MAX_HTTP_BUNDLE_GRAPH_ENTRIES,
+  readCachedHttpBundleFile,
+} from "./http-bundle-file.ts";
+import { isDegradedArtifact } from "./degraded-artifact.ts";
 
 const logger = rendererLogger.component("http-cache");
 
@@ -33,6 +40,7 @@ export function extractBundleDeps(code: string): Array<{ path: string; hash: str
     if (seen.has(hash)) continue;
     seen.add(hash);
     deps.push({ path: match[1]!, hash });
+    if (deps.length > MAX_HTTP_BUNDLE_GRAPH_ENTRIES) return deps;
   }
 
   // Match relative paths (new portable format): ./http-{hash}.mjs
@@ -42,6 +50,7 @@ export function extractBundleDeps(code: string): Array<{ path: string; hash: str
     if (seen.has(hash)) continue;
     seen.add(hash);
     deps.push({ path: `http-${hash}.mjs`, hash });
+    if (deps.length > MAX_HTTP_BUNDLE_GRAPH_ENTRIES) return deps;
   }
 
   return deps;
@@ -63,36 +72,52 @@ export async function validateBundleDepsExist(
   const pending = [...deps];
 
   while (pending.length > 0) {
-    const batch = pending.splice(0, pending.length).filter((d) => !seen.has(d.hash));
+    const batchByHash = new Map<string, { path: string; hash: string }>();
+    for (const dependency of pending.splice(0, pending.length)) {
+      if (!seen.has(dependency.hash)) batchByHash.set(dependency.hash, dependency);
+    }
+    const batch = [...batchByHash.values()];
     if (batch.length === 0) break;
+    if (
+      seen.size + batch.length > MAX_HTTP_BUNDLE_GRAPH_ENTRIES ||
+      batch.some(({ hash }) => !isValidHttpBundleHash(hash))
+    ) {
+      logger.warn("HTTP bundle dependency graph is invalid or exceeds its limit", {
+        seen: seen.size,
+        pending: batch.length,
+        max: MAX_HTTP_BUNDLE_GRAPH_ENTRIES,
+      });
+      return false;
+    }
 
     for (const { hash } of batch) seen.add(hash);
 
     const localChecks = await Promise.all(
       batch.map(async ({ hash }) => {
-        try {
-          return {
-            hash,
-            exists: await exists(join(absoluteCacheDir, `http-${hash}.mjs`)),
-          };
-        } catch {
-          return { hash, exists: false };
-        }
+        const bundle = await readCachedHttpBundleFile(
+          fs,
+          join(absoluteCacheDir, `http-${hash}.mjs`),
+        );
+        return { hash, bundle };
       }),
     );
 
-    const missingDeps = localChecks.filter((c) => !c.exists);
-    if (missingDeps.length === 0) {
-      for (const { hash } of batch) {
-        try {
-          const code = await fs.readTextFile(join(absoluteCacheDir, `http-${hash}.mjs`));
-          for (const dep of extractBundleDeps(code)) {
-            if (!seen.has(dep.hash)) pending.push(dep);
-          }
-        } catch (_) {
-          /* expected: cached bundle file may be unreadable */
+    const presentDeps = localChecks.filter((check) =>
+      check.bundle !== null && !isDegradedArtifact(check.bundle.code)
+    );
+    const missingDeps = localChecks.filter((check) =>
+      check.bundle === null || isDegradedArtifact(check.bundle.code)
+    );
+
+    for (const { bundle } of presentDeps) {
+      for (const dep of extractBundleDeps(bundle!.code)) {
+        if (!seen.has(dep.hash)) {
+          pending.push(dep);
         }
       }
+    }
+
+    if (missingDeps.length === 0) {
       continue;
     }
 
@@ -121,7 +146,11 @@ export async function validateBundleDepsExist(
 
       const code = unbrand(localCode);
 
-      if (hasIncompatibleFilePaths(code, absoluteCacheDir)) {
+      if (
+        !isHttpBundleCodeWithinLimit(code) ||
+        isDegradedArtifact(code) ||
+        hasIncompatibleFilePaths(code, absoluteCacheDir)
+      ) {
         logger.debug("Dep has incompatible paths, rejecting cache", { hash });
         return false;
       }
@@ -155,16 +184,29 @@ export async function findParentBundleWithEmbeddedUrl(
   cacheDir: string,
   fs: ReturnType<typeof createFileSystem>,
 ): Promise<{ path: string; sourceUrl: string } | null> {
+  if (!isValidHttpBundleHash(targetHash)) return null;
+
   try {
     const files = fs.readDir(cacheDir);
     const bundlePattern = /^http-([a-f0-9]+)\.mjs$/i;
+    let scannedBundles = 0;
 
     for await (const file of files) {
       if (!bundlePattern.test(file.name)) continue;
+      scannedBundles += 1;
+      if (scannedBundles > MAX_HTTP_BUNDLE_GRAPH_ENTRIES) {
+        logger.debug("Stopped bounded parent-bundle scan", {
+          targetHash,
+          max: MAX_HTTP_BUNDLE_GRAPH_ENTRIES,
+        });
+        break;
+      }
 
       const filePath = join(cacheDir, file.name);
       try {
-        const content = await fs.readTextFile(filePath);
+        const bundle = await readCachedHttpBundleFile(fs, filePath);
+        if (!bundle) continue;
+        const content = bundle.code;
 
         const importsTarget = content.includes(`./http-${targetHash}.mjs`) ||
           content.includes(`http-${targetHash}.mjs"`);

--- a/src/transforms/esm/bundle-manifest.test.ts
+++ b/src/transforms/esm/bundle-manifest.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 /** @module transforms/esm/bundle-manifest.test */
 
-import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import { makeTempDir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
@@ -10,6 +10,7 @@ import {
   computeManifestId,
   createBundleManifest,
   getManifestIdForHash,
+  parseBundleManifest,
   validateBundleGroup,
   validateBundleManifest,
 } from "./bundle-manifest.ts";
@@ -58,14 +59,63 @@ describe("Bundle Manifest", { sanitizeResources: false, sanitizeOps: false }, ()
 
     it("registers hash-to-manifest mappings for co-refresh", async () => {
       const bundles: BundleEntry[] = [
-        { hash: "corefresh1", url: "https://esm.sh/test@1", sizeBytes: 100 },
-        { hash: "corefresh2", url: "https://esm.sh/test@2", sizeBytes: 200 },
+        { hash: "c0efe511", url: "https://esm.sh/test@1", sizeBytes: 100 },
+        { hash: "c0efe522", url: "https://esm.sh/test@2", sizeBytes: 200 },
       ];
 
       const manifest = await createBundleManifest(bundles);
 
-      assertEquals(getManifestIdForHash("corefresh1"), manifest.manifestId);
-      assertEquals(getManifestIdForHash("corefresh2"), manifest.manifestId);
+      assertEquals(getManifestIdForHash("c0efe511"), manifest.manifestId);
+      assertEquals(getManifestIdForHash("c0efe522"), manifest.manifestId);
+    });
+
+    it("rejects invalid bundle hashes before constructing cache paths", async () => {
+      await assertRejects(
+        () =>
+          createBundleManifest([
+            { hash: "../escape", url: "https://esm.sh/test@1", sizeBytes: 100 },
+          ]),
+        TypeError,
+        "entry is invalid",
+      );
+    });
+
+    it("deduplicates and orders entries deterministically", async () => {
+      const first = { hash: "bbb222", url: "https://esm.sh/b@1", sizeBytes: 20 };
+      const second = { hash: "aaa111", url: "https://esm.sh/a@1", sizeBytes: 10 };
+
+      const manifest = await createBundleManifest([first, second, first]);
+
+      assertEquals(manifest.bundles, [second, first]);
+    });
+  });
+
+  describe("parseBundleManifest", () => {
+    it("authenticates a valid serialized manifest", async () => {
+      const manifest = await createBundleManifest([
+        { hash: "abc123", url: "https://esm.sh/a@1", sizeBytes: 10 },
+      ]);
+
+      assertEquals(
+        await parseBundleManifest(JSON.stringify(manifest), manifest.manifestId),
+        manifest,
+      );
+    });
+
+    it("rejects tampered identities and path-shaped hashes", async () => {
+      const manifest = await createBundleManifest([
+        { hash: "abc123", url: "https://esm.sh/a@1", sizeBytes: 10 },
+      ]);
+      const tampered = {
+        ...manifest,
+        bundles: [{ ...manifest.bundles[0], hash: "../escape" }],
+      };
+
+      assertEquals(await parseBundleManifest(JSON.stringify(tampered)), null);
+      assertEquals(
+        await parseBundleManifest(JSON.stringify(manifest), "f".repeat(64)),
+        null,
+      );
     });
   });
 
@@ -103,22 +153,42 @@ describe("Bundle Manifest", { sanitizeResources: false, sanitizeOps: false }, ()
       const tmpDir = await makeTempDir();
       try {
         const bundles: BundleEntry[] = [
-          { hash: "recover111", url: "https://esm.sh/recover@1", sizeBytes: 16 },
+          { hash: "ec0e111", url: "https://esm.sh/recover@1", sizeBytes: 16 },
         ];
         const manifest = await createBundleManifest(bundles);
         let recovered = false;
 
         const result = await validateBundleManifest(manifest, tmpDir, async (missing, cacheDir) => {
           recovered = true;
-          assertEquals(missing.map(({ hash }) => hash), ["recover111"]);
+          assertEquals(missing.map(({ hash }) => hash), ["ec0e111"]);
           assertEquals(cacheDir, tmpDir);
-          await writeTextFile(join(tmpDir, "http-recover111.mjs"), "// recovered bundle");
+          await writeTextFile(join(tmpDir, "http-ec0e111.mjs"), "// recovered bundle");
           return [];
         });
 
         assertEquals(recovered, true);
         assertEquals(result.valid, true);
         assertEquals(result.failedHashes, []);
+      } finally {
+        await remove(tmpDir, { recursive: true });
+      }
+    });
+
+    it("rejects a manifest whose present root has a missing transitive dependency", async () => {
+      const tmpDir = await makeTempDir();
+      try {
+        await writeTextFile(
+          join(tmpDir, "http-aaa111.mjs"),
+          'import "./http-bbb222.mjs";',
+        );
+        const manifest = await createBundleManifest([
+          { hash: "aaa111", url: "https://esm.sh/root@1", sizeBytes: 29 },
+        ]);
+
+        const result = await validateBundleManifest(manifest, tmpDir);
+
+        assertEquals(result.valid, false);
+        assertEquals(result.reason, "bundle_missing");
       } finally {
         await remove(tmpDir, { recursive: true });
       }

--- a/src/transforms/esm/bundle-manifest.ts
+++ b/src/transforms/esm/bundle-manifest.ts
@@ -14,13 +14,28 @@ import { buildBundleManifestCacheKey } from "#veryfront/cache/keys.ts";
 import { BUNDLE_MANIFEST_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
 import { CacheBackends, createDistributedCacheAccessor } from "#veryfront/cache/backend.ts";
 import { join } from "#veryfront/compat/path/index.ts";
-import { exists } from "#veryfront/platform/compat/fs.ts";
 import { rememberBundleManifestHashes } from "./bundle-manifest-ttl.ts";
 import type { BundleEntry, BundleManifest } from "./bundle-manifest-types.ts";
+import { validateBundleDepsExist } from "./bundle-deps-validator.ts";
+import {
+  isValidHttpBundleHash,
+  MAX_CACHED_HTTP_BUNDLE_BYTES,
+  MAX_HTTP_BUNDLE_GRAPH_ENTRIES,
+} from "./http-bundle-file.ts";
 export type { BundleEntry, BundleManifest } from "./bundle-manifest-types.ts";
 export { getManifestIdForHash, refreshManifestTTL } from "./bundle-manifest-ttl.ts";
 
 const LOG_PREFIX = "[BundleManifest]";
+const MAX_MANIFEST_SERIALIZED_CODE_UNITS = 4 * 1024 * 1024;
+const MAX_MANIFEST_URL_LENGTH = 8 * 1024;
+const MANIFEST_ID_PATTERN = /^[a-f0-9]{64}$/i;
+
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    if (value.charCodeAt(index) <= 0x1f) return true;
+  }
+  return false;
+}
 
 export type ManifestValidationReason = "manifest_missing" | "bundle_missing";
 
@@ -47,21 +62,45 @@ const getCache = createDistributedCacheAccessor(
  * Sorts hashes to ensure the same set of bundles always produces the same ID.
  */
 export async function computeManifestId(hashes: string[]): Promise<string> {
-  return computeHash([...hashes].sort().join(":"));
+  return computeHash([...new Set(hashes)].sort().join(":"));
 }
 
 /**
  * Create a bundle manifest from collected bundle metadata.
  */
 export async function createBundleManifest(bundles: BundleEntry[]): Promise<BundleManifest> {
-  const hashes = bundles.map((b) => b.hash);
+  if (bundles.length === 0 || bundles.length > MAX_HTTP_BUNDLE_GRAPH_ENTRIES) {
+    throw new TypeError(
+      `Bundle manifest must contain 1-${MAX_HTTP_BUNDLE_GRAPH_ENTRIES} entries`,
+    );
+  }
+
+  const byHash = new Map<string, BundleEntry>();
+  for (const bundle of bundles) {
+    if (
+      !isValidHttpBundleHash(bundle.hash) ||
+      typeof bundle.url !== "string" ||
+      bundle.url.length > MAX_MANIFEST_URL_LENGTH ||
+      containsControlCharacter(bundle.url) ||
+      !Number.isSafeInteger(bundle.sizeBytes) ||
+      bundle.sizeBytes < 0 ||
+      bundle.sizeBytes > MAX_CACHED_HTTP_BUNDLE_BYTES
+    ) {
+      throw new TypeError("Bundle manifest entry is invalid");
+    }
+    if (!byHash.has(bundle.hash)) byHash.set(bundle.hash, bundle);
+  }
+  const orderedBundles = [...byHash.values()].sort((left, right) =>
+    left.hash.localeCompare(right.hash)
+  );
+  const hashes = orderedBundles.map((bundle) => bundle.hash);
   const manifestId = await computeManifestId(hashes);
 
   rememberBundleManifestHashes(hashes, manifestId);
 
   return {
     manifestId,
-    bundles,
+    bundles: orderedBundles,
     createdAt: Date.now(),
     ttlSeconds: BUNDLE_MANIFEST_DISTRIBUTED_TTL_SEC,
   };
@@ -80,7 +119,14 @@ export async function storeBundleManifest(manifest: BundleManifest): Promise<voi
   const key = buildBundleManifestCacheKey(manifest.manifestId);
 
   try {
-    await cache.set(key, JSON.stringify(manifest), manifest.ttlSeconds);
+    const serialized = JSON.stringify(manifest);
+    if (serialized.length > MAX_MANIFEST_SERIALIZED_CODE_UNITS) {
+      logger.warn(`${LOG_PREFIX} Refusing to store oversized manifest`, {
+        manifestId: manifest.manifestId.slice(0, 12),
+      });
+      return;
+    }
+    await cache.set(key, serialized, manifest.ttlSeconds);
     logger.debug(`${LOG_PREFIX} Stored manifest`, {
       manifestId: manifest.manifestId.slice(0, 12),
       bundleCount: manifest.bundles.length,
@@ -90,6 +136,77 @@ export async function storeBundleManifest(manifest: BundleManifest): Promise<voi
       manifestId: manifest.manifestId.slice(0, 12),
       error,
     });
+  }
+}
+
+function parseBundleEntry(value: unknown): BundleEntry | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.hash !== "string" ||
+    !isValidHttpBundleHash(record.hash) ||
+    typeof record.url !== "string" ||
+    record.url.length > MAX_MANIFEST_URL_LENGTH ||
+    containsControlCharacter(record.url) ||
+    !Number.isSafeInteger(record.sizeBytes) ||
+    (record.sizeBytes as number) < 0 ||
+    (record.sizeBytes as number) > MAX_CACHED_HTTP_BUNDLE_BYTES
+  ) {
+    return null;
+  }
+  return {
+    hash: record.hash,
+    url: record.url,
+    sizeBytes: record.sizeBytes as number,
+  };
+}
+
+/** Parse and authenticate a manifest loaded from an external cache backend. */
+export async function parseBundleManifest(
+  raw: string,
+  expectedManifestId?: string,
+): Promise<BundleManifest | null> {
+  if (raw.length === 0 || raw.length > MAX_MANIFEST_SERIALIZED_CODE_UNITS) return null;
+
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const record = value as Record<string, unknown>;
+    if (
+      typeof record.manifestId !== "string" ||
+      !MANIFEST_ID_PATTERN.test(record.manifestId) ||
+      expectedManifestId !== undefined && record.manifestId !== expectedManifestId ||
+      !Array.isArray(record.bundles) ||
+      record.bundles.length === 0 ||
+      record.bundles.length > MAX_HTTP_BUNDLE_GRAPH_ENTRIES ||
+      !Number.isSafeInteger(record.createdAt) ||
+      (record.createdAt as number) < 0 ||
+      !Number.isSafeInteger(record.ttlSeconds) ||
+      (record.ttlSeconds as number) < 0
+    ) {
+      return null;
+    }
+
+    const bundles: BundleEntry[] = [];
+    const seen = new Set<string>();
+    for (const rawBundle of record.bundles) {
+      const bundle = parseBundleEntry(rawBundle);
+      if (!bundle || seen.has(bundle.hash)) return null;
+      seen.add(bundle.hash);
+      bundles.push(bundle);
+    }
+    if (await computeManifestId(bundles.map(({ hash }) => hash)) !== record.manifestId) {
+      return null;
+    }
+
+    return {
+      manifestId: record.manifestId,
+      bundles,
+      createdAt: record.createdAt as number,
+      ttlSeconds: record.ttlSeconds as number,
+    };
+  } catch {
+    return null;
   }
 }
 
@@ -104,7 +221,7 @@ async function loadBundleManifest(manifestId: string): Promise<BundleManifest | 
 
   try {
     const raw = await cache.get(key);
-    return raw ? (JSON.parse(raw) as BundleManifest) : null;
+    return raw ? await parseBundleManifest(raw, manifestId) : null;
   } catch (error) {
     logger.debug(`${LOG_PREFIX} Failed to load manifest`, {
       manifestId: manifestId.slice(0, 12),
@@ -140,31 +257,43 @@ export async function validateBundleGroup(
 export async function validateBundleManifest(
   manifest: BundleManifest,
   cacheDir: string,
-  recoverMissingBundles: BundleRecoveryFn = (missing) =>
-    Promise.resolve(missing.map(({ hash }) => hash)),
+  recoverMissingBundles?: BundleRecoveryFn,
 ): Promise<ManifestValidationResult> {
-  const missingBundles: Array<{ path: string; hash: string }> = [];
+  if (
+    manifest.bundles.length === 0 ||
+    manifest.bundles.length > MAX_HTTP_BUNDLE_GRAPH_ENTRIES ||
+    manifest.bundles.some(({ hash }) => !isValidHttpBundleHash(hash))
+  ) {
+    logger.warn(`${LOG_PREFIX} Manifest bundle set is invalid`, {
+      manifestId: manifest.manifestId.slice(0, 12),
+      bundleCount: manifest.bundles.length,
+      max: MAX_HTTP_BUNDLE_GRAPH_ENTRIES,
+    });
+    return {
+      valid: false,
+      failedHashes: manifest.bundles
+        .filter(({ hash }) => !isValidHttpBundleHash(hash))
+        .map(({ hash }) => hash),
+      reason: "bundle_missing",
+    };
+  }
 
-  await Promise.all(
-    manifest.bundles.map(async ({ hash }) => {
-      try {
-        const path = join(cacheDir, `http-${hash}.mjs`);
-        if (!(await exists(path))) missingBundles.push({ path, hash });
-      } catch {
-        missingBundles.push({ path: join(cacheDir, `http-${hash}.mjs`), hash });
-      }
-    }),
-  );
+  const bundles = [...new Map(
+    manifest.bundles.map(({ hash }) => [
+      hash,
+      { path: join(cacheDir, `http-${hash}.mjs`), hash },
+    ]),
+  ).values()];
+  const validateOrRecover = recoverMissingBundles ??
+    (async (roots: Array<{ path: string; hash: string }>, rootCacheDir: string) =>
+      await validateBundleDepsExist(roots, rootCacheDir) ? [] : roots.map(({ hash }) => hash));
 
-  if (missingBundles.length === 0) return { valid: true, failedHashes: [] };
-
-  logger.info(`${LOG_PREFIX} Attempting to recover missing bundles`, {
+  logger.debug(`${LOG_PREFIX} Validating manifest bundle graph`, {
     manifestId: manifest.manifestId.slice(0, 12),
-    missing: missingBundles.length,
-    total: manifest.bundles.length,
+    total: bundles.length,
   });
 
-  const unrecoverableHashes = await recoverMissingBundles(missingBundles, cacheDir);
+  const unrecoverableHashes = await validateOrRecover(bundles, cacheDir);
   if (unrecoverableHashes.length > 0) {
     logger.warn(`${LOG_PREFIX} Some bundles could not be recovered`, {
       manifestId: manifest.manifestId.slice(0, 12),
@@ -173,9 +302,9 @@ export async function validateBundleManifest(
     return { valid: false, failedHashes: unrecoverableHashes, reason: "bundle_missing" };
   }
 
-  logger.info(`${LOG_PREFIX} All missing bundles recovered successfully`, {
+  logger.debug(`${LOG_PREFIX} Bundle graph is complete`, {
     manifestId: manifest.manifestId.slice(0, 12),
-    recovered: missingBundles.length,
+    total: bundles.length,
   });
 
   return { valid: true, failedHashes: [] };

--- a/src/transforms/esm/bundle-recovery.test.ts
+++ b/src/transforms/esm/bundle-recovery.test.ts
@@ -273,10 +273,27 @@ describe("transforms/esm/bundle-recovery", () => {
     it("returns true even when the local bundle file does not exist", async () => {
       const cacheDir = await Deno.makeTempDir();
       try {
-        const result = await invalidateHttpBundle("does-not-exist", cacheDir);
+        const result = await invalidateHttpBundle("deadbeef", cacheDir);
         assertEquals(result, true);
       } finally {
         await Deno.remove(cacheDir, { recursive: true });
+      }
+    });
+
+    it("rejects invalid hashes before constructing a filesystem path", async () => {
+      const parentDir = await Deno.makeTempDir();
+      const cacheDir = join(parentDir, "cache");
+      const sentinelPath = join(parentDir, "sentinel.mjs");
+      try {
+        await Deno.mkdir(cacheDir);
+        await Deno.writeTextFile(sentinelPath, "keep");
+
+        const result = await invalidateHttpBundle("../sentinel", cacheDir);
+
+        assertEquals(result, false);
+        assertEquals(await Deno.readTextFile(sentinelPath), "keep");
+      } finally {
+        await Deno.remove(parentDir, { recursive: true });
       }
     });
   });

--- a/src/transforms/esm/bundle-recovery.ts
+++ b/src/transforms/esm/bundle-recovery.ts
@@ -26,6 +26,13 @@ import {
 } from "./http-cache-helpers.ts";
 import { extractBundleDeps, findParentBundleWithEmbeddedUrl } from "./bundle-deps-validator.ts";
 import { getCachedPaths } from "./http-cache-state.ts";
+import {
+  isHttpBundleCodeWithinLimit,
+  isValidHttpBundleHash,
+  MAX_HTTP_BUNDLE_GRAPH_ENTRIES,
+  readCachedHttpBundleFile,
+} from "./http-bundle-file.ts";
+import { isDegradedArtifact } from "./degraded-artifact.ts";
 
 const logger = rendererLogger.component("http-cache");
 
@@ -97,6 +104,8 @@ export async function recoverHttpBundleByHash(
   parentCode?: string,
   fallbackIdentity?: HttpCacheIdentityOptions,
 ): Promise<boolean> {
+  if (!isValidHttpBundleHash(hash)) return false;
+
   const absoluteCacheDir = ensureAbsoluteDir(cacheDir);
   const cachePath = join(absoluteCacheDir, `http-${hash}.mjs`);
   const fs = createFileSystem();
@@ -108,7 +117,11 @@ export async function recoverHttpBundleByHash(
     if (result.code) {
       const cachedCode = unbrand(result.code);
 
-      if (hasIncompatibleFilePaths(cachedCode, absoluteCacheDir)) {
+      if (
+        !isHttpBundleCodeWithinLimit(cachedCode) ||
+        isDegradedArtifact(cachedCode) ||
+        hasIncompatibleFilePaths(cachedCode, absoluteCacheDir)
+      ) {
         logger.warn("Cached code has incompatible file paths, will re-fetch", {
           hash,
           localCacheDir: absoluteCacheDir,
@@ -140,28 +153,30 @@ export async function recoverHttpBundleByHash(
 
         logger.info("Bundle recovery successful (direct)", { hash, path: cachePath });
 
-        const BUNDLE_RE = /file:\/\/([^"'\s]+veryfront-http-bundle\/http-([a-f0-9]+)\.mjs)/gi;
-        const transitiveDeps: Array<{ path: string; hash: string }> = [];
-        let m: RegExpExecArray | null;
-        while ((m = BUNDLE_RE.exec(cachedCode)) !== null) {
-          const tHash = m[2]!;
-          if (tHash === hash) continue;
-          transitiveDeps.push({
-            path: join(absoluteCacheDir, `http-${tHash}.mjs`),
-            hash: tHash,
-          });
-        }
+        const transitiveDeps = extractBundleDeps(cachedCode)
+          .filter(({ hash: dependencyHash }) => dependencyHash !== hash)
+          .map(({ hash: dependencyHash }) => ({
+            path: join(absoluteCacheDir, `http-${dependencyHash}.mjs`),
+            hash: dependencyHash,
+          }));
 
         if (transitiveDeps.length > 0) {
           logger.info("Recovering transitive deps from last-resort recovery", {
             count: transitiveDeps.length,
           });
-          await ensureHttpBundlesExist(
+          const failedDependencies = await ensureHttpBundlesExist(
             transitiveDeps,
             cacheDir,
             cacheHttpModule,
             recoveryIdentity.options,
           );
+          if (failedDependencies.length > 0) {
+            logger.warn("Direct recovery left transitive dependencies unresolved", {
+              hash,
+              failedDependencies,
+            });
+            return false;
+          }
         }
 
         return true;
@@ -183,8 +198,10 @@ export async function recoverHttpBundleByHash(
         return true;
       }
       if (result && /^\d+$/.test(hash) && await exists(result)) {
+        const recoveredBundle = await readCachedHttpBundleFile(fs, result);
+        if (!recoveredBundle || isDegradedArtifact(recoveredBundle.code)) return false;
         await fs.mkdir(absoluteCacheDir, { recursive: true });
-        await fs.writeTextFile(cachePath, await fs.readTextFile(result));
+        await fs.writeTextFile(cachePath, recoveredBundle.code);
         logger.info("Materialized re-fetched bundle at legacy cache path", {
           hash,
           sourcePath: result,
@@ -304,42 +321,53 @@ export async function ensureHttpBundlesExist(
   const fs = createFileSystem();
   const absoluteCacheDir = ensureAbsoluteDir(cacheDir);
 
-  const pending: Array<{ hash: string }> = bundlePaths.map((b) => ({ hash: b.hash }));
+  const pending: Array<{ hash: string }> = [];
   const seen = new Set<string>();
   const failed = new Set<string>();
+  for (const { hash } of bundlePaths) {
+    if (!isValidHttpBundleHash(hash)) {
+      failed.add(hash);
+      continue;
+    }
+    if (!pending.some((entry) => entry.hash === hash)) pending.push({ hash });
+  }
+  if (pending.length > MAX_HTTP_BUNDLE_GRAPH_ENTRIES) {
+    for (const { hash } of pending.slice(MAX_HTTP_BUNDLE_GRAPH_ENTRIES)) failed.add(hash);
+    pending.length = MAX_HTTP_BUNDLE_GRAPH_ENTRIES;
+  }
 
   while (pending.length > 0) {
-    const batch = pending.splice(0, pending.length).filter((b) => !seen.has(b.hash));
+    const batchByHash = new Map<string, { hash: string }>();
+    for (const entry of pending.splice(0, pending.length)) {
+      if (!seen.has(entry.hash)) batchByHash.set(entry.hash, entry);
+    }
+    const batch = [...batchByHash.values()];
     if (batch.length === 0) break;
+    if (seen.size + batch.length > MAX_HTTP_BUNDLE_GRAPH_ENTRIES) {
+      for (const { hash } of batch) failed.add(hash);
+      break;
+    }
 
     for (const item of batch) seen.add(item.hash);
 
     const existenceChecks = await Promise.all(
       batch.map(async ({ hash }) => {
         const canonicalPath = join(absoluteCacheDir, `http-${hash}.mjs`);
-        try {
-          return {
-            hash,
-            canonicalPath,
-            exists: await exists(canonicalPath),
-          };
-        } catch {
-          return { hash, canonicalPath, exists: false };
-        }
+        const bundle = await readCachedHttpBundleFile(fs, canonicalPath);
+        return { hash, canonicalPath, bundle };
       }),
     );
 
-    const presentLocally = existenceChecks.filter((b) => b.exists);
-    const missing = existenceChecks.filter((b) => !b.exists);
+    const presentLocally = existenceChecks.filter((entry) =>
+      entry.bundle !== null && !isDegradedArtifact(entry.bundle.code)
+    );
+    const missing = existenceChecks.filter((entry) =>
+      entry.bundle === null || isDegradedArtifact(entry.bundle.code)
+    );
 
-    for (const { canonicalPath } of presentLocally) {
-      try {
-        const code = await fs.readTextFile(canonicalPath);
-        for (const dep of extractBundleDeps(code)) {
-          if (!seen.has(dep.hash)) pending.push({ hash: dep.hash });
-        }
-      } catch (_) {
-        /* expected: cached bundle file may be unreadable during dep scan */
+    for (const { bundle } of presentLocally) {
+      for (const dep of extractBundleDeps(bundle!.code)) {
+        if (!seen.has(dep.hash)) pending.push({ hash: dep.hash });
       }
     }
 
@@ -375,20 +403,24 @@ export async function ensureHttpBundlesExist(
             return;
           }
 
-          try {
-            const recoveredCode = await fs.readTextFile(canonicalPath);
-            for (const dep of extractBundleDeps(recoveredCode)) {
-              if (!seen.has(dep.hash)) pending.push({ hash: dep.hash });
-            }
-          } catch (_) {
-            /* expected: recovered bundle file may be unreadable during dep scan */
+          const recoveredBundle = await readCachedHttpBundleFile(fs, canonicalPath);
+          if (!recoveredBundle || isDegradedArtifact(recoveredBundle.code)) {
+            failed.add(hash);
+            return;
+          }
+          for (const dep of extractBundleDeps(recoveredBundle.code)) {
+            if (!seen.has(dep.hash)) pending.push({ hash: dep.hash });
           }
           return;
         }
 
         const code = unbrand(localCode);
 
-        if (hasIncompatibleFilePaths(code, absoluteCacheDir)) {
+        if (
+          !isHttpBundleCodeWithinLimit(code) ||
+          isDegradedArtifact(code) ||
+          hasIncompatibleFilePaths(code, absoluteCacheDir)
+        ) {
           logger.warn(
             "[HTTP-CACHE] Batch-fetched code has incompatible file paths, trying single recovery",
             { hash, localCacheDir: absoluteCacheDir },
@@ -444,6 +476,11 @@ export async function ensureHttpBundlesExist(
  * Invalidate a corrupted bundle from both local and distributed cache.
  */
 export async function invalidateHttpBundle(hash: string, cacheDir: string): Promise<boolean> {
+  if (!isValidHttpBundleHash(hash)) {
+    logger.warn("Refusing to invalidate an invalid HTTP bundle hash");
+    return false;
+  }
+
   const absoluteCacheDir = ensureAbsoluteDir(cacheDir);
   const cachePath = join(absoluteCacheDir, `http-${hash}.mjs`);
   const fs = createFileSystem();

--- a/src/transforms/esm/http-bundle-file.ts
+++ b/src/transforms/esm/http-bundle-file.ts
@@ -1,0 +1,64 @@
+/**
+ * Bounded filesystem helpers for cached HTTP bundles.
+ *
+ * @module transforms/esm/http-bundle-file
+ */
+
+import type { FileSystem } from "#veryfront/platform/compat/fs.ts";
+import { MAX_BUNDLE_CHUNK_SIZE_BYTES } from "#veryfront/utils/constants/buffers.ts";
+
+/** Maximum number of HTTP bundles accepted in one dependency graph. */
+export const MAX_HTTP_BUNDLE_GRAPH_ENTRIES = 500;
+
+/**
+ * Rewriting imports can expand a fetched module. Keep cached artifacts bounded
+ * while allowing ample headroom over the four-MiB upstream response limit.
+ */
+export const MAX_CACHED_HTTP_BUNDLE_BYTES = MAX_BUNDLE_CHUNK_SIZE_BYTES * 4;
+
+const bundleSizeEncoder = new TextEncoder();
+const HTTP_BUNDLE_HASH_PATTERN = /^[a-f0-9]{1,64}$/i;
+
+export interface CachedHttpBundleFile {
+  code: string;
+  sizeBytes: number;
+}
+
+/** Hashes are used in canonical cache filenames and must never contain path syntax. */
+export function isValidHttpBundleHash(hash: string): boolean {
+  return HTTP_BUNDLE_HASH_PATTERN.test(hash);
+}
+
+/** Measure the exact UTF-8 bytes that writeTextFile will persist. */
+export function getHttpBundleCodeSizeBytes(code: string): number {
+  return bundleSizeEncoder.encode(code).byteLength;
+}
+
+export function isHttpBundleCodeWithinLimit(code: string): boolean {
+  return getHttpBundleCodeSizeBytes(code) <= MAX_CACHED_HTTP_BUNDLE_BYTES;
+}
+
+/**
+ * Read a regular cached bundle with pre- and post-read byte bounds.
+ *
+ * The post-read check closes the race where a file grows between stat and read.
+ * Operational failures are represented as null so cache callers can invalidate
+ * or recover the artifact without confusing a cache miss with valid code.
+ */
+export async function readCachedHttpBundleFile(
+  fs: FileSystem,
+  path: string,
+): Promise<CachedHttpBundleFile | null> {
+  try {
+    const stat = await fs.stat(path);
+    if (!stat.isFile || stat.size > MAX_CACHED_HTTP_BUNDLE_BYTES) return null;
+
+    const code = await fs.readTextFile(path);
+    const sizeBytes = getHttpBundleCodeSizeBytes(code);
+    if (sizeBytes > MAX_CACHED_HTTP_BUNDLE_BYTES) return null;
+
+    return { code, sizeBytes };
+  } catch {
+    return null;
+  }
+}

--- a/src/transforms/esm/http-bundler.test.ts
+++ b/src/transforms/esm/http-bundler.test.ts
@@ -1,7 +1,33 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { bundleHttpImports, hasHttpImports } from "./http-bundler.ts";
+import { bundleHttpImports, createHTTPPlugin, hasHttpImports } from "./http-bundler.ts";
+import { MAX_BUNDLE_CHUNK_SIZE_BYTES } from "#veryfront/utils/constants/buffers.ts";
+
+type HttpOnLoadResult = {
+  contents?: string;
+  errors?: Array<{ text: string }>;
+};
+
+function captureHttpOnLoad(
+  options: Parameters<typeof createHTTPPlugin>[0],
+): (args: { path: string }) => Promise<HttpOnLoadResult> {
+  let callback:
+    | ((args: { path: string }) => Promise<HttpOnLoadResult> | HttpOnLoadResult)
+    | undefined;
+  const plugin = createHTTPPlugin(options);
+  plugin.setup(
+    {
+      onResolve() {},
+      onLoad(_filter: unknown, handler: typeof callback) {
+        callback = handler;
+      },
+    } as unknown as Parameters<typeof plugin.setup>[0],
+  );
+
+  assert(callback);
+  return async (args) => await callback!(args);
+}
 
 describe("transforms/esm/http-bundler", () => {
   describe("hasHttpImports", () => {
@@ -97,6 +123,35 @@ describe("transforms/esm/http-bundler", () => {
       const code = `import lib from "https://esm.sh/lodash@4";`;
       const result = await bundleHttpImports(code, "/tmp/cache", "abc123", "19.0.0");
       assertEquals(result.includes("react@19.0.0"), true);
+    });
+  });
+
+  describe("createHTTPPlugin", () => {
+    it("rejects and cancels an oversized module response", async () => {
+      let cancelled = false;
+      const onLoad = captureHttpOnLoad({
+        timeoutMs: 1_000,
+        fetchFn: (() =>
+          Promise.resolve(
+            new Response(
+              new ReadableStream({
+                cancel() {
+                  cancelled = true;
+                },
+              }),
+              {
+                headers: {
+                  "content-length": String(MAX_BUNDLE_CHUNK_SIZE_BYTES + 1),
+                },
+              },
+            ),
+          )) as typeof fetch,
+      });
+
+      const result = await onLoad({ path: "https://cdn.example/module.js" });
+
+      assert(result.errors?.[0]?.text.includes("response exceeds"));
+      assertEquals(cancelled, true);
     });
   });
 });

--- a/src/transforms/esm/http-bundler.ts
+++ b/src/transforms/esm/http-bundler.ts
@@ -15,6 +15,11 @@ import {
 } from "#veryfront/config/environment-config.ts";
 import { isReactSpecifier } from "#veryfront/platform/compat/react-paths.ts";
 import { HTTP_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
+import { MAX_BUNDLE_CHUNK_SIZE_BYTES } from "#veryfront/utils/constants/buffers.ts";
+import { readHttpModuleText } from "../shared/http-module-response.ts";
+import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
+import { snapshotThrowableDiagnostic } from "#veryfront/errors/safe-diagnostics.ts";
+import { MAX_TIMER_DELAY_MS } from "#veryfront/utils/constants/limits.ts";
 
 const LOG_PREFIX = "[HTTP-HANDLER]";
 
@@ -42,10 +47,32 @@ export function hasHttpImports(code: string): boolean {
 /** Re-export getReactUrls for backwards compatibility */
 export { getReactUrls };
 
+export interface HttpPluginOptions {
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+}
+
+function requireHttpTimeout(timeoutMs: number): number {
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs <= 0 ||
+    timeoutMs > MAX_TIMER_DELAY_MS
+  ) {
+    throw new RangeError(
+      `HTTP plugin timeout must be an integer between 1 and ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+  return timeoutMs;
+}
+
 /**
  * esbuild plugin that fetches HTTP imports and rewrites esm.sh URLs.
  */
-export function createHTTPPlugin(): Plugin {
+export function createHTTPPlugin(options: HttpPluginOptions = {}): Plugin {
+  const configuredTimeoutMs = options.timeoutMs === undefined
+    ? undefined
+    : requireHttpTimeout(options.timeoutMs);
+
   return {
     name: "vf-http-fetch",
     setup(build: Parameters<Plugin["setup"]>[0]) {
@@ -90,6 +117,7 @@ export function createHTTPPlugin(): Plugin {
 
       build.onLoad({ filter: /.*/, namespace: "http-url" }, async (args) => {
         let requestUrl = args.path;
+        const safeUrl = sanitizeUrlForSpan(args.path);
 
         try {
           const url = new URL(args.path);
@@ -103,25 +131,36 @@ export function createHTTPPlugin(): Plugin {
             requestUrl = url.toString();
           }
         } catch (urlError) {
-          logger.debug(`${LOG_PREFIX} URL parse error for ${args.path}:`, urlError);
+          logger.debug(`${LOG_PREFIX} URL parse error for ${safeUrl}:`, urlError);
         }
 
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), getHttpTimeout());
+        const timeoutMs = configuredTimeoutMs ?? requireHttpTimeout(getHttpTimeout());
+        const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
         try {
-          const res = await fetch(requestUrl, {
+          const res = await (options.fetchFn ?? fetch)(requestUrl, {
             headers: { "user-agent": HTTP_USER_AGENT },
             signal: controller.signal,
             redirect: "follow",
           });
 
           if (!res.ok) {
-            logger.warn(`${LOG_PREFIX} HTTP ${res.status} fetching ${args.path}`);
-            return { errors: [{ text: `Failed to fetch ${args.path}: ${res.status}` }] };
+            try {
+              const cancellation = res.body?.cancel();
+              if (cancellation) void cancellation.catch(() => undefined);
+            } catch {
+              /* cancellation is best-effort cleanup */
+            }
+            logger.warn(`${LOG_PREFIX} HTTP ${res.status} fetching ${safeUrl}`);
+            return { errors: [{ text: `Failed to fetch ${safeUrl}: ${res.status}` }] };
           }
 
-          const contents = await res.text();
+          const contents = await readHttpModuleText(
+            res,
+            MAX_BUNDLE_CHUNK_SIZE_BYTES,
+            controller.signal,
+          );
 
           // Validate response is JavaScript, not an HTML error page.
           // esm.sh can return HTTP 200 with HTML error pages when packages fail to build.
@@ -134,20 +173,20 @@ export function createHTTPPlugin(): Plugin {
             /<title>ESM[^<]*<\/title>/i.test(contents.slice(0, 500));
 
           if (isHtmlContent) {
-            logger.warn(`${LOG_PREFIX} Received HTML instead of JS for ${args.path}`);
+            logger.warn(`${LOG_PREFIX} Received HTML instead of JS for ${safeUrl}`);
             return {
               errors: [{
                 text:
-                  `Received HTML instead of JavaScript from ${args.path}. Package may not exist or failed to build on esm.sh.`,
+                  `Received HTML instead of JavaScript from ${safeUrl}. Package may not exist or failed to build on esm.sh.`,
               }],
             };
           }
 
           return { contents, loader: "js" };
         } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          logger.warn(`${LOG_PREFIX} Network error fetching ${args.path}: ${errorMessage}`);
-          return { errors: [{ text: `Network error fetching ${args.path}: ${errorMessage}` }] };
+          const errorMessage = snapshotThrowableDiagnostic(error);
+          logger.warn(`${LOG_PREFIX} Network error fetching ${safeUrl}: ${errorMessage}`);
+          return { errors: [{ text: `Network error fetching ${safeUrl}: ${errorMessage}` }] };
         } finally {
           clearTimeout(timeout);
         }

--- a/src/transforms/esm/http-cache.test.ts
+++ b/src/transforms/esm/http-cache.test.ts
@@ -732,6 +732,147 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
     }
   });
 
+  it("creates the same complete manifest for network, disk, and memory cache hits", async () => {
+    const rootUrl = "https://modules.example.com/manifest-root.js";
+    const childUrl = "https://modules.example.com/manifest-child.js";
+    let fetchCount = 0;
+
+    const mockFetch = ((input: string | URL | Request) => {
+      fetchCount += 1;
+      const code = String(input) === rootUrl
+        ? `import { child } from "${childUrl}"; export { child };`
+        : "export const child = true;";
+      return Promise.resolve(
+        new Response(code, {
+          headers: { "content-type": "application/javascript" },
+        }),
+      );
+    }) as typeof fetch;
+
+    await withIsolatedHttpCache("vf-complete-manifest-", mockFetch, async (tempDir) => {
+      const source = `import { child } from "${rootUrl}"; export { child };`;
+      const options = { cacheDir: tempDir, importMap: { imports: {}, scopes: {} } };
+
+      const networkResult = await cacheHttpImportsToLocal(source, options);
+      assert(networkResult.bundleManifestId, "Expected a manifest after the network fetch");
+
+      __injectCachesForTests({
+        cachedPaths: new Map(),
+        processingStack: new Set(),
+        lastDistributedRefresh: new Map(),
+      });
+      const diskResult = await cacheHttpImportsToLocal(source, options);
+      assertEquals(diskResult.bundleManifestId, networkResult.bundleManifestId);
+
+      const memoryResult = await cacheHttpImportsToLocal(source, options);
+      assertEquals(memoryResult.bundleManifestId, networkResult.bundleManifestId);
+      assertEquals(fetchCount, 2, "Expected one network request per module");
+    });
+  });
+
+  it("creates complete manifests for every request sharing an in-flight fetch", async () => {
+    const moduleUrl = "https://modules.example.com/in-flight-manifest.js";
+    let fetchCount = 0;
+    const mockFetch = (async () => {
+      fetchCount += 1;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return new Response("export const value = true;", {
+        headers: { "content-type": "application/javascript" },
+      });
+    }) as typeof fetch;
+
+    await withIsolatedHttpCache("vf-in-flight-manifest-", mockFetch, async (tempDir) => {
+      const source = `import { value } from "${moduleUrl}"; export { value };`;
+      const options = { cacheDir: tempDir, importMap: { imports: {}, scopes: {} } };
+
+      const [first, second] = await Promise.all([
+        cacheHttpImportsToLocal(source, options),
+        cacheHttpImportsToLocal(source, options),
+      ]);
+
+      assert(first.bundleManifestId);
+      assertEquals(second.bundleManifestId, first.bundleManifestId);
+      assertEquals(fetchCount, 1);
+    });
+  });
+
+  it("reconstructs a complete manifest from distributed-cache bundles", async () => {
+    const rootUrl = "https://modules.example.com/distributed-manifest-root.js";
+    const childUrl = "https://modules.example.com/distributed-manifest-child.js";
+    const distributed = new Map<string, string>();
+    let fetchCount = 0;
+    const mockFetch = ((input: string | URL | Request) => {
+      fetchCount += 1;
+      const code = String(input) === rootUrl
+        ? `import { child } from "${childUrl}"; export { child };`
+        : "export const child = true;";
+      return Promise.resolve(
+        new Response(code, {
+          headers: { "content-type": "application/javascript" },
+        }),
+      );
+    }) as typeof fetch;
+
+    await withIsolatedHttpCache("vf-distributed-manifest-", mockFetch, async (tempDir) => {
+      __setDistributedCacheAccessorForTests(() =>
+        Promise.resolve(createMemoryBackend(distributed))
+      );
+      const source = `import { child } from "${rootUrl}"; export { child };`;
+      const options = { cacheDir: tempDir, importMap: { imports: {}, scopes: {} } };
+      const networkResult = await cacheHttpImportsToLocal(source, options);
+      assert(networkResult.bundleManifestId);
+
+      for await (const entry of readDir(tempDir)) {
+        if (entry.isFile && entry.name.endsWith(".mjs")) {
+          await remove(join(tempDir, entry.name));
+        }
+      }
+      __injectCachesForTests({
+        cachedPaths: new Map(),
+        processingStack: new Set(),
+        lastDistributedRefresh: new Map(),
+      });
+
+      const distributedResult = await cacheHttpImportsToLocal(source, options);
+
+      assertEquals(distributedResult.bundleManifestId, networkResult.bundleManifestId);
+      assertEquals(fetchCount, 2, "Expected the second transform to avoid network requests");
+    });
+  });
+
+  it("does not publish a partial manifest when one bundle is degraded", async () => {
+    const healthyUrl = "https://modules.example.com/healthy-manifest-entry.js";
+    const parentUrl = "https://modules.example.com/degraded-manifest-entry.js";
+    const childUrl = "https://modules.example.com/unavailable-lazy-entry.js";
+    const mockFetch = ((input: string | URL | Request) => {
+      const url = String(input);
+      if (url === childUrl) {
+        return Promise.resolve(new Response("upstream failure", { status: 502 }));
+      }
+      const code = url === parentUrl
+        ? `export const load = () => import("${childUrl}");`
+        : "export const healthy = true;";
+      return Promise.resolve(
+        new Response(code, {
+          headers: { "content-type": "application/javascript" },
+        }),
+      );
+    }) as typeof fetch;
+
+    await withIsolatedHttpCache("vf-partial-manifest-", mockFetch, async (tempDir) => {
+      const result = await cacheHttpImportsToLocal(
+        [
+          `import { healthy } from "${healthyUrl}";`,
+          `import { load } from "${parentUrl}";`,
+          "export { healthy, load };",
+        ].join("\n"),
+        { cacheDir: tempDir, importMap: { imports: {}, scopes: {} } },
+      );
+
+      assertEquals(result.bundleManifestId, undefined);
+    });
+  });
+
   it("rewrites react-dom dependencies with the requested React version", async () => {
     const tempDir = await makeTempDir({ prefix: "vf-react-version-cache-" });
     const originalFetch = globalThis.fetch;

--- a/src/transforms/esm/http-cache.test.ts
+++ b/src/transforms/esm/http-cache.test.ts
@@ -32,6 +32,7 @@ import type { CacheBackend } from "#veryfront/cache/types.ts";
 import { buildHttpCacheIdentity } from "./http-cache-helpers.ts";
 import { simpleHash } from "#veryfront/utils/hash-utils.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { MAX_BUNDLE_CHUNK_SIZE_BYTES } from "#veryfront/utils/constants/buffers.ts";
 
 /** Duplicated from http-cache.ts for isolated unit testing of the pattern. */
 const BUNDLE_RE = /file:\/\/([^"'\s]+veryfront-http-bundle\/http-([a-f0-9]+)\.mjs)/gi;
@@ -183,6 +184,40 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
 
       assert(cachedUrl.startsWith("file://"));
       assertEquals(fetchCount, 2);
+    });
+  });
+
+  it("rejects an oversized module body without retrying", async () => {
+    let fetchCount = 0;
+    let bodyCancelled = false;
+    const mockFetch = (() => {
+      fetchCount += 1;
+      return Promise.resolve(
+        new Response(
+          new ReadableStream({
+            cancel() {
+              bodyCancelled = true;
+            },
+          }),
+          {
+            headers: {
+              "content-length": String(MAX_BUNDLE_CHUNK_SIZE_BYTES + 1),
+            },
+          },
+        ),
+      );
+    }) as typeof fetch;
+
+    await withIsolatedHttpCache("vf-esm-oversized-response-", mockFetch, async (tempDir) => {
+      const error = await assertRejects(
+        () => cacheModuleToLocal("https://esm.sh/oversized", tempDir),
+        Error,
+        `response exceeds ${MAX_BUNDLE_CHUNK_SIZE_BYTES} bytes`,
+      );
+
+      assertInstanceOf(error, Error);
+      assertEquals(fetchCount, 1);
+      assertEquals(bodyCancelled, true);
     });
   });
 

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -29,6 +29,8 @@ import {
   tokenizeCachePaths,
 } from "#veryfront/cache/paths.ts";
 import { looksLikeHtmlContent as looksLikeHtmlNotJs } from "./html-content.ts";
+import { HttpModuleBodyError, readHttpModuleText } from "../shared/http-module-response.ts";
+import { MAX_BUNDLE_CHUNK_SIZE_BYTES } from "#veryfront/utils/constants/buffers.ts";
 
 // Extracted modules
 import { embedSourceUrl, extractSourceUrl } from "./source-url-embed.ts";
@@ -151,11 +153,17 @@ async function fetchHttpModuleAttempt(
     }
 
     return {
-      code: await response.text(),
+      code: await readHttpModuleText(
+        response,
+        MAX_BUNDLE_CHUNK_SIZE_BYTES,
+        signal,
+      ),
       contentType: response.headers.get("content-type") ?? "",
     };
   } catch (error) {
-    if (error instanceof HttpModuleResponseError) throw error;
+    if (error instanceof HttpModuleResponseError || error instanceof HttpModuleBodyError) {
+      throw error;
+    }
     if (response) await discardResponseBody(response);
 
     const requestErrorType = error instanceof Error ? error.name : typeof error;
@@ -185,8 +193,10 @@ async function fetchHttpModule(url: string): Promise<HttpModuleFetchResult> {
         maxAttempts: HTTP_MODULE_FETCH_MAX_ATTEMPTS,
         timeoutMs: HTTP_FETCH_TIMEOUT_MS,
         shouldRetry: (error) =>
-          !(error instanceof HttpModuleResponseError) ||
-          shouldRetryHttpModuleFetch(error.status),
+          error instanceof HttpModuleBodyError
+            ? false
+            : !(error instanceof HttpModuleResponseError) ||
+              shouldRetryHttpModuleFetch(error.status),
         computeDelay: (attempt) => HTTP_MODULE_FETCH_RETRY_DELAY_MS * (attempt + 1),
         onRetry: ({ error, attempt }) => {
           httpCacheLog.warn("HTTP module fetch failed, retrying", {
@@ -207,6 +217,11 @@ async function fetchHttpModule(url: string): Promise<HttpModuleFetchResult> {
     if (error instanceof HttpModuleRequestError) {
       throw BUILD_FAILED.create({
         detail: `Failed to fetch ${safeUrl}: ${error.requestErrorType}`,
+      });
+    }
+    if (error instanceof HttpModuleBodyError) {
+      throw BUILD_FAILED.create({
+        detail: `Failed to fetch ${safeUrl}: ${error.message}`,
       });
     }
     throw error;

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -53,12 +53,22 @@ import {
 } from "./http-cache-helpers.ts";
 import { extractBundleDeps, validateBundleDepsExist } from "./bundle-deps-validator.ts";
 import {
-  __clearInFlightHttpFetches,
   bundleAccumulatorStorage,
+  createBundleAccumulator,
+  markBundleAccumulatorIncomplete,
+  trackCachedBundleGraph,
+  trackWrittenBundle,
+} from "./bundle-accumulator.ts";
+import {
+  isHttpBundleCodeWithinLimit,
+  MAX_CACHED_HTTP_BUNDLE_BYTES,
+  readCachedHttpBundleFile,
+} from "./http-bundle-file.ts";
+import {
+  __clearInFlightHttpFetches,
   inFlightHttpFetches,
   processingStackStorage,
   refreshDistributedCacheAsync,
-  trackBundleAccumulator,
   waitForInFlightFetch,
 } from "./in-flight-manager.ts";
 import {
@@ -251,21 +261,31 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
   const cacheIdentity = await buildHttpCacheIdentity(normalizedUrl, options);
   const identityMetadata = await buildHttpCacheIdentityMetadata(normalizedUrl, options);
   const cacheKey = `${cacheDir}:${cacheIdentity}`;
-
-  const existing = getCachedPaths().get(cacheKey);
-  if (existing) {
-    if (await exists(existing)) return existing;
-    getCachedPaths().delete(cacheKey);
-  }
-
   const hash = await hashHttpCacheIdentity(cacheIdentity);
   const cachePath = join(cacheDir, `http-${hash}.mjs`);
   const fs = createFileSystem();
 
-  if (await exists(cachePath)) {
-    const code = await fs.readTextFile(cachePath);
+  const existing = getCachedPaths().get(cacheKey);
+  if (existing) {
+    if (
+      await exists(existing) &&
+      await trackCachedBundleGraph(hash, normalizedUrl, existing, cacheDir)
+    ) {
+      return existing;
+    }
+    getCachedPaths().delete(cacheKey);
+  }
 
-    if (isDegradedArtifact(code)) {
+  if (await exists(cachePath)) {
+    const cachedBundle = await readCachedHttpBundleFile(fs, cachePath);
+    const code = cachedBundle?.code;
+
+    if (!code) {
+      httpCacheLog.debug("Local cache bundle is unreadable or oversized, will re-fetch", {
+        url: safeUrl,
+        hash,
+      });
+    } else if (isDegradedArtifact(code)) {
       // The artifact on disk is the fallback a previous render wrote when a
       // dependency could not be prefetched. Retry the prefetch instead of
       // handing the degradation on.
@@ -294,8 +314,9 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
             identityMetadata,
             getLastDistributedRefresh,
           );
-          trackBundleAccumulator(hash, normalizedUrl, cachePath);
-          return cachePath;
+          if (await trackCachedBundleGraph(hash, normalizedUrl, cachePath, cacheDir)) {
+            return cachePath;
+          }
         }
       } else {
         getCachedPaths().set(cacheKey, cachePath);
@@ -307,8 +328,9 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
           identityMetadata,
           getLastDistributedRefresh,
         );
-        trackBundleAccumulator(hash, normalizedUrl, cachePath);
-        return cachePath;
+        if (await trackCachedBundleGraph(hash, normalizedUrl, cachePath, cacheDir)) {
+          return cachePath;
+        }
       }
     }
   }
@@ -331,7 +353,14 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
   let inFlight = inFlightHttpFetches.get(cacheKey);
   while (inFlight) {
     const result = await waitForInFlightFetch(inFlight, HTTP_MODULE_FETCH_MAX_WAIT_MS);
-    if (result !== undefined) return result;
+    if (result !== undefined) {
+      if (
+        result === null ||
+        await trackCachedBundleGraph(hash, normalizedUrl, result, cacheDir)
+      ) {
+        return result;
+      }
+    }
 
     if (inFlightHttpFetches.get(cacheKey) === inFlight) {
       inFlightHttpFetches.delete(cacheKey);
@@ -346,39 +375,20 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
     if (cacheResult.code) {
       const cachedCode = unbrand(cacheResult.code);
       const deps = extractBundleDeps(cachedCode);
+      const isUsable = !isDegradedArtifact(cachedCode) &&
+        isHttpBundleCodeWithinLimit(cachedCode) &&
+        (deps.length === 0 || await validateBundleDepsExist(deps, cacheDir));
 
-      if (deps.length > 0) {
-        const depsExist = await validateBundleDepsExist(deps, cacheDir);
-        if (!depsExist) {
-          httpCacheLog.debug("Cached code has missing bundle deps, will re-fetch", {
-            url: safeUrl,
-            hash,
-            missingDeps: deps.length,
-          });
-        } else {
-          logger.debug(
-            cacheResult.wasGzipped
-              ? "[HTTP-CACHE] Distributed cache hit (gzip decoded)"
-              : "[HTTP-CACHE] Distributed cache hit",
-            { url: safeUrl, hash },
-          );
-          await fs.mkdir(cacheDir, { recursive: true });
-          await fs.writeTextFile(cachePath, cachedCode);
-
-          if (!(await exists(cachePath))) {
-            throw FILE_NOT_FOUND.create({
-              detail:
-                `[HTTP-CACHE] INVARIANT VIOLATION: Redis recovery write succeeded but file does not exist: ${cachePath}`,
-            });
-          }
-
-          getCachedPaths().set(cacheKey, cachePath);
-          return cachePath;
-        }
+      if (!isUsable) {
+        httpCacheLog.debug("Distributed cache bundle is incomplete or oversized, will re-fetch", {
+          url: safeUrl,
+          hash,
+          dependencyCount: deps.length,
+        });
       } else {
         logger.debug(
           cacheResult.wasGzipped
-            ? "[HTTP-CACHE] Distributed cache hit (gzip decoded, no deps)"
+            ? "[HTTP-CACHE] Distributed cache hit (gzip decoded)"
             : "[HTTP-CACHE] Distributed cache hit",
           { url: safeUrl, hash },
         );
@@ -393,7 +403,10 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
         }
 
         getCachedPaths().set(cacheKey, cachePath);
-        return cachePath;
+        if (await trackCachedBundleGraph(hash, normalizedUrl, cachePath, cacheDir)) {
+          return cachePath;
+        }
+        getCachedPaths().delete(cacheKey);
       }
     } else if (cacheResult.failReason && cacheResult.failReason !== "not_found") {
       httpCacheLog.debug("Distributed cache get failed", {
@@ -440,6 +453,11 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
 
     code = embedSourceUrl(code, normalizedUrl);
     if (degraded.length > 0) code = markDegradedArtifact(code);
+    if (!isHttpBundleCodeWithinLimit(code)) {
+      throw BUNDLE_ERROR.create({
+        detail: `Rewritten HTTP module exceeds ${MAX_CACHED_HTTP_BUNDLE_BYTES} bytes`,
+      });
+    }
 
     await fs.mkdir(cacheDir, { recursive: true });
     await fs.writeTextFile(cachePath, code);
@@ -462,6 +480,7 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
         hash,
         degraded: degraded.map(sanitizeUrlForSpan),
       });
+      markBundleAccumulatorIncomplete();
       return cachePath;
     }
 
@@ -481,13 +500,10 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
     }
 
     getCachedPaths().set(cacheKey, cachePath);
-
-    const accumulator = bundleAccumulatorStorage.getStore();
-    if (accumulator) {
-      accumulator.push({
-        hash: String(hash),
-        url: normalizedUrl,
-        sizeBytes: code.length,
+    if (!(await trackWrittenBundle(hash, normalizedUrl, cachePath))) {
+      getCachedPaths().delete(cacheKey);
+      throw BUNDLE_ERROR.create({
+        detail: "Freshly written HTTP bundle could not be verified",
       });
     }
 
@@ -532,7 +548,8 @@ export function cacheHttpImportsToLocal(
   options: CacheOptions,
 ): Promise<CacheHttpImportsResult> {
   const requestOptions = prepareHttpCacheRequestOptions(options);
-  return bundleAccumulatorStorage.run([], async () => {
+  const accumulator = createBundleAccumulator();
+  return bundleAccumulatorStorage.run(accumulator, async () => {
     const { replacements } = await buildReplacements(
       code,
       undefined,
@@ -548,8 +565,13 @@ export function cacheHttpImportsToLocal(
       (specifier) => replacements.get(specifier) ?? null,
     );
 
-    const bundles = bundleAccumulatorStorage.getStore();
-    if (!bundles?.length) return { code: rewrittenCode };
+    const currentAccumulator = bundleAccumulatorStorage.getStore();
+    if (!currentAccumulator?.complete || currentAccumulator.bundles.size === 0) {
+      return { code: rewrittenCode };
+    }
+    const bundles = [...currentAccumulator.bundles.values()].sort((left, right) =>
+      left.hash.localeCompare(right.hash)
+    );
 
     try {
       const manifest = await createBundleManifest(bundles);

--- a/src/transforms/esm/in-flight-manager.ts
+++ b/src/transforms/esm/in-flight-manager.ts
@@ -8,21 +8,17 @@
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
-import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { HTTP_MODULE_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
 import { httpBundleCache } from "./http-cache-wrapper.ts";
 import { asLocalModuleCode } from "./http-cache-invariants.ts";
 import { getManifestIdForHash, refreshManifestTTL } from "./bundle-manifest-ttl.ts";
-import type { BundleEntry } from "./bundle-manifest-types.ts";
 import type { HttpCacheIdentityMetadata, HttpCacheLike } from "./http-cache-helpers.ts";
 
 const logger = rendererLogger.component("http-cache");
 
 const DISTRIBUTED_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000;
 
-/** Per-request accumulator for bundle metadata during cacheHttpImportsToLocal. */
-export const bundleAccumulatorStorage = new AsyncLocalStorage<BundleEntry[]>();
 /** Per-request stack used to detect circular HTTP module dependencies. */
 export const processingStackStorage = new AsyncLocalStorage<Set<string>>();
 /** Deduplicate concurrent HTTP module fetches to avoid races. */
@@ -118,29 +114,4 @@ export function refreshDistributedCacheAsync(
   })().catch((err) => {
     logger.debug("Distributed cache async refresh error", { err });
   });
-}
-
-/**
- * Track bundle for manifest accumulation if in accumulation context.
- */
-export function trackBundleAccumulator(
-  hash: string,
-  normalizedUrl: string,
-  cachePath: string,
-): void {
-  const accumulator = bundleAccumulatorStorage.getStore();
-  if (accumulator) {
-    void (async () => {
-      try {
-        const stat = await createFileSystem().stat(cachePath);
-        accumulator.push({
-          hash: String(hash),
-          url: normalizedUrl,
-          sizeBytes: stat?.size ?? 0,
-        });
-      } catch {
-        // Ignore stat errors
-      }
-    })();
-  }
 }

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -154,7 +154,7 @@ function matchUnresolvedVfModuleSpecifier(specifier: string): string | null {
  * Returns true if any unresolved or malformed imports are found.
  */
 function hasUnresolvedVfModules(code: string): boolean {
-  const matches = findStaticImportFromSpans(code, matchUnresolvedVfModuleSpecifier);
+  const matches = findStaticImportFromSpans(code, matchUnresolvedVfModuleSpecifier, 1);
   const first = matches[0];
   if (first) {
     logger.debug(`${LOG_PREFIX_MDX_LOADER} Cached module has unresolved _vf_modules import`, {

--- a/src/transforms/mdx/esm-module-loader/import-transformer.ts
+++ b/src/transforms/mdx/esm-module-loader/import-transformer.ts
@@ -54,6 +54,11 @@ const mdxRootBareDependencyStrategy: ImportRewriteStrategy = {
 const mdxRootDependencyRewriter = new UnifiedImportRewriter({
   strategies: [mdxRootBareDependencyStrategy],
 });
+import { parallelMap } from "#veryfront/utils/parallel.ts";
+import {
+  assertMdxModuleImportCount,
+  MAX_MDX_MODULE_TRANSFORM_CONCURRENCY,
+} from "./module-fetcher/limits.ts";
 
 /**
  * Rewrite @/ aliased imports to /_vf_modules/ paths.
@@ -203,14 +208,16 @@ export async function transformJsxImports(
   }
 
   if (importsToProcess.length === 0) return code;
+  assertMdxModuleImportCount("compiled MDX JSX imports", importsToProcess.length);
 
   const transformStart = performance.now();
   logger.debug(
     `${LOG_PREFIX_MDX_LOADER} Transforming ${importsToProcess.length} JSX imports in parallel`,
   );
 
-  const transformResults = await Promise.all(
-    importsToProcess.map(async ({ specifier, filePath, ext }) => {
+  const transformResults = await parallelMap(
+    importsToProcess,
+    async ({ specifier, filePath, ext }) => {
       try {
         const isFrameworkFile = filePath.startsWith(FRAMEWORK_ROOT);
         let jsxCode: string | Uint8Array;
@@ -284,7 +291,8 @@ export async function transformJsxImports(
         logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to transform JSX import: ${filePath}`, error);
         return null;
       }
-    }),
+    },
+    { concurrency: MAX_MDX_MODULE_TRANSFORM_CONCURRENCY },
   );
 
   logger.debug(`${LOG_PREFIX_MDX_LOADER} JSX transform phase completed`, {

--- a/src/transforms/mdx/esm-module-loader/import-transformer.ts
+++ b/src/transforms/mdx/esm-module-loader/import-transformer.ts
@@ -55,6 +55,7 @@ const mdxRootDependencyRewriter = new UnifiedImportRewriter({
   strategies: [mdxRootBareDependencyStrategy],
 });
 import { parallelMap } from "#veryfront/utils/parallel.ts";
+import { Semaphore } from "#veryfront/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts";
 import {
   assertMdxModuleImportCount,
   MAX_MDX_MODULE_TRANSFORM_CONCURRENCY,
@@ -292,7 +293,7 @@ export async function transformJsxImports(
         return null;
       }
     },
-    { concurrency: MAX_MDX_MODULE_TRANSFORM_CONCURRENCY },
+    { semaphore: new Semaphore(MAX_MDX_MODULE_TRANSFORM_CONCURRENCY) },
   );
 
   logger.debug(`${LOG_PREFIX_MDX_LOADER} JSX transform phase completed`, {

--- a/src/transforms/mdx/esm-module-loader/loader-helpers.ts
+++ b/src/transforms/mdx/esm-module-loader/loader-helpers.ts
@@ -26,6 +26,12 @@ import {
 import { createModuleFetcherContext, fetchAndCacheModule } from "./module-fetcher/index.ts";
 import { buildMissingModuleError } from "./missing-module.ts";
 import type { ESMLoaderContext } from "./types.ts";
+import { parallelMap } from "#veryfront/utils/parallel.ts";
+import {
+  assertMdxModuleImportCount,
+  MAX_MDX_MODULE_IMPORTS_PER_FILE,
+  MAX_MDX_MODULE_TRANSFORM_CONCURRENCY,
+} from "./module-fetcher/limits.ts";
 
 /**
  * Check which framework bundles are missing from disk.
@@ -106,6 +112,7 @@ export function findVfModuleImports(
   return findStaticImportFromSpans(
     code,
     (specifier) => specifier.match(/^\/?(_vf_modules\/[^?]+)(?:\?.*)?$/)?.[1],
+    MAX_MDX_MODULE_IMPORTS_PER_FILE + 1,
   );
 }
 
@@ -139,6 +146,7 @@ export async function processVfModuleImports(
     });
     return code;
   }
+  assertMdxModuleImportCount("compiled MDX entry", imports.length);
 
   if (!context.projectId) {
     throw INVALID_ARGUMENT.create({
@@ -169,8 +177,9 @@ export async function processVfModuleImports(
 
   const fetchStart = performance.now();
 
-  const results = await Promise.all(
-    imports.map(async ({ original, path, start, end }, index) => {
+  const results = await parallelMap(
+    imports,
+    async ({ original, path, start, end }, index) => {
       return await withSpan(
         SpanNames.MDX_FETCH_MODULE,
         async () => {
@@ -195,7 +204,8 @@ export async function processVfModuleImports(
           "mdx.project_slug": projectSlug,
         },
       );
-    }),
+    },
+    { concurrency: MAX_MDX_MODULE_TRANSFORM_CONCURRENCY },
   );
 
   logger.debug(`${LOG_PREFIX_MDX_LOADER} Module fetch phase completed`, {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
 import { fetchModuleViaHTTP } from "./http-fetcher.ts";
-import { MAX_MDX_MODULE_CODE_BYTES } from "./recovery-payload.ts";
+import { MAX_MDX_MODULE_CODE_BYTES } from "./limits.ts";
 import { HttpModuleBodyTooLargeError } from "../../../shared/http-module-response.ts";
 
 describe("module-fetcher/http-fetcher", () => {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts
@@ -1,9 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
 import { fetchModuleViaHTTP } from "./http-fetcher.ts";
+import { MAX_MDX_MODULE_CODE_BYTES } from "./recovery-payload.ts";
+import { HttpModuleBodyTooLargeError } from "../../../shared/http-module-response.ts";
 
 describe("module-fetcher/http-fetcher", () => {
   it("rewrites the matched import instead of the same text in an earlier comment", async () => {
@@ -56,5 +58,149 @@ describe("module-fetcher/http-fetcher", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it("rejects and cancels an oversized local module response", async () => {
+    let cancelled = false;
+    const logger = { debug: () => {}, warn: () => {} } as unknown as Logger;
+    const adapter = {
+      env: { get: () => undefined },
+    } as unknown as RuntimeAdapter;
+
+    await assertRejects(
+      () =>
+        fetchModuleViaHTTP(
+          "_vf_modules/pages/index.js",
+          adapter,
+          () => Promise.resolve(null),
+          logger,
+          "docs",
+          true,
+          undefined,
+          {
+            fetchFn: (() =>
+              Promise.resolve(
+                new Response(
+                  new ReadableStream({
+                    cancel() {
+                      cancelled = true;
+                    },
+                  }),
+                  {
+                    headers: {
+                      "content-length": String(MAX_MDX_MODULE_CODE_BYTES + 1),
+                    },
+                  },
+                ),
+              )) as typeof fetch,
+          },
+        ),
+      HttpModuleBodyTooLargeError,
+      `exceeds ${MAX_MDX_MODULE_CODE_BYTES} bytes`,
+    );
+    assertEquals(cancelled, true);
+  });
+
+  it("times out and cancels a stalled local module body", async () => {
+    let cancelled = false;
+    const logger = { debug: () => {}, warn: () => {} } as unknown as Logger;
+    const adapter = {
+      env: { get: () => undefined },
+    } as unknown as RuntimeAdapter;
+
+    await assertRejects(
+      () =>
+        fetchModuleViaHTTP(
+          "_vf_modules/pages/index.js",
+          adapter,
+          () => Promise.resolve(null),
+          logger,
+          "docs",
+          true,
+          undefined,
+          {
+            timeoutMs: 5,
+            fetchFn: (() =>
+              Promise.resolve(
+                new Response(
+                  new ReadableStream({
+                    pull() {
+                      return new Promise(() => {});
+                    },
+                    cancel() {
+                      cancelled = true;
+                    },
+                  }),
+                ),
+              )) as typeof fetch,
+          },
+        ),
+      DOMException,
+      "timed out after 5ms",
+    );
+    assertEquals(cancelled, true);
+  });
+
+  it("rejects an invalid local development port before fetching", async () => {
+    let fetched = false;
+    const logger = { debug: () => {}, warn: () => {} } as unknown as Logger;
+    const adapter = {
+      env: {
+        get(key: string) {
+          return key === "PORT" ? "not-a-port" : undefined;
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    await assertRejects(
+      () =>
+        fetchModuleViaHTTP(
+          "_vf_modules/pages/index.js",
+          adapter,
+          () => Promise.resolve(null),
+          logger,
+          "docs.example",
+          true,
+          undefined,
+          {
+            fetchFn: (() => {
+              fetched = true;
+              return Promise.resolve(new Response(""));
+            }) as typeof fetch,
+          },
+        ),
+      TypeError,
+    );
+    assertEquals(fetched, false);
+  });
+
+  it("rejects an invalid project slug before fetching", async () => {
+    let fetched = false;
+    const logger = { debug: () => {}, warn: () => {} } as unknown as Logger;
+    const adapter = {
+      env: { get: () => undefined },
+    } as unknown as RuntimeAdapter;
+
+    await assertRejects(
+      () =>
+        fetchModuleViaHTTP(
+          "_vf_modules/pages/index.js",
+          adapter,
+          () => Promise.resolve(null),
+          logger,
+          "docs.example",
+          true,
+          undefined,
+          {
+            fetchFn: (() => {
+              fetched = true;
+              return Promise.resolve(new Response(""));
+            }) as typeof fetch,
+          },
+        ),
+      TypeError,
+      "valid DNS label",
+    );
+    assertEquals(fetched, false);
   });
 });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
 import { fetchModuleViaHTTP } from "./http-fetcher.ts";
-import { MAX_MDX_MODULE_CODE_BYTES } from "./limits.ts";
+import { MAX_MDX_MODULE_CODE_BYTES, MAX_MDX_MODULE_TRANSFORM_CONCURRENCY } from "./limits.ts";
 import { HttpModuleBodyTooLargeError } from "../../../shared/http-module-response.ts";
 
 describe("module-fetcher/http-fetcher", () => {
@@ -58,6 +58,36 @@ describe("module-fetcher/http-fetcher", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it("resolves nested HTTP imports with bounded concurrency", async () => {
+    const importCount = MAX_MDX_MODULE_TRANSFORM_CONCURRENCY + 4;
+    const moduleCode = Array.from(
+      { length: importCount },
+      (_, index) => `import value${index} from "./dependency-${index}.js";`,
+    ).join("\n");
+    let active = 0;
+    let peak = 0;
+
+    const result = await fetchModuleViaHTTP(
+      "_vf_modules/pages/index.js",
+      { env: { get: () => undefined } } as unknown as RuntimeAdapter,
+      async (path) => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        active -= 1;
+        return `/cache/${path.replaceAll("/", "__")}.mjs`;
+      },
+      { debug: () => {}, warn: () => {} } as unknown as Logger,
+      "docs",
+      true,
+      undefined,
+      { fetchFn: (() => Promise.resolve(new Response(moduleCode))) as typeof fetch },
+    );
+
+    assertEquals(peak, MAX_MDX_MODULE_TRANSFORM_CONCURRENCY);
+    assertEquals(result?.includes("file:///cache/.__dependency-0.js.mjs"), true);
   });
 
   it("rejects and cancels an oversized local module response", async () => {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
@@ -15,6 +15,58 @@ import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { rewriteVeryfrontImports } from "./import-rewriter.ts";
 import { findNestedImports } from "./nested-imports.ts";
 import { replaceSourceSpans, type SourceSpanReplacement } from "../utils/source-spans.ts";
+import { HTTP_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
+import { readHttpModuleText } from "../../../shared/http-module-response.ts";
+import { MAX_MDX_MODULE_CODE_BYTES } from "./recovery-payload.ts";
+import { MAX_TIMER_DELAY_MS } from "#veryfront/utils/constants/limits.ts";
+
+export interface FetchModuleViaHttpOptions {
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+}
+
+function discardResponseBody(response: Response): void {
+  try {
+    const cancellation = response.body?.cancel();
+    if (cancellation) void cancellation.catch(() => undefined);
+  } catch {
+    /* cancellation is best-effort cleanup */
+  }
+}
+
+function requireLocalDevPort(value: string): string {
+  if (!/^\d+$/.test(value)) throw new TypeError("Local development port must be numeric");
+  const port = Number(value);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw new RangeError("Local development port must be between 1 and 65535");
+  }
+  return String(port);
+}
+
+function requireProjectSlug(value: string | undefined): string {
+  if (value === undefined) return "localhost";
+  if (
+    value.length === 0 ||
+    value.length > 63 ||
+    !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(value)
+  ) {
+    throw new TypeError("Project slug must be a valid DNS label");
+  }
+  return `${value}.lvh.me`;
+}
+
+function requireFetchTimeout(value: number): number {
+  if (
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    value > MAX_TIMER_DELAY_MS
+  ) {
+    throw new RangeError(
+      `Local module fetch timeout must be an integer between 1 and ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+  return value;
+}
 
 /**
  * Fetch module via HTTP as a fallback (local development only).
@@ -31,6 +83,7 @@ export async function fetchModuleViaHTTP(
   projectSlug?: string,
   isLocalProject?: boolean,
   dependencyPinningCacheKey?: string,
+  options: FetchModuleViaHttpOptions = {},
 ): Promise<string | null> {
   if (!isLocalProject) {
     log.warn(
@@ -41,71 +94,100 @@ export async function fetchModuleViaHTTP(
 
   log.debug(`${LOG_PREFIX_MDX_LOADER} Direct read failed, falling back to HTTP: ${normalizedPath}`);
 
-  const port = adapter.env.get("VERYFRONT_DEV_PORT") || adapter.env.get("PORT") || "3001";
-  const host = projectSlug ? `${projectSlug}.lvh.me` : "localhost";
-  const moduleUrl = new URL(`http://${host}:${port}/${normalizedPath}`);
+  const port = requireLocalDevPort(
+    adapter.env.get("VERYFRONT_DEV_PORT") || adapter.env.get("PORT") || "3001",
+  );
+  const host = requireProjectSlug(projectSlug);
+  const timeoutMs = requireFetchTimeout(options.timeoutMs ?? HTTP_FETCH_TIMEOUT_MS);
+  const fetchFn = options.fetchFn ?? fetch;
+  const moduleUrl = new URL(`http://${host}:${port}`);
+  moduleUrl.pathname = `/${normalizedPath}`;
   moduleUrl.searchParams.set("ssr", "true");
   if (dependencyPinningCacheKey?.startsWith("on:")) {
     moduleUrl.searchParams.set("pins", dependencyPinningCacheKey);
   }
-
-  const response = await withSpan(
-    SpanNames.HTTP_CLIENT_FETCH,
-    () => fetch(moduleUrl),
-    {
-      "http.method": "GET",
-      "http.url": moduleUrl.toString(),
-      "http.target": `/${normalizedPath}`,
-      "http.host": host,
-      "mdx.module_path": normalizedPath,
-    },
+  const moduleUrlString = moduleUrl.toString();
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () =>
+      controller.abort(
+        new DOMException(
+          `Local module fetch timed out after ${timeoutMs}ms`,
+          "TimeoutError",
+        ),
+      ),
+    timeoutMs,
   );
 
-  if (!response.ok) {
-    log.warn(
-      `${LOG_PREFIX_MDX_LOADER} HTTP fetch also failed: ${moduleUrl} (${response.status})`,
+  let response: Response;
+  try {
+    response = await withSpan(
+      SpanNames.HTTP_CLIENT_FETCH,
+      () => fetchFn(moduleUrlString, { signal: controller.signal, redirect: "error" }),
+      {
+        "http.method": "GET",
+        "http.url": moduleUrlString,
+        "http.target": `/${normalizedPath}`,
+        "http.host": host,
+        "mdx.module_path": normalizedPath,
+      },
     );
-    return null;
-  }
 
-  const moduleCode = rewriteVeryfrontImports(await response.text());
+    if (!response.ok) {
+      discardResponseBody(response);
+      log.warn(
+        `${LOG_PREFIX_MDX_LOADER} HTTP fetch also failed: ${moduleUrlString} (${response.status})`,
+      );
+      return null;
+    }
 
-  const { vfModules, relative } = findNestedImports(moduleCode);
-  const allImports = [
-    ...vfModules.map(({ original, path, start, end }) => ({
-      original,
-      path,
-      start,
-      end,
-      key: "nestedPath" as const,
-    })),
-    ...relative.map(({ original, path, start, end }) => ({
-      original,
-      path,
-      start,
-      end,
-      key: "relativePath" as const,
-    })),
-  ];
+    const moduleCode = rewriteVeryfrontImports(
+      await readHttpModuleText(
+        response,
+        MAX_MDX_MODULE_CODE_BYTES,
+        controller.signal,
+      ),
+    );
 
-  const results = await Promise.all(
-    allImports.map(async ({ original, path, start, end, key }) => {
-      const nestedFilePath = await fetchAndCacheModuleFn(path, normalizedPath);
-      return { original, start, end, nestedFilePath, [key]: path };
-    }),
-  );
-
-  const replacements: SourceSpanReplacement[] = [];
-  for (const { original, start, end, nestedFilePath } of results) {
-    if (nestedFilePath) {
-      replacements.push({
+    const { vfModules, relative } = findNestedImports(moduleCode);
+    const allImports = [
+      ...vfModules.map(({ original, path, start, end }) => ({
+        original,
+        path,
         start,
         end,
-        expected: original,
-        replacement: `from "file://${nestedFilePath}"`,
-      });
-    }
-  }
+        key: "nestedPath" as const,
+      })),
+      ...relative.map(({ original, path, start, end }) => ({
+        original,
+        path,
+        start,
+        end,
+        key: "relativePath" as const,
+      })),
+    ];
 
-  return replaceSourceSpans(moduleCode, replacements);
+    const results = await Promise.all(
+      allImports.map(async ({ original, path, start, end, key }) => {
+        const nestedFilePath = await fetchAndCacheModuleFn(path, normalizedPath);
+        return { original, start, end, nestedFilePath, [key]: path };
+      }),
+    );
+
+    const replacements: SourceSpanReplacement[] = [];
+    for (const { original, start, end, nestedFilePath } of results) {
+      if (nestedFilePath) {
+        replacements.push({
+          start,
+          end,
+          expected: original,
+          replacement: `from "file://${nestedFilePath}"`,
+        });
+      }
+    }
+
+    return replaceSourceSpans(moduleCode, replacements);
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
@@ -19,7 +19,9 @@ import { HTTP_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
 import { readHttpModuleText } from "../../../shared/http-module-response.ts";
 import { MAX_MDX_MODULE_CODE_BYTES } from "./limits.ts";
 import { MAX_TIMER_DELAY_MS } from "#veryfront/utils/constants/limits.ts";
-import { assertMdxModuleImportCount } from "./limits.ts";
+import { parallelMap } from "#veryfront/utils/parallel.ts";
+import { Semaphore } from "#veryfront/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts";
+import { assertMdxModuleImportCount, MAX_MDX_MODULE_TRANSFORM_CONCURRENCY } from "./limits.ts";
 
 export interface FetchModuleViaHttpOptions {
   fetchFn?: typeof fetch;
@@ -169,11 +171,16 @@ export async function fetchModuleViaHTTP(
     ];
     assertMdxModuleImportCount(normalizedPath, allImports.length);
 
-    const results = [];
-    for (const { original, path, start, end, key } of allImports) {
-      const nestedFilePath = await fetchAndCacheModuleFn(path, normalizedPath);
-      results.push({ original, start, end, nestedFilePath, [key]: path });
-    }
+    const results = await parallelMap(
+      allImports,
+      async ({ original, path, start, end, key }) => {
+        const nestedFilePath = await fetchAndCacheModuleFn(path, normalizedPath);
+        return { original, start, end, nestedFilePath, [key]: path };
+      },
+      {
+        semaphore: new Semaphore(MAX_MDX_MODULE_TRANSFORM_CONCURRENCY),
+      },
+    );
 
     const replacements: SourceSpanReplacement[] = [];
     for (const { original, start, end, nestedFilePath } of results) {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
@@ -19,6 +19,7 @@ import { HTTP_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
 import { readHttpModuleText } from "../../../shared/http-module-response.ts";
 import { MAX_MDX_MODULE_CODE_BYTES } from "./recovery-payload.ts";
 import { MAX_TIMER_DELAY_MS } from "#veryfront/utils/constants/limits.ts";
+import { assertMdxModuleImportCount } from "./limits.ts";
 
 export interface FetchModuleViaHttpOptions {
   fetchFn?: typeof fetch;
@@ -166,13 +167,13 @@ export async function fetchModuleViaHTTP(
         key: "relativePath" as const,
       })),
     ];
+    assertMdxModuleImportCount(normalizedPath, allImports.length);
 
-    const results = await Promise.all(
-      allImports.map(async ({ original, path, start, end, key }) => {
-        const nestedFilePath = await fetchAndCacheModuleFn(path, normalizedPath);
-        return { original, start, end, nestedFilePath, [key]: path };
-      }),
-    );
+    const results = [];
+    for (const { original, path, start, end, key } of allImports) {
+      const nestedFilePath = await fetchAndCacheModuleFn(path, normalizedPath);
+      results.push({ original, start, end, nestedFilePath, [key]: path });
+    }
 
     const replacements: SourceSpanReplacement[] = [];
     for (const { original, start, end, nestedFilePath } of results) {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
@@ -17,7 +17,7 @@ import { findNestedImports } from "./nested-imports.ts";
 import { replaceSourceSpans, type SourceSpanReplacement } from "../utils/source-spans.ts";
 import { HTTP_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
 import { readHttpModuleText } from "../../../shared/http-module-response.ts";
-import { MAX_MDX_MODULE_CODE_BYTES } from "./recovery-payload.ts";
+import { MAX_MDX_MODULE_CODE_BYTES } from "./limits.ts";
 import { MAX_TIMER_DELAY_MS } from "#veryfront/utils/constants/limits.ts";
 import { assertMdxModuleImportCount } from "./limits.ts";
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { rewriteDntImports, rewriteVeryfrontImports } from "./import-rewriter.ts";
+import { MAX_MDX_MODULE_IMPORTS_PER_FILE } from "./limits.ts";
 import { FRAMEWORK_ROOT } from "../constants.ts";
 import { join } from "#veryfront/compat/path";
 
@@ -106,5 +107,32 @@ describe("rewriteDntImports", () => {
 
     assertEquals(lines[0], `// Previous example: from "./ai/csp-nonce.js"`);
     assertEquals(lines[1]?.includes(`from "file://`), true);
+  });
+
+  // Side-effect imports are rewritten by their own scan, so bounding only the
+  // `from "…"` scan would leave this pattern unbounded.
+  it("fails closed when side-effect import collection exceeds its bound", async () => {
+    const code = Array.from(
+      { length: MAX_MDX_MODULE_IMPORTS_PER_FILE + 1 },
+      (_, index) => `import "./polyfill-${index}.js";`,
+    ).join("\n");
+
+    await assertRejects(
+      () => rewriteDntImports(code, "/app/node_modules/veryfront/dist/head.js"),
+      RangeError,
+      `more than ${MAX_MDX_MODULE_IMPORTS_PER_FILE} static imports`,
+    );
+  });
+
+  it("rewrites side-effect imports sitting exactly on the bound", async () => {
+    const code = Array.from(
+      { length: MAX_MDX_MODULE_IMPORTS_PER_FILE },
+      (_, index) => `import "./polyfill-${index}.js";`,
+    ).join("\n");
+
+    const result = await rewriteDntImports(code, "/app/node_modules/veryfront/dist/head.js");
+
+    assertEquals(result.split("\n").length, MAX_MDX_MODULE_IMPORTS_PER_FILE);
+    assertEquals(result.includes(`import "./polyfill-`), false);
   });
 });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts
@@ -18,6 +18,7 @@ import {
   findStaticSideEffectImportSpans,
   replaceSourceSpans,
   type SourceSpanReplacement,
+  type StaticImportSpan,
 } from "../utils/source-spans.ts";
 import { MAX_MDX_MODULE_IMPORTS_PER_FILE } from "./limits.ts";
 
@@ -30,21 +31,35 @@ const MODULE_FETCHER_VERYFRONT_CONTEXT: RewriteContext = {
   reactVersion: DEFAULT_REACT_VERSION,
 };
 
-function findBoundedStaticImportSpans(
-  source: string,
-  matcher: (specifier: string) => string | null | undefined,
-) {
-  const matches = findStaticImportFromSpans(
-    source,
-    matcher,
-    MAX_MDX_MODULE_IMPORTS_PER_FILE + 1,
-  );
+type SpecifierMatcher = (specifier: string) => string | null | undefined;
+
+/**
+ * Run a span scanner one match past the per-file bound and fail closed there.
+ *
+ * Both rewriters below replace every span they collect, so accepting a
+ * truncated scan would emit a half-rewritten module whose remaining specifiers
+ * no longer resolve.
+ */
+function findBoundedSpans(
+  scan: (maxMatches: number) => StaticImportSpan[],
+): StaticImportSpan[] {
+  const matches = scan(MAX_MDX_MODULE_IMPORTS_PER_FILE + 1);
   if (matches.length > MAX_MDX_MODULE_IMPORTS_PER_FILE) {
     throw new RangeError(
       `Module contains more than ${MAX_MDX_MODULE_IMPORTS_PER_FILE} static imports`,
     );
   }
   return matches;
+}
+
+function findBoundedStaticImportSpans(source: string, matcher: SpecifierMatcher) {
+  return findBoundedSpans((maxMatches) => findStaticImportFromSpans(source, matcher, maxMatches));
+}
+
+function findBoundedStaticSideEffectImportSpans(source: string, matcher: SpecifierMatcher) {
+  return findBoundedSpans((maxMatches) =>
+    findStaticSideEffectImportSpans(source, matcher, maxMatches)
+  );
 }
 
 function rewriteVeryfrontModuleSpecifier(specifier: string): string | null {
@@ -154,7 +169,7 @@ export async function rewriteDntImports(code: string, sourceFilePath: string): P
     },
     {
       findMatches: (source: string) =>
-        findStaticSideEffectImportSpans(
+        findBoundedStaticSideEffectImportSpans(
           source,
           (specifier) => specifier.match(/^(\.\.?\/[^?]+)(?:\?.*)?$/)?.[1],
         ),

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts
@@ -19,6 +19,7 @@ import {
   replaceSourceSpans,
   type SourceSpanReplacement,
 } from "../utils/source-spans.ts";
+import { MAX_MDX_MODULE_IMPORTS_PER_FILE } from "./limits.ts";
 
 const MODULE_FETCHER_VERYFRONT_CONTEXT: RewriteContext = {
   filePath: "",
@@ -28,6 +29,23 @@ const MODULE_FETCHER_VERYFRONT_CONTEXT: RewriteContext = {
   dev: false,
   reactVersion: DEFAULT_REACT_VERSION,
 };
+
+function findBoundedStaticImportSpans(
+  source: string,
+  matcher: (specifier: string) => string | null | undefined,
+) {
+  const matches = findStaticImportFromSpans(
+    source,
+    matcher,
+    MAX_MDX_MODULE_IMPORTS_PER_FILE + 1,
+  );
+  if (matches.length > MAX_MDX_MODULE_IMPORTS_PER_FILE) {
+    throw new RangeError(
+      `Module contains more than ${MAX_MDX_MODULE_IMPORTS_PER_FILE} static imports`,
+    );
+  }
+  return matches;
+}
 
 function rewriteVeryfrontModuleSpecifier(specifier: string): string | null {
   const result = veryfrontStrategy.rewrite(
@@ -50,7 +68,7 @@ function rewriteVeryfrontModuleSpecifier(specifier: string): string | null {
  * Uses deno.json exports/imports as the source of truth and appends ?ssr=true.
  */
 export function rewriteVeryfrontImports(code: string): string {
-  const replacements: SourceSpanReplacement[] = findStaticImportFromSpans(
+  const replacements: SourceSpanReplacement[] = findBoundedStaticImportSpans(
     code,
     (specifier) => specifier.startsWith("veryfront/") ? specifier : null,
   ).flatMap(({ original, path, start, end }) => {
@@ -128,7 +146,7 @@ export async function rewriteDntImports(code: string, sourceFilePath: string): P
   const patterns = [
     {
       findMatches: (source: string) =>
-        findStaticImportFromSpans(
+        findBoundedStaticImportSpans(
           source,
           (specifier) => specifier.match(/^(\.\.?\/[^?]+)(?:\?.*)?$/)?.[1],
         ),

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
@@ -14,6 +14,12 @@ import {
   rewriteDntImports,
   startRenderSession,
 } from "./index.ts";
+import {
+  MAX_MDX_MODULE_GRAPH_ENTRIES,
+  ModuleGraphLimitError,
+  ModuleSourceLimitError,
+} from "./limits.ts";
+import { MAX_MDX_MODULE_CODE_BYTES } from "./recovery-payload.ts";
 import { FRAMEWORK_ROOT, HASH_SEED_FNV1A } from "../constants.ts";
 import { resolveVeryfrontModuleUrl } from "../../../veryfront-module-urls.ts";
 import { MDX_ESM_CACHE_NAMESPACE } from "../cache-format.ts";
@@ -361,6 +367,37 @@ describe("module-fetcher", { sanitizeResources: false, sanitizeOps: false }, () 
       assertEquals(ctx.inFlightModules instanceof Map, true);
       assertEquals(ctx.inFlightModules!.size, 0);
     });
+
+    it("initializes a bounded module graph", () => {
+      const ctx = createModuleFetcherContext("/cache", mockAdapter, "/project", "proj-123");
+      assertEquals(ctx.moduleGraph instanceof Set, true);
+      assertEquals(ctx.moduleGraph!.size, 0);
+    });
+  });
+
+  it("rejects a new module after the request graph reaches its limit", async () => {
+    let resolved = false;
+    const adapter = {
+      env: { get: (_key: string) => undefined },
+      fs: {
+        resolveFile: () => {
+          resolved = true;
+          return Promise.resolve(null);
+        },
+      },
+    } as any;
+    const ctx = createModuleFetcherContext("/cache", adapter, "/project", "proj-limit", {
+      strictMissingModules: false,
+    });
+    for (let index = 0; index < MAX_MDX_MODULE_GRAPH_ENTRIES; index++) {
+      ctx.moduleGraph!.add(`_vf_modules/existing-${index}.js`);
+    }
+
+    await assertRejects(
+      () => fetchAndCacheModule("_vf_modules/one-too-many.js", ctx),
+      ModuleGraphLimitError,
+    );
+    assertEquals(resolved, false);
   });
 
   describe("strictMissingModules", () => {
@@ -415,6 +452,31 @@ describe("module-fetcher", { sanitizeResources: false, sanitizeOps: false }, () 
 
         const result = await fetchAndCacheModule("/_vf_modules/lib/utils.js", ctx);
         assertEquals(result, null, "Should return null for missing module when strict mode is off");
+      } finally {
+        await remove(esmCacheDir, { recursive: true });
+        await remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("does not downgrade an oversized source to a non-strict stub", async () => {
+      const esmCacheDir = await makeTempDir({ prefix: "vf-mdx-size-cache-" });
+      const projectDir = await makeTempDir({ prefix: "vf-mdx-size-proj-" });
+      const adapter = {
+        env: { get: (_key: string) => undefined },
+        fs: {
+          resolveFile: () => Promise.resolve("/virtual/oversized.ts"),
+          readFile: () => Promise.resolve("x".repeat(MAX_MDX_MODULE_CODE_BYTES + 1)),
+        },
+      } as any;
+
+      try {
+        const ctx = createModuleFetcherContext(esmCacheDir, adapter, projectDir, "proj-size", {
+          strictMissingModules: false,
+        });
+        await assertRejects(
+          () => fetchAndCacheModule("/_vf_modules/oversized.js", ctx),
+          ModuleSourceLimitError,
+        );
       } finally {
         await remove(esmCacheDir, { recursive: true });
         await remove(projectDir, { recursive: true });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
@@ -19,7 +19,7 @@ import {
   ModuleGraphLimitError,
   ModuleSourceLimitError,
 } from "./limits.ts";
-import { MAX_MDX_MODULE_CODE_BYTES } from "./recovery-payload.ts";
+import { MAX_MDX_MODULE_CODE_BYTES } from "./limits.ts";
 import { FRAMEWORK_ROOT, HASH_SEED_FNV1A } from "../constants.ts";
 import { resolveVeryfrontModuleUrl } from "../../../veryfront-module-urls.ts";
 import { MDX_ESM_CACHE_NAMESPACE } from "../cache-format.ts";

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -29,12 +29,13 @@ import { readValidCachedModulePath } from "./path-cache-lookup.ts";
 import { persistResolvedModule } from "./persistence.ts";
 import { transformResolvedModuleSource } from "./source-transform.ts";
 import {
+  MAX_MDX_MODULE_CODE_BYTES,
   MAX_MDX_MODULE_GRAPH_ENTRIES,
   ModuleGraphLimitError,
   ModuleImportLimitError,
   ModuleSourceLimitError,
+  utf8ByteLength,
 } from "./limits.ts";
-import { MAX_MDX_MODULE_CODE_BYTES, utf8ByteLength } from "./recovery-payload.ts";
 
 export {
   MAX_MDX_MODULE_GRAPH_ENTRIES,

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -28,6 +28,20 @@ import { normalizePath } from "./module-cache.ts";
 import { readValidCachedModulePath } from "./path-cache-lookup.ts";
 import { persistResolvedModule } from "./persistence.ts";
 import { transformResolvedModuleSource } from "./source-transform.ts";
+import {
+  MAX_MDX_MODULE_GRAPH_ENTRIES,
+  ModuleGraphLimitError,
+  ModuleImportLimitError,
+  ModuleSourceLimitError,
+} from "./limits.ts";
+import { MAX_MDX_MODULE_CODE_BYTES, utf8ByteLength } from "./recovery-payload.ts";
+
+export {
+  MAX_MDX_MODULE_GRAPH_ENTRIES,
+  ModuleGraphLimitError,
+  ModuleImportLimitError,
+  ModuleSourceLimitError,
+} from "./limits.ts";
 
 // Re-export extracted modules for backward compatibility
 export { rewriteDntImports } from "./import-rewriter.ts";
@@ -77,7 +91,10 @@ function isFatalModuleFetchError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   return error.name === "MissingModuleError" ||
     error instanceof TransformTreeTimeoutError ||
-    error instanceof CircularModuleDependencyError;
+    error instanceof CircularModuleDependencyError ||
+    error instanceof ModuleGraphLimitError ||
+    error instanceof ModuleImportLimitError ||
+    error instanceof ModuleSourceLimitError;
 }
 
 /**
@@ -93,6 +110,13 @@ export async function fetchAndCacheModule(
   const log = getLog(context);
   const normalizedPath = normalizePath(modulePath, parentModulePath);
   const projectSlug = context.projectSlug || "unknown";
+  const moduleGraph = context.moduleGraph ??= new Set<string>();
+  if (!moduleGraph.has(normalizedPath)) {
+    if (moduleGraph.size >= MAX_MDX_MODULE_GRAPH_ENTRIES) {
+      throw new ModuleGraphLimitError(normalizedPath);
+    }
+    moduleGraph.add(normalizedPath);
+  }
 
   const now = Date.now();
   context.transformDeadline ??= now + TRANSFORM_TREE_TIMEOUT_MS;
@@ -240,6 +264,14 @@ async function doFetchAndCacheModule(
     }
 
     const { sourceCode, actualFilePath } = resolved;
+    const sourceSizeBytes = utf8ByteLength(sourceCode);
+    if (sourceSizeBytes > MAX_MDX_MODULE_CODE_BYTES) {
+      throw new ModuleSourceLimitError(
+        normalizedPath,
+        sourceSizeBytes,
+        MAX_MDX_MODULE_CODE_BYTES,
+      );
+    }
 
     const contentHash = hashString(sourceCode);
     const transformCacheKey = contentSourceId
@@ -368,5 +400,6 @@ export function createModuleFetcherContext(
     ...options,
     // Initialize in-flight tracking for circular import detection
     inFlightModules: new Map(),
+    moduleGraph: new Set(),
   };
 }

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/limits.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/limits.ts
@@ -1,0 +1,47 @@
+/**
+ * Admission limits for recursive MDX module resolution.
+ *
+ * @module transforms/mdx/esm-module-loader/module-fetcher/limits
+ */
+
+/** Maximum unique modules admitted to one request-scoped dependency graph. */
+export const MAX_MDX_MODULE_GRAPH_ENTRIES = 500;
+
+/** Maximum static module dependencies accepted from one transformed file. */
+export const MAX_MDX_MODULE_IMPORTS_PER_FILE = 500;
+
+/** Bound independent top-level and JSX work without recursive semaphore deadlocks. */
+export const MAX_MDX_MODULE_TRANSFORM_CONCURRENCY = 16;
+
+export class ModuleGraphLimitError extends Error {
+  constructor(normalizedPath: string) {
+    super(
+      `MDX module dependency graph exceeds ${MAX_MDX_MODULE_GRAPH_ENTRIES} unique modules while admitting "${normalizedPath}"`,
+    );
+    this.name = "ModuleGraphLimitError";
+  }
+}
+
+export class ModuleImportLimitError extends Error {
+  constructor(modulePath: string, count: number) {
+    super(
+      `MDX module "${modulePath}" has too many static dependencies (${count}, max ${MAX_MDX_MODULE_IMPORTS_PER_FILE})`,
+    );
+    this.name = "ModuleImportLimitError";
+  }
+}
+
+export class ModuleSourceLimitError extends Error {
+  constructor(modulePath: string, sizeBytes: number, maxBytes: number) {
+    super(
+      `MDX module "${modulePath}" exceeds the source-size limit (${sizeBytes} bytes, max ${maxBytes})`,
+    );
+    this.name = "ModuleSourceLimitError";
+  }
+}
+
+export function assertMdxModuleImportCount(modulePath: string, count: number): void {
+  if (count > MAX_MDX_MODULE_IMPORTS_PER_FILE) {
+    throw new ModuleImportLimitError(modulePath, count);
+  }
+}

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/limits.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/limits.ts
@@ -13,6 +13,15 @@ export const MAX_MDX_MODULE_IMPORTS_PER_FILE = 500;
 /** Bound independent top-level and JSX work without recursive semaphore deadlocks. */
 export const MAX_MDX_MODULE_TRANSFORM_CONCURRENCY = 16;
 
+/** Maximum UTF-8 source bytes accepted for one fetched module. */
+export const MAX_MDX_MODULE_CODE_BYTES = 2 * 1024 * 1024;
+
+const utf8Encoder = new TextEncoder();
+
+export function utf8ByteLength(value: string): number {
+  return utf8Encoder.encode(value).byteLength;
+}
+
 export class ModuleGraphLimitError extends Error {
   constructor(normalizedPath: string) {
     super(

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   findNestedImports,
@@ -7,6 +7,7 @@ import {
   resolveNestedImportBase,
   resolveNestedModuleImports,
 } from "./nested-imports.ts";
+import { MAX_MDX_MODULE_IMPORTS_PER_FILE, ModuleImportLimitError } from "./limits.ts";
 
 describe("transforms/mdx/esm-module-loader/module-fetcher/nested-imports", () => {
   describe("findNestedImports", () => {
@@ -157,6 +158,31 @@ import { bar } from "./local.js";
           `export { local };`,
         ].join("\n"),
       );
+    });
+
+    it("rejects excessive per-file fan-out before starting child fetches", async () => {
+      let fetchCount = 0;
+      const moduleCode = Array.from(
+        { length: MAX_MDX_MODULE_IMPORTS_PER_FILE + 1 },
+        (_, index) => `import value${index} from "./dependency-${index}.js";`,
+      ).join("\n");
+
+      await assertRejects(
+        () =>
+          resolveNestedModuleImports({
+            moduleCode,
+            esmCacheDir: "/tmp/veryfront-unused",
+            normalizedPath: "_vf_modules/pages/index.js",
+            projectSlug: "docs",
+            strictMissingModules: true,
+            fetchAndCacheModule: () => {
+              fetchCount += 1;
+              return Promise.resolve(null);
+            },
+          }),
+        ModuleImportLimitError,
+      );
+      assertEquals(fetchCount, 0);
     });
   });
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
@@ -7,7 +7,11 @@ import {
   resolveNestedImportBase,
   resolveNestedModuleImports,
 } from "./nested-imports.ts";
-import { MAX_MDX_MODULE_IMPORTS_PER_FILE, ModuleImportLimitError } from "./limits.ts";
+import {
+  MAX_MDX_MODULE_IMPORTS_PER_FILE,
+  MAX_MDX_MODULE_TRANSFORM_CONCURRENCY,
+  ModuleImportLimitError,
+} from "./limits.ts";
 
 describe("transforms/mdx/esm-module-loader/module-fetcher/nested-imports", () => {
   describe("findNestedImports", () => {
@@ -158,6 +162,33 @@ import { bar } from "./local.js";
           `export { local };`,
         ].join("\n"),
       );
+    });
+
+    it("resolves admitted fan-out with bounded concurrency", async () => {
+      const importCount = MAX_MDX_MODULE_TRANSFORM_CONCURRENCY + 4;
+      const moduleCode = Array.from(
+        { length: importCount },
+        (_, index) => `import value${index} from "./dependency-${index}.js";`,
+      ).join("\n");
+      let active = 0;
+      let peak = 0;
+
+      await resolveNestedModuleImports({
+        moduleCode,
+        esmCacheDir: "/tmp/veryfront-unused",
+        normalizedPath: "_vf_modules/pages/index.js",
+        projectSlug: "docs",
+        strictMissingModules: true,
+        fetchAndCacheModule: async (path) => {
+          active += 1;
+          peak = Math.max(peak, active);
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          active -= 1;
+          return `/cache/${path.replaceAll("/", "__")}.mjs`;
+        },
+      });
+
+      assertEquals(peak, MAX_MDX_MODULE_TRANSFORM_CONCURRENCY);
     });
 
     it("rejects excessive per-file fan-out before starting child fetches", async () => {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
@@ -14,7 +14,13 @@ import {
 } from "../utils/source-spans.ts";
 import { buildMissingModuleError } from "../missing-module.ts";
 import type { Logger } from "#veryfront/utils";
-import { assertMdxModuleImportCount, MAX_MDX_MODULE_IMPORTS_PER_FILE } from "./limits.ts";
+import { parallelMap } from "#veryfront/utils/parallel.ts";
+import { Semaphore } from "#veryfront/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts";
+import {
+  assertMdxModuleImportCount,
+  MAX_MDX_MODULE_IMPORTS_PER_FILE,
+  MAX_MDX_MODULE_TRANSFORM_CONCURRENCY,
+} from "./limits.ts";
 
 function matchUnresolvedVfModuleSpecifier(specifier: string): string | null {
   return specifier.match(/^((?:file:\/\/)?\/?\/?_vf_modules\/[^?]+)(?:\?.*)?$/)?.[1] ?? null;
@@ -215,9 +221,9 @@ export async function resolveNestedModuleImports(
   ];
   assertMdxModuleImportCount(input.normalizedPath, allImports.length);
 
-  const nestedResults: NestedImportResult[] = [];
-  for (const { original, path, start, end, key } of allImports) {
-    nestedResults.push({
+  const nestedResults: NestedImportResult[] = await parallelMap(
+    allImports,
+    async ({ original, path, start, end, key }) => ({
       original,
       start,
       end,
@@ -226,8 +232,11 @@ export async function resolveNestedModuleImports(
         input.parentBasePath ?? input.normalizedPath,
       ),
       [key]: path,
-    });
-  }
+    }),
+    {
+      semaphore: new Semaphore(MAX_MDX_MODULE_TRANSFORM_CONCURRENCY),
+    },
+  );
   input.log?.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing vfModules DONE`, {
     projectSlug: input.projectSlug,
     normalizedPath: input.normalizedPath,

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
@@ -77,7 +77,11 @@ export function findNestedImports(
  * Check for unresolved /_vf_modules/ imports.
  */
 export function hasUnresolvedImports(moduleCode: string): { count: number; paths: string[] } {
-  const matches = findStaticImportFromSpans(moduleCode, matchUnresolvedVfModuleSpecifier);
+  const matches = findStaticImportFromSpans(
+    moduleCode,
+    matchUnresolvedVfModuleSpecifier,
+    MAX_MDX_MODULE_IMPORTS_PER_FILE + 1,
+  );
   return {
     count: matches.length,
     paths: matches.map((match) => match.path).slice(0, 5),

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
@@ -14,6 +14,7 @@ import {
 } from "../utils/source-spans.ts";
 import { buildMissingModuleError } from "../missing-module.ts";
 import type { Logger } from "#veryfront/utils";
+import { assertMdxModuleImportCount, MAX_MDX_MODULE_IMPORTS_PER_FILE } from "./limits.ts";
 
 function matchUnresolvedVfModuleSpecifier(specifier: string): string | null {
   return specifier.match(/^((?:file:\/\/)?\/?\/?_vf_modules\/[^?]+)(?:\?.*)?$/)?.[1] ?? null;
@@ -36,6 +37,7 @@ export function findNestedImports(
     const { original, path: rawPath, start, end } of findStaticImportFromSpans(
       moduleCode,
       matchUnresolvedVfModuleSpecifier,
+      MAX_MDX_MODULE_IMPORTS_PER_FILE + 1,
     )
   ) {
     // Strip file:// prefix and leading slashes to get clean _vf_modules/... path
@@ -51,6 +53,7 @@ export function findNestedImports(
     const { original, path, start, end } of findStaticImportFromSpans(
       moduleCode,
       (specifier) => specifier.match(/^(\.\.?\/[^?]+)(?:\?.*)?$/)?.[1],
+      MAX_MDX_MODULE_IMPORTS_PER_FILE + 1,
     )
   ) {
     relative.push({
@@ -210,8 +213,11 @@ export async function resolveNestedModuleImports(
     ...vfModules.map((module) => ({ ...module, key: "nestedPath" as const })),
     ...relative.map((module) => ({ ...module, key: "relativePath" as const })),
   ];
-  const nestedResults = await Promise.all(
-    allImports.map(async ({ original, path, start, end, key }) => ({
+  assertMdxModuleImportCount(input.normalizedPath, allImports.length);
+
+  const nestedResults: NestedImportResult[] = [];
+  for (const { original, path, start, end, key } of allImports) {
+    nestedResults.push({
       original,
       start,
       end,
@@ -220,8 +226,8 @@ export async function resolveNestedModuleImports(
         input.parentBasePath ?? input.normalizedPath,
       ),
       [key]: path,
-    })),
-  );
+    });
+  }
   input.log?.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing vfModules DONE`, {
     projectSlug: input.projectSlug,
     normalizedPath: input.normalizedPath,

--- a/src/transforms/mdx/esm-module-loader/resolution/file-finder.test.ts
+++ b/src/transforms/mdx/esm-module-loader/resolution/file-finder.test.ts
@@ -5,7 +5,7 @@ import "#veryfront/schemas/_test-setup.ts";
  * These tests ensure that framework files under _veryfront/ are
  * properly resolved from the framework source directory.
  */
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { resolveModuleFile } from "./file-finder.ts";
@@ -106,6 +106,30 @@ describe("resolveModuleFile", () => {
       assertEquals(await resolveModuleFile(path, adapter as any, "/project"), null);
       assertEquals(wasCalled(), false);
     }
+  });
+
+  it("propagates operational read failures instead of treating them as missing", async () => {
+    const permissionError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    const adapter = {
+      ...mockAdapter,
+      fs: {
+        ...mockAdapter.fs,
+        resolveFile: () => Promise.resolve("/virtual/components/Button.tsx"),
+        readFile: () => Promise.reject(permissionError),
+      },
+    };
+
+    const error = await assertRejects(
+      () =>
+        resolveModuleFile(
+          "_vf_modules/components/Button.js",
+          adapter,
+          "/project",
+        ),
+      Error,
+      "permission denied",
+    );
+    assertEquals(error, permissionError);
   });
 
   it("resolves framework react/* files", async () => {

--- a/src/transforms/mdx/esm-module-loader/resolution/file-finder.ts
+++ b/src/transforms/mdx/esm-module-loader/resolution/file-finder.ts
@@ -9,6 +9,7 @@ import {
 import { DIRECTORY_PREFIXES, LOG_PREFIX_MDX_LOADER, MODULE_EXTENSIONS } from "../constants.ts";
 import { getLocalFs } from "../cache/index.ts";
 import { canonicalizeContainedModulePath } from "./module-path.ts";
+import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 
 const logger = rendererLogger.component("file-finder");
 
@@ -34,9 +35,9 @@ async function tryReadFile(
   try {
     const content = await readFile(path);
     return { sourceCode: decodeContent(content), actualFilePath: path };
-  } catch (_) {
-    /* expected: file may not exist at this path */
-    return null;
+  } catch (error) {
+    if (isNotFoundError(error)) return null;
+    throw error;
   }
 }
 
@@ -82,6 +83,7 @@ export async function resolveModuleFile(
         });
         return { sourceCode: decodeContent(content), actualFilePath: resolvedPath };
       } catch (error) {
+        if (!isNotFoundError(error)) throw error;
         logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to read resolved file`, {
           resolvedPath,
           error: error instanceof Error ? error.message : String(error),

--- a/src/transforms/mdx/esm-module-loader/types.ts
+++ b/src/transforms/mdx/esm-module-loader/types.ts
@@ -73,6 +73,8 @@ export interface ModuleFetcherContext {
    * This prevents infinite recursion when A imports B which imports A.
    */
   inFlightModules?: Map<string, Promise<string | null>>;
+  /** Unique normalized modules admitted to this request-scoped graph. */
+  moduleGraph?: Set<string>;
   /** React version for transforms (from project config) */
   reactVersion?: string;
   /** Absolute request origin used to identify same-origin module URLs. */

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
@@ -4,8 +4,13 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   findDynamicImportSpans,
   findStaticImportFromSpans,
+  findStaticSideEffectImportSpans,
   replaceSourceSpans,
 } from "./source-spans.ts";
+
+// Cases about which specifiers a scanner recognises, rather than about how many
+// it collects, opt out of the bound explicitly.
+const UNBOUNDED = Number.MAX_SAFE_INTEGER;
 
 describe("transforms/mdx/esm-module-loader/utils/source-spans", () => {
   describe("replaceSourceSpans", () => {
@@ -124,9 +129,33 @@ describe("transforms/mdx/esm-module-loader/utils/source-spans", () => {
     // are recognised rather than about resolution.
     const matchRelative = (specifier: string) => specifier.startsWith("./") ? specifier : null;
 
+    // These cases are about which arguments the scanner recognises, so they opt
+    // out of the bound rather than exercising it.
     function specifiers(source: string): string[] {
-      return findDynamicImportSpans(source, matchRelative).map((span) => span.path);
+      return findDynamicImportSpans(source, matchRelative, UNBOUNDED).map((span) => span.path);
     }
+
+    it("requires a positive safe match bound", () => {
+      for (const maxMatches of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+        assertThrows(
+          () => findDynamicImportSpans('await import("./value.js");', matchRelative, maxMatches),
+          RangeError,
+          "positive safe integer",
+        );
+      }
+    });
+
+    it("stops collecting after the explicit match bound", () => {
+      const source = Array.from(
+        { length: 20 },
+        (_, index) => `const value${index} = await import("./value-${index}.js");`,
+      ).join("\n");
+
+      assertEquals(
+        findDynamicImportSpans(source, matchRelative, 3).map((span) => span.path),
+        ["./value-0.js", "./value-1.js", "./value-2.js"],
+      );
+    });
 
     it("finds a literal specifier", () => {
       assertEquals(specifiers(`const m = await import("./foo.js");`), ["./foo.js"]);
@@ -223,13 +252,54 @@ describe("transforms/mdx/esm-module-loader/utils/source-spans", () => {
 
     it("spans only the quoted specifier when comments surround it", () => {
       const source = `import(/* hint */ "./a.js" /* eager */);`;
-      const [span] = findDynamicImportSpans(source, matchRelative);
+      const [span] = findDynamicImportSpans(source, matchRelative, UNBOUNDED);
       assertEquals(span?.original, `"./a.js"`);
       assertEquals(
         replaceSourceSpans(source, [
           { start: span!.start, end: span!.end, replacement: `"file:///out/a.js"` },
         ]),
         `import(/* hint */ "file:///out/a.js" /* eager */);`,
+      );
+    });
+  });
+
+  describe("findStaticSideEffectImportSpans", () => {
+    const matchRelative = (specifier: string) => specifier.startsWith("./") ? specifier : null;
+
+    it("requires a positive safe match bound", () => {
+      for (const maxMatches of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+        assertThrows(
+          () => findStaticSideEffectImportSpans('import "./value.js";', matchRelative, maxMatches),
+          RangeError,
+          "positive safe integer",
+        );
+      }
+    });
+
+    it("stops collecting after the explicit match bound", () => {
+      const source = Array.from(
+        { length: 20 },
+        (_, index) => `import "./value-${index}.js";`,
+      ).join("\n");
+
+      assertEquals(
+        findStaticSideEffectImportSpans(source, matchRelative, 3).map((span) => span.path),
+        ["./value-0.js", "./value-1.js", "./value-2.js"],
+      );
+    });
+
+    // Only matched specifiers count against the bound, so unrelated side-effect
+    // imports do not crowd out the ones the caller is looking for.
+    it("counts only matched specifiers against the bound", () => {
+      const source = [
+        `import "some-package";`,
+        `import "another-package";`,
+        `import "./value.js";`,
+      ].join("\n");
+
+      assertEquals(
+        findStaticSideEffectImportSpans(source, matchRelative, 2).map((span) => span.path),
+        ["./value.js"],
       );
     });
   });

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { findDynamicImportSpans, replaceSourceSpans } from "./source-spans.ts";
+import {
+  findDynamicImportSpans,
+  findStaticImportFromSpans,
+  replaceSourceSpans,
+} from "./source-spans.ts";
 
 describe("transforms/mdx/esm-module-loader/utils/source-spans", () => {
   describe("replaceSourceSpans", () => {
@@ -85,6 +89,33 @@ describe("transforms/mdx/esm-module-loader/utils/source-spans", () => {
     it("returns source unchanged for empty replacements", () => {
       const source = "unchanged";
       assertEquals(replaceSourceSpans(source, []), "unchanged");
+    });
+  });
+
+  describe("findStaticImportFromSpans", () => {
+    const matchRelative = (specifier: string) => specifier.startsWith("./") ? specifier : null;
+
+    it("requires a positive safe match bound", () => {
+      for (const maxMatches of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+        assertThrows(
+          () =>
+            findStaticImportFromSpans('import value from "./value.js";', matchRelative, maxMatches),
+          RangeError,
+          "positive safe integer",
+        );
+      }
+    });
+
+    it("stops collecting after the explicit match bound", () => {
+      const source = Array.from(
+        { length: 20 },
+        (_, index) => `import value${index} from "./value-${index}.js";`,
+      ).join("\n");
+
+      assertEquals(
+        findStaticImportFromSpans(source, matchRelative, 3).map((span) => span.path),
+        ["./value-0.js", "./value-1.js", "./value-2.js"],
+      );
     });
   });
 

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
@@ -215,8 +215,12 @@ function findFromSpan(
 export function findStaticImportFromSpans(
   source: string,
   matcher: SpecifierMatcher,
-  maxMatches = Number.MAX_SAFE_INTEGER,
+  maxMatches: number,
 ): StaticImportSpan[] {
+  if (!Number.isSafeInteger(maxMatches) || maxMatches <= 0) {
+    throw new RangeError("maxMatches must be a positive safe integer");
+  }
+
   const spans: StaticImportSpan[] = [];
   let cursor = 0;
 

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
@@ -215,6 +215,7 @@ function findFromSpan(
 export function findStaticImportFromSpans(
   source: string,
   matcher: SpecifierMatcher,
+  maxMatches = Number.MAX_SAFE_INTEGER,
 ): StaticImportSpan[] {
   const spans: StaticImportSpan[] = [];
   let cursor = 0;
@@ -243,6 +244,7 @@ export function findStaticImportFromSpans(
     const span = findFromSpan(source, afterKeyword, matcher);
     if (span) {
       spans.push(span);
+      if (spans.length >= maxMatches) return spans;
       cursor = span.end;
       continue;
     }

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
@@ -212,14 +212,29 @@ function findFromSpan(
   return null;
 }
 
+/**
+ * Validate the match bound every scanner requires.
+ *
+ * The bound is required rather than defaulted because these scanners run over
+ * fetched, untrusted module source: a caller that forgot to bound itself would
+ * let one file allocate a span per import without limit. Reaching the bound
+ * returns a truncated prefix, so a caller that rewrites every span it collects
+ * must ask for one more than it will accept and reject the source when the
+ * extra span comes back — otherwise the dropped imports are silently left
+ * pointing at unresolved specifiers.
+ */
+function assertMaxMatches(maxMatches: number): void {
+  if (!Number.isSafeInteger(maxMatches) || maxMatches <= 0) {
+    throw new RangeError("maxMatches must be a positive safe integer");
+  }
+}
+
 export function findStaticImportFromSpans(
   source: string,
   matcher: SpecifierMatcher,
   maxMatches: number,
 ): StaticImportSpan[] {
-  if (!Number.isSafeInteger(maxMatches) || maxMatches <= 0) {
-    throw new RangeError("maxMatches must be a positive safe integer");
-  }
+  assertMaxMatches(maxMatches);
 
   const spans: StaticImportSpan[] = [];
   let cursor = 0;
@@ -268,11 +283,17 @@ export function findStaticImportFromSpans(
  * their target is only known at runtime. That includes an argument the literal
  * merely starts: rewriting the `"./foo"` in `import("./foo" + suffix)` would
  * build a path out of a resolved prefix and an unresolved tail.
+ *
+ * `maxMatches` bounds the scan on the same terms as
+ * {@link findStaticImportFromSpans}.
  */
 export function findDynamicImportSpans(
   source: string,
   matcher: SpecifierMatcher,
+  maxMatches: number,
 ): StaticImportSpan[] {
+  assertMaxMatches(maxMatches);
+
   const spans: StaticImportSpan[] = [];
   let cursor = 0;
 
@@ -322,6 +343,7 @@ export function findDynamicImportSpans(
         start: quoteIndex,
         end: quoted.end,
       });
+      if (spans.length >= maxMatches) return spans;
     }
 
     cursor = quoted.end;
@@ -330,10 +352,19 @@ export function findDynamicImportSpans(
   return spans;
 }
 
+/**
+ * Find bare `import "…"` side-effect statements.
+ *
+ * `maxMatches` bounds the scan on the same terms as
+ * {@link findStaticImportFromSpans}.
+ */
 export function findStaticSideEffectImportSpans(
   source: string,
   matcher: SpecifierMatcher,
+  maxMatches: number,
 ): StaticImportSpan[] {
+  assertMaxMatches(maxMatches);
+
   const spans: StaticImportSpan[] = [];
   let cursor = 0;
 
@@ -364,6 +395,7 @@ export function findStaticSideEffectImportSpans(
         start: cursor,
         end: quoted.end,
       });
+      if (spans.length >= maxMatches) return spans;
     }
 
     cursor = quoted.end;

--- a/src/transforms/shared/http-module-response.test.ts
+++ b/src/transforms/shared/http-module-response.test.ts
@@ -1,0 +1,84 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  HttpModuleBodyEncodingError,
+  HttpModuleBodyTooLargeError,
+  readHttpModuleText,
+} from "./http-module-response.ts";
+
+describe("transforms/shared/http-module-response", () => {
+  it("accepts a response exactly at the byte limit", async () => {
+    assertEquals(await readHttpModuleText(new Response("four"), 4), "four");
+  });
+
+  it("rejects and cancels a declared oversized response", async () => {
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream({
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { headers: { "content-length": "5" } },
+    );
+
+    await assertRejects(
+      () => readHttpModuleText(response, 4),
+      HttpModuleBodyTooLargeError,
+      "exceeds 4 bytes",
+    );
+    assertEquals(cancelled, true);
+  });
+
+  it("rejects and cancels an oversized streamed response", async () => {
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("12345"));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+
+    await assertRejects(
+      () => readHttpModuleText(response, 4),
+      HttpModuleBodyTooLargeError,
+      "exceeds 4 bytes",
+    );
+    assertEquals(cancelled, true);
+  });
+
+  it("rejects malformed UTF-8 instead of replacing source bytes", async () => {
+    await assertRejects(
+      () => readHttpModuleText(new Response(new Uint8Array([0xc3, 0x28])), 10),
+      HttpModuleBodyEncodingError,
+      "not valid UTF-8",
+    );
+  });
+
+  it("honors an abort while a response body is stalled", async () => {
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream({
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+    const controller = new AbortController();
+    const reason = new DOMException("body deadline reached", "TimeoutError");
+    const pending = readHttpModuleText(response, 10, controller.signal);
+
+    controller.abort(reason);
+
+    await assertRejects(() => pending, DOMException, "body deadline reached");
+    assertEquals(cancelled, true);
+  });
+});

--- a/src/transforms/shared/http-module-response.ts
+++ b/src/transforms/shared/http-module-response.ts
@@ -1,0 +1,86 @@
+import {
+  InvalidResponseBodyUtf8Error,
+  readResponseTextPrefix,
+} from "#veryfront/utils/response-body.ts";
+
+/** Base class for deterministic HTTP module body validation failures. */
+export class HttpModuleBodyError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "HttpModuleBodyError";
+  }
+}
+
+/** Raised when an HTTP module exceeds its caller-owned response limit. */
+export class HttpModuleBodyTooLargeError extends HttpModuleBodyError {
+  constructor(readonly maxBytes: number) {
+    super(`HTTP module response exceeds ${maxBytes} bytes`);
+    this.name = "HttpModuleBodyTooLargeError";
+  }
+}
+
+/** Raised when an HTTP module is not valid UTF-8 source text. */
+export class HttpModuleBodyEncodingError extends HttpModuleBodyError {
+  constructor(options?: ErrorOptions) {
+    super("HTTP module response is not valid UTF-8", options);
+    this.name = "HttpModuleBodyEncodingError";
+  }
+}
+
+function cancelResponseBody(response: Response): void {
+  try {
+    const cancellation = response.body?.cancel();
+    if (cancellation) void cancellation.catch(() => undefined);
+  } catch {
+    /* cancellation is best-effort cleanup */
+  }
+}
+
+function requireMaxBytes(maxBytes: number): number {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0 || maxBytes >= Number.MAX_SAFE_INTEGER) {
+    throw new RangeError("HTTP module response limit must be a positive safe integer");
+  }
+  return maxBytes;
+}
+
+/**
+ * Read one HTTP module response as strict UTF-8 without buffering more than
+ * `maxBytes + 1`. The extra probe byte distinguishes an exact-limit body from
+ * an oversized body while the shared prefix reader cancels unread data.
+ */
+export async function readHttpModuleText(
+  response: Response,
+  maxBytes: number,
+  abortSignal?: AbortSignal,
+): Promise<string> {
+  const limit = requireMaxBytes(maxBytes);
+  if (abortSignal?.aborted) {
+    cancelResponseBody(response);
+    abortSignal.throwIfAborted();
+  }
+
+  const rawContentLength = response.headers.get("content-length");
+  if (rawContentLength && /^\d+$/.test(rawContentLength)) {
+    const contentLength = Number(rawContentLength);
+    if (Number.isSafeInteger(contentLength) && contentLength > limit) {
+      cancelResponseBody(response);
+      throw new HttpModuleBodyTooLargeError(limit);
+    }
+  }
+
+  try {
+    const { text, truncated } = await readResponseTextPrefix(
+      response,
+      limit + 1,
+      abortSignal,
+      { fatalUtf8: true },
+    );
+    if (truncated) throw new HttpModuleBodyTooLargeError(limit);
+    return text;
+  } catch (cause) {
+    if (cause instanceof InvalidResponseBodyUtf8Error) {
+      throw new HttpModuleBodyEncodingError({ cause });
+    }
+    throw cause;
+  }
+}

--- a/src/utils/parallel.test.ts
+++ b/src/utils/parallel.test.ts
@@ -63,6 +63,20 @@ describe("parallel", () => {
 
       assertEquals(maxConcurrent, 2);
     });
+
+    it("should enforce the declarative concurrency limit", async () => {
+      let concurrent = 0;
+      let maxConcurrent = 0;
+
+      await parallelMap([1, 2, 3, 4], async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        concurrent--;
+      }, { concurrency: 2 });
+
+      assertEquals(maxConcurrent, 2);
+    });
   });
 
   describe("parallelAll", () => {

--- a/src/utils/parallel.ts
+++ b/src/utils/parallel.ts
@@ -25,6 +25,15 @@ type ParallelOptions = {
   timeoutMs?: number;
 };
 
+function resolveParallelSemaphore(options: ParallelOptions): Semaphore {
+  if (options.semaphore !== undefined) return options.semaphore;
+  if (options.concurrency === undefined) return apiSemaphore;
+  if (!Number.isSafeInteger(options.concurrency) || options.concurrency < 1) {
+    throw new RangeError("parallel concurrency must be a positive safe integer");
+  }
+  return new Semaphore(options.concurrency);
+}
+
 async function acquireOrThrow(
   semaphore: Semaphore,
   timeoutMs: number,
@@ -50,7 +59,7 @@ export function parallelMap<T, R>(
     async () => {
       if (items.length === 0) return [];
 
-      const semaphore = options.semaphore ?? apiSemaphore;
+      const semaphore = resolveParallelSemaphore(options);
       const timeoutMs = options.timeoutMs ?? ACQUIRE_TIMEOUT_MS;
       const results: R[] = new Array(items.length);
 


### PR DESCRIPTION
## Summary

- bound HTTP module response size, decoding, timeout, and cancellation behavior
- make ESM bundle manifests complete and validate recursive dependency admission
- bound CSS module rewriting and reserve internal module namespaces
- redact production transform failures and align module loader documentation

This is intentionally smaller than the approximate 20k-line extraction target: it is the largest coherent, independently verifiable subset of the recovered modules/transforms changes. The remaining recovered commits either depend on stale registry/SSR architectures or cross other active extraction lanes.

## Validation

- `deno test -A --no-check src/modules src/transforms` — 181 passed, 2,487 steps
- focused changed-area tests — 14 suites, 329 steps
- `deno task typecheck`
- `deno task lint:module-boundaries`
- focused formatting and lint checks

## Deliberately excluded

- legacy SSR import rewriting superseded by the current async architecture
- component discovery changes tied to the prior registry architecture
- websocket lifecycle changes tied to a deleted isolation surface
- changes owned by the platform/extensions and release-assets extraction lanes