### PR TITLE
fix(agent): let a step batch load_skill with the tools that follow it

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -292,8 +292,12 @@ When an agent uses a skill, the flow is:
    `execute_skill_script(...)` to run scripts from `scripts/`.
 4. Continue with normal tool calls under the active skill policy.
 
-The runtime enforces that non-skill tools cannot run before a successful
-`load_skill` when both are emitted in the same step.
+A step may batch `load_skill` with other tool calls. The runtime runs the calls
+in the order the model emitted them, so a successful `load_skill` activates its
+policy for the remaining calls in that same step: tools the skill allows still
+run, and tools it does not allow are rejected by the active skill policy. Calls
+emitted before `load_skill` run under whatever policy was already active, or
+unrestricted when no skill is loaded yet.
 
 ## Skill script execution
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1298,8 +1298,6 @@ export class AgentRuntime {
 
         this.status = "tool_execution";
         addSpanEvent(loopSpan, "tool_execution_start", { count: response.toolCalls.length });
-        const mustLoadSkillFirstForStep = !skillState.activeSkillPolicy &&
-          response.toolCalls.some((tc) => tc.toolName === LOAD_SKILL_TOOL_ID);
 
         for (const tc of response.toolCalls) {
           throwIfAborted(abortSignal);
@@ -1464,7 +1462,6 @@ export class AgentRuntime {
             const policyCheck = enforceSkillPolicy(
               tc.toolName,
               skillState.activeSkillPolicy,
-              mustLoadSkillFirstForStep,
               {
                 activeSkillId: skillState.activeSkillId,
                 hasSubmittedFormInput: skillState.hasSubmittedFormInput,
@@ -1889,8 +1886,6 @@ export class AgentRuntime {
 
       this.status = "tool_execution";
       const streamedToolCalls = Array.from(state.toolCalls.values());
-      const mustLoadSkillFirstForStep = !skillState.activeSkillPolicy &&
-        streamedToolCalls.some((tc) => tc.name === LOAD_SKILL_TOOL_ID);
 
       for (const tc of streamedToolCalls) {
         throwIfAborted(abortSignal);
@@ -2098,7 +2093,6 @@ export class AgentRuntime {
         const policyCheck = enforceSkillPolicy(
           tc.name,
           skillState.activeSkillPolicy,
-          mustLoadSkillFirstForStep,
           {
             activeSkillId: skillState.activeSkillId,
             hasSubmittedFormInput: skillState.hasSubmittedFormInput,

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -146,9 +146,10 @@ function submittedFormWithActiveSkillMessages(): Message[] {
 }
 
 describe("agent runtime refresh hooks", () => {
-  it("requires universal load_skill to establish policy before parallel tool calls", async () => {
+  it("applies a universal load_skill policy to the rest of its own step", async () => {
     const rootPath = await Deno.makeTempDir();
     let writeExecutions = 0;
+    let deleteExecutions = 0;
     let callCount = 0;
     const model: ModelRuntime = {
       provider: "hosted",
@@ -172,9 +173,9 @@ describe("agent runtime refresh hooks", () => {
               },
               {
                 type: "tool-call",
-                toolCallId: "write-after-skill",
-                toolName: "write_report",
-                input: '{"path":"second-report.md"}',
+                toolCallId: "delete-after-skill",
+                toolName: "delete_report",
+                input: '{"path":"report.md"}',
               },
             ],
             finishReason: "tool-calls",
@@ -200,6 +201,15 @@ describe("agent runtime refresh hooks", () => {
         return { ok: true };
       },
     });
+    const deleteReport = tool({
+      id: "delete_report",
+      description: "Delete a report",
+      inputSchema: defineSchema((v) => v.object({ path: v.string() }))(),
+      execute: () => {
+        deleteExecutions++;
+        return { ok: true };
+      },
+    });
 
     try {
       await Deno.writeTextFile(
@@ -219,19 +229,26 @@ describe("agent runtime refresh hooks", () => {
         id: "universal-skill-policy-agent",
         model: "hosted/universal-skill-policy",
         system: "Use the matching skill.",
-        tools: { write_report: writeReport },
+        tools: { write_report: writeReport, delete_report: deleteReport },
         maxSteps: 2,
         resolveModelTransport: async () => ({ model }),
       });
 
       const response = await assistant.generate({ input: "Review this report" });
 
-      assertEquals(writeExecutions, 0);
+      assertEquals(writeExecutions, 1);
+      assertEquals(deleteExecutions, 0);
       assertEquals(
-        response.toolCalls.filter((call) => call.name === "write_report").map((call) =>
-          call.status
-        ),
-        ["error", "error"],
+        response.toolCalls.map((call) => [call.name, call.status]),
+        [
+          ["write_report", "completed"],
+          ["load_skill", "completed"],
+          ["delete_report", "error"],
+        ],
+      );
+      assertEquals(
+        response.toolCalls.at(-1)?.error?.includes("not allowed by the active skill policy"),
+        true,
       );
     } finally {
       skillRegistryInternal.clearAll();

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -128,11 +128,6 @@ export type ActiveSkillState = {
   activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
 };
 
-function getSkillActivationRequiredError(toolName: string): string {
-  return `Tool "${toolName}" cannot run before load_skill succeeds in the same step. ` +
-    `Call "${LOAD_SKILL_TOOL_ID}" first to establish the active skill context.`;
-}
-
 export function hydrateActiveSkillStateFromMessages(
   messages: readonly Message[],
 ): ActiveSkillState {
@@ -434,13 +429,8 @@ export function isSkillBodyLoadRequest(toolName: string, input: unknown): boolea
 export function enforceSkillPolicy(
   toolName: string,
   activeSkillPolicy: string[] | undefined,
-  mustLoadSkillFirst: boolean,
   options: SkillPolicyOptions = {},
 ): SkillPolicyResult {
-  if (mustLoadSkillFirst && toolName !== LOAD_SKILL_TOOL_ID) {
-    return { allowed: false, error: getSkillActivationRequiredError(toolName) };
-  }
-
   if (
     options.hasSubmittedFormInput === true &&
     POST_SUBMITTED_FORM_INPUT_BLOCKED_TOOL_IDS.has(toolName)

--- a/src/agent/runtime/skill-policy-same-step.test.ts
+++ b/src/agent/runtime/skill-policy-same-step.test.ts
@@ -1,0 +1,255 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ModelRuntime } from "#veryfront/provider";
+import { defineSchema } from "#veryfront/schemas";
+import { type Tool, tool } from "#veryfront/tool";
+import { toolRegistry } from "#veryfront/tool/registry.ts";
+import { agent } from "../index.ts";
+import type { AgentConfig } from "../types.ts";
+import type { RuntimeToolFilterConfig } from "./runtime-tool-config.ts";
+
+const SAME_STEP_GATE_ERROR = "cannot run before load_skill succeeds in the same step";
+const ACTIVE_POLICY_ERROR = "is not allowed by the active skill policy";
+
+type RuntimeMode = "generate" | "stream";
+
+type ScriptedToolCall = { id: string; name: string; input: Record<string, unknown> };
+
+type ScriptedStep =
+  | { toolCalls: ScriptedToolCall[] }
+  | { text: string };
+
+function createRuntimeStream(parts: unknown[]) {
+  return new ReadableStream<unknown>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+}
+
+function stepContent(step: ScriptedStep): {
+  content: unknown[];
+  finishReason: "tool-calls" | "stop";
+} {
+  if ("text" in step) {
+    return { content: [{ type: "text", text: step.text }], finishReason: "stop" };
+  }
+  return {
+    content: step.toolCalls.map((call) => ({
+      type: "tool-call",
+      toolCallId: call.id,
+      toolName: call.name,
+      input: call.input,
+    })),
+    finishReason: "tool-calls",
+  };
+}
+
+function scriptedModel(modelId: string, steps: readonly ScriptedStep[]): ModelRuntime {
+  let index = 0;
+  const nextOutput = () => {
+    const step = steps[Math.min(index, steps.length - 1)]!;
+    index += 1;
+    return stepContent(step);
+  };
+
+  return {
+    provider: "hosted",
+    modelId,
+    // deno-lint-ignore require-await -- ModelRuntime.doGenerate is async by contract
+    async doGenerate() {
+      const output = nextOutput();
+      return {
+        ...output,
+        content: output.content.map((part) =>
+          typeof part === "object" && part !== null &&
+            (part as { type?: unknown }).type === "tool-call"
+            ? { ...part, input: JSON.stringify((part as { input: unknown }).input) }
+            : part
+        ),
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      };
+    },
+    // deno-lint-ignore require-await -- ModelRuntime.doStream is async by contract
+    async doStream() {
+      const output = nextOutput();
+      return {
+        stream: createRuntimeStream([
+          ...output.content.map((part) =>
+            typeof part === "object" && part !== null &&
+              (part as { type?: unknown }).type === "text"
+              ? { type: "text-delta", text: (part as { text: string }).text }
+              : part
+          ),
+          { type: "finish", finishReason: output.finishReason },
+        ]),
+      };
+    },
+  };
+}
+
+type BatchRun = {
+  /** Every surfaced tool error, joined; the transports report errors differently. */
+  errorText: string;
+  executions: Record<string, number>;
+};
+
+/**
+ * Drive one scripted conversation through the requested transport. Both loops
+ * enforce skill policy independently, so every case below runs through both.
+ */
+async function runBatch(options: {
+  scenario: string;
+  mode: RuntimeMode;
+  steps: readonly ScriptedStep[];
+  loadSkillResult: () => Record<string, unknown>;
+  probeToolIds: readonly string[];
+}): Promise<BatchRun> {
+  const { scenario, mode, steps, loadSkillResult, probeToolIds } = options;
+  const suffix = `${scenario}-${mode}`;
+  const loadSkillId = "load_skill";
+  const executions: Record<string, number> = {};
+
+  const tools: Record<string, Tool> = {
+    [loadSkillId]: tool({
+      id: loadSkillId,
+      description: "Load a skill body",
+      inputSchema: defineSchema((v) => v.object({ skillId: v.string() }))(),
+      execute: () => loadSkillResult(),
+    }),
+  };
+  for (const probeId of probeToolIds) {
+    executions[probeId] = 0;
+    tools[probeId] = tool({
+      id: probeId,
+      description: `Probe tool ${probeId}`,
+      inputSchema: defineSchema((v) => v.object({}))(),
+      execute: () => {
+        executions[probeId] = (executions[probeId] ?? 0) + 1;
+        return { ok: true };
+      },
+    });
+  }
+
+  try {
+    const assistant = agent(
+      {
+        id: `same-step-${suffix}`,
+        model: `hosted/same-step-${suffix}`,
+        system: "Use tools when needed.",
+        skills: true,
+        tools,
+        maxSteps: 4,
+        resolveModelTransport: () => ({
+          model: scriptedModel(`hosted/same-step-${suffix}`, steps),
+        }),
+        __vfToolLoadingMode: "eager",
+      } as AgentConfig & RuntimeToolFilterConfig,
+    );
+
+    if (mode === "generate") {
+      const response = await assistant.generate({ input: "Load the skill and work" });
+      return {
+        errorText: response.toolCalls
+          .map((call) => (call.status === "error" ? call.error ?? "unknown error" : ""))
+          .join("\n"),
+        executions,
+      };
+    }
+
+    const body = await (await assistant.stream({ input: "Load the skill and work" }))
+      .toDataStreamResponse().text();
+    return { errorText: body, executions };
+  } finally {
+    for (const toolId of [loadSkillId, ...probeToolIds]) toolRegistry.delete(toolId);
+  }
+}
+
+describe("src/agent/runtime same-step load_skill batches", () => {
+  for (const mode of ["generate", "stream"] as const) {
+    it(`executes every tool batched with load_skill (${mode})`, async () => {
+      const run = await runBatch({
+        scenario: "allowed",
+        mode,
+        probeToolIds: ["probe_a", "probe_b"],
+        loadSkillResult: () => ({
+          skillId: "batched",
+          instructions: "# Batched",
+          allowedTools: ["load_skill", "probe_a", "probe_b"],
+          references: [],
+          scripts: [],
+        }),
+        steps: [
+          {
+            toolCalls: [
+              { id: `${mode}-load`, name: "load_skill", input: { skillId: "batched" } },
+              { id: `${mode}-probe-a`, name: "probe_a", input: {} },
+              { id: `${mode}-probe-b`, name: "probe_b", input: {} },
+            ],
+          },
+          { text: "done" },
+        ],
+      });
+
+      assertEquals(run.executions.probe_a, 1);
+      assertEquals(run.executions.probe_b, 1);
+      assertEquals(run.errorText.includes(SAME_STEP_GATE_ERROR), false);
+      assertEquals(run.errorText.includes(ACTIVE_POLICY_ERROR), false);
+    });
+
+    it(`still blocks a tool denied by the freshly activated policy (${mode})`, async () => {
+      const run = await runBatch({
+        scenario: "denied",
+        mode,
+        probeToolIds: ["probe_a", "probe_denied"],
+        loadSkillResult: () => ({
+          skillId: "restricted",
+          instructions: "# Restricted",
+          allowedTools: ["load_skill", "probe_a"],
+          references: [],
+          scripts: [],
+        }),
+        steps: [
+          {
+            toolCalls: [
+              { id: `${mode}-load`, name: "load_skill", input: { skillId: "restricted" } },
+              { id: `${mode}-probe-a`, name: "probe_a", input: {} },
+              { id: `${mode}-probe-denied`, name: "probe_denied", input: {} },
+            ],
+          },
+          { text: "done" },
+        ],
+      });
+
+      assertEquals(run.executions.probe_a, 1);
+      assertEquals(run.executions.probe_denied, 0);
+      assertEquals(run.errorText.includes(ACTIVE_POLICY_ERROR), true);
+      assertEquals(run.errorText.includes(SAME_STEP_GATE_ERROR), false);
+    });
+
+    it(`lets the rest of the batch run when load_skill fails (${mode})`, async () => {
+      const run = await runBatch({
+        scenario: "failing-load",
+        mode,
+        probeToolIds: ["probe_a"],
+        loadSkillResult: () => {
+          throw new Error("skill not found");
+        },
+        steps: [
+          {
+            toolCalls: [
+              { id: `${mode}-load`, name: "load_skill", input: { skillId: "missing" } },
+              { id: `${mode}-probe-a`, name: "probe_a", input: {} },
+            ],
+          },
+          { text: "done" },
+        ],
+      });
+
+      assertEquals(run.executions.probe_a, 1);
+      assertEquals(run.errorText.includes(SAME_STEP_GATE_ERROR), false);
+    });
+  }
+});

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -115,48 +115,37 @@ describe("src/agent/runtime skill policy helpers", () => {
   });
 
   describe("enforceSkillPolicy", () => {
-    it("should allow any tool when no policy and no mustLoadFirst", () => {
-      const result = enforceSkillPolicy("Read", undefined, false);
+    it("should allow any tool when no policy is active", () => {
+      const result = enforceSkillPolicy("Read", undefined);
       assertEquals(result, { allowed: true });
     });
 
     it("should reject non-skill tools for empty policy", () => {
-      const result = enforceSkillPolicy("Read", [], false);
+      const result = enforceSkillPolicy("Read", []);
       assertEquals(result.allowed, false);
-    });
-
-    it("should reject non-skill tools when mustLoadSkillFirst is true", () => {
-      const result = enforceSkillPolicy("Read", undefined, true);
-      assertEquals(result.allowed, false);
-      assertEquals("error" in result && result.error.includes("load_skill"), true);
-    });
-
-    it("should allow load_skill even when mustLoadSkillFirst is true", () => {
-      const result = enforceSkillPolicy("load_skill", undefined, true);
-      assertEquals(result, { allowed: true });
     });
 
     it("should allow tool matching active policy", () => {
-      const result = enforceSkillPolicy("Read", ["Read", "Write"], false);
+      const result = enforceSkillPolicy("Read", ["Read", "Write"]);
       assertEquals(result, { allowed: true });
     });
 
     it("should reject tool not in active policy", () => {
-      const result = enforceSkillPolicy("Bash", ["Read", "Write"], false);
+      const result = enforceSkillPolicy("Bash", ["Read", "Write"]);
       assertEquals(result.allowed, false);
     });
 
     it("blocks repeated intake after a submitted form without blocking skill references", () => {
       assertEquals(
-        enforceSkillPolicy("form_input", ["studio_suggestions"], false).allowed,
+        enforceSkillPolicy("form_input", ["studio_suggestions"]).allowed,
         false,
       );
-      const formResult = enforceSkillPolicy("form_input", ["form_input"], false, {
+      const formResult = enforceSkillPolicy("form_input", ["form_input"], {
         hasSubmittedFormInput: true,
       });
       assertEquals(formResult.allowed, false);
       assertEquals(
-        enforceSkillPolicy("load_skill", ["load_skill"], false, {
+        enforceSkillPolicy("load_skill", ["load_skill"], {
           activeSkillId: "plan",
           hasSubmittedFormInput: true,
           skillToolAvailability: {
@@ -169,7 +158,7 @@ describe("src/agent/runtime skill policy helpers", () => {
         { allowed: true },
       );
       assertEquals(
-        enforceSkillPolicy("load_skill", ["load_skill"], false, {
+        enforceSkillPolicy("load_skill", ["load_skill"], {
           activeSkillId: "plan",
           hasSubmittedFormInput: true,
           toolInput: { skillId: "plan" },
@@ -177,7 +166,7 @@ describe("src/agent/runtime skill policy helpers", () => {
         false,
       );
       assertEquals(
-        enforceSkillPolicy("load_skill", ["load_skill"], false, {
+        enforceSkillPolicy("load_skill", ["load_skill"], {
           activeSkillId: "plan",
           hasSubmittedFormInput: true,
           toolInput: { skillId: "research", file: "references/guide.md" },
@@ -185,7 +174,7 @@ describe("src/agent/runtime skill policy helpers", () => {
         false,
       );
       assertEquals(
-        enforceSkillPolicy("load_skill", ["load_skill"], false, {
+        enforceSkillPolicy("load_skill", ["load_skill"], {
           activeSkillId: "plan",
           hasSubmittedFormInput: true,
           skillToolAvailability: {
@@ -198,13 +187,13 @@ describe("src/agent/runtime skill policy helpers", () => {
         false,
       );
       assertEquals(
-        enforceSkillPolicy("invoke_agent", ["invoke_agent"], false, {
+        enforceSkillPolicy("invoke_agent", ["invoke_agent"], {
           hasSubmittedFormInput: true,
         }),
         { allowed: true },
       );
       assertEquals(
-        enforceSkillPolicy("create_agent", ["create_agent"], false, {
+        enforceSkillPolicy("create_agent", ["create_agent"], {
           hasSubmittedFormInput: true,
         }),
         { allowed: true },
@@ -212,14 +201,14 @@ describe("src/agent/runtime skill policy helpers", () => {
     });
 
     it("should always allow load_skill regardless of policy", () => {
-      assertEquals(enforceSkillPolicy("load_skill", ["Read"], false), { allowed: true });
-      assertEquals(enforceSkillPolicy("load_skill_reference", ["Read"], false).allowed, false);
-      assertEquals(enforceSkillPolicy("execute_skill_script", ["Read"], false).allowed, false);
+      assertEquals(enforceSkillPolicy("load_skill", ["Read"]), { allowed: true });
+      assertEquals(enforceSkillPolicy("load_skill_reference", ["Read"]).allowed, false);
+      assertEquals(enforceSkillPolicy("execute_skill_script", ["Read"]).allowed, false);
     });
 
     it("allows load_skill_reference only when policy and active skill advertise it", () => {
       assertEquals(
-        enforceSkillPolicy("load_skill_reference", ["Read", "load_skill_reference"], false, {
+        enforceSkillPolicy("load_skill_reference", ["Read", "load_skill_reference"], {
           skillToolAvailability: {
             hasActiveSkill: true,
             references: ["references/guide.md"],
@@ -230,7 +219,7 @@ describe("src/agent/runtime skill policy helpers", () => {
       );
 
       assertEquals(
-        enforceSkillPolicy("load_skill_reference", ["Read"], false, {
+        enforceSkillPolicy("load_skill_reference", ["Read"], {
           skillToolAvailability: {
             hasActiveSkill: true,
             references: ["references/guide.md"],
@@ -243,7 +232,6 @@ describe("src/agent/runtime skill policy helpers", () => {
       const result = enforceSkillPolicy(
         "load_skill_reference",
         ["Read", "load_skill_reference"],
-        false,
         {
           skillToolAvailability: {
             hasActiveSkill: true,
@@ -257,7 +245,7 @@ describe("src/agent/runtime skill policy helpers", () => {
 
     it("allows execute_skill_script only when policy and active skill advertise it", () => {
       assertEquals(
-        enforceSkillPolicy("execute_skill_script", ["Read", "execute_skill_script"], false, {
+        enforceSkillPolicy("execute_skill_script", ["Read", "execute_skill_script"], {
           skillToolAvailability: {
             hasActiveSkill: true,
             references: [],
@@ -268,7 +256,7 @@ describe("src/agent/runtime skill policy helpers", () => {
       );
 
       assertEquals(
-        enforceSkillPolicy("execute_skill_script", ["Read"], false, {
+        enforceSkillPolicy("execute_skill_script", ["Read"], {
           skillToolAvailability: {
             hasActiveSkill: true,
             references: [],
@@ -281,7 +269,6 @@ describe("src/agent/runtime skill policy helpers", () => {
       const result = enforceSkillPolicy(
         "execute_skill_script",
         ["Read", "execute_skill_script"],
-        false,
         {
           skillToolAvailability: {
             hasActiveSkill: true,
@@ -315,7 +302,6 @@ describe("src/agent/runtime skill policy helpers", () => {
         enforceSkillPolicy(
           "load_skill_reference",
           active.activeSkillPolicy,
-          false,
           { skillToolAvailability: active.activeSkillToolAvailability },
         ).allowed,
         false,
@@ -324,23 +310,22 @@ describe("src/agent/runtime skill policy helpers", () => {
         enforceSkillPolicy(
           "execute_skill_script",
           active.activeSkillPolicy,
-          false,
           { skillToolAvailability: active.activeSkillToolAvailability },
         ).allowed,
         false,
       );
-      assertEquals(enforceSkillPolicy("load_skill", active.activeSkillPolicy, false), {
+      assertEquals(enforceSkillPolicy("load_skill", active.activeSkillPolicy), {
         allowed: true,
       });
     });
 
     it("should allow wildcard-matched tools", () => {
-      const result = enforceSkillPolicy("api:list-users", ["api:*"], false);
+      const result = enforceSkillPolicy("api:list-users", ["api:*"]);
       assertEquals(result, { allowed: true });
     });
 
     it("should reject tools not matching wildcard", () => {
-      const result = enforceSkillPolicy("db:query", ["api:*"], false);
+      const result = enforceSkillPolicy("db:query", ["api:*"]);
       assertEquals(result.allowed, false);
     });
 
@@ -348,18 +333,18 @@ describe("src/agent/runtime skill policy helpers", () => {
     it("should enforce new policy after skill switch", () => {
       // Skill A: only Read allowed
       const policyA: string[] = ["Read"];
-      assertEquals(enforceSkillPolicy("Read", policyA, false), { allowed: true });
-      assertEquals(enforceSkillPolicy("Write", policyA, false).allowed, false);
+      assertEquals(enforceSkillPolicy("Read", policyA), { allowed: true });
+      assertEquals(enforceSkillPolicy("Write", policyA).allowed, false);
 
       // Skill B: only Write allowed
       const policyB: string[] = ["Write"];
-      assertEquals(enforceSkillPolicy("Write", policyB, false), { allowed: true });
-      assertEquals(enforceSkillPolicy("Read", policyB, false).allowed, false);
+      assertEquals(enforceSkillPolicy("Write", policyB), { allowed: true });
+      assertEquals(enforceSkillPolicy("Read", policyB).allowed, false);
 
       // Skill C: no restrictions (undefined)
-      assertEquals(enforceSkillPolicy("Read", undefined, false), { allowed: true });
-      assertEquals(enforceSkillPolicy("Write", undefined, false), { allowed: true });
-      assertEquals(enforceSkillPolicy("Bash", undefined, false), { allowed: true });
+      assertEquals(enforceSkillPolicy("Read", undefined), { allowed: true });
+      assertEquals(enforceSkillPolicy("Write", undefined), { allowed: true });
+      assertEquals(enforceSkillPolicy("Bash", undefined), { allowed: true });
     });
   });
 


### PR DESCRIPTION
Closes veryfront/veryfront-issue-inbox#394.

## The problem

A model that emits `load_skill` alongside other tool calls in one step had every other call in that batch rejected:

```
Tool "github__get_current_user" cannot run before load_skill succeeds in the same step.
```

It re-issued the same calls in the next step and they succeeded. So nothing broke — it cost an error in the trace and a wasted model round-trip on every run that started that way.

## The gate protected nothing

It armed **only** when `load_skill` was in the same batch. The identical tool called on its own was already permitted, because `src/skill/allowed-tools.ts:89` returns `true` for an undefined policy:

```
tool alone, no skill loaded   ->  { "allowed": true }
same tool batched w/ load_skill -> { "allowed": false, "error": "cannot run before load_skill..." }
```

Anything the gate appeared to prevent was reachable by not batching. It did not constrain an uncooperative model; it penalised the cooperative one for volunteering to load a skill in the same step.

`allowed-tools.ts:89` is deliberately untouched. Returning `true` with no policy is correct for an opt-in feature — `load_skill` is not even advertised to agents without skills, and agents without skills must still use their tools.

## What changes

Tools are now judged by the policy `load_skill` activates **within the same step**, in emission order. A batched tool the loaded skill allows runs; one it does not allow is refused by the active skill policy — a real answer about permissions rather than an instruction to retry. Calls emitted *before* `load_skill` run under whatever policy was already active.

Three deliberate choices:

- **Both loops together.** The flag existed in the streaming (`index.ts:1892`) and non-streaming (`:1301`) paths. Changing one would fork behaviour by transport.
- **Parameter removed, not defaulted to `false`.** Defaulting is a smaller diff but leaves call sites passing a dead argument that reads as meaningful.
- **`refresh.test.ts` rewritten, not deleted.** It asserted the gate end-to-end through the real skill registry. Its replacement keeps that unique coverage — a registry-backed policy still denies a tool outside its allowed-tools inside the same step — so the file now guards enforcement instead of the removed gate.

## Behaviour changes worth reviewing

**A tool batched with `load_skill` that the skill forbids now returns the *policy* error instead of the *gate* error.** Previously it was rejected before the policy existed. Both new tests pin this.

**A failing `load_skill` no longer blocks the rest of its batch.** Consistent with calling those tools alone, but it is a real change and is asserted rather than left implicit.

## Testing

New file `skill-policy-same-step.test.ts` — three behaviours × both loops:

- a batch of `[load_skill, toolA, toolB]` executes every call with no error surfaced
- a tool denied by the freshly activated policy is still blocked
- a failing `load_skill` lets the rest of the batch run

Verified non-vacuous by restoring the gate and confirming all six fail. Verified failing-first before the change:

```
FAILED | 0 passed | 1 failed (6 steps)
AssertionError: Values are not equal.  - 0  + 1
```

The probe tools never executed, because the gate rejected them.

- `deno test --allow-all src/agent/runtime/ src/skill/` — **587 passed, 906 steps, 0 failed**
- `deno lint`, `deno fmt --check` — 164 files, clean
- `deno task docs:api-reference:check` — current
- No `--no-check` used anywhere

## Docs

`docs/guides/agents.md:295` still stated the runtime enforced this gate. CI could not catch it — `docs:api-reference:check` only validates the generated `docs/api-reference` tree, not hand-written guides. Rewritten to describe the new contract, including that calls emitted before `load_skill` run under the previously active policy.

## Not in scope

This fixes trace noise and a wasted round-trip. It is **not** the defect that made an agent report a false cause to a user — that was a 404 dropping a child run's result, fixed in veryfront/veryfront-api#4293.

Still open and untouched here: nothing detects a lost tool result. A child is marked `completed` before delivery is attempted and a 404 is terminal, so no run state records the loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill loading can now be batched with other tool calls in the same step.
  * Successfully loaded skills immediately govern subsequent calls in that step.
  * Other tool calls continue according to the previously active policy if skill loading fails.

* **Documentation**
  * Updated skill execution guidance to describe same-step batching and policy enforcement.

* **Bug Fixes**
  * Improved enforcement of skill-based permissions for calls made in the same step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->