### PR TITLE
fix(tool): bound deferred catalog search

### DIFF
--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -100,6 +100,12 @@ matches. Results contain the tool name, description, and loading status, but no
 input or output schema. The search tool has no page or pagination parameter.
 Refine the query when the required tool is not in the first five matches.
 
+Search work is bounded to 4,096 catalog candidates. Each parameter schema is
+inspected iteratively with depth, node, and byte budgets, and the whole search
+has an aggregate schema-work budget. A malformed, cyclic, or over-budget schema
+cannot abort the search; that tool simply cannot match by parameter description.
+Name and description matching remains available for other healthy tools.
+
 The search only loads schemas from the current authorized `tools` catalog. It
 does not search or load provider-native `providerTools`. The runtime reapplies
 the current authorization policy before executing a tool and when restoring a

--- a/src/agent/runtime/tool-exposure.test.ts
+++ b/src/agent/runtime/tool-exposure.test.ts
@@ -268,6 +268,126 @@ it("tool search caps stable schema-free results at five", () => {
   assert(!serialized.includes("outputSchema"));
 });
 
+it("tool search treats deeply nested and cyclic parameter schemas as isolated non-matches", () => {
+  const deepRoot: Record<string, unknown> = {};
+  let cursor = deepRoot;
+  for (let index = 0; index < 20_000; index += 1) {
+    const child: Record<string, unknown> = {};
+    cursor.next = child;
+    cursor = child;
+  }
+  cursor.description = "deep-only capability";
+  const cyclic: Record<string, unknown> = {};
+  cyclic.self = cyclic;
+  cyclic.description = "cyclic-only capability";
+
+  const result = searchToolExposure({
+    query: "healthy capability",
+    authorized: [
+      { name: "deep", description: "Unrelated", parameters: deepRoot },
+      { name: "cyclic", description: "Unrelated", parameters: cyclic },
+      definition("healthy", "Healthy capability"),
+    ],
+    state: createToolExposureState(),
+  });
+
+  assertEquals(result.matches.map((match) => match.name), ["healthy"]);
+});
+
+it("tool search never invokes schema accessors and contains throwing proxy reflection", () => {
+  let getterReads = 0;
+  const accessorSchema = Object.defineProperty({}, "description", {
+    enumerable: true,
+    get() {
+      getterReads += 1;
+      return "accessor capability";
+    },
+  });
+  let proxyReads = 0;
+  const proxySchema = new Proxy({}, {
+    ownKeys() {
+      proxyReads += 1;
+      throw new Error("hostile reflection");
+    },
+  });
+
+  const result = searchToolExposure({
+    query: "healthy capability",
+    authorized: [
+      { name: "accessor", description: "Unrelated", parameters: accessorSchema },
+      { name: "proxy", description: "Unrelated", parameters: proxySchema },
+      definition("healthy", "Healthy capability"),
+    ],
+    state: createToolExposureState(),
+  });
+
+  assertEquals(result.matches.map((match) => match.name), ["healthy"]);
+  assertEquals(getterReads, 0);
+  assertEquals(proxyReads, 1);
+});
+
+it("tool search bounds catalog traversal and returned description bytes", () => {
+  const within = Array.from(
+    { length: 4_096 },
+    (_, index) => definition(index === 4_095 ? "within_limit" : `irrelevant_${index}`, "Other"),
+  );
+  within.push(definition("beyondcatalog", "Beyond candidate ceiling"));
+  assertEquals(
+    searchToolExposure({
+      query: "within_limit",
+      authorized: within,
+      state: createToolExposureState(),
+    }).matches.map((match) => match.name),
+    ["within_limit"],
+  );
+  assertEquals(
+    searchToolExposure({
+      query: "beyondcatalog",
+      authorized: within,
+      state: createToolExposureState(),
+    }).miss,
+    true,
+  );
+
+  const oversizedDescription = "💥".repeat(1_100);
+  assertEquals(
+    searchToolExposure({
+      query: "healthy",
+      authorized: [
+        definition("oversized", oversizedDescription),
+        definition("healthy", "Healthy bounded result"),
+      ],
+      state: createToolExposureState(),
+    }).matches.map((match) => match.name),
+    ["healthy"],
+  );
+});
+
+it("tool search preserves later name matches after exhausting aggregate schema work", () => {
+  const wideSchema = (): Record<string, unknown> => ({
+    type: "object",
+    properties: Object.fromEntries(
+      Array.from({ length: 4_000 }, (_, index) => [`field_${index}`, { type: "string" }]),
+    ),
+  });
+  const exhausting = Array.from(
+    { length: 20 },
+    (_, index) => ({
+      name: `wide_${index}`,
+      description: "Other",
+      parameters: wideSchema(),
+    }),
+  );
+
+  const result = searchToolExposure({
+    query: "healthy_after_budget",
+    authorized: [...exhausting, definition("healthy_after_budget", "Healthy")],
+    state: createToolExposureState(),
+  });
+
+  assertEquals(result.matches.map((match) => match.name), ["healthy_after_budget"]);
+});
+
 it("authorized search matches load for the next step", () => {
   const state = createToolExposureState();
   const result = searchToolExposure({ query: "get_release", authorized: catalog, state });

--- a/src/agent/runtime/tool-exposure.test.ts
+++ b/src/agent/runtime/tool-exposure.test.ts
@@ -204,13 +204,30 @@ it("tool search falls back to deterministic whitespace terms after a phrase miss
 
 it("tool_search tells the model to search before declaring a requested tool unavailable", () => {
   const search = createToolSearchDefinition();
+  const querySchema = (search.parameters as {
+    properties?: { query?: { description?: string; maxLength?: number } };
+  }).properties?.query;
 
   assert(search.description.includes("before declaring a requested tool unavailable"));
   assertEquals(
-    (search.parameters as { properties?: { query?: { description?: string } } }).properties?.query
-      ?.description,
-    "One exact tool name when known, or one short capability phrase. Do not combine alternatives.",
+    querySchema?.description,
+    "One exact tool name when known, or one short capability phrase. UTF-8 input must be at most 256 bytes. Do not combine alternatives.",
   );
+  assertEquals(querySchema?.maxLength, undefined);
+});
+
+it("tool search enforces query limits in UTF-8 bytes", () => {
+  const search = (query: string) =>
+    searchToolExposure({
+      query,
+      authorized: [definition("matching_tool", query)],
+      state: createToolExposureState(),
+    }).matches.map((match) => match.name);
+
+  assertEquals(search("a".repeat(256)), ["matching_tool"]);
+  assertEquals(search("a".repeat(257)), []);
+  assertEquals(search("💥".repeat(64)), ["matching_tool"]);
+  assertEquals(search("💥".repeat(65)), []);
 });
 
 it("tool search breaks equal-rank ties by raw ASCII name order", () => {

--- a/src/agent/runtime/tool-exposure.ts
+++ b/src/agent/runtime/tool-exposure.ts
@@ -6,6 +6,16 @@ export const TOOL_SEARCH_TOOL_NAME = "tool_search";
 
 const DEFAULT_BOOTSTRAP_TOOL_NAMES = new Set(["form_input", "load_skill"]);
 const TOOL_SEARCH_RESULT_LIMIT = 5;
+const TOOL_SEARCH_QUERY_MAX_BYTES = 256;
+const TOOL_SEARCH_CANDIDATE_LIMIT = 4_096;
+const TOOL_SEARCH_NAME_MAX_BYTES = 256;
+const TOOL_SEARCH_DESCRIPTION_MAX_BYTES = 4_096;
+const TOOL_SEARCH_SCHEMA_MAX_DEPTH = 64;
+const TOOL_SEARCH_SCHEMA_MAX_NODES = 4_096;
+const TOOL_SEARCH_SCHEMA_MAX_BYTES = 65_536;
+const TOOL_SEARCH_TOTAL_SCHEMA_NODES = 65_536;
+const TOOL_SEARCH_TOTAL_SCHEMA_BYTES = 524_288;
+const UTF8_ENCODER = new TextEncoder();
 
 /** Run-local mutable exposure state. Create a new state for every child run. */
 export type ToolExposureState = {
@@ -57,6 +67,15 @@ type RankedToolSearchMatch = {
   match: ToolSearchMatch;
 };
 
+type SearchableTool = ToolSearchMatch & {
+  parameterDescriptions: string[];
+};
+
+type SchemaSearchBudget = {
+  nodes: number;
+  bytes: number;
+};
+
 function normalizeSearchText(value: string): string {
   return value.replace(/[A-Z]/g, (character) => String.fromCharCode(character.charCodeAt(0) + 32))
     .replaceAll("_", " ").trim().replace(/\s+/g, " ");
@@ -64,6 +83,10 @@ function normalizeSearchText(value: string): string {
 
 function compareAscii(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function isUtf8LengthWithin(value: string, maxBytes: number): boolean {
+  return value.length <= maxBytes && UTF8_ENCODER.encode(value).byteLength <= maxBytes;
 }
 
 /** Return whether a persisted name matches the existing non-empty tool id contract. */
@@ -78,96 +101,180 @@ export function isSupportedToolExposureCheckpointVersion(
   return value === 1 || value === 2;
 }
 
-function collectSchemaDescriptions(value: unknown, output: string[]): void {
-  if (Array.isArray(value)) {
-    for (const entry of value) collectSchemaDescriptions(entry, output);
-    return;
-  }
-  if (!value || typeof value !== "object") return;
+/**
+ * Collect searchable schema descriptions without recursion or property reads.
+ * Getters are never invoked. Proxy reflection traps can still run; failures are
+ * caught and make only that schema non-searchable.
+ */
+function snapshotSchemaDescriptions(
+  root: unknown,
+  aggregate: SchemaSearchBudget,
+): string[] | null {
+  if (aggregate.nodes >= TOOL_SEARCH_TOTAL_SCHEMA_NODES) return null;
+  if (aggregate.bytes >= TOOL_SEARCH_TOTAL_SCHEMA_BYTES) return null;
 
-  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-    if (key === "description" && typeof entry === "string") {
-      output.push(entry);
-    } else {
-      collectSchemaDescriptions(entry, output);
+  const descriptions: string[] = [];
+  const seen = new WeakSet<object>();
+  const stack: Array<{ value: unknown; depth: number }> = [{ value: root, depth: 0 }];
+  let nodes = 0;
+  let bytes = 0;
+
+  const debitBytes = (value: string): boolean => {
+    if (value.length > TOOL_SEARCH_SCHEMA_MAX_BYTES) return false;
+    const length = UTF8_ENCODER.encode(value).byteLength;
+    bytes += length;
+    aggregate.bytes += length;
+    return bytes <= TOOL_SEARCH_SCHEMA_MAX_BYTES &&
+      aggregate.bytes <= TOOL_SEARCH_TOTAL_SCHEMA_BYTES;
+  };
+
+  try {
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current || current.depth > TOOL_SEARCH_SCHEMA_MAX_DEPTH) return null;
+      nodes += 1;
+      aggregate.nodes += 1;
+      if (
+        nodes > TOOL_SEARCH_SCHEMA_MAX_NODES ||
+        aggregate.nodes > TOOL_SEARCH_TOTAL_SCHEMA_NODES
+      ) return null;
+
+      if (typeof current.value === "string") {
+        if (!debitBytes(current.value)) return null;
+        continue;
+      }
+      if (!current.value || typeof current.value !== "object") continue;
+      if (seen.has(current.value)) return null;
+      seen.add(current.value);
+
+      const isArray = Array.isArray(current.value);
+      const prototype = Object.getPrototypeOf(current.value);
+      if (prototype !== null && prototype !== (isArray ? Array.prototype : Object.prototype)) {
+        return null;
+      }
+      const keys = Reflect.ownKeys(current.value);
+      if (keys.length > TOOL_SEARCH_SCHEMA_MAX_NODES - nodes) return null;
+
+      let arrayLength: number | null = null;
+      if (isArray) {
+        const lengthDescriptor = Object.getOwnPropertyDescriptor(current.value, "length");
+        if (!lengthDescriptor || !("value" in lengthDescriptor)) return null;
+        const length = lengthDescriptor.value;
+        if (!Number.isSafeInteger(length) || length < 0 || keys.length !== length + 1) return null;
+        arrayLength = length;
+      }
+
+      for (const key of keys) {
+        if (isArray && key === "length") continue;
+        if (typeof key !== "string" || !debitBytes(key)) return null;
+        if (isArray) {
+          const index = Number(key);
+          if (
+            !Number.isSafeInteger(index) || index < 0 || index >= (arrayLength ?? 0) ||
+            String(index) !== key
+          ) return null;
+        }
+        const descriptor = Object.getOwnPropertyDescriptor(current.value, key);
+        if (!descriptor || !descriptor.enumerable || !("value" in descriptor)) return null;
+        if (key === "description" && typeof descriptor.value === "string") {
+          descriptions.push(normalizeSearchText(descriptor.value));
+        }
+        stack.push({ value: descriptor.value, depth: current.depth + 1 });
+      }
     }
+  } catch {
+    return null;
+  }
+
+  return descriptions;
+}
+
+function snapshotSearchableTool(
+  tool: ToolDefinition,
+  status: ToolSearchMatch["status"],
+  budget: SchemaSearchBudget,
+): SearchableTool | null {
+  try {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool)) return null;
+    const name = Object.getOwnPropertyDescriptor(tool, "name");
+    const description = Object.getOwnPropertyDescriptor(tool, "description");
+    const parameters = Object.getOwnPropertyDescriptor(tool, "parameters");
+    if (
+      !name || !("value" in name) || typeof name.value !== "string" || name.value.length === 0 ||
+      !isUtf8LengthWithin(name.value, TOOL_SEARCH_NAME_MAX_BYTES) ||
+      !description || !("value" in description) || typeof description.value !== "string" ||
+      !isUtf8LengthWithin(description.value, TOOL_SEARCH_DESCRIPTION_MAX_BYTES) ||
+      (parameters && !("value" in parameters))
+    ) return null;
+    return {
+      name: name.value,
+      description: description.value,
+      status,
+      parameterDescriptions: parameters
+        ? snapshotSchemaDescriptions(parameters.value, budget) ?? []
+        : [],
+    };
+  } catch {
+    return null;
   }
 }
 
-function getMatchRank(input: {
-  query: string;
-  name: string;
-  description: string;
-  parameters?: unknown;
-}): number | null {
-  const query = normalizeSearchText(input.query);
-  if (!query) return null;
-
-  const name = normalizeSearchText(input.name);
+function getIndexedMatchRank(
+  query: string,
+  tool: SearchableTool,
+): number | null {
+  const name = normalizeSearchText(tool.name);
   if (name === query) return 0;
   if (name.includes(query)) return 1;
-  if (normalizeSearchText(input.description).includes(query)) return 2;
-
-  const parameterDescriptions: string[] = [];
-  collectSchemaDescriptions(input.parameters, parameterDescriptions);
-  return parameterDescriptions.some((description) =>
-      normalizeSearchText(description).includes(query)
-    )
-    ? 3
-    : null;
+  if (normalizeSearchText(tool.description).includes(query)) return 2;
+  return tool.parameterDescriptions.some((description) => description.includes(query)) ? 3 : null;
 }
 
-function getTermFallbackScore(input: {
+function rankToolExposureMatches(input: {
   query: string;
-  name: string;
-  description: string;
-  parameters?: unknown;
-}): { rank: number; matchCount: number } | null {
-  const terms = [
-    ...new Set(input.query.trim().split(/\s+/).map(normalizeSearchText).filter(Boolean)),
-  ];
-  if (terms.length < 2) return null;
-
-  const ranks = terms.flatMap((term) => {
-    const rank = getMatchRank({ ...input, query: term });
-    return rank === null ? [] : [rank];
-  });
-  return ranks.length > 0 ? { rank: Math.min(...ranks), matchCount: ranks.length } : null;
-}
-
-function rankToolExposureMatches(
-  query: string,
-  candidates: readonly { tool: ToolDefinition; status: ToolSearchMatch["status"] }[],
-): RankedToolSearchMatch[] {
+  available: readonly ToolDefinition[];
+  authorized: readonly ToolDefinition[];
+}): RankedToolSearchMatch[] {
+  if (!isUtf8LengthWithin(input.query, TOOL_SEARCH_QUERY_MAX_BYTES)) return [];
+  const query = normalizeSearchText(input.query);
+  if (!query) return [];
+  const terms = [...new Set(query.split(/\s+/).filter(Boolean))];
+  const budget: SchemaSearchBudget = { nodes: 0, bytes: 0 };
+  const candidates: SearchableTool[] = [];
+  let examinedCandidates = 0;
+  const append = (tools: readonly ToolDefinition[], status: ToolSearchMatch["status"]): void => {
+    for (const tool of tools) {
+      if (examinedCandidates >= TOOL_SEARCH_CANDIDATE_LIMIT) return;
+      examinedCandidates += 1;
+      const snapshot = snapshotSearchableTool(tool, status, budget);
+      if (snapshot) candidates.push(snapshot);
+    }
+  };
+  append(input.available, "available");
+  append(input.authorized, "loaded");
   const ranked: RankedToolSearchMatch[] = [];
 
-  for (const { tool, status } of candidates) {
-    const rank = getMatchRank({
-      query,
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.parameters,
-    });
+  for (const tool of candidates) {
+    const rank = getIndexedMatchRank(query, tool);
     if (rank === null) continue;
     ranked.push({
       rank,
       matchCount: 1,
-      match: { name: tool.name, description: tool.description, status },
+      match: { name: tool.name, description: tool.description, status: tool.status },
     });
   }
 
-  if (ranked.length === 0) {
-    for (const { tool, status } of candidates) {
-      const score = getTermFallbackScore({
-        query,
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.parameters,
+  if (ranked.length === 0 && terms.length >= 2) {
+    for (const tool of candidates) {
+      const ranks = terms.flatMap((term) => {
+        const rank = getIndexedMatchRank(term, tool);
+        return rank === null ? [] : [rank];
       });
-      if (!score) continue;
+      if (ranks.length === 0) continue;
       ranked.push({
-        ...score,
-        match: { name: tool.name, description: tool.description, status },
+        rank: Math.min(...ranks),
+        matchCount: ranks.length,
+        match: { name: tool.name, description: tool.description, status: tool.status },
       });
     }
   }
@@ -217,6 +324,7 @@ export function createToolSearchDefinition(): ToolDefinition {
       properties: {
         query: {
           type: "string",
+          maxLength: TOOL_SEARCH_QUERY_MAX_BYTES,
           description:
             "One exact tool name when known, or one short capability phrase. Do not combine alternatives.",
         },
@@ -286,10 +394,11 @@ export function searchToolExposure(input: {
   state: ToolExposureState;
   maxLoadedTools?: number;
 }): ToolSearchResult {
-  const ranked = rankToolExposureMatches(input.query, [
-    ...(input.available ?? []).map((tool) => ({ tool, status: "available" as const })),
-    ...input.authorized.map((tool) => ({ tool, status: "loaded" as const })),
-  ]);
+  const ranked = rankToolExposureMatches({
+    query: input.query,
+    available: input.available ?? [],
+    authorized: input.authorized,
+  });
   if (ranked[0]?.match.status === "available") {
     const matches = ranked
       .filter(({ match }) => match.status === "available")

--- a/src/agent/runtime/tool-exposure.ts
+++ b/src/agent/runtime/tool-exposure.ts
@@ -324,9 +324,8 @@ export function createToolSearchDefinition(): ToolDefinition {
       properties: {
         query: {
           type: "string",
-          maxLength: TOOL_SEARCH_QUERY_MAX_BYTES,
           description:
-            "One exact tool name when known, or one short capability phrase. Do not combine alternatives.",
+            `One exact tool name when known, or one short capability phrase. UTF-8 input must be at most ${TOOL_SEARCH_QUERY_MAX_BYTES} bytes. Do not combine alternatives.`,
         },
       },
     },

--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -632,6 +632,61 @@ describe("tool/remote-mcp", () => {
     );
   });
 
+  it("enforces UTF-8 byte budgets for remote tool identity fields", async () => {
+    const cases = [
+      { name: "💥".repeat(33), description: "Tool", inputSchema: {} },
+      { name: "tool", description: "💥".repeat(257), inputSchema: {} },
+      { name: "tool", description: "Tool", title: "💥".repeat(257), inputSchema: {} },
+    ];
+
+    for (const tool of cases) {
+      const source = createRemoteMCPToolSource({
+        id: "docs",
+        endpoint: "https://mcp.test",
+      });
+      await assertRejects(
+        () =>
+          withMockFetch(
+            async () =>
+              Response.json({
+                jsonrpc: "2.0",
+                id: "docs:tools:list",
+                result: { tools: [tool] },
+              }),
+            async () => await source.listTools(),
+          ),
+        Error,
+        "malformed",
+      );
+    }
+  });
+
+  it("rejects compact remote schemas above the structural node budget", async () => {
+    const source = createRemoteMCPToolSource({
+      id: "docs",
+      endpoint: "https://mcp.test",
+    });
+    const emptyValue: unknown[] = [];
+    const inputSchema = { enum: new Array(4_096).fill(emptyValue) };
+
+    await assertRejects(
+      () =>
+        withMockFetch(
+          async () =>
+            Response.json({
+              jsonrpc: "2.0",
+              id: "docs:tools:list",
+              result: {
+                tools: [{ name: "wide", description: "Tool", inputSchema }],
+              },
+            }),
+          async () => await source.listTools(),
+        ),
+      Error,
+      "malformed input schema",
+    );
+  });
+
   it("rejects duplicate tool names and repeated pagination cursors", async () => {
     let callCount = 0;
     const duplicateSource = createRemoteMCPToolSource({

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -21,11 +21,12 @@ const MAX_ERROR_BODY_BYTES = MAX_ERROR_BODY_LENGTH * 4;
 export const MAX_REMOTE_MCP_TOOL_LIST_PAGES = 50;
 /** Maximum number of remote definitions admitted atomically. */
 export const MAX_REMOTE_MCP_TOOL_DEFINITIONS = 1_000;
-const MAX_REMOTE_MCP_TOOL_NAME_LENGTH = 128;
-const MAX_REMOTE_MCP_TOOL_DESCRIPTION_LENGTH = 1_024;
-const MAX_REMOTE_MCP_TOOL_TITLE_LENGTH = 1_024;
+const MAX_REMOTE_MCP_TOOL_NAME_BYTES = 128;
+const MAX_REMOTE_MCP_TOOL_DESCRIPTION_BYTES = 1_024;
+const MAX_REMOTE_MCP_TOOL_TITLE_BYTES = 1_024;
 const MAX_REMOTE_MCP_TOOL_SCHEMA_BYTES = 16_384;
 const MAX_REMOTE_MCP_TOOL_SCHEMA_DEPTH = 64;
+const MAX_REMOTE_MCP_TOOL_SCHEMA_NODES = 4_096;
 const MAX_REMOTE_MCP_CURSOR_LENGTH = 4_096;
 const UTF8_ENCODER = new TextEncoder();
 
@@ -108,12 +109,21 @@ function serializedByteLength(value: unknown): number {
   return UTF8_ENCODER.encode(JSON.stringify(value)).byteLength;
 }
 
-function isJsonDepthWithin(value: unknown, maxDepth: number): boolean {
+function isUtf8LengthWithin(value: string, maxBytes: number): boolean {
+  return value.length <= maxBytes && UTF8_ENCODER.encode(value).byteLength <= maxBytes;
+}
+
+function isJsonStructureWithin(
+  value: unknown,
+  maxDepth: number,
+  maxNodes: number,
+): boolean {
   const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+  let nodes = 0;
   while (stack.length > 0) {
     const current = stack.pop();
     if (!current) break;
-    if (current.depth > maxDepth) return false;
+    if (current.depth > maxDepth || ++nodes > maxNodes) return false;
 
     if (Array.isArray(current.value)) {
       for (const child of current.value) {
@@ -135,7 +145,11 @@ function normalizeParameters(inputSchema: unknown, toolName: string): JsonSchema
   if (
     !snapshot.success ||
     !isRecord(snapshot.value) ||
-    !isJsonDepthWithin(snapshot.value, MAX_REMOTE_MCP_TOOL_SCHEMA_DEPTH) ||
+    !isJsonStructureWithin(
+      snapshot.value,
+      MAX_REMOTE_MCP_TOOL_SCHEMA_DEPTH,
+      MAX_REMOTE_MCP_TOOL_SCHEMA_NODES,
+    ) ||
     serializedByteLength(snapshot.value) > MAX_REMOTE_MCP_TOOL_SCHEMA_BYTES
   ) {
     throw protocolError(
@@ -159,9 +173,9 @@ function normalizeToolDefinition(entry: unknown, index: number): ToolDefinition 
   if (
     typeof entry.name !== "string" ||
     entry.name.length === 0 ||
-    entry.name.length > MAX_REMOTE_MCP_TOOL_NAME_LENGTH ||
+    !isUtf8LengthWithin(entry.name, MAX_REMOTE_MCP_TOOL_NAME_BYTES) ||
     typeof entry.description !== "string" ||
-    entry.description.length > MAX_REMOTE_MCP_TOOL_DESCRIPTION_LENGTH
+    !isUtf8LengthWithin(entry.description, MAX_REMOTE_MCP_TOOL_DESCRIPTION_BYTES)
   ) {
     throw protocolError(
       `Remote MCP tools/list returned a malformed tool definition at index ${index}`,
@@ -178,7 +192,7 @@ function normalizeToolDefinition(entry: unknown, index: number): ToolDefinition 
     if (
       typeof entry.title !== "string" ||
       entry.title.length === 0 ||
-      entry.title.length > MAX_REMOTE_MCP_TOOL_TITLE_LENGTH
+      !isUtf8LengthWithin(entry.title, MAX_REMOTE_MCP_TOOL_TITLE_BYTES)
     ) {
       throw protocolError(
         `Remote MCP tools/list returned a malformed title for tool "${entry.name}"`,


### PR DESCRIPTION
## Summary

- replace recursive parameter-description traversal with an iterative, cycle-aware, data-descriptor scanner
- bound query bytes, catalog candidates, per-schema depth/nodes/bytes, aggregate schema work, and returned identity fields
- isolate malformed or over-budget schemas so healthy neighboring tools remain searchable by name and description
- harden remote MCP catalog admission with UTF-8 identity budgets and an explicit schema-node ceiling
- document the deferred-search resource envelope

This is a fix-forward for the deferred catalog risks identified in the post-merge #3222 audit. Core remains dependency-free.

## Verification

- `deno test -A src/agent/runtime/tool-exposure.test.ts src/tool/remote-mcp.test.ts` (33 passed; 27 nested steps)
- `deno task typecheck`
- `deno task lint:test-typecheck` (81 grandfathered, 0 new)
- `deno task lint:core-deps`
- `deno task lint:dependency-boundaries`
- `deno task lint:module-boundaries`
- `deno task docs:validate`
- `git diff --check`

Adversarial coverage includes 20,000-level nesting, cycles, accessors, throwing proxy reflection, compact node-heavy schemas, multibyte identity fields, candidate-ceiling behavior, aggregate-work exhaustion, and healthy-neighbor survival.