### PR TITLE
fix(server): report agent run resume/cancel 5xx failures to Sentry

### DIFF
--- a/src/server/handlers/request/agent-run-cancel.handler.test.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.test.ts
@@ -2,12 +2,12 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
-import {
-  type ApplicationErrorContext,
-  setApplicationErrorReporter,
-} from "#veryfront/observability/application-errors.ts";
 import { AgentRunCancelHandler } from "./agent-run-cancel.handler.ts";
-import { createControlPlaneSignature, createCtx } from "./internal-agent-run.test-helpers.ts";
+import {
+  createControlPlaneSignature,
+  createCtx,
+  stubApplicationErrorReporter,
+} from "./internal-agent-run.test-helpers.ts";
 
 describe("server/handlers/request/agent-run-cancel.handler", () => {
   it("cancels an active run with a valid control-plane signature", async () => {
@@ -193,14 +193,7 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
 
   it("returns 500 when session cancel fails unexpectedly, and reports it", async () => {
     const thrown = new Error("cancel boom");
-    const captures: { error: unknown; context: ApplicationErrorContext }[] = [];
-    setApplicationErrorReporter({
-      capture: (error, context) => {
-        captures.push({ error, context });
-        return "test-event-id";
-      },
-      flush: () => Promise.resolve(true),
-    });
+    const { captures, restore } = stubApplicationErrorReporter();
 
     try {
       const handler = new AgentRunCancelHandler({
@@ -239,7 +232,7 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
       assertEquals(captured.context.requestId, "run_1");
       assertEquals(captured.context.attributes?.["http.status"], 500);
     } finally {
-      setApplicationErrorReporter(undefined);
+      restore();
     }
   });
 });

--- a/src/server/handlers/request/agent-run-cancel.handler.test.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.test.ts
@@ -2,6 +2,10 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
+import {
+  type ApplicationErrorContext,
+  setApplicationErrorReporter,
+} from "#veryfront/observability/application-errors.ts";
 import { AgentRunCancelHandler } from "./agent-run-cancel.handler.ts";
 import { createControlPlaneSignature, createCtx } from "./internal-agent-run.test-helpers.ts";
 
@@ -185,5 +189,57 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
     );
 
     assertEquals(result.response, undefined);
+  });
+
+  it("returns 500 when session cancel fails unexpectedly, and reports it", async () => {
+    const thrown = new Error("cancel boom");
+    const captures: { error: unknown; context: ApplicationErrorContext }[] = [];
+    setApplicationErrorReporter({
+      capture: (error, context) => {
+        captures.push({ error, context });
+        return "test-event-id";
+      },
+      flush: () => Promise.resolve(true),
+    });
+
+    try {
+      const handler = new AgentRunCancelHandler({
+        cancelRun() {
+          throw thrown;
+        },
+      } as unknown as AgentRunSessionManager);
+      const body = JSON.stringify({ runId: "run_1" });
+      const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+        requestId: "run_1",
+        requestMethod: "DELETE",
+        requestPath: "/api/control-plane/runs/run_1",
+      });
+
+      const result = await handler.handle(
+        new Request("https://example.com/api/control-plane/runs/run_1", {
+          method: "DELETE",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-control-plane-jws": jws,
+          },
+          body,
+        }),
+        createCtx(publicKeyPem),
+      );
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 500);
+      assertEquals(await result.response.json(), { error: "Internal cancel failed" });
+
+      assertEquals(captures.length, 1);
+      const captured = captures[0];
+      assertExists(captured);
+      assertEquals(captured.error, thrown);
+      assertEquals(captured.context.boundary, "agent.run.cancel");
+      assertEquals(captured.context.requestId, "run_1");
+      assertEquals(captured.context.attributes?.["http.status"], 500);
+    } finally {
+      setApplicationErrorReporter(undefined);
+    }
   });
 });

--- a/src/server/handlers/request/agent-run-cancel.handler.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.ts
@@ -14,7 +14,11 @@ import {
 } from "#veryfront/internal-agents/request-body.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
-import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import {
+  HTTP_INTERNAL_SERVER_ERROR,
+  PRIORITY_MEDIUM_API,
+} from "#veryfront/utils/constants/index.ts";
+import { reportHandlerFailure } from "./report-handler-failure.ts";
 
 const CANCEL_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)$/;
 
@@ -77,6 +81,14 @@ export class AgentRunCancelHandler extends BaseHandler {
 
         this.logWarn("Internal agent run cancel failed", {
           error: error instanceof Error ? error.message : String(error),
+          runId,
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+        });
+        reportHandlerFailure(error, {
+          boundary: "agent.run.cancel",
+          method: req.method,
+          status: HTTP_INTERNAL_SERVER_ERROR,
           runId,
           projectId: ctx.projectId,
           projectSlug: ctx.projectSlug,

--- a/src/server/handlers/request/agent-run-resume.handler.test.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.test.ts
@@ -2,6 +2,10 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
+import {
+  type ApplicationErrorContext,
+  setApplicationErrorReporter,
+} from "#veryfront/observability/application-errors.ts";
 import { INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES } from "#veryfront/internal-agents/request-body.ts";
 import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
 import {
@@ -287,33 +291,55 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     assertEquals(await result.response.json(), { error: "RUN_NOT_ACTIVE" });
   });
 
-  it("returns 500 when session resume fails unexpectedly", async () => {
-    const handler = new AgentRunResumeHandler({
-      submitToolResult() {
-        throw new Error("resume boom");
+  it("returns 500 when session resume fails unexpectedly, and reports it", async () => {
+    const thrown = new Error("resume boom");
+    const captures: { error: unknown; context: ApplicationErrorContext }[] = [];
+    setApplicationErrorReporter({
+      capture: (error, context) => {
+        captures.push({ error, context });
+        return "test-event-id";
       },
-    } as unknown as AgentRunSessionManager);
-    const body = JSON.stringify({
-      type: "tool_result",
-      toolCallId: "tool_1",
-      result: { ok: true },
+      flush: () => Promise.resolve(true),
     });
-    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
-    const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-veryfront-control-plane-jws": jws,
+    try {
+      const handler = new AgentRunResumeHandler({
+        submitToolResult() {
+          throw thrown;
         },
-        body,
-      }),
-      createCtx(publicKeyPem),
-    );
+      } as unknown as AgentRunSessionManager);
+      const body = JSON.stringify({
+        type: "tool_result",
+        toolCallId: "tool_1",
+        result: { ok: true },
+      });
+      const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
-    assertExists(result.response);
-    assertEquals(result.response.status, 500);
-    assertEquals(await result.response.json(), { error: "Internal resume failed" });
+      const result = await handler.handle(
+        new Request("https://example.com/api/control-plane/runs/run_1/resume", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-control-plane-jws": jws,
+          },
+          body,
+        }),
+        createCtx(publicKeyPem),
+      );
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 500);
+      assertEquals(await result.response.json(), { error: "Internal resume failed" });
+
+      assertEquals(captures.length, 1);
+      const captured = captures[0];
+      assertExists(captured);
+      assertEquals(captured.error, thrown);
+      assertEquals(captured.context.boundary, "agent.run.resume");
+      assertEquals(captured.context.requestId, "run_1");
+      assertEquals(captured.context.attributes?.["http.status"], 500);
+    } finally {
+      setApplicationErrorReporter(undefined);
+    }
   });
 });

--- a/src/server/handlers/request/agent-run-resume.handler.test.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.test.ts
@@ -2,15 +2,12 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
-import {
-  type ApplicationErrorContext,
-  setApplicationErrorReporter,
-} from "#veryfront/observability/application-errors.ts";
 import { INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES } from "#veryfront/internal-agents/request-body.ts";
 import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
 import {
   createControlPlaneSignature as createTestControlPlaneSignature,
   createCtx,
+  stubApplicationErrorReporter,
 } from "./internal-agent-run.test-helpers.ts";
 
 function createControlPlaneSignature(
@@ -293,14 +290,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
 
   it("returns 500 when session resume fails unexpectedly, and reports it", async () => {
     const thrown = new Error("resume boom");
-    const captures: { error: unknown; context: ApplicationErrorContext }[] = [];
-    setApplicationErrorReporter({
-      capture: (error, context) => {
-        captures.push({ error, context });
-        return "test-event-id";
-      },
-      flush: () => Promise.resolve(true),
-    });
+    const { captures, restore } = stubApplicationErrorReporter();
 
     try {
       const handler = new AgentRunResumeHandler({
@@ -339,7 +329,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
       assertEquals(captured.context.requestId, "run_1");
       assertEquals(captured.context.attributes?.["http.status"], 500);
     } finally {
-      setApplicationErrorReporter(undefined);
+      restore();
     }
   });
 });

--- a/src/server/handlers/request/agent-run-resume.handler.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.ts
@@ -18,7 +18,11 @@ import {
 import { getResumeSignalSchema } from "#veryfront/internal-agents/schema.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
-import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import {
+  HTTP_INTERNAL_SERVER_ERROR,
+  PRIORITY_MEDIUM_API,
+} from "#veryfront/utils/constants/index.ts";
+import { reportHandlerFailure } from "./report-handler-failure.ts";
 
 const RESUME_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/resume$/;
 
@@ -99,6 +103,14 @@ export class AgentRunResumeHandler extends BaseHandler {
 
         this.logWarn("Internal agent run resume failed", {
           error: error instanceof Error ? error.message : String(error),
+          runId,
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+        });
+        reportHandlerFailure(error, {
+          boundary: "agent.run.resume",
+          method: req.method,
+          status: HTTP_INTERNAL_SERVER_ERROR,
           runId,
           projectId: ctx.projectId,
           projectSlug: ctx.projectSlug,

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,10 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { INVALID_ARGUMENT, SERVICE_OVERLOADED } from "#veryfront/errors";
 import {
-  type ApplicationErrorContext,
-  setApplicationErrorReporter,
-} from "#veryfront/observability/application-errors.ts";
-import {
   __registerLogRecordEmitter,
   __resetLogRecordEmitterForTests,
   type LogEntry,
@@ -25,6 +21,7 @@ import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
 import { AgentStreamHandler, type AgentStreamHandlerDeps } from "./agent-stream.handler.ts";
 import type { HandlerContext } from "../types.ts";
 import {
+  type CapturedApplicationError,
   createAgent,
   createAgentWithConfig,
   createControlPlaneSignature,
@@ -33,6 +30,7 @@ import {
   encodeDataStreamEvent,
   readRemainingText,
   readUntil,
+  stubApplicationErrorReporter,
 } from "./internal-agent-run.test-helpers.ts";
 import {
   createAgentStreamRequestBody,
@@ -3478,23 +3476,11 @@ describe("agent stream handler 5xx logging", () => {
 });
 
 describe("agent stream handler application-error reporting", () => {
-  type CapturedApplicationError = {
-    error: unknown;
-    context: ApplicationErrorContext;
-  };
-
   async function handleWithStubbedReporter(
     thrown: unknown,
     runIdSegment = "run_1",
   ): Promise<{ captures: CapturedApplicationError[]; response: Response }> {
-    const captures: CapturedApplicationError[] = [];
-    setApplicationErrorReporter({
-      capture: (error, context) => {
-        captures.push({ error, context });
-        return "test-event-id";
-      },
-      flush: () => Promise.resolve(true),
-    });
+    const { captures, restore } = stubApplicationErrorReporter();
 
     try {
       const handler = createTestAgentStreamHandler({
@@ -3528,7 +3514,7 @@ describe("agent stream handler application-error reporting", () => {
       assertExists(result.response);
       return { captures, response: result.response };
     } finally {
-      setApplicationErrorReporter(undefined);
+      restore();
     }
   }
 

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -718,9 +718,7 @@ function reportAgentStreamFailure(
     cause?: string;
   },
 ): void {
-  // `pathRunId` is scoped to the try block, so re-derive it here. Reporting runs
-  // inside a catch, so a malformed percent escape must not throw past it and
-  // take out the response this is describing.
+  // Runs inside a catch, so a malformed percent escape must not throw past it.
   let runId: string | null = null;
   try {
     runId = getPathRunId(new URL(req.url).pathname);

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -705,33 +705,13 @@ function getPathRunId(pathname: string): string | null {
   return match?.[1] ? decodeURIComponent(match[1]) : null;
 }
 
-function reportAgentStreamFailure(
-  error: unknown,
-  req: Request,
-  ctx: HandlerContext,
-  details: {
-    boundary: string;
-    status: number;
-    slug?: string;
-    category?: string;
-    detail?: string;
-    cause?: string;
-  },
-): void {
-  // Runs inside a catch, so a malformed percent escape must not throw past it.
-  let runId: string | null = null;
+/** getPathRunId decodes, which throws on a malformed escape; reporting must not. */
+function safeRunId(req: Request): string | null {
   try {
-    runId = getPathRunId(new URL(req.url).pathname);
+    return getPathRunId(new URL(req.url).pathname);
   } catch {
-    runId = null;
+    return null;
   }
-  reportHandlerFailure(error, {
-    ...details,
-    method: req.method,
-    runId,
-    projectId: ctx.projectId,
-    projectSlug: ctx.projectSlug,
-  });
 }
 
 export class AgentStreamHandler extends BaseHandler {
@@ -982,8 +962,8 @@ export class AgentStreamHandler extends BaseHandler {
 
       if (isVeryfrontError(error)) {
         const response = errorToResponse(error, new URL(req.url).pathname);
-        // errorToResponse strips `detail` from 5xx bodies, and this branch is
-        // otherwise silent, so the detail would be lost entirely.
+        // errorToResponse strips `detail` from 5xx bodies, so the log and the
+        // reported event are the only places it survives.
         if (response.status >= 500) {
           const cause = describeErrorCause(error.cause);
           logger.error("Internal agent stream request failed", {
@@ -996,9 +976,13 @@ export class AgentStreamHandler extends BaseHandler {
             error: error.message,
             cause,
           });
-          reportAgentStreamFailure(error, req, ctx, {
+          reportHandlerFailure(error, {
             boundary: "agent.stream.request",
+            method: req.method,
             status: response.status,
+            runId: safeRunId(req),
+            projectId: ctx.projectId,
+            projectSlug: ctx.projectSlug,
             slug: error.slug,
             category: error.category,
             detail: error.detail,
@@ -1020,9 +1004,13 @@ export class AgentStreamHandler extends BaseHandler {
       });
       // Unexpected failures have no slug or detail, so the captured stack is
       // the only real diagnostic.
-      reportAgentStreamFailure(error, req, ctx, {
+      reportHandlerFailure(error, {
         boundary: "agent.stream.handler",
+        method: req.method,
         status: HTTP_INTERNAL_SERVER_ERROR,
+        runId: safeRunId(req),
+        projectId: ctx.projectId,
+        projectSlug: ctx.projectSlug,
       });
       return this.respond(builder.json({ error: "Internal agent stream failed" }, 500));
     }

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -66,7 +66,7 @@ import {
   HTTP_INTERNAL_SERVER_ERROR,
   PRIORITY_MEDIUM_API,
 } from "#veryfront/utils/constants/index.ts";
-import { captureApplicationError } from "#veryfront/observability/application-errors.ts";
+import { reportHandlerFailure } from "./report-handler-failure.ts";
 import { buildRuntimeShuttingDownResponse } from "./runtime-shutdown-response.ts";
 import { isServerShuttingDown } from "../../shutdown-state.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
@@ -705,15 +705,6 @@ function getPathRunId(pathname: string): string | null {
   return match?.[1] ? decodeURIComponent(match[1]) : null;
 }
 
-/**
- * Report a 5xx agent stream failure.
- *
- * Handlers convert every error into a response, so nothing escapes to a global
- * handler and these would otherwise never reach Sentry. 4xx is excluded: it is
- * mostly validation and auth noise. `detail` is forwarded because
- * errorToResponse strips it from 5xx bodies. No-op when no reporter is
- * installed, so Sentry stays optional.
- */
 function reportAgentStreamFailure(
   error: unknown,
   req: Request,
@@ -727,9 +718,6 @@ function reportAgentStreamFailure(
     cause?: string;
   },
 ): void {
-  const attributes: Record<string, string | number | boolean> = {
-    "http.status": details.status,
-  };
   // `pathRunId` is scoped to the try block, so re-derive it here. Reporting runs
   // inside a catch, so a malformed percent escape must not throw past it and
   // take out the response this is describing.
@@ -739,18 +727,12 @@ function reportAgentStreamFailure(
   } catch {
     runId = null;
   }
-  if (details.slug) attributes["error.slug"] = details.slug;
-  if (details.category) attributes["error.category"] = details.category;
-  if (details.detail) attributes["error.detail"] = details.detail;
-  if (details.cause) attributes["error.cause"] = details.cause;
-  if (ctx.projectId) attributes["project.id"] = ctx.projectId;
-  if (ctx.projectSlug) attributes["project.slug"] = ctx.projectSlug;
-
-  captureApplicationError(error, {
-    boundary: details.boundary,
+  reportHandlerFailure(error, {
+    ...details,
     method: req.method,
-    ...(runId ? { requestId: runId } : {}),
-    attributes,
+    runId,
+    projectId: ctx.projectId,
+    projectSlug: ctx.projectSlug,
   });
 }
 

--- a/src/server/handlers/request/internal-agent-run.test-helpers.ts
+++ b/src/server/handlers/request/internal-agent-run.test-helpers.ts
@@ -2,6 +2,31 @@ import type { Agent, AgentResponse } from "#veryfront/agent";
 import { type Tool } from "#veryfront/tool";
 import type { HandlerContext } from "#veryfront/types";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import {
+  type ApplicationErrorContext,
+  setApplicationErrorReporter,
+} from "#veryfront/observability/application-errors.ts";
+
+export type CapturedApplicationError = {
+  error: unknown;
+  context: ApplicationErrorContext;
+};
+
+/** Install a recording application-error reporter. Call restore() in a finally. */
+export function stubApplicationErrorReporter(): {
+  captures: CapturedApplicationError[];
+  restore(): void;
+} {
+  const captures: CapturedApplicationError[] = [];
+  setApplicationErrorReporter({
+    capture: (error, context) => {
+      captures.push({ error, context });
+      return "test-event-id";
+    },
+    flush: () => Promise.resolve(true),
+  });
+  return { captures, restore: () => setApplicationErrorReporter(undefined) };
+}
 
 const encoder = new TextEncoder();
 

--- a/src/server/handlers/request/report-handler-failure.test.ts
+++ b/src/server/handlers/request/report-handler-failure.test.ts
@@ -1,0 +1,55 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { reportHandlerFailure } from "./report-handler-failure.ts";
+import { stubApplicationErrorReporter } from "./internal-agent-run.test-helpers.ts";
+
+describe("server/handlers/request/report-handler-failure", () => {
+  it("reports a 5xx with its context", () => {
+    const thrown = new Error("boom");
+    const { captures, restore } = stubApplicationErrorReporter();
+
+    try {
+      reportHandlerFailure(thrown, {
+        boundary: "test.boundary",
+        method: "POST",
+        status: 503,
+        runId: "run_1",
+        projectId: "proj-1",
+        projectSlug: "demo-project",
+        slug: "service-overloaded",
+      });
+
+      assertEquals(captures.length, 1);
+      const captured = captures[0];
+      assertExists(captured);
+      assertEquals(captured.error, thrown);
+      assertEquals(captured.context.boundary, "test.boundary");
+      assertEquals(captured.context.requestId, "run_1");
+      assertEquals(captured.context.attributes?.["http.status"], 503);
+      assertEquals(captured.context.attributes?.["error.slug"], "service-overloaded");
+    } finally {
+      restore();
+    }
+  });
+
+  // The 5xx-only boundary is the whole point of this module, so it is enforced
+  // rather than left to callers to remember.
+  it("drops anything below 500", () => {
+    const { captures, restore } = stubApplicationErrorReporter();
+
+    try {
+      for (const status of [400, 401, 404, 409, 499]) {
+        reportHandlerFailure(new Error("boom"), {
+          boundary: "test.boundary",
+          method: "POST",
+          status,
+        });
+      }
+
+      assertEquals(captures.length, 0);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/server/handlers/request/report-handler-failure.ts
+++ b/src/server/handlers/request/report-handler-failure.ts
@@ -1,0 +1,48 @@
+import { captureApplicationError } from "#veryfront/observability/application-errors.ts";
+
+/**
+ * Report a 5xx request-handler failure.
+ *
+ * Handlers convert every error into a response, so nothing escapes to a global
+ * handler and these would otherwise never reach Sentry. Call this only for 5xx:
+ * 4xx is mostly validation and auth noise.
+ *
+ * Callers pass `detail` where they have it, because errorToResponse strips it
+ * from 5xx bodies and it is then lost entirely. Attributes are sanitized by the
+ * reporter (URL credentials stripped, sensitive keys redacted, values
+ * truncated) before leaving the process.
+ *
+ * No-op when no reporter is installed, so Sentry stays optional.
+ */
+export function reportHandlerFailure(
+  error: unknown,
+  details: {
+    boundary: string;
+    method: string;
+    status: number;
+    runId?: string | null;
+    projectId?: string;
+    projectSlug?: string;
+    slug?: string;
+    category?: string;
+    detail?: string;
+    cause?: string;
+  },
+): void {
+  const attributes: Record<string, string | number | boolean> = {
+    "http.status": details.status,
+  };
+  if (details.slug) attributes["error.slug"] = details.slug;
+  if (details.category) attributes["error.category"] = details.category;
+  if (details.detail) attributes["error.detail"] = details.detail;
+  if (details.cause) attributes["error.cause"] = details.cause;
+  if (details.projectId) attributes["project.id"] = details.projectId;
+  if (details.projectSlug) attributes["project.slug"] = details.projectSlug;
+
+  captureApplicationError(error, {
+    boundary: details.boundary,
+    method: details.method,
+    ...(details.runId ? { requestId: details.runId } : {}),
+    attributes,
+  });
+}

--- a/src/server/handlers/request/report-handler-failure.ts
+++ b/src/server/handlers/request/report-handler-failure.ts
@@ -3,7 +3,7 @@ import { captureApplicationError } from "#veryfront/observability/application-er
 /**
  * Report a 5xx handler failure. Handlers convert errors into responses, so
  * these never escape to a global handler and would not otherwise reach Sentry.
- * 4xx is excluded as noise. No-op when no reporter is installed.
+ * Anything below 500 is dropped as noise. No-op when no reporter is installed.
  */
 export function reportHandlerFailure(
   error: unknown,
@@ -20,6 +20,10 @@ export function reportHandlerFailure(
     cause?: string;
   },
 ): void {
+  // Enforced here, not just documented: a future caller passing a 4xx would
+  // otherwise flood Sentry with the validation and auth noise this excludes.
+  if (details.status < 500) return;
+
   const attributes: Record<string, string | number | boolean> = {
     "http.status": details.status,
   };

--- a/src/server/handlers/request/report-handler-failure.ts
+++ b/src/server/handlers/request/report-handler-failure.ts
@@ -1,18 +1,9 @@
 import { captureApplicationError } from "#veryfront/observability/application-errors.ts";
 
 /**
- * Report a 5xx request-handler failure.
- *
- * Handlers convert every error into a response, so nothing escapes to a global
- * handler and these would otherwise never reach Sentry. Call this only for 5xx:
- * 4xx is mostly validation and auth noise.
- *
- * Callers pass `detail` where they have it, because errorToResponse strips it
- * from 5xx bodies and it is then lost entirely. Attributes are sanitized by the
- * reporter (URL credentials stripped, sensitive keys redacted, values
- * truncated) before leaving the process.
- *
- * No-op when no reporter is installed, so Sentry stays optional.
+ * Report a 5xx handler failure. Handlers convert errors into responses, so
+ * these never escape to a global handler and would not otherwise reach Sentry.
+ * 4xx is excluded as noise. No-op when no reporter is installed.
  */
 export function reportHandlerFailure(
   error: unknown,


### PR DESCRIPTION
Follow-up to #3363, which drew the reporting boundary at status (5xx reports, 4xx doesn't) for the agent-stream path.

## The same defect, two more places

`agent-run-resume` and `agent-run-cancel` both catch an unexpected error, log it at **warn** level with only a message, and convert it to a 500 that never reaches Sentry. Same shape as the bug #3363 fixed.

Both now report. Neither has a typed-error branch, so both use the plain form: boundary, method, run id, project id and slug.

| Handler | Boundary |
|---|---|
| `agent-run-resume` | `agent.run.resume` |
| `agent-run-cancel` | `agent.run.cancel` |

## Correcting the survey in #3363

That PR named **three** remaining handlers. That was wrong — it's two.

`channel-dispatch-request.ts` does not belong. Its `HTTP_INTERNAL_SERVER_ERROR` is a config-missing guard (no signing key configured), not a caught error, and its three catch blocks all return 4xx or rethrow. The original count came from a grep that counted 500-mentions in any file containing `catch`, which is not the same question.

Worth stating plainly since that survey was used to scope this follow-up.

## Consolidation

Three call sites now build the same attribute map, so it moves into `reportHandlerFailure` instead of being copy-pasted a third time. `agent-stream` keeps its `URIError` guard locally — that guard is specific to its `decodeURIComponent` path. Resume and cancel match the run id without decoding, so they cannot throw there, and both already hold `runId` in scope.

Net effect on `agent-stream.handler.ts` is -18 lines.

## Tests

Extends the **existing** resume 500 test rather than adding a parallel one, and adds the cancel 500 case, which was missing entirely.

Red proven by deleting both report calls: both tests fail. Restored, all 63 steps across the three handler test files pass.

Gates: `deno check --no-lock`, `deno lint`, `deno fmt --check`, `deno task lint:test-typecheck` (baseline holds, 0 new).

## Still open

Nothing is yet confirmed against real Sentry. #3363 shipped in `0.1.1197` and is on npm, but `veryfront-server` has not picked up that version, so no deployed service is running this code yet. The end-to-end check — trigger a 500 on staging, confirm the event carries useful context — remains the outstanding item from #3363.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected agent run cancellation, resumption, and streaming failures.
  * Errors continue to return HTTP 500 responses while now including more consistent diagnostic context.

* **Tests**
  * Added coverage verifying that unexpected failures are reported with the expected error, request, and status details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->