### PR TITLE
test: stabilize main CI scheduling-sensitive tests

### DIFF
--- a/src/react/components/chat/chat/hooks/use-conversations.hook.test.tsx
+++ b/src/react/components/chat/chat/hooks/use-conversations.hook.test.tsx
@@ -11,6 +11,7 @@ import { JSDOM } from "npm:jsdom@28.0.0";
 import { unmountReactRoot } from "#veryfront/react/react-root.test-helpers.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import type { ChatMessage } from "#veryfront/agent/react";
 import {
   conversationSummary,
@@ -2270,7 +2271,10 @@ describe("react/components/chat/hooks/useConversations — save", () => {
           </React.Suspense>,
         );
       });
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitFor(() => attemptedSuspendedRender, {
+        interval: 1,
+        message: "Concurrent conversations render did not start",
+      });
       assertEquals(attemptedSuspendedRender, true);
 
       const failure = new Error("committed list failed");


### PR DESCRIPTION
## Summary

Fixes the current main CI failure on coverage shard 8/8 by making the concurrent conversations render test wait for the abandoned render to actually start before asserting ownership. The previous `setTimeout(0)` was scheduler-sensitive under the hosted coverage shard.

Also applies the narrow skills CLI subprocess cwd stabilization that the local pre-push hook exposed: child CLI tests now spawn from the repository root instead of inheriting a cwd that parallel tests can temporarily change/remove.

The npm release/package bootstrap issue is already resolved separately: `@veryfront/ext-dev-ui-react` exists at patch versions, and subsequent tokenless GitHub provenance publishes succeeded. This PR does not change release versions or publish package metadata.

## Verification

- `npx --yes deno@2.7.7 fmt --check src/react/components/chat/chat/hooks/use-conversations.hook.test.tsx cli/commands/skills/handler.test.ts`
- `npx --yes deno@2.7.7 lint src/react/components/chat/chat/hooks/use-conversations.hook.test.tsx cli/commands/skills/handler.test.ts`
- `npx --yes deno@2.7.7 check src/react/components/chat/chat/hooks/use-conversations.hook.test.tsx cli/commands/skills/handler.test.ts`
- 5x focused `src/react/components/chat/chat/hooks/use-conversations.hook.test.tsx` runs: all passed
- `npx --yes deno@2.7.7 test --no-check --allow-all cli/commands/skills/handler.test.ts`: passed, 11 steps
- hosted-failure-shaped shard: `coverage:ci:shard -- --shard=8/8 --coverage-dir=coverage-shard-8-local`: passed, 429 tests / 3515 steps

Not scheduling merge until hosted checks finish green on the exact PR head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of concurrent-rendering tests by waiting for suspended rendering to begin.
  * Added clearer diagnostics when the expected rendering state is not reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->