### PR TITLE
docs(skill): stop implying load_skill is availability-gated

### DIFF
--- a/docs/api-reference/veryfront/skill.md
+++ b/docs/api-reference/veryfront/skill.md
@@ -77,7 +77,7 @@ validateSkillMetadata(parsed.frontmatter, "review");
 
 | Name                       | Description                                                              | Source                                                                                           |
 | -------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| `ActiveSkillContext`       | Active skill context for runtime policy tracking                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L310)          |
+| `ActiveSkillContext`       | Active skill context for runtime availability and delegation tracking    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L310)          |
 | `AgentCapabilityScope`     | Caller scope used for owner-aware capability resolution.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/registry.ts#L59)        |
 | `ParsedSkillContent`       | Result of splitting and decoding one bounded `SKILL.md` document.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/document-parser.ts#L48) |
 | `Skill`                    | Registered skill instance                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L203)          |

--- a/docs/architecture/21-agent-tool-registration-current-state.md
+++ b/docs/architecture/21-agent-tool-registration-current-state.md
@@ -190,9 +190,10 @@ appends forwarded remote definitions, and applies `allowedRemoteToolNames`.
 Provider-native tools are added later during model tool conversion. For
 example, `web_search` is selected from the allowed name list, converted into an
 Anthropic provider tool, and marked as provider-executed in stream handling.
-Runtime skill tools are local platform tools. Local and project runtimes expose
-the three-tool skill surface, gate it by what the loaded skill advertises, and
-execute it through Veryfront. Hosted chat exposes its request-scoped `load_skill` tool
+Runtime skill tools are local platform tools. Local and project runtimes always
+expose `load_skill`. They gate `load_skill_reference` and `execute_skill_script`
+by the references and scripts the loaded skill advertises, and execute them
+through Veryfront. Hosted chat exposes its request-scoped `load_skill` tool
 instead.
 
 `executeConfiguredTool` resolves in this order:

--- a/src/skill/types.ts
+++ b/src/skill/types.ts
@@ -306,7 +306,7 @@ export interface SkillScriptExecutor {
   execute(input: SkillScriptExecutorInput): Promise<SkillScriptResult>;
 }
 
-/** Active skill context for runtime policy tracking */
+/** Active skill context for runtime availability and delegation tracking */
 export interface ActiveSkillContext {
   skillId: string;
 }


### PR DESCRIPTION
Two review findings on #3464 arrived after it had already merged, so they land here.

**`load_skill` is not gated.** `isSkillInfrastructureToolAllowed` returns `true` for `load_skill` unconditionally (`src/skill/allowed-tools.ts:39-41`); only `load_skill_reference` and `execute_skill_script` depend on `hasActiveSkill` plus a non-empty references/scripts list. `docs/architecture/21-agent-tool-registration-current-state.md` described the whole three-tool surface as gated by the loaded skill, which reads as "call `load_skill` and it may be refused" — the opposite of how a model is supposed to recover from the `no skill is loaded. Call load_skill first.` error that same PR introduced.

**`ActiveSkillContext` JSDoc.** Still said "runtime policy tracking" after the policy it tracked was removed. Fixed at the source in `src/skill/types.ts` rather than in the generated table, and `docs/api-reference/veryfront/skill.md` regenerated with `deno task docs`.

Docs-only; `docs:api-reference:check` and `typecheck` are clean locally.