### PR TITLE
fix(schedule): harden schedule and webhook discovery, validation, and CLI handlers

### DIFF
--- a/cli/commands/schedule/command-help.ts
+++ b/cli/commands/schedule/command-help.ts
@@ -8,7 +8,7 @@ export const scheduleHelp: CommandHelp = {
   options: [
     {
       flag: "--input <file>",
-      description: "JSON input file to override the schedule input (run only)",
+      description: "JSON object file to override the schedule input (run only)",
     },
     {
       flag: "--remote",
@@ -18,6 +18,10 @@ export const scheduleHelp: CommandHelp = {
     {
       flag: "--json",
       description: "Output as JSON",
+    },
+    {
+      flag: "--debug",
+      description: "Enable debug logging (run only)",
     },
   ],
   examples: [

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -16,7 +16,10 @@ import {
   waitForRemoteScheduleRun,
 } from "./handler.ts";
 
-const originalCwd = Deno.cwd();
+// Derived from the module URL rather than load-time Deno.cwd(): under
+// `deno test --parallel` this module can be evaluated while a sibling test
+// file is chdir'd into a soon-to-be-deleted temp directory.
+const originalCwd = new URL("../../../", import.meta.url);
 const originalExit = Deno.exit;
 const originalFetch = globalThis.fetch;
 const originalConsoleLog = console.log;
@@ -334,6 +337,7 @@ describe("schedule command", () => {
         signalPresent: true,
       });
     } finally {
+      Deno.chdir(originalCwd);
       await stopEsbuild();
       await Deno.remove(projectDir, { recursive: true });
     }

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { clearProjectAgentRuntimeRegistries } from "../../../src/agent/project/agent-runtime.ts";
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
@@ -689,6 +694,7 @@ describe("local schedule execution boundaries", () => {
         VeryfrontError,
         "--input JSON file must contain a JSON object.",
       );
+      assertInstanceOf(error, VeryfrontError);
       assertEquals(error.slug, "invalid-argument");
     }
   });

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { clearProjectAgentRuntimeRegistries } from "../../../src/agent/project/agent-runtime.ts";
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
@@ -8,8 +8,10 @@ import type { CreateScheduleRunFromSourceResult, Run, VeryfrontRunsClient } from
 import { setJsonMode } from "../../shared/json-output.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 import {
+  createLocalScheduleTimeout,
   formatRemoteScheduleRunOutput,
   handleScheduleCommand,
+  normalizeLocalScheduleInput,
   resolveRemoteScheduleTarget,
   waitForRemoteScheduleRun,
 } from "./handler.ts";
@@ -271,6 +273,71 @@ describe("schedule command", () => {
       "Remote schedule runs use the source already pushed to Veryfront and do not accept --input.",
     );
   });
+
+  it("propagates a configured local timeout signal to the target", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-schedule-local-timeout-" });
+    const output: string[] = [];
+
+    try {
+      await Deno.mkdir(`${projectDir}/schedules`, { recursive: true });
+      await Deno.mkdir(`${projectDir}/tasks`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/veryfront.config.ts`,
+        "export default {};\n",
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/schedules/timed-task.ts`,
+        [
+          "export default {",
+          '  id: "timed-task",',
+          '  schedule: "0 8 * * *",',
+          '  target: { kind: "task", id: "signal-aware" },',
+          "  timeoutSeconds: 30,",
+          "};",
+          "",
+        ].join("\n"),
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/tasks/signal-aware.ts`,
+        [
+          "export default {",
+          '  name: "Signal aware",',
+          "  run({ signal }) {",
+          "    return { signalPresent: signal instanceof AbortSignal };",
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
+
+      Deno.chdir(projectDir);
+      setJsonMode(true);
+      console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
+      // deno-lint-ignore no-explicit-any
+      (Deno as any).exit = (code = 0) => {
+        throw new ExitSentinel(code);
+      };
+
+      let exitCode: number | undefined;
+      try {
+        await handleScheduleCommand({
+          _: ["schedule", "run", "timed-task"],
+          json: true,
+        } as ParsedArgs);
+      } catch (error) {
+        if (!(error instanceof ExitSentinel)) throw error;
+        exitCode = error.code;
+      }
+
+      assertEquals(exitCode, 0);
+      assertEquals(JSON.parse(output.at(-1) ?? "{}").data.output, {
+        signalPresent: true,
+      });
+    } finally {
+      await stopEsbuild();
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
 });
 
 describe("remote schedule polling", () => {
@@ -280,6 +347,23 @@ describe("remote schedule polling", () => {
     assertEquals(
       resolveRemoteScheduleTarget(makeRun({ target: "eval:unsupported" }), fallback),
       fallback,
+    );
+    assertEquals(
+      resolveRemoteScheduleTarget(makeRun({ target: "task:Invalid Target" }), fallback),
+      fallback,
+    );
+    assertEquals(
+      resolveRemoteScheduleTarget(makeRun({ target: `task:${"x".repeat(257)}` }), fallback),
+      fallback,
+    );
+    assertThrows(
+      () =>
+        resolveRemoteScheduleTarget(
+          makeRun({ target: "eval:unsupported" }),
+          { kind: "task", id: "Invalid Target" } as never,
+        ),
+      Error,
+      "Remote schedule returned an invalid target.",
     );
   });
 
@@ -341,6 +425,29 @@ describe("remote schedule polling", () => {
     );
 
     assertEquals(run.status, "completed");
+  });
+
+  it("rejects invalid cloud timeout metadata before polling", async () => {
+    let polls = 0;
+    const client = {
+      get: () => {
+        polls++;
+        return Promise.resolve(makeRun());
+      },
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+
+    for (const timeoutSeconds of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      await assertRejects(
+        () =>
+          waitForRemoteScheduleRun(
+            client,
+            makeAcceptedScheduleRun(timeoutSeconds),
+          ),
+        Error,
+        "Remote schedule returned an invalid execution timeout.",
+      );
+    }
+    assertEquals(polls, 0);
   });
 
   it("does not spend the execution timeout while the remote run is queued", async () => {
@@ -514,6 +621,34 @@ describe("remote schedule polling", () => {
     );
   });
 
+  it("falls back when the cloud run records an unsafe timeout", async () => {
+    const client = {
+      get: () =>
+        Promise.resolve(
+          makeRun({
+            status: "running",
+            completed_at: null,
+            timeout_seconds: Number.MAX_SAFE_INTEGER + 1,
+            started_at: "1970-01-01T00:00:00.000Z",
+          }),
+        ),
+    } satisfies Pick<VeryfrontRunsClient, "get">;
+    let now = 0;
+
+    await assertRejects(
+      () =>
+        waitForRemoteScheduleRun(client, makeAcceptedScheduleRun(1), {
+          now: () => now,
+          sleep: () => {
+            now += 32_000;
+            return Promise.resolve();
+          },
+        }),
+      Error,
+      `Timed out waiting for scheduled run: ${runId}`,
+    );
+  });
+
   it("stops polling when a remote run never leaves the queue", async () => {
     const client = {
       get: () =>
@@ -535,5 +670,65 @@ describe("remote schedule polling", () => {
       Error,
       `Timed out waiting for scheduled run to start: ${runId}`,
     );
+  });
+});
+
+describe("local schedule execution boundaries", () => {
+  it("requires input overrides to contain a JSON object", () => {
+    const input = { queue: "priority" };
+    assertEquals(normalizeLocalScheduleInput(input), input);
+
+    for (const value of [null, "priority", 42, true, []]) {
+      assertThrows(
+        () => normalizeLocalScheduleInput(value),
+        Error,
+        "--input JSON file must contain a JSON object.",
+      );
+    }
+  });
+
+  it("preserves long execution deadlines with bounded timer chunks", () => {
+    const callbacks: Array<() => void> = [];
+    const delays: number[] = [];
+    const timeout = createLocalScheduleTimeout(5, {
+      maxDelaySeconds: 2,
+      setTimer: (callback, delayMs) => {
+        callbacks.push(callback);
+        delays.push(delayMs);
+        return callbacks.length;
+      },
+      clearTimer: () => {},
+    });
+
+    assertEquals(timeout.signal?.aborted, false);
+    assertEquals(delays, [2_000]);
+
+    callbacks.shift()?.();
+    assertEquals(timeout.signal?.aborted, false);
+    assertEquals(delays, [2_000, 2_000]);
+
+    callbacks.shift()?.();
+    assertEquals(timeout.signal?.aborted, false);
+    assertEquals(delays, [2_000, 2_000, 1_000]);
+
+    callbacks.shift()?.();
+    assertEquals(timeout.signal?.aborted, true);
+    assertEquals(timeout.signal?.reason instanceof DOMException, true);
+    assertEquals(timeout.signal?.reason.name, "TimeoutError");
+  });
+
+  it("disposes the active execution timer after completion", () => {
+    const cleared: number[] = [];
+    const timeout = createLocalScheduleTimeout(30, {
+      setTimer: () => 17,
+      clearTimer: (timerId) => cleared.push(timerId),
+    });
+
+    timeout.dispose();
+    timeout.dispose();
+
+    assertEquals(cleared, [17]);
+    assertEquals(timeout.signal?.aborted, false);
+    assertEquals(createLocalScheduleTimeout(undefined).signal, undefined);
   });
 });

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { clearProjectAgentRuntimeRegistries } from "../../../src/agent/project/agent-runtime.ts";
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import { VeryfrontError } from "veryfront/errors";
 import type { CreateScheduleRunFromSourceResult, Run, VeryfrontRunsClient } from "veryfront/runs";
 import { setJsonMode } from "../../shared/json-output.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
@@ -683,11 +684,12 @@ describe("local schedule execution boundaries", () => {
     assertEquals(normalizeLocalScheduleInput(input), input);
 
     for (const value of [null, "priority", 42, true, []]) {
-      assertThrows(
+      const error = assertThrows(
         () => normalizeLocalScheduleInput(value),
-        Error,
+        VeryfrontError,
         "--input JSON file must contain a JSON object.",
       );
+      assertEquals(error.slug, "invalid-argument");
     }
   });
 
@@ -699,7 +701,7 @@ describe("local schedule execution boundaries", () => {
       setTimer: (callback, delayMs) => {
         callbacks.push(callback);
         delays.push(delayMs);
-        return callbacks.length;
+        return callbacks.length as unknown as ReturnType<typeof setTimeout>;
       },
       clearTimer: () => {},
     });
@@ -724,8 +726,8 @@ describe("local schedule execution boundaries", () => {
   it("disposes the active execution timer after completion", () => {
     const cleared: number[] = [];
     const timeout = createLocalScheduleTimeout(30, {
-      setTimer: () => 17,
-      clearTimer: (timerId) => cleared.push(timerId),
+      setTimer: () => 17 as unknown as ReturnType<typeof setTimeout>,
+      clearTimer: (timerId) => cleared.push(timerId as unknown as number),
     });
 
     timeout.dispose();

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -87,8 +87,8 @@ interface RemoteSchedulePollOptions {
 
 interface LocalScheduleTimeoutOptions {
   maxDelaySeconds?: number;
-  setTimer?: (callback: () => void, delayMs: number) => number;
-  clearTimer?: (timerId: number) => void;
+  setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (timerId: ReturnType<typeof setTimeout>) => void;
 }
 
 export interface LocalScheduleTimeout {
@@ -122,7 +122,7 @@ export function createLocalScheduleTimeout(
   const clearTimer = options.clearTimer ?? globalThis.clearTimeout;
   const controller = new AbortController();
   let remainingSeconds = timeoutSeconds;
-  let timerId: number | undefined;
+  let timerId: ReturnType<typeof setTimeout> | undefined;
   let disposed = false;
 
   const armNextChunk = (): void => {
@@ -160,7 +160,9 @@ export function createLocalScheduleTimeout(
 
 export function normalizeLocalScheduleInput(value: unknown): Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("--input JSON file must contain a JSON object.");
+    throw INVALID_ARGUMENT.create({
+      detail: "--input JSON file must contain a JSON object.",
+    });
   }
   return value as Record<string, unknown>;
 }

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -18,7 +18,12 @@ import {
   type VeryfrontRunsClient,
 } from "veryfront/runs";
 import { discoverSchedules, type ScheduleDefinition } from "veryfront/schedule";
-import { runTriggerTarget, type TriggerTarget } from "veryfront/trigger";
+import {
+  isTriggerId,
+  isTriggerTarget,
+  runTriggerTarget,
+  type TriggerTarget,
+} from "veryfront/trigger";
 import { outputTriggerList, outputTriggerRun, readJsonFile } from "../trigger-utils.ts";
 
 const REMOTE_SCHEDULE_POLL_INTERVAL_MS = 1_000;
@@ -26,6 +31,10 @@ const REMOTE_SCHEDULE_TIMEOUT_GRACE_MS = 30_000;
 // Bound how long the CLI waits for dispatch without consuming the cloud run's
 // execution budget. The run remains durable in Veryfront if this wait expires.
 const REMOTE_SCHEDULE_QUEUE_WAIT_TIMEOUT_MS = 5 * 60_000;
+// Deno and Node both clamp longer setTimeout delays. Chaining bounded chunks
+// preserves the authored timeout instead of firing early after host coercion.
+const MAX_HOST_TIMER_DELAY_MS = 2 ** 31 - 1;
+const MAX_TIMER_DELAY_SECONDS = Math.floor(MAX_HOST_TIMER_DELAY_MS / 1_000);
 
 const getScheduleArgsSchema = defineSchema((v) =>
   v.object({
@@ -76,11 +85,97 @@ interface RemoteSchedulePollOptions {
   sleep?: (delayMs: number) => Promise<void>;
 }
 
+interface LocalScheduleTimeoutOptions {
+  maxDelaySeconds?: number;
+  setTimer?: (callback: () => void, delayMs: number) => number;
+  clearTimer?: (timerId: number) => void;
+}
+
+export interface LocalScheduleTimeout {
+  readonly signal: AbortSignal | undefined;
+  dispose(): void;
+}
+
+/**
+ * Create a disposable cooperative timeout for one local schedule execution.
+ *
+ * Long durations are armed in bounded chunks so timer coercion cannot shorten
+ * the configured deadline.
+ */
+export function createLocalScheduleTimeout(
+  timeoutSeconds: number | undefined,
+  options: LocalScheduleTimeoutOptions = {},
+): LocalScheduleTimeout {
+  if (timeoutSeconds === undefined) {
+    return { signal: undefined, dispose() {} };
+  }
+  if (!Number.isSafeInteger(timeoutSeconds) || timeoutSeconds <= 0) {
+    throw new TypeError("Local schedule timeout must be a positive safe integer.");
+  }
+
+  const maxDelaySeconds = options.maxDelaySeconds ?? MAX_TIMER_DELAY_SECONDS;
+  if (!Number.isSafeInteger(maxDelaySeconds) || maxDelaySeconds <= 0) {
+    throw new TypeError("Local schedule timer chunk must be a positive safe integer.");
+  }
+
+  const setTimer = options.setTimer ?? globalThis.setTimeout;
+  const clearTimer = options.clearTimer ?? globalThis.clearTimeout;
+  const controller = new AbortController();
+  let remainingSeconds = timeoutSeconds;
+  let timerId: number | undefined;
+  let disposed = false;
+
+  const armNextChunk = (): void => {
+    if (disposed || controller.signal.aborted) return;
+    const delaySeconds = Math.min(remainingSeconds, maxDelaySeconds);
+    remainingSeconds -= delaySeconds;
+    timerId = setTimer(() => {
+      timerId = undefined;
+      if (disposed) return;
+      if (remainingSeconds > 0) {
+        armNextChunk();
+        return;
+      }
+      controller.abort(
+        new DOMException(
+          "Local schedule execution exceeded its configured timeout.",
+          "TimeoutError",
+        ),
+      );
+    }, delaySeconds * 1_000);
+  };
+
+  armNextChunk();
+  return {
+    signal: controller.signal,
+    dispose(): void {
+      disposed = true;
+      if (timerId !== undefined) {
+        clearTimer(timerId);
+        timerId = undefined;
+      }
+    },
+  };
+}
+
+export function normalizeLocalScheduleInput(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("--input JSON file must contain a JSON object.");
+  }
+  return value as Record<string, unknown>;
+}
+
 export async function waitForRemoteScheduleRun(
   client: Pick<VeryfrontRunsClient, "get">,
   accepted: CreateScheduleRunFromSourceResult,
   options: RemoteSchedulePollOptions = {},
 ): Promise<Run> {
+  if (
+    !Number.isSafeInteger(accepted.timeoutSeconds) ||
+    accepted.timeoutSeconds <= 0
+  ) {
+    throw new Error("Remote schedule returned an invalid execution timeout.");
+  }
   const now = options.now ?? Date.now;
   const sleep = options.sleep ??
     ((delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs)));
@@ -109,7 +204,8 @@ export async function waitForRemoteScheduleRun(
       throw DEPLOYMENT_ERROR.create({ detail: `Scheduled run was cancelled: ${runId}` });
     }
     const recordedTimeoutSeconds = run.timeout_seconds;
-    const executionTimeoutSeconds = recordedTimeoutSeconds !== null &&
+    const executionTimeoutSeconds = Number.isSafeInteger(recordedTimeoutSeconds) &&
+        recordedTimeoutSeconds !== null &&
         recordedTimeoutSeconds > 0
       ? recordedTimeoutSeconds
       : accepted.timeoutSeconds;
@@ -141,15 +237,22 @@ export function formatRemoteScheduleRunOutput(run: Run): Record<string, unknown>
 }
 
 export function resolveRemoteScheduleTarget(run: Run, fallback: TriggerTarget): TriggerTarget {
-  if (!run.target) return fallback;
+  const fallbackTarget = isTriggerTarget(fallback) ? { ...fallback } : null;
+  if (!run.target) {
+    if (fallbackTarget !== null) return fallbackTarget;
+    throw new Error("Remote schedule returned an invalid target.");
+  }
   const separator = run.target.indexOf(":");
-  if (separator < 1) return fallback;
+  if (separator < 1) {
+    if (fallbackTarget !== null) return fallbackTarget;
+    throw new Error("Remote schedule returned an invalid target.");
+  }
   const kind = run.target.slice(0, separator);
   const id = run.target.slice(separator + 1).trim();
-  if ((kind !== "agent" && kind !== "task" && kind !== "workflow") || id.length === 0) {
-    return fallback;
-  }
-  return { kind, id };
+  const candidate = { kind, id };
+  if (isTriggerTarget(candidate)) return candidate;
+  if (fallbackTarget !== null) return fallbackTarget;
+  throw new Error("Remote schedule returned an invalid target.");
 }
 
 async function runRemoteSchedule(
@@ -167,6 +270,9 @@ async function runRemoteSchedule(
     sourceTriggerId: opts.id,
     idempotencyKey: `schedule-cli:${crypto.randomUUID()}`,
   });
+  if (!isTriggerTarget(accepted.target)) {
+    throw new Error("Remote schedule returned an invalid target.");
+  }
   const remoteRun = await waitForRemoteScheduleRun(
     client,
     accepted,
@@ -195,7 +301,10 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
   }
 
   const projectDir = Deno.cwd();
-  if (opts.remote && opts.input) {
+  if (!isTriggerId(opts.id)) {
+    throw INVALID_ARGUMENT.create({ detail: `Invalid schedule id: "${opts.id}".` });
+  }
+  if (opts.remote && opts.input !== undefined) {
     throw INVALID_ARGUMENT.create({
       detail:
         "Remote schedule runs use the source already pushed to Veryfront and do not accept --input.",
@@ -209,7 +318,9 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
 
   await withProjectSourceContext(projectDir, async (context) => {
     const { adapter, config, configCacheKey, projectId } = context;
-    const input = opts.input ? await readJsonFile(opts.input, "--input JSON file") : undefined;
+    const input = opts.input !== undefined
+      ? await readJsonFile(opts.input, "--input JSON file")
+      : undefined;
     const result = await discoverSchedules({
       projectDir,
       adapter,
@@ -227,11 +338,10 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       throw RESOURCE_NOT_FOUND.create({ detail: `Schedule "${opts.id}" not found.` });
     }
 
-    const triggerInput = input ?? schedule.input ?? {};
-    const scheduleConfig =
-      triggerInput && typeof triggerInput === "object" && !Array.isArray(triggerInput)
-        ? triggerInput as Record<string, unknown>
-        : {};
+    const triggerInput = normalizeLocalScheduleInput(
+      opts.input === undefined ? schedule.input ?? {} : input,
+    );
+    const scheduleConfig = triggerInput;
     const scheduleName = schedule.name ?? schedule.id;
     const scheduleTarget = scheduleConfig._schedule_target;
     const conversationMode = scheduleTarget && typeof scheduleTarget === "object" &&
@@ -258,17 +368,25 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       }
       : {};
 
-    const run = await runTriggerTarget({
-      projectDir,
-      adapter,
-      config,
-      cacheKey: configCacheKey,
-      projectId,
-      target: schedule.target,
-      input: triggerInput,
-      ...agentRunOptions,
-      debug: opts.debug,
-    });
+    const timeout = createLocalScheduleTimeout(schedule.timeoutSeconds);
+    const run = await (async () => {
+      try {
+        return await runTriggerTarget({
+          projectDir,
+          adapter,
+          config,
+          cacheKey: configCacheKey,
+          projectId,
+          target: schedule.target,
+          input: triggerInput,
+          ...agentRunOptions,
+          signal: timeout.signal,
+          debug: opts.debug,
+        });
+      } finally {
+        timeout.dispose();
+      }
+    })();
 
     await outputTriggerRun({
       command: "schedule",
@@ -277,8 +395,6 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       output: run.output,
       durationMs: run.durationMs,
     });
-  }).catch((error: unknown) => {
-    throw error;
   });
 
   exitProcess(0);

--- a/cli/commands/webhook/command-help.ts
+++ b/cli/commands/webhook/command-help.ts
@@ -8,11 +8,16 @@ export const webhookHelp: CommandHelp = {
   options: [
     {
       flag: "--payload <file>",
-      description: "JSON payload fixture (run only)",
+      description:
+        "JSON payload fixture (run only; 64 KiB maximum; filters and agent templates are applied)",
     },
     {
       flag: "--json",
       description: "Output as JSON",
+    },
+    {
+      flag: "--debug",
+      description: "Enable debug logging (run only)",
     },
   ],
   examples: [

--- a/cli/commands/webhook/handler.test.ts
+++ b/cli/commands/webhook/handler.test.ts
@@ -1,12 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { clearProjectAgentRuntimeRegistries } from "#veryfront/agent/project/agent-runtime.ts";
 import { clearTranspileCache } from "#veryfront/discovery/transpiler.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import { VeryfrontError } from "veryfront/errors";
 import { setJsonMode } from "../../shared/json-output.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
-import { handleWebhookCommand } from "./handler.ts";
+import { handleWebhookCommand, toWebhookAgentOptions } from "./handler.ts";
 
 // Derived from the module URL rather than load-time Deno.cwd(): under
 // `deno test --parallel` this module can be evaluated while a sibling test
@@ -209,5 +210,45 @@ describe("webhook command", () => {
       Error,
       'Invalid webhook id: "Invalid ID".',
     );
+  });
+
+  it("reports local-only agent webhook usage failures as invalid arguments", () => {
+    const existingConversationError = assertThrows(
+      () =>
+        toWebhookAgentOptions(
+          {
+            definition: {
+              id: "pull-request",
+              target: { kind: "agent", id: "capture-agent" },
+              agentMessage: { conversationMode: "existing" },
+            },
+            payload: {},
+            matched: true,
+            targetInput: {},
+            agentInput: "Review the payload.",
+          } as unknown as Parameters<typeof toWebhookAgentOptions>[0],
+        ),
+      VeryfrontError,
+      "Local agent webhook runs cannot attach to an existing cloud conversation.",
+    );
+    assertEquals(existingConversationError.slug, "invalid-argument");
+
+    const missingPromptError = assertThrows(
+      () =>
+        toWebhookAgentOptions(
+          {
+            definition: {
+              id: "pull-request",
+              target: { kind: "agent", id: "capture-agent" },
+            },
+            payload: {},
+            matched: true,
+            targetInput: {},
+          } as unknown as Parameters<typeof toWebhookAgentOptions>[0],
+        ),
+      VeryfrontError,
+      "Local agent webhook runs require a rendered prompt.",
+    );
+    assertEquals(missingPromptError.slug, "invalid-argument");
   });
 });

--- a/cli/commands/webhook/handler.test.ts
+++ b/cli/commands/webhook/handler.test.ts
@@ -8,7 +8,10 @@ import { setJsonMode } from "../../shared/json-output.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 import { handleWebhookCommand } from "./handler.ts";
 
-const originalCwd = Deno.cwd();
+// Derived from the module URL rather than load-time Deno.cwd(): under
+// `deno test --parallel` this module can be evaluated while a sibling test
+// file is chdir'd into a soon-to-be-deleted temp directory.
+const originalCwd = new URL("../../../", import.meta.url);
 const originalExit = Deno.exit;
 const originalConsoleLog = console.log;
 
@@ -108,6 +111,7 @@ describe("webhook command", () => {
         },
       });
     } finally {
+      Deno.chdir(originalCwd);
       await Deno.remove(projectDir, { recursive: true });
     }
   });
@@ -190,6 +194,7 @@ describe("webhook command", () => {
         },
       });
     } finally {
+      Deno.chdir(originalCwd);
       await Deno.remove(projectDir, { recursive: true });
     }
   });

--- a/cli/commands/webhook/handler.test.ts
+++ b/cli/commands/webhook/handler.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { clearProjectAgentRuntimeRegistries } from "#veryfront/agent/project/agent-runtime.ts";
 import { clearTranspileCache } from "#veryfront/discovery/transpiler.ts";
@@ -231,6 +236,7 @@ describe("webhook command", () => {
       VeryfrontError,
       "Local agent webhook runs cannot attach to an existing cloud conversation.",
     );
+    assertInstanceOf(existingConversationError, VeryfrontError);
     assertEquals(existingConversationError.slug, "invalid-argument");
 
     const missingPromptError = assertThrows(
@@ -249,6 +255,7 @@ describe("webhook command", () => {
       VeryfrontError,
       "Local agent webhook runs require a rendered prompt.",
     );
+    assertInstanceOf(missingPromptError, VeryfrontError);
     assertEquals(missingPromptError.slug, "invalid-argument");
   });
 });

--- a/cli/commands/webhook/handler.test.ts
+++ b/cli/commands/webhook/handler.test.ts
@@ -1,0 +1,208 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { clearProjectAgentRuntimeRegistries } from "#veryfront/agent/project/agent-runtime.ts";
+import { clearTranspileCache } from "#veryfront/discovery/transpiler.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import { setJsonMode } from "../../shared/json-output.ts";
+import type { ParsedArgs } from "../../shared/types.ts";
+import { handleWebhookCommand } from "./handler.ts";
+
+const originalCwd = Deno.cwd();
+const originalExit = Deno.exit;
+const originalConsoleLog = console.log;
+
+class ExitSentinel extends Error {
+  constructor(readonly code: number) {
+    super(`exit:${code}`);
+  }
+}
+
+async function runCommand(args: ParsedArgs): Promise<{
+  exitCode: number | undefined;
+  output: string[];
+}> {
+  const output: string[] = [];
+  setJsonMode(true);
+  console.log = (...values: unknown[]) => output.push(values.map(String).join(" "));
+  // deno-lint-ignore no-explicit-any
+  (Deno as any).exit = (code = 0) => {
+    throw new ExitSentinel(code);
+  };
+
+  let exitCode: number | undefined;
+  try {
+    await handleWebhookCommand(args);
+  } catch (error) {
+    if (!(error instanceof ExitSentinel)) throw error;
+    exitCode = error.code;
+  }
+  return { exitCode, output };
+}
+
+describe("webhook command", () => {
+  afterEach(() => {
+    Deno.chdir(originalCwd);
+    // deno-lint-ignore no-explicit-any
+    (Deno as any).exit = originalExit;
+    console.log = originalConsoleLog;
+    setJsonMode(false);
+    clearProjectAgentRuntimeRegistries();
+    clearTranspileCache();
+  });
+
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
+  it("reports a filtered fixture without discovering or running its target", async () => {
+    const projectDir = await Deno.makeTempDir({
+      prefix: "vf-webhook-filtered-",
+    });
+    try {
+      await Deno.mkdir(`${projectDir}/webhooks`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/veryfront.config.ts`,
+        "export default {};\n",
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/webhooks/pull-request.ts`,
+        [
+          'import { webhook } from "veryfront/webhook";',
+          "export default webhook({",
+          '  id: "pull-request",',
+          '  target: { kind: "task", id: "target-must-not-run" },',
+          "  eventFilter: {",
+          '    mode: "all",',
+          "    conditions: [",
+          '      { path: "action", operator: "equals", value: "opened" },',
+          "    ],",
+          "  },",
+          "});",
+          "",
+        ].join("\n"),
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/closed.json`,
+        JSON.stringify({ action: "closed" }),
+      );
+
+      Deno.chdir(projectDir);
+      const result = await runCommand({
+        _: ["webhook", "run", "pull-request"],
+        payload: "closed.json",
+        json: true,
+      } as ParsedArgs);
+
+      assertEquals(result.exitCode, 0);
+      assertEquals(JSON.parse(result.output.at(-1) ?? "{}"), {
+        success: true,
+        command: "webhook",
+        data: {
+          command: "webhook",
+          triggerId: "pull-request",
+          target: { kind: "task", id: "target-must-not-run" },
+          matched: false,
+          status: "ignored",
+          reason: "Webhook event did not match configured filter",
+        },
+      });
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("renders an agent prompt and isolates the payload in local context", async () => {
+    const projectDir = await Deno.makeTempDir({
+      prefix: "vf-webhook-agent-",
+    });
+    try {
+      await Deno.mkdir(`${projectDir}/webhooks`, { recursive: true });
+      await Deno.mkdir(`${projectDir}/agents`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/veryfront.config.ts`,
+        "export default {};\n",
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/webhooks/pull-request.ts`,
+        [
+          'import { webhook } from "veryfront/webhook";',
+          "export default webhook({",
+          '  id: "pull-request",',
+          '  target: { kind: "agent", id: "capture-agent" },',
+          "  agentMessage: {",
+          '    promptTemplate: "Review {{payload.pull_request.title}} ({{payload.action}}).",',
+          "  },",
+          "});",
+          "",
+        ].join("\n"),
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/agents/capture-agent.ts`,
+        [
+          'import { agent } from "veryfront/agent";',
+          "",
+          "const captureAgent = agent({",
+          '  id: "capture-agent",',
+          '  model: "openai/gpt-5.4-nano",',
+          '  system: "Capture the local webhook invocation.",',
+          "});",
+          "captureAgent.generate = async ({ input, context }) => ({",
+          "  text: JSON.stringify({ input, context }),",
+          '  status: "completed",',
+          "  toolCalls: [],",
+          "});",
+          "",
+          "export default captureAgent;",
+          "",
+        ].join("\n"),
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/opened.json`,
+        JSON.stringify({
+          action: "opened",
+          pull_request: { title: "Harden webhooks" },
+        }),
+      );
+
+      Deno.chdir(projectDir);
+      const result = await runCommand({
+        _: ["webhook", "run", "pull-request"],
+        payload: "opened.json",
+        json: true,
+      } as ParsedArgs);
+
+      assertEquals(result.exitCode, 0);
+      const envelope = JSON.parse(result.output.at(-1) ?? "{}");
+      assertEquals(JSON.parse(envelope.data.output.text), {
+        input: "Review Harden webhooks (opened).",
+        context: {
+          trigger: "webhook",
+          webhook: { id: "pull-request", name: "pull-request" },
+          forwardedProps: {
+            source: "webhook",
+            source_trigger_id: "pull-request",
+            payload: {
+              action: "opened",
+              pull_request: { title: "Harden webhooks" },
+            },
+          },
+        },
+      });
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("rejects an invalid id before trying to read its fixture", async () => {
+    await assertRejects(
+      () =>
+        handleWebhookCommand({
+          _: ["webhook", "run", "Invalid ID"],
+          payload: "missing.json",
+        } as ParsedArgs),
+      Error,
+      'Invalid webhook id: "Invalid ID".',
+    );
+  });
+});

--- a/cli/commands/webhook/handler.ts
+++ b/cli/commands/webhook/handler.ts
@@ -1,13 +1,22 @@
 import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
 import type { ParsedArgs } from "#cli/shared/types";
-import { exitProcess } from "#cli/utils";
+import { cliLogger, exitProcess } from "#cli/utils";
 import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
 import { runTriggerTarget } from "veryfront/trigger";
-import { discoverWebhooks, type WebhookDefinition } from "veryfront/webhook";
+import {
+  discoverWebhooks,
+  isWebhookId,
+  type PreparedWebhookInvocation,
+  prepareWebhookInvocation,
+  type WebhookDefinition,
+} from "veryfront/webhook";
 import { outputTriggerList, outputTriggerRun, readJsonFile } from "../trigger-utils.ts";
+import { createSuccessEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
 import { INVALID_ARGUMENT } from "veryfront/errors";
+
+const FILTERED_REASON = "Webhook event did not match configured filter";
 
 const getWebhookArgsSchema = defineSchema((v) =>
   v.object({
@@ -28,6 +37,59 @@ const parseWebhookArgs = createArgParser(WebhookArgsSchema, {
   payload: { keys: ["payload"], type: "string" },
   debug: { keys: ["debug"], type: "boolean" },
 });
+
+function toWebhookAgentOptions(
+  invocation: PreparedWebhookInvocation,
+): {
+  agentInput?: string;
+  agentContext?: Record<string, unknown>;
+} {
+  const webhook = invocation.definition;
+  if (webhook.target.kind !== "agent") return {};
+  if (webhook.agentMessage?.conversationMode === "existing") {
+    throw new Error(
+      "Local agent webhook runs cannot attach to an existing cloud conversation.",
+    );
+  }
+  if (typeof invocation.agentInput !== "string") {
+    throw new Error("Local agent webhook runs require a rendered prompt.");
+  }
+  return {
+    agentInput: invocation.agentInput,
+    agentContext: {
+      trigger: "webhook",
+      webhook: {
+        id: webhook.id,
+        name: webhook.name ?? webhook.id,
+      },
+      forwardedProps: {
+        source: "webhook",
+        source_trigger_id: webhook.id,
+        payload: invocation.payload,
+      },
+    },
+  };
+}
+
+async function outputFilteredWebhook(
+  webhook: WebhookDefinition,
+): Promise<void> {
+  const result = {
+    command: "webhook",
+    triggerId: webhook.id,
+    target: webhook.target,
+    matched: false,
+    status: "ignored",
+    reason: FILTERED_REASON,
+  } as const;
+  if (isJsonMode()) {
+    await outputJson(createSuccessEnvelope("webhook", result));
+    return;
+  }
+  cliLogger.info(
+    `webhook "${webhook.id}" was ignored: ${FILTERED_REASON}`,
+  );
+}
 
 function formatWebhook(webhook: WebhookDefinition): string {
   return `${webhook.id} -> ${webhook.target.kind}:${webhook.target.id}`;
@@ -67,6 +129,9 @@ export async function handleWebhookCommand(args: ParsedArgs): Promise<void> {
   if (!opts.payload) {
     throw INVALID_ARGUMENT.create({ detail: "webhook run requires --payload <file>" });
   }
+  if (!isWebhookId(opts.id)) {
+    throw INVALID_ARGUMENT.create({ detail: `Invalid webhook id: "${opts.id}".` });
+  }
 
   const projectDir = Deno.cwd();
   const payload = await readJsonFile(opts.payload, "--payload JSON file");
@@ -83,9 +148,16 @@ export async function handleWebhookCommand(args: ParsedArgs): Promise<void> {
       throw new Error(`Webhook discovery failed: ${result.errors[0]?.message}`);
     }
 
-    const webhook = result.items.find((candidate) => candidate.id === opts.id);
-    if (!webhook) {
+    const discovered = result.items.find((candidate) => candidate.id === opts.id);
+    if (!discovered) {
       throw new Error(`Webhook "${opts.id}" not found.`);
+    }
+
+    const invocation = prepareWebhookInvocation(discovered, payload);
+    const webhook = invocation.definition;
+    if (!invocation.matched) {
+      await outputFilteredWebhook(webhook);
+      return;
     }
 
     const run = await runTriggerTarget({
@@ -95,7 +167,8 @@ export async function handleWebhookCommand(args: ParsedArgs): Promise<void> {
       cacheKey: configCacheKey,
       projectId,
       target: webhook.target,
-      input: payload,
+      input: invocation.targetInput,
+      ...toWebhookAgentOptions(invocation),
       debug: opts.debug,
     });
 
@@ -106,8 +179,6 @@ export async function handleWebhookCommand(args: ParsedArgs): Promise<void> {
       output: run.output,
       durationMs: run.durationMs,
     });
-  }).catch((error: unknown) => {
-    throw error;
   });
 
   exitProcess(0);

--- a/cli/commands/webhook/handler.ts
+++ b/cli/commands/webhook/handler.ts
@@ -38,7 +38,7 @@ const parseWebhookArgs = createArgParser(WebhookArgsSchema, {
   debug: { keys: ["debug"], type: "boolean" },
 });
 
-function toWebhookAgentOptions(
+export function toWebhookAgentOptions(
   invocation: PreparedWebhookInvocation,
 ): {
   agentInput?: string;
@@ -47,12 +47,14 @@ function toWebhookAgentOptions(
   const webhook = invocation.definition;
   if (webhook.target.kind !== "agent") return {};
   if (webhook.agentMessage?.conversationMode === "existing") {
-    throw new Error(
-      "Local agent webhook runs cannot attach to an existing cloud conversation.",
-    );
+    throw INVALID_ARGUMENT.create({
+      detail: "Local agent webhook runs cannot attach to an existing cloud conversation.",
+    });
   }
   if (typeof invocation.agentInput !== "string") {
-    throw new Error("Local agent webhook runs require a rendered prompt.");
+    throw INVALID_ARGUMENT.create({
+      detail: "Local agent webhook runs require a rendered prompt.",
+    });
   }
   return {
     agentInput: invocation.agentInput,

--- a/docs/concepts/schedule.md
+++ b/docs/concepts/schedule.md
@@ -4,8 +4,9 @@ description: "How schedules create runs over time."
 order: 26
 ---
 
-A schedule owns a trigger definition. It creates runs at configured times or at
-one configured time.
+A schedule owns a trigger definition. Platform-managed schedules can create
+runs at configured recurring times or at one configured time. Source-defined
+`schedule()` configurations are recurring schedules.
 
 Schedules exist because scheduled work has two separate concerns: when work
 starts and what work does. The schedule owns the trigger. The target owns the
@@ -16,8 +17,8 @@ business logic.
 - A trigger defines when work starts.
 - A target defines what work runs.
 - Each trigger creates a run.
-- Pausing or deleting the schedule affects future runs, not the task or workflow
-  definition.
+- Pausing or deleting the schedule affects future runs, not the task, workflow,
+  or agent definition.
 
 ## Boundary
 
@@ -29,9 +30,31 @@ workflow and let the schedule trigger it.
 ## Wrong fit
 
 Do not put the work itself in the schedule definition. Use a one-time schedule
-for delayed one-off work and a cron-style schedule for recurring work.
+through the platform API for delayed one-off work, and a source-defined
+cron schedule for recurring work.
 
 For implementation steps, see [Runs](../guides/runs.md).
+
+## Source-defined recurrence
+
+The `schedule` field (or its authoring alias, `cron`) is a five-field POSIX cron
+expression:
+
+| Field        |      Accepted range |
+| ------------ | ------------------: |
+| Minute       |                0-59 |
+| Hour         |                0-23 |
+| Day of month |                1-31 |
+| Month        | 1-12 or `JAN`-`DEC` |
+| Day of week  |  0-7 or `SUN`-`SAT` |
+
+Each field accepts `*`, comma-separated values, ranges, and positive steps such
+as `*/15` or `1-15/2`. The factory normalizes whitespace and named fields, then
+stores the canonical expression in `schedule`.
+
+When `timezone` is present, it must be `UTC` or a supported IANA timezone such
+as `Europe/Stockholm`. `timeoutSeconds` bounds local and hosted execution.
+`backoffLimit` is a non-negative retry count; set it to `0` to disable retries.
 
 ## Monitor a schedule
 

--- a/docs/concepts/webhook.md
+++ b/docs/concepts/webhook.md
@@ -1,0 +1,106 @@
+---
+title: "Webhook"
+description: "How webhooks turn external JSON events into filtered runs."
+order: 33
+---
+
+A webhook owns an event trigger definition. It receives one bounded JSON
+payload, optionally filters that payload, and starts one task, workflow, or
+agent target. The target owns the business logic.
+
+Source-defined `webhook()` configurations reconcile to hosted webhook records.
+The local `veryfront webhook run` command applies the same payload limit,
+filter, and prompt-template semantics to a fixture before it executes the
+project target.
+
+## Characteristics
+
+- The webhook owns event acceptance, filtering, and target selection.
+- A filtered event is ignored and does not start its target.
+- The target owns retries, durable execution, tools, and business behavior.
+- The webhook definition never owns the HTTP provider's signing or retry
+  protocol.
+
+Use an app or API route when the project needs to implement a provider-specific
+HTTP endpoint itself. Use a source webhook when Veryfront should own the
+hosted webhook endpoint and reconcile the trigger from project source.
+
+## Payload boundary
+
+A webhook payload must be data-only JSON whose serialized form is no larger
+than 64 KiB. Nullish input becomes an empty object. Accessors, custom
+prototypes, sparse arrays, cycles, non-finite numbers, and unsupported values
+fail before local target discovery.
+
+Target input follows the hosted run model:
+
+- A task receives an object payload as its task configuration. A primitive
+  payload is available under `payload`.
+- A workflow receives `{ payload }`.
+- An agent receives the rendered prompt and an isolated `payload` value in its
+  forwarded context.
+
+## Event filters
+
+Filter paths are dot-separated object paths such as
+`pull_request.state`. A path can select an array as its final value, but paths
+do not traverse through array indexes.
+
+```ts
+import { webhook } from "veryfront/webhook";
+
+export default webhook({
+  id: "pull-request-review",
+  target: { kind: "workflow", id: "review-pull-request" },
+  eventFilter: {
+    mode: "all",
+    conditions: [
+      { path: "action", operator: "in", value: ["opened", "reopened"] },
+      { path: "pull_request.draft", operator: "equals", value: false },
+      { path: "pull_request.labels", operator: "contains", value: "backend" },
+    ],
+  },
+});
+```
+
+`all` requires every condition; `any` requires at least one. An empty
+condition collection matches every payload. The supported comparisons are:
+
+| Operator     | Match                                                                  |
+| ------------ | ---------------------------------------------------------------------- |
+| `equals`     | Structural JSON equality                                               |
+| `not_equals` | Structural inequality; a missing path differs from a supplied value    |
+| `in`         | The actual value structurally equals one entry in the configured array |
+| `exists`     | The path resolves to a JSON value, including `null`                    |
+| `contains`   | String substring or structurally equal array member                    |
+
+## Agent prompt mapping
+
+Agent targets require `agentMessage.promptTemplate`. Use `{{payload}}` for the
+pretty-printed complete payload or `{{payload.dot.path}}` for one nested value:
+
+```ts
+export default webhook({
+  id: "support-escalation",
+  target: { kind: "agent", id: "support-agent" },
+  agentMessage: {
+    promptTemplate: "Triage {{payload.summary}} for account {{payload.account.id}}.",
+    conversationMode: "none",
+  },
+});
+```
+
+If a template has no recognized payload placeholder, the complete payload is
+appended in a JSON code block. Missing and null placeholder values render as an
+empty string; objects and arrays render as formatted JSON.
+
+Payload text is inserted verbatim. Template rendering is not an input-safety or
+prompt-injection boundary. Agents that act on untrusted event fields should
+apply an explicit input policy and keep authorization in deterministic tools.
+
+Hosted agent webhooks may use `create_new`, `existing`, or `none` conversation
+mode. `existing` requires a conversation UUID. Local runs execute standalone
+and therefore reject attempts to attach to an existing cloud conversation.
+
+For API details, see
+[veryfront/webhook](../api-reference/veryfront/webhook.md).

--- a/src/agent/service/routes.test.ts
+++ b/src/agent/service/routes.test.ts
@@ -36,6 +36,13 @@ function createAuthenticatedRequest(
   });
 }
 
+function getAuthorizationFromFetchInit(init: unknown): string | null {
+  if (typeof init !== "object" || init === null || !("headers" in init)) {
+    return null;
+  }
+  return new Headers(init.headers as HeadersInit).get("authorization");
+}
+
 function withImmutableHeaders(request: Request): Request {
   const headers = new Headers(request.headers);
   Object.defineProperty(headers, "delete", {
@@ -354,7 +361,7 @@ it("agent service routes remove verified writer credentials before detached call
         apiUrl: "https://api.example.test",
         runId: "run-1",
         fetch: async (_input, init) => {
-          childAuthorizations.push(new Headers(init?.headers).get("authorization"));
+          childAuthorizations.push(getAuthorizationFromFetchInit(init));
           return Response.json(
             { run_event_token: "child-writer-token" },
             { headers: { "Cache-Control": "no-store" } },
@@ -397,7 +404,7 @@ it("agent service routes preserve verified writer authority across request cloni
         apiUrl: "https://api.example.test",
         runId: requestClone.durableRootRun?.runId ?? "missing-run",
         fetch: async (_input, init) => {
-          childAuthorizations.push(new Headers(init?.headers).get("authorization"));
+          childAuthorizations.push(getAuthorizationFromFetchInit(init));
           return Response.json(
             { run_event_token: "child-writer-token" },
             { headers: { "Cache-Control": "no-store" } },

--- a/src/discovery/handlers/schedule-handler.test.ts
+++ b/src/discovery/handlers/schedule-handler.test.ts
@@ -1,0 +1,45 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { schedule } from "#veryfront/schedule";
+import { scheduleHandler } from "./schedule-handler.ts";
+
+describe("discovery/schedule-handler", () => {
+  it("registers an owned canonical schedule snapshot", () => {
+    const definition = schedule({
+      id: "daily-triage",
+      schedule: "0 8 * * 1-5",
+      target: { kind: "workflow", id: "escalate-ticket" },
+      input: { queue: "priority" },
+      integrationRequirements: [{
+        integration: "slack",
+        requiredScopes: ["channels:read"],
+        resources: [{ kind: "channel", id: "C012345" }],
+      }],
+    });
+
+    const registered = scheduleHandler.register(
+      definition.id,
+      definition,
+      "schedules/daily-triage.ts",
+      "schedules",
+    );
+    definition.input!.queue = "mutated";
+    definition.target.id = "mutated";
+    definition.integrationRequirements![0]!.requiredScopes[0] = "mutated";
+    definition.integrationRequirements![0]!.resources[0]!.id = "mutated";
+
+    assertStrictEquals(registered === definition, false);
+    assertEquals(registered, {
+      id: "daily-triage",
+      schedule: "0 8 * * 1-5",
+      target: { kind: "workflow", id: "escalate-ticket" },
+      input: { queue: "priority" },
+      integrationRequirements: [{
+        integration: "slack",
+        requiredScopes: ["channels:read"],
+        resources: [{ kind: "channel", id: "C012345" }],
+      }],
+    });
+  });
+});

--- a/src/discovery/handlers/schedule-handler.ts
+++ b/src/discovery/handlers/schedule-handler.ts
@@ -1,11 +1,12 @@
 import type { ScheduleDefinition } from "#veryfront/schedule";
 import { isScheduleDefinition } from "#veryfront/schedule";
+import { normalizeScheduleDefinition } from "#veryfront/schedule/validation.ts";
 import type { DiscoveryHandler, DiscoveryResult } from "../types.ts";
 
 export const scheduleHandler: DiscoveryHandler<ScheduleDefinition> = {
   typeName: "schedule",
   validate: (item): item is ScheduleDefinition => isScheduleDefinition(item),
   getId: (definition) => definition.id,
-  register: (_id, definition) => definition,
+  register: (_id, definition) => normalizeScheduleDefinition(definition),
   getResultMap: (result: DiscoveryResult) => result.schedules,
 };

--- a/src/discovery/handlers/webhook-handler.test.ts
+++ b/src/discovery/handlers/webhook-handler.test.ts
@@ -1,0 +1,60 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { webhook } from "#veryfront/webhook";
+import { webhookHandler } from "./webhook-handler.ts";
+
+describe("discovery/webhook-handler", () => {
+  it("registers an owned canonical webhook snapshot", () => {
+    const definition = webhook({
+      id: "ticket-created",
+      target: { kind: "agent", id: "support-agent" },
+      eventFilter: {
+        mode: "all",
+        conditions: [
+          {
+            path: "project",
+            operator: "equals",
+            value: { id: "project-1" },
+          },
+        ],
+      },
+      agentMessage: {
+        promptTemplate: "Triage {{payload.project.id}}.",
+        conversationMode: "none",
+      },
+    });
+
+    const registered = webhookHandler.register(
+      definition.id,
+      definition,
+      "webhooks/ticket-created.ts",
+      "webhooks",
+    );
+    definition.target.id = "mutated";
+    const condition = definition.eventFilter!.conditions[0]!;
+    condition.path = "mutated";
+    (condition.value as { id: string }).id = "mutated";
+    definition.agentMessage!.promptTemplate = "Mutated.";
+
+    assertStrictEquals(registered === definition, false);
+    assertEquals(registered, {
+      id: "ticket-created",
+      target: { kind: "agent", id: "support-agent" },
+      eventFilter: {
+        mode: "all",
+        conditions: [
+          {
+            path: "project",
+            operator: "equals",
+            value: { id: "project-1" },
+          },
+        ],
+      },
+      agentMessage: {
+        promptTemplate: "Triage {{payload.project.id}}.",
+        conversationMode: "none",
+      },
+    });
+  });
+});

--- a/src/discovery/handlers/webhook-handler.ts
+++ b/src/discovery/handlers/webhook-handler.ts
@@ -1,11 +1,12 @@
 import type { WebhookDefinition } from "#veryfront/webhook";
 import { isWebhookDefinition } from "#veryfront/webhook";
+import { normalizeWebhookDefinition } from "#veryfront/webhook/validation.ts";
 import type { DiscoveryHandler, DiscoveryResult } from "../types.ts";
 
 export const webhookHandler: DiscoveryHandler<WebhookDefinition> = {
   typeName: "webhook",
   validate: (item): item is WebhookDefinition => isWebhookDefinition(item),
   getId: (definition) => definition.id,
-  register: (_id, definition) => definition,
+  register: (_id, definition) => normalizeWebhookDefinition(definition),
   getResultMap: (result: DiscoveryResult) => result.webhooks,
 };

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -46,6 +46,7 @@ import { PageContextProvider, usePageContext } from "../../src/react/context/ind
 import { Link, RouterProvider, useRouter } from "../../src/react/router/index.tsx";
 import { Sandbox } from "../../src/sandbox/index.ts";
 import { schedule } from "../../src/schedule/index.ts";
+import { webhook } from "../../src/webhook/index.ts";
 import { isTaskDefinition } from "../../src/task/types.ts";
 import {
   getConnector,
@@ -104,6 +105,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "quickstart.md",
   "sandbox.md",
   "schedule.md",
+  "webhook.md",
   "skills.md",
   "storybook-ui-workbench.md",
   "tasks.md",
@@ -187,6 +189,47 @@ describe("Guide: concepts/schedule.md", () => {
     });
 
     assertEquals(definition.health, { maxStalenessSeconds: 1_800 });
+  });
+});
+
+describe("Guide: concepts/webhook.md", () => {
+  it("normalizes the documented event filter example", () => {
+    const definition = webhook({
+      id: "pull-request-review",
+      target: { kind: "workflow", id: "review-pull-request" },
+      eventFilter: {
+        mode: "all",
+        conditions: [
+          { path: "action", operator: "in", value: ["opened", "reopened"] },
+          { path: "pull_request.draft", operator: "equals", value: false },
+          { path: "pull_request.labels", operator: "contains", value: "backend" },
+        ],
+      },
+    });
+
+    assertEquals(definition.eventFilter?.mode, "all");
+    assertEquals(definition.eventFilter?.conditions.map((c) => c.operator), [
+      "in",
+      "equals",
+      "contains",
+    ]);
+  });
+
+  it("normalizes the documented agent prompt mapping example", () => {
+    const definition = webhook({
+      id: "support-escalation",
+      target: { kind: "agent", id: "support-agent" },
+      agentMessage: {
+        promptTemplate: "Triage {{payload.summary}} for account {{payload.account.id}}.",
+        conversationMode: "none",
+      },
+    });
+
+    assertEquals(definition.agentMessage?.conversationMode, "none");
+    assertEquals(
+      definition.agentMessage?.promptTemplate,
+      "Triage {{payload.summary}} for account {{payload.account.id}}.",
+    );
   });
 });
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -20,6 +20,7 @@ const CONCEPT_FILES = new Set<string>([
   "concepts/eval.md",
   "concepts/run.md",
   "concepts/schedule.md",
+  "concepts/webhook.md",
   "concepts/prompt.md",
   "concepts/resource.md",
   "concepts/skill.md",
@@ -477,6 +478,12 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "../api-reference/veryfront/runs.md",
     ],
     snippets: ["schedule", "runs", "trigger"],
+  },
+  "concepts/webhook.md": {
+    references: [
+      "../api-reference/veryfront/webhook.md",
+    ],
+    snippets: ["eventFilter", "promptTemplate", "64 KiB", "filtered event is ignored"],
   },
   "concepts/prompt.md": {
     references: ["../api-reference/veryfront/prompt.md"],


### PR DESCRIPTION
## Summary

Tier-1 audited slice cherry-picked file-by-file from `codex/module-reconcile-20260723` (no merge/rebase from that branch; every file was diffed against `origin/main` before inclusion).

### What the hardening does

**Discovery handlers** (`src/discovery/handlers/`)
- `schedule-handler.ts` / `webhook-handler.ts`: `register` now re-normalizes definitions via `normalizeScheduleDefinition` / `normalizeWebhookDefinition` instead of trusting the discovered value; new tests pin that the registered snapshot is owned and canonical.

**`veryfront schedule run`** (`cli/commands/schedule/handler.ts`)
- Validates the schedule id (`isTriggerId`) before any work.
- `waitForRemoteScheduleRun` rejects invalid cloud timeout metadata before polling and falls back when a cloud run records an unsafe `timeout_seconds`.
- `resolveRemoteScheduleTarget` validates both the remote target and the fallback via `isTriggerTarget` and throws instead of silently using an invalid target.
- `--input` must contain a JSON object (`normalizeLocalScheduleInput`).
- Local execution timeouts are armed in bounded timer chunks (`createLocalScheduleTimeout`) so host `setTimeout` clamping cannot fire deadlines early; the timer is disposed after the run and the abort signal is propagated to `runTriggerTarget`.

**`veryfront webhook run`** (`cli/commands/webhook/handler.ts`)
- Validates the webhook id (`isWebhookId`) before reading the payload fixture.
- Applies event filters and agent prompt templates via `prepareWebhookInvocation` before running the target; filtered events are reported as ignored without executing.
- Agent targets get the rendered prompt plus an isolated forwarded-props context; `conversationMode: existing` is rejected for local runs.

**Docs / help**: `--debug` documented for both commands, payload bounds documented, new `docs/concepts/webhook.md`, source-defined cron recurrence table in `docs/concepts/schedule.md`.

### Reverts from the reconcile branch that were NOT taken
The reconcile branch's Aug 2 merge silently reverted recent main work; these were detected and excluded:
- `allowHostProjectCodeExecution` (security PR #3285) was dropped from all four discovery call sites on the branch — re-applied from main.
- `src/schedule/` + `src/webhook/` module changes on the branch were pure reverts (JSONPath `$.` prefix normalization removal in `webhook/validation.ts`, removal of its test, path-aware error-message test expectations tied to non-slice branch code, `TEST_PUBLIC_API_ORIGIN` routable guarded-egress fixture) — main's versions kept.
- `docs/api-reference/veryfront/webhook.md` line-number tweak matched the reverted code — dropped.
- `src/discovery/handlers/primitive-handlers.test.ts` exercises non-slice handlers — left out.

### Merge gate
- Test-name audit for every modified test file: working copies are strict supersets of `origin/main` — no main test name lost.
- `git log --since=2026-07-20` checked per file; #3285 / #3155 / #3119 changes survive.

### Additional commits
- `chore: drop unused stringifyJsonValue imports to unblock pre-push lint` — pre-push `deno lint` fails on pristine main due to two unused imports in `extensions/ext-llm-anthropic` and `extensions/ext-llm-openai`; identical minimal diff carried by all slice PRs so they merge in any order.
- `test(cli): make schedule and webhook cwd teardown parallel-safe` — the cherry-picked tests chdir into temp dirs; under `deno test --parallel` a sibling module could capture that dir as `originalCwd` at load time and explode after deletion (reproduced as a 265-test cascade). Teardown now restores cwd before removal and derives the restore target from `import.meta.url`.

### Verification
- `deno check` on all changed TS files: clean.
- Targeted suite (`src/schedule src/webhook src/discovery/handlers cli/commands/schedule cli/commands/webhook`): 11 groups / 73 steps, all pass.
- Full `deno task test:unit`: 3,620+ passed, 0 failed (also verified green baseline on `origin/main` in the same environment).
- Pre-push gate (fmt check, lint, typecheck, full unit suite): passed on push.