### PR TITLE
test(import-map): stop racing wall time in preloader capacity tests

### DIFF
--- a/src/modules/import-map/preloader.test.ts
+++ b/src/modules/import-map/preloader.test.ts
@@ -18,6 +18,13 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { MAX_TIMER_DELAY_MS } from "#veryfront/utils/constants/limits.ts";
 import type { ImportMapConfig } from "./types.ts";
 
+/**
+ * `loadTimeoutMs` arms a real `setTimeout`, not the injected `now` clock, so
+ * tests holding a load unresolved race wall time and flake under CI load. Tests
+ * that do exercise timeout behavior keep their own small values.
+ */
+const TIMEOUT_NOT_UNDER_TEST_MS = 600_000;
+
 function createMinimalAdapter(): RuntimeAdapter {
   return {
     fs: {
@@ -1135,7 +1142,7 @@ describe("modules/import-map/preloader", () => {
         maxProjects: 2,
         maxVariantsPerProject: 1,
         ttlMs: 1_000,
-        loadTimeoutMs: 1_000,
+        loadTimeoutMs: TIMEOUT_NOT_UNDER_TEST_MS,
         loadImportMap: () => {
           const load = createDeferred<ImportMapConfig>();
           loads.push(load);
@@ -1223,7 +1230,7 @@ describe("modules/import-map/preloader", () => {
         maxProjects: 2,
         maxVariantsPerProject: 2,
         ttlMs: 1_000,
-        loadTimeoutMs: 1_000,
+        loadTimeoutMs: TIMEOUT_NOT_UNDER_TEST_MS,
         loadImportMap: () => {
           const load = createDeferred<ImportMapConfig>();
           loads.push(load);
@@ -1296,7 +1303,7 @@ describe("modules/import-map/preloader", () => {
         maxProjects: 1,
         maxVariantsPerProject: 2,
         ttlMs: 1_000,
-        loadTimeoutMs: 10_000,
+        loadTimeoutMs: TIMEOUT_NOT_UNDER_TEST_MS,
         now: () => {
           if (releaseDuringAdmission && admissionClockReads++ === 0) {
             loads[0]!.resolve({ imports: { source: "a" } });


### PR DESCRIPTION
Fixes veryfront-issue-inbox#364.

## The flake

`modules/import-map/preloader ... does not miss capacity released before a waiter observes its signal` failed **five times today** in `coverage shard 4/8`, always with:

```
RangeError: Import-map preloader load timed out
  at src/modules/import-map/preloader.ts:833:16
```

Shard result each time: `433 passed (3438 steps) | 1 failed (2 steps)`.

It **ejected #3365 from the merge queue** and failed PR CI on #3364 and #3369. It passes on re-run every time, and 3/3 locally.

## Root cause

`loadTimeoutMs` arms a **real `setTimeout`**, not the injected `now` clock:

```ts
timeoutId = SetTimeout(() => {
  ...
  reject(new IntrinsicRangeError("Import-map preloader load timed out"));
}, this.loadTimeoutMs);
```

Three of these tests deliberately hold a load unresolved across the whole test body — that is precisely what they exercise, since capacity accounting only matters while work is in flight. So each one is racing wall time against a 1s or 10s deadline.

Shard 4/8 runs 200+ files with `--parallel`, coverage instrumentation, and `--v8-flags=--max-old-space-size=8192`. The event loop can stall past the deadline, and the timer then rejects a load the test never intended to time out.

The injected `now` is a counter (`++clock`), so it cannot influence this — the test looks deterministic while carrying a hidden wall-clock dependency.

## Fix

Give the three tests whose subject is *not* the timeout a delay far beyond any plausible stall, behind a named constant carrying the reason:

```ts
const TIMEOUT_NOT_UNDER_TEST_MS = 600_000;
```

Ten minutes is well under `MAX_TIMER_DELAY_MS` (2^31-1). The two tests that genuinely exercise timeout behavior keep their own small values (20ms, 100ms) and are untouched — the constant's doc comment says not to fold them in.

Nothing in the product changes. `preloader.ts` is not modified.

## Verified, not assumed

Setting the constant to `1` reproduces the exact CI failure locally:

```
error: RangeError: Import-map preloader load timed out
FAILED | 0 passed (36 steps) | 2 failed (1 step)
```

Restoring it to `600_000` passes. That confirms the real timer is the mechanism rather than something incidental to CI.

## Validation

- `src/modules/import-map/preloader.test.ts` — 47 steps, 0 failed
- `src/modules/import-map/` — **6 passed, 104 steps, 0 failed**
- `deno lint` and `deno fmt --check` clean

## Note

This is a test-only fix for a test-only race. If the intent is that a load *must* complete within a bounded wall-clock window even under load, that belongs in a product-level assertion with a deterministic clock — not in tests whose subject is capacity accounting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized timeout settings for bounded-cache tests.
  * Preserved dedicated timing behavior for tests that specifically validate timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->