### PR TITLE
fix(codeql): remove dead conditional paths

### DIFF
--- a/src/routing/api/module-loader/esbuild-plugin.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.ts
@@ -83,7 +83,7 @@ function createHTTPModuleCache(projectDir: string | undefined): HTTPModuleCache 
 
         const contents = await fs.readTextFile(sourcePath);
         const integrity = await computeIntegrity(contents);
-        if (expectedIntegrity && integrity !== expectedIntegrity) {
+        if (integrity !== expectedIntegrity) {
           logger.warn(`[http] cached module integrity mismatch: ${url}`);
           return null;
         }

--- a/src/transforms/esm/package-registry.ts
+++ b/src/transforms/esm/package-registry.ts
@@ -728,7 +728,7 @@ async function readProjectDependencyVersionsUncoalesced(
       return {
         react: cached.react,
         veryfront: cached.veryfront,
-        dependencies: pinningOn ? cached.dependencies : undefined,
+        dependencies: undefined,
         dependencyState: "verified",
       };
     }

--- a/storybook/stories/ui/Button.stories.tsx
+++ b/storybook/stories/ui/Button.stories.tsx
@@ -11,7 +11,6 @@ import {
 import { Button, LoadingButton } from "../../../src/react/components/ui/index.ts";
 import {
   ArrowUpIcon,
-  PlusIcon,
   ArrowRightIcon,
 } from "../../../src/react/components/ui/icons/index.ts";
 


### PR DESCRIPTION
## Summary

- preserve the flag-off dependency result without an unreachable conditional
- compare cached integrity directly after the missing-integrity early return
- remove an unused Storybook icon import

Addresses CodeQL alerts #148, #150, and #185 with behavior-preserving cleanup.

## Verification

- package registry and HTTP module-loader suites: 85 steps passed
- `deno task storybook:check`
- `deno task verify:quick`