### PR TITLE
docs(guides): correct chat-ui, evals, and add the project-knowledge guide

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -92,9 +92,9 @@ tools: [fetch-paper] # own short names resolve first, then global tool ids
 Research the question and cite every claim.
 ```
 
-- Omit `skills` or use `skills: true` to advertise every skill visible to the
-  agent. Use `skills: []` to advertise none. `load_skill` remains available in
-  either case.
+- Omit `skills` or use `skills: true` to advertise and authorize every skill
+  visible to the agent. Use `skills: []` to advertise none and to authorize no
+  project or configured skill for `load_skill`.
 - `tools: true` - every currently scoped tool is authorized, while non-bootstrap
   schemas are deferred behind `tool_search` until the agent searches for them.
 - `skills: [..]` / `tools: [..]` - each entry resolves as the agent's own
@@ -269,9 +269,10 @@ export default agent({
 });
 ```
 
-Use `skills: ["incident-response", "repo-maintainer"]` to advertise only those
-skills. Use `skills: []` to advertise no skills. This selector does not remove
-`load_skill` or restrict which visible skills it can load by ID.
+Use `skills: ["incident-response", "repo-maintainer"]` to advertise and
+authorize only those skills. Use `skills: []` to advertise no skills and to
+authorize none for `load_skill`. An explicit selector is an authorization
+boundary for `load_skill`, not just a prompt filter.
 
 Local and project runtimes also expose `load_skill_reference` and
 `execute_skill_script`. Hosted chat reads an advertised reference through

--- a/docs/guides/chat-ui.md
+++ b/docs/guides/chat-ui.md
@@ -304,10 +304,12 @@ different requests would share the same store.
 Use chat context providers only when nested components need direct state access.
 Prefer preset props or composition components first.
 
-## Render Markdown directly
+## Present Markdown source safely
 
-Use `veryfront/markdown` when a page or custom message surface needs the same
-renderer without the rest of the chat composition:
+`veryfront/markdown` is the dependency-free Markdown boundary used by chat
+surfaces. Without an installed rich renderer, it preserves the exact source in
+an escaped `<pre><code>` element. This is useful when source visibility matters
+more than semantic formatting:
 
 ````tsx
 import { Markdown } from "veryfront/markdown";
@@ -329,45 +331,74 @@ export default function Result() {
 }
 ````
 
-CommonMark and GitHub Flavored Markdown, including tables, task lists, and
-strikethrough, are server-rendered. Fenced source is also present in the server
-HTML. Shiki highlighting and Mermaid SVG rendering are browser enhancements;
-if either enhancement cannot load or render, the source remains readable.
+The default does not claim that CommonMark, GFM, highlighting, or diagrams were
+rendered. It emits no Markdown-authored links, images, or raw HTML, and the
+escaped source is present in server HTML.
 
-Replace fenced-code rendering without changing inline code:
+### Install a semantic renderer
 
-```tsx
-<Markdown
-  renderCodeBlock={({ language, code }) => (
-    <pre data-language={language}>
-      <code>{code}</code>
-    </pre>
-  )}
->
-  {answer}
-</Markdown>;
-```
-
-Use `components` to replace an HTML element renderer. Consumer entries win
-over the built-in link, table, cell, blockquote, and code-fence renderers:
+Semantic Markdown is an explicit extension capability. Select a trusted
+extension or application adapter that implements `MarkdownRendererProps`, then
+install its component for the relevant subtree. In this example,
+`ProjectMarkdownRenderer` comes from that adapter:
 
 ```tsx
-<Markdown
-  components={{
-    a: ({ href, children }) => <a href={href}>{children}</a>,
-  }}
->
-  {"Review the [Markdown section](#render-markdown-directly)."}
-</Markdown>;
+import { Markdown, MarkdownRendererProvider } from "veryfront/markdown";
+import { ProjectMarkdownRenderer } from "./project-markdown-renderer.tsx";
+
+export default function Result() {
+  return (
+    <MarkdownRendererProvider renderer={ProjectMarkdownRenderer}>
+      <Markdown>{answer}</Markdown>
+    </MarkdownRendererProvider>
+  );
+}
 ```
 
-Raw HTML and unsafe link protocols are not emitted by the default pipeline.
-`remarkPlugins`, `rehypePlugins`, and custom components execute as trusted
-application code and can change those guarantees; never build plugin lists
-from untrusted input. Remote Markdown images can initiate browser requests, so
-override the `img` component when untrusted content needs a stricter image or
-privacy policy. Bound untrusted Markdown size before rendering when the
-application accepts arbitrarily large documents.
+The per-instance `renderer` prop takes precedence over the provider. Pass
+`renderer={null}` when a nested surface must display plain source even though
+an ancestor installed a renderer.
+
+Parser-dependent options are forwarded only after a renderer has been selected.
+For example, replace fenced-code rendering without changing the renderer used
+for the rest of the document:
+
+```tsx
+<MarkdownRendererProvider renderer={ProjectMarkdownRenderer}>
+  <Markdown
+    renderCodeBlock={({ language, code }) => (
+      <pre data-language={language}>
+        <code>{code}</code>
+      </pre>
+    )}
+  >
+    {answer}
+  </Markdown>
+</MarkdownRendererProvider>;
+```
+
+Use `components` to pass framework-neutral element overrides to the selected
+renderer:
+
+```tsx
+<MarkdownRendererProvider renderer={ProjectMarkdownRenderer}>
+  <Markdown
+    components={{
+      a: ({ href, children }) => <a href={href}>{children}</a>,
+    }}
+  >
+    {"Review the [Markdown section](#present-markdown-source-safely)."}
+  </Markdown>
+</MarkdownRendererProvider>;
+```
+
+The extension owns parsing, sanitization, unsafe link protocols, image policy,
+highlighting, and diagram security. Configure parser-specific `remarkPlugins`
+or `rehypePlugins` on that extension, not on core `Markdown`; removed or unknown
+core props are rejected instead of ignored. Renderer failures propagate, so
+handle them with an application error boundary when recovery is required.
+Never derive plugin lists from untrusted input, and bound untrusted source size
+before rendering.
 
 ## Verify it worked
 
@@ -382,8 +413,8 @@ Run `veryfront dev` and open the page that renders the chat UI:
 - A conversation persistence failure renders an alert with the failed
   operation.
 - A chat using `memoryConversationStore()` starts empty after a page reload.
-- Standalone Markdown is semantic in the initial server HTML, and fenced code
-  remains readable before browser enhancement.
+- Standalone Markdown source is escaped and readable in the initial server
+  HTML; an injected renderer is used only in the subtree where it is installed.
 
 If the assistant response is empty, check the dev-server log for provider or
 agent errors and confirm the AG-UI route is mounted.

--- a/docs/guides/cli-knowledge-ingestion.md
+++ b/docs/guides/cli-knowledge-ingestion.md
@@ -223,3 +223,7 @@ veryfront knowledge ingest uploads/sample.pdf --json | jq '.ingested'
 The `ingested` array names every file the command wrote. If the array is empty
 or the command exited non-zero, check `skipped`, `failed`, and the command
 output for the reason.
+
+Next, use [Project knowledge](./project-knowledge.md) to search the generated
+paths and frontmatter, retrieve an exact Markdown document, or index the files
+for semantic retrieval.

--- a/docs/guides/data-fetching.md
+++ b/docs/guides/data-fetching.md
@@ -4,7 +4,9 @@ description: "Server data, static generation, and client-side fetching."
 order: 13
 ---
 
-Veryfront pages can load data three ways: `getServerData` on every request, `getStaticData` at build time, or `fetch` from a client component. Each one has its place.
+Veryfront pages can load data three ways: `getServerData` on every request,
+`getStaticData` during static generation and cacheable production requests, or
+`fetch` from a client component. Each one has its place.
 
 Examples below use the default app router. Set `router: "pages"` in `veryfront.config.ts` to switch to the pages router.
 
@@ -42,23 +44,27 @@ entirely, including their top-level side effects. Put client initialization in a
 separate client-referenced module or a bare side-effect import that is not only
 used by a server data hook.
 
-The `props` you return are passed to the page component. To read them from a
-layout or a nested component without prop-drilling, use `usePageContext().data`
-(see [Pages and routing](./pages-and-routing.md)). It holds the same `props`
-object on the server render, in the hydration markup, and after client-side
-navigation.
+The `props` you return are passed to the page component. To read the same props
+data from a layout or nested component without prop-drilling, use
+`usePageContext().data` (see
+[Pages and routing](./pages-and-routing.md)). Veryfront serializes that data
+into hydration markup and restores it after client-side navigation; do not rely
+on JavaScript object identity surviving serialization.
 
 The `DataContext` provides:
 
-| Property  | Type                     | Description                                 |
-| --------- | ------------------------ | ------------------------------------------- |
-| `request` | `Request`                | The incoming HTTP request                   |
-| `params`  | `Record<string, string>` | Route parameters (e.g. `{ slug: "hello" }`) |
-| `query`   | `URLSearchParams`        | Query string parameters                     |
+| Property  | Type                                 | Description                                 |
+| --------- | ------------------------------------ | ------------------------------------------- |
+| `request` | `Request`                            | The incoming HTTP request                   |
+| `params`  | `Record<string, string \| string[]>` | Route parameters (e.g. `{ slug: "hello" }`) |
+| `query`   | `URLSearchParams`                    | Query string parameters                     |
+| `url`     | `URL`                                | Parsed request URL                          |
 
 ## Static data
 
-`getStaticData` runs at build time. Use it for content that doesn't change per request:
+`getStaticData` supplies cacheable data for static builds and production
+requests. Use it for content that does not depend on request headers, cookies,
+or request bodies:
 
 ```tsx
 // app/blog/[slug]/page.tsx
@@ -85,9 +91,35 @@ export default function BlogPost({ post }: { post: { title: string } }) {
 
 For dynamic routes, pair `getStaticData` with `getStaticPaths` to tell the framework which pages to generate.
 
+`getStaticData` receives `params` and `url`. It does not receive `request`,
+request headers, cookies, a body, or a separate `query` property. Read query
+parameters from `url.searchParams`; the complete URL, including the query
+string, participates in static cache identity.
+
+## Revalidate static data
+
+Set `revalidate` to a finite, non-negative number of seconds to refresh static
+data after it becomes stale:
+
+```tsx
+export async function getStaticData() {
+  const response = await fetch("https://api.example.com/posts");
+  const posts = await response.json();
+
+  return {
+    props: { posts },
+    revalidate: 60,
+  };
+}
+```
+
+Veryfront serves the cached result while one background refresh runs. A failed
+refresh keeps the live cached result. Omit `revalidate` or set it to `false` to
+disable background refreshes.
+
 ## Redirects and 404s
 
-Return `redirect()` or `notFound()` from any data function:
+Return `redirect()` or `notFound()` from `getServerData` or `getStaticData`:
 
 ```tsx
 import { type DataContext, notFound, redirect } from "veryfront";

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -41,18 +41,14 @@ veryfront build
 This compiles pages, bundles assets, pre-renders static routes, and writes the
 output to `dist/` by default.
 
-Customize the output directory in `veryfront.config.ts`:
+Choose a different output directory explicitly:
 
-```ts
-import { defineConfig } from "veryfront";
-
-export default defineConfig({
-  build: {
-    outDir: "dist",
-    trailingSlash: false,
-  },
-});
+```bash
+veryfront build --output build-output
 ```
+
+`build.outDir` and `build.trailingSlash` remain accepted configuration fields
+for compatibility, but the production builder does not consume them.
 
 ## Run the build locally
 
@@ -135,7 +131,7 @@ output.
 
 After `veryfront build`:
 
-- `dist/` or your configured `outDir` contains compiled assets.
+- `dist/`, or the directory passed to `--output`, contains compiled assets.
 - `veryfront serve` serves the build locally.
 - The route you chose responds the same way it did in development.
 
@@ -155,7 +151,7 @@ After `veryfront deploy`:
 - [Configuration](./configuration.md): Configure build and environment behavior
 - [Deploy from CI](./deploy-from-ci.md): Push and deploy reviewed Git commits from CI
 - [Move Studio changes into Git](./move-studio-changes-to-git.md): Review a Studio release through a Git pull request
-- [Providers](./providers.md): Configure model provider defaults
+- [Providers](./providers.md): Configure model providers
 
 ## Related
 

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -165,7 +165,9 @@ veryfront eval deep-research \
 
 Usage and p95 latency deltas are reported in `summary.json` whenever both the
 current report and baseline include those values. They fail the run only when
-the matching threshold flag is set.
+the matching threshold flag is set. A baseline is accepted only for the same
+eval definition and target; a report from another eval is rejected instead of
+being compared.
 
 Update the baseline explicitly after reviewing the current report:
 
@@ -229,10 +231,11 @@ veryfront eval deep-research \
 Policy metrics can reference `passRate`, `failed`, `gateFailures`,
 `groundednessScore`, `inputTokens`, `outputTokens`, `totalTokens`,
 `billableInputTokens`, `billableOutputTokens`, `costUsd`, `providerCostUsd`,
-`veryfrontChargeUsd`, `costCredits`, and `p95Ms`. `costUsd` remains a
-backward-compatible cost objective and prefers gateway Veryfront charge when it
-is available. Use `min`, `max`, and `maxRegressionPct` for constraints. Use
-`weight` with `direction` set to `"minimize"` or `"maximize"` for objectives.
+`veryfrontChargeUsd`, `veryfrontBilledUsd`, `costCredits`, and `p95Ms`.
+`costUsd` remains a backward-compatible cost objective and prefers gateway
+Veryfront charge when it is available. Use `min`, `max`, and
+`maxRegressionPct` for constraints. Use `weight` with `direction` set to
+`"minimize"` or `"maximize"` for objectives.
 
 Each report includes provenance metadata. Local runs record git SHA, branch,
 dirty state, and a dirty hash. Cloud runs prefer release, deployment, or preview
@@ -299,9 +302,11 @@ metrics.ops.tokens({ maxTotal: 4_000 }).budget();
 metrics.ops.cost({ maxUsd: 0.05 }).budget();
 ```
 
-`metrics.ops.cost` uses gateway `veryfrontChargeUsd` first, then legacy
-`costUsd`, then `providerCostUsd`. It does not maintain a separate pricing table
-inside the framework.
+`metrics.ops.cost` uses gateway `veryfrontBilledUsd` first, then
+`veryfrontChargeUsd`, legacy `costUsd`, and finally `providerCostUsd`. It does
+not maintain a separate pricing table inside the framework. Token and cost
+budgets fail when the measurement required by their configured limit is
+missing; absent usage evidence never passes a budget.
 
 Use `calledTool` when the agent must call a tool. Add `input` when the tool
 arguments must include specific fields. `match: "partial"` checks that the
@@ -574,6 +579,13 @@ proxy. The adapter reads AG-UI events into `record.trace.events`, records tool
 calls as `record.trace.toolCalls`, captures tool call IDs, status, streamed
 arguments, result payloads, and denied/error state when the AG-UI endpoint emits
 them, and puts the parsed text at `record.output.text`.
+
+Live adapters and CLI helpers require a non-empty `VERYFRONT_TOKEN`. CLI case
+filters cannot opt into mutation: a requested write case still requires
+`AG_UI_EVAL_WRITE=1`, and an experimental write case requires both
+`AG_UI_EVAL_WRITE=1` and `AG_UI_EVAL_EXPERIMENTAL=1`. Unknown, duplicate, or
+disabled case selections fail before any case runs. A run with no passing case
+exits unsuccessfully instead of treating an all-skipped selection as evidence.
 
 Projects with existing live AG-UI suites can also import reusable CLI, API, and
 durable canary helpers from `veryfront/eval/agent-service`. Use those helpers

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -40,6 +40,7 @@ details, see [API reference](../api-reference/index.md).
 | Emit app and eval dashboard metrics         | [Project metrics](./project-metrics.md)           |
 | Add memory or streamed responses            | [Memory and streaming](./memory-and-streaming.md) |
 | Build document Q&A with RAG                 | [Build a RAG app](./build-a-rag-app.md)           |
+| Search source-controlled project knowledge  | [Project knowledge](./project-knowledge.md)       |
 | Coordinate more than one agent              | [Multi-agent](./multi-agent.md)                   |
 | Package reusable agent instructions         | [Skills](./skills.md)                             |
 

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -150,6 +150,32 @@ function PageTitle() {
 }
 ```
 
+### Override rendered MDX elements
+
+Wrap an MDX page or layout with `MDXProvider` to replace generated elements:
+
+```tsx
+import type React from "react";
+import { MDXProvider } from "veryfront/mdx";
+
+const docsComponents = {
+  h1: (props: React.ComponentProps<"h1">) => <h1 className="docs-title" {...props} />,
+  a: (props: React.ComponentProps<"a">) => <a {...props} rel="noreferrer" />,
+};
+
+export default function DocsLayout({ children }: { children: React.ReactNode }) {
+  return <MDXProvider components={docsComponents}>{children}</MDXProvider>;
+}
+```
+
+Nested providers inherit entries from outer providers. A nearer provider wins
+for duplicate keys. Call `useMDXComponents(localOverrides)` when a component
+needs the effective map; local entries take final precedence.
+
+`MDXProvider` supplies application-owned React components to already compiled
+MDX. It does not compile or sanitize arbitrary strings. Render runtime Markdown
+strings with `veryfront/markdown`.
+
 ### Reading server data from a layout or nested component
 
 A page's [`getServerData`](./data-fetching.md) props are passed to the page

--- a/docs/guides/project-knowledge.md
+++ b/docs/guides/project-knowledge.md
@@ -1,0 +1,216 @@
+---
+title: "Project knowledge"
+description: "Search source-controlled knowledge by manifest metadata or semantic similarity."
+order: 25
+---
+
+Use `veryfront/knowledge` when an agent, tool, or route needs files from the
+project's `knowledge/` directory. Choose one of two paths:
+
+- Manifest lookup searches canonical paths and YAML frontmatter without
+  embeddings. It is deterministic and can retrieve one exact document.
+- RAG retrieval indexes document bodies, performs semantic search, and formats
+  the matches as prompt-ready context.
+
+For turning PDFs, Office documents, and uploads into Markdown first, see
+[CLI-first knowledge ingestion](./cli-knowledge-ingestion.md).
+
+## Add knowledge files
+
+Create Markdown files under `knowledge/`. Write YAML frontmatter as a mapping:
+
+```md
+---
+title: SSO recovery
+description: Restore access after an identity-provider configuration change.
+owner: support-platform
+---
+
+# SSO recovery
+
+Verify the issuer, audience, callback URL, and current signing key.
+```
+
+A file whose frontmatter fails to parse is still listed in the manifest, but
+with no searchable metadata, so metadata queries cannot find it. Keep
+frontmatter a valid YAML mapping so path and frontmatter search both work.
+
+## Search paths and frontmatter
+
+Create one helper and call `lookup()`:
+
+```ts
+import { projectKnowledge } from "veryfront/knowledge";
+
+const knowledge = projectKnowledge({ projectDir: "." });
+const page = await knowledge.lookup({
+  query: "SSO recovery",
+  limit: 8,
+});
+
+for (const item of page.data) {
+  console.log(item.path, item.matched_fields, item.frontmatter);
+}
+```
+
+Manifest search matches paths, frontmatter keys, and frontmatter values. It
+does not search document bodies and does not return body content for ordinary
+query results. Each result includes up to six compact frontmatter fields, with
+`title`, `name`, `description`, `summary`, `source`, `source_type`, and
+`added` prioritized and long values truncated.
+
+Inspect `page.mode` before treating results as evidence:
+
+- `search` means at least one path or frontmatter field matched.
+- `browse` means nothing matched. The returned data is a deterministic browse
+  page, not an answer to the query.
+
+This explicit browse mode lets an interactive agent discover available
+knowledge without representing unrelated files as matches.
+
+## Continue with a cursor
+
+Pass the opaque `page_info.next` cursor back with the same query and pagination
+options:
+
+```ts
+const first = await knowledge.lookup({
+  query: "incident",
+  limit: 8,
+  shard_count: 4,
+  shard_index: 0,
+});
+
+const second = first.page_info.next
+  ? await knowledge.lookup({
+    query: "incident",
+    cursor: first.page_info.next,
+    limit: 8,
+    shard_count: 4,
+    shard_index: 0,
+  })
+  : null;
+```
+
+Do not decode, edit, or persist a cursor as application data. A cursor binds
+the query, offset, page size, and shard selection. An invalid cursor, or a
+cursor combined with a different query, fails with a validation error instead
+of returning unrelated results.
+
+## Retrieve one exact document
+
+Use `lookup_target` when the caller already knows the canonical path:
+
+```ts
+const result = await knowledge.lookup({
+  lookup_target: { path: "knowledge/support/sso.md" },
+});
+
+const document = result.data[0];
+if (document) {
+  console.log(document.content);
+}
+```
+
+Exact lookup is the only manifest operation that returns `content`. A missing
+path returns an empty `data` array.
+
+## Expose the lookup as a tool
+
+Create the hosted-compatible `search_knowledge` tool when an agent should
+choose queries and cursors:
+
+```ts
+import { createSearchKnowledgeTool } from "veryfront/knowledge";
+
+export default createSearchKnowledgeTool({
+  id: "search_knowledge",
+  description: "Search the project's reviewed support knowledge.",
+});
+```
+
+The tool validates its input, accepts the same query, cursor, limit, and shard
+options as `lookup()`, and returns the same compact response shape as
+Veryfront Cloud's hosted `search_knowledge` tool.
+
+## Use hosted project content
+
+When no local `projectDir` is configured and the lookup runs with an
+authenticated request context (a request credential plus a project slug or
+ID), it reads the request-scoped project source through the Veryfront API
+instead of local files.
+
+Production requests read release-backed content: an immutable release ID takes
+precedence, then the environment name. Non-production requests read the
+request branch, defaulting to `main`. Configuring `projectDir` keeps the
+lookup on local files.
+
+## Index and retrieve semantically
+
+Indexing is an explicit setup or deployment operation. Keep it out of a chat
+request path:
+
+```ts
+import { projectKnowledge } from "veryfront/knowledge";
+
+const knowledge = projectKnowledge({
+  projectDir: ".",
+  contentDir: "knowledge",
+  storagePath: "data/knowledge-index.json",
+  topK: 5,
+});
+
+await knowledge.index();
+```
+
+Retrieve semantic matches and formatted context later:
+
+```ts
+const result = await knowledge.retrieve("How do I restore SSO?", {
+  topK: 5,
+  threshold: 0.65,
+});
+
+console.log(result.matches);
+console.log(result.context);
+```
+
+`search()` returns the raw RAG matches. `retrieve()` returns the normalized
+query, matches, and a deterministic context block. Treat retrieved text as
+untrusted source material: require citations or another application-level
+evidence policy rather than letting document text override system policy.
+
+## Work within the limits
+
+- Queries are normalized before search: whitespace collapses to single spaces
+  and text beyond 500 characters is dropped. Set `maxQueryChars` to change the
+  bound.
+- A manifest lookup requires a non-empty query or a lookup target.
+- A lookup page contains at most 12 results; `limit` is clamped to the 1-12
+  range and defaults to 8.
+- `shard_count` must be at least 1 and `shard_index` must be inside the shard
+  range; out-of-range values fail with a validation error.
+- Each result carries at most 6 frontmatter fields, and each value is
+  truncated to 240 characters.
+- Semantic search defaults to the top 3 matches; set `topK` per helper or per
+  call.
+
+## Verify it worked
+
+Test all three outcomes your application uses:
+
+1. A metadata query returns `mode: "search"` and the expected canonical path.
+2. An unrelated query returns `mode: "browse"` and is not treated as evidence.
+3. An exact target returns the expected content.
+
+For semantic retrieval, index a fixture, search for text that appears only in
+that fixture, and assert its source path.
+
+## Related
+
+- [Build a RAG app](./build-a-rag-app.md): Add uploads, embeddings, and
+  generated answers
+- [CLI-first knowledge ingestion](./cli-knowledge-ingestion.md): Convert source
+  documents into project knowledge
+- [veryfront/knowledge](../api-reference/veryfront/knowledge.md): Full API
+  reference

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -4,9 +4,10 @@ description: "Where to put routes, AI primitives, shared code, and configuration
 order: 8
 ---
 
-A Veryfront project keeps routes in `app/` or `pages/`. Keep AI primitives at
-the project root: `agents/`, `tools/`, `prompts/`, `workflows/`, `resources/`,
-and `skills/`. Veryfront discovers those directories on startup.
+A Veryfront project keeps routes in `app/` or `pages/`. Keep runtime primitives
+at the project root: `agents/`, `tools/`, `prompts/`, `workflows/`,
+`resources/`, `skills/`, `tasks/`, `schedules/`, `webhooks/`, and `evals/`.
+Veryfront discovers those directories on startup.
 
 The examples use the default app router. Set `router: "pages"` in
 `veryfront.config.ts` to use the pages router.
@@ -50,6 +51,10 @@ my-app/
         triage.sh
       assets/
         checklist.txt
+  tasks/                # Background task definitions (auto-discovered)
+  schedules/            # Schedule definitions (auto-discovered)
+  webhooks/             # Webhook trigger definitions (auto-discovered)
+  evals/                # Agent and workflow eval definitions (auto-discovered)
   components/           # Shared React components
     Header.tsx
   lib/                  # Shared utilities
@@ -102,8 +107,8 @@ dynamic params, and MDX.
 ## Auto-discovered directories
 
 These directories are scanned automatically at startup.
-For TypeScript-based primitives, files with a default export are registered.
-For skills, directories containing `SKILL.md` are registered.
+For TypeScript-based primitives, valid default or named exports are registered.
+For skills, immediate child directories containing `SKILL.md` are registered.
 
 | Directory    | Purpose                           | Import                           |
 | ------------ | --------------------------------- | -------------------------------- |
@@ -113,14 +118,22 @@ For skills, directories containing `SKILL.md` are registered.
 | `workflows/` | Multi-step workflow DAGs          | `veryfront/workflow`             |
 | `resources/` | MCP-exposable resources           | `veryfront/resource`             |
 | `skills/`    | Skill packs advertised to agents  | Loaded with built-in skill tools |
+| `tasks/`     | Background task definitions       | `veryfront/task`                 |
+| `schedules/` | Scheduled trigger definitions     | `veryfront/schedule`             |
+| `webhooks/`  | Webhook trigger definitions       | `veryfront/webhook`              |
+| `evals/`     | Agent and workflow evaluations    | `veryfront/eval`                 |
 
-TypeScript primitives are registered from their exported definitions. Agents can
-use the filename as the ID when no explicit ID is provided.
+TypeScript primitives are registered from their exported definitions. Discovery
+scans `.ts` and `.tsx` files. Agents can use the filename as the ID when no
+explicit ID is provided.
 
 Agent discovery also supports `agents/assistant.md`. Use frontmatter for
 metadata and the markdown body for system instructions.
 
-For skills, the directory name is the skill ID. For example, `skills/incident-response/SKILL.md` registers as `"incident-response"`.
+For skills, the directory name is always the skill ID; a differing legacy or
+display-style frontmatter `name` is treated as presentation metadata and never
+changes lookup. For example, `skills/incident-response/SKILL.md` registers as
+`"incident-response"`.
 
 Verify discovery by starting the dev server after adding an agent, tool, or
 workflow:

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -83,9 +83,10 @@ interface TaskContext {
 - **`signal`**: optional cooperative cancellation signal
 
 Reserved control variables are never copied into `ctx.env`: every variable
-prefixed `TENANT_` and the framework's own `VERYFRONT_*` control names (API
+prefixed `TENANT_` and a fixed set of framework `VERYFRONT_` control keys (API
 token, API URLs, project identity, branch ref, and the injected-payload
-variable itself). Cloud project variables are carried through the
+variable itself). Other project-defined `VERYFRONT_` names are not filtered
+solely because of that prefix. Cloud project variables are carried through the
 `VERYFRONT_TASK_ENV_JSON` payload and merged over visible host variables. That
 payload must be a JSON object; if it is malformed, execution fails before the
 task function runs instead of continuing with missing configuration.

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -59,7 +59,7 @@ interface TaskDefinition {
 | `description`  | No       | What the task does                               |
 | `inputSchema`  | No       | JSON-schema-like input contract for APIs and UIs |
 | `outputSchema` | No       | JSON-schema-like output contract                 |
-| `schedulable`  | No       | Whether it can be used as a schedule target      |
+| `schedulable`  | No       | Scheduling eligibility metadata for APIs and UIs |
 | `run`          | Yes      | The function to execute                          |
 
 ## Task context
@@ -71,24 +71,50 @@ interface TaskContext {
   env: Record<string, string>;
   config: Record<string, unknown>;
   projectId?: string;
+  environmentId?: string;
+  signal?: AbortSignal;
 }
 ```
 
 - **`env`**: filtered environment variables (use `envAllowlist` to restrict)
 - **`config`**: run configuration (passed when run in the cloud)
 - **`projectId`**: project identifier (available in cloud context)
+- **`environmentId`**: runtime-target environment identifier, when selected
+- **`signal`**: optional cooperative cancellation signal
+
+Reserved control variables are never copied into `ctx.env`: every variable
+prefixed `TENANT_` and the framework's own `VERYFRONT_*` control names (API
+token, API URLs, project identity, branch ref, and the injected-payload
+variable itself). Cloud project variables are carried through the
+`VERYFRONT_TASK_ENV_JSON` payload and merged over visible host variables. That
+payload must be a JSON object; if it is malformed, execution fails before the
+task function runs instead of continuing with missing configuration.
+
+`envAllowlist` applies to both visible host variables and injected project
+variables. Without an allowlist, local tasks receive non-reserved host
+variables; use an allowlist when a task should see only a minimal set.
+
+When execution is tied to an HTTP request or another cancellable runtime,
+Veryfront passes that cancellation signal through `ctx.signal`. A signal that
+is already aborted prevents the task from starting. Long-running task code
+should pass the signal to cancellable operations such as `fetch`; JavaScript
+functions that ignore the signal cannot be forcibly terminated by the task
+runner.
 
 ## Discovery
 
 Tasks are discovered automatically from the `tasks/` directory:
 
-```
+```text
 tasks/
   sync-data.ts           → task ID: "sync-data"
-  reports/weekly.ts      → task ID: "reports-weekly"
+  reports/weekly.ts      → task ID: "reports/weekly"
 ```
 
-File extensions `.ts`, `.tsx`, `.js`, `.jsx` are supported. Test files and `node_modules` are ignored.
+Canonical project-runtime discovery supports `.ts` and `.tsx` task modules.
+The deprecated standalone `discoverTasks` helper also accepts `.js` and
+`.jsx` and skips test files and `node_modules`. Task IDs preserve nested path
+segments and use `/` on every supported operating system.
 
 ## Running tasks
 
@@ -102,7 +128,9 @@ Task IDs come from files under `tasks/`.
 
 ### As a cloud run
 
-Tasks with `schedulable: true` can be targeted by runs and schedules:
+Set `schedulable: true` when a task should be presented as eligible for
+schedule targeting. Runs and schedules identify it with the same stable task
+ID:
 
 ```ts
 import { VeryfrontRunsClient } from "veryfront/runs";

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -2,7 +2,6 @@ import {
   jsonValuesEqual,
   readProviderOptions,
   readRecord,
-  stringifyJsonValue,
   stringifyToolResultValue,
   unwrapToolInputSchema,
 } from "veryfront/provider/shared";

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
@@ -1,7 +1,6 @@
 import {
   jsonValuesEqual,
   readProviderOptions,
-  stringifyJsonValue,
   stringifyToolArguments,
   stringifyToolResultValue,
   unwrapToolInputSchema,

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -44,6 +44,11 @@ import { GoogleFonts } from "../../src/react/fonts/index.ts";
 import { Head } from "../../src/react/components/Head.tsx";
 import { PageContextProvider, usePageContext } from "../../src/react/context/index.tsx";
 import { Link, RouterProvider, useRouter } from "../../src/react/router/index.tsx";
+import {
+  createSearchKnowledgeTool,
+  normalizeKnowledgeQuery,
+  projectKnowledge,
+} from "../../src/knowledge/index.ts";
 import { Sandbox } from "../../src/sandbox/index.ts";
 import { schedule } from "../../src/schedule/index.ts";
 import { isTaskDefinition } from "../../src/task/types.ts";
@@ -99,6 +104,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "integrations.md",
   "move-studio-changes-to-git.md",
   "pages-and-routing.md",
+  "project-knowledge.md",
   "project-structure.md",
   "project-metrics.md",
   "quickstart.md",
@@ -736,6 +742,31 @@ describe("Guide: project-structure.md", () => {
 
     assertEquals(hello.id, "hello");
     assertEquals(hello.config.system, "Say hi.");
+  });
+});
+
+describe("Guide: project-knowledge.md", () => {
+  it("uses the public manifest and RAG helper contracts", async () => {
+    const guide = await readGuide("project-knowledge.md");
+    const knowledge = projectKnowledge({ projectDir: "." });
+    const searchKnowledge = createSearchKnowledgeTool({
+      id: "search_knowledge",
+      description: "Search the project's reviewed support knowledge.",
+    });
+
+    assertEquals(typeof knowledge.lookup, "function");
+    assertEquals(typeof knowledge.index, "function");
+    assertEquals(typeof knowledge.retrieve, "function");
+    assertEquals(typeof knowledge.search, "function");
+    assertEquals(searchKnowledge.id, "search_knowledge");
+    assertEquals(normalizeKnowledgeQuery("  SSO   recovery  "), "SSO recovery");
+    assertStringIncludes(
+      guide,
+      'import { projectKnowledge } from "veryfront/knowledge"',
+    );
+    assertStringIncludes(guide, "page.mode");
+    assertStringIncludes(guide, "page_info.next");
+    assertStringIncludes(guide, "lookup_target");
   });
 });
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -588,11 +588,22 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "../api-reference/veryfront/context.md",
       "../api-reference/veryfront/mdx.md",
     ],
-    snippets: ["app router", "useRouter", "Link"],
+    snippets: ["app router", "useRouter", "Link", "MDXProvider"],
   },
   "guides/project-structure.md": {
     references: ["../api-reference/veryfront/index.md"],
     snippets: ["app/", "agents/", "tools/"],
+  },
+  "guides/project-knowledge.md": {
+    references: ["../api-reference/veryfront/knowledge.md"],
+    snippets: [
+      "projectKnowledge",
+      "createSearchKnowledgeTool",
+      'mode: "browse"',
+      "release-backed content",
+      "lookup_target",
+      "page_info.next",
+    ],
   },
   "guides/project-metrics.md": {
     references: ["../api-reference/veryfront/observability.md"],


### PR DESCRIPTION
Ports verified documentation improvements from `codex/module-reconcile-20260723` onto `main`. Nothing was merged from that branch: every claim was re-verified against main's current `src/` and `cli/` before inclusion, and branch-era content that main has moved past was rewritten or dropped.

## Included changes

| File | Correction | Main-side evidence |
| --- | --- | --- |
| `docs/guides/project-knowledge.md` (new) | New guide for `veryfront/knowledge`: manifest lookup, search/browse mode, cursors, exact document retrieval, the `search_knowledge` tool, hosted release-backed content, RAG indexing, and limits. Adapted from the branch draft to main's actual behavior (queries truncated to 500 chars rather than rejected, limit clamped 1-12, six compact frontmatter fields with 240-char values, malformed frontmatter tolerated with empty metadata, no fail-closed `project_reference`, no `abortSignal`) | `src/knowledge/index.ts` (exports :892/:908; constants :35-42; truncation :868; browse mode :802; cursor validation :488-516, :738; hosted context :623-684; content only for non-empty exact lookups :459-470) |
| `docs/guides/chat-ui.md` | Fixes the false claim that Markdown (CommonMark/GFM, Shiki, Mermaid) is server-rendered. The default `veryfront/markdown` boundary presents escaped source; semantic rendering requires an injected renderer via `MarkdownRendererProvider` or the `renderer` prop, `renderer={null}` opts a subtree out, `components`/`renderCodeBlock` are forwarded only to an injected renderer, and unknown props throw | `src/react/components/chat/markdown.tsx` (plain-source default; `MarkdownRendererProvider` :94; unsupported-prop `TypeError` :137; capability error without a renderer :161) |
| `docs/guides/evals.md` | Corrects `metrics.ops.cost` order to `veryfrontBilledUsd ?? veryfrontChargeUsd ?? costUsd ?? providerCostUsd`; adds `veryfrontBilledUsd` to the policy metric list; documents unmeasured-budget failure, baseline identity checks, and AG-UI live-eval gating (`VERYFRONT_TOKEN`, `AG_UI_EVAL_WRITE`, `AG_UI_EVAL_EXPERIMENTAL`, unknown/duplicate/disabled case failures, non-zero exit with no passing case). The branch's "dataset identity" baseline claim was narrowed to definition + target, which is what main checks | `src/eval/metrics.ts:1268`; `src/eval/model-comparison.ts:50`; `src/eval/baseline.ts:200-206`; `src/eval/agent-service.ts:648-650`; `src/eval/agent-service/live-evals/cli-runner.ts:129,182-185,264-281,376` |
| `docs/guides/pages-and-routing.md` | New section documenting `MDXProvider` / `useMDXComponents` (previously zero guide mentions): nested providers inherit, nearest wins, local overrides take final precedence, and the module does not compile or sanitize arbitrary strings | `src/react/components/MDXProvider.tsx`; `src/mdx/index.ts`; `deno.json` maps `veryfront/mdx` |
| `docs/guides/data-fetching.md` (partial) | Corrects `DataContext` (`params: Record<string, string \| string[]>`, adds `url: URL`); documents that `getStaticData` receives only `params`/`url` (no `request`/`query`) and that the full URL participates in cache identity; adds a Revalidate section (finite non-negative seconds, stale-while-revalidate, failed refresh keeps the live entry) | `src/data/schemas/data.schema.ts:5-12`; `src/data/types.ts:20` (`Omit<DataContext, "request" \| "query">`); `src/data/data-fetching-cache.ts:51-57`; `src/data/helpers.ts:120-121`; `src/data/static-data-fetcher.ts:256+` |
| `docs/guides/tasks.md` (partial) | Fixes nested task IDs (`reports/weekly.ts` registers as `reports/weekly`, not `reports-weekly`); canonical discovery scans `.ts`/`.tsx` while the deprecated `discoverTasks` also accepts `.js`/`.jsx`; documents `TaskContext.environmentId`/`signal`, env filtering (`TENANT_*` prefix and reserved `VERYFRONT_*` control names never copied, `VERYFRONT_TASK_ENV_JSON` must be a JSON object or execution fails before the task runs, allowlist applies to injected vars too), and `schedulable` as eligibility metadata. Branch claims about case-insensitive matching and oversized/NUL payload checks were dropped as branch-era | `src/discovery/handlers/task-handler.ts:12-19`; `src/discovery/file-discovery.ts:84`; `src/task/discovery.ts:33-39`; `src/task/types.ts:20-22,38`; `src/task/runner.ts:75-92,109`; `src/runs/runtime-env.ts:9-94`; `schedulable` enforced nowhere in `src/`/`cli/` |
| `docs/guides/project-structure.md` (partial) | Adds `tasks/`, `schedules/`, `webhooks/`, `evals/` to the auto-discovered directories (tree + table); named exports register; skills come from immediate child directories and the directory name is always the skill ID. Branch paragraphs about test-file skip patterns, generation retention, and 100-root path validation were dropped — main's canonical discovery has none of that | `src/discovery/discovery-engine.ts:297-333`; `deno.json` exports `./task`, `./schedule`, `./webhook`, `./eval`; `src/discovery/handlers/skill-handler.ts:62-89`; `src/discovery/file-discovery.ts` (no skip logic) |
| `docs/guides/deploying.md` | Output directory is chosen with `veryfront build --output`; `build.outDir`/`build.trailingSlash` remain accepted config fields but the production builder does not consume them | `cli/commands/build/command-help.ts:10`; `cli/commands/build/command.ts:48` (`options.outputDir ?? join(projectDir, "dist")`, config not consulted); `src/config/schemas/config.schema.ts:353-354` |
| `docs/guides/agents.md` (partial) | Corrects the skills selector semantics: it is an authorization boundary for `load_skill`, not just a prompt filter (`skills: []` authorizes none). Only these two hunks were taken | `src/agent/types.ts:253-259` (public contract: "include and authorize"; "[] or false: ... do not authorize ... for `load_skill`") |
| `docs/guides/index.md` | Adds the Project knowledge row to the guides table | order 25 is unoccupied (23 rag, 24 chat-hooks, 26 workflows) |
| `docs/guides/cli-knowledge-ingestion.md` | Cross-links the new Project knowledge guide as the next step | link target added in this PR |
| `tests/docs/guide-contracts.test.ts`, `tests/docs/guide-code-examples.test.ts` | Contract and code-example coverage for the new guide (required by the coverage tests), plus an `MDXProvider` snippet pin for pages-and-routing | `deno test tests/docs/`: 48 passed, 0 failed |
| `extensions/ext-llm-anthropic`, `extensions/ext-llm-openai` (separate commit) | Drops the two unused `stringifyJsonValue` imports that fail pre-push lint on a clean main checkout (PR #3312, which also fixes this, is not merged yet) | `deno lint` reported exactly these 2 no-unused-vars on unmodified main files |

## Rejected candidates (verified stale or unverifiable against main)

- **mcp-server.md, workflows-advanced.md** — central claims are branch-era (protocol `2025-11-25` task methods, elicitation helpers, `AgentControllerRegistry`, blob-listing capability notes) or not provable against main; also `veryfront/workflow` does re-export the React hooks on main (`src/workflow/index.ts:117-119`), so the branch's import-path "fix" is wrong for main.
- **agents.md (rest)** — `resolveRuntimeState` `abortSignal` rejected: `RuntimeStateRequest` on main (`src/agent/types.ts:308-315`) has no such field; skill-script sandbox/cancellation bullets and memory-replay skill-state claims unverified.
- **data-fetching.md (rest)** — data-worker isolation section and the "Pages routes at build time" section (fallback rejection, `generateStaticParams` claims) not provable from main's build pipeline.
- **project-structure.md (rest)** — discovery skip patterns, generation retention, and discovery-path validation rules do not exist on main.
- **DO-NOT-TOUCH / MIXED files** (agent-service-runtime, chat-hooks, extension-authoring, extensions, oauth, integrations, memory-and-streaming, providers, tools, api-routes, build-a-rag-app, middleware, move-studio-changes-to-git, project-metrics, runs, configuration, sandbox, skills, workflows) — untouched per audit classification.

Verification: `deno test tests/docs/` 48 passed / 0 failed; `deno fmt` and `deno lint` clean on all changed files; pre-push hook (fmt check + full test suite) passed.
