### PR TITLE
fix(agent): surface required model context append timeouts

### DIFF
--- a/src/agent/conversation/durable-contracts.ts
+++ b/src/agent/conversation/durable-contracts.ts
@@ -261,6 +261,7 @@ export interface ConversationRunEventQueueController {
       consecutiveFailures: number;
       disabled: false;
       errorMessage: string;
+      retryCause?: "timeout";
     }
   >;
   getSnapshot(): {

--- a/src/agent/conversation/durable.test.ts
+++ b/src/agent/conversation/durable.test.ts
@@ -681,6 +681,37 @@ describe("agent/durable", () => {
     await assertion;
   });
 
+  it("keeps timeout origin when the caller aborts after the deadline", async () => {
+    using time = new FakeTime();
+    const caller = new AbortController();
+    let rejectRequest: (() => void) | undefined;
+    globalThis.fetch =
+      ((_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) throw new Error("expected request abort signal");
+          rejectRequest = () => reject(signal.reason);
+        })) as typeof fetch;
+
+    const assertion = assertRejects(
+      () =>
+        getConversationRun({
+          authToken: AUTH_TOKEN,
+          apiUrl: API_URL,
+          conversationId: CONVERSATION_ID,
+          runId: "run_lookup_timeout_race",
+          abortSignal: caller.signal,
+        }),
+      Error,
+      "Read conversation durable run projection timed out after 15000ms",
+    );
+
+    await time.tickAsync(15_000);
+    caller.abort(new DOMException("Caller aborted too late", "AbortError"));
+    rejectRequest?.();
+    await assertion;
+  });
+
   it("fails closed without projection resync on ambiguous durable-ID replay", async () => {
     const [event] = await createModelCallContextRunEvents({
       messages: [{ role: "system", content: "A then B" }],

--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -1,5 +1,5 @@
 import type { Schema } from "#veryfront/extensions/schema/index.ts";
-import { NETWORK_ERROR, TIMEOUT_ERROR } from "#veryfront/errors";
+import { isVeryfrontError, NETWORK_ERROR, TIMEOUT_ERROR } from "#veryfront/errors";
 import {
   AppendConversationRunEventsResponseSchema,
   CompleteConversationRunResponseSchema,
@@ -77,13 +77,16 @@ const AGENT_RUN_API_TIMEOUT_MS = 15_000;
 
 function createTimedAbortSignal(timeoutMs: number, abortSignal?: AbortSignal) {
   const controller = new AbortController();
-  let abortedByCaller = false;
+  let abortOrigin: "caller" | "timeout" | null = null;
   const timeout = setTimeout(() => {
+    if (abortOrigin) return;
+    abortOrigin = "timeout";
     controller.abort(new DOMException("Conversation run API request timed out", "TimeoutError"));
   }, timeoutMs);
 
   const onAbort = () => {
-    abortedByCaller = true;
+    if (abortOrigin) return;
+    abortOrigin = "caller";
     controller.abort(abortSignal?.reason);
   };
 
@@ -95,7 +98,7 @@ function createTimedAbortSignal(timeoutMs: number, abortSignal?: AbortSignal) {
 
   return {
     signal: controller.signal,
-    wasAbortedByCaller: () => abortedByCaller,
+    wasAbortedByCaller: () => abortOrigin === "caller",
     cleanup: () => {
       clearTimeout(timeout);
       abortSignal?.removeEventListener("abort", onAbort);
@@ -288,6 +291,7 @@ export async function recoverConversationRunAppendFailure(input: {
     | "payload_too_large"
     | "auth_rejected";
   errorMessage?: string;
+  retryCause?: "timeout";
   run?: ConversationRunProjection;
 }> {
   const cursorRecovery = await recoverConversationRunCursorMismatch({
@@ -360,6 +364,9 @@ export async function recoverConversationRunAppendFailure(input: {
     latestEventId: cursorRecovery.latestEventId,
     latestExternalEventSequence: cursorRecovery.latestExternalEventSequence,
     errorMessage: input.error instanceof Error ? input.error.message : String(input.error),
+    ...(isVeryfrontError(input.error) && input.error.slug === "timeout-error"
+      ? { retryCause: "timeout" as const }
+      : {}),
     ...(cursorRecovery.run ? { run: cursorRecovery.run } : {}),
   };
 }
@@ -407,6 +414,7 @@ export async function recoverConversationRunAppendExecution(input: {
     pendingEvents: unknown[];
     consecutiveFailures: number;
     errorMessage: string;
+    retryCause?: "timeout";
   }
 > {
   const recovered = await recoverConversationRunAppendFailure({
@@ -449,6 +457,7 @@ export async function recoverConversationRunAppendExecution(input: {
     pendingEvents: [...input.remainingEvents, ...input.pendingEvents],
     consecutiveFailures: input.consecutiveFailures + 1,
     errorMessage: recovered.errorMessage ?? "Conversation run append failed",
+    ...(recovered.retryCause ? { retryCause: recovered.retryCause } : {}),
   };
 }
 
@@ -521,6 +530,7 @@ export async function flushConversationRunEventBatches(input: {
     pendingEvents: unknown[];
     consecutiveFailures: number;
     errorMessage?: string;
+    retryCause?: "timeout";
   }
   | {
     outcome: "stopped";
@@ -602,7 +612,10 @@ export async function flushConversationRunEventBatches(input: {
         pendingEvents: recovered.pendingEvents,
         consecutiveFailures: recovered.consecutiveFailures,
         ...(recovered.outcome === "retry_scheduled"
-          ? { errorMessage: recovered.errorMessage }
+          ? {
+            errorMessage: recovered.errorMessage,
+            ...(recovered.retryCause ? { retryCause: recovered.retryCause } : {}),
+          }
           : {}),
       };
     }
@@ -655,6 +668,7 @@ export async function flushConversationRunEventQueue(input: {
     pendingEvents: unknown[];
     consecutiveFailures: number;
     errorMessage: string;
+    retryCause?: "timeout";
   }
 > {
   let latestEventId = input.latestEventId;
@@ -716,6 +730,7 @@ export async function flushConversationRunEventQueue(input: {
       pendingEvents: flushed.pendingEvents,
       consecutiveFailures: flushed.consecutiveFailures,
       errorMessage: flushed.errorMessage ?? "Conversation run append failed",
+      ...(flushed.retryCause ? { retryCause: flushed.retryCause } : {}),
     };
   }
 
@@ -854,6 +869,7 @@ export function createConversationRunEventQueueController(input: {
       consecutiveFailures,
       disabled: false as const,
       errorMessage: flushed.errorMessage,
+      ...(flushed.retryCause ? { retryCause: flushed.retryCause } : {}),
     };
   }
 

--- a/src/agent/conversation/run-chunk-mirror.ts
+++ b/src/agent/conversation/run-chunk-mirror.ts
@@ -26,7 +26,10 @@ const DEFAULT_HOSTED_CHUNK_MIRROR_HIGH_BACKLOG_EVENT_COUNT = 500;
 export interface ConversationRunChunkMirror {
   handleChunk(chunk: ChatUiMessageChunk<ChatMessageMetadata>): Promise<void>;
   appendEvents(events: ConversationRunEvent[]): Promise<void>;
-  flush(options?: { abortSignal?: AbortSignal }): Promise<ConversationRunMirrorSnapshot>;
+  flush(options?: {
+    abortSignal?: AbortSignal;
+    throwOnTimeoutRetry?: boolean;
+  }): Promise<ConversationRunMirrorSnapshot>;
   getSnapshot(): ReturnType<ConversationRunMirror["getSnapshot"]>;
   dispose(): void;
 }

--- a/src/agent/conversation/run-mirror.ts
+++ b/src/agent/conversation/run-mirror.ts
@@ -1,4 +1,5 @@
 import { type ConversationRunEventQueueController } from "./durable.ts";
+import { TIMEOUT_ERROR } from "#veryfront/errors";
 import { agentLogger } from "#veryfront/utils";
 
 export type ConversationRunMirrorDisableReason =
@@ -58,7 +59,10 @@ export interface ConversationRunMirrorHighBacklogState {
 /** Public API contract for conversation run mirror. */
 export interface ConversationRunMirror {
   enqueue(events: unknown[]): void;
-  flush(options?: { abortSignal?: AbortSignal }): Promise<ConversationRunMirrorSnapshot>;
+  flush(options?: {
+    abortSignal?: AbortSignal;
+    throwOnTimeoutRetry?: boolean;
+  }): Promise<ConversationRunMirrorSnapshot>;
   getSnapshot(): ConversationRunMirrorSnapshot;
   dispose(): void;
 }
@@ -108,6 +112,7 @@ export function createConversationRunMirror(input: {
   // while its last events are still queued.
   let escapedFlushFailures = 0;
   let escapedFlushError: { error: unknown } | null = null;
+  let retryCause: "timeout" | null = null;
   let disposed = false;
   const lifecycleAbortController = new AbortController();
 
@@ -210,10 +215,12 @@ export function createConversationRunMirror(input: {
     escapedFlushError = null;
 
     if (flushed.outcome === "idle" || flushed.outcome === "flushed") {
+      retryCause = null;
       return;
     }
 
     if (flushed.outcome === "stopped") {
+      retryCause = null;
       clearFlushTimer();
       clearRetryTimer();
       await input.onStopped?.(flushed);
@@ -224,9 +231,17 @@ export function createConversationRunMirror(input: {
       return;
     }
 
+    retryCause = flushed.retryCause ?? null;
+
     const retryDelayMs = getRetryDelayMs(flushed.consecutiveFailures);
     await input.onRetryScheduled?.({
-      ...flushed,
+      outcome: "retry_scheduled",
+      latestEventId: flushed.latestEventId,
+      latestExternalEventSequence: flushed.latestExternalEventSequence,
+      pendingEventCount: flushed.pendingEventCount,
+      consecutiveFailures: flushed.consecutiveFailures,
+      disabled: false,
+      errorMessage: flushed.errorMessage,
       retryDelayMs,
     });
     scheduleRetry();
@@ -322,6 +337,12 @@ export function createConversationRunMirror(input: {
         // to complete the run"; a flush error that escaped the controller
         // must reject here instead of silently leaving events queued.
         throw escapedFlushError.error;
+      }
+
+      if (options?.throwOnTimeoutRetry && retryCause === "timeout") {
+        throw TIMEOUT_ERROR.create({
+          detail: "Append conversation run events timed out",
+        });
       }
 
       return getSnapshot();

--- a/src/agent/hosted/model-call-context-run-event-recorder.test.ts
+++ b/src/agent/hosted/model-call-context-run-event-recorder.test.ts
@@ -20,6 +20,8 @@ import { getActiveModelCallRecorder } from "../../runtime/model-call-recorder-co
 import { runWithModelCallRecorder } from "../../runtime/model-call-recorder-context.ts";
 import { streamText } from "../../runtime/runtime-bridge.ts";
 import { collectAsync, createStreamModel } from "../../runtime/runtime-bridge.test-helpers.ts";
+import { TIMEOUT_ERROR } from "#veryfront/errors";
+import { FakeTime } from "#std/testing/time";
 
 const encoder = new TextEncoder();
 const originalFetch = globalThis.fetch;
@@ -452,6 +454,63 @@ describe("agent/hosted/model-call-context-run-event-recorder", () => {
       "timed out",
     );
     assertEquals(target.isDisposed(), true);
+    assertEquals(metrics.barrierOutcomes, ["timeout"]);
+  });
+
+  it("classifies a durable append request timeout as a timeout barrier", async () => {
+    const target = mirror({
+      flush: () =>
+        Promise.reject(
+          TIMEOUT_ERROR.create({ detail: "Append conversation run events timed out" }),
+        ),
+    });
+    const metrics = metricsSink();
+    const recorder = createModelCallContextRunEventRecorder({
+      mirror: target.result,
+      metrics: metrics.result,
+    });
+
+    await assertRejects(
+      () => Promise.resolve(recorder({ messages: [{ role: "system", content: "timeout" }] })),
+      Error,
+      "Append conversation run events timed out",
+    );
+    assertEquals(target.isDisposed(), true);
+    assertEquals(metrics.writerOutcomes, []);
+    assertEquals(metrics.barrierOutcomes, ["timeout"]);
+  });
+
+  it("classifies a production mirror append timeout as a timeout barrier", async () => {
+    using time = new FakeTime();
+    globalThis.fetch =
+      ((_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) throw new Error("expected request abort signal");
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        })) as typeof fetch;
+    const target = productionMirror({ immediateFlushEventCount: 99 });
+    const metrics = metricsSink();
+    const recorder = createModelCallContextRunEventRecorder({
+      mirror: target,
+      timeoutMs: 20_000,
+      metrics: metrics.result,
+    });
+
+    const recording = Promise.resolve(
+      recorder({ messages: [{ role: "system", content: "timeout" }] }),
+    );
+    await time.tickAsync(0);
+    const assertion = assertRejects(
+      () => recording,
+      Error,
+      "Append conversation run events timed out",
+    );
+    await time.tickAsync(15_000);
+    await assertion;
+
+    assertEquals(target.getSnapshot().disabled, true);
+    assertEquals(metrics.writerOutcomes, []);
     assertEquals(metrics.barrierOutcomes, ["timeout"]);
   });
 

--- a/src/agent/hosted/model-call-context-run-event-recorder.ts
+++ b/src/agent/hosted/model-call-context-run-event-recorder.ts
@@ -22,6 +22,7 @@ import type {
   ModelCallContextBarrierOutcome,
   ModelCallContextWriterOutcome,
 } from "../../observability/metrics/types.ts";
+import { isVeryfrontError } from "#veryfront/errors";
 
 /** Maximum time a required model-call context append may block dispatch. */
 export const DEFAULT_MODEL_CALL_CONTEXT_PERSISTENCE_TIMEOUT_MS = 30_000;
@@ -337,7 +338,10 @@ export function createModelCallContextRunEventRecorder(input: {
           partCount = events.length;
           await input.mirror.appendEvents(events);
           abortSignal.throwIfAborted();
-          const resolvedSnapshot = await input.mirror.flush({ abortSignal });
+          const resolvedSnapshot = await input.mirror.flush({
+            abortSignal,
+            throwOnTimeoutRetry: true,
+          });
           assertQuiescent(resolvedSnapshot, "after");
           assertQuiescent(input.mirror.getSnapshot(), "after");
         },
@@ -347,7 +351,9 @@ export function createModelCallContextRunEventRecorder(input: {
       if (input.abortSignal?.aborted || error instanceof DOMException) {
         barrierOutcome = "aborted";
       } else if (
-        error instanceof ModelCallContextPersistenceError && error.message.includes("timed out")
+        (error instanceof ModelCallContextPersistenceError &&
+          error.message.includes("timed out")) ||
+        (isVeryfrontError(error) && error.slug === "timeout-error")
       ) {
         barrierOutcome = "timeout";
       } else {


### PR DESCRIPTION
## Summary

- preserve the original timeout source even when a caller abort arrives after the request deadline
- carry a bounded timeout retry cause through durable append recovery without changing ordinary mirror retry behavior
- make required model-call context persistence surface typed append timeouts and remain fail-closed before provider dispatch
- cover the deadline/abort race, typed timeout telemetry, production mirror timeout path, and terminal disposal behavior

## Replacement

This supersedes #3225.

#3260 merged the original model-call-context feature, but #3225 received a verified seven-file timeout tail afterward. Because the old branch retained mixed Kentaro/Koji commit ancestry, this PR reconstructs only that effective tail on current main as one Koji-authored commit so Kentaro can provide the required code-owner approval. Do not close #3225 until this replacement merges.

The resulting seven file hashes and stable patch ID match #3225 head 5e7068a5c991f7ee9a0f98f25211c3b4469b25ab exactly.

## Verification

- deno test -A src/agent/conversation/durable.test.ts src/agent/hosted/model-call-context-run-event-recorder.test.ts (2 suites, 66 steps)
- deno task verify:quick
- git diff --check
- all prior exact-head #3225 CI checks were green and all review threads were resolved