### PR TITLE
test(release-assets): pin that a scaffolded project deploys without a CSS optimizer

### DIFF
--- a/src/html/styles-builder/__tests__/css-processor-setup.ts
+++ b/src/html/styles-builder/__tests__/css-processor-setup.ts
@@ -1,9 +1,23 @@
 /**
  * Shared test helper: activates the `@veryfront/ext-css-tailwind` extension so
  * core tests that exercise the Tailwind compile path can resolve the
- * `CSSProcessor` contract. Minified test paths also receive an explicit,
- * identity-bearing no-op CSSOptimizationEngine; neither provider is discovered
- * or auto-registered by production core.
+ * `CSSProcessor` contract. That extension is `builtin-deferred` in
+ * `first-party-defaults.ts`, so composing it here mirrors what a real install
+ * has.
+ *
+ * This helper deliberately registers NOTHING ELSE. It used to also register a
+ * no-op `CSSOptimizationEngine` whenever none was present, which quietly gave
+ * every importing suite a capability that no shipped install has:
+ * `ext-css-lightning` is `selection: "explicit", rootNpm: false`. The result
+ * was that `css-compile.test.ts` and `build-executor.test.ts` stayed green
+ * across 100+ steps while every single deploy failed with
+ * `Missing extension for contract "CSSOptimizationEngine"`.
+ *
+ * The rule this encodes: a fixture must compose the extension set the product
+ * actually ships. Over-composing turns a suite into a test of a configuration
+ * no user has. A test that needs an optimiser must install one explicitly with
+ * `installTestCSSOptimizationEngine` / `withTestCSSOptimizationEngine`, so the
+ * dependency is visible at the call site.
  *
  * Import this module (for side effects) from any test that exercises the
  * Tailwind compile path via `getCompiler` / `generateTailwindCSS` /
@@ -17,12 +31,7 @@
  * @module html/styles-builder/__tests__/css-processor-setup
  */
 
-import {
-  register as registerContract,
-  tryResolve as tryResolveContract,
-} from "#veryfront/extensions/contracts.ts";
-import { CSSOptimizationEngineName } from "#veryfront/extensions/css/index.ts";
-import { createTestCSSOptimizationEngine } from "../../../../tests/_helpers/css-optimization-engine.ts";
+import { register as registerContract } from "#veryfront/extensions/contracts.ts";
 import extTailwindFactory from "../../../../extensions/ext-css-tailwind/src/index.ts";
 
 const noopLogger = {
@@ -44,9 +53,6 @@ export async function registerTailwindExtension(): Promise<void> {
     },
   };
   await ext.setup?.(ctx as never);
-  if (tryResolveContract(CSSOptimizationEngineName) === undefined) {
-    registerContract(CSSOptimizationEngineName, createTestCSSOptimizationEngine());
-  }
 }
 
 await registerTailwindExtension();

--- a/src/release-assets/css-compile.ts
+++ b/src/release-assets/css-compile.ts
@@ -16,9 +16,19 @@
  *   it resolves the explicitly composed `CSSProcessor` extension and calls
  *   `compiler.build(candidates)` with no cross-request/distributed state.
  * - Work is bounded: one compile over the candidate set the executor already
- *   gathered, output minified, no background tasks.
+ *   gathered, no background tasks.
  * - Configuration and compile failures propagate; a release must not publish
  *   a silent CSS gap.
+ *
+ * Minification is requested, not required. `CSSOptimizationEngine` ships only
+ * in `@veryfront/ext-css-lightning`, which `first-party-defaults.ts` marks
+ * `selection: "explicit"` — a scaffolded project has no optimiser, so a
+ * release that asks for minification and gets none is the normal case, not an
+ * outage. `acquireCSSGenerationSession` degrades to unminified output and
+ * records that in `cacheIdentity`, which travels into the manifest as
+ * `cssPipelineIdentity`; nothing downstream assumes minified bytes, and no
+ * cache can serve a stale minified entry in its place. A *missing optional
+ * capability* is a skip; a *failing* one still fails the release.
  *
  * @module release-assets/css-compile
  */

--- a/src/release-assets/scaffolded-project-build.test.ts
+++ b/src/release-assets/scaffolded-project-build.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Regression: a freshly scaffolded project must complete a release asset build
+ * with the extension set it actually ships with.
+ *
+ * `npm create veryfront@latest` scaffolds a project that composes no
+ * `CSSOptimizationEngine` — that contract lives only in
+ * `@veryfront/ext-css-lightning`, which `first-party-defaults.ts` marks
+ * `selection: "explicit"`. CSS *optimisation* is optional; CSS *generation*
+ * (`ext-css-tailwind`) and bundling (`ext-bundler-esbuild`) are builtin. A
+ * release that ships unminified CSS is valid: the asset is content-hashed and
+ * its `cssPipelineIdentity` records `unminified`, so no cache can serve a
+ * stale minified entry in its place.
+ *
+ * This suite therefore composes only builtins a real install has, and asserts
+ * before every build that no `CSSOptimizationEngine` is registered — so it
+ * cannot quietly start testing a configuration no user runs. That is exactly
+ * how the bug escaped: `css-processor-setup.ts` used to register a stub
+ * optimiser for every importing suite, so `css-compile.test.ts` and
+ * `build-executor.test.ts` stayed green across 100+ steps while every deploy
+ * failed with:
+ *
+ *   Missing extension for contract "CSSOptimizationEngine"
+ *
+ * Verified by mutation: re-arming the strict `resolve()` in
+ * `acquireCSSGenerationSession` fails all seven scaffolds here and leaves
+ * those two suites green.
+ *
+ * @module release-assets/scaffolded-project-build.test
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import "../transforms/plugins/__tests__/code-parser-setup.ts";
+
+import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { afterAll, afterEach, beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  register as registerContract,
+  tryResolve as tryResolveContract,
+  unregister as unregisterContract,
+} from "#veryfront/extensions/contracts.ts";
+import { CSSOptimizationEngineName } from "#veryfront/extensions/css/index.ts";
+import { FIRST_PARTY_EXTENSION_POLICIES } from "#veryfront/extensions/first-party-defaults.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { VeryfrontConfig } from "#veryfront/config";
+import { readTextFile } from "#veryfront/testing/deno-compat.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import { transformToESM } from "#veryfront/transforms/pipeline/index.ts";
+import type { ExtensionFactory } from "#veryfront/extensions/types.ts";
+import extTailwindFactory from "../../extensions/ext-css-tailwind/src/index.ts";
+import extContentMdxFactory from "../../extensions/ext-content-mdx/src/index.ts";
+import { getTemplate } from "../../cli/templates/index.ts";
+import { STARTER_TEMPLATE_NAMES } from "../../cli/templates/types.ts";
+import { createCompileProjectCss } from "./css-compile.ts";
+import { type ReleaseAssetBuildClient, runReleaseAssetBuild } from "./build-executor.ts";
+import { parseReleaseAssetManifest } from "./manifest-schema.ts";
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+/**
+ * Builtin-deferred providers the standard npm distribution ships, so a
+ * scaffolded project has them without composing anything. Both are
+ * `selection: "builtin-deferred", rootNpm: true` in `first-party-defaults.ts`;
+ * the guard test below pins that, so this list cannot drift into fiction.
+ */
+const BUILTIN_SCAFFOLD_EXTENSIONS: ReadonlyArray<[string, ExtensionFactory]> = [
+  ["ext-css-tailwind", extTailwindFactory as ExtensionFactory],
+  ["ext-content-mdx", extContentMdxFactory as ExtensionFactory],
+];
+
+/**
+ * Compose exactly what a default `npm create veryfront` project composes:
+ * the builtin providers above, and no optimiser.
+ */
+async function composeProductionExtensions(): Promise<void> {
+  for (const [, factory] of BUILTIN_SCAFFOLD_EXTENSIONS) {
+    const ext = factory();
+    await ext.setup?.(
+      {
+        config: {},
+        logger: noopLogger,
+        provide: (name: string, impl: unknown) => registerContract(name, impl),
+        get: () => undefined,
+        resolve: () => {
+          throw new Error("resolve not used in setup");
+        },
+      } as never,
+    );
+  }
+  // Defeat any optimiser a previously-loaded module registered globally.
+  unregisterContract(CSSOptimizationEngineName);
+}
+
+/** Reads the files the executor materialized into its own temp dir. */
+const fsAdapter = {
+  fs: { readFile: (path: string): Promise<string> => readTextFile(path) },
+} as unknown as RuntimeAdapter;
+
+interface Recorded {
+  uploads: Array<{ hash: string; contentType: string; bytes: Uint8Array }>;
+  manifest: unknown;
+  states: Array<{ state: string; error?: string }>;
+}
+
+function makeClient(
+  files: Array<{ path: string; content: string }>,
+  rec: Recorded,
+  projectScope: string,
+): ReleaseAssetBuildClient {
+  return {
+    beginReleaseAssetManifestBuild: () =>
+      Promise.resolve({ id: "b1", manifest_version: 1, state: "building" }),
+    listAllReleaseFiles: () => Promise.resolve(files),
+    uploadReleaseAsset: (_v, hash, contentType, bytes) => {
+      rec.uploads.push({ hash, contentType, bytes });
+      return Promise.resolve({ stored: true, existed: false });
+    },
+    putReleaseAssetManifest: (_v, manifest) => {
+      rec.manifest = manifest;
+      return Promise.resolve({ state: "ready", manifest_version: 1 });
+    },
+    reportReleaseAssetManifestState: (_v, state, error) => {
+      rec.states.push({ state, error });
+      return Promise.resolve(undefined);
+    },
+    // The real production compiler, not a stub. This is the seam that failed.
+    compileProjectCss: createCompileProjectCss({ projectScope }),
+  };
+}
+
+describe("release assets: scaffolded project build", () => {
+  const tempDirs: string[] = [];
+
+  beforeAll(async () => {
+    await composeProductionExtensions();
+  });
+
+  afterEach(async () => {
+    for (const dir of tempDirs.splice(0)) {
+      await Deno.remove(dir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
+  async function tmp(): Promise<string> {
+    const dir = await Deno.makeTempDir({ prefix: "vf-scaffold-release-" });
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it("keeps CSS optimisation an opt-in extension, so the default project has none", () => {
+    // Guard: if ext-css-lightning ever becomes builtin, the suite below stops
+    // reproducing the shipped configuration and must be revisited rather than
+    // silently passing for the wrong reason.
+    const lightning = FIRST_PARTY_EXTENSION_POLICIES.find(
+      (policy) => policy.name === "ext-css-lightning",
+    );
+    assertExists(lightning);
+    assertEquals(lightning.selection, "explicit");
+    assertEquals(lightning.rootNpm, false);
+
+    // The converse: everything this suite composes really is a builtin a
+    // scaffolded project gets for free. If one of these ever becomes
+    // "explicit", composing it here would fake a capability production lacks.
+    for (const [name] of BUILTIN_SCAFFOLD_EXTENSIONS) {
+      const policy = FIRST_PARTY_EXTENSION_POLICIES.find((entry) => entry.name === name);
+      assertExists(policy, `${name} is not a known first-party extension`);
+      assertEquals(policy.selection, "builtin-deferred", `${name} must be builtin`);
+      assertEquals(policy.rootNpm, true, `${name} must ship in the root npm package`);
+    }
+
+    assertEquals(
+      tryResolveContract(CSSOptimizationEngineName),
+      undefined,
+      "a scaffolded project composes no CSSOptimizationEngine",
+    );
+  });
+
+  for (const templateName of STARTER_TEMPLATE_NAMES) {
+    it(`builds release assets for the ${templateName} scaffold without an optimiser`, async () => {
+      assertEquals(
+        tryResolveContract(CSSOptimizationEngineName),
+        undefined,
+        "test must run with no CSSOptimizationEngine composed",
+      );
+
+      const files = await getTemplate(templateName);
+      assertExists(files, `template ${templateName} was not found`);
+      const sources = files.filter((file) => !file.path.endsWith(".svg"));
+
+      const rec: Recorded = { uploads: [], manifest: null, states: [] };
+      const result = await runReleaseAssetBuild({
+        projectReference: `scaffold-${templateName}`,
+        projectId: "proj-uuid",
+        releaseId: "rel-uuid",
+        releaseVersion: 1,
+        releaseVersionRef: "rel-uuid",
+        adapter: fsAdapter,
+        dependencyMode: "source",
+        loadConfig: () => Promise.resolve({} as VeryfrontConfig),
+        client: makeClient(sources, rec, `scaffold-${templateName}`),
+        // The real browser transform the hosted runtime injects. A passthrough
+        // stub would leave TSX unparseable and turn every module into an
+        // import-parse gap, which is precisely the kind of unrealistic fixture
+        // that let this bug reach production.
+        transform: (source, sourceFile, projectDir, adapter, options) =>
+          transformToESM(source, sourceFile, projectDir, adapter, {
+            projectId: options.projectId,
+            dev: options.dev,
+            ssr: options.ssr,
+            reactVersion: options.reactVersion,
+          }),
+      }, await tmp());
+
+      assertEquals(
+        result.error,
+        undefined,
+        `${templateName} release asset build reported: ${result.error}`,
+      );
+      assertEquals(result.success, true);
+      assertEquals(result.state, "ready");
+      assertEquals(rec.states.map(({ state }) => state), []);
+
+      const manifest = parseReleaseAssetManifest(rec.manifest);
+      assertExists(manifest);
+      assertEquals(
+        manifest.css.length,
+        1,
+        `${templateName} must publish exactly one CSS asset`,
+      );
+
+      // The published CSS must be real compiled output for this scaffold's own
+      // markup, not an empty or placeholder stylesheet. Every starter template
+      // styles its shell with Tailwind utilities, so a utility rule must
+      // survive to the uploaded asset.
+      const cssUpload = rec.uploads.find((upload) => upload.contentType === "text/css");
+      assertExists(cssUpload, "expected a text/css asset upload");
+      const css = new TextDecoder().decode(cssUpload.bytes);
+      assert(css.length > 0, "published CSS must not be empty");
+      assert(
+        /\.(min-h-screen|mx-auto|flex|font-bold)\b/.test(css),
+        `expected a compiled Tailwind utility in ${templateName} CSS`,
+      );
+      assertEquals(
+        manifest.css[0]?.size,
+        cssUpload.bytes.byteLength,
+        "manifest CSS size must match the uploaded asset",
+      );
+    });
+  }
+});


### PR DESCRIPTION
## The report

Deploys failed for every project, including a fresh `npm create veryfront@latest` scaffold:

```
✗ [deployment-error] Release asset build failed for release <uuid>
  error: 'Missing extension for contract "CSSOptimizationEngine".
          Install it with: deno add @veryfront/ext-css-lightning'
```

## Is CSS optimisation required for a valid release?

**Optional.** Decided from the code before writing anything:

- `getCSSPipelineCacheIdentity` has a first-class `"unminified"` branch — unminified output is a *named state*, not an error path.
- Nothing in `src/release-assets/` assumes minified bytes. The only `minify` references in the whole module were css-compile's own request and one stale doc comment. Assets are content-hashed and the manifest carries `cssPipelineIdentity`, so an unminified asset can never be served from a minified cache entry.
- No starter template declares `ext-css-lightning`.

So the release-asset build must degrade, and `ext-css-lightning` must **not** become builtin — Lightning CSS is a native binary and #3215 was deliberately trimming embedded weight.

## The runtime half is already fixed

#3403 (`d60537f49`, merged shortly before this was reported) moved `acquireCSSGenerationSession` from `resolve()` to `tryResolve()`. The release-asset path inherits that through the same seam. Verified in both directions rather than assumed:

- The compile at `css-compile.ts:146` throws that **exact** error with that exact stack on `8f2d54bdd`.
- On `d60537f49` it succeeds, logging `No CSSOptimizationEngine registered; emitting unminified CSS`.

## What was *not* fixed: why it shipped at all

Two fixtures made the failure invisible:

1. `css-processor-setup.ts` registered a **stub `CSSOptimizationEngine`** whenever none was present — handing all 15 importing suites a capability no shipped install has (`ext-css-lightning` is `selection: "explicit", rootNpm: false`).
2. `build-executor.test.ts` stubs `compileProjectCss` outright, so the executor tests never ran the real compiler.

Between them, nothing tested the configuration users actually run. Demonstrated, not asserted: **with the bug fully re-armed, `css-compile.test.ts` + `build-executor.test.ts` pass 104 steps green** while the new suite fails all seven scaffolds.

## Changes

- **`scaffolded-project-build.test.ts`** (new) — drives all 7 starter scaffolds through the real `runReleaseAssetBuild`, real `createCompileProjectCss`, real `transformToESM`, with no optimizer composed. Asserts compiled Tailwind utilities survive into the uploaded asset and that manifest size matches uploaded bytes.
- **`css-processor-setup.ts`** — composes only the builtin `CSSProcessor`. Suites wanting an optimizer install one explicitly, visibly, at the call site.
- **`css-compile.ts`** — documents the rule this subsystem keeps relearning: *a missing optional capability is a skip; a failing one still fails the release.* Its claim that output is minified was no longer true.

### Guarding against vacuous coverage

The suite asserts `tryResolve(CSSOptimizationEngineName) === undefined` before every build, and pins **both sides** of the policy table — lightning must stay `explicit`, and everything the suite *does* compose must be `builtin-deferred` + `rootNpm`. It cannot drift into testing a configuration nobody ships.

Two fixture defects surfaced while writing it, both exactly the kind that caused the original blind spot: a passthrough transform left every `.tsx` unparseable, and composing only Tailwind left `minimal`'s `.mdx` page without a `ContentProcessor`. Both fixed by using real production wiring.

## Verification

| Check | Result |
|---|---|
| Mutation: new test vs pre-#3403 | 7/7 fail, exact production error |
| Mutation: strict `resolve()` re-armed on main | 7/7 fail |
| Same mutation vs existing suites | **104 steps green** — vacuity proven |
| Affected suites (57) | 723 steps, 0 failed |
| Full `test:unit` (twice, incl. pre-push gate) | **3795 passed, 27805 steps, 0 failed** |
| fmt / lint / `deno check` | clean |

No runtime behaviour change, so no version bump.

## The pattern

Fifth instance. Origin confirmed: **#3215 was 158 files / +12,074 lines**, and has now needed four remediations (#3303, #3402, #3403, this).

I swept every opt-in contract for a strict `resolve()`:

- `CSSPurgingEngine`, `ImageOptimizationEngine`, `CSSOptimizationEngine` in `src/build/asset-pipeline/**` — still fail-closed, but that subsystem is **unreachable from production**; nothing outside its own tests imports it. Latent, not live.
- `RedisRuntimeProvider` — fails closed *correctly* (only reached when the user configured Redis).

**No live instance remains on the default-project path.** Left the asset-pipeline three alone rather than widen scope — but it is dead code carrying three more instances of a pattern that has caused five outages, and deserves its own decision: delete or fix.

Related: veryfront-issue-inbox #383, #382.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release builds now continue successfully when CSS minification is unavailable, producing valid unminified output instead.
  * Genuine CSS optimization failures still correctly prevent a release.

* **Tests**
  * Added comprehensive coverage for release-asset builds across all starter project templates.
  * Verified generated manifests, uploaded stylesheets, compiled Tailwind output, asset sizes, and successful build readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->