### PR TITLE
fix(agent): make the resolver test typecheck against the fetch init union

### DIFF
--- a/src/agent/hosted/project-reference-resolver.test.ts
+++ b/src/agent/hosted/project-reference-resolver.test.ts
@@ -30,7 +30,9 @@ Deno.test("resolveHostedProjectReference returns a matching normalized API ident
     (input, init) => {
       requests.push({
         url: String(input),
-        authorization: new Headers(init?.headers).get("authorization"),
+        authorization: new Headers(
+          init && "headers" in init ? init.headers : undefined,
+        ).get("authorization"),
       });
       return Promise.resolve(
         Response.json({


### PR DESCRIPTION
`ci (lint)` is red on `main`, so every branch cut from it inherits a failing check. Found while fixing #3413, whose lint job reported this file alongside its own error.

## Cause

`withMockFetch`'s `init` parameter is a union whose members do not all declare `headers`:

```
TS2339: Property 'headers' does not exist on type
  'RequestInit | (RequestInit & { client?: HttpClient }) | global.RequestInit'.
```

`src/agent/hosted/project-reference-resolver.test.ts:33` does `init?.headers`, and the file is not in `scripts/lint/test-typecheck-baseline.json`.

Verified it fails on `origin/main` itself, not just on a branch — this is not introduced by any open PR.

## Fix

Narrows with an `in` check rather than casting, matching #3382, which fixed the same union in `remote-mcp.test.ts` one day earlier. A cast would hide the next union member that lacks the property.

## Verification

- `deno check --no-lock src/agent/hosted/project-reference-resolver.test.ts` — clean (fails on main)
- `project-reference-resolver.test.ts` — 10 passed, 0 failed
- `deno lint` — clean

Kept to its own PR rather than folded into #3413, since it unblocks every branch.