### PR TITLE
refactor(agent): give the agent loop's skill policy one owner

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,13 +17,13 @@ interpretation, so provider behavior changes land in one file.
 
 ## Agent Loop Skill State
 
-The single owner of the request-scoped active-skill policy for one agent
-loop attempt — which skill is active, what it permits, and how that changes
-when a skill activates or a form input is submitted:
-`src/agent/runtime/agent-loop-skill-state.ts` (`AgentLoopSkillState`). A
-mutable class hydrated once per attempt from replay history, then mutated in
-place as tool results arrive; never module-level or shared across
-concurrent runs. `executeAgentLoop` and `executeAgentLoopStreaming` in
+`src/agent/runtime/agent-loop-skill-state.ts` (`AgentLoopSkillState`) is the
+single owner of the request-scoped active-skill policy for one agent loop
+attempt: which skill is active, what it permits, and how that changes when a
+skill activates or a form input is submitted. Each loop owns its own instance.
+`hydrate` builds it once per attempt from replay history, and the loop mutates
+it in place as tool results arrive. It is never module-level and never shared
+across concurrent runs. `executeAgentLoop` and `executeAgentLoopStreaming` in
 `src/agent/runtime/index.ts` each construct one instance and consult it
 rather than maintaining their own copies of the same policy transitions, so
 a skill-policy fix lands once instead of being hand-applied to both loops.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,6 +15,19 @@ provider errors. The agent **runtime** layer starts streams and the **hosted**
 layer finishes them; both consult this module rather than re-deriving the
 interpretation, so provider behavior changes land in one file.
 
+## Agent Loop Skill State
+
+The single owner of the request-scoped active-skill policy for one agent
+loop attempt — which skill is active, what it permits, and how that changes
+when a skill activates or a form input is submitted:
+`src/agent/runtime/agent-loop-skill-state.ts` (`AgentLoopSkillState`). A
+mutable class hydrated once per attempt from replay history, then mutated in
+place as tool results arrive; never module-level or shared across
+concurrent runs. `executeAgentLoop` and `executeAgentLoopStreaming` in
+`src/agent/runtime/index.ts` each construct one instance and consult it
+rather than maintaining their own copies of the same policy transitions, so
+a skill-policy fix lands once instead of being hand-applied to both loops.
+
 ## Stream Lifecycle
 
 The single owner of one provider stream attempt, from the first provider read

--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -1043,7 +1043,7 @@ Input delivered to a hosted agent-service detached execution callback.
 
 | Name                                 | Description                                       | Source                                                                                                             |
 | ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `AgentRuntime`                       | Implement agent runtime.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/index.ts#L683)                    |
+| `AgentRuntime`                       | Implement agent runtime.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/index.ts#L680)                    |
 | `AgentRuntimeMessageConversionError` | Error shape for agent runtime message conversion. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/message-adapter.ts#L138)          |
 | `AgentServiceAuthError`              | Error shape for hosted service auth.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/auth.ts#L14)                      |
 | `AppendConversationRunEventsError`   | Error shape for append conversation run events.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable-append-errors.ts#L4) |

--- a/src/agent/runtime/agent-loop-skill-state.test.ts
+++ b/src/agent/runtime/agent-loop-skill-state.test.ts
@@ -1,0 +1,269 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { AgentLoopSkillState } from "./agent-loop-skill-state.ts";
+import type { Message } from "../types.ts";
+
+function loadSkillResultMessage(
+  result: Record<string, unknown>,
+  id = "tool_load_skill",
+): Message {
+  return {
+    id,
+    role: "tool",
+    parts: [{
+      type: "tool-result",
+      toolCallId: id,
+      toolName: "load_skill",
+      result,
+    }],
+  };
+}
+
+function formInputResultMessage(
+  result: Record<string, unknown>,
+  id = "tool_form_input",
+): Message {
+  return {
+    id,
+    role: "tool",
+    parts: [{
+      type: "tool-result",
+      toolCallId: id,
+      toolName: "form_input",
+      result,
+    }],
+  };
+}
+
+describe("src/agent/runtime AgentLoopSkillState", () => {
+  describe("hydrate", () => {
+    it("starts inactive for empty history", () => {
+      const state = AgentLoopSkillState.hydrate([], undefined);
+
+      assertEquals(state.activeSkillId, undefined);
+      assertEquals(state.activeSkillPolicy, undefined);
+      assertEquals(state.activeSkillToolAvailability, {
+        hasActiveSkill: false,
+        references: [],
+        scripts: [],
+      });
+      assertEquals(state.activeSkillDelegationOverrides, undefined);
+      assertEquals(state.hasSubmittedFormInput, false);
+    });
+
+    it("hydrates the active skill policy from replayed load_skill history", () => {
+      const messages: Message[] = [
+        loadSkillResultMessage({
+          skillId: "review",
+          instructions: "# Review",
+          allowedTools: ["Read"],
+          references: ["references/notes.md"],
+          scripts: [],
+        }),
+      ];
+
+      const state = AgentLoopSkillState.hydrate(messages, undefined);
+
+      assertEquals(state.activeSkillId, "review");
+      assertEquals(state.activeSkillPolicy, ["Read"]);
+      assertEquals(state.activeSkillToolAvailability, {
+        hasActiveSkill: true,
+        references: ["references/notes.md"],
+        scripts: [],
+      });
+    });
+
+    it("detects a submitted form_input result in message history", () => {
+      const messages: Message[] = [
+        formInputResultMessage({ submitted: true, values: { topic: "test" } }),
+      ];
+
+      const state = AgentLoopSkillState.hydrate(messages, undefined);
+
+      assertEquals(state.hasSubmittedFormInput, true);
+    });
+
+    it("falls back to the runtime-context flag when history has no form_input result", () => {
+      const withoutContext = AgentLoopSkillState.hydrate([], undefined);
+      assertEquals(withoutContext.hasSubmittedFormInput, false);
+
+      const withContext = AgentLoopSkillState.hydrate([], {
+        hasSubmittedFormInputResult: true,
+      });
+      assertEquals(withContext.hasSubmittedFormInput, true);
+    });
+  });
+
+  describe("applySuccessfulResult", () => {
+    it("updates all four skill fields from a valid activation result", () => {
+      const state = AgentLoopSkillState.hydrate([], undefined);
+
+      state.applySuccessfulResult({
+        skillId: "deploy",
+        instructions: "# Deploy",
+        allowedTools: ["Bash"],
+        references: [],
+        scripts: ["scripts/run.sh"],
+        model: "anthropic/claude-sonnet-4-5",
+        thinking: false,
+        maxSteps: 6,
+      });
+
+      assertEquals(state.activeSkillId, "deploy");
+      assertEquals(state.activeSkillPolicy, ["Bash"]);
+      assertEquals(state.activeSkillToolAvailability, {
+        hasActiveSkill: true,
+        references: [],
+        scripts: ["scripts/run.sh"],
+      });
+      assertEquals(state.activeSkillDelegationOverrides, {
+        model: "anthropic/claude-sonnet-4-5",
+        thinking: false,
+        maxSteps: 6,
+      });
+    });
+
+    it("preserves the prior policy for an invalid activation result", () => {
+      const state = AgentLoopSkillState.hydrate(
+        [
+          loadSkillResultMessage({
+            skillId: "review",
+            instructions: "# Review",
+            allowedTools: ["Read"],
+            references: [],
+            scripts: [],
+          }),
+        ],
+        undefined,
+      );
+
+      state.applySuccessfulResult({ error: "Missing reference" });
+
+      assertEquals(state.activeSkillId, "review");
+      assertEquals(state.activeSkillPolicy, ["Read"]);
+    });
+  });
+
+  describe("markFormInputSubmitted", () => {
+    it("narrows the active policy and sets the flag when submitted is true", () => {
+      const state = AgentLoopSkillState.hydrate(
+        [
+          loadSkillResultMessage({
+            skillId: "review",
+            instructions: "# Review",
+            allowedTools: ["Read", "form_input"],
+            references: [],
+            scripts: [],
+          }),
+        ],
+        undefined,
+      );
+      assertEquals(state.activeSkillPolicy, ["Read", "form_input"]);
+      assertEquals(state.hasSubmittedFormInput, false);
+
+      state.markFormInputSubmitted(
+        "form_input",
+        { submitted: true, values: { topic: "test" } },
+        true,
+      );
+
+      assertEquals(state.activeSkillPolicy, ["Read"]);
+      assertEquals(state.hasSubmittedFormInput, true);
+    });
+
+    it("updates the policy without setting the flag when submitted is false", () => {
+      const state = AgentLoopSkillState.hydrate(
+        [
+          loadSkillResultMessage({
+            skillId: "review",
+            instructions: "# Review",
+            allowedTools: ["Read", "form_input"],
+            references: [],
+            scripts: [],
+          }),
+        ],
+        undefined,
+      );
+
+      state.markFormInputSubmitted(
+        "form_input",
+        { submitted: false, values: {} },
+        false,
+      );
+
+      assertEquals(state.activeSkillPolicy, ["Read", "form_input"]);
+      assertEquals(state.hasSubmittedFormInput, false);
+    });
+
+    it("leaves the policy untouched for non-form_input tool results", () => {
+      const state = AgentLoopSkillState.hydrate(
+        [
+          loadSkillResultMessage({
+            skillId: "review",
+            instructions: "# Review",
+            allowedTools: ["Read", "form_input"],
+            references: [],
+            scripts: [],
+          }),
+        ],
+        undefined,
+      );
+
+      state.markFormInputSubmitted("read_file", { content: "..." }, false);
+
+      assertEquals(state.activeSkillPolicy, ["Read", "form_input"]);
+      assertEquals(state.hasSubmittedFormInput, false);
+    });
+  });
+
+  describe("instance independence", () => {
+    it("keeps two hydrated instances from sharing state", () => {
+      const first = AgentLoopSkillState.hydrate([], undefined);
+      const second = AgentLoopSkillState.hydrate([], undefined);
+
+      first.applySuccessfulResult({
+        skillId: "a",
+        instructions: "# A",
+        allowedTools: ["Read"],
+        references: [],
+        scripts: [],
+      });
+      first.markFormInputSubmitted("form_input", { submitted: true }, true);
+
+      assertEquals(first.activeSkillId, "a");
+      assertEquals(first.hasSubmittedFormInput, true);
+      assertEquals(second.activeSkillId, undefined);
+      assertEquals(second.activeSkillPolicy, undefined);
+      assertEquals(second.hasSubmittedFormInput, false);
+    });
+
+    it("keeps concurrently-mutated instances independent across interleaved edits", () => {
+      const runA = AgentLoopSkillState.hydrate([], undefined);
+      const runB = AgentLoopSkillState.hydrate([], undefined);
+
+      runA.applySuccessfulResult({
+        skillId: "run-a-skill",
+        instructions: "# A",
+        allowedTools: ["Read"],
+        references: [],
+        scripts: [],
+      });
+      runB.applySuccessfulResult({
+        skillId: "run-b-skill",
+        instructions: "# B",
+        allowedTools: ["Write"],
+        references: [],
+        scripts: [],
+      });
+      runA.markFormInputSubmitted("form_input", { submitted: true }, true);
+
+      assertEquals(runA.activeSkillId, "run-a-skill");
+      assertEquals(runA.activeSkillPolicy, ["Read"]);
+      assertEquals(runA.hasSubmittedFormInput, true);
+      assertEquals(runB.activeSkillId, "run-b-skill");
+      assertEquals(runB.activeSkillPolicy, ["Write"]);
+      assertEquals(runB.hasSubmittedFormInput, false);
+    });
+  });
+});

--- a/src/agent/runtime/agent-loop-skill-state.ts
+++ b/src/agent/runtime/agent-loop-skill-state.ts
@@ -1,0 +1,80 @@
+import type { Message } from "../types.ts";
+import {
+  type ActiveSkillState,
+  applySkillActivationResult,
+  hasSubmittedFormInputResult,
+  hydrateActiveSkillStateFromMessages,
+  removeFormInputAfterSubmission,
+  SUBMITTED_FORM_INPUT_CONTEXT_KEY,
+} from "./skill-policy-enforcement.ts";
+
+/**
+ * The single owner of the request-scoped active-skill policy for one agent
+ * loop attempt: which skill is active, what it permits, and how that
+ * changes when a skill activates or a form input is submitted.
+ *
+ * Mutable and held for the caller's lifetime — construct one per attempt via
+ * `hydrate`, mutate it in place as tool results arrive, and never share an
+ * instance across concurrent runs. There is deliberately no module-level or
+ * static mutable state; `executeAgentLoop` and `executeAgentLoopStreaming`
+ * each construct their own instance instead of maintaining separate copies
+ * of the same policy transitions.
+ */
+export class AgentLoopSkillState {
+  activeSkillId: ActiveSkillState["activeSkillId"];
+  activeSkillPolicy: ActiveSkillState["activeSkillPolicy"];
+  activeSkillToolAvailability: ActiveSkillState["activeSkillToolAvailability"];
+  activeSkillDelegationOverrides: ActiveSkillState["activeSkillDelegationOverrides"];
+  hasSubmittedFormInput: boolean;
+
+  private constructor(hydrated: ActiveSkillState, hasSubmittedFormInput: boolean) {
+    this.activeSkillId = hydrated.activeSkillId;
+    this.activeSkillPolicy = hydrated.activeSkillPolicy;
+    this.activeSkillToolAvailability = hydrated.activeSkillToolAvailability;
+    this.activeSkillDelegationOverrides = hydrated.activeSkillDelegationOverrides;
+    this.hasSubmittedFormInput = hasSubmittedFormInput;
+  }
+
+  /** Hydrate request-scoped skill state from replay history. */
+  static hydrate(
+    messages: readonly Message[],
+    runtimeContext: Record<string, unknown> | undefined,
+  ): AgentLoopSkillState {
+    const hydrated = hydrateActiveSkillStateFromMessages(messages);
+    const hasSubmittedFormInput = hasSubmittedFormInputResult(messages) ||
+      runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true;
+    return new AgentLoopSkillState(hydrated, hasSubmittedFormInput);
+  }
+
+  /** Fold a successful skill-activation tool result into the active policy. */
+  applySuccessfulResult(result: unknown): void {
+    const next = applySkillActivationResult({
+      activeSkillId: this.activeSkillId,
+      activeSkillPolicy: this.activeSkillPolicy,
+      activeSkillToolAvailability: this.activeSkillToolAvailability,
+      activeSkillDelegationOverrides: this.activeSkillDelegationOverrides,
+    }, result);
+    this.activeSkillId = next.activeSkillId;
+    this.activeSkillPolicy = next.activeSkillPolicy;
+    this.activeSkillToolAvailability = next.activeSkillToolAvailability;
+    this.activeSkillDelegationOverrides = next.activeSkillDelegationOverrides;
+  }
+
+  /**
+   * Narrow the active policy after a form_input tool result, and record the
+   * flag when `submitted` reports the form was actually submitted. Callers
+   * pass `submitted` explicitly (each loop determines it from its own
+   * tool-result shape via `isSubmittedFormInputExecutionResult`) rather than
+   * this method recomputing it.
+   */
+  markFormInputSubmitted(toolName: string, result: unknown, submitted: boolean): void {
+    this.activeSkillPolicy = removeFormInputAfterSubmission(
+      toolName,
+      result,
+      this.activeSkillPolicy,
+    );
+    if (submitted) {
+      this.hasSubmittedFormInput = true;
+    }
+  }
+}

--- a/src/agent/runtime/agent-loop-skill-state.ts
+++ b/src/agent/runtime/agent-loop-skill-state.ts
@@ -13,12 +13,11 @@ import {
  * loop attempt: which skill is active, what it permits, and how that
  * changes when a skill activates or a form input is submitted.
  *
- * Mutable and held for the caller's lifetime — construct one per attempt via
- * `hydrate`, mutate it in place as tool results arrive, and never share an
- * instance across concurrent runs. There is deliberately no module-level or
- * static mutable state; `executeAgentLoop` and `executeAgentLoopStreaming`
- * each construct their own instance instead of maintaining separate copies
- * of the same policy transitions.
+ * Construct one instance per attempt via `hydrate`. Mutate it in place as tool
+ * results arrive. Never share an instance across concurrent runs. This module
+ * holds no module-level or static mutable state. `executeAgentLoop` and
+ * `executeAgentLoopStreaming` each construct their own instance instead of
+ * maintaining separate copies of the same policy transitions.
  */
 export class AgentLoopSkillState {
   activeSkillId: ActiveSkillState["activeSkillId"];

--- a/src/agent/runtime/agent-loop-skill-state.ts
+++ b/src/agent/runtime/agent-loop-skill-state.ts
@@ -63,9 +63,9 @@ export class AgentLoopSkillState {
   /**
    * Narrow the active policy after a form_input tool result, and record the
    * flag when `submitted` reports the form was actually submitted. Callers
-   * pass `submitted` explicitly (each loop determines it from its own
-   * tool-result shape via `isSubmittedFormInputExecutionResult`) rather than
-   * this method recomputing it.
+   * compute `submitted` with a broader predicate than this method applies
+   * internally; they can disagree, so the flag cannot be recomputed without
+   * changing behavior.
    */
   markFormInputSubmitted(toolName: string, result: unknown, submitted: boolean): void {
     this.activeSkillPolicy = removeFormInputAfterSubmission(

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1430,11 +1430,27 @@ export class AgentRuntime {
               if (toolCall.error !== undefined) {
                 setOtelActiveSpanErrorStatus(toolCall.error);
               }
-              if (
-                generatedToolResult.isError !== true &&
-                shouldHideProjectToolAfterAgentWriteSuccess(tc.toolName)
-              ) {
-                agentWriteFinalResponseToolGuardEnabled = true;
+              if (generatedToolResult.isError !== true) {
+                if (shouldHideProjectToolAfterAgentWriteSuccess(tc.toolName)) {
+                  agentWriteFinalResponseToolGuardEnabled = true;
+                }
+                if (tc.toolName === LOAD_SKILL_TOOL_ID) {
+                  skillState.applySuccessfulResult(generatedToolResult.result);
+                }
+                const submittedFormInput = isSubmittedFormInputExecutionResult(
+                  tc.toolName,
+                  generatedToolResult.result,
+                );
+                skillState.markFormInputSubmitted(
+                  tc.toolName,
+                  generatedToolResult.result,
+                  submittedFormInput,
+                );
+                if (submittedFormInput) {
+                  currentRuntimeContext = markSubmittedFormInputRuntimeContext(
+                    currentRuntimeContext,
+                  );
+                }
               }
               setSpanAttributes(
                 toolSpan,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -74,15 +74,12 @@ import {
   shouldContinueAfterStreamStep,
 } from "./tool-result-continuation.ts";
 import {
-  applySkillActivationResult,
   enforceSkillPolicy,
   FORM_INPUT_TOOL_ID,
-  hasSubmittedFormInputResult,
-  hydrateActiveSkillStateFromMessages,
   LOAD_SKILL_TOOL_ID,
-  removeFormInputAfterSubmission,
   SUBMITTED_FORM_INPUT_CONTEXT_KEY,
 } from "./skill-policy-enforcement.ts";
+import { AgentLoopSkillState } from "./agent-loop-skill-state.ts";
 import { markRuntimeGeneratedUserMessage } from "./runtime-message-origin.ts";
 import {
   getRuntimeAllowedRemoteTools,
@@ -1054,25 +1051,7 @@ export class AgentRuntime {
       }
 
       // Request-scoped skill policy (not class-level mutable state)
-      const hydratedSkillState = hydrateActiveSkillStateFromMessages(currentMessages);
-      let activeSkillId = hydratedSkillState.activeSkillId;
-      let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
-      let activeSkillToolAvailability = hydratedSkillState.activeSkillToolAvailability;
-      let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
-      const applySuccessfulSkillResult = (result: unknown): void => {
-        const next = applySkillActivationResult({
-          activeSkillId,
-          activeSkillPolicy,
-          activeSkillToolAvailability,
-          activeSkillDelegationOverrides,
-        }, result);
-        activeSkillId = next.activeSkillId;
-        activeSkillPolicy = next.activeSkillPolicy;
-        activeSkillToolAvailability = next.activeSkillToolAvailability;
-        activeSkillDelegationOverrides = next.activeSkillDelegationOverrides;
-      };
-      let hasSubmittedFormInputInLoop = hasSubmittedFormInputResult(currentMessages) ||
-        runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true;
+      const skillState = AgentLoopSkillState.hydrate(currentMessages, runtimeContext);
       const hasToolReplacements = toolReplacements !== undefined;
       const initialToolExposureCheckpoint = hasToolReplacements
         ? undefined
@@ -1126,17 +1105,17 @@ export class AgentRuntime {
         throwIfAborted(abortSignal);
         this.status = "thinking";
         addSpanEvent(loopSpan, "step_start", { step });
-        const stepRuntimeContext = hasSubmittedFormInputInLoop
+        const stepRuntimeContext = skillState.hasSubmittedFormInput
           ? markSubmittedFormInputRuntimeContext(currentRuntimeContext)
           : currentRuntimeContext;
 
         const preparedStep = await prepareAgentRuntimeStep({
           agentId: this.id,
-          activeSkillId: hasToolReplacements ? undefined : activeSkillId,
-          activeSkillPolicy: hasToolReplacements ? undefined : activeSkillPolicy,
+          activeSkillId: hasToolReplacements ? undefined : skillState.activeSkillId,
+          activeSkillPolicy: hasToolReplacements ? undefined : skillState.activeSkillPolicy,
           activeSkillToolAvailability: hasToolReplacements
             ? undefined
-            : activeSkillToolAvailability,
+            : skillState.activeSkillToolAvailability,
           allowedRemoteToolNames,
           config: runtimeStepConfig,
           effectiveModel,
@@ -1319,7 +1298,7 @@ export class AgentRuntime {
 
         this.status = "tool_execution";
         addSpanEvent(loopSpan, "tool_execution_start", { count: response.toolCalls.length });
-        const mustLoadSkillFirstForStep = !activeSkillPolicy &&
+        const mustLoadSkillFirstForStep = !skillState.activeSkillPolicy &&
           response.toolCalls.some((tc) => tc.toolName === LOAD_SKILL_TOOL_ID);
 
         for (const tc of response.toolCalls) {
@@ -1478,12 +1457,12 @@ export class AgentRuntime {
 
             const policyCheck = enforceSkillPolicy(
               tc.toolName,
-              activeSkillPolicy,
+              skillState.activeSkillPolicy,
               mustLoadSkillFirstForStep,
               {
-                activeSkillId,
-                hasSubmittedFormInput: hasSubmittedFormInputInLoop,
-                skillToolAvailability: activeSkillToolAvailability,
+                activeSkillId: skillState.activeSkillId,
+                hasSubmittedFormInput: skillState.hasSubmittedFormInput,
+                skillToolAvailability: skillState.activeSkillToolAvailability,
                 toolInput: tc.input,
               },
             );
@@ -1522,7 +1501,7 @@ export class AgentRuntime {
               toolCall.args = applySkillDelegationOverridesToToolInput(
                 tc.toolName,
                 toolCall.args,
-                hasToolReplacements ? undefined : activeSkillDelegationOverrides,
+                hasToolReplacements ? undefined : skillState.activeSkillDelegationOverrides,
               );
               const executionContext = {
                 toolCallId: tc.toolCallId,
@@ -1583,15 +1562,14 @@ export class AgentRuntime {
                 }
                 // Track skill policy from successful load_skill results
                 if (tc.toolName === LOAD_SKILL_TOOL_ID) {
-                  applySuccessfulSkillResult(result);
+                  skillState.applySuccessfulResult(result);
                 }
-                activeSkillPolicy = removeFormInputAfterSubmission(
+                const submittedFormInput = isSubmittedFormInputExecutionResult(
                   tc.toolName,
                   result,
-                  activeSkillPolicy,
                 );
-                if (isSubmittedFormInputExecutionResult(tc.toolName, result)) {
-                  hasSubmittedFormInputInLoop = true;
+                skillState.markFormInputSubmitted(tc.toolName, result, submittedFormInput);
+                if (submittedFormInput) {
                   currentRuntimeContext = markSubmittedFormInputRuntimeContext(
                     currentRuntimeContext,
                   );
@@ -1690,25 +1668,7 @@ export class AgentRuntime {
     }
 
     // Request-scoped skill policy (not class-level mutable state)
-    const hydratedSkillState = hydrateActiveSkillStateFromMessages(currentMessages);
-    let activeSkillId = hydratedSkillState.activeSkillId;
-    let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
-    let activeSkillToolAvailability = hydratedSkillState.activeSkillToolAvailability;
-    let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
-    const applySuccessfulSkillResult = (result: unknown): void => {
-      const next = applySkillActivationResult({
-        activeSkillId,
-        activeSkillPolicy,
-        activeSkillToolAvailability,
-        activeSkillDelegationOverrides,
-      }, result);
-      activeSkillId = next.activeSkillId;
-      activeSkillPolicy = next.activeSkillPolicy;
-      activeSkillToolAvailability = next.activeSkillToolAvailability;
-      activeSkillDelegationOverrides = next.activeSkillDelegationOverrides;
-    };
-    let hasSubmittedFormInputInLoop = hasSubmittedFormInputResult(currentMessages) ||
-      runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true;
+    const skillState = AgentLoopSkillState.hydrate(currentMessages, runtimeContext);
     let finalFinishReason: string | undefined;
     let latestAssistantText = "";
     const initialToolExposureCheckpoint = getRuntimeToolExposureCheckpoint(this.config);
@@ -1737,15 +1697,15 @@ export class AgentRuntime {
       throwIfAborted(abortSignal);
       sendSSE(controller, encoder, { type: "step-start" });
       const currentStepToolResults = new Map<string, ToolResultPart>();
-      const stepRuntimeContext = hasSubmittedFormInputInLoop
+      const stepRuntimeContext = skillState.hasSubmittedFormInput
         ? markSubmittedFormInputRuntimeContext(currentRuntimeContext)
         : currentRuntimeContext;
 
       const preparedStep = await prepareAgentRuntimeStep({
         agentId: this.id,
-        activeSkillId,
-        activeSkillPolicy,
-        activeSkillToolAvailability,
+        activeSkillId: skillState.activeSkillId,
+        activeSkillPolicy: skillState.activeSkillPolicy,
+        activeSkillToolAvailability: skillState.activeSkillToolAvailability,
         allowedRemoteToolNames,
         config: runtimeStepConfig,
         effectiveModel,
@@ -1923,7 +1883,7 @@ export class AgentRuntime {
 
       this.status = "tool_execution";
       const streamedToolCalls = Array.from(state.toolCalls.values());
-      const mustLoadSkillFirstForStep = !activeSkillPolicy &&
+      const mustLoadSkillFirstForStep = !skillState.activeSkillPolicy &&
         streamedToolCalls.some((tc) => tc.name === LOAD_SKILL_TOOL_ID);
 
       for (const tc of streamedToolCalls) {
@@ -1986,15 +1946,14 @@ export class AgentRuntime {
               agentWriteFinalResponseToolGuardEnabled = true;
             }
             if (tc.name === LOAD_SKILL_TOOL_ID) {
-              applySuccessfulSkillResult(matchingResult.output);
+              skillState.applySuccessfulResult(matchingResult.output);
             }
-            activeSkillPolicy = removeFormInputAfterSubmission(
+            const submittedFormInput = isSubmittedFormInputExecutionResult(
               tc.name,
               matchingResult.output,
-              activeSkillPolicy,
             );
-            if (isSubmittedFormInputExecutionResult(tc.name, matchingResult.output)) {
-              hasSubmittedFormInputInLoop = true;
+            skillState.markFormInputSubmitted(tc.name, matchingResult.output, submittedFormInput);
+            if (submittedFormInput) {
               currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
             }
           }
@@ -2012,15 +1971,14 @@ export class AgentRuntime {
               agentWriteFinalResponseToolGuardEnabled = true;
             }
             if (tc.name === LOAD_SKILL_TOOL_ID) {
-              applySuccessfulSkillResult(persistedResult.result);
+              skillState.applySuccessfulResult(persistedResult.result);
             }
-            activeSkillPolicy = removeFormInputAfterSubmission(
+            const submittedFormInput = isSubmittedFormInputExecutionResult(
               tc.name,
               persistedResult.result,
-              activeSkillPolicy,
             );
-            if (isSubmittedFormInputExecutionResult(tc.name, persistedResult.result)) {
-              hasSubmittedFormInputInLoop = true;
+            skillState.markFormInputSubmitted(tc.name, persistedResult.result, submittedFormInput);
+            if (submittedFormInput) {
               currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
             }
           }
@@ -2133,12 +2091,12 @@ export class AgentRuntime {
         }
         const policyCheck = enforceSkillPolicy(
           tc.name,
-          activeSkillPolicy,
+          skillState.activeSkillPolicy,
           mustLoadSkillFirstForStep,
           {
-            activeSkillId,
-            hasSubmittedFormInput: hasSubmittedFormInputInLoop,
-            skillToolAvailability: activeSkillToolAvailability,
+            activeSkillId: skillState.activeSkillId,
+            hasSubmittedFormInput: skillState.hasSubmittedFormInput,
+            skillToolAvailability: skillState.activeSkillToolAvailability,
             toolInput: toolCall.args,
           },
         );
@@ -2160,7 +2118,7 @@ export class AgentRuntime {
           toolCall.args = applySkillDelegationOverridesToToolInput(
             tc.name,
             toolCall.args,
-            activeSkillDelegationOverrides,
+            skillState.activeSkillDelegationOverrides,
           );
 
           callbacks?.onToolCall?.(toolCall);
@@ -2204,15 +2162,11 @@ export class AgentRuntime {
           if (resultError === undefined) {
             // Track skill policy from successful load_skill results
             if (tc.name === LOAD_SKILL_TOOL_ID) {
-              applySuccessfulSkillResult(result);
+              skillState.applySuccessfulResult(result);
             }
-            activeSkillPolicy = removeFormInputAfterSubmission(
-              tc.name,
-              result,
-              activeSkillPolicy,
-            );
-            if (isSubmittedFormInputExecutionResult(tc.name, result)) {
-              hasSubmittedFormInputInLoop = true;
+            const submittedFormInput = isSubmittedFormInputExecutionResult(tc.name, result);
+            skillState.markFormInputSubmitted(tc.name, result, submittedFormInput);
+            if (submittedFormInput) {
               currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
             }
             if (shouldHideProjectToolAfterAgentWriteSuccess(tc.name)) {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1404,6 +1404,12 @@ export class AgentRuntime {
               return;
             }
 
+            // Provider-executed tools (web_search/web_fetch) return results without skill-state
+            // transitions. Unlike locally-executed paths, load_skill and form_input are client-side
+            // function tools that the runtime executes itself, so they never appear in
+            // response.toolResults. This branch mirrors the streaming loop's providerExecuted===true
+            // path, not the locally-executed ones. If provider-executed tools expand beyond web_*,
+            // the transitions (skillState.applySuccessfulResult, markFormInputSubmitted) would apply.
             if (generatedToolResult && !hasToolReplacements) {
               if (generatedToolResult.providerExecuted === true) {
                 await traceProviderExecutedTool({

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1430,27 +1430,11 @@ export class AgentRuntime {
               if (toolCall.error !== undefined) {
                 setOtelActiveSpanErrorStatus(toolCall.error);
               }
-              if (generatedToolResult.isError !== true) {
-                if (shouldHideProjectToolAfterAgentWriteSuccess(tc.toolName)) {
-                  agentWriteFinalResponseToolGuardEnabled = true;
-                }
-                if (tc.toolName === LOAD_SKILL_TOOL_ID) {
-                  skillState.applySuccessfulResult(generatedToolResult.result);
-                }
-                const submittedFormInput = isSubmittedFormInputExecutionResult(
-                  tc.toolName,
-                  generatedToolResult.result,
-                );
-                skillState.markFormInputSubmitted(
-                  tc.toolName,
-                  generatedToolResult.result,
-                  submittedFormInput,
-                );
-                if (submittedFormInput) {
-                  currentRuntimeContext = markSubmittedFormInputRuntimeContext(
-                    currentRuntimeContext,
-                  );
-                }
+              if (
+                generatedToolResult.isError !== true &&
+                shouldHideProjectToolAfterAgentWriteSuccess(tc.toolName)
+              ) {
+                agentWriteFinalResponseToolGuardEnabled = true;
               }
               setSpanAttributes(
                 toolSpan,


### PR DESCRIPTION
Gives the request-scoped active-skill policy one owner, so a skill-policy fix stops having to be hand-applied to two agent loops. **Zero behaviour change.**

## The defect

`src/agent/runtime/index.ts` contains two agent loops — `executeAgentLoop` and `executeAgentLoopStreaming`. Both opened with a byte-identical 18-line skill-policy block: `hydrateActiveSkillStateFromMessages`, four `activeSkill*` `let` bindings, and the entire `applySuccessfulSkillResult` closure. A second duplicated transition (`removeFormInputAfterSubmission` + a `hasSubmittedFormInput` flag) appeared at 4 sites.

So a skill-policy bug fix had to be applied twice, with nothing enforcing the copies stayed in sync. That is the defect this PR removes.

## The change

New `src/agent/runtime/agent-loop-skill-state.ts` — **the single owner of** the request-scoped active-skill policy for one agent loop attempt: which skill is active, what it permits, and how that changes when a skill activates or a form input is submitted.

Both loops now construct one `AgentLoopSkillState` and call methods on it. `index.ts` is **net −46 lines**. `CONTEXT.md` records the domain term.

The state is a class with mutable fields, deliberately: it is read ~23 times in one loop and ~26 in the other and is mutated in place, so an immutable snapshot would have changed semantics. There is no module-level or static mutable state — the original code's "Request-scoped skill policy (not class-level mutable state)" guarantee is preserved, and the tests prove two instances are independent behaviourally rather than asserting it in prose.

## What this PR deliberately does NOT do

An earlier plan proposed unifying the two loops into one shared step function. I measured them and rejected that:

- 630 and 644 lines, **only 251 shared (~40%)**; largest divergence hunks are 206-vs-291 and 267-vs-219 lines.
- They have **different feature sets**, not just different output shapes. `executeAgentLoop` supports `toolReplacements`, forking ~40 lines of config resolution with no streaming counterpart. Streaming carries `controller`/`encoder`/`callbacks`/`textPartId` plumbing with no non-streaming counterpart. Non-streaming wraps in `withSpan("agent.execution_loop")`; streaming does not. The parameter orders even differ — `abortSignal` and `temperatureModelString` are swapped.

Unifying those is a redesign reconciling two feature sets, not a refactor — and the riskiest logic (skill-policy edge cases) sits in the shared part. The duplication was the defect; the loops being separate was not.

## Evidence

- `deno task test:unit`: baseline **3801 passed / 27907 steps / 0 failed** → **3802 / 27922 / 0 failed**. Delta is exactly +1 file / +15 steps, matching the new test file 1:1 — zero regressions across the 66 co-located test files in `src/agent/runtime/`.
- `deno task verify:quick` exit 0. `deno check src/agent/index.ts` clean.
- Every call site was enumerated in the base file and mapped one-to-one to its replacement: 4 skill-result + 4 form-input sites in, 4 and 4 out (non-streaming 1+1, streaming 3+3). Zero surviving local bindings of any of the five identifiers — verified by grep.
- `docs/api-reference/veryfront/agent.md` is a single line-pin shift, regenerated with Deno 2.7.7 matching CI's pin.

## Reviewer note: why `markFormInputSubmitted` takes a boolean

It takes a precomputed `submitted` flag rather than recomputing it, because the caller's predicate is deliberately **broader** than the one applied internally, and the two genuinely disagree:

- Callers use `isSubmittedFormInputExecutionResult` — recurses into nested objects to depth 3, ignores error markers.
- `removeFormInputAfterSubmission` internally applies `isSubmittedFormInputResult` — shallow, only unwraps `response`/`output`, bails on an error marker.

They differ on inputs like `{ data: { submitted: true } }`. So the flag cannot be recomputed inside the method without changing behaviour. The doc comment says so explicitly, to stop a future caller from "simplifying" it.

## Known follow-ups (not blocking)

- `AgentLoopSkillState`'s fields are public and mutable, so the single-owner guarantee is convention-only today. No caller bypasses the transitions (verified). Private fields + getters would be the hardening if a third consumer appears.
- `hasSubmittedFormInputResult(messages) || runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true` now lives in two places (`hydrate` and `filterToolsAfterSubmittedFormInput`). This PR reduced it from three copies to two; a one-line exported helper would finish it.
- `readApiErrorMessage` (duplicated across two runtime clients) and `isWithinJsonSizeLimit` (4 copies) remain — separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent skill-state handling across standard and streaming agent interactions.
  * Skill activation, tool availability, delegation rules, and form submissions now remain synchronized throughout an interaction.

* **Documentation**
  * Added documentation describing how skill state is maintained and updated.
  * Corrected an API reference source link.

* **Tests**
  * Added comprehensive coverage for skill activation, policy updates, form submissions, invalid activations, and concurrent interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->