### PR TITLE
docs(security): document hosted identity rollout order and close #3290 review gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ REDIS_URL=
 # PROXY_MODE=1
 # NODE_ENV=production
 # CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY=
+# Required (exactly "1") for hosted proxy mode; the runtime refuses to boot
+# without it. Set it only when the process is private behind a sanitising
+# edge. Rollout order for existing deployments: set this variable first, then
+# deploy the proxy tier, then the runtime tier — see src/security/README.md
+# ("Rollout ordering for hosted identity changes").
 # VERYFRONT_TRUST_FORWARDED_HEADERS=1
 
 # Host outbound network policy

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ REDIS_URL=
 # Required (exactly "1") for hosted proxy mode; the runtime refuses to boot
 # without it. Set it only when the process is private behind a sanitising
 # edge. Rollout order for existing deployments: set this variable first, then
-# deploy the proxy tier, then the runtime tier — see src/security/README.md
+# deploy the proxy tier, then the runtime tier. See src/security/README.md
 # ("Rollout ordering for hosted identity changes").
 # VERYFRONT_TRUST_FORWARDED_HEADERS=1
 

--- a/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
@@ -99,6 +99,43 @@ describe("ProxyFSAdapterManager", () => {
         manager.dispose();
       }
     });
+
+    it("disposes the uncached adapter when initialization fails", async () => {
+      let disposeCalls = 0;
+      const manager = createManager({
+        adapterFactory: (config) => {
+          const adapter = new VeryfrontFSAdapter(config);
+          adapter.initialize = () => Promise.reject(new Error("init failed"));
+          const originalDispose = adapter.dispose.bind(adapter);
+          adapter.dispose = () => {
+            disposeCalls++;
+            originalDispose();
+          };
+          return adapter;
+        },
+      });
+
+      try {
+        await assertRejects(
+          () =>
+            manager.getAdapter(
+              "my-project",
+              "test-token",
+              undefined,
+              false,
+              null,
+              null,
+              "main",
+            ),
+          Error,
+          "init failed",
+        );
+        assertEquals(disposeCalls, 1);
+        assertEquals(manager.hasAdapter("my-project", false, null, "main"), false);
+      } finally {
+        manager.dispose();
+      }
+    });
   });
 
   describe("exact production source", () => {

--- a/src/platform/adapters/fs/veryfront/proxy-manager.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.ts
@@ -512,6 +512,17 @@ export class ProxyFSAdapterManager {
           error: error instanceof Error ? error.message : String(error),
         });
 
+        // The failed adapter is never cached, so nothing else releases the
+        // resources it may have allocated before initialize() threw.
+        try {
+          adapter.dispose();
+        } catch (disposeError) {
+          logger.debug("Adapter dispose after failed initialization threw", {
+            cacheKey: diagnosticCacheKey,
+            error: disposeError instanceof Error ? disposeError.message : String(disposeError),
+          });
+        }
+
         throw error;
       } finally {
         projectAdapter.initializing = undefined;

--- a/src/proxy/control-plane-signature.ts
+++ b/src/proxy/control-plane-signature.ts
@@ -239,7 +239,9 @@ export async function resolveVerifiedControlPlaneBranchBinding(
     maxAgeSeconds: MAX_SIGNATURE_AGE_SECONDS,
     audience: binding.audience,
     expectedProjectId: binding.expectedProjectId,
-    requestMethod: req.method,
+    // The route gate above admits only POST (case-insensitively); verify the
+    // canonical method the control plane signs rather than the raw casing.
+    requestMethod: "POST",
     requestPath: url.pathname,
   });
   if (!verified) {

--- a/src/security/README.md
+++ b/src/security/README.md
@@ -97,6 +97,46 @@ endpoint is an error; there is no compatibility fallback to masked management
 values. Leave both internal credential variables unset when that endpoint is
 not deployed.
 
+#### Trust boundary and residual risk
+
+With `VERYFRONT_TRUST_FORWARDED_HEADERS=1` set, identity headers are trusted
+purely on network topology: any peer that can reach the runtime origin can
+assert project, environment, and branch identity on routes outside the signed
+control-plane path. There is no per-request cryptographic binding on the
+proxy-to-runtime hop, so the design has no defence in depth if pod network
+privacy fails. Operators must keep the runtime origin unreachable except from
+the proxy (private service plus network policy). Planned follow-up: an
+authenticated proxy-to-runtime hop (mTLS or a per-hop shared secret) so
+identity headers are honoured only on an authenticated channel. Agent-run
+dispatch is already independent of this hop; its branch and environment
+binding comes from the signed control-plane request body.
+
+#### Rollout ordering for hosted identity changes
+
+The hosted runtime fails closed at boot without
+`VERYFRONT_TRUST_FORWARDED_HEADERS=1`, and hosted agent runs fail closed
+without the branch identity that only the current proxy derives from the
+signed control-plane body. Upgrading an existing deployment is safe in this
+order:
+
+1. Set `VERYFRONT_TRUST_FORWARDED_HEADERS=1` (and ensure
+   `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` is set) on the runtime environment
+   while it still runs the previous version. Earlier runtimes already accept
+   the variable as an explicit operator trust opt-in, so this step is
+   behaviour-preserving inside the required private topology.
+2. Deploy the proxy tier. Earlier runtimes ignore the added
+   `x-default-branch-name` header, and the `vf-utf8:` branch-name encoding is
+   applied only to values an earlier proxy could not forward at all.
+3. Deploy the runtime tier. A new runtime booted without step 1 crash-loops
+   intentionally; a new runtime behind an old proxy rejects hosted
+   preview-branch and non-default-branch agent runs with `PERMISSION_DENIED`
+   because branch identity must come from the verified control-plane binding.
+
+Roll back in the reverse order (runtime first, then proxy). The trust variable
+can remain set during rollback. There is deliberately no warn-only
+compatibility mode for a missing trust declaration or missing branch binding:
+either one would let unbound identity select tenant data.
+
 ### Input validation
 
 Each standalone body, form, and query parser applies the same snapshotted

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -615,7 +615,10 @@ function validateProductionEnvironment(): void {
     if (!isProxyTopologyTrusted()) {
       logger.error(
         "[Bootstrap:Prod] CRITICAL: proxy mode does not trust its upstream topology. " +
-          "Set VERYFRONT_TRUST_FORWARDED_HEADERS=1 only when this process is private behind a sanitising edge.",
+          "Set VERYFRONT_TRUST_FORWARDED_HEADERS=1 only when this process is private behind a sanitising edge. " +
+          "Existing hosted deployments must set this variable on the runtime environment before rolling out " +
+          "this version, and must upgrade the proxy tier before (or together with) the runtime tier. " +
+          "See src/security/README.md, 'Rollout ordering for hosted identity changes'.",
       );
       throw INVALID_ARGUMENT.create({
         detail:

--- a/src/server/project-env/cache.ts
+++ b/src/server/project-env/cache.ts
@@ -127,9 +127,14 @@ function nonNegativeInteger(value: number, name: string): number {
   return value;
 }
 
-function abortReason(signal: AbortSignal): unknown {
-  return signal.reason ?? CACHE_ERROR.create({
+function abortReason(signal: AbortSignal): Error {
+  const reason = signal.reason;
+  // Every internal abort passes a typed Error, but the typed error contract
+  // must hold even for an unexpected non-Error reason.
+  if (reason instanceof Error) return reason;
+  return CACHE_ERROR.create({
     detail: "Project environment fetch was cancelled",
+    ...(reason === undefined || reason === null ? {} : { cause: reason }),
   });
 }
 

--- a/src/server/runtime-handler/project-resolution.ts
+++ b/src/server/runtime-handler/project-resolution.ts
@@ -113,6 +113,13 @@ export function extractRequestHeaders(
     ? req.headers.get("x-environment") ?? url.searchParams.get("x-environment") ?? undefined
     : undefined;
 
+  // `x-release-id`, `x-content-source-id`, and `x-project-path` are read
+  // without the identity-trust gate deliberately: local single-project and
+  // eval flows supply them directly, `x-project-path` is re-guarded by the
+  // adapter factory behind the same proxy trust check, and proxy mode rejects
+  // every untrusted request outright in createProxyGuard before these values
+  // can select tenant identity. Do not add tenant-identity headers here
+  // without gating them on identityHeadersTrusted.
   return {
     projectSlug: projectSlugHeader ?? parsedDomain.slug ?? undefined,
     projectId: identityHeadersTrusted ? req.headers.get("x-project-id") ?? undefined : undefined,


### PR DESCRIPTION
## Summary

PR #3290 merged while its review-fix pass was still running. This follow-up ports the remaining review fixes from the stale PR branch (commit 0a0345eb8, cherry-picked onto main):

- **Rollout runbook** in `src/security/README.md`: safe deploy order for the hosted identity binding (set `VERYFRONT_TRUST_FORWARDED_HEADERS=1` on the old runtime first → deploy proxy tier → deploy runtime tier; rollback in reverse), plus rationale for not adding a warn-only old-proxy fallback (would break fail-closed).
- **Actionable crash-loop error**: the bootstrap error in hosted proxy mode now states exactly which env var to set and points at the runbook; `.env.example` comment expanded.
- **Trust boundary & residual risk** section documenting the purely topological trust of identity headers and the mTLS / per-hop-secret follow-up.
- Reviewer nits: canonicalize signed method to `POST` in `resolveVerifiedControlPlaneBranchBinding`; best-effort `adapter.dispose()` when `initialize()` fails in `proxy-manager.ts` (+ regression test); coerce non-Error abort reasons to typed `CACHE_ERROR` in `src/server/project-env/cache.ts`; drift-guard comment on the intentional asymmetric header gating in `extractRequestHeaders`.

Complements #3332 (which ports the SSR transport commits); no overlap.

## Test plan
- Targeted suites already green on the source branch: proxy-manager, project-env cache, control-plane-signature, bootstrap, project-resolution, agent-stream.handler, mode-parity
- CI on this PR runs the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)