### PR TITLE
fix(tool): make remote-mcp test typecheck against the fetch init union

### DIFF
--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -23,7 +23,9 @@ describe("tool/remote-mcp", () => {
       trustedEndpoints: ["http://veryfront-api/mcp"],
       requestFetch: async (_input, init) => {
         transportCalls++;
-        const body = JSON.parse(String(init?.body)) as { id: string };
+        const body = JSON.parse(String(init && "body" in init ? init.body : undefined)) as {
+          id: string;
+        };
         return Response.json({
           jsonrpc: "2.0",
           id: body.id,
@@ -46,7 +48,9 @@ describe("tool/remote-mcp", () => {
       trustedEndpoints: ["http://veryfront-api:80/mcp"],
       requestFetch: async (_input, init) => {
         transportCalls++;
-        const body = JSON.parse(String(init?.body)) as { id: string };
+        const body = JSON.parse(String(init && "body" in init ? init.body : undefined)) as {
+          id: string;
+        };
         return Response.json({
           jsonrpc: "2.0",
           id: body.id,


### PR DESCRIPTION
`ci (lint)` is **red on main**, and every branch cut from it inherits the failure.

## What is broken

`src/tool/remote-mcp.test.ts:26` and `:49`:

```
TS2339: Property 'body' does not exist on type
  'RequestInit | (RequestInit & { client?: HttpClient }) | global.RequestInit'.
```

`requestFetch`'s `init` parameter is a union whose members do not all declare `body`, so `init?.body` does not typecheck. The file is **not** in `scripts/lint/test-typecheck-baseline.json` (51 entries), so the ratchet fails rather than tolerating it.

Introduced by [#3331](https://github.com/veryfront/veryfront-code/pull/3331).

## The fix

Narrow with an `in` check instead of casting:

```ts
JSON.parse(String(init && "body" in init ? init.body : undefined))
```

A cast would have been shorter and wrong — the union is real, and `as RequestInit` would silently hide the next member that lacks the property. The `in` check is the narrowing TypeScript actually supports here.

## Verification

- `deno check --no-lock src/tool/remote-mcp.test.ts` — **0 errors** (was 2).
- The test still passes: **1 passed, 33 steps, 0 failed**. Worth stating separately, since a typecheck fix that quietly changes runtime behaviour would be worse than the red check.
- `deno fmt` clean.

## How I found it

Blocking [#3381](https://github.com/veryfront/veryfront-code/pull/3381). I checked before assuming it was mine: the file is byte-identical to `origin/main`, fails against main's own content, and is untouched by my branch — which is what makes it main's problem rather than that PR's.

Splitting it out so it can land on its own rather than riding an unrelated security fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved request-mock handling to safely process JSON-RPC request bodies during automated testing.
  * Prevented test failures when request initialization data is missing or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->