### PR TITLE
fix: address post-merge review findings

### DIFF
--- a/src/platform/compat/std/dotenv.test.ts
+++ b/src/platform/compat/std/dotenv.test.ts
@@ -30,6 +30,7 @@ describe("platform/compat/std/dotenv", () => {
         "EMPTY=",
         "SINGLE='  $EXPORTED  '",
         'DOUBLE="line\\nnext\\tend"',
+        'ESCAPED_BACKSLASH="path\\\\nvalue"',
         'MULTILINE="first',
         'second"',
         "INLINE=kept#comment",
@@ -42,6 +43,7 @@ describe("platform/compat/std/dotenv", () => {
     assertEquals(Object.hasOwn(result, "EMPTY"), true);
     assertEquals(result.SINGLE, "  $EXPORTED  ");
     assertEquals(result.DOUBLE, "line\nnext\tend");
+    assertEquals(result.ESCAPED_BACKSLASH, "path\\nvalue");
     assertEquals(result.MULTILINE, "first\nsecond");
     assertEquals(result.INLINE, "kept");
   });
@@ -60,6 +62,7 @@ describe("platform/compat/std/dotenv", () => {
           "DEFAULT_VALUE=${DOES_NOT_EXIST:-fallback}",
           "NESTED_DEFAULT=${DOES_NOT_EXIST:-${LATER:-other}}",
           String.raw`ESCAPED=\$LATER`,
+          String.raw`DOUBLE_ESCAPED=\\$LATER`,
         ].join("\n"),
       );
 
@@ -69,6 +72,7 @@ describe("platform/compat/std/dotenv", () => {
       assertEquals(result.DEFAULT_VALUE, "fallback");
       assertEquals(result.NESTED_DEFAULT, "present");
       assertEquals(result.ESCAPED, String.raw`\$LATER`);
+      assertEquals(result.DOUBLE_ESCAPED, String.raw`\\present`);
     } finally {
       deleteEnv(hostKey);
     }

--- a/src/platform/compat/std/dotenv.ts
+++ b/src/platform/compat/std/dotenv.ts
@@ -236,9 +236,10 @@ function isEscaped(value: string, index: number): boolean {
 }
 
 function expandDoubleQuotedCharacters(value: string): string {
-  return value.replace(/\\([nrt])/g, (_match, character: string) => {
+  return value.replace(/\\([nrt\\])/g, (_match, character: string) => {
     if (character === "n") return "\n";
     if (character === "r") return "\r";
+    if (character === "\\") return "\\";
     return "\t";
   });
 }
@@ -318,7 +319,7 @@ function expandValue(
   let literalStart = 0;
 
   for (let index = 0; index < source.length;) {
-    if (source[index] !== "$" || (index > 0 && source[index - 1] === "\\")) {
+    if (source[index] !== "$" || isEscaped(source, index)) {
       index++;
       continue;
     }


### PR DESCRIPTION
Fixes confirmed findings from a post-merge review sweep of the last ~10 merged PRs.

## dotenv escape handling (from #3230)

- `expandDoubleQuotedCharacters` expanded `\n`/`\r`/`\t` but not `\\`, so a double-quoted value like `"path\\nvalue"` produced backslash+newline instead of the literal backslash+n that `@std/dotenv` produces.
- `expandValue` suppressed interpolation whenever the character before `$` was a backslash, so `\\$VAR` (escaped backslash — even count) wrongly skipped interpolation. Now uses the existing `isEscaped()` parity check, matching `findClosingQuote`.

Further commits on this branch address latent findings from #3226/#3227 (AJV strictness, 5xx detail stripping, logError OTel bypass).

Review provenance: adversarial post-merge sweep of #3222–#3232; all other reviewed PRs came back clean.