### PR TITLE
Make dependency artifact timeout tests deterministic

### DIFF
--- a/src/release-assets/dependency-artifact-builder.test.ts
+++ b/src/release-assets/dependency-artifact-builder.test.ts
@@ -3,6 +3,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { computeHashBytes } from "#veryfront/utils";
+import { FakeTime } from "#std/testing/time";
 import {
   buildDependencyArtifactGraph,
   type DependencyArtifactBuildClient,
@@ -14,6 +15,7 @@ import {
 import { materializeDependencyArtifactGraph } from "./dependency-artifact-graph.ts";
 
 const encoder = new TextEncoder();
+const CONTROLLED_TIMEOUT_MS = 30_000;
 
 const standardIdentity = {
   origin_key: "npm:public",
@@ -399,19 +401,46 @@ describe("release-assets/dependency-artifact-builder", () => {
   it("bounds an upstream fetch that ignores AbortSignal", async () => {
     const { client } = recordingClient();
     const upstreamSignals: AbortSignal[] = [];
-    const result = await settleBeforeWatchdog(
-      runDependencyArtifactBuild(buildTaskInput(), client, {
+    let build!: ReturnType<typeof runDependencyArtifactBuild>;
+
+    {
+      using time = new FakeTime();
+      build = runDependencyArtifactBuild(buildTaskInput(), client, {
         fetch: ((_input: RequestInfo | URL, init?: RequestInit) => {
           if (init?.signal) upstreamSignals.push(init.signal);
           return new Promise<Response>(() => undefined);
         }) as typeof fetch,
-        limits: { timeoutMs: 1 },
+        limits: { timeoutMs: CONTROLLED_TIMEOUT_MS },
+      });
+
+      assertEquals(upstreamSignals.length, 1);
+      assertEquals(upstreamSignals[0]?.aborted, false);
+      await time.tickAsync(CONTROLLED_TIMEOUT_MS);
+    }
+
+    const result = await settleBeforeWatchdog(build);
+
+    assertEquals(result.success, false);
+    assertEquals(failureCodeOf(result), "upstream_timeout");
+    assertEquals(upstreamSignals[0]?.aborted, true);
+  });
+
+  it("does not start an upstream fetch after its deadline expires", async () => {
+    const { client } = recordingClient();
+    let fetchCalls = 0;
+    const result = await settleBeforeWatchdog(
+      runDependencyArtifactBuild(buildTaskInput(), client, {
+        fetch: (() => {
+          fetchCalls++;
+          return new Promise<Response>(() => undefined);
+        }) as typeof fetch,
+        limits: { timeoutMs: 0 },
       }),
     );
 
     assertEquals(result.success, false);
     assertEquals(failureCodeOf(result), "upstream_timeout");
-    assertEquals(upstreamSignals[0]?.aborted, true);
+    assertEquals(fetchCalls, 0);
   });
 
   it("bounds an upstream body read that never settles", async () => {
@@ -426,8 +455,10 @@ describe("release-assets/dependency-artifact-builder", () => {
       },
     });
 
-    const result = await settleBeforeWatchdog(
-      runDependencyArtifactBuild(buildTaskInput(), client, {
+    let build!: ReturnType<typeof runDependencyArtifactBuild>;
+    {
+      using time = new FakeTime();
+      build = runDependencyArtifactBuild(buildTaskInput(), client, {
         fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
           if (init?.signal) upstreamSignals.push(init.signal);
           assertEquals(String(input), rootUrl);
@@ -435,9 +466,17 @@ describe("release-assets/dependency-artifact-builder", () => {
             headers: { "content-type": "text/javascript" },
           });
         }) as typeof fetch,
-        limits: { timeoutMs: 1 },
-      }),
-    );
+        limits: { timeoutMs: CONTROLLED_TIMEOUT_MS },
+      });
+
+      await time.tickAsync(0);
+      assertEquals(upstreamSignals.length, 1);
+      assertEquals(upstreamSignals[0]?.aborted, false);
+      assertEquals(bodyCancelCalls, 0);
+      await time.tickAsync(CONTROLLED_TIMEOUT_MS);
+    }
+
+    const result = await settleBeforeWatchdog(build);
 
     assertEquals(result.success, false);
     assertEquals(failureCodeOf(result), "upstream_timeout");


### PR DESCRIPTION
## Summary

- drive upstream fetch and body-read deadlines with controlled time instead of a 1 ms wall-clock race
- assert that an in-flight fetch observes an un-aborted signal before the deadline and an aborted signal after it
- cover the valid expired-before-start branch, which returns `upstream_timeout` without invoking the fetcher

## Diagnosis

The merge-group failure was test nondeterminism, not a runtime deadline failure. Under parallel coverage load, the 1 ms deadline expired between deadline creation and the first fetch race. Production correctly refused to begin already-expired work, while the test incorrectly assumed the fetch callback had necessarily captured a signal.

No production timeout behavior changed. Controlled time advances 30 seconds virtually, so this adds no wall-clock sleep.

## Verification

- 100 baseline focused iterations on current main: passed
- 200 controlled-time focused iterations: passed
- dependency artifact builder suite: 23 steps passed
- exact coverage shard 2/8 on latest main: 347 suites, 3254 steps passed
- `deno task verify:quick`: passed
- focused format, lint, typecheck, and diff checks: passed

Related: merge-group run 30763657761, job 91538524234