### PR TITLE
fix(agent): restore provider catalog and bounded project skills

### DIFF
--- a/docs/api-reference/veryfront/provider.md
+++ b/docs/api-reference/veryfront/provider.md
@@ -31,9 +31,9 @@ const model = resolveModel("veryfront-cloud/openai/gpt-5.4-nano");
 
 ### `registerModelProvider(name, factory)`
 
-Register a custom model provider factory for the current project.
+Register a custom model provider factory for the active project scope or application bootstrap.
 
-**Returns:** `void`
+**Returns:** `ModelProviderRegistrationDisposer`
 
 ### `resolveModel(modelString)`
 
@@ -85,7 +85,7 @@ Clear all registered model providers (for testing).
 | `hasModelProvider` | Check if a model provider is registered (project-scoped or shared). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L272) |
 | `markCurrentVeryfrontCloudBillingGroupUsed` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/context.ts#L35) |
 | `normalizeVeryfrontCloudModelId` | Normalizes Veryfront Cloud model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L198) |
-| `registerModelProvider` | Register a custom model provider factory for the current project. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L61) |
+| `registerModelProvider` | Register a custom model provider factory for the active project scope or application bootstrap. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L61) |
 | `resolveModel` | Resolve a "provider/model" string to a framework-compatible model runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L228) |
 | `resolveVeryfrontCloudGatewayModelId` | Resolves Veryfront Cloud gateway model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L272) |
 | `resolveVeryfrontCloudModelId` | Resolves Veryfront Cloud model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L246) |

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -190,7 +190,7 @@ For providers not covered by env vars, use `registerModelProvider()`:
 ```ts
 import { registerModelProvider } from "veryfront/provider";
 
-registerModelProvider("ollama", (id) => {
+const unregisterOllama = registerModelProvider("ollama", (id) => {
   // Return a framework-compatible model runtime for this model ID.
   // Prefer built-in providers when possible; custom registration is an
   // advanced interop surface for non-standard backends. The runtime must
@@ -206,6 +206,13 @@ agent({ model: "ollama/llama3.2" });
 The factory receives the model ID and must return a framework-compatible model
 runtime with the generation surface the framework expects, including
 `doGenerate()` and `doStream()`.
+
+Registration inside a project source context is isolated to that project.
+Registration during application bootstrap, outside a project context, becomes
+the default for every project unless a project registers an override. The
+returned disposer removes only the registration created by that call.
+Call `unregisterOllama()` during application teardown when the registration is
+no longer needed.
 
 ## Direct model resolution
 

--- a/scripts/lint/test-typecheck-baseline.json
+++ b/scripts/lint/test-typecheck-baseline.json
@@ -21,8 +21,6 @@
   "src/agent/hosted/response-stream.test.ts",
   "src/agent/memory/memory.test.ts",
   "src/agent/middleware/cost-tracking/tracker.test.ts",
-  "src/agent/runtime/load-tools-tool.test.ts",
-  "src/agent/runtime/search-tools-tool.test.ts",
   "src/build/bundler/code-splitter/manifest-builder.test.ts",
   "src/build/production-build/build/build-cleanup.test.ts",
   "src/build/production-build/manifest.test.ts",

--- a/src/agent/hosted/agent-project-steering.test.ts
+++ b/src/agent/hosted/agent-project-steering.test.ts
@@ -67,13 +67,14 @@ Deno.test("createHostedAgentProjectSteering registers the built-in schema valida
     assertEquals(tryResolve<SchemaValidator>("SchemaValidator"), undefined);
 
     const baseDir = writeAgentDefinition({ rootDir, agentId: "writer" });
-    createHostedAgentProjectSteering({
+    const steering = createHostedAgentProjectSteeringPublic({
       baseDir,
       agentId: "writer",
       getApiUrl: () => "https://api.example.com",
     });
 
     assertEquals(typeof tryResolve<SchemaValidator>("SchemaValidator")?.object, "function");
+    assertEquals(steering.getAgentConfig().id, "writer");
   });
 });
 

--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -410,6 +410,58 @@ Deno.test("createHostedProjectRemoteToolSource fails closed on claimed but uncon
   assertEquals(switchCount, 0);
 });
 
+Deno.test("createHostedProjectRemoteToolSource rejects unconfirmed claimed navigation success", async () => {
+  let switchCount = 0;
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [navigationTool("studio_open_project")],
+      execute: () => ({
+        structuredContent: {
+          success: true,
+          project_id: "different-project",
+          slug: "different-project",
+        },
+      }),
+    }),
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: ["studio_open_project"],
+    },
+    onProjectSwitch: () => {
+      switchCount += 1;
+    },
+  });
+
+  const result = await source.executeTool("studio_open_project", {
+    project_reference: "requested-project",
+  });
+
+  assertEquals(result, createUnconfirmedProjectContextSwitchResult());
+  assertEquals(switchCount, 0);
+});
+
+Deno.test("createHostedProjectRemoteToolSource preserves upstream navigation failure", async () => {
+  const failure = { structuredContent: { success: false, message: "not found" } };
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [navigationTool("studio_open_project")],
+      execute: () => failure,
+    }),
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: ["studio_open_project"],
+    },
+    onProjectSwitch: () => {
+      throw new Error("unexpected project switch");
+    },
+  });
+
+  assertEquals(
+    await source.executeTool("studio_open_project", {
+      project_reference: "missing-project",
+    }),
+    failure,
+  );
+});
+
 Deno.test("createHostedProjectRemoteToolSource skips mutation callbacks for failed results", async () => {
   let mutationCount = 0;
   const source = createHostedProjectRemoteToolSource({

--- a/src/agent/hosted/project-steering-adapter.test.ts
+++ b/src/agent/hosted/project-steering-adapter.test.ts
@@ -97,8 +97,7 @@ Deno.test("hosted project steering uses the bounded transport by default", async
     );
     await Promise.resolve();
 
-    assert(error instanceof RangeError);
-    assertStringIncludes(error.message, "Project file response may contain at most");
+    assertStringIncludes(String(error), "Project files list response exceeds");
     assertEquals(cancelled, true);
   });
 });

--- a/src/agent/hosted/project-steering-adapter.ts
+++ b/src/agent/hosted/project-steering-adapter.ts
@@ -14,7 +14,7 @@ import {
 } from "../runtime/load-skill-tool.ts";
 import type { MutableAgentProjectContext } from "../project/context.ts";
 import {
-  createRuntimeProjectFilesClient,
+  createStrictRuntimeProjectFilesClient,
   type RuntimeProjectFilesClient,
   type RuntimeProjectFilesClientOptions,
   type RuntimeProjectFilesFetch,
@@ -122,7 +122,7 @@ function createProjectFilesClientOptions(
 function createDefaultProjectFilesClient(
   options: HostedProjectSteeringAdapterOptions,
 ): RuntimeProjectFilesClient {
-  return createRuntimeProjectFilesClient(createProjectFilesClientOptions(options));
+  return createStrictRuntimeProjectFilesClient(createProjectFilesClientOptions(options));
 }
 
 function createDefaultProjectSkillLoader(

--- a/src/agent/runtime/agent-runtime-step.test.ts
+++ b/src/agent/runtime/agent-runtime-step.test.ts
@@ -43,7 +43,7 @@ describe("agent/runtime-step", () => {
         toolDefinition("get_release"),
         toolDefinition("load_skill"),
       ],
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages: [],
       mode: "generate",
       remoteToolSources: undefined,
@@ -74,7 +74,7 @@ describe("agent/runtime-step", () => {
       config: { model: "anthropic/claude-opus-4-6", system: "Base", tools: true } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
       getAvailableTools: async () => [toolDefinition("create_release")],
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages: [],
       mode: "generate",
       providerToolNames: ["web_search"],
@@ -104,7 +104,7 @@ describe("agent/runtime-step", () => {
       config: { model: "auto", system: "Base", __vfToolLoadingMode: "eager" } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
       getAvailableTools: async () => [],
-      isLocalModel: true,
+      supportsToolCalling: false,
       messages: [],
       mode: "generate",
       remoteToolSources: undefined,
@@ -138,7 +138,7 @@ describe("agent/runtime-step", () => {
         assertEquals(options?.remoteToolContext?.allowedSkillIds, ["selected"]);
         return [];
       },
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages: [],
       mode: "generate",
       remoteToolSources: undefined,
@@ -179,7 +179,7 @@ describe("agent/runtime-step", () => {
       allowedRemoteToolNames: ["remote_allowed"],
       config,
       forwardedRemoteToolDefinitions: [toolDefinition("forwarded_remote")],
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages,
       mode: "generate",
       remoteToolSources: [remoteSource],
@@ -249,7 +249,7 @@ describe("agent/runtime-step", () => {
         __vfToolLoadingMode: "eager",
       } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages: [],
       mode: "stream",
       remoteToolSources: [],
@@ -287,7 +287,7 @@ describe("agent/runtime-step", () => {
         assertEquals(options?.includeSkillTools, false);
         return [toolDefinition("ordinary_tool")];
       },
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages: [],
       mode: "stream",
       remoteToolSources: [],
@@ -320,7 +320,7 @@ describe("agent/runtime-step", () => {
       } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
       getAvailableTools: async () => [],
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages: [],
       mode: "stream",
       remoteToolSources: undefined,
@@ -342,7 +342,7 @@ describe("agent/runtime-step", () => {
     assertEquals(prepared.toolContext.__vfSourceIntegrationPolicy, sourceIntegrationPolicy);
   });
 
-  it("uses the canonical deferred exposure contract for local models", async () => {
+  it("does not load tools for runtimes that declare tool calling unsupported", async () => {
     const prepared = await prepareAgentRuntimeStep({
       agentId: "agent_1",
       activeSkillPolicy: undefined,
@@ -350,7 +350,7 @@ describe("agent/runtime-step", () => {
       allowedRemoteToolNames: undefined,
       config: { model: "local/test", system: "Local", tools: true } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
-      isLocalModel: true,
+      supportsToolCalling: false,
       messages: [],
       mode: "stream",
       remoteToolSources: [],
@@ -359,13 +359,44 @@ describe("agent/runtime-step", () => {
       systemPrompt: "Local",
       toolContextBase: undefined,
       getAvailableTools: async () => {
-        throw new Error("local model should not load tools");
+        throw new Error("tool-incompatible runtime should not load tools");
       },
       resolveRuntimeState: async () => ({ systemPrompt: "Local", context: undefined }),
     });
 
     assertEquals(prepared.tools.map((tool) => tool.name), []);
     assertEquals(prepared.toolContext, {});
+  });
+
+  it("loads tools for server-local runtimes that declare tool calling support", async () => {
+    let loaded = false;
+    const prepared = await prepareAgentRuntimeStep({
+      agentId: "agent_1",
+      activeSkillPolicy: undefined,
+      activeSkillToolAvailability: undefined,
+      allowedRemoteToolNames: undefined,
+      config: { model: "local/test", system: "Local", tools: true } as AgentConfig,
+      forwardedRemoteToolDefinitions: undefined,
+      supportsToolCalling: true,
+      messages: [],
+      mode: "stream",
+      remoteToolSources: [],
+      runtimeContext: undefined,
+      step: 0,
+      systemPrompt: "Local",
+      toolContextBase: undefined,
+      getAvailableTools: async () => {
+        loaded = true;
+        return [toolDefinition("local_lookup")];
+      },
+      resolveRuntimeState: async () => ({ systemPrompt: "Local", context: undefined }),
+    });
+
+    assertEquals(loaded, true);
+    assertEquals(
+      prepared.toolExposurePlan.authorized.map((tool) => tool.name),
+      ["local_lookup"],
+    );
   });
 
   it("hides intake tools but keeps delegation tools after submitted form input", async () => {
@@ -394,7 +425,7 @@ describe("agent/runtime-step", () => {
         __vfToolLoadingMode: "eager",
       } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages,
       mode: "stream",
       remoteToolSources: [],
@@ -489,7 +520,7 @@ describe("agent/runtime-step", () => {
         __vfToolLoadingMode: "eager",
       } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages: [],
       mode: "stream",
       remoteToolSources: [],
@@ -551,7 +582,7 @@ describe("agent/runtime-step", () => {
         __vfToolLoadingMode: "eager",
       } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages,
       mode: "stream",
       remoteToolSources: [],
@@ -593,7 +624,7 @@ describe("agent/runtime-step", () => {
         __vfToolLoadingMode: "eager",
       } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages: [],
       mode: "stream",
       remoteToolSources: [],
@@ -634,7 +665,7 @@ describe("agent/runtime-step", () => {
         __vfToolLoadingMode: "eager",
       } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages: [],
       mode: "stream",
       remoteToolSources: [],

--- a/src/agent/runtime/agent-runtime-step.test.ts
+++ b/src/agent/runtime/agent-runtime-step.test.ts
@@ -479,7 +479,7 @@ describe("agent/runtime-step", () => {
         __vfToolLoadingMode: "eager",
       } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
-      isLocalModel: false,
+      supportsToolCalling: true,
       messages,
       mode: "stream",
       remoteToolSources: [],

--- a/src/agent/runtime/agent-runtime-step.ts
+++ b/src/agent/runtime/agent-runtime-step.ts
@@ -64,7 +64,7 @@ export interface PrepareAgentRuntimeStepInput {
   excludedToolNames?: ReadonlySet<string>;
   forwardedRemoteToolDefinitions: ToolDefinition[] | undefined;
   getAvailableTools: RuntimeStepToolLoader;
-  isLocalModel: boolean;
+  supportsToolCalling: boolean;
   messages: Message[];
   mode: AgentRuntimeStepMode;
   providerToolNames?: readonly string[];
@@ -131,16 +131,18 @@ export async function prepareAgentRuntimeStep(
     toolContext.activeSkillToolAvailability = input.activeSkillToolAvailability;
   }
 
-  let tools = input.isLocalModel ? [] : await input.getAvailableTools(input.config.tools, {
-    callerAgentId: input.agentId,
-    includeSkillTools: shouldIncludeSkillTools(input.config),
-    allowedRemoteToolNames: input.allowedRemoteToolNames,
-    forwardedRemoteToolDefinitions: input.forwardedRemoteToolDefinitions,
-    remoteToolSources: input.remoteToolSources,
-    remoteToolContext: toolContext,
-    sourceIntegrationPolicy: input.sourceIntegrationPolicy,
-    strictConfiguredToolsOnly: input.strictConfiguredToolsOnly,
-  });
+  let tools = input.supportsToolCalling
+    ? await input.getAvailableTools(input.config.tools, {
+      callerAgentId: input.agentId,
+      includeSkillTools: shouldIncludeSkillTools(input.config),
+      allowedRemoteToolNames: input.allowedRemoteToolNames,
+      forwardedRemoteToolDefinitions: input.forwardedRemoteToolDefinitions,
+      remoteToolSources: input.remoteToolSources,
+      remoteToolContext: toolContext,
+      sourceIntegrationPolicy: input.sourceIntegrationPolicy,
+      strictConfiguredToolsOnly: input.strictConfiguredToolsOnly,
+    })
+    : [];
 
   if (input.activeSkillPolicy || input.activeSkillToolAvailability) {
     tools = filterToolsForSkill(

--- a/src/agent/runtime/builtin-skill-files.test.ts
+++ b/src/agent/runtime/builtin-skill-files.test.ts
@@ -40,6 +40,10 @@ async function withTempDirAsync(fn: (dir: string) => Promise<void>): Promise<voi
   }
 }
 
+function assertDoesNotExposePath(error: Error, rootDir: string): void {
+  assertEquals(error.message.includes(rootDir), false);
+}
+
 Deno.test("resolveRuntimeBuiltinSkillsDir resolves repo-root skills from dist-like paths", () => {
   withTempDir((rootDir) => {
     const baseDir = resolve(rootDir, "dist", "src", "skills");
@@ -252,17 +256,17 @@ Deno.test("runtime builtin skill reads enforce the shared text-file budget", () 
       largeContent,
     );
 
-    assertThrows(
+    const directoryError = assertThrows(
       () => readRuntimeBuiltinDirectorySkill(rootDir, "directory-skill"),
       RangeError,
       `exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
     );
-    assertThrows(
+    const flatError = assertThrows(
       () => readRuntimeBuiltinFlatSkill(rootDir, "flat-skill"),
       RangeError,
       `exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
     );
-    assertThrows(
+    const referenceError = assertThrows(
       () =>
         readRuntimeBuiltinSkillReferenceFile(
           rootDir,
@@ -272,6 +276,9 @@ Deno.test("runtime builtin skill reads enforce the shared text-file budget", () 
       RangeError,
       `exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
     );
+    for (const error of [directoryError, flatError, referenceError]) {
+      assertDoesNotExposePath(error, rootDir);
+    }
   });
 });
 
@@ -279,11 +286,12 @@ Deno.test("runtime builtin skill reads reject malformed UTF-8", () => {
   withTempDir((rootDir) => {
     Deno.writeFileSync(resolve(rootDir, "writer.md"), new Uint8Array([0xc3, 0x28]));
 
-    assertThrows(
+    const error = assertThrows(
       () => readRuntimeBuiltinFlatSkill(rootDir, "writer"),
       TypeError,
       "must contain valid UTF-8",
     );
+    assertDoesNotExposePath(error, rootDir);
   });
 });
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -55,7 +55,10 @@ import { repairToolCall } from "./repair-tool-call.ts";
 import { MiddlewareChain } from "../middleware/chain.ts";
 import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import type { ToolExecutionContext } from "#veryfront/tool";
-import { isLocalModelRuntime } from "#veryfront/provider/runtime-inspection.ts";
+import {
+  isLocalModelRuntime,
+  supportsModelRuntimeToolCalling,
+} from "#veryfront/provider/runtime-inspection.ts";
 import { generateText, streamText } from "#veryfront/runtime/runtime-bridge.ts";
 import {
   captureStreamedToolCallInput,
@@ -656,12 +659,10 @@ function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
 
-function warnLocalToolSkipping(agentId: string, modelId: string): void {
+function warnUnsupportedToolCalling(agentId: string, modelId: string): void {
   logger.warn(
-    `Agent "${agentId}" has tools configured but is using local model "${modelId}". ` +
-      "Local models don't support tool calling. Tools will be skipped. " +
-      "Set VERYFRONT_API_TOKEN and VERYFRONT_PROJECT_SLUG, or configure " +
-      "OPENAI_API_KEY, ANTHROPIC_API_KEY, or GOOGLE_API_KEY for full tool support.",
+    `Agent "${agentId}" has tools configured, but model "${modelId}" declares that ` +
+      "it does not support tool calling. Tools will be skipped.",
   );
 }
 
@@ -799,6 +800,7 @@ export class AgentRuntime {
     const transport = await this.resolveModelTransport(context, modelOverride, "generate");
     const requestedModel = transport.requestedModel;
     const resolvedModelString = transport.resolvedModelString;
+    const supportsToolCalling = supportsModelRuntimeToolCalling(transport.languageModel);
     debugRuntimeModelRemap(requestedModel, resolvedModelString);
 
     return withSpan("agent.generate", async (span) => {
@@ -832,6 +834,7 @@ export class AgentRuntime {
               projectId: tryGetCacheKeyContext()?.projectId,
             },
             context,
+            supportsToolCalling,
             resolvedModelString,
             transport.languageModel,
             transport.headers,
@@ -904,6 +907,7 @@ export class AgentRuntime {
 
     // Determine inference mode from the resolved model object, not the string.
     const isLocal = isLocalModelRuntime(languageModel);
+    const supportsToolCalling = supportsModelRuntimeToolCalling(languageModel);
 
     // Eagerly verify the model runtime is available. For local models this
     // checks that @huggingface/transformers can be imported. Must happen
@@ -958,6 +962,7 @@ export class AgentRuntime {
                 textPartId,
                 toolContext,
                 context,
+                supportsToolCalling,
                 resolvedModelString,
                 languageModel,
                 transport.headers,
@@ -1021,8 +1026,9 @@ export class AgentRuntime {
   private async executeAgentLoop(
     systemPrompt: string,
     messages: Message[],
-    toolContextBase?: ToolExecutionContext,
-    runtimeContext?: Record<string, unknown>,
+    toolContextBase: ToolExecutionContext | undefined,
+    runtimeContext: Record<string, unknown> | undefined,
+    supportsToolCalling: boolean,
     modelString?: string,
     resolvedModel?: ModelRuntime,
     headers?: HeadersInit,
@@ -1043,10 +1049,8 @@ export class AgentRuntime {
       const currentMessages = [...messages];
       const totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
 
-      // Local models can't reliably do function calling, so skip tools gracefully.
-      const isLocal = isLocalModelRuntime(languageModel);
-      if (isLocal && this.config.tools) {
-        warnLocalToolSkipping(this.id, effectiveModel);
+      if (!supportsToolCalling && this.config.tools) {
+        warnUnsupportedToolCalling(this.id, effectiveModel);
       }
 
       // Request-scoped skill policy (not class-level mutable state)
@@ -1141,7 +1145,7 @@ export class AgentRuntime {
             : undefined,
           forwardedRemoteToolDefinitions,
           getAvailableTools,
-          isLocalModel: isLocal,
+          supportsToolCalling,
           messages: currentMessages,
           mode: "generate",
           providerToolNames: agentWriteFinalResponseToolGuardEnabled ? [] : providerTools,
@@ -1653,14 +1657,15 @@ export class AgentRuntime {
     messages: Message[],
     controller: ReadableStreamDefaultController,
     encoder: TextEncoder,
-    callbacks?: {
+    callbacks: {
       onToolCall?: (toolCall: ToolCall) => void;
       onChunk?: (chunk: string) => void;
       onFinish?: (response: AgentResponse) => void;
-    },
-    textPartId?: string,
-    toolContextBase?: Record<string, unknown>,
-    runtimeContext?: Record<string, unknown>,
+    } | undefined,
+    textPartId: string | undefined,
+    toolContextBase: Record<string, unknown> | undefined,
+    runtimeContext: Record<string, unknown> | undefined,
+    supportsToolCalling: boolean,
     modelString?: string,
     resolvedModel?: ModelRuntime,
     headers?: HeadersInit,
@@ -1679,10 +1684,8 @@ export class AgentRuntime {
     const currentMessages = [...messages];
     const totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
 
-    // Local models can't reliably do function calling, so skip tools gracefully.
-    const isLocalStreaming = isLocalModelRuntime(languageModel);
-    if (isLocalStreaming && this.config.tools) {
-      warnLocalToolSkipping(this.id, effectiveModel);
+    if (!supportsToolCalling && this.config.tools) {
+      warnUnsupportedToolCalling(this.id, effectiveModel);
     }
 
     // Request-scoped skill policy (not class-level mutable state)
@@ -1750,7 +1753,7 @@ export class AgentRuntime {
           : undefined,
         forwardedRemoteToolDefinitions,
         getAvailableTools,
-        isLocalModel: isLocalStreaming,
+        supportsToolCalling,
         messages: currentMessages,
         mode: "stream",
         providerToolNames: agentWriteFinalResponseToolGuardEnabled ? [] : providerTools,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1148,7 +1148,9 @@ export class AgentRuntime {
           supportsToolCalling,
           messages: currentMessages,
           mode: "generate",
-          providerToolNames: agentWriteFinalResponseToolGuardEnabled ? [] : providerTools,
+          providerToolNames: supportsToolCalling && !agentWriteFinalResponseToolGuardEnabled
+            ? providerTools
+            : [],
           remoteToolSources,
           sourceIntegrationPolicy,
           resolveRuntimeState: this.resolveRuntimeState.bind(this),
@@ -1176,7 +1178,9 @@ export class AgentRuntime {
           "tool.catalog.deferred_count": preparedStep.toolExposurePlan.deferred.length,
           "tool.loading.path": "framework-fallback",
         });
-        const stepProviderTools = agentWriteFinalResponseToolGuardEnabled ? [] : providerTools;
+        const stepProviderTools = supportsToolCalling && !agentWriteFinalResponseToolGuardEnabled
+          ? providerTools
+          : [];
 
         const temperature = this.resolveTemperature(
           temperatureModelString ?? effectiveModel,
@@ -1756,7 +1760,9 @@ export class AgentRuntime {
         supportsToolCalling,
         messages: currentMessages,
         mode: "stream",
-        providerToolNames: agentWriteFinalResponseToolGuardEnabled ? [] : providerTools,
+        providerToolNames: supportsToolCalling && !agentWriteFinalResponseToolGuardEnabled
+          ? providerTools
+          : [],
         remoteToolSources,
         sourceIntegrationPolicy,
         resolveRuntimeState: this.resolveRuntimeState.bind(this),
@@ -1782,7 +1788,9 @@ export class AgentRuntime {
         "tool.catalog.deferred_count": preparedStep.toolExposurePlan.deferred.length,
         "tool.loading.path": "framework-fallback",
       });
-      const stepProviderTools = agentWriteFinalResponseToolGuardEnabled ? [] : providerTools;
+      const stepProviderTools = supportsToolCalling && !agentWriteFinalResponseToolGuardEnabled
+        ? providerTools
+        : [];
 
       const runtimeTools = convertToolsToRuntimeTools(tools, {
         model: effectiveModel,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -661,8 +661,8 @@ function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
 
 function warnUnsupportedToolCalling(agentId: string, modelId: string): void {
   logger.warn(
-    `Agent "${agentId}" has tools configured, but model "${modelId}" declares that ` +
-      "it does not support tool calling. Tools will be skipped.",
+    `Agent "${agentId}" has tools configured, but model "${modelId}" does not support ` +
+      "tool calling. Tools will be skipped.",
   );
 }
 

--- a/src/agent/runtime/load-tools-tool.test.ts
+++ b/src/agent/runtime/load-tools-tool.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
 import { createLoadToolsTool, type LoadToolsToolOptions } from "./load-tools-tool.ts";
@@ -254,7 +254,9 @@ describe("load_tools tool", () => {
       await tool.execute({ names: ["overflow_tool"] });
 
       assertEquals(rejected.length, 1);
-      assertEquals(rejected[0].names, ["overflow_tool"]);
+      const [rejection] = rejected;
+      assertExists(rejection);
+      assertEquals(rejection.names, ["overflow_tool"]);
     });
   });
 

--- a/src/agent/runtime/project-files-client.test.ts
+++ b/src/agent/runtime/project-files-client.test.ts
@@ -38,6 +38,7 @@ const TEST_MAX_TOTAL_PAGES = 200;
 const TEST_MAX_OPERATION_TIMEOUT_MS = 300_000;
 const TEST_MAX_PATH_CHARACTERS = 4_096;
 const TEST_MAX_ERROR_BODY_BYTES = 64 * 1_024;
+const TEST_MAX_ERROR_MESSAGE_CHARACTERS = 4_096;
 const TEST_PUBLIC_LISTING_MAX_PAGES = 50;
 
 function createUnboundedTestListingBudget() {
@@ -955,6 +956,30 @@ Deno.test("strict runtime project files client snapshots configuration and rejec
   assertEquals(overrideFetchCalls, 0);
 });
 
+Deno.test("strict runtime project files client preserves and validates per-call timeouts", async () => {
+  let fetchCalls = 0;
+  const client = createStrictRuntimeProjectFilesClient({
+    apiUrl: baseOptions.apiUrl,
+    timeoutMs: 1_000,
+    fetch: () => {
+      fetchCalls += 1;
+      return Promise.resolve(jsonResponse({ path: "src/index.ts", content: "unused" }));
+    },
+  });
+
+  await assertRejects(
+    () =>
+      client.getProjectFile({
+        ...baseOptions,
+        path: "src/index.ts",
+        timeoutMs: 0,
+      }),
+    RangeError,
+    "timeoutMs",
+  );
+  assertEquals(fetchCalls, 0);
+});
+
 Deno.test("getStrictRuntimeProjectFile reports upstream and network errors", async () => {
   const upstreamFetch = mockFetchResponses(textResponse("Internal Server Error", 500));
   const upstreamError = await assertRejects(() =>
@@ -1066,6 +1091,23 @@ Deno.test("getStrictRuntimeProjectFile bounds upstream error bodies", async () =
     `Project files API error response exceeds ${TEST_MAX_ERROR_BODY_BYTES} bytes`,
   );
   assertEquals(getErrorMessage(error).length < TEST_MAX_ERROR_BODY_BYTES, true);
+});
+
+Deno.test("getStrictRuntimeProjectFile bounds error messages from failed body reads", async () => {
+  const bodyReadError = new Error("x".repeat(TEST_MAX_ERROR_MESSAGE_CHARACTERS * 2));
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: mockFetchResponses(erroringResponse(bodyReadError, 500)),
+      path: "src/index.ts",
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "...[truncated]");
+  assertEquals(
+    getErrorMessage(error).length < TEST_MAX_ERROR_MESSAGE_CHARACTERS + 256,
+    true,
+  );
 });
 
 Deno.test("getStrictRuntimeProjectFile passes project, path, branch, fields, and auth through REST", async () => {

--- a/src/agent/runtime/project-files-client.test.ts
+++ b/src/agent/runtime/project-files-client.test.ts
@@ -4,14 +4,25 @@ import {
   assertInstanceOf,
   assertRejects,
   assertStringIncludes,
+  assertThrows,
 } from "#veryfront/testing/assert.ts";
+import { SKILL_TEXT_FILE_MAX_BYTES } from "#veryfront/skill/limits.ts";
 import {
   createRuntimeProjectFileListingBudget,
   createRuntimeProjectFilesClient,
+  createStrictRuntimeProjectFilesClient,
   getRuntimeProjectFile,
+  getRuntimeProjectFileListItemSchema,
   getRuntimeProjectFiles,
+  getRuntimeProjectFileSchema,
+  getStrictRuntimeProjectFile,
+  getStrictRuntimeProjectFileListItemSchema,
+  getStrictRuntimeProjectFiles,
+  getStrictRuntimeProjectFileSchema,
+  type RuntimeGetProjectFileOptions,
+  runtimeProjectFileListItemSchema,
   RuntimeProjectFilesApiAuthError,
-  type RuntimeProjectFilesClientOptions,
+  runtimeProjectFileSchema,
   type RuntimeProjectFilesFetch,
 } from "./project-files-client.ts";
 
@@ -21,10 +32,39 @@ const baseOptions = {
   authToken: "token-1",
 };
 
+const TEST_MAX_PAGE_LIMIT = 100;
+const TEST_MAX_TOTAL_FILES = 10_000;
+const TEST_MAX_TOTAL_PAGES = 200;
+const TEST_MAX_OPERATION_TIMEOUT_MS = 300_000;
+const TEST_MAX_PATH_CHARACTERS = 4_096;
+const TEST_MAX_ERROR_BODY_BYTES = 64 * 1_024;
+const TEST_PUBLIC_LISTING_MAX_PAGES = 50;
+
+function createUnboundedTestListingBudget() {
+  return {
+    consumePage() {},
+    consumeBytes(_byteCount: number) {},
+  };
+}
+
 type FetchCall = {
   url: string;
   init: RequestInit;
 };
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -37,22 +77,40 @@ function textResponse(body: string, status: number): Response {
   return new Response(body, { status });
 }
 
-function chunkedJsonResponse(body: unknown, chunkBytes: number): Response {
-  const bytes = new TextEncoder().encode(JSON.stringify(body));
-  let offset = 0;
+function erroringResponse(error: unknown, status = 200): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(error);
+      },
+    }),
+    { status },
+  );
+}
+
+function streamResponse(
+  chunks: readonly Uint8Array[],
+  init: ResponseInit = {},
+  hooks: { onPull?: () => void; onCancel?: () => void } = {},
+): Response {
+  let index = 0;
   return new Response(
     new ReadableStream<Uint8Array>({
       pull(controller) {
-        if (offset >= bytes.byteLength) {
+        hooks.onPull?.();
+        const chunk = chunks[index];
+        index += 1;
+        if (chunk) {
+          controller.enqueue(chunk);
+        } else {
           controller.close();
-          return;
         }
-        const end = Math.min(offset + chunkBytes, bytes.byteLength);
-        controller.enqueue(bytes.slice(offset, end));
-        offset = end;
+      },
+      cancel() {
+        hooks.onCancel?.();
       },
     }),
-    { headers: { "Content-Type": "application/json" } },
+    init,
   );
 }
 
@@ -91,13 +149,391 @@ function getErrorMessage(error: unknown): string {
   throw new Error("Expected Error");
 }
 
-Deno.test("getRuntimeProjectFile returns a project file from the API file route", async () => {
+Deno.test("legacy runtime project file schemas preserve permissive string paths", () => {
+  const legacyPaths = [
+    "",
+    "../secret.md",
+    "/absolute.md",
+    "skills\\writer\\SKILL.md",
+    "skills//writer/SKILL.md",
+    "control\u0000path",
+    String.fromCharCode(0xd800),
+    "x".repeat(TEST_MAX_PATH_CHARACTERS + 1),
+  ];
+
+  for (const path of legacyPaths) {
+    for (const schema of [getRuntimeProjectFileSchema(), runtimeProjectFileSchema]) {
+      assertEquals(schema.safeParse({ path, content: "Body" }).success, true);
+    }
+    for (
+      const schema of [
+        getRuntimeProjectFileListItemSchema(),
+        runtimeProjectFileListItemSchema,
+      ]
+    ) {
+      assertEquals(schema.safeParse({ path }).success, true);
+    }
+
+    assertEquals(
+      getStrictRuntimeProjectFileSchema().safeParse({ path, content: "Body" }).success,
+      false,
+    );
+    assertEquals(
+      getStrictRuntimeProjectFileListItemSchema().safeParse({ path }).success,
+      false,
+    );
+  }
+
+  const oversizedContent = "x".repeat(SKILL_TEXT_FILE_MAX_BYTES + 1);
+  assertEquals(
+    getRuntimeProjectFileSchema().safeParse({ path: "safe.md", content: oversizedContent }).success,
+    true,
+  );
+  assertEquals(
+    getStrictRuntimeProjectFileSchema().safeParse({
+      path: "safe.md",
+      content: oversizedContent,
+    }).success,
+    true,
+  );
+});
+
+Deno.test("runtime project files client snapshots transport and rejects call-site overrides", async () => {
+  const initialFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "initial" }),
+  );
+  const mutatedFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "mutated" }),
+  );
+  const mutableOptions: {
+    apiUrl: URL;
+    fetch: RuntimeProjectFilesFetch;
+  } = {
+    apiUrl: new URL("https://initial.example.com/v1"),
+    fetch: initialFetch,
+  };
+  const mutableClient = createRuntimeProjectFilesClient(mutableOptions);
+  mutableOptions.apiUrl.hostname = "mutated.example.com";
+  mutableOptions.fetch = mutatedFetch;
+
+  const initialResult = await mutableClient.getProjectFile({
+    projectId: "project-1",
+    authToken: "token-1",
+    path: "src/index.ts",
+  });
+  assertEquals(initialResult?.content, "initial");
+  assertEquals(initialFetch.calls.length, 1);
+  assertEquals(getRequestedUrl(initialFetch).origin, "https://initial.example.com");
+  assertEquals(mutatedFetch.calls.length, 0);
+
+  const configuredFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "configured" }),
+  );
+  const overrideFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "override" }),
+  );
+  const configuredClient = createRuntimeProjectFilesClient({
+    apiUrl: "https://configured.example.com",
+    fetch: configuredFetch,
+  });
+  const overrideResult = await configuredClient.getProjectFile({
+    projectId: "project-1",
+    authToken: "token-1",
+    path: "src/index.ts",
+    apiUrl: "https://override.example.com",
+    fetch: overrideFetch,
+  } as RuntimeGetProjectFileOptions);
+
+  assertEquals(overrideResult?.content, "configured");
+  assertEquals(getRequestedUrl(configuredFetch).origin, "https://configured.example.com");
+  assertEquals(overrideFetch.calls.length, 0);
+});
+
+Deno.test("legacy runtime project file validation remains inside the trace callback", async () => {
+  let legacyTraceCalls = 0;
+  const legacyResult = await getRuntimeProjectFile({
+    apiUrl: "not a URL",
+    projectId: "..",
+    authToken: "",
+    path: "../unsafe.md",
+    trace: async <T>(_name: string, _fn: () => Promise<T>): Promise<T> => {
+      legacyTraceCalls += 1;
+      return { path: "/trace-result.md", content: "legacy" } as T;
+    },
+  });
+  assertEquals(legacyTraceCalls, 1);
+  assertEquals(legacyResult, { path: "/trace-result.md", content: "legacy" });
+
+  let strictTraceCalls = 0;
+  await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      apiUrl: "not a URL",
+      projectId: "..",
+      authToken: "",
+      path: "../unsafe.md",
+      trace: async <T>(_name: string, fn: () => Promise<T>): Promise<T> => {
+        strictTraceCalls += 1;
+        return await fn();
+      },
+    })
+  );
+  assertEquals(strictTraceCalls, 0);
+});
+
+Deno.test("legacy getRuntimeProjectFile returns mismatched paths and oversized content", async () => {
+  const content = "x".repeat(SKILL_TEXT_FILE_MAX_BYTES + 1);
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "/different.md", content }),
+  );
+
+  const result = await getRuntimeProjectFile({
+    apiUrl: "https://api.test",
+    projectId: "project/one",
+    authToken: "",
+    branchId: "",
+    path: "../requested.md",
+    fetch: fetchSpy,
+  });
+
+  assertEquals(result, { path: "/different.md", content });
+  assertEquals(
+    getRequestedUrl(fetchSpy).pathname,
+    "/projects/project%2Fone/files/..%2Frequested.md",
+  );
+  assertEquals(getRequestedUrl(fetchSpy).searchParams.has("branch"), false);
+});
+
+Deno.test("getRuntimeProjectFile enforces its public content and transport bounds", async () => {
+  const contentError = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      path: "src/index.ts",
+      maximumContentCharacters: 10,
+      fetch: mockFetchResponses(
+        jsonResponse({ path: "src/index.ts", content: "x".repeat(11) }),
+      ),
+    })
+  );
+  assertStringIncludes(getErrorMessage(contentError), "at most 10 characters");
+
+  const oversizedBody = new TextEncoder().encode(
+    JSON.stringify({ path: "src/index.ts", content: "x".repeat(70_000) }),
+  );
+  const transportError = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      path: "src/index.ts",
+      maximumContentCharacters: 10,
+      fetch: mockFetchResponses(
+        streamResponse([oversizedBody]),
+      ),
+    })
+  );
+  assertStringIncludes(getErrorMessage(transportError), "response may contain at most");
+});
+
+Deno.test("getRuntimeProjectFiles rejects a repeated pagination cursor", async () => {
+  const firstPage = Array.from(
+    { length: TEST_MAX_PAGE_LIMIT + 1 },
+    (_, index) => ({ path: index === 0 ? "../unsafe.md" : `file-${index}.ts` }),
+  );
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ data: firstPage, page_info: { next: "repeat" } }),
+    jsonResponse({ data: [{ path: "/second.md" }], page_info: { next: "repeat" } }),
+  );
+
+  const error = await assertRejects(() =>
+    getRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      pageLimit: 10,
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "repeated pagination cursor");
+  assertEquals(fetchSpy.calls.length, 2);
+  assertEquals(getRequestedUrl(fetchSpy, 1).searchParams.get("cursor"), "repeat");
+});
+
+Deno.test("getRuntimeProjectFiles bounds every page and aggregate pagination", async () => {
+  const oversizedPageError = await assertRejects(() =>
+    getRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: mockFetchResponses(
+        streamResponse([new Uint8Array(3_000_000)]),
+      ),
+    })
+  );
+  assertStringIncludes(getErrorMessage(oversizedPageError), "response may contain at most");
+
+  const pageResponses = Array.from({ length: 50 }, (_, index) =>
+    jsonResponse({
+      data: [],
+      page_info: { next: `cursor-${index + 1}` },
+    }));
+  const fetchSpy = mockFetchResponses(...pageResponses);
+  const pageLimitError = await assertRejects(() =>
+    getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy })
+  );
+  assertStringIncludes(getErrorMessage(pageLimitError), "at most 50 pages");
+  assertEquals(fetchSpy.calls.length, 50);
+});
+
+Deno.test("legacy project file response and error body handling remains observable", async () => {
+  const malformedFetch = mockFetchResponses(new Response("{", { status: 200 }));
+  await assertRejects(
+    () =>
+      getRuntimeProjectFile({
+        ...baseOptions,
+        fetch: malformedFetch,
+        path: "src/index.ts",
+      }),
+    SyntaxError,
+  );
+
+  const detail = `start-${"x".repeat(TEST_MAX_ERROR_BODY_BYTES)}-end`;
+  const errorFetch = mockFetchResponses(jsonResponse({ detail }, 500));
+  const error = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      fetch: errorFetch,
+      path: "src/index.ts",
+    })
+  );
+  assertStringIncludes(getErrorMessage(error), detail);
+  assertEquals(getErrorMessage(error).includes("[truncated]"), false);
+
+  let cancelled = false;
+  const notFoundFetch = mockFetchResponses(
+    streamResponse([new TextEncoder().encode("not found")], { status: 404 }, {
+      onCancel: () => {
+        cancelled = true;
+      },
+    }),
+  );
+  assertEquals(
+    await getRuntimeProjectFile({
+      ...baseOptions,
+      fetch: notFoundFetch,
+      path: "missing.ts",
+    }),
+    null,
+  );
+  await Promise.resolve();
+  assertEquals(cancelled, false);
+});
+
+Deno.test("legacy project file calls preserve normal REST, auth, and response shaping", async () => {
+  const fileFetch = mockFetchResponses(
+    jsonResponse({
+      path: "src/index.ts",
+      content: "hello",
+      type: "file",
+      size: 5,
+    }),
+  );
+  assertEquals(
+    await getRuntimeProjectFile({
+      ...baseOptions,
+      branchId: "branch-1",
+      fetch: fileFetch,
+      path: "src/index.ts",
+    }),
+    { path: "src/index.ts", content: "hello" },
+  );
+  const fileUrl = getRequestedUrl(fileFetch);
+  assertEquals(fileUrl.pathname, "/projects/project-1/files/src%2Findex.ts");
+  assertEquals(fileUrl.searchParams.get("branch"), "branch-1");
+  assertEquals(fileUrl.searchParams.get("fields"), "(path,content)");
+  assertEquals(
+    new Headers(getFetchCall(fileFetch).init.headers).get("Authorization"),
+    "Bearer token-1",
+  );
+
+  const listFetch = mockFetchResponses(
+    jsonResponse({
+      data: [{ path: "src/index.ts", type: "file", size: 5 }],
+      page_info: { next: null },
+    }),
+  );
+  assertEquals(
+    await getRuntimeProjectFiles({
+      ...baseOptions,
+      branchId: "branch-1",
+      pathPrefix: "skills/catalog",
+      fetch: listFetch,
+    }),
+    [{ path: "src/index.ts" }],
+  );
+  const listUrl = getRequestedUrl(listFetch);
+  assertEquals(listUrl.pathname, "/projects/project-1/files");
+  assertEquals(listUrl.searchParams.get("branch"), "branch-1");
+  assertEquals(listUrl.searchParams.get("path"), "skills/catalog");
+  assertEquals(listUrl.searchParams.get("fields"), "(path)");
+  assertEquals(listUrl.searchParams.get("limit"), "100");
+  assertEquals(
+    new Headers(getFetchCall(listFetch).init.headers).get("Authorization"),
+    "Bearer token-1",
+  );
+});
+
+Deno.test("legacy project file calls preserve auth and custom error identities", async () => {
+  for (const status of [401, 403]) {
+    const error = await assertRejects(() =>
+      getRuntimeProjectFile({
+        ...baseOptions,
+        fetch: mockFetchResponses(textResponse("denied", status)),
+        path: "src/index.ts",
+      })
+    );
+    assertInstanceOf(error, RuntimeProjectFilesApiAuthError);
+    assertEquals((error as RuntimeProjectFilesApiAuthError).statusCode, status);
+  }
+
+  const customError = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      createAccessDeniedError: (statusCode, message) =>
+        new Error(`custom:${statusCode}:${message}`),
+      fetch: mockFetchResponses(textResponse("denied", 403)),
+      path: "src/index.ts",
+    })
+  );
+  assertEquals(
+    getErrorMessage(customError),
+    "custom:403:Access denied to project files API",
+  );
+});
+
+Deno.test("legacy project file calls preserve upstream and network failures", async () => {
+  const upstreamError = await assertRejects(() =>
+    getRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: mockFetchResponses(textResponse("Project not found", 404)),
+    })
+  );
+  assertStringIncludes(getErrorMessage(upstreamError), "Project not found");
+
+  const networkError = new Error("ECONNREFUSED");
+  const thrown = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      fetch: async () => {
+        throw networkError;
+      },
+      path: "src/index.ts",
+    })
+  );
+  assertEquals(thrown, networkError);
+});
+
+Deno.test("getStrictRuntimeProjectFile returns a project file from the API file route", async () => {
   const fileData = { path: "src/index.ts", content: "hello" };
   const fetchSpy = mockFetchResponses(
     jsonResponse({ ...fileData, type: "file", size: 5, checksum: null }),
   );
 
-  const result = await getRuntimeProjectFile({
+  const result = await getStrictRuntimeProjectFile({
     ...baseOptions,
     fetch: fetchSpy,
     path: "src/index.ts",
@@ -106,47 +542,254 @@ Deno.test("getRuntimeProjectFile returns a project file from the API file route"
   assertEquals(result, fileData);
 });
 
-Deno.test("createRuntimeProjectFilesClient keeps its configured transport immutable", async () => {
-  const trustedFetch = mockFetchResponses(
-    jsonResponse({ data: [], page_info: { next: null } }),
+Deno.test("getStrictRuntimeProjectFile validates well-formed UTF-16 paths before URL encoding", async () => {
+  let fetchCalls = 0;
+  const fetchMock: RuntimeProjectFilesFetch = async () => {
+    fetchCalls += 1;
+    return jsonResponse({ path: "unused", content: "unused" });
+  };
+
+  for (
+    const malformedPath of [
+      String.fromCharCode(0xd800),
+      String.fromCharCode(0xdc00),
+    ]
+  ) {
+    const error = await assertRejects(() =>
+      getStrictRuntimeProjectFile({
+        ...baseOptions,
+        fetch: fetchMock,
+        path: malformedPath,
+      })
+    );
+    assertInstanceOf(error, RangeError);
+    assertStringIncludes(getErrorMessage(error), "well-formed UTF-16");
+  }
+
+  assertEquals(fetchCalls, 0);
+
+  const validPath = "skills/\u{1f600}/SKILL.md";
+  const validFetch = mockFetchResponses(
+    jsonResponse({ path: validPath, content: "valid" }),
   );
-  let untrustedFetchCalls = 0;
-  const untrustedFetch: RuntimeProjectFilesFetch = () => {
-    untrustedFetchCalls += 1;
-    return Promise.resolve(jsonResponse({ data: [], page_info: { next: null } }));
-  };
-  const configuredUrl = new URL("https://api.test");
-  const clientOptions: RuntimeProjectFilesClientOptions = {
-    apiUrl: configuredUrl,
-    fetch: trustedFetch,
-    pageLimit: 25,
-  };
-  const client = createRuntimeProjectFilesClient(clientOptions);
-
-  configuredUrl.hostname = "mutated.test";
-  clientOptions.fetch = untrustedFetch;
-  clientOptions.pageLimit = 1;
-
-  await client.getProjectFiles({
-    projectId: "project-1",
-    authToken: "token-1",
-    ...({
-      apiUrl: "https://untrusted.test",
-      fetch: untrustedFetch,
-      pageLimit: 1,
-    } as object),
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: validFetch,
+    path: validPath,
   });
-
-  const url = getRequestedUrl(trustedFetch);
-  assertEquals(url.origin, "https://api.test");
-  assertEquals(url.searchParams.get("limit"), "25");
-  assertEquals(untrustedFetchCalls, 0);
+  assertEquals(result?.path, validPath);
 });
 
-Deno.test("getRuntimeProjectFile returns null when the API file route returns 404", async () => {
+Deno.test("getStrictRuntimeProjectFile rejects non-canonical project paths before URL encoding", async () => {
+  let fetchCalls = 0;
+  const fetchMock: RuntimeProjectFilesFetch = async () => {
+    fetchCalls += 1;
+    return jsonResponse({ path: "unused", content: "unused" });
+  };
+
+  for (
+    const path of [
+      "../secret.md",
+      "/absolute.md",
+      "skills\\writer\\SKILL.md",
+      "skills//writer/SKILL.md",
+      "skills/./writer/SKILL.md",
+      `skills/${"x".repeat(256)}/SKILL.md`,
+    ]
+  ) {
+    await assertRejects(
+      () =>
+        getStrictRuntimeProjectFile({
+          ...baseOptions,
+          fetch: fetchMock,
+          path,
+        }),
+      RangeError,
+      "canonical",
+    );
+  }
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects ill-formed UTF-16 response paths", async () => {
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: String.fromCharCode(0xd800), content: "invalid" }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/requested/SKILL.md",
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "invalid API response");
+  assertEquals(getErrorMessage(error).includes("response path did not match"), false);
+});
+
+Deno.test("getStrictRuntimeProjectFile accepts content at the byte limit", async () => {
+  const content = "x".repeat(SKILL_TEXT_FILE_MAX_BYTES);
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "skills/large/SKILL.md", content }),
+  );
+
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "skills/large/SKILL.md",
+  });
+
+  assertEquals(result?.content.length, SKILL_TEXT_FILE_MAX_BYTES);
+});
+
+Deno.test("getStrictRuntimeProjectFile allows bounded worst-case JSON escaping overhead", async () => {
+  const content = "\0".repeat(SKILL_TEXT_FILE_MAX_BYTES);
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "skills/escaped/SKILL.md", content }),
+  );
+
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "skills/escaped/SKILL.md",
+  });
+
+  assertEquals(result?.content.length, SKILL_TEXT_FILE_MAX_BYTES);
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects content over the byte limit", async () => {
+  const content = "€".repeat(Math.floor(SKILL_TEXT_FILE_MAX_BYTES / 3) + 1);
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "skills/large/SKILL.md", content }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/large/SKILL.md",
+    })
+  );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `content exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
+  );
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects chunked responses over the transport limit", async () => {
+  const oversizedChunk = new Uint8Array(SKILL_TEXT_FILE_MAX_BYTES * 7);
+  let sentChunk = false;
+  let cancelled = false;
+  const fetchSpy = mockFetchResponses(
+    new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (!sentChunk) {
+            sentChunk = true;
+            controller.enqueue(oversizedChunk);
+          }
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    ),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/large/SKILL.md",
+    })
+  );
+
+  await Promise.resolve();
+  assertStringIncludes(getErrorMessage(error), "Project file response exceeds");
+  assertEquals(cancelled, true);
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects oversized Content-Length before reading", async () => {
+  let pullCount = 0;
+  let cancelled = false;
+  const fetchSpy = mockFetchResponses(
+    streamResponse([new TextEncoder().encode("{}")], {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(SKILL_TEXT_FILE_MAX_BYTES * 7),
+      },
+    }, {
+      onPull: () => {
+        pullCount += 1;
+      },
+      onCancel: () => {
+        cancelled = true;
+      },
+    }),
+  );
+  await Promise.resolve();
+  const pullCountBeforeRequest = pullCount;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/large/SKILL.md",
+    })
+  );
+  await Promise.resolve();
+
+  assertStringIncludes(getErrorMessage(error), "Project file response exceeds");
+  assertEquals(pullCount, pullCountBeforeRequest);
+  assertEquals(cancelled, true);
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects invalid UTF-8", async () => {
+  const fetchSpy = mockFetchResponses(
+    streamResponse([new Uint8Array([0xc3, 0x28])], {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/invalid/SKILL.md",
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "was not valid UTF-8");
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects a response path that differs from the request", async () => {
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "skills/other/SKILL.md", content: "Body" }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/requested/SKILL.md",
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "response path did not match the request");
+});
+
+Deno.test("getStrictRuntimeProjectFile returns null when the API file route returns 404", async () => {
   const fetchSpy = mockFetchResponses(textResponse("File not found", 404));
 
-  const result = await getRuntimeProjectFile({
+  const result = await getStrictRuntimeProjectFile({
     ...baseOptions,
     fetch: fetchSpy,
     path: "missing.ts",
@@ -155,25 +798,25 @@ Deno.test("getRuntimeProjectFile returns null when the API file route returns 40
   assertEquals(result, null);
 });
 
-Deno.test("getRuntimeProjectFile throws auth errors for API HTTP 401 and 403", async () => {
+Deno.test("getStrictRuntimeProjectFile throws auth errors for API HTTP 401 and 403", async () => {
   const unauthorizedFetch = mockFetchResponses(textResponse("Unauthorized", 401));
   const unauthorizedError = await assertRejects(() =>
-    getRuntimeProjectFile({ ...baseOptions, fetch: unauthorizedFetch, path: "src/index.ts" })
+    getStrictRuntimeProjectFile({ ...baseOptions, fetch: unauthorizedFetch, path: "src/index.ts" })
   );
   assertInstanceOf(unauthorizedError, RuntimeProjectFilesApiAuthError);
 
   const forbiddenFetch = mockFetchResponses(textResponse("Forbidden", 403));
   const forbiddenError = await assertRejects(() =>
-    getRuntimeProjectFile({ ...baseOptions, fetch: forbiddenFetch, path: "src/index.ts" })
+    getStrictRuntimeProjectFile({ ...baseOptions, fetch: forbiddenFetch, path: "src/index.ts" })
   );
   assertInstanceOf(forbiddenError, RuntimeProjectFilesApiAuthError);
 });
 
-Deno.test("getRuntimeProjectFile supports a custom access-denied error factory", async () => {
+Deno.test("getStrictRuntimeProjectFile supports a custom access-denied error factory", async () => {
   const fetchSpy = mockFetchResponses(textResponse("Forbidden", 403));
 
   const error = await assertRejects(() =>
-    getRuntimeProjectFile({
+    getStrictRuntimeProjectFile({
       ...baseOptions,
       fetch: fetchSpy,
       path: "src/index.ts",
@@ -184,10 +827,138 @@ Deno.test("getRuntimeProjectFile supports a custom access-denied error factory",
   assertEquals(getErrorMessage(error), "403: Access denied to project files API");
 });
 
-Deno.test("getRuntimeProjectFile reports upstream and network errors", async () => {
+Deno.test("strict runtime project files client validates timeout and page-limit options", async () => {
+  assertThrows(
+    () =>
+      createStrictRuntimeProjectFilesClient({
+        apiUrl: baseOptions.apiUrl,
+        operationTimeoutMs: 0,
+      }),
+    RangeError,
+    "operationTimeoutMs",
+  );
+  assertThrows(
+    () =>
+      createStrictRuntimeProjectFilesClient({
+        apiUrl: baseOptions.apiUrl,
+        operationTimeoutMs: TEST_MAX_OPERATION_TIMEOUT_MS + 1,
+      }),
+    RangeError,
+    "operationTimeoutMs",
+  );
+  assertThrows(
+    () =>
+      createStrictRuntimeProjectFilesClient({
+        apiUrl: baseOptions.apiUrl,
+        timeoutMs: 0,
+      }),
+    RangeError,
+    "timeoutMs",
+  );
+  assertThrows(
+    () =>
+      createStrictRuntimeProjectFilesClient({
+        apiUrl: baseOptions.apiUrl,
+        pageLimit: TEST_MAX_PAGE_LIMIT + 1,
+      }),
+    RangeError,
+    "pageLimit",
+  );
+
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "hello" }),
+  );
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "src/index.ts",
+    // Pagination is irrelevant to the direct file route.
+    pageLimit: TEST_MAX_PAGE_LIMIT + 1,
+  });
+  assertEquals(result?.content, "hello");
+});
+
+Deno.test("strict runtime project files reject unsafe transport identity and URL fields", async () => {
+  let fetchCalls = 0;
+  const fetchMock: RuntimeProjectFilesFetch = async () => {
+    fetchCalls += 1;
+    return jsonResponse({ path: "src/index.ts", content: "unused" });
+  };
+
+  for (
+    const options of [
+      { projectId: String.fromCharCode(0xd800), authToken: "token-1" },
+      { projectId: "..", authToken: "token-1" },
+      { projectId: "project/one", authToken: "token-1" },
+      { projectId: "project-1\nforged", authToken: "token-1" },
+      { projectId: "project-1", authToken: "token-1\nforged" },
+      {
+        projectId: "project-1",
+        authToken: "token-1",
+        branchId: String.fromCharCode(0xdc00),
+      },
+    ]
+  ) {
+    await assertRejects(
+      () =>
+        getStrictRuntimeProjectFile({
+          apiUrl: baseOptions.apiUrl,
+          fetch: fetchMock,
+          path: "src/index.ts",
+          ...options,
+        }),
+      TypeError,
+    );
+  }
+  assertThrows(
+    () => createStrictRuntimeProjectFilesClient({ apiUrl: "file:///tmp/api" }),
+    TypeError,
+    "HTTP(S)",
+  );
+  assertThrows(
+    () => createStrictRuntimeProjectFilesClient({ apiUrl: "https://user:pass@example.com" }),
+    TypeError,
+    "credentials",
+  );
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("strict runtime project files client snapshots configuration and rejects call-site overrides", async () => {
+  const configuredFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "configured" }),
+  );
+  let overrideFetchCalls = 0;
+  const mutableOptions: {
+    apiUrl: URL;
+    fetch: RuntimeProjectFilesFetch;
+  } = {
+    apiUrl: new URL("https://api.example.com/v1"),
+    fetch: configuredFetch,
+  };
+  const client = createStrictRuntimeProjectFilesClient(mutableOptions);
+
+  mutableOptions.apiUrl.hostname = "mutated.example.com";
+  mutableOptions.fetch = async () => {
+    overrideFetchCalls += 1;
+    return jsonResponse({ path: "src/index.ts", content: "mutated" });
+  };
+
+  const result = await client.getProjectFile({
+    ...baseOptions,
+    path: "src/index.ts",
+    apiUrl: "https://override.example.com",
+    fetch: mutableOptions.fetch,
+  } as RuntimeGetProjectFileOptions);
+
+  assertEquals(result?.content, "configured");
+  assertEquals(getRequestedUrl(configuredFetch).origin, "https://api.example.com");
+  assertEquals(overrideFetchCalls, 0);
+});
+
+Deno.test("getStrictRuntimeProjectFile reports upstream and network errors", async () => {
   const upstreamFetch = mockFetchResponses(textResponse("Internal Server Error", 500));
   const upstreamError = await assertRejects(() =>
-    getRuntimeProjectFile({ ...baseOptions, fetch: upstreamFetch, path: "src/index.ts" })
+    getStrictRuntimeProjectFile({ ...baseOptions, fetch: upstreamFetch, path: "src/index.ts" })
   );
   assertStringIncludes(
     getErrorMessage(upstreamError),
@@ -198,93 +969,109 @@ Deno.test("getRuntimeProjectFile reports upstream and network errors", async () 
     throw new Error("ECONNREFUSED");
   };
   const networkError = await assertRejects(() =>
-    getRuntimeProjectFile({ ...baseOptions, fetch: networkFetch, path: "src/index.ts" })
+    getStrictRuntimeProjectFile({ ...baseOptions, fetch: networkFetch, path: "src/index.ts" })
   );
   assertStringIncludes(getErrorMessage(networkError), "ECONNREFUSED");
 });
 
-Deno.test("getRuntimeProjectFile bounds the response before parsing skill content", async () => {
-  const oversized = "x".repeat(70_000);
-  const fetchSpy = mockFetchResponses(
-    jsonResponse({ path: "skills/large/SKILL.md", content: oversized }),
+Deno.test("strict runtime project files preserve timeout identity across request phases", async () => {
+  const fetchTimeout = new DOMException("fetch timeout", "TimeoutError");
+  const fetchError = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: async () => {
+        throw fetchTimeout;
+      },
+      path: "src/index.ts",
+    })
   );
+  assertEquals(fetchError === fetchTimeout, true);
 
-  await assertRejects(
-    () =>
-      getRuntimeProjectFile({
-        ...baseOptions,
-        fetch: fetchSpy,
-        path: "skills/large/SKILL.md",
-        maximumContentCharacters: 1,
-      }),
-    RangeError,
-    "response may contain at most",
+  const fileBodyTimeout = new DOMException("file body timeout", "TimeoutError");
+  const fileBodyError = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: mockFetchResponses(erroringResponse(fileBodyTimeout)),
+      path: "src/index.ts",
+    })
   );
+  assertEquals(fileBodyError === fileBodyTimeout, true);
+
+  const listBodyTimeout = new DOMException("list body timeout", "TimeoutError");
+  const listBodyError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: mockFetchResponses(erroringResponse(listBodyTimeout)),
+    })
+  );
+  assertEquals(listBodyError === listBodyTimeout, true);
+
+  const timeoutCause = new DOMException("error body timeout", "TimeoutError");
+  const wrappedTimeout = new Error("response body read failed", { cause: timeoutCause });
+  const errorBodyError = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: mockFetchResponses(erroringResponse(wrappedTimeout, 500)),
+      path: "src/index.ts",
+    })
+  );
+  assertEquals(errorBodyError === wrappedTimeout, true);
+  assertEquals((errorBodyError as Error).cause === timeoutCause, true);
 });
 
-Deno.test("getRuntimeProjectFile parses heavily fragmented bounded responses", async () => {
-  const fileData = { path: "skills/example/SKILL.md", content: "x".repeat(1_024) };
-  const fetchSpy = mockFetchResponses(chunkedJsonResponse(fileData, 1));
+Deno.test("strict project file requests enforce monotonic timeouts around synchronous fetch work", async () => {
+  const responseCancelled = createDeferred<void>();
+  const response = streamResponse(
+    [new TextEncoder().encode('{"path":"src/index.ts","content":"ok"}')],
+    {},
+    { onCancel: () => responseCancelled.resolve() },
+  );
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 1,
+      fetch: async () => {
+        const busyUntil = performance.now() + 20;
+        while (performance.now() < busyUntil) {
+          // Deliberately block timer delivery to verify the monotonic check.
+        }
+        return response;
+      },
+      path: "src/index.ts",
+    })
+  );
 
-  assertEquals(
-    await getRuntimeProjectFile({
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "request timed out");
+  await responseCancelled.promise;
+});
+
+Deno.test("getStrictRuntimeProjectFile bounds upstream error bodies", async () => {
+  const oversizedError = new Uint8Array(TEST_MAX_ERROR_BODY_BYTES + 1);
+  oversizedError.fill("x".charCodeAt(0));
+  const fetchSpy = mockFetchResponses(
+    streamResponse([oversizedError], { status: 500 }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
       ...baseOptions,
       fetch: fetchSpy,
-      path: fileData.path,
-      maximumContentCharacters: 2_048,
-    }),
-    fileData,
+      path: "src/index.ts",
+    })
   );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `Project files API error response exceeds ${TEST_MAX_ERROR_BODY_BYTES} bytes`,
+  );
+  assertEquals(getErrorMessage(error).length < TEST_MAX_ERROR_BODY_BYTES, true);
 });
 
-Deno.test("getRuntimeProjectFiles rejects and cancels a response stream that makes no progress", async () => {
-  let cancelled = false;
-  const response = new Response(
-    new ReadableStream<Uint8Array>({
-      pull(controller) {
-        controller.enqueue(new Uint8Array());
-      },
-      cancel() {
-        cancelled = true;
-      },
-    }),
-  );
-
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: mockFetchResponses(response) }),
-    RangeError,
-    "made no byte progress",
-  );
-  assertEquals(cancelled, true);
-});
-
-Deno.test("getRuntimeProjectFiles cancels a stalled response body when its timeout expires", async () => {
-  let cancelled = false;
-  const response = new Response(
-    new ReadableStream<Uint8Array>({
-      cancel() {
-        cancelled = true;
-      },
-    }),
-  );
-
-  await assertRejects(
-    () =>
-      getRuntimeProjectFiles({
-        ...baseOptions,
-        fetch: mockFetchResponses(response),
-        timeoutMs: 5,
-      }),
-    DOMException,
-    "timed out",
-  );
-  assertEquals(cancelled, true);
-});
-
-Deno.test("getRuntimeProjectFile passes project, path, branch, fields, and auth through REST", async () => {
+Deno.test("getStrictRuntimeProjectFile passes project, path, branch, fields, and auth through REST", async () => {
   const fetchSpy = mockFetchResponses(jsonResponse({ path: "src/index.ts", content: "hello" }));
 
-  await getRuntimeProjectFile({
+  await getStrictRuntimeProjectFile({
     ...baseOptions,
     fetch: fetchSpy,
     path: "src/index.ts",
@@ -302,7 +1089,20 @@ Deno.test("getRuntimeProjectFile passes project, path, branch, fields, and auth 
   );
 });
 
-Deno.test("getRuntimeProjectFiles returns project file paths from the API list route", async () => {
+Deno.test("getStrictRuntimeProjectFile preserves an empty branch as the default-branch alias", async () => {
+  const fetchSpy = mockFetchResponses(jsonResponse({ path: "src/index.ts", content: "hello" }));
+
+  await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "src/index.ts",
+    branchId: "",
+  });
+
+  assertEquals(getRequestedUrl(fetchSpy).searchParams.has("branch"), false);
+});
+
+Deno.test("getStrictRuntimeProjectFiles returns project file paths from the API list route", async () => {
   const files = [{ path: "src/index.ts" }];
   const fetchSpy = mockFetchResponses(
     jsonResponse({
@@ -317,27 +1117,12 @@ Deno.test("getRuntimeProjectFiles returns project file paths from the API list r
     }),
   );
 
-  const result = await getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
+  const result = await getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
 
   assertEquals(result, files);
 });
 
-Deno.test("getRuntimeProjectFiles rejects unsafe list prefixes before network access", async () => {
-  let calls = 0;
-  const fetchSpy: RuntimeProjectFilesFetch = () => {
-    calls += 1;
-    return Promise.resolve(jsonResponse({ data: [], page_info: { next: null } }));
-  };
-  for (const pathPrefix of ["../skills", "/skills", "skills/", "skills\\nested"]) {
-    await assertRejects(
-      () => getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy, pathPrefix }),
-      RangeError,
-    );
-  }
-  assertEquals(calls, 0);
-});
-
-Deno.test("getRuntimeProjectFiles follows API pagination until no next cursor remains", async () => {
+Deno.test("getStrictRuntimeProjectFiles follows API pagination until no next cursor remains", async () => {
   const fetchSpy = mockFetchResponses(
     jsonResponse({
       data: [{ path: "a.ts" }],
@@ -349,144 +1134,799 @@ Deno.test("getRuntimeProjectFiles follows API pagination until no next cursor re
     }),
   );
 
-  const result = await getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
+  const result = await getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
 
   assertEquals(result, [{ path: "a.ts" }, { path: "b.ts" }]);
   assertEquals(getRequestedUrl(fetchSpy, 1).searchParams.get("cursor"), "cursor-2");
 });
 
-Deno.test("getRuntimeProjectFiles rejects repeated cursors before another request", async () => {
-  const fetchSpy = mockFetchResponses(
-    jsonResponse({ data: [], page_info: { next: "same" } }),
-    jsonResponse({ data: [], page_info: { next: "same" } }),
+Deno.test("getStrictRuntimeProjectFiles cancels a late terminal response after its aggregate deadline", async () => {
+  const lateFetch = createDeferred<Response>();
+  const responseCancelled = createDeferred<void>();
+  let fetchCalls = 0;
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 1,
+      fetch: () => {
+        fetchCalls += 1;
+        return lateFetch.promise;
+      },
+    })
   );
 
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy }),
-    RangeError,
-    "repeated pagination cursor",
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
+  assertEquals(fetchCalls, 1);
+
+  lateFetch.resolve(
+    streamResponse(
+      [new TextEncoder().encode('{"data":[],"page_info":{"next":null}}')],
+      {},
+      { onCancel: () => responseCancelled.resolve() },
+    ),
   );
-  assertEquals(fetchSpy.calls.length, 2);
+  await responseCancelled.promise;
 });
 
-Deno.test("getRuntimeProjectFiles makes no post-timeout request when fetch ignores abort", async () => {
-  let calls = 0;
-  const fetchIgnoringAbort: RuntimeProjectFilesFetch = async () => {
-    calls += 1;
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    return jsonResponse({ data: [], page_info: { next: "another-page" } });
-  };
-
-  await assertRejects(
-    () =>
-      getRuntimeProjectFiles({
-        ...baseOptions,
-        fetch: fetchIgnoringAbort,
-        timeoutMs: 5,
-      }),
-    DOMException,
-    "timed out",
+Deno.test("getStrictRuntimeProjectFiles bounds a stalled terminal response body", async () => {
+  const responseCancelled = createDeferred<void>();
+  const body = new ReadableStream<Uint8Array>({
+    cancel() {
+      responseCancelled.resolve();
+      return new Promise(() => undefined);
+    },
+  });
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 1,
+      fetch: () => Promise.resolve(new Response(body)),
+    })
   );
-  assertEquals(calls, 1);
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
+  await responseCancelled.promise;
+  assertEquals(body.locked, false);
 });
 
-Deno.test("getRuntimeProjectFiles enforces response bytes cumulatively across related prefixes", async () => {
-  const listingBudget = createRuntimeProjectFileListingBudget();
-  const padding = "x".repeat(2_400_000);
-  for (let index = 0; index < 6; index += 1) {
-    const fetchSpy = mockFetchResponses(
-      jsonResponse({ data: [], page_info: { next: null }, padding }),
-    );
-    assertEquals(
-      await getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy, listingBudget }),
-      [],
-    );
-  }
-  const overBudgetFetch = mockFetchResponses(
-    jsonResponse({ data: [], page_info: { next: null }, padding }),
+Deno.test("getStrictRuntimeProjectFiles bounds a noncooperative trace wrapper", async () => {
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 1,
+      fetch: () => Promise.reject(new Error("trace must not invoke the request")),
+      trace: () => new Promise(() => undefined),
+    })
   );
-  await assertRejects(
-    () =>
-      getRuntimeProjectFiles({
-        ...baseOptions,
-        fetch: overBudgetFetch,
-        listingBudget,
-      }),
-    RangeError,
-    "responses may contain at most",
-  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
 });
 
-Deno.test("getRuntimeProjectFiles stops pagination before retaining an oversized listing", async () => {
+Deno.test("strict listing trace rejection aborts an operation the trace already started", async () => {
+  const traceError = new Error("listing trace export failed");
+  const fetchStarted = createDeferred<void>();
+  let fetchSignal: AbortSignal | undefined;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 100,
+      fetch: (_url, init) => {
+        fetchSignal = init.signal as AbortSignal;
+        fetchStarted.resolve();
+        return new Promise(() => undefined);
+      },
+      trace: async <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        void operation();
+        await fetchStarted.promise;
+        throw traceError;
+      },
+    })
+  );
+
+  assertEquals(error, traceError);
+  assertEquals(fetchSignal?.aborted, true);
+  assertEquals(fetchSignal?.reason, traceError);
+});
+
+Deno.test("getStrictRuntimeProjectFiles enforces its deadline after trace post-processing", async () => {
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 10,
+      fetch: () => Promise.resolve(jsonResponse({ data: [], page_info: { next: null } })),
+      trace: async <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        const result = await operation();
+        const busyUntil = performance.now() + 50;
+        while (performance.now() < busyUntil) {
+          // Deliberately starve timer delivery after the traced work resolves.
+        }
+        return result;
+      },
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
+});
+
+Deno.test("expired aggregate deadlines do not launch fetches after trace pre-processing", async () => {
+  let fetchCalls = 0;
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 5,
+      fetch: () => {
+        fetchCalls += 1;
+        return Promise.resolve(jsonResponse({ data: [], page_info: { next: null } }));
+      },
+      trace: async <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        const busyUntil = performance.now() + 30;
+        while (performance.now() < busyUntil) {
+          // Deliberately starve timer delivery before invoking traced work.
+        }
+        return await operation();
+      },
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("pre-aborted project file listings do not invoke custom trace wrappers", async () => {
+  const controller = new AbortController();
+  const cancellation = { kind: "listing-cancelled" };
+  controller.abort(cancellation);
+  let traceCalls = 0;
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      signal: controller.signal,
+      fetch: () => Promise.reject(new Error("fetch must not run")),
+      trace: () => {
+        traceCalls += 1;
+        throw new Error("sync trace failure");
+      },
+    })
+  );
+
+  assertEquals(error === cancellation, true);
+  assertEquals(traceCalls, 0);
+});
+
+Deno.test("getStrictRuntimeProjectFile bounds a noncooperative trace wrapper", async () => {
+  let fetchCalls = 0;
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 1,
+      fetch: () => {
+        fetchCalls += 1;
+        return Promise.resolve(jsonResponse({ path: "src/index.ts", content: "unused" }));
+      },
+      path: "src/index.ts",
+      trace: () => new Promise(() => undefined),
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "request timed out");
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("strict trace rejection aborts an operation the trace already started", async () => {
+  const traceError = new Error("trace export failed");
+  const fetchStarted = createDeferred<void>();
+  let fetchSignal: AbortSignal | undefined;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 100,
+      fetch: (_url, init) => {
+        fetchSignal = init.signal as AbortSignal;
+        fetchStarted.resolve();
+        return new Promise(() => undefined);
+      },
+      path: "src/index.ts",
+      trace: async <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        void operation();
+        await fetchStarted.promise;
+        throw traceError;
+      },
+    })
+  );
+
+  assertEquals(error, traceError);
+  assertEquals(fetchSignal?.aborted, true);
+  assertEquals(fetchSignal?.reason, traceError);
+});
+
+Deno.test("strict trace success cannot fabricate a result ahead of its operation", async () => {
+  let fetchSignal: AbortSignal | undefined;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 5,
+      fetch: (_url, init) => {
+        fetchSignal = init.signal as AbortSignal;
+        return new Promise(() => undefined);
+      },
+      path: "src/index.ts",
+      trace: <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        void operation();
+        return Promise.resolve(null as T);
+      },
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "request timed out");
+  assertEquals(fetchSignal?.aborted, true);
+});
+
+Deno.test("strict trace returns the validated operation result instead of its own value", async () => {
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: () =>
+      Promise.resolve(
+        jsonResponse({ path: "src/index.ts", content: "validated" }),
+      ),
+    path: "src/index.ts",
+    trace: <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+      void operation();
+      return Promise.resolve(null as T);
+    },
+  });
+
+  assertEquals(result, { path: "src/index.ts", content: "validated" });
+});
+
+Deno.test("strict trace re-entry cannot launch the operation twice", async () => {
+  let invokeOperation: (() => Promise<unknown>) | undefined;
+  let fetchCalls = 0;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: () => {
+        fetchCalls += 1;
+        if (fetchCalls === 1) {
+          void invokeOperation?.();
+        }
+        return Promise.resolve(
+          jsonResponse({ path: "src/index.ts", content: "validated" }),
+        );
+      },
+      path: "src/index.ts",
+      trace: <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        invokeOperation = operation as () => Promise<unknown>;
+        return operation();
+      },
+    })
+  );
+
+  assertEquals(error instanceof TypeError, true);
+  assertStringIncludes(getErrorMessage(error), "exactly once");
+  assertEquals(fetchCalls, 1);
+});
+
+Deno.test("strict request aborts work started by a noncooperative trace wrapper", async () => {
+  let fetchSignal: AbortSignal | undefined;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 5,
+      fetch: (_url, init) => {
+        fetchSignal = init.signal as AbortSignal;
+        return new Promise(() => undefined);
+      },
+      path: "src/index.ts",
+      trace: <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        void operation();
+        return new Promise(() => undefined);
+      },
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "request timed out");
+  assertEquals(fetchSignal?.aborted, true);
+});
+
+Deno.test("strict project file requests propagate in-flight caller cancellation exactly", async () => {
+  const controller = new AbortController();
+  const cancellation = new DOMException("caller stopped in flight", "AbortError");
+  const fetchStarted = createDeferred<void>();
+  const observedSignals: AbortSignal[] = [];
+
+  const request = getStrictRuntimeProjectFile({
+    ...baseOptions,
+    signal: controller.signal,
+    fetch: (_url, init) => {
+      observedSignals.push(init.signal as AbortSignal);
+      fetchStarted.resolve();
+      return new Promise(() => undefined);
+    },
+    path: "src/index.ts",
+  });
+
+  await fetchStarted.promise;
+  controller.abort(cancellation);
+  const error = await assertRejects(() => request);
+
+  assertEquals(error, cancellation);
+  assertEquals(observedSignals[0]?.aborted, true);
+  assertEquals(observedSignals[0]?.reason, cancellation);
+});
+
+Deno.test("strict project error-body reads preserve arbitrary caller cancellation reasons", async () => {
+  const controller = new AbortController();
+  const cancellation = { kind: "caller-disconnected" };
+  const bodyReadStarted = createDeferred<void>();
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      pull() {
+        bodyReadStarted.resolve();
+      },
+    }),
+    { status: 500 },
+  );
+  const request = getStrictRuntimeProjectFile({
+    ...baseOptions,
+    signal: controller.signal,
+    fetch: () => Promise.resolve(response),
+    path: "src/index.ts",
+  });
+
+  await bodyReadStarted.promise;
+  controller.abort(cancellation);
+  const error = await assertRejects(() => request);
+
+  assertEquals(error === cancellation, true);
+  assertEquals(response.body?.locked, false);
+});
+
+Deno.test("successful strict project file calls dispose cancellation listeners and timers", async () => {
+  const controller = new AbortController();
+  const callerSignal = controller.signal;
+  const originalAddEventListener = callerSignal.addEventListener;
+  const originalRemoveEventListener = callerSignal.removeEventListener;
+  let abortListenerAdds = 0;
+  let abortListenerRemovals = 0;
+  Object.defineProperty(callerSignal, "addEventListener", {
+    configurable: true,
+    value(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ) {
+      if (type === "abort") abortListenerAdds += 1;
+      Reflect.apply(originalAddEventListener, callerSignal, [type, listener, options]);
+    },
+  });
+  Object.defineProperty(callerSignal, "removeEventListener", {
+    configurable: true,
+    value(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions,
+    ) {
+      if (type === "abort") abortListenerRemovals += 1;
+      Reflect.apply(originalRemoveEventListener, callerSignal, [type, listener, options]);
+    },
+  });
+  const observedSignals: AbortSignal[] = [];
+  const client = createStrictRuntimeProjectFilesClient({
+    apiUrl: baseOptions.apiUrl,
+    operationTimeoutMs: 10,
+    timeoutMs: 10,
+    fetch: (_url, init) => {
+      observedSignals.push(init.signal as AbortSignal);
+      return Promise.resolve(
+        jsonResponse({ data: [], page_info: { next: null } }),
+      );
+    },
+  });
+
+  assertEquals(
+    await client.getProjectFiles({
+      projectId: baseOptions.projectId,
+      authToken: baseOptions.authToken,
+      signal: callerSignal,
+    }),
+    [],
+  );
+
+  assertEquals(abortListenerAdds, 1);
+  assertEquals(abortListenerRemovals, 1);
+  controller.abort(new DOMException("late caller abort", "AbortError"));
+  assertEquals(observedSignals[0]?.aborted, false);
+});
+
+Deno.test("strict project file requests preserve caller cancellation identity", async () => {
+  const controller = new AbortController();
+  const cancellation = new DOMException("caller stopped", "AbortError");
+  controller.abort(cancellation);
+  let fetchCalls = 0;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      signal: controller.signal,
+      fetch: () => {
+        fetchCalls += 1;
+        throw new Error("sync custom fetch failure");
+      },
+      path: "src/index.ts",
+    })
+  );
+
+  assertEquals(error, cancellation);
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("getStrictRuntimeProjectFiles rejects repeated pagination cursors", async () => {
   const fetchSpy = mockFetchResponses(
     jsonResponse({
       data: [{ path: "a.ts" }],
-      page_info: { next: "cursor-2" },
+      page_info: { next: "cursor-repeat" },
     }),
     jsonResponse({
       data: [{ path: "b.ts" }],
-      page_info: { next: "cursor-3" },
+      page_info: { next: "cursor-repeat" },
     }),
   );
 
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy, maximumEntries: 1 }),
-    RangeError,
-    "may contain at most 1 entries",
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      listingBudget: createUnboundedTestListingBudget(),
+    })
   );
+
+  assertStringIncludes(getErrorMessage(error), "pagination returned a repeated cursor");
   assertEquals(fetchSpy.calls.length, 2);
 });
 
-Deno.test("getRuntimeProjectFiles bounds each page before parsing and rejects oversized paths", async () => {
+Deno.test("strict listings enforce a one-entry maximum before retention or another request", async () => {
   const oversizedPageFetch = mockFetchResponses(
     jsonResponse({
-      data: [{ path: "x".repeat(2_600_000) }],
+      data: [{ path: "first.ts" }, { path: "second.ts" }],
       page_info: { next: null },
     }),
   );
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: oversizedPageFetch }),
-    RangeError,
-    "response may contain at most",
+  const oversizedPageError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: oversizedPageFetch,
+      maximumEntries: 1,
+    })
+  );
+  assertStringIncludes(getErrorMessage(oversizedPageError), "requested 1 files");
+  assertEquals(oversizedPageFetch.calls.length, 1);
+
+  const continuedListingFetch = mockFetchResponses(
+    jsonResponse({
+      data: [{ path: "first.ts" }],
+      page_info: { next: "more" },
+    }),
+    jsonResponse({
+      data: [{ path: "second.ts" }],
+      page_info: { next: null },
+    }),
+  );
+  const continuedListingError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: continuedListingFetch,
+      maximumEntries: 1,
+    })
+  );
+  assertStringIncludes(getErrorMessage(continuedListingError), "file count exceeds 1");
+  assertEquals(continuedListingFetch.calls.length, 1);
+});
+
+Deno.test("strict listings exhaust a shared cross-prefix page budget before fetching", async () => {
+  const listingBudget = createRuntimeProjectFileListingBudget();
+  let fetchCalls = 0;
+  const fetch: RuntimeProjectFilesFetch = () => {
+    fetchCalls += 1;
+    return Promise.resolve(jsonResponse({ data: [{ path: "one.ts" }], page_info: { next: null } }));
+  };
+
+  for (let index = 0; index < TEST_PUBLIC_LISTING_MAX_PAGES; index += 1) {
+    const files = await getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch,
+      listingBudget,
+      maximumEntries: 1,
+      pathPrefix: `skills/prefix-${index}`,
+    });
+    assertEquals(files, [{ path: "one.ts" }]);
+  }
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch,
+      listingBudget,
+      maximumEntries: 1,
+      pathPrefix: "skills/exhausted",
+    })
+  );
+  assertStringIncludes(getErrorMessage(error), `${TEST_PUBLIC_LISTING_MAX_PAGES} pages`);
+  assertEquals(fetchCalls, TEST_PUBLIC_LISTING_MAX_PAGES);
+});
+
+Deno.test("strict listings charge response bytes to the shared budget before retaining them", async () => {
+  let consumedPages = 0;
+  let consumedBytes = 0;
+  const listingBudget = {
+    consumePage() {
+      consumedPages += 1;
+    },
+    consumeBytes(byteCount: number) {
+      consumedBytes += byteCount;
+      throw new RangeError("shared byte budget exhausted");
+    },
+  };
+  const body = new TextEncoder().encode(
+    JSON.stringify({ data: [{ path: "one.ts" }], page_info: { next: null } }),
   );
 
-  const oversizedPathFetch = mockFetchResponses(
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      listingBudget,
+      fetch: () =>
+        Promise.resolve(
+          streamResponse([body]),
+        ),
+      maximumEntries: 1,
+    })
+  );
+  assertStringIncludes(getErrorMessage(error), "shared byte budget exhausted");
+  assertEquals(consumedPages, 1);
+  assertEquals(consumedBytes, body.byteLength);
+});
+
+Deno.test("getStrictRuntimeProjectFiles rejects pages over the item budget", async () => {
+  const fetchSpy = mockFetchResponses(
     jsonResponse({
-      data: [{ path: "x".repeat(4_097) }],
+      data: Array.from(
+        { length: TEST_MAX_PAGE_LIMIT + 1 },
+        (_, index) => ({ path: `file-${index}.ts` }),
+      ),
       page_info: { next: null },
     }),
   );
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: oversizedPathFetch }),
-    RangeError,
-    "paths may contain at most 4096 characters",
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      listingBudget: createUnboundedTestListingBudget(),
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "invalid API response");
+});
+
+Deno.test("getStrictRuntimeProjectFiles enforces the requested page limit", async () => {
+  const requestedPageLimit = 10;
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({
+      data: Array.from(
+        { length: requestedPageLimit + 1 },
+        (_, index) => ({ path: `file-${index}.ts` }),
+      ),
+      page_info: { next: null },
+    }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      pageLimit: requestedPageLimit,
+    })
+  );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `page returned more than the requested ${requestedPageLimit} files`,
   );
 });
 
-Deno.test("getRuntimeProjectFiles throws auth errors for API HTTP 401 and 403", async () => {
+Deno.test("getStrictRuntimeProjectFiles rejects oversized paths", async () => {
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({
+      data: [{ path: "x".repeat(TEST_MAX_PATH_CHARACTERS + 1) }],
+      page_info: { next: null },
+    }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "invalid API response");
+});
+
+Deno.test("getStrictRuntimeProjectFiles rejects ill-formed UTF-16 paths and cursors", async () => {
+  const malformed = String.fromCharCode(0xd800);
+  const invalidPathFetch = mockFetchResponses(
+    jsonResponse({
+      data: [{ path: malformed }],
+      page_info: { next: null },
+    }),
+  );
+
+  const pathError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: invalidPathFetch })
+  );
+  assertStringIncludes(getErrorMessage(pathError), "invalid API response");
+
+  const invalidCursorFetch = mockFetchResponses(
+    jsonResponse({
+      data: [],
+      page_info: { next: malformed },
+    }),
+  );
+  const cursorError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: invalidCursorFetch })
+  );
+  assertStringIncludes(getErrorMessage(cursorError), "invalid API response");
+  assertEquals(invalidCursorFetch.calls.length, 1);
+});
+
+Deno.test("getStrictRuntimeProjectFiles rejects chunked list pages over the transport limit", async () => {
+  const oversizedChunk = new Uint8Array(SKILL_TEXT_FILE_MAX_BYTES * 3);
+  const fetchSpy = mockFetchResponses(
+    streamResponse([oversizedChunk], {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "Project files list response exceeds");
+});
+
+Deno.test("getStrictRuntimeProjectFiles caps aggregate file count", async () => {
+  const pageCount = TEST_MAX_TOTAL_FILES / TEST_MAX_PAGE_LIMIT + 1;
+  const responses = Array.from({ length: pageCount }, (_, pageIndex) =>
+    jsonResponse({
+      data: Array.from(
+        { length: TEST_MAX_PAGE_LIMIT },
+        (_, itemIndex) => ({
+          path: `page-${pageIndex}/file-${itemIndex}.ts`,
+        }),
+      ),
+      page_info: { next: `cursor-${pageIndex + 1}` },
+    }));
+  const fetchSpy = mockFetchResponses(...responses);
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      listingBudget: createUnboundedTestListingBudget(),
+    })
+  );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `file count exceeds ${TEST_MAX_TOTAL_FILES}`,
+  );
+  assertEquals(fetchSpy.calls.length, pageCount - 1);
+});
+
+Deno.test("getStrictRuntimeProjectFiles accepts exactly the aggregate file budget", async () => {
+  const pageCount = TEST_MAX_TOTAL_FILES / TEST_MAX_PAGE_LIMIT;
+  const responses = Array.from({ length: pageCount }, (_, pageIndex) =>
+    jsonResponse({
+      data: Array.from(
+        { length: TEST_MAX_PAGE_LIMIT },
+        (_, itemIndex) => ({
+          path: `page-${pageIndex}/file-${itemIndex}.ts`,
+        }),
+      ),
+      page_info: {
+        next: pageIndex + 1 < pageCount ? `cursor-${pageIndex + 1}` : null,
+      },
+    }));
+  const fetchSpy = mockFetchResponses(...responses);
+
+  const files = await getStrictRuntimeProjectFiles({
+    ...baseOptions,
+    fetch: fetchSpy,
+    listingBudget: createUnboundedTestListingBudget(),
+  });
+
+  assertEquals(files.length, TEST_MAX_TOTAL_FILES);
+  assertEquals(fetchSpy.calls.length, pageCount);
+});
+
+Deno.test("getStrictRuntimeProjectFiles caps pagination depth", async () => {
+  const responses = Array.from({ length: TEST_MAX_TOTAL_PAGES }, (_, pageIndex) =>
+    jsonResponse({
+      data: [],
+      page_info: { next: `cursor-${pageIndex + 1}` },
+    }));
+  const fetchSpy = mockFetchResponses(...responses);
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      listingBudget: createUnboundedTestListingBudget(),
+    })
+  );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `pagination exceeds ${TEST_MAX_TOTAL_PAGES} pages`,
+  );
+  assertEquals(fetchSpy.calls.length, TEST_MAX_TOTAL_PAGES);
+});
+
+Deno.test("getStrictRuntimeProjectFiles accepts exactly the pagination depth budget", async () => {
+  const responses = Array.from({ length: TEST_MAX_TOTAL_PAGES }, (_, pageIndex) =>
+    jsonResponse({
+      data: [],
+      page_info: {
+        next: pageIndex + 1 < TEST_MAX_TOTAL_PAGES ? `cursor-${pageIndex + 1}` : null,
+      },
+    }));
+  const fetchSpy = mockFetchResponses(...responses);
+
+  const files = await getStrictRuntimeProjectFiles({
+    ...baseOptions,
+    fetch: fetchSpy,
+    listingBudget: createUnboundedTestListingBudget(),
+  });
+
+  assertEquals(files, []);
+  assertEquals(fetchSpy.calls.length, TEST_MAX_TOTAL_PAGES);
+});
+
+Deno.test("getStrictRuntimeProjectFiles throws auth errors for API HTTP 401 and 403", async () => {
   const unauthorizedFetch = mockFetchResponses(textResponse("Unauthorized", 401));
   const unauthorizedError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: unauthorizedFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: unauthorizedFetch })
   );
   assertInstanceOf(unauthorizedError, RuntimeProjectFilesApiAuthError);
 
   const forbiddenFetch = mockFetchResponses(textResponse("Forbidden", 403));
   const forbiddenError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: forbiddenFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: forbiddenFetch })
   );
   assertInstanceOf(forbiddenError, RuntimeProjectFilesApiAuthError);
 });
 
-Deno.test("getRuntimeProjectFiles reports upstream and network errors", async () => {
+Deno.test("getStrictRuntimeProjectFiles reports upstream and network errors", async () => {
   const notFoundFetch = mockFetchResponses(textResponse("Project not found", 404));
   const notFoundError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: notFoundFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: notFoundFetch })
   );
   assertStringIncludes(getErrorMessage(notFoundError), "Project not found");
 
   const upstreamFetch = mockFetchResponses(textResponse("Internal Server Error", 500));
   const upstreamError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: upstreamFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: upstreamFetch })
   );
   assertStringIncludes(getErrorMessage(upstreamError), "Internal Server Error");
 
@@ -494,30 +1934,38 @@ Deno.test("getRuntimeProjectFiles reports upstream and network errors", async ()
     throw new Error("ECONNREFUSED");
   };
   const networkError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: networkFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: networkFetch })
   );
   assertStringIncludes(getErrorMessage(networkError), "ECONNREFUSED");
 });
 
-Deno.test("getRuntimeProjectFiles passes project, branch, path, fields, pagination limit, and auth through REST", async () => {
+Deno.test("getStrictRuntimeProjectFiles passes project, branch, prefix, fields, pagination limit, and auth through REST", async () => {
   const fetchSpy = mockFetchResponses(jsonResponse({ data: [], page_info: { next: null } }));
 
-  await getRuntimeProjectFiles({
+  await getStrictRuntimeProjectFiles({
     ...baseOptions,
     fetch: fetchSpy,
     branchId: "branch-1",
-    pathPrefix: "skills",
+    pathPrefix: "skills/research",
   });
 
   const url = getRequestedUrl(fetchSpy);
   assertEquals(url.origin, "https://api.test");
   assertEquals(url.pathname, "/projects/project-1/files");
   assertEquals(url.searchParams.get("branch"), "branch-1");
-  assertEquals(url.searchParams.get("path"), "skills");
+  assertEquals(url.searchParams.get("path"), "skills/research");
   assertEquals(url.searchParams.get("fields"), "(path)");
   assertEquals(url.searchParams.get("limit"), "100");
   assertEquals(
     new Headers(getFetchCall(fetchSpy).init.headers).get("Authorization"),
     "Bearer token-1",
   );
+});
+
+Deno.test("getStrictRuntimeProjectFiles preserves an empty branch as the default-branch alias", async () => {
+  const fetchSpy = mockFetchResponses(jsonResponse({ data: [], page_info: { next: null } }));
+
+  await getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy, branchId: "" });
+
+  assertEquals(getRequestedUrl(fetchSpy).searchParams.has("branch"), false);
 });

--- a/src/agent/runtime/project-files-client.test.ts
+++ b/src/agent/runtime/project-files-client.test.ts
@@ -1467,6 +1467,100 @@ Deno.test("strict project file requests propagate in-flight caller cancellation 
   assertEquals(observedSignals[0]?.reason, cancellation);
 });
 
+Deno.test("strict project files client composes public and internal caller cancellation", async () => {
+  const publicController = new AbortController();
+  const internalController = new AbortController();
+  const cancellation = new DOMException("public caller stopped in flight", "AbortError");
+  const fetchStarted = createDeferred<void>();
+  let fetchSignal: AbortSignal | undefined;
+  const client = createStrictRuntimeProjectFilesClient({
+    apiUrl: baseOptions.apiUrl,
+    operationTimeoutMs: 1_000,
+    timeoutMs: 1_000,
+    fetch: (_url, init) => {
+      fetchSignal = init.signal as AbortSignal;
+      fetchStarted.resolve();
+      return new Promise(() => undefined);
+    },
+  });
+
+  const request = client.getProjectFiles({
+    projectId: baseOptions.projectId,
+    authToken: baseOptions.authToken,
+    abortSignal: publicController.signal,
+    signal: internalController.signal,
+  });
+  await fetchStarted.promise;
+  assertEquals(fetchSignal === publicController.signal, false);
+  assertEquals(fetchSignal === internalController.signal, false);
+
+  publicController.abort(cancellation);
+  const error = await assertRejects(() => request);
+
+  assertEquals(error, cancellation);
+  assertEquals(fetchSignal?.aborted, true);
+  assertEquals(fetchSignal?.reason, cancellation);
+});
+
+Deno.test("strict project files client preserves pre-aborted internal cancellation when composed", async () => {
+  const publicController = new AbortController();
+  const internalController = new AbortController();
+  const cancellation = { kind: "internal-runtime-cancelled" };
+  internalController.abort(cancellation);
+  let fetchCalls = 0;
+  const client = createStrictRuntimeProjectFilesClient({
+    apiUrl: baseOptions.apiUrl,
+    fetch: () => {
+      fetchCalls += 1;
+      return Promise.reject(new Error("fetch must not run"));
+    },
+  });
+
+  const error = await assertRejects(() =>
+    client.getProjectFile({
+      projectId: baseOptions.projectId,
+      authToken: baseOptions.authToken,
+      abortSignal: publicController.signal,
+      signal: internalController.signal,
+      path: "src/index.ts",
+    })
+  );
+
+  assertEquals(error, cancellation);
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("strict project files client aborts a stalled file body from public cancellation", async () => {
+  const controller = new AbortController();
+  const cancellation = { kind: "skill-operation-cancelled" };
+  const bodyReadStarted = createDeferred<void>();
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      pull() {
+        bodyReadStarted.resolve();
+      },
+    }),
+  );
+  const client = createStrictRuntimeProjectFilesClient({
+    apiUrl: baseOptions.apiUrl,
+    timeoutMs: 1_000,
+    fetch: () => Promise.resolve(response),
+  });
+  const request = client.getProjectFile({
+    projectId: baseOptions.projectId,
+    authToken: baseOptions.authToken,
+    abortSignal: controller.signal,
+    path: "src/index.ts",
+  });
+
+  await bodyReadStarted.promise;
+  controller.abort(cancellation);
+  const error = await assertRejects(() => request);
+
+  assertEquals(error, cancellation);
+  assertEquals(response.body?.locked, false);
+});
+
 Deno.test("strict project error-body reads preserve arbitrary caller cancellation reasons", async () => {
   const controller = new AbortController();
   const cancellation = { kind: "caller-disconnected" };

--- a/src/agent/runtime/project-files-client.ts
+++ b/src/agent/runtime/project-files-client.ts
@@ -10,6 +10,13 @@ import {
   isUtf8WithinByteLimit,
   isWellFormedUtf16,
 } from "#veryfront/skill/string-safety.ts";
+import {
+  addAbortSignalListenerOnce,
+  getAbortSignalReason,
+  isAbortSignalAborted,
+  isAbortSignalWithoutHooks,
+  removeAbortSignalListener,
+} from "#veryfront/platform/compat/abort-signal.ts";
 
 const DEFAULT_PROJECT_FILES_TIMEOUT_MS = 15_000;
 const DEFAULT_PROJECT_FILES_PAGE_LIMIT = 100;
@@ -552,13 +559,13 @@ export async function getStrictRuntimeProjectFile(
     & StrictRuntimeProjectFilesRequestContext,
 ): Promise<RuntimeProjectFile | null> {
   validateRuntimeProjectFilesClientOptions(options, false);
-  validateStrictRuntimeProjectFilesRequestContext(options);
   validateRuntimeProjectFilesApiOptions(options);
   validateProjectFileRequestPath(options.path);
+  const callerScope = createStrictProjectFilesCallerSignalScope(options);
 
-  return runStrictProjectFilesRequest(
+  const request = runStrictProjectFilesRequest(
     options,
-    options.signal,
+    callerScope.signal,
     (requestScope) =>
       traceStrictProjectFilesRequest(options, "runtimeProjectFiles.getProjectFile", async () => {
         const url = createStrictRuntimeProjectFileUrl({
@@ -620,6 +627,7 @@ export async function getStrictRuntimeProjectFile(
         );
       }),
   );
+  return request.finally(callerScope.dispose);
 }
 
 /** Whether a runtime project file content value fits the shared Skill budget. */
@@ -746,8 +754,8 @@ export async function getStrictRuntimeProjectFiles(
     & StrictRuntimeProjectFilesRequestContext,
 ): Promise<RuntimeProjectFileListItem[]> {
   validateRuntimeProjectFilesClientOptions(options);
-  validateStrictRuntimeProjectFilesRequestContext(options);
   validateRuntimeProjectFilesApiOptions(options);
+  const callerScope = createStrictProjectFilesCallerSignalScope(options);
   const pageLimit = resolveProjectFilesPageLimit(options.pageLimit);
   const maximumEntries = Math.min(
     options.maximumEntries ?? MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS,
@@ -757,7 +765,7 @@ export async function getStrictRuntimeProjectFiles(
   const operationDeadline = performance.now() +
     resolveProjectFilesOperationTimeoutMs(options.operationTimeoutMs);
   const operationScope = createStrictProjectFilesOperationScope(
-    options.signal,
+    callerScope.signal,
     operationDeadline,
   );
 
@@ -898,6 +906,7 @@ export async function getStrictRuntimeProjectFiles(
     throw error;
   } finally {
     operationScope.dispose();
+    callerScope.dispose();
   }
 }
 
@@ -1253,6 +1262,11 @@ type StrictProjectFilesAbortScope = {
   dispose: () => void;
 };
 
+type StrictProjectFilesCallerSignalScope = {
+  signal: AbortSignal | undefined;
+  dispose: () => void;
+};
+
 type StrictProjectFilesRequestScope = StrictProjectFilesAbortScope & {
   deadline: number;
 };
@@ -1272,6 +1286,64 @@ function getStrictProjectFilesAbortReason(signal: AbortSignal): unknown {
   return signal.reason === undefined
     ? new DOMException("Project files request was aborted", "AbortError")
     : signal.reason;
+}
+
+function createStrictProjectFilesCallerSignalScope(
+  options: RuntimeProjectFilesApiOptions & StrictRuntimeProjectFilesRequestContext,
+): StrictProjectFilesCallerSignalScope {
+  validateStrictRuntimeProjectFilesRequestContext(options);
+  const publicSignal = options.abortSignal;
+  const internalSignal = options.signal;
+  if (publicSignal === undefined || publicSignal === internalSignal) {
+    return {
+      signal: internalSignal ?? publicSignal,
+      dispose: () => undefined,
+    };
+  }
+  if (internalSignal === undefined) {
+    return {
+      signal: publicSignal,
+      dispose: () => undefined,
+    };
+  }
+
+  const controller = new AbortController();
+  const listeners: Array<{ signal: AbortSignal; listener: () => void }> = [];
+  let disposed = false;
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    for (const entry of listeners) {
+      removeAbortSignalListener(entry.signal, entry.listener);
+    }
+    listeners.length = 0;
+  };
+  const attach = (source: AbortSignal) => {
+    if (isAbortSignalAborted(source)) {
+      if (!controller.signal.aborted) {
+        controller.abort(getAbortSignalReason(source));
+      }
+      dispose();
+      return;
+    }
+    const listener = () => {
+      if (!controller.signal.aborted) {
+        controller.abort(getAbortSignalReason(source));
+      }
+      dispose();
+    };
+    addAbortSignalListenerOnce(source, listener);
+    listeners.push({ signal: source, listener });
+    if (isAbortSignalAborted(source)) {
+      listener();
+    }
+  };
+
+  attach(publicSignal);
+  if (!controller.signal.aborted) {
+    attach(internalSignal);
+  }
+  return { signal: controller.signal, dispose };
 }
 
 function createStrictProjectFilesAbortScope(
@@ -1555,9 +1627,12 @@ function waitForStrictProjectFilesAbort<TResult>(
 }
 
 function validateStrictRuntimeProjectFilesRequestContext(
-  options: StrictRuntimeProjectFilesRequestContext,
+  options: RuntimeProjectFilesApiOptions & StrictRuntimeProjectFilesRequestContext,
 ): void {
-  if (options.signal !== undefined && !(options.signal instanceof AbortSignal)) {
+  if (options.abortSignal !== undefined && !isAbortSignalWithoutHooks(options.abortSignal)) {
+    throw new TypeError("abortSignal must be an AbortSignal");
+  }
+  if (options.signal !== undefined && !isAbortSignalWithoutHooks(options.signal)) {
     throw new TypeError("signal must be an AbortSignal");
   }
 }

--- a/src/agent/runtime/project-files-client.ts
+++ b/src/agent/runtime/project-files-client.ts
@@ -32,6 +32,9 @@ const MAX_PROJECT_FILES_CURSOR_CHARACTERS = 4_096;
 const MAX_PROJECT_FILES_PER_PAGE = MAX_PROJECT_FILES_PAGE_LIMIT;
 /** Maximum aggregate file records returned by one project listing. */
 export const MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS = 10_000;
+// Defense-in-depth for internal callers that supply a shared/custom listing
+// budget. The public default budget intentionally imposes the tighter 50-page
+// aggregate cap across all related listings.
 const MAX_PROJECT_FILES_TOTAL_PAGES = 200;
 const MAX_PROJECT_FILES_API_URL_CHARACTERS = 8_192;
 const MAX_PROJECT_FILES_IDENTIFIER_CHARACTERS = 256;
@@ -366,8 +369,34 @@ export function createStrictRuntimeProjectFilesClient(
 ): StrictRuntimeProjectFilesClient {
   const clientOptions = normalizeRuntimeProjectFilesClientOptions(options);
   return {
-    getProjectFile: (input) => getStrictRuntimeProjectFile({ ...input, ...clientOptions }),
-    getProjectFiles: (input) => getStrictRuntimeProjectFiles({ ...input, ...clientOptions }),
+    getProjectFile: (input) =>
+      getStrictRuntimeProjectFile({
+        ...clientOptions,
+        projectId: input.projectId,
+        authToken: input.authToken,
+        branchId: input.branchId,
+        maximumEntries: input.maximumEntries,
+        pathPrefix: input.pathPrefix,
+        listingBudget: input.listingBudget,
+        abortSignal: input.abortSignal,
+        signal: input.signal,
+        timeoutMs: input.timeoutMs ?? clientOptions.timeoutMs,
+        path: input.path,
+        maximumContentCharacters: input.maximumContentCharacters,
+      }),
+    getProjectFiles: (input) =>
+      getStrictRuntimeProjectFiles({
+        ...clientOptions,
+        projectId: input.projectId,
+        authToken: input.authToken,
+        branchId: input.branchId,
+        maximumEntries: input.maximumEntries,
+        pathPrefix: input.pathPrefix,
+        listingBudget: input.listingBudget,
+        abortSignal: input.abortSignal,
+        signal: input.signal,
+        timeoutMs: input.timeoutMs ?? clientOptions.timeoutMs,
+      }),
   };
 }
 
@@ -1883,9 +1912,9 @@ async function readStrictApiErrorMessage(
     if (error instanceof RangeError) {
       throw error;
     }
-    return error instanceof Error
-      ? error.message
-      : response.statusText || `HTTP ${response.status}`;
+    return truncateApiErrorMessage(
+      error instanceof Error ? error.message : response.statusText || `HTTP ${response.status}`,
+    );
   }
   if (!body.trim()) {
     return response.statusText || `HTTP ${response.status}`;

--- a/src/agent/runtime/project-files-client.ts
+++ b/src/agent/runtime/project-files-client.ts
@@ -13,31 +13,61 @@ import {
 
 const DEFAULT_PROJECT_FILES_TIMEOUT_MS = 15_000;
 const DEFAULT_PROJECT_FILES_PAGE_LIMIT = 100;
-const PROJECT_FILE_JSON_OVERHEAD_BYTES = 65_536;
-const PROJECT_FILE_PATH_MAX_CHARACTERS = 4_096;
-const PROJECT_FILE_CURSOR_MAX_CHARACTERS = 4_096;
-const PROJECT_FILE_LIST_MAX_PAGES = 50;
-const PROJECT_FILE_LIST_TOTAL_MAX_BYTES = 16 * 1_048_576;
-const PROJECT_FILE_LIST_PAGE_MAX_BYTES =
-  DEFAULT_PROJECT_FILES_PAGE_LIMIT * PROJECT_FILE_PATH_MAX_CHARACTERS * 6 +
-  PROJECT_FILE_JSON_OVERHEAD_BYTES;
-const PROJECT_FILE_RESPONSE_BLOCK_BYTES = 65_536;
-const PROJECT_FILE_RESPONSE_YIELD_CHUNKS = 256;
-const PROJECT_FILE_RESPONSE_MAX_CONSECUTIVE_EMPTY_CHUNKS = 4_096;
-const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
-const utf8Encoder = new TextEncoder();
+const DEFAULT_PROJECT_FILES_OPERATION_TIMEOUT_MS = 300_000;
+const MAX_PROJECT_FILES_TIMEOUT_MS = 300_000;
+const MAX_PROJECT_FILES_OPERATION_TIMEOUT_MS = 300_000;
+const MAX_PROJECT_FILES_PAGE_LIMIT = 100;
+
+// Project paths and pagination cursors cross a remote trust boundary and are
+// retained in memory by the hosted Skill catalog.
+const MAX_PROJECT_FILE_PATH_CHARACTERS = 4_096;
+const MAX_PROJECT_FILES_CURSOR_CHARACTERS = 4_096;
+const MAX_PROJECT_FILES_PER_PAGE = MAX_PROJECT_FILES_PAGE_LIMIT;
+/** Maximum aggregate file records returned by one project listing. */
+export const MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS = 10_000;
+const MAX_PROJECT_FILES_TOTAL_PAGES = 200;
+const MAX_PROJECT_FILES_API_URL_CHARACTERS = 8_192;
+const MAX_PROJECT_FILES_IDENTIFIER_CHARACTERS = 256;
+const MAX_PROJECT_FILES_AUTH_TOKEN_CHARACTERS = 16_384;
+
+// JSON can expand one decoded byte to six ASCII bytes (for example "\u0000").
+// These budgets therefore admit every valid 1 MiB file plus bounded path and
+// envelope overhead without permitting an unbounded transport allocation.
+const MAX_JSON_ESCAPE_BYTES_PER_DECODED_BYTE = 6;
+const PROJECT_FILES_JSON_ENVELOPE_BYTES = 64 * 1_024;
+const MAX_PROJECT_FILE_RESPONSE_BYTES =
+  (SKILL_TEXT_FILE_MAX_BYTES + MAX_PROJECT_FILE_PATH_CHARACTERS) *
+    MAX_JSON_ESCAPE_BYTES_PER_DECODED_BYTE +
+  PROJECT_FILES_JSON_ENVELOPE_BYTES;
+const MAX_PROJECT_FILE_LIST_PAGE_BYTES =
+  (MAX_PROJECT_FILES_PER_PAGE * MAX_PROJECT_FILE_PATH_CHARACTERS +
+      MAX_PROJECT_FILES_CURSOR_CHARACTERS) *
+    MAX_JSON_ESCAPE_BYTES_PER_DECODED_BYTE +
+  PROJECT_FILES_JSON_ENVELOPE_BYTES;
+const MAX_PROJECT_FILES_ERROR_BODY_BYTES = 64 * 1_024;
+const MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS = 4_096;
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:\//;
 
-/** Maximum aggregate file records retained by one project listing. */
-export const MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS = PROJECT_FILE_LIST_MAX_PAGES *
-  DEFAULT_PROJECT_FILES_PAGE_LIMIT;
+// Established public-client limits. The strict hosted client below adds a
+// narrower trust-boundary contract without weakening these public safeguards.
+const PUBLIC_PROJECT_FILE_JSON_OVERHEAD_BYTES = 65_536;
+const PUBLIC_PROJECT_FILE_LIST_MAX_PAGES = 50;
+const PUBLIC_PROJECT_FILE_LIST_TOTAL_MAX_BYTES = 16 * 1_048_576;
+const PUBLIC_PROJECT_FILE_LIST_PAGE_MAX_BYTES =
+  DEFAULT_PROJECT_FILES_PAGE_LIMIT * MAX_PROJECT_FILE_PATH_CHARACTERS * 6 +
+  PUBLIC_PROJECT_FILE_JSON_OVERHEAD_BYTES;
+const PUBLIC_PROJECT_FILE_RESPONSE_BLOCK_BYTES = 65_536;
+const PUBLIC_PROJECT_FILE_RESPONSE_YIELD_CHUNKS = 256;
+const PUBLIC_PROJECT_FILE_RESPONSE_MAX_CONSECUTIVE_EMPTY_CHUNKS = 4_096;
+const publicProjectFileUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+const publicProjectFileUtf8Encoder = new TextEncoder();
 
-/** Whether a value is a canonical, bounded project-relative file path. */
+/** Whether a value is a canonical project-relative file path. */
 export function isRuntimeProjectFilePath(path: unknown): path is string {
   if (
     typeof path !== "string" ||
     path.length === 0 ||
-    path.length > PROJECT_FILE_PATH_MAX_CHARACTERS ||
+    path.length > MAX_PROJECT_FILE_PATH_CHARACTERS ||
     !isWellFormedUtf16(path) ||
     hasControlCharacters(path) ||
     path.startsWith("/") ||
@@ -46,7 +76,8 @@ export function isRuntimeProjectFilePath(path: unknown): path is string {
   ) {
     return false;
   }
-  return path.split("/").every((segment) =>
+  const segments = path.split("/");
+  return segments.every((segment) =>
     segment.length > 0 &&
     segment.length <= SKILL_PATH_SEGMENT_MAX_LENGTH &&
     segment !== "." &&
@@ -54,13 +85,27 @@ export function isRuntimeProjectFilePath(path: unknown): path is string {
   );
 }
 
-/** Whether a value fits the shared runtime Skill text-file budget. */
-export function isRuntimeProjectFileContent(content: unknown): content is string {
-  return typeof content === "string" &&
-    content.length <= SKILL_TEXT_FILE_MAX_BYTES &&
-    isWellFormedUtf16(content) &&
-    isUtf8WithinByteLimit(content, SKILL_TEXT_FILE_MAX_BYTES);
-}
+const getStrictRuntimeProjectFilePathSchema = defineSchema((v) =>
+  v.string().min(1).max(MAX_PROJECT_FILE_PATH_CHARACTERS)
+    .refine(isWellFormedUtf16, "Project file path must contain well-formed UTF-16")
+    .refine(
+      (path) => !hasControlCharacters(path),
+      "Project file path must not contain control characters",
+    )
+    .refine(
+      isRuntimeProjectFilePath,
+      "Project file path must be a canonical project-relative path",
+    )
+);
+
+const getStrictRuntimeProjectFilesCursorSchema = defineSchema((v) =>
+  v.string().min(1).max(MAX_PROJECT_FILES_CURSOR_CHARACTERS)
+    .refine(isWellFormedUtf16, "Project files cursor must contain well-formed UTF-16")
+    .refine(
+      (cursor) => !hasControlCharacters(cursor),
+      "Project files cursor must not contain control characters",
+    )
+);
 
 export const getRuntimeProjectFileSchema = defineSchema((v) =>
   v.object({
@@ -75,6 +120,21 @@ export const getRuntimeProjectFileListItemSchema = defineSchema((v) =>
   })
 );
 
+/** Strict hosted-boundary schema for a runtime project file. */
+export const getStrictRuntimeProjectFileSchema = defineSchema((v) =>
+  v.object({
+    path: getStrictRuntimeProjectFilePathSchema(),
+    content: v.string(),
+  })
+);
+
+/** Strict hosted-boundary schema for a runtime project file list item. */
+export const getStrictRuntimeProjectFileListItemSchema = defineSchema((v) =>
+  v.object({
+    path: getStrictRuntimeProjectFilePathSchema(),
+  })
+);
+
 const getRuntimeProjectFileListRestResponseSchema = defineSchema((v) =>
   v.object({
     data: v.array(getRuntimeProjectFileListItemSchema()),
@@ -84,11 +144,28 @@ const getRuntimeProjectFileListRestResponseSchema = defineSchema((v) =>
   })
 );
 
+const getStrictRuntimeProjectFileListRestResponseSchema = defineSchema((v) =>
+  v.object({
+    data: v.array(getStrictRuntimeProjectFileListItemSchema()).max(MAX_PROJECT_FILES_PER_PAGE),
+    page_info: v.object({
+      next: getStrictRuntimeProjectFilesCursorSchema().nullable(),
+    }),
+  })
+);
+
 const getApiErrorBodySchema = defineSchema((v) =>
   v.object({
     detail: v.string().optional(),
     message: v.string().optional(),
     error: v.string().optional(),
+  }).passthrough()
+);
+
+const getStrictApiErrorBodySchema = defineSchema((v) =>
+  v.object({
+    detail: v.string().max(MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS).optional(),
+    message: v.string().max(MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS).optional(),
+    error: v.string().max(MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS).optional(),
   }).passthrough()
 );
 
@@ -148,6 +225,18 @@ export type RuntimeProjectFilesClientOptions = {
   createAccessDeniedError?: (statusCode: number, message: string) => Error;
 };
 
+/** Internal options for fail-closed hosted project-file reads. */
+export type StrictRuntimeProjectFilesClientOptions = RuntimeProjectFilesClientOptions & {
+  /** Aggregate listing timeout, capped at five minutes. */
+  operationTimeoutMs?: number;
+};
+
+/** Internal per-call context for fail-closed hosted project-file reads. */
+type StrictRuntimeProjectFilesRequestContext = {
+  /** Caller cancellation composed with request and aggregate deadlines. */
+  signal?: AbortSignal;
+};
+
 /** Public API contract for runtime project files client. */
 export type RuntimeProjectFilesClient = {
   getProjectFile: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
@@ -169,22 +258,32 @@ export function createRuntimeProjectFileListingBudget(): RuntimeProjectFileListi
   return Object.freeze({
     consumePage(): void {
       pages += 1;
-      if (pages > PROJECT_FILE_LIST_MAX_PAGES) {
+      if (pages > PUBLIC_PROJECT_FILE_LIST_MAX_PAGES) {
         throw new RangeError(
-          `Project file listing may contain at most ${PROJECT_FILE_LIST_MAX_PAGES} pages`,
+          `Project file listing may contain at most ${PUBLIC_PROJECT_FILE_LIST_MAX_PAGES} pages`,
         );
       }
     },
     consumeBytes(byteCount: number): void {
       bytes += byteCount;
-      if (bytes > PROJECT_FILE_LIST_TOTAL_MAX_BYTES) {
+      if (bytes > PUBLIC_PROJECT_FILE_LIST_TOTAL_MAX_BYTES) {
         throw new RangeError(
-          `Project file listing responses may contain at most ${PROJECT_FILE_LIST_TOTAL_MAX_BYTES} bytes`,
+          `Project file listing responses may contain at most ${PUBLIC_PROJECT_FILE_LIST_TOTAL_MAX_BYTES} bytes`,
         );
       }
     },
   });
 }
+
+/** Internal client contract that accepts request-scoped cancellation. */
+type StrictRuntimeProjectFilesClient = {
+  getProjectFile: (
+    options: RuntimeGetProjectFileOptions & StrictRuntimeProjectFilesRequestContext,
+  ) => Promise<RuntimeProjectFile | null>;
+  getProjectFiles: (
+    options: RuntimeProjectFilesApiOptions & StrictRuntimeProjectFilesRequestContext,
+  ) => Promise<RuntimeProjectFileListItem[]>;
+};
 
 /** Error shape for runtime project files API auth. */
 export class RuntimeProjectFilesApiAuthError extends Error {
@@ -203,9 +302,9 @@ export class RuntimeProjectFilesApiAuthError extends Error {
 export function createRuntimeProjectFilesClient(
   options: RuntimeProjectFilesClientOptions,
 ): RuntimeProjectFilesClient {
-  // Snapshot the trusted transport configuration. Callers can pass plain
-  // JavaScript objects at runtime, so spreading request input into this scope
-  // would let excess properties replace the configured origin or transport.
+  // Snapshot trusted transport configuration. Untyped JavaScript callers can
+  // supply excess request properties, so request input must never replace the
+  // configured origin, fetch implementation, or access-denied factory.
   const apiUrl = new URL(options.apiUrl).toString();
   const configuredTimeoutMs = options.timeoutMs;
   const configuredFetch = options.fetch;
@@ -251,6 +350,20 @@ export function createRuntimeProjectFilesClient(
   });
 }
 
+/**
+ * Create a runtime project files client that enforces hosted trust-boundary
+ * validation and resource limits.
+ */
+export function createStrictRuntimeProjectFilesClient(
+  options: StrictRuntimeProjectFilesClientOptions,
+): StrictRuntimeProjectFilesClient {
+  const clientOptions = normalizeRuntimeProjectFilesClientOptions(options);
+  return {
+    getProjectFile: (input) => getStrictRuntimeProjectFile({ ...input, ...clientOptions }),
+    getProjectFiles: (input) => getStrictRuntimeProjectFiles({ ...input, ...clientOptions }),
+  };
+}
+
 /** Return runtime project file. */
 export async function getRuntimeProjectFile(
   options: RuntimeProjectFilesClientOptions & RuntimeGetProjectFileOptions,
@@ -260,12 +373,13 @@ export async function getRuntimeProjectFile(
     (!Number.isSafeInteger(options.maximumContentCharacters) ||
       options.maximumContentCharacters <= 0 ||
       options.maximumContentCharacters >
-        Math.floor((Number.MAX_SAFE_INTEGER - PROJECT_FILE_JSON_OVERHEAD_BYTES) / 6))
+        Math.floor((Number.MAX_SAFE_INTEGER - PUBLIC_PROJECT_FILE_JSON_OVERHEAD_BYTES) / 6))
   ) {
     throw new RangeError(
       "Project file maximumContentCharacters must be a positive bounded safe integer",
     );
   }
+
   return withRuntimeProjectFilesRequestSignal(
     options,
     (signal) =>
@@ -291,9 +405,9 @@ export async function getRuntimeProjectFile(
 
         const responseValue = options.maximumContentCharacters === undefined
           ? await response.json()
-          : await readJsonResponseWithinLimit(
+          : await readPublicJsonResponseWithinLimit(
             response,
-            options.maximumContentCharacters * 6 + PROJECT_FILE_JSON_OVERHEAD_BYTES,
+            options.maximumContentCharacters * 6 + PUBLIC_PROJECT_FILE_JSON_OVERHEAD_BYTES,
             signal,
           );
         const parsed = getRuntimeProjectFileSchema().safeParse(responseValue);
@@ -317,13 +431,13 @@ export async function getRuntimeProjectFile(
   );
 }
 
-async function readJsonResponseWithinLimit(
+async function readPublicJsonResponseWithinLimit(
   response: Response,
   byteLimit: number,
   abortSignal?: AbortSignal,
   listingBudget?: RuntimeProjectFileListingBudget,
 ): Promise<unknown> {
-  throwIfAborted(abortSignal);
+  throwIfRuntimeProjectFilesAborted(abortSignal);
   const declaredLength = response.headers.get("content-length");
   if (declaredLength !== null) {
     const length = Number(declaredLength);
@@ -333,8 +447,8 @@ async function readJsonResponseWithinLimit(
   }
   if (!response.body) {
     const text = await response.text();
-    throwIfAborted(abortSignal);
-    const byteLength = utf8Encoder.encode(text).byteLength;
+    throwIfRuntimeProjectFilesAborted(abortSignal);
+    const byteLength = publicProjectFileUtf8Encoder.encode(text).byteLength;
     listingBudget?.consumeBytes(byteLength);
     if (byteLength > byteLimit) {
       throw new RangeError(`Project file response may contain at most ${byteLimit} bytes`);
@@ -356,13 +470,16 @@ async function readJsonResponseWithinLimit(
   try {
     while (true) {
       const result = await reader.read();
-      throwIfAborted(abortSignal);
+      throwIfRuntimeProjectFilesAborted(abortSignal);
       if (result.done) break;
 
       const chunk = result.value;
       if (chunk.byteLength === 0) {
         consecutiveEmptyChunks += 1;
-        if (consecutiveEmptyChunks > PROJECT_FILE_RESPONSE_MAX_CONSECUTIVE_EMPTY_CHUNKS) {
+        if (
+          consecutiveEmptyChunks >
+            PUBLIC_PROJECT_FILE_RESPONSE_MAX_CONSECUTIVE_EMPTY_CHUNKS
+        ) {
           throw new RangeError("Project file response stream made no byte progress");
         }
       } else {
@@ -379,7 +496,7 @@ async function readJsonResponseWithinLimit(
       while (chunkOffset < chunk.byteLength) {
         if (!currentBlock) {
           currentBlock = new Uint8Array(
-            Math.min(PROJECT_FILE_RESPONSE_BLOCK_BYTES, byteLimit),
+            Math.min(PUBLIC_PROJECT_FILE_RESPONSE_BLOCK_BYTES, byteLimit),
           );
           currentBlockLength = 0;
         }
@@ -387,7 +504,10 @@ async function readJsonResponseWithinLimit(
           currentBlock.byteLength - currentBlockLength,
           chunk.byteLength - chunkOffset,
         );
-        currentBlock.set(chunk.subarray(chunkOffset, chunkOffset + copied), currentBlockLength);
+        currentBlock.set(
+          chunk.subarray(chunkOffset, chunkOffset + copied),
+          currentBlockLength,
+        );
         currentBlockLength += copied;
         chunkOffset += copied;
         if (currentBlockLength === currentBlock.byteLength) {
@@ -398,10 +518,10 @@ async function readJsonResponseWithinLimit(
       }
 
       chunksSinceYield += 1;
-      if (chunksSinceYield >= PROJECT_FILE_RESPONSE_YIELD_CHUNKS) {
+      if (chunksSinceYield >= PUBLIC_PROJECT_FILE_RESPONSE_YIELD_CHUNKS) {
         chunksSinceYield = 0;
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
-        throwIfAborted(abortSignal);
+        throwIfRuntimeProjectFilesAborted(abortSignal);
       }
     }
   } catch (error) {
@@ -421,7 +541,93 @@ async function readJsonResponseWithinLimit(
   if (currentBlock && currentBlockLength > 0) {
     bytes.set(currentBlock.subarray(0, currentBlockLength), offset);
   }
-  return JSON.parse(utf8Decoder.decode(bytes));
+  return JSON.parse(publicProjectFileUtf8Decoder.decode(bytes));
+}
+
+/** Return a runtime project file with strict hosted-boundary enforcement. */
+export async function getStrictRuntimeProjectFile(
+  options:
+    & StrictRuntimeProjectFilesClientOptions
+    & RuntimeGetProjectFileOptions
+    & StrictRuntimeProjectFilesRequestContext,
+): Promise<RuntimeProjectFile | null> {
+  validateRuntimeProjectFilesClientOptions(options, false);
+  validateStrictRuntimeProjectFilesRequestContext(options);
+  validateRuntimeProjectFilesApiOptions(options);
+  validateProjectFileRequestPath(options.path);
+
+  return runStrictProjectFilesRequest(
+    options,
+    options.signal,
+    (requestScope) =>
+      traceStrictProjectFilesRequest(options, "runtimeProjectFiles.getProjectFile", async () => {
+        const url = createStrictRuntimeProjectFileUrl({
+          ...options,
+          fields: "(path,content)",
+        });
+        return await withStrictRuntimeProjectFilesRestResponse(
+          url,
+          options,
+          requestScope,
+          async (response, activeRequestScope) => {
+            if (response.status === 404) {
+              cancelResponseBodyWithoutWaiting(response);
+              return null;
+            }
+
+            if (!response.ok) {
+              throw NETWORK_ERROR.create({
+                detail:
+                  `Failed to fetch file ${options.path} for project ${options.projectId}: ${await readStrictApiErrorMessage(
+                    response,
+                    activeRequestScope,
+                  )}`,
+              });
+            }
+
+            const responseJson = await readBoundedJsonResponse(
+              response,
+              MAX_PROJECT_FILE_RESPONSE_BYTES,
+              "Project file response",
+              activeRequestScope,
+            ).catch((error) => {
+              if (!(error instanceof RuntimeProjectFilesProtocolError)) {
+                throw error;
+              }
+              throw createInvalidProjectFileResponseError(options, error);
+            });
+            const parsed = getStrictRuntimeProjectFileSchema().safeParse(responseJson);
+            if (!parsed.success) {
+              throw createInvalidProjectFileResponseError(options);
+            }
+            if (parsed.data.path !== options.path) {
+              throw createInvalidProjectFileResponseError(
+                options,
+                new RuntimeProjectFilesProtocolError(
+                  "Project file response path did not match the request",
+                ),
+              );
+            }
+            if (!isRuntimeProjectFileContent(parsed.data.content)) {
+              throw NETWORK_ERROR.create({
+                detail:
+                  `Failed to fetch file ${options.path} for project ${options.projectId}: content exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
+              });
+            }
+
+            return parsed.data;
+          },
+        );
+      }),
+  );
+}
+
+/** Whether a runtime project file content value fits the shared Skill budget. */
+export function isRuntimeProjectFileContent(content: unknown): content is string {
+  return typeof content === "string" &&
+    content.length <= SKILL_TEXT_FILE_MAX_BYTES &&
+    isWellFormedUtf16(content) &&
+    isUtf8WithinByteLimit(content, SKILL_TEXT_FILE_MAX_BYTES);
 }
 
 /** Return runtime project files. */
@@ -437,17 +643,20 @@ export async function getRuntimeProjectFiles(
   if (
     options.pathPrefix !== undefined &&
     (options.pathPrefix.length === 0 ||
-      options.pathPrefix.length > PROJECT_FILE_PATH_MAX_CHARACTERS ||
-      options.pathPrefix.startsWith("/") || options.pathPrefix.endsWith("/") ||
-      options.pathPrefix.includes("\\") || options.pathPrefix.includes("\0") ||
+      options.pathPrefix.length > MAX_PROJECT_FILE_PATH_CHARACTERS ||
+      options.pathPrefix.startsWith("/") ||
+      options.pathPrefix.endsWith("/") ||
+      options.pathPrefix.includes("\\") ||
+      options.pathPrefix.includes("\0") ||
       options.pathPrefix.split("/").some((segment) =>
         segment.length === 0 || segment === "." || segment === ".."
       ))
   ) {
     throw new RangeError(
-      `Project file list path must contain between 1 and ${PROJECT_FILE_PATH_MAX_CHARACTERS} characters`,
+      `Project file list path must contain between 1 and ${MAX_PROJECT_FILE_PATH_CHARACTERS} characters`,
     );
   }
+
   return withRuntimeProjectFilesRequestSignal(
     options,
     (signal) =>
@@ -458,7 +667,7 @@ export async function getRuntimeProjectFiles(
         let cursor: string | null = null;
 
         do {
-          throwIfAborted(signal);
+          throwIfRuntimeProjectFilesAborted(signal);
           listingBudget.consumePage();
           const url = createRuntimeProjectFileUrl({
             ...options,
@@ -466,7 +675,7 @@ export async function getRuntimeProjectFiles(
             cursor,
           });
           const response = await fetchRuntimeProjectFilesRestResponse(url, options, signal);
-          throwIfAborted(signal);
+          throwIfRuntimeProjectFilesAborted(signal);
 
           if (!response.ok) {
             throw NETWORK_ERROR.create({
@@ -478,9 +687,9 @@ export async function getRuntimeProjectFiles(
           }
 
           const parsed = getRuntimeProjectFileListRestResponseSchema().safeParse(
-            await readJsonResponseWithinLimit(
+            await readPublicJsonResponseWithinLimit(
               response,
-              PROJECT_FILE_LIST_PAGE_MAX_BYTES,
+              PUBLIC_PROJECT_FILE_LIST_PAGE_MAX_BYTES,
               signal,
               listingBudget,
             ),
@@ -493,18 +702,18 @@ export async function getRuntimeProjectFiles(
           }
 
           for (const file of parsed.data.data) {
-            if (file.path.length > PROJECT_FILE_PATH_MAX_CHARACTERS) {
+            if (file.path.length > MAX_PROJECT_FILE_PATH_CHARACTERS) {
               throw new RangeError(
-                `Project file paths may contain at most ${PROJECT_FILE_PATH_MAX_CHARACTERS} characters`,
+                `Project file paths may contain at most ${MAX_PROJECT_FILE_PATH_CHARACTERS} characters`,
               );
             }
           }
           if (
             parsed.data.page_info.next !== null &&
-            parsed.data.page_info.next.length > PROJECT_FILE_CURSOR_MAX_CHARACTERS
+            parsed.data.page_info.next.length > MAX_PROJECT_FILES_CURSOR_CHARACTERS
           ) {
             throw new RangeError(
-              `Project file cursors may contain at most ${PROJECT_FILE_CURSOR_MAX_CHARACTERS} characters`,
+              `Project file cursors may contain at most ${MAX_PROJECT_FILES_CURSOR_CHARACTERS} characters`,
             );
           }
 
@@ -527,6 +736,202 @@ export async function getRuntimeProjectFiles(
         return files;
       }),
   );
+}
+
+/** Return runtime project files with strict hosted-boundary enforcement. */
+export async function getStrictRuntimeProjectFiles(
+  options:
+    & StrictRuntimeProjectFilesClientOptions
+    & RuntimeProjectFilesApiOptions
+    & StrictRuntimeProjectFilesRequestContext,
+): Promise<RuntimeProjectFileListItem[]> {
+  validateRuntimeProjectFilesClientOptions(options);
+  validateStrictRuntimeProjectFilesRequestContext(options);
+  validateRuntimeProjectFilesApiOptions(options);
+  const pageLimit = resolveProjectFilesPageLimit(options.pageLimit);
+  const maximumEntries = Math.min(
+    options.maximumEntries ?? MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS,
+    MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS,
+  );
+  const listingBudget = options.listingBudget ?? createRuntimeProjectFileListingBudget();
+  const operationDeadline = performance.now() +
+    resolveProjectFilesOperationTimeoutMs(options.operationTimeoutMs);
+  const operationScope = createStrictProjectFilesOperationScope(
+    options.signal,
+    operationDeadline,
+  );
+
+  try {
+    return await waitForStrictProjectFilesOperationPromise(
+      operationScope,
+      operationDeadline,
+      () =>
+        traceStrictProjectFilesRequest(options, "runtimeProjectFiles.getProjectFiles", async () => {
+          const files: RuntimeProjectFileListItem[] = [];
+          const seenCursors = new Set<string>();
+          let cursor: string | null = null;
+          let pageCount = 0;
+
+          do {
+            throwIfStrictProjectFilesOperationExpired(
+              operationScope,
+              operationDeadline,
+            );
+            if (pageCount >= MAX_PROJECT_FILES_TOTAL_PAGES) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `pagination exceeds ${MAX_PROJECT_FILES_TOTAL_PAGES} pages`,
+              );
+            }
+            pageCount += 1;
+            listingBudget.consumePage();
+
+            const remainingEntries = maximumEntries - files.length;
+            if (remainingEntries <= 0) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `file count exceeds ${maximumEntries}`,
+              );
+            }
+            const requestPageLimit = Math.min(pageLimit, remainingEntries);
+
+            const url = createStrictRuntimeProjectFileUrl({
+              ...options,
+              fields: "(path)",
+              cursor,
+              pageLimit: requestPageLimit,
+            });
+            const page = await runStrictProjectFilesRequest(
+              options,
+              operationScope.signal,
+              (requestScope) =>
+                withStrictRuntimeProjectFilesRestResponse(
+                  url,
+                  options,
+                  requestScope,
+                  async (response, activeRequestScope) => {
+                    if (!response.ok) {
+                      throw NETWORK_ERROR.create({
+                        detail:
+                          `Failed to fetch files for project ${options.projectId}: ${await readStrictApiErrorMessage(
+                            response,
+                            activeRequestScope,
+                            listingBudget,
+                          )}`,
+                      });
+                    }
+
+                    const responseJson = await readBoundedJsonResponse(
+                      response,
+                      MAX_PROJECT_FILE_LIST_PAGE_BYTES,
+                      "Project files list response",
+                      activeRequestScope,
+                      listingBudget,
+                    ).catch((error) => {
+                      if (!(error instanceof RuntimeProjectFilesProtocolError)) {
+                        throw error;
+                      }
+                      throw createInvalidProjectFilesListResponseError(options.projectId, error);
+                    });
+                    const parsed = getStrictRuntimeProjectFileListRestResponseSchema().safeParse(
+                      responseJson,
+                    );
+                    if (!parsed.success) {
+                      throw createInvalidProjectFilesListResponseError(options.projectId);
+                    }
+                    return parsed.data;
+                  },
+                ),
+            );
+            throwIfStrictProjectFilesOperationExpired(
+              operationScope,
+              operationDeadline,
+            );
+
+            if (page.data.length > requestPageLimit) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `page returned more than the requested ${requestPageLimit} files`,
+              );
+            }
+            if (
+              files.length + page.data.length > maximumEntries
+            ) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `file count exceeds ${maximumEntries}`,
+              );
+            }
+
+            const nextCursor = page.page_info.next;
+            if (
+              nextCursor !== null &&
+              files.length + page.data.length >= maximumEntries
+            ) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `file count exceeds ${maximumEntries}`,
+              );
+            }
+            files.push(...page.data);
+            if (nextCursor !== null) {
+              if (seenCursors.has(nextCursor)) {
+                throw createProjectFilesListLimitError(
+                  options.projectId,
+                  "pagination returned a repeated cursor",
+                );
+              }
+              seenCursors.add(nextCursor);
+            }
+            cursor = nextCursor;
+          } while (cursor);
+
+          throwIfStrictProjectFilesOperationExpired(
+            operationScope,
+            operationDeadline,
+          );
+          return files;
+        }),
+    );
+  } catch (error) {
+    operationScope.abort(error);
+    throw error;
+  } finally {
+    operationScope.dispose();
+  }
+}
+
+function createInvalidProjectFileResponseError(
+  options: RuntimeGetProjectFileOptions,
+  cause?: unknown,
+): Error {
+  const reason = cause instanceof Error ? `: ${cause.message}` : "";
+  return NETWORK_ERROR.create({
+    detail:
+      `Failed to fetch file ${options.path} for project ${options.projectId}: invalid API response${reason}`,
+  });
+}
+
+/*
+ * The legacy and strict implementations intentionally coexist above. Keep the
+ * helpers below split as well so future hosted hardening cannot silently narrow
+ * the established public contract.
+ */
+
+function createInvalidProjectFilesListResponseError(
+  projectId: string,
+  cause?: unknown,
+): Error {
+  const reason = cause instanceof Error ? `: ${cause.message}` : "";
+  return NETWORK_ERROR.create({
+    detail: `Failed to fetch files for project ${projectId}: invalid API response${reason}`,
+  });
+}
+
+function createProjectFilesListLimitError(projectId: string, reason: string): Error {
+  return NETWORK_ERROR.create({
+    detail: `Failed to fetch files for project ${projectId}: ${reason}`,
+  });
 }
 
 function createRuntimeProjectFileUrl(input: {
@@ -563,6 +968,40 @@ function createRuntimeProjectFileUrl(input: {
   return url;
 }
 
+function createStrictRuntimeProjectFileUrl(input: {
+  apiUrl: string | URL;
+  projectId: string;
+  path?: string;
+  pathPrefix?: string;
+  branchId?: string | null;
+  fields: string;
+  cursor?: string | null;
+  pageLimit?: number;
+}): URL {
+  const apiUrl = new URL(input.apiUrl);
+  const encodedProjectId = encodeURIComponent(input.projectId);
+  const pathname = input.path
+    ? `/projects/${encodedProjectId}/files/${encodeURIComponent(input.path)}`
+    : `/projects/${encodedProjectId}/files`;
+  const url = new URL(pathname, apiUrl.origin);
+
+  url.searchParams.set("fields", input.fields);
+  if (input.branchId) {
+    url.searchParams.set("branch", input.branchId);
+  }
+  if (input.cursor) {
+    url.searchParams.set("cursor", input.cursor);
+  }
+  if (input.pathPrefix) {
+    url.searchParams.set("path", input.pathPrefix);
+  }
+  if (!input.path) {
+    url.searchParams.set("limit", String(resolveProjectFilesPageLimit(input.pageLimit)));
+  }
+
+  return url;
+}
+
 async function fetchRuntimeProjectFilesRestResponse(
   url: URL,
   options: RuntimeProjectFilesClientOptions & { authToken: string },
@@ -582,7 +1021,7 @@ async function fetchRuntimeProjectFilesRestResponse(
   return response;
 }
 
-function throwIfAborted(signal: AbortSignal | undefined): void {
+function throwIfRuntimeProjectFilesAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) return;
   throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
 }
@@ -607,13 +1046,538 @@ async function withRuntimeProjectFilesRequestSignal<T>(
     timeoutMs,
   );
   try {
-    throwIfAborted(controller.signal);
+    throwIfRuntimeProjectFilesAborted(controller.signal);
     const result = await fn(controller.signal);
-    throwIfAborted(controller.signal);
+    throwIfRuntimeProjectFilesAborted(controller.signal);
     return result;
   } finally {
     clearTimeout(timeoutId);
     externalSignal?.removeEventListener("abort", abortFromExternal);
+  }
+}
+
+async function withStrictRuntimeProjectFilesRestResponse<TResult>(
+  url: URL,
+  options:
+    & StrictRuntimeProjectFilesClientOptions
+    & StrictRuntimeProjectFilesRequestContext
+    & { authToken: string },
+  requestScope: StrictProjectFilesRequestScope,
+  handleResponse: (
+    response: Response,
+    requestScope: StrictProjectFilesRequestScope,
+  ) => Promise<TResult>,
+): Promise<TResult> {
+  const response = await waitForStrictProjectFilesRequestPromise(
+    requestScope,
+    () =>
+      (options.fetch ?? fetch)(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${options.authToken}`,
+        },
+        signal: requestScope.signal,
+      }),
+    (lateResponse, reason) => {
+      cancelResponseBodyWithoutWaiting(lateResponse, reason);
+    },
+  );
+
+  if (response.status === 401 || response.status === 403) {
+    cancelResponseBodyWithoutWaiting(response);
+    throw createProjectFilesAccessDeniedError(options, response.status);
+  }
+
+  try {
+    const result = await handleResponse(response, requestScope);
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return result;
+  } catch (error) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw error;
+  }
+}
+
+function validateRuntimeProjectFilesClientOptions(
+  options: StrictRuntimeProjectFilesClientOptions,
+  validatePageLimit = true,
+): void {
+  normalizeProjectFilesApiUrl(options.apiUrl);
+  resolveProjectFilesTimeoutMs(options.timeoutMs);
+  resolveProjectFilesOperationTimeoutMs(options.operationTimeoutMs);
+  if (validatePageLimit) {
+    resolveProjectFilesPageLimit(options.pageLimit);
+  }
+  if (options.fetch !== undefined && typeof options.fetch !== "function") {
+    throw new TypeError("fetch must be a function");
+  }
+  if (options.trace !== undefined && typeof options.trace !== "function") {
+    throw new TypeError("trace must be a function");
+  }
+  if (
+    options.createAccessDeniedError !== undefined &&
+    typeof options.createAccessDeniedError !== "function"
+  ) {
+    throw new TypeError("createAccessDeniedError must be a function");
+  }
+}
+
+function normalizeRuntimeProjectFilesClientOptions(
+  options: StrictRuntimeProjectFilesClientOptions,
+): Readonly<StrictRuntimeProjectFilesClientOptions> {
+  validateRuntimeProjectFilesClientOptions(options);
+  return Object.freeze({
+    apiUrl: normalizeProjectFilesApiUrl(options.apiUrl),
+    ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+    timeoutMs: resolveProjectFilesTimeoutMs(options.timeoutMs),
+    operationTimeoutMs: resolveProjectFilesOperationTimeoutMs(options.operationTimeoutMs),
+    pageLimit: resolveProjectFilesPageLimit(options.pageLimit),
+    ...(options.trace === undefined ? {} : { trace: options.trace }),
+    ...(options.createAccessDeniedError === undefined
+      ? {}
+      : { createAccessDeniedError: options.createAccessDeniedError }),
+  });
+}
+
+function normalizeProjectFilesApiUrl(value: unknown): string {
+  if (
+    !(typeof value === "string" || value instanceof URL) ||
+    String(value).length === 0 ||
+    String(value).length > MAX_PROJECT_FILES_API_URL_CHARACTERS
+  ) {
+    throw new TypeError(
+      `apiUrl must be a URL no greater than ${MAX_PROJECT_FILES_API_URL_CHARACTERS} characters`,
+    );
+  }
+  const url = new URL(value);
+  if (
+    (url.protocol !== "https:" && url.protocol !== "http:") ||
+    url.username.length > 0 ||
+    url.password.length > 0
+  ) {
+    throw new TypeError("apiUrl must be an HTTP(S) URL without embedded credentials");
+  }
+  return url.origin;
+}
+
+function requireBoundedWireString(
+  value: unknown,
+  label: string,
+  maxLength: number,
+): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    !isWellFormedUtf16(value) ||
+    hasControlCharacters(value)
+  ) {
+    throw new TypeError(
+      `${label} must be a non-empty bounded string with well-formed UTF-16 and no control characters`,
+    );
+  }
+  return value;
+}
+
+function validateRuntimeProjectFilesApiOptions(
+  options: RuntimeProjectFilesApiOptions,
+): void {
+  if (
+    options.maximumEntries !== undefined &&
+    (!Number.isSafeInteger(options.maximumEntries) || options.maximumEntries <= 0)
+  ) {
+    throw new RangeError("Project file maximumEntries must be a positive safe integer");
+  }
+  const projectId = requireBoundedWireString(
+    options.projectId,
+    "projectId",
+    MAX_PROJECT_FILES_IDENTIFIER_CHARACTERS,
+  );
+  if (
+    projectId === "." ||
+    projectId === ".." ||
+    projectId.includes("/") ||
+    projectId.includes("\\")
+  ) {
+    throw new TypeError("projectId must be a single route-safe identifier");
+  }
+  requireBoundedWireString(
+    options.authToken,
+    "authToken",
+    MAX_PROJECT_FILES_AUTH_TOKEN_CHARACTERS,
+  );
+  // Preserve the historical wire contract: an empty branch identifier means
+  // "use the project's default branch" and is omitted from the query string.
+  if (
+    options.branchId !== undefined &&
+    options.branchId !== null &&
+    options.branchId !== ""
+  ) {
+    requireBoundedWireString(
+      options.branchId,
+      "branchId",
+      MAX_PROJECT_FILES_IDENTIFIER_CHARACTERS,
+    );
+  }
+  if (options.pathPrefix !== undefined) {
+    validateProjectFileRequestPath(options.pathPrefix);
+  }
+}
+
+function resolveProjectFilesTimeoutMs(timeoutMs: number | undefined): number {
+  const value = timeoutMs ?? DEFAULT_PROJECT_FILES_TIMEOUT_MS;
+  if (!Number.isSafeInteger(value) || value <= 0 || value > MAX_PROJECT_FILES_TIMEOUT_MS) {
+    throw new RangeError(
+      `timeoutMs must be a positive safe integer no greater than ${MAX_PROJECT_FILES_TIMEOUT_MS}`,
+    );
+  }
+  return value;
+}
+
+function resolveProjectFilesOperationTimeoutMs(timeoutMs: number | undefined): number {
+  const value = timeoutMs ?? DEFAULT_PROJECT_FILES_OPERATION_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    value > MAX_PROJECT_FILES_OPERATION_TIMEOUT_MS
+  ) {
+    throw new RangeError(
+      `operationTimeoutMs must be a positive safe integer no greater than ${MAX_PROJECT_FILES_OPERATION_TIMEOUT_MS}`,
+    );
+  }
+  return value;
+}
+
+type StrictProjectFilesAbortScope = {
+  signal: AbortSignal;
+  abort: (reason: unknown) => void;
+  dispose: () => void;
+};
+
+type StrictProjectFilesRequestScope = StrictProjectFilesAbortScope & {
+  deadline: number;
+};
+
+function createStrictProjectFilesAggregateDeadlineError(): DOMException {
+  return new DOMException(
+    "Project files listing exceeded its aggregate deadline",
+    "TimeoutError",
+  );
+}
+
+function createStrictProjectFilesRequestTimeoutError(): DOMException {
+  return new DOMException("Project files request timed out", "TimeoutError");
+}
+
+function getStrictProjectFilesAbortReason(signal: AbortSignal): unknown {
+  return signal.reason === undefined
+    ? new DOMException("Project files request was aborted", "AbortError")
+    : signal.reason;
+}
+
+function createStrictProjectFilesAbortScope(
+  upstreamSignal: AbortSignal | undefined,
+  timeoutMs: number,
+  createTimeoutReason: () => unknown,
+): StrictProjectFilesAbortScope {
+  if (upstreamSignal?.aborted) {
+    return {
+      signal: upstreamSignal,
+      abort: () => undefined,
+      dispose: () => undefined,
+    };
+  }
+
+  const controller = new AbortController();
+  if (timeoutMs <= 0) {
+    controller.abort(createTimeoutReason());
+    return {
+      signal: controller.signal,
+      abort: () => undefined,
+      dispose: () => undefined,
+    };
+  }
+
+  let disposed = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const abortFromUpstream = () => {
+    if (!controller.signal.aborted && upstreamSignal) {
+      controller.abort(getStrictProjectFilesAbortReason(upstreamSignal));
+    }
+  };
+
+  if (upstreamSignal) {
+    upstreamSignal.addEventListener("abort", abortFromUpstream, { once: true });
+    if (upstreamSignal.aborted) {
+      abortFromUpstream();
+    }
+  }
+  if (!controller.signal.aborted) {
+    timeoutId = setTimeout(() => {
+      controller.abort(createTimeoutReason());
+    }, Math.max(1, Math.ceil(timeoutMs)));
+  }
+
+  return {
+    signal: controller.signal,
+    abort: (reason) => {
+      if (!controller.signal.aborted) {
+        controller.abort(reason);
+      }
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+      upstreamSignal?.removeEventListener("abort", abortFromUpstream);
+    },
+  };
+}
+
+function createStrictProjectFilesOperationScope(
+  callerSignal: AbortSignal | undefined,
+  operationDeadline: number,
+): StrictProjectFilesAbortScope {
+  return createStrictProjectFilesAbortScope(
+    callerSignal,
+    operationDeadline - performance.now(),
+    createStrictProjectFilesAggregateDeadlineError,
+  );
+}
+
+function createStrictProjectFilesRequestScope(
+  upstreamSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): StrictProjectFilesRequestScope {
+  const deadline = performance.now() + timeoutMs;
+  return {
+    ...createStrictProjectFilesAbortScope(
+      upstreamSignal,
+      deadline - performance.now(),
+      createStrictProjectFilesRequestTimeoutError,
+    ),
+    deadline,
+  };
+}
+
+function throwIfStrictProjectFilesRequestExpired(
+  requestScope: StrictProjectFilesRequestScope,
+): void {
+  throwIfStrictProjectFilesAborted(requestScope.signal);
+  if (performance.now() >= requestScope.deadline) {
+    const error = createStrictProjectFilesRequestTimeoutError();
+    requestScope.abort(error);
+    throw error;
+  }
+}
+
+function consumeStrictProjectFilesPromise<TResult>(
+  promise: Promise<TResult>,
+): void {
+  promise.then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
+async function waitForStrictProjectFilesRequestPromise<TResult>(
+  requestScope: StrictProjectFilesRequestScope,
+  createPromise: () => Promise<TResult>,
+  onLateFulfilled?: (value: TResult, reason: unknown) => void,
+): Promise<TResult> {
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+
+  let promise: Promise<TResult>;
+  try {
+    promise = Promise.resolve(createPromise());
+  } catch (error) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw error;
+  }
+
+  const guardedPromise = promise.then((value) => {
+    try {
+      throwIfStrictProjectFilesRequestExpired(requestScope);
+      return value;
+    } catch (error) {
+      try {
+        onLateFulfilled?.(value, error);
+      } catch {
+        // Best-effort cleanup must not replace the deadline or cancellation.
+      }
+      throw error;
+    }
+  });
+
+  try {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+  } catch (error) {
+    consumeStrictProjectFilesPromise(guardedPromise);
+    throw error;
+  }
+
+  let result: TResult;
+  try {
+    result = await waitForStrictProjectFilesAbort(
+      guardedPromise,
+      requestScope.signal,
+    );
+  } catch (error) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw error;
+  }
+
+  try {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return result;
+  } catch (error) {
+    try {
+      onLateFulfilled?.(result, error);
+    } catch {
+      // Best-effort cleanup must not replace the deadline or cancellation.
+    }
+    throw error;
+  }
+}
+
+async function runStrictProjectFilesRequest<TResult>(
+  options: StrictRuntimeProjectFilesClientOptions,
+  upstreamSignal: AbortSignal | undefined,
+  operation: (requestScope: StrictProjectFilesRequestScope) => Promise<TResult>,
+): Promise<TResult> {
+  const requestScope = createStrictProjectFilesRequestScope(
+    upstreamSignal,
+    resolveProjectFilesTimeoutMs(options.timeoutMs),
+  );
+  try {
+    return await waitForStrictProjectFilesRequestPromise(
+      requestScope,
+      () => operation(requestScope),
+    );
+  } catch (error) {
+    requestScope.abort(error);
+    throw error;
+  } finally {
+    requestScope.dispose();
+  }
+}
+
+function throwIfStrictProjectFilesAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw getStrictProjectFilesAbortReason(signal);
+  }
+}
+
+function throwIfStrictProjectFilesOperationExpired(
+  operationScope: StrictProjectFilesAbortScope,
+  operationDeadline: number,
+): void {
+  throwIfStrictProjectFilesAborted(operationScope.signal);
+  if (performance.now() >= operationDeadline) {
+    const error = createStrictProjectFilesAggregateDeadlineError();
+    operationScope.abort(error);
+    throw error;
+  }
+}
+
+async function waitForStrictProjectFilesOperationPromise<TResult>(
+  operationScope: StrictProjectFilesAbortScope,
+  operationDeadline: number,
+  createPromise: () => Promise<TResult>,
+): Promise<TResult> {
+  throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+
+  let promise: Promise<TResult>;
+  try {
+    promise = Promise.resolve(createPromise());
+  } catch (error) {
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+    throw error;
+  }
+
+  const guardedPromise = promise.then((value) => {
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+    return value;
+  });
+
+  try {
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+  } catch (error) {
+    consumeStrictProjectFilesPromise(guardedPromise);
+    throw error;
+  }
+
+  try {
+    const result = await waitForStrictProjectFilesAbort(
+      guardedPromise,
+      operationScope.signal,
+    );
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+    return result;
+  } catch (error) {
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+    throw error;
+  }
+}
+
+function waitForStrictProjectFilesAbort<TResult>(
+  promise: Promise<TResult>,
+  signal: AbortSignal,
+): Promise<TResult> {
+  if (signal.aborted) {
+    promise.then(
+      () => undefined,
+      () => undefined,
+    );
+    return Promise.reject(getStrictProjectFilesAbortReason(signal));
+  }
+
+  return new Promise<TResult>((resolve, reject) => {
+    let settled = false;
+    const settle = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      action();
+    };
+    const onAbort = () => settle(() => reject(getStrictProjectFilesAbortReason(signal)));
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+    promise.then(
+      (value) => settle(() => resolve(value)),
+      (error) => settle(() => reject(error)),
+    );
+  });
+}
+
+function validateStrictRuntimeProjectFilesRequestContext(
+  options: StrictRuntimeProjectFilesRequestContext,
+): void {
+  if (options.signal !== undefined && !(options.signal instanceof AbortSignal)) {
+    throw new TypeError("signal must be an AbortSignal");
+  }
+}
+
+function resolveProjectFilesPageLimit(pageLimit: number | undefined): number {
+  const value = pageLimit ?? DEFAULT_PROJECT_FILES_PAGE_LIMIT;
+  if (!Number.isSafeInteger(value) || value <= 0 || value > MAX_PROJECT_FILES_PAGE_LIMIT) {
+    throw new RangeError(
+      `pageLimit must be a positive safe integer no greater than ${MAX_PROJECT_FILES_PAGE_LIMIT}`,
+    );
+  }
+  return value;
+}
+
+function validateProjectFileRequestPath(path: string): void {
+  const parsed = getStrictRuntimeProjectFilePathSchema().safeParse(path);
+  if (!parsed.success) {
+    throw new RangeError(
+      `path must be a canonical project-relative path of 1-${MAX_PROJECT_FILE_PATH_CHARACTERS} well-formed UTF-16 characters without controls`,
+    );
   }
 }
 
@@ -624,6 +1588,178 @@ function createProjectFilesAccessDeniedError(
   const message = "Access denied to project files API";
   return options.createAccessDeniedError?.(statusCode, message) ??
     new RuntimeProjectFilesApiAuthError(statusCode, message);
+}
+
+class RuntimeProjectFilesProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeProjectFilesProtocolError";
+  }
+}
+
+function cancelResponseBodyWithoutWaiting(response: Response, reason?: unknown): void {
+  try {
+    void response.body?.cancel(reason).catch(() => undefined);
+  } catch {
+    // Best-effort cleanup; preserve the primary protocol result.
+  }
+}
+
+function cancelReaderWithoutWaiting(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason?: unknown,
+): void {
+  let cancellation: Promise<void> | undefined;
+  try {
+    cancellation = reader.cancel(reason);
+  } catch {
+    // Best-effort cleanup; preserve the primary protocol error.
+  }
+  try {
+    reader.releaseLock();
+  } catch {
+    // Best-effort cleanup; preserve the primary protocol error.
+  }
+  if (cancellation) {
+    void cancellation.catch(() => undefined);
+  }
+}
+
+function parseDeclaredContentLength(response: Response, maxBytes: number, label: string): void {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength === null) {
+    return;
+  }
+  if (!/^\d+$/.test(contentLength)) {
+    cancelResponseBodyWithoutWaiting(response);
+    throw new RuntimeProjectFilesProtocolError(`${label} had an invalid Content-Length header`);
+  }
+  const declaredBytes = Number(contentLength);
+  if (!Number.isSafeInteger(declaredBytes) || declaredBytes > maxBytes) {
+    cancelResponseBodyWithoutWaiting(response);
+    throw new RuntimeProjectFilesProtocolError(`${label} exceeds ${maxBytes} bytes`);
+  }
+}
+
+async function readBoundedResponseText(
+  response: Response,
+  maxBytes: number,
+  label: string,
+  requestScope: StrictProjectFilesRequestScope,
+  listingBudget?: RuntimeProjectFileListingBudget,
+): Promise<string> {
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+  parseDeclaredContentLength(response, maxBytes, label);
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return "";
+  }
+
+  let bytes = new Uint8Array(0);
+  let byteLength = 0;
+  let completed = false;
+  let failure: unknown;
+
+  try {
+    while (true) {
+      const { done, value } = await waitForStrictProjectFilesRequestPromise(
+        requestScope,
+        () => reader.read(),
+      );
+      if (done) {
+        completed = true;
+        break;
+      }
+      listingBudget?.consumeBytes(value.byteLength);
+      if (value.byteLength > maxBytes - byteLength) {
+        throw new RuntimeProjectFilesProtocolError(`${label} exceeds ${maxBytes} bytes`);
+      }
+
+      const nextByteLength = byteLength + value.byteLength;
+      if (bytes.byteLength < nextByteLength) {
+        let capacity = Math.min(maxBytes, Math.max(1_024, bytes.byteLength * 2));
+        while (capacity < nextByteLength) {
+          capacity = Math.min(maxBytes, capacity * 2);
+        }
+        const grown = new Uint8Array(capacity);
+        grown.set(bytes.subarray(0, byteLength));
+        bytes = grown;
+      }
+      bytes.set(value, byteLength);
+      byteLength = nextByteLength;
+    }
+  } catch (error) {
+    failure = error;
+    throw error;
+  } finally {
+    if (!completed) {
+      cancelReaderWithoutWaiting(reader, failure);
+    } else {
+      reader.releaseLock();
+    }
+  }
+
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(
+      bytes.subarray(0, byteLength),
+    );
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return text;
+  } catch {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw new RuntimeProjectFilesProtocolError(`${label} was not valid UTF-8`);
+  }
+}
+
+async function readBoundedJsonResponse(
+  response: Response,
+  maxBytes: number,
+  label: string,
+  requestScope: StrictProjectFilesRequestScope,
+  listingBudget?: RuntimeProjectFileListingBudget,
+): Promise<unknown> {
+  const text = await readBoundedResponseText(
+    response,
+    maxBytes,
+    label,
+    requestScope,
+    listingBudget,
+  );
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+  try {
+    const value = JSON.parse(text);
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return value;
+  } catch {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw new RuntimeProjectFilesProtocolError(`${label} was not valid JSON`);
+  }
+}
+
+function truncateApiErrorMessage(message: string): string {
+  if (message.length <= MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS) {
+    return message;
+  }
+  const suffix = "...[truncated]";
+  return `${message.slice(0, MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS - suffix.length)}${suffix}`;
+}
+
+function isRequestCancellationError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (typeof current === "object" && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const errorLike = current as { name?: unknown; cause?: unknown };
+    if (errorLike.name === "AbortError" || errorLike.name === "TimeoutError") {
+      return true;
+    }
+    current = errorLike.cause;
+  }
+  return false;
 }
 
 async function readApiErrorMessage(response: Response): Promise<string> {
@@ -650,10 +1786,133 @@ async function readApiErrorMessage(response: Response): Promise<string> {
   return body;
 }
 
+async function readStrictApiErrorMessage(
+  response: Response,
+  requestScope: StrictProjectFilesRequestScope,
+  listingBudget?: RuntimeProjectFileListingBudget,
+): Promise<string> {
+  let body: string;
+  try {
+    body = await readBoundedResponseText(
+      response,
+      MAX_PROJECT_FILES_ERROR_BODY_BYTES,
+      "Project files API error response",
+      requestScope,
+      listingBudget,
+    );
+  } catch (error) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    if (isRequestCancellationError(error)) {
+      throw error;
+    }
+    if (error instanceof RangeError) {
+      throw error;
+    }
+    return error instanceof Error
+      ? error.message
+      : response.statusText || `HTTP ${response.status}`;
+  }
+  if (!body.trim()) {
+    return response.statusText || `HTTP ${response.status}`;
+  }
+
+  let parsedJson: { success: true; data: { detail?: string; message?: string; error?: string } } | {
+    success: false;
+  };
+  try {
+    const jsonValue = JSON.parse(body);
+    const result = getStrictApiErrorBodySchema().safeParse(jsonValue);
+    parsedJson = result.success ? { success: true, data: result.data } : { success: false };
+  } catch {
+    parsedJson = { success: false };
+  }
+
+  if (parsedJson.success) {
+    return truncateApiErrorMessage(
+      parsedJson.data.detail ?? parsedJson.data.message ?? parsedJson.data.error ?? body,
+    );
+  }
+
+  return truncateApiErrorMessage(body);
+}
+
 function traceProjectFilesRequest<T>(
   options: RuntimeProjectFilesClientOptions,
   name: string,
   fn: () => Promise<T>,
 ): Promise<T> {
   return options.trace ? options.trace(name, fn) : fn();
+}
+
+async function traceStrictProjectFilesRequest<T>(
+  options: StrictRuntimeProjectFilesClientOptions,
+  name: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const trace = options.trace;
+  if (!trace) {
+    return await fn();
+  }
+
+  let traceSettled = false;
+  let operationInvoked = false;
+  let operationPromise: Promise<T> | undefined;
+  let invocationError: TypeError | undefined;
+  const rejectInvocation = (error: TypeError): Promise<T> => {
+    const promise = Promise.reject<T>(error);
+    consumeStrictProjectFilesPromise(promise);
+    return promise;
+  };
+  const invokeOperation = (): Promise<T> => {
+    if (traceSettled) {
+      return rejectInvocation(
+        new TypeError("trace invoked the project files operation after settling"),
+      );
+    }
+    if (operationInvoked) {
+      invocationError ??= new TypeError(
+        "trace must invoke the project files operation exactly once",
+      );
+      return rejectInvocation(invocationError);
+    }
+    operationInvoked = true;
+    try {
+      operationPromise = Promise.resolve(fn());
+    } catch (error) {
+      operationPromise = Promise.reject(error);
+    }
+    consumeStrictProjectFilesPromise(operationPromise);
+    return operationPromise;
+  };
+
+  let tracePromise: Promise<T>;
+  try {
+    tracePromise = Promise.resolve(trace(name, invokeOperation));
+  } catch (error) {
+    traceSettled = true;
+    if (operationPromise) {
+      consumeStrictProjectFilesPromise(operationPromise);
+    }
+    throw error;
+  }
+
+  try {
+    await tracePromise;
+  } catch (error) {
+    traceSettled = true;
+    if (operationPromise) {
+      consumeStrictProjectFilesPromise(operationPromise);
+    }
+    throw error;
+  }
+
+  traceSettled = true;
+  if (!operationInvoked || !operationPromise) {
+    throw new TypeError("trace must invoke the project files operation exactly once");
+  }
+  const result = await operationPromise;
+  if (invocationError) {
+    throw invocationError;
+  }
+  return result;
 }

--- a/src/agent/runtime/project-skill-catalog.test.ts
+++ b/src/agent/runtime/project-skill-catalog.test.ts
@@ -22,8 +22,10 @@ import {
   getRuntimeProjectSkillCatalog,
   loadRuntimeBuiltinSkillCatalog,
 } from "./project-skill-catalog.ts";
+import { createStrictRuntimeProjectFilesClient } from "./project-files-client.ts";
 import type {
   RuntimeGetProjectFileOptions,
+  RuntimeProjectFile,
   RuntimeProjectFileListItem,
   RuntimeProjectFilesApiOptions,
 } from "./project-files-client.ts";
@@ -35,15 +37,12 @@ const PROJECT_CONTEXT = {
   branchId: "branch-1",
 };
 
-async function withPollutedDescriptorPrototypeValue<T>(
-  value: unknown,
+async function withPollutedDescriptorPrototype<T>(
+  descriptor: PropertyDescriptor,
   fn: () => Promise<T>,
 ): Promise<T> {
   const original = Object.getOwnPropertyDescriptor(Object.prototype, "value");
-  Object.defineProperty(Object.prototype, "value", {
-    configurable: true,
-    value,
-  });
+  Object.defineProperty(Object.prototype, "value", descriptor);
   try {
     return await fn();
   } finally {
@@ -408,6 +407,44 @@ Deno.test("project catalog forwards one cancellation signal through listing and 
     timeouts.every((timeout) => typeof timeout === "number" && timeout > 0 && timeout <= 1_000),
     true,
   );
+});
+
+Deno.test("project catalog cancellation aborts strict hosted listing transport", async () => {
+  const controller = new AbortController();
+  const cancellation = new DOMException("catalog caller stopped", "AbortError");
+  let fetchSignal: AbortSignal | undefined;
+  let resolveFetchStarted!: () => void;
+  const fetchStarted = new Promise<void>((resolve) => {
+    resolveFetchStarted = resolve;
+  });
+  const client = createStrictRuntimeProjectFilesClient({
+    apiUrl: "https://api.test",
+    operationTimeoutMs: 1_000,
+    timeoutMs: 1_000,
+    fetch: (_url, init) => {
+      fetchSignal = init.signal as AbortSignal;
+      resolveFetchStarted();
+      return new Promise(() => undefined);
+    },
+  });
+  const request = getRuntimeProjectSkillCatalog({
+    ...PROJECT_CONTEXT,
+    builtinSkills: [],
+    operationBudget: createSkillOperationBudget({
+      abortSignal: controller.signal,
+      timeoutMs: 1_000,
+    }),
+    getProjectFiles: client.getProjectFiles,
+    getProjectFile: client.getProjectFile,
+  });
+
+  await fetchStarted;
+  controller.abort(cancellation);
+  const error = await assertRejects(() => request);
+
+  assertEquals(error, cancellation);
+  assertEquals(fetchSignal?.aborted, true);
+  assertEquals(fetchSignal?.reason, cancellation);
 });
 
 Deno.test("project catalog snapshots builtin definitions before awaiting project discovery", async () => {
@@ -1154,8 +1191,8 @@ Deno.test("project catalog rejects accessor entries despite inherited descriptor
     },
   });
 
-  await withPollutedDescriptorPrototypeValue(
-    { path: "skills/injected/SKILL.md" },
+  await withPollutedDescriptorPrototype(
+    { configurable: true, value: { path: "skills/injected/SKILL.md" } },
     async () => {
       await assertRejects(
         () =>
@@ -1176,4 +1213,93 @@ Deno.test("project catalog rejects accessor entries despite inherited descriptor
 
   assertEquals(getterReads, 0);
   assertEquals(fileFetches, 0);
+});
+
+Deno.test("project catalog rejects accessor file responses without inherited getter execution", async () => {
+  const skillPath = "skills/accessor-response/SKILL.md";
+  let responseGetterReads = 0;
+  let inheritedGetterReads = 0;
+  const response = Object.create(null) as RuntimeProjectFile;
+  Object.defineProperties(response, {
+    path: {
+      configurable: true,
+      get() {
+        responseGetterReads += 1;
+        return skillPath;
+      },
+    },
+    content: {
+      configurable: true,
+      get() {
+        responseGetterReads += 1;
+        return "---\nname: accessor-response\ndescription: Accessor response\n---\nBody";
+      },
+    },
+  });
+
+  await withPollutedDescriptorPrototype(
+    {
+      configurable: true,
+      get() {
+        inheritedGetterReads += 1;
+        throw new Error("inherited descriptor getter must not execute");
+      },
+    },
+    async () => {
+      await assertRejects(
+        () =>
+          getRuntimeProjectSkillCatalog({
+            ...PROJECT_CONTEXT,
+            builtinSkills: [],
+            getProjectFiles: async (options) =>
+              options.pathPrefix === "skills" ? [{ path: skillPath }] : [],
+            getProjectFile: async () => response,
+          }),
+        TypeError,
+        "Project skill response.path must be a data property",
+      );
+    },
+  );
+
+  assertEquals(responseGetterReads, 0);
+  assertEquals(inheritedGetterReads, 0);
+});
+
+Deno.test("project catalog rejects Proxy file responses without invoking traps", async () => {
+  const skillPath = "skills/proxy-response/SKILL.md";
+  let trapCalls = 0;
+  const response = new Proxy<RuntimeProjectFile>(
+    {
+      path: skillPath,
+      content: "---\nname: proxy-response\ndescription: Proxy response\n---\nBody",
+    },
+    {
+      getOwnPropertyDescriptor() {
+        trapCalls += 1;
+        throw new Error("descriptor trap must not execute");
+      },
+      getPrototypeOf() {
+        trapCalls += 1;
+        throw new Error("prototype trap must not execute");
+      },
+      ownKeys() {
+        trapCalls += 1;
+        throw new Error("ownKeys trap must not execute");
+      },
+    },
+  );
+
+  await assertRejects(
+    () =>
+      getRuntimeProjectSkillCatalog({
+        ...PROJECT_CONTEXT,
+        builtinSkills: [],
+        getProjectFiles: async (options) =>
+          options.pathPrefix === "skills" ? [{ path: skillPath }] : [],
+        getProjectFile: async () => response,
+      }),
+    TypeError,
+    "Project skill response must not be a Proxy",
+  );
+  assertEquals(trapCalls, 0);
 });

--- a/src/agent/runtime/project-skill-catalog.test.ts
+++ b/src/agent/runtime/project-skill-catalog.test.ts
@@ -3,11 +3,20 @@ import "#veryfront/skill/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects, assertThrows } from "@std/assert";
 import { resolve } from "node:path";
 import {
+  SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS,
+  SKILL_CATALOG_MAX_METADATA_CHARACTERS,
+  SKILL_CATALOG_MAX_PATH_ENTRIES,
+  SKILL_CATALOG_MAX_SKILLS,
+  SKILL_DOCUMENT_MAX_CHARACTERS,
   SKILL_LOADABLE_REFERENCE_MAX_ENTRIES,
   SKILL_STEERING_PATH_MAX_ENTRIES,
   SKILL_SUBDIR_MAX_ENTRIES,
   SKILL_TEXT_FILE_MAX_BYTES,
 } from "#veryfront/skill/limits.ts";
+import {
+  createSkillOperationBudget,
+  SkillOperationTimeoutError,
+} from "#veryfront/skill/operation-budget.ts";
 import {
   getRuntimeProjectInstructions,
   getRuntimeProjectSkillCatalog,
@@ -19,12 +28,6 @@ import type {
   RuntimeProjectFilesApiOptions,
 } from "./project-files-client.ts";
 import type { RuntimeSkillDefinition } from "./skill-metadata.ts";
-import {
-  SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS,
-  SKILL_CATALOG_MAX_METADATA_CHARACTERS,
-  SKILL_CATALOG_MAX_PATH_ENTRIES,
-  SKILL_CATALOG_MAX_SKILLS,
-} from "#veryfront/skill/limits.ts";
 
 const PROJECT_CONTEXT = {
   projectId: "project-1",
@@ -181,11 +184,12 @@ Deno.test("builtin directory skills take precedence over flat files with the sam
   });
 });
 
-Deno.test("built-in catalog rejects work beyond the cumulative skill limit", () => {
+Deno.test("built-in catalogs enforce the cumulative retained skill limit", () => {
   withTempDir((rootDir) => {
     for (let index = 0; index <= SKILL_CATALOG_MAX_SKILLS; index += 1) {
       Deno.writeTextFileSync(resolve(rootDir, `skill-${index}.md`), "# Skill");
     }
+
     assertThrows(
       () => loadRuntimeBuiltinSkillCatalog({ skillsDir: rootDir }),
       RangeError,
@@ -322,7 +326,7 @@ Deno.test("getRuntimeProjectInstructions returns the first available instruction
     {
       ...PROJECT_CONTEXT,
       path: "AGENTS.md",
-      maximumContentCharacters: 1_048_576,
+      maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
     },
   ]);
 });
@@ -355,19 +359,55 @@ Deno.test("getRuntimeProjectInstructions rejects untrusted custom loader respons
   );
 });
 
-Deno.test("getRuntimeProjectSkillCatalog returns builtin skills when project files are unavailable", async () => {
-  const builtinSkills = [
-    {
-      id: "plan",
-      name: "plan",
-      description: "Plan",
-      instructions: "# Plan",
-      allowedTools: [],
-    },
-  ];
-  const { catalog } = createSkillCatalog({ builtinSkills, paths: null });
+Deno.test("project catalog deadlines settle non-cooperative listing clients", async () => {
+  await assertRejects(
+    () =>
+      getRuntimeProjectSkillCatalog({
+        ...PROJECT_CONTEXT,
+        builtinSkills: [],
+        operationBudget: createSkillOperationBudget({ timeoutMs: 5 }),
+        getProjectFiles: () => new Promise(() => {}),
+        getProjectFile: () => Promise.resolve(null),
+      }),
+    SkillOperationTimeoutError,
+    "timed out",
+  );
+});
 
-  assertEquals(await catalog(), builtinSkills);
+Deno.test("project catalog forwards one cancellation signal through listing and reads", async () => {
+  const controller = new AbortController();
+  const signals: Array<AbortSignal | undefined> = [];
+  const timeouts: Array<number | undefined> = [];
+  const skillPath = "skills/research/SKILL.md";
+
+  const skills = await getRuntimeProjectSkillCatalog({
+    ...PROJECT_CONTEXT,
+    builtinSkills: [],
+    operationBudget: createSkillOperationBudget({
+      abortSignal: controller.signal,
+      timeoutMs: 1_000,
+    }),
+    getProjectFiles: (options) => {
+      signals.push(options.abortSignal);
+      timeouts.push(options.timeoutMs);
+      return Promise.resolve(options.pathPrefix === "skills" ? [{ path: skillPath }] : []);
+    },
+    getProjectFile: (options) => {
+      signals.push(options.abortSignal);
+      timeouts.push(options.timeoutMs);
+      return Promise.resolve({
+        path: skillPath,
+        content: "---\nname: research\ndescription: Research\n---\nBody",
+      });
+    },
+  });
+
+  assertEquals(skills.map((skill) => skill.id), ["research"]);
+  assertEquals(signals.every((signal) => signal === controller.signal), true);
+  assertEquals(
+    timeouts.every((timeout) => typeof timeout === "number" && timeout > 0 && timeout <= 1_000),
+    true,
+  );
 });
 
 Deno.test("project catalog snapshots builtin definitions before awaiting project discovery", async () => {
@@ -543,6 +583,47 @@ Deno.test("project skill catalog rejects oversized discovery before scheduling f
   assertEquals(fileReads, 0);
 });
 
+Deno.test("project catalogs reject documents beyond the aggregate retained budget", async () => {
+  const documentCount = SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS /
+      SKILL_DOCUMENT_MAX_CHARACTERS +
+    1;
+  const paths = Array.from(
+    { length: documentCount },
+    (_unused, index) => `skills/skill-${index}/SKILL.md`,
+  );
+  const maximumDocument = "x".repeat(SKILL_DOCUMENT_MAX_CHARACTERS);
+
+  await assertRejects(
+    () =>
+      getRuntimeProjectSkillCatalog({
+        ...PROJECT_CONTEXT,
+        builtinSkills: [],
+        getProjectFiles: (options) =>
+          Promise.resolve(
+            options.pathPrefix === "skills" ? paths.map((path) => ({ path })) : [],
+          ),
+        getProjectFile: ({ path }) => Promise.resolve({ path, content: maximumDocument }),
+      }),
+    RangeError,
+    `${SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS} characters`,
+  );
+});
+
+Deno.test("getRuntimeProjectSkillCatalog returns builtin skills when project files are unavailable", async () => {
+  const builtinSkills = [
+    {
+      id: "plan",
+      name: "plan",
+      description: "Plan",
+      instructions: "# Plan",
+      allowedTools: [],
+    },
+  ];
+  const { catalog } = createSkillCatalog({ builtinSkills, paths: null });
+
+  assertEquals(await catalog(), builtinSkills);
+});
+
 Deno.test("getRuntimeProjectSkillCatalog parses project directory skills and references", async () => {
   const { catalog, filesCalls, fileCalls } = createSkillCatalog({
     paths: [
@@ -573,19 +654,27 @@ Deno.test("getRuntimeProjectSkillCatalog parses project directory skills and ref
     "resources/schema.json",
   ]);
   assertEquals(filesCalls.map(withoutRuntimeBudgetFields), [
-    { ...PROJECT_CONTEXT, pathPrefix: "skills", maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES },
+    {
+      ...PROJECT_CONTEXT,
+      pathPrefix: "skills",
+      maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES,
+    },
     {
       ...PROJECT_CONTEXT,
       pathPrefix: ".veryfront/skills",
       maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES,
     },
-    { ...PROJECT_CONTEXT, pathPrefix: "agents", maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES },
+    {
+      ...PROJECT_CONTEXT,
+      pathPrefix: "agents",
+      maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES,
+    },
   ]);
   assertEquals(fileCalls.map(withoutRuntimeBudgetFields), [
     {
       ...PROJECT_CONTEXT,
       path: "skills/research/SKILL.md",
-      maximumContentCharacters: 1_048_576,
+      maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
     },
   ]);
 });
@@ -965,7 +1054,7 @@ Deno.test("project skill catalog stops scheduling after a fetch failure and awai
   assertEquals(fileFetches, fetchesAtRejection);
 });
 
-Deno.test("project catalog admits 3000 readable files and rejects 3001", async () => {
+Deno.test("project catalog enforces per-directory bounds and accepts the aggregate readable budget", async () => {
   const skillPath = "skills/research/SKILL.md";
   const readablePaths = ["references", "resources", "assets"].flatMap((directory) =>
     Array.from(
@@ -975,7 +1064,7 @@ Deno.test("project catalog admits 3000 readable files and rejects 3001", async (
   );
   const skillContent = "---\nname: research\ndescription: Research\n---\nBody";
 
-  const catalog = await getRuntimeProjectSkillCatalog({
+  const skills = await getRuntimeProjectSkillCatalog({
     ...PROJECT_CONTEXT,
     builtinSkills: [],
     getProjectFiles: async () => [
@@ -984,7 +1073,7 @@ Deno.test("project catalog admits 3000 readable files and rejects 3001", async (
     ],
     getProjectFile: async ({ path }) => path === skillPath ? { path, content: skillContent } : null,
   });
-  assertEquals(catalog[0]?.references?.length, SKILL_LOADABLE_REFERENCE_MAX_ENTRIES);
+  assertEquals(skills[0]?.references?.length, SKILL_LOADABLE_REFERENCE_MAX_ENTRIES);
 
   await assertRejects(
     () =>
@@ -993,15 +1082,41 @@ Deno.test("project catalog admits 3000 readable files and rejects 3001", async (
         builtinSkills: [],
         getProjectFiles: async () => [
           { path: skillPath },
-          ...readablePaths.map((path) => ({ path })),
-          { path: `skills/research/assets/${SKILL_SUBDIR_MAX_ENTRIES}.txt` },
+          ...Array.from(
+            { length: SKILL_SUBDIR_MAX_ENTRIES + 1 },
+            (_unused, index) => ({ path: `skills/research/resources/${index}.txt` }),
+          ),
         ],
         getProjectFile: async ({ path }) =>
           path === skillPath ? { path, content: skillContent } : null,
       }),
     RangeError,
-    `at most ${SKILL_SUBDIR_MAX_ENTRIES} entries`,
+    "resources/",
   );
+});
+
+Deno.test("project catalog rejects paths beyond its aggregate retained budget before reads", async () => {
+  let fileReads = 0;
+  const paths = Array.from(
+    { length: SKILL_CATALOG_MAX_PATH_ENTRIES + 1 },
+    (_unused, index) => ({ path: `skills/research/references/${index}.txt` }),
+  );
+
+  await assertRejects(
+    () =>
+      getRuntimeProjectSkillCatalog({
+        ...PROJECT_CONTEXT,
+        builtinSkills: [],
+        getProjectFiles: (options) => Promise.resolve(options.pathPrefix === "skills" ? paths : []),
+        getProjectFile: () => {
+          fileReads += 1;
+          return Promise.resolve(null);
+        },
+      }),
+    RangeError,
+    `${SKILL_CATALOG_MAX_PATH_ENTRIES} entries`,
+  );
+  assertEquals(fileReads, 0);
 });
 
 Deno.test("project steering path lists are bounded before lookup", async () => {

--- a/src/agent/runtime/project-skill-catalog.ts
+++ b/src/agent/runtime/project-skill-catalog.ts
@@ -43,8 +43,11 @@ import {
 } from "#veryfront/skill/limits.ts";
 import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { readOwnDataProperty, snapshotOwnDataPropertyArray } from "./data-property-descriptor.ts";
+import type { SkillDocumentParserProvider } from "#veryfront/extensions/parser/skill-document-parser.ts";
+import { SkillIdAdmission } from "#veryfront/skill/id-admission.ts";
+import { SKILL_READABLE_DIRS } from "#veryfront/skill/types.ts";
+import { utf8ByteLength } from "#veryfront/utils/utf8-byte-length.ts";
 
-const utf8Encoder = new TextEncoder();
 const ArrayIsArray = Array.isArray;
 const NumberIsFinite = Number.isFinite;
 const NumberIsSafeInteger = Number.isSafeInteger;
@@ -52,6 +55,8 @@ const ObjectDefineProperty = Object.defineProperty;
 const ObjectFreeze = Object.freeze;
 const ObjectKeys = Object.keys;
 const ReflectApply = Reflect.apply;
+
+const PROJECT_SKILL_FETCH_CONCURRENCY = 16;
 
 class RuntimeSkillCatalogBudget {
   private documentCharacters = 0;
@@ -62,19 +67,20 @@ class RuntimeSkillCatalogBudget {
 
   retainDocument(content: string): void {
     const characters = this.documentCharacters + content.length;
-    const utf8Bytes = this.documentUtf8Bytes + utf8Encoder.encode(content).byteLength;
     if (characters > SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS) {
       throw new RangeError(
         `Skill catalog documents may contain at most ${SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS} characters`,
       );
     }
-    if (utf8Bytes > SKILL_CATALOG_MAX_DOCUMENT_UTF8_BYTES) {
+    const remainingUtf8Bytes = SKILL_CATALOG_MAX_DOCUMENT_UTF8_BYTES - this.documentUtf8Bytes;
+    const addedUtf8Bytes = utf8ByteLength(content, remainingUtf8Bytes);
+    if (addedUtf8Bytes > remainingUtf8Bytes) {
       throw new RangeError(
         `Skill catalog documents may contain at most ${SKILL_CATALOG_MAX_DOCUMENT_UTF8_BYTES} UTF-8 bytes`,
       );
     }
     this.documentCharacters = characters;
-    this.documentUtf8Bytes = utf8Bytes;
+    this.documentUtf8Bytes += addedUtf8Bytes;
   }
 
   retainPath(): void {
@@ -130,11 +136,6 @@ function retainExistingDefinition(
   for (const _reference of definition.references ?? []) budget.retainPath();
   budget.retainDefinition(definition);
 }
-import { SKILL_READABLE_DIRS } from "#veryfront/skill/types.ts";
-import { SkillIdAdmission } from "#veryfront/skill/id-admission.ts";
-import type { SkillDocumentParserProvider } from "#veryfront/extensions/parser/skill-document-parser.ts";
-
-const PROJECT_SKILL_FETCH_CONCURRENCY = 16;
 
 /** Public API contract for runtime project steering lookup. */
 export type RuntimeProjectSteeringLookup = {
@@ -498,6 +499,67 @@ function createCatalogBudget(existing?: SkillOperationBudget): SkillOperationBud
   return existing ?? createSkillOperationBudget({ timeoutMs: SKILL_FILE_OPERATION_TIMEOUT_MS });
 }
 
+async function fetchProjectSkillDocument(
+  input:
+    & RuntimeProjectSteeringLookup
+    & Pick<RuntimeProjectSkillCatalogOptions, "getProjectFile" | "logger">,
+  requestedPath: string,
+  operationBudget: SkillOperationBudget,
+  catalogBudget: RuntimeSkillCatalogBudget,
+): Promise<RuntimeProjectFile | null> {
+  const value = await operationBudget.run((abortSignal) =>
+    input.getProjectFile({
+      projectId: input.projectId,
+      authToken: input.authToken,
+      branchId: input.branchId,
+      path: requestedPath,
+      maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
+      abortSignal,
+      timeoutMs: operationBudget.remainingMs(),
+    })
+  );
+  if (value === null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Project skill response must be an object or null");
+  }
+
+  const pathDescriptor = Object.getOwnPropertyDescriptor(value, "path");
+  const contentDescriptor = Object.getOwnPropertyDescriptor(value, "content");
+  const responsePath = pathDescriptor && "value" in pathDescriptor
+    ? pathDescriptor.value
+    : undefined;
+  const content = contentDescriptor && "value" in contentDescriptor
+    ? contentDescriptor.value
+    : undefined;
+  if (!isRuntimeProjectFilePath(responsePath)) {
+    input.logger?.error?.("Project skill response had an invalid path; skipping skill", {
+      expectedPath: requestedPath,
+    });
+    return null;
+  }
+  if (responsePath !== requestedPath) {
+    input.logger?.error?.(
+      "Project skill response path did not match its request; skipping skill",
+      { expectedPath: requestedPath, responsePath },
+    );
+    return null;
+  }
+  if (content === "") return null;
+  if (!isRuntimeProjectFileContent(content)) {
+    input.logger?.error?.("Project skill content exceeded its budget; skipping skill", {
+      path: requestedPath,
+    });
+    return null;
+  }
+
+  assertCatalogContent(content, "Skill document");
+  // Charge the shared catalog before returning the document to the concurrent
+  // result set. This caps retained completed reads to the aggregate budget;
+  // only the fixed-size worker set can still be in flight.
+  catalogBudget.retainDocument(content);
+  return Object.freeze({ path: responsePath, content });
+}
+
 /** Loads runtime builtin skill catalog. */
 export function loadRuntimeBuiltinSkillCatalog(input: {
   skillsDir: string;
@@ -620,15 +682,11 @@ export async function getRuntimeProjectSkillCatalog(
         })
       ),
     );
-    if (!files) {
-      continue;
-    }
+    if (!files) continue;
     hasAvailableListing = true;
     for (const file of files) {
-      // Do not trust custom clients to honor the server-side catalog filter.
-      if (!file.path.startsWith(prefixWithSlash)) {
-        continue;
-      }
+      // Custom clients may ignore the server-side catalog filter.
+      if (!file.path.startsWith(prefixWithSlash)) continue;
       if (!filesByPath.has(file.path)) catalogBudget.retainPath();
       filesByPath.set(file.path, file);
     }
@@ -680,44 +738,16 @@ export async function getRuntimeProjectSkillCatalog(
     const skillFiles = await mapWithConcurrency(
       candidates,
       PROJECT_SKILL_FETCH_CONCURRENCY,
-      ({ path }) =>
-        budget.run((abortSignal) =>
-          input.getProjectFile({
-            projectId: input.projectId,
-            authToken: input.authToken,
-            branchId: input.branchId,
-            path,
-            maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
-            abortSignal,
-            timeoutMs: budget.remainingMs(),
-          })
-        ),
+      ({ path }) => fetchProjectSkillDocument(input, path, budget, catalogBudget),
     );
 
     for (let index = 0; index < skillFiles.length; index += 1) {
+      budget.throwIfTerminated();
       const candidate = candidates[index]!;
       const file = skillFiles[index];
       if (!file?.content) {
         continue;
       }
-      if (file.path !== candidate.path) {
-        input.logger?.error?.(
-          "Project skill response path did not match its request; skipping skill",
-          {
-            expectedPath: candidate.path,
-            responsePath: file.path,
-          },
-        );
-        continue;
-      }
-      if (!isRuntimeProjectFileContent(file.content)) {
-        input.logger?.error?.("Project skill content exceeded its budget; skipping skill", {
-          path: candidate.path,
-        });
-        continue;
-      }
-      assertCatalogContent(file.content, "Skill document");
-      catalogBudget.retainDocument(file.content);
 
       const definition = candidate.isFlat
         ? buildLegacyRuntimeFlatSkillDefinition({
@@ -791,44 +821,16 @@ export async function getRuntimeProjectSkillCatalog(
     const colocatedFiles = await mapWithConcurrency(
       colocatedCandidates,
       PROJECT_SKILL_FETCH_CONCURRENCY,
-      ({ path }) =>
-        budget.run((abortSignal) =>
-          input.getProjectFile({
-            projectId: input.projectId,
-            authToken: input.authToken,
-            branchId: input.branchId,
-            path,
-            maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
-            abortSignal,
-            timeoutMs: budget.remainingMs(),
-          })
-        ),
+      ({ path }) => fetchProjectSkillDocument(input, path, budget, catalogBudget),
     );
 
     for (let index = 0; index < colocatedFiles.length; index += 1) {
+      budget.throwIfTerminated();
       const candidate = colocatedCandidates[index]!;
       const file = colocatedFiles[index];
       if (!file?.content) {
         continue;
       }
-      if (file.path !== candidate.path) {
-        input.logger?.error?.(
-          "Project skill response path did not match its request; skipping skill",
-          {
-            expectedPath: candidate.path,
-            responsePath: file.path,
-          },
-        );
-        continue;
-      }
-      if (!isRuntimeProjectFileContent(file.content)) {
-        input.logger?.error?.("Project skill content exceeded its budget; skipping skill", {
-          path: candidate.path,
-        });
-        continue;
-      }
-      assertCatalogContent(file.content, "Colocated skill document");
-      catalogBudget.retainDocument(file.content);
 
       const definition = buildRuntimeDirectorySkillDefinition({
         id: candidate.identity.id,
@@ -861,6 +863,7 @@ export async function getRuntimeProjectSkillCatalog(
     mergedSkillsById.set(skill.id, skill);
   }
 
+  budget.throwIfTerminated();
   return sortSkillsById(mergedSkillsById.values());
 }
 

--- a/src/agent/runtime/project-skill-catalog.ts
+++ b/src/agent/runtime/project-skill-catalog.ts
@@ -519,18 +519,12 @@ async function fetchProjectSkillDocument(
     })
   );
   if (value === null) return null;
-  if (typeof value !== "object" || Array.isArray(value)) {
+  if (typeof value !== "object" || ArrayIsArray(value)) {
     throw new TypeError("Project skill response must be an object or null");
   }
 
-  const pathDescriptor = Object.getOwnPropertyDescriptor(value, "path");
-  const contentDescriptor = Object.getOwnPropertyDescriptor(value, "content");
-  const responsePath = pathDescriptor && "value" in pathDescriptor
-    ? pathDescriptor.value
-    : undefined;
-  const content = contentDescriptor && "value" in contentDescriptor
-    ? contentDescriptor.value
-    : undefined;
+  const responsePath = readOwnDataProperty(value, "path", "Project skill response");
+  const content = readOwnDataProperty(value, "content", "Project skill response");
   if (!isRuntimeProjectFilePath(responsePath)) {
     input.logger?.error?.("Project skill response had an invalid path; skipping skill", {
       expectedPath: requestedPath,

--- a/src/agent/runtime/project-skill-loader.ts
+++ b/src/agent/runtime/project-skill-loader.ts
@@ -84,11 +84,17 @@ export type RuntimeProjectSkillLoaderLogger = {
   warn?: (message: string, metadata?: Record<string, unknown>) => void;
 };
 
+type RuntimeProjectSkillReadContext = {
+  budget: SkillOperationBudget;
+};
+
 /** Options accepted by runtime project skill loader. */
 export type RuntimeProjectSkillLoaderOptions = {
-  getProjectFile: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
+  getProjectFile: (
+    options: RuntimeGetProjectFileOptions & { signal?: AbortSignal },
+  ) => Promise<RuntimeProjectFile | null>;
   getProjectFiles: (
-    options: RuntimeProjectFilesApiOptions,
+    options: RuntimeProjectFilesApiOptions & { signal?: AbortSignal },
   ) => Promise<RuntimeProjectFileListItem[]>;
   steeringPaths?: Pick<ProjectSteeringPaths, "skills">;
   isAccessDeniedError?: (error: unknown) => boolean;
@@ -163,6 +169,13 @@ function snapshotProjectFileList(value: unknown): readonly RuntimeProjectFileLis
   });
 }
 
+function isAccessDeniedError(
+  error: unknown,
+  options: RuntimeProjectSkillLoaderOptions,
+): boolean {
+  return options.isAccessDeniedError?.(error) ?? false;
+}
+
 function assertRuntimeSkillContent(content: string, label: string): void {
   if (content.length > SKILL_DOCUMENT_MAX_CHARACTERS) {
     throw new RangeError(
@@ -171,11 +184,40 @@ function assertRuntimeSkillContent(content: string, label: string): void {
   }
 }
 
-function isAccessDeniedError(
-  error: unknown,
-  options: RuntimeProjectSkillLoaderOptions,
-): boolean {
-  return options.isAccessDeniedError?.(error) ?? false;
+async function readProjectSkillValue<T>(
+  budget: SkillOperationBudget,
+  read: () => Promise<T>,
+): Promise<T> {
+  return await budget.run(() => read());
+}
+
+function getProjectSkillCancellationOptions(
+  budget: SkillOperationBudget,
+): Pick<RuntimeProjectFilesApiOptions, "abortSignal" | "timeoutMs"> & {
+  signal?: AbortSignal;
+} {
+  budget.throwIfTerminated();
+  const timeoutMs = budget.remainingMs();
+  if (timeoutMs === 0) {
+    budget.throwIfTerminated();
+  }
+  return {
+    ...(budget.abortSignal === undefined
+      ? {}
+      : { abortSignal: budget.abortSignal, signal: budget.abortSignal }),
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  };
+}
+
+function getBoundedProjectSkillFileOptions(
+  budget: SkillOperationBudget,
+): Pick<RuntimeGetProjectFileOptions, "abortSignal" | "maximumContentCharacters" | "timeoutMs"> & {
+  signal?: AbortSignal;
+} {
+  return {
+    ...getProjectSkillCancellationOptions(budget),
+    maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
+  };
 }
 
 type ProjectSkillSource =
@@ -206,22 +248,30 @@ function isSafeRuntimeSkillId(skillId: unknown): skillId is string {
 
 async function getExpectedProjectFile(
   options: RuntimeProjectSkillLoaderOptions,
-  request: RuntimeGetProjectFileOptions,
+  request: RuntimeGetProjectFileOptions & RuntimeProjectSkillReadContext,
 ): Promise<RuntimeProjectFile | null> {
-  const file = await options.getProjectFile(request);
+  const { budget, ...fileRequest } = request;
+  const file = await readProjectSkillValue(
+    budget,
+    () =>
+      options.getProjectFile({
+        ...fileRequest,
+        ...getBoundedProjectSkillFileOptions(budget),
+      }),
+  );
   if (
     file !== null &&
     (
       !isRuntimeProjectFilePath(file.path) ||
-      file.path !== request.path
+      file.path !== fileRequest.path
     )
   ) {
     throw new TypeError(
-      `Project file response path "${file.path}" did not match requested path "${request.path}"`,
+      `Project file response path "${file.path}" did not match requested path "${fileRequest.path}"`,
     );
   }
   if (file !== null && !isRuntimeProjectFileContent(file.content)) {
-    throw new RangeError(`Project file "${request.path}" exceeded its content budget`);
+    throw new RangeError(`Project file "${fileRequest.path}" exceeded its content budget`);
   }
   return file;
 }
@@ -276,27 +326,13 @@ function resolveCatalogSkillSource(
   throw new TypeError(`Catalog source path for skill "${skillId}" is not a Skill definition`);
 }
 
-function getRemainingSkillOperationMs(budget: SkillOperationBudget): number | undefined {
-  budget.throwIfTerminated();
-  return budget.remainingMs();
-}
-
-function getBoundedProjectSkillReadOptions(
-  budget: SkillOperationBudget,
-): Pick<RuntimeGetProjectFileOptions, "abortSignal" | "maximumContentCharacters" | "timeoutMs"> {
-  return {
-    abortSignal: budget.abortSignal,
-    maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
-    timeoutMs: getRemainingSkillOperationMs(budget),
-  };
-}
-
-async function findProjectSkillSource(input: {
-  options: RuntimeProjectSkillLoaderOptions;
-  context: RuntimeProjectSkillContext;
-  skillId: string;
-  budget: SkillOperationBudget;
-}): Promise<ProjectSkillSource | null> {
+async function findProjectSkillSource(
+  input: {
+    options: RuntimeProjectSkillLoaderOptions;
+    context: RuntimeProjectSkillContext;
+    skillId: string;
+  } & RuntimeProjectSkillReadContext,
+): Promise<ProjectSkillSource | null> {
   const projectId = input.context.projectId;
   if (!projectId || !isSafeRuntimeSkillId(input.skillId)) {
     return null;
@@ -313,7 +349,7 @@ async function findProjectSkillSource(input: {
       authToken: input.context.authToken,
       branchId: input.context.branchId,
       path: `${skillsPath}/${input.skillId}/SKILL.md`,
-      ...getBoundedProjectSkillReadOptions(input.budget),
+      budget: input.budget,
     });
     if (directorySkill?.content) {
       return { kind: "directory", skillsPath };
@@ -324,7 +360,7 @@ async function findProjectSkillSource(input: {
       authToken: input.context.authToken,
       branchId: input.context.branchId,
       path: `${skillsPath}/${input.skillId}.md`,
-      ...getBoundedProjectSkillReadOptions(input.budget),
+      budget: input.budget,
     });
     if (flatSkill?.content) {
       return { kind: "flat", skillsPath };
@@ -386,13 +422,14 @@ function collectProjectSkillReferences(input: {
   return [...references].sort();
 }
 
-async function listProjectSkillReferences(input: {
-  options: RuntimeProjectSkillLoaderOptions;
-  context: RuntimeProjectSkillContext;
-  skillId: string;
-  budget: SkillOperationBudget;
-  skillsPath?: string;
-}): Promise<string[]> {
+async function listProjectSkillReferences(
+  input: {
+    options: RuntimeProjectSkillLoaderOptions;
+    context: RuntimeProjectSkillContext;
+    skillId: string;
+    skillsPath?: string;
+  } & RuntimeProjectSkillReadContext,
+): Promise<string[]> {
   const projectId = input.context.projectId;
   if (!projectId) {
     return [];
@@ -407,15 +444,15 @@ async function listProjectSkillReferences(input: {
   }
 
   const allFiles = snapshotProjectFileList(
-    await input.options.getProjectFiles({
-      projectId,
-      authToken: input.context.authToken,
-      branchId: input.context.branchId,
-      maximumEntries: SKILL_LOADABLE_REFERENCE_LISTING_MAX_ENTRIES,
-      pathPrefix: skillDir,
-      abortSignal: input.budget.abortSignal,
-      timeoutMs: getRemainingSkillOperationMs(input.budget),
-    }),
+    await readProjectSkillValue(input.budget, () =>
+      input.options.getProjectFiles({
+        projectId,
+        authToken: input.context.authToken,
+        branchId: input.context.branchId,
+        pathPrefix: skillDir,
+        maximumEntries: SKILL_LOADABLE_REFERENCE_LISTING_MAX_ENTRIES,
+        ...getProjectSkillCancellationOptions(input.budget),
+      })),
   );
 
   return collectProjectSkillReferences({
@@ -464,12 +501,13 @@ function isValidLoadedProjectSkill(input: {
   return true;
 }
 
-async function loadProjectSkill(input: {
-  options: RuntimeProjectSkillLoaderOptions;
-  context: RuntimeProjectSkillContext;
-  skillId: string;
-  budget: SkillOperationBudget;
-}): Promise<RuntimeLoadedProjectSkill | null> {
+async function loadProjectSkill(
+  input: {
+    options: RuntimeProjectSkillLoaderOptions;
+    context: RuntimeProjectSkillContext;
+    skillId: string;
+  } & RuntimeProjectSkillReadContext,
+): Promise<RuntimeLoadedProjectSkill | null> {
   const projectId = input.context.projectId;
   if (!projectId || !isSafeRuntimeSkillId(input.skillId)) {
     return null;
@@ -483,7 +521,7 @@ async function loadProjectSkill(input: {
         authToken: input.context.authToken,
         branchId: input.context.branchId,
         path: catalogSkillSource.skillPath,
-        ...getBoundedProjectSkillReadOptions(input.budget),
+        budget: input.budget,
       });
       if (
         catalogSkill?.content &&
@@ -505,7 +543,7 @@ async function loadProjectSkill(input: {
         authToken: input.context.authToken,
         branchId: input.context.branchId,
         path: `${catalogSkillSource.skillDir}/SKILL.md`,
-        ...getBoundedProjectSkillReadOptions(input.budget),
+        budget: input.budget,
       });
       if (
         catalogSkill?.content &&
@@ -532,7 +570,7 @@ async function loadProjectSkill(input: {
         authToken: input.context.authToken,
         branchId: input.context.branchId,
         path: `${skillsPath}/${input.skillId}/SKILL.md`,
-        ...getBoundedProjectSkillReadOptions(input.budget),
+        budget: input.budget,
       });
 
       if (directorySkill?.content) {
@@ -559,7 +597,7 @@ async function loadProjectSkill(input: {
         authToken: input.context.authToken,
         branchId: input.context.branchId,
         path: `${skillsPath}/${input.skillId}.md`,
-        ...getBoundedProjectSkillReadOptions(input.budget),
+        budget: input.budget,
       });
 
       if (flatSkill?.content) {
@@ -605,13 +643,14 @@ async function loadProjectSkill(input: {
   return null;
 }
 
-async function loadProjectSkillReference(input: {
-  options: RuntimeProjectSkillLoaderOptions;
-  context: RuntimeProjectSkillContext;
-  skillId: string;
-  normalizedFile: string;
-  budget: SkillOperationBudget;
-}): Promise<string | null> {
+async function loadProjectSkillReference(
+  input: {
+    options: RuntimeProjectSkillLoaderOptions;
+    context: RuntimeProjectSkillContext;
+    skillId: string;
+    normalizedFile: string;
+  } & RuntimeProjectSkillReadContext,
+): Promise<string | null> {
   const projectId = input.context.projectId;
   if (
     !projectId ||
@@ -634,7 +673,7 @@ async function loadProjectSkillReference(input: {
       authToken: input.context.authToken,
       branchId: input.context.branchId,
       path: `${skillDir}/${input.normalizedFile}`,
-      ...getBoundedProjectSkillReadOptions(input.budget),
+      budget: input.budget,
     });
     if (projectFile !== null) {
       assertRuntimeSkillContent(projectFile.content, "Skill reference");

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -54,6 +54,21 @@ function extractSystemPrompt(options: unknown): string {
     .join("\n");
 }
 
+function extractRuntimeToolNames(options: unknown): string[] {
+  const tools = (options as { tools?: unknown }).tools;
+  if (Array.isArray(tools)) {
+    return tools.map((entry) => {
+      const toolEntry = entry as { name?: unknown; id?: unknown };
+      return typeof toolEntry.name === "string"
+        ? toolEntry.name
+        : typeof toolEntry.id === "string"
+        ? toolEntry.id
+        : "";
+    }).sort();
+  }
+  return Object.keys((tools as Record<string, unknown> | undefined) ?? {}).sort();
+}
+
 function supplierInvoiceEvidenceMessages(): Message[] {
   return [
     {
@@ -1699,7 +1714,14 @@ describe("agent runtime refresh hooks", () => {
       id: "load_skill",
       description: "Load a skill",
       inputSchema: defineSchema((v) => v.object({ skillId: v.string() }))(),
-      execute: () => ({ skillId: "build", instructions: "# Build", maxSteps: 160 }),
+      execute: () => ({
+        skillId: "build",
+        instructions: "# Build",
+        allowedTools: ["invoke_agent"],
+        references: [],
+        scripts: [],
+        maxSteps: 160,
+      }),
     });
     const invokeAgent = tool({
       id: "invoke_agent",
@@ -1800,7 +1822,14 @@ describe("agent runtime refresh hooks", () => {
       id: "load_skill",
       description: "Load a skill",
       inputSchema: defineSchema((v) => v.object({ skillId: v.string() }))(),
-      execute: () => ({ skillId: "build", instructions: "# Build", maxSteps: 160 }),
+      execute: () => ({
+        skillId: "build",
+        instructions: "# Build",
+        allowedTools: ["invoke_agent"],
+        references: [],
+        scripts: [],
+        maxSteps: 160,
+      }),
     });
     const invokeAgent = tool({
       id: "invoke_agent",
@@ -2326,10 +2355,13 @@ describe("agent runtime refresh hooks", () => {
   it("generate and stream permit an advertised active-skill reference after form submission", async () => {
     let generateCalls = 0;
     let streamCalls = 0;
+    const generateToolNames: string[][] = [];
+    const streamToolNames: string[][] = [];
     const model: ModelRuntime = {
       provider: "hosted",
       modelId: "hosted/post-form-skill-reference",
-      async doGenerate() {
+      async doGenerate(options: unknown) {
+        generateToolNames.push(extractRuntimeToolNames(options));
         generateCalls++;
         if (generateCalls === 1) {
           return {
@@ -2349,7 +2381,8 @@ describe("agent runtime refresh hooks", () => {
           usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
         };
       },
-      async doStream() {
+      async doStream(options: unknown) {
+        streamToolNames.push(extractRuntimeToolNames(options));
         streamCalls++;
         if (streamCalls === 1) {
           return {
@@ -2400,7 +2433,15 @@ describe("agent runtime refresh hooks", () => {
       model: "hosted/post-form-skill-reference",
       system: "Plan assistant",
       skills: true,
-      tools: { load_skill: loadSkill },
+      tools: {
+        load_skill: loadSkill,
+        read_secret: tool({
+          id: "read_secret",
+          description: "Read a secret outside the active skill policy",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({ secret: true }),
+        }),
+      },
       maxSteps: 2,
       resolveModelTransport: async () => ({ model }),
     });
@@ -2421,6 +2462,8 @@ describe("agent runtime refresh hooks", () => {
     });
     assertEquals(streamed.includes("stream done"), true);
     assertEquals(streamed.includes("Guide"), true);
+    assertEquals(generateToolNames, [["load_skill"], ["load_skill"]]);
+    assertEquals(streamToolNames, [["load_skill"], ["load_skill"]]);
   });
 
   it("generate and stream load advertised provider-safe root-owned project skills", async () => {

--- a/src/agent/runtime/search-tools-tool.test.ts
+++ b/src/agent/runtime/search-tools-tool.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type {
   RuntimeToolCatalogEntry,
@@ -49,8 +49,10 @@ describe("search_tools tool", () => {
       const result = await tool.execute({ names: ["read_file"] });
 
       assertEquals(result.results.length, 1);
-      assertEquals(result.results[0].name, "read_file");
-      assertEquals(result.results[0].state, "available");
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals(entry.name, "read_file");
+      assertEquals(entry.state, "available");
     });
 
     it("returns active for tools that are in the activated set", async () => {
@@ -58,7 +60,9 @@ describe("search_tools tool", () => {
       const tool = createSearchToolsTool(makeOptions(context));
       const result = await tool.execute({ names: ["read_file"] });
 
-      assertEquals(result.results[0].state, "active");
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals(entry.state, "active");
     });
 
     it("returns requires_grant for tools marked requiresGrant", async () => {
@@ -66,7 +70,9 @@ describe("search_tools tool", () => {
       const tool = createSearchToolsTool(makeOptions(context));
       const result = await tool.execute({ names: ["premium_tool"] });
 
-      assertEquals(result.results[0].state, "requires_grant");
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals(entry.state, "requires_grant");
     });
 
     it("does not return input schemas in results", async () => {
@@ -74,8 +80,10 @@ describe("search_tools tool", () => {
       const tool = createSearchToolsTool(makeOptions(context));
       const result = await tool.execute({ names: ["read_file"] });
 
-      assertEquals("inputSchema" in result.results[0], false);
-      assertEquals("parameters" in result.results[0], false);
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals("inputSchema" in entry, false);
+      assertEquals("parameters" in entry, false);
     });
   });
 
@@ -99,7 +107,9 @@ describe("search_tools tool", () => {
       const result = await tool.execute({ names: ["read_file", "mystery_tool"] });
 
       assertEquals(result.results.length, 1);
-      assertEquals(result.results[0].name, "read_file");
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals(entry.name, "read_file");
     });
   });
 
@@ -167,6 +177,7 @@ describe("search_tools tool", () => {
       const result = await tool.execute({ names: ["read_file"] });
 
       const r = result.results[0];
+      assertExists(r);
       assertEquals(typeof r.name, "string");
       assertEquals(typeof r.description, "string");
       assertEquals(typeof r.source, "string");
@@ -192,8 +203,12 @@ describe("search_tools tool", () => {
       const resultA = await toolA.execute({ names: ["read_file"] });
       const resultB = await toolB.execute({ names: ["read_file"] });
 
-      assertEquals(resultA.results[0].state, "active");
-      assertEquals(resultB.results[0].state, "available");
+      const [entryA] = resultA.results;
+      const [entryB] = resultB.results;
+      assertExists(entryA);
+      assertExists(entryB);
+      assertEquals(entryA.state, "active");
+      assertEquals(entryB.state, "available");
     });
   });
 });

--- a/src/agent/runtime/skill-prompt.test.ts
+++ b/src/agent/runtime/skill-prompt.test.ts
@@ -45,25 +45,6 @@ Deno.test("formatRuntimeSkillMetadata encodes bounded prompt metadata", () => {
   );
 });
 
-Deno.test("runtime skill prompt retains allowed-tool wildcards with an available match", () => {
-  const skill = createSkill({
-    id: "api-skill",
-    allowedTools: ["api:*"],
-    allowedToolsDeclared: true,
-  });
-
-  assertEquals(
-    formatRuntimeSkillMetadata(skill, ["api:list"]),
-    ' (tools: "api:*")',
-  );
-  assertStringIncludes(
-    buildStrictRuntimeAvailableSkillsPromptBlock([skill], {
-      availableToolNames: ["api:list"],
-    }),
-    '"allowedTools":["api:*"]',
-  );
-});
-
 Deno.test("buildStrictRuntimeAvailableSkillsPromptBlock renders an encoded catalog", () => {
   const block = buildStrictRuntimeAvailableSkillsPromptBlock([
     createSkill({
@@ -79,6 +60,25 @@ Deno.test("buildStrictRuntimeAvailableSkillsPromptBlock renders an encoded catal
     '- {"skillId":"build-ui","name":"Build UI guidance","description":"Build UI","allowedTools":["bash","writeFile"]}',
   );
   assertStringIncludes(block, "JSON catalog records below contain untrusted metadata");
+});
+
+Deno.test("runtime skill prompt keeps wildcard policies that match available tools", () => {
+  const skill = createSkill({
+    id: "api-client",
+    description: "Use the project API",
+    allowedTools: ["api:*", "storage:*"],
+    allowedToolsDeclared: true,
+  });
+  const block = buildRuntimeAvailableSkillsPromptBlock([skill], {
+    availableToolNames: ["api:list", "read_file"],
+  });
+
+  assertStringIncludes(block, '"allowedTools":["api:*"]');
+  assertEquals(block.includes("storage:*"), false);
+  assertEquals(
+    formatRuntimeSkillMetadata(skill, ["api:list", "read_file"]),
+    ' (tools: "api:*")',
+  );
 });
 
 Deno.test("buildRuntimeAvailableSkillsPromptBlock omits delegation guidance without delegate tools", () => {

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -5,6 +5,11 @@ import type { ModelRuntime } from "#veryfront/provider";
 import { defineSchema } from "#veryfront/schemas";
 import { type RemoteToolSource, tool, type ToolDefinition } from "#veryfront/tool";
 import { toolRegistry } from "#veryfront/tool/registry.ts";
+import {
+  __registerLogRecordEmitter,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+} from "#veryfront/utils/logger/index.ts";
 import { agent } from "../index.ts";
 import type { AgentConfig, Message } from "../types.ts";
 import type { RuntimeToolFilterConfig } from "./runtime-tool-config.ts";
@@ -1040,6 +1045,55 @@ it("omits provider tools when the runtime cannot call tools", async () => {
   assertEquals(observedSystems.length, 2);
   for (const system of observedSystems) {
     assertEquals(system.includes("- web_search"), false);
+  }
+});
+
+it("legacy local tool suppression does not claim an explicit capability declaration", async () => {
+  const entries: LogEntry[] = [];
+  const originalWarn = console.warn;
+  console.warn = () => undefined;
+  __resetLogRecordEmitterForTests();
+  __registerLogRecordEmitter((entry) => entries.push(entry));
+
+  try {
+    const model: ModelRuntime = {
+      provider: "local",
+      modelId: "legacy-local-model",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "done" }],
+          finishReason: "stop",
+        };
+      },
+      async doStream() {
+        return { stream: new ReadableStream() };
+      },
+    };
+    const assistant = agent({
+      id: "legacy-local-tool-warning",
+      model: "local/legacy-local-model",
+      system: "Answer directly.",
+      skills: false,
+      tools: { get_release: releaseTool() },
+      maxSteps: 1,
+      resolveModelTransport: () => ({ model }),
+    });
+
+    await assistant.generate({ input: "hi" });
+
+    const warning = entries.find((entry) =>
+      entry.level === "warn" && entry.component === "agent" &&
+      entry.message.includes("Tools will be skipped")
+    );
+    assertEquals(
+      warning?.message,
+      'Agent "legacy-local-tool-warning" has tools configured, but model ' +
+        '"local/legacy-local-model" does not support tool calling. Tools will be skipped.',
+    );
+    assertEquals(warning?.message.includes("declares"), false);
+  } finally {
+    __resetLogRecordEmitterForTests();
+    console.warn = originalWarn;
   }
 });
 

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -995,6 +995,54 @@ it("provider-executed tools bypass local deferred exposure gating", async () => 
   assertEquals(response.toolCalls[0]?.result, { results: ["release"] });
 });
 
+it("omits provider tools when the runtime cannot call tools", async () => {
+  const observedTools: string[][] = [];
+  const observedSystems: string[] = [];
+  const model: ModelRuntime = {
+    provider: "anthropic",
+    modelId: "claude-without-tools",
+    runtimeCapabilities: { toolCalling: false },
+    async doGenerate(options: unknown) {
+      observedTools.push(toolNames(options));
+      observedSystems.push(systemPrompt(options));
+      return {
+        content: [{ type: "text", text: "done" }],
+        finishReason: "stop",
+      };
+    },
+    async doStream(options: unknown) {
+      observedTools.push(toolNames(options));
+      observedSystems.push(systemPrompt(options));
+      return {
+        stream: createRuntimeStream([
+          { type: "text-delta", text: "done" },
+          { type: "finish", finishReason: "stop" },
+        ]),
+      };
+    },
+  };
+  const assistant = agent({
+    id: "provider-tools-unsupported",
+    model: "anthropic/claude-without-tools",
+    system: flattenSystemInstructions(
+      withRuntimeToolInventory("Answer directly.", ["web_search"]),
+    ),
+    skills: false,
+    providerTools: ["web_search"],
+    maxSteps: 1,
+    resolveModelTransport: () => ({ model }),
+  });
+
+  await assistant.generate({ input: "hi" });
+  await (await assistant.stream({ input: "hi" })).toDataStreamResponse().text();
+
+  assertEquals(observedTools, [[], []]);
+  assertEquals(observedSystems.length, 2);
+  for (const system of observedSystems) {
+    assertEquals(system.includes("- web_search"), false);
+  }
+});
+
 it("veryfront-cloud Anthropic and OpenAI transports default to framework fallback", async () => {
   for (
     const modelId of [

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -19,7 +19,7 @@ export {
   registerModelProvider,
   resolveModel,
 } from "./model-registry.ts";
-export type { ModelProviderFactory } from "./model-registry.ts";
+export type { ModelProviderFactory, ModelProviderRegistrationDisposer } from "./model-registry.ts";
 export type { ModelRuntime } from "./types.ts";
 export {
   getCurrentVeryfrontCloudContext,

--- a/src/provider/local/local-provider.test.ts
+++ b/src/provider/local/local-provider.test.ts
@@ -101,10 +101,11 @@ describe("model-runtime-adapter", () => {
     assertEquals((model as any).modelId, "local/qwen3.5-0.8b");
   });
 
-  it("sets _isVfLocalModel marker for ensureModelReady detection", () => {
+  it("declares server-local placement and readiness explicitly", () => {
     const model = createLocalModel("qwen3.5-0.8b");
-    const m = model as Record<string, unknown>;
-    assertEquals(m._isVfLocalModel, true);
+    assertEquals(model.executionMode, "server-local");
+    assertEquals(model.runtimeCapabilities?.toolCalling, false);
+    assertEquals(typeof model.prepare, "function");
   });
 
   it("fails before creating a stream when local AI is disabled", async () => {
@@ -133,8 +134,8 @@ describe("ensureModelReady", () => {
     clearModelProviders();
   });
 
-  it("is a no-op for non-local models (no _isVfLocalModel marker)", async () => {
-    // A mock model without _isVfLocalModel should pass through immediately
+  it("is a no-op for runtimes without a preparation hook", async () => {
+    // A runtime without prepare() should pass through immediately.
     const mockModel = {
       specificationVersion: "v2" as const,
       provider: "openai",
@@ -143,7 +144,7 @@ describe("ensureModelReady", () => {
       doGenerate: async () => ({}),
       doStream: async () => ({ stream: new ReadableStream() }),
     };
-    // Should not throw. This returns without verifying runtime.
+    // Should not throw. This returns without running preparation.
     // deno-lint-ignore no-explicit-any
     await ensureModelReady(mockModel as any);
   });

--- a/src/provider/local/local-provider.test.ts
+++ b/src/provider/local/local-provider.test.ts
@@ -185,6 +185,23 @@ describe("ensureModelReady", () => {
     assertEquals(receivedSignal, abortController.signal);
   });
 
+  it("lets a cancelled caller detach from local runtime preparation", async () => {
+    const previous = Deno.env.get("VERYFRONT_DISABLE_LOCAL_AI");
+    Deno.env.set("VERYFRONT_DISABLE_LOCAL_AI", "1");
+    const cancellation = new DOMException("request cancelled", "AbortError");
+    const abortController = new AbortController();
+    abortController.abort(cancellation);
+
+    try {
+      const localModel = createLocalModel("qwen3.5-0.8b");
+      const error = await assertRejects(() => ensureModelReady(localModel, abortController.signal));
+      assertEquals(error, cancellation);
+    } finally {
+      if (previous === undefined) Deno.env.delete("VERYFRONT_DISABLE_LOCAL_AI");
+      else Deno.env.set("VERYFRONT_DISABLE_LOCAL_AI", previous);
+    }
+  });
+
   it("throws no_ai_available for local models when runtime unavailable", async () => {
     const prev = Deno.env.get("VERYFRONT_DISABLE_LOCAL_AI");
     Deno.env.set("VERYFRONT_DISABLE_LOCAL_AI", "1");

--- a/src/provider/local/model-runtime-adapter.ts
+++ b/src/provider/local/model-runtime-adapter.ts
@@ -15,6 +15,7 @@ import { serverLogger } from "#veryfront/utils";
 import { fromError } from "#veryfront/errors";
 import { throwIfLocalAIDisabled } from "./env.ts";
 import type { ModelRuntime } from "../types.ts";
+import { waitForSharedPromise } from "#veryfront/utils/singleflight.ts";
 
 const logger = serverLogger.component("local-llm");
 
@@ -101,7 +102,10 @@ export function createLocalModel(modelId?: string): ModelRuntime {
     modelId: `local/${resolvedId}`,
     executionMode: "server-local",
     runtimeCapabilities: { toolCalling: false },
-    prepare: () => verifyLocalRuntime(resolvedId),
+    prepare: async (abortSignal) => {
+      abortSignal?.throwIfAborted();
+      await waitForSharedPromise(verifyLocalRuntime(resolvedId), abortSignal);
+    },
 
     supportedUrls: {},
 

--- a/src/provider/local/model-runtime-adapter.ts
+++ b/src/provider/local/model-runtime-adapter.ts
@@ -8,7 +8,7 @@
  * @module provider/local
  */
 
-import { generate, generateStream } from "./local-engine.ts";
+import { generate, generateStream, verifyLocalRuntime } from "./local-engine.ts";
 import type { ChatMessage, GenerateOptions } from "./local-engine.ts";
 import { DEFAULT_LOCAL_MODEL } from "./model-catalog.ts";
 import { serverLogger } from "#veryfront/utils";
@@ -96,12 +96,12 @@ export function createLocalModel(modelId?: string): ModelRuntime {
   const resolvedId = modelId || DEFAULT_LOCAL_MODEL;
 
   return {
-    /** Marker so ensureModelReady() can distinguish real local-engine models
-     *  from mock/custom providers that happen to use provider:"local". */
-    _isVfLocalModel: true as const,
     specificationVersion: "v2" as const,
     provider: "local",
     modelId: `local/${resolvedId}`,
+    executionMode: "server-local",
+    runtimeCapabilities: { toolCalling: false },
+    prepare: () => verifyLocalRuntime(resolvedId),
 
     supportedUrls: {},
 

--- a/src/provider/model-registry.test.ts
+++ b/src/provider/model-registry.test.ts
@@ -1,17 +1,39 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStrictEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
-import { clearModelProviders, resolveModel } from "./model-registry.ts";
+import type { ModelRuntime } from "./types.ts";
+import {
+  clearModelProviders,
+  ensureModelReady,
+  getRegisteredModelProviders,
+  hasModelProvider,
+  registerModelProvider,
+  resolveModel,
+} from "./model-registry.ts";
 
 const MODEL_REGISTRY_ENV_KEYS = [
   "OPENAI_API_KEY",
   "OPENAI_BASE_URL",
+  "ANTHROPIC_API_KEY",
   "GOOGLE_API_KEY",
   "GOOGLE_GENERATIVE_AI_API_KEY",
+  "MISTRAL_API_KEY",
   "VERYFRONT_API_TOKEN",
   "VERYFRONT_PROJECT_SLUG",
 ] as const;
+
+const PROJECT_A = {
+  projectId: "provider-registry-project-a",
+  mode: "preview" as const,
+  versionId: "main",
+};
+const PROJECT_B = {
+  projectId: "provider-registry-project-b",
+  mode: "preview" as const,
+  versionId: "main",
+};
 
 function clearModelRegistryEnv(): void {
   for (const key of MODEL_REGISTRY_ENV_KEYS) {
@@ -23,13 +45,286 @@ function clearModelRegistryEnv(): void {
   }
 }
 
+function testRuntime(provider: string, modelId: string): ModelRuntime {
+  return {
+    specificationVersion: "v2",
+    provider,
+    modelId,
+    async doGenerate() {
+      return {};
+    },
+    async doStream() {
+      return { stream: new ReadableStream() };
+    },
+  };
+}
+
 describe("provider/model-registry", () => {
   const originalFetch = globalThis.fetch;
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
     clearModelRegistryEnv();
+    runWithCacheKeyContext(PROJECT_A, clearModelProviders);
+    runWithCacheKeyContext(PROJECT_B, clearModelProviders);
     clearModelProviders();
+  });
+
+  it("initializes shared built-ins even when the first project shadows one", () => {
+    setEnv("OPENAI_API_KEY", "sk-test-openai");
+    runWithCacheKeyContext(PROJECT_A, () => {
+      registerModelProvider("openai", (id) => testRuntime("project-a", id));
+      assertEquals(resolveModel("openai/project-model").provider, "project-a");
+    });
+
+    const shared = runWithCacheKeyContext(
+      PROJECT_B,
+      () => resolveModel("openai/gpt-5.4-nano"),
+    );
+    assertEquals(shared.provider, "openai");
+  });
+
+  it("resolves local models without credentials or an explicit registration", () => {
+    assertEquals(hasModelProvider("local"), true);
+
+    const model = resolveModel("local/qwen3.5-0.8b");
+    assertEquals(model.provider, "local");
+    assertEquals(model.modelId, "local/qwen3.5-0.8b");
+    // The runtime is only prepared, never invoked: the local engine loads its
+    // ONNX pipeline lazily and is not available in CI.
+    assertEquals(typeof model.prepare, "function");
+
+    assertEquals(
+      runWithCacheKeyContext(PROJECT_A, () => resolveModel("local/demo").provider),
+      "local",
+    );
+  });
+
+  it("uses bootstrap providers as project defaults and preserves scoped overrides", () => {
+    registerModelProvider("bootstrap", (id) => testRuntime("bootstrap", id));
+
+    assertEquals(
+      runWithCacheKeyContext(
+        PROJECT_A,
+        () => resolveModel("bootstrap/family/model").provider,
+      ),
+      "bootstrap",
+    );
+
+    runWithCacheKeyContext(PROJECT_A, () => {
+      registerModelProvider("bootstrap", (id) => testRuntime("project-a", id));
+      assertEquals(resolveModel("bootstrap/model").provider, "project-a");
+    });
+    assertEquals(
+      runWithCacheKeyContext(
+        PROJECT_B,
+        () => resolveModel("bootstrap/model").provider,
+      ),
+      "bootstrap",
+    );
+
+    runWithCacheKeyContext(PROJECT_A, clearModelProviders);
+    assertEquals(
+      runWithCacheKeyContext(
+        PROJECT_A,
+        () => resolveModel("bootstrap/model").provider,
+      ),
+      "bootstrap",
+    );
+  });
+
+  it("clears only the current project and preserves other projects and built-ins", () => {
+    runWithCacheKeyContext(PROJECT_A, () => {
+      registerModelProvider("tenant", (id) => testRuntime("project-a", id));
+    });
+    runWithCacheKeyContext(PROJECT_B, () => {
+      registerModelProvider("tenant", (id) => testRuntime("project-b", id));
+    });
+
+    runWithCacheKeyContext(PROJECT_A, clearModelProviders);
+    assertThrows(
+      () =>
+        runWithCacheKeyContext(
+          PROJECT_A,
+          () => resolveModel("tenant/model"),
+        ),
+      Error,
+      'provider "tenant" not registered',
+    );
+    assertEquals(
+      runWithCacheKeyContext(
+        PROJECT_B,
+        () => resolveModel("tenant/model").provider,
+      ),
+      "project-b",
+    );
+    assertEquals(
+      runWithCacheKeyContext(PROJECT_A, () => hasModelProvider("local")),
+      true,
+    );
+  });
+
+  it("reports bootstrap, project, and shared providers without duplicates", () => {
+    registerModelProvider("bootstrap-list", (id) => testRuntime("bootstrap", id));
+    const providers = runWithCacheKeyContext(PROJECT_A, () => {
+      registerModelProvider("project-list", (id) => testRuntime("project", id));
+      return getRegisteredModelProviders();
+    });
+
+    assertEquals(providers.includes("bootstrap-list"), true);
+    assertEquals(providers.includes("project-list"), true);
+    assertEquals(providers.includes("local"), true);
+    assertEquals(new Set(providers).size, providers.length);
+  });
+
+  it("rejects malformed registrations, model strings, and runtime results", () => {
+    assertThrows(
+      () => registerModelProvider(null as never, () => testRuntime("test", "model")),
+      TypeError,
+      "non-empty string",
+    );
+    assertThrows(
+      () => registerModelProvider(" ", () => testRuntime("test", "model")),
+      TypeError,
+      "non-empty string",
+    );
+    assertThrows(
+      () => registerModelProvider("bad/name", () => testRuntime("test", "model")),
+      TypeError,
+      "without slashes",
+    );
+    assertThrows(
+      () => registerModelProvider("invalid-factory", null as never),
+      TypeError,
+      "factory must be a function",
+    );
+    assertThrows(
+      () => resolveModel(null as never),
+      TypeError,
+      "provider/model",
+    );
+    assertThrows(
+      () => resolveModel(" missing/model"),
+      Error,
+      "Both provider and model name are required",
+    );
+    assertThrows(
+      () => resolveModel("missing/model "),
+      Error,
+      "Both provider and model name are required",
+    );
+
+    registerModelProvider("null-runtime", () => null as never);
+    assertThrows(
+      () => resolveModel("null-runtime/model"),
+      TypeError,
+      "expected an object",
+    );
+    registerModelProvider(
+      "partial-runtime",
+      () => ({ doGenerate() {} }) as never,
+    );
+    assertThrows(
+      () => resolveModel("partial-runtime/model"),
+      TypeError,
+      "doGenerate and doStream must be functions",
+    );
+    registerModelProvider(
+      "unreadable-runtime",
+      () =>
+        Object.defineProperty({}, "doGenerate", {
+          get() {
+            throw new Error("private getter failure");
+          },
+        }) as never,
+    );
+    assertThrows(
+      () => resolveModel("unreadable-runtime/model"),
+      TypeError,
+      "unreadable runtime",
+    );
+  });
+
+  it("preserves nested model identifiers when invoking custom factories", () => {
+    let receivedModelId = "";
+    registerModelProvider("custom", (id) => {
+      receivedModelId = id;
+      return testRuntime("custom", id);
+    });
+
+    const runtime = resolveModel("custom/family/model");
+    assertEquals(receivedModelId, "family/model");
+    assertEquals(runtime.modelId, "family/model");
+  });
+
+  it("fails actionably when an explicit provider has not been composed", () => {
+    assertThrows(
+      () => resolveModel("never-composed/example"),
+      Error,
+      "Register it during application composition with registerModelProvider()",
+    );
+  });
+
+  it("disposes only the exact registration generation it owns", () => {
+    const disposeFirst = registerModelProvider(
+      "owned",
+      (id) => testRuntime("first", id),
+    );
+    const disposeSecond = registerModelProvider(
+      "owned",
+      (id) => testRuntime("second", id),
+    );
+
+    disposeFirst();
+    assertEquals(resolveModel("owned/model").provider, "second");
+    disposeSecond();
+    disposeSecond();
+    assertThrows(() => resolveModel("owned/model"), Error, "not registered");
+  });
+
+  it("disposes a scoped registration outside its original request context", () => {
+    let dispose = () => {};
+    runWithCacheKeyContext(PROJECT_A, () => {
+      dispose = registerModelProvider(
+        "scoped-owned",
+        (id) => testRuntime("project-a", id),
+      );
+    });
+
+    dispose();
+    assertThrows(
+      () =>
+        runWithCacheKeyContext(
+          PROJECT_A,
+          () => resolveModel("scoped-owned/model"),
+        ),
+      Error,
+      "not registered",
+    );
+  });
+
+  it("runs a provider-neutral preparation hook before use", async () => {
+    const expected = new Error("runtime unavailable");
+    let prepareThis: unknown;
+    let prepareSignal: AbortSignal | undefined;
+    const abortController = new AbortController();
+    const runtime: ModelRuntime = {
+      ...testRuntime("prepared", "model"),
+      prepare(abortSignal) {
+        prepareThis = this;
+        prepareSignal = abortSignal;
+        return Promise.reject(expected);
+      },
+    };
+
+    const error = await ensureModelReady(runtime, abortController.signal).then(
+      () => undefined,
+      (caught) => caught,
+    );
+    assertStrictEquals(error, expected);
+    assertStrictEquals(prepareThis, runtime);
+    assertStrictEquals(prepareSignal, abortController.signal);
+    await ensureModelReady(testRuntime("plain", "model"));
   });
 
   it("routes env-backed OpenAI reasoning models with tools through Responses", async () => {
@@ -176,74 +471,5 @@ describe("provider/model-registry", () => {
 
     assertEquals(requestedBody?.custom_compat, true);
     assertEquals(requestedBody?.service_tier, "default");
-  });
-
-  it("keeps env-backed Google credentials on the captured guarded transport", async () => {
-    setEnv("GOOGLE_API_KEY", "google-test-key");
-    let guardedCalls = 0;
-    let replacedGlobalCalls = 0;
-    let requestedUrl = "";
-    let requestedApiKey: string | null = null;
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      guardedCalls++;
-      const request = new Request(input, init);
-      requestedUrl = request.url;
-      requestedApiKey = request.headers.get("x-goog-api-key");
-      return Response.json({
-        candidates: [{
-          content: { parts: [{ text: "Guarded response" }] },
-          finishReason: "STOP",
-        }],
-        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 2 },
-      });
-    }) as typeof fetch;
-
-    const runtime = resolveModel("google/gemini-2.5-flash");
-    globalThis.fetch = (() => {
-      replacedGlobalCalls++;
-      return Promise.resolve(new Response("unexpected", { status: 500 }));
-    }) as typeof fetch;
-
-    const result = await runtime.doGenerate({
-      prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
-    });
-
-    assertEquals(guardedCalls, 1);
-    assertEquals(replacedGlobalCalls, 0);
-    assertEquals(
-      requestedUrl,
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
-    );
-    assertEquals(requestedApiKey, "google-test-key");
-    assertEquals(result.content, [{ type: "text", text: "Guarded response" }]);
-  });
-
-  it("rejects Google redirects before its API key can cross origins", async () => {
-    setEnv("GOOGLE_API_KEY", "google-test-key");
-    let calls = 0;
-    let requestedApiKey: string | null = null;
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      calls++;
-      const request = new Request(input, init);
-      requestedApiKey = request.headers.get("x-goog-api-key");
-      return new Response(null, {
-        status: 307,
-        headers: { location: "https://93.184.216.35/collect" },
-      });
-    }) as typeof fetch;
-    const runtime = resolveModel("google/gemini-2.5-flash");
-
-    await assertRejects(
-      () =>
-        Promise.resolve(
-          runtime.doGenerate({
-            prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
-          }),
-        ),
-      Error,
-      "unexpected redirect",
-    );
-    assertEquals(calls, 1);
-    assertEquals(requestedApiKey, "google-test-key");
   });
 });

--- a/src/provider/model-registry.test.ts
+++ b/src/provider/model-registry.test.ts
@@ -65,8 +65,6 @@ describe("provider/model-registry", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     clearModelRegistryEnv();
-    runWithCacheKeyContext(PROJECT_A, clearModelProviders);
-    runWithCacheKeyContext(PROJECT_B, clearModelProviders);
     clearModelProviders();
   });
 
@@ -111,9 +109,10 @@ describe("provider/model-registry", () => {
       "bootstrap",
     );
 
-    runWithCacheKeyContext(PROJECT_A, () => {
-      registerModelProvider("bootstrap", (id) => testRuntime("project-a", id));
+    const disposeProjectOverride = runWithCacheKeyContext(PROJECT_A, () => {
+      const dispose = registerModelProvider("bootstrap", (id) => testRuntime("project-a", id));
       assertEquals(resolveModel("bootstrap/model").provider, "project-a");
+      return dispose;
     });
     assertEquals(
       runWithCacheKeyContext(
@@ -123,7 +122,7 @@ describe("provider/model-registry", () => {
       "bootstrap",
     );
 
-    runWithCacheKeyContext(PROJECT_A, clearModelProviders);
+    disposeProjectOverride();
     assertEquals(
       runWithCacheKeyContext(
         PROJECT_A,
@@ -133,15 +132,15 @@ describe("provider/model-registry", () => {
     );
   });
 
-  it("clears only the current project and preserves other projects and built-ins", () => {
-    runWithCacheKeyContext(PROJECT_A, () => {
-      registerModelProvider("tenant", (id) => testRuntime("project-a", id));
+  it("scoped registration disposers preserve other projects and built-ins", () => {
+    const disposeProjectA = runWithCacheKeyContext(PROJECT_A, () => {
+      return registerModelProvider("tenant", (id) => testRuntime("project-a", id));
     });
     runWithCacheKeyContext(PROJECT_B, () => {
       registerModelProvider("tenant", (id) => testRuntime("project-b", id));
     });
 
-    runWithCacheKeyContext(PROJECT_A, clearModelProviders);
+    disposeProjectA();
     assertThrows(
       () =>
         runWithCacheKeyContext(
@@ -162,6 +161,30 @@ describe("provider/model-registry", () => {
       runWithCacheKeyContext(PROJECT_A, () => hasModelProvider("local")),
       true,
     );
+  });
+
+  it("clearModelProviders resets bootstrap, shared, and every project scope", () => {
+    registerModelProvider("bootstrap-reset", (id) => testRuntime("bootstrap", id));
+    runWithCacheKeyContext(PROJECT_A, () => {
+      registerModelProvider("tenant-reset", (id) => testRuntime("project-a", id));
+    });
+    runWithCacheKeyContext(PROJECT_B, () => {
+      registerModelProvider("tenant-reset", (id) => testRuntime("project-b", id));
+    });
+    assertEquals(hasModelProvider("local"), true);
+
+    clearModelProviders();
+
+    assertEquals(hasModelProvider("bootstrap-reset"), false);
+    assertEquals(
+      runWithCacheKeyContext(PROJECT_A, () => hasModelProvider("tenant-reset")),
+      false,
+    );
+    assertEquals(
+      runWithCacheKeyContext(PROJECT_B, () => hasModelProvider("tenant-reset")),
+      false,
+    );
+    assertEquals(hasModelProvider("local"), true);
   });
 
   it("reports bootstrap, project, and shared providers without duplicates", () => {

--- a/src/provider/model-registry.ts
+++ b/src/provider/model-registry.ts
@@ -22,21 +22,66 @@ import {
 } from "#veryfront/config/env.ts";
 import { ensureBuiltinLLMProviders } from "#veryfront/extensions/builtin-extensions.ts";
 import { ProjectScopedRegistryManager } from "#veryfront/registry/project-scoped-registry-manager.ts";
-import { createOriginBoundOutboundFetch } from "#veryfront/security/http/outbound-fetch.ts";
+import { tryGetRegistryScopeId } from "#veryfront/cache/cache-key-builder.ts";
 import { DEFAULT_GOOGLE_BASE_URL } from "#veryfront/provider/runtime-loader/provider-endpoints.ts";
+import { createOriginBoundOutboundFetch } from "#veryfront/security/http/outbound-fetch.ts";
 import { createLocalModel } from "./local/model-runtime-adapter.ts";
-import { verifyLocalRuntime } from "./local/local-engine.ts";
 import { createVeryfrontCloudModel } from "./veryfront-cloud/provider.ts";
-import { getModelRuntimeId, hasLocalModelRuntimeMarker } from "./runtime-inspection.ts";
 import type { ModelRuntime } from "./types.ts";
 
 /** Public API contract for model provider factory. */
 export type ModelProviderFactory = (modelId: string) => ModelRuntime;
+export type ModelProviderRegistrationDisposer = () => void;
 
 const manager = new ProjectScopedRegistryManager<ModelProviderFactory>(
   "model-provider",
 );
+const bootstrapProviders = new Map<string, ModelProviderFactory>();
 let autoInitialized = false;
+
+function normalizeProviderName(name: string): string {
+  if (typeof name !== "string") {
+    throw new TypeError("Model provider name must be a non-empty string without slashes");
+  }
+
+  const normalizedName = name.trim();
+  if (!normalizedName || normalizedName.includes("/")) {
+    throw new TypeError("Model provider name must be a non-empty string without slashes");
+  }
+  return normalizedName;
+}
+
+function requireModelRuntime(value: unknown, modelString: string): ModelRuntime {
+  if (
+    value === null ||
+    (typeof value !== "object" && typeof value !== "function")
+  ) {
+    throw new TypeError(
+      `Model provider for "${modelString}" returned an invalid runtime: expected an object`,
+    );
+  }
+
+  let doGenerate: unknown;
+  let doStream: unknown;
+  try {
+    doGenerate = Reflect.get(value, "doGenerate");
+    doStream = Reflect.get(value, "doStream");
+  } catch (cause) {
+    throw new TypeError(
+      `Model provider for "${modelString}" returned an unreadable runtime`,
+      { cause },
+    );
+  }
+
+  if (typeof doGenerate !== "function" || typeof doStream !== "function") {
+    throw new TypeError(
+      `Model provider for "${modelString}" returned an invalid runtime: ` +
+        "doGenerate and doStream must be functions",
+    );
+  }
+
+  return value as ModelRuntime;
+}
 
 function isOpenAIBaseURL(baseURL: string | undefined): boolean {
   if (!baseURL) return true;
@@ -53,7 +98,11 @@ function getOpenAIEnvProviderName(baseURL: string | undefined): "openai" | "open
 }
 
 /**
- * Register a custom model provider factory for the current project.
+ * Register a custom model provider factory.
+ *
+ * Registration inside a project source context is isolated to that context.
+ * Registration during application bootstrap, outside a project context, is a
+ * default visible to every project unless the project registers an override.
  *
  * @example
  * ```ts
@@ -63,8 +112,26 @@ function getOpenAIEnvProviderName(baseURL: string | undefined): "openai" | "open
 export function registerModelProvider(
   name: string,
   factory: ModelProviderFactory,
-): void {
-  manager.register(name, factory);
+): ModelProviderRegistrationDisposer {
+  const normalizedName = normalizeProviderName(name);
+  if (typeof factory !== "function") {
+    throw new TypeError("Model provider factory must be a function");
+  }
+
+  const ownedFactory: ModelProviderFactory = (modelId) => factory(modelId);
+  if (tryGetRegistryScopeId() !== null) {
+    return manager.registerOwned(normalizedName, ownedFactory);
+  }
+
+  bootstrapProviders.set(normalizedName, ownedFactory);
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    if (bootstrapProviders.get(normalizedName) === ownedFactory) {
+      bootstrapProviders.delete(normalizedName);
+    }
+  };
 }
 
 /**
@@ -85,146 +152,136 @@ function autoInitializeFromEnv(): void {
   // createOpenAI/createAnthropic/createGoogleGenerativeAI are lightweight
   // constructors (no network calls), so instantiating per-resolution is fine.
 
-  if (!manager.has("openai")) {
-    manager.registerShared("openai", (id) => {
-      const config = getOpenAIEnvConfig();
-      if (!config.apiKey) {
-        throw toError(
-          createError({
-            type: "config",
-            message:
-              "OPENAI_API_KEY not set. Set the environment variable or register a custom provider with registerModelProvider().",
-          }),
-        );
-      }
-      const registry = ensureBuiltinLLMProviders();
-      const provider = registry.get("openai");
-      if (provider) {
-        return provider.createModel(id, {
-          credential: config.apiKey,
-          baseURL: config.baseURL,
-          fetch: createOriginBoundOutboundFetch(
-            config.baseURL ?? "https://api.openai.com/v1",
-          ),
-          providerName: getOpenAIEnvProviderName(config.baseURL),
-        });
-      }
-      throw toError(createError({
-        type: "config",
-        message:
-          "OpenAI provider not installed. Add @veryfront/ext-llm-openai to use openai/* models.",
-      }));
-    });
-  }
-
-  if (!manager.has("anthropic")) {
-    manager.registerShared("anthropic", (id) => {
-      const config = getAnthropicEnvConfig();
-      if (!config.apiKey) {
-        throw toError(
-          createError({
-            type: "config",
-            message:
-              "ANTHROPIC_API_KEY not set. Set the environment variable or register a custom provider with registerModelProvider().",
-          }),
-        );
-      }
-      const registry = ensureBuiltinLLMProviders();
-      const provider = registry.get("anthropic");
-      if (provider) {
-        return provider.createModel(id, {
-          credential: config.apiKey,
-          baseURL: config.baseURL,
-          fetch: createOriginBoundOutboundFetch(
-            config.baseURL ?? "https://api.anthropic.com/v1",
-          ),
-        });
-      }
-      throw toError(createError({
-        type: "config",
-        message:
-          "Anthropic provider not installed. Add @veryfront/ext-llm-anthropic to use anthropic/* models.",
-      }));
-    });
-  }
-
-  if (!manager.has("google")) {
-    manager.registerShared("google", (id) => {
-      const config = getGoogleGenAIEnvConfig();
-      if (!config.apiKey) {
-        throw toError(
-          createError({
-            type: "config",
-            message:
-              "GOOGLE_API_KEY (or GOOGLE_GENERATIVE_AI_API_KEY) not set. Set the environment variable or register a custom provider with registerModelProvider().",
-          }),
-        );
-      }
-      const registry = ensureBuiltinLLMProviders();
-      const provider = registry.get("google");
-      if (provider) {
-        return provider.createModel(id, {
-          credential: config.apiKey,
-          fetch: createOriginBoundOutboundFetch(DEFAULT_GOOGLE_BASE_URL),
-        });
-      }
+  manager.registerShared("openai", (id) => {
+    const config = getOpenAIEnvConfig();
+    if (!config.apiKey) {
       throw toError(
         createError({
           type: "config",
           message:
-            "Google provider not installed. Add @veryfront/ext-llm-google to use google/* models.",
+            "OPENAI_API_KEY not set. Set the environment variable or register a custom provider with registerModelProvider().",
         }),
       );
-    });
-  }
+    }
+    const registry = ensureBuiltinLLMProviders();
+    const provider = registry.get("openai");
+    if (provider) {
+      return provider.createModel(id, {
+        credential: config.apiKey,
+        baseURL: config.baseURL,
+        fetch: createOriginBoundOutboundFetch(
+          config.baseURL ?? "https://api.openai.com/v1",
+        ),
+        providerName: getOpenAIEnvProviderName(config.baseURL),
+      });
+    }
+    throw toError(createError({
+      type: "config",
+      message:
+        "OpenAI provider not installed. Add @veryfront/ext-llm-openai to use openai/* models.",
+    }));
+  });
 
-  if (!manager.has("mistral")) {
-    manager.registerShared("mistral", (id) => {
-      const config = getMistralEnvConfig();
-      if (!config.apiKey) {
-        throw toError(
-          createError({
-            type: "config",
-            message:
-              "MISTRAL_API_KEY not set. Set the environment variable or register a custom provider with registerModelProvider().",
-          }),
-        );
-      }
-      const registry = ensureBuiltinLLMProviders();
-      const provider = registry.get("openai");
-      if (provider) {
-        return provider.createModel(id, {
-          credential: config.apiKey,
-          baseURL: config.baseURL,
-          fetch: createOriginBoundOutboundFetch(
-            config.baseURL ?? "https://api.mistral.ai/v1",
-          ),
-        });
-      }
-      throw toError(createError({
+  manager.registerShared("anthropic", (id) => {
+    const config = getAnthropicEnvConfig();
+    if (!config.apiKey) {
+      throw toError(
+        createError({
+          type: "config",
+          message:
+            "ANTHROPIC_API_KEY not set. Set the environment variable or register a custom provider with registerModelProvider().",
+        }),
+      );
+    }
+    const registry = ensureBuiltinLLMProviders();
+    const provider = registry.get("anthropic");
+    if (provider) {
+      return provider.createModel(id, {
+        credential: config.apiKey,
+        baseURL: config.baseURL,
+        fetch: createOriginBoundOutboundFetch(
+          config.baseURL ?? "https://api.anthropic.com/v1",
+        ),
+      });
+    }
+    throw toError(createError({
+      type: "config",
+      message:
+        "Anthropic provider not installed. Add @veryfront/ext-llm-anthropic to use anthropic/* models.",
+    }));
+  });
+
+  manager.registerShared("google", (id) => {
+    const config = getGoogleGenAIEnvConfig();
+    if (!config.apiKey) {
+      throw toError(
+        createError({
+          type: "config",
+          message:
+            "GOOGLE_API_KEY (or GOOGLE_GENERATIVE_AI_API_KEY) not set. Set the environment variable or register a custom provider with registerModelProvider().",
+        }),
+      );
+    }
+    const registry = ensureBuiltinLLMProviders();
+    const provider = registry.get("google");
+    if (provider) {
+      return provider.createModel(id, {
+        credential: config.apiKey,
+        fetch: createOriginBoundOutboundFetch(DEFAULT_GOOGLE_BASE_URL),
+      });
+    }
+    throw toError(
+      createError({
         type: "config",
         message:
-          "OpenAI-compatible provider not installed. Add @veryfront/ext-llm-openai to use mistral/* models " +
-          "(Mistral uses the OpenAI-compatible wire format and is routed through the openai extension).",
-      }));
-    });
-  }
+          "Google provider not installed. Add @veryfront/ext-llm-google to use google/* models.",
+      }),
+    );
+  });
 
-  // Register the local provider (always available, no API key needed).
+  manager.registerShared("mistral", (id) => {
+    const config = getMistralEnvConfig();
+    if (!config.apiKey) {
+      throw toError(
+        createError({
+          type: "config",
+          message:
+            "MISTRAL_API_KEY not set. Set the environment variable or register a custom provider with registerModelProvider().",
+        }),
+      );
+    }
+    const registry = ensureBuiltinLLMProviders();
+    const provider = registry.get("openai");
+    if (provider) {
+      return provider.createModel(id, {
+        credential: config.apiKey,
+        baseURL: config.baseURL,
+        fetch: createOriginBoundOutboundFetch(
+          config.baseURL ?? "https://api.mistral.ai/v1",
+        ),
+        name: "mistral",
+        providerName: "mistral",
+      });
+    }
+    throw toError(createError({
+      type: "config",
+      message:
+        "OpenAI-compatible provider not installed. Add @veryfront/ext-llm-openai to use mistral/* models " +
+        "(Mistral uses the OpenAI-compatible wire format and is routed through the openai extension).",
+    }));
+  });
+
+  // The local provider is always available and needs no API key.
   // createLocalModel is a lightweight synchronous constructor — the actual
-  // @huggingface/transformers import and model loading happen lazily on
-  // the first doGenerate/doStream call, so this doesn't add startup overhead.
-  if (!manager.has("local")) {
-    manager.registerShared("local", (id) => {
-      return createLocalModel(id);
-    });
-  }
+  // @huggingface/transformers import and model loading happen lazily on the
+  // first prepare/doGenerate/doStream call, so this adds no startup overhead.
+  manager.registerShared("local", (id) => {
+    return createLocalModel(id);
+  });
 
-  if (!manager.has("veryfront-cloud")) {
-    manager.registerShared("veryfront-cloud", (id) => {
-      return createVeryfrontCloudModel(id);
-    });
-  }
+  manager.registerShared("veryfront-cloud", (id) => {
+    return createVeryfrontCloudModel(id);
+  });
 }
 
 /**
@@ -238,7 +295,9 @@ function autoInitializeFromEnv(): void {
  * ```
  */
 export function resolveModel(modelString: string): ModelRuntime {
-  autoInitializeFromEnv();
+  if (typeof modelString !== "string") {
+    throw new TypeError('Model must be a string in "provider/model" format');
+  }
 
   const slashIndex = modelString.indexOf("/");
   if (slashIndex === -1) {
@@ -254,7 +313,12 @@ export function resolveModel(modelString: string): ModelRuntime {
   const providerName = modelString.slice(0, slashIndex);
   const modelId = modelString.slice(slashIndex + 1);
 
-  if (!providerName || !modelId) {
+  if (
+    !providerName ||
+    !modelId ||
+    providerName !== providerName.trim() ||
+    modelId !== modelId.trim()
+  ) {
     throw toError(
       createError({
         type: "config",
@@ -264,70 +328,78 @@ export function resolveModel(modelString: string): ModelRuntime {
     );
   }
 
-  const factory = manager.get(providerName);
+  autoInitializeFromEnv();
+  const factory = manager.getOwn(providerName) ??
+    bootstrapProviders.get(providerName) ??
+    manager.get(providerName);
   if (!factory) {
     const available = getRegisteredModelProviders().join(", ") || "none";
     throw toError(
       createError({
         type: "agent",
-        message: `Model provider "${providerName}" not registered. Available: ${available}`,
+        message:
+          `Model provider "${providerName}" not registered. Register it during application ` +
+          `composition with registerModelProvider() before resolving models. Available: ${available}`,
       }),
     );
   }
 
-  return factory(modelId);
+  return requireModelRuntime(factory(modelId), modelString);
 }
 
 /**
- * Check if a model provider is registered (project-scoped or shared).
+ * Check whether a model provider is available in the current scope.
+ *
+ * Project overrides, application bootstrap defaults, and framework-provided
+ * shared providers are all considered.
  */
 export function hasModelProvider(name: string): boolean {
+  const normalizedName = normalizeProviderName(name);
   autoInitializeFromEnv();
-  return manager.has(name);
+  return manager.getOwn(normalizedName) !== undefined ||
+    bootstrapProviders.has(normalizedName) ||
+    manager.has(normalizedName);
 }
 
 /**
- * Get list of registered model provider names (project-scoped + shared).
+ * Get provider names available in the current scope.
+ *
+ * The result includes project overrides, application bootstrap defaults, and
+ * framework-provided shared providers without duplicates.
  */
 export function getRegisteredModelProviders(): string[] {
   autoInitializeFromEnv();
-  return manager.getAllIds();
+  return Array.from(new Set([...manager.getAllIds(), ...bootstrapProviders.keys()]));
 }
 
 /**
  * Eagerly verify that the resolved model's runtime is available.
  *
- * For real local-engine models (created by `createLocalModel()`) this
- * eagerly loads the ONNX pipeline to surface `no_ai_available` errors
- * **before** the HTTP response stream is created. Must happen before the
- * ReadableStream so the chat handler can return a proper 503 rather than a
- * 200 with an in-band SSE error.
- *
- * Uses the `_isVfLocalModel` marker set by `createLocalModel()` to
- * distinguish real local-engine models from mock/custom providers that
- * happen to use `provider: "local"`.
+ * Provider runtimes can expose an idempotent `prepare()` hook to perform work
+ * that must fail before an HTTP response stream is created. Runtimes without a
+ * preparation phase require no action.
  */
 export async function ensureModelReady(
   model: ModelRuntime,
   abortSignal?: AbortSignal,
 ): Promise<void> {
-  if (model.prepare !== undefined) {
-    if (typeof model.prepare !== "function") {
-      throw new TypeError("Model runtime prepare hook must be a function");
-    }
-    await model.prepare(abortSignal);
-    return;
+  const prepare = model.prepare;
+  if (prepare === undefined) return;
+  if (typeof prepare !== "function") {
+    throw new TypeError("Model runtime prepare hook must be a function");
   }
-  if (!hasLocalModelRuntimeMarker(model)) return;
-  // modelId is "local/<id>" — strip the prefix to get the catalog id.
-  const catalogId = getModelRuntimeId(model)?.replace(/^local\//, "");
-  await verifyLocalRuntime(catalogId);
+  await prepare.call(model, abortSignal);
 }
 
 /**
- * Clear all registered model providers (for testing).
+ * Clear model providers registered in the current project source scope.
+ *
+ * Outside a project context, clears application bootstrap registrations.
+ * Framework-provided shared providers and other projects remain available.
  */
 export function clearModelProviders(): void {
-  manager.clearAll();
-  autoInitialized = false;
+  manager.clear();
+  if (tryGetRegistryScopeId() === null) {
+    bootstrapProviders.clear();
+  }
 }

--- a/src/provider/model-registry.ts
+++ b/src/provider/model-registry.ts
@@ -98,7 +98,8 @@ function getOpenAIEnvProviderName(baseURL: string | undefined): "openai" | "open
 }
 
 /**
- * Register a custom model provider factory.
+ * Register a custom model provider factory for the active project scope or
+ * application bootstrap.
  *
  * Registration inside a project source context is isolated to that context.
  * Registration during application bootstrap, outside a project context, is a
@@ -106,7 +107,13 @@ function getOpenAIEnvProviderName(baseURL: string | undefined): "openai" | "open
  *
  * @example
  * ```ts
- * registerModelProvider("custom", (id) => createCustomRuntime(id));
+ * const unregister = registerModelProvider(
+ *   "custom",
+ *   (id) => createCustomRuntime(id),
+ * );
+ *
+ * // Call during teardown when the registration is no longer needed.
+ * unregister();
  * ```
  */
 export function registerModelProvider(

--- a/src/provider/model-registry.ts
+++ b/src/provider/model-registry.ts
@@ -391,15 +391,9 @@ export async function ensureModelReady(
   await prepare.call(model, abortSignal);
 }
 
-/**
- * Clear model providers registered in the current project source scope.
- *
- * Outside a project context, clears application bootstrap registrations.
- * Framework-provided shared providers and other projects remain available.
- */
+/** Clear all registered model providers and reset lazy built-ins (for testing). */
 export function clearModelProviders(): void {
-  manager.clear();
-  if (tryGetRegistryScopeId() === null) {
-    bootstrapProviders.clear();
-  }
+  manager.clearAll();
+  bootstrapProviders.clear();
+  autoInitialized = false;
 }

--- a/src/provider/runtime-inspection.test.ts
+++ b/src/provider/runtime-inspection.test.ts
@@ -51,7 +51,7 @@ describe("provider/runtime-inspection", () => {
     assertEquals(providerReads, 1);
   });
 
-  it("classifies only runtimes that explicitly declare server-local execution", () => {
+  it("honors explicit placement before legacy local metadata", () => {
     let executionModeReads = 0;
     const model = runtimeWith({
       executionMode: {
@@ -69,7 +69,31 @@ describe("provider/runtime-inspection", () => {
         provider: { value: "local" },
         modelId: { value: "local/demo" },
       })),
+      true,
+    );
+    assertEquals(
+      isLocalModelRuntime(runtimeWith({
+        executionMode: { value: "remote" },
+        provider: { value: "local" },
+        modelId: { value: "local/demo" },
+        _isVfLocalModel: { value: true },
+      })),
       false,
+    );
+  });
+
+  it("preserves each legacy local runtime marker", () => {
+    assertEquals(
+      isLocalModelRuntime(runtimeWith({ provider: { value: "local" } })),
+      true,
+    );
+    assertEquals(
+      isLocalModelRuntime(runtimeWith({ modelId: { value: "local/demo" } })),
+      true,
+    );
+    assertEquals(
+      isLocalModelRuntime(runtimeWith({ _isVfLocalModel: { value: true } })),
+      true,
     );
   });
 
@@ -89,6 +113,19 @@ describe("provider/runtime-inspection", () => {
       false,
     );
     assertEquals(supportsModelRuntimeToolCalling(runtimeWith({})), true);
+    assertEquals(
+      supportsModelRuntimeToolCalling(runtimeWith({
+        provider: { value: "local" },
+      })),
+      false,
+    );
+    assertEquals(
+      supportsModelRuntimeToolCalling(runtimeWith({
+        modelId: { value: "local/demo" },
+        runtimeCapabilities: { value: { toolCalling: true } },
+      })),
+      true,
+    );
   });
 
   it("rejects malformed tool capability metadata", () => {
@@ -99,6 +136,17 @@ describe("provider/runtime-inspection", () => {
         })),
       TypeError,
       "must be a boolean",
+    );
+  });
+
+  it("rejects malformed execution placement metadata", () => {
+    assertThrows(
+      () =>
+        isLocalModelRuntime(runtimeWith({
+          executionMode: { value: "browser" },
+        })),
+      TypeError,
+      "executionMode",
     );
   });
 });

--- a/src/provider/runtime-inspection.test.ts
+++ b/src/provider/runtime-inspection.test.ts
@@ -1,0 +1,104 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ModelRuntime } from "./types.ts";
+import {
+  getModelRuntimeId,
+  getModelRuntimeProvider,
+  isLocalModelRuntime,
+  supportsModelRuntimeToolCalling,
+} from "./runtime-inspection.ts";
+
+function runtimeWith(metadata: PropertyDescriptorMap): ModelRuntime {
+  return Object.defineProperties({
+    async doGenerate() {
+      return {};
+    },
+    async doStream() {
+      return { stream: new ReadableStream() };
+    },
+  }, metadata) as ModelRuntime;
+}
+
+describe("provider/runtime-inspection", () => {
+  it("reads model metadata accessors once before validating their value", () => {
+    let modelIdReads = 0;
+    const model = runtimeWith({
+      modelId: {
+        get() {
+          modelIdReads += 1;
+          return modelIdReads === 1 ? "local/demo" : undefined;
+        },
+      },
+    });
+
+    assertEquals(getModelRuntimeId(model), "local/demo");
+    assertEquals(modelIdReads, 1);
+  });
+
+  it("reads provider metadata accessors once before validating their value", () => {
+    let providerReads = 0;
+    const model = runtimeWith({
+      provider: {
+        get() {
+          providerReads += 1;
+          return providerReads === 1 ? "local" : undefined;
+        },
+      },
+    });
+
+    assertEquals(getModelRuntimeProvider(model), "local");
+    assertEquals(providerReads, 1);
+  });
+
+  it("classifies only runtimes that explicitly declare server-local execution", () => {
+    let executionModeReads = 0;
+    const model = runtimeWith({
+      executionMode: {
+        get() {
+          executionModeReads += 1;
+          return executionModeReads === 1 ? "server-local" : undefined;
+        },
+      },
+    });
+
+    assertEquals(isLocalModelRuntime(model), true);
+    assertEquals(executionModeReads, 1);
+    assertEquals(
+      isLocalModelRuntime(runtimeWith({
+        provider: { value: "local" },
+        modelId: { value: "local/demo" },
+      })),
+      false,
+    );
+  });
+
+  it("keeps tool support independent from execution placement", () => {
+    assertEquals(
+      supportsModelRuntimeToolCalling(runtimeWith({
+        executionMode: { value: "server-local" },
+        runtimeCapabilities: { value: { toolCalling: true } },
+      })),
+      true,
+    );
+    assertEquals(
+      supportsModelRuntimeToolCalling(runtimeWith({
+        executionMode: { value: "remote" },
+        runtimeCapabilities: { value: { toolCalling: false } },
+      })),
+      false,
+    );
+    assertEquals(supportsModelRuntimeToolCalling(runtimeWith({})), true);
+  });
+
+  it("rejects malformed tool capability metadata", () => {
+    assertThrows(
+      () =>
+        supportsModelRuntimeToolCalling(runtimeWith({
+          runtimeCapabilities: { value: { toolCalling: "sometimes" } },
+        })),
+      TypeError,
+      "must be a boolean",
+    );
+  });
+});

--- a/src/provider/runtime-inspection.ts
+++ b/src/provider/runtime-inspection.ts
@@ -11,24 +11,33 @@ export function getModelRuntimeProvider(model: ModelRuntime): string | undefined
 }
 
 export function isLocalModelRuntime(model: ModelRuntime): boolean {
-  return model.executionMode === "server-local";
+  const executionMode = model.executionMode;
+  if (executionMode === "server-local") return true;
+  if (executionMode === "remote") return false;
+  if (executionMode !== undefined) {
+    throw new TypeError("Model runtime executionMode must be remote or server-local");
+  }
+
+  return model._isVfLocalModel === true ||
+    getModelRuntimeProvider(model) === "local" ||
+    (getModelRuntimeId(model)?.startsWith("local/") ?? false);
 }
 
 /**
  * Return whether a runtime supports tool calling.
  *
  * Existing runtimes predate capability metadata, so omission preserves their
- * historical behavior. An explicit `false` is authoritative regardless of
- * where inference executes.
+ * historical behavior: legacy local runtimes do not receive tools and other
+ * runtimes do. An explicit value is authoritative regardless of placement.
  */
 export function supportsModelRuntimeToolCalling(model: ModelRuntime): boolean {
   const capabilities = model.runtimeCapabilities;
-  if (capabilities === undefined) return true;
+  if (capabilities === undefined) return !isLocalModelRuntime(model);
   if (typeof capabilities !== "object" || capabilities === null) {
     throw new TypeError("Model runtime capabilities must be an object");
   }
   const toolCalling = capabilities.toolCalling;
-  if (toolCalling === undefined) return true;
+  if (toolCalling === undefined) return !isLocalModelRuntime(model);
   if (typeof toolCalling !== "boolean") {
     throw new TypeError("Model runtime toolCalling capability must be a boolean");
   }

--- a/src/provider/runtime-inspection.ts
+++ b/src/provider/runtime-inspection.ts
@@ -1,25 +1,36 @@
 import type { ModelRuntime } from "./types.ts";
 
-function toRuntimeRecord(model: ModelRuntime): ModelRuntime {
-  return model;
-}
-
 export function getModelRuntimeId(model: ModelRuntime): string | undefined {
-  const runtimeRecord = toRuntimeRecord(model);
-  return typeof runtimeRecord.modelId === "string" ? runtimeRecord.modelId : undefined;
+  const modelId = model.modelId;
+  return typeof modelId === "string" ? modelId : undefined;
 }
 
 export function getModelRuntimeProvider(model: ModelRuntime): string | undefined {
-  const runtimeRecord = toRuntimeRecord(model);
-  return typeof runtimeRecord.provider === "string" ? runtimeRecord.provider : undefined;
-}
-
-export function hasLocalModelRuntimeMarker(model: ModelRuntime): boolean {
-  return toRuntimeRecord(model)._isVfLocalModel === true;
+  const provider = model.provider;
+  return typeof provider === "string" ? provider : undefined;
 }
 
 export function isLocalModelRuntime(model: ModelRuntime): boolean {
-  return hasLocalModelRuntimeMarker(model) ||
-    getModelRuntimeProvider(model) === "local" ||
-    (getModelRuntimeId(model)?.startsWith("local/") ?? false);
+  return model.executionMode === "server-local";
+}
+
+/**
+ * Return whether a runtime supports tool calling.
+ *
+ * Existing runtimes predate capability metadata, so omission preserves their
+ * historical behavior. An explicit `false` is authoritative regardless of
+ * where inference executes.
+ */
+export function supportsModelRuntimeToolCalling(model: ModelRuntime): boolean {
+  const capabilities = model.runtimeCapabilities;
+  if (capabilities === undefined) return true;
+  if (typeof capabilities !== "object" || capabilities === null) {
+    throw new TypeError("Model runtime capabilities must be an object");
+  }
+  const toolCalling = capabilities.toolCalling;
+  if (toolCalling === undefined) return true;
+  if (typeof toolCalling !== "boolean") {
+    throw new TypeError("Model runtime toolCalling capability must be a boolean");
+  }
+  return toolCalling;
 }

--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -194,7 +194,10 @@ export interface ModelRuntimeCallOptions {
 
 /** Explicit behavioral support advertised by a model runtime. */
 export interface ModelRuntimeCapabilities {
-  /** Whether the runtime accepts and can emit tool calls. Defaults to true for legacy runtimes. */
+  /**
+   * Whether the runtime accepts and can emit tool calls. Omission preserves
+   * legacy behavior: false for legacy local runtimes and true otherwise.
+   */
   readonly toolCalling?: boolean;
   /** Whether the runtime accepts JSON or JSON-schema response formats. */
   readonly structuredOutput?: boolean;
@@ -205,7 +208,10 @@ export interface ModelRuntime<
   CallOptions = unknown,
   ContentPart = unknown,
 > extends RuntimeMetadata {
-  /** Where inference executes. Omitted runtimes are treated as remote. */
+  /**
+   * Where inference executes. When omitted, legacy `provider: "local"`,
+   * `local/*` model IDs, and `_isVfLocalModel` markers remain server-local.
+   */
   readonly executionMode?: "remote" | "server-local";
   /** Provider behavior, kept separate from execution placement. */
   readonly runtimeCapabilities?: ModelRuntimeCapabilities;

--- a/src/provider/veryfront-cloud/model-catalog.test.ts
+++ b/src/provider/veryfront-cloud/model-catalog.test.ts
@@ -2,6 +2,10 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  DEFAULT_VERYFRONT_CLOUD_CHAT_MODEL,
+  DEFAULT_VERYFRONT_CLOUD_MODEL_ID,
+  DEFAULT_VERYFRONT_CLOUD_PROVIDER_MODEL_ID,
+  DEFAULT_VERYFRONT_CLOUD_RUNTIME_MODEL_ID,
   findVeryfrontCloudModel,
   findVeryfrontCloudModelByModelId,
   getVeryfrontCloudProviderFromModelId,
@@ -10,8 +14,10 @@ import {
   resolveVeryfrontCloudGatewayModelId,
   resolveVeryfrontCloudModelId,
   resolveVeryfrontCloudModelThinking,
+  resolveVeryfrontCloudReasoningOption,
   resolveVeryfrontCloudThinkingProviderOptions,
   tryGetVeryfrontCloudProviderFromModelId,
+  VERYFRONT_CLOUD_CHAT_MODELS,
 } from "./model-catalog.ts";
 
 describe("provider/veryfront-cloud/model-catalog", () => {
@@ -36,9 +42,22 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(findVeryfrontCloudModel("nonexistent"), undefined);
   });
 
+  it("derives every default-model representation from one catalog entry", () => {
+    assertEquals(DEFAULT_VERYFRONT_CLOUD_CHAT_MODEL.id, DEFAULT_VERYFRONT_CLOUD_MODEL_ID);
+    assertEquals(
+      DEFAULT_VERYFRONT_CLOUD_PROVIDER_MODEL_ID,
+      DEFAULT_VERYFRONT_CLOUD_CHAT_MODEL.modelId,
+    );
+    assertEquals(
+      DEFAULT_VERYFRONT_CLOUD_RUNTIME_MODEL_ID,
+      `veryfront-cloud/${DEFAULT_VERYFRONT_CLOUD_PROVIDER_MODEL_ID}`,
+    );
+  });
+
   it("extracts providers from direct and hosted model ids", () => {
     assertEquals(getVeryfrontCloudProviderFromModelId("anthropic/claude-opus-4-8"), "anthropic");
     assertEquals(getVeryfrontCloudProviderFromModelId("veryfront-cloud/openai/gpt-5.5"), "openai");
+    assertEquals(getVeryfrontCloudProviderFromModelId("google/gemini-3.5-flash"), "google");
     assertEquals(
       getVeryfrontCloudProviderFromModelId("google-ai-studio/gemini-3.1-pro-preview"),
       "google",
@@ -50,6 +69,26 @@ describe("provider/veryfront-cloud/model-catalog", () => {
       Error,
       'Unknown model provider prefix "unknown"',
     );
+  });
+
+  it("keeps the exported catalog immutable", () => {
+    const originalFirstModelId = VERYFRONT_CLOUD_CHAT_MODELS[0]?.id;
+    assertThrows(
+      () =>
+        (VERYFRONT_CLOUD_CHAT_MODELS as unknown as Array<{ id: string }>).push({
+          id: "injected",
+        }),
+      TypeError,
+    );
+    assertThrows(
+      () => {
+        (VERYFRONT_CLOUD_CHAT_MODELS[0] as { id: string }).id = "corrupted";
+      },
+      TypeError,
+    );
+
+    assertEquals(VERYFRONT_CLOUD_CHAT_MODELS[0]?.id, originalFirstModelId);
+    assertEquals(findVeryfrontCloudModel("injected"), undefined);
   });
 
   it("returns undefined for unknown provider prefixes in the try helper", () => {
@@ -151,6 +190,45 @@ describe("provider/veryfront-cloud/model-catalog", () => {
       undefined,
     );
     assertEquals(resolveVeryfrontCloudModelThinking("mistral/mistral-large-2512"), undefined);
+    for (const model of VERYFRONT_CLOUD_CHAT_MODELS) {
+      if (model.thinkingBudgetTokens !== undefined) {
+        assertEquals(Number.isSafeInteger(model.thinkingBudgetTokens), true);
+        assertEquals(model.thinkingBudgetTokens > 0, true);
+      }
+    }
+  });
+
+  it("rejects non-positive and non-safe thinking budgets", () => {
+    const invalidBudgets = [
+      0,
+      -1,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.MAX_SAFE_INTEGER + 1,
+    ];
+
+    for (const budgetTokens of invalidBudgets) {
+      assertThrows(
+        () =>
+          resolveVeryfrontCloudReasoningOption("anthropic/claude-sonnet-4-6", {
+            enabled: true,
+            budgetTokens,
+          }),
+        Error,
+        "positive safe integer",
+      );
+      assertThrows(
+        () =>
+          resolveVeryfrontCloudThinkingProviderOptions("anthropic/claude-sonnet-4-6", {
+            enabled: true,
+            budgetTokens,
+          }),
+        Error,
+        "positive safe integer",
+      );
+    }
   });
 
   it("prefixes direct provider model ids for the Veryfront Cloud gateway", () => {
@@ -161,6 +239,10 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(
       resolveVeryfrontCloudGatewayModelId("google-ai-studio/gemini-3.5-flash"),
       "veryfront-cloud/google-ai-studio/gemini-3.5-flash",
+    );
+    assertEquals(
+      resolveVeryfrontCloudGatewayModelId("google/gemini-3.5-flash"),
+      "veryfront-cloud/google/gemini-3.5-flash",
     );
     assertEquals(
       resolveVeryfrontCloudGatewayModelId("mistral/mistral-large-2512"),

--- a/src/provider/veryfront-cloud/model-catalog.test.ts
+++ b/src/provider/veryfront-cloud/model-catalog.test.ts
@@ -310,6 +310,46 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     );
   });
 
+  it("keeps adaptive Anthropic thinking out of provider-neutral reasoning", () => {
+    for (
+      const modelId of [
+        "anthropic/claude-opus-4-7",
+        "anthropic/claude-opus-4-8",
+        "veryfront-cloud/anthropic/claude-opus-4-8",
+      ]
+    ) {
+      assertEquals(
+        resolveVeryfrontCloudReasoningOption(modelId, {
+          enabled: true,
+          budgetTokens: 2048,
+        }),
+        undefined,
+      );
+    }
+
+    assertEquals(
+      resolveVeryfrontCloudReasoningOption("anthropic/claude-opus-4-8", {
+        enabled: false,
+      }),
+      { enabled: false },
+    );
+  });
+
+  it("preserves provider-neutral reasoning for non-adaptive models", () => {
+    assertEquals(
+      resolveVeryfrontCloudReasoningOption("anthropic/claude-sonnet-4-6", {
+        enabled: true,
+        effort: "high",
+        budgetTokens: 2048,
+      }),
+      {
+        enabled: true,
+        effort: "high",
+        budgetTokens: 2048,
+      },
+    );
+  });
+
   it("omits disabled, missing-budget, and non-Anthropic thinking options", () => {
     assertEquals(
       resolveVeryfrontCloudThinkingProviderOptions("anthropic/claude-sonnet-4-6", {

--- a/src/provider/veryfront-cloud/model-catalog.ts
+++ b/src/provider/veryfront-cloud/model-catalog.ts
@@ -68,15 +68,32 @@ export function normalizeVeryfrontCloudProviderAlias(
 ): VeryfrontCloudProviderId | undefined {
   return VERYFRONT_CLOUD_PROVIDER_ALIASES.get(provider);
 }
+
+type VeryfrontCloudModelTransportCapabilities = {
+  readonly anthropicThinkingMode?: "adaptive";
+};
+
 /**
- * Anthropic models that use the adaptive thinking API (type: "adaptive").
- * New Opus/Sonnet versions supporting adaptive thinking must be added here,
- * otherwise they fall back to the standard budget-token thinking path.
+ * Model-specific transport capabilities that cannot be inferred from the
+ * provider family. Both provider-specific and provider-neutral option
+ * resolution must consult this catalog so the two representations cannot
+ * contradict each other.
  */
-const ANTHROPIC_ADAPTIVE_THINKING_ONLY_MODELS = new Set([
-  "anthropic/claude-opus-4-7",
-  "anthropic/claude-opus-4-8",
+const VERYFRONT_CLOUD_MODEL_TRANSPORT_CAPABILITIES = new Map<
+  string,
+  Readonly<VeryfrontCloudModelTransportCapabilities>
+>([
+  ["anthropic/claude-opus-4-7", Object.freeze({ anthropicThinkingMode: "adaptive" })],
+  ["anthropic/claude-opus-4-8", Object.freeze({ anthropicThinkingMode: "adaptive" })],
 ]);
+
+function getVeryfrontCloudModelTransportCapabilities(
+  modelId: string,
+): Readonly<VeryfrontCloudModelTransportCapabilities> | undefined {
+  return VERYFRONT_CLOUD_MODEL_TRANSPORT_CAPABILITIES.get(
+    normalizeVeryfrontCloudModelId(modelId),
+  );
+}
 
 /** Returns true if the given model ID is a Mistral model in the catalog. */
 export function isSupportedMistralModelId(modelId: string): boolean {
@@ -384,6 +401,11 @@ export function resolveVeryfrontCloudReasoningOption(
   }
 
   const budgetTokens = requireThinkingBudgetTokens(thinking.budgetTokens);
+  const capabilities = getVeryfrontCloudModelTransportCapabilities(modelId);
+  if (capabilities?.anthropicThinkingMode === "adaptive") {
+    return undefined;
+  }
+
   return {
     enabled: true,
     ...(thinking.effort ? { effort: thinking.effort } : {}),
@@ -405,8 +427,8 @@ export function resolveVeryfrontCloudThinkingProviderOptions(
     return undefined;
   }
 
-  const normalizedModelId = normalizeVeryfrontCloudModelId(modelId);
-  if (ANTHROPIC_ADAPTIVE_THINKING_ONLY_MODELS.has(normalizedModelId)) {
+  const capabilities = getVeryfrontCloudModelTransportCapabilities(modelId);
+  if (capabilities?.anthropicThinkingMode === "adaptive") {
     requireThinkingBudgetTokens(thinking.budgetTokens);
     return {
       anthropic: {

--- a/src/provider/veryfront-cloud/model-catalog.ts
+++ b/src/provider/veryfront-cloud/model-catalog.ts
@@ -17,14 +17,28 @@ export type VeryfrontCloudModelThinkingConfig = {
 
 /** Public API contract for Veryfront Cloud chat model. */
 export type VeryfrontCloudChatModel = {
-  id: string;
-  modelId: string;
-  provider: VeryfrontCloudProviderId;
-  name: string;
-  description: string;
-  thinking?: boolean;
-  thinkingBudgetTokens?: number;
+  readonly id: string;
+  readonly modelId: string;
+  readonly provider: VeryfrontCloudProviderId;
+  readonly name: string;
+  readonly description: string;
+  readonly thinking?: boolean;
+  readonly thinkingBudgetTokens?: number;
 };
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function requireThinkingBudgetTokens(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  if (!isPositiveSafeInteger(value)) {
+    throw INVALID_ARGUMENT.create({
+      detail: "Veryfront Cloud thinking budgetTokens must be a positive safe integer",
+    });
+  }
+  return value;
+}
 
 /**
  * Default Veryfront Cloud model ID used when no model is configured.
@@ -35,14 +49,25 @@ export const DEFAULT_VERYFRONT_CLOUD_MODEL_ID = "gpt-5.4-nano";
 /** Shared Veryfront Cloud model prefix value. */
 export const VERYFRONT_CLOUD_MODEL_PREFIX = "veryfront-cloud/";
 
-const VERYFRONT_CLOUD_GATEWAY_MODEL_PROVIDER_PREFIXES = [
-  "anthropic/",
-  "openai/",
-  "google/",
-  "google-ai-studio/",
-  "mistral/",
-  "moonshotai/",
-];
+const VERYFRONT_CLOUD_PROVIDER_ALIASES = new Map<string, VeryfrontCloudProviderId>([
+  ["anthropic", "anthropic"],
+  ["openai", "openai"],
+  ["google", "google"],
+  ["google-ai-studio", "google"],
+  ["mistral", "mistral"],
+  ["moonshotai", "moonshotai"],
+]);
+
+const VERYFRONT_CLOUD_GATEWAY_MODEL_PROVIDER_PREFIXES = Object.freeze(
+  Array.from(VERYFRONT_CLOUD_PROVIDER_ALIASES.keys(), (provider) => `${provider}/`),
+);
+
+/** Resolve a supported gateway provider alias without consulting object prototypes. */
+export function normalizeVeryfrontCloudProviderAlias(
+  provider: string,
+): VeryfrontCloudProviderId | undefined {
+  return VERYFRONT_CLOUD_PROVIDER_ALIASES.get(provider);
+}
 /**
  * Anthropic models that use the adaptive thinking API (type: "adaptive").
  * New Opus/Sonnet versions supporting adaptive thinking must be added here,
@@ -60,8 +85,7 @@ export function isSupportedMistralModelId(modelId: string): boolean {
   );
 }
 
-/** Shared Veryfront Cloud chat models value. */
-export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
+const veryfrontCloudChatModels: VeryfrontCloudChatModel[] = [
   {
     id: "opus",
     modelId: "anthropic/claude-opus-4-8",
@@ -189,6 +213,38 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
   },
 ];
 
+/** Shared Veryfront Cloud chat models value. */
+export const VERYFRONT_CLOUD_CHAT_MODELS: readonly VeryfrontCloudChatModel[] = Object.freeze(
+  veryfrontCloudChatModels.map((model) => {
+    if (
+      model.thinkingBudgetTokens !== undefined &&
+      !isPositiveSafeInteger(model.thinkingBudgetTokens)
+    ) {
+      throw new TypeError(
+        `Veryfront Cloud model "${model.id}" thinkingBudgetTokens must be a positive safe integer`,
+      );
+    }
+    return Object.freeze(model);
+  }),
+);
+
+const defaultVeryfrontCloudChatModel = VERYFRONT_CLOUD_CHAT_MODELS.find(
+  (model) => model.id === DEFAULT_VERYFRONT_CLOUD_MODEL_ID,
+);
+if (!defaultVeryfrontCloudChatModel) {
+  throw new Error(
+    `Veryfront Cloud default model "${DEFAULT_VERYFRONT_CLOUD_MODEL_ID}" is missing from the catalog`,
+  );
+}
+
+/** Catalog-backed default model descriptor. */
+export const DEFAULT_VERYFRONT_CLOUD_CHAT_MODEL = defaultVeryfrontCloudChatModel;
+/** Canonical direct provider/model ID for the default chat model. */
+export const DEFAULT_VERYFRONT_CLOUD_PROVIDER_MODEL_ID = DEFAULT_VERYFRONT_CLOUD_CHAT_MODEL.modelId;
+/** Canonical hosted runtime ID for the default chat model. */
+export const DEFAULT_VERYFRONT_CLOUD_RUNTIME_MODEL_ID =
+  `${VERYFRONT_CLOUD_MODEL_PREFIX}${DEFAULT_VERYFRONT_CLOUD_PROVIDER_MODEL_ID}`;
+
 /** Find Veryfront Cloud model. */
 export function findVeryfrontCloudModel(id: string): VeryfrontCloudChatModel | undefined {
   return VERYFRONT_CLOUD_CHAT_MODELS.find((model) => model.id === id);
@@ -214,17 +270,9 @@ export function getVeryfrontCloudProviderFromModelId(
   modelId: string,
 ): VeryfrontCloudProviderId {
   const normalizedModelId = normalizeVeryfrontCloudModelId(modelId);
-  const prefix = normalizedModelId.split("/")[0];
-
-  switch (prefix) {
-    case "google-ai-studio":
-      return "google";
-    case "openai":
-    case "anthropic":
-    case "mistral":
-    case "moonshotai":
-      return prefix;
-  }
+  const prefix = normalizedModelId.split("/", 1)[0] ?? "";
+  const provider = normalizeVeryfrontCloudProviderAlias(prefix);
+  if (provider) return provider;
 
   throw INVALID_ARGUMENT.create({
     detail: `Unknown model provider prefix "${prefix}" in model ID "${modelId}"`,
@@ -303,10 +351,7 @@ export function resolveVeryfrontCloudModelThinking(
   }
 
   const model = findVeryfrontCloudModelByModelId(modelId) ?? findVeryfrontCloudModel(modelId);
-  const budgetTokens = typeof model?.thinkingBudgetTokens === "number" &&
-      model.thinkingBudgetTokens > 0
-    ? model.thinkingBudgetTokens
-    : undefined;
+  const budgetTokens = requireThinkingBudgetTokens(model?.thinkingBudgetTokens);
   if (model?.thinking !== true && budgetTokens === undefined) {
     return undefined;
   }
@@ -338,12 +383,11 @@ export function resolveVeryfrontCloudReasoningOption(
     return undefined;
   }
 
+  const budgetTokens = requireThinkingBudgetTokens(thinking.budgetTokens);
   return {
     enabled: true,
     ...(thinking.effort ? { effort: thinking.effort } : {}),
-    ...(typeof thinking.budgetTokens === "number" && thinking.budgetTokens > 0
-      ? { budgetTokens: Math.floor(thinking.budgetTokens) }
-      : {}),
+    ...(budgetTokens !== undefined ? { budgetTokens } : {}),
   };
 }
 
@@ -363,6 +407,7 @@ export function resolveVeryfrontCloudThinkingProviderOptions(
 
   const normalizedModelId = normalizeVeryfrontCloudModelId(modelId);
   if (ANTHROPIC_ADAPTIVE_THINKING_ONLY_MODELS.has(normalizedModelId)) {
+    requireThinkingBudgetTokens(thinking.budgetTokens);
     return {
       anthropic: {
         thinking: {
@@ -376,16 +421,15 @@ export function resolveVeryfrontCloudThinkingProviderOptions(
     };
   }
 
-  if (typeof thinking.budgetTokens !== "number" || thinking.budgetTokens <= 0) {
-    return undefined;
-  }
+  const budgetTokens = requireThinkingBudgetTokens(thinking.budgetTokens);
+  if (budgetTokens === undefined) return undefined;
 
   return {
     anthropic: {
       temperature: 1,
       thinking: {
         type: "enabled",
-        budget_tokens: Math.floor(thinking.budgetTokens),
+        budget_tokens: budgetTokens,
       },
     },
   };
@@ -409,14 +453,16 @@ const PROVIDER_ORDER: VeryfrontCloudProviderId[] = [
 
 /** Group Veryfront Cloud models by provider. */
 export function groupVeryfrontCloudModelsByProvider(): Array<{
-  provider: VeryfrontCloudProviderId;
-  label: string;
-  models: VeryfrontCloudChatModel[];
+  readonly provider: VeryfrontCloudProviderId;
+  readonly label: string;
+  readonly models: readonly VeryfrontCloudChatModel[];
 }> {
   return PROVIDER_ORDER.map((provider) => ({
     provider,
     label: PROVIDER_LABELS[provider],
-    models: VERYFRONT_CLOUD_CHAT_MODELS.filter((model) => model.provider === provider),
+    models: Object.freeze(
+      VERYFRONT_CLOUD_CHAT_MODELS.filter((model) => model.provider === provider),
+    ),
   })).filter((group) => group.models.length > 0);
 }
 

--- a/src/provider/veryfront-cloud/shared.test.ts
+++ b/src/provider/veryfront-cloud/shared.test.ts
@@ -35,6 +35,23 @@ describe("provider/veryfront-cloud/shared", () => {
       Error,
       'Invalid veryfront-cloud model string: "openai"',
     );
+    for (const modelId of ["openai/ gpt-5.5", "openai/gpt-5.5 ", "openai/ "]) {
+      assertThrows(
+        () => parseVeryfrontCloudModelId(modelId, "language"),
+        Error,
+        `Invalid veryfront-cloud model string: "${modelId}"`,
+      );
+    }
+  });
+
+  it("rejects object-prototype names as provider aliases", () => {
+    for (const provider of ["constructor", "toString", "valueOf", "__proto__"]) {
+      assertThrows(
+        () => parseVeryfrontCloudModelId(`${provider}/model`, "language"),
+        Error,
+        `Invalid veryfront-cloud model string: "${provider}/model"`,
+      );
+    }
   });
 
   it("rejects unsupported Mistral model IDs at the provider boundary", () => {
@@ -61,6 +78,52 @@ describe("provider/veryfront-cloud/shared", () => {
     );
   });
 
+  it("preserves base URL query parameters and removes fragments", () => {
+    assertEquals(
+      getVeryfrontCloudGatewayBaseUrl(
+        "https://api.veryfront.com/base/?region=eu#private-fragment",
+        "openai",
+      ),
+      "https://api.veryfront.com/base/ai/gateway/openai/v1?region=eu",
+    );
+  });
+
+  it("rejects unsafe gateway base URLs and unknown providers", () => {
+    for (
+      const baseURL of [
+        "file:///tmp/gateway",
+        "javascript:alert(1)",
+        "not a URL",
+        "https://user:private-password@api.veryfront.com",
+      ]
+    ) {
+      assertThrows(
+        () => getVeryfrontCloudGatewayBaseUrl(baseURL, "openai"),
+        TypeError,
+        "API base URL",
+      );
+    }
+    assertThrows(
+      () => getVeryfrontCloudGatewayBaseUrl("https://api.veryfront.com", "constructor" as never),
+      TypeError,
+      'Unsupported Veryfront Cloud provider "constructor"',
+    );
+  });
+
+  it("rejects malformed gateway credentials before creating a fetch wrapper", () => {
+    for (const token of ["", " token", "token ", "token\nprivate", "token-\u00e5"]) {
+      assertThrows(
+        () =>
+          createVeryfrontCloudFetch(
+            token,
+            "https://93.184.216.34/ai/gateway/openai/v1",
+          ),
+        TypeError,
+        "Veryfront Cloud API token",
+      );
+    }
+  });
+
   it("rewrites auth headers for the gateway fetch wrapper", async () => {
     let capturedRequest: Request | undefined;
     globalThis.fetch = ((input: URL | Request | string, init?: RequestInit) => {
@@ -78,6 +141,8 @@ describe("provider/veryfront-cloud/shared", () => {
         Authorization: "Bearer upstream-token",
         "x-api-key": "anthropic-key",
         "x-goog-api-key": "google-key",
+        "x-veryfront-project-slug": "spoofed-project",
+        "x-veryfront-billing-group-id": "spoofed-billing-group",
         "x-extra-header": "kept",
       },
     });
@@ -86,10 +151,11 @@ describe("provider/veryfront-cloud/shared", () => {
     assertEquals(capturedRequest?.headers.get("x-api-key"), null);
     assertEquals(capturedRequest?.headers.get("x-goog-api-key"), null);
     assertEquals(capturedRequest?.headers.get("x-extra-header"), "kept");
+    assertEquals(capturedRequest?.headers.get("x-veryfront-project-slug"), null);
     assertEquals(capturedRequest?.headers.get("x-veryfront-billing-group-id"), null);
   });
 
-  it("forwards the request-scoped billing group id to the gateway", async () => {
+  it("replaces caller identity headers with trusted project and billing context", async () => {
     let capturedRequest: Request | undefined;
     globalThis.fetch = ((input: URL | Request | string, init?: RequestInit) => {
       capturedRequest = new Request(input, init);
@@ -99,13 +165,24 @@ describe("provider/veryfront-cloud/shared", () => {
     const wrappedFetch = createVeryfrontCloudFetch(
       "vf_test_provider",
       "https://93.184.216.34/ai/gateway/openai/v1",
+      "trusted-project",
     );
 
     await runWithVeryfrontCloudContext(
       { billingGroupId: "evalrun_20260628_kimi" },
-      () => wrappedFetch("https://93.184.216.34/ai/gateway/openai/v1/chat/completions"),
+      () =>
+        wrappedFetch("https://93.184.216.34/ai/gateway/openai/v1/chat/completions", {
+          headers: {
+            "x-veryfront-project-slug": "spoofed-project",
+            "x-veryfront-billing-group-id": "spoofed-billing-group",
+          },
+        }),
     );
 
+    assertEquals(
+      capturedRequest?.headers.get("x-veryfront-project-slug"),
+      "trusted-project",
+    );
     assertEquals(
       capturedRequest?.headers.get("x-veryfront-billing-group-id"),
       "evalrun_20260628_kimi",

--- a/src/provider/veryfront-cloud/shared.test.ts
+++ b/src/provider/veryfront-cloud/shared.test.ts
@@ -124,6 +124,28 @@ describe("provider/veryfront-cloud/shared", () => {
     }
   });
 
+  it("rejects unsafe API base URLs before creating a fetch wrapper", () => {
+    const cases = [
+      ["", "non-empty valid HTTP(S) URL"],
+      [" https://api.veryfront.com", "non-empty valid HTTP(S) URL"],
+      ["not a URL", "valid HTTP(S) URL"],
+      ["file:///tmp/gateway", "HTTP or HTTPS"],
+      ["javascript:alert(1)", "HTTP or HTTPS"],
+      [
+        "https://user:private-password@api.veryfront.com/ai/gateway/openai/v1",
+        "must not contain embedded credentials",
+      ],
+    ] as const;
+
+    for (const [baseURL, expectedMessage] of cases) {
+      assertThrows(
+        () => createVeryfrontCloudFetch("vf_test_provider", baseURL),
+        TypeError,
+        expectedMessage,
+      );
+    }
+  });
+
   it("rewrites auth headers for the gateway fetch wrapper", async () => {
     let capturedRequest: Request | undefined;
     globalThis.fetch = ((input: URL | Request | string, init?: RequestInit) => {

--- a/src/provider/veryfront-cloud/shared.ts
+++ b/src/provider/veryfront-cloud/shared.ts
@@ -30,10 +30,16 @@ const GATEWAY_PATHS = new Map<VeryfrontCloudProviderId, string>([
   ["moonshotai", "ai/gateway/moonshotai/v1"],
 ]);
 
-function joinUrl(base: string, path: string): string {
+function parseVeryfrontCloudApiBaseUrl(value: string): URL {
+  if (typeof value !== "string" || value.length === 0 || value.trim() !== value) {
+    throw new TypeError(
+      "Veryfront Cloud API base URL must be a non-empty valid HTTP(S) URL",
+    );
+  }
+
   let url: URL;
   try {
-    url = new URL(base);
+    url = new URL(value);
   } catch {
     throw new TypeError("Veryfront Cloud API base URL must be a valid HTTP(S) URL");
   }
@@ -45,6 +51,11 @@ function joinUrl(base: string, path: string): string {
       "Veryfront Cloud API base URL must not contain embedded credentials",
     );
   }
+  return url;
+}
+
+function joinUrl(base: string, path: string): string {
+  const url = parseVeryfrontCloudApiBaseUrl(base);
   url.pathname = `${url.pathname.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
   url.hash = "";
   return url.toString();
@@ -165,7 +176,7 @@ export function createVeryfrontCloudFetch(
     apiToken,
     "Veryfront Cloud API token",
   );
-  const authorizedOrigin = new URL(apiBaseUrl).origin;
+  const authorizedOrigin = parseVeryfrontCloudApiBaseUrl(apiBaseUrl).origin;
   return (input, init) => {
     const request = new Request(input, init);
     const headers = new Headers(request.headers);

--- a/src/provider/veryfront-cloud/shared.ts
+++ b/src/provider/veryfront-cloud/shared.ts
@@ -8,7 +8,12 @@ import {
   getCurrentVeryfrontCloudContext,
   markCurrentVeryfrontCloudBillingGroupUsed,
 } from "./context.ts";
-import { isSupportedMistralModelId, type VeryfrontCloudProviderId } from "./model-catalog.ts";
+import {
+  isSupportedMistralModelId,
+  normalizeVeryfrontCloudProviderAlias,
+  type VeryfrontCloudProviderId,
+} from "./model-catalog.ts";
+import { requireProviderCredential } from "../runtime-loader/provider-request-init.ts";
 
 export type { VeryfrontCloudProviderId } from "./model-catalog.ts";
 
@@ -17,25 +22,32 @@ interface ParsedVeryfrontCloudModelId {
   modelId: string;
 }
 
-const PROVIDER_ALIASES: Record<string, VeryfrontCloudProviderId> = {
-  anthropic: "anthropic",
-  openai: "openai",
-  google: "google",
-  "google-ai-studio": "google",
-  mistral: "mistral",
-  moonshotai: "moonshotai",
-};
-
-const GATEWAY_PATHS: Record<VeryfrontCloudProviderId, string> = {
-  anthropic: "ai/gateway/anthropic/v1",
-  openai: "ai/gateway/openai/v1",
-  google: "ai/gateway/google/v1beta",
-  mistral: "ai/gateway/mistral/v1",
-  moonshotai: "ai/gateway/moonshotai/v1",
-};
+const GATEWAY_PATHS = new Map<VeryfrontCloudProviderId, string>([
+  ["anthropic", "ai/gateway/anthropic/v1"],
+  ["openai", "ai/gateway/openai/v1"],
+  ["google", "ai/gateway/google/v1beta"],
+  ["mistral", "ai/gateway/mistral/v1"],
+  ["moonshotai", "ai/gateway/moonshotai/v1"],
+]);
 
 function joinUrl(base: string, path: string): string {
-  return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+  let url: URL;
+  try {
+    url = new URL(base);
+  } catch {
+    throw new TypeError("Veryfront Cloud API base URL must be a valid HTTP(S) URL");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new TypeError("Veryfront Cloud API base URL must use HTTP or HTTPS");
+  }
+  if (url.username || url.password) {
+    throw new TypeError(
+      "Veryfront Cloud API base URL must not contain embedded credentials",
+    );
+  }
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+  url.hash = "";
+  return url.toString();
 }
 
 function createInvalidModelIdError(modelId: string): Error {
@@ -58,10 +70,13 @@ export function parseVeryfrontCloudModelId(
   }
 
   const rawProvider = modelId.slice(0, slashIndex);
-  const normalizedProvider = PROVIDER_ALIASES[rawProvider];
+  const normalizedProvider = normalizeVeryfrontCloudProviderAlias(rawProvider);
   const upstreamModelId = modelId.slice(slashIndex + 1);
 
-  if (!normalizedProvider || !upstreamModelId) {
+  if (
+    !normalizedProvider || !upstreamModelId ||
+    upstreamModelId.trim() !== upstreamModelId
+  ) {
     throw createInvalidModelIdError(modelId);
   }
 
@@ -125,7 +140,11 @@ export function getVeryfrontCloudGatewayBaseUrl(
   apiBaseUrl: string,
   provider: VeryfrontCloudProviderId,
 ): string {
-  return joinUrl(apiBaseUrl, GATEWAY_PATHS[provider]);
+  const gatewayPath = GATEWAY_PATHS.get(provider);
+  if (!gatewayPath) {
+    throw new TypeError(`Unsupported Veryfront Cloud provider "${String(provider)}"`);
+  }
+  return joinUrl(apiBaseUrl, gatewayPath);
 }
 
 /**
@@ -142,15 +161,20 @@ export function createVeryfrontCloudFetch(
   apiBaseUrl: string,
   projectSlug?: string,
 ): typeof fetch {
+  const trustedApiToken = requireProviderCredential(
+    apiToken,
+    "Veryfront Cloud API token",
+  );
   const authorizedOrigin = new URL(apiBaseUrl).origin;
-
   return (input, init) => {
     const request = new Request(input, init);
     const headers = new Headers(request.headers);
 
     headers.delete("x-api-key");
     headers.delete("x-goog-api-key");
-    headers.set("Authorization", `Bearer ${apiToken}`);
+    headers.delete("x-veryfront-project-slug");
+    headers.delete("x-veryfront-billing-group-id");
+    headers.set("Authorization", `Bearer ${trustedApiToken}`);
 
     if (projectSlug) {
       headers.set("x-veryfront-project-slug", projectSlug);

--- a/src/skill/limits.ts
+++ b/src/skill/limits.ts
@@ -41,8 +41,9 @@ export const SKILL_RUNTIME_AVAILABLE_TOOL_MAX_ENTRIES = 1_000;
 export const SKILL_CATALOG_MAX_SKILLS = 128;
 export const SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS = 8 * 1_048_576;
 export const SKILL_CATALOG_MAX_DOCUMENT_UTF8_BYTES = 16 * 1_048_576;
-// One catalog can retain a maximally populated Skill plus one source path for
-// every admitted definition. Other combinations share this same bounded total.
+// One skill may legitimately advertise the full three-directory readable-file
+// budget. Keep enough aggregate space for that catalog member plus one source
+// path for every retained definition, while still bounding total path memory.
 export const SKILL_CATALOG_MAX_PATH_ENTRIES = SKILL_LOADABLE_REFERENCE_MAX_ENTRIES +
   SKILL_CATALOG_MAX_SKILLS;
 export const SKILL_CATALOG_MAX_METADATA_CHARACTERS = 1_048_576;


### PR DESCRIPTION
## Summary

- restores the provider runtime catalog and project-scoped provider registry on current main
- restores the bounded hosted project-skill runtime with strict path, response, pagination, byte, entry, concurrency, deadline, and cancellation enforcement
- keeps runtime tool support independent from local versus remote execution placement
- validates Veryfront Cloud model identifiers, gateway base URLs, credentials, trusted identity headers, and adaptive thinking contracts
- preserves request-scoped cancellation through skill listing, file reads, tracing, and local model preparation
- documents provider registration ownership and teardown

## Review fixes

- per-call skill deadlines now override client defaults without allowing call sites to replace trusted transport configuration
- strict error fallback messages are bounded
- pre-aborted local preparation does not start a cold load; in-flight callers can detach safely from shared cached preparation
- the 200-page strict ceiling is documented as defense in depth for caller-supplied budgets; the public shared default remains the tighter 50-page aggregate ceiling

The deferred-results review suggestion was not applied. AI SDK 7 treats that flag as provider-tool configuration and consults it from the active tool set; its output message parts do not carry the field. Propagating it through framework message and UI protocols would create a new wire contract rather than preserve an upstream one.

## Verification

- deno task verify:quick
- 226 changed-surface tests passed; the six transport tests that require the deterministic host seam were rerun with DENO_TESTING=1 and passed
- 81 post-rebase provider, project-file, and local preparation tests passed
- full formatting, lint, documentation, dependency, module, extension, core dependency, and typecheck gates passed
- git diff check passed

Current diff: 34 files, 5323 additions, 981 deletions.