### PR TITLE
test: remove the two flakes that dequeued the v0.1.1201 release

### DIFF
--- a/src/config/declarative-evaluator-worker-runner.ts
+++ b/src/config/declarative-evaluator-worker-runner.ts
@@ -744,9 +744,18 @@ async function evaluateWithAdmissionController(
   admissionController: DeclarativeConfigWorkerAdmissionController,
   terminationDrainTimeoutMs = DEFAULT_WORKER_TERMINATION_DRAIN_TIMEOUT_MS,
   startupController: DeclarativeConfigWorkerStartupController = workerStartupController,
+  /**
+   * Monotonic clock used to charge admission wait time against the caller
+   * deadline. Seamed so a test can hold it still: the budget check below
+   * otherwise races real time spent inside `acquire`, and a starved worker can
+   * exhaust a short deadline before the startup permit is ever taken. Both
+   * outcomes report `worker-timeout`, but only one leaves the orphan accounted
+   * for, so a test asserting that accounting cannot depend on wall time.
+   */
+  now: () => number = monotonicNow,
 ): Promise<ConfigSnapshotRecord> {
   const timeoutMs = validateTimeoutMs(options.timeoutMs);
-  const startedAt = monotonicNow();
+  const startedAt = now();
   const release = await admissionController.acquire(
     timeoutMs,
     options.signal,
@@ -756,7 +765,7 @@ async function evaluateWithAdmissionController(
   let operation: WorkerEvaluationOperation;
   try {
     const remainingMs = MathCeil(
-      timeoutMs - (monotonicNow() - startedAt),
+      timeoutMs - (now() - startedAt),
     );
     if (remainingMs < 1) {
       throw createDeclarativeConfigWorkerInfrastructureError(

--- a/src/config/declarative-evaluator-worker.test.ts
+++ b/src/config/declarative-evaluator-worker.test.ts
@@ -647,6 +647,20 @@ Deno.test("declarative config worker bounds active and queued evaluations", asyn
   assertEquals(terminationCount, 2);
 });
 
+/**
+ * A monotonic clock that never advances.
+ *
+ * The runner charges time spent inside `admissionController.acquire` against
+ * the caller deadline, so a short `timeoutMs` can be exhausted before the
+ * startup permit is taken. That path reports `worker-timeout` without ever
+ * counting the orphan, which is indistinguishable by reason from the timeout
+ * these tests do want. Freezing the clock keeps the deadline unspent until the
+ * evaluation itself owns it.
+ */
+function frozenClock(): () => number {
+  return () => 0;
+}
+
 Deno.test("declarative config worker bounds factories that never settle without retaining ordinary admission", async () => {
   const payload = await createPayload("export default { ready: true };");
   const admission = declarativeConfigWorkerRunnerInternals
@@ -667,6 +681,7 @@ Deno.test("declarative config worker bounds factories that never settle without 
       admission,
       5,
       startup,
+      frozenClock(),
     );
   const timeoutError = await assertRejects(
     () => first,
@@ -772,6 +787,7 @@ Deno.test("declarative config worker terminates a late factory result and recove
       admission,
       5,
       startup,
+      frozenClock(),
     );
   const timeoutError = await assertRejects(
     () => first,

--- a/src/modules/import-map/preloader.test.ts
+++ b/src/modules/import-map/preloader.test.ts
@@ -1458,6 +1458,11 @@ describe("modules/import-map/preloader", () => {
       const first = preloader.preload("/project", adapter, "project", {
         contentSourceId: "source-a",
       });
+      // Wait for source-a to reach the loader before starting source-b. The
+      // loader runs in a microtask after an async identity hash, so two
+      // concurrently started preloads can reach it in either order under load,
+      // and this test indexes `loads` positionally.
+      await waitForLoadCount(loads, 1);
       const unrelated = preloader.preload("/project", adapter, "project", {
         contentSourceId: "source-b",
       });


### PR DESCRIPTION
Both flakes that removed `v0.1.1201` from the merge queue, root-caused and fixed. Neither is a product defect; both are tests letting real time decide something the code decides logically.

The release was dequeued twice by `github-merge-queue[bot]`, on different shards each time, while its own CI was 26/26 green. Merge-queue runs test a temporary branch, so each attempt is another roll of the dice.

---

## 1. `preloader.test.ts` — positional assumption over unordered admission

`does not miss capacity released before a waiter observes its signal` starts two preloads concurrently, then addresses them **by position**, resolving `loads[0]` to stand for the `source-a` caller.

The loader is reached through `promiseThen(resolvedPromise(), ...)` after an async identity hash, so which of the two arrives first is not ordered. When `source-b` wins, `loads[0]` is *its* load: the release resolves the wrong caller and `first` waits on a load nothing resolves until after the assertion.

**Two wrong explanations, ruled out with evidence:**

*Not a timing bound.* Every `settleWithin` call settles in `0.0ms` idle. Raising the budget 200 → 20000 turns made it **worse** — 5/14 failures taking 45s each instead of failing fast. The promise genuinely never settles.

*Not a preloader defect.* Instrumented virtual state is identical on passing and failing runs:

```
[diag] released=true loads=3 clockReads=5 clock=9     <- every run, pass and fail alike
```

**Fix:** wait for `source-a` to reach the loader before starting `source-b`. The scenario is unchanged: two variants still occupy the per-project ceiling and the third still queues behind them.

---

## 2. `declarative-evaluator-worker.test.ts` — a 1ms deadline racing orphan accounting

Two tests assert `pending: 1` and got `0`. `evaluateWithAdmissionController` charges time spent inside `admissionController.acquire` against the caller deadline:

```ts
const remainingMs = MathCeil(timeoutMs - (now() - startedAt));
if (remainingMs < 1) throw ...("worker-timeout");
releaseStartup = startupController.acquire();
```

Both tests pass `timeoutMs: 1`. On a loaded shard the acquire consumes that whole millisecond, so the guard fires **before** the startup permit is taken. The reason is `worker-timeout` either way — which is why the reason assertion kept passing — but only the later timeout leaves the orphan counted.

**Fix:** the clock becomes a parameter defaulting to the real monotonic source, and the two tests freeze it, so the deadline is spent by the evaluation that owns it rather than by scheduling noise. Same remedy the preloader took in #3377.

---

## Verification

Reproduced with busy loops saturating the CPU, emulating a loaded shard runner:

| | before | after |
|---|---|---|
| preloader | 1/10, then 9/12 instrumented | **0/16** |
| evaluator | not reproducible by CPU load alone | **0/12** |

The evaluator diagnosis was confirmed by driving the new seam the other way: a clock that advances past the deadline during acquire reproduces the CI failure exactly — both tests, same `pending: 0` against `1`.

`src/config/` suite: 44 passed, 0 failed. `deno fmt` / `deno lint` / `deno check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved preload test reliability by ensuring deferred preloads are started only after the first preload’s loader is reached, keeping access ordering deterministic.
  * Enhanced timeout/admission-related tests with a controllable monotonic clock, isolating evaluation deadlines from admission-acquisition timing.
  * Updated the relevant test seam to accept an optional injected clock to support deterministic, repeatable test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->