### PR TITLE
fix(css): stop a failed preview stylesheet from looking like an empty one

### DIFF
--- a/src/server/handlers/dev/styles-css-error-response.test.ts
+++ b/src/server/handlers/dev/styles-css-error-response.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Regression: a stylesheet that failed to build must never look like a
+ * stylesheet that succeeded.
+ *
+ * `/_vf_styles/styles.css` serves the preview and dev shell (production goes
+ * through the release manifest or `/_vf/css/<hash>.css`). Both of its error
+ * paths answer 200 `text/css`, which is the only way the browser will render
+ * the diagnostic — but the outer catch used to answer with a bare comment:
+ * zero rules, no visible signal, indistinguishable from a project that simply
+ * has no styles. The page rendered completely unstyled and nothing in the
+ * browser said why.
+ *
+ * @module server/handlers/dev/styles-css-error-response.test
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import "../../../html/styles-builder/__tests__/css-processor-setup.ts";
+
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { HandlerContext } from "../types.ts";
+import {
+  clearCSSCache,
+  invalidateCompiler,
+  invalidateProjectCSS,
+} from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { invalidatePreparedProjectCSS } from "#veryfront/html/styles-builder/prepared-project-css-cache.ts";
+import { invalidateProjectCandidateManifests } from "#veryfront/rendering/orchestrator/css-candidate-manifest.ts";
+import { StylesCSSHandler } from "./styles-css.handler.ts";
+
+const SLUG = "styles-css-error-project";
+const PAGE = {
+  path: "/project/pages/index.tsx",
+  content: '<div className="text-cyan-500 brand-header">Hi</div>',
+};
+
+function reset(): void {
+  clearCSSCache();
+  invalidateCompiler();
+  invalidateProjectCSS(SLUG);
+  invalidatePreparedProjectCSS(SLUG);
+  invalidateProjectCandidateManifests(SLUG);
+}
+
+function makeAdapter(
+  stylesheet: string,
+  sourceFiles: () => Promise<Array<{ path: string; content?: string }>>,
+): RuntimeAdapter {
+  const base = createMockAdapter();
+  base.fs.files.set("/project/globals.css", stylesheet);
+  const underlying = {
+    getAllSourceFiles: sourceFiles,
+    getContentContext: () => null,
+  };
+  return {
+    ...base,
+    fs: { ...base.fs, getUnderlyingAdapter: () => underlying },
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(adapter: RuntimeAdapter): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter,
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: SLUG,
+    config: { tailwind: { stylesheet: "globals.css" } },
+  } as unknown as HandlerContext;
+}
+
+async function serve(adapter: RuntimeAdapter): Promise<Response> {
+  reset();
+  try {
+    const result = await new StylesCSSHandler().handle(
+      new Request("http://localhost/_vf_styles/styles.css"),
+      makeCtx(adapter),
+    );
+    assert(result.response, "handler must answer the styles route");
+    return result.response;
+  } finally {
+    reset();
+  }
+}
+
+/** CSS text with every comment removed — what the browser would actually apply. */
+function activeRules(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "").trim();
+}
+
+/**
+ * Applicable CSS with quoted strings blanked out. Diagnostic text is echoed
+ * inside a `content:` string where it is inert, so only what survives *outside*
+ * a string literal can actually take effect.
+ */
+function effectiveCSS(css: string): string {
+  return activeRules(css).replace(/"(?:\\.|[^"\\])*"/g, '""');
+}
+
+describe("server/handlers/dev/styles-css error responses", () => {
+  it("shows a visible diagnostic when the stylesheet cannot be built at all", async () => {
+    // Source listing failure: reaches the handler's outermost catch, the path
+    // that previously answered with a bare `/* StylesCSSHandler error: ... */`.
+    const response = await serve(
+      makeAdapter(
+        '@import "tailwindcss";',
+        () => Promise.reject(new Error("source listing exploded")),
+      ),
+    );
+    const css = await response.text();
+
+    assertEquals(response.status, 200);
+    // The failure must reach the page, not just the comment block.
+    assert(
+      activeRules(css).length > 0,
+      "a failed stylesheet must not be served as zero applicable rules",
+    );
+    assertStringIncludes(css, "body::before");
+    assertStringIncludes(css, "CSS Error:");
+    assertStringIncludes(css, "source listing exploded");
+  });
+
+  it("shows a visible diagnostic when a stylesheet uses a non-allowlisted plugin", async () => {
+    const response = await serve(
+      makeAdapter(
+        '@import "tailwindcss";\n@plugin "some-random-plugin";\n.brand-header { color: red; }',
+        () => Promise.resolve([PAGE]),
+      ),
+    );
+    const css = await response.text();
+
+    assertEquals(response.status, 200);
+    assertStringIncludes(css, "body::before");
+    assertStringIncludes(css, "some-random-plugin");
+  });
+
+  it("keeps a hostile plugin name from escaping the comment or the CSS string", async () => {
+    // The plugin name is project-controlled and reaches the diagnostic text
+    // verbatim, so it must not be able to close the banner comment and have
+    // the remainder parsed as rules.
+    const hostile = 'x*/body{display:none}/*"';
+    const response = await serve(
+      makeAdapter(
+        `@import "tailwindcss";\n@plugin "${hostile}";`,
+        () => Promise.resolve([PAGE]),
+      ),
+    );
+    const css = await response.text();
+
+    assertEquals(response.status, 200);
+    // The name is echoed back, so the diagnostic is still useful...
+    assertStringIncludes(css, "display:none");
+    // ...but only ever inside a comment or a quoted string, never as a rule.
+    assertEquals(
+      effectiveCSS(css).includes("display:none"),
+      false,
+      "hostile plugin name must not survive as an applicable rule",
+    );
+    // The banner comment must not be closed early by the injected sequence:
+    // what remains after the comment is exactly one declaration block.
+    assertEquals(activeRules(css).startsWith("body::before"), true);
+    assertEquals((effectiveCSS(css).match(/\{/g) ?? []).length, 1, "exactly one rule block");
+  });
+});

--- a/src/server/handlers/dev/styles-css-error-response.test.ts
+++ b/src/server/handlers/dev/styles-css-error-response.test.ts
@@ -28,7 +28,7 @@ import {
 } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import { invalidatePreparedProjectCSS } from "#veryfront/html/styles-builder/prepared-project-css-cache.ts";
 import { invalidateProjectCandidateManifests } from "#veryfront/rendering/orchestrator/css-candidate-manifest.ts";
-import { StylesCSSHandler } from "./styles-css.handler.ts";
+import { renderCSSDiagnostic, StylesCSSHandler } from "./styles-css.handler.ts";
 
 const SLUG = "styles-css-error-project";
 const PAGE = {
@@ -85,18 +85,69 @@ async function serve(adapter: RuntimeAdapter): Promise<Response> {
   }
 }
 
-/** CSS text with every comment removed — what the browser would actually apply. */
+/**
+ * Scan CSS once, dropping comments and (optionally) blanking string literals.
+ *
+ * A regex cannot do this: the diagnostic deliberately echoes project-controlled
+ * text into a `content:` string, so a payload containing comment delimiters
+ * would make a naive stripper eat real rules and hide a regression.
+ */
+function scanCSS(css: string, blankStrings: boolean): string {
+  let out = "";
+  let index = 0;
+  let quote: string | null = null;
+
+  while (index < css.length) {
+    const char = css[index]!;
+
+    if (quote !== null) {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+        out += blankStrings ? '""' : char;
+        index++;
+        continue;
+      }
+      if (!blankStrings) out += char;
+      index++;
+      continue;
+    }
+
+    if (char === "/" && css[index + 1] === "*") {
+      const end = css.indexOf("*/", index + 2);
+      index = end === -1 ? css.length : end + 2;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      out += blankStrings ? "" : char;
+      index++;
+      continue;
+    }
+
+    out += char;
+    index++;
+  }
+
+  return out.trim();
+}
+
+/** CSS the browser would actually apply, comments removed. */
 function activeRules(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, "").trim();
+  return scanCSS(css, false);
 }
 
 /**
- * Applicable CSS with quoted strings blanked out. Diagnostic text is echoed
- * inside a `content:` string where it is inert, so only what survives *outside*
- * a string literal can actually take effect.
+ * Applicable CSS with string literals blanked. Diagnostic text is echoed inside
+ * a `content:` string where it is inert, so only what survives *outside* a
+ * string literal can take effect.
  */
 function effectiveCSS(css: string): string {
-  return activeRules(css).replace(/"(?:\\.|[^"\\])*"/g, '""');
+  return scanCSS(css, true);
 }
 
 describe("server/handlers/dev/styles-css error responses", () => {
@@ -119,7 +170,14 @@ describe("server/handlers/dev/styles-css error responses", () => {
     );
     assertStringIncludes(css, "body::before");
     assertStringIncludes(css, "CSS Error:");
-    assertStringIncludes(css, "source listing exploded");
+    // ...but the raw fault must not reach a shareable preview URL. This catch
+    // fires on infrastructure errors whose messages carry server internals;
+    // the detail belongs in the log, not the page.
+    assertEquals(
+      css.includes("source listing exploded"),
+      false,
+      "internal error text must not be disclosed in the served stylesheet",
+    );
   });
 
   it("shows a visible diagnostic when a stylesheet uses a non-allowlisted plugin", async () => {
@@ -162,5 +220,61 @@ describe("server/handlers/dev/styles-css error responses", () => {
     // what remains after the comment is exactly one declaration block.
     assertEquals(activeRules(css).startsWith("body::before"), true);
     assertEquals((effectiveCSS(css).match(/\{/g) ?? []).length, 1, "exactly one rule block");
+  });
+
+  it("escapes diagnostic text that would otherwise break out of the CSS string", () => {
+    // No end-to-end route reaches this: a `"` inside `@plugin "..."` closes the
+    // stylesheet's own string first, so the escape contract is pinned directly.
+    const css = renderCSSDiagnostic("HEADING", {
+      title: "T",
+      message: 'a";}body{display:none}{content:"',
+      suggestion: "s",
+    });
+
+    assertEquals(
+      effectiveCSS(css).includes("display:none"),
+      false,
+      "a quote in diagnostic text must not close the content string",
+    );
+    assertEquals((effectiveCSS(css).match(/\{/g) ?? []).length, 1, "exactly one rule block");
+  });
+
+  it("escapes a backslash so it cannot neutralize the escape added to a quote", () => {
+    // The backslash must sit directly before a quote. Escaping the quote alone
+    // turns `\"` into `\\"` — an escaped backslash followed by a live quote,
+    // which closes the string. Only escaping the backslash first prevents it.
+    const css = renderCSSDiagnostic("HEADING", {
+      title: "T",
+      message: 'a\\";}body{display:none}{content:"',
+      suggestion: "s",
+    });
+
+    assertEquals(
+      effectiveCSS(css).includes("display:none"),
+      false,
+      "a backslash must not neutralize the escape applied to the following quote",
+    );
+  });
+
+  it("keeps newlines and control characters out of the CSS string literal", () => {
+    const css = renderCSSDiagnostic("HEADING", {
+      title: "T",
+      message: "line\u0000one\u2028two",
+      suggestion: "s",
+    });
+    const content = /content: "([^"]*)"/.exec(css)?.[1] ?? "";
+
+    // deno-lint-ignore no-control-regex -- asserting control characters are absent.
+    assertEquals(/[\u0000-\u001f\u2028\u2029]/.test(content), false);
+  });
+
+  it("bounds diagnostic text so a pathological error cannot inline a huge stylesheet", () => {
+    const css = renderCSSDiagnostic("HEADING", {
+      title: "T",
+      message: "x".repeat(50_000),
+      suggestion: "s",
+    });
+
+    assert(css.length < 10_000, `diagnostic must stay bounded, got ${css.length}`);
   });
 });

--- a/src/server/handlers/dev/styles-css-error-response.test.ts
+++ b/src/server/handlers/dev/styles-css-error-response.test.ts
@@ -5,7 +5,7 @@
  * `/_vf_styles/styles.css` serves the preview and dev shell (production goes
  * through the release manifest or `/_vf/css/<hash>.css`). Both of its error
  * paths answer 200 `text/css`, which is the only way the browser will render
- * the diagnostic — but the outer catch used to answer with a bare comment:
+ * the diagnostic. The outer catch, though, used to answer with a bare comment:
  * zero rules, no visible signal, indistinguishable from a project that simply
  * has no styles. The page rendered completely unstyled and nothing in the
  * browser said why.
@@ -241,7 +241,7 @@ describe("server/handlers/dev/styles-css error responses", () => {
 
   it("escapes a backslash so it cannot neutralize the escape added to a quote", () => {
     // The backslash must sit directly before a quote. Escaping the quote alone
-    // turns `\"` into `\\"` — an escaped backslash followed by a live quote,
+    // turns `\"` into `\\"`: an escaped backslash followed by a live quote,
     // which closes the string. Only escaping the backslash first prevents it.
     const css = renderCSSDiagnostic("HEADING", {
       title: "T",

--- a/src/server/handlers/dev/styles-css.handler.ts
+++ b/src/server/handlers/dev/styles-css.handler.ts
@@ -46,6 +46,72 @@ const logger = serverLogger.component("styles-css-handler");
 type GeneratedStylesResult = Awaited<ReturnType<typeof getProjectCSS>>;
 type StyleArtifactSelectorContext = Omit<ResolveStyleArtifactInput, "styleProfileHash">;
 
+/** Longest diagnostic text embedded in a served stylesheet. */
+const MAX_DIAGNOSTIC_LENGTH = 2_000;
+
+/**
+ * Neutralize the only sequence that can terminate a CSS comment (a star
+ * followed by a slash). Diagnostic text is derived from project-controlled
+ * input — a stylesheet's `@plugin` name reaches the message verbatim — so
+ * leaving that sequence intact would close the banner early and let the rest
+ * of the message be parsed as CSS rules.
+ */
+function forCSSComment(value: string): string {
+  return value.replaceAll("*/", "* /");
+}
+
+/**
+ * Escape text for a double-quoted CSS string. Backslash must be escaped first
+ * or it would re-escape the quotes added afterwards, and newlines terminate a
+ * CSS string literal outright.
+ */
+function forCSSString(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    // deno-lint-ignore no-control-regex -- raw control characters terminate a CSS string.
+    .replace(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]/g, " ");
+}
+
+function clampDiagnostic(value: string): string {
+  const text = typeof value === "string" ? value : String(value);
+  return text.length > MAX_DIAGNOSTIC_LENGTH ? `${text.slice(0, MAX_DIAGNOSTIC_LENGTH)}…` : text;
+}
+
+/**
+ * Render a stylesheet that both explains the failure in the source and shows
+ * it in the page. Every error path serves this: a stylesheet that failed to
+ * build must never be mistaken for a project that simply has no styles.
+ */
+function renderCSSDiagnostic(
+  heading: string,
+  detail: { title: string; message: string; suggestion: string },
+): string {
+  const summary = clampDiagnostic(
+    `${detail.title}: ${detail.message}\nSuggestion: ${detail.suggestion}`,
+  );
+  return `/*
+  ${forCSSComment(heading)}
+  ${forCSSComment(summary).replaceAll("\n", "\n  ")}
+*/
+
+body::before {
+  content: "CSS Error: ${forCSSString(summary.replaceAll("\n", " "))}";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 16px;
+  background: #dc2626;
+  color: white;
+  font-family: monospace;
+  font-size: 14px;
+  z-index: 99999;
+  white-space: pre-wrap;
+}
+`;
+}
+
 export class StylesCSSHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "StylesCSSHandler",
@@ -179,33 +245,12 @@ export class StylesCSSHandler extends BaseHandler {
             suggestion: formatted.suggestion,
           });
 
-          const errorMessage =
-            `${formatted.title}: ${formatted.message}\nSuggestion: ${formatted.suggestion}`;
-          const errorCSS = `/*
-  ╔══════════════════════════════════════════════════════════════╗
-  ║  TAILWIND CSS COMPILATION ERROR                               ║
-  ╠══════════════════════════════════════════════════════════════╣
-  ║  ${errorMessage.replace(/\n/g, "\n  ║  ")}
-  ╚══════════════════════════════════════════════════════════════╝
-*/
-
-body::before {
-  content: "CSS Error: ${errorMessage.replace(/"/g, '\\"').replace(/\n/g, " ")}";
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  padding: 16px;
-  background: #dc2626;
-  color: white;
-  font-family: monospace;
-  font-size: 14px;
-  z-index: 99999;
-  white-space: pre-wrap;
-}
-`;
           return this.respond(
-            responseBuilder.withContentType("text/css; charset=utf-8", errorCSS, HTTP_OK),
+            responseBuilder.withContentType(
+              "text/css; charset=utf-8",
+              renderCSSDiagnostic("TAILWIND CSS COMPILATION ERROR", formatted),
+              HTTP_OK,
+            ),
           );
         }
 
@@ -254,12 +299,22 @@ body::before {
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined,
       });
+      // This path used to answer with a bare CSS comment: 200, zero rules, no
+      // visible signal. A stylesheet that failed to build is indistinguishable
+      // from a project that legitimately has no styles, so the page renders
+      // completely unstyled and nothing in the browser says why. Route it
+      // through the same visible diagnostic the compile path uses.
       const responseBuilder = this.createResponseBuilder(ctx).withCache("no-cache");
-      const errorCSS = `/* StylesCSSHandler error: ${
-        (error instanceof Error ? error.message : String(error)).replace(/\*\//g, "")
-      } */`;
       return this.respond(
-        responseBuilder.withContentType("text/css; charset=utf-8", errorCSS, HTTP_OK),
+        responseBuilder.withContentType(
+          "text/css; charset=utf-8",
+          renderCSSDiagnostic("STYLESHEET COULD NOT BE BUILT", {
+            title: "CSS Handler Error",
+            message: error instanceof Error ? error.message : String(error),
+            suggestion: "Check the server logs for the full stack trace.",
+          }),
+          HTTP_OK,
+        ),
       );
     }
   }

--- a/src/server/handlers/dev/styles-css.handler.ts
+++ b/src/server/handlers/dev/styles-css.handler.ts
@@ -52,7 +52,7 @@ const MAX_DIAGNOSTIC_LENGTH = 2_000;
 /**
  * Neutralize the only sequence that can terminate a CSS comment (a star
  * followed by a slash). Diagnostic text is derived from project-controlled
- * input — a stylesheet's `@plugin` name reaches the message verbatim — so
+ * input (a stylesheet's `@plugin` name reaches the message verbatim), so
  * leaving that sequence intact would close the banner early and let the rest
  * of the message be parsed as CSS rules.
  */
@@ -298,7 +298,7 @@ export class StylesCSSHandler extends BaseHandler {
         );
       });
     } catch (error) {
-      // Ensure the handler never throws — an uncaught error causes the route registry
+      // Ensure the handler never throws: an uncaught error causes the route registry
       // to skip this handler silently and fall through to the 404 handler.
       logger.error("Unhandled error in CSS handler", {
         error: error instanceof Error ? error.message : String(error),
@@ -310,9 +310,9 @@ export class StylesCSSHandler extends BaseHandler {
       // completely unstyled and nothing in the browser says why. Route it
       // through the same visible diagnostic the compile path uses.
       //
-      // The message stays generic. Unlike the compile path — whose text comes
-      // from the project's own stylesheet and is the whole point of this route
-      // — this catch fires on infrastructure faults (adapter, filesystem,
+      // The message stays generic. The compile path's text comes from the
+      // project's own stylesheet and is the whole point of this route. This
+      // catch instead fires on infrastructure faults (adapter, filesystem,
       // network) whose messages carry server-side paths and internals, and a
       // preview URL is shareable. The detail is logged above instead.
       const responseBuilder = this.createResponseBuilder(ctx).withCache("no-cache");

--- a/src/server/handlers/dev/styles-css.handler.ts
+++ b/src/server/handlers/dev/styles-css.handler.ts
@@ -82,8 +82,13 @@ function clampDiagnostic(value: string): string {
  * Render a stylesheet that both explains the failure in the source and shows
  * it in the page. Every error path serves this: a stylesheet that failed to
  * build must never be mistaken for a project that simply has no styles.
+ *
+ * Exported for direct testing. The escaping contract cannot be fully driven
+ * through the handler: a `"` inside `@plugin "..."` closes the CSS string
+ * before it ever reaches a diagnostic, so the string-literal escape path has
+ * no end-to-end route and must be exercised here.
  */
-function renderCSSDiagnostic(
+export function renderCSSDiagnostic(
   heading: string,
   detail: { title: string; message: string; suggestion: string },
 ): string {
@@ -304,14 +309,20 @@ export class StylesCSSHandler extends BaseHandler {
       // from a project that legitimately has no styles, so the page renders
       // completely unstyled and nothing in the browser says why. Route it
       // through the same visible diagnostic the compile path uses.
+      //
+      // The message stays generic. Unlike the compile path — whose text comes
+      // from the project's own stylesheet and is the whole point of this route
+      // — this catch fires on infrastructure faults (adapter, filesystem,
+      // network) whose messages carry server-side paths and internals, and a
+      // preview URL is shareable. The detail is logged above instead.
       const responseBuilder = this.createResponseBuilder(ctx).withCache("no-cache");
       return this.respond(
         responseBuilder.withContentType(
           "text/css; charset=utf-8",
           renderCSSDiagnostic("STYLESHEET COULD NOT BE BUILT", {
             title: "CSS Handler Error",
-            message: error instanceof Error ? error.message : String(error),
-            suggestion: "Check the server logs for the full stack trace.",
+            message: "The stylesheet could not be built for this request.",
+            suggestion: "Check the server logs for this request's error and stack trace.",
           }),
           HTTP_OK,
         ),


### PR DESCRIPTION
Follow-up to the pattern audit in #3407. Independent of it — this branch is cut from `main` and touches different files.

## The bug

`/_vf_styles/styles.css` serves the preview and dev shell. It has two error paths, both answering `200 text/css`, but only one of them said anything.

The **outer catch** answered with a bare `/* StylesCSSHandler error: ... */`. Measured against the real handler before the change:

```
source-listing failure → 200, body 53 bytes, 0 applicable rules, no banner
```

Status 200, valid CSS, **zero applicable rules**. Indistinguishable from a project that legitimately has no styles — the page renders completely unstyled and nothing in the browser explains why. Only a server log line.

Everything that rethrows into it lands here, including the CSS-import merge and candidate extraction — the same scan whose throw #3402 had to fix on the release path.

The **compile path** (a non-allowlisted `@plugin`) does paint a red banner, but it also drops every project rule:

```
status=200  hasBrandHeader=false  hasCyan=false   ← all project CSS gone
```

## The fix

Both paths now render one shared diagnostic that states the failure in the stylesheet source *and* shows it on the page. A stylesheet that failed to build can never be mistaken for one that succeeded.

## A CSS injection found while unifying them

The diagnostic echoes project-controlled text — a stylesheet's `@plugin` name reaches the message verbatim. The banner interpolated it into a CSS comment with **no escaping at all**, and the `body::before` content string escaped quotes but not backslashes. Verified with:

```css
@plugin "x*/body{display:none}/*\"";
```

which closed the comment early and left `body{display:none}` as a **live rule**. Escaping is now per-context: the comment terminator neutralized for the comment block, backslash-then-quote plus control characters for the string literal. Diagnostic text is clamped so a pathological error cannot inline an unbounded stylesheet.

## Scope

Preview and dev only. `html-shell-generator.ts:220` gates production onto the release manifest or `/_vf/css/<hash>.css`; there a bad plugin rejects out of `getProjectCSS` and fails the render loudly, which is already correct.

## Two things deliberately not changed

- **Status stays 200.** A non-2xx stylesheet is discarded by the browser, which would take the diagnostic with it and put us back to an unstyled page with no explanation.
- **Caching stays `no-cache`.** I initially "hardened" this to `no-store` — wrong: the `no-cache` preset already expands to `no-cache, no-store, must-revalidate`, strictly stronger. Mutation testing caught it — the assertion pinning it passed with or without the change, so it was removed rather than kept as decoration.

## Verification

| Check | Result |
|---|---|
| Mutation: restore bare-comment outer catch | fails test 1 (`zero applicable rules`) |
| Mutation: drop comment escaping | fails test 3 (`must not survive as an applicable rule`) |
| `src/server/handlers/dev/`, `styles-builder/`, `orchestrator/html` | 39 suites, 417 steps, 0 failed |
| Full `test:unit` (pre-push gate) | 3795 passed, 27805 steps, 0 failed |
| fmt / lint / `deno check` | clean |

No behaviour change outside the two error paths, so no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stylesheet compilation and source-listing errors now display clear diagnostics while preserving a valid CSS response.
  * Error details are safely escaped and length-limited to prevent malformed or executable CSS.
  * Unexpected failures continue to return a CSS response with appropriate no-cache behavior.
* **Tests**
  * Added regression coverage for visible error diagnostics and protection against unsafe plugin names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->