### PR TITLE
feat(eval,cli): describe metrics in prose and restructure eval output

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../../../src/integrations/source-policy.ts";
 import { saveToken } from "../../auth/token-store.ts";
 import { setJsonMode } from "../../shared/json-output.ts";
+import { stripAnsi } from "../../ui/ansi.ts";
 import {
   applyGatewayBillingGroupFinalization,
   createAgentAdapter,
@@ -343,24 +344,25 @@ async function captureConsoleOutput(fn: () => Promise<unknown>): Promise<{
 
 function relevantEvalHumanLines(output: { stdout: string[]; stderr: string[] }): string[] {
   return [...output.stdout, ...output.stderr]
+    .map((line) => stripAnsi(line))
     .map((line) => {
       // Strip logger text-mode prefix before matching content.
       // Server preset (default in tests): "HH:MM:SS  TAGNAME    G " = 23 chars (PREFIX_WIDTH).
       // CLI preset (when entry point sets it): "  G " = 4 chars.
       if (/^\d{2}:\d{2}:\d{2}\s{2}/.test(line)) return line.slice(23);
       if (/^\s{2}[·●!✗]\s/.test(line)) return line.slice(4);
+      // The eval command writes its own lines to stdout at a 2-space indent, no logger involved.
+      if (line.startsWith("  ")) return line.slice(2);
       return line;
     })
     .filter((line) =>
-      line.startsWith("Eval ") ||
+      line.startsWith("Eval:") ||
       line.startsWith("Target: ") ||
       line.startsWith("Result: ") ||
-      line.startsWith("Report directory: ") ||
-      line.startsWith("Report markdown: ") ||
       line.startsWith("Report: ") ||
+      line.startsWith("Report JSON: ") ||
       line.startsWith("JUnit: ") ||
       line.startsWith("Baseline written: ") ||
-      line.startsWith("Suite report: ") ||
       line.startsWith("Model: ") ||
       line.startsWith("Recommendation: ") ||
       line.startsWith("  - ") ||
@@ -368,6 +370,14 @@ function relevantEvalHumanLines(output: { stdout: string[]; stderr: string[] }):
       line.startsWith("Comparison markdown: ") ||
       line.startsWith("Eval suite: ")
     );
+}
+
+/** The `●` lines, which mark individual metric assertions and nothing else. */
+function evalMetricLines(output: { stdout: string[] }): string[] {
+  return output.stdout
+    .map((line) => stripAnsi(line))
+    .filter((line) => line.startsWith("  ● "))
+    .map((line) => line.slice(4));
 }
 
 function parseLastJsonEnvelope(output: { stdout: string[] }): {
@@ -1156,6 +1166,70 @@ describe("eval CLI command helpers", () => {
     }
   });
 
+  it("describes each metric in prose, naming the tool it asserted on", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-eval-metric-labels-" });
+    const configHome = await Deno.makeTempDir({ prefix: "vf-eval-metric-labels-auth-" });
+    const fixtureAgent = {
+      id: "fixture",
+      config: {},
+      generate: async () => ({
+        text: "expected",
+        messages: [],
+        status: "completed",
+        toolCalls: [],
+      } satisfies AgentResponse),
+    } as unknown as Agent;
+    const labelled = evalAgent({
+      id: "eval:labelled",
+      name: "Assistant smoke test",
+      target: "agent:fixture",
+      dataset: [{ id: "only", input: "only" }],
+      metrics: [
+        metrics.agent.calledTool("calculator").gate(),
+        metrics.agent.noFailedTools().gate(),
+        metrics.answer.contains({ text: "expected" }).gate(),
+      ],
+    });
+    labelled.source = { filePath: `${projectDir}/evals/labelled.eval.ts`, exportName: "default" };
+    const runtime = createProjectRuntimeDiscovery(normalizeSourceIntegrationPolicy({ allow: {} }));
+    runtime.agents.set(fixtureAgent.id, fixtureAgent);
+    runtime.evals.set(labelled.id, labelled);
+
+    try {
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORT");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+
+      const output = await captureConsoleOutput(async () => {
+        await runEvalCommand(
+          {
+            id: "labelled",
+            list: false,
+            exporters: [],
+            debug: false,
+            candidateModels: [],
+            projectDir,
+            reportDir: `${projectDir}/report`,
+          },
+          { discoverProjectAgentRuntime: () => Promise.resolve(runtime) },
+        );
+      });
+
+      // The definition name heads the block, not the generated eval id.
+      assertEquals(relevantEvalHumanLines(output)[0], "Eval:   Assistant smoke test");
+      assertEquals(evalMetricLines(output), [
+        'Agent called tool "calculator": 0/1 passed (0%)',
+        "Agent had no failed tool calls: 1/1 passed (100%)",
+        'Answer contained "expected": 1/1 passed (100%)',
+      ]);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
+  });
+
   it("prints single, suite, and comparison eval output in CLI-owned order", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-eval-output-order-" });
     const configHome = await Deno.makeTempDir({ prefix: "vf-eval-output-order-auth-" });
@@ -1212,12 +1286,11 @@ describe("eval CLI command helpers", () => {
         assertEquals(exitCode, 0);
       });
       assertEquals(relevantEvalHumanLines(singleOutput), [
-        "Eval eval:single-output",
+        "Eval:   eval:single-output",
         "Target: agent:fixture",
         "Result: 1/1 passed (100%)",
-        `Report directory: ${projectDir}/single`,
-        `Report markdown: ${projectDir}/single/report.md`,
-        `Report: ${projectDir}/single/report.json`,
+        `Report: ${projectDir}/single/report.md`,
+        `Report JSON: ${projectDir}/single/report.json`,
         `JUnit: ${projectDir}/single/junit.xml`,
         `Baseline written: ${projectDir}/single/baseline.json`,
       ]);
@@ -1238,17 +1311,14 @@ describe("eval CLI command helpers", () => {
         assertEquals(typeof exitCode, "number");
       });
       assertEquals(relevantEvalHumanLines(suiteOutput), [
-        "Eval eval:single-output",
+        "Eval:   eval:single-output",
         "Target: agent:fixture",
         "Result: 1/1 passed (100%)",
-        `Report directory: ${projectDir}/suite/001-single-output`,
-        "Eval eval:suite-output",
+        "Eval:   eval:suite-output",
         "Target: agent:fixture",
         "Result: 1/1 passed (100%)",
-        `Report directory: ${projectDir}/suite/002-suite-output`,
         "Eval suite: 2/2 passed",
-        `Report directory: ${projectDir}/suite`,
-        `Suite report: ${projectDir}/suite/report.md`,
+        `Report: ${projectDir}/suite/report.md`,
         `JUnit: ${projectDir}/suite/junit.xml`,
       ]);
 
@@ -1271,12 +1341,12 @@ describe("eval CLI command helpers", () => {
       });
       const comparisonLines = relevantEvalHumanLines(comparisonOutput);
       assertEquals(comparisonLines.slice(0, 8), [
-        "Model: test/baseline",
-        "Eval eval:single-output",
+        "Model:  test/baseline",
+        "Eval:   eval:single-output",
         "Target: agent:fixture",
         "Result: 1/1 passed (100%)",
-        "Model: test/candidate",
-        "Eval eval:single-output",
+        "Model:  test/candidate",
+        "Eval:   eval:single-output",
         "Target: agent:fixture",
         "Result: 1/1 passed (100%)",
       ]);
@@ -1287,10 +1357,9 @@ describe("eval CLI command helpers", () => {
       ]);
       assertStringIncludes(comparisonLines[11] ?? "", "  - ");
       assertEquals(comparisonLines.slice(12), [
-        `Report directory: ${projectDir}/comparison`,
         `Comparison: ${projectDir}/comparison/comparison.json`,
         `Comparison markdown: ${projectDir}/comparison/comparison.md`,
-        `Report: ${projectDir}/comparison/report.json`,
+        `Report JSON: ${projectDir}/comparison/report.json`,
       ]);
     } finally {
       await Deno.remove(projectDir, { recursive: true });

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -39,6 +39,7 @@ import {
   runWithVeryfrontCloudContextAsync,
 } from "veryfront/provider";
 import { applyRuntimeAuthContext, resolveLinkedProjectSlug } from "#cli/shared/runtime-auth";
+import { brand, dim } from "#cli/ui";
 import { cliLogger, exitProcess, VERSION } from "#cli/utils";
 import {
   discoverProjectAgentRuntime,
@@ -799,26 +800,65 @@ function getDiscoveredEvals(runtime: ProjectAgentRuntimeDiscovery): DiscoveredEv
   });
 }
 
-function printReport(report: EvalReport, baseline?: EvalReportComparison): void {
-  cliLogger.info(`Eval ${report.definitionId}`);
-  cliLogger.info(`Target: ${report.target}`);
-  cliLogger.info(
-    `Result: ${report.summary.passed}/${report.summary.records} passed (${
-      Math.round(report.summary.passRate * 100)
-    }%)`,
+/**
+ * Eval output is written straight to stdout rather than through `cliLogger`, because the logger
+ * stamps every line with its level glyph. Here the `●` is meaningful on its own: it marks the
+ * individual metric assertions, and nothing else, so a reader can find them without reading labels.
+ */
+function printLine(text: string): void {
+  console.log(`  ${text}`);
+}
+
+function printBlankLine(): void {
+  console.log("");
+}
+
+/** Width of "Target:", the longest header label, so the header values line up in one column. */
+const HEADER_LABEL_WIDTH = "Target:".length + 1;
+
+function printHeader(label: string, value: string): void {
+  printLine(`${`${label}:`.padEnd(HEADER_LABEL_WIDTH)}${value}`);
+}
+
+/** Written artifacts are follow-up detail for the results above them, so they are dimmed. */
+function printArtifact(label: string, path: string): void {
+  printLine(dim(`${label}: ${path}`));
+}
+
+function formatPercent(rate: number): string {
+  return `${Math.round(rate * 100)}%`;
+}
+
+function printReport(
+  report: EvalReport,
+  options: { name?: string; baseline?: EvalReportComparison } = {},
+): void {
+  printHeader("Eval", options.name ?? report.definitionId);
+  printHeader("Target", report.target);
+  printHeader(
+    "Result",
+    `${report.summary.passed}/${report.summary.records} passed (${
+      formatPercent(report.summary.passRate)
+    })`,
   );
 
+  if (report.summary.metrics.length > 0) printBlankLine();
   for (const metric of report.summary.metrics) {
-    cliLogger.info(
-      `  ${metric.name}: ${metric.passed}/${metric.passed + metric.failed} passed (${
-        Math.round(metric.passRate * 100)
-      }%)`,
+    const total = metric.passed + metric.failed;
+    printLine(
+      `${brand("●")} ${metric.label ?? metric.name}: ${metric.passed}/${total} passed (${
+        formatPercent(metric.passRate)
+      })`,
     );
   }
 
+  const { baseline } = options;
+  const notes = (report.exports ?? []).length > 0 || baseline !== undefined;
+  if (notes) printBlankLine();
+
   for (const result of report.exports ?? []) {
     if (result.ok) {
-      cliLogger.info(`Export ${result.exporterId}: ok`);
+      printLine(`Export ${result.exporterId}: ok`);
     } else {
       cliLogger.warn(`Export ${result.exporterId}: failed: ${result.error}`);
     }
@@ -826,7 +866,7 @@ function printReport(report: EvalReport, baseline?: EvalReportComparison): void 
 
   if (baseline) {
     const direction = baseline.passRateDelta >= 0 ? "+" : "";
-    cliLogger.info(
+    printLine(
       `Baseline: ${baseline.regressed ? "regressed" : "ok"} (${direction}${
         Math.round(baseline.passRateDelta * 100)
       } pp pass rate)`,
@@ -1278,20 +1318,18 @@ export async function runEvalCommand(
                 artifacts: outcome.artifacts,
               }));
             } else {
-              for (const child of outcome.outputHints.children ?? []) {
+              for (const [index, child] of (outcome.outputHints.children ?? []).entries()) {
+                if (index > 0) printBlankLine();
                 if (child.kind === "report") {
-                  printReport(child.report);
-                  cliLogger.info(`Report directory: ${child.reportDirectory}`);
+                  printReport(child.report, { name: child.name });
                 } else {
                   cliLogger.error(`Eval ${child.evalId}: ${child.error}`);
                 }
               }
-              cliLogger.info(
-                `Eval suite: ${outcome.suite.passed}/${outcome.suite.total} passed`,
-              );
-              cliLogger.info(`Report directory: ${outcome.outputHints.reportDirectory}`);
-              cliLogger.info(`Suite report: ${outcome.outputHints.reportMarkdown}`);
-              if (outcome.outputHints.junit) cliLogger.info(`JUnit: ${outcome.outputHints.junit}`);
+              printBlankLine();
+              printLine(`Eval suite: ${outcome.suite.passed}/${outcome.suite.total} passed`);
+              printArtifact("Report", outcome.outputHints.reportMarkdown);
+              if (outcome.outputHints.junit) printArtifact("JUnit", outcome.outputHints.junit);
             }
             return outcome.exitCode;
           },
@@ -1402,28 +1440,30 @@ export async function runEvalCommand(
                 artifacts: outcome.artifacts,
               }));
             } else {
-              for (const model of outcome.outputHints.models ?? []) {
-                cliLogger.info(`Model: ${model.model}`);
-                printReport(model.report);
+              for (const [index, model] of (outcome.outputHints.models ?? []).entries()) {
+                if (index > 0) printBlankLine();
+                printHeader("Model", model.model);
+                printReport(model.report, { name: evalItem.name });
               }
               const recommendation = outcome.comparison.recommendation;
-              cliLogger.info(
+              printBlankLine();
+              printLine(
                 `Recommendation: ${recommendation.decision}${
                   recommendation.model ? ` (${recommendation.model})` : ""
                 }`,
               );
               for (const reason of recommendation.reasons) {
-                cliLogger.info(`  - ${reason}`);
+                printLine(`  - ${reason}`);
               }
-              cliLogger.info(`Report directory: ${outcome.outputHints.reportDirectory}`);
+              printBlankLine();
               if (outcome.outputHints.comparisonJson) {
-                cliLogger.info(`Comparison: ${outcome.outputHints.comparisonJson}`);
+                printArtifact("Comparison", outcome.outputHints.comparisonJson);
               }
               if (outcome.outputHints.comparisonMarkdown) {
-                cliLogger.info(`Comparison markdown: ${outcome.outputHints.comparisonMarkdown}`);
+                printArtifact("Comparison markdown", outcome.outputHints.comparisonMarkdown);
               }
               if (outcome.outputHints.report) {
-                cliLogger.info(`Report: ${outcome.outputHints.report}`);
+                printArtifact("Report JSON", outcome.outputHints.report);
               }
             }
             return outcome.exitCode;
@@ -1486,13 +1526,16 @@ export async function runEvalCommand(
           artifacts: outcome.artifacts,
         }));
       } else {
-        printReport(outcome.report, outcome.baseline);
-        cliLogger.info(`Report directory: ${outcome.outputHints.reportDirectory}`);
-        cliLogger.info(`Report markdown: ${outcome.outputHints.reportMarkdown}`);
-        if (outcome.outputHints.report) cliLogger.info(`Report: ${outcome.outputHints.report}`);
-        if (outcome.outputHints.junit) cliLogger.info(`JUnit: ${outcome.outputHints.junit}`);
+        printReport(outcome.report, {
+          name: evalItem.name,
+          ...(outcome.baseline ? { baseline: outcome.baseline } : {}),
+        });
+        printBlankLine();
+        printArtifact("Report", outcome.outputHints.reportMarkdown);
+        if (outcome.outputHints.report) printArtifact("Report JSON", outcome.outputHints.report);
+        if (outcome.outputHints.junit) printArtifact("JUnit", outcome.outputHints.junit);
         if (outcome.outputHints.baselineWritten) {
-          cliLogger.info(`Baseline written: ${outcome.outputHints.baselineWritten}`);
+          printArtifact("Baseline written", outcome.outputHints.baselineWritten);
         }
       }
 

--- a/docs/api-reference/veryfront/eval.md
+++ b/docs/api-reference/veryfront/eval.md
@@ -74,7 +74,7 @@ const report = await runEval(definition, {
 | `compareEvalReports`                | Compare a current eval report against a saved baseline report.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/baseline.ts#L194)         |
 | `createEvalDatasetMetadata`         | Create stable dataset metadata for report consumers and CI artifacts.                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L71)            |
 | `createEvalModelComparisonMarkdown` | Render a human-reviewable markdown summary for a model comparison report.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/model-comparison.ts#L828) |
-| `createEvalReport`                  | Create a JSON-serializable eval report from executed records.                                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L326)           |
+| `createEvalReport`                  | Create a JSON-serializable eval report from executed records.                                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L332)           |
 | `createEvalRunId`                   | Create a timestamp-sortable eval run id with a collision-resistant suffix.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/run-id.ts#L8)             |
 | `createEvalRunProvenance`           | Build stable provenance metadata from explicit git/cloud inputs.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/provenance.ts#L140)       |
 | `createEvalSourceDocument`          | Create the normalized Eval document Studio can list, inspect, and edit.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L312)           |
@@ -87,7 +87,7 @@ const report = await runEval(definition, {
 | `isEvalDefinition`                  | Check whether a value is a normalized eval definition.                                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/factory.ts#L119)          |
 | `resolveEvalRunProvenance`          | Resolve local or Cloud provenance for an eval run without failing the eval if git metadata is unavailable. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/provenance.ts#L255)       |
 | `runEval`                           | Execute an eval locally with injected target adapters.                                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/runner.ts#L583)           |
-| `summarizeEvalRecords`              | Summarize eval records into pass/fail and metric aggregates.                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L303)           |
+| `summarizeEvalRecords`              | Summarize eval records into pass/fail and metric aggregates.                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L309)           |
 
 ### Types
 
@@ -100,7 +100,7 @@ const report = await runEval(definition, {
 | `EvalAgentAdapterResult`              | Agent adapter result normalized into an eval record.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L447)    |
 | `EvalAgentInput`                      | Input accepted by `evalAgent`.                                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L406)    |
 | `EvalAnswerGroundednessMetricOptions` | Options for judge-backed answer grounding checks.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L231)    |
-| `EvalBudgetDeltaSummary`              | Numeric budget delta between a current eval report and a baseline report.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L603)    |
+| `EvalBudgetDeltaSummary`              | Numeric budget delta between a current eval report and a baseline report.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L608)    |
 | `EvalCheckContext`                    | Context passed to an eval definition's `check` callback.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L357)    |
 | `EvalCitation`                        | Citation emitted by an answer and matched against retrieved or expected sources.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L258)    |
 | `EvalDataset`                         | Dataset loader used by an eval definition.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L131)    |
@@ -108,15 +108,15 @@ const report = await runEval(definition, {
 | `EvalDefinition`                      | First-class eval definition discovered from project source.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L387)    |
 | `EvalDiscoveryOptions`                | Options for project-local eval discovery.                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L42) |
 | `EvalDiscoveryResult`                 | Result returned by eval discovery.                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L54) |
-| `EvalDurationSummary`                 | Duration aggregate for an eval report.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L524)    |
+| `EvalDurationSummary`                 | Duration aggregate for an eval report.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L529)    |
 | `EvalEditableField`                   | Form-editable Eval source field name.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L241)   |
 | `EvalExample`                         | Normalized dataset example used by eval runners and reports.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L110)    |
 | `EvalExampleInput`                    | Dataset example shape accepted by eval definitions.                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L118)    |
 | `EvalExpect`                          | Built-in expectation helpers available inside `check`.                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L347)    |
 | `EvalExpectation`                     | Fluent severity helpers for `check` expectations.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L340)    |
-| `EvalFailedExampleSummary`            | Per-example failure aggregate included in a report summary.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L571)    |
-| `EvalFlakeSummary`                    | Flake classification for repeated eval examples.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L581)    |
-| `EvalGateFailureSummary`              | Blocking failure included in a report summary.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L559)    |
+| `EvalFailedExampleSummary`            | Per-example failure aggregate included in a report summary.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L576)    |
+| `EvalFlakeSummary`                    | Flake classification for repeated eval examples.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L586)    |
+| `EvalGateFailureSummary`              | Blocking failure included in a report summary.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L564)    |
 | `EvalKnowledgeCitationMetricOptions`  | Options for citation precision and recall over retrieved knowledge.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L222)    |
 | `EvalKnowledgeExpectedSource`         | Expected knowledge source or passage for retrieval-quality metrics.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L192)    |
 | `EvalKnowledgeMrrMetricOptions`       | Options for mean reciprocal rank over retrieved knowledge.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L214)    |
@@ -125,7 +125,7 @@ const report = await runEval(definition, {
 | `EvalLlmRubricJudgeOptions`           | Options for the built-in general-purpose LLM rubric judge.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/judges.ts#L24)    |
 | `EvalMetric`                          | Metric contract used by eval definitions.                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L327)    |
 | `EvalMetricContext`                   | Optional runtime context passed to metric evaluators.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L322)    |
-| `EvalMetricDeltaSummary`              | Per-metric delta between a current eval report and a baseline report.             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L589)    |
+| `EvalMetricDeltaSummary`              | Per-metric delta between a current eval report and a baseline report.             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L594)    |
 | `EvalMetricFamily`                    | Metric family used for grouping report summaries.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L16)     |
 | `EvalMetricResult`                    | Result emitted by a metric or check assertion.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L309)    |
 | `EvalMetricSummary`                   | Aggregate pass/fail summary for one metric.                                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L513)    |
@@ -133,25 +133,25 @@ const report = await runEval(definition, {
 | `EvalMockTools`                       | Static or request-scoped mock tools for local `evalAgent` execution.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L378)    |
 | `EvalMockToolsResolver`               | Request-scoped mock tool resolver for local `evalAgent` execution.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L373)    |
 | `EvalMockToolsResolverContext`        | Context passed to an agent eval mock tool resolver.                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L366)    |
-| `EvalModelCandidateComparison`        | Candidate-vs-baseline comparison used to decide whether a model is promotable.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L710)    |
-| `EvalModelComparison`                 | Aggregate report for comparing one baseline model against candidate models.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L733)    |
-| `EvalModelComparisonConstraint`       | Hard model comparison eligibility constraint.                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L769)    |
-| `EvalModelComparisonDecision`         | Conservative model comparison recommendation.                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L727)    |
-| `EvalModelComparisonMetricName`       | Metric names available to model comparison constraints and objectives.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L747)    |
-| `EvalModelComparisonObjective`        | Weighted model comparison objective used to rank eligible candidates.             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L776)    |
-| `EvalModelComparisonOptions`          | Promotion thresholds for model comparison.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L782)    |
-| `EvalModelReportSummary`              | Per-model row in an eval model comparison report.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L679)    |
+| `EvalModelCandidateComparison`        | Candidate-vs-baseline comparison used to decide whether a model is promotable.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L715)    |
+| `EvalModelComparison`                 | Aggregate report for comparing one baseline model against candidate models.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L738)    |
+| `EvalModelComparisonConstraint`       | Hard model comparison eligibility constraint.                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L774)    |
+| `EvalModelComparisonDecision`         | Conservative model comparison recommendation.                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L732)    |
+| `EvalModelComparisonMetricName`       | Metric names available to model comparison constraints and objectives.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L752)    |
+| `EvalModelComparisonObjective`        | Weighted model comparison objective used to rank eligible candidates.             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L781)    |
+| `EvalModelComparisonOptions`          | Promotion thresholds for model comparison.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L787)    |
+| `EvalModelReportSummary`              | Per-model row in an eval model comparison report.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L684)    |
 | `EvalRecord`                          | One executed example and repetition inside an eval report.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L287)    |
-| `EvalReport`                          | JSON-serializable report produced by `runEval`.                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L814)    |
-| `EvalReportComparison`                | Baseline comparison for a current eval report.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L624)    |
-| `EvalReportComparisonPolicy`          | Regression policy for comparing a current eval report to a saved baseline.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L615)    |
-| `EvalReportDatasetMetadata`           | Stable dataset identity attached to new eval reports when examples are available. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L671)    |
+| `EvalReport`                          | JSON-serializable report produced by `runEval`.                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L819)    |
+| `EvalReportComparison`                | Baseline comparison for a current eval report.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L629)    |
+| `EvalReportComparisonPolicy`          | Regression policy for comparing a current eval report to a saved baseline.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L620)    |
+| `EvalReportDatasetMetadata`           | Stable dataset identity attached to new eval reports when examples are available. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L676)    |
 | `EvalReportExportConfig`              | Export configuration for a completed eval report.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L504)    |
-| `EvalReportMetadata`                  | Additional report metadata that should not affect pass/fail semantics.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L665)    |
-| `EvalReportSummary`                   | Aggregate pass/fail summary for one eval report.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L793)    |
+| `EvalReportMetadata`                  | Additional report metadata that should not affect pass/fail semantics.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L670)    |
+| `EvalReportSummary`                   | Aggregate pass/fail summary for one eval report.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L798)    |
 | `EvalRetrievedContext`                | Retrieved context item captured for deterministic RAG metrics.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L246)    |
 | `EvalRun`                             | V2-ready Eval run projection.                                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L249)   |
-| `EvalRunProvenance`                   | Runtime and source identity attached to an eval report.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L639)    |
+| `EvalRunProvenance`                   | Runtime and source identity attached to an eval report.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L644)    |
 | `EvalSeverity`                        | How a metric result affects the final eval result.                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L13)     |
 | `EvalSource`                          | Source location for a discovered eval definition.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L381)    |
 | `EvalSourceDocument`                  | Studio-editable Eval source document.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L245)   |
@@ -170,7 +170,7 @@ const report = await runEval(definition, {
 | `EvalToolInputMatchMode`              | How expected tool input is compared to the captured tool input.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L176)    |
 | `EvalTrace`                           | Trace metadata captured for one eval record.                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L281)    |
 | `EvalUsage`                           | Token and cost usage captured for one eval record.                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L148)    |
-| `EvalUsageSummary`                    | Usage totals for an eval report.                                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L534)    |
+| `EvalUsageSummary`                    | Usage totals for an eval report.                                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L539)    |
 | `RunEvalOptions`                      | Options for running an eval locally.                                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L491)    |
 
 ### Constants
@@ -186,7 +186,7 @@ const report = await runEval(definition, {
 | `getEvalStudioCapabilitySchema` | Schema for Eval Studio capabilities.                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L7)    |
 | `getEvalTargetKindSchema`       | Schema for an Eval target primitive kind.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L12)   |
 | `judges`                        | Built-in judge factories for semantic eval metrics.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/judges.ts#L404)  |
-| `metrics`                       | Metric factories for deterministic answers, agent behavior, operations, and judges. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/metrics.ts#L762) |
+| `metrics`                       | Metric factories for deterministic answers, agent behavior, operations, and judges. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/metrics.ts#L766) |
 
 ## Deep imports
 

--- a/src/eval/metric-labels.test.ts
+++ b/src/eval/metric-labels.test.ts
@@ -1,0 +1,58 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { formatEvalMetricLabel } from "./metric-labels.ts";
+
+describe("eval/metric-labels", () => {
+  it("names the parameter that makes a metric specific", () => {
+    assertEquals(
+      formatEvalMetricLabel("agent.calledTool", { tool: "calculator" }),
+      'Agent called tool "calculator"',
+    );
+    assertEquals(
+      formatEvalMetricLabel("agent.notCalledTool", { tool: "refunds_issue" }),
+      'Agent did not call tool "refunds_issue"',
+    );
+    assertEquals(formatEvalMetricLabel("knowledge.recallAtK", { k: 5 }), "Knowledge recall@5");
+    assertEquals(
+      formatEvalMetricLabel("ops.latency", { maxMs: 2000 }),
+      "Latency stayed under 2000ms",
+    );
+    assertEquals(formatEvalMetricLabel("ops.cost", { maxUsd: 0.05 }), "Cost stayed under $0.05");
+  });
+
+  it("phrases parameterless metrics without inventing a parameter", () => {
+    assertEquals(formatEvalMetricLabel("agent.noFailedTools"), "Agent had no failed tool calls");
+    assertEquals(formatEvalMetricLabel("judge.rubric"), "LLM as a judge passed");
+    assertEquals(
+      formatEvalMetricLabel("answer.exactMatch"),
+      "Answer matched the reference exactly",
+    );
+  });
+
+  it("falls back to a generic phrasing when the config is missing or the wrong type", () => {
+    assertEquals(formatEvalMetricLabel("agent.calledTool"), "Agent called the expected tool");
+    assertEquals(
+      formatEvalMetricLabel("agent.calledTool", { tool: 42 }),
+      "Agent called the expected tool",
+    );
+    assertEquals(formatEvalMetricLabel("knowledge.mrr", {}), "Knowledge MRR");
+    assertEquals(
+      formatEvalMetricLabel("ops.cost", { maxUsd: Number.NaN }),
+      "Cost stayed within budget",
+    );
+  });
+
+  it("elides a long parameter so a metric line stays on one row", () => {
+    const pattern = "a".repeat(60);
+
+    assertEquals(
+      formatEvalMetricLabel("answer.regex", { pattern }),
+      `Answer matched pattern ${"a".repeat(39)}…`,
+    );
+  });
+
+  it("returns undefined for unknown metrics so callers can print the raw name", () => {
+    assertEquals(formatEvalMetricLabel("custom.metric"), undefined);
+    assertEquals(formatEvalMetricLabel("toString"), undefined);
+  });
+});

--- a/src/eval/metric-labels.ts
+++ b/src/eval/metric-labels.ts
@@ -1,0 +1,100 @@
+/**
+ * Human-readable labels for the built-in metrics.
+ *
+ * A metric summary is keyed by its factory name, and a bare `agent.calledTool` does not tell a
+ * reader which tool the eval actually asserted on. Each label is built from the metric name plus
+ * the config its factory captured, so the parameter that makes the assertion specific travels with
+ * the result into reports and CLI output.
+ *
+ * @module
+ */
+
+/** Longest metric parameter rendered inline before it is elided. Keeps CLI lines from wrapping. */
+const MAX_PARAM_LENGTH = 40;
+
+// Null-prototype: a metric named `toString` or `constructor` must miss the table, not inherit a
+// function off `Object.prototype` and hand it back as a label.
+const STATIC_LABELS: Record<string, string> = Object.assign(Object.create(null), {
+  "answer.exactMatch": "Answer matched the reference exactly",
+  "answer.jsonMatch": "Answer matched the expected JSON",
+  "answer.groundedness": "Answer was grounded in its sources",
+  "agent.noFailedTools": "Agent had no failed tool calls",
+  "knowledge.citationPrecision": "Knowledge citations were precise",
+  "knowledge.citationRecall": "Knowledge citations were complete",
+  "ops.tokens": "Token usage stayed within budget",
+  "judge.rubric": "LLM as a judge passed",
+});
+
+function readString(config: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = config?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNumber(config: Record<string, unknown> | undefined, key: string): number | undefined {
+  const value = config?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function elide(value: string): string {
+  return value.length <= MAX_PARAM_LENGTH ? value : `${value.slice(0, MAX_PARAM_LENGTH - 1)}…`;
+}
+
+/**
+ * Describe a metric in prose. Returns `undefined` for names with no known phrasing so callers can
+ * fall back to the raw metric name rather than print a worse guess.
+ */
+export function formatEvalMetricLabel(
+  name: string,
+  config?: Record<string, unknown>,
+): string | undefined {
+  switch (name) {
+    case "answer.contains": {
+      const text = readString(config, "text");
+      return text ? `Answer contained "${elide(text)}"` : "Answer contained the expected text";
+    }
+    case "answer.regex": {
+      const pattern = readString(config, "pattern");
+      return pattern
+        ? `Answer matched pattern ${elide(pattern)}`
+        : "Answer matched the expected pattern";
+    }
+    case "agent.calledTool": {
+      const tool = readString(config, "tool");
+      return tool ? `Agent called tool "${tool}"` : "Agent called the expected tool";
+    }
+    case "agent.notCalledTool": {
+      const tool = readString(config, "tool");
+      return tool ? `Agent did not call tool "${tool}"` : "Agent avoided the excluded tool";
+    }
+    case "agent.toolCallCount": {
+      const tool = readString(config, "tool");
+      return tool
+        ? `Agent call count for tool "${tool}" was in range`
+        : "Agent tool call count was in range";
+    }
+    case "knowledge.recallAtK": {
+      const k = readNumber(config, "k");
+      return k === undefined ? "Knowledge recall" : `Knowledge recall@${k}`;
+    }
+    case "knowledge.precisionAtK": {
+      const k = readNumber(config, "k");
+      return k === undefined ? "Knowledge precision" : `Knowledge precision@${k}`;
+    }
+    case "knowledge.mrr": {
+      const k = readNumber(config, "k");
+      return k === undefined ? "Knowledge MRR" : `Knowledge MRR@${k}`;
+    }
+    case "ops.latency": {
+      const maxMs = readNumber(config, "maxMs");
+      return maxMs === undefined
+        ? "Latency stayed within budget"
+        : `Latency stayed under ${maxMs}ms`;
+    }
+    case "ops.cost": {
+      const maxUsd = readNumber(config, "maxUsd");
+      return maxUsd === undefined ? "Cost stayed within budget" : `Cost stayed under $${maxUsd}`;
+    }
+    default:
+      return STATIC_LABELS[name];
+  }
+}

--- a/src/eval/metrics.test.ts
+++ b/src/eval/metrics.test.ts
@@ -34,6 +34,7 @@ describe("eval/metrics", () => {
       severity: "gate",
       score: 1,
       pass: true,
+      label: "Answer matched the reference exactly",
     });
     assertEquals((await contains.evaluate(createRecord())).pass, true);
     assertEquals((await regex.evaluate(createRecord())).pass, true);
@@ -240,6 +241,7 @@ describe("eval/metrics", () => {
         severity: "budget",
         score: 0,
         pass: false,
+        label: "Cost stayed under $0.05",
         evidence: {
           costUsd: 0.1,
           maxUsd: 0.05,
@@ -280,6 +282,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 1,
         pass: true,
+        label: 'Agent called tool "orders_lookup"',
         evidence: {
           tool: "orders_lookup",
           calls: 1,
@@ -296,6 +299,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 1,
         pass: true,
+        label: 'Agent did not call tool "refunds_issue"',
         evidence: { tool: "refunds_issue", calls: 0 },
       },
     );
@@ -307,6 +311,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 1,
         pass: true,
+        label: 'Agent call count for tool "orders_lookup" was in range',
         evidence: { tool: "orders_lookup", calls: 1, expected: { exact: 1 } },
       },
     );
@@ -321,6 +326,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 0,
         pass: false,
+        label: 'Agent called tool "orders_lookup"',
         evidence: {
           tool: "orders_lookup",
           calls: 1,
@@ -349,6 +355,7 @@ describe("eval/metrics", () => {
       score: 0.95,
       pass: true,
       explanation: "The answer names Paris.",
+      label: "LLM as a judge passed",
     });
 
     const belowThreshold = metrics.judge.rubric({
@@ -402,6 +409,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 0.5,
         pass: true,
+        label: "Knowledge recall@2",
         evidence: {
           tool: "search_knowledge",
           k: 2,
@@ -434,6 +442,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 0.5,
         pass: true,
+        label: "Knowledge precision@2",
         evidence: {
           tool: "search_knowledge",
           k: 2,
@@ -462,6 +471,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 1 / 3,
         pass: true,
+        label: "Knowledge MRR",
         evidence: {
           tool: "search_knowledge",
           k: 3,
@@ -540,6 +550,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 1,
         pass: true,
+        label: "Knowledge recall@2",
         evidence: {
           tool: "search_knowledge",
           k: 2,
@@ -602,6 +613,7 @@ describe("eval/metrics", () => {
         severity: "soft",
         score: 0.5,
         pass: true,
+        label: "Knowledge citations were precise",
         evidence: {
           tool: "search_knowledge",
           citations: [
@@ -629,6 +641,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 0.5,
         pass: true,
+        label: "Knowledge citations were complete",
         evidence: {
           tool: "search_knowledge",
           citations: [
@@ -685,6 +698,7 @@ describe("eval/metrics", () => {
         severity: "gate",
         score: 0.5,
         pass: true,
+        label: "Knowledge citations were precise",
         evidence: {
           tool: "search_knowledge",
           citations: [
@@ -741,6 +755,7 @@ describe("eval/metrics", () => {
         score: 0.9,
         pass: true,
         explanation: "Answer is supported by the retrieved SSO runbook.",
+        label: "Answer was grounded in its sources",
         evidence: {
           tool: "search_knowledge",
           evidenceCount: 1,
@@ -802,6 +817,7 @@ describe("eval/metrics", () => {
         score: 0.95,
         pass: true,
         explanation: "Compact knowledge result contains enough support for the answer.",
+        label: "Answer was grounded in its sources",
         evidence: {
           tool: "search_knowledge",
           evidenceCount: 2,

--- a/src/eval/metrics.ts
+++ b/src/eval/metrics.ts
@@ -13,6 +13,7 @@ import type {
   EvalToolCallCountOptions,
   EvalToolCallMatchOptions,
 } from "./types.ts";
+import { formatEvalMetricLabel } from "./metric-labels.ts";
 import {
   evaluateCalledTool,
   evaluateNotCalledTool,
@@ -721,6 +722,7 @@ function createMetric(
   evaluator: MetricEvaluator,
   config?: Record<string, unknown>,
 ): EvalMetric {
+  const label = formatEvalMetricLabel(name, config);
   const metric = {
     name,
     family,
@@ -733,6 +735,8 @@ function createMetric(
         name,
         family,
         severity: "gate",
+        // An evaluator that phrased its own outcome knows more than the static label does.
+        ...(label !== undefined && result.label === undefined ? { label } : {}),
       };
     },
   };

--- a/src/eval/report.test.ts
+++ b/src/eval/report.test.ts
@@ -299,6 +299,52 @@ describe("eval/report", () => {
     });
   });
 
+  it("carries a metric label into its summary row", () => {
+    const summary = summarizeEvalRecords([
+      createRecord({
+        metrics: [{
+          name: "agent.calledTool",
+          family: "agent",
+          severity: "gate",
+          score: 1,
+          pass: true,
+          label: 'Agent called tool "calculator"',
+        }],
+      }),
+    ]);
+
+    assertEquals(summary.metrics[0]?.label, 'Agent called tool "calculator"');
+  });
+
+  it("drops the label when metrics sharing a summary row disagree on it", () => {
+    const summary = summarizeEvalRecords([
+      createRecord({
+        metrics: [
+          {
+            name: "agent.calledTool",
+            family: "agent",
+            severity: "gate",
+            score: 1,
+            pass: true,
+            label: 'Agent called tool "calculator"',
+          },
+          {
+            name: "agent.calledTool",
+            family: "agent",
+            severity: "gate",
+            score: 1,
+            pass: true,
+            label: 'Agent called tool "search"',
+          },
+        ],
+      }),
+    ]);
+
+    assertEquals(summary.metrics.length, 1);
+    assertEquals(summary.metrics[0]?.passed, 2);
+    assertEquals(summary.metrics[0]?.label, undefined);
+  });
+
   it("returns empty aggregate fields for an empty report", () => {
     assertEquals(summarizeEvalRecords([]), {
       records: 0,

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -272,7 +272,8 @@ function summarizeMetricResults(records: EvalRecord[]): EvalMetricSummary[] {
   for (const record of records) {
     for (const result of allResults(record)) {
       const key = `${result.name}:${result.family}:${result.severity}`;
-      const summary = summaries.get(key) ?? {
+      const existing = summaries.get(key);
+      const summary = existing ?? {
         name: result.name,
         family: result.family,
         severity: result.severity,
@@ -280,7 +281,12 @@ function summarizeMetricResults(records: EvalRecord[]): EvalMetricSummary[] {
         failed: 0,
         skipped: 0,
         passRate: 0,
+        ...(result.label !== undefined ? { label: result.label } : {}),
       };
+
+      // Two metrics of the same name share a summary row — `calledTool("a")` and `calledTool("b")`,
+      // say. No single label describes both, so drop it rather than credit the row to the first.
+      if (existing && existing.label !== result.label) delete existing.label;
 
       if (result.skipped) {
         summary.skipped += 1;

--- a/src/eval/run-report.test.ts
+++ b/src/eval/run-report.test.ts
@@ -846,6 +846,7 @@ describe("runEvalReport suite mode", () => {
       {
         kind: "report",
         evalId: "eval:alpha",
+        name: "Alpha",
         reportDirectory: "suite/001-alpha",
         report: {
           ...reportById.get("eval:alpha")!,
@@ -867,6 +868,7 @@ describe("runEvalReport suite mode", () => {
       {
         kind: "report",
         evalId: "eval:beta",
+        name: "Beta",
         reportDirectory: "suite/003-beta",
         report: {
           ...reportById.get("eval:beta")!,
@@ -883,6 +885,7 @@ describe("runEvalReport suite mode", () => {
       {
         kind: "report",
         evalId: "eval:gamma",
+        name: "Gamma",
         reportDirectory: "suite/004-gamma",
         report: {
           ...reportById.get("eval:gamma")!,

--- a/src/eval/run-report.ts
+++ b/src/eval/run-report.ts
@@ -80,6 +80,8 @@ type EvalRunReportChildOutputHint =
   | {
     kind: "report";
     evalId: string;
+    /** Definition name, for CLI headers that read better than the generated eval id. */
+    name: string;
     reportDirectory: string;
     report: EvalReport;
   }
@@ -927,6 +929,7 @@ async function runEvalReportSuite(
       children.push({
         kind: "report",
         evalId: evalItem.id,
+        name: evalItem.name,
         reportDirectory: childArtifacts.directory,
         report,
       });

--- a/src/eval/runner.test.ts
+++ b/src/eval/runner.test.ts
@@ -68,6 +68,7 @@ describe("eval/runner", () => {
         failed: 0,
         skipped: 0,
         passRate: 1,
+        label: "Answer matched the reference exactly",
       },
     ]);
   });

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -518,6 +518,11 @@ export interface EvalMetricSummary {
   failed: number;
   skipped: number;
   passRate: number;
+  /**
+   * Human-readable phrasing of the assertion, including its parameters. Absent when the metric had
+   * no known phrasing, or when results sharing this summary disagreed on it.
+   */
+  label?: string;
 }
 
 /** Duration aggregate for an eval report. */


### PR DESCRIPTION
## What

`veryfront eval` printed one line per metric keyed by factory name, so `agent.calledTool` never said which tool the eval asserted on. It also put the `●` glyph on every line, including report paths, which made nothing stand out.

**Before**

```
  ● Eval eval:assistant
  ● Target: agent:assistant
  ● Result: 1/1 passed (100%)
  ●   agent.calledTool: 1/1 passed (100%)
  ●   agent.noFailedTools: 1/1 passed (100%)
  ●   judge.rubric: 1/1 passed (100%)
  ● Report directory: .veryfront/evals/20260807_081251961_b01ba68d70d06f57/001-assistant
  ● Eval suite: 1/1 passed
  ● Report directory: .veryfront/evals/20260807_081251961_b01ba68d70d06f57
  ● Suite report: .veryfront/evals/20260807_081251961_b01ba68d70d06f57/report.md
```

**After**

```
  Eval:   Assistant smoke test
  Target: agent:assistant
  Result: 1/1 passed (100%)

  ● Agent called tool "calculator": 1/1 passed (100%)
  ● Agent had no failed tool calls: 1/1 passed (100%)
  ● LLM as a judge passed: 1/1 passed (100%)

  Eval suite: 1/1 passed
  Report: .veryfront/evals/20260807_100517129_69ecbeee6f8fb0aa/report.md
```

## Where the label comes from

The parameter that makes an assertion specific lives in the config the metric factory captured, so the label is built there rather than reconstructed in the CLI:

- **`src/eval/metric-labels.ts`** (new) maps a metric name plus its config to prose for all built-in metrics — `agent.calledTool` → `Agent called tool "calculator"`, `ops.cost` → `Cost stayed under $0.05`, `knowledge.recallAtK` → `Knowledge recall@2`. Unknown names return `undefined` so callers fall back to the raw name instead of guessing. Long parameters (the scaffold's regexes) elide at 40 chars so a metric line stays on one row.
- **`createMetric`** is the single choke point every metric funnels through, so the label attaches there and rides on `EvalMetricResult.label` — a field that already existed and was unused.
- **`EvalMetricSummary.label`** carries it into the JSON report, not just the terminal.
- Suite children now carry the definition `name`, so `Eval:` heads the block with `Assistant smoke test` rather than the generated id.

## Known limitation

Two `calledTool` assertions in one eval share a summary row keyed `name:family:severity`. No single label describes both, so it is dropped there and the row falls back to `agent.calledTool`.

The summary key is deliberately unchanged: `src/eval/baseline.ts:12` derives the same key independently, so splitting rows would silently drop data in baseline comparisons.

## Other output changes

- `Report directory` and `Report markdown` collapse into one `Report:` pointing at the markdown.
- `--report` is relabeled `Report JSON:`. That flag writes the JSON summary, not markdown, and previously shared the `Report:` label with the markdown line.
- Per-child `Report directory` lines are gone from suite output; the directory is the report path's parent.

## Testing

- `src/eval/` + `cli/commands/eval/` — 19 passed, 209 steps, 0 failed
- `extensions/ext-eval-report-mlflow/` (the only other consumer of these types) — passing
- `deno lint`, `deno fmt --check`, `lint:module-boundaries`, `lint:dependency-boundaries`, `lint:cli-boundary`, `lint:barrel-jsdoc`, `lint:core-deps`, `docs:api-reference:check` — all passing

New tests cover the label formatter (including fallback and elision paths), label propagation into the summary, the conflict-drop rule, and the rendered CLI lines. Writing the formatter test caught a prototype-pollution bug in the lookup table: a metric named `toString` returned `Object.prototype.toString` as its label. Fixed with a null-prototype object.

The regenerated `docs/api-reference/veryfront/eval.md` contains only source-link line shifts from these edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, human-readable labels for evaluation metrics, including configured parameters where applicable.
  * Evaluation reports now show metric markers, evaluation names, aligned output, and artifact paths.
  * Suite reports identify each evaluation by name and ID.
  * Metric labels are preserved in summaries when results are consistent.

* **Bug Fixes**
  * Conflicting metric labels are no longer incorrectly represented in aggregated summaries.

* **Documentation**
  * Updated evaluation API reference links to match the current source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->