### PR TITLE
fix(agent): restore project skill runtime hardening

### DIFF
--- a/src/agent/hosted/agent-project-steering.test.ts
+++ b/src/agent/hosted/agent-project-steering.test.ts
@@ -67,13 +67,14 @@ Deno.test("createHostedAgentProjectSteering registers the built-in schema valida
     assertEquals(tryResolve<SchemaValidator>("SchemaValidator"), undefined);
 
     const baseDir = writeAgentDefinition({ rootDir, agentId: "writer" });
-    createHostedAgentProjectSteering({
+    const steering = createHostedAgentProjectSteeringPublic({
       baseDir,
       agentId: "writer",
       getApiUrl: () => "https://api.example.com",
     });
 
     assertEquals(typeof tryResolve<SchemaValidator>("SchemaValidator")?.object, "function");
+    assertEquals(steering.getAgentConfig().id, "writer");
   });
 });
 

--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -410,6 +410,58 @@ Deno.test("createHostedProjectRemoteToolSource fails closed on claimed but uncon
   assertEquals(switchCount, 0);
 });
 
+Deno.test("createHostedProjectRemoteToolSource rejects unconfirmed claimed navigation success", async () => {
+  let switchCount = 0;
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [navigationTool("studio_open_project")],
+      execute: () => ({
+        structuredContent: {
+          success: true,
+          project_id: "different-project",
+          slug: "different-project",
+        },
+      }),
+    }),
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: ["studio_open_project"],
+    },
+    onProjectSwitch: () => {
+      switchCount += 1;
+    },
+  });
+
+  const result = await source.executeTool("studio_open_project", {
+    project_reference: "requested-project",
+  });
+
+  assertEquals(result, createUnconfirmedProjectContextSwitchResult());
+  assertEquals(switchCount, 0);
+});
+
+Deno.test("createHostedProjectRemoteToolSource preserves upstream navigation failure", async () => {
+  const failure = { structuredContent: { success: false, message: "not found" } };
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [navigationTool("studio_open_project")],
+      execute: () => failure,
+    }),
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: ["studio_open_project"],
+    },
+    onProjectSwitch: () => {
+      throw new Error("unexpected project switch");
+    },
+  });
+
+  assertEquals(
+    await source.executeTool("studio_open_project", {
+      project_reference: "missing-project",
+    }),
+    failure,
+  );
+});
+
 Deno.test("createHostedProjectRemoteToolSource skips mutation callbacks for failed results", async () => {
   let mutationCount = 0;
   const source = createHostedProjectRemoteToolSource({

--- a/src/agent/hosted/project-steering-adapter.test.ts
+++ b/src/agent/hosted/project-steering-adapter.test.ts
@@ -97,8 +97,7 @@ Deno.test("hosted project steering uses the bounded transport by default", async
     );
     await Promise.resolve();
 
-    assert(error instanceof RangeError);
-    assertStringIncludes(error.message, "Project file response may contain at most");
+    assertStringIncludes(String(error), "Project files list response exceeds");
     assertEquals(cancelled, true);
   });
 });

--- a/src/agent/hosted/project-steering-adapter.ts
+++ b/src/agent/hosted/project-steering-adapter.ts
@@ -14,7 +14,7 @@ import {
 } from "../runtime/load-skill-tool.ts";
 import type { MutableAgentProjectContext } from "../project/context.ts";
 import {
-  createRuntimeProjectFilesClient,
+  createStrictRuntimeProjectFilesClient,
   type RuntimeProjectFilesClient,
   type RuntimeProjectFilesClientOptions,
   type RuntimeProjectFilesFetch,
@@ -122,7 +122,7 @@ function createProjectFilesClientOptions(
 function createDefaultProjectFilesClient(
   options: HostedProjectSteeringAdapterOptions,
 ): RuntimeProjectFilesClient {
-  return createRuntimeProjectFilesClient(createProjectFilesClientOptions(options));
+  return createStrictRuntimeProjectFilesClient(createProjectFilesClientOptions(options));
 }
 
 function createDefaultProjectSkillLoader(

--- a/src/agent/runtime/builtin-skill-files.test.ts
+++ b/src/agent/runtime/builtin-skill-files.test.ts
@@ -40,6 +40,10 @@ async function withTempDirAsync(fn: (dir: string) => Promise<void>): Promise<voi
   }
 }
 
+function assertDoesNotExposePath(error: Error, rootDir: string): void {
+  assertEquals(error.message.includes(rootDir), false);
+}
+
 Deno.test("resolveRuntimeBuiltinSkillsDir resolves repo-root skills from dist-like paths", () => {
   withTempDir((rootDir) => {
     const baseDir = resolve(rootDir, "dist", "src", "skills");
@@ -252,17 +256,17 @@ Deno.test("runtime builtin skill reads enforce the shared text-file budget", () 
       largeContent,
     );
 
-    assertThrows(
+    const directoryError = assertThrows(
       () => readRuntimeBuiltinDirectorySkill(rootDir, "directory-skill"),
       RangeError,
       `exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
     );
-    assertThrows(
+    const flatError = assertThrows(
       () => readRuntimeBuiltinFlatSkill(rootDir, "flat-skill"),
       RangeError,
       `exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
     );
-    assertThrows(
+    const referenceError = assertThrows(
       () =>
         readRuntimeBuiltinSkillReferenceFile(
           rootDir,
@@ -272,6 +276,9 @@ Deno.test("runtime builtin skill reads enforce the shared text-file budget", () 
       RangeError,
       `exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
     );
+    for (const error of [directoryError, flatError, referenceError]) {
+      assertDoesNotExposePath(error, rootDir);
+    }
   });
 });
 
@@ -279,11 +286,12 @@ Deno.test("runtime builtin skill reads reject malformed UTF-8", () => {
   withTempDir((rootDir) => {
     Deno.writeFileSync(resolve(rootDir, "writer.md"), new Uint8Array([0xc3, 0x28]));
 
-    assertThrows(
+    const error = assertThrows(
       () => readRuntimeBuiltinFlatSkill(rootDir, "writer"),
       TypeError,
       "must contain valid UTF-8",
     );
+    assertDoesNotExposePath(error, rootDir);
   });
 });
 

--- a/src/agent/runtime/load-tools-tool.test.ts
+++ b/src/agent/runtime/load-tools-tool.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeToolDiscoveryContext } from "./tool-discovery-context.ts";
 import { createLoadToolsTool, type LoadToolsToolOptions } from "./load-tools-tool.ts";
@@ -254,7 +254,9 @@ describe("load_tools tool", () => {
       await tool.execute({ names: ["overflow_tool"] });
 
       assertEquals(rejected.length, 1);
-      assertEquals(rejected[0].names, ["overflow_tool"]);
+      const [rejection] = rejected;
+      assertExists(rejection);
+      assertEquals(rejection.names, ["overflow_tool"]);
     });
   });
 

--- a/src/agent/runtime/project-files-client.test.ts
+++ b/src/agent/runtime/project-files-client.test.ts
@@ -4,14 +4,25 @@ import {
   assertInstanceOf,
   assertRejects,
   assertStringIncludes,
+  assertThrows,
 } from "#veryfront/testing/assert.ts";
+import { SKILL_TEXT_FILE_MAX_BYTES } from "#veryfront/skill/limits.ts";
 import {
   createRuntimeProjectFileListingBudget,
   createRuntimeProjectFilesClient,
+  createStrictRuntimeProjectFilesClient,
   getRuntimeProjectFile,
+  getRuntimeProjectFileListItemSchema,
   getRuntimeProjectFiles,
+  getRuntimeProjectFileSchema,
+  getStrictRuntimeProjectFile,
+  getStrictRuntimeProjectFileListItemSchema,
+  getStrictRuntimeProjectFiles,
+  getStrictRuntimeProjectFileSchema,
+  type RuntimeGetProjectFileOptions,
+  runtimeProjectFileListItemSchema,
   RuntimeProjectFilesApiAuthError,
-  type RuntimeProjectFilesClientOptions,
+  runtimeProjectFileSchema,
   type RuntimeProjectFilesFetch,
 } from "./project-files-client.ts";
 
@@ -21,10 +32,39 @@ const baseOptions = {
   authToken: "token-1",
 };
 
+const TEST_MAX_PAGE_LIMIT = 100;
+const TEST_MAX_TOTAL_FILES = 10_000;
+const TEST_MAX_TOTAL_PAGES = 200;
+const TEST_MAX_OPERATION_TIMEOUT_MS = 300_000;
+const TEST_MAX_PATH_CHARACTERS = 4_096;
+const TEST_MAX_ERROR_BODY_BYTES = 64 * 1_024;
+const TEST_PUBLIC_LISTING_MAX_PAGES = 50;
+
+function createUnboundedTestListingBudget() {
+  return {
+    consumePage() {},
+    consumeBytes(_byteCount: number) {},
+  };
+}
+
 type FetchCall = {
   url: string;
   init: RequestInit;
 };
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -37,22 +77,40 @@ function textResponse(body: string, status: number): Response {
   return new Response(body, { status });
 }
 
-function chunkedJsonResponse(body: unknown, chunkBytes: number): Response {
-  const bytes = new TextEncoder().encode(JSON.stringify(body));
-  let offset = 0;
+function erroringResponse(error: unknown, status = 200): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(error);
+      },
+    }),
+    { status },
+  );
+}
+
+function streamResponse(
+  chunks: readonly Uint8Array[],
+  init: ResponseInit = {},
+  hooks: { onPull?: () => void; onCancel?: () => void } = {},
+): Response {
+  let index = 0;
   return new Response(
     new ReadableStream<Uint8Array>({
       pull(controller) {
-        if (offset >= bytes.byteLength) {
+        hooks.onPull?.();
+        const chunk = chunks[index];
+        index += 1;
+        if (chunk) {
+          controller.enqueue(chunk);
+        } else {
           controller.close();
-          return;
         }
-        const end = Math.min(offset + chunkBytes, bytes.byteLength);
-        controller.enqueue(bytes.slice(offset, end));
-        offset = end;
+      },
+      cancel() {
+        hooks.onCancel?.();
       },
     }),
-    { headers: { "Content-Type": "application/json" } },
+    init,
   );
 }
 
@@ -91,13 +149,391 @@ function getErrorMessage(error: unknown): string {
   throw new Error("Expected Error");
 }
 
-Deno.test("getRuntimeProjectFile returns a project file from the API file route", async () => {
+Deno.test("legacy runtime project file schemas preserve permissive string paths", () => {
+  const legacyPaths = [
+    "",
+    "../secret.md",
+    "/absolute.md",
+    "skills\\writer\\SKILL.md",
+    "skills//writer/SKILL.md",
+    "control\u0000path",
+    String.fromCharCode(0xd800),
+    "x".repeat(TEST_MAX_PATH_CHARACTERS + 1),
+  ];
+
+  for (const path of legacyPaths) {
+    for (const schema of [getRuntimeProjectFileSchema(), runtimeProjectFileSchema]) {
+      assertEquals(schema.safeParse({ path, content: "Body" }).success, true);
+    }
+    for (
+      const schema of [
+        getRuntimeProjectFileListItemSchema(),
+        runtimeProjectFileListItemSchema,
+      ]
+    ) {
+      assertEquals(schema.safeParse({ path }).success, true);
+    }
+
+    assertEquals(
+      getStrictRuntimeProjectFileSchema().safeParse({ path, content: "Body" }).success,
+      false,
+    );
+    assertEquals(
+      getStrictRuntimeProjectFileListItemSchema().safeParse({ path }).success,
+      false,
+    );
+  }
+
+  const oversizedContent = "x".repeat(SKILL_TEXT_FILE_MAX_BYTES + 1);
+  assertEquals(
+    getRuntimeProjectFileSchema().safeParse({ path: "safe.md", content: oversizedContent }).success,
+    true,
+  );
+  assertEquals(
+    getStrictRuntimeProjectFileSchema().safeParse({
+      path: "safe.md",
+      content: oversizedContent,
+    }).success,
+    true,
+  );
+});
+
+Deno.test("runtime project files client snapshots transport and rejects call-site overrides", async () => {
+  const initialFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "initial" }),
+  );
+  const mutatedFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "mutated" }),
+  );
+  const mutableOptions: {
+    apiUrl: URL;
+    fetch: RuntimeProjectFilesFetch;
+  } = {
+    apiUrl: new URL("https://initial.example.com/v1"),
+    fetch: initialFetch,
+  };
+  const mutableClient = createRuntimeProjectFilesClient(mutableOptions);
+  mutableOptions.apiUrl.hostname = "mutated.example.com";
+  mutableOptions.fetch = mutatedFetch;
+
+  const initialResult = await mutableClient.getProjectFile({
+    projectId: "project-1",
+    authToken: "token-1",
+    path: "src/index.ts",
+  });
+  assertEquals(initialResult?.content, "initial");
+  assertEquals(initialFetch.calls.length, 1);
+  assertEquals(getRequestedUrl(initialFetch).origin, "https://initial.example.com");
+  assertEquals(mutatedFetch.calls.length, 0);
+
+  const configuredFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "configured" }),
+  );
+  const overrideFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "override" }),
+  );
+  const configuredClient = createRuntimeProjectFilesClient({
+    apiUrl: "https://configured.example.com",
+    fetch: configuredFetch,
+  });
+  const overrideResult = await configuredClient.getProjectFile({
+    projectId: "project-1",
+    authToken: "token-1",
+    path: "src/index.ts",
+    apiUrl: "https://override.example.com",
+    fetch: overrideFetch,
+  } as RuntimeGetProjectFileOptions);
+
+  assertEquals(overrideResult?.content, "configured");
+  assertEquals(getRequestedUrl(configuredFetch).origin, "https://configured.example.com");
+  assertEquals(overrideFetch.calls.length, 0);
+});
+
+Deno.test("legacy runtime project file validation remains inside the trace callback", async () => {
+  let legacyTraceCalls = 0;
+  const legacyResult = await getRuntimeProjectFile({
+    apiUrl: "not a URL",
+    projectId: "..",
+    authToken: "",
+    path: "../unsafe.md",
+    trace: async <T>(_name: string, _fn: () => Promise<T>): Promise<T> => {
+      legacyTraceCalls += 1;
+      return { path: "/trace-result.md", content: "legacy" } as T;
+    },
+  });
+  assertEquals(legacyTraceCalls, 1);
+  assertEquals(legacyResult, { path: "/trace-result.md", content: "legacy" });
+
+  let strictTraceCalls = 0;
+  await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      apiUrl: "not a URL",
+      projectId: "..",
+      authToken: "",
+      path: "../unsafe.md",
+      trace: async <T>(_name: string, fn: () => Promise<T>): Promise<T> => {
+        strictTraceCalls += 1;
+        return await fn();
+      },
+    })
+  );
+  assertEquals(strictTraceCalls, 0);
+});
+
+Deno.test("legacy getRuntimeProjectFile returns mismatched paths and oversized content", async () => {
+  const content = "x".repeat(SKILL_TEXT_FILE_MAX_BYTES + 1);
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "/different.md", content }),
+  );
+
+  const result = await getRuntimeProjectFile({
+    apiUrl: "https://api.test",
+    projectId: "project/one",
+    authToken: "",
+    branchId: "",
+    path: "../requested.md",
+    fetch: fetchSpy,
+  });
+
+  assertEquals(result, { path: "/different.md", content });
+  assertEquals(
+    getRequestedUrl(fetchSpy).pathname,
+    "/projects/project%2Fone/files/..%2Frequested.md",
+  );
+  assertEquals(getRequestedUrl(fetchSpy).searchParams.has("branch"), false);
+});
+
+Deno.test("getRuntimeProjectFile enforces its public content and transport bounds", async () => {
+  const contentError = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      path: "src/index.ts",
+      maximumContentCharacters: 10,
+      fetch: mockFetchResponses(
+        jsonResponse({ path: "src/index.ts", content: "x".repeat(11) }),
+      ),
+    })
+  );
+  assertStringIncludes(getErrorMessage(contentError), "at most 10 characters");
+
+  const oversizedBody = new TextEncoder().encode(
+    JSON.stringify({ path: "src/index.ts", content: "x".repeat(70_000) }),
+  );
+  const transportError = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      path: "src/index.ts",
+      maximumContentCharacters: 10,
+      fetch: mockFetchResponses(
+        streamResponse([oversizedBody]),
+      ),
+    })
+  );
+  assertStringIncludes(getErrorMessage(transportError), "response may contain at most");
+});
+
+Deno.test("getRuntimeProjectFiles rejects a repeated pagination cursor", async () => {
+  const firstPage = Array.from(
+    { length: TEST_MAX_PAGE_LIMIT + 1 },
+    (_, index) => ({ path: index === 0 ? "../unsafe.md" : `file-${index}.ts` }),
+  );
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ data: firstPage, page_info: { next: "repeat" } }),
+    jsonResponse({ data: [{ path: "/second.md" }], page_info: { next: "repeat" } }),
+  );
+
+  const error = await assertRejects(() =>
+    getRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      pageLimit: 10,
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "repeated pagination cursor");
+  assertEquals(fetchSpy.calls.length, 2);
+  assertEquals(getRequestedUrl(fetchSpy, 1).searchParams.get("cursor"), "repeat");
+});
+
+Deno.test("getRuntimeProjectFiles bounds every page and aggregate pagination", async () => {
+  const oversizedPageError = await assertRejects(() =>
+    getRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: mockFetchResponses(
+        streamResponse([new Uint8Array(3_000_000)]),
+      ),
+    })
+  );
+  assertStringIncludes(getErrorMessage(oversizedPageError), "response may contain at most");
+
+  const pageResponses = Array.from({ length: 50 }, (_, index) =>
+    jsonResponse({
+      data: [],
+      page_info: { next: `cursor-${index + 1}` },
+    }));
+  const fetchSpy = mockFetchResponses(...pageResponses);
+  const pageLimitError = await assertRejects(() =>
+    getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy })
+  );
+  assertStringIncludes(getErrorMessage(pageLimitError), "at most 50 pages");
+  assertEquals(fetchSpy.calls.length, 50);
+});
+
+Deno.test("legacy project file response and error body handling remains observable", async () => {
+  const malformedFetch = mockFetchResponses(new Response("{", { status: 200 }));
+  await assertRejects(
+    () =>
+      getRuntimeProjectFile({
+        ...baseOptions,
+        fetch: malformedFetch,
+        path: "src/index.ts",
+      }),
+    SyntaxError,
+  );
+
+  const detail = `start-${"x".repeat(TEST_MAX_ERROR_BODY_BYTES)}-end`;
+  const errorFetch = mockFetchResponses(jsonResponse({ detail }, 500));
+  const error = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      fetch: errorFetch,
+      path: "src/index.ts",
+    })
+  );
+  assertStringIncludes(getErrorMessage(error), detail);
+  assertEquals(getErrorMessage(error).includes("[truncated]"), false);
+
+  let cancelled = false;
+  const notFoundFetch = mockFetchResponses(
+    streamResponse([new TextEncoder().encode("not found")], { status: 404 }, {
+      onCancel: () => {
+        cancelled = true;
+      },
+    }),
+  );
+  assertEquals(
+    await getRuntimeProjectFile({
+      ...baseOptions,
+      fetch: notFoundFetch,
+      path: "missing.ts",
+    }),
+    null,
+  );
+  await Promise.resolve();
+  assertEquals(cancelled, false);
+});
+
+Deno.test("legacy project file calls preserve normal REST, auth, and response shaping", async () => {
+  const fileFetch = mockFetchResponses(
+    jsonResponse({
+      path: "src/index.ts",
+      content: "hello",
+      type: "file",
+      size: 5,
+    }),
+  );
+  assertEquals(
+    await getRuntimeProjectFile({
+      ...baseOptions,
+      branchId: "branch-1",
+      fetch: fileFetch,
+      path: "src/index.ts",
+    }),
+    { path: "src/index.ts", content: "hello" },
+  );
+  const fileUrl = getRequestedUrl(fileFetch);
+  assertEquals(fileUrl.pathname, "/projects/project-1/files/src%2Findex.ts");
+  assertEquals(fileUrl.searchParams.get("branch"), "branch-1");
+  assertEquals(fileUrl.searchParams.get("fields"), "(path,content)");
+  assertEquals(
+    new Headers(getFetchCall(fileFetch).init.headers).get("Authorization"),
+    "Bearer token-1",
+  );
+
+  const listFetch = mockFetchResponses(
+    jsonResponse({
+      data: [{ path: "src/index.ts", type: "file", size: 5 }],
+      page_info: { next: null },
+    }),
+  );
+  assertEquals(
+    await getRuntimeProjectFiles({
+      ...baseOptions,
+      branchId: "branch-1",
+      pathPrefix: "skills/catalog",
+      fetch: listFetch,
+    }),
+    [{ path: "src/index.ts" }],
+  );
+  const listUrl = getRequestedUrl(listFetch);
+  assertEquals(listUrl.pathname, "/projects/project-1/files");
+  assertEquals(listUrl.searchParams.get("branch"), "branch-1");
+  assertEquals(listUrl.searchParams.get("path"), "skills/catalog");
+  assertEquals(listUrl.searchParams.get("fields"), "(path)");
+  assertEquals(listUrl.searchParams.get("limit"), "100");
+  assertEquals(
+    new Headers(getFetchCall(listFetch).init.headers).get("Authorization"),
+    "Bearer token-1",
+  );
+});
+
+Deno.test("legacy project file calls preserve auth and custom error identities", async () => {
+  for (const status of [401, 403]) {
+    const error = await assertRejects(() =>
+      getRuntimeProjectFile({
+        ...baseOptions,
+        fetch: mockFetchResponses(textResponse("denied", status)),
+        path: "src/index.ts",
+      })
+    );
+    assertInstanceOf(error, RuntimeProjectFilesApiAuthError);
+    assertEquals((error as RuntimeProjectFilesApiAuthError).statusCode, status);
+  }
+
+  const customError = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      createAccessDeniedError: (statusCode, message) =>
+        new Error(`custom:${statusCode}:${message}`),
+      fetch: mockFetchResponses(textResponse("denied", 403)),
+      path: "src/index.ts",
+    })
+  );
+  assertEquals(
+    getErrorMessage(customError),
+    "custom:403:Access denied to project files API",
+  );
+});
+
+Deno.test("legacy project file calls preserve upstream and network failures", async () => {
+  const upstreamError = await assertRejects(() =>
+    getRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: mockFetchResponses(textResponse("Project not found", 404)),
+    })
+  );
+  assertStringIncludes(getErrorMessage(upstreamError), "Project not found");
+
+  const networkError = new Error("ECONNREFUSED");
+  const thrown = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      fetch: async () => {
+        throw networkError;
+      },
+      path: "src/index.ts",
+    })
+  );
+  assertEquals(thrown, networkError);
+});
+
+Deno.test("getStrictRuntimeProjectFile returns a project file from the API file route", async () => {
   const fileData = { path: "src/index.ts", content: "hello" };
   const fetchSpy = mockFetchResponses(
     jsonResponse({ ...fileData, type: "file", size: 5, checksum: null }),
   );
 
-  const result = await getRuntimeProjectFile({
+  const result = await getStrictRuntimeProjectFile({
     ...baseOptions,
     fetch: fetchSpy,
     path: "src/index.ts",
@@ -106,47 +542,254 @@ Deno.test("getRuntimeProjectFile returns a project file from the API file route"
   assertEquals(result, fileData);
 });
 
-Deno.test("createRuntimeProjectFilesClient keeps its configured transport immutable", async () => {
-  const trustedFetch = mockFetchResponses(
-    jsonResponse({ data: [], page_info: { next: null } }),
+Deno.test("getStrictRuntimeProjectFile validates well-formed UTF-16 paths before URL encoding", async () => {
+  let fetchCalls = 0;
+  const fetchMock: RuntimeProjectFilesFetch = async () => {
+    fetchCalls += 1;
+    return jsonResponse({ path: "unused", content: "unused" });
+  };
+
+  for (
+    const malformedPath of [
+      String.fromCharCode(0xd800),
+      String.fromCharCode(0xdc00),
+    ]
+  ) {
+    const error = await assertRejects(() =>
+      getStrictRuntimeProjectFile({
+        ...baseOptions,
+        fetch: fetchMock,
+        path: malformedPath,
+      })
+    );
+    assertInstanceOf(error, RangeError);
+    assertStringIncludes(getErrorMessage(error), "well-formed UTF-16");
+  }
+
+  assertEquals(fetchCalls, 0);
+
+  const validPath = "skills/\u{1f600}/SKILL.md";
+  const validFetch = mockFetchResponses(
+    jsonResponse({ path: validPath, content: "valid" }),
   );
-  let untrustedFetchCalls = 0;
-  const untrustedFetch: RuntimeProjectFilesFetch = () => {
-    untrustedFetchCalls += 1;
-    return Promise.resolve(jsonResponse({ data: [], page_info: { next: null } }));
-  };
-  const configuredUrl = new URL("https://api.test");
-  const clientOptions: RuntimeProjectFilesClientOptions = {
-    apiUrl: configuredUrl,
-    fetch: trustedFetch,
-    pageLimit: 25,
-  };
-  const client = createRuntimeProjectFilesClient(clientOptions);
-
-  configuredUrl.hostname = "mutated.test";
-  clientOptions.fetch = untrustedFetch;
-  clientOptions.pageLimit = 1;
-
-  await client.getProjectFiles({
-    projectId: "project-1",
-    authToken: "token-1",
-    ...({
-      apiUrl: "https://untrusted.test",
-      fetch: untrustedFetch,
-      pageLimit: 1,
-    } as object),
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: validFetch,
+    path: validPath,
   });
-
-  const url = getRequestedUrl(trustedFetch);
-  assertEquals(url.origin, "https://api.test");
-  assertEquals(url.searchParams.get("limit"), "25");
-  assertEquals(untrustedFetchCalls, 0);
+  assertEquals(result?.path, validPath);
 });
 
-Deno.test("getRuntimeProjectFile returns null when the API file route returns 404", async () => {
+Deno.test("getStrictRuntimeProjectFile rejects non-canonical project paths before URL encoding", async () => {
+  let fetchCalls = 0;
+  const fetchMock: RuntimeProjectFilesFetch = async () => {
+    fetchCalls += 1;
+    return jsonResponse({ path: "unused", content: "unused" });
+  };
+
+  for (
+    const path of [
+      "../secret.md",
+      "/absolute.md",
+      "skills\\writer\\SKILL.md",
+      "skills//writer/SKILL.md",
+      "skills/./writer/SKILL.md",
+      `skills/${"x".repeat(256)}/SKILL.md`,
+    ]
+  ) {
+    await assertRejects(
+      () =>
+        getStrictRuntimeProjectFile({
+          ...baseOptions,
+          fetch: fetchMock,
+          path,
+        }),
+      RangeError,
+      "canonical",
+    );
+  }
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects ill-formed UTF-16 response paths", async () => {
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: String.fromCharCode(0xd800), content: "invalid" }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/requested/SKILL.md",
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "invalid API response");
+  assertEquals(getErrorMessage(error).includes("response path did not match"), false);
+});
+
+Deno.test("getStrictRuntimeProjectFile accepts content at the byte limit", async () => {
+  const content = "x".repeat(SKILL_TEXT_FILE_MAX_BYTES);
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "skills/large/SKILL.md", content }),
+  );
+
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "skills/large/SKILL.md",
+  });
+
+  assertEquals(result?.content.length, SKILL_TEXT_FILE_MAX_BYTES);
+});
+
+Deno.test("getStrictRuntimeProjectFile allows bounded worst-case JSON escaping overhead", async () => {
+  const content = "\0".repeat(SKILL_TEXT_FILE_MAX_BYTES);
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "skills/escaped/SKILL.md", content }),
+  );
+
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "skills/escaped/SKILL.md",
+  });
+
+  assertEquals(result?.content.length, SKILL_TEXT_FILE_MAX_BYTES);
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects content over the byte limit", async () => {
+  const content = "€".repeat(Math.floor(SKILL_TEXT_FILE_MAX_BYTES / 3) + 1);
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "skills/large/SKILL.md", content }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/large/SKILL.md",
+    })
+  );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `content exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
+  );
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects chunked responses over the transport limit", async () => {
+  const oversizedChunk = new Uint8Array(SKILL_TEXT_FILE_MAX_BYTES * 7);
+  let sentChunk = false;
+  let cancelled = false;
+  const fetchSpy = mockFetchResponses(
+    new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (!sentChunk) {
+            sentChunk = true;
+            controller.enqueue(oversizedChunk);
+          }
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    ),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/large/SKILL.md",
+    })
+  );
+
+  await Promise.resolve();
+  assertStringIncludes(getErrorMessage(error), "Project file response exceeds");
+  assertEquals(cancelled, true);
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects oversized Content-Length before reading", async () => {
+  let pullCount = 0;
+  let cancelled = false;
+  const fetchSpy = mockFetchResponses(
+    streamResponse([new TextEncoder().encode("{}")], {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(SKILL_TEXT_FILE_MAX_BYTES * 7),
+      },
+    }, {
+      onPull: () => {
+        pullCount += 1;
+      },
+      onCancel: () => {
+        cancelled = true;
+      },
+    }),
+  );
+  await Promise.resolve();
+  const pullCountBeforeRequest = pullCount;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/large/SKILL.md",
+    })
+  );
+  await Promise.resolve();
+
+  assertStringIncludes(getErrorMessage(error), "Project file response exceeds");
+  assertEquals(pullCount, pullCountBeforeRequest);
+  assertEquals(cancelled, true);
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects invalid UTF-8", async () => {
+  const fetchSpy = mockFetchResponses(
+    streamResponse([new Uint8Array([0xc3, 0x28])], {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/invalid/SKILL.md",
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "was not valid UTF-8");
+});
+
+Deno.test("getStrictRuntimeProjectFile rejects a response path that differs from the request", async () => {
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "skills/other/SKILL.md", content: "Body" }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "skills/requested/SKILL.md",
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "response path did not match the request");
+});
+
+Deno.test("getStrictRuntimeProjectFile returns null when the API file route returns 404", async () => {
   const fetchSpy = mockFetchResponses(textResponse("File not found", 404));
 
-  const result = await getRuntimeProjectFile({
+  const result = await getStrictRuntimeProjectFile({
     ...baseOptions,
     fetch: fetchSpy,
     path: "missing.ts",
@@ -155,25 +798,25 @@ Deno.test("getRuntimeProjectFile returns null when the API file route returns 40
   assertEquals(result, null);
 });
 
-Deno.test("getRuntimeProjectFile throws auth errors for API HTTP 401 and 403", async () => {
+Deno.test("getStrictRuntimeProjectFile throws auth errors for API HTTP 401 and 403", async () => {
   const unauthorizedFetch = mockFetchResponses(textResponse("Unauthorized", 401));
   const unauthorizedError = await assertRejects(() =>
-    getRuntimeProjectFile({ ...baseOptions, fetch: unauthorizedFetch, path: "src/index.ts" })
+    getStrictRuntimeProjectFile({ ...baseOptions, fetch: unauthorizedFetch, path: "src/index.ts" })
   );
   assertInstanceOf(unauthorizedError, RuntimeProjectFilesApiAuthError);
 
   const forbiddenFetch = mockFetchResponses(textResponse("Forbidden", 403));
   const forbiddenError = await assertRejects(() =>
-    getRuntimeProjectFile({ ...baseOptions, fetch: forbiddenFetch, path: "src/index.ts" })
+    getStrictRuntimeProjectFile({ ...baseOptions, fetch: forbiddenFetch, path: "src/index.ts" })
   );
   assertInstanceOf(forbiddenError, RuntimeProjectFilesApiAuthError);
 });
 
-Deno.test("getRuntimeProjectFile supports a custom access-denied error factory", async () => {
+Deno.test("getStrictRuntimeProjectFile supports a custom access-denied error factory", async () => {
   const fetchSpy = mockFetchResponses(textResponse("Forbidden", 403));
 
   const error = await assertRejects(() =>
-    getRuntimeProjectFile({
+    getStrictRuntimeProjectFile({
       ...baseOptions,
       fetch: fetchSpy,
       path: "src/index.ts",
@@ -184,10 +827,138 @@ Deno.test("getRuntimeProjectFile supports a custom access-denied error factory",
   assertEquals(getErrorMessage(error), "403: Access denied to project files API");
 });
 
-Deno.test("getRuntimeProjectFile reports upstream and network errors", async () => {
+Deno.test("strict runtime project files client validates timeout and page-limit options", async () => {
+  assertThrows(
+    () =>
+      createStrictRuntimeProjectFilesClient({
+        apiUrl: baseOptions.apiUrl,
+        operationTimeoutMs: 0,
+      }),
+    RangeError,
+    "operationTimeoutMs",
+  );
+  assertThrows(
+    () =>
+      createStrictRuntimeProjectFilesClient({
+        apiUrl: baseOptions.apiUrl,
+        operationTimeoutMs: TEST_MAX_OPERATION_TIMEOUT_MS + 1,
+      }),
+    RangeError,
+    "operationTimeoutMs",
+  );
+  assertThrows(
+    () =>
+      createStrictRuntimeProjectFilesClient({
+        apiUrl: baseOptions.apiUrl,
+        timeoutMs: 0,
+      }),
+    RangeError,
+    "timeoutMs",
+  );
+  assertThrows(
+    () =>
+      createStrictRuntimeProjectFilesClient({
+        apiUrl: baseOptions.apiUrl,
+        pageLimit: TEST_MAX_PAGE_LIMIT + 1,
+      }),
+    RangeError,
+    "pageLimit",
+  );
+
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "hello" }),
+  );
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "src/index.ts",
+    // Pagination is irrelevant to the direct file route.
+    pageLimit: TEST_MAX_PAGE_LIMIT + 1,
+  });
+  assertEquals(result?.content, "hello");
+});
+
+Deno.test("strict runtime project files reject unsafe transport identity and URL fields", async () => {
+  let fetchCalls = 0;
+  const fetchMock: RuntimeProjectFilesFetch = async () => {
+    fetchCalls += 1;
+    return jsonResponse({ path: "src/index.ts", content: "unused" });
+  };
+
+  for (
+    const options of [
+      { projectId: String.fromCharCode(0xd800), authToken: "token-1" },
+      { projectId: "..", authToken: "token-1" },
+      { projectId: "project/one", authToken: "token-1" },
+      { projectId: "project-1\nforged", authToken: "token-1" },
+      { projectId: "project-1", authToken: "token-1\nforged" },
+      {
+        projectId: "project-1",
+        authToken: "token-1",
+        branchId: String.fromCharCode(0xdc00),
+      },
+    ]
+  ) {
+    await assertRejects(
+      () =>
+        getStrictRuntimeProjectFile({
+          apiUrl: baseOptions.apiUrl,
+          fetch: fetchMock,
+          path: "src/index.ts",
+          ...options,
+        }),
+      TypeError,
+    );
+  }
+  assertThrows(
+    () => createStrictRuntimeProjectFilesClient({ apiUrl: "file:///tmp/api" }),
+    TypeError,
+    "HTTP(S)",
+  );
+  assertThrows(
+    () => createStrictRuntimeProjectFilesClient({ apiUrl: "https://user:pass@example.com" }),
+    TypeError,
+    "credentials",
+  );
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("strict runtime project files client snapshots configuration and rejects call-site overrides", async () => {
+  const configuredFetch = mockFetchResponses(
+    jsonResponse({ path: "src/index.ts", content: "configured" }),
+  );
+  let overrideFetchCalls = 0;
+  const mutableOptions: {
+    apiUrl: URL;
+    fetch: RuntimeProjectFilesFetch;
+  } = {
+    apiUrl: new URL("https://api.example.com/v1"),
+    fetch: configuredFetch,
+  };
+  const client = createStrictRuntimeProjectFilesClient(mutableOptions);
+
+  mutableOptions.apiUrl.hostname = "mutated.example.com";
+  mutableOptions.fetch = async () => {
+    overrideFetchCalls += 1;
+    return jsonResponse({ path: "src/index.ts", content: "mutated" });
+  };
+
+  const result = await client.getProjectFile({
+    ...baseOptions,
+    path: "src/index.ts",
+    apiUrl: "https://override.example.com",
+    fetch: mutableOptions.fetch,
+  } as RuntimeGetProjectFileOptions);
+
+  assertEquals(result?.content, "configured");
+  assertEquals(getRequestedUrl(configuredFetch).origin, "https://api.example.com");
+  assertEquals(overrideFetchCalls, 0);
+});
+
+Deno.test("getStrictRuntimeProjectFile reports upstream and network errors", async () => {
   const upstreamFetch = mockFetchResponses(textResponse("Internal Server Error", 500));
   const upstreamError = await assertRejects(() =>
-    getRuntimeProjectFile({ ...baseOptions, fetch: upstreamFetch, path: "src/index.ts" })
+    getStrictRuntimeProjectFile({ ...baseOptions, fetch: upstreamFetch, path: "src/index.ts" })
   );
   assertStringIncludes(
     getErrorMessage(upstreamError),
@@ -198,93 +969,109 @@ Deno.test("getRuntimeProjectFile reports upstream and network errors", async () 
     throw new Error("ECONNREFUSED");
   };
   const networkError = await assertRejects(() =>
-    getRuntimeProjectFile({ ...baseOptions, fetch: networkFetch, path: "src/index.ts" })
+    getStrictRuntimeProjectFile({ ...baseOptions, fetch: networkFetch, path: "src/index.ts" })
   );
   assertStringIncludes(getErrorMessage(networkError), "ECONNREFUSED");
 });
 
-Deno.test("getRuntimeProjectFile bounds the response before parsing skill content", async () => {
-  const oversized = "x".repeat(70_000);
-  const fetchSpy = mockFetchResponses(
-    jsonResponse({ path: "skills/large/SKILL.md", content: oversized }),
+Deno.test("strict runtime project files preserve timeout identity across request phases", async () => {
+  const fetchTimeout = new DOMException("fetch timeout", "TimeoutError");
+  const fetchError = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: async () => {
+        throw fetchTimeout;
+      },
+      path: "src/index.ts",
+    })
   );
+  assertEquals(fetchError === fetchTimeout, true);
 
-  await assertRejects(
-    () =>
-      getRuntimeProjectFile({
-        ...baseOptions,
-        fetch: fetchSpy,
-        path: "skills/large/SKILL.md",
-        maximumContentCharacters: 1,
-      }),
-    RangeError,
-    "response may contain at most",
+  const fileBodyTimeout = new DOMException("file body timeout", "TimeoutError");
+  const fileBodyError = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: mockFetchResponses(erroringResponse(fileBodyTimeout)),
+      path: "src/index.ts",
+    })
   );
+  assertEquals(fileBodyError === fileBodyTimeout, true);
+
+  const listBodyTimeout = new DOMException("list body timeout", "TimeoutError");
+  const listBodyError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: mockFetchResponses(erroringResponse(listBodyTimeout)),
+    })
+  );
+  assertEquals(listBodyError === listBodyTimeout, true);
+
+  const timeoutCause = new DOMException("error body timeout", "TimeoutError");
+  const wrappedTimeout = new Error("response body read failed", { cause: timeoutCause });
+  const errorBodyError = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: mockFetchResponses(erroringResponse(wrappedTimeout, 500)),
+      path: "src/index.ts",
+    })
+  );
+  assertEquals(errorBodyError === wrappedTimeout, true);
+  assertEquals((errorBodyError as Error).cause === timeoutCause, true);
 });
 
-Deno.test("getRuntimeProjectFile parses heavily fragmented bounded responses", async () => {
-  const fileData = { path: "skills/example/SKILL.md", content: "x".repeat(1_024) };
-  const fetchSpy = mockFetchResponses(chunkedJsonResponse(fileData, 1));
+Deno.test("strict project file requests enforce monotonic timeouts around synchronous fetch work", async () => {
+  const responseCancelled = createDeferred<void>();
+  const response = streamResponse(
+    [new TextEncoder().encode('{"path":"src/index.ts","content":"ok"}')],
+    {},
+    { onCancel: () => responseCancelled.resolve() },
+  );
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 1,
+      fetch: async () => {
+        const busyUntil = performance.now() + 20;
+        while (performance.now() < busyUntil) {
+          // Deliberately block timer delivery to verify the monotonic check.
+        }
+        return response;
+      },
+      path: "src/index.ts",
+    })
+  );
 
-  assertEquals(
-    await getRuntimeProjectFile({
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "request timed out");
+  await responseCancelled.promise;
+});
+
+Deno.test("getStrictRuntimeProjectFile bounds upstream error bodies", async () => {
+  const oversizedError = new Uint8Array(TEST_MAX_ERROR_BODY_BYTES + 1);
+  oversizedError.fill("x".charCodeAt(0));
+  const fetchSpy = mockFetchResponses(
+    streamResponse([oversizedError], { status: 500 }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
       ...baseOptions,
       fetch: fetchSpy,
-      path: fileData.path,
-      maximumContentCharacters: 2_048,
-    }),
-    fileData,
+      path: "src/index.ts",
+    })
   );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `Project files API error response exceeds ${TEST_MAX_ERROR_BODY_BYTES} bytes`,
+  );
+  assertEquals(getErrorMessage(error).length < TEST_MAX_ERROR_BODY_BYTES, true);
 });
 
-Deno.test("getRuntimeProjectFiles rejects and cancels a response stream that makes no progress", async () => {
-  let cancelled = false;
-  const response = new Response(
-    new ReadableStream<Uint8Array>({
-      pull(controller) {
-        controller.enqueue(new Uint8Array());
-      },
-      cancel() {
-        cancelled = true;
-      },
-    }),
-  );
-
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: mockFetchResponses(response) }),
-    RangeError,
-    "made no byte progress",
-  );
-  assertEquals(cancelled, true);
-});
-
-Deno.test("getRuntimeProjectFiles cancels a stalled response body when its timeout expires", async () => {
-  let cancelled = false;
-  const response = new Response(
-    new ReadableStream<Uint8Array>({
-      cancel() {
-        cancelled = true;
-      },
-    }),
-  );
-
-  await assertRejects(
-    () =>
-      getRuntimeProjectFiles({
-        ...baseOptions,
-        fetch: mockFetchResponses(response),
-        timeoutMs: 5,
-      }),
-    DOMException,
-    "timed out",
-  );
-  assertEquals(cancelled, true);
-});
-
-Deno.test("getRuntimeProjectFile passes project, path, branch, fields, and auth through REST", async () => {
+Deno.test("getStrictRuntimeProjectFile passes project, path, branch, fields, and auth through REST", async () => {
   const fetchSpy = mockFetchResponses(jsonResponse({ path: "src/index.ts", content: "hello" }));
 
-  await getRuntimeProjectFile({
+  await getStrictRuntimeProjectFile({
     ...baseOptions,
     fetch: fetchSpy,
     path: "src/index.ts",
@@ -302,7 +1089,20 @@ Deno.test("getRuntimeProjectFile passes project, path, branch, fields, and auth 
   );
 });
 
-Deno.test("getRuntimeProjectFiles returns project file paths from the API list route", async () => {
+Deno.test("getStrictRuntimeProjectFile preserves an empty branch as the default-branch alias", async () => {
+  const fetchSpy = mockFetchResponses(jsonResponse({ path: "src/index.ts", content: "hello" }));
+
+  await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "src/index.ts",
+    branchId: "",
+  });
+
+  assertEquals(getRequestedUrl(fetchSpy).searchParams.has("branch"), false);
+});
+
+Deno.test("getStrictRuntimeProjectFiles returns project file paths from the API list route", async () => {
   const files = [{ path: "src/index.ts" }];
   const fetchSpy = mockFetchResponses(
     jsonResponse({
@@ -317,27 +1117,12 @@ Deno.test("getRuntimeProjectFiles returns project file paths from the API list r
     }),
   );
 
-  const result = await getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
+  const result = await getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
 
   assertEquals(result, files);
 });
 
-Deno.test("getRuntimeProjectFiles rejects unsafe list prefixes before network access", async () => {
-  let calls = 0;
-  const fetchSpy: RuntimeProjectFilesFetch = () => {
-    calls += 1;
-    return Promise.resolve(jsonResponse({ data: [], page_info: { next: null } }));
-  };
-  for (const pathPrefix of ["../skills", "/skills", "skills/", "skills\\nested"]) {
-    await assertRejects(
-      () => getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy, pathPrefix }),
-      RangeError,
-    );
-  }
-  assertEquals(calls, 0);
-});
-
-Deno.test("getRuntimeProjectFiles follows API pagination until no next cursor remains", async () => {
+Deno.test("getStrictRuntimeProjectFiles follows API pagination until no next cursor remains", async () => {
   const fetchSpy = mockFetchResponses(
     jsonResponse({
       data: [{ path: "a.ts" }],
@@ -349,144 +1134,799 @@ Deno.test("getRuntimeProjectFiles follows API pagination until no next cursor re
     }),
   );
 
-  const result = await getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
+  const result = await getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
 
   assertEquals(result, [{ path: "a.ts" }, { path: "b.ts" }]);
   assertEquals(getRequestedUrl(fetchSpy, 1).searchParams.get("cursor"), "cursor-2");
 });
 
-Deno.test("getRuntimeProjectFiles rejects repeated cursors before another request", async () => {
-  const fetchSpy = mockFetchResponses(
-    jsonResponse({ data: [], page_info: { next: "same" } }),
-    jsonResponse({ data: [], page_info: { next: "same" } }),
+Deno.test("getStrictRuntimeProjectFiles cancels a late terminal response after its aggregate deadline", async () => {
+  const lateFetch = createDeferred<Response>();
+  const responseCancelled = createDeferred<void>();
+  let fetchCalls = 0;
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 1,
+      fetch: () => {
+        fetchCalls += 1;
+        return lateFetch.promise;
+      },
+    })
   );
 
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy }),
-    RangeError,
-    "repeated pagination cursor",
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
+  assertEquals(fetchCalls, 1);
+
+  lateFetch.resolve(
+    streamResponse(
+      [new TextEncoder().encode('{"data":[],"page_info":{"next":null}}')],
+      {},
+      { onCancel: () => responseCancelled.resolve() },
+    ),
   );
-  assertEquals(fetchSpy.calls.length, 2);
+  await responseCancelled.promise;
 });
 
-Deno.test("getRuntimeProjectFiles makes no post-timeout request when fetch ignores abort", async () => {
-  let calls = 0;
-  const fetchIgnoringAbort: RuntimeProjectFilesFetch = async () => {
-    calls += 1;
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    return jsonResponse({ data: [], page_info: { next: "another-page" } });
-  };
-
-  await assertRejects(
-    () =>
-      getRuntimeProjectFiles({
-        ...baseOptions,
-        fetch: fetchIgnoringAbort,
-        timeoutMs: 5,
-      }),
-    DOMException,
-    "timed out",
+Deno.test("getStrictRuntimeProjectFiles bounds a stalled terminal response body", async () => {
+  const responseCancelled = createDeferred<void>();
+  const body = new ReadableStream<Uint8Array>({
+    cancel() {
+      responseCancelled.resolve();
+      return new Promise(() => undefined);
+    },
+  });
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 1,
+      fetch: () => Promise.resolve(new Response(body)),
+    })
   );
-  assertEquals(calls, 1);
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
+  await responseCancelled.promise;
+  assertEquals(body.locked, false);
 });
 
-Deno.test("getRuntimeProjectFiles enforces response bytes cumulatively across related prefixes", async () => {
-  const listingBudget = createRuntimeProjectFileListingBudget();
-  const padding = "x".repeat(2_400_000);
-  for (let index = 0; index < 6; index += 1) {
-    const fetchSpy = mockFetchResponses(
-      jsonResponse({ data: [], page_info: { next: null }, padding }),
-    );
-    assertEquals(
-      await getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy, listingBudget }),
-      [],
-    );
-  }
-  const overBudgetFetch = mockFetchResponses(
-    jsonResponse({ data: [], page_info: { next: null }, padding }),
+Deno.test("getStrictRuntimeProjectFiles bounds a noncooperative trace wrapper", async () => {
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 1,
+      fetch: () => Promise.reject(new Error("trace must not invoke the request")),
+      trace: () => new Promise(() => undefined),
+    })
   );
-  await assertRejects(
-    () =>
-      getRuntimeProjectFiles({
-        ...baseOptions,
-        fetch: overBudgetFetch,
-        listingBudget,
-      }),
-    RangeError,
-    "responses may contain at most",
-  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
 });
 
-Deno.test("getRuntimeProjectFiles stops pagination before retaining an oversized listing", async () => {
+Deno.test("strict listing trace rejection aborts an operation the trace already started", async () => {
+  const traceError = new Error("listing trace export failed");
+  const fetchStarted = createDeferred<void>();
+  let fetchSignal: AbortSignal | undefined;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 100,
+      fetch: (_url, init) => {
+        fetchSignal = init.signal as AbortSignal;
+        fetchStarted.resolve();
+        return new Promise(() => undefined);
+      },
+      trace: async <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        void operation();
+        await fetchStarted.promise;
+        throw traceError;
+      },
+    })
+  );
+
+  assertEquals(error, traceError);
+  assertEquals(fetchSignal?.aborted, true);
+  assertEquals(fetchSignal?.reason, traceError);
+});
+
+Deno.test("getStrictRuntimeProjectFiles enforces its deadline after trace post-processing", async () => {
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 10,
+      fetch: () => Promise.resolve(jsonResponse({ data: [], page_info: { next: null } })),
+      trace: async <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        const result = await operation();
+        const busyUntil = performance.now() + 50;
+        while (performance.now() < busyUntil) {
+          // Deliberately starve timer delivery after the traced work resolves.
+        }
+        return result;
+      },
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
+});
+
+Deno.test("expired aggregate deadlines do not launch fetches after trace pre-processing", async () => {
+  let fetchCalls = 0;
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      operationTimeoutMs: 5,
+      fetch: () => {
+        fetchCalls += 1;
+        return Promise.resolve(jsonResponse({ data: [], page_info: { next: null } }));
+      },
+      trace: async <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        const busyUntil = performance.now() + 30;
+        while (performance.now() < busyUntil) {
+          // Deliberately starve timer delivery before invoking traced work.
+        }
+        return await operation();
+      },
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "aggregate deadline");
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("pre-aborted project file listings do not invoke custom trace wrappers", async () => {
+  const controller = new AbortController();
+  const cancellation = { kind: "listing-cancelled" };
+  controller.abort(cancellation);
+  let traceCalls = 0;
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      signal: controller.signal,
+      fetch: () => Promise.reject(new Error("fetch must not run")),
+      trace: () => {
+        traceCalls += 1;
+        throw new Error("sync trace failure");
+      },
+    })
+  );
+
+  assertEquals(error === cancellation, true);
+  assertEquals(traceCalls, 0);
+});
+
+Deno.test("getStrictRuntimeProjectFile bounds a noncooperative trace wrapper", async () => {
+  let fetchCalls = 0;
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 1,
+      fetch: () => {
+        fetchCalls += 1;
+        return Promise.resolve(jsonResponse({ path: "src/index.ts", content: "unused" }));
+      },
+      path: "src/index.ts",
+      trace: () => new Promise(() => undefined),
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "request timed out");
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("strict trace rejection aborts an operation the trace already started", async () => {
+  const traceError = new Error("trace export failed");
+  const fetchStarted = createDeferred<void>();
+  let fetchSignal: AbortSignal | undefined;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 100,
+      fetch: (_url, init) => {
+        fetchSignal = init.signal as AbortSignal;
+        fetchStarted.resolve();
+        return new Promise(() => undefined);
+      },
+      path: "src/index.ts",
+      trace: async <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        void operation();
+        await fetchStarted.promise;
+        throw traceError;
+      },
+    })
+  );
+
+  assertEquals(error, traceError);
+  assertEquals(fetchSignal?.aborted, true);
+  assertEquals(fetchSignal?.reason, traceError);
+});
+
+Deno.test("strict trace success cannot fabricate a result ahead of its operation", async () => {
+  let fetchSignal: AbortSignal | undefined;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 5,
+      fetch: (_url, init) => {
+        fetchSignal = init.signal as AbortSignal;
+        return new Promise(() => undefined);
+      },
+      path: "src/index.ts",
+      trace: <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        void operation();
+        return Promise.resolve(null as T);
+      },
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "request timed out");
+  assertEquals(fetchSignal?.aborted, true);
+});
+
+Deno.test("strict trace returns the validated operation result instead of its own value", async () => {
+  const result = await getStrictRuntimeProjectFile({
+    ...baseOptions,
+    fetch: () =>
+      Promise.resolve(
+        jsonResponse({ path: "src/index.ts", content: "validated" }),
+      ),
+    path: "src/index.ts",
+    trace: <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+      void operation();
+      return Promise.resolve(null as T);
+    },
+  });
+
+  assertEquals(result, { path: "src/index.ts", content: "validated" });
+});
+
+Deno.test("strict trace re-entry cannot launch the operation twice", async () => {
+  let invokeOperation: (() => Promise<unknown>) | undefined;
+  let fetchCalls = 0;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      fetch: () => {
+        fetchCalls += 1;
+        if (fetchCalls === 1) {
+          void invokeOperation?.();
+        }
+        return Promise.resolve(
+          jsonResponse({ path: "src/index.ts", content: "validated" }),
+        );
+      },
+      path: "src/index.ts",
+      trace: <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        invokeOperation = operation as () => Promise<unknown>;
+        return operation();
+      },
+    })
+  );
+
+  assertEquals(error instanceof TypeError, true);
+  assertStringIncludes(getErrorMessage(error), "exactly once");
+  assertEquals(fetchCalls, 1);
+});
+
+Deno.test("strict request aborts work started by a noncooperative trace wrapper", async () => {
+  let fetchSignal: AbortSignal | undefined;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      timeoutMs: 5,
+      fetch: (_url, init) => {
+        fetchSignal = init.signal as AbortSignal;
+        return new Promise(() => undefined);
+      },
+      path: "src/index.ts",
+      trace: <T>(_name: string, operation: () => Promise<T>): Promise<T> => {
+        void operation();
+        return new Promise(() => undefined);
+      },
+    })
+  );
+
+  assertEquals((error as Error).name, "TimeoutError");
+  assertStringIncludes(getErrorMessage(error), "request timed out");
+  assertEquals(fetchSignal?.aborted, true);
+});
+
+Deno.test("strict project file requests propagate in-flight caller cancellation exactly", async () => {
+  const controller = new AbortController();
+  const cancellation = new DOMException("caller stopped in flight", "AbortError");
+  const fetchStarted = createDeferred<void>();
+  const observedSignals: AbortSignal[] = [];
+
+  const request = getStrictRuntimeProjectFile({
+    ...baseOptions,
+    signal: controller.signal,
+    fetch: (_url, init) => {
+      observedSignals.push(init.signal as AbortSignal);
+      fetchStarted.resolve();
+      return new Promise(() => undefined);
+    },
+    path: "src/index.ts",
+  });
+
+  await fetchStarted.promise;
+  controller.abort(cancellation);
+  const error = await assertRejects(() => request);
+
+  assertEquals(error, cancellation);
+  assertEquals(observedSignals[0]?.aborted, true);
+  assertEquals(observedSignals[0]?.reason, cancellation);
+});
+
+Deno.test("strict project error-body reads preserve arbitrary caller cancellation reasons", async () => {
+  const controller = new AbortController();
+  const cancellation = { kind: "caller-disconnected" };
+  const bodyReadStarted = createDeferred<void>();
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      pull() {
+        bodyReadStarted.resolve();
+      },
+    }),
+    { status: 500 },
+  );
+  const request = getStrictRuntimeProjectFile({
+    ...baseOptions,
+    signal: controller.signal,
+    fetch: () => Promise.resolve(response),
+    path: "src/index.ts",
+  });
+
+  await bodyReadStarted.promise;
+  controller.abort(cancellation);
+  const error = await assertRejects(() => request);
+
+  assertEquals(error === cancellation, true);
+  assertEquals(response.body?.locked, false);
+});
+
+Deno.test("successful strict project file calls dispose cancellation listeners and timers", async () => {
+  const controller = new AbortController();
+  const callerSignal = controller.signal;
+  const originalAddEventListener = callerSignal.addEventListener;
+  const originalRemoveEventListener = callerSignal.removeEventListener;
+  let abortListenerAdds = 0;
+  let abortListenerRemovals = 0;
+  Object.defineProperty(callerSignal, "addEventListener", {
+    configurable: true,
+    value(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ) {
+      if (type === "abort") abortListenerAdds += 1;
+      Reflect.apply(originalAddEventListener, callerSignal, [type, listener, options]);
+    },
+  });
+  Object.defineProperty(callerSignal, "removeEventListener", {
+    configurable: true,
+    value(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions,
+    ) {
+      if (type === "abort") abortListenerRemovals += 1;
+      Reflect.apply(originalRemoveEventListener, callerSignal, [type, listener, options]);
+    },
+  });
+  const observedSignals: AbortSignal[] = [];
+  const client = createStrictRuntimeProjectFilesClient({
+    apiUrl: baseOptions.apiUrl,
+    operationTimeoutMs: 10,
+    timeoutMs: 10,
+    fetch: (_url, init) => {
+      observedSignals.push(init.signal as AbortSignal);
+      return Promise.resolve(
+        jsonResponse({ data: [], page_info: { next: null } }),
+      );
+    },
+  });
+
+  assertEquals(
+    await client.getProjectFiles({
+      projectId: baseOptions.projectId,
+      authToken: baseOptions.authToken,
+      signal: callerSignal,
+    }),
+    [],
+  );
+
+  assertEquals(abortListenerAdds, 1);
+  assertEquals(abortListenerRemovals, 1);
+  controller.abort(new DOMException("late caller abort", "AbortError"));
+  assertEquals(observedSignals[0]?.aborted, false);
+});
+
+Deno.test("strict project file requests preserve caller cancellation identity", async () => {
+  const controller = new AbortController();
+  const cancellation = new DOMException("caller stopped", "AbortError");
+  controller.abort(cancellation);
+  let fetchCalls = 0;
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFile({
+      ...baseOptions,
+      signal: controller.signal,
+      fetch: () => {
+        fetchCalls += 1;
+        throw new Error("sync custom fetch failure");
+      },
+      path: "src/index.ts",
+    })
+  );
+
+  assertEquals(error, cancellation);
+  assertEquals(fetchCalls, 0);
+});
+
+Deno.test("getStrictRuntimeProjectFiles rejects repeated pagination cursors", async () => {
   const fetchSpy = mockFetchResponses(
     jsonResponse({
       data: [{ path: "a.ts" }],
-      page_info: { next: "cursor-2" },
+      page_info: { next: "cursor-repeat" },
     }),
     jsonResponse({
       data: [{ path: "b.ts" }],
-      page_info: { next: "cursor-3" },
+      page_info: { next: "cursor-repeat" },
     }),
   );
 
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy, maximumEntries: 1 }),
-    RangeError,
-    "may contain at most 1 entries",
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      listingBudget: createUnboundedTestListingBudget(),
+    })
   );
+
+  assertStringIncludes(getErrorMessage(error), "pagination returned a repeated cursor");
   assertEquals(fetchSpy.calls.length, 2);
 });
 
-Deno.test("getRuntimeProjectFiles bounds each page before parsing and rejects oversized paths", async () => {
+Deno.test("strict listings enforce a one-entry maximum before retention or another request", async () => {
   const oversizedPageFetch = mockFetchResponses(
     jsonResponse({
-      data: [{ path: "x".repeat(2_600_000) }],
+      data: [{ path: "first.ts" }, { path: "second.ts" }],
       page_info: { next: null },
     }),
   );
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: oversizedPageFetch }),
-    RangeError,
-    "response may contain at most",
+  const oversizedPageError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: oversizedPageFetch,
+      maximumEntries: 1,
+    })
+  );
+  assertStringIncludes(getErrorMessage(oversizedPageError), "requested 1 files");
+  assertEquals(oversizedPageFetch.calls.length, 1);
+
+  const continuedListingFetch = mockFetchResponses(
+    jsonResponse({
+      data: [{ path: "first.ts" }],
+      page_info: { next: "more" },
+    }),
+    jsonResponse({
+      data: [{ path: "second.ts" }],
+      page_info: { next: null },
+    }),
+  );
+  const continuedListingError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: continuedListingFetch,
+      maximumEntries: 1,
+    })
+  );
+  assertStringIncludes(getErrorMessage(continuedListingError), "file count exceeds 1");
+  assertEquals(continuedListingFetch.calls.length, 1);
+});
+
+Deno.test("strict listings exhaust a shared cross-prefix page budget before fetching", async () => {
+  const listingBudget = createRuntimeProjectFileListingBudget();
+  let fetchCalls = 0;
+  const fetch: RuntimeProjectFilesFetch = () => {
+    fetchCalls += 1;
+    return Promise.resolve(jsonResponse({ data: [{ path: "one.ts" }], page_info: { next: null } }));
+  };
+
+  for (let index = 0; index < TEST_PUBLIC_LISTING_MAX_PAGES; index += 1) {
+    const files = await getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch,
+      listingBudget,
+      maximumEntries: 1,
+      pathPrefix: `skills/prefix-${index}`,
+    });
+    assertEquals(files, [{ path: "one.ts" }]);
+  }
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch,
+      listingBudget,
+      maximumEntries: 1,
+      pathPrefix: "skills/exhausted",
+    })
+  );
+  assertStringIncludes(getErrorMessage(error), `${TEST_PUBLIC_LISTING_MAX_PAGES} pages`);
+  assertEquals(fetchCalls, TEST_PUBLIC_LISTING_MAX_PAGES);
+});
+
+Deno.test("strict listings charge response bytes to the shared budget before retaining them", async () => {
+  let consumedPages = 0;
+  let consumedBytes = 0;
+  const listingBudget = {
+    consumePage() {
+      consumedPages += 1;
+    },
+    consumeBytes(byteCount: number) {
+      consumedBytes += byteCount;
+      throw new RangeError("shared byte budget exhausted");
+    },
+  };
+  const body = new TextEncoder().encode(
+    JSON.stringify({ data: [{ path: "one.ts" }], page_info: { next: null } }),
   );
 
-  const oversizedPathFetch = mockFetchResponses(
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      listingBudget,
+      fetch: () =>
+        Promise.resolve(
+          streamResponse([body]),
+        ),
+      maximumEntries: 1,
+    })
+  );
+  assertStringIncludes(getErrorMessage(error), "shared byte budget exhausted");
+  assertEquals(consumedPages, 1);
+  assertEquals(consumedBytes, body.byteLength);
+});
+
+Deno.test("getStrictRuntimeProjectFiles rejects pages over the item budget", async () => {
+  const fetchSpy = mockFetchResponses(
     jsonResponse({
-      data: [{ path: "x".repeat(4_097) }],
+      data: Array.from(
+        { length: TEST_MAX_PAGE_LIMIT + 1 },
+        (_, index) => ({ path: `file-${index}.ts` }),
+      ),
       page_info: { next: null },
     }),
   );
-  await assertRejects(
-    () => getRuntimeProjectFiles({ ...baseOptions, fetch: oversizedPathFetch }),
-    RangeError,
-    "paths may contain at most 4096 characters",
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      listingBudget: createUnboundedTestListingBudget(),
+    })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "invalid API response");
+});
+
+Deno.test("getStrictRuntimeProjectFiles enforces the requested page limit", async () => {
+  const requestedPageLimit = 10;
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({
+      data: Array.from(
+        { length: requestedPageLimit + 1 },
+        (_, index) => ({ path: `file-${index}.ts` }),
+      ),
+      page_info: { next: null },
+    }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      pageLimit: requestedPageLimit,
+    })
+  );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `page returned more than the requested ${requestedPageLimit} files`,
   );
 });
 
-Deno.test("getRuntimeProjectFiles throws auth errors for API HTTP 401 and 403", async () => {
+Deno.test("getStrictRuntimeProjectFiles rejects oversized paths", async () => {
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({
+      data: [{ path: "x".repeat(TEST_MAX_PATH_CHARACTERS + 1) }],
+      page_info: { next: null },
+    }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "invalid API response");
+});
+
+Deno.test("getStrictRuntimeProjectFiles rejects ill-formed UTF-16 paths and cursors", async () => {
+  const malformed = String.fromCharCode(0xd800);
+  const invalidPathFetch = mockFetchResponses(
+    jsonResponse({
+      data: [{ path: malformed }],
+      page_info: { next: null },
+    }),
+  );
+
+  const pathError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: invalidPathFetch })
+  );
+  assertStringIncludes(getErrorMessage(pathError), "invalid API response");
+
+  const invalidCursorFetch = mockFetchResponses(
+    jsonResponse({
+      data: [],
+      page_info: { next: malformed },
+    }),
+  );
+  const cursorError = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: invalidCursorFetch })
+  );
+  assertStringIncludes(getErrorMessage(cursorError), "invalid API response");
+  assertEquals(invalidCursorFetch.calls.length, 1);
+});
+
+Deno.test("getStrictRuntimeProjectFiles rejects chunked list pages over the transport limit", async () => {
+  const oversizedChunk = new Uint8Array(SKILL_TEXT_FILE_MAX_BYTES * 3);
+  const fetchSpy = mockFetchResponses(
+    streamResponse([oversizedChunk], {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy })
+  );
+
+  assertStringIncludes(getErrorMessage(error), "Project files list response exceeds");
+});
+
+Deno.test("getStrictRuntimeProjectFiles caps aggregate file count", async () => {
+  const pageCount = TEST_MAX_TOTAL_FILES / TEST_MAX_PAGE_LIMIT + 1;
+  const responses = Array.from({ length: pageCount }, (_, pageIndex) =>
+    jsonResponse({
+      data: Array.from(
+        { length: TEST_MAX_PAGE_LIMIT },
+        (_, itemIndex) => ({
+          path: `page-${pageIndex}/file-${itemIndex}.ts`,
+        }),
+      ),
+      page_info: { next: `cursor-${pageIndex + 1}` },
+    }));
+  const fetchSpy = mockFetchResponses(...responses);
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      listingBudget: createUnboundedTestListingBudget(),
+    })
+  );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `file count exceeds ${TEST_MAX_TOTAL_FILES}`,
+  );
+  assertEquals(fetchSpy.calls.length, pageCount - 1);
+});
+
+Deno.test("getStrictRuntimeProjectFiles accepts exactly the aggregate file budget", async () => {
+  const pageCount = TEST_MAX_TOTAL_FILES / TEST_MAX_PAGE_LIMIT;
+  const responses = Array.from({ length: pageCount }, (_, pageIndex) =>
+    jsonResponse({
+      data: Array.from(
+        { length: TEST_MAX_PAGE_LIMIT },
+        (_, itemIndex) => ({
+          path: `page-${pageIndex}/file-${itemIndex}.ts`,
+        }),
+      ),
+      page_info: {
+        next: pageIndex + 1 < pageCount ? `cursor-${pageIndex + 1}` : null,
+      },
+    }));
+  const fetchSpy = mockFetchResponses(...responses);
+
+  const files = await getStrictRuntimeProjectFiles({
+    ...baseOptions,
+    fetch: fetchSpy,
+    listingBudget: createUnboundedTestListingBudget(),
+  });
+
+  assertEquals(files.length, TEST_MAX_TOTAL_FILES);
+  assertEquals(fetchSpy.calls.length, pageCount);
+});
+
+Deno.test("getStrictRuntimeProjectFiles caps pagination depth", async () => {
+  const responses = Array.from({ length: TEST_MAX_TOTAL_PAGES }, (_, pageIndex) =>
+    jsonResponse({
+      data: [],
+      page_info: { next: `cursor-${pageIndex + 1}` },
+    }));
+  const fetchSpy = mockFetchResponses(...responses);
+
+  const error = await assertRejects(() =>
+    getStrictRuntimeProjectFiles({
+      ...baseOptions,
+      fetch: fetchSpy,
+      listingBudget: createUnboundedTestListingBudget(),
+    })
+  );
+
+  assertStringIncludes(
+    getErrorMessage(error),
+    `pagination exceeds ${TEST_MAX_TOTAL_PAGES} pages`,
+  );
+  assertEquals(fetchSpy.calls.length, TEST_MAX_TOTAL_PAGES);
+});
+
+Deno.test("getStrictRuntimeProjectFiles accepts exactly the pagination depth budget", async () => {
+  const responses = Array.from({ length: TEST_MAX_TOTAL_PAGES }, (_, pageIndex) =>
+    jsonResponse({
+      data: [],
+      page_info: {
+        next: pageIndex + 1 < TEST_MAX_TOTAL_PAGES ? `cursor-${pageIndex + 1}` : null,
+      },
+    }));
+  const fetchSpy = mockFetchResponses(...responses);
+
+  const files = await getStrictRuntimeProjectFiles({
+    ...baseOptions,
+    fetch: fetchSpy,
+    listingBudget: createUnboundedTestListingBudget(),
+  });
+
+  assertEquals(files, []);
+  assertEquals(fetchSpy.calls.length, TEST_MAX_TOTAL_PAGES);
+});
+
+Deno.test("getStrictRuntimeProjectFiles throws auth errors for API HTTP 401 and 403", async () => {
   const unauthorizedFetch = mockFetchResponses(textResponse("Unauthorized", 401));
   const unauthorizedError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: unauthorizedFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: unauthorizedFetch })
   );
   assertInstanceOf(unauthorizedError, RuntimeProjectFilesApiAuthError);
 
   const forbiddenFetch = mockFetchResponses(textResponse("Forbidden", 403));
   const forbiddenError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: forbiddenFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: forbiddenFetch })
   );
   assertInstanceOf(forbiddenError, RuntimeProjectFilesApiAuthError);
 });
 
-Deno.test("getRuntimeProjectFiles reports upstream and network errors", async () => {
+Deno.test("getStrictRuntimeProjectFiles reports upstream and network errors", async () => {
   const notFoundFetch = mockFetchResponses(textResponse("Project not found", 404));
   const notFoundError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: notFoundFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: notFoundFetch })
   );
   assertStringIncludes(getErrorMessage(notFoundError), "Project not found");
 
   const upstreamFetch = mockFetchResponses(textResponse("Internal Server Error", 500));
   const upstreamError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: upstreamFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: upstreamFetch })
   );
   assertStringIncludes(getErrorMessage(upstreamError), "Internal Server Error");
 
@@ -494,30 +1934,38 @@ Deno.test("getRuntimeProjectFiles reports upstream and network errors", async ()
     throw new Error("ECONNREFUSED");
   };
   const networkError = await assertRejects(() =>
-    getRuntimeProjectFiles({ ...baseOptions, fetch: networkFetch })
+    getStrictRuntimeProjectFiles({ ...baseOptions, fetch: networkFetch })
   );
   assertStringIncludes(getErrorMessage(networkError), "ECONNREFUSED");
 });
 
-Deno.test("getRuntimeProjectFiles passes project, branch, path, fields, pagination limit, and auth through REST", async () => {
+Deno.test("getStrictRuntimeProjectFiles passes project, branch, prefix, fields, pagination limit, and auth through REST", async () => {
   const fetchSpy = mockFetchResponses(jsonResponse({ data: [], page_info: { next: null } }));
 
-  await getRuntimeProjectFiles({
+  await getStrictRuntimeProjectFiles({
     ...baseOptions,
     fetch: fetchSpy,
     branchId: "branch-1",
-    pathPrefix: "skills",
+    pathPrefix: "skills/research",
   });
 
   const url = getRequestedUrl(fetchSpy);
   assertEquals(url.origin, "https://api.test");
   assertEquals(url.pathname, "/projects/project-1/files");
   assertEquals(url.searchParams.get("branch"), "branch-1");
-  assertEquals(url.searchParams.get("path"), "skills");
+  assertEquals(url.searchParams.get("path"), "skills/research");
   assertEquals(url.searchParams.get("fields"), "(path)");
   assertEquals(url.searchParams.get("limit"), "100");
   assertEquals(
     new Headers(getFetchCall(fetchSpy).init.headers).get("Authorization"),
     "Bearer token-1",
   );
+});
+
+Deno.test("getStrictRuntimeProjectFiles preserves an empty branch as the default-branch alias", async () => {
+  const fetchSpy = mockFetchResponses(jsonResponse({ data: [], page_info: { next: null } }));
+
+  await getStrictRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy, branchId: "" });
+
+  assertEquals(getRequestedUrl(fetchSpy).searchParams.has("branch"), false);
 });

--- a/src/agent/runtime/project-files-client.ts
+++ b/src/agent/runtime/project-files-client.ts
@@ -13,31 +13,61 @@ import {
 
 const DEFAULT_PROJECT_FILES_TIMEOUT_MS = 15_000;
 const DEFAULT_PROJECT_FILES_PAGE_LIMIT = 100;
-const PROJECT_FILE_JSON_OVERHEAD_BYTES = 65_536;
-const PROJECT_FILE_PATH_MAX_CHARACTERS = 4_096;
-const PROJECT_FILE_CURSOR_MAX_CHARACTERS = 4_096;
-const PROJECT_FILE_LIST_MAX_PAGES = 50;
-const PROJECT_FILE_LIST_TOTAL_MAX_BYTES = 16 * 1_048_576;
-const PROJECT_FILE_LIST_PAGE_MAX_BYTES =
-  DEFAULT_PROJECT_FILES_PAGE_LIMIT * PROJECT_FILE_PATH_MAX_CHARACTERS * 6 +
-  PROJECT_FILE_JSON_OVERHEAD_BYTES;
-const PROJECT_FILE_RESPONSE_BLOCK_BYTES = 65_536;
-const PROJECT_FILE_RESPONSE_YIELD_CHUNKS = 256;
-const PROJECT_FILE_RESPONSE_MAX_CONSECUTIVE_EMPTY_CHUNKS = 4_096;
-const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
-const utf8Encoder = new TextEncoder();
+const DEFAULT_PROJECT_FILES_OPERATION_TIMEOUT_MS = 300_000;
+const MAX_PROJECT_FILES_TIMEOUT_MS = 300_000;
+const MAX_PROJECT_FILES_OPERATION_TIMEOUT_MS = 300_000;
+const MAX_PROJECT_FILES_PAGE_LIMIT = 100;
+
+// Project paths and pagination cursors cross a remote trust boundary and are
+// retained in memory by the hosted Skill catalog.
+const MAX_PROJECT_FILE_PATH_CHARACTERS = 4_096;
+const MAX_PROJECT_FILES_CURSOR_CHARACTERS = 4_096;
+const MAX_PROJECT_FILES_PER_PAGE = MAX_PROJECT_FILES_PAGE_LIMIT;
+/** Maximum aggregate file records returned by one project listing. */
+export const MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS = 10_000;
+const MAX_PROJECT_FILES_TOTAL_PAGES = 200;
+const MAX_PROJECT_FILES_API_URL_CHARACTERS = 8_192;
+const MAX_PROJECT_FILES_IDENTIFIER_CHARACTERS = 256;
+const MAX_PROJECT_FILES_AUTH_TOKEN_CHARACTERS = 16_384;
+
+// JSON can expand one decoded byte to six ASCII bytes (for example "\u0000").
+// These budgets therefore admit every valid 1 MiB file plus bounded path and
+// envelope overhead without permitting an unbounded transport allocation.
+const MAX_JSON_ESCAPE_BYTES_PER_DECODED_BYTE = 6;
+const PROJECT_FILES_JSON_ENVELOPE_BYTES = 64 * 1_024;
+const MAX_PROJECT_FILE_RESPONSE_BYTES =
+  (SKILL_TEXT_FILE_MAX_BYTES + MAX_PROJECT_FILE_PATH_CHARACTERS) *
+    MAX_JSON_ESCAPE_BYTES_PER_DECODED_BYTE +
+  PROJECT_FILES_JSON_ENVELOPE_BYTES;
+const MAX_PROJECT_FILE_LIST_PAGE_BYTES =
+  (MAX_PROJECT_FILES_PER_PAGE * MAX_PROJECT_FILE_PATH_CHARACTERS +
+      MAX_PROJECT_FILES_CURSOR_CHARACTERS) *
+    MAX_JSON_ESCAPE_BYTES_PER_DECODED_BYTE +
+  PROJECT_FILES_JSON_ENVELOPE_BYTES;
+const MAX_PROJECT_FILES_ERROR_BODY_BYTES = 64 * 1_024;
+const MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS = 4_096;
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:\//;
 
-/** Maximum aggregate file records retained by one project listing. */
-export const MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS = PROJECT_FILE_LIST_MAX_PAGES *
-  DEFAULT_PROJECT_FILES_PAGE_LIMIT;
+// Established public-client limits. The strict hosted client below adds a
+// narrower trust-boundary contract without weakening these public safeguards.
+const PUBLIC_PROJECT_FILE_JSON_OVERHEAD_BYTES = 65_536;
+const PUBLIC_PROJECT_FILE_LIST_MAX_PAGES = 50;
+const PUBLIC_PROJECT_FILE_LIST_TOTAL_MAX_BYTES = 16 * 1_048_576;
+const PUBLIC_PROJECT_FILE_LIST_PAGE_MAX_BYTES =
+  DEFAULT_PROJECT_FILES_PAGE_LIMIT * MAX_PROJECT_FILE_PATH_CHARACTERS * 6 +
+  PUBLIC_PROJECT_FILE_JSON_OVERHEAD_BYTES;
+const PUBLIC_PROJECT_FILE_RESPONSE_BLOCK_BYTES = 65_536;
+const PUBLIC_PROJECT_FILE_RESPONSE_YIELD_CHUNKS = 256;
+const PUBLIC_PROJECT_FILE_RESPONSE_MAX_CONSECUTIVE_EMPTY_CHUNKS = 4_096;
+const publicProjectFileUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+const publicProjectFileUtf8Encoder = new TextEncoder();
 
-/** Whether a value is a canonical, bounded project-relative file path. */
+/** Whether a value is a canonical project-relative file path. */
 export function isRuntimeProjectFilePath(path: unknown): path is string {
   if (
     typeof path !== "string" ||
     path.length === 0 ||
-    path.length > PROJECT_FILE_PATH_MAX_CHARACTERS ||
+    path.length > MAX_PROJECT_FILE_PATH_CHARACTERS ||
     !isWellFormedUtf16(path) ||
     hasControlCharacters(path) ||
     path.startsWith("/") ||
@@ -46,7 +76,8 @@ export function isRuntimeProjectFilePath(path: unknown): path is string {
   ) {
     return false;
   }
-  return path.split("/").every((segment) =>
+  const segments = path.split("/");
+  return segments.every((segment) =>
     segment.length > 0 &&
     segment.length <= SKILL_PATH_SEGMENT_MAX_LENGTH &&
     segment !== "." &&
@@ -54,13 +85,27 @@ export function isRuntimeProjectFilePath(path: unknown): path is string {
   );
 }
 
-/** Whether a value fits the shared runtime Skill text-file budget. */
-export function isRuntimeProjectFileContent(content: unknown): content is string {
-  return typeof content === "string" &&
-    content.length <= SKILL_TEXT_FILE_MAX_BYTES &&
-    isWellFormedUtf16(content) &&
-    isUtf8WithinByteLimit(content, SKILL_TEXT_FILE_MAX_BYTES);
-}
+const getStrictRuntimeProjectFilePathSchema = defineSchema((v) =>
+  v.string().min(1).max(MAX_PROJECT_FILE_PATH_CHARACTERS)
+    .refine(isWellFormedUtf16, "Project file path must contain well-formed UTF-16")
+    .refine(
+      (path) => !hasControlCharacters(path),
+      "Project file path must not contain control characters",
+    )
+    .refine(
+      isRuntimeProjectFilePath,
+      "Project file path must be a canonical project-relative path",
+    )
+);
+
+const getStrictRuntimeProjectFilesCursorSchema = defineSchema((v) =>
+  v.string().min(1).max(MAX_PROJECT_FILES_CURSOR_CHARACTERS)
+    .refine(isWellFormedUtf16, "Project files cursor must contain well-formed UTF-16")
+    .refine(
+      (cursor) => !hasControlCharacters(cursor),
+      "Project files cursor must not contain control characters",
+    )
+);
 
 export const getRuntimeProjectFileSchema = defineSchema((v) =>
   v.object({
@@ -75,6 +120,21 @@ export const getRuntimeProjectFileListItemSchema = defineSchema((v) =>
   })
 );
 
+/** Strict hosted-boundary schema for a runtime project file. */
+export const getStrictRuntimeProjectFileSchema = defineSchema((v) =>
+  v.object({
+    path: getStrictRuntimeProjectFilePathSchema(),
+    content: v.string(),
+  })
+);
+
+/** Strict hosted-boundary schema for a runtime project file list item. */
+export const getStrictRuntimeProjectFileListItemSchema = defineSchema((v) =>
+  v.object({
+    path: getStrictRuntimeProjectFilePathSchema(),
+  })
+);
+
 const getRuntimeProjectFileListRestResponseSchema = defineSchema((v) =>
   v.object({
     data: v.array(getRuntimeProjectFileListItemSchema()),
@@ -84,11 +144,28 @@ const getRuntimeProjectFileListRestResponseSchema = defineSchema((v) =>
   })
 );
 
+const getStrictRuntimeProjectFileListRestResponseSchema = defineSchema((v) =>
+  v.object({
+    data: v.array(getStrictRuntimeProjectFileListItemSchema()).max(MAX_PROJECT_FILES_PER_PAGE),
+    page_info: v.object({
+      next: getStrictRuntimeProjectFilesCursorSchema().nullable(),
+    }),
+  })
+);
+
 const getApiErrorBodySchema = defineSchema((v) =>
   v.object({
     detail: v.string().optional(),
     message: v.string().optional(),
     error: v.string().optional(),
+  }).passthrough()
+);
+
+const getStrictApiErrorBodySchema = defineSchema((v) =>
+  v.object({
+    detail: v.string().max(MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS).optional(),
+    message: v.string().max(MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS).optional(),
+    error: v.string().max(MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS).optional(),
   }).passthrough()
 );
 
@@ -148,6 +225,18 @@ export type RuntimeProjectFilesClientOptions = {
   createAccessDeniedError?: (statusCode: number, message: string) => Error;
 };
 
+/** Internal options for fail-closed hosted project-file reads. */
+export type StrictRuntimeProjectFilesClientOptions = RuntimeProjectFilesClientOptions & {
+  /** Aggregate listing timeout, capped at five minutes. */
+  operationTimeoutMs?: number;
+};
+
+/** Internal per-call context for fail-closed hosted project-file reads. */
+type StrictRuntimeProjectFilesRequestContext = {
+  /** Caller cancellation composed with request and aggregate deadlines. */
+  signal?: AbortSignal;
+};
+
 /** Public API contract for runtime project files client. */
 export type RuntimeProjectFilesClient = {
   getProjectFile: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
@@ -169,22 +258,32 @@ export function createRuntimeProjectFileListingBudget(): RuntimeProjectFileListi
   return Object.freeze({
     consumePage(): void {
       pages += 1;
-      if (pages > PROJECT_FILE_LIST_MAX_PAGES) {
+      if (pages > PUBLIC_PROJECT_FILE_LIST_MAX_PAGES) {
         throw new RangeError(
-          `Project file listing may contain at most ${PROJECT_FILE_LIST_MAX_PAGES} pages`,
+          `Project file listing may contain at most ${PUBLIC_PROJECT_FILE_LIST_MAX_PAGES} pages`,
         );
       }
     },
     consumeBytes(byteCount: number): void {
       bytes += byteCount;
-      if (bytes > PROJECT_FILE_LIST_TOTAL_MAX_BYTES) {
+      if (bytes > PUBLIC_PROJECT_FILE_LIST_TOTAL_MAX_BYTES) {
         throw new RangeError(
-          `Project file listing responses may contain at most ${PROJECT_FILE_LIST_TOTAL_MAX_BYTES} bytes`,
+          `Project file listing responses may contain at most ${PUBLIC_PROJECT_FILE_LIST_TOTAL_MAX_BYTES} bytes`,
         );
       }
     },
   });
 }
+
+/** Internal client contract that accepts request-scoped cancellation. */
+type StrictRuntimeProjectFilesClient = {
+  getProjectFile: (
+    options: RuntimeGetProjectFileOptions & StrictRuntimeProjectFilesRequestContext,
+  ) => Promise<RuntimeProjectFile | null>;
+  getProjectFiles: (
+    options: RuntimeProjectFilesApiOptions & StrictRuntimeProjectFilesRequestContext,
+  ) => Promise<RuntimeProjectFileListItem[]>;
+};
 
 /** Error shape for runtime project files API auth. */
 export class RuntimeProjectFilesApiAuthError extends Error {
@@ -203,9 +302,9 @@ export class RuntimeProjectFilesApiAuthError extends Error {
 export function createRuntimeProjectFilesClient(
   options: RuntimeProjectFilesClientOptions,
 ): RuntimeProjectFilesClient {
-  // Snapshot the trusted transport configuration. Callers can pass plain
-  // JavaScript objects at runtime, so spreading request input into this scope
-  // would let excess properties replace the configured origin or transport.
+  // Snapshot trusted transport configuration. Untyped JavaScript callers can
+  // supply excess request properties, so request input must never replace the
+  // configured origin, fetch implementation, or access-denied factory.
   const apiUrl = new URL(options.apiUrl).toString();
   const configuredTimeoutMs = options.timeoutMs;
   const configuredFetch = options.fetch;
@@ -251,6 +350,20 @@ export function createRuntimeProjectFilesClient(
   });
 }
 
+/**
+ * Create a runtime project files client that enforces hosted trust-boundary
+ * validation and resource limits.
+ */
+export function createStrictRuntimeProjectFilesClient(
+  options: StrictRuntimeProjectFilesClientOptions,
+): StrictRuntimeProjectFilesClient {
+  const clientOptions = normalizeRuntimeProjectFilesClientOptions(options);
+  return {
+    getProjectFile: (input) => getStrictRuntimeProjectFile({ ...input, ...clientOptions }),
+    getProjectFiles: (input) => getStrictRuntimeProjectFiles({ ...input, ...clientOptions }),
+  };
+}
+
 /** Return runtime project file. */
 export async function getRuntimeProjectFile(
   options: RuntimeProjectFilesClientOptions & RuntimeGetProjectFileOptions,
@@ -260,12 +373,13 @@ export async function getRuntimeProjectFile(
     (!Number.isSafeInteger(options.maximumContentCharacters) ||
       options.maximumContentCharacters <= 0 ||
       options.maximumContentCharacters >
-        Math.floor((Number.MAX_SAFE_INTEGER - PROJECT_FILE_JSON_OVERHEAD_BYTES) / 6))
+        Math.floor((Number.MAX_SAFE_INTEGER - PUBLIC_PROJECT_FILE_JSON_OVERHEAD_BYTES) / 6))
   ) {
     throw new RangeError(
       "Project file maximumContentCharacters must be a positive bounded safe integer",
     );
   }
+
   return withRuntimeProjectFilesRequestSignal(
     options,
     (signal) =>
@@ -291,9 +405,9 @@ export async function getRuntimeProjectFile(
 
         const responseValue = options.maximumContentCharacters === undefined
           ? await response.json()
-          : await readJsonResponseWithinLimit(
+          : await readPublicJsonResponseWithinLimit(
             response,
-            options.maximumContentCharacters * 6 + PROJECT_FILE_JSON_OVERHEAD_BYTES,
+            options.maximumContentCharacters * 6 + PUBLIC_PROJECT_FILE_JSON_OVERHEAD_BYTES,
             signal,
           );
         const parsed = getRuntimeProjectFileSchema().safeParse(responseValue);
@@ -317,13 +431,13 @@ export async function getRuntimeProjectFile(
   );
 }
 
-async function readJsonResponseWithinLimit(
+async function readPublicJsonResponseWithinLimit(
   response: Response,
   byteLimit: number,
   abortSignal?: AbortSignal,
   listingBudget?: RuntimeProjectFileListingBudget,
 ): Promise<unknown> {
-  throwIfAborted(abortSignal);
+  throwIfRuntimeProjectFilesAborted(abortSignal);
   const declaredLength = response.headers.get("content-length");
   if (declaredLength !== null) {
     const length = Number(declaredLength);
@@ -333,8 +447,8 @@ async function readJsonResponseWithinLimit(
   }
   if (!response.body) {
     const text = await response.text();
-    throwIfAborted(abortSignal);
-    const byteLength = utf8Encoder.encode(text).byteLength;
+    throwIfRuntimeProjectFilesAborted(abortSignal);
+    const byteLength = publicProjectFileUtf8Encoder.encode(text).byteLength;
     listingBudget?.consumeBytes(byteLength);
     if (byteLength > byteLimit) {
       throw new RangeError(`Project file response may contain at most ${byteLimit} bytes`);
@@ -356,13 +470,16 @@ async function readJsonResponseWithinLimit(
   try {
     while (true) {
       const result = await reader.read();
-      throwIfAborted(abortSignal);
+      throwIfRuntimeProjectFilesAborted(abortSignal);
       if (result.done) break;
 
       const chunk = result.value;
       if (chunk.byteLength === 0) {
         consecutiveEmptyChunks += 1;
-        if (consecutiveEmptyChunks > PROJECT_FILE_RESPONSE_MAX_CONSECUTIVE_EMPTY_CHUNKS) {
+        if (
+          consecutiveEmptyChunks >
+            PUBLIC_PROJECT_FILE_RESPONSE_MAX_CONSECUTIVE_EMPTY_CHUNKS
+        ) {
           throw new RangeError("Project file response stream made no byte progress");
         }
       } else {
@@ -379,7 +496,7 @@ async function readJsonResponseWithinLimit(
       while (chunkOffset < chunk.byteLength) {
         if (!currentBlock) {
           currentBlock = new Uint8Array(
-            Math.min(PROJECT_FILE_RESPONSE_BLOCK_BYTES, byteLimit),
+            Math.min(PUBLIC_PROJECT_FILE_RESPONSE_BLOCK_BYTES, byteLimit),
           );
           currentBlockLength = 0;
         }
@@ -387,7 +504,10 @@ async function readJsonResponseWithinLimit(
           currentBlock.byteLength - currentBlockLength,
           chunk.byteLength - chunkOffset,
         );
-        currentBlock.set(chunk.subarray(chunkOffset, chunkOffset + copied), currentBlockLength);
+        currentBlock.set(
+          chunk.subarray(chunkOffset, chunkOffset + copied),
+          currentBlockLength,
+        );
         currentBlockLength += copied;
         chunkOffset += copied;
         if (currentBlockLength === currentBlock.byteLength) {
@@ -398,10 +518,10 @@ async function readJsonResponseWithinLimit(
       }
 
       chunksSinceYield += 1;
-      if (chunksSinceYield >= PROJECT_FILE_RESPONSE_YIELD_CHUNKS) {
+      if (chunksSinceYield >= PUBLIC_PROJECT_FILE_RESPONSE_YIELD_CHUNKS) {
         chunksSinceYield = 0;
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
-        throwIfAborted(abortSignal);
+        throwIfRuntimeProjectFilesAborted(abortSignal);
       }
     }
   } catch (error) {
@@ -421,7 +541,93 @@ async function readJsonResponseWithinLimit(
   if (currentBlock && currentBlockLength > 0) {
     bytes.set(currentBlock.subarray(0, currentBlockLength), offset);
   }
-  return JSON.parse(utf8Decoder.decode(bytes));
+  return JSON.parse(publicProjectFileUtf8Decoder.decode(bytes));
+}
+
+/** Return a runtime project file with strict hosted-boundary enforcement. */
+export async function getStrictRuntimeProjectFile(
+  options:
+    & StrictRuntimeProjectFilesClientOptions
+    & RuntimeGetProjectFileOptions
+    & StrictRuntimeProjectFilesRequestContext,
+): Promise<RuntimeProjectFile | null> {
+  validateRuntimeProjectFilesClientOptions(options, false);
+  validateStrictRuntimeProjectFilesRequestContext(options);
+  validateRuntimeProjectFilesApiOptions(options);
+  validateProjectFileRequestPath(options.path);
+
+  return runStrictProjectFilesRequest(
+    options,
+    options.signal,
+    (requestScope) =>
+      traceStrictProjectFilesRequest(options, "runtimeProjectFiles.getProjectFile", async () => {
+        const url = createStrictRuntimeProjectFileUrl({
+          ...options,
+          fields: "(path,content)",
+        });
+        return await withStrictRuntimeProjectFilesRestResponse(
+          url,
+          options,
+          requestScope,
+          async (response, activeRequestScope) => {
+            if (response.status === 404) {
+              cancelResponseBodyWithoutWaiting(response);
+              return null;
+            }
+
+            if (!response.ok) {
+              throw NETWORK_ERROR.create({
+                detail:
+                  `Failed to fetch file ${options.path} for project ${options.projectId}: ${await readStrictApiErrorMessage(
+                    response,
+                    activeRequestScope,
+                  )}`,
+              });
+            }
+
+            const responseJson = await readBoundedJsonResponse(
+              response,
+              MAX_PROJECT_FILE_RESPONSE_BYTES,
+              "Project file response",
+              activeRequestScope,
+            ).catch((error) => {
+              if (!(error instanceof RuntimeProjectFilesProtocolError)) {
+                throw error;
+              }
+              throw createInvalidProjectFileResponseError(options, error);
+            });
+            const parsed = getStrictRuntimeProjectFileSchema().safeParse(responseJson);
+            if (!parsed.success) {
+              throw createInvalidProjectFileResponseError(options);
+            }
+            if (parsed.data.path !== options.path) {
+              throw createInvalidProjectFileResponseError(
+                options,
+                new RuntimeProjectFilesProtocolError(
+                  "Project file response path did not match the request",
+                ),
+              );
+            }
+            if (!isRuntimeProjectFileContent(parsed.data.content)) {
+              throw NETWORK_ERROR.create({
+                detail:
+                  `Failed to fetch file ${options.path} for project ${options.projectId}: content exceeds ${SKILL_TEXT_FILE_MAX_BYTES} bytes`,
+              });
+            }
+
+            return parsed.data;
+          },
+        );
+      }),
+  );
+}
+
+/** Whether a runtime project file content value fits the shared Skill budget. */
+export function isRuntimeProjectFileContent(content: unknown): content is string {
+  return typeof content === "string" &&
+    content.length <= SKILL_TEXT_FILE_MAX_BYTES &&
+    isWellFormedUtf16(content) &&
+    isUtf8WithinByteLimit(content, SKILL_TEXT_FILE_MAX_BYTES);
 }
 
 /** Return runtime project files. */
@@ -437,17 +643,20 @@ export async function getRuntimeProjectFiles(
   if (
     options.pathPrefix !== undefined &&
     (options.pathPrefix.length === 0 ||
-      options.pathPrefix.length > PROJECT_FILE_PATH_MAX_CHARACTERS ||
-      options.pathPrefix.startsWith("/") || options.pathPrefix.endsWith("/") ||
-      options.pathPrefix.includes("\\") || options.pathPrefix.includes("\0") ||
+      options.pathPrefix.length > MAX_PROJECT_FILE_PATH_CHARACTERS ||
+      options.pathPrefix.startsWith("/") ||
+      options.pathPrefix.endsWith("/") ||
+      options.pathPrefix.includes("\\") ||
+      options.pathPrefix.includes("\0") ||
       options.pathPrefix.split("/").some((segment) =>
         segment.length === 0 || segment === "." || segment === ".."
       ))
   ) {
     throw new RangeError(
-      `Project file list path must contain between 1 and ${PROJECT_FILE_PATH_MAX_CHARACTERS} characters`,
+      `Project file list path must contain between 1 and ${MAX_PROJECT_FILE_PATH_CHARACTERS} characters`,
     );
   }
+
   return withRuntimeProjectFilesRequestSignal(
     options,
     (signal) =>
@@ -458,7 +667,7 @@ export async function getRuntimeProjectFiles(
         let cursor: string | null = null;
 
         do {
-          throwIfAborted(signal);
+          throwIfRuntimeProjectFilesAborted(signal);
           listingBudget.consumePage();
           const url = createRuntimeProjectFileUrl({
             ...options,
@@ -466,7 +675,7 @@ export async function getRuntimeProjectFiles(
             cursor,
           });
           const response = await fetchRuntimeProjectFilesRestResponse(url, options, signal);
-          throwIfAborted(signal);
+          throwIfRuntimeProjectFilesAborted(signal);
 
           if (!response.ok) {
             throw NETWORK_ERROR.create({
@@ -478,9 +687,9 @@ export async function getRuntimeProjectFiles(
           }
 
           const parsed = getRuntimeProjectFileListRestResponseSchema().safeParse(
-            await readJsonResponseWithinLimit(
+            await readPublicJsonResponseWithinLimit(
               response,
-              PROJECT_FILE_LIST_PAGE_MAX_BYTES,
+              PUBLIC_PROJECT_FILE_LIST_PAGE_MAX_BYTES,
               signal,
               listingBudget,
             ),
@@ -493,18 +702,18 @@ export async function getRuntimeProjectFiles(
           }
 
           for (const file of parsed.data.data) {
-            if (file.path.length > PROJECT_FILE_PATH_MAX_CHARACTERS) {
+            if (file.path.length > MAX_PROJECT_FILE_PATH_CHARACTERS) {
               throw new RangeError(
-                `Project file paths may contain at most ${PROJECT_FILE_PATH_MAX_CHARACTERS} characters`,
+                `Project file paths may contain at most ${MAX_PROJECT_FILE_PATH_CHARACTERS} characters`,
               );
             }
           }
           if (
             parsed.data.page_info.next !== null &&
-            parsed.data.page_info.next.length > PROJECT_FILE_CURSOR_MAX_CHARACTERS
+            parsed.data.page_info.next.length > MAX_PROJECT_FILES_CURSOR_CHARACTERS
           ) {
             throw new RangeError(
-              `Project file cursors may contain at most ${PROJECT_FILE_CURSOR_MAX_CHARACTERS} characters`,
+              `Project file cursors may contain at most ${MAX_PROJECT_FILES_CURSOR_CHARACTERS} characters`,
             );
           }
 
@@ -527,6 +736,202 @@ export async function getRuntimeProjectFiles(
         return files;
       }),
   );
+}
+
+/** Return runtime project files with strict hosted-boundary enforcement. */
+export async function getStrictRuntimeProjectFiles(
+  options:
+    & StrictRuntimeProjectFilesClientOptions
+    & RuntimeProjectFilesApiOptions
+    & StrictRuntimeProjectFilesRequestContext,
+): Promise<RuntimeProjectFileListItem[]> {
+  validateRuntimeProjectFilesClientOptions(options);
+  validateStrictRuntimeProjectFilesRequestContext(options);
+  validateRuntimeProjectFilesApiOptions(options);
+  const pageLimit = resolveProjectFilesPageLimit(options.pageLimit);
+  const maximumEntries = Math.min(
+    options.maximumEntries ?? MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS,
+    MAX_RUNTIME_PROJECT_FILES_TOTAL_ITEMS,
+  );
+  const listingBudget = options.listingBudget ?? createRuntimeProjectFileListingBudget();
+  const operationDeadline = performance.now() +
+    resolveProjectFilesOperationTimeoutMs(options.operationTimeoutMs);
+  const operationScope = createStrictProjectFilesOperationScope(
+    options.signal,
+    operationDeadline,
+  );
+
+  try {
+    return await waitForStrictProjectFilesOperationPromise(
+      operationScope,
+      operationDeadline,
+      () =>
+        traceStrictProjectFilesRequest(options, "runtimeProjectFiles.getProjectFiles", async () => {
+          const files: RuntimeProjectFileListItem[] = [];
+          const seenCursors = new Set<string>();
+          let cursor: string | null = null;
+          let pageCount = 0;
+
+          do {
+            throwIfStrictProjectFilesOperationExpired(
+              operationScope,
+              operationDeadline,
+            );
+            if (pageCount >= MAX_PROJECT_FILES_TOTAL_PAGES) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `pagination exceeds ${MAX_PROJECT_FILES_TOTAL_PAGES} pages`,
+              );
+            }
+            pageCount += 1;
+            listingBudget.consumePage();
+
+            const remainingEntries = maximumEntries - files.length;
+            if (remainingEntries <= 0) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `file count exceeds ${maximumEntries}`,
+              );
+            }
+            const requestPageLimit = Math.min(pageLimit, remainingEntries);
+
+            const url = createStrictRuntimeProjectFileUrl({
+              ...options,
+              fields: "(path)",
+              cursor,
+              pageLimit: requestPageLimit,
+            });
+            const page = await runStrictProjectFilesRequest(
+              options,
+              operationScope.signal,
+              (requestScope) =>
+                withStrictRuntimeProjectFilesRestResponse(
+                  url,
+                  options,
+                  requestScope,
+                  async (response, activeRequestScope) => {
+                    if (!response.ok) {
+                      throw NETWORK_ERROR.create({
+                        detail:
+                          `Failed to fetch files for project ${options.projectId}: ${await readStrictApiErrorMessage(
+                            response,
+                            activeRequestScope,
+                            listingBudget,
+                          )}`,
+                      });
+                    }
+
+                    const responseJson = await readBoundedJsonResponse(
+                      response,
+                      MAX_PROJECT_FILE_LIST_PAGE_BYTES,
+                      "Project files list response",
+                      activeRequestScope,
+                      listingBudget,
+                    ).catch((error) => {
+                      if (!(error instanceof RuntimeProjectFilesProtocolError)) {
+                        throw error;
+                      }
+                      throw createInvalidProjectFilesListResponseError(options.projectId, error);
+                    });
+                    const parsed = getStrictRuntimeProjectFileListRestResponseSchema().safeParse(
+                      responseJson,
+                    );
+                    if (!parsed.success) {
+                      throw createInvalidProjectFilesListResponseError(options.projectId);
+                    }
+                    return parsed.data;
+                  },
+                ),
+            );
+            throwIfStrictProjectFilesOperationExpired(
+              operationScope,
+              operationDeadline,
+            );
+
+            if (page.data.length > requestPageLimit) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `page returned more than the requested ${requestPageLimit} files`,
+              );
+            }
+            if (
+              files.length + page.data.length > maximumEntries
+            ) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `file count exceeds ${maximumEntries}`,
+              );
+            }
+
+            const nextCursor = page.page_info.next;
+            if (
+              nextCursor !== null &&
+              files.length + page.data.length >= maximumEntries
+            ) {
+              throw createProjectFilesListLimitError(
+                options.projectId,
+                `file count exceeds ${maximumEntries}`,
+              );
+            }
+            files.push(...page.data);
+            if (nextCursor !== null) {
+              if (seenCursors.has(nextCursor)) {
+                throw createProjectFilesListLimitError(
+                  options.projectId,
+                  "pagination returned a repeated cursor",
+                );
+              }
+              seenCursors.add(nextCursor);
+            }
+            cursor = nextCursor;
+          } while (cursor);
+
+          throwIfStrictProjectFilesOperationExpired(
+            operationScope,
+            operationDeadline,
+          );
+          return files;
+        }),
+    );
+  } catch (error) {
+    operationScope.abort(error);
+    throw error;
+  } finally {
+    operationScope.dispose();
+  }
+}
+
+function createInvalidProjectFileResponseError(
+  options: RuntimeGetProjectFileOptions,
+  cause?: unknown,
+): Error {
+  const reason = cause instanceof Error ? `: ${cause.message}` : "";
+  return NETWORK_ERROR.create({
+    detail:
+      `Failed to fetch file ${options.path} for project ${options.projectId}: invalid API response${reason}`,
+  });
+}
+
+/*
+ * The legacy and strict implementations intentionally coexist above. Keep the
+ * helpers below split as well so future hosted hardening cannot silently narrow
+ * the established public contract.
+ */
+
+function createInvalidProjectFilesListResponseError(
+  projectId: string,
+  cause?: unknown,
+): Error {
+  const reason = cause instanceof Error ? `: ${cause.message}` : "";
+  return NETWORK_ERROR.create({
+    detail: `Failed to fetch files for project ${projectId}: invalid API response${reason}`,
+  });
+}
+
+function createProjectFilesListLimitError(projectId: string, reason: string): Error {
+  return NETWORK_ERROR.create({
+    detail: `Failed to fetch files for project ${projectId}: ${reason}`,
+  });
 }
 
 function createRuntimeProjectFileUrl(input: {
@@ -563,6 +968,40 @@ function createRuntimeProjectFileUrl(input: {
   return url;
 }
 
+function createStrictRuntimeProjectFileUrl(input: {
+  apiUrl: string | URL;
+  projectId: string;
+  path?: string;
+  pathPrefix?: string;
+  branchId?: string | null;
+  fields: string;
+  cursor?: string | null;
+  pageLimit?: number;
+}): URL {
+  const apiUrl = new URL(input.apiUrl);
+  const encodedProjectId = encodeURIComponent(input.projectId);
+  const pathname = input.path
+    ? `/projects/${encodedProjectId}/files/${encodeURIComponent(input.path)}`
+    : `/projects/${encodedProjectId}/files`;
+  const url = new URL(pathname, apiUrl.origin);
+
+  url.searchParams.set("fields", input.fields);
+  if (input.branchId) {
+    url.searchParams.set("branch", input.branchId);
+  }
+  if (input.cursor) {
+    url.searchParams.set("cursor", input.cursor);
+  }
+  if (input.pathPrefix) {
+    url.searchParams.set("path", input.pathPrefix);
+  }
+  if (!input.path) {
+    url.searchParams.set("limit", String(resolveProjectFilesPageLimit(input.pageLimit)));
+  }
+
+  return url;
+}
+
 async function fetchRuntimeProjectFilesRestResponse(
   url: URL,
   options: RuntimeProjectFilesClientOptions & { authToken: string },
@@ -582,7 +1021,7 @@ async function fetchRuntimeProjectFilesRestResponse(
   return response;
 }
 
-function throwIfAborted(signal: AbortSignal | undefined): void {
+function throwIfRuntimeProjectFilesAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) return;
   throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
 }
@@ -607,13 +1046,538 @@ async function withRuntimeProjectFilesRequestSignal<T>(
     timeoutMs,
   );
   try {
-    throwIfAborted(controller.signal);
+    throwIfRuntimeProjectFilesAborted(controller.signal);
     const result = await fn(controller.signal);
-    throwIfAborted(controller.signal);
+    throwIfRuntimeProjectFilesAborted(controller.signal);
     return result;
   } finally {
     clearTimeout(timeoutId);
     externalSignal?.removeEventListener("abort", abortFromExternal);
+  }
+}
+
+async function withStrictRuntimeProjectFilesRestResponse<TResult>(
+  url: URL,
+  options:
+    & StrictRuntimeProjectFilesClientOptions
+    & StrictRuntimeProjectFilesRequestContext
+    & { authToken: string },
+  requestScope: StrictProjectFilesRequestScope,
+  handleResponse: (
+    response: Response,
+    requestScope: StrictProjectFilesRequestScope,
+  ) => Promise<TResult>,
+): Promise<TResult> {
+  const response = await waitForStrictProjectFilesRequestPromise(
+    requestScope,
+    () =>
+      (options.fetch ?? fetch)(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${options.authToken}`,
+        },
+        signal: requestScope.signal,
+      }),
+    (lateResponse, reason) => {
+      cancelResponseBodyWithoutWaiting(lateResponse, reason);
+    },
+  );
+
+  if (response.status === 401 || response.status === 403) {
+    cancelResponseBodyWithoutWaiting(response);
+    throw createProjectFilesAccessDeniedError(options, response.status);
+  }
+
+  try {
+    const result = await handleResponse(response, requestScope);
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return result;
+  } catch (error) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw error;
+  }
+}
+
+function validateRuntimeProjectFilesClientOptions(
+  options: StrictRuntimeProjectFilesClientOptions,
+  validatePageLimit = true,
+): void {
+  normalizeProjectFilesApiUrl(options.apiUrl);
+  resolveProjectFilesTimeoutMs(options.timeoutMs);
+  resolveProjectFilesOperationTimeoutMs(options.operationTimeoutMs);
+  if (validatePageLimit) {
+    resolveProjectFilesPageLimit(options.pageLimit);
+  }
+  if (options.fetch !== undefined && typeof options.fetch !== "function") {
+    throw new TypeError("fetch must be a function");
+  }
+  if (options.trace !== undefined && typeof options.trace !== "function") {
+    throw new TypeError("trace must be a function");
+  }
+  if (
+    options.createAccessDeniedError !== undefined &&
+    typeof options.createAccessDeniedError !== "function"
+  ) {
+    throw new TypeError("createAccessDeniedError must be a function");
+  }
+}
+
+function normalizeRuntimeProjectFilesClientOptions(
+  options: StrictRuntimeProjectFilesClientOptions,
+): Readonly<StrictRuntimeProjectFilesClientOptions> {
+  validateRuntimeProjectFilesClientOptions(options);
+  return Object.freeze({
+    apiUrl: normalizeProjectFilesApiUrl(options.apiUrl),
+    ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+    timeoutMs: resolveProjectFilesTimeoutMs(options.timeoutMs),
+    operationTimeoutMs: resolveProjectFilesOperationTimeoutMs(options.operationTimeoutMs),
+    pageLimit: resolveProjectFilesPageLimit(options.pageLimit),
+    ...(options.trace === undefined ? {} : { trace: options.trace }),
+    ...(options.createAccessDeniedError === undefined
+      ? {}
+      : { createAccessDeniedError: options.createAccessDeniedError }),
+  });
+}
+
+function normalizeProjectFilesApiUrl(value: unknown): string {
+  if (
+    !(typeof value === "string" || value instanceof URL) ||
+    String(value).length === 0 ||
+    String(value).length > MAX_PROJECT_FILES_API_URL_CHARACTERS
+  ) {
+    throw new TypeError(
+      `apiUrl must be a URL no greater than ${MAX_PROJECT_FILES_API_URL_CHARACTERS} characters`,
+    );
+  }
+  const url = new URL(value);
+  if (
+    (url.protocol !== "https:" && url.protocol !== "http:") ||
+    url.username.length > 0 ||
+    url.password.length > 0
+  ) {
+    throw new TypeError("apiUrl must be an HTTP(S) URL without embedded credentials");
+  }
+  return url.origin;
+}
+
+function requireBoundedWireString(
+  value: unknown,
+  label: string,
+  maxLength: number,
+): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    !isWellFormedUtf16(value) ||
+    hasControlCharacters(value)
+  ) {
+    throw new TypeError(
+      `${label} must be a non-empty bounded string with well-formed UTF-16 and no control characters`,
+    );
+  }
+  return value;
+}
+
+function validateRuntimeProjectFilesApiOptions(
+  options: RuntimeProjectFilesApiOptions,
+): void {
+  if (
+    options.maximumEntries !== undefined &&
+    (!Number.isSafeInteger(options.maximumEntries) || options.maximumEntries <= 0)
+  ) {
+    throw new RangeError("Project file maximumEntries must be a positive safe integer");
+  }
+  const projectId = requireBoundedWireString(
+    options.projectId,
+    "projectId",
+    MAX_PROJECT_FILES_IDENTIFIER_CHARACTERS,
+  );
+  if (
+    projectId === "." ||
+    projectId === ".." ||
+    projectId.includes("/") ||
+    projectId.includes("\\")
+  ) {
+    throw new TypeError("projectId must be a single route-safe identifier");
+  }
+  requireBoundedWireString(
+    options.authToken,
+    "authToken",
+    MAX_PROJECT_FILES_AUTH_TOKEN_CHARACTERS,
+  );
+  // Preserve the historical wire contract: an empty branch identifier means
+  // "use the project's default branch" and is omitted from the query string.
+  if (
+    options.branchId !== undefined &&
+    options.branchId !== null &&
+    options.branchId !== ""
+  ) {
+    requireBoundedWireString(
+      options.branchId,
+      "branchId",
+      MAX_PROJECT_FILES_IDENTIFIER_CHARACTERS,
+    );
+  }
+  if (options.pathPrefix !== undefined) {
+    validateProjectFileRequestPath(options.pathPrefix);
+  }
+}
+
+function resolveProjectFilesTimeoutMs(timeoutMs: number | undefined): number {
+  const value = timeoutMs ?? DEFAULT_PROJECT_FILES_TIMEOUT_MS;
+  if (!Number.isSafeInteger(value) || value <= 0 || value > MAX_PROJECT_FILES_TIMEOUT_MS) {
+    throw new RangeError(
+      `timeoutMs must be a positive safe integer no greater than ${MAX_PROJECT_FILES_TIMEOUT_MS}`,
+    );
+  }
+  return value;
+}
+
+function resolveProjectFilesOperationTimeoutMs(timeoutMs: number | undefined): number {
+  const value = timeoutMs ?? DEFAULT_PROJECT_FILES_OPERATION_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    value > MAX_PROJECT_FILES_OPERATION_TIMEOUT_MS
+  ) {
+    throw new RangeError(
+      `operationTimeoutMs must be a positive safe integer no greater than ${MAX_PROJECT_FILES_OPERATION_TIMEOUT_MS}`,
+    );
+  }
+  return value;
+}
+
+type StrictProjectFilesAbortScope = {
+  signal: AbortSignal;
+  abort: (reason: unknown) => void;
+  dispose: () => void;
+};
+
+type StrictProjectFilesRequestScope = StrictProjectFilesAbortScope & {
+  deadline: number;
+};
+
+function createStrictProjectFilesAggregateDeadlineError(): DOMException {
+  return new DOMException(
+    "Project files listing exceeded its aggregate deadline",
+    "TimeoutError",
+  );
+}
+
+function createStrictProjectFilesRequestTimeoutError(): DOMException {
+  return new DOMException("Project files request timed out", "TimeoutError");
+}
+
+function getStrictProjectFilesAbortReason(signal: AbortSignal): unknown {
+  return signal.reason === undefined
+    ? new DOMException("Project files request was aborted", "AbortError")
+    : signal.reason;
+}
+
+function createStrictProjectFilesAbortScope(
+  upstreamSignal: AbortSignal | undefined,
+  timeoutMs: number,
+  createTimeoutReason: () => unknown,
+): StrictProjectFilesAbortScope {
+  if (upstreamSignal?.aborted) {
+    return {
+      signal: upstreamSignal,
+      abort: () => undefined,
+      dispose: () => undefined,
+    };
+  }
+
+  const controller = new AbortController();
+  if (timeoutMs <= 0) {
+    controller.abort(createTimeoutReason());
+    return {
+      signal: controller.signal,
+      abort: () => undefined,
+      dispose: () => undefined,
+    };
+  }
+
+  let disposed = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const abortFromUpstream = () => {
+    if (!controller.signal.aborted && upstreamSignal) {
+      controller.abort(getStrictProjectFilesAbortReason(upstreamSignal));
+    }
+  };
+
+  if (upstreamSignal) {
+    upstreamSignal.addEventListener("abort", abortFromUpstream, { once: true });
+    if (upstreamSignal.aborted) {
+      abortFromUpstream();
+    }
+  }
+  if (!controller.signal.aborted) {
+    timeoutId = setTimeout(() => {
+      controller.abort(createTimeoutReason());
+    }, Math.max(1, Math.ceil(timeoutMs)));
+  }
+
+  return {
+    signal: controller.signal,
+    abort: (reason) => {
+      if (!controller.signal.aborted) {
+        controller.abort(reason);
+      }
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+      upstreamSignal?.removeEventListener("abort", abortFromUpstream);
+    },
+  };
+}
+
+function createStrictProjectFilesOperationScope(
+  callerSignal: AbortSignal | undefined,
+  operationDeadline: number,
+): StrictProjectFilesAbortScope {
+  return createStrictProjectFilesAbortScope(
+    callerSignal,
+    operationDeadline - performance.now(),
+    createStrictProjectFilesAggregateDeadlineError,
+  );
+}
+
+function createStrictProjectFilesRequestScope(
+  upstreamSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): StrictProjectFilesRequestScope {
+  const deadline = performance.now() + timeoutMs;
+  return {
+    ...createStrictProjectFilesAbortScope(
+      upstreamSignal,
+      deadline - performance.now(),
+      createStrictProjectFilesRequestTimeoutError,
+    ),
+    deadline,
+  };
+}
+
+function throwIfStrictProjectFilesRequestExpired(
+  requestScope: StrictProjectFilesRequestScope,
+): void {
+  throwIfStrictProjectFilesAborted(requestScope.signal);
+  if (performance.now() >= requestScope.deadline) {
+    const error = createStrictProjectFilesRequestTimeoutError();
+    requestScope.abort(error);
+    throw error;
+  }
+}
+
+function consumeStrictProjectFilesPromise<TResult>(
+  promise: Promise<TResult>,
+): void {
+  promise.then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
+async function waitForStrictProjectFilesRequestPromise<TResult>(
+  requestScope: StrictProjectFilesRequestScope,
+  createPromise: () => Promise<TResult>,
+  onLateFulfilled?: (value: TResult, reason: unknown) => void,
+): Promise<TResult> {
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+
+  let promise: Promise<TResult>;
+  try {
+    promise = Promise.resolve(createPromise());
+  } catch (error) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw error;
+  }
+
+  const guardedPromise = promise.then((value) => {
+    try {
+      throwIfStrictProjectFilesRequestExpired(requestScope);
+      return value;
+    } catch (error) {
+      try {
+        onLateFulfilled?.(value, error);
+      } catch {
+        // Best-effort cleanup must not replace the deadline or cancellation.
+      }
+      throw error;
+    }
+  });
+
+  try {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+  } catch (error) {
+    consumeStrictProjectFilesPromise(guardedPromise);
+    throw error;
+  }
+
+  let result: TResult;
+  try {
+    result = await waitForStrictProjectFilesAbort(
+      guardedPromise,
+      requestScope.signal,
+    );
+  } catch (error) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw error;
+  }
+
+  try {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return result;
+  } catch (error) {
+    try {
+      onLateFulfilled?.(result, error);
+    } catch {
+      // Best-effort cleanup must not replace the deadline or cancellation.
+    }
+    throw error;
+  }
+}
+
+async function runStrictProjectFilesRequest<TResult>(
+  options: StrictRuntimeProjectFilesClientOptions,
+  upstreamSignal: AbortSignal | undefined,
+  operation: (requestScope: StrictProjectFilesRequestScope) => Promise<TResult>,
+): Promise<TResult> {
+  const requestScope = createStrictProjectFilesRequestScope(
+    upstreamSignal,
+    resolveProjectFilesTimeoutMs(options.timeoutMs),
+  );
+  try {
+    return await waitForStrictProjectFilesRequestPromise(
+      requestScope,
+      () => operation(requestScope),
+    );
+  } catch (error) {
+    requestScope.abort(error);
+    throw error;
+  } finally {
+    requestScope.dispose();
+  }
+}
+
+function throwIfStrictProjectFilesAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw getStrictProjectFilesAbortReason(signal);
+  }
+}
+
+function throwIfStrictProjectFilesOperationExpired(
+  operationScope: StrictProjectFilesAbortScope,
+  operationDeadline: number,
+): void {
+  throwIfStrictProjectFilesAborted(operationScope.signal);
+  if (performance.now() >= operationDeadline) {
+    const error = createStrictProjectFilesAggregateDeadlineError();
+    operationScope.abort(error);
+    throw error;
+  }
+}
+
+async function waitForStrictProjectFilesOperationPromise<TResult>(
+  operationScope: StrictProjectFilesAbortScope,
+  operationDeadline: number,
+  createPromise: () => Promise<TResult>,
+): Promise<TResult> {
+  throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+
+  let promise: Promise<TResult>;
+  try {
+    promise = Promise.resolve(createPromise());
+  } catch (error) {
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+    throw error;
+  }
+
+  const guardedPromise = promise.then((value) => {
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+    return value;
+  });
+
+  try {
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+  } catch (error) {
+    consumeStrictProjectFilesPromise(guardedPromise);
+    throw error;
+  }
+
+  try {
+    const result = await waitForStrictProjectFilesAbort(
+      guardedPromise,
+      operationScope.signal,
+    );
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+    return result;
+  } catch (error) {
+    throwIfStrictProjectFilesOperationExpired(operationScope, operationDeadline);
+    throw error;
+  }
+}
+
+function waitForStrictProjectFilesAbort<TResult>(
+  promise: Promise<TResult>,
+  signal: AbortSignal,
+): Promise<TResult> {
+  if (signal.aborted) {
+    promise.then(
+      () => undefined,
+      () => undefined,
+    );
+    return Promise.reject(getStrictProjectFilesAbortReason(signal));
+  }
+
+  return new Promise<TResult>((resolve, reject) => {
+    let settled = false;
+    const settle = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      action();
+    };
+    const onAbort = () => settle(() => reject(getStrictProjectFilesAbortReason(signal)));
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+    promise.then(
+      (value) => settle(() => resolve(value)),
+      (error) => settle(() => reject(error)),
+    );
+  });
+}
+
+function validateStrictRuntimeProjectFilesRequestContext(
+  options: StrictRuntimeProjectFilesRequestContext,
+): void {
+  if (options.signal !== undefined && !(options.signal instanceof AbortSignal)) {
+    throw new TypeError("signal must be an AbortSignal");
+  }
+}
+
+function resolveProjectFilesPageLimit(pageLimit: number | undefined): number {
+  const value = pageLimit ?? DEFAULT_PROJECT_FILES_PAGE_LIMIT;
+  if (!Number.isSafeInteger(value) || value <= 0 || value > MAX_PROJECT_FILES_PAGE_LIMIT) {
+    throw new RangeError(
+      `pageLimit must be a positive safe integer no greater than ${MAX_PROJECT_FILES_PAGE_LIMIT}`,
+    );
+  }
+  return value;
+}
+
+function validateProjectFileRequestPath(path: string): void {
+  const parsed = getStrictRuntimeProjectFilePathSchema().safeParse(path);
+  if (!parsed.success) {
+    throw new RangeError(
+      `path must be a canonical project-relative path of 1-${MAX_PROJECT_FILE_PATH_CHARACTERS} well-formed UTF-16 characters without controls`,
+    );
   }
 }
 
@@ -624,6 +1588,178 @@ function createProjectFilesAccessDeniedError(
   const message = "Access denied to project files API";
   return options.createAccessDeniedError?.(statusCode, message) ??
     new RuntimeProjectFilesApiAuthError(statusCode, message);
+}
+
+class RuntimeProjectFilesProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeProjectFilesProtocolError";
+  }
+}
+
+function cancelResponseBodyWithoutWaiting(response: Response, reason?: unknown): void {
+  try {
+    void response.body?.cancel(reason).catch(() => undefined);
+  } catch {
+    // Best-effort cleanup; preserve the primary protocol result.
+  }
+}
+
+function cancelReaderWithoutWaiting(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason?: unknown,
+): void {
+  let cancellation: Promise<void> | undefined;
+  try {
+    cancellation = reader.cancel(reason);
+  } catch {
+    // Best-effort cleanup; preserve the primary protocol error.
+  }
+  try {
+    reader.releaseLock();
+  } catch {
+    // Best-effort cleanup; preserve the primary protocol error.
+  }
+  if (cancellation) {
+    void cancellation.catch(() => undefined);
+  }
+}
+
+function parseDeclaredContentLength(response: Response, maxBytes: number, label: string): void {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength === null) {
+    return;
+  }
+  if (!/^\d+$/.test(contentLength)) {
+    cancelResponseBodyWithoutWaiting(response);
+    throw new RuntimeProjectFilesProtocolError(`${label} had an invalid Content-Length header`);
+  }
+  const declaredBytes = Number(contentLength);
+  if (!Number.isSafeInteger(declaredBytes) || declaredBytes > maxBytes) {
+    cancelResponseBodyWithoutWaiting(response);
+    throw new RuntimeProjectFilesProtocolError(`${label} exceeds ${maxBytes} bytes`);
+  }
+}
+
+async function readBoundedResponseText(
+  response: Response,
+  maxBytes: number,
+  label: string,
+  requestScope: StrictProjectFilesRequestScope,
+  listingBudget?: RuntimeProjectFileListingBudget,
+): Promise<string> {
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+  parseDeclaredContentLength(response, maxBytes, label);
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return "";
+  }
+
+  let bytes = new Uint8Array(0);
+  let byteLength = 0;
+  let completed = false;
+  let failure: unknown;
+
+  try {
+    while (true) {
+      const { done, value } = await waitForStrictProjectFilesRequestPromise(
+        requestScope,
+        () => reader.read(),
+      );
+      if (done) {
+        completed = true;
+        break;
+      }
+      listingBudget?.consumeBytes(value.byteLength);
+      if (value.byteLength > maxBytes - byteLength) {
+        throw new RuntimeProjectFilesProtocolError(`${label} exceeds ${maxBytes} bytes`);
+      }
+
+      const nextByteLength = byteLength + value.byteLength;
+      if (bytes.byteLength < nextByteLength) {
+        let capacity = Math.min(maxBytes, Math.max(1_024, bytes.byteLength * 2));
+        while (capacity < nextByteLength) {
+          capacity = Math.min(maxBytes, capacity * 2);
+        }
+        const grown = new Uint8Array(capacity);
+        grown.set(bytes.subarray(0, byteLength));
+        bytes = grown;
+      }
+      bytes.set(value, byteLength);
+      byteLength = nextByteLength;
+    }
+  } catch (error) {
+    failure = error;
+    throw error;
+  } finally {
+    if (!completed) {
+      cancelReaderWithoutWaiting(reader, failure);
+    } else {
+      reader.releaseLock();
+    }
+  }
+
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(
+      bytes.subarray(0, byteLength),
+    );
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return text;
+  } catch {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw new RuntimeProjectFilesProtocolError(`${label} was not valid UTF-8`);
+  }
+}
+
+async function readBoundedJsonResponse(
+  response: Response,
+  maxBytes: number,
+  label: string,
+  requestScope: StrictProjectFilesRequestScope,
+  listingBudget?: RuntimeProjectFileListingBudget,
+): Promise<unknown> {
+  const text = await readBoundedResponseText(
+    response,
+    maxBytes,
+    label,
+    requestScope,
+    listingBudget,
+  );
+  throwIfStrictProjectFilesRequestExpired(requestScope);
+  try {
+    const value = JSON.parse(text);
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    return value;
+  } catch {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    throw new RuntimeProjectFilesProtocolError(`${label} was not valid JSON`);
+  }
+}
+
+function truncateApiErrorMessage(message: string): string {
+  if (message.length <= MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS) {
+    return message;
+  }
+  const suffix = "...[truncated]";
+  return `${message.slice(0, MAX_PROJECT_FILES_ERROR_MESSAGE_CHARACTERS - suffix.length)}${suffix}`;
+}
+
+function isRequestCancellationError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (typeof current === "object" && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const errorLike = current as { name?: unknown; cause?: unknown };
+    if (errorLike.name === "AbortError" || errorLike.name === "TimeoutError") {
+      return true;
+    }
+    current = errorLike.cause;
+  }
+  return false;
 }
 
 async function readApiErrorMessage(response: Response): Promise<string> {
@@ -650,10 +1786,133 @@ async function readApiErrorMessage(response: Response): Promise<string> {
   return body;
 }
 
+async function readStrictApiErrorMessage(
+  response: Response,
+  requestScope: StrictProjectFilesRequestScope,
+  listingBudget?: RuntimeProjectFileListingBudget,
+): Promise<string> {
+  let body: string;
+  try {
+    body = await readBoundedResponseText(
+      response,
+      MAX_PROJECT_FILES_ERROR_BODY_BYTES,
+      "Project files API error response",
+      requestScope,
+      listingBudget,
+    );
+  } catch (error) {
+    throwIfStrictProjectFilesRequestExpired(requestScope);
+    if (isRequestCancellationError(error)) {
+      throw error;
+    }
+    if (error instanceof RangeError) {
+      throw error;
+    }
+    return error instanceof Error
+      ? error.message
+      : response.statusText || `HTTP ${response.status}`;
+  }
+  if (!body.trim()) {
+    return response.statusText || `HTTP ${response.status}`;
+  }
+
+  let parsedJson: { success: true; data: { detail?: string; message?: string; error?: string } } | {
+    success: false;
+  };
+  try {
+    const jsonValue = JSON.parse(body);
+    const result = getStrictApiErrorBodySchema().safeParse(jsonValue);
+    parsedJson = result.success ? { success: true, data: result.data } : { success: false };
+  } catch {
+    parsedJson = { success: false };
+  }
+
+  if (parsedJson.success) {
+    return truncateApiErrorMessage(
+      parsedJson.data.detail ?? parsedJson.data.message ?? parsedJson.data.error ?? body,
+    );
+  }
+
+  return truncateApiErrorMessage(body);
+}
+
 function traceProjectFilesRequest<T>(
   options: RuntimeProjectFilesClientOptions,
   name: string,
   fn: () => Promise<T>,
 ): Promise<T> {
   return options.trace ? options.trace(name, fn) : fn();
+}
+
+async function traceStrictProjectFilesRequest<T>(
+  options: StrictRuntimeProjectFilesClientOptions,
+  name: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const trace = options.trace;
+  if (!trace) {
+    return await fn();
+  }
+
+  let traceSettled = false;
+  let operationInvoked = false;
+  let operationPromise: Promise<T> | undefined;
+  let invocationError: TypeError | undefined;
+  const rejectInvocation = (error: TypeError): Promise<T> => {
+    const promise = Promise.reject<T>(error);
+    consumeStrictProjectFilesPromise(promise);
+    return promise;
+  };
+  const invokeOperation = (): Promise<T> => {
+    if (traceSettled) {
+      return rejectInvocation(
+        new TypeError("trace invoked the project files operation after settling"),
+      );
+    }
+    if (operationInvoked) {
+      invocationError ??= new TypeError(
+        "trace must invoke the project files operation exactly once",
+      );
+      return rejectInvocation(invocationError);
+    }
+    operationInvoked = true;
+    try {
+      operationPromise = Promise.resolve(fn());
+    } catch (error) {
+      operationPromise = Promise.reject(error);
+    }
+    consumeStrictProjectFilesPromise(operationPromise);
+    return operationPromise;
+  };
+
+  let tracePromise: Promise<T>;
+  try {
+    tracePromise = Promise.resolve(trace(name, invokeOperation));
+  } catch (error) {
+    traceSettled = true;
+    if (operationPromise) {
+      consumeStrictProjectFilesPromise(operationPromise);
+    }
+    throw error;
+  }
+
+  try {
+    await tracePromise;
+  } catch (error) {
+    traceSettled = true;
+    if (operationPromise) {
+      consumeStrictProjectFilesPromise(operationPromise);
+    }
+    throw error;
+  }
+
+  traceSettled = true;
+  if (!operationInvoked || !operationPromise) {
+    throw new TypeError("trace must invoke the project files operation exactly once");
+  }
+  const result = await operationPromise;
+  if (invocationError) {
+    throw invocationError;
+  }
+  return result;
 }

--- a/src/agent/runtime/project-skill-catalog.test.ts
+++ b/src/agent/runtime/project-skill-catalog.test.ts
@@ -3,11 +3,20 @@ import "#veryfront/skill/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects, assertThrows } from "@std/assert";
 import { resolve } from "node:path";
 import {
+  SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS,
+  SKILL_CATALOG_MAX_METADATA_CHARACTERS,
+  SKILL_CATALOG_MAX_PATH_ENTRIES,
+  SKILL_CATALOG_MAX_SKILLS,
+  SKILL_DOCUMENT_MAX_CHARACTERS,
   SKILL_LOADABLE_REFERENCE_MAX_ENTRIES,
   SKILL_STEERING_PATH_MAX_ENTRIES,
   SKILL_SUBDIR_MAX_ENTRIES,
   SKILL_TEXT_FILE_MAX_BYTES,
 } from "#veryfront/skill/limits.ts";
+import {
+  createSkillOperationBudget,
+  SkillOperationTimeoutError,
+} from "#veryfront/skill/operation-budget.ts";
 import {
   getRuntimeProjectInstructions,
   getRuntimeProjectSkillCatalog,
@@ -19,12 +28,6 @@ import type {
   RuntimeProjectFilesApiOptions,
 } from "./project-files-client.ts";
 import type { RuntimeSkillDefinition } from "./skill-metadata.ts";
-import {
-  SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS,
-  SKILL_CATALOG_MAX_METADATA_CHARACTERS,
-  SKILL_CATALOG_MAX_PATH_ENTRIES,
-  SKILL_CATALOG_MAX_SKILLS,
-} from "#veryfront/skill/limits.ts";
 
 const PROJECT_CONTEXT = {
   projectId: "project-1",
@@ -181,11 +184,12 @@ Deno.test("builtin directory skills take precedence over flat files with the sam
   });
 });
 
-Deno.test("built-in catalog rejects work beyond the cumulative skill limit", () => {
+Deno.test("built-in catalogs enforce the cumulative retained skill limit", () => {
   withTempDir((rootDir) => {
     for (let index = 0; index <= SKILL_CATALOG_MAX_SKILLS; index += 1) {
       Deno.writeTextFileSync(resolve(rootDir, `skill-${index}.md`), "# Skill");
     }
+
     assertThrows(
       () => loadRuntimeBuiltinSkillCatalog({ skillsDir: rootDir }),
       RangeError,
@@ -322,7 +326,7 @@ Deno.test("getRuntimeProjectInstructions returns the first available instruction
     {
       ...PROJECT_CONTEXT,
       path: "AGENTS.md",
-      maximumContentCharacters: 1_048_576,
+      maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
     },
   ]);
 });
@@ -355,19 +359,55 @@ Deno.test("getRuntimeProjectInstructions rejects untrusted custom loader respons
   );
 });
 
-Deno.test("getRuntimeProjectSkillCatalog returns builtin skills when project files are unavailable", async () => {
-  const builtinSkills = [
-    {
-      id: "plan",
-      name: "plan",
-      description: "Plan",
-      instructions: "# Plan",
-      allowedTools: [],
-    },
-  ];
-  const { catalog } = createSkillCatalog({ builtinSkills, paths: null });
+Deno.test("project catalog deadlines settle non-cooperative listing clients", async () => {
+  await assertRejects(
+    () =>
+      getRuntimeProjectSkillCatalog({
+        ...PROJECT_CONTEXT,
+        builtinSkills: [],
+        operationBudget: createSkillOperationBudget({ timeoutMs: 5 }),
+        getProjectFiles: () => new Promise(() => {}),
+        getProjectFile: () => Promise.resolve(null),
+      }),
+    SkillOperationTimeoutError,
+    "timed out",
+  );
+});
 
-  assertEquals(await catalog(), builtinSkills);
+Deno.test("project catalog forwards one cancellation signal through listing and reads", async () => {
+  const controller = new AbortController();
+  const signals: Array<AbortSignal | undefined> = [];
+  const timeouts: Array<number | undefined> = [];
+  const skillPath = "skills/research/SKILL.md";
+
+  const skills = await getRuntimeProjectSkillCatalog({
+    ...PROJECT_CONTEXT,
+    builtinSkills: [],
+    operationBudget: createSkillOperationBudget({
+      abortSignal: controller.signal,
+      timeoutMs: 1_000,
+    }),
+    getProjectFiles: (options) => {
+      signals.push(options.abortSignal);
+      timeouts.push(options.timeoutMs);
+      return Promise.resolve(options.pathPrefix === "skills" ? [{ path: skillPath }] : []);
+    },
+    getProjectFile: (options) => {
+      signals.push(options.abortSignal);
+      timeouts.push(options.timeoutMs);
+      return Promise.resolve({
+        path: skillPath,
+        content: "---\nname: research\ndescription: Research\n---\nBody",
+      });
+    },
+  });
+
+  assertEquals(skills.map((skill) => skill.id), ["research"]);
+  assertEquals(signals.every((signal) => signal === controller.signal), true);
+  assertEquals(
+    timeouts.every((timeout) => typeof timeout === "number" && timeout > 0 && timeout <= 1_000),
+    true,
+  );
 });
 
 Deno.test("project catalog snapshots builtin definitions before awaiting project discovery", async () => {
@@ -543,6 +583,47 @@ Deno.test("project skill catalog rejects oversized discovery before scheduling f
   assertEquals(fileReads, 0);
 });
 
+Deno.test("project catalogs reject documents beyond the aggregate retained budget", async () => {
+  const documentCount = SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS /
+      SKILL_DOCUMENT_MAX_CHARACTERS +
+    1;
+  const paths = Array.from(
+    { length: documentCount },
+    (_unused, index) => `skills/skill-${index}/SKILL.md`,
+  );
+  const maximumDocument = "x".repeat(SKILL_DOCUMENT_MAX_CHARACTERS);
+
+  await assertRejects(
+    () =>
+      getRuntimeProjectSkillCatalog({
+        ...PROJECT_CONTEXT,
+        builtinSkills: [],
+        getProjectFiles: (options) =>
+          Promise.resolve(
+            options.pathPrefix === "skills" ? paths.map((path) => ({ path })) : [],
+          ),
+        getProjectFile: ({ path }) => Promise.resolve({ path, content: maximumDocument }),
+      }),
+    RangeError,
+    `${SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS} characters`,
+  );
+});
+
+Deno.test("getRuntimeProjectSkillCatalog returns builtin skills when project files are unavailable", async () => {
+  const builtinSkills = [
+    {
+      id: "plan",
+      name: "plan",
+      description: "Plan",
+      instructions: "# Plan",
+      allowedTools: [],
+    },
+  ];
+  const { catalog } = createSkillCatalog({ builtinSkills, paths: null });
+
+  assertEquals(await catalog(), builtinSkills);
+});
+
 Deno.test("getRuntimeProjectSkillCatalog parses project directory skills and references", async () => {
   const { catalog, filesCalls, fileCalls } = createSkillCatalog({
     paths: [
@@ -573,19 +654,27 @@ Deno.test("getRuntimeProjectSkillCatalog parses project directory skills and ref
     "resources/schema.json",
   ]);
   assertEquals(filesCalls.map(withoutRuntimeBudgetFields), [
-    { ...PROJECT_CONTEXT, pathPrefix: "skills", maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES },
+    {
+      ...PROJECT_CONTEXT,
+      pathPrefix: "skills",
+      maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES,
+    },
     {
       ...PROJECT_CONTEXT,
       pathPrefix: ".veryfront/skills",
       maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES,
     },
-    { ...PROJECT_CONTEXT, pathPrefix: "agents", maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES },
+    {
+      ...PROJECT_CONTEXT,
+      pathPrefix: "agents",
+      maximumEntries: SKILL_CATALOG_MAX_PATH_ENTRIES,
+    },
   ]);
   assertEquals(fileCalls.map(withoutRuntimeBudgetFields), [
     {
       ...PROJECT_CONTEXT,
       path: "skills/research/SKILL.md",
-      maximumContentCharacters: 1_048_576,
+      maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
     },
   ]);
 });
@@ -965,7 +1054,7 @@ Deno.test("project skill catalog stops scheduling after a fetch failure and awai
   assertEquals(fileFetches, fetchesAtRejection);
 });
 
-Deno.test("project catalog admits 3000 readable files and rejects 3001", async () => {
+Deno.test("project catalog enforces per-directory bounds and accepts the aggregate readable budget", async () => {
   const skillPath = "skills/research/SKILL.md";
   const readablePaths = ["references", "resources", "assets"].flatMap((directory) =>
     Array.from(
@@ -975,7 +1064,7 @@ Deno.test("project catalog admits 3000 readable files and rejects 3001", async (
   );
   const skillContent = "---\nname: research\ndescription: Research\n---\nBody";
 
-  const catalog = await getRuntimeProjectSkillCatalog({
+  const skills = await getRuntimeProjectSkillCatalog({
     ...PROJECT_CONTEXT,
     builtinSkills: [],
     getProjectFiles: async () => [
@@ -984,7 +1073,7 @@ Deno.test("project catalog admits 3000 readable files and rejects 3001", async (
     ],
     getProjectFile: async ({ path }) => path === skillPath ? { path, content: skillContent } : null,
   });
-  assertEquals(catalog[0]?.references?.length, SKILL_LOADABLE_REFERENCE_MAX_ENTRIES);
+  assertEquals(skills[0]?.references?.length, SKILL_LOADABLE_REFERENCE_MAX_ENTRIES);
 
   await assertRejects(
     () =>
@@ -993,15 +1082,41 @@ Deno.test("project catalog admits 3000 readable files and rejects 3001", async (
         builtinSkills: [],
         getProjectFiles: async () => [
           { path: skillPath },
-          ...readablePaths.map((path) => ({ path })),
-          { path: `skills/research/assets/${SKILL_SUBDIR_MAX_ENTRIES}.txt` },
+          ...Array.from(
+            { length: SKILL_SUBDIR_MAX_ENTRIES + 1 },
+            (_unused, index) => ({ path: `skills/research/resources/${index}.txt` }),
+          ),
         ],
         getProjectFile: async ({ path }) =>
           path === skillPath ? { path, content: skillContent } : null,
       }),
     RangeError,
-    `at most ${SKILL_SUBDIR_MAX_ENTRIES} entries`,
+    "resources/",
   );
+});
+
+Deno.test("project catalog rejects paths beyond its aggregate retained budget before reads", async () => {
+  let fileReads = 0;
+  const paths = Array.from(
+    { length: SKILL_CATALOG_MAX_PATH_ENTRIES + 1 },
+    (_unused, index) => ({ path: `skills/research/references/${index}.txt` }),
+  );
+
+  await assertRejects(
+    () =>
+      getRuntimeProjectSkillCatalog({
+        ...PROJECT_CONTEXT,
+        builtinSkills: [],
+        getProjectFiles: (options) => Promise.resolve(options.pathPrefix === "skills" ? paths : []),
+        getProjectFile: () => {
+          fileReads += 1;
+          return Promise.resolve(null);
+        },
+      }),
+    RangeError,
+    `${SKILL_CATALOG_MAX_PATH_ENTRIES} entries`,
+  );
+  assertEquals(fileReads, 0);
 });
 
 Deno.test("project steering path lists are bounded before lookup", async () => {

--- a/src/agent/runtime/project-skill-catalog.ts
+++ b/src/agent/runtime/project-skill-catalog.ts
@@ -43,8 +43,11 @@ import {
 } from "#veryfront/skill/limits.ts";
 import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { readOwnDataProperty, snapshotOwnDataPropertyArray } from "./data-property-descriptor.ts";
+import type { SkillDocumentParserProvider } from "#veryfront/extensions/parser/skill-document-parser.ts";
+import { SkillIdAdmission } from "#veryfront/skill/id-admission.ts";
+import { SKILL_READABLE_DIRS } from "#veryfront/skill/types.ts";
+import { utf8ByteLength } from "#veryfront/utils/utf8-byte-length.ts";
 
-const utf8Encoder = new TextEncoder();
 const ArrayIsArray = Array.isArray;
 const NumberIsFinite = Number.isFinite;
 const NumberIsSafeInteger = Number.isSafeInteger;
@@ -52,6 +55,8 @@ const ObjectDefineProperty = Object.defineProperty;
 const ObjectFreeze = Object.freeze;
 const ObjectKeys = Object.keys;
 const ReflectApply = Reflect.apply;
+
+const PROJECT_SKILL_FETCH_CONCURRENCY = 16;
 
 class RuntimeSkillCatalogBudget {
   private documentCharacters = 0;
@@ -62,19 +67,20 @@ class RuntimeSkillCatalogBudget {
 
   retainDocument(content: string): void {
     const characters = this.documentCharacters + content.length;
-    const utf8Bytes = this.documentUtf8Bytes + utf8Encoder.encode(content).byteLength;
     if (characters > SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS) {
       throw new RangeError(
         `Skill catalog documents may contain at most ${SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS} characters`,
       );
     }
-    if (utf8Bytes > SKILL_CATALOG_MAX_DOCUMENT_UTF8_BYTES) {
+    const remainingUtf8Bytes = SKILL_CATALOG_MAX_DOCUMENT_UTF8_BYTES - this.documentUtf8Bytes;
+    const addedUtf8Bytes = utf8ByteLength(content, remainingUtf8Bytes);
+    if (addedUtf8Bytes > remainingUtf8Bytes) {
       throw new RangeError(
         `Skill catalog documents may contain at most ${SKILL_CATALOG_MAX_DOCUMENT_UTF8_BYTES} UTF-8 bytes`,
       );
     }
     this.documentCharacters = characters;
-    this.documentUtf8Bytes = utf8Bytes;
+    this.documentUtf8Bytes += addedUtf8Bytes;
   }
 
   retainPath(): void {
@@ -130,11 +136,6 @@ function retainExistingDefinition(
   for (const _reference of definition.references ?? []) budget.retainPath();
   budget.retainDefinition(definition);
 }
-import { SKILL_READABLE_DIRS } from "#veryfront/skill/types.ts";
-import { SkillIdAdmission } from "#veryfront/skill/id-admission.ts";
-import type { SkillDocumentParserProvider } from "#veryfront/extensions/parser/skill-document-parser.ts";
-
-const PROJECT_SKILL_FETCH_CONCURRENCY = 16;
 
 /** Public API contract for runtime project steering lookup. */
 export type RuntimeProjectSteeringLookup = {
@@ -498,6 +499,67 @@ function createCatalogBudget(existing?: SkillOperationBudget): SkillOperationBud
   return existing ?? createSkillOperationBudget({ timeoutMs: SKILL_FILE_OPERATION_TIMEOUT_MS });
 }
 
+async function fetchProjectSkillDocument(
+  input:
+    & RuntimeProjectSteeringLookup
+    & Pick<RuntimeProjectSkillCatalogOptions, "getProjectFile" | "logger">,
+  requestedPath: string,
+  operationBudget: SkillOperationBudget,
+  catalogBudget: RuntimeSkillCatalogBudget,
+): Promise<RuntimeProjectFile | null> {
+  const value = await operationBudget.run((abortSignal) =>
+    input.getProjectFile({
+      projectId: input.projectId,
+      authToken: input.authToken,
+      branchId: input.branchId,
+      path: requestedPath,
+      maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
+      abortSignal,
+      timeoutMs: operationBudget.remainingMs(),
+    })
+  );
+  if (value === null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Project skill response must be an object or null");
+  }
+
+  const pathDescriptor = Object.getOwnPropertyDescriptor(value, "path");
+  const contentDescriptor = Object.getOwnPropertyDescriptor(value, "content");
+  const responsePath = pathDescriptor && "value" in pathDescriptor
+    ? pathDescriptor.value
+    : undefined;
+  const content = contentDescriptor && "value" in contentDescriptor
+    ? contentDescriptor.value
+    : undefined;
+  if (!isRuntimeProjectFilePath(responsePath)) {
+    input.logger?.error?.("Project skill response had an invalid path; skipping skill", {
+      expectedPath: requestedPath,
+    });
+    return null;
+  }
+  if (responsePath !== requestedPath) {
+    input.logger?.error?.(
+      "Project skill response path did not match its request; skipping skill",
+      { expectedPath: requestedPath, responsePath },
+    );
+    return null;
+  }
+  if (content === "") return null;
+  if (!isRuntimeProjectFileContent(content)) {
+    input.logger?.error?.("Project skill content exceeded its budget; skipping skill", {
+      path: requestedPath,
+    });
+    return null;
+  }
+
+  assertCatalogContent(content, "Skill document");
+  // Charge the shared catalog before returning the document to the concurrent
+  // result set. This caps retained completed reads to the aggregate budget;
+  // only the fixed-size worker set can still be in flight.
+  catalogBudget.retainDocument(content);
+  return Object.freeze({ path: responsePath, content });
+}
+
 /** Loads runtime builtin skill catalog. */
 export function loadRuntimeBuiltinSkillCatalog(input: {
   skillsDir: string;
@@ -620,15 +682,11 @@ export async function getRuntimeProjectSkillCatalog(
         })
       ),
     );
-    if (!files) {
-      continue;
-    }
+    if (!files) continue;
     hasAvailableListing = true;
     for (const file of files) {
-      // Do not trust custom clients to honor the server-side catalog filter.
-      if (!file.path.startsWith(prefixWithSlash)) {
-        continue;
-      }
+      // Custom clients may ignore the server-side catalog filter.
+      if (!file.path.startsWith(prefixWithSlash)) continue;
       if (!filesByPath.has(file.path)) catalogBudget.retainPath();
       filesByPath.set(file.path, file);
     }
@@ -680,44 +738,16 @@ export async function getRuntimeProjectSkillCatalog(
     const skillFiles = await mapWithConcurrency(
       candidates,
       PROJECT_SKILL_FETCH_CONCURRENCY,
-      ({ path }) =>
-        budget.run((abortSignal) =>
-          input.getProjectFile({
-            projectId: input.projectId,
-            authToken: input.authToken,
-            branchId: input.branchId,
-            path,
-            maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
-            abortSignal,
-            timeoutMs: budget.remainingMs(),
-          })
-        ),
+      ({ path }) => fetchProjectSkillDocument(input, path, budget, catalogBudget),
     );
 
     for (let index = 0; index < skillFiles.length; index += 1) {
+      budget.throwIfTerminated();
       const candidate = candidates[index]!;
       const file = skillFiles[index];
       if (!file?.content) {
         continue;
       }
-      if (file.path !== candidate.path) {
-        input.logger?.error?.(
-          "Project skill response path did not match its request; skipping skill",
-          {
-            expectedPath: candidate.path,
-            responsePath: file.path,
-          },
-        );
-        continue;
-      }
-      if (!isRuntimeProjectFileContent(file.content)) {
-        input.logger?.error?.("Project skill content exceeded its budget; skipping skill", {
-          path: candidate.path,
-        });
-        continue;
-      }
-      assertCatalogContent(file.content, "Skill document");
-      catalogBudget.retainDocument(file.content);
 
       const definition = candidate.isFlat
         ? buildLegacyRuntimeFlatSkillDefinition({
@@ -791,44 +821,16 @@ export async function getRuntimeProjectSkillCatalog(
     const colocatedFiles = await mapWithConcurrency(
       colocatedCandidates,
       PROJECT_SKILL_FETCH_CONCURRENCY,
-      ({ path }) =>
-        budget.run((abortSignal) =>
-          input.getProjectFile({
-            projectId: input.projectId,
-            authToken: input.authToken,
-            branchId: input.branchId,
-            path,
-            maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
-            abortSignal,
-            timeoutMs: budget.remainingMs(),
-          })
-        ),
+      ({ path }) => fetchProjectSkillDocument(input, path, budget, catalogBudget),
     );
 
     for (let index = 0; index < colocatedFiles.length; index += 1) {
+      budget.throwIfTerminated();
       const candidate = colocatedCandidates[index]!;
       const file = colocatedFiles[index];
       if (!file?.content) {
         continue;
       }
-      if (file.path !== candidate.path) {
-        input.logger?.error?.(
-          "Project skill response path did not match its request; skipping skill",
-          {
-            expectedPath: candidate.path,
-            responsePath: file.path,
-          },
-        );
-        continue;
-      }
-      if (!isRuntimeProjectFileContent(file.content)) {
-        input.logger?.error?.("Project skill content exceeded its budget; skipping skill", {
-          path: candidate.path,
-        });
-        continue;
-      }
-      assertCatalogContent(file.content, "Colocated skill document");
-      catalogBudget.retainDocument(file.content);
 
       const definition = buildRuntimeDirectorySkillDefinition({
         id: candidate.identity.id,
@@ -861,6 +863,7 @@ export async function getRuntimeProjectSkillCatalog(
     mergedSkillsById.set(skill.id, skill);
   }
 
+  budget.throwIfTerminated();
   return sortSkillsById(mergedSkillsById.values());
 }
 

--- a/src/agent/runtime/project-skill-loader.ts
+++ b/src/agent/runtime/project-skill-loader.ts
@@ -84,11 +84,17 @@ export type RuntimeProjectSkillLoaderLogger = {
   warn?: (message: string, metadata?: Record<string, unknown>) => void;
 };
 
+type RuntimeProjectSkillReadContext = {
+  budget: SkillOperationBudget;
+};
+
 /** Options accepted by runtime project skill loader. */
 export type RuntimeProjectSkillLoaderOptions = {
-  getProjectFile: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
+  getProjectFile: (
+    options: RuntimeGetProjectFileOptions & { signal?: AbortSignal },
+  ) => Promise<RuntimeProjectFile | null>;
   getProjectFiles: (
-    options: RuntimeProjectFilesApiOptions,
+    options: RuntimeProjectFilesApiOptions & { signal?: AbortSignal },
   ) => Promise<RuntimeProjectFileListItem[]>;
   steeringPaths?: Pick<ProjectSteeringPaths, "skills">;
   isAccessDeniedError?: (error: unknown) => boolean;
@@ -163,6 +169,13 @@ function snapshotProjectFileList(value: unknown): readonly RuntimeProjectFileLis
   });
 }
 
+function isAccessDeniedError(
+  error: unknown,
+  options: RuntimeProjectSkillLoaderOptions,
+): boolean {
+  return options.isAccessDeniedError?.(error) ?? false;
+}
+
 function assertRuntimeSkillContent(content: string, label: string): void {
   if (content.length > SKILL_DOCUMENT_MAX_CHARACTERS) {
     throw new RangeError(
@@ -171,11 +184,40 @@ function assertRuntimeSkillContent(content: string, label: string): void {
   }
 }
 
-function isAccessDeniedError(
-  error: unknown,
-  options: RuntimeProjectSkillLoaderOptions,
-): boolean {
-  return options.isAccessDeniedError?.(error) ?? false;
+async function readProjectSkillValue<T>(
+  budget: SkillOperationBudget,
+  read: () => Promise<T>,
+): Promise<T> {
+  return await budget.run(() => read());
+}
+
+function getProjectSkillCancellationOptions(
+  budget: SkillOperationBudget,
+): Pick<RuntimeProjectFilesApiOptions, "abortSignal" | "timeoutMs"> & {
+  signal?: AbortSignal;
+} {
+  budget.throwIfTerminated();
+  const timeoutMs = budget.remainingMs();
+  if (timeoutMs === 0) {
+    budget.throwIfTerminated();
+  }
+  return {
+    ...(budget.abortSignal === undefined
+      ? {}
+      : { abortSignal: budget.abortSignal, signal: budget.abortSignal }),
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  };
+}
+
+function getBoundedProjectSkillFileOptions(
+  budget: SkillOperationBudget,
+): Pick<RuntimeGetProjectFileOptions, "abortSignal" | "maximumContentCharacters" | "timeoutMs"> & {
+  signal?: AbortSignal;
+} {
+  return {
+    ...getProjectSkillCancellationOptions(budget),
+    maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
+  };
 }
 
 type ProjectSkillSource =
@@ -206,22 +248,30 @@ function isSafeRuntimeSkillId(skillId: unknown): skillId is string {
 
 async function getExpectedProjectFile(
   options: RuntimeProjectSkillLoaderOptions,
-  request: RuntimeGetProjectFileOptions,
+  request: RuntimeGetProjectFileOptions & RuntimeProjectSkillReadContext,
 ): Promise<RuntimeProjectFile | null> {
-  const file = await options.getProjectFile(request);
+  const { budget, ...fileRequest } = request;
+  const file = await readProjectSkillValue(
+    budget,
+    () =>
+      options.getProjectFile({
+        ...fileRequest,
+        ...getBoundedProjectSkillFileOptions(budget),
+      }),
+  );
   if (
     file !== null &&
     (
       !isRuntimeProjectFilePath(file.path) ||
-      file.path !== request.path
+      file.path !== fileRequest.path
     )
   ) {
     throw new TypeError(
-      `Project file response path "${file.path}" did not match requested path "${request.path}"`,
+      `Project file response path "${file.path}" did not match requested path "${fileRequest.path}"`,
     );
   }
   if (file !== null && !isRuntimeProjectFileContent(file.content)) {
-    throw new RangeError(`Project file "${request.path}" exceeded its content budget`);
+    throw new RangeError(`Project file "${fileRequest.path}" exceeded its content budget`);
   }
   return file;
 }
@@ -276,27 +326,13 @@ function resolveCatalogSkillSource(
   throw new TypeError(`Catalog source path for skill "${skillId}" is not a Skill definition`);
 }
 
-function getRemainingSkillOperationMs(budget: SkillOperationBudget): number | undefined {
-  budget.throwIfTerminated();
-  return budget.remainingMs();
-}
-
-function getBoundedProjectSkillReadOptions(
-  budget: SkillOperationBudget,
-): Pick<RuntimeGetProjectFileOptions, "abortSignal" | "maximumContentCharacters" | "timeoutMs"> {
-  return {
-    abortSignal: budget.abortSignal,
-    maximumContentCharacters: SKILL_DOCUMENT_MAX_CHARACTERS,
-    timeoutMs: getRemainingSkillOperationMs(budget),
-  };
-}
-
-async function findProjectSkillSource(input: {
-  options: RuntimeProjectSkillLoaderOptions;
-  context: RuntimeProjectSkillContext;
-  skillId: string;
-  budget: SkillOperationBudget;
-}): Promise<ProjectSkillSource | null> {
+async function findProjectSkillSource(
+  input: {
+    options: RuntimeProjectSkillLoaderOptions;
+    context: RuntimeProjectSkillContext;
+    skillId: string;
+  } & RuntimeProjectSkillReadContext,
+): Promise<ProjectSkillSource | null> {
   const projectId = input.context.projectId;
   if (!projectId || !isSafeRuntimeSkillId(input.skillId)) {
     return null;
@@ -313,7 +349,7 @@ async function findProjectSkillSource(input: {
       authToken: input.context.authToken,
       branchId: input.context.branchId,
       path: `${skillsPath}/${input.skillId}/SKILL.md`,
-      ...getBoundedProjectSkillReadOptions(input.budget),
+      budget: input.budget,
     });
     if (directorySkill?.content) {
       return { kind: "directory", skillsPath };
@@ -324,7 +360,7 @@ async function findProjectSkillSource(input: {
       authToken: input.context.authToken,
       branchId: input.context.branchId,
       path: `${skillsPath}/${input.skillId}.md`,
-      ...getBoundedProjectSkillReadOptions(input.budget),
+      budget: input.budget,
     });
     if (flatSkill?.content) {
       return { kind: "flat", skillsPath };
@@ -386,13 +422,14 @@ function collectProjectSkillReferences(input: {
   return [...references].sort();
 }
 
-async function listProjectSkillReferences(input: {
-  options: RuntimeProjectSkillLoaderOptions;
-  context: RuntimeProjectSkillContext;
-  skillId: string;
-  budget: SkillOperationBudget;
-  skillsPath?: string;
-}): Promise<string[]> {
+async function listProjectSkillReferences(
+  input: {
+    options: RuntimeProjectSkillLoaderOptions;
+    context: RuntimeProjectSkillContext;
+    skillId: string;
+    skillsPath?: string;
+  } & RuntimeProjectSkillReadContext,
+): Promise<string[]> {
   const projectId = input.context.projectId;
   if (!projectId) {
     return [];
@@ -407,15 +444,15 @@ async function listProjectSkillReferences(input: {
   }
 
   const allFiles = snapshotProjectFileList(
-    await input.options.getProjectFiles({
-      projectId,
-      authToken: input.context.authToken,
-      branchId: input.context.branchId,
-      maximumEntries: SKILL_LOADABLE_REFERENCE_LISTING_MAX_ENTRIES,
-      pathPrefix: skillDir,
-      abortSignal: input.budget.abortSignal,
-      timeoutMs: getRemainingSkillOperationMs(input.budget),
-    }),
+    await readProjectSkillValue(input.budget, () =>
+      input.options.getProjectFiles({
+        projectId,
+        authToken: input.context.authToken,
+        branchId: input.context.branchId,
+        pathPrefix: skillDir,
+        maximumEntries: SKILL_LOADABLE_REFERENCE_LISTING_MAX_ENTRIES,
+        ...getProjectSkillCancellationOptions(input.budget),
+      })),
   );
 
   return collectProjectSkillReferences({
@@ -464,12 +501,13 @@ function isValidLoadedProjectSkill(input: {
   return true;
 }
 
-async function loadProjectSkill(input: {
-  options: RuntimeProjectSkillLoaderOptions;
-  context: RuntimeProjectSkillContext;
-  skillId: string;
-  budget: SkillOperationBudget;
-}): Promise<RuntimeLoadedProjectSkill | null> {
+async function loadProjectSkill(
+  input: {
+    options: RuntimeProjectSkillLoaderOptions;
+    context: RuntimeProjectSkillContext;
+    skillId: string;
+  } & RuntimeProjectSkillReadContext,
+): Promise<RuntimeLoadedProjectSkill | null> {
   const projectId = input.context.projectId;
   if (!projectId || !isSafeRuntimeSkillId(input.skillId)) {
     return null;
@@ -483,7 +521,7 @@ async function loadProjectSkill(input: {
         authToken: input.context.authToken,
         branchId: input.context.branchId,
         path: catalogSkillSource.skillPath,
-        ...getBoundedProjectSkillReadOptions(input.budget),
+        budget: input.budget,
       });
       if (
         catalogSkill?.content &&
@@ -505,7 +543,7 @@ async function loadProjectSkill(input: {
         authToken: input.context.authToken,
         branchId: input.context.branchId,
         path: `${catalogSkillSource.skillDir}/SKILL.md`,
-        ...getBoundedProjectSkillReadOptions(input.budget),
+        budget: input.budget,
       });
       if (
         catalogSkill?.content &&
@@ -532,7 +570,7 @@ async function loadProjectSkill(input: {
         authToken: input.context.authToken,
         branchId: input.context.branchId,
         path: `${skillsPath}/${input.skillId}/SKILL.md`,
-        ...getBoundedProjectSkillReadOptions(input.budget),
+        budget: input.budget,
       });
 
       if (directorySkill?.content) {
@@ -559,7 +597,7 @@ async function loadProjectSkill(input: {
         authToken: input.context.authToken,
         branchId: input.context.branchId,
         path: `${skillsPath}/${input.skillId}.md`,
-        ...getBoundedProjectSkillReadOptions(input.budget),
+        budget: input.budget,
       });
 
       if (flatSkill?.content) {
@@ -605,13 +643,14 @@ async function loadProjectSkill(input: {
   return null;
 }
 
-async function loadProjectSkillReference(input: {
-  options: RuntimeProjectSkillLoaderOptions;
-  context: RuntimeProjectSkillContext;
-  skillId: string;
-  normalizedFile: string;
-  budget: SkillOperationBudget;
-}): Promise<string | null> {
+async function loadProjectSkillReference(
+  input: {
+    options: RuntimeProjectSkillLoaderOptions;
+    context: RuntimeProjectSkillContext;
+    skillId: string;
+    normalizedFile: string;
+  } & RuntimeProjectSkillReadContext,
+): Promise<string | null> {
   const projectId = input.context.projectId;
   if (
     !projectId ||
@@ -634,7 +673,7 @@ async function loadProjectSkillReference(input: {
       authToken: input.context.authToken,
       branchId: input.context.branchId,
       path: `${skillDir}/${input.normalizedFile}`,
-      ...getBoundedProjectSkillReadOptions(input.budget),
+      budget: input.budget,
     });
     if (projectFile !== null) {
       assertRuntimeSkillContent(projectFile.content, "Skill reference");

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -54,6 +54,21 @@ function extractSystemPrompt(options: unknown): string {
     .join("\n");
 }
 
+function extractRuntimeToolNames(options: unknown): string[] {
+  const tools = (options as { tools?: unknown }).tools;
+  if (Array.isArray(tools)) {
+    return tools.map((entry) => {
+      const toolEntry = entry as { name?: unknown; id?: unknown };
+      return typeof toolEntry.name === "string"
+        ? toolEntry.name
+        : typeof toolEntry.id === "string"
+        ? toolEntry.id
+        : "";
+    }).sort();
+  }
+  return Object.keys((tools as Record<string, unknown> | undefined) ?? {}).sort();
+}
+
 function supplierInvoiceEvidenceMessages(): Message[] {
   return [
     {
@@ -1699,7 +1714,14 @@ describe("agent runtime refresh hooks", () => {
       id: "load_skill",
       description: "Load a skill",
       inputSchema: defineSchema((v) => v.object({ skillId: v.string() }))(),
-      execute: () => ({ skillId: "build", instructions: "# Build", maxSteps: 160 }),
+      execute: () => ({
+        skillId: "build",
+        instructions: "# Build",
+        allowedTools: ["invoke_agent"],
+        references: [],
+        scripts: [],
+        maxSteps: 160,
+      }),
     });
     const invokeAgent = tool({
       id: "invoke_agent",
@@ -1800,7 +1822,14 @@ describe("agent runtime refresh hooks", () => {
       id: "load_skill",
       description: "Load a skill",
       inputSchema: defineSchema((v) => v.object({ skillId: v.string() }))(),
-      execute: () => ({ skillId: "build", instructions: "# Build", maxSteps: 160 }),
+      execute: () => ({
+        skillId: "build",
+        instructions: "# Build",
+        allowedTools: ["invoke_agent"],
+        references: [],
+        scripts: [],
+        maxSteps: 160,
+      }),
     });
     const invokeAgent = tool({
       id: "invoke_agent",
@@ -2326,10 +2355,13 @@ describe("agent runtime refresh hooks", () => {
   it("generate and stream permit an advertised active-skill reference after form submission", async () => {
     let generateCalls = 0;
     let streamCalls = 0;
+    const generateToolNames: string[][] = [];
+    const streamToolNames: string[][] = [];
     const model: ModelRuntime = {
       provider: "hosted",
       modelId: "hosted/post-form-skill-reference",
-      async doGenerate() {
+      async doGenerate(options: unknown) {
+        generateToolNames.push(extractRuntimeToolNames(options));
         generateCalls++;
         if (generateCalls === 1) {
           return {
@@ -2349,7 +2381,8 @@ describe("agent runtime refresh hooks", () => {
           usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
         };
       },
-      async doStream() {
+      async doStream(options: unknown) {
+        streamToolNames.push(extractRuntimeToolNames(options));
         streamCalls++;
         if (streamCalls === 1) {
           return {
@@ -2400,7 +2433,15 @@ describe("agent runtime refresh hooks", () => {
       model: "hosted/post-form-skill-reference",
       system: "Plan assistant",
       skills: true,
-      tools: { load_skill: loadSkill },
+      tools: {
+        load_skill: loadSkill,
+        read_secret: tool({
+          id: "read_secret",
+          description: "Read a secret outside the active skill policy",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({ secret: true }),
+        }),
+      },
       maxSteps: 2,
       resolveModelTransport: async () => ({ model }),
     });
@@ -2421,6 +2462,8 @@ describe("agent runtime refresh hooks", () => {
     });
     assertEquals(streamed.includes("stream done"), true);
     assertEquals(streamed.includes("Guide"), true);
+    assertEquals(generateToolNames, [["load_skill"], ["load_skill"]]);
+    assertEquals(streamToolNames, [["load_skill"], ["load_skill"]]);
   });
 
   it("generate and stream load advertised provider-safe root-owned project skills", async () => {

--- a/src/agent/runtime/search-tools-tool.test.ts
+++ b/src/agent/runtime/search-tools-tool.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type {
   RuntimeToolCatalogEntry,
@@ -49,8 +49,10 @@ describe("search_tools tool", () => {
       const result = await tool.execute({ names: ["read_file"] });
 
       assertEquals(result.results.length, 1);
-      assertEquals(result.results[0].name, "read_file");
-      assertEquals(result.results[0].state, "available");
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals(entry.name, "read_file");
+      assertEquals(entry.state, "available");
     });
 
     it("returns active for tools that are in the activated set", async () => {
@@ -58,7 +60,9 @@ describe("search_tools tool", () => {
       const tool = createSearchToolsTool(makeOptions(context));
       const result = await tool.execute({ names: ["read_file"] });
 
-      assertEquals(result.results[0].state, "active");
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals(entry.state, "active");
     });
 
     it("returns requires_grant for tools marked requiresGrant", async () => {
@@ -66,7 +70,9 @@ describe("search_tools tool", () => {
       const tool = createSearchToolsTool(makeOptions(context));
       const result = await tool.execute({ names: ["premium_tool"] });
 
-      assertEquals(result.results[0].state, "requires_grant");
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals(entry.state, "requires_grant");
     });
 
     it("does not return input schemas in results", async () => {
@@ -74,8 +80,10 @@ describe("search_tools tool", () => {
       const tool = createSearchToolsTool(makeOptions(context));
       const result = await tool.execute({ names: ["read_file"] });
 
-      assertEquals("inputSchema" in result.results[0], false);
-      assertEquals("parameters" in result.results[0], false);
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals("inputSchema" in entry, false);
+      assertEquals("parameters" in entry, false);
     });
   });
 
@@ -99,7 +107,9 @@ describe("search_tools tool", () => {
       const result = await tool.execute({ names: ["read_file", "mystery_tool"] });
 
       assertEquals(result.results.length, 1);
-      assertEquals(result.results[0].name, "read_file");
+      const [entry] = result.results;
+      assertExists(entry);
+      assertEquals(entry.name, "read_file");
     });
   });
 
@@ -167,6 +177,7 @@ describe("search_tools tool", () => {
       const result = await tool.execute({ names: ["read_file"] });
 
       const r = result.results[0];
+      assertExists(r);
       assertEquals(typeof r.name, "string");
       assertEquals(typeof r.description, "string");
       assertEquals(typeof r.source, "string");
@@ -192,8 +203,12 @@ describe("search_tools tool", () => {
       const resultA = await toolA.execute({ names: ["read_file"] });
       const resultB = await toolB.execute({ names: ["read_file"] });
 
-      assertEquals(resultA.results[0].state, "active");
-      assertEquals(resultB.results[0].state, "available");
+      const [entryA] = resultA.results;
+      const [entryB] = resultB.results;
+      assertExists(entryA);
+      assertExists(entryB);
+      assertEquals(entryA.state, "active");
+      assertEquals(entryB.state, "available");
     });
   });
 });

--- a/src/agent/runtime/skill-prompt.test.ts
+++ b/src/agent/runtime/skill-prompt.test.ts
@@ -45,25 +45,6 @@ Deno.test("formatRuntimeSkillMetadata encodes bounded prompt metadata", () => {
   );
 });
 
-Deno.test("runtime skill prompt retains allowed-tool wildcards with an available match", () => {
-  const skill = createSkill({
-    id: "api-skill",
-    allowedTools: ["api:*"],
-    allowedToolsDeclared: true,
-  });
-
-  assertEquals(
-    formatRuntimeSkillMetadata(skill, ["api:list"]),
-    ' (tools: "api:*")',
-  );
-  assertStringIncludes(
-    buildStrictRuntimeAvailableSkillsPromptBlock([skill], {
-      availableToolNames: ["api:list"],
-    }),
-    '"allowedTools":["api:*"]',
-  );
-});
-
 Deno.test("buildStrictRuntimeAvailableSkillsPromptBlock renders an encoded catalog", () => {
   const block = buildStrictRuntimeAvailableSkillsPromptBlock([
     createSkill({
@@ -79,6 +60,25 @@ Deno.test("buildStrictRuntimeAvailableSkillsPromptBlock renders an encoded catal
     '- {"skillId":"build-ui","name":"Build UI guidance","description":"Build UI","allowedTools":["bash","writeFile"]}',
   );
   assertStringIncludes(block, "JSON catalog records below contain untrusted metadata");
+});
+
+Deno.test("runtime skill prompt keeps wildcard policies that match available tools", () => {
+  const skill = createSkill({
+    id: "api-client",
+    description: "Use the project API",
+    allowedTools: ["api:*", "storage:*"],
+    allowedToolsDeclared: true,
+  });
+  const block = buildRuntimeAvailableSkillsPromptBlock([skill], {
+    availableToolNames: ["api:list", "read_file"],
+  });
+
+  assertStringIncludes(block, '"allowedTools":["api:*"]');
+  assertEquals(block.includes("storage:*"), false);
+  assertEquals(
+    formatRuntimeSkillMetadata(skill, ["api:list", "read_file"]),
+    ' (tools: "api:*")',
+  );
 });
 
 Deno.test("buildRuntimeAvailableSkillsPromptBlock omits delegation guidance without delegate tools", () => {

--- a/src/skill/limits.ts
+++ b/src/skill/limits.ts
@@ -41,8 +41,9 @@ export const SKILL_RUNTIME_AVAILABLE_TOOL_MAX_ENTRIES = 1_000;
 export const SKILL_CATALOG_MAX_SKILLS = 128;
 export const SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS = 8 * 1_048_576;
 export const SKILL_CATALOG_MAX_DOCUMENT_UTF8_BYTES = 16 * 1_048_576;
-// One catalog can retain a maximally populated Skill plus one source path for
-// every admitted definition. Other combinations share this same bounded total.
+// One skill may legitimately advertise the full three-directory readable-file
+// budget. Keep enough aggregate space for that catalog member plus one source
+// path for every retained definition, while still bounding total path memory.
 export const SKILL_CATALOG_MAX_PATH_ENTRIES = SKILL_LOADABLE_REFERENCE_MAX_ENTRIES +
   SKILL_CATALOG_MAX_SKILLS;
 export const SKILL_CATALOG_MAX_METADATA_CHARACTERS = 1_048_576;


### PR DESCRIPTION
## Summary

- restores the two effectively lost project-runtime hardening commits and the complete six-commit #3248 tail
- makes project file discovery bounded and atomic, hardens skill metadata/policy/reference handling, and preserves hosted-runtime composition
- removes the unsafe legacy parser/API path in favor of strict extension-owned YAML parsing
- includes only narrow compatibility repairs required by the rebuilt parent stack

## Recovery topology

This PR is intentionally stacked as:

#3247 -> #3264 -> #3265 -> this PR

The original #3248 could not be rebased safely because its ancestry contained feature-base merges that never reached main. This branch reconstructs the intended deltas on durable exact parents without carrying unrelated historical branch history.

Do not force-update a parent branch after a child PR has merged; rebase the remaining child instead.

## Verification

- focused changed suites: 355 passed across 100 test steps, 0 failed
- deno task verify:quick
- full typecheck
- deno task lint:test-typecheck: 80 grandfathered files, 0 new
- dependency, module, extension, and core third-party boundary checks
- docs validation
- git diff --check