### PR TITLE
fix(errors): preserve boundary detachment

### DIFF
--- a/docs/api-reference/veryfront/errors.md
+++ b/docs/api-reference/veryfront/errors.md
@@ -198,7 +198,7 @@ throw INVALID_WIDGET.create({ detail: "The widget id is malformed." });
 | `withErrorContextSync` | Execute sync operation with error logging and fallback | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/error-context.ts#L79) |
 | `wrapErrorHandler` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/user-friendly/error-wrapper.ts#L6) |
 | `wrapHandlerWithErrorBoundary` | Wrap a complete Handler object with error boundary | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/middleware/http-error-boundary.ts#L78) |
-| `wrapUnknownError` | Return a detached, framework-owned VeryfrontError while preserving safe identity fields from valid VeryfrontError inputs | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/middleware/wrap-unknown.ts#L35) |
+| `wrapUnknownError` | Return a detached VeryfrontError, preserving safe identity fields from valid VeryfrontError inputs | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/middleware/wrap-unknown.ts#L35) |
 | `wrapWithContext` | Wrap an error with additional context | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/middleware/wrap-unknown.ts#L78) |
 
 ### Classes

--- a/docs/api-reference/veryfront/errors.md
+++ b/docs/api-reference/veryfront/errors.md
@@ -198,7 +198,7 @@ throw INVALID_WIDGET.create({ detail: "The widget id is malformed." });
 | `withErrorContextSync` | Execute sync operation with error logging and fallback | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/error-context.ts#L79) |
 | `wrapErrorHandler` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/user-friendly/error-wrapper.ts#L6) |
 | `wrapHandlerWithErrorBoundary` | Wrap a complete Handler object with error boundary | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/middleware/http-error-boundary.ts#L78) |
-| `wrapUnknownError` | Wrap any unknown error as a VeryfrontError with unknown-error slug | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/middleware/wrap-unknown.ts#L35) |
+| `wrapUnknownError` | Return a detached, framework-owned VeryfrontError while preserving safe identity fields from valid VeryfrontError inputs | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/middleware/wrap-unknown.ts#L35) |
 | `wrapWithContext` | Wrap an error with additional context | [source](https://github.com/veryfront/veryfront-code/blob/main/src/errors/middleware/wrap-unknown.ts#L78) |
 
 ### Classes

--- a/src/errors/README.md
+++ b/src/errors/README.md
@@ -116,9 +116,11 @@ metadata, and return RFC 9457 responses.
 Use `cliErrorBoundary()` for CLI entry points. CLI output may include local
 diagnostic details and development stack frames.
 
-`wrapUnknownError()` retains an existing `VeryfrontError` or creates the
-canonical `unknown-error`. `wrapWithContext()` creates a new error and preserves
-the original error as provenance.
+`wrapUnknownError()` always returns a detached, framework-owned error. A valid
+`VeryfrontError` keeps its stable slug, category, status, title, and other safe
+identity fields, but never its object identity or mutable caller-owned context.
+Other values become the canonical `unknown-error`. `wrapWithContext()` creates
+a new error and preserves the original error as provenance.
 
 Boundary adapters inspect genuine errors through runtime brand checks and own
 data properties. Proxy-wrapped errors and arbitrary thrown objects are opaque:

--- a/src/errors/middleware/wrap-unknown.test.ts
+++ b/src/errors/middleware/wrap-unknown.test.ts
@@ -28,12 +28,16 @@ describe("wrap-unknown", () => {
       assertEquals(wrapped.cause, error);
     });
 
-    it("should return VeryfrontError unchanged", () => {
-      const error = CONFIG_NOT_FOUND.create();
+    it("should detach a VeryfrontError from mutable caller-owned state", () => {
+      const context = { operation: "initial" };
+      const error = CONFIG_NOT_FOUND.create({ context });
       const wrapped = wrapUnknownError(error);
 
-      assertEquals(wrapped, error);
+      context.operation = "mutated";
+
+      assertEquals(wrapped === error, false);
       assertEquals(wrapped.slug, "config-not-found");
+      assertEquals(wrapped.context, undefined);
     });
 
     it("should safely replace hostile VeryfrontError proxies", () => {

--- a/src/errors/middleware/wrap-unknown.ts
+++ b/src/errors/middleware/wrap-unknown.ts
@@ -53,7 +53,7 @@ export function wrapUnknownError(
 ): VeryfrontError {
   const detached = detachThrowableForBoundary(error);
   if (isVeryfrontErrorInstance(detached)) {
-    return isVeryfrontErrorInstance(error) ? error : detached;
+    return detached;
   }
 
   return UNKNOWN_ERROR.create({

--- a/src/errors/middleware/wrap-unknown.ts
+++ b/src/errors/middleware/wrap-unknown.ts
@@ -35,7 +35,8 @@ function snapshotContext(
  *
  * @param error - Any error value (Error, VeryfrontError, string, etc.)
  * @param context - Optional context to add to the wrapped error
- * @returns VeryfrontError instance with unknown-error slug
+ * @returns A detached, framework-owned VeryfrontError. Valid VeryfrontError
+ * inputs retain safe identity fields; other inputs use the unknown-error slug.
  *
  * @example
  * ```typescript

--- a/src/errors/middleware/wrap-unknown.ts
+++ b/src/errors/middleware/wrap-unknown.ts
@@ -28,13 +28,13 @@ function snapshotContext(
 }
 
 /**
- * Wrap any unknown error as a VeryfrontError with unknown-error slug
+ * Return a detached VeryfrontError, preserving safe identity fields from valid VeryfrontError inputs
  *
  * This function is used at system boundaries (HTTP, CLI, etc.) to ensure
  * all errors have slug-based identity for consistent handling.
  *
- * @param error - Any error value (Error, VeryfrontError, string, etc.)
- * @param context - Optional context to add to the wrapped error
+ * @param error - A valid VeryfrontError to detach, or another value to wrap as unknown-error
+ * @param context - Optional context added only when error is not a valid VeryfrontError
  * @returns A detached, framework-owned VeryfrontError. Valid VeryfrontError
  * inputs retain safe identity fields; other inputs use the unknown-error slug.
  *


### PR DESCRIPTION
## Summary

- return the framework-owned detached `VeryfrontError` snapshot from `wrapUnknownError`
- stop re-exposing mutable caller-owned error/context state after the boundary snapshot
- replace the historical identity assertion with a mutation-isolation regression

## Source

Fix-forward finding from the post-merge audit of #3227. The hardening change detached the throwable but then returned the original branded error, defeating the boundary guarantee.

## Verification

- `deno test --allow-all src/errors/middleware/wrap-unknown.test.ts src/errors/safe-diagnostics.test.ts src/errors/middleware/http-error-boundary.test.ts`
- `deno check src/errors/middleware/wrap-unknown.ts`
- `git diff --check`