### PR TITLE
fix(chat): keep reused text blocks in order and drop empty reasoning spans

### DIFF
--- a/src/agent/react/use-chat/streaming/handler.test.ts
+++ b/src/agent/react/use-chat/streaming/handler.test.ts
@@ -535,4 +535,106 @@ describe("use-chat streaming handler", () => {
       { type: "text", text: "answer", state: "done" },
     ]);
   });
+
+  it("keeps a step-2 answer after the step-1 text when the provider reuses the text id", async () => {
+    const rec = recorder();
+
+    await handleStreamingResponse(
+      sseStream([
+        { type: "message-start", messageId: "msg-text-reuse" },
+        { type: "text-start", id: "text-0" },
+        { type: "text-delta", id: "text-0", delta: "first answer" },
+        { type: "text-end", id: "text-0" },
+        { type: "tool-input-start", toolCallId: "call-1", toolName: "calculator" },
+        {
+          type: "tool-input-available",
+          toolCallId: "call-1",
+          toolName: "calculator",
+          input: { a: 1 },
+        },
+        { type: "tool-output-available", toolCallId: "call-1", output: { result: 1 } },
+        { type: "text-start", id: "text-0" },
+        { type: "text-delta", id: "text-0", delta: "second answer" },
+        { type: "text-end", id: "text-0" },
+        { type: "message-finish" },
+      ]),
+      rec.callbacks,
+    );
+
+    assertEquals(
+      rec.messages[0]!.parts.map((part) =>
+        part.type === "text" ? `text:${(part as { text: string }).text}` : part.type
+      ),
+      ["text:first answer", "tool-calculator", "text:second answer"],
+    );
+  });
+
+  it("keeps text and position when a still-open text block restarts", async () => {
+    const rec = recorder();
+
+    await handleStreamingResponse(
+      sseStream([
+        { type: "message-start", messageId: "msg-text-replay" },
+        { type: "text-start", id: "t1" },
+        { type: "text-delta", id: "t1", delta: "partial" },
+        { type: "text-start", id: "t1" },
+        { type: "text-delta", id: "t1", delta: " more" },
+        { type: "text-end", id: "t1" },
+        { type: "message-finish" },
+      ]),
+      rec.callbacks,
+    );
+
+    assertEquals(rec.messages[0]!.parts, [
+      { type: "text", text: "partial more", state: "done" },
+    ]);
+  });
+
+  it("drops a reasoning span that closed without any content", async () => {
+    const rec = recorder();
+
+    await handleStreamingResponse(
+      sseStream([
+        { type: "message-start", messageId: "msg-empty-reasoning" },
+        // A step that produced no reasoning still opens and closes the span.
+        { type: "reasoning-start", id: "reasoning-0" },
+        { type: "reasoning-end", id: "reasoning-0" },
+        { type: "reasoning-start", id: "reasoning-0" },
+        { type: "reasoning-delta", id: "reasoning-0", delta: "real thinking" },
+        { type: "reasoning-end", id: "reasoning-0" },
+        { type: "text-start", id: "t1" },
+        { type: "text-delta", id: "t1", delta: "answer" },
+        { type: "text-end", id: "t1" },
+        { type: "message-finish" },
+      ]),
+      rec.callbacks,
+    );
+
+    assertEquals(rec.messages[0]!.parts, [
+      { type: "reasoning", text: "real thinking", state: "done" },
+      { type: "text", text: "answer", state: "done" },
+    ]);
+  });
+
+  it("keeps a redacted reasoning span that carries no visible text", async () => {
+    const rec = recorder();
+
+    await handleStreamingResponse(
+      sseStream([
+        { type: "message-start", messageId: "msg-redacted" },
+        { type: "reasoning-start", id: "r1" },
+        { type: "reasoning-end", id: "r1", redactedData: "opaque" },
+        { type: "text-start", id: "t1" },
+        { type: "text-delta", id: "t1", delta: "answer" },
+        { type: "text-end", id: "t1" },
+        { type: "message-finish" },
+      ]),
+      rec.callbacks,
+    );
+
+    assertEquals(rec.messages[0]!.parts, [
+      { type: "reasoning", text: "", redactedData: "opaque", state: "done" },
+      { type: "text", text: "answer", state: "done" },
+    ]);
+  });
 });

--- a/src/agent/react/use-chat/streaming/handler.ts
+++ b/src/agent/react/use-chat/streaming/handler.ts
@@ -21,6 +21,8 @@ import type {
 
 interface StreamingState {
   textBlocks: Map<string, TextBlock>;
+  /** Closed text blocks whose content id was reused by a later block. */
+  closedTextBlocks: TextBlock[];
   toolCalls: Map<string, OrderedToolCall>;
   reasoningBlocks: Map<string, OrderedReasoning>;
   /** Closed reasoning spans whose wire id was reused by a later span. */
@@ -38,6 +40,7 @@ interface StreamingState {
 function createStreamingState(): StreamingState {
   return {
     textBlocks: new Map(),
+    closedTextBlocks: [],
     toolCalls: new Map(),
     reasoningBlocks: new Map(),
     closedReasoningBlocks: [],
@@ -68,6 +71,7 @@ export async function handleStreamingResponse(
       state.steps,
       state.dataParts,
       state.closedReasoningBlocks,
+      state.closedTextBlocks,
     );
 
   let buffer = "";
@@ -132,6 +136,7 @@ export async function handleAgUiStreamingResponse(
       state.steps,
       state.dataParts,
       state.closedReasoningBlocks,
+      state.closedTextBlocks,
     );
 
   const processDecodedEvents = (events: ChatStreamEvent[]) => {
@@ -395,6 +400,7 @@ function handleStart(
 ): void {
   state.messageId = typeof parsed.messageId === "string" ? parsed.messageId : "";
   state.textBlocks.clear();
+  state.closedTextBlocks.length = 0;
   state.toolCalls.clear();
   state.reasoningBlocks.clear();
   state.closedReasoningBlocks.length = 0;
@@ -428,6 +434,22 @@ function handleTextStart(parsed: Record<string, unknown>, state: StreamingState)
   if (!state.messageId) {
     state.messageId = getTextMessageId(parsed) ?? state.currentTextId;
   }
+
+  const existing = state.textBlocks.get(state.currentTextId);
+
+  // Same rule as reasoning spans, for the same reason: a start on a block that
+  // is still open is a replayed start, so the accumulated text and the order it
+  // already holds both survive. Re-creating it here would blank the answer and
+  // move it below everything that streamed in between.
+  if (existing && existing.state !== "done") return;
+
+  // A start after the block closed is a new answer under a reused id. Providers
+  // hand out per-step content ids, so step 2 can arrive as `text-0` again.
+  if (existing) {
+    state.closedTextBlocks.push(existing);
+    state.textBlocks.delete(state.currentTextId);
+  }
+
   state.textBlocks.set(state.currentTextId, { text: "", state: "streaming", order: null });
 }
 

--- a/src/agent/react/use-chat/streaming/parts-builder.ts
+++ b/src/agent/react/use-chat/streaming/parts-builder.ts
@@ -24,10 +24,16 @@ export function buildCurrentParts(
    * belong in the transcript at the position they streamed in.
    */
   closedReasoningBlocks?: readonly OrderedReasoning[],
+  /**
+   * Text blocks that closed and were then superseded by a later block reusing
+   * the same content id. No longer addressable, still part of the answer.
+   */
+  closedTextBlocks?: readonly TextBlock[],
 ): ChatMessagePart[] {
   const orderedParts: OrderedPart[] = [];
 
-  addTextParts(orderedParts, textBlocks);
+  addTextParts(orderedParts, textBlocks.values());
+  if (closedTextBlocks) addTextParts(orderedParts, closedTextBlocks);
   addReasoningParts(orderedParts, reasoningBlocks.values());
   if (closedReasoningBlocks) addReasoningParts(orderedParts, closedReasoningBlocks);
   addToolParts(orderedParts, toolCalls);
@@ -49,9 +55,9 @@ function addExtraParts(
 
 function addTextParts(
   orderedParts: OrderedPart[],
-  textBlocks: Map<string, TextBlock>,
+  textBlocks: Iterable<TextBlock>,
 ): void {
-  for (const { text, order, state } of textBlocks.values()) {
+  for (const { text, order, state } of textBlocks) {
     if (!text || order === null) continue;
 
     orderedParts.push({
@@ -66,6 +72,16 @@ function addReasoningParts(
   reasoningBlocks: Iterable<OrderedReasoning>,
 ): void {
   for (const { order, text, signature, redactedData, isComplete } of reasoningBlocks) {
+    // A span that closed without producing anything is not reasoning the reader
+    // can open — it renders as an empty "Thought process" disclosure. Providers
+    // open and close the span on steps that did no thinking, so this is common.
+    // A redacted or signed span carries meaning without visible text, so only
+    // the entirely empty ones are dropped, and only once they have closed: an
+    // open one is still the "thinking" affordance.
+    if (isComplete && !text && signature === undefined && redactedData === undefined) {
+      continue;
+    }
+
     orderedParts.push({
       order,
       part: {


### PR DESCRIPTION
Follow-up to #3438. After that landed I probed the rest of the streaming assembly for the same defect class. Two findings, one latent and one live.

## `handleTextStart` had the identical overwrite bug

It replaced its map entry unconditionally, exactly as `handleReasoningStart` did before #3438. A content id reused across steps blanks the earlier answer and moves the later one below everything that streamed in between:

```
stream: text(STEP1) → tool → text(STEP2)
before: ["tool-calc", "text:STEP2"]              ← STEP1 destroyed
after:  ["text:STEP1", "tool-calc", "text:STEP2"]
```

Reasoning ids collide on every run because providers index them (`reasoning-0`). Text ids usually carry a random suffix (`text-BG3xwKvhoiJGrrdZ`), which is the only reason this hadn't surfaced. It is reachable today: `src/provider/local/model-runtime-adapter.ts:145` builds `text-${Date.now()}` per `doStream` call, so two steps completing inside one millisecond reuse the id.

Worth flagging because it would have been hard to spot from the UI: `getAnswerPartsForRendering` already hides pre-tool text once a post-tool answer exists, so the screen looks correct while the persisted message silently loses content.

Same rule as reasoning now applies. A start on a block that is still open is a replayed start and keeps its text and its order; a start after the block closed opens a new block and retires the old one to `closedTextBlocks`.

## Empty reasoning spans rendered an empty "Thought process"

A `reasoning-start` / `reasoning-end` pair with no delta produced `{type: "reasoning", text: ""}`, and nothing guarded against it — not `parts-builder`, not `groupPartsInOrder`, not the `Reasoning` component, which renders the disclosure trigger regardless of content. Providers open and close the span on any step that did no thinking, so this is common.

This predates #3438 (a single empty span already produced it), but #3438 increased exposure: empty spans sharing an id used to collapse into one overwritten slot and now each is retained.

Completed empty spans are dropped. Two deliberate carve-outs, both covered by tests:

- An **open** empty span stays, so the thinking affordance still shows while a span streams.
- A **redacted or signed** span stays even with empty text, because it carries meaning without visible content.

## Verification

Probes against the built handler, five steps with both ids fully reused:

```
L: reason:R1, text:T1, reason:R2, text:T2, reason:R3, text:T3, reason:R4, text:T4, reason:R5, text:T5
```

Nothing lost, nothing reordered, no duplicates.

Suites: agent + chat + react 1390 passed / 0 failed. `deno task typecheck` clean, `deno fmt --check` and `deno lint` clean.

## Not fixed here

Reusing a **tool call id** across steps destroys the earlier call the same way. Left alone deliberately: correlating a result to a call requires the id to be unique, so a duplicate id is already ambiguous at the protocol level rather than something the client should paper over.

The AG-UI encoder still emits duplicate reasoning `messageId`s across steps. `use-chat` is now robust to it, but other consumers of that wire are not. Fixing it there is a wire-contract change and wants its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses when content identifiers are reused, preserving previously generated text and its ordering.
  * Prevented empty reasoning segments from appearing in responses.
  * Preserved meaningful reasoning content, including redaction metadata, during streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->