### PR TITLE
fix(agent): close alias pollution, unverified project lookups, and false-success exits

### DIFF
--- a/extensions/ext-llm-anthropic/src/anthropic-native-content.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-native-content.test.ts
@@ -9,6 +9,18 @@ import {
   validateAnthropicRawAssistantMessages,
 } from "./anthropic-native-content.ts";
 
+async function runNoBrandEval(script: string): Promise<unknown> {
+  const output = await new Deno.Command(Deno.execPath(), {
+    args: ["eval", "--config=deno.json", script],
+    cwd: new URL("../../../", import.meta.url),
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  const stderr = new TextDecoder().decode(output.stderr);
+  assertEquals(output.code, 0, stderr);
+  return JSON.parse(new TextDecoder().decode(output.stdout));
+}
+
 describe("Anthropic provider-native content normalization", () => {
   it("owns exact replay metadata and rejects executable object behavior", () => {
     const rawMessages = [[{
@@ -77,6 +89,59 @@ describe("Anthropic provider-native content normalization", () => {
       TypeError,
       `Anthropic raw assistant metadata exceeded ${MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES} UTF-8 bytes`,
     );
+  });
+
+  it("accepts plain raw assistant metadata without Proxy detection", async () => {
+    const result = await runNoBrandEval(`
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(globalThis, "WebSocketPair", {
+        configurable: true,
+        value: function WebSocketPair() {},
+      });
+
+      const { canIdentifyProxyWithoutHooks } = await import(
+        "./src/platform/compat/error-introspection.ts"
+      );
+      const { validateAnthropicRawAssistantMessages } = await import(
+        "./extensions/ext-llm-anthropic/src/anthropic-native-content.ts"
+      );
+
+      console.log(JSON.stringify({
+        canIdentifyProxyWithoutHooks,
+        messages: validateAnthropicRawAssistantMessages([[
+          {
+            type: "thinking",
+            thinking: "valid",
+            signature: "sig_edge",
+          },
+          {
+            type: "tool_use",
+            id: "tool_edge",
+            name: "lookup",
+            input: { query: "Veryfront" },
+          },
+        ]]),
+      }));
+    `);
+    assertEquals(result, {
+      canIdentifyProxyWithoutHooks: false,
+      messages: [[
+        {
+          type: "thinking",
+          thinking: "valid",
+          signature: "sig_edge",
+        },
+        {
+          type: "tool_use",
+          id: "tool_edge",
+          name: "lookup",
+          input: { query: "Veryfront" },
+        },
+      ]],
+    });
   });
 
   it("keeps ordinary client tool_use blocks out of the provider-executed path", () => {

--- a/extensions/ext-llm-anthropic/src/anthropic-native-content.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-native-content.ts
@@ -1,4 +1,8 @@
-import { type JsonSnapshotValue, readRecord, snapshotJsonValue } from "veryfront/provider/shared";
+import {
+  type JsonSnapshotValue,
+  readRecord,
+  snapshotProviderJsonValue,
+} from "veryfront/provider/shared";
 
 export type AnthropicProviderToolNameRegistry = Map<string, string>;
 
@@ -109,7 +113,7 @@ export function snapshotAnthropicRawAssistantMetadata(
   value: unknown,
 ): JsonSnapshotValue {
   try {
-    return snapshotJsonValue(value, {
+    return snapshotProviderJsonValue(value, {
       maxBytes: MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_BYTES,
       maxDepth: MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_DEPTH,
       maxNodes: MAX_ANTHROPIC_RAW_ASSISTANT_METADATA_NODES,

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -2,7 +2,6 @@ import {
   jsonValuesEqual,
   readProviderOptions,
   readRecord,
-  stringifyJsonValue,
   stringifyToolResultValue,
   unwrapToolInputSchema,
 } from "veryfront/provider/shared";

--- a/extensions/ext-llm-google/src/google-request-builder.test.ts
+++ b/extensions/ext-llm-google/src/google-request-builder.test.ts
@@ -70,6 +70,18 @@ function assertJsonEquals(actual: unknown, expected: unknown): void {
   );
 }
 
+async function runNoBrandEval(script: string): Promise<unknown> {
+  const output = await new Deno.Command(Deno.execPath(), {
+    args: ["eval", "--config=deno.json", script],
+    cwd: new URL("../../../", import.meta.url),
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  const stderr = new TextDecoder().decode(output.stderr);
+  assertEquals(output.code, 0, stderr);
+  return JSON.parse(new TextDecoder().decode(output.stdout));
+}
+
 describe("ext-llm-google/google-request-builder", () => {
   it("preserves generateContent request shaping, provider option merge order, and warnings", () => {
     const prompt: RuntimePromptMessage[] = [
@@ -1325,6 +1337,68 @@ describe("ext-llm-google/google-request-builder", () => {
       "Google provider metadata namespace must be an enumerable data property",
     );
     assertEquals(googleGetterReads, 0);
+  });
+
+  it("accepts plain thought-signature and grounding metadata without Proxy detection", async () => {
+    const result = await runNoBrandEval(`
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(globalThis, "WebSocketPair", {
+        configurable: true,
+        value: function WebSocketPair() {},
+      });
+
+      const { canIdentifyProxyWithoutHooks } = await import(
+        "./src/platform/compat/error-introspection.ts"
+      );
+      const { buildGoogleGenerateContentRequest } = await import(
+        "./extensions/ext-llm-google/src/google-request-builder.ts"
+      );
+      const { createGoogleProviderMetadata } = await import(
+        "./extensions/ext-llm-google/src/google-thought-signatures.ts"
+      );
+
+      const metadata = createGoogleProviderMetadata(
+        [{ text: "Private thought.", thought: true, thoughtSignature: "sig_edge" }],
+        { source: "google-search" },
+      );
+      const body = buildGoogleGenerateContentRequest(
+        "google",
+        {
+          prompt: [{
+            role: "assistant",
+            content: [{ type: "reasoning", text: "Private thought." }],
+            providerMetadata: metadata,
+          }],
+        },
+        { push() {}, drain() { return []; } },
+      );
+      console.log(JSON.stringify({
+        canIdentifyProxyWithoutHooks,
+        metadata,
+        parts: body.contents[0].parts,
+      }));
+    `);
+    assertEquals(result, {
+      canIdentifyProxyWithoutHooks: false,
+      metadata: {
+        google: {
+          rawAssistantParts: [{
+            text: "Private thought.",
+            thought: true,
+            thoughtSignature: "sig_edge",
+          }],
+          groundingMetadata: { source: "google-search" },
+        },
+      },
+      parts: [{
+        text: "Private thought.",
+        thought: true,
+        thoughtSignature: "sig_edge",
+      }],
+    });
   });
 
   it("enforces the exact Google raw-part count boundary", () => {

--- a/extensions/ext-llm-google/src/google-thought-signatures.ts
+++ b/extensions/ext-llm-google/src/google-thought-signatures.ts
@@ -1,4 +1,8 @@
-import { type JsonSnapshotValue, readRecord, snapshotJsonValue } from "veryfront/provider/shared";
+import {
+  type JsonSnapshotValue,
+  readRecord,
+  snapshotProviderJsonValue,
+} from "veryfront/provider/shared";
 import {
   createGoogleToolCallCorrelationRegistry,
   type GoogleSupportedPartDataField,
@@ -19,7 +23,7 @@ const GOOGLE_PROVIDER_METADATA_SNAPSHOT_OPTIONS = {
 } as const;
 
 function snapshotGoogleProviderMetadata(value: unknown): JsonSnapshotValue {
-  return snapshotJsonValue(value, GOOGLE_PROVIDER_METADATA_SNAPSHOT_OPTIONS);
+  return snapshotProviderJsonValue(value, GOOGLE_PROVIDER_METADATA_SNAPSHOT_OPTIONS);
 }
 
 function asSnapshotRecord(value: JsonSnapshotValue): Record<string, unknown> | undefined {

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
@@ -1,7 +1,6 @@
 import {
   jsonValuesEqual,
   readProviderOptions,
-  stringifyJsonValue,
   stringifyToolArguments,
   stringifyToolResultValue,
   unwrapToolInputSchema,

--- a/extensions/ext-llm-openai/src/openai-web-search.test.ts
+++ b/extensions/ext-llm-openai/src/openai-web-search.test.ts
@@ -35,6 +35,18 @@ function captureThrownError(
   throw new Error("Expected function to throw");
 }
 
+async function runNoBrandEval(script: string): Promise<unknown> {
+  const output = await new Deno.Command(Deno.execPath(), {
+    args: ["eval", "--config=deno.json", script],
+    cwd: new URL("../../../", import.meta.url),
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  const stderr = new TextDecoder().decode(output.stderr);
+  assertEquals(output.code, 0, stderr);
+  return JSON.parse(new TextDecoder().decode(output.stdout));
+}
+
 describe("ext-llm-openai/openai-web-search", () => {
   it("maps the four supported provider tool revisions and preserves the runtime name", () => {
     for (
@@ -537,5 +549,46 @@ describe("ext-llm-openai/openai-web-search", () => {
     );
     assertEquals(proxyPropertyReads, 0);
     assertEquals(proxyError.cause, undefined);
+  });
+
+  it("accepts plain raw response metadata without Proxy detection", async () => {
+    const result = await runNoBrandEval(`
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(globalThis, "WebSocketPair", {
+        configurable: true,
+        value: function WebSocketPair() {},
+      });
+
+      const { canIdentifyProxyWithoutHooks } = await import(
+        "./src/platform/compat/error-introspection.ts"
+      );
+      const {
+        createOpenAIRawResponseMetadata,
+        readOpenAIRawResponseOutputItems,
+      } = await import("./extensions/ext-llm-openai/src/openai-web-search.ts");
+
+      const metadata = createOpenAIRawResponseMetadata([{
+        id: "ws_edge",
+        type: "web_search_call",
+        status: "completed",
+        action: { type: "search", query: "Veryfront" },
+      }]);
+      console.log(JSON.stringify({
+        canIdentifyProxyWithoutHooks,
+        items: readOpenAIRawResponseOutputItems(metadata),
+      }));
+    `);
+    assertEquals(result, {
+      canIdentifyProxyWithoutHooks: false,
+      items: [{
+        id: "ws_edge",
+        type: "web_search_call",
+        status: "completed",
+        action: { type: "search", query: "Veryfront" },
+      }],
+    });
   });
 });

--- a/extensions/ext-llm-openai/src/openai-web-search.ts
+++ b/extensions/ext-llm-openai/src/openai-web-search.ts
@@ -1,4 +1,8 @@
-import { readRecord, snapshotJsonValue, stringifyJsonValue } from "veryfront/provider/shared";
+import {
+  readRecord,
+  snapshotProviderJsonValue,
+  stringifyJsonValue,
+} from "veryfront/provider/shared";
 import {
   isBoundedOpenAIStreamString,
   MAX_OPENAI_STREAM_IDENTIFIER_BYTES,
@@ -310,7 +314,7 @@ function snapshotOpenAIRawResponseOutputItems(
 ): Array<Record<string, unknown>> {
   let snapshot: unknown;
   try {
-    snapshot = snapshotJsonValue(value, {
+    snapshot = snapshotProviderJsonValue(value, {
       maxBytes: MAX_OPENAI_RAW_RESPONSE_METADATA_BYTES,
     });
   } catch (error) {

--- a/src/agent/hosted/child-fork-run-context.test.ts
+++ b/src/agent/hosted/child-fork-run-context.test.ts
@@ -115,6 +115,7 @@ Deno.test("createHostedChildForkRunContext closes pending tool calls with host l
     pendingToolLogContext: {
       conversationId: "conversation-1",
       parentRunId: "run-1",
+      childRunId: "child-run-1",
       description: "Check the app",
     },
     pendingToolLogWriter: {
@@ -137,7 +138,9 @@ Deno.test("createHostedChildForkRunContext closes pending tool calls with host l
   assertEquals(warnings[0]?.message, "Closing incomplete child fork tool lifecycles");
   assertEquals(warnings[0]?.context, {
     conversationId: "conversation-1",
-    runId: "run-1",
+    runId: "child-run-1",
+    parentRunId: "run-1",
+    childRunId: "child-run-1",
     description: "Check the app",
     reason: "aborted",
     toolCallIds: ["tool-call-1"],

--- a/src/agent/hosted/child-fork-run-context.test.ts
+++ b/src/agent/hosted/child-fork-run-context.test.ts
@@ -138,7 +138,7 @@ Deno.test("createHostedChildForkRunContext closes pending tool calls with host l
   assertEquals(warnings[0]?.message, "Closing incomplete child fork tool lifecycles");
   assertEquals(warnings[0]?.context, {
     conversationId: "conversation-1",
-    runId: "child-run-1",
+    runId: "run-1",
     parentRunId: "run-1",
     childRunId: "child-run-1",
     description: "Check the app",

--- a/src/agent/hosted/child-fork-run-context.ts
+++ b/src/agent/hosted/child-fork-run-context.ts
@@ -186,7 +186,10 @@ export function createHostedDurableChildForkRunContext(
     ...createHostedChildForkRunContext({
       mirror: durableRunMirror,
       messageId: input.durableChildRun?.childMessageId ?? null,
-      pendingToolLogContext: input.pendingToolLogContext,
+      pendingToolLogContext: {
+        ...input.pendingToolLogContext,
+        childRunId: input.durableChildRun?.childRunId,
+      },
       pendingToolLogWriter: input.pendingToolLogWriter,
     }),
   };

--- a/src/agent/hosted/child-lifecycle.test.ts
+++ b/src/agent/hosted/child-lifecycle.test.ts
@@ -360,4 +360,33 @@ describe("agent/hosted-child-lifecycle", () => {
     assertEquals(result.terminalState.status, "completed");
     assertEquals(result.terminalState.terminalErrorCode, "DURABLE_CHILD_COMPLETED_EXTERNALLY");
   });
+
+  it("returns externally completed terminal states without rethrowing unexpected final status", async () => {
+    const result = await runHostedChildExecutionLifecycle({
+      adapter: {
+        completed: () => {
+          throw new Error("completed terminal persistence must be skipped");
+        },
+      },
+      executionFailedCode: "INVOKE_AGENT_FAILED",
+      execute: () => {
+        throw new HostedChildTerminalStateError("completed", {
+          childConversationId: "conversation-1",
+          childRunId: "run-1",
+          childMessageId: "message-1",
+          latestEventId: 1,
+          latestExternalEventSequence: 1,
+        });
+      },
+      getExecutionSnapshot: () => null,
+    });
+
+    assertEquals(result.status, "failed");
+    assertEquals(result.terminalState, {
+      status: "completed",
+      terminalErrorCode: "DURABLE_CHILD_COMPLETED_EXTERNALLY",
+      terminalErrorMessage:
+        "Hosted child run run-1 became completed before local execution finished",
+    });
+  });
 });

--- a/src/agent/hosted/child-pending-tool-lifecycle.test.ts
+++ b/src/agent/hosted/child-pending-tool-lifecycle.test.ts
@@ -176,3 +176,34 @@ Deno.test("createHostedChildPendingToolLifecycleLogger writes host context for p
     },
   ]);
 });
+
+Deno.test("createHostedChildPendingToolLifecycleLogger preserves the parent run as runId", () => {
+  const warnings: Array<{ message: string; context: Record<string, unknown> }> = [];
+  const logger = createHostedChildPendingToolLifecycleLogger(
+    {
+      parentRunId: "run-parent",
+      childRunId: "run-child",
+      description: "Summarize docs",
+    },
+    {
+      warn: (message, context) => warnings.push({ message, context }),
+    },
+  );
+
+  logger.warnIncompleteToolLifecycles?.({
+    reason: "ended",
+    toolCallIds: ["tool-1"],
+    errorMessage: null,
+  });
+
+  assertEquals(warnings[0]?.context, {
+    conversationId: undefined,
+    runId: "run-parent",
+    parentRunId: "run-parent",
+    childRunId: "run-child",
+    description: "Summarize docs",
+    reason: "ended",
+    toolCallIds: ["tool-1"],
+    errorMessage: null,
+  });
+});

--- a/src/agent/hosted/child-pending-tool-lifecycle.test.ts
+++ b/src/agent/hosted/child-pending-tool-lifecycle.test.ts
@@ -154,6 +154,7 @@ Deno.test("createHostedChildPendingToolLifecycleLogger writes host context for p
       context: {
         conversationId: "conv-1",
         runId: "run-1",
+        parentRunId: "run-1",
         description: "Summarize docs",
         reason: "error",
         toolCallIds: ["tool-1", "tool-2"],
@@ -165,6 +166,7 @@ Deno.test("createHostedChildPendingToolLifecycleLogger writes host context for p
       context: {
         conversationId: "conv-1",
         runId: "run-1",
+        parentRunId: "run-1",
         description: "Summarize docs",
         toolCallId: "tool-1",
         phase: "input_streaming",

--- a/src/agent/hosted/child-pending-tool-lifecycle.ts
+++ b/src/agent/hosted/child-pending-tool-lifecycle.ts
@@ -42,6 +42,7 @@ export interface HostedChildPendingToolLifecycleLogger {
 export interface HostedChildPendingToolLifecycleLogContext {
   conversationId?: string;
   parentRunId?: string;
+  childRunId?: string;
   description: string;
 }
 
@@ -55,11 +56,19 @@ export function createHostedChildPendingToolLifecycleLogger(
   context: HostedChildPendingToolLifecycleLogContext,
   writer: HostedChildPendingToolLifecycleLogWriter,
 ): HostedChildPendingToolLifecycleLogger {
+  const runContext = {
+    ...(context.childRunId ?? context.parentRunId
+      ? { runId: context.childRunId ?? context.parentRunId }
+      : {}),
+    ...(context.parentRunId ? { parentRunId: context.parentRunId } : {}),
+    ...(context.childRunId ? { childRunId: context.childRunId } : {}),
+  };
+
   return {
     warnIncompleteToolLifecycles: (log) => {
       writer.warn("Closing incomplete child fork tool lifecycles", {
         conversationId: context.conversationId,
-        runId: context.parentRunId,
+        ...runContext,
         description: context.description,
         reason: log.reason,
         toolCallIds: log.toolCallIds,
@@ -69,7 +78,7 @@ export function createHostedChildPendingToolLifecycleLogger(
     warnUnknownToolIdentity: (log) => {
       writer.warn("Closing child fork tool lifecycle without recoverable tool identity", {
         conversationId: context.conversationId,
-        runId: context.parentRunId,
+        ...runContext,
         description: context.description,
         toolCallId: log.toolCallId,
         phase: log.phase,

--- a/src/agent/hosted/child-pending-tool-lifecycle.ts
+++ b/src/agent/hosted/child-pending-tool-lifecycle.ts
@@ -56,10 +56,9 @@ export function createHostedChildPendingToolLifecycleLogger(
   context: HostedChildPendingToolLifecycleLogContext,
   writer: HostedChildPendingToolLifecycleLogWriter,
 ): HostedChildPendingToolLifecycleLogger {
+  const runId = context.parentRunId ?? context.childRunId;
   const runContext = {
-    ...(context.childRunId ?? context.parentRunId
-      ? { runId: context.childRunId ?? context.parentRunId }
-      : {}),
+    ...(runId ? { runId } : {}),
     ...(context.parentRunId ? { parentRunId: context.parentRunId } : {}),
     ...(context.childRunId ? { childRunId: context.childRunId } : {}),
   };

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -2,12 +2,14 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import {
   DEFAULT_HOSTED_CHILD_AGENT_ID,
+  getHostedChildForkToolInputSchema,
   hostedChildForkToolInputSchema,
   MAX_HOSTED_CHILD_DELEGATION_DEPTH,
   resolveHostedChildForkRuntimeConfig,
   resolveHostedChildForkThinkingOverride,
   withHostedChildInvocationContext,
 } from "./child-tool-input.ts";
+import { schemaToJsonSchema } from "#veryfront/schemas/index.ts";
 import { INVALID_AGENT_PROJECT_REFERENCE_MESSAGE } from "../project/context.ts";
 import { MAX_OPAQUE_ID_CODE_UNITS } from "#veryfront/utils/project-identity.ts";
 
@@ -149,7 +151,6 @@ Deno.test("hostedChildForkToolInputSchema rejects unsafe project references", ()
   for (
     const projectReference of [
       "",
-      " project-123",
       "project-\n123",
       "p".repeat(MAX_OPAQUE_ID_CODE_UNITS + 1),
     ]
@@ -173,6 +174,27 @@ Deno.test("hostedChildForkToolInputSchema rejects unsafe project references", ()
         : INVALID_AGENT_PROJECT_REFERENCE_MESSAGE,
     );
   }
+});
+
+Deno.test("hostedChildForkToolInputSchema trims project references", () => {
+  const result = hostedChildForkToolInputSchema.parse({
+    description: "switch project",
+    prompt: "Open the requested project.",
+    project_reference: "  project-123  ",
+  });
+
+  assertEquals(result.project_reference, "project-123");
+});
+
+Deno.test("hosted child fork JSON Schema exposes project-reference bounds", () => {
+  const schema = schemaToJsonSchema(getHostedChildForkToolInputSchema());
+  const projectReference = schema.properties?.project_reference as
+    | Record<string, unknown>
+    | undefined;
+
+  assertEquals(projectReference?.type, "string");
+  assertEquals(projectReference?.minLength, 1);
+  assertEquals(projectReference?.maxLength, MAX_OPAQUE_ID_CODE_UNITS);
 });
 
 Deno.test("DEFAULT_HOSTED_CHILD_AGENT_ID names the hosted child runtime agent", () => {

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -5,6 +5,7 @@ import {
   getHostedChildForkToolInputSchema,
   hostedChildForkToolInputSchema,
   MAX_HOSTED_CHILD_DELEGATION_DEPTH,
+  MAX_HOSTED_CHILD_PROJECT_REFERENCE_INPUT_CODE_UNITS,
   resolveHostedChildForkRuntimeConfig,
   resolveHostedChildForkThinkingOverride,
   withHostedChildInvocationContext,
@@ -186,7 +187,30 @@ Deno.test("hostedChildForkToolInputSchema trims project references", () => {
   assertEquals(result.project_reference, "project-123");
 });
 
-Deno.test("hosted child fork JSON Schema exposes project-reference bounds", () => {
+Deno.test("hostedChildForkToolInputSchema trims project references before enforcing canonical length", () => {
+  const canonicalReference = "p".repeat(MAX_OPAQUE_ID_CODE_UNITS);
+  const result = hostedChildForkToolInputSchema.parse({
+    description: "switch project",
+    prompt: "Open the requested project.",
+    project_reference: ` ${canonicalReference} `,
+  });
+
+  assertEquals(result.project_reference, canonicalReference);
+});
+
+Deno.test("hostedChildForkToolInputSchema rejects raw project-reference payloads beyond the DoS bound", () => {
+  const result = hostedChildForkToolInputSchema.safeParse({
+    description: "switch project",
+    prompt: "Open the requested project.",
+    project_reference: `${
+      " ".repeat(MAX_HOSTED_CHILD_PROJECT_REFERENCE_INPUT_CODE_UNITS)
+    }project-123`,
+  });
+
+  assertEquals(result.success, false);
+});
+
+Deno.test("hosted child fork JSON Schema exposes project-reference input bounds", () => {
   const schema = schemaToJsonSchema(getHostedChildForkToolInputSchema());
   const projectReference = schema.properties?.project_reference as
     | Record<string, unknown>
@@ -194,7 +218,7 @@ Deno.test("hosted child fork JSON Schema exposes project-reference bounds", () =
 
   assertEquals(projectReference?.type, "string");
   assertEquals(projectReference?.minLength, 1);
-  assertEquals(projectReference?.maxLength, MAX_OPAQUE_ID_CODE_UNITS);
+  assertEquals(projectReference?.maxLength, MAX_HOSTED_CHILD_PROJECT_REFERENCE_INPUT_CODE_UNITS);
 });
 
 Deno.test("DEFAULT_HOSTED_CHILD_AGENT_ID names the hosted child runtime agent", () => {

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -8,6 +8,7 @@ import {
   resolveHostedChildForkThinkingOverride,
   withHostedChildInvocationContext,
 } from "./child-tool-input.ts";
+import { MAX_OPAQUE_ID_CODE_UNITS } from "#veryfront/utils/project-identity.ts";
 
 Deno.test("hostedChildForkToolInputSchema accepts the hosted child fork fields", () => {
   const parsed = hostedChildForkToolInputSchema.parse({
@@ -141,6 +142,26 @@ Deno.test("hostedChildForkToolInputSchema rejects negative thinking budgets", ()
   });
 
   assertEquals(result.success, false);
+});
+
+Deno.test("hostedChildForkToolInputSchema rejects unsafe project references", () => {
+  for (
+    const projectReference of [
+      "",
+      " project-123",
+      "project-\n123",
+      "p".repeat(MAX_OPAQUE_ID_CODE_UNITS + 1),
+    ]
+  ) {
+    const result = hostedChildForkToolInputSchema.safeParse({
+      description: "invalid project",
+      prompt: "Try an invalid project reference.",
+      context: {},
+      project_reference: projectReference,
+    });
+
+    assertEquals(result.success, false);
+  }
 });
 
 Deno.test("DEFAULT_HOSTED_CHILD_AGENT_ID names the hosted child runtime agent", () => {

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -8,6 +8,7 @@ import {
   resolveHostedChildForkThinkingOverride,
   withHostedChildInvocationContext,
 } from "./child-tool-input.ts";
+import { INVALID_AGENT_PROJECT_REFERENCE_MESSAGE } from "../project/context.ts";
 import { MAX_OPAQUE_ID_CODE_UNITS } from "#veryfront/utils/project-identity.ts";
 
 Deno.test("hostedChildForkToolInputSchema accepts the hosted child fork fields", () => {
@@ -161,6 +162,16 @@ Deno.test("hostedChildForkToolInputSchema rejects unsafe project references", ()
     });
 
     assertEquals(result.success, false);
+    if (result.success) {
+      throw new Error("Expected invalid hosted child fork input");
+    }
+    const error = result.error as { issues?: Array<{ message?: string }> };
+    assertEquals(
+      error.issues?.[0]?.message,
+      projectReference.length > MAX_OPAQUE_ID_CODE_UNITS
+        ? `Too big: expected string to have <=${MAX_OPAQUE_ID_CODE_UNITS} characters`
+        : INVALID_AGENT_PROJECT_REFERENCE_MESSAGE,
+    );
   }
 });
 

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -26,10 +26,17 @@ export const getHostedChildForkToolInputSchema = defineSchema((v) =>
     ),
     project_reference: v
       .string()
+      .min(1, INVALID_AGENT_PROJECT_REFERENCE_MESSAGE)
       .max(MAX_OPAQUE_ID_CODE_UNITS)
-      .refine(
-        isCanonicalOpaqueProjectIdentifier,
-        INVALID_AGENT_PROJECT_REFERENCE_MESSAGE,
+      .transform((value) => value.trim())
+      .pipe(
+        v.string()
+          .min(1, INVALID_AGENT_PROJECT_REFERENCE_MESSAGE)
+          .max(MAX_OPAQUE_ID_CODE_UNITS)
+          .refine(
+            isCanonicalOpaqueProjectIdentifier,
+            INVALID_AGENT_PROJECT_REFERENCE_MESSAGE,
+          ),
       )
       .optional()
       .describe(

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -2,6 +2,7 @@ import { defineSchema, getJsonValueSchema, lazySchema } from "#veryfront/schemas
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
 import { withDefaultResearchArtifactPath } from "../artifacts/default-research-artifact-policy.ts";
 import type { ChildRunResultMode } from "../child-run/result-summary.ts";
+import { INVALID_AGENT_PROJECT_REFERENCE_MESSAGE } from "../project/context.ts";
 import type { RuntimeAgentThinkingConfig } from "../runtime/agent-definition.ts";
 import {
   isCanonicalOpaqueProjectIdentifier,
@@ -25,11 +26,10 @@ export const getHostedChildForkToolInputSchema = defineSchema((v) =>
     ),
     project_reference: v
       .string()
-      .min(1)
       .max(MAX_OPAQUE_ID_CODE_UNITS)
       .refine(
         isCanonicalOpaqueProjectIdentifier,
-        "project_reference must be trimmed and contain no control characters",
+        INVALID_AGENT_PROJECT_REFERENCE_MESSAGE,
       )
       .optional()
       .describe(

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -3,6 +3,10 @@ import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
 import { withDefaultResearchArtifactPath } from "../artifacts/default-research-artifact-policy.ts";
 import type { ChildRunResultMode } from "../child-run/result-summary.ts";
 import type { RuntimeAgentThinkingConfig } from "../runtime/agent-definition.ts";
+import {
+  isCanonicalOpaqueProjectIdentifier,
+  MAX_OPAQUE_ID_CODE_UNITS,
+} from "#veryfront/utils/project-identity.ts";
 
 /** Default value for hosted child agent ID. */
 export const DEFAULT_HOSTED_CHILD_AGENT_ID = "invoke-agent-child";
@@ -19,9 +23,18 @@ export const getHostedChildForkToolInputSchema = defineSchema((v) =>
     context: v.record(v.string(), getJsonValueSchema()).default({}).describe(
       "Structured data payload for the child task. Use this for critical facts, records, ids, decisions, and values the child must act on. Defaults to {} when the delegation has no record or evidence payload.",
     ),
-    project_reference: v.string().optional().describe(
-      "Override project context by UUID or slug. Use after studio_open_project.",
-    ),
+    project_reference: v
+      .string()
+      .min(1)
+      .max(MAX_OPAQUE_ID_CODE_UNITS)
+      .refine(
+        isCanonicalOpaqueProjectIdentifier,
+        "project_reference must be trimmed and contain no control characters",
+      )
+      .optional()
+      .describe(
+        "Override project context by UUID or slug. Use after studio_open_project.",
+      ),
     tools: v.array(v.string()).optional().describe(
       "Tool subset for this fork. Omit = inherit all parent tools.",
     ),

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -12,6 +12,7 @@ import {
 /** Default value for hosted child agent ID. */
 export const DEFAULT_HOSTED_CHILD_AGENT_ID = "invoke-agent-child";
 export const MAX_HOSTED_CHILD_DELEGATION_DEPTH = 8;
+export const MAX_HOSTED_CHILD_PROJECT_REFERENCE_INPUT_CODE_UNITS = 8_192;
 const HOSTED_CHILD_FORK_RESULT_MODES = ["summary", "full", "structured"] as const;
 
 /** Hosted child fork result return mode. */
@@ -27,7 +28,7 @@ export const getHostedChildForkToolInputSchema = defineSchema((v) =>
     project_reference: v
       .string()
       .min(1, INVALID_AGENT_PROJECT_REFERENCE_MESSAGE)
-      .max(MAX_OPAQUE_ID_CODE_UNITS)
+      .max(MAX_HOSTED_CHILD_PROJECT_REFERENCE_INPUT_CODE_UNITS)
       .transform((value) => value.trim())
       .pipe(
         v.string()

--- a/src/agent/hosted/project-reference-resolver.test.ts
+++ b/src/agent/hosted/project-reference-resolver.test.ts
@@ -1,0 +1,116 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { resolveHostedProjectReference } from "./project-reference-resolver.ts";
+import { MAX_OPAQUE_ID_CODE_UNITS } from "#veryfront/utils/project-identity.ts";
+
+Deno.test("resolveHostedProjectReference binds normalized API identity to the request", async () => {
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ url: string; authorization: string | null }> = [];
+
+  try {
+    globalThis.fetch = (input, init) => {
+      requests.push({
+        url: String(input),
+        authorization: new Headers(
+          typeof init === "object" && init !== null
+            ? Reflect.get(init, "headers") as HeadersInit | undefined
+            : undefined,
+        ).get("authorization"),
+      });
+      return Promise.resolve(
+        Response.json({
+          id: "11111111-1111-4111-8111-111111111111",
+          slug: " target-project ",
+        }),
+      );
+    };
+
+    assertEquals(
+      await resolveHostedProjectReference({
+        projectReference: "target-project",
+        authToken: "token-1",
+        apiUrl: "https://api.example.test",
+      }),
+      {
+        projectId: "11111111-1111-4111-8111-111111111111",
+        slug: "target-project",
+      },
+    );
+    assertEquals(requests, [{
+      url: "https://api.example.test/projects/target-project",
+      authorization: "Bearer token-1",
+    }]);
+
+    globalThis.fetch = () =>
+      Promise.resolve(
+        Response.json({
+          id: "22222222-2222-4222-8222-222222222222",
+          slug: "different-project",
+        }),
+      );
+
+    await assertRejects(
+      () =>
+        resolveHostedProjectReference({
+          projectReference: "target-project",
+          authToken: "token-1",
+          apiUrl: "https://api.example.test",
+        }),
+      Error,
+      "Project lookup response did not confirm the requested project identity",
+    );
+
+    let invalidReferenceFetchCount = 0;
+    globalThis.fetch = () => {
+      invalidReferenceFetchCount += 1;
+      throw new Error("invalid project references must not reach fetch");
+    };
+    for (
+      const projectReference of [
+        "",
+        " target-project",
+        "target-\nproject",
+        "p".repeat(MAX_OPAQUE_ID_CODE_UNITS + 1),
+      ]
+    ) {
+      await assertRejects(
+        () =>
+          resolveHostedProjectReference({
+            projectReference,
+            authToken: "token-1",
+            apiUrl: "https://api.example.test",
+          }),
+        TypeError,
+        "Project reference must be a trimmed non-empty bounded identifier without control characters",
+      );
+    }
+    assertEquals(invalidReferenceFetchCount, 0);
+
+    let cancellationCount = 0;
+    globalThis.fetch = () =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream({
+            cancel() {
+              cancellationCount += 1;
+              throw new Error("cleanup failed");
+            },
+          }),
+          { status: 502 },
+        ),
+      );
+    await assertRejects(
+      () =>
+        resolveHostedProjectReference({
+          projectReference: "target-project",
+          authToken: "token-1",
+          apiUrl: "https://api.example.test",
+        }),
+      Error,
+      "Project lookup failed (502)",
+    );
+    assertEquals(cancellationCount, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/src/agent/hosted/project-reference-resolver.test.ts
+++ b/src/agent/hosted/project-reference-resolver.test.ts
@@ -1,21 +1,44 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
-import { resolveHostedProjectReference } from "./project-reference-resolver.ts";
 import { MAX_OPAQUE_ID_CODE_UNITS } from "#veryfront/utils/project-identity.ts";
+import { resolveHostedProjectReference } from "./project-reference-resolver.ts";
 
-Deno.test("resolveHostedProjectReference binds normalized API identity to the request", async () => {
+const LOOKUP_INPUT = {
+  projectReference: "target-project",
+  authToken: "token-1",
+  apiUrl: "https://api.example.test",
+};
+
+async function withMockFetch<T>(
+  mockFetch: typeof globalThis.fetch,
+  operation: () => Promise<T>,
+): Promise<T> {
   const originalFetch = globalThis.fetch;
+  globalThis.fetch = mockFetch;
+  try {
+    return await operation();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function assertLookupFailure(mockFetch: typeof globalThis.fetch): Promise<void> {
+  await withMockFetch(mockFetch, () =>
+    assertRejects(
+      () => resolveHostedProjectReference(LOOKUP_INPUT),
+      Error,
+      "Project lookup failed (502)",
+    ));
+}
+
+Deno.test("resolveHostedProjectReference returns a matching normalized API identity", async () => {
   const requests: Array<{ url: string; authorization: string | null }> = [];
 
-  try {
-    globalThis.fetch = (input, init) => {
+  await withMockFetch(
+    (input, init) => {
       requests.push({
         url: String(input),
-        authorization: new Headers(
-          typeof init === "object" && init !== null
-            ? Reflect.get(init, "headers") as HeadersInit | undefined
-            : undefined,
-        ).get("authorization"),
+        authorization: new Headers(init?.headers).get("authorization"),
       });
       return Promise.resolve(
         Response.json({
@@ -23,94 +46,145 @@ Deno.test("resolveHostedProjectReference binds normalized API identity to the re
           slug: " target-project ",
         }),
       );
-    };
-
-    assertEquals(
-      await resolveHostedProjectReference({
-        projectReference: "target-project",
-        authToken: "token-1",
-        apiUrl: "https://api.example.test",
-      }),
-      {
+    },
+    async () => {
+      assertEquals(await resolveHostedProjectReference(LOOKUP_INPUT), {
         projectId: "11111111-1111-4111-8111-111111111111",
         slug: "target-project",
-      },
-    );
-    assertEquals(requests, [{
-      url: "https://api.example.test/projects/target-project",
-      authorization: "Bearer token-1",
-    }]);
+      });
+    },
+  );
 
-    globalThis.fetch = () =>
+  assertEquals(requests, [{
+    url: "https://api.example.test/projects/target-project",
+    authorization: "Bearer token-1",
+  }]);
+});
+
+Deno.test("resolveHostedProjectReference rejects an API identity that does not match the request", async () => {
+  await withMockFetch(
+    () =>
       Promise.resolve(
         Response.json({
           id: "22222222-2222-4222-8222-222222222222",
           slug: "different-project",
         }),
-      );
-
-    await assertRejects(
-      () =>
-        resolveHostedProjectReference({
-          projectReference: "target-project",
-          authToken: "token-1",
-          apiUrl: "https://api.example.test",
-        }),
-      Error,
-      "Project lookup response did not confirm the requested project identity",
-    );
-
-    let invalidReferenceFetchCount = 0;
-    globalThis.fetch = () => {
-      invalidReferenceFetchCount += 1;
-      throw new Error("invalid project references must not reach fetch");
-    };
-    for (
-      const projectReference of [
-        "",
-        " target-project",
-        "target-\nproject",
-        "p".repeat(MAX_OPAQUE_ID_CODE_UNITS + 1),
-      ]
-    ) {
+      ),
+    async () => {
       await assertRejects(
-        () =>
-          resolveHostedProjectReference({
-            projectReference,
-            authToken: "token-1",
-            apiUrl: "https://api.example.test",
-          }),
-        TypeError,
-        "Project reference must be a trimmed non-empty bounded identifier without control characters",
+        () => resolveHostedProjectReference(LOOKUP_INPUT),
+        Error,
+        "Project lookup response did not confirm the requested project identity",
       );
-    }
-    assertEquals(invalidReferenceFetchCount, 0);
+    },
+  );
+});
 
-    let cancellationCount = 0;
-    globalThis.fetch = () =>
+Deno.test("resolveHostedProjectReference rejects unsafe references before fetch", async () => {
+  let fetchCount = 0;
+
+  await withMockFetch(
+    () => {
+      fetchCount += 1;
+      throw new Error("invalid project references must not reach fetch");
+    },
+    async () => {
+      for (
+        const projectReference of [
+          "",
+          " target-project",
+          "target-\nproject",
+          "p".repeat(MAX_OPAQUE_ID_CODE_UNITS + 1),
+        ]
+      ) {
+        await assertRejects(
+          () => resolveHostedProjectReference({ ...LOOKUP_INPUT, projectReference }),
+          TypeError,
+          "Project reference must be a trimmed non-empty bounded identifier without control characters",
+        );
+      }
+    },
+  );
+
+  assertEquals(fetchCount, 0);
+});
+
+Deno.test("resolveHostedProjectReference preserves lookup failure when cancellation rejects", async () => {
+  let cancellationCount = 0;
+
+  await assertLookupFailure(() =>
+    Promise.resolve(
+      new Response(
+        new ReadableStream({
+          cancel() {
+            cancellationCount += 1;
+            return Promise.reject(new Error("cleanup failed"));
+          },
+        }),
+        { status: 502 },
+      ),
+    )
+  );
+  await Promise.resolve();
+
+  assertEquals(cancellationCount, 1);
+});
+
+Deno.test("resolveHostedProjectReference preserves lookup failure when cancellation throws", async () => {
+  let cancellationCount = 0;
+
+  await assertLookupFailure(() =>
+    Promise.resolve({
+      ok: false,
+      status: 502,
+      body: {
+        cancel() {
+          cancellationCount += 1;
+          throw new Error("cleanup failed");
+        },
+      },
+    } as unknown as Response)
+  );
+
+  assertEquals(cancellationCount, 1);
+});
+
+Deno.test("resolveHostedProjectReference does not await stalled error-body cancellation", async () => {
+  let cancellationStarted = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  await withMockFetch(
+    () =>
       Promise.resolve(
         new Response(
           new ReadableStream({
             cancel() {
-              cancellationCount += 1;
-              throw new Error("cleanup failed");
+              cancellationStarted = true;
+              return new Promise<void>(() => {});
             },
           }),
           { status: 502 },
         ),
-      );
-    await assertRejects(
-      () =>
-        resolveHostedProjectReference({
-          projectReference: "target-project",
-          authToken: "token-1",
-          apiUrl: "https://api.example.test",
-        }),
-      Error,
-      "Project lookup failed (502)",
-    );
-    assertEquals(cancellationCount, 1);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+      ),
+    async () => {
+      const timeout = new Promise<"timed-out">((resolve) => {
+        timeoutId = setTimeout(() => resolve("timed-out"), 100);
+      });
+
+      try {
+        const outcome = await Promise.race([
+          resolveHostedProjectReference(LOOKUP_INPUT).then(
+            () => "resolved",
+            (error) => error instanceof Error ? error.message : "non-error rejection",
+          ),
+          timeout,
+        ]);
+
+        assertEquals(outcome, "Project lookup failed (502)");
+        assertEquals(cancellationStarted, true);
+      } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+      }
+    },
+  );
 });

--- a/src/agent/hosted/project-reference-resolver.test.ts
+++ b/src/agent/hosted/project-reference-resolver.test.ts
@@ -80,6 +80,60 @@ Deno.test("resolveHostedProjectReference rejects an API identity that does not m
   );
 });
 
+Deno.test("resolveHostedProjectReference ignores accessors and inherited descriptor values", async () => {
+  const defineProperty = Object.defineProperty;
+  const deleteProperty = Reflect.deleteProperty;
+  const previousValue = Object.getOwnPropertyDescriptor(Object.prototype, "value");
+  let payloadAccessorCalls = 0;
+  let inheritedValueCalls = 0;
+  const payload = defineProperty({}, "id", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      payloadAccessorCalls += 1;
+      return "target-project";
+    },
+  });
+  let failure: unknown;
+
+  try {
+    defineProperty(Object.prototype, "value", {
+      configurable: true,
+      get() {
+        inheritedValueCalls += 1;
+        return "target-project";
+      },
+    });
+    await withMockFetch(
+      () =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(payload),
+        } as unknown as Response),
+      async () => {
+        try {
+          await resolveHostedProjectReference(LOOKUP_INPUT);
+        } catch (error) {
+          failure = error;
+        }
+      },
+    );
+  } finally {
+    if (previousValue) {
+      defineProperty(Object.prototype, "value", previousValue);
+    } else {
+      deleteProperty(Object.prototype, "value");
+    }
+  }
+
+  assertEquals(
+    failure instanceof Error ? failure.message : undefined,
+    "Project lookup response did not confirm the requested project identity",
+  );
+  assertEquals(payloadAccessorCalls, 0);
+  assertEquals(inheritedValueCalls, 0);
+});
+
 Deno.test("resolveHostedProjectReference rejects unsafe references before fetch", async () => {
   let fetchCount = 0;
 

--- a/src/agent/hosted/project-reference-resolver.test.ts
+++ b/src/agent/hosted/project-reference-resolver.test.ts
@@ -2,7 +2,10 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { canIdentifyProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { MAX_OPAQUE_ID_CODE_UNITS } from "#veryfront/utils/project-identity.ts";
-import { resolveHostedProjectReference } from "./project-reference-resolver.ts";
+import {
+  canReadHostedProjectLookupDataProperties,
+  resolveHostedProjectReference,
+} from "./project-reference-resolver.ts";
 
 const LOOKUP_INPUT = {
   projectReference: "target-project",
@@ -161,6 +164,16 @@ Deno.test("resolveHostedProjectReference rejects active response proxies without
   );
 
   assertEquals(trapCalls, 0);
+});
+
+Deno.test("project lookup data reads fail closed when proxy detection is unavailable", () => {
+  assertEquals(
+    canReadHostedProjectLookupDataProperties(
+      { id: "target-project", slug: "target-project" },
+      false,
+    ),
+    false,
+  );
 });
 
 Deno.test("resolveHostedProjectReference rejects revoked response proxies without leaking revocation errors", async () => {

--- a/src/agent/hosted/project-reference-resolver.test.ts
+++ b/src/agent/hosted/project-reference-resolver.test.ts
@@ -1,5 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { canIdentifyProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { MAX_OPAQUE_ID_CODE_UNITS } from "#veryfront/utils/project-identity.ts";
 import { resolveHostedProjectReference } from "./project-reference-resolver.ts";
 
@@ -132,6 +133,54 @@ Deno.test("resolveHostedProjectReference ignores accessors and inherited descrip
   );
   assertEquals(payloadAccessorCalls, 0);
   assertEquals(inheritedValueCalls, 0);
+});
+
+Deno.test("resolveHostedProjectReference rejects active response proxies without invoking traps", async () => {
+  assertEquals(canIdentifyProxyWithoutHooks, true);
+  let trapCalls = 0;
+  const payload = new Proxy({ id: "target-project", slug: "target-project" }, {
+    getOwnPropertyDescriptor() {
+      trapCalls += 1;
+      throw new Error("private descriptor failure");
+    },
+  });
+
+  await withMockFetch(
+    () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(payload),
+      } as unknown as Response),
+    async () => {
+      await assertRejects(
+        () => resolveHostedProjectReference(LOOKUP_INPUT),
+        Error,
+        "Project lookup response did not confirm the requested project identity",
+      );
+    },
+  );
+
+  assertEquals(trapCalls, 0);
+});
+
+Deno.test("resolveHostedProjectReference rejects revoked response proxies without leaking revocation errors", async () => {
+  const revocable = Proxy.revocable({ id: "target-project", slug: "target-project" }, {});
+  revocable.revoke();
+
+  await withMockFetch(
+    () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(revocable.proxy),
+      } as unknown as Response),
+    async () => {
+      await assertRejects(
+        () => resolveHostedProjectReference(LOOKUP_INPUT),
+        Error,
+        "Project lookup response did not confirm the requested project identity",
+      );
+    },
+  );
 });
 
 Deno.test("resolveHostedProjectReference rejects unsafe references before fetch", async () => {

--- a/src/agent/hosted/project-reference-resolver.test.ts
+++ b/src/agent/hosted/project-reference-resolver.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { canIdentifyProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { MAX_OPAQUE_ID_CODE_UNITS } from "#veryfront/utils/project-identity.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   canReadHostedProjectLookupDataProperties,
   resolveHostedProjectReference,
@@ -12,19 +13,6 @@ const LOOKUP_INPUT = {
   authToken: "token-1",
   apiUrl: "https://api.example.test",
 };
-
-async function withMockFetch<T>(
-  mockFetch: typeof globalThis.fetch,
-  operation: () => Promise<T>,
-): Promise<T> {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = mockFetch;
-  try {
-    return await operation();
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-}
 
 async function assertLookupFailure(mockFetch: typeof globalThis.fetch): Promise<void> {
   await withMockFetch(mockFetch, () =>

--- a/src/agent/hosted/project-reference-resolver.ts
+++ b/src/agent/hosted/project-reference-resolver.ts
@@ -18,20 +18,25 @@ const ArrayIsArray = Array.isArray;
  * Read an own data property from untrusted JSON without invoking accessors or
  * walking the prototype chain.
  */
+export function canReadHostedProjectLookupDataProperties(
+  source: unknown,
+  proxyDetectionAvailable = canIdentifyProxyWithoutHooks,
+): source is object {
+  if (typeof source !== "object" || source === null || ArrayIsArray(source)) {
+    return false;
+  }
+  if (!proxyDetectionAvailable) {
+    return false;
+  }
+  return !isProxyWithoutHooks(source);
+}
+
 function readOwnDataProperty(source: unknown, key: string): unknown {
-  if (
-    !canIdentifyProxyWithoutHooks ||
-    typeof source !== "object" ||
-    source === null ||
-    isProxyWithoutHooks(source)
-  ) {
+  if (!canReadHostedProjectLookupDataProperties(source)) {
     return undefined;
   }
 
   try {
-    if (ArrayIsArray(source)) {
-      return undefined;
-    }
     return readRuntimeOwnDataProperty(source, key, "project lookup response", false);
   } catch {
     return undefined;

--- a/src/agent/hosted/project-reference-resolver.ts
+++ b/src/agent/hosted/project-reference-resolver.ts
@@ -7,7 +7,10 @@ import {
   UNCONFIRMED_AGENT_PROJECT_IDENTITY_MESSAGE,
 } from "../project/context.ts";
 import { readOwnDataProperty as readRuntimeOwnDataProperty } from "../runtime/data-property-descriptor.ts";
-import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
+import {
+  canIdentifyProxyWithoutHooks,
+  isProxyWithoutHooks,
+} from "#veryfront/platform/compat/error-introspection.ts";
 
 const ArrayIsArray = Array.isArray;
 
@@ -16,7 +19,12 @@ const ArrayIsArray = Array.isArray;
  * walking the prototype chain.
  */
 function readOwnDataProperty(source: unknown, key: string): unknown {
-  if (typeof source !== "object" || source === null || isProxyWithoutHooks(source)) {
+  if (
+    !canIdentifyProxyWithoutHooks ||
+    typeof source !== "object" ||
+    source === null ||
+    isProxyWithoutHooks(source)
+  ) {
     return undefined;
   }
 

--- a/src/agent/hosted/project-reference-resolver.ts
+++ b/src/agent/hosted/project-reference-resolver.ts
@@ -1,8 +1,35 @@
 import {
   type ConfirmedAgentProjectContextSwitch,
+  getConfirmedAgentProjectIdentity,
   getConfirmedResolvedAgentProjectIdentity,
+  INVALID_AGENT_PROJECT_REFERENCE_MESSAGE,
+  normalizeAgentProjectReference,
   UNCONFIRMED_AGENT_PROJECT_IDENTITY_MESSAGE,
 } from "../project/context.ts";
+
+const ArrayIsArray = Array.isArray;
+const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+
+/**
+ * Read an own data property from untrusted JSON without invoking accessors or
+ * walking the prototype chain.
+ */
+function readOwnDataProperty(source: unknown, key: string): unknown {
+  if (typeof source !== "object" || source === null || ArrayIsArray(source)) {
+    return undefined;
+  }
+
+  const descriptor = ObjectGetOwnPropertyDescriptor(source, key);
+  return descriptor && "value" in descriptor ? descriptor.value : undefined;
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Preserve the primary lookup failure when connection cleanup also fails.
+  }
+}
 
 /** Resolver for public project references used by hosted agent tools. */
 export type HostedProjectReferenceResolver = (input: {
@@ -34,25 +61,40 @@ export async function resolveHostedProjectReference(input: {
   apiUrl: string;
   abortSignal?: AbortSignal;
 }): Promise<{ projectId: string; slug?: string | null }> {
+  const projectReference = normalizeAgentProjectReference(input.projectReference);
+  if (!projectReference) {
+    throw new TypeError(INVALID_AGENT_PROJECT_REFERENCE_MESSAGE);
+  }
+
   const response = await fetch(
-    new URL(`/projects/${encodeURIComponent(input.projectReference)}`, input.apiUrl),
+    new URL(`/projects/${encodeURIComponent(projectReference)}`, input.apiUrl),
     {
       headers: { Authorization: `Bearer ${input.authToken}` },
       signal: input.abortSignal,
     },
   );
   if (!response.ok) {
+    await cancelResponseBody(response);
     throw new Error(`Project lookup failed (${response.status})`);
   }
 
-  const data = await response.json() as { id?: unknown; slug?: unknown };
-  if (typeof data.id !== "string" || data.id.length === 0) {
-    throw new Error("Project lookup response did not include project id");
+  const data: unknown = await response.json();
+  const identity = getConfirmedAgentProjectIdentity({
+    projectId: readOwnDataProperty(data, "id"),
+    projectSlug: readOwnDataProperty(data, "slug"),
+    requestedProjectReference: projectReference,
+  });
+  // The response must name the project that was asked for; a lookup that
+  // answers with a different identity must not silently retarget the caller.
+  if (
+    !identity
+  ) {
+    throw new Error("Project lookup response did not confirm the requested project identity");
   }
 
   const resolution = {
-    projectId: data.id,
-    slug: typeof data.slug === "string" ? data.slug : null,
+    projectId: identity.projectId,
+    slug: identity.projectSlug ?? null,
   };
   const confirmed = requireConfirmedHostedProjectReference(
     resolution,

--- a/src/agent/hosted/project-reference-resolver.ts
+++ b/src/agent/hosted/project-reference-resolver.ts
@@ -23,12 +23,14 @@ function readOwnDataProperty(source: unknown, key: string): unknown {
   return descriptor && "value" in descriptor ? descriptor.value : undefined;
 }
 
-async function cancelResponseBody(response: Response): Promise<void> {
+function cancelResponseBodyWithoutWaiting(response: Response): void {
+  let cancellation: Promise<void> | undefined;
   try {
-    await response.body?.cancel();
+    cancellation = response.body?.cancel();
   } catch {
     // Preserve the primary lookup failure when connection cleanup also fails.
   }
+  void cancellation?.catch(() => undefined);
 }
 
 /** Resolver for public project references used by hosted agent tools. */
@@ -74,7 +76,7 @@ export async function resolveHostedProjectReference(input: {
     },
   );
   if (!response.ok) {
-    await cancelResponseBody(response);
+    cancelResponseBodyWithoutWaiting(response);
     throw new Error(`Project lookup failed (${response.status})`);
   }
 
@@ -86,9 +88,7 @@ export async function resolveHostedProjectReference(input: {
   });
   // The response must name the project that was asked for; a lookup that
   // answers with a different identity must not silently retarget the caller.
-  if (
-    !identity
-  ) {
+  if (!identity) {
     throw new Error("Project lookup response did not confirm the requested project identity");
   }
 

--- a/src/agent/hosted/project-reference-resolver.ts
+++ b/src/agent/hosted/project-reference-resolver.ts
@@ -6,27 +6,28 @@ import {
   normalizeAgentProjectReference,
   UNCONFIRMED_AGENT_PROJECT_IDENTITY_MESSAGE,
 } from "../project/context.ts";
+import { readOwnDataProperty as readRuntimeOwnDataProperty } from "../runtime/data-property-descriptor.ts";
+import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 
 const ArrayIsArray = Array.isArray;
-const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
-const ObjectPrototypeHasOwnProperty = Object.prototype.hasOwnProperty;
-const ReflectApply = Reflect.apply;
-
-function hasOwn(object: object, key: PropertyKey): boolean {
-  return ReflectApply(ObjectPrototypeHasOwnProperty, object, [key]) as boolean;
-}
 
 /**
  * Read an own data property from untrusted JSON without invoking accessors or
  * walking the prototype chain.
  */
 function readOwnDataProperty(source: unknown, key: string): unknown {
-  if (typeof source !== "object" || source === null || ArrayIsArray(source)) {
+  if (typeof source !== "object" || source === null || isProxyWithoutHooks(source)) {
     return undefined;
   }
 
-  const descriptor = ObjectGetOwnPropertyDescriptor(source, key);
-  return descriptor && hasOwn(descriptor, "value") ? descriptor.value : undefined;
+  try {
+    if (ArrayIsArray(source)) {
+      return undefined;
+    }
+    return readRuntimeOwnDataProperty(source, key, "project lookup response", false);
+  } catch {
+    return undefined;
+  }
 }
 
 function cancelResponseBodyWithoutWaiting(response: Response): void {
@@ -86,7 +87,12 @@ export async function resolveHostedProjectReference(input: {
     throw new Error(`Project lookup failed (${response.status})`);
   }
 
-  const data: unknown = await response.json();
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error("Project lookup response did not confirm the requested project identity");
+  }
   const identity = getConfirmedAgentProjectIdentity({
     projectId: readOwnDataProperty(data, "id"),
     projectSlug: readOwnDataProperty(data, "slug"),

--- a/src/agent/hosted/project-reference-resolver.ts
+++ b/src/agent/hosted/project-reference-resolver.ts
@@ -9,6 +9,12 @@ import {
 
 const ArrayIsArray = Array.isArray;
 const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const ObjectPrototypeHasOwnProperty = Object.prototype.hasOwnProperty;
+const ReflectApply = Reflect.apply;
+
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return ReflectApply(ObjectPrototypeHasOwnProperty, object, [key]) as boolean;
+}
 
 /**
  * Read an own data property from untrusted JSON without invoking accessors or
@@ -20,7 +26,7 @@ function readOwnDataProperty(source: unknown, key: string): unknown {
   }
 
   const descriptor = ObjectGetOwnPropertyDescriptor(source, key);
-  return descriptor && "value" in descriptor ? descriptor.value : undefined;
+  return descriptor && hasOwn(descriptor, "value") ? descriptor.value : undefined;
 }
 
 function cancelResponseBodyWithoutWaiting(response: Response): void {

--- a/src/agent/hosted/project-reference-resolver.ts
+++ b/src/agent/hosted/project-reference-resolver.ts
@@ -123,7 +123,7 @@ export async function resolveHostedProjectReference(input: {
   };
   const confirmed = requireConfirmedHostedProjectReference(
     resolution,
-    input.projectReference,
+    projectReference,
   );
   return {
     projectId: confirmed.projectId,

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -102,6 +102,18 @@ describe("agent/runtime/error-utils", () => {
       assertStringIncludes(result, '"details"');
     });
 
+    it("bounds best-effort string leaves before JSON serialization", () => {
+      const result = stringifyToolError({
+        code: "E_TOOL",
+        detail: "x".repeat(MAX_TOOL_ERROR_TEXT_BYTES * 1_024),
+        unsupported: undefined,
+      });
+
+      assertEquals(new TextEncoder().encode(result).byteLength <= MAX_TOOL_ERROR_TEXT_BYTES, true);
+      assertStringIncludes(result, '"code":"E_TOOL"');
+      assertStringIncludes(result, "…");
+    });
+
     it("uses a stable fallback when safe JSON serialization fails", () => {
       const circular: Record<string, unknown> = {};
       circular.self = circular;

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -319,6 +319,69 @@ describe("agent/runtime/error-utils", () => {
       assertEquals(hookCalls, 0);
     });
 
+    it("does not consult mutable primordials while snapshotting structured errors", () => {
+      const defineProperty = Object.defineProperty;
+      const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+      const targets: ReadonlyArray<readonly [object, PropertyKey]> = [
+        [Array, "isArray"],
+        [Array.prototype, "push"],
+        [Array.prototype, "sort"],
+        [JSON, "stringify"],
+        [Number, "isFinite"],
+        [Number, "isInteger"],
+        [Number, "isSafeInteger"],
+        [Object, "create"],
+        [Object, "defineProperty"],
+        [Object, "freeze"],
+        [Object, "getOwnPropertyDescriptor"],
+        [Object, "getPrototypeOf"],
+        [Object, "is"],
+        [Object, "keys"],
+        [Object.prototype, "hasOwnProperty"],
+        [Reflect, "apply"],
+        [Reflect, "ownKeys"],
+        [String.prototype, "charCodeAt"],
+        [WeakSet.prototype, "add"],
+        [WeakSet.prototype, "delete"],
+        [WeakSet.prototype, "has"],
+        [globalThis, "Array"],
+        [globalThis, "Number"],
+        [globalThis, "String"],
+        [globalThis, "TypeError"],
+        [globalThis, "WeakSet"],
+      ];
+      const originals = targets.map(([owner, key]) => ({
+        key,
+        owner,
+        descriptor: getOwnPropertyDescriptor(owner, key)!,
+      }));
+      const structuredError = { retryable: true, code: "E_TOOL" };
+      let hookCalls = 0;
+      let result: string | undefined;
+      const hostile = () => {
+        hookCalls += 1;
+        throw new Error("mutable primordial must not run");
+      };
+
+      try {
+        for (const { owner, key } of originals) {
+          defineProperty(owner, key, {
+            configurable: true,
+            value: hostile,
+            writable: true,
+          });
+        }
+        result = stringifyToolError(structuredError);
+      } finally {
+        for (const { owner, key, descriptor } of originals) {
+          defineProperty(owner, key, descriptor);
+        }
+      }
+
+      assertEquals(result, '{"code":"E_TOOL","retryable":true}');
+      assertEquals(hookCalls, 0);
+    });
+
     it("bounds direct and Error diagnostic text by UTF-8 byte length", () => {
       const oversized = "é".repeat(MAX_TOOL_ERROR_TEXT_BYTES);
       const direct = stringifyToolError(oversized);

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -140,6 +140,185 @@ describe("agent/runtime/error-utils", () => {
       assertEquals(calls, 0);
     });
 
+    it("fails closed without Proxy introspection in a fresh Cloudflare process", async () => {
+      const script = `
+        Object.defineProperty(globalThis, "caches", {
+          configurable: true,
+          value: {},
+        });
+        Object.defineProperty(globalThis, "WebSocketPair", {
+          configurable: true,
+          value: function WebSocketPair() {},
+        });
+
+        const { runtimeKind } = await import("./src/platform/compat/runtime.ts");
+        const {
+          canIdentifyProxyWithoutHooks,
+          isNativeErrorWithoutHooks,
+        } = await import("./src/platform/compat/error-introspection.ts");
+        const { stringifyToolError } = await import("./src/agent/runtime/error-utils.ts");
+
+        let calls = 0;
+        const handler = {
+          get(target, property, receiver) {
+            calls += 1;
+            return Reflect.get(target, property, receiver);
+          },
+          getOwnPropertyDescriptor(target, property) {
+            calls += 1;
+            return Reflect.getOwnPropertyDescriptor(target, property);
+          },
+          getPrototypeOf(target) {
+            calls += 1;
+            return Reflect.getPrototypeOf(target);
+          },
+          ownKeys(target) {
+            calls += 1;
+            return Reflect.ownKeys(target);
+          },
+        };
+        const proxy = new Proxy({}, handler);
+        const errorProxy = new Proxy(new Error("private"), handler);
+
+        const result = {
+          runtimeKind,
+          canIdentifyProxyWithoutHooks,
+          proxy: stringifyToolError(proxy),
+          errorProxy: stringifyToolError(errorProxy),
+          calls,
+          nativeError: isNativeErrorWithoutHooks(new Error("native")),
+          error: stringifyToolError(new Error("tool exploded")),
+          domException: stringifyToolError(
+            new DOMException("provider timed out", "TimeoutError"),
+          ),
+          object: stringifyToolError({ code: "E_TOOL" }),
+          callable: stringifyToolError(() => undefined),
+          nullValue: stringifyToolError(null),
+          booleanValue: stringifyToolError(true),
+          numberValue: stringifyToolError(42),
+          undefinedValue: stringifyToolError(undefined),
+          bigintValue: stringifyToolError(1n),
+          symbolValue: stringifyToolError(Symbol("private")),
+        };
+        console.log(JSON.stringify(result));
+      `;
+      const output = await new Deno.Command(Deno.execPath(), {
+        args: ["eval", "--config=deno.json", script],
+        cwd: new URL("../../../", import.meta.url),
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      const stderr = new TextDecoder().decode(output.stderr);
+      assertEquals(output.code, 0, stderr);
+
+      const result = JSON.parse(new TextDecoder().decode(output.stdout));
+      assertEquals(result, {
+        runtimeKind: "cloudflare",
+        canIdentifyProxyWithoutHooks: false,
+        proxy: "Unknown error",
+        errorProxy: "Unknown error",
+        calls: 0,
+        nativeError: true,
+        error: "tool exploded",
+        domException: "provider timed out",
+        object: "Unknown error",
+        callable: "Unknown error",
+        nullValue: "null",
+        booleanValue: "true",
+        numberValue: "42",
+        undefinedValue: "undefined",
+        bigintValue: "bigint",
+        symbolValue: "symbol",
+      });
+    });
+
+    it("uses captured primordials for native and primitive diagnostics", () => {
+      const defineProperty = Object.defineProperty;
+      const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+      const descriptors = {
+        apply: getOwnPropertyDescriptor(Reflect, "apply")!,
+        charCodeAt: getOwnPropertyDescriptor(String.prototype, "charCodeAt")!,
+        domMessage: getOwnPropertyDescriptor(DOMException.prototype, "message")!,
+        getOwnPropertyDescriptor: getOwnPropertyDescriptor(
+          Object,
+          "getOwnPropertyDescriptor",
+        )!,
+        hasOwnProperty: getOwnPropertyDescriptor(
+          Object.prototype,
+          "hasOwnProperty",
+        )!,
+        jsonStringify: getOwnPropertyDescriptor(JSON, "stringify")!,
+        slice: getOwnPropertyDescriptor(String.prototype, "slice")!,
+      };
+      const domException = new DOMException("provider timed out", "TimeoutError");
+      const oversized = "é".repeat(MAX_TOOL_ERROR_TEXT_BYTES);
+      let hookCalls = 0;
+      const hostile = () => {
+        hookCalls += 1;
+        throw new Error("mutable primordial must not run");
+      };
+      let result:
+        | {
+          bounded: string;
+          domException: string;
+          error: string;
+          nullValue: string;
+        }
+        | undefined;
+
+      try {
+        for (
+          const [owner, key] of [
+            [Reflect, "apply"],
+            [String.prototype, "charCodeAt"],
+            [DOMException.prototype, "message"],
+            [Object, "getOwnPropertyDescriptor"],
+            [Object.prototype, "hasOwnProperty"],
+            [JSON, "stringify"],
+            [String.prototype, "slice"],
+          ] as const
+        ) {
+          defineProperty(owner, key, {
+            configurable: true,
+            value: hostile,
+            writable: true,
+          });
+        }
+
+        result = {
+          bounded: stringifyToolError(oversized),
+          domException: stringifyToolError(domException),
+          error: stringifyToolError(new Error("tool exploded")),
+          nullValue: stringifyToolError(null),
+        };
+      } finally {
+        defineProperty(Reflect, "apply", descriptors.apply);
+        defineProperty(String.prototype, "charCodeAt", descriptors.charCodeAt);
+        defineProperty(DOMException.prototype, "message", descriptors.domMessage);
+        defineProperty(
+          Object,
+          "getOwnPropertyDescriptor",
+          descriptors.getOwnPropertyDescriptor,
+        );
+        defineProperty(
+          Object.prototype,
+          "hasOwnProperty",
+          descriptors.hasOwnProperty,
+        );
+        defineProperty(JSON, "stringify", descriptors.jsonStringify);
+        defineProperty(String.prototype, "slice", descriptors.slice);
+      }
+
+      assertEquals(result?.error, "tool exploded");
+      assertEquals(result?.domException, "provider timed out");
+      assertEquals(result?.nullValue, "null");
+      assertEquals(
+        new TextEncoder().encode(result?.bounded).byteLength <= MAX_TOOL_ERROR_TEXT_BYTES,
+        true,
+      );
+      assertEquals(hookCalls, 0);
+    });
+
     it("bounds direct and Error diagnostic text by UTF-8 byte length", () => {
       const oversized = "é".repeat(MAX_TOOL_ERROR_TEXT_BYTES);
       const direct = stringifyToolError(oversized);

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -144,6 +144,40 @@ describe("agent/runtime/error-utils", () => {
       assertEquals(calls, 0);
     });
 
+    it("shadows inherited array toJSON in best-effort diagnostics", () => {
+      const defineProperty = Object.defineProperty;
+      const deleteProperty = Reflect.deleteProperty;
+      const original = Object.getOwnPropertyDescriptor(Array.prototype, "toJSON");
+      let calls = 0;
+      let result: string | undefined;
+
+      try {
+        defineProperty(Array.prototype, "toJSON", {
+          configurable: true,
+          value() {
+            calls += 1;
+            return "mutated-array";
+          },
+          writable: true,
+        });
+
+        result = stringifyToolError({
+          code: "E_TOOL",
+          details: ["safe", 1],
+          skipped: undefined,
+        });
+      } finally {
+        if (original) {
+          defineProperty(Array.prototype, "toJSON", original);
+        } else {
+          deleteProperty(Array.prototype, "toJSON");
+        }
+      }
+
+      assertEquals(result, '{"code":"E_TOOL","details":["safe",1]}');
+      assertEquals(calls, 0);
+    });
+
     it("fails closed for revoked proxies", () => {
       const { proxy, revoke } = Proxy.revocable({}, {});
       revoke();

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -355,31 +355,113 @@ describe("agent/runtime/error-utils", () => {
         owner,
         descriptor: getOwnPropertyDescriptor(owner, key)!,
       }));
-      const structuredError = { retryable: true, code: "E_TOOL" };
+      const structuredError = {
+        retryable: true,
+        details: ["safe", 1],
+        code: "E_TOOL",
+      };
       let hookCalls = 0;
       let result: string | undefined;
-      const hostile = () => {
-        hookCalls += 1;
-        throw new Error("mutable primordial must not run");
-      };
 
       try {
-        for (const { owner, key } of originals) {
+        for (let index = 0; index < originals.length; index += 1) {
+          const { owner, key } = originals[index]!;
+          const label = typeof key === "string" ? key : "Symbol.iterator";
           defineProperty(owner, key, {
             configurable: true,
-            value: hostile,
+            value: () => {
+              hookCalls += 1;
+              throw new Error(`mutable primordial ${label} must not run`);
+            },
             writable: true,
           });
         }
         result = stringifyToolError(structuredError);
       } finally {
-        for (const { owner, key, descriptor } of originals) {
+        for (let index = 0; index < originals.length; index += 1) {
+          const { owner, key, descriptor } = originals[index]!;
           defineProperty(owner, key, descriptor);
         }
       }
 
-      assertEquals(result, '{"code":"E_TOOL","retryable":true}');
+      assertEquals(
+        result,
+        '{"code":"E_TOOL","details":["safe",1],"retryable":true}',
+      );
       assertEquals(hookCalls, 0);
+    });
+
+    it("avoids Array iterators and inherited numeric setters in a fresh process", async () => {
+      const script = `
+        const { stringifyToolError } = await import(
+          "./src/agent/runtime/error-utils.ts"
+        );
+        const defineProperty = Object.defineProperty;
+        const deleteProperty = Reflect.deleteProperty;
+        const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+        const iteratorDescriptor = getOwnPropertyDescriptor(
+          Array.prototype,
+          Symbol.iterator,
+        );
+        const indexDescriptor = getOwnPropertyDescriptor(Array.prototype, "0");
+        const structuredError = {
+          retryable: true,
+          details: ["safe", 1],
+          code: "E_TOOL",
+        };
+        let iteratorCalls = 0;
+        let inheritedSetterCalls = 0;
+        let result;
+
+        try {
+          defineProperty(Array.prototype, Symbol.iterator, {
+            configurable: true,
+            value() {
+              iteratorCalls += 1;
+              throw new Error("Array iterator must not run");
+            },
+            writable: true,
+          });
+          defineProperty(Array.prototype, "0", {
+            configurable: true,
+            set() {
+              inheritedSetterCalls += 1;
+            },
+          });
+          result = stringifyToolError(structuredError);
+        } finally {
+          if (iteratorDescriptor) {
+            defineProperty(Array.prototype, Symbol.iterator, iteratorDescriptor);
+          }
+          if (indexDescriptor) {
+            defineProperty(Array.prototype, "0", indexDescriptor);
+          } else {
+            deleteProperty(Array.prototype, "0");
+          }
+        }
+
+        console.log(JSON.stringify({
+          inheritedSetterCalls,
+          iteratorCalls,
+          result,
+        }));
+      `;
+      const output = await new Deno.Command(Deno.execPath(), {
+        args: ["eval", "--config=deno.json", script],
+        cwd: new URL("../../../", import.meta.url),
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      const stderr = new TextDecoder().decode(output.stderr);
+      assertEquals(output.code, 0, stderr);
+      assertEquals(
+        JSON.parse(new TextDecoder().decode(output.stdout)),
+        {
+          inheritedSetterCalls: 0,
+          iteratorCalls: 0,
+          result: '{"code":"E_TOOL","details":["safe",1],"retryable":true}',
+        },
+      );
     });
 
     it("bounds direct and Error diagnostic text by UTF-8 byte length", () => {

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -80,6 +80,16 @@ describe("agent/runtime/error-utils", () => {
       );
     });
 
+    it("bounds serialized structured values after JSON escaping", () => {
+      const value = { message: "\u0000".repeat(MAX_TOOL_ERROR_TEXT_BYTES) };
+      const result = stringifyToolError(value);
+
+      assertEquals(
+        new TextEncoder().encode(result).byteLength <= MAX_TOOL_ERROR_TEXT_BYTES,
+        true,
+      );
+    });
+
     it("uses a stable fallback when safe JSON serialization fails", () => {
       const circular: Record<string, unknown> = {};
       circular.self = circular;

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -80,14 +80,26 @@ describe("agent/runtime/error-utils", () => {
       );
     });
 
+    it("retains safe fields when structured diagnostics contain unsupported values", () => {
+      assertEquals(
+        stringifyToolError({
+          code: "E_TOOL",
+          detail: undefined,
+          occurredAt: new Date("2026-08-03T00:00:00.000Z"),
+        }),
+        '{"code":"E_TOOL","occurredAt":"2026-08-03T00:00:00.000Z"}',
+      );
+    });
+
     it("bounds serialized structured values after JSON escaping", () => {
-      const value = { message: "\u0000".repeat(MAX_TOOL_ERROR_TEXT_BYTES) };
+      const value = { details: "\u0000".repeat(MAX_TOOL_ERROR_TEXT_BYTES) };
       const result = stringifyToolError(value);
 
       assertEquals(
         new TextEncoder().encode(result).byteLength <= MAX_TOOL_ERROR_TEXT_BYTES,
         true,
       );
+      assertStringIncludes(result, '"details"');
     });
 
     it("uses a stable fallback when safe JSON serialization fails", () => {
@@ -115,6 +127,20 @@ describe("agent/runtime/error-utils", () => {
       };
 
       assertEquals(stringifyToolError(hostile), "Unknown error");
+      assertEquals(calls, 0);
+    });
+
+    it("retains safe siblings without invoking unsupported diagnostic branches", () => {
+      let calls = 0;
+      const diagnostic = Object.defineProperty({ code: "E_TOOL" }, "detail", {
+        enumerable: true,
+        get() {
+          calls += 1;
+          return "private";
+        },
+      });
+
+      assertEquals(stringifyToolError(diagnostic), '{"code":"E_TOOL"}');
       assertEquals(calls, 0);
     });
 

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -115,6 +115,31 @@ describe("agent/runtime/error-utils", () => {
       assertEquals(stringifyToolError(proxy), "Unknown error");
     });
 
+    it("fails closed for active proxies without invoking traps", () => {
+      let calls = 0;
+      const proxy = new Proxy({}, {
+        get(target, property, receiver) {
+          calls += 1;
+          return Reflect.get(target, property, receiver);
+        },
+        getOwnPropertyDescriptor(target, property) {
+          calls += 1;
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+        getPrototypeOf(target) {
+          calls += 1;
+          return Reflect.getPrototypeOf(target);
+        },
+        ownKeys(target) {
+          calls += 1;
+          return Reflect.ownKeys(target);
+        },
+      });
+
+      assertEquals(stringifyToolError(proxy), "Unknown error");
+      assertEquals(calls, 0);
+    });
+
     it("bounds direct and Error diagnostic text by UTF-8 byte length", () => {
       const oversized = "é".repeat(MAX_TOOL_ERROR_TEXT_BYTES);
       const direct = stringifyToolError(oversized);

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -1,7 +1,17 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStrictEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertStrictEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createAbortError, stringifyToolError, throwIfAborted } from "./error-utils.ts";
+import {
+  createAbortError,
+  MAX_TOOL_ERROR_TEXT_BYTES,
+  stringifyToolError,
+  throwIfAborted,
+} from "./error-utils.ts";
 
 describe("agent/runtime/error-utils", () => {
   describe("createAbortError", () => {
@@ -52,6 +62,17 @@ describe("agent/runtime/error-utils", () => {
       assertEquals(stringifyToolError(new Error("tool exploded")), "tool exploded");
     });
 
+    it("preserves native abort and timeout DOMException messages", () => {
+      assertEquals(
+        stringifyToolError(new DOMException("client disconnected", "AbortError")),
+        "client disconnected",
+      );
+      assertEquals(
+        stringifyToolError(new DOMException("provider timed out", "TimeoutError")),
+        "provider timed out",
+      );
+    });
+
     it("stringifies structured values as JSON", () => {
       assertEquals(
         stringifyToolError({ code: "E_TOOL", retryable: true }),
@@ -59,11 +80,53 @@ describe("agent/runtime/error-utils", () => {
       );
     });
 
-    it("falls back to String() when JSON serialization fails", () => {
+    it("uses a stable fallback when safe JSON serialization fails", () => {
       const circular: Record<string, unknown> = {};
       circular.self = circular;
 
-      assertEquals(stringifyToolError(circular), "[object Object]");
+      assertEquals(stringifyToolError(circular), "Unknown error");
+    });
+
+    it("does not invoke getters or custom serialization and coercion hooks", () => {
+      let calls = 0;
+      const hostile = {
+        get message(): string {
+          calls += 1;
+          return "getter executed";
+        },
+        toJSON(): string {
+          calls += 1;
+          return "serializer executed";
+        },
+        [Symbol.toPrimitive](): string {
+          calls += 1;
+          return "coercion executed";
+        },
+      };
+
+      assertEquals(stringifyToolError(hostile), "Unknown error");
+      assertEquals(calls, 0);
+    });
+
+    it("fails closed for revoked proxies", () => {
+      const { proxy, revoke } = Proxy.revocable({}, {});
+      revoke();
+
+      assertEquals(stringifyToolError(proxy), "Unknown error");
+    });
+
+    it("bounds direct and Error diagnostic text by UTF-8 byte length", () => {
+      const oversized = "é".repeat(MAX_TOOL_ERROR_TEXT_BYTES);
+      const direct = stringifyToolError(oversized);
+      const fromError = stringifyToolError(new Error(oversized));
+
+      assertEquals(new TextEncoder().encode(direct).byteLength <= MAX_TOOL_ERROR_TEXT_BYTES, true);
+      assertEquals(
+        new TextEncoder().encode(fromError).byteLength <= MAX_TOOL_ERROR_TEXT_BYTES,
+        true,
+      );
+      assertStringIncludes(direct, "…");
+      assertStringIncludes(fromError, "…");
     });
   });
 });

--- a/src/agent/runtime/error-utils.ts
+++ b/src/agent/runtime/error-utils.ts
@@ -207,7 +207,8 @@ function snapshotBestEffortDiagnostic(
   state.nodes += 1;
 
   if (value === null) return null;
-  if (typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "string") return boundToolErrorText(value);
+  if (typeof value === "boolean") return value;
   if (typeof value === "number") return numberIsFinite(value) ? value : OMIT_DIAGNOSTIC_VALUE;
   if (typeof value !== "object") return OMIT_DIAGNOSTIC_VALUE;
 

--- a/src/agent/runtime/error-utils.ts
+++ b/src/agent/runtime/error-utils.ts
@@ -14,14 +14,46 @@ const TOOL_ERROR_TEXT_TRUNCATION_SUFFIX = "…";
 const TOOL_ERROR_TEXT_TRUNCATION_SUFFIX_BYTES = 3;
 const UNKNOWN_TOOL_ERROR_TEXT = "Unknown error";
 const apply = Reflect.apply;
+const ArrayIsArray = Array.isArray;
+const dateToISOString = Date.prototype.toISOString;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const getPrototypeOf = Object.getPrototypeOf;
+const objectCreate = Object.create;
+const objectDefineProperty = Object.defineProperty;
 const objectHasOwnProperty = Object.prototype.hasOwnProperty;
+const ownKeys = Reflect.ownKeys;
 const stringCharCodeAt = String.prototype.charCodeAt;
 const stringSlice = String.prototype.slice;
 const jsonStringify = JSON.stringify;
+const mathMin = Math.min;
+const NativeArrayPrototype = Array.prototype;
+const NativeDatePrototype = Date.prototype;
+const NativeObjectPrototype = Object.prototype;
+const NativeWeakSet = WeakSet;
+const numberIsFinite = Number.isFinite;
+const numberIsSafeInteger = Number.isSafeInteger;
+const stringFromValue = String;
+const weakSetAdd = WeakSet.prototype.add;
+const weakSetDelete = WeakSet.prototype.delete;
+const weakSetHas = WeakSet.prototype.has;
+const MAX_BEST_EFFORT_DEPTH = 8;
+const MAX_BEST_EFFORT_NODES = 256;
+const OMIT_DIAGNOSTIC_VALUE = Symbol("omit-diagnostic-value");
 
 function hasOwn(object: object, key: PropertyKey): boolean {
   return apply(objectHasOwnProperty, object, [key]) as boolean;
+}
+
+function hasWeakSetValue(set: WeakSet<object>, value: object): boolean {
+  return apply(weakSetHas, set, [value]) as boolean;
+}
+
+function addWeakSetValue(set: WeakSet<object>, value: object): void {
+  apply(weakSetAdd, set, [value]);
+}
+
+function deleteWeakSetValue(set: WeakSet<object>, value: object): void {
+  apply(weakSetDelete, set, [value]);
 }
 
 function readOwnGetter(object: object, key: PropertyKey): (() => unknown) | undefined {
@@ -112,6 +144,163 @@ function readNativeDomExceptionMessage(error: unknown): string | undefined {
   }
 }
 
+type BestEffortDiagnosticValue =
+  | null
+  | boolean
+  | number
+  | string
+  | BestEffortDiagnosticValue[]
+  | { [key: string]: BestEffortDiagnosticValue };
+
+interface BestEffortDiagnosticState {
+  ancestors: WeakSet<object>;
+  nodes: number;
+}
+
+function inspectOwnDescriptor(
+  value: object,
+  key: PropertyKey,
+): PropertyDescriptor | undefined {
+  try {
+    return getOwnPropertyDescriptor(value, key);
+  } catch {
+    return undefined;
+  }
+}
+
+function defineDiagnosticProperty(
+  target: object,
+  key: PropertyKey,
+  value: BestEffortDiagnosticValue,
+): void {
+  objectDefineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+/**
+ * Build a partial diagnostic after the strict JSON snapshot rejects one
+ * branch. This path never evaluates accessors, coercion hooks, or Proxy traps:
+ * unsafe branches are omitted (or represented as null in arrays) while safe
+ * siblings remain useful to operators and models.
+ */
+function snapshotBestEffortDiagnostic(
+  value: unknown,
+  depth: number,
+  state: BestEffortDiagnosticState,
+): BestEffortDiagnosticValue | typeof OMIT_DIAGNOSTIC_VALUE {
+  if (state.nodes >= MAX_BEST_EFFORT_NODES || depth > MAX_BEST_EFFORT_DEPTH) {
+    return OMIT_DIAGNOSTIC_VALUE;
+  }
+  state.nodes += 1;
+
+  if (value === null) return null;
+  if (typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") return numberIsFinite(value) ? value : OMIT_DIAGNOSTIC_VALUE;
+  if (typeof value !== "object") return OMIT_DIAGNOSTIC_VALUE;
+
+  if (isProxyWithoutHooks(value) || hasWeakSetValue(state.ancestors, value)) {
+    return OMIT_DIAGNOSTIC_VALUE;
+  }
+
+  let prototype: object | null;
+  try {
+    prototype = getPrototypeOf(value);
+  } catch {
+    return OMIT_DIAGNOSTIC_VALUE;
+  }
+
+  if (prototype === NativeDatePrototype) {
+    try {
+      return apply(dateToISOString, value, []) as string;
+    } catch {
+      return OMIT_DIAGNOSTIC_VALUE;
+    }
+  }
+
+  const isArray = ArrayIsArray(value);
+  if (
+    (isArray && prototype !== NativeArrayPrototype) ||
+    (!isArray && prototype !== NativeObjectPrototype && prototype !== null)
+  ) {
+    return OMIT_DIAGNOSTIC_VALUE;
+  }
+
+  addWeakSetValue(state.ancestors, value);
+  try {
+    if (isArray) {
+      const lengthDescriptor = inspectOwnDescriptor(value, "length");
+      if (
+        !lengthDescriptor || !hasOwn(lengthDescriptor, "value") ||
+        !numberIsSafeInteger(lengthDescriptor.value) || lengthDescriptor.value < 0
+      ) {
+        return OMIT_DIAGNOSTIC_VALUE;
+      }
+      const length = mathMin(
+        lengthDescriptor.value as number,
+        MAX_BEST_EFFORT_NODES - state.nodes,
+      );
+      const result: BestEffortDiagnosticValue[] = [];
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = inspectOwnDescriptor(value, stringFromValue(index));
+        const child = descriptor && descriptor.enumerable === true && hasOwn(descriptor, "value")
+          ? snapshotBestEffortDiagnostic(descriptor.value, depth + 1, state)
+          : OMIT_DIAGNOSTIC_VALUE;
+        defineDiagnosticProperty(
+          result,
+          index,
+          child === OMIT_DIAGNOSTIC_VALUE ? null : child,
+        );
+      }
+      return result;
+    }
+
+    let keys: (string | symbol)[];
+    try {
+      keys = ownKeys(value);
+    } catch {
+      return OMIT_DIAGNOSTIC_VALUE;
+    }
+    const result = objectCreate(null) as Record<string, BestEffortDiagnosticValue>;
+    let retainedProperties = 0;
+    for (let index = 0; index < keys.length; index += 1) {
+      const key = keys[index]!;
+      if (typeof key !== "string") continue;
+      const descriptor = inspectOwnDescriptor(value, key);
+      if (!descriptor || descriptor.enumerable !== true || !hasOwn(descriptor, "value")) continue;
+      const child = snapshotBestEffortDiagnostic(descriptor.value, depth + 1, state);
+      if (child !== OMIT_DIAGNOSTIC_VALUE) {
+        defineDiagnosticProperty(result, key, child);
+        retainedProperties += 1;
+      }
+      if (state.nodes >= MAX_BEST_EFFORT_NODES) break;
+    }
+    return retainedProperties > 0 ? result : OMIT_DIAGNOSTIC_VALUE;
+  } finally {
+    deleteWeakSetValue(state.ancestors, value);
+  }
+}
+
+function stringifyBestEffortDiagnostic(error: unknown): string | undefined {
+  if (!canIdentifyProxyWithoutHooks) return undefined;
+  const snapshot = snapshotBestEffortDiagnostic(error, 0, {
+    ancestors: new NativeWeakSet(),
+    nodes: 0,
+  });
+  if (snapshot === OMIT_DIAGNOSTIC_VALUE) return undefined;
+  try {
+    const serialized = jsonStringify(snapshot);
+    return typeof serialized === "string" && serialized.length > 0
+      ? boundToolErrorText(serialized)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function stringifyToolError(error: unknown): string {
   if (typeof error === "string" && error.length > 0) {
     return boundToolErrorText(error);
@@ -159,6 +348,6 @@ export function stringifyToolError(error: unknown): string {
     if (error === undefined) return "undefined";
     if (typeof error === "bigint") return "bigint";
     if (typeof error === "symbol") return "symbol";
-    return UNKNOWN_TOOL_ERROR_TEXT;
+    return stringifyBestEffortDiagnostic(error) ?? UNKNOWN_TOOL_ERROR_TEXT;
   }
 }

--- a/src/agent/runtime/error-utils.ts
+++ b/src/agent/runtime/error-utils.ts
@@ -1,17 +1,117 @@
+import { snapshotJsonValue } from "#veryfront/provider/runtime-loader/json-snapshot.ts";
+
 export { createAbortError, throwIfAborted } from "#veryfront/utils/abort.ts";
 
-export function stringifyToolError(error: unknown): string {
-  if (typeof error === "string" && error.length > 0) {
-    return error;
+/** Maximum UTF-8 size of tool failure text forwarded to logs, clients, or models. */
+export const MAX_TOOL_ERROR_TEXT_BYTES = 4_096;
+
+const TOOL_ERROR_TEXT_TRUNCATION_SUFFIX = "…";
+const TOOL_ERROR_TEXT_TRUNCATION_SUFFIX_BYTES = 3;
+const UNKNOWN_TOOL_ERROR_TEXT = "Unknown error";
+const apply = Reflect.apply;
+const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const DOM_EXCEPTION_MESSAGE_GETTER = typeof DOMException === "function"
+  ? getOwnPropertyDescriptor(DOMException.prototype, "message")?.get
+  : undefined;
+
+function codePointUtf8Width(value: string, index: number): { bytes: number; codeUnits: number } {
+  const codeUnit = value.charCodeAt(index);
+  if (codeUnit <= 0x7f) return { bytes: 1, codeUnits: 1 };
+  if (codeUnit <= 0x7ff) return { bytes: 2, codeUnits: 1 };
+  if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+    const next = value.charCodeAt(index + 1);
+    if (next >= 0xdc00 && next <= 0xdfff) {
+      return { bytes: 4, codeUnits: 2 };
+    }
+  }
+  // TextEncoder replaces lone surrogates with the three-byte U+FFFD sequence.
+  return { bytes: 3, codeUnits: 1 };
+}
+
+function boundToolErrorText(value: string): string {
+  let bytes = 0;
+  let index = 0;
+  let suffixSafeIndex = 0;
+
+  while (index < value.length) {
+    const width = codePointUtf8Width(value, index);
+    if (width.bytes > MAX_TOOL_ERROR_TEXT_BYTES - bytes) {
+      return value.slice(0, suffixSafeIndex) + TOOL_ERROR_TEXT_TRUNCATION_SUFFIX;
+    }
+    bytes += width.bytes;
+    index += width.codeUnits;
+    if (bytes <= MAX_TOOL_ERROR_TEXT_BYTES - TOOL_ERROR_TEXT_TRUNCATION_SUFFIX_BYTES) {
+      suffixSafeIndex = index;
+    }
   }
 
-  if (error instanceof Error && typeof error.message === "string" && error.message.length > 0) {
-    return error.message;
+  return value;
+}
+
+function readOwnMessage(error: unknown): string | undefined {
+  if (
+    (typeof error !== "object" || error === null) &&
+    typeof error !== "function"
+  ) {
+    return undefined;
   }
 
   try {
-    return JSON.stringify(error);
+    const descriptor = getOwnPropertyDescriptor(error, "message");
+    return descriptor && Object.hasOwn(descriptor, "value") &&
+        typeof descriptor.value === "string"
+      ? descriptor.value
+      : undefined;
   } catch {
-    return String(error);
+    return undefined;
+  }
+}
+
+function readNativeDomExceptionMessage(error: unknown): string | undefined {
+  if (
+    !DOM_EXCEPTION_MESSAGE_GETTER ||
+    ((typeof error !== "object" || error === null) && typeof error !== "function")
+  ) {
+    return undefined;
+  }
+
+  try {
+    const message = apply(DOM_EXCEPTION_MESSAGE_GETTER, error, []);
+    return typeof message === "string" ? message : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function stringifyToolError(error: unknown): string {
+  if (typeof error === "string" && error.length > 0) {
+    return boundToolErrorText(error);
+  }
+
+  const ownMessage = readOwnMessage(error);
+  if (ownMessage !== undefined && ownMessage.length > 0) {
+    return boundToolErrorText(ownMessage);
+  }
+
+  const domExceptionMessage = readNativeDomExceptionMessage(error);
+  if (domExceptionMessage !== undefined && domExceptionMessage.length > 0) {
+    return boundToolErrorText(domExceptionMessage);
+  }
+
+  try {
+    const snapshot = snapshotJsonValue(error, {
+      maxBytes: MAX_TOOL_ERROR_TEXT_BYTES,
+      maxDepth: 16,
+      maxNodes: 1_024,
+    });
+    const serialized = JSON.stringify(snapshot);
+    return typeof serialized === "string" && serialized.length > 0
+      ? serialized
+      : UNKNOWN_TOOL_ERROR_TEXT;
+  } catch {
+    if (error === undefined) return "undefined";
+    if (typeof error === "bigint") return "bigint";
+    if (typeof error === "symbol") return "symbol";
+    return UNKNOWN_TOOL_ERROR_TEXT;
   }
 }

--- a/src/agent/runtime/error-utils.ts
+++ b/src/agent/runtime/error-utils.ts
@@ -1,4 +1,5 @@
 import { snapshotJsonValue } from "#veryfront/provider/runtime-loader/json-snapshot.ts";
+import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 
 export { createAbortError, throwIfAborted } from "#veryfront/utils/abort.ts";
 
@@ -86,6 +87,10 @@ function readNativeDomExceptionMessage(error: unknown): string | undefined {
 export function stringifyToolError(error: unknown): string {
   if (typeof error === "string" && error.length > 0) {
     return boundToolErrorText(error);
+  }
+
+  if (isProxyWithoutHooks(error)) {
+    return UNKNOWN_TOOL_ERROR_TEXT;
   }
 
   const ownMessage = readOwnMessage(error);

--- a/src/agent/runtime/error-utils.ts
+++ b/src/agent/runtime/error-utils.ts
@@ -181,6 +181,15 @@ function defineDiagnosticProperty(
   });
 }
 
+function defineDiagnosticSerializationGuard(target: object): void {
+  objectDefineProperty(target, "toJSON", {
+    configurable: false,
+    enumerable: false,
+    value: undefined,
+    writable: false,
+  });
+}
+
 /**
  * Build a partial diagnostic after the strict JSON snapshot rejects one
  * branch. This path never evaluates accessors, coercion hooks, or Proxy traps:
@@ -255,6 +264,7 @@ function snapshotBestEffortDiagnostic(
           child === OMIT_DIAGNOSTIC_VALUE ? null : child,
         );
       }
+      defineDiagnosticSerializationGuard(result);
       return result;
     }
 

--- a/src/agent/runtime/error-utils.ts
+++ b/src/agent/runtime/error-utils.ts
@@ -1,5 +1,9 @@
 import { snapshotJsonValue } from "#veryfront/provider/runtime-loader/json-snapshot.ts";
-import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
+import {
+  canIdentifyProxyWithoutHooks,
+  isNativeErrorWithoutHooks,
+  isProxyWithoutHooks,
+} from "#veryfront/platform/compat/error-introspection.ts";
 
 export { createAbortError, throwIfAborted } from "#veryfront/utils/abort.ts";
 
@@ -11,16 +15,40 @@ const TOOL_ERROR_TEXT_TRUNCATION_SUFFIX_BYTES = 3;
 const UNKNOWN_TOOL_ERROR_TEXT = "Unknown error";
 const apply = Reflect.apply;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectHasOwnProperty = Object.prototype.hasOwnProperty;
+const stringCharCodeAt = String.prototype.charCodeAt;
+const stringSlice = String.prototype.slice;
+const jsonStringify = JSON.stringify;
+
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return apply(objectHasOwnProperty, object, [key]) as boolean;
+}
+
+function readOwnGetter(object: object, key: PropertyKey): (() => unknown) | undefined {
+  const descriptor = getOwnPropertyDescriptor(object, key);
+  return descriptor && hasOwn(descriptor, "get") && typeof descriptor.get === "function"
+    ? descriptor.get
+    : undefined;
+}
+
 const DOM_EXCEPTION_MESSAGE_GETTER = typeof DOMException === "function"
-  ? getOwnPropertyDescriptor(DOMException.prototype, "message")?.get
+  ? readOwnGetter(DOMException.prototype, "message")
   : undefined;
 
+function charCodeAt(value: string, index: number): number {
+  return apply(stringCharCodeAt, value, [index]);
+}
+
+function slice(value: string, start: number, end?: number): string {
+  return apply(stringSlice, value, end === undefined ? [start] : [start, end]);
+}
+
 function codePointUtf8Width(value: string, index: number): { bytes: number; codeUnits: number } {
-  const codeUnit = value.charCodeAt(index);
+  const codeUnit = charCodeAt(value, index);
   if (codeUnit <= 0x7f) return { bytes: 1, codeUnits: 1 };
   if (codeUnit <= 0x7ff) return { bytes: 2, codeUnits: 1 };
   if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-    const next = value.charCodeAt(index + 1);
+    const next = charCodeAt(value, index + 1);
     if (next >= 0xdc00 && next <= 0xdfff) {
       return { bytes: 4, codeUnits: 2 };
     }
@@ -37,7 +65,7 @@ function boundToolErrorText(value: string): string {
   while (index < value.length) {
     const width = codePointUtf8Width(value, index);
     if (width.bytes > MAX_TOOL_ERROR_TEXT_BYTES - bytes) {
-      return value.slice(0, suffixSafeIndex) + TOOL_ERROR_TEXT_TRUNCATION_SUFFIX;
+      return slice(value, 0, suffixSafeIndex) + TOOL_ERROR_TEXT_TRUNCATION_SUFFIX;
     }
     bytes += width.bytes;
     index += width.codeUnits;
@@ -59,7 +87,7 @@ function readOwnMessage(error: unknown): string | undefined {
 
   try {
     const descriptor = getOwnPropertyDescriptor(error, "message");
-    return descriptor && Object.hasOwn(descriptor, "value") &&
+    return descriptor && hasOwn(descriptor, "value") &&
         typeof descriptor.value === "string"
       ? descriptor.value
       : undefined;
@@ -89,8 +117,16 @@ export function stringifyToolError(error: unknown): string {
     return boundToolErrorText(error);
   }
 
-  if (isProxyWithoutHooks(error)) {
-    return UNKNOWN_TOOL_ERROR_TEXT;
+  const objectLike = (typeof error === "object" && error !== null) || typeof error === "function";
+  if (objectLike) {
+    if (canIdentifyProxyWithoutHooks) {
+      if (isProxyWithoutHooks(error)) return UNKNOWN_TOOL_ERROR_TEXT;
+    } else if (!isNativeErrorWithoutHooks(error)) {
+      // Without a no-hook Proxy brand check, ordinary objects and functions
+      // cannot be distinguished safely from Proxy values. Native Error brands
+      // remain readable through the captured Error.isError primitive.
+      return UNKNOWN_TOOL_ERROR_TEXT;
+    }
   }
 
   const ownMessage = readOwnMessage(error);
@@ -103,13 +139,19 @@ export function stringifyToolError(error: unknown): string {
     return boundToolErrorText(domExceptionMessage);
   }
 
+  // A genuine Error without a readable message is already exhausted here.
+  // Do not pass it into object reflection when Proxy detection is unavailable.
+  if (objectLike && !canIdentifyProxyWithoutHooks) {
+    return UNKNOWN_TOOL_ERROR_TEXT;
+  }
+
   try {
     const snapshot = snapshotJsonValue(error, {
       maxBytes: MAX_TOOL_ERROR_TEXT_BYTES,
       maxDepth: 16,
       maxNodes: 1_024,
     });
-    const serialized = JSON.stringify(snapshot);
+    const serialized = jsonStringify(snapshot);
     return typeof serialized === "string" && serialized.length > 0
       ? serialized
       : UNKNOWN_TOOL_ERROR_TEXT;

--- a/src/agent/runtime/error-utils.ts
+++ b/src/agent/runtime/error-utils.ts
@@ -153,7 +153,7 @@ export function stringifyToolError(error: unknown): string {
     });
     const serialized = jsonStringify(snapshot);
     return typeof serialized === "string" && serialized.length > 0
-      ? serialized
+      ? boundToolErrorText(serialized)
       : UNKNOWN_TOOL_ERROR_TEXT;
   } catch {
     if (error === undefined) return "undefined";

--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { VERYFRONT_CLOUD_CHAT_MODELS } from "#veryfront/provider/veryfront-cloud/model-catalog.ts";
 import {
   AUTO_AGENT_MODEL,
   DEFAULT_AGENT_MODEL,
@@ -100,6 +101,30 @@ describe("agent/runtime/model-resolution", () => {
       resolveConfiguredAgentModel("mistral-large"),
       "mistral/mistral-large-2512",
     );
+  });
+
+  it("aliases every Veryfront Cloud catalog model id to its provider model", () => {
+    for (const model of VERYFRONT_CLOUD_CHAT_MODELS) {
+      assertEquals(resolveConfiguredAgentModel(model.id), model.modelId);
+    }
+  });
+
+  it("does not resolve Object.prototype members as model aliases", () => {
+    for (
+      const inherited of [
+        "constructor",
+        "toString",
+        "valueOf",
+        "hasOwnProperty",
+        "isPrototypeOf",
+        "propertyIsEnumerable",
+        "toLocaleString",
+        "__proto__",
+        "__defineGetter__",
+      ]
+    ) {
+      assertEquals(resolveConfiguredAgentModel(inherited), inherited);
+    }
   });
 
   it("uses the default model through Veryfront Cloud when cloud bootstrap is available", () => {

--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -121,6 +121,9 @@ describe("agent/runtime/model-resolution", () => {
         "toLocaleString",
         "__proto__",
         "__defineGetter__",
+        "__defineSetter__",
+        "__lookupGetter__",
+        "__lookupSetter__",
       ]
     ) {
       assertEquals(resolveConfiguredAgentModel(inherited), inherited);

--- a/src/agent/runtime/model-resolution.ts
+++ b/src/agent/runtime/model-resolution.ts
@@ -34,33 +34,33 @@ const DIRECT_AUTO_MODEL_DEFAULTS: Array<{ provider: string; modelId: string }> =
   { provider: "google-ai-studio", modelId: "gemini-3.5-flash" },
   { provider: "mistral", modelId: "mistral-large-2512" },
 ];
-const LEGACY_MODEL_ALIASES: Record<string, string> = {
-  opus: "anthropic/claude-opus-4-8",
-  sonnet: "anthropic/claude-sonnet-4-6",
-  haiku: "anthropic/claude-haiku-4-5-20251001",
-  "claude-opus-4-8": "anthropic/claude-opus-4-8",
-  "claude-opus-4-6": "anthropic/claude-opus-4-6",
-  "claude-sonnet-4-6": "anthropic/claude-sonnet-4-6",
-  "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4-5-20251001",
-  "gpt-5.5": "openai/gpt-5.5",
-  "gpt-5.2": "openai/gpt-5.2",
-  "gpt-5.4": "openai/gpt-5.4",
-  "gpt-5.4-mini": "openai/gpt-5.4-mini",
-  "gpt-5.4-nano": "openai/gpt-5.4-nano",
-  "o3-pro": "openai/o3-pro",
-  "o4-mini": "openai/o4-mini",
-  "gemini-3.1-pro": "google-ai-studio/gemini-3.1-pro-preview",
-  "gemini-3.1-pro-preview": "google-ai-studio/gemini-3.1-pro-preview",
-  "gemini-3.5-flash": "google-ai-studio/gemini-3.5-flash",
-  "gemini-3-flash-preview": "google-ai-studio/gemini-3-flash-preview",
-  "gemini-3.1-flash-lite": "google-ai-studio/gemini-3.1-flash-lite",
-  "gemini-2.5-pro": "google-ai-studio/gemini-2.5-pro",
-  "gemini-2.5-flash": "google-ai-studio/gemini-2.5-flash",
-  "mistral-large": "mistral/mistral-large-2512",
-  "mistral-large-2512": "mistral/mistral-large-2512",
-  "kimi-k2.6": "moonshotai/kimi-k2.6",
-  "kimi-k2.5": "moonshotai/kimi-k2.5",
-};
+const LEGACY_MODEL_ALIASES = new Map<string, string>([
+  ["opus", "anthropic/claude-opus-4-8"],
+  ["sonnet", "anthropic/claude-sonnet-4-6"],
+  ["haiku", "anthropic/claude-haiku-4-5-20251001"],
+  ["claude-opus-4-8", "anthropic/claude-opus-4-8"],
+  ["claude-opus-4-6", "anthropic/claude-opus-4-6"],
+  ["claude-sonnet-4-6", "anthropic/claude-sonnet-4-6"],
+  ["claude-haiku-4-5-20251001", "anthropic/claude-haiku-4-5-20251001"],
+  ["gpt-5.5", "openai/gpt-5.5"],
+  ["gpt-5.2", "openai/gpt-5.2"],
+  ["gpt-5.4", "openai/gpt-5.4"],
+  ["gpt-5.4-mini", "openai/gpt-5.4-mini"],
+  ["gpt-5.4-nano", "openai/gpt-5.4-nano"],
+  ["o3-pro", "openai/o3-pro"],
+  ["o4-mini", "openai/o4-mini"],
+  ["gemini-3.1-pro", "google-ai-studio/gemini-3.1-pro-preview"],
+  ["gemini-3.1-pro-preview", "google-ai-studio/gemini-3.1-pro-preview"],
+  ["gemini-3.5-flash", "google-ai-studio/gemini-3.5-flash"],
+  ["gemini-3-flash-preview", "google-ai-studio/gemini-3-flash-preview"],
+  ["gemini-3.1-flash-lite", "google-ai-studio/gemini-3.1-flash-lite"],
+  ["gemini-2.5-pro", "google-ai-studio/gemini-2.5-pro"],
+  ["gemini-2.5-flash", "google-ai-studio/gemini-2.5-flash"],
+  ["mistral-large", "mistral/mistral-large-2512"],
+  ["mistral-large-2512", "mistral/mistral-large-2512"],
+  ["kimi-k2.6", "moonshotai/kimi-k2.6"],
+  ["kimi-k2.5", "moonshotai/kimi-k2.5"],
+]);
 
 export function normalizeAgentModelConfig(model?: string): string {
   if (model === undefined) return DEFAULT_AGENT_MODEL;
@@ -79,7 +79,7 @@ export function resolveConfiguredAgentModel(model?: string): string {
     return normalized;
   }
 
-  return LEGACY_MODEL_ALIASES[normalized] ?? normalized;
+  return LEGACY_MODEL_ALIASES.get(normalized) ?? normalized;
 }
 
 function hasDirectProviderCredentials(provider: string): boolean {

--- a/src/agent/runtime/model-resolution.ts
+++ b/src/agent/runtime/model-resolution.ts
@@ -22,12 +22,12 @@ const HOSTED_PROVIDER_NAMES = new Set([
   "moonshotai",
   "openai",
 ]);
-const DIRECT_CREDENTIAL_PROVIDER_ALIASES: Record<string, string> = {
-  "google-ai-studio": "google",
-};
-const DIRECT_RUNTIME_PROVIDER_ALIASES: Record<string, string> = {
-  "google-ai-studio": "google",
-};
+const DIRECT_CREDENTIAL_PROVIDER_ALIASES = new Map<string, string>([
+  ["google-ai-studio", "google"],
+]);
+const DIRECT_RUNTIME_PROVIDER_ALIASES = new Map<string, string>([
+  ["google-ai-studio", "google"],
+]);
 const DIRECT_AUTO_MODEL_DEFAULTS: Array<{ provider: string; modelId: string }> = [
   { provider: "openai", modelId: "gpt-5.4-nano" },
   { provider: "anthropic", modelId: "claude-sonnet-4-6" },
@@ -83,7 +83,7 @@ export function resolveConfiguredAgentModel(model?: string): string {
 }
 
 function hasDirectProviderCredentials(provider: string): boolean {
-  switch (DIRECT_CREDENTIAL_PROVIDER_ALIASES[provider] ?? provider) {
+  switch (DIRECT_CREDENTIAL_PROVIDER_ALIASES.get(provider) ?? provider) {
     case "anthropic":
       return Boolean(getAnthropicEnvConfig().apiKey);
     case "google":
@@ -114,7 +114,7 @@ function normalizeVeryfrontCloudRuntimeModel(modelId: string): string {
 }
 
 function toDirectRuntimeModel(provider: string, modelId: string): string {
-  const runtimeProvider = DIRECT_RUNTIME_PROVIDER_ALIASES[provider] ?? provider;
+  const runtimeProvider = DIRECT_RUNTIME_PROVIDER_ALIASES.get(provider) ?? provider;
   return `${runtimeProvider}/${modelId}`;
 }
 

--- a/src/platform/compat/error-introspection.ts
+++ b/src/platform/compat/error-introspection.ts
@@ -18,16 +18,44 @@ const NativeError = Error;
 const NativeAsyncFunctionPrototype = getPrototypeOf(async function () {});
 const toStringTagSymbol = Symbol.toStringTag;
 
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return apply(objectHasOwnProperty, object, [key]) as boolean;
+}
+
+type ErrorBrandCheck = (value: unknown) => boolean;
+
+function captureErrorIsError(): ErrorBrandCheck | undefined {
+  const descriptor = getOwnPropertyDescriptor(NativeError, "isError");
+  return descriptor && hasOwn(descriptor, "value") &&
+      typeof descriptor.value === "function"
+    ? descriptor.value as ErrorBrandCheck
+    : undefined;
+}
+
+const capturedErrorIsError = captureErrorIsError();
 const unavailableBrandCheck = (_value: unknown): boolean => false;
+
+function portableErrorBrandCheck(value: unknown): boolean {
+  if (!capturedErrorIsError) return false;
+  try {
+    return apply(capturedErrorIsError, NativeError, [value]) === true;
+  } catch (_) {
+    return false;
+  }
+}
+
 const nativeAsyncFunctionBrandCheck = nativeBrandChecks?.isAsyncFunction ?? unavailableBrandCheck;
-const nativeErrorBrandCheck = nativeBrandChecks?.isNativeError ?? unavailableBrandCheck;
+const nativeErrorBrandCheck = nativeBrandChecks?.isNativeError ?? portableErrorBrandCheck;
 const nativePromiseBrandCheck = nativeBrandChecks?.isPromise ?? unavailableBrandCheck;
 const nativeProxyBrandCheck = nativeBrandChecks?.isProxy ?? unavailableBrandCheck;
 const nativeUint8ArrayBrandCheck = nativeBrandChecks?.isUint8Array ?? unavailableBrandCheck;
 
-function hasOwn(object: object, key: PropertyKey): boolean {
-  return apply(objectHasOwnProperty, object, [key]) as boolean;
-}
+/**
+ * Whether this runtime can distinguish Proxy values without evaluating a trap.
+ * Callers that need a fail-closed guarantee must not treat a `false` result
+ * from {@link isProxyWithoutHooks} as proof when this capability is absent.
+ */
+export const canIdentifyProxyWithoutHooks = nativeBrandChecks !== undefined;
 
 function createDataDescriptor(value: unknown): PropertyDescriptor {
   const descriptor = createObject(null) as PropertyDescriptor;
@@ -249,7 +277,12 @@ export function readNativeErrorNameWithoutHooks(error: Error): string {
   }
 }
 
-/** Identify a Proxy without evaluating any trap on the proxied value. */
+/**
+ * Identify a Proxy without evaluating any trap on the proxied value.
+ *
+ * Returns `false` without inspecting `value` when
+ * {@link canIdentifyProxyWithoutHooks} is false.
+ */
 export function isProxyWithoutHooks(value: unknown): boolean {
   return nativeProxyBrandCheck(value);
 }

--- a/src/platform/compat/error-introspection.ts
+++ b/src/platform/compat/error-introspection.ts
@@ -24,6 +24,12 @@ function hasOwn(object: object, key: PropertyKey): boolean {
 
 type ErrorBrandCheck = (value: unknown) => boolean;
 
+/**
+ * Capture the portable Error brand primitive during trusted framework
+ * bootstrap, before tenant code can replace mutable globals. Edge runtimes do
+ * not expose an immutable host-module equivalent, so this capture boundary is
+ * the authority for later no-hook Error checks.
+ */
 function captureErrorIsError(): ErrorBrandCheck | undefined {
   const descriptor = getOwnPropertyDescriptor(NativeError, "isError");
   return descriptor && hasOwn(descriptor, "value") &&

--- a/src/provider/runtime-loader-helpers.test.ts
+++ b/src/provider/runtime-loader-helpers.test.ts
@@ -149,6 +149,76 @@ describe("provider/runtime-loader helpers", () => {
     );
   });
 
+  it("fails closed for object snapshots without Proxy detection", async () => {
+    const script = `
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(globalThis, "WebSocketPair", {
+        configurable: true,
+        value: function WebSocketPair() {},
+      });
+
+      const {
+        canIdentifyProxyWithoutHooks,
+      } = await import("./src/platform/compat/error-introspection.ts");
+      const { snapshotJsonValue } = await import("./src/provider/runtime-loader.ts");
+
+      let calls = 0;
+      const proxy = new Proxy({ safe: true }, {
+        getPrototypeOf(target) {
+          calls += 1;
+          return Reflect.getPrototypeOf(target);
+        },
+        getOwnPropertyDescriptor(target, property) {
+          calls += 1;
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+        ownKeys(target) {
+          calls += 1;
+          return Reflect.ownKeys(target);
+        },
+      });
+
+      const result = {
+        canIdentifyProxyWithoutHooks,
+        primitive: snapshotJsonValue("safe"),
+        calls,
+        plainObject: "",
+        proxy: "",
+      };
+      try {
+        snapshotJsonValue({ safe: true });
+      } catch (error) {
+        result.plainObject = error instanceof Error ? error.message : String(error);
+      }
+      try {
+        snapshotJsonValue(proxy);
+      } catch (error) {
+        result.proxy = error instanceof Error ? error.message : String(error);
+      }
+      console.log(JSON.stringify(result));
+    `;
+    const output = await new Deno.Command(Deno.execPath(), {
+      args: ["eval", "--config=deno.json", script],
+      cwd: new URL("../../", import.meta.url),
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const stderr = new TextDecoder().decode(output.stderr);
+    assertEquals(output.code, 0, stderr);
+
+    const result = JSON.parse(new TextDecoder().decode(output.stdout));
+    assertEquals(result, {
+      canIdentifyProxyWithoutHooks: false,
+      primitive: "safe",
+      calls: 0,
+      plainObject: "Provider JSON snapshot cannot inspect object values without Proxy detection",
+      proxy: "Provider JSON snapshot cannot inspect object values without Proxy detection",
+    });
+  });
+
   it("serializes only owned snapshots without invoking getters or toJSON", () => {
     let getterCalls = 0;
     let toJsonCalls = 0;

--- a/src/provider/runtime-loader-helpers.test.ts
+++ b/src/provider/runtime-loader-helpers.test.ts
@@ -163,9 +163,19 @@ describe("provider/runtime-loader helpers", () => {
       const {
         canIdentifyProxyWithoutHooks,
       } = await import("./src/platform/compat/error-introspection.ts");
-      const { snapshotJsonValue } = await import("./src/provider/runtime-loader.ts");
+      const { jsonValuesEqual, snapshotJsonValue, stringifyJsonValue } = await import(
+        "./src/provider/runtime-loader.ts"
+      );
 
       let calls = 0;
+      let getterCalls = 0;
+      const accessor = Object.defineProperty({}, "safe", {
+        enumerable: true,
+        get() {
+          getterCalls += 1;
+          return true;
+        },
+      });
       const proxy = new Proxy({ safe: true }, {
         getPrototypeOf(target) {
           calls += 1;
@@ -186,7 +196,12 @@ describe("provider/runtime-loader helpers", () => {
         primitive: snapshotJsonValue("safe"),
         calls,
         plainObject: "",
+        providerObject: "",
+        providerAccessor: stringifyJsonValue(accessor),
+        providerEquality: jsonValuesEqual('{"safe":true}', { safe: true }, true),
+        getterCalls,
         proxy: "",
+        providerProxy: "",
       };
       try {
         snapshotJsonValue({ safe: true });
@@ -194,9 +209,19 @@ describe("provider/runtime-loader helpers", () => {
         result.plainObject = error instanceof Error ? error.message : String(error);
       }
       try {
+        result.providerObject = stringifyJsonValue({ safe: true });
+      } catch (error) {
+        result.providerObject = error instanceof Error ? error.message : String(error);
+      }
+      try {
         snapshotJsonValue(proxy);
       } catch (error) {
         result.proxy = error instanceof Error ? error.message : String(error);
+      }
+      try {
+        stringifyJsonValue({ nested: proxy });
+      } catch (error) {
+        result.providerProxy = error instanceof Error ? error.message : String(error);
       }
       console.log(JSON.stringify(result));
     `;
@@ -215,7 +240,12 @@ describe("provider/runtime-loader helpers", () => {
       primitive: "safe",
       calls: 0,
       plainObject: "Provider JSON snapshot cannot inspect object values without Proxy detection",
+      providerObject: '{"safe":true}',
+      providerAccessor: '{"safe":true}',
+      providerEquality: true,
+      getterCalls: 1,
       proxy: "Provider JSON snapshot cannot inspect object values without Proxy detection",
+      providerProxy: "Provider tool value must be JSON-serializable",
     });
   });
 

--- a/src/provider/runtime-loader-helpers.test.ts
+++ b/src/provider/runtime-loader-helpers.test.ts
@@ -503,6 +503,51 @@ describe("provider/runtime-loader helpers", () => {
     }
   });
 
+  it("reads snapshot options only from own data properties", () => {
+    const optionKeys = [
+      "maxDepth",
+      "maxNodes",
+      "maxBytes",
+      "sortObjectKeys",
+    ] as const;
+
+    for (let index = 0; index < optionKeys.length; index += 1) {
+      const key = optionKeys[index]!;
+      let getterCalls = 0;
+      const options = Object.defineProperty({}, key, {
+        configurable: true,
+        get() {
+          getterCalls += 1;
+          return key === "sortObjectKeys" ? false : 1;
+        },
+      });
+
+      assertThrows(
+        () => snapshotJsonValue(null, options),
+        TypeError,
+        "options must use own data properties",
+      );
+      assertEquals(getterCalls, 0);
+    }
+
+    const inheritedOptions = Object.create({
+      maxDepth: 0,
+      maxNodes: 1,
+      maxBytes: 1,
+      sortObjectKeys: false,
+    });
+    assertEquals(
+      Object.keys(snapshotJsonValue({ b: 2, a: 1 }, inheritedOptions) as object),
+      ["a", "b"],
+    );
+    assertEquals(
+      Object.keys(
+        snapshotJsonValue({ b: 2, a: 1 }, { sortObjectKeys: false }) as object,
+      ),
+      ["b", "a"],
+    );
+  });
+
   it("makes JSON equality fail closed without invoking accessors or serialization hooks", () => {
     let getterCalls = 0;
     const accessor = Object.defineProperty({}, "value", {

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -20,7 +20,11 @@ import {
 } from "./runtime-loader/tool-input-status.ts";
 import { snapshotProviderJsonValue } from "./runtime-loader/json-snapshot.ts";
 
-export { jsonValuesEqual, snapshotJsonValue } from "./runtime-loader/json-snapshot.ts";
+export {
+  jsonValuesEqual,
+  snapshotJsonValue,
+  snapshotProviderJsonValue,
+} from "./runtime-loader/json-snapshot.ts";
 export type { JsonSnapshotOptions, JsonSnapshotValue } from "./runtime-loader/json-snapshot.ts";
 export {
   ProviderError,

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -18,7 +18,7 @@ import {
   TOOL_INPUT_PENDING_THRESHOLD_MS,
   withToolInputStatusTransitions,
 } from "./runtime-loader/tool-input-status.ts";
-import { snapshotJsonValue } from "./runtime-loader/json-snapshot.ts";
+import { snapshotProviderJsonValue } from "./runtime-loader/json-snapshot.ts";
 
 export { jsonValuesEqual, snapshotJsonValue } from "./runtime-loader/json-snapshot.ts";
 export type { JsonSnapshotOptions, JsonSnapshotValue } from "./runtime-loader/json-snapshot.ts";
@@ -146,7 +146,9 @@ export function createWarningCollector(): WarningCollector {
 /** Serialize a JSON-compatible value. */
 export function stringifyJsonValue(value: unknown): string {
   try {
-    const serialized = JSON.stringify(snapshotJsonValue(value, { sortObjectKeys: false }));
+    const serialized = JSON.stringify(
+      snapshotProviderJsonValue(value, { sortObjectKeys: false }),
+    );
     if (serialized === undefined) {
       throw new TypeError("value has no JSON representation");
     }

--- a/src/provider/runtime-loader/json-snapshot.test.ts
+++ b/src/provider/runtime-loader/json-snapshot.test.ts
@@ -1,0 +1,33 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { snapshotJsonValue } from "./json-snapshot.ts";
+
+describe("provider/runtime-loader/json-snapshot", () => {
+  it("rejects proxy options before descriptor inspection", () => {
+    let descriptorReads = 0;
+    const options = new Proxy(
+      { maxDepth: 1 },
+      {
+        getOwnPropertyDescriptor() {
+          descriptorReads += 1;
+          throw new TypeError("options descriptor trap must not run");
+        },
+      },
+    );
+
+    assertThrows(
+      () => snapshotJsonValue(null, options),
+      TypeError,
+      "Provider JSON snapshot options could not be inspected",
+    );
+    assertEquals(descriptorReads, 0);
+  });
+
+  it("preserves plain own-data options", () => {
+    assertEquals(
+      snapshotJsonValue({ b: 1, a: 2 }, { sortObjectKeys: false }),
+      { b: 1, a: 2 },
+    );
+  });
+});

--- a/src/provider/runtime-loader/json-snapshot.ts
+++ b/src/provider/runtime-loader/json-snapshot.ts
@@ -8,7 +8,6 @@ import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspect
  */
 const apply = Reflect.apply;
 const ArrayIsArray = Array.isArray;
-const arrayPush = Array.prototype.push;
 const arraySort = Array.prototype.sort;
 const NativeArray = Array;
 const NativeTypeError = TypeError;
@@ -53,6 +52,15 @@ function addWeakSetValue(set: WeakSet<object>, value: object): void {
 
 function deleteWeakSetValue(set: WeakSet<object>, value: object): void {
   apply(weakSetDelete, set, [value]);
+}
+
+function defineArrayElement<T>(array: T[], index: number, value: T): void {
+  objectDefineProperty(array, index, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
 }
 
 const DEFAULT_MAX_DEPTH = 64;
@@ -117,13 +125,14 @@ function invalidValue(reason: string): never {
 }
 
 function readLimit(
-  value: number | undefined,
+  value: unknown,
   fallback: number,
   name: keyof JsonSnapshotOptions,
   minimum: number,
 ): number {
   const resolved = value ?? fallback;
   if (
+    typeof resolved !== "number" ||
     !numberIsSafeInteger(resolved) ||
     resolved < minimum
   ) {
@@ -134,15 +143,40 @@ function readLimit(
   return resolved;
 }
 
+function readOwnOption(
+  options: JsonSnapshotOptions,
+  key: keyof JsonSnapshotOptions,
+): unknown {
+  if ((typeof options !== "object" && typeof options !== "function") || options === null) {
+    throw new NativeTypeError("Provider JSON snapshot options must be an object");
+  }
+
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = objectGetOwnPropertyDescriptor(options, key);
+  } catch {
+    throw new NativeTypeError("Provider JSON snapshot options could not be inspected");
+  }
+  if (!descriptor) return undefined;
+  if (!hasOwn(descriptor, "value")) {
+    throw new NativeTypeError("Provider JSON snapshot options must use own data properties");
+  }
+  return descriptor.value;
+}
+
 function resolveOptions(options: JsonSnapshotOptions): ResolvedJsonSnapshotOptions {
-  if (options.sortObjectKeys !== undefined && typeof options.sortObjectKeys !== "boolean") {
+  const maxDepth = readOwnOption(options, "maxDepth");
+  const maxNodes = readOwnOption(options, "maxNodes");
+  const maxBytes = readOwnOption(options, "maxBytes");
+  const sortObjectKeys = readOwnOption(options, "sortObjectKeys");
+  if (sortObjectKeys !== undefined && typeof sortObjectKeys !== "boolean") {
     throw new NativeTypeError("Provider JSON snapshot sortObjectKeys must be a boolean");
   }
   return {
-    maxDepth: readLimit(options.maxDepth, DEFAULT_MAX_DEPTH, "maxDepth", 0),
-    maxNodes: readLimit(options.maxNodes, DEFAULT_MAX_NODES, "maxNodes", 1),
-    maxBytes: readLimit(options.maxBytes, DEFAULT_MAX_BYTES, "maxBytes", 1),
-    sortObjectKeys: options.sortObjectKeys ?? true,
+    maxDepth: readLimit(maxDepth, DEFAULT_MAX_DEPTH, "maxDepth", 0),
+    maxNodes: readLimit(maxNodes, DEFAULT_MAX_NODES, "maxNodes", 1),
+    maxBytes: readLimit(maxBytes, DEFAULT_MAX_BYTES, "maxBytes", 1),
+    sortObjectKeys: sortObjectKeys ?? true,
   };
 }
 
@@ -331,7 +365,8 @@ function snapshotArray(
   }
 
   const elementValues: unknown[] = new NativeArray(length);
-  for (const key of keys) {
+  for (let keyIndex = 0; keyIndex < keys.length; keyIndex += 1) {
+    const key = keys[keyIndex]!;
     if (key === "length") {
       continue;
     }
@@ -360,7 +395,7 @@ function snapshotArray(
     ) {
       invalidValue("arrays must be dense and contain no extra properties");
     }
-    elementValues[index] = readDataProperty(value, key, true);
+    defineArrayElement(elementValues, index, readDataProperty(value, key, true));
   }
 
   addBytes(state, 1);
@@ -369,7 +404,11 @@ function snapshotArray(
     if (index > 0) {
       addBytes(state, 1);
     }
-    snapshot[index] = snapshotValue(elementValues[index], depth + 1, state);
+    defineArrayElement(
+      snapshot,
+      index,
+      snapshotValue(elementValues[index], depth + 1, state),
+    );
   }
   addBytes(state, 1);
   objectDefineProperty(snapshot, "toJSON", {
@@ -397,14 +436,15 @@ function snapshotObject(
     invalidValue(`exceeded ${state.maxNodes} nodes`);
   }
   const entries: { key: string; value: unknown }[] = [];
-  for (const key of keys) {
+  for (let keyIndex = 0; keyIndex < keys.length; keyIndex += 1) {
+    const key = keys[keyIndex]!;
     if (typeof key !== "string") {
       invalidValue("must not contain symbol properties");
     }
-    apply(arrayPush, entries, [{
+    defineArrayElement(entries, entries.length, {
       key,
       value: readDataProperty(value, key, true),
-    }]);
+    });
   }
   if (state.sortObjectKeys) {
     apply(arraySort, entries, [

--- a/src/provider/runtime-loader/json-snapshot.ts
+++ b/src/provider/runtime-loader/json-snapshot.ts
@@ -1,9 +1,64 @@
 import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 
+/**
+ * Security-sensitive primordials are captured during trusted framework
+ * bootstrap, before tenant code runs. Snapshotting must not consult mutable
+ * global constructors or prototype methods after that boundary: callers use
+ * this module while handling values supplied by project and provider code.
+ */
+const apply = Reflect.apply;
+const ArrayIsArray = Array.isArray;
+const arrayPush = Array.prototype.push;
+const arraySort = Array.prototype.sort;
+const NativeArray = Array;
+const NativeTypeError = TypeError;
+const NativeWeakSet = WeakSet;
+const numberIsFinite = Number.isFinite;
+const numberIsInteger = Number.isInteger;
+const numberIsSafeInteger = Number.isSafeInteger;
+const numberFromValue = Number;
+const objectCreate = Object.create;
+const objectDefineProperty = Object.defineProperty;
+const objectFreeze = Object.freeze;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectGetPrototypeOf = Object.getPrototypeOf;
+const objectHasOwnProperty = Object.prototype.hasOwnProperty;
+const objectIs = Object.is;
+const objectKeys = Object.keys;
+const ownKeys = Reflect.ownKeys;
+const jsonParse = JSON.parse;
+const stringCharCodeAt = String.prototype.charCodeAt;
+const stringFromValue = String;
+const weakSetAdd = WeakSet.prototype.add;
+const weakSetDelete = WeakSet.prototype.delete;
+const weakSetHas = WeakSet.prototype.has;
+const NativeArrayPrototype = Array.prototype;
+const NativeObjectPrototype = Object.prototype;
+
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return apply(objectHasOwnProperty, object, [key]) as boolean;
+}
+
+function charCodeAt(value: string, index: number): number {
+  return apply(stringCharCodeAt, value, [index]);
+}
+
+function hasWeakSetValue(set: WeakSet<object>, value: object): boolean {
+  return apply(weakSetHas, set, [value]) as boolean;
+}
+
+function addWeakSetValue(set: WeakSet<object>, value: object): void {
+  apply(weakSetAdd, set, [value]);
+}
+
+function deleteWeakSetValue(set: WeakSet<object>, value: object): void {
+  apply(weakSetDelete, set, [value]);
+}
+
 const DEFAULT_MAX_DEPTH = 64;
 const DEFAULT_MAX_NODES = 65_536;
 const DEFAULT_MAX_BYTES = 8 * 1024 * 1024;
-const OWNED_ARRAY_SNAPSHOTS = new WeakSet<object>();
+const OWNED_ARRAY_SNAPSHOTS = new NativeWeakSet<object>();
 
 /**
  * A deeply owned JSON value returned by {@link snapshotJsonValue}.
@@ -58,7 +113,7 @@ type SnapshotState = ResolvedJsonSnapshotOptions & {
 };
 
 function invalidValue(reason: string): never {
-  throw new TypeError(`Provider JSON snapshot ${reason}`);
+  throw new NativeTypeError(`Provider JSON snapshot ${reason}`);
 }
 
 function readLimit(
@@ -69,10 +124,10 @@ function readLimit(
 ): number {
   const resolved = value ?? fallback;
   if (
-    !Number.isSafeInteger(resolved) ||
+    !numberIsSafeInteger(resolved) ||
     resolved < minimum
   ) {
-    throw new TypeError(
+    throw new NativeTypeError(
       `Provider JSON snapshot ${name} must be a safe integer no less than ${minimum}`,
     );
   }
@@ -81,7 +136,7 @@ function readLimit(
 
 function resolveOptions(options: JsonSnapshotOptions): ResolvedJsonSnapshotOptions {
   if (options.sortObjectKeys !== undefined && typeof options.sortObjectKeys !== "boolean") {
-    throw new TypeError("Provider JSON snapshot sortObjectKeys must be a boolean");
+    throw new NativeTypeError("Provider JSON snapshot sortObjectKeys must be a boolean");
   }
   return {
     maxDepth: readLimit(options.maxDepth, DEFAULT_MAX_DEPTH, "maxDepth", 0),
@@ -106,7 +161,7 @@ function addJsonStringBytes(state: SnapshotState, value: string): void {
   addBytes(state, 2); // Opening and closing quotation marks.
 
   for (let index = 0; index < value.length; index += 1) {
-    const codeUnit = value.charCodeAt(index);
+    const codeUnit = charCodeAt(value, index);
 
     if (codeUnit === 0x22 || codeUnit === 0x5c) {
       addBytes(state, 2);
@@ -134,7 +189,7 @@ function addJsonStringBytes(state: SnapshotState, value: string): void {
       continue;
     }
     if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-      const next = value.charCodeAt(index + 1);
+      const next = charCodeAt(value, index + 1);
       if (next >= 0xdc00 && next <= 0xdfff) {
         addBytes(state, 4);
         index += 1;
@@ -162,7 +217,7 @@ function assertRawJsonTextWithinByteLimit(value: string, maxBytes: number): void
   };
 
   for (let index = 0; index < value.length; index += 1) {
-    const codeUnit = value.charCodeAt(index);
+    const codeUnit = charCodeAt(value, index);
     if (codeUnit <= 0x7f) {
       add(1);
       continue;
@@ -172,7 +227,7 @@ function assertRawJsonTextWithinByteLimit(value: string, maxBytes: number): void
       continue;
     }
     if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-      const next = value.charCodeAt(index + 1);
+      const next = charCodeAt(value, index + 1);
       if (next >= 0xdc00 && next <= 0xdfff) {
         add(4);
         index += 1;
@@ -188,7 +243,7 @@ function assertRawJsonTextWithinByteLimit(value: string, maxBytes: number): void
 
 function inspectPrototype(value: object): object | null {
   try {
-    return Object.getPrototypeOf(value);
+    return objectGetPrototypeOf(value);
   } catch {
     invalidValue("could not inspect a value");
   }
@@ -196,7 +251,7 @@ function inspectPrototype(value: object): object | null {
 
 function inspectOwnKeys(value: object): (string | symbol)[] {
   try {
-    return Reflect.ownKeys(value);
+    return ownKeys(value);
   } catch {
     invalidValue("could not inspect a value");
   }
@@ -207,7 +262,7 @@ function inspectOwnDescriptor(
   key: string | symbol,
 ): PropertyDescriptor {
   try {
-    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    const descriptor = objectGetOwnPropertyDescriptor(value, key);
     if (descriptor === undefined) {
       invalidValue("changed while it was being inspected");
     }
@@ -224,7 +279,7 @@ function readDataProperty(
 ): unknown {
   const descriptor = inspectOwnDescriptor(value, key);
   if (
-    !Object.hasOwn(descriptor, "value") ||
+    !hasOwn(descriptor, "value") ||
     (requireEnumerable && descriptor.enumerable !== true)
   ) {
     invalidValue("must contain only enumerable data properties");
@@ -247,16 +302,16 @@ function snapshotArray(
   depth: number,
   state: SnapshotState,
 ): readonly JsonSnapshotValue[] {
-  if (inspectPrototype(value) !== Array.prototype) {
+  if (inspectPrototype(value) !== NativeArrayPrototype) {
     invalidValue("arrays must use the intrinsic Array prototype");
   }
 
   const lengthDescriptor = inspectOwnDescriptor(value, "length");
   if (
-    !Object.hasOwn(lengthDescriptor, "value") ||
+    !hasOwn(lengthDescriptor, "value") ||
     lengthDescriptor.enumerable !== false ||
     lengthDescriptor.configurable !== false ||
-    !Number.isSafeInteger(lengthDescriptor.value) ||
+    !numberIsSafeInteger(lengthDescriptor.value) ||
     lengthDescriptor.value < 0
   ) {
     invalidValue("contained an invalid array length");
@@ -270,12 +325,12 @@ function snapshotArray(
   }
 
   const keys = inspectOwnKeys(value);
-  const ownedSnapshot = OWNED_ARRAY_SNAPSHOTS.has(value);
+  const ownedSnapshot = hasWeakSetValue(OWNED_ARRAY_SNAPSHOTS, value);
   if (keys.length !== length + 1 + (ownedSnapshot ? 1 : 0)) {
     invalidValue("arrays must be dense and contain no extra properties");
   }
 
-  const elementValues: unknown[] = new Array(length);
+  const elementValues: unknown[] = new NativeArray(length);
   for (const key of keys) {
     if (key === "length") {
       continue;
@@ -283,7 +338,7 @@ function snapshotArray(
     if (key === "toJSON" && ownedSnapshot) {
       const descriptor = inspectOwnDescriptor(value, key);
       if (
-        !Object.hasOwn(descriptor, "value") ||
+        !hasOwn(descriptor, "value") ||
         descriptor.value !== undefined ||
         descriptor.configurable !== false ||
         descriptor.enumerable !== false ||
@@ -296,12 +351,12 @@ function snapshotArray(
     if (typeof key !== "string") {
       invalidValue("must not contain symbol properties");
     }
-    const index = Number(key);
+    const index = numberFromValue(key);
     if (
-      !Number.isInteger(index) ||
+      !numberIsInteger(index) ||
       index < 0 ||
       index >= length ||
-      String(index) !== key
+      stringFromValue(index) !== key
     ) {
       invalidValue("arrays must be dense and contain no extra properties");
     }
@@ -317,14 +372,14 @@ function snapshotArray(
     snapshot[index] = snapshotValue(elementValues[index], depth + 1, state);
   }
   addBytes(state, 1);
-  Object.defineProperty(snapshot, "toJSON", {
+  objectDefineProperty(snapshot, "toJSON", {
     configurable: false,
     enumerable: false,
     value: undefined,
     writable: false,
   });
-  OWNED_ARRAY_SNAPSHOTS.add(snapshot);
-  return Object.freeze(snapshot);
+  addWeakSetValue(OWNED_ARRAY_SNAPSHOTS, snapshot);
+  return objectFreeze(snapshot);
 }
 
 function snapshotObject(
@@ -333,7 +388,7 @@ function snapshotObject(
   state: SnapshotState,
 ): { readonly [key: string]: JsonSnapshotValue } {
   const prototype = inspectPrototype(value);
-  if (prototype !== Object.prototype && prototype !== null) {
+  if (prototype !== NativeObjectPrototype && prototype !== null) {
     invalidValue("objects must have a plain or null prototype");
   }
 
@@ -346,17 +401,20 @@ function snapshotObject(
     if (typeof key !== "string") {
       invalidValue("must not contain symbol properties");
     }
-    entries.push({
+    apply(arrayPush, entries, [{
       key,
       value: readDataProperty(value, key, true),
-    });
+    }]);
   }
   if (state.sortObjectKeys) {
-    entries.sort((left, right) => left.key < right.key ? -1 : left.key > right.key ? 1 : 0);
+    apply(arraySort, entries, [
+      (left: { key: string }, right: { key: string }) =>
+        left.key < right.key ? -1 : left.key > right.key ? 1 : 0,
+    ]);
   }
 
   addBytes(state, 1);
-  const snapshot = Object.create(null) as Record<string, JsonSnapshotValue>;
+  const snapshot = objectCreate(null) as Record<string, JsonSnapshotValue>;
   for (let index = 0; index < entries.length; index += 1) {
     if (index > 0) {
       addBytes(state, 1);
@@ -364,7 +422,7 @@ function snapshotObject(
     const entry = entries[index]!;
     addJsonStringBytes(state, entry.key);
     addBytes(state, 1);
-    Object.defineProperty(snapshot, entry.key, {
+    objectDefineProperty(snapshot, entry.key, {
       configurable: false,
       enumerable: true,
       value: snapshotValue(entry.value, depth + 1, state),
@@ -372,7 +430,7 @@ function snapshotObject(
     });
   }
   addBytes(state, 1);
-  return Object.freeze(snapshot);
+  return objectFreeze(snapshot);
 }
 
 function snapshotValue(
@@ -395,26 +453,26 @@ function snapshotValue(
       addJsonStringBytes(state, value);
       return value;
     case "number":
-      if (!Number.isFinite(value)) {
+      if (!numberIsFinite(value)) {
         invalidValue("numbers must be finite");
       }
-      if (Object.is(value, -0)) {
+      if (objectIs(value, -0)) {
         addBytes(state, 1);
         return 0;
       }
-      addBytes(state, String(value).length);
+      addBytes(state, stringFromValue(value).length);
       return value;
     case "object": {
       const objectValue = value as object;
       if (isProxyWithoutHooks(objectValue)) {
         invalidValue("must not contain Proxy values");
       }
-      if (state.ancestors.has(objectValue)) {
+      if (hasWeakSetValue(state.ancestors, objectValue)) {
         invalidValue("must not contain cycles");
       }
-      state.ancestors.add(objectValue);
+      addWeakSetValue(state.ancestors, objectValue);
       try {
-        if (Array.isArray(value)) {
+        if (ArrayIsArray(value)) {
           return snapshotArray(value, depth, state);
         }
         return snapshotObject(
@@ -423,7 +481,7 @@ function snapshotValue(
           state,
         );
       } finally {
-        state.ancestors.delete(objectValue);
+        deleteWeakSetValue(state.ancestors, objectValue);
       }
     }
     default:
@@ -445,8 +503,8 @@ function snapshotsEqual(
     return false;
   }
 
-  const leftIsArray = Array.isArray(left);
-  if (leftIsArray !== Array.isArray(right)) {
+  const leftIsArray = ArrayIsArray(left);
+  if (leftIsArray !== ArrayIsArray(right)) {
     return false;
   }
   if (leftIsArray) {
@@ -465,8 +523,8 @@ function snapshotsEqual(
 
   const leftObject = left as { readonly [key: string]: JsonSnapshotValue };
   const rightObject = right as { readonly [key: string]: JsonSnapshotValue };
-  const leftKeys = Object.keys(leftObject);
-  const rightKeys = Object.keys(rightObject);
+  const leftKeys = objectKeys(leftObject);
+  const rightKeys = objectKeys(rightObject);
   if (leftKeys.length !== rightKeys.length) {
     return false;
   }
@@ -497,7 +555,7 @@ export function snapshotJsonValue(
   const resolved = resolveOptions(options);
   return snapshotValue(value, 0, {
     ...resolved,
-    ancestors: new WeakSet(),
+    ancestors: new NativeWeakSet(),
     bytes: 0,
     nodes: 0,
   });
@@ -522,7 +580,7 @@ export function jsonValuesEqual(
     }
     assertRawJsonTextWithinByteLimit(value, DEFAULT_MAX_BYTES);
     try {
-      return JSON.parse(value);
+      return apply(jsonParse, undefined, [value]);
     } catch {
       // Preserve non-JSON text as a string for backwards compatibility.
       return value;

--- a/src/provider/runtime-loader/json-snapshot.ts
+++ b/src/provider/runtime-loader/json-snapshot.ts
@@ -1,4 +1,7 @@
-import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
+import {
+  canIdentifyProxyWithoutHooks,
+  isProxyWithoutHooks,
+} from "#veryfront/platform/compat/error-introspection.ts";
 
 /**
  * Security-sensitive primordials are captured during trusted framework
@@ -504,6 +507,9 @@ function snapshotValue(
       return value;
     case "object": {
       const objectValue = value as object;
+      if (!canIdentifyProxyWithoutHooks) {
+        invalidValue("cannot inspect object values without Proxy detection");
+      }
       if (isProxyWithoutHooks(objectValue)) {
         invalidValue("must not contain Proxy values");
       }

--- a/src/provider/runtime-loader/json-snapshot.ts
+++ b/src/provider/runtime-loader/json-snapshot.ts
@@ -169,11 +169,35 @@ function readOwnOption(
   return descriptor.value;
 }
 
+function prepareOptionsForInspection(options: JsonSnapshotOptions): JsonSnapshotOptions {
+  if ((typeof options !== "object" && typeof options !== "function") || options === null) {
+    throw new NativeTypeError("Provider JSON snapshot options must be an object");
+  }
+
+  if (canIdentifyProxyWithoutHooks) {
+    if (isProxyWithoutHooks(options)) {
+      throw new NativeTypeError("Provider JSON snapshot options could not be inspected");
+    }
+    return options;
+  }
+
+  if (typeof structuredCloneValue !== "function") {
+    throw new NativeTypeError("Provider JSON snapshot options could not be inspected");
+  }
+
+  try {
+    return apply(structuredCloneValue, globalThis, [options]) as JsonSnapshotOptions;
+  } catch {
+    throw new NativeTypeError("Provider JSON snapshot options could not be inspected");
+  }
+}
+
 function resolveOptions(options: JsonSnapshotOptions): ResolvedJsonSnapshotOptions {
-  const maxDepth = readOwnOption(options, "maxDepth");
-  const maxNodes = readOwnOption(options, "maxNodes");
-  const maxBytes = readOwnOption(options, "maxBytes");
-  const sortObjectKeys = readOwnOption(options, "sortObjectKeys");
+  const inspectedOptions = prepareOptionsForInspection(options);
+  const maxDepth = readOwnOption(inspectedOptions, "maxDepth");
+  const maxNodes = readOwnOption(inspectedOptions, "maxNodes");
+  const maxBytes = readOwnOption(inspectedOptions, "maxBytes");
+  const sortObjectKeys = readOwnOption(inspectedOptions, "sortObjectKeys");
   if (sortObjectKeys !== undefined && typeof sortObjectKeys !== "boolean") {
     throw new NativeTypeError("Provider JSON snapshot sortObjectKeys must be a boolean");
   }

--- a/src/provider/runtime-loader/json-snapshot.ts
+++ b/src/provider/runtime-loader/json-snapshot.ts
@@ -29,6 +29,7 @@ const objectIs = Object.is;
 const objectKeys = Object.keys;
 const ownKeys = Reflect.ownKeys;
 const jsonParse = JSON.parse;
+const structuredCloneValue = globalThis.structuredClone;
 const stringCharCodeAt = String.prototype.charCodeAt;
 const stringFromValue = String;
 const weakSetAdd = WeakSet.prototype.add;
@@ -121,6 +122,7 @@ type SnapshotState = ResolvedJsonSnapshotOptions & {
   nodes: number;
   bytes: number;
   ancestors: WeakSet<object>;
+  valuesAreOwned: boolean;
 };
 
 function invalidValue(reason: string): never {
@@ -507,11 +509,13 @@ function snapshotValue(
       return value;
     case "object": {
       const objectValue = value as object;
-      if (!canIdentifyProxyWithoutHooks) {
-        invalidValue("cannot inspect object values without Proxy detection");
-      }
-      if (isProxyWithoutHooks(objectValue)) {
-        invalidValue("must not contain Proxy values");
+      if (!state.valuesAreOwned) {
+        if (!canIdentifyProxyWithoutHooks) {
+          invalidValue("cannot inspect object values without Proxy detection");
+        }
+        if (isProxyWithoutHooks(objectValue)) {
+          invalidValue("must not contain Proxy values");
+        }
       }
       if (hasWeakSetValue(state.ancestors, objectValue)) {
         invalidValue("must not contain cycles");
@@ -604,6 +608,46 @@ export function snapshotJsonValue(
     ancestors: new NativeWeakSet(),
     bytes: 0,
     nodes: 0,
+    valuesAreOwned: false,
+  });
+}
+
+/**
+ * Create the provider-boundary snapshot used by request builders.
+ *
+ * Node-compatible runtimes use the strict descriptor walk above. Edge hosts
+ * cannot distinguish Proxy objects before reflection, so they first cross the
+ * captured structured-clone boundary. The host rejects Proxy values (including
+ * nested Proxies) without running Proxy traps and returns a newly owned graph.
+ * Ordinary accessors follow the host's structured-clone semantics; this is an
+ * explicit edge-runtime compatibility trade-off because those hosts expose no
+ * no-hook Proxy brand primitive.
+ */
+export function snapshotProviderJsonValue(
+  value: unknown,
+  options: JsonSnapshotOptions = {},
+): JsonSnapshotValue {
+  if (canIdentifyProxyWithoutHooks) {
+    return snapshotJsonValue(value, options);
+  }
+  if (typeof structuredCloneValue !== "function") {
+    invalidValue("cannot inspect object values without Proxy detection or structured clone");
+  }
+
+  const resolved = resolveOptions(options);
+  let cloned: unknown;
+  try {
+    cloned = apply(structuredCloneValue, globalThis, [value]);
+  } catch {
+    invalidValue("could not cross the edge-runtime structured-clone boundary");
+  }
+
+  return snapshotValue(cloned, 0, {
+    ...resolved,
+    ancestors: new NativeWeakSet(),
+    bytes: 0,
+    nodes: 0,
+    valuesAreOwned: true,
   });
 }
 
@@ -635,8 +679,8 @@ export function jsonValuesEqual(
 
   try {
     return snapshotsEqual(
-      snapshotJsonValue(normalize(left)),
-      snapshotJsonValue(normalize(right)),
+      snapshotProviderJsonValue(normalize(left)),
+      snapshotProviderJsonValue(normalize(right)),
     );
   } catch {
     return false;

--- a/src/provider/shared/index.ts
+++ b/src/provider/shared/index.ts
@@ -59,6 +59,7 @@ export {
   requestJson,
   requestStream,
   snapshotJsonValue,
+  snapshotProviderJsonValue,
   stringifyJsonValue,
   stringifyToolArguments,
   stringifyToolResultValue,

--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -289,6 +289,69 @@ describe("tool factory", () => {
       );
     });
 
+    it("rejects MCP config objects before descriptor inspection when proxy detection is unavailable", async () => {
+      const script = `
+        Object.defineProperty(globalThis, "caches", {
+          configurable: true,
+          value: {},
+        });
+        Object.defineProperty(globalThis, "WebSocketPair", {
+          configurable: true,
+          value: function WebSocketPair() {},
+        });
+
+        const {
+          canIdentifyProxyWithoutHooks,
+        } = await import("./src/platform/compat/error-introspection.ts");
+        const { tool } = await import("./src/tool/factory.ts");
+
+        let trapCalls = 0;
+        const mcp = new Proxy({ enabled: true }, {
+          ownKeys() {
+            trapCalls += 1;
+            throw new Error("ownKeys trap must not escape");
+          },
+          getOwnPropertyDescriptor() {
+            trapCalls += 1;
+            throw new Error("descriptor trap must not escape");
+          },
+        });
+        const result = {
+          canIdentifyProxyWithoutHooks,
+          trapCalls,
+          message: "",
+        };
+        try {
+          tool({
+            id: "edge-mcp-config",
+            description: "desc",
+            inputSchema: { type: "object" },
+            execute: async () => null,
+            mcp,
+          });
+        } catch (error) {
+          result.message = error instanceof Error ? error.message : String(error);
+          result.trapCalls = trapCalls;
+        }
+        console.log(JSON.stringify(result));
+      `;
+      const output = await new Deno.Command(Deno.execPath(), {
+        args: ["eval", "--config=deno.json", script],
+        cwd: new URL("../../", import.meta.url),
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      const stderr = new TextDecoder().decode(output.stderr);
+      assertEquals(output.code, 0, stderr);
+
+      const result = JSON.parse(new TextDecoder().decode(output.stdout));
+      assertEquals(result, {
+        canIdentifyProxyWithoutHooks: false,
+        trapCalls: 0,
+        message: 'Tool "edge-mcp-config" MCP configuration must contain only data properties',
+      });
+    });
+
     it("snapshots raw schemas and metadata at construction", () => {
       const inputSchema: JsonSchema = {
         type: "object",

--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -289,6 +289,74 @@ describe("tool factory", () => {
       );
     });
 
+    it("rejects MCP accessors despite descriptor prototype pollution", () => {
+      const originalValue = Object.getOwnPropertyDescriptor(Object.prototype, "value");
+      let accessorCalls = 0;
+      const mcp = Object.defineProperty({}, "enabled", {
+        enumerable: true,
+        get() {
+          accessorCalls += 1;
+          throw new Error("MCP accessors must not run");
+        },
+      });
+      let thrown: unknown;
+
+      try {
+        Object.defineProperty(Object.prototype, "value", {
+          configurable: true,
+          value: true,
+          writable: true,
+        });
+
+        try {
+          tool({
+            id: "accessor-mcp-config",
+            description: "desc",
+            inputSchema: { type: "object" },
+            execute: async () => null,
+            mcp,
+          });
+        } catch (error) {
+          thrown = error;
+        }
+      } finally {
+        if (originalValue) {
+          Object.defineProperty(Object.prototype, "value", originalValue);
+        } else {
+          Reflect.deleteProperty(Object.prototype, "value");
+        }
+      }
+
+      assertEquals(thrown instanceof Error, true);
+      assertEquals(accessorCalls, 0);
+    });
+
+    it("copies special MCP property names without changing object prototypes", () => {
+      const mcp = Object.create(null) as Record<string, unknown>;
+      Object.defineProperty(mcp, "__proto__", {
+        enumerable: true,
+        value: { polluted: true },
+      });
+      Object.defineProperty(mcp, "enabled", {
+        enumerable: true,
+        value: true,
+      });
+
+      const result = tool({
+        id: "special-key-mcp-config",
+        description: "desc",
+        inputSchema: defineSchema((v) => v.object({}))(),
+        execute: async () => null,
+        mcp,
+      }).mcp as Record<string, unknown>;
+
+      assertEquals(Object.getPrototypeOf(result), Object.prototype);
+      assertEquals(Object.getOwnPropertyDescriptor(result, "__proto__")?.value, {
+        polluted: true,
+      });
+      assertEquals(({} as { polluted?: boolean }).polluted, undefined);
+    });
+
     it("loads MCP config through structured clone when proxy detection is unavailable", async () => {
       const script = `
         Object.defineProperty(globalThis, "caches", {

--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -289,7 +289,7 @@ describe("tool factory", () => {
       );
     });
 
-    it("rejects MCP config objects before descriptor inspection when proxy detection is unavailable", async () => {
+    it("loads MCP config through structured clone when proxy detection is unavailable", async () => {
       const script = `
         Object.defineProperty(globalThis, "caches", {
           configurable: true,
@@ -306,7 +306,12 @@ describe("tool factory", () => {
         const { tool } = await import("./src/tool/factory.ts");
 
         let trapCalls = 0;
-        const mcp = new Proxy({ enabled: true }, {
+        const plainMcp = {
+          enabled: true,
+          title: "Edge tool",
+          annotations: { readOnlyHint: true },
+        };
+        const proxiedMcp = new Proxy({ enabled: true }, {
           ownKeys() {
             trapCalls += 1;
             throw new Error("ownKeys trap must not escape");
@@ -319,18 +324,26 @@ describe("tool factory", () => {
         const result = {
           canIdentifyProxyWithoutHooks,
           trapCalls,
-          message: "",
+          plainMcp: undefined,
+          proxyMessage: "",
         };
+        result.plainMcp = tool({
+          id: "edge-mcp-config",
+          description: "desc",
+          inputSchema: { type: "object" },
+          execute: async () => null,
+          mcp: plainMcp,
+        }).mcp;
         try {
           tool({
-            id: "edge-mcp-config",
+            id: "edge-mcp-config-proxy",
             description: "desc",
             inputSchema: { type: "object" },
             execute: async () => null,
-            mcp,
+            mcp: proxiedMcp,
           });
         } catch (error) {
-          result.message = error instanceof Error ? error.message : String(error);
+          result.proxyMessage = error instanceof Error ? error.message : String(error);
           result.trapCalls = trapCalls;
         }
         console.log(JSON.stringify(result));
@@ -348,7 +361,13 @@ describe("tool factory", () => {
       assertEquals(result, {
         canIdentifyProxyWithoutHooks: false,
         trapCalls: 0,
-        message: 'Tool "edge-mcp-config" MCP configuration must contain only data properties',
+        plainMcp: {
+          enabled: true,
+          title: "Edge tool",
+          annotations: { readOnlyHint: true },
+        },
+        proxyMessage:
+          'Tool "edge-mcp-config-proxy" MCP configuration must contain only data properties',
       });
     });
 

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -9,6 +9,9 @@ import {
   isProxyWithoutHooks,
 } from "#veryfront/platform/compat/error-introspection.ts";
 
+const apply = Reflect.apply;
+const structuredCloneValue = globalThis.structuredClone;
+
 interface ContractSchemaShape {
   __zod?: unknown;
   _output?: unknown;
@@ -206,20 +209,33 @@ function snapshotMcpConfig(
   if (typeof value !== "object" || value === null) {
     schemaError(toolId, "MCP configuration must be a bounded JSON object");
   }
-  if (!canIdentifyProxyWithoutHooks) {
-    schemaError(toolId, "MCP configuration must contain only data properties");
+  let inspectedValue: object = value;
+  if (canIdentifyProxyWithoutHooks) {
+    if (isProxyWithoutHooks(value)) {
+      schemaError(toolId, "MCP configuration must contain only data properties");
+    }
+  } else {
+    if (typeof structuredCloneValue !== "function") {
+      schemaError(toolId, "MCP configuration must contain only data properties");
+    }
+    // Local MCP metadata crosses the same edge-runtime trust boundary as
+    // provider-bound JSON: hosts without no-hook Proxy detection use the
+    // captured structured clone primitive to reject Proxies before reflection
+    // and then validate the owned clone.
+    try {
+      inspectedValue = apply(structuredCloneValue, globalThis, [value]) as object;
+    } catch {
+      schemaError(toolId, "MCP configuration must contain only data properties");
+    }
   }
-  if (isProxyWithoutHooks(value)) {
-    schemaError(toolId, "MCP configuration must contain only data properties");
-  }
-  if (Array.isArray(value)) {
+  if (Array.isArray(inspectedValue)) {
     schemaError(toolId, "MCP configuration must be a bounded JSON object");
   }
 
   const canonicalInput: Record<string, unknown> = {};
   let keys: PropertyKey[];
   try {
-    keys = Reflect.ownKeys(value);
+    keys = Reflect.ownKeys(inspectedValue);
   } catch {
     schemaError(toolId, "MCP configuration must be a bounded JSON object");
   }
@@ -229,7 +245,7 @@ function snapshotMcpConfig(
     }
     let descriptor: PropertyDescriptor | undefined;
     try {
-      descriptor = Object.getOwnPropertyDescriptor(value, key);
+      descriptor = Object.getOwnPropertyDescriptor(inspectedValue, key);
     } catch {
       schemaError(toolId, "MCP configuration must contain only data properties");
     }

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -4,7 +4,10 @@ import { zodToJsonSchema } from "./schema/zod-json-schema.ts";
 import { agentLogger } from "#veryfront/utils";
 import { createError, getErrorMessage, INVALID_ARGUMENT, toError } from "#veryfront/errors";
 import { snapshotBoundedJsonValue } from "#veryfront/schemas/json-value.ts";
-import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
+import {
+  canIdentifyProxyWithoutHooks,
+  isProxyWithoutHooks,
+} from "#veryfront/platform/compat/error-introspection.ts";
 
 interface ContractSchemaShape {
   __zod?: unknown;
@@ -202,6 +205,9 @@ function snapshotMcpConfig(
   if (value === undefined) return undefined;
   if (typeof value !== "object" || value === null) {
     schemaError(toolId, "MCP configuration must be a bounded JSON object");
+  }
+  if (!canIdentifyProxyWithoutHooks) {
+    schemaError(toolId, "MCP configuration must contain only data properties");
   }
   if (isProxyWithoutHooks(value)) {
     schemaError(toolId, "MCP configuration must contain only data properties");

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -10,7 +10,16 @@ import {
 } from "#veryfront/platform/compat/error-introspection.ts";
 
 const apply = Reflect.apply;
+const arrayIsArray = Array.isArray;
+const objectCreate = Object.create;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectHasOwnProperty = Object.prototype.hasOwnProperty;
+const ownKeys = Reflect.ownKeys;
 const structuredCloneValue = globalThis.structuredClone;
+
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return apply(objectHasOwnProperty, object, [key]) as boolean;
+}
 
 interface ContractSchemaShape {
   __zod?: unknown;
@@ -228,31 +237,34 @@ function snapshotMcpConfig(
       schemaError(toolId, "MCP configuration must contain only data properties");
     }
   }
-  if (Array.isArray(inspectedValue)) {
+  if (arrayIsArray(inspectedValue)) {
     schemaError(toolId, "MCP configuration must be a bounded JSON object");
   }
 
-  const canonicalInput: Record<string, unknown> = {};
+  const canonicalInput = objectCreate(null) as Record<string, unknown>;
   let keys: PropertyKey[];
   try {
-    keys = Reflect.ownKeys(inspectedValue);
+    keys = ownKeys(inspectedValue);
   } catch {
     schemaError(toolId, "MCP configuration must be a bounded JSON object");
   }
-  for (const key of keys) {
+  for (let index = 0; index < keys.length; index++) {
+    const key = keys[index]!;
     if (typeof key !== "string") {
       schemaError(toolId, "MCP configuration must be a bounded JSON object");
     }
     let descriptor: PropertyDescriptor | undefined;
     try {
-      descriptor = Object.getOwnPropertyDescriptor(inspectedValue, key);
+      descriptor = objectGetOwnPropertyDescriptor(inspectedValue, key);
     } catch {
       schemaError(toolId, "MCP configuration must contain only data properties");
     }
-    if (!descriptor || !("value" in descriptor)) {
+    if (!descriptor || !hasOwn(descriptor, "value")) {
       schemaError(toolId, "MCP configuration must contain only data properties");
     }
     if (descriptor.enumerable && descriptor.value !== undefined) {
+      // A null prototype makes assignment safe even for `__proto__` and other
+      // special names without consulting inherited setters.
       canonicalInput[key] = descriptor.value;
     }
   }
@@ -262,7 +274,7 @@ function snapshotMcpConfig(
     !snapshot.success ||
     typeof snapshot.value !== "object" ||
     snapshot.value === null ||
-    Array.isArray(snapshot.value)
+    arrayIsArray(snapshot.value)
   ) {
     schemaError(toolId, "MCP configuration must be a bounded JSON object");
   }

--- a/src/workflow/worker/shared.test.ts
+++ b/src/workflow/worker/shared.test.ts
@@ -132,7 +132,7 @@ describe("workflow worker shared helpers", () => {
     );
   });
 
-  it("maps waiting and unexpected statuses to success exit codes", () => {
+  it("maps a paused waiting run to the success exit code", () => {
     const logger = createLogger();
     const exitCodes = { SUCCESS: 0, WORKFLOW_FAILED: 1 };
 
@@ -140,7 +140,6 @@ describe("workflow worker shared helpers", () => {
       getFinalRunExitCode(logger, exitCodes, "run-1", { status: "waiting" } as never, false),
       0,
     );
-    assertEquals(getFinalRunExitCode(logger, exitCodes, "run-1", null, false), 0);
   });
 
   it("maps failed runs to the failure exit code", () => {
@@ -149,6 +148,25 @@ describe("workflow worker shared helpers", () => {
 
     assertEquals(
       getFinalRunExitCode(logger, exitCodes, "run-1", { status: "failed" } as never, false),
+      1,
+    );
+  });
+
+  it("does not report success for runs that never reached a durable final state", () => {
+    const logger = createLogger();
+    const exitCodes = { SUCCESS: 0, WORKFLOW_FAILED: 1 };
+
+    assertEquals(getFinalRunExitCode(logger, exitCodes, "run-1", null, false), 1);
+    assertEquals(
+      getFinalRunExitCode(logger, exitCodes, "run-1", { status: "cancelled" } as never, false),
+      1,
+    );
+    assertEquals(
+      getFinalRunExitCode(logger, exitCodes, "run-1", { status: "pending" } as never, false),
+      1,
+    );
+    assertEquals(
+      getFinalRunExitCode(logger, exitCodes, "run-1", { status: "running" } as never, false),
       1,
     );
   });

--- a/src/workflow/worker/shared.test.ts
+++ b/src/workflow/worker/shared.test.ts
@@ -58,6 +58,20 @@ function createLogger() {
   };
 }
 
+function createCapturingLogger() {
+  const warnings: string[] = [];
+  return {
+    logger: {
+      error: () => undefined,
+      info: () => undefined,
+      warn: (message: string) => {
+        warnings.push(message);
+      },
+    },
+    warnings,
+  };
+}
+
 function createRun(id: string, status: WorkflowRun["status"], workerId?: string): WorkflowRun {
   return {
     id,
@@ -169,6 +183,37 @@ describe("workflow worker shared helpers", () => {
       getFinalRunExitCode(logger, exitCodes, "run-1", { status: "running" } as never, false),
       1,
     );
+  });
+
+  it("logs sanitized run ids for runs that never reached a durable final state", () => {
+    const { logger, warnings } = createCapturingLogger();
+    const exitCodes = { SUCCESS: 0, WORKFLOW_FAILED: 1 };
+
+    assertEquals(
+      getFinalRunExitCode(
+        logger,
+        exitCodes,
+        "run-\x1b[2Jtoken=secret",
+        { status: "pending" } as never,
+        false,
+      ),
+      1,
+    );
+    assertEquals(
+      getFinalRunExitCode(
+        logger,
+        exitCodes,
+        "run-\x1b[2Jtoken=secret",
+        { status: "running" } as never,
+        false,
+      ),
+      1,
+    );
+
+    assertEquals(warnings, [
+      "Workflow did not reach a durable final state: pending (runId: run-token=secret)",
+      "Workflow did not reach a durable final state: running (runId: run-token=secret)",
+    ]);
   });
 
   it("persists approvals before an isolated executor returns a waiting run", async () => {

--- a/src/workflow/worker/shared.test.ts
+++ b/src/workflow/worker/shared.test.ts
@@ -59,15 +59,23 @@ function createLogger() {
 }
 
 function createCapturingLogger() {
+  const errors: string[] = [];
+  const infos: string[] = [];
   const warnings: string[] = [];
   return {
     logger: {
-      error: () => undefined,
-      info: () => undefined,
+      error: (message: string) => {
+        errors.push(message);
+      },
+      info: (message: string) => {
+        infos.push(message);
+      },
       warn: (message: string) => {
         warnings.push(message);
       },
     },
+    errors,
+    infos,
     warnings,
   };
 }
@@ -240,6 +248,31 @@ describe("workflow worker shared helpers", () => {
       "Workflow did not reach a durable final state: running (runId: run-token=secret)",
       "Unexpected final status: unexpected (runId: run-token=secret)",
     ]);
+  });
+
+  it("logs sanitized run ids for completed, failed, and waiting runs", () => {
+    const { errors, infos, logger } = createCapturingLogger();
+    const exitCodes = { SUCCESS: 0, WORKFLOW_FAILED: 1 };
+    const runId = "run-\x1b[2Jtoken=secret";
+
+    assertEquals(
+      getFinalRunExitCode(logger, exitCodes, runId, { status: "completed" } as never, true),
+      0,
+    );
+    assertEquals(
+      getFinalRunExitCode(logger, exitCodes, runId, { status: "failed" } as never, false),
+      1,
+    );
+    assertEquals(
+      getFinalRunExitCode(logger, exitCodes, runId, { status: "waiting" } as never, true),
+      0,
+    );
+
+    assertEquals(infos, [
+      "Workflow completed successfully: run-token=secret",
+      "Workflow paused (waiting): run-token=secret",
+    ]);
+    assertEquals(errors, ["Workflow failed: run-token=secret"]);
   });
 
   it("persists approvals before an isolated executor returns a waiting run", async () => {

--- a/src/workflow/worker/shared.test.ts
+++ b/src/workflow/worker/shared.test.ts
@@ -188,12 +188,25 @@ describe("workflow worker shared helpers", () => {
   it("logs sanitized run ids for runs that never reached a durable final state", () => {
     const { logger, warnings } = createCapturingLogger();
     const exitCodes = { SUCCESS: 0, WORKFLOW_FAILED: 1 };
+    const runId = "run-\x1b[2Jtoken=secret";
+
+    assertEquals(getFinalRunExitCode(logger, exitCodes, runId, null, false), 1);
+    assertEquals(
+      getFinalRunExitCode(
+        logger,
+        exitCodes,
+        runId,
+        { status: "cancelled" } as never,
+        false,
+      ),
+      1,
+    );
 
     assertEquals(
       getFinalRunExitCode(
         logger,
         exitCodes,
-        "run-\x1b[2Jtoken=secret",
+        runId,
         { status: "pending" } as never,
         false,
       ),
@@ -203,16 +216,29 @@ describe("workflow worker shared helpers", () => {
       getFinalRunExitCode(
         logger,
         exitCodes,
-        "run-\x1b[2Jtoken=secret",
+        runId,
         { status: "running" } as never,
+        false,
+      ),
+      1,
+    );
+    assertEquals(
+      getFinalRunExitCode(
+        logger,
+        exitCodes,
+        runId,
+        { status: "unexpected" } as never,
         false,
       ),
       1,
     );
 
     assertEquals(warnings, [
+      "Workflow run was not found after execution: run-token=secret",
+      "Workflow was cancelled: run-token=secret",
       "Workflow did not reach a durable final state: pending (runId: run-token=secret)",
       "Workflow did not reach a durable final state: running (runId: run-token=secret)",
+      "Unexpected final status: unexpected (runId: run-token=secret)",
     ]);
   });
 

--- a/src/workflow/worker/shared.ts
+++ b/src/workflow/worker/shared.ts
@@ -100,6 +100,8 @@ export function getFinalRunExitCode(
   finalRun: WorkflowRun | null,
   debug = false,
 ): number {
+  const sanitizedRunId = sanitizeTerminalDiagnosticText(runId);
+
   switch (finalRun?.status) {
     case "completed":
       if (debug) {
@@ -118,23 +120,21 @@ export function getFinalRunExitCode(
       return exitCodes.SUCCESS;
 
     case "cancelled":
-      logger.warn(`Workflow was cancelled: ${runId}`);
+      logger.warn(`Workflow was cancelled: ${sanitizedRunId}`);
       return exitCodes.WORKFLOW_FAILED;
 
     case "pending":
     case "running":
       logger.warn(
-        `Workflow did not reach a durable final state: ${finalRun.status} (runId: ${
-          sanitizeTerminalDiagnosticText(runId)
-        })`,
+        `Workflow did not reach a durable final state: ${finalRun.status} (runId: ${sanitizedRunId})`,
       );
       return exitCodes.WORKFLOW_FAILED;
 
     default:
       logger.warn(
         finalRun
-          ? `Unexpected final status: ${finalRun.status}`
-          : `Workflow run was not found after execution: ${runId}`,
+          ? `Unexpected final status: ${finalRun.status} (runId: ${sanitizedRunId})`
+          : `Workflow run was not found after execution: ${sanitizedRunId}`,
       );
       return exitCodes.WORKFLOW_FAILED;
   }

--- a/src/workflow/worker/shared.ts
+++ b/src/workflow/worker/shared.ts
@@ -105,17 +105,17 @@ export function getFinalRunExitCode(
   switch (finalRun?.status) {
     case "completed":
       if (debug) {
-        logger.info(`Workflow completed successfully: ${runId}`);
+        logger.info(`Workflow completed successfully: ${sanitizedRunId}`);
       }
       return exitCodes.SUCCESS;
 
     case "failed":
-      logger.error(`Workflow failed: ${runId}`, finalRun.error);
+      logger.error(`Workflow failed: ${sanitizedRunId}`, finalRun.error);
       return exitCodes.WORKFLOW_FAILED;
 
     case "waiting":
       if (debug) {
-        logger.info(`Workflow paused (waiting): ${runId}`);
+        logger.info(`Workflow paused (waiting): ${sanitizedRunId}`);
       }
       return exitCodes.SUCCESS;
 

--- a/src/workflow/worker/shared.ts
+++ b/src/workflow/worker/shared.ts
@@ -116,9 +116,22 @@ export function getFinalRunExitCode(
       }
       return exitCodes.SUCCESS;
 
+    case "cancelled":
+      logger.warn(`Workflow was cancelled: ${runId}`);
+      return exitCodes.WORKFLOW_FAILED;
+
+    case "pending":
+    case "running":
+      logger.warn(`Workflow did not reach a durable final state: ${finalRun.status}`);
+      return exitCodes.WORKFLOW_FAILED;
+
     default:
-      logger.warn(`Unexpected final status: ${finalRun?.status}`);
-      return exitCodes.SUCCESS;
+      logger.warn(
+        finalRun
+          ? `Unexpected final status: ${finalRun.status}`
+          : `Workflow run was not found after execution: ${runId}`,
+      );
+      return exitCodes.WORKFLOW_FAILED;
   }
 }
 

--- a/src/workflow/worker/shared.ts
+++ b/src/workflow/worker/shared.ts
@@ -1,4 +1,5 @@
 import { env as getProcessEnv } from "#veryfront/compat/process.ts";
+import { sanitizeTerminalDiagnosticText } from "#veryfront/errors/safe-diagnostics.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { mergeInjectedWorkflowEnv } from "#veryfront/runs/runtime-env.ts";
@@ -122,7 +123,11 @@ export function getFinalRunExitCode(
 
     case "pending":
     case "running":
-      logger.warn(`Workflow did not reach a durable final state: ${finalRun.status}`);
+      logger.warn(
+        `Workflow did not reach a durable final state: ${finalRun.status} (runId: ${
+          sanitizeTerminalDiagnosticText(runId)
+        })`,
+      );
       return exitCodes.WORKFLOW_FAILED;
 
     default:


### PR DESCRIPTION
## Summary

Ports the useful agent/runtime correctness work from `codex/module-reconcile-20260723` onto current main without touching the reconcile branch's unrelated changes.

### Changes

1. **Model aliases** use prototype-safe `Map` lookup, including direct-provider aliases.
2. **Hosted project references** are canonical, bounded, request/response-bound, and read only through own data descriptors; failed-response cleanup cannot mask the primary lookup error.
3. **Tool diagnostics** are UTF-8 bounded, accessor/Proxy safe, and preserve safe structured siblings when another branch is unsupported. Best-effort strings are bounded before JSON allocation.
4. **Provider snapshots** capture their security-sensitive primordials, enforce depth/node/byte budgets, avoid mutable iterators and inherited setters, and inspect only own-data options.
5. **Edge MCP/provider compatibility** uses a captured structured-clone boundary when the host has no no-hook Proxy brand primitive. Plain structured configuration remains usable; nested or top-level Proxies fail closed without trap execution. MCP descriptor handling is protected against descriptor prototype pollution and special property names.
6. **Hosted child logs** retain the parent run in `runId`, with explicit parent/child dimensions.
7. **Workflow exit semantics** return failure for vanished, cancelled, pending, running, and unexpected executions. A deliberate `waiting` pause remains successful. All terminal-facing run IDs are sanitized.

## Trust-boundary policy

Security-sensitive primordials are captured during trusted framework bootstrap, before tenant code executes. On runtimes with no safe Proxy brand primitive, structured clone is used only at provider and MCP configuration boundaries where plain structured values must remain portable. Diagnostic and project-identity paths remain strict and fail closed because partial or cloned authority/error objects would weaken their contracts.

## Upgrade note

Workflow CLI/process consumers may now receive a non-zero `WORKFLOW_FAILED` exit for a cancelled, missing, still-pending, still-running, or unknown final run state. Those outcomes previously reported success even though durable completion was not established. CI wrappers that intentionally ignored those states should handle the non-zero result explicitly; a deliberate `waiting` workflow pause still exits successfully.

The repository has no standalone changelog/changeset mechanism, so this PR upgrade note is the release-note source for that behavioral correction.

## Deliberately excluded

`getTenantFromEnv` remains because current main still has live consumers; removal requires the separate entrypoint rewrite.

## Verification at `2852774a9`

- `deno task verify:quick` passed, including format/lint/style ratchets, core third-party dependency audit, dependency/module boundaries, extension contracts, docs validation, and public-entrypoint typecheck.
- Focused MCP/tool diagnostics, provider snapshot, provider helper, and workflow suite: **5 files, 106 steps, 0 failures**.
- Additional affected-file format, lint, typecheck, and `git diff --check`: passed.
- Fresh-process edge tests prove plain MCP configuration remains loadable and Proxy configurations fail without trap execution.
- Regression coverage pins own-data descriptor checks, descriptor prototype pollution, `__proto__` handling, oversized diagnostic strings, mutable primordials, sanitized workflow logging, and corrected exit codes.

Fresh exact-head GitHub CI and a qualifying independent approval are required before merge.
