### PR TITLE
fix(ssr): stop installing a `window` global during server rendering

### DIFF
--- a/src/rendering/ssr-globals/dom-stubs.test.ts
+++ b/src/rendering/ssr-globals/dom-stubs.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   createDocumentStub,
@@ -314,7 +314,9 @@ describe("rendering/ssr-globals/dom-stubs", () => {
         setupSSRGlobals();
 
         const globalRecord = globalThis as Record<string, unknown>;
-        const windowStub = globalRecord.window as {
+        // Reached through the document, because SSR installs no `window`
+        // global -- see the "leaves `window` undefined" case below.
+        const windowStub = (globalRecord.document as { defaultView: unknown }).defaultView as {
           ResizeObserver: ObserverStubConstructor;
           IntersectionObserver: ObserverStubConstructor;
           MutationObserver: ObserverStubConstructor;
@@ -329,6 +331,48 @@ describe("rendering/ssr-globals/dom-stubs", () => {
           observer.disconnect();
           assertEquals(observer.takeRecords().length, 0);
         }
+      } finally {
+        resetSSRGlobalsState();
+        for (const name of globalNames) {
+          const descriptor = originalDescriptors.get(name);
+          if (descriptor) {
+            Object.defineProperty(globalThis, name, descriptor);
+          } else {
+            Reflect.deleteProperty(globalThis, name);
+          }
+        }
+      }
+    });
+
+    it("leaves `window` undefined so libraries can still detect the server", () => {
+      const originalDescriptors = new Map<PropertyKey, PropertyDescriptor | undefined>();
+      for (const name of globalNames) {
+        originalDescriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+        Reflect.deleteProperty(globalThis, name);
+      }
+
+      try {
+        resetSSRGlobalsState();
+        setupSSRGlobals();
+
+        const globalRecord = globalThis as Record<string, unknown>;
+
+        // The contract third-party code relies on. A stubbed `window` made
+        // `typeof window === "undefined"` answer "browser" during SSR, which
+        // is how next-themes came to emit `nonce=""` on a nonce-based CSP.
+        assertEquals(typeof globalRecord.window, "undefined");
+
+        // Everything the stub exists to provide is still reachable.
+        assertExists(globalRecord.document);
+        assertEquals(typeof globalRecord.matchMedia, "function");
+        assertEquals(typeof globalRecord.HTMLElement, "function");
+
+        // Including for libraries that reach the window through an element,
+        // which is the access path the stub was written for.
+        const defaultView = (globalRecord.document as { defaultView: Record<string, unknown> })
+          .defaultView;
+        assertExists(defaultView);
+        assertEquals(defaultView.HTMLElement, globalRecord.HTMLElement);
       } finally {
         resetSSRGlobalsState();
         for (const name of globalNames) {

--- a/src/rendering/ssr-globals/index.ts
+++ b/src/rendering/ssr-globals/index.ts
@@ -47,6 +47,9 @@ function setGlobalIfMissing(name: string, value: unknown): void {
 
 export function setupSSRGlobals(): void {
   if (isSSRGlobalsActive()) return;
+  // Both defined means a real browser, which needs nothing from this module.
+  // Since the stub no longer installs `window`, this can no longer be
+  // satisfied by a previous call to this function.
   if (globalThis.window !== undefined && globalThis.document !== undefined) return;
 
   const windowStub = createWindowStub();
@@ -70,7 +73,21 @@ export function setupSSRGlobals(): void {
   }
   (windowStub.document as Record<string, unknown>).defaultView = windowStub;
 
-  setGlobal("window", windowStub);
+  // `window` is deliberately NOT installed as a global.
+  //
+  // `typeof window === "undefined"` is how the ecosystem asks "am I on the
+  // server", and a global stub answers "no". First-party code was given
+  // `isServerEnvironment()` to route around that, but a project's dependencies
+  // cannot call it: next-themes renders its anti-flash script with
+  // `nonce={typeof window === 'undefined' ? nonce : ''}`, took the browser
+  // branch under SSR, emitted `nonce=""`, and CSP blocked the script on every
+  // hosted page that used it.
+  //
+  // Everything the stub actually provides stays reachable. Libraries that need
+  // DOM constructors find them as bare globals below, and the ones that reach
+  // them through an element (Headless UI's focus manager reads
+  // `window.HTMLElement.prototype` via `ownerDocument.defaultView`) resolve
+  // through `document.defaultView`, wired to the stub just above.
   setGlobal("document", windowStub.document);
   setGlobal("navigator", windowStub.navigator);
   setGlobal("location", windowStub.location);


### PR DESCRIPTION
## What

`setupSSRGlobals` no longer installs a bare `window` global. Everything else the stub provides — `document`, `navigator`, `location`, `matchMedia`, storage, DOM constructors — stays, and the constructors remain reachable through `document.defaultView`.

## Why

next-themes renders its anti-flash script with:

```jsx
nonce={typeof window === 'undefined' ? nonce : ''}
```

Under veryfront SSR that ternary took the browser branch, so the script went out as `<script nonce="">`, and a nonce-based CSP blocked it on every render.

Confirmed against production. The blocked script's hash on codersociety's preview is `sha256-Rcq79NsqIRfp7JA/RMr/1IFEj6q7YAyDVrf6BpzxXwM=`, which is exactly the sha256 of that tag's contents in the served HTML. It was the only element in the document with an empty nonce — every framework-emitted script carried the real one.

`typeof window === "undefined"` is how the ecosystem asks whether it is on the server, and the stub answered "no". First-party code was already routed around this — `isServerEnvironment()` (`src/platform/compat/runtime.ts:140`) exists for precisely this reason and consults `__VERYFRONT_SSR__` first — but a project's dependencies cannot call it, so the workaround only ever covered half the problem. Removing the global makes the question answer itself, for everyone.

## Before / after

A probe evaluating next-themes' exact expression under `setupSSRGlobals`:

| | `typeof window` | emitted nonce attr |
|---|---|---|
| before | `"object"` | `""` → blocked |
| after | `"undefined"` | real nonce → allowed |

## Compatibility

Nothing the stub exists to provide is withdrawn. Libraries needing DOM constructors find them as bare globals; those that arrive via an element (Headless UI's focus manager reads `window.HTMLElement.prototype` through `ownerDocument.defaultView`) resolve through `document.defaultView`, wired to the stub.

The early-return guard is unchanged and still correct: `window` and `document` both defined means a real browser, and since this function no longer installs `window`, that condition can no longer be produced by an earlier call to it.

## Verification

Full unit suite green: **3811 passed, 27995 steps, 0 failed**. `deno check`, `lint`, `fmt` clean on `src/rendering/ssr-globals`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering compatibility by avoiding installation of a global `window`.
  * Preserved access to required browser APIs and DOM constructors through supported global and document-level interfaces.
  * Added coverage to verify SSR globals are initialized correctly without browser-specific leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->