### PR TITLE
test: synchronize async lifecycle regressions

### DIFF
--- a/src/agent/hosted/model-call-context-run-event-recorder.test.ts
+++ b/src/agent/hosted/model-call-context-run-event-recorder.test.ts
@@ -533,11 +533,14 @@ describe("agent/hosted/model-call-context-run-event-recorder", () => {
   });
 
   it("aborts the active append at the deadline and makes disposal terminal", async () => {
+    using time = new FakeTime();
     let requestCount = 0;
     let appendWasAborted = false;
     let resolveLateAppend: ((response: Response) => void) | undefined;
+    const requestStarted = Promise.withResolvers<void>();
     globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
       requestCount += 1;
+      requestStarted.resolve();
       return new Promise<Response>((resolve) => {
         resolveLateAppend = resolve;
         init?.signal?.addEventListener("abort", () => {
@@ -553,12 +556,17 @@ describe("agent/hosted/model-call-context-run-event-recorder", () => {
       metrics: metrics.result,
     });
 
-    await assertRejects(
-      () => Promise.resolve(recorder({ messages: [{ role: "system", content: "deadline" }] })),
+    const recording = Promise.resolve(
+      recorder({ messages: [{ role: "system", content: "deadline" }] }),
+    );
+    await requestStarted.promise;
+    const assertion = assertRejects(
+      () => recording,
       ModelCallContextPersistenceError,
       "timed out",
     );
-    await Promise.resolve();
+    await time.tickAsync(5);
+    await assertion;
     assertEquals(appendWasAborted, true);
     assertEquals(requestCount, 1);
     assertEquals(metrics.measurements[0]?.appendRequestCount, 1);
@@ -567,7 +575,7 @@ describe("agent/hosted/model-call-context-run-event-recorder", () => {
     await target.appendEvents([{ type: "CUSTOM", value: "after disposal" }]);
     await target.flush();
     resolveLateAppend?.(appendResponse(1, 1));
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await time.tickAsync(0);
     assertEquals(requestCount, 1);
     const finalSnapshot = target.getSnapshot();
     assertEquals(finalSnapshot.latestEventId, rejectedSnapshot.latestEventId);

--- a/src/agent/hosted/model-call-context-run-event-recorder.test.ts
+++ b/src/agent/hosted/model-call-context-run-event-recorder.test.ts
@@ -25,6 +25,26 @@ import { FakeTime } from "#std/testing/time";
 
 const encoder = new TextEncoder();
 const originalFetch = globalThis.fetch;
+const wallClockSetTimeout = globalThis.setTimeout.bind(globalThis);
+const wallClockClearTimeout = globalThis.clearTimeout.bind(globalThis);
+
+async function withWallClockTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = wallClockSetTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutId !== undefined) {
+      wallClockClearTimeout(timeoutId);
+    }
+  }
+}
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -559,7 +579,19 @@ describe("agent/hosted/model-call-context-run-event-recorder", () => {
     const recording = Promise.resolve(
       recorder({ messages: [{ role: "system", content: "deadline" }] }),
     );
-    await requestStarted.promise;
+    const recordingSettledBeforeRequest = recording.then(
+      () => {
+        throw new Error("model-call recording completed before its append request started");
+      },
+      (error) => {
+        throw error;
+      },
+    );
+    await withWallClockTimeout(
+      Promise.race([requestStarted.promise, recordingSettledBeforeRequest]),
+      10_000,
+      "model-call append request did not start",
+    );
     const assertion = assertRejects(
       () => recording,
       ModelCallContextPersistenceError,

--- a/src/rendering/cache/stores/api-store.test.ts
+++ b/src/rendering/cache/stores/api-store.test.ts
@@ -296,8 +296,8 @@ describe("rendering/cache/stores/api-store", () => {
       const globals = globalThis as Record<string, unknown>;
       const originalAdapter = globals.__vf_multi_project_adapter;
 
-      let releaseSet: () => void = () => {};
-      let setStarted = false;
+      const setStarted = Promise.withResolvers<void>();
+      const releaseSet = Promise.withResolvers<void>();
       let setCompleted = false;
       const server = Deno.serve(
         { hostname: "127.0.0.1", port: 0, onListen: () => {} },
@@ -310,10 +310,8 @@ describe("rendering/cache/stores/api-store", () => {
             return Response.json({ error: "not found" }, { status: 404 });
           }
 
-          setStarted = true;
-          await new Promise<void>((resolve) => {
-            releaseSet = resolve;
-          });
+          setStarted.resolve();
+          await releaseSet.promise;
           setCompleted = true;
           return Response.json({ success: true });
         },
@@ -340,20 +338,17 @@ describe("rendering/cache/stores/api-store", () => {
           setResolved = true;
         });
 
-        for (let attempts = 0; attempts < 50 && !setStarted; attempts++) {
-          await new Promise((resolve) => setTimeout(resolve, 0));
-        }
-        assertEquals(setStarted, true);
+        await setStarted.promise;
         assertEquals(setResolved, false);
         assertEquals(setCompleted, false);
 
-        releaseSet();
+        releaseSet.resolve();
         await setPromise;
 
         assertEquals(setCompleted, true);
         assertEquals(setResolved, true);
       } finally {
-        releaseSet();
+        releaseSet.resolve();
         await store.destroy();
         await server.shutdown();
         if (previousApiBaseUrl === undefined) {

--- a/src/rendering/cache/stores/api-store.test.ts
+++ b/src/rendering/cache/stores/api-store.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withTimeoutThrow } from "../../utils/stream-utils.ts";
 import { APICacheStore } from "./api-store.ts";
 
 async function withStoreTtlEnabled(fn: () => Promise<void>): Promise<void> {
@@ -299,6 +300,7 @@ describe("rendering/cache/stores/api-store", () => {
       const setStarted = Promise.withResolvers<void>();
       const releaseSet = Promise.withResolvers<void>();
       let setCompleted = false;
+      let setPromise: Promise<void> | undefined;
       const server = Deno.serve(
         { hostname: "127.0.0.1", port: 0, onListen: () => {} },
         async (request) => {
@@ -334,11 +336,11 @@ describe("rendering/cache/stores/api-store", () => {
 
       try {
         let setResolved = false;
-        const setPromise = store.set("distributed-key", payload).then(() => {
+        setPromise = store.set("distributed-key", payload).then(() => {
           setResolved = true;
         });
 
-        await setStarted.promise;
+        await withTimeoutThrow(setStarted.promise, 10_000, "distributed cache write to start");
         assertEquals(setResolved, false);
         assertEquals(setCompleted, false);
 
@@ -351,6 +353,7 @@ describe("rendering/cache/stores/api-store", () => {
         releaseSet.resolve();
         await store.destroy();
         await server.shutdown();
+        await setPromise;
         if (previousApiBaseUrl === undefined) {
           Deno.env.delete("VERYFRONT_API_BASE_URL");
         } else {

--- a/src/rendering/cache/stores/api-store.test.ts
+++ b/src/rendering/cache/stores/api-store.test.ts
@@ -351,23 +351,32 @@ describe("rendering/cache/stores/api-store", () => {
         assertEquals(setResolved, true);
       } finally {
         releaseSet.resolve();
-        await store.destroy();
-        await server.shutdown();
-        await setPromise;
-        if (previousApiBaseUrl === undefined) {
-          Deno.env.delete("VERYFRONT_API_BASE_URL");
-        } else {
-          Deno.env.set("VERYFRONT_API_BASE_URL", previousApiBaseUrl);
-        }
-        if (previousApiToken === undefined) {
-          Deno.env.delete("VERYFRONT_API_TOKEN");
-        } else {
-          Deno.env.set("VERYFRONT_API_TOKEN", previousApiToken);
-        }
-        if (originalAdapter === undefined) {
-          delete globals.__vf_multi_project_adapter;
-        } else {
-          globals.__vf_multi_project_adapter = originalAdapter;
+        try {
+          await withTimeoutThrow(
+            Promise.all([
+              store.destroy(),
+              server.shutdown(),
+              setPromise ?? Promise.resolve(),
+            ]),
+            10_000,
+            "distributed cache write test cleanup",
+          );
+        } finally {
+          if (previousApiBaseUrl === undefined) {
+            Deno.env.delete("VERYFRONT_API_BASE_URL");
+          } else {
+            Deno.env.set("VERYFRONT_API_BASE_URL", previousApiBaseUrl);
+          }
+          if (previousApiToken === undefined) {
+            Deno.env.delete("VERYFRONT_API_TOKEN");
+          } else {
+            Deno.env.set("VERYFRONT_API_TOKEN", previousApiToken);
+          }
+          if (originalAdapter === undefined) {
+            delete globals.__vf_multi_project_adapter;
+          } else {
+            globals.__vf_multi_project_adapter = originalAdapter;
+          }
         }
       }
     });


### PR DESCRIPTION
## Problem

Two async lifecycle regressions depended on scheduler speed instead of observable state:

- The distributed API-cache write test polled fifty zero-delay turns for its local HTTP handler. Under parallel coverage load those turns could complete before the request was scheduled, and a missing request could then leave cleanup unbounded.
- The model-call persistence deadline test used a five-millisecond wall-clock race. Under coverage, the deadline could fire before the mocked fetch attached its abort listener, producing the false `appendWasAborted === false` failure seen in PR #3297.

These are test-harness defects, not production-behavior changes.

## Fix

- Replace API-cache scheduler polling with explicit start/release promises.
- Bound API-cache request-start observation and cleanup; restore process environment and the global adapter even if cleanup fails.
- Observe model-call recording settlement immediately, bound its request-start handshake with a wall-clock watchdog captured before `FakeTime`, then advance the fake clock to the exact deadline only after the mocked request is active.
- Keep the original assertions: distributed `set()` waits for its backend, the active append receives an abort, and disposal remains terminal.

No retries, production fallbacks, timeout increases, or production source changes are introduced.

## Verification

- focused API-store and model-call recorder suites on current `main`: 55 steps, green
- both synchronized regressions together: 100 consecutive runs, green
- `deno task lint:test-typecheck`: green, zero new test type errors
- `deno task verify:quick`: green
- formatting, lint, typecheck, dependency boundaries, dependency-free core, and docs checks: green
