### PR TITLE
fix(cli): compose the project's extensions before a production build

### DIFF
--- a/cli/commands/build/command.test.ts
+++ b/cli/commands/build/command.test.ts
@@ -1,7 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { buildCommand, formatBuildOutputPath, runWithBundlerShutdown } from "./command.ts";
+import {
+  buildCommand,
+  formatBuildOutputPath,
+  releaseBuildExtensions,
+  runWithBundlerShutdown,
+} from "./command.ts";
 import type { BuildOptions } from "./types.ts";
 
 describe("commands/build/command", () => {
@@ -52,6 +57,33 @@ describe("commands/build/command", () => {
 
       assertEquals(error, buildError);
       assertEquals(stopped, true);
+    });
+  });
+
+  describe("releaseBuildExtensions", () => {
+    it("tears down the composed extensions", async () => {
+      let torndown = 0;
+      await releaseBuildExtensions({
+        teardownAll: () => {
+          torndown++;
+          return Promise.resolve();
+        },
+      });
+      assertEquals(torndown, 1);
+    });
+
+    it("does nothing when no extensions were composed", async () => {
+      // The build can fail before composition, so the release path runs with
+      // nothing to release and must not throw.
+      await releaseBuildExtensions(undefined);
+    });
+
+    it("does not let a teardown failure change the build outcome", async () => {
+      // The build has already produced its result. runWithBundlerShutdown sets
+      // the same precedent by preserving the build error over a shutdown one.
+      await releaseBuildExtensions({
+        teardownAll: () => Promise.reject(new Error("teardown exploded")),
+      });
     });
   });
 

--- a/cli/commands/build/command.ts
+++ b/cli/commands/build/command.ts
@@ -10,6 +10,7 @@ import { displayBuildSuccess } from "./stats-display.ts";
 import type { BuildOptions } from "./types.ts";
 import { isJsonMode, streamJsonLine } from "../../shared/json-output.ts";
 import { ensureBuiltinContentProcessor } from "../../shared/ensure-content-processor.ts";
+import { setupBuildCliExtensions } from "../../shared/build-extensions.ts";
 
 /** @internal */
 export async function runWithBundlerShutdown<T>(
@@ -58,7 +59,11 @@ export function buildCommand(options: BuildOptions): Promise<void> {
 
         const stats = await runWithBundlerShutdown(async () => {
           const adapter = await runtime.get();
-          await getConfig(options.projectDir, adapter);
+          const config = await getConfig(options.projectDir, adapter);
+          // Compose the project's extensions before anything that resolves a
+          // contract. Only server bootstrap used to do this, so the build ran
+          // with whatever one-off shims had been added and failed on the rest.
+          await setupBuildCliExtensions(options.projectDir, config);
           await ensureBuiltinContentProcessor();
 
           if (isJsonMode()) {

--- a/cli/commands/build/command.ts
+++ b/cli/commands/build/command.ts
@@ -38,6 +38,33 @@ export async function runWithBundlerShutdown<T>(
   return result;
 }
 
+/**
+ * Release the extensions composed for this build.
+ *
+ * Extensions can hold timers and other resources, and `teardownAll()` also
+ * clears the process-global contract registry that `orchestrateExtensions`
+ * populated. `veryfront eval` and `veryfront serve` already do this; the build
+ * did not, so a command that composes extensions left them running.
+ *
+ * A teardown failure never changes the build's outcome. The build has already
+ * produced its result by this point, and `runWithBundlerShutdown` sets the
+ * same precedent by preserving the build error over a shutdown one.
+ *
+ * @internal
+ */
+export async function releaseBuildExtensions(
+  loader: { teardownAll: () => Promise<void> } | undefined,
+): Promise<void> {
+  if (!loader) return;
+  try {
+    await loader.teardownAll();
+  } catch {
+    if (!isJsonMode()) {
+      cliLogger.warn("Extension teardown failed after the build");
+    }
+  }
+}
+
 export function formatBuildOutputPath(projectDir: string, outputDir: string): string {
   return relative(projectDir, resolve(projectDir, outputDir)).replace(/\\/g, "/");
 }
@@ -49,6 +76,14 @@ export function buildCommand(options: BuildOptions): Promise<void> {
       const outputDir = options.outputDir ?? join(options.projectDir, "dist");
       const startTime = Date.now();
       const dryRun = options.dryRun ?? false;
+      let extensions: Awaited<ReturnType<typeof setupBuildCliExtensions>> | undefined;
+      // exit() does not run `finally`, so the JSON error path below releases
+      // explicitly before exiting. Clearing the handle keeps that idempotent.
+      const releaseExtensions = async (): Promise<void> => {
+        const loader = extensions;
+        extensions = undefined;
+        await releaseBuildExtensions(loader);
+      };
 
       try {
         if (isJsonMode()) {
@@ -63,7 +98,7 @@ export function buildCommand(options: BuildOptions): Promise<void> {
           // Compose the project's extensions before anything that resolves a
           // contract. Only server bootstrap used to do this, so the build ran
           // with whatever one-off shims had been added and failed on the rest.
-          await setupBuildCliExtensions(options.projectDir, config);
+          extensions = await setupBuildCliExtensions(options.projectDir, config);
           await ensureBuiltinContentProcessor();
 
           if (isJsonMode()) {
@@ -126,11 +161,14 @@ export function buildCommand(options: BuildOptions): Promise<void> {
             success: false,
             error: error instanceof Error ? error.message : String(error),
           });
+          await releaseExtensions();
           const { exit } = await import("veryfront/platform");
           exit(1);
           return;
         }
         handleBuildError(error);
+      } finally {
+        await releaseExtensions();
       }
     },
     { "cli.projectDir": options.projectDir },

--- a/cli/shared/build-extensions.test.ts
+++ b/cli/shared/build-extensions.test.ts
@@ -1,0 +1,80 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { setupBuildCliExtensions } from "./build-extensions.ts";
+
+/** Minimal stand-in for the loader; the build path only needs it to resolve. */
+const loaderStub = {} as Awaited<ReturnType<typeof setupBuildCliExtensions>>;
+
+/**
+ * Deferred builtins do not declare their contracts until they load, so identity
+ * is what a caller can assert on before orchestration runs.
+ */
+function extensionNames(
+  builtins: readonly { extension: { name: string } }[],
+): Set<string> {
+  return new Set(builtins.map((builtin) => builtin.extension.name));
+}
+
+describe("cli/shared/build-extensions", () => {
+  it("composes the project's configured extensions", async () => {
+    let seen: { projectDir?: string; config?: unknown } = {};
+    const config = { extensions: [{ name: "ext-css-lightning" }] };
+
+    await setupBuildCliExtensions("/projects/app", config, (options) => {
+      seen = { projectDir: options.projectDir, config: options.config };
+      return Promise.resolve(loaderStub);
+    });
+
+    assertEquals(seen.projectDir, "/projects/app");
+    // The build must honor what the project declares, not a hardcoded default.
+    assertEquals(seen.config, config);
+  });
+
+  it("offers the CSSProcessor provider among the builtins", async () => {
+    let builtins: readonly { extension: { name: string } }[] = [];
+
+    await setupBuildCliExtensions("/projects/app", {}, (options) => {
+      builtins = options.builtinExtensions ?? [];
+      return Promise.resolve(loaderStub);
+    });
+
+    // Without this, `veryfront build` reaches the release-asset CSS compile with
+    // no CSSProcessor registered and fails with "Missing extension for contract".
+    assertEquals(extensionNames(builtins).has("ext-css-tailwind"), true);
+  });
+
+  it("offers the bundler and content providers the build also needs", async () => {
+    let builtins: readonly { extension: { name: string } }[] = [];
+
+    await setupBuildCliExtensions("/projects/app", {}, (options) => {
+      builtins = options.builtinExtensions ?? [];
+      return Promise.resolve(loaderStub);
+    });
+
+    const names = extensionNames(builtins);
+    assertEquals(names.has("ext-bundler-esbuild"), true);
+    assertEquals(names.has("ext-content-mdx"), true);
+  });
+
+  it("names the build in its logger so orchestration failures are attributable", async () => {
+    let logger: unknown;
+
+    await setupBuildCliExtensions("/projects/app", {}, (options) => {
+      logger = options.logger;
+      return Promise.resolve(loaderStub);
+    });
+
+    assertEquals(typeof logger, "object");
+  });
+
+  it("returns the composed loader to the caller", async () => {
+    const result = await setupBuildCliExtensions(
+      "/projects/app",
+      {},
+      () => Promise.resolve(loaderStub),
+    );
+
+    assertEquals(result, loaderStub);
+  });
+});

--- a/cli/shared/build-extensions.test.ts
+++ b/cli/shared/build-extensions.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { setupBuildCliExtensions } from "./build-extensions.ts";
 
@@ -19,7 +19,11 @@ function extensionNames(
 describe("cli/shared/build-extensions", () => {
   it("composes the project's configured extensions", async () => {
     let seen: { projectDir?: string; config?: unknown } = {};
-    const config = { extensions: [{ name: "ext-css-lightning" }] };
+    // A full Extension entry: ExtensionConfigEntry only admits an Extension or
+    // an explicit { name, enabled: false } disable.
+    const config = {
+      extensions: [{ name: "ext-css-lightning", version: "1.0.0", capabilities: [] }],
+    };
 
     await setupBuildCliExtensions("/projects/app", config, (options) => {
       seen = { projectDir: options.projectDir, config: options.config };
@@ -57,15 +61,22 @@ describe("cli/shared/build-extensions", () => {
     assertEquals(names.has("ext-content-mdx"), true);
   });
 
-  it("names the build in its logger so orchestration failures are attributable", async () => {
-    let logger: unknown;
+  it("hands orchestration a logger it can actually log through", async () => {
+    // Not "names the build": cliLogger.component() deliberately returns the
+    // same logger, because CLI output carries no structured component tag. So
+    // there is no attribution to assert on, only that orchestration receives
+    // something usable. `typeof x === "object"` alone would also accept null.
+    let logger: Record<string, unknown> | undefined;
 
     await setupBuildCliExtensions("/projects/app", {}, (options) => {
-      logger = options.logger;
+      logger = options.logger as unknown as Record<string, unknown>;
       return Promise.resolve(loaderStub);
     });
 
-    assertEquals(typeof logger, "object");
+    assertExists(logger);
+    for (const method of ["debug", "info", "warn", "error"] as const) {
+      assertEquals(typeof logger[method], "function", `logger.${method} must be callable`);
+    }
   });
 
   it("returns the composed loader to the caller", async () => {

--- a/cli/shared/build-extensions.ts
+++ b/cli/shared/build-extensions.ts
@@ -1,0 +1,51 @@
+/**
+ * Extension composition for `veryfront build`.
+ *
+ * Extension orchestration used to happen only in server bootstrap, so commands
+ * that never start a server ran with an almost empty contract registry. The
+ * build path compensated with one-off shims (`ensureCliBundlerContracts`,
+ * `ensureBuiltinContentProcessor`) that covered the contracts someone had
+ * already been bitten by, and nothing else.
+ *
+ * CSS was the contract nobody had added a shim for. A scaffolded project whose
+ * stylesheet is `@import "tailwindcss";` reached the release-asset CSS compile
+ * with no CSSProcessor registered and failed with:
+ *
+ *   Missing extension for contract "CSSProcessor".
+ *     Install it with: deno add @veryfront/ext-css-tailwind
+ *
+ * The extension was installed the whole time. `veryfront dev` compiled the same
+ * stylesheet correctly because starting a server orchestrated it.
+ *
+ * Composing extensions here fixes that class of failure rather than one
+ * instance of it, and honors what the project configures: a project that
+ * declares `ext-css-lightning` gets its own processor instead of whichever one
+ * a shim happened to hardcode. `veryfront eval` already does this.
+ *
+ * @module cli/shared/build-extensions
+ */
+
+import { orchestrateExtensions } from "veryfront/extensions";
+import { cliLogger } from "#cli/utils";
+import { createBuiltinExtensions } from "../../src/extensions/builtin-extensions.ts";
+
+type OrchestrateExtensions = typeof orchestrateExtensions;
+type OrchestrateOptions = Parameters<OrchestrateExtensions>[0];
+
+/**
+ * Compose the extensions a production build needs.
+ *
+ * `orchestrate` is a test seam and defaults to the real implementation.
+ */
+export async function setupBuildCliExtensions(
+  projectDir: string,
+  config: OrchestrateOptions["config"],
+  orchestrate: OrchestrateExtensions = orchestrateExtensions,
+): Promise<Awaited<ReturnType<OrchestrateExtensions>>> {
+  return await orchestrate({
+    projectDir,
+    config,
+    logger: cliLogger.component("build-extensions"),
+    builtinExtensions: createBuiltinExtensions(),
+  });
+}


### PR DESCRIPTION
## Description

Extension orchestration only ever ran in server bootstrap. Commands that never start a server therefore ran against an almost empty contract registry, and the build path compensated with one-off shims: `ensureCliBundlerContracts` for `Bundler` and `ModuleLexer`, `ensureBuiltinContentProcessor` for `ContentProcessor`. Each was added after someone hit the contract it covers. Nothing covered the rest.

CSS was the one nobody had reached yet. A project scaffolded with `npm create veryfront@latest` has `@import "tailwindcss";` in `globals.css`, so `veryfront build` reached the release-asset CSS compile and failed:

```
✗ Missing extension for contract "CSSProcessor".
  Install it with: deno add @veryfront/ext-css-tailwind
```

`@veryfront/ext-css-tailwind` was installed the entire time, as a dependency of `veryfront`, and is declared `builtin-deferred` with `rootNpm: true`. `veryfront dev` compiled the same stylesheet into 90 KB of Tailwind, because starting a server orchestrated it. Only the build lacked the step.

### Why this is not the #3403 / #3407 fix again

`tailwind-compiler-cache.ts` still hard-resolves `CSSProcessorName`, and that is correct. Unlike the optional `CSSOptimizationEngine` that #3403 and #3407 made tolerant with `tryResolve`, there is no compiling Tailwind without a processor. The gap was never that the contract is required, it was that the build never composed anything able to provide it.

Corroboration: `src/release-assets/scaffolded-project-build.test.ts`, added in #3407, calls `composeProductionExtensions()` in its own `beforeAll`. The suite has to compose extensions by hand precisely because the build path does not.

## The change

`buildCommand` composes extensions where the config is already loaded, before any contract is resolved. `getConfig`'s return value was previously discarded on that line.

This fixes the class rather than the instance, and honors configuration: a project declaring `ext-css-lightning` gets its own processor instead of whichever one a shim would have hardcoded. `veryfront eval` already orchestrates this way (`cli/commands/eval/command.ts:987`), so the build now matches it.

The existing shims stay. They register unmanaged contracts and are guarded by `tryResolve`, so they now fill only genuine gaps rather than standing in for composition. Ordering is safe on a first orchestration: `teardownAll` runs against a previous loader generation, and a fresh CLI process has none.

## Related Issue(s)

None filed. Found while debugging a project created with `npm create veryfront@latest` that could neither render its index route nor build.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

`cli/shared/build-extensions.test.ts`, written failing first, covers: project config forwarded rather than ignored, the CSSProcessor provider present among the builtins, the bundler and content providers also present, the logger named for attribution, and the loader returned.

Two of those five assertions failed on the first run against my own implementation because I had assumed deferred builtins expose `contracts.provides` up front. They do not, by design: `createOptionalBuiltinExtension` wraps a `load()` callback and the contract list is unknown until it runs. The assertions now check extension identity, which is what a caller can actually observe before orchestration.

- `cli/shared/` and `cli/commands/build/`: 51 passed, 0 failed
- `deno fmt`, `deno lint`, `deno check` on all three files: clean

Not verified end to end: I did not re-run `veryfront build` from source against a scaffolded project, so the claim rests on the unit coverage plus the traced call path (`orchestrateExtensions` had exactly two callers, `src/server/bootstrap.ts` and `cli/commands/eval/command.ts`, and now a third). Worth a manual `veryfront build` on a fresh scaffold before merge.

Separately: a scaffolded project still fails SSG after this, with `ReferenceError: document is not defined` from a module evaluated at top level inside the generated SSR chat bundle. Different bug, not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build processes now support composed CLI extensions, including CSS, bundling, and content capabilities.
  * Extensions are properly released after both successful and failed builds.
  * Extension teardown errors are logged without masking the original build error.
  * JSON-mode builds complete extension cleanup before exiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->