### PR TITLE
fix(build): restore dependency-free path glob parity

### DIFF
--- a/src/build/asset-pipeline/css-optimizer/utils.test.ts
+++ b/src/build/asset-pipeline/css-optimizer/utils.test.ts
@@ -212,6 +212,30 @@ describe("CSS Optimizer Utils", () => {
       }
     });
 
+    it("applies negative extglobs to complete CSS discovery segments", async () => {
+      await cleanupTestDir();
+      try {
+        await ensureDir(join(TEST_DIR, "src", "app"));
+        await ensureDir(join(TEST_DIR, "src", "generated"));
+        await ensureDir(join(TEST_DIR, "src", "generated-extra"));
+        await ensureDir(join(TEST_DIR, "src", "vendor"));
+        await writeTextFile(join(TEST_DIR, "src", "app", "page.tsx"), "content");
+        await writeTextFile(join(TEST_DIR, "src", "generated", "page.tsx"), "content");
+        await writeTextFile(join(TEST_DIR, "src", "generated-extra", "page.tsx"), "content");
+        await writeTextFile(join(TEST_DIR, "src", "vendor", "page.tsx"), "content");
+
+        const files = await globFiles(
+          `${TEST_DIR}/src/!(generated|vendor)/**/*.tsx`,
+        );
+
+        assertEquals(files.map((file) => file.replaceAll("\\", "/")), [
+          resolve(TEST_DIR, "src", "app", "page.tsx").replaceAll("\\", "/"),
+        ]);
+      } finally {
+        await cleanupTestDir();
+      }
+    });
+
     it("rejects patterns outside the project boundary", async () => {
       const baseDir = await Deno.makeTempDir();
       try {

--- a/src/build/utils/path-glob.test.ts
+++ b/src/build/utils/path-glob.test.ts
@@ -65,6 +65,69 @@ describe("build/utils/path-glob", () => {
     assertMatches("!(test).ts", ["page.ts", "contest.ts"], ["test.ts"]);
   });
 
+  it("preserves captured extended-glob and globstar compatibility", () => {
+    const parityCases: ReadonlyArray<{
+      pattern: string;
+      matches: string[];
+      rejects: string[];
+    }> = [
+      {
+        pattern: "!(foo|bar).ts",
+        matches: ["baz.ts", "quxfoo.ts"],
+        rejects: ["foo.ts", "bar.ts", "foobar.ts"],
+      },
+      {
+        pattern: "src/!(generated|vendor)/**/*.ts",
+        matches: ["src/app/index.ts"],
+        rejects: [
+          "src/generated/index.ts",
+          "src/generated-extra/index.ts",
+          "src/vendor/a.ts",
+          "src/vendorized/a.ts",
+        ],
+      },
+      {
+        pattern: "foo!(@(bar|baz)|qux)end",
+        matches: ["fooend", "foomoreend"],
+        rejects: ["foobarend", "foobazend", "fooquxend", "foobazmoreend"],
+      },
+      {
+        pattern: "@(src|app)/**/!(*.test).@(ts|tsx)",
+        matches: ["src/a.ts", "src/x/a.tsx", "app/test.ts", "app/.ts"],
+        rejects: ["src/a.test.ts", "other/a.ts"],
+      },
+      {
+        pattern: "a/**",
+        matches: ["a/", "a/b", "a/b/c"],
+        rejects: ["a", "b"],
+      },
+      {
+        pattern: "a/**/b/**",
+        matches: ["a/b/", "a/b/c", "a/x/b/c"],
+        rejects: ["a/b", "a/x/b"],
+      },
+      {
+        pattern: "a/**/**",
+        matches: ["a/b", "a/b/c"],
+        rejects: ["a"],
+      },
+      {
+        pattern: "a/**/b",
+        matches: ["a/b", "a/x/b", "a/x/y/b"],
+        rejects: ["a", "a/x"],
+      },
+      {
+        pattern: "{src,app}/**/*.{ts,tsx}",
+        matches: ["src/a.ts", "src/x/a.tsx", "app/a.tsx"],
+        rejects: ["app/a.js", "other/a.ts"],
+      },
+    ];
+
+    for (const testCase of parityCases) {
+      assertMatches(testCase.pattern, testCase.matches, testCase.rejects);
+    }
+  });
+
   it("supports character ranges, negation, POSIX classes, and escapes", () => {
     assertMatches("file[0-2].ts", ["file0.ts", "file2.ts"], ["file3.ts", "file10.ts"]);
     assertMatches("file[!0-2].ts", ["file3.ts", "filex.ts"], ["file0.ts"]);

--- a/src/build/utils/path-glob.test.ts
+++ b/src/build/utils/path-glob.test.ts
@@ -128,6 +128,62 @@ describe("build/utils/path-glob", () => {
     }
   });
 
+  it("sinks negative extglobs that carry an empty alternative", () => {
+    // An empty alternative matches at every position, so the negative
+    // lookahead it compiles to can never succeed. `globToRegExp` builds
+    // `^(?!|foo)[^/]*\.ts\/*$` for `!(|foo).ts`, which matches nothing; the
+    // positive forms below confirm the empty alternative is still parsed
+    // rather than silently dropped.
+    const emptyAlternativeCases: ReadonlyArray<{
+      pattern: string;
+      matches: string[];
+      rejects: string[];
+    }> = [
+      {
+        pattern: "!(|foo).ts",
+        matches: [],
+        rejects: ["bar.ts", "foo.ts", ".ts", "foobar.ts"],
+      },
+      {
+        pattern: "!(foo|).ts",
+        matches: [],
+        rejects: ["bar.ts", "foo.ts", ".ts", "foobar.ts"],
+      },
+      {
+        pattern: "!(|).ts",
+        matches: [],
+        rejects: ["bar.ts", ".ts"],
+      },
+      {
+        pattern: "a!(|b)c",
+        matches: [],
+        rejects: ["abc", "ac", "axc"],
+      },
+      // Control: the same negation without an empty alternative still
+      // excludes only the forbidden stem.
+      {
+        pattern: "!(foo).ts",
+        matches: ["bar.ts", ".ts"],
+        rejects: ["foo.ts", "foobar.ts"],
+      },
+      // Positive extglobs honor the empty alternative as a zero-length branch.
+      {
+        pattern: "@(|foo).ts",
+        matches: ["foo.ts", ".ts"],
+        rejects: ["bar.ts"],
+      },
+      {
+        pattern: "?(|foo).ts",
+        matches: ["foo.ts", ".ts"],
+        rejects: ["bar.ts"],
+      },
+    ];
+
+    for (const testCase of emptyAlternativeCases) {
+      assertMatches(testCase.pattern, testCase.matches, testCase.rejects);
+    }
+  });
+
   it("supports character ranges, negation, POSIX classes, and escapes", () => {
     assertMatches("file[0-2].ts", ["file0.ts", "file2.ts"], ["file3.ts", "file10.ts"]);
     assertMatches("file[!0-2].ts", ["file3.ts", "filex.ts"], ["file0.ts"]);

--- a/src/build/utils/path-glob.test.ts
+++ b/src/build/utils/path-glob.test.ts
@@ -63,9 +63,15 @@ describe("build/utils/path-glob", () => {
     assertMatches("*(ab)c.ts", ["c.ts", "abc.ts", "ababc.ts"], ["ac.ts"]);
     assertMatches("+(ab)c.ts", ["abc.ts", "ababc.ts"], ["c.ts", "ac.ts"]);
     assertMatches("!(test).ts", ["page.ts", "contest.ts"], ["test.ts"]);
+    assertMatches("!(|foo).ts", ["bar.ts"], [".ts", "foo.ts", "foobar.ts"]);
   });
 
-  it("preserves captured extended-glob and globstar compatibility", () => {
+  it("keeps normalized path semantics instead of legacy empty-segment leakage", () => {
+    assertMatches("**/!(a|b)", ["c", "x/c"], ["a", "b", "x/a", "x/b"]);
+    assertMatches("a/*", ["a/b"], ["a", "a/"]);
+  });
+
+  it("preserves captured extended-glob and globstar compatibility where semantics agree", () => {
     const parityCases: ReadonlyArray<{
       pattern: string;
       matches: string[];
@@ -128,12 +134,7 @@ describe("build/utils/path-glob", () => {
     }
   });
 
-  it("sinks negative extglobs that carry an empty alternative", () => {
-    // An empty alternative matches at every position, so the negative
-    // lookahead it compiles to can never succeed. `globToRegExp` builds
-    // `^(?!|foo)[^/]*\.ts\/*$` for `!(|foo).ts`, which matches nothing; the
-    // positive forms below confirm the empty alternative is still parsed
-    // rather than silently dropped.
+  it("treats an empty negative alternative as excluding the zero-length endpoint", () => {
     const emptyAlternativeCases: ReadonlyArray<{
       pattern: string;
       matches: string[];
@@ -141,23 +142,23 @@ describe("build/utils/path-glob", () => {
     }> = [
       {
         pattern: "!(|foo).ts",
-        matches: [],
-        rejects: ["bar.ts", "foo.ts", ".ts", "foobar.ts"],
+        matches: ["bar.ts"],
+        rejects: ["foo.ts", ".ts", "foobar.ts"],
       },
       {
         pattern: "!(foo|).ts",
-        matches: [],
-        rejects: ["bar.ts", "foo.ts", ".ts", "foobar.ts"],
+        matches: ["bar.ts"],
+        rejects: ["foo.ts", ".ts", "foobar.ts"],
       },
       {
         pattern: "!(|).ts",
-        matches: [],
-        rejects: ["bar.ts", ".ts"],
+        matches: ["bar.ts"],
+        rejects: [".ts"],
       },
       {
         pattern: "a!(|b)c",
-        matches: [],
-        rejects: ["abc", "ac", "axc"],
+        matches: ["axc"],
+        rejects: ["abc", "ac"],
       },
       // Control: the same negation without an empty alternative still
       // excludes only the forbidden stem.

--- a/src/build/utils/path-glob.ts
+++ b/src/build/utils/path-glob.ts
@@ -454,6 +454,9 @@ function compileSegment(segment: string, pattern: string): CompiledSegment {
             // segment-local wildcard. Any forbidden alternative that matches
             // at this position rejects the whole node; it is not merely one
             // disallowed end position among otherwise valid prefixes.
+            // An empty alternative therefore sinks the node outright, because
+            // it matches at every position: `!(|foo)` matches nothing at all,
+            // exactly as the `(?!|foo)` lookahead it mirrors.
             if (excluded.size === 0) {
               budget.consume(value.length - start + 1);
               for (let end = start; end <= value.length; end++) ends.add(end);

--- a/src/build/utils/path-glob.ts
+++ b/src/build/utils/path-glob.ts
@@ -454,12 +454,20 @@ function compileSegment(segment: string, pattern: string): CompiledSegment {
             // segment-local wildcard. Any forbidden alternative that matches
             // at this position rejects the whole node; it is not merely one
             // disallowed end position among otherwise valid prefixes.
-            // An empty alternative therefore sinks the node outright, because
-            // it matches at every position: `!(|foo)` matches nothing at all,
-            // exactly as the `(?!|foo)` lookahead it mirrors.
-            if (excluded.size === 0) {
+            // An empty alternative excludes only the zero-length endpoint; it
+            // must not turn the entire negative group into match-nothing.
+            let excludesNonEmptyPrefix = false;
+            for (const end of excluded) {
+              if (end > start) {
+                excludesNonEmptyPrefix = true;
+                break;
+              }
+            }
+            if (!excludesNonEmptyPrefix) {
               budget.consume(value.length - start + 1);
-              for (let end = start; end <= value.length; end++) ends.add(end);
+              for (let end = start; end <= value.length; end++) {
+                if (!excluded.has(end)) ends.add(end);
+              }
             }
             break;
           }

--- a/src/build/utils/path-glob.ts
+++ b/src/build/utils/path-glob.ts
@@ -450,9 +450,13 @@ function compileSegment(segment: string, pattern: string): CompiledSegment {
             break;
           case "negative": {
             const excluded = evaluateAlternatives(node.alternatives, start);
-            budget.consume(value.length - start + 1);
-            for (let end = start; end <= value.length; end++) {
-              if (!excluded.has(end)) ends.add(end);
+            // A negative extglob is a negative lookahead followed by a
+            // segment-local wildcard. Any forbidden alternative that matches
+            // at this position rejects the whole node; it is not merely one
+            // disallowed end position among otherwise valid prefixes.
+            if (excluded.size === 0) {
+              budget.consume(value.length - start + 1);
+              for (let end = start; end <= value.length; end++) ends.add(end);
             }
             break;
           }
@@ -531,11 +535,15 @@ function normalizePattern(value: string): { absolute: boolean; segments: string[
   };
 }
 
-function normalizeCandidatePath(value: string): { absolute: boolean; segments: string[] } {
+function normalizeCandidatePath(
+  value: string,
+): { absolute: boolean; trailingSeparator: boolean; segments: string[] } {
   const portable = value.replaceAll("\\", "/");
   return {
     absolute: portable.startsWith("/"),
-    // Repeated and trailing separators have no matching significance.
+    // A trailing separator is significant when it is the separator required
+    // before a final globstar that consumes zero complete segments.
+    trailingSeparator: portable.endsWith("/"),
     segments: portable.split("/").filter((segment) => segment.length > 0),
   };
 }
@@ -568,7 +576,8 @@ export function compilePathGlob(pattern: string): PathGlobMatcher {
     const budget = createMatchBudget(pattern);
     let reachablePathIndexes = new Set([0]);
 
-    for (const segment of compiledSegments) {
+    for (let segmentIndex = 0; segmentIndex < compiledSegments.length; segmentIndex++) {
+      const segment = compiledSegments[segmentIndex]!;
       budget.consume();
       if (segment === "globstar") {
         let firstReachable = candidate.segments.length + 1;
@@ -576,6 +585,18 @@ export function compilePathGlob(pattern: string): PathGlobMatcher {
           if (pathIndex < firstReachable) firstReachable = pathIndex;
         }
         reachablePathIndexes = new Set<number>();
+        // Every non-leading pattern segment has a separator before it. A
+        // globstar may consume zero segments only when that separator exists:
+        // either another candidate segment follows or the candidate itself
+        // ends in a separator. This preserves `a/**` != `a` while retaining
+        // the zero-segment behavior of `a/**/b` and leading `**/b`.
+        if (
+          segmentIndex > 0 &&
+          firstReachable === candidate.segments.length &&
+          !candidate.trailingSeparator
+        ) {
+          continue;
+        }
         budget.consume(candidate.segments.length - firstReachable + 1);
         for (
           let pathIndex = firstReachable;


### PR DESCRIPTION
## Summary

- restore bounded negative-extglob prefix exclusion without making empty alternatives match nothing
- preserve the separator required before a trailing zero-segment globstar
- define normalized empty-segment semantics with explicit regression tests
- cover negative extglobs through CSS content-file discovery

## Why

The dependency-free matcher introduced in #3229 treated each forbidden negative-extglob endpoint independently. That admitted paths beginning with an excluded non-empty alternative, such as generated-extra for !(generated|vendor). It also normalized away the separator that distinguishes a/** from a.

An empty negative alternative excludes only the zero-length endpoint: !(|foo).ts matches bar.ts while rejecting .ts, foo.ts, and the existing forbidden-prefix cases.

## Intentional divergences from the former regex matcher

Candidate separators are normalized before matching. Therefore a/* rejects both a and a/, and **/!(a|b) rejects terminal a or b instead of allowing the former regex engine to leak a globstar-consumed segment into an empty trailing match. These are explicit contract cases, not claimed parity gaps.

## Verification

- focused path matcher and CSS discovery suites: 42 steps green
- deno check src/build/utils/path-glob.ts
- deno task lint:core-deps
- deno task verify:quick on the earlier focused head

Core remains dependency-free; no external matcher was reintroduced.