### PR TITLE
fix(platform): share and cache host resolutions across a module fan-out

### DIFF
--- a/src/platform/compat/dns.test.ts
+++ b/src/platform/compat/dns.test.ts
@@ -1,0 +1,194 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createHostAddressResolver,
+  HOST_ADDRESS_CACHE_MAX_ENTRIES,
+  HOST_ADDRESS_CACHE_TTL_MS,
+} from "./dns.ts";
+
+/** Deferred promise so a test can hold a resolution open and observe fan-in. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createHostAddressResolver", () => {
+  it("collapses concurrent resolutions of one host into a single lookup", async () => {
+    let calls = 0;
+    const gate = deferred<string[]>();
+    const resolve = createHostAddressResolver({
+      resolve: () => {
+        calls++;
+        return gate.promise;
+      },
+    });
+
+    // Model the real failure: a page importing one CDN package fans out into
+    // dozens of module fetches, each of which validated egress separately.
+    const pending = Array.from({ length: 55 }, () => resolve("esm.sh"));
+    gate.resolve(["93.184.216.34"]);
+    const results = await Promise.all(pending);
+
+    assertEquals(calls, 1);
+    assertEquals(results.length, 55);
+    for (const addresses of results) {
+      assertEquals(addresses, ["93.184.216.34"]);
+    }
+  });
+
+  it("keeps distinct hosts on separate lookups", async () => {
+    const seen: string[] = [];
+    const resolve = createHostAddressResolver({
+      resolve: (hostname) => {
+        seen.push(hostname);
+        return Promise.resolve([hostname === "a.example" ? "1.1.1.1" : "2.2.2.2"]);
+      },
+    });
+
+    assertEquals(await resolve("a.example"), ["1.1.1.1"]);
+    assertEquals(await resolve("b.example"), ["2.2.2.2"]);
+    assertEquals(seen, ["a.example", "b.example"]);
+  });
+
+  it("reuses a resolution until the ttl expires", async () => {
+    let calls = 0;
+    let now = 1_000;
+    const resolve = createHostAddressResolver({
+      resolve: () => {
+        calls++;
+        return Promise.resolve(["93.184.216.34"]);
+      },
+      ttlMs: 30_000,
+      now: () => now,
+    });
+
+    await resolve("esm.sh");
+    now += 29_999;
+    await resolve("esm.sh");
+    assertEquals(calls, 1);
+
+    now += 2;
+    await resolve("esm.sh");
+    assertEquals(calls, 2);
+  });
+
+  it("separates cache entries by requested record type", async () => {
+    const seen: (readonly string[] | undefined)[] = [];
+    const resolve = createHostAddressResolver({
+      resolve: (_hostname, options) => {
+        seen.push(options.recordTypes);
+        return Promise.resolve(["93.184.216.34"]);
+      },
+    });
+
+    await resolve("esm.sh", { recordTypes: ["A"] });
+    await resolve("esm.sh", { recordTypes: ["A", "AAAA"] });
+    await resolve("esm.sh", { recordTypes: ["A"] });
+
+    assertEquals(seen.length, 2);
+  });
+
+  it("does not cache an empty result", async () => {
+    let calls = 0;
+    const resolve = createHostAddressResolver({
+      resolve: () => {
+        calls++;
+        return Promise.resolve(calls === 1 ? [] : ["93.184.216.34"]);
+      },
+    });
+
+    assertEquals(await resolve("esm.sh"), []);
+    // An unresolvable host is a blocking condition for the egress guard, so it
+    // must stay a live question rather than a cached verdict.
+    assertEquals(await resolve("esm.sh"), ["93.184.216.34"]);
+    assertEquals(calls, 2);
+  });
+
+  it("does not cache a failed resolution", async () => {
+    let calls = 0;
+    const resolve = createHostAddressResolver({
+      resolve: () => {
+        calls++;
+        return calls === 1
+          ? Promise.reject(new Error("SERVFAIL"))
+          : Promise.resolve(["93.184.216.34"]);
+      },
+    });
+
+    await assertRejects(() => resolve("esm.sh"));
+    assertEquals(await resolve("esm.sh"), ["93.184.216.34"]);
+    assertEquals(calls, 2);
+  });
+
+  it("rejects every caller waiting on a failed shared lookup", async () => {
+    let calls = 0;
+    const gate = deferred<string[]>();
+    const resolve = createHostAddressResolver({
+      resolve: () => {
+        calls++;
+        return gate.promise;
+      },
+    });
+
+    const pending = [resolve("esm.sh"), resolve("esm.sh"), resolve("esm.sh")];
+    gate.reject(new Error("SERVFAIL"));
+
+    for (const attempt of pending) {
+      await assertRejects(() => attempt);
+    }
+    assertEquals(calls, 1);
+  });
+
+  it("bounds the number of cached hosts", async () => {
+    let calls = 0;
+    const resolve = createHostAddressResolver({
+      resolve: () => {
+        calls++;
+        return Promise.resolve(["93.184.216.34"]);
+      },
+      maxEntries: 2,
+    });
+
+    await resolve("a.example");
+    await resolve("b.example");
+    await resolve("c.example");
+    assertEquals(calls, 3);
+
+    // "a.example" was evicted, so it must be resolved again.
+    await resolve("a.example");
+    assertEquals(calls, 4);
+
+    // "c.example" is still the newest entry and must still be cached.
+    await resolve("c.example");
+    assertEquals(calls, 4);
+  });
+
+  it("hands each caller an array it cannot use to corrupt the cache", async () => {
+    const resolve = createHostAddressResolver({
+      resolve: () => Promise.resolve(["93.184.216.34"]),
+    });
+
+    const first = await resolve("esm.sh");
+    first.push("10.0.0.1");
+
+    assertEquals(await resolve("esm.sh"), ["93.184.216.34"]);
+  });
+
+  it("exposes defaults that keep a fan-out inside one module-fetch budget", () => {
+    // HTTP_MODULE_FETCH_TIMEOUT_MS is 2_500ms per attempt. The ttl must outlive
+    // a page render so one render resolves a CDN host once, and the entry cap
+    // must hold a realistic dependency fan-out.
+    assertEquals(HOST_ADDRESS_CACHE_TTL_MS >= 5_000, true);
+    assertEquals(HOST_ADDRESS_CACHE_MAX_ENTRIES >= 64, true);
+  });
+});

--- a/src/platform/compat/dns.ts
+++ b/src/platform/compat/dns.ts
@@ -1,3 +1,32 @@
+/**
+ * Cross-runtime host address resolution.
+ *
+ * Resolution goes through a short-lived cache that also collapses concurrent
+ * lookups of the same host into one query. The egress guard
+ * (`security/sandbox/worker-egress-guard.ts`) validates every outbound request
+ * through here, so without that collapsing a single page render issues one
+ * query per module fetch.
+ *
+ * That fan-out is what makes it matter. A page importing one CDN package pulls
+ * dozens of modules from the same host, and the underlying resolvers query the
+ * configured nameservers directly rather than going through the OS resolver
+ * cache that getaddrinfo uses. Resolvers that serialize concurrent queries then
+ * add seconds: a Tailscale MagicDNS resolver measured 46ms for one lookup but
+ * 2061ms for 51 concurrent lookups, against roughly 60ms for public resolvers at
+ * the same concurrency. HTTP_MODULE_FETCH_TIMEOUT_MS allows each module fetch
+ * 2_500ms total, so DNS alone exhausted the budget and the fetches failed with
+ * AbortError until the render hit its idle deadline.
+ *
+ * Caching resolved addresses does not widen the DNS-rebinding window that
+ * pinning closes: reusing an already validated address set is what pinning
+ * does, and every caller still runs the full egress policy against the returned
+ * addresses. Only the DNS answer is cached, never a policy verdict. Empty and
+ * failed resolutions are never cached, so "this host does not resolve" stays a
+ * live question rather than a sticky one.
+ *
+ * @module platform/compat/dns
+ */
+
 import { getDenoRuntime, isBun, isDeno, isNode } from "./runtime.ts";
 
 export type DnsAddressRecordType = "A" | "AAAA";
@@ -6,18 +35,135 @@ export interface ResolveHostAddressesOptions {
   recordTypes?: readonly DnsAddressRecordType[];
 }
 
-export async function resolveHostAddresses(
+/**
+ * How long a successful resolution stays reusable.
+ *
+ * Long enough that one page render resolves a CDN host once, short enough that
+ * a legitimate address change is picked up quickly.
+ */
+export const HOST_ADDRESS_CACHE_TTL_MS = 30_000;
+
+/**
+ * Upper bound on cached hosts, so hostnames drawn from request data cannot grow
+ * the cache without limit.
+ */
+export const HOST_ADDRESS_CACHE_MAX_ENTRIES = 256;
+
+const DEFAULT_RECORD_TYPES: readonly DnsAddressRecordType[] = ["A", "AAAA"];
+
+export type ResolveHostAddresses = (
   hostname: string,
-  options: ResolveHostAddressesOptions = {},
+  options?: ResolveHostAddressesOptions,
+) => Promise<string[]>;
+
+export interface HostAddressResolverOptions {
+  /** Underlying resolver. Receives the caller's normalized record types. */
+  resolve: (
+    hostname: string,
+    options: { recordTypes: readonly DnsAddressRecordType[] },
+  ) => Promise<string[]>;
+  ttlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+}
+
+interface HostAddressCacheEntry {
+  addresses: readonly string[];
+  expiresAt: number;
+}
+
+/**
+ * Key a resolution by host and record types: an A-only answer cannot serve a
+ * caller that asked for A and AAAA. A pipe cannot appear in either part, so the
+ * two fields stay unambiguous.
+ */
+function cacheKey(hostname: string, recordTypes: readonly DnsAddressRecordType[]): string {
+  return `${hostname}|${recordTypes.join(",")}`;
+}
+
+/**
+ * Build a resolver that caches successful answers and shares in-flight lookups.
+ *
+ * Exported so the caching behavior can be tested against an injected resolver
+ * and clock. Runtime callers use `resolveHostAddresses`.
+ */
+export function createHostAddressResolver(
+  options: HostAddressResolverOptions,
+): ResolveHostAddresses {
+  const ttlMs = options.ttlMs ?? HOST_ADDRESS_CACHE_TTL_MS;
+  const maxEntries = options.maxEntries ?? HOST_ADDRESS_CACHE_MAX_ENTRIES;
+  const now = options.now ?? (() => Date.now());
+
+  const entries = new Map<string, HostAddressCacheEntry>();
+  const inFlight = new Map<string, Promise<string[]>>();
+
+  function readFresh(key: string): readonly string[] | undefined {
+    const entry = entries.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= now()) {
+      entries.delete(key);
+      return undefined;
+    }
+    return entry.addresses;
+  }
+
+  function store(key: string, addresses: readonly string[]): void {
+    // Insertion order is eviction order, so refreshing a key must re-insert it.
+    entries.delete(key);
+    entries.set(key, { addresses, expiresAt: now() + ttlMs });
+
+    for (const [candidate, entry] of entries) {
+      if (entries.size <= maxEntries) break;
+      if (entry.expiresAt <= now()) entries.delete(candidate);
+    }
+    while (entries.size > maxEntries) {
+      const oldest = entries.keys().next();
+      if (oldest.done) break;
+      entries.delete(oldest.value);
+    }
+  }
+
+  return async function resolve(
+    hostname: string,
+    callOptions: ResolveHostAddressesOptions = {},
+  ): Promise<string[]> {
+    const recordTypes = callOptions.recordTypes ?? DEFAULT_RECORD_TYPES;
+    const key = cacheKey(hostname, recordTypes);
+
+    const cached = readFresh(key);
+    if (cached) return [...cached];
+
+    const pending = inFlight.get(key);
+    if (pending) return [...await pending];
+
+    const lookup = (async () => {
+      const addresses = await options.resolve(hostname, { recordTypes });
+      // An empty answer is a blocking condition upstream, not a fact worth
+      // holding on to.
+      if (addresses.length > 0) store(key, [...addresses]);
+      return addresses;
+    })();
+
+    inFlight.set(key, lookup);
+    try {
+      return [...await lookup];
+    } finally {
+      if (inFlight.get(key) === lookup) inFlight.delete(key);
+    }
+  };
+}
+
+async function resolveHostAddressesUncached(
+  hostname: string,
+  options: { recordTypes: readonly DnsAddressRecordType[] },
 ): Promise<string[]> {
-  const recordTypes = options.recordTypes ?? ["A", "AAAA"];
   const results: string[] = [];
 
   if (isDeno) {
     const deno = getDenoRuntime();
     if (!deno) return results;
 
-    for (const recordType of recordTypes) {
+    for (const recordType of options.recordTypes) {
       try {
         results.push(...await deno.resolveDns(hostname, recordType));
       } catch {
@@ -29,7 +175,7 @@ export async function resolveHostAddresses(
 
   if (isNode || isBun) {
     const dns = await import("node:dns/promises");
-    for (const recordType of recordTypes) {
+    for (const recordType of options.recordTypes) {
       try {
         const addresses = recordType === "A"
           ? await dns.resolve4(hostname)
@@ -42,4 +188,18 @@ export async function resolveHostAddresses(
   }
 
   return results;
+}
+
+let cachedResolver = createHostAddressResolver({ resolve: resolveHostAddressesUncached });
+
+export async function resolveHostAddresses(
+  hostname: string,
+  options: ResolveHostAddressesOptions = {},
+): Promise<string[]> {
+  return await cachedResolver(hostname, options);
+}
+
+/** Drop cached resolutions so one test cannot observe another test's answers. */
+export function __resetHostAddressCacheForTests(): void {
+  cachedResolver = createHostAddressResolver({ resolve: resolveHostAddressesUncached });
 }

--- a/src/platform/compat/dns.ts
+++ b/src/platform/compat/dns.ts
@@ -13,9 +13,10 @@
  * cache that getaddrinfo uses. Resolvers that serialize concurrent queries then
  * add seconds: a Tailscale MagicDNS resolver measured 46ms for one lookup but
  * 2061ms for 51 concurrent lookups, against roughly 60ms for public resolvers at
- * the same concurrency. HTTP_MODULE_FETCH_TIMEOUT_MS allows each module fetch
- * 2_500ms total, so DNS alone exhausted the budget and the fetches failed with
- * AbortError until the render hit its idle deadline.
+ * the same concurrency. HTTP_MODULE_FETCH_TIMEOUT_MS gives each fetch attempt
+ * 2_500ms rather than each fetch, so DNS alone exhausted one attempt. Every
+ * attempt then failed the same way and the fetches died with AbortError, until
+ * the render hit its idle deadline.
  *
  * Caching resolved addresses does not widen the DNS-rebinding window that
  * pinning closes: reusing an already validated address set is what pinning

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -17,7 +17,7 @@ import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
 import { replaceSpecifiers } from "./lexer.ts";
 import { createBundleManifest, storeBundleManifest } from "./bundle-manifest.ts";
 import { HTTP_MODULE_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
-import { HTTP_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
+import { HTTP_MODULE_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
 import { httpBundleCache } from "./http-cache-wrapper.ts";
 import { unbrand } from "./http-cache-types.ts";
 import { asLocalModuleCode, VeryfrontError } from "./http-cache-invariants.ts";
@@ -93,7 +93,8 @@ const SLOW_HTTP_FETCH_THRESHOLD_MS = 500;
 const HTTP_MODULE_FETCH_MAX_ATTEMPTS = 3;
 const HTTP_MODULE_FETCH_RETRY_DELAY_MS = 100;
 const HTTP_MODULE_FETCH_WAIT_GRACE_MS = 5_000;
-const HTTP_MODULE_FETCH_MAX_WAIT_MS = HTTP_FETCH_TIMEOUT_MS * HTTP_MODULE_FETCH_MAX_ATTEMPTS +
+const HTTP_MODULE_FETCH_MAX_WAIT_MS =
+  HTTP_MODULE_FETCH_TIMEOUT_MS * HTTP_MODULE_FETCH_MAX_ATTEMPTS +
   HTTP_MODULE_FETCH_RETRY_DELAY_MS *
     ((HTTP_MODULE_FETCH_MAX_ATTEMPTS - 1) * HTTP_MODULE_FETCH_MAX_ATTEMPTS / 2) +
   HTTP_MODULE_FETCH_WAIT_GRACE_MS;
@@ -207,7 +208,7 @@ async function fetchHttpModule(url: string): Promise<HttpModuleFetchResult> {
         ),
       {
         maxAttempts: HTTP_MODULE_FETCH_MAX_ATTEMPTS,
-        timeoutMs: HTTP_FETCH_TIMEOUT_MS,
+        timeoutMs: HTTP_MODULE_FETCH_TIMEOUT_MS,
         shouldRetry: (error) =>
           error instanceof HttpModuleBodyError
             ? false


### PR DESCRIPTION
## Description

`resolveHostAddresses` resolved from scratch on every call, and the worker egress guard validates every outbound request through it. One page render therefore issued one DNS query per module fetch.

The fan-out is what makes that expensive. A page importing `react-markdown` pulls about 55 modules from `esm.sh`, so the guard issued about 110 concurrent queries (A and AAAA per fetch) for a single hostname. `resolve4`/`resolve6` and `Deno.resolveDns` query the configured nameservers directly rather than going through the OS resolver cache that getaddrinfo uses, so a resolver that serializes concurrent queries adds seconds.

Measured against a Tailscale MagicDNS resolver (`100.100.100.100`) resolving `esm.sh`:

| Concurrency | Wall | p50 |
| ----------- | ---- | --- |
| 1           | 46ms | 46ms |
| 10          | 573ms | 350ms |
| 51          | 2061ms | 1447ms |

Public resolvers (`1.1.1.1`, `8.8.8.8`) and the local router all stayed near 60ms at concurrency 51.

`HTTP_MODULE_FETCH_TIMEOUT_MS` gives each fetch *attempt* 2500ms, not each fetch, so DNS alone exhausted a single attempt. Every attempt then failed the same way, the fetches died with `AbortError`, and the render hit its 10s idle deadline and returned 500. `curl` and plain `fetch` looked healthy throughout because they use getaddrinfo and answer from the OS cache in about 6ms, which is why this reads as a network problem and is not one.

Resolution now goes through a resolver that collapses concurrent lookups of the same host into one query and caches the answer for 30s. On the fan-out above that is 110 queries down to 2, so a render no longer depends on how a resolver behaves under concurrency.

The collapsing is the part that fixes a cold render. A TTL cache alone does nothing when all 55 fetches start at once with nothing cached.

### Security

Caching resolved addresses does not widen the DNS-rebinding window that pinning closes. Reusing an already validated address set is what pinning does, and the window shrinks rather than grows.

- Only the DNS answer is cached, never a policy verdict. Every caller still runs the full egress policy against the returned addresses, so internal, metadata, and loopback blocking is unchanged.
- Empty and failed resolutions are never cached, so an unresolvable host stays a live question rather than a sticky verdict.
- The cache is bounded at 256 hosts because hostnames can come from request data.

### Runtime coverage

The caching layer is runtime-neutral and sits above the existing Deno, Node, and Bun branches, which are unchanged.

## Related Issue(s)

None filed. Found while debugging a scaffolded project created with `npm create veryfront@latest` that could not render its own index route.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

10 unit tests in `src/platform/compat/dns.test.ts`, written failing first: concurrent collapsing, TTL reuse and expiry, record-type keying, empty and failed answers not cached, shared-failure propagation, entry bound, and returned-array isolation.

- `src/platform/` and `src/security/`: 327 passed, 0 failed
- `deno fmt`, `deno lint`, `deno check`, and the module-boundaries gate all clean
- Cross-runtime check passed on Deno 2.7.12, Bun 1.3.6, and Node 25.2.1, including that the real resolver still answers and that a 55-way fan-out costs about one lookup on each

End to end against the scaffolded project, resolver left on Tailscale MagicDNS, no application-level configuration, cold module cache on every run:

| Resolver | Result | Fetch failures | Retry attempts |
| -------- | ------ | -------------- | -------------- |
| current  | 500 error page | 102 | 51x attempt 1, 51x attempt 2, all exhausted |
| patched  | 200, 94 KB page plus 90 KB CSS | 0 | none |
| current again | 500 error page | 102 | all exhausted |
| patched again | 200, page rendered | 21 | 21x attempt 1 only, every retry landed |

The last row is the interesting one. 21 first attempts still failed transiently, but every retry succeeded and the page rendered. Without this change all 51 fetches failed every attempt. DNS no longer consumes the per-attempt budget, so the retry policy from 52fa2f15e can actually land.

