### PR TITLE
fix(platform): fail closed on GitHub filesystem config errors

### DIFF
--- a/src/platform/adapters/fs/cache/file-cache.test.ts
+++ b/src/platform/adapters/fs/cache/file-cache.test.ts
@@ -367,6 +367,12 @@ describe("Distributed cache functions", () => {
       circular.self = circular;
       distributedCache.set("cyclic", circular);
       assertEquals(backendWrites, 0);
+
+      // Positive control: a serializable entry must reach the fake backend,
+      // proving the harness is live and the zero-write assertion above is not
+      // vacuously passing because the backend was never wired up.
+      distributedCache.set("serializable", { ok: true });
+      assertEquals(backendWrites, 1);
     });
 
     it("should return boolean", async () => {

--- a/src/platform/adapters/fs/github/adapter.ts
+++ b/src/platform/adapters/fs/github/adapter.ts
@@ -48,12 +48,6 @@ export class GitHubFSAdapter implements FSAdapter {
       retry: githubConfig.retry,
     };
 
-    if (!rawConfig.token) {
-      throw CONFIG_INVALID.create({
-        detail: "GitHub adapter requires a token; set GITHUB_TOKEN or pass config.github.token",
-      });
-    }
-
     this.config = createGitHubConfig(rawConfig);
     this.client = new GitHubApiClient(this.config);
 

--- a/src/platform/adapters/fs/github/github-api-client.test.ts
+++ b/src/platform/adapters/fs/github/github-api-client.test.ts
@@ -61,8 +61,7 @@ describe("GitHubApiClient", () => {
           ["repo", "r".repeat(257)],
         ] as const
       ) {
-        // A CONFIG-category error keeps enhanceAdapterWithFS failing closed;
-        // a bare TypeError would silently fall back to the local filesystem.
+        // Repository identity failures retain stable CONFIG error semantics.
         const error = assertThrows(
           () => new GitHubApiClient({ ...mockConfig, [field]: value }),
           VeryfrontError,

--- a/src/platform/adapters/fs/github/github-api-client.test.ts
+++ b/src/platform/adapters/fs/github/github-api-client.test.ts
@@ -7,6 +7,7 @@ import {
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 import { GitHubApiClient } from "./github-api-client.ts";
 
 const mockConfig = {
@@ -59,11 +60,14 @@ describe("GitHubApiClient", () => {
           ["repo", "r".repeat(257)],
         ] as const
       ) {
-        assertThrows(
+        // A CONFIG-category error keeps enhanceAdapterWithFS failing closed;
+        // a bare TypeError would silently fall back to the local filesystem.
+        const error = assertThrows(
           () => new GitHubApiClient({ ...mockConfig, [field]: value }),
-          TypeError,
+          VeryfrontError,
           "GitHub",
         );
+        assertEquals(error.slug, "config-validation-failed");
       }
     });
   });

--- a/src/platform/adapters/fs/github/github-api-client.test.ts
+++ b/src/platform/adapters/fs/github/github-api-client.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import {
   assertEquals,
   assertExists,
+  assertInstanceOf,
   assertRejects,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
@@ -67,6 +68,7 @@ describe("GitHubApiClient", () => {
           VeryfrontError,
           "GitHub",
         );
+        assertInstanceOf(error, VeryfrontError);
         assertEquals(error.slug, "config-validation-failed");
       }
     });

--- a/src/platform/adapters/fs/github/github-api-client.ts
+++ b/src/platform/adapters/fs/github/github-api-client.ts
@@ -106,10 +106,7 @@ export class GitHubApiClient {
   private rateLimitInfo: RateLimitInfo | null = null;
 
   constructor(private readonly config: ResolvedGitHubConfig) {
-    // Invalid repository identity is a configuration error: it must fail
-    // closed (surface as a CONFIG-category VeryfrontError) instead of a bare
-    // TypeError that enhanceAdapterWithFS would swallow before silently
-    // falling back to the host-local filesystem adapter.
+    // Invalid repository identity remains a CONFIG-category boundary error.
     try {
       const owner = encodeRepositorySegment(config.owner, "owner");
       const repo = encodeRepositorySegment(config.repo, "repository");

--- a/src/platform/adapters/fs/github/github-api-client.ts
+++ b/src/platform/adapters/fs/github/github-api-client.ts
@@ -1,4 +1,5 @@
 import { createError, retryWithBackoff, toError } from "#veryfront/errors";
+import { CONFIG_VALIDATION_FAILED } from "#veryfront/errors/error-registry/config.ts";
 import { logger } from "#veryfront/utils";
 import type { ResolvedGitHubConfig } from "./types.ts";
 import {
@@ -105,9 +106,20 @@ export class GitHubApiClient {
   private rateLimitInfo: RateLimitInfo | null = null;
 
   constructor(private readonly config: ResolvedGitHubConfig) {
-    const owner = encodeRepositorySegment(config.owner, "owner");
-    const repo = encodeRepositorySegment(config.repo, "repository");
-    this.repositoryEndpoint = `/repos/${owner}/${repo}`;
+    // Invalid repository identity is a configuration error: it must fail
+    // closed (surface as a CONFIG-category VeryfrontError) instead of a bare
+    // TypeError that enhanceAdapterWithFS would swallow before silently
+    // falling back to the host-local filesystem adapter.
+    try {
+      const owner = encodeRepositorySegment(config.owner, "owner");
+      const repo = encodeRepositorySegment(config.repo, "repository");
+      this.repositoryEndpoint = `/repos/${owner}/${repo}`;
+    } catch (cause) {
+      throw CONFIG_VALIDATION_FAILED.create({
+        detail: cause instanceof Error ? cause.message : "GitHub repository identity is invalid",
+        cause,
+      });
+    }
   }
 
   get repoId(): string {

--- a/src/platform/adapters/fs/github/types.ts
+++ b/src/platform/adapters/fs/github/types.ts
@@ -68,17 +68,19 @@ const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000;
 const DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
 
+function isBlankConfigValue(value: unknown): boolean {
+  return typeof value !== "string" || value.trim().length === 0;
+}
+
 export function createGitHubConfig(config: GitHubConfig): ResolvedGitHubConfig {
-  // CONFIG-category registry errors fail closed in enhanceAdapterWithFS;
-  // legacy plain Errors would trigger its silent local-filesystem fallback.
-  if (!config.token) {
+  if (isBlankConfigValue(config.token)) {
     throw CONFIG_INVALID.create({
       detail:
         "GitHub adapter requires a token. Set GITHUB_TOKEN environment variable or provide token in config.",
     });
   }
 
-  if (!config.owner || !config.repo) {
+  if (isBlankConfigValue(config.owner) || isBlankConfigValue(config.repo)) {
     throw CONFIG_INVALID.create({
       detail:
         "GitHub adapter requires owner and repo. Provide them in config or via GITHUB_OWNER and GITHUB_REPO environment variables.",

--- a/src/platform/adapters/fs/github/types.ts
+++ b/src/platform/adapters/fs/github/types.ts
@@ -1,4 +1,4 @@
-import { createError, toError } from "#veryfront/errors";
+import { CONFIG_INVALID } from "#veryfront/errors";
 
 export type { DirectoryEntry } from "../shared-types.ts";
 
@@ -69,24 +69,20 @@ const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000;
 const DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
 
 export function createGitHubConfig(config: GitHubConfig): ResolvedGitHubConfig {
+  // CONFIG-category registry errors fail closed in enhanceAdapterWithFS;
+  // legacy plain Errors would trigger its silent local-filesystem fallback.
   if (!config.token) {
-    throw toError(
-      createError({
-        type: "config",
-        message:
-          "GitHub adapter requires a token. Set GITHUB_TOKEN environment variable or provide token in config.",
-      }),
-    );
+    throw CONFIG_INVALID.create({
+      detail:
+        "GitHub adapter requires a token. Set GITHUB_TOKEN environment variable or provide token in config.",
+    });
   }
 
   if (!config.owner || !config.repo) {
-    throw toError(
-      createError({
-        type: "config",
-        message:
-          "GitHub adapter requires owner and repo. Provide them in config or via GITHUB_OWNER and GITHUB_REPO environment variables.",
-      }),
-    );
+    throw CONFIG_INVALID.create({
+      detail:
+        "GitHub adapter requires owner and repo. Provide them in config or via GITHUB_OWNER and GITHUB_REPO environment variables.",
+    });
   }
 
   return {

--- a/src/platform/adapters/fs/integration.test.ts
+++ b/src/platform/adapters/fs/integration.test.ts
@@ -4,8 +4,10 @@ import {
   assertExists,
   assertInstanceOf,
   assertRejects,
+  assertStrictEquals,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   createFSAdapterFromConfig,
   enhanceAdapterWithFS,
@@ -99,7 +101,7 @@ describe("integration.ts", () => {
     assertEquals(getFSAdapterType({ fs: {} }), "local");
   });
 
-  describe("enhanceAdapterWithFS error fallback", () => {
+  describe("enhanceAdapterWithFS error propagation", () => {
     it("should preserve invalid retry configuration instead of changing filesystems", async () => {
       let rejection: unknown;
       try {
@@ -174,28 +176,131 @@ describe("integration.ts", () => {
       assertEquals(error.slug, "config-invalid");
     });
 
-    it("should fall back to original adapter for unsupported type", async () => {
-      const adapter = await enhanceAdapterWithFS(denoAdapter, {
-        fs: { type: "unsupported-type" as any },
-      });
-      assertEquals(adapter, denoAdapter);
-    });
-
-    it("should fall back to original adapter for github type without config", async () => {
-      const adapter = await enhanceAdapterWithFS(denoAdapter, {
-        fs: { type: "github" },
-      });
-      assertEquals(adapter, denoAdapter);
-    });
-
-    it("should pass projectDir to FSAdapter config", async () => {
-      // With an unsupported type, it will fail and fall back, but the branch is exercised
-      const adapter = await enhanceAdapterWithFS(
-        denoAdapter,
-        { fs: { type: "unknown-type" as any } },
-        "/some/project/dir",
+    it("should fail closed when the GitHub token contains only whitespace", async () => {
+      let requests = 0;
+      const error = await withMockFetch(
+        () => {
+          requests += 1;
+          return Promise.resolve(new Response("Unauthorized", { status: 401 }));
+        },
+        () =>
+          assertRejects(
+            () =>
+              enhanceAdapterWithFS(denoAdapter, {
+                fs: {
+                  type: "github",
+                  github: { token: " ", owner: "owner", repo: "repo" },
+                },
+              }),
+            VeryfrontError,
+            "token",
+          ),
       );
-      assertEquals(adapter, denoAdapter);
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "config-invalid");
+      assertEquals(requests, 0);
+    });
+
+    it("should propagate GitHub network initialization failures", async () => {
+      const networkFailure = new Error("simulated GitHub outage");
+      const error = await withMockFetch(
+        () => Promise.reject(networkFailure),
+        () =>
+          assertRejects(() =>
+            enhanceAdapterWithFS(denoAdapter, {
+              fs: {
+                type: "github",
+                github: {
+                  token: "test-token",
+                  owner: "owner",
+                  repo: "repo",
+                  retry: { maxRetries: 1, initialDelay: 0, maxDelay: 0 },
+                },
+              },
+            })
+          ),
+      );
+      assertStrictEquals(error, networkFailure);
+    });
+
+    it("should propagate GitHub authentication failures", async () => {
+      const error = await withMockFetch(
+        () => Promise.resolve(new Response("Unauthorized", { status: 401 })),
+        () =>
+          assertRejects(
+            () =>
+              enhanceAdapterWithFS(denoAdapter, {
+                fs: {
+                  type: "github",
+                  github: {
+                    token: "invalid-token",
+                    owner: "owner",
+                    repo: "repo",
+                    retry: { maxRetries: 1, initialDelay: 0, maxDelay: 0 },
+                  },
+                },
+              }),
+            Error,
+            "authentication",
+          ),
+      );
+      assertInstanceOf(error, Error);
+    });
+
+    it("should propagate unsupported adapter failures", async () => {
+      await assertRejects(
+        () =>
+          enhanceAdapterWithFS(denoAdapter, {
+            fs: { type: "unsupported-type" as any },
+          }),
+        Error,
+        'FSAdapter type "unsupported-type" is not implemented',
+      );
+    });
+
+    it("should fail closed for github type without config", async () => {
+      await assertRejects(
+        () =>
+          enhanceAdapterWithFS(denoAdapter, {
+            fs: { type: "github" },
+          }),
+        Error,
+        "GitHub adapter requires github configuration",
+      );
+    });
+
+    it("should not consult VeryfrontError Symbol.hasInstance while propagating", async () => {
+      const originalHasInstance = Object.getOwnPropertyDescriptor(
+        VeryfrontError,
+        Symbol.hasInstance,
+      );
+      Object.defineProperty(VeryfrontError, Symbol.hasInstance, {
+        configurable: true,
+        value() {
+          throw new Error("poisoned VeryfrontError Symbol.hasInstance was used");
+        },
+      });
+
+      let caught: unknown;
+      try {
+        await enhanceAdapterWithFS(denoAdapter, {
+          fs: {
+            type: "github",
+            github: { token: "test-token", owner: "team/other", repo: "repo" },
+          },
+        });
+      } catch (error) {
+        caught = error;
+      } finally {
+        if (originalHasInstance) {
+          Object.defineProperty(VeryfrontError, Symbol.hasInstance, originalHasInstance);
+        } else {
+          Reflect.deleteProperty(VeryfrontError, Symbol.hasInstance);
+        }
+      }
+
+      assertInstanceOf(caught, VeryfrontError);
+      assertEquals(caught.slug, "config-validation-failed");
     });
   });
 

--- a/src/platform/adapters/fs/integration.test.ts
+++ b/src/platform/adapters/fs/integration.test.ts
@@ -140,6 +140,40 @@ describe("integration.ts", () => {
       assertEquals(error.slug, "config-validation-failed");
     });
 
+    it("should fail closed when GitHub repository identity is invalid", async () => {
+      const error = await assertRejects(
+        () =>
+          enhanceAdapterWithFS(denoAdapter, {
+            fs: {
+              type: "github",
+              github: { token: "test-token", owner: "team/other", repo: "repo" },
+            },
+          }),
+        VeryfrontError,
+        "GitHub owner",
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "config-validation-failed");
+    });
+
+    it("should fail closed when the GitHub adapter has no token", async () => {
+      // token: "" is explicit so the GITHUB_TOKEN environment variable cannot
+      // satisfy the requirement and mask the regression in CI.
+      const error = await assertRejects(
+        () =>
+          enhanceAdapterWithFS(denoAdapter, {
+            fs: {
+              type: "github",
+              github: { token: "", owner: "owner", repo: "repo" },
+            },
+          }),
+        VeryfrontError,
+        "token",
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "config-invalid");
+    });
+
     it("should fall back to original adapter for unsupported type", async () => {
       const adapter = await enhanceAdapterWithFS(denoAdapter, {
         fs: { type: "unsupported-type" as any },

--- a/src/platform/adapters/fs/integration.ts
+++ b/src/platform/adapters/fs/integration.ts
@@ -64,7 +64,11 @@ export function enhanceAdapterWithFS(
 
         return enhancedAdapter;
       } catch (error) {
-        if (error instanceof VeryfrontError && error.slug === "config-validation-failed") {
+        // Any configuration-class failure must fail closed: silently falling
+        // back to the host-local filesystem on a misconfigured remote adapter
+        // would serve the wrong filesystem. Only non-config runtime failures
+        // (network, transient init) may degrade to the local adapter.
+        if (error instanceof VeryfrontError && error.category === "CONFIG") {
           throw error;
         }
         logger.error("Failed to initialize FSAdapter", {

--- a/src/platform/adapters/fs/integration.ts
+++ b/src/platform/adapters/fs/integration.ts
@@ -4,7 +4,6 @@ import { createFSAdapter } from "./factory.ts";
 import { wrapFSAdapter } from "./wrapper.ts";
 import { logger as baseLogger } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
-import { VeryfrontError } from "#veryfront/errors/types.ts";
 
 const logger = baseLogger.component("fs-integration");
 
@@ -35,50 +34,36 @@ export function enhanceAdapterWithFS(
   return withSpan(
     "platform.fs.enhanceAdapterWithFS",
     async () => {
-      try {
-        logger.debug("Initializing FSAdapter", {
-          type: fsType,
-          projectSlug: config.fs?.veryfront?.projectSlug,
-        });
+      logger.debug("Initializing FSAdapter", {
+        type: fsType,
+        projectSlug: config.fs?.veryfront?.projectSlug,
+      });
 
-        const fsAdapterConfig: FSAdapterConfig = {
-          ...config.fs,
-          projectDir,
-        };
+      const fsAdapterConfig: FSAdapterConfig = {
+        ...config.fs,
+        projectDir,
+      };
 
-        const fsAdapter = await createFSAdapter(fsAdapterConfig);
-        const wrappedFS = wrapFSAdapter(fsAdapter);
+      // An explicitly selected remote filesystem is an authority boundary.
+      // Propagate every initialization failure so callers never continue with
+      // the host-local adapter and serve files from the wrong source.
+      const fsAdapter = await createFSAdapter(fsAdapterConfig);
+      const wrappedFS = wrapFSAdapter(fsAdapter);
 
-        const enhancedAdapter: RuntimeAdapter = new Proxy(adapter, {
-          get(target, prop, receiver) {
-            if (prop === "fs") return wrappedFS;
+      const enhancedAdapter: RuntimeAdapter = new Proxy(adapter, {
+        get(target, prop, receiver) {
+          if (prop === "fs") return wrappedFS;
 
-            const value = Reflect.get(target, prop, receiver);
-            return typeof value === "function" ? value.bind(target) : value;
-          },
-        });
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
 
-        logger.debug("FSAdapter initialized successfully", {
-          type: fsType,
-        });
+      logger.debug("FSAdapter initialized successfully", {
+        type: fsType,
+      });
 
-        return enhancedAdapter;
-      } catch (error) {
-        // Any configuration-class failure must fail closed: silently falling
-        // back to the host-local filesystem on a misconfigured remote adapter
-        // would serve the wrong filesystem. Only non-config runtime failures
-        // (network, transient init) may degrade to the local adapter.
-        if (error instanceof VeryfrontError && error.category === "CONFIG") {
-          throw error;
-        }
-        logger.error("Failed to initialize FSAdapter", {
-          error: error instanceof Error ? error.message : String(error),
-          type: fsType,
-        });
-
-        logger.warn("Falling back to local filesystem");
-        return adapter;
-      }
+      return enhancedAdapter;
     },
     { "fs.adapter.type": fsType },
   );

--- a/src/platform/adapters/fs/veryfront/path-normalizer.test.ts
+++ b/src/platform/adapters/fs/veryfront/path-normalizer.test.ts
@@ -152,6 +152,18 @@ describe("PathNormalizer", () => {
       );
     });
 
+    it("should reject C1 control characters like the GitHub normalizer", () => {
+      const normalizer = new PathNormalizer();
+      // U+0080 and U+009F bound the C1 range; NUL is the C0 control anchor.
+      for (const codeUnit of [0x00, 0x80, 0x9f]) {
+        assertThrows(
+          () => normalizer.normalize(`src/${String.fromCharCode(codeUnit)}secrets.ts`),
+          TypeError,
+          "must not contain control characters",
+        );
+      }
+    });
+
     it("should reject unbounded paths", () => {
       const normalizer = new PathNormalizer();
       assertThrows(

--- a/src/platform/adapters/fs/veryfront/path-normalizer.ts
+++ b/src/platform/adapters/fs/veryfront/path-normalizer.ts
@@ -4,7 +4,7 @@ import { CONFIG_VALIDATION_FAILED } from "#veryfront/errors/error-registry/confi
 const logger = baseLogger.component("path-normalizer");
 const MAX_PATH_CODE_UNITS = 4_096;
 
-// Rejects the full non-printable control range (C0, DEL, and C1) — the same
+// Rejects the full non-printable control range (C0, DEL, and C1), the same
 // policy as the GitHub path normalizer in ../github/path-utils.ts.
 function hasControlCharacter(value: string): boolean {
   for (let index = 0; index < value.length; index++) {

--- a/src/platform/adapters/fs/veryfront/path-normalizer.ts
+++ b/src/platform/adapters/fs/veryfront/path-normalizer.ts
@@ -4,10 +4,12 @@ import { CONFIG_VALIDATION_FAILED } from "#veryfront/errors/error-registry/confi
 const logger = baseLogger.component("path-normalizer");
 const MAX_PATH_CODE_UNITS = 4_096;
 
-function hasAsciiControlCharacter(value: string): boolean {
+// Rejects the full non-printable control range (C0, DEL, and C1) — the same
+// policy as the GitHub path normalizer in ../github/path-utils.ts.
+function hasControlCharacter(value: string): boolean {
   for (let index = 0; index < value.length; index++) {
     const codeUnit = value.charCodeAt(index);
-    if (codeUnit <= 0x1f || codeUnit === 0x7f) return true;
+    if (codeUnit <= 0x1f || (codeUnit >= 0x7f && codeUnit <= 0x9f)) return true;
   }
   return false;
 }
@@ -97,7 +99,7 @@ export class PathNormalizer {
         `Filesystem ${label} exceeds the ${MAX_PATH_CODE_UNITS}-character limit`,
       );
     }
-    if (hasAsciiControlCharacter(path)) {
+    if (hasControlCharacter(path)) {
       throw new TypeError(`Filesystem ${label} must not contain control characters`);
     }
     if (path.includes("\\")) {


### PR DESCRIPTION
Follow-up to #3323 and #3315. This closes the filesystem authority gap where an explicitly configured remote source could silently downgrade to the host-local filesystem.

## Problem

`enhanceAdapterWithFS` previously returned the base runtime adapter after many remote adapter initialization failures. That behavior changed the configured source authority:

- Invalid GitHub identity and some configuration errors could fall through to local files.
- Network and authentication failures always fell through to local files.
- `VeryfrontError[Symbol.hasInstance]` mutation could bypass the partial CONFIG-only guard.
- Whitespace-only GitHub tokens reached the network instead of failing at configuration construction.

In a hosted or multi-project runtime, continuing with host-local files after remote selection fails can serve the wrong source.

## Fix

- Explicit remote filesystem selection now propagates every initialization failure. Local files are used only when no remote type is selected or `type: "local"` is explicit.
- Removed the `instanceof VeryfrontError` classification path and the local fallback catch.
- GitHub configuration construction rejects blank tokens, owners, and repository names.
- GitHub repository identity failures use the CONFIG error registry.
- Veryfront filesystem paths reject the full C0, DEL, and C1 control range.
- File-cache serialization coverage includes a positive backend-write control.

## Upgrade note

Remote filesystem startup is now fail closed. Applications that intentionally use local files must select `fs.type: "local"` or omit the remote filesystem configuration. A failed GitHub or Veryfront API initialization no longer continues against the process filesystem.

## Verification

- Red-green integration proof for blank token, network failure, authentication failure, unsupported type, missing GitHub config, and poisoned `VeryfrontError[Symbol.hasInstance]`.
- Complete filesystem adapter suite: 51 tests, 864 steps, 0 failures.
- Changed-file `deno fmt --check`, `deno lint`, `deno check --no-lock`, and `git diff --check`: pass.
- `deno task verify:quick`: pass, including manifests, format, lint ratchets, zero core dependencies, dependency boundaries, docs validation, and public entrypoint type checks.
