### PR TITLE
fix(observability): make Sentry lifecycle transactional

### DIFF
--- a/src/agent/service/node-sentry.test.ts
+++ b/src/agent/service/node-sentry.test.ts
@@ -392,6 +392,114 @@ describe("agent/service/node-sentry", () => {
     }
   });
 
+  it("keeps the current reporter active until a concurrent replacement is ready", async () => {
+    const firstReporter = createReporter();
+    const secondReporter = createReporter();
+    const firstLifecycle = await initializeNodeAgentServiceSentryApplicationErrors({
+      env: { SENTRY_DSN: "https://public@example.ingest.sentry.io/1" },
+      loadExtension: () =>
+        Promise.resolve({
+          createNodeSentryApplicationErrorReporter: () => firstReporter,
+        }),
+    });
+    let resolveReplacement:
+      | ((
+        extension: { createNodeSentryApplicationErrorReporter: () => ApplicationErrorReporter },
+      ) => void)
+      | undefined;
+    const replacement = initializeNodeAgentServiceSentryApplicationErrors({
+      env: { SENTRY_DSN: "https://public@example.ingest.sentry.io/2" },
+      loadExtension: () =>
+        new Promise((resolve) => {
+          resolveReplacement = resolve;
+        }),
+    });
+
+    try {
+      withMutedConsole(() => {
+        agentLogger.error("while replacement loads");
+      });
+      assertEquals(firstReporter.captured.length, 1);
+      assertEquals(secondReporter.captured, []);
+
+      resolveReplacement?.({
+        createNodeSentryApplicationErrorReporter: () => secondReporter,
+      });
+      const secondLifecycle = await replacement;
+      try {
+        withMutedConsole(() => {
+          agentLogger.error("after replacement");
+        });
+        assertEquals(firstReporter.captured.length, 1);
+        assertEquals(secondReporter.captured.length, 1);
+
+        firstLifecycle.reset();
+        withMutedConsole(() => {
+          agentLogger.error("after stale reset");
+        });
+        assertEquals(secondReporter.captured.length, 2);
+      } finally {
+        secondLifecycle.reset();
+      }
+    } finally {
+      firstLifecycle.reset();
+      __resetLogRecordEmitterForTests();
+      setApplicationErrorReporter(undefined);
+    }
+  });
+
+  it("preserves the current reporter when replacement loading or construction fails", async () => {
+    const reporter = createReporter();
+    const lifecycle = await initializeNodeAgentServiceSentryApplicationErrors({
+      env: { SENTRY_DSN: "https://public@example.ingest.sentry.io/1" },
+      loadExtension: () =>
+        Promise.resolve({
+          createNodeSentryApplicationErrorReporter: () => reporter,
+        }),
+    });
+
+    try {
+      for (
+        const loadExtension of [
+          () => Promise.reject(new Error("replacement load failed")),
+          () =>
+            Promise.resolve({
+              createNodeSentryApplicationErrorReporter: () => {
+                throw new Error("replacement construction failed");
+              },
+            }),
+        ]
+      ) {
+        try {
+          await initializeNodeAgentServiceSentryApplicationErrors({
+            env: { SENTRY_DSN: "https://public@example.ingest.sentry.io/2" },
+            loadExtension,
+          });
+          throw new Error("Expected replacement initialization to fail");
+        } catch (error) {
+          assertEquals(
+            error instanceof Error && error.message.startsWith("replacement "),
+            true,
+          );
+        }
+        withMutedConsole(() => {
+          agentLogger.error("after failed replacement");
+        });
+      }
+
+      assertEquals(reporter.captured.length, 2);
+      lifecycle.reset();
+      withMutedConsole(() => {
+        agentLogger.error("after cleanup");
+      });
+      assertEquals(reporter.captured.length, 2);
+    } finally {
+      lifecycle.reset();
+      __resetLogRecordEmitterForTests();
+      setApplicationErrorReporter(undefined);
+    }
+  });
+
   it("prevents stale concurrent initialization from winning reporter ownership", async () => {
     const firstReporter = createReporter();
     const secondReporter = createReporter();

--- a/src/agent/service/node-sentry.ts
+++ b/src/agent/service/node-sentry.ts
@@ -229,7 +229,12 @@ async function withWallClockTimeout(
   }
 }
 
-/** Initialize node agent service Sentry application-error reporting. */
+/**
+ * Initialize or replace node agent service Sentry application-error reporting.
+ *
+ * An active lifecycle remains installed while an enabled replacement loads
+ * and is only retired after the replacement reporter is ready to take over.
+ */
 export async function initializeNodeAgentServiceSentryApplicationErrors(options: {
   env: NodeAgentServiceApplicationErrorEnv;
   defaultServiceName?: string;
@@ -237,10 +242,10 @@ export async function initializeNodeAgentServiceSentryApplicationErrors(options:
   flushTimeoutMs?: number;
 }): Promise<NodeAgentServiceApplicationErrorLifecycle> {
   const initializationId = ++currentInitializationId;
-  deactivateCurrentLifecycle();
 
   const config = resolveNodeAgentServiceSentryConfig(options.env, options.defaultServiceName);
   if (!config) {
+    deactivateCurrentLifecycle();
     if (
       isSentryEnabled(options.env.SENTRY_ENABLED, false) &&
       !readTrimmedEnv(options.env, "SENTRY_DSN")
@@ -259,13 +264,12 @@ export async function initializeNodeAgentServiceSentryApplicationErrors(options:
     release: config.release ?? "",
     serviceName: config.serviceName,
   });
-  setApplicationErrorReporter(reporter);
 
+  const previousLifecycle = currentLifecycle;
   const owner = Symbol("node-agent-service-sentry");
   const unsubscribeLogCapture = __subscribeLogRecordEmitter(
     createNodeAgentServiceLogApplicationErrorEmitter(),
   );
-  currentLifecycleOwner = owner;
   let active = true;
   let logCaptureActive = true;
   const flushTimeoutMs = options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS;
@@ -298,7 +302,10 @@ export async function initializeNodeAgentServiceSentryApplicationErrors(options:
       }
     },
   };
+  setApplicationErrorReporter(reporter);
+  currentLifecycleOwner = owner;
   currentLifecycle = lifecycle;
+  previousLifecycle?.reset();
   return lifecycle;
 }
 

--- a/src/observability/sentry.test.ts
+++ b/src/observability/sentry.test.ts
@@ -258,6 +258,49 @@ describe("observability/sentry", () => {
     assertEquals(state.config?.dsn, "https://public@errors.example.test/42");
   });
 
+  it("does not report success for a concurrent or installed different configuration", async () => {
+    resetSentryForTests();
+    const { load, state } = createSentryExtension();
+    let resolveLoad: (() => void) | undefined;
+    let firstLoadCount = 0;
+    let conflictingLoadCount = 0;
+    const firstConfig = {
+      dsn: "https://public@errors.example.test/1",
+      environment: " production ",
+      serviceName: " veryfront-server ",
+    };
+    const conflictingConfig = {
+      dsn: "https://public@errors.example.test/2",
+      environment: "production",
+      serviceName: "veryfront-proxy",
+    };
+    const first = initializeSentry(firstConfig, async () => {
+      firstLoadCount += 1;
+      await new Promise<void>((resolve) => {
+        resolveLoad = resolve;
+      });
+      return await load();
+    });
+    const conflicting = initializeSentry(conflictingConfig, async () => {
+      conflictingLoadCount += 1;
+      return await load();
+    });
+
+    assertEquals(await conflicting, false);
+    resolveLoad?.();
+    assertEquals(await first, true);
+    assertEquals(firstLoadCount, 1);
+    assertEquals(conflictingLoadCount, 0);
+    assertEquals(state.config, {
+      dsn: "https://public@errors.example.test/1",
+      environment: "production",
+      release: "",
+      serviceName: "veryfront-server",
+    });
+    assertEquals(await initializeSentry({ ...firstConfig, environment: "production" }), true);
+    assertEquals(await initializeSentry(conflictingConfig), false);
+  });
+
   it("a reset initialization cannot clear the replacement initialization", async () => {
     resetSentryForTests();
     const { load } = createSentryExtension();

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -28,10 +28,11 @@ type SentryExtensionModule = {
 
 type SentryExtensionLoader = () => Promise<SentryExtensionModule>;
 
-let initialized = false;
 let initializationGeneration = 0;
 let initializationPromise: Promise<boolean> | undefined;
 let initializationOwner: symbol | undefined;
+let initializingConfig: Required<SentryConfig> | undefined;
+let installedConfig: Required<SentryConfig> | undefined;
 let missingDsnWarningEmitted = false;
 
 /**
@@ -88,16 +89,32 @@ export function initializeSentryFromEnv(
   return config ? initializeSentry(config, loadExtension) : Promise.resolve(false);
 }
 
+/**
+ * Initialize the process-wide Sentry reporter once.
+ *
+ * Concurrent calls coalesce only when their normalized configurations are
+ * identical. Once installed, an identical configuration remains idempotent;
+ * a different configuration returns `false` because it was not applied.
+ */
 export async function initializeSentry(
   config: SentryConfig,
   loadExtension: SentryExtensionLoader = loadSentryExtension,
 ): Promise<boolean> {
-  if (initialized) return true;
-
   const dsn = config.dsn?.trim();
   if (!dsn) return false;
 
-  if (initializationPromise) return await initializationPromise;
+  const normalizedConfig: Required<SentryConfig> = {
+    dsn,
+    environment: config.environment?.trim() ?? "",
+    release: config.release?.trim() ?? "",
+    serviceName: config.serviceName?.trim() || DEFAULT_SERVICE_NAME,
+  };
+  if (installedConfig) return sentryConfigsEqual(installedConfig, normalizedConfig);
+  if (initializationPromise) {
+    return initializingConfig && sentryConfigsEqual(initializingConfig, normalizedConfig)
+      ? await initializationPromise
+      : false;
+  }
 
   const generation = initializationGeneration;
   const owner = Symbol("sentry-initialization");
@@ -105,24 +122,21 @@ export async function initializeSentry(
     const extension = await loadExtension();
     if (generation !== initializationGeneration) return false;
 
-    const reporter = extension.createSentryApplicationErrorReporter({
-      dsn,
-      environment: config.environment?.trim() ?? "",
-      release: config.release?.trim() ?? "",
-      serviceName: config.serviceName?.trim() || DEFAULT_SERVICE_NAME,
-    });
+    const reporter = extension.createSentryApplicationErrorReporter({ ...normalizedConfig });
     setApplicationErrorReporter(reporter);
-    initialized = true;
+    installedConfig = normalizedConfig;
     return true;
   })();
   initializationPromise = pending;
   initializationOwner = owner;
+  initializingConfig = normalizedConfig;
   try {
     return await pending;
   } finally {
     if (generation === initializationGeneration && initializationOwner === owner) {
       initializationPromise = undefined;
       initializationOwner = undefined;
+      initializingConfig = undefined;
     }
   }
 }
@@ -131,9 +145,18 @@ export function resetSentryForTests(): void {
   initializationGeneration += 1;
   initializationPromise = undefined;
   initializationOwner = undefined;
+  initializingConfig = undefined;
+  installedConfig = undefined;
   missingDsnWarningEmitted = false;
-  initialized = false;
   setApplicationErrorReporter(undefined);
+}
+
+function sentryConfigsEqual(
+  left: Required<SentryConfig>,
+  right: Required<SentryConfig>,
+): boolean {
+  return left.dsn === right.dsn && left.environment === right.environment &&
+    left.release === right.release && left.serviceName === right.serviceName;
 }
 
 function shouldWarnAboutMissingDsn(): boolean {


### PR DESCRIPTION
## Summary

- make framework Sentry initialization first-wins by exact normalized config identity, so conflicting concurrent or later requests return false instead of claiming an unapplied configuration succeeded
- keep identical concurrent and installed configurations idempotent without loading the extension twice
- make Node Agent Sentry replacement transactional: the healthy reporter and subscriber remain active while a replacement loads and constructs, then the new lifecycle takes ownership before the old lifecycle retires
- preserve the active Agent reporter when replacement loading or construction fails, while retaining stale-completion and cleanup protections
- keep all third-party Sentry SDK imports inside ext-observability-sentry

## Verification

- focused framework, Agent, policy, and Node/Deno adapter suites: 22 registrations / 27 BDD steps passed with --trace-leaks
- deno task typecheck
- touched-file deno check, lint, and formatting
- core dependency, dependency boundary, module boundary, extension contract, and extension capability checks
- Sentry Node/Deno runtime package generation smoke

## Audit origin

Follow-up to the post-merge audit of #3223. The audit reproduced both failures against current main before this fix.