### PR TITLE
fix(rendering): validate render-cache inputs and evict corrupt entries

### DIFF
--- a/src/rendering/cache/cache-coordinator.test.ts
+++ b/src/rendering/cache/cache-coordinator.test.ts
@@ -84,6 +84,57 @@ describe("CacheCoordinator", () => {
     assertEquals(deletedKey, "project:draft:malformed");
   });
 
+  it("skips caching when a result cannot be snapshotted", async () => {
+    let setCalls = 0;
+    const data = new Map<string, CachePayload>();
+    const store: CacheStore = {
+      get: (key) => Promise.resolve(data.get(key)),
+      set: (key, value) => {
+        setCalls++;
+        data.set(key, value);
+        return Promise.resolve();
+      },
+      delete: (key) => {
+        data.delete(key);
+        return Promise.resolve();
+      },
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "bounds" });
+
+    // Nest past MAX_CACHE_VALUE_DEPTH so the snapshot fails its bounds check.
+    const root: Record<string, unknown> = {};
+    let branch = root;
+    for (let depth = 0; depth < 80; depth++) {
+      const next: Record<string, unknown> = {};
+      branch.child = next;
+      branch = next;
+    }
+    const result = makeResult("<html>too deep</html>");
+    setFrontmatter(result, root);
+
+    await coordinator.persistResult(result, "too-deep");
+
+    assertEquals(setCalls, 0);
+    assertEquals((await coordinator.checkCache("too-deep")).cacheStatus, "miss");
+  });
+
+  it("keeps rendering when the cache store rejects a write", async () => {
+    const store: CacheStore = {
+      get: () => Promise.resolve(undefined),
+      set: () => Promise.reject(new Error("store unavailable")),
+      delete: () => Promise.resolve(),
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "unavailable" });
+
+    await coordinator.persistResult(makeResult("<html>ok</html>"), "written");
+
+    assertEquals((await coordinator.checkCache("written")).cacheStatus, "miss");
+  });
+
   it("preserves Date frontmatter across a serializing store round-trip", async () => {
     let stored: CachePayload | undefined;
     const serializedStore: CacheStore = {

--- a/src/rendering/cache/cache-coordinator.test.ts
+++ b/src/rendering/cache/cache-coordinator.test.ts
@@ -1,11 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { scaleMs } from "#veryfront/testing/timing.ts";
 import type { RenderResult } from "../orchestrator/types.ts";
 import { CacheCoordinator } from "./cache-coordinator.ts";
 import { wrapInHTMLShell } from "#veryfront/html/html-shell-generator.ts";
 import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
+import { serializeCachePayload } from "./cache-payload.ts";
+import type { CachePayload, CacheStore } from "./types.ts";
 
 function makeResult(html: string): RenderResult {
   return {
@@ -16,6 +18,10 @@ function makeResult(html: string): RenderResult {
     stream: null,
     ssrHash: "hash",
   };
+}
+
+function setFrontmatter(result: RenderResult, value: unknown): void {
+  result.frontmatter = value as RenderResult["frontmatter"];
 }
 
 function delay(ms: number): Promise<void> {
@@ -48,6 +54,82 @@ async function withStoreTtlEnabled(fn: () => Promise<void>): Promise<void> {
 }
 
 describe("CacheCoordinator", () => {
+  it("rejects invalid TTL/stale durations", () => {
+    for (const ttlMs of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      assertThrows(() => new CacheCoordinator({ ttlMs }), RangeError, "ttlMs");
+    }
+    for (const staleMs of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      assertThrows(() => new CacheCoordinator({ staleMs }), RangeError, "staleMs");
+    }
+  });
+
+  it("evicts malformed store values and treats them as misses", async () => {
+    let deletedKey: string | undefined;
+    const store: CacheStore = {
+      get: () => Promise.resolve({} as CachePayload),
+      set: () => Promise.resolve(),
+      delete: (key) => {
+        deletedKey = key;
+        return Promise.resolve();
+      },
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "project" });
+
+    const lookup = await coordinator.checkCache("malformed");
+
+    assertEquals(lookup.cacheStatus, "miss");
+    assertEquals(lookup.cachedResult, undefined);
+    assertEquals(deletedKey, "project:draft:malformed");
+  });
+
+  it("preserves Date frontmatter across a serializing store round-trip", async () => {
+    let stored: CachePayload | undefined;
+    const serializedStore: CacheStore = {
+      get: () => Promise.resolve(stored),
+      set: (_key, value) => {
+        stored = JSON.parse(serializeCachePayload(value)) as CachePayload;
+        return Promise.resolve();
+      },
+      delete: () => {
+        stored = undefined;
+        return Promise.resolve();
+      },
+      clear: () => {
+        stored = undefined;
+        return Promise.resolve();
+      },
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({
+      store: serializedStore,
+      ttlMs: 10_000,
+      projectId: "date-project",
+    });
+    const result = makeResult("<html>dated</html>");
+    const publicationDate = new Date("2026-07-24T08:30:00.000Z");
+    setFrontmatter(result, {
+      date: publicationDate,
+      metadata: {
+        revisedAt: new Date("2026-07-25T09:45:00.000Z"),
+      },
+    });
+
+    await coordinator.persistResult(result, "dated");
+    const lookup = await coordinator.checkCache("dated");
+
+    assertEquals(lookup.cacheStatus, "hit");
+    assertEquals(lookup.cachedResult?.frontmatter as unknown, {
+      date: new Date("2026-07-24T08:30:00.000Z"),
+      metadata: {
+        revisedAt: new Date("2026-07-25T09:45:00.000Z"),
+      },
+    });
+    assertEquals((lookup.cachedResult?.frontmatter.date as unknown) === publicationDate, false);
+    await coordinator.destroy();
+  });
+
   it("returns cached result on second lookup", async () => {
     const coordinator = new CacheCoordinator({ ttlMs: 10_000 });
     const slug = "home";

--- a/src/rendering/cache/cache-coordinator.test.ts
+++ b/src/rendering/cache/cache-coordinator.test.ts
@@ -109,9 +109,10 @@ describe("CacheCoordinator", () => {
     const store: CacheStore = {
       get: () => Promise.resolve({} as CachePayload),
       set: () => Promise.resolve(),
-      delete: (key) => {
+      delete: () => Promise.reject(new Error("unsafe unconditional delete")),
+      deleteIfUnchanged: (key) => {
         deletedKey = key;
-        return Promise.resolve();
+        return Promise.resolve(true);
       },
       clear: () => Promise.resolve(),
       destroy: () => Promise.resolve(),
@@ -226,6 +227,39 @@ describe("CacheCoordinator", () => {
     assertEquals(evictionCalls, 1);
   });
 
+  it("bounds distinct hung evictions", async () => {
+    let evictionCalls = 0;
+    const capacityReached = Promise.withResolvers<void>();
+    const store: CacheStore = {
+      get: () => Promise.resolve({} as CachePayload),
+      set: () => Promise.resolve(),
+      delete: () => Promise.reject(new Error("unsafe unconditional delete")),
+      deleteIfUnchanged: () => {
+        evictionCalls++;
+        if (evictionCalls === 128) capacityReached.resolve();
+        return new Promise<boolean>(() => {});
+      },
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "project" });
+
+    const lookups = await withTimeoutThrow(
+      Promise.all(
+        Array.from(
+          { length: 129 },
+          (_, index) => coordinator.checkCache(`malformed-${index}`),
+        ),
+      ),
+      1_000,
+      "bounded corrupt-cache lookups",
+    );
+    await withTimeoutThrow(capacityReached.promise, 1_000, "eviction capacity");
+
+    assertEquals(lookups.every((lookup) => lookup.cacheStatus === "miss"), true);
+    assertEquals(evictionCalls, 128);
+  });
+
   it("skips caching when a result cannot be snapshotted", async () => {
     let setCalls = 0;
     const data = new Map<string, CachePayload>();
@@ -293,6 +327,30 @@ describe("CacheCoordinator", () => {
     const coordinator = new CacheCoordinator({ store, projectId: "hostile" });
 
     await coordinator.persistResult(makeResult("<html>ok</html>"), "written");
+  });
+
+  it("contains a revoked-proxy eviction failure", async () => {
+    const attempted = Promise.withResolvers<void>();
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    const store: CacheStore = {
+      get: () => Promise.resolve({} as CachePayload),
+      set: () => Promise.resolve(),
+      delete: () => Promise.reject(new Error("unsafe unconditional delete")),
+      deleteIfUnchanged: () => {
+        attempted.resolve();
+        return Promise.reject(revoked.proxy);
+      },
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "hostile-eviction" });
+
+    const lookup = await coordinator.checkCache("malformed");
+    await withTimeoutThrow(attempted.promise, 1_000, "revoked-proxy eviction attempt");
+    await delay(0);
+
+    assertEquals(lookup.cacheStatus, "miss");
   });
 
   it("preserves Date frontmatter across a serializing store round-trip", async () => {
@@ -444,7 +502,11 @@ describe("CacheCoordinator", () => {
   });
 
   it("preserves the public zero-TTL non-expiring contract", async () => {
-    const coordinator = new CacheCoordinator({ ttlMs: 0, projectId: "non-expiring" });
+    const coordinator = new CacheCoordinator({
+      ttlMs: 0,
+      staleMs: 500,
+      projectId: "non-expiring",
+    });
 
     await coordinator.persistResult(makeResult("still fresh"), "zero-ttl");
     const lookup = await coordinator.checkCache("zero-ttl");

--- a/src/rendering/cache/cache-coordinator.test.ts
+++ b/src/rendering/cache/cache-coordinator.test.ts
@@ -84,6 +84,22 @@ describe("CacheCoordinator", () => {
     assertEquals(deletedKey, "project:draft:malformed");
   });
 
+  it("treats malformed store values as misses when eviction fails", async () => {
+    const store: CacheStore = {
+      get: () => Promise.resolve({} as CachePayload),
+      set: () => Promise.resolve(),
+      delete: () => Promise.reject(new Error("delete unavailable")),
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "project" });
+
+    const lookup = await coordinator.checkCache("malformed");
+
+    assertEquals(lookup.cacheStatus, "miss");
+    assertEquals(lookup.cachedResult, undefined);
+  });
+
   it("skips caching when a result cannot be snapshotted", async () => {
     let setCalls = 0;
     const data = new Map<string, CachePayload>();
@@ -282,6 +298,39 @@ describe("CacheCoordinator", () => {
 
     await coordinator.destroy();
   });
+
+  it("treats a zero TTL as immediate expiry", async () => {
+    const coordinator = new CacheCoordinator({ ttlMs: 0, projectId: "immediate" });
+
+    await coordinator.persistResult(makeResult("never fresh"), "zero-ttl");
+    const lookup = await coordinator.checkCache("zero-ttl");
+
+    assertEquals(lookup.cachedResult, undefined);
+    assertEquals(lookup.cacheStatus, "expired");
+    await coordinator.destroy();
+  });
+
+  it("reports an expired entry when eviction fails", async () => {
+    const payload: CachePayload = {
+      result: makeResult("expired"),
+      storedAt: 0,
+      expiresAt: 0,
+    };
+    const store: CacheStore = {
+      get: () => Promise.resolve(payload),
+      set: () => Promise.resolve(),
+      delete: () => Promise.reject(new Error("delete unavailable")),
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "expired" });
+
+    const lookup = await coordinator.checkCache("entry");
+
+    assertEquals(lookup.cachedResult, undefined);
+    assertEquals(lookup.cacheStatus, "expired");
+  });
+
   it("serves recently expired entries as stale while refresh can run", async () => {
     const coordinator = new CacheCoordinator({
       ttlMs: scaleMs(20),

--- a/src/rendering/cache/cache-coordinator.test.ts
+++ b/src/rendering/cache/cache-coordinator.test.ts
@@ -2,7 +2,9 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { scaleMs } from "#veryfront/testing/timing.ts";
+import { MAX_CACHE_TTL_MILLISECONDS } from "#veryfront/cache/backends/ttl.ts";
 import type { RenderResult } from "../orchestrator/types.ts";
+import { withTimeoutThrow } from "../utils/stream-utils.ts";
 import { CacheCoordinator } from "./cache-coordinator.ts";
 import { wrapInHTMLShell } from "#veryfront/html/html-shell-generator.ts";
 import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
@@ -55,12 +57,51 @@ async function withStoreTtlEnabled(fn: () => Promise<void>): Promise<void> {
 
 describe("CacheCoordinator", () => {
   it("rejects invalid TTL/stale durations", () => {
-    for (const ttlMs of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    for (
+      const ttlMs of [
+        -1,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        MAX_CACHE_TTL_MILLISECONDS + 1,
+      ]
+    ) {
       assertThrows(() => new CacheCoordinator({ ttlMs }), RangeError, "ttlMs");
     }
-    for (const staleMs of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    for (
+      const staleMs of [
+        -1,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        MAX_CACHE_TTL_MILLISECONDS + 1,
+      ]
+    ) {
       assertThrows(() => new CacheCoordinator({ staleMs }), RangeError, "staleMs");
     }
+  });
+
+  it("rounds fractional TTL and stale windows up to whole milliseconds", async () => {
+    let stored: CachePayload | undefined;
+    const store: CacheStore = {
+      get: () => Promise.resolve(stored),
+      set: (_key, value) => {
+        stored = value;
+        return Promise.resolve();
+      },
+      delete: () => Promise.resolve(),
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({
+      store,
+      projectId: "fractional",
+      ttlMs: 1_000.25,
+      staleMs: 500.25,
+    });
+
+    await coordinator.persistResult(makeResult("fractional"), "entry");
+
+    assertEquals(stored?.expiresAt, (stored?.storedAt ?? 0) + 1_001);
+    assertEquals(stored?.staleUntil, (stored?.expiresAt ?? 0) + 501);
   });
 
   it("evicts malformed store values and treats them as misses", async () => {
@@ -85,10 +126,15 @@ describe("CacheCoordinator", () => {
   });
 
   it("treats malformed store values as misses when eviction fails", async () => {
+    const evictionAttempted = Promise.withResolvers<void>();
     const store: CacheStore = {
       get: () => Promise.resolve({} as CachePayload),
       set: () => Promise.resolve(),
-      delete: () => Promise.reject(new Error("delete unavailable")),
+      delete: () => Promise.reject(new Error("unsafe unconditional delete")),
+      deleteIfUnchanged: () => {
+        evictionAttempted.resolve();
+        return Promise.reject(new Error("delete unavailable"));
+      },
       clear: () => Promise.resolve(),
       destroy: () => Promise.resolve(),
     };
@@ -98,6 +144,86 @@ describe("CacheCoordinator", () => {
 
     assertEquals(lookup.cacheStatus, "miss");
     assertEquals(lookup.cachedResult, undefined);
+    await withTimeoutThrow(evictionAttempted.promise, 1_000, "cache eviction attempt");
+  });
+
+  it("does not block on a hung eviction or delete a replacement", async () => {
+    const malformed = {} as CachePayload;
+    const replacement: CachePayload = {
+      result: makeResult("replacement"),
+      storedAt: 1,
+    };
+    let current: CachePayload | undefined = malformed;
+    const evictionStarted = Promise.withResolvers<void>();
+    const releaseEviction = Promise.withResolvers<void>();
+    const evictionFinished = Promise.withResolvers<boolean>();
+    const store: CacheStore = {
+      get: () => Promise.resolve(current),
+      set: (_key, value) => {
+        current = value;
+        return Promise.resolve();
+      },
+      delete: () => Promise.reject(new Error("unsafe unconditional delete")),
+      deleteIfUnchanged: async (_key, expected) => {
+        evictionStarted.resolve();
+        await releaseEviction.promise;
+        if (current !== expected) {
+          evictionFinished.resolve(false);
+          return false;
+        }
+        current = undefined;
+        evictionFinished.resolve(true);
+        return true;
+      },
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "project" });
+
+    const lookup = await withTimeoutThrow(
+      coordinator.checkCache("malformed"),
+      1_000,
+      "non-blocking corrupt-cache lookup",
+    );
+    await withTimeoutThrow(evictionStarted.promise, 1_000, "cache eviction start");
+    current = replacement;
+    releaseEviction.resolve();
+
+    assertEquals(lookup.cacheStatus, "miss");
+    assertEquals(
+      await withTimeoutThrow(evictionFinished.promise, 1_000, "cache eviction completion"),
+      false,
+    );
+    assertEquals(current, replacement);
+  });
+
+  it("deduplicates hung evictions without delaying cache misses", async () => {
+    let evictionCalls = 0;
+    const store: CacheStore = {
+      get: () => Promise.resolve({} as CachePayload),
+      set: () => Promise.resolve(),
+      delete: () => Promise.reject(new Error("unsafe unconditional delete")),
+      deleteIfUnchanged: () => {
+        evictionCalls++;
+        return new Promise<boolean>(() => {});
+      },
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "project" });
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      assertEquals(
+        (await withTimeoutThrow(
+          coordinator.checkCache("malformed"),
+          1_000,
+          "deduplicated corrupt-cache lookup",
+        )).cacheStatus,
+        "miss",
+      );
+    }
+
+    assertEquals(evictionCalls, 1);
   });
 
   it("skips caching when a result cannot be snapshotted", async () => {
@@ -149,6 +275,24 @@ describe("CacheCoordinator", () => {
     await coordinator.persistResult(makeResult("<html>ok</html>"), "written");
 
     assertEquals((await coordinator.checkCache("written")).cacheStatus, "miss");
+  });
+
+  it("keeps rendering when a cache failure cannot be stringified", async () => {
+    const hostileFailure = {
+      toString(): string {
+        throw new Error("stringification trap");
+      },
+    };
+    const store: CacheStore = {
+      get: () => Promise.resolve(undefined),
+      set: () => Promise.reject(hostileFailure),
+      delete: () => Promise.resolve(),
+      clear: () => Promise.resolve(),
+      destroy: () => Promise.resolve(),
+    };
+    const coordinator = new CacheCoordinator({ store, projectId: "hostile" });
+
+    await coordinator.persistResult(makeResult("<html>ok</html>"), "written");
   });
 
   it("preserves Date frontmatter across a serializing store round-trip", async () => {
@@ -299,18 +443,19 @@ describe("CacheCoordinator", () => {
     await coordinator.destroy();
   });
 
-  it("treats a zero TTL as immediate expiry", async () => {
-    const coordinator = new CacheCoordinator({ ttlMs: 0, projectId: "immediate" });
+  it("preserves the public zero-TTL non-expiring contract", async () => {
+    const coordinator = new CacheCoordinator({ ttlMs: 0, projectId: "non-expiring" });
 
-    await coordinator.persistResult(makeResult("never fresh"), "zero-ttl");
+    await coordinator.persistResult(makeResult("still fresh"), "zero-ttl");
     const lookup = await coordinator.checkCache("zero-ttl");
 
-    assertEquals(lookup.cachedResult, undefined);
-    assertEquals(lookup.cacheStatus, "expired");
+    assertEquals(lookup.cachedResult?.html, "still fresh");
+    assertEquals(lookup.cacheStatus, "hit");
     await coordinator.destroy();
   });
 
   it("reports an expired entry when eviction fails", async () => {
+    const evictionAttempted = Promise.withResolvers<void>();
     const payload: CachePayload = {
       result: makeResult("expired"),
       storedAt: 0,
@@ -319,7 +464,11 @@ describe("CacheCoordinator", () => {
     const store: CacheStore = {
       get: () => Promise.resolve(payload),
       set: () => Promise.resolve(),
-      delete: () => Promise.reject(new Error("delete unavailable")),
+      delete: () => Promise.reject(new Error("unsafe unconditional delete")),
+      deleteIfUnchanged: () => {
+        evictionAttempted.resolve();
+        return Promise.reject(new Error("delete unavailable"));
+      },
       clear: () => Promise.resolve(),
       destroy: () => Promise.resolve(),
     };
@@ -329,6 +478,7 @@ describe("CacheCoordinator", () => {
 
     assertEquals(lookup.cachedResult, undefined);
     assertEquals(lookup.cacheStatus, "expired");
+    await withTimeoutThrow(evictionAttempted.promise, 1_000, "expired cache eviction attempt");
   });
 
   it("serves recently expired entries as stale while refresh can run", async () => {

--- a/src/rendering/cache/cache-coordinator.ts
+++ b/src/rendering/cache/cache-coordinator.ts
@@ -9,9 +9,24 @@ import {
   isHtmlNonceCacheCompatible,
   sealHtmlNonceForCache,
 } from "#veryfront/html/nonce-injection.ts";
+import { cloneCachePayload, parseCachePayload } from "./cache-payload.ts";
+import { MAX_CACHE_TTL_MILLISECONDS } from "#veryfront/cache/backends/ttl.ts";
 
 /** Default TTL for cache entries (5 minutes) */
 const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1_000;
+
+function validateDurations(ttlMs: number, staleMs: number): void {
+  if (!Number.isFinite(ttlMs) || ttlMs < 0 || ttlMs > MAX_CACHE_TTL_MILLISECONDS) {
+    throw new RangeError(
+      `Cache coordinator ttlMs must be between 0 and ${MAX_CACHE_TTL_MILLISECONDS}`,
+    );
+  }
+  if (!Number.isFinite(staleMs) || staleMs < 0 || staleMs > MAX_CACHE_TTL_MILLISECONDS) {
+    throw new RangeError(
+      `Cache coordinator staleMs must be between 0 and ${MAX_CACHE_TTL_MILLISECONDS}`,
+    );
+  }
+}
 
 export interface CacheCoordinatorOptions {
   store?: CacheStore;
@@ -58,8 +73,11 @@ export class CacheCoordinator {
   private readonly cachePrefix: string;
 
   constructor(options: CacheCoordinatorOptions = {}) {
-    this.ttlMs = options.ttlMs ?? this.defaultTtlMs;
-    this.staleMs = options.staleMs ?? 0;
+    const ttlMs = options.ttlMs ?? this.defaultTtlMs;
+    const staleMs = options.staleMs ?? 0;
+    validateDurations(ttlMs, staleMs);
+    this.ttlMs = ttlMs;
+    this.staleMs = staleMs;
     this.projectId = options.projectId;
     this.contentSourceId = options.contentSourceId;
 
@@ -101,7 +119,14 @@ export class CacheCoordinator {
       "cache.checkCache",
       async () => {
         const lookupStart = performance.now();
-        const cached = await this.store.get(key);
+        const stored = await this.store.get(key);
+        const cached = stored === undefined ? undefined : parseCachePayload(stored);
+
+        // A stored value that fails validation is unusable; drop it so the next
+        // render repopulates the key instead of replaying corrupt data.
+        if (stored !== undefined && cached === undefined) {
+          await this.store.delete(key);
+        }
 
         if (!cached) {
           const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
@@ -196,7 +221,7 @@ export class CacheCoordinator {
           staleUntil: this.ttlMs && this.staleMs > 0 ? now + this.ttlMs + this.staleMs : undefined,
         };
 
-        await this.store.set(key, payload);
+        await this.store.set(key, cloneCachePayload(payload));
       },
       { "cache.slug": slug, "cache.key": key, "cache.projectId": this.projectId ?? "unknown" },
     );

--- a/src/rendering/cache/cache-coordinator.ts
+++ b/src/rendering/cache/cache-coordinator.ts
@@ -11,27 +11,27 @@ import {
 } from "#veryfront/html/nonce-injection.ts";
 import { cloneCachePayload, parseCachePayload } from "./cache-payload.ts";
 import { MAX_CACHE_TTL_MILLISECONDS } from "#veryfront/cache/backends/ttl.ts";
+import { getErrorMessage } from "#veryfront/errors";
 
 /** Default TTL for cache entries (5 minutes) */
 const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1_000;
+const MAX_PENDING_CACHE_EVICTIONS = 128;
 
-function validateDurations(ttlMs: number, staleMs: number): void {
-  if (!Number.isFinite(ttlMs) || ttlMs < 0 || ttlMs > MAX_CACHE_TTL_MILLISECONDS) {
+function normalizeDurationMilliseconds(value: number, label: "ttlMs" | "staleMs"): number {
+  if (!Number.isFinite(value) || value < 0 || value > MAX_CACHE_TTL_MILLISECONDS) {
     throw new RangeError(
-      `Cache coordinator ttlMs must be between 0 and ${MAX_CACHE_TTL_MILLISECONDS}`,
+      `Cache coordinator ${label} must be between 0 and ${MAX_CACHE_TTL_MILLISECONDS}`,
     );
   }
-  if (!Number.isFinite(staleMs) || staleMs < 0 || staleMs > MAX_CACHE_TTL_MILLISECONDS) {
-    throw new RangeError(
-      `Cache coordinator staleMs must be between 0 and ${MAX_CACHE_TTL_MILLISECONDS}`,
-    );
-  }
+  return Math.ceil(value);
 }
 
 export interface CacheCoordinatorOptions {
   store?: CacheStore;
   memory?: MemoryCacheStoreOptions;
+  /** Logical freshness window in milliseconds. Zero means no logical expiration. */
   ttlMs?: number;
+  /** Stale-while-refresh window in milliseconds; ignored when `ttlMs` is zero. */
   staleMs?: number;
   /**
    * Project identifier for cache key prefixing.
@@ -71,13 +71,14 @@ export class CacheCoordinator {
   private readonly projectId: string | undefined;
   private readonly contentSourceId: string | undefined;
   private readonly cachePrefix: string;
+  private readonly pendingEvictions = new Map<string, Promise<void>>();
 
   constructor(options: CacheCoordinatorOptions = {}) {
-    const ttlMs = options.ttlMs ?? this.defaultTtlMs;
-    const staleMs = options.staleMs ?? 0;
-    validateDurations(ttlMs, staleMs);
-    this.ttlMs = ttlMs;
-    this.staleMs = staleMs;
+    this.ttlMs = normalizeDurationMilliseconds(
+      options.ttlMs ?? this.defaultTtlMs,
+      "ttlMs",
+    );
+    this.staleMs = normalizeDurationMilliseconds(options.staleMs ?? 0, "staleMs");
     this.projectId = options.projectId;
     this.contentSourceId = options.contentSourceId;
 
@@ -120,22 +121,26 @@ export class CacheCoordinator {
       async () => {
         const lookupStart = performance.now();
         const stored = await this.store.get(key);
-        const cached = stored === undefined ? undefined : parseCachePayload(stored);
+
+        if (stored === undefined) {
+          const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
+          recordCacheLookup("miss", lookupDurationMs);
+          return { depAwareSlug: slug, moduleCacheKey: key, cacheStatus: "miss", lookupDurationMs };
+        }
+
+        const cached = parseCachePayload(stored);
 
         // A stored value that fails validation is unusable; drop it so the next
         // render repopulates the key instead of replaying corrupt data.
-        if (stored !== undefined && cached === undefined) {
-          await this.evictBestEffort(key, "invalid payload");
-        }
-
-        if (!cached) {
+        if (cached === undefined) {
+          this.scheduleEviction(key, stored, "invalid payload");
           const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
           recordCacheLookup("miss", lookupDurationMs);
           return { depAwareSlug: slug, moduleCacheKey: key, cacheStatus: "miss", lookupDurationMs };
         }
 
         if (!isHtmlNonceCacheCompatible(cached.htmlNoncePlaceholder, nonce)) {
-          await this.store.delete(key);
+          this.scheduleEviction(key, stored, "nonce-incompatible payload");
           const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
           recordCacheLookup("miss", lookupDurationMs);
           return {
@@ -160,7 +165,7 @@ export class CacheCoordinator {
             };
           }
 
-          await this.evictBestEffort(key, "expired payload");
+          this.scheduleEviction(key, stored, "expired payload");
           const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
           recordCacheLookup("expired", lookupDurationMs);
           return {
@@ -207,7 +212,7 @@ export class CacheCoordinator {
             css: result.css,
             frontmatter: result.frontmatter,
             headings: result.headings,
-            nodeMap: result.nodeMap ? new Map(result.nodeMap) : undefined,
+            nodeMap: result.nodeMap,
             stream: null,
             ssrHash: result.ssrHash,
             pageModule: result.pageModule,
@@ -215,10 +220,11 @@ export class CacheCoordinator {
           ...(sealedHtml.placeholder === undefined
             ? {}
             : { htmlNoncePlaceholder: sealedHtml.placeholder }),
-          nodeMapEntries: result.nodeMap ? Array.from(result.nodeMap.entries()) : undefined,
           storedAt: now,
-          expiresAt: now + this.ttlMs,
-          staleUntil: this.staleMs > 0 ? now + this.ttlMs + this.staleMs : undefined,
+          expiresAt: this.ttlMs > 0 ? now + this.ttlMs : undefined,
+          staleUntil: this.ttlMs > 0 && this.staleMs > 0
+            ? now + this.ttlMs + this.staleMs
+            : undefined,
         };
 
         // Caching is best-effort: a result too large to snapshot, or a store
@@ -229,7 +235,7 @@ export class CacheCoordinator {
           logger.warn("[CacheCoordinator] Skipped caching render result", {
             slug,
             key,
-            reason: error instanceof Error ? error.message : String(error),
+            reason: getErrorMessage(error),
           });
         }
       },
@@ -272,16 +278,33 @@ export class CacheCoordinator {
     return typeof entry.expiresAt === "number" && Date.now() >= entry.expiresAt;
   }
 
-  private async evictBestEffort(key: string, reason: string): Promise<void> {
-    try {
-      await this.store.delete(key);
-    } catch (error) {
-      logger.warn("[CacheCoordinator] Cache eviction failed", {
-        key,
-        reason,
-        error: error instanceof Error ? error.message : String(error),
-      });
+  private scheduleEviction(key: string, expected: CachePayload, reason: string): void {
+    const deleteIfUnchanged = this.store.deleteIfUnchanged;
+    if (
+      deleteIfUnchanged === undefined ||
+      this.pendingEvictions.has(key) ||
+      this.pendingEvictions.size >= MAX_PENDING_CACHE_EVICTIONS
+    ) {
+      return;
     }
+
+    const eviction = Promise.resolve()
+      .then(async () => {
+        await deleteIfUnchanged.call(this.store, key, expected);
+      })
+      .catch((error: unknown) => {
+        logger.warn("[CacheCoordinator] Cache eviction failed", {
+          key,
+          reason,
+          error: getErrorMessage(error),
+        });
+      })
+      .finally(() => {
+        if (this.pendingEvictions.get(key) === eviction) {
+          this.pendingEvictions.delete(key);
+        }
+      });
+    this.pendingEvictions.set(key, eviction);
   }
 
   private isStaleUsable(entry: CachePayload): boolean {

--- a/src/rendering/cache/cache-coordinator.ts
+++ b/src/rendering/cache/cache-coordinator.ts
@@ -221,7 +221,17 @@ export class CacheCoordinator {
           staleUntil: this.ttlMs && this.staleMs > 0 ? now + this.ttlMs + this.staleMs : undefined,
         };
 
-        await this.store.set(key, cloneCachePayload(payload));
+        // Caching is best-effort: a result too large to snapshot, or a store
+        // that refuses the write, must not fail the render that produced it.
+        try {
+          await this.store.set(key, cloneCachePayload(payload));
+        } catch (error) {
+          logger.warn("[CacheCoordinator] Skipped caching render result", {
+            slug,
+            key,
+            reason: error instanceof Error ? error.message : String(error),
+          });
+        }
       },
       { "cache.slug": slug, "cache.key": key, "cache.projectId": this.projectId ?? "unknown" },
     );

--- a/src/rendering/cache/cache-coordinator.ts
+++ b/src/rendering/cache/cache-coordinator.ts
@@ -65,8 +65,8 @@ export interface CacheLookupResult {
 
 export class CacheCoordinator {
   private store: CacheStore;
-  private ttlMs: number | undefined;
-  private staleMs: number;
+  private readonly ttlMs: number;
+  private readonly staleMs: number;
   private readonly defaultTtlMs = DEFAULT_CACHE_TTL_MS;
   private readonly projectId: string | undefined;
   private readonly contentSourceId: string | undefined;
@@ -125,7 +125,7 @@ export class CacheCoordinator {
         // A stored value that fails validation is unusable; drop it so the next
         // render repopulates the key instead of replaying corrupt data.
         if (stored !== undefined && cached === undefined) {
-          await this.store.delete(key);
+          await this.evictBestEffort(key, "invalid payload");
         }
 
         if (!cached) {
@@ -160,7 +160,7 @@ export class CacheCoordinator {
             };
           }
 
-          await this.store.delete(key);
+          await this.evictBestEffort(key, "expired payload");
           const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
           recordCacheLookup("expired", lookupDurationMs);
           return {
@@ -217,8 +217,8 @@ export class CacheCoordinator {
             : { htmlNoncePlaceholder: sealedHtml.placeholder }),
           nodeMapEntries: result.nodeMap ? Array.from(result.nodeMap.entries()) : undefined,
           storedAt: now,
-          expiresAt: this.ttlMs ? now + this.ttlMs : undefined,
-          staleUntil: this.ttlMs && this.staleMs > 0 ? now + this.ttlMs + this.staleMs : undefined,
+          expiresAt: now + this.ttlMs,
+          staleUntil: this.staleMs > 0 ? now + this.ttlMs + this.staleMs : undefined,
         };
 
         // Caching is best-effort: a result too large to snapshot, or a store
@@ -269,7 +269,19 @@ export class CacheCoordinator {
   }
 
   private isExpired(entry: CachePayload): boolean {
-    return typeof entry.expiresAt === "number" && Date.now() > entry.expiresAt;
+    return typeof entry.expiresAt === "number" && Date.now() >= entry.expiresAt;
+  }
+
+  private async evictBestEffort(key: string, reason: string): Promise<void> {
+    try {
+      await this.store.delete(key);
+    } catch (error) {
+      logger.warn("[CacheCoordinator] Cache eviction failed", {
+        key,
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private isStaleUsable(entry: CachePayload): boolean {

--- a/src/rendering/cache/cache-payload.test.ts
+++ b/src/rendering/cache/cache-payload.test.ts
@@ -70,6 +70,48 @@ describe("rendering/cache/cache-payload", () => {
     assertThrows(() => serializeCachePayload(payload), TypeError, "value is too large");
   });
 
+  it("rejects oversized node-map arrays before walking their entries", () => {
+    const payload = payloadWithNodeMap();
+    let ordinaryLengthReads = 0;
+    let lengthDescriptorReads = 0;
+    let indexDescriptorReads = 0;
+    const oversized = new Proxy(new Array(100_001), {
+      get(target, key, receiver) {
+        if (key === "length") ordinaryLengthReads++;
+        return Reflect.get(target, key, receiver);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        if (key === "length") lengthDescriptorReads++;
+        if (typeof key === "string" && /^\d+$/.test(key)) {
+          indexDescriptorReads++;
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    });
+    payload.nodeMapEntries = oversized as Array<[number, unknown]>;
+
+    assertEquals(parseCachePayload(payload), undefined);
+    assertEquals(ordinaryLengthReads, 0);
+    assertEquals(lengthDescriptorReads, 1);
+    assertEquals(indexDescriptorReads, 0);
+  });
+
+  it("reads node-map pair lengths without invoking ordinary property access", () => {
+    const payload = payloadWithNodeMap();
+    let ordinaryLengthReads = 0;
+    const pair = new Proxy<[number, unknown]>([1, { safe: true }], {
+      get(target, key, receiver) {
+        if (key === "length") ordinaryLengthReads++;
+        return Reflect.get(target, key, receiver);
+      },
+    });
+    payload.nodeMapEntries = [pair];
+    payload.result.nodeMap = new Map([[1, { safe: true }]]);
+
+    assertEquals(parseCachePayload(payload)?.nodeMapEntries, [[1, { safe: true }]]);
+    assertEquals(ordinaryLengthReads, 0);
+  });
+
   it("round-trips detached Date values without changing cached frontmatter", () => {
     const payload = payloadWithNodeMap();
     const publicationDate = new Date("2026-07-24T08:30:00.000Z");

--- a/src/rendering/cache/cache-payload.test.ts
+++ b/src/rendering/cache/cache-payload.test.ts
@@ -42,6 +42,34 @@ describe("rendering/cache/cache-payload", () => {
     );
   });
 
+  it("charges compatibility node-map projections only once", () => {
+    const payload = payloadWithNodeMap();
+    const entries = Array.from(
+      { length: 50_000 },
+      (_, index): [number, unknown] => [index, {}],
+    );
+    payload.nodeMapEntries = entries;
+    payload.result.nodeMap = new Map(entries);
+
+    const serialized = serializeCachePayload(payload);
+    const parsed = parseSerializedCachePayload(serialized);
+
+    assertEquals(parsed?.nodeMapEntries?.length, entries.length);
+    assertEquals(parsed?.result.nodeMap?.size, entries.length);
+  });
+
+  it("still rejects node maps beyond the logical node budget", () => {
+    const payload = payloadWithNodeMap();
+    const entries = Array.from(
+      { length: 100_000 },
+      (_, index): [number, unknown] => [index, {}],
+    );
+    payload.nodeMapEntries = entries;
+    payload.result.nodeMap = new Map(entries);
+
+    assertThrows(() => serializeCachePayload(payload), TypeError, "value is too large");
+  });
+
   it("round-trips detached Date values without changing cached frontmatter", () => {
     const payload = payloadWithNodeMap();
     const publicationDate = new Date("2026-07-24T08:30:00.000Z");

--- a/src/rendering/cache/cache-payload.ts
+++ b/src/rendering/cache/cache-payload.ts
@@ -175,12 +175,19 @@ function cloneNodeMapEntries(
       }
       if (seen.has(key)) fail("nodeMap contains duplicate keys");
       seen.add(key);
+      return [key, rawValue];
+    });
+  };
 
-      const value = cloneJsonValue(rawValue, state, 1);
+  const cloneEntries = (
+    entries: Array<[number, unknown]>,
+    cloneState: CloneState,
+  ): Array<[number, unknown]> =>
+    entries.map(([key, rawValue]) => {
+      const value = cloneJsonValue(rawValue, cloneState, 1);
       if (value === undefined) fail("nodeMap values cannot be undefined");
       return [key, value];
     });
-  };
 
   const readEntries = (
     rawNodeMapEntries: unknown,
@@ -211,14 +218,7 @@ function cloneNodeMapEntries(
     ownDataValue(result, "nodeMapEntries"),
     "result.nodeMapEntries",
   );
-  if (
-    topLevelEntries !== undefined &&
-    nestedEntries !== undefined &&
-    !nodeMapEntriesEqual(topLevelEntries, nestedEntries)
-  ) {
-    fail("nodeMapEntries conflicts with result.nodeMapEntries");
-  }
-  const serialized = topLevelEntries ?? nestedEntries;
+  const serializedEntries = topLevelEntries ?? nestedEntries;
 
   let resultEntries: Array<[number, unknown]> | undefined;
   const rawResultNodeMap = ownDataValue(result, "nodeMap");
@@ -229,21 +229,50 @@ function cloneNodeMapEntries(
     const keys = Object.keys(rawResultNodeMap);
     // JSON.stringify(Map) produced this exact empty record in origin/main.
     // Prefer the explicit entries array when it is present.
-    if (keys.length > 0 || serialized === undefined) {
+    if (keys.length > 0 || serializedEntries === undefined) {
       resultEntries = normalize(
         keys.map((key) => [key, ownDataValue(rawResultNodeMap, key)]),
       );
     }
   }
 
-  if (
-    serialized !== undefined && resultEntries !== undefined &&
-    !nodeMapEntriesEqual(serialized, resultEntries)
-  ) {
-    fail("nodeMapEntries conflicts with result.nodeMap");
-  }
+  const canonicalRaw = serializedEntries ?? resultEntries;
+  if (canonicalRaw === undefined) return undefined;
 
-  return serialized ?? resultEntries;
+  // Compatibility payloads can contain the same logical node map in three
+  // representations. Charge the canonical data to the payload budget once,
+  // then validate each duplicate independently before comparing it. This
+  // preserves the limit without rejecting valid data merely because an older
+  // reader requires an additional projection on the wire.
+  const canonical = cloneEntries(canonicalRaw, state);
+  const assertCompatible = (
+    candidate: Array<[number, unknown]> | undefined,
+    message: string,
+  ): void => {
+    if (candidate === undefined || candidate === canonicalRaw) return;
+    const validationState: CloneState = {
+      nodes: 0,
+      stringBytes: 0,
+      ancestors: new WeakSet<object>(),
+    };
+    const validated = cloneEntries(candidate, validationState);
+    if (!nodeMapEntriesEqual(canonical, validated)) fail(message);
+  };
+
+  assertCompatible(
+    topLevelEntries,
+    "nodeMapEntries conflicts with the canonical node map",
+  );
+  assertCompatible(
+    nestedEntries,
+    "result.nodeMapEntries conflicts with the canonical node map",
+  );
+  assertCompatible(
+    resultEntries,
+    "result.nodeMap conflicts with the canonical node map",
+  );
+
+  return canonical;
 }
 
 function nodeMapEntriesEqual(

--- a/src/rendering/cache/cache-payload.ts
+++ b/src/rendering/cache/cache-payload.ts
@@ -714,10 +714,13 @@ function applyCacheDatePaths(
       fail("cache codec nodeMap Date path does not resolve");
     }
     const valuePath = path.slice(2);
-    entry[1] = replaceDateAtPath(entry[1], valuePath);
+    const serializedValue = entry[1];
+    const mapValue = payload.result.nodeMap.get(nodeId);
+    const hydratedValue = replaceDateAtPath(serializedValue, valuePath);
+    entry[1] = hydratedValue;
     payload.result.nodeMap.set(
       nodeId,
-      replaceDateAtPath(payload.result.nodeMap.get(nodeId), valuePath),
+      mapValue === serializedValue ? hydratedValue : replaceDateAtPath(mapValue, valuePath),
     );
   }
   return payload;
@@ -855,13 +858,9 @@ function buildCachePayload(value: unknown): CachePayload {
     fail("staleUntil cannot precede expiry");
   }
 
-  const resultNodeMap = nodeMapEntries === undefined ? undefined : new Map<number, unknown>(
-    nodeMapEntries.map(([key, entry]) => {
-      const cloned = cloneJsonValue(entry, state, 1);
-      if (cloned === undefined) fail("nodeMap values cannot be undefined");
-      return [key, cloned];
-    }),
-  );
+  const resultNodeMap = nodeMapEntries === undefined
+    ? undefined
+    : new Map<number, unknown>(nodeMapEntries);
 
   return {
     result: {
@@ -878,9 +877,7 @@ function buildCachePayload(value: unknown): CachePayload {
     storedAt,
     ...(expiresAt === undefined ? {} : { expiresAt }),
     ...(staleUntil === undefined ? {} : { staleUntil }),
-    ...(nodeMapEntries === undefined
-      ? {}
-      : { nodeMapEntries: nodeMapEntries.map(([key, entry]) => [key, entry]) }),
+    ...(nodeMapEntries === undefined ? {} : { nodeMapEntries }),
   };
 }
 

--- a/src/rendering/cache/cache-payload.ts
+++ b/src/rendering/cache/cache-payload.ts
@@ -195,12 +195,23 @@ function cloneNodeMapEntries(
   ): Array<[number, unknown]> | undefined => {
     if (rawNodeMapEntries === undefined) return undefined;
     if (!Array.isArray(rawNodeMapEntries)) fail(`${label} must be an array`);
+    const length = ownDataValue(rawNodeMapEntries, "length");
+    if (
+      typeof length !== "number" || !Number.isSafeInteger(length) ||
+      length < 0
+    ) {
+      fail(`${label} has an invalid length`);
+    }
+    if (length > MAX_NODE_MAP_ENTRIES) {
+      fail("nodeMap contains too many entries");
+    }
     const entries: Array<[unknown, unknown]> = [];
-    for (let index = 0; index < rawNodeMapEntries.length; index++) {
+    for (let index = 0; index < length; index++) {
       if (!Object.hasOwn(rawNodeMapEntries, index)) fail(`${label} is sparse`);
       const entry = ownDataValue(rawNodeMapEntries, index);
       if (
-        !Array.isArray(entry) || entry.length !== 2 || !Object.hasOwn(entry, 0) ||
+        !Array.isArray(entry) || ownDataValue(entry, "length") !== 2 ||
+        !Object.hasOwn(entry, 0) ||
         !Object.hasOwn(entry, 1)
       ) {
         fail(`${label} must contain complete [number, value] pairs`);
@@ -223,10 +234,23 @@ function cloneNodeMapEntries(
   let resultEntries: Array<[number, unknown]> | undefined;
   const rawResultNodeMap = ownDataValue(result, "nodeMap");
   if (rawResultNodeMap instanceof Map) {
-    resultEntries = normalize([...Map.prototype.entries.call(rawResultNodeMap)]);
+    const entries: Array<[unknown, unknown]> = [];
+    Map.prototype.forEach.call(
+      rawResultNodeMap,
+      (rawValue: unknown, rawKey: unknown) => {
+        if (entries.length >= MAX_NODE_MAP_ENTRIES) {
+          fail("nodeMap contains too many entries");
+        }
+        entries.push([rawKey, rawValue]);
+      },
+    );
+    resultEntries = normalize(entries);
   } else if (rawResultNodeMap !== undefined) {
     if (!isPlainRecord(rawResultNodeMap)) fail("result.nodeMap must be a Map or record");
     const keys = Object.keys(rawResultNodeMap);
+    if (keys.length > MAX_NODE_MAP_ENTRIES) {
+      fail("nodeMap contains too many entries");
+    }
     // JSON.stringify(Map) produced this exact empty record in origin/main.
     // Prefer the explicit entries array when it is present.
     if (keys.length > 0 || serializedEntries === undefined) {

--- a/src/rendering/cache/stores/api-store.test.ts
+++ b/src/rendering/cache/stores/api-store.test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { withTimeoutThrow } from "../../utils/stream-utils.ts";
 import { APICacheStore } from "./api-store.ts";
+import type { CachePayload } from "../types.ts";
 
 async function withStoreTtlEnabled(fn: () => Promise<void>): Promise<void> {
   const previousGlobal = (globalThis as Record<string, unknown>).__vfDisableLruInterval;
@@ -76,125 +77,6 @@ describe("rendering/cache/stores/api-store", () => {
     it("should delete without error", async () => {
       const store = new APICacheStore();
       await store.delete("some-key");
-    });
-  });
-
-  describe("serialize/deserialize round-trip", () => {
-    interface TestPayload {
-      result: {
-        html: string;
-        css?: string;
-        frontmatter: Record<string, unknown>;
-        headings?: Array<{ id: string; text: string; level: number }>;
-        nodeMap?: Map<number, unknown>;
-        stream: null;
-        pageModule?: { slug: string; code: string; type: "mdx" | "component" };
-        ssrHash?: string;
-      };
-      storedAt: number;
-      expiresAt?: number;
-      staleUntil?: number;
-      htmlNoncePlaceholder?: string;
-    }
-
-    function makePayload(overrides: Record<string, unknown> = {}): TestPayload {
-      return {
-        result: {
-          html: "<h1>Test</h1>",
-          frontmatter: { title: "Test" },
-          headings: [],
-          stream: null,
-          ...overrides,
-        },
-        storedAt: Date.now(),
-      };
-    }
-
-    it("round-trips basic HTML payload", () => {
-      const store = new APICacheStore();
-      const payload = makePayload();
-      const serialized = (store as any).serialize(payload);
-      const deserialized = (store as any).deserialize(serialized);
-      assertEquals(deserialized.result.html, "<h1>Test</h1>");
-      assertEquals(deserialized.result.frontmatter.title, "Test");
-      assertEquals(deserialized.storedAt, payload.storedAt);
-    });
-
-    it("round-trips payload with nodeMap", () => {
-      const store = new APICacheStore();
-      const nodeMap = new Map<number, unknown>([
-        [1, { type: "div" }],
-        [2, { type: "span" }],
-      ]);
-      const payload = makePayload({ nodeMap });
-      const serialized = (store as any).serialize(payload);
-      const deserialized = (store as any).deserialize(serialized);
-      assertEquals(deserialized.result.nodeMap instanceof Map, true);
-      assertEquals(deserialized.result.nodeMap.size, 2);
-      assertEquals(
-        (deserialized.result.nodeMap.get(1) as Record<string, string>).type,
-        "div",
-      );
-    });
-
-    it("round-trips payload with ssrHash and css", () => {
-      const store = new APICacheStore();
-      const payload = makePayload({ ssrHash: "hash123", css: "body{}" });
-      const serialized = (store as any).serialize(payload);
-      const deserialized = (store as any).deserialize(serialized);
-      assertEquals(deserialized.result.ssrHash, "hash123");
-      assertEquals(deserialized.result.css, "body{}");
-    });
-
-    it("round-trips cache-owned CSP nonce metadata", () => {
-      const store = new APICacheStore();
-      const payload = {
-        ...makePayload(),
-        htmlNoncePlaceholder: `vf-cache-${"a".repeat(48)}`,
-      };
-      const serialized = (store as any).serialize(payload);
-      const deserialized = (store as any).deserialize(serialized);
-      assertEquals(deserialized.htmlNoncePlaceholder, payload.htmlNoncePlaceholder);
-    });
-
-    it("round-trips payload with pageModule", () => {
-      const store = new APICacheStore();
-      const payload = makePayload({
-        pageModule: { slug: "index", code: "export default {}", type: "mdx" as const },
-      });
-      const serialized = (store as any).serialize(payload);
-      const deserialized = (store as any).deserialize(serialized);
-      assertEquals(deserialized.result.pageModule.slug, "index");
-      assertEquals(deserialized.result.pageModule.type, "mdx");
-    });
-
-    it("deserializes stream as null (streams are not cacheable)", () => {
-      const store = new APICacheStore();
-      const payload = makePayload();
-      const serialized = (store as any).serialize(payload);
-      const deserialized = (store as any).deserialize(serialized);
-      assertEquals(deserialized.result.stream, null);
-    });
-
-    it("preserves expiresAt field", () => {
-      const store = new APICacheStore();
-      const payload = { ...makePayload(), expiresAt: Date.now() + 60000 };
-      const serialized = (store as any).serialize(payload);
-      const deserialized = (store as any).deserialize(serialized);
-      assertEquals(deserialized.expiresAt, payload.expiresAt);
-    });
-
-    it("preserves staleUntil field for stale-while-refresh cache entries", () => {
-      const store = new APICacheStore();
-      const payload = {
-        ...makePayload(),
-        expiresAt: Date.now() - 1,
-        staleUntil: Date.now() + 60_000,
-      };
-      const serialized = (store as any).serialize(payload);
-      const deserialized = (store as any).deserialize(serialized);
-      assertEquals(deserialized.expiresAt, payload.expiresAt);
-      assertEquals(deserialized.staleUntil, payload.staleUntil);
     });
   });
 
@@ -377,6 +259,74 @@ describe("rendering/cache/stores/api-store", () => {
           } else {
             globals.__vf_multi_project_adapter = originalAdapter;
           }
+        }
+      }
+    });
+
+    it("preserves Dates through an actual API backend round-trip", async () => {
+      const previousApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
+      const previousApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      const globals = globalThis as Record<string, unknown>;
+      const originalAdapter = globals.__vf_multi_project_adapter;
+      const values = new Map<string, string>();
+      const server = Deno.serve(
+        { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+        async (request) => {
+          const url = new URL(request.url);
+          if (url.pathname === "/projects/api-store-date-project/cache/set") {
+            const body = await request.json() as { key: string; value: string };
+            values.set(body.key, body.value);
+            return Response.json({ success: true });
+          }
+          if (url.pathname === "/projects/api-store-date-project/cache/get") {
+            return Response.json({ value: values.get(url.searchParams.get("key") ?? "") ?? null });
+          }
+          return Response.json({ error: "not found" }, { status: 404 });
+        },
+      );
+      const addr = server.addr as Deno.NetAddr;
+      Deno.env.set("VERYFRONT_API_BASE_URL", `http://${addr.hostname}:${addr.port}`);
+      Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+      globals.__vf_multi_project_adapter = {
+        getCurrentRequestContext: () => ({
+          token: "request-token",
+          projectSlug: "api-store-date-project",
+          productionMode: true,
+        }),
+      };
+      const store = new APICacheStore({ enableLocalCache: false });
+      const publishedAt = new Date("2026-07-24T08:30:00.000Z");
+      const payload: CachePayload = {
+        result: {
+          html: "<p>dated</p>",
+          frontmatter: { publishedAt } as unknown as CachePayload["result"]["frontmatter"],
+          stream: null,
+        },
+        storedAt: Date.now(),
+      };
+
+      try {
+        await store.set("dated-key", payload);
+        const result = await store.get("dated-key");
+
+        assertEquals(result?.result.frontmatter as unknown, { publishedAt });
+      } finally {
+        await store.destroy();
+        await server.shutdown();
+        if (previousApiBaseUrl === undefined) {
+          Deno.env.delete("VERYFRONT_API_BASE_URL");
+        } else {
+          Deno.env.set("VERYFRONT_API_BASE_URL", previousApiBaseUrl);
+        }
+        if (previousApiToken === undefined) {
+          Deno.env.delete("VERYFRONT_API_TOKEN");
+        } else {
+          Deno.env.set("VERYFRONT_API_TOKEN", previousApiToken);
+        }
+        if (originalAdapter === undefined) {
+          delete globals.__vf_multi_project_adapter;
+        } else {
+          globals.__vf_multi_project_adapter = originalAdapter;
         }
       }
     });

--- a/src/rendering/cache/stores/api-store.ts
+++ b/src/rendering/cache/stores/api-store.ts
@@ -2,6 +2,7 @@ import type { CachePayload, CacheStore, CacheStoreStats } from "../types.ts";
 import { MemoryCacheStore } from "./memory-store.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { type CacheBackend, createCacheBackend } from "#veryfront/cache/backend.ts";
+import { parseSerializedCachePayload, serializeCachePayload } from "../cache-payload.ts";
 
 const logger = rendererLogger.component("api-cache-store");
 
@@ -19,30 +20,6 @@ export interface APICacheStoreOptions {
   localMaxEntries?: number;
   /** Disable local memory cache (no in-memory fallback) */
   enableLocalCache?: boolean;
-}
-
-/**
- * Serializable version of CachePayload for JSON storage
- */
-interface SerializedCachePayload {
-  result: {
-    html: string;
-    css?: string;
-    frontmatter: Record<string, unknown>;
-    headings?: Array<{ id: string; text: string; level: number }>;
-    // nodeMap serialized as array of [key, value] pairs
-    nodeMapEntries?: Array<[number, unknown]>;
-    pageModule?: {
-      slug: string;
-      code: string;
-      type: "mdx" | "component";
-    };
-    ssrHash?: string;
-  };
-  htmlNoncePlaceholder?: string;
-  storedAt: number;
-  expiresAt?: number;
-  staleUntil?: number;
 }
 
 export class APICacheStore implements CacheStore {
@@ -93,51 +70,6 @@ export class APICacheStore implements CacheStore {
     return this.backendInitPromise;
   }
 
-  private serialize(payload: CachePayload): string {
-    const serialized: SerializedCachePayload = {
-      result: {
-        html: payload.result.html,
-        css: payload.result.css,
-        frontmatter: payload.result.frontmatter as Record<string, unknown>,
-        headings: payload.result.headings,
-        nodeMapEntries: payload.result.nodeMap
-          ? Array.from(payload.result.nodeMap.entries())
-          : undefined,
-        pageModule: payload.result.pageModule,
-        ssrHash: payload.result.ssrHash,
-      },
-      htmlNoncePlaceholder: payload.htmlNoncePlaceholder,
-      storedAt: payload.storedAt,
-      expiresAt: payload.expiresAt,
-      staleUntil: payload.staleUntil,
-    };
-
-    return JSON.stringify(serialized);
-  }
-
-  private deserialize(json: string): CachePayload {
-    const serialized = JSON.parse(json) as SerializedCachePayload;
-
-    return {
-      result: {
-        html: serialized.result.html,
-        css: serialized.result.css,
-        frontmatter: serialized.result.frontmatter as CachePayload["result"]["frontmatter"],
-        headings: serialized.result.headings,
-        nodeMap: serialized.result.nodeMapEntries
-          ? new Map(serialized.result.nodeMapEntries)
-          : undefined,
-        stream: null, // Streams can't be serialized
-        pageModule: serialized.result.pageModule,
-        ssrHash: serialized.result.ssrHash,
-      },
-      htmlNoncePlaceholder: serialized.htmlNoncePlaceholder,
-      storedAt: serialized.storedAt,
-      expiresAt: serialized.expiresAt,
-      staleUntil: serialized.staleUntil,
-    };
-  }
-
   async get(key: string): Promise<CachePayload | undefined> {
     const local = await this.localCache?.get(key);
     if (local) return local;
@@ -147,7 +79,8 @@ export class APICacheStore implements CacheStore {
       const json = await backend.get(key);
       if (!json) return undefined;
 
-      const payload = this.deserialize(json);
+      const payload = parseSerializedCachePayload(json);
+      if (payload === undefined) return undefined;
       await this.localCache?.set(key, payload);
       logger.debug("Distributed cache hit", { key });
       return payload;
@@ -167,7 +100,7 @@ export class APICacheStore implements CacheStore {
 
     try {
       const backend = await this.getBackend();
-      await backend.set(key, this.serialize(value), this.resolveBackendTtlSeconds(value));
+      await backend.set(key, serializeCachePayload(value), this.resolveBackendTtlSeconds(value));
     } catch (error) {
       logger.debug(
         "[APICacheStore] Failed to store in distributed cache (no fallback)",

--- a/src/rendering/cache/stores/filesystem-store.test.ts
+++ b/src/rendering/cache/stores/filesystem-store.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { FilesystemCacheStore } from "./filesystem-store.ts";
+import type { CachePayload } from "../types.ts";
 
 describe("rendering/cache/stores/filesystem-store", () => {
   describe("FilesystemCacheStore constructor", () => {
@@ -34,6 +35,33 @@ describe("rendering/cache/stores/filesystem-store", () => {
       await store.set("test-key", payload as any);
       const result = await store.get("test-key");
       assertEquals(result?.result?.html, "<p>test</p>");
+    });
+
+    it("preserves Dates through an actual file round-trip", async () => {
+      const dir = baseDir + "-dates";
+      const store = new FilesystemCacheStore({ baseDir: dir });
+      const publishedAt = new Date("2026-07-24T08:30:00.000Z");
+      const payload: CachePayload = {
+        result: {
+          html: "<p>dated</p>",
+          frontmatter: { publishedAt } as unknown as CachePayload["result"]["frontmatter"],
+          nodeMap: new Map([[1, { revisedAt: new Date("2026-07-25T09:45:00.000Z") }]]),
+          stream: null,
+        },
+        storedAt: Date.now(),
+      };
+
+      try {
+        await store.set("dated-key", payload);
+        const result = await store.get("dated-key");
+
+        assertEquals(result?.result.frontmatter as unknown, { publishedAt });
+        assertEquals(result?.result.nodeMap?.get(1), {
+          revisedAt: new Date("2026-07-25T09:45:00.000Z"),
+        });
+      } finally {
+        await store.destroy();
+      }
     });
 
     it("should delete a value", async () => {

--- a/src/rendering/cache/stores/filesystem-store.ts
+++ b/src/rendering/cache/stores/filesystem-store.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "#veryfront/compat/path";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { CachePayload, CacheStore } from "../types.ts";
+import { parseSerializedCachePayload, serializeCachePayload } from "../cache-payload.ts";
 
 export interface FilesystemCacheStoreOptions {
   baseDir: string;
@@ -25,12 +26,7 @@ export class FilesystemCacheStore implements CacheStore {
     const file = await this.readFileForKey(key);
     if (!file) return undefined;
 
-    try {
-      return JSON.parse(file) as CachePayload;
-    } catch (_) {
-      /* expected: cached file may contain malformed JSON */
-      return undefined;
-    }
+    return parseSerializedCachePayload(file);
   }
 
   async set(key: string, value: CachePayload): Promise<void> {
@@ -38,7 +34,7 @@ export class FilesystemCacheStore implements CacheStore {
     await this.ensureDir(dirname(filePath));
 
     const fs = await this.getLocalFS();
-    await fs.writeFile(filePath, JSON.stringify(value));
+    await fs.writeFile(filePath, serializeCachePayload(value));
   }
 
   async delete(key: string): Promise<void> {

--- a/src/rendering/cache/stores/memory-store.test.ts
+++ b/src/rendering/cache/stores/memory-store.test.ts
@@ -31,6 +31,20 @@ describe("rendering/cache/stores/memory-store", () => {
       assertEquals(await store.get("key1"), undefined);
     });
 
+    it("should compare-delete without removing a replacement", async () => {
+      const store = new MemoryCacheStore();
+      const observed = makePayload("observed");
+      const replacement = makePayload("replacement");
+      await store.set("key1", observed);
+      const read = await store.get("key1");
+      await store.set("key1", replacement);
+
+      assertEquals(await store.deleteIfUnchanged("key1", read!), false);
+      assertEquals(await store.get("key1"), replacement);
+      assertEquals(await store.deleteIfUnchanged("key1", replacement), true);
+      assertEquals(await store.get("key1"), undefined);
+    });
+
     it("should delete by prefix", async () => {
       const store = new MemoryCacheStore();
       await store.set("proj:a:page1", makePayload("a1"));

--- a/src/rendering/cache/stores/memory-store.ts
+++ b/src/rendering/cache/stores/memory-store.ts
@@ -62,6 +62,12 @@ export class MemoryCacheStore implements CacheStore {
     return Promise.resolve();
   }
 
+  deleteIfUnchanged(key: string, expected: CachePayload): Promise<boolean> {
+    if (this.cache.get(key) !== expected) return Promise.resolve(false);
+    this.cache.delete(key);
+    return Promise.resolve(true);
+  }
+
   deleteByPrefix(prefix: string): Promise<number> {
     let deleted = 0;
 

--- a/src/rendering/cache/stores/redis-store.test.ts
+++ b/src/rendering/cache/stores/redis-store.test.ts
@@ -196,6 +196,93 @@ describe("RedisCacheStore", () => {
       }
     });
 
+    it("compare-deletes the exact legacy bytes returned by get", async () => {
+      const legacyPayload = {
+        result: {
+          html: "<p>legacy</p>",
+          frontmatter: { source: "legacy" },
+          stream: null,
+        },
+        storedAt: 1_000,
+      };
+      let raw: string | null = JSON.stringify(legacyPayload);
+      let compared: string | undefined;
+      const client: RedisClient = {
+        ...createRedisClient(),
+        get: () => Promise.resolve(raw),
+        eval: (_script, options) => {
+          compared = options.arguments[0];
+          if (raw === compared) {
+            raw = null;
+            return Promise.resolve(1);
+          }
+          return Promise.resolve(0);
+        },
+      };
+      register(
+        RedisRuntimeProviderName,
+        createRedisProvider(client, () => Promise.resolve()),
+      );
+      const store = createStore({ keyPrefix: "render:" });
+
+      try {
+        const observed = await store.get("legacy-key");
+        assertExists(observed);
+        assertEquals(observed.result.html, "<p>legacy</p>");
+
+        raw = JSON.stringify({
+          ...legacyPayload,
+          result: { ...legacyPayload.result, html: "<p>replacement</p>" },
+        });
+        assertEquals(await store.deleteIfUnchanged("legacy-key", observed), false);
+        assertEquals(compared, JSON.stringify(legacyPayload));
+
+        raw = JSON.stringify(legacyPayload);
+        assertEquals(await store.deleteIfUnchanged("legacy-key", observed), true);
+        assertEquals(compared, JSON.stringify(legacyPayload));
+        assertEquals(raw, null);
+      } finally {
+        await store.destroy();
+        unregister(RedisRuntimeProviderName);
+      }
+    });
+
+    it("uses canonical bytes for independently constructed expectations", async () => {
+      const expected: CachePayload = {
+        result: { html: "<p>canonical</p>", frontmatter: {}, stream: null },
+        storedAt: 1_000,
+      };
+      let raw: string | null = null;
+      const client: RedisClient = {
+        ...createRedisClient(),
+        set: (_key, value) => {
+          raw = value;
+          return Promise.resolve("OK");
+        },
+        eval: (_script, options) => {
+          if (raw === options.arguments[0]) {
+            raw = null;
+            return Promise.resolve(1);
+          }
+          return Promise.resolve(0);
+        },
+      };
+      register(
+        RedisRuntimeProviderName,
+        createRedisProvider(client, () => Promise.resolve()),
+      );
+      const store = createStore({ keyPrefix: "render:" });
+
+      try {
+        await store.set("canonical-key", expected);
+        assertEquals(await store.deleteIfUnchanged("canonical-key", expected), true);
+        assertEquals(raw, null);
+      } finally {
+        await store.destroy();
+        unregister(RedisRuntimeProviderName);
+      }
+    });
+
     it("uses object-shaped SCAN results and closes its owned connection", async () => {
       const scanResults = [
         { cursor: 3, keys: ["render:a"] },

--- a/src/rendering/cache/stores/redis-store.test.ts
+++ b/src/rendering/cache/stores/redis-store.test.ts
@@ -283,6 +283,43 @@ describe("RedisCacheStore", () => {
       }
     });
 
+    it("recognizes only exact successful Redis integer replies", async () => {
+      const expected: CachePayload = {
+        result: { html: "<p>expected</p>", frontmatter: {}, stream: null },
+        storedAt: 1_000,
+      };
+      const cases: Array<[unknown, boolean]> = [
+        [1, true],
+        ["1", true],
+        [1n, true],
+        [0, false],
+        ["0", false],
+        [true, false],
+      ];
+
+      for (const [reply, expectedResult] of cases) {
+        const client: RedisClient = {
+          ...createRedisClient(),
+          eval: () => Promise.resolve(reply),
+        };
+        register(
+          RedisRuntimeProviderName,
+          createRedisProvider(client, () => Promise.resolve()),
+        );
+        const store = createStore({ keyPrefix: "render:" });
+
+        try {
+          assertEquals(
+            await store.deleteIfUnchanged("reply-key", expected),
+            expectedResult,
+          );
+        } finally {
+          await store.destroy();
+          unregister(RedisRuntimeProviderName);
+        }
+      }
+    });
+
     it("uses object-shaped SCAN results and closes its owned connection", async () => {
       const scanResults = [
         { cursor: 3, keys: ["render:a"] },

--- a/src/rendering/cache/stores/redis-store.test.ts
+++ b/src/rendering/cache/stores/redis-store.test.ts
@@ -4,7 +4,8 @@ import type { RedisClient, RedisRuntimeProvider } from "#veryfront/extensions/di
 import { RedisRuntimeProviderName } from "#veryfront/extensions/distributed";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { RedisCacheStore } from "./redis-store.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import type { CachePayload } from "../types.ts";
 
 async function withStoreTtlEnabled(fn: () => Promise<void>): Promise<void> {
   const previousGlobal = (globalThis as Record<string, unknown>).__vfDisableLruInterval;
@@ -134,6 +135,67 @@ describe("RedisCacheStore", () => {
   });
 
   describe("extension-owned Redis connection", () => {
+    it("preserves Dates and compare-deletes only the observed value", async () => {
+      let raw: string | null = null;
+      const client: RedisClient = {
+        ...createRedisClient(),
+        get: () => Promise.resolve(raw),
+        set: (_key, value) => {
+          raw = value;
+          return Promise.resolve("OK");
+        },
+        eval: (_script, options) => {
+          if (raw === options.arguments[0]) {
+            raw = null;
+            return Promise.resolve(1);
+          }
+          return Promise.resolve(0);
+        },
+      };
+      register(
+        RedisRuntimeProviderName,
+        createRedisProvider(client, () => Promise.resolve()),
+      );
+      const store = createStore({ keyPrefix: "render:" });
+      const observed: CachePayload = {
+        result: {
+          html: "<p>dated</p>",
+          frontmatter: {
+            publishedAt: new Date("2026-07-24T08:30:00.000Z"),
+          } as unknown as CachePayload["result"]["frontmatter"],
+          stream: null,
+        },
+        storedAt: Date.now(),
+      };
+      const replacement: CachePayload = {
+        result: { html: "<p>replacement</p>", frontmatter: {}, stream: null },
+        storedAt: Date.now() + 1,
+      };
+
+      try {
+        await store.set("dated-key", observed);
+        const roundTripped = await store.get("dated-key");
+        assertEquals(roundTripped?.result.frontmatter as unknown, {
+          publishedAt: new Date("2026-07-24T08:30:00.000Z"),
+        });
+
+        await store.set("dated-key", replacement);
+        assertExists(roundTripped);
+        assertEquals(
+          await store.deleteIfUnchanged("dated-key", roundTripped),
+          false,
+        );
+        const current = await store.get("dated-key");
+        assertEquals(current?.result.html, "<p>replacement</p>");
+        assertExists(current);
+        assertEquals(await store.deleteIfUnchanged("dated-key", current), true);
+        assertEquals(await store.get("dated-key"), undefined);
+      } finally {
+        await store.destroy();
+        unregister(RedisRuntimeProviderName);
+      }
+    });
+
     it("uses object-shaped SCAN results and closes its owned connection", async () => {
       const scanResults = [
         { cursor: 3, keys: ["render:a"] },

--- a/src/rendering/cache/stores/redis-store.ts
+++ b/src/rendering/cache/stores/redis-store.ts
@@ -18,6 +18,10 @@ const REDIS_CLEAR_SCAN_COUNT = 50;
 const COMPARE_AND_DELETE_SCRIPT =
   'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end';
 
+function isSuccessfulRedisDelete(value: unknown): boolean {
+  return value === 1 || value === "1" || value === 1n;
+}
+
 export interface RedisCacheStoreOptions {
   url?: string;
   keyPrefix?: string;
@@ -183,8 +187,9 @@ export class RedisCacheStore implements CacheStore {
         keys: [this.storageKey(key)],
         arguments: [comparisonValue],
       });
-      if (deleted === 1) this.observedRawByPayload.delete(expected);
-      return deleted === 1;
+      const succeeded = isSuccessfulRedisDelete(deleted);
+      if (succeeded) this.observedRawByPayload.delete(expected);
+      return succeeded;
     } catch (error) {
       this.markRedisUnavailable();
       logger.warn("compare-and-delete failed", { key, error });

--- a/src/rendering/cache/stores/redis-store.ts
+++ b/src/rendering/cache/stores/redis-store.ts
@@ -28,6 +28,7 @@ export interface RedisCacheStoreOptions {
 
 export class RedisCacheStore implements CacheStore {
   private readonly connection: OwnedRedisClientConnection;
+  private readonly observedRawByPayload = new WeakMap<CachePayload, string>();
   private readonly keyPrefix: string;
   private readonly enableFallback: boolean;
   private readonly ttlSeconds: number;
@@ -103,7 +104,9 @@ export class RedisCacheStore implements CacheStore {
       const raw = await client.get(this.storageKey(key));
       if (!raw) return undefined;
 
-      return parseSerializedCachePayload(raw);
+      const parsed = parseSerializedCachePayload(raw);
+      if (parsed !== undefined) this.observedRawByPayload.set(parsed, raw);
+      return parsed;
     } catch (error) {
       this.markRedisUnavailable();
 
@@ -124,9 +127,11 @@ export class RedisCacheStore implements CacheStore {
     try {
       const client = await this.ensureClient();
       // Apply TTL to prevent unbounded Redis growth
-      await client.set(this.storageKey(key), serializeCachePayload(value), {
+      const serialized = serializeCachePayload(value);
+      await client.set(this.storageKey(key), serialized, {
         EX: this.ttlSeconds,
       });
+      this.observedRawByPayload.set(value, serialized);
     } catch (error) {
       this.markRedisUnavailable();
 
@@ -168,10 +173,17 @@ export class RedisCacheStore implements CacheStore {
 
     try {
       const client = await this.ensureClient();
+      // Values returned by get() retain the exact bytes that were observed so
+      // compare-and-delete remains correct across serialization upgrades.
+      // Independently constructed values compare against the current canonical
+      // serialization, which is the only byte sequence they can have observed.
+      const comparisonValue = this.observedRawByPayload.get(expected) ??
+        serializeCachePayload(expected);
       const deleted = await client.eval(COMPARE_AND_DELETE_SCRIPT, {
         keys: [this.storageKey(key)],
-        arguments: [serializeCachePayload(expected)],
+        arguments: [comparisonValue],
       });
+      if (deleted === 1) this.observedRawByPayload.delete(expected);
       return deleted === 1;
     } catch (error) {
       this.markRedisUnavailable();

--- a/src/rendering/cache/stores/redis-store.ts
+++ b/src/rendering/cache/stores/redis-store.ts
@@ -3,6 +3,7 @@ import { OwnedRedisClientConnection } from "#veryfront/extensions/distributed/ow
 import type { RedisClient } from "#veryfront/extensions/distributed";
 import { rendererLogger } from "#veryfront/utils";
 import { MemoryCacheStore } from "./memory-store.ts";
+import { parseSerializedCachePayload, serializeCachePayload } from "../cache-payload.ts";
 
 const logger = rendererLogger.component("redis");
 
@@ -14,6 +15,8 @@ const FALLBACK_MAX_ENTRIES = 100;
 const REDIS_SCAN_COUNT = 100;
 /** Smaller scan batch size for clear operations (deletes each key inline) */
 const REDIS_CLEAR_SCAN_COUNT = 50;
+const COMPARE_AND_DELETE_SCRIPT =
+  'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end';
 
 export interface RedisCacheStoreOptions {
   url?: string;
@@ -100,12 +103,7 @@ export class RedisCacheStore implements CacheStore {
       const raw = await client.get(this.storageKey(key));
       if (!raw) return undefined;
 
-      try {
-        return JSON.parse(raw) as CachePayload;
-      } catch (_) {
-        /* expected: cached data may be corrupted or malformed JSON */
-        return undefined;
-      }
+      return parseSerializedCachePayload(raw);
     } catch (error) {
       this.markRedisUnavailable();
 
@@ -126,7 +124,9 @@ export class RedisCacheStore implements CacheStore {
     try {
       const client = await this.ensureClient();
       // Apply TTL to prevent unbounded Redis growth
-      await client.set(this.storageKey(key), JSON.stringify(value), { EX: this.ttlSeconds });
+      await client.set(this.storageKey(key), serializeCachePayload(value), {
+        EX: this.ttlSeconds,
+      });
     } catch (error) {
       this.markRedisUnavailable();
 
@@ -157,6 +157,26 @@ export class RedisCacheStore implements CacheStore {
 
       logger.warn("delete failed, using fallback", { key, error });
       await this.getFallbackStore().delete(key);
+    }
+  }
+
+  async deleteIfUnchanged(key: string, expected: CachePayload): Promise<boolean> {
+    if (this.shouldUseFallback()) {
+      return await this.getFallbackStore().deleteIfUnchanged(key, expected);
+    }
+    if (this.shouldSkipRedis()) return false;
+
+    try {
+      const client = await this.ensureClient();
+      const deleted = await client.eval(COMPARE_AND_DELETE_SCRIPT, {
+        keys: [this.storageKey(key)],
+        arguments: [serializeCachePayload(expected)],
+      });
+      return deleted === 1;
+    } catch (error) {
+      this.markRedisUnavailable();
+      logger.warn("compare-and-delete failed", { key, error });
+      return false;
     }
   }
 

--- a/src/rendering/cache/types.ts
+++ b/src/rendering/cache/types.ts
@@ -19,6 +19,14 @@ export interface CacheStore {
   get(key: string): Promise<CachePayload | undefined>;
   set(key: string, value: CachePayload): Promise<void>;
   delete(key: string): Promise<void>;
+  /**
+   * Delete `key` only when it still contains the value returned by `get`.
+   *
+   * Stores must implement this as an atomic compare-and-delete operation. A
+   * read followed by an unconditional delete is not sufficient because it can
+   * remove a replacement written by a concurrent render.
+   */
+  deleteIfUnchanged?(key: string, expected: CachePayload): Promise<boolean>;
   /** Delete all entries with keys starting with the given prefix */
   deleteByPrefix?(prefix: string): Promise<number>;
   clear(): Promise<void>;


### PR DESCRIPTION
Rebased onto `d4dc53b3b` (#3299) and re-derived against the current render-cache and CSP-nonce contracts.

## What changed

- Validates coordinator TTL/stale durations, rejects non-finite/out-of-range values, and rounds accepted fractional milliseconds up so valid config never produces an invalid timestamp.
- Preserves the established `ttlMs: 0` coordinator contract: no logical expiry. A stale window is ignored when no expiry exists.
- Validates and snapshots cache payloads without failing the render when caching is unavailable or the payload is not cacheable. Hostile and revoked-proxy failures are normalized safely.
- Uses the authoritative bounded cache serializer/parser in the filesystem, built-in Redis, and API render stores. Date-valued frontmatter and node-map data survive real file, Redis-client, and HTTP API round trips.
- Accounts for compatibility node-map projections once per logical payload while independently validating every duplicate representation.
- Enforces the node-map structural cap before traversal or secondary graph allocation: array lengths are captured once through data descriptors, tuple lengths avoid ordinary property access, Maps stop at entry 100,001 without spreading, and records are capped before pair materialization.
- Preserves exact Redis bytes returned by `get()` as the atomic compare-delete token, so legacy entries can be safely evicted during rolling upgrades. Independently constructed expectations use the current canonical serialization.
- Accepts only exact successful Redis delete replies (`1`, `"1"`, or `1n`) without broad coercion.
- Replaces foreground unconditional corrupt/expired cleanup with bounded, per-key-deduplicated background cleanup through atomic `deleteIfUnchanged`, so a racing refresh cannot be deleted.
- Removes redundant node-map construction and the API store's duplicate codec implementation/tests.
- Retains #3298's authenticated CSP nonce binding and applies replacement-safe cleanup to nonce-incompatible entries.

No third-party dependency was added to core; Redis remains behind the extension-owned core contract.

## Regression coverage

- fractional TTL/stale normalization and zero-TTL compatibility
- corrupt/expired entry behavior when cleanup rejects or never settles
- bounded (128), per-key-deduplicated cleanup and concurrent replacement safety
- hostile `toString` and revoked-proxy containment
- Date round trips through filesystem, Redis, and HTTP API stores
- valid 50,000-entry compatibility round trips and logical over-budget rejection
- immediate oversized proxy-array rejection with one descriptor length read and no entry walk
- descriptor-safe tuple lengths, bounded Map traversal, and pre-allocation record caps
- Redis compare-delete for current, replacement, legacy, independently constructed, and reply-type variants

## Verification

Current head: `efbb4e18a`, based on `d4dc53b3b`. Fresh independent exact-head re-review is in progress after the prior reviewer identified the pre-allocation cap issue.

- `deno test -A src/rendering/cache extensions/ext-redis/src/render-cache-store.test.ts`: 8 files, 147 steps passed
- `deno task verify:quick`: passed
- `deno task lint:test-typecheck`: passed with 0 new files
- changed production `deno check`: passed
- core dependency and module/dependency/extension boundary audits: passed
- `git diff --check`: passed
