### PR TITLE
fix(security): contain MCP parse diagnostics

### DIFF
--- a/cli/mcp/jsonrpc.test.ts
+++ b/cli/mcp/jsonrpc.test.ts
@@ -3,12 +3,65 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildInitializeResult,
+  internalError,
+  invalidRequestError,
   MCP_SUPPORTED_VERSIONS,
   negotiateVersion,
+  parseError,
   toParamsRecord,
 } from "./jsonrpc.ts";
 
 describe("cli/mcp/jsonrpc", () => {
+  describe("error responses", () => {
+    it("does not expose parser diagnostics to the client", () => {
+      const response = parseError(
+        new Error("Unexpected token at an internal source location"),
+      );
+
+      assertEquals(response, {
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32700,
+          message: "Parse error",
+        },
+      });
+    });
+
+    it("does not coerce untrusted thrown values", () => {
+      const response = parseError({
+        toString(): never {
+          throw new Error("untrusted coercion ran");
+        },
+      });
+
+      assertEquals(response.error?.message, "Parse error");
+      assertEquals(response.error?.data, undefined);
+    });
+
+    it("distinguishes invalid requests without exposing validation details", () => {
+      assertEquals(invalidRequestError(new Error("private schema detail")), {
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32600,
+          message: "Invalid Request",
+        },
+      });
+    });
+
+    it("contains unexpected handler failures", () => {
+      assertEquals(internalError(7), {
+        jsonrpc: "2.0",
+        id: 7,
+        error: {
+          code: -32603,
+          message: "Internal error",
+        },
+      });
+    });
+  });
+
   describe("toParamsRecord", () => {
     it("returns object params as-is", () => {
       const params = { foo: "bar" };

--- a/cli/mcp/jsonrpc.ts
+++ b/cli/mcp/jsonrpc.ts
@@ -27,7 +27,7 @@ export type JSONRPCRequest = InferSchema<ReturnType<typeof getJSONRPCRequestSche
  */
 export interface JSONRPCResponse {
   jsonrpc: "2.0";
-  id?: string | number;
+  id?: string | number | null;
   result?: unknown;
   error?: {
     code: number;
@@ -62,13 +62,45 @@ export class JsonRpcError extends Error {
 /**
  * Create a JSON-RPC parse error response
  */
-export function parseError(e: unknown): JSONRPCResponse {
+export function parseError(_error?: unknown): JSONRPCResponse {
   return {
     jsonrpc: "2.0",
+    id: null,
     error: {
       code: JSONRPC_ERRORS.PARSE_ERROR,
       message: "Parse error",
-      data: e instanceof Error ? e.message : String(e),
+    },
+  };
+}
+
+/**
+ * Create a JSON-RPC invalid-request response without reflecting validator
+ * diagnostics back to an untrusted client.
+ */
+export function invalidRequestError(_error?: unknown): JSONRPCResponse {
+  return {
+    jsonrpc: "2.0",
+    id: null,
+    error: {
+      code: JSONRPC_ERRORS.INVALID_REQUEST,
+      message: "Invalid Request",
+    },
+  };
+}
+
+/**
+ * Create a generic JSON-RPC internal-error response for failures outside a
+ * method handler's normal error boundary.
+ */
+export function internalError(
+  id: string | number | null | undefined,
+): JSONRPCResponse {
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: {
+      code: JSONRPC_ERRORS.INTERNAL_ERROR,
+      message: "Internal error",
     },
   };
 }

--- a/cli/mcp/server.test.ts
+++ b/cli/mcp/server.test.ts
@@ -522,8 +522,60 @@ describe("cli/mcp/server", { sanitizeOps: false, sanitizeResources: false }, () 
 
       assertEquals(response.status, 400);
       const data = await response.json();
-      assertExists(data.error);
-      assertEquals(data.error.code, -32700);
+      assertEquals(data, {
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32700,
+          message: "Parse error",
+        },
+      });
+    });
+
+    it("should distinguish invalid JSON-RPC requests", async () => {
+      const portNum = 19903;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 1,
+      });
+
+      assertEquals(response.status, 400);
+      assertEquals(await response.json(), {
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32600,
+          message: "Invalid Request",
+        },
+      });
+    });
+
+    it("should treat an empty HTTP body as malformed JSON", async () => {
+      const portNum = 19904;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await fetch(`http://localhost:${portNum}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      assertEquals(response.status, 400);
+      assertEquals(await response.json(), {
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32700,
+          message: "Parse error",
+        },
+      });
     });
 
     it("should negotiate protocol version 2025-11-25", async () => {

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -21,6 +21,8 @@ import { startStdioJsonRpc } from "./stdio.ts";
 import {
   buildInitializeResult,
   errorResponse,
+  internalError,
+  invalidRequestError,
   JsonRpcError,
   type JSONRPCRequest,
   JSONRPCRequestSchema,
@@ -88,7 +90,9 @@ export class MCPDevServer {
         isRunning: () => this.running,
         parseRequest: (payload) => JSONRPCRequestSchema.parse(payload),
         handleRequest: (request) => this.handleRequest(request),
-        toErrorResponse: (error) => parseError(error),
+        toParseErrorResponse: (error) => parseError(error),
+        toInvalidRequestResponse: (error) => invalidRequestError(error),
+        toErrorResponse: (_error, request) => internalError(request.id),
       });
     }
     if (this.config.httpPort) this.startHTTP(this.config.httpPort);
@@ -169,11 +173,9 @@ export class MCPDevServer {
         );
       }
 
+      let bodyText: string;
       try {
-        const bodyText = await readBodyWithLimit(req, 1_048_576);
-        const body = JSONRPCRequestSchema.parse(JSON.parse(bodyText));
-        const response = await this.handleRequest(body);
-        return new Response(JSON.stringify(response), { headers });
+        bodyText = await readBodyWithLimit(req, 1_048_576);
       } catch (e) {
         if (isRequestBodyTooLargeError(e)) {
           return new Response(
@@ -185,7 +187,37 @@ export class MCPDevServer {
             { status: 413, headers },
           );
         }
-        return new Response(JSON.stringify(parseError(e)), { status: 400, headers });
+        return new Response(JSON.stringify(invalidRequestError(e)), {
+          status: 400,
+          headers,
+        });
+      }
+
+      let payload: unknown;
+      try {
+        payload = JSON.parse(bodyText);
+      } catch (error) {
+        return new Response(JSON.stringify(parseError(error)), { status: 400, headers });
+      }
+
+      let body: JSONRPCRequest;
+      try {
+        body = JSONRPCRequestSchema.parse(payload);
+      } catch (error) {
+        return new Response(JSON.stringify(invalidRequestError(error)), {
+          status: 400,
+          headers,
+        });
+      }
+
+      try {
+        const response = await this.handleRequest(body);
+        return new Response(JSON.stringify(response), { headers });
+      } catch (_error) {
+        return new Response(JSON.stringify(internalError(body.id)), {
+          status: 500,
+          headers,
+        });
       }
     };
 

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -13,6 +13,8 @@ import { startStdioJsonRpc } from "./stdio.ts";
 import {
   buildInitializeResult,
   errorResponse,
+  internalError,
+  invalidRequestError,
   JsonRpcError,
   type JSONRPCRequest,
   JSONRPCRequestSchema,
@@ -57,7 +59,9 @@ export class StandaloneMCPServer {
       isRunning: () => this.running,
       parseRequest: (payload) => JSONRPCRequestSchema.parse(payload),
       handleRequest: (request) => this.handleRequest(request),
-      toErrorResponse: (error) => parseError(error),
+      toParseErrorResponse: (error) => parseError(error),
+      toInvalidRequestResponse: (error) => invalidRequestError(error),
+      toErrorResponse: (_error, request) => internalError(request.id),
     });
   }
 

--- a/cli/mcp/stdio.ts
+++ b/cli/mcp/stdio.ts
@@ -5,7 +5,9 @@ export interface StartStdioJsonRpcOptions<TRequest, TResponse> {
   isRunning: () => boolean;
   parseRequest: (payload: unknown) => TRequest;
   handleRequest: (request: TRequest) => Promise<TResponse>;
-  toErrorResponse: (error: unknown) => TResponse;
+  toParseErrorResponse: (error: unknown) => TResponse;
+  toInvalidRequestResponse: (error: unknown) => TResponse;
+  toErrorResponse: (error: unknown, request: TRequest) => TResponse;
 }
 
 export function startStdioJsonRpc<TRequest, TResponse>(
@@ -38,12 +40,27 @@ export function startStdioJsonRpc<TRequest, TResponse>(
           buffer = buffer.slice(newlineIndex + 1);
           if (!line) continue;
 
+          let payload: unknown;
           try {
-            const request = options.parseRequest(JSON.parse(line));
+            payload = JSON.parse(line);
+          } catch (error) {
+            await writeResponse(options.toParseErrorResponse(error));
+            continue;
+          }
+
+          let request: TRequest;
+          try {
+            request = options.parseRequest(payload);
+          } catch (error) {
+            await writeResponse(options.toInvalidRequestResponse(error));
+            continue;
+          }
+
+          try {
             const response = await options.handleRequest(request);
             await writeResponse(response);
           } catch (error) {
-            await writeResponse(options.toErrorResponse(error));
+            await writeResponse(options.toErrorResponse(error, request));
           }
         }
       } catch {

--- a/src/transforms/mdx/esm-module-loader/import-transformer.test.ts
+++ b/src/transforms/mdx/esm-module-loader/import-transformer.test.ts
@@ -171,16 +171,13 @@ describe("rewriteMdxRootDependencyImports", () => {
       baseOptions,
     );
 
-    assertEquals(result.includes(`from "fs"`), true);
-    assertEquals(result.includes(`from "path"`), true);
-    assertEquals(result.includes(`from "fs/promises"`), true);
-    assertEquals(result.includes(`from "assert/strict"`), true);
-    assertEquals(result.includes(`import("node:crypto")`), true);
-    assertEquals(result.includes(`import("node:path/posix")`), true);
-    assertEquals(result.includes("https://esm.sh/lodash@4.17.21"), true);
-    assertEquals(result.includes("https://esm.sh/fs"), false);
-    assertEquals(result.includes("https://esm.sh/path"), false);
-    assertEquals(result.includes(`'import("fs")'`), true);
+    assertEquals(
+      result,
+      code.replace(
+        `import lodash from "lodash";`,
+        `import lodash from "https://esm.sh/lodash@4.17.21?external=react,react-dom&target=es2022";`,
+      ),
+    );
   });
 
   it("keeps every supported bare Node builtin and its node: form unchanged", async () => {


### PR DESCRIPTION
## Summary

- return the standard JSON-RPC parse error without raw parser diagnostics
- avoid coercing untrusted thrown values while building error responses
- replace URL substring assertions with an exact import transformation contract

Addresses CodeQL alerts #160, #183, and #184 without suppressing or weakening analysis.

## Verification

- `deno test --no-check --allow-all cli/mcp/jsonrpc.test.ts src/transforms/mdx/esm-module-loader/import-transformer.test.ts`
- `deno task verify:quick`