### PR TITLE
feat(eval,cli): print why a gated metric failed, not just that it did

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -1231,6 +1231,133 @@ describe("eval CLI command helpers", () => {
     }
   });
 
+  it("prints why a gated metric failed, without restating it as a record error", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-eval-reasons-" });
+    const configHome = await Deno.makeTempDir({ prefix: "vf-eval-reasons-auth-" });
+    const fixtureAgent = {
+      id: "fixture",
+      config: {},
+      generate: async () => ({
+        text: "The split is $33.2366 each.",
+        messages: [],
+        status: "completed",
+        toolCalls: [],
+      } satisfies AgentResponse),
+    } as unknown as Agent;
+    const failing = evalAgent({
+      id: "eval:reasons",
+      target: "agent:fixture",
+      dataset: [{ id: "calculator", input: "split the bill" }],
+      metrics: [
+        metrics.judge.rubric({
+          rubric: "Every amount must be exact to the cent.",
+          judge: () =>
+            Promise.resolve({
+              score: 0.2,
+              pass: false,
+              explanation: "The answer states $33.2366, which is not exact to the cent.",
+            }),
+        }).gate({ min: 0.8 }),
+      ],
+    });
+    failing.source = { filePath: `${projectDir}/evals/reasons.eval.ts`, exportName: "default" };
+    const runtime = createProjectRuntimeDiscovery(normalizeSourceIntegrationPolicy({ allow: {} }));
+    runtime.agents.set(fixtureAgent.id, fixtureAgent);
+    runtime.evals.set(failing.id, failing);
+
+    try {
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORT");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+
+      const output = await captureConsoleOutput(async () => {
+        await runEvalCommand(
+          {
+            id: "reasons",
+            list: false,
+            exporters: [],
+            debug: false,
+            candidateModels: [],
+            projectDir,
+            reportDir: `${projectDir}/report`,
+          },
+          { discoverProjectAgentRuntime: () => Promise.resolve(runtime) },
+        );
+      });
+
+      const printed = [...output.stdout].map((line) => stripAnsi(line));
+      assertEquals(
+        printed.some((line) =>
+          line ===
+            "    calculator: The answer states $33.2366, which is not exact to the cent."
+        ),
+        true,
+      );
+      // The runner flips `completed` off whenever a gate fails, so "Record did not complete."
+      // would only restate the judge verdict above it.
+      assertEquals(printed.some((line) => line.includes("Record did not complete")), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
+  });
+
+  it("keeps a record error that carries detail of its own", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-eval-adapter-" });
+    const configHome = await Deno.makeTempDir({ prefix: "vf-eval-adapter-auth-" });
+    const fixtureAgent = {
+      id: "boom",
+      config: {},
+      generate: () => Promise.reject(new Error("upstream refused the connection")),
+    } as unknown as Agent;
+    const failing = evalAgent({
+      id: "eval:adapter",
+      target: "agent:boom",
+      dataset: [{ id: "calculator", input: "split the bill" }],
+      metrics: [metrics.agent.calledTool("calculator").gate()],
+    });
+    failing.source = { filePath: `${projectDir}/evals/adapter.eval.ts`, exportName: "default" };
+    const runtime = createProjectRuntimeDiscovery(normalizeSourceIntegrationPolicy({ allow: {} }));
+    runtime.agents.set(fixtureAgent.id, fixtureAgent);
+    runtime.evals.set(failing.id, failing);
+
+    try {
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORT");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+
+      const output = await captureConsoleOutput(async () => {
+        await runEvalCommand(
+          {
+            id: "adapter",
+            list: false,
+            exporters: [],
+            debug: false,
+            candidateModels: [],
+            projectDir,
+            reportDir: `${projectDir}/report`,
+          },
+          { discoverProjectAgentRuntime: () => Promise.resolve(runtime) },
+        );
+      });
+
+      // The gate fails too, so the record error is suppressed by the recordId rule alone.
+      // Its text is the only report of why the agent never answered, so it has to survive.
+      const printed = [...output.stdout].map((line) => stripAnsi(line));
+      assertEquals(
+        printed.some((line) => line.includes("upstream refused the connection")),
+        true,
+      );
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
+  });
+
   it("prints no report output under --quiet", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-eval-quiet-" });
     const configHome = await Deno.makeTempDir({ prefix: "vf-eval-quiet-auth-" });

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -14,6 +14,7 @@ import {
 import type {
   DiscoveredEval,
   EvalAgentAdapterContext,
+  EvalGateFailureSummary,
   EvalMockTools,
   EvalModelComparisonMetricName,
   EvalModelComparisonOptions,
@@ -24,6 +25,7 @@ import type {
   EvalToolAdapterContext,
   EvalToolCall,
 } from "veryfront/eval";
+import { RECORD_INCOMPLETE_EXPLANATION } from "../../../src/eval/report.ts";
 import { orchestrateExtensions } from "veryfront/extensions";
 import {
   createEvalReportExporterRegistry,
@@ -834,6 +836,61 @@ function formatPercent(rate: number): string {
   return `${Math.round(rate * 100)}%`;
 }
 
+/** Reasons printed per metric before deferring the rest to the written report. */
+const MAX_PRINTED_REASONS = 3;
+
+/**
+ * Group gate failure explanations by the metric that produced them.
+ *
+ * A failing metric line states that something failed, and the explanation states why. The judge
+ * rubric is the clearest case: its verdict is the whole reason the eval failed, and reading it
+ * used to mean opening `summary.json`.
+ *
+ * `record.error` is dropped only when it carries the `RECORD_INCOMPLETE_EXPLANATION` stand-in and
+ * the record already reported a blocking failure. `isBlockingFailure` clears `completed` for both
+ * gate and budget severities (src/eval/runner.ts), so either one produces that stand-in, and
+ * printing it would restate the failure above it. A record error with text of its own, such as an
+ * adapter error, always prints: it is detail no other line carries.
+ */
+function groupGateFailureReasons(
+  failures: EvalGateFailureSummary[],
+): { byMetric: Map<string, string[]>; unattached: string[] } {
+  const derived = new Set(
+    failures.filter((failure) => failure.name !== "record.error").map((failure) =>
+      failure.recordId
+    ),
+  );
+  const byMetric = new Map<string, string[]>();
+  const unattached: string[] = [];
+
+  for (const failure of failures) {
+    if (!failure.explanation) continue;
+    if (
+      failure.name === "record.error" &&
+      failure.explanation === RECORD_INCOMPLETE_EXPLANATION &&
+      derived.has(failure.recordId)
+    ) continue;
+    const reason = `${failure.exampleId}: ${failure.explanation}`;
+    if (failure.name === "record.error") {
+      unattached.push(reason);
+      continue;
+    }
+    const existing = byMetric.get(failure.name);
+    if (existing) existing.push(reason);
+    else byMetric.set(failure.name, [reason]);
+  }
+
+  return { byMetric, unattached };
+}
+
+function printFailureReasons(reasons: string[]): void {
+  for (const reason of reasons.slice(0, MAX_PRINTED_REASONS)) {
+    printLine(`  ${dim(reason)}`);
+  }
+  const hidden = reasons.length - MAX_PRINTED_REASONS;
+  if (hidden > 0) printLine(`  ${dim(`and ${hidden} more, see the report`)}`);
+}
+
 function printReport(
   report: EvalReport,
   options: { name?: string; baseline?: EvalReportComparison } = {},
@@ -847,6 +904,8 @@ function printReport(
     })`,
   );
 
+  const reasons = groupGateFailureReasons(report.summary.gateFailures ?? []);
+
   if (report.summary.metrics.length > 0) printBlankLine();
   for (const metric of report.summary.metrics) {
     const total = metric.passed + metric.failed;
@@ -855,7 +914,9 @@ function printReport(
         formatPercent(metric.passRate)
       })`,
     );
+    printFailureReasons(reasons.byMetric.get(metric.name) ?? []);
   }
+  printFailureReasons(reasons.unattached);
 
   const { baseline } = options;
   const notes = (report.exports ?? []).length > 0 || baseline !== undefined;

--- a/docs/api-reference/veryfront/eval.md
+++ b/docs/api-reference/veryfront/eval.md
@@ -72,9 +72,9 @@ const report = await runEval(definition, {
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `compareEvalModelReports`           | Compare eval reports from multiple models using conservative promotion rules.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/model-comparison.ts#L756) |
 | `compareEvalReports`                | Compare a current eval report against a saved baseline report.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/baseline.ts#L194)         |
-| `createEvalDatasetMetadata`         | Create stable dataset metadata for report consumers and CI artifacts.                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L71)            |
+| `createEvalDatasetMetadata`         | Create stable dataset metadata for report consumers and CI artifacts.                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L74)            |
 | `createEvalModelComparisonMarkdown` | Render a human-reviewable markdown summary for a model comparison report.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/model-comparison.ts#L828) |
-| `createEvalReport`                  | Create a JSON-serializable eval report from executed records.                                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L333)           |
+| `createEvalReport`                  | Create a JSON-serializable eval report from executed records.                                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L336)           |
 | `createEvalRunId`                   | Create a timestamp-sortable eval run id with a collision-resistant suffix.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/run-id.ts#L8)             |
 | `createEvalRunProvenance`           | Build stable provenance metadata from explicit git/cloud inputs.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/provenance.ts#L140)       |
 | `createEvalSourceDocument`          | Create the normalized Eval document Studio can list, inspect, and edit.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L312)           |
@@ -87,7 +87,7 @@ const report = await runEval(definition, {
 | `isEvalDefinition`                  | Check whether a value is a normalized eval definition.                                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/factory.ts#L119)          |
 | `resolveEvalRunProvenance`          | Resolve local or Cloud provenance for an eval run without failing the eval if git metadata is unavailable. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/provenance.ts#L255)       |
 | `runEval`                           | Execute an eval locally with injected target adapters.                                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/runner.ts#L583)           |
-| `summarizeEvalRecords`              | Summarize eval records into pass/fail and metric aggregates.                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L310)           |
+| `summarizeEvalRecords`              | Summarize eval records into pass/fail and metric aggregates.                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L313)           |
 
 ### Types
 

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -20,6 +20,9 @@ import { computeHash } from "#veryfront/utils";
 /** Additive eval report contract version written by new reports and summary artifacts. */
 export const EVAL_REPORT_SCHEMA_VERSION = 2;
 
+/** Stand-in explanation when a record is incomplete but carries no error of its own. */
+export const RECORD_INCOMPLETE_EXPLANATION = "Record did not complete.";
+
 const USAGE_NUMERIC_KEYS = [
   "inputTokens",
   "outputTokens",
@@ -185,7 +188,7 @@ function createRecordFailure(record: EvalRecord): EvalGateFailureSummary | null 
     name: "record.error",
     family: "check",
     severity: "gate",
-    explanation: record.error ?? "Record did not complete.",
+    explanation: record.error ?? RECORD_INCOMPLETE_EXPLANATION,
   };
 }
 

--- a/src/eval/run-report.ts
+++ b/src/eval/run-report.ts
@@ -2,7 +2,7 @@ import { join, relative } from "#veryfront/compat/path";
 import { compareEvalReports } from "./baseline.ts";
 import type { DiscoveredEval } from "./discovery.ts";
 import { compareEvalModelReports, createEvalModelComparisonMarkdown } from "./model-comparison.ts";
-import { EVAL_REPORT_SCHEMA_VERSION } from "./report.ts";
+import { EVAL_REPORT_SCHEMA_VERSION, RECORD_INCOMPLETE_EXPLANATION } from "./report.ts";
 import { createEvalRunId } from "./run-id.ts";
 import { INVALID_ARGUMENT } from "#veryfront/errors";
 import type {
@@ -587,7 +587,7 @@ function createJunitXml(report: EvalReport): string {
   for (const record of report.records) {
     const failures = blockingResults(record);
     const recordFailure = !record.completed || record.error
-      ? record.error ?? "Record did not complete."
+      ? record.error ?? RECORD_INCOMPLETE_EXPLANATION
       : undefined;
     const attrs = `classname="${xmlEscape(report.definitionId)}" name="${
       xmlEscape(testcaseName(record))


### PR DESCRIPTION
A failing metric line said *that* something failed, never *why*:

```
  ● LLM as a judge passed: 0/1 passed (0%)
```

Everything needed to act on that already existed in `summary.json`, unprinted:

> The answer correctly states the $15.21 tip and $99.71 total, but it does not split the total into $33.24, $33.24, and $33.23; it incorrectly claims $33.24 each.

For a judge rubric the verdict *is* the reason the eval failed. Reading it should not mean opening a JSON artifact.

## After

```
  Eval:   Assistant smoke test
  Target: agent:assistant
  Result: 0/1 passed (0%)

  ● Agent called tool "calculator": 1/1 passed (100%)
  ● Agent had no failed tool calls: 1/1 passed (100%)
  ● LLM as a judge passed: 0/1 passed (0%)
      calculator: The answer correctly states the $15.21 tip and $99.71 total, but ...
```

Explanations print under the metric that produced them, three per metric, then `and N more, see the report`. The cap keeps a large dataset from burying the summary; the pointer says where the rest live.

## Which record errors are suppressed

`summary.gateFailures` also carries a `record.error` entry whenever a record did not complete. Printing it unconditionally would restate the judge verdict directly above it as a second, independent problem.

The rule keys on the *explanation*, not the severity:

```ts
if (
  failure.name === "record.error" &&
  failure.explanation === RECORD_INCOMPLETE_EXPLANATION &&
  derived.has(failure.recordId)
) continue;
```

- `isBlockingFailure` (`src/eval/runner.ts:232`) clears `completed` for **both** `gate` and `budget` severities, so either one yields the synthesized `Record did not complete.` stand-in. Both are suppressed when another failure already explains the record.
- A `record.error` carrying text of its own — an adapter that threw, say — **always** prints. It is the only line explaining why the agent never answered, and nothing else reports it.

The stand-in string was written out at both sites that build it (`report.ts`, `run-report.ts`). It is now an exported `RECORD_INCOMPLETE_EXPLANATION`, so the suppression rule cannot drift from the text it matches.

## Review follow-ups

- **Bounded suppression to the stand-in explanation** ([#discussion_r3736104367](https://github.com/veryfront/veryfront-code/pull/3458#discussion_r3736104367)). CodeRabbit proposed filtering `derived` to `severity === "gate"`. I did not take that: budget failures clear `completed` too, so it would have reintroduced the duplicate line for every budget metric. It did surface a real bug next door — a thrown adapter error being swallowed — which is what the explanation check fixes.
- **Env restore in tests** ([#discussion_r3736104363](https://github.com/veryfront/veryfront-code/pull/3458#discussion_r3736104363)) — skipped with reasoning. Ten tests in this file share the pattern; changing one would make the file inconsistent. Offered as a separate cleanup.

## Testing

- `src/eval/`, `cli/commands/eval/`, `src/extensions/eval/`, `extensions/ext-eval-report-mlflow/`: 21 passed, 255 steps, 0 failed
- `deno lint`, `deno fmt --check` (58 files): clean
- `deno check` on every touched file: clean

Both new tests were verified failing against the previous code first:

- `prints why a gated metric failed, without restating it as a record error`
- `keeps a record error that carries detail of its own` — drives a rejecting adapter plus a failing gate, asserts the upstream message survives

Not from this branch: `deno check src/eval/judges.test.ts` reports three `TS18048 'call' is possibly 'undefined'` errors. They reproduce unchanged on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explanations for gated evaluation metric failures in CLI output.
  * Grouped failure reasons by metric and summarized additional reasons when more than three apply.
  * Preserved independent upstream errors alongside gate failures.

* **Bug Fixes**
  * Removed redundant incomplete-record messages when a more specific metric explanation is available.
  * Standardized incomplete-record explanations across evaluation and report outputs.

* **Documentation**
  * Updated evaluation API reference links and documented the shared incomplete-record explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->