### PR TITLE
docs(proxy): stop claiming a 503 is unreachable after the queue caps went

### DIFF
--- a/src/proxy/asset-handler.ts
+++ b/src/proxy/asset-handler.ts
@@ -54,10 +54,10 @@ const MAX_CACHED_ASSET_BYTES = 32 * 1024 * 1024;
  * and finally an honest 504.
  *
  * A 503 is still reachable, but only from the semaphore's own
- * DEFAULT_PERMIT_SEMAPHORE_MAX_QUEUE_SIZE backstop. That threshold is two
+ * `DEFAULT_PERMIT_SEMAPHORE_MAX_QUEUE_SIZE` backstop. That threshold is two
  * orders of magnitude above one page's module graph, so reaching it means a
  * genuine flood rather than a project being shed for the size of the document
- * this proxy just served it.
+ * this proxy just served.
  */
 const MAX_CONCURRENT_COLD_LOADS = 4;
 

--- a/src/proxy/asset-handler.ts
+++ b/src/proxy/asset-handler.ts
@@ -51,7 +51,13 @@ const MAX_CACHED_ASSET_BYTES = 32 * 1024 * 1024;
  * never retries, which turns one shed asset into a dead page. Callers are
  * already bounded by their own deadline (`timeoutMs`) and the producer ceiling
  * (`MAX_UPSTREAM_TIMEOUT_MS`); a saturated proxy therefore shows up as latency
- * and finally an honest 504, never a phantom 503.
+ * and finally an honest 504.
+ *
+ * A 503 is still reachable, but only from the semaphore's own
+ * DEFAULT_PERMIT_SEMAPHORE_MAX_QUEUE_SIZE backstop. That threshold is two
+ * orders of magnitude above one page's module graph, so reaching it means a
+ * genuine flood rather than a project being shed for the size of the document
+ * this proxy just served it.
  */
 const MAX_CONCURRENT_COLD_LOADS = 4;
 


### PR DESCRIPTION
## Description

Follow-up to a Copilot review comment on #3420 that merged before the correction landed, so the inaccurate comment is on `main` now.

#3420 removed the two cold-load queue caps and left this in `asset-handler.ts`:

> a saturated proxy therefore shows up as latency and finally an honest 504, **never a phantom 503**.

That overstates it. `PermitSemaphore` still carries its own `DEFAULT_PERMIT_SEMAPHORE_MAX_QUEUE_SIZE` backstop, and exhausting it raises `ReleaseAssetOverloadedError` and returns 503. The `serviceUnavailable()` path was deliberately kept for exactly that case.

The comment now says so, and says why the distinction the PR was making still holds: that threshold is two orders of magnitude above one page's module graph, so reaching it means a genuine flood rather than a project being shed for the size of the document this proxy just served it.

## Type of Change

- [x] Documentation update

Comment only, no behaviour change. `asset-handler.test.ts` 29 steps pass; `fmt:check`, `lint` and `docs:api-reference:check` all exit 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified concurrency behavior: saturated demand is queued and may eventually return a 504 response.
  * Documented that 503 responses are reserved for the semaphore’s extreme queue backstop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->