### PR TITLE
feat(platform): add bounded filesystem read capabilities

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1778,6 +1778,20 @@ export interface HostedConfigOptions {
   readonly signal?: AbortSignal;
 }
 
+/**
+ * Authenticated source and environment binding for one hosted evaluation.
+ *
+ * A composition root derives this once from control-plane state and threads it
+ * to every consumer of that request's configuration. Nothing downstream may
+ * re-derive source or environment identity for itself.
+ *
+ * @internal
+ */
+export type PreparedHostedConfigContext = Pick<
+  HostedConfigOptions,
+  "sourceContext" | "preparedContext"
+>;
+
 /** Exact declarative source selected by a trusted composition boundary. */
 export type HostedConfigSource = Readonly<{
   source: string;

--- a/src/platform/adapters/bounded-text-reader.test.ts
+++ b/src/platform/adapters/bounded-text-reader.test.ts
@@ -75,6 +75,18 @@ describe("platform/adapters/bounded-text-reader", () => {
     );
   });
 
+  it("normalizes an oversized snapshot result to the content-admission error", async () => {
+    const reader = captureSnapshotTextReader({
+      readFileSnapshotWithinLimit: () => Promise.resolve(new Uint8Array(9)),
+    }, "Snapshot text reader");
+
+    await assertRejects(
+      () => reader.readUtf8("/oversized.css", "/root", 4, "Snapshot stylesheet"),
+      TypeError,
+      "Snapshot stylesheet exceeds 4 bytes",
+    );
+  });
+
   it("captures only bounded-text read fields", async () => {
     let unrelatedReads = 0;
     const adapter = {

--- a/src/platform/adapters/bounded-text-reader.test.ts
+++ b/src/platform/adapters/bounded-text-reader.test.ts
@@ -1,0 +1,359 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { runInNewContext } from "node:vm";
+import {
+  captureBoundedTextReader,
+  captureSnapshotTextReader,
+  copyFixedUint8ArrayWithinLimit,
+} from "./bounded-text-reader.ts";
+
+describe("platform/adapters/bounded-text-reader", () => {
+  it("copies admitted byte views into a tight fixed buffer", () => {
+    const source = new Uint8Array([9, 1, 2, 8]);
+    const admitted = copyFixedUint8ArrayWithinLimit(
+      source.subarray(1, 3),
+      2,
+      "Test bytes",
+    );
+
+    source[1] = 7;
+    assertEquals([...admitted], [1, 2]);
+    assertEquals(admitted.byteOffset, 0);
+    assertEquals(admitted.buffer.byteLength, 2);
+  });
+
+  it("uses the captured native constructor after the global is replaced", () => {
+    const NativeUint8Array = globalThis.Uint8Array;
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "Uint8Array");
+    const source = new NativeUint8Array([1, 2, 3, 4]);
+    class OversizedUint8Array extends NativeUint8Array {
+      constructor(length: number) {
+        super(length * 8);
+      }
+    }
+    Object.defineProperty(globalThis, "Uint8Array", {
+      configurable: true,
+      writable: true,
+      value: OversizedUint8Array,
+    });
+    try {
+      const admitted = copyFixedUint8ArrayWithinLimit(source, 4, "Test bytes");
+      assertEquals(admitted.byteLength, 4);
+      assertEquals([...admitted], [1, 2, 3, 4]);
+    } finally {
+      if (descriptor === undefined) {
+        delete (globalThis as Record<string, unknown>).Uint8Array;
+      } else {
+        Object.defineProperty(globalThis, "Uint8Array", descriptor);
+      }
+    }
+  });
+
+  it("rejects a dishonest exact-reader result before fixed-buffer admission", async () => {
+    const reader = captureBoundedTextReader({
+      readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array(5)),
+    });
+
+    await assertRejects(
+      () => reader.readUtf8("/oversized.css", 4, "Exact stylesheet"),
+      TypeError,
+      "Exact stylesheet exceeds 4 bytes",
+    );
+  });
+
+  it("rejects a dishonest whole-reader result before fixed-buffer admission", async () => {
+    const reader = captureBoundedTextReader({
+      readFileBytes: () => Promise.resolve(new Uint8Array(5)),
+      maxWholeFileReadBytes: 4,
+    });
+
+    await assertRejects(
+      () => reader.readUtf8("/oversized.css", 4, "Whole stylesheet"),
+      TypeError,
+      "Whole stylesheet exceeds 4 bytes",
+    );
+  });
+
+  it("captures only bounded-text read fields", async () => {
+    let unrelatedReads = 0;
+    const adapter = {
+      readFileBytesWithinLimit: () => Promise.resolve(new TextEncoder().encode("safe")),
+    };
+    Object.defineProperty(adapter, "writeFileBytes", {
+      get() {
+        unrelatedReads++;
+        throw new Error("must not run");
+      },
+    });
+    Object.defineProperty(adapter, "createFileBytesExclusive", {
+      get() {
+        unrelatedReads++;
+        throw new Error("must not run");
+      },
+    });
+    const reader = captureBoundedTextReader(adapter);
+
+    assertEquals(await reader.readUtf8("safe.css", 4, "CSS input"), {
+      content: "safe",
+      byteLength: 4,
+    });
+    assertEquals(unrelatedReads, 0);
+  });
+
+  it("passes the accepted maximum directly to an exact bounded reader", async () => {
+    let receivedLimit = 0;
+    const reader = captureBoundedTextReader({
+      readFileBytesWithinLimit: (_path: string, byteLimit: number) => {
+        receivedLimit = byteLimit;
+        return Promise.resolve(new TextEncoder().encode("safe"));
+      },
+    });
+
+    assertEquals(await reader.readUtf8("safe.css", 4, "CSS input"), {
+      content: "safe",
+      byteLength: 4,
+    });
+    assertEquals(receivedLimit, 4);
+  });
+
+  it("captures and forwards one root-bound stable snapshot reader", async () => {
+    const calls: Array<[string, string, number]> = [];
+    let replacementCalls = 0;
+    const adapter = {
+      readFileSnapshotWithinLimit: (path: string, root: string, byteLimit: number) => {
+        calls.push([path, root, byteLimit]);
+        return Promise.resolve(new TextEncoder().encode("safe"));
+      },
+    };
+    const reader = captureSnapshotTextReader(adapter, "Project filesystem");
+    adapter.readFileSnapshotWithinLimit = () => {
+      replacementCalls++;
+      return Promise.resolve(new Uint8Array());
+    };
+
+    assertEquals(
+      await reader.readUtf8("/project/app.css", "/project", 4, "Project CSS"),
+      { content: "safe", byteLength: 4 },
+    );
+    assertEquals(calls, [["/project/app.css", "/project", 4]]);
+    assertEquals(replacementCalls, 0);
+  });
+
+  it("requires stable snapshot authority during capture", () => {
+    try {
+      captureSnapshotTextReader({
+        readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array()),
+      });
+      throw new Error("expected missing snapshot authority to reject");
+    } catch (error) {
+      assertEquals(error instanceof TypeError, true);
+      assertEquals((error as Error).message.includes("stable snapshot"), true);
+    }
+  });
+
+  it("accounts bytes through the captured intrinsic getter", async () => {
+    const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+    const descriptor = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteLength")!;
+    const source = new TextEncoder().encode("safe");
+    const reader = captureBoundedTextReader({
+      readFileBytesWithinLimit: () => Promise.resolve(source),
+    });
+    Object.defineProperty(typedArrayPrototype, "byteLength", {
+      configurable: true,
+      get: () => 999,
+    });
+    try {
+      assertEquals(await reader.readUtf8("safe.css", 4, "CSS input"), {
+        content: "safe",
+        byteLength: 4,
+      });
+    } finally {
+      Object.defineProperty(typedArrayPrototype, "byteLength", descriptor);
+    }
+  });
+
+  it("exposes fixed byte length without consulting a poisoned getter", async () => {
+    const module = await import("./bounded-text-reader.ts") as unknown as {
+      getFixedUint8ArrayByteLength?: (value: unknown, label: string) => number;
+    };
+    const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+    const descriptor = Object.getOwnPropertyDescriptor(typedArrayPrototype, "byteLength")!;
+    const source = new TextEncoder().encode("safe");
+    Object.defineProperty(typedArrayPrototype, "byteLength", {
+      configurable: true,
+      get: () => 999,
+    });
+    try {
+      assertEquals(
+        module.getFixedUint8ArrayByteLength?.(source, "CSS input"),
+        4,
+      );
+    } finally {
+      Object.defineProperty(typedArrayPrototype, "byteLength", descriptor);
+    }
+  });
+
+  it("accepts a whole reader only when its fixed upstream ceiling fits", async () => {
+    const bytes = new TextEncoder().encode("safe");
+    const reader = captureBoundedTextReader({
+      maxWholeFileReadBytes: 16,
+      readFileBytes: () => Promise.resolve(bytes),
+    });
+
+    assertEquals(await reader.readUtf8("safe.css", 16, "CSS input"), {
+      content: "safe",
+      byteLength: 4,
+    });
+  });
+
+  it("rejects a 64 MiB whole-reader ceiling for a 16 MiB source without reading", async () => {
+    let reads = 0;
+    const reader = captureBoundedTextReader({
+      maxWholeFileReadBytes: 64 * 1024 * 1024,
+      readFileBytes: () => {
+        reads++;
+        return Promise.resolve(new Uint8Array());
+      },
+    });
+
+    await assertRejects(
+      () => reader.readUtf8("source.tsx", 16 * 1024 * 1024, "CSS source file"),
+      TypeError,
+      "exact bounded byte reader",
+    );
+    assertEquals(reads, 0);
+  });
+
+  it("rejects proxied capability objects without invoking traps", () => {
+    let trapCalls = 0;
+    const reader = new Proxy({
+      readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array()),
+    }, {
+      getOwnPropertyDescriptor(target, property) {
+        trapCalls++;
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+      getPrototypeOf(target) {
+        trapCalls++;
+        return Reflect.getPrototypeOf(target);
+      },
+    });
+
+    try {
+      captureBoundedTextReader(reader);
+      throw new Error("expected proxy rejection");
+    } catch (error) {
+      assertEquals(error instanceof TypeError, true);
+    }
+    assertEquals(trapCalls, 0);
+  });
+
+  it("does not accept a capability forged on a foreign Object.prototype", async () => {
+    const foreign = runInNewContext(`
+      let calls = 0;
+      Object.prototype.readFileBytesWithinLimit = function () {
+        calls++;
+        return Promise.resolve(new Uint8Array([1]));
+      };
+      ({ adapter: {}, getCalls: () => calls });
+    `) as { adapter: object; getCalls: () => number };
+    const reader = captureBoundedTextReader(foreign.adapter);
+
+    await assertRejects(
+      () => reader.readUtf8("forged.css", 1, "Foreign CSS source"),
+      TypeError,
+      "exact bounded byte reader",
+    );
+    assertEquals(foreign.getCalls(), 0);
+  });
+
+  it("accepts an explicitly supplied null-prototype capability object", async () => {
+    const adapter = Object.assign(Object.create(null), {
+      readFileBytesWithinLimit: () => Promise.resolve(new TextEncoder().encode("safe")),
+    });
+    const reader = captureBoundedTextReader(adapter);
+
+    assertEquals(await reader.readUtf8("safe.css", 4, "CSS source"), {
+      content: "safe",
+      byteLength: 4,
+    });
+  });
+
+  it("does not accept a prefix-only reader as an exact bounded reader", async () => {
+    let reads = 0;
+    const reader = captureBoundedTextReader({
+      readFileBytesBounded: () => {
+        reads++;
+        return Promise.resolve(new Uint8Array());
+      },
+    });
+
+    await assertRejects(
+      () => reader.readUtf8("source.tsx", 16, "CSS source file"),
+      TypeError,
+      "exact bounded byte reader",
+    );
+    assertEquals(reads, 0);
+  });
+
+  it("propagates proxied operational failures without invoking their traps", async () => {
+    let trapCalls = 0;
+    const failure = new Proxy(new Error("read failed"), {
+      getPrototypeOf() {
+        trapCalls++;
+        throw new Error("must not run");
+      },
+      getOwnPropertyDescriptor() {
+        trapCalls++;
+        throw new Error("must not run");
+      },
+    });
+    const reader = captureBoundedTextReader({
+      readFileBytesWithinLimit: () => Promise.reject(failure),
+    });
+
+    let caught: unknown;
+    try {
+      await reader.readUtf8("source.tsx", 16, "CSS source file");
+    } catch (error) {
+      caught = error;
+    }
+    assertEquals(caught === failure, true);
+    assertEquals(trapCalls, 0);
+  });
+
+  it("rejects SharedArrayBuffer-backed bytes before UTF-8 decoding", async () => {
+    const shared = new SharedArrayBuffer(4);
+    const bytes = new Uint8Array(shared);
+    bytes.set([0x73, 0x61, 0x66, 0x65]);
+    const reader = captureBoundedTextReader({
+      readFileBytesWithinLimit: () => Promise.resolve(bytes),
+    });
+
+    await assertRejects(
+      () => reader.readUtf8("shared.css", 4, "CSS source file"),
+      TypeError,
+      "fixed ArrayBuffer",
+    );
+  });
+
+  it("rejects resizable ArrayBuffer-backed bytes before UTF-8 decoding", async () => {
+    const ResizableArrayBuffer = ArrayBuffer as unknown as new (
+      byteLength: number,
+      options: { maxByteLength: number },
+    ) => ArrayBuffer;
+    const buffer = new ResizableArrayBuffer(4, { maxByteLength: 8 });
+    const bytes = new Uint8Array(buffer);
+    bytes.set([0x73, 0x61, 0x66, 0x65]);
+    const reader = captureBoundedTextReader({
+      readFileBytesWithinLimit: () => Promise.resolve(bytes),
+    });
+
+    await assertRejects(
+      () => reader.readUtf8("resizable.css", 4, "CSS source file"),
+      TypeError,
+      "fixed ArrayBuffer",
+    );
+  });
+});

--- a/src/platform/adapters/bounded-text-reader.ts
+++ b/src/platform/adapters/bounded-text-reader.ts
@@ -1,0 +1,180 @@
+import {
+  isNativeErrorWithoutHooks,
+  readNativeErrorNameWithoutHooks,
+} from "../compat/error-introspection.ts";
+import {
+  captureFileSystemCapabilities,
+  captureSnapshotReadCapability,
+  copyFixedUint8ArrayWithinLimit,
+  getFixedUint8ArrayByteLength,
+} from "./file-system-capabilities.ts";
+
+export {
+  copyFixedUint8ArrayWithinLimit,
+  getFixedUint8ArrayBuffer,
+  getFixedUint8ArrayByteLength,
+} from "./file-system-capabilities.ts";
+
+const apply = Reflect.apply;
+const numberIsSafeInteger = Number.isSafeInteger;
+const freezeObject = Object.freeze;
+const textDecoderDecode = TextDecoder.prototype.decode;
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+export interface CapturedBoundedTextReader {
+  readUtf8(
+    path: string,
+    maximumBytes: number,
+    label: string,
+  ): Promise<{ content: string; byteLength: number }>;
+}
+
+export interface CapturedSnapshotTextReader {
+  readUtf8(
+    path: string,
+    containmentRoot: string,
+    maximumBytes: number,
+    label: string,
+  ): Promise<{ content: string; byteLength: number }>;
+}
+
+function decodeUtf8(bytes: Uint8Array, label: string): string {
+  try {
+    return apply(textDecoderDecode, strictUtf8Decoder, [bytes]) as string;
+  } catch (cause) {
+    throw new TypeError(`${label} must contain valid UTF-8`, { cause });
+  }
+}
+
+function validateTextRead(
+  path: string,
+  maximumBytes: number,
+  label: string,
+): void {
+  if (typeof path !== "string" || path.length === 0) {
+    throw new TypeError(`${label} path must be a non-empty string`);
+  }
+  if (!numberIsSafeInteger(maximumBytes) || maximumBytes <= 0) {
+    throw new RangeError(`${label} maximum must be a positive safe integer`);
+  }
+}
+
+function isNativeRangeError(value: unknown): boolean {
+  return isNativeErrorWithoutHooks(value) &&
+    readNativeErrorNameWithoutHooks(value) === "RangeError";
+}
+
+/**
+ * Capture a filesystem's genuine exact bounded-read capability without invoking
+ * accessors or Proxy traps. The returned reader never falls back to text or
+ * unbounded binary reads. A whole-file reader is usable only when its fixed
+ * upstream ceiling is no larger than the caller's requested maximum.
+ */
+export function captureBoundedTextReader(
+  value: unknown,
+  label = "Bounded text reader",
+): CapturedBoundedTextReader {
+  const capabilities = captureFileSystemCapabilities(value, label, "bounded-text");
+  const exactReader = capabilities.readFileBytesWithinLimit;
+  const wholeFileReader = capabilities.wholeFileReader;
+
+  return freezeObject({
+    async readUtf8(
+      path: string,
+      maximumBytes: number,
+      contentLabel: string,
+    ): Promise<{ content: string; byteLength: number }> {
+      validateTextRead(path, maximumBytes, contentLabel);
+
+      let bytes: unknown;
+      if (exactReader !== undefined) {
+        try {
+          bytes = await exactReader(path, maximumBytes);
+        } catch (cause) {
+          // The exact-read contract reserves RangeError for source overflow.
+          // Normalize it to the content-admission error used by CSS callers
+          // while preserving operational filesystem failures unchanged.
+          if (isNativeRangeError(cause)) {
+            throw new TypeError(`${contentLabel} exceeds ${maximumBytes} bytes`, {
+              cause,
+            });
+          }
+          throw cause;
+        }
+      } else if (
+        wholeFileReader !== undefined &&
+        wholeFileReader.maximumBytes <= maximumBytes
+      ) {
+        bytes = await wholeFileReader.read(path);
+      } else {
+        throw new TypeError(
+          `${contentLabel} requires a genuine exact bounded byte reader or a fixed whole-file ceiling no larger than ${maximumBytes} bytes`,
+        );
+      }
+
+      const admittedMaximum = exactReader === undefined
+        ? wholeFileReader!.maximumBytes
+        : maximumBytes;
+      const admittedBytes = copyFixedUint8ArrayWithinLimit(
+        bytes,
+        admittedMaximum,
+        contentLabel,
+      );
+      const byteLength = getFixedUint8ArrayByteLength(admittedBytes, contentLabel);
+
+      return {
+        content: decodeUtf8(admittedBytes, contentLabel),
+        byteLength,
+      };
+    },
+  });
+}
+
+/**
+ * Capture and require a filesystem's root-bound stable snapshot capability.
+ * The returned reader keeps the original method authority, admits a fixed
+ * byte copy, and decodes strict UTF-8 without consulting mutable globals.
+ */
+export function captureSnapshotTextReader(
+  value: unknown,
+  label = "Snapshot text reader",
+): CapturedSnapshotTextReader {
+  const snapshotReader = captureSnapshotReadCapability(value, label);
+  if (snapshotReader === undefined) {
+    throw new TypeError(
+      `${label} requires a genuine root-bound stable snapshot byte reader`,
+    );
+  }
+
+  return freezeObject({
+    async readUtf8(
+      path: string,
+      containmentRoot: string,
+      maximumBytes: number,
+      contentLabel: string,
+    ): Promise<{ content: string; byteLength: number }> {
+      validateTextRead(path, maximumBytes, contentLabel);
+      if (typeof containmentRoot !== "string" || containmentRoot.length === 0) {
+        throw new TypeError(`${contentLabel} containment root must be a non-empty string`);
+      }
+
+      let bytes: Uint8Array;
+      try {
+        bytes = await snapshotReader.read(path, containmentRoot, maximumBytes);
+      } catch (cause) {
+        if (isNativeRangeError(cause)) {
+          throw new TypeError(`${contentLabel} exceeds ${maximumBytes} bytes`, {
+            cause,
+          });
+        }
+        throw cause;
+      }
+
+      const byteLength = getFixedUint8ArrayByteLength(bytes, contentLabel);
+      return {
+        content: decodeUtf8(bytes, contentLabel),
+        byteLength,
+      };
+    },
+  });
+}

--- a/src/platform/adapters/bounded-text-reader.ts
+++ b/src/platform/adapters/bounded-text-reader.ts
@@ -115,11 +115,22 @@ export function captureBoundedTextReader(
       const admittedMaximum = exactReader === undefined
         ? wholeFileReader!.maximumBytes
         : maximumBytes;
-      const admittedBytes = copyFixedUint8ArrayWithinLimit(
-        bytes,
-        admittedMaximum,
-        contentLabel,
-      );
+      let admittedBytes: Uint8Array;
+      try {
+        admittedBytes = copyFixedUint8ArrayWithinLimit(
+          bytes,
+          admittedMaximum,
+          contentLabel,
+        );
+      } catch (cause) {
+        // A dishonest reader result overflows during admission rather than in
+        // the reader itself; both overflows reach CSS callers as the same
+        // content-admission error.
+        if (isNativeRangeError(cause)) {
+          throw new TypeError(`${contentLabel} exceeds ${maximumBytes} bytes`, { cause });
+        }
+        throw cause;
+      }
       const byteLength = getFixedUint8ArrayByteLength(admittedBytes, contentLabel);
 
       return {

--- a/src/platform/adapters/file-system-capabilities.test.ts
+++ b/src/platform/adapters/file-system-capabilities.test.ts
@@ -1,191 +1,271 @@
 import "#veryfront/schemas/_test-setup.ts";
-
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { runInNewContext } from "node:vm";
-import {
-  captureByteReadCapabilities,
-  captureExclusiveCreateCapability,
-  captureSnapshotReadCapability,
-  captureStaticReadCapabilities,
-} from "./file-system-capabilities.ts";
+import * as capabilityModule from "./file-system-capabilities.ts";
+
+type SnapshotReader = {
+  read(path: string, containmentRoot: string, byteLimit: number): Promise<Uint8Array>;
+};
+type ExclusiveCreator = {
+  create(path: string, content: Uint8Array): Promise<void>;
+};
+type StaticReaders = {
+  snapshot?: SnapshotReader;
+  virtual?: {
+    generation(): Promise<number>;
+    exact?: (path: string, byteLimit: number) => Promise<Uint8Array>;
+    whole?: { maximumBytes: number; read(path: string): Promise<Uint8Array> };
+  };
+};
+type ByteReaders = {
+  unbounded?: (path: string) => Promise<Uint8Array>;
+  whole?: { maximumBytes: number; read(path: string): Promise<Uint8Array> };
+  prefix?: (path: string, byteLimit: number) => Promise<Uint8Array>;
+  exact?: (path: string, byteLimit: number) => Promise<Uint8Array>;
+};
+
+const captureSnapshotReadCapability = (
+  capabilityModule as unknown as {
+    captureSnapshotReadCapability?: (value: unknown, label?: string) =>
+      | SnapshotReader
+      | undefined;
+  }
+).captureSnapshotReadCapability!;
+const captureExclusiveCreateCapability = (
+  capabilityModule as unknown as {
+    captureExclusiveCreateCapability?: (value: unknown, label?: string) =>
+      | ExclusiveCreator
+      | undefined;
+  }
+).captureExclusiveCreateCapability!;
+const captureStaticReadCapabilities = (
+  capabilityModule as unknown as {
+    captureStaticReadCapabilities?: (value: unknown, label?: string) => StaticReaders;
+  }
+).captureStaticReadCapabilities!;
+const captureLegacyFileSystemCapabilitiesForSnapshot = (
+  capabilityModule as unknown as {
+    captureLegacyFileSystemCapabilitiesForSnapshot?: (
+      value: unknown,
+      label?: string,
+    ) => {
+      readFileBytes?: (path: string) => Promise<Uint8Array>;
+      readFileBytesBounded?: (path: string, byteLimit: number) => Promise<Uint8Array>;
+      readFileBytesWithinLimit?: (path: string, byteLimit: number) => Promise<Uint8Array>;
+      writeFileBytes?: (path: string, content: Uint8Array) => Promise<void>;
+      wholeFileReader?: {
+        maximumBytes: number;
+        read(path: string): Promise<Uint8Array>;
+      };
+    };
+  }
+).captureLegacyFileSystemCapabilitiesForSnapshot!;
+const captureByteReadCapabilities = (
+  capabilityModule as unknown as {
+    captureByteReadCapabilities?: (value: unknown, label?: string) => ByteReaders;
+  }
+).captureByteReadCapabilities!;
 
 function assertFrozenNullRecord(value: object): void {
   assertEquals(Object.isFrozen(value), true);
   assertEquals(Object.getPrototypeOf(value), null);
 }
 
-describe("filesystem capability capture", () => {
-  it("captures snapshot authority without inspecting unrelated reader fields", async () => {
-    let unrelatedGetterCalls = 0;
+describe("platform/adapters/file-system-capabilities", () => {
+  it("preserves the defensive byte-reader compatibility surface", async () => {
+    let receiverMatches = false;
+    const source = new Uint8Array([1, 2]);
     const adapter = {
-      readFileSnapshotWithinLimit: () => Promise.resolve(new Uint8Array([1, 2])),
+      maxWholeFileReadBytes: 2,
+      readFileBytes() {
+        receiverMatches = this === adapter;
+        return Promise.resolve(source);
+      },
+      readFileBytesBounded(_path: string, byteLimit: number) {
+        return Promise.resolve(source.subarray(0, byteLimit));
+      },
+      readFileBytesWithinLimit(_path: string, byteLimit: number) {
+        return Promise.resolve(source.subarray(0, byteLimit));
+      },
     };
-    Object.defineProperty(adapter, "readFileBytesWithinLimit", {
+    const captured = captureByteReadCapabilities(adapter);
+
+    assertFrozenNullRecord(captured);
+    assertFrozenNullRecord(captured.whole!);
+    const results = await Promise.all([
+      captured.unbounded!("/a"),
+      captured.whole!.read("/a"),
+      captured.prefix!("/a", 2),
+      captured.exact!("/a", 2),
+    ]);
+    source[0] = 9;
+    for (const result of results) assertEquals([...result], [1, 2]);
+    assertEquals(receiverMatches, true);
+    await assertRejects(() => captured.exact!("/a", 0), RangeError, "positive safe integer");
+  });
+
+  it("captures snapshot authority without inspecting unrelated writer fields", async () => {
+    let unrelatedReads = 0;
+    const adapter = {
+      readFileSnapshotWithinLimit() {
+        return Promise.resolve(new Uint8Array([1, 2]));
+      },
+      createFileBytesExclusive: new Proxy(function () {}, {}),
+    };
+    Object.defineProperty(adapter, "maxWholeFileReadBytes", {
       get() {
-        unrelatedGetterCalls++;
+        unrelatedReads++;
         throw new Error("must not run");
       },
     });
 
     const captured = captureSnapshotReadCapability(adapter)!;
+
     assertFrozenNullRecord(captured);
     assertEquals([...(await captured.read("/root/a", "/root", 2))], [1, 2]);
-    assertEquals(unrelatedGetterCalls, 0);
+    assertEquals(unrelatedReads, 0);
   });
 
-  it("captures exclusive-create authority without inspecting unrelated readers", async () => {
-    let unrelatedGetterCalls = 0;
-    let createdPath = "";
+  it("quarantines malformed legacy fields independently for a proven snapshot adapter", async () => {
+    let ceilingGetterCalls = 0;
+    let exactApplyCalls = 0;
+    let writeCalls = 0;
     const adapter = {
-      createFileBytesExclusive(path: string) {
-        createdPath = path;
+      readFileBytes: () => Promise.resolve(new Uint8Array([1])),
+      readFileBytesBounded: () => Promise.resolve(new Uint8Array([2])),
+      readFileBytesWithinLimit: new Proxy(function () {}, {
+        apply() {
+          exactApplyCalls++;
+          throw new Error("must not run");
+        },
+      }),
+      writeFileBytes: () => {
+        writeCalls++;
         return Promise.resolve();
       },
     };
     Object.defineProperty(adapter, "maxWholeFileReadBytes", {
       get() {
-        unrelatedGetterCalls++;
+        ceilingGetterCalls++;
+        throw new Error("must not run");
+      },
+    });
+
+    const captured = captureLegacyFileSystemCapabilitiesForSnapshot(adapter);
+
+    assertFrozenNullRecord(captured);
+    assertEquals([...(await captured.readFileBytes!("/a"))], [1]);
+    assertEquals([...(await captured.readFileBytesBounded!("/a", 1))], [2]);
+    await captured.writeFileBytes!("/a", new Uint8Array([3]));
+    assertEquals(captured.readFileBytesWithinLimit, undefined);
+    assertEquals(captured.wholeFileReader, undefined);
+    assertEquals({ ceilingGetterCalls, exactApplyCalls, writeCalls }, {
+      ceilingGetterCalls: 0,
+      exactApplyCalls: 0,
+      writeCalls: 1,
+    });
+  });
+
+  it("still rejects unsafe capability provenance for a proven snapshot adapter", () => {
+    let trapCalls = 0;
+    const hostilePrototype = new Proxy({}, {
+      getOwnPropertyDescriptor() {
+        trapCalls++;
+        throw new Error("must not run");
+      },
+      getPrototypeOf() {
+        trapCalls++;
+        throw new Error("must not run");
+      },
+    });
+    const adapter = Object.setPrototypeOf({}, hostilePrototype);
+
+    assertThrows(
+      () => captureLegacyFileSystemCapabilitiesForSnapshot(adapter),
+      TypeError,
+      "Proxy",
+    );
+    assertEquals(trapCalls, 0);
+  });
+
+  it("captures exclusive-create authority without inspecting unrelated reader fields", async () => {
+    let unrelatedReads = 0;
+    let created = "";
+    const adapter = {
+      createFileBytesExclusive(path: string) {
+        created = path;
+        return Promise.resolve();
+      },
+      readFileSnapshotWithinLimit: new Proxy(function () {}, {}),
+    };
+    Object.defineProperty(adapter, "readFileBytesWithinLimit", {
+      get() {
+        unrelatedReads++;
         throw new Error("must not run");
       },
     });
 
     const captured = captureExclusiveCreateCapability(adapter)!;
+
     assertFrozenNullRecord(captured);
     await captured.create("/root/new", new Uint8Array([1]));
-    assertEquals(createdPath, "/root/new");
-    assertEquals(unrelatedGetterCalls, 0);
+    assertEquals(created, "/root/new");
+    assertEquals(unrelatedReads, 0);
   });
 
-  it("freezes ordinary reader authority and receiver identity at capture time", async () => {
-    let receiverMatches = false;
-    const adapter = {
-      maxWholeFileReadBytes: 4,
-      readFileBytes(path: string) {
-        receiverMatches = this === adapter;
-        return Promise.resolve(new Uint8Array([path.length]));
-      },
-      readFileBytesWithinLimit(_path: string, maximumBytes: number) {
-        return Promise.resolve(new Uint8Array([maximumBytes]));
-      },
-    };
-    const captured = captureByteReadCapabilities(adapter);
-    adapter.readFileBytes = () => Promise.resolve(new Uint8Array([9]));
-    adapter.readFileBytesWithinLimit = () => Promise.resolve(new Uint8Array([9]));
-
-    assertFrozenNullRecord(captured);
-    assertFrozenNullRecord(captured.whole!);
-    assertEquals([...(await captured.unbounded!("/a"))], [2]);
-    assertEquals([...(await captured.whole!.read("/a"))], [2]);
-    assertEquals([...(await captured.exact!("/a", 3))], [3]);
-    assertEquals(receiverMatches, true);
-  });
-
-  it("rejects malformed selected data properties without invoking accessors", () => {
-    let getterCalls = 0;
-    const adapter = {};
-    Object.defineProperty(adapter, "readFileBytesWithinLimit", {
-      get() {
-        getterCalls++;
-        return () => Promise.resolve(new Uint8Array());
-      },
-    });
-
+  it("returns undefined only when a single-purpose raw method is absent", () => {
+    assertEquals(captureSnapshotReadCapability({}), undefined);
+    assertEquals(captureExclusiveCreateCapability({}), undefined);
     assertThrows(
-      () => captureByteReadCapabilities(adapter),
+      () => captureSnapshotReadCapability({ readFileSnapshotWithinLimit: undefined }),
       TypeError,
-      "must be a data property",
+      "readFileSnapshotWithinLimit must be a non-Proxy function",
     );
-    assertEquals(getterCalls, 0);
     assertThrows(
-      () => captureByteReadCapabilities({ maxWholeFileReadBytes: 4 }),
+      () => captureExclusiveCreateCapability({ createFileBytesExclusive: undefined }),
       TypeError,
-      "requires readFileBytes",
+      "createFileBytesExclusive must be a non-Proxy function",
+    );
+    assertThrows(
+      () => captureSnapshotReadCapability({ readFileSnapshotWithinLimit: 1 }),
+      TypeError,
+      "readFileSnapshotWithinLimit must be a non-Proxy function",
+    );
+    assertThrows(
+      () => captureExclusiveCreateCapability({ createFileBytesExclusive: 1 }),
+      TypeError,
+      "createFileBytesExclusive must be a non-Proxy function",
     );
   });
 
-  it("keeps proven snapshot authority when malformed ordinary readers are quarantined", async () => {
-    let getterCalls = 0;
-    const adapter = {
-      symlinkSemantics: "none" as const,
-      readFileSnapshotWithinLimit: () => Promise.resolve(new Uint8Array([1])),
-      getSourceSnapshotVersion: () => 1,
-    };
-    Object.defineProperty(adapter, "readFileBytesWithinLimit", {
-      get() {
-        getterCalls++;
+  it("rejects direct Proxy capability objects and selected Proxy functions", () => {
+    let trapCalls = 0;
+    const adapter = new Proxy({}, {
+      getOwnPropertyDescriptor() {
+        trapCalls++;
+        throw new Error("must not run");
+      },
+      getPrototypeOf() {
+        trapCalls++;
         throw new Error("must not run");
       },
     });
 
-    const captured = captureStaticReadCapabilities(adapter);
-    assertEquals(captured.virtual, undefined);
-    assertEquals([...(await captured.snapshot!.read("/root/a", "/root", 1))], [1]);
-    assertEquals(getterCalls, 0);
-  });
-
-  it("requires an own data marker before inspecting virtual authority", () => {
-    let getterCalls = 0;
-    const withoutMarker = {
-      getSourceSnapshotVersion: () => 1,
-    };
-    Object.defineProperty(withoutMarker, "readFileBytesWithinLimit", {
-      get() {
-        getterCalls++;
-        throw new Error("must not run");
-      },
-    });
-    assertEquals(captureStaticReadCapabilities(withoutMarker).virtual, undefined);
-    assertEquals(getterCalls, 0);
-
-    const inheritedMarker = Object.create({ symlinkSemantics: "none" }) as Record<
-      string,
-      unknown
-    >;
-    inheritedMarker.getSourceSnapshotVersion = () => 1;
-    inheritedMarker.readFileBytesWithinLimit = () => Promise.resolve(new Uint8Array());
-    assertEquals(captureStaticReadCapabilities(inheritedMarker).virtual, undefined);
-  });
-
-  it("captures snapshot and virtual generation records independently", async () => {
-    const adapter = {
-      symlinkSemantics: "none" as const,
-      readFileSnapshotWithinLimit: () => Promise.resolve(new Uint8Array([1])),
-      getSourceSnapshotVersion: () => 7,
-      readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array([2])),
-      readFileBytes: () => Promise.resolve(new Uint8Array([3])),
-      maxWholeFileReadBytes: 4,
-    };
-    const captured = captureStaticReadCapabilities(adapter);
-
-    assertFrozenNullRecord(captured);
-    assertFrozenNullRecord(captured.snapshot!);
-    assertFrozenNullRecord(captured.virtual!);
-    assertFrozenNullRecord(captured.virtual!.whole!);
-    assertEquals(await captured.virtual!.generation(), 7);
-    assertEquals([...(await captured.virtual!.exact!("/a", 2))], [2]);
-    assertEquals([...(await captured.virtual!.whole!.read("/b"))], [3]);
-  });
-
-  it("validates every virtual generation at the authority boundary", async () => {
-    let generation: unknown = 0;
-    const captured = captureStaticReadCapabilities({
-      symlinkSemantics: "none",
-      getSourceSnapshotVersion: () => generation,
-      readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array()),
-    });
-
-    assertEquals(await captured.virtual!.generation(), 0);
-    generation = 1;
-    assertEquals(await captured.virtual!.generation(), 1);
-    for (const invalid of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1, undefined, "1"]) {
-      generation = invalid;
-      await assertRejects(() => captured.virtual!.generation(), RangeError);
-    }
+    assertThrows(() => captureSnapshotReadCapability(adapter), TypeError, "non-Proxy object");
+    assertEquals(trapCalls, 0);
+    assertThrows(
+      () =>
+        captureSnapshotReadCapability({
+          readFileSnapshotWithinLimit: new Proxy(function () {}, {}),
+        }),
+      TypeError,
+      "non-Proxy function",
+    );
   });
 
   it("ignores local and foreign terminal Object.prototype capabilities", () => {
-    const prior = Object.getOwnPropertyDescriptor(
+    const localDescriptor = Object.getOwnPropertyDescriptor(
       Object.prototype,
       "readFileSnapshotWithinLimit",
     );
@@ -196,53 +276,57 @@ describe("filesystem capability capture", () => {
     try {
       assertEquals(captureSnapshotReadCapability({}), undefined);
     } finally {
-      if (prior === undefined) {
+      if (localDescriptor === undefined) {
         Reflect.deleteProperty(Object.prototype, "readFileSnapshotWithinLimit");
       } else {
-        Object.defineProperty(Object.prototype, "readFileSnapshotWithinLimit", prior);
+        Object.defineProperty(
+          Object.prototype,
+          "readFileSnapshotWithinLimit",
+          localDescriptor,
+        );
       }
     }
 
     const foreign = runInNewContext(`
-      Object.prototype.readFileSnapshotWithinLimit = () => Promise.resolve(new Uint8Array([1]));
+      Object.prototype.readFileSnapshotWithinLimit = function () {
+        return Promise.resolve(new Uint8Array([1]));
+      };
       ({});
     `) as object;
     assertEquals(captureSnapshotReadCapability(foreign), undefined);
   });
 
-  it("bounds hostile prototype traversal and captures Proxy authority only once", async () => {
-    let deep = Object.create(null) as object;
-    for (let depth = 0; depth < 65; depth++) deep = Object.create(deep) as object;
+  it("rejects a 65-level capability prototype chain", () => {
+    let adapter = Object.create(null) as object;
+    for (let depth = 0; depth < 65; depth++) adapter = Object.create(adapter) as object;
+
     assertThrows(
-      () => captureSnapshotReadCapability(deep),
+      () => captureSnapshotReadCapability(adapter),
       TypeError,
       "prototype chain is too deep",
     );
-
-    let traps = 0;
-    const proxied = new Proxy(
-      {
-        readFileSnapshotWithinLimit: () => Promise.resolve(new Uint8Array([4])),
-      },
-      {
-        getOwnPropertyDescriptor(target, property) {
-          traps++;
-          return Reflect.getOwnPropertyDescriptor(target, property);
-        },
-        getPrototypeOf(target) {
-          traps++;
-          return Reflect.getPrototypeOf(target);
-        },
-      },
-    );
-    const captured = captureSnapshotReadCapability(proxied)!;
-    const captureTrapCount = traps;
-    assertEquals(captureTrapCount > 0, true);
-    assertEquals([...(await captured.read("/a", "/", 1))], [4]);
-    assertEquals(traps, captureTrapCount);
   });
 
-  it("copies subclassed and cross-realm byte results into tight fixed arrays", async () => {
+  it("keeps captured methods bound to the exact original adapter after mutation", async () => {
+    let receiverMatches = false;
+    const adapter = {
+      readFileSnapshotWithinLimit(
+        path: string,
+        containmentRoot: string,
+        byteLimit: number,
+      ) {
+        receiverMatches = this === adapter;
+        return Promise.resolve(new Uint8Array([path.length, containmentRoot.length, byteLimit]));
+      },
+    };
+    const captured = captureSnapshotReadCapability(adapter)!;
+    adapter.readFileSnapshotWithinLimit = () => Promise.resolve(new Uint8Array([9]));
+
+    assertEquals([...(await captured.read("/a", "/", 3))], [2, 1, 3]);
+    assertEquals(receiverMatches, true);
+  });
+
+  it("copies subclassed and cross-realm snapshot byte results into tight fixed arrays", async () => {
     class Bytes extends Uint8Array {}
     const subclassed = new Bytes([8, 1, 2, 9]);
     const foreign = runInNewContext("new Uint8Array([3, 4])") as Uint8Array;
@@ -266,41 +350,63 @@ describe("filesystem capability capture", () => {
     assertEquals(second.buffer.byteLength, 2);
   });
 
-  it("rejects mutable shared or resizable byte storage", async () => {
+  it("rejects SharedArrayBuffer-backed and resizable snapshot results", async () => {
     let result: Uint8Array = new Uint8Array(new SharedArrayBuffer(2));
     const captured = captureSnapshotReadCapability({
       readFileSnapshotWithinLimit: () => Promise.resolve(result),
     })!;
+
     await assertRejects(
       () => captured.read("/root/a", "/root", 2),
       TypeError,
       "fixed ArrayBuffer",
     );
 
-    if (Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "resizable")?.get) {
-      const ResizableArrayBuffer = ArrayBuffer as unknown as new (
-        byteLength: number,
-        options: { maxByteLength: number },
-      ) => ArrayBuffer;
-      result = new Uint8Array(new ResizableArrayBuffer(2, { maxByteLength: 4 }));
-      await assertRejects(
-        () => captured.read("/root/a", "/root", 2),
-        TypeError,
-        "fixed ArrayBuffer",
-      );
-    }
+    const ResizableArrayBuffer = ArrayBuffer as unknown as new (
+      byteLength: number,
+      options: { maxByteLength: number },
+    ) => ArrayBuffer;
+    result = new Uint8Array(new ResizableArrayBuffer(2, { maxByteLength: 4 }));
+    await assertRejects(
+      () => captured.read("/root/a", "/root", 2),
+      TypeError,
+      "fixed ArrayBuffer",
+    );
   });
 
-  it("copies bytes without consulting poisoned view properties or species", async () => {
+  it("copies snapshot bytes without consulting poisoned view properties or species", async () => {
     class PoisonedBytes extends Uint8Array {}
     Object.defineProperties(PoisonedBytes.prototype, {
-      buffer: { get: () => Promise.reject(new Error("poisoned buffer")) },
-      byteLength: { get: () => Promise.reject(new Error("poisoned length")) },
-      byteOffset: { get: () => Promise.reject(new Error("poisoned offset")) },
-      [Symbol.toStringTag]: { get: () => Promise.reject(new Error("poisoned tag")) },
+      buffer: {
+        get: () => {
+          throw new Error("poisoned buffer");
+        },
+      },
+      byteLength: {
+        get: () => {
+          throw new Error("poisoned byteLength");
+        },
+      },
+      byteOffset: {
+        get: () => {
+          throw new Error("poisoned byteOffset");
+        },
+      },
+      length: {
+        get: () => {
+          throw new Error("poisoned length");
+        },
+      },
+      [Symbol.toStringTag]: {
+        get: () => {
+          throw new Error("poisoned tag");
+        },
+      },
     });
     Object.defineProperty(PoisonedBytes, Symbol.species, {
-      get: () => Promise.reject(new Error("poisoned species")),
+      get: () => {
+        throw new Error("poisoned species");
+      },
     });
     const bytes = new PoisonedBytes([5, 6]);
     const captured = captureSnapshotReadCapability({
@@ -310,7 +416,7 @@ describe("filesystem capability capture", () => {
     assertEquals([...(await captured.read("/root/a", "/root", 2))], [5, 6]);
   });
 
-  it("snapshots exclusive-create input before asynchronous observation", async () => {
+  it("snapshots exclusive-create input before the raw creator can observe mutation", async () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
@@ -328,6 +434,111 @@ describe("filesystem capability capture", () => {
     source[0] = 9;
     release();
     await pending;
+
     assertEquals(observed, [1, 2]);
+  });
+
+  it("captures snapshot and virtual records independently", async () => {
+    const adapter = {
+      symlinkSemantics: "none" as const,
+      readFileSnapshotWithinLimit: () => Promise.resolve(new Uint8Array([1])),
+      getSourceSnapshotVersion: () => 7,
+      readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array([2])),
+      readFileBytes: () => Promise.resolve(new Uint8Array([3])),
+      maxWholeFileReadBytes: 4,
+    };
+    const captured = captureStaticReadCapabilities(adapter);
+
+    assertFrozenNullRecord(captured);
+    assertFrozenNullRecord(captured.snapshot!);
+    assertFrozenNullRecord(captured.virtual!);
+    assertFrozenNullRecord(captured.virtual!.whole!);
+    assertEquals(await captured.virtual!.generation(), 7);
+    assertEquals([...(await captured.virtual!.exact!("/a", 1))], [2]);
+    assertEquals([...(await captured.virtual!.whole!.read("/b"))], [3]);
+    assertEquals(captured.virtual!.whole!.maximumBytes, 4);
+  });
+
+  it("does not inspect virtual readers unless the own-data virtual gate is established", async () => {
+    let unrelatedReads = 0;
+    const adapter = {
+      readFileSnapshotWithinLimit: () => Promise.resolve(new Uint8Array([1])),
+      getSourceSnapshotVersion: () => 1,
+    };
+    Object.defineProperty(adapter, "maxWholeFileReadBytes", {
+      get() {
+        unrelatedReads++;
+        throw new Error("must not run");
+      },
+    });
+    const captured = captureStaticReadCapabilities(adapter);
+
+    assertEquals(captured.virtual, undefined);
+    assertEquals([...(await captured.snapshot!.read("/root/a", "/root", 1))], [1]);
+    assertEquals(unrelatedReads, 0);
+
+    const inheritedMarker = Object.create({ symlinkSemantics: "none" }) as Record<string, unknown>;
+    inheritedMarker.getSourceSnapshotVersion = () => 1;
+    inheritedMarker.readFileBytesWithinLimit = () => Promise.resolve(new Uint8Array());
+    assertEquals(captureStaticReadCapabilities(inheritedMarker).virtual, undefined);
+  });
+
+  it("fails closed on malformed selected virtual fields", () => {
+    const accessorAdapter = { symlinkSemantics: "none" };
+    Object.defineProperty(accessorAdapter, "getSourceSnapshotVersion", {
+      get() {
+        throw new Error("must not run");
+      },
+    });
+    assertThrows(
+      () => captureStaticReadCapabilities(accessorAdapter),
+      TypeError,
+      "getSourceSnapshotVersion must be a data-property method",
+    );
+
+    assertThrows(
+      () =>
+        captureStaticReadCapabilities({
+          symlinkSemantics: "none",
+          getSourceSnapshotVersion: new Proxy(function () {}, {}),
+        }),
+      TypeError,
+      "getSourceSnapshotVersion must be a non-Proxy function",
+    );
+
+    const readerAccessor = {
+      symlinkSemantics: "none" as const,
+      getSourceSnapshotVersion: () => 1,
+    };
+    Object.defineProperty(readerAccessor, "readFileBytesWithinLimit", {
+      get() {
+        throw new Error("must not run");
+      },
+    });
+    assertThrows(
+      () => captureStaticReadCapabilities(readerAccessor),
+      TypeError,
+      "readFileBytesWithinLimit must be a data-property method",
+    );
+  });
+
+  it("validates every virtual generation result as a non-negative safe integer", async () => {
+    let generation: unknown = 0;
+    const captured = captureStaticReadCapabilities({
+      symlinkSemantics: "none",
+      getSourceSnapshotVersion: () => generation,
+    });
+
+    assertEquals(await captured.virtual!.generation(), 0);
+    generation = 1;
+    assertEquals(await captured.virtual!.generation(), 1);
+    for (const invalid of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1, undefined, "1"]) {
+      generation = invalid;
+      await assertRejects(
+        () => captured.virtual!.generation(),
+        TypeError,
+        "non-negative safe integer",
+      );
+    }
   });
 });

--- a/src/platform/adapters/file-system-capabilities.test.ts
+++ b/src/platform/adapters/file-system-capabilities.test.ts
@@ -105,6 +105,19 @@ describe("platform/adapters/file-system-capabilities", () => {
     await assertRejects(() => captured.exact!("/a", 0), RangeError, "positive safe integer");
   });
 
+  it("separates size overflow from malformed result types", () => {
+    assertThrows(
+      () => capabilityModule.copyFixedUint8ArrayWithinLimit(new Uint8Array(3), 2, "Payload"),
+      RangeError,
+      "Payload exceeds 2 bytes",
+    );
+    assertThrows(
+      () => capabilityModule.copyFixedUint8ArrayWithinLimit("not bytes", 2, "Payload"),
+      TypeError,
+      "Payload reader returned invalid bytes",
+    );
+  });
+
   it("captures byte readers without inspecting an unrelated malformed writer", async () => {
     const captured = captureByteReadCapabilities({
       readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array([4])),

--- a/src/platform/adapters/file-system-capabilities.test.ts
+++ b/src/platform/adapters/file-system-capabilities.test.ts
@@ -105,6 +105,15 @@ describe("platform/adapters/file-system-capabilities", () => {
     await assertRejects(() => captured.exact!("/a", 0), RangeError, "positive safe integer");
   });
 
+  it("captures byte readers without inspecting an unrelated malformed writer", async () => {
+    const captured = captureByteReadCapabilities({
+      readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array([4])),
+      writeFileBytes: new Proxy(function () {}, {}),
+    });
+
+    assertEquals([...(await captured.exact!("/a", 1))], [4]);
+  });
+
   it("captures snapshot authority without inspecting unrelated writer fields", async () => {
     let unrelatedReads = 0;
     const adapter = {
@@ -522,11 +531,20 @@ describe("platform/adapters/file-system-capabilities", () => {
     );
   });
 
+  it("does not publish virtual authority without an admissible bounded reader", () => {
+    const captured = captureStaticReadCapabilities({
+      symlinkSemantics: "none",
+      getSourceSnapshotVersion: () => 0,
+    });
+    assertEquals(captured.virtual, undefined);
+  });
+
   it("validates every virtual generation result as a non-negative safe integer", async () => {
     let generation: unknown = 0;
     const captured = captureStaticReadCapabilities({
       symlinkSemantics: "none",
       getSourceSnapshotVersion: () => generation,
+      readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array()),
     });
 
     assertEquals(await captured.virtual!.generation(), 0);

--- a/src/platform/adapters/file-system-capabilities.ts
+++ b/src/platform/adapters/file-system-capabilities.ts
@@ -290,8 +290,11 @@ export function copyFixedUint8ArrayWithinLimit(
   if (byteLength === undefined) {
     throw new TypeError(`${label} reader returned invalid bytes`);
   }
+  // Size overflow is a RangeError across the bounded-read surface; a malformed
+  // or dishonest result type stays a TypeError. Boundaries that present a
+  // different class to their own callers normalize this cause themselves.
   if (byteLength > maximumBytes) {
-    throw new TypeError(`${label} exceeds ${maximumBytes} bytes`);
+    throw new RangeError(`${label} exceeds ${maximumBytes} bytes`);
   }
 
   let buffer: unknown;

--- a/src/platform/adapters/file-system-capabilities.ts
+++ b/src/platform/adapters/file-system-capabilities.ts
@@ -56,6 +56,12 @@ const BOUNDED_TEXT_CAPABILITY_KEYS = [
   "readFileBytesWithinLimit",
   "maxWholeFileReadBytes",
 ] as const;
+const BYTE_READ_CAPABILITY_KEYS = [
+  "readFileBytes",
+  "readFileBytesBounded",
+  "readFileBytesWithinLimit",
+  "maxWholeFileReadBytes",
+] as const;
 const SNAPSHOT_CAPABILITY_KEYS = ["readFileSnapshotWithinLimit"] as const;
 const EXCLUSIVE_CREATE_CAPABILITY_KEYS = ["createFileBytesExclusive"] as const;
 const GENERATION_CAPABILITY_KEYS = ["getSourceSnapshotVersion"] as const;
@@ -443,10 +449,14 @@ function captureWholeFileReader(
 export function captureFileSystemCapabilities(
   value: unknown,
   label = "Filesystem",
-  purpose: "legacy" | "bounded-text" = "legacy",
+  purpose: "legacy" | "bounded-text" | "byte-read" = "legacy",
 ): CapturedFileSystemCapabilities {
   requireCapabilityObject(value, label);
-  const keys = purpose === "bounded-text" ? BOUNDED_TEXT_CAPABILITY_KEYS : LEGACY_CAPABILITY_KEYS;
+  const keys = purpose === "bounded-text"
+    ? BOUNDED_TEXT_CAPABILITY_KEYS
+    : purpose === "byte-read"
+    ? BYTE_READ_CAPABILITY_KEYS
+    : LEGACY_CAPABILITY_KEYS;
   const properties = captureDataProperties(value, label, keys);
   const rawReadFileBytes = requireOptionalMethod<ByteReader>(
     properties.readFileBytes,
@@ -465,7 +475,7 @@ export function captureFileSystemCapabilities(
     label,
     "readFileBytesWithinLimit",
   );
-  const rawWriter = purpose === "bounded-text" ? undefined : requireOptionalMethod<ByteWriter>(
+  const rawWriter = purpose !== "legacy" ? undefined : requireOptionalMethod<ByteWriter>(
     properties.writeFileBytes,
     label,
     "writeFileBytes",
@@ -508,7 +518,7 @@ export function captureByteReadCapabilities(
   value: unknown,
   label = "Filesystem",
 ): CapturedByteReaders {
-  const capabilities = captureFileSystemCapabilities(value, label);
+  const capabilities = captureFileSystemCapabilities(value, label, "byte-read");
   const captured = createObject(null) as {
     unbounded?: ByteReader;
     whole?: CapturedWholeFileReader;
@@ -743,6 +753,9 @@ export function captureStaticReadCapabilities(
     };
   }
   if (whole !== undefined) virtual.whole = whole;
+  if (virtual.exact === undefined && virtual.whole === undefined) {
+    return freezeObject(captured);
+  }
   captured.virtual = freezeObject(virtual);
   return freezeObject(captured);
 }

--- a/src/platform/adapters/file-system-capabilities.ts
+++ b/src/platform/adapters/file-system-capabilities.ts
@@ -1,11 +1,14 @@
+import { isProxyWithoutHooks } from "../compat/error-introspection.ts";
+
 const apply = Reflect.apply;
-const createObject = Object.create;
-const freezeObject = Object.freeze;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const getPrototypeOf = Object.getPrototypeOf;
-const hasOwnProperty = Object.prototype.hasOwnProperty;
+const objectHasOwnProperty = Object.prototype.hasOwnProperty;
+const createObject = Object.create;
+const freezeObject = Object.freeze;
 const isArray = Array.isArray;
 const numberIsSafeInteger = Number.isSafeInteger;
+const universalObjectPrototype = Object.prototype;
 const NativeUint8Array = Uint8Array;
 const typedArrayPrototype = getPrototypeOf(NativeUint8Array.prototype);
 const typedArrayBufferGetter = requireIntrinsicGetter(
@@ -31,50 +34,79 @@ const typedArrayNameGetter = requireIntrinsicGetter(
 const arrayBufferByteLengthGetter = requireIntrinsicGetter(
   ArrayBuffer.prototype,
   "byteLength",
-  "ArrayBuffer byte length",
+  "ArrayBuffer byteLength",
 );
 const arrayBufferResizableGetter = getOwnPropertyDescriptor(
   ArrayBuffer.prototype,
   "resizable",
 )?.get;
 const setBytes = NativeUint8Array.prototype.set;
+const ABSENT_CAPABILITY = Symbol("absent filesystem capability");
+const INVALID_CAPABILITY = Symbol("invalid filesystem capability");
 
-const MAX_CAPABILITY_PROTOTYPE_DEPTH = 64;
-const universalObjectPrototype = Object.prototype;
+const LEGACY_CAPABILITY_KEYS = [
+  "readFileBytes",
+  "readFileBytesBounded",
+  "readFileBytesWithinLimit",
+  "writeFileBytes",
+  "maxWholeFileReadBytes",
+] as const;
+const BOUNDED_TEXT_CAPABILITY_KEYS = [
+  "readFileBytes",
+  "readFileBytesWithinLimit",
+  "maxWholeFileReadBytes",
+] as const;
+const SNAPSHOT_CAPABILITY_KEYS = ["readFileSnapshotWithinLimit"] as const;
+const EXCLUSIVE_CREATE_CAPABILITY_KEYS = ["createFileBytesExclusive"] as const;
+const GENERATION_CAPABILITY_KEYS = ["getSourceSnapshotVersion"] as const;
+const VIRTUAL_READ_CAPABILITY_KEYS = [
+  "readFileBytes",
+  "readFileBytesWithinLimit",
+  "maxWholeFileReadBytes",
+] as const;
 
+type CapabilityKey =
+  | (typeof LEGACY_CAPABILITY_KEYS)[number]
+  | (typeof SNAPSHOT_CAPABILITY_KEYS)[number]
+  | (typeof EXCLUSIVE_CREATE_CAPABILITY_KEYS)[number]
+  | (typeof GENERATION_CAPABILITY_KEYS)[number];
 type ByteReader = (path: string) => Promise<Uint8Array>;
-type LimitedByteReader = (path: string, byteLimit: number) => Promise<Uint8Array>;
+type BoundedByteReader = (path: string, byteLimit: number) => Promise<Uint8Array>;
 type SnapshotByteReader = (
   path: string,
   containmentRoot: string,
   byteLimit: number,
 ) => Promise<Uint8Array>;
 type ByteWriter = (path: string, content: Uint8Array) => Promise<void>;
-type GenerationReader = () => number | undefined | Promise<number | undefined>;
-
-type CapabilityKey =
-  | "readFileBytes"
-  | "readFileBytesBounded"
-  | "readFileBytesWithinLimit"
-  | "readFileSnapshotWithinLimit"
-  | "createFileBytesExclusive"
-  | "maxWholeFileReadBytes"
-  | "getSourceSnapshotVersion";
+type SnapshotVersionReader = () => number | undefined | Promise<number | undefined>;
 
 export interface CapturedWholeFileReader {
   readonly maximumBytes: number;
-  read(path: string): Promise<Uint8Array>;
+  readonly read: ByteReader;
 }
 
+export interface CapturedFileSystemCapabilities {
+  readonly readFileBytes?: ByteReader;
+  readonly readFileBytesBounded?: BoundedByteReader;
+  readonly readFileBytesWithinLimit?: BoundedByteReader;
+  readonly writeFileBytes?: ByteWriter;
+  readonly wholeFileReader?: CapturedWholeFileReader;
+}
+
+/** Compatibility view used by existing filesystem wrappers and adapters. */
 export interface CapturedByteReaders {
-  readonly unbounded?: (path: string) => Promise<Uint8Array>;
+  readonly unbounded?: ByteReader;
   readonly whole?: CapturedWholeFileReader;
-  readonly prefix?: LimitedByteReader;
-  readonly exact?: LimitedByteReader;
+  readonly prefix?: BoundedByteReader;
+  readonly exact?: BoundedByteReader;
 }
 
 export interface CapturedSnapshotReader {
-  read(path: string, containmentRoot: string, byteLimit: number): Promise<Uint8Array>;
+  read(
+    path: string,
+    containmentRoot: string,
+    byteLimit: number,
+  ): Promise<Uint8Array>;
 }
 
 export interface CapturedExclusiveCreator {
@@ -82,54 +114,70 @@ export interface CapturedExclusiveCreator {
 }
 
 export interface CapturedStaticReaders {
-  readonly snapshot?: CapturedSnapshotReader;
-  readonly virtual?: {
+  snapshot?: CapturedSnapshotReader;
+  virtual?: {
     generation(): Promise<number>;
-    readonly exact?: LimitedByteReader;
-    readonly whole?: CapturedWholeFileReader;
+    exact?: (path: string, byteLimit: number) => Promise<Uint8Array>;
+    whole?: { maximumBytes: number; read(path: string): Promise<Uint8Array> };
   };
 }
 
 function hasOwn(value: object, key: PropertyKey): boolean {
-  return apply(hasOwnProperty, value, [key]) as boolean;
+  return apply(objectHasOwnProperty, value, [key]) as boolean;
 }
 
 function requireIntrinsicGetter(
   target: object,
   property: PropertyKey,
-  label: string,
+  name: string,
 ): (this: object) => unknown {
   const descriptor = getOwnPropertyDescriptor(target, property);
-  const getter = descriptor && hasOwn(descriptor, "get") ? descriptor.get : undefined;
+  const getter = descriptor !== undefined && hasOwn(descriptor, "get") ? descriptor.get : undefined;
   if (typeof getter !== "function") {
-    throw new TypeError(`Required ${label} intrinsic is unavailable`);
+    throw new TypeError(`Required ${name} intrinsic is unavailable`);
   }
   return getter;
 }
 
+function invalidCapability(label: string, detail: string, cause?: unknown): TypeError {
+  return cause === undefined
+    ? new TypeError(`${label} ${detail}`)
+    : new TypeError(`${label} ${detail}`, { cause });
+}
+
 function requireCapabilityObject(value: unknown, label: string): asserts value is object {
-  if (typeof value !== "object" || value === null || isArray(value)) {
-    throw new TypeError(`${label} must be a non-array object`);
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    isProxyWithoutHooks(value) ||
+    isArray(value)
+  ) {
+    throw invalidCapability(label, "must be a non-Proxy object");
   }
 }
 
 function captureDataProperties(
   value: object,
-  keys: readonly CapabilityKey[],
   label: string,
-): Readonly<Partial<Record<CapabilityKey, unknown>>> {
-  const result = createObject(null) as Partial<Record<CapabilityKey, unknown>>;
-  const unresolved = new Set<CapabilityKey>(keys);
-  const seen = new Set<object>();
+  keys: readonly CapabilityKey[],
+  invalidFieldPolicy: "reject" | "quarantine" = "reject",
+): Readonly<Record<CapabilityKey, unknown>> {
+  const properties = createObject(null) as Record<CapabilityKey, unknown>;
+  const resolved = createObject(null) as Record<CapabilityKey, boolean>;
+  let remaining = keys.length;
   let owner: object | null = value;
+  const seen = new Set<object>();
 
-  for (let depth = 0; owner !== null && depth < MAX_CAPABILITY_PROTOTYPE_DEPTH; depth++) {
+  for (let depth = 0; owner !== null && depth < 64; depth++) {
     if (owner === universalObjectPrototype) {
       owner = null;
       break;
     }
+    if (isProxyWithoutHooks(owner)) {
+      throw invalidCapability(label, "capabilities must not use a Proxy");
+    }
     if (seen.has(owner)) {
-      throw new TypeError(`${label} has an invalid capability prototype chain`);
+      throw invalidCapability(label, "capabilities have an invalid prototype chain");
     }
     seen.add(owner);
 
@@ -137,64 +185,76 @@ function captureDataProperties(
     try {
       parent = getPrototypeOf(owner);
     } catch (cause) {
-      throw new TypeError(`${label} capabilities could not be inspected safely`, { cause });
+      throw invalidCapability(label, "capabilities could not be inspected safely", cause);
     }
-    // Do not treat a foreign realm's terminal Object.prototype as authority.
+    // A foreign realm's Object.prototype is identified by its terminal
+    // position rather than by local identity and is never adapter authority.
     if (owner !== value && parent === null) {
       owner = null;
       break;
     }
 
-    for (const key of unresolved) {
+    for (let index = 0; index < keys.length; index++) {
+      const key = keys[index]!;
+      if (resolved[key]) continue;
       let descriptor: PropertyDescriptor | undefined;
       try {
         descriptor = getOwnPropertyDescriptor(owner, key);
       } catch (cause) {
-        throw new TypeError(`${label} capabilities could not be inspected safely`, { cause });
+        throw invalidCapability(label, "capabilities could not be inspected safely", cause);
       }
       if (descriptor === undefined) continue;
-      unresolved.delete(key);
+      resolved[key] = true;
+      remaining--;
       if (!hasOwn(descriptor, "value")) {
-        throw new TypeError(`${label} ${key} must be a data property`);
+        if (invalidFieldPolicy === "reject") {
+          throw invalidCapability(
+            label,
+            key === "maxWholeFileReadBytes"
+              ? `${key} must be a data property`
+              : `${key} must be a data-property method`,
+          );
+        }
+        properties[key] = INVALID_CAPABILITY;
+        continue;
       }
-      result[key] = descriptor.value;
+      properties[key] = descriptor.value;
     }
-    if (unresolved.size === 0) {
+
+    if (remaining === 0) {
       owner = null;
       break;
     }
     owner = parent;
   }
 
-  if (owner !== null && unresolved.size > 0) {
-    throw new TypeError(`${label} capability prototype chain is too deep`);
+  if (owner !== null && remaining > 0) {
+    throw invalidCapability(label, "capability prototype chain is too deep");
   }
-  return freezeObject(result);
+  for (let index = 0; index < keys.length; index++) {
+    const key = keys[index]!;
+    if (!resolved[key]) properties[key] = ABSENT_CAPABILITY;
+  }
+  return freezeObject(properties);
 }
 
-function optionalMethod<T>(candidate: unknown, label: string, key: string): T | undefined {
-  if (candidate === undefined) return undefined;
-  if (typeof candidate !== "function") {
-    throw new TypeError(`${label} ${key} must be a function`);
+function requireOptionalMethod<T>(
+  candidate: unknown,
+  label: string,
+  key: CapabilityKey,
+  allowExplicitUndefined = true,
+): T | undefined {
+  if (
+    candidate === ABSENT_CAPABILITY ||
+    (allowExplicitUndefined && candidate === undefined)
+  ) return undefined;
+  if (typeof candidate !== "function" || isProxyWithoutHooks(candidate)) {
+    throw invalidCapability(label, `${key} must be a non-Proxy function`);
   }
   return candidate as T;
 }
 
-function positiveSafeInteger(value: unknown, label: string): number {
-  if (!numberIsSafeInteger(value) || (value as number) <= 0) {
-    throw new RangeError(`${label} must be a positive safe integer`);
-  }
-  return value as number;
-}
-
-function nonNegativeSafeInteger(value: unknown, label: string): number {
-  if (!numberIsSafeInteger(value) || (value as number) < 0) {
-    throw new RangeError(`${label} must be a non-negative safe integer`);
-  }
-  return value as number;
-}
-
-function uint8ArrayByteLength(value: unknown): number | undefined {
+function getUint8ArrayByteLength(value: unknown): number | undefined {
   if (typeof value !== "object" || value === null) return undefined;
   try {
     if (apply(typedArrayNameGetter, value, []) !== "Uint8Array") return undefined;
@@ -207,16 +267,26 @@ function uint8ArrayByteLength(value: unknown): number | undefined {
   }
 }
 
-/** Copy untrusted bytes into a tightly allocated, immutable-size ArrayBuffer. */
+/**
+ * Admit an untrusted byte result before copying it into an immutable-size,
+ * tightly allocated ArrayBuffer. The maximum is checked from the intrinsic
+ * Uint8Array byte length before allocating the defensive copy.
+ */
 export function copyFixedUint8ArrayWithinLimit(
   value: unknown,
   maximumBytes: number,
   label: string,
 ): Uint8Array {
-  positiveSafeInteger(maximumBytes, `${label} maximum`);
-  const byteLength = uint8ArrayByteLength(value);
-  if (byteLength === undefined) throw new TypeError(`${label} returned invalid bytes`);
-  if (byteLength > maximumBytes) throw new RangeError(`${label} exceeds ${maximumBytes} bytes`);
+  if (!numberIsSafeInteger(maximumBytes) || maximumBytes <= 0) {
+    throw new RangeError(`${label} maximum must be a positive safe integer`);
+  }
+  const byteLength = getUint8ArrayByteLength(value);
+  if (byteLength === undefined) {
+    throw new TypeError(`${label} reader returned invalid bytes`);
+  }
+  if (byteLength > maximumBytes) {
+    throw new TypeError(`${label} exceeds ${maximumBytes} bytes`);
+  }
 
   let buffer: unknown;
   let resizable = false;
@@ -226,127 +296,369 @@ export function copyFixedUint8ArrayWithinLimit(
     resizable = arrayBufferResizableGetter !== undefined &&
       apply(arrayBufferResizableGetter, buffer as object, []) === true;
   } catch (cause) {
-    throw new TypeError(`${label} must use a fixed ArrayBuffer`, { cause });
+    throw new TypeError(`${label} reader must return bytes backed by a fixed ArrayBuffer`, {
+      cause,
+    });
   }
-  if (resizable) throw new TypeError(`${label} must use a fixed ArrayBuffer`);
+  if (resizable) {
+    throw new TypeError(`${label} reader must return bytes backed by a fixed ArrayBuffer`);
+  }
 
   const copy = new NativeUint8Array(byteLength);
   try {
     apply(setBytes, copy, [value]);
   } catch (cause) {
-    throw new TypeError(`${label} returned invalid bytes`, { cause });
+    throw new TypeError(`${label} reader returned invalid bytes`, { cause });
   }
-  const copyBuffer = apply(typedArrayBufferGetter, copy, []) as object;
+  let copyByteLength: unknown;
+  let copyByteOffset: unknown;
+  let copyBuffer: unknown;
+  let copyBufferByteLength: unknown;
+  try {
+    copyByteLength = apply(typedArrayByteLengthGetter, copy, []);
+    copyByteOffset = apply(typedArrayByteOffsetGetter, copy, []);
+    copyBuffer = apply(typedArrayBufferGetter, copy, []);
+    copyBufferByteLength = apply(arrayBufferByteLengthGetter, copyBuffer as object, []);
+  } catch (cause) {
+    throw new TypeError(`${label} could not allocate a fixed byte copy`, { cause });
+  }
   if (
-    apply(typedArrayByteOffsetGetter, copy, []) !== 0 ||
-    apply(arrayBufferByteLengthGetter, copyBuffer, []) !== byteLength
+    copyByteLength !== byteLength ||
+    copyByteOffset !== 0 ||
+    copyBufferByteLength !== byteLength
   ) {
-    throw new TypeError(`${label} could not allocate a tight byte copy`);
+    throw new TypeError(`${label} could not allocate a tight fixed byte copy`);
   }
   return copy;
 }
 
-/** Capture only ordinary byte-read authority. Snapshot authority is independent. */
-export function captureByteReadCapabilities(
+/**
+ * Extract the ArrayBuffer from an admitted tight fixed Uint8Array without
+ * consulting mutable global constructors or configurable typed-array getters.
+ */
+export function getFixedUint8ArrayBuffer(value: unknown, label: string): ArrayBuffer {
+  const byteLength = getUint8ArrayByteLength(value);
+  if (byteLength === undefined) {
+    throw new TypeError(`${label} must be a Uint8Array`);
+  }
+  let byteOffset: unknown;
+  let buffer: unknown;
+  let bufferByteLength: unknown;
+  let resizable = false;
+  try {
+    byteOffset = apply(typedArrayByteOffsetGetter, value as object, []);
+    buffer = apply(typedArrayBufferGetter, value as object, []);
+    bufferByteLength = apply(arrayBufferByteLengthGetter, buffer as object, []);
+    resizable = arrayBufferResizableGetter !== undefined &&
+      apply(arrayBufferResizableGetter, buffer as object, []) === true;
+  } catch (cause) {
+    throw new TypeError(`${label} must use a tight fixed ArrayBuffer`, { cause });
+  }
+  if (byteOffset !== 0 || bufferByteLength !== byteLength || resizable) {
+    throw new TypeError(`${label} must use a tight fixed ArrayBuffer`);
+  }
+  return buffer as ArrayBuffer;
+}
+
+/** Read the intrinsic byte length only after verifying a tight fixed buffer. */
+export function getFixedUint8ArrayByteLength(value: unknown, label: string): number {
+  const byteLength = getUint8ArrayByteLength(value);
+  if (byteLength === undefined) {
+    throw new TypeError(`${label} must be a Uint8Array`);
+  }
+  getFixedUint8ArrayBuffer(value, label);
+  return byteLength;
+}
+
+function copyExclusiveCreateBytes(content: unknown, label: string): Uint8Array {
+  const byteLength = getUint8ArrayByteLength(content);
+  if (byteLength === undefined) {
+    throw invalidCapability(label, "create content must be a Uint8Array");
+  }
+  return copyFixedUint8ArrayWithinLimit(
+    content,
+    byteLength === 0 ? 1 : byteLength,
+    `${label} create content`,
+  );
+}
+
+function requirePositiveByteLimit(value: unknown, label: string): number {
+  if (!numberIsSafeInteger(value) || (value as number) <= 0) {
+    throw new RangeError(`${label} must be a positive safe integer`);
+  }
+  return value as number;
+}
+
+function requireGeneration(value: unknown, label: string): number {
+  if (!numberIsSafeInteger(value) || (value as number) < 0) {
+    throw invalidCapability(label, "generation must be a non-negative safe integer");
+  }
+  return value as number;
+}
+
+function captureWholeFileReader(
+  value: object,
+  properties: Readonly<Record<CapabilityKey, unknown>>,
+  label: string,
+  defensiveResults: boolean,
+  allowExplicitUndefined: boolean,
+): CapturedWholeFileReader | undefined {
+  const rawReadFileBytes = requireOptionalMethod<ByteReader>(
+    properties.readFileBytes,
+    label,
+    "readFileBytes",
+    allowExplicitUndefined,
+  );
+  const ceilingCandidate = properties.maxWholeFileReadBytes;
+  const ceiling = ceilingCandidate === ABSENT_CAPABILITY ||
+      (allowExplicitUndefined && ceilingCandidate === undefined)
+    ? undefined
+    : ceilingCandidate;
+  if (ceiling !== undefined && (!numberIsSafeInteger(ceiling) || (ceiling as number) <= 0)) {
+    throw invalidCapability(label, "maxWholeFileReadBytes must be a positive safe integer");
+  }
+  if (ceiling !== undefined && rawReadFileBytes === undefined) {
+    throw invalidCapability(label, "maxWholeFileReadBytes requires readFileBytes");
+  }
+  if (ceiling === undefined || rawReadFileBytes === undefined) return undefined;
+
+  const maximumBytes = ceiling as number;
+  const read = defensiveResults
+    ? async (path: string): Promise<Uint8Array> => {
+      const result = await apply(rawReadFileBytes, value, [path]);
+      return copyFixedUint8ArrayWithinLimit(result, maximumBytes, `${label} whole-file`);
+    }
+    : (path: string) => apply(rawReadFileBytes, value, [path]) as Promise<Uint8Array>;
+  const captured = createObject(null) as { maximumBytes: number; read: ByteReader };
+  captured.maximumBytes = maximumBytes;
+  captured.read = read;
+  return freezeObject(captured);
+}
+
+/**
+ * Preserve the broad legacy capture temporarily for its scheduled consumers.
+ * Bounded text passes the narrow purpose so writer and prefix fields are never
+ * inspected.
+ */
+export function captureFileSystemCapabilities(
   value: unknown,
   label = "Filesystem",
-): CapturedByteReaders {
+  purpose: "legacy" | "bounded-text" = "legacy",
+): CapturedFileSystemCapabilities {
   requireCapabilityObject(value, label);
-  const properties = captureDataProperties(value, [
-    "readFileBytes",
-    "readFileBytesBounded",
-    "readFileBytesWithinLimit",
-    "maxWholeFileReadBytes",
-  ], label);
-  const rawWhole = optionalMethod<ByteReader>(properties.readFileBytes, label, "readFileBytes");
-  const rawPrefix = optionalMethod<LimitedByteReader>(
-    properties.readFileBytesBounded,
+  const keys = purpose === "bounded-text" ? BOUNDED_TEXT_CAPABILITY_KEYS : LEGACY_CAPABILITY_KEYS;
+  const properties = captureDataProperties(value, label, keys);
+  const rawReadFileBytes = requireOptionalMethod<ByteReader>(
+    properties.readFileBytes,
     label,
-    "readFileBytesBounded",
+    "readFileBytes",
   );
-  const rawExact = optionalMethod<LimitedByteReader>(
+  const rawBoundedReader = purpose === "bounded-text"
+    ? undefined
+    : requireOptionalMethod<BoundedByteReader>(
+      properties.readFileBytesBounded,
+      label,
+      "readFileBytesBounded",
+    );
+  const rawExactReader = requireOptionalMethod<BoundedByteReader>(
     properties.readFileBytesWithinLimit,
     label,
     "readFileBytesWithinLimit",
   );
-  const ceiling = properties.maxWholeFileReadBytes === undefined
-    ? undefined
-    : positiveSafeInteger(properties.maxWholeFileReadBytes, `${label} maxWholeFileReadBytes`);
-  if (ceiling !== undefined && rawWhole === undefined) {
-    throw new TypeError(`${label} maxWholeFileReadBytes requires readFileBytes`);
-  }
+  const rawWriter = purpose === "bounded-text" ? undefined : requireOptionalMethod<ByteWriter>(
+    properties.writeFileBytes,
+    label,
+    "writeFileBytes",
+  );
 
+  const readFileBytes = rawReadFileBytes === undefined
+    ? undefined
+    : (path: string) => apply(rawReadFileBytes, value, [path]) as Promise<Uint8Array>;
+  const readFileBytesBounded = rawBoundedReader === undefined
+    ? undefined
+    : (path: string, byteLimit: number) =>
+      apply(rawBoundedReader, value, [path, byteLimit]) as Promise<Uint8Array>;
+  const readFileBytesWithinLimit = rawExactReader === undefined
+    ? undefined
+    : (path: string, byteLimit: number) =>
+      apply(rawExactReader, value, [path, byteLimit]) as Promise<Uint8Array>;
+  const writeFileBytes = rawWriter === undefined
+    ? undefined
+    : (path: string, content: Uint8Array) =>
+      apply(rawWriter, value, [path, content]) as Promise<void>;
+  const wholeFileReader = captureWholeFileReader(value, properties, label, false, true);
+
+  const captured = createObject(null) as Record<string, unknown>;
+  if (readFileBytes !== undefined) captured.readFileBytes = readFileBytes;
+  if (readFileBytesBounded !== undefined) captured.readFileBytesBounded = readFileBytesBounded;
+  if (readFileBytesWithinLimit !== undefined) {
+    captured.readFileBytesWithinLimit = readFileBytesWithinLimit;
+  }
+  if (writeFileBytes !== undefined) captured.writeFileBytes = writeFileBytes;
+  if (wholeFileReader !== undefined) captured.wholeFileReader = wholeFileReader;
+  return freezeObject(captured) as CapturedFileSystemCapabilities;
+}
+
+/**
+ * Capture the established byte-reader surface while defensively admitting
+ * every result. New purpose-specific code should prefer the narrower capture
+ * functions above.
+ */
+export function captureByteReadCapabilities(
+  value: unknown,
+  label = "Filesystem",
+): CapturedByteReaders {
+  const capabilities = captureFileSystemCapabilities(value, label);
   const captured = createObject(null) as {
     unbounded?: ByteReader;
     whole?: CapturedWholeFileReader;
-    prefix?: LimitedByteReader;
-    exact?: LimitedByteReader;
+    prefix?: BoundedByteReader;
+    exact?: BoundedByteReader;
   };
-  if (rawWhole !== undefined) {
-    captured.unbounded = async (path: string) =>
+
+  if (capabilities.readFileBytes !== undefined) {
+    captured.unbounded = async (path: string): Promise<Uint8Array> =>
       copyFixedUint8ArrayWithinLimit(
-        await apply(rawWhole, value, [path]),
+        await capabilities.readFileBytes!(path),
         Number.MAX_SAFE_INTEGER,
-        `${label} whole-file read`,
+        `${label} whole-file`,
       );
   }
-  if (rawWhole !== undefined && ceiling !== undefined) {
+  if (capabilities.wholeFileReader !== undefined) {
+    const rawWhole = capabilities.wholeFileReader;
     const whole = createObject(null) as {
       maximumBytes: number;
-      read(path: string): Promise<Uint8Array>;
+      read: ByteReader;
     };
-    whole.maximumBytes = ceiling;
-    whole.read = async (path: string) =>
+    whole.maximumBytes = rawWhole.maximumBytes;
+    whole.read = async (path: string): Promise<Uint8Array> =>
       copyFixedUint8ArrayWithinLimit(
-        await apply(rawWhole, value, [path]),
-        ceiling,
-        `${label} whole-file read`,
+        await rawWhole.read(path),
+        rawWhole.maximumBytes,
+        `${label} whole-file`,
       );
     captured.whole = freezeObject(whole);
   }
-  if (rawPrefix !== undefined) {
-    captured.prefix = async (path: string, byteLimit: number) => {
-      const limit = positiveSafeInteger(byteLimit, `${label} prefix byte limit`);
+  if (capabilities.readFileBytesBounded !== undefined) {
+    captured.prefix = async (path: string, byteLimit: number): Promise<Uint8Array> => {
+      const limit = requirePositiveByteLimit(byteLimit, `${label} prefix byte limit`);
       return copyFixedUint8ArrayWithinLimit(
-        await apply(rawPrefix, value, [path, limit]),
+        await capabilities.readFileBytesBounded!(path, limit),
         limit,
-        `${label} prefix read`,
+        `${label} prefix`,
       );
     };
   }
-  if (rawExact !== undefined) {
-    captured.exact = async (path: string, byteLimit: number) => {
-      const limit = positiveSafeInteger(byteLimit, `${label} exact byte limit`);
+  if (capabilities.readFileBytesWithinLimit !== undefined) {
+    captured.exact = async (path: string, byteLimit: number): Promise<Uint8Array> => {
+      const limit = requirePositiveByteLimit(byteLimit, `${label} exact byte limit`);
       return copyFixedUint8ArrayWithinLimit(
-        await apply(rawExact, value, [path, limit]),
+        await capabilities.readFileBytesWithinLimit!(path, limit),
         limit,
-        `${label} exact read`,
+        `${label} exact`,
       );
     };
   }
   return freezeObject(captured);
 }
 
+function admitQuarantinedMethod<T>(candidate: unknown): T | undefined {
+  if (
+    candidate === ABSENT_CAPABILITY ||
+    candidate === INVALID_CAPABILITY ||
+    candidate === undefined ||
+    typeof candidate !== "function" ||
+    isProxyWithoutHooks(candidate)
+  ) {
+    return undefined;
+  }
+  return candidate as T;
+}
+
+/**
+ * Capture legacy byte capabilities after genuine snapshot authority has been
+ * proven independently. Malformed optional fields are omitted one at a time;
+ * unsafe object or prototype provenance still rejects the adapter.
+ */
+export function captureLegacyFileSystemCapabilitiesForSnapshot(
+  value: unknown,
+  label = "Filesystem",
+): CapturedFileSystemCapabilities {
+  requireCapabilityObject(value, label);
+  const properties = captureDataProperties(
+    value,
+    label,
+    LEGACY_CAPABILITY_KEYS,
+    "quarantine",
+  );
+  const rawReadFileBytes = admitQuarantinedMethod<ByteReader>(properties.readFileBytes);
+  const rawBoundedReader = admitQuarantinedMethod<BoundedByteReader>(
+    properties.readFileBytesBounded,
+  );
+  const rawExactReader = admitQuarantinedMethod<BoundedByteReader>(
+    properties.readFileBytesWithinLimit,
+  );
+  const rawWriter = admitQuarantinedMethod<ByteWriter>(properties.writeFileBytes);
+  const ceilingCandidate = properties.maxWholeFileReadBytes;
+  const maximumBytes = numberIsSafeInteger(ceilingCandidate) &&
+      (ceilingCandidate as number) > 0
+    ? ceilingCandidate as number
+    : undefined;
+
+  const captured = createObject(null) as Record<string, unknown>;
+  if (rawReadFileBytes !== undefined) {
+    const readFileBytes = (path: string) =>
+      apply(rawReadFileBytes, value, [path]) as Promise<Uint8Array>;
+    captured.readFileBytes = readFileBytes;
+    if (maximumBytes !== undefined) {
+      const wholeFileReader = createObject(null) as {
+        maximumBytes: number;
+        read: ByteReader;
+      };
+      wholeFileReader.maximumBytes = maximumBytes;
+      wholeFileReader.read = readFileBytes;
+      captured.wholeFileReader = freezeObject(wholeFileReader);
+    }
+  }
+  if (rawBoundedReader !== undefined) {
+    captured.readFileBytesBounded = (path: string, byteLimit: number) =>
+      apply(rawBoundedReader, value, [path, byteLimit]) as Promise<Uint8Array>;
+  }
+  if (rawExactReader !== undefined) {
+    captured.readFileBytesWithinLimit = (path: string, byteLimit: number) =>
+      apply(rawExactReader, value, [path, byteLimit]) as Promise<Uint8Array>;
+  }
+  if (rawWriter !== undefined) {
+    captured.writeFileBytes = (path: string, content: Uint8Array) =>
+      apply(rawWriter, value, [path, content]) as Promise<void>;
+  }
+  return freezeObject(captured) as CapturedFileSystemCapabilities;
+}
+
 export function captureSnapshotReadCapability(
   value: unknown,
   label = "Filesystem",
+  allowExplicitUndefined = false,
 ): CapturedSnapshotReader | undefined {
   requireCapabilityObject(value, label);
-  const properties = captureDataProperties(value, ["readFileSnapshotWithinLimit"], label);
-  const raw = optionalMethod<SnapshotByteReader>(
+  const properties = captureDataProperties(value, label, SNAPSHOT_CAPABILITY_KEYS);
+  const rawReader = requireOptionalMethod<SnapshotByteReader>(
     properties.readFileSnapshotWithinLimit,
     label,
     "readFileSnapshotWithinLimit",
+    allowExplicitUndefined,
   );
-  if (raw === undefined) return undefined;
+  if (rawReader === undefined) return undefined;
+
   const captured = createObject(null) as CapturedSnapshotReader;
-  captured.read = async (path: string, containmentRoot: string, byteLimit: number) => {
-    const limit = positiveSafeInteger(byteLimit, `${label} snapshot byte limit`);
-    return copyFixedUint8ArrayWithinLimit(
-      await apply(raw, value, [path, containmentRoot, limit]),
-      limit,
-      `${label} snapshot read`,
-    );
+  captured.read = async (
+    path: string,
+    containmentRoot: string,
+    byteLimit: number,
+  ): Promise<Uint8Array> => {
+    requirePositiveByteLimit(byteLimit, `${label} snapshot byte limit`);
+    const result = await apply(rawReader, value, [path, containmentRoot, byteLimit]);
+    return copyFixedUint8ArrayWithinLimit(result, byteLimit, `${label} snapshot`);
   };
   return freezeObject(captured);
 }
@@ -356,85 +668,81 @@ export function captureExclusiveCreateCapability(
   label = "Filesystem",
 ): CapturedExclusiveCreator | undefined {
   requireCapabilityObject(value, label);
-  const properties = captureDataProperties(value, ["createFileBytesExclusive"], label);
-  const raw = optionalMethod<ByteWriter>(
+  const properties = captureDataProperties(value, label, EXCLUSIVE_CREATE_CAPABILITY_KEYS);
+  const rawCreator = requireOptionalMethod<ByteWriter>(
     properties.createFileBytesExclusive,
     label,
     "createFileBytesExclusive",
+    false,
   );
-  if (raw === undefined) return undefined;
+  if (rawCreator === undefined) return undefined;
+
   const captured = createObject(null) as CapturedExclusiveCreator;
-  captured.create = (path: string, content: Uint8Array) => {
-    const length = uint8ArrayByteLength(content);
-    if (length === undefined) throw new TypeError(`${label} create content must be Uint8Array`);
-    const copy = copyFixedUint8ArrayWithinLimit(
-      content,
-      length === 0 ? 1 : length,
-      `${label} create content`,
-    );
-    return apply(raw, value, [path, copy]) as Promise<void>;
+  captured.create = (path: string, content: Uint8Array): Promise<void> => {
+    const fixedContent = copyExclusiveCreateBytes(content, label);
+    return apply(rawCreator, value, [path, fixedContent]) as Promise<void>;
   };
   return freezeObject(captured);
 }
 
-/**
- * Capture static-read authority by purpose. A malformed ordinary byte reader
- * cannot invalidate an independently captured native snapshot reader.
- */
 export function captureStaticReadCapabilities(
   value: unknown,
   label = "Filesystem",
 ): CapturedStaticReaders {
   requireCapabilityObject(value, label);
-  const captured = createObject(null) as {
-    snapshot?: CapturedSnapshotReader;
-    virtual?: NonNullable<CapturedStaticReaders["virtual"]>;
-  };
   const snapshot = captureSnapshotReadCapability(value, label);
+  const captured = createObject(null) as CapturedStaticReaders;
   if (snapshot !== undefined) captured.snapshot = snapshot;
 
-  let marker: PropertyDescriptor | undefined;
-  try {
-    marker = getOwnPropertyDescriptor(value, "symlinkSemantics");
-  } catch (cause) {
-    throw new TypeError(`${label} symlink semantics could not be inspected safely`, { cause });
-  }
-  if (!marker || !hasOwn(marker, "value") || marker.value !== "none") {
+  // Virtual readers are authority only behind an explicit own data marker.
+  // An absent, inherited, or accessor marker leaves unrelated fields unobserved.
+  const semantics = getOwnPropertyDescriptor(value, "symlinkSemantics");
+  if (
+    semantics === undefined ||
+    !hasOwn(semantics, "value") ||
+    semantics.value !== "none"
+  ) {
     return freezeObject(captured);
   }
 
-  const generationProperties = captureDataProperties(value, ["getSourceSnapshotVersion"], label);
-  const rawGeneration = optionalMethod<GenerationReader>(
+  const generationProperties = captureDataProperties(
+    value,
+    label,
+    GENERATION_CAPABILITY_KEYS,
+  );
+  const rawGeneration = requireOptionalMethod<SnapshotVersionReader>(
     generationProperties.getSourceSnapshotVersion,
     label,
     "getSourceSnapshotVersion",
+    false,
   );
   if (rawGeneration === undefined) return freezeObject(captured);
 
-  let readers: CapturedByteReaders;
-  try {
-    readers = captureByteReadCapabilities(value, label);
-  } catch {
-    // Snapshot authority remains available even when legacy reader fields are
-    // malformed. Virtual authority is omitted as one indivisible capability.
-    return freezeObject(captured);
-  }
-  if (readers.exact === undefined && readers.whole === undefined) {
-    return freezeObject(captured);
-  }
-
-  const virtual = createObject(null) as {
-    generation(): Promise<number>;
-    exact?: LimitedByteReader;
-    whole?: CapturedWholeFileReader;
+  const readerProperties = captureDataProperties(
+    value,
+    label,
+    VIRTUAL_READ_CAPABILITY_KEYS,
+  );
+  const rawExactReader = requireOptionalMethod<BoundedByteReader>(
+    readerProperties.readFileBytesWithinLimit,
+    label,
+    "readFileBytesWithinLimit",
+    false,
+  );
+  const whole = captureWholeFileReader(value, readerProperties, label, true, false);
+  const virtual = createObject(null) as NonNullable<CapturedStaticReaders["virtual"]>;
+  virtual.generation = async (): Promise<number> => {
+    const result = await apply(rawGeneration, value, []);
+    return requireGeneration(result, label);
   };
-  virtual.generation = async () =>
-    nonNegativeSafeInteger(
-      await apply(rawGeneration, value, []),
-      `${label} source snapshot generation`,
-    );
-  if (readers.exact !== undefined) virtual.exact = readers.exact;
-  if (readers.whole !== undefined) virtual.whole = readers.whole;
+  if (rawExactReader !== undefined) {
+    virtual.exact = async (path: string, byteLimit: number): Promise<Uint8Array> => {
+      requirePositiveByteLimit(byteLimit, `${label} exact byte limit`);
+      const result = await apply(rawExactReader, value, [path, byteLimit]);
+      return copyFixedUint8ArrayWithinLimit(result, byteLimit, `${label} exact`);
+    };
+  }
+  if (whole !== undefined) virtual.whole = whole;
   captured.virtual = freezeObject(virtual);
   return freezeObject(captured);
 }

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -226,6 +226,23 @@ describe("VeryfrontFSAdapter", () => {
       adapter.clearRequestToken();
       assertEquals(websocketToken, "static-token");
     });
+
+    it("advances the snapshot generation across request-authority ABA changes", () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "static-token",
+          projectSlug: "test-project",
+          cache: { enabled: false },
+        },
+      });
+      const before = adapter.getSourceSnapshotVersion();
+
+      adapter.setRequestToken("tenant-token");
+      adapter.setRequestToken("static-token");
+
+      assertEquals(adapter.getSourceSnapshotVersion() > before, true);
+    });
   });
 
   describe("content context", () => {
@@ -575,6 +592,44 @@ describe("VeryfrontFSAdapter", () => {
       adapter.setContentContext(ctx);
 
       assertEquals(adapter.getContentContext()?.branch, "main");
+    });
+
+    it("detects a source-context ABA change during an in-flight exact read", async () => {
+      const adapter = createAdapter();
+      const originalContext: ResolvedContentContext = {
+        sourceType: "release",
+        projectSlug: "test-project",
+        releaseId: "release-a",
+      };
+      adapter.setContentContext(originalContext);
+      const before = adapter.getSourceSnapshotVersion();
+      const readStarted = Promise.withResolvers<void>();
+      const releaseRead = Promise.withResolvers<void>();
+      const internals = adapter as unknown as {
+        ensureExactReadInitialized(): Promise<void>;
+        readOps: {
+          readFileBytesWithinLimit(path: string, byteLimit: number): Promise<Uint8Array>;
+        };
+      };
+      internals.ensureExactReadInitialized = () => Promise.resolve();
+      internals.readOps.readFileBytesWithinLimit = async () => {
+        readStarted.resolve();
+        await releaseRead.promise;
+        return new Uint8Array([1]);
+      };
+
+      const pendingRead = adapter.readFileBytesWithinLimit("config.json", 1);
+      await readStarted.promise;
+      adapter.setContentContext({
+        sourceType: "release",
+        projectSlug: "test-project",
+        releaseId: "release-b",
+      });
+      adapter.setContentContext(originalContext);
+      releaseRead.resolve();
+
+      assertEquals([...(await pendingRead)], [1]);
+      assertEquals(adapter.getSourceSnapshotVersion() > before, true);
     });
 
     it("should detect context change between different source types", () => {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -58,6 +58,9 @@ const BRANCH_SOURCE_SNAPSHOT_FRESHNESS_MS = 30_000;
 let sourceSnapshotGeneration = 0;
 
 function nextSourceSnapshotGeneration(): number {
+  if (sourceSnapshotGeneration >= Number.MAX_SAFE_INTEGER) {
+    throw new RangeError("Source snapshot generation space is exhausted");
+  }
   sourceSnapshotGeneration++;
   return sourceSnapshotGeneration;
 }
@@ -141,7 +144,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private readonly branchMissRecoveryFailures = new Map<string, number>();
   /** Last successful source check and generation of the materialized snapshot. */
   private sourceSnapshotCheckedAt = 0;
-  private sourceSnapshotVersion = 0;
+  private sourceSnapshotVersion = nextSourceSnapshotGeneration();
   private sourceSnapshotIdentity: string | undefined;
   private sourceSnapshotFiles: SourceSnapshotFile[] | undefined;
   private sourceSnapshotRefreshPromise: Promise<void> | null = null;
@@ -150,6 +153,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private projectData?: Project;
   private apiBaseUrl: string;
   private apiToken: string;
+  private activeRequestToken: string;
   private projectSlug: string;
   private invalidationCallbacks: InvalidationCallbacks;
   private styleCallbacks: StyleCallbacks;
@@ -248,6 +252,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
     this.apiBaseUrl = vf.apiBaseUrl ?? "";
     this.apiToken = vf.apiToken ?? "";
+    this.activeRequestToken = this.apiToken;
     this.projectSlug = vf.projectSlug ?? "";
     this.contentSource = vf.contentSource ?? { type: "branch", branch: "main" };
     this.proxyMode = vf.proxyMode ?? false;
@@ -1012,6 +1017,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
   }
 
   dispose(): void {
+    this.sourceSnapshotVersion = nextSourceSnapshotGeneration();
     this.wsManager.dispose();
     this.cache.clear();
     this.statOps.clearIndex();
@@ -1118,16 +1124,27 @@ export class VeryfrontFSAdapter implements FSAdapter {
   }
 
   setRequestToken(token: string): void {
+    if (token !== this.activeRequestToken) {
+      this.activeRequestToken = token;
+      this.sourceSnapshotVersion = nextSourceSnapshotGeneration();
+    }
     this.client.setRequestToken(token);
     this.wsManager.setApiToken(token);
   }
 
   clearRequestToken(): void {
+    if (this.activeRequestToken !== this.apiToken) {
+      this.activeRequestToken = this.apiToken;
+      this.sourceSnapshotVersion = nextSourceSnapshotGeneration();
+    }
     this.client.clearRequestToken();
     this.wsManager.setApiToken(this.apiToken);
   }
 
   setRequestBranch(branch: string | null): void {
+    if (branch !== this.requestBranch) {
+      this.sourceSnapshotVersion = nextSourceSnapshotGeneration();
+    }
     this.requestBranch = branch;
     this.syncClientContext();
   }
@@ -1137,6 +1154,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
   }
 
   clearRequestBranch(): void {
+    if (this.requestBranch !== null) {
+      this.sourceSnapshotVersion = nextSourceSnapshotGeneration();
+    }
     this.requestBranch = null;
     this.syncClientContext();
   }
@@ -1186,7 +1206,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       this.branchMissRecoveryGeneration++;
       this.branchMissRecoveryFailures.clear();
       this.sourceSnapshotCheckedAt = 0;
-      this.sourceSnapshotVersion = 0;
+      this.sourceSnapshotVersion = nextSourceSnapshotGeneration();
       this.sourceSnapshotIdentity = undefined;
       this.sourceSnapshotFiles = undefined;
       this.sourceSnapshotRefreshPromise = null;

--- a/src/platform/adapters/fs/wrapper.ts
+++ b/src/platform/adapters/fs/wrapper.ts
@@ -155,7 +155,7 @@ export class FSAdapterWrapper implements ExtendedFileSystemAdapter {
       ? "none"
       : undefined;
 
-    const snapshotReader = captureSnapshotReadCapability(fsAdapter, "FSAdapter");
+    const snapshotReader = captureSnapshotReadCapability(fsAdapter, "FSAdapter", true);
     let byteReaders: CapturedByteReaders;
     try {
       byteReaders = captureByteReadCapabilities(fsAdapter, "FSAdapter");

--- a/src/react/components/ui/color-mode.test.tsx
+++ b/src/react/components/ui/color-mode.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { flushSync } from "react-dom";
-import { createRoot, hydrateRoot } from "react-dom/client";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
@@ -103,6 +103,18 @@ function ToggleFixture(): React.ReactElement {
   );
 }
 
+/**
+ * Unmount and drain the scheduler task React leaves behind.
+ *
+ * React's scheduler holds a `setImmediate` until it next runs. It completes on
+ * its own, but the test has to yield once more or Deno's leak sanitizer sees
+ * the timer still pending.
+ */
+async function unmount(root: Root): Promise<void> {
+  flushSync(() => root.unmount());
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("react/components/ui/color-mode", () => {
   it("escapes storage keys before embedding them in the inline color-mode script", () => {
     const storageKey = `vf";</script><script>alert(1)</script>//`;
@@ -151,7 +163,7 @@ describe("react/components/ui/color-mode", () => {
       await waitFor(() => document.documentElement.classList.contains("light"));
       assertEquals(document.documentElement.style.colorScheme, "light");
 
-      root.unmount();
+      await unmount(root);
     } finally {
       restore();
     }
@@ -186,7 +198,7 @@ describe("react/components/ui/color-mode", () => {
       assertEquals(document.querySelector("button")?.getAttribute("data-mode"), "dark");
       assertEquals(document.documentElement.style.colorScheme, "dark");
 
-      flushSync(() => root.unmount());
+      await unmount(root);
     } finally {
       restore();
     }
@@ -217,7 +229,7 @@ describe("react/components/ui/color-mode", () => {
       await waitFor(() => document.querySelector("button")?.getAttribute("data-mode") === "dark");
       assertEquals(document.documentElement.style.colorScheme, "dark");
 
-      flushSync(() => root.unmount());
+      await unmount(root);
     } finally {
       restore();
     }
@@ -255,7 +267,7 @@ describe("react/components/ui/color-mode", () => {
       await waitFor(() => document.querySelector("button")?.getAttribute("data-mode") === "dark");
       assertEquals(recoverableErrors, []);
 
-      flushSync(() => root.unmount());
+      await unmount(root);
     } finally {
       restore();
     }

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -2013,13 +2013,16 @@ function validateAndMergeReleaseConfig(userConfig: unknown): VeryfrontConfig {
     throw new Error(`Expected object from veryfront.config, received ${typeof userConfig}`);
   }
 
-  validateVeryfrontConfig(userConfig);
+  // Reported before schema validation: the strict schema rejects an unknown key
+  // with its own generic message, and a release build should name the typo and
+  // where to fix it.
   const unknownKeys = findUnknownTopLevelKeys(userConfig as Record<string, unknown>);
   if (unknownKeys.length > 0) {
     throw new Error(
       `Unknown config keys: ${unknownKeys.join(", ")}. Check for typos in veryfront.config.`,
     );
   }
+  validateVeryfrontConfig(userConfig);
 
   return mergeConfigs(userConfig as Partial<VeryfrontConfig>);
 }

--- a/src/server/handlers/request/agent-stream.handler.test-helpers.ts
+++ b/src/server/handlers/request/agent-stream.handler.test-helpers.ts
@@ -109,7 +109,11 @@ export function createNoopFsAdapter(
   }>,
 ): SourceContextTestFsAdapter {
   const adapter: SourceContextTestFsAdapter = {
-    readFile: async () => "",
+    // This adapter holds no files, so reads report absence the way a real
+    // filesystem does rather than returning empty content that hosted config
+    // evaluation would treat as a present, unparseable source.
+    readFile: (path: string) =>
+      Promise.reject(Object.assign(new Error(`File not found: ${path}`), { code: "ENOENT" })),
     writeFile: async () => {},
     exists: async () => false,
     async *readDir() {},

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1910,10 +1910,12 @@ describe("server/handlers/request/agent-stream.handler", () => {
     });
     assertEquals(capturedAllowedRemoteTools, ["list_projects", "search_knowledge"]);
     assertEquals(capturedRemoteToolNames, ["search_knowledge", "list_projects"]);
+    // The environment is resolved before the source config is evaluated, so
+    // both the config and the MCP tool headers see the same variables.
     assertEquals(fetchUrls, [
-      "https://api.veryfront.org/mcp",
       "https://api.veryfront.org/projects/support-agent-fork/environments",
       "https://api.veryfront.org/projects/support-agent-fork/environment-variables?environment_id=env-production&limit=100",
+      "https://api.veryfront.org/mcp",
     ]);
   });
 
@@ -2071,9 +2073,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
     });
     assertStringIncludes(capturedSystem ?? "", `api=${apiBaseUrl}`);
     assertEquals(fetchUrls, [
-      `${new URL(apiBaseUrl).origin}/mcp`,
       `${apiBaseUrl}/projects/base-url-agent-fork/environments`,
       `${apiBaseUrl}/projects/base-url-agent-fork/environment-variables?environment_id=env-production-base-url&limit=100`,
+      `${new URL(apiBaseUrl).origin}/mcp`,
     ]);
   });
 

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -69,7 +69,8 @@ import {
   filterRuntimeProjectEnv,
   runWithProjectEnv,
 } from "../../project-env/index.ts";
-import { getConfig, type VeryfrontConfig } from "#veryfront/config/loader.ts";
+import { getHostedConfig, type VeryfrontConfig } from "#veryfront/config/loader.ts";
+import { prepareDeclarativeConfigContext } from "#veryfront/config/declarative-evaluator.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 
@@ -352,18 +353,71 @@ function createStaticRemoteToolSource(
   };
 }
 
+/**
+ * Environment label bound to one agent source.
+ *
+ * A bare release carries no authoritative environment identity, so it is
+ * evaluated under the `release` label against an empty environment and never
+ * inherits production secrets by convention.
+ */
+function buildAgentSourceEnvironmentName(sourceContext: RuntimeAgentSourceContext): string {
+  switch (sourceContext.type) {
+    case "branch":
+      return "preview";
+    case "environment":
+      return sourceContext.environmentName;
+    case "release":
+      return "release";
+  }
+}
+
+/**
+ * Load the project environment this agent source may read.
+ *
+ * Control-plane requests don't go through the proxy and therefore don't carry
+ * x-environment-id, so the production environment ID is discovered from the API
+ * (one fetch per project per server lifetime, then cached).
+ */
+async function resolveAgentSourceEnvironment(
+  ctx: HandlerContext,
+  sourceContext: RuntimeAgentSourceContext,
+  apiAuthToken: string,
+): Promise<Record<string, string>> {
+  if (sourceContext.type === "release") return {};
+  if (!ctx.projectSlug || !apiAuthToken) return {};
+
+  const environmentId = ctx.environmentId ??
+    await _resolveProductionEnvironmentId(ctx.projectSlug, apiAuthToken);
+  if (!environmentId) return {};
+
+  return await _agentEnvVarCache.get(environmentId, apiAuthToken, ctx.projectSlug);
+}
+
+/**
+ * Load config for an exact agent source.
+ *
+ * This runs only on a shared multi-project runtime (see
+ * {@link AgentStreamHandler.withAgentSourceContext}), so the source is
+ * untrusted and is evaluated declaratively, bound to the same source and
+ * environment the run itself will use.
+ */
 async function resolveAgentSourceConfig(
   ctx: HandlerContext,
   sourceContext: RuntimeAgentSourceContext,
+  environment: Record<string, string>,
 ): Promise<VeryfrontConfig> {
   const cacheKey = ctx.projectId ?? ctx.projectSlug;
   if (!cacheKey) {
     throw new Error("Explicit agent source requires a project identity");
   }
   await ctx.adapter.fs.ensureSourceSnapshotFresh?.("agent-source-config");
-  return await getConfig(ctx.projectDir, ctx.adapter, {
+  return await getHostedConfig(ctx.projectDir, ctx.adapter, {
     cacheKey,
     sourceContext: buildAgentSourceRunOptions(sourceContext),
+    preparedContext: await prepareDeclarativeConfigContext({
+      environmentName: buildAgentSourceEnvironmentName(sourceContext),
+      environment,
+    }),
   });
 }
 
@@ -690,9 +744,17 @@ export class AgentStreamHandler extends BaseHandler {
           requestScopedContext,
           payload.agentSource,
           async () => {
+            // Resolved before the config load because hosted evaluation binds
+            // config to the same environment the run will execute with.
+            const envVarsForAgent = await resolveAgentSourceEnvironment(
+              requestScopedContext,
+              payload.agentSource,
+              apiAuthToken,
+            );
             const sourceConfig = await resolveAgentSourceConfig(
               requestScopedContext,
               payload.agentSource,
+              envVarsForAgent,
             );
             const sourceScopedContext: HandlerContext = {
               ...requestScopedContext,
@@ -742,31 +804,14 @@ export class AgentStreamHandler extends BaseHandler {
                   conversationId: runtimeInput.threadId,
                 });
 
-                // Load project env vars so source-defined MCP tool headers resolve
-                // via _getProjectEnv(). Control-plane requests don't go through the proxy and
-                // therefore don't carry x-environment-id, so we discover the production env ID
-                // from the API (one fetch per project per server lifetime, then cached).
-                let envVarsForAgent: Record<string, string> = {};
-                if (sourceScopedContext.projectSlug && apiAuthToken) {
-                  const environmentId = sourceScopedContext.environmentId ??
-                    await _resolveProductionEnvironmentId(
-                      sourceScopedContext.projectSlug,
-                      apiAuthToken,
-                    );
-                  if (environmentId) {
-                    envVarsForAgent = await _agentEnvVarCache.get(
-                      environmentId,
-                      apiAuthToken,
-                      sourceScopedContext.projectSlug,
-                    );
-                    logger.debug("Agent stream env vars loaded", {
-                      runId: payload.runId,
-                      projectSlug: sourceScopedContext.projectSlug,
-                      environmentId,
-                      count: Object.keys(envVarsForAgent).length,
-                    });
-                  }
-                }
+                // Source-defined MCP tool headers resolve these via
+                // _getProjectEnv(); they are the same variables the source
+                // config was evaluated against.
+                logger.debug("Agent stream env vars loaded", {
+                  runId: payload.runId,
+                  projectSlug: sourceScopedContext.projectSlug,
+                  count: Object.keys(envVarsForAgent).length,
+                });
 
                 const runAgentStream = () =>
                   createRuntimeAgentStreamResponse(runtimeInput, runtimeAgent, {

--- a/src/server/runtime-handler/adapter-factory.ts
+++ b/src/server/runtime-handler/adapter-factory.ts
@@ -12,10 +12,12 @@ import { CACHE_INVARIANT_VIOLATION, getErrorMessage } from "#veryfront/errors";
 import { runtime } from "#veryfront/platform/adapters/detect.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
-import { getConfig, getHostedConfig } from "#veryfront/config/loader.ts";
-import type { PreparedDeclarativeConfigContext } from "#veryfront/config/declarative-evaluator.ts";
+import {
+  getConfig,
+  getHostedConfig,
+  type PreparedHostedConfigContext,
+} from "#veryfront/config/loader.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
-import type { VirtualConfigSourceContext } from "#veryfront/cache/keys.ts";
 import { isConfigOptionalControlPlaneRunRequest } from "#veryfront/channels/control-plane.ts";
 import { timeAsync } from "./request-lifecycle.ts";
 import {
@@ -40,11 +42,6 @@ interface AdapterResolutionResult {
   config: VeryfrontConfig | undefined;
   /** Whether this is a local project (filesystem-first) */
   isLocalProject: boolean;
-}
-
-interface PreparedHostedConfigLoad {
-  readonly sourceContext: VirtualConfigSourceContext;
-  readonly preparedContext: PreparedDeclarativeConfigContext;
 }
 
 interface AdapterResolutionOptions {
@@ -89,7 +86,7 @@ interface AdapterResolutionOptions {
    */
   prepareHostedConfigContext?: (
     isLocalProject: boolean,
-  ) => Promise<PreparedHostedConfigLoad>;
+  ) => Promise<PreparedHostedConfigContext>;
 }
 
 function usesExactSourceConfig(opts: AdapterResolutionOptions): boolean {
@@ -110,7 +107,7 @@ function shouldDeferConfigLoad(opts: AdapterResolutionOptions): boolean {
 async function prepareProxyConfigLoad(
   opts: AdapterResolutionOptions,
   isLocalProject: boolean,
-): Promise<PreparedHostedConfigLoad & { cacheKey: string }> {
+): Promise<PreparedHostedConfigContext & { cacheKey: string }> {
   if (!opts.projectSlug || !opts.prepareHostedConfigContext) {
     throw CACHE_INVARIANT_VIOLATION.create({
       detail: "Proxy project config requires an authenticated declarative evaluation context",

--- a/src/server/runtime-handler/handler-context-builder.ts
+++ b/src/server/runtime-handler/handler-context-builder.ts
@@ -58,6 +58,11 @@ export interface HandlerContextOptions {
   environmentId: string | undefined;
   /** Skip render-specific enriched context requirements for non-render control-plane routes */
   skipEnrichedContext?: boolean;
+  /**
+   * Prepares the authenticated hosted evaluation context for this request.
+   * Supplied only for shared multi-project runtimes.
+   */
+  prepareHostedConfigContext?: HandlerContext["prepareHostedConfigContext"];
 }
 
 /**
@@ -112,6 +117,7 @@ export function buildHandlerContext(opts: HandlerContextOptions): HandlerContext
     routeRegistry: opts.routeRegistry,
     isLocalProject: opts.isLocalProject,
     environmentId: opts.environmentId,
+    prepareHostedConfigContext: opts.prepareHostedConfigContext,
     enriched: enrichedContext,
   };
 }

--- a/src/server/runtime-handler/project-runtime-context.ts
+++ b/src/server/runtime-handler/project-runtime-context.ts
@@ -314,6 +314,13 @@ export async function resolveProjectRuntimeContext(
     moduleServerUrl: input.moduleServerUrl,
     environmentId: input.environmentId ?? input.headers.environmentId,
     skipEnrichedContext: input.skipEnrichedContext ?? shouldSkipEnrichedContext(input.url.pathname),
+    // Handlers that load config themselves reuse this request's identity
+    // instead of deriving their own.
+    ...(input.isProxyMode
+      ? {
+        prepareHostedConfigContext: () => prepareHostedConfigContext(adapterRes.isLocalProject),
+      }
+      : {}),
   });
 
   let rawEnvVars: Record<string, string> = hostedConfigLoadPromise

--- a/src/server/shared/renderer/adapter.test.ts
+++ b/src/server/shared/renderer/adapter.test.ts
@@ -8,6 +8,8 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { Renderer, RendererOptions } from "#veryfront/rendering/renderer.ts";
+import { prepareDeclarativeConfigContext } from "#veryfront/config/declarative-evaluator.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import {
   destroyRendererAdapter,
   getRendererForProject,
@@ -450,6 +452,70 @@ describe("RendererAdapter with RendererInitializer", () => {
       assertEquals(ctx.enriched !== undefined, true);
       const pages = await adapter.getAllPages();
       assertEquals(pages, ["/"]);
+    });
+
+    it("evaluates shared multi-project config through the request's hosted context", async () => {
+      const ctx = stubHandlerContext();
+      ctx.enriched = undefined;
+      ctx.config = undefined;
+      ctx.isLocalProject = false;
+      ctx.projectDir = "/tmp/hosted-project";
+      ctx.resolvedEnvironment = "preview";
+      ctx.requestContext = { branch: "feature/hosted-render", mode: "preview" };
+
+      const sourceContext = {
+        productionMode: false,
+        branch: "feature/hosted-render",
+      } as const;
+      ctx.prepareHostedConfigContext = async () => ({
+        sourceContext,
+        preparedContext: await prepareDeclarativeConfigContext({
+          environmentName: "preview",
+          environment: { TENANT: "tenant-value" },
+        }),
+      });
+
+      const fs = {
+        isVeryfrontAdapter: () => true,
+        getUnderlyingAdapter: () => ({}),
+        isMultiProjectMode: () => true,
+        runWithContext: (
+          projectSlug: string,
+          token: string,
+          fn: () => Promise<unknown>,
+          projectId?: string,
+          opts?: Record<string, unknown>,
+        ) =>
+          runWithRequestContext(
+            { projectSlug, token, projectId, ...opts },
+            fn as () => Promise<never>,
+          ),
+        exists: () => Promise.reject(new Error("hosted config must not probe exists")),
+        readFile: (path: string) => {
+          if (path !== "/veryfront.config.ts") {
+            return Promise.reject(
+              Object.assign(new Error(`File not found: ${path}`), { code: "ENOENT" }),
+            );
+          }
+          return Promise.resolve(`
+            import { defineConfigWithEnv, getEnv } from "veryfront";
+            export default defineConfigWithEnv((environmentName) => ({
+              title: \`\${environmentName}:\${getEnv("TENANT") ?? "missing"}\`,
+            }));
+          `);
+        },
+        readDir: async function* () {},
+        stat: () => Promise.resolve({ isFile: false, isDirectory: false }),
+      };
+      ctx.adapter = {
+        fs,
+        env: { get: () => undefined, set: () => {}, delete: () => {}, toObject: () => ({}) },
+      } as unknown as any;
+
+      await getRendererForProject(ctx);
+
+      assertEquals(ctx.enriched !== undefined, true);
+      assertEquals(ctx.enriched.config.title, "preview:tenant-value");
     });
 
     it("derives projectId from projectDir when no explicit id", async () => {

--- a/src/server/shared/renderer/adapter.ts
+++ b/src/server/shared/renderer/adapter.ts
@@ -10,6 +10,7 @@
 
 import { rendererLogger } from "#veryfront/utils";
 import { getConfig, type VeryfrontConfig } from "#veryfront/config";
+import { getHostedConfig } from "#veryfront/config/loader.ts";
 import { getEnvBoolean, getEnvString } from "#veryfront/compat/process.ts";
 import type { HandlerContext } from "../../handlers/types.ts";
 import { buildEnrichedContext } from "../../context/enriched-context.ts";
@@ -211,6 +212,28 @@ function resolveEnvironment(ctx: HandlerContext): "preview" | "production" {
   return ctx.requestContext?.mode ?? "preview";
 }
 
+/**
+ * Load project config for a handler that did not receive one.
+ *
+ * A shared multi-project runtime serves untrusted project sources, so config
+ * is evaluated declaratively under the identity the request already
+ * established. Deriving a source or environment here instead would let one
+ * request evaluate the same project two different ways.
+ */
+async function loadConfigForHandler(
+  ctx: HandlerContext,
+  cacheKey: string | undefined,
+): Promise<VeryfrontConfig> {
+  if (shouldUseMultiProjectContext(ctx) && ctx.prepareHostedConfigContext && cacheKey) {
+    return await getHostedConfig(ctx.projectDir, ctx.adapter, {
+      cacheKey,
+      ...await ctx.prepareHostedConfigContext(),
+    });
+  }
+
+  return await getConfig(ctx.projectDir, ctx.adapter, { cacheKey });
+}
+
 async function createContextFromHandler(ctx: HandlerContext): Promise<RenderContext> {
   // "unknown" is used only for debug logging below — actual cache keys and enriched context
   // use ctx.projectSlug ?? ctx.projectId ?? derivedProjectId (never "unknown"), so there
@@ -233,7 +256,7 @@ async function createContextFromHandler(ctx: HandlerContext): Promise<RenderCont
     });
 
     const configStartTime = performance.now();
-    config = await getConfig(ctx.projectDir, ctx.adapter, { cacheKey });
+    config = await loadConfigForHandler(ctx, cacheKey);
     logger.debug("Loading config from adapter DONE", {
       projectSlug,
       duration: `${(performance.now() - configStartTime).toFixed(2)}ms`,

--- a/src/task/discovery.test.ts
+++ b/src/task/discovery.test.ts
@@ -20,7 +20,12 @@ function createMockAdapter(files: Record<string, string>): FileSystemAdapter {
   return {
     async readFile(path: string): Promise<string> {
       const content = normalizedFiles[normalize(path)];
-      if (content === undefined) throw new Error(`File not found: ${path}`);
+      // Absence must be signalled the way a real filesystem does; config
+      // discovery only moves to the next candidate on a not-found error and
+      // propagates anything else as a backend failure.
+      if (content === undefined) {
+        throw Object.assign(new Error(`File not found: ${path}`), { code: "ENOENT" });
+      }
       return content;
     },
     async exists(path: string): Promise<boolean> {
@@ -113,12 +118,22 @@ function makeTaskSource(name: string): string {
   ].join("\n");
 }
 
+/**
+ * Present the adapter as a trusted single-project virtual filesystem.
+ *
+ * Multi-project mode is not an independent flag: the real wrapper reports it
+ * only when the underlying adapter exposes `runWithContext`, and config on such
+ * a filesystem is untrusted and requires an authenticated request context.
+ * Discovery runs against a single-project API filesystem (see the workflow
+ * worker, which pins one `projectSlug` with `proxyMode: false`), so modelling
+ * it as multi-project here would describe an adapter that cannot exist.
+ */
 function markAdapterAsVirtual(adapter: RuntimeAdapter): void {
   Object.assign(adapter.fs, {
     getUnderlyingAdapter: () => adapter.fs,
     getAdapterType: () => "VeryfrontFSAdapter",
     isVeryfrontAdapter: () => true,
-    isMultiProjectMode: () => true,
+    isMultiProjectMode: () => false,
   });
 }
 
@@ -336,7 +351,7 @@ describe("task/discovery", { sanitizeOps: false, sanitizeResources: false }, () 
     const firstAdapter = createRuntimeAdapter({
       "/veryfront.config.ts": [
         "export default {",
-        '  fs: { type: "veryfront-api" },',
+        '  fs: { type: "veryfront-api", veryfront: { projectSlug: "project-a" } },',
         '  ai: { tasks: { discovery: { paths: ["first-tasks"] } } },',
         "};",
         "",
@@ -356,7 +371,7 @@ describe("task/discovery", { sanitizeOps: false, sanitizeResources: false }, () 
     const secondAdapter = createRuntimeAdapter({
       "/veryfront.config.ts": [
         "export default {",
-        '  fs: { type: "veryfront-api" },',
+        '  fs: { type: "veryfront-api", veryfront: { projectSlug: "project-b" } },',
         '  ai: { tasks: { discovery: { paths: ["second-tasks"] } } },',
         "};",
         "",

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -1,5 +1,6 @@
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "../config/schemas/index.ts";
+import type { PreparedHostedConfigContext } from "../config/loader.ts";
 import type { RequestContext } from "../server/context/request-context.ts";
 import type { EnrichedContext } from "../server/context/enriched-context-types.ts";
 import type { ParsedDomain } from "../server/utils/domain-parser.ts";
@@ -69,6 +70,15 @@ export interface HandlerContext {
   isLocalProject?: boolean;
   /** Environment ID for per-project env var resolution (from proxy x-environment-id header) */
   environmentId?: string;
+  /**
+   * Prepares this request's authenticated hosted evaluation context.
+   *
+   * Present only for shared multi-project runtimes, where project config is
+   * untrusted and must be evaluated declaratively. Handlers that load config
+   * themselves must use this rather than deriving source or environment
+   * identity, so every load in a request shares one identity.
+   */
+  prepareHostedConfigContext?: () => Promise<PreparedHostedConfigContext>;
   /** Route registry for handler chain inspection (dev dashboard) */
   routeRegistry?: {
     getHandlers(): ReadonlyArray<{ metadata: HandlerMetadata }>;


### PR DESCRIPTION
## Summary
- add purpose-specific, proxy-safe filesystem capability capture
- add bounded UTF-8 text reads with exact, whole-file, and stable-snapshot authority
- defensively copy admitted bytes and preserve existing wrapper compatibility
- retain zero-based source snapshot generations

## Verification
- deno task verify:quick
- focused platform capability, bounded reader, wrapper, and multi-project suites: 169 steps green

Stacked on #3233.