### PR TITLE
fix(import-map): give the preloader a timer seam so deadlines follow its clock

### DIFF
--- a/src/modules/import-map/preloader.test.ts
+++ b/src/modules/import-map/preloader.test.ts
@@ -68,6 +68,72 @@ async function waitForLoadCount(
   assertEquals(loads.length, expected);
 }
 
+/**
+ * Timer seam that never fires on its own.
+ *
+ * Tests that inject a virtual clock must inject timers too. Otherwise the
+ * preloader's deadline is measured against the wall clock while the rest of the
+ * test advances by fake ticks, so a starved CI worker can trip a timeout during
+ * work that consumed no virtual time at all. That turned a millisecond test into
+ * a ten-minute hang that only reproduced under full-shard load.
+ */
+function createInertTimers() {
+  let nextHandle = 1;
+  const pending = new Map<number, () => void>();
+  return {
+    setTimer: (callback: () => void, _delayMs: number) => {
+      const handle = nextHandle++;
+      pending.set(handle, callback);
+      return handle as unknown as ReturnType<typeof setTimeout>;
+    },
+    cancelTimer: (handle: ReturnType<typeof setTimeout>) => {
+      pending.delete(handle as unknown as number);
+    },
+    /** Fire a pending deadline explicitly when the timeout *is* under test. */
+    fireAll: () => {
+      const callbacks = [...pending.values()];
+      pending.clear();
+      for (const callback of callbacks) callback();
+    },
+  };
+}
+
+/**
+ * Await `promise` within a bounded number of macrotask turns.
+ *
+ * With inert timers a missed signal would hang forever rather than fail, so the
+ * bound is what keeps a genuine regression fast and legible instead of silent.
+ */
+async function settleWithin<T>(
+  promise: Promise<T>,
+  label: string,
+  turns = 200,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let cancelled = false;
+  const deadline = new Promise<never>((_, reject) => {
+    let turn = 0;
+    const tick = () => {
+      if (cancelled) return;
+      if (++turn >= turns) {
+        reject(new Error(`${label} did not settle within ${turns} macrotask turns`));
+        return;
+      }
+      timer = setTimeout(tick, 0);
+    };
+    timer = setTimeout(tick, 0);
+  });
+  try {
+    return await Promise.race([promise, deadline]);
+  } finally {
+    // The chain must be torn down explicitly: a pending tick would outlive the
+    // test and trip the runner's timer-leak detector.
+    cancelled = true;
+    if (timer !== undefined) clearTimeout(timer);
+    deadline.catch(() => {});
+  }
+}
+
 describe("modules/import-map/preloader", () => {
   describe("preloadImportMap", () => {
     it("should return an import map config", async () => {
@@ -1299,11 +1365,14 @@ describe("modules/import-map/preloader", () => {
       let releaseDuringAdmission = false;
       let admissionClockReads = 0;
       let clock = 0;
+      const timers = createInertTimers();
       const preloader = new ImportMapPreloader({
         maxProjects: 1,
         maxVariantsPerProject: 2,
         ttlMs: 1_000,
         loadTimeoutMs: TIMEOUT_NOT_UNDER_TEST_MS,
+        setTimer: timers.setTimer,
+        cancelTimer: timers.cancelTimer,
         now: () => {
           if (releaseDuringAdmission && admissionClockReads++ === 0) {
             loads[0]!.resolve({ imports: { source: "a" } });
@@ -1332,10 +1401,13 @@ describe("modules/import-map/preloader", () => {
 
       await waitForLoadCount(loads, 3);
       loads[2]!.resolve({ imports: { source: "c" } });
-      assertEquals((await first).imports?.source, "a");
-      assertEquals((await queued).imports?.source, "c");
+      assertEquals((await settleWithin(first, "first preload")).imports?.source, "a");
+      assertEquals((await settleWithin(queued, "queued preload")).imports?.source, "c");
       loads[1]!.resolve({ imports: { source: "b" } });
-      assertEquals((await unrelated).imports?.source, "b");
+      assertEquals(
+        (await settleWithin(unrelated, "unrelated preload")).imports?.source,
+        "b",
+      );
     });
 
     it("keeps variant identity and capacity deterministic after primordial poisoning", async () => {

--- a/src/modules/import-map/preloader.test.ts
+++ b/src/modules/import-map/preloader.test.ts
@@ -1410,6 +1410,70 @@ describe("modules/import-map/preloader", () => {
       );
     });
 
+    it("measures the capacity deadline on the injected monotonic clock", async () => {
+      // The injected monotonic clock is frozen while host time keeps running.
+      // A capacity-blocked caller must therefore never reach its deadline: if
+      // the retry still consulted performance.now, real time would sail past
+      // loadTimeoutMs and reject it. Keeping this seam separate from `now` also
+      // matters, because `now` defaults to Date.now, which NTP can move
+      // backwards, and deadline arithmetic needs a monotonic source.
+      const adapter = createMinimalAdapter();
+      const loads: Array<ReturnType<typeof createDeferred<ImportMapConfig>>> = [];
+      const timers = createInertTimers();
+      const preloader = new ImportMapPreloader({
+        maxProjects: 1,
+        maxVariantsPerProject: 1,
+        ttlMs: TIMEOUT_NOT_UNDER_TEST_MS,
+        loadTimeoutMs: 50,
+        setTimer: timers.setTimer,
+        cancelTimer: timers.cancelTimer,
+        monotonicNow: () => 1_000,
+        now: () => 1,
+        loadImportMap: () => {
+          const load = createDeferred<ImportMapConfig>();
+          loads.push(load);
+          return load.promise;
+        },
+      });
+
+      const occupying = preloader.preload("/project", adapter, "project", {
+        contentSourceId: "source-a",
+      });
+      await waitForLoadCount(loads, 1);
+
+      const blocked = preloader.preload("/project", adapter, "project", {
+        contentSourceId: "source-b",
+      });
+
+      let settledEarly = false;
+      const observed = blocked.then(
+        () => {
+          settledEarly = true;
+        },
+        () => {
+          settledEarly = true;
+        },
+      );
+      for (let turn = 0; turn < 50; turn++) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+      assertEquals(settledEarly, false);
+
+      // Releasing capacity, not the passage of host time, is what lets it run.
+      loads[0]!.resolve({ imports: { source: "a" } });
+      assertEquals(
+        (await settleWithin(occupying, "occupying preload")).imports?.source,
+        "a",
+      );
+      await waitForLoadCount(loads, 2);
+      loads[1]!.resolve({ imports: { source: "b" } });
+      assertEquals(
+        (await settleWithin(blocked, "capacity-blocked preload")).imports?.source,
+        "b",
+      );
+      await observed;
+    });
+
     it("keeps variant identity and capacity deterministic after primordial poisoning", async () => {
       const worker = new Worker(
         new URL("./preloader-primordial-poisoning.worker.ts", import.meta.url),

--- a/src/modules/import-map/preloader.test.ts
+++ b/src/modules/import-map/preloader.test.ts
@@ -1454,9 +1454,16 @@ describe("modules/import-map/preloader", () => {
           settledEarly = true;
         },
       );
-      for (let turn = 0; turn < 50; turn++) {
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      // Host time must genuinely pass loadTimeoutMs, otherwise this proves
+      // nothing: a retry still reading performance.now would also be inside its
+      // deadline, and the test would pass with the bug present. Yield on timed
+      // sleeps rather than a fixed turn count, so the wait is bounded by the
+      // real clock advancing instead of by a turn budget that can run out first.
+      const hostDeadline = performance.now() + 50;
+      while (performance.now() < hostDeadline) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 5));
       }
+      assertEquals(performance.now() >= hostDeadline, true);
       assertEquals(settledEarly, false);
 
       // Releasing capacity, not the passage of host time, is what lets it run.

--- a/src/modules/import-map/preloader.ts
+++ b/src/modules/import-map/preloader.ts
@@ -207,6 +207,15 @@ export interface ImportMapPreloaderOptions {
   loadTimeoutMs?: number;
   /** Monotonic-enough clock seam; defaults to Date.now. */
   now?: () => number;
+  /**
+   * Timer seam, paired with `now`. Defaults to the host timers.
+   *
+   * Without this, a caller that injects `now` still has its deadlines measured
+   * against the wall clock, so a starved process can trip a timeout during work
+   * that took no virtual time at all. Override both halves together.
+   */
+  setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  cancelTimer?: (handle: ReturnType<typeof setTimeout>) => void;
   /** Loader seam for alternate runtimes and deterministic verification. */
   loadImportMap?: typeof loadImportMap;
 }
@@ -368,6 +377,11 @@ export class ImportMapPreloader {
   private readonly ttlMs: number;
   private readonly loadTimeoutMs: number;
   private readonly now: () => number;
+  private readonly setTimer: (
+    callback: () => void,
+    delayMs: number,
+  ) => ReturnType<typeof setTimeout>;
+  private readonly cancelTimer: (handle: ReturnType<typeof setTimeout>) => void;
   private readonly loader: typeof loadImportMap;
 
   constructor(options: ImportMapPreloaderOptions = {}) {
@@ -395,6 +409,11 @@ export class ImportMapPreloader {
       DEFAULT_IMPORT_MAP_LOAD_TIMEOUT_MS,
     );
     this.now = options.now ?? DateNow;
+    // Wrap rather than store the host timers directly: called as `this.setTimer`
+    // they would receive the preloader as their receiver, and Deno's timers
+    // reject any receiver that is not the global object.
+    this.setTimer = options.setTimer ?? ((callback, delayMs) => SetTimeout(callback, delayMs));
+    this.cancelTimer = options.cancelTimer ?? ((handle) => ClearTimeout(handle));
     this.loader = options.loadImportMap ?? loadImportMap;
   }
 
@@ -554,17 +573,17 @@ export class ImportMapPreloader {
     if (!hasActiveWork) return resolvedPromise();
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeout = new IntrinsicPromise<void>((_, reject) => {
-      timeoutId = SetTimeout(() => {
+      timeoutId = this.setTimer(() => {
         reject(new IntrinsicRangeError("Import-map preloader capacity wait timed out"));
       }, timeoutMs);
     });
     return promiseThen(
       raceTwo(capacityChange, timeout),
       () => {
-        if (timeoutId !== undefined) ClearTimeout(timeoutId);
+        if (timeoutId !== undefined) this.cancelTimer(timeoutId);
       },
       (error) => {
-        if (timeoutId !== undefined) ClearTimeout(timeoutId);
+        if (timeoutId !== undefined) this.cancelTimer(timeoutId);
         throw error;
       },
     );
@@ -824,7 +843,7 @@ export class ImportMapPreloader {
     this.trackActiveLoad(loaderPromise);
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new IntrinsicPromise<ImportMapConfig>((_, reject) => {
-      timeoutId = SetTimeout(() => {
+      timeoutId = this.setTimer(() => {
         if (setDelete(this.activeLoads, loaderPromise)) {
           this.trackOrphanedLoad(cacheKey, loaderPromise);
           this.notifyCapacityChange();
@@ -836,11 +855,11 @@ export class ImportMapPreloader {
     const boundedLoaderPromise = promiseThen(
       raceTwo(loaderPromise, timeoutPromise),
       (value) => {
-        if (timeoutId !== undefined) ClearTimeout(timeoutId);
+        if (timeoutId !== undefined) this.cancelTimer(timeoutId);
         return value;
       },
       (error) => {
-        if (timeoutId !== undefined) ClearTimeout(timeoutId);
+        if (timeoutId !== undefined) this.cancelTimer(timeoutId);
         throw error;
       },
     );

--- a/src/modules/import-map/preloader.ts
+++ b/src/modules/import-map/preloader.ts
@@ -216,6 +216,17 @@ export interface ImportMapPreloaderOptions {
    */
   setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
   cancelTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+  /**
+   * Elapsed-time seam for the capacity-retry deadline; defaults to
+   * performance.now.
+   *
+   * Deliberately separate from `now`: that clock carries absolute time for TTL
+   * and expiry, and defaults to Date.now, which can jump backwards under NTP
+   * correction. Deadline arithmetic needs a monotonic source, so the two cannot
+   * share one seam without either breaking expiry semantics or making timeouts
+   * clock-skew sensitive.
+   */
+  monotonicNow?: () => number;
   /** Loader seam for alternate runtimes and deterministic verification. */
   loadImportMap?: typeof loadImportMap;
 }
@@ -382,6 +393,7 @@ export class ImportMapPreloader {
     delayMs: number,
   ) => ReturnType<typeof setTimeout>;
   private readonly cancelTimer: (handle: ReturnType<typeof setTimeout>) => void;
+  private readonly monotonicNow: () => number;
   private readonly loader: typeof loadImportMap;
 
   constructor(options: ImportMapPreloaderOptions = {}) {
@@ -409,11 +421,17 @@ export class ImportMapPreloader {
       DEFAULT_IMPORT_MAP_LOAD_TIMEOUT_MS,
     );
     this.now = options.now ?? DateNow;
-    // Wrap rather than store the host timers directly: called as `this.setTimer`
-    // they would receive the preloader as their receiver, and Deno's timers
-    // reject any receiver that is not the global object.
-    this.setTimer = options.setTimer ?? ((callback, delayMs) => SetTimeout(callback, delayMs));
-    this.cancelTimer = options.cancelTimer ?? ((handle) => ClearTimeout(handle));
+    // Wrap every timer, caller-supplied ones included, rather than storing them
+    // directly. Invoked as `this.setTimer` a stored function receives the
+    // preloader as its receiver, and Deno's timers reject any receiver that is
+    // not the global object, so `setTimer: setTimeout` would throw
+    // `Illegal invocation` at the first load.
+    const setTimer = options.setTimer ?? SetTimeout;
+    const cancelTimer = options.cancelTimer ?? ClearTimeout;
+    const monotonic = options.monotonicNow ?? monotonicNow;
+    this.setTimer = (callback, delayMs) => setTimer(callback, delayMs);
+    this.cancelTimer = (handle) => cancelTimer(handle);
+    this.monotonicNow = () => monotonic();
     this.loader = options.loadImportMap ?? loadImportMap;
   }
 
@@ -876,14 +894,14 @@ export class ImportMapPreloader {
     projectId?: string,
     context?: PreloadImportMapContext,
   ): Promise<ImportMapConfig> {
-    const capacityDeadline = monotonicNow() + this.loadTimeoutMs;
+    const capacityDeadline = this.monotonicNow() + this.loadTimeoutMs;
     for (;;) {
       const capacityChange = this.capacityChange.promise;
       try {
         return await this.preloadOnce(projectDir, adapter, projectId, context);
       } catch (error) {
         if (!this.isCapacityError(error)) throw error;
-        const remainingMs = capacityDeadline - monotonicNow();
+        const remainingMs = capacityDeadline - this.monotonicNow();
         if (remainingMs <= 0) throw error;
         await this.waitForActiveWork(capacityChange, remainingMs);
       }


### PR DESCRIPTION
Fixes the flake that failed the `v0.1.1200-rc.1` release run and cost a coverage shard ten minutes.

## What happened

`coverage shard 4/8` failed on `main` with:

```
'modules/import-map/preloader' has been running for over (2m0s) ... (8m0s)
FAILED (10m0s)
error: RangeError: Import-map preloader load timed out   (preloader.ts:843)
post-test: orphanedLoadsForProject=1 orphanedProjects=1 activeLoads=0
```

Not an assertion failure. The test hung, and after ten minutes the preloader's own load timeout fired and failed it. `prerelease` was skipped as a result, so the RC never published until the run was retried.

## Root cause

`ImportMapPreloader` injects `now` and `loadImportMap`, but not its timers. `loadTimeoutMs` was handed straight to the host `setTimeout`, so a caller supplying a virtual clock still had its deadline measured against wall time.

The capacity-release test sets `loadTimeoutMs: 600_000` and drives everything else on a fake clock that advances one tick per read. The work involved takes milliseconds of virtual time. On a starved CI worker, though, ten minutes of wall time can pass while that work is still in flight, and the real timer fires against a test that was never slow in its own terms.

That is why it never reproduced in isolation. I ran it 18 times under deliberate CPU contention and it passed every time; the trigger is full-shard starvation, not logic.

## Fix

`setTimer` / `cancelTimer` now pair with `now()` and default to the host timers. The defaults are wrapped rather than stored directly, because calling them as `this.setTimer` hands Deno's timers the preloader as their receiver, which they reject with `Illegal invocation`.

On the test side:

- The capacity-release test injects inert timers, so wall-clock starvation can no longer trip it.
- Its awaits go through a bounded `settleWithin` helper, so a genuinely missed capacity signal fails fast with a label rather than hanging. The helper tears its own tick chain down in `finally`; without that, a pending tick outlives the test and trips the runner's timer-leak detector.

## Verification

Confirmed the fix converts the failure mode rather than hiding it. Suppressing the capacity-release hook, which is exactly the regression this test exists to catch:

- **before:** ten-minute hang, then `Import-map preloader load timed out`
- **after:** `first preload did not settle within 200 macrotask turns`, in **560ms**

Restored, the file passes: 47 steps, 0 failed. Wider run across `src/modules` plus `src/utils/import-map.test.ts`: 48 passed, 627 steps, 0 failed. `deno fmt`, `deno lint`, and `deno check src/modules/index.ts` clean.

## Note

`setTimer` is a general seam, so any future test that injects a clock should inject timers with it. Injecting one without the other is what created this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import map preloading reliability by preventing timer-related races and indefinite waits.
  * Improved capacity-limit handling and load-timeout accuracy using consistent deadline tracking.
  * Ensured blocked preload operations settle correctly when capacity becomes available.

* **Enhancements**
  * Added support for customized timer, cancellation, and time-tracking behavior during import map preloading.
  * Improved compatibility with controlled or virtual-clock environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->