### PR TITLE
fix(security): bind channel payload to dispatch claims

### DIFF
--- a/src/server/handlers/request/channel-dispatch-request.test.ts
+++ b/src/server/handlers/request/channel-dispatch-request.test.ts
@@ -22,6 +22,11 @@ async function sha256Base64url(body: string): Promise<string> {
 
 async function createDispatchSignature(
   body: string,
+  overrides: Partial<{
+    sub: string;
+    project_id: string;
+    platform: string;
+  }> = {},
 ): Promise<{ jws: string; publicKeyPem: string }> {
   const keyPair = await crypto.subtle.generateKey("Ed25519", true, [
     "sign",
@@ -40,6 +45,7 @@ async function createDispatchSignature(
     body_sha256: await sha256Base64url(body),
     iat: now,
     exp: now + 60,
+    ...overrides,
   }));
   const signingInput = encoder.encode(`${header}.${payload}`);
   const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
@@ -66,7 +72,13 @@ function createCtx(publicKeyPem?: string): HandlerContext {
   } as unknown as HandlerContext;
 }
 
-function createValidBody(): string {
+function createValidBody(
+  overrides: Partial<{
+    dispatchId: string;
+    projectId: string;
+    platform: "slack";
+  }> = {},
+): string {
   return JSON.stringify({
     dispatchId: "dispatch-1",
     conversationId: "conversation-1",
@@ -80,6 +92,7 @@ function createValidBody(): string {
       isDirectMessage: false,
     },
     conversationHistory: [],
+    ...overrides,
   });
 }
 
@@ -114,6 +127,46 @@ describe("server/handlers/request/channel-dispatch-request", () => {
       assertEquals(result.claims.sub, "dispatch-1");
     }
   });
+
+  for (
+    const mismatch of [
+      {
+        label: "dispatch subject",
+        body: {},
+        claims: { sub: "different-dispatch" },
+      },
+      {
+        label: "project identity",
+        body: { projectId: "different-project" },
+        claims: {},
+      },
+      {
+        label: "platform",
+        body: {},
+        claims: { platform: "different-platform" },
+      },
+    ] as const
+  ) {
+    it(`rejects a signed body whose ${mismatch.label} disagrees with its claims`, async () => {
+      const body = createValidBody(mismatch.body);
+      const { jws, publicKeyPem } = await createDispatchSignature(body, mismatch.claims);
+
+      const result = await readFixture(
+        new Request("https://example.com/channels/invoke", {
+          method: "POST",
+          headers: { "x-veryfront-dispatch-jws": jws },
+          body,
+        }),
+        createCtx(publicKeyPem),
+      );
+
+      assertEquals(result.ok, false);
+      if (!result.ok) {
+        assertEquals(result.response.status, 401);
+        assertEquals(await result.response.json(), { error: "Invalid dispatch signature" });
+      }
+    });
+  }
 
   it("preserves the shared setup error responses", async () => {
     const missingKey = await readFixture(

--- a/src/server/handlers/request/channel-dispatch-request.ts
+++ b/src/server/handlers/request/channel-dispatch-request.ts
@@ -39,6 +39,30 @@ export interface ReadSignedChannelDispatchRequestOptions<T> {
   schema: ParseSchema<T>;
 }
 
+type ChannelDispatchBinding = {
+  dispatchId: string;
+  platform: string;
+  projectId: string;
+};
+
+function hasChannelDispatchBinding(value: unknown): value is ChannelDispatchBinding {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.dispatchId === "string" &&
+    typeof record.platform === "string" &&
+    typeof record.projectId === "string";
+}
+
+function payloadMatchesSignedDispatchClaims(
+  payload: unknown,
+  claims: Awaited<ReturnType<typeof verifyDispatchJws>>,
+): boolean {
+  return hasChannelDispatchBinding(payload) &&
+    payload.dispatchId === claims.sub &&
+    payload.platform === claims.platform &&
+    payload.projectId === claims.project_id;
+}
+
 export async function readSignedChannelDispatchRequest<T>(
   req: Request,
   ctx: HandlerContext,
@@ -115,12 +139,19 @@ export async function readSignedChannelDispatchRequest<T>(
   }
 
   try {
-    return {
-      ok: true,
-      claims,
-      payload: options.schema.parse(JSON.parse(rawBody)),
-      rawBody,
-    };
+    const payload = options.schema.parse(JSON.parse(rawBody));
+    if (!payloadMatchesSignedDispatchClaims(payload, claims)) {
+      options.logWarn(`${logLabel} signed claims do not match the request payload`, {
+        projectSlug,
+        projectId: ctx.projectId,
+      });
+      return {
+        ok: false,
+        response: options.builder.json({ error: "Invalid dispatch signature" }, 401),
+      };
+    }
+
+    return { ok: true, claims, payload, rawBody };
   } catch (error) {
     options.logWarn(`${logLabel} request validation failed`, {
       error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary

- bind dispatch ID, platform, and project ID in the request payload to the independently verified control-plane claims
- reject mismatches with a generic unauthorized response
- retain schema validation behavior for malformed requests

## Verification

- channel dispatch and invocation tests: 30 steps
- channel handler tests: 4 steps
- `deno task verify:quick`
- independent exact-head production review: no blockers