### PR TITLE
fix(runtime): keep providerExecuted on non-streamed tool results

### DIFF
--- a/docs/api-reference/veryfront/embedding.md
+++ b/docs/api-reference/veryfront/embedding.md
@@ -42,7 +42,7 @@ export const { POST, GET, DELETE } = createUploadHandler(store, {
 | `ragStore`                  | Creates a persistent RAG store with lazy embedding and similarity search.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/rag-store.ts#L212)      |
 | `registerEmbeddingProvider` | Register an embedding provider factory.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L25)         |
 | `resolveEmbeddingModel`     | Resolve a "provider/model" string to an embedding runtime instance.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L116)        |
-| `similarity`                | Compute cosine similarity between two numeric vectors.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runtime/runtime-bridge.ts#L973)   |
+| `similarity`                | Compute cosine similarity between two numeric vectors.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runtime/runtime-bridge.ts#L975)   |
 | `vectorStore`               | Creates an in-memory vector store with integrated embedding and similarity search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/vector-store.ts#L46)    |
 
 ### Types

--- a/src/runtime/runtime-bridge.test.ts
+++ b/src/runtime/runtime-bridge.test.ts
@@ -1186,6 +1186,69 @@ describe("runtime-bridge", () => {
     }]);
   });
 
+  it("keeps providerExecuted on direct generate provider tool results", async () => {
+    // Mirrors what ext-llm-anthropic's buildAnthropicGenerateResult and
+    // ext-llm-openai's Responses normalizer actually return from doGenerate:
+    // server-side tool results always carry providerExecuted: true.
+    const model = createGenerateModel(
+      "anthropic",
+      "anthropic/test-direct-provider-executed-generate",
+      async () => ({
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tool-web-3",
+            toolName: "web_search",
+            input: '{"query":"Veryfront"}',
+            providerExecuted: true,
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-web-3",
+            toolName: "web_search",
+            result: [{ url: "https://veryfront.com", title: "Veryfront" }],
+            providerExecuted: true,
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-web-4",
+            toolName: "web_fetch",
+            result: { message: "fetch blocked" },
+            isError: true,
+            providerExecuted: true,
+          },
+        ],
+        finishReason: { unified: "stop", raw: "stop" },
+        usage: {
+          inputTokens: { total: 6 },
+          outputTokens: { total: 9 },
+        },
+      }),
+    );
+
+    const result = await generateText({
+      model,
+      messages: [{ role: "user", content: "Research Veryfront" }],
+      temperature: 0,
+    });
+
+    assertEquals(result.toolResults, [
+      {
+        toolCallId: "tool-web-3",
+        toolName: "web_search",
+        result: [{ url: "https://veryfront.com", title: "Veryfront" }],
+        providerExecuted: true,
+      },
+      {
+        toolCallId: "tool-web-4",
+        toolName: "web_fetch",
+        result: { message: "fetch blocked" },
+        isError: true,
+        providerExecuted: true,
+      },
+    ]);
+  });
+
   it("uses the direct stream path for provider-native web_fetch", async () => {
     const model = createStreamModel(
       "anthropic",

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -540,6 +540,7 @@ function isDirectToolResultPart(
   toolName: string;
   result: unknown;
   isError?: boolean;
+  providerExecuted?: boolean;
 } {
   return !!part &&
     typeof part === "object" &&
@@ -579,6 +580,7 @@ function buildDirectGenerateResult(
         toolName: part.toolName,
         result: part.result,
         ...(part.isError === true ? { isError: true } : {}),
+        ...(part.providerExecuted === true ? { providerExecuted: true } : {}),
       });
     }
   }


### PR DESCRIPTION
A provider-executed tool result loses its `providerExecuted` marker on the non-streamed generate path, and is then persisted into conversation history as an ordinary client-side tool result.

## The bug

`src/runtime/runtime-bridge.ts` has two result builders that should agree:

- **Streamed** (`buildGenerateResultFromStream`) propagates `providerExecuted` in both its `tool-result` and `tool-error` cases.
- **Non-streamed** (`buildDirectGenerateResult`) never set it.

The type guard `isDirectToolResultPart` narrowed to a shape that omitted `providerExecuted` entirely, so the field was invisible at the type level and the omission never surfaced as a compile error.

## It is on the default path, not an edge case

Providers really do send it. `extensions/ext-llm-anthropic/src/anthropic-provider.ts:275-282` sets `providerExecuted: true` **unconditionally** on every `web_search` / `web_fetch` / MCP tool-result block, typed as the literal `true`. `extensions/ext-llm-openai/src/openai-provider.ts:837-844` does the same for `web_search_call`.

And the non-streamed path is the common one: `shouldGenerateViaStream` is just `model._generateViaStream === true`, and that flag is set in exactly one place — `src/provider/veryfront-cloud/provider.ts:17`. So veryfront-cloud models divert to the stream builder (which was correct), while **direct-key Anthropic and OpenAI models take `doGenerate` and hit the buggy builder.**

## Consequences

1. **Wrong persisted data — the real impact.** `persistGeneratedToolResult` passes `generatedToolResult.providerExecuted === true` into `createToolResultMessage`, whose parameter defaults to `false` and drives a conditional spread (`tool-result-continuation.ts:17,28`). A genuinely provider-executed result was therefore written into conversation history with the marker absent entirely. Downstream code keys on that marker — e.g. `src/chat/conversation.ts:376`, and the completeness rule exercised by `finalized-message.test.ts:62` ("fails local web_fetch input-available tools without providerExecuted").
2. **Observability gap.** `traceProviderExecutedTool` fires only under `providerExecuted === true`, so provider-executed tools were never traced in generate mode.

Link 1 is traced through the file:line hops above rather than proven end-to-end; link 2 is covered by the test below.

## The fix

Two lines in `runtime-bridge.ts`: widen `isDirectToolResultPart`'s narrowed type with `providerExecuted?: boolean`, and add the same conditional spread the streamed builder uses, so the field is omitted rather than set to `false`.

## Proof, in commit order

The two commits are deliberately ordered test-then-fix so the red/green is visible in history rather than asserted here.

Against the unfixed code, the new test fails on exactly the missing field:

```
[Diff] Actual / Expected
[
  {
+   providerExecuted: true,
    result: [ { title: "Veryfront", url: "https://veryfront.com" } ],
    toolCallId: "tool-web-3",
    toolName: "web_search",
  },
  {
    isError: true,
+   providerExecuted: true,
    result: { message: "fetch blocked" },
    ...
```

All 26 pre-existing steps in that file passed at the test-only commit, so the failure is attributable to the bug and nothing else. After the fix: 27 passed, 0 failed.

## Why this survived until now

The neighbouring `uses the direct generate path for provider-native tools` test feeds model content carrying **no `providerExecuted` field at all** — an unrealistic fixture, since the real Anthropic provider always sets it on server-tool blocks. Nothing could observe the field being dropped because nothing ever supplied it. That test still passes unchanged (the conditional spread omits the field when absent) and was not modified.

## Evidence

- `deno task test:unit`: **3801 passed / 27916 steps / 0 failed / 1 ignored**, exit 0. No pre-existing test broke; none needed updating.
- `deno task verify:quick` exit 0; `deno check src/index.ts` clean; fmt and lint clean.
- `docs/api-reference/veryfront/embedding.md` is a one-line change: it pins a source line into `runtime-bridge.ts`, and the fix shifted `#L973` → `#L975`. This was **not** assumed pre-existing — the base versions were checked out and `docs:api-reference:check` reported "current (43 files)", confirming the staleness came from this change. Regenerated with `deno task docs` on Deno 2.7.7 (the CI-pinned version), never hand-edited.

## Known adjacent issue, deliberately not fixed here

`tool-call` parts drop `providerExecuted` on the same path (`runtime-bridge.ts:568-573`), while both providers set it on the matching tool-call part and the streamed path carries it. Same asymmetry, adjacent lines. Whether `RuntimeGenerateTextResult["toolCalls"]` should carry it depends on whether any consumer reads it, which hasn't been investigated — so it is flagged rather than swept in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved provider execution status for tool results during direct generation.
  - Tool results now retain this status consistently for both successful and errored outcomes, including associated metadata and error indicators.
  - Added validation support for the optional execution-status field.

- **Documentation**
  - Corrected the source-code link for the `similarity` function in the API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->