### PR TITLE
fix(styles): resolve the preview stylesheet like production does

### DIFF
--- a/src/server/handlers/dev/styles-css.handler.test.ts
+++ b/src/server/handlers/dev/styles-css.handler.test.ts
@@ -107,6 +107,60 @@ function makeCtx(adapter: RuntimeAdapter, overrides: Partial<HandlerContext> = {
 }
 
 describe("server/handlers/dev/styles-css.handler", () => {
+  it("carries the project @theme into the served stylesheet", async () => {
+    // Mechanism check A: the stylesheet IS at the single path the dev route
+    // reads. If the theme still does not reach the output, the loss is
+    // downstream of loadStylesheet rather than in path resolution.
+    const stub = mockTailwindFetch();
+    try {
+      const adapter = createHandlerAdapter(
+        [{ path: "pages/index.tsx", content: '<div className="bg-brand" />' }],
+        null,
+      );
+      adapter.fs.files.set(
+        "/project/globals.css",
+        '@import "tailwindcss";\n@theme { --color-brand: #123456; }',
+      );
+      const ctx = makeCtx(adapter);
+      const req = new Request("http://localhost/_vf_styles/styles.css");
+
+      const result = await new StylesCSSHandler().handle(req, ctx);
+      const body = await result.response!.text();
+
+      assertEquals(result.response!.status, 200);
+      assertEquals(body.includes("--color-brand"), true);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("finds a stylesheet at styles/globals.css like the production resolver", async () => {
+    // Mechanism check B: production's findStylesheetFromFiles searches
+    // globals.css, global.css, styles/globals.css and app/globals.css. The dev
+    // route reads exactly one hardcoded path.
+    const stub = mockTailwindFetch();
+    try {
+      const adapter = createHandlerAdapter(
+        [{ path: "pages/index.tsx", content: '<div className="bg-brand" />' }],
+        null,
+      );
+      adapter.fs.files.delete("/project/globals.css");
+      adapter.fs.files.set(
+        "/project/styles/globals.css",
+        '@import "tailwindcss";\n@theme { --color-brand: #123456; }',
+      );
+      const ctx = makeCtx(adapter);
+      const req = new Request("http://localhost/_vf_styles/styles.css");
+
+      const result = await new StylesCSSHandler().handle(req, ctx);
+      const body = await result.response!.text();
+
+      assertEquals(body.includes("--color-brand"), true);
+    } finally {
+      stub.restore();
+    }
+  });
+
   it("serves Tailwind-only development CSS without an optimization provider", async () => {
     const previousEngine = tryResolve<CSSOptimizationEngine>(CSSOptimizationEngineName);
     unregister(CSSOptimizationEngineName);

--- a/src/server/handlers/dev/styles-css.handler.ts
+++ b/src/server/handlers/dev/styles-css.handler.ts
@@ -37,6 +37,7 @@ import type {
   VeryfrontApiClient,
 } from "#veryfront/platform/adapters/veryfront-api-client/index.ts";
 import { extractProjectCandidates } from "./styles-candidate-scanner.ts";
+import { findStylesheetFromFiles } from "#veryfront/html/styles-builder/css-pregeneration.ts";
 import { extractProjectCssImports } from "./styles-css-import-scanner.ts";
 import { mergeImportedCSS } from "#veryfront/rendering/orchestrator/html-imported-css.ts";
 import { profilePhase } from "#veryfront/observability";
@@ -330,21 +331,70 @@ export class StylesCSSHandler extends BaseHandler {
     }
   }
 
+  /**
+   * Resolve the project stylesheet the same way the production pipeline does.
+   *
+   * Production calls `findStylesheetFromFiles` over the loaded source files,
+   * which accepts `globals.css`, `global.css`, `styles/globals.css` and
+   * `app/globals.css`. This route used to read a single hardcoded
+   * `<projectDir>/globals.css` through the filesystem adapter, so a project
+   * whose stylesheet sits anywhere else silently fell back to the provider
+   * default and lost its `@theme` tokens -- every `bg-<token>` utility the
+   * theme defines then fails to generate, and the preview renders unstyled
+   * while production is fine.
+   *
+   * Resolving from the same file list also removes the dependency on a
+   * path-shaped filesystem read, which is not how sources arrive when they are
+   * served from the control plane rather than local disk.
+   */
   private async loadStylesheet(ctx: HandlerContext): Promise<string | undefined> {
     const configuredPath = ctx.config?.tailwind?.stylesheet;
 
-    if (configuredPath) {
-      const filePath = joinPath(ctx.projectDir, configuredPath);
-      return ctx.adapter.fs.readFile(filePath);
+    const files = await this.getSourceFiles(ctx);
+    if (files) {
+      const fromFiles = findStylesheetFromFiles(files, configuredPath);
+      if (fromFiles) return fromFiles;
     }
 
-    const globalsPath = joinPath(ctx.projectDir, "globals.css");
+    // No source list available (or nothing matched): fall back to reading the
+    // configured path, then the conventional locations, directly.
+    const candidatePaths = configuredPath
+      ? [configuredPath]
+      : ["globals.css", "global.css", "styles/globals.css", "app/globals.css"];
+
+    for (const candidate of candidatePaths) {
+      try {
+        const contents = await ctx.adapter.fs.readFile(joinPath(ctx.projectDir, candidate));
+        if (contents) return contents;
+      } catch (_) {
+        /* try the next conventional location */
+      }
+    }
+
+    // Worth a warning rather than a debug line: the page still renders, but
+    // without the project's theme, which looks like a broken site.
+    logger.warn("No project stylesheet found; provider default will be used", {
+      projectDir: ctx.projectDir,
+      configuredPath: configuredPath ?? null,
+    });
+    return undefined;
+  }
+
+  private async getSourceFiles(
+    ctx: HandlerContext,
+  ): Promise<Array<{ path: string; content?: string }> | null> {
+    const wrappedFs = ctx.adapter.fs as { getUnderlyingAdapter?: () => unknown };
+    if (typeof wrappedFs.getUnderlyingAdapter !== "function") return null;
+
+    const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
+      getAllSourceFiles?: () => Promise<Array<{ path: string; content?: string }>>;
+    };
+    if (typeof fsAdapter.getAllSourceFiles !== "function") return null;
+
     try {
-      return await ctx.adapter.fs.readFile(globalsPath);
+      return await fsAdapter.getAllSourceFiles();
     } catch (_) {
-      /* expected: globals.css may not exist */
-      logger.debug("No project stylesheet found; provider default will be used");
-      return undefined;
+      return null;
     }
   }
 


### PR DESCRIPTION
Fixes hosted previews rendering unstyled while production renders correctly.

## The symptom

codersociety's preview stylesheet carries the stock Tailwind palette and **none of the project's theme**:

```
production CSS:  --color-background ✓  --color-panel ✓  --color-border ✓  --color-input ✓
preview CSS:     ✗                    ✗                ✗                 ✗
```

Those tokens come from an `@theme` block in the project's `globals.css`, so every `bg-background`, `bg-panel` and `border-border` utility the pages use simply fails to generate — 65 classes present in production and absent from the preview. The page renders as unstyled text with no layout.

## Cause

The two paths resolved the project stylesheet differently:

| | Resolution |
|---|---|
| **Production** (`style-callbacks.ts`) | `findStylesheetFromFiles(files, stylesheetPath)` — accepts `globals.css`, `global.css`, `styles/globals.css`, `app/globals.css` |
| **Preview** (`styles-css.handler.ts`) | one hardcoded `<projectDir>/globals.css` via `fs.readFile`, failure swallowed at `debug` |

On miss it fell through to the provider default — a stylesheet with no project theme.

## The fix

Resolve from the same file list production uses, keeping a direct read over the same four conventional locations as a fallback. That also removes the dependency on a path-shaped filesystem read, which isn't how sources arrive when they come from the control plane rather than local disk.

Raised the give-up log from `debug` to `warn`. I went looking for that line in production and found nothing — because it was filtered. A project silently losing its theme on every preview page shouldn't be diagnosable only with debug logging on.

## Two tests, because there were two candidate mechanisms

I didn't know whether the theme was lost at load or downstream in `getProjectCSS`, so each test isolates one:

| Test | Before | Meaning |
|---|---|---|
| `@theme` at the one path this route read | **passed** | nothing lost downstream — the load is the problem |
| stylesheet at `styles/globals.css` | **failed** | not found at all |

The second fails without this change.

## ⚠️ Honest caveat for review

This fixes the resolution gap, which is a real defect on its own. But **codersociety's `globals.css` is at the repository root**, so the narrow path list alone does not explain that project. Resolving from the file list is what I expect fixes it — sources there arrive from the control plane, not local disk — but I could not prove that without a hosted environment.

**So: verify codersociety's preview after this deploys.** If it's still themeless, the remaining cause is in how the API-backed fs adapter serves that read, and this PR will have narrowed it rather than closed it.

## Verification

- 27 files / 229 steps across dev handlers
- 42 files / 530 steps across styles-builder and the rendering orchestrator
- `deno lint`, `fmt`, `check` clean on the changed files
- The two `TS2353` errors under styles-builder and rendering are pre-existing — confirmed by stashing onto a clean tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development CSS handling to discover stylesheets from configured and conventional project locations.
  * Project-level `@theme` declarations are now included in served CSS.
  * Added fallback handling when source files are unavailable or stylesheets cannot be found.
  * Stylesheets at `styles/globals.css` are now correctly discovered and compiled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->