### PR TITLE
fix(compat): restore fetch header parity in the pinned egress transport

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -78,6 +78,11 @@ jobs:
           cp -R tests/node/resolver-dependencies/node_modules/. npm/node_modules/
       - name: Run Node cache-link compatibility tests
         run: node ./tests/node/run-tests.mjs 'src/utils/cache-dir.test.ts'
+      # The pinned egress transport is Node/Bun-only, so the Deno lanes skip its
+      # tests entirely. Without this step nothing in CI exercises it, which is
+      # how it shipped omitting the request headers `fetch` normally supplies.
+      - name: Run Node egress transport tests
+        run: node ./tests/node/run-tests.mjs 'src/platform/compat/http/pinned-fetch.test.ts'
       - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 10

--- a/src/platform/compat/http/pinned-fetch.test.ts
+++ b/src/platform/compat/http/pinned-fetch.test.ts
@@ -106,6 +106,62 @@ describe("fetchWithPinnedAddresses", () => {
     }
   });
 
+  it("derives sec-fetch-mode and accept-encoding the way the runtime does", async () => {
+    // Both defaults are conditional in undici, so a fixed value would be wrong
+    // for range requests (a compressed byte range is ambiguous to decode) and
+    // for any non-default request mode. Baselines come from the live runtime.
+    const { createServer } = await import("node:http");
+    const seen = new Map<string, Record<string, string | string[] | undefined>>();
+    const server = createServer((request, response) => {
+      seen.set(request.url ?? "", request.headers);
+      response.writeHead(204);
+      response.end();
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Test server did not expose a TCP address");
+      }
+      const origin = `http://127.0.0.1:${address.port}`;
+      await fetch(`${origin}/range`, { headers: { range: "bytes=0-0" } });
+      await fetch(`${origin}/no-cors`, { mode: "no-cors" });
+
+      const ranged = applyRuntimeDefaultRequestHeaders(
+        new Headers({ range: "bytes=0-0" }),
+      );
+      assertEquals(
+        ranged.get("accept-encoding"),
+        seen.get("/range")?.["accept-encoding"],
+      );
+      assertEquals(ranged.get("accept-encoding"), "identity");
+
+      // Both Node and Deno send `identity` for a range request, so that
+      // baseline is compared unconditionally above. Fetch metadata is not
+      // universal — Deno omits `sec-fetch-mode` entirely — so cross-check it
+      // only where the runtime actually emits one.
+      const noCors = applyRuntimeDefaultRequestHeaders(new Headers(), "no-cors");
+      const runtimeMode = seen.get("/no-cors")?.["sec-fetch-mode"];
+      if (runtimeMode !== undefined) {
+        assertEquals(noCors.get("sec-fetch-mode"), runtimeMode);
+      }
+      assertEquals(noCors.get("sec-fetch-mode"), "no-cors");
+
+      // Unranged, default-mode requests keep the compressed-body offer.
+      const plain = applyRuntimeDefaultRequestHeaders(new Headers());
+      assertEquals(plain.get("accept-encoding"), "gzip, deflate");
+      assertEquals(plain.get("sec-fetch-mode"), "cors");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+    }
+  });
+
   it("keeps caller-supplied headers ahead of the runtime defaults", () => {
     const headers = applyRuntimeDefaultRequestHeaders(
       new Headers({ "user-agent": "caller/1.0", accept: "application/json" }),

--- a/src/platform/compat/http/pinned-fetch.test.ts
+++ b/src/platform/compat/http/pinned-fetch.test.ts
@@ -1,7 +1,12 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isNode } from "#veryfront/platform/compat/runtime.ts";
-import { createPinnedFetchResponse, fetchWithPinnedAddresses } from "./pinned-fetch.ts";
+import {
+  applyRuntimeDefaultRequestHeaders,
+  createPinnedFetchResponse,
+  DEFAULT_OUTBOUND_USER_AGENT,
+  fetchWithPinnedAddresses,
+} from "./pinned-fetch.ts";
 
 describe("fetchWithPinnedAddresses", () => {
   it("preserves Fetch null-body semantics for 204, 205, and 304", async () => {
@@ -41,6 +46,108 @@ describe("fetchWithPinnedAddresses", () => {
       assertEquals(response.headers.get("content-length"), "21");
       assertEquals(response.body, null);
       assertEquals(await response.text(), "");
+    }
+  });
+
+  it("fills in every request header the runtime's own fetch sends", async () => {
+    // The defect this guards: the pinned transport talks to `node:http`
+    // directly, so headers `fetch` supplies for free silently go missing.
+    //
+    // Runs on every runtime by checking the header policy rather than the
+    // Node-only transport — `deno task test` is the only lane CI runs, so a
+    // check gated on `isNode` would never execute. The baseline comes from a
+    // live `fetch` instead of a hardcoded list, so a runtime that starts
+    // sending a new default fails here rather than drifting silently.
+    const { createServer } = await import("node:http");
+    let runtimeSent: Record<string, string | string[] | undefined> = {};
+    const server = createServer((request, response) => {
+      runtimeSent = request.headers;
+      response.writeHead(204);
+      response.end();
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Test server did not expose a TCP address");
+      }
+      await fetch(`http://127.0.0.1:${address.port}/baseline`, {
+        method: "POST",
+        body: '{"hello":"world"}',
+        headers: { "content-type": "application/json" },
+      });
+
+      const defaulted = applyRuntimeDefaultRequestHeaders(
+        new Headers({ "content-type": "application/json" }),
+      );
+
+      // `host` and the framing headers belong to whoever opens the socket.
+      const transportOwned = new Set([
+        "host",
+        "connection",
+        "content-length",
+        "transfer-encoding",
+      ]);
+      // Sending more than the runtime does is harmless; sending less is the
+      // regression, so assert the absence of gaps rather than an exact match.
+      const missing = Object.keys(runtimeSent)
+        .filter((name) => !transportOwned.has(name) && !defaulted.has(name))
+        .sort();
+      assertEquals(missing, []);
+      assertEquals(defaulted.get("user-agent"), DEFAULT_OUTBOUND_USER_AGENT);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+    }
+  });
+
+  it("keeps caller-supplied headers ahead of the runtime defaults", () => {
+    const headers = applyRuntimeDefaultRequestHeaders(
+      new Headers({ "user-agent": "caller/1.0", accept: "application/json" }),
+    );
+    assertEquals(headers.get("user-agent"), "caller/1.0");
+    assertEquals(headers.get("accept"), "application/json");
+    // Untouched defaults still land.
+    assertEquals(headers.get("accept-encoding"), "gzip, deflate");
+  });
+
+  it("puts the defaults on the wire through the Node transport", async () => {
+    if (!isNode) return;
+
+    const { createServer } = await import("node:http");
+    let seen: Record<string, string | string[] | undefined> = {};
+    const server = createServer((request, response) => {
+      seen = request.headers;
+      response.writeHead(204);
+      response.end();
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Node test server did not expose a TCP address");
+      }
+      await fetchWithPinnedAddresses(
+        new URL(`http://127.0.0.1:${address.port}/resource`),
+        ["127.0.0.1"],
+        { method: "POST", body: "{}", headers: { "content-type": "application/json" } },
+      );
+      assertEquals(seen["user-agent"], DEFAULT_OUTBOUND_USER_AGENT);
+      assertEquals(seen["accept"], "*/*");
+      assertEquals(seen["content-type"], "application/json");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
     }
   });
 

--- a/src/platform/compat/http/pinned-fetch.ts
+++ b/src/platform/compat/http/pinned-fetch.ts
@@ -16,38 +16,47 @@ const NULL_BODY_STATUSES = new Set([204, 205, 304]);
  */
 export const DEFAULT_OUTBOUND_USER_AGENT = `veryfront/${VERSION}`;
 
-/**
- * Request headers a plain `fetch` attaches on its own. This transport talks to
- * `node:http` directly, so nothing fills them in and requests leave measurably
- * thinner than the same call made through `fetch` — hosts behind a WAF reject
- * user-agent-less requests outright, and omitting `accept-encoding` silently
- * gives up response compression this transport already knows how to decode.
- *
- * Values mirror what Node's `fetch` sends. Exact strings do not need to track
- * the runtime version by version; `pinned-fetch.test.ts` asserts only that no
- * header the runtime sends goes missing here, so a runtime that adds one fails
- * loudly rather than drifting. Caller-supplied headers always win.
- */
-const RUNTIME_DEFAULT_REQUEST_HEADERS: ReadonlyArray<readonly [string, string]> = [
-  ["accept", "*/*"],
-  ["accept-language", "*"],
-  ["accept-encoding", "gzip, deflate"],
-  ["sec-fetch-mode", "cors"],
-  ["user-agent", DEFAULT_OUTBOUND_USER_AGENT],
-];
+/** What the runtime advertises when it is willing to decode a compressed body. */
+const DEFAULT_ACCEPT_ENCODING = "gzip, deflate";
 
 /**
- * Fill in the headers a plain `fetch` would have added, leaving any the caller
- * set untouched. Split out from the transport so the parity check can run on
- * every runtime: the transport itself is Node/Bun-only, and a test gated on
- * that never executes in the Deno-only CI lanes.
+ * Fill in the request headers a plain `fetch` attaches on its own, leaving any
+ * the caller set untouched. This transport talks to `node:http` directly, so
+ * nothing supplies them and requests leave measurably thinner than the same
+ * call made through `fetch` — hosts behind a WAF reject user-agent-less
+ * requests outright, and omitting `accept-encoding` silently gives up response
+ * compression this transport already knows how to decode.
+ *
+ * Values mirror what Node's `fetch` sends, including the two that are derived
+ * rather than fixed: `sec-fetch-mode` follows the request mode, and
+ * `accept-encoding` becomes `identity` for range requests. Exact strings need
+ * not track the runtime version by version — `pinned-fetch.test.ts` asserts
+ * only that no header the runtime sends goes missing, so a runtime that adds
+ * one fails loudly rather than drifting.
+ *
+ * Split out from the transport so that parity check can run on every runtime:
+ * the transport itself is Node/Bun-only, and a test gated on that never
+ * executes in the Deno-only CI lanes.
  *
  * @internal
  */
-export function applyRuntimeDefaultRequestHeaders(headers: Headers): Headers {
-  for (const [name, value] of RUNTIME_DEFAULT_REQUEST_HEADERS) {
-    if (!headers.has(name)) headers.set(name, value);
+export function applyRuntimeDefaultRequestHeaders(
+  headers: Headers,
+  mode?: RequestMode,
+): Headers {
+  if (!headers.has("accept")) headers.set("accept", "*/*");
+  if (!headers.has("accept-language")) headers.set("accept-language", "*");
+  if (!headers.has("accept-encoding")) {
+    // A compressed byte range is ambiguous to decode, so the runtime asks for
+    // `identity` whenever the caller requested a range.
+    headers.set(
+      "accept-encoding",
+      headers.has("range") ? "identity" : DEFAULT_ACCEPT_ENCODING,
+    );
   }
+  // Fetch metadata reports the request mode; it is not always `cors`.
+  if (!headers.has("sec-fetch-mode")) headers.set("sec-fetch-mode", mode ?? "cors");
+  if (!headers.has("user-agent")) headers.set("user-agent", DEFAULT_OUTBOUND_USER_AGENT);
   return headers;
 }
 
@@ -201,7 +210,7 @@ export async function fetchWithPinnedAddresses(
   if (addresses.length === 0) {
     throw new Error(`No validated addresses are available for ${url.host}`);
   }
-  const headers = applyRuntimeDefaultRequestHeaders(new Headers(init.headers));
+  const headers = applyRuntimeDefaultRequestHeaders(new Headers(init.headers), init.mode);
   const body = await normalizeRequestBody(url, init, headers);
   const method = (init.method ?? "GET").toUpperCase();
   const requestHeaders: Record<string, string> = {};

--- a/src/platform/compat/http/pinned-fetch.ts
+++ b/src/platform/compat/http/pinned-fetch.ts
@@ -6,8 +6,50 @@
 
 import type { ClientRequest, IncomingMessage, RequestOptions } from "node:http";
 import type { Readable } from "node:stream";
+import { VERSION } from "#veryfront/utils/version-constant.ts";
 
 const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
+/**
+ * Client identity for guarded egress, standing in for the runtime-supplied
+ * `user-agent` (`node`, `Deno/x.y.z`) that this transport cannot inherit.
+ */
+export const DEFAULT_OUTBOUND_USER_AGENT = `veryfront/${VERSION}`;
+
+/**
+ * Request headers a plain `fetch` attaches on its own. This transport talks to
+ * `node:http` directly, so nothing fills them in and requests leave measurably
+ * thinner than the same call made through `fetch` — hosts behind a WAF reject
+ * user-agent-less requests outright, and omitting `accept-encoding` silently
+ * gives up response compression this transport already knows how to decode.
+ *
+ * Values mirror what Node's `fetch` sends. Exact strings do not need to track
+ * the runtime version by version; `pinned-fetch.test.ts` asserts only that no
+ * header the runtime sends goes missing here, so a runtime that adds one fails
+ * loudly rather than drifting. Caller-supplied headers always win.
+ */
+const RUNTIME_DEFAULT_REQUEST_HEADERS: ReadonlyArray<readonly [string, string]> = [
+  ["accept", "*/*"],
+  ["accept-language", "*"],
+  ["accept-encoding", "gzip, deflate"],
+  ["sec-fetch-mode", "cors"],
+  ["user-agent", DEFAULT_OUTBOUND_USER_AGENT],
+];
+
+/**
+ * Fill in the headers a plain `fetch` would have added, leaving any the caller
+ * set untouched. Split out from the transport so the parity check can run on
+ * every runtime: the transport itself is Node/Bun-only, and a test gated on
+ * that never executes in the Deno-only CI lanes.
+ *
+ * @internal
+ */
+export function applyRuntimeDefaultRequestHeaders(headers: Headers): Headers {
+  for (const [name, value] of RUNTIME_DEFAULT_REQUEST_HEADERS) {
+    if (!headers.has(name)) headers.set(name, value);
+  }
+  return headers;
+}
 
 /** @internal Construct a Fetch response without violating null-body statuses. */
 export function createPinnedFetchResponse(
@@ -159,7 +201,7 @@ export async function fetchWithPinnedAddresses(
   if (addresses.length === 0) {
     throw new Error(`No validated addresses are available for ${url.host}`);
   }
-  const headers = new Headers(init.headers);
+  const headers = applyRuntimeDefaultRequestHeaders(new Headers(init.headers));
   const body = await normalizeRequestBody(url, init, headers);
   const method = (init.method ?? "GET").toUpperCase();
   const requestHeaders: Record<string, string> = {};

--- a/src/platform/compat/http/pinned-fetch.ts
+++ b/src/platform/compat/http/pinned-fetch.ts
@@ -34,6 +34,11 @@ const DEFAULT_ACCEPT_ENCODING = "gzip, deflate";
  * only that no header the runtime sends goes missing, so a runtime that adds
  * one fails loudly rather than drifting.
  *
+ * `user-agent` is the deliberate exception: the runtime default (`node`,
+ * `Deno/x.y.z`) cannot be inherited here and identifies nothing useful, so
+ * guarded egress sends DEFAULT_OUTBOUND_USER_AGENT instead. Parity for that
+ * header means "present", not "identical".
+ *
  * Split out from the transport so that parity check can run on every runtime:
  * the transport itself is Node/Bun-only, and a test gated on that never
  * executes in the Deno-only CI lanes.

--- a/src/security/sandbox/worker-egress-guard.test.ts
+++ b/src/security/sandbox/worker-egress-guard.test.ts
@@ -683,6 +683,34 @@ describe("worker-egress-guard guardedEgressFetch redirect handling", () => {
     assertEquals(calls, 1);
   });
 
+  it("streams request bodies unless a redirect could force a replay", async () => {
+    const capture = async (redirect: RequestRedirect) => {
+      let seen: unknown;
+      const fetchImpl: WorkerEgressFetch = (_input, init) => {
+        seen = init?.body;
+        return Promise.resolve(new Response(null, { status: 204 }));
+      };
+      const request = new Request("http://93.184.216.34/upload", {
+        method: "POST",
+        body: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("payload"));
+            controller.close();
+          },
+        }),
+        duplex: "half",
+      } as unknown as RequestInit);
+      await guardedEgressFetch(request, { redirect }, { fetchImpl });
+      return seen;
+    };
+
+    // Nothing can replay the body, so hand the stream to the transport as-is
+    // rather than materializing an upload in memory.
+    assert((await capture("error")) instanceof ReadableStream);
+    // A redirect hop would have to resend it, so it must be buffered.
+    assert((await capture("follow")) instanceof Uint8Array);
+  });
+
   it("follows a public -> public redirect chain and returns the final response", async () => {
     const fetchImpl: WorkerEgressFetch = (input) => {
       const url = input instanceof Request ? input.url : String(input);

--- a/src/security/sandbox/worker-egress-guard.test.ts
+++ b/src/security/sandbox/worker-egress-guard.test.ts
@@ -684,31 +684,48 @@ describe("worker-egress-guard guardedEgressFetch redirect handling", () => {
   });
 
   it("streams request bodies unless a redirect could force a replay", async () => {
-    const capture = async (redirect: RequestRedirect) => {
+    const streamBody = () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("payload"));
+          controller.close();
+        },
+      });
+
+    // A stream reaches the guard either on a Request or through `init.body`.
+    // Both have to obey the same rule, or a followed 307/308 hits
+    // isReplayableBody and the hop is refused.
+    const capture = async (redirect: RequestRedirect, source: "request" | "init") => {
       let seen: unknown;
       const fetchImpl: WorkerEgressFetch = (_input, init) => {
         seen = init?.body;
         return Promise.resolve(new Response(null, { status: 204 }));
       };
-      const request = new Request("http://93.184.216.34/upload", {
-        method: "POST",
-        body: new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode("payload"));
-            controller.close();
-          },
-        }),
-        duplex: "half",
-      } as unknown as RequestInit);
-      await guardedEgressFetch(request, { redirect }, { fetchImpl });
+      if (source === "request") {
+        const request = new Request("http://93.184.216.34/upload", {
+          method: "POST",
+          body: streamBody(),
+          duplex: "half",
+        } as unknown as RequestInit);
+        await guardedEgressFetch(request, { redirect }, { fetchImpl });
+      } else {
+        await guardedEgressFetch("http://93.184.216.34/upload", {
+          method: "POST",
+          body: streamBody(),
+          redirect,
+          duplex: "half",
+        } as unknown as RequestInit, { fetchImpl });
+      }
       return seen;
     };
 
-    // Nothing can replay the body, so hand the stream to the transport as-is
-    // rather than materializing an upload in memory.
-    assert((await capture("error")) instanceof ReadableStream);
-    // A redirect hop would have to resend it, so it must be buffered.
-    assert((await capture("follow")) instanceof Uint8Array);
+    for (const source of ["request", "init"] as const) {
+      // Nothing can replay the body, so hand the stream to the transport as-is
+      // rather than materializing an upload in memory.
+      assert((await capture("error", source)) instanceof ReadableStream, `${source}/error`);
+      // A redirect hop would have to resend it, so it must be buffered.
+      assert((await capture("follow", source)) instanceof Uint8Array, `${source}/follow`);
+    }
   });
 
   it("follows a public -> public redirect chain and returns the final response", async () => {

--- a/src/security/sandbox/worker-egress-guard.ts
+++ b/src/security/sandbox/worker-egress-guard.ts
@@ -1177,15 +1177,20 @@ export async function guardedEgressFetch(
     init?.headers ?? (input instanceof Request ? input.headers : undefined),
   );
   // Following a redirect means resending the body, and a stream cannot replay,
-  // so it is materialized only when redirects are actually followed. Callers
-  // that pass `redirect: "error"` or `"manual"` -- every guarded caller today,
-  // blob uploads included -- stream straight through rather than holding the
-  // whole payload in memory.
+  // so streams are materialized only when redirects are actually followed --
+  // otherwise isReplayableBody rejects the hop. Callers that pass
+  // `redirect: "error"` or `"manual"` -- every guarded caller today, blob
+  // uploads included -- stream straight through rather than holding the whole
+  // payload in memory, and never reach the replay check because both modes
+  // return or throw first.
+  const mayFollowRedirect = requestedRedirect === "follow";
   let body: BodyInit | undefined;
   if (init?.body != null) {
-    body = init.body as BodyInit;
+    body = mayFollowRedirect && init.body instanceof ReadableStream
+      ? new Uint8Array(await new Response(init.body).arrayBuffer())
+      : init.body as BodyInit;
   } else if (input instanceof Request && input.body) {
-    body = requestedRedirect === "follow" ? new Uint8Array(await input.arrayBuffer()) : input.body;
+    body = mayFollowRedirect ? new Uint8Array(await input.arrayBuffer()) : input.body;
   }
 
   // Preserve request-level options (notably `signal`, so aborts keep working)

--- a/src/security/sandbox/worker-egress-guard.ts
+++ b/src/security/sandbox/worker-egress-guard.ts
@@ -1176,11 +1176,16 @@ export async function guardedEgressFetch(
   const headers = new Headers(
     init?.headers ?? (input instanceof Request ? input.headers : undefined),
   );
+  // Following a redirect means resending the body, and a stream cannot replay,
+  // so it is materialized only when redirects are actually followed. Callers
+  // that pass `redirect: "error"` or `"manual"` -- every guarded caller today,
+  // blob uploads included -- stream straight through rather than holding the
+  // whole payload in memory.
   let body: BodyInit | undefined;
   if (init?.body != null) {
     body = init.body as BodyInit;
   } else if (input instanceof Request && input.body) {
-    body = new Uint8Array(await input.arrayBuffer());
+    body = requestedRedirect === "follow" ? new Uint8Array(await input.arrayBuffer()) : input.body;
   }
 
   // Preserve request-level options (notably `signal`, so aborts keep working)
@@ -1207,13 +1212,15 @@ export async function guardedEgressFetch(
     let pinnedResponse: Promise<Response> | undefined;
     const isNetworkRequest = hostname !== null &&
       (parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:");
-    const requestInit: RequestInit = {
+    const requestInit: RequestInit & { duplex?: "half" } = {
       ...init,
       ...carryInit,
       method,
       headers,
       body,
       redirect: "manual",
+      // Streaming a request body requires the half-duplex opt-in.
+      ...(body instanceof ReadableStream ? { duplex: "half" as const } : {}),
     };
 
     if (options.httpBroker && isNetworkRequest) {


### PR DESCRIPTION
## Summary

Agent inference on Node/Bun has been returning `403` since `0.1.1189`. The cause is not credentials or credits: the pinned egress transport sends requests **without a `user-agent`**, and the WAF in front of `api.veryfront.com` answers user-agent-less requests with an HTML interstitial carrying HTTP 403.

Reproduced end-to-end, then A/B'd across the regression to confirm:

```
veryfront 0.1.1186   user-agent on the wire: "node"          (authorization: present)
veryfront 0.1.1189   user-agent on the wire: *** ABSENT ***  (authorization: present)
```

Against the live gateway, two requests differing only in that header:

| Request | Result |
|---|---|
| `POST /ai/gateway/openai/v1/responses`, no UA | **403** + Cloudflare `Just a moment...` |
| identical + `User-Agent: node` | **200**, streams normally |

`GET /me` behaves the same, so this is host-wide rather than gateway-specific.

## Root cause

#3285 moved `createVeryfrontCloudFetch` from `fetch(...)` to `guardedOutboundFetch(...)` — correct for SSRF (validate-then-`fetch` is vulnerable to DNS rebinding; pinning the validated address and re-authorizing each redirect hop is the right fix).

The cost is *how*. `fetchWithPinnedAddresses` drives `node:http` directly, because Node has no public API to pin DNS on `globalThis.fetch`. Bypassing `fetch` also drops every header it supplies for free — `accept`, `accept-language`, `accept-encoding`, `sec-fetch-mode`, `user-agent`. Deno is unaffected: it pins via `Deno.createHttpClient` and still goes through a real `fetch`.

The HTML body also made this opaque — `buildProviderError` parses as JSON, so callers saw `Provider request failed with status 403` with an undefined cause.

## Changes

1. **`pinned-fetch.ts`** — fill in the runtime's default request headers; caller values always win. Dropping `accept-encoding` had separately been giving up response compression this transport already decodes.
2. **`worker-egress-guard.ts`** — stop buffering every request body. Only a followed redirect needs a replay, so buffering is limited to `redirect: "follow"`. Every guarded caller today passes `redirect: "error"`, including the blob upload path, which was holding whole uploads in memory for a replay that could never happen.
3. **`cicd.yml`** — run the transport's tests in the Node lane.

## Why point 3 matters most

These tests are gated `if (!isNode) return`, and CI runs only Deno lanes. They were reporting `ok (0ms)` — green, executing nothing. That is how five missing headers shipped.

So the header policy is split into `applyRuntimeDefaultRequestHeaders`, pure and runtime-independent, and the parity test now runs under **Deno** where CI executes it. Its baseline is a **live `fetch`**, not a hardcoded list, so a runtime that adds a default fails the build instead of drifting. It is a superset check by design — `sec-fetch-mode` is absent under Deno, and an exact-match assertion would be red on Deno and green on Node.

With the fix removed, under Deno:

```
fills in every request header the runtime's own fetch sends ... FAILED
-   [ "accept", "accept-encoding", "accept-language", "user-agent" ]
+   []
```

## Verification

- Both new guards fail without their fix and pass with it.
- `src/platform` + `src/security` + `src/provider` + `src/workflow/blob` + `src/cache`: **477 passed, 4845 steps, 0 failed**.
- Node lane (as CI will run it): **6/6**.
- `deno fmt --check src/`, `deno lint`, `deno check`: clean. `cicd.yml` parses.
- End-to-end: patched only the transport in an installed `0.1.1193`, ran `veryfront dev` — agent streams, no `RunError`.

## Deliberately not in this PR

Tracked in #3350 and #3351.

- **Socket pooling vs. address validation.** Node's `globalAgent` (`keepAlive: true`) pools by host:port, so a reused socket skips the pinned lookup — measured 4 requests over 1 connection, 3 of them skipping it. Severity is **low**, and narrower than "SSRF bypass": a pooled socket can only reach an address that was already validated, and Node keys the pool by host, so there is no cross-host reuse. Pooling makes rebinding harder, not easier. What is actually lost is **revocation latency** — most concretely, a host allowed via `VERYFRONT_WORKER_ALLOWED_INTERNAL_HOSTS` keeps a working socket to its internal IP after being removed from the allowlist, until idle timeout. Pre-existing and unchanged here. See #3350.
- **HTTP/2.** `node:http` is HTTP/1.1-only, so guarded calls lost h2. Impact unmeasured; `node:http2` with ALPN negotiation and session pooling is a lot of hand-rolled protocol surface, which is what caused this bug. Measure before funding. See #3351.
- **Connector/dispatcher refactor** (keep `fetch`, override only the socket). Investigated and **not recommended**: Node cannot do it without adding `undici` to a deliberately dependency-free module, and Bun still could not use it, so the hand-rolled path survives either way. A dependency-free subset — replacing `normalizeRequestBody`'s hand-rolled `FormData`/`Blob`/`URLSearchParams` handling with `new Request(...)` — is worth doing. See #3351.
- **Full `test:node` lane.** Currently fails on unrelated suites (esbuild, front-matter-yaml). See #3351.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved outbound HTTP requests to use runtime-compatible default headers, including user-agent, language, encoding, and fetch mode.
  - Caller-provided headers are preserved, including content-related headers.
  - Range requests now use appropriate encoding behavior.
  - Improved redirect handling for streamed request bodies, preserving streaming when redirects are not followed and buffering when replay is required.

- **Tests**
  - Expanded compatibility coverage for request headers, pinned transport behavior, and redirect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->