### PR TITLE
test(release-assets): assert on each scaffold's own utilities, not a fixed list

### DIFF
--- a/src/release-assets/css-compile.ts
+++ b/src/release-assets/css-compile.ts
@@ -22,7 +22,7 @@
  *
  * Minification is requested, not required. `CSSOptimizationEngine` ships only
  * in `@veryfront/ext-css-lightning`, which `first-party-defaults.ts` marks
- * `selection: "explicit"` — a scaffolded project has no optimiser, so a
+ * `selection: "explicit"`. A scaffolded project has no optimiser, so a
  * release that asks for minification and gets none is the normal case, not an
  * outage. `acquireCSSGenerationSession` degrades to unminified output and
  * records that in `cacheIdentity`, which travels into the manifest as

--- a/src/release-assets/scaffolded-project-build.test.ts
+++ b/src/release-assets/scaffolded-project-build.test.ts
@@ -3,7 +3,7 @@
  * with the extension set it actually ships with.
  *
  * `npm create veryfront@latest` scaffolds a project that composes no
- * `CSSOptimizationEngine` — that contract lives only in
+ * `CSSOptimizationEngine`. That contract lives only in
  * `@veryfront/ext-css-lightning`, which `first-party-defaults.ts` marks
  * `selection: "explicit"`. CSS *optimisation* is optional; CSS *generation*
  * (`ext-css-tailwind`) and bundling (`ext-bundler-esbuild`) are builtin. A
@@ -12,7 +12,7 @@
  * stale minified entry in its place.
  *
  * This suite therefore composes only builtins a real install has, and asserts
- * before every build that no `CSSOptimizationEngine` is registered — so it
+ * before every build that no `CSSOptimizationEngine` is registered, so it
  * cannot quietly start testing a configuration no user runs. That is exactly
  * how the bug escaped: `css-processor-setup.ts` used to register a stub
  * optimiser for every importing suite, so `css-compile.test.ts` and
@@ -99,6 +99,35 @@ async function composeProductionExtensions(): Promise<void> {
 const fsAdapter = {
   fs: { readFile: (path: string): Promise<string> => readTextFile(path) },
 } as unknown as RuntimeAdapter;
+
+/**
+ * Utility class names this scaffold's own markup asks for.
+ *
+ * The compiled stylesheet must contain a rule the scaffold actually requested,
+ * not merely something a framework dependency contributed. A hard-coded list
+ * cannot express that: `ai-agent`, for instance, styles its shell with only
+ * `h-screen`, so a fixed set of utilities would silently pass on CSS that came
+ * from somewhere else. Reading the markup keeps the assertion tied to the
+ * template and lets templates change without weakening it.
+ *
+ * Deliberately plain tokens only. Variants (`hover:`), arbitrary values
+ * (`w-[3px]`) and slashes (`bg-black/50`) compile to escaped selectors, and
+ * matching those is a CSS-escaping exercise this check does not need.
+ */
+function scaffoldUtilityClasses(
+  files: ReadonlyArray<{ path: string; content: string }>,
+): string[] {
+  const found = new Set<string>();
+  for (const file of files) {
+    if (!/\.(tsx|jsx)$/.test(file.path)) continue;
+    for (const match of file.content.matchAll(/className="([^"]+)"/g)) {
+      for (const token of match[1]!.split(/\s+/)) {
+        if (/^[a-z][a-z0-9-]*$/.test(token)) found.add(token);
+      }
+    }
+  }
+  return [...found];
+}
 
 interface Recorded {
   uploads: Array<{ hash: string; contentType: string; bytes: Uint8Array }>;
@@ -244,9 +273,15 @@ describe("release assets: scaffolded project build", () => {
       assertExists(cssUpload, "expected a text/css asset upload");
       const css = new TextDecoder().decode(cssUpload.bytes);
       assert(css.length > 0, "published CSS must not be empty");
+      const utilities = scaffoldUtilityClasses(sources);
       assert(
-        /\.(min-h-screen|mx-auto|flex|font-bold)\b/.test(css),
-        `expected a compiled Tailwind utility in ${templateName} CSS`,
+        utilities.length > 0,
+        `${templateName} markup declares no plain utility classes to check`,
+      );
+      assert(
+        utilities.some((utility) => new RegExp(`\\.${utility}(?![\\w-])`).test(css)),
+        `expected a utility from ${templateName}'s own markup in the compiled CSS; ` +
+          `looked for ${utilities.slice(0, 12).join(", ")}`,
       );
       assertEquals(
         manifest.css[0]?.size,

--- a/src/release-assets/scaffolded-project-build.test.ts
+++ b/src/release-assets/scaffolded-project-build.test.ts
@@ -110,9 +110,12 @@ const fsAdapter = {
  * from somewhere else. Reading the markup keeps the assertion tied to the
  * template and lets templates change without weakening it.
  *
- * Deliberately plain tokens only. Variants (`hover:`), arbitrary values
- * (`w-[3px]`) and slashes (`bg-black/50`) compile to escaped selectors, and
- * matching those is a CSS-escaping exercise this check does not need.
+ * Deliberately narrow: only tokens matching `/^[a-z][a-z0-9-]*$/`. That leaves
+ * out variants (`hover:`), arbitrary values (`w-[3px]`), slashes
+ * (`bg-black/50`), negative utilities (`-mt-4`) and anything leading with a
+ * digit, all of which compile to escaped or prefixed selectors. Matching those
+ * is a CSS-escaping exercise this check does not need to take on, and every
+ * starter declares plain utilities without them.
  */
 function scaffoldUtilityClasses(
   files: ReadonlyArray<{ path: string; content: string }>,


### PR DESCRIPTION
Follow-up to review feedback on #3407, which merged before these two comments landed. Both were valid.

## 1. The Tailwind assertion was partly vacuous (Copilot)

It matched a hard-coded set: `min-h-screen`, `mx-auto`, `flex`, `font-bold`. The `ai-agent` template declares **none** of them — its shell is styled with `h-screen` alone (`cli/templates/files/ai-agent/app/page.tsx:10`).

So for that template the check passed on CSS contributed by framework dependencies, not on anything the scaffold asked for. That is exactly the failure mode #3407 exists to prevent, in #3407's own test.

Adding `h-screen` to the list — as suggested — fixes `ai-agent` but leaves the same trap for the next template. Instead the assertion now reads utilities out of the scaffold's **own markup** and requires one of them in the compiled stylesheet, so it stays tied to the template and cannot drift.

Measured per template, declared vs matched:

| Template | Declared | Matched |
|---|---|---|
| `ai-agent` | `h-screen` | `h-screen` |
| `minimal` | 24 | all 24 |
| `docs-agent` | 18 | all 18 |
| `agentic-workflow` | 57 | all 57 |
| `multi-agent-system` | 31 | all 31 |
| `coding-agent` | 35 | all 35 |
| `saas-starter` | 79 | all 79 |

Plain tokens only. Variants (`hover:`), arbitrary values (`w-[3px]`) and slashes (`bg-black/50`) compile to escaped selectors, and matching those is a CSS-escaping exercise this check doesn't need to take on.

## 2. Em dashes (CodeRabbit)

`AGENTS.md:55` prohibits em and en dashes. I dismissed this on #3407 on the grounds that the surrounding prose already used them — that was wrong. A pre-existing violation doesn't license a new one, and the rule is documented.

Fixes the three I introduced, rewriting the sentences rather than swapping the character so they still read. The older ones elsewhere in `css-compile.ts` are left alone, being outside what this change touches.

## Verification

`src/release-assets/`: 15 suites, 220 steps, 0 failed. fmt / lint / `deno check` clean. No production code changes beyond one comment line.