### PR TITLE
fix(styles): skip an overlong CSS candidate instead of failing the page

### DIFF
--- a/src/html/styles-builder/candidate-tokenizer.ts
+++ b/src/html/styles-builder/candidate-tokenizer.ts
@@ -53,9 +53,21 @@ export function extractCandidatesWithByteLength(
         candidate.length > MAX_CSS_SELECTOR_TOKEN_CHARACTERS ||
         hasCandidateContinuation(content, candidatePattern.lastIndex)
       ) {
-        throw new NativeTypeError(
-          `CSS candidate tokens cannot exceed ${MAX_CSS_SELECTOR_TOKEN_CHARACTERS} characters`,
-        );
+        // Skip the over-long run instead of aborting the extraction.
+        //
+        // This used to throw, and the throw reached generateHTMLShellParts, so
+        // one oversized token anywhere in a page took down stylesheet
+        // generation for that whole page -- the page rendered unstyled. A run
+        // longer than the bound is not a plausible class name (a base64 data
+        // URI or a minified blob in prose will do it), so dropping it loses
+        // nothing, while dropping the stylesheet loses the site.
+        //
+        // The bound still holds: no candidate over the limit is emitted, and
+        // advancing past the run keeps the scan moving without re-matching it.
+        while (hasCandidateContinuation(content, candidatePattern.lastIndex)) {
+          candidatePattern.lastIndex += 1;
+        }
+        continue;
       }
       if (apply(setHas, seenCandidates, [candidate])) continue;
       if (candidates.length >= MAX_CSS_SELECTOR_TOKENS) {

--- a/src/html/styles-builder/tailwind-compiler.test.ts
+++ b/src/html/styles-builder/tailwind-compiler.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "./__tests__/css-processor-setup.ts";
-import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { MAX_CSS_SELECTOR_TOKEN_CHARACTERS } from "#veryfront/utils/constants/css.ts";
 import {
@@ -98,16 +98,24 @@ describe("styles-builder/tailwind-compiler", () => {
       assertEquals(candidates.includes("bg-[var(--color)]"), true);
     });
 
-    it("rejects an overlong candidate as one token instead of extracting fragments", () => {
+    it("skips an overlong candidate without extracting fragments", () => {
       const admitted = "a".repeat(MAX_CSS_SELECTOR_TOKEN_CHARACTERS);
       const overlong = `${admitted}a`;
 
       assertEquals(extractCandidates(`class="${admitted}"`).includes(admitted), true);
-      assertThrows(
-        () => extractCandidates(`class="${overlong}"`),
-        TypeError,
-        `cannot exceed ${MAX_CSS_SELECTOR_TOKEN_CHARACTERS} characters`,
-      );
+
+      // This used to throw, and the throw reached generateHTMLShellParts, so a
+      // single oversized token took down stylesheet generation for the whole
+      // page and it rendered unstyled. Reproduced against a real project whose
+      // pages/index.mdx contains one.
+      //
+      // The original guarantee is kept -- no fragment of the run is emitted as
+      // a candidate -- and scanning continues, so real classes after it are
+      // still found. That last part is what makes skipping safe rather than
+      // merely quieter.
+      const candidates = extractCandidates(`class="${overlong}" mt-4`);
+      assertEquals(candidates.some((candidate) => candidate.startsWith("aa")), false);
+      assertEquals(candidates.includes("mt-4"), true);
     });
   });
 


### PR DESCRIPTION
**This is the live cause of codersociety.com returning 500 in production right now.**

```
CSS pre-generation failed: CSS candidate tokens cannot exceed 1024 characters
```

`extractCandidates` threw, the throw reached `generateHTMLShellParts`, and stylesheet generation for the **entire page** died. One oversized token anywhere in a source file takes the whole page down. Reproduced against that project's real source, where `pages/index.mdx` contains one.

## Why skipping is safe

The bound was already enforced by the pattern itself, which caps a match at `MAX_CSS_SELECTOR_TOKEN_CHARACTERS - 1`. The throw fired on the *continuation* check — meaning the run was longer than the bound. A run that long is not a plausible class name (a base64 data URI or a minified blob in prose will do it), so dropping it costs nothing, while dropping the stylesheet costs the site.

The bound still holds: no candidate over the limit is emitted, and no fragment of the run is emitted either — which was the original guarantee.

## The test

It asserted the throw. Rewritten to assert the property that actually mattered — no fragments — **plus** that scanning continues, so a real class after the overlong run is still found. That last part is what makes skipping safe rather than merely quieter.

## Verified

Reproduced end to end against codersociety's real source running this framework: page went **500 → 200**, stylesheet from **not generated → 47 KB / 720 rules**. Full suite `3794 passed, 0 failed`.

## Context

Fourth defect from the same family as #3402 — a loud total failure where a skip belongs. Separate PR because it's an unrelated subsystem and #3402 already carried ten findings.

Note this alone does not fully restore codersociety: that project also needs its Tailwind v3→v4 migration (veryfront/codersociety#2). This fixes the crash; that fixes the theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Oversized CSS candidates are now skipped cleanly instead of causing an error.
  * Scanning continues after oversized content, allowing valid candidates that follow it to be detected.
  * Partial fragments from oversized candidates are no longer emitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->