### PR TITLE
test(release-assets): assert the rejection reason on the log record, not the console

### DIFF
--- a/src/release-assets/manifest-cache.test.ts
+++ b/src/release-assets/manifest-cache.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/logger/index.ts";
 import {
   clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
@@ -9,6 +10,36 @@ import {
 } from "./manifest-cache.ts";
 import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 import { RELEASE_ASSET_MANIFEST_SCHEMA_VERSION } from "./constants.ts";
+
+/** Component the manifest cache logs under, and the only one these tests read. */
+const MANIFEST_LOG_COMPONENT = "release-asset-manifest";
+
+/**
+ * Collect this component's structured log records for the duration of `run`.
+ *
+ * Reads the records operators actually consume rather than the rendered console
+ * line: the reason exists to reach a log pipeline, so asserting on the record is
+ * asserting on the thing that has to work. It also keeps the test off global
+ * mutable state — patching `console.error` leaks across a file if a run throws
+ * before it is restored, and couples every assertion to the text formatter.
+ */
+async function captureManifestLogs(run: () => Promise<void>): Promise<LogEntry[]> {
+  const records: LogEntry[] = [];
+  const unsubscribe = __subscribeLogRecordEmitter((entry) => {
+    if (entry.component === MANIFEST_LOG_COMPONENT) records.push(entry);
+  });
+  try {
+    await run();
+  } finally {
+    unsubscribe();
+  }
+  return records;
+}
+
+/** The single error-level rejection record, or undefined when none was emitted. */
+function rejectionRecord(records: LogEntry[]): LogEntry | undefined {
+  return records.find((entry) => entry.level === "error");
+}
 
 function manifest(releaseId: string, manifestVersion: number): ReleaseAssetManifest {
   return {
@@ -93,22 +124,21 @@ describe("release asset manifest fetcher ownership", () => {
         },
       }));
 
-    const originalError = console.error;
-    let logged = "";
-    console.error = (...values: unknown[]) => {
-      logged += values.map((value) => typeof value === "string" ? value : JSON.stringify(value))
-        .join(" ");
-    };
-
-    try {
+    const records = await captureManifestLogs(async () => {
       assertEquals(await getReadyManifestForRenderAsync("release-skew"), null);
-    } finally {
-      console.error = originalError;
-    }
+    });
 
-    assertStringIncludes(logged, "release-skew");
-    assertStringIncludes(logged, "manifest schema version");
-    assertStringIncludes(logged, "built by a different framework version");
+    // Error level is load-bearing: it is what separates "an operator must act"
+    // from the debug-level "not ready yet" that is the normal path.
+    const rejection = rejectionRecord(records);
+    assertExists(rejection, "expected an error-level rejection record");
+    assertEquals(rejection.context?.releaseId, "release-skew");
+
+    // Assert on the versions the reason has to name, not its prose. Naming both
+    // is what tells an operator to deploy a newer builder rather than rebuild.
+    const reason = String(rejection.context?.reason ?? "");
+    assertStringIncludes(reason, String(RELEASE_ASSET_MANIFEST_SCHEMA_VERSION + 1));
+    assertStringIncludes(reason, String(RELEASE_ASSET_MANIFEST_SCHEMA_VERSION));
   });
 
   it("reports a ready response whose envelope has no usable manifest_version", async () => {
@@ -124,21 +154,17 @@ describe("release asset manifest fetcher ownership", () => {
         manifest: manifest("release-envelope", 1),
       } as unknown as ReturnType<typeof readyManifestResponse>));
 
-    const originalError = console.error;
-    let logged = "";
-    console.error = (...values: unknown[]) => {
-      logged += values.map((value) => typeof value === "string" ? value : JSON.stringify(value))
-        .join(" ");
-    };
-
-    try {
+    const records = await captureManifestLogs(async () => {
       assertEquals(await getReadyManifestForRenderAsync("release-envelope"), null);
-    } finally {
-      console.error = originalError;
-    }
+    });
 
-    assertStringIncludes(logged, "release-envelope");
-    assertStringIncludes(logged, "no usable manifest_version");
+    // Classifying on the derived `state` routes this to debug, which the level
+    // gate drops before it ever reaches a subscriber — so an empty record set is
+    // exactly the regression, and this assertion is what catches it.
+    const rejection = rejectionRecord(records);
+    assertExists(rejection, "expected an error-level rejection record");
+    assertEquals(rejection.context?.releaseId, "release-envelope");
+    assertStringIncludes(String(rejection.context?.reason ?? ""), "manifest_version");
   });
 
   it("keeps cache identities distinct for delimiter-shaped release IDs", async () => {


### PR DESCRIPTION
## Description

Follow-up to #3424, addressing review feedback that I merged without acting on.

Copilot posted it as **three suppressed comments inside a collapsed `<details>` block** in its second review body, rather than as inline comments. My enumeration only walked the inline-comment list, so they never surfaced. Worth naming plainly: a review's actionable content is not always in the inline comments.

All three made one point — the two tests #3424 added capture their assertions by monkeypatching `console.error` and matching prose fragments against the accumulated text.

## What changed

Test file only. `manifest-cache.ts` is untouched.

The tests now use `__subscribeLogRecordEmitter`, already the pattern in `rate-limit.test.ts`, `cache-file-ops.test.ts` and `logger.test.ts`.

Three reasons, in the order they matter:

- **It asserts the thing that has to work.** The reason exists to reach a log pipeline, and pipelines consume the structured record. Matching the rendered console line tested the text formatter as much as the diagnostic.
- **It drops global mutable state.** `console.error` was restored in a `finally`, but the patch is process-wide while installed, and it only worked because the logger resolves the console method at call time — a detail no test should depend on.
- **It stops pinning prose.** Assertions now read `context.releaseId` and check that the reason names the two schema versions, or names `manifest_version`. The wording is free to change; what an operator needs from it is not.

## Type of Change

- [x] Test-only change (no production behavior change)

## Checklist

- [x] I have added tests that prove my fix is effective

## Verification

**Both tests are still non-vacuous — verified by mutation, not assumed:**

| Mutation | Result |
|---|---|
| `rawState` → `state` | envelope test fails: `expected an error-level rejection record` |
| helper call → old generic `"invalid or mismatched"` | skew test fails on the missing version numbers |

The first is the interesting one. Classifying on `state` routes the rejection to `debug`, and `logger.ts:655` applies the level gate *before* notifying subscribers — so the record never reaches the emitter at all. An empty record set is precisely the regression, which is what `assertExists` catches.

**Gates:** release-assets suite 15 passed / 222 steps / 0 failed under the CI env with `--parallel`; `fmt:check`, `lint`, and `lint:test-typecheck` (`baseline holds: 51 grandfathered files, 0 new`) all exit 0; `deno check` on the test file exits 0; `deno task docs` regenerates with no diff.

## Notes for review

One correction to the original review's reasoning, since it shouldn't propagate: the comments cited a race under `deno test --parallel`. Deno parallelizes across test *files* in separate workers, and tests within a file run sequentially — so a cross-file `console.error` race was not actually reachable here. The change is still worth making for the three reasons above; it just isn't fixing a live flake, and I'd rather say so than let a wrong rationale stand.

The follow-up #3424 flagged is still open and unaddressed: manifest validation runs at request time behind a `mode === "production"` gate, so preview never executes it and this class of failure stays structurally undetectable until it reaches a live customer site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated manifest rejection tests to validate structured diagnostic records.
  * Expanded coverage for release IDs, error severity, schema versions, and missing manifest version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->