### PR TITLE
fix(runtime): make async lifecycle ownership explicit

### DIFF
--- a/extensions/ext-blob-gcs/src/gcs-storage.ts
+++ b/extensions/ext-blob-gcs/src/gcs-storage.ts
@@ -80,6 +80,10 @@ interface GCSObject {
   metadata: Record<string, string>;
 }
 
+interface TokenRequest {
+  readonly promise: Promise<string>;
+}
+
 function linkAbortSignal(
   upstream: AbortSignal | undefined,
   controller: AbortController,
@@ -649,7 +653,7 @@ export class GCSBlobStorage implements BlobStorage {
   readonly #lifecycleController = new AbortController();
   readonly #detachConfigAbort: () => void;
   #privateKey: Promise<CryptoKey> | undefined;
-  #tokenRequest: Promise<string> | undefined;
+  #tokenRequest: TokenRequest | undefined;
   #tokenCache: { accessToken: string; refreshAt: number } | undefined;
   #closed = false;
 
@@ -789,15 +793,15 @@ export class GCSBlobStorage implements BlobStorage {
       return this.#tokenCache.accessToken;
     }
     if (!this.#tokenRequest) {
-      const pending = this.#requestAccessToken();
-      this.#tokenRequest = pending;
+      const request: TokenRequest = { promise: this.#requestAccessToken() };
+      this.#tokenRequest = request;
       try {
-        return await pending;
+        return await request.promise;
       } finally {
-        if (this.#tokenRequest === pending) this.#tokenRequest = undefined;
+        if (this.#tokenRequest === request) this.#tokenRequest = undefined;
       }
     }
-    return await this.#tokenRequest;
+    return await this.#tokenRequest.promise;
   }
 
   async #authorizedHeaders(): Promise<Headers> {

--- a/extensions/ext-blob-s3/src/s3-storage.test.ts
+++ b/extensions/ext-blob-s3/src/s3-storage.test.ts
@@ -314,6 +314,59 @@ describe("S3BlobStorage", () => {
     assert(client.commands[3] instanceof PutObjectCommand);
   });
 
+  it("coalesces concurrent bucket initialization", async () => {
+    let releaseBucketCheck: (() => void) | undefined;
+    const bucketCheck = new Promise<void>((resolve) => {
+      releaseBucketCheck = resolve;
+    });
+    let bucketChecks = 0;
+    const client = new StubClient(async (command) => {
+      if (command instanceof HeadBucketCommand) {
+        bucketChecks++;
+        await bucketCheck;
+      }
+      return {};
+    });
+    const storage = new S3BlobStorage(config({ autoCreateBucket: true }), { client });
+
+    const first = storage.put(new Uint8Array([1]), { id: "first" });
+    const second = storage.put(new Uint8Array([2]), { id: "second" });
+    await Promise.resolve();
+    assertEquals(bucketChecks, 1);
+
+    releaseBucketCheck?.();
+    await Promise.all([first, second]);
+    assertEquals(bucketChecks, 1);
+    assertEquals(
+      client.commands.filter((command) => command instanceof PutObjectCommand).length,
+      2,
+    );
+  });
+
+  it("allows bucket initialization to retry after a provider failure", async () => {
+    const providerFailure = new Error("bucket check failed");
+    let bucketChecks = 0;
+    const client = new StubClient((command) => {
+      if (command instanceof HeadBucketCommand) {
+        bucketChecks++;
+        if (bucketChecks === 1) throw providerFailure;
+      }
+      return {};
+    });
+    const storage = new S3BlobStorage(config({ autoCreateBucket: true }), { client });
+
+    let caught: unknown;
+    try {
+      await storage.put(new Uint8Array([1]), { id: "first" });
+    } catch (error) {
+      caught = error;
+    }
+    assertStrictEquals(caught, providerFailure);
+
+    await storage.put(new Uint8Array([2]), { id: "second" });
+    assertEquals(bucketChecks, 2);
+  });
+
   it("does not perform bucket discovery unless auto-create is selected", async () => {
     const client = new StubClient();
     const storage = new S3BlobStorage(config(), { client });

--- a/extensions/ext-blob-s3/src/s3-storage.ts
+++ b/extensions/ext-blob-s3/src/s3-storage.ts
@@ -141,6 +141,10 @@ interface DefaultS3Resources {
   readonly streamUploader: S3BlobStorageStreamUploader;
 }
 
+interface BucketInitialization {
+  readonly promise: Promise<void>;
+}
+
 function linkAbortSignal(
   upstream: AbortSignal | undefined,
   controller: AbortController,
@@ -593,7 +597,7 @@ export class S3BlobStorage implements BlobStorage {
   readonly #streamUploader: S3BlobStorageStreamUploader | undefined;
   readonly #lifecycleController = new AbortController();
   readonly #detachConfigAbort: () => void;
-  #bucketReady: Promise<void> | undefined;
+  #bucketReady: BucketInitialization | undefined;
   #clientDestroyed = false;
   #closed = false;
 
@@ -702,17 +706,19 @@ export class S3BlobStorage implements BlobStorage {
   async #ensureBucket(): Promise<void> {
     if (!this.#config.autoCreateBucket) return;
     if (!this.#bucketReady) {
-      const pending = this.#initializeBucket();
-      this.#bucketReady = pending;
+      const initialization: BucketInitialization = {
+        promise: this.#initializeBucket(),
+      };
+      this.#bucketReady = initialization;
       try {
-        await pending;
+        await initialization.promise;
       } catch (error) {
-        if (this.#bucketReady === pending) this.#bucketReady = undefined;
+        if (this.#bucketReady === initialization) this.#bucketReady = undefined;
         throw error;
       }
       return;
     }
-    await this.#bucketReady;
+    await this.#bucketReady.promise;
   }
 
   async put(

--- a/src/config/declarative-evaluator.ts
+++ b/src/config/declarative-evaluator.ts
@@ -397,7 +397,11 @@ interface CapturedEvaluationOptions {
   readonly preparedContext: CapturedOption;
 }
 
-let trustedParserPromise: Promise<TrustedCodeParser> | undefined;
+interface TrustedParserLoad {
+  readonly promise: Promise<TrustedCodeParser>;
+}
+
+let trustedParserLoad: TrustedParserLoad | undefined;
 let fingerprintKeyPromise: Promise<CryptoKey> | undefined;
 const preparedContextStates = new IntrinsicWeakMap<object, PreparedContextState>();
 
@@ -637,11 +641,11 @@ function throwParserShapeError(): never {
 }
 
 async function getTrustedParser(): Promise<TrustedCodeParser> {
-  const pending = trustedParserPromise ??= loadTrustedParser();
+  const load = trustedParserLoad ??= { promise: loadTrustedParser() };
   try {
-    return await pending;
+    return await load.promise;
   } catch (error) {
-    if (trustedParserPromise === pending) trustedParserPromise = undefined;
+    if (trustedParserLoad === load) trustedParserLoad = undefined;
     throw error;
   }
 }

--- a/src/platform/adapters/token/veryfront/adapter.ts
+++ b/src/platform/adapters/token/veryfront/adapter.ts
@@ -16,11 +16,15 @@ import {
 
 const logger = baseLogger.component("veryfront-token-adapter");
 
+interface InitializationAttempt {
+  readonly controller: AbortController;
+  readonly promise: Promise<void>;
+}
+
 export class VeryfrontTokenAdapter implements TokenStorageAdapter {
   private client: TokenStorageApiClient;
   private initialized = false;
-  private initialization: Promise<void> | null = null;
-  private initializationController: AbortController | null = null;
+  private initialization: InitializationAttempt | null = null;
   private lifecycleGeneration = 0;
 
   constructor(config: TokenStorageAdapterConfig) {
@@ -35,22 +39,23 @@ export class VeryfrontTokenAdapter implements TokenStorageAdapter {
 
   async initialize(): Promise<void> {
     if (this.initialized) return;
-    if (this.initialization) return await this.initialization;
+    if (this.initialization) return await this.initialization.promise;
 
     logger.debug("Initializing...");
 
     const generation = this.lifecycleGeneration;
     const controller = new AbortController();
-    const initialization = this.doInitialize(generation, controller.signal);
-    this.initializationController = controller;
+    const initialization: InitializationAttempt = {
+      controller,
+      promise: this.doInitialize(generation, controller.signal),
+    };
     this.initialization = initialization;
 
     try {
-      await initialization;
+      await initialization.promise;
     } finally {
       if (this.initialization === initialization) {
         this.initialization = null;
-        this.initializationController = null;
       }
     }
   }
@@ -81,10 +86,9 @@ export class VeryfrontTokenAdapter implements TokenStorageAdapter {
 
   dispose(): void {
     this.lifecycleGeneration++;
-    this.initializationController?.abort(
+    this.initialization?.controller.abort(
       new DOMException("Token storage initialization was invalidated", "AbortError"),
     );
-    this.initializationController = null;
     this.initialization = null;
     this.initialized = false;
     logger.debug("Disposed");


### PR DESCRIPTION
## Summary

- track parser loads, token-adapter initialization, S3 bucket setup, and GCS token fetches as explicit operation records
- preserve coalescing while making retry cleanup depend on operation identity rather than Promise identity
- add deterministic S3 concurrency and failed-initialization retry coverage

Addresses repository code-scanning alerts [#198](https://github.com/veryfront/veryfront-code/security/code-scanning/198), [#199](https://github.com/veryfront/veryfront-code/security/code-scanning/199), [#224](https://github.com/veryfront/veryfront-code/security/code-scanning/224), and [#225](https://github.com/veryfront/veryfront-code/security/code-scanning/225) — not GitHub issue numbers — without suppressions or behavior fallbacks.

## Verification

- affected suites: 85 steps passed
- `deno task verify:quick`