### PR TITLE
chore: gitignore the SDD scratch workspace and drop a dead export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ benchmarks/apps/nextjs/node_modules/
 # Claude Octopus plugin state
 .claude-octopus/
 plan.md
+
+# SDD review tooling scratch workspace (implementation reports, generated review diffs)
+.superpowers/

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -25,7 +25,6 @@ import {
   type ReleaseAssetBuildClient,
   type ReleaseAssetBuildInput,
   type ReleaseAssetBuildResult,
-  releaseAssetDependencyUrlForSpecifier,
   type ReleaseAssetHttpDependencyVendor,
   type ReleaseAssetVendorResult,
   routeForPage,
@@ -460,42 +459,6 @@ describe("release asset build executor", () => {
     assertEquals(rec.began, false);
     assertEquals(rec.uploads, []);
     assertEquals([...Deno.readDirSync(tempDir)], []);
-  });
-
-  it("keeps distinct HTTP query variants as distinct dependency identities", () => {
-    const baseUrl = "https://cdn.example/pkg.js";
-    const dependencyUrls = new Map([[baseUrl, "/_vf/assets/es2020.js"]]);
-
-    assertEquals(
-      releaseAssetDependencyUrlForSpecifier(
-        dependencyUrls,
-        `${baseUrl}?target=es2022`,
-      ),
-      null,
-    );
-  });
-
-  it("keeps distinct HTTP fragment variants as distinct dependency identities", () => {
-    const baseUrl = "https://cdn.example/pkg.js";
-    const dependencyUrls = new Map([
-      [
-        `${baseUrl}#a`,
-        "/_vf/assets/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js#a",
-      ],
-      [
-        `${baseUrl}#b`,
-        "/_vf/assets/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js#b",
-      ],
-    ]);
-
-    assertEquals(
-      releaseAssetDependencyUrlForSpecifier(dependencyUrls, `${baseUrl}#a`),
-      dependencyUrls.get(`${baseUrl}#a`),
-    );
-    assertEquals(
-      releaseAssetDependencyUrlForSpecifier(dependencyUrls, `${baseUrl}#b`),
-      dependencyUrls.get(`${baseUrl}#b`),
-    );
   });
 
   it("never admits a module whose transform failed", async () => {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -729,13 +729,6 @@ function dependencyUrlForSpecifier(
   return null;
 }
 
-export function releaseAssetDependencyUrlForSpecifier(
-  dependencyUrls: Map<string, string>,
-  specifier: string,
-): string | null {
-  return dependencyUrlForSpecifier(dependencyUrls, specifier);
-}
-
 function buildDependencyUrlMap(
   dependencies: Record<string, PreparedAsset>,
   dependencyModules?: Map<string, DependencyModule>,


### PR DESCRIPTION
Two small, unrelated hygiene changes, one commit each.

## 1. Gitignore `.superpowers/`

`docs/superpowers/` is already ignored (`.gitignore:90`), but `.superpowers/` — a scratch workspace written by review tooling (implementation reports, generated review diffs) — was not. Two scratch files leaked into #3441 because of this and had to be removed after review caught them.

Verified before: `git check-ignore -v .superpowers` exited 1. Verified after against a real file under the directory, matching `.gitignore:105`. (Checking a nonexistent bare path is unreliable for a trailing-slash pattern — it can exit 1 even when the pattern would match, so the real-file test is the one that counts.)

## 2. Delete `releaseAssetDependencyUrlForSpecifier`

No production consumer. Repo-wide grep across `src/` and `cli/` found exactly five hits: the definition at `build-executor.ts:732` and four usages inside its own test. Not re-exported from `src/release-assets/index.ts`, and `deno.json` maps `veryfront/release-assets` to the barrel only.

Removed the exported wrapper plus the two `it()` blocks that existed solely to exercise it. **The private helper it wrapped, `dependencyUrlForSpecifier`, stays** — still used internally at lines 654, 658 and 2026, and still covered by the `runReleaseAssetBuild` tests.

## Evidence

- `deno task test:unit`: 3801 passed / 27915 steps → 3801 / 27913. Delta is **−2 steps, exactly the two deleted cases**; 0 failed in both runs. (The top-level count is unchanged because Deno's BDD `it()` cases nest as steps under the file-level test.)
- `deno task verify:quick` exit 0; `deno lint` and `deno check src/index.ts` clean.
- Each commit touches only its own files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused release asset dependency URL utility.
  * Simplified internal release asset handling without changing dependency resolution behavior.

* **Chores**
  * Excluded tooling scratch files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->