### PR TITLE
fix(esm): give module fetches a retry budget that fits the deadline

### DIFF
--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -17,7 +17,7 @@ import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
 import { replaceSpecifiers } from "./lexer.ts";
 import { createBundleManifest, storeBundleManifest } from "./bundle-manifest.ts";
 import { HTTP_MODULE_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
-import { HTTP_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
+import { HTTP_MODULE_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
 import { httpBundleCache } from "./http-cache-wrapper.ts";
 import { unbrand } from "./http-cache-types.ts";
 import { asLocalModuleCode, VeryfrontError } from "./http-cache-invariants.ts";
@@ -93,7 +93,8 @@ const SLOW_HTTP_FETCH_THRESHOLD_MS = 500;
 const HTTP_MODULE_FETCH_MAX_ATTEMPTS = 3;
 const HTTP_MODULE_FETCH_RETRY_DELAY_MS = 100;
 const HTTP_MODULE_FETCH_WAIT_GRACE_MS = 5_000;
-const HTTP_MODULE_FETCH_MAX_WAIT_MS = HTTP_FETCH_TIMEOUT_MS * HTTP_MODULE_FETCH_MAX_ATTEMPTS +
+const HTTP_MODULE_FETCH_MAX_WAIT_MS =
+  HTTP_MODULE_FETCH_TIMEOUT_MS * HTTP_MODULE_FETCH_MAX_ATTEMPTS +
   HTTP_MODULE_FETCH_RETRY_DELAY_MS *
     ((HTTP_MODULE_FETCH_MAX_ATTEMPTS - 1) * HTTP_MODULE_FETCH_MAX_ATTEMPTS / 2) +
   HTTP_MODULE_FETCH_WAIT_GRACE_MS;
@@ -207,7 +208,7 @@ async function fetchHttpModule(url: string): Promise<HttpModuleFetchResult> {
         ),
       {
         maxAttempts: HTTP_MODULE_FETCH_MAX_ATTEMPTS,
-        timeoutMs: HTTP_FETCH_TIMEOUT_MS,
+        timeoutMs: HTTP_MODULE_FETCH_TIMEOUT_MS,
         shouldRetry: (error) =>
           error instanceof HttpModuleBodyError
             ? false


### PR DESCRIPTION
`npm run dev` dies with `Module loading for / timed out after 10000ms` on projects with a large dependency fan-out. Root cause is arithmetic, not networking.

## The defect

`src/transforms/esm/http-cache.ts` imported **`HTTP_FETCH_TIMEOUT_MS` (30 000)** — the general-purpose timeout used by OAuth providers — instead of **`HTTP_MODULE_FETCH_TIMEOUT_MS` (2 500)**, which exists for exactly this purpose and is what the sibling module loader already uses (`esbuild-plugin.ts:165`).

```
30_000 × 3 attempts + delays + 5_000 grace  ≈  95_300 ms   ← fetch budget
                                  10_000 ms                 ← module-loader idle deadline
```

A single failing fetch could not finish even its **first** attempt before the deadline fired. **The retry policy could never execute at all.**

## What a real failure looked like

37 concurrent module fetches, every one logging `attempt=1`, **no `attempt=2` anywhere**, then the page dies at 10 s. esm.sh was healthy throughout — the exact URLs being retried return 200 in ~0.25 s:

```
200  0.297s  framer-motion@11.11.1/X-ZXJlYWN0.../hex.mjs
200  0.249s  @emotion/memoize@0.9.0/X-ZXJlYWN0/es2022/memoize.mjs
```

So any transient hiccup on one module of a large fan-out became a hard page failure with no possible recovery. It reproduces on a freshly scaffolded project.

## The fix

One constant. At 2 500 ms the three attempts complete in **7 800 ms**, inside the deadline, so a retry can actually land.

## What this does not fix

The coupling is still unsafe, only correct today. The fetch budget and the deadline live in different files with **no relationship** — either can be changed without the other, and this reappears silently. Deriving the budget from the caller's remaining time is the real fix and deserves its own PR.

Also worth doing: log the failure reason. 37 `HttpModuleRequestError` lines carrying no status, no message, and a claimed "retrying" that provably never retried is what made this take several passes to locate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP module fetch timeout handling to ensure maximum wait and retry behavior use the appropriate timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->