### PR TITLE
fix(release-assets): harden manifest publication pipeline

### DIFF
--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -130,7 +130,13 @@ export async function startCliProductionServer(
     const manifest = parseReleaseAssetManifest(JSON.parse(manifestRaw));
     if (manifest) {
       clearReleaseAssetManifestCache();
-      configureReleaseAssetManifestFetcher(() => Promise.resolve({ state: "ready", manifest }));
+      configureReleaseAssetManifestFetcher(() =>
+        Promise.resolve({
+          state: "ready",
+          manifest_version: manifest.manifestVersion,
+          manifest,
+        })
+      );
       registeredLocalManifest = true;
       localReleaseId = manifest.releaseId;
     }

--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -12,10 +12,10 @@ import {
   prefetchBuiltinContentProcessor,
 } from "./ensure-content-processor.ts";
 import { join } from "veryfront/platform/path";
-import { parseReleaseAssetManifest } from "veryfront/release-assets";
 import {
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
+  parseReleaseAssetManifest,
+  registerManifestFetcherForRelease,
 } from "veryfront/release-assets";
 import { LOCAL_RELEASE_ASSET_MANIFEST_PATH } from "veryfront/build";
 
@@ -122,7 +122,7 @@ export async function startCliProductionServer(
 ): Promise<Awaited<ReturnType<typeof startProductionServer>>> {
   const adapter = options.adapter ?? (await runtime.get());
   const manifestPath = join(options.projectDir, "dist", LOCAL_RELEASE_ASSET_MANIFEST_PATH);
-  let registeredLocalManifest = false;
+  let unregisterLocalManifest: (() => void) | undefined;
   let localReleaseId: string | undefined;
 
   try {
@@ -130,14 +130,15 @@ export async function startCliProductionServer(
     const manifest = parseReleaseAssetManifest(JSON.parse(manifestRaw));
     if (manifest) {
       clearReleaseAssetManifestCache();
-      configureReleaseAssetManifestFetcher(() =>
-        Promise.resolve({
-          state: "ready",
-          manifest_version: manifest.manifestVersion,
-          manifest,
-        })
+      unregisterLocalManifest = registerManifestFetcherForRelease(
+        manifest.releaseId,
+        () =>
+          Promise.resolve({
+            state: "ready",
+            manifest_version: manifest.manifestVersion,
+            manifest,
+          }),
       );
-      registeredLocalManifest = true;
       localReleaseId = manifest.releaseId;
     }
   } catch (_) {
@@ -170,8 +171,8 @@ export async function startCliProductionServer(
   return {
     ...result,
     stop: async () => {
-      if (registeredLocalManifest) {
-        configureReleaseAssetManifestFetcher(undefined);
+      if (unregisterLocalManifest) {
+        unregisterLocalManifest();
         clearReleaseAssetManifestCache();
       }
       await result.stop();

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -33,7 +33,7 @@ order: 1
 | [`veryfront/observability`](./veryfront/observability.md) | Tracing, metrics, errors, and logs. |
 | [`veryfront/prompt`](./veryfront/prompt.md) | MCP prompt definitions. |
 | [`veryfront/provider`](./veryfront/provider.md) | Model provider registry. |
-| [`veryfront/release-assets`](./veryfront/release-assets.md) | Release Asset Manifest - public barrel. |
+| [`veryfront/release-assets`](./veryfront/release-assets.md) | Content-addressed release asset build, schema, cache, and consumption contracts. |
 | [`veryfront/resource`](./veryfront/resource.md) | MCP resource definitions. |
 | [`veryfront/router`](./veryfront/router.md) | Client navigation and route context. |
 | [`veryfront/runs`](./veryfront/runs.md) | Canonical durable task and workflow runs. |

--- a/docs/api-reference/veryfront/release-assets.md
+++ b/docs/api-reference/veryfront/release-assets.md
@@ -10,10 +10,10 @@ order: 25
 import {
   clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
   contentTypeForExtension,
   getReadyManifestForRender,
   getReadyManifestForRenderAsync,
+  hasImmutableReleaseAssetDependencies,
 } from "veryfront/release-assets";
 ```
 
@@ -66,25 +66,24 @@ const url = releaseAssetUrl("a".repeat(64), "js");
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `clearCachedReleaseAssetManifests` | Clear cached manifest bodies while keeping registered fetchers intact. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L572) |
-| `clearReleaseAssetManifestCache` | Clear the cache and fetcher registry (tests / adapter teardown). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L582) |
-| `configureReleaseAssetManifestFetcher` | Register a single global fetcher (for tests / simple single-project setups). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L209) |
+| `clearCachedReleaseAssetManifests` | Clear cached manifest bodies while keeping registered fetchers intact. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L544) |
+| `clearReleaseAssetManifestCache` | Clear the cache and fetcher registry (tests / adapter teardown). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L554) |
 | `contentTypeForExtension` | Resolve the content type for an extension, or null if not allowed. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L96) |
-| `getReadyManifestForRender` | Return a ready manifest for `releaseId` if one is cached, else null. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L286) |
-| `getReadyManifestForRenderAsync` | Await a ready manifest for `releaseId`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L339) |
+| `getReadyManifestForRender` | Return a ready manifest for `releaseId` if one is cached, else null. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L257) |
+| `getReadyManifestForRenderAsync` | Await a ready manifest for `releaseId`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L310) |
 | `hasImmutableReleaseAssetDependencies` | True only when manifest dependency entries are safe immutable rewrite targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L279) |
 | `isAllowedReleaseAssetContentType` | True when the value is a valid allowlisted release asset content type. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L105) |
-| `isReleaseAssetManifestEnabled` | True when production manifest consumption is enabled via env flag. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L231) |
+| `isReleaseAssetManifestEnabled` | True when production manifest consumption is enabled via env flag. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L202) |
 | `isValidContentHash` | Validate a content hash is exactly 64 lowercase hex characters. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L114) |
 | `normalizeManifestModuleKey` | Normalize a logical module path to the manifest's key convention. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/html-consumption.ts#L27) |
 | `parseReadyReleaseAssetManifestResponse` | Parse an untrusted ready response without executing accessors. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L332) |
 | `parseReleaseAssetManifest` | Parse an untrusted manifest without requiring a registered schema extension. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L317) |
-| `registerManifestFetcherForRelease` | Register a project-scoped manifest fetcher for the given releaseId. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L160) |
+| `registerManifestFetcherForRelease` | Register a project-scoped manifest fetcher for the given releaseId. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L158) |
 | `releaseAssetUrl` | Map a 64-hex content hash + extension to its public asset URL. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L85) |
 | `resolveManifestModuleUrl` | Resolve a module URL through the manifest. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/html-consumption.ts#L42) |
 | `resolveManifestRoutePreloadUrls` | Resolve the route closure module URLs for preload hints from the manifest. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/html-consumption.ts#L64) |
 | `routeForPage` | Derive a route path from a page module logical path. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/route-path.ts#L50) |
-| `unregisterManifestFetcherForRelease` | Remove the manifest fetcher for the given releaseId. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L198) |
+| `unregisterManifestFetcherForRelease` | Remove the manifest fetcher for the given releaseId. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L196) |
 
 ### Types
 

--- a/docs/api-reference/veryfront/release-assets.md
+++ b/docs/api-reference/veryfront/release-assets.md
@@ -1,6 +1,6 @@
 ---
 title: "veryfront/release-assets"
-description: "Release Asset Manifest - public barrel."
+description: "Content-addressed release asset build, schema, cache, and consumption contracts."
 order: 25
 ---
 
@@ -8,16 +8,31 @@ order: 25
 
 ```ts
 import {
+  clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
   configureReleaseAssetManifestFetcher,
   contentTypeForExtension,
-  createCompileProjectCss,
   getReadyManifestForRender,
-  isAllowedReleaseAssetContentType,
+  getReadyManifestForRenderAsync,
 } from "veryfront/release-assets";
 ```
 
 ## Examples
+
+### Validate an API response before consuming its manifest body.
+
+```ts
+import { parseReadyReleaseAssetManifestResponse } from "veryfront/release-assets";
+
+const expectedReleaseId = "release-123";
+const response = await fetch("/api/releases/current/asset-manifest");
+const ready = parseReadyReleaseAssetManifestResponse(
+  await response.json(),
+  expectedReleaseId,
+);
+if (!ready) throw new Error("Invalid release asset manifest response");
+const manifest = ready.manifest;
+```
 
 ### Build an immutable URL for a published JavaScript asset
 
@@ -34,58 +49,65 @@ const url = releaseAssetUrl("a".repeat(64), "js");
 | Name | Description | Source |
 |------|-------------|--------|
 | `RELEASE_ASSET_BASE_PATH` | Public asset base path served on the project's own domain (proxy-owned). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L11) |
-| `RELEASE_ASSET_CONTENT_TYPE_ALLOWLIST` | Allowlist of accepted content types (upstream + upload validation). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L23) |
+| `RELEASE_ASSET_CONTENT_TYPE_ALLOWLIST` | Allowlist of accepted content types (upstream + upload validation). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L27) |
 | `RELEASE_ASSET_CONTENT_TYPES` | Content types permitted for release assets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L14) |
-| `RELEASE_ASSET_IMMUTABLE_MAX_AGE_SECONDS` | Immutable cache max-age in seconds (1 year). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L32) |
-| `RELEASE_ASSET_MANIFEST_ENV_FLAG` | Env flag that enables HTML manifest consumption in production (default OFF). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L44) |
+| `RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG` | Env flag that enables manifest dependency import-map rewrites (default OFF). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L78) |
+| `RELEASE_ASSET_IMMUTABLE_MAX_AGE_SECONDS` | Immutable cache max-age in seconds (1 year). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L63) |
+| `RELEASE_ASSET_MANIFEST_ENV_FLAG` | Env flag that enables HTML manifest consumption in production (default OFF). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L75) |
+| `RELEASE_ASSET_MANIFEST_LIMITS` | Work and memory bounds enforced by every manifest producer and consumer. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L40) |
 | `RELEASE_ASSET_MANIFEST_SCHEMA_VERSION` | Current manifest body schema version. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L8) |
-| `RELEASE_ASSET_MAX_SIZE_BYTES` | Maximum size (bytes) for a single uploaded asset (10 MB). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L29) |
-| `RELEASE_ASSET_UPLOAD_CONCURRENCY` | Bounded upload concurrency when posting assets during a build. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L41) |
+| `RELEASE_ASSET_MAX_PENDING_BYTES` | Maximum aggregate bytes retained while preparing one asset generation. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L37) |
+| `RELEASE_ASSET_MAX_SIZE_BYTES` | Maximum size (bytes) for a single uploaded asset (10 MB). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L34) |
+| `RELEASE_ASSET_UPLOAD_CONCURRENCY` | Bounded upload concurrency when posting assets during a build. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L72) |
+| `RELEASE_MODULE_RUNTIME_VERSION_PARAM` | Query param that scopes fallback module URLs to the Veryfront runtime build. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L69) |
+| `RELEASE_MODULE_VERSION_PARAM` | Query param that scopes fallback module URLs to an immutable release. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L66) |
 
 ### Functions
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `clearReleaseAssetManifestCache` | Clear the cache and fetcher registry (tests / adapter teardown). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L369) |
-| `configureReleaseAssetManifestFetcher` | Register a single global fetcher (for tests / simple single-project setups). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L121) |
-| `contentTypeForExtension` | Resolve the content type for an extension, or null if not allowed. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L59) |
-| `createCompileProjectCss` | Build a `compileProjectCss` function bound to a specific release build. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/css-compile.ts#L64) |
-| `getReadyManifestForRender` | Return a ready manifest for `releaseId` if one is cached, else null. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L184) |
-| `isAllowedReleaseAssetContentType` | True when the value is a valid allowlisted release asset content type. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L68) |
-| `isReleaseAssetManifestEnabled` | True when production manifest consumption is enabled via env flag. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L139) |
-| `isValidContentHash` | Validate a content hash is exactly 64 lowercase hex characters. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L77) |
+| `clearCachedReleaseAssetManifests` | Clear cached manifest bodies while keeping registered fetchers intact. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L572) |
+| `clearReleaseAssetManifestCache` | Clear the cache and fetcher registry (tests / adapter teardown). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L582) |
+| `configureReleaseAssetManifestFetcher` | Register a single global fetcher (for tests / simple single-project setups). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L209) |
+| `contentTypeForExtension` | Resolve the content type for an extension, or null if not allowed. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L96) |
+| `getReadyManifestForRender` | Return a ready manifest for `releaseId` if one is cached, else null. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L286) |
+| `getReadyManifestForRenderAsync` | Await a ready manifest for `releaseId`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L339) |
+| `hasImmutableReleaseAssetDependencies` | True only when manifest dependency entries are safe immutable rewrite targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L279) |
+| `isAllowedReleaseAssetContentType` | True when the value is a valid allowlisted release asset content type. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L105) |
+| `isReleaseAssetManifestEnabled` | True when production manifest consumption is enabled via env flag. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L231) |
+| `isValidContentHash` | Validate a content hash is exactly 64 lowercase hex characters. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L114) |
 | `normalizeManifestModuleKey` | Normalize a logical module path to the manifest's key convention. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/html-consumption.ts#L27) |
-| `parseReleaseAssetManifest` | Hand-rolled structural validator. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L106) |
-| `registerManifestFetcherForRelease` | Register a project-scoped manifest fetcher for the given releaseId. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L99) |
-| `releaseAssetUrl` | Map a 64-hex content hash + extension to its public asset URL. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L54) |
-| `resolveManifestModuleUrl` | Resolve a module URL through the manifest. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/html-consumption.ts#L41) |
-| `resolveManifestRoutePreloadUrls` | Resolve the route closure module URLs for preload hints from the manifest. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/html-consumption.ts#L61) |
-| `routeForPage` | Derive a route path from a page module logical path. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/route-path.ts#L47) |
-| `runReleaseAssetBuild` | Execute a release asset build. Pure orchestration over the injected client and a runtime-provided temp dir + react version. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/build-executor.ts#L1517) |
-| `unregisterManifestFetcherForRelease` | Remove the manifest fetcher for the given releaseId. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L111) |
+| `parseReadyReleaseAssetManifestResponse` | Parse an untrusted ready response without executing accessors. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L332) |
+| `parseReleaseAssetManifest` | Parse an untrusted manifest without requiring a registered schema extension. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L317) |
+| `registerManifestFetcherForRelease` | Register a project-scoped manifest fetcher for the given releaseId. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L160) |
+| `releaseAssetUrl` | Map a 64-hex content hash + extension to its public asset URL. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L85) |
+| `resolveManifestModuleUrl` | Resolve a module URL through the manifest. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/html-consumption.ts#L42) |
+| `resolveManifestRoutePreloadUrls` | Resolve the route closure module URLs for preload hints from the manifest. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/html-consumption.ts#L64) |
+| `routeForPage` | Derive a route path from a page module logical path. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/route-path.ts#L50) |
+| `unregisterManifestFetcherForRelease` | Remove the manifest fetcher for the given releaseId. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L198) |
 
 ### Types
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `CompileProjectCssOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/css-compile.ts#L44) |
-| `CompileProjectCssResult` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/css-compile.ts#L39) |
-| `ReleaseAssetBuildClient` | Subset of the API client used by the builder (eases testing). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/build-executor.ts#L183) |
-| `ReleaseAssetBuildInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/build-executor.ts#L103) |
-| `ReleaseAssetBuildResult` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/build-executor.ts#L220) |
-| `ReleaseAssetContentType` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L20) |
-| `ReleaseAssetCssEntry` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L80) |
-| `ReleaseAssetEntry` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L79) |
-| `ReleaseAssetExtension` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L19) |
-| `ReleaseAssetManifest` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L76) |
-| `ReleaseAssetManifestFetcher` | Fetcher used to retrieve a manifest for a release. Registered per-releaseId by the runtime adapter that owns that release, so the correct project-scoped token is always used. Returns null when the manifest is unavailable. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L83) |
-| `ReleaseAssetManifestResponse` | Response shape for the GET asset-manifest endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L93) |
-| `ReleaseAssetManifestState` | Manifest lifecycle states (DB-owned; mirrored here for runtime checks). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L84) |
-| `ReleaseAssetRouteEntry` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L81) |
-| `ReleaseAssetTransform` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/build-executor.ts#L140) |
+| `ImmutableReleaseAssetManifest` | Manifest whose dependency entries name uploaded content-addressed assets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L274) |
+| `ReadyManifestReadOptions` | Controls revalidation behavior for awaited manifest reads. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L76) |
+| `ReadyReleaseAssetManifestResponse` | Strict ready response with a generation-matched validated manifest body. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L301) |
+| `ReleaseAssetContentType` | MIME types accepted for immutable release asset uploads and responses. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L24) |
+| `ReleaseAssetCssEntry` | Content-addressed CSS entry. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L268) |
+| `ReleaseAssetDependencyMode` | Capability represented by entries in the manifest dependency map. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L272) |
+| `ReleaseAssetEntry` | Content-addressed JavaScript module entry. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L266) |
+| `ReleaseAssetExtension` | File extensions supported by the immutable release asset endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/constants.ts#L22) |
+| `ReleaseAssetManifest` | Validated, immutable release asset manifest v2 body. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L262) |
+| `ReleaseAssetManifestFetchContext` | Cancellation context passed to a release-scoped manifest fetcher. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L91) |
+| `ReleaseAssetManifestFetcher` | Fetcher used to retrieve a manifest for a release. Registered per-releaseId by the runtime adapter that owns that release, so the correct project-scoped token is always used. Returns null when the manifest is unavailable. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L108) |
+| `ReleaseAssetManifestFetcherCleanup` | Idempotent cleanup for one fetcher registration. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-cache.ts#L116) |
+| `ReleaseAssetManifestResponse` | Response shape for the GET asset-manifest endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L294) |
+| `ReleaseAssetManifestState` | Manifest lifecycle states (DB-owned; mirrored here for runtime checks). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L286) |
+| `ReleaseAssetRouteEntry` | Per-route module and CSS closure. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L270) |
 
 ### Constants
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `getReleaseAssetManifestSchema` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L50) |
+| `getReleaseAssetManifestSchema` | Extension-backed validator for the strict release asset manifest v2 body. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/release-assets/manifest-schema.ts#L212) |

--- a/src/build/production-build/local-release-assets.test.ts
+++ b/src/build/production-build/local-release-assets.test.ts
@@ -304,6 +304,7 @@ describe("build/production-build/local-release-assets", () => {
           vendorHttpImports: () => {
             throw new Error("esm.sh unavailable");
           },
+          frameworkTransform: fakeFrameworkTransform,
         }),
       Error,
       "Failed to generate local release dependency assets",

--- a/src/build/production-build/local-release-assets.ts
+++ b/src/build/production-build/local-release-assets.ts
@@ -69,6 +69,13 @@ export async function generateLocalReleaseAssetManifest(
   options: LocalReleaseAssetOptions,
 ): Promise<ReleaseAssetManifest | null> {
   if (!shouldBuildLocalDependencyAssets()) return null;
+  if (!options.vendorHttpImports || !options.frameworkTransform) {
+    throw new Error(
+      "Local immutable release assets require explicit HTTP vendoring and framework transform providers",
+    );
+  }
+  const vendorHttpImports = options.vendorHttpImports;
+  const frameworkTransform = options.frameworkTransform;
 
   const tempDir = await options.adapter.fs.makeTempDir("vf-local-release-assets-");
 
@@ -94,7 +101,7 @@ export async function generateLocalReleaseAssetManifest(
       const built = await buildReactImportMapDependencyAssets({
         tempDir,
         reactVersion,
-        vendorHttpImports: options.vendorHttpImports,
+        vendorHttpImports,
       });
       const cached = await buildCachedHttpDependencyAssets({
         cacheDir: join(options.projectDir, ".cache", "veryfront-http-bundle"),
@@ -106,7 +113,7 @@ export async function generateLocalReleaseAssetManifest(
         adapter: options.adapter,
         reactVersion,
         projectId: options.projectId ?? "local",
-        transform: options.frameworkTransform,
+        transform: frameworkTransform,
         dependencyUrls,
         dependencyPinningSource,
         dependencyPinningSnapshot,
@@ -117,6 +124,11 @@ export async function generateLocalReleaseAssetManifest(
         assetsByHash.set(asset.contentHash, asset);
       }
       const gaps = [...cached.gaps, ...built.gaps, ...framework.gaps];
+      if (gaps.length > 0) {
+        throw new Error(
+          `Local release asset coverage is incomplete: ${gaps.slice(0, 20).join(", ")}`,
+        );
+      }
       const sourceContentHash = await computeHashBytes(
         new TextEncoder().encode(
           [
@@ -139,6 +151,7 @@ export async function generateLocalReleaseAssetManifest(
         sourceContentHash,
         createdAt: new Date().toISOString(),
         assetBasePath: RELEASE_ASSET_BASE_PATH,
+        dependencyMode: "immutable",
         modules: {},
         css: [],
         routes: {},
@@ -149,7 +162,6 @@ export async function generateLocalReleaseAssetManifest(
             contentType: entry.contentType,
           }]),
         ),
-        fallback: { mode: "jit", gaps },
       };
 
       if (options.dryRun) return manifest;

--- a/src/build/production-build/static-generation.test.ts
+++ b/src/build/production-build/static-generation.test.ts
@@ -452,13 +452,13 @@ describe(
         const jsxDevRuntimeHash = "5".repeat(64);
         const headHash = "6".repeat(64);
         const manifest: ReleaseAssetManifest = {
-          schemaVersion: 1,
+          schemaVersion: 2,
           projectId: "local-project",
           releaseId: "standalone-dev",
           releaseVersion: 0,
           manifestVersion: 1,
           builderVersion: "0.1.810",
-          sourceContentHash: "source",
+          sourceContentHash: "a".repeat(64),
           createdAt: "2026-06-15T00:00:00.000Z",
           assetBasePath: "/_vf/assets",
           modules: {},
@@ -501,7 +501,7 @@ describe(
               contentType: "text/javascript",
             },
           },
-          fallback: { mode: "jit", gaps: [] },
+          dependencyMode: "immutable",
         };
         const renderer = {
           renderPage: (

--- a/src/cache/keys.test.ts
+++ b/src/cache/keys.test.ts
@@ -25,9 +25,9 @@ import {
 } from "./keys.ts";
 import {
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
   getReadyManifestForRender,
   getReadyManifestForRenderAsync,
+  registerManifestFetcherForRelease,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
@@ -132,7 +132,6 @@ describe("cache/keys", () => {
 
     afterEach(() => {
       clearReleaseAssetManifestCache();
-      configureReleaseAssetManifestFetcher(undefined);
       try {
         Deno.env.delete("VERYFRONT_RELEASE_ASSET_MANIFEST");
       } catch (_) { /* env may be read-only in some test configs */ }
@@ -142,7 +141,7 @@ describe("cache/keys", () => {
       try {
         Deno.env.delete("VERYFRONT_RELEASE_ASSET_MANIFEST");
       } catch (_) { /* ok */ }
-      configureReleaseAssetManifestFetcher(async () => ({
+      registerManifestFetcherForRelease("rel_456", async () => ({
         state: "ready",
         manifest_version: 1,
         manifest: makeManifest(),
@@ -168,7 +167,7 @@ describe("cache/keys", () => {
       const fetchDone = new Promise<void>((r) => {
         resolvePromise = r;
       });
-      configureReleaseAssetManifestFetcher(async () => {
+      registerManifestFetcherForRelease("rel_456", async () => {
         resolvePromise();
         return { state: "ready", manifest_version: 1, manifest: makeManifest() };
       });

--- a/src/cache/keys.test.ts
+++ b/src/cache/keys.test.ts
@@ -27,6 +27,7 @@ import {
   clearReleaseAssetManifestCache,
   configureReleaseAssetManifestFetcher,
   getReadyManifestForRender,
+  getReadyManifestForRenderAsync,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
@@ -113,19 +114,19 @@ describe("cache/keys", () => {
 
   describe("render cache prefix + manifest consumption", () => {
     const makeManifest = (): ReleaseAssetManifest => ({
-      schemaVersion: 1,
+      schemaVersion: 2,
       manifestVersion: 1,
       projectId: "proj_123",
       releaseId: "rel_456",
       releaseVersion: 1,
       builderVersion: "0.1.765",
-      sourceContentHash: "abc123",
+      sourceContentHash: "a".repeat(64),
       createdAt: "2026-06-12T00:00:00Z",
       assetBasePath: "/_vf/assets",
       modules: {},
       css: [],
       routes: {},
-      fallback: { mode: "jit" as const, gaps: [] },
+      dependencyMode: "immutable",
       dependencies: {},
     });
 
@@ -143,6 +144,7 @@ describe("cache/keys", () => {
       } catch (_) { /* ok */ }
       configureReleaseAssetManifestFetcher(async () => ({
         state: "ready",
+        manifest_version: 1,
         manifest: makeManifest(),
       }));
       // With flag off, must return null
@@ -168,7 +170,7 @@ describe("cache/keys", () => {
       });
       configureReleaseAssetManifestFetcher(async () => {
         resolvePromise();
-        return { state: "ready", manifest: makeManifest() };
+        return { state: "ready", manifest_version: 1, manifest: makeManifest() };
       });
 
       // First call: cache miss → background fetch scheduled → returns null
@@ -176,7 +178,7 @@ describe("cache/keys", () => {
 
       // Wait for the background fetch to complete
       await fetchDone;
-      await Promise.resolve();
+      await getReadyManifestForRenderAsync("rel_456");
 
       // Second call: cache hit → returns manifest
       const cached = getReadyManifestForRender("rel_456");

--- a/src/html/html-injection.test.ts
+++ b/src/html/html-injection.test.ts
@@ -16,13 +16,13 @@ const ABOUT_HASH = "c".repeat(64);
 
 function releaseManifest(): ReleaseAssetManifest {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     projectId: "project-id",
     releaseId: "release-id",
     releaseVersion: 1,
     manifestVersion: 1,
     builderVersion: "0.1.765",
-    sourceContentHash: "",
+    sourceContentHash: "a".repeat(64),
     createdAt: "2026-07-27T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
     modules: {
@@ -36,7 +36,7 @@ function releaseManifest(): ReleaseAssetManifest {
     css: [],
     routes: { "/": { modules: ["app/page.tsx"], css: [] } },
     dependencies: {},
-    fallback: { mode: "jit", gaps: [] },
+    dependencyMode: "immutable",
   };
 }
 

--- a/src/html/html-shell-generator.test.ts
+++ b/src/html/html-shell-generator.test.ts
@@ -423,16 +423,16 @@ describe("html-generation/html-shell-generator", () => {
       );
     });
 
-    it("escapes release-manifest URLs in modulepreload attributes", async () => {
+    it("rejects invalid release-manifest asset hashes before generating preload URLs", async () => {
       const hostileHash = 'hash"><script>alert(1)</script>';
       const manifest: ReleaseAssetManifest = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         projectId: "project",
         releaseId: "release",
         releaseVersion: 1,
         manifestVersion: 1,
         builderVersion: "test",
-        sourceContentHash: "source",
+        sourceContentHash: "a".repeat(64),
         createdAt: "2026-01-01T00:00:00.000Z",
         assetBasePath: "/_vf/assets",
         modules: {
@@ -447,7 +447,7 @@ describe("html-generation/html-shell-generator", () => {
           "/dashboard": { modules: ["pages/dashboard.tsx"], css: [] },
         },
         dependencies: {},
-        fallback: { mode: "jit", gaps: [] },
+        dependencyMode: "immutable",
       };
       const options = {
         ...createOptions({
@@ -462,14 +462,11 @@ describe("html-generation/html-shell-generator", () => {
         options,
       );
 
-      assertStringIncludes(
-        result,
-        'href="/_vf/assets/hash&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;.js"',
-      );
       assertEquals(
-        result.includes('href="/_vf/assets/hash"><script>alert(1)</script>.js"'),
+        result.includes("/_vf/assets/hash"),
         false,
       );
+      assertStringIncludes(result, 'href="/_vf_modules/pages/dashboard.js"');
     });
 
     it("should include Tailwind CSS link in development mode", async () => {

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -9,7 +9,7 @@ import type { RenderMetadata } from "#veryfront/types";
 import type { HTMLGenerationOptions } from "./types.ts";
 import {
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
+  registerManifestFetcherForRelease,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import {
   RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG,
@@ -76,14 +76,14 @@ describe("html shell release asset manifest consumption", () => {
   afterEach(() => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalFlag ?? "");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, originalDependencyFlag ?? "");
-    configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
   });
 
   it("is byte-identical with the flag off (no hashed URLs)", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() })
+    registerManifestFetcherForRelease(
+      "rel-1",
+      () => Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() }),
     );
 
     const withReleaseId = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
@@ -97,8 +97,9 @@ describe("html shell release asset manifest consumption", () => {
 
   it("emits a hashed asset URL for a covered page when the flag is on", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() })
+    registerManifestFetcherForRelease(
+      "rel-1",
+      () => Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() }),
     );
 
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
@@ -107,7 +108,6 @@ describe("html shell release asset manifest consumption", () => {
 
   it("version-stamps fallback module URLs when manifest lookup is enabled but unavailable", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(undefined);
 
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
 
@@ -117,7 +117,6 @@ describe("html shell release asset manifest consumption", () => {
 
   it("preserves release params when pinning fallback page and import-map modules", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(undefined);
 
     const result = await generateHTMLShellParts(
       meta(),
@@ -145,7 +144,7 @@ describe("html shell release asset manifest consumption", () => {
 
   it("uses manifest route closure preloads for index routes", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("rel-1", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -165,8 +164,7 @@ describe("html shell release asset manifest consumption", () => {
           },
           routes: { "/": { modules: ["pages/index.tsx", "components/Hero.tsx"], css: [] } },
         },
-      })
-    );
+      }));
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assertStringIncludes(result.start, `/_vf/assets/${COMPONENT_HASH}.js`);
   });
@@ -174,7 +172,7 @@ describe("html shell release asset manifest consumption", () => {
   it("emits the manifest CSS asset link when the manifest carries CSS", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     const CSS_HASH = "c".repeat(64);
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("rel-1", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -189,8 +187,7 @@ describe("html shell release asset manifest consumption", () => {
           }],
           routes: { "/": { modules: ["pages/index.tsx"], css: [CSS_HASH] } },
         },
-      })
-    );
+      }));
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assertStringIncludes(result.start, `/_vf/assets/${CSS_HASH}.css`);
     // The JIT project-CSS link is replaced, not duplicated.
@@ -199,7 +196,7 @@ describe("html shell release asset manifest consumption", () => {
 
   it("keeps covered HTTP import-map dependencies on CDN URLs by default", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("rel-1", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -213,8 +210,7 @@ describe("html shell release asset manifest consumption", () => {
             },
           },
         },
-      })
-    );
+      }));
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assertStringIncludes(result.start, `"react":"https://esm.sh/react@19.2.4`);
     assert(!result.start.includes(`"react":"/_vf/assets/${REACT_HASH}.js"`));
@@ -224,7 +220,7 @@ describe("html shell release asset manifest consumption", () => {
   it("rewrites covered HTTP import-map dependencies when explicitly enabled", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("rel-1", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -238,8 +234,7 @@ describe("html shell release asset manifest consumption", () => {
             },
           },
         },
-      })
-    );
+      }));
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assertStringIncludes(result.start, `"react":"/_vf/assets/${REACT_HASH}.js"`);
     assertStringIncludes(result.start, `"react-dom/client":"https://esm.sh/react-dom@19.2.4`);
@@ -247,7 +242,7 @@ describe("html shell release asset manifest consumption", () => {
 
   it("uses one ready manifest snapshot on a cold first render", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("rel-1", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -268,8 +263,7 @@ describe("html shell release asset manifest consumption", () => {
             },
           },
         },
-      })
-    );
+      }));
 
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assertStringIncludes(result.start, `/_vf/assets/${PAGE_HASH}.js`);
@@ -279,8 +273,9 @@ describe("html shell release asset manifest consumption", () => {
 
   it("treats an undefined manifest option as absent and fetches the ready manifest", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() })
+    registerManifestFetcherForRelease(
+      "rel-1",
+      () => Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() }),
     );
 
     const result = await generateHTMLShellParts(
@@ -298,7 +293,7 @@ describe("html shell release asset manifest consumption", () => {
 
   it("keeps covered framework import-map entries on the module-server path", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("rel-1", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -312,8 +307,7 @@ describe("html shell release asset manifest consumption", () => {
             },
           },
         },
-      })
-    );
+      }));
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assert(!result.start.includes(`/_vf/assets/${CHAT_HASH}.js`));
     const imports = extractImportMap(result.start);
@@ -326,8 +320,9 @@ describe("html shell release asset manifest consumption", () => {
 
   it("falls back to the existing URL for an uncovered page when the flag is on", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() })
+    registerManifestFetcherForRelease(
+      "rel-1",
+      () => Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() }),
     );
 
     const result = await generateHTMLShellParts(

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -49,13 +49,13 @@ function extractImportMap(html: string): Record<string, string> {
 
 function manifest(): ReleaseAssetManifest {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     projectId: "p",
     releaseId: "rel-1",
     releaseVersion: 1,
     manifestVersion: 1,
     builderVersion: "0.1.765",
-    sourceContentHash: "",
+    sourceContentHash: "a".repeat(64),
     createdAt: "2026-06-12T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
     modules: {
@@ -64,7 +64,7 @@ function manifest(): ReleaseAssetManifest {
     css: [],
     routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
     dependencies: {},
-    fallback: { mode: "jit", gaps: [] },
+    dependencyMode: "immutable",
   };
 }
 
@@ -83,7 +83,7 @@ describe("html shell release asset manifest consumption", () => {
   it("is byte-identical with the flag off (no hashed URLs)", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "");
     configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest: manifest() })
+      Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() })
     );
 
     const withReleaseId = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
@@ -98,7 +98,7 @@ describe("html shell release asset manifest consumption", () => {
   it("emits a hashed asset URL for a covered page when the flag is on", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest: manifest() })
+      Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() })
     );
 
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
@@ -148,6 +148,7 @@ describe("html shell release asset manifest consumption", () => {
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
         state: "ready",
+        manifest_version: 1,
         manifest: {
           ...manifest(),
           modules: {
@@ -176,13 +177,15 @@ describe("html shell release asset manifest consumption", () => {
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
         state: "ready",
+        manifest_version: 1,
         manifest: {
           ...manifest(),
           css: [{
             contentHash: CSS_HASH,
             size: 10,
             contentType: "text/css",
-            styleProfileHash: "sp",
+            styleProfileHash: "d".repeat(64),
+            cssPipelineIdentity: "tailwind-v4",
           }],
           routes: { "/": { modules: ["pages/index.tsx"], css: [CSS_HASH] } },
         },
@@ -199,6 +202,7 @@ describe("html shell release asset manifest consumption", () => {
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
         state: "ready",
+        manifest_version: 1,
         manifest: {
           ...manifest(),
           dependencies: {
@@ -223,6 +227,7 @@ describe("html shell release asset manifest consumption", () => {
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
         state: "ready",
+        manifest_version: 1,
         manifest: {
           ...manifest(),
           dependencies: {
@@ -245,13 +250,15 @@ describe("html shell release asset manifest consumption", () => {
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
         state: "ready",
+        manifest_version: 1,
         manifest: {
           ...manifest(),
           css: [{
             contentHash: "f".repeat(64),
             size: 10,
             contentType: "text/css",
-            styleProfileHash: "sp",
+            styleProfileHash: "d".repeat(64),
+            cssPipelineIdentity: "tailwind-v4",
           }],
           dependencies: {
             "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022": {
@@ -273,7 +280,7 @@ describe("html shell release asset manifest consumption", () => {
   it("treats an undefined manifest option as absent and fetches the ready manifest", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest: manifest() })
+      Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() })
     );
 
     const result = await generateHTMLShellParts(
@@ -294,6 +301,7 @@ describe("html shell release asset manifest consumption", () => {
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
         state: "ready",
+        manifest_version: 1,
         manifest: {
           ...manifest(),
           dependencies: {
@@ -319,7 +327,7 @@ describe("html shell release asset manifest consumption", () => {
   it("falls back to the existing URL for an uncovered page when the flag is on", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest: manifest() })
+      Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() })
     );
 
     const result = await generateHTMLShellParts(

--- a/src/html/hydration-script-builder/hydration-data-generator.test.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.test.ts
@@ -159,13 +159,13 @@ describe("hydration-data-generator", () => {
 
     it("includes release asset module URLs for hydration when a manifest is provided", () => {
       const manifest: ReleaseAssetManifest = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         projectId: "project-id",
         releaseId: "release-id",
         releaseVersion: 1,
         manifestVersion: 5,
         builderVersion: "0.1.784",
-        sourceContentHash: "",
+        sourceContentHash: "a".repeat(64),
         createdAt: "2026-06-13T00:00:00.000Z",
         assetBasePath: "/_vf/assets",
         modules: {
@@ -183,7 +183,7 @@ describe("hydration-data-generator", () => {
         css: [],
         routes: {},
         dependencies: {},
-        fallback: { mode: "jit", gaps: [] },
+        dependencyMode: "immutable",
       };
       const parsed = parseHydrationData(
         "page",
@@ -213,13 +213,13 @@ describe("hydration-data-generator", () => {
 
     it("includes App Router release asset module URLs for hydration", () => {
       const manifest: ReleaseAssetManifest = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         projectId: "project-id",
         releaseId: "release-id",
         releaseVersion: 1,
         manifestVersion: 5,
         builderVersion: "0.1.1156",
-        sourceContentHash: "",
+        sourceContentHash: "a".repeat(64),
         createdAt: "2026-07-27T00:00:00.000Z",
         assetBasePath: "/_vf/assets",
         modules: {
@@ -239,7 +239,7 @@ describe("hydration-data-generator", () => {
           "/": { modules: ["app/page.tsx", "app/layout.tsx"], css: [] },
         },
         dependencies: {},
-        fallback: { mode: "jit", gaps: [] },
+        dependencyMode: "immutable",
       };
       const parsed = parseHydrationData(
         "page",

--- a/src/html/utils.test.ts
+++ b/src/html/utils.test.ts
@@ -399,7 +399,7 @@ describe("html-generation/utils", () => {
     });
 
     it("keeps React import-map aliases on CDN URLs by default", async () => {
-      const dependencies = Object.fromEntries(
+      const dependencies: ReleaseAssetManifest["dependencies"] = Object.fromEntries(
         [
           "react",
           "react-dom",
@@ -416,20 +416,20 @@ describe("html-generation/utils", () => {
         ]),
       );
       const manifest: ReleaseAssetManifest = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         projectId: "project-id",
         releaseId: "release-id",
         releaseVersion: 1,
         manifestVersion: 1,
         builderVersion: "0.1.802",
-        sourceContentHash: "source",
+        sourceContentHash: "a".repeat(64),
         createdAt: "2026-06-14T00:00:00.000Z",
         assetBasePath: "/_vf/assets",
         modules: {},
         css: [],
         routes: {},
         dependencies,
-        fallback: { mode: "jit", gaps: [] },
+        dependencyMode: "immutable",
       };
 
       const result = await buildImportMapJson({
@@ -447,7 +447,7 @@ describe("html-generation/utils", () => {
 
     it("rewrites React import-map aliases from manifest dependency keys when explicitly enabled", async () => {
       setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
-      const dependencies = Object.fromEntries(
+      const dependencies: ReleaseAssetManifest["dependencies"] = Object.fromEntries(
         [
           "react",
           "react-dom",
@@ -464,20 +464,20 @@ describe("html-generation/utils", () => {
         ]),
       );
       const manifest: ReleaseAssetManifest = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         projectId: "project-id",
         releaseId: "release-id",
         releaseVersion: 1,
         manifestVersion: 1,
         builderVersion: "0.1.802",
-        sourceContentHash: "source",
+        sourceContentHash: "a".repeat(64),
         createdAt: "2026-06-14T00:00:00.000Z",
         assetBasePath: "/_vf/assets",
         modules: {},
         css: [],
         routes: {},
         dependencies,
-        fallback: { mode: "jit", gaps: [] },
+        dependencyMode: "immutable",
       };
 
       const result = await buildImportMapJson({
@@ -498,13 +498,13 @@ describe("html-generation/utils", () => {
       const headHash = "a".repeat(64);
       const workflowHash = "b".repeat(64);
       const manifest: ReleaseAssetManifest = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         projectId: "project-id",
         releaseId: "release-id",
         releaseVersion: 1,
         manifestVersion: 1,
         builderVersion: "0.1.810",
-        sourceContentHash: "source",
+        sourceContentHash: "a".repeat(64),
         createdAt: "2026-06-15T00:00:00.000Z",
         assetBasePath: "/_vf/assets",
         modules: {},
@@ -527,7 +527,7 @@ describe("html-generation/utils", () => {
             contentType: "text/javascript",
           },
         },
-        fallback: { mode: "jit", gaps: [] },
+        dependencyMode: "immutable",
       };
 
       const result = await buildImportMapJson({
@@ -543,20 +543,20 @@ describe("html-generation/utils", () => {
 
     it("versions local module-server import-map aliases in release manifest context", async () => {
       const manifest: ReleaseAssetManifest = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         projectId: "project-id",
         releaseId: "release-id",
         releaseVersion: 1,
         manifestVersion: 1,
         builderVersion: "0.1.810",
-        sourceContentHash: "source",
+        sourceContentHash: "a".repeat(64),
         createdAt: "2026-06-15T00:00:00.000Z",
         assetBasePath: "/_vf/assets",
         modules: {},
         css: [],
         routes: {},
         dependencies: {},
-        fallback: { mode: "jit", gaps: [] },
+        dependencyMode: "immutable",
       };
 
       const result = await buildImportMapJson({
@@ -574,20 +574,20 @@ describe("html-generation/utils", () => {
 
     it("preserves release query params when pinning local import-map aliases", async () => {
       const manifest: ReleaseAssetManifest = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         projectId: "project-id",
         releaseId: "release-id",
         releaseVersion: 1,
         manifestVersion: 1,
         builderVersion: "0.1.810",
-        sourceContentHash: "source",
+        sourceContentHash: "a".repeat(64),
         createdAt: "2026-06-15T00:00:00.000Z",
         assetBasePath: "/_vf/assets",
         modules: {},
         css: [],
         routes: {},
         dependencies: {},
-        fallback: { mode: "jit", gaps: [] },
+        dependencyMode: "immutable",
       };
 
       const result = await buildImportMapJson({

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -91,6 +91,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     deleteEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG);
     deleteEnv(DEPENDENCY_PINNING_ENV_FLAG);
     deleteEnv("VERYFRONT_ENABLE_SERVER_TIMING");
+    deleteEnv("VERYFRONT_CACHE_DIR");
     configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
     clearReleaseModuleResponseCache();
@@ -127,22 +128,26 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     return match?.[1] ?? "";
   }
 
-  function manifest(dependencies: ReleaseAssetManifest["dependencies"]): ReleaseAssetManifest {
+  function manifest(
+    dependencies: ReleaseAssetManifest["dependencies"],
+    releaseId = "release-id",
+    dependencyMode: ReleaseAssetManifest["dependencyMode"] = "immutable",
+  ): ReleaseAssetManifest {
     return {
       schemaVersion: RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
       projectId: "project-id",
-      releaseId: "release-id",
+      releaseId,
       releaseVersion: 1,
       manifestVersion: 1,
       builderVersion: "test",
-      sourceContentHash: "source",
+      sourceContentHash: "a".repeat(64),
       createdAt: new Date(0).toISOString(),
       assetBasePath: "/_vf/assets",
       modules: {},
       css: [],
       routes: {},
+      dependencyMode,
       dependencies,
-      fallback: { mode: "jit", gaps: [] },
     };
   }
 
@@ -685,7 +690,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     );
 
     configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "building", manifest: null })
+      Promise.resolve({ state: "building", manifest_version: 1, manifest: null })
     );
 
     async function serveWithProfile(): Promise<{
@@ -859,6 +864,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const projectDir = await Deno.makeTempDir({ prefix: "vf-module-release-assets-" });
     const cacheDir = await Deno.makeTempDir({ prefix: "vf-module-cache-" });
+    setEnv("VERYFRONT_CACHE_DIR", cacheDir);
     const dependencyDir = `${cacheDir}/veryfront-http-bundle`;
     const dependencyPath = `${dependencyDir}/http-123abc.mjs`;
     const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
@@ -878,6 +884,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       configureReleaseAssetManifestFetcher(() =>
         Promise.resolve({
           state: "ready",
+          manifest_version: 1,
           manifest: manifest({
             [sourceUrl]: {
               contentHash: hash,
@@ -909,12 +916,13 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     }
   });
 
-  it("caches dependency-bearing release modules with partial manifest bodies", async () => {
+  it("rejects partial manifests and keeps dependency-bearing modules uncached", async () => {
     setEnv("VERYFRONT_ENABLE_SERVER_TIMING", "1");
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const projectDir = await Deno.makeTempDir({ prefix: "vf-module-partial-manifest-" });
     const cacheDir = await Deno.makeTempDir({ prefix: "vf-module-partial-cache-" });
+    setEnv("VERYFRONT_CACHE_DIR", cacheDir);
     const dependencyDir = `${cacheDir}/veryfront-http-bundle`;
     const dependencyPath = `${dependencyDir}/http-123abc.mjs`;
     const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
@@ -938,13 +946,14 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       configureReleaseAssetManifestFetcher(() =>
         Promise.resolve({
           state: "partial",
+          manifest_version: 1,
           manifest: manifest({
             [sourceUrl]: {
               contentHash: hash,
               size: 100,
               contentType: "text/javascript",
             },
-          }),
+          }, releaseId),
         })
       );
 
@@ -953,14 +962,17 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
 
       assertEquals(first.status, 200);
       assertEquals(second.status, 200);
-      assertEquals(first.cacheControl, "public, max-age=31536000, immutable");
-      assertEquals(second.cacheControl, "public, max-age=31536000, immutable");
-      assertStringIncludes(first.body, `"/_vf/assets/${hash}.js"`);
+      assertEquals(first.cacheControl, "no-cache");
+      assertEquals(second.cacheControl, "no-cache");
+      assertEquals(first.body.includes(`"/_vf/assets/${hash}.js"`), false);
+      assertStringIncludes(first.body, sourceUrl);
       assertEquals(first.body.includes("file://"), false);
+      assertStringIncludes(second.body, sourceUrl);
+      assertEquals(second.body.includes("file://"), false);
       assertEquals(second.body, first.body);
       assertEquals(first.record.phases["release_manifest.fetch_partial"], 0);
-      assertEquals(second.record.phases["module.response_cache_hit"], 0);
-      assertEquals("module.source_lookup" in second.record.phases, false);
+      assertEquals("module.response_cache_hit" in second.record.phases, false);
+      assertEquals(Boolean(second.record.phases["module.source_lookup"]), true);
     } finally {
       await Deno.remove(projectDir, { recursive: true });
       await Deno.remove(cacheDir, { recursive: true });
@@ -973,6 +985,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const projectDir = await Deno.makeTempDir({ prefix: "vf-module-manifest-miss-" });
     const cacheDir = await Deno.makeTempDir({ prefix: "vf-module-manifest-miss-cache-" });
+    setEnv("VERYFRONT_CACHE_DIR", cacheDir);
     const dependencyDir = `${cacheDir}/veryfront-http-bundle`;
     const dependencyPath = `${dependencyDir}/http-123abc.mjs`;
     const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
@@ -993,7 +1006,11 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
         `import React from ${JSON.stringify(`file://${dependencyPath}`)};\nexport default React;\n`,
       );
       configureReleaseAssetManifestFetcher(() =>
-        Promise.resolve({ state: "ready", manifest: manifest({}) })
+        Promise.resolve({
+          state: "ready",
+          manifest_version: 1,
+          manifest: manifest({}, releaseId, "source"),
+        })
       );
 
       const first = await serveProductionModuleWithProfile(request, projectDir, releaseId);
@@ -1864,6 +1881,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const projectDir = await Deno.makeTempDir({ prefix: "vf-module-release-cache-gate-" });
     const cacheDir = await Deno.makeTempDir({ prefix: "vf-module-cache-gate-" });
+    setEnv("VERYFRONT_CACHE_DIR", cacheDir);
     const dependencyDir = `${cacheDir}/veryfront-http-bundle`;
     const dependencyPath = `${dependencyDir}/http-123abc.mjs`;
     const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
@@ -1922,15 +1940,16 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
           ready
             ? {
               state: "ready",
+              manifest_version: 1,
               manifest: manifest({
                 [sourceUrl]: {
                   contentHash: hash,
                   size: 100,
                   contentType: "text/javascript",
                 },
-              }),
+              }, releaseId),
             }
-            : { state: "building", manifest: null },
+            : { state: "building", manifest_version: 1, manifest: null },
         )
       );
 

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -33,7 +33,7 @@ import {
 import {
   clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
+  registerManifestFetcherForRelease,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import {
@@ -92,7 +92,6 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     deleteEnv(DEPENDENCY_PINNING_ENV_FLAG);
     deleteEnv("VERYFRONT_ENABLE_SERVER_TIMING");
     deleteEnv("VERYFRONT_CACHE_DIR");
-    configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
     clearReleaseModuleResponseCache();
     clearImportMapCache();
@@ -689,8 +688,9 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       `http://localhost:3000/_vf_modules/components/App.js?vf_release=${releaseId}&vf_runtime=${VERSION}`,
     );
 
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "building", manifest_version: 1, manifest: null })
+    registerManifestFetcherForRelease(
+      releaseId,
+      () => Promise.resolve({ state: "building", manifest_version: 1, manifest: null }),
     );
 
     async function serveWithProfile(): Promise<{
@@ -881,7 +881,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
         `${projectDir}/components/App.tsx`,
         `import React from ${JSON.stringify(`file://${dependencyPath}`)};\nexport default React;\n`,
       );
-      configureReleaseAssetManifestFetcher(() =>
+      registerManifestFetcherForRelease("release-id", () =>
         Promise.resolve({
           state: "ready",
           manifest_version: 1,
@@ -892,8 +892,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
               contentType: "text/javascript",
             },
           }),
-        })
-      );
+        }));
 
       const { serveModule } = await import("./module-server.ts");
       const response = await serveModule(
@@ -943,7 +942,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
         `${projectDir}/components/App.tsx`,
         `import React from ${JSON.stringify(`file://${dependencyPath}`)};\nexport default React;\n`,
       );
-      configureReleaseAssetManifestFetcher(() =>
+      registerManifestFetcherForRelease(releaseId, () =>
         Promise.resolve({
           state: "partial",
           manifest_version: 1,
@@ -954,8 +953,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
               contentType: "text/javascript",
             },
           }, releaseId),
-        })
-      );
+        }));
 
       const first = await serveProductionModuleWithProfile(request, projectDir, releaseId);
       const second = await serveProductionModuleWithProfile(request, projectDir, releaseId);
@@ -1005,13 +1003,12 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
         `${projectDir}/components/App.tsx`,
         `import React from ${JSON.stringify(`file://${dependencyPath}`)};\nexport default React;\n`,
       );
-      configureReleaseAssetManifestFetcher(() =>
+      registerManifestFetcherForRelease(releaseId, () =>
         Promise.resolve({
           state: "ready",
           manifest_version: 1,
           manifest: manifest({}, releaseId, "source"),
-        })
-      );
+        }));
 
       const first = await serveProductionModuleWithProfile(request, projectDir, releaseId);
       const second = await serveProductionModuleWithProfile(request, projectDir, releaseId);
@@ -1935,7 +1932,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
         `${projectDir}/components/App.tsx`,
         `import React from ${JSON.stringify(`file://${dependencyPath}`)};\nexport default React;\n`,
       );
-      configureReleaseAssetManifestFetcher(() =>
+      registerManifestFetcherForRelease(releaseId, () =>
         Promise.resolve(
           ready
             ? {
@@ -1950,8 +1947,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
               }, releaseId),
             }
             : { state: "building", manifest_version: 1, manifest: null },
-        )
-      );
+        ));
 
       const first = await serveWithProfile();
       ready = true;

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -70,6 +70,7 @@ import {
   extractDependencyPinningPathKey,
 } from "#veryfront/transforms/import-rewriter/url-builder.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
+import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 
 const logger = serverLogger.component("module-server");
 const PROJECT_FALLBACK_EMBEDDED_POLYFILLS = new Set(["deno"]);
@@ -342,6 +343,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         },
       });
       const platformFs = createFileSystem();
+      const dependencyCacheRoot = getHttpBundleCacheDir();
 
       const debugUserAgent = req.headers.get("user-agent") ?? "";
       logger.debug("Request", {
@@ -431,6 +433,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
             },
             releaseRewriteOptions: {
               releaseId: options.releaseId,
+              dependencyCacheRoot,
               readDependencySource: (path) => platformFs.readTextFile(path),
             },
             profile: true,
@@ -538,6 +541,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
             },
             releaseRewriteOptions: {
               releaseId: options.releaseId,
+              dependencyCacheRoot,
               readDependencySource: (path) => platformFs.readTextFile(path),
             },
             profile: true,
@@ -750,6 +754,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
               releaseId: options.releaseId,
               manifest: releaseDependencyRewriteEnabled ? releaseDependencyManifest : undefined,
               manifestReadOptions: { refreshCachedNull: true },
+              dependencyCacheRoot,
               readDependencySource: (path) => platformFs.readTextFile(path),
             },
             profile: true,

--- a/src/modules/server/module-transform.test.ts
+++ b/src/modules/server/module-transform.test.ts
@@ -112,6 +112,7 @@ describe(
           isSSR: false,
           releaseRewriteOptions: {
             releaseId: null, // null → rewriteReleaseDependencyImportsForModule returns early
+            dependencyCacheRoot: projectDir,
             readDependencySource: (_path) => Promise.resolve(""),
           },
         });

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   clearReleaseAssetManifestCache,
   getReadyManifestForRender,
+  getReadyManifestForRenderAsync,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
 
@@ -368,6 +369,41 @@ describe("VeryfrontFSAdapter", () => {
       assertEquals(getReadyManifestForRender(releaseId), null);
       await waitFor(async () => getReadyManifestForRender(releaseId)?.manifestVersion === 2);
       assertEquals(fetchCount, 1);
+    });
+
+    it("should stop awaiting a manifest request when the release context loses ownership", async () => {
+      setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+      const releaseId = "release-env-abort";
+      const adapter = createAdapter();
+      let requestStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        requestStarted = resolve;
+      });
+      const neverSettles = new Promise<never>(() => {});
+
+      (adapter.getClient() as unknown as {
+        getReleaseAssetManifest: (releaseId: string) => Promise<never>;
+      }).getReleaseAssetManifest = (requestedReleaseId: string) => {
+        assertEquals(requestedReleaseId, releaseId);
+        requestStarted();
+        return neverSettles;
+      };
+
+      adapter.setContentContext({
+        sourceType: "release",
+        projectSlug: "test-project",
+        releaseId,
+      });
+      const manifest = getReadyManifestForRenderAsync(releaseId);
+      await started;
+
+      adapter.setContentContext({
+        sourceType: "release",
+        projectSlug: "test-project",
+        releaseId: "release-env-next",
+      });
+
+      assertEquals(await manifest, null);
     });
 
     it("should register a release asset manifest fetcher when initialize resolves the release id", async () => {

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -380,11 +380,17 @@ describe("VeryfrontFSAdapter", () => {
         requestStarted = resolve;
       });
       const neverSettles = new Promise<never>(() => {});
+      let requestSignal: AbortSignal | undefined;
 
       (adapter.getClient() as unknown as {
-        getReleaseAssetManifest: (releaseId: string) => Promise<never>;
-      }).getReleaseAssetManifest = (requestedReleaseId: string) => {
+        getReleaseAssetManifest: (
+          releaseId: string,
+          projectRef?: string,
+          signal?: AbortSignal,
+        ) => Promise<never>;
+      }).getReleaseAssetManifest = (requestedReleaseId, _projectRef, signal) => {
         assertEquals(requestedReleaseId, releaseId);
+        requestSignal = signal;
         requestStarted();
         return neverSettles;
       };
@@ -403,6 +409,7 @@ describe("VeryfrontFSAdapter", () => {
         releaseId: "release-env-next",
       });
 
+      assertEquals(requestSignal?.aborted, true);
       assertEquals(await manifest, null);
     });
 

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -332,16 +332,18 @@ describe("VeryfrontFSAdapter", () => {
         assertEquals(requestedReleaseId, releaseId);
         return {
           state: "ready",
+          manifest_version: 2,
           manifest: {
-            schemaVersion: 1,
+            schemaVersion: 2,
             projectId: "project-123",
             releaseId,
             releaseVersion: 1,
             manifestVersion: 2,
             builderVersion: "0.1.765",
-            sourceContentHash: "",
+            sourceContentHash: "a".repeat(64),
             createdAt: "2026-06-12T00:00:00.000Z",
             assetBasePath: "/_vf/assets",
+            dependencyMode: "source",
             modules: {
               "pages/index.tsx": {
                 contentHash,
@@ -352,7 +354,6 @@ describe("VeryfrontFSAdapter", () => {
             css: [],
             routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
             dependencies: {},
-            fallback: { mode: "jit", gaps: [] },
           },
         };
       };
@@ -429,16 +430,18 @@ describe("VeryfrontFSAdapter", () => {
         assertEquals(requestedReleaseId, releaseId);
         return {
           state: "ready",
+          manifest_version: 3,
           manifest: {
-            schemaVersion: 1,
+            schemaVersion: 2,
             projectId: "project-123",
             releaseId,
             releaseVersion: 1,
             manifestVersion: 3,
             builderVersion: "0.1.792",
-            sourceContentHash: "",
+            sourceContentHash: "a".repeat(64),
             createdAt: "2026-06-12T00:00:00.000Z",
             assetBasePath: "/_vf/assets",
+            dependencyMode: "source",
             modules: {
               "pages/index.tsx": {
                 contentHash,
@@ -449,7 +452,6 @@ describe("VeryfrontFSAdapter", () => {
             css: [],
             routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
             dependencies: {},
-            fallback: { mode: "jit", gaps: [] },
           },
         };
       };
@@ -482,16 +484,18 @@ describe("VeryfrontFSAdapter", () => {
         assertEquals(requestedReleaseId, releaseId);
         return {
           state: "ready",
+          manifest_version: 1,
           manifest: {
-            schemaVersion: 1,
+            schemaVersion: 2,
             projectId: "project-123",
             releaseId,
             releaseVersion: 1,
             manifestVersion: 1,
             builderVersion: "0.1.765",
-            sourceContentHash: "",
+            sourceContentHash: "a".repeat(64),
             createdAt: "2026-06-12T00:00:00.000Z",
             assetBasePath: "/_vf/assets",
+            dependencyMode: "source",
             modules: {
               "pages/index.tsx": {
                 contentHash,
@@ -502,7 +506,6 @@ describe("VeryfrontFSAdapter", () => {
             css: [],
             routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
             dependencies: {},
-            fallback: { mode: "jit", gaps: [] },
           },
         };
       };

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -46,9 +46,9 @@ import { requireBoundedFileReadLimit } from "../../bounded-file-read.ts";
 import {
   clearCachedReleaseAssetManifests,
   registerManifestFetcherForRelease,
-  unregisterManifestFetcherForRelease,
+  type ReleaseAssetManifestFetcher,
+  type ReleaseAssetManifestFetcherCleanup,
 } from "#veryfront/release-assets/manifest-cache.ts";
-import { parseReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 const logger = baseLogger.component("veryfront-fs-adapter");
 const BRANCH_MISS_RECOVERY_FAILURE_TTL_MS = 5_000;
@@ -105,16 +105,8 @@ interface BranchSnapshotRecoveryOptions<T> {
  */
 function buildManifestFetcher(
   client: VeryfrontApiClient,
-): (
-  releaseId: string,
-) => Promise<{ state: string; manifest: ReturnType<typeof parseReleaseAssetManifest> } | null> {
-  return async (releaseId: string) => {
-    const response = await client.getReleaseAssetManifest(releaseId);
-    return {
-      state: response.state,
-      manifest: response.manifest ? parseReleaseAssetManifest(response.manifest) : null,
-    };
-  };
+): ReleaseAssetManifestFetcher {
+  return (releaseId: string) => client.getReleaseAssetManifest(releaseId);
 }
 
 export class VeryfrontFSAdapter implements FSAdapter {
@@ -154,6 +146,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private invalidationCallbacks: InvalidationCallbacks;
   private styleCallbacks: StyleCallbacks;
   private wsManager: WebSocketManager;
+  private manifestFetcherCleanup: ReleaseAssetManifestFetcherCleanup | null = null;
 
   /** Per-request branch override (for branch preview URLs) */
   private requestBranch: string | null = null;
@@ -1013,6 +1006,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   dispose(): void {
     this.wsManager.dispose();
+    this.manifestFetcherCleanup?.();
+    this.manifestFetcherCleanup = null;
     this.cache.clear();
     this.statOps.clearIndex();
     this.dirOps.clearTree();
@@ -1157,21 +1152,20 @@ export class VeryfrontFSAdapter implements FSAdapter {
       contextWillChange: contextChanged,
     });
 
-    const oldReleaseId = oldContext?.releaseId;
     const nextReleaseId = context.releaseId;
 
-    // Unregister the manifest fetcher for the previous release (if any).
-    // Environment/domain contexts can also carry a deployed releaseId.
-    if (oldReleaseId && oldReleaseId !== nextReleaseId) {
-      unregisterManifestFetcherForRelease(oldReleaseId);
-    }
+    this.manifestFetcherCleanup?.();
+    this.manifestFetcherCleanup = null;
 
     // Register a per-releaseId manifest fetcher so production HTML can
     // consult ready manifests when the feature flag is on. Using the per-
     // releaseId registry ensures the correct project-scoped token is always
     // used, even under multi-tenant / proxy-manager operation.
     if (nextReleaseId) {
-      registerManifestFetcherForRelease(nextReleaseId, buildManifestFetcher(this.client));
+      this.manifestFetcherCleanup = registerManifestFetcherForRelease(
+        nextReleaseId,
+        buildManifestFetcher(this.client),
+      );
     }
 
     this.contentContext = context;

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -106,7 +106,33 @@ interface BranchSnapshotRecoveryOptions<T> {
 function buildManifestFetcher(
   client: VeryfrontApiClient,
 ): ReleaseAssetManifestFetcher {
-  return (releaseId: string) => client.getReleaseAssetManifest(releaseId);
+  return (releaseId: string, context) => {
+    const request = client.getReleaseAssetManifest(releaseId);
+    if (context.signal.aborted) {
+      return Promise.reject(manifestFetchAbortReason(context.signal));
+    }
+
+    return new Promise((resolve, reject) => {
+      const onAbort = () => reject(manifestFetchAbortReason(context.signal));
+      context.signal.addEventListener("abort", onAbort, { once: true });
+      request.then(
+        (result) => {
+          context.signal.removeEventListener("abort", onAbort);
+          resolve(result);
+        },
+        (error) => {
+          context.signal.removeEventListener("abort", onAbort);
+          reject(error);
+        },
+      );
+    });
+  };
+}
+
+function manifestFetchAbortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error("Release manifest fetch aborted");
 }
 
 export class VeryfrontFSAdapter implements FSAdapter {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -106,33 +106,8 @@ interface BranchSnapshotRecoveryOptions<T> {
 function buildManifestFetcher(
   client: VeryfrontApiClient,
 ): ReleaseAssetManifestFetcher {
-  return (releaseId: string, context) => {
-    const request = client.getReleaseAssetManifest(releaseId);
-    if (context.signal.aborted) {
-      return Promise.reject(manifestFetchAbortReason(context.signal));
-    }
-
-    return new Promise((resolve, reject) => {
-      const onAbort = () => reject(manifestFetchAbortReason(context.signal));
-      context.signal.addEventListener("abort", onAbort, { once: true });
-      request.then(
-        (result) => {
-          context.signal.removeEventListener("abort", onAbort);
-          resolve(result);
-        },
-        (error) => {
-          context.signal.removeEventListener("abort", onAbort);
-          reject(error);
-        },
-      );
-    });
-  };
-}
-
-function manifestFetchAbortReason(signal: AbortSignal): Error {
-  return signal.reason instanceof Error
-    ? signal.reason
-    : new Error("Release manifest fetch aborted");
+  return (releaseId: string, context) =>
+    client.getReleaseAssetManifest(releaseId, undefined, context.signal);
 }
 
 export class VeryfrontFSAdapter implements FSAdapter {

--- a/src/platform/adapters/veryfront-api-client/client.ts
+++ b/src/platform/adapters/veryfront-api-client/client.ts
@@ -468,8 +468,12 @@ export class VeryfrontApiClient {
     return this.operations.reportReleaseAssetManifestState(projectRef, version, state, error);
   }
 
-  getReleaseAssetManifest(version: string, projectRef = this.requireProjectSlug()) {
-    return this.operations.getReleaseAssetManifest(projectRef, version);
+  getReleaseAssetManifest(
+    version: string,
+    projectRef = this.requireProjectSlug(),
+    signal?: AbortSignal,
+  ) {
+    return this.operations.getReleaseAssetManifest(projectRef, version, signal);
   }
 
   // =============================================================================

--- a/src/platform/adapters/veryfront-api-client/operations.test.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.test.ts
@@ -545,6 +545,53 @@ describe("VeryfrontAPIOperations", () => {
       assertEquals(fetchCalls, 1);
     });
 
+    it("propagates caller cancellation when AbortSignal.any is unavailable", async () => {
+      const anyDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+      Object.defineProperty(AbortSignal, "any", {
+        configurable: true,
+        value: undefined,
+        writable: true,
+      });
+      try {
+        let observedSignal: AbortSignal | undefined;
+        let markStarted!: () => void;
+        const started = new Promise<void>((resolve) => {
+          markStarted = resolve;
+        });
+        globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+          observedSignal = init?.signal ?? undefined;
+          markStarted();
+          return new Promise<Response>((_resolve, reject) => {
+            observedSignal?.addEventListener(
+              "abort",
+              () => reject(observedSignal?.reason),
+              { once: true },
+            );
+          });
+        }) as typeof fetch;
+        const transport = createVeryfrontApiTransport<unknown>({
+          baseUrl: "https://api.example.com",
+          getToken: () => "token",
+          retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
+        });
+        const controller = new AbortController();
+        const cancellation = new Error("compat cancellation");
+        const request = transport.request("/cancelled", { signal: controller.signal });
+        await started;
+
+        controller.abort(cancellation);
+
+        assertEquals(observedSignal?.reason, cancellation);
+        await assertRejects(() => request, Error, "compat cancellation");
+      } finally {
+        if (anyDescriptor === undefined) {
+          Reflect.deleteProperty(AbortSignal, "any");
+        } else {
+          Object.defineProperty(AbortSignal, "any", anyDescriptor);
+        }
+      }
+    });
+
     it("reserves worst-case JSON escape bytes outside the non-value response budget", async () => {
       const body = '{"content":"\\u0000\\u0000"}';
       assertEquals(new TextEncoder().encode(body).byteLength, 26);

--- a/src/platform/adapters/veryfront-api-client/operations.test.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.test.ts
@@ -513,6 +513,38 @@ describe("VeryfrontAPIOperations", () => {
   });
 
   describe("bounded transport failures", () => {
+    it("propagates caller cancellation to the active fetch without retrying", async () => {
+      let fetchCalls = 0;
+      let requestStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        requestStarted = resolve;
+      });
+      globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+        fetchCalls++;
+        const signal = init?.signal;
+        requestStarted();
+        return new Promise<Response>((_resolve, reject) => {
+          if (!signal) return;
+          const rejectAbort = () => reject(signal.reason);
+          if (signal.aborted) rejectAbort();
+          else signal.addEventListener("abort", rejectAbort, { once: true });
+        });
+      }) as typeof fetch;
+      const transport = createVeryfrontApiTransport<unknown>({
+        baseUrl: "https://api.example.com",
+        getToken: () => "token",
+        retry: { maxRetries: 2, initialDelay: 0, maxDelay: 0 },
+      });
+      const controller = new AbortController();
+      const request = transport.request("/cancelled", { signal: controller.signal });
+      await started;
+
+      controller.abort(new Error("caller cancelled"));
+
+      await assertRejects(() => request, Error, "caller cancelled");
+      assertEquals(fetchCalls, 1);
+    });
+
     it("reserves worst-case JSON escape bytes outside the non-value response budget", async () => {
       const body = '{"content":"\\u0000\\u0000"}';
       assertEquals(new TextEncoder().encode(body).byteLength, 26);

--- a/src/platform/adapters/veryfront-api-client/operations.test.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.test.ts
@@ -39,6 +39,55 @@ function assertMethodExists<T extends object>(obj: T, key: keyof T): void {
   assertEquals(typeof value, "function");
 }
 
+async function withoutAbortSignalAny<T>(operation: () => Promise<T>): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+  Object.defineProperty(AbortSignal, "any", {
+    configurable: true,
+    value: undefined,
+    writable: true,
+  });
+  try {
+    return await operation();
+  } finally {
+    if (descriptor === undefined) Reflect.deleteProperty(AbortSignal, "any");
+    else Object.defineProperty(AbortSignal, "any", descriptor);
+  }
+}
+
+function observeAbortListenerBalance(signal: AbortSignal): {
+  readonly counts: { added: number; removed: number };
+  restore(): void;
+} {
+  const addDescriptor = Object.getOwnPropertyDescriptor(signal, "addEventListener");
+  const removeDescriptor = Object.getOwnPropertyDescriptor(signal, "removeEventListener");
+  const addEventListener = signal.addEventListener.bind(signal);
+  const removeEventListener = signal.removeEventListener.bind(signal);
+  const counts = { added: 0, removed: 0 };
+  Object.defineProperty(signal, "addEventListener", {
+    configurable: true,
+    value: ((...args: Parameters<AbortSignal["addEventListener"]>) => {
+      if (args[0] === "abort") counts.added++;
+      return addEventListener(...args);
+    }) as AbortSignal["addEventListener"],
+  });
+  Object.defineProperty(signal, "removeEventListener", {
+    configurable: true,
+    value: ((...args: Parameters<AbortSignal["removeEventListener"]>) => {
+      if (args[0] === "abort") counts.removed++;
+      return removeEventListener(...args);
+    }) as AbortSignal["removeEventListener"],
+  });
+  return {
+    counts,
+    restore() {
+      if (addDescriptor === undefined) Reflect.deleteProperty(signal, "addEventListener");
+      else Object.defineProperty(signal, "addEventListener", addDescriptor);
+      if (removeDescriptor === undefined) Reflect.deleteProperty(signal, "removeEventListener");
+      else Object.defineProperty(signal, "removeEventListener", removeDescriptor);
+    },
+  };
+}
+
 describe("VeryfrontAPIOperations", () => {
   const originalFetch = globalThis.fetch;
 
@@ -546,13 +595,7 @@ describe("VeryfrontAPIOperations", () => {
     });
 
     it("propagates caller cancellation when AbortSignal.any is unavailable", async () => {
-      const anyDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
-      Object.defineProperty(AbortSignal, "any", {
-        configurable: true,
-        value: undefined,
-        writable: true,
-      });
-      try {
+      await withoutAbortSignalAny(async () => {
         let observedSignal: AbortSignal | undefined;
         let markStarted!: () => void;
         const started = new Promise<void>((resolve) => {
@@ -575,21 +618,98 @@ describe("VeryfrontAPIOperations", () => {
           retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
         });
         const controller = new AbortController();
-        const cancellation = new Error("compat cancellation");
-        const request = transport.request("/cancelled", { signal: controller.signal });
-        await started;
+        const observation = observeAbortListenerBalance(controller.signal);
+        try {
+          const cancellation = new Error("compat cancellation");
+          const request = transport.request("/cancelled", { signal: controller.signal });
+          await started;
 
-        controller.abort(cancellation);
+          controller.abort(cancellation);
 
-        assertEquals(observedSignal?.reason, cancellation);
-        await assertRejects(() => request, Error, "compat cancellation");
-      } finally {
-        if (anyDescriptor === undefined) {
-          Reflect.deleteProperty(AbortSignal, "any");
-        } else {
-          Object.defineProperty(AbortSignal, "any", anyDescriptor);
+          assertEquals(observedSignal?.reason, cancellation);
+          await assertRejects(() => request, Error, "compat cancellation");
+          assertEquals(observation.counts, { added: 1, removed: 1 });
+        } finally {
+          observation.restore();
         }
-      }
+      });
+    });
+
+    it("detaches compatibility listeners after a successful request", async () => {
+      await withoutAbortSignalAny(async () => {
+        globalThis.fetch = (() => Promise.resolve(new Response("{}"))) as typeof fetch;
+        const caller = new AbortController();
+        const observation = observeAbortListenerBalance(caller.signal);
+        try {
+          const transport = createVeryfrontApiTransport<unknown>({
+            baseUrl: "https://api.example.com",
+            getToken: () => "token",
+            retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
+            timeoutMs: 1_000,
+          });
+
+          await transport.request("/ok", { signal: caller.signal });
+
+          assertEquals(observation.counts, { added: 1, removed: 1 });
+        } finally {
+          observation.restore();
+        }
+      });
+    });
+
+    it("detaches compatibility listeners after a non-abort failure", async () => {
+      await withoutAbortSignalAny(async () => {
+        globalThis.fetch = (() => Promise.reject(new Error("network failed"))) as typeof fetch;
+        const caller = new AbortController();
+        const observation = observeAbortListenerBalance(caller.signal);
+        try {
+          const transport = createVeryfrontApiTransport<unknown>({
+            baseUrl: "https://api.example.com",
+            getToken: () => "token",
+            retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
+            timeoutMs: 1_000,
+          });
+
+          await assertRejects(
+            () => transport.request("/failed", { signal: caller.signal }),
+            VeryfrontError,
+            "network failed",
+          );
+
+          assertEquals(observation.counts, { added: 1, removed: 1 });
+        } finally {
+          observation.restore();
+        }
+      });
+    });
+
+    it("balances compatibility listeners across retry attempts", async () => {
+      await withoutAbortSignalAny(async () => {
+        let fetchCalls = 0;
+        globalThis.fetch = (() => {
+          fetchCalls++;
+          return fetchCalls === 1
+            ? Promise.reject(new Error("retryable failure"))
+            : Promise.resolve(new Response("{}"));
+        }) as typeof fetch;
+        const caller = new AbortController();
+        const observation = observeAbortListenerBalance(caller.signal);
+        try {
+          const transport = createVeryfrontApiTransport<unknown>({
+            baseUrl: "https://api.example.com",
+            getToken: () => "token",
+            retry: { maxRetries: 1, initialDelay: 0, maxDelay: 0 },
+            timeoutMs: 1_000,
+          });
+
+          await transport.request("/retried", { signal: caller.signal });
+
+          assertEquals(fetchCalls, 2);
+          assertEquals(observation.counts, { added: 2, removed: 2 });
+        } finally {
+          observation.restore();
+        }
+      });
     });
 
     it("reserves worst-case JSON escape bytes outside the non-value response budget", async () => {

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -802,13 +802,14 @@ export class VeryfrontAPIOperations {
   async getReleaseAssetManifest(
     projectRef: string,
     version: string,
+    signal?: AbortSignal,
   ): Promise<ReleaseAssetManifestApiResponse> {
     const url = `/projects/${encodeURIComponent(projectRef)}/releases/${
       encodeURIComponent(version)
     }/asset-manifest`;
     logger.debug("getReleaseAssetManifest", { projectRef, version });
 
-    const raw = await this.request(url);
+    const raw = await this.request(url, { signal });
     return getReleaseAssetManifestResponseSchema().parse(raw);
   }
 

--- a/src/platform/adapters/veryfront-api-transport.ts
+++ b/src/platform/adapters/veryfront-api-transport.ts
@@ -51,6 +51,8 @@ export interface TransportRequestInit {
   };
   expected404?: boolean;
   timeoutMs?: number;
+  /** Caller-owned cancellation propagated to the underlying fetch. */
+  signal?: AbortSignal;
 }
 
 export interface VeryfrontApiTransportConfig<T> {
@@ -128,6 +130,7 @@ function snapshotRequestInit(init: TransportRequestInit): TransportRequestInit {
     jsonStringFieldWithinLimit,
     expected404: init.expected404,
     timeoutMs: init.timeoutMs,
+    signal: init.signal,
   };
 }
 
@@ -169,7 +172,7 @@ export function createVeryfrontApiTransport<T>(
       // matching the pre-transport requestWithRetry semantics.
       const token = getToken();
       return await retryWithBackoff(
-        (signal, attempt) => {
+        (attemptSignal, attempt) => {
           const doFetch = async (): Promise<T> => {
             const headers = new Headers(requestInit.headers);
             for (const [k, v] of Object.entries(defaultHeaders)) {
@@ -178,6 +181,7 @@ export function createVeryfrontApiTransport<T>(
             headers.set("Authorization", `Bearer ${token}`);
             injectContext(headers);
             const start = performance.now();
+            const signal = combineRequestSignals(attemptSignal, requestInit.signal);
             const res = await fetch(url, { method, headers, body: requestInit.body, signal });
             afterFetch?.(res.status, performance.now() - start);
             return onResponse(res, requestInit, url, signal);
@@ -189,7 +193,8 @@ export function createVeryfrontApiTransport<T>(
           initialDelay,
           maxDelay,
           timeoutMs,
-          shouldRetry,
+          shouldRetry: (error, attempt) =>
+            requestInit.signal?.aborted !== true && shouldRetry(error, attempt),
           onRetry: config.onRetry
             ? ({ error, attempt, delay, isTimeout }) =>
               config.onRetry!({ error, attempt, delay, isTimeout, url, timeoutMs })
@@ -204,6 +209,10 @@ export function createVeryfrontApiTransport<T>(
               });
             },
           wrapFinalError(lastError, lastAttempt) {
+            if (requestInit.signal?.aborted) {
+              const reason = requestInit.signal.reason;
+              return reason instanceof Error ? reason : new Error("API request aborted");
+            }
             if (lastError.name === "AbortError") logTimeout(url, timeoutMs, lastAttempt);
             return wrapFinalError(lastError, lastAttempt);
           },
@@ -211,6 +220,15 @@ export function createVeryfrontApiTransport<T>(
       );
     },
   };
+}
+
+function combineRequestSignals(
+  attemptSignal: AbortSignal | undefined,
+  callerSignal: AbortSignal | undefined,
+): AbortSignal | undefined {
+  if (!attemptSignal) return callerSignal;
+  if (!callerSignal) return attemptSignal;
+  return AbortSignal.any([attemptSignal, callerSignal]);
 }
 
 /** Canonical transport: span tracing, request metrics, API_CLIENT_ERROR mapping. */

--- a/src/platform/adapters/veryfront-api-transport.ts
+++ b/src/platform/adapters/veryfront-api-transport.ts
@@ -228,7 +228,33 @@ function combineRequestSignals(
 ): AbortSignal | undefined {
   if (!attemptSignal) return callerSignal;
   if (!callerSignal) return attemptSignal;
-  return AbortSignal.any([attemptSignal, callerSignal]);
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any([attemptSignal, callerSignal]);
+  }
+
+  const controller = new AbortController();
+  const abortFromAttempt = () => {
+    detach();
+    controller.abort(attemptSignal.reason);
+  };
+  const abortFromCaller = () => {
+    detach();
+    controller.abort(callerSignal.reason);
+  };
+  const detach = () => {
+    attemptSignal.removeEventListener("abort", abortFromAttempt);
+    callerSignal.removeEventListener("abort", abortFromCaller);
+  };
+
+  if (attemptSignal.aborted) {
+    abortFromAttempt();
+  } else if (callerSignal.aborted) {
+    abortFromCaller();
+  } else {
+    attemptSignal.addEventListener("abort", abortFromAttempt, { once: true });
+    callerSignal.addEventListener("abort", abortFromCaller, { once: true });
+  }
+  return controller.signal;
 }
 
 /** Canonical transport: span tracing, request metrics, API_CLIENT_ERROR mapping. */

--- a/src/platform/adapters/veryfront-api-transport.ts
+++ b/src/platform/adapters/veryfront-api-transport.ts
@@ -181,10 +181,19 @@ export function createVeryfrontApiTransport<T>(
             headers.set("Authorization", `Bearer ${token}`);
             injectContext(headers);
             const start = performance.now();
-            const signal = combineRequestSignals(attemptSignal, requestInit.signal);
-            const res = await fetch(url, { method, headers, body: requestInit.body, signal });
-            afterFetch?.(res.status, performance.now() - start);
-            return onResponse(res, requestInit, url, signal);
+            const combined = combineRequestSignals(attemptSignal, requestInit.signal);
+            try {
+              const res = await fetch(url, {
+                method,
+                headers,
+                body: requestInit.body,
+                signal: combined.signal,
+              });
+              afterFetch?.(res.status, performance.now() - start);
+              return await onResponse(res, requestInit, url, combined.signal);
+            } finally {
+              combined.dispose();
+            }
           };
           return wrapFetch ? wrapFetch(doFetch, url, method, attempt) : doFetch();
         },
@@ -222,17 +231,41 @@ export function createVeryfrontApiTransport<T>(
   };
 }
 
+interface CombinedRequestSignal {
+  readonly signal: AbortSignal | undefined;
+  dispose(): void;
+}
+
 function combineRequestSignals(
   attemptSignal: AbortSignal | undefined,
   callerSignal: AbortSignal | undefined,
-): AbortSignal | undefined {
-  if (!attemptSignal) return callerSignal;
-  if (!callerSignal) return attemptSignal;
+): CombinedRequestSignal {
+  if (!attemptSignal || !callerSignal) {
+    return {
+      signal: attemptSignal ?? callerSignal,
+      dispose() {},
+    };
+  }
   if (typeof AbortSignal.any === "function") {
-    return AbortSignal.any([attemptSignal, callerSignal]);
+    return {
+      signal: AbortSignal.any([attemptSignal, callerSignal]),
+      dispose() {},
+    };
   }
 
   const controller = new AbortController();
+  let attemptListenerAttached = false;
+  let callerListenerAttached = false;
+  const detach = () => {
+    if (attemptListenerAttached) {
+      attemptListenerAttached = false;
+      attemptSignal.removeEventListener("abort", abortFromAttempt);
+    }
+    if (callerListenerAttached) {
+      callerListenerAttached = false;
+      callerSignal.removeEventListener("abort", abortFromCaller);
+    }
+  };
   const abortFromAttempt = () => {
     detach();
     controller.abort(attemptSignal.reason);
@@ -241,10 +274,6 @@ function combineRequestSignals(
     detach();
     controller.abort(callerSignal.reason);
   };
-  const detach = () => {
-    attemptSignal.removeEventListener("abort", abortFromAttempt);
-    callerSignal.removeEventListener("abort", abortFromCaller);
-  };
 
   if (attemptSignal.aborted) {
     abortFromAttempt();
@@ -252,9 +281,15 @@ function combineRequestSignals(
     abortFromCaller();
   } else {
     attemptSignal.addEventListener("abort", abortFromAttempt, { once: true });
+    attemptListenerAttached = true;
     callerSignal.addEventListener("abort", abortFromCaller, { once: true });
+    callerListenerAttached = true;
+    // Close the check-to-listen window for signals aborted by an unusual
+    // host implementation while listeners were being attached.
+    if (attemptSignal.aborted) abortFromAttempt();
+    else if (callerSignal.aborted) abortFromCaller();
   }
-  return controller.signal;
+  return { signal: controller.signal, dispose: detach };
 }
 
 /** Canonical transport: span tracing, request metrics, API_CLIENT_ERROR mapping. */

--- a/src/release-assets/README.md
+++ b/src/release-assets/README.md
@@ -79,8 +79,8 @@ project scoping, or release scoping.
 Manifest fetchers are registered per release ID. Cache entries and in-flight
 requests are tied to the current fetcher owner, use collision-free tuple keys,
 time out after 10 seconds, and are aborted when ownership or cache generation
-changes. The global fallback fetcher exists for simple single-project and test
-setups; hosted runtimes should register a release-scoped fetcher.
+changes. A release without its own registered fetcher returns `null` and uses
+the existing release-scoped JIT path.
 
 ## Feature flags
 

--- a/src/release-assets/README.md
+++ b/src/release-assets/README.md
@@ -1,0 +1,185 @@
+# Release asset manifest reference
+
+The release-assets module turns an immutable release file set into
+content-addressed JavaScript and CSS assets plus a versioned manifest. Production
+HTML, hydration, module serving, rendering caches, and the asset proxy consume
+that manifest without changing the existing JIT authorization boundary.
+
+```text
+release files -> build + upload -> validated manifest -> HTML/module consumers
+```
+
+## Core contracts
+
+### Manifest trust boundary
+
+Treat every manifest body as untrusted input. `parseReleaseAssetManifest()`:
+
+- accepts only the exact v2 object shape;
+- validates canonical identifiers, paths, timestamps, hashes, content types,
+  sizes, route references, and collection limits;
+- does not execute accessors or propagate validation exceptions;
+- returns a detached, deeply frozen snapshot with null-prototype records; and
+- returns `null` for any invalid body.
+
+Producers validate their assembled manifest through the same parser before the
+PUT request. Consumers must use a parsed manifest or another trusted
+`ReleaseAssetManifest`; they must not cast arbitrary API JSON to that type.
+
+Manifest v2 makes every CSS entry provenance-complete: `styleProfileHash` is a
+required lowercase SHA-256 digest and `cssPipelineIdentity` is the exact bounded
+compiler/optimizer identity captured for that compilation. V1 manifests are
+rejected rather than upgraded because those identities cannot be reconstructed
+reliably from legacy output.
+
+Every v2 manifest also declares `dependencyMode`. `"source"` means the built
+module closure may retain HTTP imports, so its dependency map is not an
+authoritative immutable closure and is never eligible for URL substitution.
+`"immutable"` means every dependency entry names an uploaded,
+content-addressed asset and the published module closure contains no source HTTP
+imports. HTML import maps and module rewrites consume only immutable dependency
+entries; fragment variants remain distinct and keep their original fragment on
+the rewritten asset URL.
+
+### Content identity
+
+An uploaded asset is identified by both its lowercase SHA-256 hash and its
+allowlisted content type. JavaScript and CSS with equal bytes are separate
+content identities and are each acknowledged independently. Public URLs use:
+
+```text
+/_vf/assets/{64-lowercase-hex}.{js|css}
+```
+
+`releaseAssetUrl()` rejects malformed hashes and unsupported extensions.
+
+### Build acknowledgement
+
+`runReleaseAssetBuild()` fails closed when:
+
+- the build-start response is malformed or carries an unsafe manifest version;
+- release paths, source sizes, graph sizes, or dependency identities violate a
+  declared boundary;
+- an upload is not acknowledged as stored or already present; or
+- the final PUT does not acknowledge `ready` for the expected manifest version.
+
+Transform, dependency, route-closure, and CSS coverage failures are bounded
+diagnostics, but they never produce a manifest. The executor proves complete
+coverage before its first upload, then accepts only a `ready` acknowledgement
+for the exact manifest version. This prevents an incomplete build from leaving
+unreferenced immutable assets or silently delegating selected entries to JIT.
+
+### JIT fallback is not an authorization fallback
+
+When manifest consumption is disabled, unavailable, timed out, not ready, or
+invalid, readers return `null`. Callers then use the existing release-scoped JIT
+module path. This availability fallback does not bypass authentication,
+project scoping, or release scoping.
+
+Manifest fetchers are registered per release ID. Cache entries and in-flight
+requests are tied to the current fetcher owner, use collision-free tuple keys,
+time out after 10 seconds, and are aborted when ownership or cache generation
+changes. The global fallback fetcher exists for simple single-project and test
+setups; hosted runtimes should register a release-scoped fetcher.
+
+## Feature flags
+
+Both flags are host deployment settings and default to off.
+
+| Constant                                       | Environment variable                            | Effect                                                                             |
+| ---------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `RELEASE_ASSET_MANIFEST_ENV_FLAG`              | `VERYFRONT_RELEASE_ASSET_MANIFEST`              | Enables manifest reads for production HTML, hydration, and cache versioning.       |
+| `RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG` | `VERYFRONT_RELEASE_ASSET_DEPENDENCY_IMPORT_MAP` | Enables immutable dependency consumption and requests local dependency generation. |
+
+Dependency rewrites require an available manifest body with
+`dependencyMode: "immutable"`. Source-mode or missing dependency entries preserve
+the verified source/JIT URL and prevent an unsafe immutable module response
+cache entry.
+
+The dependency flag is a consumer and local-build setting; it does not select a
+hosted build mode. Hosted builders pass `dependencyMode` explicitly. Source mode
+forbids a vendor argument. Immutable mode requires an explicitly composed,
+policy-enforced `ReleaseAssetHttpDependencyVendor` implementation before the
+build begins. That implementation belongs in an extension; the framework does
+not silently select the legacy HTTP cache because it is not an adequate
+network-policy boundary.
+
+## Manifest limits
+
+`RELEASE_ASSET_MANIFEST_LIMITS` is the single producer-and-consumer source for
+these v2 bounds.
+
+| Field                     |            Limit |
+| ------------------------- | ---------------: |
+| Identifier length         |   256 characters |
+| Builder version length    |   128 characters |
+| Manifest key length       | 2,048 characters |
+| Style profile hash length |    64 characters |
+| CSS pipeline identity     | 2,048 characters |
+| Coverage failure length   | 4,096 characters |
+| Module entries            |           20,000 |
+| Dependency entries        |           10,000 |
+| Dependency specifiers     |           40,000 |
+| CSS entries               |                1 |
+| Route entries             |           20,000 |
+| Modules per route         |           20,000 |
+| CSS hashes per route      |                1 |
+| Coverage failures         |           20,000 |
+| Total route references    |          200,000 |
+| Bytes per asset           |           10 MiB |
+| Pending asset bytes       |          256 MiB |
+
+The build executor also caps the release file list, total source bytes, pending
+asset bytes, dependency traversal depth, CSS candidates, and upload
+concurrency. Exceeding a structural build boundary produces an explicit failed
+build rather than silent truncation. Diagnostic overflow uses a stable bounded
+marker so failed-build diagnostics remain deterministic without unbounded
+memory or error payloads.
+
+## Public API
+
+Import the supported surface from `veryfront/release-assets`.
+
+| Area        | Main exports                                                                               |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| Schema      | strict manifest/ready-envelope parsers, immutable capability guard, and manifest types     |
+| Cache       | release-scoped fetcher registration, sync and async ready-manifest readers, cache clearing |
+| Consumption | module URL normalization and manifest route preload resolution                             |
+| Constants   | schema version, limits, paths, flags, content types, size and version-query constants      |
+
+The hosted build executor and CSS compiler are internal composition surfaces,
+not exports of `veryfront/release-assets`. Runtime code imports their exact
+internal modules and supplies required extension capabilities explicitly. This
+keeps the public release-assets dependency graph free of third-party packages.
+
+The synchronous reader is non-blocking: a cold miss schedules a fetch and
+returns `null`. Use `getReadyManifestForRenderAsync()` when one render must use a
+single manifest snapshot across import maps, preload hints, CSS, and hydration.
+
+## Internal map
+
+| File                    | Responsibility                                                    |
+| ----------------------- | ----------------------------------------------------------------- |
+| `manifest-schema.ts`    | v2 schema, dependency-free parser, immutable snapshot             |
+| `manifest-cache.ts`     | release/owner-scoped cache, in-flight deduplication, cancellation |
+| `build-executor.ts`     | release materialization, transform graph, uploads, manifest PUT   |
+| `css-compile.ts`        | bounded production CSS compilation                                |
+| `html-consumption.ts`   | hashed module and route preload resolution                        |
+| `module-consumption.ts` | cache-root-authorized, size-bounded dependency import rewrites    |
+| `client-module-map.ts`  | safe hydration module map construction                            |
+| `constants.ts`          | shared identity, flag, content, and limit contracts               |
+
+## Verification
+
+Run the module checks with:
+
+```sh
+deno fmt --check src/release-assets
+deno lint src/release-assets
+deno check src/release-assets/*.ts
+deno test -A src/release-assets
+```
+
+Changes to manifest semantics also require the direct consumer suites under
+`src/build`, `src/cache`, `src/html`, `src/modules/server`, `src/platform`,
+`src/proxy`, `src/rendering`, and `src/server`.

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -1757,9 +1757,9 @@ export default defineConfig({ tailwind: { stylesheet: "src/styles/app.css" } });
       ...baseInput(client, transform),
       loadConfig: (source) => {
         selectedConfigSource = source;
-        return releaseConfigLoader({
+        return Promise.resolve({
           tailwind: { stylesheet: "src/styles/app.css" },
-        })();
+        } as VeryfrontConfig);
       },
     }, await tmp());
 

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -1759,7 +1759,7 @@ export default defineConfig({ tailwind: { stylesheet: "src/styles/app.css" } });
         selectedConfigSource = source;
         return releaseConfigLoader({
           tailwind: { stylesheet: "src/styles/app.css" },
-        })(source);
+        })();
       },
     }, await tmp());
 

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -10,23 +10,29 @@ import {
 } from "#veryfront/testing/assert.ts";
 import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { join } from "#veryfront/compat/path";
 import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
 import { parseImports } from "#veryfront/transforms/esm/lexer.ts";
+import { toScopedCssModuleClass } from "#veryfront/transforms/css-modules/naming.ts";
 import {
   DEPENDENCY_PINNING_ENV_FLAG,
   RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG,
+  RELEASE_ASSET_MANIFEST_LIMITS,
   RELEASE_ASSET_MAX_SIZE_BYTES,
 } from "./constants.ts";
 import {
   type ReleaseAssetBuildClient,
   type ReleaseAssetBuildInput,
+  type ReleaseAssetBuildResult,
+  releaseAssetDependencyUrlForSpecifier,
   type ReleaseAssetHttpDependencyVendor,
   type ReleaseAssetVendorResult,
   routeForPage,
   runReleaseAssetBuild,
 } from "./build-executor.ts";
-import { parseReleaseAssetManifest } from "./manifest-schema.ts";
+import { parseReleaseAssetManifest, type ReleaseAssetManifest } from "./manifest-schema.ts";
+import type { CompileProjectCssResult } from "./css-compile.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import {
   clearReactVersionCache,
@@ -34,6 +40,17 @@ import {
   type DependencyPinningSourceInput,
   resolveDependencyPinningSnapshot,
 } from "#veryfront/transforms/esm/package-registry.ts";
+
+const STYLE_PROFILE_HASH = "d".repeat(64);
+const CSS_PIPELINE_IDENTITY = "test-css-pipeline@1";
+
+function compiledCss(
+  css: string,
+  styleProfileHash = STYLE_PROFILE_HASH,
+  cssPipelineIdentity = CSS_PIPELINE_IDENTITY,
+): CompileProjectCssResult {
+  return { css, styleProfileHash, cssPipelineIdentity };
+}
 
 interface Recorded {
   began: boolean;
@@ -43,7 +60,7 @@ interface Recorded {
 }
 
 function makeClient(
-  files: Array<{ path: string; content?: string }>,
+  files: Array<{ path: string; content: string }>,
   rec: Recorded,
   overrides: Partial<ReleaseAssetBuildClient> = {},
 ): ReleaseAssetBuildClient {
@@ -65,32 +82,59 @@ function makeClient(
       rec.states.push({ state, error });
       return Promise.resolve(undefined);
     },
+    compileProjectCss: () => Promise.resolve(compiledCss("/* test release CSS */")),
     ...overrides,
   };
+}
+
+function assertCoverageFailure(
+  result: ReleaseAssetBuildResult,
+  rec: Recorded,
+  expectedFailure: string,
+): void {
+  assertEquals(result.success, false);
+  assertEquals(result.state, "failed");
+  assertEquals(rec.manifest, null);
+  assertEquals(rec.uploads, []);
+  assertEquals(rec.states.map(({ state }) => state), ["failed"]);
+  assert(
+    result.coverageFailures.some((failure) => failure.startsWith(expectedFailure)),
+    `expected coverage failure ${JSON.stringify(expectedFailure)} in ${
+      JSON.stringify(result.coverageFailures)
+    }`,
+  );
+}
+
+function releaseConfigLoader(
+  config: Partial<VeryfrontConfig> = {},
+): ReleaseAssetBuildInput["loadConfig"] {
+  return () => Promise.resolve(config as VeryfrontConfig);
 }
 
 function baseInput(
   client: ReleaseAssetBuildClient,
   transform: ReleaseAssetBuildInput["transform"],
 ): ReleaseAssetBuildInput {
+  const immutableDependencies = getHostEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG) === "1";
   return {
     projectReference: "demo",
     projectId: "proj-uuid",
     releaseId: "rel-uuid",
     releaseVersion: 5,
     releaseVersionRef: "rel-uuid",
-    adapter: {},
+    adapter: {} as RuntimeAdapter,
+    dependencyMode: immutableDependencies ? "immutable" : "source",
+    loadConfig: releaseConfigLoader(),
     client,
     transform,
-    vendorHttpImports: fakeVendorHttpImports,
+    ...(immutableDependencies ? { vendorHttpImports: fakeVendorHttpImports } : {}),
   };
 }
 
 function fakeHttpCachePath(url: string): string {
   const hash = Array.from(new TextEncoder().encode(url))
     .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("")
-    .slice(0, 32);
+    .join("");
   return `/tmp/veryfront-http-bundle/http-${hash}.mjs`;
 }
 
@@ -220,12 +264,11 @@ describe("release asset build executor", () => {
     assertEquals(manifest.modules["pages/_app.tsx"], undefined);
     // Page route maps to its module (single module, no imports).
     assertEquals(manifest.routes["/"]?.modules, ["pages/index.tsx"]);
-    // No CSS pipeline injected → css empty + gap recorded.
-    assertEquals(manifest.css.length, 0);
-    assert(manifest.fallback.gaps.includes("css:no-pipeline"));
-    // Project modules plus framework import-map dependencies are uploaded.
+    assertEquals(manifest.css.length, 1);
+    // Project modules, framework dependencies, and compiled CSS are uploaded.
     assert(rec.uploads.length >= 2);
-    assert(rec.uploads.every((u) => u.contentType === "text/javascript"));
+    assert(rec.uploads.some((u) => u.contentType === "text/javascript"));
+    assert(rec.uploads.some((u) => u.contentType === "text/css"));
   });
 
   it("assembles App Router page routes from app/page modules", async () => {
@@ -273,6 +316,70 @@ describe("release asset build executor", () => {
     assertEquals(await Deno.stat(escapedPath).then(() => true, () => false), false);
   });
 
+  it("rejects changing release file accessors before they can bypass size validation", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    let pathReads = 0;
+    let contentReads = 0;
+    const file: Record<string, unknown> = {};
+    Object.defineProperty(file, "path", {
+      enumerable: true,
+      get() {
+        pathReads++;
+        return "pages/index.tsx";
+      },
+    });
+    Object.defineProperty(file, "content", {
+      enumerable: true,
+      get() {
+        contentReads++;
+        return contentReads < 3
+          ? "export default null;"
+          : "x".repeat(RELEASE_ASSET_MAX_SIZE_BYTES + 1);
+      },
+    });
+    const client = makeClient([], rec, {
+      listAllReleaseFiles: () =>
+        Promise.resolve([
+          file as unknown as { path: string; content: string },
+        ]),
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, () => Promise.resolve("export default null;")),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(pathReads, 0);
+    assertEquals(contentReads, 0);
+    assertEquals(rec.manifest, null);
+    assertEquals(rec.states.map(({ state }) => state), ["failed"]);
+  });
+
+  it("rejects release file proxies whose own data properties cannot be inspected", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const file = new Proxy(
+      { path: "pages/index.tsx", content: "export default null;" },
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("descriptor access denied");
+        },
+      },
+    );
+    const client = makeClient([], rec, {
+      listAllReleaseFiles: () => Promise.resolve([file]),
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(rec.manifest, null);
+    assertEquals(rec.states.map(({ state }) => state), ["failed"]);
+  });
+
   it("keeps transformed HTTP imports on their source URLs by default", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
@@ -305,7 +412,93 @@ describe("release asset build executor", () => {
     assert(!pageUpload.text.includes("/_vf/assets/"));
   });
 
-  it("keeps the manifest ready when one module transform fails", async () => {
+  it("uses the explicit source dependency mode regardless of the consumer flag", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const sourceUrl = "https://cdn.example.com/dependency.js#source";
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: `import ${JSON.stringify(sourceUrl)};` }],
+      rec,
+    );
+    const transform = (source: string) => Promise.resolve(source);
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(client, transform),
+      dependencyMode: "source",
+      vendorHttpImports: undefined,
+    }, await tmp());
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.dependencyMode, "source");
+    assertEquals(Object.keys(manifest.dependencies), []);
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+    assertStringIncludes(rec.uploads.find((upload) => upload.hash === pageHash)!.text, sourceUrl);
+  });
+
+  it("rejects immutable dependency mode without a vendor before materialization", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "export default null;" }],
+      rec,
+    );
+    const tempDir = await tmp();
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(client, (source) => Promise.resolve(source)),
+      dependencyMode: "immutable",
+      vendorHttpImports: undefined,
+    }, tempDir);
+
+    assertEquals(result.success, false);
+    assertStringIncludes(
+      result.error ?? "",
+      "Immutable release dependencies require a policy-enforced vendor extension",
+    );
+    assertEquals(rec.began, false);
+    assertEquals(rec.uploads, []);
+    assertEquals([...Deno.readDirSync(tempDir)], []);
+  });
+
+  it("keeps distinct HTTP query variants as distinct dependency identities", () => {
+    const baseUrl = "https://cdn.example/pkg.js";
+    const dependencyUrls = new Map([[baseUrl, "/_vf/assets/es2020.js"]]);
+
+    assertEquals(
+      releaseAssetDependencyUrlForSpecifier(
+        dependencyUrls,
+        `${baseUrl}?target=es2022`,
+      ),
+      null,
+    );
+  });
+
+  it("keeps distinct HTTP fragment variants as distinct dependency identities", () => {
+    const baseUrl = "https://cdn.example/pkg.js";
+    const dependencyUrls = new Map([
+      [
+        `${baseUrl}#a`,
+        "/_vf/assets/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js#a",
+      ],
+      [
+        `${baseUrl}#b`,
+        "/_vf/assets/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js#b",
+      ],
+    ]);
+
+    assertEquals(
+      releaseAssetDependencyUrlForSpecifier(dependencyUrls, `${baseUrl}#a`),
+      dependencyUrls.get(`${baseUrl}#a`),
+    );
+    assertEquals(
+      releaseAssetDependencyUrlForSpecifier(dependencyUrls, `${baseUrl}#b`),
+      dependencyUrls.get(`${baseUrl}#b`),
+    );
+  });
+
+  it("fails closed when one module transform fails", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       { path: "pages/index.tsx", content: "export default () => null;" },
@@ -321,17 +514,10 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
-    assertEquals(result.success, true);
-    assertEquals(result.state, "ready");
-    assertEquals(rec.states, []);
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertExists(manifest.modules["pages/index.tsx"]);
-    assertEquals(manifest.modules["pages/broken.tsx"], undefined);
-    assert(manifest.fallback.gaps.includes("module-transform-failed:pages/broken.tsx"));
+    assertCoverageFailure(result, rec, "module-transform-failed:pages/broken.tsx");
   });
 
-  it("falls back to unvendored module code when HTTP dependency vendoring fails", async () => {
+  it("fails closed when HTTP dependency vendoring fails", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
@@ -347,24 +533,170 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, true);
-    assertEquals(result.state, "ready");
-    assertEquals(rec.states, []);
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertExists(manifest.modules["pages/index.tsx"]);
-    assert(manifest.fallback.gaps.includes("module-dependency-vendor-failed:pages/index.tsx"));
-    assert(manifest.fallback.gaps.includes("dependency-vendor-failed:react-import-map"));
-
-    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
-    assertExists(pageHash);
-    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
-    assertExists(pageUpload);
-    assert(pageUpload.text.includes(reactUrl));
-    assert(!pageUpload.text.includes("file://"));
+    assertCoverageFailure(result, rec, "module-dependency-vendor-failed:pages/index.tsx");
+    assert(result.coverageFailures.includes("dependency-vendor-failed:react-import-map"));
   });
 
-  it("keeps project modules ready when React import-map dependency vendoring fails", async () => {
+  it("bounds dependency aliases and atomically discards an oversized vendor batch", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const sourceUrl = "https://cdn.example/dependency.js";
+    const dependencyCode = "export const dependencyAliasBoundary = true;";
+    const files = [{
+      path: "pages/index.tsx",
+      content: `import ${JSON.stringify(sourceUrl)}; export default null;`,
+    }];
+    const client = makeClient(files, rec);
+    const transform = (source: string) => Promise.resolve(source);
+    const vendorHttpImports = withFakeReactVendor((code: string) =>
+      Promise.resolve({
+        code,
+        dependencies: Array.from(
+          { length: RELEASE_ASSET_MANIFEST_LIMITS.dependencyEntries },
+          (_, index) => ({
+            specifier: `dependency-alias-${index}`,
+            manifestKey: sourceUrl,
+            code: dependencyCode,
+          }),
+        ),
+      })
+    );
+
+    const result = await runReleaseAssetBuild(
+      { ...baseInput(client, transform), vendorHttpImports },
+      await tmp(),
+    );
+
+    assertCoverageFailure(result, rec, "dependency-finalize-failed");
+  });
+
+  it("rejects accessor-backed vendor results without executing accessors", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [{ path: "pages/index.tsx", content: "export default null;" }];
+    const client = makeClient(files, rec);
+    let accessorCalls = 0;
+    const hostileResult: Record<string, unknown> = {};
+    Object.defineProperty(hostileResult, "code", {
+      get() {
+        accessorCalls++;
+        return "export default null;";
+      },
+    });
+    Object.defineProperty(hostileResult, "dependencies", {
+      value: [],
+      enumerable: true,
+    });
+
+    const result = await runReleaseAssetBuild(
+      {
+        ...baseInput(client, (source) => Promise.resolve(source)),
+        vendorHttpImports: withFakeReactVendor(() =>
+          Promise.resolve(hostileResult as unknown as ReleaseAssetVendorResult)
+        ),
+      },
+      await tmp(),
+    );
+
+    assertCoverageFailure(
+      result,
+      rec,
+      "module-dependency-vendor-failed:pages/index.tsx",
+    );
+    assertEquals(accessorCalls, 0);
+  });
+
+  it("never publishes project modules with unresolved local file imports", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [{ path: "pages/index.tsx", content: "export default null;" }];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      {
+        ...baseInput(client, (source) => Promise.resolve(source)),
+        vendorHttpImports: withFakeReactVendor(() =>
+          Promise.resolve({
+            code: 'import "file:///tmp/unresolved-release-dependency.mjs"; export default null;',
+            dependencies: [],
+          })
+        ),
+      },
+      await tmp(),
+    );
+
+    assertCoverageFailure(result, rec, "module-rewrite-failed:pages/index.tsx");
+  });
+
+  it("never publishes project modules with unresolved relative imports", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: 'import "./missing.ts"; export default null;' }],
+      rec,
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertCoverageFailure(result, rec, "module-rewrite-failed:pages/index.tsx");
+  });
+
+  it("never publishes non-literal dynamic imports", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient([{
+      path: "pages/index.tsx",
+      content: 'const name = "feature"; export default import("./" + name);',
+    }], rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertCoverageFailure(result, rec, "module-rewrite-failed:pages/index.tsx");
+  });
+
+  it("rejects HTTP imports retained by a composed vendor", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const sourceUrl = "https://cdn.example/retained.js";
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: `import ${JSON.stringify(sourceUrl)};` }],
+      rec,
+    );
+    const vendorHttpImports = withFakeReactVendor((code) =>
+      Promise.resolve({ code, dependencies: [] })
+    );
+
+    const result = await runReleaseAssetBuild(
+      {
+        ...baseInput(client, (source) => Promise.resolve(source)),
+        vendorHttpImports,
+      },
+      await tmp(),
+    );
+
+    assertCoverageFailure(result, rec, "module-rewrite-failed:pages/index.tsx");
+  });
+
+  it("rejects case-insensitive local file URL schemes", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient([{
+      path: "pages/index.tsx",
+      content: 'import "FILE:///tmp/secret.mjs"; export default null;',
+    }], rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertCoverageFailure(result, rec, "module-rewrite-failed:pages/index.tsx");
+  });
+
+  it("fails closed when React import-map dependency vendoring fails", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
@@ -378,16 +710,10 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, true);
-    assertEquals(result.state, "ready");
-    assertEquals(rec.states, []);
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertExists(manifest.modules["pages/index.tsx"]);
-    assert(manifest.fallback.gaps.includes("dependency-vendor-failed:react-import-map"));
+    assertCoverageFailure(result, rec, "dependency-vendor-failed:react-import-map");
   });
 
-  it("records framework import-map modules as manifest dependencies when dependency vendoring is enabled", async () => {
+  it("records React import-map dependencies without publishing unused framework modules", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
@@ -404,16 +730,9 @@ describe("release asset build executor", () => {
     assertExists(manifest.dependencies["react-dom/client"]);
     assertExists(manifest.dependencies["react/jsx-runtime"]);
     assertExists(manifest.dependencies["react/jsx-dev-runtime"]);
-    assertExists(manifest.dependencies["veryfront/chat"]);
-    assertExists(manifest.dependencies["veryfront/workflow"]);
-    assertEquals(
-      manifest.fallback.gaps.some((gap) => gap.includes("_deno-config")),
-      false,
-    );
-    assertEquals(
-      manifest.dependencies["veryfront/head"]?.contentHash,
-      manifest.dependencies["veryfront/react/head"]?.contentHash,
-    );
+    assertEquals(manifest.dependencies["veryfront/chat"], undefined);
+    assertEquals(manifest.dependencies["veryfront/workflow"], undefined);
+    assertEquals(manifest.dependencies["veryfront/head"], undefined);
   });
 
   it("keeps framework dependency assets on the vendored React instance", async () => {
@@ -537,7 +856,7 @@ describe("release asset build executor", () => {
     assertExists(manifest.dependencies["react/jsx-runtime"]);
   });
 
-  it("records a gap when React import-map dependencies cannot be vendored", async () => {
+  it("fails closed when React import-map dependencies cannot be vendored", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
@@ -550,13 +869,7 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, true);
-    assertEquals(result.state, "ready");
-    assertEquals(rec.states, []);
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertExists(manifest.modules["pages/index.tsx"]);
-    assert(manifest.fallback.gaps.includes("dependency-vendor-failed:react-import-map"));
+    assertCoverageFailure(result, rec, "dependency-vendor-failed:react-import-map");
   });
 
   it("rewrites covered project module imports to immutable asset URLs", async () => {
@@ -776,7 +1089,7 @@ describe("release asset build executor", () => {
     assert(!bParentUpload.text.includes(`"/_vf/assets/${aSharedHash}.js"`));
   });
 
-  it("falls back to source URLs when vendored dependency assets contain a cycle", async () => {
+  it("fails closed when vendored dependency assets contain a cycle", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
@@ -818,25 +1131,10 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, true);
-    assertEquals(result.state, "ready");
-    assert(result.gaps.some((gap) => gap.startsWith("dependency-cycle:")));
-
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertEquals(manifest.dependencies["https://esm.sh/parent@1"], undefined);
-    assertEquals(manifest.dependencies["https://esm.sh/child@1"], undefined);
-
-    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
-    assertExists(pageHash);
-    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
-    assertExists(pageUpload);
-    assert(pageUpload.text.includes('"https://esm.sh/parent@1"'));
-    assert(!pageUpload.text.includes("file:///tmp/veryfront-http-bundle"));
-    assertEquals(rec.states.find((state) => state.state === "failed"), undefined);
+    assertCoverageFailure(result, rec, "dependency-cycle:");
   });
 
-  it("falls back to source URLs when a vendored dependency keeps an unresolved file import", async () => {
+  it("fails closed when a vendored dependency keeps an unresolved file import", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
@@ -870,22 +1168,10 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, true);
-    assertEquals(result.state, "ready");
-    assertEquals(rec.states, []);
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertExists(manifest.modules["pages/index.tsx"]);
-    assert(manifest.fallback.gaps.includes("dependency-finalize-failed"));
-    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
-    assertExists(pageHash);
-    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
-    assertExists(pageUpload);
-    assert(pageUpload.text.includes("https://esm.sh/parent@1"));
-    assert(!pageUpload.text.includes("file://"));
+    assertCoverageFailure(result, rec, "dependency-finalize-failed");
   });
 
-  it("falls back to source URLs when a vendored dependency asset exceeds the size limit", async () => {
+  it("fails closed when a vendored dependency asset exceeds the size limit", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
@@ -919,19 +1205,7 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, true);
-    assertEquals(result.state, "ready");
-    assertEquals(rec.states, []);
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertExists(manifest.modules["pages/index.tsx"]);
-    assert(manifest.fallback.gaps.includes("dependency-finalize-failed"));
-    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
-    assertExists(pageHash);
-    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
-    assertExists(pageUpload);
-    assert(pageUpload.text.includes("https://esm.sh/parent@1"));
-    assert(!pageUpload.text.includes("file://"));
+    assertCoverageFailure(result, rec, "module-dependency-vendor-failed:pages/index.tsx");
   });
 
   it("rewrites transformed relative project imports to immutable asset URLs", async () => {
@@ -1041,7 +1315,7 @@ describe("release asset build executor", () => {
       }
       if (sourceFile.endsWith("components/Header.tsx")) {
         return Promise.resolve(
-          'import { BreakpointsProvider } from "../../custom-client/BreakpointsProvider.js"; export { BreakpointsProvider };',
+          'import { BreakpointsProvider } from "../custom-client/BreakpointsProvider.js"; export { BreakpointsProvider };',
         );
       }
       return Promise.resolve("export const BreakpointsProvider = ({ children }) => children;");
@@ -1059,7 +1333,7 @@ describe("release asset build executor", () => {
     const headerUpload = rec.uploads.find((u) => u.hash === headerHash);
     assertExists(headerUpload);
     assert(headerUpload.text.includes(`"/_vf/assets/${providerHash}.js"`));
-    assert(!headerUpload.text.includes("../../custom-client/BreakpointsProvider.js"));
+    assert(!headerUpload.text.includes("../custom-client/BreakpointsProvider.js"));
 
     const routeModules = manifest.routes["/"]?.modules ?? [];
     assert(routeModules.includes("custom-client/BreakpointsProvider.tsx"));
@@ -1095,16 +1369,13 @@ describe("release asset build executor", () => {
       return Promise.resolve("export default function Header() { return null; }");
     };
 
-    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
     const manifest = parseReleaseAssetManifest(rec.manifest);
     assertExists(manifest);
+    assertEquals(result.coverageFailures, []);
     assertEquals(manifest.modules["providers/BreakpointsProvider.ts"], undefined);
     assertEquals(manifest.routes["/"]?.modules.includes("providers/BreakpointsProvider.ts"), false);
-    assertEquals(
-      manifest.fallback.gaps.some((gap) => gap.includes("providers/BreakpointsProvider.ts")),
-      false,
-    );
   });
 
   it("does not preload inline type-only import or export specifiers", async () => {
@@ -1142,20 +1413,13 @@ describe("release asset build executor", () => {
       return Promise.resolve("export default function Header() { return null; }");
     };
 
-    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
     const manifest = parseReleaseAssetManifest(rec.manifest);
     assertExists(manifest);
+    assertEquals(result.coverageFailures, []);
     assertEquals(manifest.modules["providers/BreakpointsProvider.ts"], undefined);
     assertEquals(manifest.modules["providers/BreakpointTokens.ts"], undefined);
-    assertEquals(
-      manifest.fallback.gaps.some((gap) => gap.includes("providers/BreakpointsProvider.ts")),
-      false,
-    );
-    assertEquals(
-      manifest.fallback.gaps.some((gap) => gap.includes("providers/BreakpointTokens.ts")),
-      false,
-    );
   });
 
   it("builds route closure from transformed modules when raw page source is not JavaScript", async () => {
@@ -1193,10 +1457,7 @@ describe("release asset build executor", () => {
     const routeModules = manifest.routes["/blog"]?.modules ?? [];
     assert(routeModules.includes("pages/blog.mdx"));
     assert(routeModules.includes("components/Hero.tsx"));
-    assertEquals(
-      manifest.fallback.gaps.some((gap) => gap.startsWith("closure-import-parse-failed:")),
-      false,
-    );
+    assertEquals(result.coverageFailures, []);
   });
 
   it("does not rewrite import-like strings or comments in transformed modules", async () => {
@@ -1237,7 +1498,7 @@ describe("release asset build executor", () => {
     assert(!pageUpload.text.includes(`/_vf/assets/${buttonHash}.js`));
   });
 
-  it("keeps framework module imports on the module-server path", async () => {
+  it("rewrites framework module imports to immutable release assets", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       {
@@ -1266,15 +1527,15 @@ describe("release asset build executor", () => {
 
     const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
     assertExists(pageUpload);
-    assert(pageUpload.text.includes(`"${frameworkUrl}"`));
+    assert(!pageUpload.text.includes(`"${frameworkUrl}"`));
     assert(
-      !pageUpload.text.includes(
+      pageUpload.text.includes(
         `"/_vf/assets/${manifest.dependencies["veryfront/workflow"]?.contentHash}.js"`,
       ),
     );
   });
 
-  it("keeps cyclic project imports on the JIT fallback path", async () => {
+  it("fails closed on cyclic project imports", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       { path: "pages/a.tsx", content: 'import B from "../components/B.tsx"; export default B;' },
@@ -1290,15 +1551,10 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
-    assert(result.gaps.includes("cycle:pages/a.tsx->components/B.tsx->pages/a.tsx"));
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertEquals(manifest.modules["pages/a.tsx"], undefined);
-    assertEquals(manifest.modules["components/B.tsx"], undefined);
-    assertEquals(manifest.routes["/a"], undefined);
+    assertCoverageFailure(result, rec, "cycle:pages/a.tsx->components/B.tsx->pages/a.tsx");
   });
 
-  it("records a gap and still PUTs when a project module transform fails", async () => {
+  it("fails closed when a project module transform fails", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [{ path: "pages/index.tsx", content: "boom" }];
     const client = makeClient(files, rec);
@@ -1306,13 +1562,7 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
-    assertEquals(result.success, true);
-    assertEquals(result.state, "ready");
-    assertEquals(rec.states, []);
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertEquals(manifest.modules["pages/index.tsx"], undefined);
-    assert(manifest.fallback.gaps.includes("module-transform-failed:pages/index.tsx"));
+    assertCoverageFailure(result, rec, "module-transform-failed:pages/index.tsx");
   });
 
   it("dedupes identical transformed bytes into a single upload", async () => {
@@ -1341,17 +1591,17 @@ describe("release asset build executor", () => {
       content: 'export default () => "<div class=\\"p-4\\"/>";',
     }];
     const client = makeClient(files, rec, {
-      compileProjectCss: () =>
-        Promise.resolve({ css: ".p-4{padding:1rem}", styleProfileHash: "sp-1" }),
+      compileProjectCss: () => Promise.resolve(compiledCss(".p-4{padding:1rem}")),
     });
-    const transform = (s: string) => Promise.resolve(s);
+    const transform = () => Promise.resolve("export default null;");
 
     const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
     assertEquals(result.cssCount, 1);
     const manifest = parseReleaseAssetManifest(rec.manifest);
     assertExists(manifest);
-    assertEquals(manifest.css[0]?.styleProfileHash, "sp-1");
+    assertEquals(manifest.css[0]?.styleProfileHash, STYLE_PROFILE_HASH);
+    assertEquals(manifest.css[0]?.cssPipelineIdentity, CSS_PIPELINE_IDENTITY);
     assertEquals(manifest.css[0]?.contentType, "text/css");
     // The route entry must carry the compiled CSS hash (project-level CSS is
     // applied to every route per the executor contract).
@@ -1360,7 +1610,7 @@ describe("release asset build executor", () => {
     assertEquals(manifest.routes["/"]?.css, [cssHash]);
   });
 
-  it("records css:compile-failed when the compiler returns null", async () => {
+  it("fails the release when requested CSS compilation returns null", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [{
       path: "pages/index.tsx",
@@ -1369,21 +1619,94 @@ describe("release asset build executor", () => {
     const client = makeClient(files, rec, {
       compileProjectCss: () => Promise.resolve(null),
     });
-    const transform = (s: string) => Promise.resolve(s);
+    const transform = () => Promise.resolve("export default null;");
 
     const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
-    assertEquals(result.cssCount, 0);
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    assertEquals(manifest.css.length, 0);
-    assert(manifest.fallback.gaps.includes("css:compile-failed"), "null compile records gap");
+    assertEquals(result.success, false);
+    assertEquals(result.state, "failed");
+    assertEquals(rec.manifest, null);
+    assertEquals(rec.states.at(-1)?.state, "failed");
+    assertStringIncludes(result.error ?? "", "returned no requested output");
+  });
+
+  it("fails the release when compiled CSS identity metadata is invalid", async () => {
+    const files = [{
+      path: "pages/index.tsx",
+      content: 'export default () => "<div class=\\"p-4\\"/>";',
+    }];
+    const invalidResults: Array<{ label: string; result: unknown }> = [
+      {
+        label: "noncanonical profile hash",
+        result: compiledCss(".p-4{}", "profile-1"),
+      },
+      {
+        label: "missing pipeline identity",
+        result: { css: ".p-4{}", styleProfileHash: STYLE_PROFILE_HASH },
+      },
+      {
+        label: "noncanonical pipeline identity",
+        result: compiledCss(".p-4{}", STYLE_PROFILE_HASH, " pipeline\nidentity "),
+      },
+      {
+        label: "empty output",
+        result: compiledCss(""),
+      },
+    ];
+
+    for (const invalid of invalidResults) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const client = makeClient(files, rec, {
+        compileProjectCss: () => Promise.resolve(invalid.result as CompileProjectCssResult),
+      });
+
+      const result = await runReleaseAssetBuild(
+        baseInput(client, (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertEquals(result.success, false, invalid.label);
+      assertEquals(result.state, "failed", invalid.label);
+      assertEquals(rec.manifest, null, invalid.label);
+      assertEquals(rec.states.at(-1)?.state, "failed", invalid.label);
+      assertStringIncludes(result.error ?? "", "invalid identity result");
+    }
+  });
+
+  it("does not execute accessors on a forged CSS compiler result", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    let getterCalls = 0;
+    const forgedResult = {
+      get css(): string {
+        getterCalls++;
+        throw new Error("must not execute");
+      },
+      styleProfileHash: STYLE_PROFILE_HASH,
+      cssPipelineIdentity: CSS_PIPELINE_IDENTITY,
+    };
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "export default null;" }],
+      rec,
+      {
+        compileProjectCss: () => Promise.resolve(forgedResult as CompileProjectCssResult),
+      },
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(getterCalls, 0);
+    assertEquals(rec.manifest, null);
+    assertStringIncludes(result.error ?? "", "invalid identity result");
   });
 
   it("passes the resolved stylesheet to compileProjectCss", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
-      { path: "globals.css", content: '@import "tailwindcss"; /* custom */' },
+      { path: "globals.css", content: ":root { --brand: blue; } /* custom */" },
       {
         path: "pages/index.tsx",
         content: 'export default () => "<div class=\\"p-4\\"/>";',
@@ -1393,17 +1716,17 @@ describe("release asset build executor", () => {
     const client = makeClient(files, rec, {
       compileProjectCss: (_candidates, stylesheet) => {
         seenStylesheet = stylesheet;
-        return Promise.resolve({ css: ".p-4{padding:1rem}", styleProfileHash: "sp-1" });
+        return Promise.resolve(compiledCss(".p-4{padding:1rem}"));
       },
     });
     const transform = (s: string) => Promise.resolve(s);
 
     await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
-    assertEquals(seenStylesheet, '@import "tailwindcss"; /* custom */');
+    assertEquals(seenStylesheet, ":root { --brand: blue; } /* custom */");
   });
 
-  it("loads release config from materialized files for CSS compilation", async () => {
+  it("passes the exact materialized config source to the trusted config loader", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       {
@@ -1412,7 +1735,7 @@ describe("release asset build executor", () => {
 export default defineConfig({ tailwind: { stylesheet: "src/styles/app.css" } });`,
       },
       { path: "globals.css", content: "/* fallback stylesheet that should not be used */" },
-      { path: "src/styles/app.css", content: '@import "tailwindcss"; /* release-config */' },
+      { path: "src/styles/app.css", content: ":root { --brand: blue; } /* release-config */" },
       {
         path: "pages/index.tsx",
         content: 'export default () => "<div class=\\"p-4\\"/>";',
@@ -1424,18 +1747,31 @@ export default defineConfig({ tailwind: { stylesheet: "src/styles/app.css" } });
       compileProjectCss: (_candidates, stylesheet, options) => {
         seenStylesheet = stylesheet;
         seenConfig = options?.config;
-        return Promise.resolve({ css: ".p-4{padding:1rem}", styleProfileHash: "sp-1" });
+        return Promise.resolve(compiledCss(".p-4{padding:1rem}"));
       },
     });
     const transform = (s: string) => Promise.resolve(s);
+    let selectedConfigSource: Parameters<ReleaseAssetBuildInput["loadConfig"]>[0] | undefined;
 
-    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+    await runReleaseAssetBuild({
+      ...baseInput(client, transform),
+      loadConfig: (source) => {
+        selectedConfigSource = source;
+        return releaseConfigLoader({
+          tailwind: { stylesheet: "src/styles/app.css" },
+        })(source);
+      },
+    }, await tmp());
 
-    assertEquals(seenStylesheet, '@import "tailwindcss"; /* release-config */');
+    assertEquals(seenStylesheet, ":root { --brand: blue; } /* release-config */");
     assertEquals(seenConfig?.tailwind?.stylesheet, "src/styles/app.css");
+    assertEquals(selectedConfigSource, {
+      fileName: "veryfront.config.ts",
+      source: files[0]!.content,
+    });
   });
 
-  it("prefers release-file config over stale request-context stylesheet input", async () => {
+  it("uses only the config returned for the immutable release source", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       {
@@ -1446,7 +1782,7 @@ export default defineConfig({ tailwind: { stylesheet: "src/styles/release.css" }
       { path: "src/styles/stale.css", content: "/* stale request-context config */" },
       {
         path: "src/styles/release.css",
-        content: '@import "tailwindcss"; /* release config wins */',
+        content: ":root { --brand: blue; } /* release config wins */",
       },
       {
         path: "pages/index.tsx",
@@ -1457,33 +1793,58 @@ export default defineConfig({ tailwind: { stylesheet: "src/styles/release.css" }
     const client = makeClient(files, rec, {
       compileProjectCss: (_candidates, stylesheet) => {
         seenStylesheet = stylesheet;
-        return Promise.resolve({ css: ".p-4{padding:1rem}", styleProfileHash: "sp-1" });
+        return Promise.resolve(compiledCss(".p-4{padding:1rem}"));
       },
     });
     const transform = (s: string) => Promise.resolve(s);
 
     await runReleaseAssetBuild({
       ...baseInput(client, transform),
-      stylesheetPath: "src/styles/stale.css",
+      loadConfig: releaseConfigLoader({
+        tailwind: { stylesheet: "src/styles/release.css" },
+      }),
     }, await tmp());
 
-    assertEquals(seenStylesheet, '@import "tailwindcss"; /* release config wins */');
+    assertEquals(seenStylesheet, ":root { --brand: blue; } /* release config wins */");
   });
 
-  it("loads config relative imports from the materialized release file tree", async () => {
+  it("fails closed when the configured release stylesheet is missing", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    let compileCalls = 0;
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "export default () => null;" }],
+      rec,
+      {
+        compileProjectCss: () => {
+          compileCalls++;
+          return Promise.resolve(compiledCss(".unexpected{}"));
+        },
+      },
+    );
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(client, (source) => Promise.resolve(source)),
+      loadConfig: releaseConfigLoader({
+        tailwind: { stylesheet: "src/styles/missing.css" },
+      }),
+    }, await tmp());
+
+    assertCoverageFailure(result, rec, "stylesheet-missing:src/styles/missing.css");
+    assertEquals(compileCalls, 0);
+  });
+
+  it("never executes materialized config source in the build host", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       {
         path: "veryfront.config.ts",
-        content: `import { defineConfig } from "veryfront";
-import { stylesheet } from "./style-config.ts";
-export default defineConfig({ tailwind: { stylesheet } });`,
+        content: `throw new Error("tenant config executed in build host");
+export default { tailwind: { stylesheet: "src/styles/imported.css" } };`,
       },
-      { path: "style-config.ts", content: 'export const stylesheet = "src/styles/imported.css";' },
       { path: "globals.css", content: "/* fallback stylesheet that should not be used */" },
       {
         path: "src/styles/imported.css",
-        content: '@import "tailwindcss"; /* imported release config */',
+        content: ":root { --brand: blue; } /* imported release config */",
       },
       {
         path: "pages/index.tsx",
@@ -1496,18 +1857,24 @@ export default defineConfig({ tailwind: { stylesheet } });`,
       compileProjectCss: (_candidates, stylesheet, options) => {
         seenStylesheet = stylesheet;
         seenConfig = options?.config;
-        return Promise.resolve({ css: ".p-4{padding:1rem}", styleProfileHash: "sp-1" });
+        return Promise.resolve(compiledCss(".p-4{padding:1rem}"));
       },
     });
     const transform = (s: string) => Promise.resolve(s);
 
-    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+    const result = await runReleaseAssetBuild({
+      ...baseInput(client, transform),
+      loadConfig: releaseConfigLoader({
+        tailwind: { stylesheet: "src/styles/imported.css" },
+      }),
+    }, await tmp());
 
-    assertEquals(seenStylesheet, '@import "tailwindcss"; /* imported release config */');
+    assertEquals(result.success, true);
+    assertEquals(seenStylesheet, ":root { --brand: blue; } /* imported release config */");
     assertEquals(seenConfig?.tailwind?.stylesheet, "src/styles/imported.css");
   });
 
-  it("fails the build when materialized release config has unknown keys", async () => {
+  it("fails closed when the trusted config loader rejects release config", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       {
@@ -1515,36 +1882,45 @@ export default defineConfig({ tailwind: { stylesheet } });`,
         content: `import { defineConfig } from "veryfront";
 export default defineConfig({ tailwind: { stylesheet: "globals.css" }, typoKey: true });`,
       },
-      { path: "globals.css", content: '@import "tailwindcss";' },
+      { path: "globals.css", content: ":root { --brand: blue; }" },
       { path: "pages/index.tsx", content: "export default () => null;" },
     ];
     const client = makeClient(files, rec);
     const transform = (s: string) => Promise.resolve(s);
 
-    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+    const result = await runReleaseAssetBuild({
+      ...baseInput(client, transform),
+      loadConfig: () => Promise.reject(new Error("release config rejected")),
+    }, await tmp());
 
     assertEquals(result.success, false);
     assertEquals(result.state, "failed");
-    assertStringIncludes(result.error ?? "", "Unknown config keys: typoKey");
+    assertStringIncludes(
+      result.error ?? "",
+      "release config rejected",
+    );
     assertEquals(rec.states.length, 1);
     assertEquals(rec.states[0]?.state, "failed");
-    assertStringIncludes(rec.states[0]?.error ?? "", "Unknown config keys: typoKey");
+    assertStringIncludes(
+      rec.states[0]?.error ?? "",
+      "release config rejected",
+    );
   });
 
-  it("loads release config that uses framework config helpers", async () => {
+  it("uses the validated helper result returned by the config boundary", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       {
         path: "veryfront.config.ts",
-        content: `import { defineConfigWithEnv, mergeConfigs } from "veryfront";
-const shared = { tailwind: { stylesheet: "src/styles/helper.css" } };
+        content: `import { defineConfigWithEnv, getEnv, mergeConfigs } from "veryfront";
+const shared = { tailwind: { stylesheet: getEnv("VERYFRONT_RELEASE_CONFIG_STYLESHEET") } };
 export default defineConfigWithEnv((env) =>
   mergeConfigs(shared, { react: { version: env === "production" ? "19.2.8" : "19.2.9" } })
 );`,
       },
       {
         path: "src/styles/helper.css",
-        content: '@import "tailwindcss"; /* helper config */',
+        content: ":root { --brand: blue; } /* helper config */",
       },
       { path: "pages/index.tsx", content: "export default () => null;" },
     ];
@@ -1553,7 +1929,7 @@ export default defineConfigWithEnv((env) =>
     const client = makeClient(files, rec, {
       compileProjectCss: (_candidates, stylesheet) => {
         seenStylesheet = stylesheet;
-        return Promise.resolve({ css: ".helper{}", styleProfileHash: "sp-helper" });
+        return Promise.resolve(compiledCss(".helper{}"));
       },
     });
     const transform: ReleaseAssetBuildInput["transform"] = (
@@ -1567,14 +1943,20 @@ export default defineConfigWithEnv((env) =>
       return Promise.resolve("export default () => null;");
     };
 
-    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+    await runReleaseAssetBuild({
+      ...baseInput(client, transform),
+      loadConfig: releaseConfigLoader({
+        tailwind: { stylesheet: "src/styles/helper.css" },
+        react: { version: "19.2.8" },
+      }),
+    }, await tmp());
 
-    assertEquals(seenStylesheet, '@import "tailwindcss"; /* helper config */');
+    assertEquals(seenStylesheet, ":root { --brand: blue; } /* helper config */");
     assert(seenReactVersions.length > 0);
     assert(seenReactVersions.every((version) => version === "19.2.8"));
   });
 
-  it("loads React version from materialized release config for module transforms", async () => {
+  it("uses the source-bound React version for module transforms", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       {
@@ -1599,7 +1981,7 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
 
     await runReleaseAssetBuild({
       ...baseInput(client, transform),
-      reactVersion: "18.0.0",
+      loadConfig: releaseConfigLoader({ react: { version: "19.2.1" } }),
     }, await tmp());
 
     assert(seenReactVersions.length > 0);
@@ -1628,10 +2010,7 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
       return Promise.resolve("export default () => null;");
     };
 
-    await runReleaseAssetBuild({
-      ...baseInput(client, transform),
-      reactVersion: "18.0.0",
-    }, await tmp());
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
     assert(seenReactVersions.length > 0);
     assert(seenReactVersions.every((version) => version === "19.2.3"));
@@ -1654,7 +2033,10 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
         path: "veryfront.config.ts",
         content: `export default { react: { version: "19.2.1" } };`,
       },
-      { path: "pages/a.tsx", content: "export default () => 'a';" },
+      {
+        path: "pages/a.tsx",
+        content: 'import "veryfront/head"; export default () => "a";',
+      },
       { path: "pages/b.tsx", content: "export default () => 'b';" },
     ];
     const client = makeClient(files, rec);
@@ -1693,7 +2075,10 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
       return sourceFile.includes("/pages/") ? source : "export const framework = true;";
     };
 
-    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+    const result = await runReleaseAssetBuild({
+      ...baseInput(client, transform),
+      loadConfig: releaseConfigLoader({ react: { version: "19.2.1" } }),
+    }, await tmp());
 
     assertEquals(result.success, true);
     assert(observations.some(({ sourceFile }) => sourceFile.endsWith("pages/a.tsx")));
@@ -1719,10 +2104,10 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     assertEquals(newerSnapshot.cacheKey === buildSnapshot.cacheKey, false);
   });
 
-  it("keeps fallback stylesheet and React version when release files have no config", async () => {
+  it("uses conventional stylesheet and default React version when config is absent", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
-      { path: "globals.css", content: '@import "tailwindcss"; /* fallback */' },
+      { path: "globals.css", content: ":root { --brand: blue; } /* fallback */" },
       { path: "pages/index.tsx", content: 'export default () => "<div class="p-4"/>";' },
     ];
     let seenStylesheet: string | undefined;
@@ -1730,7 +2115,7 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     const client = makeClient(files, rec, {
       compileProjectCss: (_candidates, stylesheet) => {
         seenStylesheet = stylesheet;
-        return Promise.resolve({ css: ".p-4{padding:1rem}", styleProfileHash: "sp-1" });
+        return Promise.resolve(compiledCss(".p-4{padding:1rem}"));
       },
     });
     const transform: ReleaseAssetBuildInput["transform"] = (
@@ -1744,20 +2129,17 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
       return Promise.resolve("export default () => null;");
     };
 
-    await runReleaseAssetBuild({
-      ...baseInput(client, transform),
-      reactVersion: "18.3.1",
-    }, await tmp());
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
-    assertEquals(seenStylesheet, '@import "tailwindcss"; /* fallback */');
+    assertEquals(seenStylesheet, ":root { --brand: blue; } /* fallback */");
     assert(seenReactVersions.length > 0);
-    assert(seenReactVersions.every((version) => version === "18.3.1"));
+    assert(seenReactVersions.every((version) => version === "19.2.4"));
   });
 
   it("merges module-imported CSS into the stylesheet passed to compileProjectCss", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
-      { path: "globals.css", content: '@import "tailwindcss";' },
+      { path: "globals.css", content: ":root { --brand: blue; }" },
       { path: "app/styles.css", content: ".calc { background: #191919; }" },
       {
         path: "app/layout.tsx",
@@ -1772,16 +2154,16 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     const client = makeClient(files, rec, {
       compileProjectCss: (_candidates, stylesheet) => {
         seenStylesheet = stylesheet;
-        return Promise.resolve({ css: ".calc{background:#191919}", styleProfileHash: "sp-1" });
+        return Promise.resolve(compiledCss(".calc{background:#191919}"));
       },
     });
-    const transform = (s: string) => Promise.resolve(s);
+    const transform = () => Promise.resolve("export default null;");
 
     await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
     assertExists(seenStylesheet);
     assert(
-      seenStylesheet!.includes('@import "tailwindcss";'),
+      seenStylesheet!.includes(":root { --brand: blue; }"),
       "resolved stylesheet must be preserved",
     );
     assert(
@@ -1793,7 +2175,7 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
   it("does not duplicate the resolved stylesheet when a module imports it directly", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
-      { path: "globals.css", content: '@import "tailwindcss"; /* custom */' },
+      { path: "globals.css", content: ":root { --brand: blue; } /* custom */" },
       {
         path: "app/layout.tsx",
         content: 'import "../globals.css";\nexport default ({ children }) => children;',
@@ -1807,10 +2189,10 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     const client = makeClient(files, rec, {
       compileProjectCss: (_candidates, stylesheet) => {
         seenStylesheet = stylesheet;
-        return Promise.resolve({ css: ".p-4{padding:1rem}", styleProfileHash: "sp-1" });
+        return Promise.resolve(compiledCss(".p-4{padding:1rem}"));
       },
     });
-    const transform = (s: string) => Promise.resolve(s);
+    const transform = () => Promise.resolve("export default null;");
 
     await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
@@ -1818,10 +2200,10 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     assertEquals(seenStylesheet!.split("/* custom */").length - 1, 1);
   });
 
-  it("keeps CSS module files out of the merged release stylesheet", async () => {
+  it("merges CSS Modules with the same scoped classes used by transformed code", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
-      { path: "globals.css", content: '@import "tailwindcss";' },
+      { path: "globals.css", content: ":root { --brand: blue; }" },
       { path: "components/button.module.css", content: ".button { color: red; }" },
       {
         path: "components/Button.tsx",
@@ -1836,22 +2218,97 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     const client = makeClient(files, rec, {
       compileProjectCss: (_candidates, stylesheet) => {
         seenStylesheet = stylesheet;
-        return Promise.resolve({ css: "body{}", styleProfileHash: "sp-1" });
+        return Promise.resolve(compiledCss("body{}"));
       },
     });
-    const transform = (s: string) => Promise.resolve(s);
-
-    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
-
-    assertExists(seenStylesheet);
-    assertEquals(
-      seenStylesheet!.includes(".button"),
-      false,
-      "CSS module content must not be inlined unscoped into the release stylesheet",
+    const scopedButtonClass = toScopedCssModuleClass(
+      "/components/button.module.css",
+      "button",
     );
+    const transform = (source: string, sourceFile: string) =>
+      Promise.resolve(
+        sourceFile.endsWith("components/Button.tsx")
+          ? `export const buttonClass = ${JSON.stringify(scopedButtonClass)};`
+          : source,
+      );
+
+    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    assertEquals(result.success, true);
+    assertExists(seenStylesheet);
+    assertStringIncludes(seenStylesheet!, `.${scopedButtonClass} { color: red; }`);
+    assertEquals(seenStylesheet!.includes(".button { color: red; }"), false);
   });
 
-  it("passes helper-composed Tailwind candidates to compileProjectCss", async () => {
+  it("produces identical module and CSS assets across temporary roots", async () => {
+    const files = [
+      { path: "components/card.module.css", content: ".root { color: red; }" },
+      {
+        path: "pages/index.tsx",
+        content: 'import styles from "../components/card.module.css"; export default styles.root;',
+      },
+    ];
+    const scopedClass = toScopedCssModuleClass("/components/card.module.css", "root");
+
+    async function build(): Promise<ReleaseAssetManifest> {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const client = makeClient(files, rec, {
+        compileProjectCss: (_candidates, stylesheet) =>
+          Promise.resolve(compiledCss(stylesheet ?? "")),
+      });
+      const result = await runReleaseAssetBuild(
+        baseInput(client, () => Promise.resolve(`export default ${JSON.stringify(scopedClass)};`)),
+        await tmp(),
+      );
+      assertEquals(result.success, true);
+      const manifest = parseReleaseAssetManifest(rec.manifest);
+      assertExists(manifest);
+      return manifest;
+    }
+
+    const first = await build();
+    const second = await build();
+    assertEquals(first.modules["pages/index.tsx"], second.modules["pages/index.tsx"]);
+    assertEquals(first.css, second.css);
+  });
+
+  it("fails closed when an imported stylesheet is missing or unsupported", async () => {
+    for (
+      const specifier of ["./missing.css", "theme-package/theme.css", "https://cdn.test/x.css"]
+    ) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      let compileCalls = 0;
+      const client = makeClient(
+        [{
+          path: "pages/index.tsx",
+          content: `import ${JSON.stringify(specifier)}; export default null;`,
+        }],
+        rec,
+        {
+          compileProjectCss: () => {
+            compileCalls++;
+            return Promise.resolve(compiledCss("body{}"));
+          },
+        },
+      );
+
+      const result = await runReleaseAssetBuild(
+        baseInput(client, () => Promise.resolve("export default null;")),
+        await tmp(),
+      );
+
+      assertCoverageFailure(
+        result,
+        rec,
+        specifier.startsWith("./")
+          ? "stylesheet-import-missing:pages/missing.css"
+          : "stylesheet-import-unsupported:pages/index.tsx",
+      );
+      assertEquals(compileCalls, 0, specifier);
+    }
+  });
+
+  it("passes helper-composed CSS candidates to compileProjectCss", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       {
@@ -1872,7 +2329,7 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     const client = makeClient(files, rec, {
       compileProjectCss: (candidates) => {
         seenCandidates = new Set(candidates);
-        return Promise.resolve({ css: ".h-16{height:4rem}", styleProfileHash: "sp-1" });
+        return Promise.resolve(compiledCss(".h-16{height:4rem}"));
       },
     });
     const transform = (s: string) => Promise.resolve(s);
@@ -1973,7 +2430,12 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     const client = makeClient(files, rec);
     const transform = (s: string) => Promise.resolve(s);
 
-    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+    await runReleaseAssetBuild({
+      ...baseInput(client, transform),
+      loadConfig: releaseConfigLoader({
+        directories: { app: "src\\site", pages: "src\\pages" },
+      }),
+    }, await tmp());
 
     const manifest = parseReleaseAssetManifest(rec.manifest);
     assertExists(manifest);
@@ -1984,6 +2446,24 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
       "src/site/layout.tsx",
     ]);
     assertEquals(manifest.routes["/about"]?.modules, ["src/pages/about.tsx"]);
+  });
+
+  it("fails closed on route collisions independently of release file order", async () => {
+    const collidingFiles = [
+      { path: "pages/index.tsx", content: "export default () => null;" },
+      { path: "app/page.tsx", content: "export default () => null;" },
+    ];
+
+    for (const files of [collidingFiles, [...collidingFiles].reverse()]) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const client = makeClient(files, rec);
+      const result = await runReleaseAssetBuild(
+        baseInput(client, (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertCoverageFailure(result, rec, "route-collision:/");
+    }
   });
 
   // H1: non-transform failures (e.g., listAllReleaseFiles throws) report failed.
@@ -2003,6 +2483,44 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     assertEquals(rec.states[0]?.state, "failed");
     // Error is sanitized.
     assert(!(rec.states[0]?.error ?? "").includes("/internal/path"));
+  });
+
+  it("reports downstream failures for both acknowledged active build states", async () => {
+    for (const state of ["queued", "building"] as const) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const client = makeClient([], rec, {
+        beginReleaseAssetManifestBuild: () => {
+          rec.began = true;
+          return Promise.resolve({ id: `build-${state}`, manifest_version: 7, state });
+        },
+        listAllReleaseFiles: () => Promise.reject(new Error(`source listing failed: ${state}`)),
+      });
+
+      const result = await runReleaseAssetBuild(
+        baseInput(client, (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertEquals(result.success, false, state);
+      assertEquals(rec.states.map(({ state }) => state), ["failed"], state);
+    }
+  });
+
+  it("preserves the primary build failure when failure reporting also fails", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient([], rec, {
+      listAllReleaseFiles: () => Promise.reject(new Error("primary source listing failure")),
+      reportReleaseAssetManifestState: () =>
+        Promise.reject(new Error("secondary state reporting failure")),
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertStringIncludes(result.error ?? "", "primary source listing failure");
   });
 
   // H1: PUT failure also reports failed.
@@ -2046,8 +2564,412 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     assertEquals(manifest.manifestVersion, 42);
   });
 
-  // M2: modules exceeding the 10 MB limit are skipped with a gap.
-  it("skips oversized modules with a gap instead of uploading (M2)", async () => {
+  it("hashes release file contents, not only the file-name set", async () => {
+    async function build(content: string): Promise<ReleaseAssetManifest> {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const client = makeClient([{ path: "pages/index.tsx", content }], rec);
+      const result = await runReleaseAssetBuild(
+        baseInput(client, (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+      assertEquals(result.success, true);
+      const parsed = parseReleaseAssetManifest(rec.manifest);
+      assertExists(parsed);
+      return parsed;
+    }
+
+    const first = await build("export default 1;");
+    const second = await build("export default 2;");
+
+    assert(first.sourceContentHash !== second.sourceContentHash);
+  });
+
+  it("fails closed when an upload is not acknowledged", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "export default null;" }],
+      rec,
+      {
+        uploadReleaseAsset: () => Promise.resolve({ stored: false, existed: false }),
+      },
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(rec.manifest, null);
+    assertEquals(rec.states.map(({ state }) => state), ["failed"]);
+  });
+
+  it("does not execute accessors on upload acknowledgements", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    let accessorCalls = 0;
+    const forgedAcknowledgement: Record<string, unknown> = { existed: false };
+    Object.defineProperty(forgedAcknowledgement, "stored", {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return true;
+      },
+    });
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "export default null;" }],
+      rec,
+      {
+        uploadReleaseAsset: () =>
+          Promise.resolve(
+            forgedAcknowledgement as unknown as { stored: boolean; existed: boolean },
+          ),
+      },
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(accessorCalls, 0);
+    assertEquals(rec.manifest, null);
+  });
+
+  it("fails closed when PUT does not acknowledge the expected manifest", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "export default null;" }],
+      rec,
+      {
+        putReleaseAssetManifest: (_version, manifest) => {
+          rec.manifest = manifest;
+          return Promise.resolve({ state: "failed", manifest_version: 99 });
+        },
+      },
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(result.state, "failed");
+    assertEquals(rec.states.map(({ state }) => state), ["failed"]);
+  });
+
+  it("requires the PUT acknowledgement to name the exact manifest generation", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "export default null;" }],
+      rec,
+      {
+        putReleaseAssetManifest: (_version, manifest) => {
+          rec.manifest = manifest;
+          return Promise.resolve({ state: "ready" });
+        },
+      },
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(result.state, "failed");
+    assertEquals(rec.states.map(({ state }) => state), ["failed"]);
+  });
+
+  it("does not execute accessors on manifest PUT acknowledgements", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    let accessorCalls = 0;
+    const forgedAcknowledgement: Record<string, unknown> = { manifest_version: 7 };
+    Object.defineProperty(forgedAcknowledgement, "state", {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return "ready";
+      },
+    });
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "export default null;" }],
+      rec,
+      {
+        putReleaseAssetManifest: (_version, manifest) => {
+          rec.manifest = manifest;
+          return Promise.resolve(
+            forgedAcknowledgement as unknown as { state: string; manifest_version?: number },
+          );
+        },
+      },
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(accessorCalls, 0);
+    assertEquals(rec.states.map(({ state }) => state), ["failed"]);
+  });
+
+  it("rejects unsafe manifest versions before materializing release files", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    let listed = false;
+    const client = makeClient([], rec, {
+      beginReleaseAssetManifestBuild: () =>
+        Promise.resolve({ id: "build-1", manifest_version: Number.NaN, state: "building" }),
+      listAllReleaseFiles: () => {
+        listed = true;
+        return Promise.resolve([]);
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(listed, false);
+    assertEquals(rec.states, []);
+  });
+
+  it("does not execute accessors on build-start acknowledgements", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    let accessorCalls = 0;
+    let listed = false;
+    const forgedAcknowledgement: Record<string, unknown> = {
+      id: "build-1",
+      manifest_version: 7,
+    };
+    Object.defineProperty(forgedAcknowledgement, "state", {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return "building";
+      },
+    });
+    const client = makeClient([], rec, {
+      beginReleaseAssetManifestBuild: () =>
+        Promise.resolve(
+          forgedAcknowledgement as unknown as {
+            id: string;
+            manifest_version: number;
+            state: string;
+          },
+        ),
+      listAllReleaseFiles: () => {
+        listed = true;
+        return Promise.resolve([]);
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(accessorCalls, 0);
+    assertEquals(listed, false);
+    assertEquals(rec.states, []);
+  });
+
+  it("does not mutate remote state for terminal build-start acknowledgements", async () => {
+    for (const state of ["ready", "partial", "failed", "superseded"] as const) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      let listed = false;
+      const client = makeClient([], rec, {
+        beginReleaseAssetManifestBuild: () => {
+          rec.began = true;
+          return Promise.resolve({ id: `build-${state}`, manifest_version: 7, state });
+        },
+        listAllReleaseFiles: () => {
+          listed = true;
+          return Promise.resolve([]);
+        },
+      });
+
+      const result = await runReleaseAssetBuild(
+        baseInput(client, (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertEquals(result.success, false, state);
+      assertEquals(listed, false, state);
+      assertEquals(rec.uploads, [], state);
+      assertEquals(rec.manifest, null, state);
+      assertEquals(rec.states, [], state);
+    }
+  });
+
+  it("does not report failure when build start rejects", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    let listed = false;
+    const client = makeClient([], rec, {
+      beginReleaseAssetManifestBuild: () => Promise.reject(new Error("build start unavailable")),
+      listAllReleaseFiles: () => {
+        listed = true;
+        return Promise.resolve([]);
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(listed, false);
+    assertEquals(rec.states, []);
+  });
+
+  it("does not report failure before build ownership is established", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient([], rec);
+    const input = {
+      ...baseInput(client, (source) => Promise.resolve(source)),
+      projectId: "",
+    };
+
+    const result = await runReleaseAssetBuild(input, await tmp());
+
+    assertEquals(result.success, false);
+    assertEquals(rec.began, false);
+    assertEquals(rec.states, []);
+  });
+
+  it("rejects non-canonical release file paths", async () => {
+    for (const path of ["pages/./index.tsx", "pages//index.tsx"]) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const client = makeClient([{ path, content: "export default null;" }], rec);
+
+      const result = await runReleaseAssetBuild(
+        baseInput(client, (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertEquals(result.success, false, path);
+      assertEquals(rec.manifest, null, path);
+    }
+  });
+
+  it("rejects duplicate slash aliases after normalizing Windows release paths", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient(
+      [
+        { path: "pages\\index.tsx", content: "export default null;" },
+        { path: "pages/index.tsx", content: "export default null;" },
+      ],
+      rec,
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertEquals(rec.manifest, null);
+  });
+
+  it("rejects portable case-folding path collisions before materialization", async () => {
+    const fileOrders = [
+      ["components/Foo.tsx", "components/foo.tsx"],
+      ["components/foo.tsx", "components/Foo.tsx"],
+    ];
+    for (const paths of fileOrders) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const tempDir = await tmp();
+      const client = makeClient(
+        paths.map((path) => ({ path, content: "export default null;" })),
+        rec,
+      );
+
+      const result = await runReleaseAssetBuild(
+        baseInput(client, (source) => Promise.resolve(source)),
+        tempDir,
+      );
+
+      assertEquals(result.success, false, paths.join(","));
+      assertEquals(rec.manifest, null, paths.join(","));
+      const materialized: string[] = [];
+      for await (const entry of Deno.readDir(tempDir)) materialized.push(entry.name);
+      assertEquals(materialized, [], paths.join(","));
+    }
+  });
+
+  it("rejects non-NFC and Windows-reserved release paths", async () => {
+    for (const path of ["components/cafe\u0301.tsx", "components/CON.tsx", "lib/name:ads.ts"]) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const tempDir = await tmp();
+      const client = makeClient([{ path, content: "export default null;" }], rec);
+
+      const result = await runReleaseAssetBuild(
+        baseInput(client, (source) => Promise.resolve(source)),
+        tempDir,
+      );
+
+      assertEquals(result.success, false, path);
+      const materialized: string[] = [];
+      for await (const entry of Deno.readDir(tempDir)) materialized.push(entry.name);
+      assertEquals(materialized, [], path);
+    }
+  });
+
+  it("uploads equal JavaScript and CSS bytes under both content identities", async () => {
+    const shared = "same release asset bytes";
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "source" }],
+      rec,
+      {
+        compileProjectCss: () => Promise.resolve(compiledCss(shared)),
+      },
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, () => Promise.resolve(shared)),
+      await tmp(),
+    );
+    assertEquals(result.success, true);
+
+    const sharedUploads = rec.uploads.filter(({ text }) => text === shared);
+    assertEquals(
+      sharedUploads.map(({ contentType }) => contentType).sort(),
+      ["text/css", "text/javascript"],
+    );
+  });
+
+  it("fails the release when compiled CSS exceeds the upload boundary", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const oversizedCss = "x".repeat(RELEASE_ASSET_MAX_SIZE_BYTES + 1);
+    const client = makeClient(
+      [{ path: "pages/index.tsx", content: "export default null;" }],
+      rec,
+      {
+        compileProjectCss: () => Promise.resolve(compiledCss(oversizedCss)),
+      },
+    );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+    assertEquals(result.success, false);
+    assertEquals(result.state, "failed");
+    assertEquals(rec.manifest, null);
+    assertEquals(rec.states.at(-1)?.state, "failed");
+    assertStringIncludes(result.error ?? "", "CSS output exceeds");
+    assertEquals(rec.uploads.some(({ text }) => text.length > RELEASE_ASSET_MAX_SIZE_BYTES), false);
+  });
+
+  // M2: modules exceeding the 10 MB limit fail before any upload.
+  it("fails closed on oversized modules without uploading (M2)", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
     const client = makeClient(files, rec);
@@ -2057,12 +2979,79 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
 
     const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
-    const manifest = parseReleaseAssetManifest(rec.manifest);
-    assertExists(manifest);
-    // Module is skipped — not uploaded as a page asset, not in manifest modules.
-    assertEquals(Object.keys(manifest.modules).length, 0);
-    // Gap is recorded.
-    assert(result.gaps.some((g) => g.startsWith("oversized:")));
+    assertCoverageFailure(result, rec, "oversized:pages/index.tsx");
+  });
+
+  // L3: nested index route derivation.
+  it("routeForPage derives nested index routes correctly (L3)", () => {
+    assertEquals(routeForPage("pages/index.tsx"), "/");
+    assertEquals(routeForPage("pages/about.tsx"), "/about");
+    assertEquals(routeForPage("pages/blog/index.tsx"), "/blog");
+    assertEquals(routeForPage("pages/blog/post.tsx"), "/blog/post");
+    assertEquals(routeForPage("pages/a/b/index.tsx"), "/a/b");
+    assertEquals(routeForPage("pages/api/hello.ts"), null);
+    assertEquals(routeForPage("pages/api/users/[id].ts"), null);
+    assertEquals(routeForPage("pages/index.d.ts"), null);
+    assertEquals(routeForPage("pages/blog/post.d.ts"), null);
+    assertEquals(routeForPage("pages/index.css"), null);
+    assertEquals(routeForPage("pages/_app.tsx"), null);
+    assertEquals(routeForPage("pages/_document.tsx"), null);
+    assertEquals(routeForPage("pages/blog/_draft.tsx"), null);
+    assertEquals(routeForPage("app/page.tsx"), "/");
+    assertEquals(routeForPage("app/(marketing)/page.tsx"), "/");
+    assertEquals(routeForPage("app/(marketing)/blog/page.tsx"), "/blog");
+    assertEquals(routeForPage("app/page.d.ts"), null);
+    assertEquals(routeForPage("app/page.css"), null);
+    assertEquals(routeForPage("app/@modal/page.tsx"), null);
+    assertEquals(routeForPage("app/_components/page.tsx"), null);
+    assertEquals(routeForPage("components/Button.tsx"), null);
+    assertEquals(routeForPage("pages/../secret.tsx"), null);
+    assertEquals(routeForPage("pages/not-a-module.txt"), null);
+    assertEquals(routeForPage("pages//index.tsx"), null);
+    assertEquals(routeForPage(`pages/${"a".repeat(2_048)}.tsx`), null);
+  });
+
+  it("bounds oversized cycle diagnostics before failing the build", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const firstUrl = `https://example.com/${"a".repeat(1_400)}`;
+    const secondUrl = `https://example.com/${"b".repeat(1_400)}`;
+    const firstPath = "/tmp/veryfront-http-bundle/http-long-a.mjs";
+    const secondPath = "/tmp/veryfront-http-bundle/http-long-b.mjs";
+    const files = [{
+      path: "pages/index.tsx",
+      content: "export default null;",
+    }];
+    const client = makeClient(files, rec);
+    const input = {
+      ...baseInput(
+        client,
+        () => Promise.resolve(`import value from "${firstUrl}"; export default value;`),
+      ),
+      vendorHttpImports: withFakeReactVendor((code: string) =>
+        Promise.resolve({
+          code: code.replace(firstUrl, `file://${firstPath}`),
+          dependencies: [
+            {
+              specifier: `file://${firstPath}`,
+              manifestKey: firstUrl,
+              sourcePath: firstPath,
+              code: 'import value from "./http-long-b.mjs"; export default value;',
+            },
+            {
+              specifier: `file://${secondPath}`,
+              manifestKey: secondUrl,
+              sourcePath: secondPath,
+              code: 'import value from "./http-long-a.mjs"; export default value;',
+            },
+          ],
+        })
+      ),
+    };
+
+    const result = await runReleaseAssetBuild(input, await tmp());
+
+    assertCoverageFailure(result, rec, "coverage-failures:detail-limit-exceeded");
   });
 });
 

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -3,38 +3,43 @@
  *
  * Runs inside the project runtime as the `task:release-asset-build` handler.
  * Materializes a release's file set, transforms every browser module through
- * the SAME pipeline `serveModule` uses (byte parity with the JIT fallback is a
- * hard requirement), compiles route CSS where reachable, content-addresses and
+ * the SAME pipeline `serveModule` uses (byte parity is a hard requirement),
+ * compiles route CSS where reachable, content-addresses and
  * uploads each asset, then assembles and PUTs the manifest (→ ready).
  *
  * Defensive by construction:
- * - Browser graph failures that can fall back to JIT are recorded as gaps.
- * - Other build failures (list/hash/upload/PUT) report `failed`.
+ * - Any browser graph or CSS coverage failure prevents manifest publication.
+ * - Build failures (transform/list/hash/upload/PUT) report `failed`.
  * - The temp dir is always cleaned up by the caller.
  *
  * @module release-assets/build-executor
  */
 
-import {
-  findUnknownTopLevelKeys,
-  validateVeryfrontConfig,
-  type VeryfrontConfig,
-} from "#veryfront/config";
+import type { VeryfrontConfig } from "#veryfront/config";
 import { VERYFRONT_CONFIG_FILES } from "#veryfront/config/config-files.ts";
-import { mergeConfigs } from "#veryfront/config/loader.ts";
-import { serverLogger } from "#veryfront/utils";
+import { serverLogger } from "#veryfront/utils/logger/index.ts";
+import {
+  isCSSPipelineIdentity,
+  isStyleProfileHash,
+} from "#veryfront/utils/css-artifact-identity.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
-import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
-import { getHostEnv } from "#veryfront/platform/compat/process.ts";
-import { dirname, join, normalize, toFileUrl } from "#veryfront/compat/path/index.ts";
+import { createFileSystem, isNotFoundError, realPath } from "#veryfront/platform/compat/fs.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import {
+  dirname,
+  fromFileUrl,
+  isAbsolute,
+  join,
+  normalize,
+  toFileUrl,
+} from "#veryfront/compat/path/index.ts";
 import {
   FRAMEWORK_EMBEDDED_SRC_DIR,
   FRAMEWORK_SRC_DIR,
   resolveFrameworkSourcePath,
   resolveRelativeFrameworkSourceImport,
 } from "#veryfront/platform/compat/framework-source-resolver.ts";
-import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
-import { cacheHttpImportsToLocal, normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
+import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache-helpers.ts";
 import { extractSourceUrl } from "#veryfront/transforms/esm/source-url-embed.ts";
 import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 import {
@@ -46,39 +51,42 @@ import {
 } from "#veryfront/transforms/esm/package-registry.ts";
 import { getReactUrls } from "#veryfront/transforms/esm/react-cdn.ts";
 import { PLATFORM_UTILITIES } from "#veryfront/html/utils.ts";
-import { ensureDefaultBundlerContracts } from "../extensions/bundler/defaults.ts";
-import { register, tryResolve } from "../extensions/contracts.ts";
-import type { Plugin } from "veryfront/extensions/bundler";
-import { getEsbuildLoader } from "#veryfront/utils/path-utils.ts";
 import { extractCandidatesFromFiles } from "#veryfront/html/styles-builder/candidate-extractor.ts";
 import { FRAMEWORK_CANDIDATES } from "#veryfront/server/handlers/dev/framework-candidates.generated.ts";
 import { validatePathSync } from "#veryfront/security/path-validation.ts";
 import {
-  collectCssImportPaths,
   CSS_IMPORTING_SOURCE_EXTENSIONS,
+  resolveCssImportPath,
 } from "#veryfront/html/styles-builder/css-import-extraction.ts";
+import { rewriteCssModuleContent } from "#veryfront/transforms/css-modules/naming.ts";
 import { computeHashBytes } from "#veryfront/utils";
 import {
   RELEASE_ASSET_BASE_PATH,
   RELEASE_ASSET_CONTENT_TYPES,
-  RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG,
+  RELEASE_ASSET_MANIFEST_LIMITS,
   RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
+  RELEASE_ASSET_MAX_PENDING_BYTES,
   RELEASE_ASSET_MAX_SIZE_BYTES,
   RELEASE_ASSET_UPLOAD_CONCURRENCY,
+  type ReleaseAssetContentType,
   releaseAssetUrl,
 } from "./constants.ts";
 import {
   configuredRoutePath,
-  normalizeLogicalPath,
+  normalizeLogicalPath as normalizeRouteLogicalPath,
   routeForConfiguredPage,
   routeForPage,
 } from "./route-path.ts";
 export { routeForPage } from "./route-path.ts";
-import type {
-  ReleaseAssetCssEntry,
-  ReleaseAssetManifest,
-  ReleaseAssetRouteEntry,
+import { hasControlCharacters } from "./string-validation.ts";
+import {
+  parseReleaseAssetManifest,
+  type ReleaseAssetCssEntry,
+  type ReleaseAssetDependencyMode,
+  type ReleaseAssetManifest,
+  type ReleaseAssetRouteEntry,
 } from "./manifest-schema.ts";
+import type { CompileProjectCssResult } from "./css-compile.ts";
 
 const logger = serverLogger.component("release-asset-build");
 
@@ -95,11 +103,26 @@ const REACT_IMPORT_MAP_DEPENDENCIES = [
   "react/jsx-runtime",
   "react/jsx-dev-runtime",
 ] as const;
+const MAX_RELEASE_FILES = 50_000;
+const MAX_RELEASE_FILE_PATH_LENGTH = RELEASE_ASSET_MANIFEST_LIMITS.manifestKeyLength;
+const MAX_RELEASE_SOURCE_BYTES = 64 * 1024 * 1024;
+const MAX_CSS_CANDIDATES = 100_000;
+const MAX_CSS_INPUT_BYTES = RELEASE_ASSET_MAX_SIZE_BYTES;
+const MAX_BUILD_IDENTIFIER_LENGTH = RELEASE_ASSET_MANIFEST_LIMITS.identifierLength;
+const MAX_DEPENDENCY_MODULES = RELEASE_ASSET_MANIFEST_LIMITS.dependencyEntries;
+const MAX_DEPENDENCY_SPECIFIERS = RELEASE_ASSET_MANIFEST_LIMITS.dependencySpecifiers;
+const MAX_DEPENDENCY_SOURCE_BYTES = RELEASE_ASSET_MAX_PENDING_BYTES;
+const MAX_DEPENDENCY_DIRECTORY_DEPTH = 64;
+const MAX_DEPENDENCY_SPECIFIER_LENGTH = RELEASE_ASSET_MANIFEST_LIMITS.manifestKeyLength;
+const FRAMEWORK_DEPENDENCY_ENTRY_RESERVE = Object.keys(PLATFORM_UTILITIES).length;
+const MAX_HTTP_DEPENDENCY_ENTRIES = Math.max(
+  0,
+  RELEASE_ASSET_MANIFEST_LIMITS.dependencyEntries - FRAMEWORK_DEPENDENCY_ENTRY_RESERVE,
+);
+const textEncoder = new TextEncoder();
+type VeryfrontConfigFileName = (typeof VERYFRONT_CONFIG_FILES)[number];
 
-function isDependencyImportMapEnabled(): boolean {
-  return getHostEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG) === "1";
-}
-
+/** Inputs required to build and publish one release asset manifest generation. */
 export interface ReleaseAssetBuildInput {
   /** Project reference (slug or id) used for API calls. */
   projectReference: string;
@@ -111,38 +134,52 @@ export interface ReleaseAssetBuildInput {
   releaseVersion: number;
   /** Release version string used for API path segments. */
   releaseVersionRef: string;
-  /** React version for transforms. */
-  reactVersion?: string;
   /**
-   * Fallback Tailwind stylesheet path (relative to the project root). The
-   * release's own veryfront.config.* from the materialized file set is
-   * preferred; when absent, this path and then conventional defaults are tried.
+   * Trusted composition seam for declaratively evaluating the exact config
+   * source selected from the immutable release file set. Implementations must
+   * return a validated configuration snapshot without executing tenant code in
+   * the host realm. `null` requests framework defaults.
    */
-  stylesheetPath?: string;
+  loadConfig: ReleaseAssetConfigLoader;
   /** Authenticated, project-scoped API client. */
   client: ReleaseAssetBuildClient;
   /** Runtime adapter used by the transform pipeline. */
-  // deno-lint-ignore no-explicit-any -- adapter is passed through to transformToESM
-  adapter: any;
+  adapter: RuntimeAdapter;
   /**
-   * Transform function. Defaults to the same `transformToESM` pipeline
-   * `serveModule` uses (browser, non-SSR) — byte parity is a hard requirement.
-   * Injectable for tests.
+   * Dependency closure represented by the published manifest. `immutable`
+   * requires an explicitly composed policy-enforced vendor; `source` keeps
+   * transformed HTTP imports on their canonical source URLs.
    */
-  transform?: ReleaseAssetTransform;
+  dependencyMode: ReleaseAssetDependencyMode;
   /**
-   * Optional HTTP dependency vendor. Defaults to the existing HTTP module cache
-   * and is injectable so tests do not depend on live package CDN behavior.
+   * Explicit browser transform composition seam. Production must provide the
+   * same pipeline `serveModule` uses (browser, non-SSR); byte parity is a hard
+   * requirement.
+   */
+  transform: ReleaseAssetTransform;
+  /**
+   * HTTP dependency vendor required by `dependencyMode: "immutable"`.
    */
   vendorHttpImports?: ReleaseAssetHttpDependencyVendor;
 }
 
+/** Exact configuration source selected from the immutable release file set. */
+export interface ReleaseAssetConfigSource {
+  readonly fileName: VeryfrontConfigFileName;
+  readonly source: string;
+}
+
+/** Trusted release configuration composition boundary. */
+export type ReleaseAssetConfigLoader = (
+  source: ReleaseAssetConfigSource | null,
+) => Promise<VeryfrontConfig>;
+
+/** Browser transform contract shared with the module-serving pipeline. */
 export type ReleaseAssetTransform = (
   source: string,
   sourceFile: string,
   projectDir: string,
-  // deno-lint-ignore no-explicit-any -- adapter is opaque to the executor
-  adapter: any,
+  adapter: RuntimeAdapter,
   options: {
     projectId: string;
     dev: boolean;
@@ -155,6 +192,7 @@ export type ReleaseAssetTransform = (
   },
 ) => Promise<string>;
 
+/** One vendored dependency and the source identity represented by its code. */
 export interface ReleaseAssetVendorDependency {
   /** Specifier currently used by transformed code after vendoring. */
   specifier: string;
@@ -166,11 +204,13 @@ export interface ReleaseAssetVendorDependency {
   code: string;
 }
 
+/** Rewritten module code plus every dependency needed by that rewrite. */
 export interface ReleaseAssetVendorResult {
   code: string;
   dependencies: ReleaseAssetVendorDependency[];
 }
 
+/** Injectable HTTP dependency vendoring contract. */
 export type ReleaseAssetHttpDependencyVendor = (
   code: string,
   options: {
@@ -190,7 +230,7 @@ export interface ReleaseAssetBuildClient {
   uploadReleaseAsset(
     version: string,
     contentHash: string,
-    contentType: string,
+    contentType: ReleaseAssetContentType,
     bytes: Uint8Array,
   ): Promise<{ stored: boolean; existed: boolean }>;
   putReleaseAssetManifest(
@@ -199,31 +239,36 @@ export interface ReleaseAssetBuildClient {
   ): Promise<{ state: string; manifest_version?: number }>;
   reportReleaseAssetManifestState(
     version: string,
-    state: "partial" | "failed",
+    state: "failed",
     error?: string,
   ): Promise<unknown>;
   /**
-   * Optional project CSS compiler; when absent, css:[] is recorded.
+   * Required project CSS compiler. A build client without an explicitly
+   * composed CSS pipeline is invalid even when the current source set happens
+   * not to request CSS.
    *
-   * Receives the Tailwind class candidates extracted from the release source
+   * Receives the CSS class candidates extracted from the release source
    * plus the resolved project stylesheet (so the implementation can compile
-   * without re-fetching the file set). Returns `null` only when no CSS input
-   * exists; failures reject and the executor records an explicit CSS gap.
+   * without re-fetching the file set). It may return `null` only when neither
+   * candidates nor a stylesheet require CSS. Invalid output and compilation
+   * failures fail the release build.
    */
-  compileProjectCss?(
+  compileProjectCss(
     candidates: Set<string>,
     stylesheet: string | undefined,
-    options?: { config?: VeryfrontConfig },
-  ): Promise<{ css: string; styleProfileHash: string | null } | null>;
+    options: { config: VeryfrontConfig },
+  ): Promise<CompileProjectCssResult | null>;
 }
 
+/** Observable outcome of a release asset build attempt. */
 export interface ReleaseAssetBuildResult {
   success: boolean;
   state: "ready" | "failed";
   moduleCount: number;
   cssCount: number;
   routeCount: number;
-  gaps: string[];
+  /** Bounded coverage diagnostics; always empty for a successful build. */
+  coverageFailures: readonly string[];
   error?: string;
 }
 
@@ -231,9 +276,10 @@ interface PreparedAsset {
   logicalPath: string;
   contentHash: string;
   size: number;
-  contentType: string;
+  contentType: ReleaseAssetContentType;
 }
 
+/** Prepared content-addressed asset bytes ready for upload. */
 export interface PreparedReleaseAsset extends PreparedAsset {
   bytes: Uint8Array;
 }
@@ -249,11 +295,120 @@ interface DependencyModule {
   specifiers: Set<string>;
   sourcePath?: string;
   code: string;
+  codeSize: number;
+}
+
+interface DependencyModuleCollection {
+  modules: Map<string, DependencyModule>;
+  specifierCount: number;
+  sourceBytes: number;
 }
 
 interface FinalizedDependencyModules {
   assets: Record<string, PreparedAsset>;
   fallbackUrls: Map<string, string>;
+}
+
+interface PendingAssetStore {
+  entries: Map<
+    string,
+    {
+      bytes: Uint8Array<ArrayBuffer>;
+      contentType: ReleaseAssetContentType;
+    }
+  >;
+  totalBytes: number;
+}
+
+interface FrameworkBuildContext {
+  projectId: string;
+  adapter: RuntimeAdapter;
+  reactVersion?: string;
+  allowHttp: boolean;
+  requestedSpecifiers?: ReadonlySet<string>;
+}
+
+function createPendingAssetStore(): PendingAssetStore {
+  return { entries: new Map(), totalBytes: 0 };
+}
+
+function pendingAssetKey(
+  contentHash: string,
+  contentType: ReleaseAssetContentType,
+): string {
+  return JSON.stringify([contentHash, contentType]);
+}
+
+function rememberPendingAsset(
+  store: PendingAssetStore,
+  asset: PreparedAsset,
+  bytes: Uint8Array<ArrayBuffer>,
+): boolean {
+  const key = pendingAssetKey(asset.contentHash, asset.contentType);
+  const existing = store.entries.get(key);
+  if (existing) {
+    if (!bytesEqual(existing.bytes, bytes)) {
+      throw new Error("Release asset hash collision detected");
+    }
+    return false;
+  }
+
+  if (store.totalBytes + bytes.byteLength > RELEASE_ASSET_MAX_PENDING_BYTES) {
+    throw new Error(
+      `Pending release assets exceed ${RELEASE_ASSET_MAX_PENDING_BYTES} bytes`,
+    );
+  }
+
+  store.entries.set(key, { bytes, contentType: asset.contentType });
+  store.totalBytes += bytes.byteLength;
+  return true;
+}
+
+function getPendingAsset(
+  store: PendingAssetStore,
+  asset: PreparedAsset,
+): { bytes: Uint8Array<ArrayBuffer>; contentType: ReleaseAssetContentType } | undefined {
+  return store.entries.get(pendingAssetKey(asset.contentHash, asset.contentType));
+}
+
+function requirePendingAsset(
+  store: PendingAssetStore,
+  asset: PreparedAsset,
+): { bytes: Uint8Array<ArrayBuffer>; contentType: ReleaseAssetContentType } {
+  const stored = getPendingAsset(store, asset);
+  if (!stored) {
+    throw new Error("Prepared release asset is missing its pending bytes");
+  }
+  return stored;
+}
+
+function forgetPendingAsset(store: PendingAssetStore, asset: PreparedAsset): void {
+  const key = pendingAssetKey(asset.contentHash, asset.contentType);
+  const existing = store.entries.get(key);
+  if (!existing) return;
+  store.entries.delete(key);
+  store.totalBytes -= existing.bytes.byteLength;
+}
+
+function discardPendingAssetsSince(
+  uploadQueue: PreparedAsset[],
+  store: PendingAssetStore,
+  startIndex: number,
+): void {
+  for (const asset of uploadQueue.splice(startIndex)) {
+    forgetPendingAsset(store, asset);
+  }
+}
+
+function bytesEqual(
+  left: Uint8Array<ArrayBuffer>,
+  right: Uint8Array<ArrayBuffer>,
+): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  for (let index = 0; index < left.byteLength; index++) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
 }
 
 interface ReleaseRouterDirectories {
@@ -263,9 +418,20 @@ interface ReleaseRouterDirectories {
 
 function frameworkModuleUrlToSourceKey(moduleUrl: string): string | null {
   if (!moduleUrl.startsWith(FRAMEWORK_MODULE_URL_PREFIX)) return null;
-  return moduleUrl
+  const sourceKey = moduleUrl
     .slice(FRAMEWORK_MODULE_URL_PREFIX.length)
     .replace(/\.(mjs|cjs|js|jsx|ts|tsx)$/, "");
+  if (
+    sourceKey.length === 0 ||
+    sourceKey.length > RELEASE_ASSET_MANIFEST_LIMITS.manifestKeyLength ||
+    sourceKey.includes("\\") ||
+    sourceKey.includes("?") ||
+    sourceKey.includes("#") ||
+    hasControlCharacters(sourceKey)
+  ) {
+    return null;
+  }
+  return normalizeLogicalPath(sourceKey) === sourceKey ? sourceKey : null;
 }
 
 function frameworkSourceKeyToModuleUrl(sourceKey: string): string {
@@ -294,8 +460,12 @@ function frameworkSourcePathToSourceKey(sourcePath: string, lookupDirs: string[]
 
 /** Sanitize an error for state reporting (no internal paths / stack traces). */
 function sanitizeError(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/\/[^\s]+/g, "<path>").slice(0, 300);
+  try {
+    const message = error instanceof Error ? error.message : String(error);
+    return String(message).replace(/\/[^\s]+/g, "<path>").slice(0, 300);
+  } catch {
+    return "Unknown release asset build error";
+  }
 }
 
 /** True when a logical path is an eligible browser module. */
@@ -333,7 +503,7 @@ function collectConfiguredAppRouterLayoutsForPage(
 
   const segments = logicalPath.split("/");
   segments.pop();
-  const appRootDepth = normalizeLogicalPath(directories.app).split("/").filter(Boolean).length;
+  const appRootDepth = normalizeRouteLogicalPath(directories.app).split("/").filter(Boolean).length;
 
   const layouts: string[] = [];
   for (let depth = appRootDepth; depth <= segments.length; depth++) {
@@ -363,6 +533,7 @@ function resolveKnownModulePath(path: string, knownPaths: Set<string>): string |
       .replace(/^\/+/, "")
       .replace(/[?#].*$/, ""),
   );
+  if (!normalized) return null;
 
   if (normalized.startsWith("_veryfront/")) return null;
   if (knownPaths.has(normalized)) return normalized;
@@ -374,6 +545,21 @@ function resolveKnownModulePath(path: string, knownPaths: Set<string>): string |
   }
 
   return null;
+}
+
+function normalizeLogicalPath(path: string): string | null {
+  if (path.includes("\\") || hasControlCharacters(path)) return null;
+  const parts: string[] = [];
+  for (const part of path.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (parts.length === 0) return null;
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return parts.length > 0 ? parts.join("/") : null;
 }
 
 function normalizeProjectSpecifier(specifier: string, logicalPath: string): string | null {
@@ -458,6 +644,51 @@ async function rewriteProjectModuleImports(
   return await replaceSpecifiers(code, (specifier) => rewriteSpecifier(specifier));
 }
 
+async function assertFinalModuleImports(
+  code: string,
+  options: { allowHttp: boolean },
+): Promise<void> {
+  for (const imp of await parseImports(code)) {
+    if (imp.d === -2) continue;
+    if (imp.n === undefined) {
+      throw new Error("Release module contains a non-literal dynamic import");
+    }
+
+    const specifier = imp.n;
+    if (
+      !hasControlCharacters(specifier) &&
+      /^\/_vf\/assets\/[0-9a-f]{64}\.js(?:[?#].*)?$/.test(specifier)
+    ) {
+      continue;
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(specifier);
+    } catch {
+      throw new Error(`Release module contains an unresolved import: ${specifier}`);
+    }
+
+    const protocol = parsed.protocol.toLowerCase();
+    if (protocol === "http:" || protocol === "https:") {
+      if (
+        !options.allowHttp ||
+        parsed.username !== "" ||
+        parsed.password !== "" ||
+        !isSafeBuildText(specifier, MAX_DEPENDENCY_SPECIFIER_LENGTH)
+      ) {
+        throw new Error("Release module contains an unvendored HTTP import");
+      }
+      continue;
+    }
+
+    if (protocol === "file:") {
+      throw new Error("Release module contains an unresolved local file import");
+    }
+    throw new Error(`Release module contains an unsupported import: ${specifier}`);
+  }
+}
+
 function dependencyUrlForSpecifier(
   dependencyUrls: Map<string, string>,
   specifier: string,
@@ -491,28 +722,79 @@ function buildDependencyUrlMap(
     const dependency = dependencyModules?.get(manifestKey);
     const url = releaseAssetUrl(entry.contentHash, "js");
 
-    urls.set(manifestKey, url);
-    urls.set(normalizeDependencySpecifier(manifestKey), url);
+    setDependencyUrlAlias(urls, manifestKey, url);
+    setDependencyUrlAlias(urls, normalizeDependencySpecifier(manifestKey), url);
     if (manifestKey.startsWith("http://") || manifestKey.startsWith("https://")) {
       const normalized = normalizeHttpUrl(manifestKey);
-      urls.set(normalized, url);
-      urls.set(normalizeDependencySpecifier(normalized), url);
+      setDependencyUrlAlias(urls, normalized, url);
+      setDependencyUrlAlias(urls, normalizeDependencySpecifier(normalized), url);
     }
 
     if (!dependency) continue;
 
-    urls.set(entry.logicalPath, url);
+    setDependencyUrlAlias(urls, entry.logicalPath, url);
     for (const specifier of dependency.specifiers) {
-      urls.set(specifier, url);
-      urls.set(normalizeDependencySpecifier(specifier), url);
+      setDependencyUrlAlias(urls, specifier, url);
+      setDependencyUrlAlias(urls, normalizeDependencySpecifier(specifier), url);
       if (specifier.startsWith("http://") || specifier.startsWith("https://")) {
         const normalized = normalizeHttpUrl(specifier);
-        urls.set(normalized, url);
-        urls.set(normalizeDependencySpecifier(normalized), url);
+        setDependencyUrlAlias(urls, normalized, url);
+        setDependencyUrlAlias(urls, normalizeDependencySpecifier(normalized), url);
       }
     }
   }
   return urls;
+}
+
+function setDependencyUrlAlias(
+  urls: Map<string, string>,
+  key: string,
+  url: string,
+): void {
+  const existing = urls.get(key);
+  if (existing !== undefined && existing !== url) {
+    throw new Error(`Conflicting release dependency alias: ${key}`);
+  }
+  urls.set(key, url);
+}
+
+function setDependencyModuleAlias(
+  aliases: Map<string, DependencyModule>,
+  key: string,
+  dependency: DependencyModule,
+): void {
+  const existing = aliases.get(key);
+  if (existing && existing !== dependency) {
+    throw new Error(`Conflicting vendored dependency alias: ${key}`);
+  }
+  aliases.set(key, dependency);
+}
+
+function preparedAssetsEqual(left: PreparedAsset, right: PreparedAsset): boolean {
+  return left.contentHash === right.contentHash &&
+    left.size === right.size &&
+    left.contentType === right.contentType;
+}
+
+function mergePreparedAssetRecords(
+  ...records: Array<Record<string, PreparedAsset>>
+): Record<string, PreparedAsset> {
+  const merged: Record<string, PreparedAsset> = Object.create(null);
+  for (const record of records) {
+    for (const [key, asset] of Object.entries(record)) {
+      const existing = Object.hasOwn(merged, key) ? merged[key] : undefined;
+      if (existing && !preparedAssetsEqual(existing, asset)) {
+        throw new Error(`Conflicting release asset manifest key: ${key}`);
+      }
+      Object.defineProperty(merged, key, {
+        value: asset,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+  }
+  return merged;
 }
 
 export function buildReleaseAssetDependencyUrlMap(
@@ -524,8 +806,13 @@ export function buildReleaseAssetDependencyUrlMap(
 function exposeDependencySpecifierAliases(
   assets: Record<string, PreparedAsset>,
   dependencyModules: Map<string, DependencyModule>,
+  maximumEntries: number = RELEASE_ASSET_MANIFEST_LIMITS.dependencyEntries,
 ): Record<string, PreparedAsset> {
-  const aliased = { ...assets };
+  const aliased = mergePreparedAssetRecords(assets);
+  let entryCount = Object.keys(aliased).length;
+  if (entryCount > maximumEntries) {
+    throw new Error(`Release dependency manifest exceeds ${maximumEntries} entries`);
+  }
   for (const dependency of dependencyModules.values()) {
     const asset = assets[dependency.manifestKey];
     if (!asset) continue;
@@ -541,7 +828,20 @@ function exposeDependencySpecifierAliases(
       ) {
         continue;
       }
-      aliased[normalized] = asset;
+      const existing = Object.hasOwn(aliased, normalized) ? aliased[normalized] : undefined;
+      if (existing && !preparedAssetsEqual(existing, asset)) {
+        throw new Error(`Conflicting release dependency manifest alias: ${normalized}`);
+      }
+      if (!existing && entryCount >= maximumEntries) {
+        throw new Error(`Release dependency manifest exceeds ${maximumEntries} entries`);
+      }
+      Object.defineProperty(aliased, normalized, {
+        value: asset,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+      if (!existing) entryCount++;
     }
   }
   return aliased;
@@ -569,40 +869,286 @@ function addDependencyUrlAliases(
   dependency: DependencyModule,
   url: string,
 ): void {
-  urls.set(dependency.manifestKey, url);
-  if (dependency.sourcePath) urls.set(`file://${dependency.sourcePath}`, url);
+  setDependencyUrlAlias(urls, dependency.manifestKey, url);
+  if (dependency.sourcePath) {
+    setDependencyUrlAlias(urls, toFileUrl(dependency.sourcePath).href, url);
+  }
   for (const specifier of dependency.specifiers) {
-    urls.set(normalizeDependencySpecifier(specifier), url);
+    setDependencyUrlAlias(urls, normalizeDependencySpecifier(specifier), url);
   }
 }
 
-function addDependencyModule(
-  dependencies: Map<string, DependencyModule>,
-  dependency: ReleaseAssetVendorDependency,
-): void {
-  const sourcePath = dependency.sourcePath ?? resolveLocalDependencyPath(dependency.specifier) ??
-    undefined;
-  const existing = dependencies.get(dependency.manifestKey);
-  if (existing) {
-    existing.specifiers.add(dependency.specifier);
-    existing.sourcePath ??= sourcePath;
-    return;
+const UNREADABLE_DATA_PROPERTY = Symbol("unreadable-data-property");
+
+function readOwnDataProperty(
+  value: unknown,
+  key: PropertyKey,
+): unknown | typeof UNREADABLE_DATA_PROPERTY {
+  if (typeof value !== "object" || value === null) return UNREADABLE_DATA_PROPERTY;
+  try {
+    const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+    if (!descriptor) return undefined;
+    return Object.hasOwn(descriptor, "value") ? descriptor.value : UNREADABLE_DATA_PROPERTY;
+  } catch {
+    return UNREADABLE_DATA_PROPERTY;
+  }
+}
+
+function snapshotCompiledProjectCss(value: unknown): CompileProjectCssResult {
+  const css = readOwnDataProperty(value, "css");
+  const styleProfileHash = readOwnDataProperty(value, "styleProfileHash");
+  const cssPipelineIdentity = readOwnDataProperty(value, "cssPipelineIdentity");
+  if (
+    typeof css !== "string" ||
+    css.length === 0 ||
+    !isStyleProfileHash(styleProfileHash) ||
+    !isCSSPipelineIdentity(cssPipelineIdentity)
+  ) {
+    throw new Error("Release asset CSS compiler returned an invalid identity result");
   }
 
-  dependencies.set(dependency.manifestKey, {
-    manifestKey: dependency.manifestKey,
-    specifiers: new Set([dependency.specifier]),
-    sourcePath,
-    code: dependency.code,
-  });
+  return Object.freeze({ css, styleProfileHash, cssPipelineIdentity });
+}
+
+function createDependencyModuleCollection(): DependencyModuleCollection {
+  return {
+    modules: new Map(),
+    specifierCount: 0,
+    sourceBytes: 0,
+  };
+}
+
+function clearDependencyModules(collection: DependencyModuleCollection): void {
+  collection.modules.clear();
+  collection.specifierCount = 0;
+  collection.sourceBytes = 0;
+}
+
+function validateVendorResult(
+  value: unknown,
+): { code: string; dependencies: readonly unknown[] } {
+  const code = readOwnDataProperty(value, "code");
+  const dependencies = readOwnDataProperty(value, "dependencies");
+  if (
+    typeof code !== "string" ||
+    textEncoder.encode(code).byteLength > RELEASE_ASSET_MAX_SIZE_BYTES ||
+    !Array.isArray(dependencies) ||
+    dependencies.length > MAX_DEPENDENCY_MODULES
+  ) {
+    throw new Error("HTTP dependency vendor returned an invalid or oversized result");
+  }
+  return { code, dependencies };
+}
+
+function stageDependencyModules(
+  dependencies: readonly unknown[],
+): DependencyModuleCollection {
+  const staged = createDependencyModuleCollection();
+
+  for (let index = 0; index < dependencies.length; index++) {
+    const dependency = readOwnDataProperty(dependencies, String(index));
+    const manifestKey = readOwnDataProperty(dependency, "manifestKey");
+    const specifier = readOwnDataProperty(dependency, "specifier");
+    const code = readOwnDataProperty(dependency, "code");
+    const declaredSourcePath = readOwnDataProperty(dependency, "sourcePath");
+    if (
+      !isSafeBuildText(manifestKey, MAX_DEPENDENCY_SPECIFIER_LENGTH) ||
+      !isSafeBuildText(specifier, MAX_DEPENDENCY_SPECIFIER_LENGTH) ||
+      typeof code !== "string"
+    ) {
+      throw new Error("Vendored dependency exceeds the supported boundary");
+    }
+
+    const codeSize = textEncoder.encode(code).byteLength;
+    if (codeSize > RELEASE_ASSET_MAX_SIZE_BYTES) {
+      throw new Error("Vendored dependency exceeds the supported boundary");
+    }
+
+    let sourcePath: string | undefined;
+    if (declaredSourcePath !== undefined) {
+      if (
+        !isSafeBuildText(declaredSourcePath, MAX_RELEASE_FILE_PATH_LENGTH) ||
+        !isAbsolute(declaredSourcePath) ||
+        normalize(declaredSourcePath) !== declaredSourcePath
+      ) {
+        throw new Error("Vendored dependency source path must be canonical and absolute");
+      }
+      sourcePath = declaredSourcePath;
+    } else {
+      sourcePath = resolveLocalDependencyPath(specifier) ?? undefined;
+    }
+
+    const existing = staged.modules.get(manifestKey);
+    if (existing) {
+      if (
+        existing.code !== code ||
+        (existing.sourcePath !== undefined &&
+          sourcePath !== undefined &&
+          existing.sourcePath !== sourcePath)
+      ) {
+        throw new Error(`Conflicting vendored dependency identity: ${manifestKey}`);
+      }
+      if (!existing.specifiers.has(specifier)) {
+        existing.specifiers.add(specifier);
+        staged.specifierCount++;
+      }
+      existing.sourcePath ??= sourcePath;
+    } else {
+      staged.modules.set(manifestKey, {
+        manifestKey,
+        specifiers: new Set([specifier]),
+        sourcePath,
+        code,
+        codeSize,
+      });
+      staged.specifierCount++;
+      staged.sourceBytes += codeSize;
+    }
+
+    if (
+      staged.modules.size > MAX_DEPENDENCY_MODULES ||
+      staged.specifierCount > MAX_DEPENDENCY_SPECIFIERS ||
+      staged.sourceBytes > MAX_DEPENDENCY_SOURCE_BYTES
+    ) {
+      throw new Error("Vendored dependency collection exceeds the supported boundary");
+    }
+  }
+
+  return staged;
+}
+
+function addStagedDependencySpecifier(
+  staged: DependencyModuleCollection,
+  dependency: DependencyModule,
+  specifier: string,
+): void {
+  if (!isSafeBuildText(specifier, MAX_DEPENDENCY_SPECIFIER_LENGTH)) {
+    throw new Error("Vendored dependency specifier exceeds the supported boundary");
+  }
+  if (dependency.specifiers.has(specifier)) return;
+  if (staged.specifierCount >= MAX_DEPENDENCY_SPECIFIERS) {
+    throw new Error("Vendored dependency specifiers exceed the supported boundary");
+  }
+  dependency.specifiers.add(specifier);
+  staged.specifierCount++;
+}
+
+function commitDependencyModules(
+  target: DependencyModuleCollection,
+  staged: DependencyModuleCollection,
+): void {
+  let addedModules = 0;
+  let addedSpecifiers = 0;
+  let addedSourceBytes = 0;
+
+  for (const dependency of staged.modules.values()) {
+    const existing = target.modules.get(dependency.manifestKey);
+    if (!existing) {
+      addedModules++;
+      addedSpecifiers += dependency.specifiers.size;
+      addedSourceBytes += dependency.codeSize;
+      continue;
+    }
+    if (
+      existing.code !== dependency.code ||
+      (existing.sourcePath !== undefined &&
+        dependency.sourcePath !== undefined &&
+        existing.sourcePath !== dependency.sourcePath)
+    ) {
+      throw new Error(
+        `Conflicting vendored dependency identity: ${dependency.manifestKey}`,
+      );
+    }
+    for (const specifier of dependency.specifiers) {
+      if (!existing.specifiers.has(specifier)) addedSpecifiers++;
+    }
+  }
+
+  if (
+    target.modules.size + addedModules > MAX_DEPENDENCY_MODULES ||
+    target.specifierCount + addedSpecifiers > MAX_DEPENDENCY_SPECIFIERS ||
+    target.sourceBytes + addedSourceBytes > MAX_DEPENDENCY_SOURCE_BYTES
+  ) {
+    throw new Error("Vendored dependency collection exceeds the supported boundary");
+  }
+
+  for (const dependency of staged.modules.values()) {
+    const existing = target.modules.get(dependency.manifestKey);
+    if (!existing) {
+      target.modules.set(dependency.manifestKey, {
+        ...dependency,
+        specifiers: new Set(dependency.specifiers),
+      });
+      continue;
+    }
+    for (const specifier of dependency.specifiers) existing.specifiers.add(specifier);
+    existing.sourcePath ??= dependency.sourcePath;
+  }
+
+  target.specifierCount += addedSpecifiers;
+  target.sourceBytes += addedSourceBytes;
+}
+
+function mergeDependencyModules(
+  target: DependencyModuleCollection,
+  dependencies: readonly unknown[],
+): void {
+  commitDependencyModules(target, stageDependencyModules(dependencies));
 }
 
 function normalizeDependencySpecifier(specifier: string): string {
-  return specifier.replace(/[?#].*$/, "");
+  return specifier.startsWith("http://") || specifier.startsWith("https://")
+    ? normalizeHttpUrl(specifier)
+    : specifier;
 }
 
+const gapIndexes = new WeakMap<string[], Set<string>>();
+const GAP_DETAIL_LIMIT_MARKER = "coverage-failures:detail-limit-exceeded";
+const GAP_ENTRY_LIMIT_MARKER = "coverage-failures:entry-limit-exceeded";
+
 function pushGap(gaps: string[], gap: string): void {
-  if (!gaps.includes(gap)) gaps.push(gap);
+  let index = gapIndexes.get(gaps);
+  if (!index) {
+    index = new Set(gaps);
+    gapIndexes.set(gaps, index);
+  }
+  if (index.has(GAP_ENTRY_LIMIT_MARKER)) return;
+
+  const boundedGap = gap.length > RELEASE_ASSET_MANIFEST_LIMITS.coverageFailureLength ||
+      gap.length === 0 ||
+      gap.trim() !== gap ||
+      hasControlCharacters(gap)
+    ? GAP_DETAIL_LIMIT_MARKER
+    : gap;
+  if (index.has(boundedGap)) return;
+
+  if (index.size >= RELEASE_ASSET_MANIFEST_LIMITS.coverageFailures - 1) {
+    index.add(GAP_ENTRY_LIMIT_MARKER);
+    gaps.push(GAP_ENTRY_LIMIT_MARKER);
+    return;
+  }
+
+  index.add(boundedGap);
+  gaps.push(boundedGap);
+}
+
+class IncompleteReleaseAssetBuildError extends Error {
+  readonly coverageFailures: readonly string[];
+
+  constructor(coverageFailures: readonly string[]) {
+    const snapshot = Object.freeze([...coverageFailures]);
+    const summary = snapshot.slice(0, 3).map((failure) => failure.slice(0, 200)).join(", ");
+    const remaining = snapshot.length > 3 ? ` (+${snapshot.length - 3} more)` : "";
+    super(`Release asset coverage is incomplete: ${summary}${remaining}`);
+    this.name = "IncompleteReleaseAssetBuildError";
+    this.coverageFailures = snapshot;
+  }
+}
+
+function assertCompleteReleaseAssetCoverage(coverageFailures: readonly string[]): void {
+  if (coverageFailures.length > 0) {
+    throw new IncompleteReleaseAssetBuildError(coverageFailures);
+  }
 }
 
 function dependencyLookupKeys(specifier: string): Set<string> {
@@ -646,7 +1192,7 @@ async function collectReactImportMapDependencyModules(
   input: { reactVersion?: string },
   tempDir: string,
   vendorHttpImports: ReleaseAssetHttpDependencyVendor,
-  dependencies: Map<string, DependencyModule>,
+  dependencies: DependencyModuleCollection,
 ): Promise<void> {
   const reactUrls = getReactUrls(input.reactVersion);
   const entries: Array<readonly [string, string]> = [];
@@ -658,21 +1204,23 @@ async function collectReactImportMapDependencyModules(
   const source = entries.map(([, url]) => `import ${JSON.stringify(url)};`).join("\n");
   if (!source) return;
 
-  const vendored = await vendorHttpImports(source, {
-    tempDir,
-    reactVersion: input.reactVersion,
-  });
-  for (const dependency of vendored.dependencies) {
-    addDependencyModule(dependencies, dependency);
-  }
+  const vendored = validateVendorResult(
+    await vendorHttpImports(source, {
+      tempDir,
+      reactVersion: input.reactVersion,
+    }),
+  );
+  const staged = stageDependencyModules(vendored.dependencies);
 
   for (const [specifier, url] of entries) {
-    const dependency = findDependencyModuleBySpecifier(dependencies, url);
+    const dependency = findDependencyModuleBySpecifier(staged.modules, url);
     if (!dependency) {
       throw new Error(`React import-map dependency missing: ${specifier}`);
     }
-    dependency.specifiers.add(specifier);
+    addStagedDependencySpecifier(staged, dependency, specifier);
   }
+
+  commitDependencyModules(dependencies, staged);
 }
 
 function resolveLocalDependencyPath(specifier: string, parentFilePath?: string): string | null {
@@ -680,7 +1228,17 @@ function resolveLocalDependencyPath(specifier: string, parentFilePath?: string):
 
   if (normalized.startsWith("file://")) {
     try {
-      return normalize(decodeURIComponent(new URL(normalized).pathname));
+      const url = new URL(normalized);
+      if (
+        url.protocol !== "file:" ||
+        (url.hostname !== "" && url.hostname !== "localhost") ||
+        url.username !== "" ||
+        url.password !== "" ||
+        url.port !== ""
+      ) {
+        return null;
+      }
+      return normalize(fromFileUrl(url));
     } catch (_) {
       return null;
     }
@@ -697,6 +1255,119 @@ function isPathInsideRoot(filePath: string, rootPath: string): boolean {
   const file = normalize(filePath);
   const root = normalize(rootPath);
   return file === root || file.startsWith(`${root}/`) || file.startsWith(`${root}\\`);
+}
+
+async function readHttpDependencyCacheFile(
+  fs: ReturnType<typeof createFileSystem>,
+  filePath: string,
+): Promise<{ code: string; sourceUrl: string }> {
+  const fileInfo = fs.lstat ? await fs.lstat(filePath) : await fs.stat(filePath);
+  if (
+    fileInfo.isSymlink ||
+    !fileInfo.isFile ||
+    fileInfo.isDirectory ||
+    !Number.isSafeInteger(fileInfo.size) ||
+    fileInfo.size < 0 ||
+    fileInfo.size > RELEASE_ASSET_MAX_SIZE_BYTES
+  ) {
+    throw new Error("HTTP dependency cache file is not a safe bounded regular file");
+  }
+
+  const bytes = await fs.readFile(filePath);
+  if (
+    bytes.byteLength !== fileInfo.size ||
+    bytes.byteLength > RELEASE_ASSET_MAX_SIZE_BYTES
+  ) {
+    throw new Error("HTTP dependency cache file changed while it was being read");
+  }
+
+  let code: string;
+  try {
+    code = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch (error) {
+    throw new Error("HTTP dependency cache file is not valid UTF-8", { cause: error });
+  }
+
+  const embeddedSourceUrl = extractSourceUrl(code);
+  if (
+    !isSafeBuildText(embeddedSourceUrl, MAX_DEPENDENCY_SPECIFIER_LENGTH) ||
+    (!embeddedSourceUrl.startsWith("http://") &&
+      !embeddedSourceUrl.startsWith("https://"))
+  ) {
+    throw new Error("HTTP dependency cache file is missing a valid HTTP source marker");
+  }
+
+  let parsedSourceUrl: URL;
+  try {
+    parsedSourceUrl = new URL(embeddedSourceUrl);
+  } catch (error) {
+    throw new Error("HTTP dependency cache file has an invalid HTTP source marker", {
+      cause: error,
+    });
+  }
+  if (parsedSourceUrl.protocol !== "http:" && parsedSourceUrl.protocol !== "https:") {
+    throw new Error("HTTP dependency cache file has an invalid HTTP source marker");
+  }
+
+  const sourceUrl = normalizeHttpUrl(parsedSourceUrl.toString());
+  if (!isSafeBuildText(sourceUrl, MAX_DEPENDENCY_SPECIFIER_LENGTH)) {
+    throw new Error("HTTP dependency cache source exceeds the supported boundary");
+  }
+  return { code, sourceUrl };
+}
+
+function isSafeBuildText(
+  value: unknown,
+  maximumLength: number = MAX_BUILD_IDENTIFIER_LENGTH,
+): value is string {
+  return typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= maximumLength &&
+    value.trim() === value &&
+    !hasControlCharacters(value);
+}
+
+function requireCanonicalReleaseFilePath(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_RELEASE_FILE_PATH_LENGTH ||
+    value.normalize("NFC") !== value ||
+    value.startsWith("/") ||
+    value.startsWith("\\") ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.endsWith("/") ||
+    value.endsWith("\\") ||
+    value.includes("?") ||
+    value.includes("#") ||
+    hasControlCharacters(value)
+  ) {
+    throw new Error("Release file path must be a canonical relative path");
+  }
+
+  const normalizedValue = value.replace(/\\/g, "/");
+  const parts = normalizedValue.split("/");
+  if (
+    parts.some((part) =>
+      part.length === 0 ||
+      part === "." ||
+      part === ".." ||
+      part.endsWith(".") ||
+      part.endsWith(" ") ||
+      part.includes(":") ||
+      /^(?:con|prn|aux|nul|clock\$|conin\$|conout\$|com[1-9¹²³]|lpt[1-9¹²³])(?:\.|$)/i
+        .test(part)
+    ) ||
+    normalizeLogicalPath(normalizedValue) !== normalizedValue
+  ) {
+    throw new Error("Release file path must be a canonical relative path");
+  }
+
+  return normalizedValue;
+}
+
+function portableReleaseFilePathKey(filePath: string): string {
+  return filePath.normalize("NFC").toUpperCase();
 }
 
 function resolveMaterializedReleasePath(tempDir: string, filePath: string): string {
@@ -719,106 +1390,20 @@ function resolveMaterializedReleasePath(tempDir: string, filePath: string): stri
   return resolvedPath;
 }
 
-async function collectLocalHttpDependencyModules(
-  code: string,
-  dependencies: Map<string, DependencyModule>,
-  cacheDir: string,
-): Promise<void> {
-  const fs = createFileSystem();
-  const cacheRoot = normalize(cacheDir);
-  const seen = new Set<string>();
-  const queue: Array<{ specifier: string; parentFilePath?: string }> = [];
-
-  for (const imp of await parseImports(code)) {
-    if (imp.n) queue.push({ specifier: imp.n });
-  }
-
-  while (queue.length > 0) {
-    const { specifier, parentFilePath } = queue.shift()!;
-    const filePath = resolveLocalDependencyPath(specifier, parentFilePath);
-    if (!filePath || seen.has(filePath)) continue;
-    if (!isPathInsideRoot(filePath, cacheRoot)) {
-      throw new Error(`Vendored HTTP dependency resolved outside cache root: ${specifier}`);
-    }
-    seen.add(filePath);
-
-    const depCode = await fs.readTextFile(filePath);
-    const manifestKey = extractSourceUrl(depCode) ?? `file://${filePath}`;
-    const depSpecifiers = new Set<string>([
-      normalizeDependencySpecifier(specifier),
-      `file://${filePath}`,
-    ]);
-
-    const existing = dependencies.get(manifestKey);
-    if (existing) {
-      for (const depSpecifier of depSpecifiers) existing.specifiers.add(depSpecifier);
-      existing.sourcePath ??= filePath;
-    } else {
-      dependencies.set(manifestKey, {
-        manifestKey,
-        specifiers: depSpecifiers,
-        sourcePath: filePath,
-        code: depCode,
-      });
-    }
-
-    for (const imp of await parseImports(depCode)) {
-      if (imp.n) queue.push({ specifier: imp.n, parentFilePath: filePath });
-    }
-  }
-}
-
-async function vendorHttpImportsWithCache(
-  code: string,
-  options: { tempDir: string; reactVersion?: string },
-): Promise<ReleaseAssetVendorResult> {
-  const imports = await parseImports(code);
-  if (
-    !imports.some((imp) =>
-      imp.n &&
-      (imp.n.startsWith("http://") || imp.n.startsWith("https://") || imp.n.startsWith("npm:"))
-    )
-  ) {
-    return { code, dependencies: [] };
-  }
-
-  const cacheDir = join(options.tempDir, ".veryfront-http-bundle");
-  const result = await cacheHttpImportsToLocal(code, {
-    cacheDir,
-    importMap: { imports: {}, scopes: {} },
-    reactVersion: options.reactVersion,
-  });
-
-  const dependencies = new Map<string, DependencyModule>();
-  await collectLocalHttpDependencyModules(result.code, dependencies, cacheDir);
-
-  return {
-    code: result.code,
-    dependencies: [...dependencies.values()].flatMap((dependency) =>
-      [...dependency.specifiers].map((specifier) => ({
-        specifier,
-        manifestKey: dependency.manifestKey,
-        sourcePath: dependency.sourcePath,
-        code: dependency.code,
-      }))
-    ),
-  };
-}
-
 export async function buildReactImportMapDependencyAssets(options: {
   tempDir: string;
   reactVersion?: string;
-  vendorHttpImports?: ReleaseAssetHttpDependencyVendor;
+  vendorHttpImports: ReleaseAssetHttpDependencyVendor;
 }): Promise<{
   dependencies: Record<string, PreparedAsset>;
   assets: PreparedReleaseAsset[];
   gaps: string[];
 }> {
-  const dependencyModules = new Map<string, DependencyModule>();
+  const dependencyModules = createDependencyModuleCollection();
   const uploadQueue: PreparedAsset[] = [];
-  const pendingBytes = new Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>();
+  const pendingBytes = createPendingAssetStore();
   const gaps: string[] = [];
-  const vendorHttpImports = options.vendorHttpImports ?? vendorHttpImportsWithCache;
+  const vendorHttpImports = options.vendorHttpImports;
 
   await collectReactImportMapDependencyModules(
     { reactVersion: options.reactVersion },
@@ -828,22 +1413,24 @@ export async function buildReactImportMapDependencyAssets(options: {
   );
 
   const finalized = await finalizeDependencyModules(
-    dependencyModules,
+    dependencyModules.modules,
     uploadQueue,
     pendingBytes,
     gaps,
   );
-  const dependencies = exposeDependencySpecifierAliases(finalized.assets, dependencyModules);
+  const dependencies = exposeDependencySpecifierAliases(
+    finalized.assets,
+    dependencyModules.modules,
+  );
 
   return {
     dependencies,
-    assets: uploadQueue.flatMap((asset) => {
-      const stored = pendingBytes.get(asset.contentHash);
-      if (!stored) return [];
-      return [{
+    assets: uploadQueue.map((asset) => {
+      const stored = requirePendingAsset(pendingBytes, asset);
+      return {
         ...asset,
         bytes: stored.bytes,
-      }];
+      };
     }),
     gaps,
   };
@@ -851,54 +1438,79 @@ export async function buildReactImportMapDependencyAssets(options: {
 
 async function collectCachedHttpDependencyModules(
   cacheDir: string,
-  dependencies: Map<string, DependencyModule>,
+  physicalCacheRoot: string,
+  dependencies: DependencyModuleCollection,
 ): Promise<void> {
   const fs = createFileSystem();
   const cacheRoot = normalize(cacheDir);
 
-  async function visit(dir: string): Promise<void> {
-    let entries: AsyncIterable<{ name: string; isFile?: boolean; isDirectory?: boolean }>;
-    try {
-      entries = fs.readDir(dir);
-    } catch {
-      return;
-    }
+  let fileCount = 0;
+  let entryCount = 0;
 
-    for await (const entry of entries) {
+  async function visit(dir: string, depth: number): Promise<void> {
+    if (depth > MAX_DEPENDENCY_DIRECTORY_DEPTH) {
+      throw new Error(
+        `Cached dependency tree exceeds ${MAX_DEPENDENCY_DIRECTORY_DEPTH} levels`,
+      );
+    }
+    const entries: Array<{
+      name: string;
+      isFile: boolean;
+      isDirectory: boolean;
+      isSymlink?: boolean;
+    }> = [];
+    for await (const entry of fs.readDir(dir)) {
+      entryCount++;
+      if (entryCount > MAX_DEPENDENCY_SPECIFIERS) {
+        throw new Error(
+          `Cached dependency tree exceeds ${MAX_DEPENDENCY_SPECIFIERS} filesystem entries`,
+        );
+      }
+      entries.push(entry);
+    }
+    entries.sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
+
+    for (const entry of entries) {
       const path = join(dir, entry.name);
+      if (entry.isSymlink) {
+        throw new Error(`Cached HTTP dependency tree contains a symbolic link: ${path}`);
+      }
       if (entry.isDirectory) {
-        await visit(path);
+        await visit(path, depth + 1);
         continue;
       }
       if (!entry.isFile || !/^http-[a-z0-9]+\.mjs$/i.test(entry.name)) continue;
+      fileCount++;
+      if (fileCount > MAX_DEPENDENCY_MODULES) {
+        throw new Error(`Cached dependency tree exceeds ${MAX_DEPENDENCY_MODULES} modules`);
+      }
       const filePath = normalize(path);
       if (!isPathInsideRoot(filePath, cacheRoot)) {
         throw new Error(`Cached HTTP dependency resolved outside cache root: ${filePath}`);
       }
-
-      const code = await fs.readTextFile(filePath);
-      const manifestKey = extractSourceUrl(code) ?? `file://${filePath}`;
-      const specifiers = [`file://${filePath}`];
-      if (manifestKey.startsWith("http://") || manifestKey.startsWith("https://")) {
-        specifiers.push(manifestKey);
+      const physicalFilePath = normalize(await realPath(filePath));
+      if (!isPathInsideRoot(physicalFilePath, physicalCacheRoot)) {
+        throw new Error(`Cached HTTP dependency escaped its physical cache root: ${filePath}`);
       }
 
-      const existing = dependencies.get(manifestKey);
-      if (existing) {
-        for (const specifier of specifiers) existing.specifiers.add(specifier);
-        existing.sourcePath ??= filePath;
-      } else {
-        dependencies.set(manifestKey, {
+      const { code, sourceUrl: manifestKey } = await readHttpDependencyCacheFile(
+        fs,
+        filePath,
+      );
+
+      mergeDependencyModules(
+        dependencies,
+        [toFileUrl(filePath).href, manifestKey].map((specifier) => ({
           manifestKey,
-          specifiers: new Set(specifiers),
+          specifier,
           sourcePath: filePath,
           code,
-        });
-      }
+        })),
+      );
     }
   }
 
-  await visit(cacheDir);
+  await visit(cacheDir, 0);
 }
 
 export async function buildCachedHttpDependencyAssets(options: {
@@ -909,35 +1521,50 @@ export async function buildCachedHttpDependencyAssets(options: {
   gaps: string[];
 }> {
   const fs = createFileSystem();
-  const cacheStat = await fs.stat(options.cacheDir).catch(() => null);
-  if (!cacheStat?.isDirectory) {
-    return { dependencies: {}, assets: [], gaps: [] };
+  let cacheStat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    cacheStat = fs.lstat ? await fs.lstat(options.cacheDir) : await fs.stat(options.cacheDir);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return { dependencies: {}, assets: [], gaps: [] };
+    }
+    throw error;
   }
+  if (cacheStat.isSymlink || cacheStat.isFile || !cacheStat.isDirectory) {
+    throw new Error("Cached HTTP dependency path is not a safe directory");
+  }
+  const physicalCacheRoot = normalize(await realPath(options.cacheDir));
 
-  const dependencyModules = new Map<string, DependencyModule>();
+  const dependencyModules = createDependencyModuleCollection();
   const uploadQueue: PreparedAsset[] = [];
-  const pendingBytes = new Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>();
+  const pendingBytes = createPendingAssetStore();
   const gaps: string[] = [];
 
-  await collectCachedHttpDependencyModules(options.cacheDir, dependencyModules);
+  await collectCachedHttpDependencyModules(
+    options.cacheDir,
+    physicalCacheRoot,
+    dependencyModules,
+  );
 
   const finalized = await finalizeDependencyModules(
-    dependencyModules,
+    dependencyModules.modules,
     uploadQueue,
     pendingBytes,
     gaps,
   );
-  const dependencies = exposeDependencySpecifierAliases(finalized.assets, dependencyModules);
+  const dependencies = exposeDependencySpecifierAliases(
+    finalized.assets,
+    dependencyModules.modules,
+  );
 
   return {
     dependencies,
-    assets: uploadQueue.flatMap((asset) => {
-      const stored = pendingBytes.get(asset.contentHash);
-      if (!stored) return [];
-      return [{
+    assets: uploadQueue.map((asset) => {
+      const stored = requirePendingAsset(pendingBytes, asset);
+      return {
         ...asset,
         bytes: stored.bytes,
-      }];
+      };
     }),
     gaps,
   };
@@ -946,18 +1573,28 @@ export async function buildCachedHttpDependencyAssets(options: {
 async function finalizeDependencyModules(
   dependencyModules: Map<string, DependencyModule>,
   uploadQueue: PreparedAsset[],
-  pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
+  pendingBytes: PendingAssetStore,
   gaps: string[],
 ): Promise<FinalizedDependencyModules> {
   const bySpecifier = new Map<string, DependencyModule>();
   const byFilePath = new Map<string, DependencyModule>();
   for (const dependency of dependencyModules.values()) {
     for (const specifier of dependency.specifiers) {
-      bySpecifier.set(normalizeDependencySpecifier(specifier), dependency);
+      setDependencyModuleAlias(
+        bySpecifier,
+        normalizeDependencySpecifier(specifier),
+        dependency,
+      );
       const filePath = resolveLocalDependencyPath(specifier);
-      if (filePath) byFilePath.set(filePath, dependency);
+      if (filePath) setDependencyModuleAlias(byFilePath, filePath, dependency);
     }
-    if (dependency.sourcePath) byFilePath.set(dependency.sourcePath, dependency);
+    if (dependency.sourcePath) {
+      setDependencyModuleAlias(
+        byFilePath,
+        normalize(dependency.sourcePath),
+        dependency,
+      );
+    }
   }
 
   const finalized = new Map<string, PreparedAsset>();
@@ -987,7 +1624,7 @@ async function finalizeDependencyModules(
     const gap = `dependency-cycle:${cycleKeys.join("->")}`;
     if (!recordedCycleGaps.has(gap)) {
       recordedCycleGaps.add(gap);
-      gaps.push(gap);
+      pushGap(gaps, gap);
     }
   }
 
@@ -1035,6 +1672,7 @@ async function finalizeDependencyModules(
         if (asset) return releaseAssetUrl(asset.contentHash, "js");
         return cycleFallbackFor(child);
       });
+      await assertFinalModuleImports(rewritten, { allowHttp: false });
 
       const entry = await addPreparedJavaScriptAsset(
         `__dependencies__/${manifestKey}`,
@@ -1046,7 +1684,11 @@ async function finalizeDependencyModules(
         throw new Error(`Vendored dependency exceeds release asset size limit: ${manifestKey}`);
       }
       for (const specifier of dependency.specifiers) {
-        bySpecifier.set(normalizeDependencySpecifier(specifier), dependency);
+        setDependencyModuleAlias(
+          bySpecifier,
+          normalizeDependencySpecifier(specifier),
+          dependency,
+        );
       }
       finalized.set(manifestKey, entry);
       return entry;
@@ -1081,11 +1723,13 @@ async function finalizeProjectModules(
   knownPaths: Set<string>,
   dependencyUrls: Map<string, string>,
   uploadQueue: PreparedAsset[],
-  pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
+  pendingBytes: PendingAssetStore,
   gaps: string[],
+  allowHttp: boolean,
 ): Promise<{ modules: Record<string, PreparedAsset>; skippedModules: Set<string> }> {
   const finalized = new Map<string, PreparedAsset>();
   const unresolvedCycles = new Set<string>();
+  const nonSizeFailures = new Set<string>();
   const cyclicModules = await collectCyclicProjectModules(transformedModules, knownPaths, gaps);
   const skippedModules = new Set(cyclicModules);
 
@@ -1099,8 +1743,9 @@ async function finalizeProjectModules(
       const gap = `cycle:${cycle}`;
       if (!unresolvedCycles.has(gap)) {
         unresolvedCycles.add(gap);
-        gaps.push(gap);
+        pushGap(gaps, gap);
       }
+      nonSizeFailures.add(logicalPath);
       return null;
     }
 
@@ -1117,19 +1762,32 @@ async function finalizeProjectModules(
         path: logicalPath,
         error: sanitizeError(error),
       });
+      nonSizeFailures.add(logicalPath);
       return null;
     }
     for (const importedPath of imports.values()) {
       await finalize(importedPath, nextStack);
     }
 
-    const rewritten = await rewriteProjectModuleImports(
-      transformed.code,
-      logicalPath,
-      finalized,
-      knownPaths,
-      dependencyUrls,
-    );
+    let rewritten: string;
+    try {
+      rewritten = await rewriteProjectModuleImports(
+        transformed.code,
+        logicalPath,
+        finalized,
+        knownPaths,
+        dependencyUrls,
+      );
+      await assertFinalModuleImports(rewritten, { allowHttp });
+    } catch (error) {
+      pushGap(gaps, `module-rewrite-failed:${logicalPath}`);
+      logger.warn("Module import rewrite failed during release asset finalization", {
+        path: logicalPath,
+        error: sanitizeError(error),
+      });
+      nonSizeFailures.add(logicalPath);
+      return null;
+    }
     const entry = await addPreparedJavaScriptAsset(
       logicalPath,
       rewritten,
@@ -1148,8 +1806,9 @@ async function finalizeProjectModules(
     const entry = await finalize(logicalPath, []);
     if (!entry) {
       skippedModules.add(logicalPath);
-      const gap = `oversized:${logicalPath}`;
-      if (!gaps.includes(gap)) gaps.push(gap);
+      if (!nonSizeFailures.has(logicalPath)) {
+        pushGap(gaps, `oversized:${logicalPath}`);
+      }
     }
   }
 
@@ -1180,7 +1839,7 @@ async function collectCyclicProjectModules(
       const gap = `cycle:${[...cycleMembers, logicalPath].join("->")}`;
       if (!recordedCycles.has(gap)) {
         recordedCycles.add(gap);
-        gaps.push(gap);
+        pushGap(gaps, gap);
       }
       return;
     }
@@ -1223,7 +1882,7 @@ async function addPreparedJavaScriptAsset(
   logicalPath: string,
   code: string,
   uploadQueue: PreparedAsset[],
-  pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
+  pendingBytes: PendingAssetStore,
 ): Promise<PreparedAsset | null> {
   const bytes = new TextEncoder().encode(code) as Uint8Array<ArrayBuffer>;
   if (bytes.byteLength > RELEASE_ASSET_MAX_SIZE_BYTES) return null;
@@ -1235,22 +1894,21 @@ async function addPreparedJavaScriptAsset(
     size: bytes.byteLength,
     contentType: RELEASE_ASSET_CONTENT_TYPES.js,
   };
-  if (!pendingBytes.has(contentHash)) {
-    pendingBytes.set(contentHash, { bytes, contentType: RELEASE_ASSET_CONTENT_TYPES.js });
+  if (rememberPendingAsset(pendingBytes, entry, bytes)) {
     uploadQueue.push(entry);
   }
   return entry;
 }
 
 async function buildFrameworkDependencies(
-  input: ReleaseAssetBuildInput,
+  input: FrameworkBuildContext,
   tempDir: string,
   transform: ReleaseAssetTransform,
   dependencyPinningSnapshot: DependencyPinningSnapshot,
   dependencyPinningSource: DependencyPinningSourceInput,
   dependencyUrls: Map<string, string>,
   uploadQueue: PreparedAsset[],
-  pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
+  pendingBytes: PendingAssetStore,
   gaps: string[],
 ): Promise<Record<string, PreparedAsset>> {
   const fs = createFileSystem();
@@ -1283,7 +1941,7 @@ async function buildFrameworkDependencies(
     if (existing) return existing;
 
     if (visiting.has(sourceKey)) {
-      gaps.push(`dependency-cycle:${publicSpecifier}:${sourceKey}`);
+      pushGap(gaps, `dependency-cycle:${publicSpecifier}:${sourceKey}`);
       return null;
     }
 
@@ -1292,7 +1950,7 @@ async function buildFrameworkDependencies(
     });
     const embeddedCode = frameworkSource ? null : embeddedFrameworkModuleCode(sourceKey);
     if (!frameworkSource && embeddedCode === null) {
-      gaps.push(`dependency-missing:${publicSpecifier}:${sourceKey}`);
+      pushGap(gaps, `dependency-missing:${publicSpecifier}:${sourceKey}`);
       return null;
     }
 
@@ -1336,8 +1994,9 @@ async function buildFrameworkDependencies(
           frameworkImportUrls.get(specifier) ??
             dependencyUrlForSpecifier(dependencyUrls, specifier),
       );
+      await assertFinalModuleImports(code, { allowHttp: input.allowHttp });
     } catch (error) {
-      gaps.push(`dependency-transform-failed:${publicSpecifier}:${sourceKey}`);
+      pushGap(gaps, `dependency-transform-failed:${publicSpecifier}:${sourceKey}`);
       logger.warn("Framework dependency transform failed during release asset build", {
         specifier: publicSpecifier,
         sourceKey,
@@ -1356,7 +2015,7 @@ async function buildFrameworkDependencies(
       pendingBytes,
     );
     if (!entry) {
-      gaps.push(`dependency-oversized:${publicSpecifier}:${sourceKey}`);
+      pushGap(gaps, `dependency-oversized:${publicSpecifier}:${sourceKey}`);
       return null;
     }
 
@@ -1365,6 +2024,7 @@ async function buildFrameworkDependencies(
   }
 
   for (const [specifier, moduleUrl] of Object.entries(PLATFORM_UTILITIES)) {
+    if (input.requestedSpecifiers && !input.requestedSpecifiers.has(specifier)) continue;
     const sourceKey = frameworkModuleUrlToSourceKey(moduleUrl);
     if (!sourceKey) continue;
 
@@ -1379,13 +2039,34 @@ async function buildFrameworkDependencies(
   return dependencies;
 }
 
+async function collectRequestedFrameworkSpecifiers(
+  transformedModules: ReadonlyMap<string, TransformedProjectModule>,
+): Promise<Set<string>> {
+  const requested = new Set<string>();
+  const specifiersByModuleUrl = new Map<string, string[]>();
+  for (const [specifier, moduleUrl] of Object.entries(PLATFORM_UTILITIES)) {
+    const aliases = specifiersByModuleUrl.get(moduleUrl) ?? [];
+    aliases.push(specifier);
+    specifiersByModuleUrl.set(moduleUrl, aliases);
+  }
+
+  for (const transformed of transformedModules.values()) {
+    for (const imp of await parseImports(transformed.code)) {
+      if (!imp.n) continue;
+      if (Object.hasOwn(PLATFORM_UTILITIES, imp.n)) requested.add(imp.n);
+      for (const alias of specifiersByModuleUrl.get(imp.n) ?? []) requested.add(alias);
+    }
+  }
+
+  return requested;
+}
+
 export async function buildFrameworkDependencyAssets(options: {
   tempDir: string;
-  // deno-lint-ignore no-explicit-any -- adapter is passed through to transformToESM
-  adapter: any;
+  adapter: RuntimeAdapter;
   reactVersion?: string;
   projectId?: string;
-  transform?: ReleaseAssetTransform;
+  transform: ReleaseAssetTransform;
   dependencyUrls: Map<string, string>;
   dependencyPinningSnapshot?: DependencyPinningSnapshot;
   dependencyPinningSource?: DependencyPinningSourceInput;
@@ -1395,7 +2076,7 @@ export async function buildFrameworkDependencyAssets(options: {
   gaps: string[];
 }> {
   const uploadQueue: PreparedAsset[] = [];
-  const pendingBytes = new Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>();
+  const pendingBytes = createPendingAssetStore();
   const gaps: string[] = [];
   const dependencyPinningSource = options.dependencyPinningSource ??
     createDependencyPinningSource({
@@ -1405,28 +2086,13 @@ export async function buildFrameworkDependencyAssets(options: {
     });
   const dependencyPinningSnapshot = options.dependencyPinningSnapshot ??
     await resolveDependencyPinningSnapshot(dependencyPinningSource);
-  const transform: ReleaseAssetTransform = options.transform ??
-    ((source, sourceFile, projectDir, adapter, transformOptions) =>
-      transformToESM(source, sourceFile, projectDir, adapter, {
-        projectId: transformOptions.projectId,
-        dev: transformOptions.dev,
-        ssr: transformOptions.ssr,
-        reactVersion: transformOptions.reactVersion,
-        dependencyPinningCacheKey: transformOptions.dependencyPinningSnapshot?.cacheKey,
-        dependencyPinningDependencies: transformOptions.dependencyPinningSnapshot?.dependencies,
-        dependencyPinningSource: transformOptions.dependencyPinningSource,
-      }));
+  const transform = options.transform;
   const dependencies = await buildFrameworkDependencies(
     {
-      projectReference: options.projectId ?? "local",
       projectId: options.projectId ?? "local",
-      releaseId: "local",
-      releaseVersion: 0,
-      releaseVersionRef: "local",
       reactVersion: options.reactVersion,
-      client: undefined as unknown as ReleaseAssetBuildClient,
       adapter: options.adapter,
-      transform,
+      allowHttp: false,
     },
     options.tempDir,
     transform,
@@ -1440,13 +2106,12 @@ export async function buildFrameworkDependencyAssets(options: {
 
   return {
     dependencies,
-    assets: uploadQueue.flatMap((asset) => {
-      const stored = pendingBytes.get(asset.contentHash);
-      if (!stored) return [];
-      return [{
+    assets: uploadQueue.map((asset) => {
+      const stored = requirePendingAsset(pendingBytes, asset);
+      return {
         ...asset,
         bytes: stored.bytes,
-      }];
+      };
     }),
     gaps,
   };
@@ -1458,10 +2123,10 @@ function addFrameworkDependencyUrlAliases(
 ): void {
   for (const [specifier, entry] of Object.entries(dependencies)) {
     const url = releaseAssetUrl(entry.contentHash, "js");
-    urls.set(specifier, url);
+    setDependencyUrlAlias(urls, specifier, url);
 
     const moduleUrl = PLATFORM_UTILITIES[specifier];
-    if (moduleUrl) urls.set(moduleUrl, url);
+    if (moduleUrl) setDependencyUrlAlias(urls, moduleUrl, url);
   }
 }
 
@@ -1479,15 +2144,15 @@ async function collectRouteClosure(
   const queue = [...entrypoints];
   const gaps: string[] = [];
 
-  while (queue.length > 0) {
-    const current = queue.shift()!;
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+    const current = queue[queueIndex]!;
     if (visited.has(current)) continue;
     visited.add(current);
 
     const transformed = transformedModules.get(current);
     if (!transformed) {
       // Module referenced but not transformable or not successfully transformed.
-      gaps.push(`closure-missing:${current}`);
+      pushGap(gaps, `closure-missing:${current}`);
       continue;
     }
 
@@ -1510,6 +2175,87 @@ async function collectRouteClosure(
   return { modules: [...visited], gaps };
 }
 
+function validateReleaseAssetBuildInput(
+  input: ReleaseAssetBuildInput,
+  tempDir: string,
+): void {
+  if (!isSafeBuildText(input.projectReference)) {
+    throw new Error("Release asset project reference is invalid");
+  }
+  if (!isSafeBuildText(input.projectId)) {
+    throw new Error("Release asset project ID is invalid");
+  }
+  if (!isSafeBuildText(input.releaseId)) {
+    throw new Error("Release asset release ID is invalid");
+  }
+  if (!isSafeBuildText(input.releaseVersionRef)) {
+    throw new Error("Release asset release version reference is invalid");
+  }
+  if (!Number.isSafeInteger(input.releaseVersion) || input.releaseVersion < 0) {
+    throw new Error("Release asset release version must be a non-negative safe integer");
+  }
+  if (!isSafeBuildText(tempDir, MAX_RELEASE_FILE_PATH_LENGTH)) {
+    throw new Error("Release asset temporary directory is invalid");
+  }
+  if (
+    typeof input.client?.beginReleaseAssetManifestBuild !== "function" ||
+    typeof input.client.listAllReleaseFiles !== "function" ||
+    typeof input.client.uploadReleaseAsset !== "function" ||
+    typeof input.client.putReleaseAssetManifest !== "function" ||
+    typeof input.client.reportReleaseAssetManifestState !== "function" ||
+    typeof input.client.compileProjectCss !== "function"
+  ) {
+    throw new Error("Release asset build client is incomplete");
+  }
+  if (typeof input.transform !== "function") {
+    throw new Error("Release asset transform must be a function");
+  }
+  if (typeof input.loadConfig !== "function") {
+    throw new Error("Release asset config loader is unavailable");
+  }
+  if (input.dependencyMode !== "source" && input.dependencyMode !== "immutable") {
+    throw new Error("Release asset dependency mode is invalid");
+  }
+  if (
+    input.vendorHttpImports !== undefined &&
+    typeof input.vendorHttpImports !== "function"
+  ) {
+    throw new Error("Release asset dependency vendor must be a function");
+  }
+  if (input.dependencyMode === "source" && input.vendorHttpImports !== undefined) {
+    throw new Error("Release asset dependency vendor requires immutable dependency mode");
+  }
+  if (input.dependencyMode === "immutable" && typeof input.vendorHttpImports !== "function") {
+    throw new Error(
+      "Immutable release dependencies require a policy-enforced vendor extension",
+    );
+  }
+}
+
+interface ValidatedReleaseAssetBuildStart {
+  readonly id: string;
+  readonly manifestVersion: number;
+  readonly state: "queued" | "building";
+}
+
+function validateBuildStart(
+  value: Awaited<ReturnType<ReleaseAssetBuildClient["beginReleaseAssetManifestBuild"]>>,
+): ValidatedReleaseAssetBuildStart {
+  const id = readOwnDataProperty(value, "id");
+  const manifestVersion = readOwnDataProperty(value, "manifest_version");
+  const state = readOwnDataProperty(value, "state");
+  if (
+    !isSafeBuildText(id) ||
+    typeof manifestVersion !== "number" ||
+    !Number.isSafeInteger(manifestVersion) ||
+    manifestVersion < 0 ||
+    (state !== "queued" && state !== "building")
+  ) {
+    throw new Error("Release asset build start was not acknowledged");
+  }
+  return Object.freeze({ id, manifestVersion, state });
+}
+
 /**
  * Execute a release asset build. Pure orchestration over the injected client
  * and a runtime-provided temp dir + react version.
@@ -1519,39 +2265,41 @@ export async function runReleaseAssetBuild(
   tempDir: string,
 ): Promise<ReleaseAssetBuildResult> {
   const { client } = input;
-  const transform: ReleaseAssetTransform = input.transform ??
-    ((source, sourceFile, projectDir, adapter, options) =>
-      transformToESM(source, sourceFile, projectDir, adapter, {
-        projectId: options.projectId,
-        dev: options.dev,
-        ssr: options.ssr,
-        studioEmbed: false,
-        reactVersion: options.reactVersion,
-        dependencyPinningCacheKey: options.dependencyPinningSnapshot?.cacheKey,
-        dependencyPinningDependencies: options.dependencyPinningSnapshot?.dependencies,
-        dependencyPinningSource: options.dependencyPinningSource,
-      }));
-
-  // H1: wrap the whole build so any non-transform failure also reports failed.
+  let validatedStart: ValidatedReleaseAssetBuildStart | null = null;
   try {
-    return await runBuildInner(input, tempDir, client, transform);
+    validateReleaseAssetBuildInput(input, tempDir);
+    const transform = input.transform;
+    validatedStart = validateBuildStart(
+      await client.beginReleaseAssetManifestBuild(input.releaseVersionRef),
+    );
+
+    // Wrap the whole build so any non-transform failure also reports failed.
+    return await runBuildInner(
+      input,
+      tempDir,
+      client,
+      transform,
+      validatedStart.manifestVersion,
+    );
   } catch (error) {
     const sanitized = sanitizeError(error);
     logger.warn("Release asset build failed (non-transform error)", {
       releaseId: input.releaseId,
       error: sanitized,
     });
-    try {
-      await client.reportReleaseAssetManifestState(
-        input.releaseVersionRef,
-        "failed",
-        sanitized,
-      );
-    } catch (reportErr) {
-      logger.warn("Failed to report build failure state", {
-        releaseId: input.releaseId,
-        error: sanitizeError(reportErr),
-      });
+    if (validatedStart) {
+      try {
+        await client.reportReleaseAssetManifestState(
+          input.releaseVersionRef,
+          "failed",
+          sanitized,
+        );
+      } catch (reportErr) {
+        logger.warn("Failed to report build failure state", {
+          releaseId: input.releaseId,
+          error: sanitizeError(reportErr),
+        });
+      }
     }
     return {
       success: false,
@@ -1559,65 +2307,27 @@ export async function runReleaseAssetBuild(
       moduleCount: 0,
       cssCount: 0,
       routeCount: 0,
-      gaps: [],
+      coverageFailures: error instanceof IncompleteReleaseAssetBuildError
+        ? error.coverageFailures
+        : [],
       error: sanitized,
     };
   }
 }
 
 async function resolveReleaseReactVersion(
-  sourceByPath: Map<string, string>,
   releaseConfig: VeryfrontConfig,
-  fallbackReactVersion: string | undefined,
   tempDir: string,
   dependencyPinningSnapshot: DependencyPinningSnapshot,
   dependencyPinningSource: DependencyPinningSourceInput,
-): Promise<string | undefined> {
-  const hasReleaseReactConfig = !!releaseConfig.react?.version ||
-    (releaseConfig.client?.cdn?.versions !== undefined &&
-      releaseConfig.client.cdn.versions !== "auto");
-  const hasReleasePackageJson = sourceByPath.has("package.json");
-  const releaseReactVersion = await resolveProjectReactVersion({
+): Promise<string> {
+  return await resolveProjectReactVersion({
     projectDir: tempDir,
     config: releaseConfig,
     dependencyPinningSource,
     dependencyPinningCacheKey: dependencyPinningSnapshot.cacheKey,
     dependencyPinningDependencies: dependencyPinningSnapshot.dependencies,
   });
-
-  if (hasReleaseReactConfig || hasReleasePackageJson || fallbackReactVersion === undefined) {
-    return releaseReactVersion;
-  }
-
-  return fallbackReactVersion;
-}
-
-function dependencyConfigForRelease(
-  sourceByPath: Map<string, string>,
-  releaseConfig: VeryfrontConfig,
-  fallbackReactVersion: string | undefined,
-): VeryfrontConfig {
-  const hasReleaseReactConfig = !!releaseConfig.react?.version ||
-    (releaseConfig.client?.cdn?.versions !== undefined &&
-      releaseConfig.client.cdn.versions !== "auto");
-  if (
-    hasReleaseReactConfig ||
-    sourceByPath.has("package.json") ||
-    fallbackReactVersion === undefined
-  ) {
-    return releaseConfig;
-  }
-
-  // The request-context React version is the established fallback when a
-  // release has no package/config declaration. Capture it in the build
-  // snapshot so its cache key and transforms cannot diverge.
-  return {
-    ...releaseConfig,
-    react: {
-      ...releaseConfig.react,
-      version: fallbackReactVersion,
-    },
-  };
 }
 
 async function runBuildInner(
@@ -1625,122 +2335,187 @@ async function runBuildInner(
   tempDir: string,
   client: ReleaseAssetBuildClient,
   transform: ReleaseAssetTransform,
+  manifestVersion: number,
 ): Promise<ReleaseAssetBuildResult> {
-  // 1. Begin (idempotent). H2: capture manifest_version from the API response.
-  const beginResult = await client.beginReleaseAssetManifestBuild(input.releaseVersionRef);
-  const manifestVersion = beginResult.manifest_version;
-
-  // 2. Materialize the release file set.
+  // Materialize only after the control plane acknowledges an active build.
   const files = await client.listAllReleaseFiles(input.releaseVersionRef);
+  if (!Array.isArray(files) || files.length > MAX_RELEASE_FILES) {
+    throw new Error(`Release file list exceeds ${MAX_RELEASE_FILES} entries`);
+  }
   const fs = createFileSystem();
   const sourceByPath = new Map<string, string>();
+  const portablePathKeys = new Set<string>();
+  let sourceBytes = 0;
+  let transformableSourceCount = 0;
 
   for (const file of files) {
-    if (typeof file.content !== "string") continue;
-    const logicalPath = file.path.replace(/\\/g, "/");
-    const abs = resolveMaterializedReleasePath(tempDir, logicalPath);
-    sourceByPath.set(normalizeLogicalPath(logicalPath), file.content);
-    await fs.mkdir(dirname(abs), { recursive: true });
-    await fs.writeTextFile(abs, file.content);
+    const path = readOwnDataProperty(file, "path");
+    const content = readOwnDataProperty(file, "content");
+    if (typeof content !== "string") {
+      throw new Error("Release file entry must include string content");
+    }
+    const logicalPath = requireCanonicalReleaseFilePath(path);
+    if (sourceByPath.has(logicalPath)) {
+      throw new Error("Release file list contains a duplicate path");
+    }
+    const portablePathKey = portableReleaseFilePathKey(logicalPath);
+    if (portablePathKeys.has(portablePathKey)) {
+      throw new Error("Release file list contains a portable path collision");
+    }
+    portablePathKeys.add(portablePathKey);
+    if (isTransformableBrowserModule(logicalPath)) {
+      transformableSourceCount++;
+      if (transformableSourceCount > RELEASE_ASSET_MANIFEST_LIMITS.moduleEntries) {
+        throw new Error(
+          `Release browser modules exceed ${RELEASE_ASSET_MANIFEST_LIMITS.moduleEntries} entries`,
+        );
+      }
+    }
+    const contentBytes = textEncoder.encode(content).byteLength;
+    if (contentBytes > RELEASE_ASSET_MAX_SIZE_BYTES) {
+      throw new Error(`Release source file exceeds ${RELEASE_ASSET_MAX_SIZE_BYTES} bytes`);
+    }
+    sourceBytes += contentBytes;
+    if (sourceBytes > MAX_RELEASE_SOURCE_BYTES) {
+      throw new Error(`Release source files exceed ${MAX_RELEASE_SOURCE_BYTES} bytes`);
+    }
+
+    sourceByPath.set(logicalPath, content);
   }
+
+  // Validate the entire logical file set before writing any tenant-controlled
+  // path. This keeps case-insensitive and Unicode-normalizing filesystems from
+  // making the materialized bytes differ from the hashed in-memory snapshot.
+  for (const [logicalPath, content] of sourceByPath) {
+    const abs = resolveMaterializedReleasePath(tempDir, logicalPath);
+    await fs.mkdir(dirname(abs), { recursive: true });
+    await fs.writeTextFile(abs, content);
+  }
+
+  const sourceContentHash = await releaseFileSetSignature(sourceByPath);
 
   // 3 + 4. Collect the browser module closure and transform each module
   // through the SAME pipeline serveModule uses (browser, non-SSR).
   const transformedModules = new Map<string, TransformedProjectModule>();
-  const dependencyModules = new Map<string, DependencyModule>();
+  const dependencyModules = createDependencyModuleCollection();
   const gaps: string[] = [];
   const uploadQueue: PreparedAsset[] = [];
   // Bytes are held per-hash only until uploaded, then dropped (M3).
-  const pendingBytes = new Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>();
+  const pendingBytes = createPendingAssetStore();
   const knownPaths = new Set(sourceByPath.keys());
-  const vendorHttpImports = input.vendorHttpImports ?? vendorHttpImportsWithCache;
-  const vendorDependencies = isDependencyImportMapEnabled();
-  const releaseConfig = await resolveReleaseConfigFromSourceFiles(sourceByPath, input, tempDir);
-  const routeDirectories = releaseRouterDirectories(releaseConfig);
-  const dependencyConfig = dependencyConfigForRelease(
-    sourceByPath,
-    releaseConfig,
-    input.reactVersion,
+  const vendorDependencies = input.dependencyMode === "immutable";
+  const configuredVendor = input.vendorHttpImports;
+  const vendorHttpImports = vendorDependencies ? configuredVendor : undefined;
+  const configFile = VERYFRONT_CONFIG_FILES.find((candidate) => sourceByPath.has(candidate));
+  const releaseConfig = await input.loadConfig(
+    configFile
+      ? {
+        fileName: configFile,
+        source: sourceByPath.get(configFile)!,
+      }
+      : null,
   );
+  if (!releaseConfig || typeof releaseConfig !== "object" || Array.isArray(releaseConfig)) {
+    throw new Error("Release asset config loader returned an invalid config");
+  }
+  const routeDirectories = releaseRouterDirectories(releaseConfig);
   const dependencyPinningSource = createDependencyPinningSource({
     projectDir: tempDir,
     projectId: input.projectId,
     releaseId: input.releaseId,
     contentSourceId: `release-assets:${input.releaseVersionRef}`,
     isLocalProject: true,
-    config: dependencyConfig,
+    config: releaseConfig,
   });
   const dependencyPinningSnapshot = await resolveDependencyPinningSnapshot(
     dependencyPinningSource,
   );
   const releaseReactVersion = await resolveReleaseReactVersion(
-    sourceByPath,
-    dependencyConfig,
-    input.reactVersion,
+    releaseConfig,
     tempDir,
     dependencyPinningSnapshot,
     dependencyPinningSource,
   );
-  const transformingModules = new Set<string>();
 
   async function transformProjectModule(
     logicalPath: string,
-  ): Promise<ReleaseAssetBuildResult | null> {
-    if (transformedModules.has(logicalPath) || transformingModules.has(logicalPath)) return null;
-    if (!isTransformableBrowserModule(logicalPath)) return null;
+  ): Promise<string[]> {
+    if (transformedModules.has(logicalPath) || !isTransformableBrowserModule(logicalPath)) {
+      return [];
+    }
 
     const source = sourceByPath.get(logicalPath);
-    if (typeof source !== "string") return null;
+    if (typeof source !== "string") return [];
 
-    transformingModules.add(logicalPath);
-
+    const sourceFile = join(tempDir, logicalPath);
+    let code: string;
     try {
-      // M2: enforce client-side size limit before transform (source is a proxy;
-      // transformed output is checked after encoding below).
-      const sourceFile = join(tempDir, logicalPath);
-      let code: string;
+      code = await transform(source, sourceFile, tempDir, input.adapter, {
+        projectId: input.projectId,
+        dev: false,
+        ssr: false,
+        reactVersion: releaseReactVersion,
+        dependencyPinningSnapshot,
+        dependencyPinningSource,
+      });
+    } catch (error) {
+      const sanitized = sanitizeError(error);
+      pushGap(gaps, `module-transform-failed:${logicalPath}`);
+      logger.warn("Module transform failed during release asset build", {
+        path: logicalPath,
+        error: sanitized,
+      });
+      return [];
+    }
+    if (typeof code !== "string") {
+      pushGap(gaps, `module-transform-failed:${logicalPath}`);
+      logger.warn("Module transform returned a non-string result", {
+        path: logicalPath,
+      });
+      return [];
+    }
+    const transformedSize = textEncoder.encode(code).byteLength;
+    if (transformedSize > RELEASE_ASSET_MAX_SIZE_BYTES) {
+      pushGap(gaps, `oversized:${logicalPath}`);
+      logger.warn("Module transform output exceeds the release asset limit", {
+        path: logicalPath,
+        size: transformedSize,
+        limit: RELEASE_ASSET_MAX_SIZE_BYTES,
+      });
+      return [];
+    }
+
+    const unvendoredCode = code;
+    let imports: Map<string, string> | undefined;
+    if (typeof vendorHttpImports === "function") {
       try {
-        code = await transform(source, sourceFile, tempDir, input.adapter, {
-          projectId: input.projectId,
-          dev: false,
-          ssr: false,
-          reactVersion: releaseReactVersion,
-          dependencyPinningSnapshot,
-          dependencyPinningSource,
-        });
+        const vendored = validateVendorResult(
+          await vendorHttpImports(code, {
+            tempDir,
+            reactVersion: releaseReactVersion,
+          }),
+        );
+        const stagedDependencies = stageDependencyModules(vendored.dependencies);
+        const vendoredImports = await collectProjectModuleImports(
+          vendored.code,
+          logicalPath,
+          knownPaths,
+        );
+        commitDependencyModules(dependencyModules, stagedDependencies);
+        code = vendored.code;
+        imports = vendoredImports;
       } catch (error) {
         const sanitized = sanitizeError(error);
-        pushGap(gaps, `module-transform-failed:${logicalPath}`);
-        logger.warn("Module transform failed during release asset build", {
+        pushGap(gaps, `module-dependency-vendor-failed:${logicalPath}`);
+        logger.warn("HTTP dependency vendoring failed during release asset build", {
           path: logicalPath,
           error: sanitized,
         });
-        return null;
+        code = unvendoredCode;
       }
+    }
 
-      const unvendoredCode = code;
-      if (vendorDependencies) {
-        try {
-          const vendored = await vendorHttpImports(code, {
-            tempDir,
-            reactVersion: releaseReactVersion,
-          });
-          code = vendored.code;
-          for (const dependency of vendored.dependencies) {
-            addDependencyModule(dependencyModules, dependency);
-          }
-        } catch (error) {
-          const sanitized = sanitizeError(error);
-          pushGap(gaps, `module-dependency-vendor-failed:${logicalPath}`);
-          logger.warn("HTTP dependency vendoring failed during release asset build", {
-            path: logicalPath,
-            error: sanitized,
-          });
-          code = unvendoredCode;
-        }
-      }
-
-      let imports: Map<string, string>;
+    if (!imports) {
       try {
         imports = await collectProjectModuleImports(code, logicalPath, knownPaths);
       } catch (error) {
@@ -1750,29 +2525,31 @@ async function runBuildInner(
           path: logicalPath,
           error: sanitized,
         });
-        return null;
+        return [];
       }
-
-      transformedModules.set(logicalPath, { logicalPath, code, unvendoredCode });
-      for (const importedPath of imports.values()) {
-        const failure = await transformProjectModule(importedPath);
-        if (failure) return failure;
-      }
-    } finally {
-      transformingModules.delete(logicalPath);
     }
 
-    return null;
+    transformedModules.set(logicalPath, { logicalPath, code, unvendoredCode });
+    return [...imports.values()];
   }
 
+  const moduleQueue: string[] = [];
+  const queuedModules = new Set<string>();
   for (const logicalPath of sourceByPath.keys()) {
     if (!isBrowserModule(logicalPath, routeDirectories)) continue;
-
-    const failure = await transformProjectModule(logicalPath);
-    if (failure) return failure;
+    moduleQueue.push(logicalPath);
+    queuedModules.add(logicalPath);
+  }
+  for (let index = 0; index < moduleQueue.length; index++) {
+    const logicalPath = moduleQueue[index]!;
+    for (const importedPath of await transformProjectModule(logicalPath)) {
+      if (queuedModules.has(importedPath)) continue;
+      queuedModules.add(importedPath);
+      moduleQueue.push(importedPath);
+    }
   }
 
-  if (vendorDependencies) {
+  if (typeof vendorHttpImports === "function") {
     try {
       await collectReactImportMapDependencyModules(
         { ...input, reactVersion: releaseReactVersion },
@@ -1791,14 +2568,19 @@ async function runBuildInner(
 
   let httpDependencies: Record<string, PreparedAsset>;
   let httpDependencyFallbackUrls: Map<string, string>;
+  const dependencyUploadQueueStart = uploadQueue.length;
   try {
     const finalizedHttpDependencies = await finalizeDependencyModules(
-      dependencyModules,
+      dependencyModules.modules,
       uploadQueue,
       pendingBytes,
       gaps,
     );
-    httpDependencies = finalizedHttpDependencies.assets;
+    httpDependencies = exposeDependencySpecifierAliases(
+      finalizedHttpDependencies.assets,
+      dependencyModules.modules,
+      MAX_HTTP_DEPENDENCY_ENTRIES,
+    );
     httpDependencyFallbackUrls = finalizedHttpDependencies.fallbackUrls;
   } catch (error) {
     const sanitized = sanitizeError(error);
@@ -1809,17 +2591,29 @@ async function runBuildInner(
     for (const transformed of transformedModules.values()) {
       transformed.code = transformed.unvendoredCode;
     }
-    dependencyModules.clear();
+    discardPendingAssetsSince(uploadQueue, pendingBytes, dependencyUploadQueueStart);
+    clearDependencyModules(dependencyModules);
     httpDependencies = {};
     httpDependencyFallbackUrls = new Map();
   }
-  httpDependencies = exposeDependencySpecifierAliases(httpDependencies, dependencyModules);
-  const dependencyUrls = buildDependencyUrlMap(httpDependencies, dependencyModules);
+  const dependencyUrls = buildDependencyUrlMap(
+    httpDependencies,
+    dependencyModules.modules,
+  );
   for (const [specifier, url] of httpDependencyFallbackUrls) {
-    dependencyUrls.set(specifier, url);
+    setDependencyUrlAlias(dependencyUrls, specifier, url);
   }
+  const requestedFrameworkSpecifiers = await collectRequestedFrameworkSpecifiers(
+    transformedModules,
+  );
   const frameworkDependencies = await buildFrameworkDependencies(
-    { ...input, reactVersion: releaseReactVersion },
+    {
+      projectId: input.projectId,
+      adapter: input.adapter,
+      reactVersion: releaseReactVersion,
+      allowHttp: !vendorDependencies,
+      requestedSpecifiers: requestedFrameworkSpecifiers,
+    },
     tempDir,
     transform,
     dependencyPinningSnapshot,
@@ -1829,8 +2623,16 @@ async function runBuildInner(
     pendingBytes,
     gaps,
   );
-  if (vendorDependencies) addFrameworkDependencyUrlAliases(dependencyUrls, frameworkDependencies);
-  const dependencies = { ...frameworkDependencies, ...httpDependencies };
+  addFrameworkDependencyUrlAliases(dependencyUrls, frameworkDependencies);
+  const dependencies = mergePreparedAssetRecords(
+    frameworkDependencies,
+    httpDependencies,
+  );
+  if (Object.keys(dependencies).length > RELEASE_ASSET_MANIFEST_LIMITS.dependencyEntries) {
+    throw new Error(
+      `Release dependency manifest exceeds ${RELEASE_ASSET_MANIFEST_LIMITS.dependencyEntries} entries`,
+    );
+  }
 
   const { modules, skippedModules } = await finalizeProjectModules(
     transformedModules,
@@ -1839,6 +2641,7 @@ async function runBuildInner(
     uploadQueue,
     pendingBytes,
     gaps,
+    !vendorDependencies,
   );
 
   for (const logicalPath of transformedModules.keys()) {
@@ -1851,68 +2654,66 @@ async function runBuildInner(
     });
   }
 
-  // 5b. CSS: compile project CSS where reachable, else record css:[] and note.
+  // 5b. CSS: compile requested project CSS and fail closed on any invalid output.
   const css: ReleaseAssetCssEntry[] = [];
   const cssHashes: string[] = [];
-  if (client.compileProjectCss) {
-    try {
-      const candidates = collectClassCandidates(sourceByPath);
-      const stylesheetPath = releaseConfig.tailwind?.stylesheet ?? input.stylesheetPath;
-      const resolvedStylesheet = resolveProjectStylesheet(sourceByPath, stylesheetPath);
-      const stylesheet = mergeModuleCssImports(sourceByPath, resolvedStylesheet);
-      const compiled = await client.compileProjectCss(candidates, stylesheet, {
-        config: releaseConfig,
-      });
-      if (compiled && compiled.css) {
-        const bytes = new TextEncoder().encode(compiled.css) as Uint8Array<ArrayBuffer>;
-        const contentHash = await computeHashBytes(bytes);
-        css.push({
-          contentHash,
-          size: bytes.byteLength,
-          contentType: RELEASE_ASSET_CONTENT_TYPES.css,
-          styleProfileHash: compiled.styleProfileHash,
-        });
-        cssHashes.push(contentHash);
-        if (!pendingBytes.has(contentHash)) {
-          pendingBytes.set(contentHash, { bytes, contentType: RELEASE_ASSET_CONTENT_TYPES.css });
-          uploadQueue.push({
-            logicalPath: `__css__/${contentHash}`,
-            contentHash,
-            size: bytes.byteLength,
-            contentType: RELEASE_ASSET_CONTENT_TYPES.css,
-          });
-        }
-      } else {
-        // The compiler degraded (returned null/empty) — record the gap so a
-        // ready manifest never silently lacks the promised CSS signal.
-        gaps.push("css:compile-failed");
-        logger.warn("Release asset CSS compile returned no output (recording gap)");
-      }
-    } catch (error) {
-      // CSS is best-effort: record a gap, keep css:[].
-      gaps.push("css:compile-failed");
-      logger.warn("Release asset CSS compile failed (recording gap)", {
-        error: sanitizeError(error),
-      });
-    }
-  } else {
-    gaps.push("css:no-pipeline");
+  const candidates = collectClassCandidates(sourceByPath);
+  if (candidates.size > MAX_CSS_CANDIDATES) {
+    throw new Error(
+      `Release asset CSS candidates exceed ${MAX_CSS_CANDIDATES} entries`,
+    );
   }
 
-  // 5a. Upload assets with bounded concurrency, dropping bytes after each
-  // successful upload (M3) to bound peak memory.
-  await uploadWithConcurrency(uploadQueue, RELEASE_ASSET_UPLOAD_CONCURRENCY, async (asset) => {
-    const stored = pendingBytes.get(asset.contentHash);
-    if (!stored) return;
-    await client.uploadReleaseAsset(
-      input.releaseVersionRef,
-      asset.contentHash,
-      stored.contentType,
-      stored.bytes,
-    );
-    // M3: drop bytes immediately after upload.
-    pendingBytes.delete(asset.contentHash);
-  });
+  const stylesheetPath = releaseConfig.tailwind?.stylesheet;
+  const resolvedStylesheet = resolveProjectStylesheet(sourceByPath, stylesheetPath);
+  if (stylesheetPath !== undefined && resolvedStylesheet === undefined) {
+    pushGap(gaps, `stylesheet-missing:${stylesheetPath}`);
+    assertCompleteReleaseAssetCoverage(gaps);
+  }
+  const stylesheet = await mergeModuleCssImports(sourceByPath, resolvedStylesheet, gaps);
+  assertCompleteReleaseAssetCoverage(gaps);
+  const cssRequested = candidates.size > 0 || stylesheet !== undefined;
+  if (cssRequested) {
+    const stylesheetBytes = stylesheet ? textEncoder.encode(stylesheet).byteLength : 0;
+    if (stylesheetBytes > MAX_CSS_INPUT_BYTES) {
+      throw new Error(
+        `Release asset CSS input exceeds ${MAX_CSS_INPUT_BYTES} bytes`,
+      );
+    }
+
+    const compiledResult = await client.compileProjectCss(candidates, stylesheet, {
+      config: releaseConfig,
+    });
+    if (compiledResult === null) {
+      throw new Error("Release asset CSS compiler returned no requested output");
+    }
+    const compiled = snapshotCompiledProjectCss(compiledResult);
+    const bytes = textEncoder.encode(compiled.css) as Uint8Array<ArrayBuffer>;
+    if (bytes.byteLength > RELEASE_ASSET_MAX_SIZE_BYTES) {
+      throw new Error(
+        `Release asset CSS output exceeds ${RELEASE_ASSET_MAX_SIZE_BYTES} bytes`,
+      );
+    }
+
+    const contentHash = await computeHashBytes(bytes);
+    css.push({
+      contentHash,
+      size: bytes.byteLength,
+      contentType: RELEASE_ASSET_CONTENT_TYPES.css,
+      styleProfileHash: compiled.styleProfileHash,
+      cssPipelineIdentity: compiled.cssPipelineIdentity,
+    });
+    cssHashes.push(contentHash);
+    const asset: PreparedAsset = {
+      logicalPath: `__css__/${contentHash}`,
+      contentHash,
+      size: bytes.byteLength,
+      contentType: RELEASE_ASSET_CONTENT_TYPES.css,
+    };
+    if (rememberPendingAsset(pendingBytes, asset, bytes)) {
+      uploadQueue.push(asset);
+    }
+  }
 
   // B2. Routes: walk the transformed browser import closure from each page entrypoint.
   // Modules missing from transformedModules are recorded as closure gaps.
@@ -1924,6 +2725,10 @@ async function runBuildInner(
   for (const logicalPath of pageModules) {
     const route = routeForConfiguredPage(logicalPath, routeDirectories);
     if (!route) continue;
+    if (Object.hasOwn(routes, route)) {
+      pushGap(gaps, `route-collision:${route}`);
+      continue;
+    }
 
     const entryModules = [
       logicalPath,
@@ -1944,22 +2749,46 @@ async function runBuildInner(
     // framework-provided) are recorded as gaps for this route.
     for (const missing of closureModules) {
       if (modules[missing] === undefined && !missing.startsWith("lib/")) {
-        closureGaps.push(`route-gap:${route}:${missing}`);
+        pushGap(closureGaps, `route-gap:${route}:${missing}`);
       }
     }
     if (closureGaps.length > 0) {
-      gaps.push(...closureGaps.filter((g) => !gaps.includes(g)));
+      for (const gap of closureGaps) pushGap(gaps, gap);
     }
 
     routes[route] = { modules: manifestedModules, css: cssHashes };
   }
 
+  // A v2 manifest is publishable only when every requested module,
+  // dependency, route closure, and stylesheet has complete immutable coverage.
+  assertCompleteReleaseAssetCoverage(gaps);
+
+  // Upload only after coverage is proven complete, so failed builds do not
+  // leave unreferenced immutable assets behind.
+  await uploadWithConcurrency(uploadQueue, RELEASE_ASSET_UPLOAD_CONCURRENCY, async (asset) => {
+    const stored = requirePendingAsset(pendingBytes, asset);
+    const acknowledgement = await client.uploadReleaseAsset(
+      input.releaseVersionRef,
+      asset.contentHash,
+      stored.contentType,
+      stored.bytes,
+    );
+    const acknowledgedStored = readOwnDataProperty(acknowledgement, "stored");
+    const acknowledgedExisting = readOwnDataProperty(acknowledgement, "existed");
+    if (
+      typeof acknowledgedStored !== "boolean" ||
+      typeof acknowledgedExisting !== "boolean" ||
+      (!acknowledgedStored && !acknowledgedExisting)
+    ) {
+      throw new Error("Release asset upload was not acknowledged");
+    }
+    forgetPendingAsset(pendingBytes, asset);
+  });
+
   // 6. Assemble and PUT the manifest.
-  const sourceContentHash = await computeHashBytes(
-    new TextEncoder().encode([...sourceByPath.keys()].sort().join("\n")) as Uint8Array<ArrayBuffer>,
-  );
   const manifest: ReleaseAssetManifest = {
     schemaVersion: RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
+    dependencyMode: input.dependencyMode,
     projectId: input.projectId,
     releaseId: input.releaseId,
     releaseVersion: input.releaseVersion,
@@ -1985,17 +2814,33 @@ async function runBuildInner(
         contentType: entry.contentType,
       }]),
     ),
-    fallback: { mode: "jit", gaps },
   };
 
-  const result = await client.putReleaseAssetManifest(input.releaseVersionRef, manifest);
+  const verifiedManifest = parseReleaseAssetManifest(manifest);
+  if (!verifiedManifest) {
+    throw new Error("Release asset manifest failed internal validation");
+  }
+  const result = await client.putReleaseAssetManifest(
+    input.releaseVersionRef,
+    verifiedManifest,
+  );
+  const acknowledgedState = readOwnDataProperty(result, "state");
+  const acknowledgedManifestVersion = readOwnDataProperty(result, "manifest_version");
+  if (
+    acknowledgedState !== "ready" ||
+    typeof acknowledgedManifestVersion !== "number" ||
+    !Number.isSafeInteger(acknowledgedManifestVersion) ||
+    acknowledgedManifestVersion !== manifestVersion
+  ) {
+    throw new Error("Release asset manifest PUT was not acknowledged");
+  }
   logger.info("Release asset manifest built", {
     releaseId: input.releaseId,
     manifestVersion,
     moduleCount: Object.keys(modules).length,
     cssCount: css.length,
     routeCount: Object.keys(routes).length,
-    state: result.state,
+    state: "ready",
   });
 
   return {
@@ -2004,165 +2849,31 @@ async function runBuildInner(
     moduleCount: Object.keys(modules).length,
     cssCount: css.length,
     routeCount: Object.keys(routes).length,
-    gaps,
+    coverageFailures: [],
   };
 }
 
-function validateAndMergeReleaseConfig(userConfig: unknown): VeryfrontConfig {
-  if (!userConfig || typeof userConfig !== "object" || Array.isArray(userConfig)) {
-    throw new Error(`Expected object from veryfront.config, received ${typeof userConfig}`);
-  }
-
-  validateVeryfrontConfig(userConfig);
-  const unknownKeys = findUnknownTopLevelKeys(userConfig as Record<string, unknown>);
-  if (unknownKeys.length > 0) {
-    throw new Error(
-      `Unknown config keys: ${unknownKeys.join(", ")}. Check for typos in veryfront.config.`,
-    );
-  }
-
-  return mergeConfigs(userConfig as Partial<VeryfrontConfig>);
-}
-
-const VERYFRONT_CONFIG_SHIM_MODULE = `
-export const defineConfig = (config) => config;
-export const defineConfigWithEnv = (factory, envConfig) =>
-  factory(envConfig?.nodeEnv ?? globalThis.Deno?.env?.get?.("NODE_ENV") ??
-    globalThis.process?.env?.NODE_ENV ?? "production");
-export const mergeConfigs = (...configs) => Object.assign({}, ...configs);
-export default { defineConfig, defineConfigWithEnv, mergeConfigs };
-`;
-
-const RELEASE_CONFIG_SHIM_NAMESPACE = "veryfront-release-config-shim";
-
-const releaseConfigVeryfrontPlugin: Plugin = {
-  name: "veryfront-release-config-shim",
-  setup(build) {
-    build.onResolve({ filter: /^veryfront$/ }, () => ({
-      path: "veryfront-config-shim",
-      namespace: RELEASE_CONFIG_SHIM_NAMESPACE,
-    }));
-    build.onLoad({ filter: /.*/, namespace: RELEASE_CONFIG_SHIM_NAMESPACE }, () => ({
-      contents: VERYFRONT_CONFIG_SHIM_MODULE,
-      loader: "js",
-    }));
-  },
-};
-
-async function ensureReleaseConfigBundlerContracts(): Promise<void> {
-  await ensureDefaultBundlerContracts();
-  if (tryResolve("Bundler") && tryResolve("ModuleLexer")) return;
-
-  const { EsbuildBundler, EsModuleLexer } = await import(
-    "@veryfront/ext-bundler-esbuild"
-  );
-  if (!tryResolve("Bundler")) register("Bundler", new EsbuildBundler());
-  if (!tryResolve("ModuleLexer")) register("ModuleLexer", new EsModuleLexer());
-}
-
-async function bundleReleaseConfigForImport(
-  tempDir: string,
-  configFile: string,
-  source: string,
-): Promise<string> {
-  await ensureReleaseConfigBundlerContracts();
-  const { build } = await import("veryfront/extensions/bundler");
-  const result = await build({
-    bundle: true,
-    write: false,
-    format: "esm",
-    platform: "neutral",
-    target: "es2022",
-    resolveExtensions: [".ts", ".tsx", ".js", ".jsx", ".mjs"],
-    packages: "external",
-    external: ["node:*"],
-    plugins: [releaseConfigVeryfrontPlugin],
-    stdin: {
-      contents: source,
-      loader: getEsbuildLoader(configFile),
-      resolveDir: tempDir,
-      sourcefile: configFile,
-    },
-  });
-
-  if (result.errors.length > 0) {
-    throw new Error(
-      `Failed to bundle veryfront.config: ${result.errors[0]?.text ?? "unknown error"}`,
-    );
-  }
-
-  const output = result.outputFiles?.[0]?.text;
-  if (!output) throw new Error("Failed to bundle veryfront.config: no output emitted");
-  return output;
-}
-
-async function loadReleaseConfigModule(
-  tempDir: string,
-  configFile: string,
-  source: string,
-): Promise<unknown> {
-  const fs = createFileSystem();
-  const bundledConfigPath = join(tempDir, `.veryfront-release-${crypto.randomUUID()}.mjs`);
-  await fs.writeTextFile(
-    bundledConfigPath,
-    await bundleReleaseConfigForImport(tempDir, configFile, source),
-  );
-
-  try {
-    const moduleUrl = toFileUrl(bundledConfigPath);
-    moduleUrl.searchParams.set("t", `${Date.now()}-${crypto.randomUUID()}`);
-    const configModule = await import(moduleUrl.href);
-    return configModule.default || configModule;
-  } finally {
-    await fs.remove(bundledConfigPath).catch(() => undefined);
-  }
-}
-
 async function releaseFileSetSignature(sourceByPath: Map<string, string>): Promise<string> {
-  const separator = "::veryfront-release-file::";
-  const serialized = [...sourceByPath.entries()]
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([path, content]) => `${path}${separator}${content}`)
-    .join(separator);
-  return await computeHashBytes(new TextEncoder().encode(serialized) as Uint8Array<ArrayBuffer>);
-}
-
-async function resolveReleaseConfigFromSourceFiles(
-  sourceByPath: Map<string, string>,
-  input: ReleaseAssetBuildInput,
-  tempDir: string,
-): Promise<VeryfrontConfig> {
-  const releaseSignature = await releaseFileSetSignature(sourceByPath);
-  const configFile = VERYFRONT_CONFIG_FILES.find((candidate) =>
-    typeof sourceByPath.get(candidate) === "string"
+  const entries = [...sourceByPath.entries()]
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0);
+  const serialized = JSON.stringify(entries);
+  return await computeHashBytes(
+    textEncoder.encode(serialized) as Uint8Array<ArrayBuffer>,
   );
-  const source = configFile ? sourceByPath.get(configFile) : undefined;
-
-  logger.debug("Loading release config from materialized release files", {
-    releaseId: input.releaseId,
-    releaseVersionRef: input.releaseVersionRef,
-    releaseSignature,
-    hasConfigFile: !!configFile,
-  });
-
-  if (!configFile || typeof source !== "string") return mergeConfigs({});
-
-  const userConfig = await loadReleaseConfigModule(tempDir, configFile, source);
-  return validateAndMergeReleaseConfig(userConfig);
 }
 
 /**
- * Resolve the project Tailwind stylesheet from the materialized file set.
- * Tries the configured path first, then conventional defaults. Returns
- * `undefined` when none is present (the CSS compiler then uses its default).
+ * Resolve the project stylesheet from the materialized file set.
+ * A configured path is authoritative and must be canonical. Conventional
+ * defaults are considered only when no path was configured.
  */
 function resolveProjectStylesheet(
   sourceByPath: Map<string, string>,
   stylesheetPath: string | undefined,
 ): { content: string; path: string } | undefined {
-  const candidatePaths = stylesheetPath
-    ? [stylesheetPath, stylesheetPath.replace(/^\.?\//, "")]
-    : ["globals.css", "src/globals.css"];
+  const candidatePaths = stylesheetPath === undefined
+    ? ["globals.css", "src/globals.css"]
+    : [requireCanonicalReleaseFilePath(stylesheetPath)];
   for (const path of candidatePaths) {
     const content = sourceByPath.get(path);
     if (typeof content === "string") return { content, path };
@@ -2177,39 +2888,80 @@ function resolveProjectStylesheet(
  * compiled once per release, so the merge happens here instead — mirroring the
  * dev /_vf_styles route.
  *
- * `*.module.css` files are skipped: their class names are rewritten per-module
- * by the runtime, so inlining them raw would leak unscoped selectors.
+ * CSS Module selectors are rewritten with the same project-relative identity
+ * used by the transform and HTML aggregation paths.
  */
-function mergeModuleCssImports(
+async function mergeModuleCssImports(
   sourceByPath: Map<string, string>,
   stylesheet: { content: string; path: string } | undefined,
-): string | undefined {
-  const sourceFiles: Array<{ path: string; content: string }> = [];
+  gaps: string[],
+): Promise<string | undefined> {
+  const importedPaths = new Set<string>();
   for (const [path, content] of sourceByPath) {
     if (!CSS_IMPORTING_SOURCE_EXTENSIONS.some((ext) => path.endsWith(ext))) continue;
-    // Resolution is rooted at "/" so relative and @/ specifiers resolve
-    // against the release file set's project-relative paths.
-    sourceFiles.push({ path: `/${path}`, content });
+    let imports: Awaited<ReturnType<typeof parseImports>>;
+    try {
+      imports = await parseImports(content);
+    } catch (error) {
+      pushGap(gaps, `stylesheet-import-parse-failed:${path}`);
+      logger.warn("CSS import parsing failed during release asset build", {
+        path,
+        error: sanitizeError(error),
+      });
+      continue;
+    }
+
+    for (const imp of imports) {
+      const specifier = imp.n;
+      if (!specifier) continue;
+      const cssPath = specifier.split(/[?#]/, 1)[0] ?? "";
+      if (!cssPath.endsWith(".css")) continue;
+      if (cssPath !== specifier) {
+        pushGap(gaps, `stylesheet-import-unsupported:${path}`);
+        continue;
+      }
+      const importedPath = resolveCssImportPath(specifier, `/${path}`, "/");
+      if (!importedPath) {
+        pushGap(gaps, `stylesheet-import-unsupported:${path}`);
+        continue;
+      }
+
+      const relativePath = importedPath.replace(/^\/+/, "");
+      if (!sourceByPath.has(relativePath)) {
+        pushGap(gaps, `stylesheet-import-missing:${relativePath}`);
+        continue;
+      }
+      importedPaths.add(relativePath);
+    }
   }
 
   const segments: string[] = [];
-  for (const importedPath of collectCssImportPaths(sourceFiles, "/")) {
-    const relativePath = importedPath.replace(/^\/+/, "");
+  let moduleCount = 0;
+  let regularCount = 0;
+  for (const relativePath of [...importedPaths].sort()) {
     if (relativePath === stylesheet?.path) continue;
-    if (relativePath.endsWith(".module.css")) continue;
     const content = sourceByPath.get(relativePath);
-    if (content) segments.push(content);
+    if (content === undefined) continue;
+    if (relativePath.endsWith(".module.css")) {
+      segments.push(rewriteCssModuleContent(content, `/${relativePath}`));
+      moduleCount++;
+    } else {
+      segments.push(content);
+      regularCount++;
+    }
   }
 
   if (segments.length === 0) return stylesheet?.content;
 
   logger.debug("Merged module CSS imports into release stylesheet", {
     importedCount: segments.length,
+    regularCount,
+    moduleCount,
   });
-  return [stylesheet?.content, ...segments].filter(Boolean).join("\n");
+  return [stylesheet?.content, ...segments].filter((value) => value !== undefined).join("\n");
 }
 
-/** Extract Tailwind class candidates from materialized source. */
+/** Extract CSS class candidates from materialized source. */
 function collectClassCandidates(sourceByPath: Map<string, string>): Set<string> {
   const candidates = extractCandidatesFromFiles(
     [...sourceByPath.entries()].map(([path, content]) => ({ path, content })),

--- a/src/release-assets/client-module-map.test.ts
+++ b/src/release-assets/client-module-map.test.ts
@@ -1,43 +1,108 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 import { buildReleaseAssetModules } from "./client-module-map.ts";
+import type { ReleaseAssetManifest } from "./manifest-schema.ts";
+import { RELEASE_ASSET_MANIFEST_SCHEMA_VERSION } from "./constants.ts";
 
 const PAGE_HASH = "a".repeat(64);
 const FALLBACK_HASH = "b".repeat(64);
 
-function manifest(): ReleaseAssetManifest {
+function manifestWithModules(
+  modules: ReleaseAssetManifest["modules"],
+  routes: ReleaseAssetManifest["routes"] = {},
+): ReleaseAssetManifest {
   return {
-    schemaVersion: 1,
-    projectId: "project-id",
-    releaseId: "release-id",
+    schemaVersion: RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
+    projectId: "project-1",
+    releaseId: "release-1",
     releaseVersion: 1,
     manifestVersion: 1,
-    builderVersion: "0.1.765",
-    sourceContentHash: "",
-    createdAt: "2026-07-27T00:00:00.000Z",
+    builderVersion: "test",
+    sourceContentHash: "a".repeat(64),
+    createdAt: "2026-07-26T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
-    modules: {
-      "app/page.tsx": { contentHash: PAGE_HASH, size: 1, contentType: "text/javascript" },
+    modules,
+    css: [],
+    routes,
+    dependencyMode: "source",
+    dependencies: {},
+  };
+}
+
+function manifest(): ReleaseAssetManifest {
+  return manifestWithModules(
+    {
+      "app/page.tsx": {
+        contentHash: PAGE_HASH,
+        size: 1,
+        contentType: "text/javascript",
+      },
       "components/Fallback.tsx": {
         contentHash: FALLBACK_HASH,
         size: 1,
         contentType: "text/javascript",
       },
     },
-    css: [],
-    routes: {
+    {
       "/": { modules: ["app/page.tsx"], css: [] },
       "/empty": { modules: [], css: [] },
       "/partial-stale": { modules: ["app/page.tsx", "src/site/page.tsx"], css: [] },
       "/stale": { modules: ["src/site/page.tsx"], css: [] },
     },
-    dependencies: {},
-    fallback: { mode: "jit", gaps: [] },
-  };
+  );
 }
 
 describe("release asset client module map", () => {
+  it("uses an own-property-only result for adversarial module keys", () => {
+    const modules = JSON.parse(
+      `{"__proto__":{"contentHash":"${PAGE_HASH}","size":1,"contentType":"text/javascript"}}`,
+    ) as ReleaseAssetManifest["modules"];
+
+    const result = buildReleaseAssetModules(manifestWithModules(modules));
+
+    assertEquals(Object.getPrototypeOf(result), null);
+    assertEquals(Object.hasOwn(result ?? {}, "__proto__"), true);
+    assertEquals(result?.["__proto__"], `/_vf/assets/${PAGE_HASH}.js`);
+  });
+
+  it("omits malformed runtime entries instead of emitting unsafe URLs", () => {
+    const result = buildReleaseAssetModules(
+      manifestWithModules({
+        "pages/index.tsx": {
+          contentHash: "../asset",
+          size: 1,
+          contentType: "text/javascript",
+        },
+      }),
+    );
+
+    assertEquals(result, undefined);
+  });
+
+  it("can scope a browser map to an explicit module set", () => {
+    const result = buildReleaseAssetModules(
+      manifestWithModules({
+        "app/page.tsx": {
+          contentHash: FALLBACK_HASH,
+          size: 1,
+          contentType: "text/javascript",
+        },
+        "app/unrelated.tsx": {
+          contentHash: "c".repeat(64),
+          size: 1,
+          contentType: "text/javascript",
+        },
+      }),
+      {
+        logicalPaths: ["app/page.tsx", "app/page.tsx", "app/missing.tsx"],
+      },
+    );
+
+    assertEquals(result, {
+      "app/page.tsx": `/_vf/assets/${FALLBACK_HASH}.js`,
+    });
+  });
+
   it("uses route-scoped modules when route entries match manifest modules", () => {
     assertEquals(buildReleaseAssetModules(manifest(), { route: "/" }), {
       "app/page.tsx": `/_vf/assets/${PAGE_HASH}.js`,

--- a/src/release-assets/client-module-map.ts
+++ b/src/release-assets/client-module-map.ts
@@ -1,30 +1,66 @@
-import { releaseAssetUrl } from "./constants.ts";
+import { isValidContentHash, RELEASE_ASSET_CONTENT_TYPES, releaseAssetUrl } from "./constants.ts";
 import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 
-export function buildReleaseAssetModules(
-  manifest?: ReleaseAssetManifest | null,
-  options: { route?: string | null } = {},
+export interface BuildReleaseAssetModulesOptions {
+  /** Prefer the manifest closure for this route, falling back to the full map when stale. */
+  route?: string | null;
+  /** Restrict non-route callers to an explicit set of logical module paths. */
+  logicalPaths?: Iterable<string>;
+}
+
+function buildModuleMap(
+  manifest: ReleaseAssetManifest,
+  logicalPaths: Iterable<string>,
+  requireComplete: boolean,
 ): Record<string, string> | undefined {
-  if (!manifest) return undefined;
+  const modules: Record<string, string> = Object.create(null);
 
-  const routeModules = options.route ? manifest.routes[options.route]?.modules : undefined;
-  const buildFallback = (): Record<string, string> | undefined => {
-    const fallbackModules: Record<string, string> = {};
-    for (const [path, entry] of Object.entries(manifest.modules)) {
-      fallbackModules[path] = releaseAssetUrl(entry.contentHash, "js");
+  for (const path of new Set(logicalPaths)) {
+    if (!Object.hasOwn(manifest.modules, path)) {
+      if (requireComplete) return undefined;
+      continue;
     }
-    return Object.keys(fallbackModules).length > 0 ? fallbackModules : undefined;
-  };
 
-  if (!routeModules) return buildFallback();
-  if (routeModules.length === 0) return buildFallback();
-
-  const modules: Record<string, string> = {};
-  for (const path of routeModules) {
     const entry = manifest.modules[path];
-    if (!entry) return buildFallback();
+    if (
+      !entry ||
+      entry.contentType !== RELEASE_ASSET_CONTENT_TYPES.js ||
+      typeof entry.contentHash !== "string" ||
+      !isValidContentHash(entry.contentHash)
+    ) {
+      if (requireComplete) return undefined;
+      continue;
+    }
+
     modules[path] = releaseAssetUrl(entry.contentHash, "js");
   }
 
-  return modules;
+  return Object.keys(modules).length > 0 ? modules : undefined;
+}
+
+export function buildReleaseAssetModules(
+  manifest?: ReleaseAssetManifest | null,
+  options: BuildReleaseAssetModulesOptions = {},
+): Record<string, string> | undefined {
+  if (!manifest) return undefined;
+
+  if (options.route) {
+    const routeEntry = Object.hasOwn(manifest.routes, options.route)
+      ? manifest.routes[options.route]
+      : undefined;
+    if (routeEntry?.modules.length) {
+      const routeModules = buildModuleMap(manifest, routeEntry.modules, true);
+      if (routeModules) return routeModules;
+    }
+
+    // Missing, empty, or stale route metadata must not produce an incomplete
+    // hydration map. Rebuild from the validated full manifest instead.
+    return buildModuleMap(manifest, Object.keys(manifest.modules), false);
+  }
+
+  return buildModuleMap(
+    manifest,
+    options.logicalPaths ?? Object.keys(manifest.modules),
+    false,
+  );
 }

--- a/src/release-assets/constants.test.ts
+++ b/src/release-assets/constants.test.ts
@@ -1,0 +1,30 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  RELEASE_ASSET_CONTENT_TYPE_ALLOWLIST,
+  RELEASE_ASSET_CONTENT_TYPES,
+  RELEASE_ASSET_MANIFEST_LIMITS,
+  RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
+  releaseAssetUrl,
+} from "./constants.ts";
+
+describe("release asset constants", () => {
+  it("builds URLs only from canonical content identities", () => {
+    const hash = "a".repeat(64);
+    assertEquals(releaseAssetUrl(hash, "js"), `/_vf/assets/${hash}.js`);
+    assertThrows(() => releaseAssetUrl("../asset", "js"));
+    assertThrows(() => releaseAssetUrl(hash, "map" as "js"));
+  });
+
+  it("does not expose mutable content-type policy", () => {
+    assertEquals(Object.isFrozen(RELEASE_ASSET_CONTENT_TYPES), true);
+    assertEquals(Object.isFrozen(RELEASE_ASSET_CONTENT_TYPE_ALLOWLIST), true);
+    assertEquals(Object.isFrozen(RELEASE_ASSET_MANIFEST_LIMITS), true);
+  });
+
+  it("publishes the strict CSS identity manifest version and bounds", () => {
+    assertEquals(RELEASE_ASSET_MANIFEST_SCHEMA_VERSION, 2);
+    assertEquals(RELEASE_ASSET_MANIFEST_LIMITS.styleProfileHashLength, 64);
+    assertEquals(RELEASE_ASSET_MANIFEST_LIMITS.cssPipelineIdentityLength, 2_048);
+  });
+});

--- a/src/release-assets/constants.ts
+++ b/src/release-assets/constants.ts
@@ -5,28 +5,59 @@
  */
 
 /** Current manifest body schema version. */
-export const RELEASE_ASSET_MANIFEST_SCHEMA_VERSION = 1 as const;
+export const RELEASE_ASSET_MANIFEST_SCHEMA_VERSION = 2 as const;
 
 /** Public asset base path served on the project's own domain (proxy-owned). */
 export const RELEASE_ASSET_BASE_PATH = "/_vf/assets" as const;
 
 /** Content types permitted for release assets. */
-export const RELEASE_ASSET_CONTENT_TYPES = {
-  js: "text/javascript",
-  css: "text/css",
-} as const;
+export const RELEASE_ASSET_CONTENT_TYPES = Object.freeze(
+  {
+    js: "text/javascript",
+    css: "text/css",
+  } as const,
+);
 
+/** File extensions supported by the immutable release asset endpoint. */
 export type ReleaseAssetExtension = keyof typeof RELEASE_ASSET_CONTENT_TYPES;
+/** MIME types accepted for immutable release asset uploads and responses. */
 export type ReleaseAssetContentType = (typeof RELEASE_ASSET_CONTENT_TYPES)[ReleaseAssetExtension];
 
 /** Allowlist of accepted content types (upstream + upload validation). */
-export const RELEASE_ASSET_CONTENT_TYPE_ALLOWLIST: readonly ReleaseAssetContentType[] = [
-  RELEASE_ASSET_CONTENT_TYPES.js,
-  RELEASE_ASSET_CONTENT_TYPES.css,
-];
+export const RELEASE_ASSET_CONTENT_TYPE_ALLOWLIST: readonly ReleaseAssetContentType[] = Object
+  .freeze([
+    RELEASE_ASSET_CONTENT_TYPES.js,
+    RELEASE_ASSET_CONTENT_TYPES.css,
+  ]);
 
 /** Maximum size (bytes) for a single uploaded asset (10 MB). */
 export const RELEASE_ASSET_MAX_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Maximum aggregate bytes retained while preparing one asset generation. */
+export const RELEASE_ASSET_MAX_PENDING_BYTES = 256 * 1024 * 1024;
+
+/** Work and memory bounds enforced by every manifest producer and consumer. */
+export const RELEASE_ASSET_MANIFEST_LIMITS = Object.freeze(
+  {
+    identifierLength: 256,
+    builderVersionLength: 128,
+    manifestKeyLength: 2_048,
+    styleProfileHashLength: 64,
+    cssPipelineIdentityLength: 2_048,
+    coverageFailureLength: 4_096,
+    moduleEntries: 20_000,
+    dependencyEntries: 10_000,
+    dependencySpecifiers: 40_000,
+    // v2 publishes one release-global stylesheet. Consumers intentionally use
+    // that single immutable asset rather than selecting per-route variants.
+    cssEntries: 1,
+    routeEntries: 20_000,
+    routeModules: 20_000,
+    routeCssEntries: 1,
+    coverageFailures: 20_000,
+    totalRouteReferences: 200_000,
+  } as const,
+);
 
 /** Immutable cache max-age in seconds (1 year). */
 export const RELEASE_ASSET_IMMUTABLE_MAX_AGE_SECONDS = 31_536_000;
@@ -52,6 +83,12 @@ export const DEPENDENCY_PINNING_ENV_FLAG = "VERYFRONT_DEPENDENCY_PINNING";
 
 /** Map a 64-hex content hash + extension to its public asset URL. */
 export function releaseAssetUrl(contentHash: string, extension: ReleaseAssetExtension): string {
+  if (!isValidContentHash(contentHash)) {
+    throw new TypeError("Release asset content hash must be 64 lowercase hexadecimal characters");
+  }
+  if (!contentTypeForExtension(extension)) {
+    throw new TypeError(`Unsupported release asset extension: ${String(extension)}`);
+  }
   return `${RELEASE_ASSET_BASE_PATH}/${contentHash}.${extension}`;
 }
 

--- a/src/release-assets/css-compile.test.ts
+++ b/src/release-assets/css-compile.test.ts
@@ -1,20 +1,48 @@
 import "#veryfront/schemas/_test-setup.ts";
 // Activates the @veryfront/ext-css-tailwind CSSProcessor so the pure
-// `generateTailwindCSS` compile path resolves a real compiler.
+// `generateCSS` compile path resolves a real compiler.
 import "#veryfront/html/styles-builder/__tests__/css-processor-setup.ts";
 
-import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
-import { register, tryResolve, unregister } from "#veryfront/extensions/contracts.ts";
-import { type CSSProcessor, CSSProcessorName } from "#veryfront/extensions/css/index.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createTestCSSOptimizationEngine,
+  installTestCSSOptimizationEngine,
+} from "../../tests/_helpers/css-optimization-engine.ts";
+import {
+  isCSSPipelineIdentity,
+  isStyleProfileHash,
+} from "#veryfront/utils/css-artifact-identity.ts";
+import { acquireCSSGenerationSession } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import type { VeryfrontConfig } from "#veryfront/config";
 import { createCompileProjectCss } from "./css-compile.ts";
 
+const RELEASE_CONFIG = { config: {} as VeryfrontConfig };
+
 describe("release-assets/css-compile", () => {
-  it("compiles tailwind candidates into a text/css string with a styleProfileHash", async () => {
+  let restoreCSSOptimizationEngine: (() => void) | undefined;
+
+  beforeEach(() => {
+    restoreCSSOptimizationEngine = installTestCSSOptimizationEngine();
+  });
+
+  afterEach(() => {
+    restoreCSSOptimizationEngine?.();
+    restoreCSSOptimizationEngine = undefined;
+  });
+
+  it("returns the canonical profile and exact pipeline identities used for compilation", async () => {
     const compile = createCompileProjectCss({ projectScope: "css-compile-test" });
+    const expectedPipelineIdentity = acquireCSSGenerationSession(true).cacheIdentity;
 
     const candidates = new Set(["p-4", "text-red-500", "flex"]);
-    const result = await compile(candidates, '@import "tailwindcss";');
+    const result = await compile(candidates, '@import "tailwindcss";', RELEASE_CONFIG);
 
     assert(result !== null, "expected a compiled result");
     assert(result.css.length > 0, "expected non-empty CSS output");
@@ -23,13 +51,14 @@ describe("release-assets/css-compile", () => {
       result.css.includes("padding") || result.css.includes(".p-4"),
       "expected the p-4 utility to be present in the compiled CSS",
     );
-    // styleProfileHash is derived from the style-scope profile (string, never throws).
-    assertEquals(typeof result.styleProfileHash, "string");
+    assert(isStyleProfileHash(result.styleProfileHash));
+    assert(isCSSPipelineIdentity(result.cssPipelineIdentity));
+    assertEquals(result.cssPipelineIdentity, expectedPipelineIdentity);
   });
 
   it("returns null only when there are no candidates AND no stylesheet", async () => {
     const compile = createCompileProjectCss({ projectScope: "css-compile-empty" });
-    const result = await compile(new Set<string>(), undefined);
+    const result = await compile(new Set<string>(), undefined, RELEASE_CONFIG);
     assertEquals(result, null);
   });
 
@@ -38,25 +67,45 @@ describe("release-assets/css-compile", () => {
     const result = await compile(
       new Set<string>(),
       '@import "tailwindcss"; :root { --brand: #123456; }',
+      RELEASE_CONFIG,
     );
     // Stylesheet-only compiles must not be skipped: base/custom rules ship.
     assertExists(result);
     assert(result.css.length > 0, "stylesheet-only compile produced CSS");
   });
 
-  it("propagates missing-provider failures so the executor records an explicit gap", async () => {
+  it("propagates compiler failures instead of publishing a CSS gap", async () => {
     const compile = createCompileProjectCss({ projectScope: "css-compile-fail" });
     const candidates = new Set(["p-4"]);
-    const previous = tryResolve<CSSProcessor>(CSSProcessorName);
-    unregister(CSSProcessorName);
+    const restoreFailingEngine = installTestCSSOptimizationEngine(
+      createTestCSSOptimizationEngine(() => {
+        throw new Error("release CSS optimization failed");
+      }, "test-failing-css-optimization-engine@1"),
+    );
     try {
       await assertRejects(
-        () => compile(candidates, '@import "tailwindcss";'),
+        () => compile(candidates, '@import "tailwindcss";', RELEASE_CONFIG),
         Error,
-        'Missing extension for contract "CSSProcessor"',
+        "release CSS optimization failed",
       );
     } finally {
-      if (previous !== undefined) register(CSSProcessorName, previous);
+      restoreFailingEngine();
     }
+  });
+
+  it("rejects invalid project scopes at configuration time", () => {
+    assertThrows(() => createCompileProjectCss({ projectScope: "bad\nscope" }));
+    assertThrows(() => createCompileProjectCss(null as never));
+  });
+
+  it("rejects malformed candidate input", async () => {
+    const compile = createCompileProjectCss({ projectScope: "project-1" });
+    const candidates = new Set<string>(["text-red-500", "bad\u0000candidate"]);
+
+    await assertRejects(
+      () => compile(candidates, undefined, RELEASE_CONFIG),
+      TypeError,
+      "candidate is invalid",
+    );
   });
 });

--- a/src/release-assets/css-compile.ts
+++ b/src/release-assets/css-compile.ts
@@ -2,116 +2,180 @@
  * Release Asset Manifest — production CSS compiler.
  *
  * Provides the `compileProjectCss` implementation injected into the build
- * executor's client. It compiles project CSS through an explicitly registered
- * processor (`generateTailwindCSS` is retained as a compatibility name) against the candidates
+ * executor's client. It compiles project CSS directly through the
+ * provider-neutral compiler (`generateCSS`) against the candidates the executor
  * extracted from the materialized release file set, using the project
  * stylesheet the executor resolved from that same file set.
  *
  * Why this is safe to run inside the project runtime:
- * - It uses `generateTailwindCSS`, NOT `getProjectCSS`. `getProjectCSS` pulls in
+ * - It uses `generateCSS`, NOT `getProjectCSS`. `getProjectCSS` pulls in
  *   the distributed/project-CSS cache (`initializeProjectCSSCache`,
  *   prepared-project-css, style-artifact resolution) — the very machinery whose
  *   per-route candidate contract and distributed-cache init motivated deferring
- *   CSS from the builder. The compile primitive captures explicit compiler and
- *   optimizer providers once and performs no discovery, network loading, or
- *   empty-output fallback.
+ *   CSS from the builder. `generateCSS` is the pure compile primitive:
+ *   it resolves the explicitly composed `CSSProcessor` extension and calls
+ *   `compiler.build(candidates)` with no cross-request/distributed state.
  * - Work is bounded: one compile over the candidate set the executor already
  *   gathered, output minified, no background tasks.
- * - `null` means only that there is no stylesheet and no candidate to compile.
- *   Provider/compiler failures propagate to the executor, which records its
- *   explicit `css:compile-failed` gap.
+ * - Configuration and compile failures propagate; a release must not publish
+ *   a silent CSS gap.
  *
  * @module release-assets/css-compile
  */
 
-import { serverLogger } from "#veryfront/utils";
+import {
+  assertCSSPipelineIdentity,
+  assertStyleProfileHash,
+} from "#veryfront/utils/css-artifact-identity.ts";
+import { serverLogger } from "#veryfront/utils/logger/index.ts";
+import { COMPILATION_ERROR } from "#veryfront/errors";
 import type { VeryfrontConfig } from "#veryfront/config";
 import {
   acquireCSSGenerationSession,
   generateTailwindCSS,
   hashCSS,
 } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
-import { composeCSSStyleProfileHash } from "#veryfront/html/styles-builder/css-identity.ts";
 import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
+import { RELEASE_ASSET_MAX_SIZE_BYTES } from "./constants.ts";
+import { hasControlCharacters } from "./string-validation.ts";
 
 const logger = serverLogger.component("release-asset-css-compile");
+const MAX_PROJECT_SCOPE_LENGTH = 256;
+const MAX_CSS_CANDIDATES = 100_000;
+const MAX_CSS_CANDIDATE_LENGTH = 2_048;
+const textEncoder = new TextEncoder();
 
+/** Successful bounded CSS compilation output. */
 export interface CompileProjectCssResult {
-  css: string;
-  styleProfileHash: string | null;
+  readonly css: string;
+  readonly styleProfileHash: string;
+  readonly cssPipelineIdentity: string;
 }
 
+/** Configuration captured by a release-scoped CSS compiler. */
 export interface CompileProjectCssOptions {
   /** Project scope (slug or id) — isolates the compiler cache per project. */
   projectScope: string;
-  /** Fallback project config, used when the executor cannot provide release config. */
-  config?: VeryfrontConfig;
 }
 
+/** Per-build configuration resolved from the materialized release. */
 export interface CompileProjectCssRuntimeOptions {
-  /** Project config resolved from the materialized release file set. */
-  config?: VeryfrontConfig;
+  /** Validated project config resolved from the exact materialized release. */
+  config: VeryfrontConfig;
 }
 
 /**
  * Build a `compileProjectCss` function bound to a specific release build.
  *
  * The returned function matches the build executor's injected client signature:
- * `(candidates, stylesheet, options) => Promise<{ css, styleProfileHash } | null>`.
- * Missing providers and compilation failures reject; only a genuinely empty
- * CSS input resolves to `null`.
+ * `(candidates, stylesheet, options) => Promise<{ css, styleProfileHash,
+ * cssPipelineIdentity } | null>`.
+ * The factory rejects invalid configuration synchronously. The returned
+ * function returns `null` only when there is no stylesheet and no candidate;
+ * malformed input and compile failures reject.
  */
 export function createCompileProjectCss(
   options: CompileProjectCssOptions,
 ): (
   candidates: Set<string>,
   stylesheet: string | undefined,
-  runtimeOptions?: CompileProjectCssRuntimeOptions,
+  runtimeOptions: CompileProjectCssRuntimeOptions,
 ) => Promise<CompileProjectCssResult | null> {
+  if (
+    !options ||
+    typeof options !== "object" ||
+    typeof options.projectScope !== "string" ||
+    options.projectScope.length === 0 ||
+    options.projectScope.length > MAX_PROJECT_SCOPE_LENGTH ||
+    options.projectScope.trim() !== options.projectScope ||
+    hasControlCharacters(options.projectScope)
+  ) {
+    throw new TypeError("Release CSS project scope is invalid");
+  }
+
   return async (
     candidates: Set<string>,
     stylesheet: string | undefined,
-    runtimeOptions?: CompileProjectCssRuntimeOptions,
+    runtimeOptions: CompileProjectCssRuntimeOptions,
   ): Promise<CompileProjectCssResult | null> => {
+    if (!(candidates instanceof Set) || candidates.size > MAX_CSS_CANDIDATES) {
+      throw new TypeError(
+        `Release asset CSS candidates must be a Set with at most ${MAX_CSS_CANDIDATES} entries`,
+      );
+    }
+    const candidateSnapshot = new Set<string>();
+    for (const candidate of candidates) {
+      if (
+        typeof candidate !== "string" ||
+        candidate.length === 0 ||
+        candidate.length > MAX_CSS_CANDIDATE_LENGTH ||
+        hasControlCharacters(candidate)
+      ) {
+        throw new TypeError("Release asset CSS candidate is invalid");
+      }
+      candidateSnapshot.add(candidate);
+    }
+    if (
+      stylesheet !== undefined &&
+      (typeof stylesheet !== "string" ||
+        textEncoder.encode(stylesheet).byteLength > RELEASE_ASSET_MAX_SIZE_BYTES)
+    ) {
+      throw new TypeError(
+        `Release asset stylesheet exceeds ${RELEASE_ASSET_MAX_SIZE_BYTES} bytes`,
+      );
+    }
+
     // A stylesheet can emit base/custom CSS without any utility candidates
     // (CSS variables, global rules), so only skip when there is neither a
     // stylesheet nor any candidates to compile.
-    if (candidates.size === 0 && !stylesheet) {
+    if (candidateSnapshot.size === 0 && !stylesheet) {
       logger.debug("No CSS candidates or stylesheet for release; skipping compile", {
         projectScope: options.projectScope,
       });
       return null;
     }
 
-    const styleProfile = createStyleScopeProfile(runtimeOptions?.config ?? options.config);
-    const generationSession = acquireCSSGenerationSession(true);
-    const resolvedStylesheet = stylesheet ??
-      generationSession.compilationSession.defaultStylesheet;
+    if (!runtimeOptions || typeof runtimeOptions !== "object" || !runtimeOptions.config) {
+      throw new TypeError("Release CSS config is unavailable");
+    }
 
-    const result = await generateTailwindCSS(resolvedStylesheet, candidates, {
+    const styleProfileHash = assertStyleProfileHash(
+      createStyleScopeProfile(runtimeOptions.config).hash,
+      "Release CSS style profile hash",
+    );
+    const generationSession = acquireCSSGenerationSession(true);
+    const cssPipelineIdentity = assertCSSPipelineIdentity(
+      generationSession.cacheIdentity,
+      "Release CSS pipeline identity",
+    );
+
+    const result = await generateTailwindCSS(stylesheet, candidateSnapshot, {
       minify: true,
       environment: "production",
       buildMode: "production",
       projectSlug: options.projectScope,
     }, { generationSession });
 
-    if (result.css.length === 0) {
-      throw new TypeError("Release asset CSS compiler produced an empty output");
+    if (!result.css) {
+      throw COMPILATION_ERROR.create({
+        detail: "Release asset CSS compilation produced empty output",
+      });
     }
-
-    const styleArtifactProfileHash = composeCSSStyleProfileHash(
-      styleProfile.hash,
-      result.cacheIdentity,
-    );
+    if (textEncoder.encode(result.css).byteLength > RELEASE_ASSET_MAX_SIZE_BYTES) {
+      throw new TypeError(
+        `Release asset CSS output exceeds ${RELEASE_ASSET_MAX_SIZE_BYTES} bytes`,
+      );
+    }
 
     logger.debug("Release asset CSS compiled", {
       projectScope: options.projectScope,
-      candidateCount: candidates.size,
+      candidateCount: candidateSnapshot.size,
       cssLength: result.css.length,
       cssHash: hashCSS(result.css),
-      styleProfileHash: styleArtifactProfileHash,
+      styleProfileHash,
+      cssPipelineIdentity,
     });
 
-    return { css: result.css, styleProfileHash: styleArtifactProfileHash };
+    return { css: result.css, styleProfileHash, cssPipelineIdentity };
   };
 }

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -20,20 +20,23 @@ import {
   getReadyManifestForRender,
   getReadyManifestForRenderAsync,
 } from "./manifest-cache.ts";
-import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "./constants.ts";
+import {
+  RELEASE_ASSET_MANIFEST_ENV_FLAG,
+  RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
+} from "./constants.ts";
 import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 
 const MOD_HASH = "a".repeat(64);
 
 function manifest(contentHash = MOD_HASH, manifestVersion = 3): ReleaseAssetManifest {
   return {
-    schemaVersion: 1,
+    schemaVersion: RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
     projectId: "p",
     releaseId: "r",
     releaseVersion: 1,
     manifestVersion,
     builderVersion: "0.1.765",
-    sourceContentHash: "",
+    sourceContentHash: "f".repeat(64),
     createdAt: "2026-06-12T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
     modules: {
@@ -41,9 +44,21 @@ function manifest(contentHash = MOD_HASH, manifestVersion = 3): ReleaseAssetMani
     },
     css: [],
     routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
+    dependencyMode: "source",
     dependencies: {},
-    fallback: { mode: "jit", gaps: [] },
   };
+}
+
+function manifestResponse(state: string, value: ReleaseAssetManifest | null) {
+  return {
+    state,
+    manifest_version: value?.manifestVersion ?? 0,
+    manifest: value,
+  };
+}
+
+function readyManifestResponse(value = manifest()) {
+  return manifestResponse("ready", value);
 }
 
 describe("html consumption helpers", () => {
@@ -91,6 +106,40 @@ describe("html consumption helpers", () => {
   it("returns no preloads for an uncovered route", () => {
     assertEquals(resolveManifestRoutePreloadUrls(manifest(), "/other"), []);
   });
+
+  it("ignores inherited route and module entries", () => {
+    const inheritedRoutes = Object.create({
+      "/inherited": { modules: ["pages/index.tsx"], css: [] },
+    }) as ReleaseAssetManifest["routes"];
+    const inheritedModules = Object.create({
+      "pages/inherited.tsx": {
+        contentHash: MOD_HASH,
+        size: 1,
+        contentType: "text/javascript",
+      },
+    }) as ReleaseAssetManifest["modules"];
+    const value = manifest();
+    value.routes = inheritedRoutes;
+    value.modules = inheritedModules;
+
+    assertEquals(resolveManifestRoutePreloadUrls(value, "/inherited"), []);
+    assertEquals(resolveManifestModuleUrl(value, "pages/inherited.tsx"), null);
+  });
+
+  it("deduplicates repeated preload identities", () => {
+    const value = manifest();
+    value.routes["/"]!.modules.push("pages/index.tsx");
+    assertEquals(resolveManifestRoutePreloadUrls(value, "/"), [
+      `/_vf/assets/${MOD_HASH}.js`,
+    ]);
+  });
+
+  it("falls back instead of emitting a malformed content hash", () => {
+    const value = manifest();
+    value.modules["pages/index.tsx"]!.contentHash = "../asset";
+    assertEquals(resolveManifestModuleUrl(value, "pages/index.tsx"), null);
+    assertEquals(resolveManifestRoutePreloadUrls(value, "/"), []);
+  });
 });
 
 describe("manifest cache gating", () => {
@@ -106,9 +155,7 @@ describe("manifest cache gating", () => {
 
   it("returns null when the flag is off (byte-identical fallback)", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest: manifest() })
-    );
+    configureReleaseAssetManifestFetcher(() => Promise.resolve(readyManifestResponse()));
     assertEquals(getReadyManifestForRender("r"), null);
   });
 
@@ -137,9 +184,7 @@ describe("manifest cache gating", () => {
   it("marks ready manifest fetches during profiled async reads", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest: manifest() })
-    );
+    configureReleaseAssetManifestFetcher(() => Promise.resolve(readyManifestResponse()));
 
     const record = await runWithRequestProfiling(
       { category: "html", method: "GET", pathname: "/" },
@@ -152,23 +197,24 @@ describe("manifest cache gating", () => {
     assertEquals(record?.phases["release_manifest.fetch_ready"], 0);
   });
 
-  it("uses partial manifests that include a manifest body", async () => {
+  it("rejects partial manifests even when they include a manifest body", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
     configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "partial", manifest: manifest() })
+      Promise.resolve(manifestResponse("partial", manifest()))
     );
 
     const record = await runWithRequestProfiling(
       { category: "html", method: "GET", pathname: "/" },
       async () => {
-        assertEquals((await getReadyManifestForRenderAsync("r"))?.manifestVersion, 3);
+        assertEquals(await getReadyManifestForRenderAsync("r"), null);
         return finalizeRequestProfiling(200);
       },
     );
 
     assertEquals(record?.phases["release_manifest.fetch_partial"], 0);
-    assertEquals(getReadyManifestForRender("r")?.manifestVersion, 3);
+    assertEquals(record?.phases["release_manifest.fetch_not_ready"], 0);
+    assertEquals(getReadyManifestForRender("r"), null);
   });
 
   it("marks manifest fetch failures during profiled async reads", async () => {
@@ -193,7 +239,7 @@ describe("manifest cache gating", () => {
     const gate = new Promise<void>((r) => (resolveFetch = r));
     configureReleaseAssetManifestFetcher(async () => {
       await gate;
-      return { state: "ready", manifest: manifest() };
+      return readyManifestResponse();
     });
 
     // First call schedules the fetch and returns null.
@@ -208,9 +254,7 @@ describe("manifest cache gating", () => {
 
   it("awaits a ready manifest on the first async read", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest: manifest() })
-    );
+    configureReleaseAssetManifestFetcher(() => Promise.resolve(readyManifestResponse()));
 
     const ready = await getReadyManifestForRenderAsync("r");
 
@@ -227,7 +271,7 @@ describe("manifest cache gating", () => {
     configureReleaseAssetManifestFetcher(async () => {
       fetchCount++;
       await gate;
-      return { state: "ready", manifest: manifest() };
+      return readyManifestResponse();
     });
 
     const first = getReadyManifestForRenderAsync("r");
@@ -252,9 +296,7 @@ describe("manifest cache gating", () => {
       let fetchCount = 0;
       configureReleaseAssetManifestFetcher(async () => {
         fetchCount++;
-        return fetchCount === 1
-          ? { state: "building", manifest: null }
-          : { state: "ready", manifest: manifest() };
+        return fetchCount === 1 ? manifestResponse("building", null) : readyManifestResponse();
       });
 
       assertEquals(await getReadyManifestForRenderAsync("r"), null);
@@ -290,11 +332,11 @@ describe("manifest cache gating", () => {
       fetchCount++;
       if (fetchCount === 1) {
         await firstGate;
-        return { state: "ready", manifest: manifest(firstHash) };
+        return readyManifestResponse(manifest(firstHash));
       }
 
       await secondGate;
-      return { state: "ready", manifest: manifest(secondHash) };
+      return readyManifestResponse(manifest(secondHash));
     });
 
     assertEquals(getReadyManifestForRender("r"), null);
@@ -334,8 +376,8 @@ describe("manifest cache gating", () => {
       configureReleaseAssetManifestFetcher(async () => {
         fetchCount++;
         return fetchCount === 1
-          ? { state: "ready", manifest: manifest(firstHash, 3) }
-          : { state: "ready", manifest: manifest(secondHash, 4) };
+          ? readyManifestResponse(manifest(firstHash, 3))
+          : readyManifestResponse(manifest(secondHash, 4));
       });
 
       assertEquals(getReadyManifestForRender("r"), null);
@@ -354,6 +396,57 @@ describe("manifest cache gating", () => {
     }
   });
 
+  const invalidatingRefreshes = [
+    {
+      name: "a partial response",
+      response: () => manifestResponse("partial", manifest("b".repeat(64), 4)),
+    },
+    {
+      name: "a terminal failed response",
+      response: () => manifestResponse("failed", manifest("b".repeat(64), 4)),
+    },
+    {
+      name: "a ready response with a mismatched envelope generation",
+      response: () => ({
+        state: "ready",
+        manifest_version: 3,
+        manifest: manifest("b".repeat(64), 4),
+      }),
+    },
+  ];
+
+  for (const invalidatingRefresh of invalidatingRefreshes) {
+    it(`evicts a cached ready manifest after ${invalidatingRefresh.name}`, async () => {
+      setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+      let now = 1_000;
+      const originalDateNow = Date.now;
+      Date.now = () => now;
+
+      try {
+        let fetchCount = 0;
+        configureReleaseAssetManifestFetcher(async () => {
+          fetchCount++;
+          return fetchCount === 1
+            ? readyManifestResponse(manifest("a".repeat(64), 3))
+            : invalidatingRefresh.response();
+        });
+
+        assertEquals(getReadyManifestForRender("r"), null);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assertEquals(getReadyManifestForRender("r")?.manifestVersion, 3);
+
+        now += 61_000;
+        assertEquals(getReadyManifestForRender("r")?.manifestVersion, 3);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        assertEquals(fetchCount, 2);
+        assertEquals(getReadyManifestForRender("r"), null);
+      } finally {
+        Date.now = originalDateNow;
+      }
+    });
+  }
+
   it("throttles failed ready-manifest revalidation while serving the stale ready manifest", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     let now = 1_000;
@@ -364,7 +457,10 @@ describe("manifest cache gating", () => {
       let fetchCount = 0;
       configureReleaseAssetManifestFetcher(async () => {
         fetchCount++;
-        return fetchCount === 1 ? { state: "ready", manifest: manifest("a".repeat(64), 3) } : null;
+        if (fetchCount === 1) {
+          return readyManifestResponse(manifest("a".repeat(64), 3));
+        }
+        throw new Error("temporary control-plane outage");
       });
 
       assertEquals(getReadyManifestForRender("r"), null);

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -16,9 +16,9 @@ import {
 import {
   clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
   getReadyManifestForRender,
   getReadyManifestForRenderAsync,
+  registerManifestFetcherForRelease,
 } from "./manifest-cache.ts";
 import {
   RELEASE_ASSET_MANIFEST_ENV_FLAG,
@@ -148,27 +148,24 @@ describe("manifest cache gating", () => {
   afterEach(() => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalFlag ?? "");
     Deno.env.delete("VERYFRONT_ENABLE_SERVER_TIMING");
-    configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
     resetRequestProfiles();
   });
 
   it("returns null when the flag is off (byte-identical fallback)", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "");
-    configureReleaseAssetManifestFetcher(() => Promise.resolve(readyManifestResponse()));
+    registerManifestFetcherForRelease("r", () => Promise.resolve(readyManifestResponse()));
     assertEquals(getReadyManifestForRender("r"), null);
   });
 
   it("returns null when no fetcher is registered", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(undefined);
     assertEquals(getReadyManifestForRender("r"), null);
   });
 
   it("marks the no-fetcher fallback reason during profiled async reads", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
-    configureReleaseAssetManifestFetcher(undefined);
 
     const record = await runWithRequestProfiling(
       { category: "html", method: "GET", pathname: "/" },
@@ -184,7 +181,7 @@ describe("manifest cache gating", () => {
   it("marks ready manifest fetches during profiled async reads", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
-    configureReleaseAssetManifestFetcher(() => Promise.resolve(readyManifestResponse()));
+    registerManifestFetcherForRelease("r", () => Promise.resolve(readyManifestResponse()));
 
     const record = await runWithRequestProfiling(
       { category: "html", method: "GET", pathname: "/" },
@@ -200,8 +197,9 @@ describe("manifest cache gating", () => {
   it("rejects partial manifests even when they include a manifest body", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve(manifestResponse("partial", manifest()))
+    registerManifestFetcherForRelease(
+      "r",
+      () => Promise.resolve(manifestResponse("partial", manifest())),
     );
 
     const record = await runWithRequestProfiling(
@@ -220,7 +218,7 @@ describe("manifest cache gating", () => {
   it("marks manifest fetch failures during profiled async reads", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
-    configureReleaseAssetManifestFetcher(() => Promise.reject(new Error("boom")));
+    registerManifestFetcherForRelease("r", () => Promise.reject(new Error("boom")));
 
     const record = await runWithRequestProfiling(
       { category: "html", method: "GET", pathname: "/" },
@@ -237,7 +235,7 @@ describe("manifest cache gating", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     let resolveFetch: () => void = () => {};
     const gate = new Promise<void>((r) => (resolveFetch = r));
-    configureReleaseAssetManifestFetcher(async () => {
+    registerManifestFetcherForRelease("r", async () => {
       await gate;
       return readyManifestResponse();
     });
@@ -254,7 +252,7 @@ describe("manifest cache gating", () => {
 
   it("awaits a ready manifest on the first async read", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() => Promise.resolve(readyManifestResponse()));
+    registerManifestFetcherForRelease("r", () => Promise.resolve(readyManifestResponse()));
 
     const ready = await getReadyManifestForRenderAsync("r");
 
@@ -268,7 +266,7 @@ describe("manifest cache gating", () => {
     const gate = new Promise<void>((resolve) => (resolveFetch = resolve));
     let fetchCount = 0;
 
-    configureReleaseAssetManifestFetcher(async () => {
+    registerManifestFetcherForRelease("r", async () => {
       fetchCount++;
       await gate;
       return readyManifestResponse();
@@ -294,7 +292,7 @@ describe("manifest cache gating", () => {
 
     try {
       let fetchCount = 0;
-      configureReleaseAssetManifestFetcher(async () => {
+      registerManifestFetcherForRelease("r", async () => {
         fetchCount++;
         return fetchCount === 1 ? manifestResponse("building", null) : readyManifestResponse();
       });
@@ -328,7 +326,7 @@ describe("manifest cache gating", () => {
     const secondGate = new Promise<void>((resolve) => (resolveSecond = resolve));
     let fetchCount = 0;
 
-    configureReleaseAssetManifestFetcher(async () => {
+    registerManifestFetcherForRelease("r", async () => {
       fetchCount++;
       if (fetchCount === 1) {
         await firstGate;
@@ -373,7 +371,7 @@ describe("manifest cache gating", () => {
 
     try {
       let fetchCount = 0;
-      configureReleaseAssetManifestFetcher(async () => {
+      registerManifestFetcherForRelease("r", async () => {
         fetchCount++;
         return fetchCount === 1
           ? readyManifestResponse(manifest(firstHash, 3))
@@ -424,7 +422,7 @@ describe("manifest cache gating", () => {
 
       try {
         let fetchCount = 0;
-        configureReleaseAssetManifestFetcher(async () => {
+        registerManifestFetcherForRelease("r", async () => {
           fetchCount++;
           return fetchCount === 1
             ? readyManifestResponse(manifest("a".repeat(64), 3))
@@ -455,7 +453,7 @@ describe("manifest cache gating", () => {
 
     try {
       let fetchCount = 0;
-      configureReleaseAssetManifestFetcher(async () => {
+      registerManifestFetcherForRelease("r", async () => {
         fetchCount++;
         if (fetchCount === 1) {
           return readyManifestResponse(manifest("a".repeat(64), 3));

--- a/src/release-assets/html-consumption.ts
+++ b/src/release-assets/html-consumption.ts
@@ -10,7 +10,7 @@
  */
 
 import { serverLogger } from "#veryfront/utils";
-import { releaseAssetUrl } from "./constants.ts";
+import { isValidContentHash, RELEASE_ASSET_CONTENT_TYPES, releaseAssetUrl } from "./constants.ts";
 import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 
 const logger = serverLogger.component("release-asset-consume");
@@ -25,7 +25,8 @@ const logger = serverLogger.component("release-asset-consume");
  * extensions.
  */
 export function normalizeManifestModuleKey(path: string): string {
-  let key = String(path || "").replace(/^\/?_vf_modules\//, "");
+  if (typeof path !== "string") return "";
+  let key = path.replace(/^\/?_vf_modules\//, "");
   key = key.replace(/^\/+/, "");
   key = key.replace(/[?#].*$/, "");
   return key;
@@ -43,14 +44,16 @@ export function resolveManifestModuleUrl(
   logicalPath: string,
 ): string | null {
   const key = normalizeManifestModuleKey(logicalPath);
-  const direct = manifest.modules[key];
-  if (direct) return releaseAssetUrl(direct.contentHash, "js");
+  const direct = ownEntry(manifest.modules, key);
+  if (isUsableJavaScriptAsset(direct)) return releaseAssetUrl(direct.contentHash, "js");
 
   // Tolerate keys that differ only by extension (e.g. ".js" vs source ext).
   const withoutExt = key.replace(/\.(tsx|ts|jsx|mdx|js)$/, "");
   for (const candidateExt of [".tsx", ".ts", ".jsx", ".mdx", ".js"]) {
-    const candidate = manifest.modules[withoutExt + candidateExt];
-    if (candidate) return releaseAssetUrl(candidate.contentHash, "js");
+    const candidate = ownEntry(manifest.modules, withoutExt + candidateExt);
+    if (isUsableJavaScriptAsset(candidate)) {
+      return releaseAssetUrl(candidate.contentHash, "js");
+    }
   }
 
   logger.debug("manifest module miss", { key });
@@ -62,17 +65,32 @@ export function resolveManifestRoutePreloadUrls(
   manifest: ReleaseAssetManifest,
   route: string,
 ): string[] {
-  const entry = manifest.routes[route] ?? manifest.routes[`/${route}`] ??
-    manifest.routes[route.replace(/^\//, "")];
+  const entry = ownEntry(manifest.routes, route) ??
+    ownEntry(manifest.routes, `/${route}`) ??
+    ownEntry(manifest.routes, route.replace(/^\//, ""));
   if (!entry) {
     logger.debug("manifest route miss", { route });
     return [];
   }
 
-  const urls: string[] = [];
+  const urls = new Set<string>();
   for (const modulePath of entry.modules) {
-    const asset = manifest.modules[modulePath];
-    if (asset) urls.push(releaseAssetUrl(asset.contentHash, "js"));
+    const asset = ownEntry(manifest.modules, modulePath);
+    if (isUsableJavaScriptAsset(asset)) {
+      urls.add(releaseAssetUrl(asset.contentHash, "js"));
+    }
   }
-  return urls;
+  return [...urls];
+}
+
+function ownEntry<T>(record: Record<string, T>, key: string): T | undefined {
+  return Object.hasOwn(record, key) ? record[key] : undefined;
+}
+
+function isUsableJavaScriptAsset(
+  value: ReleaseAssetManifest["modules"][string] | undefined,
+): value is ReleaseAssetManifest["modules"][string] {
+  return value !== undefined &&
+    value.contentType === RELEASE_ASSET_CONTENT_TYPES.js &&
+    isValidContentHash(value.contentHash);
 }

--- a/src/release-assets/index.ts
+++ b/src/release-assets/index.ts
@@ -64,7 +64,6 @@ export {
 export {
   clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
   getReadyManifestForRender,
   getReadyManifestForRenderAsync,
   isReleaseAssetManifestEnabled,

--- a/src/release-assets/index.ts
+++ b/src/release-assets/index.ts
@@ -1,5 +1,20 @@
 /**
- * Release Asset Manifest — public barrel.
+ * Content-addressed release asset build, schema, cache, and consumption
+ * contracts.
+ *
+ * @example Validate an API response before consuming its manifest body.
+ * ```ts
+ * import { parseReadyReleaseAssetManifestResponse } from "veryfront/release-assets";
+ *
+ * const expectedReleaseId = "release-123";
+ * const response = await fetch("/api/releases/current/asset-manifest");
+ * const ready = parseReadyReleaseAssetManifestResponse(
+ *   await response.json(),
+ *   expectedReleaseId,
+ * );
+ * if (!ready) throw new Error("Invalid release asset manifest response");
+ * const manifest = ready.manifest;
+ * ```
  *
  * @module release-assets
  * @example Build an immutable URL for a published JavaScript asset
@@ -17,19 +32,29 @@ export {
   RELEASE_ASSET_BASE_PATH,
   RELEASE_ASSET_CONTENT_TYPE_ALLOWLIST,
   RELEASE_ASSET_CONTENT_TYPES,
+  RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG,
   RELEASE_ASSET_IMMUTABLE_MAX_AGE_SECONDS,
   RELEASE_ASSET_MANIFEST_ENV_FLAG,
+  RELEASE_ASSET_MANIFEST_LIMITS,
   RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
+  RELEASE_ASSET_MAX_PENDING_BYTES,
   RELEASE_ASSET_MAX_SIZE_BYTES,
   RELEASE_ASSET_UPLOAD_CONCURRENCY,
+  RELEASE_MODULE_RUNTIME_VERSION_PARAM,
+  RELEASE_MODULE_VERSION_PARAM,
   type ReleaseAssetContentType,
   type ReleaseAssetExtension,
   releaseAssetUrl,
 } from "./constants.ts";
 export {
   getReleaseAssetManifestSchema,
+  hasImmutableReleaseAssetDependencies,
+  type ImmutableReleaseAssetManifest,
+  parseReadyReleaseAssetManifestResponse,
   parseReleaseAssetManifest,
+  type ReadyReleaseAssetManifestResponse,
   type ReleaseAssetCssEntry,
+  type ReleaseAssetDependencyMode,
   type ReleaseAssetEntry,
   type ReleaseAssetManifest,
   type ReleaseAssetManifestResponse,
@@ -37,12 +62,17 @@ export {
   type ReleaseAssetRouteEntry,
 } from "./manifest-schema.ts";
 export {
+  clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
   configureReleaseAssetManifestFetcher,
   getReadyManifestForRender,
+  getReadyManifestForRenderAsync,
   isReleaseAssetManifestEnabled,
+  type ReadyManifestReadOptions,
   registerManifestFetcherForRelease,
+  type ReleaseAssetManifestFetchContext,
   type ReleaseAssetManifestFetcher,
+  type ReleaseAssetManifestFetcherCleanup,
   unregisterManifestFetcherForRelease,
 } from "./manifest-cache.ts";
 export {
@@ -50,16 +80,4 @@ export {
   resolveManifestModuleUrl,
   resolveManifestRoutePreloadUrls,
 } from "./html-consumption.ts";
-export {
-  type ReleaseAssetBuildClient,
-  type ReleaseAssetBuildInput,
-  type ReleaseAssetBuildResult,
-  type ReleaseAssetTransform,
-  runReleaseAssetBuild,
-} from "./build-executor.ts";
-export {
-  type CompileProjectCssOptions,
-  type CompileProjectCssResult,
-  createCompileProjectCss,
-} from "./css-compile.ts";
 export { routeForPage } from "./route-path.ts";

--- a/src/release-assets/manifest-cache.test.ts
+++ b/src/release-assets/manifest-cache.test.ts
@@ -1,10 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
   getReadyManifestForRenderAsync,
   registerManifestFetcherForRelease,
 } from "./manifest-cache.ts";
@@ -152,36 +151,20 @@ describe("release asset manifest fetcher ownership", () => {
     assertEquals(await getReadyManifestForRenderAsync("release-1"), null);
   });
 
-  it("does not reserve a real release ID for the global fallback", async () => {
+  it("never invokes another release owner's fetcher", async () => {
     Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", "1");
-    configureReleaseAssetManifestFetcher(() => Promise.resolve(readyManifestResponse("other", 1)));
-    registerManifestFetcherForRelease(
-      "*",
-      () => Promise.resolve(readyManifestResponse("*", 2)),
-    );
+    const calls: string[] = [];
+    registerManifestFetcherForRelease("release-a", (releaseId) => {
+      calls.push(releaseId);
+      return Promise.resolve(readyManifestResponse("release-a", 1));
+    });
 
-    const resolved = await getReadyManifestForRenderAsync("*");
-    assertEquals(resolved?.releaseId, "*");
-    assertEquals(resolved?.manifestVersion, 2);
-    assert(resolved !== null);
-  });
-
-  it("does not reuse a cached manifest across fallback owners", async () => {
-    Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", "1");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve(readyManifestResponse("release-1", 1))
-    );
+    assertEquals(await getReadyManifestForRenderAsync("release-b"), null);
+    assertEquals(calls, []);
     assertEquals(
-      (await getReadyManifestForRenderAsync("release-1"))?.manifestVersion,
-      1,
+      (await getReadyManifestForRenderAsync("release-a"))?.releaseId,
+      "release-a",
     );
-
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve(readyManifestResponse("release-1", 2))
-    );
-    assertEquals(
-      (await getReadyManifestForRenderAsync("release-1"))?.manifestVersion,
-      2,
-    );
+    assertEquals(calls, ["release-a"]);
   });
 });

--- a/src/release-assets/manifest-cache.test.ts
+++ b/src/release-assets/manifest-cache.test.ts
@@ -1,0 +1,187 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  clearCachedReleaseAssetManifests,
+  clearReleaseAssetManifestCache,
+  configureReleaseAssetManifestFetcher,
+  getReadyManifestForRenderAsync,
+  registerManifestFetcherForRelease,
+} from "./manifest-cache.ts";
+import type { ReleaseAssetManifest } from "./manifest-schema.ts";
+import { RELEASE_ASSET_MANIFEST_SCHEMA_VERSION } from "./constants.ts";
+
+function manifest(releaseId: string, manifestVersion: number): ReleaseAssetManifest {
+  return {
+    schemaVersion: RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
+    projectId: "project-1",
+    releaseId,
+    releaseVersion: 1,
+    manifestVersion,
+    builderVersion: "test",
+    sourceContentHash: "a".repeat(64),
+    createdAt: "2026-07-26T00:00:00.000Z",
+    assetBasePath: "/_vf/assets",
+    modules: {},
+    css: [],
+    routes: {},
+    dependencyMode: "source",
+    dependencies: {},
+  };
+}
+
+function readyManifestResponse(releaseId: string, manifestVersion: number) {
+  const value = manifest(releaseId, manifestVersion);
+  return {
+    state: "ready",
+    manifest_version: value.manifestVersion,
+    manifest: value,
+  };
+}
+
+describe("release asset manifest fetcher ownership", () => {
+  const originalFlag = Deno.env.get("VERYFRONT_RELEASE_ASSET_MANIFEST");
+
+  afterEach(() => {
+    clearReleaseAssetManifestCache();
+    if (originalFlag === undefined) {
+      Deno.env.delete("VERYFRONT_RELEASE_ASSET_MANIFEST");
+    } else {
+      Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", originalFlag);
+    }
+  });
+
+  it("does not let an older adapter cleanup remove a newer fetcher", async () => {
+    const calls: string[] = [];
+    clearReleaseAssetManifestCache();
+    Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", "1");
+
+    const cleanupOlder = registerManifestFetcherForRelease("release-1", async () => {
+      calls.push("older");
+      return null;
+    });
+    const cleanupNewer = registerManifestFetcherForRelease("release-1", async () => {
+      calls.push("newer");
+      return null;
+    });
+
+    cleanupOlder();
+    cleanupOlder();
+    clearCachedReleaseAssetManifests();
+    await getReadyManifestForRenderAsync("release-1");
+    assertEquals(calls, ["newer"]);
+
+    cleanupNewer();
+    clearCachedReleaseAssetManifests();
+    await getReadyManifestForRenderAsync("release-1");
+    assertEquals(calls, ["newer"]);
+  });
+
+  it("keeps cache identities distinct for delimiter-shaped release IDs", async () => {
+    Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", "1");
+    const calls: string[] = [];
+    registerManifestFetcherForRelease("release", () => {
+      calls.push("release");
+      return Promise.resolve(readyManifestResponse("release", 1));
+    });
+    registerManifestFetcherForRelease("release:1", () => {
+      calls.push("release:1");
+      return Promise.resolve(readyManifestResponse("release:1", 2));
+    });
+
+    assertEquals((await getReadyManifestForRenderAsync("release"))?.releaseId, "release");
+    assertEquals((await getReadyManifestForRenderAsync("release:1"))?.releaseId, "release:1");
+    assertEquals(calls, ["release", "release:1"]);
+  });
+
+  it("does not let a superseded in-flight fetch publish stale state", async () => {
+    Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", "1");
+    let resolveOlder:
+      | ((value: ReturnType<typeof readyManifestResponse>) => void)
+      | undefined;
+    const olderResult = new Promise<ReturnType<typeof readyManifestResponse>>(
+      (resolve) => {
+        resolveOlder = resolve;
+      },
+    );
+
+    registerManifestFetcherForRelease("release-1", () => olderResult);
+    const olderRead = getReadyManifestForRenderAsync("release-1");
+
+    registerManifestFetcherForRelease(
+      "release-1",
+      () => Promise.resolve(readyManifestResponse("release-1", 2)),
+    );
+    const newerRead = getReadyManifestForRenderAsync("release-1");
+    resolveOlder?.(readyManifestResponse("release-1", 1));
+
+    assertEquals((await newerRead)?.manifestVersion, 2);
+    await olderRead;
+    assertEquals((await getReadyManifestForRenderAsync("release-1"))?.manifestVersion, 2);
+  });
+
+  it("aborts a pending fetch when its cache generation is cleared", async () => {
+    Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", "1");
+    let signal: AbortSignal | undefined;
+    let markStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+
+    registerManifestFetcherForRelease("release-1", (_releaseId, context) => {
+      signal = context.signal;
+      markStarted?.();
+      return new Promise(() => undefined);
+    });
+
+    const pendingRead = getReadyManifestForRenderAsync("release-1");
+    await started;
+    clearCachedReleaseAssetManifests();
+
+    assertEquals(signal?.aborted, true);
+    assertEquals(await pendingRead, null);
+  });
+
+  it("rejects a manifest returned for a different release", async () => {
+    Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", "1");
+    registerManifestFetcherForRelease(
+      "release-1",
+      () => Promise.resolve(readyManifestResponse("release-2", 1)),
+    );
+
+    assertEquals(await getReadyManifestForRenderAsync("release-1"), null);
+  });
+
+  it("does not reserve a real release ID for the global fallback", async () => {
+    Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", "1");
+    configureReleaseAssetManifestFetcher(() => Promise.resolve(readyManifestResponse("other", 1)));
+    registerManifestFetcherForRelease(
+      "*",
+      () => Promise.resolve(readyManifestResponse("*", 2)),
+    );
+
+    const resolved = await getReadyManifestForRenderAsync("*");
+    assertEquals(resolved?.releaseId, "*");
+    assertEquals(resolved?.manifestVersion, 2);
+    assert(resolved !== null);
+  });
+
+  it("does not reuse a cached manifest across fallback owners", async () => {
+    Deno.env.set("VERYFRONT_RELEASE_ASSET_MANIFEST", "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve(readyManifestResponse("release-1", 1))
+    );
+    assertEquals(
+      (await getReadyManifestForRenderAsync("release-1"))?.manifestVersion,
+      1,
+    );
+
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve(readyManifestResponse("release-1", 2))
+    );
+    assertEquals(
+      (await getReadyManifestForRenderAsync("release-1"))?.manifestVersion,
+      2,
+    );
+  });
+});

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -122,8 +122,6 @@ interface FetcherRegistration {
 
 /** Per-releaseId fetcher registry (keyed by releaseId). */
 const fetcherRegistry = new Map<string, FetcherRegistration>();
-/** Optional fallback for simple single-project/test setups. */
-let fallbackFetcher: FetcherRegistration | undefined;
 
 function isValidReleaseId(value: unknown): value is string {
   return typeof value === "string" &&
@@ -144,7 +142,7 @@ function requireValidReleaseId(value: string): string {
 
 function retireStaleInFlightFetches(): void {
   for (const [releaseId, fetch] of inFlight) {
-    if (resolveFetcher(releaseId)?.token === fetch.ownerToken) continue;
+    if (fetcherRegistry.get(releaseId)?.token === fetch.ownerToken) continue;
     inFlight.delete(releaseId);
     fetch.controller.abort(new Error("Release manifest fetcher ownership changed"));
   }
@@ -198,33 +196,6 @@ export function registerManifestFetcherForRelease(
 export function unregisterManifestFetcherForRelease(releaseId: string): void {
   fetcherRegistry.delete(requireValidReleaseId(releaseId));
   retireStaleInFlightFetches();
-}
-
-/**
- * Register a single global fetcher (for tests / simple single-project setups).
- *
- * In production multi-tenant mode prefer `registerManifestFetcherForRelease`.
- * Passing `undefined` clears the global fallback.
- */
-export function configureReleaseAssetManifestFetcher(
-  fetcher: ReleaseAssetManifestFetcher | undefined,
-): void {
-  if (fetcher) {
-    if (typeof fetcher !== "function") {
-      throw new TypeError("Manifest fetcher must be a function");
-    }
-    fallbackFetcher = { fetcher, token: Symbol("fallback-manifest-fetcher") };
-  } else {
-    fallbackFetcher = undefined;
-  }
-  retireStaleInFlightFetches();
-}
-
-/** Resolve the fetcher for a releaseId: prefer per-releaseId, then global fallback. */
-function resolveFetcher(
-  releaseId: string,
-): FetcherRegistration | undefined {
-  return fetcherRegistry.get(releaseId) ?? fallbackFetcher;
 }
 
 /** True when production manifest consumption is enabled via env flag. */
@@ -298,7 +269,7 @@ export function getReadyManifestForRender(
     markManifestDecision("disabled");
     return null;
   }
-  const activeFetcher = resolveFetcher(releaseId);
+  const activeFetcher = fetcherRegistry.get(releaseId);
   if (!activeFetcher) {
     markManifestDecision("no_fetcher");
     return null;
@@ -352,7 +323,7 @@ export async function getReadyManifestForRenderAsync(
     markManifestDecision("disabled");
     return null;
   }
-  const activeFetcher = resolveFetcher(releaseId);
+  const activeFetcher = fetcherRegistry.get(releaseId);
   if (!activeFetcher) {
     markManifestDecision("no_fetcher");
     return null;
@@ -389,7 +360,7 @@ function scheduleFetch(releaseId: string): void {
 }
 
 function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> {
-  const active = resolveFetcher(releaseId);
+  const active = fetcherRegistry.get(releaseId);
   if (!active) {
     markManifestDecision("no_fetcher");
     return Promise.resolve(null);
@@ -499,7 +470,8 @@ function isCurrentFetchOwner(
   generation: symbol,
   ownerToken: symbol,
 ): boolean {
-  return generation === cacheGeneration && resolveFetcher(releaseId)?.token === ownerToken;
+  return generation === cacheGeneration &&
+    fetcherRegistry.get(releaseId)?.token === ownerToken;
 }
 
 async function invokeManifestFetcher(
@@ -582,5 +554,4 @@ export function clearCachedReleaseAssetManifests(): void {
 export function clearReleaseAssetManifestCache(): void {
   clearCachedReleaseAssetManifests();
   fetcherRegistry.clear();
-  fallbackFetcher = undefined;
 }

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -2,7 +2,7 @@
  * Release Asset Manifest — in-process consumption cache (production HTML).
  *
  * Fetches manifests from the project-scoped GET endpoint once per release and
- * caches them keyed by `${releaseId}:${manifestVersion}`. Ready manifests are
+ * caches them under collision-free release/version tuple identities. Ready manifests are
  * cached for a bounded TTL (15 min) so superseded manifests are eventually
  * replaced; non-ready / missing results are cached for a short TTL so the
  * common "no manifest" case stays cheap.
@@ -23,13 +23,17 @@
  * @module release-assets/manifest-cache
  */
 
-import { serverLogger } from "#veryfront/utils";
+import { serverLogger } from "#veryfront/utils/logger/index.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { markRequestProfilePhase, profilePhase } from "#veryfront/observability";
-import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "./constants.ts";
-import { parseReleaseAssetManifest, type ReleaseAssetManifest } from "./manifest-schema.ts";
+import { RELEASE_ASSET_MANIFEST_ENV_FLAG, RELEASE_ASSET_MANIFEST_LIMITS } from "./constants.ts";
+import {
+  parseReadyReleaseAssetManifestResponse,
+  type ReleaseAssetManifest,
+} from "./manifest-schema.ts";
+import { hasControlCharacters } from "./string-validation.ts";
 
 const logger = serverLogger.component("release-asset-manifest");
 
@@ -43,8 +47,13 @@ const NON_READY_REVALIDATE_MS = 5_000;
 const READY_TTL_MS = 15 * 60 * 1000;
 /** Background revalidation interval for ready manifests (1 min). */
 const READY_REVALIDATE_MS = 60_000;
+/** A manifest fetch must not hold an HTML render or in-flight slot forever. */
+const MANIFEST_FETCH_TIMEOUT_MS = 10_000;
+const MAX_REGISTERED_FETCHERS = 10_000;
 
 interface CacheEntry {
+  releaseId: string;
+  ownerToken: symbol;
   manifest: ReleaseAssetManifest | null;
   /** Absolute expiry timestamp. */
   expiresAt: number;
@@ -56,11 +65,14 @@ const manifestCache = new LRUCache<string, CacheEntry>({ maxEntries: MAX_CACHED_
 registerLRUCache("release-asset-manifest-cache", manifestCache);
 
 interface InFlightFetch {
-  generation: number;
+  generation: symbol;
   token: symbol;
+  ownerToken: symbol;
+  controller: AbortController;
   promise: Promise<ReleaseAssetManifest | null>;
 }
 
+/** Controls revalidation behavior for awaited manifest reads. */
 export interface ReadyManifestReadOptions {
   /**
    * Retry a cached non-ready result after a short throttle instead of waiting
@@ -73,7 +85,20 @@ export interface ReadyManifestReadOptions {
 /** In-flight fetches, deduped per releaseId. */
 const inFlight = new Map<string, InFlightFetch>();
 /** Monotonic guard that invalidates pending fetch writers after cache clears. */
-let cacheGeneration = 0;
+let cacheGeneration = Symbol("release-asset-manifest-cache-generation");
+
+/** Cancellation context passed to a release-scoped manifest fetcher. */
+export interface ReleaseAssetManifestFetchContext {
+  /** Aborted when the fetch times out or its fetcher loses ownership. */
+  readonly signal: AbortSignal;
+}
+
+/** Untrusted control-plane response returned by a registered fetcher. */
+export interface ReleaseAssetManifestFetchResult {
+  readonly state: string;
+  readonly manifest_version: number;
+  readonly manifest: unknown;
+}
 
 /**
  * Fetcher used to retrieve a manifest for a release. Registered per-releaseId
@@ -81,13 +106,49 @@ let cacheGeneration = 0;
  * token is always used. Returns null when the manifest is unavailable.
  */
 export interface ReleaseAssetManifestFetcher {
-  (releaseId: string): Promise<
-    { state: string; manifest: ReleaseAssetManifest | null } | null
-  >;
+  (
+    releaseId: string,
+    context: ReleaseAssetManifestFetchContext,
+  ): Promise<ReleaseAssetManifestFetchResult | null>;
+}
+
+/** Idempotent cleanup for one fetcher registration. */
+export type ReleaseAssetManifestFetcherCleanup = () => void;
+
+interface FetcherRegistration {
+  fetcher: ReleaseAssetManifestFetcher;
+  token: symbol;
 }
 
 /** Per-releaseId fetcher registry (keyed by releaseId). */
-const fetcherRegistry = new Map<string, ReleaseAssetManifestFetcher>();
+const fetcherRegistry = new Map<string, FetcherRegistration>();
+/** Optional fallback for simple single-project/test setups. */
+let fallbackFetcher: FetcherRegistration | undefined;
+
+function isValidReleaseId(value: unknown): value is string {
+  return typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= RELEASE_ASSET_MANIFEST_LIMITS.identifierLength &&
+    value.trim() === value &&
+    !hasControlCharacters(value);
+}
+
+function requireValidReleaseId(value: string): string {
+  if (!isValidReleaseId(value)) {
+    throw new TypeError(
+      `releaseId must be non-empty, trimmed text up to ${RELEASE_ASSET_MANIFEST_LIMITS.identifierLength} characters`,
+    );
+  }
+  return value;
+}
+
+function retireStaleInFlightFetches(): void {
+  for (const [releaseId, fetch] of inFlight) {
+    if (resolveFetcher(releaseId)?.token === fetch.ownerToken) continue;
+    inFlight.delete(releaseId);
+    fetch.controller.abort(new Error("Release manifest fetcher ownership changed"));
+  }
+}
 
 /**
  * Register a project-scoped manifest fetcher for the given releaseId.
@@ -99,17 +160,44 @@ const fetcherRegistry = new Map<string, ReleaseAssetManifestFetcher>();
 export function registerManifestFetcherForRelease(
   releaseId: string,
   fetcher: ReleaseAssetManifestFetcher,
-): void {
-  fetcherRegistry.set(releaseId, fetcher);
+): ReleaseAssetManifestFetcherCleanup {
+  const validReleaseId = requireValidReleaseId(releaseId);
+  if (typeof fetcher !== "function") {
+    throw new TypeError("Manifest fetcher must be a function");
+  }
+  if (
+    !fetcherRegistry.has(validReleaseId) &&
+    fetcherRegistry.size >= MAX_REGISTERED_FETCHERS
+  ) {
+    throw new Error(`Manifest fetcher registry is limited to ${MAX_REGISTERED_FETCHERS} releases`);
+  }
+  const registration: FetcherRegistration = {
+    fetcher,
+    token: Symbol(validReleaseId),
+  };
+  fetcherRegistry.set(validReleaseId, registration);
+  retireStaleInFlightFetches();
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    if (fetcherRegistry.get(validReleaseId)?.token === registration.token) {
+      fetcherRegistry.delete(validReleaseId);
+      retireStaleInFlightFetches();
+    }
+  };
 }
 
 /**
  * Remove the manifest fetcher for the given releaseId.
  *
- * Called when an adapter transitions away from a release context.
+ * This is an unconditional administrative removal. Adapter owners should use
+ * the cleanup returned by `registerManifestFetcherForRelease` so an older
+ * adapter cannot remove a newer registration for the same release.
  */
 export function unregisterManifestFetcherForRelease(releaseId: string): void {
-  fetcherRegistry.delete(releaseId);
+  fetcherRegistry.delete(requireValidReleaseId(releaseId));
+  retireStaleInFlightFetches();
 }
 
 /**
@@ -122,17 +210,21 @@ export function configureReleaseAssetManifestFetcher(
   fetcher: ReleaseAssetManifestFetcher | undefined,
 ): void {
   if (fetcher) {
-    fetcherRegistry.set("*", fetcher);
+    if (typeof fetcher !== "function") {
+      throw new TypeError("Manifest fetcher must be a function");
+    }
+    fallbackFetcher = { fetcher, token: Symbol("fallback-manifest-fetcher") };
   } else {
-    fetcherRegistry.delete("*");
+    fallbackFetcher = undefined;
   }
+  retireStaleInFlightFetches();
 }
 
 /** Resolve the fetcher for a releaseId: prefer per-releaseId, then global fallback. */
 function resolveFetcher(
   releaseId: string,
-): ReleaseAssetManifestFetcher | undefined {
-  return fetcherRegistry.get(releaseId) ?? fetcherRegistry.get("*");
+): FetcherRegistration | undefined {
+  return fetcherRegistry.get(releaseId) ?? fallbackFetcher;
 }
 
 /** True when production manifest consumption is enabled via env flag. */
@@ -145,17 +237,17 @@ export function isReleaseAssetManifestEnabled(): boolean {
 
 /** Build the cache key from releaseId + the latest known manifestVersion. */
 function cacheKey(releaseId: string, manifestVersion?: number): string {
-  return manifestVersion !== undefined ? `${releaseId}:${manifestVersion}` : releaseId;
+  return JSON.stringify([releaseId, manifestVersion ?? null]);
 }
 
 function markManifestDecision(decision: string): void {
   markRequestProfilePhase(`release_manifest.${decision}`);
 }
 
-function findCachedReadyEntry(releaseId: string): CacheEntry | null {
+function findCachedReadyEntry(releaseId: string, ownerToken: symbol): CacheEntry | null {
   let best: CacheEntry | null = null;
-  for (const [k, v] of manifestCache.entries()) {
-    if (k !== releaseId && !k.startsWith(`${releaseId}:`)) continue;
+  for (const [, v] of manifestCache.entries()) {
+    if (v.releaseId !== releaseId || v.ownerToken !== ownerToken) continue;
     if (v.expiresAt > Date.now() && v.manifest) {
       const existingVersion = best?.manifest?.manifestVersion ?? -1;
       if ((v.manifest.manifestVersion ?? 0) > existingVersion) {
@@ -174,6 +266,16 @@ function maybeScheduleReadyRefresh(releaseId: string, entry: CacheEntry): void {
   }
 }
 
+function evictReadyManifests(releaseId: string, ownerToken: symbol): void {
+  const keys: string[] = [];
+  for (const [key, entry] of manifestCache.entries()) {
+    if (entry.releaseId === releaseId && entry.ownerToken === ownerToken && entry.manifest) {
+      keys.push(key);
+    }
+  }
+  for (const key of keys) manifestCache.delete(key);
+}
+
 /**
  * Return a ready manifest for `releaseId` if one is cached, else null.
  *
@@ -188,16 +290,21 @@ export function getReadyManifestForRender(
     markManifestDecision("no_release_id");
     return null;
   }
+  if (!isValidReleaseId(releaseId)) {
+    markManifestDecision("invalid_release_id");
+    return null;
+  }
   if (!isReleaseAssetManifestEnabled()) {
     markManifestDecision("disabled");
     return null;
   }
-  if (!resolveFetcher(releaseId)) {
+  const activeFetcher = resolveFetcher(releaseId);
+  if (!activeFetcher) {
     markManifestDecision("no_fetcher");
     return null;
   }
 
-  const best = findCachedReadyEntry(releaseId);
+  const best = findCachedReadyEntry(releaseId, activeFetcher.token);
   if (best) {
     markManifestDecision("cached_ready");
     maybeScheduleReadyRefresh(releaseId, best);
@@ -205,8 +312,12 @@ export function getReadyManifestForRender(
   }
 
   // Also check the plain releaseId slot (non-ready / null entry).
-  const plain = manifestCache.get(releaseId);
-  if (plain && plain.expiresAt > Date.now()) {
+  const plain = manifestCache.get(cacheKey(releaseId));
+  if (
+    plain &&
+    plain.ownerToken === activeFetcher.token &&
+    plain.expiresAt > Date.now()
+  ) {
     // Non-ready entry still warm — return null without scheduling another fetch.
     markManifestDecision("cached_null");
     return null;
@@ -233,16 +344,21 @@ export async function getReadyManifestForRenderAsync(
     markManifestDecision("no_release_id");
     return null;
   }
+  if (!isValidReleaseId(releaseId)) {
+    markManifestDecision("invalid_release_id");
+    return null;
+  }
   if (!isReleaseAssetManifestEnabled()) {
     markManifestDecision("disabled");
     return null;
   }
-  if (!resolveFetcher(releaseId)) {
+  const activeFetcher = resolveFetcher(releaseId);
+  if (!activeFetcher) {
     markManifestDecision("no_fetcher");
     return null;
   }
 
-  const best = findCachedReadyEntry(releaseId);
+  const best = findCachedReadyEntry(releaseId, activeFetcher.token);
   if (best) {
     markManifestDecision("cached_ready");
     maybeScheduleReadyRefresh(releaseId, best);
@@ -250,8 +366,12 @@ export async function getReadyManifestForRenderAsync(
   }
 
   const now = Date.now();
-  const plain = manifestCache.get(releaseId);
-  if (plain && plain.expiresAt > now) {
+  const plain = manifestCache.get(cacheKey(releaseId));
+  if (
+    plain &&
+    plain.ownerToken === activeFetcher.token &&
+    plain.expiresAt > now
+  ) {
     if (options.refreshCachedNull && (plain.refreshAfter ?? plain.expiresAt) <= now) {
       markManifestDecision("cached_null_refresh");
       return await fetchManifest(releaseId);
@@ -269,39 +389,60 @@ function scheduleFetch(releaseId: string): void {
 }
 
 function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> {
-  const existing = inFlight.get(releaseId);
-  if (existing) {
-    markManifestDecision("await_inflight");
-    return existing.promise;
-  }
   const active = resolveFetcher(releaseId);
   if (!active) {
     markManifestDecision("no_fetcher");
     return Promise.resolve(null);
   }
+  const existing = inFlight.get(releaseId);
+  if (
+    existing &&
+    existing.generation === cacheGeneration &&
+    existing.ownerToken === active.token
+  ) {
+    markManifestDecision("await_inflight");
+    return existing.promise;
+  }
+  if (existing) {
+    inFlight.delete(releaseId);
+    existing.controller.abort(new Error("Release manifest fetch superseded"));
+  }
   const fetchGeneration = cacheGeneration;
   const token = Symbol(releaseId);
+  const controller = new AbortController();
 
   const promise = profilePhase("release_manifest.fetch", async () => {
     try {
-      const result = await active(releaseId);
-      if (fetchGeneration !== cacheGeneration) return null;
+      const result = await invokeManifestFetcher(active, releaseId, controller);
+      if (!isCurrentFetchOwner(releaseId, fetchGeneration, active.token)) return null;
 
       if (!result) {
         markManifestDecision("fetch_missing");
-        cacheNonReadyManifest(releaseId);
+        evictReadyManifests(releaseId, active.token);
+        cacheNonReadyManifest(releaseId, active.token);
         return null;
       }
 
-      const manifestState = normalizeManifestState(result.state);
-      const manifest = isUsableManifestState(result.state) && result.manifest
-        ? parseReleaseAssetManifest(result.manifest)
+      const rawState = readOwnDataProperty(result, "state");
+      const rawManifestVersion = readOwnDataProperty(result, "manifest_version");
+      const state = typeof rawState === "string" && rawState.length <= 64 &&
+          typeof rawManifestVersion === "number" &&
+          Number.isSafeInteger(rawManifestVersion) &&
+          rawManifestVersion >= 0
+        ? rawState
+        : "invalid";
+      const manifestState = normalizeManifestState(state);
+      const readyResponse = isUsableManifestState(state)
+        ? parseReadyReleaseAssetManifestResponse(result, releaseId)
         : null;
+      const manifest = readyResponse?.manifest ?? null;
 
       if (manifest) {
-        markManifestDecision(manifestState === "partial" ? "fetch_partial" : "fetch_ready");
+        markManifestDecision("fetch_ready");
         const key = cacheKey(releaseId, manifest.manifestVersion);
         manifestCache.set(key, {
+          releaseId,
+          ownerToken: active.token,
           manifest,
           expiresAt: Date.now() + READY_TTL_MS,
           refreshAfter: Date.now() + READY_REVALIDATE_MS,
@@ -309,49 +450,118 @@ function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> 
         logger.debug("Cached ready manifest", {
           releaseId,
           manifestVersion: manifest.manifestVersion,
-          state: result.state,
+          state,
           ttlMs: READY_TTL_MS,
           refreshMs: READY_REVALIDATE_MS,
         });
         return manifest;
       } else {
+        if (state === "ready") markManifestDecision("fetch_ready_invalid");
         markManifestDecision(`fetch_${manifestState}`);
         markManifestDecision("fetch_not_ready");
-        cacheNonReadyManifest(releaseId);
+        evictReadyManifests(releaseId, active.token);
+        cacheNonReadyManifest(releaseId, active.token);
         return null;
       }
     } catch (error) {
+      if (!isCurrentFetchOwner(releaseId, fetchGeneration, active.token)) return null;
       logger.debug("Manifest fetch failed", {
         releaseId,
         error: error instanceof Error ? error.message : String(error),
       });
-      if (fetchGeneration !== cacheGeneration) return null;
       markManifestDecision("fetch_failed");
-      cacheNonReadyManifest(releaseId);
+      cacheNonReadyManifest(releaseId, active.token);
       return null;
     } finally {
       const current = inFlight.get(releaseId);
-      if (current?.token === token && current.generation === fetchGeneration) {
+      if (
+        current?.token === token &&
+        current.generation === fetchGeneration &&
+        current.ownerToken === active.token
+      ) {
         inFlight.delete(releaseId);
       }
     }
   });
 
-  inFlight.set(releaseId, { generation: fetchGeneration, token, promise });
+  inFlight.set(releaseId, {
+    generation: fetchGeneration,
+    token,
+    ownerToken: active.token,
+    controller,
+    promise,
+  });
   return promise;
 }
 
+function isCurrentFetchOwner(
+  releaseId: string,
+  generation: symbol,
+  ownerToken: symbol,
+): boolean {
+  return generation === cacheGeneration && resolveFetcher(releaseId)?.token === ownerToken;
+}
+
+async function invokeManifestFetcher(
+  registration: FetcherRegistration,
+  releaseId: string,
+  controller: AbortController,
+): Promise<ReleaseAssetManifestFetchResult | null> {
+  if (controller.signal.aborted) {
+    const reason = controller.signal.reason;
+    throw reason instanceof Error ? reason : new Error("Release manifest fetch aborted");
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let abortListener: (() => void) | undefined;
+  const cancellation = new Promise<never>((_resolve, reject) => {
+    abortListener = () => {
+      const reason = controller.signal.reason;
+      reject(reason instanceof Error ? reason : new Error("Release manifest fetch aborted"));
+    };
+    controller.signal.addEventListener("abort", abortListener, { once: true });
+    timeoutId = setTimeout(() => {
+      controller.abort(
+        new Error(`Release manifest fetch exceeded ${MANIFEST_FETCH_TIMEOUT_MS}ms`),
+      );
+    }, MANIFEST_FETCH_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([
+      Promise.resolve().then(() => registration.fetcher(releaseId, { signal: controller.signal })),
+      cancellation,
+    ]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    if (abortListener) controller.signal.removeEventListener("abort", abortListener);
+  }
+}
+
 function isUsableManifestState(state: string): boolean {
-  return state === "ready" || state === "partial";
+  return state === "ready";
+}
+
+function readOwnDataProperty(value: unknown, key: PropertyKey): unknown {
+  if (typeof value !== "object" || value === null) return undefined;
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && "value" in descriptor ? descriptor.value : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeManifestState(state: string): string {
-  return state.toLowerCase().replace(/[^a-z0-9_]/g, "_").slice(0, 32) || "unknown";
+  return state.slice(0, 64).toLowerCase().replace(/[^a-z0-9_]/g, "_").slice(0, 32) ||
+    "unknown";
 }
 
-function cacheNonReadyManifest(releaseId: string): void {
+function cacheNonReadyManifest(releaseId: string, ownerToken: symbol): void {
   const now = Date.now();
-  manifestCache.set(releaseId, {
+  manifestCache.set(cacheKey(releaseId), {
+    releaseId,
+    ownerToken,
     manifest: null,
     expiresAt: now + NON_READY_TTL_MS,
     refreshAfter: now + NON_READY_REVALIDATE_MS,
@@ -360,8 +570,11 @@ function cacheNonReadyManifest(releaseId: string): void {
 
 /** Clear cached manifest bodies while keeping registered fetchers intact. */
 export function clearCachedReleaseAssetManifests(): void {
-  cacheGeneration++;
+  cacheGeneration = Symbol("release-asset-manifest-cache-generation");
   manifestCache.clear();
+  for (const fetch of inFlight.values()) {
+    fetch.controller.abort(new Error("Release manifest cache cleared"));
+  }
   inFlight.clear();
 }
 
@@ -369,4 +582,5 @@ export function clearCachedReleaseAssetManifests(): void {
 export function clearReleaseAssetManifestCache(): void {
   clearCachedReleaseAssetManifests();
   fetcherRegistry.clear();
+  fallbackFetcher = undefined;
 }

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -457,7 +457,7 @@ function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> 
         return manifest;
       } else {
         if (state === "ready") markManifestDecision("fetch_ready_invalid");
-        markManifestDecision(`fetch_${manifestState}`);
+        else markManifestDecision(`fetch_${manifestState}`);
         markManifestDecision("fetch_not_ready");
         evictReadyManifests(releaseId, active.token);
         cacheNonReadyManifest(releaseId, active.token);

--- a/src/release-assets/manifest-schema.test.ts
+++ b/src/release-assets/manifest-schema.test.ts
@@ -1,22 +1,27 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   getReleaseAssetManifestSchema,
+  parseReadyReleaseAssetManifestResponse,
   parseReleaseAssetManifest,
   type ReleaseAssetManifest,
 } from "./manifest-schema.ts";
+import { RELEASE_ASSET_MANIFEST_SCHEMA_VERSION } from "./constants.ts";
+
+const STYLE_PROFILE_HASH = "c".repeat(64);
+const CSS_PIPELINE_IDENTITY = "test-css-pipeline@1";
 
 function validManifest(): ReleaseAssetManifest {
   return {
-    schemaVersion: 1,
+    schemaVersion: RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
     projectId: "11111111-1111-1111-1111-111111111111",
     releaseId: "22222222-2222-2222-2222-222222222222",
     releaseVersion: 7,
     manifestVersion: 1,
     builderVersion: "0.1.765",
-    sourceContentHash: "abc123",
+    sourceContentHash: "d".repeat(64),
     createdAt: "2026-06-12T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
     modules: {
@@ -31,14 +36,15 @@ function validManifest(): ReleaseAssetManifest {
         contentHash: "b".repeat(64),
         size: 4321,
         contentType: "text/css",
-        styleProfileHash: null,
+        styleProfileHash: STYLE_PROFILE_HASH,
+        cssPipelineIdentity: CSS_PIPELINE_IDENTITY,
       },
     ],
     routes: {
       "/": { modules: ["pages/index.tsx"], css: ["b".repeat(64)] },
     },
+    dependencyMode: "immutable",
     dependencies: {},
-    fallback: { mode: "jit", gaps: [] },
   };
 }
 
@@ -65,9 +71,141 @@ describe("release asset manifest schema", () => {
     assertEquals(parsed, manifest);
   });
 
-  it("rejects a wrong schema version in the hand-rolled validator", () => {
-    const manifest = { ...validManifest(), schemaVersion: 2 };
+  it("requires an explicit dependency capability mode in both validators", () => {
+    const sourceManifest = validManifest();
+    sourceManifest.dependencyMode = "source";
+    assertEquals(getReleaseAssetManifestSchema().safeParse(sourceManifest).success, true);
+    assertEquals(parseReleaseAssetManifest(sourceManifest)?.dependencyMode, "source");
+
+    const missingMode = validManifest() as unknown as Record<string, unknown>;
+    delete missingMode.dependencyMode;
+    assertEquals(getReleaseAssetManifestSchema().safeParse(missingMode).success, false);
+    assertEquals(parseReleaseAssetManifest(missingMode), null);
+
+    const invalidMode = {
+      ...validManifest(),
+      dependencyMode: "fallback",
+    };
+    assertEquals(getReleaseAssetManifestSchema().safeParse(invalidMode).success, false);
+    assertEquals(parseReleaseAssetManifest(invalidMode), null);
+  });
+
+  it("accepts a generation-matched ready response", () => {
+    const manifest = validManifest();
+    const parsed = parseReadyReleaseAssetManifestResponse(
+      {
+        state: "ready",
+        manifest_version: manifest.manifestVersion,
+        manifest,
+      },
+      manifest.releaseId,
+    );
+
+    assertExists(parsed);
+    assertEquals(parsed.state, "ready");
+    assertEquals(parsed.manifest_version, manifest.manifestVersion);
+    assertEquals(parsed.manifest, manifest);
+  });
+
+  it("rejects missing or mismatched response manifest versions", () => {
+    const manifest = validManifest();
+    assertEquals(
+      parseReadyReleaseAssetManifestResponse(
+        { state: "ready", manifest },
+        manifest.releaseId,
+      ),
+      null,
+    );
+    assertEquals(
+      parseReadyReleaseAssetManifestResponse(
+        {
+          state: "ready",
+          manifest_version: manifest.manifestVersion + 1,
+          manifest,
+        },
+        manifest.releaseId,
+      ),
+      null,
+    );
+  });
+
+  it("rejects a manifest body for a different release", () => {
+    const manifest = validManifest();
+    assertEquals(
+      parseReadyReleaseAssetManifestResponse(
+        {
+          state: "ready",
+          manifest_version: manifest.manifestVersion,
+          manifest,
+        },
+        "33333333-3333-3333-3333-333333333333",
+      ),
+      null,
+    );
+  });
+
+  it("rejects accessor-backed response envelopes without executing accessors", () => {
+    let accessorCalls = 0;
+
+    for (const accessorKey of ["state", "manifest_version", "manifest"] as const) {
+      const manifest = validManifest();
+      const envelope: Record<string, unknown> = {
+        state: "ready",
+        manifest_version: manifest.manifestVersion,
+        manifest,
+      };
+      const accessorValue = envelope[accessorKey];
+      Object.defineProperty(envelope, accessorKey, {
+        enumerable: true,
+        get() {
+          accessorCalls++;
+          return accessorValue;
+        },
+      });
+
+      assertEquals(
+        parseReadyReleaseAssetManifestResponse(envelope, manifest.releaseId),
+        null,
+      );
+    }
+
+    assertEquals(accessorCalls, 0);
+  });
+
+  it("rejects a legacy schema version in both validators", () => {
+    const manifest = { ...validManifest(), schemaVersion: 1 };
+    assertEquals(getReleaseAssetManifestSchema().safeParse(manifest).success, false);
     assertEquals(parseReleaseAssetManifest(manifest), null);
+  });
+
+  it("requires canonical CSS profile and pipeline identities", () => {
+    const missingPipeline = validManifest() as unknown as {
+      css: Array<Record<string, unknown>>;
+    };
+    delete missingPipeline.css[0]?.cssPipelineIdentity;
+    assertEquals(getReleaseAssetManifestSchema().safeParse(missingPipeline).success, false);
+    assertEquals(parseReleaseAssetManifest(missingPipeline), null);
+
+    const nullProfile = validManifest() as unknown as {
+      css: Array<Record<string, unknown>>;
+    };
+    nullProfile.css[0]!.styleProfileHash = null;
+    assertEquals(getReleaseAssetManifestSchema().safeParse(nullProfile).success, false);
+    assertEquals(parseReleaseAssetManifest(nullProfile), null);
+
+    const shortProfile = validManifest() as unknown as {
+      css: Array<Record<string, unknown>>;
+    };
+    shortProfile.css[0]!.styleProfileHash = "profile-1";
+    assertEquals(getReleaseAssetManifestSchema().safeParse(shortProfile).success, false);
+    assertEquals(parseReleaseAssetManifest(shortProfile), null);
+
+    const nonCanonicalPipeline = validManifest() as unknown as {
+      css: Array<Record<string, unknown>>;
+    };
+    nonCanonicalPipeline.css[0]!.cssPipelineIdentity = " decomposed\nidentity ";
+    assertEquals(getReleaseAssetManifestSchema().safeParse(nonCanonicalPipeline).success, false);
+    assertEquals(parseReleaseAssetManifest(nonCanonicalPipeline), null);
   });
 
   it("rejects a malformed module entry in the hand-rolled validator", () => {
@@ -75,6 +213,137 @@ describe("release asset manifest schema", () => {
     // deno-lint-ignore no-explicit-any -- intentionally malformed for the test
     (manifest.modules as any)["pages/bad.tsx"] = { contentHash: 123 };
     assertEquals(parseReleaseAssetManifest(manifest), null);
+  });
+
+  it("rejects unsafe asset metadata and manifest versions", () => {
+    const invalidHash = validManifest();
+    invalidHash.modules["pages/index.tsx"]!.contentHash = "../asset";
+    assertEquals(parseReleaseAssetManifest(invalidHash), null);
+
+    const invalidContentType = validManifest();
+    invalidContentType.modules["pages/index.tsx"]!.contentType = "text/css";
+    assertEquals(parseReleaseAssetManifest(invalidContentType), null);
+
+    const invalidSize = validManifest();
+    invalidSize.modules["pages/index.tsx"]!.size = Number.POSITIVE_INFINITY;
+    assertEquals(parseReleaseAssetManifest(invalidSize), null);
+
+    const invalidVersion = validManifest();
+    invalidVersion.manifestVersion = Number.NaN;
+    assertEquals(parseReleaseAssetManifest(invalidVersion), null);
+
+    const invalidBasePath = {
+      ...validManifest(),
+      assetBasePath: "/attacker-controlled",
+    };
+    assertEquals(parseReleaseAssetManifest(invalidBasePath), null);
+  });
+
+  it("rejects dangling route references and non-canonical module keys", () => {
+    const danglingModule = validManifest();
+    danglingModule.routes["/"]!.modules.push("pages/missing.tsx");
+    assertEquals(parseReleaseAssetManifest(danglingModule), null);
+
+    const danglingCss = validManifest();
+    danglingCss.routes["/"]!.css.push("c".repeat(64));
+    assertEquals(parseReleaseAssetManifest(danglingCss), null);
+
+    const traversalKey = validManifest();
+    traversalKey.modules["pages/../secret.tsx"] = traversalKey.modules["pages/index.tsx"]!;
+    assertEquals(parseReleaseAssetManifest(traversalKey), null);
+  });
+
+  it("rejects multiple CSS assets because v2 defines one release-global stylesheet", () => {
+    const manifest = validManifest();
+    manifest.css.push({
+      ...manifest.css[0]!,
+      contentHash: "c".repeat(64),
+    });
+    manifest.routes["/"]!.css.push("c".repeat(64));
+
+    assertEquals(getReleaseAssetManifestSchema().safeParse(manifest).success, false);
+    assertEquals(parseReleaseAssetManifest(manifest), null);
+  });
+
+  it("returns an immutable snapshot instead of aliasing fetched data", () => {
+    const manifest = validManifest();
+    const parsed = parseReleaseAssetManifest(manifest);
+    assertExists(parsed);
+
+    manifest.modules["pages/index.tsx"]!.contentHash = "e".repeat(64);
+    manifest.routes["/"]!.modules.push("pages/other.tsx");
+
+    assertEquals(parsed.modules["pages/index.tsx"]?.contentHash, "a".repeat(64));
+    assertEquals(parsed.routes["/"]?.modules, ["pages/index.tsx"]);
+    assert(Object.isFrozen(parsed));
+    assert(Object.isFrozen(parsed.modules));
+    assert(Object.isFrozen(parsed.modules["pages/index.tsx"]));
+    assert(Object.isFrozen(parsed.routes["/"]?.modules));
+  });
+
+  it("keeps both validators aligned on bounded strict input", () => {
+    const manifest = validManifest();
+    manifest.projectId = "";
+    assertEquals(getReleaseAssetManifestSchema().safeParse(manifest).success, false);
+    assertEquals(parseReleaseAssetManifest(manifest), null);
+
+    const extraField = { ...validManifest(), unexpected: true };
+    assertEquals(getReleaseAssetManifestSchema().safeParse(extraField).success, false);
+    assertEquals(parseReleaseAssetManifest(extraField), null);
+  });
+
+  it("never throws for hostile object input", () => {
+    const hostile = new Proxy({}, {
+      ownKeys() {
+        throw new Error("hostile ownKeys");
+      },
+    });
+    assertEquals(parseReleaseAssetManifest(hostile), null);
+  });
+
+  it("rejects accessor-backed input without executing accessors", () => {
+    let accessorCalls = 0;
+    const topLevelAccessor = validManifest();
+    Object.defineProperty(topLevelAccessor, "schemaVersion", {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return RELEASE_ASSET_MANIFEST_SCHEMA_VERSION;
+      },
+    });
+    assertEquals(parseReleaseAssetManifest(topLevelAccessor), null);
+
+    const dependencyModeAccessor = validManifest();
+    Object.defineProperty(dependencyModeAccessor, "dependencyMode", {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return "immutable";
+      },
+    });
+    assertEquals(parseReleaseAssetManifest(dependencyModeAccessor), null);
+
+    const nestedAccessor = validManifest();
+    Object.defineProperty(nestedAccessor.modules["pages/index.tsx"]!, "contentHash", {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return "a".repeat(64);
+      },
+    });
+    assertEquals(parseReleaseAssetManifest(nestedAccessor), null);
+
+    const arrayAccessor = validManifest();
+    const cssEntry = arrayAccessor.css[0]!;
+    Object.defineProperty(arrayAccessor.css, 0, {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return cssEntry;
+      },
+    });
+    assertEquals(parseReleaseAssetManifest(arrayAccessor), null);
+    assertEquals(accessorCalls, 0);
   });
 
   it("rejects non-object input", () => {

--- a/src/release-assets/manifest-schema.ts
+++ b/src/release-assets/manifest-schema.ts
@@ -1,90 +1,291 @@
 /**
- * Release Asset Manifest — v1 body schema, types, and validator.
+ * Release Asset Manifest — v2 body schema, types, and validator.
  *
- * The manifest body is content-addressed metadata describing the transformed
+ * The manifest body is content-addressed metadata describing transformed
  * browser modules and compiled CSS for a release, plus the per-route closure
  * used to drive preload hints and asset URL rewriting.
  *
- * Validation follows the repo's `defineSchema` convention (zod via the
- * `SchemaValidator` extension contract). The schema is materialized lazily so
- * core modules can import these types without pulling in the validator.
+ * The extension-backed schema is used when the schema contract is available.
+ * Consumption paths also use a dependency-free parser that applies the same
+ * bounds and returns a detached, deeply frozen snapshot.
  *
  * @module release-assets/manifest-schema
  */
 
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema, SchemaValidator } from "veryfront/extensions/schema";
-import { RELEASE_ASSET_MANIFEST_SCHEMA_VERSION } from "./constants.ts";
+import {
+  isCSSPipelineIdentity,
+  isStyleProfileHash,
+} from "#veryfront/utils/css-artifact-identity.ts";
+import {
+  isValidContentHash,
+  RELEASE_ASSET_BASE_PATH,
+  RELEASE_ASSET_CONTENT_TYPES,
+  RELEASE_ASSET_MANIFEST_LIMITS,
+  RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
+  RELEASE_ASSET_MAX_SIZE_BYTES,
+  type ReleaseAssetContentType,
+} from "./constants.ts";
+import { hasControlCharacters } from "./string-validation.ts";
+
+const {
+  identifierLength: MAX_IDENTIFIER_LENGTH,
+  builderVersionLength: MAX_BUILDER_VERSION_LENGTH,
+  manifestKeyLength: MAX_MANIFEST_KEY_LENGTH,
+  styleProfileHashLength: MAX_STYLE_PROFILE_HASH_LENGTH,
+  cssPipelineIdentityLength: MAX_CSS_PIPELINE_IDENTITY_LENGTH,
+  moduleEntries: MAX_MODULE_ENTRIES,
+  dependencyEntries: MAX_DEPENDENCY_ENTRIES,
+  cssEntries: MAX_CSS_ENTRIES,
+  routeEntries: MAX_ROUTE_ENTRIES,
+  routeModules: MAX_ROUTE_MODULES,
+  routeCssEntries: MAX_ROUTE_CSS_ENTRIES,
+  totalRouteReferences: MAX_TOTAL_ROUTE_REFERENCES,
+} = RELEASE_ASSET_MANIFEST_LIMITS;
+const MODULE_EXTENSION_PATTERN = /\.(?:tsx?|jsx?|mdx)$/;
+const CANONICAL_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const RELEASE_ASSET_DEPENDENCY_MODES = ["source", "immutable"] as const;
+
+const MANIFEST_KEYS = new Set([
+  "schemaVersion",
+  "projectId",
+  "releaseId",
+  "releaseVersion",
+  "manifestVersion",
+  "builderVersion",
+  "sourceContentHash",
+  "createdAt",
+  "assetBasePath",
+  "modules",
+  "css",
+  "routes",
+  "dependencyMode",
+  "dependencies",
+]);
+const ASSET_ENTRY_KEYS = new Set(["contentHash", "size", "contentType"]);
+const CSS_ENTRY_KEYS = new Set([
+  "contentHash",
+  "size",
+  "contentType",
+  "styleProfileHash",
+  "cssPipelineIdentity",
+]);
+const ROUTE_ENTRY_KEYS = new Set(["modules", "css"]);
+
+function isSafeBoundedText(value: unknown, maxLength: number): value is string {
+  return typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= maxLength &&
+    value.trim() === value &&
+    !hasControlCharacters(value);
+}
+
+function isCanonicalModuleKey(value: string): boolean {
+  if (
+    !isSafeBoundedText(value, MAX_MANIFEST_KEY_LENGTH) ||
+    value.startsWith("/") ||
+    value.endsWith("/") ||
+    value.includes("\\") ||
+    value.includes("?") ||
+    value.includes("#") ||
+    !MODULE_EXTENSION_PATTERN.test(value)
+  ) {
+    return false;
+  }
+
+  const parts = value.split("/");
+  return parts.every((part) => part.length > 0 && part !== "." && part !== "..");
+}
+
+function isSafeDependencyKey(value: string): boolean {
+  return isSafeBoundedText(value, MAX_MANIFEST_KEY_LENGTH);
+}
+
+function isCanonicalRoutePath(value: string): boolean {
+  if (
+    !isSafeBoundedText(value, MAX_MANIFEST_KEY_LENGTH) ||
+    !value.startsWith("/") ||
+    value.includes("\\") ||
+    value.includes("?") ||
+    value.includes("#") ||
+    (value.length > 1 && value.endsWith("/"))
+  ) {
+    return false;
+  }
+
+  if (value === "/") return true;
+  const parts = value.slice(1).split("/");
+  return parts.every((part) => part.length > 0 && part !== "." && part !== "..");
+}
+
+function isCanonicalTimestamp(value: string): boolean {
+  if (
+    value.length > 64 ||
+    !CANONICAL_TIMESTAMP_PATTERN.test(value) ||
+    !Number.isFinite(Date.parse(value))
+  ) {
+    return false;
+  }
+
+  try {
+    const canonical = new Date(value).toISOString();
+    return canonical === value || canonical.replace(".000Z", "Z") === value;
+  } catch {
+    return false;
+  }
+}
+
+function isSafeIntegerInRange(value: unknown, maximum: number): value is number {
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= maximum;
+}
+
+function hasUniqueStrings(values: readonly string[]): boolean {
+  return new Set(values).size === values.length;
+}
+
+function recordEntryCountWithin(value: object, limit: number): boolean {
+  return Object.keys(value).length <= limit;
+}
 
 // ---------------------------------------------------------------------------
-// Schema fragments
+// Extension-backed schema
 // ---------------------------------------------------------------------------
 
-const assetEntryShape = (v: SchemaValidator) => ({
-  contentHash: v.string(),
-  size: v.number(),
-  contentType: v.string(),
-});
+const boundedIdentifierSchema = (v: SchemaValidator) =>
+  v.string()
+    .min(1)
+    .max(MAX_IDENTIFIER_LENGTH)
+    .refine((value) => isSafeBoundedText(value, MAX_IDENTIFIER_LENGTH));
 
-const cssEntryShape = (v: SchemaValidator) => ({
-  contentHash: v.string(),
-  size: v.number(),
-  contentType: v.string(),
-  styleProfileHash: v.string().nullable(),
-});
+const assetEntrySchema = (
+  v: SchemaValidator,
+  contentType: ReleaseAssetContentType,
+) =>
+  v.object({
+    contentHash: v.string().regex(/^[0-9a-f]{64}$/),
+    size: v.number().int().nonnegative().max(RELEASE_ASSET_MAX_SIZE_BYTES),
+    contentType: v.literal(contentType),
+  }).strict();
 
-const routeEntryShape = (v: SchemaValidator) => ({
-  modules: v.array(v.string()),
-  css: v.array(v.string()),
-});
+const routeEntrySchema = (v: SchemaValidator) =>
+  v.object({
+    modules: v.array(
+      v.string()
+        .min(1)
+        .max(MAX_MANIFEST_KEY_LENGTH)
+        .refine(isCanonicalModuleKey),
+    )
+      .max(MAX_ROUTE_MODULES)
+      .refine(hasUniqueStrings),
+    css: v.array(v.string().regex(/^[0-9a-f]{64}$/))
+      .max(MAX_ROUTE_CSS_ENTRIES)
+      .refine(hasUniqueStrings),
+  }).strict();
 
-const fallbackShape = (v: SchemaValidator) => ({
-  mode: v.literal("jit"),
-  gaps: v.array(v.string()),
-});
+interface ManifestReferenceShape {
+  modules: Record<string, unknown>;
+  css: Array<{ contentHash: string }>;
+  routes: Record<string, { modules: string[]; css: string[] }>;
+}
 
-// ---------------------------------------------------------------------------
-// Exported schema getter
-// ---------------------------------------------------------------------------
+function hasValidManifestReferences(manifest: ManifestReferenceShape): boolean {
+  const cssHashes = new Set(manifest.css.map((entry) => entry.contentHash));
+  let referenceCount = 0;
 
+  for (const route of Object.values(manifest.routes)) {
+    referenceCount += route.modules.length + route.css.length;
+    if (referenceCount > MAX_TOTAL_ROUTE_REFERENCES) return false;
+    if (route.modules.some((modulePath) => !Object.hasOwn(manifest.modules, modulePath))) {
+      return false;
+    }
+    if (route.css.some((contentHash) => !cssHashes.has(contentHash))) return false;
+  }
+
+  return true;
+}
+
+/** Extension-backed validator for the strict release asset manifest v2 body. */
 export const getReleaseAssetManifestSchema = defineSchema((v) =>
   v.object({
     schemaVersion: v.literal(RELEASE_ASSET_MANIFEST_SCHEMA_VERSION),
-    projectId: v.string(),
-    releaseId: v.string(),
-    releaseVersion: v.number(),
-    manifestVersion: v.number(),
-    builderVersion: v.string(),
-    sourceContentHash: v.string(),
-    createdAt: v.string(),
-    assetBasePath: v.string(),
-    modules: v.record(v.string(), v.object(assetEntryShape(v))),
-    css: v.array(v.object(cssEntryShape(v))),
-    routes: v.record(v.string(), v.object(routeEntryShape(v))),
-    // `dependencies` records framework dependency artifacts for future S7
-    // vendoring. HTML keeps import-map entries on module URLs until those
-    // artifacts include their own rewritten import closures.
-    dependencies: v.record(v.string(), v.object(assetEntryShape(v))),
-    fallback: v.object(fallbackShape(v)),
-  })
+    projectId: boundedIdentifierSchema(v),
+    releaseId: boundedIdentifierSchema(v),
+    releaseVersion: v.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    manifestVersion: v.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    builderVersion: v.string()
+      .min(1)
+      .max(MAX_BUILDER_VERSION_LENGTH)
+      .refine((value) => isSafeBoundedText(value, MAX_BUILDER_VERSION_LENGTH)),
+    sourceContentHash: v.string().regex(/^[0-9a-f]{64}$/),
+    createdAt: v.string().max(64).refine(isCanonicalTimestamp),
+    assetBasePath: v.literal(RELEASE_ASSET_BASE_PATH),
+    modules: v.record(
+      v.string().min(1).max(MAX_MANIFEST_KEY_LENGTH).refine(isCanonicalModuleKey),
+      assetEntrySchema(v, RELEASE_ASSET_CONTENT_TYPES.js),
+    ).refine((value) => recordEntryCountWithin(value, MAX_MODULE_ENTRIES)),
+    css: v.array(
+      v.object({
+        contentHash: v.string().regex(/^[0-9a-f]{64}$/),
+        size: v.number().int().nonnegative().max(RELEASE_ASSET_MAX_SIZE_BYTES),
+        contentType: v.literal(RELEASE_ASSET_CONTENT_TYPES.css),
+        styleProfileHash: v.string()
+          .min(MAX_STYLE_PROFILE_HASH_LENGTH)
+          .max(MAX_STYLE_PROFILE_HASH_LENGTH)
+          .refine(isStyleProfileHash),
+        cssPipelineIdentity: v.string()
+          .min(1)
+          .max(MAX_CSS_PIPELINE_IDENTITY_LENGTH)
+          .refine(isCSSPipelineIdentity),
+      }).strict(),
+    ).max(MAX_CSS_ENTRIES),
+    routes: v.record(
+      v.string().min(1).max(MAX_MANIFEST_KEY_LENGTH).refine(isCanonicalRoutePath),
+      routeEntrySchema(v),
+    ).refine((value) => recordEntryCountWithin(value, MAX_ROUTE_ENTRIES)),
+    dependencyMode: v.enum(RELEASE_ASSET_DEPENDENCY_MODES),
+    dependencies: v.record(
+      v.string().min(1).max(MAX_MANIFEST_KEY_LENGTH).refine(isSafeDependencyKey),
+      assetEntrySchema(v, RELEASE_ASSET_CONTENT_TYPES.js),
+    ).refine((value) => recordEntryCountWithin(value, MAX_DEPENDENCY_ENTRIES)),
+  }).strict().refine(hasValidManifestReferences, "Manifest route references must resolve")
 );
 
 // ---------------------------------------------------------------------------
-// Inferred types
+// Inferred public types
 // ---------------------------------------------------------------------------
 
+/** Validated, immutable release asset manifest v2 body. */
 export type ReleaseAssetManifest = InferSchema<
   ReturnType<typeof getReleaseAssetManifestSchema>
 >;
+/** Content-addressed JavaScript module entry. */
 export type ReleaseAssetEntry = ReleaseAssetManifest["modules"][string];
+/** Content-addressed CSS entry. */
 export type ReleaseAssetCssEntry = ReleaseAssetManifest["css"][number];
+/** Per-route module and CSS closure. */
 export type ReleaseAssetRouteEntry = ReleaseAssetManifest["routes"][string];
+/** Capability represented by entries in the manifest dependency map. */
+export type ReleaseAssetDependencyMode = ReleaseAssetManifest["dependencyMode"];
+/** Manifest whose dependency entries name uploaded content-addressed assets. */
+export type ImmutableReleaseAssetManifest = ReleaseAssetManifest & {
+  readonly dependencyMode: "immutable";
+};
+
+/** True only when manifest dependency entries are safe immutable rewrite targets. */
+export function hasImmutableReleaseAssetDependencies(
+  manifest: ReleaseAssetManifest | null | undefined,
+): manifest is ImmutableReleaseAssetManifest {
+  return manifest?.dependencyMode === "immutable";
+}
 
 /** Manifest lifecycle states (DB-owned; mirrored here for runtime checks). */
 export type ReleaseAssetManifestState =
   | "queued"
   | "building"
-  | "partial"
   | "ready"
   | "failed"
   | "superseded";
@@ -96,81 +297,307 @@ export interface ReleaseAssetManifestResponse {
   manifest: ReleaseAssetManifest | null;
 }
 
+/** Strict ready response with a generation-matched validated manifest body. */
+export interface ReadyReleaseAssetManifestResponse {
+  readonly state: "ready";
+  readonly manifest_version: number;
+  readonly manifest: ReleaseAssetManifest;
+}
+
+// ---------------------------------------------------------------------------
+// Dependency-free consumption parser
+// ---------------------------------------------------------------------------
+
 /**
- * Hand-rolled structural validator.
+ * Parse an untrusted manifest without requiring a registered schema extension.
  *
- * Used on consumption paths (HTML/proxy) where the `SchemaValidator` extension
- * may not be registered. Returns the typed manifest on success, or null. Does
- * not throw — consumption is always best-effort with a JIT fallback.
+ * The parser is non-throwing, applies explicit work and memory bounds, validates
+ * route references, and returns a detached deeply frozen snapshot.
  */
 export function parseReleaseAssetManifest(value: unknown): ReleaseAssetManifest | null {
-  if (!isRecord(value)) return null;
-  if (value.schemaVersion !== RELEASE_ASSET_MANIFEST_SCHEMA_VERSION) return null;
+  try {
+    return parseReleaseAssetManifestImpl(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse an untrusted ready response without executing accessors.
+ *
+ * The response envelope and manifest body must identify the same release and
+ * manifest generation. Extra envelope fields are ignored so the control plane
+ * can add unrelated metadata without weakening these identity checks.
+ */
+export function parseReadyReleaseAssetManifestResponse(
+  value: unknown,
+  expectedReleaseId: string,
+): ReadyReleaseAssetManifestResponse | null {
+  try {
+    if (!isSafeBoundedText(expectedReleaseId, MAX_IDENTIFIER_LENGTH)) return null;
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+
+    const state = readOwnDataProperty(value, "state");
+    const manifestVersion = readOwnDataProperty(value, "manifest_version");
+    const manifest = parseReleaseAssetManifest(readOwnDataProperty(value, "manifest"));
+    if (
+      state !== "ready" ||
+      !isSafeIntegerInRange(manifestVersion, Number.MAX_SAFE_INTEGER) ||
+      !manifest ||
+      manifest.releaseId !== expectedReleaseId ||
+      manifest.manifestVersion !== manifestVersion
+    ) {
+      return null;
+    }
+
+    return Object.freeze({
+      state: "ready",
+      manifest_version: manifestVersion,
+      manifest,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function parseReleaseAssetManifestImpl(value: unknown): ReleaseAssetManifest | null {
+  const candidate = snapshotExactDataRecord(value, MANIFEST_KEYS);
+  if (!candidate) return null;
+  if (candidate.schemaVersion !== RELEASE_ASSET_MANIFEST_SCHEMA_VERSION) return null;
+  if (!isSafeBoundedText(candidate.projectId, MAX_IDENTIFIER_LENGTH)) return null;
+  if (!isSafeBoundedText(candidate.releaseId, MAX_IDENTIFIER_LENGTH)) return null;
+  if (!isSafeIntegerInRange(candidate.releaseVersion, Number.MAX_SAFE_INTEGER)) return null;
+  if (!isSafeIntegerInRange(candidate.manifestVersion, Number.MAX_SAFE_INTEGER)) return null;
+  if (!isSafeBoundedText(candidate.builderVersion, MAX_BUILDER_VERSION_LENGTH)) return null;
   if (
-    typeof value.projectId !== "string" ||
-    typeof value.releaseId !== "string" ||
-    typeof value.releaseVersion !== "number" ||
-    typeof value.manifestVersion !== "number" ||
-    typeof value.builderVersion !== "string" ||
-    typeof value.sourceContentHash !== "string" ||
-    typeof value.createdAt !== "string" ||
-    typeof value.assetBasePath !== "string"
+    typeof candidate.sourceContentHash !== "string" ||
+    !isValidContentHash(candidate.sourceContentHash)
   ) {
     return null;
   }
+  if (
+    typeof candidate.createdAt !== "string" ||
+    !isCanonicalTimestamp(candidate.createdAt)
+  ) return null;
+  if (candidate.assetBasePath !== RELEASE_ASSET_BASE_PATH) return null;
+  if (
+    candidate.dependencyMode !== "source" &&
+    candidate.dependencyMode !== "immutable"
+  ) return null;
 
-  if (!isAssetEntryRecord(value.modules)) return null;
-  if (!isAssetEntryRecord(value.dependencies)) return null;
-  if (!Array.isArray(value.css) || !value.css.every(isCssEntry)) return null;
-  if (!isRouteRecord(value.routes)) return null;
-  if (!isFallback(value.fallback)) return null;
-
-  return value as unknown as ReleaseAssetManifest;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isAssetEntry(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    typeof value.contentHash === "string" &&
-    typeof value.size === "number" &&
-    typeof value.contentType === "string"
+  const modules = snapshotAssetRecord(
+    candidate.modules,
+    MAX_MODULE_ENTRIES,
+    isCanonicalModuleKey,
+    RELEASE_ASSET_CONTENT_TYPES.js,
   );
-}
+  if (!modules) return null;
 
-function isAssetEntryRecord(value: unknown): boolean {
-  return isRecord(value) && Object.values(value).every(isAssetEntry);
-}
-
-function isCssEntry(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    typeof value.contentHash === "string" &&
-    typeof value.size === "number" &&
-    typeof value.contentType === "string" &&
-    (value.styleProfileHash === null || typeof value.styleProfileHash === "string")
+  const dependencies = snapshotAssetRecord(
+    candidate.dependencies,
+    MAX_DEPENDENCY_ENTRIES,
+    isSafeDependencyKey,
+    RELEASE_ASSET_CONTENT_TYPES.js,
   );
+  if (!dependencies) return null;
+
+  const css = snapshotCssEntries(candidate.css);
+  if (!css) return null;
+
+  const routes = snapshotRoutes(candidate.routes);
+  if (!routes) return null;
+
+  const manifest = Object.freeze({
+    schemaVersion: RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
+    projectId: candidate.projectId,
+    releaseId: candidate.releaseId,
+    releaseVersion: candidate.releaseVersion,
+    manifestVersion: candidate.manifestVersion,
+    builderVersion: candidate.builderVersion,
+    sourceContentHash: candidate.sourceContentHash,
+    createdAt: candidate.createdAt,
+    assetBasePath: RELEASE_ASSET_BASE_PATH,
+    modules,
+    css,
+    routes,
+    dependencyMode: candidate.dependencyMode,
+    dependencies,
+  }) satisfies ReleaseAssetManifest;
+
+  return hasValidManifestReferences(manifest) ? manifest : null;
 }
 
-function isRouteRecord(value: unknown): boolean {
-  if (!isRecord(value)) return false;
-  return Object.values(value).every((entry) =>
-    isRecord(entry) &&
-    Array.isArray(entry.modules) &&
-    entry.modules.every((m) => typeof m === "string") &&
-    Array.isArray(entry.css) &&
-    entry.css.every((c) => typeof c === "string")
-  );
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
-function isFallback(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    value.mode === "jit" &&
-    Array.isArray(value.gaps) &&
-    value.gaps.every((g) => typeof g === "string")
-  );
+function hasExactKeys(value: Record<string, unknown>, expected: ReadonlySet<string>): boolean {
+  const keys = Object.keys(value);
+  return keys.length === expected.size && keys.every((key) => expected.has(key));
+}
+
+function readOwnDataProperty(value: object, key: PropertyKey): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  return descriptor && "value" in descriptor ? descriptor.value : undefined;
+}
+
+function snapshotExactDataRecord(
+  value: unknown,
+  expected: ReadonlySet<string>,
+): Record<string, unknown> | null {
+  if (!isPlainRecord(value) || !hasExactKeys(value, expected)) return null;
+
+  const snapshot: Record<string, unknown> = Object.create(null);
+  for (const key of expected) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !("value" in descriptor) || !descriptor.enumerable) return null;
+    snapshot[key] = descriptor.value;
+  }
+  return snapshot;
+}
+
+function boundedArrayLength(value: unknown, maximumLength: number): number | null {
+  if (!Array.isArray(value)) return null;
+  const length = readOwnDataProperty(value, "length");
+  return isSafeIntegerInRange(length, maximumLength) ? length : null;
+}
+
+function snapshotAssetRecord(
+  value: unknown,
+  maxEntries: number,
+  validateKey: (key: string) => boolean,
+  contentType: ReleaseAssetContentType,
+): Record<string, ReleaseAssetEntry> | null {
+  if (!isPlainRecord(value)) return null;
+  const keys = Object.keys(value);
+  if (keys.length > maxEntries) return null;
+
+  const snapshot: Record<string, ReleaseAssetEntry> = Object.create(null);
+  for (const key of keys) {
+    if (!validateKey(key)) return null;
+    const entry = snapshotAssetEntry(readOwnDataProperty(value, key), contentType);
+    if (!entry) return null;
+    Object.defineProperty(snapshot, key, {
+      value: entry,
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    });
+  }
+
+  return Object.freeze(snapshot);
+}
+
+function snapshotAssetEntry(
+  value: unknown,
+  contentType: ReleaseAssetContentType,
+): ReleaseAssetEntry | null {
+  const candidate = snapshotExactDataRecord(value, ASSET_ENTRY_KEYS);
+  if (!candidate) return null;
+  if (
+    typeof candidate.contentHash !== "string" ||
+    !isValidContentHash(candidate.contentHash)
+  ) return null;
+  if (!isSafeIntegerInRange(candidate.size, RELEASE_ASSET_MAX_SIZE_BYTES)) return null;
+  if (candidate.contentType !== contentType) return null;
+
+  return Object.freeze({
+    contentHash: candidate.contentHash,
+    size: candidate.size,
+    contentType,
+  });
+}
+
+function snapshotCssEntries(value: unknown): ReleaseAssetCssEntry[] | null {
+  const length = boundedArrayLength(value, MAX_CSS_ENTRIES);
+  if (length === null) return null;
+  const entries: ReleaseAssetCssEntry[] = [];
+
+  for (let index = 0; index < length; index++) {
+    const candidate = snapshotExactDataRecord(
+      readOwnDataProperty(value as unknown[], index),
+      CSS_ENTRY_KEYS,
+    );
+    if (!candidate) return null;
+    if (
+      typeof candidate.contentHash !== "string" ||
+      !isValidContentHash(candidate.contentHash) ||
+      !isSafeIntegerInRange(candidate.size, RELEASE_ASSET_MAX_SIZE_BYTES) ||
+      candidate.contentType !== RELEASE_ASSET_CONTENT_TYPES.css ||
+      !isStyleProfileHash(candidate.styleProfileHash) ||
+      !isCSSPipelineIdentity(candidate.cssPipelineIdentity)
+    ) {
+      return null;
+    }
+
+    entries.push(Object.freeze({
+      contentHash: candidate.contentHash,
+      size: candidate.size,
+      contentType: RELEASE_ASSET_CONTENT_TYPES.css,
+      styleProfileHash: candidate.styleProfileHash,
+      cssPipelineIdentity: candidate.cssPipelineIdentity,
+    }));
+  }
+
+  return Object.freeze(entries) as ReleaseAssetCssEntry[];
+}
+
+function snapshotRoutes(value: unknown): Record<string, ReleaseAssetRouteEntry> | null {
+  if (!isPlainRecord(value)) return null;
+  const keys = Object.keys(value);
+  if (keys.length > MAX_ROUTE_ENTRIES) return null;
+
+  const routes: Record<string, ReleaseAssetRouteEntry> = Object.create(null);
+  for (const key of keys) {
+    if (!isCanonicalRoutePath(key)) return null;
+    const candidate = snapshotExactDataRecord(
+      readOwnDataProperty(value, key),
+      ROUTE_ENTRY_KEYS,
+    );
+    if (!candidate) return null;
+
+    const modules = snapshotStringArray(
+      candidate.modules,
+      MAX_ROUTE_MODULES,
+      isCanonicalModuleKey,
+    );
+    const css = snapshotStringArray(
+      candidate.css,
+      MAX_ROUTE_CSS_ENTRIES,
+      isValidContentHash,
+    );
+    if (!modules || !css) return null;
+
+    Object.defineProperty(routes, key, {
+      value: Object.freeze({ modules, css }),
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    });
+  }
+
+  return Object.freeze(routes);
+}
+
+function snapshotStringArray(
+  value: unknown,
+  maximumLength: number,
+  validate: (item: string) => boolean,
+  requireUnique = true,
+): string[] | null {
+  const length = boundedArrayLength(value, maximumLength);
+  if (length === null) return null;
+  const result: string[] = [];
+  const seen = requireUnique ? new Set<string>() : null;
+
+  for (let index = 0; index < length; index++) {
+    const item = readOwnDataProperty(value as unknown[], index);
+    if (typeof item !== "string" || !validate(item) || seen?.has(item)) return null;
+    seen?.add(item);
+    result.push(item);
+  }
+
+  return Object.freeze(result) as string[];
 }

--- a/src/release-assets/module-consumption.test.ts
+++ b/src/release-assets/module-consumption.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./constants.ts";
 import {
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
+  registerManifestFetcherForRelease,
 } from "./manifest-cache.ts";
 import {
   hasReleaseDependencyImportSpecifiers,
@@ -56,7 +56,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("release-id", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -67,8 +67,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
             contentType: "text/javascript",
           },
         }),
-      })
-    );
+      }));
 
     const result = await rewriteReleaseDependencyImportsForModule(
       'import React from "file:///tmp/veryfront-http-bundle/http-123abc.mjs";\nexport default React;',
@@ -88,7 +87,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("release-id", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -99,8 +98,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
             contentType: "text/javascript",
           },
         }),
-      })
-    );
+      }));
 
     const result = await rewriteReleaseDependencyImportsForModule(
       'import React from "https://esm.sh/file:///tmp/veryfront-http-bundle/http-123abc.mjs?external=react&target=es2022";',
@@ -120,7 +118,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const sourceUrl = "https://esm.sh/react@19.2.4";
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("release-id", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -131,8 +129,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
             contentType: "text/javascript",
           },
         }),
-      })
-    );
+      }));
     const code = 'import React from "file:///unowned/veryfront-http-bundle/http-123abc.mjs";';
     let reads = 0;
 
@@ -152,7 +149,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
   it("rewrites direct HTTP imports using normalized manifest dependency keys", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("release-id", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -163,8 +160,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
             contentType: "text/javascript",
           },
         }),
-      })
-    );
+      }));
 
     const result = await rewriteReleaseDependencyImportsForModule(
       'import pkg from "https://esm.sh/pkg@1?z=2&a=1";',
@@ -183,7 +179,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const fragmentA = "https://cdn.example.com/pkg.js?z=2&a=1#a";
     const fragmentB = "https://cdn.example.com/pkg.js?z=2&a=1#b";
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("release-id", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -199,8 +195,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
             contentType: "text/javascript",
           },
         }),
-      })
-    );
+      }));
 
     const result = await rewriteReleaseDependencyImportsForModule(
       `import a from "${fragmentA}";\nimport b from "${fragmentB}";`,
@@ -223,7 +218,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const fragmentless = "https://cdn.example.com/pkg.js";
     const code = `import value from "${fragmentless}#a";`;
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("release-id", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -234,8 +229,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
             contentType: "text/javascript",
           },
         }),
-      })
-    );
+      }));
 
     const result = await rewriteReleaseDependencyImportsForModule(code, {
       releaseId: "release-id",
@@ -250,7 +244,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const sourceUrl = "https://esm.sh/react@19.2.4?target=es2022";
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("release-id", () =>
       Promise.resolve({
         state: "ready",
         manifest_version: 1,
@@ -261,8 +255,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
             contentType: "text/javascript",
           },
         }, "source"),
-      })
-    );
+      }));
 
     const result = await rewriteReleaseDependencyImportsForModule(
       `import React from "file:///tmp/veryfront-http-bundle/http-123abc.mjs";`,
@@ -283,13 +276,12 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("release-id", () =>
       Promise.resolve({
         state: "building",
         manifest_version: 1,
         manifest: null,
-      })
-    );
+      }));
 
     const result = await rewriteReleaseDependencyImportsForModule(
       'import React from "file:///tmp/veryfront-http-bundle/http-123abc.mjs";\nexport default React;',
@@ -308,13 +300,12 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
   it("preserves the owned bundle import for unsafe embedded source markers", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
+    registerManifestFetcherForRelease("release-id", () =>
       Promise.resolve({
         state: "building",
         manifest_version: 1,
         manifest: null,
-      })
-    );
+      }));
     const bundleUrl = "file:///tmp/veryfront-http-bundle/http-123abc.mjs";
     const code = `import value from "${bundleUrl}";`;
     const unsafeMarkers = [

--- a/src/release-assets/module-consumption.test.ts
+++ b/src/release-assets/module-consumption.test.ts
@@ -6,20 +6,27 @@ import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import {
   RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG,
   RELEASE_ASSET_MANIFEST_ENV_FLAG,
+  RELEASE_ASSET_MANIFEST_LIMITS,
   RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
 } from "./constants.ts";
 import {
   clearReleaseAssetManifestCache,
   configureReleaseAssetManifestFetcher,
 } from "./manifest-cache.ts";
-import { rewriteReleaseDependencyImportsForModule } from "./module-consumption.ts";
+import {
+  hasReleaseDependencyImportSpecifiers,
+  rewriteReleaseDependencyImportsForModule,
+} from "./module-consumption.ts";
 import type { ReleaseAssetManifest } from "./manifest-schema.ts";
-import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
+import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache-helpers.ts";
 
 const HASH_A = "a".repeat(64);
 const HASH_B = "b".repeat(64);
 
-function manifest(dependencies: ReleaseAssetManifest["dependencies"]): ReleaseAssetManifest {
+function manifest(
+  dependencies: ReleaseAssetManifest["dependencies"],
+  dependencyMode: ReleaseAssetManifest["dependencyMode"] = "immutable",
+): ReleaseAssetManifest {
   return {
     schemaVersion: RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
     projectId: "project-id",
@@ -27,14 +34,14 @@ function manifest(dependencies: ReleaseAssetManifest["dependencies"]): ReleaseAs
     releaseVersion: 1,
     manifestVersion: 1,
     builderVersion: "test",
-    sourceContentHash: "source",
+    sourceContentHash: "c".repeat(64),
     createdAt: new Date(0).toISOString(),
     assetBasePath: "/_vf/assets",
     modules: {},
     css: [],
     routes: {},
+    dependencyMode,
     dependencies,
-    fallback: { mode: "jit", gaps: [] },
   };
 }
 
@@ -52,6 +59,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
         state: "ready",
+        manifest_version: 1,
         manifest: manifest({
           [sourceUrl]: {
             contentHash: HASH_A,
@@ -66,6 +74,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
       'import React from "file:///tmp/veryfront-http-bundle/http-123abc.mjs";\nexport default React;',
       {
         releaseId: "release-id",
+        dependencyCacheRoot: "/tmp/veryfront-http-bundle",
         readDependencySource: () =>
           Promise.resolve(`/*! @vf-source: ${sourceUrl} */\nexport default {};`),
       },
@@ -82,6 +91,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
         state: "ready",
+        manifest_version: 1,
         manifest: manifest({
           [sourceUrl]: {
             contentHash: HASH_A,
@@ -96,6 +106,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
       'import React from "https://esm.sh/file:///tmp/veryfront-http-bundle/http-123abc.mjs?external=react&target=es2022";',
       {
         releaseId: "release-id",
+        dependencyCacheRoot: "/tmp/veryfront-http-bundle",
         readDependencySource: () =>
           Promise.resolve(`/*! @vf-source: ${sourceUrl} */\nexport default {};`),
       },
@@ -105,12 +116,46 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
     assertEquals(result.includes("https://esm.sh/file://"), false);
   });
 
+  it("does not read matching bundle-shaped paths outside the owned cache root", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    const sourceUrl = "https://esm.sh/react@19.2.4";
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "ready",
+        manifest_version: 1,
+        manifest: manifest({
+          [sourceUrl]: {
+            contentHash: HASH_A,
+            size: 100,
+            contentType: "text/javascript",
+          },
+        }),
+      })
+    );
+    const code = 'import React from "file:///unowned/veryfront-http-bundle/http-123abc.mjs";';
+    let reads = 0;
+
+    const result = await rewriteReleaseDependencyImportsForModule(code, {
+      releaseId: "release-id",
+      dependencyCacheRoot: "/owned/veryfront-http-bundle",
+      readDependencySource: () => {
+        reads++;
+        return Promise.resolve(`/*! @vf-source: ${sourceUrl} */`);
+      },
+    });
+
+    assertEquals(result, code);
+    assertEquals(reads, 0);
+  });
+
   it("rewrites direct HTTP imports using normalized manifest dependency keys", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
         state: "ready",
+        manifest_version: 1,
         manifest: manifest({
           [normalizeHttpUrl("https://esm.sh/pkg@1?z=2&a=1")]: {
             contentHash: HASH_B,
@@ -125,11 +170,172 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
       'import pkg from "https://esm.sh/pkg@1?z=2&a=1";',
       {
         releaseId: "release-id",
+        dependencyCacheRoot: "/tmp/veryfront-http-bundle",
         readDependencySource: () => Promise.reject(new Error("unused")),
       },
     );
 
     assertEquals(result, `import pkg from "/_vf/assets/${HASH_B}.js";`);
+  });
+
+  it("preserves distinct HTTP fragment identities in immutable asset URLs", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    const fragmentA = "https://cdn.example.com/pkg.js?z=2&a=1#a";
+    const fragmentB = "https://cdn.example.com/pkg.js?z=2&a=1#b";
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "ready",
+        manifest_version: 1,
+        manifest: manifest({
+          [normalizeHttpUrl(fragmentA)]: {
+            contentHash: HASH_A,
+            size: 100,
+            contentType: "text/javascript",
+          },
+          [normalizeHttpUrl(fragmentB)]: {
+            contentHash: HASH_B,
+            size: 100,
+            contentType: "text/javascript",
+          },
+        }),
+      })
+    );
+
+    const result = await rewriteReleaseDependencyImportsForModule(
+      `import a from "${fragmentA}";\nimport b from "${fragmentB}";`,
+      {
+        releaseId: "release-id",
+        dependencyCacheRoot: "/tmp/veryfront-http-bundle",
+        readDependencySource: () => Promise.reject(new Error("unused")),
+      },
+    );
+
+    assertEquals(
+      result,
+      `import a from "/_vf/assets/${HASH_A}.js#a";\n` +
+        `import b from "/_vf/assets/${HASH_B}.js#b";`,
+    );
+  });
+
+  it("does not fall back from a fragment variant to a fragmentless dependency", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    const fragmentless = "https://cdn.example.com/pkg.js";
+    const code = `import value from "${fragmentless}#a";`;
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "ready",
+        manifest_version: 1,
+        manifest: manifest({
+          [fragmentless]: {
+            contentHash: HASH_A,
+            size: 100,
+            contentType: "text/javascript",
+          },
+        }),
+      })
+    );
+
+    const result = await rewriteReleaseDependencyImportsForModule(code, {
+      releaseId: "release-id",
+      dependencyCacheRoot: "/tmp/veryfront-http-bundle",
+      readDependencySource: () => Promise.reject(new Error("unused")),
+    });
+
+    assertEquals(result, code);
+  });
+
+  it("does not use source-mode dependency entries as immutable assets", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    const sourceUrl = "https://esm.sh/react@19.2.4?target=es2022";
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "ready",
+        manifest_version: 1,
+        manifest: manifest({
+          [sourceUrl]: {
+            contentHash: HASH_A,
+            size: 100,
+            contentType: "text/javascript",
+          },
+        }, "source"),
+      })
+    );
+
+    const result = await rewriteReleaseDependencyImportsForModule(
+      `import React from "file:///tmp/veryfront-http-bundle/http-123abc.mjs";`,
+      {
+        releaseId: "release-id",
+        dependencyCacheRoot: "/tmp/veryfront-http-bundle",
+        readDependencySource: () =>
+          Promise.resolve(`/*! @vf-source: ${sourceUrl} */\nexport default {};`),
+      },
+    );
+
+    assertEquals(result, `import React from "${sourceUrl}";`);
+    assertEquals(result.includes(`/_vf/assets/${HASH_A}.js`), false);
+    assertEquals(result.includes("file://"), false);
+  });
+
+  it("restores the verified HTTP source URL when the manifest is unavailable", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "building",
+        manifest_version: 1,
+        manifest: null,
+      })
+    );
+
+    const result = await rewriteReleaseDependencyImportsForModule(
+      'import React from "file:///tmp/veryfront-http-bundle/http-123abc.mjs";\nexport default React;',
+      {
+        releaseId: "release-id",
+        dependencyCacheRoot: "/tmp/veryfront-http-bundle",
+        readDependencySource: () =>
+          Promise.resolve(`/*! @vf-source: ${sourceUrl} */\nexport default {};`),
+      },
+    );
+
+    assertEquals(result, `import React from "${sourceUrl}";\nexport default React;`);
+    assertEquals(result.includes("file://"), false);
+  });
+
+  it("preserves the owned bundle import for unsafe embedded source markers", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "building",
+        manifest_version: 1,
+        manifest: null,
+      })
+    );
+    const bundleUrl = "file:///tmp/veryfront-http-bundle/http-123abc.mjs";
+    const code = `import value from "${bundleUrl}";`;
+    const unsafeMarkers = [
+      "file:///private/module.mjs",
+      "data:text/javascript,export default 1",
+      "https://user:secret@example.com/module.mjs",
+      "https://example.com/module\u0000.mjs",
+      `https://example.com/${"a".repeat(RELEASE_ASSET_MANIFEST_LIMITS.manifestKeyLength)}`,
+    ];
+
+    for (const marker of unsafeMarkers) {
+      const result = await rewriteReleaseDependencyImportsForModule(code, {
+        releaseId: "release-id",
+        dependencyCacheRoot: "/tmp/veryfront-http-bundle",
+        readDependencySource: () =>
+          Promise.resolve(`/*! @vf-source: ${marker} */\nexport default {};`),
+      });
+
+      assertEquals(result, code);
+      assertEquals(await hasReleaseDependencyImportSpecifiers(result), true);
+    }
   });
 
   it("does not rewrite when the dependency import-map flag is off", async () => {
@@ -138,6 +344,7 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
 
     const result = await rewriteReleaseDependencyImportsForModule(code, {
       releaseId: "release-id",
+      dependencyCacheRoot: "/tmp/veryfront-http-bundle",
       readDependencySource: () => Promise.reject(new Error("unused")),
     });
 

--- a/src/release-assets/module-consumption.ts
+++ b/src/release-assets/module-consumption.ts
@@ -10,15 +10,28 @@
  */
 
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
-import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
+import { isAbsolute, normalize, relative } from "#veryfront/compat/path/index.ts";
+import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache-helpers.ts";
 import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 import { extractSourceUrl } from "#veryfront/transforms/esm/source-url-embed.ts";
-import { RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, releaseAssetUrl } from "./constants.ts";
+import {
+  RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG,
+  RELEASE_ASSET_MANIFEST_LIMITS,
+  RELEASE_ASSET_MAX_SIZE_BYTES,
+  releaseAssetUrl,
+} from "./constants.ts";
 import { getReadyManifestForRenderAsync, type ReadyManifestReadOptions } from "./manifest-cache.ts";
-import type { ReleaseAssetManifest } from "./manifest-schema.ts";
+import {
+  hasImmutableReleaseAssetDependencies,
+  type ReleaseAssetManifest,
+} from "./manifest-schema.ts";
+import { hasControlCharacters } from "./string-validation.ts";
+
+const textEncoder = new TextEncoder();
 
 export interface RewriteReleaseDependencyImportsOptions {
   releaseId?: string | null;
+  dependencyCacheRoot: string;
   readDependencySource: (path: string) => Promise<string>;
   manifest?: ReleaseAssetManifest | null;
   manifestReadOptions?: ReadyManifestReadOptions;
@@ -71,14 +84,25 @@ function dependencyAssetUrl(
   manifest: ReleaseAssetManifest,
   specifier: string,
 ): string | null {
-  const direct = manifest.dependencies[specifier] ??
-    manifest.dependencies[specifier.replace(/[?#].*$/, "")];
-  if (direct) return releaseAssetUrl(direct.contentHash, "js");
+  if (!hasImmutableReleaseAssetDependencies(manifest)) return null;
+  const canonicalSpecifier = canonicalHttpSourceUrl(specifier);
+  if (!canonicalSpecifier) return null;
+  const fragmentIndex = specifier.indexOf("#");
+  const fragment = fragmentIndex >= 0 ? specifier.slice(fragmentIndex) : "";
+  const direct = ownDependency(manifest, specifier);
+  if (direct) return `${releaseAssetUrl(direct.contentHash, "js")}${fragment}`;
 
-  const normalized = normalizeHttpUrl(specifier);
-  const normalizedEntry = manifest.dependencies[normalized] ??
-    manifest.dependencies[normalized.replace(/[?#].*$/, "")];
-  return normalizedEntry ? releaseAssetUrl(normalizedEntry.contentHash, "js") : null;
+  const normalizedEntry = ownDependency(manifest, canonicalSpecifier);
+  return normalizedEntry
+    ? `${releaseAssetUrl(normalizedEntry.contentHash, "js")}${fragment}`
+    : null;
+}
+
+function ownDependency(
+  manifest: ReleaseAssetManifest,
+  key: string,
+): ReleaseAssetManifest["dependencies"][string] | undefined {
+  return Object.hasOwn(manifest.dependencies, key) ? manifest.dependencies[key] : undefined;
 }
 
 function localHttpBundlePath(specifier: string): string | null {
@@ -102,15 +126,83 @@ function localHttpBundlePath(specifier: string): string | null {
   }
 }
 
+function authorizedLocalHttpBundlePath(
+  specifier: string,
+  dependencyCacheRoot: string,
+): string | null {
+  const path = localHttpBundlePath(specifier);
+  if (
+    !path ||
+    !isAbsolute(path) ||
+    !isAbsolute(dependencyCacheRoot) ||
+    normalize(path) !== path
+  ) {
+    return null;
+  }
+
+  const root = normalize(dependencyCacheRoot);
+  const relativePath = relative(root, path);
+  if (
+    relativePath.length === 0 ||
+    relativePath === ".." ||
+    relativePath.startsWith("../") ||
+    relativePath.startsWith("..\\") ||
+    isAbsolute(relativePath)
+  ) {
+    return null;
+  }
+  return path;
+}
+
+function canonicalHttpSourceUrl(value: unknown): string | null {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > RELEASE_ASSET_MANIFEST_LIMITS.manifestKeyLength ||
+    value.trim() !== value ||
+    hasControlCharacters(value)
+  ) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.username !== "" ||
+    parsed.password !== ""
+  ) {
+    return null;
+  }
+
+  const canonical = normalizeHttpUrl(parsed.toString());
+  return canonical.length <= RELEASE_ASSET_MANIFEST_LIMITS.manifestKeyLength &&
+      !hasControlCharacters(canonical)
+    ? canonical
+    : null;
+}
+
 async function sourceUrlForLocalHttpBundle(
   specifier: string,
+  dependencyCacheRoot: string,
   readDependencySource: (path: string) => Promise<string>,
 ): Promise<string | null> {
-  const path = localHttpBundlePath(specifier);
+  const path = authorizedLocalHttpBundlePath(specifier, dependencyCacheRoot);
   if (!path) return null;
 
   try {
-    return extractSourceUrl(await readDependencySource(path));
+    const source = await readDependencySource(path);
+    if (
+      typeof source !== "string" ||
+      textEncoder.encode(source).byteLength > RELEASE_ASSET_MAX_SIZE_BYTES
+    ) {
+      return null;
+    }
+    return canonicalHttpSourceUrl(extractSourceUrl(source));
   } catch {
     return null;
   }
@@ -127,23 +219,29 @@ export async function rewriteReleaseDependencyImportsForModule(
   const manifest = options.manifest !== undefined
     ? options.manifest
     : await getReadyManifestForRenderAsync(options.releaseId, options.manifestReadOptions);
-  if (!manifest || Object.keys(manifest.dependencies).length === 0) return code;
 
   const replacements = new Map<string, string>();
   for (const imp of await parseImports(code)) {
     if (!imp.n || replacements.has(imp.n)) continue;
 
-    const direct = dependencyAssetUrl(manifest, imp.n);
+    const direct = manifest ? dependencyAssetUrl(manifest, imp.n) : null;
     if (direct) {
       replacements.set(imp.n, direct);
       continue;
     }
 
-    const sourceUrl = await sourceUrlForLocalHttpBundle(imp.n, options.readDependencySource);
+    const sourceUrl = await sourceUrlForLocalHttpBundle(
+      imp.n,
+      options.dependencyCacheRoot,
+      options.readDependencySource,
+    );
     if (!sourceUrl) continue;
 
-    const assetUrl = dependencyAssetUrl(manifest, sourceUrl);
-    if (assetUrl) replacements.set(imp.n, assetUrl);
+    const assetUrl = manifest ? dependencyAssetUrl(manifest, sourceUrl) : null;
+    // A non-ready or incomplete manifest must never leak a local cache path to
+    // the browser. Preserve the authenticated JIT path by restoring the
+    // bundle's verified HTTP source URL, and keep the response uncached.
+    replacements.set(imp.n, assetUrl ?? sourceUrl);
   }
 
   if (replacements.size === 0) return code;

--- a/src/release-assets/route-path.ts
+++ b/src/release-assets/route-path.ts
@@ -1,3 +1,6 @@
+import { hasControlCharacters } from "./string-validation.ts";
+import { RELEASE_ASSET_MANIFEST_LIMITS } from "./constants.ts";
+
 const PAGE_MODULE_EXTENSION = /\.(tsx|ts|jsx|mdx|js)$/;
 const DECLARATION_MODULE_EXTENSION = /\.d\.(tsx|ts)$/;
 
@@ -45,11 +48,29 @@ export function configuredRoutePath(
 
 /** Derive a route path from a page module logical path. */
 export function routeForPage(logicalPath: string): string | null {
+  if (
+    typeof logicalPath !== "string" ||
+    logicalPath.length > RELEASE_ASSET_MANIFEST_LIMITS.manifestKeyLength ||
+    logicalPath.includes("\\") ||
+    logicalPath.includes("?") ||
+    logicalPath.includes("#") ||
+    hasControlCharacters(logicalPath)
+  ) {
+    return null;
+  }
+
+  const pathSegments = logicalPath.split("/");
+  if (
+    pathSegments.some((segment) => segment.length === 0 || segment === "." || segment === "..")
+  ) {
+    return null;
+  }
+
   if (logicalPath.startsWith("pages/")) {
     const withoutPrefix = logicalPath.slice("pages/".length);
     const withoutExt = stripPageModuleExtension(withoutPrefix);
     if (withoutExt === null) return null;
-    const segments = withoutExt.split("/").filter(Boolean);
+    const segments = withoutExt.split("/");
     if (
       segments.length === 0 ||
       segments[0] === "api" ||
@@ -72,7 +93,14 @@ export function routeForPage(logicalPath: string): string | null {
       .replace(/^page$/, "")
       .split("/")
       .filter(Boolean);
-    if (segments.some((segment) => segment.startsWith("@") || segment.startsWith("_"))) {
+    if (
+      segments.some((segment) =>
+        segment.startsWith("@") ||
+        segment.startsWith("_") ||
+        (segment.startsWith("(") &&
+          (!segment.endsWith(")") || segment.length === 2))
+      )
+    ) {
       return null;
     }
 

--- a/src/release-assets/string-validation.ts
+++ b/src/release-assets/string-validation.ts
@@ -1,0 +1,8 @@
+/** True when text contains a C0 control code unit or DEL. */
+export function hasControlCharacters(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x1f || codeUnit === 0x7f) return true;
+  }
+  return false;
+}

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -15,7 +15,7 @@ import {
 } from "#veryfront/release-assets/constants.ts";
 import {
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
+  registerManifestFetcherForRelease,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { FSAdapterWrapper } from "#veryfront/platform/adapters/fs/wrapper.ts";
@@ -74,7 +74,6 @@ describe("HTMLGenerator helpers", () => {
   afterEach(() => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
     setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, originalDependencyFlag ?? "");
-    configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
     clearCSSCache();
   });
@@ -452,8 +451,9 @@ describe("HTMLGenerator helpers", () => {
     it("treats an undefined manifest option as absent for full HTML import maps", async () => {
       setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
       setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
-      configureReleaseAssetManifestFetcher(() =>
-        Promise.resolve({ state: "ready", manifest_version: 1, manifest: releaseManifest() })
+      registerManifestFetcherForRelease(
+        "rel-1",
+        () => Promise.resolve({ state: "ready", manifest_version: 1, manifest: releaseManifest() }),
       );
       const generator = createHTMLGenerator({
         readFile: async (path: string) => path.endsWith("/app/page.tsx") ? `'use client';` : "",

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -44,13 +44,13 @@ const PIN_KEY_B = "on:3w5e11264sgsf";
 
 function releaseManifest(): ReleaseAssetManifest {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     projectId: "p",
     releaseId: "rel-1",
     releaseVersion: 1,
     manifestVersion: 1,
     builderVersion: "0.1.800",
-    sourceContentHash: "",
+    sourceContentHash: "a".repeat(64),
     createdAt: "2026-06-12T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
     modules: {},
@@ -63,7 +63,7 @@ function releaseManifest(): ReleaseAssetManifest {
         contentType: "text/javascript",
       },
     },
-    fallback: { mode: "jit", gaps: [] },
+    dependencyMode: "immutable",
   };
 }
 
@@ -453,7 +453,7 @@ describe("HTMLGenerator helpers", () => {
       setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
       setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
       configureReleaseAssetManifestFetcher(() =>
-        Promise.resolve({ state: "ready", manifest: releaseManifest() })
+        Promise.resolve({ state: "ready", manifest_version: 1, manifest: releaseManifest() })
       );
       const generator = createHTMLGenerator({
         readFile: async (path: string) => path.endsWith("/app/page.tsx") ? `'use client';` : "",

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -10,8 +10,8 @@ import { cacheCSSAsync, hashCSS } from "#veryfront/html/styles-builder/index.ts"
 import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
 import {
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
   getReadyManifestForRender,
+  registerManifestFetcherForRelease,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
@@ -135,8 +135,10 @@ function releaseManifestWithCss(): ReleaseAssetManifest {
 }
 
 async function primeReadyReleaseCssManifest(): Promise<void> {
-  configureReleaseAssetManifestFetcher(() =>
-    Promise.resolve({ state: "ready", manifest_version: 1, manifest: releaseManifestWithCss() })
+  registerManifestFetcherForRelease(
+    "rel-css",
+    () =>
+      Promise.resolve({ state: "ready", manifest_version: 1, manifest: releaseManifestWithCss() }),
   );
   setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
   getReadyManifestForRender("rel-css");
@@ -150,7 +152,6 @@ describe("RenderPipeline behavior", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
     Deno.env.delete("VERYFRONT_ENABLE_SERVER_TIMING");
     resetRequestProfiles();
-    configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
   });
 

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -111,13 +111,13 @@ function primeCssCache(slug: string, projectId: string): void {
 
 function releaseManifestWithCss(): ReleaseAssetManifest {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     projectId: "p",
     releaseId: "rel-css",
     releaseVersion: 1,
     manifestVersion: 1,
     builderVersion: "0.1.793",
-    sourceContentHash: "",
+    sourceContentHash: "a".repeat(64),
     createdAt: "2026-06-12T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
     modules: {},
@@ -125,17 +125,18 @@ function releaseManifestWithCss(): ReleaseAssetManifest {
       contentHash: RELEASE_CSS_HASH,
       size: 10,
       contentType: "text/css",
-      styleProfileHash: "style-profile",
+      styleProfileHash: "b".repeat(64),
+      cssPipelineIdentity: "tailwind-v4",
     }],
     routes: { "/behavior-release-css": { modules: [], css: [RELEASE_CSS_HASH] } },
     dependencies: {},
-    fallback: { mode: "jit", gaps: [] },
+    dependencyMode: "immutable",
   };
 }
 
 async function primeReadyReleaseCssManifest(): Promise<void> {
   configureReleaseAssetManifestFetcher(() =>
-    Promise.resolve({ state: "ready", manifest: releaseManifestWithCss() })
+    Promise.resolve({ state: "ready", manifest_version: 1, manifest: releaseManifestWithCss() })
   );
   setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
   getReadyManifestForRender("rel-css");
@@ -936,7 +937,7 @@ describe("RenderPipeline behavior", () => {
       "pages/behavior-release-modules.mdx": {
         contentHash: "a".repeat(64),
         size: 100,
-        contentType: "application/javascript",
+        contentType: "text/javascript",
       },
     };
 

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -8,7 +8,7 @@ import {
 } from "#veryfront/release-assets/constants.ts";
 import {
   clearReleaseAssetManifestCache,
-  configureReleaseAssetManifestFetcher,
+  registerManifestFetcherForRelease,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
@@ -278,14 +278,14 @@ describe("Renderer release asset cache isolation", () => {
 
   afterEach(() => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
-    configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
   });
 
   it("checks the manifest-versioned cache prefix after awaiting a ready manifest", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest_version: 1, manifest: makeReadyManifest() })
+    registerManifestFetcherForRelease(
+      "rel-1",
+      () => Promise.resolve({ state: "ready", manifest_version: 1, manifest: makeReadyManifest() }),
     );
 
     const store = createInMemoryStore();
@@ -319,8 +319,9 @@ describe("Renderer release asset cache isolation", () => {
 
   it("persists rendered HTML under the manifest-versioned cache prefix", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest_version: 1, manifest: makeReadyManifest() })
+    registerManifestFetcherForRelease(
+      "rel-1",
+      () => Promise.resolve({ state: "ready", manifest_version: 1, manifest: makeReadyManifest() }),
     );
 
     const store = createInMemoryStore();

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -121,20 +121,20 @@ async function waitForProductionPrewarm(renderer: Renderer): Promise<void> {
 
 function makeReadyManifest(): ReleaseAssetManifest {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     projectId: "proj-1",
     releaseId: "rel-1",
     releaseVersion: 1,
     manifestVersion: 1,
     builderVersion: "0.1.799",
-    sourceContentHash: "",
+    sourceContentHash: "a".repeat(64),
     createdAt: "2026-06-14T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
     modules: {},
     css: [],
     routes: {},
     dependencies: {},
-    fallback: { mode: "jit", gaps: [] },
+    dependencyMode: "immutable",
   };
 }
 
@@ -285,7 +285,7 @@ describe("Renderer release asset cache isolation", () => {
   it("checks the manifest-versioned cache prefix after awaiting a ready manifest", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest: makeReadyManifest() })
+      Promise.resolve({ state: "ready", manifest_version: 1, manifest: makeReadyManifest() })
     );
 
     const store = createInMemoryStore();
@@ -320,7 +320,7 @@ describe("Renderer release asset cache isolation", () => {
   it("persists rendered HTML under the manifest-versioned cache prefix", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(() =>
-      Promise.resolve({ state: "ready", manifest: makeReadyManifest() })
+      Promise.resolve({ state: "ready", manifest_version: 1, manifest: makeReadyManifest() })
     );
 
     const store = createInMemoryStore();

--- a/src/server/build-app-route-renderer.test.ts
+++ b/src/server/build-app-route-renderer.test.ts
@@ -200,13 +200,13 @@ Deno.test({
       const jsxRuntimeHash = "4".repeat(64);
       const jsxDevRuntimeHash = "5".repeat(64);
       const manifest: ReleaseAssetManifest = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         projectId: "local-project",
         releaseId: "standalone-dev",
         releaseVersion: 0,
         manifestVersion: 1,
         builderVersion: "0.1.810",
-        sourceContentHash: "source",
+        sourceContentHash: "a".repeat(64),
         createdAt: "2026-06-15T00:00:00.000Z",
         assetBasePath: "/_vf/assets",
         modules: {},
@@ -239,7 +239,7 @@ Deno.test({
             contentType: "text/javascript",
           },
         },
-        fallback: { mode: "jit", gaps: [] },
+        dependencyMode: "immutable",
       };
       const releaseHtml = await renderAppRouteToHTML({
         adapter: denoAdapter,

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -1086,6 +1086,7 @@ async function executeReleaseAssetBuildRun(input: {
       "#veryfront/platform/adapters/veryfront-api-client/client.ts"
     );
     const { runReleaseAssetBuild } = await import("#veryfront/release-assets/build-executor.ts");
+    const { transformToESM } = await import("#veryfront/transforms/esm-transform.ts");
     const { createCompileProjectCss } = await import(
       "#veryfront/release-assets/css-compile.ts"
     );
@@ -1104,6 +1105,10 @@ async function executeReleaseAssetBuildRun(input: {
     apiClient.setProjectSlug(projectReference);
 
     const releaseVersionRef = releaseId;
+    const releaseConfig = input.ctx.config;
+    if (!releaseConfig) {
+      throw INVALID_ARGUMENT.create({ detail: "Missing validated project config" });
+    }
 
     // Production CSS compiler: compiles the project's Tailwind CSS in-runtime
     // via the pure `generateTailwindCSS` primitive (no distributed-cache /
@@ -1111,7 +1116,6 @@ async function executeReleaseAssetBuildRun(input: {
     // propagate to the executor, which records an explicit CSS gap.
     const compileProjectCss = createCompileProjectCss({
       projectScope: projectReference,
-      config: input.ctx.config,
     });
 
     const result = await runReleaseAssetBuild({
@@ -1121,10 +1125,34 @@ async function executeReleaseAssetBuildRun(input: {
       releaseVersion,
       releaseVersionRef,
       adapter: input.ctx.adapter,
+      dependencyMode: "source",
+      transform: (source, sourceFile, projectDir, adapter, options) =>
+        transformToESM(source, sourceFile, projectDir, adapter, {
+          projectId: options.projectId,
+          dev: options.dev,
+          ssr: options.ssr,
+          studioEmbed: false,
+          reactVersion: options.reactVersion,
+          dependencyPinningCacheKey: options.dependencyPinningSnapshot?.cacheKey,
+          dependencyPinningDependencies: options.dependencyPinningSnapshot?.dependencies,
+          dependencyPinningSource: options.dependencyPinningSource,
+        }),
+      loadConfig: () => Promise.resolve(releaseConfig),
       client: {
         beginReleaseAssetManifestBuild: (version) =>
           apiClient.beginReleaseAssetManifestBuild(version),
-        listAllReleaseFiles: (version) => apiClient.listAllReleaseFiles(version),
+        listAllReleaseFiles: async (version) => {
+          const files = await apiClient.listAllReleaseFiles(version);
+          return files.map((file) => {
+            if (typeof file.content !== "string") {
+              throw API_CLIENT_ERROR.create({
+                detail: "Release file list omitted file content",
+                status: 502,
+              });
+            }
+            return { path: file.path, content: file.content };
+          });
+        },
         uploadReleaseAsset: (version, hash, contentType, bytes) =>
           apiClient.uploadReleaseAsset(version, hash, contentType, bytes),
         putReleaseAssetManifest: (version, manifest) =>


### PR DESCRIPTION
## Summary

- make release manifest v2 parsing bounded, strict, immutable, and generation-matched
- fail closed on incomplete module, dependency, route, CSS, and upload coverage
- bound source materialization, pending asset memory, dependency traversal, and manifest registries
- enforce release-scoped fetcher ownership, cancellation, and cache isolation
- preserve explicit core extension boundaries for transforms, dependency vendoring, CSS compilation, and config loading
- reconcile the direct CLI/build/modules/platform/server call sites without permissive compatibility fallbacks
- document the release-assets subsystem contract and rollout behavior

## Size and scope

- 28 files
- 5,151 additions / 1,306 deletions (6,457 changed LOC)

This is below the approximate 20k-line target because release-assets is a natural, independently testable subsystem boundary. The additional eight files are only direct integration call sites and their tests.

## Validation

- `deno test -A --no-check src/release-assets src/build/production-build/local-release-assets.test.ts src/modules/server/module-server.test.ts src/platform/adapters/fs/veryfront/adapter.test.ts src/server/handlers/request/project-run-execute.handler.test.ts cli/shared/server-startup.test.ts` — 21 passed, 373 steps
- `deno task typecheck`
- `deno task lint:module-boundaries`
- focused `deno lint` and `deno fmt --check` across all changed files

## Merge order

Review can proceed in parallel, but merge #3236 first. This PR touches the module-server integration added there and should be rebased onto main immediately after #3236 lands; no code dependency is hidden, and the current branch independently passes against main.