### PR TITLE
fix(build): embed the declarative evaluator worker entry in compiled binaries

### DIFF
--- a/scripts/build/compile-binary.ts
+++ b/scripts/build/compile-binary.ts
@@ -11,6 +11,12 @@ export const DEFAULT_INCLUDES = [
   "src/platform/polyfills",
   "src/proxy/main.ts",
   "src/security/sandbox/worker-script.ts",
+  // Spawned through a computed sibling URL in
+  // src/config/declarative-evaluator-worker-runner.ts, which compile cannot
+  // trace. Without this the binary boots and only fails when the declarative
+  // config evaluator first runs, and the unhandled child-worker error takes
+  // the process down instead of failing the single request.
+  "src/config/declarative-evaluator-worker-entry.ts",
   "extensions/ext-auth-jwt/src/index.ts",
   // Explicit extensions remain inert until selected. Default extensions are
   // activated by the normal builtin composition when their source is embedded.

--- a/tests/unit/build/compile-binary-includes.test.ts
+++ b/tests/unit/build/compile-binary-includes.test.ts
@@ -110,4 +110,47 @@ describe("compile-binary includes", () => {
       );
     }
   });
+
+  it("should include every worker entrypoint under src", async () => {
+    // Worker entrypoints are reached through a computed sibling URL, e.g.
+    // `new URL(`./name-worker-entry${extension}`, import.meta.url)`, which
+    // deno compile's module graph cannot follow. A missing entry compiles and
+    // boots fine, then throws "Module not found" the first time the worker is
+    // spawned. The child-worker failure is unhandled, so it takes the whole
+    // process down rather than degrading that one request.
+    //
+    // Regression: src/config/declarative-evaluator-worker-entry.ts was absent,
+    // which crashlooped veryfront-server in production once traffic reached
+    // the declarative config evaluator.
+    const workerEntrypoints: string[] = [];
+    async function collect(dir: string): Promise<void> {
+      for await (const entry of Deno.readDir(dir)) {
+        const path = `${dir}/${entry.name}`;
+        if (entry.isDirectory) {
+          await collect(path);
+          continue;
+        }
+        if (!entry.isFile || entry.name.endsWith(".test.ts")) continue;
+        if (/-worker-entry\.ts$|(?:^|-)worker-script\.ts$/.test(entry.name)) {
+          workerEntrypoints.push(path);
+        }
+      }
+    }
+    await collect("src");
+
+    assertEquals(
+      workerEntrypoints.length > 0,
+      true,
+      "expected to discover at least one worker entrypoint under src",
+    );
+
+    const includeFlags = getIncludeFlags();
+    for (const entrypoint of workerEntrypoints) {
+      assertEquals(
+        includeFlags.some((path) => entrypoint === path || entrypoint.startsWith(`${path}/`)),
+        true,
+        `${entrypoint} must be in compile-binary.ts DEFAULT_INCLUDES; deno compile cannot trace the computed worker URL, so the binary crashes when the worker is spawned`,
+      );
+    }
+  });
 });


### PR DESCRIPTION
Fixes the production crashloop of `veryfront-server` by embedding the declarative evaluator worker entry in compiled binaries.

## What broke

`veryfront-server` `20260805195841-cafa104cc127` went to production and all 4 pods entered CrashLoopBackOff, 502ing a live customer site:

```
error: Uncaught (in worker "") Module not found:
  file:///tmp/deno-compile-veryfront/src/config/declarative-evaluator-worker-entry.ts
error: Uncaught (in promise) Error: Unhandled error in child worker.
```

`workerEntryUrl()` in `src/config/declarative-evaluator-worker-runner.ts` builds the specifier with a template literal:

```ts
const extension = import.meta.url.endsWith(".ts") ? ".ts" : ".js";
return new URL(`./declarative-evaluator-worker-entry${extension}`, import.meta.url);
```

`deno compile`'s module graph cannot follow a computed specifier, so the module was never embedded. The binary boots clean and only fails the first time hosted declarative config evaluation spawns the worker — and because the child-worker failure is unhandled, it takes the whole process down instead of failing that one request.

`DEFAULT_INCLUDES` already carries three other computed-URL workers (`ext-react-ssr/src/worker-renderer.ts`, two kreuzberg extraction workers) with comments saying exactly this. The declarative evaluator was simply never added.

**This is not a regression from the recent proxy work.** `git log -S` shows the include was never present; the worker and its spawn site both arrived in dbe5ab190 (#3245) without it. It stayed dormant until a binary reaching that path met production traffic.

### Why `dist/framework-src` does not already cover it

`dist/framework-src` is in `DEFAULT_INCLUDES`, and it does contain the file — but renamed as a data asset:

```
dist/framework-src/config/declarative-evaluator-worker-entry.ts.src
```

The `.src` suffix exists precisely so `deno compile` does not treat it as a module. It is not loadable at `src/config/declarative-evaluator-worker-entry.ts`, which is what the runner resolves.

## Verification

The unit test alone is **not** proof — it asserts a string is in an array, and the binary that took production down would have passed it. So I compiled both sides and compared the embedded VFS.

| Embedded entry | Control (`origin/main`) | Fixed |
| --- | --- | --- |
| `./declarative-evaluator-worker-entry` (runner's template fragment) | 2 | 2 |
| `declarative-evaluator-worker-entry.ts.src` (framework-src data asset) | 1 | 1 |
| **`declarative-evaluator-worker-entry.ts`** (loadable module at the resolved path) | **0** | **2** |

The bare `.ts` path — the one the runtime resolves and the one production could not find — is present only with the fix. Both binaries are real and distinct (different md5).

A caution for anyone re-running this: body markers like `evaluateRequest` are **not** valid discriminators. They appear in both binaries via the `framework-src` copy (2 in control, 4 in fixed). I initially used one and it did not separate. The module path entry is the discriminator.

Test evidence: the new test fails on `origin/main` and passes with the fix; all 4 tests in the file green.

## What this does not prove

The worker only spawns behind `isHostedMultiProjectFilesystem`, which needs a real `veryfront-api` filesystem, so end-to-end "worker spawns and evaluates a tenant config" is not reproducible locally.

**This artifact must be exercised on staging through the shared runtime against a real project before it goes to production.** Staging is what missed this the first time: the gate never reached this path. A green pipeline is not sufficient evidence for this change.

## Changes

- `scripts/build/compile-binary.ts` — add `src/config/declarative-evaluator-worker-entry.ts` to `DEFAULT_INCLUDES`, with a comment matching the existing computed-URL worker entries.
- `tests/unit/build/compile-binary-includes.test.ts` — guard covering *every* worker entrypoint under `src/`, not just this one. It discovers `*-worker-entry.ts` and `worker-script.ts` and asserts each is included, so the next computed-URL worker cannot repeat this.

## Follow-ups, not in this PR

- `PROXY_INCLUDES` only carries `src/proxy/main.ts`. If the dedicated proxy binary can ever reach the declarative evaluator it has the same latent defect. `veryfront-proxy` is healthy on the same artifact today, so I did not widen an incident fix on speculation — worth confirming separately.
- The unhandled child-worker error killing the process is its own defect. A worker that cannot load should fail the request, not the pod. That fault-isolation gap turned a missing module into an outage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured declarative configuration evaluation works correctly in compiled application binaries.

* **Tests**
  * Added coverage to verify worker entrypoints are included when building compiled binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->