### PR TITLE
fix(security): honor the host-execution capability on the remaining request surfaces

### DIFF
--- a/src/server/handlers/preview/markdown-preview.handler.test.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import type { HandlerContext } from "../types.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { MarkdownPreviewHandler } from "./markdown-preview.handler.ts";
@@ -97,6 +97,73 @@ Deno.test("MarkdownPreviewHandler fails closed before shared source reads", asyn
   assertEquals(result.response?.status, 503);
   assertEquals(result.response?.headers.get("content-type"), "application/problem+json");
   assertEquals(reads, 0);
+});
+
+Deno.test("MarkdownPreviewHandler renders shared markdown once the host grants execution", async () => {
+  const originalFetch = globalThis.fetch;
+  let contentReads = 0;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    if (url.includes("/git/trees/")) {
+      return Promise.resolve(Response.json({
+        sha: "tree",
+        tree: [{ path: "README.md", mode: "100644", type: "blob", sha: "readme", size: 7 }],
+        truncated: false,
+      }));
+    }
+    if (url.includes("/contents/README.md")) {
+      contentReads += 1;
+      const content = "# Hello";
+      return Promise.resolve(Response.json({
+        type: "file",
+        name: "README.md",
+        path: "README.md",
+        sha: "readme",
+        size: content.length,
+        content: btoa(content),
+        encoding: "base64",
+        download_url: null,
+      }));
+    }
+    return Promise.resolve(new Response("Not found", { status: 404 }));
+  };
+
+  const github = new GitHubFSAdapter({
+    type: "github",
+    projectDir: "/project",
+    github: { token: "token", owner: "owner", repo: "repo" },
+  });
+  const fs = new FSAdapterWrapper(github);
+  try {
+    const result = await new MarkdownPreviewHandler().handle(
+      new Request("https://tenant.example/README.md"),
+      makeCtx({
+        isLocalProject: false,
+        allowHostProjectCodeExecution: true,
+        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+        prepareHostedConfigContext: (() =>
+          Promise.resolve(
+            undefined,
+          )) as unknown as HandlerContext["prepareHostedConfigContext"],
+        securityConfig: null,
+        adapter: { fs } as unknown as HandlerContext["adapter"],
+      }),
+    );
+
+    assertNotEquals(
+      result.response?.status,
+      503,
+      "a granted shared executor must not return project-execution-unavailable",
+    );
+    assertEquals(
+      contentReads,
+      1,
+      "the request must reach the project source read instead of failing at the guard",
+    );
+  } finally {
+    await fs.shutdown();
+    globalThis.fetch = originalFetch;
+  }
 });
 
 Deno.test("MarkdownPreviewHandler admits and reads through a real wrapped GitHub adapter", async () => {

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -16,7 +16,7 @@ import { extract } from "#std/front-matter/yaml.ts";
 import { tryNotFoundFallback } from "../request/ssr/not-found-fallback.ts";
 import { generateMarkdownHtml } from "./markdown-html-generator.ts";
 import { validateLexicalPath, validatePath, ValidationPresets } from "#veryfront/security";
-import { isSharedProjectRuntime } from "#veryfront/security/project-locality.ts";
+import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import {
   createErrorResponseFromDefinition,
   PROJECT_EXECUTION_UNAVAILABLE,
@@ -48,7 +48,7 @@ export class MarkdownPreviewHandler extends BaseHandler {
       return this.continue();
     }
 
-    if (isSharedProjectRuntime(ctx)) {
+    if (requiresIsolatedProjectRuntime(ctx)) {
       const problem = createErrorResponseFromDefinition(
         PROJECT_EXECUTION_UNAVAILABLE,
         {

--- a/src/server/handlers/request/module/module.handler.test.ts
+++ b/src/server/handlers/request/module/module.handler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { ModuleHandler } from "./module.handler.ts";
 import { handleBatchModuleEndpoint } from "./batch-module-handler.ts";
@@ -272,6 +272,54 @@ describe("server/handlers/request/module/module.handler", () => {
 
       assertEquals(result.response?.status, 503);
       assertEquals(await result.response?.text(), "");
+    });
+
+    it("reaches the host renderer once the host grants execution", async () => {
+      let rendererCalls = 0;
+      const renderer = {
+        renderPage: () =>
+          Promise.resolve({ pageModule: { code: "export default 1;" } }) as ReturnType<
+            Renderer["renderPage"]
+          >,
+      } as unknown as Renderer;
+      setRendererInitializer({
+        initialize: () => {
+          rendererCalls++;
+          return Promise.resolve(renderer);
+        },
+        isInitialized: () => rendererCalls > 0,
+        get: () => renderer,
+        destroy: () => Promise.resolve(),
+      });
+
+      const result = await new ModuleHandler().handle(
+        new Request("https://tenant.example/_veryfront/pages/page.js"),
+        makeCtx({
+          isLocalProject: false,
+          allowHostProjectCodeExecution: true,
+          projectSlug: "tenant",
+          proxyToken: "token",
+          adapter: {
+            fs: {
+              isMultiProjectMode: () => true,
+              runWithContext: <R>(_s: string, _t: string, fn: () => Promise<R>) => fn(),
+              exists: () => Promise.resolve(true),
+              readFile: () => Promise.resolve(""),
+            },
+          } as unknown as HandlerContext["adapter"],
+        }),
+      );
+
+      assertNotEquals(
+        result.response?.status,
+        503,
+        "a granted shared executor must not return project-execution-unavailable",
+      );
+      assertEquals(
+        rendererCalls > 0,
+        true,
+        "the request must reach the host renderer instead of failing at the guard",
+      );
     });
   });
 

--- a/src/server/handlers/request/module/module.handler.ts
+++ b/src/server/handlers/request/module/module.handler.ts
@@ -16,7 +16,7 @@ import {
   createErrorResponseFromDefinition,
   PROJECT_EXECUTION_UNAVAILABLE,
 } from "#veryfront/errors";
-import { isSharedProjectRuntime } from "#veryfront/security/project-locality.ts";
+import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 
 const MODULE_ENDPOINT_PREFIXES = [
   "/_vf_modules/",
@@ -69,11 +69,11 @@ export class ModuleHandler extends BaseHandler {
     }
 
     // These endpoints delegate to the legacy renderer, whose module loader
-    // imports page and layout code in the host process. Remote source must not
-    // reach that path until rendering has a generation-owned prepared module
-    // graph equivalent to isolated API routes.
+    // imports page and layout code in the host process. A shared runtime must
+    // not reach that path unless its host-owned entrypoint granted the
+    // host-execution capability.
     if (
-      isSharedProjectRuntime(ctx) &&
+      requiresIsolatedProjectRuntime(ctx) &&
       HOST_RENDERER_ENDPOINT_PREFIXES.some((prefix) => pathname.startsWith(prefix))
     ) {
       const problem = createErrorResponseFromDefinition(

--- a/src/server/handlers/request/snippet.handler.test.ts
+++ b/src/server/handlers/request/snippet.handler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { validateLexicalPath } from "#veryfront/security";
 import { SnippetHandler } from "./snippet.handler.ts";
@@ -94,7 +94,7 @@ Deno.test("SnippetHandler rejects shared rendering before proxy context or sourc
     projectDir: "/project",
     projectSlug: "project",
     proxyToken: "token",
-    isLocalProject: true,
+    isLocalProject: false,
     adapter: { fs },
   } as unknown as HandlerContext;
 
@@ -106,6 +106,57 @@ Deno.test("SnippetHandler rejects shared rendering before proxy context or sourc
   assertEquals(result.response?.headers.get("content-type"), "application/problem+json");
   assertEquals(contextCalls, 0);
   assertEquals(readPath, undefined);
+});
+
+Deno.test("SnippetHandler renders shared snippets once the host grants execution", async () => {
+  let contextCalls = 0;
+  let readPath: string | undefined;
+  const fs = {
+    symlinkSemantics: "none" as const,
+    isMultiProjectMode: () => true,
+    isContextualMode: () => true,
+    runWithContext: async (
+      _slug: string,
+      _token: string,
+      fn: () => Promise<unknown>,
+    ) => {
+      contextCalls++;
+      return await fn();
+    },
+    exists: () => Promise.resolve(true),
+    stat: () =>
+      Promise.resolve({
+        isFile: true,
+        isDirectory: false,
+        isSymlink: false,
+        size: 0,
+        mtime: new Date(),
+      }),
+    readFile: (path: string) => {
+      readPath = path;
+      return Promise.resolve("");
+    },
+  };
+  const ctx = {
+    projectDir: "/project",
+    projectSlug: "project",
+    proxyToken: "token",
+    isLocalProject: false,
+    allowHostProjectCodeExecution: true,
+    adapter: { fs },
+  } as unknown as HandlerContext;
+
+  const result = await new SnippetHandler().handle(
+    new Request("http://localhost/@components/button"),
+    ctx,
+  );
+  assertNotEquals(
+    result.response?.status,
+    503,
+    "a granted shared executor must not return project-execution-unavailable",
+  );
+  assertEquals(contextCalls, 1);
+  assertEquals(readPath, "/project/components/button.snippet.mdx");
 });
 
 Deno.test("SnippetHandler preserves dedicated local rendering", async () => {

--- a/src/server/handlers/request/snippet.handler.ts
+++ b/src/server/handlers/request/snippet.handler.ts
@@ -12,7 +12,7 @@ import {
   VeryfrontError,
 } from "#veryfront/errors";
 import { validatePath, ValidationPresets } from "#veryfront/security";
-import { isSharedProjectRuntime } from "#veryfront/security/project-locality.ts";
+import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import {
   createHandlerDependencyPinningSource,
   getHandlerDependencyPinningIdentity,
@@ -37,7 +37,7 @@ export class SnippetHandler extends BaseHandler {
       return this.continue();
     }
 
-    if (isSharedProjectRuntime(ctx)) {
+    if (requiresIsolatedProjectRuntime(ctx)) {
       const problem = createErrorResponseFromDefinition(
         PROJECT_EXECUTION_UNAVAILABLE,
         {

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -141,11 +141,61 @@ describe("server/handlers/response/cors", () => {
           prepareHostedConfigContext: (() => {
             throw new Error("shared preflight prepared project config");
           }) as HandlerContext["prepareHostedConfigContext"],
+          securityConfig: { cors: { origin: ["https://app.example"] } } as never,
         }),
       );
 
       assertEquals(result.response instanceof Response, true);
       assertEquals(routeResolutionCalls, 0);
+      assertEquals(
+        result.response?.headers.get("access-control-allow-methods"),
+        "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+      );
+    });
+
+    it("resolves project route methods once the host grants execution", async () => {
+      const dir = await Deno.makeTempDir({ prefix: "vf-cors-granted-" });
+      const routeFile = `${dir}/route.ts`;
+      await Deno.writeTextFile(
+        routeFile,
+        "export function GET() {}\nexport function POST() {}\n",
+      );
+
+      let routeResolutionCalls = 0;
+      const handler = new CorsHandler({
+        resolveAppRouteFile: () => {
+          routeResolutionCalls++;
+          return Promise.resolve({ file: routeFile } as never);
+        },
+      });
+
+      try {
+        const result = await handler.handle(
+          new Request("https://tenant.example/api/private", {
+            method: "OPTIONS",
+            headers: {
+              Origin: "https://app.example",
+              "access-control-request-method": "POST",
+            },
+          }),
+          makeCtx({
+            allowHostProjectCodeExecution: true,
+            prepareHostedConfigContext: (() =>
+              Promise.resolve(
+                undefined,
+              )) as unknown as HandlerContext["prepareHostedConfigContext"],
+            securityConfig: { cors: { origin: ["https://app.example"] } } as never,
+          }),
+        );
+
+        assertEquals(routeResolutionCalls, 1);
+        assertEquals(
+          result.response?.headers.get("access-control-allow-methods"),
+          "HEAD, GET, POST, OPTIONS",
+        );
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
     });
 
     it("does not advertise infrastructure-only request headers", async () => {

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -10,7 +10,7 @@ import { ResponseBuilder } from "#veryfront/security/index.ts";
 import { getConfig } from "#veryfront/config";
 import { PRIORITY_VERY_HIGH } from "#veryfront/utils/constants/index.ts";
 import { resolveAppRouteFile } from "../request/api/app-router-resolver.ts";
-import { isSharedProjectRuntime } from "#veryfront/security/project-locality.ts";
+import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import { isInfrastructureOnlyRequestHeader } from "#veryfront/security/http/application-request.ts";
 
 type AppRouteResolver = typeof resolveAppRouteFile;
@@ -50,13 +50,13 @@ export class CorsHandler extends BaseHandler {
     if (req.method.toUpperCase() !== "OPTIONS") return this.continue();
 
     const pathname = new URL(req.url).pathname;
-    const isSharedRuntime = isSharedProjectRuntime(ctx);
-    const allowMethods = isSharedRuntime
+    const mustDenyProjectExecution = requiresIsolatedProjectRuntime(ctx);
+    const allowMethods = mustDenyProjectExecution
       ? CorsHandler.DEFAULT_METHODS
       : await this.resolveAllowedMethods(pathname, ctx);
 
     let corsConfig = ctx.securityConfig?.cors;
-    if (!isSharedRuntime) {
+    if (!mustDenyProjectExecution) {
       try {
         const cfg = await getConfig(ctx.projectDir, ctx.adapter);
         corsConfig = cfg?.security?.cors ?? corsConfig;


### PR DESCRIPTION
Four request surfaces still gated on the bare topology check `isSharedProjectRuntime(ctx)` instead of the capability predicate `requiresIsolatedProjectRuntime(ctx)`. A shared runtime whose host-owned entrypoint granted `allowHostProjectCodeExecution` was denied anyway.

Live symptom on 0.1.1200-rc.1.10162 — authenticated `GET /README.md` on a preview host:

```
503 project-execution-unavailable
"Shared runtimes require a dedicated isolated project runtime for markdown rendering"
```

It only reproduces authenticated because `MarkdownPreviewHandler.metadata.enabled` requires a preview-mode request; unauthenticated, the proxy returns the sign-in page first.

Deployment already grants the capability (veryfront-server#286 sets `VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION=1`).

## Sites converted

| Site | Behavior before |
|---|---|
| `src/server/handlers/request/module/module.handler.ts:76` | denied 503 — legacy renderer endpoints |
| `src/server/handlers/request/snippet.handler.ts:40` | denied 503 — component snippets |
| `src/server/handlers/preview/markdown-preview.handler.ts:51` | denied 503 — the live symptom |
| `src/server/handlers/response/cors.ts:53` | degraded, not denied |

`requiresIsolatedProjectRuntime` is `!isHostProjectCodeExecutionAllowed(value) && isSharedProjectRuntime(value)`. It strictly widens permission — nothing previously allowed becomes denied. Response bodies, headers, and HEAD handling are untouched.

### On cors.ts

It degrades rather than denies: it returns `DEFAULT_METHODS` instead of resolving the route's real methods, and skips loading the project's own `security.cors` config. Converted it too. A granted shared executor already imports project code on every other surface, so resolving its route methods and reading its CORS config is strictly less privileged than what the process is already permitted. Both degradations are pure loss under a grant — the preflight advertises a wrong method set and silently ignores a project CORS block that may be *more* restrictive than the ctx fallback. Its local is renamed `isSharedRuntime` -> `mustDenyProjectExecution`, per #3365, so the name no longer claims topology.

## Paired tests

#3364 shipped a hardcoded `true` on the multi-project branch of `api-handler-wrapper.ts` that survived review precisely because a fail-closed test cannot distinguish a correct predicate from a literal denial. Only the granted-path test caught it. (That literal is already fixed on main — it was repaired inside #3364 by a later commit on the same branch, and #3365 renamed the local. No live defect remains there.)

Every guard here is now paired. Each granted test pins that the request reaches the work the guard was blocking, not merely that the status changed:

| Surface | Granted-path assertion |
|---|---|
| module | reaches the host renderer (`rendererCalls > 0`) — the exact inverse of the deny test's `rendererCalls === 0` |
| snippet | `contextCalls === 1` and `readPath === "/project/components/button.snippet.mdx"` — mirrors the deny test's `0` / `undefined` |
| markdown-preview | project source is actually read through a real wrapped GitHub adapter (`contentReads === 1`) — inverts the deny test's `reads === 0` |
| cors | `routeResolutionCalls === 1` and `access-control-allow-methods` is the resolved `"HEAD, GET, POST, OPTIONS"`, not the degraded default. Asserting non-503 proves nothing here since this site degrades rather than denies, so the deny half now pins the degraded header value too. |

The snippet guard fixture also had `isLocalProject: true` while asserting a denial — which the capability correctly grants. Changed to `false` so it stays a genuine fail-closed test rather than weakening the guard to keep it passing.

## Verification

Red, with the final test bodies against unconverted `origin/main` source (reverted via `git checkout origin/main -- <files>`, restored after):

```
FAILED | 7 passed (43 steps) | 4 failed (4 steps)

MarkdownPreviewHandler renders shared markdown once the host grants execution
  AssertionError: Expected actual: 503 not to be: 503: a granted shared executor
  must not return project-execution-unavailable
module.handler ... reaches the host renderer once the host grants execution
  AssertionError: Expected actual: 503 not to be: 503: ...
SnippetHandler renders shared snippets once the host grants execution
  AssertionError: Expected actual: 503 not to be: 503: ...
cors ... resolves project route methods once the host grants execution
  AssertionError: Values are not equal.  - 0  / + 1   (routeResolutionCalls)
```

All four fail on behavioural assertions, not module resolution. Every deny half passes both before and after.

Green — full `src/server/handlers/` and `src/security/` suites:

```
ok | 187 passed (2020 steps) | 0 failed (3s)
```

`deno fmt`, `deno lint`, and `deno check` clean on all 8 changed files.

Note: the suites need the repo's `--unstable-worker-options --unstable-net` flags (per the `test` task); without them `src/security/sandbox/deno-sandbox.test.ts` aborts the run on an unstable-API error unrelated to this change.

Refs veryfront-code#366.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shared previews, module requests, and snippets now work correctly when host-granted project execution is enabled, instead of incorrectly returning an unavailable/error response.
  * CORS responses now respect the available runtime mode, returning the expected allowed methods and resolving route settings only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->