### PR TITLE
fix(extensions): bound preset metadata

### DIFF
--- a/docs/guides/extension-authoring.md
+++ b/docs/guides/extension-authoring.md
@@ -225,6 +225,10 @@ const webPreset: ExtensionFactory = () => ({
 export default webPreset;
 ```
 
+Preset metadata must be a dense array with at most 256 direct children.
+Veryfront rejects graphs deeper than 32 levels or larger than 4,096 visited
+nodes so malformed or cyclic composition cannot exhaust startup resources.
+
 During development, changes to `veryfront.config.ts` trigger teardown,
 rediscovery, and setup. Release resources in `teardown()` so reloads do not leak
 connections, timers, or file handles.

--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -1421,6 +1421,42 @@ describe("ExtensionLoader", () => {
       assertEquals(flat[0]?.extension.name, "leaf");
       assertEquals(flat[1]?.extension.name, "leaf");
     });
+
+    it("uses the bounded descriptor snapshot instead of proxy get traps", () => {
+      const child = makeExt("child");
+      const target = makeExt("preset", { extends: [child] });
+      let getCalls = 0;
+      const preset = new Proxy(target, {
+        get(_target, property, receiver) {
+          getCalls++;
+          if (property === "extends") return [receiver];
+          return Reflect.get(target, property, receiver);
+        },
+      });
+      const resolved = makeResolved(preset);
+      getCalls = 0;
+
+      const loader = new ExtensionLoader(noopLogger);
+      const flat = loader.flattenPresets([resolved]);
+
+      assertEquals(getCalls, 0);
+      assertEquals(flat.length, 1);
+      assertEquals(flat[0]?.extension, child);
+    });
+
+    it("bounds recursive preset graphs before stack or memory exhaustion", () => {
+      let preset = makeExt("leaf");
+      for (let depth = 0; depth <= 32; depth++) {
+        preset = makeExt(`preset-${depth}`, { extends: [preset] });
+      }
+
+      const loader = new ExtensionLoader(noopLogger);
+      assertThrows(
+        () => loader.flattenPresets([makeResolved(preset)]),
+        Error,
+        "nesting exceeds 32 levels",
+      );
+    });
   });
 
   describe("setupAll() — source priority on register()", () => {

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -49,7 +49,11 @@ import {
   containsUnicodeControlOrLineSeparator,
   isWellFormedUnicode,
   MAX_EXTENSION_NAME_CHARACTERS,
+  MAX_EXTENSION_PRESET_CHILDREN,
+  MAX_EXTENSION_PRESET_DEPTH,
+  MAX_EXTENSION_PRESET_NODES,
   MAX_EXTENSION_VERSION_CHARACTERS,
+  snapshotDenseMetadataArray,
 } from "./metadata-policy.ts";
 import {
   createIntrinsicPromise,
@@ -265,33 +269,47 @@ export class ExtensionLoader {
    * than stack-overflowing.
    */
   flattenPresets(extensions: ResolvedExtension[]): ResolvedExtension[] {
-    return this.flattenPresetsInner(extensions, new Set());
+    return this.flattenPresetsInner(extensions, new Set(), 0, { visited: 0 });
   }
 
   private flattenPresetsInner(
     extensions: ResolvedExtension[],
     path: Set<Extension>,
+    depth: number,
+    budget: { visited: number },
   ): ResolvedExtension[] {
+    if (depth > MAX_EXTENSION_PRESET_DEPTH) {
+      throw EXTENSION_VALIDATION_ERROR.create({
+        message: `Extension preset nesting exceeds ${MAX_EXTENSION_PRESET_DEPTH} levels`,
+      });
+    }
     const result: ResolvedExtension[] = [];
 
     for (const resolved of extensions) {
+      budget.visited += 1;
+      if (budget.visited > MAX_EXTENSION_PRESET_NODES) {
+        throw EXTENSION_VALIDATION_ERROR.create({
+          message: `Extension preset graph exceeds ${MAX_EXTENSION_PRESET_NODES} nodes`,
+        });
+      }
       const candidate = resolved.extension as unknown;
       this.assertValidExtension(candidate);
       const ext = candidate;
+      const preset = this.snapshotPresetMetadata(ext);
 
-      if (ext.extends && ext.extends.length > 0) {
+      if (preset.children.length > 0) {
         if (path.has(ext)) {
           throw EXTENSION_VALIDATION_ERROR.create({
-            message: `Circular preset extends chain detected via "${ext.name}"`,
+            message: `Circular preset extends chain detected via "${preset.extensionName}"`,
           });
         }
         path.add(ext);
-        const children = ext.extends.map((child) => ({
+        const children = preset.children.map((child) => ({
           extension: child,
           source: resolved.source,
           origin: resolved.origin,
         }));
-        result.push(...this.flattenPresetsInner(children, path));
+        result.push(...this.flattenPresetsInner(children, path, depth + 1, budget));
         path.delete(ext);
       } else {
         result.push(resolved);
@@ -299,6 +317,50 @@ export class ExtensionLoader {
     }
 
     return result;
+  }
+
+  private snapshotPresetMetadata(
+    extension: Extension,
+  ): Readonly<{ extensionName: string; children: readonly Extension[] }> {
+    const read = (field: "name" | "extends"): unknown => {
+      let descriptor: PropertyDescriptor | undefined;
+      try {
+        descriptor = Object.getOwnPropertyDescriptor(extension, field);
+      } catch (cause) {
+        throw new TypeError(`extension.${field} could not be inspected`, { cause });
+      }
+      if (!descriptor) return undefined;
+      if (!descriptor.enumerable || !("value" in descriptor)) {
+        throw new TypeError(
+          `extension.${field} must be an enumerable own data property`,
+        );
+      }
+      return descriptor.value;
+    };
+
+    const extensionName = read("name");
+    if (
+      typeof extensionName !== "string" || extensionName.trim().length === 0 ||
+      extensionName.trim() !== extensionName ||
+      extensionName.length > MAX_EXTENSION_NAME_CHARACTERS ||
+      !isWellFormedUnicode(extensionName) ||
+      containsUnicodeControlOrLineSeparator(extensionName)
+    ) {
+      throw new TypeError("extension.name changed after validation");
+    }
+    const extendsValue = read("extends");
+    const children = extendsValue === undefined
+      ? Object.freeze([]) as readonly unknown[]
+      : snapshotDenseMetadataArray(
+        extendsValue,
+        "extension.extends",
+        0,
+        MAX_EXTENSION_PRESET_CHILDREN,
+      );
+    return Object.freeze({
+      extensionName,
+      children: children as readonly Extension[],
+    });
   }
 
   /**

--- a/src/extensions/metadata-policy.ts
+++ b/src/extensions/metadata-policy.ts
@@ -21,6 +21,9 @@ export const MAX_CAPABILITY_AUDIT_UTF8_BYTES = 49_152;
 export const MAX_CAPABILITY_AUDIT_UTF16_CODE_UNITS = 49_152;
 export const MAX_EXTENSION_CONTRACTS_PER_LIST = 256;
 export const MAX_EXTENSION_CONTRACT_NAME_CHARACTERS = 256;
+export const MAX_EXTENSION_PRESET_CHILDREN = 256;
+export const MAX_EXTENSION_PRESET_DEPTH = 32;
+export const MAX_EXTENSION_PRESET_NODES = 4096;
 
 /**
  * Conservative aggregate budget for every Deno permission flag produced for

--- a/src/extensions/validation.test.ts
+++ b/src/extensions/validation.test.ts
@@ -480,6 +480,55 @@ describe("validateExtension", () => {
     assertEquals(issues.some((issue) => issue.includes("extends")), true);
   });
 
+  it("requires preset children to be a bounded dense descriptor snapshot", () => {
+    const child: Extension = {
+      name: "child",
+      version: "1.0.0",
+      capabilities: [],
+    };
+    const children = new Proxy([child], {
+      get(target, property, receiver) {
+        if (property === "length" || property === "0") {
+          throw new Error(`must not read ${String(property)}`);
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    assertEquals(
+      validateExtension({
+        name: "preset",
+        version: "1.0.0",
+        capabilities: [],
+        extends: children,
+      }),
+      [],
+    );
+
+    const sparse = new Array<Extension>(1);
+    const sparseIssues = validateExtension({
+      name: "sparse-preset",
+      version: "1.0.0",
+      capabilities: [],
+      extends: sparse,
+    });
+    assertEquals(
+      sparseIssues.some((issue) => issue.includes("dense array")),
+      true,
+    );
+
+    const oversized = Array.from({ length: 257 }, () => child);
+    const oversizedIssues = validateExtension({
+      name: "oversized-preset",
+      version: "1.0.0",
+      capabilities: [],
+      extends: oversized,
+    });
+    assertEquals(
+      oversizedIssues.some((issue) => issue.includes("at most 256 entries")),
+      true,
+    );
+  });
+
   it("rejects null input", () => {
     const issues = validateExtension(null);
     assertEquals(issues.length, 1);

--- a/src/extensions/validation.ts
+++ b/src/extensions/validation.ts
@@ -18,6 +18,7 @@ import {
   MAX_EXTENSION_CONTRACT_NAME_CHARACTERS,
   MAX_EXTENSION_CONTRACTS_PER_LIST,
   MAX_EXTENSION_NAME_CHARACTERS,
+  MAX_EXTENSION_PRESET_CHILDREN,
   MAX_EXTENSION_VERSION_CHARACTERS,
   snapshotDenseMetadataArray,
 } from "./metadata-policy.ts";
@@ -489,12 +490,17 @@ export function validateExtension(ext: unknown): string[] {
   }
 
   const extendsField = readField(candidate, "extends", issues);
-  if (
-    extendsField.ok &&
-    extendsField.value !== undefined &&
-    !Array.isArray(extendsField.value)
-  ) {
-    issues.push("extends must be an array");
+  if (extendsField.ok && extendsField.value !== undefined) {
+    try {
+      snapshotDenseMetadataArray(
+        extendsField.value,
+        "extends",
+        0,
+        MAX_EXTENSION_PRESET_CHILDREN,
+      );
+    } catch (error) {
+      issues.push(describeThrownValue(error));
+    }
   }
 
   return issues;


### PR DESCRIPTION
## Summary
- descriptor-snapshot preset `extends` metadata without invoking proxy get traps
- require dense arrays and bound direct children, nesting depth, and total visited nodes
- document the production limits and cover proxy TOCTOU, sparse, oversized, and deep graphs

## Post-merge finding
Symptom: preset composition was the remaining extension metadata path read directly after descriptor-based validation and had no density or size limits.

Source: `flattenPresetsInner()` repeatedly read `ext.extends` and `ext.name`, while `validateExtension()` only checked `Array.isArray(extends)`.

Consequence: a proxy could return different composition data through `get` than the data validated through descriptors, and malformed graphs could consume unbounded startup stack or memory.

Remedy: use an immutable descriptor snapshot and enforce shared limits of 256 children, 32 levels, and 4,096 visited nodes.

## Verification
- `deno test --allow-all src/extensions/validation.test.ts src/extensions/loader.test.ts` (143 steps passed)
- `deno task typecheck`
- `git diff --check`
