### PR TITLE
fix(provider): accept repeated post-finish usage events

### DIFF
--- a/extensions/ext-llm-openai/src/openai-chat-stream.test.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-stream.test.ts
@@ -407,6 +407,30 @@ describe("ext-llm-openai/openai-chat-stream", () => {
     );
   });
 
+  it("accepts repeated post-finish usage events without double counting", async () => {
+    // OpenAI's include_usage chunk uses `choices: []`; aggregators add a bare
+    // `{usage}`. Repeated cumulative totals must merge, not accumulate.
+    const usage = { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 };
+    const finish = data({ choices: [{ delta: {}, finish_reason: "stop" }] });
+    const emptyChoices = data({ choices: [], usage });
+    const bare = data({ usage });
+
+    for (
+      const tail of [[emptyChoices, emptyChoices], [emptyChoices, bare], [bare, bare]]
+    ) {
+      assertEquals(
+        await collectParts(
+          streamFromText([finish, ...tail, "data: [DONE]\r\n\r\n"].join("")),
+        ),
+        [{
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+        }],
+      );
+    }
+  });
+
   it("rejects structurally empty and unterminated successful streams", async () => {
     await assertRejects(
       () => collectParts(streamFromText(data({}))),

--- a/extensions/ext-llm-openai/src/openai-chat-stream.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-stream.ts
@@ -226,7 +226,6 @@ export async function* streamOpenAICompatibleParts(
   let sawChoiceEnvelope = false;
   let sawFinishReason = false;
   let sawDone = false;
-  let sawPostFinishUsage = false;
   const toolArgumentBudget: OpenAIStreamToolArgumentBudget = {
     bytes: 0,
     fragments: 0,
@@ -258,12 +257,6 @@ export async function* streamOpenAICompatibleParts(
       if (!usageRecord) {
         throw invalidOpenAIStream(context, "event had neither choices nor usage");
       }
-      if (sawFinishReason) {
-        if (sawPostFinishUsage) {
-          throw invalidOpenAIStream(context, "stream contained multiple post-finish usage events");
-        }
-        sawPostFinishUsage = true;
-      }
       return;
     }
     if (!Array.isArray(record.choices)) {
@@ -272,12 +265,6 @@ export async function* streamOpenAICompatibleParts(
     if (record.choices.length === 0) {
       if (!usageRecord) {
         throw invalidOpenAIStream(context, "empty choices event had no usage");
-      }
-      if (sawFinishReason) {
-        if (sawPostFinishUsage) {
-          throw invalidOpenAIStream(context, "stream contained multiple post-finish usage events");
-        }
-        sawPostFinishUsage = true;
       }
       return;
     }


### PR DESCRIPTION
## Summary

Agent runs on OpenAI-compatible providers die mid-turn with:

```
veryfront-cloud request failed: invalid successful stream
  (stream contained multiple post-finish usage events)
```

`openai-chat-stream.ts` allowed exactly **one** usage-only chunk after the finish reason and threw on the second. Providers behind veryfront-cloud send more than one.

Observed on staging with `moonshotai/kimi-k2.6`, run `07a460b0-e707-4181-bf31-3cbed7a62554`, which died while streaming its first tool call (`outlook__list_emails_0`, still at `streaming_input`).

## Why the guard was wrong

**Both chunk shapes are legitimate.** OpenAI's own `stream_options.include_usage` final chunk uses `choices: []`; aggregators add a bare `{usage}` summary. The two throw sites handled these different shapes but **shared one `sawPostFinishUsage` flag**, so a stream carrying one of each was rejected as well.

**The throw contradicted the line above it.** `mergeOpenAIUsage` already ran on every event *before* the guard:

```ts
usage = mergeOpenAIUsage(usage, record);   // merge happens first

if (record.choices === undefined) {
  ...
  if (sawPostFinishUsage) {
    throw invalidOpenAIStream(...);        // then throws anyway
  }
```

The second usage payload was merged correctly and then discarded along with the entire run.

**Merging repeated totals is safe.** `mergeRuntimeUsage` resolves each field with `latestValidValue(incoming, previous)` — last-write-wins, not additive. Repeated cumulative usage cannot double-count. The new test asserts this directly rather than assuming it.

## Reproduction

Against the real parser, a Kimi-style turn (reasoning → tool call → `finish_reason: tool_calls` → usage → `[DONE]`):

| Post-finish usage chunks | Before | After |
|---|---|---|
| 1 × `{choices:[], usage}` | OK | OK |
| 2 × `{choices:[], usage}` | **THREW** | OK, total `120` |
| `{choices:[], usage}` + `{usage}` | **THREW** | OK, total `120` |
| 2 × `{usage}` | **THREW** | OK, total `120` |

Totals stay at the provider's numbers (`100/20/120`), not doubled — confirming last-write-wins empirically.

## What is unchanged

Every other guard from #3235 still fails closed:

- data after the done marker
- choice data after the finish reason
- events with neither choices nor usage
- empty-choices events without usage
- malformed choices, deltas, finish reasons, tool-call identities and budgets

Only the multi-usage assertion is removed, along with a flag that no longer had a reader.

## Note on test coverage

**Nothing pinned the removed behavior.** #3235 added the guard without a test asserting it, which is why deleting it broke no existing test. The new test fails on `origin/main` with the exact production error and passes with the fix — verified by reverting the source and re-running.

## Validation

`extensions/ext-llm-openai/` — **9 passed, 146 steps, 0 failed.** `deno lint` and `deno fmt --check` clean.

## Blast radius

4 occurrences in Loki over 72h, all `outlook-agent-hvjoe9`. That undercounts: agent chat was broken repo-wide until veryfront-issue-inbox#356 was fixed at ~20:29 today, so those 4 are from roughly a 3.5-hour window of working traffic. This is not specific to Kimi or to the Outlook agent — any agent on an OpenAI-compatible provider that emits two usage chunks hits it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed usage reporting for repeated post-completion events.
  * Prevented cumulative usage totals from being double-counted across different event formats and ordering scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->