### PR TITLE
fix(css): stop an optional optimizer and a sourcemap blob failing every render

### DIFF
--- a/src/html/styles-builder/candidate-tokenizer.ts
+++ b/src/html/styles-builder/candidate-tokenizer.ts
@@ -29,6 +29,23 @@ function hasCandidateContinuation(content: string, index: number): boolean {
   return apply(regExpExec, candidateContinuationPattern, [nextCharacter]) !== null;
 }
 
+/**
+ * Advance past the remainder of a run that exceeded the token ceiling.
+ *
+ * The run is discarded whole rather than split: a fragment of it is not a
+ * candidate anybody wrote, and emitting fragments would pollute the snapshot.
+ * Each character is visited once, so skipping stays linear in the source.
+ */
+function skipOverlongCandidateRun(content: string, index: number): number {
+  let cursor = index;
+  while (cursor < content.length) {
+    const character = apply(stringCharAt, content, [cursor]) as string;
+    if (apply(regExpExec, candidateContinuationPattern, [character]) === null) break;
+    cursor++;
+  }
+  return cursor;
+}
+
 export interface ExtractedCSSCandidates {
   readonly candidates: string[];
   readonly sourceBytes: number;
@@ -53,9 +70,15 @@ export function extractCandidatesWithByteLength(
         candidate.length > MAX_CSS_SELECTOR_TOKEN_CHARACTERS ||
         hasCandidateContinuation(content, candidatePattern.lastIndex)
       ) {
-        throw new NativeTypeError(
-          `CSS candidate tokens cannot exceed ${MAX_CSS_SELECTOR_TOKEN_CHARACTERS} characters`,
+        // A run this long is not a class anyone authored -- an inline base64
+        // sourcemap is the common case, and its alphabet lies entirely inside
+        // the candidate body class. Skip it. Failing here would take down the
+        // whole render or release for a token that could never match a rule.
+        candidatePattern.lastIndex = skipOverlongCandidateRun(
+          content,
+          candidatePattern.lastIndex,
         );
+        continue;
       }
       if (apply(setHas, seenCandidates, [candidate])) continue;
       if (candidates.length >= MAX_CSS_SELECTOR_TOKENS) {

--- a/src/html/styles-builder/css-provider-session.test.ts
+++ b/src/html/styles-builder/css-provider-session.test.ts
@@ -6,7 +6,7 @@ import {
   type CSSProcessor,
   CSSProcessorName,
 } from "#veryfront/extensions/css/index.ts";
-import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   acquireCSSGenerationSession,
@@ -182,17 +182,18 @@ describe("styles-builder CSS provider sessions", () => {
     }
   });
 
-  it("fails closed when minification is requested without an optimizer", async () => {
+  it("serves unminified CSS when minification is requested without an optimizer", async () => {
     installProcessor(createProcessor("missing-optimizer"));
-    assertThrows(
-      () => acquireCSSGenerationSession(true),
-      Error,
-      'Missing extension for contract "CSSOptimizationEngine"',
-    );
-    await assertRejects(
-      () => generateTailwindCSS("sheet", ["alpha"], { minify: true }),
-      Error,
-      'Missing extension for contract "CSSOptimizationEngine"',
-    );
+
+    // Minification is an enhancement, not a precondition. No first-party
+    // package registers a CSSOptimizationEngine, while the production shell
+    // always asks for minify:true -- so failing here took down every hosted
+    // render and blocked every release asset build.
+    const session = acquireCSSGenerationSession(true);
+    assertEquals(session.minify, true);
+    assertEquals(session.optimizationEngine, undefined);
+
+    const generated = await generateTailwindCSS("sheet", ["alpha"], { minify: true });
+    assertEquals(generated.css, "missing-optimizer|sheet|alpha");
   });
 });

--- a/src/html/styles-builder/tailwind-compiler.test.ts
+++ b/src/html/styles-builder/tailwind-compiler.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "./__tests__/css-processor-setup.ts";
-import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { MAX_CSS_SELECTOR_TOKEN_CHARACTERS } from "#veryfront/utils/constants/css.ts";
 import {
@@ -98,16 +98,30 @@ describe("styles-builder/tailwind-compiler", () => {
       assertEquals(candidates.includes("bg-[var(--color)]"), true);
     });
 
-    it("rejects an overlong candidate as one token instead of extracting fragments", () => {
+    it("drops an overlong run whole instead of extracting fragments", () => {
       const admitted = "a".repeat(MAX_CSS_SELECTOR_TOKEN_CHARACTERS);
       const overlong = `${admitted}a`;
 
       assertEquals(extractCandidates(`class="${admitted}"`).includes(admitted), true);
-      assertThrows(
-        () => extractCandidates(`class="${overlong}"`),
-        TypeError,
-        `cannot exceed ${MAX_CSS_SELECTOR_TOKEN_CHARACTERS} characters`,
-      );
+
+      const candidates = extractCandidates(`class="mt-4 ${overlong} flex"`);
+      assertEquals(candidates.includes("mt-4"), true);
+      assertEquals(candidates.includes("flex"), true);
+      assertEquals(candidates.includes(overlong), false);
+      assertEquals(candidates.some((candidate) => candidate.startsWith("aa")), false);
+    });
+
+    it("scans past an inline base64 sourcemap instead of failing the file", () => {
+      // esbuild writes these into the build cache. Base64's alphabet sits
+      // entirely inside the candidate body class, so the payload reads as one
+      // unbroken multi-kilobyte token. This threw and took down every render.
+      const payload = "eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXX0".repeat(64);
+      const content =
+        `<div className="mt-4 flex" />\n//# sourceMappingURL=data:application/json;base64,${payload}\n`;
+
+      const candidates = extractCandidates(content);
+      assertEquals(candidates.includes("mt-4"), true);
+      assertEquals(candidates.includes("flex"), true);
     });
   });
 

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -6,7 +6,7 @@
  * an explicit CSSOptimizationEngine owns minification.
  */
 
-import { resolve } from "#veryfront/extensions/contracts.ts";
+import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import {
   captureCSSOptimizationEngine,
   type CSSOptimizationEngine,
@@ -128,9 +128,18 @@ function getCSSPipelineCacheIdentity(
 /** Capture all output-affecting providers before the operation performs an await. */
 export function acquireCSSGenerationSession(minify: boolean): CSSGenerationSession {
   const compilationSession = acquireCSSCompilationSession();
-  const optimizationEngine = minify
-    ? captureCSSOptimizationEngine(resolve<unknown>(CSSOptimizationEngineName))
-    : undefined;
+  // Minification is an optional enhancement, not a precondition for serving
+  // CSS. No first-party package installs a CSSOptimizationEngine by default,
+  // so requiring one here failed every hosted render and every release asset
+  // build for projects that never opted into one. Absent an engine the CSS is
+  // emitted unminified, and the pipeline identity below records it as such.
+  const optimizationProvider = minify ? tryResolve<unknown>(CSSOptimizationEngineName) : undefined;
+  if (minify && optimizationProvider === undefined) {
+    logger.debug("No CSSOptimizationEngine registered; emitting unminified CSS");
+  }
+  const optimizationEngine = optimizationProvider === undefined
+    ? undefined
+    : captureCSSOptimizationEngine(optimizationProvider);
   const session: CSSGenerationSession = {
     minify,
     compilationSession,


### PR DESCRIPTION
Two independent CSS-pipeline defects. Both were latent until v0.1.1203 embedded the declarative evaluator worker (#3399) and this code first executed in production. Together they 500'd a live production site and failed the release asset build for **every** project — including a freshly scaffolded `npm create veryfront@latest`, which could not deploy at all.

This is the next layer under #3402, which fixed the `stylesheet-import-parse-failed` class and revealed these.

## 1. Missing `CSSOptimizationEngine` failed the build — all deploys

`acquireCSSGenerationSession` resolved the contract through `resolve()`, which throws when nothing registered it:

```
Release asset build failed (non-transform error)
  error: Missing extension for contract "CSSOptimizationEngine"
```

No first-party package installs a `CSSOptimizationEngine`. It ships only in `@veryfront/ext-css-lightning`, which is not a dependency of `veryfront`. Meanwhile `html-shell-generator.ts` hardcodes `minify: true` for production. So the fail-closed path was unreachable-by-design for any default project and guaranteed an outage.

It now resolves through `tryResolve()` and emits unminified CSS when no engine is registered. Output stays correct, only larger. The pipeline cache identity already encodes an absent optimizer as `unminified`, so nothing can serve a stale minified entry. `generateTailwindCSS` already branched on an absent engine — this just stops the session throwing before it gets there.

**This reverses the explicit \"fails closed\" contract** added with the optimizer seam, and replaces its test. That stance is right for correctness and security properties. It is wrong for a size optimization, where the fallback is a strictly working page and the alternative is a 500. Flagging it clearly since it was a deliberate prior decision.

## 2. An inline base64 sourcemap failed the candidate scan — live sites

```
Render failed: CSS candidate tokens cannot exceed 1024 characters
  at extractCandidatesWithByteLength (candidate-tokenizer.ts:56)
  at buildCandidateManifest (rendering/orchestrator/css-candidate-manifest.ts:126)
```

esbuild writes `//# sourceMappingURL=data:application/json;base64,...` into the build cache. Base64's alphabet (`A–Z a–z 0–9 + / =`) sits entirely inside the candidate body character class, so the payload reads as one unbroken multi-kilobyte token. A 2.2KB cached module carried a 1064-character payload and took the whole render down.

`.cache` is already in `DEFAULT_IGNORED_ROOTS`, but both scan entry points (`candidate-extractor.ts`, `css-candidate-manifest.ts`) apply that filter only when a `styleProfile` is passed, so these files were scanned regardless.

The ceiling exists to bound work, not to validate input — a 1024-character run can never match a rule. The run is now skipped whole, never split into fragments (which is what the previous test pinned), and each character is visited once so the scan stays linear.

## Verification

Verified against the real artifact, not a synthetic string. The cached module that crashed the renderer:

| | parent commit | this branch |
|---|---|---|
| `extractCandidates(content)` | throws `cannot exceed 1024 characters` | 40 candidates, longest 151 chars, payload absent |

- All 3 new tests fail on the parent commit and pass here.
- `src/html/` + `src/rendering/`: 148 passed, 0 failed (2375 steps).
- `src/html/styles-builder/`: 11 passed, 0 failed (140 steps).
- `deno check` and `deno lint` clean on changed files.

## Not covered here

The conditional `if (options.styleProfile && ...)` filter is left as-is in both scan paths. Fix 2 removes the failure mode regardless of whether the filter runs, but scanning the build cache for utility classes is still wasted work and worth tightening separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Overly long class-name candidates are now skipped safely instead of causing errors.
  * Valid classes can still be extracted when inline Base64 source maps are present.
  * CSS minification no longer fails when no optimization engine is available; readable CSS is returned instead.
  * Registered optimization engines continue to be used when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->