### PR TITLE
fix(release): key published runtime helpers by package root

### DIFF
--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -1634,6 +1634,80 @@ describe("release asset build executor", () => {
     assertExists(rec.uploads.find((u) => u.hash === helperMatch[1]));
   });
 
+  it("keeps same-named published runtime helpers from different roots distinct", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import { useWorkflow } from "veryfront/workflow"; export default useWorkflow;',
+      },
+    ];
+    const client = makeClient(files, rec);
+    const frameworkUrl = "/_vf_modules/_veryfront/workflow/react/index.js";
+    const consumerAUrl = "/_vf_modules/_veryfront/published-helper-consumer.js";
+    const consumerBUrl = "/_vf_modules/_veryfront/nested/src/consumer.js";
+
+    // Two package roots (tempDir and tempDir/src/nested), each with its own
+    // deno.js helper carrying different contents.
+    const tempDir = await tmp();
+    await Deno.mkdir(join(tempDir, "src", "nested", "src"), { recursive: true });
+    await Deno.writeTextFile(
+      join(tempDir, "src", "published-helper-consumer.ts"),
+      'import "../deno.js";\nexport const consumerA = true;\n',
+    );
+    await Deno.writeTextFile(join(tempDir, "deno.js"), 'export const helperA = "a";\n');
+    await Deno.writeTextFile(
+      join(tempDir, "src", "nested", "src", "consumer.ts"),
+      'import "../deno.js";\nexport const consumerB = true;\n',
+    );
+    await Deno.writeTextFile(
+      join(tempDir, "src", "nested", "deno.js"),
+      'export const helperB = "b";\n',
+    );
+
+    const transform = (source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve(
+          `import { useWorkflow } from "${frameworkUrl}"; export default useWorkflow;`,
+        );
+      }
+      if (sourceFile.endsWith("src/workflow/react/index.ts")) {
+        return Promise.resolve(
+          `import { consumerA } from "${consumerAUrl}"; import { consumerB } from "${consumerBUrl}"; export const useWorkflow = () => consumerA && consumerB;`,
+        );
+      }
+      if (
+        sourceFile.endsWith("published-helper-consumer.ts") ||
+        sourceFile.endsWith("nested/src/consumer.ts") ||
+        sourceFile.endsWith("deno.js")
+      ) {
+        return Promise.resolve(source);
+      }
+      return Promise.resolve("export const value = true;");
+    };
+
+    const result = await runReleaseAssetBuild(baseInput(client, transform), tempDir);
+
+    assertEquals(result.success, true);
+    const consumerAUpload = rec.uploads.find((u) => u.text.includes("consumerA = true"));
+    const consumerBUpload = rec.uploads.find((u) => u.text.includes("consumerB = true"));
+    assertExists(consumerAUpload);
+    assertExists(consumerBUpload);
+
+    const helperAHash = consumerAUpload.text.match(/"\/_vf\/assets\/([a-f0-9]{64})\.js"/)?.[1];
+    const helperBHash = consumerBUpload.text.match(/"\/_vf\/assets\/([a-f0-9]{64})\.js"/)?.[1];
+    assertExists(helperAHash);
+    assertExists(helperBHash);
+    assert(helperAHash !== helperBHash);
+
+    const helperAUpload = rec.uploads.find((u) => u.hash === helperAHash);
+    const helperBUpload = rec.uploads.find((u) => u.hash === helperBHash);
+    assertExists(helperAUpload);
+    assertExists(helperBUpload);
+    assert(helperAUpload.text.includes("helperA"));
+    assert(helperBUpload.text.includes("helperB"));
+  });
+
   it("fails closed on cyclic project imports", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -40,6 +40,7 @@ import {
   resolveRelativeFrameworkSourceImport,
 } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { PUBLISHED_RUNTIME_HELPERS } from "#veryfront/platform/compat/published-runtime-helpers.ts";
+import { getFrameworkRoot } from "#veryfront/platform/compat/vfs-paths.ts";
 import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache-helpers.ts";
 import { extractSourceUrl } from "#veryfront/transforms/esm/source-url-embed.ts";
 import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
@@ -460,35 +461,21 @@ function frameworkSourcePathToSourceKey(sourcePath: string, lookupDirs: string[]
   return null;
 }
 
-function frameworkRootsForLookupDirs(lookupDirs: string[]): string[] {
-  const roots = new Set<string>();
-  for (const lookupDir of lookupDirs) {
-    if (lookupDir.endsWith("/dist/framework-src")) {
-      roots.add(lookupDir.slice(0, -"/dist/framework-src".length));
-    } else if (lookupDir.endsWith("/src")) {
-      roots.add(lookupDir.slice(0, -"/src".length));
-    }
-  }
-  return [...roots];
-}
-
 /**
  * Published npm packages emit DNT runtime helpers (`_dnt.shims.js`,
- * `_dnt.polyfills.js`, `deno.js`) at the package ESM root — outside every
- * framework source lookup dir. Map those exact files to a reserved source key
- * so the release dependency walk can publish them instead of leaving the
- * relative import unresolved.
+ * `_dnt.polyfills.js`, `deno.js`) at the package ESM root, outside every
+ * framework source lookup dir. Detect those exact files (relative to the
+ * importing module's package root) so the release dependency walk can publish
+ * them instead of leaving the relative import unresolved.
  */
-function publishedRuntimeHelperSourceKey(
-  sourcePath: string,
-  lookupDirs: string[],
+function matchPublishedRuntimeHelper(
+  resolvedPath: string,
+  fromSourcePath: string,
 ): string | null {
-  for (const root of frameworkRootsForLookupDirs(lookupDirs)) {
-    for (const helper of PUBLISHED_RUNTIME_HELPERS) {
-      if (sourcePath === join(root, helper)) {
-        return `_published-runtime/${helper.replace(/\.js$/, "")}`;
-      }
-    }
+  const packageRoot = getFrameworkRoot(fromSourcePath);
+  if (!packageRoot) return null;
+  for (const helper of PUBLISHED_RUNTIME_HELPERS) {
+    if (resolvedPath === join(packageRoot, helper)) return helper;
   }
   return null;
 }
@@ -1927,6 +1914,7 @@ async function buildFrameworkDependencies(
   const moduleAssets = new Map<string, PreparedAsset>();
   const visiting = new Set<string>();
   const publishedHelperPaths = new Map<string, string>();
+  const publishedHelperKeysByPath = new Map<string, string>();
 
   async function resolveFrameworkImport(
     specifier: string,
@@ -1935,9 +1923,17 @@ async function buildFrameworkDependencies(
     if (specifier.startsWith("./") || specifier.startsWith("../")) {
       const resolvedPath = await resolveRelativeFrameworkSourceImport(specifier, fromSourcePath);
       if (!resolvedPath) return null;
-      const helperSourceKey = publishedRuntimeHelperSourceKey(resolvedPath, lookupDirs);
-      if (helperSourceKey) {
-        publishedHelperPaths.set(helperSourceKey, resolvedPath);
+      const helperName = matchPublishedRuntimeHelper(resolvedPath, fromSourcePath);
+      if (helperName) {
+        // Key helpers by resolved path: distinct package roots can each emit
+        // a helper with the same filename but different contents.
+        let helperSourceKey = publishedHelperKeysByPath.get(resolvedPath);
+        if (!helperSourceKey) {
+          const stem = helperName.replace(/\.js$/, "");
+          helperSourceKey = `_published-runtime/${publishedHelperKeysByPath.size}/${stem}`;
+          publishedHelperKeysByPath.set(resolvedPath, helperSourceKey);
+          publishedHelperPaths.set(helperSourceKey, resolvedPath);
+        }
         return helperSourceKey;
       }
       return frameworkSourcePathToSourceKey(resolvedPath, lookupDirs);


### PR DESCRIPTION
## Description

Follow-up to #3341. The release dependency walk allocated published runtime helper source keys per helper filename, so two package roots emitting the same helper name (e.g. `deno.js`) with different contents would alias to the first cached asset. Helper source keys now include package-root identity by keying on the resolved helper path.

Addresses the remaining CodeRabbit thread on #3341 (the branch was locked by the merge queue when the fix was ready).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Verification

- `deno fmt --check`, `deno lint`, `deno check` on changed files: pass.
- `src/release-assets/build-executor.test.ts`: 2 tests / 97 steps, 0 failures, including a new two-root regression test asserting each consumer rewrites to its own helper asset.
- Pre-push full gate: passed.