### PR TITLE
fix(security): patch audited brace-expansion dependency

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -8,6 +8,8 @@ on:
       - "cli/deno.json"
       - "react/deno.json"
       - "extensions/**/deno.json"
+      - "storybook/package.json"
+      - "storybook/package-lock.json"
       - "scripts/build/generate-sbom.ts"
       - "scripts/lib/deno-lock.ts"
       - "scripts/lint/audit-core-deps.ts"

--- a/deno.json
+++ b/deno.json
@@ -545,7 +545,7 @@
     "sbom": "deno run --allow-read --allow-write scripts/build/generate-sbom.ts",
     "sbom:all": "deno run --allow-read --allow-write scripts/build/generate-sbom.ts --all-manifests",
     "submit-deps": "deno run --allow-read --allow-env --allow-net=api.github.com scripts/security/submit-dependency-snapshot.ts",
-    "audit": "deno run --allow-read --allow-run --allow-write scripts/security/audit-npm.ts"
+    "audit": "deno run --allow-read --allow-run --allow-write scripts/security/audit-npm.ts && npm --prefix storybook audit --package-lock-only --audit-level=high"
   },
   "lint": {
     "include": [

--- a/deno.lock
+++ b/deno.lock
@@ -61,7 +61,7 @@
     "npm:ajv@8.18.0": "8.18.0",
     "npm:bash-tool@1.3.18": "1.3.18_ai@7.0.41__zod@3.25.76_just-bash@3.0.1",
     "npm:better-sqlite3@9.6.0": "9.6.0",
-    "npm:brace-expansion@5.0.8": "5.0.8",
+    "npm:brace-expansion@5.0.9": "5.0.9",
     "npm:browserslist@4.28.7": "4.28.7",
     "npm:daisyui@5.5.14": "5.5.14",
     "npm:es-module-lexer@2.3.1": "2.3.1",
@@ -2961,8 +2961,8 @@
     "bowser@2.14.1": {
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
-    "brace-expansion@5.0.8": {
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+    "brace-expansion@5.0.9": {
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dependencies": [
         "balanced-match"
       ]
@@ -6545,7 +6545,7 @@
           "jsr:@std/testing@1.0.17",
           "npm:ai@7.0.41",
           "npm:bash-tool@1.3.18",
-          "npm:brace-expansion@5.0.8",
+          "npm:brace-expansion@5.0.9",
           "npm:just-bash@3.0.1"
         ]
       },

--- a/extensions/ext-sandbox-shell-tools/deno.json
+++ b/extensions/ext-sandbox-shell-tools/deno.json
@@ -14,7 +14,7 @@
   "imports": {
     "ai": "npm:ai@7.0.41",
     "bash-tool": "npm:bash-tool@1.3.18",
-    "brace-expansion": "npm:brace-expansion@5.0.8",
+    "brace-expansion": "npm:brace-expansion@5.0.9",
     "just-bash": "npm:just-bash@3.0.1",
     "@std/assert": "jsr:@std/assert@1.0.19",
     "@std/testing/bdd": "jsr:@std/testing@1.0.17/bdd",

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -404,7 +404,7 @@ describe("normalizeNpmPackageMetadata", () => {
         "@opentelemetry/sdk-metrics": "2.8.0",
         "@opentelemetry/sdk-node": "0.218.0",
         "@sentry/deno": "10.68.0",
-        "brace-expansion": "5.0.8",
+        "brace-expansion": "5.0.9",
         "gaxios": "7.2.0",
         "gcp-metadata": "8.1.2",
         "protobufjs": "7.6.5",

--- a/scripts/build/proxy-deno.lock
+++ b/scripts/build/proxy-deno.lock
@@ -1690,7 +1690,7 @@
           "jsr:@std/testing@1.0.17",
           "npm:ai@7.0.41",
           "npm:bash-tool@1.3.18",
-          "npm:brace-expansion@5.0.8",
+          "npm:brace-expansion@5.0.9",
           "npm:just-bash@3.0.1"
         ]
       },

--- a/scripts/deno.lock
+++ b/scripts/deno.lock
@@ -14,6 +14,7 @@
     "jsr:@std/path@1.1.4": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/testing@1.0.17": "1.0.17",
+    "jsr:@std/yaml@1.1.0": "1.1.0",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
     "jsr:@ts-morph/common@0.27": "0.27.0",
     "npm:@babel/parser@7.29.2": "7.29.2",
@@ -69,6 +70,9 @@
         "jsr:@std/assert@^1.0.17",
         "jsr:@std/internal"
       ]
+    },
+    "@std/yaml@1.1.0": {
+      "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     },
     "@ts-morph/bootstrap@0.27.0": {
       "integrity": "b8d7bc8f7942ce853dde4161b28f9aa96769cef3d8eebafb379a81800b9e2448",
@@ -1104,6 +1108,7 @@
       "jsr:@std/fs@1.0.23",
       "jsr:@std/path@1.1.4",
       "jsr:@std/testing@1.0.17",
+      "jsr:@std/yaml@1.1.0",
       "npm:@babel/parser@7.29.2"
     ]
   }

--- a/scripts/security/audit-npm.test.ts
+++ b/scripts/security/audit-npm.test.ts
@@ -68,3 +68,16 @@ describe("buildAuditPackageJson", () => {
     assertEquals(pkg.peerDependenciesMeta, undefined);
   });
 });
+
+describe("audit task", () => {
+  it("audits the independent Storybook package lock", async () => {
+    const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+
+    assertEquals(
+      denoConfig.tasks.audit.includes(
+        "npm --prefix storybook audit --package-lock-only --audit-level=high",
+      ),
+      true,
+    );
+  });
+});

--- a/scripts/security/audit-npm.test.ts
+++ b/scripts/security/audit-npm.test.ts
@@ -72,6 +72,9 @@ describe("buildAuditPackageJson", () => {
 describe("audit task", () => {
   it("audits the independent Storybook package lock", async () => {
     const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+    const workflow = await Deno.readTextFile(
+      ".github/workflows/security-audit.yml",
+    );
 
     assertEquals(
       denoConfig.tasks.audit.includes(
@@ -79,5 +82,7 @@ describe("audit task", () => {
       ),
       true,
     );
+    assertEquals(workflow.includes('- "storybook/package.json"'), true);
+    assertEquals(workflow.includes('- "storybook/package-lock.json"'), true);
   });
 });

--- a/scripts/security/audit-npm.test.ts
+++ b/scripts/security/audit-npm.test.ts
@@ -1,5 +1,6 @@
-import { assertEquals } from "#std/assert";
-import { describe, it } from "#std/testing/bdd";
+import { parse } from "#std/yaml/parse";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import { buildAuditPackageJson, collectNpmDependencies } from "./audit-npm.ts";
 
 describe("collectNpmDependencies", () => {
@@ -75,6 +76,9 @@ describe("audit task", () => {
     const workflow = await Deno.readTextFile(
       ".github/workflows/security-audit.yml",
     );
+    const pullRequestPaths = (parse(workflow) as {
+      on: { pull_request: { paths: string[] } };
+    }).on.pull_request.paths;
 
     assertEquals(
       denoConfig.tasks.audit.includes(
@@ -82,7 +86,10 @@ describe("audit task", () => {
       ),
       true,
     );
-    assertEquals(workflow.includes('- "storybook/package.json"'), true);
-    assertEquals(workflow.includes('- "storybook/package-lock.json"'), true);
+    assertEquals(pullRequestPaths.includes("storybook/package.json"), true);
+    assertEquals(
+      pullRequestPaths.includes("storybook/package-lock.json"),
+      true,
+    );
   });
 });

--- a/scripts/test.deno.json
+++ b/scripts/test.deno.json
@@ -13,6 +13,7 @@
     "#std/fs/ensure-dir": "jsr:@std/fs@1.0.23/ensure-dir",
     "#std/path": "jsr:@std/path@1.1.4",
     "#std/path.ts": "jsr:@std/path@1.1.4",
+    "#std/yaml/parse": "jsr:@std/yaml@1.1.0/parse",
     "#std/testing/bdd": "jsr:@std/testing@1.0.17/bdd",
     "#std/testing/bdd.ts": "jsr:@std/testing@1.0.17/bdd"
   }

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -2937,16 +2937,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
## Summary
- Bump the sandbox shell extension's direct `brace-expansion` npm import from `5.0.8` to `5.0.9`.
- Refresh the root and proxy Deno locks plus the npm metadata expectation so the audit uses the patched package.

## Main CI failure addressed
Main run `30836151908` failed in Security Audit job `91761708129` because `deno task audit` reported one high-severity npm advisory for `brace-expansion@5.0.8`.

## Verification
- `npx --yes deno@2.7.7 task audit` -> passes, no vulnerabilities found
- `npx --yes deno@2.7.7 fmt --check deno.json extensions/ext-sandbox-shell-tools/deno.json scripts/build/npm-package-metadata.test.ts scripts/build/proxy-deno.lock deno.lock` -> passes
- `npx --yes deno@2.7.7 lint --config=scripts/test.deno.json scripts/security/audit-npm.ts scripts/security/audit-npm.test.ts scripts/build/npm-package-metadata.test.ts` -> passes
- `npx --yes deno@2.7.7 check --config=scripts/test.deno.json scripts/security/audit-npm.ts scripts/security/audit-npm.test.ts scripts/build/npm-package-metadata.test.ts` -> passes
- `npx --yes deno@2.7.7 test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/security/audit-npm.test.ts` -> passes, 2 tests / 3 steps
- `git diff --check origin/main..origin/fix/main-brace-expansion-audit` -> passes

## Merge posture
This PR is intentionally not queued ahead of older open PRs yet. It is a narrow main-CI repair PR and should be queued once hosted checks finish and the oldest-to-newest merge gate allows it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Expanded automated security audits to include Storybook dependencies.
  - Audits now report high-severity and critical vulnerabilities across all tracked package lockfiles.

- **Maintenance**
  - Updated the `brace-expansion` dependency to version 5.0.9.

- **Tests**
  - Added coverage to verify Storybook packages are included in security auditing and dependency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->