### PR TITLE
feat(integrations): let a host publish adapter-only connectors it drives itself

### DIFF
--- a/src/integrations/feature-flags.test.ts
+++ b/src/integrations/feature-flags.test.ts
@@ -5,8 +5,11 @@ import {
   DECLARED_INTEGRATION_NAMES,
   EXPERIMENTAL_INTEGRATIONS_ENV,
   filterVisibleIntegrations,
+  HOST_ADAPTER_INTEGRATIONS_ENV,
   INTEGRATIONS_REQUIRING_PROVIDER_ADAPTER,
+  isCatalogVisibleIntegration,
   isExperimentalIntegrationEnabled,
+  isHostAdapterIntegration,
   isSupportedIntegration,
   isVisibleIntegration,
   SUPPORTED_INTEGRATION_NAMES,
@@ -52,6 +55,44 @@ describe("integration feature flags", () => {
     assertEquals(isVisibleIntegration("salesforce"), false);
     assertEquals(isVisibleIntegration("stripe"), true);
     assertEquals(isVisibleIntegration("not-a-provider"), false);
+  });
+
+  it("keeps a host-declared adapter connector out of scaffolding visibility", () => {
+    // The scaffolding guard must not move: generated routes run on the generic
+    // runtime, which is exactly what cannot serve these connectors.
+    Deno.env.set(HOST_ADAPTER_INTEGRATIONS_ENV, "salesforce");
+    try {
+      assertEquals(isVisibleIntegration("salesforce"), false);
+      assertEquals(isExperimentalIntegrationEnabled("salesforce"), false);
+    } finally {
+      Deno.env.delete(HOST_ADAPTER_INTEGRATIONS_ENV);
+    }
+  });
+
+  it("exposes a host-declared adapter connector to catalog lookup", () => {
+    // A host naming a connector is asserting it ships the client itself, so it
+    // keeps the tool definitions it needs to drive it.
+    Deno.env.set(HOST_ADAPTER_INTEGRATIONS_ENV, "salesforce");
+    try {
+      assertEquals(isHostAdapterIntegration("salesforce"), true);
+      assertEquals(isCatalogVisibleIntegration("salesforce"), true);
+      // Not named, so still absent even though it is adapter-only too.
+      assertEquals(isCatalogVisibleIntegration("pipedrive"), false);
+    } finally {
+      Deno.env.delete(HOST_ADAPTER_INTEGRATIONS_ENV);
+    }
+  });
+
+  it("ignores blanket values for the host adapter declaration", () => {
+    for (const blanket of ["1", "true", "all", "*"]) {
+      Deno.env.set(HOST_ADAPTER_INTEGRATIONS_ENV, blanket);
+      try {
+        assertEquals(isHostAdapterIntegration("salesforce"), false, blanket);
+        assertEquals(isCatalogVisibleIntegration("salesforce"), false, blanket);
+      } finally {
+        Deno.env.delete(HOST_ADAPTER_INTEGRATIONS_ENV);
+      }
+    }
   });
 
   it("filters collections by integration id", () => {

--- a/src/integrations/feature-flags.ts
+++ b/src/integrations/feature-flags.ts
@@ -2,6 +2,8 @@ import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { ALL_INTEGRATION_NAMES } from "./schema.ts";
 
 export const EXPERIMENTAL_INTEGRATIONS_ENV = "VERYFRONT_EXPERIMENTAL_INTEGRATIONS";
+/** Env var naming adapter-only connectors the host drives with its own client. */
+export const HOST_ADAPTER_INTEGRATIONS_ENV = "VERYFRONT_HOST_ADAPTER_INTEGRATIONS";
 
 /**
  * The subset of {@link ALL_INTEGRATION_NAMES} that ships visible by default.
@@ -104,6 +106,48 @@ export function isExperimentalIntegrationEnabled(name: string | null | undefined
     .map((item) => item.trim())
     .filter(Boolean)
     .includes(normalizedName);
+}
+
+/**
+ * Adapter-only connectors the embedding host declares it drives with its own
+ * client. Only {@link isCatalogVisibleIntegration} honours this: scaffolding
+ * keeps refusing them, because generated routes run on the generic runtime and
+ * that is precisely what cannot serve them. Blanket values are ignored, so a
+ * host has to name each connector it actually implements.
+ */
+export function isHostAdapterIntegration(name: string | null | undefined): boolean {
+  if (
+    typeof name !== "string" || !isDeclaredIntegration(name) || !requiresProviderAdapter(name)
+  ) return false;
+
+  const value = readEnv(HOST_ADAPTER_INTEGRATIONS_ENV);
+  if (!value) return false;
+
+  const normalizedName = normalizeIntegrationName(name);
+  return value
+    .trim()
+    .toLowerCase()
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .includes(normalizedName);
+}
+
+/**
+ * Visibility for catalog lookup. Wider than {@link isVisibleIntegration}: a
+ * host that supplies its own adapter still needs the connector definitions,
+ * otherwise it has a working integration with no tools.
+ */
+export function isCatalogVisibleIntegration(name: string | null | undefined): boolean {
+  return isVisibleIntegration(name) || isHostAdapterIntegration(name);
+}
+
+export function filterCatalogVisibleIntegrations<T extends { id?: string; name?: string }>(
+  integrations: readonly T[],
+): T[] {
+  return integrations.filter((integration) =>
+    isCatalogVisibleIntegration(integration.id ?? integration.name)
+  );
 }
 
 export function isVisibleIntegration(name: string | null | undefined): boolean {

--- a/src/integrations/index.test.ts
+++ b/src/integrations/index.test.ts
@@ -2,7 +2,11 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { connectors, icons } from "./_data.ts";
-import { EXPERIMENTAL_INTEGRATIONS_ENV, filterVisibleIntegrations } from "./feature-flags.ts";
+import {
+  EXPERIMENTAL_INTEGRATIONS_ENV,
+  filterVisibleIntegrations,
+  HOST_ADAPTER_INTEGRATIONS_ENV,
+} from "./feature-flags.ts";
 import { getConnector, getConnectorNames, getIcon, listConnectors } from "./index.ts";
 
 describe("integrations/index", () => {
@@ -43,6 +47,22 @@ describe("integrations/index", () => {
     assertEquals(getConnector("salesforce"), undefined);
     assertEquals(getIcon("salesforce"), undefined);
     assertEquals(getConnectorNames().includes("salesforce"), false);
+  });
+
+  it("publishes an adapter-only connector the host declares it drives", () => {
+    // This is the seam veryfront-api depends on: it ships its own Salesforce
+    // client, so it needs the connector definitions to resolve tool names and
+    // authorize calls. Without this the integration stays connectable but every
+    // tool call fails to resolve.
+    Deno.env.set(HOST_ADAPTER_INTEGRATIONS_ENV, "salesforce");
+    try {
+      assertEquals(getConnector("salesforce") !== undefined, true);
+      assertEquals(getConnectorNames().includes("salesforce"), true);
+      // Adapter-only and not declared by the host, so still absent.
+      assertEquals(getConnector("pipedrive"), undefined);
+    } finally {
+      Deno.env.delete(HOST_ADAPTER_INTEGRATIONS_ENV);
+    }
   });
 
   it("returns undefined for unknown connector lookups", () => {

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -40,20 +40,20 @@ export {
 } from "./schema.ts";
 
 import { connectors, icons } from "./_data.ts";
-import { filterVisibleIntegrations, isVisibleIntegration } from "./feature-flags.ts";
+import { filterCatalogVisibleIntegrations, isCatalogVisibleIntegration } from "./feature-flags.ts";
 import type { IntegrationConfig, IntegrationName } from "./schema.ts";
 
 const iconMap = new Map(Object.entries(icons));
 
 /** Return connector. */
 export function getConnector(name: IntegrationName | string): IntegrationConfig | undefined {
-  if (!isVisibleIntegration(name)) return undefined;
+  if (!isCatalogVisibleIntegration(name)) return undefined;
   return connectors.find((connector) => connector.name === name);
 }
 
 /** List connectors. */
 export function listConnectors(): readonly IntegrationConfig[] {
-  return filterVisibleIntegrations(connectors);
+  return filterCatalogVisibleIntegrations(connectors);
 }
 
 /** Return connector names. */
@@ -63,7 +63,7 @@ export function getConnectorNames(): readonly string[] {
 
 /** Return icon. */
 export function getIcon(name: IntegrationName | string): string | undefined {
-  if (!isVisibleIntegration(name)) return undefined;
+  if (!isCatalogVisibleIntegration(name)) return undefined;
   return iconMap.get(name);
 }
 


### PR DESCRIPTION
## Problem

Hiding adapter-only connectors from **every** lookup removed the connector definitions out from under hosts that do implement the adapter.

`veryfront-api` ships a full Salesforce client (`usecases/integrations/salesforce/api-client.ts` — resolves `instance_url` from the token bundle, handles auth retry) and names `salesforce` in its promoted set. After `0.1.1209`:

- `getConnector('salesforce')` returns `undefined` even with the host's flag set
- `isKnownIntegrationToolName('salesforce__…')` is `false`, so tool names stop resolving
- `requiresOAuthConnectionBinding('salesforce')` silently becomes `false`

The integration stays connectable and the adapter still works, but it has no tools. A user who connected Salesforce and called a case tool two weeks ago cannot do so now.

## What is *not* changing

The scaffolding guard is correct and stays exactly where it is. I initially tried widening `isExperimentalIntegrationEnabled` and it broke `cli/commands/init/catalog.test.ts` and `cli/templates/integration-loader.test.ts` — which is the guard doing its job. Generated routes run on the generic OAuth runtime, and that is precisely what cannot serve these connectors.

Unchanged, still refusing adapter-only connectors:

- `cli/commands/init/catalog.ts`, `cli/templates/integration-loader.ts`, `cli/mcp/tools/catalog-tools.ts`
- `src/oauth/providers/common.ts` visible-service filtering
- the `OAuthProvider` constructor guard on `runtimeSupport: "provider-adapter-required"`

Those CLI tests pass **unmodified** in this PR, which is the clearest evidence the seam is right.

## The change

Catalog lookup was the part that was too narrow, so it gets its own predicate.

`getConnector`, `listConnectors` and `getIcon` now use `isCatalogVisibleIntegration`, which is `isVisibleIntegration` plus `isHostAdapterIntegration`. The latter reads a new `VERYFRONT_HOST_ADAPTER_INTEGRATIONS` env var.

Deliberate properties:

- **Explicit names only.** Blanket values (`1`, `true`, `all`, `*`) are ignored, so a sweep can never widen the surface by accident. Covered for all four forms.
- **Adapter-only connectors only.** The predicate returns `false` for anything not in `INTEGRATIONS_REQUIRING_PROVIDER_ADAPTER`, so it cannot become a second general-purpose visibility flag.
- **Catalog only.** Scaffolding and the generic OAuth runtime never consult it.

## Tests

- host-declared connector stays **out** of scaffolding visibility
- host-declared connector **is** visible to catalog lookup, and an undeclared adapter-only connector (`pipedrive`) is not
- blanket values ignored, all four forms
- `getConnector("salesforce")` and `getConnectorNames()` include it under the declaration

Each confirmed to actually execute rather than silently skip.

## Verification

- `deno task test:unit`: **3811 passed, 0 failed**
- `deno task verify:quick`: exit 0 (full 22-task chain)

## Follow-up

Consumers still need to opt in. `veryfront-api` will set `VERYFRONT_HOST_ADAPTER_INTEGRATIONS=salesforce` and restore its catalog expectations once this publishes. The other 11 adapter-only connectors stay hidden everywhere until some host declares an adapter for them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly declared host adapter integrations.
  * Declared integrations can now appear in catalog lookups and connector listings.
  * Catalog entries can be found by integration ID or name.
* **Bug Fixes**
  * Prevented blanket environment values such as `all`, `*`, `true`, and `1` from enabling integrations.
  * Maintained scaffolding visibility rules so host-only integrations are not shown there.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->