### PR TITLE
test(config): stabilize worker admission cleanup regression

### DIFF
--- a/src/config/declarative-evaluator-worker.test.ts
+++ b/src/config/declarative-evaluator-worker.test.ts
@@ -1003,14 +1003,17 @@ Deno.test("declarative config worker releases admission after a stuck terminatio
   const payload = await createPayload("export default { ready: true };");
   const admission = declarativeConfigWorkerRunnerInternals
     .createAdmissionController(1, 0);
+  const abort = new AbortController();
   let terminationCount = 0;
 
   const first = declarativeConfigWorkerRunnerInternals
     .evaluateWithAdmissionController(
       payload,
-      { timeoutMs: 1 },
+      { signal: abort.signal, timeoutMs: 100 },
       async () => ({
-        postMessage() {},
+        postMessage() {
+          abort.abort();
+        },
         subscribe() {
           return () => {};
         },
@@ -1023,11 +1026,11 @@ Deno.test("declarative config worker releases admission after a stuck terminatio
       5,
     );
 
-  const timeoutError = await assertRejects(
+  const abortError = await assertRejects(
     () => first,
     DeclarativeConfigEvaluationError,
   ) as DeclarativeConfigEvaluationError;
-  assertEquals(timeoutError.reason, "worker-timeout");
+  assertEquals(abortError.reason, "worker-aborted");
   assertEquals(terminationCount, 1);
   await waitForAdmissionState(admission, { active: 0, queued: 0 });
 


### PR DESCRIPTION
## Summary

Fixes the current `main` CI failure in coverage shard 1/8 by removing a wall-clock race from `src/config/declarative-evaluator-worker.test.ts`.

The failing CI assertion expected `terminationCount === 1`, but the test used `timeoutMs: 1`. Under runner load the deadline can fire before the fake endpoint is created, so the test observes zero terminations and fails before it proves the stuck-termination cleanup contract.

This patch triggers cancellation from the fake endpoint after subscription instead. That deterministically exercises the same stuck termination drain and admission release path without depending on a 1 ms startup race.

## Failure

Main CI failure: https://github.com/veryfront/veryfront-code/actions/runs/30817108809/job/91697452911

Observed failure:
- `src/config/declarative-evaluator-worker.test.ts:1031`
- expected `terminationCount` to be `1`
- actual `terminationCount` was `0`

## Verification

Passed:
- `npx --yes deno@2.7.7 test --no-check --allow-all --unstable-worker-options --unstable-net src/config/declarative-evaluator-worker.test.ts`
- `npx --yes deno@2.7.7 check src/config/declarative-evaluator-worker.test.ts`
- `npx --yes deno@2.7.7 lint src/config/declarative-evaluator-worker.test.ts`
- `npx --yes deno@2.7.7 fmt --check src/config/declarative-evaluator-worker.test.ts`
- `git diff --check`
- repeated focused single-test run 5x
- local coverage-shard-shaped run reached and passed the formerly failing worker test
- reran the unrelated pre-push failure directly: `src/security/sandbox/worker-script.test.ts` passed, 6 suites / 43 steps

Local caveat:
- The broad local shard later failed in `cli/commands/schedule/handler.test.ts` because the local SOCKS proxy rejected a request to `93.184.216.34`.
- The normal pre-push hook later failed once in `src/security/sandbox/worker-script.test.ts` after 3,725 passing tests; direct rerun of that file passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated worker termination coverage to validate in-flight abort handling.
  * Confirmed workers terminate once, release admission capacity, and allow subsequent evaluations to succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->