### PR TITLE
fix(server): report agent stream 5xx failures to Sentry

### DIFF
--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -3485,6 +3485,7 @@ describe("agent stream handler application-error reporting", () => {
 
   async function handleWithStubbedReporter(
     thrown: unknown,
+    runIdSegment = "run_1",
   ): Promise<{ captures: CapturedApplicationError[]; response: Response }> {
     const captures: CapturedApplicationError[] = [];
     setApplicationErrorReporter({
@@ -3513,7 +3514,7 @@ describe("agent stream handler application-error reporting", () => {
       });
 
       const result = await handler.handle(
-        new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+        new Request(`https://example.com/api/control-plane/runs/${runIdSegment}/stream`, {
           method: "POST",
           headers: {
             "content-type": "application/json",
@@ -3539,8 +3540,8 @@ describe("agent stream handler application-error reporting", () => {
     await response.body?.cancel();
 
     assertEquals(response.status, 503);
-    // Exactly one capture: the typed and untyped branches are mutually
-    // exclusive, so a rethrow that double-reports would turn this red.
+    // The two branches are mutually exclusive, so a rethrow that
+    // double-reports turns this red.
     assertEquals(captures.length, 1);
 
     const captured = captures[0];
@@ -3548,7 +3549,6 @@ describe("agent stream handler application-error reporting", () => {
     assertEquals(captured.error, thrown);
     assertEquals(captured.context.boundary, "agent.stream.request");
     assertEquals(captured.context.method, "POST");
-    // The run id is what ties a Sentry event back to a single agent run.
     assertEquals(captured.context.requestId, "run_1");
 
     const attributes = captured.context.attributes;
@@ -3562,10 +3562,14 @@ describe("agent stream handler application-error reporting", () => {
     assertEquals(attributes["project.slug"], "demo-project");
   });
 
-  it("reports an unexpected non-VeryfrontError failure that becomes a generic 500", async () => {
-    const thrown = new TypeError("cannot read properties of undefined");
-
-    const { captures, response } = await handleWithStubbedReporter(thrown);
+  // A malformed percent escape makes the run-id decode throw. Reporting runs
+  // inside the catch, so an unguarded decode would throw past it and destroy
+  // the 500 instead of describing it.
+  it("still reports and still answers 500 when the run id cannot be decoded", async () => {
+    const { captures, response } = await handleWithStubbedReporter(
+      new TypeError("unused: the malformed path throws first"),
+      "run_%ZZ",
+    );
     await response.body?.cancel();
 
     assertEquals(response.status, 500);
@@ -3573,15 +3577,13 @@ describe("agent stream handler application-error reporting", () => {
 
     const captured = captures[0];
     assertExists(captured);
-    assertEquals(captured.error, thrown);
     assertEquals(captured.context.boundary, "agent.stream.handler");
-    assertEquals(captured.context.requestId, "run_1");
+    assertEquals(captured.context.requestId, undefined);
 
     const attributes = captured.context.attributes;
     assertExists(attributes);
     assertEquals(attributes["http.status"], 500);
     assertEquals(attributes["project.id"], "proj-1");
-    assertEquals(attributes["project.slug"], "demo-project");
   });
 
   it("stays silent for a 4xx VeryfrontError so Sentry is not flooded", async () => {

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,5 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { SERVICE_OVERLOADED } from "#veryfront/errors";
+import { INVALID_ARGUMENT, SERVICE_OVERLOADED } from "#veryfront/errors";
+import {
+  type ApplicationErrorContext,
+  setApplicationErrorReporter,
+} from "#veryfront/observability/application-errors.ts";
 import {
   __registerLogRecordEmitter,
   __resetLogRecordEmitterForTests,
@@ -3470,5 +3474,125 @@ describe("agent stream handler 5xx logging", () => {
       else Deno.env.set("LOG_LEVEL", previousLogLevel);
       refreshLoggerConfig();
     }
+  });
+});
+
+describe("agent stream handler application-error reporting", () => {
+  type CapturedApplicationError = {
+    error: unknown;
+    context: ApplicationErrorContext;
+  };
+
+  async function handleWithStubbedReporter(
+    thrown: unknown,
+  ): Promise<{ captures: CapturedApplicationError[]; response: Response }> {
+    const captures: CapturedApplicationError[] = [];
+    setApplicationErrorReporter({
+      capture: (error, context) => {
+        captures.push({ error, context });
+        return "test-event-id";
+      },
+      flush: () => Promise.resolve(true),
+    });
+
+    try {
+      const handler = createTestAgentStreamHandler({
+        ensureProjectDiscovery: () => {
+          throw thrown;
+        },
+        getAgent: () => undefined,
+        getAllAgentIds: () => [],
+        sessionManager: new AgentRunSessionManager(),
+      });
+
+      const body = createAgentStreamRequestBody({
+        agentSource: { type: "branch", branch: "main" },
+      });
+      const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+        requestId: "run_1",
+      });
+
+      const result = await handler.handle(
+        new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-control-plane-jws": jws,
+          },
+          body,
+        }),
+        createCtx(publicKeyPem),
+      );
+
+      assertExists(result.response);
+      return { captures, response: result.response };
+    } finally {
+      setApplicationErrorReporter(undefined);
+    }
+  }
+
+  it("reports a 5xx VeryfrontError with context that is actionable without a log dive", async () => {
+    const detail = "Remote executable discovery requires an isolated project runtime";
+    const thrown = SERVICE_OVERLOADED.create({ detail, cause: "adapter boot failed" });
+
+    const { captures, response } = await handleWithStubbedReporter(thrown);
+    await response.body?.cancel();
+
+    assertEquals(response.status, 503);
+    // Exactly one capture: the typed and untyped branches are mutually
+    // exclusive, so a rethrow that double-reports would turn this red.
+    assertEquals(captures.length, 1);
+
+    const captured = captures[0];
+    assertExists(captured);
+    assertEquals(captured.error, thrown);
+    assertEquals(captured.context.boundary, "agent.stream.request");
+    assertEquals(captured.context.method, "POST");
+    // The run id is what ties a Sentry event back to a single agent run.
+    assertEquals(captured.context.requestId, "run_1");
+
+    const attributes = captured.context.attributes;
+    assertExists(attributes);
+    assertEquals(attributes["error.slug"], "service-overloaded");
+    assertEquals(attributes["error.category"], "SERVER");
+    assertEquals(attributes["error.detail"], detail);
+    assertEquals(attributes["error.cause"], "adapter boot failed");
+    assertEquals(attributes["http.status"], 503);
+    assertEquals(attributes["project.id"], "proj-1");
+    assertEquals(attributes["project.slug"], "demo-project");
+  });
+
+  it("reports an unexpected non-VeryfrontError failure that becomes a generic 500", async () => {
+    const thrown = new TypeError("cannot read properties of undefined");
+
+    const { captures, response } = await handleWithStubbedReporter(thrown);
+    await response.body?.cancel();
+
+    assertEquals(response.status, 500);
+    assertEquals(captures.length, 1);
+
+    const captured = captures[0];
+    assertExists(captured);
+    assertEquals(captured.error, thrown);
+    assertEquals(captured.context.boundary, "agent.stream.handler");
+    assertEquals(captured.context.requestId, "run_1");
+
+    const attributes = captured.context.attributes;
+    assertExists(attributes);
+    assertEquals(attributes["http.status"], 500);
+    assertEquals(attributes["project.id"], "proj-1");
+    assertEquals(attributes["project.slug"], "demo-project");
+  });
+
+  it("stays silent for a 4xx VeryfrontError so Sentry is not flooded", async () => {
+    const thrown = INVALID_ARGUMENT.create({
+      detail: "Agent source branch is not a known branch",
+    });
+
+    const { captures, response } = await handleWithStubbedReporter(thrown);
+    await response.body?.cancel();
+
+    assertEquals(response.status, 400);
+    assertEquals(captures.length, 0);
   });
 });

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -62,7 +62,11 @@ import {
 } from "#veryfront/errors";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
-import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import {
+  HTTP_INTERNAL_SERVER_ERROR,
+  PRIORITY_MEDIUM_API,
+} from "#veryfront/utils/constants/index.ts";
+import { captureApplicationError } from "#veryfront/observability/application-errors.ts";
 import { buildRuntimeShuttingDownResponse } from "./runtime-shutdown-response.ts";
 import { isServerShuttingDown } from "../../shutdown-state.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
@@ -701,6 +705,58 @@ function getPathRunId(pathname: string): string | null {
   return match?.[1] ? decodeURIComponent(match[1]) : null;
 }
 
+/**
+ * Report a server-side agent stream failure to the application-error reporter.
+ *
+ * Request handlers convert every error into a response, so nothing escapes to a
+ * global handler and per-request 5xx failures are invisible in Sentry unless
+ * they are reported here. Only 5xx reaches this function: 4xx failures are
+ * validation and auth outcomes that would drown the signal.
+ *
+ * `detail` is forwarded because it is the field that made the difference during
+ * the isolated-runtime incident, and because errorToResponse deliberately
+ * strips it from the 5xx body so the caller never receives it. Every attribute
+ * is sanitized by the reporter (URL credentials stripped, sensitive keys
+ * redacted, values truncated) before it leaves the process.
+ *
+ * Reporting is best-effort and optional: captureApplicationError is a no-op
+ * when no reporter is installed, which is the normal case for framework users
+ * running veryfront without Sentry configured.
+ */
+function reportAgentStreamFailure(
+  error: unknown,
+  req: Request,
+  ctx: HandlerContext,
+  details: {
+    boundary: string;
+    status: number;
+    slug?: string;
+    category?: string;
+    detail?: string;
+    cause?: string;
+  },
+): void {
+  const attributes: Record<string, string | number | boolean> = {
+    "http.status": details.status,
+  };
+  // `pathRunId` is scoped to the try block, so the run id is re-derived from
+  // the URL here. It is the identifier that ties an event to a single run.
+  const runId = getPathRunId(new URL(req.url).pathname);
+  if (details.slug) attributes["error.slug"] = details.slug;
+  if (details.category) attributes["error.category"] = details.category;
+  if (details.detail) attributes["error.detail"] = details.detail;
+  if (details.cause) attributes["error.cause"] = details.cause;
+  if (ctx.projectId) attributes["project.id"] = ctx.projectId;
+  if (ctx.projectSlug) attributes["project.slug"] = ctx.projectSlug;
+
+  captureApplicationError(error, {
+    boundary: details.boundary,
+    method: req.method,
+    ...(runId ? { requestId: runId } : {}),
+    attributes,
+  });
+}
+
 export class AgentStreamHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "AgentStreamHandler",
@@ -952,6 +1008,7 @@ export class AgentStreamHandler extends BaseHandler {
         // errorToResponse strips `detail` from 5xx bodies, and this branch is
         // otherwise silent, so the detail would be lost entirely.
         if (response.status >= 500) {
+          const cause = describeErrorCause(error.cause);
           logger.error("Internal agent stream request failed", {
             projectId: ctx.projectId,
             projectSlug: ctx.projectSlug,
@@ -960,7 +1017,15 @@ export class AgentStreamHandler extends BaseHandler {
             category: error.category,
             detail: error.detail,
             error: error.message,
-            cause: describeErrorCause(error.cause),
+            cause,
+          });
+          reportAgentStreamFailure(error, req, ctx, {
+            boundary: "agent.stream.request",
+            status: response.status,
+            slug: error.slug,
+            category: error.category,
+            detail: error.detail,
+            cause,
           });
         }
         return this.respond(applyBuilderHeaders(response, builder.headers));
@@ -975,6 +1040,12 @@ export class AgentStreamHandler extends BaseHandler {
         projectId: ctx.projectId,
         projectSlug: ctx.projectSlug,
         error: error instanceof Error ? error.message : String(error),
+      });
+      // Unexpected failures carry no slug/detail, so the log above is a bare
+      // message. This is the case where the captured stack is worth the most.
+      reportAgentStreamFailure(error, req, ctx, {
+        boundary: "agent.stream.handler",
+        status: HTTP_INTERNAL_SERVER_ERROR,
       });
       return this.respond(builder.json({ error: "Internal agent stream failed" }, 500));
     }

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -706,22 +706,13 @@ function getPathRunId(pathname: string): string | null {
 }
 
 /**
- * Report a server-side agent stream failure to the application-error reporter.
+ * Report a 5xx agent stream failure.
  *
- * Request handlers convert every error into a response, so nothing escapes to a
- * global handler and per-request 5xx failures are invisible in Sentry unless
- * they are reported here. Only 5xx reaches this function: 4xx failures are
- * validation and auth outcomes that would drown the signal.
- *
- * `detail` is forwarded because it is the field that made the difference during
- * the isolated-runtime incident, and because errorToResponse deliberately
- * strips it from the 5xx body so the caller never receives it. Every attribute
- * is sanitized by the reporter (URL credentials stripped, sensitive keys
- * redacted, values truncated) before it leaves the process.
- *
- * Reporting is best-effort and optional: captureApplicationError is a no-op
- * when no reporter is installed, which is the normal case for framework users
- * running veryfront without Sentry configured.
+ * Handlers convert every error into a response, so nothing escapes to a global
+ * handler and these would otherwise never reach Sentry. 4xx is excluded: it is
+ * mostly validation and auth noise. `detail` is forwarded because
+ * errorToResponse strips it from 5xx bodies. No-op when no reporter is
+ * installed, so Sentry stays optional.
  */
 function reportAgentStreamFailure(
   error: unknown,
@@ -739,9 +730,15 @@ function reportAgentStreamFailure(
   const attributes: Record<string, string | number | boolean> = {
     "http.status": details.status,
   };
-  // `pathRunId` is scoped to the try block, so the run id is re-derived from
-  // the URL here. It is the identifier that ties an event to a single run.
-  const runId = getPathRunId(new URL(req.url).pathname);
+  // `pathRunId` is scoped to the try block, so re-derive it here. Reporting runs
+  // inside a catch, so a malformed percent escape must not throw past it and
+  // take out the response this is describing.
+  let runId: string | null = null;
+  try {
+    runId = getPathRunId(new URL(req.url).pathname);
+  } catch {
+    runId = null;
+  }
   if (details.slug) attributes["error.slug"] = details.slug;
   if (details.category) attributes["error.category"] = details.category;
   if (details.detail) attributes["error.detail"] = details.detail;
@@ -1041,8 +1038,8 @@ export class AgentStreamHandler extends BaseHandler {
         projectSlug: ctx.projectSlug,
         error: error instanceof Error ? error.message : String(error),
       });
-      // Unexpected failures carry no slug/detail, so the log above is a bare
-      // message. This is the case where the captured stack is worth the most.
+      // Unexpected failures have no slug or detail, so the captured stack is
+      // the only real diagnostic.
       reportAgentStreamFailure(error, req, ctx, {
         boundary: "agent.stream.handler",
         status: HTTP_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## The problem

Request handlers catch every error and convert it to an HTTP response. Sentry only sees what escapes to a global handler — uncaught exceptions and unhandled rejections. A caught-and-converted error never escapes, so **every per-request failure is invisible in Sentry by construction**.

Confirming evidence: every issue currently in the `veryfront-server` Sentry project is a startup/bootstrap failure (`VERYFRONT_TRUST_FORWARDED_HEADERS`, `AddrInUse`, config-load errors). Those throw outside a request handler. Nothing per-request is there.

This is what made the isolated-runtime incident expensive: agent chat on staging returned 500 on every attempt for hours, with nothing in Sentry, nothing useful in logs, and no detail in the response. It was found only because a user reported broken chat.

## The design flaw

The handled/unhandled boundary was drawn at *"is it a `VeryfrontError`"* rather than *"is it 5xx"*.

That's right for the common case — most `VeryfrontError`s are 4xx (validation, auth) and reporting them would flood Sentry. But it swallows server errors too, which are exactly the ones worth paging on.

**The boundary should be status, not error type.** 5xx reports; 4xx doesn't.

## The change

Both 5xx exits of the agent-stream catch block now report:

| Exit | Boundary | Why |
|---|---|---|
| `isVeryfrontError` + `status >= 500` | `agent.stream.request` | Sits alongside the logging added in #3359 |
| generic fallback | `agent.stream.handler` | An unexpected `TypeError` produces a bare one-line log with no slug, detail, or stack — the case where a captured stack is worth the most |

Each event carries `slug`, `category`, `detail`, `project.id`, `project.slug`, `http.status` and the **run id** as `requestId`, so an event is actionable without a Loki dive.

## Notes for review

**`detail` is in the event but still not in the response.** `errorToResponse` strips `detail` from 5xx bodies at `src/errors/http-error.ts:104-106`. That is unchanged, and the existing test still asserts the caller never receives it. Forwarding it to Sentry is the whole point — it is the field that identified the isolated-runtime root cause.

**PII.** All 7 `detail` values this handler constructs are static string literals — no interpolated tokens, paths, or user input. Errors from deeper code are the residual risk, so the guarantee rests on the sanitizer rather than that audit: `sanitizeTelemetryAttributes` strips URL credentials, redacts sensitive key names, and truncates every value. This is the same treatment `detail` already gets in Loki today.

**Sentry is optional.** `captureApplicationError` is a no-op when no reporter is installed and swallows its own failures internally — so framework users running veryfront without Sentry configured are unaffected, and a reporter fault can never replace the application failure that triggered it. No call-site guard needed.

**No double-reporting.** The two branches are mutually exclusive — the typed branch returns, so the generic path cannot also fire for the same error. Nothing inside the `try` captures-and-rethrows. This is asserted behaviorally (`captures.length === 1`) rather than guarded with a `WeakSet`, so a future rethrow turns the test red instead of being silently absorbed. If a second capture site ever appears here, dedupe belongs in `captureApplicationError` itself.

## Tests

Three cases in `agent-stream.handler.test.ts`, modelled on the existing 5xx logging test — injecting a throw via `ensureProjectDiscovery` and installing a stub via `setApplicationErrorReporter`:

1. 5xx `VeryfrontError` reports exactly once, with full context
2. unexpected non-`VeryfrontError` reports exactly once
3. 4xx stays silent

Red proven by flipping the condition to `>= 600`: the typed 5xx test fails, the untyped one correctly still passes (different branch). Restored, all 45 steps in the file pass.

Gates: `deno check --no-lock`, `deno lint`, `deno fmt --check`, `deno task lint:test-typecheck` (baseline holds, 0 new). The test file was also typechecked directly to confirm it is not grandfathered.

## Scope

Deliberately one path. A survey found `agent-stream.handler.ts` is the **only** file under `src/server/handlers/` using `isVeryfrontError`/`errorToResponse`. Only three other request handlers convert a caught error to a 500 at all: `channel-dispatch-request.ts`, `agent-run-resume.handler.ts`, `agent-run-cancel.handler.ts`.

Those are follow-ups once events are confirmed landing in Sentry with useful context — not a blanket instrumentation pass in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring for agent stream failures.
  * Added contextual details to server-side error reports for faster diagnosis.
  * Prevented client-side (4xx) errors from being reported as application failures.
  * Added reporting for unexpected failures with appropriate internal-server error status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->