### PR TITLE
fix(schemas): bound compiled validation resources

### DIFF
--- a/extensions/ext-schema-zod/README.md
+++ b/extensions/ext-schema-zod/README.md
@@ -78,6 +78,28 @@ register("SchemaValidator", createZodAdapter());
 
 `toJsonSchema(schema)` converts any `Schema<T>` to a JSON Schema object for OpenAPI or tool-call definitions.
 
+`compileJsonSchema(schema)` compiles raw JSON Schema with strict validation,
+standard formats, and no coercion, default insertion, or removal of additional
+properties.
+
+| Boundary                          | Limit                                         |
+| --------------------------------- | --------------------------------------------- |
+| Schema depth                      | 64 levels                                     |
+| Schema nodes                      | 8,192                                         |
+| Serialized schema                 | 512 KiB                                       |
+| Schema string                     | 256 KiB                                       |
+| Schema property name              | 4 KiB UTF-8                                   |
+| Direct combinator or tuple fanout | 256 branches                                  |
+| Nested compilation work           | 24,000 units                                  |
+| Validation input                  | 128 levels, 100,000 nodes, 4 MiB serialized   |
+| Compiled-validator cache          | 128 entries and 2 MiB aggregate source weight |
+
+Schemas and inputs must be data-only JSON. Accessors, symbol or hidden keys,
+custom object prototypes, cycles, sparse arrays, and revoked proxies are
+rejected without invoking user code. Successful validation returns the
+adapter-owned input snapshot. Cache eviction is least-recently used when
+either cache limit is exceeded.
+
 ## Running Tests
 
 ```sh

--- a/extensions/ext-schema-zod/README.md
+++ b/extensions/ext-schema-zod/README.md
@@ -89,16 +89,18 @@ properties.
 | Serialized schema                 | 512 KiB                                       |
 | Schema string                     | 256 KiB                                       |
 | Schema property name              | 4 KiB UTF-8                                   |
-| Direct combinator or tuple fanout | 256 branches                                  |
+| Code-generating collection fanout | 256 entries                                   |
 | Nested compilation work           | 24,000 units                                  |
 | Validation input                  | 128 levels, 100,000 nodes, 4 MiB serialized   |
 | Compiled-validator cache          | 128 entries and 2 MiB aggregate source weight |
 
 Schemas and inputs must be data-only JSON. Accessors, symbol or hidden keys,
 custom object prototypes, cycles, sparse arrays, and revoked proxies are
-rejected without invoking user code. Successful validation returns the
-adapter-owned input snapshot. Cache eviction is least-recently used when
-either cache limit is exceeded.
+rejected without invoking property getters, setters, iterators, or `toJSON`.
+Inspecting a Proxy necessarily invokes its reflection traps; a trap may run or
+throw before the value is rejected. Successful validation returns the
+adapter-owned input snapshot. Cache eviction is least-recently used when either
+cache limit is exceeded.
 
 ## Running Tests
 

--- a/extensions/ext-schema-zod/src/adapter.ts
+++ b/extensions/ext-schema-zod/src/adapter.ts
@@ -168,17 +168,55 @@ const coerce: SchemaValidatorCoerce = {
 };
 
 const JSON_SCHEMA_VALIDATOR_CACHE_SIZE = 128;
+const JSON_SCHEMA_VALIDATOR_CACHE_MAX_WEIGHT = 2 * 1024 * 1024;
 
 // Raw schemas can originate in extensions and tool metadata, so snapshot them
 // through a deliberately bounded JSON boundary before handing them to Ajv.
 // These ceilings are comfortably above practical tool schemas while keeping a
 // single compilation from consuming unbounded stack, CPU, or memory.
-const JSON_SCHEMA_MAX_DEPTH = 128;
-const JSON_SCHEMA_MAX_NODES = 100_000;
-const JSON_SCHEMA_MAX_SERIALIZED_BYTES = 4 * 1024 * 1024;
-const JSON_SCHEMA_MAX_STRING_BYTES = 1024 * 1024;
-const JSON_SCHEMA_MAX_KEY_BYTES = 16 * 1024;
+const JSON_SCHEMA_MAX_DEPTH = 64;
+const JSON_SCHEMA_MAX_NODES = 8_192;
+const JSON_SCHEMA_MAX_SERIALIZED_BYTES = 512 * 1024;
+const JSON_SCHEMA_MAX_STRING_BYTES = 256 * 1024;
+const JSON_SCHEMA_MAX_KEY_BYTES = 4 * 1024;
+const JSON_SCHEMA_MAX_COMBINATOR_FANOUT = 256;
+const JSON_SCHEMA_MAX_COMPILATION_WORK = 24_000;
+const JSON_INSTANCE_MAX_DEPTH = 128;
+const JSON_INSTANCE_MAX_NODES = 100_000;
+const JSON_INSTANCE_MAX_SERIALIZED_BYTES = 4 * 1024 * 1024;
+const JSON_INSTANCE_MAX_STRING_BYTES = 1024 * 1024;
+const JSON_INSTANCE_MAX_KEY_BYTES = 16 * 1024;
 const JSON_UTF8_ENCODER = new TextEncoder();
+
+interface CanonicalizationLimits {
+  maxDepth: number;
+  maxNodes: number;
+  maxSerializedBytes: number;
+  maxStringBytes: number;
+  maxKeyBytes: number;
+}
+
+interface CanonicalJsonSnapshot {
+  value: unknown;
+  nodeCount: number;
+  serializedBytes: number;
+}
+
+const JSON_SCHEMA_LIMITS: CanonicalizationLimits = {
+  maxDepth: JSON_SCHEMA_MAX_DEPTH,
+  maxNodes: JSON_SCHEMA_MAX_NODES,
+  maxSerializedBytes: JSON_SCHEMA_MAX_SERIALIZED_BYTES,
+  maxStringBytes: JSON_SCHEMA_MAX_STRING_BYTES,
+  maxKeyBytes: JSON_SCHEMA_MAX_KEY_BYTES,
+};
+
+const JSON_INSTANCE_LIMITS: CanonicalizationLimits = {
+  maxDepth: JSON_INSTANCE_MAX_DEPTH,
+  maxNodes: JSON_INSTANCE_MAX_NODES,
+  maxSerializedBytes: JSON_INSTANCE_MAX_SERIALIZED_BYTES,
+  maxStringBytes: JSON_INSTANCE_MAX_STRING_BYTES,
+  maxKeyBytes: JSON_INSTANCE_MAX_KEY_BYTES,
+};
 
 type JsonSchemaCompiler = {
   compile(schema: AnySchema): ValidateFunction<unknown>;
@@ -282,7 +320,9 @@ class JsonSchemaCanonicalizer {
   private nodeCount = 0;
   private serializedBytes = 0;
 
-  canonicalize(value: unknown): unknown {
+  constructor(private readonly limits: CanonicalizationLimits) {}
+
+  canonicalize(value: unknown): CanonicalJsonSnapshot {
     this.stack.push({ kind: "visit", value, depth: 0 });
     while (this.stack.length > 0) {
       const frame = this.stack.pop();
@@ -297,7 +337,11 @@ class JsonSchemaCanonicalizer {
     if (!this.rootAssigned) {
       throw new TypeError("JSON Schema must contain a JSON value");
     }
-    return this.canonicalRoot;
+    return {
+      value: this.canonicalRoot,
+      nodeCount: this.nodeCount,
+      serializedBytes: this.serializedBytes,
+    };
   }
 
   private visit(frame: CanonicalizationVisitFrame): void {
@@ -326,7 +370,7 @@ class JsonSchemaCanonicalizer {
       return true;
     }
     if (typeof current === "string") {
-      boundedUtf8Length(current, JSON_SCHEMA_MAX_STRING_BYTES, "string");
+      boundedUtf8Length(current, this.limits.maxStringBytes, "string");
       this.assign(frame, current);
       this.addSerializedBytes(serializedJsonTokenByteLength(current));
       return true;
@@ -357,8 +401,10 @@ class JsonSchemaCanonicalizer {
     ) {
       throw new TypeError("JSON Schema arrays must have a non-negative integer data length");
     }
-    if (length > JSON_SCHEMA_MAX_NODES) {
-      throw new TypeError(`JSON Schema exceeds the maximum node count of ${JSON_SCHEMA_MAX_NODES}`);
+    if (length > this.limits.maxNodes) {
+      throw new TypeError(
+        `JSON Schema exceeds the maximum node count of ${this.limits.maxNodes}`,
+      );
     }
     const ownKeys = Reflect.ownKeys(current);
     if (
@@ -406,8 +452,10 @@ class JsonSchemaCanonicalizer {
       throw new TypeError("JSON Schema objects must be plain JSON objects");
     }
     const ownKeys = Reflect.ownKeys(current);
-    if (ownKeys.length > JSON_SCHEMA_MAX_NODES) {
-      throw new TypeError(`JSON Schema exceeds the maximum node count of ${JSON_SCHEMA_MAX_NODES}`);
+    if (ownKeys.length > this.limits.maxNodes) {
+      throw new TypeError(
+        `JSON Schema exceeds the maximum node count of ${this.limits.maxNodes}`,
+      );
     }
     if (ownKeys.some((key) => typeof key === "symbol")) {
       throw new TypeError("JSON Schema objects must not contain symbol keys");
@@ -415,7 +463,7 @@ class JsonSchemaCanonicalizer {
     this.addSerializedBytes(2 + Math.max(0, ownKeys.length - 1));
 
     const entries = (ownKeys as string[]).map((key) => {
-      boundedUtf8Length(key, JSON_SCHEMA_MAX_KEY_BYTES, "key");
+      boundedUtf8Length(key, this.limits.maxKeyBytes, "key");
       this.addSerializedBytes(serializedJsonTokenByteLength(key) + 1);
       const descriptor = Object.getOwnPropertyDescriptor(current, key);
       if (!descriptor || !("value" in descriptor)) {
@@ -447,20 +495,22 @@ class JsonSchemaCanonicalizer {
   }
 
   private consumeNode(depth: number): void {
-    if (depth > JSON_SCHEMA_MAX_DEPTH) {
-      throw new TypeError(`JSON Schema exceeds the maximum depth of ${JSON_SCHEMA_MAX_DEPTH}`);
+    if (depth > this.limits.maxDepth) {
+      throw new TypeError(`JSON Schema exceeds the maximum depth of ${this.limits.maxDepth}`);
     }
     this.nodeCount++;
-    if (this.nodeCount > JSON_SCHEMA_MAX_NODES) {
-      throw new TypeError(`JSON Schema exceeds the maximum node count of ${JSON_SCHEMA_MAX_NODES}`);
+    if (this.nodeCount > this.limits.maxNodes) {
+      throw new TypeError(
+        `JSON Schema exceeds the maximum node count of ${this.limits.maxNodes}`,
+      );
     }
   }
 
   private addSerializedBytes(amount: number): void {
     this.serializedBytes += amount;
-    if (this.serializedBytes > JSON_SCHEMA_MAX_SERIALIZED_BYTES) {
+    if (this.serializedBytes > this.limits.maxSerializedBytes) {
       throw new TypeError(
-        `JSON Schema exceeds the ${JSON_SCHEMA_MAX_SERIALIZED_BYTES}-byte serialized limit`,
+        `JSON Schema exceeds the ${this.limits.maxSerializedBytes}-byte serialized limit`,
       );
     }
   }
@@ -479,18 +529,101 @@ class JsonSchemaCanonicalizer {
   }
 }
 
-function canonicalizeJsonValue(value: unknown): unknown {
-  return new JsonSchemaCanonicalizer().canonicalize(value);
+function canonicalizeJsonValue(
+  value: unknown,
+  limits: CanonicalizationLimits,
+): CanonicalJsonSnapshot {
+  return new JsonSchemaCanonicalizer(limits).canonicalize(value);
 }
 
-function snapshotJsonSchema(schema: JsonSchema): { key: string; schema: JsonSchema } {
-  const canonical = canonicalizeJsonValue(schema);
+interface JsonSchemaSnapshot {
+  key: string;
+  schema: JsonSchema;
+  nodeCount: number;
+  serializedBytes: number;
+  compilationWork: number;
+  cacheWeight: number;
+}
+
+const COMBINATOR_KEYWORDS = new Set(["allOf", "anyOf", "oneOf"]);
+
+/**
+ * Estimate generated-validator work before Ajv sees a schema. Node and byte
+ * limits alone do not capture wide combinators, large enums, or property maps,
+ * all of which expand generated code and retained compiler state.
+ */
+function estimateCompilationWork(schema: JsonSchema): number {
+  const stack: unknown[] = [schema];
+  let work = 0;
+  const addWork = (amount: number): void => {
+    work += amount;
+    if (work > JSON_SCHEMA_MAX_COMPILATION_WORK) {
+      throw new TypeError(
+        `JSON Schema exceeds the compilation work limit of ${JSON_SCHEMA_MAX_COMPILATION_WORK}`,
+      );
+    }
+  };
+
+  while (stack.length > 0) {
+    const value = stack.pop();
+    if (!value || typeof value !== "object") continue;
+    if (Array.isArray(value)) {
+      for (let index = value.length - 1; index >= 0; index--) stack.push(value[index]);
+      continue;
+    }
+
+    for (const [keyword, keywordValue] of Object.entries(value)) {
+      addWork(1);
+      if (COMBINATOR_KEYWORDS.has(keyword) && Array.isArray(keywordValue)) {
+        if (keywordValue.length > JSON_SCHEMA_MAX_COMBINATOR_FANOUT) {
+          throw new TypeError(
+            `JSON Schema ${keyword} exceeds the branch fanout limit of ${JSON_SCHEMA_MAX_COMBINATOR_FANOUT}`,
+          );
+        }
+        addWork(keywordValue.length * 8);
+      } else if (keyword === "prefixItems" && Array.isArray(keywordValue)) {
+        if (keywordValue.length > JSON_SCHEMA_MAX_COMBINATOR_FANOUT) {
+          throw new TypeError(
+            `JSON Schema prefixItems exceeds the branch fanout limit of ${JSON_SCHEMA_MAX_COMBINATOR_FANOUT}`,
+          );
+        }
+        addWork(keywordValue.length * 2);
+      } else if (keyword === "enum" && Array.isArray(keywordValue)) {
+        addWork(keywordValue.length * 2);
+      } else if (
+        (keyword === "properties" || keyword === "$defs" || keyword === "definitions" ||
+          keyword === "dependentSchemas") &&
+        keywordValue && typeof keywordValue === "object" && !Array.isArray(keywordValue)
+      ) {
+        addWork(Object.keys(keywordValue).length * 2);
+      } else if (keyword === "pattern" && typeof keywordValue === "string") {
+        addWork(Math.ceil(keywordValue.length / 8));
+      }
+      stack.push(keywordValue);
+    }
+  }
+
+  return work;
+}
+
+function snapshotJsonSchema(schema: JsonSchema): JsonSchemaSnapshot {
+  const snapshot = canonicalizeJsonValue(schema, JSON_SCHEMA_LIMITS);
+  const canonical = snapshot.value;
   if (canonical === null || typeof canonical !== "object" || Array.isArray(canonical)) {
     throw new TypeError("JSON Schema root must be a plain object");
   }
   const key = JSON.stringify(canonical);
   if (key === undefined) throw new TypeError("JSON Schema must be JSON serializable");
-  return { key, schema: canonical as JsonSchema };
+  const compilationWork = estimateCompilationWork(canonical as JsonSchema);
+  const cacheWeight = snapshot.serializedBytes + snapshot.nodeCount * 64 + compilationWork * 32;
+  return {
+    key,
+    schema: canonical as JsonSchema,
+    nodeCount: snapshot.nodeCount,
+    serializedBytes: snapshot.serializedBytes,
+    compilationWork,
+    cacheWeight,
+  };
 }
 
 function copyValidationIssue(error: ErrorObject): JsonSchemaValidationIssue {
@@ -523,6 +656,29 @@ function validationSuccess<T>(input: unknown): JsonSchemaValidationSuccess<T> {
   return { success: true, value: input as T };
 }
 
+const DATA_ONLY_INPUT_FAILURE: JsonSchemaValidationFailure = Object.freeze({
+  success: false,
+  errors: Object.freeze([
+    Object.freeze({
+      instancePath: "",
+      schemaPath: "",
+      keyword: "veryfrontDataOnly",
+      params: Object.freeze({}),
+      message: "Input must be a bounded, data-only JSON value",
+    }),
+  ]),
+});
+
+function snapshotJsonInstance(input: unknown): CanonicalJsonSnapshot | undefined {
+  try {
+    return canonicalizeJsonValue(input, JSON_INSTANCE_LIMITS);
+  } catch {
+    // Accessors, throwing/revoked Proxies, cycles, custom prototypes, and
+    // oversized inputs are ordinary validation failures at this boundary.
+    return undefined;
+  }
+}
+
 function errorObjectsFromUnknown(error: unknown): ErrorObject[] | undefined {
   if (!error || typeof error !== "object" || !("errors" in error)) {
     return undefined;
@@ -541,10 +697,13 @@ function compileJsonSchemaValidator<T>(schema: JsonSchema): JsonSchemaValidation
   const validate = createJsonSchemaCompiler(schema).compile(schemaForCompilation(schema));
 
   return (input) => {
-    const outcome = validate(input);
+    const inputSnapshot = snapshotJsonInstance(input);
+    if (!inputSnapshot) return DATA_ONLY_INPUT_FAILURE;
+    const acceptedInput = inputSnapshot.value;
+    const outcome = validate(acceptedInput);
     if (isPromiseLike(outcome)) {
       return Promise.resolve(outcome).then(
-        () => validationSuccess<T>(input),
+        () => validationSuccess<T>(acceptedInput),
         (error: unknown) => {
           const errors = errorObjectsFromUnknown(error);
           if (errors) return validationFailure(errors);
@@ -553,12 +712,17 @@ function compileJsonSchemaValidator<T>(schema: JsonSchema): JsonSchemaValidation
       );
     }
 
-    return outcome ? validationSuccess<T>(input) : validationFailure(validate.errors);
+    return outcome ? validationSuccess<T>(acceptedInput) : validationFailure(validate.errors);
   };
 }
 
 function createJsonSchemaCompilationCache(): SchemaValidator["compileJsonSchema"] {
-  const cache = new Map<string, JsonSchemaValidationFunction>();
+  interface CacheEntry {
+    validator: JsonSchemaValidationFunction;
+    weight: number;
+  }
+  const cache = new Map<string, CacheEntry>();
+  let cacheWeight = 0;
 
   return <T>(schema: JsonSchema): JsonSchemaValidationFunction<T> => {
     const snapshot = snapshotJsonSchema(schema);
@@ -566,16 +730,22 @@ function createJsonSchemaCompilationCache(): SchemaValidator["compileJsonSchema"
     if (cached) {
       cache.delete(snapshot.key);
       cache.set(snapshot.key, cached);
-      return cached as JsonSchemaValidationFunction<T>;
+      return cached.validator as JsonSchemaValidationFunction<T>;
     }
 
     const compiled = compileJsonSchemaValidator<T>(snapshot.schema);
-    while (cache.size >= JSON_SCHEMA_VALIDATOR_CACHE_SIZE) {
+    while (
+      cache.size >= JSON_SCHEMA_VALIDATOR_CACHE_SIZE ||
+      cacheWeight + snapshot.cacheWeight > JSON_SCHEMA_VALIDATOR_CACHE_MAX_WEIGHT
+    ) {
       const oldestKey = cache.keys().next().value;
       if (oldestKey === undefined) break;
+      const oldest = cache.get(oldestKey);
       cache.delete(oldestKey);
+      if (oldest) cacheWeight -= oldest.weight;
     }
-    cache.set(snapshot.key, compiled);
+    cache.set(snapshot.key, { validator: compiled, weight: snapshot.cacheWeight });
+    cacheWeight += snapshot.cacheWeight;
     return compiled;
   };
 }
@@ -583,8 +753,8 @@ function createJsonSchemaCompilationCache(): SchemaValidator["compileJsonSchema"
 /**
  * Build a zod-backed `SchemaValidator` instance.
  *
- * Adapter instances snapshot schemas into plain JSON and retain at most 128
- * compiled validators in an LRU cache. Each unique validator owns an isolated
+ * Adapter instances snapshot schemas into plain JSON and retain validators in
+ * an entry- and weight-bounded LRU cache. Each unique validator owns an isolated
  * Ajv compiler, so unrelated `$id` values cannot collide or accumulate in a
  * process-wide registry. It is therefore safe to call this once at extension setup and pass the returned value to
  * `ctx.provide("SchemaValidator", …)`. Tests that need to register the

--- a/extensions/ext-schema-zod/src/adapter.ts
+++ b/extensions/ext-schema-zod/src/adapter.ts
@@ -581,10 +581,12 @@ function estimateCompilationWork(schema: JsonSchema): number {
           );
         }
         addWork(keywordValue.length * 8);
-      } else if (keyword === "prefixItems" && Array.isArray(keywordValue)) {
+      } else if (
+        (keyword === "prefixItems" || keyword === "items") && Array.isArray(keywordValue)
+      ) {
         if (keywordValue.length > JSON_SCHEMA_MAX_COMBINATOR_FANOUT) {
           throw new TypeError(
-            `JSON Schema prefixItems exceeds the branch fanout limit of ${JSON_SCHEMA_MAX_COMBINATOR_FANOUT}`,
+            `JSON Schema ${keyword} exceeds the branch fanout limit of ${JSON_SCHEMA_MAX_COMBINATOR_FANOUT}`,
           );
         }
         addWork(keywordValue.length * 2);

--- a/extensions/ext-schema-zod/src/adapter.ts
+++ b/extensions/ext-schema-zod/src/adapter.ts
@@ -546,6 +546,18 @@ interface JsonSchemaSnapshot {
 }
 
 const COMBINATOR_KEYWORDS = new Set(["allOf", "anyOf", "oneOf"]);
+const CODE_GENERATING_MAP_KEYWORDS = new Map<string, number>([
+  ["properties", 4],
+  ["patternProperties", 8],
+  ["dependencies", 4],
+  ["dependentRequired", 4],
+  ["dependentSchemas", 4],
+]);
+const RETAINED_SCHEMA_MAP_KEYWORDS = new Set(["$defs", "definitions"]);
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
 
 /**
  * Estimate generated-validator work before Ajv sees a schema. Node and byte
@@ -563,6 +575,18 @@ function estimateCompilationWork(schema: JsonSchema): number {
       );
     }
   };
+  const addBoundedCollectionWork = (
+    keyword: string,
+    length: number,
+    multiplier: number,
+  ): void => {
+    if (length > JSON_SCHEMA_MAX_COMBINATOR_FANOUT) {
+      throw new TypeError(
+        `JSON Schema ${keyword} exceeds the code-generation collection limit of ${JSON_SCHEMA_MAX_COMBINATOR_FANOUT}`,
+      );
+    }
+    addWork(length * multiplier);
+  };
 
   while (stack.length > 0) {
     const value = stack.pop();
@@ -572,31 +596,47 @@ function estimateCompilationWork(schema: JsonSchema): number {
       continue;
     }
 
-    for (const [keyword, keywordValue] of Object.entries(value)) {
+    const schemaObject = value as Record<string, unknown>;
+    const propertyCount = isJsonObject(schemaObject.properties)
+      ? Object.keys(schemaObject.properties).length
+      : 0;
+    const patternPropertyCount = isJsonObject(schemaObject.patternProperties)
+      ? Object.keys(schemaObject.patternProperties).length
+      : 0;
+    if (propertyCount > 0 && patternPropertyCount > 0) {
+      // In Ajv strict mode every pattern is checked against every named
+      // property during compilation, so account for the cross-product.
+      addWork(propertyCount * patternPropertyCount);
+    }
+
+    for (const [keyword, keywordValue] of Object.entries(schemaObject)) {
       addWork(1);
       if (COMBINATOR_KEYWORDS.has(keyword) && Array.isArray(keywordValue)) {
-        if (keywordValue.length > JSON_SCHEMA_MAX_COMBINATOR_FANOUT) {
-          throw new TypeError(
-            `JSON Schema ${keyword} exceeds the branch fanout limit of ${JSON_SCHEMA_MAX_COMBINATOR_FANOUT}`,
-          );
-        }
-        addWork(keywordValue.length * 8);
+        addBoundedCollectionWork(keyword, keywordValue.length, 8);
       } else if (
         (keyword === "prefixItems" || keyword === "items") && Array.isArray(keywordValue)
       ) {
-        if (keywordValue.length > JSON_SCHEMA_MAX_COMBINATOR_FANOUT) {
-          throw new TypeError(
-            `JSON Schema ${keyword} exceeds the branch fanout limit of ${JSON_SCHEMA_MAX_COMBINATOR_FANOUT}`,
-          );
-        }
-        addWork(keywordValue.length * 2);
-      } else if (keyword === "enum" && Array.isArray(keywordValue)) {
-        addWork(keywordValue.length * 2);
+        addBoundedCollectionWork(keyword, keywordValue.length, 2);
       } else if (
-        (keyword === "properties" || keyword === "$defs" || keyword === "definitions" ||
-          keyword === "dependentSchemas") &&
-        keywordValue && typeof keywordValue === "object" && !Array.isArray(keywordValue)
+        (keyword === "enum" || keyword === "required" || keyword === "type") &&
+        Array.isArray(keywordValue)
       ) {
+        addBoundedCollectionWork(keyword, keywordValue.length, keyword === "required" ? 4 : 2);
+      } else if (isJsonObject(keywordValue) && CODE_GENERATING_MAP_KEYWORDS.has(keyword)) {
+        const entryCount = Object.keys(keywordValue).length;
+        addBoundedCollectionWork(
+          keyword,
+          entryCount,
+          CODE_GENERATING_MAP_KEYWORDS.get(keyword)!,
+        );
+        if (keyword === "dependentRequired" || keyword === "dependencies") {
+          for (const dependencyValue of Object.values(keywordValue)) {
+            if (Array.isArray(dependencyValue)) {
+              addBoundedCollectionWork(`${keyword} entry`, dependencyValue.length, 4);
+            }
+          }
+        }
+      } else if (isJsonObject(keywordValue) && RETAINED_SCHEMA_MAP_KEYWORDS.has(keyword)) {
         addWork(Object.keys(keywordValue).length * 2);
       } else if (keyword === "pattern" && typeof keywordValue === "string") {
         addWork(Math.ceil(keywordValue.length / 8));

--- a/extensions/ext-schema-zod/src/json-schema-validation.test.ts
+++ b/extensions/ext-schema-zod/src/json-schema-validation.test.ts
@@ -303,7 +303,7 @@ describe("SchemaValidator.compileJsonSchema", () => {
     assertThrows(
       () => compile({ anyOf: new Array(257).fill(branch) }),
       TypeError,
-      "branch fanout limit of 256",
+      "code-generation collection limit of 256",
     );
   });
 
@@ -319,7 +319,7 @@ describe("SchemaValidator.compileJsonSchema", () => {
       minItems: 256,
       maxItems: 256,
       additionalItems: false,
-    });
+    } as never);
 
     assertEquals((await validate(atLimit, new Array(256).fill("value"))).success, true);
     assertThrows(
@@ -331,9 +331,70 @@ describe("SchemaValidator.compileJsonSchema", () => {
           minItems: 257,
           maxItems: 257,
           additionalItems: false,
+        } as never),
+      TypeError,
+      "code-generation collection limit of 256",
+    );
+  });
+
+  it("rejects every wide code-generating JSON Schema collection before Ajv", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const fields = Array.from({ length: 257 }, (_, index) => `field${index}`);
+    const schemas = Object.fromEntries(fields.map((field) => [field, { type: "string" }]));
+    const patterns = Object.fromEntries(fields.map((field) => [`^${field}$`, { type: "string" }]));
+    const draft7 = "http://json-schema.org/draft-07/schema#";
+    const cases: Array<{ keyword: string; schema: Record<string, unknown> }> = [
+      { keyword: "required", schema: { type: "object", required: fields } },
+      { keyword: "enum", schema: { enum: fields } },
+      { keyword: "properties", schema: { type: "object", properties: schemas } },
+      { keyword: "patternProperties", schema: { type: "object", patternProperties: patterns } },
+      { keyword: "dependentSchemas", schema: { type: "object", dependentSchemas: schemas } },
+      {
+        keyword: "dependencies",
+        schema: { $schema: draft7, type: "object", dependencies: schemas },
+      },
+    ];
+
+    for (const testCase of cases) {
+      assertThrows(
+        () => compile(testCase.schema),
+        TypeError,
+        `${testCase.keyword} exceeds the code-generation collection limit of 256`,
+      );
+    }
+  });
+
+  it("rejects adversarial dependentRequired maps and entry arrays before Ajv", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const dependencies = Object.fromEntries(
+      Array.from({ length: 4_000 }, (_, index) => [`field${index}`, ["requiredField"]]),
+    );
+
+    assertThrows(
+      () => compile({ type: "object", dependentRequired: dependencies }),
+      TypeError,
+      "dependentRequired exceeds the code-generation collection limit of 256",
+    );
+    assertThrows(
+      () =>
+        compile({
+          type: "object",
+          dependentRequired: { source: new Array(257).fill("requiredField") },
         }),
       TypeError,
-      "branch fanout limit of 256",
+      "dependentRequired entry exceeds the code-generation collection limit of 256",
+    );
+    assertThrows(
+      () =>
+        compile({
+          $schema: "http://json-schema.org/draft-07/schema#",
+          type: "object",
+          dependencies: { source: new Array(257).fill("requiredField") },
+        }),
+      TypeError,
+      "dependencies entry exceeds the code-generation collection limit of 256",
     );
   });
 

--- a/extensions/ext-schema-zod/src/json-schema-validation.test.ts
+++ b/extensions/ext-schema-zod/src/json-schema-validation.test.ts
@@ -14,7 +14,7 @@ async function validate(
 }
 
 describe("SchemaValidator.compileJsonSchema", () => {
-  it("validates Draft 2020-12 schemas without mutating accepted input", async () => {
+  it("validates Draft 2020-12 schemas through a non-mutating data snapshot", async () => {
     const compile = createZodAdapter().compileJsonSchema;
     assert(compile);
     const validator = compile({
@@ -33,6 +33,7 @@ describe("SchemaValidator.compileJsonSchema", () => {
 
     assertEquals(result, { success: true, value: input });
     assertEquals(input, { count: 2 });
+    assert(result.success && result.value !== input);
   });
 
   it("selects the compiler declared by Draft 7 and Draft 2019-09 schemas", async () => {
@@ -257,13 +258,13 @@ describe("SchemaValidator.compileJsonSchema", () => {
     const compile = createZodAdapter().compileJsonSchema;
     assert(compile);
     let deeplyNested: unknown = { type: "string" };
-    for (let depth = 0; depth < 130; depth++) {
+    for (let depth = 0; depth < 66; depth++) {
       deeplyNested = { allOf: [deeplyNested] };
     }
-    const tooManyNodes = new Array(100_001).fill(null);
-    const tooLongString = "x".repeat(1024 * 1024 + 1);
-    const tooLongKey = "k".repeat(16 * 1024 + 1);
-    const maximumString = "x".repeat(1024 * 1024);
+    const tooManyNodes = new Array(8_193).fill(null);
+    const tooLongString = "x".repeat(256 * 1024 + 1);
+    const tooLongKey = "k".repeat(4 * 1024 + 1);
+    const maximumString = "x".repeat(132 * 1024);
 
     assertThrows(
       () => compile(deeplyNested as never),
@@ -290,6 +291,151 @@ describe("SchemaValidator.compileJsonSchema", () => {
       TypeError,
       "serialized limit",
     );
+  });
+
+  it("accepts the combinator fanout boundary and rejects the next branch", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const branch = { type: "string" as const };
+    const atLimit = compile({ anyOf: new Array(256).fill(branch) });
+
+    assertEquals((await validate(atLimit, "value")).success, true);
+    assertThrows(
+      () => compile({ anyOf: new Array(257).fill(branch) }),
+      TypeError,
+      "branch fanout limit of 256",
+    );
+  });
+
+  it("rejects schemas whose nested combinators exceed the compile-work budget", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const branch = { type: "string" as const };
+    const properties = Object.fromEntries(
+      Array.from({ length: 12 }, (_, index) => [
+        `field${index}`,
+        { anyOf: new Array(256).fill(branch) },
+      ]),
+    );
+
+    assertThrows(
+      () => compile({ type: "object", properties }),
+      TypeError,
+      "compilation work limit",
+    );
+  });
+
+  it("evicts by aggregate source weight before the entry-count ceiling", () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const firstSchema = { type: "string" as const, description: "0".repeat(240_000) };
+    const first = compile(firstSchema);
+
+    for (let index = 1; index <= 9; index++) {
+      compile({ type: "string", description: String(index).repeat(240_000) });
+    }
+
+    assertEquals(compile(firstSchema) === first, false);
+  });
+
+  it("validates realistic nested tool schemas below every compile budget", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      type: "object",
+      properties: {
+        query: { type: "string", minLength: 1, maxLength: 4_096 },
+        filters: {
+          type: "array",
+          maxItems: 50,
+          items: {
+            type: "object",
+            properties: {
+              field: { type: "string", enum: ["status", "owner", "createdAt"] },
+              operator: { type: "string", enum: ["eq", "contains", "after"] },
+              value: { type: ["string", "number", "boolean", "null"] },
+            },
+            required: ["field", "operator", "value"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    });
+
+    assertEquals(
+      (await validate(validator, {
+        query: "production incidents",
+        filters: [{ field: "status", operator: "eq", value: "open" }],
+      })).success,
+      true,
+    );
+  });
+
+  it("rejects accessors and revoked proxies without invoking input getters", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    });
+    let getterReads = 0;
+    const accessor: Record<string, unknown> = {};
+    Object.defineProperty(accessor, "value", {
+      enumerable: true,
+      get() {
+        getterReads += 1;
+        throw new Error("must not run");
+      },
+    });
+    const revoked = Proxy.revocable({ value: "ok" }, {});
+    revoked.revoke();
+
+    const accessorResult = await validate(validator, accessor);
+    const revokedResult = await validate(validator, revoked.proxy);
+
+    assertEquals(getterReads, 0);
+    assertEquals(accessorResult.success, false);
+    assertEquals(revokedResult.success, false);
+    if (!accessorResult.success) {
+      assertEquals(accessorResult.errors[0]?.keyword, "veryfrontDataOnly");
+    }
+  });
+
+  it("validates one descriptor snapshot of stateful proxied input", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const validator = compile({
+      type: "object",
+      properties: { value: { const: "snapshot" } },
+      required: ["value"],
+    });
+    let descriptorReads = 0;
+    let valueReads = 0;
+    const input = new Proxy({ value: "target" }, {
+      getOwnPropertyDescriptor(_target, property) {
+        if (property !== "value") return undefined;
+        descriptorReads += 1;
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: "snapshot",
+        };
+      },
+      get(target, property, receiver) {
+        if (property === "value") valueReads += 1;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const result = await validate(validator, input);
+
+    assertEquals(result, { success: true, value: { value: "snapshot" } });
+    assertEquals(descriptorReads, 1);
+    assertEquals(valueReads, 0);
   });
 
   it("accepts null-prototype schemas and safely canonicalizes __proto__ data keys", async () => {
@@ -475,7 +621,7 @@ describe("SchemaValidator.compileJsonSchema", () => {
     );
   });
 
-  it("does not satisfy required properties from an inherited prototype", async () => {
+  it("rejects validation inputs with inherited prototypes", async () => {
     const compile = createZodAdapter().compileJsonSchema;
     assert(compile);
     const validator = compile({
@@ -490,10 +636,10 @@ describe("SchemaValidator.compileJsonSchema", () => {
 
     assertEquals(result.success, false);
     if (result.success) return;
-    assertEquals(result.errors.map((error) => error.keyword), ["required"]);
+    assertEquals(result.errors.map((error) => error.keyword), ["veryfrontDataOnly"]);
   });
 
-  it("ignores inherited keys when enforcing additionalProperties", async () => {
+  it("rejects inherited keys instead of passing them to Ajv", async () => {
     const compile = createZodAdapter().compileJsonSchema;
     assert(compile);
     const validator = compile({
@@ -509,6 +655,8 @@ describe("SchemaValidator.compileJsonSchema", () => {
 
     const result = await validate(validator, input);
 
-    assertEquals(result.success, true);
+    assertEquals(result.success, false);
+    if (result.success) return;
+    assertEquals(result.errors.map((error) => error.keyword), ["veryfrontDataOnly"]);
   });
 });

--- a/extensions/ext-schema-zod/src/json-schema-validation.test.ts
+++ b/extensions/ext-schema-zod/src/json-schema-validation.test.ts
@@ -307,6 +307,36 @@ describe("SchemaValidator.compileJsonSchema", () => {
     );
   });
 
+  it("applies the tuple fanout boundary to Draft 7 items arrays", async () => {
+    const compile = createZodAdapter().compileJsonSchema;
+    assert(compile);
+    const branch = { type: "string" as const };
+    const draft7 = "http://json-schema.org/draft-07/schema#";
+    const atLimit = compile({
+      $schema: draft7,
+      type: "array",
+      items: new Array(256).fill(branch),
+      minItems: 256,
+      maxItems: 256,
+      additionalItems: false,
+    });
+
+    assertEquals((await validate(atLimit, new Array(256).fill("value"))).success, true);
+    assertThrows(
+      () =>
+        compile({
+          $schema: draft7,
+          type: "array",
+          items: new Array(257).fill(branch),
+          minItems: 257,
+          maxItems: 257,
+          additionalItems: false,
+        }),
+      TypeError,
+      "branch fanout limit of 256",
+    );
+  });
+
   it("rejects schemas whose nested combinators exceed the compile-work budget", () => {
     const compile = createZodAdapter().compileJsonSchema;
     assert(compile);

--- a/src/extensions/schema/schema-validator.ts
+++ b/src/extensions/schema/schema-validator.ts
@@ -276,8 +276,10 @@ export interface SchemaValidator {
    * descriptor-based data reads before invoking a compiler. An invalid schema
    * causes compilation to throw. Invalid input returns a validation failure.
    * Accessors, proxies that cannot be inspected, cycles, and non-JSON object
-   * prototypes are rejected without executing caller code. Successful
-   * validation returns the accepted snapshot rather than caller-owned state.
+   * prototypes are rejected without invoking property getters, setters,
+   * iterators, or serialization hooks. Proxy reflection traps necessarily run
+   * during inspection and may throw before rejection. Successful validation
+   * returns the accepted snapshot rather than caller-owned state.
    *
    * This capability is optional so existing third-party `SchemaValidator`
    * implementations remain source-compatible. Framework features that accept

--- a/src/extensions/schema/schema-validator.ts
+++ b/src/extensions/schema/schema-validator.ts
@@ -273,10 +273,11 @@ export interface SchemaValidator {
    * Compile a JSON Schema into a reusable, non-mutating validator.
    *
    * Implementations must snapshot schemas and inputs through bounded,
-   * descriptor-based data reads before invoking a compiler. Accessors,
-   * proxies that cannot be inspected, cycles, and non-JSON object prototypes
-   * fail validation without executing caller code. Successful validation
-   * returns the accepted snapshot rather than caller-owned state.
+   * descriptor-based data reads before invoking a compiler. An invalid schema
+   * causes compilation to throw. Invalid input returns a validation failure.
+   * Accessors, proxies that cannot be inspected, cycles, and non-JSON object
+   * prototypes are rejected without executing caller code. Successful
+   * validation returns the accepted snapshot rather than caller-owned state.
    *
    * This capability is optional so existing third-party `SchemaValidator`
    * implementations remain source-compatible. Framework features that accept

--- a/src/extensions/schema/schema-validator.ts
+++ b/src/extensions/schema/schema-validator.ts
@@ -165,7 +165,7 @@ export interface JsonSchemaValidationIssue {
 /** Successful validation of an input against a compiled JSON Schema. */
 export interface JsonSchemaValidationSuccess<T = unknown> {
   success: true;
-  /** The accepted input. Validators must not mutate this value. */
+  /** Stable, validator-owned JSON snapshot of the accepted input. */
   value: T;
 }
 
@@ -271,6 +271,12 @@ export interface SchemaValidator {
 
   /**
    * Compile a JSON Schema into a reusable, non-mutating validator.
+   *
+   * Implementations must snapshot schemas and inputs through bounded,
+   * descriptor-based data reads before invoking a compiler. Accessors,
+   * proxies that cannot be inspected, cycles, and non-JSON object prototypes
+   * fail validation without executing caller code. Successful validation
+   * returns the accepted snapshot rather than caller-owned state.
    *
    * This capability is optional so existing third-party `SchemaValidator`
    * implementations remain source-compatible. Framework features that accept

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -55,10 +55,26 @@ src/
 | Absolute path | Filesystem-rooted, no null bytes, at most 4,096 characters                                                                                                                                                                                                                                             |
 | JSON value    | Data-only JSON with at most 128 levels, 100,000 nodes, and 4 MiB serialized size. A string is at most 1 MiB and an object key is at most 16 KiB in UTF-8. Cycles, accessors, symbol keys, non-enumerable properties, and plain-object prototypes other than `Object.prototype` or `null` are rejected. |
 
-Raw JSON Schema compilation and adapter-generated JSON Schema documents use
-the same bounded, data-only snapshot. Only that canonical snapshot crosses the
-helper boundary, so later reads cannot observe different Proxy values. Invalid
-adapter results fail with a `TypeError`.
+Raw JSON Schema compilation uses a separate, smaller resource envelope. The
+default adapter accepts schemas with at most 64 levels, 8,192 nodes, and 512
+KiB serialized size. A schema string is at most 256 KiB and a property name is
+at most 4 KiB in UTF-8. A direct combinator or tuple fanout is at most 256, and
+nested combinators are subject to a 24,000-unit compilation-work budget.
+
+Both schema documents and validation inputs cross the adapter boundary as
+bounded, data-only snapshots. A validation input uses the JSON value limits in
+the table above. Cycles, accessors, symbols, hidden properties, revoked
+proxies, and custom object prototypes are rejected before the compiler runs.
+Successful validation returns the accepted snapshot rather than caller-owned
+state.
+
+Compiled validators are cached locally by the default adapter. The cache holds
+at most 128 entries and has a 2 MiB aggregate source-weight budget; least
+recently used entries are evicted when either limit is exceeded.
+
+Adapter-generated JSON Schema documents use the JSON value bounds. Only the
+canonical snapshot crosses the helper boundary, so later reads cannot observe
+different Proxy values. Invalid adapter results fail with a `TypeError`.
 
 ## JSON Schema conversion
 

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -64,11 +64,12 @@ entries, and nested compilation is subject to a 24,000-unit work budget.
 Both schema documents and validation inputs cross the adapter boundary as
 bounded, data-only snapshots. A validation input uses the JSON value limits in
 the table above. Cycles, accessors, symbols, hidden properties, revoked
-proxies, and custom object prototypes are rejected before the compiler runs.
-Successful validation returns the accepted snapshot rather than caller-owned
-state. The snapshot does not invoke property getters, setters, iterators, or
-`toJSON`. Inspecting a Proxy necessarily invokes its reflection traps; a trap
-may run or throw before rejection.
+proxies, and custom object prototypes are rejected at the snapshot boundary.
+Invalid schemas do not reach compilation, and invalid inputs do not reach
+validation. Successful validation returns the accepted snapshot rather than
+caller-owned state. The snapshot does not invoke property getters, setters,
+iterators, or `toJSON`. Inspecting a Proxy necessarily invokes its reflection
+traps; a trap may run or throw before rejection.
 
 Compiled validators are cached locally by the default adapter. The cache holds
 at most 128 entries and has a 2 MiB aggregate source-weight budget; least

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -58,15 +58,17 @@ src/
 Raw JSON Schema compilation uses a separate, smaller resource envelope. The
 default adapter accepts schemas with at most 64 levels, 8,192 nodes, and 512
 KiB serialized size. A schema string is at most 256 KiB and a property name is
-at most 4 KiB in UTF-8. A direct combinator or tuple fanout is at most 256, and
-nested combinators are subject to a 24,000-unit compilation-work budget.
+at most 4 KiB in UTF-8. A direct code-generating collection is at most 256
+entries, and nested compilation is subject to a 24,000-unit work budget.
 
 Both schema documents and validation inputs cross the adapter boundary as
 bounded, data-only snapshots. A validation input uses the JSON value limits in
 the table above. Cycles, accessors, symbols, hidden properties, revoked
 proxies, and custom object prototypes are rejected before the compiler runs.
 Successful validation returns the accepted snapshot rather than caller-owned
-state.
+state. The snapshot does not invoke property getters, setters, iterators, or
+`toJSON`. Inspecting a Proxy necessarily invokes its reflection traps; a trap
+may run or throw before rejection.
 
 Compiled validators are cached locally by the default adapter. The cache holds
 at most 128 entries and has a 2 MiB aggregate source-weight budget; least


### PR DESCRIPTION
## Symptom

Raw JSON Schema documents could remain inside the existing JSON-value envelope while still generating very large Ajv programs. Validation also passed caller-owned objects directly to Ajv, allowing hostile accessors or revoked proxies to escape the validation result contract. The compiled-validator cache bounded entry count but not aggregate retained source weight.

## Source

The compilation boundary measured serialized JSON structure only. It did not account for combinator fanout or generated-code work, and the input side had no descriptor-based ownership boundary. Cache eviction treated a tiny schema and a near-limit schema equally.

## Consequence

A structurally valid schema could consume disproportionate compilation CPU and memory. Untrusted input objects could execute user code during validation. A cache of large validators could retain substantially more memory than its entry count implied.

## Remedy

- add schema-specific depth, node, byte, direct-fanout, and weighted compilation-work limits before Ajv compilation
- snapshot validation input through bounded descriptor reads and return a stable failure for accessors, revoked proxies, cycles, custom prototypes, or oversized values
- validate and return the adapter-owned snapshot
- evict compiled validators by both LRU entry count and aggregate source weight
- document the exact extension limits as reference material
- add boundary, hostile-object, realistic-schema, and weighted-eviction regressions

## Verification

- `deno test --no-check --allow-all extensions/ext-schema-zod/src src/schemas` (156 steps)
- `deno lint extensions/ext-schema-zod/src/adapter.ts extensions/ext-schema-zod/src/json-schema-validation.test.ts src/extensions/schema/schema-validator.ts`
- `deno task typecheck`
- `git diff --check`