### PR TITLE
fix(provider): harden Anthropic and Google adapters

### DIFF
--- a/extensions/ext-llm-anthropic/README.md
+++ b/extensions/ext-llm-anthropic/README.md
@@ -43,7 +43,8 @@ Automatic `max_tokens` defaults based on model family:
 
 | Model                        | Default max_tokens |
 | ---------------------------- | ------------------ |
-| Claude Opus/Sonnet 4.6       | 128,000            |
+| Claude Opus 4.8/4.7/4.6      | 128,000            |
+| Claude Sonnet 4.6            | 64,000             |
 | Claude Opus/Sonnet/Haiku 4.5 | 64,000             |
 | Claude Opus 4.1              | 32,000             |
 | Claude 3 Haiku               | 4,096              |
@@ -69,6 +70,20 @@ runtime.doGenerate({
 Effort-to-budget mapping: `low` = 1024, `medium` = 4096, `high` = 16384, `max` = 32768.
 
 When thinking is enabled, `temperature` and `topP` are automatically dropped (Anthropic rejects the combo).
+
+### Exact Replay
+
+Thinking, redacted thinking, ordinary `tool_use`, server-tool calls, and
+server-tool results are retained in assistant provider metadata for later
+turns. Manual callers must carry that metadata forward with the canonical
+assistant message.
+
+Raw replay is limited to six assistant messages, 4,096 total content blocks,
+and 8 MiB. When canonical calls or provider-executed results survive, their
+IDs, names, semantic inputs or results, multiplicity, and interleaving must
+match the raw blocks before transport. Structurally valid raw-only history is
+accepted only when the corresponding canonical projection is absent, for
+example after compaction.
 
 ### Prompt Caching
 
@@ -103,7 +118,13 @@ Already-versioned IDs (e.g. `anthropic.code_execution_20250522`) pass through ve
 
 ### MCP Servers
 
-Pass Anthropic-native MCP servers via `mcpServers`. Keys are automatically converted from camelCase to snake_case:
+Pass Anthropic-native MCP server connection details via `mcpServers`. The runtime validates
+that every server has a unique name and an absolute HTTPS URL, emits the current
+`mcp_servers` wire shape, and adds the required
+`mcp-client-2025-11-20` beta without dropping unrelated caller betas.
+
+Every server is paired with exactly one `mcp_toolset`. When no toolset is supplied, the
+runtime generates one that enables all tools:
 
 ```ts
 runtime.doGenerate({
@@ -112,13 +133,78 @@ runtime.doGenerate({
     type: "url",
     url: "https://example.com/mcp",
     name: "my-server",
-    authorizationToken: "Bearer ...",
-    toolConfiguration: {
-      enabled: true,
-      allowedTools: ["search"],
+    authorizationToken: "opaque-access-token",
+  }],
+});
+```
+
+For current per-tool configuration, add a provider tool whose `name` exactly matches the
+MCP server name. Camel-case arguments are converted recursively to Anthropic's wire names:
+
+```ts
+runtime.doGenerate({
+  prompt: [...],
+  mcpServers: [{
+    type: "url",
+    url: "https://example.com/mcp",
+    name: "my-server",
+    authorizationToken: "opaque-access-token",
+  }],
+  tools: [{
+    type: "provider",
+    id: "anthropic.mcp_toolset",
+    name: "my-server",
+    args: {
+      defaultConfig: {
+        enabled: false,
+        deferLoading: true,
+      },
+      configs: {
+        search: {
+          enabled: true,
+          deferLoading: false,
+        },
+      },
     },
   }],
 });
+```
+
+The previously documented convenience form remains supported and is translated to the
+current MCPToolset allowlist contract:
+
+```ts
+mcpServers: [{
+  type: "url",
+  url: "https://example.com/mcp",
+  name: "my-server",
+  toolConfiguration: {
+    enabled: true,
+    allowedTools: ["search"],
+  },
+}];
+```
+
+Do not configure the same server or toolset through both `mcpServers` and raw
+`providerOptions`. Ambiguous definitions, duplicate names/toolsets, dangling toolsets,
+unknown MCP fields, non-HTTPS URLs, and malformed tool configuration fail before a network
+request is made. If raw `mcp_servers` and `tools` are supplied through `providerOptions`,
+they must already use Anthropic's current wire contract:
+
+```ts
+providerOptions: {
+  anthropic: {
+    mcp_servers: [{
+      type: "url",
+      url: "https://example.com/mcp",
+      name: "my-server",
+    }],
+    tools: [{
+      type: "mcp_toolset",
+      mcp_server_name: "my-server",
+    }],
+  },
+}
 ```
 
 ### Container

--- a/extensions/ext-llm-anthropic/src/anthropic-citations.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-citations.ts
@@ -1,0 +1,198 @@
+import { readRecord } from "veryfront/provider/shared";
+
+export type AnthropicCitation = {
+  type:
+    | "char_location"
+    | "page_location"
+    | "content_block_location"
+    | "web_search_result_location"
+    | "search_result_location";
+  citedText: string;
+  url?: string;
+  title?: string;
+  encryptedIndex?: string;
+  source?: string;
+  fileId?: string;
+  startCharIndex?: number;
+  endCharIndex?: number;
+  startBlockIndex?: number;
+  endBlockIndex?: number;
+  startPageNumber?: number;
+  endPageNumber?: number;
+  documentIndex?: number;
+  documentTitle?: string;
+  searchResultIndex?: number;
+};
+
+function readRequiredString(
+  record: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  const value = record[field];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readOptionalNullableString(
+  record: Record<string, unknown>,
+  field: string,
+): string | null | undefined {
+  const value = record[field];
+  return value === undefined || value === null || typeof value === "string" ? value : undefined;
+}
+
+function readNonNegativeInteger(
+  record: Record<string, unknown>,
+  field: string,
+): number | undefined {
+  const value = record[field];
+  return typeof value === "number" &&
+      Number.isSafeInteger(value) &&
+      value >= 0
+    ? value
+    : undefined;
+}
+
+function hasValidOptionalNullableString(
+  record: Record<string, unknown>,
+  field: string,
+): boolean {
+  return record[field] === undefined ||
+    record[field] === null ||
+    typeof record[field] === "string";
+}
+
+function withOptionalString(
+  key: "title" | "fileId" | "documentTitle",
+  value: string | null | undefined,
+): Partial<AnthropicCitation> {
+  return typeof value === "string" ? { [key]: value } : {};
+}
+
+/**
+ * Validates and normalizes the current Messages API citation union.
+ *
+ * Citation records are provider-controlled protocol data. Returning
+ * `undefined` for any malformed or unknown variant lets callers fail the
+ * successful response closed instead of silently discarding attribution.
+ */
+export function normalizeAnthropicCitation(
+  raw: unknown,
+): AnthropicCitation | undefined {
+  const record = readRecord(raw);
+  if (!record || typeof record.type !== "string") return undefined;
+
+  const citedText = readRequiredString(record, "cited_text");
+  if (citedText === undefined) return undefined;
+
+  if (record.type === "web_search_result_location") {
+    const url = readRequiredString(record, "url");
+    const encryptedIndex = readRequiredString(record, "encrypted_index");
+    const title = readOptionalNullableString(record, "title");
+    if (
+      url === undefined ||
+      encryptedIndex === undefined ||
+      !hasValidOptionalNullableString(record, "title")
+    ) {
+      return undefined;
+    }
+    return {
+      type: record.type,
+      citedText,
+      url,
+      encryptedIndex,
+      ...withOptionalString("title", title),
+    };
+  }
+
+  if (record.type === "search_result_location") {
+    const source = readRequiredString(record, "source");
+    const title = readOptionalNullableString(record, "title");
+    const searchResultIndex = readNonNegativeInteger(record, "search_result_index");
+    const startBlockIndex = readNonNegativeInteger(record, "start_block_index");
+    const endBlockIndex = readNonNegativeInteger(record, "end_block_index");
+    if (
+      source === undefined ||
+      searchResultIndex === undefined ||
+      startBlockIndex === undefined ||
+      endBlockIndex === undefined ||
+      endBlockIndex <= startBlockIndex ||
+      !hasValidOptionalNullableString(record, "title")
+    ) {
+      return undefined;
+    }
+    return {
+      type: record.type,
+      citedText,
+      source,
+      searchResultIndex,
+      startBlockIndex,
+      endBlockIndex,
+      ...withOptionalString("title", title),
+    };
+  }
+
+  const documentIndex = readNonNegativeInteger(record, "document_index");
+  const documentTitle = readOptionalNullableString(record, "document_title");
+  const fileId = readOptionalNullableString(record, "file_id");
+  if (
+    documentIndex === undefined ||
+    !hasValidOptionalNullableString(record, "document_title") ||
+    !hasValidOptionalNullableString(record, "file_id")
+  ) {
+    return undefined;
+  }
+
+  const common = {
+    citedText,
+    documentIndex,
+    ...withOptionalString("documentTitle", documentTitle),
+    ...withOptionalString("fileId", fileId),
+  };
+
+  if (record.type === "char_location") {
+    const startCharIndex = readNonNegativeInteger(record, "start_char_index");
+    const endCharIndex = readNonNegativeInteger(record, "end_char_index");
+    return startCharIndex !== undefined &&
+        endCharIndex !== undefined &&
+        endCharIndex >= startCharIndex
+      ? {
+        type: record.type,
+        ...common,
+        startCharIndex,
+        endCharIndex,
+      }
+      : undefined;
+  }
+
+  if (record.type === "page_location") {
+    const startPageNumber = readNonNegativeInteger(record, "start_page_number");
+    const endPageNumber = readNonNegativeInteger(record, "end_page_number");
+    return startPageNumber !== undefined &&
+        endPageNumber !== undefined &&
+        endPageNumber >= startPageNumber
+      ? {
+        type: record.type,
+        ...common,
+        startPageNumber,
+        endPageNumber,
+      }
+      : undefined;
+  }
+
+  if (record.type === "content_block_location") {
+    const startBlockIndex = readNonNegativeInteger(record, "start_block_index");
+    const endBlockIndex = readNonNegativeInteger(record, "end_block_index");
+    return startBlockIndex !== undefined &&
+        endBlockIndex !== undefined &&
+        endBlockIndex > startBlockIndex
+      ? {
+        type: record.type,
+        ...common,
+        startBlockIndex,
+        endBlockIndex,
+      }
+      : undefined;
+  }
+
+  return undefined;
+}

--- a/extensions/ext-llm-anthropic/src/anthropic-mcp-request.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-mcp-request.test.ts
@@ -1,0 +1,230 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  assertAnthropicMcpRequestContract,
+  normalizeAnthropicMcpServers,
+} from "./anthropic-mcp-request.ts";
+
+function captureThrownError(fn: () => unknown, expectedType?: typeof Error): Error {
+  try {
+    fn();
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
+    const actualName = error.name;
+    if (expectedType && !(error instanceof expectedType)) {
+      throw new Error(`Expected ${expectedType.name}, received ${actualName}`);
+    }
+    return error;
+  }
+  throw new Error("Expected function to throw");
+}
+
+describe("ext-llm-anthropic/anthropic-mcp-request", () => {
+  it("translates documented MCP server options into current server and toolset objects", () => {
+    const normalized = normalizeAnthropicMcpServers([{
+      type: "url",
+      url: "https://mcp.example.test/sse",
+      name: "calendar",
+      authorizationToken: "opaque-token",
+      toolConfiguration: {
+        enabled: true,
+        allowedTools: ["search_events", "create_event"],
+      },
+    }, {
+      type: "url",
+      url: "https://mcp.example.test/files",
+      name: "files",
+    }]);
+
+    assertEquals(normalized?.servers, [{
+      type: "url",
+      url: "https://mcp.example.test/sse",
+      name: "calendar",
+      authorization_token: "opaque-token",
+    }, {
+      type: "url",
+      url: "https://mcp.example.test/files",
+      name: "files",
+    }]);
+    assertEquals(normalized?.defaultToolsets, [{
+      type: "mcp_toolset",
+      mcp_server_name: "calendar",
+      default_config: { enabled: false },
+      configs: {
+        search_events: { enabled: true },
+        create_event: { enabled: true },
+      },
+    }, {
+      type: "mcp_toolset",
+      mcp_server_name: "files",
+    }]);
+    assertEquals(
+      normalized?.legacyConfiguredServerNames.has("calendar"),
+      true,
+    );
+    assertEquals(normalized?.legacyConfiguredServerNames.has("files"), false);
+  });
+
+  it("accepts one spelling of each supported camelCase or snake_case input field", () => {
+    const normalized = normalizeAnthropicMcpServers([{
+      type: "url",
+      url: "https://mcp.example.test",
+      name: "docs",
+      authorization_token: "token",
+      tool_configuration: {
+        enabled: false,
+        allowed_tools: [],
+      },
+    }]);
+
+    assertEquals(normalized?.servers, [{
+      type: "url",
+      url: "https://mcp.example.test",
+      name: "docs",
+      authorization_token: "token",
+    }]);
+    assertEquals(normalized?.defaultToolsets, [{
+      type: "mcp_toolset",
+      mcp_server_name: "docs",
+      default_config: { enabled: false },
+    }]);
+  });
+
+  it("fails closed on malformed or ambiguous convenience input without exposing values", () => {
+    const privateValue = "PRIVATE_MCP_CREDENTIAL";
+    const invalidInputs: unknown[] = [
+      "not-an-array",
+      [null],
+      [{ type: "stdio", url: "https://mcp.example.test", name: "docs" }],
+      [{ type: "url", url: "http://mcp.example.test", name: "docs" }],
+      [{ type: "url", url: "https://mcp.example.test", name: "" }],
+      [{
+        type: "url",
+        url: "https://mcp.example.test",
+        name: "docs",
+        authorizationToken: privateValue,
+        authorization_token: privateValue,
+      }],
+      [{
+        type: "url",
+        url: "https://mcp.example.test",
+        name: "docs",
+        authorizationToken: "",
+      }],
+      [{
+        type: "url",
+        url: "https://mcp.example.test",
+        name: "docs",
+        secret: privateValue,
+      }],
+      [{
+        type: "url",
+        url: "https://mcp.example.test",
+        name: "docs",
+        toolConfiguration: { enabled: "yes" },
+      }],
+      [{
+        type: "url",
+        url: "https://mcp.example.test",
+        name: "docs",
+        toolConfiguration: {
+          enabled: false,
+          allowedTools: ["search"],
+        },
+      }],
+      [{
+        type: "url",
+        url: "https://mcp.example.test",
+        name: "docs",
+        toolConfiguration: {
+          allowedTools: ["search", "search"],
+        },
+      }],
+      [
+        { type: "url", url: "https://one.example.test", name: "duplicate" },
+        { type: "url", url: "https://two.example.test", name: "duplicate" },
+      ],
+    ];
+
+    for (const invalidInput of invalidInputs) {
+      const error = captureThrownError(
+        () => normalizeAnthropicMcpServers(invalidInput),
+        TypeError,
+      );
+      assertEquals(error.message.includes(privateValue), false);
+    }
+  });
+
+  it("validates the exact current MCP request identity contract", () => {
+    assertEquals(
+      assertAnthropicMcpRequestContract({
+        mcp_servers: [{
+          type: "url",
+          url: "https://mcp.example.test",
+          name: "docs",
+          authorization_token: "opaque-token",
+        }],
+        tools: [{
+          type: "mcp_toolset",
+          mcp_server_name: "docs",
+          default_config: { enabled: false, defer_loading: true },
+          configs: {
+            search: { enabled: true, defer_loading: false },
+          },
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        }],
+      }),
+      true,
+    );
+    assertEquals(assertAnthropicMcpRequestContract({ tools: [] }), false);
+    assertEquals(
+      assertAnthropicMcpRequestContract({ mcp_servers: [], tools: [] }),
+      false,
+    );
+  });
+
+  it("rejects dangling, duplicate, missing, and malformed MCP toolsets", () => {
+    const server = {
+      type: "url",
+      url: "https://mcp.example.test",
+      name: "docs",
+    };
+    const validToolset = {
+      type: "mcp_toolset",
+      mcp_server_name: "docs",
+    };
+    const invalidBodies: Array<Record<string, unknown>> = [
+      { tools: [validToolset] },
+      { mcp_servers: [server], tools: [] },
+      { mcp_servers: [server], tools: [validToolset, validToolset] },
+      {
+        mcp_servers: [server],
+        tools: [{ type: "mcp_toolset", mcp_server_name: "other" }],
+      },
+      {
+        mcp_servers: [{ ...server, tool_configuration: { enabled: true } }],
+        tools: [validToolset],
+      },
+      {
+        mcp_servers: [server],
+        tools: [{ ...validToolset, name: "not-a-wire-field" }],
+      },
+      {
+        mcp_servers: [server],
+        tools: [{ ...validToolset, default_config: { enabled: "yes" } }],
+      },
+      {
+        mcp_servers: [server],
+        tools: [{ ...validToolset, configs: { search: { unknown: true } } }],
+      },
+      {
+        mcp_servers: [server],
+        tools: [{ ...validToolset, cache_control: { type: "forever" } }],
+      },
+    ];
+
+    for (const body of invalidBodies) {
+      assertThrows(() => assertAnthropicMcpRequestContract(body), TypeError);
+    }
+  });
+});

--- a/extensions/ext-llm-anthropic/src/anthropic-mcp-request.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-mcp-request.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assertEquals, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
 import {
   assertAnthropicMcpRequestContract,
   normalizeAnthropicMcpServers,

--- a/extensions/ext-llm-anthropic/src/anthropic-mcp-request.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-mcp-request.ts
@@ -1,0 +1,517 @@
+type AnthropicMcpToolConfig = {
+  enabled?: boolean;
+  defer_loading?: boolean;
+};
+
+type AnthropicMcpToolset = {
+  type: "mcp_toolset";
+  mcp_server_name: string;
+  default_config?: AnthropicMcpToolConfig;
+  configs?: Record<string, AnthropicMcpToolConfig>;
+  cache_control?: {
+    type: "ephemeral";
+    ttl?: "5m" | "1h";
+  };
+};
+
+export type AnthropicMcpRequestConfiguration = {
+  servers: Array<Record<string, unknown>>;
+  defaultToolsets: AnthropicMcpToolset[];
+  legacyConfiguredServerNames: ReadonlySet<string>;
+};
+
+const SERVER_INPUT_KEYS = new Set([
+  "type",
+  "url",
+  "name",
+  "authorizationToken",
+  "authorization_token",
+  "toolConfiguration",
+  "tool_configuration",
+]);
+const LEGACY_TOOL_CONFIGURATION_KEYS = new Set([
+  "enabled",
+  "allowedTools",
+  "allowed_tools",
+]);
+const SERVER_WIRE_KEYS = new Set([
+  "type",
+  "url",
+  "name",
+  "authorization_token",
+]);
+const TOOLSET_WIRE_KEYS = new Set([
+  "type",
+  "mcp_server_name",
+  "default_config",
+  "configs",
+  "cache_control",
+]);
+const TOOL_CONFIG_KEYS = new Set(["enabled", "defer_loading"]);
+const TOOLSET_INPUT_KEYS = new Set([
+  "defaultConfig",
+  "default_config",
+  "configs",
+  "cacheControl",
+  "cache_control",
+]);
+const TOOL_CONFIG_INPUT_KEYS = new Set([
+  "enabled",
+  "deferLoading",
+  "defer_loading",
+]);
+const CACHE_CONTROL_KEYS = new Set(["type", "ttl"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertOnlyKeys(
+  record: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+  message: string,
+): void {
+  if (Object.keys(record).some((key) => !allowedKeys.has(key))) {
+    throw new TypeError(message);
+  }
+}
+
+function readAliasedValue(
+  record: Record<string, unknown>,
+  camelCaseKey: string,
+  snakeCaseKey: string,
+  message: string,
+): unknown {
+  const hasCamelCase = Object.hasOwn(record, camelCaseKey);
+  const hasSnakeCase = Object.hasOwn(record, snakeCaseKey);
+  if (hasCamelCase && hasSnakeCase) {
+    throw new TypeError(message);
+  }
+  if (hasCamelCase) return record[camelCaseKey];
+  if (hasSnakeCase) return record[snakeCaseKey];
+  return undefined;
+}
+
+function requireNonEmptyString(value: unknown, message: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(message);
+  }
+  return value;
+}
+
+function requireHttpsUrl(value: unknown): string {
+  const url = requireNonEmptyString(value, "Anthropic MCP server url must be a non-empty string");
+  try {
+    if (!url.startsWith("https://") || new URL(url).protocol !== "https:") {
+      throw new TypeError();
+    }
+  } catch {
+    throw new TypeError("Anthropic MCP server url must be an absolute HTTPS URL");
+  }
+  return url;
+}
+
+function readLegacyToolConfiguration(
+  raw: unknown,
+): {
+  defaultConfig?: AnthropicMcpToolConfig;
+  configs?: Record<string, AnthropicMcpToolConfig>;
+} {
+  if (!isRecord(raw)) {
+    throw new TypeError("Anthropic MCP toolConfiguration must be an object");
+  }
+  assertOnlyKeys(
+    raw,
+    LEGACY_TOOL_CONFIGURATION_KEYS,
+    "Anthropic MCP toolConfiguration contains unsupported fields",
+  );
+
+  const enabled = raw.enabled;
+  if (enabled !== undefined && typeof enabled !== "boolean") {
+    throw new TypeError("Anthropic MCP toolConfiguration.enabled must be a boolean");
+  }
+
+  const allowedTools = readAliasedValue(
+    raw,
+    "allowedTools",
+    "allowed_tools",
+    "Anthropic MCP toolConfiguration must not define both allowedTools spellings",
+  );
+  if (allowedTools === undefined) {
+    return enabled === undefined ? {} : { defaultConfig: { enabled } };
+  }
+  if (
+    !Array.isArray(allowedTools) ||
+    allowedTools.some((name) => typeof name !== "string" || name.length === 0)
+  ) {
+    throw new TypeError(
+      "Anthropic MCP toolConfiguration.allowedTools must be an array of non-empty strings",
+    );
+  }
+  if (new Set(allowedTools).size !== allowedTools.length) {
+    throw new TypeError("Anthropic MCP toolConfiguration.allowedTools must be unique");
+  }
+  if (enabled === false && allowedTools.length > 0) {
+    throw new TypeError(
+      "Anthropic MCP toolConfiguration cannot disable a server and enable individual tools",
+    );
+  }
+
+  const configs = Object.fromEntries(
+    allowedTools.map((name) => [name, { enabled: true }]),
+  );
+  return {
+    defaultConfig: { enabled: false },
+    ...(allowedTools.length > 0 ? { configs } : {}),
+  };
+}
+
+/**
+ * Validate and translate the existing camelCase MCP convenience option into
+ * Anthropic's current MCP server and MCPToolset wire objects.
+ */
+export function normalizeAnthropicMcpServers(
+  rawServers: unknown,
+): AnthropicMcpRequestConfiguration | undefined {
+  if (rawServers === undefined) return undefined;
+  if (!Array.isArray(rawServers)) {
+    throw new TypeError("Anthropic mcpServers must be an array");
+  }
+  if (rawServers.length === 0) return undefined;
+
+  const servers: Array<Record<string, unknown>> = [];
+  const defaultToolsets: AnthropicMcpToolset[] = [];
+  const legacyConfiguredServerNames = new Set<string>();
+  const seenServerNames = new Set<string>();
+
+  for (const rawServer of rawServers) {
+    if (!isRecord(rawServer)) {
+      throw new TypeError("Anthropic mcpServers entries must be objects");
+    }
+    assertOnlyKeys(
+      rawServer,
+      SERVER_INPUT_KEYS,
+      "Anthropic MCP server contains unsupported fields",
+    );
+    if (rawServer.type !== "url") {
+      throw new TypeError('Anthropic MCP server type must be "url"');
+    }
+
+    const url = requireHttpsUrl(rawServer.url);
+    const name = requireNonEmptyString(
+      rawServer.name,
+      "Anthropic MCP server name must be a non-empty string",
+    );
+    if (seenServerNames.has(name)) {
+      throw new TypeError("Anthropic MCP server names must be unique");
+    }
+    seenServerNames.add(name);
+
+    const authorizationToken = readAliasedValue(
+      rawServer,
+      "authorizationToken",
+      "authorization_token",
+      "Anthropic MCP server must not define both authorization token spellings",
+    );
+    if (
+      authorizationToken !== undefined &&
+      (typeof authorizationToken !== "string" || authorizationToken.length === 0)
+    ) {
+      throw new TypeError("Anthropic MCP server authorization token must be a non-empty string");
+    }
+
+    const toolConfiguration = readAliasedValue(
+      rawServer,
+      "toolConfiguration",
+      "tool_configuration",
+      "Anthropic MCP server must not define both toolConfiguration spellings",
+    );
+    const translatedToolConfiguration = toolConfiguration === undefined
+      ? {}
+      : readLegacyToolConfiguration(toolConfiguration);
+    if (toolConfiguration !== undefined) {
+      legacyConfiguredServerNames.add(name);
+    }
+
+    servers.push({
+      type: "url",
+      url,
+      name,
+      ...(authorizationToken !== undefined ? { authorization_token: authorizationToken } : {}),
+    });
+    defaultToolsets.push({
+      type: "mcp_toolset",
+      mcp_server_name: name,
+      ...(translatedToolConfiguration.defaultConfig
+        ? { default_config: translatedToolConfiguration.defaultConfig }
+        : {}),
+      ...(translatedToolConfiguration.configs
+        ? { configs: translatedToolConfiguration.configs }
+        : {}),
+    });
+  }
+
+  return {
+    servers,
+    defaultToolsets,
+    legacyConfiguredServerNames,
+  };
+}
+
+function normalizeToolConfigInput(raw: unknown): AnthropicMcpToolConfig {
+  if (!isRecord(raw)) {
+    throw new TypeError("Anthropic MCP provider tool config must be an object");
+  }
+  assertOnlyKeys(
+    raw,
+    TOOL_CONFIG_INPUT_KEYS,
+    "Anthropic MCP provider tool config contains unsupported fields",
+  );
+  if (raw.enabled !== undefined && typeof raw.enabled !== "boolean") {
+    throw new TypeError("Anthropic MCP provider tool config enabled must be a boolean");
+  }
+  const deferLoading = readAliasedValue(
+    raw,
+    "deferLoading",
+    "defer_loading",
+    "Anthropic MCP provider tool config must not define both deferLoading spellings",
+  );
+  if (deferLoading !== undefined && typeof deferLoading !== "boolean") {
+    throw new TypeError("Anthropic MCP provider tool config deferLoading must be a boolean");
+  }
+  return {
+    ...(raw.enabled !== undefined ? { enabled: raw.enabled } : {}),
+    ...(deferLoading !== undefined ? { defer_loading: deferLoading } : {}),
+  };
+}
+
+/**
+ * Convert generic provider-tool arguments without rewriting the dynamic tool
+ * names used as keys in `configs`.
+ */
+export function normalizeAnthropicMcpToolsetArgs(
+  rawArgs: Record<string, unknown>,
+): Omit<AnthropicMcpToolset, "type" | "mcp_server_name"> {
+  assertOnlyKeys(
+    rawArgs,
+    TOOLSET_INPUT_KEYS,
+    "Anthropic MCP provider tool contains unsupported arguments",
+  );
+  const defaultConfig = readAliasedValue(
+    rawArgs,
+    "defaultConfig",
+    "default_config",
+    "Anthropic MCP provider tool must not define both defaultConfig spellings",
+  );
+  const cacheControl = readAliasedValue(
+    rawArgs,
+    "cacheControl",
+    "cache_control",
+    "Anthropic MCP provider tool must not define both cacheControl spellings",
+  );
+
+  let configs: Record<string, AnthropicMcpToolConfig> | undefined;
+  if (rawArgs.configs !== undefined) {
+    if (!isRecord(rawArgs.configs)) {
+      throw new TypeError("Anthropic MCP provider tool configs must be an object");
+    }
+    const entries = Object.entries(rawArgs.configs);
+    if (entries.some(([toolName]) => toolName.length === 0)) {
+      throw new TypeError("Anthropic MCP provider tool config names must be non-empty");
+    }
+    configs = Object.fromEntries(
+      entries.map(([toolName, config]) => [toolName, normalizeToolConfigInput(config)]),
+    );
+  }
+
+  if (cacheControl !== undefined) {
+    validateCacheControl(cacheControl);
+  }
+  const normalizedCacheControl = cacheControl as
+    | { type: "ephemeral"; ttl?: "5m" | "1h" }
+    | undefined;
+  return {
+    ...(defaultConfig !== undefined
+      ? { default_config: normalizeToolConfigInput(defaultConfig) }
+      : {}),
+    ...(configs !== undefined ? { configs } : {}),
+    ...(normalizedCacheControl !== undefined
+      ? {
+        cache_control: {
+          type: normalizedCacheControl.type,
+          ...(normalizedCacheControl.ttl !== undefined ? { ttl: normalizedCacheControl.ttl } : {}),
+        },
+      }
+      : {}),
+  };
+}
+
+function validateWireServer(rawServer: unknown): string {
+  if (!isRecord(rawServer)) {
+    throw new TypeError("Anthropic mcp_servers entries must be objects");
+  }
+  assertOnlyKeys(
+    rawServer,
+    SERVER_WIRE_KEYS,
+    "Anthropic mcp_servers entry contains unsupported fields",
+  );
+  if (rawServer.type !== "url") {
+    throw new TypeError('Anthropic mcp_servers entry type must be "url"');
+  }
+  requireHttpsUrl(rawServer.url);
+  const name = requireNonEmptyString(
+    rawServer.name,
+    "Anthropic mcp_servers entry name must be a non-empty string",
+  );
+  if (
+    rawServer.authorization_token !== undefined &&
+    (typeof rawServer.authorization_token !== "string" ||
+      rawServer.authorization_token.length === 0)
+  ) {
+    throw new TypeError(
+      "Anthropic mcp_servers entry authorization_token must be a non-empty string",
+    );
+  }
+  return name;
+}
+
+function validateToolConfig(raw: unknown, message: string): void {
+  if (!isRecord(raw)) {
+    throw new TypeError(message);
+  }
+  assertOnlyKeys(raw, TOOL_CONFIG_KEYS, message);
+  if (raw.enabled !== undefined && typeof raw.enabled !== "boolean") {
+    throw new TypeError(message);
+  }
+  if (raw.defer_loading !== undefined && typeof raw.defer_loading !== "boolean") {
+    throw new TypeError(message);
+  }
+}
+
+function validateCacheControl(raw: unknown): void {
+  if (!isRecord(raw)) {
+    throw new TypeError("Anthropic MCP toolset cache_control must be an object");
+  }
+  assertOnlyKeys(
+    raw,
+    CACHE_CONTROL_KEYS,
+    "Anthropic MCP toolset cache_control contains unsupported fields",
+  );
+  if (raw.type !== "ephemeral") {
+    throw new TypeError('Anthropic MCP toolset cache_control.type must be "ephemeral"');
+  }
+  if (raw.ttl !== undefined && raw.ttl !== "5m" && raw.ttl !== "1h") {
+    throw new TypeError('Anthropic MCP toolset cache_control.ttl must be "5m" or "1h"');
+  }
+}
+
+function validateMcpToolset(rawTool: Record<string, unknown>): string {
+  assertOnlyKeys(
+    rawTool,
+    TOOLSET_WIRE_KEYS,
+    "Anthropic MCP toolset contains unsupported fields",
+  );
+  const serverName = requireNonEmptyString(
+    rawTool.mcp_server_name,
+    "Anthropic MCP toolset mcp_server_name must be a non-empty string",
+  );
+  if (rawTool.default_config !== undefined) {
+    validateToolConfig(
+      rawTool.default_config,
+      "Anthropic MCP toolset default_config must contain only boolean tool settings",
+    );
+  }
+  if (rawTool.configs !== undefined) {
+    if (!isRecord(rawTool.configs)) {
+      throw new TypeError("Anthropic MCP toolset configs must be an object");
+    }
+    for (const [toolName, config] of Object.entries(rawTool.configs)) {
+      if (toolName.length === 0) {
+        throw new TypeError("Anthropic MCP toolset config names must be non-empty");
+      }
+      validateToolConfig(
+        config,
+        "Anthropic MCP toolset configs must contain only boolean tool settings",
+      );
+    }
+  }
+  if (rawTool.cache_control !== undefined) {
+    validateCacheControl(rawTool.cache_control);
+  }
+  return serverName;
+}
+
+/**
+ * Validate the final request after raw provider options have been merged.
+ * Returns whether the current MCP connector beta is required.
+ */
+export function assertAnthropicMcpRequestContract(
+  body: Record<string, unknown>,
+): boolean {
+  const rawServers = body.mcp_servers;
+  const rawTools = body.tools;
+  const mcpToolsets: Array<Record<string, unknown>> = [];
+
+  if (rawTools !== undefined) {
+    if (!Array.isArray(rawTools)) {
+      if (rawServers !== undefined) {
+        throw new TypeError("Anthropic MCP requests require tools to be an array");
+      }
+    } else {
+      for (const rawTool of rawTools) {
+        if (!isRecord(rawTool)) {
+          if (rawServers !== undefined) {
+            throw new TypeError("Anthropic MCP requests require tool entries to be objects");
+          }
+          continue;
+        }
+        if (rawTool.type === "mcp_toolset") {
+          mcpToolsets.push(rawTool);
+        }
+      }
+    }
+  }
+
+  if (rawServers === undefined) {
+    if (mcpToolsets.length > 0) {
+      throw new TypeError("Anthropic MCP toolsets require matching mcp_servers");
+    }
+    return false;
+  }
+  if (!Array.isArray(rawServers)) {
+    throw new TypeError("Anthropic mcp_servers must be an array");
+  }
+  if (rawServers.length === 0) {
+    if (mcpToolsets.length > 0) {
+      throw new TypeError("Anthropic MCP toolsets require matching mcp_servers");
+    }
+    return false;
+  }
+
+  const serverNames = new Set<string>();
+  for (const rawServer of rawServers) {
+    const serverName = validateWireServer(rawServer);
+    if (serverNames.has(serverName)) {
+      throw new TypeError("Anthropic mcp_servers names must be unique");
+    }
+    serverNames.add(serverName);
+  }
+
+  const toolsetCountByServer = new Map<string, number>();
+  for (const rawToolset of mcpToolsets) {
+    const serverName = validateMcpToolset(rawToolset);
+    if (!serverNames.has(serverName)) {
+      throw new TypeError("Anthropic MCP toolset references an unknown server");
+    }
+    toolsetCountByServer.set(serverName, (toolsetCountByServer.get(serverName) ?? 0) + 1);
+  }
+
+  for (const serverName of serverNames) {
+    if (toolsetCountByServer.get(serverName) !== 1) {
+      throw new TypeError(
+        "Anthropic MCP requests require exactly one mcp_toolset per server",
+      );
+    }
+  }
+  return true;
+}

--- a/extensions/ext-llm-anthropic/src/anthropic-native-content.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-native-content.test.ts
@@ -1,0 +1,443 @@
+import { assertEquals, assertInstanceOf, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  AnthropicServerToolResultError,
+  MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES,
+  parseAnthropicProviderToolUse,
+  parseAnthropicServerToolResult,
+  validateAnthropicRawAssistantMessages,
+} from "./anthropic-native-content.ts";
+
+describe("Anthropic provider-native content normalization", () => {
+  it("owns exact replay metadata and rejects executable object behavior", () => {
+    const rawMessages = [[{
+      type: "tool_use",
+      id: "tool_lookup",
+      name: "lookup",
+      input: { query: "Veryfront" },
+    }]];
+    const snapshot = validateAnthropicRawAssistantMessages(rawMessages);
+    rawMessages[0]![0]!.input.query = "mutated";
+    assertEquals(snapshot, [[{
+      type: "tool_use",
+      id: "tool_lookup",
+      name: "lookup",
+      input: { query: "Veryfront" },
+    }]]);
+
+    let accessorReads = 0;
+    const hostileInput = Object.defineProperty({}, "query", {
+      enumerable: true,
+      get() {
+        accessorReads += 1;
+        throw new Error("private metadata diagnostic");
+      },
+    });
+    const accessorError = assertThrows(
+      () =>
+        validateAnthropicRawAssistantMessages([[{
+          type: "tool_use",
+          id: "tool_accessor",
+          name: "lookup",
+          input: hostileInput,
+        }]]),
+      TypeError,
+      "Anthropic raw assistant metadata was not valid bounded JSON",
+    );
+    assertEquals(accessorReads, 0);
+    assertEquals(accessorError.message.includes("private metadata diagnostic"), false);
+
+    let serializationHookCalls = 0;
+    assertThrows(
+      () =>
+        validateAnthropicRawAssistantMessages([[{
+          type: "tool_use",
+          id: "tool_to_json",
+          name: "lookup",
+          input: {
+            query: "Veryfront",
+            toJSON() {
+              serializationHookCalls += 1;
+              return { query: "changed" };
+            },
+          },
+        }]]),
+      TypeError,
+      "Anthropic raw assistant metadata was not valid bounded JSON",
+    );
+    assertEquals(serializationHookCalls, 0);
+
+    assertThrows(
+      () =>
+        validateAnthropicRawAssistantMessages([[{
+          type: "text",
+          text: "x".repeat(MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES),
+        }]]),
+      TypeError,
+      `Anthropic raw assistant metadata exceeded ${MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES} UTF-8 bytes`,
+    );
+  });
+
+  it("keeps ordinary client tool_use blocks out of the provider-executed path", () => {
+    assertEquals(
+      parseAnthropicProviderToolUse({
+        type: "tool_use",
+        id: "tool_bash",
+        name: "bash",
+        input: { command: "pwd" },
+      }),
+      undefined,
+    );
+  });
+
+  it("parses server and MCP tool uses with their actual names", () => {
+    assertEquals(
+      parseAnthropicProviderToolUse({
+        type: "server_tool_use",
+        id: "srvtool_code",
+        name: "code_execution",
+        input: { code: "1 + 1" },
+        caller: { type: "direct" },
+      }),
+      {
+        blockType: "server_tool_use",
+        toolCallId: "srvtool_code",
+        toolName: "code_execution",
+        input: { code: "1 + 1" },
+      },
+    );
+    assertEquals(
+      parseAnthropicProviderToolUse({
+        type: "mcp_tool_use",
+        id: "mcptool_echo",
+        name: "echo",
+        server_name: "example-mcp",
+        input: { value: "hello" },
+      }),
+      {
+        blockType: "mcp_tool_use",
+        toolCallId: "mcptool_echo",
+        toolName: "echo",
+        serverName: "example-mcp",
+        input: { value: "hello" },
+      },
+    );
+  });
+
+  it("normalizes generic, encrypted, and bash code-execution results", () => {
+    const cases = [{
+      toolCallId: "srvtool_code",
+      toolName: "code_execution",
+      block: {
+        type: "code_execution_tool_result",
+        tool_use_id: "srvtool_code",
+        content: {
+          type: "code_execution_result",
+          stdout: "2\n",
+          stderr: "",
+          return_code: 0,
+          content: [{ type: "code_execution_output", file_id: "file_1" }],
+        },
+      },
+      expected: {
+        type: "code_execution_result",
+        stdout: "2\n",
+        stderr: "",
+        returnCode: 0,
+        content: [{ type: "code_execution_output", fileId: "file_1" }],
+      },
+    }, {
+      toolCallId: "srvtool_encrypted",
+      toolName: "code_execution",
+      block: {
+        type: "code_execution_tool_result",
+        tool_use_id: "srvtool_encrypted",
+        content: {
+          type: "encrypted_code_execution_result",
+          encrypted_stdout: "opaque",
+          stderr: "",
+          return_code: 0,
+          content: [],
+        },
+      },
+      expected: {
+        type: "encrypted_code_execution_result",
+        encryptedStdout: "opaque",
+        stderr: "",
+        returnCode: 0,
+        content: [],
+      },
+    }, {
+      toolCallId: "srvtool_bash",
+      toolName: "bash_code_execution",
+      block: {
+        type: "bash_code_execution_tool_result",
+        tool_use_id: "srvtool_bash",
+        content: {
+          type: "bash_code_execution_result",
+          stdout: "done\n",
+          stderr: "",
+          return_code: 0,
+          content: [{ type: "bash_code_execution_output", file_id: "file_2" }],
+        },
+      },
+      expected: {
+        type: "bash_code_execution_result",
+        stdout: "done\n",
+        stderr: "",
+        returnCode: 0,
+        content: [{ type: "bash_code_execution_output", fileId: "file_2" }],
+      },
+    }];
+
+    for (const testCase of cases) {
+      assertEquals(
+        parseAnthropicServerToolResult(
+          testCase.block,
+          new Map([[testCase.toolCallId, testCase.toolName]]),
+        ),
+        {
+          toolCallId: testCase.toolCallId,
+          toolName: testCase.toolName,
+          result: testCase.expected,
+        },
+      );
+    }
+  });
+
+  it("normalizes every text-editor code-execution result variant", () => {
+    const registry = new Map([["srvtool_editor", "text_editor_code_execution"]]);
+    const parseContent = (content: unknown) =>
+      parseAnthropicServerToolResult({
+        type: "text_editor_code_execution_tool_result",
+        tool_use_id: "srvtool_editor",
+        content,
+      }, registry)?.result;
+
+    assertEquals(
+      parseContent({
+        type: "text_editor_code_execution_view_result",
+        content: "line one",
+        file_type: "text",
+        num_lines: 1,
+        start_line: 1,
+        total_lines: 1,
+      }),
+      {
+        type: "text_editor_code_execution_view_result",
+        content: "line one",
+        fileType: "text",
+        numLines: 1,
+        startLine: 1,
+        totalLines: 1,
+      },
+    );
+    assertEquals(
+      parseContent({
+        type: "text_editor_code_execution_create_result",
+        is_file_update: false,
+      }),
+      {
+        type: "text_editor_code_execution_create_result",
+        isFileUpdate: false,
+      },
+    );
+    assertEquals(
+      parseContent({
+        type: "text_editor_code_execution_str_replace_result",
+        lines: null,
+        old_start: null,
+        old_lines: null,
+        new_start: null,
+        new_lines: null,
+      }),
+      {
+        type: "text_editor_code_execution_str_replace_result",
+        lines: null,
+        oldStart: null,
+        oldLines: null,
+        newStart: null,
+        newLines: null,
+      },
+    );
+  });
+
+  it("preserves official server-tool error codes and rejects unknown ones", () => {
+    const cases = [{
+      outerType: "code_execution_tool_result",
+      contentType: "code_execution_tool_result_error",
+      toolCallId: "srvtool_code_error",
+      toolName: "code_execution",
+      code: "invalid_tool_input",
+    }, {
+      outerType: "bash_code_execution_tool_result",
+      contentType: "bash_code_execution_tool_result_error",
+      toolCallId: "srvtool_bash_error",
+      toolName: "bash_code_execution",
+      code: "output_file_too_large",
+    }, {
+      outerType: "text_editor_code_execution_tool_result",
+      contentType: "text_editor_code_execution_tool_result_error",
+      toolCallId: "srvtool_editor_error",
+      toolName: "text_editor_code_execution",
+      code: "file_not_found",
+      errorMessage: "missing.txt",
+    }];
+
+    for (const testCase of cases) {
+      const parsed = parseAnthropicServerToolResult({
+        type: testCase.outerType,
+        tool_use_id: testCase.toolCallId,
+        content: {
+          type: testCase.contentType,
+          error_code: testCase.code,
+          ...(testCase.errorMessage === undefined ? {} : { error_message: testCase.errorMessage }),
+        },
+      }, new Map([[testCase.toolCallId, testCase.toolName]]));
+      assertEquals(parsed?.isError, true);
+      assertInstanceOf(parsed?.result, AnthropicServerToolResultError);
+      assertEquals((parsed?.result as AnthropicServerToolResultError).code, testCase.code);
+      assertEquals(
+        (parsed?.result as AnthropicServerToolResultError).detail,
+        testCase.errorMessage,
+      );
+    }
+
+    assertEquals(
+      parseAnthropicServerToolResult({
+        type: "code_execution_tool_result",
+        tool_use_id: "srvtool_bad_error",
+        content: {
+          type: "code_execution_tool_result_error",
+          error_code: "future_unverified_error",
+        },
+      }, new Map([["srvtool_bad_error", "code_execution"]])),
+      undefined,
+    );
+  });
+
+  it("normalizes MCP string and text-block results and their error flag", () => {
+    const registry = new Map([["mcptool_echo", "echo"]]);
+    assertEquals(
+      parseAnthropicServerToolResult({
+        type: "mcp_tool_result",
+        tool_use_id: "mcptool_echo",
+        is_error: false,
+        content: "hello",
+      }, registry),
+      {
+        toolCallId: "mcptool_echo",
+        toolName: "echo",
+        result: "hello",
+      },
+    );
+    assertEquals(
+      parseAnthropicServerToolResult({
+        type: "mcp_tool_result",
+        tool_use_id: "mcptool_echo",
+        is_error: true,
+        content: [{
+          type: "text",
+          text: "remote failure",
+          citations: null,
+        }],
+      }, registry),
+      {
+        toolCallId: "mcptool_echo",
+        toolName: "echo",
+        result: [{ type: "text", text: "remote failure", citations: null }],
+        isError: true,
+      },
+    );
+  });
+
+  it("fails closed on malformed provider-native result variants", () => {
+    const malformed = [{
+      type: "code_execution_tool_result",
+      tool_use_id: "srvtool_code",
+      content: {
+        type: "code_execution_result",
+        stdout: "ok",
+        stderr: "",
+        return_code: "0",
+        content: [],
+      },
+    }, {
+      type: "text_editor_code_execution_tool_result",
+      tool_use_id: "srvtool_editor",
+      content: {
+        type: "text_editor_code_execution_view_result",
+        content: "ok",
+        file_type: "binary",
+        num_lines: 1,
+        start_line: 1,
+        total_lines: 1,
+      },
+    }, {
+      type: "mcp_tool_result",
+      tool_use_id: "mcptool_missing_name",
+      is_error: false,
+      content: "hello",
+    }];
+
+    for (const block of malformed) {
+      assertEquals(
+        parseAnthropicServerToolResult(
+          block,
+          new Map([
+            ["srvtool_code", "code_execution"],
+            ["srvtool_editor", "text_editor_code_execution"],
+          ]),
+        ),
+        undefined,
+      );
+    }
+  });
+
+  it("rejects orphan results and non-integral execution metadata", () => {
+    const result = {
+      type: "code_execution_tool_result",
+      tool_use_id: "srvtool_code",
+      content: {
+        type: "code_execution_result",
+        stdout: "ok",
+        stderr: "",
+        return_code: 0,
+        content: [],
+      },
+    };
+    assertEquals(parseAnthropicServerToolResult(result, new Map()), undefined);
+    assertEquals(
+      parseAnthropicServerToolResult(
+        {
+          ...result,
+          content: {
+            ...result.content,
+            return_code: 0.5,
+          },
+        },
+        new Map([["srvtool_code", "code_execution"]]),
+      ),
+      undefined,
+    );
+    assertEquals(
+      parseAnthropicServerToolResult(
+        {
+          type: "text_editor_code_execution_tool_result",
+          tool_use_id: "srvtool_editor",
+          content: {
+            type: "text_editor_code_execution_view_result",
+            content: "line",
+            file_type: "text",
+            num_lines: -1,
+            start_line: 1,
+            total_lines: 1,
+          },
+        },
+        new Map([["srvtool_editor", "text_editor_code_execution"]]),
+      ),
+      undefined,
+    );
+  });
+});

--- a/extensions/ext-llm-anthropic/src/anthropic-native-content.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-native-content.ts
@@ -1,0 +1,786 @@
+import { type JsonSnapshotValue, readRecord, snapshotJsonValue } from "veryfront/provider/shared";
+
+export type AnthropicProviderToolNameRegistry = Map<string, string>;
+
+export type AnthropicProviderToolUse = {
+  blockType: "server_tool_use" | "mcp_tool_use";
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  serverName?: string;
+};
+
+export type AnthropicServerToolResult = {
+  toolCallId: string;
+  toolName: string;
+  result: unknown;
+  isError?: true;
+};
+
+const PROVIDER_TOOL_RESULT_BLOCK_TYPES = new Set([
+  "web_search_tool_result",
+  "web_fetch_tool_result",
+  "code_execution_tool_result",
+  "bash_code_execution_tool_result",
+  "text_editor_code_execution_tool_result",
+  "mcp_tool_result",
+]);
+
+const WEB_SEARCH_ERROR_CODES = new Set([
+  "invalid_tool_input",
+  "unavailable",
+  "max_uses_exceeded",
+  "too_many_requests",
+  "query_too_long",
+  "request_too_large",
+]);
+
+const WEB_FETCH_ERROR_CODES = new Set([
+  "invalid_tool_input",
+  "url_too_long",
+  "url_not_allowed",
+  "url_not_in_prior_context",
+  "url_not_accessible",
+  "unsupported_content_type",
+  "too_many_requests",
+  "max_uses_exceeded",
+  "unavailable",
+]);
+
+const CODE_EXECUTION_ERROR_CODES = new Set([
+  "invalid_tool_input",
+  "unavailable",
+  "too_many_requests",
+  "execution_time_exceeded",
+]);
+
+const BASH_CODE_EXECUTION_ERROR_CODES = new Set([
+  ...CODE_EXECUTION_ERROR_CODES,
+  "output_file_too_large",
+]);
+
+const TEXT_EDITOR_CODE_EXECUTION_ERROR_CODES = new Set([
+  ...CODE_EXECUTION_ERROR_CODES,
+  "file_not_found",
+]);
+
+export class AnthropicServerToolResultError extends Error {
+  override readonly name = "AnthropicServerToolResultError";
+  readonly provider = "anthropic";
+  readonly code: string;
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly detail?: string;
+
+  constructor(options: {
+    code: string;
+    toolCallId: string;
+    toolName: string;
+    detail?: string;
+  }) {
+    super(
+      `Anthropic ${options.toolName} failed with ${options.code} ` +
+        `(tool call ${options.toolCallId})`,
+    );
+    this.code = options.code;
+    this.toolCallId = options.toolCallId;
+    this.toolName = options.toolName;
+    if (options.detail !== undefined) this.detail = options.detail;
+  }
+}
+
+export function isAnthropicProviderToolResultBlockType(type: string): boolean {
+  return PROVIDER_TOOL_RESULT_BLOCK_TYPES.has(type);
+}
+
+export function isAnthropicProviderExecutedContentBlockType(type: unknown): boolean {
+  return type === "server_tool_use" ||
+    type === "mcp_tool_use" ||
+    typeof type === "string" && isAnthropicProviderToolResultBlockType(type);
+}
+
+export const MAX_ANTHROPIC_RAW_ASSISTANT_MESSAGES = 6;
+export const MAX_ANTHROPIC_RAW_ASSISTANT_BLOCKS = 4_096;
+export const MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES = 8 * 1024 * 1024;
+export const MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_DEPTH = 64;
+export const MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_NODES = 65_536;
+
+export function snapshotAnthropicRawAssistantMetadata(
+  value: unknown,
+): JsonSnapshotValue {
+  try {
+    return snapshotJsonValue(value, {
+      maxBytes: MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES,
+      maxDepth: MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_DEPTH,
+      maxNodes: MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_NODES,
+    });
+  } catch (error) {
+    if (
+      error instanceof TypeError &&
+      error.message ===
+        `Provider JSON snapshot exceeded ${MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES} UTF-8 bytes`
+    ) {
+      throw new TypeError(
+        `Anthropic raw assistant metadata exceeded ${MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES} UTF-8 bytes`,
+      );
+    }
+    throw new TypeError("Anthropic raw assistant metadata was not valid bounded JSON");
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value);
+}
+
+function isNullableNonNegativeSafeInteger(value: unknown): value is number | null {
+  return value === null || isSafeInteger(value) && value >= 0;
+}
+
+function hasValidCaller(value: unknown): boolean {
+  if (value === undefined) {
+    // Anthropic's narrative and direct-call examples omit `caller`, while the
+    // current generated response model marks it required. Accept both wire
+    // shapes, but validate the field strictly whenever it is present.
+    return true;
+  }
+  const caller = readRecord(value);
+  if (!caller) return false;
+  if (caller.type === "direct") return true;
+  if (
+    caller.type === "code_execution_20250825" ||
+    caller.type === "code_execution_20260120"
+  ) {
+    return isNonEmptyString(caller.tool_id);
+  }
+  return false;
+}
+
+/**
+ * Validate exact Anthropic assistant content before replaying it from provider
+ * metadata. The records retain their provider wire shape; validation only
+ * proves that every block is supported and provider-tool results correlate.
+ */
+export function validateAnthropicRawAssistantMessages(
+  value: unknown,
+  providerToolNamesById: AnthropicProviderToolNameRegistry = new Map(),
+): Array<Array<Record<string, unknown>>> {
+  const snapshot = snapshotAnthropicRawAssistantMetadata(value);
+  if (
+    !Array.isArray(snapshot) ||
+    snapshot.length === 0 ||
+    snapshot.length > MAX_ANTHROPIC_RAW_ASSISTANT_MESSAGES
+  ) {
+    throw new TypeError(
+      `Anthropic raw assistant messages must contain between 1 and ${MAX_ANTHROPIC_RAW_ASSISTANT_MESSAGES} messages`,
+    );
+  }
+
+  const messages = snapshot as Array<Array<Record<string, unknown>>>;
+  let blockCount = 0;
+
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex += 1) {
+    const content = messages[messageIndex];
+    if (!Array.isArray(content) || content.length === 0) {
+      throw new TypeError(
+        "Anthropic raw assistant messages must contain non-empty arrays of content blocks",
+      );
+    }
+    if (content.length > MAX_ANTHROPIC_RAW_ASSISTANT_BLOCKS - blockCount) {
+      throw new TypeError(
+        `Anthropic raw assistant metadata exceeded ${MAX_ANTHROPIC_RAW_ASSISTANT_BLOCKS} content blocks`,
+      );
+    }
+    blockCount += content.length;
+
+    for (let blockIndex = 0; blockIndex < content.length; blockIndex += 1) {
+      const value = content[blockIndex];
+      const block = readRecord(value);
+      if (!block || !isNonEmptyString(block.type)) {
+        throw new TypeError("Anthropic raw assistant content block must be an object with a type");
+      }
+
+      switch (block.type) {
+        case "text":
+          if (typeof block.text !== "string") {
+            throw new TypeError("Anthropic raw assistant text block is malformed");
+          }
+          break;
+        case "thinking":
+          if (
+            (block.thinking !== undefined && typeof block.thinking !== "string") ||
+            (block.signature !== undefined && typeof block.signature !== "string") ||
+            (typeof block.thinking !== "string" && typeof block.signature !== "string")
+          ) {
+            throw new TypeError("Anthropic raw assistant thinking block is malformed");
+          }
+          break;
+        case "redacted_thinking":
+          if (!isNonEmptyString(block.data)) {
+            throw new TypeError("Anthropic raw assistant redacted thinking block is malformed");
+          }
+          break;
+        case "tool_use": {
+          const input = block.input === undefined ? {} : readRecord(block.input);
+          if (!isNonEmptyString(block.id) || !isNonEmptyString(block.name) || !input) {
+            throw new TypeError("Anthropic raw assistant tool-use block is malformed");
+          }
+          break;
+        }
+        case "server_tool_use":
+        case "mcp_tool_use": {
+          const providerToolUse = parseAnthropicProviderToolUse(block);
+          if (
+            !providerToolUse ||
+            providerToolNamesById.has(providerToolUse.toolCallId)
+          ) {
+            throw new TypeError(
+              "Anthropic raw assistant provider tool-use block is malformed or duplicated",
+            );
+          }
+          providerToolNamesById.set(
+            providerToolUse.toolCallId,
+            providerToolUse.toolName,
+          );
+          break;
+        }
+        default:
+          if (!isAnthropicProviderToolResultBlockType(block.type)) {
+            throw new TypeError("Anthropic raw assistant content block type is unsupported");
+          }
+          if (!parseAnthropicServerToolResult(block, providerToolNamesById)) {
+            throw new TypeError(
+              "Anthropic raw assistant provider tool result is malformed or unpaired",
+            );
+          }
+          providerToolNamesById.delete(String(block.tool_use_id));
+      }
+    }
+  }
+
+  return messages;
+}
+
+export function parseAnthropicProviderToolUse(
+  value: unknown,
+): AnthropicProviderToolUse | undefined {
+  const block = readRecord(value);
+  if (!block || (block.type !== "server_tool_use" && block.type !== "mcp_tool_use")) {
+    return undefined;
+  }
+  const input = block.input === undefined ? {} : readRecord(block.input);
+  if (
+    !isNonEmptyString(block.id) ||
+    !isNonEmptyString(block.name) ||
+    !input
+  ) {
+    return undefined;
+  }
+
+  if (block.type === "server_tool_use") {
+    if (!hasValidCaller(block.caller)) return undefined;
+    return {
+      blockType: "server_tool_use",
+      toolCallId: block.id,
+      toolName: block.name,
+      input,
+    };
+  }
+
+  if (!isNonEmptyString(block.server_name)) return undefined;
+  return {
+    blockType: "mcp_tool_use",
+    toolCallId: block.id,
+    toolName: block.name,
+    input,
+    serverName: block.server_name,
+  };
+}
+
+function createToolResultError(
+  content: Record<string, unknown>,
+  expectedType: string,
+  allowedCodes: ReadonlySet<string>,
+  toolCallId: string,
+  toolName: string,
+  allowDetail = false,
+): AnthropicServerToolResult | undefined {
+  if (content.type !== expectedType || !isNonEmptyString(content.error_code)) {
+    return undefined;
+  }
+  if (!allowedCodes.has(content.error_code)) return undefined;
+
+  let detail: string | undefined;
+  if (allowDetail) {
+    if (
+      !("error_message" in content) ||
+      content.error_message !== null && typeof content.error_message !== "string"
+    ) {
+      return undefined;
+    }
+    if (typeof content.error_message === "string") detail = content.error_message;
+  }
+
+  return {
+    toolCallId,
+    toolName,
+    result: new AnthropicServerToolResultError({
+      code: content.error_code,
+      toolCallId,
+      toolName,
+      ...(detail === undefined ? {} : { detail }),
+    }),
+    isError: true,
+  };
+}
+
+function normalizeFileOutputs(
+  value: unknown,
+  expectedType: "code_execution_output" | "bash_code_execution_output",
+): Array<Record<string, unknown>> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const output: Array<Record<string, unknown>> = [];
+  for (const item of value) {
+    const record = readRecord(item);
+    if (!record || record.type !== expectedType || !isNonEmptyString(record.file_id)) {
+      return undefined;
+    }
+    output.push({ type: expectedType, fileId: record.file_id });
+  }
+  return output;
+}
+
+function normalizeCodeExecutionContent(
+  content: Record<string, unknown>,
+  toolCallId: string,
+): AnthropicServerToolResult | undefined {
+  const toolName = "code_execution";
+  const error = createToolResultError(
+    content,
+    "code_execution_tool_result_error",
+    CODE_EXECUTION_ERROR_CODES,
+    toolCallId,
+    toolName,
+  );
+  if (error) return error;
+
+  if (content.type === "code_execution_result") {
+    const outputs = normalizeFileOutputs(content.content, "code_execution_output");
+    if (
+      !outputs ||
+      typeof content.stdout !== "string" ||
+      typeof content.stderr !== "string" ||
+      !isSafeInteger(content.return_code)
+    ) {
+      return undefined;
+    }
+    return {
+      toolCallId,
+      toolName,
+      result: {
+        type: "code_execution_result",
+        stdout: content.stdout,
+        stderr: content.stderr,
+        returnCode: content.return_code,
+        content: outputs,
+      },
+    };
+  }
+
+  if (content.type === "encrypted_code_execution_result") {
+    const outputs = normalizeFileOutputs(content.content, "code_execution_output");
+    if (
+      !outputs ||
+      typeof content.encrypted_stdout !== "string" ||
+      typeof content.stderr !== "string" ||
+      !isSafeInteger(content.return_code)
+    ) {
+      return undefined;
+    }
+    return {
+      toolCallId,
+      toolName,
+      result: {
+        type: "encrypted_code_execution_result",
+        encryptedStdout: content.encrypted_stdout,
+        stderr: content.stderr,
+        returnCode: content.return_code,
+        content: outputs,
+      },
+    };
+  }
+
+  return undefined;
+}
+
+function normalizeBashCodeExecutionContent(
+  content: Record<string, unknown>,
+  toolCallId: string,
+): AnthropicServerToolResult | undefined {
+  const toolName = "bash_code_execution";
+  const error = createToolResultError(
+    content,
+    "bash_code_execution_tool_result_error",
+    BASH_CODE_EXECUTION_ERROR_CODES,
+    toolCallId,
+    toolName,
+  );
+  if (error) return error;
+
+  const outputs = normalizeFileOutputs(content.content, "bash_code_execution_output");
+  if (
+    content.type !== "bash_code_execution_result" ||
+    !outputs ||
+    typeof content.stdout !== "string" ||
+    typeof content.stderr !== "string" ||
+    !isSafeInteger(content.return_code)
+  ) {
+    return undefined;
+  }
+  return {
+    toolCallId,
+    toolName,
+    result: {
+      type: "bash_code_execution_result",
+      stdout: content.stdout,
+      stderr: content.stderr,
+      returnCode: content.return_code,
+      content: outputs,
+    },
+  };
+}
+
+function normalizeTextEditorCodeExecutionContent(
+  content: Record<string, unknown>,
+  toolCallId: string,
+): AnthropicServerToolResult | undefined {
+  const toolName = "text_editor_code_execution";
+  const error = createToolResultError(
+    content,
+    "text_editor_code_execution_tool_result_error",
+    TEXT_EDITOR_CODE_EXECUTION_ERROR_CODES,
+    toolCallId,
+    toolName,
+    true,
+  );
+  if (error) return error;
+
+  if (content.type === "text_editor_code_execution_view_result") {
+    if (
+      typeof content.content !== "string" ||
+      (content.file_type !== "text" &&
+        content.file_type !== "image" &&
+        content.file_type !== "pdf") ||
+      !("num_lines" in content) ||
+      !isNullableNonNegativeSafeInteger(content.num_lines) ||
+      !("start_line" in content) ||
+      !isNullableNonNegativeSafeInteger(content.start_line) ||
+      !("total_lines" in content) ||
+      !isNullableNonNegativeSafeInteger(content.total_lines)
+    ) {
+      return undefined;
+    }
+    return {
+      toolCallId,
+      toolName,
+      result: {
+        type: "text_editor_code_execution_view_result",
+        content: content.content,
+        fileType: content.file_type,
+        numLines: content.num_lines,
+        startLine: content.start_line,
+        totalLines: content.total_lines,
+      },
+    };
+  }
+
+  if (content.type === "text_editor_code_execution_create_result") {
+    if (typeof content.is_file_update !== "boolean") return undefined;
+    return {
+      toolCallId,
+      toolName,
+      result: {
+        type: "text_editor_code_execution_create_result",
+        isFileUpdate: content.is_file_update,
+      },
+    };
+  }
+
+  if (content.type === "text_editor_code_execution_str_replace_result") {
+    if (
+      !("lines" in content) ||
+      !(content.lines === null ||
+        Array.isArray(content.lines) &&
+          content.lines.every((line) => typeof line === "string")) ||
+      !("old_start" in content) ||
+      !isNullableNonNegativeSafeInteger(content.old_start) ||
+      !("old_lines" in content) ||
+      !isNullableNonNegativeSafeInteger(content.old_lines) ||
+      !("new_start" in content) ||
+      !isNullableNonNegativeSafeInteger(content.new_start) ||
+      !("new_lines" in content) ||
+      !isNullableNonNegativeSafeInteger(content.new_lines)
+    ) {
+      return undefined;
+    }
+    return {
+      toolCallId,
+      toolName,
+      result: {
+        type: "text_editor_code_execution_str_replace_result",
+        lines: content.lines,
+        oldStart: content.old_start,
+        oldLines: content.old_lines,
+        newStart: content.new_start,
+        newLines: content.new_lines,
+      },
+    };
+  }
+
+  return undefined;
+}
+
+function normalizeWebSearchContent(
+  content: unknown,
+  toolCallId: string,
+): AnthropicServerToolResult | undefined {
+  const toolName = "web_search";
+  const errorContent = readRecord(content);
+  if (errorContent) {
+    return createToolResultError(
+      errorContent,
+      "web_search_tool_result_error",
+      WEB_SEARCH_ERROR_CODES,
+      toolCallId,
+      toolName,
+    );
+  }
+  if (!Array.isArray(content)) return undefined;
+
+  const results: Array<Record<string, unknown>> = [];
+  for (const value of content) {
+    const record = readRecord(value);
+    if (
+      !record ||
+      record.type !== "web_search_result" ||
+      !isNonEmptyString(record.url) ||
+      typeof record.title !== "string" ||
+      typeof record.encrypted_content !== "string" ||
+      !("page_age" in record) ||
+      record.page_age !== null && typeof record.page_age !== "string"
+    ) {
+      return undefined;
+    }
+    results.push({
+      type: "web_search_result",
+      url: record.url,
+      title: record.title,
+      pageAge: record.page_age,
+      encryptedContent: record.encrypted_content,
+    });
+  }
+  return { toolCallId, toolName, result: results };
+}
+
+function normalizeWebFetchSource(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  const source = readRecord(value);
+  if (!source || typeof source.data !== "string") return undefined;
+  if (source.type === "text" && source.media_type === "text/plain") {
+    return {
+      type: "text",
+      mediaType: "text/plain",
+      data: source.data,
+    };
+  }
+  if (source.type === "base64" && source.media_type === "application/pdf") {
+    return {
+      type: "base64",
+      mediaType: "application/pdf",
+      data: source.data,
+    };
+  }
+  return undefined;
+}
+
+function normalizeWebFetchContent(
+  content: Record<string, unknown>,
+  toolCallId: string,
+): AnthropicServerToolResult | undefined {
+  const toolName = "web_fetch";
+  const error = createToolResultError(
+    content,
+    "web_fetch_tool_result_error",
+    WEB_FETCH_ERROR_CODES,
+    toolCallId,
+    toolName,
+  );
+  if (error) return error;
+
+  const document = readRecord(content.content);
+  const source = normalizeWebFetchSource(document?.source);
+  if (
+    content.type !== "web_fetch_result" ||
+    !isNonEmptyString(content.url) ||
+    !("retrieved_at" in content) ||
+    content.retrieved_at !== null && typeof content.retrieved_at !== "string" ||
+    !document ||
+    document.type !== "document" ||
+    !source ||
+    document.title !== undefined &&
+      document.title !== null &&
+      typeof document.title !== "string"
+  ) {
+    return undefined;
+  }
+  const citations = document.citations;
+  if (
+    citations !== undefined &&
+    citations !== null &&
+    (readRecord(citations)?.enabled !== true && readRecord(citations)?.enabled !== false)
+  ) {
+    return undefined;
+  }
+
+  return {
+    toolCallId,
+    toolName,
+    result: {
+      type: "web_fetch_result",
+      url: content.url,
+      content: {
+        type: "document",
+        source,
+        ...(document.title === undefined ? {} : { title: document.title }),
+        ...(citations === undefined ? {} : { citations }),
+      },
+      retrievedAt: content.retrieved_at,
+    },
+  };
+}
+
+function normalizeMcpContent(value: unknown): string | Array<Record<string, unknown>> | undefined {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return undefined;
+  const blocks: Array<Record<string, unknown>> = [];
+  for (const item of value) {
+    const block = readRecord(item);
+    const citations = block?.citations;
+    if (
+      !block ||
+      block.type !== "text" ||
+      typeof block.text !== "string" ||
+      citations !== undefined &&
+        citations !== null &&
+        (!Array.isArray(citations) ||
+          citations.some((citation) => {
+            const record = readRecord(citation);
+            return !record || !isNonEmptyString(record.type);
+          }))
+    ) {
+      return undefined;
+    }
+    blocks.push({
+      type: "text",
+      text: block.text,
+      ...(citations === undefined ? {} : { citations }),
+    });
+  }
+  return blocks;
+}
+
+function resultMatchesRegisteredTool(
+  toolNamesById: ReadonlyMap<string, string> | undefined,
+  toolCallId: string,
+  expectedToolName: string,
+): boolean {
+  const registeredName = toolNamesById?.get(toolCallId);
+  return registeredName === expectedToolName;
+}
+
+export function parseAnthropicServerToolResult(
+  value: unknown,
+  toolNamesById?: ReadonlyMap<string, string>,
+): AnthropicServerToolResult | undefined {
+  const block = readRecord(value);
+  if (
+    !block ||
+    !isAnthropicProviderToolResultBlockType(String(block.type)) ||
+    !isNonEmptyString(block.tool_use_id)
+  ) {
+    return undefined;
+  }
+  const toolCallId = block.tool_use_id;
+
+  if (block.type === "mcp_tool_result") {
+    const toolName = toolNamesById?.get(toolCallId);
+    const content = normalizeMcpContent(block.content);
+    if (
+      !isNonEmptyString(toolName) ||
+      typeof block.is_error !== "boolean" ||
+      content === undefined
+    ) {
+      return undefined;
+    }
+    return {
+      toolCallId,
+      toolName,
+      result: content,
+      ...(block.is_error ? { isError: true } : {}),
+    };
+  }
+
+  if (block.type === "web_search_tool_result") {
+    if (
+      !hasValidCaller(block.caller) ||
+      !resultMatchesRegisteredTool(toolNamesById, toolCallId, "web_search")
+    ) {
+      return undefined;
+    }
+    return normalizeWebSearchContent(block.content, toolCallId);
+  }
+
+  if (block.type === "web_fetch_tool_result") {
+    const content = readRecord(block.content);
+    if (
+      !content ||
+      !hasValidCaller(block.caller) ||
+      !resultMatchesRegisteredTool(toolNamesById, toolCallId, "web_fetch")
+    ) {
+      return undefined;
+    }
+    return normalizeWebFetchContent(content, toolCallId);
+  }
+
+  const content = readRecord(block.content);
+  if (!content) return undefined;
+  if (block.type === "code_execution_tool_result") {
+    if (!resultMatchesRegisteredTool(toolNamesById, toolCallId, "code_execution")) {
+      return undefined;
+    }
+    return normalizeCodeExecutionContent(content, toolCallId);
+  }
+  if (block.type === "bash_code_execution_tool_result") {
+    if (!resultMatchesRegisteredTool(toolNamesById, toolCallId, "bash_code_execution")) {
+      return undefined;
+    }
+    return normalizeBashCodeExecutionContent(content, toolCallId);
+  }
+  if (block.type === "text_editor_code_execution_tool_result") {
+    if (
+      !resultMatchesRegisteredTool(
+        toolNamesById,
+        toolCallId,
+        "text_editor_code_execution",
+      )
+    ) {
+      return undefined;
+    }
+    return normalizeTextEditorCodeExecutionContent(content, toolCallId);
+  }
+  return undefined;
+}

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "@std/testing/bdd";
 
 import { ProviderRequestError } from "veryfront/provider/shared";
 
+import { MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES } from "./anthropic-native-content.ts";
 import { createAnthropicModelRuntime } from "./anthropic-provider.ts";
 
 async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {
@@ -218,6 +219,47 @@ describe("anthropic-provider", () => {
     assertEquals(error.status, 200);
     assertEquals(error.retryable, false);
     assertEquals(error.message.includes(privatePayload), false);
+  });
+
+  it("maps raw assistant metadata budget failures to the typed response error", async () => {
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "k",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [
+                {
+                  type: "text",
+                  text: "x".repeat(MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES),
+                },
+                {
+                  type: "server_tool_use",
+                  id: "srvtool_oversized_metadata",
+                  name: "web_search",
+                  input: { query: "bounded" },
+                },
+              ],
+              stop_reason: "end_turn",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const error = await assertRejects(
+      () =>
+        runtime.doGenerate({
+          prompt: [{ role: "user", content: [{ type: "text", text: "Search" }] }],
+        }),
+      ProviderRequestError,
+      "raw assistant metadata could not be retained safely",
+    );
+
+    assertEquals(error.provider, "anthropic");
+    assertEquals(error.status, 200);
+    assertEquals(error.retryable, false);
   });
 
   it("does not attach raw-assistant metadata to an empty assistant stream", async () => {

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
@@ -1603,7 +1603,7 @@ describe("anthropic-provider", () => {
     );
   });
 
-  it("bounds pause_turn continuation attempts and returns the final pause normally", async () => {
+  it("fails closed when direct pause_turn continuation exceeds its cap", async () => {
     let requestCount = 0;
     const runtime = createAnthropicModelRuntime({
       apiKey: "test-anthropic-key",
@@ -1623,14 +1623,64 @@ describe("anthropic-provider", () => {
       },
     }, "claude-sonnet-4-6");
 
-    const result = await runtime.doGenerate({
+    const error = await assertRejects(
+      () =>
+        runtime.doGenerate({
+          prompt: [{ role: "user", content: [{ type: "text", text: "Wait" }] }],
+          maxOutputTokens: 64,
+        }),
+      ProviderRequestError,
+      "pause_turn continuation limit exceeded",
+    );
+
+    assertEquals(requestCount, 6);
+    assertEquals(error.provider, "anthropic");
+    assertEquals(error.status, 200);
+    assertEquals(error.retryable, false);
+  });
+
+  it("fails closed when streamed pause_turn continuation exceeds its cap", async () => {
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        return Promise.resolve(
+          new Response(
+            [
+              'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+              `event: content_block_start\ndata: ${
+                JSON.stringify({
+                  type: "content_block_start",
+                  index: 0,
+                  content_block: { type: "text", text: `Waiting ${requestCount}.` },
+                })
+              }\n\n`,
+              'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"pause_turn"},"usage":{"output_tokens":1}}\n\n',
+              'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+            ].join(""),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
       prompt: [{ role: "user", content: [{ type: "text", text: "Wait" }] }],
       maxOutputTokens: 64,
     });
+    const error = await assertRejects(
+      () => collectAsync(result.stream),
+      ProviderRequestError,
+      "pause_turn continuation limit exceeded",
+    );
 
     assertEquals(requestCount, 6);
-    assertEquals(result.finishReason, "pause_turn");
-    assertEquals(result.usage, { inputTokens: 6, outputTokens: 6, totalTokens: 12 });
+    assertEquals(error.provider, "anthropic");
+    assertEquals(error.status, 200);
+    assertEquals(error.retryable, false);
   });
 
   it("stops pause_turn continuation before a follow-up request when aborted", async () => {

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
@@ -1,5 +1,7 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
+
+import { ProviderRequestError } from "veryfront/provider/shared";
 
 import { createAnthropicModelRuntime } from "./anthropic-provider.ts";
 
@@ -9,6 +11,23 @@ async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {
     values.push(value);
   }
   return values;
+}
+
+async function waitWithin<T>(promise: Promise<T>, timeoutMs = 500): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`Timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
 }
 
 function readRequestBody(init: RequestInit | undefined): string | null {
@@ -23,6 +42,45 @@ function readRequestHeader(init: RequestInit | undefined, name: string): string 
     return null;
   }
   return new Headers(init.headers).get(name);
+}
+
+function createSettledLegacyMcpPrompt(toolCallId: string) {
+  return [{
+    role: "user",
+    content: [{ type: "text", text: "Echo" }],
+  }, {
+    role: "assistant",
+    content: [],
+    providerToolCalls: [{
+      toolCallId,
+      toolName: "echo",
+      input: { value: "hello" },
+    }],
+    providerMetadata: {
+      anthropic: {
+        rawAssistantMessages: [[{
+          type: "mcp_tool_use",
+          id: toolCallId,
+          name: "echo",
+          server_name: "example-mcp",
+          input: { value: "hello" },
+        }]],
+      },
+    },
+  }, {
+    role: "assistant",
+    content: [{ type: "text", text: "Completed." }],
+    providerMetadata: {
+      anthropic: {
+        rawAssistantMessages: [[{
+          type: "mcp_tool_result",
+          tool_use_id: toolCallId,
+          is_error: false,
+          content: "hello",
+        }]],
+      },
+    },
+  }] as const;
 }
 
 describe("anthropic-provider", () => {
@@ -129,6 +187,1583 @@ describe("anthropic-provider", () => {
     });
   });
 
+  it("fails closed on an empty successful response without leaking its payload", async () => {
+    const privatePayload = "<PRIVATE_PROVIDER_PAYLOAD>";
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "k",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [],
+              stop_reason: "end_turn",
+              diagnostic: privatePayload,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const error = await assertRejects(
+      async () =>
+        await runtime.doGenerate({
+          prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        }),
+      ProviderRequestError,
+      "invalid successful response",
+    );
+
+    assertEquals(error.provider, "anthropic");
+    assertEquals(error.status, 200);
+    assertEquals(error.retryable, false);
+    assertEquals(error.message.includes(privatePayload), false);
+  });
+
+  it("does not attach raw-assistant metadata to an empty assistant stream", async () => {
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "k",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            [
+              'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+              'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n',
+              'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+            ].join(""),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+    });
+
+    assertEquals(await collectAsync(result.stream), [{
+      type: "finish",
+      finishReason: { unified: "stop", raw: "end_turn" },
+      usage: { inputTokens: 1, totalTokens: 1 },
+    }]);
+  });
+
+  it("fails closed on an unknown block mixed into an otherwise valid direct response", async () => {
+    const privateBlockType = "future_block_<PRIVATE_PROVIDER_PAYLOAD>";
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "k",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [
+                { type: "text", text: "visible" },
+                { type: privateBlockType, private: "must not be ignored" },
+              ],
+              stop_reason: "end_turn",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const error = await assertRejects(
+      async () =>
+        await runtime.doGenerate({
+          prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        }),
+      ProviderRequestError,
+      "unsupported content block type",
+    );
+    assertEquals(error.message.includes(privateBlockType), false);
+  });
+
+  it("fails closed on an unknown block mixed into an otherwise valid stream", async () => {
+    const privateBlockType = "future_block_<PRIVATE_PROVIDER_PAYLOAD>";
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "k",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            [
+              'event: message_start\ndata: {"type":"message_start","message":{}}\n\n',
+              'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"visible"}}\n\n',
+              'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              `event: content_block_start\ndata: ${
+                JSON.stringify({
+                  type: "content_block_start",
+                  index: 1,
+                  content_block: { type: privateBlockType, private: "must not be ignored" },
+                })
+              }\n\n`,
+            ].join(""),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+    const result = await runtime.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+    });
+
+    const error = await assertRejects(
+      () => collectAsync(result.stream),
+      ProviderRequestError,
+      "unsupported content block type",
+    );
+    assertEquals(error.message.includes(privateBlockType), false);
+  });
+
+  it("rejects malformed tool inputs and thinking fields in successful responses", async () => {
+    const malformedBlocks = [
+      { type: "tool_use", id: "tool_1", name: "lookup", input: [] },
+      { type: "tool_use", id: "tool_1", name: "lookup", input: "private" },
+      { type: "thinking", thinking: "valid", signature: 42 },
+      { type: "thinking", thinking: 42, signature: "valid" },
+    ];
+
+    for (const block of malformedBlocks) {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [block],
+                stop_reason: "end_turn",
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-sonnet-4-6");
+
+      await assertRejects(
+        async () =>
+          await runtime.doGenerate({
+            prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+          }),
+        ProviderRequestError,
+        "malformed",
+      );
+    }
+  });
+
+  it("keeps Anthropic-schema bash, text-editor, computer, and memory calls client-executed", async () => {
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "k",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [
+                { type: "tool_use", id: "tool_bash", name: "bash", input: { command: "pwd" } },
+                {
+                  type: "tool_use",
+                  id: "tool_editor",
+                  name: "str_replace_editor",
+                  input: { command: "view", path: "/tmp/a" },
+                },
+                {
+                  type: "tool_use",
+                  id: "tool_computer",
+                  name: "computer",
+                  input: { action: "screenshot" },
+                },
+                {
+                  type: "tool_use",
+                  id: "tool_memory",
+                  name: "memory",
+                  input: { command: "view", path: "/memories" },
+                },
+              ],
+              stop_reason: "tool_use",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Use local tools" }] }],
+    });
+    assertEquals(
+      result.content?.map((part) =>
+        typeof part === "object" && part !== null && "providerExecuted" in part
+          ? part.providerExecuted
+          : undefined
+      ),
+      [undefined, undefined, undefined, undefined],
+    );
+  });
+
+  it("normalizes direct code-execution calls and results as provider-executed", async () => {
+    const rawContent = [{
+      type: "server_tool_use",
+      id: "srvtool_code_direct",
+      name: "code_execution",
+      input: { code: "print(2)" },
+    }, {
+      type: "code_execution_tool_result",
+      tool_use_id: "srvtool_code_direct",
+      content: {
+        type: "code_execution_result",
+        stdout: "2\n",
+        stderr: "",
+        return_code: 0,
+        content: [{ type: "code_execution_output", file_id: "file_result" }],
+      },
+    }];
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "k",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: rawContent,
+              stop_reason: "end_turn",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Run code" }] }],
+    });
+    assertEquals(result.content, [{
+      type: "tool-call",
+      toolCallId: "srvtool_code_direct",
+      toolName: "code_execution",
+      input: '{"code":"print(2)"}',
+      providerExecuted: true,
+    }, {
+      type: "tool-result",
+      toolCallId: "srvtool_code_direct",
+      toolName: "code_execution",
+      result: {
+        type: "code_execution_result",
+        stdout: "2\n",
+        stderr: "",
+        returnCode: 0,
+        content: [{ type: "code_execution_output", fileId: "file_result" }],
+      },
+      providerExecuted: true,
+    }]);
+    assertEquals(result.providerMetadata, {
+      anthropic: { rawAssistantMessages: [rawContent] },
+    });
+  });
+
+  it("omits malformed Anthropic usage counters", async () => {
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "k",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{ type: "text", text: "ok" }],
+              stop_reason: "end_turn",
+              usage: {
+                input_tokens: -1,
+                output_tokens: 1.5,
+                cache_creation_input_tokens: -2,
+                cache_read_input_tokens: 0.5,
+                veryfront: {
+                  provider_cost_usd: -1,
+                  cost_credits: -1,
+                },
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+    });
+
+    assertEquals(result.usage, undefined);
+  });
+
+  it("retains raw mixed server/client assistant blocks for direct local-tool continuation", async () => {
+    const rawContent = [{
+      type: "server_tool_use",
+      id: "server_search_mixed",
+      name: "web_search",
+      input: { query: "Veryfront" },
+    }, {
+      type: "tool_use",
+      id: "local_lookup_mixed",
+      name: "local_lookup",
+      input: { query: "runtime" },
+    }];
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: rawContent,
+              stop_reason: "tool_use",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Search and inspect" }] }],
+      tools: [{
+        type: "provider",
+        name: "web_search",
+        id: "anthropic.web_search_20250305",
+        args: {},
+      }, {
+        type: "function",
+        name: "local_lookup",
+        inputSchema: { type: "object" },
+      }],
+      maxOutputTokens: 64,
+    });
+
+    assertEquals(result.providerMetadata, {
+      anthropic: { rawAssistantMessages: [rawContent] },
+    });
+  });
+
+  it("retains raw mixed server/client assistant blocks for streamed local-tool continuation", async () => {
+    const rawContent = [{
+      type: "server_tool_use",
+      id: "server_search_mixed_stream",
+      name: "web_search",
+      input: { query: "Veryfront" },
+    }, {
+      type: "tool_use",
+      id: "local_lookup_mixed_stream",
+      name: "local_lookup",
+      input: { query: "runtime" },
+    }];
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            [
+              'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+              `event: content_block_start\ndata: ${
+                JSON.stringify({
+                  type: "content_block_start",
+                  index: 0,
+                  content_block: rawContent[0],
+                })
+              }\n\n`,
+              'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              `event: content_block_start\ndata: ${
+                JSON.stringify({
+                  type: "content_block_start",
+                  index: 1,
+                  content_block: rawContent[1],
+                })
+              }\n\n`,
+              'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+              'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}\n\n',
+              'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+            ].join(""),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Search and inspect" }] }],
+      tools: [{
+        type: "provider",
+        name: "web_search",
+        id: "anthropic.web_search_20250305",
+        args: {},
+      }, {
+        type: "function",
+        name: "local_lookup",
+        inputSchema: { type: "object" },
+      }],
+      maxOutputTokens: 64,
+    });
+    const parts = await collectAsync(result.stream);
+    const finish = parts.find((part) =>
+      part && typeof part === "object" && "type" in part && part.type === "finish"
+    );
+
+    assertEquals(
+      finish && typeof finish === "object" && "providerMetadata" in finish
+        ? finish.providerMetadata
+        : undefined,
+      {
+        anthropic: { rawAssistantMessages: [rawContent] },
+      },
+    );
+  });
+
+  it("continues direct pause_turn responses with the raw assistant content and unchanged tools", async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (_input, init) => {
+        requestBodies.push(JSON.parse(readRequestBody(init) ?? "{}"));
+        requestCount++;
+        const payload = requestCount === 1
+          ? {
+            content: [{
+              type: "server_tool_use",
+              id: "srvtool_pause_direct",
+              name: "web_search",
+              input: { query: "Veryfront" },
+            }],
+            stop_reason: "pause_turn",
+            usage: { input_tokens: 8, output_tokens: 2 },
+          }
+          : {
+            content: [{
+              type: "web_search_tool_result",
+              tool_use_id: "srvtool_pause_direct",
+              content: [{
+                type: "web_search_result",
+                url: "https://veryfront.com",
+                title: "Veryfront",
+                page_age: null,
+                encrypted_content: "opaque",
+              }],
+            }, { type: "text", text: "Search completed." }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 9, output_tokens: 4 },
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Search" }],
+      }],
+      tools: [{
+        type: "provider",
+        name: "web_search",
+        id: "anthropic.web_search_20250305",
+        args: { maxUses: 5 },
+      }],
+      maxOutputTokens: 64,
+    });
+
+    assertEquals(requestCount, 2);
+    assertEquals(requestBodies[1]?.tools, requestBodies[0]?.tools);
+    assertEquals(requestBodies[1]?.messages, [{
+      role: "user",
+      content: [{ type: "text", text: "Search" }],
+    }, {
+      role: "assistant",
+      content: [{
+        type: "server_tool_use",
+        id: "srvtool_pause_direct",
+        name: "web_search",
+        input: { query: "Veryfront" },
+      }],
+    }]);
+    assertEquals(result, {
+      content: [{
+        type: "tool-call",
+        toolCallId: "srvtool_pause_direct",
+        toolName: "web_search",
+        input: '{"query":"Veryfront"}',
+        providerExecuted: true,
+      }, {
+        type: "tool-result",
+        toolCallId: "srvtool_pause_direct",
+        toolName: "web_search",
+        result: [{
+          type: "web_search_result",
+          url: "https://veryfront.com",
+          title: "Veryfront",
+          pageAge: null,
+          encryptedContent: "opaque",
+        }],
+        providerExecuted: true,
+      }, { type: "text", text: "Search completed." }],
+      finishReason: { unified: "stop", raw: "end_turn" },
+      providerMetadata: {
+        anthropic: {
+          rawAssistantMessages: [[{
+            type: "server_tool_use",
+            id: "srvtool_pause_direct",
+            name: "web_search",
+            input: { query: "Veryfront" },
+          }], [{
+            type: "web_search_tool_result",
+            tool_use_id: "srvtool_pause_direct",
+            content: [{
+              type: "web_search_result",
+              url: "https://veryfront.com",
+              title: "Veryfront",
+              page_age: null,
+              encrypted_content: "opaque",
+            }],
+          }, { type: "text", text: "Search completed." }]],
+        },
+      },
+      usage: { inputTokens: 17, outputTokens: 6, totalTokens: 23 },
+    });
+  });
+
+  it("correlates a direct MCP result with its tool name across pause_turn continuation", async () => {
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        const payload = requestCount === 1
+          ? {
+            content: [{
+              type: "mcp_tool_use",
+              id: "mcptool_echo_direct",
+              name: "echo",
+              server_name: "example-mcp",
+              input: { value: "hello" },
+            }],
+            stop_reason: "pause_turn",
+          }
+          : {
+            content: [{
+              type: "mcp_tool_result",
+              tool_use_id: "mcptool_echo_direct",
+              is_error: false,
+              content: [{ type: "text", text: "hello", citations: null }],
+            }, { type: "text", text: "MCP completed." }],
+            stop_reason: "end_turn",
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Echo" }] }],
+      maxOutputTokens: 64,
+    });
+
+    assertEquals(requestCount, 2);
+    assertEquals(result.content, [{
+      type: "tool-call",
+      toolCallId: "mcptool_echo_direct",
+      toolName: "echo",
+      input: '{"value":"hello"}',
+      providerExecuted: true,
+    }, {
+      type: "tool-result",
+      toolCallId: "mcptool_echo_direct",
+      toolName: "echo",
+      result: [{ type: "text", text: "hello", citations: null }],
+      providerExecuted: true,
+    }, { type: "text", text: "MCP completed." }]);
+  });
+
+  it("correlates a direct provider result with a canonical call from a prior invocation", async () => {
+    const rawProviderCall = [{
+      type: "mcp_tool_use",
+      id: "mcptool_cross_invocation_direct",
+      name: "echo",
+      server_name: "example-mcp",
+      input: { value: "hello" },
+    }];
+    const rawProviderResult = [{
+      type: "mcp_tool_result",
+      tool_use_id: "mcptool_cross_invocation_direct",
+      is_error: false,
+      content: [{ type: "text", text: "hello", citations: null }],
+    }];
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: rawProviderResult,
+              stop_reason: "end_turn",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Echo" }],
+      }, {
+        role: "assistant",
+        content: [],
+        providerToolCalls: [{
+          toolCallId: "mcptool_cross_invocation_direct",
+          toolName: "echo",
+          input: { value: "hello" },
+          supportsDeferredResults: true,
+        }],
+        providerMetadata: {
+          anthropic: { rawAssistantMessages: [rawProviderCall] },
+        },
+      }],
+      maxOutputTokens: 64,
+    });
+
+    assertEquals(requestCount, 1);
+    assertEquals(result, {
+      content: [{
+        type: "tool-result",
+        toolCallId: "mcptool_cross_invocation_direct",
+        toolName: "echo",
+        result: [{ type: "text", text: "hello", citations: null }],
+        providerExecuted: true,
+      }],
+      finishReason: { unified: "stop", raw: "end_turn" },
+      providerMetadata: {
+        anthropic: { rawAssistantMessages: [rawProviderResult] },
+      },
+    });
+  });
+
+  it("does not seed response correlation from raw-only provider history", async () => {
+    const rawProviderCall = [{
+      type: "mcp_tool_use",
+      id: "mcptool_raw_only",
+      name: "echo",
+      server_name: "example-mcp",
+      input: { value: "hello" },
+    }];
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{
+                type: "mcp_tool_result",
+                tool_use_id: "mcptool_raw_only",
+                is_error: false,
+                content: "hello",
+              }],
+              stop_reason: "end_turn",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    await assertRejects(
+      () =>
+        runtime.doGenerate({
+          prompt: [{
+            role: "user",
+            content: [{ type: "text", text: "Echo" }],
+          }, {
+            role: "assistant",
+            content: [],
+            providerMetadata: {
+              anthropic: { rawAssistantMessages: [rawProviderCall] },
+            },
+          }],
+          maxOutputTokens: 64,
+        }),
+      ProviderRequestError,
+      "provider tool-result content block was malformed",
+    );
+    assertEquals(requestCount, 1);
+  });
+
+  it("does not seed direct correlation after a validated raw-only result settled the call", async () => {
+    const toolCallId = "mcptool_settled_direct";
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{
+                type: "mcp_tool_result",
+                tool_use_id: toolCallId,
+                is_error: false,
+                content: "duplicate",
+              }],
+              stop_reason: "end_turn",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    await assertRejects(
+      () =>
+        runtime.doGenerate({
+          prompt: createSettledLegacyMcpPrompt(toolCallId),
+          maxOutputTokens: 64,
+        }),
+      ProviderRequestError,
+      "provider tool-result content block was malformed",
+    );
+    assertEquals(requestCount, 1);
+  });
+
+  it("does not seed streamed correlation after a validated raw-only result settled the call", async () => {
+    const toolCallId = "mcptool_settled_stream";
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        return Promise.resolve(
+          new Response(
+            [
+              'event: message_start\ndata: {"type":"message_start","message":{}}\n\n',
+              `event: content_block_start\ndata: ${
+                JSON.stringify({
+                  type: "content_block_start",
+                  index: 0,
+                  content_block: {
+                    type: "mcp_tool_result",
+                    tool_use_id: toolCallId,
+                    is_error: false,
+                    content: "duplicate",
+                  },
+                })
+              }\n\n`,
+              'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n',
+              'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+            ].join(""),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: createSettledLegacyMcpPrompt(toolCallId),
+      maxOutputTokens: 64,
+    });
+    await assertRejects(
+      () => collectAsync(result.stream),
+      ProviderRequestError,
+      "provider tool-result content block was malformed",
+    );
+    assertEquals(requestCount, 1);
+  });
+
+  it("does not reuse a provider call across a later user boundary", async () => {
+    const rawProviderCall = [{
+      type: "mcp_tool_use",
+      id: "mcptool_stale_reused",
+      name: "echo",
+      server_name: "example-mcp",
+      input: { value: "old" },
+    }];
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{
+                type: "mcp_tool_result",
+                tool_use_id: "mcptool_stale_reused",
+                is_error: false,
+                content: "stale",
+              }],
+              stop_reason: "end_turn",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    await assertRejects(
+      () =>
+        runtime.doGenerate({
+          prompt: [{
+            role: "user",
+            content: [{ type: "text", text: "First turn" }],
+          }, {
+            role: "assistant",
+            content: [{
+              type: "tool-call",
+              toolCallId: "mcptool_stale_reused",
+              toolName: "echo",
+              input: { value: "old" },
+              providerExecuted: true,
+            }],
+            providerToolCalls: [{
+              toolCallId: "mcptool_stale_reused",
+              toolName: "echo",
+              input: { value: "old" },
+            }],
+            providerMetadata: {
+              anthropic: { rawAssistantMessages: [rawProviderCall] },
+            },
+          }, {
+            role: "user",
+            content: [{ type: "text", text: "Start a new turn" }],
+          }, {
+            role: "assistant",
+            content: [],
+            providerToolCalls: [{
+              toolCallId: "mcptool_stale_reused",
+              toolName: "echo",
+              input: { value: "new" },
+            }],
+          }],
+          maxOutputTokens: 64,
+        }),
+      ProviderRequestError,
+      "provider tool-result content block was malformed",
+    );
+    assertEquals(requestCount, 1);
+  });
+
+  it("bounds canonical provider-call correlation state before transport", async () => {
+    const createRawProviderCalls = (offset: number, length: number) =>
+      Array.from({ length }, (_, index) => ({
+        type: "mcp_tool_use",
+        id: `mcptool_${offset + index}`,
+        name: "echo",
+        server_name: "example-mcp",
+        input: { value: offset + index },
+      }));
+    const firstRawProviderCalls = createRawProviderCalls(0, 2_049);
+    const secondRawProviderCalls = createRawProviderCalls(2_049, 2_048);
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        throw new Error("fetch must not be called");
+      },
+    }, "claude-sonnet-4-6");
+
+    await assertRejects(
+      () =>
+        runtime.doGenerate({
+          prompt: [{
+            role: "user",
+            content: [{ type: "text", text: "Echo" }],
+          }, {
+            role: "assistant",
+            content: [],
+            providerToolCalls: firstRawProviderCalls.map((call) => ({
+              toolCallId: call.id,
+              toolName: call.name,
+              input: call.input,
+            })),
+            providerMetadata: {
+              anthropic: { rawAssistantMessages: [firstRawProviderCalls] },
+            },
+          }, {
+            role: "assistant",
+            content: [],
+            providerToolCalls: secondRawProviderCalls.map((call) => ({
+              toolCallId: call.id,
+              toolName: call.name,
+              input: call.input,
+            })),
+            providerMetadata: {
+              anthropic: { rawAssistantMessages: [secondRawProviderCalls] },
+            },
+          }],
+          maxOutputTokens: 64,
+        }),
+      TypeError,
+      "exceeded 4096 outstanding calls",
+    );
+    assertEquals(requestCount, 0);
+  });
+
+  it("continues streamed pause_turn responses and emits one cumulative finish", async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (_input, init) => {
+        requestBodies.push(JSON.parse(readRequestBody(init) ?? "{}"));
+        requestCount++;
+        const body = requestCount === 1
+          ? [
+            'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":8}}}\n\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtool_pause_stream","name":"web_search","input":{}}}\n\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"query\\":\\"Veryfront\\"}"}}\n\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"pause_turn"},"usage":{"output_tokens":2}}\n\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+          ].join("")
+          : [
+            'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":9}}}\n\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtool_pause_stream","content":[{"type":"web_search_result","url":"https://veryfront.com","title":"Veryfront","page_age":null,"encrypted_content":"opaque"}]}}\n\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":"Search completed."}}\n\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}\n\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+          ].join("");
+        return Promise.resolve(
+          new Response(body, {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Search" }],
+      }],
+      tools: [{
+        type: "provider",
+        name: "web_search",
+        id: "anthropic.web_search_20250305",
+        args: { maxUses: 5 },
+      }],
+      maxOutputTokens: 64,
+    });
+    const parts = await collectAsync(result.stream);
+    const finishes = parts.filter((part) =>
+      typeof part === "object" && part !== null && "type" in part && part.type === "finish"
+    );
+    const toolResult = parts.find((part) =>
+      typeof part === "object" && part !== null && "type" in part && part.type === "tool-result"
+    );
+
+    assertEquals(requestCount, 2);
+    assertEquals(requestBodies[1]?.tools, requestBodies[0]?.tools);
+    assertEquals(requestBodies[1]?.messages, [{
+      role: "user",
+      content: [{ type: "text", text: "Search" }],
+    }, {
+      role: "assistant",
+      content: [{
+        type: "server_tool_use",
+        id: "srvtool_pause_stream",
+        name: "web_search",
+        input: { query: "Veryfront" },
+      }],
+    }]);
+    assertEquals(toolResult, {
+      type: "tool-result",
+      toolCallId: "srvtool_pause_stream",
+      toolName: "web_search",
+      result: [{
+        type: "web_search_result",
+        url: "https://veryfront.com",
+        title: "Veryfront",
+        pageAge: null,
+        encryptedContent: "opaque",
+      }],
+      providerExecuted: true,
+    });
+    assertEquals(finishes, [{
+      type: "finish",
+      finishReason: { unified: "stop", raw: "end_turn" },
+      providerMetadata: {
+        anthropic: {
+          rawAssistantMessages: [[{
+            type: "server_tool_use",
+            id: "srvtool_pause_stream",
+            name: "web_search",
+            input: { query: "Veryfront" },
+          }], [{
+            type: "web_search_tool_result",
+            tool_use_id: "srvtool_pause_stream",
+            content: [{
+              type: "web_search_result",
+              url: "https://veryfront.com",
+              title: "Veryfront",
+              page_age: null,
+              encrypted_content: "opaque",
+            }],
+          }, { type: "text", text: "Search completed." }]],
+        },
+      },
+      usage: { inputTokens: 17, outputTokens: 6, totalTokens: 23 },
+    }]);
+  });
+
+  it("correlates a streamed MCP result with its tool name across pause_turn continuation", async () => {
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        const body = requestCount === 1
+          ? [
+            'event: message_start\ndata: {"type":"message_start","message":{}}\n\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"mcp_tool_use","id":"mcptool_echo_stream","name":"echo","server_name":"example-mcp","input":{}}}\n\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"value\\":\\"hello\\"}"}}\n\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"pause_turn"}}\n\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+          ].join("")
+          : [
+            'event: message_start\ndata: {"type":"message_start","message":{}}\n\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"mcp_tool_result","tool_use_id":"mcptool_echo_stream","is_error":false,"content":"hello"}}\n\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+            'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":"MCP completed."}}\n\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+          ].join("");
+        return Promise.resolve(
+          new Response(body, {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Echo" }] }],
+      maxOutputTokens: 64,
+    });
+    const parts = await collectAsync(result.stream);
+    const toolResult = parts.find((part) =>
+      typeof part === "object" && part !== null && "type" in part &&
+      part.type === "tool-result"
+    );
+
+    assertEquals(requestCount, 2);
+    assertEquals(toolResult, {
+      type: "tool-result",
+      toolCallId: "mcptool_echo_stream",
+      toolName: "echo",
+      result: "hello",
+      providerExecuted: true,
+    });
+  });
+
+  it("correlates a streamed provider result with a canonical call from a prior invocation", async () => {
+    const rawProviderCall = [{
+      type: "mcp_tool_use",
+      id: "mcptool_cross_invocation_stream",
+      name: "echo",
+      server_name: "example-mcp",
+      input: { value: "hello" },
+    }];
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        return Promise.resolve(
+          new Response(
+            [
+              'event: message_start\ndata: {"type":"message_start","message":{}}\n\n',
+              'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"mcp_tool_result","tool_use_id":"mcptool_cross_invocation_stream","is_error":false,"content":"hello"}}\n\n',
+              'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n',
+              'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+            ].join(""),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Echo" }],
+      }, {
+        role: "assistant",
+        content: [{
+          type: "tool-call",
+          toolCallId: "mcptool_cross_invocation_stream",
+          toolName: "echo",
+          input: { value: "hello" },
+          providerExecuted: true,
+          supportsDeferredResults: true,
+        }],
+        providerMetadata: {
+          anthropic: { rawAssistantMessages: [rawProviderCall] },
+        },
+      }],
+      maxOutputTokens: 64,
+    });
+    const parts = await collectAsync(result.stream);
+
+    assertEquals(requestCount, 1);
+    assertEquals(parts, [{
+      type: "tool-result",
+      toolCallId: "mcptool_cross_invocation_stream",
+      toolName: "echo",
+      result: "hello",
+      providerExecuted: true,
+    }, {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "end_turn" },
+      providerMetadata: {
+        anthropic: {
+          rawAssistantMessages: [[{
+            type: "mcp_tool_result",
+            tool_use_id: "mcptool_cross_invocation_stream",
+            is_error: false,
+            content: "hello",
+          }]],
+        },
+      },
+    }]);
+  });
+
+  it("aborts an in-flight pause_turn continuation without blocking on delayed cleanup", async () => {
+    let requestCount = 0;
+    let continuationSignal: AbortSignal | null | undefined;
+    let continuationCleanupSettled = false;
+    let resolveContinuationCleanup!: () => void;
+    const continuationCleanup = new Promise<void>((resolve) => {
+      resolveContinuationCleanup = resolve;
+    });
+    let notifyContinuationStarted: (() => void) | undefined;
+    const continuationStarted = new Promise<void>((resolve) => {
+      notifyContinuationStarted = resolve;
+    });
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (_input, init) => {
+        requestCount++;
+        if (requestCount === 1) {
+          return Promise.resolve(
+            new Response(
+              [
+                'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+                'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Still working."}}\n\n',
+                'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"pause_turn"}}\n\n',
+                'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+              ].join(""),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          );
+        }
+
+        continuationSignal = init && "signal" in init && init.signal instanceof AbortSignal
+          ? init.signal
+          : undefined;
+        notifyContinuationStarted?.();
+        return new Promise<Response>((_resolve, reject) => {
+          const rejectAfterCleanup = () => {
+            setTimeout(() => {
+              continuationCleanupSettled = true;
+              resolveContinuationCleanup();
+              reject(
+                continuationSignal?.reason ??
+                  new DOMException("Continuation canceled", "AbortError"),
+              );
+            }, 10);
+          };
+          if (continuationSignal?.aborted) {
+            rejectAfterCleanup();
+          } else {
+            continuationSignal?.addEventListener("abort", rejectAfterCleanup, { once: true });
+          }
+        });
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Continue" }] }],
+      maxOutputTokens: 64,
+    });
+    const reader = result.stream.getReader();
+    assertEquals(await reader.read(), {
+      done: false,
+      value: { type: "text-delta", delta: "Still working." },
+    });
+    const pendingRead = reader.read();
+    await waitWithin(continuationStarted);
+
+    await waitWithin(reader.cancel("consumer stopped"));
+    assertEquals(continuationSignal?.aborted, true);
+    assertEquals((await waitWithin(pendingRead)).done, true);
+    assertEquals(requestCount, 2);
+    await waitWithin(continuationCleanup);
+    assertEquals(continuationCleanupSettled, true);
+  });
+
+  it("closes the upstream response body when canceled immediately after the first part", async () => {
+    let upstreamCancelReason: unknown;
+    let upstreamCancelSettled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            [
+              'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+              'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"First."}}\n\n',
+            ].join(""),
+          ),
+        );
+      },
+      async cancel(reason) {
+        await Promise.resolve();
+        upstreamCancelReason = reason;
+        upstreamCancelSettled = true;
+      },
+    });
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(body, {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Continue" }] }],
+      maxOutputTokens: 64,
+    });
+    const reader = result.stream.getReader();
+
+    assertEquals(await waitWithin(reader.read()), {
+      done: false,
+      value: { type: "text-delta", delta: "First." },
+    });
+    await waitWithin(reader.cancel("consumer stopped after first part"));
+
+    assertEquals(upstreamCancelSettled, true);
+    assertEquals(
+      upstreamCancelReason,
+      "consumer stopped after first part",
+    );
+  });
+
+  it("accumulates every direct pause_turn assistant response across repeated pauses", async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (_input, init) => {
+        requestBodies.push(JSON.parse(readRequestBody(init) ?? "{}"));
+        requestCount++;
+        const payload = requestCount === 1
+          ? { content: [{ type: "text", text: "First pause." }], stop_reason: "pause_turn" }
+          : requestCount === 2
+          ? { content: [{ type: "text", text: "Second pause." }], stop_reason: "pause_turn" }
+          : { content: [{ type: "text", text: "Complete." }], stop_reason: "end_turn" };
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Continue" }] }],
+      maxOutputTokens: 64,
+    });
+
+    assertEquals(requestCount, 3);
+    assertEquals(requestBodies[2]?.messages, [{
+      role: "user",
+      content: [{ type: "text", text: "Continue" }],
+    }, {
+      role: "assistant",
+      content: [{ type: "text", text: "First pause." }],
+    }, {
+      role: "assistant",
+      content: [{ type: "text", text: "Second pause." }],
+    }]);
+    assertEquals(result.finishReason, { unified: "stop", raw: "end_turn" });
+  });
+
+  it("accumulates every streamed pause_turn assistant response across repeated pauses", async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (_input, init) => {
+        requestBodies.push(JSON.parse(readRequestBody(init) ?? "{}"));
+        requestCount++;
+        const text = requestCount === 1
+          ? "First pause."
+          : requestCount === 2
+          ? "Second pause."
+          : "Complete.";
+        const stopReason = requestCount < 3 ? "pause_turn" : "end_turn";
+        return Promise.resolve(
+          new Response(
+            [
+              'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+              `event: content_block_start\ndata: ${
+                JSON.stringify({
+                  type: "content_block_start",
+                  index: 0,
+                  content_block: { type: "text", text },
+                })
+              }\n\n`,
+              'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              `event: message_delta\ndata: ${
+                JSON.stringify({
+                  type: "message_delta",
+                  delta: { stop_reason: stopReason },
+                })
+              }\n\n`,
+              'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+            ].join(""),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Continue" }] }],
+      maxOutputTokens: 64,
+    });
+    const parts = await collectAsync(result.stream);
+
+    assertEquals(requestCount, 3);
+    assertEquals(requestBodies[2]?.messages, [{
+      role: "user",
+      content: [{ type: "text", text: "Continue" }],
+    }, {
+      role: "assistant",
+      content: [{ type: "text", text: "First pause." }],
+    }, {
+      role: "assistant",
+      content: [{ type: "text", text: "Second pause." }],
+    }]);
+    assertEquals(
+      parts.filter((part) =>
+        part && typeof part === "object" && "type" in part && part.type === "finish"
+      ).length,
+      1,
+    );
+  });
+
+  it("bounds pause_turn continuation attempts and returns the final pause normally", async () => {
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{ type: "text", text: `Waiting ${requestCount}.` }],
+              stop_reason: "pause_turn",
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Wait" }] }],
+      maxOutputTokens: 64,
+    });
+
+    assertEquals(requestCount, 6);
+    assertEquals(result.finishReason, "pause_turn");
+    assertEquals(result.usage, { inputTokens: 6, outputTokens: 6, totalTokens: 12 });
+  });
+
+  it("stops pause_turn continuation before a follow-up request when aborted", async () => {
+    const abortController = new AbortController();
+    let requestCount = 0;
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () => {
+        requestCount++;
+        abortController.abort(new DOMException("Stopped", "AbortError"));
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{
+                type: "server_tool_use",
+                id: "srvtool_pause_direct",
+                name: "web_search",
+                input: { query: "Veryfront" },
+              }],
+              stop_reason: "pause_turn",
+              usage: { input_tokens: 8, output_tokens: 2 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-6");
+
+    await assertRejects(
+      () =>
+        runtime.doGenerate({
+          prompt: [{
+            role: "user",
+            content: [{ type: "text", text: "Search" }],
+          }],
+          maxOutputTokens: 64,
+          abortSignal: abortController.signal,
+        }),
+      DOMException,
+      "Stopped",
+    );
+    assertEquals(requestCount, 1);
+  });
+
+  it("preserves official web_search error codes in direct tool results", async () => {
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{
+                type: "server_tool_use",
+                id: "srvtool_search_error",
+                name: "web_search",
+                input: { query: "Veryfront" },
+              }, {
+                type: "web_search_tool_result",
+                tool_use_id: "srvtool_search_error",
+                content: {
+                  type: "web_search_tool_result_error",
+                  error_code: "too_many_requests",
+                },
+              }],
+              stop_reason: "end_turn",
+              usage: { input_tokens: 4, output_tokens: 2 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Search" }] }],
+      maxOutputTokens: 64,
+    });
+    const errorPart = result.content?.find((part) =>
+      typeof part === "object" && part !== null && "type" in part && part.type === "tool-result"
+    ) as
+      | { isError?: boolean; result?: unknown }
+      | undefined;
+    const error = errorPart?.result as
+      | { name?: unknown; code?: unknown; toolCallId?: unknown; toolName?: unknown }
+      | undefined;
+
+    assertEquals(errorPart?.isError, true);
+    assertEquals(error?.name, "AnthropicServerToolResultError");
+    assertEquals(error?.code, "too_many_requests");
+    assertEquals(error?.toolCallId, "srvtool_search_error");
+    assertEquals(error?.toolName, "web_search");
+  });
+
+  it("preserves official web_fetch error codes in streamed tool errors", async () => {
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            [
+              'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+              'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtool_fetch_error","name":"web_fetch","input":{"url":"https://example.com"}}}\n\n',
+              'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"web_fetch_tool_result","tool_use_id":"srvtool_fetch_error","content":{"type":"web_fetch_tool_result_error","error_code":"url_not_allowed"}}}\n\n',
+              'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+              'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":4,"output_tokens":2}}\n\n',
+              'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+            ].join(""),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        ),
+    }, "claude-sonnet-4-6");
+
+    const result = await runtime.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "Fetch" }] }],
+      maxOutputTokens: 64,
+    });
+    const parts = await collectAsync(result.stream);
+    const errorPart = parts.find((part) =>
+      typeof part === "object" && part !== null && "type" in part && part.type === "tool-error"
+    ) as { error?: unknown } | undefined;
+    const error = errorPart?.error as
+      | { name?: unknown; code?: unknown; toolCallId?: unknown; toolName?: unknown }
+      | undefined;
+
+    assertEquals(error?.name, "AnthropicServerToolResultError");
+    assertEquals(error?.code, "url_not_allowed");
+    assertEquals(error?.toolCallId, "srvtool_fetch_error");
+    assertEquals(error?.toolName, "web_fetch");
+  });
+
   it("preserves Veryfront gateway billing metadata for generate usage", async () => {
     const runtime = createAnthropicModelRuntime({
       apiKey: "test-anthropic-key",
@@ -208,6 +1843,11 @@ describe("anthropic-provider", () => {
               start(controller) {
                 controller.enqueue(
                   encoder.encode(
+                    'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+                  ),
+                );
+                controller.enqueue(
+                  encoder.encode(
                     'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"bash"}}\n\n',
                   ),
                 );
@@ -260,8 +1900,9 @@ describe("anthropic-provider", () => {
       type: "finish",
       finishReason: { unified: "tool-calls", raw: "tool_use" },
       usage: {
+        inputTokens: 1,
         outputTokens: 4,
-        totalTokens: 4,
+        totalTokens: 5,
       },
     });
   });
@@ -326,7 +1967,7 @@ describe("anthropic-provider", () => {
         return Promise.resolve(
           new Response(
             JSON.stringify({
-              content: [],
+              content: [{ type: "text", text: "ok" }],
               stop_reason: "end_turn",
               usage: {
                 input_tokens: 8,
@@ -518,7 +2159,10 @@ describe("anthropic-provider", () => {
                 'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
               ),
               encoder.encode(
-                'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtool_web_1","content":[{"type":"web_search_result","url":"https://veryfront.com","title":"Veryfront","pageAge":null,"encryptedContent":"opaque"}]}}\n\n',
+                'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtool_web_1","content":[{"type":"web_search_result","url":"https://veryfront.com","title":"Veryfront","page_age":null,"encrypted_content":"opaque"}]}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
               ),
               encoder.encode(
                 'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\n\n',
@@ -612,6 +2256,26 @@ describe("anthropic-provider", () => {
       {
         type: "finish",
         finishReason: { unified: "stop", raw: "end_turn" },
+        providerMetadata: {
+          anthropic: {
+            rawAssistantMessages: [[{
+              type: "server_tool_use",
+              id: "srvtool_web_1",
+              name: "web_search",
+              input: { query: "Veryfront" },
+            }, {
+              type: "web_search_tool_result",
+              tool_use_id: "srvtool_web_1",
+              content: [{
+                type: "web_search_result",
+                url: "https://veryfront.com",
+                title: "Veryfront",
+                page_age: null,
+                encrypted_content: "opaque",
+              }],
+            }]],
+          },
+        },
         usage: {
           inputTokens: 8,
           outputTokens: 5,
@@ -649,12 +2313,12 @@ describe("anthropic-provider", () => {
                     type: "document",
                     source: {
                       type: "text",
-                      mediaType: "text/plain",
+                      media_type: "text/plain",
                       data: "Veryfront docs",
                     },
                     title: "Docs",
                   },
-                  retrievedAt: "2026-04-11T10:00:00Z",
+                  retrieved_at: null,
                 },
               }],
               stop_reason: "end_turn",
@@ -705,6 +2369,7 @@ describe("anthropic-provider", () => {
         toolCallId: "srvtool_fetch_1",
         toolName: "web_fetch",
         input: '{"url":"https://veryfront.com/docs"}',
+        providerExecuted: true,
       }, {
         type: "tool-result",
         toolCallId: "srvtool_fetch_1",
@@ -721,10 +2386,38 @@ describe("anthropic-provider", () => {
             },
             title: "Docs",
           },
-          retrievedAt: "2026-04-11T10:00:00Z",
+          retrievedAt: null,
         },
+        providerExecuted: true,
       }],
       finishReason: { unified: "stop", raw: "end_turn" },
+      providerMetadata: {
+        anthropic: {
+          rawAssistantMessages: [[{
+            type: "server_tool_use",
+            id: "srvtool_fetch_1",
+            name: "web_fetch",
+            input: { url: "https://veryfront.com/docs" },
+          }, {
+            type: "web_fetch_tool_result",
+            tool_use_id: "srvtool_fetch_1",
+            content: {
+              type: "web_fetch_result",
+              url: "https://veryfront.com/docs",
+              content: {
+                type: "document",
+                source: {
+                  type: "text",
+                  media_type: "text/plain",
+                  data: "Veryfront docs",
+                },
+                title: "Docs",
+              },
+              retrieved_at: null,
+            },
+          }]],
+        },
+      },
       usage: {
         inputTokens: 12,
         outputTokens: 7,
@@ -760,7 +2453,10 @@ describe("anthropic-provider", () => {
                 'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
               ),
               encoder.encode(
-                'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"web_fetch_tool_result","tool_use_id":"srvtool_fetch_2","content":{"type":"web_fetch_result","url":"https://veryfront.com/docs","content":{"type":"document","source":{"type":"text","mediaType":"text/plain","data":"Veryfront docs"}},"retrievedAt":"2026-04-11T10:05:00Z"}}}\n\n',
+                'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"web_fetch_tool_result","tool_use_id":"srvtool_fetch_2","content":{"type":"web_fetch_result","url":"https://veryfront.com/docs","content":{"type":"document","source":{"type":"text","media_type":"text/plain","data":"Veryfront docs"}},"retrieved_at":null}}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
               ),
               encoder.encode(
                 'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}\n\n',
@@ -841,13 +2537,39 @@ describe("anthropic-provider", () => {
           type: "document",
           source: { type: "text", mediaType: "text/plain", data: "Veryfront docs" },
         },
-        retrievedAt: "2026-04-11T10:05:00Z",
+        retrievedAt: null,
       },
       providerExecuted: true,
     });
     assertEquals(parts[4], {
       type: "finish",
       finishReason: { unified: "stop", raw: "end_turn" },
+      providerMetadata: {
+        anthropic: {
+          rawAssistantMessages: [[{
+            type: "server_tool_use",
+            id: "srvtool_fetch_2",
+            name: "web_fetch",
+            input: { url: "https://veryfront.com/docs" },
+          }, {
+            type: "web_fetch_tool_result",
+            tool_use_id: "srvtool_fetch_2",
+            content: {
+              type: "web_fetch_result",
+              url: "https://veryfront.com/docs",
+              content: {
+                type: "document",
+                source: {
+                  type: "text",
+                  media_type: "text/plain",
+                  data: "Veryfront docs",
+                },
+              },
+              retrieved_at: null,
+            },
+          }]],
+        },
+      },
       usage: { inputTokens: 10, outputTokens: 4, totalTokens: 14 },
     });
   });
@@ -865,7 +2587,13 @@ describe("anthropic-provider", () => {
                 'event: message_start\r\ndata: {"type":"message_start","message":{"usage":{"input_tokens":8}}}\r\n\r\n',
               ),
               encoder.encode(
+                'event: content_block_start\r\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\r\n\r\n',
+              ),
+              encoder.encode(
                 'event: content_block_delta\r\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\r\n\r\n',
+              ),
+              encoder.encode(
+                'event: content_block_stop\r\ndata: {"type":"content_block_stop","index":0}\r\n\r\n',
               ),
               encoder.encode(
                 'event: message_delta\r\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\r\n\r\n',
@@ -993,6 +2721,9 @@ describe("anthropic-provider", () => {
           new Response(
             ReadableStream.from([
               encoder.encode(
+                'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":8}}}\n\n',
+              ),
+              encoder.encode(
                 'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n',
               ),
               encoder.encode(
@@ -1012,6 +2743,9 @@ describe("anthropic-provider", () => {
               ),
               encoder.encode(
                 'event: content_block_start\ndata: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":"Done."}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_stop\ndata: {"type":"content_block_stop","index":2}\n\n',
               ),
               encoder.encode(
                 'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":8,"output_tokens":2}}\n\n',
@@ -1160,9 +2894,21 @@ describe("anthropic-provider", () => {
       return getBody();
     }
 
-    it("defaults Opus 4.6 to 128k when caller omits maxOutputTokens", async () => {
-      const body = await generateWith("claude-opus-4-6");
-      assertEquals((body as { max_tokens: number }).max_tokens, 128_000);
+    it("defaults Opus 4.8, 4.7, and 4.6 to 128k when caller omits maxOutputTokens", async () => {
+      for (
+        const modelId of [
+          "claude-opus-4-8",
+          "claude-opus-4-7",
+          "claude-opus-4-6",
+        ]
+      ) {
+        const body = await generateWith(modelId);
+        assertEquals(
+          (body as { max_tokens: number }).max_tokens,
+          128_000,
+          `expected 128k for ${modelId}`,
+        );
+      }
     });
 
     it("defaults Sonnet 4.6 to 64k when caller omits maxOutputTokens", async () => {
@@ -1182,8 +2928,19 @@ describe("anthropic-provider", () => {
     });
 
     it("clamps caller-provided maxOutputTokens at the model ceiling for known models", async () => {
-      const body = await generateWith("claude-sonnet-4-6", 999_999);
-      assertEquals((body as { max_tokens: number }).max_tokens, 64_000);
+      for (
+        const [modelId, expected] of [
+          ["claude-opus-4-8", 128_000],
+          ["claude-sonnet-4-6", 64_000],
+        ] as const
+      ) {
+        const body = await generateWith(modelId, 999_999);
+        assertEquals(
+          (body as { max_tokens: number }).max_tokens,
+          expected,
+          `expected ${expected} for ${modelId}`,
+        );
+      }
     });
 
     it("passes through maxOutputTokens unchanged for unknown models", async () => {
@@ -1478,10 +3235,12 @@ describe("anthropic-provider", () => {
 
     function captureRuntime() {
       let captured: Record<string, unknown> | null = null;
+      let capturedInit: RequestInit | undefined;
       const runtime = createAnthropicModelRuntime({
         apiKey: "k",
         baseURL: "https://example.anthropic.test/v1",
         fetch: (_input, init) => {
+          capturedInit = init;
           const raw = readRequestBody(init);
           captured = raw ? JSON.parse(raw) : null;
           return Promise.resolve(
@@ -1496,13 +3255,20 @@ describe("anthropic-provider", () => {
           );
         },
       }, "claude-opus-4-6");
-      return { runtime, getBody: () => captured };
+      return {
+        runtime,
+        getBody: () => captured,
+        getHeader: (name: string) => readRequestHeader(capturedInit, name),
+      };
     }
 
-    it("emits mcp_servers on the body when set, with deep snake_case conversion", async () => {
-      const { runtime, getBody } = captureRuntime();
+    it("emits the current MCP server/toolset contract and required beta", async () => {
+      const { runtime, getBody, getHeader } = captureRuntime();
       await runtime.doGenerate({
         prompt: [userPrompt],
+        headers: {
+          "anthropic-beta": "context-management-2025-06-27, mcp-client-2025-04-04",
+        },
         mcpServers: [{
           type: "url",
           url: "https://example.com/mcp",
@@ -1514,27 +3280,140 @@ describe("anthropic-provider", () => {
           },
         }],
       });
-      const body = getBody() as { mcp_servers: Array<Record<string, unknown>> } | null;
+      const body = getBody() as {
+        mcp_servers: Array<Record<string, unknown>>;
+        tools: Array<Record<string, unknown>>;
+      } | null;
       assertEquals(body?.mcp_servers, [{
         type: "url",
         url: "https://example.com/mcp",
         name: "example",
         authorization_token: "Bearer abc",
-        tool_configuration: {
-          enabled: true,
-          allowed_tools: ["search", "fetch"],
+      }]);
+      assertEquals(body?.tools, [{
+        type: "mcp_toolset",
+        mcp_server_name: "example",
+        default_config: { enabled: false },
+        configs: {
+          search: { enabled: true },
+          fetch: { enabled: true },
         },
       }]);
+      assertEquals(
+        getHeader("anthropic-beta"),
+        "context-management-2025-06-27,mcp-client-2025-11-20",
+      );
     });
 
     it("omits mcp_servers when the option is empty or unset", async () => {
-      const { runtime, getBody } = captureRuntime();
+      const { runtime, getBody, getHeader } = captureRuntime();
       await runtime.doGenerate({ prompt: [userPrompt], mcpServers: [] });
       assertEquals("mcp_servers" in (getBody() ?? {}), false);
+      assertEquals(getHeader("anthropic-beta"), null);
 
       const second = captureRuntime();
       await second.runtime.doGenerate({ prompt: [userPrompt] });
       assertEquals("mcp_servers" in (second.getBody() ?? {}), false);
+      assertEquals(second.getHeader("anthropic-beta"), null);
+    });
+
+    it("adds the MCP beta to streaming requests without dropping other betas", async () => {
+      let capturedInit: RequestInit | undefined;
+      const encoder = new TextEncoder();
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          capturedInit = init;
+          return Promise.resolve(
+            new Response(
+              ReadableStream.from([
+                encoder.encode(
+                  'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                ),
+              ]),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          );
+        },
+      }, "claude-opus-4-6");
+
+      const result = await runtime.doStream({
+        prompt: [userPrompt],
+        headers: {
+          "anthropic-beta": "context-management-2025-06-27",
+        },
+        mcpServers: [{
+          type: "url",
+          url: "https://example.com/mcp",
+          name: "example",
+        }],
+      });
+      await collectAsync(result.stream);
+
+      assertEquals(
+        readRequestHeader(capturedInit, "anthropic-beta"),
+        "context-management-2025-06-27,mcp-client-2025-11-20,fine-grained-tool-streaming-2025-05-14",
+      );
+    });
+
+    it("keeps the required MCP beta on pause_turn continuation requests", async () => {
+      const betaHeaders: Array<string | null> = [];
+      let requestCount = 0;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          requestCount++;
+          betaHeaders.push(readRequestHeader(init, "anthropic-beta"));
+          return Promise.resolve(
+            new Response(
+              JSON.stringify(
+                requestCount === 1
+                  ? {
+                    content: [{ type: "text", text: "Working." }],
+                    stop_reason: "pause_turn",
+                  }
+                  : {
+                    content: [{ type: "text", text: "Done." }],
+                    stop_reason: "end_turn",
+                  },
+              ),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-opus-4-6");
+
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        mcpServers: [{
+          type: "url",
+          url: "https://example.com/mcp",
+          name: "example",
+        }],
+      });
+
+      assertEquals(requestCount, 2);
+      assertEquals(betaHeaders, [
+        "mcp-client-2025-11-20",
+        "mcp-client-2025-11-20",
+      ]);
     });
 
     it("emits container field verbatim when anthropicContainer is set", async () => {
@@ -1768,6 +3647,7 @@ describe("anthropic-provider", () => {
         totalTokens: 110,
         cacheCreationInputTokens: 50,
         cacheReadInputTokens: 30,
+        cachedInputTokens: 30,
       });
     });
 
@@ -1994,6 +3874,9 @@ describe("anthropic-provider", () => {
             new Response(
               ReadableStream.from([
                 encoder.encode(
+                  'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":5}}}\n\n',
+                ),
+                encoder.encode(
                   'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"encrypted"}}\n\n',
                 ),
                 encoder.encode(
@@ -2003,7 +3886,13 @@ describe("anthropic-provider", () => {
                   'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":"Answer."}}\n\n',
                 ),
                 encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+                ),
+                encoder.encode(
                   'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":5,"output_tokens":2}}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
                 ),
               ]),
               { status: 200, headers: { "content-type": "text/event-stream" } },
@@ -2046,8 +3935,7 @@ describe("anthropic-provider", () => {
                     cited_text: "Veryfront is a full-stack framework",
                     url: "https://veryfront.com",
                     title: "Veryfront",
-                    start_char_index: 25,
-                    end_char_index: 60,
+                    encrypted_index: "encrypted-citation-index",
                   }],
                 }],
                 stop_reason: "end_turn",
@@ -2069,10 +3957,62 @@ describe("anthropic-provider", () => {
           citedText: "Veryfront is a full-stack framework",
           url: "https://veryfront.com",
           title: "Veryfront",
-          startCharIndex: 25,
-          endCharIndex: 60,
+          encryptedIndex: "encrypted-citation-index",
         }],
       }]);
+    });
+
+    it("fails closed on malformed or unknown citation records", async () => {
+      for (
+        const citation of [
+          {
+            type: "web_search_result_location",
+            cited_text: "Private source",
+            url: "https://example.test",
+          },
+          {
+            type: "char_location",
+            cited_text: "Private source",
+            document_index: 0,
+            start_char_index: 0,
+            end_char_index: Number.NaN,
+          },
+          {
+            type: "future_location",
+            cited_text: "Private source",
+          },
+        ]
+      ) {
+        const runtime = createAnthropicModelRuntime({
+          apiKey: "k",
+          baseURL: "https://example.anthropic.test/v1",
+          fetch: () =>
+            Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  content: [{
+                    type: "text",
+                    text: "Answer",
+                    citations: [citation],
+                  }],
+                  stop_reason: "end_turn",
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                }),
+                { status: 200, headers: { "content-type": "application/json" } },
+              ),
+            ),
+        }, "claude-sonnet-4-20250514");
+
+        const error = await assertRejects(
+          () =>
+            runtime.doGenerate({
+              prompt: [{ role: "user", content: [{ type: "text", text: "Question" }] }],
+            }),
+          ProviderRequestError,
+          "text citation was malformed",
+        );
+        assertEquals(error.message.includes("Private source"), false);
+      }
     });
   });
 

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.ts
@@ -526,12 +526,16 @@ export function createAnthropicModelRuntime(
 
         const raw = readRawAnthropicResponse(payload);
         if (raw.rawContent.length > 0) rawAssistantMessages.push(raw.rawContent);
-        if (
-          raw.rawStopReason !== "pause_turn" ||
-          raw.rawContent.length === 0 ||
-          continuationCount >= MAX_PAUSE_TURN_CONTINUATIONS
-        ) {
+        const shouldContinue = raw.rawStopReason === "pause_turn" &&
+          raw.rawContent.length > 0;
+        if (!shouldContinue) {
           break;
+        }
+        if (continuationCount >= MAX_PAUSE_TURN_CONTINUATIONS) {
+          throw invalidAnthropicResponse(
+            providerName,
+            "pause_turn continuation limit exceeded",
+          );
         }
 
         continuationCount++;
@@ -626,11 +630,11 @@ export function createAnthropicModelRuntime(
           if (completion && completion.rawContent.length > 0) {
             rawAssistantMessages.push(completion.rawContent);
           }
-          if (
-            completion?.rawStopReason !== "pause_turn" ||
-            completion.rawContent.length === 0 ||
-            continuationCount >= MAX_PAUSE_TURN_CONTINUATIONS
-          ) {
+          const continuationContent = completion?.rawStopReason === "pause_turn" &&
+              completion.rawContent.length > 0
+            ? completion.rawContent
+            : undefined;
+          if (!continuationContent) {
             const providerMetadata = createAnthropicRawAssistantMetadata(
               options.prompt,
               rawAssistantMessages,
@@ -643,9 +647,15 @@ export function createAnthropicModelRuntime(
             };
             return;
           }
+          if (continuationCount >= MAX_PAUSE_TURN_CONTINUATIONS) {
+            throw invalidAnthropicResponse(
+              providerName,
+              "pause_turn continuation limit exceeded",
+            );
+          }
 
           continuationCount++;
-          requestBody = createPauseTurnContinuationBody(requestBody, completion.rawContent);
+          requestBody = createPauseTurnContinuationBody(requestBody, continuationContent);
           throwIfAnthropicRequestAborted(providerAbortScope.controller.signal);
           responseStream = await requestStream({
             url,

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.ts
@@ -363,6 +363,7 @@ function shouldPreserveAnthropicRawAssistantHistory(
 }
 
 function createAnthropicRawAssistantMetadata(
+  providerLabel: string,
   prompt: OpenAICompatibleLanguageOptions["prompt"],
   rawAssistantMessages: unknown[][],
   initialProviderToolNamesById: ReadonlyMap<string, string>,
@@ -370,14 +371,21 @@ function createAnthropicRawAssistantMetadata(
   if (rawAssistantMessages.length === 0) {
     return undefined;
   }
-  const snapshot = validateAnthropicRawAssistantMessages(
-    rawAssistantMessages,
-    new Map(initialProviderToolNamesById),
-  );
-  if (!shouldPreserveAnthropicRawAssistantHistory(prompt, snapshot)) {
-    return undefined;
+  try {
+    const snapshot = validateAnthropicRawAssistantMessages(
+      rawAssistantMessages,
+      new Map(initialProviderToolNamesById),
+    );
+    if (!shouldPreserveAnthropicRawAssistantHistory(prompt, snapshot)) {
+      return undefined;
+    }
+    return { anthropic: { rawAssistantMessages: snapshot } };
+  } catch {
+    throw invalidAnthropicResponse(
+      providerLabel,
+      "raw assistant metadata could not be retained safely",
+    );
   }
-  return { anthropic: { rawAssistantMessages: snapshot } };
 }
 
 function createProviderAbortScope(callerSignal: AbortSignal | undefined): {
@@ -544,6 +552,7 @@ export function createAnthropicModelRuntime(
 
       const drained = warnings.drain();
       const providerMetadata = createAnthropicRawAssistantMetadata(
+        providerName,
         options.prompt,
         rawAssistantMessages,
         initialProviderToolNamesById,
@@ -636,6 +645,7 @@ export function createAnthropicModelRuntime(
             : undefined;
           if (!continuationContent) {
             const providerMetadata = createAnthropicRawAssistantMetadata(
+              providerName,
               options.prompt,
               rawAssistantMessages,
               initialProviderToolNamesById,

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.ts
@@ -31,14 +31,27 @@ import {
   TOOL_INPUT_PENDING_THRESHOLD_MS,
 } from "veryfront/provider/shared";
 import {
-  buildAnthropicMessagesRequest,
+  buildAnthropicMessagesRequestWithCorrelationState,
   type OpenAICompatibleLanguageOptions,
 } from "./anthropic-request-builder.ts";
 import {
+  type AnthropicProviderToolNameRegistry,
+  isAnthropicProviderExecutedContentBlockType,
+  isAnthropicProviderToolResultBlockType,
+  parseAnthropicProviderToolUse,
+  parseAnthropicServerToolResult,
+  validateAnthropicRawAssistantMessages,
+} from "./anthropic-native-content.ts";
+import {
+  addAnthropicUsage,
+  type AnthropicStreamCompletion,
   extractAnthropicUsage,
   normalizeAnthropicFinishReason,
   streamAnthropicCompatibleParts,
 } from "./anthropic-stream.ts";
+import { type AnthropicCitation, normalizeAnthropicCitation } from "./anthropic-citations.ts";
+
+const MAX_PAUSE_TURN_CONTINUATIONS = 5;
 
 export {
   buildProviderError,
@@ -72,84 +85,96 @@ type AnthropicReasoningContent = {
   redactedData?: string;
 };
 
-type AnthropicCitation = {
-  type: string;
-  citedText?: string;
-  url?: string;
-  title?: string;
-  startCharIndex?: number;
-  endCharIndex?: number;
-  startBlockIndex?: number;
-  endBlockIndex?: number;
-  startPageNumber?: number;
-  endPageNumber?: number;
-  documentIndex?: number;
-  documentTitle?: string;
-};
-
 type AnthropicTextContent = {
   type: "text";
   text: string;
   citations?: AnthropicCitation[];
 };
 
-/**
- * Best-effort camelCase normalization of a single Anthropic citation
- * record. Handles the union of fields across web_search_result_location,
- * web_fetch_result_location, char_location, page_location, and
- * content_block_location citation kinds - see
- * https://docs.claude.com/en/docs/build-with-claude/citations
- */
-function normalizeAnthropicCitation(raw: unknown): AnthropicCitation | undefined {
-  const r = readRecord(raw);
-  if (!r) return undefined;
-  const typeStr = typeof r.type === "string" ? r.type : undefined;
-  if (!typeStr) return undefined;
-  const out: AnthropicCitation = { type: typeStr };
-  if (typeof r.cited_text === "string") out.citedText = r.cited_text;
-  if (typeof r.url === "string") out.url = r.url;
-  if (typeof r.title === "string") out.title = r.title;
-  if (typeof r.start_char_index === "number") out.startCharIndex = r.start_char_index;
-  if (typeof r.end_char_index === "number") out.endCharIndex = r.end_char_index;
-  if (typeof r.start_block_index === "number") out.startBlockIndex = r.start_block_index;
-  if (typeof r.end_block_index === "number") out.endBlockIndex = r.end_block_index;
-  if (typeof r.start_page_number === "number") out.startPageNumber = r.start_page_number;
-  if (typeof r.end_page_number === "number") out.endPageNumber = r.end_page_number;
-  if (typeof r.document_index === "number") out.documentIndex = r.document_index;
-  if (typeof r.document_title === "string") out.documentTitle = r.document_title;
-  return out;
+type AnthropicToolCallContent = {
+  type: "tool-call";
+  toolCallId: string;
+  toolName: string;
+  input: string;
+  providerExecuted?: boolean;
+};
+
+type AnthropicToolResultContent = {
+  type: "tool-result";
+  toolCallId: string;
+  toolName: string;
+  result: unknown;
+  isError?: boolean;
+  providerExecuted: true;
+};
+
+type AnthropicGenerateContent =
+  | AnthropicTextContent
+  | AnthropicReasoningContent
+  | AnthropicToolCallContent
+  | AnthropicToolResultContent;
+
+function invalidAnthropicResponse(
+  providerLabel: string,
+  issue: string,
+): ProviderRequestError {
+  return new ProviderRequestError({
+    provider: "anthropic",
+    status: 200,
+    message: `${providerLabel} request failed: invalid successful response (${issue})`,
+    retryable: false,
+  });
 }
 
-function buildAnthropicGenerateResult(payload: unknown): {
-  content: Array<
-    | AnthropicTextContent
-    | AnthropicReasoningContent
-    | { type: "tool-call"; toolCallId: string; toolName: string; input: string }
-    | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown }
-  >;
+function sanitizeAnthropicUsage(usage: RuntimeUsage | undefined): RuntimeUsage | undefined {
+  const normalized = mergeUsage(undefined, usage);
+  return normalized && Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function buildAnthropicGenerateResult(
+  payload: unknown,
+  providerLabel: string,
+  providerToolNamesById: AnthropicProviderToolNameRegistry,
+): {
+  content: AnthropicGenerateContent[];
   finishReason?: string | { unified: string; raw: string } | null;
   usage?: RuntimeUsage;
 } {
   const record = readRecord(payload);
-  const content = Array.isArray(record?.content) ? record.content : [];
-  const normalized: Array<
-    | AnthropicTextContent
-    | AnthropicReasoningContent
-    | { type: "tool-call"; toolCallId: string; toolName: string; input: string }
-    | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown }
-  > = [];
+  if (!record) {
+    throw invalidAnthropicResponse(providerLabel, "response body was not an object");
+  }
+  if (!Array.isArray(record.content) || record.content.length === 0) {
+    throw invalidAnthropicResponse(providerLabel, "content array missing or empty");
+  }
+  if (typeof record.stop_reason !== "string" || record.stop_reason.length === 0) {
+    throw invalidAnthropicResponse(providerLabel, "stop reason missing");
+  }
+  const content = record.content;
+  const normalized: AnthropicGenerateContent[] = [];
 
   for (const blockValue of content) {
     const block = readRecord(blockValue);
+    if (!block) {
+      throw invalidAnthropicResponse(providerLabel, "content block was not an object");
+    }
     const blockType = typeof block?.type === "string" ? block.type : undefined;
 
-    if (blockType === "text" && typeof block?.text === "string" && block.text.length > 0) {
-      const citationsRaw = Array.isArray(block.citations) ? block.citations : undefined;
-      const citations = citationsRaw
-        ?.flatMap((c) => {
-          const normalizedCitation = normalizeAnthropicCitation(c);
-          return normalizedCitation ? [normalizedCitation] : [];
-        });
+    if (blockType === "text") {
+      if (typeof block.text !== "string") {
+        throw invalidAnthropicResponse(providerLabel, "text content block was malformed");
+      }
+      if (block.text.length === 0) continue;
+      if (block.citations !== undefined && !Array.isArray(block.citations)) {
+        throw invalidAnthropicResponse(providerLabel, "text citations were malformed");
+      }
+      const citations = block.citations?.map((citation) => {
+        const normalizedCitation = normalizeAnthropicCitation(citation);
+        if (!normalizedCitation) {
+          throw invalidAnthropicResponse(providerLabel, "text citation was malformed");
+        }
+        return normalizedCitation;
+      });
       normalized.push({
         type: "text",
         text: block.text,
@@ -163,6 +188,13 @@ function buildAnthropicGenerateResult(payload: unknown): {
     // callers persist them as `reasoning` content parts and replay on
     // the next turn so Claude can continue from the same thinking.
     if (blockType === "thinking") {
+      if (
+        (block.thinking !== undefined && typeof block.thinking !== "string") ||
+        (block.signature !== undefined && typeof block.signature !== "string") ||
+        (typeof block.thinking !== "string" && typeof block.signature !== "string")
+      ) {
+        throw invalidAnthropicResponse(providerLabel, "thinking content block was malformed");
+      }
       normalized.push({
         type: "reasoning",
         ...(typeof block?.thinking === "string" ? { text: block.thinking } : {}),
@@ -175,70 +207,267 @@ function buildAnthropicGenerateResult(payload: unknown): {
     // hides the trace. Pass the encrypted blob through opaquely so the
     // caller can replay it on the next turn (Anthropic still needs the
     // blob to verify continuity even though it can't read it).
-    if (blockType === "redacted_thinking" && typeof block?.data === "string") {
-      normalized.push({
-        type: "reasoning",
-        redactedData: block.data,
-      });
+    if (blockType === "redacted_thinking") {
+      if (typeof block.data !== "string" || block.data.length === 0) {
+        throw invalidAnthropicResponse(
+          providerLabel,
+          "redacted thinking content block was malformed",
+        );
+      }
+      normalized.push({ type: "reasoning", redactedData: block.data });
       continue;
     }
 
-    if (
-      (blockType === "tool_use" || blockType === "server_tool_use") &&
-      typeof block?.id === "string" &&
-      typeof block?.name === "string"
-    ) {
+    if (blockType === "tool_use") {
+      const input = block.input === undefined ? {} : readRecord(block.input);
+      if (
+        typeof block.id !== "string" ||
+        block.id.length === 0 ||
+        typeof block.name !== "string" ||
+        block.name.length === 0 ||
+        !input
+      ) {
+        throw invalidAnthropicResponse(providerLabel, "tool-use content block was malformed");
+      }
       normalized.push({
         type: "tool-call",
         toolCallId: block.id,
         toolName: block.name,
-        input: stringifyJsonValue(block.input ?? {}),
+        input: stringifyJsonValue(input),
       });
       continue;
     }
 
-    if (
-      blockType === "web_search_tool_result" &&
-      typeof block?.tool_use_id === "string" &&
-      Array.isArray(block?.content)
-    ) {
+    if (blockType === "server_tool_use" || blockType === "mcp_tool_use") {
+      const providerToolUse = parseAnthropicProviderToolUse(block);
+      if (
+        !providerToolUse ||
+        providerToolNamesById.has(providerToolUse.toolCallId)
+      ) {
+        throw invalidAnthropicResponse(
+          providerLabel,
+          "provider tool-use content block was malformed",
+        );
+      }
+      providerToolNamesById.set(
+        providerToolUse.toolCallId,
+        providerToolUse.toolName,
+      );
       normalized.push({
-        type: "tool-result",
-        toolCallId: block.tool_use_id,
-        toolName: "web_search",
-        result: block.content,
+        type: "tool-call",
+        toolCallId: providerToolUse.toolCallId,
+        toolName: providerToolUse.toolName,
+        input: stringifyJsonValue(providerToolUse.input),
+        providerExecuted: true,
       });
+      continue;
     }
 
-    if (
-      blockType === "web_fetch_tool_result" &&
-      typeof block?.tool_use_id === "string" &&
-      readRecord(block?.content)
-    ) {
+    if (blockType && isAnthropicProviderToolResultBlockType(blockType)) {
+      const parsedResult = parseAnthropicServerToolResult(block, providerToolNamesById);
+      if (!parsedResult) {
+        throw invalidAnthropicResponse(
+          providerLabel,
+          "provider tool-result content block was malformed",
+        );
+      }
+      providerToolNamesById.delete(parsedResult.toolCallId);
       normalized.push({
         type: "tool-result",
-        toolCallId: block.tool_use_id,
-        toolName: "web_fetch",
-        result: block.content,
+        toolCallId: parsedResult.toolCallId,
+        toolName: parsedResult.toolName,
+        result: parsedResult.result,
+        ...(parsedResult.isError === true ? { isError: true } : {}),
+        providerExecuted: true,
       });
+      continue;
     }
+
+    throw invalidAnthropicResponse(
+      providerLabel,
+      "unsupported content block type",
+    );
+  }
+  if (normalized.length === 0) {
+    throw invalidAnthropicResponse(providerLabel, "content contained no supported blocks");
   }
 
   return {
     content: normalized,
     finishReason: normalizeAnthropicFinishReason(record?.stop_reason),
-    usage: extractAnthropicUsage(payload),
+    usage: sanitizeAnthropicUsage(extractAnthropicUsage(payload)),
   };
+}
+
+type AnthropicRequestBody = Record<string, unknown> & {
+  messages?: unknown[];
+};
+
+function usesAnthropicMcpConnector(body: AnthropicRequestBody): boolean {
+  return Array.isArray(body.mcp_servers) && body.mcp_servers.length > 0;
+}
+
+function createPauseTurnContinuationBody(
+  baseBody: AnthropicRequestBody,
+  rawAssistantContent: unknown[],
+): AnthropicRequestBody {
+  return {
+    ...baseBody,
+    messages: [
+      ...(Array.isArray(baseBody.messages) ? baseBody.messages : []),
+      { role: "assistant", content: rawAssistantContent },
+    ],
+  };
+}
+
+function readRawAnthropicResponse(payload: unknown): {
+  rawContent: unknown[];
+  rawStopReason?: string;
+} {
+  const record = readRecord(payload);
+  return {
+    rawContent: Array.isArray(record?.content) ? record.content : [],
+    ...(typeof record?.stop_reason === "string" ? { rawStopReason: record.stop_reason } : {}),
+  };
+}
+
+function throwIfAnthropicRequestAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  if (signal.reason !== undefined) throw signal.reason;
+  throw new DOMException("The Anthropic request was aborted", "AbortError");
+}
+
+function shouldPreserveAnthropicRawAssistantHistory(
+  prompt: OpenAICompatibleLanguageOptions["prompt"],
+  rawAssistantMessages: unknown[][],
+): boolean {
+  const hasPriorProviderCall = prompt.some((message) =>
+    message.role === "assistant" &&
+    (
+      (message.providerToolCalls?.length ?? 0) > 0 ||
+      message.content.some((part) => part.type === "tool-call" && part.providerExecuted === true)
+    )
+  );
+  let hasServerToolContent = false;
+  for (const content of rawAssistantMessages) {
+    for (const value of content) {
+      const block = readRecord(value);
+      if (
+        isAnthropicProviderExecutedContentBlockType(block?.type)
+      ) {
+        hasServerToolContent = true;
+      }
+    }
+  }
+  return hasPriorProviderCall || hasServerToolContent;
+}
+
+function createAnthropicRawAssistantMetadata(
+  prompt: OpenAICompatibleLanguageOptions["prompt"],
+  rawAssistantMessages: unknown[][],
+  initialProviderToolNamesById: ReadonlyMap<string, string>,
+): Record<string, unknown> | undefined {
+  if (rawAssistantMessages.length === 0) {
+    return undefined;
+  }
+  const snapshot = validateAnthropicRawAssistantMessages(
+    rawAssistantMessages,
+    new Map(initialProviderToolNamesById),
+  );
+  if (!shouldPreserveAnthropicRawAssistantHistory(prompt, snapshot)) {
+    return undefined;
+  }
+  return { anthropic: { rawAssistantMessages: snapshot } };
+}
+
+function createProviderAbortScope(callerSignal: AbortSignal | undefined): {
+  controller: AbortController;
+  dispose: () => void;
+} {
+  const controller = new AbortController();
+  const abortFromCaller = () => controller.abort(callerSignal?.reason);
+
+  if (callerSignal?.aborted) {
+    abortFromCaller();
+    return { controller, dispose() {} };
+  }
+
+  callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+  return {
+    controller,
+    dispose() {
+      callerSignal?.removeEventListener("abort", abortFromCaller);
+    },
+  };
+}
+
+function createCancelableProviderStream(
+  iterable: AsyncIterable<unknown>,
+  providerAbortController: AbortController,
+  disposeAbortScope: () => void,
+): ReadableStream<unknown> {
+  const iterator = iterable[Symbol.asyncIterator]();
+  let consumerCanceled = false;
+  let disposed = false;
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    disposeAbortScope();
+  };
+
+  return new ReadableStream<unknown>(
+    {
+      async pull(controller) {
+        try {
+          const next = await iterator.next();
+          if (next.done) {
+            dispose();
+            controller.close();
+            return;
+          }
+          controller.enqueue(next.value);
+        } catch (error) {
+          dispose();
+          if (!consumerCanceled) {
+            controller.error(error);
+          }
+        }
+      },
+      async cancel(reason) {
+        consumerCanceled = true;
+        if (!providerAbortController.signal.aborted) {
+          providerAbortController.abort(reason);
+        }
+        try {
+          await iterator.return?.();
+        } catch (error) {
+          if (!providerAbortController.signal.aborted) {
+            throw error;
+          }
+        } finally {
+          dispose();
+        }
+      },
+    },
+    // Do not speculatively pull the nested async iterators. Keeping zero
+    // buffered parts lets cancel() reach their return/finally chain
+    // immediately after the consumer's last read.
+    { highWaterMark: 0 },
+  );
 }
 
 export function createAnthropicModelRuntime(
   config: AnthropicRuntimeConfig,
   modelId: string,
-): ModelRuntime {
+): ModelRuntime<OpenAICompatibleLanguageOptions, AnthropicGenerateContent> {
   const fetchImpl = config.fetch ?? globalThis.fetch;
   const providerName = config.name ?? "anthropic";
   const streamOptions = providerName === "veryfront-cloud"
-    ? { clientToolUseTrailingUsageTimeoutMode: "drain" as const }
+    ? {
+      clientToolUseTrailingUsageTimeoutMode: "drain" as const,
+      allowPostTerminalUsage: true,
+    }
     : undefined;
 
   return {
@@ -246,70 +475,204 @@ export function createAnthropicModelRuntime(
     modelId,
     specificationVersion: "v3",
     supportedUrls: {},
-    doGenerate(optionsForRuntime: unknown) {
-      const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
+    async doGenerate(options: OpenAICompatibleLanguageOptions) {
       const url = getAnthropicMessagesUrl(config.baseURL);
       const warnings = createWarningCollector();
-      const body = buildAnthropicMessagesRequest(
+      const {
+        body,
+        providerToolNamesById: initialProviderToolNamesById,
+      } = buildAnthropicMessagesRequestWithCorrelationState(
         modelId,
         config.name ?? "anthropic",
         options,
         false,
         warnings,
       );
-      return requestJson({
-        url,
-        fetchImpl,
-        providerLabel: config.name ?? "anthropic",
-        providerKind: "anthropic",
-        init: createAnthropicRequestInit({
-          apiKey: config.apiKey,
-          authToken: config.authToken,
-          extraHeaders: options.headers,
-          body: JSON.stringify(body),
-          signal: options.abortSignal,
-        }),
-      }).then((payload) => {
-        const drained = warnings.drain();
-        return {
-          ...buildAnthropicGenerateResult(payload),
-          ...(drained.length > 0 ? { warnings: drained } : {}),
-        };
-      });
+      const enableMcpConnector = usesAnthropicMcpConnector(body);
+      let requestBody: AnthropicRequestBody = body;
+      let continuationCount = 0;
+      let aggregateUsage: RuntimeUsage | undefined;
+      const aggregateContent: AnthropicGenerateContent[] = [];
+      const rawAssistantMessages: unknown[][] = [];
+      const providerToolNamesById: AnthropicProviderToolNameRegistry = new Map(
+        initialProviderToolNamesById,
+      );
+      let finalResult: ReturnType<typeof buildAnthropicGenerateResult> | undefined;
+
+      while (true) {
+        throwIfAnthropicRequestAborted(options.abortSignal);
+        const payload = await requestJson({
+          url,
+          fetchImpl,
+          providerLabel: config.name ?? "anthropic",
+          providerKind: "anthropic",
+          init: createAnthropicRequestInit({
+            apiKey: config.apiKey,
+            authToken: config.authToken,
+            extraHeaders: options.headers,
+            enableMcpConnector,
+            body: JSON.stringify(requestBody),
+            signal: options.abortSignal,
+          }),
+        });
+        const result = buildAnthropicGenerateResult(
+          payload,
+          providerName,
+          providerToolNamesById,
+        );
+        aggregateContent.push(...result.content);
+        aggregateUsage = addAnthropicUsage(aggregateUsage, result.usage);
+        finalResult = result;
+
+        const raw = readRawAnthropicResponse(payload);
+        if (raw.rawContent.length > 0) rawAssistantMessages.push(raw.rawContent);
+        if (
+          raw.rawStopReason !== "pause_turn" ||
+          raw.rawContent.length === 0 ||
+          continuationCount >= MAX_PAUSE_TURN_CONTINUATIONS
+        ) {
+          break;
+        }
+
+        continuationCount++;
+        requestBody = createPauseTurnContinuationBody(requestBody, raw.rawContent);
+      }
+
+      const drained = warnings.drain();
+      const providerMetadata = createAnthropicRawAssistantMetadata(
+        options.prompt,
+        rawAssistantMessages,
+        initialProviderToolNamesById,
+      );
+      return {
+        content: aggregateContent,
+        finishReason: finalResult?.finishReason ?? null,
+        ...(aggregateUsage ? { usage: aggregateUsage } : {}),
+        ...(providerMetadata ? { providerMetadata } : {}),
+        ...(drained.length > 0 ? { warnings: drained } : {}),
+      };
     },
-    doStream(optionsForRuntime: unknown) {
-      const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
+    async doStream(options: OpenAICompatibleLanguageOptions) {
       const url = getAnthropicMessagesUrl(config.baseURL);
       const warnings = createWarningCollector();
-      const body = buildAnthropicMessagesRequest(
+      const {
+        body,
+        providerToolNamesById: initialProviderToolNamesById,
+      } = buildAnthropicMessagesRequestWithCorrelationState(
         modelId,
         config.name ?? "anthropic",
         options,
         true,
         warnings,
       );
-      return requestStream({
-        url,
-        fetchImpl,
-        providerLabel: config.name ?? "anthropic",
-        providerKind: "anthropic",
-        init: createAnthropicRequestInit({
-          apiKey: config.apiKey,
-          authToken: config.authToken,
-          extraHeaders: options.headers,
-          enableFineGrainedToolStreaming: true,
-          body: JSON.stringify(body),
-          signal: options.abortSignal,
-        }),
-      }).then((responseStream) => {
-        const drained = warnings.drain();
-        return {
-          stream: ReadableStream.from(
-            streamAnthropicCompatibleParts(responseStream, streamOptions),
-          ),
-          ...(drained.length > 0 ? { warnings: drained } : {}),
-        };
-      });
+      const enableMcpConnector = usesAnthropicMcpConnector(body);
+      throwIfAnthropicRequestAborted(options.abortSignal);
+      const providerAbortScope = createProviderAbortScope(options.abortSignal);
+      let firstResponseStream: ReadableStream<Uint8Array>;
+      try {
+        firstResponseStream = await requestStream({
+          url,
+          fetchImpl,
+          providerLabel: config.name ?? "anthropic",
+          providerKind: "anthropic",
+          init: createAnthropicRequestInit({
+            apiKey: config.apiKey,
+            authToken: config.authToken,
+            extraHeaders: options.headers,
+            enableFineGrainedToolStreaming: true,
+            enableMcpConnector,
+            body: JSON.stringify(body),
+            signal: providerAbortScope.controller.signal,
+          }),
+        });
+      } catch (error) {
+        providerAbortScope.dispose();
+        throw error;
+      }
+      const drained = warnings.drain();
+
+      const continuePausedStream = async function* (): AsyncIterable<unknown> {
+        let responseStream = firstResponseStream;
+        let continuationCount = 0;
+        let aggregateUsage: RuntimeUsage | undefined;
+        let requestBody: AnthropicRequestBody = body;
+        const rawAssistantMessages: unknown[][] = [];
+        const providerToolNamesById: AnthropicProviderToolNameRegistry = new Map(
+          initialProviderToolNamesById,
+        );
+
+        while (true) {
+          let completion: AnthropicStreamCompletion | undefined;
+          let finishPart: Record<string, unknown> | undefined;
+          for await (
+            const part of streamAnthropicCompatibleParts(responseStream, {
+              ...streamOptions,
+              providerLabel: providerName,
+              providerToolNamesById,
+              onCompletion(value) {
+                completion = value;
+              },
+            })
+          ) {
+            const record = readRecord(part);
+            if (record?.type === "finish") {
+              finishPart = record;
+              continue;
+            }
+            yield part;
+          }
+
+          aggregateUsage = addAnthropicUsage(aggregateUsage, completion?.usage);
+          if (completion && completion.rawContent.length > 0) {
+            rawAssistantMessages.push(completion.rawContent);
+          }
+          if (
+            completion?.rawStopReason !== "pause_turn" ||
+            completion.rawContent.length === 0 ||
+            continuationCount >= MAX_PAUSE_TURN_CONTINUATIONS
+          ) {
+            const providerMetadata = createAnthropicRawAssistantMetadata(
+              options.prompt,
+              rawAssistantMessages,
+              initialProviderToolNamesById,
+            );
+            yield {
+              ...(finishPart ?? { type: "finish", finishReason: completion?.finishReason ?? null }),
+              ...(aggregateUsage ? { usage: aggregateUsage } : {}),
+              ...(providerMetadata ? { providerMetadata } : {}),
+            };
+            return;
+          }
+
+          continuationCount++;
+          requestBody = createPauseTurnContinuationBody(requestBody, completion.rawContent);
+          throwIfAnthropicRequestAborted(providerAbortScope.controller.signal);
+          responseStream = await requestStream({
+            url,
+            fetchImpl,
+            providerLabel: config.name ?? "anthropic",
+            providerKind: "anthropic",
+            init: createAnthropicRequestInit({
+              apiKey: config.apiKey,
+              authToken: config.authToken,
+              extraHeaders: options.headers,
+              enableFineGrainedToolStreaming: true,
+              enableMcpConnector,
+              body: JSON.stringify(requestBody),
+              signal: providerAbortScope.controller.signal,
+            }),
+          });
+        }
+      };
+
+      return {
+        stream: createCancelableProviderStream(
+          continuePausedStream(),
+          providerAbortScope.controller,
+          providerAbortScope.dispose,
+        ),
+        ...(drained.length > 0 ? { warnings: drained } : {}),
+      };
     },
   };
 }
@@ -317,7 +680,10 @@ export function createAnthropicModelRuntime(
 export class AnthropicProvider implements LLMProvider {
   readonly id = "anthropic";
 
-  createModel(modelId: string, config: LLMProviderConfig): ModelRuntime {
+  createModel(
+    modelId: string,
+    config: LLMProviderConfig,
+  ): ModelRuntime<OpenAICompatibleLanguageOptions, AnthropicGenerateContent> {
     return createAnthropicModelRuntime(
       {
         apiKey: config.credential,

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -1,7 +1,33 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { RuntimePromptMessage } from "veryfront/provider/shared";
+import type {
+  ModelRuntimePromptMessage,
+  RuntimeAssistantContentPart,
+  RuntimePromptMessage,
+} from "veryfront/provider/shared";
+import { AnthropicServerToolResultError } from "./anthropic-native-content.ts";
 import { buildAnthropicMessagesRequest } from "./anthropic-request-builder.ts";
+
+function captureThrownError(
+  fn: () => unknown,
+  expectedType?: typeof Error,
+  messageIncludes?: string,
+): Error {
+  try {
+    fn();
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
+    const actualName = error.name;
+    if (expectedType && !(error instanceof expectedType)) {
+      throw new Error(`Expected ${expectedType.name}, received ${actualName}`);
+    }
+    if (messageIncludes && !error.message.includes(messageIncludes)) {
+      throw new Error(`Expected error message to include ${messageIncludes}`);
+    }
+    return error;
+  }
+  throw new Error("Expected function to throw");
+}
 
 function createWarningCollector() {
   const warnings: Array<{
@@ -103,6 +129,7 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
         mcpServers: [{
           type: "url",
           url: "https://example.test/mcp",
+          name: "example-mcp",
           authorizationToken: "token_123",
           toolConfiguration: {
             allowedTools: ["read_file"],
@@ -184,6 +211,14 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
           type: "web_search_20250305",
           name: "web",
           max_uses: 2,
+        },
+        {
+          type: "mcp_toolset",
+          mcp_server_name: "example-mcp",
+          default_config: { enabled: false },
+          configs: {
+            read_file: { enabled: true },
+          },
           cache_control: { type: "ephemeral", ttl: "1h" },
         },
       ],
@@ -193,10 +228,8 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
       mcp_servers: [{
         type: "url",
         url: "https://example.test/mcp",
+        name: "example-mcp",
         authorization_token: "token_123",
-        tool_configuration: {
-          allowed_tools: ["read_file"],
-        },
       }],
       container: { id: "ctr_1" },
       custom_anthropic: true,
@@ -213,6 +246,1479 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
       "topP",
       "responseFormat",
     ]);
+  });
+
+  it("maps an explicit generic provider MCP toolset to the matching server identity", () => {
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Use docs." }] }],
+        mcpServers: [{
+          type: "url",
+          url: "https://mcp.example.test",
+          name: "docs",
+        }],
+        tools: [{
+          type: "provider",
+          name: "docs",
+          id: "anthropic.mcp_toolset",
+          args: {
+            defaultConfig: { enabled: false, deferLoading: true },
+            configs: {
+              searchEvents: { enabled: true, deferLoading: false },
+            },
+            cacheControl: { type: "ephemeral", ttl: "1h" },
+          },
+        }],
+      },
+      false,
+      createWarningCollector(),
+    );
+
+    assertEquals(body.mcp_servers, [{
+      type: "url",
+      url: "https://mcp.example.test",
+      name: "docs",
+    }]);
+    assertEquals(body.tools, [{
+      type: "mcp_toolset",
+      mcp_server_name: "docs",
+      default_config: { enabled: false, defer_loading: true },
+      configs: {
+        searchEvents: { enabled: true, defer_loading: false },
+      },
+      cache_control: { type: "ephemeral", ttl: "1h" },
+    }]);
+  });
+
+  it("validates an official raw MCP contract supplied through providerOptions", () => {
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Use docs." }] }],
+        providerOptions: {
+          anthropic: {
+            mcp_servers: [{
+              type: "url",
+              url: "https://mcp.example.test",
+              name: "docs",
+            }],
+            tools: [{
+              type: "mcp_toolset",
+              mcp_server_name: "docs",
+            }],
+          },
+        },
+      },
+      false,
+      createWarningCollector(),
+    );
+
+    assertEquals(body.mcp_servers, [{
+      type: "url",
+      url: "https://mcp.example.test",
+      name: "docs",
+    }]);
+    assertEquals(body.tools, [{
+      type: "mcp_toolset",
+      mcp_server_name: "docs",
+    }]);
+  });
+
+  it("rejects ambiguous MCP configuration sources", () => {
+    const prompt: RuntimePromptMessage[] = [
+      { role: "user", content: [{ type: "text", text: "Use docs." }] },
+    ];
+    const server = {
+      type: "url",
+      url: "https://mcp.example.test",
+      name: "docs",
+    };
+    const explicitToolset = {
+      type: "provider" as const,
+      name: "docs",
+      id: "anthropic.mcp_toolset" as const,
+      args: {},
+    };
+
+    const ambiguousOptions = [{
+      prompt,
+      mcpServers: [server],
+      providerOptions: {
+        anthropic: { mcp_servers: [server] },
+      },
+    }, {
+      prompt,
+      mcpServers: [server],
+      providerOptions: {
+        anthropic: {
+          tools: [{ type: "mcp_toolset", mcp_server_name: "docs" }],
+        },
+      },
+    }, {
+      prompt,
+      mcpServers: [{
+        ...server,
+        toolConfiguration: { enabled: true },
+      }],
+      tools: [explicitToolset],
+    }];
+
+    for (const options of ambiguousOptions) {
+      assertThrows(
+        () =>
+          buildAnthropicMessagesRequest(
+            "claude-sonnet-4-6",
+            "anthropic",
+            options,
+            false,
+            createWarningCollector(),
+          ),
+        TypeError,
+      );
+    }
+  });
+
+  it("replays raw mixed server/client assistant blocks before the local tool result", () => {
+    const rawAssistantMessages = [[{
+      type: "server_tool_use",
+      id: "server_search_1",
+      name: "web_search",
+      input: { query: "Veryfront" },
+    }, {
+      type: "tool_use",
+      id: "local_lookup_1",
+      name: "local_lookup",
+      input: { query: "runtime" },
+    }]];
+    const [rawAssistantContent] = rawAssistantMessages;
+    assertExists(rawAssistantContent);
+    const prompt = [{
+      role: "user",
+      content: [{ type: "text", text: "Search and inspect" }],
+    }, {
+      role: "assistant",
+      content: [{
+        type: "tool-call",
+        toolCallId: "local_lookup_1",
+        toolName: "local_lookup",
+        input: { query: "runtime" },
+      }],
+      providerMetadata: { anthropic: { rawAssistantMessages } },
+    }, {
+      role: "tool",
+      content: [{
+        type: "tool-result",
+        toolCallId: "local_lookup_1",
+        toolName: "local_lookup",
+        output: { type: "json", value: { matches: 1 } },
+      }],
+    }] as unknown as RuntimePromptMessage[];
+
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      { prompt, maxOutputTokens: 64 },
+      false,
+      createWarningCollector(),
+    );
+
+    assertEquals(body.messages, [{
+      role: "user",
+      content: [{ type: "text", text: "Search and inspect" }],
+    }, {
+      role: "assistant",
+      content: rawAssistantContent,
+    }, {
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: "local_lookup_1",
+        content: '{"matches":1}',
+      }],
+    }]);
+  });
+
+  it("rejects raw client tool tampering when canonical content survives", () => {
+    const canonicalCall = {
+      type: "tool-call" as const,
+      toolCallId: "safe_lookup_1",
+      toolName: "safe_lookup",
+      input: '{"accountId":"public-account","operation":"read"}',
+    };
+    const build = (rawToolUse: Record<string, unknown>) =>
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{
+            role: "assistant",
+            content: [canonicalCall],
+            providerMetadata: {
+              anthropic: { rawAssistantMessages: [[rawToolUse]] },
+            },
+          }],
+        },
+        false,
+        createWarningCollector(),
+      );
+    const safeRawToolUse = {
+      type: "tool_use",
+      id: "safe_lookup_1",
+      name: "safe_lookup",
+      input: { accountId: "public-account", operation: "read" },
+    };
+
+    assertEquals(build(safeRawToolUse).messages, [{
+      role: "assistant",
+      content: [safeRawToolUse],
+    }]);
+
+    for (
+      const tamperedRawToolUse of [
+        { ...safeRawToolUse, id: "attacker_selected_id" },
+        { ...safeRawToolUse, name: "delete_account" },
+        {
+          ...safeRawToolUse,
+          input: { accountId: "victim-account", operation: "delete" },
+        },
+      ]
+    ) {
+      assertThrows(
+        () => build(tamperedRawToolUse),
+        TypeError,
+        "Anthropic raw client tool call does not match canonical client-executed content",
+      );
+    }
+  });
+
+  it("correlates raw client tool calls one-for-one in occurrence order", () => {
+    const firstCall = {
+      type: "tool-call" as const,
+      toolCallId: "lookup_1",
+      toolName: "lookup",
+      input: { id: 1 },
+    };
+    const secondCall = {
+      type: "tool-call" as const,
+      toolCallId: "lookup_2",
+      toolName: "lookup",
+      input: { id: 2 },
+    };
+    const firstRawCall = {
+      type: "tool_use",
+      id: "lookup_1",
+      name: "lookup",
+      input: { id: 1 },
+    };
+    const secondRawCall = {
+      type: "tool_use",
+      id: "lookup_2",
+      name: "lookup",
+      input: { id: 2 },
+    };
+    const build = (
+      rawCalls: Record<string, unknown>[],
+      content = [firstCall, secondCall],
+    ) =>
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{
+            role: "assistant",
+            content,
+            providerMetadata: {
+              anthropic: { rawAssistantMessages: [rawCalls] },
+            },
+          }],
+        },
+        false,
+        createWarningCollector(),
+      );
+
+    assertEquals(build([firstRawCall, secondRawCall]).messages, [{
+      role: "assistant",
+      content: [firstRawCall, secondRawCall],
+    }]);
+    for (
+      const rawCalls of [
+        [secondRawCall, firstRawCall],
+        [firstRawCall],
+        [firstRawCall, firstRawCall],
+        [firstRawCall, secondRawCall, secondRawCall],
+      ]
+    ) {
+      assertThrows(
+        () => build(rawCalls),
+        TypeError,
+        "Anthropic raw client tool call does not match canonical client-executed content",
+      );
+    }
+    assertThrows(
+      () => build([firstRawCall, firstRawCall], [firstCall, firstCall]),
+      TypeError,
+      "Anthropic raw client tool call does not match canonical client-executed content",
+    );
+  });
+
+  it("allows raw-only client tool replay when its canonical projection was compacted", () => {
+    const rawToolUse = {
+      type: "tool_use",
+      id: "historical_lookup_1",
+      name: "historical_lookup",
+      input: { retained: true },
+    };
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: "The normalized client call was compacted.",
+          }],
+          providerMetadata: {
+            anthropic: { rawAssistantMessages: [[rawToolUse]] },
+          },
+        }],
+      },
+      false,
+      createWarningCollector(),
+    );
+
+    assertEquals(body.messages, [{
+      role: "assistant",
+      content: [rawToolUse],
+    }]);
+  });
+
+  it("preserves the surviving client/provider call and result interleaving", () => {
+    const rawOrdinaryCall = {
+      type: "tool_use",
+      id: "lookup_1",
+      name: "lookup",
+      input: { id: 1 },
+    };
+    const rawProviderCall = {
+      type: "server_tool_use",
+      id: "code_1",
+      name: "code_execution",
+      input: { code: "print(1)" },
+    };
+    const rawProviderResult = {
+      type: "code_execution_tool_result",
+      tool_use_id: "code_1",
+      content: {
+        type: "code_execution_result",
+        stdout: "1\n",
+        stderr: "",
+        return_code: 0,
+        content: [],
+      },
+    };
+    const ordinaryCall = {
+      type: "tool-call" as const,
+      toolCallId: "lookup_1",
+      toolName: "lookup",
+      input: { id: 1 },
+    };
+    const providerCall = {
+      type: "tool-call" as const,
+      toolCallId: "code_1",
+      toolName: "code_execution",
+      input: { code: "print(1)" },
+      providerExecuted: true as const,
+    };
+    const providerResult = {
+      type: "tool-result" as const,
+      toolCallId: "code_1",
+      toolName: "code_execution",
+      result: {
+        type: "code_execution_result",
+        stdout: "1\n",
+        stderr: "",
+        returnCode: 0,
+        content: [],
+      },
+      providerExecuted: true as const,
+    };
+    const rawAssistantContent = [
+      rawOrdinaryCall,
+      rawProviderCall,
+      rawProviderResult,
+    ];
+    const rawAssistantMessages = [rawAssistantContent];
+    const build = (content: RuntimeAssistantContentPart[]) =>
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{
+            role: "assistant",
+            content,
+            providerToolCalls: [{
+              toolCallId: "code_1",
+              toolName: "code_execution",
+              input: { code: "print(1)" },
+            }],
+            providerMetadata: {
+              anthropic: { rawAssistantMessages },
+            },
+          }],
+        },
+        false,
+        createWarningCollector(),
+      );
+
+    assertEquals(
+      build([ordinaryCall, providerCall, providerResult]).messages,
+      [{
+        role: "assistant",
+        content: rawAssistantContent,
+      }],
+    );
+    for (
+      const content of [
+        [providerCall, ordinaryCall, providerResult],
+        [ordinaryCall, providerResult, providerCall],
+      ]
+    ) {
+      assertThrows(
+        () => build(content),
+        TypeError,
+        "Anthropic raw tool event order does not match canonical assistant content",
+      );
+    }
+  });
+
+  it("replays the latest pure provider-tool round before a later user message", () => {
+    const rawAssistantContent = [{
+      type: "server_tool_use",
+      id: "srvtool_code_1",
+      name: "code_execution",
+      input: { code: "print(2)" },
+    }, {
+      type: "code_execution_tool_result",
+      tool_use_id: "srvtool_code_1",
+      content: {
+        type: "code_execution_result",
+        stdout: "2\n",
+        stderr: "",
+        return_code: 0,
+        content: [],
+      },
+    }, {
+      type: "text",
+      text: "The result is 2.",
+    }];
+    const prompt: ModelRuntimePromptMessage[] = [{
+      role: "user",
+      content: [{ type: "text", text: "Run the calculation." }],
+    }, {
+      role: "assistant",
+      content: [{
+        type: "tool-call",
+        toolCallId: "srvtool_code_1",
+        toolName: "code_execution",
+        input: { code: "print(2)" },
+        providerExecuted: true,
+      }, {
+        type: "tool-result",
+        toolCallId: "srvtool_code_1",
+        toolName: "code_execution",
+        result: {
+          type: "code_execution_result",
+          stdout: "2\n",
+          stderr: "",
+          returnCode: 0,
+          content: [],
+        },
+        providerExecuted: true,
+      }, {
+        type: "text",
+        text: "The result is 2.",
+      }],
+      providerMetadata: {
+        anthropic: { rawAssistantMessages: [rawAssistantContent] },
+      },
+    }, {
+      role: "user",
+      content: [{ type: "text", text: "Explain it." }],
+    }];
+
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      { prompt },
+      false,
+      createWarningCollector(),
+    );
+
+    assertEquals(body.messages, [{
+      role: "user",
+      content: [{ type: "text", text: "Run the calculation." }],
+    }, {
+      role: "assistant",
+      content: rawAssistantContent,
+    }, {
+      role: "user",
+      content: [{ type: "text", text: "Explain it." }],
+    }]);
+  });
+
+  it("rejects replayed provider-tool calls that conflict with canonical content", () => {
+    const rawAssistantMessages = [[{
+      type: "server_tool_use",
+      id: "srvtool_code_1",
+      name: "code_execution",
+      input: { code: "print(2)" },
+    }]];
+    const canonicalVariants = [{
+      toolCallId: "different_id",
+      toolName: "code_execution",
+      input: { code: "print(2)" },
+    }, {
+      toolCallId: "srvtool_code_1",
+      toolName: "web_search",
+      input: { code: "print(2)" },
+    }, {
+      toolCallId: "srvtool_code_1",
+      toolName: "code_execution",
+      input: { code: "print(3)" },
+    }];
+
+    for (const canonical of canonicalVariants) {
+      assertThrows(
+        () =>
+          buildAnthropicMessagesRequest(
+            "claude-sonnet-4-6",
+            "anthropic",
+            {
+              prompt: [{
+                role: "assistant",
+                content: [{
+                  type: "tool-call",
+                  ...canonical,
+                  providerExecuted: true,
+                }],
+                providerMetadata: { anthropic: { rawAssistantMessages } },
+              }],
+            },
+            false,
+            createWarningCollector(),
+          ),
+        TypeError,
+        "Anthropic raw provider tool call does not match canonical provider-executed content",
+      );
+    }
+  });
+
+  it("rejects replayed provider-tool results that conflict with canonical content", () => {
+    const rawAssistantMessages = [[{
+      type: "server_tool_use",
+      id: "srvtool_code_1",
+      name: "code_execution",
+      input: { code: "print(2)" },
+    }, {
+      type: "code_execution_tool_result",
+      tool_use_id: "srvtool_code_1",
+      content: {
+        type: "code_execution_result",
+        stdout: "2\n",
+        stderr: "",
+        return_code: 0,
+        content: [],
+      },
+    }]];
+    const canonicalCall = {
+      type: "tool-call" as const,
+      toolCallId: "srvtool_code_1",
+      toolName: "code_execution",
+      input: { code: "print(2)" },
+      providerExecuted: true as const,
+    };
+    const matchingResult = {
+      type: "code_execution_result",
+      stdout: "2\n",
+      stderr: "",
+      returnCode: 0,
+      content: [],
+    };
+    const canonicalVariants = [{
+      toolCallId: "different_id",
+      toolName: "code_execution",
+      result: matchingResult,
+    }, {
+      toolCallId: "srvtool_code_1",
+      toolName: "web_search",
+      result: matchingResult,
+    }, {
+      toolCallId: "srvtool_code_1",
+      toolName: "code_execution",
+      result: { ...matchingResult, stdout: "different\n" },
+    }, {
+      toolCallId: "srvtool_code_1",
+      toolName: "code_execution",
+      result: matchingResult,
+      isError: true,
+    }];
+
+    for (const canonical of canonicalVariants) {
+      assertThrows(
+        () =>
+          buildAnthropicMessagesRequest(
+            "claude-sonnet-4-6",
+            "anthropic",
+            {
+              prompt: [{
+                role: "assistant",
+                content: [
+                  canonicalCall,
+                  {
+                    type: "tool-result",
+                    ...canonical,
+                    providerExecuted: true,
+                  },
+                ],
+                providerMetadata: { anthropic: { rawAssistantMessages } },
+              }],
+            },
+            false,
+            createWarningCollector(),
+          ),
+        TypeError,
+        "Anthropic raw provider tool result does not match canonical provider-executed content",
+      );
+    }
+  });
+
+  it("rejects reordered or duplicated canonical provider-tool occurrences", () => {
+    const rawCalls = [{
+      type: "server_tool_use",
+      id: "server_search_1",
+      name: "web_search",
+      input: { query: "Veryfront" },
+    }, {
+      type: "server_tool_use",
+      id: "server_search_2",
+      name: "web_search",
+      input: { query: "runtime" },
+    }];
+    const firstCall = {
+      toolCallId: "server_search_1",
+      toolName: "web_search",
+      input: { query: "Veryfront" },
+      supportsDeferredResults: true,
+    };
+    const secondCall = {
+      toolCallId: "server_search_2",
+      toolName: "web_search",
+      input: { query: "runtime" },
+      supportsDeferredResults: true,
+    };
+    const build = (
+      providerToolCalls: typeof firstCall[],
+      content: unknown[] = [],
+    ) =>
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{
+            role: "assistant",
+            content,
+            providerToolCalls,
+            providerMetadata: {
+              anthropic: { rawAssistantMessages: [rawCalls] },
+            },
+          }] as unknown as ModelRuntimePromptMessage[],
+        },
+        false,
+        createWarningCollector(),
+      );
+
+    assertThrows(
+      () => build([secondCall, firstCall]),
+      TypeError,
+      "Anthropic raw provider tool call does not match canonical provider-executed content",
+    );
+    assertThrows(
+      () => build([firstCall, firstCall]),
+      TypeError,
+      "Anthropic raw provider tool call does not match canonical provider-executed content",
+    );
+    assertThrows(
+      () =>
+        build([firstCall, secondCall], [{
+          type: "tool-call",
+          toolCallId: "server_search_2",
+          toolName: "web_search",
+          input: { query: "runtime" },
+          providerExecuted: true,
+        }, {
+          type: "tool-call",
+          toolCallId: "server_search_1",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+          providerExecuted: true,
+        }]),
+      TypeError,
+      "Anthropic raw provider tool call does not match canonical provider-executed content",
+    );
+  });
+
+  it("rejects reordered or duplicated canonical provider-tool results", () => {
+    const rawAssistantMessages = [[{
+      type: "server_tool_use",
+      id: "server_search_1",
+      name: "web_search",
+      input: { query: "Veryfront" },
+    }, {
+      type: "web_search_tool_result",
+      tool_use_id: "server_search_1",
+      content: [],
+    }, {
+      type: "server_tool_use",
+      id: "server_search_2",
+      name: "web_search",
+      input: { query: "runtime" },
+    }, {
+      type: "web_search_tool_result",
+      tool_use_id: "server_search_2",
+      content: [],
+    }]];
+    const firstCall = {
+      type: "tool-call" as const,
+      toolCallId: "server_search_1",
+      toolName: "web_search",
+      input: { query: "Veryfront" },
+      providerExecuted: true as const,
+    };
+    const secondCall = {
+      type: "tool-call" as const,
+      toolCallId: "server_search_2",
+      toolName: "web_search",
+      input: { query: "runtime" },
+      providerExecuted: true as const,
+    };
+    const firstResult = {
+      type: "tool-result" as const,
+      toolCallId: "server_search_1",
+      toolName: "web_search",
+      result: [],
+      providerExecuted: true as const,
+    };
+    const secondResult = {
+      type: "tool-result" as const,
+      toolCallId: "server_search_2",
+      toolName: "web_search",
+      result: [],
+      providerExecuted: true as const,
+    };
+    const build = (results: typeof firstResult[]) =>
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{
+            role: "assistant",
+            content: [firstCall, secondCall, ...results],
+            providerMetadata: {
+              anthropic: { rawAssistantMessages },
+            },
+          }],
+        },
+        false,
+        createWarningCollector(),
+      );
+
+    assertThrows(
+      () => build([secondResult, firstResult]),
+      TypeError,
+      "Anthropic raw provider tool result does not match canonical provider-executed content",
+    );
+    assertThrows(
+      () => build([firstResult, firstResult]),
+      TypeError,
+      "Anthropic raw provider tool result does not match canonical provider-executed content",
+    );
+  });
+
+  it("correlates the exact provider error payload and rejects a different error", () => {
+    const rawAssistantContent = [{
+      type: "server_tool_use",
+      id: "server_search_1",
+      name: "web_search",
+      input: { query: "Veryfront" },
+    }, {
+      type: "web_search_tool_result",
+      tool_use_id: "server_search_1",
+      content: {
+        type: "web_search_tool_result_error",
+        error_code: "unavailable",
+      },
+    }];
+    const rawAssistantMessages = [rawAssistantContent];
+    const build = (code: string) =>
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{
+            role: "assistant",
+            content: [{
+              type: "tool-call",
+              toolCallId: "server_search_1",
+              toolName: "web_search",
+              input: { query: "Veryfront" },
+              providerExecuted: true,
+            }, {
+              type: "tool-result",
+              toolCallId: "server_search_1",
+              toolName: "web_search",
+              result: new AnthropicServerToolResultError({
+                code,
+                toolCallId: "server_search_1",
+                toolName: "web_search",
+              }),
+              isError: true,
+              providerExecuted: true,
+            }],
+            providerMetadata: { anthropic: { rawAssistantMessages } },
+          }],
+        },
+        false,
+        createWarningCollector(),
+      );
+
+    assertEquals(build("unavailable").messages, [{
+      role: "assistant",
+      content: rawAssistantContent,
+    }]);
+    assertThrows(
+      () => build("max_uses_exceeded"),
+      TypeError,
+      "Anthropic raw provider tool result does not match canonical provider-executed content",
+    );
+  });
+
+  it("correlates a JSON-round-tripped provider error payload", () => {
+    const rawAssistantContent = [{
+      type: "server_tool_use",
+      id: "server_search_round_trip",
+      name: "web_search",
+      input: { query: "Veryfront" },
+    }, {
+      type: "web_search_tool_result",
+      tool_use_id: "server_search_round_trip",
+      content: {
+        type: "web_search_tool_result_error",
+        error_code: "unavailable",
+      },
+    }];
+    const result = JSON.parse(JSON.stringify(
+      new AnthropicServerToolResultError({
+        code: "unavailable",
+        toolCallId: "server_search_round_trip",
+        toolName: "web_search",
+      }),
+    ));
+
+    const request = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [{
+            type: "tool-call",
+            toolCallId: "server_search_round_trip",
+            toolName: "web_search",
+            input: { query: "Veryfront" },
+            providerExecuted: true,
+          }, {
+            type: "tool-result",
+            toolCallId: "server_search_round_trip",
+            toolName: "web_search",
+            result,
+            isError: true,
+            providerExecuted: true,
+          }],
+          providerMetadata: {
+            anthropic: { rawAssistantMessages: [rawAssistantContent] },
+          },
+        }],
+      },
+      false,
+      createWarningCollector(),
+    );
+
+    assertEquals(request.messages, [{
+      role: "assistant",
+      content: rawAssistantContent,
+    }]);
+  });
+
+  it("rejects extra fields on a serialized provider error", () => {
+    const toolCallId = "server_search_extra_field";
+    const result = {
+      ...JSON.parse(JSON.stringify(
+        new AnthropicServerToolResultError({
+          code: "unavailable",
+          toolCallId,
+          toolName: "web_search",
+        }),
+      )),
+      extra: "must not be ignored",
+    };
+
+    assertThrows(
+      () =>
+        buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{
+                type: "tool-call",
+                toolCallId,
+                toolName: "web_search",
+                input: { query: "Veryfront" },
+                providerExecuted: true,
+              }, {
+                type: "tool-result",
+                toolCallId,
+                toolName: "web_search",
+                result,
+                isError: true,
+                providerExecuted: true,
+              }],
+              providerMetadata: {
+                anthropic: {
+                  rawAssistantMessages: [[{
+                    type: "server_tool_use",
+                    id: toolCallId,
+                    name: "web_search",
+                    input: { query: "Veryfront" },
+                  }, {
+                    type: "web_search_tool_result",
+                    tool_use_id: toolCallId,
+                    content: {
+                      type: "web_search_tool_result_error",
+                      error_code: "unavailable",
+                    },
+                  }]],
+                },
+              },
+            }],
+          },
+          false,
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Anthropic raw provider tool result does not match canonical provider-executed content",
+    );
+  });
+
+  it("rejects provider error accessors without invoking them", () => {
+    let codeReads = 0;
+    const result = Object.defineProperty(
+      {
+        name: "AnthropicServerToolResultError",
+        provider: "anthropic",
+        toolCallId: "server_search_accessor",
+        toolName: "web_search",
+      },
+      "code",
+      {
+        enumerable: true,
+        get() {
+          codeReads++;
+          return "unavailable";
+        },
+      },
+    );
+
+    assertThrows(
+      () =>
+        buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{
+                type: "tool-call",
+                toolCallId: "server_search_accessor",
+                toolName: "web_search",
+                input: { query: "Veryfront" },
+                providerExecuted: true,
+              }, {
+                type: "tool-result",
+                toolCallId: "server_search_accessor",
+                toolName: "web_search",
+                result,
+                isError: true,
+                providerExecuted: true,
+              }],
+              providerMetadata: {
+                anthropic: {
+                  rawAssistantMessages: [[{
+                    type: "server_tool_use",
+                    id: "server_search_accessor",
+                    name: "web_search",
+                    input: { query: "Veryfront" },
+                  }, {
+                    type: "web_search_tool_result",
+                    tool_use_id: "server_search_accessor",
+                    content: {
+                      type: "web_search_tool_result_error",
+                      error_code: "unavailable",
+                    },
+                  }]],
+                },
+              },
+            }],
+          },
+          false,
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Anthropic raw provider tool result does not match canonical provider-executed content",
+    );
+    assertEquals(codeReads, 0);
+  });
+
+  it("keeps a cross-assistant provider call and result in one replay transaction", () => {
+    const rawProviderCall = {
+      type: "server_tool_use",
+      id: "server_search_1",
+      name: "web_search",
+      input: { query: "Veryfront" },
+    };
+    const rawLocalCall = {
+      type: "tool_use",
+      id: "local_lookup_1",
+      name: "local_lookup",
+      input: { query: "runtime" },
+    };
+    const rawProviderResult = {
+      type: "web_search_tool_result",
+      tool_use_id: "server_search_1",
+      content: [{
+        type: "web_search_result",
+        url: "https://veryfront.com",
+        title: "Veryfront",
+        encrypted_content: "encrypted-result",
+        page_age: null,
+      }],
+    };
+    const prompt: ModelRuntimePromptMessage[] = [{
+      role: "user",
+      content: [{ type: "text", text: "Search and inspect" }],
+    }, {
+      role: "assistant",
+      content: [{
+        type: "tool-call",
+        toolCallId: "local_lookup_1",
+        toolName: "local_lookup",
+        input: { query: "runtime" },
+      }],
+      providerToolCalls: [{
+        toolCallId: "server_search_1",
+        toolName: "web_search",
+        input: { query: "Veryfront" },
+        supportsDeferredResults: true,
+      }],
+      providerMetadata: {
+        anthropic: { rawAssistantMessages: [[rawProviderCall, rawLocalCall]] },
+      },
+    }, {
+      role: "tool",
+      content: [{
+        type: "tool-result",
+        toolCallId: "local_lookup_1",
+        toolName: "local_lookup",
+        output: { type: "json", value: { matches: 1 } },
+      }],
+    }, {
+      role: "assistant",
+      content: [{
+        type: "tool-result",
+        toolCallId: "server_search_1",
+        toolName: "web_search",
+        result: [{
+          type: "web_search_result",
+          url: "https://veryfront.com",
+          title: "Veryfront",
+          pageAge: null,
+          encryptedContent: "encrypted-result",
+        }],
+        providerExecuted: true,
+      }, {
+        type: "text",
+        text: "Combined both results.",
+      }],
+      providerMetadata: {
+        anthropic: {
+          rawAssistantMessages: [[rawProviderResult, {
+            type: "text",
+            text: "Combined both results.",
+          }]],
+        },
+      },
+    }, {
+      role: "user",
+      content: [{ type: "text", text: "Summarize that" }],
+    }];
+
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      { prompt },
+      false,
+      createWarningCollector(),
+    );
+
+    assertEquals(body.messages, [{
+      role: "user",
+      content: [{ type: "text", text: "Search and inspect" }],
+    }, {
+      role: "assistant",
+      content: [rawProviderCall, rawLocalCall],
+    }, {
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: "local_lookup_1",
+        content: '{"matches":1}',
+      }],
+    }, {
+      role: "assistant",
+      content: [rawProviderResult, {
+        type: "text",
+        text: "Combined both results.",
+      }],
+    }, {
+      role: "user",
+      content: [{ type: "text", text: "Summarize that" }],
+    }]);
+  });
+
+  it("rejects a canonical provider result backed only by a raw legacy call", () => {
+    const toolCallId = "mcptool_raw_only";
+    assertThrows(
+      () =>
+        buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{
+              role: "user",
+              content: [{ type: "text", text: "Echo" }],
+            }, {
+              role: "assistant",
+              content: [{ type: "text", text: "Calling a legacy provider tool." }],
+              providerMetadata: {
+                anthropic: {
+                  rawAssistantMessages: [[{
+                    type: "mcp_tool_use",
+                    id: toolCallId,
+                    name: "echo",
+                    server_name: "example-mcp",
+                    input: { value: "hello" },
+                  }]],
+                },
+              },
+            }, {
+              role: "assistant",
+              content: [{
+                type: "tool-result",
+                toolCallId,
+                toolName: "echo",
+                result: "hello",
+                providerExecuted: true,
+              }],
+              providerMetadata: {
+                anthropic: {
+                  rawAssistantMessages: [[{
+                    type: "mcp_tool_result",
+                    tool_use_id: toolCallId,
+                    is_error: false,
+                    content: "hello",
+                  }]],
+                },
+              },
+            }],
+          },
+          false,
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Anthropic raw provider tool result does not match canonical provider-executed content",
+    );
+  });
+
+  it("rejects malformed present Anthropic replay metadata", () => {
+    assertThrows(
+      () =>
+        buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{ type: "text", text: "Do not silently fall back." }],
+              providerMetadata: {
+                anthropic: { rawAssistantMessages: "invalid" },
+              },
+            }],
+          },
+          false,
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Anthropic raw assistant messages must be a non-empty array",
+    );
+    assertThrows(
+      () =>
+        buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{ type: "text", text: "Do not replay unknown blocks." }],
+              providerMetadata: {
+                anthropic: {
+                  rawAssistantMessages: [[{ type: "future_unsupported_block" }]],
+                },
+              },
+            }],
+          },
+          false,
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Anthropic raw assistant content block type is unsupported",
+    );
+    assertThrows(
+      () =>
+        buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{
+                type: "tool-result",
+                toolCallId: "orphan",
+                toolName: "web_search",
+                result: [],
+                providerExecuted: true,
+              }],
+              providerMetadata: {
+                anthropic: {
+                  rawAssistantMessages: [[{
+                    type: "web_search_tool_result",
+                    tool_use_id: "orphan",
+                    content: [],
+                  }]],
+                },
+              },
+            }],
+          },
+          false,
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Anthropic raw assistant provider tool result is malformed or unpaired",
+    );
+  });
+
+  it("rejects replay metadata accessors without invoking them", () => {
+    let namespaceReads = 0;
+    const hostileNamespace = Object.defineProperty({}, "anthropic", {
+      enumerable: true,
+      get() {
+        namespaceReads += 1;
+        throw new Error("private namespace diagnostic");
+      },
+    }) as Record<string, unknown>;
+    const build = (providerMetadata: Record<string, unknown>) =>
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{
+            role: "assistant",
+            content: [{ type: "text", text: "Do not invoke metadata accessors." }],
+            providerMetadata,
+          }],
+        },
+        false,
+        createWarningCollector(),
+      );
+
+    const namespaceError = captureThrownError(
+      () => build(hostileNamespace),
+      TypeError,
+      "Anthropic provider metadata namespace must be an enumerable data property",
+    );
+    assertEquals(namespaceReads, 0);
+    assertEquals(namespaceError.message.includes("private namespace diagnostic"), false);
+
+    let rawHistoryReads = 0;
+    const hostileRawHistory = Object.defineProperty({}, "rawAssistantMessages", {
+      enumerable: true,
+      get() {
+        rawHistoryReads += 1;
+        throw new Error("private history diagnostic");
+      },
+    });
+    const historyError = captureThrownError(
+      () => build({ anthropic: hostileRawHistory }),
+      TypeError,
+      "Anthropic raw assistant messages must be an enumerable data property",
+    );
+    assertEquals(rawHistoryReads, 0);
+    assertEquals(historyError.message.includes("private history diagnostic"), false);
+
+    let proxyPropertyReads = 0;
+    const rawAssistantMessages = new Proxy([[{
+      type: "server_tool_use",
+      id: "server_search_proxy",
+      name: "web_search",
+      input: { query: "Veryfront" },
+    }]], {
+      get() {
+        proxyPropertyReads += 1;
+        throw new Error("proxy property read");
+      },
+    });
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [{
+            type: "tool-call",
+            toolCallId: "server_search_proxy",
+            toolName: "web_search",
+            input: { query: "Veryfront" },
+            providerExecuted: true,
+          }],
+          providerMetadata: {
+            anthropic: { rawAssistantMessages },
+          },
+        }],
+      },
+      false,
+      createWarningCollector(),
+    );
+    assertEquals(body.messages, [{
+      role: "assistant",
+      content: [{
+        type: "server_tool_use",
+        id: "server_search_proxy",
+        name: "web_search",
+        input: { query: "Veryfront" },
+      }],
+    }]);
+    assertEquals(proxyPropertyReads, 0);
+  });
+
+  it("compacts raw provider tool history after the turn has completed", () => {
+    const prompt: RuntimePromptMessage[] = [{
+      role: "user",
+      content: [{ type: "text", text: "Search and inspect" }],
+    }, {
+      role: "assistant",
+      content: [{
+        type: "tool-call",
+        toolCallId: "local_lookup_1",
+        toolName: "local_lookup",
+        input: { query: "runtime" },
+      }],
+      providerToolCalls: [{
+        toolCallId: "server_search_1",
+        toolName: "web_search",
+        input: { query: "Veryfront" },
+        supportsDeferredResults: true,
+      }],
+      providerMetadata: {
+        anthropic: {
+          rawAssistantMessages: [[{
+            type: "server_tool_use",
+            id: "server_search_1",
+            name: "web_search",
+            input: { query: "Veryfront" },
+          }, {
+            type: "tool_use",
+            id: "local_lookup_1",
+            name: "local_lookup",
+            input: { query: "runtime" },
+          }]],
+        },
+      },
+    }, {
+      role: "tool",
+      content: [{
+        type: "tool-result",
+        toolCallId: "local_lookup_1",
+        toolName: "local_lookup",
+        output: { type: "json", value: { matches: 1 } },
+      }],
+    }, {
+      role: "assistant",
+      content: [{ type: "text", text: "Combined both results." }],
+      providerMetadata: {
+        anthropic: {
+          rawAssistantMessages: [[{
+            type: "web_search_tool_result",
+            tool_use_id: "server_search_1",
+            content: [{
+              type: "web_search_result",
+              url: "https://veryfront.com",
+              title: "Veryfront",
+              encrypted_content: "encrypted-result",
+              page_age: null,
+            }],
+          }, {
+            type: "text",
+            text: "Combined both results.",
+          }]],
+        },
+      },
+    }, {
+      role: "user",
+      content: [{ type: "text", text: "Summarize that" }],
+    }];
+
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      { prompt },
+      false,
+      createWarningCollector(),
+    );
+
+    assertEquals(body.messages, [{
+      role: "user",
+      content: [{ type: "text", text: "Search and inspect" }],
+    }, {
+      role: "assistant",
+      content: [{ type: "text", text: "Combined both results." }],
+    }, {
+      role: "user",
+      content: [{ type: "text", text: "Summarize that" }],
+    }]);
   });
 
   it("treats provider-option thinking as enabled while shaping sampling settings", () => {
@@ -247,6 +1753,103 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
       "temperature",
       "topP",
     ]);
+  });
+
+  it("rejects unsafe or non-integral explicit thinking budgets", () => {
+    const prompt: RuntimePromptMessage[] = [
+      { role: "user", content: [{ type: "text", text: "Think carefully." }] },
+    ];
+    const invalidBudgets = [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      1023,
+      1024.5,
+      Number.MAX_SAFE_INTEGER + 1,
+    ];
+
+    for (const budgetTokens of invalidBudgets) {
+      assertThrows(
+        () =>
+          buildAnthropicMessagesRequest(
+            "claude-sonnet-4-6",
+            "anthropic",
+            {
+              prompt,
+              reasoning: { enabled: true, budgetTokens },
+            },
+            false,
+            createWarningCollector(),
+          ),
+        TypeError,
+        "budgetTokens must be a safe integer of at least 1024",
+      );
+      assertThrows(
+        () =>
+          buildAnthropicMessagesRequest(
+            "claude-sonnet-4-6",
+            "anthropic",
+            {
+              prompt,
+              providerOptions: {
+                anthropic: {
+                  thinking: { type: "enabled", budget_tokens: budgetTokens },
+                },
+              },
+            },
+            false,
+            createWarningCollector(),
+          ),
+        TypeError,
+        "thinking.budget_tokens must be a safe integer of at least 1024",
+      );
+    }
+
+    for (
+      const thinking of [
+        null,
+        [],
+        "enabled",
+        {},
+        { type: "" },
+        { type: "enabled" },
+      ]
+    ) {
+      assertThrows(
+        () =>
+          buildAnthropicMessagesRequest(
+            "claude-sonnet-4-6",
+            "anthropic",
+            {
+              prompt,
+              providerOptions: { anthropic: { thinking } },
+            },
+            false,
+            createWarningCollector(),
+          ),
+        TypeError,
+        "Anthropic provider thinking",
+      );
+    }
+  });
+
+  it("keeps provider-neutral reasoning authoritative over raw thinking options", () => {
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Think." }] }],
+        reasoning: { enabled: true, budgetTokens: 4096 },
+        providerOptions: {
+          anthropic: {
+            thinking: { type: "enabled", budget_tokens: 2048 },
+          },
+        },
+      },
+      false,
+      createWarningCollector(),
+    );
+
+    assertEquals(body.thinking, { type: "enabled", budget_tokens: 4096 });
   });
 
   it("compacts completed historical tool rounds before replaying later user turns", () => {
@@ -596,5 +2199,54 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
         }],
       },
     ]);
+  });
+
+  it("requires raw metadata to replay provider-executed assistant results", () => {
+    assertThrows(
+      () =>
+        buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{
+                type: "tool-call",
+                toolCallId: "srvtoolu_search_1",
+                toolName: "web_search",
+                input: { query: "Veryfront" },
+                providerExecuted: true,
+              }],
+            }],
+          },
+          false,
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Anthropic provider-executed assistant tool calls require exact raw replay metadata",
+    );
+    assertThrows(
+      () =>
+        buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{
+                type: "tool-result",
+                toolCallId: "srvtoolu_search_1",
+                toolName: "web_search",
+                result: { results: [] },
+                providerExecuted: true,
+              }],
+            }],
+          },
+          false,
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Anthropic provider-executed assistant tool results require exact raw replay metadata",
+    );
   });
 });

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -1601,36 +1601,32 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
         throw new Error("proxy property read");
       },
     });
-    const body = buildAnthropicMessagesRequest(
-      "claude-sonnet-4-6",
-      "anthropic",
-      {
-        prompt: [{
-          role: "assistant",
-          content: [{
-            type: "tool-call",
-            toolCallId: "server_search_proxy",
-            toolName: "web_search",
-            input: { query: "Veryfront" },
-            providerExecuted: true,
-          }],
-          providerMetadata: {
-            anthropic: { rawAssistantMessages },
+    captureThrownError(
+      () =>
+        buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{
+                type: "tool-call",
+                toolCallId: "server_search_proxy",
+                toolName: "web_search",
+                input: { query: "Veryfront" },
+                providerExecuted: true,
+              }],
+              providerMetadata: {
+                anthropic: { rawAssistantMessages },
+              },
+            }],
           },
-        }],
-      },
-      false,
-      createWarningCollector(),
+          false,
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Anthropic raw assistant metadata was not valid bounded JSON",
     );
-    assertEquals(body.messages, [{
-      role: "assistant",
-      content: [{
-        type: "server_tool_use",
-        id: "server_search_proxy",
-        name: "web_search",
-        input: { query: "Veryfront" },
-      }],
-    }]);
     assertEquals(proxyPropertyReads, 0);
   });
 

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -1,9 +1,34 @@
 import {
+  jsonValuesEqual,
   readProviderOptions,
+  readRecord,
   stringifyJsonValue,
   unwrapToolInputSchema,
 } from "veryfront/provider/shared";
-import type { RuntimePromptMessage } from "veryfront/provider/shared";
+import type {
+  ModelRuntimeCallOptions,
+  ModelRuntimePromptMessage,
+  ModelRuntimeToolDefinition,
+  RuntimeReasoningOption,
+} from "veryfront/provider/shared";
+import {
+  type AnthropicMcpRequestConfiguration,
+  assertAnthropicMcpRequestContract,
+  normalizeAnthropicMcpServers,
+  normalizeAnthropicMcpToolsetArgs,
+} from "./anthropic-mcp-request.ts";
+import {
+  type AnthropicProviderToolNameRegistry,
+  type AnthropicProviderToolUse,
+  type AnthropicServerToolResult,
+  isAnthropicProviderToolResultBlockType,
+  MAX_ANTHROPIC_RAW_ASSISTANT_BLOCKS,
+  MAX_ANTHROPIC_RAW_ASSISTANT_MESSAGES,
+  parseAnthropicProviderToolUse,
+  parseAnthropicServerToolResult,
+  snapshotAnthropicRawAssistantMetadata,
+  validateAnthropicRawAssistantMessages,
+} from "./anthropic-native-content.ts";
 
 type ProviderCacheTtl = boolean | "5m" | "1h";
 
@@ -12,68 +37,14 @@ type ProviderCacheControlOption = {
   tools?: ProviderCacheTtl;
 };
 
-type ProviderReasoningEffort = "low" | "medium" | "high" | "max";
-
-type ProviderReasoningOption = {
-  enabled?: boolean;
-  effort?: ProviderReasoningEffort;
-  budgetTokens?: number;
-};
-
-export type RuntimeToolDefinition =
-  | {
-    type: "function";
-    name: string;
-    description?: string;
-    inputSchema: unknown;
-  }
-  | {
-    type: "provider";
-    name: string;
-    id: `${string}.${string}`;
-    args: Record<string, unknown>;
-  };
-
-export type OpenAICompatibleLanguageOptions = {
-  prompt: RuntimePromptMessage[];
-  maxOutputTokens?: number;
-  temperature?: number;
-  topP?: number;
-  topK?: number;
-  stopSequences?: string[];
-  tools?: RuntimeToolDefinition[];
-  toolChoice?: unknown;
-  seed?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  headers?: HeadersInit;
-  providerOptions?: Record<string, unknown>;
-  includeRawChunks?: boolean;
-  abortSignal?: AbortSignal;
+export interface OpenAICompatibleLanguageOptions extends ModelRuntimeCallOptions {
   cacheControl?: ProviderCacheControlOption;
-  reasoning?: ProviderReasoningOption;
-  userId?: string;
-  requestLabels?: Record<string, string>;
-  serviceTier?: "auto" | "default" | "flex" | "scale";
-  parallelToolCalls?: boolean;
-  responseFormat?:
-    | { type: "text" }
-    | { type: "json" }
-    | {
-      type: "json_schema";
-      name: string;
-      schema: unknown;
-      description?: string;
-      strict?: boolean;
-    };
   anthropicContainer?: unknown;
-  googleCachedContent?: string;
-  googleSafetySettings?: Array<{
-    category: string;
-    threshold: string;
-  }>;
-  mcpServers?: Array<Record<string, unknown>>;
-};
+  mcpServers?: readonly Record<string, unknown>[];
+}
+
+/** @deprecated Import `ModelRuntimeToolDefinition` from `veryfront/provider` instead. */
+export type RuntimeToolDefinition = ModelRuntimeToolDefinition;
 
 type WarningCollector = {
   push(warning: {
@@ -126,21 +97,6 @@ function toSnakeCaseRecord(record: Record<string, unknown>): Record<string, unkn
   );
 }
 
-function deepSnakeCase(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(deepSnakeCase);
-  }
-  if (value !== null && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([key, v]) => [
-        key.replace(/[A-Z]/g, (match) => `_${match.toLowerCase()}`),
-        deepSnakeCase(v),
-      ]),
-    );
-  }
-  return value;
-}
-
 function pushAnthropicUserContent(
   messages: AnthropicCompatibleMessage[],
   content: Array<Record<string, unknown>>,
@@ -161,8 +117,657 @@ function pushAnthropicUserContent(
   });
 }
 
+function readOwnAnthropicMetadataProperty(
+  value: object,
+  key: "anthropic" | "rawAssistantMessages",
+  malformedMessage: string,
+): unknown {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(value, key);
+  } catch {
+    throw new TypeError(malformedMessage);
+  }
+  if (descriptor === undefined) return undefined;
+  if (!Object.hasOwn(descriptor, "value") || descriptor.enumerable !== true) {
+    throw new TypeError(malformedMessage);
+  }
+  return descriptor.value;
+}
+
+function readAnthropicRawAssistantMessagesValue(
+  message: Extract<ModelRuntimePromptMessage, { readonly role: "assistant" }>,
+): unknown[] | undefined {
+  const metadata = message.providerMetadata;
+  if (metadata === undefined) return undefined;
+  if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new TypeError("Anthropic provider metadata must be an object");
+  }
+  const anthropic = readOwnAnthropicMetadataProperty(
+    metadata,
+    "anthropic",
+    "Anthropic provider metadata namespace must be an enumerable data property",
+  );
+  if (anthropic === undefined) return undefined;
+  if (anthropic === null || typeof anthropic !== "object" || Array.isArray(anthropic)) {
+    throw new TypeError("Anthropic provider metadata namespace must be an object");
+  }
+  const rawAssistantMessages = readOwnAnthropicMetadataProperty(
+    anthropic,
+    "rawAssistantMessages",
+    "Anthropic raw assistant messages must be an enumerable data property",
+  );
+  if (rawAssistantMessages === undefined) return undefined;
+  const snapshot = snapshotAnthropicRawAssistantMetadata(rawAssistantMessages);
+  if (!Array.isArray(snapshot) || snapshot.length === 0) {
+    throw new TypeError("Anthropic raw assistant messages must be a non-empty array");
+  }
+  return snapshot;
+}
+
+type CanonicalProviderCall = {
+  id: string;
+  name: string;
+  input: unknown;
+};
+
+type CanonicalProviderResult = {
+  id: string;
+  name: string;
+  result: unknown;
+  isError: boolean;
+};
+
+type AnthropicToolEventKind =
+  | "client-call"
+  | "provider-call"
+  | "provider-result";
+
+type AnthropicToolEvent = {
+  kind: AnthropicToolEventKind;
+  id: string;
+};
+
+type ValidatedAnthropicReplay = {
+  messages: Array<Array<Record<string, unknown>>>;
+  nextProviderToolNamesById: AnthropicProviderToolNameRegistry;
+  nextCanonicalProviderToolNamesById: AnthropicProviderToolNameRegistry;
+};
+
+const MAX_ANTHROPIC_OUTSTANDING_PROVIDER_TOOL_CALLS = MAX_ANTHROPIC_RAW_ASSISTANT_BLOCKS;
+
+function assertBoundedAnthropicProviderToolState(
+  providerToolNamesById: ReadonlyMap<string, string>,
+): void {
+  if (
+    providerToolNamesById.size >
+      MAX_ANTHROPIC_OUTSTANDING_PROVIDER_TOOL_CALLS
+  ) {
+    throw new TypeError(
+      `Anthropic provider tool correlation exceeded ${MAX_ANTHROPIC_OUTSTANDING_PROVIDER_TOOL_CALLS} outstanding calls`,
+    );
+  }
+}
+
+function invalidAnthropicClientCallHistory(): TypeError {
+  return new TypeError(
+    "Anthropic raw client tool call does not match canonical client-executed content",
+  );
+}
+
+function invalidAnthropicProviderCallHistory(): TypeError {
+  return new TypeError(
+    "Anthropic raw provider tool call does not match canonical provider-executed content",
+  );
+}
+
+function invalidAnthropicProviderResultHistory(): TypeError {
+  return new TypeError(
+    "Anthropic raw provider tool result does not match canonical provider-executed content",
+  );
+}
+
+function invalidAnthropicToolEventOrder(): TypeError {
+  return new TypeError(
+    "Anthropic raw tool event order does not match canonical assistant content",
+  );
+}
+
+function anthropicCallsEqual(
+  left: CanonicalProviderCall,
+  right: CanonicalProviderCall,
+): boolean {
+  return left.id === right.id &&
+    left.name === right.name &&
+    jsonValuesEqual(left.input, right.input, true);
+}
+
+function orderedAnthropicCallsEqual(
+  left: readonly CanonicalProviderCall[],
+  right: readonly CanonicalProviderCall[],
+): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    const leftCall = left[index];
+    const rightCall = right[index];
+    if (!leftCall || !rightCall || !anthropicCallsEqual(leftCall, rightCall)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function rejectDuplicateAnthropicCallIds(
+  calls: readonly CanonicalProviderCall[],
+  invalid: () => TypeError,
+): void {
+  const ids = new Set<string>();
+  for (const call of calls) {
+    if (ids.has(call.id)) throw invalid();
+    ids.add(call.id);
+  }
+}
+
+function survivingAnthropicToolEvents(
+  events: readonly AnthropicToolEvent[],
+  activeKinds: ReadonlySet<AnthropicToolEventKind>,
+): AnthropicToolEvent[] {
+  const surviving: AnthropicToolEvent[] = [];
+  for (const event of events) {
+    if (activeKinds.has(event.kind)) surviving.push(event);
+  }
+  return surviving;
+}
+
+function orderedAnthropicToolEventsEqual(
+  left: readonly AnthropicToolEvent[],
+  right: readonly AnthropicToolEvent[],
+): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    const leftEvent = left[index];
+    const rightEvent = right[index];
+    if (
+      !leftEvent ||
+      !rightEvent ||
+      leftEvent.kind !== rightEvent.kind ||
+      leftEvent.id !== rightEvent.id
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+type AnthropicServerToolResultErrorFields = {
+  code: string;
+  toolCallId: string;
+  toolName: string;
+  detail?: string;
+};
+
+const ANTHROPIC_SERVER_TOOL_RESULT_ERROR_FIELDS = new Set([
+  "name",
+  "provider",
+  "code",
+  "toolCallId",
+  "toolName",
+  "detail",
+]);
+
+function readOwnEnumerableDataProperty(
+  value: object,
+  key: string,
+): { present: boolean; value?: unknown } | undefined {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined) return { present: false };
+    if (!Object.hasOwn(descriptor, "value") || descriptor.enumerable !== true) {
+      return undefined;
+    }
+    return { present: true, value: descriptor.value };
+  } catch {
+    return undefined;
+  }
+}
+
+function readAnthropicServerToolResultErrorFields(
+  value: unknown,
+): AnthropicServerToolResultErrorFields | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    if (
+      Object.keys(value).some((key) => !ANTHROPIC_SERVER_TOOL_RESULT_ERROR_FIELDS.has(key))
+    ) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  const name = readOwnEnumerableDataProperty(value, "name");
+  const provider = readOwnEnumerableDataProperty(value, "provider");
+  const code = readOwnEnumerableDataProperty(value, "code");
+  const toolCallId = readOwnEnumerableDataProperty(value, "toolCallId");
+  const toolName = readOwnEnumerableDataProperty(value, "toolName");
+  const detail = readOwnEnumerableDataProperty(value, "detail");
+  if (
+    name?.present !== true ||
+    name.value !== "AnthropicServerToolResultError" ||
+    provider?.present !== true ||
+    provider.value !== "anthropic" ||
+    code?.present !== true ||
+    typeof code.value !== "string" ||
+    code.value.length === 0 ||
+    toolCallId?.present !== true ||
+    typeof toolCallId.value !== "string" ||
+    toolCallId.value.length === 0 ||
+    toolName?.present !== true ||
+    typeof toolName.value !== "string" ||
+    toolName.value.length === 0 ||
+    detail === undefined ||
+    (detail.present && detail.value !== undefined && typeof detail.value !== "string")
+  ) {
+    return undefined;
+  }
+  return {
+    code: code.value,
+    toolCallId: toolCallId.value,
+    toolName: toolName.value,
+    ...(typeof detail.value === "string" ? { detail: detail.value } : {}),
+  };
+}
+
+function anthropicProviderResultsEqual(left: unknown, right: unknown): boolean {
+  const leftError = readAnthropicServerToolResultErrorFields(left);
+  const rightError = readAnthropicServerToolResultErrorFields(right);
+  if (leftError || rightError) {
+    return leftError !== undefined &&
+      rightError !== undefined &&
+      leftError.code === rightError.code &&
+      leftError.toolCallId === rightError.toolCallId &&
+      leftError.toolName === rightError.toolName &&
+      leftError.detail === rightError.detail;
+  }
+  return jsonValuesEqual(left, right);
+}
+
+function validateAnthropicProviderReplay(
+  message: Extract<ModelRuntimePromptMessage, { readonly role: "assistant" }>,
+  rawAssistantMessages: unknown,
+  currentProviderToolNamesById: AnthropicProviderToolNameRegistry,
+  currentCanonicalProviderToolNamesById: AnthropicProviderToolNameRegistry,
+): ValidatedAnthropicReplay {
+  const nextProviderToolNamesById = new Map(currentProviderToolNamesById);
+  const messages = validateAnthropicRawAssistantMessages(
+    rawAssistantMessages,
+    nextProviderToolNamesById,
+  );
+  assertBoundedAnthropicProviderToolState(nextProviderToolNamesById);
+  const replayProviderToolNamesById = new Map(currentProviderToolNamesById);
+  const rawClientCalls: CanonicalProviderCall[] = [];
+  const rawProviderCalls: AnthropicProviderToolUse[] = [];
+  const rawProviderResults: AnthropicServerToolResult[] = [];
+  const rawToolEvents: AnthropicToolEvent[] = [];
+  const rawToolCallIds = new Set(currentProviderToolNamesById.keys());
+
+  for (const content of messages) {
+    for (const block of content) {
+      if (block.type === "tool_use") {
+        const input = block.input === undefined ? {} : readRecord(block.input);
+        if (
+          typeof block.id !== "string" ||
+          block.id.length === 0 ||
+          typeof block.name !== "string" ||
+          block.name.length === 0 ||
+          !input ||
+          rawToolCallIds.has(block.id)
+        ) {
+          throw invalidAnthropicClientCallHistory();
+        }
+        rawToolCallIds.add(block.id);
+        rawClientCalls.push({
+          id: block.id,
+          name: block.name,
+          input,
+        });
+        rawToolEvents.push({ kind: "client-call", id: block.id });
+        continue;
+      }
+      const call = parseAnthropicProviderToolUse(block);
+      if (call) {
+        if (rawToolCallIds.has(call.toolCallId)) {
+          throw invalidAnthropicProviderCallHistory();
+        }
+        rawToolCallIds.add(call.toolCallId);
+        rawProviderCalls.push(call);
+        rawToolEvents.push({ kind: "provider-call", id: call.toolCallId });
+        replayProviderToolNamesById.set(call.toolCallId, call.toolName);
+        continue;
+      }
+      if (
+        typeof block.type !== "string" ||
+        !isAnthropicProviderToolResultBlockType(block.type)
+      ) {
+        continue;
+      }
+      const result = parseAnthropicServerToolResult(
+        block,
+        replayProviderToolNamesById,
+      );
+      if (!result) {
+        throw invalidAnthropicProviderResultHistory();
+      }
+      rawProviderResults.push(result);
+      rawToolEvents.push({ kind: "provider-result", id: result.toolCallId });
+      replayProviderToolNamesById.delete(result.toolCallId);
+    }
+  }
+
+  const providerToolCallProjection = (message.providerToolCalls ?? []).map((call) => ({
+    id: call.toolCallId,
+    name: call.toolName,
+    input: call.input,
+  }));
+  const contentToolCallProjection: CanonicalProviderCall[] = [];
+  const canonicalClientCalls: CanonicalProviderCall[] = [];
+  const canonicalResults: CanonicalProviderResult[] = [];
+  const contentToolEvents: AnthropicToolEvent[] = [];
+  const contentCallIds = new Set<string>();
+  const canonicalResultIds = new Set<string>();
+
+  rejectDuplicateAnthropicCallIds(
+    providerToolCallProjection,
+    invalidAnthropicProviderCallHistory,
+  );
+  const providerToolCallIds = new Set(
+    providerToolCallProjection.map((call) => call.id),
+  );
+  for (const part of message.content) {
+    if (part.type === "tool-call") {
+      const call = {
+        id: part.toolCallId,
+        name: part.toolName,
+        input: part.input,
+      };
+      if (contentCallIds.has(call.id)) {
+        throw part.providerExecuted === true
+          ? invalidAnthropicProviderCallHistory()
+          : invalidAnthropicClientCallHistory();
+      }
+      contentCallIds.add(call.id);
+      if (part.providerExecuted === true) {
+        contentToolCallProjection.push(call);
+        contentToolEvents.push({ kind: "provider-call", id: call.id });
+      } else {
+        canonicalClientCalls.push(call);
+        contentToolEvents.push({ kind: "client-call", id: call.id });
+      }
+      continue;
+    }
+    if (part.type !== "tool-result") {
+      continue;
+    }
+    const result: CanonicalProviderResult = {
+      id: part.toolCallId,
+      name: part.toolName,
+      result: part.result,
+      isError: part.isError === true,
+    };
+    if (canonicalResultIds.has(result.id)) {
+      throw invalidAnthropicProviderResultHistory();
+    }
+    canonicalResultIds.add(result.id);
+    canonicalResults.push(result);
+    contentToolEvents.push({ kind: "provider-result", id: result.id });
+  }
+
+  for (const clientCall of canonicalClientCalls) {
+    if (providerToolCallIds.has(clientCall.id)) {
+      throw invalidAnthropicClientCallHistory();
+    }
+  }
+
+  if (
+    providerToolCallProjection.length > 0 &&
+    contentToolCallProjection.length > 0 &&
+    !orderedAnthropicCallsEqual(
+      providerToolCallProjection,
+      contentToolCallProjection,
+    )
+  ) {
+    throw invalidAnthropicProviderCallHistory();
+  }
+  const canonicalProviderCalls = providerToolCallProjection.length > 0
+    ? providerToolCallProjection
+    : contentToolCallProjection;
+
+  // Provider-native tool_use blocks have an exact canonical representation.
+  // Correlate every surviving client projection by occurrence. When that
+  // projection is absent (for example, after compaction), retain structurally
+  // validated raw-only history for compatibility.
+  if (
+    canonicalClientCalls.length > 0 &&
+    !orderedAnthropicCallsEqual(rawClientCalls, canonicalClientCalls)
+  ) {
+    throw invalidAnthropicClientCallHistory();
+  }
+
+  // Old persisted history can retain provider-native raw content after its
+  // canonical provider-tool projection has been compacted. It remains safe to
+  // replay after structural validation only when no provider semantics survive.
+  if (
+    canonicalProviderCalls.length > 0 ||
+    canonicalResults.length > 0
+  ) {
+    if (
+      rawProviderCalls.length !== canonicalProviderCalls.length ||
+      rawProviderResults.length !== canonicalResults.length
+    ) {
+      if (rawProviderCalls.length !== canonicalProviderCalls.length) {
+        throw invalidAnthropicProviderCallHistory();
+      }
+      throw invalidAnthropicProviderResultHistory();
+    }
+
+    for (let index = 0; index < canonicalProviderCalls.length; index += 1) {
+      const raw = rawProviderCalls[index];
+      const canonical = canonicalProviderCalls[index];
+      if (
+        !raw ||
+        !canonical ||
+        raw.toolCallId !== canonical.id ||
+        raw.toolName !== canonical.name ||
+        !jsonValuesEqual(raw.input, canonical.input, true)
+      ) {
+        throw invalidAnthropicProviderCallHistory();
+      }
+    }
+
+    for (let index = 0; index < canonicalResults.length; index += 1) {
+      const raw = rawProviderResults[index];
+      const canonical = canonicalResults[index];
+      if (
+        !raw ||
+        !canonical ||
+        raw.toolCallId !== canonical.id ||
+        raw.toolName !== canonical.name ||
+        (raw.isError === true) !== canonical.isError ||
+        !anthropicProviderResultsEqual(raw.result, canonical.result)
+      ) {
+        throw invalidAnthropicProviderResultHistory();
+      }
+    }
+  }
+
+  // providerToolCalls is a message-level projection without positions relative
+  // to assistant content. For each event kind that survives in content, filter
+  // compacted kinds from the raw sequence and prove the complete observable
+  // interleaving, including provider results.
+  const activeContentEventKinds = new Set<AnthropicToolEventKind>();
+  if (canonicalClientCalls.length > 0) {
+    activeContentEventKinds.add("client-call");
+  }
+  if (contentToolCallProjection.length > 0) {
+    activeContentEventKinds.add("provider-call");
+  }
+  if (canonicalResults.length > 0) {
+    activeContentEventKinds.add("provider-result");
+  }
+  if (
+    !orderedAnthropicToolEventsEqual(
+      survivingAnthropicToolEvents(rawToolEvents, activeContentEventKinds),
+      survivingAnthropicToolEvents(contentToolEvents, activeContentEventKinds),
+    )
+  ) {
+    throw invalidAnthropicToolEventOrder();
+  }
+
+  const nextCanonicalProviderToolNamesById = new Map(
+    currentCanonicalProviderToolNamesById,
+  );
+  for (const call of canonicalProviderCalls) {
+    if (nextCanonicalProviderToolNamesById.has(call.id)) {
+      throw invalidAnthropicProviderCallHistory();
+    }
+    nextCanonicalProviderToolNamesById.set(call.id, call.name);
+  }
+  for (const result of canonicalResults) {
+    if (nextCanonicalProviderToolNamesById.get(result.id) !== result.name) {
+      throw invalidAnthropicProviderResultHistory();
+    }
+    nextCanonicalProviderToolNamesById.delete(result.id);
+  }
+  assertBoundedAnthropicProviderToolState(
+    nextCanonicalProviderToolNamesById,
+  );
+
+  return {
+    messages,
+    nextProviderToolNamesById,
+    nextCanonicalProviderToolNamesById,
+  };
+}
+
+function requiresExactAnthropicProviderReplay(
+  message: Extract<ModelRuntimePromptMessage, { readonly role: "assistant" }>,
+): boolean {
+  return message.content.some((part) =>
+    part.type === "tool-result" ||
+    part.type === "tool-call" && part.providerExecuted === true
+  );
+}
+
+function shouldCompactAnthropicToolRound(
+  message: Extract<ModelRuntimePromptMessage, { readonly role: "assistant" }>,
+  index: number,
+  lastHistoricalAssistantTextIndex: number,
+): boolean {
+  return index < lastHistoricalAssistantTextIndex &&
+    message.content.some((part) => part.type === "tool-call");
+}
+
+function connectAnthropicReplayIndices(
+  dependencies: Map<number, Set<number>>,
+  left: number,
+  right: number,
+): void {
+  if (left === right) return;
+  const leftDependencies = dependencies.get(left) ?? new Set<number>();
+  leftDependencies.add(right);
+  dependencies.set(left, leftDependencies);
+  const rightDependencies = dependencies.get(right) ?? new Set<number>();
+  rightDependencies.add(left);
+  dependencies.set(right, rightDependencies);
+}
+
+function planAnthropicRawAssistantReplay(
+  prompt: readonly ModelRuntimePromptMessage[],
+  rawAssistantMessagesByIndex: ReadonlyMap<number, unknown[]>,
+  lastUserIndex: number,
+  lastHistoricalAssistantTextIndex: number,
+): Set<number> {
+  const replayIndices = new Set<number>();
+  const dependencies = new Map<number, Set<number>>();
+  const pendingProviderCallIndexById = new Map<string, number>();
+
+  for (const [index, message] of prompt.entries()) {
+    if (message.role === "system" || message.role === "user") {
+      pendingProviderCallIndexById.clear();
+      continue;
+    }
+    if (message.role !== "assistant") continue;
+
+    const rawAssistantMessages = rawAssistantMessagesByIndex.get(index);
+    if (!rawAssistantMessages) continue;
+    const shouldCompactCompletedToolRound = shouldCompactAnthropicToolRound(
+      message,
+      index,
+      lastHistoricalAssistantTextIndex,
+    );
+    if (
+      requiresExactAnthropicProviderReplay(message) ||
+      !shouldCompactCompletedToolRound && index >= lastUserIndex
+    ) {
+      replayIndices.add(index);
+    }
+
+    let remainingBlockCount = MAX_ANTHROPIC_RAW_ASSISTANT_BLOCKS;
+    const rawMessageCount = Math.min(
+      rawAssistantMessages.length,
+      MAX_ANTHROPIC_RAW_ASSISTANT_MESSAGES,
+    );
+    for (let rawMessageIndex = 0; rawMessageIndex < rawMessageCount; rawMessageIndex++) {
+      const rawContent = rawAssistantMessages[rawMessageIndex];
+      if (!Array.isArray(rawContent)) continue;
+      const rawBlockCount = Math.min(rawContent.length, remainingBlockCount);
+      remainingBlockCount -= rawBlockCount;
+      for (let rawBlockIndex = 0; rawBlockIndex < rawBlockCount; rawBlockIndex++) {
+        const value = rawContent[rawBlockIndex];
+        const block = readRecord(value);
+        if (!block || typeof block.type !== "string") continue;
+        if (
+          (block.type === "server_tool_use" || block.type === "mcp_tool_use") &&
+          typeof block.id === "string" &&
+          block.id.length > 0
+        ) {
+          pendingProviderCallIndexById.set(block.id, index);
+          continue;
+        }
+        if (
+          !isAnthropicProviderToolResultBlockType(block.type) ||
+          typeof block.tool_use_id !== "string" ||
+          block.tool_use_id.length === 0
+        ) {
+          continue;
+        }
+        const providerCallIndex = pendingProviderCallIndexById.get(block.tool_use_id);
+        if (providerCallIndex !== undefined) {
+          connectAnthropicReplayIndices(dependencies, providerCallIndex, index);
+          pendingProviderCallIndexById.delete(block.tool_use_id);
+        }
+      }
+      if (remainingBlockCount === 0) break;
+    }
+  }
+
+  const pendingReplayIndices = [...replayIndices];
+  for (let cursor = 0; cursor < pendingReplayIndices.length; cursor++) {
+    const index = pendingReplayIndices[cursor];
+    if (index === undefined) continue;
+    for (const dependency of dependencies.get(index) ?? []) {
+      if (replayIndices.has(dependency)) continue;
+      replayIndices.add(dependency);
+      pendingReplayIndices.push(dependency);
+    }
+  }
+
+  return replayIndices;
+}
+
 function toAnthropicUserContent(
-  parts: Extract<RuntimePromptMessage, { role: "user" }>["content"],
+  parts: Extract<ModelRuntimePromptMessage, { readonly role: "user" }>["content"],
 ): Array<Record<string, unknown>> {
   const content: Array<Record<string, unknown>> = [];
 
@@ -200,12 +805,28 @@ function resolveAnthropicCacheControlBlock(
   return { type: "ephemeral" };
 }
 
+function createValidatedAnthropicProviderToolCorrelationState(
+  canonicalProviderToolNamesById: ReadonlyMap<string, string>,
+  rawProviderToolNamesById: ReadonlyMap<string, string>,
+): AnthropicProviderToolNameRegistry {
+  assertBoundedAnthropicProviderToolState(canonicalProviderToolNamesById);
+  assertBoundedAnthropicProviderToolState(rawProviderToolNamesById);
+  const correlated = new Map<string, string>();
+  for (const [toolCallId, toolName] of canonicalProviderToolNamesById) {
+    if (rawProviderToolNamesById.get(toolCallId) === toolName) {
+      correlated.set(toolCallId, toolName);
+    }
+  }
+  return correlated;
+}
+
 function toAnthropicMessages(
-  prompt: RuntimePromptMessage[],
+  prompt: readonly ModelRuntimePromptMessage[],
   systemCacheControl?: { type: "ephemeral"; ttl?: "1h" },
 ): {
   system?: string | Array<Record<string, unknown>>;
   messages: AnthropicCompatibleMessage[];
+  providerToolNamesById: AnthropicProviderToolNameRegistry;
 } {
   const systemParts: string[] = [];
   const messages: AnthropicCompatibleMessage[] = [];
@@ -215,14 +836,32 @@ function toAnthropicMessages(
     message.role === "assistant" &&
     message.content.some((part) => part.type === "text" && part.text.length > 0)
   );
+  const rawAssistantMessagesByIndex = new Map<number, unknown[]>();
+  for (const [index, message] of prompt.entries()) {
+    if (message.role !== "assistant") continue;
+    const rawAssistantMessages = readAnthropicRawAssistantMessagesValue(message);
+    if (rawAssistantMessages) {
+      rawAssistantMessagesByIndex.set(index, rawAssistantMessages);
+    }
+  }
+  const rawReplayIndices = planAnthropicRawAssistantReplay(
+    prompt,
+    rawAssistantMessagesByIndex,
+    lastUserIndex,
+    lastHistoricalAssistantTextIndex,
+  );
   let skippingHistoricalToolResults = false;
   let pendingToolUseIds = new Set<string>();
+  let rawProviderToolNamesById: AnthropicProviderToolNameRegistry = new Map();
+  let canonicalProviderToolNamesById: AnthropicProviderToolNameRegistry = new Map();
 
   for (const [index, message] of prompt.entries()) {
     switch (message.role) {
       case "system":
         skippingHistoricalToolResults = false;
         pendingToolUseIds = new Set();
+        rawProviderToolNamesById = new Map();
+        canonicalProviderToolNamesById = new Map();
         if (message.content.length > 0) {
           systemParts.push(message.content);
         }
@@ -230,12 +869,38 @@ function toAnthropicMessages(
       case "user":
         skippingHistoricalToolResults = false;
         pendingToolUseIds = new Set();
+        rawProviderToolNamesById = new Map();
+        canonicalProviderToolNamesById = new Map();
         pushAnthropicUserContent(messages, toAnthropicUserContent(message.content));
         break;
       case "assistant": {
         skippingHistoricalToolResults = false;
-        const shouldCompactCompletedToolRound = index < lastHistoricalAssistantTextIndex &&
-          message.content.some((part) => part.type === "tool-call");
+        const shouldCompactCompletedToolRound = shouldCompactAnthropicToolRound(
+          message,
+          index,
+          lastHistoricalAssistantTextIndex,
+        );
+        const rawAssistantMessages = rawAssistantMessagesByIndex.get(index);
+        if (rawAssistantMessages && rawReplayIndices.has(index)) {
+          const replay = validateAnthropicProviderReplay(
+            message,
+            rawAssistantMessages,
+            rawProviderToolNamesById,
+            canonicalProviderToolNamesById,
+          );
+          rawProviderToolNamesById = replay.nextProviderToolNamesById;
+          canonicalProviderToolNamesById = replay.nextCanonicalProviderToolNamesById;
+          pendingToolUseIds = new Set();
+          for (const rawContent of replay.messages) {
+            messages.push({ role: "assistant", content: rawContent });
+            for (const block of rawContent) {
+              if (block.type === "tool_use" && typeof block.id === "string") {
+                pendingToolUseIds.add(block.id);
+              }
+            }
+          }
+          break;
+        }
         const assistantContent = shouldCompactCompletedToolRound
           ? message.content.filter((part) => part.type === "text" && part.text.length > 0)
           : message.content;
@@ -267,6 +932,16 @@ function toAnthropicMessages(
                 thinking: part.text ?? "",
                 ...(typeof part.signature === "string" ? { signature: part.signature } : {}),
               };
+            }
+            if (part.type === "tool-result") {
+              throw new TypeError(
+                "Anthropic provider-executed assistant tool results require exact raw replay metadata",
+              );
+            }
+            if (part.providerExecuted === true) {
+              throw new TypeError(
+                "Anthropic provider-executed assistant tool calls require exact raw replay metadata",
+              );
             }
             return {
               type: "tool_use",
@@ -306,7 +981,13 @@ function toAnthropicMessages(
   }
 
   if (systemParts.length === 0) {
-    return { messages };
+    return {
+      messages,
+      providerToolNamesById: createValidatedAnthropicProviderToolCorrelationState(
+        canonicalProviderToolNamesById,
+        rawProviderToolNamesById,
+      ),
+    };
   }
 
   const joined = systemParts.join("\n\n");
@@ -318,10 +999,21 @@ function toAnthropicMessages(
         cache_control: systemCacheControl,
       }],
       messages,
+      providerToolNamesById: createValidatedAnthropicProviderToolCorrelationState(
+        canonicalProviderToolNamesById,
+        rawProviderToolNamesById,
+      ),
     };
   }
 
-  return { system: joined, messages };
+  return {
+    system: joined,
+    messages,
+    providerToolNamesById: createValidatedAnthropicProviderToolCorrelationState(
+      canonicalProviderToolNamesById,
+      rawProviderToolNamesById,
+    ),
+  };
 }
 
 const ANTHROPIC_TOOL_VERSION_ALIASES: Record<string, string> = {
@@ -343,8 +1035,7 @@ function resolveAnthropicProviderType(rawType: string): string {
 }
 
 function toAnthropicTools(
-  tools: RuntimeToolDefinition[] | undefined,
-  toolsCacheControl?: { type: "ephemeral"; ttl?: "1h" },
+  tools: readonly ModelRuntimeToolDefinition[] | undefined,
 ): Array<Record<string, unknown>> | undefined {
   if (!tools) {
     return undefined;
@@ -371,6 +1062,16 @@ function toAnthropicTools(
       continue;
     }
 
+    if (rawType === "mcp_toolset") {
+      const args = normalizeAnthropicMcpToolsetArgs(tool.args);
+      normalized.push({
+        type: "mcp_toolset",
+        mcp_server_name: tool.name,
+        ...args,
+      });
+      continue;
+    }
+
     normalized.push({
       type: resolveAnthropicProviderType(rawType),
       name: tool.name,
@@ -382,21 +1083,63 @@ function toAnthropicTools(
     return undefined;
   }
 
-  if (toolsCacheControl) {
-    const lastIndex = normalized.length - 1;
-    normalized[lastIndex] = {
-      ...normalized[lastIndex],
-      cache_control: toolsCacheControl,
-    };
-  }
-
   return normalized;
+}
+
+function mergeAnthropicMcpToolsets(
+  tools: Array<Record<string, unknown>> | undefined,
+  mcpConfiguration: AnthropicMcpRequestConfiguration | undefined,
+): Array<Record<string, unknown>> | undefined {
+  if (!mcpConfiguration) return tools;
+
+  const merged = [...(tools ?? [])];
+  const explicitServerNames = new Set(
+    merged.flatMap((tool) =>
+      tool.type === "mcp_toolset" && typeof tool.mcp_server_name === "string"
+        ? [tool.mcp_server_name]
+        : []
+    ),
+  );
+
+  for (const defaultToolset of mcpConfiguration.defaultToolsets) {
+    if (explicitServerNames.has(defaultToolset.mcp_server_name)) {
+      if (mcpConfiguration.legacyConfiguredServerNames.has(defaultToolset.mcp_server_name)) {
+        throw new TypeError(
+          "Anthropic MCP tool configuration must use either mcpServers or a provider tool",
+        );
+      }
+      continue;
+    }
+    merged.push(defaultToolset);
+  }
+  return merged;
+}
+
+function applyAnthropicToolsCacheControl(
+  tools: Array<Record<string, unknown>> | undefined,
+  cacheControl: { type: "ephemeral"; ttl?: "1h" } | undefined,
+): Array<Record<string, unknown>> | undefined {
+  if (!tools || !cacheControl) return tools;
+  const lastIndex = tools.length - 1;
+  return tools.map((tool, index) =>
+    index === lastIndex ? { ...tool, cache_control: cacheControl } : tool
+  );
+}
+
+function containsAnthropicMcpToolset(
+  tools: Array<Record<string, unknown>> | undefined,
+): boolean {
+  return tools?.some((tool) => tool.type === "mcp_toolset") ?? false;
 }
 
 function getAnthropicModelCapabilities(
   modelId: string,
 ): { maxOutputTokens: number; isKnownModel: boolean } {
-  if (modelId.includes("claude-opus-4-6")) {
+  if (
+    modelId.includes("claude-opus-4-8") ||
+    modelId.includes("claude-opus-4-7") ||
+    modelId.includes("claude-opus-4-6")
+  ) {
     return { maxOutputTokens: 128_000, isKnownModel: true };
   }
   if (modelId.includes("claude-sonnet-4-6")) {
@@ -437,12 +1180,17 @@ function resolveAnthropicMaxTokens(
 }
 
 function resolveAnthropicThinkingBudget(
-  option: ProviderReasoningOption | undefined,
+  option: RuntimeReasoningOption | undefined,
 ): number | undefined {
   if (!option || option.enabled !== true) {
     return undefined;
   }
-  if (typeof option.budgetTokens === "number" && option.budgetTokens >= 1024) {
+  if (option.budgetTokens !== undefined) {
+    if (!Number.isSafeInteger(option.budgetTokens) || option.budgetTokens < 1024) {
+      throw new TypeError(
+        "Anthropic reasoning budgetTokens must be a safe integer of at least 1024",
+      );
+    }
     return option.budgetTokens;
   }
   switch (option.effort) {
@@ -462,27 +1210,46 @@ function resolveAnthropicProviderThinkingBudget(
   options: Record<string, unknown>,
 ): number | undefined {
   const thinking = options.thinking;
-  if (thinking === null || typeof thinking !== "object" || Array.isArray(thinking)) {
+  if (thinking === undefined) {
     return undefined;
   }
+  if (thinking === null || typeof thinking !== "object" || Array.isArray(thinking)) {
+    throw new TypeError("Anthropic provider thinking must be an object");
+  }
   const record = thinking as Record<string, unknown>;
+  if (typeof record.type !== "string" || record.type.length === 0) {
+    throw new TypeError("Anthropic provider thinking.type must be a non-empty string");
+  }
+  const budgetTokens = record.budget_tokens;
+  if (
+    budgetTokens !== undefined &&
+    (!Number.isSafeInteger(budgetTokens) || (budgetTokens as number) < 1024)
+  ) {
+    throw new TypeError(
+      "Anthropic provider thinking.budget_tokens must be a safe integer of at least 1024",
+    );
+  }
   if (record.type !== "enabled") {
     return undefined;
   }
-  const budgetTokens = record.budget_tokens;
-  if (typeof budgetTokens === "number" && Number.isFinite(budgetTokens) && budgetTokens >= 1024) {
-    return budgetTokens;
+  if (budgetTokens === undefined) {
+    throw new TypeError(
+      "Anthropic provider thinking.budget_tokens must be a safe integer of at least 1024",
+    );
   }
-  return undefined;
+  return budgetTokens as number;
 }
 
-export function buildAnthropicMessagesRequest(
+export function buildAnthropicMessagesRequestWithCorrelationState(
   modelId: string,
   providerName: string,
   options: OpenAICompatibleLanguageOptions,
   stream: boolean,
   warnings: WarningCollector,
-): AnthropicCompatibleRequest {
+): {
+  body: AnthropicCompatibleRequest;
+  providerToolNamesById: AnthropicProviderToolNameRegistry;
+} {
   const systemCacheControl = resolveAnthropicCacheControlBlock(
     options.cacheControl?.system,
   );
@@ -490,13 +1257,38 @@ export function buildAnthropicMessagesRequest(
     options.cacheControl?.tools,
   );
 
-  const { system, messages } = toAnthropicMessages(options.prompt, systemCacheControl);
-  const anthropicTools = toAnthropicTools(options.tools, toolsCacheControl);
+  const { system, messages, providerToolNamesById } = toAnthropicMessages(
+    options.prompt,
+    systemCacheControl,
+  );
+  const mcpConfiguration = normalizeAnthropicMcpServers(options.mcpServers);
+  const callerTools = toAnthropicTools(options.tools);
+  const anthropicTools = applyAnthropicToolsCacheControl(
+    mergeAnthropicMcpToolsets(callerTools, mcpConfiguration),
+    toolsCacheControl,
+  );
   const rawProviderOptions = readProviderOptions(
     options.providerOptions,
     "anthropic",
     providerName,
   );
+  if (
+    mcpConfiguration &&
+    (Object.hasOwn(rawProviderOptions, "mcp_servers") ||
+      Object.hasOwn(rawProviderOptions, "tools"))
+  ) {
+    throw new TypeError(
+      "Anthropic MCP configuration must not be split between mcpServers and providerOptions",
+    );
+  }
+  if (
+    Object.hasOwn(rawProviderOptions, "tools") &&
+    containsAnthropicMcpToolset(callerTools)
+  ) {
+    throw new TypeError(
+      "Anthropic MCP toolsets must not be defined in both tools and providerOptions",
+    );
+  }
   const thinkingBudget = resolveAnthropicThinkingBudget(options.reasoning);
   const providerThinkingBudget = resolveAnthropicProviderThinkingBudget(rawProviderOptions);
   const effectiveThinkingBudget = thinkingBudget ?? providerThinkingBudget;
@@ -602,12 +1394,33 @@ export function buildAnthropicMessagesRequest(
     ...(typeof options.userId === "string" && options.userId.length > 0
       ? { metadata: { user_id: options.userId } }
       : {}),
-    ...(options.mcpServers && options.mcpServers.length > 0
-      ? { mcp_servers: deepSnakeCase(options.mcpServers) as unknown[] }
-      : {}),
+    ...(mcpConfiguration ? { mcp_servers: mcpConfiguration.servers } : {}),
     ...(options.anthropicContainer !== undefined ? { container: options.anthropicContainer } : {}),
   };
 
   Object.assign(body, rawProviderOptions);
-  return body;
+  if (thinkingBudget !== undefined || providerThinkingBudget !== undefined) {
+    body.thinking = { type: "enabled", budget_tokens: effectiveThinkingBudget };
+  }
+  assertAnthropicMcpRequestContract(body);
+  return {
+    body,
+    providerToolNamesById: new Map(providerToolNamesById),
+  };
+}
+
+export function buildAnthropicMessagesRequest(
+  modelId: string,
+  providerName: string,
+  options: OpenAICompatibleLanguageOptions,
+  stream: boolean,
+  warnings: WarningCollector,
+): AnthropicCompatibleRequest {
+  return buildAnthropicMessagesRequestWithCorrelationState(
+    modelId,
+    providerName,
+    options,
+    stream,
+    warnings,
+  ).body;
 }

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -43,7 +43,7 @@ export interface OpenAICompatibleLanguageOptions extends ModelRuntimeCallOptions
   mcpServers?: readonly Record<string, unknown>[];
 }
 
-/** @deprecated Import `ModelRuntimeToolDefinition` from `veryfront/provider` instead. */
+/** @deprecated Import `ModelRuntimeToolDefinition` from `veryfront/provider/shared` instead. */
 export type RuntimeToolDefinition = ModelRuntimeToolDefinition;
 
 type WarningCollector = {

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
@@ -4,6 +4,7 @@ import { ProviderOverloadedError, ProviderRequestError } from "veryfront/provide
 import {
   addAnthropicUsage,
   extractAnthropicUsage,
+  MAX_ANTHROPIC_RETAINED_CONTENT_BYTES,
   MAX_ANTHROPIC_RETAINED_CONTENT_ITEMS,
   streamAnthropicCompatibleParts,
 } from "./anthropic-stream.ts";
@@ -155,6 +156,10 @@ async function waitForCondition(
 
 function data(payload: unknown): string {
   return `event: ${(payload as { type: string }).type}\r\ndata: ${JSON.stringify(payload)}\r\n\r\n`;
+}
+
+function utf8StringWithByteLength(byteLength: number): string {
+  return `${"é".repeat(Math.floor(byteLength / 2))}${byteLength % 2 === 0 ? "" : "x"}`;
 }
 
 describe("ext-llm-anthropic/anthropic-stream", () => {
@@ -438,6 +443,47 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
       () => collectParts(streamFromText(events.join(""))),
       ProviderRequestError,
       `retained content exceeded ${MAX_ANTHROPIC_RETAINED_CONTENT_ITEMS} items`,
+    );
+  });
+
+  it("accepts the exact aggregate UTF-8 byte limit and rejects limit plus one", async () => {
+    const contentBlock = { type: "text", text: "" };
+    const initialBytes = new TextEncoder().encode(JSON.stringify(contentBlock)).byteLength;
+    const remainingBytes = MAX_ANTHROPIC_RETAINED_CONTENT_BYTES - initialBytes;
+    const quarter = Math.floor(remainingBytes / 4);
+    const chunkBytes = [quarter, quarter, quarter, remainingBytes - quarter * 3];
+    const lifecycle = (lastChunkExtraBytes: number) =>
+      [
+        data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+        data({ type: "content_block_start", index: 0, content_block: contentBlock }),
+        ...chunkBytes.map((byteLength, index) =>
+          data({
+            type: "content_block_delta",
+            index: 0,
+            delta: {
+              type: "text_delta",
+              text: utf8StringWithByteLength(
+                byteLength + (index === chunkBytes.length - 1 ? lastChunkExtraBytes : 0),
+              ),
+            },
+          })
+        ),
+        data({ type: "content_block_stop", index: 0 }),
+        data({ type: "message_delta", delta: { stop_reason: "end_turn" } }),
+        data({ type: "message_stop" }),
+      ].join("");
+
+    const exactParts = await collectParts(streamFromText(lifecycle(0)));
+    assertEquals(exactParts.at(-1), {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "end_turn" },
+      usage: { inputTokens: 1, totalTokens: 1 },
+    });
+
+    await assertRejects(
+      () => collectParts(streamFromText(lifecycle(1))),
+      ProviderRequestError,
+      `retained content exceeded ${MAX_ANTHROPIC_RETAINED_CONTENT_BYTES} UTF-8 bytes`,
     );
   });
 

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
@@ -1,7 +1,12 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { ProviderRequestError } from "veryfront/provider/shared";
-import { streamAnthropicCompatibleParts } from "./anthropic-stream.ts";
+import { ProviderOverloadedError, ProviderRequestError } from "veryfront/provider/shared";
+import {
+  addAnthropicUsage,
+  extractAnthropicUsage,
+  MAX_ANTHROPIC_RETAINED_CONTENT_ITEMS,
+  streamAnthropicCompatibleParts,
+} from "./anthropic-stream.ts";
 
 type AnthropicStreamOptions = Parameters<typeof streamAnthropicCompatibleParts>[1];
 
@@ -49,6 +54,18 @@ function streamFromChunksWithCancelSpy(
         clearTimeout(closeTimer);
       }
       options.onCancel();
+    },
+  });
+}
+
+function streamWithNeverSettlingCancel(text: string): ReadableStream<Uint8Array> {
+  const encoded = new TextEncoder().encode(text);
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoded);
+    },
+    cancel() {
+      return new Promise<void>(() => {});
     },
   });
 }
@@ -105,6 +122,24 @@ async function nextWithTimeout<T>(
   }
 }
 
+async function promiseWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`timed out after ${timeoutMs}ms waiting for promise`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 async function waitForCondition(
   condition: () => boolean,
   timeoutMs: number,
@@ -123,6 +158,96 @@ function data(payload: unknown): string {
 }
 
 describe("ext-llm-anthropic/anthropic-stream", () => {
+  it("sanitizes usage at the exported extraction boundary", () => {
+    assertEquals(
+      extractAnthropicUsage({
+        usage: {
+          input_tokens: Number.MAX_SAFE_INTEGER + 1,
+          output_tokens: 2,
+          cache_creation_input_tokens: 1.5,
+          veryfront: {
+            provider_cost_usd: Number.POSITIVE_INFINITY,
+            cost_credits: 0.25,
+          },
+        },
+      }),
+      {
+        outputTokens: 2,
+        totalTokens: 2,
+        costCredits: 0.25,
+      },
+    );
+  });
+
+  it("rejects invalid trailing-usage timers without locking the body", async () => {
+    for (const invalidTimeout of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const stream = streamFromText("");
+      await assertRejects(
+        () =>
+          collectParts(stream, {
+            clientToolUseTrailingUsageGraceMs: invalidTimeout,
+          }),
+        RangeError,
+      );
+      assertEquals(stream.locked, false);
+    }
+  });
+
+  it("adds continuation usage without emitting unsafe or non-finite totals", () => {
+    assertEquals(
+      addAnthropicUsage(
+        {
+          inputTokens: 8,
+          outputTokens: 2,
+          totalTokens: 10,
+          cacheReadInputTokens: 4,
+          providerCostUsd: 1.25,
+          costUsd: 2,
+        },
+        {
+          inputTokens: 9,
+          outputTokens: 3,
+          totalTokens: 12,
+          cacheReadInputTokens: 6,
+          providerCostUsd: 0.75,
+          costUsd: 3,
+        },
+      ),
+      {
+        inputTokens: 17,
+        outputTokens: 5,
+        totalTokens: 22,
+        cacheReadInputTokens: 10,
+        cachedInputTokens: 10,
+        costUsd: 5,
+        providerCostUsd: 2,
+      },
+    );
+
+    assertEquals(
+      addAnthropicUsage(
+        {
+          inputTokens: Number.MAX_SAFE_INTEGER,
+          totalTokens: Number.MAX_SAFE_INTEGER,
+          providerCostUsd: Number.MAX_VALUE,
+        },
+        {
+          inputTokens: 1,
+          totalTokens: 1,
+          providerCostUsd: Number.MAX_VALUE,
+        },
+      ),
+      undefined,
+    );
+    assertEquals(
+      addAnthropicUsage(undefined, {
+        inputTokens: Number.POSITIVE_INFINITY,
+        providerCostUsd: Number.NaN,
+      }),
+      undefined,
+    );
+  });
+
   it("preserves thinking, text, tool-call assembly, usage, and finish events", async () => {
     const parts = await collectParts(streamFromText([
       data({
@@ -149,19 +274,30 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
       data({
         type: "content_block_start",
         index: 1,
-        content_block: { type: "tool_use", id: "toolu_1", name: "lookup", input: { id: 1 } },
+        content_block: { type: "tool_use", id: "toolu_1", name: "lookup", input: {} },
       }),
       data({
         type: "content_block_delta",
         index: 1,
-        delta: { type: "input_json_delta", partial_json: ', "next": true' },
+        delta: { type: "input_json_delta", partial_json: '{"id":1' },
+      }),
+      data({
+        type: "content_block_delta",
+        index: 1,
+        delta: { type: "input_json_delta", partial_json: ',"next":true}' },
       }),
       data({ type: "content_block_stop", index: 1 }),
+      data({
+        type: "content_block_start",
+        index: 2,
+        content_block: { type: "text", text: "" },
+      }),
       data({
         type: "content_block_delta",
         index: 2,
         delta: { type: "text_delta", text: "Done." },
       }),
+      data({ type: "content_block_stop", index: 2 }),
       data({
         type: "message_delta",
         delta: { stop_reason: "tool_use" },
@@ -176,13 +312,13 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
       { type: "reasoning-delta", id: "thinking-0", delta: " more" },
       { type: "reasoning-end", id: "thinking-0" },
       { type: "tool-input-start", id: "toolu_1", toolName: "lookup" },
-      { type: "tool-input-delta", id: "toolu_1", delta: '{"id":1}' },
-      { type: "tool-input-delta", id: "toolu_1", delta: ', "next": true' },
+      { type: "tool-input-delta", id: "toolu_1", delta: '{"id":1' },
+      { type: "tool-input-delta", id: "toolu_1", delta: ',"next":true}' },
       {
         type: "tool-call",
         toolCallId: "toolu_1",
         toolName: "lookup",
-        input: '{"id":1}, "next": true',
+        input: '{"id":1,"next":true}',
       },
       { type: "text-delta", delta: "Done." },
       {
@@ -200,6 +336,248 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
     ]);
   });
 
+  it("accepts exactly 1 MiB of partial_json then rejects the next byte and cancels", async () => {
+    let cancelCount = 0;
+    const exactBoundaryPartialJson = "é".repeat(524_288);
+    const stream = streamFromChunksWithCancelSpy([
+      [
+        data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+        data({
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "toolu_oversized", name: "bash" },
+        }),
+        data({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: exactBoundaryPartialJson },
+        }),
+        data({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: "x" },
+        }),
+      ].join(""),
+    ], { onCancel: () => cancelCount++ });
+    const iterator = streamAnthropicCompatibleParts(stream)[Symbol.asyncIterator]();
+
+    assertEquals(await iterator.next(), {
+      done: false,
+      value: { type: "tool-input-start", id: "toolu_oversized", toolName: "bash" },
+    });
+    assertEquals(await iterator.next(), {
+      done: false,
+      value: {
+        type: "tool-input-delta",
+        id: "toolu_oversized",
+        delta: exactBoundaryPartialJson,
+      },
+    });
+    await assertRejects(
+      () => iterator.next(),
+      RangeError,
+      "partial_json exceeded 1048576 UTF-8 bytes",
+    );
+    assertEquals(cancelCount, 1);
+    assertEquals(stream.locked, false);
+  });
+
+  it("rejects more than 4096 partial_json deltas and cancels the provider body", async () => {
+    let cancelCount = 0;
+    const stream = streamFromChunksWithCancelSpy([
+      [
+        data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+        data({
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "toolu_many_deltas", name: "bash" },
+        }),
+        ...Array.from({ length: 4_097 }, () =>
+          data({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: "" },
+          })),
+      ].join(""),
+    ], { onCancel: () => cancelCount++ });
+    const iterator = streamAnthropicCompatibleParts(stream)[Symbol.asyncIterator]();
+
+    assertEquals((await iterator.next()).done, false);
+    for (let index = 0; index < 4_096; index++) {
+      assertEquals((await iterator.next()).done, false);
+    }
+    await assertRejects(
+      () => iterator.next(),
+      RangeError,
+      "partial_json exceeded 4096 deltas",
+    );
+    assertEquals(cancelCount, 1);
+    assertEquals(stream.locked, false);
+  });
+
+  it("bounds retained content across many small text deltas", async () => {
+    const events = [
+      data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+      data({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      ...Array.from(
+        { length: MAX_ANTHROPIC_RETAINED_CONTENT_ITEMS },
+        () =>
+          data({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "x" },
+          }),
+      ),
+    ];
+
+    await assertRejects(
+      () => collectParts(streamFromText(events.join(""))),
+      ProviderRequestError,
+      `retained content exceeded ${MAX_ANTHROPIC_RETAINED_CONTENT_ITEMS} items`,
+    );
+  });
+
+  it("caps an unterminated SSE remainder and cancels the provider body", async () => {
+    let cancelCount = 0;
+    const stream = streamFromChunksWithCancelSpy([
+      "x".repeat(8_388_609),
+    ], { onCancel: () => cancelCount++ });
+    const iterator = streamAnthropicCompatibleParts(stream)[Symbol.asyncIterator]();
+
+    await assertRejects(
+      () => iterator.next(),
+      RangeError,
+      "SSE remainder exceeded 8388608 bytes",
+    );
+    assertEquals(cancelCount, 1);
+    assertEquals(stream.locked, false);
+  });
+
+  it("caps a complete SSE event across individually bounded lines and cancels", async () => {
+    let cancelCount = 0;
+    const boundedLine = `:${"x".repeat(4_200_000)}\n`;
+    const stream = streamFromChunksWithCancelSpy([
+      `${boundedLine}${boundedLine}\n`,
+    ], { onCancel: () => cancelCount++ });
+    const iterator = streamAnthropicCompatibleParts(stream)[Symbol.asyncIterator]();
+
+    await assertRejects(
+      () => iterator.next(),
+      RangeError,
+      "SSE event exceeded 8388608 bytes",
+    );
+    assertEquals(cancelCount, 1);
+    assertEquals(stream.locked, false);
+  });
+
+  it("rejects invalid UTF-8 and malformed JSON as contextual stream failures", async () => {
+    let invalidUtf8CancelCount = 0;
+    const invalidUtf8 = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new Uint8Array([
+            ...new TextEncoder().encode("data: "),
+            0xc3,
+            0x28,
+            0x0a,
+            0x0a,
+          ]),
+        );
+      },
+      cancel() {
+        invalidUtf8CancelCount++;
+      },
+    });
+    await assertRejects(
+      () => collectParts(invalidUtf8),
+      ProviderRequestError,
+      "SSE event was not valid UTF-8",
+    );
+    assertEquals(invalidUtf8CancelCount, 1);
+    assertEquals(invalidUtf8.locked, false);
+
+    let malformedJsonCancelCount = 0;
+    const malformedJson = streamFromChunksWithCancelSpy(
+      ['data: {"type":\n\n'],
+      { onCancel: () => malformedJsonCancelCount++ },
+    );
+    await assertRejects(
+      () => collectParts(malformedJson),
+      ProviderRequestError,
+      "SSE event contained malformed JSON",
+    );
+    assertEquals(malformedJsonCancelCount, 1);
+    assertEquals(malformedJson.locked, false);
+  });
+
+  it("fails closed on unknown typed stream events", async () => {
+    let cancelCount = 0;
+    const stream = streamFromChunksWithCancelSpy([
+      data({
+        type: "message_start",
+        message: { usage: { input_tokens: 1 } },
+      }) + data({ type: "future_actionable_event" }),
+    ], { onCancel: () => cancelCount++ });
+
+    await assertRejects(
+      () => collectParts(stream),
+      ProviderRequestError,
+      "unsupported event type",
+    );
+    assertEquals(cancelCount, 1);
+    assertEquals(stream.locked, false);
+  });
+
+  it("surfaces HTTP-200 SSE error events as typed failures and cancels", async () => {
+    let cancelCount = 0;
+    const privateProviderMessage = "private upstream diagnostic";
+    const stream = streamFromChunksWithCancelSpy([
+      data({
+        type: "error",
+        error: { type: "overloaded_error", message: privateProviderMessage },
+      }),
+    ], { onCancel: () => cancelCount++ });
+    const iterator = streamAnthropicCompatibleParts(stream)[Symbol.asyncIterator]();
+
+    const error = await assertRejects(
+      () => iterator.next(),
+      ProviderOverloadedError,
+      "provider overloaded",
+    );
+    if (!(error instanceof ProviderOverloadedError)) {
+      throw new Error("Expected a ProviderOverloadedError");
+    }
+    assertEquals(error.message.includes(privateProviderMessage), false);
+    assertEquals(cancelCount, 1);
+    assertEquals(stream.locked, false);
+  });
+
+  it("cancels the provider body when the consumer returns early", async () => {
+    let cancelCount = 0;
+    const stream = streamFromChunksWithCancelSpy([
+      data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+      data({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "partial" },
+      }),
+    ], { closeDelayMs: 600, onCancel: () => cancelCount++ });
+    const iterator = streamAnthropicCompatibleParts(stream)[Symbol.asyncIterator]();
+
+    assertEquals(await iterator.next(), {
+      done: false,
+      value: { type: "text-delta", delta: "partial" },
+    });
+    await iterator.return?.();
+
+    assertEquals(cancelCount, 1);
+    assertEquals(stream.locked, false);
+  });
+
   it("preserves Veryfront gateway billing metadata from usage envelopes", async () => {
     const parts = await collectParts(streamFromText([
       data({
@@ -212,10 +590,16 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
         },
       }),
       data({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      data({
         type: "content_block_delta",
         index: 0,
         delta: { type: "text_delta", text: "Done." },
       }),
+      data({ type: "content_block_stop", index: 0 }),
       data({
         type: "message_delta",
         delta: { stop_reason: "end_turn" },
@@ -236,6 +620,7 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
           },
         },
       }),
+      data({ type: "message_stop" }),
     ].join("")));
 
     assertEquals(parts, [
@@ -267,24 +652,241 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
 
   it("emits zero-length reasoning blocks for redacted thinking", async () => {
     const parts = await collectParts(streamFromText([
+      data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
       data({
         type: "content_block_start",
         index: 0,
         content_block: { type: "redacted_thinking", data: "encrypted" },
       }),
       data({ type: "content_block_stop", index: 0 }),
+      data({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+      }),
+      data({ type: "message_stop" }),
     ].join("")));
 
     assertEquals(parts, [
       { type: "reasoning-start", id: "thinking-0" },
       { type: "reasoning-end", id: "thinking-0", redactedData: "encrypted" },
-      { type: "finish", finishReason: null },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "end_turn" },
+        usage: { inputTokens: 1, totalTokens: 1 },
+      },
     ]);
   });
 
-  it("preserves gateway billing metadata appended after a client tool-use step", async () => {
-    const parts = await collectParts(streamFromChunks([
+  it("fully processes a trailing terminal event without a final delimiter", async () => {
+    const terminal = { type: "message_stop" };
+    const parts = await collectParts(streamFromText([
+      data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+      data({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "tail" },
+      }),
+      data({ type: "content_block_stop", index: 0 }),
+      data({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 1 },
+      }),
+      `event: ${terminal.type}\r\ndata: ${JSON.stringify(terminal)}`,
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "text-delta", delta: "tail" },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "end_turn" },
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      },
+    ]);
+  });
+
+  it("recognizes bare-CR SSE framing before the provider closes the stream", async () => {
+    const encoder = new TextEncoder();
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(value) {
+        controller = value;
+        controller.enqueue(encoder.encode([
+          'event: message_start\rdata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\r\r',
+          'event: content_block_start\rdata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Hello"}}\r\r',
+        ].join("")));
+      },
+    });
+    const iterator = streamAnthropicCompatibleParts(stream)[Symbol.asyncIterator]();
+    let settledBeforeFallback = false;
+    const nextPart = iterator.next().then((part) => {
+      settledBeforeFallback = true;
+      return part;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const parsedBeforeFallback = settledBeforeFallback;
+    controller.enqueue(encoder.encode("\n"));
+    controller.close();
+
+    assertEquals(await nextPart, {
+      done: false,
+      value: { type: "text-delta", delta: "Hello" },
+    });
+    assertEquals(parsedBeforeFallback, true);
+    await assertRejects(
+      () => iterator.next(),
+      ProviderRequestError,
+      "unfinished content blocks",
+    );
+  });
+
+  it("rejects structurally empty, unterminated, and malformed tool streams", async () => {
+    await assertRejects(
+      () => collectParts(streamFromText(data({ type: "ping" }))),
+      ProviderRequestError,
+      "stream contained no provider envelope",
+    );
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "partial" },
+          }),
+          data({ type: "content_block_stop", index: 0 }),
+        ].join(""))),
+      ProviderRequestError,
+      "stream ended before a stop reason",
+    );
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_bad", name: "lookup", input: {} },
+          }),
+          data({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '{"id":' },
+          }),
+          data({ type: "content_block_stop", index: 0 }),
+        ].join(""))),
+      ProviderRequestError,
+      "tool call arguments were not valid JSON object text",
+    );
+    await assertRejects(
+      () => collectParts(streamFromText(data({ type: "message_stop" }))),
+      ProviderRequestError,
+      "message_stop was out of sequence",
+    );
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "first" },
+          }),
+          data({ type: "content_block_stop", index: 0 }),
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "second" },
+          }),
+          data({ type: "content_block_stop", index: 0 }),
+          data({ type: "message_delta", delta: { stop_reason: "end_turn" } }),
+          data({ type: "message_stop" }),
+        ].join(""))),
+      ProviderRequestError,
+      "content block index was reused",
+    );
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "done" },
+          }),
+          data({ type: "content_block_stop", index: 0 }),
+          data({ type: "message_delta", delta: { stop_reason: "end_turn" } }),
+          "data: [DONE]\r\n\r\n",
+          "data: [DONE]\r\n\r\n",
+        ].join(""))),
+      ProviderRequestError,
+      "terminal marker was out of sequence",
+    );
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "web_search_tool_result",
+              content: [],
+            },
+          }),
+        ].join(""))),
+      ProviderRequestError,
+      "web-search result block was malformed",
+    );
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "thinking", thinking: "" },
+          }),
+          data({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "signature_delta", signature: 42 },
+          }),
+        ].join(""))),
+      ProviderRequestError,
+      "signature delta was malformed",
+    );
+  });
+
+  it("accepts a complete empty assistant stream", async () => {
+    for (
+      const terminal of [
+        data({ type: "message_stop" }),
+        "data: [DONE]\r\n\r\n",
+      ]
+    ) {
+      assertEquals(
+        await collectParts(streamFromText([
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+          data({ type: "message_delta", delta: { stop_reason: "end_turn" } }),
+          terminal,
+        ].join(""))),
+        [{
+          type: "finish",
+          finishReason: { unified: "stop", raw: "end_turn" },
+          usage: { inputTokens: 1, totalTokens: 1 },
+        }],
+      );
+    }
+  });
+
+  it("does not finish a client-tool stream while a later content block is unfinished", async () => {
+    let cancelCount = 0;
+    const stream = streamFromChunksWithCancelSpy([
       [
+        data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
         data({
           type: "content_block_start",
           index: 0,
@@ -297,31 +899,98 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
         }),
         data({ type: "content_block_stop", index: 0 }),
         data({
-          type: "message_delta",
-          delta: { stop_reason: "tool_use" },
-          usage: { output_tokens: 4 },
+          type: "content_block_start",
+          index: 1,
+          content_block: { type: "text", text: "unfinished" },
         }),
-        data({ type: "message_stop" }),
       ].join(""),
+    ], {
+      closeDelayMs: 30,
+      onCancel: () => cancelCount++,
+    });
+
+    await assertRejects(
+      () =>
+        collectParts(stream, {
+          clientToolUseTrailingUsageGraceMs: 5,
+        }),
+      ProviderRequestError,
+      "unfinished content blocks",
+    );
+    assertEquals(cancelCount, 0);
+  });
+
+  it("does not await a hostile provider body cancellation forever", async () => {
+    const stream = streamWithNeverSettlingCancel(
       data({
-        type: "message_delta",
-        delta: {},
-        usage: {
-          input_tokens: 10,
-          output_tokens: 4,
-          veryfront: {
-            billable_input_tokens: 10,
-            billable_output_tokens: 4,
-            provider_cost_usd: 0.001,
-            veryfront_charge_usd: 0.0025,
-            veryfront_billed_usd: 0.1,
-            cost_credits: 1,
-            cost_source: "gateway",
-            usage_capture_status: "complete",
-          },
-        },
+        type: "message_start",
+        message: { usage: { input_tokens: 1 } },
+      }) + data({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "partial" },
       }),
-    ], { close: true }));
+    );
+    const iterator = streamAnthropicCompatibleParts(stream)[Symbol.asyncIterator]();
+
+    assertEquals(await iterator.next(), {
+      done: false,
+      value: { type: "text-delta", delta: "partial" },
+    });
+    assertEquals(
+      await promiseWithTimeout(
+        iterator.return?.() ?? Promise.resolve({ done: true, value: undefined }),
+        100,
+      ),
+      { done: true, value: undefined },
+    );
+    assertEquals(stream.locked, false);
+  });
+
+  it("preserves gateway billing metadata appended after a client tool-use step", async () => {
+    const parts = await collectParts(
+      streamFromChunks([
+        [
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
+          }),
+          data({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
+          }),
+          data({ type: "content_block_stop", index: 0 }),
+          data({
+            type: "message_delta",
+            delta: { stop_reason: "tool_use" },
+            usage: { output_tokens: 4 },
+          }),
+          data({ type: "message_stop" }),
+        ].join(""),
+        data({
+          type: "message_delta",
+          delta: {},
+          usage: {
+            input_tokens: 10,
+            output_tokens: 4,
+            veryfront: {
+              billable_input_tokens: 10,
+              billable_output_tokens: 4,
+              provider_cost_usd: 0.001,
+              veryfront_charge_usd: 0.0025,
+              veryfront_billed_usd: 0.1,
+              cost_credits: 1,
+              cost_source: "gateway",
+              usage_capture_status: "complete",
+            },
+          },
+        }),
+      ], { close: true }),
+      { allowPostTerminalUsage: true },
+    );
 
     assertEquals(parts, [
       { type: "tool-input-start", id: "toolu_1", toolName: "bash" },
@@ -354,41 +1023,47 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
 
   it("drains the gateway billing metadata close after a client tool-use step", async () => {
     let cancelCount = 0;
-    const parts = await collectParts(streamFromChunksWithCancelSpy([
-      [
-        data({
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
-        }),
-        data({
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
-        }),
-        data({ type: "content_block_stop", index: 0 }),
+    const parts = await collectParts(
+      streamFromChunksWithCancelSpy([
+        [
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
+          }),
+          data({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
+          }),
+          data({ type: "content_block_stop", index: 0 }),
+          data({
+            type: "message_delta",
+            delta: { stop_reason: "tool_use" },
+            usage: { output_tokens: 4 },
+          }),
+          data({ type: "message_stop" }),
+        ].join(""),
         data({
           type: "message_delta",
-          delta: { stop_reason: "tool_use" },
-          usage: { output_tokens: 4 },
-        }),
-        data({ type: "message_stop" }),
-      ].join(""),
-      data({
-        type: "message_delta",
-        delta: {},
-        usage: {
-          input_tokens: 10,
-          output_tokens: 4,
-          veryfront: {
-            billable_input_tokens: 10,
-            billable_output_tokens: 4,
-            cost_source: "gateway",
-            usage_capture_status: "complete",
+          delta: {},
+          usage: {
+            input_tokens: 10,
+            output_tokens: 4,
+            veryfront: {
+              billable_input_tokens: 10,
+              billable_output_tokens: 4,
+              cost_source: "gateway",
+              usage_capture_status: "complete",
+            },
           },
-        },
-      }),
-    ], { closeDelayMs: 5, onCancel: () => cancelCount++ }));
+        }),
+      ], { closeDelayMs: 5, onCancel: () => cancelCount++ }),
+      {
+        allowPostTerminalUsage: true,
+      },
+    );
 
     assertEquals(cancelCount, 0);
     assertEquals(parts.at(-1), {
@@ -415,6 +1090,7 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
     const parts = await collectParts(
       streamFromChunksWithCancelSpy([
         [
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
           data({
             type: "content_block_start",
             index: 0,
@@ -441,7 +1117,10 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
         },
         onClose: resolveClosed,
       }),
-      { clientToolUseTrailingUsageTimeoutMode: "drain" },
+      {
+        clientToolUseTrailingUsageTimeoutMode: "drain",
+        allowPostTerminalUsage: true,
+      },
     );
 
     await closed;
@@ -451,8 +1130,9 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
       type: "finish",
       finishReason: { unified: "tool-calls", raw: "tool_use" },
       usage: {
+        inputTokens: 1,
         outputTokens: 4,
-        totalTokens: 4,
+        totalTokens: 5,
       },
     });
   });
@@ -461,6 +1141,7 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
     let cancelCount = 0;
     const stream = streamFromChunksWithCancelSpy([
       [
+        data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
         data({
           type: "content_block_start",
           index: 0,
@@ -488,6 +1169,7 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
       clientToolUseTrailingUsageGraceMs: 5,
       clientToolUseTrailingUsageTimeoutMode: "drain",
       clientToolUseTrailingUsageDrainTimeoutMs: 20,
+      allowPostTerminalUsage: true,
     });
 
     await waitForCondition(() => cancelCount === 1 && !stream.locked, 500);
@@ -498,8 +1180,9 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
       type: "finish",
       finishReason: { unified: "tool-calls", raw: "tool_use" },
       usage: {
+        inputTokens: 1,
         outputTokens: 4,
-        totalTokens: 4,
+        totalTokens: 5,
       },
     });
   });
@@ -508,6 +1191,7 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
     const parts = await collectFirstParts(
       streamFromChunks(
         [[
+          data({ type: "message_start", message: { usage: { input_tokens: 1 } } }),
           data({
             type: "content_block_start",
             index: 0,
@@ -544,43 +1228,11 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
         type: "finish",
         finishReason: { unified: "tool-calls", raw: "tool_use" },
         usage: {
+          inputTokens: 1,
           outputTokens: 4,
-          totalTokens: 4,
+          totalTokens: 5,
         },
       },
     ]);
-  });
-
-  it("reports malformed SSE JSON as a typed provider error", async () => {
-    await assertRejects(
-      () => collectParts(streamFromText('data: {"type":\n\n')),
-      ProviderRequestError,
-      "SSE event framing was malformed",
-    );
-  });
-
-  it("reports a malformed trailing SSE buffer as a typed provider error", async () => {
-    await assertRejects(
-      () => collectParts(streamFromText('data: {"type":')),
-      ProviderRequestError,
-      "trailing SSE event was malformed",
-    );
-  });
-
-  it("aborts the stream when a malformed event follows valid ones", async () => {
-    await assertRejects(
-      () =>
-        collectParts(streamFromText([
-          data({
-            type: "content_block_start",
-            index: 0,
-            content_block: { type: "text", text: "Done." },
-          }),
-          "data: {malformed\r\n\r\n",
-          data({ type: "message_stop" }),
-        ].join(""))),
-      ProviderRequestError,
-      "SSE event framing was malformed",
-    );
   });
 });

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.ts
@@ -1,54 +1,80 @@
 import {
   mergeUsage,
-  parseFinalSseChunk,
   parseSseChunk,
+  ProviderOverloadedError,
+  ProviderRateLimitError,
   ProviderRequestError,
   readGatewayBillingMode,
   readRecord,
   stringifyJsonValue,
 } from "veryfront/provider/shared";
 import type { RuntimeUsage } from "veryfront/provider/shared";
+import {
+  type AnthropicProviderToolNameRegistry,
+  isAnthropicProviderToolResultBlockType,
+  parseAnthropicProviderToolUse,
+  parseAnthropicServerToolResult,
+} from "./anthropic-native-content.ts";
+import { normalizeAnthropicCitation } from "./anthropic-citations.ts";
 
-function invalidAnthropicStream(issue: string): ProviderRequestError {
-  return new ProviderRequestError({
-    provider: "anthropic",
-    status: 200,
-    message: `anthropic request failed: invalid successful stream (${issue})`,
-    retryable: false,
-  });
-}
+export {
+  AnthropicServerToolResultError,
+  parseAnthropicServerToolResult,
+} from "./anthropic-native-content.ts";
 
-function parseAnthropicSseBuffer(
-  buffer: string,
-  trailing = false,
-): ReturnType<typeof parseSseChunk> {
-  try {
-    return trailing ? parseFinalSseChunk(buffer) : parseSseChunk(buffer);
-  } catch {
-    throw invalidAnthropicStream(
-      trailing ? "trailing SSE event was malformed" : "SSE event framing was malformed",
+// Web timers use a signed 32-bit millisecond delay across the supported
+// runtimes. Validate here because this extension is published independently
+// and cannot rely on a private core utility subpath.
+const MAX_PORTABLE_TIMER_DELAY_MS = 2_147_483_647;
+
+function normalizeAnthropicTimerDurationMs(
+  durationMs: number,
+  optionName: string,
+): number {
+  if (!Number.isFinite(durationMs) || durationMs < 0) {
+    throw new RangeError(
+      `${optionName} must be finite and between 0 and ${MAX_PORTABLE_TIMER_DELAY_MS} milliseconds`,
     );
   }
+  const normalized = Math.ceil(durationMs);
+  if (normalized > MAX_PORTABLE_TIMER_DELAY_MS) {
+    throw new RangeError(
+      `${optionName} must be finite and between 0 and ${MAX_PORTABLE_TIMER_DELAY_MS} milliseconds`,
+    );
+  }
+  return normalized === 0 ? 0 : normalized;
 }
 
 type AnthropicStreamToolCallState = {
   id: string;
   name: string;
-  input: string;
+  inputChunks: string[];
+  inputBytes: number;
+  partialJsonDeltaCount: number;
   providerExecuted?: boolean;
 };
 
 type AnthropicStreamReasoningState = {
   id: string;
-  text: string;
   signature?: string;
   redactedData?: string;
+};
+
+export type AnthropicStreamCompletion = {
+  finishReason: string | { unified: string; raw: string } | null;
+  rawStopReason?: string;
+  rawContent: unknown[];
+  usage?: RuntimeUsage;
 };
 
 type AnthropicStreamOptions = {
   clientToolUseTrailingUsageGraceMs?: number;
   clientToolUseTrailingUsageTimeoutMode?: "cancel" | "drain";
   clientToolUseTrailingUsageDrainTimeoutMs?: number;
+  allowPostTerminalUsage?: boolean;
+  providerLabel?: string;
+  providerToolNamesById?: AnthropicProviderToolNameRegistry;
+  onCompletion?: (completion: AnthropicStreamCompletion) => void;
 };
 
 type AnthropicStreamReadResult =
@@ -59,6 +85,449 @@ type AnthropicStreamReadResult =
 const CLIENT_TOOL_USE_FINISH_REASON = { unified: "tool-calls", raw: "tool_use" } as const;
 const DEFAULT_CLIENT_TOOL_USE_TRAILING_USAGE_GRACE_MS = 100;
 const DEFAULT_CLIENT_TOOL_USE_TRAILING_USAGE_DRAIN_TIMEOUT_MS = 15_000;
+const MAX_ANTHROPIC_PARTIAL_JSON_BYTES = 1_048_576;
+const MAX_ANTHROPIC_PARTIAL_JSON_DELTAS = 4_096;
+const MAX_ANTHROPIC_SSE_EVENT_BYTES = 8_388_608;
+const MAX_ANTHROPIC_SSE_REMAINDER_BYTES = 8_388_608;
+export const MAX_ANTHROPIC_RETAINED_CONTENT_BYTES = 16_777_216;
+export const MAX_ANTHROPIC_RETAINED_CONTENT_ITEMS = 8_192;
+const ANTHROPIC_TOOL_INPUT_ENCODER = new TextEncoder();
+
+function invalidAnthropicStream(
+  providerLabel: string,
+  issue: string,
+): ProviderRequestError {
+  return new ProviderRequestError({
+    provider: "anthropic",
+    status: 200,
+    message: `${providerLabel} request failed: invalid successful stream (${issue})`,
+    retryable: false,
+  });
+}
+
+function readAnthropicStreamIndex(
+  record: Record<string, unknown>,
+  eventType: string,
+  providerLabel: string,
+): number {
+  if (!Number.isSafeInteger(record.index) || (record.index as number) < 0) {
+    throw invalidAnthropicStream(providerLabel, `${eventType} index was malformed`);
+  }
+  return record.index as number;
+}
+
+function appendAnthropicToolInput(
+  toolCall: AnthropicStreamToolCallState,
+  delta: string,
+  countPartialJsonDelta = false,
+): void {
+  if (
+    countPartialJsonDelta &&
+    toolCall.partialJsonDeltaCount >= MAX_ANTHROPIC_PARTIAL_JSON_DELTAS
+  ) {
+    throw new RangeError(
+      `Anthropic partial_json exceeded ${MAX_ANTHROPIC_PARTIAL_JSON_DELTAS} deltas`,
+    );
+  }
+  const deltaBytes = ANTHROPIC_TOOL_INPUT_ENCODER.encode(delta).byteLength;
+  if (deltaBytes > MAX_ANTHROPIC_PARTIAL_JSON_BYTES - toolCall.inputBytes) {
+    throw new RangeError(
+      `Anthropic partial_json exceeded ${MAX_ANTHROPIC_PARTIAL_JSON_BYTES} UTF-8 bytes`,
+    );
+  }
+  if (countPartialJsonDelta) {
+    toolCall.partialJsonDeltaCount++;
+  }
+  toolCall.inputBytes += deltaBytes;
+  toolCall.inputChunks.push(delta);
+}
+
+function joinAnthropicToolInput(toolCall: AnthropicStreamToolCallState): string {
+  return toolCall.inputChunks.join("");
+}
+
+class AnthropicRetainedContentBudget {
+  #bytes = 0;
+  #items = 0;
+
+  retain(value: string, issue: string): void {
+    if (this.#items >= MAX_ANTHROPIC_RETAINED_CONTENT_ITEMS) {
+      throw new RangeError(
+        `Anthropic retained content exceeded ${MAX_ANTHROPIC_RETAINED_CONTENT_ITEMS} items (${issue})`,
+      );
+    }
+    const bytes = ANTHROPIC_TOOL_INPUT_ENCODER.encode(value).byteLength;
+    if (bytes > MAX_ANTHROPIC_RETAINED_CONTENT_BYTES - this.#bytes) {
+      throw new RangeError(
+        `Anthropic retained content exceeded ${MAX_ANTHROPIC_RETAINED_CONTENT_BYTES} UTF-8 bytes (${issue})`,
+      );
+    }
+    this.#items++;
+    this.#bytes += bytes;
+  }
+}
+
+class BoundedAnthropicSseParser {
+  readonly #decoder = new TextDecoder("utf-8", { fatal: true });
+  readonly #providerLabel: string;
+  #eventContent: Uint8Array = new Uint8Array(0);
+  #eventContentBytes = 0;
+  #eventLineCount = 0;
+  #eventBytes = 0;
+  #line: Uint8Array = new Uint8Array(0);
+  #lineBytes = 0;
+  #skipLineFeedAfterCarriageReturn = false;
+
+  constructor(providerLabel: string) {
+    this.#providerLabel = providerLabel;
+  }
+
+  push(chunk: Uint8Array): Array<unknown | "[DONE]"> {
+    const events: Array<unknown | "[DONE]"> = [];
+    let offset = 0;
+
+    while (offset < chunk.byteLength) {
+      if (this.#skipLineFeedAfterCarriageReturn) {
+        this.#skipLineFeedAfterCarriageReturn = false;
+        if (chunk[offset] === 10) {
+          offset++;
+          continue;
+        }
+      }
+
+      let newlineIndex = -1;
+      for (let index = offset; index < chunk.byteLength; index++) {
+        if (chunk[index] === 10 || chunk[index] === 13) {
+          newlineIndex = index;
+          break;
+        }
+      }
+      if (newlineIndex < 0) {
+        this.#appendLineBytes(chunk.subarray(offset));
+        this.#addEventBytes(chunk.byteLength - offset);
+        break;
+      }
+
+      this.#appendLineBytes(chunk.subarray(offset, newlineIndex));
+      this.#addEventBytes(newlineIndex - offset);
+      const delimiter = chunk[newlineIndex];
+      this.#addEventBytes(1);
+      this.#skipLineFeedAfterCarriageReturn = delimiter === 13;
+      offset = newlineIndex + 1;
+      events.push(...this.#completeLine());
+    }
+    return events;
+  }
+
+  flush(): Array<unknown | "[DONE]"> {
+    const events: Array<unknown | "[DONE]"> = [];
+    this.#skipLineFeedAfterCarriageReturn = false;
+    if (this.#lineBytes > 0) {
+      this.#appendEventLine();
+      this.#resetLine();
+    }
+    if (this.#eventBytes > 0 || this.#eventContentBytes > 0) {
+      events.push(...this.#completeEvent());
+    }
+    return events;
+  }
+
+  #appendLineBytes(bytes: Uint8Array): void {
+    if (bytes.byteLength === 0) return;
+    if (bytes.byteLength > MAX_ANTHROPIC_SSE_REMAINDER_BYTES - this.#lineBytes) {
+      throw new RangeError(
+        `Anthropic SSE remainder exceeded ${MAX_ANTHROPIC_SSE_REMAINDER_BYTES} bytes`,
+      );
+    }
+    const requiredBytes = this.#lineBytes + bytes.byteLength;
+    this.#line = this.#growBuffer(
+      this.#line,
+      requiredBytes,
+      MAX_ANTHROPIC_SSE_REMAINDER_BYTES,
+    );
+    this.#line.set(bytes, this.#lineBytes);
+    this.#lineBytes += bytes.byteLength;
+  }
+
+  #addEventBytes(bytes: number): void {
+    if (bytes > MAX_ANTHROPIC_SSE_EVENT_BYTES - this.#eventBytes) {
+      throw new RangeError(
+        `Anthropic SSE event exceeded ${MAX_ANTHROPIC_SSE_EVENT_BYTES} bytes`,
+      );
+    }
+    this.#eventBytes += bytes;
+  }
+
+  #completeLine(): Array<unknown | "[DONE]"> {
+    const events = this.#lineBytes === 0 ? this.#completeEvent() : [];
+    if (this.#lineBytes > 0) {
+      this.#appendEventLine();
+    }
+    this.#resetLine();
+    return events;
+  }
+
+  #appendEventLine(): void {
+    const separatorBytes = this.#eventLineCount > 0 ? 1 : 0;
+    const requiredBytes = this.#eventContentBytes + separatorBytes + this.#lineBytes;
+    this.#eventContent = this.#growBuffer(
+      this.#eventContent,
+      requiredBytes,
+      MAX_ANTHROPIC_SSE_EVENT_BYTES,
+    );
+    if (separatorBytes > 0) {
+      this.#eventContent[this.#eventContentBytes++] = 10;
+    }
+    this.#eventContent.set(this.#line.subarray(0, this.#lineBytes), this.#eventContentBytes);
+    this.#eventContentBytes += this.#lineBytes;
+    this.#eventLineCount++;
+  }
+
+  #growBuffer(buffer: Uint8Array, requiredBytes: number, maximumBytes: number): Uint8Array {
+    if (buffer.byteLength >= requiredBytes) return buffer;
+    let capacity = Math.min(maximumBytes, Math.max(1_024, buffer.byteLength * 2));
+    while (capacity < requiredBytes) {
+      capacity = Math.min(maximumBytes, capacity * 2);
+    }
+    const grown = new Uint8Array(capacity);
+    grown.set(buffer);
+    return grown;
+  }
+
+  #resetLine(): void {
+    this.#lineBytes = 0;
+  }
+
+  #completeEvent(): Array<unknown | "[DONE]"> {
+    let block: string;
+    try {
+      block = this.#decoder.decode(
+        this.#eventContent.subarray(0, this.#eventContentBytes),
+      );
+    } catch {
+      throw invalidAnthropicStream(
+        this.#providerLabel,
+        "SSE event was not valid UTF-8",
+      );
+    }
+    this.#eventContentBytes = 0;
+    this.#eventLineCount = 0;
+    this.#eventBytes = 0;
+    if (block.length === 0) return [];
+    try {
+      return parseSseChunk(`${block}\n\n`).events;
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw invalidAnthropicStream(
+          this.#providerLabel,
+          "SSE event contained malformed JSON",
+        );
+      }
+      throw error;
+    }
+  }
+}
+
+function buildAnthropicSseError(record: Record<string, unknown>): Error {
+  const error = readRecord(record.error) ?? record;
+  const type = typeof error.type === "string" ? error.type : "unknown_error";
+
+  if (type === "overloaded_error") {
+    return new ProviderOverloadedError({
+      provider: "anthropic",
+      status: 529,
+      message: "Anthropic stream failed: provider overloaded",
+      retryable: true,
+    });
+  }
+  if (type === "rate_limit_error") {
+    return new ProviderRateLimitError({
+      provider: "anthropic",
+      status: 429,
+      message: "Anthropic stream failed: rate limit exceeded",
+      retryable: true,
+    });
+  }
+
+  const status = type === "authentication_error"
+    ? 401
+    : type === "billing_error"
+    ? 402
+    : type === "permission_error"
+    ? 403
+    : type === "not_found_error"
+    ? 404
+    : type === "request_too_large"
+    ? 413
+    : type === "api_error"
+    ? 500
+    : 400;
+  return new ProviderRequestError({
+    provider: "anthropic",
+    status,
+    message: `Anthropic stream failed with status ${status}`,
+    retryable: type === "api_error",
+  });
+}
+
+function addOptionalTokenCount(
+  left: number | undefined,
+  right: number | undefined,
+): number | undefined {
+  if (left === undefined && right === undefined) {
+    return undefined;
+  }
+  const sum = (left ?? 0) + (right ?? 0);
+  return Number.isSafeInteger(sum) && sum >= 0 ? sum : undefined;
+}
+
+function addOptionalCost(
+  left: number | undefined,
+  right: number | undefined,
+): number | undefined {
+  if (left === undefined && right === undefined) {
+    return undefined;
+  }
+  const sum = (left ?? 0) + (right ?? 0);
+  return Number.isFinite(sum) && sum >= 0 ? sum : undefined;
+}
+
+function sanitizeUsage(usage: RuntimeUsage | undefined): RuntimeUsage | undefined {
+  const sanitized = mergeUsage(undefined, usage);
+  return sanitized && Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
+function combineCostSource(
+  left: RuntimeUsage["costSource"],
+  right: RuntimeUsage["costSource"],
+): RuntimeUsage["costSource"] {
+  if (left === undefined) return right;
+  if (right === undefined || left === right) return left;
+  return "partial";
+}
+
+function combineCaptureStatus(
+  left: RuntimeUsage["usageCaptureStatus"],
+  right: RuntimeUsage["usageCaptureStatus"],
+): RuntimeUsage["usageCaptureStatus"] {
+  if (left === undefined) return right;
+  if (right === undefined || left === right) return left;
+  return "partial";
+}
+
+/** Add independently billed Anthropic attempts, such as pause_turn continuations. */
+export function addAnthropicUsage(
+  current: RuntimeUsage | undefined,
+  next: RuntimeUsage | undefined,
+): RuntimeUsage | undefined {
+  const sanitizedCurrent = sanitizeUsage(current);
+  const sanitizedNext = sanitizeUsage(next);
+  if (!sanitizedCurrent) return sanitizedNext;
+  if (!sanitizedNext) return sanitizedCurrent;
+
+  const costSource = combineCostSource(sanitizedCurrent.costSource, sanitizedNext.costSource);
+  const usageCaptureStatus = combineCaptureStatus(
+    sanitizedCurrent.usageCaptureStatus,
+    sanitizedNext.usageCaptureStatus,
+  );
+  const billingMode = sanitizedCurrent.billingMode === "deferred" ||
+      sanitizedNext.billingMode === "deferred"
+    ? "deferred"
+    : sanitizedCurrent.billingMode ?? sanitizedNext.billingMode;
+  const inputTokens = addOptionalTokenCount(
+    sanitizedCurrent.inputTokens,
+    sanitizedNext.inputTokens,
+  );
+  const outputTokens = addOptionalTokenCount(
+    sanitizedCurrent.outputTokens,
+    sanitizedNext.outputTokens,
+  );
+  const totalTokens = addOptionalTokenCount(
+    sanitizedCurrent.totalTokens,
+    sanitizedNext.totalTokens,
+  );
+  const cacheCreationInputTokens = addOptionalTokenCount(
+    sanitizedCurrent.cacheCreationInputTokens,
+    sanitizedNext.cacheCreationInputTokens,
+  );
+  const cacheReadInputTokens = addOptionalTokenCount(
+    sanitizedCurrent.cacheReadInputTokens,
+    sanitizedNext.cacheReadInputTokens,
+  );
+  const reasoningTokens = addOptionalTokenCount(
+    sanitizedCurrent.reasoningTokens,
+    sanitizedNext.reasoningTokens,
+  );
+  const billableInputTokens = addOptionalTokenCount(
+    sanitizedCurrent.billableInputTokens,
+    sanitizedNext.billableInputTokens,
+  );
+  const billableOutputTokens = addOptionalTokenCount(
+    sanitizedCurrent.billableOutputTokens,
+    sanitizedNext.billableOutputTokens,
+  );
+  const costUsd = addOptionalCost(
+    sanitizedCurrent.costUsd,
+    sanitizedNext.costUsd,
+  );
+  const providerInputCostUsd = addOptionalCost(
+    sanitizedCurrent.providerInputCostUsd,
+    sanitizedNext.providerInputCostUsd,
+  );
+  const providerOutputCostUsd = addOptionalCost(
+    sanitizedCurrent.providerOutputCostUsd,
+    sanitizedNext.providerOutputCostUsd,
+  );
+  const providerCostUsd = addOptionalCost(
+    sanitizedCurrent.providerCostUsd,
+    sanitizedNext.providerCostUsd,
+  );
+  const veryfrontInputChargeUsd = addOptionalCost(
+    sanitizedCurrent.veryfrontInputChargeUsd,
+    sanitizedNext.veryfrontInputChargeUsd,
+  );
+  const veryfrontOutputChargeUsd = addOptionalCost(
+    sanitizedCurrent.veryfrontOutputChargeUsd,
+    sanitizedNext.veryfrontOutputChargeUsd,
+  );
+  const veryfrontChargeUsd = addOptionalCost(
+    sanitizedCurrent.veryfrontChargeUsd,
+    sanitizedNext.veryfrontChargeUsd,
+  );
+  const veryfrontBilledUsd = addOptionalCost(
+    sanitizedCurrent.veryfrontBilledUsd,
+    sanitizedNext.veryfrontBilledUsd,
+  );
+  const costCredits = addOptionalCost(
+    sanitizedCurrent.costCredits,
+    sanitizedNext.costCredits,
+  );
+
+  const aggregate: RuntimeUsage = {
+    ...(inputTokens === undefined ? {} : { inputTokens }),
+    ...(outputTokens === undefined ? {} : { outputTokens }),
+    ...(totalTokens === undefined ? {} : { totalTokens }),
+    ...(cacheCreationInputTokens === undefined ? {} : { cacheCreationInputTokens }),
+    ...(cacheReadInputTokens === undefined ? {} : { cacheReadInputTokens }),
+    ...(cacheReadInputTokens === undefined ? {} : { cachedInputTokens: cacheReadInputTokens }),
+    ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
+    ...(billableInputTokens === undefined ? {} : { billableInputTokens }),
+    ...(billableOutputTokens === undefined ? {} : { billableOutputTokens }),
+    ...(costUsd === undefined ? {} : { costUsd }),
+    ...(providerInputCostUsd === undefined ? {} : { providerInputCostUsd }),
+    ...(providerOutputCostUsd === undefined ? {} : { providerOutputCostUsd }),
+    ...(providerCostUsd === undefined ? {} : { providerCostUsd }),
+    ...(veryfrontInputChargeUsd === undefined ? {} : { veryfrontInputChargeUsd }),
+    ...(veryfrontOutputChargeUsd === undefined ? {} : { veryfrontOutputChargeUsd }),
+    ...(veryfrontChargeUsd === undefined ? {} : { veryfrontChargeUsd }),
+    ...(veryfrontBilledUsd === undefined ? {} : { veryfrontBilledUsd }),
+    ...(costCredits === undefined ? {} : { costCredits }),
+    ...(costSource === undefined ? {} : { costSource }),
+    ...(billingMode === undefined ? {} : { billingMode }),
+    ...(usageCaptureStatus === undefined ? {} : { usageCaptureStatus }),
+  };
+  return Object.keys(aggregate).length > 0 ? aggregate : undefined;
+}
 
 function isEmptyRecord(value: unknown): value is Record<string, never> {
   return Boolean(
@@ -105,7 +574,7 @@ export function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefine
   const billingMode = readGatewayBillingMode(veryfront?.billing_mode);
   const usageCaptureStatus = veryfront?.usage_capture_status;
 
-  return {
+  return sanitizeUsage({
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
     outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
     totalTokens: typeof inputTokens === "number" || typeof outputTokens === "number"
@@ -151,7 +620,7 @@ export function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefine
         usageCaptureStatus === "partial"
       ? { usageCaptureStatus }
       : {}),
-  };
+  });
 }
 
 function isToolCallsFinishReason(
@@ -179,7 +648,7 @@ async function readStreamChunk(
   const timeoutPromise = new Promise<AnthropicStreamReadResult>((resolve) => {
     timeoutId = setTimeout(
       () => resolve({ kind: "timeout", readerMode: timeoutMode }),
-      Math.max(1, timeoutMs),
+      timeoutMs,
     );
   });
 
@@ -189,7 +658,7 @@ async function readStreamChunk(
       if (timeoutMode === "drain") {
         void drainStreamReaderAfterTimeout(reader, readPromise, drainTimeoutMs);
       } else {
-        await cancelStreamReader(
+        cancelStreamReader(
           reader,
           "Timed out waiting for trailing Anthropic tool-use usage metadata",
         );
@@ -203,12 +672,17 @@ async function readStreamChunk(
   }
 }
 
-async function cancelStreamReader(
+function cancelStreamReader(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   reason: string,
-): Promise<void> {
+): void {
   try {
-    await reader.cancel(reason);
+    // Web Streams closes pending reads immediately, but a hostile underlying
+    // source may return a never-settling cancellation promise. Cleanup must
+    // not keep the consumer or timeout path waiting on that source.
+    void reader.cancel(reason).catch(() => {
+      // The upstream body may already be closed or canceled by the runtime.
+    });
   } catch {
     // The upstream body may already be closed or canceled by the runtime.
   }
@@ -224,7 +698,7 @@ async function drainStreamReaderAfterTimeout(
       reader,
       "Timed out draining trailing Anthropic tool-use usage metadata",
     );
-  }, Math.max(1, timeoutMs));
+  }, timeoutMs);
 
   try {
     const firstRead = await pendingRead;
@@ -251,41 +725,162 @@ export async function* streamAnthropicCompatibleParts(
   stream: ReadableStream<Uint8Array>,
   options: AnthropicStreamOptions = {},
 ): AsyncIterable<unknown> {
-  const decoder = new TextDecoder();
-  const reader = stream.getReader();
-  const trailingUsageGraceMs = options.clientToolUseTrailingUsageGraceMs ??
-    DEFAULT_CLIENT_TOOL_USE_TRAILING_USAGE_GRACE_MS;
+  const providerLabel = options.providerLabel ?? "anthropic";
+  const sseParser = new BoundedAnthropicSseParser(providerLabel);
+  const trailingUsageGraceMs = normalizeAnthropicTimerDurationMs(
+    options.clientToolUseTrailingUsageGraceMs ??
+      DEFAULT_CLIENT_TOOL_USE_TRAILING_USAGE_GRACE_MS,
+    "clientToolUseTrailingUsageGraceMs",
+  );
   const trailingUsageTimeoutMode = options.clientToolUseTrailingUsageTimeoutMode ?? "cancel";
-  const trailingUsageDrainTimeoutMs = options.clientToolUseTrailingUsageDrainTimeoutMs ??
-    DEFAULT_CLIENT_TOOL_USE_TRAILING_USAGE_DRAIN_TIMEOUT_MS;
+  const trailingUsageDrainTimeoutMs = normalizeAnthropicTimerDurationMs(
+    options.clientToolUseTrailingUsageDrainTimeoutMs ??
+      DEFAULT_CLIENT_TOOL_USE_TRAILING_USAGE_DRAIN_TIMEOUT_MS,
+    "clientToolUseTrailingUsageDrainTimeoutMs",
+  );
+  if (trailingUsageGraceMs === 0 || trailingUsageDrainTimeoutMs === 0) {
+    throw new RangeError(
+      "Anthropic trailing usage timeouts must be greater than zero",
+    );
+  }
+  const reader = stream.getReader();
+  const allowPostTerminalUsage = options.allowPostTerminalUsage === true;
+  const providerToolNamesById = options.providerToolNamesById ?? new Map<string, string>();
   let readerReleased = false;
-  let buffer = "";
+  let sourceSettled = false;
   const toolCalls = new Map<number, AnthropicStreamToolCallState>();
   const reasoningBlocks = new Map<number, AnthropicStreamReasoningState>();
+  const rawContentBlocks = new Map<number, Record<string, unknown>>();
+  const rawTextChunks = new Map<number, string[]>();
+  const rawThinkingChunks = new Map<number, string[]>();
+  const retainedContentBudget = new AnthropicRetainedContentBudget();
+  const openContentBlocks = new Set<number>();
+  const seenContentBlocks = new Set<number>();
+  const supportedContentBlocks = new Set<number>();
   let finishReason: string | { unified: string; raw: string } | null = null;
+  let rawStopReason: string | undefined;
   let usage: RuntimeUsage | undefined;
   let completedClientToolUseStep = false;
   let clientToolUseIdleDeadlineMs: number | null = null;
   let clientToolUseTerminalDeadlineMs: number | null = null;
+  let sawMessageStart = false;
+  let sawMessageStop = false;
+  let sawDoneMarker = false;
+  let sawStopReason = false;
+  let completedSupportedContentBlocks = 0;
 
-  const mergeTrailingBufferUsage = () => {
-    if (buffer.trim().length === 0) {
+  const mergeRecordUsage = (record: Record<string, unknown>) => {
+    usage = mergeUsage(usage, extractAnthropicUsage(record));
+  };
+
+  const applyTrailingLifecycleEvent = (event: unknown | "[DONE]") => {
+    if (event === "[DONE]") {
+      if (
+        sawDoneMarker ||
+        !sawMessageStart ||
+        !sawStopReason ||
+        openContentBlocks.size > 0 ||
+        reasoningBlocks.size > 0 ||
+        toolCalls.size > 0
+      ) {
+        throw invalidAnthropicStream(providerLabel, "terminal marker was out of sequence");
+      }
+      sawDoneMarker = true;
       return;
     }
 
-    const parsed = parseAnthropicSseBuffer(buffer, true);
-    buffer = parsed.remainder;
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
+    const record = readRecord(event);
+    const eventType = typeof record?.type === "string" && record.type.length > 0
+      ? record.type
+      : undefined;
+    if (!record || !eventType) {
+      throw invalidAnthropicStream(providerLabel, "trailing event type was missing");
+    }
+    if (eventType === "error") {
+      throw buildAnthropicSseError(record);
+    }
+    if (eventType === "ping") {
+      return;
+    }
+    if (eventType === "message_stop") {
+      if (
+        sawDoneMarker ||
+        sawMessageStop ||
+        !sawMessageStart ||
+        !sawStopReason ||
+        openContentBlocks.size > 0 ||
+        reasoningBlocks.size > 0 ||
+        toolCalls.size > 0
+      ) {
+        throw invalidAnthropicStream(providerLabel, "message_stop was out of sequence");
       }
-      const record = readRecord(event);
-      usage = mergeUsage(usage, extractAnthropicUsage(record));
+      sawMessageStop = true;
+      return;
+    }
+    if (eventType !== "message_delta") {
+      throw invalidAnthropicStream(
+        providerLabel,
+        "trailing event was not a usage-bearing lifecycle event",
+      );
+    }
+
+    const delta = readRecord(record.delta);
+    if (!delta) {
+      throw invalidAnthropicStream(providerLabel, "message delta was malformed");
+    }
+    if (sawMessageStop || sawDoneMarker) {
+      if (
+        !allowPostTerminalUsage ||
+        Object.keys(delta).length > 0 ||
+        !readRecord(record.usage)
+      ) {
+        throw invalidAnthropicStream(
+          providerLabel,
+          "event followed the terminal message_stop",
+        );
+      }
+      mergeRecordUsage(record);
+      return;
+    }
+    if (
+      !sawMessageStart ||
+      openContentBlocks.size > 0 ||
+      reasoningBlocks.size > 0 ||
+      toolCalls.size > 0
+    ) {
+      throw invalidAnthropicStream(providerLabel, "message_delta was out of sequence");
+    }
+    if (
+      delta.stop_reason !== undefined &&
+      delta.stop_reason !== null &&
+      (typeof delta.stop_reason !== "string" || delta.stop_reason.length === 0)
+    ) {
+      throw invalidAnthropicStream(providerLabel, "message stop reason was malformed");
+    }
+    if (typeof delta.stop_reason === "string") {
+      if (sawStopReason) {
+        throw invalidAnthropicStream(providerLabel, "message stop reason was repeated");
+      }
+      sawStopReason = true;
+      rawStopReason = delta.stop_reason;
+      finishReason = normalizeAnthropicFinishReason(delta.stop_reason);
+    }
+    mergeRecordUsage(record);
+  };
+
+  const mergeTrailingBufferUsage = () => {
+    for (const event of sseParser.flush()) {
+      applyTrailingLifecycleEvent(event);
     }
   };
 
   const getClientToolUseReadTimeoutMs = () => {
-    if (!completedClientToolUseStep || toolCalls.size > 0) {
+    if (
+      !completedClientToolUseStep ||
+      toolCalls.size > 0 ||
+      reasoningBlocks.size > 0 ||
+      openContentBlocks.size > 0
+    ) {
       return undefined;
     }
 
@@ -295,12 +890,46 @@ export async function* streamAnthropicCompatibleParts(
     return deadline === null ? undefined : Math.max(1, deadline - Date.now());
   };
 
+  const validateCompletion = () => {
+    if (!sawMessageStart) {
+      throw invalidAnthropicStream(providerLabel, "stream contained no provider envelope");
+    }
+    if (
+      openContentBlocks.size > 0 ||
+      reasoningBlocks.size > 0 ||
+      toolCalls.size > 0
+    ) {
+      throw invalidAnthropicStream(providerLabel, "stream ended with unfinished content blocks");
+    }
+    if (completedSupportedContentBlocks === 0 && seenContentBlocks.size > 0) {
+      throw invalidAnthropicStream(providerLabel, "stream contained no supported content blocks");
+    }
+    if (!sawStopReason && !completedClientToolUseStep) {
+      throw invalidAnthropicStream(providerLabel, "stream ended before a stop reason");
+    }
+    if (!sawMessageStop && !sawDoneMarker && !completedClientToolUseStep) {
+      throw invalidAnthropicStream(providerLabel, "stream ended before a terminal marker");
+    }
+  };
+
   const buildFinishPart = () => ({
     type: "finish",
     finishReason: finishReason ??
       (completedClientToolUseStep ? CLIENT_TOOL_USE_FINISH_REASON : null),
     ...(usage ? { usage } : {}),
   });
+
+  const notifyCompletion = () => {
+    options.onCompletion?.({
+      finishReason: finishReason ??
+        (completedClientToolUseStep ? CLIENT_TOOL_USE_FINISH_REASON : null),
+      ...(rawStopReason === undefined ? {} : { rawStopReason }),
+      rawContent: [...rawContentBlocks.entries()]
+        .sort(([left], [right]) => left - right)
+        .map(([, block]) => block),
+      ...(usage ? { usage } : {}),
+    });
+  };
 
   try {
     while (true) {
@@ -311,61 +940,143 @@ export async function* streamAnthropicCompatibleParts(
         trailingUsageDrainTimeoutMs,
       );
       if (read.kind === "timeout") {
+        sourceSettled = true;
         readerReleased = read.readerMode === "drain";
         mergeTrailingBufferUsage();
+        validateCompletion();
         finishReason ??= CLIENT_TOOL_USE_FINISH_REASON;
+        notifyCompletion();
         yield buildFinishPart();
         return;
       }
 
-      if (read.kind === "done") {
-        break;
+      const reachedEndOfStream = read.kind === "done";
+      if (reachedEndOfStream) {
+        sourceSettled = true;
       }
 
-      buffer += decoder.decode(read.chunk, { stream: true });
-      const parsed = parseAnthropicSseBuffer(buffer);
-      buffer = parsed.remainder;
-
-      for (const event of parsed.events) {
+      const events = reachedEndOfStream ? sseParser.flush() : sseParser.push(read.chunk);
+      for (const event of events) {
         if (event === "[DONE]") {
+          applyTrailingLifecycleEvent(event);
           continue;
         }
 
         const record = readRecord(event);
-        const eventType = typeof record?.type === "string" ? record.type : undefined;
-        usage = mergeUsage(usage, extractAnthropicUsage(record));
+        if (!record) {
+          throw invalidAnthropicStream(providerLabel, "event was not an object");
+        }
+        const eventType = typeof record.type === "string" && record.type.length > 0
+          ? record.type
+          : undefined;
+        if (!eventType) {
+          throw invalidAnthropicStream(providerLabel, "event type was missing");
+        }
+
+        if (sawMessageStop || sawDoneMarker) {
+          applyTrailingLifecycleEvent(event);
+          continue;
+        }
+        mergeRecordUsage(record);
+
+        if (eventType === "error") {
+          throw buildAnthropicSseError(record);
+        }
 
         if (eventType === "message_start") {
-          usage = mergeUsage(usage, extractAnthropicUsage(record?.message));
+          if (
+            sawMessageStart ||
+            seenContentBlocks.size > 0 ||
+            sawStopReason
+          ) {
+            throw invalidAnthropicStream(providerLabel, "message_start was out of sequence");
+          }
+          const message = readRecord(record.message);
+          if (!message) {
+            throw invalidAnthropicStream(providerLabel, "message_start message was malformed");
+          }
+          sawMessageStart = true;
+          mergeRecordUsage(message);
           continue;
         }
 
         if (eventType === "content_block_start") {
-          const index = typeof record?.index === "number" ? record.index : 0;
-          const contentBlock = readRecord(record?.content_block);
-          const blockType = typeof contentBlock?.type === "string" ? contentBlock.type : undefined;
+          if (!sawMessageStart || sawStopReason) {
+            throw invalidAnthropicStream(
+              providerLabel,
+              "content_block_start was out of sequence",
+            );
+          }
+          const index = readAnthropicStreamIndex(record, eventType, providerLabel);
+          const contentBlock = readRecord(record.content_block);
+          const blockType = typeof contentBlock?.type === "string" && contentBlock.type.length > 0
+            ? contentBlock.type
+            : undefined;
+          if (!contentBlock || !blockType) {
+            throw invalidAnthropicStream(
+              providerLabel,
+              "content_block_start content block was malformed",
+            );
+          }
+          if (seenContentBlocks.has(index)) {
+            throw invalidAnthropicStream(providerLabel, "content block index was reused");
+          }
+          seenContentBlocks.add(index);
+          openContentBlocks.add(index);
+          clientToolUseIdleDeadlineMs = null;
+          clientToolUseTerminalDeadlineMs = null;
+          try {
+            retainedContentBudget.retain(
+              stringifyJsonValue(contentBlock),
+              "content block",
+            );
+          } catch (error) {
+            if (error instanceof RangeError) {
+              throw invalidAnthropicStream(providerLabel, error.message);
+            }
+            throw invalidAnthropicStream(
+              providerLabel,
+              "content block could not be retained safely",
+            );
+          }
+          rawContentBlocks.set(index, { ...contentBlock });
 
-          if (
-            blockType === "text" && typeof contentBlock?.text === "string" &&
-            contentBlock.text.length > 0
-          ) {
-            yield { type: "text-delta", delta: contentBlock.text };
+          if (blockType === "text") {
+            if (typeof contentBlock.text !== "string") {
+              throw invalidAnthropicStream(providerLabel, "text content block was malformed");
+            }
+            supportedContentBlocks.add(index);
+            rawTextChunks.set(index, [contentBlock.text]);
+            if (contentBlock.text.length > 0) {
+              yield { type: "text-delta", delta: contentBlock.text };
+            }
             continue;
           }
 
           if (blockType === "thinking") {
+            if (
+              (contentBlock.thinking !== undefined &&
+                typeof contentBlock.thinking !== "string") ||
+              (contentBlock.signature !== undefined &&
+                typeof contentBlock.signature !== "string")
+            ) {
+              throw invalidAnthropicStream(providerLabel, "thinking content block was malformed");
+            }
+            supportedContentBlocks.add(index);
             const reasoningId = `thinking-${index}`;
-            reasoningBlocks.set(index, { id: reasoningId, text: "" });
+            reasoningBlocks.set(index, {
+              id: reasoningId,
+              ...(typeof contentBlock.signature === "string"
+                ? { signature: contentBlock.signature }
+                : {}),
+            });
+            rawThinkingChunks.set(index, [contentBlock.thinking ?? ""]);
             yield {
               type: "reasoning-start",
               id: reasoningId,
             };
 
             if (typeof contentBlock?.thinking === "string" && contentBlock.thinking.length > 0) {
-              const current = reasoningBlocks.get(index);
-              if (current) {
-                current.text += contentBlock.thinking;
-              }
               yield {
                 type: "reasoning-delta",
                 id: reasoningId,
@@ -380,13 +1091,17 @@ export async function* streamAnthropicCompatibleParts(
           // as a zero-length reasoning block so callers know thinking happened
           // without leaking the (legitimately hidden) contents.
           if (blockType === "redacted_thinking") {
+            if (typeof contentBlock.data !== "string" || contentBlock.data.length === 0) {
+              throw invalidAnthropicStream(
+                providerLabel,
+                "redacted thinking content block was malformed",
+              );
+            }
+            supportedContentBlocks.add(index);
             const reasoningId = `thinking-${index}`;
             reasoningBlocks.set(index, {
               id: reasoningId,
-              text: "",
-              ...(typeof contentBlock?.data === "string"
-                ? { redactedData: contentBlock.data }
-                : {}),
+              redactedData: contentBlock.data,
             });
             yield {
               type: "reasoning-start",
@@ -395,17 +1110,23 @@ export async function* streamAnthropicCompatibleParts(
             continue;
           }
 
-          if (
-            (blockType === "tool_use" || blockType === "server_tool_use") &&
-            typeof contentBlock?.id === "string" &&
-            typeof contentBlock?.name === "string"
-          ) {
-            const providerExecuted = blockType === "server_tool_use" ? true : undefined;
+          if (blockType === "tool_use") {
+            if (
+              typeof contentBlock.id !== "string" ||
+              contentBlock.id.length === 0 ||
+              typeof contentBlock.name !== "string" ||
+              contentBlock.name.length === 0 ||
+              (contentBlock.input !== undefined && !readRecord(contentBlock.input))
+            ) {
+              throw invalidAnthropicStream(providerLabel, "tool-use content block was malformed");
+            }
+            supportedContentBlocks.add(index);
             const current: AnthropicStreamToolCallState = {
               id: contentBlock.id,
               name: contentBlock.name,
-              input: "",
-              ...(providerExecuted ? { providerExecuted } : {}),
+              inputChunks: [],
+              inputBytes: 0,
+              partialJsonDeltaCount: 0,
             };
 
             toolCalls.set(index, current);
@@ -415,13 +1136,12 @@ export async function* streamAnthropicCompatibleParts(
               type: "tool-input-start",
               id: current.id,
               toolName: current.name,
-              ...(providerExecuted ? { providerExecuted } : {}),
             };
 
             const initialInput = contentBlock.input;
             if (initialInput !== undefined && !isEmptyRecord(initialInput)) {
               const serializedInput = stringifyJsonValue(initialInput);
-              current.input += serializedInput;
+              appendAnthropicToolInput(current, serializedInput);
               yield {
                 type: "tool-input-delta",
                 id: current.id,
@@ -431,94 +1151,273 @@ export async function* streamAnthropicCompatibleParts(
             continue;
           }
 
-          if (
-            blockType === "web_search_tool_result" &&
-            typeof contentBlock?.tool_use_id === "string" &&
-            Array.isArray(contentBlock?.content)
-          ) {
-            yield {
-              type: "tool-result",
-              toolCallId: contentBlock.tool_use_id,
-              toolName: "web_search",
-              result: contentBlock.content,
+          if (blockType === "server_tool_use" || blockType === "mcp_tool_use") {
+            const providerToolUse = parseAnthropicProviderToolUse(contentBlock);
+            if (
+              !providerToolUse ||
+              providerToolNamesById.has(providerToolUse.toolCallId)
+            ) {
+              throw invalidAnthropicStream(
+                providerLabel,
+                "provider tool-use content block was malformed",
+              );
+            }
+            providerToolNamesById.set(
+              providerToolUse.toolCallId,
+              providerToolUse.toolName,
+            );
+            supportedContentBlocks.add(index);
+            const current: AnthropicStreamToolCallState = {
+              id: providerToolUse.toolCallId,
+              name: providerToolUse.toolName,
+              inputChunks: [],
+              inputBytes: 0,
+              partialJsonDeltaCount: 0,
               providerExecuted: true,
             };
-          }
-
-          if (
-            blockType === "web_fetch_tool_result" &&
-            typeof contentBlock?.tool_use_id === "string" &&
-            readRecord(contentBlock?.content)
-          ) {
+            toolCalls.set(index, current);
             yield {
-              type: "tool-result",
-              toolCallId: contentBlock.tool_use_id,
-              toolName: "web_fetch",
-              result: contentBlock.content,
+              type: "tool-input-start",
+              id: current.id,
+              toolName: current.name,
               providerExecuted: true,
             };
+
+            if (!isEmptyRecord(providerToolUse.input)) {
+              const serializedInput = stringifyJsonValue(providerToolUse.input);
+              appendAnthropicToolInput(current, serializedInput);
+              yield {
+                type: "tool-input-delta",
+                id: current.id,
+                delta: serializedInput,
+              };
+            }
+            continue;
           }
 
-          continue;
+          if (isAnthropicProviderToolResultBlockType(blockType)) {
+            const parsedResult = parseAnthropicServerToolResult(
+              contentBlock,
+              providerToolNamesById,
+            );
+            if (!parsedResult) {
+              const issue = blockType === "web_search_tool_result"
+                ? "web-search result block was malformed"
+                : blockType === "web_fetch_tool_result"
+                ? "web-fetch result block was malformed"
+                : "provider tool-result content block was malformed";
+              throw invalidAnthropicStream(
+                providerLabel,
+                issue,
+              );
+            }
+            providerToolNamesById.delete(parsedResult.toolCallId);
+            supportedContentBlocks.add(index);
+            yield parsedResult.isError === true
+              ? {
+                type: "tool-error",
+                toolCallId: parsedResult.toolCallId,
+                toolName: parsedResult.toolName,
+                error: parsedResult.result,
+                isError: true,
+                providerExecuted: true,
+              }
+              : {
+                type: "tool-result",
+                ...parsedResult,
+                providerExecuted: true,
+              };
+            continue;
+          }
+
+          throw invalidAnthropicStream(
+            providerLabel,
+            "unsupported content block type",
+          );
         }
 
         if (eventType === "content_block_delta") {
-          const index = typeof record?.index === "number" ? record.index : 0;
-          const delta = readRecord(record?.delta);
-          const deltaType = typeof delta?.type === "string" ? delta.type : undefined;
-
-          if (
-            deltaType === "text_delta" && typeof delta?.text === "string" && delta.text.length > 0
-          ) {
-            yield { type: "text-delta", delta: delta.text };
+          const index = readAnthropicStreamIndex(record, eventType, providerLabel);
+          if (!openContentBlocks.has(index)) {
+            throw invalidAnthropicStream(
+              providerLabel,
+              "content block delta referenced an unopened block",
+            );
+          }
+          const delta = readRecord(record.delta);
+          const deltaType = typeof delta?.type === "string" && delta.type.length > 0
+            ? delta.type
+            : undefined;
+          if (!delta || !deltaType) {
+            throw invalidAnthropicStream(providerLabel, "content block delta was malformed");
+          }
+          if (deltaType === "text_delta") {
+            if (typeof delta.text !== "string") {
+              throw invalidAnthropicStream(providerLabel, "text delta was malformed");
+            }
+            const rawBlock = rawContentBlocks.get(index);
+            if (!rawBlock || rawBlock.type !== "text") {
+              throw invalidAnthropicStream(
+                providerLabel,
+                "text delta did not match its content block",
+              );
+            }
+            const chunks = rawTextChunks.get(index);
+            if (!chunks) {
+              throw invalidAnthropicStream(
+                providerLabel,
+                "text delta retention state was missing",
+              );
+            }
+            try {
+              retainedContentBudget.retain(delta.text, "text delta");
+            } catch (error) {
+              throw invalidAnthropicStream(
+                providerLabel,
+                error instanceof Error ? error.message : "text retention budget was exceeded",
+              );
+            }
+            chunks.push(delta.text);
+            if (delta.text.length > 0) {
+              yield { type: "text-delta", delta: delta.text };
+            }
             continue;
           }
 
-          if (
-            deltaType === "thinking_delta" && typeof delta?.thinking === "string" &&
-            delta.thinking.length > 0
-          ) {
+          if (deltaType === "thinking_delta") {
+            if (typeof delta.thinking !== "string") {
+              throw invalidAnthropicStream(providerLabel, "thinking delta was malformed");
+            }
             const current = reasoningBlocks.get(index);
             if (!current) {
-              continue;
+              throw invalidAnthropicStream(
+                providerLabel,
+                "thinking delta did not match its content block",
+              );
             }
 
-            current.text += delta.thinking;
-            yield {
-              type: "reasoning-delta",
-              id: current.id,
-              delta: delta.thinking,
-            };
+            const rawBlock = rawContentBlocks.get(index);
+            const chunks = rawThinkingChunks.get(index);
+            if (!rawBlock || !chunks) {
+              throw invalidAnthropicStream(
+                providerLabel,
+                "thinking delta retention state was missing",
+              );
+            }
+            try {
+              retainedContentBudget.retain(delta.thinking, "thinking delta");
+            } catch (error) {
+              throw invalidAnthropicStream(
+                providerLabel,
+                error instanceof Error ? error.message : "thinking retention budget was exceeded",
+              );
+            }
+            chunks.push(delta.thinking);
+            if (delta.thinking.length > 0) {
+              yield {
+                type: "reasoning-delta",
+                id: current.id,
+                delta: delta.thinking,
+              };
+            }
             continue;
           }
 
-          if (deltaType === "signature_delta" && typeof delta?.signature === "string") {
+          if (deltaType === "signature_delta") {
+            if (typeof delta.signature !== "string") {
+              throw invalidAnthropicStream(providerLabel, "signature delta was malformed");
+            }
             const current = reasoningBlocks.get(index);
-            if (current) {
-              current.signature = delta.signature;
+            if (!current) {
+              throw invalidAnthropicStream(
+                providerLabel,
+                "signature delta did not match its content block",
+              );
             }
+            current.signature = delta.signature;
+            const rawBlock = rawContentBlocks.get(index);
+            if (rawBlock) rawBlock.signature = delta.signature;
             continue;
           }
 
-          if (deltaType === "input_json_delta" && typeof delta?.partial_json === "string") {
+          const citation = readRecord(delta?.citation);
+          if (deltaType === "citations_delta") {
+            if (!citation || !normalizeAnthropicCitation(citation)) {
+              throw invalidAnthropicStream(providerLabel, "citation delta was malformed");
+            }
+            const rawBlock = rawContentBlocks.get(index);
+            if (!rawBlock || rawBlock.type !== "text") {
+              throw invalidAnthropicStream(
+                providerLabel,
+                "citation delta did not match its content block",
+              );
+            }
+            const citations = Array.isArray(rawBlock.citations) ? rawBlock.citations : [];
+            try {
+              retainedContentBudget.retain(
+                stringifyJsonValue(citation),
+                "citation delta",
+              );
+            } catch (error) {
+              throw invalidAnthropicStream(
+                providerLabel,
+                error instanceof Error ? error.message : "citation retention budget was exceeded",
+              );
+            }
+            citations.push(citation);
+            rawBlock.citations = citations;
+            continue;
+          }
+
+          if (deltaType === "input_json_delta") {
+            if (typeof delta.partial_json !== "string") {
+              throw invalidAnthropicStream(providerLabel, "tool-input delta was malformed");
+            }
             const current = toolCalls.get(index);
             if (!current) {
-              continue;
+              throw invalidAnthropicStream(
+                providerLabel,
+                "tool-input delta did not match its content block",
+              );
             }
 
-            current.input += delta.partial_json;
+            appendAnthropicToolInput(current, delta.partial_json, true);
             yield {
               type: "tool-input-delta",
               id: current.id,
               delta: delta.partial_json,
             };
+            continue;
           }
 
-          continue;
+          throw invalidAnthropicStream(
+            providerLabel,
+            "unsupported content block delta type",
+          );
         }
 
         if (eventType === "content_block_stop") {
-          const index = typeof record?.index === "number" ? record.index : 0;
+          const index = readAnthropicStreamIndex(record, eventType, providerLabel);
+          if (!openContentBlocks.delete(index)) {
+            throw invalidAnthropicStream(
+              providerLabel,
+              "content block stop referenced an unopened block",
+            );
+          }
+          if (supportedContentBlocks.delete(index)) {
+            completedSupportedContentBlocks++;
+          }
+          const rawBlock = rawContentBlocks.get(index);
+          const textChunks = rawTextChunks.get(index);
+          if (rawBlock && textChunks) {
+            rawBlock.text = textChunks.join("");
+            rawTextChunks.delete(index);
+          }
+          const thinkingChunks = rawThinkingChunks.get(index);
+          if (rawBlock && thinkingChunks) {
+            rawBlock.thinking = thinkingChunks.join("");
+            rawThinkingChunks.delete(index);
+          }
           const reasoning = reasoningBlocks.get(index);
           if (reasoning) {
             yield {
@@ -535,12 +1434,29 @@ export async function* streamAnthropicCompatibleParts(
           if (!current) {
             continue;
           }
+          const input = joinAnthropicToolInput(current) || "{}";
+          let parsedInput: Record<string, unknown>;
+          try {
+            const parsed = JSON.parse(input) as unknown;
+            const parsedRecord = readRecord(parsed);
+            if (!parsedRecord) {
+              throw new TypeError("tool input was not an object");
+            }
+            parsedInput = parsedRecord;
+          } catch {
+            throw invalidAnthropicStream(
+              providerLabel,
+              "tool call arguments were not valid JSON object text",
+            );
+          }
+
+          if (rawBlock) rawBlock.input = parsedInput;
 
           yield {
             type: "tool-call",
             toolCallId: current.id,
             toolName: current.name,
-            input: current.input.length > 0 ? current.input : "{}",
+            input,
             ...(current.providerExecuted ? { providerExecuted: true } : {}),
           };
           if (!current.providerExecuted) {
@@ -552,30 +1468,94 @@ export async function* streamAnthropicCompatibleParts(
         }
 
         if (eventType === "message_delta") {
-          const delta = readRecord(record?.delta);
-          const normalizedFinishReason = normalizeAnthropicFinishReason(delta?.stop_reason);
+          if (
+            !sawMessageStart ||
+            openContentBlocks.size > 0 ||
+            reasoningBlocks.size > 0 ||
+            toolCalls.size > 0
+          ) {
+            throw invalidAnthropicStream(providerLabel, "message_delta was out of sequence");
+          }
+          const delta = readRecord(record.delta);
+          if (!delta) {
+            throw invalidAnthropicStream(providerLabel, "message delta was malformed");
+          }
+          if (
+            delta.stop_reason !== undefined &&
+            delta.stop_reason !== null &&
+            (typeof delta.stop_reason !== "string" || delta.stop_reason.length === 0)
+          ) {
+            throw invalidAnthropicStream(providerLabel, "message stop reason was malformed");
+          }
+          if (typeof delta.stop_reason === "string") {
+            if (sawStopReason) {
+              throw invalidAnthropicStream(providerLabel, "message stop reason was repeated");
+            }
+            rawStopReason = delta.stop_reason;
+            sawStopReason = true;
+          }
+          const normalizedFinishReason = normalizeAnthropicFinishReason(delta.stop_reason);
           if (normalizedFinishReason) {
             finishReason = normalizedFinishReason;
           }
+          continue;
         }
+
+        if (eventType === "message_stop") {
+          if (
+            !sawMessageStart ||
+            !sawStopReason ||
+            openContentBlocks.size > 0 ||
+            reasoningBlocks.size > 0 ||
+            toolCalls.size > 0
+          ) {
+            throw invalidAnthropicStream(providerLabel, "message_stop was out of sequence");
+          }
+          sawMessageStop = true;
+          continue;
+        }
+
+        if (eventType === "ping") {
+          continue;
+        }
+        throw invalidAnthropicStream(
+          providerLabel,
+          "unsupported event type",
+        );
       }
 
-      if (completedClientToolUseStep && toolCalls.size === 0) {
+      if (
+        completedClientToolUseStep &&
+        toolCalls.size === 0 &&
+        reasoningBlocks.size === 0 &&
+        openContentBlocks.size === 0
+      ) {
         if (isToolCallsFinishReason(finishReason)) {
           clientToolUseIdleDeadlineMs = null;
           clientToolUseTerminalDeadlineMs ??= Date.now() + trailingUsageGraceMs;
         } else {
           clientToolUseIdleDeadlineMs ??= Date.now() + trailingUsageGraceMs;
         }
+      } else {
+        clientToolUseIdleDeadlineMs = null;
+        clientToolUseTerminalDeadlineMs = null;
+      }
+      if (reachedEndOfStream) {
+        break;
       }
     }
   } finally {
     if (!readerReleased) {
+      if (!sourceSettled) {
+        cancelStreamReader(reader, "Anthropic stream consumer returned before completion");
+      }
       reader.releaseLock();
     }
   }
 
   mergeTrailingBufferUsage();
+  validateCompletion();
 
+  notifyCompletion();
   yield buildFinishPart();
 }

--- a/extensions/ext-llm-google/README.md
+++ b/extensions/ext-llm-google/README.md
@@ -47,7 +47,7 @@ Any model accessible through the Google Generative Language API:
 
 - **Flagship:** `gemini-2.5-pro`, `gemini-2.5-flash`
 - **Stable:** `gemini-2.0-flash`, `gemini-1.5-pro`, `gemini-1.5-flash`
-- **Embeddings:** `text-embedding-005`, `text-embedding-004`
+- **Embeddings:** `gemini-embedding-2`
 
 ## Configuration
 
@@ -98,7 +98,16 @@ Set `budgetTokens` directly to override the effort mapping:
 reasoning: { enabled: true, budgetTokens: 4096 }
 ```
 
+Explicit budgets must be non-negative safe integers. The `-1` dynamic-budget
+sentinel is reserved for `effort: "max"` and is rejected when supplied through
+`budgetTokens`.
+
 When thinking is enabled, Gemini returns `thought` parts that the runtime emits as `reasoning-start` / `reasoning-delta` / `reasoning-end` stream events.
+
+Gemini `thoughtSignature` fields are retained with the exact assistant parts that produced them and replayed automatically on later turns, including parallel function-call responses.
+Streaming and replay share one deterministic raw-position tool-ID registry.
+Exact replay retains at most 4,096 raw assistant parts and 8 MiB; surviving
+canonical calls and results must match the raw history in occurrence order.
 
 ## Prompt Caching
 
@@ -111,11 +120,23 @@ const response = await ai.chat("google/gemini-2.5-pro", {
 });
 ```
 
-When a cached content resource is attached, the response `usageMetadata.cachedContentTokenCount` is surfaced as `cacheReadInputTokens` on the result.
+When a cached content resource is attached, the response
+`usageMetadata.cachedContentTokenCount` is surfaced as the canonical
+`cacheReadInputTokens` field and the compatible `cachedInputTokens` alias on
+the result.
 
 ## Provider Tools
 
 Gemini supports provider-native tools alongside function declarations. Use the `provider` tool type with a `google.*` id:
+
+The extension intentionally supports only the provider tools whose request and
+response contracts are normalized end to end:
+
+- `google.code_execution` with name `code_execution`
+- `google.google_search` with name `google_search`
+
+Unknown or duplicate provider-tool IDs, tools for another provider, mismatched
+names, and unsupported argument fields throw before the HTTP request is sent.
 
 ### Code Execution
 
@@ -125,15 +146,47 @@ tools: [
 ];
 ```
 
+Google `executableCode` / `codeExecutionResult` parts are exposed as correlated
+`code_execution` tool calls and results with `providerExecuted: true`. Failed
+and deadline-exceeded outcomes are marked as tool errors. The original ordered
+Google parts, including provider IDs and thought signatures, are retained for
+exact replay on subsequent turns.
+
 ### Google Search
 
 ```ts
 tools: [
-  { type: "provider", name: "google_search", id: "google.google_search", args: {} },
+  {
+    type: "provider",
+    name: "google_search",
+    id: "google.google_search",
+    args: {
+      searchTypes: { webSearch: {}, imageSearch: {} },
+      timeRangeFilter: {
+        startTime: "2026-01-01T00:00:00Z",
+        endTime: "2026-07-01T00:00:00Z",
+      },
+    },
+  },
 ];
 ```
 
-Provider tools can be combined with regular function tools in the same request. When Google Search is used, the response includes `groundingMetadata` with web search queries, grounding chunks, and citation indices.
+Both Google Search argument groups are optional; `{}` keeps Google's default web
+search behavior. A time range requires both RFC 3339 timestamps. The nested
+`webSearch` and `imageSearch` configurations are currently empty objects, as
+defined by Google's API.
+
+Provider tools can be combined with regular function tools in the same request.
+Google Search does not produce a client-executed tool call. Instead, Google
+returns a candidate-level `groundingMetadata` object containing queries,
+grounding chunks, and citation indices. The direct adapter result retains the
+legacy top-level `groundingMetadata` property, and direct and streaming results
+also expose the same opaque object at
+`providerMetadata.google.groundingMetadata`, which survives runtime
+normalization. The object envelope and stable citation list fields
+(`groundingChunks`, `groundingSupports`, `webSearchQueries`, and
+`imageSearchQueries`) are validated for shape. Other nested fields remain
+Google-owned so new metadata can pass through without an extension release.
 
 ## Safety Settings
 
@@ -199,12 +252,11 @@ The following settings emit `unsupported-setting` warnings and are silently drop
 
 The extension surfaces typed provider errors:
 
-| Error Class               | Trigger                       | Retryable |
-| ------------------------- | ----------------------------- | --------- |
-| `ProviderOverloadedError` | HTTP 503                      | Yes       |
-| `ProviderQuotaError`      | HTTP 429 `RESOURCE_EXHAUSTED` | No        |
-| `ProviderRateLimitError`  | HTTP 429 with `Retry-After`   | Yes       |
-| `ProviderRequestError`    | Other HTTP errors             | No        |
+| Error Class               | Trigger                                        | Retryable |
+| ------------------------- | ---------------------------------------------- | --------- |
+| `ProviderOverloadedError` | HTTP 503                                       | Yes       |
+| `ProviderRateLimitError`  | HTTP 429 `RESOURCE_EXHAUSTED` or rate limiting | Yes       |
+| `ProviderRequestError`    | Other HTTP errors                              | No        |
 
 If the extension is not installed and a `google/*` model is requested:
 
@@ -226,22 +278,22 @@ The unified `toolChoice` option maps to Gemini's `functionCallingConfig`:
 
 ```bash
 # From the repository root
-deno test --no-check --allow-all extensions/ext-google/
+deno test --no-check --allow-all extensions/ext-llm-google/src/
 
 # Or from the extension directory
-cd extensions/ext-google
+cd extensions/ext-llm-google
 deno task test
 ```
 
 The test suite covers:
 
 - Generate and stream request/response mapping
-- Extended thinking (thinkingConfig budget mapping, thought-part streaming)
+- Extended thinking (validated thinkingConfig budgets, thought-part streaming)
 - Embedding runtime (single and batch)
 - Error classification (503, 429 RESOURCE_EXHAUSTED)
 - Unsupported-setting warnings (presencePenalty, frequencyPenalty)
 - User ID and request label forwarding
 - Tool choice normalization (auto, any, none, single-tool, multi-tool)
 - Grounding metadata pass-through (google_search)
-- Provider tools (code_execution, google_search)
+- Provider tools (correlated code_execution calls/results and google_search)
 - Safety settings and cached content

--- a/extensions/ext-llm-google/README.md
+++ b/extensions/ext-llm-google/README.md
@@ -36,7 +36,7 @@ const response = await ai.chat("google/gemini-2.5-pro", {
 ### Embeddings
 
 ```ts
-const result = await ai.embed("google/text-embedding-005", {
+const result = await ai.embed("google/gemini-embedding-2", {
   values: ["search query"],
 });
 ```

--- a/extensions/ext-llm-google/src/google-content-parts.ts
+++ b/extensions/ext-llm-google/src/google-content-parts.ts
@@ -1,0 +1,237 @@
+import { readRecord } from "veryfront/provider/shared";
+
+export const GOOGLE_CODE_EXECUTION_TOOL_NAME = "code_execution";
+
+const GOOGLE_PART_DATA_FIELDS = [
+  "text",
+  "inlineData",
+  "functionCall",
+  "functionResponse",
+  "fileData",
+  "executableCode",
+  "codeExecutionResult",
+  "toolCall",
+  "toolResponse",
+] as const;
+
+const GOOGLE_PART_METADATA_FIELDS = new Set([
+  "mediaResolution",
+  "partMetadata",
+  "thought",
+  "thoughtSignature",
+  "videoMetadata",
+]);
+
+export type GoogleSupportedPartDataField =
+  | "text"
+  | "functionCall"
+  | "executableCode"
+  | "codeExecutionResult";
+
+export type GoogleExecutableCode = {
+  providerId?: string;
+  language: "PYTHON";
+  code: string;
+};
+
+export type GoogleCodeExecutionResult = {
+  providerId?: string;
+  outcome: "OUTCOME_OK" | "OUTCOME_FAILED" | "OUTCOME_DEADLINE_EXCEEDED";
+  output: string;
+  isError: boolean;
+};
+
+export type GoogleToolCallCorrelationRegistry = {
+  registerFunctionCall(partIndex: number, providerId: string | undefined): string;
+  registerCodeExecution(providerId: string | undefined): string;
+  resolveCodeExecutionResult(providerId: string | undefined): string;
+  assertSettled(): void;
+};
+
+/**
+ * Owns Gemini's tool-call id allocation and code-execution pairing rules.
+ *
+ * The response normalizer and exact-replay validator must derive identical
+ * ids for anonymous code execution. Keeping the allocator here prevents those
+ * two protocol boundaries from drifting independently.
+ */
+export function createGoogleToolCallCorrelationRegistry(): GoogleToolCallCorrelationRegistry {
+  const usedToolCallIds = new Set<string>();
+  const pendingCodeExecutionsByProviderId = new Map<string, string>();
+  const pendingAnonymousCodeExecutions: string[] = [];
+  let anonymousCodeExecutionIndex = 0;
+
+  const reserve = (id: string): string => {
+    if (usedToolCallIds.has(id)) {
+      throw new TypeError("Google tool call id was duplicated");
+    }
+    usedToolCallIds.add(id);
+    return id;
+  };
+
+  return {
+    registerFunctionCall(partIndex, providerId) {
+      return reserve(providerId ?? `tool-${partIndex}`);
+    },
+    registerCodeExecution(providerId) {
+      if (providerId !== undefined) {
+        const id = reserve(providerId);
+        pendingCodeExecutionsByProviderId.set(providerId, id);
+        return id;
+      }
+
+      let id: string;
+      do {
+        id = `google-code-execution-${anonymousCodeExecutionIndex++}`;
+      } while (usedToolCallIds.has(id));
+      usedToolCallIds.add(id);
+      pendingAnonymousCodeExecutions.push(id);
+      return id;
+    },
+    resolveCodeExecutionResult(providerId) {
+      if (providerId === undefined) {
+        const id = pendingAnonymousCodeExecutions.shift();
+        if (id === undefined) {
+          throw new TypeError(
+            "Google code execution result had no matching executable code",
+          );
+        }
+        return id;
+      }
+
+      const id = pendingCodeExecutionsByProviderId.get(providerId);
+      if (id === undefined) {
+        throw new TypeError(
+          "Google code execution result id did not match executable code",
+        );
+      }
+      pendingCodeExecutionsByProviderId.delete(providerId);
+      return id;
+    },
+    assertSettled() {
+      if (
+        pendingCodeExecutionsByProviderId.size > 0 ||
+        pendingAnonymousCodeExecutions.length > 0
+      ) {
+        throw new TypeError(
+          "Google executable code had no matching execution result",
+        );
+      }
+    },
+  };
+}
+
+/**
+ * Validates the documented `Part.data` oneof and returns the supported field.
+ *
+ * The extension intentionally fails closed for media/file/function-response
+ * output parts until it has a canonical runtime representation for them.
+ */
+export function readGooglePartDataField(
+  part: Record<string, unknown>,
+): GoogleSupportedPartDataField {
+  const unknownField = Object.keys(part).find((field) =>
+    !GOOGLE_PART_DATA_FIELDS.includes(
+      field as (typeof GOOGLE_PART_DATA_FIELDS)[number],
+    ) && !GOOGLE_PART_METADATA_FIELDS.has(field)
+  );
+  if (unknownField !== undefined) {
+    throw new TypeError(`Google part field "${unknownField}" is unknown`);
+  }
+
+  const presentFields = GOOGLE_PART_DATA_FIELDS.filter((field) => part[field] !== undefined);
+  if (presentFields.length !== 1) {
+    throw new TypeError("Google part must contain exactly one data field");
+  }
+
+  const field = presentFields[0];
+  switch (field) {
+    case "text":
+    case "functionCall":
+    case "executableCode":
+    case "codeExecutionResult":
+      return field;
+    default:
+      throw new TypeError(`Google part data field "${field}" is unsupported`);
+  }
+}
+
+function readOptionalProviderId(
+  record: Record<string, unknown>,
+  subject: string,
+): string | undefined {
+  if (record.id === undefined) {
+    return undefined;
+  }
+  if (typeof record.id !== "string" || record.id.length === 0) {
+    throw new TypeError(`Google ${subject} id must be a non-empty string`);
+  }
+  return record.id;
+}
+
+export function readGoogleExecutableCode(value: unknown): GoogleExecutableCode {
+  const record = readRecord(value);
+  if (
+    !record ||
+    record.language !== "PYTHON" ||
+    typeof record.code !== "string" ||
+    record.code.length === 0
+  ) {
+    throw new TypeError("Google executable code is malformed");
+  }
+
+  const providerId = readOptionalProviderId(record, "executable code");
+  return {
+    ...(providerId !== undefined ? { providerId } : {}),
+    language: "PYTHON",
+    code: record.code,
+  };
+}
+
+export function readGoogleCodeExecutionResult(value: unknown): GoogleCodeExecutionResult {
+  const record = readRecord(value);
+  if (!record) {
+    throw new TypeError("Google code execution result is malformed");
+  }
+
+  const providerId = readOptionalProviderId(record, "code execution result");
+  const outcome = record.outcome;
+  if (
+    outcome !== "OUTCOME_OK" &&
+    outcome !== "OUTCOME_FAILED" &&
+    outcome !== "OUTCOME_DEADLINE_EXCEEDED"
+  ) {
+    throw new TypeError("Google code execution result outcome is malformed");
+  }
+  if (record.output !== undefined && typeof record.output !== "string") {
+    throw new TypeError("Google code execution result output is malformed");
+  }
+
+  return {
+    ...(providerId !== undefined ? { providerId } : {}),
+    outcome,
+    output: typeof record.output === "string" ? record.output : "",
+    isError: outcome !== "OUTCOME_OK",
+  };
+}
+
+export function googleCodeExecutionInput(
+  executableCode: GoogleExecutableCode,
+): { language: "PYTHON"; code: string } {
+  return {
+    language: executableCode.language,
+    code: executableCode.code,
+  };
+}
+
+export function googleCodeExecutionOutput(
+  result: GoogleCodeExecutionResult,
+): {
+  outcome: GoogleCodeExecutionResult["outcome"];
+  output: string;
+} {
+  return {
+    outcome: result.outcome,
+    output: result.output,
+  };
+}

--- a/extensions/ext-llm-google/src/google-grounding-metadata.ts
+++ b/extensions/ext-llm-google/src/google-grounding-metadata.ts
@@ -1,0 +1,110 @@
+import { readRecord } from "veryfront/provider/shared";
+
+const APPENDED_OBJECT_ARRAY_FIELDS = [
+  "groundingChunks",
+  "groundingSupports",
+] as const;
+const MERGED_STRING_ARRAY_FIELDS = [
+  "webSearchQueries",
+  "imageSearchQueries",
+] as const;
+
+type AppendedObjectArrayField = (typeof APPENDED_OBJECT_ARRAY_FIELDS)[number];
+type MergedStringArrayField = (typeof MERGED_STRING_ARRAY_FIELDS)[number];
+
+function readObjectArray(
+  value: unknown,
+  field: AppendedObjectArrayField,
+): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`Google grounding metadata ${field} must be an array`);
+  }
+  return value.map((item) => {
+    const record = readRecord(item);
+    if (!record) {
+      throw new TypeError(`Google grounding metadata ${field} item must be an object`);
+    }
+    return record;
+  });
+}
+
+function readStringArray(
+  value: unknown,
+  field: MergedStringArrayField,
+): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new TypeError(`Google grounding metadata ${field} must be a string array`);
+  }
+  return value;
+}
+
+/**
+ * Validate the stable list fields needed to preserve citation integrity while
+ * retaining all other Google-owned metadata fields opaquely.
+ */
+export function readGoogleGroundingMetadata(
+  value: unknown,
+): Record<string, unknown> {
+  const metadata = readRecord(value);
+  if (!metadata) {
+    throw new TypeError("Google grounding metadata must be an object");
+  }
+
+  const normalized = { ...metadata };
+  for (const field of APPENDED_OBJECT_ARRAY_FIELDS) {
+    if (metadata[field] !== undefined) {
+      normalized[field] = readObjectArray(metadata[field], field);
+    }
+  }
+  for (const field of MERGED_STRING_ARRAY_FIELDS) {
+    if (metadata[field] !== undefined) {
+      normalized[field] = readStringArray(metadata[field], field);
+    }
+  }
+  return normalized;
+}
+
+/**
+ * Merge one streaming GroundingMetadata delta into the aggregate result.
+ *
+ * Google documents groundingChunks as incremental in streaming responses and
+ * defines support indices across every response. Supports are therefore
+ * appended too, while query strings are accumulated without duplicates.
+ * Scalar/object fields and unknown future fields use the latest value.
+ */
+export function mergeGoogleGroundingMetadata(
+  current: Record<string, unknown> | undefined,
+  incoming: unknown,
+): Record<string, unknown> {
+  const normalizedIncoming = readGoogleGroundingMetadata(incoming);
+  const merged: Record<string, unknown> = {
+    ...(current ?? {}),
+    ...normalizedIncoming,
+  };
+
+  for (const field of APPENDED_OBJECT_ARRAY_FIELDS) {
+    const previousItems = current?.[field];
+    const incomingItems = normalizedIncoming[field];
+    if (incomingItems !== undefined) {
+      merged[field] = [
+        ...(Array.isArray(previousItems) ? previousItems : []),
+        ...(incomingItems as unknown[]),
+      ];
+    }
+  }
+
+  for (const field of MERGED_STRING_ARRAY_FIELDS) {
+    const previousItems = current?.[field];
+    const incomingItems = normalizedIncoming[field];
+    if (incomingItems !== undefined) {
+      merged[field] = [
+        ...new Set([
+          ...(Array.isArray(previousItems) ? previousItems as string[] : []),
+          ...(incomingItems as string[]),
+        ]),
+      ];
+    }
+  }
+
+  return merged;
+}

--- a/extensions/ext-llm-google/src/google-provider.test.ts
+++ b/extensions/ext-llm-google/src/google-provider.test.ts
@@ -904,7 +904,7 @@ describe("ext-llm-google/google-provider", () => {
           issue: "candidate function call arguments were not an object",
         },
         {
-          part: { functionCall: { id: "tool_1", name: "lookup" } },
+          part: { functionCall: { id: "tool_1", name: "lookup", args: null } },
           issue: "candidate function call arguments were not an object",
         },
       ];
@@ -929,6 +929,33 @@ describe("ext-llm-google/google-provider", () => {
           issue,
         );
       }
+    });
+
+    it("treats an omitted function call args field as empty arguments", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [{
+                content: {
+                  role: "model",
+                  parts: [{ functionCall: { id: "tool_1", name: "ping" } }],
+                },
+                finishReason: "STOP",
+              }],
+            }),
+          ),
+      }, "gemini-3-pro");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+
+      assertEquals(result.content, [{
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "ping",
+        input: "{}",
+      }]);
     });
 
     it("rejects a generation candidate with no supported output", async () => {

--- a/extensions/ext-llm-google/src/google-provider.test.ts
+++ b/extensions/ext-llm-google/src/google-provider.test.ts
@@ -9,6 +9,7 @@ import {
 
 import { createGoogleEmbeddingRuntime, createGoogleModelRuntime } from "./google-provider.ts";
 import { buildGoogleGenerateContentRequest } from "./google-request-builder.ts";
+import { MAX_GOOGLE_PROVIDER_METADATA_BYTES } from "./google-thought-signatures.ts";
 
 async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {
   const values: T[] = [];
@@ -710,6 +711,33 @@ describe("ext-llm-google/google-provider", () => {
           google: { rawAssistantParts },
         },
       });
+    });
+
+    it("maps direct replay metadata budget failures to the typed response error", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [{
+                content: {
+                  role: "model",
+                  parts: [{
+                    text: "x".repeat(MAX_GOOGLE_PROVIDER_METADATA_BYTES),
+                    thoughtSignature: "oversized-signed-part",
+                  }],
+                },
+                finishReason: "STOP",
+              }],
+            }),
+          ),
+      }, "gemini-3-pro");
+
+      await expectInvalidSuccessfulResponse(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        "google",
+        "provider metadata could not be retained safely",
+      );
     });
 
     it("normalizes correlated Google code execution and preserves every raw part for replay", async () => {

--- a/extensions/ext-llm-google/src/google-provider.test.ts
+++ b/extensions/ext-llm-google/src/google-provider.test.ts
@@ -8,6 +8,7 @@ import {
 } from "veryfront/provider/shared";
 
 import { createGoogleEmbeddingRuntime, createGoogleModelRuntime } from "./google-provider.ts";
+import { buildGoogleGenerateContentRequest } from "./google-request-builder.ts";
 
 async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {
   const values: T[] = [];
@@ -932,6 +933,10 @@ describe("ext-llm-google/google-provider", () => {
     });
 
     it("treats an omitted function call args field as empty arguments", async () => {
+      const rawAssistantParts = [{
+        functionCall: { id: "tool_1", name: "ping" },
+        thoughtSignature: "signed-zero-argument-call",
+      }];
       const runtime = createGoogleModelRuntime({
         apiKey: "k",
         fetch: () =>
@@ -940,7 +945,7 @@ describe("ext-llm-google/google-provider", () => {
               candidates: [{
                 content: {
                   role: "model",
-                  parts: [{ functionCall: { id: "tool_1", name: "ping" } }],
+                  parts: rawAssistantParts,
                 },
                 finishReason: "STOP",
               }],
@@ -955,6 +960,28 @@ describe("ext-llm-google/google-provider", () => {
         toolCallId: "tool_1",
         toolName: "ping",
         input: "{}",
+      }]);
+      assertEquals(result.providerMetadata, {
+        google: { rawAssistantParts },
+      });
+      if (!result.content) {
+        throw new Error("Expected Google tool-call content");
+      }
+
+      const continuation = buildGoogleGenerateContentRequest(
+        "google",
+        {
+          prompt: [{
+            role: "assistant",
+            content: result.content,
+            providerMetadata: result.providerMetadata,
+          }],
+        },
+        { push() {}, drain: () => [] },
+      );
+      assertEquals(continuation.contents, [{
+        role: "model",
+        parts: rawAssistantParts,
       }]);
     });
 

--- a/extensions/ext-llm-google/src/google-provider.test.ts
+++ b/extensions/ext-llm-google/src/google-provider.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 
-import { ProviderOverloadedError, ProviderRateLimitError } from "veryfront/provider/shared";
+import {
+  ProviderOverloadedError,
+  ProviderRateLimitError,
+  ProviderRequestError,
+} from "veryfront/provider/shared";
 
 import { createGoogleEmbeddingRuntime, createGoogleModelRuntime } from "./google-provider.ts";
 
@@ -11,6 +15,25 @@ async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {
     values.push(value);
   }
   return values;
+}
+
+async function waitWithin<T>(promise: Promise<T>, timeoutMs = 500): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`Timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 function readRequestBody(init: RequestInit | undefined): string | null {
@@ -25,6 +48,52 @@ function readRequestHeader(init: RequestInit | undefined, name: string): string 
     return null;
   }
   return new Headers(init.headers).get(name);
+}
+
+function readRequestSignal(init: RequestInit | undefined): AbortSignal | undefined {
+  if (!init || !("signal" in init) || !(init.signal instanceof AbortSignal)) {
+    return undefined;
+  }
+  return init.signal;
+}
+
+function googleJsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function expectInvalidSuccessfulResponse(
+  promise: PromiseLike<unknown>,
+  providerLabel: string,
+  issue: string,
+  forbiddenText?: string,
+): Promise<ProviderRequestError> {
+  try {
+    await promise;
+  } catch (error) {
+    if (!(error instanceof ProviderRequestError)) {
+      throw new Error(
+        `Expected ProviderRequestError, got ${
+          error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+        }`,
+      );
+    }
+    assertEquals(error.provider, "google");
+    assertEquals(error.status, 200);
+    assertEquals(error.retryable, false);
+    assertEquals(
+      error.message,
+      `${providerLabel} request failed: invalid successful response (${issue})`,
+    );
+    assertEquals(error.responseBody, undefined);
+    if (forbiddenText !== undefined) {
+      assertEquals(error.message.includes(forbiddenText), false);
+    }
+    return error;
+  }
+  throw new Error("Expected ProviderRequestError, but the request resolved");
 }
 
 describe("ext-llm-google/google-provider", () => {
@@ -308,6 +377,66 @@ describe("ext-llm-google/google-provider", () => {
     ]);
   });
 
+  it("aborts the request and cancels a pending upstream body when the consumer cancels", async () => {
+    const consumerReason = new DOMException("Consumer stopped Google stream", "AbortError");
+    let requestSignal: AbortSignal | undefined;
+    let upstreamCancelReason: unknown;
+    let notifyUpstreamPull!: () => void;
+    const upstreamPullStarted = new Promise<void>((resolve) => {
+      notifyUpstreamPull = resolve;
+    });
+    let notifyUpstreamCanceled!: () => void;
+    const upstreamCanceled = new Promise<void>((resolve) => {
+      notifyUpstreamCanceled = resolve;
+    });
+    let pullNotified = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        if (!pullNotified) {
+          pullNotified = true;
+          notifyUpstreamPull();
+        }
+        return new Promise<void>(() => {});
+      },
+      cancel(reason) {
+        upstreamCancelReason = reason;
+        notifyUpstreamCanceled();
+      },
+    });
+
+    const runtime = createGoogleModelRuntime({
+      apiKey: "test-google-key",
+      baseURL: "https://example.google.test/v1beta",
+      fetch: (_input, init) => {
+        requestSignal = readRequestSignal(init);
+        return Promise.resolve(
+          new Response(body, {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        );
+      },
+    }, "gemini-3-flash");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Wait for an answer" }],
+      }],
+    });
+    const reader = result.stream.getReader();
+    const pendingRead = reader.read();
+    await waitWithin(upstreamPullStarted);
+
+    await waitWithin(reader.cancel(consumerReason));
+    await waitWithin(upstreamCanceled);
+
+    assertEquals(requestSignal?.aborted, true);
+    assertEquals(requestSignal?.reason === consumerReason, true);
+    assertEquals(upstreamCancelReason === consumerReason, true);
+    assertEquals((await waitWithin(pendingRead)).done, true);
+  });
+
   it("parses Google thought parts into reasoning events", async () => {
     const encoder = new TextEncoder();
 
@@ -427,6 +556,683 @@ describe("ext-llm-google/google-provider", () => {
     ]);
     assertEquals(result.embeddings, [[10, 20], [30, 40]]);
     assertEquals(result.usage, { tokens: 8 });
+  });
+
+  describe("successful response validation", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    it("rejects an empty generation envelope without leaking its payload", async () => {
+      const providerLabel = "google-test";
+      const secret = "private-upstream-diagnostic";
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        name: providerLabel,
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [],
+              upstreamDiagnostic: secret,
+            }),
+          ),
+      }, "gemini-2.0-flash");
+
+      await expectInvalidSuccessfulResponse(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        providerLabel,
+        "candidates array missing or empty",
+        secret,
+      );
+    });
+
+    it("rejects malformed generation candidate content", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [{
+                content: { parts: [null] },
+                finishReason: "STOP",
+              }],
+            }),
+          ),
+      }, "gemini-2.0-flash");
+
+      await expectInvalidSuccessfulResponse(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        "google",
+        "candidate content part was not an object",
+      );
+    });
+
+    it("rejects ambiguous successful responses with multiple candidates", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [
+                {
+                  content: { parts: [{ text: "first" }] },
+                  finishReason: "STOP",
+                },
+                {
+                  content: { parts: [{ text: "second" }] },
+                  finishReason: "STOP",
+                },
+              ],
+            }),
+          ),
+      }, "gemini-2.0-flash");
+
+      await expectInvalidSuccessfulResponse(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        "google",
+        "generation response contained multiple candidates",
+      );
+    });
+
+    it("preserves signed thought and parallel function-call parts without exposing thought text", async () => {
+      const rawAssistantParts = [
+        {
+          text: "Private chain of thought.",
+          thought: true,
+          thoughtSignature: "thought-signature",
+        },
+        {
+          functionCall: {
+            id: "tool_paris",
+            name: "weather",
+            args: { city: "Paris" },
+          },
+          thoughtSignature: "parallel-call-signature",
+        },
+        {
+          functionCall: {
+            id: "tool_london",
+            name: "weather",
+            args: { city: "London" },
+          },
+        },
+      ];
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [{
+                content: { role: "model", parts: rawAssistantParts },
+                finishReason: "STOP",
+              }],
+            }),
+          ),
+      }, "gemini-3-pro");
+
+      assertEquals(await runtime.doGenerate({ prompt: [userPrompt] }), {
+        content: [
+          {
+            type: "reasoning",
+            text: "Private chain of thought.",
+            signature: "thought-signature",
+          },
+          {
+            type: "tool-call",
+            toolCallId: "tool_paris",
+            toolName: "weather",
+            input: '{"city":"Paris"}',
+          },
+          {
+            type: "tool-call",
+            toolCallId: "tool_london",
+            toolName: "weather",
+            input: '{"city":"London"}',
+          },
+        ],
+        finishReason: { unified: "stop", raw: "STOP" },
+        providerMetadata: {
+          google: { rawAssistantParts },
+        },
+      });
+    });
+
+    it("normalizes correlated Google code execution and preserves every raw part for replay", async () => {
+      const rawAssistantParts = [
+        {
+          executableCode: {
+            id: "code_1",
+            language: "PYTHON",
+            code: "print(6 * 7)",
+          },
+          thoughtSignature: "code-signature",
+        },
+        {
+          codeExecutionResult: {
+            id: "code_1",
+            outcome: "OUTCOME_OK",
+            output: "42\n",
+          },
+        },
+        { text: "The answer is 42." },
+      ];
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [{
+                content: { role: "model", parts: rawAssistantParts },
+                finishReason: "STOP",
+              }],
+            }),
+          ),
+      }, "gemini-3-pro");
+
+      assertEquals(await runtime.doGenerate({ prompt: [userPrompt] }), {
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "code_1",
+            toolName: "code_execution",
+            input: '{"language":"PYTHON","code":"print(6 * 7)"}',
+            providerExecuted: true,
+          },
+          {
+            type: "tool-result",
+            toolCallId: "code_1",
+            toolName: "code_execution",
+            result: { outcome: "OUTCOME_OK", output: "42\n" },
+            providerExecuted: true,
+          },
+          { type: "text", text: "The answer is 42." },
+        ],
+        finishReason: { unified: "stop", raw: "STOP" },
+        providerMetadata: {
+          google: { rawAssistantParts },
+        },
+      });
+    });
+
+    it("synthesizes stable ids and marks failed code execution outcomes as errors", async () => {
+      for (
+        const outcome of [
+          "OUTCOME_FAILED",
+          "OUTCOME_DEADLINE_EXCEEDED",
+        ] as const
+      ) {
+        const rawAssistantParts = [
+          {
+            executableCode: {
+              language: "PYTHON",
+              code: "raise RuntimeError('boom')",
+            },
+          },
+          {
+            codeExecutionResult: {
+              outcome,
+              output: "boom",
+            },
+          },
+        ];
+        const runtime = createGoogleModelRuntime({
+          apiKey: "k",
+          fetch: () =>
+            Promise.resolve(
+              googleJsonResponse({
+                candidates: [{
+                  content: { role: "model", parts: rawAssistantParts },
+                  finishReason: "STOP",
+                }],
+              }),
+            ),
+        }, "gemini-3-pro");
+
+        assertEquals(await runtime.doGenerate({ prompt: [userPrompt] }), {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "google-code-execution-0",
+              toolName: "code_execution",
+              input: '{"language":"PYTHON","code":"raise RuntimeError(\'boom\')"}',
+              providerExecuted: true,
+            },
+            {
+              type: "tool-result",
+              toolCallId: "google-code-execution-0",
+              toolName: "code_execution",
+              result: { outcome, output: "boom" },
+              isError: true,
+              providerExecuted: true,
+            },
+          ],
+          finishReason: { unified: "stop", raw: "STOP" },
+          providerMetadata: {
+            google: { rawAssistantParts },
+          },
+        });
+      }
+    });
+
+    it("fails closed on malformed, unpaired, and unsupported Google output parts", async () => {
+      const malformedCases = [
+        {
+          parts: [{
+            executableCode: { id: "code_1", language: "JAVASCRIPT", code: "1 + 1" },
+          }],
+          issue: "candidate executable code was malformed",
+        },
+        {
+          parts: [{
+            executableCode: { id: "code_1", language: "PYTHON", code: "1 + 1" },
+          }, {
+            codeExecutionResult: {
+              id: "code_2",
+              outcome: "OUTCOME_OK",
+              output: "2",
+            },
+          }],
+          issue: "candidate code execution result did not match executable code",
+        },
+        {
+          parts: [{
+            executableCode: { id: "code_1", language: "PYTHON", code: "1 + 1" },
+          }],
+          issue: "candidate executable code had no matching execution result",
+        },
+        {
+          parts: [{
+            executableCode: { id: "code_1", language: "PYTHON", code: "1 + 1" },
+          }, {
+            codeExecutionResult: {
+              id: "code_1",
+              outcome: "OUTCOME_UNSPECIFIED",
+            },
+          }],
+          issue: "candidate code execution result was malformed",
+        },
+        {
+          parts: [{ inlineData: { mimeType: "image/png", data: "AAAA" } }],
+          issue: "candidate part contained an unsupported data field",
+        },
+        {
+          parts: [{ futureServerTool: { id: "unknown" } }],
+          issue: "candidate part contained an unsupported data field",
+        },
+      ];
+
+      for (const { parts, issue } of malformedCases) {
+        const runtime = createGoogleModelRuntime({
+          apiKey: "k",
+          fetch: () =>
+            Promise.resolve(
+              googleJsonResponse({
+                candidates: [{
+                  content: { role: "model", parts },
+                  finishReason: "STOP",
+                }],
+              }),
+            ),
+        }, "gemini-3-pro");
+
+        await assertRejects(
+          () => Promise.resolve(runtime.doGenerate({ prompt: [userPrompt] })),
+          ProviderRequestError,
+          issue,
+        );
+      }
+    });
+
+    it("rejects malformed thought signatures and non-object function arguments", async () => {
+      const malformedCases = [
+        {
+          part: { text: "answer", thoughtSignature: 42 },
+          issue: "candidate thought signature was malformed",
+        },
+        {
+          part: {
+            text: "answer",
+            functionCall: { id: "tool_1", name: "lookup", args: {} },
+          },
+          issue: "candidate part contained multiple data fields",
+        },
+        {
+          part: {
+            functionCall: { id: "tool_1", name: "lookup", args: ["not", "an", "object"] },
+          },
+          issue: "candidate function call arguments were not an object",
+        },
+        {
+          part: { functionCall: { id: "tool_1", name: "lookup" } },
+          issue: "candidate function call arguments were not an object",
+        },
+      ];
+
+      for (const { part, issue } of malformedCases) {
+        const runtime = createGoogleModelRuntime({
+          apiKey: "k",
+          fetch: () =>
+            Promise.resolve(
+              googleJsonResponse({
+                candidates: [{
+                  content: { role: "model", parts: [part] },
+                  finishReason: "STOP",
+                }],
+              }),
+            ),
+        }, "gemini-3-pro");
+
+        await assertRejects(
+          () => Promise.resolve(runtime.doGenerate({ prompt: [userPrompt] })),
+          ProviderRequestError,
+          issue,
+        );
+      }
+    });
+
+    it("rejects a generation candidate with no supported output", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [{
+                content: { parts: [] },
+                finishReason: "STOP",
+              }],
+            }),
+          ),
+      }, "gemini-2.0-flash");
+
+      await expectInvalidSuccessfulResponse(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        "google",
+        "candidate contained no supported output content",
+      );
+    });
+
+    it("preserves a prompt-level content-filter response without candidates", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [],
+              promptFeedback: { blockReason: "PROHIBITED_CONTENT" },
+            }),
+          ),
+      }, "gemini-2.0-flash");
+
+      assertEquals(
+        await runtime.doGenerate({ prompt: [userPrompt] }),
+        {
+          content: [],
+          finishReason: {
+            unified: "content-filter",
+            raw: "PROHIBITED_CONTENT",
+          },
+        },
+      );
+    });
+
+    it("preserves a finish-only content-filter response", async () => {
+      const contentFilterReasons = [
+        "SAFETY",
+        "RECITATION",
+        "LANGUAGE",
+        "BLOCKLIST",
+        "PROHIBITED_CONTENT",
+        "SPII",
+        "IMAGE_SAFETY",
+        "IMAGE_PROHIBITED_CONTENT",
+        "IMAGE_RECITATION",
+        "ESCALATION",
+      ];
+
+      for (const finishReason of contentFilterReasons) {
+        const runtime = createGoogleModelRuntime({
+          apiKey: "k",
+          fetch: () =>
+            Promise.resolve(
+              googleJsonResponse({
+                candidates: [{
+                  content: { role: "model" },
+                  finishReason,
+                }],
+              }),
+            ),
+        }, "gemini-2.0-flash");
+
+        assertEquals(
+          await runtime.doGenerate({ prompt: [userPrompt] }),
+          {
+            content: [],
+            finishReason: { unified: "content-filter", raw: finishReason },
+          },
+        );
+      }
+    });
+
+    it("normalizes successful generation usage through the shared usage invariant", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              candidates: [{
+                content: { parts: [{ text: "ok" }] },
+                finishReason: "STOP",
+              }],
+              usageMetadata: {
+                promptTokenCount: 4,
+                candidatesTokenCount: 3,
+                totalTokenCount: 1,
+                cachedContentTokenCount: -2,
+              },
+            }),
+          ),
+      }, "gemini-2.0-flash");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 4,
+        outputTokens: 3,
+        totalTokens: 7,
+      });
+    });
+
+    it("rejects a malformed embedding envelope without leaking its payload", async () => {
+      const providerLabel = "google-embedding-test";
+      const secret = "private-embedding-diagnostic";
+      const runtime = createGoogleEmbeddingRuntime({
+        apiKey: "k",
+        name: providerLabel,
+        fetch: () =>
+          Promise.resolve(
+            googleJsonResponse({
+              embeddings: [],
+              upstreamDiagnostic: secret,
+            }),
+          ),
+      }, "text-embedding-004");
+
+      await expectInvalidSuccessfulResponse(
+        runtime.doEmbed({ values: ["alpha"] }),
+        providerLabel,
+        "embedding response must contain exactly one embedding",
+        secret,
+      );
+    });
+
+    it("rejects an empty or non-finite embedding vector", async () => {
+      const malformedBodies = [
+        JSON.stringify({ embedding: { values: [] } }),
+        '{"embedding":{"values":[1,1e309]}}',
+      ];
+
+      for (const body of malformedBodies) {
+        const runtime = createGoogleEmbeddingRuntime({
+          apiKey: "k",
+          fetch: () =>
+            Promise.resolve(
+              new Response(body, {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+            ),
+        }, "text-embedding-004");
+
+        await expectInvalidSuccessfulResponse(
+          runtime.doEmbed({ values: ["alpha"] }),
+          "google",
+          "embedding vector missing or invalid",
+        );
+      }
+    });
+
+    it("rejects inconsistent embedding dimensions across batched inputs", async () => {
+      let requestCount = 0;
+      const runtime = createGoogleEmbeddingRuntime({
+        apiKey: "k",
+        fetch: () => {
+          requestCount += 1;
+          return Promise.resolve(
+            googleJsonResponse({
+              embedding: {
+                values: requestCount === 1 ? [1, 2] : [3],
+              },
+              usageMetadata: { promptTokenCount: 1 },
+            }),
+          );
+        },
+      }, "text-embedding-004");
+
+      await expectInvalidSuccessfulResponse(
+        runtime.doEmbed({ values: ["alpha", "beta"] }),
+        "google",
+        "embedding vectors had inconsistent dimensions",
+      );
+    });
+
+    it("omits aggregate embedding usage when any response lacks a valid token count", async () => {
+      let requestCount = 0;
+      const runtime = createGoogleEmbeddingRuntime({
+        apiKey: "k",
+        fetch: () => {
+          requestCount += 1;
+          return Promise.resolve(
+            googleJsonResponse({
+              embedding: { values: requestCount === 1 ? [1, 2] : [3, 4] },
+              usageMetadata: requestCount === 1
+                ? { promptTokenCount: 3 }
+                : { promptTokenCount: Number.MAX_SAFE_INTEGER + 1 },
+            }),
+          );
+        },
+      }, "text-embedding-004");
+
+      const result = await runtime.doEmbed({ values: ["alpha", "beta"] });
+      assertEquals(result.embeddings, [[1, 2], [3, 4]]);
+      assertEquals("usage" in result, false);
+    });
+
+    it("aborts a never-settling embedding sibling after the first response fails validation", async () => {
+      let requestCount = 0;
+      let siblingSignal: AbortSignal | undefined;
+      let siblingAbortReason: unknown;
+      let notifySiblingStarted!: () => void;
+      const siblingStarted = new Promise<void>((resolve) => {
+        notifySiblingStarted = resolve;
+      });
+      let notifySiblingAborted!: () => void;
+      const siblingAborted = new Promise<void>((resolve) => {
+        notifySiblingAborted = resolve;
+      });
+
+      const runtime = createGoogleEmbeddingRuntime({
+        apiKey: "k",
+        fetch: (_input, init) => {
+          requestCount += 1;
+          if (requestCount === 1) {
+            return Promise.resolve(googleJsonResponse({ embedding: { values: [] } }));
+          }
+
+          siblingSignal = readRequestSignal(init);
+          notifySiblingStarted();
+          return new Promise<Response>((_resolve, reject) => {
+            const onAbort = () => {
+              siblingAbortReason = siblingSignal?.reason;
+              notifySiblingAborted();
+              reject(siblingSignal?.reason);
+            };
+            if (siblingSignal?.aborted) {
+              onAbort();
+            } else {
+              siblingSignal?.addEventListener("abort", onAbort, { once: true });
+            }
+          });
+        },
+      }, "text-embedding-004");
+
+      const embeddingPromise = Promise.resolve(
+        runtime.doEmbed({ values: ["invalid", "never settles"] }),
+      );
+      await waitWithin(siblingStarted);
+      const error = await assertRejects(
+        () => embeddingPromise,
+        ProviderRequestError,
+        "embedding vector missing or invalid",
+      );
+      await waitWithin(siblingAborted);
+
+      assertEquals(siblingSignal?.aborted, true);
+      assertEquals(siblingAbortReason === error, true);
+    });
+
+    it("preserves the caller abort reason across embedding fan-out", async () => {
+      const abortController = new AbortController();
+      const callerReason = new DOMException("Caller stopped embeddings", "AbortError");
+      const requestSignals: AbortSignal[] = [];
+      let notifyRequestsStarted!: () => void;
+      const requestsStarted = new Promise<void>((resolve) => {
+        notifyRequestsStarted = resolve;
+      });
+
+      const runtime = createGoogleEmbeddingRuntime({
+        apiKey: "k",
+        fetch: (_input, init) => {
+          const signal = readRequestSignal(init);
+          if (signal) {
+            requestSignals.push(signal);
+            if (requestSignals.length === 2) {
+              notifyRequestsStarted();
+            }
+          }
+          return new Promise<Response>((_resolve, reject) => {
+            const onAbort = () => reject(signal?.reason);
+            if (signal?.aborted) {
+              onAbort();
+            } else {
+              signal?.addEventListener("abort", onAbort, { once: true });
+            }
+          });
+        },
+      }, "text-embedding-004");
+
+      const embeddingPromise = Promise.resolve(
+        runtime.doEmbed({
+          values: ["alpha", "beta"],
+          abortSignal: abortController.signal,
+        }),
+      );
+      await waitWithin(requestsStarted);
+      abortController.abort(callerReason);
+      const error = await assertRejects(() => embeddingPromise, DOMException);
+
+      assertEquals(error === callerReason, true);
+      assertEquals(requestSignals.every((signal) => signal.reason === callerReason), true);
+    });
   });
 
   describe("reasoning / thinking request options", () => {
@@ -549,6 +1355,7 @@ describe("ext-llm-google/google-provider", () => {
         outputTokens: 45,
         totalTokens: 168,
         cacheReadInputTokens: 100,
+        cachedInputTokens: 100,
       });
     });
 
@@ -735,7 +1542,7 @@ describe("ext-llm-google/google-provider", () => {
     });
   });
 
-  describe("Anthropic thinking signature multi-turn replay", () => {
+  describe("Google provider-specific request options", () => {
     it("normalizes Google toolChoice 'tools' multi-name allowlist", async () => {
       let captured: Record<string, unknown> | null = null;
       const runtime = createGoogleModelRuntime({
@@ -857,8 +1664,14 @@ describe("ext-llm-google/google-provider", () => {
       }, "gemini-2.5-pro");
       const result = await runtime.doGenerate({
         prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
-      }) as { groundingMetadata?: Record<string, unknown> };
+      }) as {
+        groundingMetadata?: Record<string, unknown>;
+        providerMetadata?: Record<string, unknown>;
+      };
       assertEquals(result.groundingMetadata, groundingMetadata);
+      assertEquals(result.providerMetadata, {
+        google: { groundingMetadata },
+      });
     });
 
     it("omits groundingMetadata when the candidate doesn't have any", async () => {
@@ -887,6 +1700,35 @@ describe("ext-llm-google/google-provider", () => {
         prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
       }) as { groundingMetadata?: unknown };
       assertEquals("groundingMetadata" in result, false);
+    });
+
+    it("rejects malformed Google grounding metadata", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                  groundingMetadata: [],
+                }],
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gemini-2.5-pro");
+
+      await assertRejects(
+        () =>
+          runtime.doGenerate({
+            prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+          }),
+        ProviderRequestError,
+        "candidate grounding metadata was malformed",
+      );
     });
 
     it("emits Google code_execution provider tool", async () => {

--- a/extensions/ext-llm-google/src/google-provider.test.ts
+++ b/extensions/ext-llm-google/src/google-provider.test.ts
@@ -588,6 +588,19 @@ describe("ext-llm-google/google-provider", () => {
       );
     });
 
+    it("distinguishes a non-array candidates field from an empty candidates array", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        fetch: () => Promise.resolve(googleJsonResponse({ candidates: {} })),
+      }, "gemini-2.0-flash");
+
+      await expectInvalidSuccessfulResponse(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        "google",
+        "candidates was not an array",
+      );
+    });
+
     it("rejects malformed generation candidate content", async () => {
       const runtime = createGoogleModelRuntime({
         apiKey: "k",
@@ -636,7 +649,7 @@ describe("ext-llm-google/google-provider", () => {
       );
     });
 
-    it("preserves signed thought and parallel function-call parts without exposing thought text", async () => {
+    it("preserves signed thought text and parallel function-call parts", async () => {
       const rawAssistantParts = [
         {
           text: "Private chain of thought.",

--- a/extensions/ext-llm-google/src/google-provider.ts
+++ b/extensions/ext-llm-google/src/google-provider.ts
@@ -8,7 +8,11 @@
  */
 
 import type { LLMProvider, LLMProviderConfig } from "veryfront/extensions/llm";
-import type { EmbeddingRuntime, ModelRuntime } from "veryfront/provider/types";
+import type {
+  EmbeddingRuntime,
+  ModelRuntime,
+  RuntimeAssistantContentPart,
+} from "veryfront/provider/types";
 import {
   buildProviderError,
   createGoogleRequestInit,
@@ -38,7 +42,20 @@ import {
   type OpenAICompatibleLanguageOptions,
 } from "./google-request-builder.ts";
 import {
-  extractFirstGoogleCandidate,
+  createGoogleToolCallCorrelationRegistry,
+  GOOGLE_CODE_EXECUTION_TOOL_NAME,
+  googleCodeExecutionInput,
+  googleCodeExecutionOutput,
+  readGoogleCodeExecutionResult,
+  readGoogleExecutableCode,
+  readGooglePartDataField,
+} from "./google-content-parts.ts";
+import { readGoogleGroundingMetadata } from "./google-grounding-metadata.ts";
+import {
+  createGoogleProviderMetadata,
+  readGoogleThoughtSignature,
+} from "./google-thought-signatures.ts";
+import {
   extractGoogleCandidateParts,
   extractGoogleUsage,
   normalizeGoogleFinishReason,
@@ -69,6 +86,15 @@ export interface GoogleRuntimeConfig {
   fetch?: typeof globalThis.fetch;
 }
 
+type GoogleResponseContext = {
+  providerLabel: string;
+};
+
+type GoogleGenerateEnvelope = {
+  candidate?: Record<string, unknown>;
+  promptBlockReason?: string;
+};
+
 // ---------------------------------------------------------------------------
 // Google-specific types
 // ---------------------------------------------------------------------------
@@ -77,105 +103,469 @@ export interface GoogleRuntimeConfig {
 // Google helper functions
 // ---------------------------------------------------------------------------
 
-function extractGoogleEmbedding(payload: unknown): number[] {
+function invalidGoogleResponse(
+  context: GoogleResponseContext,
+  issue: string,
+): ProviderRequestError {
+  return new ProviderRequestError({
+    provider: "google",
+    status: 200,
+    message: `${context.providerLabel} request failed: invalid successful response (${issue})`,
+    retryable: false,
+  });
+}
+
+function sanitizeRuntimeUsage(usage: RuntimeUsage | undefined): RuntimeUsage | undefined {
+  const normalized = mergeUsage(undefined, usage);
+  return normalized && Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function readUsageTokenCount(value: unknown): number | undefined {
+  return typeof value === "number" &&
+      Number.isFinite(value) &&
+      Number.isSafeInteger(value) &&
+      value >= 0
+    ? value
+    : undefined;
+}
+
+function extractGoogleEmbedding(
+  payload: unknown,
+  context: GoogleResponseContext,
+): number[] {
   const record = readRecord(payload);
+  if (!record) {
+    throw invalidGoogleResponse(context, "embedding response body was not an object");
+  }
   const embeddings = record?.embeddings;
 
-  if (Array.isArray(embeddings) && embeddings.length > 0) {
+  if (embeddings !== undefined) {
+    if (!Array.isArray(embeddings) || embeddings.length !== 1) {
+      throw invalidGoogleResponse(
+        context,
+        "embedding response must contain exactly one embedding",
+      );
+    }
     const firstEmbedding = readRecord(embeddings[0]);
     const values = firstEmbedding?.values;
-    if (isNumberArray(values)) {
+    if (isNumberArray(values) && values.length > 0) {
       return values;
     }
+    throw invalidGoogleResponse(context, "embedding vector missing or invalid");
   }
 
-  const embedding = readRecord(record?.embedding);
+  const embedding = readRecord(record.embedding);
   const values = embedding?.values;
-  if (isNumberArray(values)) {
+  if (isNumberArray(values) && values.length > 0) {
     return values;
   }
 
-  throw new Error("Invalid Google embedding response: embedding vector missing");
+  throw invalidGoogleResponse(context, "embedding vector missing or invalid");
 }
 
 function extractGoogleUsageTokens(payload: unknown): number | undefined {
   const record = readRecord(payload);
   const usageMetadata = readRecord(record?.usageMetadata);
   const promptTokenCount = usageMetadata?.promptTokenCount;
-  return typeof promptTokenCount === "number" ? promptTokenCount : undefined;
+  return readUsageTokenCount(promptTokenCount);
 }
 
-function buildGoogleGenerateResult(payload: unknown): {
+function sumGoogleUsageTokens(payloads: unknown[]): number | undefined {
+  let totalTokens = 0;
+  for (const payload of payloads) {
+    const tokens = extractGoogleUsageTokens(payload);
+    if (tokens === undefined) {
+      return undefined;
+    }
+    totalTokens += tokens;
+    if (readUsageTokenCount(totalTokens) === undefined) {
+      return undefined;
+    }
+  }
+  return totalTokens;
+}
+
+function readGoogleGenerateCandidate(
+  payload: unknown,
+  context: GoogleResponseContext,
+): GoogleGenerateEnvelope {
+  const record = readRecord(payload);
+  if (!record) {
+    throw invalidGoogleResponse(context, "generation response body was not an object");
+  }
+
+  const candidates = record.candidates;
+  if (candidates !== undefined && !Array.isArray(candidates)) {
+    throw invalidGoogleResponse(context, "candidates array missing or empty");
+  }
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    const promptFeedback = readRecord(record.promptFeedback);
+    const promptBlockReason = promptFeedback?.blockReason;
+    if (typeof promptBlockReason === "string" && promptBlockReason.length > 0) {
+      return { promptBlockReason };
+    }
+    throw invalidGoogleResponse(context, "candidates array missing or empty");
+  }
+  if (candidates.length !== 1) {
+    throw invalidGoogleResponse(context, "generation response contained multiple candidates");
+  }
+
+  const candidate = readRecord(candidates[0]);
+  if (!candidate) {
+    throw invalidGoogleResponse(context, "first candidate was not an object");
+  }
+
+  const finishReason = candidate.finishReason;
+  if (finishReason !== undefined && typeof finishReason !== "string") {
+    throw invalidGoogleResponse(context, "candidate finish reason was malformed");
+  }
+
+  if (candidate.content === undefined) {
+    if (typeof finishReason !== "string") {
+      throw invalidGoogleResponse(context, "candidate contained no output content");
+    }
+    return { candidate };
+  }
+
+  const content = readRecord(candidate.content);
+  if (!content) {
+    throw invalidGoogleResponse(context, "candidate content parts missing or malformed");
+  }
+  if (content.parts === undefined && typeof finishReason === "string") {
+    return { candidate };
+  }
+  if (!Array.isArray(content.parts)) {
+    throw invalidGoogleResponse(context, "candidate content parts missing or malformed");
+  }
+  for (const part of content.parts) {
+    if (!readRecord(part)) {
+      throw invalidGoogleResponse(context, "candidate content part was not an object");
+    }
+  }
+
+  return { candidate };
+}
+
+function buildGoogleGenerateResult(
+  payload: unknown,
+  context: GoogleResponseContext,
+): {
   content: Array<
     | { type: "text"; text: string }
-    | { type: "tool-call"; toolCallId: string; toolName: string; input: string }
+    | { type: "reasoning"; text?: string; signature?: string }
+    | {
+      type: "tool-call";
+      toolCallId: string;
+      toolName: string;
+      input: string;
+      providerExecuted?: boolean;
+    }
+    | {
+      type: "tool-result";
+      toolCallId: string;
+      toolName: string;
+      result: unknown;
+      isError?: boolean;
+      providerExecuted: true;
+    }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
   usage?: RuntimeUsage;
   groundingMetadata?: Record<string, unknown>;
+  providerMetadata?: Record<string, unknown>;
 } {
-  const parts = extractGoogleCandidateParts(payload);
+  const envelope = readGoogleGenerateCandidate(payload, context);
+  const candidate = envelope.candidate;
+  const parts = candidate ? extractGoogleCandidateParts(payload) : [];
   const content: Array<
     | { type: "text"; text: string }
-    | { type: "tool-call"; toolCallId: string; toolName: string; input: string }
+    | { type: "reasoning"; text?: string; signature?: string }
+    | {
+      type: "tool-call";
+      toolCallId: string;
+      toolName: string;
+      input: string;
+      providerExecuted?: boolean;
+    }
+    | {
+      type: "tool-result";
+      toolCallId: string;
+      toolName: string;
+      result: unknown;
+      isError?: boolean;
+      providerExecuted: true;
+    }
   > = [];
+  const toolCallRegistry = createGoogleToolCallCorrelationRegistry();
 
   for (const [index, part] of parts.entries()) {
-    if (typeof part.text === "string" && part.text.length > 0) {
-      content.push({ type: "text", text: part.text });
+    let thoughtSignature: string | undefined;
+    try {
+      thoughtSignature = readGoogleThoughtSignature(part);
+    } catch {
+      throw invalidGoogleResponse(context, "candidate thought signature was malformed");
+    }
+    if (part.thought !== undefined && typeof part.thought !== "boolean") {
+      throw invalidGoogleResponse(context, "candidate thought marker was malformed");
+    }
+    let dataField: ReturnType<typeof readGooglePartDataField>;
+    try {
+      dataField = readGooglePartDataField(part);
+    } catch (error) {
+      const issue = error instanceof Error &&
+          (error.message.includes("unsupported") || error.message.includes("unknown"))
+        ? "candidate part contained an unsupported data field"
+        : "candidate part contained multiple data fields";
+      throw invalidGoogleResponse(context, issue);
+    }
+    if (dataField === "text") {
+      if (typeof part.text !== "string") {
+        throw invalidGoogleResponse(context, "candidate text part was malformed");
+      }
+      if (part.thought === true) {
+        if (part.text.length > 0 || thoughtSignature !== undefined) {
+          content.push({
+            type: "reasoning",
+            ...(part.text.length > 0 ? { text: part.text } : {}),
+            ...(thoughtSignature !== undefined ? { signature: thoughtSignature } : {}),
+          });
+        }
+        continue;
+      }
+      if (part.text.length > 0) {
+        content.push({ type: "text", text: part.text });
+      }
       continue;
     }
 
-    const functionCall = readRecord(part.functionCall);
-    if (typeof functionCall?.name === "string") {
+    if (dataField === "functionCall") {
+      const functionCall = readRecord(part.functionCall);
+      if (
+        !functionCall || typeof functionCall.name !== "string" || functionCall.name.length === 0
+      ) {
+        throw invalidGoogleResponse(context, "candidate function call was malformed");
+      }
+      if (
+        functionCall.id !== undefined &&
+        (typeof functionCall.id !== "string" || functionCall.id.length === 0)
+      ) {
+        throw invalidGoogleResponse(context, "candidate function call id was malformed");
+      }
+      const functionCallArgs = readRecord(functionCall.args);
+      if (!functionCallArgs) {
+        throw invalidGoogleResponse(
+          context,
+          "candidate function call arguments were not an object",
+        );
+      }
+      let toolCallId: string;
+      try {
+        toolCallId = toolCallRegistry.registerFunctionCall(
+          index,
+          typeof functionCall.id === "string" ? functionCall.id : undefined,
+        );
+      } catch {
+        throw invalidGoogleResponse(context, "candidate tool call id was duplicated");
+      }
       content.push({
         type: "tool-call",
-        toolCallId: typeof functionCall.id === "string" ? functionCall.id : `tool-${index}`,
+        toolCallId,
         toolName: functionCall.name,
-        input: stringifyJsonValue(functionCall.args ?? {}),
+        input: stringifyJsonValue(functionCallArgs),
       });
+      continue;
     }
+
+    if (dataField === "executableCode") {
+      let executableCode: ReturnType<typeof readGoogleExecutableCode>;
+      try {
+        executableCode = readGoogleExecutableCode(part.executableCode);
+      } catch {
+        throw invalidGoogleResponse(context, "candidate executable code was malformed");
+      }
+
+      let toolCallId: string;
+      try {
+        toolCallId = toolCallRegistry.registerCodeExecution(
+          executableCode.providerId,
+        );
+      } catch {
+        throw invalidGoogleResponse(context, "candidate executable code id was duplicated");
+      }
+
+      content.push({
+        type: "tool-call",
+        toolCallId,
+        toolName: GOOGLE_CODE_EXECUTION_TOOL_NAME,
+        input: stringifyJsonValue(googleCodeExecutionInput(executableCode)),
+        providerExecuted: true,
+      });
+      continue;
+    }
+
+    let result: ReturnType<typeof readGoogleCodeExecutionResult>;
+    try {
+      result = readGoogleCodeExecutionResult(part.codeExecutionResult);
+    } catch {
+      throw invalidGoogleResponse(context, "candidate code execution result was malformed");
+    }
+    let toolCallId: string;
+    try {
+      toolCallId = toolCallRegistry.resolveCodeExecutionResult(
+        result.providerId,
+      );
+    } catch {
+      throw invalidGoogleResponse(
+        context,
+        "candidate code execution result did not match executable code",
+      );
+    }
+    content.push({
+      type: "tool-result",
+      toolCallId,
+      toolName: GOOGLE_CODE_EXECUTION_TOOL_NAME,
+      result: googleCodeExecutionOutput(result),
+      ...(result.isError ? { isError: true } : {}),
+      providerExecuted: true,
+    });
+  }
+  try {
+    toolCallRegistry.assertSettled();
+  } catch {
+    throw invalidGoogleResponse(
+      context,
+      "candidate executable code had no matching execution result",
+    );
+  }
+  const finishReason = envelope.promptBlockReason
+    ? { unified: "content-filter", raw: envelope.promptBlockReason }
+    : normalizeGoogleFinishReason(candidate?.finishReason);
+  const isContentFiltered = typeof finishReason === "object" &&
+    finishReason?.unified === "content-filter";
+  if (content.length === 0 && !isContentFiltered) {
+    throw invalidGoogleResponse(context, "candidate contained no supported output content");
   }
 
-  // Gemini grounding (google_search / google_search_retrieval) returns
-  // a per-candidate groundingMetadata object with web search queries,
-  // grounding chunks, and citation indices into the response text.
-  // Pass it through opaquely so callers can render footnotes / source
-  // chips / "Search results" UI without parsing the wire shape.
-  const candidate = extractFirstGoogleCandidate(payload);
-  const groundingMetadata = readRecord(candidate?.groundingMetadata);
+  // Google owns the nested grounding shape and may add fields over time. Keep
+  // it opaque, but require the documented object envelope before exposing it.
+  let groundingMetadata: Record<string, unknown> | undefined;
+  if (candidate?.groundingMetadata !== undefined) {
+    try {
+      groundingMetadata = readGoogleGroundingMetadata(candidate.groundingMetadata);
+    } catch {
+      throw invalidGoogleResponse(context, "candidate grounding metadata was malformed");
+    }
+  }
+  const usage = sanitizeRuntimeUsage(extractGoogleUsage(payload));
+  const providerMetadata = createGoogleProviderMetadata(parts, groundingMetadata);
 
   return {
     content,
-    finishReason: normalizeGoogleFinishReason(candidate?.finishReason),
-    usage: extractGoogleUsage(payload),
+    finishReason,
+    ...(usage ? { usage } : {}),
     ...(groundingMetadata ? { groundingMetadata } : {}),
+    ...(providerMetadata ? { providerMetadata } : {}),
   };
+}
+
+function createGoogleProviderAbortScope(callerSignal: AbortSignal | undefined): {
+  controller: AbortController;
+  dispose: () => void;
+} {
+  const controller = new AbortController();
+  const abortFromCaller = () => controller.abort(callerSignal?.reason);
+
+  if (callerSignal?.aborted) {
+    abortFromCaller();
+    return { controller, dispose() {} };
+  }
+
+  callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+  return {
+    controller,
+    dispose() {
+      callerSignal?.removeEventListener("abort", abortFromCaller);
+    },
+  };
+}
+
+function createCancelableGoogleStream(
+  iterable: AsyncIterable<unknown>,
+  providerAbortController: AbortController,
+  disposeAbortScope: () => void,
+): ReadableStream<unknown> {
+  const iterator = iterable[Symbol.asyncIterator]();
+  let consumerCanceled = false;
+  let disposed = false;
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    disposeAbortScope();
+  };
+
+  return new ReadableStream<unknown>(
+    {
+      async pull(controller) {
+        try {
+          const next = await iterator.next();
+          if (next.done) {
+            dispose();
+            controller.close();
+            return;
+          }
+          controller.enqueue(next.value);
+        } catch (error) {
+          dispose();
+          if (!consumerCanceled) {
+            controller.error(error);
+          }
+        }
+      },
+      async cancel(reason) {
+        consumerCanceled = true;
+        if (!providerAbortController.signal.aborted) {
+          providerAbortController.abort(reason);
+        }
+        try {
+          await iterator.return?.();
+        } catch (error) {
+          if (!providerAbortController.signal.aborted) {
+            throw error;
+          }
+        } finally {
+          dispose();
+        }
+      },
+    },
+    { highWaterMark: 0 },
+  );
 }
 
 export function createGoogleModelRuntime(
   config: GoogleRuntimeConfig,
   modelId: string,
-): ModelRuntime {
+): ModelRuntime<OpenAICompatibleLanguageOptions, RuntimeAssistantContentPart> {
   const fetchImpl = config.fetch ?? globalThis.fetch;
+  const providerLabel = config.name ?? "google";
+  const responseContext = { providerLabel };
   return {
-    provider: config.name ?? "google",
+    provider: providerLabel,
     modelId,
     specificationVersion: "v3",
     supportedUrls: {},
-    doGenerate(optionsForRuntime: unknown) {
-      const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
+    doGenerate(options: OpenAICompatibleLanguageOptions) {
       const url = getGoogleGenerateContentUrl(config.baseURL, modelId);
       const warnings = createWarningCollector();
       const body = buildGoogleGenerateContentRequest(
-        config.name ?? "google",
+        providerLabel,
         options,
         warnings,
       );
       return requestJson({
         url,
         fetchImpl,
-        providerLabel: config.name ?? "google",
+        providerLabel,
         providerKind: "google",
         init: createGoogleRequestInit({
           apiKey: config.apiKey,
@@ -186,40 +576,48 @@ export function createGoogleModelRuntime(
       }).then((payload) => {
         const drained = warnings.drain();
         return {
-          ...buildGoogleGenerateResult(payload),
+          ...buildGoogleGenerateResult(payload, responseContext),
           ...(drained.length > 0 ? { warnings: drained } : {}),
         };
       });
     },
-    doStream(optionsForRuntime: unknown) {
-      const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
+    async doStream(options: OpenAICompatibleLanguageOptions) {
       const url = getGoogleStreamGenerateContentUrl(config.baseURL, modelId);
       const warnings = createWarningCollector();
       const body = buildGoogleGenerateContentRequest(
-        config.name ?? "google",
+        providerLabel,
         options,
         warnings,
       );
-      return requestStream({
-        url,
-        fetchImpl,
-        providerLabel: config.name ?? "google",
-        providerKind: "google",
-        init: createGoogleRequestInit({
-          apiKey: config.apiKey,
-          extraHeaders: options.headers,
-          body: JSON.stringify(body),
-          signal: options.abortSignal,
-        }),
-      }).then((responseStream) => {
-        const drained = warnings.drain();
-        return {
-          stream: ReadableStream.from(
-            streamGoogleCompatibleParts(responseStream),
-          ),
-          ...(drained.length > 0 ? { warnings: drained } : {}),
-        };
-      });
+      const providerAbortScope = createGoogleProviderAbortScope(options.abortSignal);
+      let responseStream: ReadableStream<Uint8Array>;
+      try {
+        responseStream = await requestStream({
+          url,
+          fetchImpl,
+          providerLabel,
+          providerKind: "google",
+          init: createGoogleRequestInit({
+            apiKey: config.apiKey,
+            extraHeaders: options.headers,
+            body: JSON.stringify(body),
+            signal: providerAbortScope.controller.signal,
+          }),
+        });
+      } catch (error) {
+        providerAbortScope.dispose();
+        throw error;
+      }
+
+      const drained = warnings.drain();
+      return {
+        stream: createCancelableGoogleStream(
+          streamGoogleCompatibleParts(responseStream, responseContext),
+          providerAbortScope.controller,
+          providerAbortScope.dispose,
+        ),
+        ...(drained.length > 0 ? { warnings: drained } : {}),
+      };
     },
   };
 }
@@ -229,47 +627,83 @@ export function createGoogleEmbeddingRuntime(
   modelId: string,
 ): EmbeddingRuntime {
   const fetchImpl = config.fetch ?? globalThis.fetch;
+  const providerLabel = config.name ?? "google";
+  const responseContext = { providerLabel };
   return {
-    provider: config.name ?? "google",
+    provider: providerLabel,
     modelId,
     supportsParallelCalls: true,
-    doEmbed({ values, abortSignal }) {
+    async doEmbed({ values, abortSignal }) {
       if (values.length === 0) {
-        return Promise.resolve({
+        return {
           embeddings: [],
           warnings: [],
           rawResponse: { embeddings: [] },
-        });
+        };
       }
 
       const url = getGoogleEmbeddingUrl(config.baseURL, modelId);
-      return Promise.all(values.map((value) =>
-        requestJson({
-          url,
-          fetchImpl,
-          providerLabel: config.name ?? "google",
-          providerKind: "google",
-          init: createGoogleRequestInit({
-            apiKey: config.apiKey,
-            body: JSON.stringify({
-              content: {
-                parts: [{ text: value }],
-              },
+      const providerAbortScope = createGoogleProviderAbortScope(abortSignal);
+      try {
+        providerAbortScope.controller.signal.throwIfAborted();
+        const requests = values.map((value) =>
+          requestJson({
+            url,
+            fetchImpl,
+            providerLabel,
+            providerKind: "google",
+            init: createGoogleRequestInit({
+              apiKey: config.apiKey,
+              body: JSON.stringify({
+                content: {
+                  parts: [{ text: value }],
+                },
+              }),
+              signal: providerAbortScope.controller.signal,
             }),
-            signal: abortSignal,
-          }),
-        })
-      )).then((payloads) => ({
-        embeddings: payloads.map(extractGoogleEmbedding),
-        usage: {
-          tokens: payloads.reduce<number>(
-            (total, payload) => total + (extractGoogleUsageTokens(payload) ?? 0),
-            0,
-          ),
-        },
-        rawResponse: payloads,
-        warnings: [],
-      }));
+          }).then((payload) => ({
+            payload,
+            embedding: extractGoogleEmbedding(payload, responseContext),
+          })).catch((error) => {
+            if (!providerAbortScope.controller.signal.aborted) {
+              providerAbortScope.controller.abort(error);
+            }
+            throw error;
+          })
+        );
+
+        let results: Array<{ payload: unknown; embedding: number[] }>;
+        try {
+          results = await Promise.all(requests);
+        } catch (error) {
+          if (abortSignal?.aborted) {
+            throw abortSignal.reason;
+          }
+          throw error;
+        }
+
+        const payloads = results.map((result) => result.payload);
+        const tokens = sumGoogleUsageTokens(payloads);
+        const embeddings = results.map((result) => result.embedding);
+        const dimensions = embeddings[0]?.length;
+        if (
+          dimensions !== undefined &&
+          embeddings.some((embedding) => embedding.length !== dimensions)
+        ) {
+          throw invalidGoogleResponse(
+            responseContext,
+            "embedding vectors had inconsistent dimensions",
+          );
+        }
+        return {
+          embeddings,
+          ...(tokens !== undefined ? { usage: { tokens } } : {}),
+          rawResponse: payloads,
+          warnings: [],
+        };
+      } finally {
+        providerAbortScope.dispose();
+      }
     },
   };
 }
@@ -277,7 +711,10 @@ export function createGoogleEmbeddingRuntime(
 export class GoogleProvider implements LLMProvider {
   readonly id = "google";
 
-  createModel(modelId: string, config: LLMProviderConfig): ModelRuntime {
+  createModel(
+    modelId: string,
+    config: LLMProviderConfig,
+  ): ModelRuntime<OpenAICompatibleLanguageOptions, RuntimeAssistantContentPart> {
     return createGoogleModelRuntime(
       {
         apiKey: config.credential,

--- a/extensions/ext-llm-google/src/google-provider.ts
+++ b/extensions/ext-llm-google/src/google-provider.ts
@@ -351,7 +351,8 @@ function buildGoogleGenerateResult(
       ) {
         throw invalidGoogleResponse(context, "candidate function call id was malformed");
       }
-      const functionCallArgs = readRecord(functionCall.args);
+      // Gemini omits `args` entirely for zero-parameter tool calls.
+      const functionCallArgs = functionCall.args === undefined ? {} : readRecord(functionCall.args);
       if (!functionCallArgs) {
         throw invalidGoogleResponse(
           context,

--- a/extensions/ext-llm-google/src/google-provider.ts
+++ b/extensions/ext-llm-google/src/google-provider.ts
@@ -458,7 +458,15 @@ function buildGoogleGenerateResult(
     }
   }
   const usage = sanitizeRuntimeUsage(extractGoogleUsage(payload));
-  const providerMetadata = createGoogleProviderMetadata(parts, groundingMetadata);
+  let providerMetadata: Record<string, unknown> | undefined;
+  try {
+    providerMetadata = createGoogleProviderMetadata(parts, groundingMetadata);
+  } catch {
+    throw invalidGoogleResponse(
+      context,
+      "provider metadata could not be retained safely",
+    );
+  }
 
   return {
     content,

--- a/extensions/ext-llm-google/src/google-provider.ts
+++ b/extensions/ext-llm-google/src/google-provider.ts
@@ -196,7 +196,7 @@ function readGoogleGenerateCandidate(
 
   const candidates = record.candidates;
   if (candidates !== undefined && !Array.isArray(candidates)) {
-    throw invalidGoogleResponse(context, "candidates array missing or empty");
+    throw invalidGoogleResponse(context, "candidates was not an array");
   }
   if (!Array.isArray(candidates) || candidates.length === 0) {
     const promptFeedback = readRecord(record.promptFeedback);

--- a/extensions/ext-llm-google/src/google-request-builder.test.ts
+++ b/extensions/ext-llm-google/src/google-request-builder.test.ts
@@ -1,7 +1,11 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { RuntimePromptMessage } from "veryfront/provider/shared";
-import { buildGoogleGenerateContentRequest } from "./google-request-builder.ts";
+import type { RuntimeAssistantContentPart, RuntimePromptMessage } from "veryfront/provider/shared";
+import {
+  buildGoogleGenerateContentRequest,
+  type RuntimeToolDefinition,
+} from "./google-request-builder.ts";
+import { createGoogleProviderMetadata } from "./google-thought-signatures.ts";
 
 function createWarningCollector() {
   const warnings: Array<{
@@ -24,6 +28,46 @@ function createWarningCollector() {
       return warnings.slice();
     },
   };
+}
+
+function buildGoogleAssistantReplay(
+  rawAssistantParts: Array<Record<string, unknown>>,
+  content: readonly RuntimeAssistantContentPart[],
+  providerToolCalls?: readonly {
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }[],
+) {
+  return buildGoogleGenerateContentRequest(
+    "google",
+    {
+      prompt: [{
+        role: "assistant",
+        content,
+        ...(providerToolCalls ? { providerToolCalls } : {}),
+        providerMetadata: {
+          google: { rawAssistantParts },
+        },
+      }],
+    },
+    createWarningCollector(),
+  );
+}
+
+function nestedGoogleArguments(wrappers: number): Record<string, unknown> {
+  let value: Record<string, unknown> = { leaf: true };
+  for (let index = 0; index < wrappers; index += 1) {
+    value = { nested: value };
+  }
+  return value;
+}
+
+function assertJsonEquals(actual: unknown, expected: unknown): void {
+  assertEquals(
+    JSON.parse(JSON.stringify(actual)),
+    JSON.parse(JSON.stringify(expected)),
+  );
 }
 
 describe("ext-llm-google/google-request-builder", () => {
@@ -84,9 +128,9 @@ describe("ext-llm-google/google-request-builder", () => {
           },
           {
             type: "provider",
-            name: "code",
+            name: "code_execution",
             id: "google.code_execution",
-            args: { enabled: true },
+            args: {},
           },
         ],
         toolChoice: { type: "tool", name: "lookup" },
@@ -159,7 +203,7 @@ describe("ext-llm-google/google-request-builder", () => {
             parameters: { type: "object", properties: { id: { type: "string" } } },
           }],
         },
-        { codeExecution: { enabled: true } },
+        { codeExecution: {} },
       ],
       toolConfig: {
         functionCallingConfig: {
@@ -179,5 +223,1592 @@ describe("ext-llm-google/google-request-builder", () => {
       "frequencyPenalty",
       "responseFormat",
     ]);
+  });
+
+  it("accepts only the explicitly supported Google provider-tool schemas", () => {
+    const prompt: RuntimePromptMessage[] = [{
+      role: "user",
+      content: [{ type: "text", text: "Search and calculate." }],
+    }];
+    const buildWithTools = (tools: RuntimeToolDefinition[]) =>
+      buildGoogleGenerateContentRequest(
+        "google",
+        { prompt, tools },
+        createWarningCollector(),
+      );
+
+    assertEquals(
+      buildWithTools([
+        {
+          type: "provider",
+          name: "code_execution",
+          id: "google.code_execution",
+          args: {},
+        },
+        {
+          type: "provider",
+          name: "google_search",
+          id: "google.google_search",
+          args: {
+            searchTypes: { webSearch: {}, imageSearch: {} },
+            timeRangeFilter: {
+              startTime: "2026-01-01T00:00:00Z",
+              endTime: "2026-07-01T00:00:00+00:00",
+            },
+          },
+        },
+      ]).tools,
+      [
+        { codeExecution: {} },
+        {
+          googleSearch: {
+            searchTypes: { webSearch: {}, imageSearch: {} },
+            timeRangeFilter: {
+              startTime: "2026-01-01T00:00:00Z",
+              endTime: "2026-07-01T00:00:00+00:00",
+            },
+          },
+        },
+      ],
+    );
+
+    const malformedCases: Array<{
+      tools: RuntimeToolDefinition[];
+      issue: string;
+    }> = [
+      {
+        tools: [{
+          type: "provider",
+          name: "future_tool",
+          id: "google.future_tool",
+          args: {},
+        }],
+        issue: "Unsupported Google provider tool id",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "web_search",
+          id: "anthropic.web_search",
+          args: {},
+        }],
+        issue: "provider tool for another provider",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "code",
+          id: "google.code_execution",
+          args: {},
+        }],
+        issue: "provider tool name must be code_execution",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "code_execution",
+          id: "google.code_execution",
+          args: { enabled: true },
+        }],
+        issue: "google.code_execution args must be an empty object",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "google_search",
+          id: "google.google_search",
+          args: { futureOption: true },
+        }],
+        issue: "google.google_search args contained an unsupported field",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "google_search",
+          id: "google.google_search",
+          args: { searchTypes: { webSearch: { enabled: true } } },
+        }],
+        issue: "google.google_search webSearch must be an empty object",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "google_search",
+          id: "google.google_search",
+          args: {
+            timeRangeFilter: { startTime: "2026-01-01T00:00:00Z" },
+          },
+        }],
+        issue: "timeRangeFilter requires both startTime and endTime",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "google_search",
+          id: "google.google_search",
+          args: {
+            timeRangeFilter: {
+              startTime: "not-a-timestamp",
+              endTime: "2026-01-01T00:00:00Z",
+            },
+          },
+        }],
+        issue: "startTime must be an RFC 3339 timestamp",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "google_search",
+          id: "google.google_search",
+          args: {
+            timeRangeFilter: {
+              startTime: "2026-02-29T00:00:00Z",
+              endTime: "2026-03-01T00:00:00Z",
+            },
+          },
+        }],
+        issue: "startTime must be an RFC 3339 timestamp",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "google_search",
+          id: "google.google_search",
+          args: {
+            timeRangeFilter: {
+              startTime: "2024-02-29T24:00:00Z",
+              endTime: "2024-03-01T00:00:00Z",
+            },
+          },
+        }],
+        issue: "startTime must be an RFC 3339 timestamp",
+      },
+      {
+        tools: [{
+          type: "provider",
+          name: "google_search",
+          id: "google.google_search",
+          args: {
+            timeRangeFilter: {
+              startTime: "2026-07-01T00:00:00Z",
+              endTime: "2026-01-01T00:00:00Z",
+            },
+          },
+        }],
+        issue: "startTime must not be after endTime",
+      },
+      {
+        tools: [
+          {
+            type: "provider",
+            name: "google_search",
+            id: "google.google_search",
+            args: {},
+          },
+          {
+            type: "provider",
+            name: "google_search",
+            id: "google.google_search",
+            args: {},
+          },
+        ],
+        issue: "Google provider tool id was duplicated",
+      },
+    ];
+
+    for (const { tools, issue } of malformedCases) {
+      assertThrows(
+        () => buildWithTools(tools),
+        TypeError,
+        issue,
+      );
+    }
+  });
+
+  it("replays signed Google assistant parts exactly from provider metadata", () => {
+    const rawAssistantParts = [
+      {
+        text: "Private thought.",
+        thought: true,
+        thoughtSignature: "thought-signature",
+      },
+      {
+        functionCall: {
+          id: "tool_paris",
+          name: "weather",
+          args: { city: "Paris" },
+        },
+        thoughtSignature: "parallel-call-signature",
+      },
+      {
+        functionCall: {
+          id: "tool_london",
+          name: "weather",
+          args: { city: "London" },
+        },
+      },
+    ];
+    const warnings = createWarningCollector();
+
+    const body = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "Private thought." },
+            {
+              type: "tool-call",
+              toolCallId: "tool_paris",
+              toolName: "weather",
+              input: { city: "Paris" },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "tool_london",
+              toolName: "weather",
+              input: { city: "London" },
+            },
+          ],
+          providerMetadata: {
+            google: { rawAssistantParts },
+          },
+        }],
+      },
+      warnings,
+    );
+
+    assertJsonEquals(body.contents, [{
+      role: "model",
+      parts: rawAssistantParts,
+    }]);
+  });
+
+  it("accepts raw-position and legacy occurrence ids while preserving exact correlation", () => {
+    const rawAssistantParts: [
+      Record<string, unknown>,
+      Record<string, unknown>,
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ] = [{
+      text: "Private thought.",
+      thought: true,
+      thoughtSignature: "signature",
+    }, {
+      functionCall: {
+        name: "weather",
+        args: { city: "Paris" },
+      },
+    }, {
+      text: "Checking another city.",
+    }, {
+      functionCall: {
+        name: "weather",
+        args: { city: "London" },
+      },
+    }];
+    const canonicalCalls: [
+      Extract<RuntimeAssistantContentPart, { type: "tool-call" }>,
+      Extract<RuntimeAssistantContentPart, { type: "tool-call" }>,
+    ] = [{
+      type: "tool-call",
+      toolCallId: "tool-1",
+      toolName: "weather",
+      input: '{"city":"Paris"}',
+    }, {
+      type: "tool-call",
+      toolCallId: "tool-3",
+      toolName: "weather",
+      input: { city: "London" },
+    }];
+
+    assertJsonEquals(
+      buildGoogleAssistantReplay(rawAssistantParts, canonicalCalls).contents,
+      [{ role: "model", parts: rawAssistantParts }],
+    );
+    assertJsonEquals(
+      buildGoogleAssistantReplay(
+        rawAssistantParts,
+        [
+          { ...canonicalCalls[0], toolCallId: "tool-0" },
+          { ...canonicalCalls[1], toolCallId: "tool-1" },
+        ],
+      ).contents,
+      [{ role: "model", parts: rawAssistantParts }],
+    );
+
+    const mismatches = [
+      [{ ...canonicalCalls[0], toolCallId: "tool-0" }, canonicalCalls[1]],
+      [canonicalCalls[0], { ...canonicalCalls[1], toolCallId: "tool-1" }],
+      [{ ...canonicalCalls[0], toolCallId: "tool-0" }, {
+        ...canonicalCalls[1],
+        toolCallId: "tool-0",
+      }],
+      [{ ...canonicalCalls[0], toolName: "forecast" }, canonicalCalls[1]],
+      [{ ...canonicalCalls[0], input: { city: "Berlin" } }, canonicalCalls[1]],
+      [canonicalCalls[1], canonicalCalls[0]],
+      [canonicalCalls[0]],
+    ];
+    for (const content of mismatches) {
+      assertThrows(
+        () => buildGoogleAssistantReplay(rawAssistantParts, content),
+        TypeError,
+        "Google raw assistant metadata did not match canonical provider tool history",
+      );
+    }
+  });
+
+  it("restarts legacy anonymous occurrence ids for each persisted assistant turn", () => {
+    const firstRawParts = [{
+      text: "First private thought.",
+      thought: true,
+      thoughtSignature: "first-signature",
+    }, {
+      functionCall: {
+        name: "weather",
+        args: { city: "Paris" },
+      },
+    }];
+    const secondRawParts = [{
+      text: "Second private thought.",
+      thought: true,
+      thoughtSignature: "second-signature",
+    }, {
+      functionCall: {
+        name: "weather",
+        args: { city: "London" },
+      },
+    }];
+    const legacyCall = (city: string): RuntimeAssistantContentPart => ({
+      type: "tool-call",
+      toolCallId: "tool-0",
+      toolName: "weather",
+      input: { city },
+    });
+
+    const body = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [legacyCall("Paris")],
+          providerMetadata: {
+            google: { rawAssistantParts: firstRawParts },
+          },
+        }, {
+          role: "user",
+          content: [{ type: "text", text: "Check another city." }],
+        }, {
+          role: "assistant",
+          content: [legacyCall("London")],
+          providerMetadata: {
+            google: { rawAssistantParts: secondRawParts },
+          },
+        }],
+      },
+      createWarningCollector(),
+    );
+
+    assertJsonEquals(body.contents, [{
+      role: "model",
+      parts: firstRawParts,
+    }, {
+      role: "user",
+      parts: [{ text: "Check another city." }],
+    }, {
+      role: "model",
+      parts: secondRawParts,
+    }]);
+  });
+
+  it("allows raw-only client function replay only when its canonical projection is absent", () => {
+    const rawAssistantParts = [{
+      functionCall: {
+        id: "raw_only",
+        name: "historical_tool",
+        args: { retained: true },
+      },
+      thoughtSignature: "signature",
+    }];
+
+    assertJsonEquals(
+      buildGoogleAssistantReplay(rawAssistantParts, [{
+        type: "text",
+        text: "The normalized call was compacted.",
+      }]).contents,
+      [{ role: "model", parts: rawAssistantParts }],
+    );
+    assertThrows(
+      () =>
+        buildGoogleAssistantReplay(rawAssistantParts, [{
+          type: "tool-call",
+          toolCallId: "different",
+          toolName: "historical_tool",
+          input: { retained: true },
+        }]),
+      TypeError,
+      "Google raw assistant metadata did not match canonical provider tool history",
+    );
+  });
+
+  it("rejects duplicate client calls instead of coalescing identical ids", () => {
+    const rawAssistantParts = [{
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: { id: 1 },
+      },
+      thoughtSignature: "signature",
+    }];
+    const call: RuntimeAssistantContentPart = {
+      type: "tool-call",
+      toolCallId: "call_1",
+      toolName: "lookup",
+      input: { id: 1 },
+    };
+
+    assertThrows(
+      () => buildGoogleAssistantReplay(rawAssistantParts, [call, { ...call }]),
+      TypeError,
+      "Google raw assistant metadata did not match canonical provider tool history",
+    );
+  });
+
+  it("preserves interleaving between client and provider calls", () => {
+    const rawAssistantParts = [{
+      functionCall: {
+        id: "lookup_1",
+        name: "lookup",
+        args: { id: 1 },
+      },
+      thoughtSignature: "signature",
+    }, {
+      executableCode: {
+        id: "code_1",
+        language: "PYTHON",
+        code: "print(1)",
+      },
+    }, {
+      codeExecutionResult: {
+        id: "code_1",
+        outcome: "OUTCOME_OK",
+        output: "1\n",
+      },
+    }];
+    const ordinaryCall: RuntimeAssistantContentPart = {
+      type: "tool-call",
+      toolCallId: "lookup_1",
+      toolName: "lookup",
+      input: { id: 1 },
+    };
+    const providerCall: RuntimeAssistantContentPart = {
+      type: "tool-call",
+      toolCallId: "code_1",
+      toolName: "code_execution",
+      input: { language: "PYTHON", code: "print(1)" },
+      providerExecuted: true,
+    };
+
+    assertJsonEquals(
+      buildGoogleAssistantReplay(
+        rawAssistantParts,
+        [ordinaryCall, providerCall],
+      ).contents,
+      [{ role: "model", parts: rawAssistantParts }],
+    );
+    assertThrows(
+      () =>
+        buildGoogleAssistantReplay(
+          rawAssistantParts,
+          [providerCall, ordinaryCall],
+        ),
+      TypeError,
+      "Google raw assistant metadata did not match canonical provider tool history",
+    );
+  });
+
+  it("replays Google code-execution parts exactly even without a thought signature", () => {
+    const rawAssistantParts = [
+      {
+        executableCode: {
+          id: "code_1",
+          language: "PYTHON",
+          code: "print('ok')",
+        },
+      },
+      {
+        codeExecutionResult: {
+          id: "code_1",
+          outcome: "OUTCOME_OK",
+          output: "ok\n",
+        },
+      },
+      { text: "Done." },
+    ];
+
+    const body = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "code_1",
+              toolName: "code_execution",
+              input: { language: "PYTHON", code: "print('ok')" },
+              providerExecuted: true,
+            },
+            { type: "text", text: "Done." },
+          ],
+          providerMetadata: {
+            google: { rawAssistantParts },
+          },
+        }],
+      },
+      createWarningCollector(),
+    );
+
+    assertJsonEquals(body.contents, [{
+      role: "model",
+      parts: rawAssistantParts,
+    }]);
+  });
+
+  it("rejects raw code-execution replay that disagrees with canonical provider content", () => {
+    const rawAssistantParts = [{
+      executableCode: {
+        id: "code_1",
+        language: "PYTHON",
+        code: "print('ok')",
+      },
+    }, {
+      codeExecutionResult: {
+        id: "code_1",
+        outcome: "OUTCOME_OK",
+        output: "ok\n",
+      },
+    }];
+    const build = (
+      canonical: {
+        id?: string;
+        name?: string;
+        input?: unknown;
+        result?: unknown;
+        isError?: boolean;
+      },
+      rawParts: Array<Record<string, unknown>> = rawAssistantParts,
+    ) =>
+      buildGoogleGenerateContentRequest(
+        "google",
+        {
+          prompt: [{
+            role: "assistant",
+            content: [{
+              type: "tool-call",
+              toolCallId: canonical.id ?? "code_1",
+              toolName: canonical.name ?? "code_execution",
+              input: canonical.input ?? {
+                language: "PYTHON",
+                code: "print('ok')",
+              },
+              providerExecuted: true,
+            }, {
+              type: "tool-result",
+              toolCallId: canonical.id ?? "code_1",
+              toolName: canonical.name ?? "code_execution",
+              result: canonical.result ?? {
+                outcome: "OUTCOME_OK",
+                output: "ok\n",
+              },
+              ...(canonical.isError === true ? { isError: true } : {}),
+              providerExecuted: true,
+            }],
+            providerMetadata: {
+              google: { rawAssistantParts: rawParts },
+            },
+          }],
+        },
+        createWarningCollector(),
+      );
+
+    assertJsonEquals(build({}).contents, [{
+      role: "model",
+      parts: rawAssistantParts,
+    }]);
+    for (
+      const canonical of [
+        { id: "different-id" },
+        { name: "different-name" },
+        { input: { language: "PYTHON", code: "print('different')" } },
+        { result: { outcome: "OUTCOME_OK", output: "different\n" } },
+        { isError: true },
+      ]
+    ) {
+      assertThrows(
+        () => build(canonical),
+        TypeError,
+        "Google raw assistant metadata did not match canonical provider tool history",
+      );
+    }
+    assertThrows(
+      () =>
+        build({}, [{
+          text: "Signed reasoning without code execution",
+          thought: true,
+          thoughtSignature: "signature",
+        }]),
+      TypeError,
+      "Google raw assistant metadata did not match canonical provider tool history",
+    );
+  });
+
+  it("correlates provider code calls and results one-for-one in occurrence order", () => {
+    const rawAssistantParts: [
+      Record<string, unknown>,
+      Record<string, unknown>,
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ] = [{
+      executableCode: {
+        id: "code_a",
+        language: "PYTHON",
+        code: "print('a')",
+      },
+    }, {
+      executableCode: {
+        id: "code_b",
+        language: "PYTHON",
+        code: "print('b')",
+      },
+    }, {
+      codeExecutionResult: {
+        id: "code_a",
+        outcome: "OUTCOME_OK",
+        output: "a\n",
+      },
+    }, {
+      codeExecutionResult: {
+        id: "code_b",
+        outcome: "OUTCOME_FAILED",
+        output: "b failed\n",
+      },
+    }];
+    const calls: [
+      RuntimeAssistantContentPart,
+      RuntimeAssistantContentPart,
+    ] = [{
+      type: "tool-call",
+      toolCallId: "code_a",
+      toolName: "code_execution",
+      input: { language: "PYTHON", code: "print('a')" },
+      providerExecuted: true,
+    }, {
+      type: "tool-call",
+      toolCallId: "code_b",
+      toolName: "code_execution",
+      input: { language: "PYTHON", code: "print('b')" },
+      providerExecuted: true,
+    }];
+    const results: [
+      RuntimeAssistantContentPart,
+      RuntimeAssistantContentPart,
+    ] = [{
+      type: "tool-result",
+      toolCallId: "code_a",
+      toolName: "code_execution",
+      result: { outcome: "OUTCOME_OK", output: "a\n" },
+      providerExecuted: true,
+    }, {
+      type: "tool-result",
+      toolCallId: "code_b",
+      toolName: "code_execution",
+      result: { outcome: "OUTCOME_FAILED", output: "b failed\n" },
+      isError: true,
+      providerExecuted: true,
+    }];
+
+    assertJsonEquals(
+      buildGoogleAssistantReplay(rawAssistantParts, [...calls, ...results]).contents,
+      [{ role: "model", parts: rawAssistantParts }],
+    );
+    for (
+      const content of [
+        [calls[1], calls[0], ...results],
+        [...calls, results[1], results[0]],
+        [calls[0], { ...calls[0] }, ...results],
+        [...calls, results[0], { ...results[0] }],
+      ]
+    ) {
+      assertThrows(
+        () => buildGoogleAssistantReplay(rawAssistantParts, content),
+        TypeError,
+        "Google raw assistant metadata did not match canonical provider tool history",
+      );
+    }
+
+    const interleavedRawParts = [
+      rawAssistantParts[0],
+      rawAssistantParts[2],
+      rawAssistantParts[1],
+      rawAssistantParts[3],
+    ];
+    assertJsonEquals(
+      buildGoogleAssistantReplay(
+        interleavedRawParts,
+        [calls[0], results[0], calls[1], results[1]],
+      ).contents,
+      [{ role: "model", parts: interleavedRawParts }],
+    );
+    assertThrows(
+      () =>
+        buildGoogleAssistantReplay(
+          interleavedRawParts,
+          [...calls, ...results],
+        ),
+      TypeError,
+      "Google raw assistant metadata did not match canonical provider tool history",
+    );
+  });
+
+  it("coalesces only matching providerToolCalls/content projections", () => {
+    const rawAssistantParts = [{
+      executableCode: {
+        id: "code_a",
+        language: "PYTHON",
+        code: "print('a')",
+      },
+    }, {
+      executableCode: {
+        id: "code_b",
+        language: "PYTHON",
+        code: "print('b')",
+      },
+    }, {
+      codeExecutionResult: {
+        id: "code_a",
+        outcome: "OUTCOME_OK",
+        output: "a\n",
+      },
+    }, {
+      codeExecutionResult: {
+        id: "code_b",
+        outcome: "OUTCOME_OK",
+        output: "b\n",
+      },
+    }];
+    const contentCalls: [
+      RuntimeAssistantContentPart,
+      RuntimeAssistantContentPart,
+    ] = [{
+      type: "tool-call",
+      toolCallId: "code_a",
+      toolName: "code_execution",
+      input: { language: "PYTHON", code: "print('a')" },
+      providerExecuted: true,
+    }, {
+      type: "tool-call",
+      toolCallId: "code_b",
+      toolName: "code_execution",
+      input: { language: "PYTHON", code: "print('b')" },
+      providerExecuted: true,
+    }];
+    const providerToolCalls: [
+      { toolCallId: string; toolName: string; input: unknown },
+      { toolCallId: string; toolName: string; input: unknown },
+    ] = [{
+      toolCallId: "code_a",
+      toolName: "code_execution",
+      input: { language: "PYTHON", code: "print('a')" },
+    }, {
+      toolCallId: "code_b",
+      toolName: "code_execution",
+      input: { language: "PYTHON", code: "print('b')" },
+    }];
+
+    assertJsonEquals(
+      buildGoogleAssistantReplay(
+        rawAssistantParts,
+        contentCalls,
+        providerToolCalls,
+      ).contents,
+      [{ role: "model", parts: rawAssistantParts }],
+    );
+    assertThrows(
+      () =>
+        buildGoogleAssistantReplay(
+          rawAssistantParts,
+          contentCalls,
+          [providerToolCalls[1], providerToolCalls[0]],
+        ),
+      TypeError,
+      "Google raw assistant metadata did not match canonical provider tool history",
+    );
+    assertThrows(
+      () =>
+        buildGoogleAssistantReplay(
+          rawAssistantParts,
+          contentCalls,
+          [providerToolCalls[0], { ...providerToolCalls[0] }],
+        ),
+      TypeError,
+      "Google raw assistant metadata did not match canonical provider tool history",
+    );
+  });
+
+  it("uses the provider's deterministic ids when correlating anonymous code execution", () => {
+    const rawAssistantParts = [{
+      functionCall: {
+        id: "google-code-execution-0",
+        name: "lookup",
+        args: {},
+      },
+      thoughtSignature: "signature",
+    }, {
+      executableCode: {
+        language: "PYTHON",
+        code: "print('ok')",
+      },
+    }, {
+      codeExecutionResult: {
+        outcome: "OUTCOME_OK",
+        output: "ok\n",
+      },
+    }];
+
+    const body = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [{
+            type: "tool-call",
+            toolCallId: "google-code-execution-1",
+            toolName: "code_execution",
+            input: '{"code":"print(\'ok\')","language":"PYTHON"}',
+            providerExecuted: true,
+          }],
+          providerMetadata: {
+            google: { rawAssistantParts },
+          },
+        }],
+      },
+      createWarningCollector(),
+    );
+
+    assertJsonEquals(body.contents, [{
+      role: "model",
+      parts: rawAssistantParts,
+    }]);
+  });
+
+  it("correlates raw code execution with legacy providerToolCalls metadata", () => {
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{ type: "text", text: "Execution complete" }],
+              providerToolCalls: [{
+                toolCallId: "different-id",
+                toolName: "code_execution",
+                input: { language: "PYTHON", code: "print('ok')" },
+              }],
+              providerMetadata: {
+                google: {
+                  rawAssistantParts: [{
+                    executableCode: {
+                      id: "code_1",
+                      language: "PYTHON",
+                      code: "print('ok')",
+                    },
+                  }, {
+                    codeExecutionResult: {
+                      id: "code_1",
+                      outcome: "OUTCOME_OK",
+                      output: "ok\n",
+                    },
+                  }],
+                },
+              },
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Google raw assistant metadata did not match canonical provider tool history",
+    );
+  });
+
+  it("owns exact-replay metadata without invoking accessors or retaining live input", () => {
+    let getterReads = 0;
+    const hostileExecutableCode = Object.defineProperty(
+      { id: "code_1", language: "PYTHON" },
+      "code",
+      {
+        enumerable: true,
+        get() {
+          getterReads += 1;
+          return "print('changed')";
+        },
+      },
+    );
+    assertThrows(
+      () =>
+        createGoogleProviderMetadata([{
+          executableCode: hostileExecutableCode,
+        }]),
+      TypeError,
+      "Provider JSON snapshot must contain only enumerable data properties",
+    );
+    assertEquals(getterReads, 0);
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{ type: "text", text: "Do not invoke the getter." }],
+              providerMetadata: {
+                google: {
+                  rawAssistantParts: [{
+                    executableCode: hostileExecutableCode,
+                  }],
+                },
+              },
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Provider JSON snapshot must contain only enumerable data properties",
+    );
+    assertEquals(getterReads, 0);
+
+    const sourcePart = {
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: { value: "original" },
+      },
+      thoughtSignature: "signature",
+    };
+    const sourceParts = [sourcePart];
+    const providerMetadata = createGoogleProviderMetadata(sourceParts);
+    sourcePart.functionCall.args.value = "mutated";
+    assertEquals(Object.isFrozen(providerMetadata), true);
+
+    const body = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [{
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            input: { value: "original" },
+          }],
+          providerMetadata,
+        }],
+      },
+      createWarningCollector(),
+    );
+    assertJsonEquals(body.contents, [{
+      role: "model",
+      parts: [{
+        functionCall: {
+          args: { value: "original" },
+          id: "call_1",
+          name: "lookup",
+        },
+        thoughtSignature: "signature",
+      }],
+    }]);
+  });
+
+  it("isolates Google replay from unrelated provider metadata namespaces", () => {
+    let unrelatedGetterReads = 0;
+    const unrelatedNamespace = Object.defineProperty(
+      { oversized: "x".repeat(8 * 1024 * 1024 + 1) },
+      "hostile",
+      {
+        enumerable: true,
+        get() {
+          unrelatedGetterReads += 1;
+          return "private";
+        },
+      },
+    );
+    const body = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [{ type: "text", text: "No Google metadata." }],
+          providerMetadata: {
+            anotherProvider: unrelatedNamespace,
+          },
+        }],
+      },
+      createWarningCollector(),
+    );
+    assertEquals(body.contents, [{
+      role: "model",
+      parts: [{ text: "No Google metadata." }],
+    }]);
+    assertEquals(unrelatedGetterReads, 0);
+
+    let groundingGetterReads = 0;
+    const hostileGroundingMetadata = Object.defineProperty(
+      { oversized: "x".repeat(8 * 1024 * 1024 + 1) },
+      "privateField",
+      {
+        enumerable: true,
+        get() {
+          groundingGetterReads += 1;
+          return "private";
+        },
+      },
+    );
+    const groundingOnlyBody = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [{ type: "text", text: "No exact replay metadata." }],
+          providerMetadata: {
+            google: {
+              groundingMetadata: hostileGroundingMetadata,
+              futureMetadata: new Date(0),
+            },
+          },
+        }],
+      },
+      createWarningCollector(),
+    );
+    assertEquals(groundingOnlyBody.contents, [{
+      role: "model",
+      parts: [{ text: "No exact replay metadata." }],
+    }]);
+    assertEquals(groundingGetterReads, 0);
+
+    let googleGetterReads = 0;
+    const providerMetadata = Object.defineProperty(
+      {},
+      "google",
+      {
+        enumerable: true,
+        get() {
+          googleGetterReads += 1;
+          return { rawAssistantParts: [] };
+        },
+      },
+    );
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{ type: "text", text: "Do not invoke Google metadata." }],
+              providerMetadata,
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Google provider metadata namespace must be an enumerable data property",
+    );
+    assertEquals(googleGetterReads, 0);
+  });
+
+  it("enforces the exact Google raw-part count boundary", () => {
+    const atLimit = Array.from(
+      { length: 4_096 },
+      (_, index) => index === 0 ? { text: "", thoughtSignature: "signature" } : { text: "" },
+    );
+    const metadata = createGoogleProviderMetadata(atLimit);
+    const googleMetadata = metadata?.google as Record<string, unknown>;
+    assertEquals(
+      (googleMetadata.rawAssistantParts as unknown[]).length,
+      4_096,
+    );
+    assertEquals(
+      buildGoogleAssistantReplay(atLimit, [{
+        type: "text",
+        text: "The raw projection is retained.",
+      }]).contents.length,
+      1,
+    );
+
+    const overLimit = [...atLimit, { text: "" }];
+    assertThrows(
+      () => createGoogleProviderMetadata(overLimit),
+      TypeError,
+      "Google raw assistant parts exceeded 4096 entries",
+    );
+    assertThrows(
+      () =>
+        buildGoogleAssistantReplay(overLimit, [{
+          type: "text",
+          text: "Do not replay too many raw parts.",
+        }]),
+      TypeError,
+      "Google raw assistant parts exceeded 4096 entries",
+    );
+  });
+
+  it("does not charge omitted ordinary parts against exact-replay budgets", () => {
+    const ordinaryParts = Array.from(
+      { length: 4_097 },
+      (_, index) => ({
+        text: index === 0 ? "x".repeat(8 * 1024 * 1024 + 1) : "",
+      }),
+    );
+    assertEquals(createGoogleProviderMetadata(ordinaryParts), undefined);
+
+    const groundingMetadata = { source: "google-search" };
+    assertJsonEquals(
+      createGoogleProviderMetadata(ordinaryParts, groundingMetadata),
+      {
+        google: { groundingMetadata },
+      },
+    );
+
+    let textGetterReads = 0;
+    const ordinaryAccessorPart = Object.defineProperty(
+      {},
+      "text",
+      {
+        enumerable: true,
+        get() {
+          textGetterReads += 1;
+          return "not persisted";
+        },
+      },
+    ) as Record<string, unknown>;
+    assertEquals(
+      createGoogleProviderMetadata([ordinaryAccessorPart]),
+      undefined,
+    );
+    assertEquals(textGetterReads, 0);
+  });
+
+  it("enforces the exact 8 MiB Google provider-metadata boundary", () => {
+    const maxBytes = 8 * 1024 * 1024;
+    const skeleton = {
+      google: {
+        rawAssistantParts: [{
+          text: "",
+          thoughtSignature: "signature",
+        }],
+      },
+    };
+    const fixedBytes = new TextEncoder().encode(JSON.stringify(skeleton)).byteLength;
+    const exactText = "a".repeat(maxBytes - fixedBytes);
+    const exactMetadata = createGoogleProviderMetadata([{
+      text: exactText,
+      thoughtSignature: "signature",
+    }]);
+    assertEquals(
+      new TextEncoder().encode(JSON.stringify(exactMetadata)).byteLength,
+      maxBytes,
+    );
+    assertEquals(
+      buildGoogleGenerateContentRequest(
+        "google",
+        {
+          prompt: [{
+            role: "assistant",
+            content: [{ type: "text", text: "Compacted canonical output." }],
+            providerMetadata: exactMetadata,
+          }],
+        },
+        createWarningCollector(),
+      ).contents.length,
+      1,
+    );
+
+    assertThrows(
+      () =>
+        createGoogleProviderMetadata([{
+          text: `${exactText}a`,
+          thoughtSignature: "signature",
+        }]),
+      TypeError,
+      "Provider JSON snapshot exceeded 8388608 UTF-8 bytes",
+    );
+
+    const rawPartsSkeleton = skeleton.google.rawAssistantParts;
+    const rawPartsFixedBytes =
+      new TextEncoder().encode(JSON.stringify(rawPartsSkeleton)).byteLength;
+    const exactReplayText = "a".repeat(maxBytes - rawPartsFixedBytes);
+    assertEquals(
+      buildGoogleAssistantReplay([{
+        text: exactReplayText,
+        thoughtSignature: "signature",
+      }], [{
+        type: "text",
+        text: "Replay the exact boundary.",
+      }]).contents.length,
+      1,
+    );
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{ type: "text", text: "Do not replay oversized metadata." }],
+              providerMetadata: {
+                google: {
+                  rawAssistantParts: [{
+                    text: `${exactReplayText}a`,
+                    thoughtSignature: "signature",
+                  }],
+                },
+              },
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Provider JSON snapshot exceeded 8388608 UTF-8 bytes",
+    );
+  });
+
+  it("enforces the exact Google metadata depth and node boundaries", () => {
+    const exactDepthParts = [{
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: nestedGoogleArguments(58),
+      },
+      thoughtSignature: "signature",
+    }];
+    assertEquals(
+      createGoogleProviderMetadata(exactDepthParts) !== undefined,
+      true,
+    );
+    assertEquals(
+      buildGoogleAssistantReplay(exactDepthParts, [{
+        type: "text",
+        text: "The canonical call was compacted.",
+      }]).contents.length,
+      1,
+    );
+    const overDepthParts = [{
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: nestedGoogleArguments(59),
+      },
+      thoughtSignature: "signature",
+    }];
+    assertThrows(
+      () => createGoogleProviderMetadata(overDepthParts),
+      TypeError,
+      "Provider JSON snapshot exceeded maximum depth 64",
+    );
+    const exactReplayDepthParts = [{
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: nestedGoogleArguments(60),
+      },
+      thoughtSignature: "signature",
+    }];
+    assertEquals(
+      buildGoogleAssistantReplay(exactReplayDepthParts, [{
+        type: "text",
+        text: "The canonical call was compacted.",
+      }]).contents.length,
+      1,
+    );
+    const overReplayDepthParts = [{
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: nestedGoogleArguments(61),
+      },
+      thoughtSignature: "signature",
+    }];
+    assertThrows(
+      () =>
+        buildGoogleAssistantReplay(overReplayDepthParts, [{
+          type: "text",
+          text: "Do not replay excessively deep metadata.",
+        }]),
+      TypeError,
+      "Provider JSON snapshot exceeded maximum depth 64",
+    );
+
+    const exactNodeValues = Array.from({ length: 65_526 }, () => true);
+    const exactNodeParts = [{
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: { values: exactNodeValues },
+      },
+      thoughtSignature: "signature",
+    }];
+    assertEquals(
+      createGoogleProviderMetadata(exactNodeParts) !== undefined,
+      true,
+    );
+    assertEquals(
+      buildGoogleAssistantReplay(exactNodeParts, [{
+        type: "text",
+        text: "The canonical call was compacted.",
+      }]).contents.length,
+      1,
+    );
+    const overNodeParts = [{
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: { values: [...exactNodeValues, true] },
+      },
+      thoughtSignature: "signature",
+    }];
+    assertThrows(
+      () => createGoogleProviderMetadata(overNodeParts),
+      TypeError,
+      "Provider JSON snapshot exceeded 65536 nodes",
+    );
+    const exactReplayNodeValues = [...exactNodeValues, true, true];
+    const exactReplayNodeParts = [{
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: { values: exactReplayNodeValues },
+      },
+      thoughtSignature: "signature",
+    }];
+    assertEquals(
+      buildGoogleAssistantReplay(exactReplayNodeParts, [{
+        type: "text",
+        text: "The canonical call was compacted.",
+      }]).contents.length,
+      1,
+    );
+    const overReplayNodeParts = [{
+      functionCall: {
+        id: "call_1",
+        name: "lookup",
+        args: { values: [...exactReplayNodeValues, true] },
+      },
+      thoughtSignature: "signature",
+    }];
+    assertThrows(
+      () =>
+        buildGoogleAssistantReplay(overReplayNodeParts, [{
+          type: "text",
+          text: "Do not replay excessive metadata nodes.",
+        }]),
+      TypeError,
+      "Provider JSON snapshot exceeded 65536 nodes",
+    );
+  });
+
+  it("fails closed on malformed signed-assistant metadata", () => {
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{ type: "text", text: "Fallback text must not hide bad metadata." }],
+              providerMetadata: {
+                google: {
+                  rawAssistantParts: [{ text: "answer", thoughtSignature: 42 }],
+                },
+              },
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Google thought signature must be a non-empty string",
+    );
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{
+                type: "tool-call",
+                toolCallId: "tool_1",
+                toolName: "lookup",
+                input: {},
+              }],
+              providerMetadata: {
+                google: {
+                  rawAssistantParts: [{
+                    functionCall: { id: "tool_1", name: "lookup", args: [] },
+                    thoughtSignature: "signature",
+                  }],
+                },
+              },
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Google raw assistant function call is malformed",
+    );
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{ type: "text", text: "Do not fall back." }],
+              providerMetadata: {
+                google: {
+                  rawAssistantParts: [{
+                    executableCode: {
+                      id: "code_1",
+                      language: "PYTHON",
+                      code: "print('ok')",
+                    },
+                  }, {
+                    codeExecutionResult: {
+                      id: "code_2",
+                      outcome: "OUTCOME_OK",
+                      output: "ok\n",
+                    },
+                  }],
+                },
+              },
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      "code execution result id did not match executable code",
+    );
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{ type: "text", text: "Do not fall back." }],
+              providerMetadata: {
+                google: {
+                  rawAssistantParts: [{
+                    inlineData: { mimeType: "image/png", data: "AAAA" },
+                    thoughtSignature: "signature",
+                  }],
+                },
+              },
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      'Google part data field "inlineData" is unsupported',
+    );
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{
+                type: "tool-call",
+                toolCallId: "code_1",
+                toolName: "code_execution",
+                input: { language: "PYTHON", code: "print('ok')" },
+                providerExecuted: true,
+              }],
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Google provider-executed assistant tool calls require exact raw replay metadata",
+    );
+    assertThrows(
+      () =>
+        buildGoogleGenerateContentRequest(
+          "google",
+          {
+            prompt: [{
+              role: "assistant",
+              content: [{
+                type: "tool-result",
+                toolCallId: "code_1",
+                toolName: "code_execution",
+                result: { outcome: "OK" },
+                providerExecuted: true,
+              }],
+            }],
+          },
+          createWarningCollector(),
+        ),
+      TypeError,
+      "Google provider-executed assistant tool results require exact raw replay metadata",
+    );
+  });
+
+  it("accepts only non-negative safe explicit Google thinking budgets", () => {
+    const prompt: RuntimePromptMessage[] = [{
+      role: "user",
+      content: [{ type: "text", text: "Think." }],
+    }];
+    const valid = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt,
+        reasoning: { enabled: true, effort: "low", budgetTokens: 0 },
+      },
+      createWarningCollector(),
+    );
+    assertEquals(valid.generationConfig, {
+      thinkingConfig: {
+        includeThoughts: true,
+        thinkingBudget: 0,
+      },
+    });
+
+    for (
+      const budgetTokens of [
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+        1.5,
+        -1,
+        -2,
+        Number.MAX_SAFE_INTEGER + 1,
+      ]
+    ) {
+      assertThrows(
+        () =>
+          buildGoogleGenerateContentRequest(
+            "google",
+            {
+              prompt,
+              reasoning: { enabled: true, budgetTokens },
+            },
+            createWarningCollector(),
+          ),
+        TypeError,
+        "Google reasoning budgetTokens must be a non-negative safe integer",
+      );
+    }
   });
 });

--- a/extensions/ext-llm-google/src/google-request-builder.ts
+++ b/extensions/ext-llm-google/src/google-request-builder.ts
@@ -1,68 +1,37 @@
-import { readProviderOptions, readRecord, unwrapToolInputSchema } from "veryfront/provider/shared";
-import type { RuntimePromptMessage } from "veryfront/provider/shared";
+import {
+  jsonValuesEqual,
+  readProviderOptions,
+  readRecord,
+  unwrapToolInputSchema,
+} from "veryfront/provider/shared";
+import type {
+  ModelRuntimeCallOptions,
+  ModelRuntimePromptMessage,
+  ModelRuntimeToolDefinition,
+  RuntimeReasoningOption,
+} from "veryfront/provider/shared";
+import {
+  createGoogleToolCallCorrelationRegistry,
+  GOOGLE_CODE_EXECUTION_TOOL_NAME,
+  googleCodeExecutionInput,
+  googleCodeExecutionOutput,
+  readGoogleCodeExecutionResult,
+  readGoogleExecutableCode,
+  readGooglePartDataField,
+} from "./google-content-parts.ts";
+import { readGoogleRawAssistantParts } from "./google-thought-signatures.ts";
 
-export type RuntimeToolDefinition =
-  | {
-    type: "function";
-    name: string;
-    description?: string;
-    inputSchema: unknown;
-  }
-  | {
-    type: "provider";
-    name: string;
-    id: `${string}.${string}`;
-    args: Record<string, unknown>;
-  };
-
-type ProviderReasoningEffort = "low" | "medium" | "high" | "max";
-
-type ProviderReasoningOption = {
-  enabled?: boolean;
-  effort?: ProviderReasoningEffort;
-  budgetTokens?: number;
-};
-
-export type OpenAICompatibleLanguageOptions = {
-  prompt: RuntimePromptMessage[];
-  maxOutputTokens?: number;
-  temperature?: number;
-  topP?: number;
-  topK?: number;
-  stopSequences?: string[];
-  tools?: RuntimeToolDefinition[];
-  toolChoice?: unknown;
-  seed?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  headers?: HeadersInit;
-  providerOptions?: Record<string, unknown>;
-  includeRawChunks?: boolean;
-  abortSignal?: AbortSignal;
-  cacheControl?: unknown;
-  reasoning?: ProviderReasoningOption;
-  userId?: string;
+export interface OpenAICompatibleLanguageOptions extends ModelRuntimeCallOptions {
   requestLabels?: Record<string, string>;
-  serviceTier?: "auto" | "default" | "flex" | "scale";
-  parallelToolCalls?: boolean;
-  responseFormat?:
-    | { type: "text" }
-    | { type: "json" }
-    | {
-      type: "json_schema";
-      name: string;
-      schema: unknown;
-      description?: string;
-      strict?: boolean;
-    };
-  anthropicContainer?: unknown;
   googleCachedContent?: string;
-  googleSafetySettings?: Array<{
+  googleSafetySettings?: ReadonlyArray<{
     category: string;
     threshold: string;
   }>;
-  mcpServers?: Array<Record<string, unknown>>;
-};
+}
+
+/** @deprecated Import `ModelRuntimeToolDefinition` from `veryfront/provider` instead. */
+export type RuntimeToolDefinition = ModelRuntimeToolDefinition;
 
 type WarningCollector = {
   push(warning: {
@@ -81,7 +50,7 @@ type WarningCollector = {
 
 type GoogleCompatibleContent = {
   role: "user" | "model";
-  parts: Array<Record<string, unknown>>;
+  parts: readonly Record<string, unknown>[];
 };
 
 type GoogleCompatibleRequest = {
@@ -97,8 +66,346 @@ type GoogleCompatibleRequest = {
   [key: string]: unknown;
 };
 
+type CanonicalProviderCall = {
+  id: string;
+  name: string;
+  input: unknown;
+};
+
+type CanonicalProviderResult = {
+  id: string;
+  name: string;
+  result: unknown;
+  isError: boolean;
+};
+
+type GoogleToolEventKind =
+  | "ordinary-call"
+  | "provider-call"
+  | "provider-result";
+
+type GoogleToolEvent = {
+  kind: GoogleToolEventKind;
+  id: string;
+};
+
+type GoogleRawToolHistory = {
+  ordinaryCalls: CanonicalProviderCall[];
+  legacyOrdinaryCalls: CanonicalProviderCall[];
+  providerCalls: CanonicalProviderCall[];
+  providerResults: CanonicalProviderResult[];
+  toolEvents: GoogleToolEvent[];
+  legacyToolEvents: GoogleToolEvent[];
+};
+
+function invalidGoogleProviderHistory(): TypeError {
+  return new TypeError(
+    "Google raw assistant metadata did not match canonical provider tool history",
+  );
+}
+
+function readGoogleRawToolHistory(
+  rawAssistantParts: readonly Record<string, unknown>[],
+): GoogleRawToolHistory {
+  const registry = createGoogleToolCallCorrelationRegistry();
+  const ordinaryCalls: CanonicalProviderCall[] = [];
+  const legacyOrdinaryCalls: CanonicalProviderCall[] = [];
+  const providerCalls: CanonicalProviderCall[] = [];
+  const providerResults: CanonicalProviderResult[] = [];
+  const toolEvents: GoogleToolEvent[] = [];
+  const legacyToolEvents: GoogleToolEvent[] = [];
+  let anonymousFunctionCallIndex = 0;
+
+  for (let partIndex = 0; partIndex < rawAssistantParts.length; partIndex += 1) {
+    const part = rawAssistantParts[partIndex];
+    if (part === undefined) {
+      throw invalidGoogleProviderHistory();
+    }
+    const dataField = readGooglePartDataField(part);
+    if (dataField === "functionCall") {
+      const functionCall = readRecord(part.functionCall);
+      if (
+        !functionCall ||
+        typeof functionCall.name !== "string" ||
+        !readRecord(functionCall.args)
+      ) {
+        throw invalidGoogleProviderHistory();
+      }
+      const providerId = typeof functionCall.id === "string" ? functionCall.id : undefined;
+      const id = registry.registerFunctionCall(partIndex, providerId);
+      // Histories persisted before raw-position ids used the anonymous-call
+      // occurrence instead. Build both complete projections so validation
+      // cannot accept a mixture that no implementation ever emitted.
+      const legacyId = providerId === undefined ? `tool-${anonymousFunctionCallIndex++}` : id;
+      const call = {
+        name: functionCall.name,
+        input: functionCall.args,
+      };
+      ordinaryCalls.push({ id, ...call });
+      legacyOrdinaryCalls.push({ id: legacyId, ...call });
+      toolEvents.push({ kind: "ordinary-call", id });
+      legacyToolEvents.push({ kind: "ordinary-call", id: legacyId });
+      continue;
+    }
+    if (dataField === "executableCode") {
+      const executableCode = readGoogleExecutableCode(part.executableCode);
+      const id = registry.registerCodeExecution(executableCode.providerId);
+      providerCalls.push({
+        id,
+        name: GOOGLE_CODE_EXECUTION_TOOL_NAME,
+        input: googleCodeExecutionInput(executableCode),
+      });
+      toolEvents.push({ kind: "provider-call", id });
+      legacyToolEvents.push({ kind: "provider-call", id });
+      continue;
+    }
+    if (dataField !== "codeExecutionResult") {
+      continue;
+    }
+
+    const result = readGoogleCodeExecutionResult(part.codeExecutionResult);
+    const id = registry.resolveCodeExecutionResult(result.providerId);
+    providerResults.push({
+      id,
+      name: GOOGLE_CODE_EXECUTION_TOOL_NAME,
+      result: googleCodeExecutionOutput(result),
+      isError: result.isError,
+    });
+    toolEvents.push({ kind: "provider-result", id });
+    legacyToolEvents.push({ kind: "provider-result", id });
+  }
+  registry.assertSettled();
+  return {
+    ordinaryCalls,
+    legacyOrdinaryCalls,
+    providerCalls,
+    providerResults,
+    toolEvents,
+    legacyToolEvents,
+  };
+}
+
+function callsMatch(
+  left: CanonicalProviderCall,
+  right: CanonicalProviderCall,
+): boolean {
+  return left.id === right.id &&
+    left.name === right.name &&
+    jsonValuesEqual(left.input, right.input, true);
+}
+
+function resultsMatch(
+  left: CanonicalProviderResult,
+  right: CanonicalProviderResult,
+): boolean {
+  return left.id === right.id &&
+    left.name === right.name &&
+    left.isError === right.isError &&
+    jsonValuesEqual(left.result, right.result);
+}
+
+function orderedProjectionMatches<T extends object>(
+  left: readonly T[],
+  right: readonly T[],
+  entryMatches: (left: T, right: T) => boolean,
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    const entry = left[index];
+    const matchingEntry = right[index];
+    if (
+      entry === undefined ||
+      matchingEntry === undefined ||
+      !entryMatches(entry, matchingEntry)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function rejectDuplicateIds(
+  entries: readonly { id: string }[],
+): void {
+  const ids = new Set<string>();
+  for (const entry of entries) {
+    if (ids.has(entry.id)) {
+      throw invalidGoogleProviderHistory();
+    }
+    ids.add(entry.id);
+  }
+}
+
+function survivingToolEvents(
+  events: readonly GoogleToolEvent[],
+  activeKinds: ReadonlySet<GoogleToolEventKind>,
+): GoogleToolEvent[] {
+  const surviving: GoogleToolEvent[] = [];
+  for (const event of events) {
+    if (activeKinds.has(event.kind)) {
+      surviving.push(event);
+    }
+  }
+  return surviving;
+}
+
+function validateGoogleToolReplay(
+  message: Extract<ModelRuntimePromptMessage, { readonly role: "assistant" }>,
+  rawAssistantParts: readonly Record<string, unknown>[],
+): void {
+  const providerToolCalls = (message.providerToolCalls ?? []).map((call) => ({
+    id: call.toolCallId,
+    name: call.toolName,
+    input: call.input,
+  }));
+  rejectDuplicateIds(providerToolCalls);
+
+  const contentProviderCalls: CanonicalProviderCall[] = [];
+  const ordinaryCalls: CanonicalProviderCall[] = [];
+  const providerResults: CanonicalProviderResult[] = [];
+  const contentToolEvents: GoogleToolEvent[] = [];
+  const contentCallIds = new Set<string>();
+  for (const part of message.content) {
+    if (part.type === "tool-call") {
+      if (contentCallIds.has(part.toolCallId)) {
+        throw invalidGoogleProviderHistory();
+      }
+      contentCallIds.add(part.toolCallId);
+      const call = {
+        id: part.toolCallId,
+        name: part.toolName,
+        input: part.input,
+      };
+      const callKind = part.providerExecuted === true ? "provider" : "ordinary";
+      (callKind === "provider" ? contentProviderCalls : ordinaryCalls).push(call);
+      contentToolEvents.push({
+        kind: callKind === "provider" ? "provider-call" : "ordinary-call",
+        id: call.id,
+      });
+      continue;
+    }
+    if (part.type !== "tool-result" || part.providerExecuted !== true) {
+      continue;
+    }
+    providerResults.push({
+      id: part.toolCallId,
+      name: part.toolName,
+      result: part.result,
+      isError: part.isError === true,
+    });
+    contentToolEvents.push({
+      kind: "provider-result",
+      id: part.toolCallId,
+    });
+  }
+  rejectDuplicateIds(providerResults);
+
+  let canonicalProviderCalls: CanonicalProviderCall[];
+  if (providerToolCalls.length > 0 && contentProviderCalls.length > 0) {
+    if (
+      !orderedProjectionMatches(
+        providerToolCalls,
+        contentProviderCalls,
+        callsMatch,
+      )
+    ) {
+      throw invalidGoogleProviderHistory();
+    }
+    // `providerToolCalls` is the historical message-level projection of the
+    // same provider-executed content. Validate both sources above, but compare
+    // the replay only once.
+    canonicalProviderCalls = providerToolCalls;
+  } else {
+    canonicalProviderCalls = providerToolCalls.length > 0
+      ? providerToolCalls
+      : contentProviderCalls;
+  }
+  rejectDuplicateIds([...ordinaryCalls, ...canonicalProviderCalls]);
+
+  let rawHistory: GoogleRawToolHistory;
+  try {
+    rawHistory = readGoogleRawToolHistory(rawAssistantParts);
+  } catch {
+    throw invalidGoogleProviderHistory();
+  }
+
+  // Exact wire history may outlive an absent canonical projection, for example
+  // after compaction. Once any projection survives, however, it must correlate
+  // one-for-one and in occurrence order; maps or sets would silently accept
+  // reordered or duplicated calls/results.
+  if (
+    canonicalProviderCalls.length > 0 &&
+    !orderedProjectionMatches(
+      rawHistory.providerCalls,
+      canonicalProviderCalls,
+      callsMatch,
+    )
+  ) {
+    throw invalidGoogleProviderHistory();
+  }
+  if (
+    providerResults.length > 0 &&
+    !orderedProjectionMatches(
+      rawHistory.providerResults,
+      providerResults,
+      resultsMatch,
+    )
+  ) {
+    throw invalidGoogleProviderHistory();
+  }
+  const activeContentEventKinds = new Set<GoogleToolEventKind>();
+  if (ordinaryCalls.length > 0) {
+    activeContentEventKinds.add("ordinary-call");
+  }
+  if (contentProviderCalls.length > 0) {
+    activeContentEventKinds.add("provider-call");
+  }
+  if (providerResults.length > 0) {
+    activeContentEventKinds.add("provider-result");
+  }
+  const currentRawSurvivingEvents = survivingToolEvents(
+    rawHistory.toolEvents,
+    activeContentEventKinds,
+  );
+  const legacyRawSurvivingEvents = survivingToolEvents(
+    rawHistory.legacyToolEvents,
+    activeContentEventKinds,
+  );
+  const canonicalSurvivingEvents = survivingToolEvents(
+    contentToolEvents,
+    activeContentEventKinds,
+  );
+  const currentIdsMatch = (
+    ordinaryCalls.length === 0 ||
+    orderedProjectionMatches(rawHistory.ordinaryCalls, ordinaryCalls, callsMatch)
+  ) &&
+    orderedProjectionMatches(
+      currentRawSurvivingEvents,
+      canonicalSurvivingEvents,
+      (left, right) => left.kind === right.kind && left.id === right.id,
+    );
+  const legacyIdsMatch = (
+    ordinaryCalls.length === 0 ||
+    orderedProjectionMatches(
+      rawHistory.legacyOrdinaryCalls,
+      ordinaryCalls,
+      callsMatch,
+    )
+  ) &&
+    orderedProjectionMatches(
+      legacyRawSurvivingEvents,
+      canonicalSurvivingEvents,
+      (left, right) => left.kind === right.kind && left.id === right.id,
+    );
+  if (!currentIdsMatch && !legacyIdsMatch) {
+    throw invalidGoogleProviderHistory();
+  }
+}
+
 function toGoogleContents(
-  prompt: RuntimePromptMessage[],
+  prompt: readonly ModelRuntimePromptMessage[],
 ): {
   systemInstruction?: { parts: Array<{ text: string }> };
   contents: GoogleCompatibleContent[];
@@ -120,6 +427,13 @@ function toGoogleContents(
         });
         break;
       case "assistant": {
+        const rawAssistantParts = readGoogleRawAssistantParts(message.providerMetadata);
+        if (rawAssistantParts) {
+          validateGoogleToolReplay(message, rawAssistantParts);
+          contents.push({ role: "model", parts: rawAssistantParts });
+          break;
+        }
+
         const parts: Array<Record<string, unknown>> = [];
         for (const part of message.content) {
           if (part.type === "text") {
@@ -128,6 +442,16 @@ function toGoogleContents(
           }
           if (part.type === "reasoning") {
             continue;
+          }
+          if (part.type === "tool-result") {
+            throw new TypeError(
+              "Google provider-executed assistant tool results require exact raw replay metadata",
+            );
+          }
+          if (part.providerExecuted === true) {
+            throw new TypeError(
+              "Google provider-executed assistant tool calls require exact raw replay metadata",
+            );
           }
           parts.push({
             functionCall: {
@@ -166,7 +490,7 @@ function toGoogleContents(
 }
 
 function toGoogleUserParts(
-  parts: Extract<RuntimePromptMessage, { role: "user" }>["content"],
+  parts: Extract<ModelRuntimePromptMessage, { readonly role: "user" }>["content"],
 ): Array<Record<string, unknown>> {
   const content: Array<Record<string, unknown>> = [];
 
@@ -191,8 +515,212 @@ function toGoogleUserParts(
   return content;
 }
 
+const GOOGLE_CODE_EXECUTION_TOOL_ID = "google.code_execution";
+const GOOGLE_SEARCH_TOOL_ID = "google.google_search";
+const GOOGLE_SEARCH_TOOL_NAME = "google_search";
+const GOOGLE_SEARCH_ARGUMENT_KEYS = new Set(["searchTypes", "timeRangeFilter"]);
+const GOOGLE_SEARCH_TYPE_KEYS = new Set(["webSearch", "imageSearch"]);
+const GOOGLE_TIME_RANGE_KEYS = new Set(["startTime", "endTime"]);
+const RFC_3339_TIMESTAMP =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|[+-](\d{2}):(\d{2}))$/;
+
+function rejectUnknownKeys(
+  record: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+  subject: string,
+): void {
+  if (Object.keys(record).some((key) => !allowedKeys.has(key))) {
+    throw new TypeError(`${subject} contained an unsupported field`);
+  }
+}
+
+function readEmptyGoogleToolObject(value: unknown, subject: string): Record<string, never> {
+  const record = readRecord(value);
+  if (!record || Object.keys(record).length > 0) {
+    throw new TypeError(`${subject} must be an empty object`);
+  }
+  return {};
+}
+
+function readGoogleTimestamp(value: unknown, subject: string): string {
+  const timestamp = typeof value === "string" ? value : undefined;
+  const match = timestamp === undefined ? null : RFC_3339_TIMESTAMP.exec(timestamp);
+  if (!match || timestamp === undefined) {
+    throw new TypeError(`${subject} must be an RFC 3339 timestamp`);
+  }
+  const [
+    ,
+    yearText,
+    monthText,
+    dayText,
+    hourText,
+    minuteText,
+    secondText,
+    offsetHourText,
+    offsetMinuteText,
+  ] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const offsetHour = offsetHourText === undefined ? 0 : Number(offsetHourText);
+  const offsetMinute = offsetMinuteText === undefined ? 0 : Number(offsetMinuteText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    leapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ][month - 1];
+  if (
+    year < 1 ||
+    daysInMonth === undefined ||
+    day < 1 ||
+    day > daysInMonth ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59 ||
+    !Number.isFinite(Date.parse(timestamp))
+  ) {
+    throw new TypeError(`${subject} must be an RFC 3339 timestamp`);
+  }
+  return timestamp;
+}
+
+function readGoogleSearchArguments(value: unknown): Record<string, unknown> {
+  const args = readRecord(value);
+  if (!args) {
+    throw new TypeError("google.google_search args must be an object");
+  }
+  rejectUnknownKeys(args, GOOGLE_SEARCH_ARGUMENT_KEYS, "google.google_search args");
+
+  const normalized: Record<string, unknown> = {};
+  if (args.searchTypes !== undefined) {
+    const searchTypes = readRecord(args.searchTypes);
+    if (!searchTypes) {
+      throw new TypeError("google.google_search searchTypes must be an object");
+    }
+    rejectUnknownKeys(
+      searchTypes,
+      GOOGLE_SEARCH_TYPE_KEYS,
+      "google.google_search searchTypes",
+    );
+    normalized.searchTypes = {
+      ...(searchTypes.webSearch !== undefined
+        ? {
+          webSearch: readEmptyGoogleToolObject(
+            searchTypes.webSearch,
+            "google.google_search webSearch",
+          ),
+        }
+        : {}),
+      ...(searchTypes.imageSearch !== undefined
+        ? {
+          imageSearch: readEmptyGoogleToolObject(
+            searchTypes.imageSearch,
+            "google.google_search imageSearch",
+          ),
+        }
+        : {}),
+    };
+  }
+
+  if (args.timeRangeFilter !== undefined) {
+    const timeRangeFilter = readRecord(args.timeRangeFilter);
+    if (!timeRangeFilter) {
+      throw new TypeError("google.google_search timeRangeFilter must be an object");
+    }
+    rejectUnknownKeys(
+      timeRangeFilter,
+      GOOGLE_TIME_RANGE_KEYS,
+      "google.google_search timeRangeFilter",
+    );
+    const hasStart = timeRangeFilter.startTime !== undefined;
+    const hasEnd = timeRangeFilter.endTime !== undefined;
+    if (hasStart !== hasEnd) {
+      throw new TypeError(
+        "google.google_search timeRangeFilter requires both startTime and endTime",
+      );
+    }
+    if (hasStart && hasEnd) {
+      const startTime = readGoogleTimestamp(
+        timeRangeFilter.startTime,
+        "google.google_search startTime",
+      );
+      const endTime = readGoogleTimestamp(
+        timeRangeFilter.endTime,
+        "google.google_search endTime",
+      );
+      if (Date.parse(startTime) > Date.parse(endTime)) {
+        throw new TypeError(
+          "google.google_search timeRangeFilter startTime must not be after endTime",
+        );
+      }
+      normalized.timeRangeFilter = { startTime, endTime };
+    } else {
+      normalized.timeRangeFilter = {};
+    }
+  }
+
+  return normalized;
+}
+
+function toGoogleProviderTool(
+  tool: Extract<ModelRuntimeToolDefinition, { type: "provider" }>,
+): { id: string; wireTool: Record<string, unknown> } {
+  if (typeof tool.id !== "string") {
+    throw new TypeError("Google provider tool id must be a string");
+  }
+
+  switch (tool.id) {
+    case GOOGLE_CODE_EXECUTION_TOOL_ID:
+      if (tool.name !== GOOGLE_CODE_EXECUTION_TOOL_NAME) {
+        throw new TypeError(
+          "google.code_execution provider tool name must be code_execution",
+        );
+      }
+      return {
+        id: tool.id,
+        wireTool: {
+          codeExecution: readEmptyGoogleToolObject(
+            tool.args,
+            "google.code_execution args",
+          ),
+        },
+      };
+    case GOOGLE_SEARCH_TOOL_ID:
+      if (tool.name !== GOOGLE_SEARCH_TOOL_NAME) {
+        throw new TypeError(
+          "google.google_search provider tool name must be google_search",
+        );
+      }
+      return {
+        id: tool.id,
+        wireTool: { googleSearch: readGoogleSearchArguments(tool.args) },
+      };
+    default:
+      throw new TypeError(
+        tool.id.startsWith("google.")
+          ? "Unsupported Google provider tool id"
+          : "Google requests cannot contain a provider tool for another provider",
+      );
+  }
+}
+
 function toGoogleTools(
-  tools: RuntimeToolDefinition[] | undefined,
+  tools: readonly ModelRuntimeToolDefinition[] | undefined,
 ): Array<Record<string, unknown>> | undefined {
   if (!tools) {
     return undefined;
@@ -200,6 +728,7 @@ function toGoogleTools(
 
   const functionDeclarations: Array<Record<string, unknown>> = [];
   const providerEntries: Array<Record<string, unknown>> = [];
+  const providerToolIds = new Set<string>();
 
   for (const tool of tools) {
     if (tool.type === "function") {
@@ -210,16 +739,16 @@ function toGoogleTools(
       });
       continue;
     }
+    if (tool.type !== "provider") {
+      throw new TypeError("Google tool type must be function or provider");
+    }
 
-    if (!tool.id.startsWith("google.")) {
-      continue;
+    const providerTool = toGoogleProviderTool(tool);
+    if (providerToolIds.has(providerTool.id)) {
+      throw new TypeError("Google provider tool id was duplicated");
     }
-    const providerType = tool.id.slice("google.".length);
-    if (providerType.length === 0) {
-      continue;
-    }
-    const camelKey = providerType.replace(/_([a-z])/g, (_, ch) => ch.toUpperCase());
-    providerEntries.push({ [camelKey]: tool.args ?? {} });
+    providerToolIds.add(providerTool.id);
+    providerEntries.push(providerTool.wireTool);
   }
 
   const result: Array<Record<string, unknown>> = [];
@@ -287,13 +816,21 @@ function normalizeGoogleToolChoice(toolChoice: unknown):
 }
 
 function resolveGoogleThinkingConfig(
-  option: ProviderReasoningOption | undefined,
+  option: RuntimeReasoningOption | undefined,
 ): Record<string, unknown> | undefined {
+  if (
+    option?.budgetTokens !== undefined &&
+    (!Number.isSafeInteger(option.budgetTokens) || option.budgetTokens < 0)
+  ) {
+    throw new TypeError(
+      "Google reasoning budgetTokens must be a non-negative safe integer",
+    );
+  }
   if (!option || option.enabled !== true) {
     return undefined;
   }
   const config: Record<string, unknown> = { includeThoughts: true };
-  if (typeof option.budgetTokens === "number") {
+  if (option.budgetTokens !== undefined) {
     config.thinkingBudget = option.budgetTokens;
     return config;
   }
@@ -367,6 +904,8 @@ export function buildGoogleGenerateContentRequest(
 
   const { systemInstruction, contents } = toGoogleContents(options.prompt);
   const generationConfig = buildGoogleGenerationConfig(options);
+  const tools = toGoogleTools(options.tools);
+  const toolConfig = normalizeGoogleToolChoice(options.toolChoice);
   const labels = options.requestLabels && Object.keys(options.requestLabels).length > 0
     ? options.requestLabels
     : typeof options.userId === "string" && options.userId.length > 0
@@ -375,10 +914,8 @@ export function buildGoogleGenerateContentRequest(
   const body: GoogleCompatibleRequest = {
     contents,
     ...(systemInstruction ? { systemInstruction } : {}),
-    ...(toGoogleTools(options.tools) ? { tools: toGoogleTools(options.tools) } : {}),
-    ...(normalizeGoogleToolChoice(options.toolChoice)
-      ? { toolConfig: normalizeGoogleToolChoice(options.toolChoice) }
-      : {}),
+    ...(tools ? { tools } : {}),
+    ...(toolConfig ? { toolConfig } : {}),
     ...(generationConfig ? { generationConfig } : {}),
     ...(labels ? { labels } : {}),
     ...(typeof options.googleCachedContent === "string" && options.googleCachedContent.length > 0

--- a/extensions/ext-llm-google/src/google-request-builder.ts
+++ b/extensions/ext-llm-google/src/google-request-builder.ts
@@ -30,7 +30,7 @@ export interface OpenAICompatibleLanguageOptions extends ModelRuntimeCallOptions
   }>;
 }
 
-/** @deprecated Import `ModelRuntimeToolDefinition` from `veryfront/provider` instead. */
+/** @deprecated Import `ModelRuntimeToolDefinition` from `veryfront/provider/shared` instead. */
 export type RuntimeToolDefinition = ModelRuntimeToolDefinition;
 
 type WarningCollector = {

--- a/extensions/ext-llm-google/src/google-request-builder.ts
+++ b/extensions/ext-llm-google/src/google-request-builder.ts
@@ -124,10 +124,13 @@ function readGoogleRawToolHistory(
     const dataField = readGooglePartDataField(part);
     if (dataField === "functionCall") {
       const functionCall = readRecord(part.functionCall);
+      const functionCallArgs = functionCall?.args === undefined
+        ? {}
+        : readRecord(functionCall.args);
       if (
         !functionCall ||
         typeof functionCall.name !== "string" ||
-        !readRecord(functionCall.args)
+        !functionCallArgs
       ) {
         throw invalidGoogleProviderHistory();
       }
@@ -139,7 +142,7 @@ function readGoogleRawToolHistory(
       const legacyId = providerId === undefined ? `tool-${anonymousFunctionCallIndex++}` : id;
       const call = {
         name: functionCall.name,
-        input: functionCall.args,
+        input: functionCallArgs,
       };
       ordinaryCalls.push({ id, ...call });
       legacyOrdinaryCalls.push({ id: legacyId, ...call });

--- a/extensions/ext-llm-google/src/google-stream.test.ts
+++ b/extensions/ext-llm-google/src/google-stream.test.ts
@@ -10,6 +10,7 @@ import {
   streamGoogleCompatibleParts,
 } from "./google-stream.ts";
 import { buildGoogleGenerateContentRequest } from "./google-request-builder.ts";
+import { MAX_GOOGLE_PROVIDER_METADATA_BYTES } from "./google-thought-signatures.ts";
 
 function streamFromText(text: string): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -67,6 +68,10 @@ function createWarningCollector() {
 }
 
 describe("ext-llm-google/google-stream", () => {
+  it("uses the provider metadata byte ceiling for retained stream state", () => {
+    assertEquals(MAX_GOOGLE_RETAINED_STATE_BYTES, MAX_GOOGLE_PROVIDER_METADATA_BYTES);
+  });
+
   it("preserves thought, text, tool-call, usage, and finish events", async () => {
     const parts = await collectParts(streamFromText([
       data({
@@ -1149,6 +1154,48 @@ describe("ext-llm-google/google-stream", () => {
       () => collectParts(streamFromBytes(...events(1))),
       ProviderRequestError,
       `retained state exceeded ${MAX_GOOGLE_RETAINED_STATE_BYTES} UTF-8 bytes`,
+    );
+  });
+
+  it("maps final replay metadata budget failures to the typed stream error", async () => {
+    const signedPart = { text: "", thought: true, thoughtSignature: "signature" };
+    const signedPartBytes = new TextEncoder().encode(JSON.stringify(signedPart)).byteLength;
+    const ordinaryPartBytes = new TextEncoder().encode(JSON.stringify({ text: "" })).byteLength;
+    const quarter = Math.floor(MAX_GOOGLE_RETAINED_STATE_BYTES / 4);
+    const serializedPartBytes = [
+      quarter,
+      quarter,
+      quarter,
+      MAX_GOOGLE_RETAINED_STATE_BYTES - quarter * 3,
+    ];
+    const encoder = new TextEncoder();
+    const events = serializedPartBytes.map((byteLength, index) =>
+      encoder.encode(data({
+        candidates: [{
+          content: {
+            parts: [
+              index === 0
+                ? {
+                  ...signedPart,
+                  text: "x".repeat(byteLength - signedPartBytes),
+                }
+                : {
+                  text: "x".repeat(byteLength - ordinaryPartBytes),
+                },
+            ],
+          },
+        }],
+      }))
+    );
+    events.push(
+      encoder.encode(data({ candidates: [{ finishReason: "STOP" }] })),
+      encoder.encode("data: [DONE]\r\n\r\n"),
+    );
+
+    await assertRejects(
+      () => collectParts(streamFromBytes(...events)),
+      ProviderRequestError,
+      "provider metadata could not be retained safely",
     );
   });
 

--- a/extensions/ext-llm-google/src/google-stream.test.ts
+++ b/extensions/ext-llm-google/src/google-stream.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ProviderRequestError } from "veryfront/provider/shared";
 import {
   extractGoogleUsage,
+  MAX_GOOGLE_RETAINED_STATE_BYTES,
   MAX_GOOGLE_RETAINED_STATE_ITEMS,
   MAX_GOOGLE_SSE_BUFFER_CODE_UNITS,
   MAX_GOOGLE_SSE_CHUNK_BYTES,
@@ -41,6 +42,10 @@ async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown
 
 function data(payload: unknown): string {
   return `data: ${JSON.stringify(payload)}\r\n\r\n`;
+}
+
+function utf8StringWithByteLength(byteLength: number): string {
+  return `${"é".repeat(Math.floor(byteLength / 2))}${byteLength % 2 === 0 ? "" : "x"}`;
 }
 
 function createWarningCollector() {
@@ -1066,6 +1071,49 @@ describe("ext-llm-google/google-stream", () => {
       () => collectParts(streamFromText(events.join(""))),
       ProviderRequestError,
       `retained state exceeded ${MAX_GOOGLE_RETAINED_STATE_ITEMS} items`,
+    );
+  });
+
+  it("accepts the exact aggregate UTF-8 byte limit and rejects limit plus one", async () => {
+    const emptyPartBytes = new TextEncoder().encode(JSON.stringify({ text: "" })).byteLength;
+    const quarter = Math.floor(MAX_GOOGLE_RETAINED_STATE_BYTES / 4);
+    const serializedPartBytes = [
+      quarter,
+      quarter,
+      quarter,
+      MAX_GOOGLE_RETAINED_STATE_BYTES - quarter * 3,
+    ];
+    const encoder = new TextEncoder();
+    const events = (lastPartExtraBytes: number) =>
+      [
+        ...serializedPartBytes.map((byteLength, index) =>
+          data({
+            candidates: [{
+              content: {
+                parts: [{
+                  text: utf8StringWithByteLength(
+                    byteLength - emptyPartBytes +
+                      (index === serializedPartBytes.length - 1 ? lastPartExtraBytes : 0),
+                  ),
+                }],
+              },
+            }],
+          })
+        ),
+        data({ candidates: [{ finishReason: "STOP" }] }),
+        "data: [DONE]\r\n\r\n",
+      ].map((event) => encoder.encode(event));
+
+    const exactParts = await collectParts(streamFromBytes(...events(0)));
+    assertEquals(exactParts.at(-1), {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "STOP" },
+    });
+
+    await assertRejects(
+      () => collectParts(streamFromBytes(...events(1))),
+      ProviderRequestError,
+      `retained state exceeded ${MAX_GOOGLE_RETAINED_STATE_BYTES} UTF-8 bytes`,
     );
   });
 

--- a/extensions/ext-llm-google/src/google-stream.test.ts
+++ b/extensions/ext-llm-google/src/google-stream.test.ts
@@ -1,13 +1,31 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ProviderRequestError } from "veryfront/provider/shared";
-import { streamGoogleCompatibleParts } from "./google-stream.ts";
+import {
+  extractGoogleUsage,
+  MAX_GOOGLE_RETAINED_STATE_ITEMS,
+  MAX_GOOGLE_SSE_BUFFER_CODE_UNITS,
+  MAX_GOOGLE_SSE_CHUNK_BYTES,
+  streamGoogleCompatibleParts,
+} from "./google-stream.ts";
+import { buildGoogleGenerateContentRequest } from "./google-request-builder.ts";
 
 function streamFromText(text: string): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   return new ReadableStream({
     start(controller) {
       controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+function streamFromBytes(...chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
       controller.close();
     },
   });
@@ -23,6 +41,24 @@ async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown
 
 function data(payload: unknown): string {
   return `data: ${JSON.stringify(payload)}\r\n\r\n`;
+}
+
+function createWarningCollector() {
+  const warnings: Array<{
+    type: "unsupported-setting" | "other";
+    setting?: string;
+    details?: string;
+    provider: string;
+  }> = [];
+
+  return {
+    push(warning: (typeof warnings)[number]) {
+      warnings.push(warning);
+    },
+    drain() {
+      return warnings.slice();
+    },
+  };
 }
 
 describe("ext-llm-google/google-stream", () => {
@@ -94,16 +130,684 @@ describe("ext-llm-google/google-stream", () => {
           outputTokens: 7,
           totalTokens: 12,
           cacheReadInputTokens: 3,
+          cachedInputTokens: 3,
           reasoningTokens: 2,
         },
       },
     ]);
   });
 
-  it("flushes trailing buffered usage records without a final delimiter", async () => {
+  it("sanitizes Google usage counters at the response boundary", () => {
+    assertEquals(
+      extractGoogleUsage({
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: -1,
+          totalTokenCount: Number.POSITIVE_INFINITY,
+          cachedContentTokenCount: 3,
+          thoughtsTokenCount: 1.5,
+        },
+      }),
+      {
+        inputTokens: 5,
+        outputTokens: undefined,
+        totalTokens: undefined,
+        cacheReadInputTokens: 3,
+      },
+    );
+    assertEquals(
+      extractGoogleUsage({
+        usageMetadata: {
+          promptTokenCount: Number.NaN,
+          candidatesTokenCount: -1,
+          totalTokenCount: Number.MAX_SAFE_INTEGER + 1,
+          cachedContentTokenCount: 0.5,
+          thoughtsTokenCount: Number.NEGATIVE_INFINITY,
+        },
+      }),
+      undefined,
+    );
+  });
+
+  it("accumulates ordered Google Search grounding metadata deltas", async () => {
+    const initialGroundingMetadata = {
+      webSearchQueries: ["first query"],
+      groundingChunks: [{
+        web: {
+          uri: "https://example.test/first",
+          title: "First source",
+        },
+      }],
+      groundingSupports: [{
+        segment: { startIndex: 0, endIndex: 8 },
+        groundingChunkIndices: [0],
+      }],
+    };
+    const finalGroundingMetadata = {
+      webSearchQueries: ["second query"],
+      groundingChunks: [{
+        web: {
+          uri: "https://example.test/second",
+          title: "Second source",
+        },
+      }],
+      groundingSupports: [{
+        segment: { startIndex: 9, endIndex: 16 },
+        groundingChunkIndices: [1],
+      }],
+    };
+    const mergedGroundingMetadata = {
+      webSearchQueries: ["first query", "second query"],
+      groundingChunks: [
+        initialGroundingMetadata.groundingChunks[0],
+        finalGroundingMetadata.groundingChunks[0],
+      ],
+      groundingSupports: [
+        initialGroundingMetadata.groundingSupports[0],
+        finalGroundingMetadata.groundingSupports[0],
+      ],
+    };
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{
+          content: { parts: [{ text: "Grounded answer." }] },
+          groundingMetadata: initialGroundingMetadata,
+        }],
+      }),
+      data({
+        candidates: [{
+          finishReason: "STOP",
+          groundingMetadata: finalGroundingMetadata,
+        }],
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "text-delta", delta: "Grounded answer." },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "STOP" },
+        providerMetadata: {
+          google: {
+            groundingMetadata: mergedGroundingMetadata,
+          },
+        },
+      },
+    ]);
+
+    await assertRejects(
+      () =>
+        collectParts(streamFromText(data({
+          candidates: [{
+            content: { parts: [{ text: "Do not accept malformed metadata." }] },
+            finishReason: "STOP",
+            groundingMetadata: [],
+          }],
+        }))),
+      ProviderRequestError,
+      "candidate grounding metadata was malformed",
+    );
+  });
+
+  it("preserves signed thought and parallel function-call parts for exact replay", async () => {
+    const signedThought = {
+      text: "Think",
+      thought: true,
+      thoughtSignature: "thought-signature",
+    };
+    const signedToolCall = {
+      functionCall: {
+        id: "tool_paris",
+        name: "weather",
+        args: { city: "Paris" },
+      },
+      thoughtSignature: "parallel-call-signature",
+    };
+    const unsignedToolCall = {
+      functionCall: {
+        id: "tool_london",
+        name: "weather",
+        args: { city: "London" },
+      },
+    };
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{
+          content: { role: "model", parts: [signedThought] },
+        }],
+      }),
+      data({
+        candidates: [{
+          content: { role: "model", parts: [signedToolCall, unsignedToolCall] },
+        }],
+      }),
+      data({ candidates: [{ finishReason: "STOP" }] }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "reasoning-start", id: "reasoning-0" },
+      { type: "reasoning-delta", id: "reasoning-0", delta: "Think" },
+      {
+        type: "reasoning-end",
+        id: "reasoning-0",
+        signature: "thought-signature",
+      },
+      { type: "tool-input-start", id: "tool_paris", toolName: "weather" },
+      { type: "tool-input-delta", id: "tool_paris", delta: '{"city":"Paris"}' },
+      {
+        type: "tool-call",
+        toolCallId: "tool_paris",
+        toolName: "weather",
+        input: '{"city":"Paris"}',
+      },
+      { type: "tool-input-start", id: "tool_london", toolName: "weather" },
+      { type: "tool-input-delta", id: "tool_london", delta: '{"city":"London"}' },
+      {
+        type: "tool-call",
+        toolCallId: "tool_london",
+        toolName: "weather",
+        input: '{"city":"London"}',
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "STOP" },
+        providerMetadata: {
+          google: {
+            rawAssistantParts: [signedThought, signedToolCall, unsignedToolCall],
+          },
+        },
+      },
+    ]);
+  });
+
+  it("keeps anonymous function ids stable from stream output through exact continuation replay", async () => {
+    const signedThought = {
+      text: "Think",
+      thought: true,
+      thoughtSignature: "thought-signature",
+    };
+    const anonymousFunctionCall = {
+      functionCall: {
+        name: "lookup",
+        args: { city: "Paris" },
+      },
+    };
+    const executableCode = {
+      executableCode: {
+        id: "tool-2",
+        language: "PYTHON",
+        code: "print('ok')",
+      },
+    };
+    const executionResult = {
+      codeExecutionResult: {
+        id: "tool-2",
+        outcome: "OUTCOME_OK",
+        output: "ok\n",
+      },
+    };
+    const rawAssistantParts = [
+      signedThought,
+      anonymousFunctionCall,
+      executableCode,
+      executionResult,
+    ];
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{
+          content: { role: "model", parts: rawAssistantParts },
+          finishReason: "STOP",
+        }],
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(
+      parts.filter((part) =>
+        typeof part === "object" &&
+        part !== null &&
+        "type" in part &&
+        part.type === "tool-call"
+      ),
+      [{
+        type: "tool-call",
+        toolCallId: "tool-1",
+        toolName: "lookup",
+        input: '{"city":"Paris"}',
+      }, {
+        type: "tool-call",
+        toolCallId: "tool-2",
+        toolName: "code_execution",
+        input: '{"language":"PYTHON","code":"print(\'ok\')"}',
+        providerExecuted: true,
+      }],
+    );
+    assertEquals(parts.at(-1), {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "STOP" },
+      providerMetadata: {
+        google: { rawAssistantParts },
+      },
+    });
+
+    const continuation = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [{
+            type: "reasoning",
+            text: "Think",
+          }, {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "lookup",
+            input: { city: "Paris" },
+          }, {
+            type: "tool-call",
+            toolCallId: "tool-2",
+            toolName: "code_execution",
+            input: { language: "PYTHON", code: "print('ok')" },
+            providerExecuted: true,
+          }, {
+            type: "tool-result",
+            toolCallId: "tool-2",
+            toolName: "code_execution",
+            result: { outcome: "OUTCOME_OK", output: "ok\n" },
+            providerExecuted: true,
+          }],
+          providerMetadata: {
+            google: { rawAssistantParts },
+          },
+        }],
+      },
+      createWarningCollector(),
+    );
+
+    assertEquals(continuation.contents, [{
+      role: "model",
+      parts: rawAssistantParts,
+    }]);
+  });
+
+  it("coalesces replayed anonymous function calls by candidate position", async () => {
+    const functionCall = {
+      functionCall: {
+        name: "lookup",
+        args: { city: "Paris" },
+      },
+    };
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{ content: { role: "model", parts: [functionCall] } }],
+      }),
+      data({
+        candidates: [{
+          content: { role: "model", parts: [functionCall] },
+          finishReason: "STOP",
+        }],
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(
+      parts.filter((part) =>
+        typeof part === "object" &&
+        part !== null &&
+        "type" in part &&
+        part.type === "tool-call"
+      ),
+      [{
+        type: "tool-call",
+        toolCallId: "tool-0",
+        toolName: "lookup",
+        input: '{"city":"Paris"}',
+      }],
+    );
+  });
+
+  it("rejects a provider id that collides with an anonymous raw-position id", async () => {
+    await assertRejects(
+      () =>
+        collectParts(streamFromText(data({
+          candidates: [{
+            content: {
+              role: "model",
+              parts: [{
+                text: "Think",
+                thought: true,
+                thoughtSignature: "thought-signature",
+              }, {
+                functionCall: {
+                  name: "lookup",
+                  args: { city: "Paris" },
+                },
+              }, {
+                executableCode: {
+                  id: "tool-1",
+                  language: "PYTHON",
+                  code: "print('collision')",
+                },
+              }],
+            },
+            finishReason: "STOP",
+          }],
+        }))),
+      ProviderRequestError,
+      "candidate executable code id was duplicated",
+    );
+  });
+
+  it("retains an empty final text part carrying a thought signature", async () => {
+    const visibleText = { text: "Answer." };
+    const signatureCarrier = { text: "", thoughtSignature: "final-text-signature" };
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{
+          content: { role: "model", parts: [visibleText] },
+        }],
+      }),
+      data({
+        candidates: [{
+          content: { role: "model", parts: [signatureCarrier] },
+        }],
+      }),
+      data({ candidates: [{ finishReason: "STOP" }] }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "text-delta", delta: "Answer." },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "STOP" },
+        providerMetadata: {
+          google: {
+            rawAssistantParts: [visibleText, signatureCarrier],
+          },
+        },
+      },
+    ]);
+  });
+
+  it("normalizes correlated provider-executed code calls, results, and failures", async () => {
+    const signedExecutableCode = {
+      executableCode: {
+        id: "code_1",
+        language: "PYTHON",
+        code: "print(6 * 7)",
+      },
+      thoughtSignature: "code-signature",
+    };
+    const successfulResult = {
+      codeExecutionResult: {
+        id: "code_1",
+        outcome: "OUTCOME_OK",
+        output: "42\n",
+      },
+    };
+    const anonymousExecutableCode = {
+      executableCode: {
+        language: "PYTHON",
+        code: "while True: pass",
+      },
+    };
+    const deadlineResult = {
+      codeExecutionResult: {
+        outcome: "OUTCOME_DEADLINE_EXCEEDED",
+        output: "partial",
+      },
+    };
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{
+          content: { role: "model", parts: [signedExecutableCode] },
+        }],
+      }),
+      data({
+        candidates: [{
+          content: { role: "model", parts: [successfulResult] },
+        }],
+      }),
+      // Some compatible gateways retransmit a cumulative tool snapshot.
+      data({
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [signedExecutableCode, successfulResult],
+          },
+        }],
+      }),
+      data({
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [anonymousExecutableCode, deadlineResult],
+          },
+        }],
+      }),
+      data({ candidates: [{ finishReason: "STOP" }] }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(parts, [
+      {
+        type: "tool-input-start",
+        id: "code_1",
+        toolName: "code_execution",
+        providerExecuted: true,
+      },
+      {
+        type: "tool-input-delta",
+        id: "code_1",
+        delta: '{"language":"PYTHON","code":"print(6 * 7)"}',
+      },
+      {
+        type: "tool-call",
+        toolCallId: "code_1",
+        toolName: "code_execution",
+        input: '{"language":"PYTHON","code":"print(6 * 7)"}',
+        providerExecuted: true,
+      },
+      {
+        type: "tool-result",
+        toolCallId: "code_1",
+        toolName: "code_execution",
+        result: { outcome: "OUTCOME_OK", output: "42\n" },
+        providerExecuted: true,
+      },
+      {
+        type: "tool-input-start",
+        id: "google-code-execution-0",
+        toolName: "code_execution",
+        providerExecuted: true,
+      },
+      {
+        type: "tool-input-delta",
+        id: "google-code-execution-0",
+        delta: '{"language":"PYTHON","code":"while True: pass"}',
+      },
+      {
+        type: "tool-call",
+        toolCallId: "google-code-execution-0",
+        toolName: "code_execution",
+        input: '{"language":"PYTHON","code":"while True: pass"}',
+        providerExecuted: true,
+      },
+      {
+        type: "tool-error",
+        toolCallId: "google-code-execution-0",
+        toolName: "code_execution",
+        error: {
+          outcome: "OUTCOME_DEADLINE_EXCEEDED",
+          output: "partial",
+        },
+        isError: true,
+        providerExecuted: true,
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "STOP" },
+        providerMetadata: {
+          google: {
+            rawAssistantParts: [
+              signedExecutableCode,
+              successfulResult,
+              anonymousExecutableCode,
+              deadlineResult,
+            ],
+          },
+        },
+      },
+    ]);
+  });
+
+  it("fails closed on malformed, unpaired, and unsupported streamed parts", async () => {
+    const malformedCases = [
+      {
+        parts: [{
+          executableCode: { id: "code_1", language: "JAVASCRIPT", code: "1 + 1" },
+        }],
+        issue: "candidate executable code was malformed",
+      },
+      {
+        parts: [{
+          executableCode: { id: "code_1", language: "PYTHON", code: "1 + 1" },
+        }, {
+          codeExecutionResult: {
+            id: "code_2",
+            outcome: "OUTCOME_OK",
+            output: "2",
+          },
+        }],
+        issue: "candidate code execution result did not match executable code",
+      },
+      {
+        parts: [{
+          executableCode: { id: "code_1", language: "PYTHON", code: "1 + 1" },
+        }, {
+          codeExecutionResult: {
+            id: "code_1",
+            outcome: "OUTCOME_UNSPECIFIED",
+          },
+        }],
+        issue: "candidate code execution result was malformed",
+      },
+      {
+        parts: [{ inlineData: { mimeType: "image/png", data: "AAAA" } }],
+        issue: "candidate part contained an unsupported data field",
+      },
+      {
+        parts: [{ futureServerTool: { id: "unknown" } }],
+        issue: "candidate part contained an unsupported data field",
+      },
+    ];
+
+    for (const { parts, issue } of malformedCases) {
+      await assertRejects(
+        () =>
+          collectParts(streamFromText(
+            data({
+              candidates: [{
+                content: { role: "model", parts },
+                finishReason: "STOP",
+              }],
+            }),
+          )),
+        ProviderRequestError,
+        issue,
+      );
+    }
+
+    await assertRejects(
+      () =>
+        collectParts(streamFromText(
+          data({
+            candidates: [{
+              content: {
+                parts: [{
+                  executableCode: {
+                    id: "code_1",
+                    language: "PYTHON",
+                    code: "print('missing result')",
+                  },
+                }],
+              },
+            }],
+          }) +
+            data({ candidates: [{ finishReason: "STOP" }] }),
+        )),
+      ProviderRequestError,
+      "candidate executable code had no matching execution result",
+    );
+  });
+
+  it("accepts every current content-filter finish reason without output", async () => {
+    const contentFilterReasons = [
+      "SAFETY",
+      "RECITATION",
+      "LANGUAGE",
+      "BLOCKLIST",
+      "PROHIBITED_CONTENT",
+      "SPII",
+      "IMAGE_SAFETY",
+      "IMAGE_PROHIBITED_CONTENT",
+      "IMAGE_RECITATION",
+      "ESCALATION",
+    ];
+
+    for (const finishReason of contentFilterReasons) {
+      assertEquals(
+        await collectParts(streamFromText(
+          data({ candidates: [{ finishReason }] }) + "data: [DONE]\r\n\r\n",
+        )),
+        [{
+          type: "finish",
+          finishReason: { unified: "content-filter", raw: finishReason },
+        }],
+      );
+    }
+  });
+
+  it("rejects malformed thought signatures and non-object function arguments", async () => {
+    await assertRejects(
+      () =>
+        collectParts(streamFromText(data({
+          candidates: [{
+            content: { parts: [{ text: "answer", thoughtSignature: 42 }] },
+            finishReason: "STOP",
+          }],
+        }))),
+      ProviderRequestError,
+      "candidate thought signature was malformed",
+    );
+    await assertRejects(
+      () =>
+        collectParts(streamFromText(data({
+          candidates: [{
+            content: {
+              parts: [{
+                functionCall: { id: "tool_1", name: "lookup", args: ["not", "an", "object"] },
+              }],
+            },
+            finishReason: "STOP",
+          }],
+        }))),
+      ProviderRequestError,
+      "candidate function call arguments were not an object",
+    );
+  });
+
+  it("fully processes a trailing terminal record without a final delimiter", async () => {
     const parts = await collectParts(streamFromText(
       `data: ${
         JSON.stringify({
+          candidates: [{
+            content: { parts: [{ text: "tail" }] },
+            finishReason: "STOP",
+          }],
           usageMetadata: {
             promptTokenCount: 1,
             candidatesTokenCount: 2,
@@ -113,45 +817,231 @@ describe("ext-llm-google/google-stream", () => {
       }`,
     ));
 
-    assertEquals(parts, [{
-      type: "finish",
-      finishReason: null,
-      usage: {
-        inputTokens: 1,
-        outputTokens: 2,
-        totalTokens: 3,
+    assertEquals(parts, [
+      { type: "text-delta", delta: "tail" },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "STOP" },
+        usage: {
+          inputTokens: 1,
+          outputTokens: 2,
+          totalTokens: 3,
+        },
       },
-    }]);
+    ]);
   });
 
-  it("reports malformed SSE JSON as a typed provider error", async () => {
+  it("enforces one candidate and a single successful-stream terminal lifecycle", async () => {
     await assertRejects(
-      () => collectParts(streamFromText('data: {"candidates":\r\n\r\n')),
+      () =>
+        collectParts(streamFromText(
+          data({
+            candidates: [
+              { content: { parts: [{ text: "first" }] } },
+              { content: { parts: [{ text: "second" }] } },
+            ],
+          }),
+        )),
       ProviderRequestError,
-      "SSE event framing was malformed",
+      "event contained multiple candidates",
     );
-  });
 
-  it("reports a malformed trailing SSE buffer as a typed provider error", async () => {
-    await assertRejects(
-      () => collectParts(streamFromText('data: {"candidates":')),
-      ProviderRequestError,
-      "trailing SSE event was malformed",
-    );
-  });
-
-  it("aborts the stream when a malformed event follows valid ones", async () => {
     await assertRejects(
       () =>
         collectParts(streamFromText([
           data({
-            candidates: [{ content: { role: "model", parts: [{ text: "Done." }] } }],
+            candidates: [{
+              content: { parts: [{ text: "before" }] },
+              finishReason: "STOP",
+            }],
           }),
-          "data: {malformed\r\n\r\n",
+          data({ candidates: [{ content: { parts: [{ text: "after" }] } }] }),
+        ].join(""))),
+      ProviderRequestError,
+      "candidate appeared after a terminal marker",
+    );
+
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({ candidates: [{ content: { parts: [{ text: "before" }] } }] }),
+          "data: [DONE]\r\n\r\n",
+          data({ candidates: [{ content: { parts: [{ text: "after" }] } }] }),
+        ].join(""))),
+      ProviderRequestError,
+      "event appeared after [DONE]",
+    );
+
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({ candidates: [{ content: { parts: [{ text: "answer" }] } }] }),
+          "data: [DONE]\r\n\r\n",
+          "data: [DONE]\r\n\r\n",
+        ].join(""))),
+      ProviderRequestError,
+      "stream contained duplicate [DONE] markers",
+    );
+
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({ candidates: [{ content: { parts: [{ text: "answer" }] } }] }),
+          "data: [DONE]\r\n\r\n",
+          data({
+            usageMetadata: {
+              promptTokenCount: 2,
+              candidatesTokenCount: 1,
+              totalTokenCount: 3,
+            },
+          }),
+        ].join(""))),
+      ProviderRequestError,
+      "event appeared after [DONE]",
+    );
+
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({
+            candidates: [{
+              content: { parts: [{ text: "answer" }] },
+              finishReason: "STOP",
+            }],
+          }),
           data({ candidates: [{ finishReason: "STOP" }] }),
         ].join(""))),
       ProviderRequestError,
-      "SSE event framing was malformed",
+      "stream contained duplicate terminal reasons",
+    );
+
+    const usageTail = await collectParts(streamFromText([
+      data({ candidates: [{ content: { parts: [{ text: "answer" }] } }] }),
+      data({ candidates: [{ finishReason: "STOP" }] }),
+      data({
+        usageMetadata: {
+          promptTokenCount: 2,
+          candidatesTokenCount: 1,
+          totalTokenCount: 3,
+        },
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+    assertEquals(usageTail, [
+      { type: "text-delta", delta: "answer" },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "STOP" },
+        usage: {
+          inputTokens: 2,
+          outputTokens: 1,
+          totalTokens: 3,
+        },
+      },
+    ]);
+  });
+
+  it("bounds raw chunks and decoded SSE buffers without leaking payloads", async () => {
+    await assertRejects(
+      () => collectParts(streamFromBytes(new Uint8Array([0xff]))),
+      ProviderRequestError,
+      "google request failed: invalid successful stream (stream contained invalid UTF-8)",
+    );
+
+    const terminalEvent = data({
+      candidates: [{
+        content: { parts: [{ text: "ok" }] },
+        finishReason: "STOP",
+      }],
+    }) + "data: [DONE]\r\n\r\n";
+    const paddingLength = MAX_GOOGLE_SSE_CHUNK_BYTES - terminalEvent.length;
+    const exactBoundaryText = `:${"x".repeat(paddingLength - 3)}\n\n${terminalEvent}`;
+    const encoder = new TextEncoder();
+    const exactBoundaryChunk = encoder.encode(exactBoundaryText);
+    assertEquals(exactBoundaryChunk.byteLength, MAX_GOOGLE_SSE_CHUNK_BYTES);
+    assertEquals(
+      await collectParts(streamFromBytes(exactBoundaryChunk)),
+      [
+        { type: "text-delta", delta: "ok" },
+        {
+          type: "finish",
+          finishReason: { unified: "stop", raw: "STOP" },
+        },
+      ],
+    );
+
+    const secret = "private-provider-payload";
+    const oversizedRawChunk = new Uint8Array(MAX_GOOGLE_SSE_CHUNK_BYTES + 1);
+    oversizedRawChunk.set(encoder.encode(secret));
+    const rawError = await assertRejects(
+      () => collectParts(streamFromBytes(oversizedRawChunk)),
+      ProviderRequestError,
+      `SSE chunk exceeded ${MAX_GOOGLE_SSE_CHUNK_BYTES} bytes`,
+    );
+    assertEquals(
+      rawError instanceof Error && rawError.message.includes(secret),
+      false,
+    );
+
+    await assertRejects(
+      () =>
+        collectParts(streamFromBytes(
+          encoder.encode("x".repeat(MAX_GOOGLE_SSE_BUFFER_CODE_UNITS)),
+          encoder.encode("y"),
+        )),
+      ProviderRequestError,
+      `SSE buffer exceeded ${MAX_GOOGLE_SSE_BUFFER_CODE_UNITS} code units`,
+    );
+  });
+
+  it("bounds retained raw parts across many small candidate events", async () => {
+    const events = Array.from(
+      { length: MAX_GOOGLE_RETAINED_STATE_ITEMS + 1 },
+      () => data({ candidates: [{ content: { parts: [{ text: "x" }] } }] }),
+    );
+
+    await assertRejects(
+      () => collectParts(streamFromText(events.join(""))),
+      ProviderRequestError,
+      `retained state exceeded ${MAX_GOOGLE_RETAINED_STATE_ITEMS} items`,
+    );
+  });
+
+  it("bounds retained correlation maps across many small function calls", async () => {
+    const events = Array.from(
+      { length: Math.floor(MAX_GOOGLE_RETAINED_STATE_ITEMS / 2) + 1 },
+      (_, index) =>
+        data({
+          candidates: [{
+            content: {
+              parts: [{
+                functionCall: { id: `call-${index}`, name: "lookup", args: {} },
+              }],
+            },
+          }],
+        }),
+    );
+
+    await assertRejects(
+      () => collectParts(streamFromText(events.join(""))),
+      ProviderRequestError,
+      `retained state exceeded ${MAX_GOOGLE_RETAINED_STATE_ITEMS} items`,
+    );
+  });
+
+  it("rejects structurally empty and unterminated successful streams", async () => {
+    await assertRejects(
+      () => collectParts(streamFromText(data({}))),
+      ProviderRequestError,
+      "event had neither candidates nor usage",
+    );
+    await assertRejects(
+      () =>
+        collectParts(streamFromText(data({
+          candidates: [{ content: { parts: [{ text: "partial" }] } }],
+        }))),
+      ProviderRequestError,
+      "stream ended before a terminal marker",
     );
   });
 });

--- a/extensions/ext-llm-google/src/google-stream.test.ts
+++ b/extensions/ext-llm-google/src/google-stream.test.ts
@@ -798,6 +798,46 @@ describe("ext-llm-google/google-stream", () => {
       ProviderRequestError,
       "candidate function call arguments were not an object",
     );
+    await assertRejects(
+      () =>
+        collectParts(streamFromText(data({
+          candidates: [{
+            content: {
+              parts: [{ functionCall: { id: "tool_1", name: "lookup", args: null } }],
+            },
+            finishReason: "STOP",
+          }],
+        }))),
+      ProviderRequestError,
+      "candidate function call arguments were not an object",
+    );
+  });
+
+  it("treats an omitted function call args field as empty arguments", async () => {
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{
+          content: { role: "model", parts: [{ functionCall: { id: "tool_1", name: "ping" } }] },
+          finishReason: "STOP",
+        }],
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(
+      parts.filter((part) =>
+        typeof part === "object" &&
+        part !== null &&
+        "type" in part &&
+        part.type === "tool-call"
+      ),
+      [{
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "ping",
+        input: "{}",
+      }],
+    );
   });
 
   it("fully processes a trailing terminal record without a final delimiter", async () => {

--- a/extensions/ext-llm-google/src/google-stream.test.ts
+++ b/extensions/ext-llm-google/src/google-stream.test.ts
@@ -819,10 +819,14 @@ describe("ext-llm-google/google-stream", () => {
   });
 
   it("treats an omitted function call args field as empty arguments", async () => {
+    const rawAssistantParts = [{
+      functionCall: { id: "tool_1", name: "ping" },
+      thoughtSignature: "signed-zero-argument-call",
+    }];
     const parts = await collectParts(streamFromText([
       data({
         candidates: [{
-          content: { role: "model", parts: [{ functionCall: { id: "tool_1", name: "ping" } }] },
+          content: { role: "model", parts: rawAssistantParts },
           finishReason: "STOP",
         }],
       }),
@@ -843,6 +847,37 @@ describe("ext-llm-google/google-stream", () => {
         input: "{}",
       }],
     );
+
+    assertEquals(parts.at(-1), {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "STOP" },
+      providerMetadata: {
+        google: { rawAssistantParts },
+      },
+    });
+
+    const continuation = buildGoogleGenerateContentRequest(
+      "google",
+      {
+        prompt: [{
+          role: "assistant",
+          content: [{
+            type: "tool-call",
+            toolCallId: "tool_1",
+            toolName: "ping",
+            input: {},
+          }],
+          providerMetadata: {
+            google: { rawAssistantParts },
+          },
+        }],
+      },
+      createWarningCollector(),
+    );
+    assertEquals(continuation.contents, [{
+      role: "model",
+      parts: rawAssistantParts,
+    }]);
   });
 
   it("fully processes a trailing terminal record without a final delimiter", async () => {

--- a/extensions/ext-llm-google/src/google-stream.test.ts
+++ b/extensions/ext-llm-google/src/google-stream.test.ts
@@ -41,6 +41,18 @@ async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown
   return parts;
 }
 
+function collectToolEventIdentities(parts: unknown[]): unknown[] {
+  return parts.flatMap((part) =>
+    typeof part === "object" &&
+      part !== null &&
+      "type" in part &&
+      "toolCallId" in part &&
+      (part.type === "tool-call" || part.type === "tool-result")
+      ? [{ type: part.type, toolCallId: part.toolCallId }]
+      : []
+  );
+}
+
 function data(payload: unknown): string {
   return `data: ${JSON.stringify(payload)}\r\n\r\n`;
 }
@@ -476,6 +488,109 @@ describe("ext-llm-google/google-stream", () => {
         input: '{"city":"Paris"}',
       }],
     );
+  });
+
+  it("coalesces replayed anonymous code execution pairs by candidate position", async () => {
+    const executableCode = {
+      executableCode: {
+        language: "PYTHON",
+        code: "print('same')",
+      },
+    };
+    const executionResult = {
+      codeExecutionResult: {
+        outcome: "OUTCOME_OK",
+        output: "same\n",
+      },
+    };
+    const snapshot = [
+      executableCode,
+      executionResult,
+      executableCode,
+      executionResult,
+    ];
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{ content: { role: "model", parts: snapshot } }],
+      }),
+      data({
+        candidates: [{
+          content: { role: "model", parts: snapshot },
+          finishReason: "STOP",
+        }],
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(collectToolEventIdentities(parts), [
+      { type: "tool-call", toolCallId: "google-code-execution-0" },
+      { type: "tool-result", toolCallId: "google-code-execution-0" },
+      { type: "tool-call", toolCallId: "google-code-execution-1" },
+      { type: "tool-result", toolCallId: "google-code-execution-1" },
+    ]);
+
+    await assertRejects(
+      () =>
+        collectParts(streamFromText([
+          data({
+            candidates: [{ content: { role: "model", parts: [executableCode] } }],
+          }),
+          data({
+            candidates: [{ content: { role: "model", parts: [executionResult] } }],
+          }),
+          data({
+            candidates: [{
+              content: {
+                role: "model",
+                parts: [{
+                  codeExecutionResult: {
+                    outcome: "OUTCOME_OK",
+                    output: "changed\n",
+                  },
+                }],
+              },
+              finishReason: "STOP",
+            }],
+          }),
+        ].join(""))),
+      ProviderRequestError,
+      "candidate code execution result changed after emission",
+    );
+  });
+
+  it("ignores a replayed anonymous code execution result after correlation", async () => {
+    const executableCode = {
+      executableCode: {
+        language: "PYTHON",
+        code: "print('once')",
+      },
+    };
+    const executionResult = {
+      codeExecutionResult: {
+        outcome: "OUTCOME_OK",
+        output: "once\n",
+      },
+    };
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{ content: { role: "model", parts: [executableCode] } }],
+      }),
+      data({
+        candidates: [{ content: { role: "model", parts: [executionResult] } }],
+      }),
+      data({
+        candidates: [{
+          content: { role: "model", parts: [executionResult] },
+          finishReason: "STOP",
+        }],
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(collectToolEventIdentities(parts), [
+      { type: "tool-call", toolCallId: "google-code-execution-0" },
+      { type: "tool-result", toolCallId: "google-code-execution-0" },
+    ]);
   });
 
   it("rejects a provider id that collides with an anonymous raw-position id", async () => {

--- a/extensions/ext-llm-google/src/google-stream.ts
+++ b/extensions/ext-llm-google/src/google-stream.ts
@@ -19,12 +19,13 @@ import {
 import { mergeGoogleGroundingMetadata } from "./google-grounding-metadata.ts";
 import {
   createGoogleProviderMetadata,
+  MAX_GOOGLE_PROVIDER_METADATA_BYTES,
   readGoogleThoughtSignature,
 } from "./google-thought-signatures.ts";
 
 export const MAX_GOOGLE_SSE_CHUNK_BYTES = 8 * 1024 * 1024;
 export const MAX_GOOGLE_SSE_BUFFER_CODE_UNITS = 8 * 1024 * 1024;
-export const MAX_GOOGLE_RETAINED_STATE_BYTES = 16 * 1024 * 1024;
+export const MAX_GOOGLE_RETAINED_STATE_BYTES = MAX_GOOGLE_PROVIDER_METADATA_BYTES;
 export const MAX_GOOGLE_RETAINED_STATE_ITEMS = 8_192;
 const GOOGLE_RETAINED_STATE_ENCODER = new TextEncoder();
 
@@ -804,10 +805,20 @@ export async function* streamGoogleCompatibleParts(
     };
   }
 
-  const providerMetadata = createGoogleProviderMetadata(
-    rawAssistantParts,
-    groundingMetadata,
-  );
+  let providerMetadata: Record<string, unknown> | undefined;
+  try {
+    providerMetadata = createGoogleProviderMetadata(
+      rawAssistantParts,
+      groundingMetadata,
+    );
+  } catch {
+    // The stream accounts for retained raw parts and correlation state under
+    // the same byte ceiling as replay metadata. The final owned snapshot also
+    // includes JSON container overhead and grounding metadata, so translate
+    // any remaining snapshot-boundary failure into the stream's typed error
+    // contract instead of leaking an implementation TypeError.
+    throw invalidGoogleStream(context, "provider metadata could not be retained safely");
+  }
   yield {
     type: "finish",
     finishReason,

--- a/extensions/ext-llm-google/src/google-stream.ts
+++ b/extensions/ext-llm-google/src/google-stream.ts
@@ -1,4 +1,5 @@
 import {
+  mergeUsage,
   parseFinalSseChunk,
   parseSseChunk,
   ProviderRequestError,
@@ -6,28 +7,39 @@ import {
   type RuntimeUsage,
   stringifyJsonValue,
 } from "veryfront/provider/shared";
+import {
+  createGoogleToolCallCorrelationRegistry,
+  GOOGLE_CODE_EXECUTION_TOOL_NAME,
+  googleCodeExecutionInput,
+  googleCodeExecutionOutput,
+  readGoogleCodeExecutionResult,
+  readGoogleExecutableCode,
+  readGooglePartDataField,
+} from "./google-content-parts.ts";
+import { mergeGoogleGroundingMetadata } from "./google-grounding-metadata.ts";
+import {
+  createGoogleProviderMetadata,
+  readGoogleThoughtSignature,
+} from "./google-thought-signatures.ts";
 
-function invalidGoogleStream(issue: string): ProviderRequestError {
-  return new ProviderRequestError({
-    provider: "google",
-    status: 200,
-    message: `google request failed: invalid successful stream (${issue})`,
-    retryable: false,
-  });
-}
+export const MAX_GOOGLE_SSE_CHUNK_BYTES = 8 * 1024 * 1024;
+export const MAX_GOOGLE_SSE_BUFFER_CODE_UNITS = 8 * 1024 * 1024;
+export const MAX_GOOGLE_RETAINED_STATE_BYTES = 16 * 1024 * 1024;
+export const MAX_GOOGLE_RETAINED_STATE_ITEMS = 8_192;
+const GOOGLE_RETAINED_STATE_ENCODER = new TextEncoder();
 
-function parseGoogleSseBuffer(
-  buffer: string,
-  trailing = false,
-): ReturnType<typeof parseSseChunk> {
-  try {
-    return trailing ? parseFinalSseChunk(buffer) : parseSseChunk(buffer);
-  } catch {
-    throw invalidGoogleStream(
-      trailing ? "trailing SSE event was malformed" : "SSE event framing was malformed",
-    );
-  }
-}
+const GOOGLE_CONTENT_FILTER_FINISH_REASONS = new Set([
+  "SAFETY",
+  "RECITATION",
+  "LANGUAGE",
+  "BLOCKLIST",
+  "PROHIBITED_CONTENT",
+  "SPII",
+  "IMAGE_SAFETY",
+  "IMAGE_PROHIBITED_CONTENT",
+  "IMAGE_RECITATION",
+  "ESCALATION",
+]);
 
 export function normalizeGoogleFinishReason(
   raw: unknown,
@@ -41,10 +53,10 @@ export function normalizeGoogleFinishReason(
       return { unified: "stop", raw };
     case "MAX_TOKENS":
       return { unified: "length", raw };
-    case "SAFETY":
-    case "RECITATION":
-      return { unified: "content-filter", raw };
     default:
+      if (GOOGLE_CONTENT_FILTER_FINISH_REASONS.has(raw)) {
+        return { unified: "content-filter", raw };
+      }
       return raw.toLowerCase();
   }
 }
@@ -56,21 +68,27 @@ export function extractGoogleUsage(payload: unknown): RuntimeUsage | undefined {
     return undefined;
   }
 
-  const inputTokens = usage.promptTokenCount;
-  const outputTokens = usage.candidatesTokenCount;
-  const totalTokens = usage.totalTokenCount;
-  const cachedContentTokenCount = usage.cachedContentTokenCount;
-  const thoughtsTokenCount = usage.thoughtsTokenCount;
-
-  return {
-    inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
-    outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
-    totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
-    ...(typeof cachedContentTokenCount === "number"
-      ? { cacheReadInputTokens: cachedContentTokenCount }
-      : {}),
-    ...(typeof thoughtsTokenCount === "number" ? { reasoningTokens: thoughtsTokenCount } : {}),
+  const readTokenCount = (value: unknown): number | undefined =>
+    typeof value === "number" &&
+      Number.isFinite(value) &&
+      Number.isSafeInteger(value) &&
+      value >= 0
+      ? value
+      : undefined;
+  const inputTokens = readTokenCount(usage.promptTokenCount);
+  const outputTokens = readTokenCount(usage.candidatesTokenCount);
+  const totalTokens = readTokenCount(usage.totalTokenCount);
+  const cacheReadInputTokens = readTokenCount(usage.cachedContentTokenCount);
+  const reasoningTokens = readTokenCount(usage.thoughtsTokenCount);
+  const normalized: RuntimeUsage = {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    ...(cacheReadInputTokens !== undefined ? { cacheReadInputTokens } : {}),
+    ...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
   };
+
+  return Object.values(normalized).some((value) => value !== undefined) ? normalized : undefined;
 }
 
 export function extractFirstGoogleCandidate(payload: unknown): Record<string, unknown> | undefined {
@@ -97,78 +115,407 @@ export function extractGoogleCandidateParts(payload: unknown): Array<Record<stri
   });
 }
 
+type GoogleStreamContext = {
+  providerLabel?: string;
+};
+
+function invalidGoogleStream(
+  context: GoogleStreamContext,
+  issue: string,
+): ProviderRequestError {
+  return new ProviderRequestError({
+    provider: "google",
+    status: 200,
+    message: `${
+      context.providerLabel ?? "google"
+    } request failed: invalid successful stream (${issue})`,
+    retryable: false,
+  });
+}
+
+function mergeGoogleUsage(
+  current: RuntimeUsage | undefined,
+  payload: unknown,
+): RuntimeUsage | undefined {
+  const merged = mergeUsage(current, extractGoogleUsage(payload));
+  return merged && Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function isContentFilterFinishReason(
+  value: string | { unified: string; raw: string } | null,
+): boolean {
+  return typeof value === "object" && value?.unified === "content-filter";
+}
+
 export async function* streamGoogleCompatibleParts(
   stream: ReadableStream<Uint8Array>,
+  context: GoogleStreamContext = {},
 ): AsyncIterable<unknown> {
-  const decoder = new TextDecoder();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
   let buffer = "";
-  const seenToolCalls = new Set<string>();
+  const seenToolCalls = new Map<
+    string,
+    {
+      callShape: string;
+      rawPartIndex: number;
+      thoughtSignature?: string;
+    }
+  >();
+  const seenCodeExecutions = new Map<
+    string,
+    {
+      callShape: string;
+      rawPartIndex: number;
+      thoughtSignature?: string;
+    }
+  >();
+  const seenCodeExecutionResults = new Map<
+    string,
+    {
+      resultShape: string;
+      rawPartIndex: number;
+      thoughtSignature?: string;
+    }
+  >();
+  const pendingAnonymousCodeExecutions: Array<{
+    callShape: string;
+    rawPartIndex: number;
+    thoughtSignature?: string;
+  }> = [];
+  const toolCallRegistry = createGoogleToolCallCorrelationRegistry();
+  const rawAssistantParts: Array<Record<string, unknown>> = [];
+  let retainedStateBytes = 0;
+  let retainedStateItems = 0;
   let reasoningId: string | null = null;
+  let reasoningSignature: string | undefined;
   let reasoningIndex = 0;
   let finishReason: string | { unified: string; raw: string } | null = null;
   let usage: RuntimeUsage | undefined;
+  let groundingMetadata: Record<string, unknown> | undefined;
+  let sawCandidateEnvelope = false;
+  let sawOutput = false;
+  let sawFinishReason = false;
+  let sawDone = false;
 
-  for await (const chunk of stream) {
-    buffer += decoder.decode(chunk, { stream: true });
-    const parsed = parseGoogleSseBuffer(buffer);
-    buffer = parsed.remainder;
+  const reserveRetainedItem = (issue: string): void => {
+    if (retainedStateItems >= MAX_GOOGLE_RETAINED_STATE_ITEMS) {
+      throw invalidGoogleStream(
+        context,
+        `retained state exceeded ${MAX_GOOGLE_RETAINED_STATE_ITEMS} items (${issue})`,
+      );
+    }
+    retainedStateItems++;
+  };
 
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
+  const reserveRetainedBytes = (value: string, issue: string): void => {
+    const bytes = GOOGLE_RETAINED_STATE_ENCODER.encode(value).byteLength;
+    if (bytes > MAX_GOOGLE_RETAINED_STATE_BYTES - retainedStateBytes) {
+      throw invalidGoogleStream(
+        context,
+        `retained state exceeded ${MAX_GOOGLE_RETAINED_STATE_BYTES} UTF-8 bytes (${issue})`,
+      );
+    }
+    retainedStateBytes += bytes;
+  };
+
+  const retainRawAssistantPart = (part: Record<string, unknown>): number => {
+    let serialized: string;
+    try {
+      serialized = stringifyJsonValue(part);
+    } catch {
+      throw invalidGoogleStream(context, "candidate part could not be retained safely");
+    }
+    reserveRetainedItem("raw candidate part");
+    reserveRetainedBytes(serialized, "raw candidate part");
+    return rawAssistantParts.push(part) - 1;
+  };
+
+  const reserveCorrelation = (issue: string, ...values: string[]): void => {
+    reserveRetainedItem(issue);
+    for (const value of values) reserveRetainedBytes(value, issue);
+  };
+
+  const mergeReplaySignature = (
+    prior: { rawPartIndex: number; thoughtSignature?: string },
+    thoughtSignature: string | undefined,
+    changedIssue: string,
+  ): void => {
+    if (
+      thoughtSignature !== undefined &&
+      prior.thoughtSignature !== undefined &&
+      thoughtSignature !== prior.thoughtSignature
+    ) {
+      throw invalidGoogleStream(context, changedIssue);
+    }
+    if (thoughtSignature !== undefined && prior.thoughtSignature === undefined) {
+      const previousRawPart = rawAssistantParts[prior.rawPartIndex];
+      if (!previousRawPart) {
+        throw invalidGoogleStream(context, "candidate replay history was inconsistent");
+      }
+      reserveRetainedBytes(thoughtSignature, "replayed thought signature");
+      previousRawPart.thoughtSignature = thoughtSignature;
+      prior.thoughtSignature = thoughtSignature;
+    }
+  };
+
+  function* processEvent(event: unknown | "[DONE]"): Generator<unknown> {
+    if (event === "[DONE]") {
+      if (sawDone) {
+        throw invalidGoogleStream(context, "stream contained duplicate [DONE] markers");
+      }
+      sawDone = true;
+      return;
+    }
+    if (sawDone) {
+      throw invalidGoogleStream(context, "event appeared after [DONE]");
+    }
+    const record = readRecord(event);
+    if (!record) {
+      throw invalidGoogleStream(context, "event was not an object");
+    }
+    const usageRecord = readRecord(record.usageMetadata);
+    usage = mergeGoogleUsage(usage, record);
+
+    const promptFeedback = readRecord(record.promptFeedback);
+    const promptBlockReason = promptFeedback?.blockReason;
+    if (
+      promptBlockReason !== undefined &&
+      (typeof promptBlockReason !== "string" || promptBlockReason.length === 0)
+    ) {
+      throw invalidGoogleStream(context, "prompt block reason was malformed");
+    }
+    if (typeof promptBlockReason === "string") {
+      if (sawFinishReason || sawDone) {
+        throw invalidGoogleStream(context, "stream contained duplicate terminal reasons");
+      }
+      finishReason = { unified: "content-filter", raw: promptBlockReason };
+      sawCandidateEnvelope = true;
+      sawFinishReason = true;
+    }
+
+    if (record.candidates === undefined) {
+      if (!usageRecord && typeof promptBlockReason !== "string") {
+        throw invalidGoogleStream(context, "event had neither candidates nor usage");
+      }
+      return;
+    }
+    if (!Array.isArray(record.candidates)) {
+      throw invalidGoogleStream(context, "candidates was not an array");
+    }
+    if (record.candidates.length === 0) {
+      if (!usageRecord && typeof promptBlockReason !== "string") {
+        throw invalidGoogleStream(context, "empty candidates event had no usage or block reason");
+      }
+      return;
+    }
+    if (record.candidates.length !== 1) {
+      throw invalidGoogleStream(context, "event contained multiple candidates");
+    }
+    if (typeof promptBlockReason === "string") {
+      throw invalidGoogleStream(context, "blocked event also contained a candidate");
+    }
+    const candidate = readRecord(record.candidates[0]);
+    if (!candidate) {
+      throw invalidGoogleStream(context, "first candidate was not an object");
+    }
+    if (sawFinishReason || sawDone) {
+      const issue = typeof candidate.finishReason === "string"
+        ? "stream contained duplicate terminal reasons"
+        : "candidate appeared after a terminal marker";
+      throw invalidGoogleStream(context, issue);
+    }
+    sawCandidateEnvelope = true;
+    if (candidate.groundingMetadata !== undefined) {
+      try {
+        groundingMetadata = mergeGoogleGroundingMetadata(
+          groundingMetadata,
+          candidate.groundingMetadata,
+        );
+      } catch {
+        throw invalidGoogleStream(context, "candidate grounding metadata was malformed");
+      }
+    }
+    if (
+      candidate.finishReason !== undefined &&
+      (typeof candidate.finishReason !== "string" || candidate.finishReason.length === 0)
+    ) {
+      throw invalidGoogleStream(context, "candidate finish reason was malformed");
+    }
+    const candidateFinishReason = typeof candidate.finishReason === "string"
+      ? candidate.finishReason
+      : undefined;
+
+    let parts: unknown[] = [];
+    if (candidate.content !== undefined) {
+      const content = readRecord(candidate.content);
+      if (!content) {
+        throw invalidGoogleStream(context, "candidate content was not an object");
+      }
+      if (content.parts !== undefined && !Array.isArray(content.parts)) {
+        throw invalidGoogleStream(context, "candidate content parts was not an array");
+      }
+      parts = Array.isArray(content.parts) ? content.parts : [];
+    } else if (candidateFinishReason === undefined) {
+      throw invalidGoogleStream(context, "candidate had neither content nor a finish reason");
+    }
+
+    for (const [candidatePartIndex, rawPart] of parts.entries()) {
+      const part = readRecord(rawPart);
+      if (!part) {
+        throw invalidGoogleStream(context, "candidate content part was not an object");
+      }
+      if (part.thought !== undefined && typeof part.thought !== "boolean") {
+        throw invalidGoogleStream(context, "candidate thought marker was malformed");
+      }
+      let thoughtSignature: string | undefined;
+      try {
+        thoughtSignature = readGoogleThoughtSignature(part);
+      } catch {
+        throw invalidGoogleStream(context, "candidate thought signature was malformed");
+      }
+      let dataField: ReturnType<typeof readGooglePartDataField>;
+      try {
+        dataField = readGooglePartDataField(part);
+      } catch (error) {
+        const issue = error instanceof Error &&
+            (error.message.includes("unsupported") || error.message.includes("unknown"))
+          ? "candidate part contained an unsupported data field"
+          : "candidate part contained multiple data fields";
+        throw invalidGoogleStream(context, issue);
       }
 
-      usage = extractGoogleUsage(event) ?? usage;
-      const candidate = extractFirstGoogleCandidate(event);
-      const normalizedFinishReason = normalizeGoogleFinishReason(candidate?.finishReason);
-      if (normalizedFinishReason) {
-        finishReason = normalizedFinishReason;
+      const partText = dataField === "text" && typeof part.text === "string"
+        ? part.text
+        : undefined;
+      if (dataField === "text" && partText === undefined) {
+        throw invalidGoogleStream(context, "candidate text part was malformed");
+      }
+      if (dataField === "text") {
+        retainRawAssistantPart(part);
       }
 
-      for (const [index, part] of extractGoogleCandidateParts(event).entries()) {
-        const isThought = part.thought === true;
-        if (isThought && typeof part.text === "string" && part.text.length > 0) {
-          if (!reasoningId) {
-            reasoningId = `reasoning-${reasoningIndex++}`;
-            yield {
-              type: "reasoning-start",
-              id: reasoningId,
-            };
-          }
-
-          yield {
-            type: "reasoning-delta",
-            id: reasoningId,
-            delta: part.text,
-          };
-          continue;
-        }
-
-        if (reasoningId) {
+      if (partText !== undefined && part.thought === true) {
+        if (
+          reasoningId &&
+          thoughtSignature !== undefined &&
+          reasoningSignature !== undefined &&
+          thoughtSignature !== reasoningSignature
+        ) {
           yield {
             type: "reasoning-end",
             id: reasoningId,
+            signature: reasoningSignature,
           };
           reasoningId = null;
+          reasoningSignature = undefined;
         }
-
-        if (typeof part.text === "string" && part.text.length > 0) {
-          yield { type: "text-delta", delta: part.text };
-          continue;
+        if (!reasoningId && (partText.length > 0 || thoughtSignature !== undefined)) {
+          reasoningId = `reasoning-${reasoningIndex++}`;
+          yield { type: "reasoning-start", id: reasoningId };
         }
+        if (thoughtSignature !== undefined) {
+          reasoningSignature = thoughtSignature;
+        }
+        if (reasoningId) {
+          sawOutput = true;
+          if (partText.length > 0) {
+            yield {
+              type: "reasoning-delta",
+              id: reasoningId,
+              delta: partText,
+            };
+          }
+        }
+        continue;
+      }
 
+      if (reasoningId) {
+        yield {
+          type: "reasoning-end",
+          id: reasoningId,
+          ...(reasoningSignature !== undefined ? { signature: reasoningSignature } : {}),
+        };
+        reasoningId = null;
+        reasoningSignature = undefined;
+      }
+
+      if (partText !== undefined) {
+        if (partText.length > 0) {
+          sawOutput = true;
+          yield { type: "text-delta", delta: partText };
+        }
+        continue;
+      }
+
+      if (dataField === "functionCall") {
         const functionCall = readRecord(part.functionCall);
-        if (typeof functionCall?.name !== "string") {
+        if (
+          !functionCall ||
+          typeof functionCall.name !== "string" ||
+          functionCall.name.length === 0
+        ) {
+          throw invalidGoogleStream(context, "candidate function call was malformed");
+        }
+        if (
+          functionCall.id !== undefined &&
+          (typeof functionCall.id !== "string" || functionCall.id.length === 0)
+        ) {
+          throw invalidGoogleStream(context, "candidate function call id was malformed");
+        }
+        const functionCallArgs = readRecord(functionCall.args);
+        if (!functionCallArgs) {
+          throw invalidGoogleStream(
+            context,
+            "candidate function call arguments were not an object",
+          );
+        }
+
+        let serializedInput: string;
+        try {
+          serializedInput = stringifyJsonValue(functionCallArgs);
+        } catch {
+          throw invalidGoogleStream(context, "candidate function call arguments were malformed");
+        }
+        const providerId = typeof functionCall.id === "string" ? functionCall.id : undefined;
+        const rawPartIndex = rawAssistantParts.length;
+        // Gemini may replay an anonymous function call in later candidate
+        // envelopes. Its candidate-part position is stable across those
+        // cumulative snapshots; our growing retained-output index is not.
+        const deduplicationKey = providerId ?? `anonymous-${candidatePartIndex}`;
+        const callShape = `${functionCall.name}\u0000${serializedInput}`;
+        const previousToolCall = seenToolCalls.get(deduplicationKey);
+        if (previousToolCall !== undefined) {
+          if (previousToolCall.callShape !== callShape) {
+            throw invalidGoogleStream(context, "candidate function call changed after emission");
+          }
+          mergeReplaySignature(
+            previousToolCall,
+            thoughtSignature,
+            "candidate function call thought signature changed after emission",
+          );
           continue;
         }
 
-        const toolCallId = typeof functionCall.id === "string" ? functionCall.id : `tool-${index}`;
-        if (seenToolCalls.has(toolCallId)) {
-          continue;
+        let toolCallId: string;
+        try {
+          toolCallId = toolCallRegistry.registerFunctionCall(rawPartIndex, providerId);
+        } catch {
+          throw invalidGoogleStream(context, "candidate tool call id was duplicated");
         }
+        retainRawAssistantPart(part);
+        reserveCorrelation(
+          "function-call correlation",
+          deduplicationKey,
+          callShape,
+          ...(thoughtSignature === undefined ? [] : [thoughtSignature]),
+        );
+        seenToolCalls.set(deduplicationKey, {
+          callShape,
+          rawPartIndex,
+          ...(thoughtSignature !== undefined ? { thoughtSignature } : {}),
+        });
 
-        const serializedInput = stringifyJsonValue(functionCall.args ?? {});
-        seenToolCalls.add(toolCallId);
+        sawOutput = true;
         yield {
           type: "tool-input-start",
           id: toolCallId,
@@ -185,30 +532,283 @@ export async function* streamGoogleCompatibleParts(
           toolName: functionCall.name,
           input: serializedInput,
         };
+        continue;
       }
+
+      if (dataField === "executableCode") {
+        let executableCode: ReturnType<typeof readGoogleExecutableCode>;
+        try {
+          executableCode = readGoogleExecutableCode(part.executableCode);
+        } catch {
+          throw invalidGoogleStream(context, "candidate executable code was malformed");
+        }
+        const serializedInput = stringifyJsonValue(googleCodeExecutionInput(executableCode));
+        const callShape = serializedInput;
+        let toolCallId: string;
+
+        if (executableCode.providerId !== undefined) {
+          const prior = seenCodeExecutions.get(executableCode.providerId);
+          if (prior) {
+            if (prior.callShape !== callShape) {
+              throw invalidGoogleStream(
+                context,
+                "candidate executable code changed after emission",
+              );
+            }
+            mergeReplaySignature(
+              prior,
+              thoughtSignature,
+              "candidate executable code thought signature changed after emission",
+            );
+            continue;
+          }
+          try {
+            toolCallId = toolCallRegistry.registerCodeExecution(
+              executableCode.providerId,
+            );
+          } catch {
+            throw invalidGoogleStream(context, "candidate executable code id was duplicated");
+          }
+        } else {
+          const prior = pendingAnonymousCodeExecutions.at(-1);
+          if (prior?.callShape === callShape) {
+            mergeReplaySignature(
+              prior,
+              thoughtSignature,
+              "candidate executable code thought signature changed after emission",
+            );
+            continue;
+          }
+          try {
+            toolCallId = toolCallRegistry.registerCodeExecution(undefined);
+          } catch {
+            throw invalidGoogleStream(context, "candidate executable code id was duplicated");
+          }
+        }
+
+        const rawPartIndex = retainRawAssistantPart(part);
+        reserveCorrelation(
+          "code-execution correlation",
+          callShape,
+          ...(executableCode.providerId === undefined ? [] : [executableCode.providerId]),
+          ...(thoughtSignature === undefined ? [] : [thoughtSignature]),
+        );
+        const pending = {
+          callShape,
+          rawPartIndex,
+          ...(thoughtSignature !== undefined ? { thoughtSignature } : {}),
+        };
+        if (executableCode.providerId === undefined) {
+          pendingAnonymousCodeExecutions.push(pending);
+        } else {
+          seenCodeExecutions.set(executableCode.providerId, pending);
+        }
+
+        sawOutput = true;
+        yield {
+          type: "tool-input-start",
+          id: toolCallId,
+          toolName: GOOGLE_CODE_EXECUTION_TOOL_NAME,
+          providerExecuted: true,
+        };
+        yield {
+          type: "tool-input-delta",
+          id: toolCallId,
+          delta: serializedInput,
+        };
+        yield {
+          type: "tool-call",
+          toolCallId,
+          toolName: GOOGLE_CODE_EXECUTION_TOOL_NAME,
+          input: serializedInput,
+          providerExecuted: true,
+        };
+        continue;
+      }
+
+      let result: ReturnType<typeof readGoogleCodeExecutionResult>;
+      try {
+        result = readGoogleCodeExecutionResult(part.codeExecutionResult);
+      } catch {
+        throw invalidGoogleStream(context, "candidate code execution result was malformed");
+      }
+      const resultValue = googleCodeExecutionOutput(result);
+      const resultShape = stringifyJsonValue(resultValue);
+      let toolCallId: string;
+
+      if (result.providerId !== undefined) {
+        const priorResult = seenCodeExecutionResults.get(result.providerId);
+        if (priorResult) {
+          if (priorResult.resultShape !== resultShape) {
+            throw invalidGoogleStream(
+              context,
+              "candidate code execution result changed after emission",
+            );
+          }
+          mergeReplaySignature(
+            priorResult,
+            thoughtSignature,
+            "candidate code execution result thought signature changed after emission",
+          );
+          continue;
+        }
+        try {
+          toolCallId = toolCallRegistry.resolveCodeExecutionResult(result.providerId);
+        } catch {
+          throw invalidGoogleStream(
+            context,
+            "candidate code execution result did not match executable code",
+          );
+        }
+      } else {
+        try {
+          toolCallId = toolCallRegistry.resolveCodeExecutionResult(undefined);
+        } catch {
+          throw invalidGoogleStream(
+            context,
+            "candidate code execution result did not match executable code",
+          );
+        }
+        pendingAnonymousCodeExecutions.shift();
+      }
+
+      const rawPartIndex = retainRawAssistantPart(part);
+      if (result.providerId !== undefined) {
+        reserveCorrelation(
+          "code-result correlation",
+          result.providerId,
+          resultShape,
+          ...(thoughtSignature === undefined ? [] : [thoughtSignature]),
+        );
+        seenCodeExecutionResults.set(result.providerId, {
+          resultShape,
+          rawPartIndex,
+          ...(thoughtSignature !== undefined ? { thoughtSignature } : {}),
+        });
+      }
+      sawOutput = true;
+      yield result.isError
+        ? {
+          type: "tool-error",
+          toolCallId,
+          toolName: GOOGLE_CODE_EXECUTION_TOOL_NAME,
+          error: resultValue,
+          isError: true,
+          providerExecuted: true,
+        }
+        : {
+          type: "tool-result",
+          toolCallId,
+          toolName: GOOGLE_CODE_EXECUTION_TOOL_NAME,
+          result: resultValue,
+          providerExecuted: true,
+        };
+    }
+
+    if (candidateFinishReason !== undefined) {
+      if (sawFinishReason) {
+        throw invalidGoogleStream(context, "stream contained duplicate terminal reasons");
+      }
+      finishReason = normalizeGoogleFinishReason(candidateFinishReason);
+      sawFinishReason = true;
     }
   }
 
-  if (buffer.trim().length > 0) {
-    const parsed = parseGoogleSseBuffer(buffer, true);
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
-      }
-      usage = extractGoogleUsage(event) ?? usage;
+  for await (const chunk of stream) {
+    if (!(chunk instanceof Uint8Array)) {
+      throw invalidGoogleStream(context, "stream chunk was not binary data");
     }
+    if (chunk.byteLength > MAX_GOOGLE_SSE_CHUNK_BYTES) {
+      throw invalidGoogleStream(
+        context,
+        `SSE chunk exceeded ${MAX_GOOGLE_SSE_CHUNK_BYTES} bytes`,
+      );
+    }
+    let decodedChunk: string;
+    try {
+      decodedChunk = decoder.decode(chunk, { stream: true });
+    } catch {
+      throw invalidGoogleStream(context, "stream contained invalid UTF-8");
+    }
+    if (decodedChunk.length > MAX_GOOGLE_SSE_BUFFER_CODE_UNITS - buffer.length) {
+      throw invalidGoogleStream(
+        context,
+        `SSE buffer exceeded ${MAX_GOOGLE_SSE_BUFFER_CODE_UNITS} code units`,
+      );
+    }
+    buffer += decodedChunk;
+    let parsed: ReturnType<typeof parseSseChunk>;
+    try {
+      parsed = parseSseChunk(buffer);
+    } catch {
+      throw invalidGoogleStream(context, "SSE event framing was malformed");
+    }
+    buffer = parsed.remainder;
+    for (const event of parsed.events) {
+      yield* processEvent(event);
+    }
+  }
+
+  let decodedTail: string;
+  try {
+    decodedTail = decoder.decode();
+  } catch {
+    throw invalidGoogleStream(context, "stream contained invalid UTF-8");
+  }
+  if (decodedTail.length > MAX_GOOGLE_SSE_BUFFER_CODE_UNITS - buffer.length) {
+    throw invalidGoogleStream(
+      context,
+      `SSE buffer exceeded ${MAX_GOOGLE_SSE_BUFFER_CODE_UNITS} code units`,
+    );
+  }
+  buffer += decodedTail;
+  if (buffer.trim().length > 0) {
+    let parsed: ReturnType<typeof parseSseChunk>;
+    try {
+      parsed = parseFinalSseChunk(buffer);
+    } catch {
+      throw invalidGoogleStream(context, "trailing SSE event was malformed");
+    }
+    for (const event of parsed.events) {
+      yield* processEvent(event);
+    }
+  }
+
+  if (!sawCandidateEnvelope) {
+    throw invalidGoogleStream(context, "stream contained no candidate envelope");
+  }
+  if (!sawFinishReason && !sawDone) {
+    throw invalidGoogleStream(context, "stream ended before a terminal marker");
+  }
+  try {
+    toolCallRegistry.assertSettled();
+  } catch {
+    throw invalidGoogleStream(
+      context,
+      "candidate executable code had no matching execution result",
+    );
+  }
+  const contentFiltered = isContentFilterFinishReason(finishReason);
+  if (!sawOutput && !contentFiltered) {
+    throw invalidGoogleStream(context, "stream contained no supported output content");
   }
 
   if (reasoningId) {
     yield {
       type: "reasoning-end",
       id: reasoningId,
+      ...(reasoningSignature !== undefined ? { signature: reasoningSignature } : {}),
     };
   }
 
+  const providerMetadata = createGoogleProviderMetadata(
+    rawAssistantParts,
+    groundingMetadata,
+  );
   yield {
     type: "finish",
     finishReason,
     ...(usage ? { usage } : {}),
+    ...(providerMetadata ? { providerMetadata } : {}),
   };
 }

--- a/extensions/ext-llm-google/src/google-stream.ts
+++ b/extensions/ext-llm-google/src/google-stream.ts
@@ -178,11 +178,22 @@ export async function* streamGoogleCompatibleParts(
       thoughtSignature?: string;
     }
   >();
-  const pendingAnonymousCodeExecutions: Array<{
+  type AnonymousCodeExecutionReplay = {
     callShape: string;
     rawPartIndex: number;
     thoughtSignature?: string;
-  }> = [];
+    settled: boolean;
+  };
+  const seenAnonymousCodeExecutions = new Map<number, AnonymousCodeExecutionReplay>();
+  const seenAnonymousCodeExecutionResults = new Map<
+    number,
+    {
+      resultShape: string;
+      rawPartIndex: number;
+      thoughtSignature?: string;
+    }
+  >();
+  const pendingAnonymousCodeExecutions: AnonymousCodeExecutionReplay[] = [];
   const toolCallRegistry = createGoogleToolCallCorrelationRegistry();
   const rawAssistantParts: Array<Record<string, unknown>> = [];
   let retainedStateBytes = 0;
@@ -574,14 +585,22 @@ export async function* streamGoogleCompatibleParts(
             throw invalidGoogleStream(context, "candidate executable code id was duplicated");
           }
         } else {
-          const prior = pendingAnonymousCodeExecutions.at(-1);
-          if (prior?.callShape === callShape) {
-            mergeReplaySignature(
-              prior,
-              thoughtSignature,
-              "candidate executable code thought signature changed after emission",
-            );
-            continue;
+          const prior = seenAnonymousCodeExecutions.get(candidatePartIndex);
+          if (prior) {
+            if (prior.callShape === callShape) {
+              mergeReplaySignature(
+                prior,
+                thoughtSignature,
+                "candidate executable code thought signature changed after emission",
+              );
+              continue;
+            }
+            if (!prior.settled) {
+              throw invalidGoogleStream(
+                context,
+                "candidate executable code changed after emission",
+              );
+            }
           }
           try {
             toolCallId = toolCallRegistry.registerCodeExecution(undefined);
@@ -601,8 +620,10 @@ export async function* streamGoogleCompatibleParts(
           callShape,
           rawPartIndex,
           ...(thoughtSignature !== undefined ? { thoughtSignature } : {}),
+          settled: false,
         };
         if (executableCode.providerId === undefined) {
+          seenAnonymousCodeExecutions.set(candidatePartIndex, pending);
           pendingAnonymousCodeExecutions.push(pending);
         } else {
           seenCodeExecutions.set(executableCode.providerId, pending);
@@ -665,6 +686,28 @@ export async function* streamGoogleCompatibleParts(
           );
         }
       } else {
+        const pendingExecution = pendingAnonymousCodeExecutions[0];
+        if (!pendingExecution) {
+          const priorResult = seenAnonymousCodeExecutionResults.get(candidatePartIndex);
+          if (priorResult) {
+            if (priorResult.resultShape !== resultShape) {
+              throw invalidGoogleStream(
+                context,
+                "candidate code execution result changed after emission",
+              );
+            }
+            mergeReplaySignature(
+              priorResult,
+              thoughtSignature,
+              "candidate code execution result thought signature changed after emission",
+            );
+            continue;
+          }
+          throw invalidGoogleStream(
+            context,
+            "candidate code execution result did not match executable code",
+          );
+        }
         try {
           toolCallId = toolCallRegistry.resolveCodeExecutionResult(undefined);
         } catch {
@@ -673,6 +716,7 @@ export async function* streamGoogleCompatibleParts(
             "candidate code execution result did not match executable code",
           );
         }
+        pendingExecution.settled = true;
         pendingAnonymousCodeExecutions.shift();
       }
 
@@ -685,6 +729,19 @@ export async function* streamGoogleCompatibleParts(
           ...(thoughtSignature === undefined ? [] : [thoughtSignature]),
         );
         seenCodeExecutionResults.set(result.providerId, {
+          resultShape,
+          rawPartIndex,
+          ...(thoughtSignature !== undefined ? { thoughtSignature } : {}),
+        });
+      } else {
+        const deduplicationKey = `anonymous-${candidatePartIndex}`;
+        reserveCorrelation(
+          "code-result correlation",
+          deduplicationKey,
+          resultShape,
+          ...(thoughtSignature === undefined ? [] : [thoughtSignature]),
+        );
+        seenAnonymousCodeExecutionResults.set(candidatePartIndex, {
           resultShape,
           rawPartIndex,
           ...(thoughtSignature !== undefined ? { thoughtSignature } : {}),

--- a/extensions/ext-llm-google/src/google-stream.ts
+++ b/extensions/ext-llm-google/src/google-stream.ts
@@ -462,7 +462,10 @@ export async function* streamGoogleCompatibleParts(
         ) {
           throw invalidGoogleStream(context, "candidate function call id was malformed");
         }
-        const functionCallArgs = readRecord(functionCall.args);
+        // Gemini omits `args` entirely for zero-parameter tool calls.
+        const functionCallArgs = functionCall.args === undefined
+          ? {}
+          : readRecord(functionCall.args);
         if (!functionCallArgs) {
           throw invalidGoogleStream(
             context,

--- a/extensions/ext-llm-google/src/google-thought-signatures.ts
+++ b/extensions/ext-llm-google/src/google-thought-signatures.ts
@@ -192,7 +192,7 @@ function validateReplayableGooglePart(
         !functionCall ||
         typeof functionCall.name !== "string" ||
         functionCall.name.length === 0 ||
-        !readRecord(functionCall.args)
+        (functionCall.args !== undefined && !readRecord(functionCall.args))
       ) {
         throw new TypeError("Google raw assistant function call is malformed");
       }

--- a/extensions/ext-llm-google/src/google-thought-signatures.ts
+++ b/extensions/ext-llm-google/src/google-thought-signatures.ts
@@ -11,10 +11,11 @@ const GOOGLE_METADATA_KEY = "google";
 const RAW_ASSISTANT_PARTS_KEY = "rawAssistantParts";
 const GROUNDING_METADATA_KEY = "groundingMetadata";
 const MAX_GOOGLE_RAW_ASSISTANT_PARTS = 4_096;
+export const MAX_GOOGLE_PROVIDER_METADATA_BYTES = 8 * 1024 * 1024;
 const GOOGLE_PROVIDER_METADATA_SNAPSHOT_OPTIONS = {
   maxDepth: 64,
   maxNodes: 65_536,
-  maxBytes: 8 * 1024 * 1024,
+  maxBytes: MAX_GOOGLE_PROVIDER_METADATA_BYTES,
 } as const;
 
 function snapshotGoogleProviderMetadata(value: unknown): JsonSnapshotValue {

--- a/extensions/ext-llm-google/src/google-thought-signatures.ts
+++ b/extensions/ext-llm-google/src/google-thought-signatures.ts
@@ -1,0 +1,365 @@
+import { type JsonSnapshotValue, readRecord, snapshotJsonValue } from "veryfront/provider/shared";
+import {
+  createGoogleToolCallCorrelationRegistry,
+  type GoogleSupportedPartDataField,
+  readGoogleCodeExecutionResult,
+  readGoogleExecutableCode,
+  readGooglePartDataField,
+} from "./google-content-parts.ts";
+
+const GOOGLE_METADATA_KEY = "google";
+const RAW_ASSISTANT_PARTS_KEY = "rawAssistantParts";
+const GROUNDING_METADATA_KEY = "groundingMetadata";
+const MAX_GOOGLE_RAW_ASSISTANT_PARTS = 4_096;
+const GOOGLE_PROVIDER_METADATA_SNAPSHOT_OPTIONS = {
+  maxDepth: 64,
+  maxNodes: 65_536,
+  maxBytes: 8 * 1024 * 1024,
+} as const;
+
+function snapshotGoogleProviderMetadata(value: unknown): JsonSnapshotValue {
+  return snapshotJsonValue(value, GOOGLE_PROVIDER_METADATA_SNAPSHOT_OPTIONS);
+}
+
+function asSnapshotRecord(value: JsonSnapshotValue): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readGoogleMetadataNamespace(
+  providerMetadata: Record<string, unknown>,
+): unknown {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(
+      providerMetadata,
+      GOOGLE_METADATA_KEY,
+    );
+  } catch {
+    throw new TypeError("Google provider metadata could not be inspected");
+  }
+  if (descriptor === undefined) {
+    return undefined;
+  }
+  if (
+    descriptor.enumerable !== true ||
+    !Object.hasOwn(descriptor, "value")
+  ) {
+    throw new TypeError(
+      "Google provider metadata namespace must be an enumerable data property",
+    );
+  }
+  return descriptor.value;
+}
+
+function readGoogleRawPartsValue(
+  googleMetadata: unknown,
+): unknown {
+  if (
+    googleMetadata === null ||
+    typeof googleMetadata !== "object" ||
+    Array.isArray(googleMetadata)
+  ) {
+    throw new TypeError("Google provider metadata must be an object");
+  }
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(
+      googleMetadata,
+      RAW_ASSISTANT_PARTS_KEY,
+    );
+  } catch {
+    throw new TypeError("Google provider metadata could not be inspected");
+  }
+  if (descriptor === undefined) {
+    return undefined;
+  }
+  if (
+    descriptor.enumerable !== true ||
+    !Object.hasOwn(descriptor, "value")
+  ) {
+    throw new TypeError(
+      "Google raw assistant parts must be an enumerable data property",
+    );
+  }
+  return descriptor.value;
+}
+
+function hasGoogleReplayTriggerProperty(
+  part: object,
+  key: "thoughtSignature" | "executableCode" | "codeExecutionResult",
+): boolean {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(part, key);
+  } catch {
+    throw new TypeError("Google assistant part could not be inspected");
+  }
+  if (descriptor === undefined) {
+    return false;
+  }
+  // An accessor might conceal a replay trigger. Treat it as present so the
+  // descriptor-based snapshot rejects it without invoking caller code.
+  return !Object.hasOwn(descriptor, "value") || descriptor.value !== undefined;
+}
+
+function needsGoogleExactReplay(
+  parts: Array<Record<string, unknown>>,
+): boolean {
+  let lengthDescriptor: PropertyDescriptor | undefined;
+  try {
+    lengthDescriptor = Object.getOwnPropertyDescriptor(parts, "length");
+  } catch {
+    throw new TypeError("Google assistant parts could not be inspected");
+  }
+  if (
+    lengthDescriptor === undefined ||
+    !Object.hasOwn(lengthDescriptor, "value") ||
+    !Number.isSafeInteger(lengthDescriptor.value) ||
+    lengthDescriptor.value < 0
+  ) {
+    throw new TypeError("Google assistant parts had an invalid length");
+  }
+  const partsLength = lengthDescriptor.value as number;
+  let partKeys: (string | symbol)[];
+  try {
+    partKeys = Reflect.ownKeys(parts);
+  } catch {
+    throw new TypeError("Google assistant parts could not be inspected");
+  }
+  for (const partKey of partKeys) {
+    if (partKey === "length" || typeof partKey !== "string") {
+      continue;
+    }
+    const partIndex = Number(partKey);
+    if (
+      !Number.isSafeInteger(partIndex) ||
+      partIndex < 0 ||
+      partIndex >= partsLength ||
+      String(partIndex) !== partKey
+    ) {
+      continue;
+    }
+    let partDescriptor: PropertyDescriptor | undefined;
+    try {
+      partDescriptor = Object.getOwnPropertyDescriptor(
+        parts,
+        partKey,
+      );
+    } catch {
+      throw new TypeError("Google assistant parts could not be inspected");
+    }
+    if (partDescriptor === undefined) {
+      throw new TypeError("Google assistant parts changed while being inspected");
+    }
+    if (!Object.hasOwn(partDescriptor, "value")) {
+      // Force the protected snapshot path, which rejects array accessors
+      // without invoking them.
+      return true;
+    }
+    const part = partDescriptor.value;
+    if (part === null || typeof part !== "object") {
+      continue;
+    }
+    if (
+      hasGoogleReplayTriggerProperty(part, "thoughtSignature") ||
+      hasGoogleReplayTriggerProperty(part, "executableCode") ||
+      hasGoogleReplayTriggerProperty(part, "codeExecutionResult")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function validateReplayableGooglePart(
+  part: Record<string, unknown>,
+): GoogleSupportedPartDataField {
+  if (part.thought !== undefined && typeof part.thought !== "boolean") {
+    throw new TypeError("Google raw assistant thought marker must be a boolean");
+  }
+  const dataField = readGooglePartDataField(part);
+  switch (dataField) {
+    case "text":
+      if (typeof part.text !== "string") {
+        throw new TypeError("Google raw assistant text must be a string");
+      }
+      break;
+    case "functionCall": {
+      const functionCall = readRecord(part.functionCall);
+      if (
+        !functionCall ||
+        typeof functionCall.name !== "string" ||
+        functionCall.name.length === 0 ||
+        !readRecord(functionCall.args)
+      ) {
+        throw new TypeError("Google raw assistant function call is malformed");
+      }
+      if (
+        functionCall.id !== undefined &&
+        (typeof functionCall.id !== "string" || functionCall.id.length === 0)
+      ) {
+        throw new TypeError("Google raw assistant function call id is malformed");
+      }
+      break;
+    }
+    case "executableCode":
+      readGoogleExecutableCode(part.executableCode);
+      break;
+    case "codeExecutionResult":
+      readGoogleCodeExecutionResult(part.codeExecutionResult);
+      break;
+  }
+  return dataField;
+}
+
+export function readGoogleThoughtSignature(
+  part: Record<string, unknown>,
+): string | undefined {
+  const signature = part.thoughtSignature;
+  if (signature === undefined) {
+    return undefined;
+  }
+  if (typeof signature !== "string" || signature.length === 0) {
+    throw new TypeError("Google thought signature must be a non-empty string");
+  }
+  return signature;
+}
+
+export function createGoogleProviderMetadata(
+  parts: Array<Record<string, unknown>>,
+  groundingMetadata?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const needsExactReplay = needsGoogleExactReplay(parts);
+  if (!needsExactReplay && groundingMetadata === undefined) {
+    return undefined;
+  }
+  let ownedParts: readonly Record<string, unknown>[] | undefined;
+  if (needsExactReplay) {
+    const partsSnapshot = snapshotGoogleProviderMetadata(parts);
+    if (!Array.isArray(partsSnapshot)) {
+      throw new TypeError("Google raw assistant parts must be an array");
+    }
+    if (partsSnapshot.length > MAX_GOOGLE_RAW_ASSISTANT_PARTS) {
+      throw new TypeError(
+        `Google raw assistant parts exceeded ${MAX_GOOGLE_RAW_ASSISTANT_PARTS} entries`,
+      );
+    }
+    ownedParts = validateGoogleRawAssistantParts(
+      partsSnapshot as readonly JsonSnapshotValue[],
+    );
+  }
+
+  const metadata = snapshotGoogleProviderMetadata({
+    [GOOGLE_METADATA_KEY]: {
+      ...(needsExactReplay ? { [RAW_ASSISTANT_PARTS_KEY]: ownedParts } : {}),
+      ...(groundingMetadata !== undefined ? { [GROUNDING_METADATA_KEY]: groundingMetadata } : {}),
+    },
+  });
+  const metadataRecord = asSnapshotRecord(metadata);
+  if (!metadataRecord) {
+    throw new TypeError("Google provider metadata must be an object");
+  }
+  return metadataRecord;
+}
+
+function validateGoogleRawAssistantParts(
+  rawParts: readonly JsonSnapshotValue[],
+): readonly Record<string, unknown>[] {
+  if (rawParts.length === 0) {
+    throw new TypeError("Google raw assistant parts must be a non-empty array");
+  }
+  if (rawParts.length > MAX_GOOGLE_RAW_ASSISTANT_PARTS) {
+    throw new TypeError(
+      `Google raw assistant parts exceeded ${MAX_GOOGLE_RAW_ASSISTANT_PARTS} entries`,
+    );
+  }
+
+  let hasThoughtSignature = false;
+  let hasCodeExecution = false;
+  const toolCallRegistry = createGoogleToolCallCorrelationRegistry();
+  for (let partIndex = 0; partIndex < rawParts.length; partIndex += 1) {
+    const rawPart = rawParts[partIndex];
+    if (rawPart === undefined) {
+      throw new TypeError("Google raw assistant parts must be dense");
+    }
+    const part = asSnapshotRecord(rawPart);
+    if (!part) {
+      throw new TypeError("Google raw assistant part must be an object");
+    }
+    const dataField = validateReplayableGooglePart(part);
+    if (readGoogleThoughtSignature(part) !== undefined) {
+      hasThoughtSignature = true;
+    }
+    if (dataField === "functionCall") {
+      const functionCall = readRecord(part.functionCall);
+      const functionCallId = typeof functionCall?.id === "string" ? functionCall.id : undefined;
+      try {
+        toolCallRegistry.registerFunctionCall(partIndex, functionCallId);
+      } catch {
+        throw new TypeError("Google raw assistant tool call id was duplicated");
+      }
+    } else if (dataField === "executableCode") {
+      const executableCode = readGoogleExecutableCode(part.executableCode);
+      hasCodeExecution = true;
+      try {
+        toolCallRegistry.registerCodeExecution(executableCode.providerId);
+      } catch {
+        throw new TypeError("Google raw assistant executable code id was duplicated");
+      }
+    } else if (dataField === "codeExecutionResult") {
+      const result = readGoogleCodeExecutionResult(part.codeExecutionResult);
+      hasCodeExecution = true;
+      try {
+        toolCallRegistry.resolveCodeExecutionResult(result.providerId);
+      } catch {
+        throw new TypeError(
+          result.providerId === undefined
+            ? "Google raw assistant code execution result had no matching executable code"
+            : "Google raw assistant code execution result id did not match executable code",
+        );
+      }
+    }
+  }
+
+  if (!hasThoughtSignature && !hasCodeExecution) {
+    throw new TypeError(
+      "Google raw assistant parts contained neither a thought signature nor code execution",
+    );
+  }
+  try {
+    toolCallRegistry.assertSettled();
+  } catch {
+    throw new TypeError("Google raw assistant executable code had no matching result");
+  }
+  // Return the exact frozen snapshot array that was validated. Do not rebuild
+  // a shallow collection whose contents could diverge before serialization.
+  return rawParts as readonly Record<string, unknown>[];
+}
+
+export function readGoogleRawAssistantParts(
+  providerMetadata: Record<string, unknown> | undefined,
+): readonly Record<string, unknown>[] | undefined {
+  if (providerMetadata === undefined) {
+    return undefined;
+  }
+  const rawGoogleMetadata = readGoogleMetadataNamespace(providerMetadata);
+  if (rawGoogleMetadata === undefined) {
+    return undefined;
+  }
+  const rawParts = readGoogleRawPartsValue(rawGoogleMetadata);
+  if (rawParts === undefined) {
+    return undefined;
+  }
+  // Grounding and future Google metadata fields are not replayed. Snapshot
+  // only the exact wire value that will be validated and transmitted so those
+  // independent fields cannot consume replay budgets or invoke accessors.
+  const rawPartsSnapshot = snapshotGoogleProviderMetadata(rawParts);
+  if (!Array.isArray(rawPartsSnapshot)) {
+    throw new TypeError("Google raw assistant parts must be a non-empty array");
+  }
+  return validateGoogleRawAssistantParts(
+    rawPartsSnapshot as readonly JsonSnapshotValue[],
+  );
+}


### PR DESCRIPTION
## Summary
- harden Anthropic request, replay, native-content, MCP, tool-use, citation, and streaming contracts
- harden Google request, replay, thought-signature, grounding, code-execution, and streaming contracts
- enforce aggregate retained-byte and item budgets for Anthropic raw/text/thinking state and Google raw/correlation state
- assemble Anthropic streamed text/thinking from bounded chunks to avoid quadratic concatenation

## Stack
Depends on #3235 (provider/OpenAI runtime foundation).

## Verification
- `deno task typecheck`
- focused Anthropic + Google extension suites: 10 files, 275 steps
- explicit many-small-event retained-state regressions for both providers
- `git diff --check`

Recovery checkpoint: the pre-rebase head is preserved on `codex/provider-anthropic-google-pre-rebase-20260802` until descendants validate.