### PR TITLE
fix(embedding): tolerate released lock observation race

### DIFF
--- a/src/embedding/local-json-store-lock.ts
+++ b/src/embedding/local-json-store-lock.ts
@@ -109,6 +109,23 @@ async function readBoundedText(fs: FileSystem, path: string): Promise<string | n
   }
 }
 
+async function readDirectoryEntryNames(
+  fs: FileSystem,
+  directory: string,
+): Promise<string[] | null> {
+  const names: string[] = [];
+  try {
+    for await (const entry of fs.readDir(directory)) names.push(entry.name);
+  } catch (error) {
+    // A cooperating owner removes the lock directory after releasing its
+    // generation. Disappearance between lstat and enumeration is therefore a
+    // normal observation race, not storage corruption.
+    if (isCanonicalNotFoundError(error)) return null;
+    throw error;
+  }
+  return names;
+}
+
 async function readObservation(
   fs: FileSystem,
   lockDirectory: string,
@@ -135,11 +152,11 @@ async function readObservation(
   let ownerFileName: string | null = OWNER_FILE_NAME;
   let ownerText = await readBoundedText(fs, join(lockDirectory, OWNER_FILE_NAME));
   if (ownerText === null) {
-    directoryEntryNames = [];
+    directoryEntryNames = await readDirectoryEntryNames(fs, lockDirectory);
+    if (directoryEntryNames === null) return null;
     const ownerMarkers: string[] = [];
-    for await (const entry of fs.readDir(lockDirectory)) {
-      directoryEntryNames.push(entry.name);
-      if (LOCK_OWNER_MARKER_PATTERN.test(entry.name)) ownerMarkers.push(entry.name);
+    for (const entryName of directoryEntryNames) {
+      if (LOCK_OWNER_MARKER_PATTERN.test(entryName)) ownerMarkers.push(entryName);
     }
     if (ownerMarkers.length > 1) {
       throw new LocalJsonStoreLockError(
@@ -172,10 +189,8 @@ async function readObservation(
     // independently so ambiguous ownership can never make a live lock appear
     // ownerless and stale merely because the directory mtime is old.
     if (directoryEntryNames === null) {
-      directoryEntryNames = [];
-      for await (const entry of fs.readDir(lockDirectory)) {
-        directoryEntryNames.push(entry.name);
-      }
+      directoryEntryNames = await readDirectoryEntryNames(fs, lockDirectory);
+      if (directoryEntryNames === null) return null;
     }
     let newestLeaseMtimeMs: number | null = null;
     for (const entryName of directoryEntryNames) {

--- a/src/embedding/rag-store.test.ts
+++ b/src/embedding/rag-store.test.ts
@@ -315,6 +315,48 @@ describe("ragStore", () => {
     });
   });
 
+  it("retries when a completed writer removes the lock during observation", async () => {
+    await withTempDir(async (tempDir) => {
+      const storagePath = join(tempDir, "data", "index.json");
+      const lockDirectory = `${storagePath}.veryfront-rag.lock`;
+      await Deno.mkdir(lockDirectory, { recursive: true });
+
+      const readDirDescriptor = Object.getOwnPropertyDescriptor(Deno, "readDir");
+      assert(readDirDescriptor !== undefined);
+      const originalReadDir = Deno.readDir.bind(Deno);
+      let releaseObserved = false;
+      Object.defineProperty(Deno, "readDir", {
+        ...readDirDescriptor,
+        value: (path: string | URL) => {
+          if (String(path) !== lockDirectory || releaseObserved) {
+            return originalReadDir(path);
+          }
+          releaseObserved = true;
+          return {
+            [Symbol.asyncIterator]() {
+              return {
+                async next(): Promise<IteratorResult<Deno.DirEntry>> {
+                  await Deno.remove(lockDirectory, { recursive: true });
+                  throw new Deno.errors.NotFound("lock released during observation");
+                },
+              };
+            },
+          } satisfies AsyncIterable<Deno.DirEntry>;
+        },
+      });
+
+      try {
+        const store = ragStore({ model: "local/test-model", storagePath });
+        assertEquals(await store.listDocuments(), []);
+      } finally {
+        Object.defineProperty(Deno, "readDir", readDirDescriptor);
+      }
+
+      assertEquals(releaseObserved, true);
+      assertEquals(await exists(lockDirectory), false);
+    });
+  });
+
   it("recovers an expired adjacent store lock before reading", async () => {
     await withTempDir(async (tempDir) => {
       const storagePath = join(tempDir, "data", "index.json");


### PR DESCRIPTION
## Summary

- treat lock-directory disappearance between metadata inspection and enumeration as a completed-writer race
- keep ownership and lease mutations fail-closed
- add a deterministic regression for the release window that failed coverage shard 2

## Verification

- deno test --no-check --allow-all src/embedding/rag-store.test.ts
- deno fmt --check src/embedding/local-json-store-lock.ts src/embedding/rag-store.test.ts
- deno check src/embedding/local-json-store-lock.ts src/embedding/rag-store.test.ts
- deno task verify:quick
- git diff --check