### PR TITLE
test(routing): pin the prepared route entry points production actually calls

### DIFF
--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -1,11 +1,15 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   __serializeRequestForTests,
   executeAppRoute as executeAppRouteRaw,
   executePagesRoute as executePagesRouteRaw,
+  executePreparedAppRoute,
+  executePreparedPagesRoute,
   type ExecuteRouteOptions,
+  type PreparedRouteExecutionOptions,
+  resolvePreparedRouteMethods,
 } from "./route-executor.ts";
 import type { RouteMatch } from "./api-route-matcher.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -133,6 +137,19 @@ async function isolatedRouteOptions(
     isLocalProject: false,
     preparedModule: await prepareModuleSource(source),
     executionScopeId,
+  };
+}
+
+async function preparedRouteOptions(
+  source: string,
+  executionScopeId: string,
+): Promise<PreparedRouteExecutionOptions> {
+  return {
+    executionScopeId,
+    module: await prepareModuleSource(source),
+    modulePath: "/tmp/test/handler.ts",
+    projectDir: "/tmp/test",
+    isLocalProject: false,
   };
 }
 
@@ -944,6 +961,150 @@ describe("routing/api/route-executor", () => {
 
       assertEquals(response.status, 204);
       assertEquals(response.body, null);
+    });
+  });
+
+  describe("executePreparedAppRoute() / executePreparedPagesRoute() / resolvePreparedRouteMethods()", () => {
+    afterEach(async () => {
+      Deno.env.delete("WORKER_ISOLATION_ENABLED");
+      Deno.env.delete("WORKER_ISOLATION_API");
+      await __resetPoolForTests();
+    });
+
+    it("executes a prepared app route module in the worker and returns its response", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const options = await preparedRouteOptions(
+        "export function GET(_req, ctx) { return Response.json({ id: ctx.params.id }); }",
+        "prepared-app-happy",
+      );
+
+      const response = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          executePreparedAppRoute(
+            new Request("http://localhost/api/users/42", { method: "GET" }),
+            makeMatch("/api/users/[id]", "/tmp/test/handler.ts", { id: "42" }),
+            "/api/users/42",
+            options,
+          ),
+      );
+
+      assertEquals(response.status, 200);
+      assertStringIncludes(response.headers.get("content-type") ?? "", "application/json");
+      assertEquals(await response.json(), { id: "42" });
+    });
+
+    it("returns a 500 error response when the prepared app route handler throws", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const options = await preparedRouteOptions(
+        "export function GET() { throw new Error('prepared app boom'); }",
+        "prepared-app-error",
+      );
+
+      const response = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          executePreparedAppRoute(
+            new Request("http://localhost/api/test", { method: "GET" }),
+            makeMatch(),
+            "/api/test",
+            options,
+          ),
+      );
+
+      assertEquals(response.status, 500);
+    });
+
+    it("executes a prepared pages route module in the worker and returns its response", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const options = await preparedRouteOptions(
+        "export function GET(ctx) { return ctx.text('prepared pages ok'); }",
+        "prepared-pages-happy",
+      );
+
+      const response = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          executePreparedPagesRoute(
+            new Request("http://localhost/api/test", { method: "GET" }),
+            makeMatch(),
+            "/api/test",
+            options,
+          ),
+      );
+
+      assertEquals(response.status, 200);
+      assertEquals(await response.text(), "prepared pages ok");
+    });
+
+    it("returns a 500 error response when the prepared pages route handler throws", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const options = await preparedRouteOptions(
+        "export function GET() { throw new Error('prepared pages boom'); }",
+        "prepared-pages-error",
+      );
+
+      const response = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          executePreparedPagesRoute(
+            new Request("http://localhost/api/test", { method: "GET" }),
+            makeMatch(),
+            "/api/test",
+            options,
+          ),
+      );
+
+      assertEquals(response.status, 500);
+    });
+
+    it("resolves the exported HTTP methods for a prepared route", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const options = await preparedRouteOptions(
+        "export function GET() {} export function POST() {}",
+        "prepared-methods-happy",
+      );
+
+      const methods = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () => resolvePreparedRouteMethods(undefined, options),
+      );
+
+      assertEquals(methods, ["GET", "HEAD", "POST", "OPTIONS"]);
+    });
+
+    it("rejects when the prepared module has no callable route export", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const options = await preparedRouteOptions(
+        "export const notARouteHandler = 1;",
+        "prepared-methods-error",
+      );
+
+      await assertRejects(
+        () =>
+          runWithExactSourceIntegrationPolicy(
+            normalizeSourceIntegrationPolicy({ allow: {} }),
+            () => resolvePreparedRouteMethods(undefined, options),
+          ),
+      );
     });
   });
 });

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -132,8 +132,8 @@ async function isolatedRouteOptions(
   executionScopeId: string,
 ): Promise<ExecuteRouteOptions> {
   return {
-    modulePath: "/tmp/test/handler.ts",
-    projectDir: "/tmp/test",
+    modulePath: "/test/project/handler.ts",
+    projectDir: "/test/project",
     isLocalProject: false,
     preparedModule: await prepareModuleSource(source),
     executionScopeId,
@@ -147,8 +147,8 @@ async function preparedRouteOptions(
   return {
     executionScopeId,
     module: await prepareModuleSource(source),
-    modulePath: "/tmp/test/handler.ts",
-    projectDir: "/tmp/test",
+    modulePath: "/test/project/handler.ts",
+    projectDir: "/test/project",
     isLocalProject: false,
   };
 }
@@ -986,7 +986,7 @@ describe("routing/api/route-executor", () => {
         () =>
           executePreparedAppRoute(
             new Request("http://localhost/api/users/42", { method: "GET" }),
-            makeMatch("/api/users/[id]", "/tmp/test/handler.ts", { id: "42" }),
+            makeMatch("/api/users/[id]", "/test/project/handler.ts", { id: "42" }),
             "/api/users/42",
             options,
           ),

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -1104,6 +1104,8 @@ describe("routing/api/route-executor", () => {
             normalizeSourceIntegrationPolicy({ allow: {} }),
             () => resolvePreparedRouteMethods(undefined, options),
           ),
+        Error,
+        "Prepared API route module has no callable route export",
       );
     });
   });


### PR DESCRIPTION
Adds characterization tests for the route-execution entry points production actually calls. **Tests only — no source changes.**

## The gap

`src/routing/api/handler.ts` — the production HTTP path — calls `executePreparedAppRoute` (line ~345) and `executePreparedPagesRoute` (line ~352).

`src/routing/api/route-executor.test.ts` (949 lines, 31 cases) contained **zero** references to either, or to `resolvePreparedRouteMethods`. It exercised the older `executeAppRoute`/`executePagesRoute` entry points, which take an options bag and branch internally into the same isolated code path.

So there was no test at the seam between what is tested and what production calls.

That matters here more than usual: `route-executor.ts` gates execution of arbitrary user-project code, carries deliberate prototype-pollution hardening (captured primordials at the top of the file), and changed as recently as #3428. Whoever touches it next deserves a fence at the production entry point.

## What was added

6 cases in one new describe block, reusing the file's existing harness exactly — same `prepareModuleSource` fixture shape as `isolatedRouteOptions`, same `runWithExactSourceIntegrationPolicy` + `normalizeSourceIntegrationPolicy` wrapping, same `afterEach` env cleanup + `__resetPoolForTests()`, real `WorkerPool`, no fakes and no sanitizer overrides.

- `executePreparedAppRoute` — happy path (asserts status, content-type, JSON body, and that `ctx.params.id` round-trips through the handler, pinning param normalization rather than just plumbing) and handler-throw → 500.
- `executePreparedPagesRoute` — happy path (status + body) and handler-throw → 500.
- `resolvePreparedRouteMethods` — a module exporting GET+POST resolving to `["GET","HEAD","POST","OPTIONS"]`, and a module with no callable route export rejecting.

## Evidence

- `deno task test:unit`: **3801 passed / 27907 steps → 3801 / 27914**, exactly +7 steps (6 cases + 1 describe), zero regressions.
- Target file directly: green.
- `deno task verify:quick` exit 0; `deno lint` clean.
- Commit touches only `src/routing/api/route-executor.test.ts`.

## On the ordering assertion

`["GET","HEAD","POST","OPTIONS"]` was verified against the source rather than assumed. `resolveExecutableRouteMethods` (`src/routing/api/route-methods.ts:77`) collects `["GET","POST"]` from the module's exports, adds `HEAD` (because GET is present) and `OPTIONS` (framework default), then re-sorts into the `STANDARD_ROUTE_METHODS` canonical order — yielding exactly that sequence. The worker's `handleInspectApiRouteMethods` calls the same function, so the expectation pins real canonical behaviour rather than locking in a bug.

The rejection case likewise asserts the specific surfaced failure, not merely that *something* rejected — a bare `assertRejects` would have passed under an unrelated worker or fixture error, which would have read as coverage without being any.

## Note: `resolvePreparedRouteMethods` is dead outside tests

Repo-wide grep finds only its own declaration (`route-executor.ts:1183`) and these tests — no production consumer; `handler.ts` calls only the two execute functions. It is still exported, so pinning it costs nothing and gives a fence if it is later wired into OPTIONS handling. **Kept deliberately.** Whether to delete it is a separate decision, not folded into a tests-only change.

## Known residual gap (not blocking)

`isLocalProject` is hardcoded `false` in the new options helper, so a regression that stopped threading `isLocalProject` correctly would not be caught by these cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for prepared application and page route execution.
  * Verified successful responses, error handling, and HTTP method resolution.
  * Added checks for rejecting routes without a callable export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->