### PR TITLE
ci: drop coverage from the release gate

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -589,7 +589,9 @@ jobs:
     needs: [
       ci,
       tests,
-      coverage,
+      # coverage is deliberately absent: it is a quality metric, not a
+      # correctness gate, and an npm publish cannot be taken back. Every
+      # remaining entry can fail the release for a reason a user would feel.
       tests-binary-e2e,
       tests-npm-install-smoke,
       tests-sentry-runtime-packages,


### PR DESCRIPTION
Takes the coverage fan-out (8 shards + gate) off the critical path between merging to main and publishing to npm.

## Why only this one

Coverage is a quality metric. It cannot tell you the release is broken, and an npm publish cannot be taken back. Every other entry in the gate can fail for a reason a user would feel, so they stay.

`tests-binary-e2e` is deliberately **kept**, and this week is the argument for it: the incident began with a compiled binary missing its embedded worker entry — the startup probe passed and every render then 503'd. That job is what catches exactly that, and it would have been the tempting one to cut on speed grounds.

## What this does not do

It does not speed up the release currently in flight. GitHub Actions reads the workflow from the commit that triggered the run, and run 31079490326 started on `59fe62c4c` before this existed. This helps the next release, not that one.