### PR TITLE
fix(modules): gate the module pin conflict on the cohort, not the flag

### DIFF
--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -41,6 +41,7 @@ import {
   clearReactVersionCache,
   getDependencyPinningSnapshot,
 } from "#veryfront/transforms/esm/package-registry.ts";
+import { DEPENDENCY_PINNING_ROLLOUT_PERCENT_ENV } from "#veryfront/transforms/esm/dependency-pinning-cohort.ts";
 import { buildImportMapJson, clearImportMapCache } from "../../html/utils.ts";
 import { hashString } from "#veryfront/cache/hash.ts";
 import { register, tryResolve, unregister } from "#veryfront/extensions/contracts.ts";
@@ -2862,6 +2863,38 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
         assertEquals(response.headers.get("cache-control"), "no-store");
       }
     } finally {
+      clearReactVersionCache();
+      clearImportMapCache();
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("serves a client boundary for a project outside the pinning cohort", async () => {
+    // The flag arms the rollout; the cohort decides who is in it. An armed flag
+    // at 0% must stay inert. It did not: the early snapshot resolve was gated on
+    // the flag alone, so an out-of-cohort project skipped it, then carried no
+    // requested key -- because its document correctly emits none -- and every
+    // client module answered 409 instead of being served unpinned.
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-cohort-out-" });
+    try {
+      setEnv(DEPENDENCY_PINNING_ENV_FLAG, "1");
+      setEnv(DEPENDENCY_PINNING_ROLLOUT_PERCENT_ENV, "0");
+      await Deno.writeTextFile(
+        `${projectDir}/package.json`,
+        JSON.stringify({ dependencies: { react: "19.2.4" } }),
+      );
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/Widget.tsx`,
+        ['"use client";', "export default function Widget() { return null; }"].join("\n"),
+      );
+
+      const url = new URL("http://localhost:3000/_vf_modules/components/Widget.js");
+      const response = await serve(new Request(url), projectDir);
+      assertEquals(response.status, 200);
+      assertEquals(response.headers.get("content-type")?.includes("javascript"), true);
+    } finally {
+      deleteEnv(DEPENDENCY_PINNING_ROLLOUT_PERCENT_ENV);
       clearReactVersionCache();
       clearImportMapCache();
       await Deno.remove(projectDir, { recursive: true });

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -96,6 +96,10 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     deleteEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
     deleteEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG);
     deleteEnv(DEPENDENCY_PINNING_ENV_FLAG);
+    // Paired with the flag above: the flag arms the rollout and this decides
+    // who is in it, so a test that sets one and leaks the other leaves a later
+    // test on a cohort it never chose.
+    deleteEnv(DEPENDENCY_PINNING_ROLLOUT_PERCENT_ENV);
     deleteEnv("VERYFRONT_ENABLE_SERVER_TIMING");
     deleteEnv("VERYFRONT_CACHE_DIR");
     clearReleaseAssetManifestCache();
@@ -2894,7 +2898,6 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       assertEquals(response.status, 200);
       assertEquals(response.headers.get("content-type")?.includes("javascript"), true);
     } finally {
-      deleteEnv(DEPENDENCY_PINNING_ROLLOUT_PERCENT_ENV);
       clearReactVersionCache();
       clearImportMapCache();
       await Deno.remove(projectDir, { recursive: true });

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -41,7 +41,10 @@ import {
   clearReactVersionCache,
   getDependencyPinningSnapshot,
 } from "#veryfront/transforms/esm/package-registry.ts";
-import { DEPENDENCY_PINNING_ROLLOUT_PERCENT_ENV } from "#veryfront/transforms/esm/dependency-pinning-cohort.ts";
+import {
+  DEPENDENCY_PINNING_PROJECTS_ENV,
+  DEPENDENCY_PINNING_ROLLOUT_PERCENT_ENV,
+} from "#veryfront/transforms/esm/dependency-pinning-cohort.ts";
 import { buildImportMapJson, clearImportMapCache } from "../../html/utils.ts";
 import { hashString } from "#veryfront/cache/hash.ts";
 import { register, tryResolve, unregister } from "#veryfront/extensions/contracts.ts";
@@ -100,6 +103,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     // who is in it, so a test that sets one and leaks the other leaves a later
     // test on a cohort it never chose.
     deleteEnv(DEPENDENCY_PINNING_ROLLOUT_PERCENT_ENV);
+    deleteEnv(DEPENDENCY_PINNING_PROJECTS_ENV);
     deleteEnv("VERYFRONT_ENABLE_SERVER_TIMING");
     deleteEnv("VERYFRONT_CACHE_DIR");
     clearReleaseAssetManifestCache();
@@ -2898,6 +2902,54 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       assertEquals(response.status, 200);
       assertEquals(response.headers.get("content-type")?.includes("javascript"), true);
     } finally {
+      clearReactVersionCache();
+      clearImportMapCache();
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("conflicts an allowlisted project that carries no pin key", async () => {
+    // Covers the allowlist arm of the cohort, which the rollout-percent tests
+    // do not reach: named explicitly, the project is in the cohort, and a
+    // request with no pin key is a conflict.
+    //
+    // This does NOT prove which identity the cohort check reads. Where the UUID
+    // and the path id disagree, other guards answer 409 with the identical body
+    // for their own reasons, so the response cannot distinguish them. That the
+    // check must read effectiveProjectId -- the same identity handed to
+    // createDependencyPinningSource below it -- is established by reading the
+    // code, not by this test.
+    const { serveModule } = await import("./module-server.ts");
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-cohort-id-" });
+    try {
+      setEnv(DEPENDENCY_PINNING_ENV_FLAG, "1");
+      setEnv(DEPENDENCY_PINNING_PROJECTS_ENV, "pinned-uuid");
+      await Deno.writeTextFile(
+        `${projectDir}/package.json`,
+        JSON.stringify({ dependencies: { react: "19.2.4" } }),
+      );
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/Widget.tsx`,
+        ['"use client";', "export default function Widget() { return null; }"].join("\n"),
+      );
+
+      const response = await serveModule(
+        new Request("http://localhost:3000/_vf_modules/components/Widget.js"),
+        {
+          projectId: "test",
+          projectUUID: "pinned-uuid",
+          projectDir,
+          adapter: denoAdapter,
+          isLocalProject: true,
+          allowSSRModuleMode: true,
+        },
+      );
+
+      assertEquals(response.status, 409);
+      assertEquals(await response.text(), "Unknown dependency snapshot");
+    } finally {
+      deleteEnv(DEPENDENCY_PINNING_PROJECTS_ENV);
       clearReactVersionCache();
       clearImportMapCache();
       await Deno.remove(projectDir, { recursive: true });

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -71,6 +71,7 @@ import {
   resolveProjectReactVersion,
   resolveRequestedDependencyPinningSnapshot,
 } from "#veryfront/transforms/esm/package-registry.ts";
+import { isProjectInDependencyPinningCohort } from "#veryfront/transforms/esm/dependency-pinning-cohort.ts";
 import {
   appendDependencyPinningPathKey,
   extractDependencyPinningPathKey,
@@ -414,7 +415,13 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         requestedPinCount > 1 ||
         (hasRequestedPinKey &&
           (!requestedPinKey || !isCanonicalDependencyPinningCacheKey(requestedPinKey))) ||
-        (!hasRequestedPinKey && dependencyPinningEnabled)
+        // The flag arms the rollout; the cohort decides who is in it. Gating on
+        // the flag alone conflicted every module of every project while the
+        // rollout sat at 0%, because an out-of-cohort document correctly emits
+        // no key -- so the armed flag was never inert, which is the property it
+        // is supposed to have.
+        (!hasRequestedPinKey && dependencyPinningEnabled &&
+          isProjectInDependencyPinningCohort(options.projectId))
       ) {
         return unknownDependencySnapshotModuleResponse(method);
       }

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -420,8 +420,12 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         // rollout sat at 0%, because an out-of-cohort document correctly emits
         // no key -- so the armed flag was never inert, which is the property it
         // is supposed to have.
+        // effectiveProjectId, not options.projectId: the UUID is the identity a
+        // hosted multi-project request is pinned under, and it is what the
+        // snapshot resolve below uses. Bucketing on the directory-path id would
+        // put this check in a different cohort than the snapshot it guards.
         (!hasRequestedPinKey && dependencyPinningEnabled &&
-          isProjectInDependencyPinningCohort(options.projectId))
+          isProjectInDependencyPinningCohort(effectiveProjectId))
       ) {
         return unknownDependencySnapshotModuleResponse(method);
       }


### PR DESCRIPTION
Every client module of every hosted project answered `409 Unknown dependency snapshot` in production. No page hydrated.

## The defect

`src/modules/server/module-server.ts:417` conflicted a module request whenever the pinning flag was set and the request carried no pin key:

```ts
(!hasRequestedPinKey && dependencyPinningEnabled)
```

That is the **flag**, not the **cohort**. Production runs `VERYFRONT_DEPENDENCY_PINNING=1` with `ROLLOUT_PERCENT=0` and no project allowlist, so no project is in the cohort and every document correctly emits no pin key. The document and the module handler therefore disagreed: one emitted no key, the other refused every request that lacked one.

`dependency-pinning-cohort.ts` states the property this broke:

> *"An absent or malformed percentage collapses to zero so a typo can never widen the rollout, which is the property that keeps the already-armed production pinning flag inert until it is deliberately ramped."*

The armed flag was not inert. At 0% it conflicted 100% of client modules.

## Reproduction

Locally, against the real production release, with the environment read off the live deployment rather than guessed:

| env | module request (no pins) |
| --- | --- |
| `PINNING=1`, `ROLLOUT=0` (production's config) | **409** `Unknown dependency snapshot` |
| `PINNING=0` | 503 (unrelated local manifest branch) |

Production returns the same 409 for `/_vf_modules/pages/index.js`, so the reproduction is faithful.

## Fix

Consult the cohort, which is what decides who is actually pinning. A project genuinely in the cohort that omits its key still conflicts — that path is unchanged and its existing tests still pass.

## Proof

Regression test written first, red before the change with the exact production symptom:

```
serves a client boundary for a project outside the pinning cohort ... FAILED
AssertionError: Values are not equal.
-   409
+   200
```

Green after. End to end with the rebuilt binary, production env, real release:

```
/_vf_modules/_veryfront/react/runtime/core.js   409  ->  200 (4964 B)
```

Zero 409s remain on any module path. Two project-module URLs return 503 in my sandbox from a separate release-asset-manifest branch that also fires with pinning disabled, so it is not this defect and not this fix.

Suite: 268 passed / 3344 steps across `modules`, `security`, `handlers`, and `transforms/esm`. `deno fmt` clean.

## Not fixed here

The same pages also violate CSP: the document references `esm.sh`, `images.veryfront.com`, and `fonts.googleapis.com` while the default policy is `'self'`-only. I confirmed this is **independent** of this fix — with modules serving correctly, the document still carries 6 `esm.sh` references and 291 image references.

I did try adding the ESM CDN to the default `script-src` and reverted it: an existing test, *"default CSP admits no remote hosts or broad network schemes"*, fails with `script-src must not hardcode a remote host`. That strictness is deliberate, so widening it is a design decision rather than a bug fix, and it belongs in its own change with an owner who can make that call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dependency-pinning rollout behavior for projects outside the configured rollout cohort.
  * Client-boundary modules now load successfully for out-of-cohort projects, even when dependency pinning is enabled.
* **Tests**
  * Added regression coverage to verify successful JavaScript responses and proper rollout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->