### PR TITLE
Scope durable child run event writers

### DIFF
--- a/src/agent/conversation/root-run-lifecycle.test.ts
+++ b/src/agent/conversation/root-run-lifecycle.test.ts
@@ -5,6 +5,10 @@ import {
   prepareConversationRootRunLifecycle,
   prepareHostedConversationRootRunContext,
 } from "./root-run-lifecycle.ts";
+import {
+  createHostedRunEventWriterCapability,
+  runWithHostedRunEventWriterCapability,
+} from "../hosted/child-run-event-writer-token.ts";
 
 describe("agent/conversation-root-run-lifecycle", () => {
   it("starts a run and derives root-run lineage plus a mirror in one helper", async () => {
@@ -110,32 +114,39 @@ describe("agent/conversation-root-run-lifecycle", () => {
     }) as typeof fetch;
 
     try {
-      const context = await prepareHostedConversationRootRunContext(
-        {
-          authToken: "user-api-token",
-          runEventAppendToken: "run-event-service-token",
+      const context = await runWithHostedRunEventWriterCapability(
+        createHostedRunEventWriterCapability({
           apiUrl: "https://api.example.test",
-          conversationId,
-          projectId: "project-1",
-          branchId: "branch-1",
-          agentId: "agent-1",
-          messages: [],
-          providedRun: {
-            runId: "run-1",
-            messageId: "msg-1",
-            latestEventId: 5,
-            latestExternalEventSequence: 6,
-          },
-          persistLatestUserMessageBeforeRun: true,
-          parentRunId: "parent-run",
-          parentMessageId: "parent-message",
-          instrumentation: {
-            debug: (message) => {
-              debugMessages.push(message);
+          runId: "run-1",
+          runEventAppendToken: "run-event-service-token",
+        }),
+        () =>
+          prepareHostedConversationRootRunContext(
+            {
+              authToken: "user-api-token",
+              apiUrl: "https://api.example.test",
+              conversationId,
+              projectId: "project-1",
+              branchId: "branch-1",
+              agentId: "agent-1",
+              messages: [],
+              providedRun: {
+                runId: "run-1",
+                messageId: "msg-1",
+                latestEventId: 5,
+                latestExternalEventSequence: 6,
+              },
+              persistLatestUserMessageBeforeRun: true,
+              parentRunId: "parent-run",
+              parentMessageId: "parent-message",
+              instrumentation: {
+                debug: (message) => {
+                  debugMessages.push(message);
+                },
+              },
             },
-          },
-        },
-        { abortSignal: new AbortController().signal },
+            { abortSignal: new AbortController().signal },
+          ),
       );
 
       try {

--- a/src/agent/conversation/root-run-lifecycle.ts
+++ b/src/agent/conversation/root-run-lifecycle.ts
@@ -13,6 +13,10 @@ import {
 import { type ConversationRunEvent } from "./run-events.ts";
 import type { ConversationRunProjection } from "./durable.ts";
 import type { ChatUiMessage } from "#veryfront/chat/types.ts";
+import {
+  createHostedConversationRunChunkMirrorFromCapability,
+  getActiveHostedRunEventWriterCapability,
+} from "../hosted/child-run-event-writer-token.ts";
 
 /** Public API contract for conversation root run lifecycle. */
 export interface ConversationRootRunLifecycle<TMirror> extends ConversationRootRunContext {
@@ -76,8 +80,6 @@ export interface HostedConversationRootRunContext {
 /** Input payload for prepare hosted conversation root run context. */
 export interface PrepareHostedConversationRootRunContextInput {
   authToken: string;
-  /** Exact-run service credential used only for durable event appends. */
-  runEventAppendToken?: string;
   apiUrl: string;
   conversationId?: string;
   projectId?: string | null;
@@ -124,7 +126,7 @@ export async function prepareHostedConversationRootRunContext(
   options: { abortSignal: AbortSignal },
 ): Promise<HostedConversationRootRunContext> {
   let durableRunMirror: ConversationRunChunkMirror | null = null;
-  const runEventAppendToken = input.runEventAppendToken;
+  const runEventWriterCapability = getActiveHostedRunEventWriterCapability();
   const startConversationRootRun = createConversationRootRunStartAdapter({
     authToken: input.authToken,
     apiUrl: input.apiUrl,
@@ -164,14 +166,20 @@ export async function prepareHostedConversationRootRunContext(
         await durableRunMirror.appendEvents(events);
       },
       createMirror: (run) => {
-        durableRunMirror = createHostedConversationRunChunkMirror({
-          authToken: runEventAppendToken ?? input.authToken,
+        const mirrorOptions = {
           apiUrl: input.apiUrl,
           conversationId: run.conversationId,
           runId: run.runId,
           latestEventId: run.latestEventId,
           latestExternalEventSequence: run.latestExternalEventSequence,
           instrumentation: input.instrumentation,
+        };
+        durableRunMirror = createHostedConversationRunChunkMirrorFromCapability(
+          runEventWriterCapability,
+          mirrorOptions,
+        ) ?? createHostedConversationRunChunkMirror({
+          ...mirrorOptions,
+          authToken: input.authToken,
         });
 
         return durableRunMirror;
@@ -185,7 +193,7 @@ export async function prepareHostedConversationRootRunContext(
   return {
     durableRootRun: toHostedConversationRootRunState(rootRunLifecycle.run),
     durableRunMirror,
-    privateDurableRunMirror: runEventAppendToken ? durableRunMirror : null,
+    privateDurableRunMirror: runEventWriterCapability ? durableRunMirror : null,
     effectiveParentRunId: rootRunLifecycle.effectiveParentRunId,
     effectiveParentMessageId: rootRunLifecycle.effectiveParentMessageId,
     publishParentRunEvents: rootRunLifecycle.publishParentRunEvents

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -182,6 +182,7 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
   const result = await prepareHostedChatRuntimeCreationOptions({
     request: createParsedHostedChatRequest({
       allowDelegation: false,
+      runEventAppendToken: "root-writer-token",
       model: "requested-model",
       runtimeOverrides: {
         allowedTools: ["load_skill"],
@@ -320,6 +321,7 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
   assertEquals(result.creationOptions, {
     projectId: "project-1",
     authToken: "token-1",
+    runEventAppendToken: "root-writer-token",
     instructions: [
       {
         role: "system",

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -321,7 +321,6 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
   assertEquals(result.creationOptions, {
     projectId: "project-1",
     authToken: "token-1",
-    runEventAppendToken: "root-writer-token",
     instructions: [
       {
         role: "system",
@@ -372,6 +371,7 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
       initialSkills: [skill],
     },
   });
+  assertEquals(JSON.stringify(result.creationOptions).includes("root-writer-token"), false);
 
   await result.creationOptions.publishParentRunEvents?.([{ type: "state_delta" }]);
   assertEquals(parentEvents, [{ type: "state_delta" }]);

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -12,6 +12,7 @@ import {
   prepareHostedChatRuntimeMessages,
 } from "./chat-preparation.ts";
 import { buildVeryfrontCloudRuntimeInstructions } from "./cloud-runtime-system-messages.ts";
+import { registerHostedRunEventWriterToken } from "./child-run-event-writer-token.ts";
 
 const userMessage: ChatUiMessage = {
   id: "user-message-1",
@@ -76,9 +77,10 @@ function pendingResponseUntilAbort(signal: AbortSignal | null | undefined): Prom
 }
 
 function createParsedHostedChatRequest(
-  overrides: Partial<ParsedHostedChatRequest> = {},
+  overrides: Partial<ParsedHostedChatRequest> & { runEventAppendToken?: string } = {},
 ): ParsedHostedChatRequest {
-  return {
+  const { runEventAppendToken, ...requestOverrides } = overrides;
+  const request: ParsedHostedChatRequest = {
     agentId: undefined,
     userId: "user-1",
     authToken: "auth-token",
@@ -100,8 +102,10 @@ function createParsedHostedChatRequest(
     runtimeOverrides: undefined,
     durableRootRun: undefined,
     persistLatestUserMessageBeforeDurableRun: false,
-    ...overrides,
+    ...requestOverrides,
   };
+  if (runEventAppendToken) registerHostedRunEventWriterToken(request, runEventAppendToken);
+  return request;
 }
 
 Deno.test("normalizeParsedHostedChatRequest uses the latest user message as parent message id", () => {
@@ -1056,8 +1060,11 @@ Deno.test("prepareHostedChatExecution compacts oversized context and appends a d
           content: `${input.agentConfig.id}:${input.instructions}`,
         },
       ],
-      createRuntime: (options) =>
-        Promise.resolve({
+      createRuntime: (options) => {
+        assertEquals("runEventAppendToken" in options, false);
+        assertEquals("runEventWriterCapability" in options, false);
+        assertEquals(JSON.stringify(options).includes("run-event-service-token"), false);
+        return Promise.resolve({
           runtimeKind: "framework",
           modelId: options.model ?? "resolved:configured-model",
           cleanup: () => Promise.resolve(),
@@ -1068,7 +1075,8 @@ Deno.test("prepareHostedChatExecution compacts oversized context and appends a d
                 toUIMessageStream: async function* () {},
               }),
           },
-        }),
+        });
+      },
       contextBudget: {
         tokenBudget: 220,
         reserveTokens: 20,

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -104,7 +104,13 @@ function createParsedHostedChatRequest(
     persistLatestUserMessageBeforeDurableRun: false,
     ...requestOverrides,
   };
-  if (runEventAppendToken) registerHostedRunEventWriterToken(request, runEventAppendToken);
+  if (runEventAppendToken) {
+    registerHostedRunEventWriterToken(
+      request,
+      runEventAppendToken,
+      new Request("https://agent.example.test/api/runs"),
+    );
+  }
   return request;
 }
 
@@ -982,7 +988,7 @@ Deno.test("prepareHostedChatExecution preserves allowed remote tool history", as
 Deno.test("prepareHostedChatExecution compacts oversized context and appends a durable event", async () => {
   const originalFetch = globalThis.fetch;
   const appendedBodies: unknown[] = [];
-  globalThis.fetch = (input, init): Promise<Response> => {
+  globalThis.fetch = (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     if (input.toString().endsWith("/events")) {
       appendedBodies.push(JSON.parse(String(init?.body ?? "{}")));
       return Promise.resolve(
@@ -1279,7 +1285,7 @@ Deno.test("prepareHostedChatExecution aborts stalled signed attachment fetch bef
   let cancelStartGuard = () => {};
   let cancelPreparationGuard = () => {};
 
-  globalThis.fetch = (input, init): Promise<Response> => {
+  globalThis.fetch = (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const url = input.toString();
     if (url === "https://api.example.com/projects/project-1/uploads/upload-1/url") {
       return Promise.resolve(

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -395,6 +395,9 @@ export async function prepareHostedChatRuntimeCreationOptions<
       projectId: input.projectId,
       ...(input.request.projectSlug ? { projectSlug: input.request.projectSlug } : {}),
       authToken: input.authToken,
+      ...(input.request.runEventAppendToken
+        ? { runEventAppendToken: input.request.runEventAppendToken }
+        : {}),
       instructions: agentInstructions,
       ...(input.branchId !== undefined ? { branchId: input.branchId } : {}),
       ...(input.runtimeTargetKind !== undefined

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -46,6 +46,10 @@ import {
 } from "../runtime/tool-exposure.ts";
 import type { ConversationRunChunkMirror } from "../conversation/run-chunk-mirror.ts";
 import type { HostedHostToolPolicy } from "./chat-runtime-tool-assembly.ts";
+import {
+  createHostedRunEventWriterCapabilityForRequest,
+  runWithHostedRunEventWriterCapability,
+} from "./child-run-event-writer-token.ts";
 
 /** Request payload for normalized hosted chat. */
 export type NormalizedHostedChatRequest = {
@@ -495,23 +499,29 @@ export async function prepareHostedChatExecution<
   HostedChatExecutionPreparationResult<TRuntimeAgentDefinition, TRuntimeResult>
 > {
   const normalized = normalizeParsedHostedChatRequest(input.request);
-  const rootRunContext = await prepareHostedConversationRootRunContext(
-    {
-      authToken: input.request.authToken,
-      runEventAppendToken: input.request.runEventAppendToken,
+  const rootRunEventWriterCapability = input.request.durableRootRun
+    ? createHostedRunEventWriterCapabilityForRequest(input.request, {
       apiUrl: input.apiUrl.toString(),
-      conversationId: input.request.conversationId,
-      projectId: input.request.projectId,
-      branchId: normalized.effectiveValidatedContext.branchId,
-      agentId: input.agentConfig.id,
-      messages: normalized.effectiveMessages,
-      parentRunId: input.request.parentRunId,
-      parentMessageId: normalized.parentMessageId,
-      providedRun: input.request.durableRootRun,
-      persistLatestUserMessageBeforeRun: input.request.persistLatestUserMessageBeforeDurableRun,
-      ...input.rootRun,
-    },
-    { abortSignal: input.abortSignal },
+      runId: input.request.durableRootRun.runId,
+    })
+    : undefined;
+  const rootRunContext = await runWithHostedRunEventWriterCapability(
+    rootRunEventWriterCapability,
+    () =>
+      prepareHostedConversationRootRunContext({
+        authToken: input.request.authToken,
+        apiUrl: input.apiUrl.toString(),
+        conversationId: input.request.conversationId,
+        projectId: input.request.projectId,
+        branchId: normalized.effectiveValidatedContext.branchId,
+        agentId: input.agentConfig.id,
+        messages: normalized.effectiveMessages,
+        parentRunId: input.request.parentRunId,
+        parentMessageId: normalized.parentMessageId,
+        providedRun: input.request.durableRootRun,
+        persistLatestUserMessageBeforeRun: input.request.persistLatestUserMessageBeforeDurableRun,
+        ...input.rootRun,
+      }, { abortSignal: input.abortSignal }),
   );
   const runtimePreparation = await prepareHostedChatRuntimeCreationOptions({
     request: input.request,
@@ -578,10 +588,14 @@ export async function prepareHostedChatExecution<
       ...budgetedContext.diagnostics,
     });
   }
-  const runtime = await input.createRuntime({
-    ...runtimePreparation.creationOptions,
-    ...(submittedFormInputResult ? { submittedFormInputResult } : {}),
-  });
+  const runtime = await runWithHostedRunEventWriterCapability(
+    rootRunEventWriterCapability,
+    () =>
+      input.createRuntime({
+        ...runtimePreparation.creationOptions,
+        ...(submittedFormInputResult ? { submittedFormInputResult } : {}),
+      }),
+  );
 
   return {
     ...normalized,

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -395,9 +395,6 @@ export async function prepareHostedChatRuntimeCreationOptions<
       projectId: input.projectId,
       ...(input.request.projectSlug ? { projectSlug: input.request.projectSlug } : {}),
       authToken: input.authToken,
-      ...(input.request.runEventAppendToken
-        ? { runEventAppendToken: input.request.runEventAppendToken }
-        : {}),
       instructions: agentInstructions,
       ...(input.branchId !== undefined ? { branchId: input.branchId } : {}),
       ...(input.runtimeTargetKind !== undefined

--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -25,6 +25,7 @@ import {
   verifyHostedRuntimeSourceBinding,
 } from "./runtime-source-binding.ts";
 import { getHostedChatUiToolIdentity } from "./chat-request-tool-part.ts";
+import { registerHostedRunEventWriterToken } from "./child-run-event-writer-token.ts";
 
 /** Internal control-plane credential for exact-run durable event appends. */
 export const RUN_EVENT_APPEND_TOKEN_HEADER = "X-Veryfront-Run-Event-Token";
@@ -52,8 +53,6 @@ export type ParsedHostedChatRequest = {
   agentId: string | undefined;
   userId: string;
   authToken: string;
-  /** Internal control-plane credential; never parsed from the public request body. */
-  runEventAppendToken?: string;
   /** True only after a server envelope credential is verified and bound to this run. */
   serverEnvelopeVerified?: true;
   messages: ChatUiMessage[];
@@ -161,14 +160,15 @@ async function withVerifiedRunEventAppendToken(
     );
   }
 
-  return {
+  const verifiedRequest: ParsedHostedChatRequest = {
     ...parsedRequest,
-    runEventAppendToken: token,
     ...(trustServerEnvelope ? { serverEnvelopeVerified: true as const } : {}),
     forwardedProps: trustServerEnvelope
       ? parsedRequest.forwardedProps
       : stripUnverifiedServerResolvedForwardedProps(parsedRequest.forwardedProps),
   };
+  registerHostedRunEventWriterToken(verifiedRequest, token);
+  return verifiedRequest;
 }
 
 function stripUnverifiedServerResolvedForwardedProps(

--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -167,8 +167,37 @@ async function withVerifiedRunEventAppendToken(
       ? parsedRequest.forwardedProps
       : stripUnverifiedServerResolvedForwardedProps(parsedRequest.forwardedProps),
   };
-  registerHostedRunEventWriterToken(verifiedRequest, token);
+  registerHostedRunEventWriterToken(
+    verifiedRequest,
+    token,
+    removeRunEventAppendTokenHeader(request),
+  );
   return verifiedRequest;
+}
+
+function removeRunEventAppendTokenHeader(request: Request): Request {
+  try {
+    request.headers.delete(RUN_EVENT_APPEND_TOKEN_HEADER);
+    if (!request.headers.has(RUN_EVENT_APPEND_TOKEN_HEADER)) return request;
+  } catch {
+    // Some host Request implementations use immutable header guards.
+  }
+
+  const headers = new Headers(request.headers);
+  headers.delete(RUN_EVENT_APPEND_TOKEN_HEADER);
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    cache: request.cache,
+    credentials: request.credentials,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    mode: request.mode,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    signal: request.signal,
+  });
 }
 
 function stripUnverifiedServerResolvedForwardedProps(

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1650,7 +1650,8 @@ describe("agent/hosted-chat-request", () => {
 
     assertEquals(parsed.userId, userId);
     assertEquals(parsed.authToken, "token_1");
-    assertEquals(parsed.runEventAppendToken, "untrusted-public-header-token");
+    assertEquals("runEventAppendToken" in parsed, false);
+    assertEquals(JSON.stringify(parsed).includes("untrusted-public-header-token"), false);
     assertEquals(parsed.serverEnvelopeVerified, undefined);
     assertEquals(verifiedRunEventTokens, [{
       token: "untrusted-public-header-token",
@@ -1735,7 +1736,9 @@ describe("agent/hosted-chat-request", () => {
     }
 
     assertEquals(parsed.authToken, "user-api-token");
-    assertEquals(parsed.runEventAppendToken, "run-event-service-token");
+    assertEquals("runEventAppendToken" in parsed, false);
+    assertEquals(Object.keys(parsed).includes("runEventAppendToken"), false);
+    assertEquals(JSON.stringify(parsed).includes("run-event-service-token"), false);
     assertEquals(parsed.serverEnvelopeVerified, true);
     assertEquals(verifiedRunEventTokens, [{
       token: "run-event-service-token",
@@ -1777,7 +1780,8 @@ describe("agent/hosted-chat-request", () => {
     );
 
     if (parsed instanceof Response) throw new Error("Expected parsed request");
-    assertEquals(parsed.runEventAppendToken, "run-event-service-token");
+    assertEquals("runEventAppendToken" in parsed, false);
+    assertEquals(JSON.stringify(parsed).includes("run-event-service-token"), false);
     assertEquals(parsed.serverEnvelopeVerified, undefined);
     assertEquals(parsed.forwardedProps, { harmless: "preserved" });
   });

--- a/src/agent/hosted/chat-runtime-contract.ts
+++ b/src/agent/hosted/chat-runtime-contract.ts
@@ -123,8 +123,6 @@ export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingC
   runtimeTargetKind?: HostedChatRuntimeTargetKind | null;
   runtimeTargetEnvironmentId?: string | null;
   authToken: string;
-  /** @internal Verified exact-run credential for durable event persistence. */
-  runEventAppendToken?: string;
   instructions: string | ChatSystemMessage[];
   runId?: string;
   agentId?: string;

--- a/src/agent/hosted/chat-runtime-contract.ts
+++ b/src/agent/hosted/chat-runtime-contract.ts
@@ -123,6 +123,8 @@ export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingC
   runtimeTargetKind?: HostedChatRuntimeTargetKind | null;
   runtimeTargetEnvironmentId?: string | null;
   authToken: string;
+  /** @internal Verified exact-run credential for durable event persistence. */
+  runEventAppendToken?: string;
   instructions: string | ChatSystemMessage[];
   runId?: string;
   agentId?: string;

--- a/src/agent/hosted/child-fork-execution-runner.test.ts
+++ b/src/agent/hosted/child-fork-execution-runner.test.ts
@@ -212,12 +212,49 @@ Deno.test("executeHostedChildForkWithPreparedTools allows injecting the runtime 
   }
 });
 
+Deno.test("executeHostedChildForkWithPreparedTools fails closed before provider dispatch without a child writer token", async () => {
+  let startRuntimeCalls = 0;
+  const result = await executeHostedChildForkWithPreparedTools({
+    authToken: "user-token",
+    apiUrl: "https://api.example.com",
+    description: "Check the app",
+    kind: "invoke_agent",
+    provider: "anthropic",
+    forkModel: "anthropic/claude-sonnet-4",
+    maxSteps: 4,
+    effectivePrompt: "Do the work.",
+    durableChildRun: {
+      childConversationId: "11111111-1111-4111-a111-111111111111",
+      childRunId: "child-run-scoped",
+      childMessageId: "22222222-2222-4222-a222-222222222222",
+      latestEventId: 0,
+      latestExternalEventSequence: 0,
+    },
+    toolAssembly: {
+      ok: true,
+      forkTools: {},
+      availableToolNames: [],
+    },
+    startRuntime: () => {
+      startRuntimeCalls += 1;
+      throw new Error("provider dispatch must not start");
+    },
+  });
+
+  assertEquals(startRuntimeCalls, 0);
+  assertEquals(result.success, false);
+  if (!result.success) {
+    assertEquals(result.error, "Durable hosted child run requires an event mirror");
+  }
+});
+
 Deno.test("executeHostedChildForkWithPreparedTools allows injecting the run context factory", async () => {
   let createRunContextCalls = 0;
   let activeDuringStart = false;
   let activeDuringIteration = false;
   const result = await executeHostedChildForkWithPreparedTools({
     authToken: "token",
+    runEventAppendToken: "child-writer-token",
     apiUrl: "https://api.example.com",
     description: "Check the app",
     kind: "invoke_agent",
@@ -240,6 +277,7 @@ Deno.test("executeHostedChildForkWithPreparedTools allows injecting the run cont
     createRunContext: (input) => {
       createRunContextCalls += 1;
       assertEquals(input.authToken, "token");
+      assertEquals(input.runEventAppendToken, "child-writer-token");
       assertEquals(input.apiUrl, "https://api.example.com");
       const context = createHostedDurableChildForkRunContext({
         authToken: input.authToken,
@@ -273,7 +311,8 @@ Deno.test("executeHostedChildForkWithPreparedTools allows injecting the run cont
         },
       };
     },
-    startRuntime: () => {
+    startRuntime: (input) => {
+      assertEquals(input.authToken, "token");
       activeDuringStart = getActiveModelCallRecorder() !== undefined;
       return {
         forkStreamAbortController: new AbortController(),

--- a/src/agent/hosted/child-fork-execution-runner.test.ts
+++ b/src/agent/hosted/child-fork-execution-runner.test.ts
@@ -254,7 +254,6 @@ Deno.test("executeHostedChildForkWithPreparedTools allows injecting the run cont
   let activeDuringIteration = false;
   const result = await executeHostedChildForkWithPreparedTools({
     authToken: "token",
-    runEventAppendToken: "child-writer-token",
     apiUrl: "https://api.example.com",
     description: "Check the app",
     kind: "invoke_agent",
@@ -277,10 +276,10 @@ Deno.test("executeHostedChildForkWithPreparedTools allows injecting the run cont
     createRunContext: (input) => {
       createRunContextCalls += 1;
       assertEquals(input.authToken, "token");
-      assertEquals(input.runEventAppendToken, "child-writer-token");
+      assertEquals("runEventAppendToken" in input, false);
+      assertEquals("runEventWriterCapability" in input, false);
       assertEquals(input.apiUrl, "https://api.example.com");
       const context = createHostedDurableChildForkRunContext({
-        authToken: input.authToken,
         apiUrl: input.apiUrl,
         instrumentation: input.instrumentation,
         pendingToolLogContext: {

--- a/src/agent/hosted/child-fork-execution-runner.ts
+++ b/src/agent/hosted/child-fork-execution-runner.ts
@@ -64,6 +64,7 @@ import {
   createModelCallContextRunEventRecorder,
   ModelCallContextPersistenceError,
 } from "./model-call-context-run-event-recorder.ts";
+import type { HostedRunEventWriterCapability } from "./child-run-event-writer-token.ts";
 
 /** Default value for hosted child fork stream idle timeout ms. */
 export const DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS = 45_000;
@@ -98,8 +99,6 @@ export type HostedChildForkExecutionRunContextFactoryInput<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 > = {
   authToken: string;
-  /** @internal Exact-child credential used only by the durable mirror. */
-  runEventAppendToken?: string;
   apiUrl: string;
   durableChildRun?: HostedChildRunIdentifiers;
   conversationId?: string;
@@ -114,8 +113,6 @@ export type ExecuteHostedChildForkWithPreparedToolsInput<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 > = {
   authToken: string;
-  /** @internal Exact-child credential used only by the durable mirror. */
-  runEventAppendToken?: string;
   apiUrl: string;
   projectId?: string | null;
   description: string;
@@ -167,6 +164,7 @@ function createForkRunContext<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 >(
   input: HostedChildForkExecutionRunContextFactoryInput<TAttributes>,
+  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): HostedDurableChildForkRunContext {
   const sourceInstrumentation = input.instrumentation;
   const sourceTrace = sourceInstrumentation?.trace;
@@ -185,8 +183,6 @@ function createForkRunContext<
       : undefined;
 
   return createHostedDurableChildForkRunContext({
-    authToken: input.authToken,
-    runEventAppendToken: input.runEventAppendToken,
     apiUrl: input.apiUrl,
     durableChildRun: input.durableChildRun,
     instrumentation,
@@ -196,7 +192,7 @@ function createForkRunContext<
       description: input.description,
     },
     pendingToolLogWriter: input.pendingToolLogWriter,
-  });
+  }, runEventWriterCapability);
 }
 
 function defaultResolveSystem(input: {
@@ -261,6 +257,7 @@ export async function executeHostedChildForkToolInput<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 >(
   input: ExecuteHostedChildForkToolInputOptions<TAttributes>,
+  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<ChildRunExecutionResult> {
   const requestedProjectReference = input.forkInput.project_reference;
   if (requestedProjectReference) {
@@ -321,7 +318,7 @@ export async function executeHostedChildForkToolInput<
       runtimeConfig.thinkingConfig,
     ),
     resultMode: forkInput.result_mode,
-  });
+  }, runEventWriterCapability);
 }
 
 /** Execute hosted child fork with prepared tools. */
@@ -329,12 +326,11 @@ export async function executeHostedChildForkWithPreparedTools<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 >(
   input: ExecuteHostedChildForkWithPreparedToolsInput<TAttributes>,
+  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<ChildRunExecutionResult> {
   const startTime = input.startTime ?? Date.now();
-  const createRunContext = input.createRunContext ?? createForkRunContext;
-  const runContext = createRunContext({
+  const runContextInput = {
     authToken: input.authToken,
-    runEventAppendToken: input.runEventAppendToken,
     apiUrl: input.apiUrl,
     durableChildRun: input.durableChildRun,
     conversationId: input.conversationId,
@@ -342,7 +338,10 @@ export async function executeHostedChildForkWithPreparedTools<
     description: input.description,
     instrumentation: input.instrumentation,
     pendingToolLogWriter: input.pendingToolLogWriter,
-  });
+  };
+  const runContext = input.createRunContext
+    ? input.createRunContext(runContextInput)
+    : createForkRunContext(runContextInput, runEventWriterCapability);
 
   let closeTooling: (() => Promise<void>) | undefined;
   let closeRuntime: (() => Promise<void>) | undefined;

--- a/src/agent/hosted/child-fork-execution-runner.ts
+++ b/src/agent/hosted/child-fork-execution-runner.ts
@@ -64,7 +64,6 @@ import {
   createModelCallContextRunEventRecorder,
   ModelCallContextPersistenceError,
 } from "./model-call-context-run-event-recorder.ts";
-import type { HostedRunEventWriterCapability } from "./child-run-event-writer-token.ts";
 
 /** Default value for hosted child fork stream idle timeout ms. */
 export const DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS = 45_000;
@@ -164,7 +163,6 @@ function createForkRunContext<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 >(
   input: HostedChildForkExecutionRunContextFactoryInput<TAttributes>,
-  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): HostedDurableChildForkRunContext {
   const sourceInstrumentation = input.instrumentation;
   const sourceTrace = sourceInstrumentation?.trace;
@@ -192,7 +190,7 @@ function createForkRunContext<
       description: input.description,
     },
     pendingToolLogWriter: input.pendingToolLogWriter,
-  }, runEventWriterCapability);
+  });
 }
 
 function defaultResolveSystem(input: {
@@ -257,7 +255,6 @@ export async function executeHostedChildForkToolInput<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 >(
   input: ExecuteHostedChildForkToolInputOptions<TAttributes>,
-  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<ChildRunExecutionResult> {
   const requestedProjectReference = input.forkInput.project_reference;
   if (requestedProjectReference) {
@@ -318,7 +315,7 @@ export async function executeHostedChildForkToolInput<
       runtimeConfig.thinkingConfig,
     ),
     resultMode: forkInput.result_mode,
-  }, runEventWriterCapability);
+  });
 }
 
 /** Execute hosted child fork with prepared tools. */
@@ -326,7 +323,6 @@ export async function executeHostedChildForkWithPreparedTools<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 >(
   input: ExecuteHostedChildForkWithPreparedToolsInput<TAttributes>,
-  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<ChildRunExecutionResult> {
   const startTime = input.startTime ?? Date.now();
   const runContextInput = {
@@ -341,7 +337,7 @@ export async function executeHostedChildForkWithPreparedTools<
   };
   const runContext = input.createRunContext
     ? input.createRunContext(runContextInput)
-    : createForkRunContext(runContextInput, runEventWriterCapability);
+    : createForkRunContext(runContextInput);
 
   let closeTooling: (() => Promise<void>) | undefined;
   let closeRuntime: (() => Promise<void>) | undefined;

--- a/src/agent/hosted/child-fork-execution-runner.ts
+++ b/src/agent/hosted/child-fork-execution-runner.ts
@@ -98,6 +98,8 @@ export type HostedChildForkExecutionRunContextFactoryInput<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 > = {
   authToken: string;
+  /** @internal Exact-child credential used only by the durable mirror. */
+  runEventAppendToken?: string;
   apiUrl: string;
   durableChildRun?: HostedChildRunIdentifiers;
   conversationId?: string;
@@ -112,6 +114,8 @@ export type ExecuteHostedChildForkWithPreparedToolsInput<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 > = {
   authToken: string;
+  /** @internal Exact-child credential used only by the durable mirror. */
+  runEventAppendToken?: string;
   apiUrl: string;
   projectId?: string | null;
   description: string;
@@ -182,6 +186,7 @@ function createForkRunContext<
 
   return createHostedDurableChildForkRunContext({
     authToken: input.authToken,
+    runEventAppendToken: input.runEventAppendToken,
     apiUrl: input.apiUrl,
     durableChildRun: input.durableChildRun,
     instrumentation,
@@ -329,6 +334,7 @@ export async function executeHostedChildForkWithPreparedTools<
   const createRunContext = input.createRunContext ?? createForkRunContext;
   const runContext = createRunContext({
     authToken: input.authToken,
+    runEventAppendToken: input.runEventAppendToken,
     apiUrl: input.apiUrl,
     durableChildRun: input.durableChildRun,
     conversationId: input.conversationId,

--- a/src/agent/hosted/child-fork-run-context.test.ts
+++ b/src/agent/hosted/child-fork-run-context.test.ts
@@ -62,6 +62,7 @@ Deno.test("createHostedDurableChildForkRunContext wires conversation mirror and 
   const traces: string[] = [];
   const context = createHostedDurableChildForkRunContext({
     authToken: "token",
+    runEventAppendToken: "child-writer-token",
     apiUrl: "https://api.example.com",
     durableChildRun: {
       childConversationId: "child-conversation-1",
@@ -101,6 +102,52 @@ Deno.test("createHostedDurableChildForkRunContext wires conversation mirror and 
     "child-message-1:reasoning",
   );
   assertEquals(traces, []);
+});
+
+Deno.test("createHostedDurableChildForkRunContext authorizes its mirror with only the child writer token", async () => {
+  const originalFetch = globalThis.fetch;
+  let authorization: string | null = null;
+  try {
+    globalThis.fetch = (input, init) => {
+      authorization = new Request(input, init).headers.get("Authorization");
+      return Promise.resolve(Response.json({
+        latestEventId: 1,
+        latestExternalEventSequence: 1,
+        appendedCount: 1,
+        run: {
+          runId: "child-run-1",
+          conversationId: "11111111-1111-4111-a111-111111111111",
+          latestEventId: 1,
+          latestExternalEventSequence: 1,
+        },
+      }));
+    };
+    const context = createHostedDurableChildForkRunContext({
+      authToken: "user-token-must-not-authorize-mirror",
+      runEventAppendToken: "child-writer-token",
+      apiUrl: "https://api.example.com",
+      durableChildRun: {
+        childConversationId: "11111111-1111-4111-a111-111111111111",
+        childRunId: "child-run-1",
+        childMessageId: "child-message-1",
+        latestEventId: 0,
+        latestExternalEventSequence: 0,
+      },
+      pendingToolLogContext: { description: "Check the app" },
+    });
+
+    await context.durableRunMirror?.appendEvents([{
+      type: "CUSTOM",
+      name: "child-progress",
+      value: { status: "running" },
+    }]);
+    await context.durableRunMirror?.flush();
+
+    assertEquals(authorization, "Bearer child-writer-token");
+    context.durableRunMirror?.dispose();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 Deno.test("createHostedChildForkRunContext closes pending tool calls with host logger", async () => {

--- a/src/agent/hosted/child-fork-run-context.test.ts
+++ b/src/agent/hosted/child-fork-run-context.test.ts
@@ -8,6 +8,7 @@ import {
   handleHostedChildForkRunContextError,
 } from "./child-fork-run-context.ts";
 import type { ForkPart, ForkRuntimeStep } from "../streaming/fork-runtime-stream.ts";
+import { createHostedRunEventWriterCapability } from "./child-run-event-writer-token.ts";
 
 async function* forkParts(parts: ForkPart[]): AsyncGenerator<ForkPart, void, void> {
   for (const part of parts) {
@@ -60,29 +61,34 @@ Deno.test("createHostedChildForkRunContext wires stream mirror state and buffers
 
 Deno.test("createHostedDurableChildForkRunContext wires conversation mirror and child identifiers", () => {
   const traces: string[] = [];
-  const context = createHostedDurableChildForkRunContext({
-    authToken: "token",
-    runEventAppendToken: "child-writer-token",
-    apiUrl: "https://api.example.com",
-    durableChildRun: {
-      childConversationId: "child-conversation-1",
-      childRunId: "child-run-1",
-      childMessageId: "child-message-1",
-      latestEventId: 5,
-      latestExternalEventSequence: 7,
-    },
-    instrumentation: {
-      trace: (operationName, operation) => {
-        traces.push(operationName);
-        return operation();
+  const context = createHostedDurableChildForkRunContext(
+    {
+      apiUrl: "https://api.example.com",
+      durableChildRun: {
+        childConversationId: "child-conversation-1",
+        childRunId: "child-run-1",
+        childMessageId: "child-message-1",
+        latestEventId: 5,
+        latestExternalEventSequence: 7,
+      },
+      instrumentation: {
+        trace: (operationName, operation) => {
+          traces.push(operationName);
+          return operation();
+        },
+      },
+      pendingToolLogContext: {
+        conversationId: "conversation-1",
+        parentRunId: "run-1",
+        description: "Check the app",
       },
     },
-    pendingToolLogContext: {
-      conversationId: "conversation-1",
-      parentRunId: "run-1",
-      description: "Check the app",
-    },
-  });
+    createHostedRunEventWriterCapability({
+      apiUrl: "https://api.example.com",
+      runId: "child-run-1",
+      runEventAppendToken: "child-writer-token",
+    }),
+  );
 
   assertEquals(context.durableRunMirror?.getSnapshot(), {
     latestEventId: 5,
@@ -122,19 +128,24 @@ Deno.test("createHostedDurableChildForkRunContext authorizes its mirror with onl
         },
       }));
     };
-    const context = createHostedDurableChildForkRunContext({
-      authToken: "user-token-must-not-authorize-mirror",
-      runEventAppendToken: "child-writer-token",
-      apiUrl: "https://api.example.com",
-      durableChildRun: {
-        childConversationId: "11111111-1111-4111-a111-111111111111",
-        childRunId: "child-run-1",
-        childMessageId: "child-message-1",
-        latestEventId: 0,
-        latestExternalEventSequence: 0,
+    const context = createHostedDurableChildForkRunContext(
+      {
+        apiUrl: "https://api.example.com",
+        durableChildRun: {
+          childConversationId: "11111111-1111-4111-a111-111111111111",
+          childRunId: "child-run-1",
+          childMessageId: "child-message-1",
+          latestEventId: 0,
+          latestExternalEventSequence: 0,
+        },
+        pendingToolLogContext: { description: "Check the app" },
       },
-      pendingToolLogContext: { description: "Check the app" },
-    });
+      createHostedRunEventWriterCapability({
+        apiUrl: "https://api.example.com",
+        runId: "child-run-1",
+        runEventAppendToken: "child-writer-token",
+      }),
+    );
 
     await context.durableRunMirror?.appendEvents([{
       type: "CUSTOM",

--- a/src/agent/hosted/child-fork-run-context.test.ts
+++ b/src/agent/hosted/child-fork-run-context.test.ts
@@ -8,7 +8,10 @@ import {
   handleHostedChildForkRunContextError,
 } from "./child-fork-run-context.ts";
 import type { ForkPart, ForkRuntimeStep } from "../streaming/fork-runtime-stream.ts";
-import { createHostedRunEventWriterCapability } from "./child-run-event-writer-token.ts";
+import {
+  createHostedRunEventWriterCapability,
+  runWithHostedRunEventWriterCapability,
+} from "./child-run-event-writer-token.ts";
 
 async function* forkParts(parts: ForkPart[]): AsyncGenerator<ForkPart, void, void> {
   for (const part of parts) {
@@ -61,33 +64,36 @@ Deno.test("createHostedChildForkRunContext wires stream mirror state and buffers
 
 Deno.test("createHostedDurableChildForkRunContext wires conversation mirror and child identifiers", () => {
   const traces: string[] = [];
-  const context = createHostedDurableChildForkRunContext(
-    {
-      apiUrl: "https://api.example.com",
-      durableChildRun: {
-        childConversationId: "child-conversation-1",
-        childRunId: "child-run-1",
-        childMessageId: "child-message-1",
-        latestEventId: 5,
-        latestExternalEventSequence: 7,
-      },
-      instrumentation: {
-        trace: (operationName, operation) => {
-          traces.push(operationName);
-          return operation();
-        },
-      },
-      pendingToolLogContext: {
-        conversationId: "conversation-1",
-        parentRunId: "run-1",
-        description: "Check the app",
-      },
-    },
+  const context = runWithHostedRunEventWriterCapability(
     createHostedRunEventWriterCapability({
       apiUrl: "https://api.example.com",
       runId: "child-run-1",
       runEventAppendToken: "child-writer-token",
     }),
+    () =>
+      createHostedDurableChildForkRunContext(
+        {
+          apiUrl: "https://api.example.com",
+          durableChildRun: {
+            childConversationId: "child-conversation-1",
+            childRunId: "child-run-1",
+            childMessageId: "child-message-1",
+            latestEventId: 5,
+            latestExternalEventSequence: 7,
+          },
+          instrumentation: {
+            trace: (operationName, operation) => {
+              traces.push(operationName);
+              return operation();
+            },
+          },
+          pendingToolLogContext: {
+            conversationId: "conversation-1",
+            parentRunId: "run-1",
+            description: "Check the app",
+          },
+        },
+      ),
   );
 
   assertEquals(context.durableRunMirror?.getSnapshot(), {
@@ -128,23 +134,26 @@ Deno.test("createHostedDurableChildForkRunContext authorizes its mirror with onl
         },
       }));
     };
-    const context = createHostedDurableChildForkRunContext(
-      {
-        apiUrl: "https://api.example.com",
-        durableChildRun: {
-          childConversationId: "11111111-1111-4111-a111-111111111111",
-          childRunId: "child-run-1",
-          childMessageId: "child-message-1",
-          latestEventId: 0,
-          latestExternalEventSequence: 0,
-        },
-        pendingToolLogContext: { description: "Check the app" },
-      },
+    const context = runWithHostedRunEventWriterCapability(
       createHostedRunEventWriterCapability({
         apiUrl: "https://api.example.com",
         runId: "child-run-1",
         runEventAppendToken: "child-writer-token",
       }),
+      () =>
+        createHostedDurableChildForkRunContext(
+          {
+            apiUrl: "https://api.example.com",
+            durableChildRun: {
+              childConversationId: "11111111-1111-4111-a111-111111111111",
+              childRunId: "child-run-1",
+              childMessageId: "child-message-1",
+              latestEventId: 0,
+              latestExternalEventSequence: 0,
+            },
+            pendingToolLogContext: { description: "Check the app" },
+          },
+        ),
     );
 
     await context.durableRunMirror?.appendEvents([{

--- a/src/agent/hosted/child-fork-run-context.ts
+++ b/src/agent/hosted/child-fork-run-context.ts
@@ -10,7 +10,7 @@ import {
 } from "../conversation/run-chunk-mirror.ts";
 import {
   createHostedConversationRunChunkMirrorFromCapability,
-  type HostedRunEventWriterCapability,
+  getActiveHostedRunEventWriterCapability,
 } from "./child-run-event-writer-token.ts";
 import {
   createHostedChildPendingToolLifecycle,
@@ -170,8 +170,8 @@ export function createHostedChildForkRunContext(
 /** Context for create hosted durable child fork run. */
 export function createHostedDurableChildForkRunContext(
   input: HostedDurableChildForkRunContextInput,
-  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): HostedDurableChildForkRunContext {
+  const runEventWriterCapability = getActiveHostedRunEventWriterCapability();
   const durableRunMirror = input.durableChildRun
     ? createHostedConversationRunChunkMirrorFromCapability(runEventWriterCapability, {
       apiUrl: input.apiUrl,

--- a/src/agent/hosted/child-fork-run-context.ts
+++ b/src/agent/hosted/child-fork-run-context.ts
@@ -6,9 +6,12 @@ import {
 } from "./child-mirror.ts";
 import {
   type ConversationRunChunkMirror,
-  createHostedConversationRunChunkMirror,
   type HostedConversationRunChunkMirrorInstrumentation,
 } from "../conversation/run-chunk-mirror.ts";
+import {
+  createHostedConversationRunChunkMirrorFromCapability,
+  type HostedRunEventWriterCapability,
+} from "./child-run-event-writer-token.ts";
 import {
   createHostedChildPendingToolLifecycle,
   createHostedChildPendingToolLifecycleLogger,
@@ -93,9 +96,6 @@ export interface HostedChildForkRunContextInput {
 
 /** Input payload for hosted durable child fork run context. */
 export interface HostedDurableChildForkRunContextInput {
-  authToken: string;
-  /** @internal Exact-child credential used only by the durable mirror. */
-  runEventAppendToken?: string;
   apiUrl: string;
   durableChildRun?: HostedChildRunIdentifiers;
   instrumentation?: HostedConversationRunChunkMirrorInstrumentation;
@@ -170,17 +170,17 @@ export function createHostedChildForkRunContext(
 /** Context for create hosted durable child fork run. */
 export function createHostedDurableChildForkRunContext(
   input: HostedDurableChildForkRunContextInput,
+  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): HostedDurableChildForkRunContext {
-  const durableRunMirror = input.durableChildRun && input.runEventAppendToken
-    ? createHostedConversationRunChunkMirror({
-      authToken: input.runEventAppendToken,
+  const durableRunMirror = input.durableChildRun
+    ? createHostedConversationRunChunkMirrorFromCapability(runEventWriterCapability, {
       apiUrl: input.apiUrl,
       conversationId: input.durableChildRun.childConversationId,
       runId: input.durableChildRun.childRunId,
       latestEventId: input.durableChildRun.latestEventId,
       latestExternalEventSequence: input.durableChildRun.latestExternalEventSequence,
       instrumentation: input.instrumentation,
-    })
+    }) ?? null
     : null;
 
   return {

--- a/src/agent/hosted/child-fork-run-context.ts
+++ b/src/agent/hosted/child-fork-run-context.ts
@@ -94,6 +94,8 @@ export interface HostedChildForkRunContextInput {
 /** Input payload for hosted durable child fork run context. */
 export interface HostedDurableChildForkRunContextInput {
   authToken: string;
+  /** @internal Exact-child credential used only by the durable mirror. */
+  runEventAppendToken?: string;
   apiUrl: string;
   durableChildRun?: HostedChildRunIdentifiers;
   instrumentation?: HostedConversationRunChunkMirrorInstrumentation;
@@ -169,9 +171,9 @@ export function createHostedChildForkRunContext(
 export function createHostedDurableChildForkRunContext(
   input: HostedDurableChildForkRunContextInput,
 ): HostedDurableChildForkRunContext {
-  const durableRunMirror = input.durableChildRun
+  const durableRunMirror = input.durableChildRun && input.runEventAppendToken
     ? createHostedConversationRunChunkMirror({
-      authToken: input.authToken,
+      authToken: input.runEventAppendToken,
       apiUrl: input.apiUrl,
       conversationId: input.durableChildRun.childConversationId,
       runId: input.durableChildRun.childRunId,

--- a/src/agent/hosted/child-run-event-writer-token.test.ts
+++ b/src/agent/hosted/child-run-event-writer-token.test.ts
@@ -76,6 +76,31 @@ Deno.test("run event writer capability delegates parent to child to grandchild e
   );
 });
 
+Deno.test("run event writer capability preserves the configured API base path", async () => {
+  let requestUrl: string | undefined;
+  const capability = createHostedRunEventWriterCapability({
+    apiUrl: "https://api.example.test/v1",
+    runId: "run_parent",
+    runEventAppendToken: "parent-writer-token",
+    fetch: (input, init) => {
+      requestUrl = new Request(input, init).url;
+      return Promise.resolve(
+        Response.json(
+          { run_event_token: "child-writer-token" },
+          { headers: { "Cache-Control": "no-store" } },
+        ),
+      );
+    },
+  });
+
+  await capability.mintChildRunEventAppendToken("run_child");
+
+  assertEquals(
+    requestUrl,
+    "https://api.example.test/v1/runs/run_parent/children/run_child/event-writer-token",
+  );
+});
+
 Deno.test("exchangeHostedChildRunEventWriterToken rejects responses without no-store", async () => {
   await assertRejects(
     () =>

--- a/src/agent/hosted/child-run-event-writer-token.test.ts
+++ b/src/agent/hosted/child-run-event-writer-token.test.ts
@@ -1,0 +1,148 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  exchangeHostedChildRunEventWriterToken,
+  HostedChildRunEventWriterTokenExchangeError,
+} from "./child-run-event-writer-token.ts";
+
+Deno.test("exchangeHostedChildRunEventWriterToken uses the active parent writer token without a body", async () => {
+  let request: Request | undefined;
+
+  const token = await exchangeHostedChildRunEventWriterToken({
+    apiUrl: "https://api.example.com/",
+    parentRunId: "run_parent",
+    childRunId: "run_child",
+    runEventAppendToken: "parent-writer-token",
+    fetch: (input, init) => {
+      request = new Request(input, init);
+      return Promise.resolve(
+        Response.json(
+          { run_event_token: "child-writer-token" },
+          { headers: { "Cache-Control": "no-store" } },
+        ),
+      );
+    },
+  });
+
+  assertEquals(token, "child-writer-token");
+  assertEquals(
+    request?.url,
+    "https://api.example.com/runs/run_parent/children/run_child/event-writer-token",
+  );
+  assertEquals(request?.method, "POST");
+  assertEquals(request?.headers.get("Authorization"), "Bearer parent-writer-token");
+  assertEquals(request?.headers.get("Cache-Control"), "no-store");
+  assertEquals(await request?.text(), "");
+});
+
+Deno.test("exchangeHostedChildRunEventWriterToken rejects responses without no-store", async () => {
+  await assertRejects(
+    () =>
+      exchangeHostedChildRunEventWriterToken({
+        apiUrl: "https://api.example.com",
+        parentRunId: "run_parent",
+        childRunId: "run_child",
+        runEventAppendToken: "parent-writer-token",
+        fetch: () => Promise.resolve(Response.json({ run_event_token: "child-writer-token" })),
+      }),
+    HostedChildRunEventWriterTokenExchangeError,
+    "Unable to initialize durable child event persistence",
+  );
+});
+
+Deno.test("exchangeHostedChildRunEventWriterToken rejects control-plane errors without reading their body", async () => {
+  let bodyRead = false;
+  const response = new Response("parent-writer-token-must-not-leak", { status: 503 });
+  const originalJson = response.json.bind(response);
+  response.json = () => {
+    bodyRead = true;
+    return originalJson();
+  };
+
+  await assertRejects(
+    () =>
+      exchangeHostedChildRunEventWriterToken({
+        apiUrl: "https://api.example.com",
+        parentRunId: "run_parent",
+        childRunId: "run_child",
+        runEventAppendToken: "parent-writer-token",
+        fetch: () => Promise.resolve(response),
+      }),
+    HostedChildRunEventWriterTokenExchangeError,
+    "Unable to initialize durable child event persistence",
+  );
+  assertEquals(bodyRead, false);
+});
+
+for (
+  const body of [
+    {},
+    { run_event_token: "" },
+    { run_event_token: 1 },
+    { run_event_token: "child-writer-token", extra: true },
+  ]
+) {
+  Deno.test(`exchangeHostedChildRunEventWriterToken rejects invalid response ${JSON.stringify(body)}`, async () => {
+    await assertRejects(
+      () =>
+        exchangeHostedChildRunEventWriterToken({
+          apiUrl: "https://api.example.com",
+          parentRunId: "run_parent",
+          childRunId: "run_child",
+          runEventAppendToken: "parent-writer-token",
+          fetch: () =>
+            Promise.resolve(
+              Response.json(body, { headers: { "Cache-Control": "no-store" } }),
+            ),
+        }),
+      HostedChildRunEventWriterTokenExchangeError,
+      "Unable to initialize durable child event persistence",
+    );
+  });
+}
+
+Deno.test("exchangeHostedChildRunEventWriterToken maps aborts to a sanitized error", async () => {
+  const controller = new AbortController();
+  controller.abort("parent-writer-token-must-not-leak");
+
+  const error = await assertRejects(
+    () =>
+      exchangeHostedChildRunEventWriterToken({
+        apiUrl: "https://api.example.com",
+        parentRunId: "run_parent",
+        childRunId: "run_child",
+        runEventAppendToken: "parent-writer-token",
+        abortSignal: controller.signal,
+        fetch: (input, init) => Promise.reject(new Request(input, init).signal.reason),
+      }),
+    HostedChildRunEventWriterTokenExchangeError,
+    "Unable to initialize durable child event persistence",
+  );
+
+  assertEquals(
+    error instanceof Error && error.message.includes("parent-writer-token"),
+    false,
+  );
+});
+
+Deno.test("exchangeHostedChildRunEventWriterToken applies a bounded timeout", async () => {
+  const error = await assertRejects(
+    () =>
+      exchangeHostedChildRunEventWriterToken({
+        apiUrl: "https://api.example.com",
+        parentRunId: "run_parent",
+        childRunId: "run_child",
+        runEventAppendToken: "parent-writer-token",
+        timeoutMs: 1,
+        fetch: (input, init) => {
+          const signal = new Request(input, init).signal;
+          return new Promise<Response>((_resolve, reject) => {
+            signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          });
+        },
+      }),
+    HostedChildRunEventWriterTokenExchangeError,
+    "Unable to initialize durable child event persistence",
+  );
+
+  assertEquals(error instanceof Error && error.message.includes("parent-writer-token"), false);
+});

--- a/src/agent/hosted/child-run-event-writer-token.test.ts
+++ b/src/agent/hosted/child-run-event-writer-token.test.ts
@@ -1,49 +1,64 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import {
-  exchangeHostedChildRunEventWriterToken,
+  createHostedRunEventWriterCapability,
   HostedChildRunEventWriterTokenExchangeError,
 } from "./child-run-event-writer-token.ts";
 
-Deno.test("exchangeHostedChildRunEventWriterToken uses the active parent writer token without a body", async () => {
-  let request: Request | undefined;
-
-  const token = await exchangeHostedChildRunEventWriterToken({
+Deno.test("run event writer capability delegates parent to child to grandchild exactly once without exposing credentials", async () => {
+  const requests: Request[] = [];
+  const responses = ["child-writer-token", "grandchild-writer-token"];
+  const capability = createHostedRunEventWriterCapability({
     apiUrl: "https://api.example.com/",
-    parentRunId: "run_parent",
-    childRunId: "run_child",
+    runId: "run_parent",
     runEventAppendToken: "parent-writer-token",
     fetch: (input, init) => {
-      request = new Request(input, init);
+      requests.push(new Request(input, init));
       return Promise.resolve(
         Response.json(
-          { run_event_token: "child-writer-token" },
+          { run_event_token: responses[requests.length - 1] },
           { headers: { "Cache-Control": "no-store" } },
         ),
       );
     },
   });
-
-  assertEquals(token, "child-writer-token");
-  assertEquals(
-    request?.url,
-    "https://api.example.com/runs/run_parent/children/run_child/event-writer-token",
+  const childCapability = await capability.mintChildRunEventAppendToken("run_child");
+  const grandchildCapability = await childCapability.mintChildRunEventAppendToken(
+    "run_grandchild",
   );
-  assertEquals(request?.method, "POST");
-  assertEquals(request?.headers.get("Authorization"), "Bearer parent-writer-token");
-  assertEquals(request?.headers.get("Cache-Control"), "no-store");
-  assertEquals(await request?.text(), "");
+
+  assertEquals(
+    requests.map((request) => request.url),
+    [
+      "https://api.example.com/runs/run_parent/children/run_child/event-writer-token",
+      "https://api.example.com/runs/run_child/children/run_grandchild/event-writer-token",
+    ],
+  );
+  assertEquals(
+    requests.map((request) => request.headers.get("Authorization")),
+    ["Bearer parent-writer-token", "Bearer child-writer-token"],
+  );
+  assertEquals(requests.every((request) => request.method === "POST"), true);
+  assertEquals(
+    requests.every((request) => request.headers.get("Cache-Control") === "no-store"),
+    true,
+  );
+  assertEquals(await Promise.all(requests.map((request) => request.text())), ["", ""]);
+  assertEquals(Object.keys(capability), []);
+  assertEquals(
+    JSON.stringify({ capability, childCapability, grandchildCapability }),
+    '{"capability":{},"childCapability":{},"grandchildCapability":{}}',
+  );
 });
 
 Deno.test("exchangeHostedChildRunEventWriterToken rejects responses without no-store", async () => {
   await assertRejects(
     () =>
-      exchangeHostedChildRunEventWriterToken({
+      createHostedRunEventWriterCapability({
         apiUrl: "https://api.example.com",
-        parentRunId: "run_parent",
-        childRunId: "run_child",
+        runId: "run_parent",
         runEventAppendToken: "parent-writer-token",
         fetch: () => Promise.resolve(Response.json({ run_event_token: "child-writer-token" })),
-      }),
+      }).mintChildRunEventAppendToken("run_child"),
     HostedChildRunEventWriterTokenExchangeError,
     "Unable to initialize durable child event persistence",
   );
@@ -60,13 +75,12 @@ Deno.test("exchangeHostedChildRunEventWriterToken rejects control-plane errors w
 
   await assertRejects(
     () =>
-      exchangeHostedChildRunEventWriterToken({
+      createHostedRunEventWriterCapability({
         apiUrl: "https://api.example.com",
-        parentRunId: "run_parent",
-        childRunId: "run_child",
+        runId: "run_parent",
         runEventAppendToken: "parent-writer-token",
         fetch: () => Promise.resolve(response),
-      }),
+      }).mintChildRunEventAppendToken("run_child"),
     HostedChildRunEventWriterTokenExchangeError,
     "Unable to initialize durable child event persistence",
   );
@@ -84,16 +98,15 @@ for (
   Deno.test(`exchangeHostedChildRunEventWriterToken rejects invalid response ${JSON.stringify(body)}`, async () => {
     await assertRejects(
       () =>
-        exchangeHostedChildRunEventWriterToken({
+        createHostedRunEventWriterCapability({
           apiUrl: "https://api.example.com",
-          parentRunId: "run_parent",
-          childRunId: "run_child",
+          runId: "run_parent",
           runEventAppendToken: "parent-writer-token",
           fetch: () =>
             Promise.resolve(
               Response.json(body, { headers: { "Cache-Control": "no-store" } }),
             ),
-        }),
+        }).mintChildRunEventAppendToken("run_child"),
       HostedChildRunEventWriterTokenExchangeError,
       "Unable to initialize durable child event persistence",
     );
@@ -106,14 +119,12 @@ Deno.test("exchangeHostedChildRunEventWriterToken maps aborts to a sanitized err
 
   const error = await assertRejects(
     () =>
-      exchangeHostedChildRunEventWriterToken({
+      createHostedRunEventWriterCapability({
         apiUrl: "https://api.example.com",
-        parentRunId: "run_parent",
-        childRunId: "run_child",
+        runId: "run_parent",
         runEventAppendToken: "parent-writer-token",
-        abortSignal: controller.signal,
         fetch: (input, init) => Promise.reject(new Request(input, init).signal.reason),
-      }),
+      }).mintChildRunEventAppendToken("run_child", controller.signal),
     HostedChildRunEventWriterTokenExchangeError,
     "Unable to initialize durable child event persistence",
   );
@@ -122,15 +133,18 @@ Deno.test("exchangeHostedChildRunEventWriterToken maps aborts to a sanitized err
     error instanceof Error && error.message.includes("parent-writer-token"),
     false,
   );
+  assertEquals(
+    error instanceof HostedChildRunEventWriterTokenExchangeError && error.classification,
+    "aborted",
+  );
 });
 
 Deno.test("exchangeHostedChildRunEventWriterToken applies a bounded timeout", async () => {
   const error = await assertRejects(
     () =>
-      exchangeHostedChildRunEventWriterToken({
+      createHostedRunEventWriterCapability({
         apiUrl: "https://api.example.com",
-        parentRunId: "run_parent",
-        childRunId: "run_child",
+        runId: "run_parent",
         runEventAppendToken: "parent-writer-token",
         timeoutMs: 1,
         fetch: (input, init) => {
@@ -139,10 +153,14 @@ Deno.test("exchangeHostedChildRunEventWriterToken applies a bounded timeout", as
             signal.addEventListener("abort", () => reject(signal.reason), { once: true });
           });
         },
-      }),
+      }).mintChildRunEventAppendToken("run_child"),
     HostedChildRunEventWriterTokenExchangeError,
     "Unable to initialize durable child event persistence",
   );
 
   assertEquals(error instanceof Error && error.message.includes("parent-writer-token"), false);
+  assertEquals(
+    error instanceof HostedChildRunEventWriterTokenExchangeError && error.classification,
+    "failed",
+  );
 });

--- a/src/agent/hosted/child-run-event-writer-token.test.ts
+++ b/src/agent/hosted/child-run-event-writer-token.test.ts
@@ -1,8 +1,34 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import {
   createHostedRunEventWriterCapability,
+  getActiveHostedRunEventWriterCapability,
   HostedChildRunEventWriterTokenExchangeError,
+  runWithHostedRunEventWriterCapability,
 } from "./child-run-event-writer-token.ts";
+
+Deno.test("explicit authority-less scopes clear and restore ambient writer authority", async () => {
+  const capability = createHostedRunEventWriterCapability({
+    apiUrl: "https://api.example.com/",
+    runId: "run_parent",
+    runEventAppendToken: "parent-writer-token",
+  });
+
+  await runWithHostedRunEventWriterCapability(capability, async () => {
+    assertEquals(getActiveHostedRunEventWriterCapability(), capability);
+
+    await runWithHostedRunEventWriterCapability(undefined, async () => {
+      const detachedCapability = getActiveHostedRunEventWriterCapability();
+      assertEquals(detachedCapability, undefined);
+      assertEquals(detachedCapability?.mintChildRunEventAppendToken, undefined);
+    });
+
+    assertEquals(getActiveHostedRunEventWriterCapability(), capability);
+    await Promise.resolve();
+    assertEquals(getActiveHostedRunEventWriterCapability(), capability);
+  });
+
+  assertEquals(getActiveHostedRunEventWriterCapability(), undefined);
+});
 
 Deno.test("run event writer capability delegates parent to child to grandchild exactly once without exposing credentials", async () => {
   const requests: Request[] = [];

--- a/src/agent/hosted/child-run-event-writer-token.test.ts
+++ b/src/agent/hosted/child-run-event-writer-token.test.ts
@@ -73,7 +73,7 @@ Deno.test("exchangeHostedChildRunEventWriterToken rejects control-plane errors w
     return originalJson();
   };
 
-  await assertRejects(
+  const error = await assertRejects(
     () =>
       createHostedRunEventWriterCapability({
         apiUrl: "https://api.example.com",
@@ -85,6 +85,10 @@ Deno.test("exchangeHostedChildRunEventWriterToken rejects control-plane errors w
     "Unable to initialize durable child event persistence",
   );
   assertEquals(bodyRead, false);
+  assertEquals(
+    error instanceof HostedChildRunEventWriterTokenExchangeError && error.classification,
+    "failed",
+  );
 });
 
 for (
@@ -161,6 +165,40 @@ Deno.test("exchangeHostedChildRunEventWriterToken applies a bounded timeout", as
   assertEquals(error instanceof Error && error.message.includes("parent-writer-token"), false);
   assertEquals(
     error instanceof HostedChildRunEventWriterTokenExchangeError && error.classification,
-    "failed",
+    "timeout",
   );
+});
+
+Deno.test("exchangeHostedChildRunEventWriterToken keeps the first cancellation classification", async () => {
+  const controller = new AbortController();
+  const callerAbort = setTimeout(
+    () => controller.abort("parent-writer-token-must-not-leak"),
+    20,
+  );
+  try {
+    const error = await assertRejects(
+      () =>
+        createHostedRunEventWriterCapability({
+          apiUrl: "https://api.example.com",
+          runId: "run_parent",
+          runEventAppendToken: "parent-writer-token",
+          timeoutMs: 1,
+          fetch: (input, init) => {
+            const signal = new Request(input, init).signal;
+            return new Promise<Response>((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+            });
+          },
+        }).mintChildRunEventAppendToken("run_child", controller.signal),
+      HostedChildRunEventWriterTokenExchangeError,
+      "Unable to initialize durable child event persistence",
+    );
+
+    assertEquals(
+      error instanceof HostedChildRunEventWriterTokenExchangeError && error.classification,
+      "timeout",
+    );
+  } finally {
+    clearTimeout(callerAbort);
+  }
 });

--- a/src/agent/hosted/child-run-event-writer-token.ts
+++ b/src/agent/hosted/child-run-event-writer-token.ts
@@ -1,3 +1,10 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  type ConversationRunChunkMirror,
+  createHostedConversationRunChunkMirror,
+  type HostedConversationRunChunkMirrorOptions,
+} from "../conversation/run-chunk-mirror.ts";
+
 const DEFAULT_CHILD_RUN_EVENT_WRITER_TOKEN_TIMEOUT_MS = 10_000;
 const CHILD_RUN_EVENT_WRITER_TOKEN_SETUP_ERROR =
   "Unable to initialize durable child event persistence";
@@ -6,22 +13,33 @@ type Fetch = typeof globalThis.fetch;
 
 /** Internal failure raised when the control plane cannot issue an exact-child writer token. */
 export class HostedChildRunEventWriterTokenExchangeError extends Error {
-  constructor() {
+  readonly classification: "aborted" | "failed";
+
+  constructor(classification: "aborted" | "failed" = "failed") {
     super(CHILD_RUN_EVENT_WRITER_TOKEN_SETUP_ERROR);
     this.name = "HostedChildRunEventWriterTokenExchangeError";
+    this.classification = classification;
   }
 }
 
-/** Internal input for exchanging an active parent writer token for an exact-child token. */
-export interface ExchangeHostedChildRunEventWriterTokenInput {
-  apiUrl: string;
-  parentRunId: string;
-  childRunId: string;
-  runEventAppendToken: string;
-  abortSignal?: AbortSignal;
-  timeoutMs?: number;
-  fetch?: Fetch;
+/** Non-serializable authority that can delegate only to a direct child run. */
+export interface HostedRunEventWriterCapability {
+  mintChildRunEventAppendToken(
+    childRunId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<HostedRunEventWriterCapability>;
 }
+
+type CapabilityState = {
+  apiUrl: string;
+  runId: string;
+  runEventAppendToken: string;
+  timeoutMs: number;
+  fetch: Fetch;
+};
+
+const capabilityState = new WeakMap<HostedRunEventWriterCapability, CapabilityState>();
+const capabilityStorage = new AsyncLocalStorage<HostedRunEventWriterCapability>();
 
 function isNoStoreResponse(response: Response): boolean {
   return response.headers.get("Cache-Control")?.split(",").some((directive) =>
@@ -46,30 +64,26 @@ function parseRunEventToken(value: unknown): string {
   return token;
 }
 
-/** Exchange a verified active-parent credential for an exact-child event writer credential. */
-export async function exchangeHostedChildRunEventWriterToken(
-  input: ExchangeHostedChildRunEventWriterTokenInput,
+async function exchangeChildRunEventWriterToken(
+  state: CapabilityState,
+  childRunId: string,
+  abortSignal?: AbortSignal,
 ): Promise<string> {
-  const timeoutSignal = AbortSignal.timeout(
-    input.timeoutMs ?? DEFAULT_CHILD_RUN_EVENT_WRITER_TOKEN_TIMEOUT_MS,
-  );
-  const signal = input.abortSignal
-    ? AbortSignal.any([input.abortSignal, timeoutSignal])
-    : timeoutSignal;
-  const fetch = input.fetch ?? globalThis.fetch;
+  const timeoutSignal = AbortSignal.timeout(state.timeoutMs);
+  const signal = abortSignal ? AbortSignal.any([abortSignal, timeoutSignal]) : timeoutSignal;
   const url = new URL(
-    `/runs/${encodeURIComponent(input.parentRunId)}/children/${
-      encodeURIComponent(input.childRunId)
+    `/runs/${encodeURIComponent(state.runId)}/children/${
+      encodeURIComponent(childRunId)
     }/event-writer-token`,
-    input.apiUrl,
+    state.apiUrl,
   );
 
   try {
-    const response = await fetch(url, {
+    const response = await state.fetch(url, {
       method: "POST",
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${input.runEventAppendToken}`,
+        Authorization: `Bearer ${state.runEventAppendToken}`,
         "Cache-Control": "no-store",
       },
       cache: "no-store",
@@ -82,9 +96,68 @@ export async function exchangeHostedChildRunEventWriterToken(
 
     return parseRunEventToken(await response.json());
   } catch (error) {
-    if (error instanceof HostedChildRunEventWriterTokenExchangeError) {
-      throw error;
-    }
-    throw new HostedChildRunEventWriterTokenExchangeError();
+    if (error instanceof HostedChildRunEventWriterTokenExchangeError) throw error;
+    throw new HostedChildRunEventWriterTokenExchangeError(
+      abortSignal?.aborted ? "aborted" : "failed",
+    );
   }
+}
+
+/** Create an exact-run capability while keeping its credential in module-private state. */
+export function createHostedRunEventWriterCapability(input: {
+  apiUrl: string;
+  runId: string;
+  runEventAppendToken: string;
+  timeoutMs?: number;
+  fetch?: Fetch;
+}): HostedRunEventWriterCapability {
+  const state: CapabilityState = {
+    apiUrl: input.apiUrl,
+    runId: input.runId,
+    runEventAppendToken: input.runEventAppendToken,
+    timeoutMs: input.timeoutMs ?? DEFAULT_CHILD_RUN_EVENT_WRITER_TOKEN_TIMEOUT_MS,
+    fetch: input.fetch ?? globalThis.fetch,
+  };
+  const capability = Object.create(null) as HostedRunEventWriterCapability;
+  Object.defineProperty(capability, "mintChildRunEventAppendToken", {
+    enumerable: false,
+    value: async (childRunId: string, abortSignal?: AbortSignal) => {
+      const childToken = await exchangeChildRunEventWriterToken(state, childRunId, abortSignal);
+      return createHostedRunEventWriterCapability({
+        apiUrl: state.apiUrl,
+        runId: childRunId,
+        runEventAppendToken: childToken,
+        timeoutMs: state.timeoutMs,
+        fetch: state.fetch,
+      });
+    },
+  });
+  capabilityState.set(capability, state);
+  return Object.freeze(capability);
+}
+
+/** Build a durable mirror from private capability state without exposing its credential. */
+export function createHostedConversationRunChunkMirrorFromCapability(
+  capability: HostedRunEventWriterCapability | undefined,
+  input: Omit<HostedConversationRunChunkMirrorOptions, "authToken">,
+): ConversationRunChunkMirror | undefined {
+  if (!capability) return undefined;
+  const state = capabilityState.get(capability);
+  if (!state) return undefined;
+  return createHostedConversationRunChunkMirror({ ...input, authToken: state.runEventAppendToken });
+}
+
+/** Return the capability installed only while internal tool closures are assembled. */
+export function getActiveHostedRunEventWriterCapability():
+  | HostedRunEventWriterCapability
+  | undefined {
+  return capabilityStorage.getStore();
+}
+
+/** Assemble internal child tools while privately binding their exact-run authority. */
+export function runWithHostedRunEventWriterCapability<T>(
+  capability: HostedRunEventWriterCapability | undefined,
+  operation: () => T,
+): T {
+  return capability ? capabilityStorage.run(capability, operation) : operation();
 }

--- a/src/agent/hosted/child-run-event-writer-token.ts
+++ b/src/agent/hosted/child-run-event-writer-token.ts
@@ -1,0 +1,90 @@
+const DEFAULT_CHILD_RUN_EVENT_WRITER_TOKEN_TIMEOUT_MS = 10_000;
+const CHILD_RUN_EVENT_WRITER_TOKEN_SETUP_ERROR =
+  "Unable to initialize durable child event persistence";
+
+type Fetch = typeof globalThis.fetch;
+
+/** Internal failure raised when the control plane cannot issue an exact-child writer token. */
+export class HostedChildRunEventWriterTokenExchangeError extends Error {
+  constructor() {
+    super(CHILD_RUN_EVENT_WRITER_TOKEN_SETUP_ERROR);
+    this.name = "HostedChildRunEventWriterTokenExchangeError";
+  }
+}
+
+/** Internal input for exchanging an active parent writer token for an exact-child token. */
+export interface ExchangeHostedChildRunEventWriterTokenInput {
+  apiUrl: string;
+  parentRunId: string;
+  childRunId: string;
+  runEventAppendToken: string;
+  abortSignal?: AbortSignal;
+  timeoutMs?: number;
+  fetch?: Fetch;
+}
+
+function isNoStoreResponse(response: Response): boolean {
+  return response.headers.get("Cache-Control")?.split(",").some((directive) =>
+    directive.trim().toLowerCase() === "no-store"
+  ) ?? false;
+}
+
+function parseRunEventToken(value: unknown): string {
+  if (
+    typeof value !== "object" || value === null || Array.isArray(value) ||
+    Object.keys(value).length !== 1 ||
+    !Object.prototype.hasOwnProperty.call(value, "run_event_token")
+  ) {
+    throw new HostedChildRunEventWriterTokenExchangeError();
+  }
+
+  const token = (value as { run_event_token?: unknown }).run_event_token;
+  if (typeof token !== "string" || token.length === 0 || token.trim() !== token) {
+    throw new HostedChildRunEventWriterTokenExchangeError();
+  }
+
+  return token;
+}
+
+/** Exchange a verified active-parent credential for an exact-child event writer credential. */
+export async function exchangeHostedChildRunEventWriterToken(
+  input: ExchangeHostedChildRunEventWriterTokenInput,
+): Promise<string> {
+  const timeoutSignal = AbortSignal.timeout(
+    input.timeoutMs ?? DEFAULT_CHILD_RUN_EVENT_WRITER_TOKEN_TIMEOUT_MS,
+  );
+  const signal = input.abortSignal
+    ? AbortSignal.any([input.abortSignal, timeoutSignal])
+    : timeoutSignal;
+  const fetch = input.fetch ?? globalThis.fetch;
+  const url = new URL(
+    `/runs/${encodeURIComponent(input.parentRunId)}/children/${
+      encodeURIComponent(input.childRunId)
+    }/event-writer-token`,
+    input.apiUrl,
+  );
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${input.runEventAppendToken}`,
+        "Cache-Control": "no-store",
+      },
+      cache: "no-store",
+      signal,
+    });
+
+    if (!response.ok || !isNoStoreResponse(response)) {
+      throw new HostedChildRunEventWriterTokenExchangeError();
+    }
+
+    return parseRunEventToken(await response.json());
+  } catch (error) {
+    if (error instanceof HostedChildRunEventWriterTokenExchangeError) {
+      throw error;
+    }
+    throw new HostedChildRunEventWriterTokenExchangeError();
+  }
+}

--- a/src/agent/hosted/child-run-event-writer-token.ts
+++ b/src/agent/hosted/child-run-event-writer-token.ts
@@ -38,8 +38,13 @@ type CapabilityState = {
   fetch: Fetch;
 };
 
+type VerifiedRequestWriterState = {
+  token: string;
+  sanitizedRequest: Request;
+};
+
 const capabilityState = new WeakMap<HostedRunEventWriterCapability, CapabilityState>();
-const requestRunEventWriterTokens = new WeakMap<object, string>();
+const requestRunEventWriterState = new WeakMap<object, VerifiedRequestWriterState>();
 const capabilityStorage = new AsyncLocalStorage<HostedRunEventWriterCapability | undefined>();
 
 function isNoStoreResponse(response: Response): boolean {
@@ -124,9 +129,21 @@ async function exchangeChildRunEventWriterToken(
   }
 }
 
-/** Retain a verified ingress credential without adding it to the parsed request contract. */
-export function registerHostedRunEventWriterToken(request: object, token: string): void {
-  requestRunEventWriterTokens.set(request, token);
+/** Retain verified ingress authority without adding it to the parsed request contract. */
+export function registerHostedRunEventWriterToken(
+  request: object,
+  token: string,
+  sanitizedRequest: Request,
+): void {
+  requestRunEventWriterState.set(request, { token, sanitizedRequest });
+}
+
+/** Return the credential-free request associated with a verified parsed request. */
+export function getSanitizedHostedRunEventWriterRequest(
+  request: object,
+  fallback: Request,
+): Request {
+  return requestRunEventWriterState.get(request)?.sanitizedRequest ?? fallback;
 }
 
 /** Create the opaque exact-run capability associated with a verified parsed request. */
@@ -134,7 +151,7 @@ export function createHostedRunEventWriterCapabilityForRequest(
   request: object,
   input: Omit<Parameters<typeof createHostedRunEventWriterCapability>[0], "runEventAppendToken">,
 ): HostedRunEventWriterCapability | undefined {
-  const token = requestRunEventWriterTokens.get(request);
+  const token = requestRunEventWriterState.get(request)?.token;
   return token
     ? createHostedRunEventWriterCapability({ ...input, runEventAppendToken: token })
     : undefined;

--- a/src/agent/hosted/child-run-event-writer-token.ts
+++ b/src/agent/hosted/child-run-event-writer-token.ts
@@ -1,5 +1,9 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import {
+  createVeryfrontApiRequestUrlResolver,
+  type VeryfrontApiRequestUrlResolver,
+} from "#veryfront/platform/adapters/veryfront-api-url.ts";
+import {
   type ConversationRunChunkMirror,
   createHostedConversationRunChunkMirror,
   type HostedConversationRunChunkMirrorOptions,
@@ -32,6 +36,7 @@ export interface HostedRunEventWriterCapability {
 
 type CapabilityState = {
   apiUrl: string;
+  resolveApiUrl: VeryfrontApiRequestUrlResolver;
   runId: string;
   runEventAppendToken: string;
   timeoutMs: number;
@@ -89,11 +94,10 @@ async function exchangeChildRunEventWriterToken(
     abortSignal?.addEventListener("abort", onAbort, { once: true });
   }
   const timeoutId = setTimeout(() => cancel("timeout"), state.timeoutMs);
-  const url = new URL(
+  const url = state.resolveApiUrl(
     `/runs/${encodeURIComponent(state.runId)}/children/${
       encodeURIComponent(childRunId)
     }/event-writer-token`,
-    state.apiUrl,
   );
 
   try {
@@ -167,6 +171,7 @@ export function createHostedRunEventWriterCapability(input: {
 }): HostedRunEventWriterCapability {
   const state: CapabilityState = {
     apiUrl: input.apiUrl,
+    resolveApiUrl: createVeryfrontApiRequestUrlResolver(input.apiUrl),
     runId: input.runId,
     runEventAppendToken: input.runEventAppendToken,
     timeoutMs: input.timeoutMs ?? DEFAULT_CHILD_RUN_EVENT_WRITER_TOKEN_TIMEOUT_MS,

--- a/src/agent/hosted/child-run-event-writer-token.ts
+++ b/src/agent/hosted/child-run-event-writer-token.ts
@@ -13,9 +13,9 @@ type Fetch = typeof globalThis.fetch;
 
 /** Internal failure raised when the control plane cannot issue an exact-child writer token. */
 export class HostedChildRunEventWriterTokenExchangeError extends Error {
-  readonly classification: "aborted" | "failed";
+  readonly classification: "aborted" | "timeout" | "failed";
 
-  constructor(classification: "aborted" | "failed" = "failed") {
+  constructor(classification: "aborted" | "timeout" | "failed" = "failed") {
     super(CHILD_RUN_EVENT_WRITER_TOKEN_SETUP_ERROR);
     this.name = "HostedChildRunEventWriterTokenExchangeError";
     this.classification = classification;
@@ -39,6 +39,7 @@ type CapabilityState = {
 };
 
 const capabilityState = new WeakMap<HostedRunEventWriterCapability, CapabilityState>();
+const requestRunEventWriterTokens = new WeakMap<object, string>();
 const capabilityStorage = new AsyncLocalStorage<HostedRunEventWriterCapability>();
 
 function isNoStoreResponse(response: Response): boolean {
@@ -69,8 +70,20 @@ async function exchangeChildRunEventWriterToken(
   childRunId: string,
   abortSignal?: AbortSignal,
 ): Promise<string> {
-  const timeoutSignal = AbortSignal.timeout(state.timeoutMs);
-  const signal = abortSignal ? AbortSignal.any([abortSignal, timeoutSignal]) : timeoutSignal;
+  const controller = new AbortController();
+  let cancellation: "aborted" | "timeout" | undefined;
+  const cancel = (classification: "aborted" | "timeout") => {
+    if (controller.signal.aborted) return;
+    cancellation = classification;
+    controller.abort();
+  };
+  const onAbort = () => cancel("aborted");
+  if (abortSignal?.aborted) {
+    cancel("aborted");
+  } else {
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+  }
+  const timeoutId = setTimeout(() => cancel("timeout"), state.timeoutMs);
   const url = new URL(
     `/runs/${encodeURIComponent(state.runId)}/children/${
       encodeURIComponent(childRunId)
@@ -87,20 +100,44 @@ async function exchangeChildRunEventWriterToken(
         "Cache-Control": "no-store",
       },
       cache: "no-store",
-      signal,
+      signal: controller.signal,
     });
+    if (cancellation) {
+      throw new HostedChildRunEventWriterTokenExchangeError(cancellation);
+    }
 
     if (!response.ok || !isNoStoreResponse(response)) {
       throw new HostedChildRunEventWriterTokenExchangeError();
     }
 
-    return parseRunEventToken(await response.json());
+    const token = parseRunEventToken(await response.json());
+    if (cancellation) {
+      throw new HostedChildRunEventWriterTokenExchangeError(cancellation);
+    }
+    return token;
   } catch (error) {
     if (error instanceof HostedChildRunEventWriterTokenExchangeError) throw error;
-    throw new HostedChildRunEventWriterTokenExchangeError(
-      abortSignal?.aborted ? "aborted" : "failed",
-    );
+    throw new HostedChildRunEventWriterTokenExchangeError(cancellation ?? "failed");
+  } finally {
+    clearTimeout(timeoutId);
+    abortSignal?.removeEventListener("abort", onAbort);
   }
+}
+
+/** Retain a verified ingress credential without adding it to the parsed request contract. */
+export function registerHostedRunEventWriterToken(request: object, token: string): void {
+  requestRunEventWriterTokens.set(request, token);
+}
+
+/** Create the opaque exact-run capability associated with a verified parsed request. */
+export function createHostedRunEventWriterCapabilityForRequest(
+  request: object,
+  input: Omit<Parameters<typeof createHostedRunEventWriterCapability>[0], "runEventAppendToken">,
+): HostedRunEventWriterCapability | undefined {
+  const token = requestRunEventWriterTokens.get(request);
+  return token
+    ? createHostedRunEventWriterCapability({ ...input, runEventAppendToken: token })
+    : undefined;
 }
 
 /** Create an exact-run capability while keeping its credential in module-private state. */

--- a/src/agent/hosted/child-run-event-writer-token.ts
+++ b/src/agent/hosted/child-run-event-writer-token.ts
@@ -40,7 +40,7 @@ type CapabilityState = {
 
 const capabilityState = new WeakMap<HostedRunEventWriterCapability, CapabilityState>();
 const requestRunEventWriterTokens = new WeakMap<object, string>();
-const capabilityStorage = new AsyncLocalStorage<HostedRunEventWriterCapability>();
+const capabilityStorage = new AsyncLocalStorage<HostedRunEventWriterCapability | undefined>();
 
 function isNoStoreResponse(response: Response): boolean {
   return response.headers.get("Cache-Control")?.split(",").some((directive) =>
@@ -196,5 +196,5 @@ export function runWithHostedRunEventWriterCapability<T>(
   capability: HostedRunEventWriterCapability | undefined,
   operation: () => T,
 ): T {
-  return capability ? capabilityStorage.run(capability, operation) : operation();
+  return capabilityStorage.run(capability, operation);
 }

--- a/src/agent/hosted/cloud-agent-chat-execution.ts
+++ b/src/agent/hosted/cloud-agent-chat-execution.ts
@@ -64,6 +64,10 @@ import {
   setFilteredTraceAttributes,
 } from "./cloud-agent-child-tools.ts";
 import { getServerResolvedToolExposureCheckpoint } from "./runtime-request-config.ts";
+import {
+  createHostedRunEventWriterCapability,
+  type HostedRunEventWriterCapability,
+} from "./child-run-event-writer-token.ts";
 
 const DEFAULT_FORWARDED_CONFIG_NAMESPACE = "veryfront";
 const DEFAULT_PROJECT_NAVIGATION_TOOL_NAMES = ["studio_open_project"];
@@ -135,6 +139,7 @@ export function createProjectSteeringRefresh(context: NodeVeryfrontCloudAgentSer
 export function createAgentRuntime(
   context: NodeVeryfrontCloudAgentServiceContext,
   options: DefaultHostedChatRuntimeCreationOptions,
+  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<HostedChatRuntimeCreationResult> {
   const config = context.infrastructure.getConfig();
   const projectRuntime = getProjectAgentRuntime(context);
@@ -192,7 +197,7 @@ export function createAgentRuntime(
       setAttributes: (attributes) => setFilteredTraceAttributes(context, attributes),
     },
     logger: context.infrastructure.logger,
-  });
+  }, runEventWriterCapability);
 }
 
 function setPrepareChatExecutionStartAttributes(
@@ -347,11 +352,19 @@ export async function prepareChatExecutionWithinProjectRuntime(
       abortController.signal,
     ),
     createRuntime: (creationOptions) =>
-      context.trace("chat.createRuntime", () =>
-        createAgentRuntime(context, {
+      context.trace("chat.createRuntime", () => {
+        const runEventWriterCapability = req.runEventAppendToken && creationOptions.runId
+          ? createHostedRunEventWriterCapability({
+            apiUrl: config.VERYFRONT_API_URL,
+            runId: creationOptions.runId,
+            runEventAppendToken: req.runEventAppendToken,
+          })
+          : undefined;
+        return createAgentRuntime(context, {
           ...creationOptions,
           userId: req.userId,
-        })),
+        }, runEventWriterCapability);
+      }),
   });
 
   setPrepareChatExecutionResultAttributes(context, {

--- a/src/agent/hosted/cloud-agent-chat-execution.ts
+++ b/src/agent/hosted/cloud-agent-chat-execution.ts
@@ -64,10 +64,6 @@ import {
   setFilteredTraceAttributes,
 } from "./cloud-agent-child-tools.ts";
 import { getServerResolvedToolExposureCheckpoint } from "./runtime-request-config.ts";
-import {
-  createHostedRunEventWriterCapability,
-  type HostedRunEventWriterCapability,
-} from "./child-run-event-writer-token.ts";
 
 const DEFAULT_FORWARDED_CONFIG_NAMESPACE = "veryfront";
 const DEFAULT_PROJECT_NAVIGATION_TOOL_NAMES = ["studio_open_project"];
@@ -139,7 +135,6 @@ export function createProjectSteeringRefresh(context: NodeVeryfrontCloudAgentSer
 export function createAgentRuntime(
   context: NodeVeryfrontCloudAgentServiceContext,
   options: DefaultHostedChatRuntimeCreationOptions,
-  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<HostedChatRuntimeCreationResult> {
   const config = context.infrastructure.getConfig();
   const projectRuntime = getProjectAgentRuntime(context);
@@ -197,7 +192,7 @@ export function createAgentRuntime(
       setAttributes: (attributes) => setFilteredTraceAttributes(context, attributes),
     },
     logger: context.infrastructure.logger,
-  }, runEventWriterCapability);
+  });
 }
 
 function setPrepareChatExecutionStartAttributes(
@@ -353,17 +348,10 @@ export async function prepareChatExecutionWithinProjectRuntime(
     ),
     createRuntime: (creationOptions) =>
       context.trace("chat.createRuntime", () => {
-        const runEventWriterCapability = req.runEventAppendToken && creationOptions.runId
-          ? createHostedRunEventWriterCapability({
-            apiUrl: config.VERYFRONT_API_URL,
-            runId: creationOptions.runId,
-            runEventAppendToken: req.runEventAppendToken,
-          })
-          : undefined;
         return createAgentRuntime(context, {
           ...creationOptions,
           userId: req.userId,
-        }, runEventWriterCapability);
+        });
       }),
   });
 

--- a/src/agent/hosted/default-chat-runtime.test.ts
+++ b/src/agent/hosted/default-chat-runtime.test.ts
@@ -20,6 +20,7 @@ import { buildVeryfrontCloudRuntimeInstructions } from "./cloud-runtime-system-m
 import {
   createHostedRunEventWriterCapability,
   getActiveHostedRunEventWriterCapability,
+  runWithHostedRunEventWriterCapability,
 } from "./child-run-event-writer-token.ts";
 
 const unrestrictedSourceIntegrationPolicy = {
@@ -88,37 +89,41 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
     runEventAppendToken: "root-writer-token",
   });
 
-  const runtime = await createDefaultHostedChatRuntime({
-    sourceIntegrationPolicy: unrestrictedSourceIntegrationPolicy,
-    options: {
-      projectId: "project-1",
-      branchId: "branch-1",
-      authToken: "token-1",
-      instructions: "Base instructions",
-      model: "sonnet",
-      allowedTools: ["sleep"],
-      conversationId: "conversation-1",
-      userId: "user-1",
-      parentRunId: "run-1",
-      parentMessageId: "message-1",
-      submittedFormInputResult: {
-        values: { topic: "Support FAQ assistant" },
-        inputRequestId: "input-request-1",
-      },
-    },
-    config: {
-      apiUrl: "https://api.example.com",
-      apiMcpUrl: "https://api.example.com/mcp",
-      studioMcpUrl: "https://studio.example.com/mcp",
-    },
-    buildLocalTools: (taskContext) => {
-      capturedContext = taskContext;
-      capturedCapability = getActiveHostedRunEventWriterCapability();
-      return { sleep: localTool("Sleep") };
-    },
-    createRemoteToolSource: emptyRemoteSource,
-    preloadLatestConversationUserText: false,
-  }, runEventWriterCapability);
+  const runtime = await runWithHostedRunEventWriterCapability(
+    runEventWriterCapability,
+    () =>
+      createDefaultHostedChatRuntime({
+        sourceIntegrationPolicy: unrestrictedSourceIntegrationPolicy,
+        options: {
+          projectId: "project-1",
+          branchId: "branch-1",
+          authToken: "token-1",
+          instructions: "Base instructions",
+          model: "sonnet",
+          allowedTools: ["sleep"],
+          conversationId: "conversation-1",
+          userId: "user-1",
+          parentRunId: "run-1",
+          parentMessageId: "message-1",
+          submittedFormInputResult: {
+            values: { topic: "Support FAQ assistant" },
+            inputRequestId: "input-request-1",
+          },
+        },
+        config: {
+          apiUrl: "https://api.example.com",
+          apiMcpUrl: "https://api.example.com/mcp",
+          studioMcpUrl: "https://studio.example.com/mcp",
+        },
+        buildLocalTools: (taskContext) => {
+          capturedContext = taskContext;
+          capturedCapability = getActiveHostedRunEventWriterCapability();
+          return { sleep: localTool("Sleep") };
+        },
+        createRemoteToolSource: emptyRemoteSource,
+        preloadLatestConversationUserText: false,
+      }),
+  );
 
   assertEquals(runtime.runtimeKind, "framework");
   assertEquals(runtime.modelId, "anthropic/claude-sonnet-4-6");

--- a/src/agent/hosted/default-chat-runtime.test.ts
+++ b/src/agent/hosted/default-chat-runtime.test.ts
@@ -84,6 +84,7 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
       projectId: "project-1",
       branchId: "branch-1",
       authToken: "token-1",
+      runEventAppendToken: "root-writer-token",
       instructions: "Base instructions",
       model: "sonnet",
       allowedTools: ["sleep"],
@@ -115,6 +116,7 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
   assertEquals(capturedContext.projectId, "project-1");
   assertEquals(capturedContext.branchId, "branch-1");
   assertEquals(capturedContext.model, "anthropic/claude-sonnet-4-6");
+  assertEquals(capturedContext.runEventAppendToken, "root-writer-token");
   assertEquals(capturedContext.userId, "user-1");
   assertEquals(capturedContext.submittedFormInputResult, {
     values: { topic: "Support FAQ assistant" },

--- a/src/agent/hosted/default-chat-runtime.test.ts
+++ b/src/agent/hosted/default-chat-runtime.test.ts
@@ -17,6 +17,10 @@ import {
 } from "./default-chat-runtime.ts";
 import { prepareHostedChatRuntimeCreationOptions } from "./chat-preparation.ts";
 import { buildVeryfrontCloudRuntimeInstructions } from "./cloud-runtime-system-messages.ts";
+import {
+  createHostedRunEventWriterCapability,
+  getActiveHostedRunEventWriterCapability,
+} from "./child-run-event-writer-token.ts";
 
 const unrestrictedSourceIntegrationPolicy = {
   schemaVersion: 1,
@@ -77,6 +81,12 @@ function restoreEnv(key: string, value: string | undefined): void {
 
 Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime", async () => {
   let capturedContext: DefaultHostedChatRuntimeTaskContext | undefined;
+  let capturedCapability: unknown;
+  const runEventWriterCapability = createHostedRunEventWriterCapability({
+    apiUrl: "https://api.example.com",
+    runId: "run-1",
+    runEventAppendToken: "root-writer-token",
+  });
 
   const runtime = await createDefaultHostedChatRuntime({
     sourceIntegrationPolicy: unrestrictedSourceIntegrationPolicy,
@@ -84,7 +94,6 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
       projectId: "project-1",
       branchId: "branch-1",
       authToken: "token-1",
-      runEventAppendToken: "root-writer-token",
       instructions: "Base instructions",
       model: "sonnet",
       allowedTools: ["sleep"],
@@ -104,11 +113,12 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
     },
     buildLocalTools: (taskContext) => {
       capturedContext = taskContext;
+      capturedCapability = getActiveHostedRunEventWriterCapability();
       return { sleep: localTool("Sleep") };
     },
     createRemoteToolSource: emptyRemoteSource,
     preloadLatestConversationUserText: false,
-  });
+  }, runEventWriterCapability);
 
   assertEquals(runtime.runtimeKind, "framework");
   assertEquals(runtime.modelId, "anthropic/claude-sonnet-4-6");
@@ -116,7 +126,10 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
   assertEquals(capturedContext.projectId, "project-1");
   assertEquals(capturedContext.branchId, "branch-1");
   assertEquals(capturedContext.model, "anthropic/claude-sonnet-4-6");
-  assertEquals(capturedContext.runEventAppendToken, "root-writer-token");
+  assertEquals("runEventAppendToken" in capturedContext, false);
+  assertEquals("runEventWriterCapability" in capturedContext, false);
+  assertEquals(JSON.stringify(capturedContext).includes("root-writer-token"), false);
+  assertEquals(capturedCapability, runEventWriterCapability);
   assertEquals(capturedContext.userId, "user-1");
   assertEquals(capturedContext.submittedFormInputResult, {
     values: { topic: "Support FAQ assistant" },

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -29,6 +29,10 @@ import type {
   HostedChatRuntimeCreationResult,
 } from "./chat-runtime-contract.ts";
 import {
+  type HostedRunEventWriterCapability,
+  runWithHostedRunEventWriterCapability,
+} from "./child-run-event-writer-token.ts";
+import {
   type HostedChatRuntimeToolAssemblyResult,
   type HostedHostToolPolicy,
   prepareHostedChatRuntimeToolAssembly,
@@ -76,8 +80,6 @@ export type DefaultHostedChatRuntimeCreationOptions =
 /** Context for default hosted chat runtime task. */
 export type DefaultHostedChatRuntimeTaskContext = HostedRuntimeStateResolverContext & {
   authToken: string;
-  /** @internal Active exact-run credential inherited only by durable child setup. */
-  runEventAppendToken?: string;
   runId?: string;
   agentId?: string;
   projectId: string;
@@ -161,7 +163,6 @@ function createDefaultTaskContext(
 ): DefaultHostedChatRuntimeTaskContext {
   return {
     authToken: input.options.authToken,
-    runEventAppendToken: input.options.runEventAppendToken,
     runId: input.options.runId,
     agentId: input.options.agentId,
     projectId: input.options.projectId ?? "",
@@ -371,6 +372,7 @@ function runWithDefaultHostedRequestContext<TResult>(
 /** Create default hosted chat runtime. */
 export async function createDefaultHostedChatRuntime(
   input: CreateDefaultHostedChatRuntimeOptions,
+  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<HostedChatRuntimeCreationResult> {
   return await runWithEffectiveSourceIntegrationPolicy(
     input.sourceIntegrationPolicy,
@@ -386,10 +388,10 @@ export async function createDefaultHostedChatRuntime(
       const cleanup = input.cleanup ?? (() => Promise.resolve());
 
       try {
-        const toolAssembly = await buildToolAssembly({
-          ...input,
-          taskContext,
-        });
+        const toolAssembly = await runWithHostedRunEventWriterCapability(
+          runEventWriterCapability,
+          () => buildToolAssembly({ ...input, taskContext }),
+        );
         const runtimeAgentConfig = createRuntimeAgentConfig({
           options: input.options,
           taskContext,

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -29,7 +29,7 @@ import type {
   HostedChatRuntimeCreationResult,
 } from "./chat-runtime-contract.ts";
 import {
-  type HostedRunEventWriterCapability,
+  getActiveHostedRunEventWriterCapability,
   runWithHostedRunEventWriterCapability,
 } from "./child-run-event-writer-token.ts";
 import {
@@ -372,8 +372,8 @@ function runWithDefaultHostedRequestContext<TResult>(
 /** Create default hosted chat runtime. */
 export async function createDefaultHostedChatRuntime(
   input: CreateDefaultHostedChatRuntimeOptions,
-  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<HostedChatRuntimeCreationResult> {
+  const effectiveRunEventWriterCapability = getActiveHostedRunEventWriterCapability();
   return await runWithEffectiveSourceIntegrationPolicy(
     input.sourceIntegrationPolicy,
     async () => {
@@ -389,7 +389,7 @@ export async function createDefaultHostedChatRuntime(
 
       try {
         const toolAssembly = await runWithHostedRunEventWriterCapability(
-          runEventWriterCapability,
+          effectiveRunEventWriterCapability,
           () => buildToolAssembly({ ...input, taskContext }),
         );
         const runtimeAgentConfig = createRuntimeAgentConfig({

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -76,6 +76,8 @@ export type DefaultHostedChatRuntimeCreationOptions =
 /** Context for default hosted chat runtime task. */
 export type DefaultHostedChatRuntimeTaskContext = HostedRuntimeStateResolverContext & {
   authToken: string;
+  /** @internal Active exact-run credential inherited only by durable child setup. */
+  runEventAppendToken?: string;
   runId?: string;
   agentId?: string;
   projectId: string;
@@ -159,6 +161,7 @@ function createDefaultTaskContext(
 ): DefaultHostedChatRuntimeTaskContext {
   return {
     authToken: input.options.authToken,
+    runEventAppendToken: input.options.runEventAppendToken,
     runId: input.options.runId,
     agentId: input.options.agentId,
     projectId: input.options.projectId ?? "",

--- a/src/agent/hosted/default-invoke-agent-tool.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.ts
@@ -422,7 +422,6 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
     childConfig?: DefaultHostedChildAgentExecutionConfig;
     onSettled?: (snapshot: ChildRunExecutionSnapshot) => void | Promise<void>;
     durableChildRun?: HostedChildRunIdentifiers;
-    runEventWriterCapability?: HostedRunEventWriterCapability;
   },
 ): Promise<ChildRunExecutionResult> {
   const baseConfig = options.getConfig();
@@ -479,20 +478,16 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
       });
     },
     prepareToolAssembly: ({ runtimeConfig, requestedTools, abortSignal }) =>
-      runWithHostedRunEventWriterCapability(
-        runtimeOptions.runEventWriterCapability,
-        () =>
-          prepareForkToolAssembly(scopedOptions, config, {
-            childAgentId: runtimeOptions.childAgentId,
-            childConfig: runtimeOptions.childConfig,
-            provider: runtimeConfig.provider,
-            forkModel: runtimeConfig.forkModel,
-            effectivePrompt: runtimeConfig.effectivePrompt,
-            requestedTools,
-            abortSignal,
-            durableChildRun: runtimeOptions.durableChildRun,
-          }),
-      ),
+      prepareForkToolAssembly(scopedOptions, config, {
+        childAgentId: runtimeOptions.childAgentId,
+        childConfig: runtimeOptions.childConfig,
+        provider: runtimeConfig.provider,
+        forkModel: runtimeConfig.forkModel,
+        effectivePrompt: runtimeConfig.effectivePrompt,
+        requestedTools,
+        abortSignal,
+        durableChildRun: runtimeOptions.durableChildRun,
+      }),
     resolveProviderOptions: options.resolveProviderOptions,
     resolveReasoning: options.resolveReasoning,
     forkContext: scopedOptions.context,
@@ -526,7 +521,7 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
     shouldRethrowError: options.shouldRethrowError,
     instrumentation,
     sourceIntegrationPolicy: execution.sourceIntegrationPolicy,
-  }, runtimeOptions.runEventWriterCapability);
+  });
 }
 
 function getToolCallId(executionContext?: ToolExecutionContext): string {
@@ -580,200 +575,218 @@ export async function executeDefaultHostedInvokeAgentTool<
   input: DefaultHostedInvokeAgentInput,
   childAgentId: string,
   executionContext?: ToolExecutionContext,
-  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<DefaultHostedInvokeAgentToolResult> {
-  let executionSnapshot: ChildRunExecutionSnapshot | null = null;
-  const config = options.getConfig();
-  const toolCallId = getToolCallId(executionContext);
-  const abortSignal = getAbortSignal(executionContext);
-  const requestedProjectReference = input.project_reference;
-  let targetProjectId = options.context.projectId;
-  let resolvedInput = input;
-  if (requestedProjectReference) {
-    const resolver = options.resolveProjectReference ?? resolveHostedProjectReference;
-    const resolvedProject = await resolver({
-      projectReference: requestedProjectReference,
-      authToken: options.context.authToken,
-      apiUrl: config.apiUrl,
-      abortSignal,
-    });
-    targetProjectId = resolvedProject.projectId;
-    await applyRequestedProjectId(options, targetProjectId);
-    resolvedInput = {
-      ...input,
-      project_reference: undefined,
-    };
-  }
-  const childConfig = await options.resolveChildAgentExecutionConfig?.(
+  return await executeDefaultHostedInvokeAgentToolWithCapability(
+    options,
+    input,
     childAgentId,
-    targetProjectId,
+    executionContext,
+    getActiveHostedRunEventWriterCapability(),
   );
-  const sourceIntegrationPolicy = getRuntimeSourceIntegrationPolicyFromContext(executionContext);
-  const configuredInput = applyChildAgentExecutionConfig(resolvedInput, childConfig);
-  const forkInput = configuredInput;
-  const durableInvokeRecorder = createHostedDurableChildInvokeTraceRecorder({
-    traceBase: {
-      conversationId: options.context.conversationId,
-      projectId: options.context.projectId,
-      runId: options.context.parentRunId,
-      toolCallId,
-      childAgentId,
-    },
-    executionFailedCode: "INVOKE_AGENT_FAILED",
-    setTraceAttributes: options.setTraceAttributes,
-  });
+}
 
-  const executeLocalInvoke = (runtimeOptions: HostedDurableChildExecutionOptions = {}) =>
-    executeForkTask(
-      options,
-      forkInput,
-      {
-        toolCallId,
+async function executeDefaultHostedInvokeAgentToolWithCapability<
+  TContext extends DefaultHostedInvokeAgentContext,
+>(
+  options: DefaultHostedInvokeAgentToolOptions<TContext>,
+  input: DefaultHostedInvokeAgentInput,
+  childAgentId: string,
+  executionContext: ToolExecutionContext | undefined,
+  runEventWriterCapability: HostedRunEventWriterCapability | undefined,
+): Promise<DefaultHostedInvokeAgentToolResult> {
+  return await runWithHostedRunEventWriterCapability(runEventWriterCapability, async () => {
+    let executionSnapshot: ChildRunExecutionSnapshot | null = null;
+    const config = options.getConfig();
+    const toolCallId = getToolCallId(executionContext);
+    const abortSignal = getAbortSignal(executionContext);
+    const requestedProjectReference = input.project_reference;
+    let targetProjectId = options.context.projectId;
+    let resolvedInput = input;
+    if (requestedProjectReference) {
+      const resolver = options.resolveProjectReference ?? resolveHostedProjectReference;
+      const resolvedProject = await resolver({
+        projectReference: requestedProjectReference,
+        authToken: options.context.authToken,
+        apiUrl: config.apiUrl,
         abortSignal,
-        sourceIntegrationPolicy,
-      },
-      {
-        childAgentId,
-        childConfig,
-        onSettled: (snapshot) => {
-          executionSnapshot = snapshot;
-        },
-        durableChildRun: runtimeOptions.durableChildRun,
-        runEventWriterCapability: runtimeOptions.runEventWriterCapability,
-      },
+      });
+      targetProjectId = resolvedProject.projectId;
+      await applyRequestedProjectId(options, targetProjectId);
+      resolvedInput = {
+        ...input,
+        project_reference: undefined,
+      };
+    }
+    const childConfig = await options.resolveChildAgentExecutionConfig?.(
+      childAgentId,
+      targetProjectId,
     );
-
-  durableInvokeRecorder.annotate();
-
-  if (!config.enableDurableInvokeAgent && !options.requireDurableInvokeAgent) {
-    return executeHostedLocalChildInvoke({
-      forkInput,
-      abortSignal,
-      traceRecorder: durableInvokeRecorder,
-      execute: executeLocalInvoke,
-      getExecutionSnapshot: () => executionSnapshot,
-      resultMode: input.result_mode,
-    });
-  }
-
-  executionSnapshot = null;
-
-  try {
-    return await executeHostedDurableChildFork<
-      HostedDurableChildInvokeResult,
-      ChildRunExecutionResult
-    >({
-      authToken: options.context.authToken,
-      runEventWriterCapability,
-      apiUrl: config.apiUrl,
-      forkInput,
-      executionOptions: {
+    const sourceIntegrationPolicy = getRuntimeSourceIntegrationPolicyFromContext(executionContext);
+    const configuredInput = applyChildAgentExecutionConfig(resolvedInput, childConfig);
+    const forkInput = configuredInput;
+    const durableInvokeRecorder = createHostedDurableChildInvokeTraceRecorder({
+      traceBase: {
+        conversationId: options.context.conversationId,
+        projectId: options.context.projectId,
+        runId: options.context.parentRunId,
         toolCallId,
-        abortSignal,
+        childAgentId,
       },
-      childAgentId,
-      runProjectId: targetProjectId,
-      parentConversationId: options.context.conversationId,
-      parentRunId: options.context.parentRunId,
-      parentMessageId: options.context.parentMessageId,
-      trustedInvocationContext: options.context.veryfrontInvocationContext,
-      getProjectId: () => options.context.projectId,
-      getRuntimeTargetKind: () => options.context.runtimeTargetKind,
-      getRuntimeTargetEnvironmentId: () => options.context.runtimeTargetEnvironmentId,
-      getBranchId: () => options.context.branchId,
-      getContextModel: () => options.context.model,
-      defaultModel: options.defaultModel ?? DEFAULT_USER_AGENT_MODEL,
-      resolveModelId: options.resolveModelId,
-      resolveProvider: options.resolveProvider,
-      onRequestedProjectId: (projectId) => applyRequestedProjectId(options, projectId),
-      publishParentRunEvents: options.context.publishParentRunEvents,
-      contextUnavailableMessage:
-        "invoke_agent requires durable conversation context when durable child runs are enabled.",
-      setupFailedCode: DURABLE_INVOKE_SETUP_FAILED,
       executionFailedCode: "INVOKE_AGENT_FAILED",
-      executeLocal: executeLocalInvoke,
-      getExecutionSnapshot: () => executionSnapshot,
-      buildContextUnavailableResult: (message) => {
-        durableInvokeRecorder.annotate({
-          status: "failed",
-          terminalErrorCode: DURABLE_INVOKE_CONTEXT_UNAVAILABLE,
-          terminalErrorMessage: message,
-        });
+      setTraceAttributes: options.setTraceAttributes,
+    });
 
-        return buildHostedDurableChildInvokeFailureResult({
-          terminalErrorCode: DURABLE_INVOKE_CONTEXT_UNAVAILABLE,
-          terminalErrorMessage: message,
-        });
-      },
-      buildSetupFailureResult: (failure) => durableInvokeRecorder.recordSetupFailure(failure),
-      buildTerminalFailureResult: (failure) => durableInvokeRecorder.recordTerminalFailure(failure),
-      buildSuccessResult: (success) =>
-        durableInvokeRecorder.recordSuccess(success, { resultMode: input.result_mode }),
-      runtime: {
-        bootstrapChildRun: bootstrapHostedChildRun,
-        createLifecycleAdapter: createConversationChildLifecycleAdapter,
-        runLifecycle: runHostedChildExecutionLifecycle,
-        shouldSkipTerminalPersistence: shouldSkipHostedChildTerminalPersistence,
-      },
-      bootstrap: {
-        runBootstrap: (operation) =>
-          options.trace("invoke_agent.durableChildSetup", async () => {
-            options.setTraceAttributes({
-              "conversation.id": options.context.conversationId,
-              "run.id": options.context.parentRunId,
-              "tool.call.id": toolCallId,
+    const executeLocalInvoke = (runtimeOptions: HostedDurableChildExecutionOptions = {}) =>
+      executeForkTask(
+        options,
+        forkInput,
+        {
+          toolCallId,
+          abortSignal,
+          sourceIntegrationPolicy,
+        },
+        {
+          childAgentId,
+          childConfig,
+          onSettled: (snapshot) => {
+            executionSnapshot = snapshot;
+          },
+          durableChildRun: runtimeOptions.durableChildRun,
+        },
+      );
+
+    durableInvokeRecorder.annotate();
+
+    if (!config.enableDurableInvokeAgent && !options.requireDurableInvokeAgent) {
+      return executeHostedLocalChildInvoke({
+        forkInput,
+        abortSignal,
+        traceRecorder: durableInvokeRecorder,
+        execute: executeLocalInvoke,
+        getExecutionSnapshot: () => executionSnapshot,
+        resultMode: input.result_mode,
+      });
+    }
+
+    executionSnapshot = null;
+
+    try {
+      return await executeHostedDurableChildFork<
+        HostedDurableChildInvokeResult,
+        ChildRunExecutionResult
+      >({
+        authToken: options.context.authToken,
+        apiUrl: config.apiUrl,
+        forkInput,
+        executionOptions: {
+          toolCallId,
+          abortSignal,
+        },
+        childAgentId,
+        runProjectId: targetProjectId,
+        parentConversationId: options.context.conversationId,
+        parentRunId: options.context.parentRunId,
+        parentMessageId: options.context.parentMessageId,
+        trustedInvocationContext: options.context.veryfrontInvocationContext,
+        getProjectId: () => options.context.projectId,
+        getRuntimeTargetKind: () => options.context.runtimeTargetKind,
+        getRuntimeTargetEnvironmentId: () => options.context.runtimeTargetEnvironmentId,
+        getBranchId: () => options.context.branchId,
+        getContextModel: () => options.context.model,
+        defaultModel: options.defaultModel ?? DEFAULT_USER_AGENT_MODEL,
+        resolveModelId: options.resolveModelId,
+        resolveProvider: options.resolveProvider,
+        onRequestedProjectId: (projectId) => applyRequestedProjectId(options, projectId),
+        publishParentRunEvents: options.context.publishParentRunEvents,
+        contextUnavailableMessage:
+          "invoke_agent requires durable conversation context when durable child runs are enabled.",
+        setupFailedCode: DURABLE_INVOKE_SETUP_FAILED,
+        executionFailedCode: "INVOKE_AGENT_FAILED",
+        executeLocal: executeLocalInvoke,
+        getExecutionSnapshot: () => executionSnapshot,
+        buildContextUnavailableResult: (message) => {
+          durableInvokeRecorder.annotate({
+            status: "failed",
+            terminalErrorCode: DURABLE_INVOKE_CONTEXT_UNAVAILABLE,
+            terminalErrorMessage: message,
+          });
+
+          return buildHostedDurableChildInvokeFailureResult({
+            terminalErrorCode: DURABLE_INVOKE_CONTEXT_UNAVAILABLE,
+            terminalErrorMessage: message,
+          });
+        },
+        buildSetupFailureResult: (failure) => durableInvokeRecorder.recordSetupFailure(failure),
+        buildTerminalFailureResult: (failure) =>
+          durableInvokeRecorder.recordTerminalFailure(failure),
+        buildSuccessResult: (success) =>
+          durableInvokeRecorder.recordSuccess(success, { resultMode: input.result_mode }),
+        runtime: {
+          bootstrapChildRun: bootstrapHostedChildRun,
+          createLifecycleAdapter: createConversationChildLifecycleAdapter,
+          runLifecycle: runHostedChildExecutionLifecycle,
+          shouldSkipTerminalPersistence: shouldSkipHostedChildTerminalPersistence,
+        },
+        bootstrap: {
+          runBootstrap: (operation) =>
+            options.trace("invoke_agent.durableChildSetup", async () => {
+              options.setTraceAttributes({
+                "conversation.id": options.context.conversationId,
+                "run.id": options.context.parentRunId,
+                "tool.call.id": toolCallId,
+              });
+
+              return operation();
+            }),
+          onBootstrapStart: (bootstrapContext) => {
+            options.logger.info("Bootstrapping durable child run", {
+              parentConversationId: bootstrapContext.parentConversationId,
+              parentRunId: bootstrapContext.parentRunId,
+              toolCallId,
+              childAgentId,
+              description: input.description,
             });
-
-            return operation();
-          }),
-        onBootstrapStart: (bootstrapContext) => {
-          options.logger.info("Bootstrapping durable child run", {
-            parentConversationId: bootstrapContext.parentConversationId,
-            parentRunId: bootstrapContext.parentRunId,
-            toolCallId,
-            childAgentId,
-            description: input.description,
-          });
+          },
+          onBootstrapComplete: (bootstrapContext) => {
+            options.logger.info("Durable child bootstrap complete", {
+              parentConversationId: bootstrapContext.parentConversationId,
+              childConversationId: bootstrapContext.identifiers.childConversationId,
+              childRunId: bootstrapContext.identifiers.childRunId,
+              childMessageId: bootstrapContext.identifiers.childMessageId,
+              toolCallId,
+            });
+          },
+          onBootstrapError: ({ error, parentConversationId }) => {
+            options.logger.warn("Durable child-run persistence failed", {
+              parentConversationId,
+              toolCallId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          },
         },
-        onBootstrapComplete: (bootstrapContext) => {
-          options.logger.info("Durable child bootstrap complete", {
-            parentConversationId: bootstrapContext.parentConversationId,
-            childConversationId: bootstrapContext.identifiers.childConversationId,
-            childRunId: bootstrapContext.identifiers.childRunId,
-            childMessageId: bootstrapContext.identifiers.childMessageId,
-            toolCallId,
-          });
-        },
-        onBootstrapError: ({ error, parentConversationId }) => {
-          options.logger.warn("Durable child-run persistence failed", {
-            parentConversationId,
+        onLifecycleError: (error) => {
+          options.logger.warn("Durable child lifecycle adapter failed", {
             toolCallId,
             error: error instanceof Error ? error.message : String(error),
           });
         },
-      },
-      onLifecycleError: (error) => {
-        options.logger.warn("Durable child lifecycle adapter failed", {
-          toolCallId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      },
-      onLifecycleFinalized: ({ identifiers, status }) =>
-        options.trace("invoke_agent.durableChildFinalize", async () => {
-          options.setTraceAttributes({
-            "child.conversation.id": identifiers.childConversationId,
-            "child.run.id": identifiers.childRunId,
-            "child.message.id": identifiers.childMessageId,
-            "agent.run.final_status": status,
-          });
-        }),
-    });
-  } catch (error) {
-    durableInvokeRecorder.recordLocalFailure(
-      error instanceof Error ? error.message : String(error),
-    );
-    throw error;
-  }
+        onLifecycleFinalized: ({ identifiers, status }) =>
+          options.trace("invoke_agent.durableChildFinalize", async () => {
+            options.setTraceAttributes({
+              "child.conversation.id": identifiers.childConversationId,
+              "child.run.id": identifiers.childRunId,
+              "child.message.id": identifiers.childMessageId,
+              "agent.run.final_status": status,
+            });
+          }),
+      });
+    } catch (error) {
+      durableInvokeRecorder.recordLocalFailure(
+        error instanceof Error ? error.message : String(error),
+      );
+      throw error;
+    }
+  });
 }
 
 /** Create default hosted invoke agent tool. */
@@ -781,8 +794,8 @@ export function createDefaultHostedInvokeAgentTool<
   TContext extends DefaultHostedInvokeAgentContext,
 >(
   options: DefaultHostedInvokeAgentToolOptions<TContext>,
-  runEventWriterCapability = getActiveHostedRunEventWriterCapability(),
 ) {
+  const runEventWriterCapability = getActiveHostedRunEventWriterCapability();
   return createHostedChildInvokeTool<
     DefaultHostedInvokeAgentInput,
     DefaultHostedInvokeAgentToolResult
@@ -795,7 +808,7 @@ export function createDefaultHostedInvokeAgentTool<
     buildFailureResult: buildHostedDurableChildInvokeFailureResult,
     decorateResult: withRootOwnedChildResultHint,
     execute: (input, executionOptions) =>
-      executeDefaultHostedInvokeAgentTool(
+      executeDefaultHostedInvokeAgentToolWithCapability(
         options,
         input,
         resolveChildAgentId(options, input),

--- a/src/agent/hosted/default-invoke-agent-tool.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.ts
@@ -78,6 +78,8 @@ import {
 /** Context for default hosted invoke agent. */
 export type DefaultHostedInvokeAgentContext = MutableAgentProjectContext & {
   authToken: string;
+  /** @internal Active exact-run credential inherited only by durable child setup. */
+  runEventAppendToken?: string;
   clientProfile?: RuntimeClientProfile | null;
   model?: string;
   conversationId?: string;
@@ -417,6 +419,7 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
     childConfig?: DefaultHostedChildAgentExecutionConfig;
     onSettled?: (snapshot: ChildRunExecutionSnapshot) => void | Promise<void>;
     durableChildRun?: HostedChildRunIdentifiers;
+    runEventAppendToken?: string;
   },
 ): Promise<ChildRunExecutionResult> {
   const baseConfig = options.getConfig();
@@ -434,12 +437,15 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
   const invocationContext = forkInput.context?.veryfront_invocation_context as
     | HostedChildInvocationContext
     | undefined;
-  const scopedOptions = invocationContext
+  const scopedOptions = invocationContext || runtimeOptions.durableChildRun
     ? {
       ...options,
       context: {
         ...options.context,
-        veryfrontInvocationContext: invocationContext,
+        ...(invocationContext ? { veryfrontInvocationContext: invocationContext } : {}),
+        ...(runtimeOptions.durableChildRun
+          ? { runEventAppendToken: runtimeOptions.runEventAppendToken }
+          : {}),
       },
     }
     : options;
@@ -449,6 +455,7 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
   return executeHostedChildForkToolInput<DefaultHostedInvokeAgentTraceAttributes>({
     apiUrl: config.apiUrl,
     authToken: scopedOptions.context.authToken,
+    runEventAppendToken: runtimeOptions.runEventAppendToken,
     projectId: scopedOptions.context.projectId || null,
     forkInput,
     toolCallId: execution.toolCallId,
@@ -628,6 +635,7 @@ export async function executeDefaultHostedInvokeAgentTool<
           executionSnapshot = snapshot;
         },
         durableChildRun: runtimeOptions.durableChildRun,
+        runEventAppendToken: runtimeOptions.runEventAppendToken,
       },
     );
 
@@ -652,6 +660,7 @@ export async function executeDefaultHostedInvokeAgentTool<
       ChildRunExecutionResult
     >({
       authToken: options.context.authToken,
+      runEventAppendToken: options.context.runEventAppendToken,
       apiUrl: config.apiUrl,
       forkInput,
       executionOptions: {

--- a/src/agent/hosted/default-invoke-agent-tool.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.ts
@@ -437,7 +437,7 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
   const invocationContext = forkInput.context?.veryfront_invocation_context as
     | HostedChildInvocationContext
     | undefined;
-  const scopedOptions = invocationContext || runtimeOptions.durableChildRun
+  const scopedOptions = (invocationContext || runtimeOptions.durableChildRun)
     ? {
       ...options,
       context: {

--- a/src/agent/hosted/default-invoke-agent-tool.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.ts
@@ -74,12 +74,15 @@ import {
   type HostedProjectReferenceResolver,
   resolveHostedProjectReference,
 } from "./project-reference-resolver.ts";
+import {
+  getActiveHostedRunEventWriterCapability,
+  type HostedRunEventWriterCapability,
+  runWithHostedRunEventWriterCapability,
+} from "./child-run-event-writer-token.ts";
 
 /** Context for default hosted invoke agent. */
 export type DefaultHostedInvokeAgentContext = MutableAgentProjectContext & {
   authToken: string;
-  /** @internal Active exact-run credential inherited only by durable child setup. */
-  runEventAppendToken?: string;
   clientProfile?: RuntimeClientProfile | null;
   model?: string;
   conversationId?: string;
@@ -419,7 +422,7 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
     childConfig?: DefaultHostedChildAgentExecutionConfig;
     onSettled?: (snapshot: ChildRunExecutionSnapshot) => void | Promise<void>;
     durableChildRun?: HostedChildRunIdentifiers;
-    runEventAppendToken?: string;
+    runEventWriterCapability?: HostedRunEventWriterCapability;
   },
 ): Promise<ChildRunExecutionResult> {
   const baseConfig = options.getConfig();
@@ -437,15 +440,12 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
   const invocationContext = forkInput.context?.veryfront_invocation_context as
     | HostedChildInvocationContext
     | undefined;
-  const scopedOptions = (invocationContext || runtimeOptions.durableChildRun)
+  const scopedOptions = invocationContext
     ? {
       ...options,
       context: {
         ...options.context,
-        ...(invocationContext ? { veryfrontInvocationContext: invocationContext } : {}),
-        ...(runtimeOptions.durableChildRun
-          ? { runEventAppendToken: runtimeOptions.runEventAppendToken }
-          : {}),
+        veryfrontInvocationContext: invocationContext,
       },
     }
     : options;
@@ -455,7 +455,6 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
   return executeHostedChildForkToolInput<DefaultHostedInvokeAgentTraceAttributes>({
     apiUrl: config.apiUrl,
     authToken: scopedOptions.context.authToken,
-    runEventAppendToken: runtimeOptions.runEventAppendToken,
     projectId: scopedOptions.context.projectId || null,
     forkInput,
     toolCallId: execution.toolCallId,
@@ -480,16 +479,20 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
       });
     },
     prepareToolAssembly: ({ runtimeConfig, requestedTools, abortSignal }) =>
-      prepareForkToolAssembly(scopedOptions, config, {
-        childAgentId: runtimeOptions.childAgentId,
-        childConfig: runtimeOptions.childConfig,
-        provider: runtimeConfig.provider,
-        forkModel: runtimeConfig.forkModel,
-        effectivePrompt: runtimeConfig.effectivePrompt,
-        requestedTools,
-        abortSignal,
-        durableChildRun: runtimeOptions.durableChildRun,
-      }),
+      runWithHostedRunEventWriterCapability(
+        runtimeOptions.runEventWriterCapability,
+        () =>
+          prepareForkToolAssembly(scopedOptions, config, {
+            childAgentId: runtimeOptions.childAgentId,
+            childConfig: runtimeOptions.childConfig,
+            provider: runtimeConfig.provider,
+            forkModel: runtimeConfig.forkModel,
+            effectivePrompt: runtimeConfig.effectivePrompt,
+            requestedTools,
+            abortSignal,
+            durableChildRun: runtimeOptions.durableChildRun,
+          }),
+      ),
     resolveProviderOptions: options.resolveProviderOptions,
     resolveReasoning: options.resolveReasoning,
     forkContext: scopedOptions.context,
@@ -523,7 +526,7 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
     shouldRethrowError: options.shouldRethrowError,
     instrumentation,
     sourceIntegrationPolicy: execution.sourceIntegrationPolicy,
-  });
+  }, runtimeOptions.runEventWriterCapability);
 }
 
 function getToolCallId(executionContext?: ToolExecutionContext): string {
@@ -577,6 +580,7 @@ export async function executeDefaultHostedInvokeAgentTool<
   input: DefaultHostedInvokeAgentInput,
   childAgentId: string,
   executionContext?: ToolExecutionContext,
+  runEventWriterCapability?: HostedRunEventWriterCapability,
 ): Promise<DefaultHostedInvokeAgentToolResult> {
   let executionSnapshot: ChildRunExecutionSnapshot | null = null;
   const config = options.getConfig();
@@ -635,7 +639,7 @@ export async function executeDefaultHostedInvokeAgentTool<
           executionSnapshot = snapshot;
         },
         durableChildRun: runtimeOptions.durableChildRun,
-        runEventAppendToken: runtimeOptions.runEventAppendToken,
+        runEventWriterCapability: runtimeOptions.runEventWriterCapability,
       },
     );
 
@@ -660,7 +664,7 @@ export async function executeDefaultHostedInvokeAgentTool<
       ChildRunExecutionResult
     >({
       authToken: options.context.authToken,
-      runEventAppendToken: options.context.runEventAppendToken,
+      runEventWriterCapability,
       apiUrl: config.apiUrl,
       forkInput,
       executionOptions: {
@@ -777,6 +781,7 @@ export function createDefaultHostedInvokeAgentTool<
   TContext extends DefaultHostedInvokeAgentContext,
 >(
   options: DefaultHostedInvokeAgentToolOptions<TContext>,
+  runEventWriterCapability = getActiveHostedRunEventWriterCapability(),
 ) {
   return createHostedChildInvokeTool<
     DefaultHostedInvokeAgentInput,
@@ -795,6 +800,7 @@ export function createDefaultHostedInvokeAgentTool<
         input,
         resolveChildAgentId(options, input),
         executionOptions,
+        runEventWriterCapability,
       ),
   });
 }

--- a/src/agent/hosted/durable-chat-run-start.test.ts
+++ b/src/agent/hosted/durable-chat-run-start.test.ts
@@ -67,16 +67,18 @@ describe("agent/hosted-durable-chat-run-start", () => {
     let prepared = false;
     let started = false;
 
+    const rawRequest = createRequest();
     const response = await executeHostedDurableChatRun({
       req: createParsedRequest(),
-      rawRequest: createRequest(),
+      rawRequest,
       tracker,
       prepareExecution: async () => {
         prepared = true;
         return preparedExecution;
       },
-      startDetachedExecution: async ({ execution }) => {
+      startDetachedExecution: async ({ execution, rawRequest: detachedRawRequest }) => {
         assertEquals(execution, preparedExecution);
+        assertEquals(detachedRawRequest, rawRequest);
         started = true;
       },
     });

--- a/src/agent/hosted/durable-chat-run-start.ts
+++ b/src/agent/hosted/durable-chat-run-start.ts
@@ -41,6 +41,7 @@ export type HostedDurableRunLogger = {
 export type HostedDurableRunStartExecutionInput<TExecution> = {
   execution: TExecution;
   abortSignal: AbortSignal;
+  rawRequest: Request;
 };
 
 /** Input payload for hosted durable run start cleanup. */
@@ -179,10 +180,11 @@ async function executeHostedDurableChatRunStart<TExecution>(
   const detachedStartResponse = await executeAgUiDetachedStart(
     {
       sessionManager: input.tracker.sessionManager,
-      startDetachedExecution: async ({ abortSignal }) => {
+      startDetachedExecution: async ({ abortSignal, rawRequest }) => {
         const detachedExecution = input.startDetachedExecution({
           execution,
           abortSignal,
+          rawRequest,
         });
         input.tracker.registerExecution(durableRootRun.runId, detachedExecution);
         await detachedExecution;

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -22,6 +22,8 @@ import { bootstrapHostedChildRun, type BootstrapHostedChildRunInput } from "./ch
 
 const API_URL = "https://api.example.com";
 const AUTH_TOKEN = "token-123";
+const PARENT_RUN_EVENT_TOKEN = "parent-run-event-token";
+const CHILD_RUN_EVENT_TOKEN = "child-run-event-token";
 const PARENT_CONVERSATION_ID = "11111111-1111-4111-a111-111111111111";
 const CHILD_CONVERSATION_ID = "22222222-2222-4222-a222-222222222222";
 const PARENT_MESSAGE_ID = "33333333-3333-4333-a333-333333333333";
@@ -771,6 +773,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
       {
         authToken: AUTH_TOKEN,
+        runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
         apiUrl: API_URL,
         forkInput: {
           description: "Inspect logs",
@@ -822,7 +825,10 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         contextUnavailableMessage: "missing context",
         setupFailedCode: "SETUP_FAILED",
         executionFailedCode: "INVOKE_AGENT_FAILED",
-        executeLocal: () => baseSuccessResult(),
+        executeLocal: (options) => {
+          bootstrapCalls.push(`execute:${options?.runEventAppendToken}`);
+          return baseSuccessResult();
+        },
         getExecutionSnapshot: () => null,
         buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
         buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
@@ -832,6 +838,13 @@ describe("agent/hosted-durable-child-fork-execution", () => {
           bootstrapChildRun: (input) => {
             capturedBootstrapInputs.push(input);
             return bootstrapHostedChildRun(input);
+          },
+          exchangeChildRunEventWriterToken: (input) => {
+            assertEquals(input.runEventAppendToken, PARENT_RUN_EVENT_TOKEN);
+            assertEquals(input.parentRunId, "run_parent_1");
+            assertEquals(input.childRunId, "run_child_1");
+            bootstrapCalls.push(`exchange:${input.childRunId}`);
+            return Promise.resolve(CHILD_RUN_EVENT_TOKEN);
           },
         },
         bootstrap: {
@@ -858,8 +871,15 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       capturedBootstrapInputs[0]?.ensureProjectId,
       "77777777-7777-4777-8777-777777777777",
     );
+    assertEquals(capturedBootstrapInputs[0]?.authToken, AUTH_TOKEN);
     assertEquals(capturedBootstrapInputs[0]?.runProjectId, "77777777-7777-4777-8777-777777777777");
-    assertEquals(bootstrapCalls, ["wrapped", "start:resolved-sonnet", "complete:run_child_1"]);
+    assertEquals(bootstrapCalls, [
+      "wrapped",
+      "start:resolved-sonnet",
+      "complete:run_child_1",
+      "exchange:run_child_1",
+      `execute:${CHILD_RUN_EVENT_TOKEN}`,
+    ]);
     assertEquals(lifecycleStatuses, ["pending", "running", "completed"]);
     assertEquals(result.success.identifiers, {
       childConversationId: CHILD_CONVERSATION_ID,
@@ -922,5 +942,98 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       terminal_error_code: null,
       terminal_error_message: null,
     });
+  });
+
+  it("fails and finalizes a created child before dispatch when writer-token exchange fails", async () => {
+    let executed = false;
+    const lifecycleFailures: unknown[] = [];
+    const setupErrors: unknown[] = [];
+
+    const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
+      {
+        authToken: AUTH_TOKEN,
+        runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+        apiUrl: API_URL,
+        forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
+        executionOptions: { toolCallId: "tool-call-1" },
+        childAgentId: "invoke-agent-child",
+        parentConversationId: PARENT_CONVERSATION_ID,
+        parentRunId: "run_parent_1",
+        parentMessageId: PARENT_MESSAGE_ID,
+        getProjectId: () => PROJECT_ID,
+        defaultModel: "opus",
+        resolveModelId: (model) => `resolved-${model}`,
+        resolveProvider: () => "anthropic",
+        contextUnavailableMessage: "missing context",
+        setupFailedCode: "SETUP_FAILED",
+        executionFailedCode: "INVOKE_AGENT_FAILED",
+        executeLocal: () => {
+          executed = true;
+          return baseSuccessResult();
+        },
+        getExecutionSnapshot: () => null,
+        buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
+        buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
+        buildTerminalFailureResult: () => ({ status: "missing_context", message: "unexpected" }),
+        buildSuccessResult: (success) => ({ status: "completed", success }),
+        runtime: {
+          bootstrapChildRun: () =>
+            Promise.resolve({
+              childConversationId: CHILD_CONVERSATION_ID,
+              childRunId: "run_child_1",
+              childMessageId: CHILD_MESSAGE_ID,
+              latestEventId: 7,
+              latestExternalEventSequence: 3,
+              status: "running",
+            }),
+          exchangeChildRunEventWriterToken: () =>
+            Promise.reject(new Error(`upstream rejected ${PARENT_RUN_EVENT_TOKEN}`)),
+          createLifecycleAdapter: (input) => {
+            assertEquals(input.authToken, AUTH_TOKEN);
+            return {
+              failed: (terminalState) => {
+                lifecycleFailures.push(terminalState);
+              },
+            };
+          },
+        },
+        bootstrap: {
+          onBootstrapError: ({ error }) => {
+            setupErrors.push(error);
+          },
+        },
+      },
+    );
+
+    assertEquals(executed, false);
+    assertEquals(lifecycleFailures, [{
+      status: "failed",
+      terminalErrorCode: "SETUP_FAILED",
+      terminalErrorMessage: "Unable to initialize durable child event persistence",
+    }]);
+    assertEquals(setupErrors.length, 1);
+    assertEquals(
+      setupErrors.some((error) => String(error).includes(PARENT_RUN_EVENT_TOKEN)),
+      false,
+    );
+    assertEquals(result, {
+      status: "setup_failed",
+      failure: {
+        targets: {
+          sourceTargetKind: "project",
+          runtimeTargetKind: "main_branch",
+          targetEnvironmentId: null,
+          targetBranchId: null,
+        },
+        childConversationId: CHILD_CONVERSATION_ID,
+        childRunId: "run_child_1",
+        childMessageId: CHILD_MESSAGE_ID,
+        terminalErrorCode: "SETUP_FAILED",
+        terminalErrorMessage: "Unable to initialize durable child event persistence",
+      },
+    });
+    const serializedFailure = JSON.stringify({ result, lifecycleFailures, setupErrors });
+    assertEquals(serializedFailure.includes(PARENT_RUN_EVENT_TOKEN), false);
+    assertEquals(serializedFailure.includes(CHILD_RUN_EVENT_TOKEN), false);
   });
 });

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -14,12 +14,19 @@ import {
   createHostedDurableChildInvokeTraceRecorder,
   executeHostedDurableChildFork,
   executeHostedLocalChildInvoke,
+  HostedChildRunFinalizationError,
   type HostedDurableChildSetupFailure,
   type HostedDurableChildSuccess,
+  type HostedDurableChildTerminalFailure,
 } from "./durable-child-fork-execution.ts";
 import type { InvokeAgentChildRunProgressEvent } from "../child-run/invoke-agent-child-runs.ts";
 import { bootstrapHostedChildRun, type BootstrapHostedChildRunInput } from "./child-bootstrap.ts";
-import { createHostedRunEventWriterCapability } from "./child-run-event-writer-token.ts";
+import {
+  createHostedRunEventWriterCapability,
+  getActiveHostedRunEventWriterCapability,
+  HostedChildRunEventWriterTokenExchangeError,
+  runWithHostedRunEventWriterCapability,
+} from "./child-run-event-writer-token.ts";
 
 const API_URL = "https://api.example.com";
 const AUTH_TOKEN = "token-123";
@@ -37,6 +44,7 @@ const originalFetch = globalThis.fetch;
 type DurableChildResult =
   | { status: "missing_context"; message: string }
   | { status: "setup_failed"; failure: HostedDurableChildSetupFailure }
+  | { status: "terminal_failed"; failure: HostedDurableChildTerminalFailure }
   | { status: "completed"; success: HostedDurableChildSuccess<ChildRunExecutionResult> };
 
 function jsonResponse(body: unknown, status: number): Response {
@@ -789,93 +797,100 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       throw new Error("Unexpected fetch call");
     });
 
-    const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
-      {
-        authToken: AUTH_TOKEN,
-        runEventWriterCapability,
-        apiUrl: API_URL,
-        forkInput: {
-          description: "Inspect logs",
-          prompt: "Find logs",
-          project_reference: "target-project",
-          context: {
-            veryfront_invocation_context: {
+    const result = await runWithHostedRunEventWriterCapability(
+      runEventWriterCapability,
+      () =>
+        executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
+          {
+            authToken: AUTH_TOKEN,
+            apiUrl: API_URL,
+            forkInput: {
+              description: "Inspect logs",
+              prompt: "Find logs",
+              project_reference: "target-project",
+              context: {
+                veryfront_invocation_context: {
+                  root_conversation_id: "root-conversation-1",
+                  root_run_id: "run_root_1",
+                },
+              },
+            },
+            executionOptions: { toolCallId: "tool-call-1" },
+            childAgentId: "invoke-agent-child",
+            runProjectId: projectId,
+            parentConversationId: PARENT_CONVERSATION_ID,
+            parentRunId: "run_parent_1",
+            parentMessageId: PARENT_MESSAGE_ID,
+            trustedInvocationContext: {
               root_conversation_id: "root-conversation-1",
               root_run_id: "run_root_1",
+              delegation_depth: 0,
+            },
+            getProjectId: () => projectId,
+            getRuntimeTargetKind: () => "environment",
+            getRuntimeTargetEnvironmentId: () => ENVIRONMENT_ID,
+            getBranchId: () => null,
+            getContextModel: () => "sonnet",
+            defaultModel: "opus",
+            resolveModelId: (model) => `resolved-${model}`,
+            resolveProvider: (model) => `provider-${model}`,
+            resolveProjectReference: ({ projectReference }) => {
+              assertEquals(projectReference, "target-project");
+              return Promise.resolve({
+                projectId: "77777777-7777-4777-8777-777777777777",
+                slug: "target-project",
+              });
+            },
+            onRequestedProjectId: (requestedProjectId) => {
+              projectId = requestedProjectId;
+            },
+            publishParentRunEvents: (events: InvokeAgentChildRunProgressEvent[]) => {
+              for (const event of events) {
+                if (event.type === "CUSTOM") {
+                  lifecycleStatuses.push(event.value.status);
+                }
+              }
+            },
+            contextUnavailableMessage: "missing context",
+            setupFailedCode: "SETUP_FAILED",
+            executionFailedCode: "INVOKE_AGENT_FAILED",
+            executeLocal: async (options) => {
+              assertEquals(JSON.stringify(options).includes(CHILD_RUN_EVENT_TOKEN), false);
+              assertEquals("runEventWriterCapability" in (options ?? {}), false);
+              const grandchildCapability = await getActiveHostedRunEventWriterCapability()
+                ?.mintChildRunEventAppendToken("run_grandchild_1");
+              assertEquals(JSON.stringify(grandchildCapability), "{}");
+              bootstrapCalls.push("execute");
+              return baseSuccessResult();
+            },
+            getExecutionSnapshot: () => null,
+            buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
+            buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
+            buildTerminalFailureResult: () => ({
+              status: "missing_context",
+              message: "unexpected",
+            }),
+            buildSuccessResult: (success) => ({ status: "completed", success }),
+            runtime: {
+              bootstrapChildRun: (input) => {
+                capturedBootstrapInputs.push(input);
+                return bootstrapHostedChildRun(input);
+              },
+            },
+            bootstrap: {
+              runBootstrap: async (operation) => {
+                bootstrapCalls.push("wrapped");
+                return operation();
+              },
+              onBootstrapStart: (bootstrapContext) => {
+                bootstrapCalls.push(`start:${bootstrapContext.resolvedModel}`);
+              },
+              onBootstrapComplete: (bootstrapContext) => {
+                bootstrapCalls.push(`complete:${bootstrapContext.identifiers.childRunId}`);
+              },
             },
           },
-        },
-        executionOptions: { toolCallId: "tool-call-1" },
-        childAgentId: "invoke-agent-child",
-        runProjectId: projectId,
-        parentConversationId: PARENT_CONVERSATION_ID,
-        parentRunId: "run_parent_1",
-        parentMessageId: PARENT_MESSAGE_ID,
-        trustedInvocationContext: {
-          root_conversation_id: "root-conversation-1",
-          root_run_id: "run_root_1",
-          delegation_depth: 0,
-        },
-        getProjectId: () => projectId,
-        getRuntimeTargetKind: () => "environment",
-        getRuntimeTargetEnvironmentId: () => ENVIRONMENT_ID,
-        getBranchId: () => null,
-        getContextModel: () => "sonnet",
-        defaultModel: "opus",
-        resolveModelId: (model) => `resolved-${model}`,
-        resolveProvider: (model) => `provider-${model}`,
-        resolveProjectReference: ({ projectReference }) => {
-          assertEquals(projectReference, "target-project");
-          return Promise.resolve({
-            projectId: "77777777-7777-4777-8777-777777777777",
-            slug: "target-project",
-          });
-        },
-        onRequestedProjectId: (requestedProjectId) => {
-          projectId = requestedProjectId;
-        },
-        publishParentRunEvents: (events: InvokeAgentChildRunProgressEvent[]) => {
-          for (const event of events) {
-            if (event.type === "CUSTOM") {
-              lifecycleStatuses.push(event.value.status);
-            }
-          }
-        },
-        contextUnavailableMessage: "missing context",
-        setupFailedCode: "SETUP_FAILED",
-        executionFailedCode: "INVOKE_AGENT_FAILED",
-        executeLocal: async (options) => {
-          assertEquals(JSON.stringify(options).includes(CHILD_RUN_EVENT_TOKEN), false);
-          const grandchildCapability = await options?.runEventWriterCapability
-            ?.mintChildRunEventAppendToken("run_grandchild_1");
-          assertEquals(JSON.stringify(grandchildCapability), "{}");
-          bootstrapCalls.push("execute");
-          return baseSuccessResult();
-        },
-        getExecutionSnapshot: () => null,
-        buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
-        buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
-        buildTerminalFailureResult: () => ({ status: "missing_context", message: "unexpected" }),
-        buildSuccessResult: (success) => ({ status: "completed", success }),
-        runtime: {
-          bootstrapChildRun: (input) => {
-            capturedBootstrapInputs.push(input);
-            return bootstrapHostedChildRun(input);
-          },
-        },
-        bootstrap: {
-          runBootstrap: async (operation) => {
-            bootstrapCalls.push("wrapped");
-            return operation();
-          },
-          onBootstrapStart: (bootstrapContext) => {
-            bootstrapCalls.push(`start:${bootstrapContext.resolvedModel}`);
-          },
-          onBootstrapComplete: (bootstrapContext) => {
-            bootstrapCalls.push(`complete:${bootstrapContext.identifiers.childRunId}`);
-          },
-        },
-      },
+        ),
     );
 
     if (result.status !== "completed") {
@@ -973,63 +988,70 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     const lifecycleFailures: unknown[] = [];
     const setupErrors: unknown[] = [];
 
-    const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
-      {
-        authToken: AUTH_TOKEN,
-        runEventWriterCapability: createHostedRunEventWriterCapability({
-          apiUrl: API_URL,
-          runId: "run_parent_1",
-          runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
-          fetch: () => Promise.reject(new Error(`upstream rejected ${PARENT_RUN_EVENT_TOKEN}`)),
-        }),
-        apiUrl: API_URL,
-        forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
-        executionOptions: { toolCallId: "tool-call-1" },
-        childAgentId: "invoke-agent-child",
-        parentConversationId: PARENT_CONVERSATION_ID,
-        parentRunId: "run_parent_1",
-        parentMessageId: PARENT_MESSAGE_ID,
-        getProjectId: () => PROJECT_ID,
-        defaultModel: "opus",
-        resolveModelId: (model) => `resolved-${model}`,
-        resolveProvider: () => "anthropic",
-        contextUnavailableMessage: "missing context",
-        setupFailedCode: "SETUP_FAILED",
-        executionFailedCode: "INVOKE_AGENT_FAILED",
-        executeLocal: () => {
-          executed = true;
-          return baseSuccessResult();
-        },
-        getExecutionSnapshot: () => null,
-        buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
-        buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
-        buildTerminalFailureResult: () => ({ status: "missing_context", message: "unexpected" }),
-        buildSuccessResult: (success) => ({ status: "completed", success }),
-        runtime: {
-          bootstrapChildRun: () =>
-            Promise.resolve({
-              childConversationId: CHILD_CONVERSATION_ID,
-              childRunId: "run_child_1",
-              childMessageId: CHILD_MESSAGE_ID,
-              latestEventId: 7,
-              latestExternalEventSequence: 3,
-              status: "running",
+    const runEventWriterCapability = createHostedRunEventWriterCapability({
+      apiUrl: API_URL,
+      runId: "run_parent_1",
+      runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+      fetch: () => Promise.reject(new Error(`upstream rejected ${PARENT_RUN_EVENT_TOKEN}`)),
+    });
+    const result = await runWithHostedRunEventWriterCapability(
+      runEventWriterCapability,
+      () =>
+        executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
+          {
+            authToken: AUTH_TOKEN,
+            apiUrl: API_URL,
+            forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
+            executionOptions: { toolCallId: "tool-call-1" },
+            childAgentId: "invoke-agent-child",
+            parentConversationId: PARENT_CONVERSATION_ID,
+            parentRunId: "run_parent_1",
+            parentMessageId: PARENT_MESSAGE_ID,
+            getProjectId: () => PROJECT_ID,
+            defaultModel: "opus",
+            resolveModelId: (model) => `resolved-${model}`,
+            resolveProvider: () => "anthropic",
+            contextUnavailableMessage: "missing context",
+            setupFailedCode: "SETUP_FAILED",
+            executionFailedCode: "INVOKE_AGENT_FAILED",
+            executeLocal: () => {
+              executed = true;
+              return baseSuccessResult();
+            },
+            getExecutionSnapshot: () => null,
+            buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
+            buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
+            buildTerminalFailureResult: () => ({
+              status: "missing_context",
+              message: "unexpected",
             }),
-          createLifecycleAdapter: (input) => {
-            assertEquals(input.authToken, AUTH_TOKEN);
-            return {
-              failed: (terminalState) => {
-                lifecycleFailures.push(terminalState);
+            buildSuccessResult: (success) => ({ status: "completed", success }),
+            runtime: {
+              bootstrapChildRun: () =>
+                Promise.resolve({
+                  childConversationId: CHILD_CONVERSATION_ID,
+                  childRunId: "run_child_1",
+                  childMessageId: CHILD_MESSAGE_ID,
+                  latestEventId: 7,
+                  latestExternalEventSequence: 3,
+                  status: "running",
+                }),
+              createLifecycleAdapter: (input) => {
+                assertEquals(input.authToken, AUTH_TOKEN);
+                return {
+                  failed: (terminalState) => {
+                    lifecycleFailures.push(terminalState);
+                  },
+                };
               },
-            };
+            },
+            bootstrap: {
+              onBootstrapError: ({ error }) => {
+                setupErrors.push(error);
+              },
+            },
           },
-        },
-        bootstrap: {
-          onBootstrapError: ({ error }) => {
-            setupErrors.push(error);
-          },
-        },
-      },
+        ),
     );
 
     assertEquals(executed, false);
@@ -1068,73 +1090,88 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     let finalizationAttempts = 0;
     let executed = false;
     const observedLifecycleErrors: unknown[] = [];
-    const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
-      {
-        authToken: AUTH_TOKEN,
-        runEventWriterCapability: createHostedRunEventWriterCapability({
-          apiUrl: API_URL,
-          runId: "run_parent_1",
-          runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
-          fetch: () => Promise.reject(new Error(`secret ${PARENT_RUN_EVENT_TOKEN}`)),
-        }),
-        apiUrl: API_URL,
-        forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
-        executionOptions: { toolCallId: "tool-call-1" },
-        childAgentId: "invoke-agent-child",
-        parentConversationId: PARENT_CONVERSATION_ID,
-        parentRunId: "run_parent_1",
-        parentMessageId: PARENT_MESSAGE_ID,
-        getProjectId: () => PROJECT_ID,
-        defaultModel: "opus",
-        resolveModelId: (model) => `resolved-${model}`,
-        resolveProvider: () => "anthropic",
-        contextUnavailableMessage: "missing context",
-        setupFailedCode: "SETUP_FAILED",
-        executionFailedCode: "INVOKE_AGENT_FAILED",
-        executeLocal: () => {
-          executed = true;
-          return baseSuccessResult();
-        },
-        getExecutionSnapshot: () => null,
-        buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
-        buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
-        buildTerminalFailureResult: () => ({ status: "missing_context", message: "unexpected" }),
-        buildSuccessResult: (success) => ({ status: "completed", success }),
-        runtime: {
-          bootstrapChildRun: () =>
-            Promise.resolve({
-              childConversationId: CHILD_CONVERSATION_ID,
-              childRunId: "run_child_1",
-              childMessageId: CHILD_MESSAGE_ID,
-              latestEventId: 7,
-              latestExternalEventSequence: 3,
-              status: "running",
-            }),
-          createLifecycleAdapter: () => ({
-            failed: () => {
-              finalizationAttempts += 1;
-              return Promise.reject(new Error(`finalization secret ${CHILD_RUN_EVENT_TOKEN}`));
+    const runEventWriterCapability = createHostedRunEventWriterCapability({
+      apiUrl: API_URL,
+      runId: "run_parent_1",
+      runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+      fetch: () => Promise.reject(new Error(`secret ${PARENT_RUN_EVENT_TOKEN}`)),
+    });
+    const result = await runWithHostedRunEventWriterCapability(
+      runEventWriterCapability,
+      () =>
+        executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
+          {
+            authToken: AUTH_TOKEN,
+            apiUrl: API_URL,
+            forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
+            executionOptions: { toolCallId: "tool-call-1" },
+            childAgentId: "invoke-agent-child",
+            parentConversationId: PARENT_CONVERSATION_ID,
+            parentRunId: "run_parent_1",
+            parentMessageId: PARENT_MESSAGE_ID,
+            getProjectId: () => PROJECT_ID,
+            defaultModel: "opus",
+            resolveModelId: (model) => `resolved-${model}`,
+            resolveProvider: () => "anthropic",
+            contextUnavailableMessage: "missing context",
+            setupFailedCode: "SETUP_FAILED",
+            executionFailedCode: "INVOKE_AGENT_FAILED",
+            executeLocal: () => {
+              executed = true;
+              return baseSuccessResult();
             },
-          }),
-        },
-        bootstrap: {
-          onBootstrapError: () => Promise.reject(new Error("observer failed")),
-        },
-        onLifecycleError: (error) => {
-          observedLifecycleErrors.push(error);
-        },
-      },
+            getExecutionSnapshot: () => null,
+            buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
+            buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
+            buildTerminalFailureResult: () => ({
+              status: "missing_context",
+              message: "unexpected",
+            }),
+            buildSuccessResult: (success) => ({ status: "completed", success }),
+            runtime: {
+              bootstrapChildRun: () =>
+                Promise.resolve({
+                  childConversationId: CHILD_CONVERSATION_ID,
+                  childRunId: "run_child_1",
+                  childMessageId: CHILD_MESSAGE_ID,
+                  latestEventId: 7,
+                  latestExternalEventSequence: 3,
+                  status: "running",
+                }),
+              createLifecycleAdapter: () => ({
+                failed: () => {
+                  finalizationAttempts += 1;
+                  return Promise.reject(new Error(`finalization secret ${CHILD_RUN_EVENT_TOKEN}`));
+                },
+              }),
+            },
+            bootstrap: {
+              onBootstrapError: () => Promise.reject(new Error("observer failed")),
+            },
+            onLifecycleError: (error) => {
+              observedLifecycleErrors.push(error);
+            },
+          },
+        ),
     );
 
     assertEquals(executed, false);
     assertEquals(finalizationAttempts, 1);
     assertEquals(observedLifecycleErrors.length, 2);
     assertEquals(
-      observedLifecycleErrors.every((error) =>
-        error instanceof Error &&
-        error.message === "Unable to initialize durable child event persistence"
-      ),
+      observedLifecycleErrors[0] instanceof Error &&
+        observedLifecycleErrors[0].message ===
+          "Unable to initialize durable child event persistence",
       true,
+    );
+    assertEquals(observedLifecycleErrors[1] instanceof HostedChildRunFinalizationError, true);
+    assertEquals(
+      observedLifecycleErrors[1] instanceof Error && observedLifecycleErrors[1].message,
+      "Unable to finalize durable child run after setup failure",
+    );
+    assertEquals(
+      observedLifecycleErrors[1] instanceof Error && "cause" in observedLifecycleErrors[1],
+      false,
     );
     assertEquals(JSON.stringify(observedLifecycleErrors).includes(CHILD_RUN_EVENT_TOKEN), false);
     assertEquals(result.status, "setup_failed");
@@ -1146,6 +1183,104 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         "Unable to initialize durable child event persistence",
       );
     }
+  });
+
+  it("cancels exactly once when writer-token exchange is aborted after bootstrap", async () => {
+    const controller = new AbortController();
+    let executed = false;
+    let cancellationAttempts = 0;
+    const observedLifecycleErrors: unknown[] = [];
+    const capability = createHostedRunEventWriterCapability({
+      apiUrl: API_URL,
+      runId: "run_parent_1",
+      runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+      fetch: (input, init) => {
+        const signal = new Request(input, init).signal;
+        controller.abort(`secret ${PARENT_RUN_EVENT_TOKEN}`);
+        return Promise.reject(signal.reason);
+      },
+    });
+
+    const result = await runWithHostedRunEventWriterCapability(
+      capability,
+      () =>
+        executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>({
+          authToken: AUTH_TOKEN,
+          apiUrl: API_URL,
+          forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
+          executionOptions: { toolCallId: "tool-call-1", abortSignal: controller.signal },
+          childAgentId: "invoke-agent-child",
+          parentConversationId: PARENT_CONVERSATION_ID,
+          parentRunId: "run_parent_1",
+          parentMessageId: PARENT_MESSAGE_ID,
+          getProjectId: () => PROJECT_ID,
+          defaultModel: "opus",
+          resolveModelId: (model) => `resolved-${model}`,
+          resolveProvider: () => "anthropic",
+          contextUnavailableMessage: "missing context",
+          setupFailedCode: "SETUP_FAILED",
+          executionFailedCode: "INVOKE_AGENT_FAILED",
+          executeLocal: () => {
+            executed = true;
+            return baseSuccessResult();
+          },
+          getExecutionSnapshot: () => null,
+          buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
+          buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
+          buildTerminalFailureResult: (failure) => ({
+            status: "terminal_failed",
+            failure,
+          }),
+          buildSuccessResult: (success) => ({ status: "completed", success }),
+          runtime: {
+            bootstrapChildRun: () =>
+              Promise.resolve({
+                childConversationId: CHILD_CONVERSATION_ID,
+                childRunId: "run_child_1",
+                childMessageId: CHILD_MESSAGE_ID,
+                latestEventId: 7,
+                latestExternalEventSequence: 3,
+                status: "running",
+              }),
+            createLifecycleAdapter: () => ({
+              cancelled: () => {
+                cancellationAttempts += 1;
+                return Promise.reject(new Error(`finalization ${CHILD_RUN_EVENT_TOKEN}`));
+              },
+            }),
+          },
+          bootstrap: {
+            onBootstrapError: () => Promise.reject(new Error("observer rejected")),
+          },
+          onLifecycleError: (error) => {
+            observedLifecycleErrors.push(error);
+          },
+        }),
+    );
+
+    assertEquals(executed, false);
+    assertEquals(cancellationAttempts, 1);
+    assertEquals(result.status, "terminal_failed");
+    if (result.status === "terminal_failed") {
+      assertEquals(result.failure.status, "cancelled");
+      assertEquals(result.failure.terminalErrorCode, "CANCELLED");
+      assertEquals(result.failure.terminalErrorMessage, "Child run cancelled");
+    }
+    assertEquals(observedLifecycleErrors.length, 2);
+    assertEquals(
+      observedLifecycleErrors[0] instanceof HostedChildRunEventWriterTokenExchangeError &&
+        observedLifecycleErrors[0].classification,
+      "aborted",
+    );
+    assertEquals(observedLifecycleErrors[1] instanceof HostedChildRunFinalizationError, true);
+    assertEquals(
+      JSON.stringify({ result, observedLifecycleErrors }).includes(PARENT_RUN_EVENT_TOKEN),
+      false,
+    );
+    assertEquals(
+      JSON.stringify({ result, observedLifecycleErrors }).includes(CHILD_RUN_EVENT_TOKEN),
+      false,
+    );
   });
 
   it("keeps a rejecting bootstrap observer from masking the bootstrap failure", async () => {

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -1036,4 +1036,90 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     assertEquals(serializedFailure.includes(PARENT_RUN_EVENT_TOKEN), false);
     assertEquals(serializedFailure.includes(CHILD_RUN_EVENT_TOKEN), false);
   });
+
+  it("finalizes the child and returns setup failure when onBootstrapError throws", async () => {
+    let executed = false;
+    const lifecycleFailures: unknown[] = [];
+    const callbackErrors: unknown[] = [];
+
+    const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
+      {
+        authToken: AUTH_TOKEN,
+        runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+        apiUrl: API_URL,
+        forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
+        executionOptions: { toolCallId: "tool-call-1" },
+        childAgentId: "invoke-agent-child",
+        parentConversationId: PARENT_CONVERSATION_ID,
+        parentRunId: "run_parent_1",
+        parentMessageId: PARENT_MESSAGE_ID,
+        getProjectId: () => PROJECT_ID,
+        defaultModel: "opus",
+        resolveModelId: (model) => `resolved-${model}`,
+        resolveProvider: () => "anthropic",
+        contextUnavailableMessage: "missing context",
+        setupFailedCode: "SETUP_FAILED",
+        executionFailedCode: "INVOKE_AGENT_FAILED",
+        executeLocal: () => {
+          executed = true;
+          return baseSuccessResult();
+        },
+        getExecutionSnapshot: () => null,
+        buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
+        buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
+        buildTerminalFailureResult: () => ({ status: "missing_context", message: "unexpected" }),
+        buildSuccessResult: (success) => ({ status: "completed", success }),
+        runtime: {
+          bootstrapChildRun: () =>
+            Promise.resolve({
+              childConversationId: CHILD_CONVERSATION_ID,
+              childRunId: "run_child_1",
+              childMessageId: CHILD_MESSAGE_ID,
+              latestEventId: 7,
+              latestExternalEventSequence: 3,
+              status: "running",
+            }),
+          exchangeChildRunEventWriterToken: () => Promise.reject(new Error("upstream rejected")),
+          createLifecycleAdapter: () => ({
+            failed: (terminalState) => {
+              lifecycleFailures.push(terminalState);
+            },
+          }),
+        },
+        bootstrap: {
+          onBootstrapError: () => {
+            throw new Error("observability sink exploded");
+          },
+        },
+        onLifecycleError: (error) => {
+          callbackErrors.push(error);
+        },
+      },
+    );
+
+    assertEquals(executed, false);
+    assertEquals(lifecycleFailures, [{
+      status: "failed",
+      terminalErrorCode: "SETUP_FAILED",
+      terminalErrorMessage: "Unable to initialize durable child event persistence",
+    }]);
+    assertEquals(callbackErrors.length, 1);
+    assertStringIncludes(String(callbackErrors[0]), "observability sink exploded");
+    assertEquals(result, {
+      status: "setup_failed",
+      failure: {
+        targets: {
+          sourceTargetKind: "project",
+          runtimeTargetKind: "main_branch",
+          targetEnvironmentId: null,
+          targetBranchId: null,
+        },
+        childConversationId: CHILD_CONVERSATION_ID,
+        childRunId: "run_child_1",
+        childMessageId: CHILD_MESSAGE_ID,
+        terminalErrorCode: "SETUP_FAILED",
+        terminalErrorMessage: "Unable to initialize durable child event persistence",
+      },
+    });
+  });
 });

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -19,6 +19,7 @@ import {
 } from "./durable-child-fork-execution.ts";
 import type { InvokeAgentChildRunProgressEvent } from "../child-run/invoke-agent-child-runs.ts";
 import { bootstrapHostedChildRun, type BootstrapHostedChildRunInput } from "./child-bootstrap.ts";
+import { createHostedRunEventWriterCapability } from "./child-run-event-writer-token.ts";
 
 const API_URL = "https://api.example.com";
 const AUTH_TOKEN = "token-123";
@@ -730,6 +731,24 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     const lifecycleStatuses: string[] = [];
     const bootstrapCalls: string[] = [];
     const capturedBootstrapInputs: BootstrapHostedChildRunInput[] = [];
+    const exchangeRequests: Request[] = [];
+    const runEventWriterCapability = createHostedRunEventWriterCapability({
+      apiUrl: API_URL,
+      runId: "run_parent_1",
+      runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+      fetch: (input, init) => {
+        const request = new Request(input, init);
+        exchangeRequests.push(request);
+        return Promise.resolve(Response.json(
+          {
+            run_event_token: exchangeRequests.length === 1
+              ? CHILD_RUN_EVENT_TOKEN
+              : "grandchild-run-event-token",
+          },
+          { headers: { "Cache-Control": "no-store" } },
+        ));
+      },
+    });
     const { requests } = stubFetchWithRecorder((_input, _init) => {
       const requestCount = requests.length;
       if (requestCount === 1) {
@@ -773,7 +792,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
       {
         authToken: AUTH_TOKEN,
-        runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+        runEventWriterCapability,
         apiUrl: API_URL,
         forkInput: {
           description: "Inspect logs",
@@ -825,8 +844,12 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         contextUnavailableMessage: "missing context",
         setupFailedCode: "SETUP_FAILED",
         executionFailedCode: "INVOKE_AGENT_FAILED",
-        executeLocal: (options) => {
-          bootstrapCalls.push(`execute:${options?.runEventAppendToken}`);
+        executeLocal: async (options) => {
+          assertEquals(JSON.stringify(options).includes(CHILD_RUN_EVENT_TOKEN), false);
+          const grandchildCapability = await options?.runEventWriterCapability
+            ?.mintChildRunEventAppendToken("run_grandchild_1");
+          assertEquals(JSON.stringify(grandchildCapability), "{}");
+          bootstrapCalls.push("execute");
           return baseSuccessResult();
         },
         getExecutionSnapshot: () => null,
@@ -838,13 +861,6 @@ describe("agent/hosted-durable-child-fork-execution", () => {
           bootstrapChildRun: (input) => {
             capturedBootstrapInputs.push(input);
             return bootstrapHostedChildRun(input);
-          },
-          exchangeChildRunEventWriterToken: (input) => {
-            assertEquals(input.runEventAppendToken, PARENT_RUN_EVENT_TOKEN);
-            assertEquals(input.parentRunId, "run_parent_1");
-            assertEquals(input.childRunId, "run_child_1");
-            bootstrapCalls.push(`exchange:${input.childRunId}`);
-            return Promise.resolve(CHILD_RUN_EVENT_TOKEN);
           },
         },
         bootstrap: {
@@ -877,8 +893,16 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       "wrapped",
       "start:resolved-sonnet",
       "complete:run_child_1",
-      "exchange:run_child_1",
-      `execute:${CHILD_RUN_EVENT_TOKEN}`,
+      "execute",
+    ]);
+    assertEquals(exchangeRequests.length, 2);
+    assertEquals(exchangeRequests.map((request) => request.headers.get("Authorization")), [
+      `Bearer ${PARENT_RUN_EVENT_TOKEN}`,
+      `Bearer ${CHILD_RUN_EVENT_TOKEN}`,
+    ]);
+    assertEquals(exchangeRequests.map((request) => request.url), [
+      `${API_URL}/runs/run_parent_1/children/run_child_1/event-writer-token`,
+      `${API_URL}/runs/run_child_1/children/run_grandchild_1/event-writer-token`,
     ]);
     assertEquals(lifecycleStatuses, ["pending", "running", "completed"]);
     assertEquals(result.success.identifiers, {
@@ -952,7 +976,12 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
       {
         authToken: AUTH_TOKEN,
-        runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+        runEventWriterCapability: createHostedRunEventWriterCapability({
+          apiUrl: API_URL,
+          runId: "run_parent_1",
+          runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+          fetch: () => Promise.reject(new Error(`upstream rejected ${PARENT_RUN_EVENT_TOKEN}`)),
+        }),
         apiUrl: API_URL,
         forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
         executionOptions: { toolCallId: "tool-call-1" },
@@ -986,8 +1015,6 @@ describe("agent/hosted-durable-child-fork-execution", () => {
               latestExternalEventSequence: 3,
               status: "running",
             }),
-          exchangeChildRunEventWriterToken: () =>
-            Promise.reject(new Error(`upstream rejected ${PARENT_RUN_EVENT_TOKEN}`)),
           createLifecycleAdapter: (input) => {
             assertEquals(input.authToken, AUTH_TOKEN);
             return {
@@ -1037,15 +1064,19 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     assertEquals(serializedFailure.includes(CHILD_RUN_EVENT_TOKEN), false);
   });
 
-  it("finalizes the child and returns setup failure when onBootstrapError throws", async () => {
+  it("returns the sanitized setup failure after rejecting observers and failed finalization", async () => {
+    let finalizationAttempts = 0;
     let executed = false;
-    const lifecycleFailures: unknown[] = [];
-    const callbackErrors: unknown[] = [];
-
+    const observedLifecycleErrors: unknown[] = [];
     const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
       {
         authToken: AUTH_TOKEN,
-        runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+        runEventWriterCapability: createHostedRunEventWriterCapability({
+          apiUrl: API_URL,
+          runId: "run_parent_1",
+          runEventAppendToken: PARENT_RUN_EVENT_TOKEN,
+          fetch: () => Promise.reject(new Error(`secret ${PARENT_RUN_EVENT_TOKEN}`)),
+        }),
         apiUrl: API_URL,
         forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
         executionOptions: { toolCallId: "tool-call-1" },
@@ -1079,17 +1110,74 @@ describe("agent/hosted-durable-child-fork-execution", () => {
               latestExternalEventSequence: 3,
               status: "running",
             }),
-          exchangeChildRunEventWriterToken: () => Promise.reject(new Error("upstream rejected")),
           createLifecycleAdapter: () => ({
-            failed: (terminalState) => {
-              lifecycleFailures.push(terminalState);
+            failed: () => {
+              finalizationAttempts += 1;
+              return Promise.reject(new Error(`finalization secret ${CHILD_RUN_EVENT_TOKEN}`));
             },
           }),
         },
         bootstrap: {
-          onBootstrapError: () => {
-            throw new Error("observability sink exploded");
-          },
+          onBootstrapError: () => Promise.reject(new Error("observer failed")),
+        },
+        onLifecycleError: (error) => {
+          observedLifecycleErrors.push(error);
+        },
+      },
+    );
+
+    assertEquals(executed, false);
+    assertEquals(finalizationAttempts, 1);
+    assertEquals(observedLifecycleErrors.length, 2);
+    assertEquals(
+      observedLifecycleErrors.every((error) =>
+        error instanceof Error &&
+        error.message === "Unable to initialize durable child event persistence"
+      ),
+      true,
+    );
+    assertEquals(JSON.stringify(observedLifecycleErrors).includes(CHILD_RUN_EVENT_TOKEN), false);
+    assertEquals(result.status, "setup_failed");
+    assertEquals(JSON.stringify(result).includes(PARENT_RUN_EVENT_TOKEN), false);
+    assertEquals(JSON.stringify(result).includes(CHILD_RUN_EVENT_TOKEN), false);
+    if (result.status === "setup_failed") {
+      assertEquals(
+        result.failure.terminalErrorMessage,
+        "Unable to initialize durable child event persistence",
+      );
+    }
+  });
+
+  it("keeps a rejecting bootstrap observer from masking the bootstrap failure", async () => {
+    const callbackErrors: unknown[] = [];
+    const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
+      {
+        authToken: AUTH_TOKEN,
+        apiUrl: API_URL,
+        forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
+        executionOptions: { toolCallId: "tool-call-1" },
+        childAgentId: "invoke-agent-child",
+        parentConversationId: PARENT_CONVERSATION_ID,
+        parentRunId: "run_parent_1",
+        parentMessageId: PARENT_MESSAGE_ID,
+        getProjectId: () => PROJECT_ID,
+        defaultModel: "opus",
+        resolveModelId: (model) => `resolved-${model}`,
+        resolveProvider: () => "anthropic",
+        contextUnavailableMessage: "missing context",
+        setupFailedCode: "SETUP_FAILED",
+        executionFailedCode: "INVOKE_AGENT_FAILED",
+        executeLocal: () => baseSuccessResult(),
+        getExecutionSnapshot: () => null,
+        buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
+        buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
+        buildTerminalFailureResult: () => ({ status: "missing_context", message: "unexpected" }),
+        buildSuccessResult: (success) => ({ status: "completed", success }),
+        runtime: {
+          bootstrapChildRun: () => Promise.reject(new Error("bootstrap failed")),
+        },
+        bootstrap: {
+          onBootstrapError: () => Promise.reject(new Error("observer failed")),
         },
         onLifecycleError: (error) => {
           callbackErrors.push(error);
@@ -1097,29 +1185,12 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       },
     );
 
-    assertEquals(executed, false);
-    assertEquals(lifecycleFailures, [{
-      status: "failed",
-      terminalErrorCode: "SETUP_FAILED",
-      terminalErrorMessage: "Unable to initialize durable child event persistence",
-    }]);
     assertEquals(callbackErrors.length, 1);
-    assertStringIncludes(String(callbackErrors[0]), "observability sink exploded");
-    assertEquals(result, {
-      status: "setup_failed",
-      failure: {
-        targets: {
-          sourceTargetKind: "project",
-          runtimeTargetKind: "main_branch",
-          targetEnvironmentId: null,
-          targetBranchId: null,
-        },
-        childConversationId: CHILD_CONVERSATION_ID,
-        childRunId: "run_child_1",
-        childMessageId: CHILD_MESSAGE_ID,
-        terminalErrorCode: "SETUP_FAILED",
-        terminalErrorMessage: "Unable to initialize durable child event persistence",
-      },
-    });
+    assertStringIncludes(String(callbackErrors[0]), "observer failed");
+    assertEquals(result.status, "setup_failed");
+    if (result.status === "setup_failed") {
+      assertEquals(result.failure.childRunId, null);
+      assertEquals(result.failure.terminalErrorMessage, "bootstrap failed");
+    }
   });
 });

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -36,10 +36,16 @@ import {
   type HostedProjectReferenceResolver,
   resolveHostedProjectReference,
 } from "./project-reference-resolver.ts";
+import {
+  exchangeHostedChildRunEventWriterToken,
+  HostedChildRunEventWriterTokenExchangeError,
+} from "./child-run-event-writer-token.ts";
 
 /** Options accepted by hosted durable child execution. */
 export type HostedDurableChildExecutionOptions = {
   durableChildRun?: HostedChildRunIdentifiers;
+  /** @internal Exact-run credential used only for durable child event persistence. */
+  runEventAppendToken?: string;
 };
 
 /** Result returned from hosted durable child invoke. */
@@ -414,6 +420,7 @@ export type HostedDurableChildBootstrapCallbacks = {
 /** Public API contract for hosted durable child runtime dependencies. */
 export type HostedDurableChildRuntimeDependencies = {
   bootstrapChildRun?: typeof bootstrapHostedChildRun;
+  exchangeChildRunEventWriterToken?: typeof exchangeHostedChildRunEventWriterToken;
   createLifecycleAdapter?: typeof createConversationChildLifecycleAdapter;
   runLifecycle?: typeof runHostedChildExecutionLifecycle;
   shouldSkipTerminalPersistence?: typeof shouldSkipHostedChildTerminalPersistence;
@@ -425,6 +432,8 @@ export type ExecuteHostedDurableChildForkInput<
   TLocalResult extends ChildRunExecutionResult,
 > = {
   authToken: string;
+  /** @internal Verified active-parent credential used only to mint the child writer token. */
+  runEventAppendToken?: string;
   apiUrl: string;
   forkInput: HostedChildForkToolInput;
   executionOptions: {
@@ -613,34 +622,12 @@ async function executeHostedDurableChildLifecycle<
   input: ExecuteHostedDurableChildForkInput<TResult, TLocalResult> & {
     bootstrapContext: HostedDurableChildBootstrapContext;
     identifiers: HostedChildRunIdentifiers;
+    childRunEventAppendToken: string;
   },
 ): Promise<TResult> {
   const { bootstrapContext, identifiers } = input;
   const { targets } = bootstrapContext;
-  const createLifecycleAdapter = input.runtime?.createLifecycleAdapter ??
-    createConversationChildLifecycleAdapter;
-  const lifecycleAdapter = createLifecycleAdapter({
-    authToken: input.authToken,
-    apiUrl: input.apiUrl,
-    parentConversationId: bootstrapContext.parentConversationId,
-    parentRunId: bootstrapContext.parentRunId,
-    projectId: input.getProjectId(),
-    publishParentRunEvents: input.publishParentRunEvents,
-    progress: {
-      toolCallId: input.executionOptions.toolCallId,
-      childAgentId: input.childAgentId,
-      childConversationId: identifiers.childConversationId,
-      childRunId: identifiers.childRunId,
-      childMessageId: identifiers.childMessageId,
-      description: input.forkInput.description,
-      sourceTargetKind: targets.sourceTargetKind,
-      runtimeTargetKind: targets.runtimeTargetKind,
-      targetEnvironmentId: targets.targetEnvironmentId,
-      targetBranchId: targets.targetBranchId,
-    },
-    model: bootstrapContext.resolvedModel,
-    provider: bootstrapContext.provider,
-  });
+  const lifecycleAdapter = createDurableChildLifecycleAdapter(input);
 
   const runLifecycle = input.runtime?.runLifecycle ?? runHostedChildExecutionLifecycle;
   const skipTerminalPersistence = input.runtime?.shouldSkipTerminalPersistence ??
@@ -652,6 +639,7 @@ async function executeHostedDurableChildLifecycle<
     execute: () =>
       input.executeLocal({
         durableChildRun: identifiers,
+        runEventAppendToken: input.childRunEventAppendToken,
       }),
     getExecutionSnapshot: input.getExecutionSnapshot,
     onLifecycleError: input.onLifecycleError,
@@ -686,6 +674,44 @@ async function executeHostedDurableChildLifecycle<
     snapshot: lifecycleResult.snapshot,
     identifiers,
     targets,
+  });
+}
+
+function createDurableChildLifecycleAdapter<
+  TResult,
+  TLocalResult extends ChildRunExecutionResult,
+>(
+  input: ExecuteHostedDurableChildForkInput<TResult, TLocalResult> & {
+    bootstrapContext: HostedDurableChildBootstrapContext;
+    identifiers: HostedChildRunIdentifiers;
+  },
+) {
+  const { bootstrapContext, identifiers } = input;
+  const { targets } = bootstrapContext;
+  const createLifecycleAdapter = input.runtime?.createLifecycleAdapter ??
+    createConversationChildLifecycleAdapter;
+
+  return createLifecycleAdapter({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    parentConversationId: bootstrapContext.parentConversationId,
+    parentRunId: bootstrapContext.parentRunId,
+    projectId: input.getProjectId(),
+    publishParentRunEvents: input.publishParentRunEvents,
+    progress: {
+      toolCallId: input.executionOptions.toolCallId,
+      childAgentId: input.childAgentId,
+      childConversationId: identifiers.childConversationId,
+      childRunId: identifiers.childRunId,
+      childMessageId: identifiers.childMessageId,
+      description: input.forkInput.description,
+      sourceTargetKind: targets.sourceTargetKind,
+      runtimeTargetKind: targets.runtimeTargetKind,
+      targetEnvironmentId: targets.targetEnvironmentId,
+      targetBranchId: targets.targetBranchId,
+    },
+    model: bootstrapContext.resolvedModel,
+    provider: bootstrapContext.provider,
   });
 }
 
@@ -733,9 +759,61 @@ export async function executeHostedDurableChildFork<
     });
   }
 
+  let childRunEventAppendToken: string;
+  try {
+    if (!input.runEventAppendToken) {
+      throw new HostedChildRunEventWriterTokenExchangeError();
+    }
+    const exchangeChildRunEventWriterToken = input.runtime?.exchangeChildRunEventWriterToken ??
+      exchangeHostedChildRunEventWriterToken;
+    childRunEventAppendToken = await exchangeChildRunEventWriterToken({
+      apiUrl: input.apiUrl,
+      parentRunId: bootstrapContext.parentRunId,
+      childRunId: identifiers.childRunId,
+      runEventAppendToken: input.runEventAppendToken,
+      abortSignal: input.executionOptions.abortSignal,
+    });
+  } catch {
+    const setupError = new HostedChildRunEventWriterTokenExchangeError();
+    await input.bootstrap?.onBootstrapError?.({
+      error: setupError,
+      parentConversationId: bootstrapContext.parentConversationId,
+      toolCallId: input.executionOptions.toolCallId,
+    });
+
+    const terminalState = {
+      status: "failed" as const,
+      terminalErrorCode: input.setupFailedCode,
+      terminalErrorMessage: setupError.message,
+    };
+    try {
+      await createDurableChildLifecycleAdapter({
+        ...input,
+        bootstrapContext,
+        identifiers,
+      }).failed?.(terminalState);
+    } catch (lifecycleError) {
+      if (input.onLifecycleError) {
+        await input.onLifecycleError(lifecycleError);
+      } else {
+        throw lifecycleError;
+      }
+    }
+
+    return input.buildSetupFailureResult({
+      targets,
+      childConversationId: identifiers.childConversationId,
+      childRunId: identifiers.childRunId,
+      childMessageId: identifiers.childMessageId,
+      terminalErrorCode: input.setupFailedCode,
+      terminalErrorMessage: setupError.message,
+    });
+  }
+
   return executeHostedDurableChildLifecycle({
     ...input,
     bootstrapContext,
     identifiers,
+    childRunEventAppendToken,
   });
 }

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -37,15 +37,15 @@ import {
   resolveHostedProjectReference,
 } from "./project-reference-resolver.ts";
 import {
-  exchangeHostedChildRunEventWriterToken,
   HostedChildRunEventWriterTokenExchangeError,
+  type HostedRunEventWriterCapability,
 } from "./child-run-event-writer-token.ts";
 
 /** Options accepted by hosted durable child execution. */
 export type HostedDurableChildExecutionOptions = {
   durableChildRun?: HostedChildRunIdentifiers;
-  /** @internal Exact-run credential used only for durable child event persistence. */
-  runEventAppendToken?: string;
+  /** @internal Non-serializable exact-run authority for nested durable children. */
+  runEventWriterCapability?: HostedRunEventWriterCapability;
 };
 
 /** Result returned from hosted durable child invoke. */
@@ -420,7 +420,6 @@ export type HostedDurableChildBootstrapCallbacks = {
 /** Public API contract for hosted durable child runtime dependencies. */
 export type HostedDurableChildRuntimeDependencies = {
   bootstrapChildRun?: typeof bootstrapHostedChildRun;
-  exchangeChildRunEventWriterToken?: typeof exchangeHostedChildRunEventWriterToken;
   createLifecycleAdapter?: typeof createConversationChildLifecycleAdapter;
   runLifecycle?: typeof runHostedChildExecutionLifecycle;
   shouldSkipTerminalPersistence?: typeof shouldSkipHostedChildTerminalPersistence;
@@ -432,8 +431,8 @@ export type ExecuteHostedDurableChildForkInput<
   TLocalResult extends ChildRunExecutionResult,
 > = {
   authToken: string;
-  /** @internal Verified active-parent credential used only to mint the child writer token. */
-  runEventAppendToken?: string;
+  /** @internal Non-serializable active-run authority used only for direct children. */
+  runEventWriterCapability?: HostedRunEventWriterCapability;
   apiUrl: string;
   forkInput: HostedChildForkToolInput;
   executionOptions: {
@@ -622,7 +621,7 @@ async function executeHostedDurableChildLifecycle<
   input: ExecuteHostedDurableChildForkInput<TResult, TLocalResult> & {
     bootstrapContext: HostedDurableChildBootstrapContext;
     identifiers: HostedChildRunIdentifiers;
-    childRunEventAppendToken: string;
+    childRunEventWriterCapability: HostedRunEventWriterCapability;
   },
 ): Promise<TResult> {
   const { bootstrapContext, identifiers } = input;
@@ -639,7 +638,7 @@ async function executeHostedDurableChildLifecycle<
     execute: () =>
       input.executeLocal({
         durableChildRun: identifiers,
-        runEventAppendToken: input.childRunEventAppendToken,
+        runEventWriterCapability: input.childRunEventWriterCapability,
       }),
     getExecutionSnapshot: input.getExecutionSnapshot,
     onLifecycleError: input.onLifecycleError,
@@ -715,11 +714,7 @@ function createDurableChildLifecycleAdapter<
   });
 }
 
-/**
- * Reports a bootstrap failure through the observability-only callback. The callback must
- * never abort child finalization or the setup-failure result, so its own failure is
- * routed to the lifecycle-error sink instead of propagating.
- */
+/** Report an observability callback failure without changing durable setup control flow. */
 async function notifyBootstrapError(
   callbacks: {
     onBootstrapError?: HostedDurableChildBootstrapCallbacks["onBootstrapError"];
@@ -733,7 +728,7 @@ async function notifyBootstrapError(
     try {
       await callbacks.onCallbackError?.(callbackError);
     } catch {
-      // The reporting sink itself failed; there is no further channel to report to.
+      // Observability must not alter durable setup or terminal persistence.
     }
   }
 }
@@ -788,26 +783,28 @@ export async function executeHostedDurableChildFork<
     });
   }
 
-  let childRunEventAppendToken: string;
+  let childRunEventWriterCapability: HostedRunEventWriterCapability;
   try {
-    if (!input.runEventAppendToken) {
+    if (!input.runEventWriterCapability) {
       throw new HostedChildRunEventWriterTokenExchangeError();
     }
-    const exchangeChildRunEventWriterToken = input.runtime?.exchangeChildRunEventWriterToken ??
-      exchangeHostedChildRunEventWriterToken;
-    childRunEventAppendToken = await exchangeChildRunEventWriterToken({
-      apiUrl: input.apiUrl,
-      parentRunId: bootstrapContext.parentRunId,
-      childRunId: identifiers.childRunId,
-      runEventAppendToken: input.runEventAppendToken,
-      abortSignal: input.executionOptions.abortSignal,
-    });
-  } catch {
-    const setupError = new HostedChildRunEventWriterTokenExchangeError();
+    childRunEventWriterCapability = await input.runEventWriterCapability
+      .mintChildRunEventAppendToken(
+        identifiers.childRunId,
+        input.executionOptions.abortSignal,
+      );
+  } catch (error) {
+    const setupError = new HostedChildRunEventWriterTokenExchangeError(
+      error instanceof HostedChildRunEventWriterTokenExchangeError
+        ? error.classification
+        : input.executionOptions.abortSignal?.aborted
+        ? "aborted"
+        : "failed",
+    );
     await notifyBootstrapError(
       {
         onBootstrapError: input.bootstrap?.onBootstrapError,
-        onCallbackError: input.onLifecycleError,
+        onCallbackError: () => input.onLifecycleError?.(setupError),
       },
       {
         error: setupError,
@@ -827,11 +824,11 @@ export async function executeHostedDurableChildFork<
         bootstrapContext,
         identifiers,
       }).failed?.(terminalState);
-    } catch (lifecycleError) {
-      if (input.onLifecycleError) {
-        await input.onLifecycleError(lifecycleError);
-      } else {
-        throw lifecycleError;
+    } catch {
+      try {
+        await input.onLifecycleError?.(setupError);
+      } catch {
+        // The structured setup failure remains authoritative and sanitized.
       }
     }
 
@@ -849,6 +846,6 @@ export async function executeHostedDurableChildFork<
     ...input,
     bootstrapContext,
     identifiers,
-    childRunEventAppendToken,
+    childRunEventWriterCapability,
   });
 }

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -37,15 +37,25 @@ import {
   resolveHostedProjectReference,
 } from "./project-reference-resolver.ts";
 import {
+  getActiveHostedRunEventWriterCapability,
   HostedChildRunEventWriterTokenExchangeError,
   type HostedRunEventWriterCapability,
+  runWithHostedRunEventWriterCapability,
 } from "./child-run-event-writer-token.ts";
+
+const CHILD_RUN_FINALIZATION_ERROR = "Unable to finalize durable child run after setup failure";
+
+/** Sanitized failure raised when setup-failure finalization itself cannot be persisted. */
+export class HostedChildRunFinalizationError extends Error {
+  constructor() {
+    super(CHILD_RUN_FINALIZATION_ERROR);
+    this.name = "HostedChildRunFinalizationError";
+  }
+}
 
 /** Options accepted by hosted durable child execution. */
 export type HostedDurableChildExecutionOptions = {
   durableChildRun?: HostedChildRunIdentifiers;
-  /** @internal Non-serializable exact-run authority for nested durable children. */
-  runEventWriterCapability?: HostedRunEventWriterCapability;
 };
 
 /** Result returned from hosted durable child invoke. */
@@ -431,8 +441,6 @@ export type ExecuteHostedDurableChildForkInput<
   TLocalResult extends ChildRunExecutionResult,
 > = {
   authToken: string;
-  /** @internal Non-serializable active-run authority used only for direct children. */
-  runEventWriterCapability?: HostedRunEventWriterCapability;
   apiUrl: string;
   forkInput: HostedChildForkToolInput;
   executionOptions: {
@@ -636,10 +644,10 @@ async function executeHostedDurableChildLifecycle<
     executionFailedCode: input.executionFailedCode,
     abortSignal: input.executionOptions.abortSignal,
     execute: () =>
-      input.executeLocal({
-        durableChildRun: identifiers,
-        runEventWriterCapability: input.childRunEventWriterCapability,
-      }),
+      runWithHostedRunEventWriterCapability(
+        input.childRunEventWriterCapability,
+        () => input.executeLocal({ durableChildRun: identifiers }),
+      ),
     getExecutionSnapshot: input.getExecutionSnapshot,
     onLifecycleError: input.onLifecycleError,
     skipTerminalPersistence,
@@ -741,6 +749,7 @@ export async function executeHostedDurableChildFork<
   input: ExecuteHostedDurableChildForkInput<TResult, TLocalResult>,
 ): Promise<TResult> {
   throwIfChildRunAborted(input.executionOptions.abortSignal);
+  const runEventWriterCapability = getActiveHostedRunEventWriterCapability();
 
   if (!input.parentConversationId || !input.parentRunId || !input.parentMessageId) {
     return input.buildContextUnavailableResult(input.contextUnavailableMessage);
@@ -785,10 +794,10 @@ export async function executeHostedDurableChildFork<
 
   let childRunEventWriterCapability: HostedRunEventWriterCapability;
   try {
-    if (!input.runEventWriterCapability) {
+    if (!runEventWriterCapability) {
       throw new HostedChildRunEventWriterTokenExchangeError();
     }
-    childRunEventWriterCapability = await input.runEventWriterCapability
+    childRunEventWriterCapability = await runEventWriterCapability
       .mintChildRunEventAppendToken(
         identifiers.childRunId,
         input.executionOptions.abortSignal,
@@ -813,33 +822,54 @@ export async function executeHostedDurableChildFork<
       },
     );
 
-    const terminalState = {
-      status: "failed" as const,
-      terminalErrorCode: input.setupFailedCode,
-      terminalErrorMessage: setupError.message,
-    };
+    const cancelled = setupError.classification === "aborted";
+    const terminalState = cancelled
+      ? {
+        status: "cancelled" as const,
+        terminalErrorCode: "CANCELLED",
+        terminalErrorMessage: "Child run cancelled",
+      }
+      : {
+        status: "failed" as const,
+        terminalErrorCode: input.setupFailedCode,
+        terminalErrorMessage: setupError.message,
+      };
     try {
-      await createDurableChildLifecycleAdapter({
+      const lifecycleAdapter = createDurableChildLifecycleAdapter({
         ...input,
         bootstrapContext,
         identifiers,
-      }).failed?.(terminalState);
+      });
+      if (cancelled) {
+        await lifecycleAdapter.cancelled?.(terminalState);
+      } else {
+        await lifecycleAdapter.failed?.(terminalState);
+      }
     } catch {
       try {
-        await input.onLifecycleError?.(setupError);
+        await input.onLifecycleError?.(new HostedChildRunFinalizationError());
       } catch {
-        // The structured setup failure remains authoritative and sanitized.
+        // The structured terminal result remains authoritative and sanitized.
       }
     }
 
-    return input.buildSetupFailureResult({
+    const failure = {
       targets,
       childConversationId: identifiers.childConversationId,
       childRunId: identifiers.childRunId,
       childMessageId: identifiers.childMessageId,
-      terminalErrorCode: input.setupFailedCode,
-      terminalErrorMessage: setupError.message,
-    });
+      terminalErrorCode: terminalState.terminalErrorCode,
+      terminalErrorMessage: terminalState.terminalErrorMessage,
+    };
+    return cancelled
+      ? input.buildTerminalFailureResult({
+        status: "cancelled",
+        identifiers,
+        targets,
+        terminalErrorCode: terminalState.terminalErrorCode,
+        terminalErrorMessage: terminalState.terminalErrorMessage,
+      })
+      : input.buildSetupFailureResult(failure);
   }
 
   return executeHostedDurableChildLifecycle({

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -715,6 +715,29 @@ function createDurableChildLifecycleAdapter<
   });
 }
 
+/**
+ * Reports a bootstrap failure through the observability-only callback. The callback must
+ * never abort child finalization or the setup-failure result, so its own failure is
+ * routed to the lifecycle-error sink instead of propagating.
+ */
+async function notifyBootstrapError(
+  callbacks: {
+    onBootstrapError?: HostedDurableChildBootstrapCallbacks["onBootstrapError"];
+    onCallbackError?: (error: unknown) => Promise<void> | void;
+  },
+  payload: { error: unknown; parentConversationId: string; toolCallId: string },
+): Promise<void> {
+  try {
+    await callbacks.onBootstrapError?.(payload);
+  } catch (callbackError) {
+    try {
+      await callbacks.onCallbackError?.(callbackError);
+    } catch {
+      // The reporting sink itself failed; there is no further channel to report to.
+    }
+  }
+}
+
 /** Execute hosted durable child fork. */
 export async function executeHostedDurableChildFork<
   TResult,
@@ -743,11 +766,17 @@ export async function executeHostedDurableChildFork<
       bootstrapContext,
     });
   } catch (error) {
-    await input.bootstrap?.onBootstrapError?.({
-      error,
-      parentConversationId: bootstrapContext.parentConversationId,
-      toolCallId: input.executionOptions.toolCallId,
-    });
+    await notifyBootstrapError(
+      {
+        onBootstrapError: input.bootstrap?.onBootstrapError,
+        onCallbackError: input.onLifecycleError,
+      },
+      {
+        error,
+        parentConversationId: bootstrapContext.parentConversationId,
+        toolCallId: input.executionOptions.toolCallId,
+      },
+    );
 
     return input.buildSetupFailureResult({
       targets,
@@ -775,11 +804,17 @@ export async function executeHostedDurableChildFork<
     });
   } catch {
     const setupError = new HostedChildRunEventWriterTokenExchangeError();
-    await input.bootstrap?.onBootstrapError?.({
-      error: setupError,
-      parentConversationId: bootstrapContext.parentConversationId,
-      toolCallId: input.executionOptions.toolCallId,
-    });
+    await notifyBootstrapError(
+      {
+        onBootstrapError: input.bootstrap?.onBootstrapError,
+        onCallbackError: input.onLifecycleError,
+      },
+      {
+        error: setupError,
+        parentConversationId: bootstrapContext.parentConversationId,
+        toolCallId: input.executionOptions.toolCallId,
+      },
+    );
 
     const terminalState = {
       status: "failed" as const,

--- a/src/agent/hosted/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.test.ts
@@ -652,7 +652,6 @@ Deno.test("hosted nested delegates inherit child scope and durable lineage", () 
   const context = veryfrontCloudAgentServiceInternals.buildHostedChildToolContext(
     {
       authToken: "token-1",
-      runEventAppendToken: "active-child-writer-token",
       projectId: "project-1",
       branchId: "branch-1",
       agentId: "orchestrator",
@@ -697,7 +696,7 @@ Deno.test("hosted nested delegates inherit child scope and durable lineage", () 
   assertEquals(context.conversationId, "child-conversation");
   assertEquals(context.parentRunId, "child-run");
   assertEquals(context.parentMessageId, "child-message");
-  assertEquals(context.runEventAppendToken, "active-child-writer-token");
+  assertEquals("runEventAppendToken" in context, false);
 });
 
 Deno.test("hosted nested delegates clear inherited skill catalog state for empty child selectors", () => {

--- a/src/agent/hosted/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.test.ts
@@ -652,6 +652,7 @@ Deno.test("hosted nested delegates inherit child scope and durable lineage", () 
   const context = veryfrontCloudAgentServiceInternals.buildHostedChildToolContext(
     {
       authToken: "token-1",
+      runEventAppendToken: "active-child-writer-token",
       projectId: "project-1",
       branchId: "branch-1",
       agentId: "orchestrator",
@@ -696,6 +697,7 @@ Deno.test("hosted nested delegates inherit child scope and durable lineage", () 
   assertEquals(context.conversationId, "child-conversation");
   assertEquals(context.parentRunId, "child-run");
   assertEquals(context.parentMessageId, "child-message");
+  assertEquals(context.runEventAppendToken, "active-child-writer-token");
 });
 
 Deno.test("hosted nested delegates clear inherited skill catalog state for empty child selectors", () => {

--- a/src/agent/service/route-export.check.ts
+++ b/src/agent/service/route-export.check.ts
@@ -2,8 +2,25 @@ import {
   agent,
   type AgentServiceRoute,
   createAgentServiceServerRuntime,
+  type DefaultHostedChatRuntimeCreationOptions,
   defineAgentService,
+  type HostedDurableChildExecutionOptions,
+  type ParsedHostedChatRequest,
+  type PrepareHostedConversationRootRunContextInput,
 } from "../index.ts";
+
+type ForbiddenRunEventAuthorityKey = "runEventAppendToken" | "runEventWriterCapability";
+type HasNoRunEventAuthorityKey<T> = Extract<keyof T, ForbiddenRunEventAuthorityKey> extends never
+  ? true
+  : false;
+
+const publicRunEventAuthorityBoundary: [
+  HasNoRunEventAuthorityKey<ParsedHostedChatRequest>,
+  HasNoRunEventAuthorityKey<PrepareHostedConversationRootRunContextInput>,
+  HasNoRunEventAuthorityKey<DefaultHostedChatRuntimeCreationOptions>,
+  HasNoRunEventAuthorityKey<HostedDurableChildExecutionOptions>,
+] = [true, true, true, true];
+void publicRunEventAuthorityBoundary;
 
 const routes: AgentServiceRoute[] = [
   {

--- a/src/agent/service/routes.test.ts
+++ b/src/agent/service/routes.test.ts
@@ -227,18 +227,21 @@ it("agent service routes bind verified run-event tokens on both production launc
   assertEquals(
     preparedRequests.map((request) => ({
       authToken: request.authToken,
-      runEventAppendToken: request.runEventAppendToken,
+      hasRunEventAppendToken: "runEventAppendToken" in request,
+      serializedToken: JSON.stringify(request).includes("run-event-service-token"),
       serverEnvelopeVerified: request.serverEnvelopeVerified,
     })),
     [
       {
         authToken: createDevToken({ userId: "user-1" }),
-        runEventAppendToken: "run-event-service-token",
+        hasRunEventAppendToken: false,
+        serializedToken: false,
         serverEnvelopeVerified: undefined,
       },
       {
         authToken: createDevToken({ userId: "user-1" }),
-        runEventAppendToken: "run-event-service-token",
+        hasRunEventAppendToken: false,
+        serializedToken: false,
         serverEnvelopeVerified: true,
       },
     ],
@@ -342,7 +345,8 @@ it("a verified writer token does not trust ordinary durable-chat body state", as
 
   assertEquals(response.status, 202);
   assertEquals(preparedRequests[0]?.serverEnvelopeVerified, undefined);
-  assertEquals(preparedRequests[0]?.runEventAppendToken, "verified-event-token");
+  assertEquals("runEventAppendToken" in (preparedRequests[0] ?? {}), false);
+  assertEquals(JSON.stringify(preparedRequests[0]).includes("verified-event-token"), false);
   assertEquals(preparedRequests[0]?.forwardedProps, undefined);
   assertEquals(resolved, [{ checkpoint: undefined }]);
 });
@@ -382,7 +386,8 @@ it("verified control-plane envelopes accept private state without returning it p
 
   assertEquals(response.status, 202);
   assertEquals(preparedRequests[0]?.serverEnvelopeVerified, true);
-  assertEquals(preparedRequests[0]?.runEventAppendToken, "verified-event-token");
+  assertEquals("runEventAppendToken" in (preparedRequests[0] ?? {}), false);
+  assertEquals(JSON.stringify(preparedRequests[0]).includes("verified-event-token"), false);
   assertEquals(resolved, [{ checkpoint }]);
   const publicBody = await response.text();
   assertEquals(publicBody.includes("AGENT_RUN_TOOL_EXPOSURE_CHECKPOINT"), false);

--- a/src/agent/service/routes.test.ts
+++ b/src/agent/service/routes.test.ts
@@ -7,6 +7,8 @@ import type { ParsedHostedChatRequest } from "../hosted/chat-request-parser.ts";
 import type { HostedRuntimeSourceIdentity } from "../hosted/runtime-source-binding.ts";
 import type { AgUiResumeValue } from "../ag-ui/tool-shared.ts";
 import { getServerResolvedToolExposureCheckpoint } from "../hosted/runtime-request-config.ts";
+import { createHostedRunEventWriterCapabilityForRequest } from "../hosted/child-run-event-writer-token.ts";
+import type { HostedAgentServiceDetachedExecutionInput } from "./routes.ts";
 
 const runtimeSource = { type: "release", releaseId: "release-42" } as const;
 
@@ -30,6 +32,22 @@ function createAuthenticatedRequest(
       ...Object.fromEntries(new Headers(headers)),
     },
     body: method === "DELETE" ? undefined : JSON.stringify(body),
+  });
+}
+
+function withImmutableHeaders(request: Request): Request {
+  const headers = new Headers(request.headers);
+  Object.defineProperty(headers, "delete", {
+    value: () => {
+      throw new TypeError("immutable headers");
+    },
+  });
+  return new Proxy(request, {
+    get(target, property) {
+      if (property === "headers") return headers;
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
   });
 }
 
@@ -75,6 +93,9 @@ function createRouteSet(input: {
     projectId: string;
     runId: string;
   }) => Promise<boolean>;
+  startDetachedExecution?: (
+    input: HostedAgentServiceDetachedExecutionInput<{ executionId: string }>,
+  ) => Promise<void>;
 } = {}) {
   const tracker = createDetachedRunTracker<AgUiResumeValue>();
   const preparedRequests: ParsedHostedChatRequest[] = [];
@@ -104,7 +125,7 @@ function createRouteSet(input: {
       });
       return input.streamResponse ?? new Response("streamed");
     },
-    startDetachedExecution: async () => {},
+    startDetachedExecution: input.startDetachedExecution ?? (async () => {}),
   });
 
   return { routeSet, tracker, preparedRequests, streamInputs };
@@ -258,6 +279,111 @@ it("agent service routes bind verified run-event tokens on both production launc
       runId: "run-1",
     },
   ]);
+});
+
+it("agent service routes remove verified writer credentials before detached callbacks", async () => {
+  const sentinel = "verified-root-writer-sentinel";
+  const detachedRequests: Request[] = [];
+  const childAuthorizations: Array<string | null> = [];
+  let headerWasPresentDuringVerification = false;
+  const ingressRequest = createAuthenticatedRequest(
+    "/api/runs",
+    {
+      messages: [],
+      context: {
+        conversationId: "00000000-0000-4000-8000-000000000001",
+        projectId: "00000000-0000-4000-8000-000000000005",
+        branchId: null,
+      },
+      durableRootRun: {
+        runId: "run-1",
+        messageId: "00000000-0000-4000-8000-000000000002",
+      },
+    },
+    "POST",
+    { "X-Veryfront-Run-Event-Token": sentinel },
+  );
+  const { routeSet } = createRouteSet({
+    verifyRunEventAppendToken: async () => {
+      headerWasPresentDuringVerification = ingressRequest.headers.get(
+        "X-Veryfront-Run-Event-Token",
+      ) === sentinel;
+      return true;
+    },
+    prepareExecution: async (request) => {
+      const capability = createHostedRunEventWriterCapabilityForRequest(request, {
+        apiUrl: "https://api.example.test",
+        runId: "run-1",
+        fetch: async (_input, init) => {
+          childAuthorizations.push(new Headers(init?.headers).get("authorization"));
+          return Response.json(
+            { run_event_token: "child-writer-token" },
+            { headers: { "Cache-Control": "no-store" } },
+          );
+        },
+      });
+      await capability?.mintChildRunEventAppendToken("child-run-1");
+      return { executionId: "exec-sanitized" };
+    },
+    startDetachedExecution: async ({ rawRequest }) => {
+      detachedRequests.push(rawRequest);
+    },
+  });
+  const response = await routeSet.handleDurableChatRunExecuteRequest({
+    request: ingressRequest,
+    requestOrCtx: ingressRequest,
+  });
+
+  assertEquals(response.status, 202);
+  assertEquals(headerWasPresentDuringVerification, true);
+  assertEquals(childAuthorizations, [`Bearer ${sentinel}`]);
+  assertEquals(detachedRequests.length, 1);
+  assertEquals(
+    detachedRequests[0]?.headers.has("X-Veryfront-Run-Event-Token"),
+    false,
+  );
+  assertEquals(JSON.stringify([...detachedRequests[0]!.headers]).includes(sentinel), false);
+});
+
+it("agent service routes clone verified requests when host headers are immutable", async () => {
+  const sentinel = "immutable-root-writer-sentinel";
+  const detachedRequests: Request[] = [];
+  const ingressRequest = withImmutableHeaders(createAuthenticatedRequest(
+    "/api/runs",
+    {
+      messages: [],
+      context: {
+        conversationId: "00000000-0000-4000-8000-000000000001",
+        projectId: "00000000-0000-4000-8000-000000000005",
+        branchId: null,
+      },
+      durableRootRun: {
+        runId: "run-1",
+        messageId: "00000000-0000-4000-8000-000000000002",
+      },
+    },
+    "POST",
+    { "X-Veryfront-Run-Event-Token": sentinel },
+  ));
+  const { routeSet } = createRouteSet({
+    verifyRunEventAppendToken: () => Promise.resolve(true),
+    startDetachedExecution: async ({ rawRequest }) => {
+      detachedRequests.push(rawRequest);
+    },
+  });
+
+  const response = await routeSet.handleDurableChatRunExecuteRequest({
+    request: ingressRequest,
+  });
+
+  assertEquals(response.status, 202);
+  assertEquals(detachedRequests.length, 1);
+  assertEquals(detachedRequests[0] === ingressRequest, false);
+  assertEquals(
+    detachedRequests[0]?.headers.has("X-Veryfront-Run-Event-Token"),
+    false,
+  );
+  assertEquals(JSON.stringify([...detachedRequests[0]!.headers]).includes(sentinel), false);
 });
 
 it("ordinary durable-chat routes strip spoofed server-resolved tool state", async () => {

--- a/src/agent/service/routes.ts
+++ b/src/agent/service/routes.ts
@@ -25,6 +25,7 @@ import {
   type HostedRuntimeSourceIdentity,
   snapshotHostedRuntimeSourceIdentity,
 } from "../hosted/runtime-source-binding.ts";
+import { getSanitizedHostedRunEventWriterRequest } from "../hosted/child-run-event-writer-token.ts";
 
 /** Public API contract for hosted agent service routes logger. */
 export type HostedAgentServiceRoutesLogger = {
@@ -66,6 +67,7 @@ export type AgentServiceStreamExecutionInput<TExecution extends object> =
 export type HostedAgentServiceDetachedExecutionInput<TExecution extends object> = {
   execution: TExecution;
   abortSignal: AbortSignal;
+  rawRequest: Request;
 };
 
 /** Input payload for agent service detached execution. */
@@ -285,10 +287,12 @@ export function createHostedAgentServiceRouteSet<TExecution extends object>(
     request: Request;
     requestOrCtx?: unknown;
   }): Promise<Response> {
+    const rawRequest = getSanitizedHostedRunEventWriterRequest(input.req, input.request);
+    const requestOrCtx = input.requestOrCtx instanceof Request ? rawRequest : input.requestOrCtx;
     return executeHostedDurableChatRun({
       req: input.req,
-      rawRequest: input.request,
-      requestOrCtx: input.requestOrCtx,
+      rawRequest,
+      requestOrCtx,
       tracker: options.tracker,
       prepareExecution: options.prepareExecution,
       startDetachedExecution: options.startDetachedExecution,

--- a/src/platform/adapters/veryfront-api-transport.ts
+++ b/src/platform/adapters/veryfront-api-transport.ts
@@ -19,6 +19,10 @@ import {
   readResponseJsonStringBytesWithinLimit,
   readResponseTextPrefix,
 } from "#veryfront/utils/response-body.ts";
+import {
+  createVeryfrontApiRequestUrlResolver,
+  type VeryfrontApiRequestUrlResolver,
+} from "./veryfront-api-url.ts";
 
 const log = serverLogger.component("veryfront-api-transport");
 const apiClientLog = serverLogger.component("veryfront-api-client");
@@ -27,11 +31,6 @@ const MAX_VERYFRONT_API_ERROR_BODY_BYTES = 8 * 1024;
 export const DEFAULT_VERYFRONT_API_SUCCESS_BODY_BYTES = 64 * 1024 * 1024;
 export const MAX_VERYFRONT_API_SUCCESS_BODY_BYTES = 128 * 1024 * 1024;
 const NON_RETRYABLE_RESPONSE_PROTOCOL_ERRORS = new WeakSet<object>();
-
-interface ValidatedBaseUrl {
-  origin: string;
-  prefix: string;
-}
 
 export type TransportRetryConfig = BoundedRetryConfig;
 
@@ -87,13 +86,17 @@ export function createVeryfrontApiTransport<T>(
   config: VeryfrontApiTransportConfig<T>,
 ): VeryfrontApiTransport<T> {
   const retry = requireVeryfrontApiRetryConfig(config.retry);
-  return createValidatedVeryfrontApiTransport(config, retry, validateBaseUrl(config.baseUrl));
+  return createValidatedVeryfrontApiTransport(
+    config,
+    retry,
+    createVeryfrontApiRequestUrlResolver(config.baseUrl),
+  );
 }
 
 function createValidatedVeryfrontApiTransport<T>(
   config: VeryfrontApiTransportConfig<T>,
   retry: TransportRetryConfig,
-  validatedBaseUrl: ValidatedBaseUrl,
+  resolveRequestUrl: VeryfrontApiRequestUrlResolver,
 ): VeryfrontApiTransport<T> {
   const {
     getToken,
@@ -130,7 +133,7 @@ function createValidatedVeryfrontApiTransport<T>(
         init.jsonStringFieldWithinLimit,
         maxResponseBytes,
       );
-      const url = resolveRequestUrl(validatedBaseUrl, pathOrUrl);
+      const url = resolveRequestUrl(pathOrUrl);
       const method = init.method ?? "GET";
       const timeoutMs = init.timeoutMs ?? cfgTimeout;
       const requestHeaders = new Headers(init.headers);
@@ -248,7 +251,7 @@ export function createCanonicalVeryfrontApiTransport(
       },
     },
     normalizedRetry,
-    validateBaseUrl(baseUrl),
+    createVeryfrontApiRequestUrlResolver(baseUrl),
   );
 }
 
@@ -541,71 +544,4 @@ function defaultShouldRetry(error: unknown): boolean {
   if (!(error instanceof VeryfrontError) || error.slug !== "api-client-error") return true;
   const { status } = error as VeryfrontError;
   return !status || status < 400 || status >= 500 || status === 429;
-}
-
-function validateBaseUrl(value: string): ValidatedBaseUrl {
-  if (typeof value !== "string" || value.length === 0 || value.trim() !== value) {
-    throw new TypeError("Veryfront API base URL must be a non-empty absolute URL");
-  }
-
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch (cause) {
-    throw new TypeError("Veryfront API base URL must be a valid absolute URL", {
-      cause,
-    });
-  }
-
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new TypeError("Veryfront API base URL must use http or https");
-  }
-  if (url.username || url.password) {
-    throw new TypeError("Veryfront API base URL must not contain credentials");
-  }
-  if (url.search || url.hash) {
-    throw new TypeError("Veryfront API base URL must not contain a query or fragment");
-  }
-
-  const pathname = url.pathname.replace(/\/+$/, "");
-  return {
-    origin: url.origin,
-    prefix: `${url.origin}${pathname}`,
-  };
-}
-
-function resolveRequestUrl(baseUrl: ValidatedBaseUrl, pathOrUrl: string): string {
-  if (typeof pathOrUrl !== "string") {
-    throw new TypeError("Veryfront API request URL must be a string");
-  }
-  if (pathOrUrl.startsWith("//")) {
-    throw new TypeError("Veryfront API request URL must not use a protocol-relative origin");
-  }
-
-  let absolute: URL | undefined;
-  try {
-    absolute = new URL(pathOrUrl);
-  } catch {
-    // Relative API paths are resolved below.
-  }
-
-  if (absolute) {
-    if (absolute.protocol !== "http:" && absolute.protocol !== "https:") {
-      throw new TypeError("Veryfront API request URL must use http or https");
-    }
-    if (absolute.username || absolute.password) {
-      throw new TypeError("Veryfront API request URL must not contain credentials");
-    }
-    if (absolute.origin !== baseUrl.origin) {
-      throw new TypeError("Veryfront API request origin must match the configured API origin");
-    }
-    return absolute.href;
-  }
-
-  const separator = pathOrUrl.startsWith("/") || pathOrUrl.startsWith("?") ? "" : "/";
-  const resolved = new URL(`${baseUrl.prefix}${separator}${pathOrUrl}`);
-  if (resolved.origin !== baseUrl.origin) {
-    throw new TypeError("Veryfront API request origin must match the configured API origin");
-  }
-  return resolved.href;
 }

--- a/src/platform/adapters/veryfront-api-url.test.ts
+++ b/src/platform/adapters/veryfront-api-url.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { createVeryfrontApiRequestUrlResolver } from "./veryfront-api-url.ts";
+
+Deno.test("Veryfront API URL resolver preserves configured base paths", () => {
+  const resolveUrl = createVeryfrontApiRequestUrlResolver("https://api.example.test/v1");
+
+  assertEquals(
+    resolveUrl("/runs/run_parent/children/run_child/event-writer-token"),
+    "https://api.example.test/v1/runs/run_parent/children/run_child/event-writer-token",
+  );
+  assertEquals(
+    resolveUrl("projects/project_1"),
+    "https://api.example.test/v1/projects/project_1",
+  );
+});
+
+Deno.test("Veryfront API URL resolver rejects a different request origin", () => {
+  const resolveUrl = createVeryfrontApiRequestUrlResolver("https://api.example.test/v1");
+
+  assertThrows(
+    () => resolveUrl("https://attacker.example/runs/run_1"),
+    TypeError,
+    "origin",
+  );
+});

--- a/src/platform/adapters/veryfront-api-url.ts
+++ b/src/platform/adapters/veryfront-api-url.ts
@@ -1,0 +1,86 @@
+interface ValidatedBaseUrl {
+  origin: string;
+  prefix: string;
+}
+
+export type VeryfrontApiRequestUrlResolver = (pathOrUrl: string) => string;
+
+/**
+ * Create the canonical resolver for Veryfront API endpoints.
+ *
+ * Relative request paths are appended to the configured base path. Absolute
+ * request URLs are accepted only when they use the configured origin.
+ */
+export function createVeryfrontApiRequestUrlResolver(
+  baseUrl: string,
+): VeryfrontApiRequestUrlResolver {
+  const validatedBaseUrl = validateBaseUrl(baseUrl);
+  return (pathOrUrl) => resolveRequestUrl(validatedBaseUrl, pathOrUrl);
+}
+
+function validateBaseUrl(value: string): ValidatedBaseUrl {
+  if (typeof value !== "string" || value.length === 0 || value.trim() !== value) {
+    throw new TypeError("Veryfront API base URL must be a non-empty absolute URL");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (cause) {
+    throw new TypeError("Veryfront API base URL must be a valid absolute URL", {
+      cause,
+    });
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new TypeError("Veryfront API base URL must use http or https");
+  }
+  if (url.username || url.password) {
+    throw new TypeError("Veryfront API base URL must not contain credentials");
+  }
+  if (url.search || url.hash) {
+    throw new TypeError("Veryfront API base URL must not contain a query or fragment");
+  }
+
+  const pathname = url.pathname.replace(/\/+$/, "");
+  return {
+    origin: url.origin,
+    prefix: `${url.origin}${pathname}`,
+  };
+}
+
+function resolveRequestUrl(baseUrl: ValidatedBaseUrl, pathOrUrl: string): string {
+  if (typeof pathOrUrl !== "string") {
+    throw new TypeError("Veryfront API request URL must be a string");
+  }
+  if (pathOrUrl.startsWith("//")) {
+    throw new TypeError("Veryfront API request URL must not use a protocol-relative origin");
+  }
+
+  let absolute: URL | undefined;
+  try {
+    absolute = new URL(pathOrUrl);
+  } catch {
+    // Relative API paths are resolved below.
+  }
+
+  if (absolute) {
+    if (absolute.protocol !== "http:" && absolute.protocol !== "https:") {
+      throw new TypeError("Veryfront API request URL must use http or https");
+    }
+    if (absolute.username || absolute.password) {
+      throw new TypeError("Veryfront API request URL must not contain credentials");
+    }
+    if (absolute.origin !== baseUrl.origin) {
+      throw new TypeError("Veryfront API request origin must match the configured API origin");
+    }
+    return absolute.href;
+  }
+
+  const separator = pathOrUrl.startsWith("/") || pathOrUrl.startsWith("?") ? "" : "/";
+  const resolved = new URL(`${baseUrl.prefix}${separator}${pathOrUrl}`);
+  if (resolved.origin !== baseUrl.origin) {
+    throw new TypeError("Veryfront API request origin must match the configured API origin");
+  }
+  return resolved.href;
+}


### PR DESCRIPTION
## Summary

- terminate the verified root writer credential at request ingress and retain it only in module-private WeakMap state
- keep root/child/grandchild writer authority behind private async-local scope and closures, absent from public request, runtime, lifecycle, and callback contracts
- exchange exact-parent authority for exact-child authority after durable child bootstrap and authorize each durable mirror with only its matching run credential
- classify exchange outcomes as aborted, timeout, or failed using the first winning cancellation signal without propagating abort reasons
- finalize post-bootstrap aborts as cancelled with the fixed CANCELLED result; timeout and exchange failures remain sanitized setup failures
- report failed terminal persistence as a distinct fixed HostedChildRunFinalizationError without replacing the authoritative result

## API dependency

Depends on veryfront-api#4237: https://github.com/veryfront/veryfront-api/pull/4237

Expected contract: POST /runs/{parentRunId}/children/{childRunId}/event-writer-token with the parent run writer credential and strict no-store {run_event_token:string} response.

Keep this PR draft until that API dependency is merged and the integration contract is reverified.

## Verification

- deno task verify:quick
- focused authority/request/lifecycle suite: 70 passed (92 steps), 0 failed
- isolated unrelated useUpload test: 15 steps passed
- deno doc src/agent/index.ts contains no runEventAppendToken, runEventWriterCapability, or HostedRunEventWriterCapability public surface
- full unit suite: 3,277 passed; known src/config/loader.test.ts dangling-promise failure remains, and one parallel-only useUpload timing failure passed immediately in isolation

## Security properties

- parsed requests, root lifecycle inputs, runtime creation options, child execution options, run-context callbacks, tool callbacks, Object.keys, JSON, logs, traces, and structured failures expose neither the raw token nor an authority property
- capability methods are non-enumerable and capability serialization contains no credential or authority data
- parent -> child -> grandchild exchange is tested once per direct edge with exact-parent authority
- no retry or request body on credential exchange; timeout, abort, and failure classifications are sanitized
- missing child authority prevents model/provider dispatch
- observer and terminal-finalization failures cannot replace or leak through the authoritative cancelled/setup result