### PR TITLE
fix(proxy): answer 404 for a veryfront domain that names no project

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -1608,6 +1608,37 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("returns 404 for an environment root that names no project", async () => {
+      // staging.veryfront.com parses as an environment root: a veryfront domain
+      // with slug null. It used to be forwarded with x-project-slug: "", which
+      // the runtime answers 502 "Missing project context" — a config gap
+      // reported as an upstream failure. It is the same condition a custom
+      // domain answers 404 for.
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+        if (pathname === "/auth/token") return createTokenResponse();
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        for (const host of ["staging.veryfront.com", "preview.veryfront.com"]) {
+          const ctx = await handler.processRequest(
+            new Request(`http://${host}/page`, { headers: { host } }),
+          );
+
+          assertEquals(ctx.projectSlug, undefined);
+          assertEquals(ctx.error?.status, 404);
+          assertEquals(ctx.error?.message, `No project configured for domain: ${host}`);
+        }
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("returns 404 error when custom domain not found", async () => {
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -1608,7 +1608,7 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("returns 404 for an environment root that names no project", async () => {
+    it("returns 404 for a hosted environment root that names no project", async () => {
       // staging.veryfront.com parses as an environment root: a veryfront domain
       // with slug null. It used to be forwarded with x-project-slug: "", which
       // the runtime answers 502 "Missing project context" — a config gap
@@ -1623,7 +1623,14 @@ describe("Proxy Handler", () => {
       try {
         const handler = createHandler(port);
 
-        for (const host of ["staging.veryfront.com", "preview.veryfront.com"]) {
+        for (
+          const host of [
+            "staging.veryfront.com",
+            "preview.veryfront.com",
+            "production.veryfront.com",
+            "staging.veryfront.org",
+          ]
+        ) {
           const ctx = await handler.processRequest(
             new Request(`http://${host}/page`, { headers: { host } }),
           );
@@ -1631,6 +1638,43 @@ describe("Proxy Handler", () => {
           assertEquals(ctx.projectSlug, undefined);
           assertEquals(ctx.error?.status, 404);
           assertEquals(ctx.error?.message, `No project configured for domain: ${host}`);
+        }
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("keeps project-less local dev hosts reachable for the project chooser", async () => {
+      // Locally a project-less veryfront host is not a misconfiguration: it is
+      // how the chooser is reached. ProjectsHandler is enabled for exactly
+      // `isVeryfrontDomain && !projectSlug`, so these must keep forwarding
+      // rather than 404 like their hosted counterparts.
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+        if (pathname === "/auth/token") return createTokenResponse();
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        for (
+          const host of [
+            "lvh.me",
+            "veryfront.me",
+            "veryfront.dev",
+            "preview.lvh.me",
+            "staging.lvh.me",
+          ]
+        ) {
+          const ctx = await handler.processRequest(
+            new Request(`http://${host}/`, { headers: { host } }),
+          );
+
+          assertEquals(ctx.error, undefined, `${host} must not be an error context`);
+          assertEquals(ctx.contentSourceId, "no-project");
         }
 
         await handler.close();

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -1,5 +1,9 @@
 import { TokenManager, type TokenScope } from "./token-manager.ts";
-import { type ParsedDomain, parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
+import {
+  isHostedVeryfrontDomain,
+  type ParsedDomain,
+  parseProjectDomain,
+} from "#veryfront/server/utils/domain-parser.ts";
 import type { TokenCache } from "./cache/types.ts";
 import { computeContentSourceId } from "#veryfront/cache/keys.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
@@ -815,16 +819,34 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       }, logger);
 
     if (!projectSlug && parsedDomain.isVeryfrontDomain) {
-      // An environment root (staging.veryfront.com) or a bare dev domain names no
-      // project. Forwarding it sends x-project-slug: "" to the runtime, which
-      // answers 502 "Missing project context" — a config gap reported as an
-      // upstream failure. A custom domain in the same state already answers 404,
-      // so answer the same way here.
-      logger?.info("No project for veryfront domain", { host });
-      return createProxyErrorContext(base, {
-        status: 404,
-        message: `No project configured for domain: ${host}`,
-      });
+      // A hosted environment root (staging.veryfront.com) names no project and
+      // nothing downstream can supply one, so forwarding only sends
+      // x-project-slug: "" and earns 502 "Missing project context" — a
+      // configuration gap reported as an upstream failure. A custom domain in
+      // that state already answers 404.
+      //
+      // Locally the same shape means something else: on lvh.me and friends a
+      // project-less host is how the project chooser is reached, so those keep
+      // forwarding. See ProjectsHandler, enabled for exactly this state.
+      if (isHostedVeryfrontDomain(host)) {
+        logger?.info("No project for hosted veryfront domain", { host });
+        return createProxyErrorContext(base, {
+          status: 404,
+          message: `No project configured for domain: ${host}`,
+        });
+      }
+
+      return {
+        token: undefined,
+        projectSlug: undefined,
+        projectId: undefined,
+        environment: "preview",
+        contentSourceId: "no-project",
+        localPath: undefined,
+        host,
+        parsedDomain,
+        isLocalProject: false,
+      };
     }
 
     const localPath = projectSlug ? await localProjectResolver.find(projectSlug) : undefined;

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -815,17 +815,16 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       }, logger);
 
     if (!projectSlug && parsedDomain.isVeryfrontDomain) {
-      return {
-        token: undefined,
-        projectSlug: undefined,
-        projectId: undefined,
-        environment: "preview",
-        contentSourceId: "no-project",
-        localPath: undefined,
-        host,
-        parsedDomain,
-        isLocalProject: false,
-      };
+      // An environment root (staging.veryfront.com) or a bare dev domain names no
+      // project. Forwarding it sends x-project-slug: "" to the runtime, which
+      // answers 502 "Missing project context" — a config gap reported as an
+      // upstream failure. A custom domain in the same state already answers 404,
+      // so answer the same way here.
+      logger?.info("No project for veryfront domain", { host });
+      return createProxyErrorContext(base, {
+        status: 404,
+        message: `No project configured for domain: ${host}`,
+      });
     }
 
     const localPath = projectSlug ? await localProjectResolver.find(projectSlug) : undefined;

--- a/src/server/utils/domain-parser.ts
+++ b/src/server/utils/domain-parser.ts
@@ -179,6 +179,18 @@ export function parseProjectDomain(host: string): ParsedDomain {
 }
 
 /**
+ * Whether the host is a hosted veryfront domain (veryfront.com / veryfront.org)
+ * rather than one of the local development domains.
+ *
+ * The two differ in what a project-less host means. Locally it means "no project
+ * chosen yet" and the project chooser answers; hosted it means the domain names
+ * no project at all and nothing can answer.
+ */
+export function isHostedVeryfrontDomain(host: string): boolean {
+  return new RegExp(`^(?:.+\\.)?(${PROD_DOMAINS})$`, "i").test(stripPort(host));
+}
+
+/**
  * Check if a domain is a valid veryfront domain (includes veryfront.me and lvh.me for local dev)
  */
 export function isVeryfrontDomain(host: string): boolean {


### PR DESCRIPTION
Found while verifying the v0.1.1214 rollout.

```
development.veryfront.com -> 404 {"error":"No project configured for domain: development.veryfront.com"}
staging.veryfront.com     -> 502 {"error":"Missing project context","detail":"x-project-slug header is required in proxy mode"}
preview.veryfront.com     -> 502 {"error":"Missing project context","detail":"x-project-slug header is required in proxy mode"}
```

Same condition, three hosts, two answers.

**Why they differ.** `parseProjectDomain` has an explicit environment-root branch for `^(preview|staging|production)\.veryfront\.(com|org)$` (`src/server/utils/domain-parser.ts:168`) that returns slug `null` with `isVeryfrontDomain: true`. `development` is not in that list, so it falls through to the custom-domain case and gets the correct 404. Its two siblings hit `handler.ts:817`, which returned a forwarding context; `injectContextHeaders` then sends `x-project-slug: ""` and the runtime answers 502.

**Why 404 is right for hosted domains.** Nothing downstream can supply the missing slug, so each request spent a round trip to the renderer only to report a configuration gap as an upstream failure — and 502 reads as "the backend is broken", which is what made me stop and investigate mid-rollout. A custom domain in the same state has always answered 404.

**Scope — corrected.** My first version returned 404 for *every* project-less veryfront domain, including `lvh.me`, `veryfront.me`, `veryfront.dev` and the local environment roots. That was wrong, and the claim in the original description that those were intended scope was wrong too. `ProjectsHandler` is enabled for exactly `isVeryfrontDomain && !projectSlug` (`src/server/handlers/dev/projects/index.ts:44-58`) and serves the project chooser at `/` and `/_projects`, so locally that state is meaningful, not broken. The forwarding path was not dead code. Thanks to @chatgpt-codex-connector for catching it.

The 404 now applies only to hosted domains, via a new `isHostedVeryfrontDomain` that names the distinction: locally a project-less host means "no project chosen yet"; hosted it means the domain names no project at all. `isLocalDevHost` would have been the wrong predicate — it returns `false` for `staging.lvh.me`, which would have left that chooser broken.

**Tests.** Hosted roots (`staging`/`preview`/`production.veryfront.com`, `staging.veryfront.org`) assert 404; the local hosts assert they keep forwarding with no error context. I confirmed the hosted test fails against `main` before trusting it.

Not a regression from v0.1.1214 — this predates it; 1214 touched CSP, nanoid and skills, not host routing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests to hosted Veryfront environment domains without a configured project now return a clear 404 error.
  * Prevented these requests from being forwarded incorrectly and producing misleading project-related errors across staging, preview, production, and `.org` domains.
  * Project-less local development hosts remain reachable and continue working as expected.
  * Added regression coverage for hosted environment domains and local development behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->