### PR TITLE
test(chat): cover the tool-replay reconciliation algorithm directly

### DIFF
--- a/src/chat/tool-replay-reconciliation.test.ts
+++ b/src/chat/tool-replay-reconciliation.test.ts
@@ -212,15 +212,20 @@ describe("tool-replay-reconciliation", () => {
       "streaming",
     );
     const mismatchedResult = rawToolResult("tool-1", { data: [] }, "github__list_prs");
+    const controlCall = rawToolCall("tool-2", "github__list_prs", { state: "open" });
+    const controlResult = rawToolResult("tool-2", { data: [] }, "github__list_prs");
 
     const matches = findProviderVisibleToolReplayMatches([
-      assistantMessage([call]),
-      toolMessage([mismatchedResult]),
+      assistantMessage([call, controlCall]),
+      toolMessage([mismatchedResult, controlResult]),
     ]);
 
     assertEquals(matches.matchedToolCallParts.has(call), false);
     assertEquals(matches.matchedToolResultParts.has(mismatchedResult), false);
     assertEquals(matches.preservedTransientToolParts.has(call), false);
+    // Positive control: a compatible pair in the same history really is
+    // matched, proving the fixture was processed rather than short-circuited.
+    assertEquals(matches.matchedToolCallParts.has(controlCall), true);
   });
 
   it("leaves a pending call with no result unmatched and unpreserved", () => {
@@ -275,36 +280,86 @@ describe("tool-replay-reconciliation", () => {
     assertEquals(matches.matchedToolResultParts.has(secondResult), false);
   });
 
-  it("drops earlier-message pending calls once a user message intervenes", () => {
-    const staleCall = dynamicToolCall(
-      "duplicate-call",
-      "github__get_pr_diff",
-      { pull_number: 1 },
-      "streaming",
-    );
-    const freshCall = dynamicToolCall(
-      "duplicate-call",
-      "github__get_pr_diff",
-      { pull_number: 2 },
-      "output-available",
-      { files: ["new.ts"] },
-    );
+  it(
+    "supersedes an earlier same-id call via toolCallsById even once it's been evicted from the pending queue",
+    () => {
+      // This pins toolCallsById-based supersession only: staleCall and
+      // freshCall share a toolCallId, so removePendingCallsWithId's own
+      // id-based eviction removes staleCall from pendingCalls when freshCall
+      // is processed, regardless of whether any earlier-message/user-turn
+      // boundary flush ran. And freshCall is self-contained, so no result
+      // ever needs to match against pendingCalls. Neither of those redundant
+      // paths exercises the user-message boundary itself — see the next case
+      // for a fixture that actually discriminates that behavior.
+      const staleCall = dynamicToolCall(
+        "duplicate-call",
+        "github__get_pr_diff",
+        { pull_number: 1 },
+        "streaming",
+      );
+      const freshCall = dynamicToolCall(
+        "duplicate-call",
+        "github__get_pr_diff",
+        { pull_number: 2 },
+        "output-available",
+        { files: ["new.ts"] },
+      );
 
-    const matches = findProviderVisibleToolReplayMatches([
-      assistantMessage([staleCall], "assistant-1"),
-      userMessage("continue with a different PR", "user-2"),
-      assistantMessage([freshCall], "assistant-2"),
-    ]);
+      const matches = findProviderVisibleToolReplayMatches([
+        assistantMessage([staleCall], "assistant-1"),
+        userMessage("continue with a different PR", "user-2"),
+        assistantMessage([freshCall], "assistant-2"),
+      ]);
 
-    // The stale transient call from before the user turn is never resolved
-    // (its slot was dropped, not matched), so it is not preserved.
-    assertEquals(matches.preservedTransientToolParts.has(staleCall), false);
-    assertEquals(matches.matchedToolCallParts.has(staleCall), false);
-    // The fresh occurrence is self-contained and needs no separate match, but
-    // supersession still tracks it via toolCallsById independent of
-    // pendingCalls eviction: the stale call is superseded even though it was
-    // already dropped from the pending queue by the user-message boundary.
-    assertEquals(matches.supersededToolCallParts.has(staleCall), true);
-    assertEquals(matches.matchedToolCallParts.has(freshCall), false);
-  });
+      // The stale transient call from before the user turn is never resolved
+      // (its slot was dropped, not matched), so it is not preserved.
+      assertEquals(matches.preservedTransientToolParts.has(staleCall), false);
+      assertEquals(matches.matchedToolCallParts.has(staleCall), false);
+      // supersession tracks it via toolCallsById independent of pendingCalls
+      // eviction: the stale call is superseded even though it was already
+      // dropped from the pending queue by the same-id removal above.
+      assertEquals(matches.supersededToolCallParts.has(staleCall), true);
+      assertEquals(matches.matchedToolCallParts.has(freshCall), false);
+    },
+  );
+
+  it(
+    "ends a pending call's window at a user message, so a later result can't resolve it",
+    () => {
+      // Unlike the case above, staleCall and lateResult share a toolCallId
+      // that appears nowhere else, so removePendingCallsWithId's same-id
+      // eviction can't be doing the work, and lateResult actually needs
+      // pendingCalls to still hold an entry to match against. If user text
+      // stopped counting as provider-visible content, staleCall would
+      // survive in pendingCalls and lateResult would match it, flipping all
+      // three assertions below to true. (A mutant that deletes only the
+      // immediate origin-filtered flush call inside the visible-content
+      // branch is *not* caught here: for a callless user message, the
+      // end-of-message-loop `pendingCalls.splice(0,
+      // pendingCountBeforeSameMessageVisibleContent)` fallback evicts the
+      // exact same entries regardless, since everything in pendingCalls
+      // before such a message is by construction from an earlier message.)
+      const staleCall = dynamicToolCall(
+        "only-call",
+        "github__get_pr_diff",
+        { pull_number: 1 },
+        "streaming",
+      );
+      const lateResult = rawToolResult(
+        "only-call",
+        { files: ["late.ts"] },
+        "github__get_pr_diff",
+      );
+
+      const matches = findProviderVisibleToolReplayMatches([
+        assistantMessage([staleCall], "assistant-1"),
+        userMessage("different question", "user-2"),
+        assistantMessage([lateResult], "assistant-3"),
+      ]);
+
+      assertEquals(matches.matchedToolCallParts.has(staleCall), false);
+      assertEquals(matches.preservedTransientToolParts.has(staleCall), false);
+      assertEquals(matches.matchedToolResultParts.has(lateResult), false);
+    },
+  );
 });

--- a/src/chat/tool-replay-reconciliation.test.ts
+++ b/src/chat/tool-replay-reconciliation.test.ts
@@ -5,6 +5,67 @@ import {
   findProviderVisibleToolReplayMatches,
   isTransientToolState,
 } from "./tool-replay-reconciliation.ts";
+import type { ChatProviderModelInputMessage, ChatProviderModelInputPart } from "./conversation.ts";
+
+function assistantMessage(
+  parts: ChatProviderModelInputPart[],
+  id = "assistant-1",
+): ChatProviderModelInputMessage {
+  return { id, role: "assistant", parts };
+}
+
+function toolMessage(
+  parts: ChatProviderModelInputPart[],
+  id = "assistant-1:tool",
+): ChatProviderModelInputMessage {
+  return { id, role: "tool", parts };
+}
+
+function userMessage(text: string, id = "user-1"): ChatProviderModelInputMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] };
+}
+
+function rawToolCall(
+  toolCallId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+  state = "completed",
+): ChatProviderModelInputPart {
+  return {
+    type: "tool_call",
+    id: toolCallId,
+    name: toolName,
+    input,
+    state,
+  } as ChatProviderModelInputPart;
+}
+
+function rawToolResult(
+  toolCallId: string,
+  output: unknown,
+  toolName?: string,
+): ChatProviderModelInputPart {
+  return (toolName
+    ? { type: "tool_result", tool_call_id: toolCallId, tool_name: toolName, output }
+    : { type: "tool_result", tool_call_id: toolCallId, output }) as ChatProviderModelInputPart;
+}
+
+function dynamicToolCall(
+  toolCallId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+  state: string,
+  output?: unknown,
+): ChatProviderModelInputPart {
+  return (output === undefined ? { type: "dynamic-tool", toolName, toolCallId, input, state } : {
+    type: "dynamic-tool",
+    toolName,
+    toolCallId,
+    input,
+    state,
+    output,
+  }) as ChatProviderModelInputPart;
+}
 
 describe("tool-replay-reconciliation", () => {
   it("classifies in-flight states as transient", () => {
@@ -20,5 +81,230 @@ describe("tool-replay-reconciliation", () => {
     assertEquals(typeof matches.matchedToolResultNames.get, "function");
     assertEquals(matches.matchedToolCallParts.has({}), false);
     assertEquals(matches.supersededToolResultParts.has({}), false);
+  });
+
+  it("matches a simple call/result pair and records the result's tool name", () => {
+    const call = rawToolCall("tc-1", "bash", { command: "ls" });
+    const result = rawToolResult("tc-1", "ok", "bash");
+    const matches = findProviderVisibleToolReplayMatches([
+      assistantMessage([call]),
+      toolMessage([result]),
+    ]);
+
+    assertEquals(matches.matchedToolCallParts.has(call), true);
+    assertEquals(matches.matchedToolResultParts.has(result), true);
+    assertEquals(matches.matchedToolResultNames.get(result), "bash");
+    // A non-transient, once-only occurrence is neither preserved-as-transient,
+    // superseded, nor a batch start.
+    assertEquals(matches.preservedTransientToolParts.has(call), false);
+    assertEquals(matches.supersededToolCallParts.has(call), false);
+    assertEquals(matches.supersededToolResultParts.has(result), false);
+    assertEquals(matches.toolCallPartsStartingNewBatch.has(call), false);
+  });
+
+  it("discriminates by part object identity, not structural equality", () => {
+    // THE CRITICAL PROPERTY: matching keys every collection off the exact part
+    // object seen during the walk. A structurally identical clone that was
+    // never part of the actual history must read as absent, even though it
+    // would satisfy any value-based equality check.
+    const call = rawToolCall("tc-1", "bash", { command: "ls" });
+    const result = rawToolResult("tc-1", "ok", "bash");
+    const matches = findProviderVisibleToolReplayMatches([
+      assistantMessage([call]),
+      toolMessage([result]),
+    ]);
+
+    const equalButDistinctCall = { ...call };
+    const equalButDistinctResult = { ...result };
+
+    assertEquals(matches.matchedToolCallParts.has(call), true);
+    assertEquals(matches.matchedToolCallParts.has(equalButDistinctCall), false);
+    assertEquals(matches.matchedToolResultParts.has(result), true);
+    assertEquals(matches.matchedToolResultParts.has(equalButDistinctResult), false);
+    assertEquals(matches.matchedToolResultNames.get(result), "bash");
+    assertEquals(matches.matchedToolResultNames.get(equalButDistinctResult), undefined);
+  });
+
+  it("supersedes an earlier call/result occurrence when a later same-id call wins the match", () => {
+    // Core of the algorithm: two split call/result pairs share a toolCallId
+    // across four messages. The later occurrence is authoritative; the
+    // earlier call AND its already-matched result are both marked superseded
+    // (while remaining "matched", since they were matched before losing).
+    const call1 = rawToolCall("dup", "github__get_pr_diff", { pull_number: 1 });
+    const result1 = rawToolResult("dup", { files: ["old.ts"] }, "github__get_pr_diff");
+    const call2 = rawToolCall("dup", "github__get_pr_diff", { pull_number: 2 });
+    const result2 = rawToolResult("dup", { files: ["new.ts"] }, "github__get_pr_diff");
+
+    const matches = findProviderVisibleToolReplayMatches([
+      assistantMessage([call1], "assistant-1"),
+      toolMessage([result1], "assistant-1:tool"),
+      assistantMessage([call2], "assistant-2"),
+      toolMessage([result2], "assistant-2:tool"),
+    ]);
+
+    assertEquals(matches.matchedToolCallParts.has(call1), true);
+    assertEquals(matches.supersededToolCallParts.has(call1), true);
+    assertEquals(matches.matchedToolResultParts.has(result1), true);
+    assertEquals(matches.supersededToolResultParts.has(result1), true);
+
+    assertEquals(matches.matchedToolCallParts.has(call2), true);
+    assertEquals(matches.supersededToolCallParts.has(call2), false);
+    assertEquals(matches.matchedToolResultParts.has(result2), true);
+    assertEquals(matches.supersededToolResultParts.has(result2), false);
+  });
+
+  it("supersedes an earlier self-contained call occurrence when a later same-id self-contained call lands", () => {
+    // The *other* supersede path: two self-contained occurrences (their own
+    // output, no separate result part) share a toolCallId in one message.
+    // Neither ever enters matchedToolCallParts (that set is only populated by
+    // the pendingCalls/result-matching path), but the earlier one is still
+    // marked superseded so it won't render.
+    const call1 = dynamicToolCall("dup", "github__list_prs", { page: 1 }, "output-available", {
+      data: [{ number: 3092 }],
+    });
+    const call2 = dynamicToolCall("dup", "github__list_prs", { page: 2 }, "output-available", {
+      data: [{ number: 3093 }],
+    });
+
+    const matches = findProviderVisibleToolReplayMatches([
+      assistantMessage([call1, call2]),
+    ]);
+
+    assertEquals(matches.supersededToolCallParts.has(call1), true);
+    assertEquals(matches.supersededToolCallParts.has(call2), false);
+    assertEquals(matches.matchedToolCallParts.has(call1), false);
+    assertEquals(matches.matchedToolCallParts.has(call2), false);
+  });
+
+  it("preserves a transient call only when a later result actually resolves it", () => {
+    const resolvedCall = dynamicToolCall(
+      "resolved",
+      "github__get_pr_diff",
+      { pull_number: 1 },
+      "streaming",
+    );
+    const unresolvedCall = dynamicToolCall(
+      "unresolved",
+      "github__get_issue",
+      { number: 12 },
+      "pending",
+    );
+    const result = rawToolResult("resolved", { files: ["a.ts"] }, "github__get_pr_diff");
+
+    const matches = findProviderVisibleToolReplayMatches([
+      assistantMessage([resolvedCall, unresolvedCall]),
+      toolMessage([result]),
+    ]);
+
+    assertEquals(matches.preservedTransientToolParts.has(resolvedCall), true);
+    assertEquals(matches.matchedToolCallParts.has(resolvedCall), true);
+
+    // Never resolved: stays pending forever, never matched, never preserved.
+    assertEquals(matches.preservedTransientToolParts.has(unresolvedCall), false);
+    assertEquals(matches.matchedToolCallParts.has(unresolvedCall), false);
+  });
+
+  it("does not match a result whose tool name conflicts with the pending call's name", () => {
+    const call = dynamicToolCall(
+      "tool-1",
+      "github__get_pr_diff",
+      { pull_number: 1 },
+      "streaming",
+    );
+    const mismatchedResult = rawToolResult("tool-1", { data: [] }, "github__list_prs");
+
+    const matches = findProviderVisibleToolReplayMatches([
+      assistantMessage([call]),
+      toolMessage([mismatchedResult]),
+    ]);
+
+    assertEquals(matches.matchedToolCallParts.has(call), false);
+    assertEquals(matches.matchedToolResultParts.has(mismatchedResult), false);
+    assertEquals(matches.preservedTransientToolParts.has(call), false);
+  });
+
+  it("leaves a pending call with no result unmatched and unpreserved", () => {
+    const call = rawToolCall("never-resolved", "github__get_issue", { number: 42 });
+
+    const matches = findProviderVisibleToolReplayMatches([
+      assistantMessage([call]),
+    ]);
+
+    assertEquals(matches.matchedToolCallParts.has(call), false);
+    assertEquals(matches.supersededToolCallParts.has(call), false);
+    assertEquals(matches.preservedTransientToolParts.has(call), false);
+    assertEquals(matches.toolCallPartsStartingNewBatch.has(call), false);
+  });
+
+  it("marks a same-message call as starting a new batch when an earlier message's call is still pending", () => {
+    // Mirrors conversion.test.ts's "does not join prior-message unresolved
+    // calls into a new same-message call batch": first-call and second-call
+    // start pending in message 1. Message 2 resolves first-call, then
+    // introduces third-call while second-call (from the earlier message) is
+    // still pending — third-call starts a new batch. second-call is orphaned
+    // (its pending entry is dropped as stale before its own result arrives),
+    // so it never matches.
+    const firstCall = rawToolCall("first-call", "github__get_pr_diff", { pull_number: 1 });
+    const secondCall = rawToolCall("second-call", "github__list_prs", { state: "open" });
+    const firstResult = rawToolResult("first-call", { files: ["one.ts"] }, "github__get_pr_diff");
+    const thirdCall = rawToolCall("third-call", "github__get_issue", { number: 42 });
+    const secondResult = rawToolResult(
+      "second-call",
+      { data: [{ number: 3092 }] },
+      "github__list_prs",
+    );
+    const thirdResult = rawToolResult("third-call", { issue: 42 }, "github__get_issue");
+
+    const matches = findProviderVisibleToolReplayMatches([
+      assistantMessage([firstCall, secondCall], "assistant-1"),
+      assistantMessage(
+        [firstResult, thirdCall, secondResult, thirdResult],
+        "assistant-2",
+      ),
+    ]);
+
+    assertEquals(matches.toolCallPartsStartingNewBatch.has(thirdCall), true);
+    assertEquals(matches.toolCallPartsStartingNewBatch.has(firstCall), false);
+    assertEquals(matches.toolCallPartsStartingNewBatch.has(secondCall), false);
+
+    assertEquals(matches.matchedToolCallParts.has(firstCall), true);
+    assertEquals(matches.matchedToolCallParts.has(thirdCall), true);
+    // second-call's own result arrives after third-call already evicted it
+    // from the pending list as a stale earlier-message entry.
+    assertEquals(matches.matchedToolCallParts.has(secondCall), false);
+    assertEquals(matches.matchedToolResultParts.has(secondResult), false);
+  });
+
+  it("drops earlier-message pending calls once a user message intervenes", () => {
+    const staleCall = dynamicToolCall(
+      "duplicate-call",
+      "github__get_pr_diff",
+      { pull_number: 1 },
+      "streaming",
+    );
+    const freshCall = dynamicToolCall(
+      "duplicate-call",
+      "github__get_pr_diff",
+      { pull_number: 2 },
+      "output-available",
+      { files: ["new.ts"] },
+    );
+
+    const matches = findProviderVisibleToolReplayMatches([
+      assistantMessage([staleCall], "assistant-1"),
+      userMessage("continue with a different PR", "user-2"),
+      assistantMessage([freshCall], "assistant-2"),
+    ]);
+
+    // The stale transient call from before the user turn is never resolved
+    // (its slot was dropped, not matched), so it is not preserved.
+    assertEquals(matches.preservedTransientToolParts.has(staleCall), false);
+    assertEquals(matches.matchedToolCallParts.has(staleCall), false);
+    // The fresh occurrence is self-contained and needs no separate match, but
+    // supersession still tracks it via toolCallsById independent of
+    // pendingCalls eviction: the stale call is superseded even though it was
+    // already dropped from the pending queue by the user-message boundary.
+    assertEquals(matches.supersededToolCallParts.has(staleCall), true);
+    assertEquals(matches.matchedToolCallParts.has(freshCall), false);
   });
 });


### PR DESCRIPTION
> **Stacked on #3439** (`refactor/chat-tool-replay-extraction`) — the module under test does not exist on `main`. Merge #3439 first.

Writes the first real test suite for `findProviderVisibleToolReplayMatches`. **Tests only — no source changes.**

## Why

#3439 extracted a ~100-line algorithm that decides which tool-call/result occurrences in replay history are authoritative for provider conversion — matching by **part object identity** via seven `WeakSet`/`WeakMap` collections. It shipped with 2 smoke tests (`isTransientToolState` classification, and empty history). The algorithm itself was covered only indirectly, through provider conversion in `conversation.test.ts` / `message-prep.test.ts`.

That was the point of extracting it. This is the follow-through.

## What was added

10 cases (2 existing smoke tests kept; 12 total): pair matching, supersession via both paths, transient preservation, name-mismatch rejection, unmatched pending call, batch start, `toolCallsById` supersession after pending-queue eviction, the user-message batch boundary, and object identity.

## The case that matters most

**Identity discrimination.** It builds a matched call/result pair, then checks structurally identical but distinct clones against `matchedToolCallParts`, `matchedToolResultParts`, and `matchedToolResultNames` — asserting the real object reads true/has-a-name and the clone reads false/undefined.

Its exclusive value: it is the **only** case that fails if the returned `WeakSet`/`WeakMap` collections are swapped for structural-equality lookups. No consumer's compile would catch that — callers only use `.has()` and `.get()`. Without this case, a change that "optimized" by comparing parts structurally, or by cloning them internally, would pass every other test while silently breaking replay matching.

## Test quality was verified by mutation, not by reading

The suite was reviewed by building 9 mutants of the implementation (as copies — tracked source was never modified) and mapping which cases catch which:

| Mutation | Caught by |
|---|---|
| Clone parts internally before adding to the sets | cases 1, 2, 3, 5, 8 |
| Return structural-equality collections instead of WeakSet/WeakMap | **case 2 only** |
| Drop supersession propagation to the earlier matched result | **case 3 only** |
| `isCompatibleToolResultName` → always true | **case 6 only** |
| Preserve every transient call unconditionally | cases 5, 6, 9 |
| Batch-start fires on any pending call | **case 8 only** |
| Self-contained path also adds to `matchedToolCallParts` | cases 4, 9 |

That exercise found a real defect in the first draft: a case titled as fencing the user-message boundary survived both boundary mutants. Its assertions were correct, but they pinned something else — its fixture shared a `toolCallId`, so `removePendingCallsWithId` evicted the stale entry regardless and the boundary was never exercised. It has been retitled to what it actually pins, and a genuine boundary case added alongside it (verified to flip under the mutant).

## A documented limitation

The new boundary case fences the "user text stops counting as provider-visible content" regression. It does **not** fence deleting the earlier-message flush inside the visible-content branch: for a call-less user message, `pendingCountBeforeSameMessageVisibleContent` still captures the pre-message length, so the end-of-loop `splice` fallback evicts exactly the same entries — the two paths are provably equivalent in that shape. Discriminating it would need a boundary message with calls interleaved with visible content. This is stated in the case's comment rather than left implied.

## Behaviour pinned, not fixed

A call already evicted from `pendingCalls` as stale still lands in `supersededToolCallParts` when a later same-`toolCallId` occurrence arrives — `toolCallsById` accumulates every occurrence and is never pruned, while `pendingCalls` is pruned by three separate paths.

Reviewed as harmless, and arguably the safer behaviour: the flag only fires when another occurrence with the same `toolCallId` appears later, and emitting two tool-call blocks under one id is exactly what this module exists to prevent. Consumers checked: `conversation.ts:816` (`pushToolCall`, reached only after the transient-skip guard), `:889`/`:928`/`:949` (provider tool messages), and `message-prep.ts:883-885` (`stripPendingToolParts`). Pinned as characterization; no source change.

## Evidence

- `deno task test:unit`: branch baseline **3804 passed / 27918 steps** → **3804 / 27928**, zero regressions.
- Target file green; `deno lint`, `deno task verify:quick`, `deno task lint:chat-ratchets` all exit 0.
- Commit touches only `src/chat/tool-replay-reconciliation.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for reconciling assistant, user, tool, and dynamic tool messages.
  * Verified matching behavior, duplicate calls, transient data preservation, unresolved calls, batch boundaries, stale entries, and user-message boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->