### PR TITLE
test(import-map): move the last two capacity tests onto the timer seam

### DIFF
--- a/src/modules/import-map/preloader.test.ts
+++ b/src/modules/import-map/preloader.test.ts
@@ -19,9 +19,13 @@ import { MAX_TIMER_DELAY_MS } from "#veryfront/utils/constants/limits.ts";
 import type { ImportMapConfig } from "./types.ts";
 
 /**
- * `loadTimeoutMs` arms a real `setTimeout`, not the injected `now` clock, so
- * tests holding a load unresolved race wall time and flake under CI load. Tests
- * that do exercise timeout behavior keep their own small values.
+ * Budget for loads whose deadline must not fire during the test.
+ *
+ * Deliberately far larger than any test needs. A test that wants a deadline to
+ * fire no longer shortens this value and waits for the host clock to catch up —
+ * it injects `setTimer`/`cancelTimer` from `createInertTimers` and fires the
+ * deadline explicitly. So no assertion here depends on how much wall time the
+ * host took, and reaching this value means the test hung on its own logic.
  */
 const TIMEOUT_NOT_UNDER_TEST_MS = 600_000;
 
@@ -95,7 +99,33 @@ function createInertTimers() {
       pending.clear();
       for (const callback of callbacks) callback();
     },
+    /** Deadlines currently armed, so a test can wait for one to exist. */
+    pendingCount: () => pending.size,
   };
+}
+
+/**
+ * Fire the preloader's next armed deadline, once it is actually armed.
+ *
+ * A deadline the test wants to trigger is armed several async turns after the
+ * call that requests it — a capacity wait, for instance, is only armed after
+ * admission has already failed. Spinning until one appears ties the trigger to
+ * the arming rather than to a guessed turn count, which is what keeps these
+ * tests independent of how fast the host happens to be.
+ */
+async function fireWhenArmed(
+  timers: ReturnType<typeof createInertTimers>,
+  label: string,
+  turns = 200,
+): Promise<void> {
+  for (let turn = 0; turn < turns; turn++) {
+    if (timers.pendingCount() > 0) {
+      timers.fireAll();
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`${label} never armed a deadline within ${turns} macrotask turns`);
 }
 
 /**
@@ -1243,11 +1273,16 @@ describe("modules/import-map/preloader", () => {
     it("keeps timed-out underlying work scoped to its project capacity", async () => {
       const adapter = createMinimalAdapter();
       const loads: Array<ReturnType<typeof createDeferred<ImportMapConfig>>> = [];
+      const timers = createInertTimers();
       const preloader = new ImportMapPreloader({
         maxProjects: 2,
         maxVariantsPerProject: 1,
         ttlMs: 1_000,
-        loadTimeoutMs: 20,
+        loadTimeoutMs: TIMEOUT_NOT_UNDER_TEST_MS,
+        setTimer: timers.setTimer,
+        cancelTimer: timers.cancelTimer,
+        monotonicNow: () => 0,
+        now: () => 1,
         loadImportMap: () => {
           const load = createDeferred<ImportMapConfig>();
           loads.push(load);
@@ -1255,18 +1290,26 @@ describe("modules/import-map/preloader", () => {
         },
       });
 
+      // Both deadlines below are the subject of the test, so they are fired
+      // explicitly. The frozen clocks keep every other load in flight for the
+      // rest of the test no matter how long the host takes to get there.
       const hungA = preloader.preload("/hung-a", adapter, "hung-a");
       await waitForLoadCount(loads, 1);
-      await assertRejects(
+      const hungARejected = assertRejects(
         () => hungA,
         RangeError,
         "load timed out",
       );
-      await assertRejects(
+      await fireWhenArmed(timers, "hung-a load");
+      await hungARejected;
+
+      const capacityBlocked = assertRejects(
         () => preloader.preload("/hung-a", adapter, "hung-a"),
         RangeError,
         "capacity wait timed out",
       );
+      await fireWhenArmed(timers, "hung-a capacity wait");
+      await capacityBlocked;
       assertEquals(loads.length, 1);
 
       const hungB = preloader.preload("/hung-b", adapter, "hung-b");
@@ -1276,17 +1319,24 @@ describe("modules/import-map/preloader", () => {
       assertEquals(loads.length, 2);
 
       loads[1]!.resolve({ imports: { source: "b" } });
-      assertEquals((await hungB).imports?.source, "b");
+      assertEquals((await settleWithin(hungB, "hung-b preload")).imports?.source, "b");
       loads[0]!.resolve({ imports: { source: "late" } });
       await waitForLoadCount(loads, 3);
       loads[2]!.resolve({ imports: { source: "next" } });
-      assertEquals((await nextBlockedByCapacity).imports?.source, "next");
+      assertEquals(
+        (await settleWithin(nextBlockedByCapacity, "next preload")).imports?.source,
+        "next",
+      );
 
       await Promise.resolve();
       const sameProjectRecovered = preloader.preload("/hung-a", adapter, "hung-a");
       await waitForLoadCount(loads, 4);
       loads[3]!.resolve({ imports: { source: "hung-recovered" } });
-      assertEquals((await sameProjectRecovered).imports?.source, "hung-recovered");
+      assertEquals(
+        (await settleWithin(sameProjectRecovered, "hung-a recovery preload")).imports
+          ?.source,
+        "hung-recovered",
+      );
     });
 
     it("reserves project capacity before an invalidated load times out", async () => {
@@ -1329,11 +1379,16 @@ describe("modules/import-map/preloader", () => {
     it("counts timed-out work against the total project bound", async () => {
       const adapter = createMinimalAdapter();
       const loads: Array<ReturnType<typeof createDeferred<ImportMapConfig>>> = [];
+      const timers = createInertTimers();
       const preloader = new ImportMapPreloader({
         maxProjects: 2,
         maxVariantsPerProject: 1,
         ttlMs: 1_000,
-        loadTimeoutMs: 100,
+        loadTimeoutMs: TIMEOUT_NOT_UNDER_TEST_MS,
+        setTimer: timers.setTimer,
+        cancelTimer: timers.cancelTimer,
+        monotonicNow: () => 0,
+        now: () => 1,
         loadImportMap: () => {
           const load = createDeferred<ImportMapConfig>();
           loads.push(load);
@@ -1341,9 +1396,17 @@ describe("modules/import-map/preloader", () => {
         },
       });
 
+      // Only project-a's deadline is under test; it is fired explicitly so the
+      // later loads can stay in flight for as long as the host needs.
       const timedOutA = preloader.preload("/project-a", adapter, "project-a");
       await waitForLoadCount(loads, 1);
-      await assertRejects(() => timedOutA, RangeError, "load timed out");
+      const timedOutARejected = assertRejects(
+        () => timedOutA,
+        RangeError,
+        "load timed out",
+      );
+      await fireWhenArmed(timers, "project-a load");
+      await timedOutARejected;
 
       const activeB = preloader.preload("/project-b", adapter, "project-b");
       await waitForLoadCount(loads, 2);
@@ -1355,8 +1418,14 @@ describe("modules/import-map/preloader", () => {
       await waitForLoadCount(loads, 3);
       loads[1]!.resolve({ imports: { source: "b" } });
       loads[2]!.resolve({ imports: { source: "c" } });
-      assertEquals((await activeB).imports?.source, "b");
-      assertEquals((await queuedC).imports?.source, "c");
+      assertEquals(
+        (await settleWithin(activeB, "project-b preload")).imports?.source,
+        "b",
+      );
+      assertEquals(
+        (await settleWithin(queuedC, "project-c preload")).imports?.source,
+        "c",
+      );
     });
 
     it("does not miss capacity released before a waiter observes its signal", async () => {


### PR DESCRIPTION
## What

#3377 gave the preloader a `setTimer`/`cancelTimer`/`monotonicNow` seam so deadlines follow the injected clock. Two tests never got migrated onto it.

| Line | Was | Loads left racing wall time |
|---|---|---|
| `keeps timed-out underlying work scoped to its project capacity` | `loadTimeoutMs: 20` | `hungB`, `nextBlockedByCapacity` |
| `counts timed-out work against the total project bound` | `loadTimeoutMs: 100` | `activeB`, `queuedC` |

Both armed a real `setTimeout` on loads that were **not** the subject of the assertion, then crossed a `waitForLoadCount` spin (up to 100 `setTimeout(0)` turns) before resolving them. A starved CI worker could trip those deadlines during work that consumed no virtual time — the shape that ejected #3365 from the merge queue.

## Change

Test-only. No production code touched.

- Both preloaders now take `setTimer`/`cancelTimer` from `createInertTimers`, with `monotonicNow` and `now` frozen, so nothing expires on host time.
- `loadTimeoutMs` becomes `TIMEOUT_NOT_UNDER_TEST_MS`; the deadlines that *are* under test are fired explicitly.
- New `fireWhenArmed` helper spins until a deadline actually exists, then fires it. A capacity wait is only armed after admission has already failed, so firing on a guessed turn count would reintroduce the timing dependency this removes.
- `assertRejects` is attached before firing, so a rejection can never land without a handler.
- Remaining awaits use the existing `settleWithin`, so a missed signal fails fast instead of hanging.
- Stale header comment on `TIMEOUT_NOT_UNDER_TEST_MS` updated — it still described the pre-seam world.

After this, no preloader construction in the file uses a short numeric `loadTimeoutMs` without the seam (verified: 0 of 23).

## Proof

Passing tests alone prove nothing here — these already pass on a good day. So a 500ms stall was injected between arming a load and resolving it, in both tests:

| | Result |
|---|---|
| `origin/main` + stall | `0 passed (37 steps) \| 2 failed` — `RangeError: ...capacity is occupied by in-flight loads` |
| this branch + stall | `1 passed (48 steps) \| 0 failed` |

Stalls removed before commit.

Other evidence:
- `src/modules/import-map/` — `6 passed (105 steps) | 0 failed`, 3 consecutive runs
- `deno task typecheck` — exit 0 (full repo)
- `deno lint`, `deno fmt --check` — clean

The two migrated tests also got faster (8ms and 4ms), since they no longer wait out real timers.

Follow-up to #3370 and #3377. Closes the residual noted on veryfront-issue-inbox#364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timeout test reliability by using controlled timers and frozen clocks.
  * Added bounded waiting and settlement safeguards to prevent tests from hanging.
  * Updated deadline-related assertions for more deterministic results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->