### PR TITLE
test(ui): poll for the copy failure state instead of a fixed tick budget

### DIFF
--- a/src/react/components/ui/code-block.test.tsx
+++ b/src/react/components/ui/code-block.test.tsx
@@ -64,6 +64,25 @@ async function settle(): Promise<void> {
 }
 
 /**
+ * Wait for a condition the copy handler reaches asynchronously.
+ *
+ * `settle` spends a fixed budget of one microtask and one macrotask, which is
+ * enough for the success path but not reliably for the failure path: a rejected
+ * `clipboard.writeText` falls back to `execCommand`, and only once that returns
+ * false does the failed state get set. That chain is several ticks long, so on
+ * a loaded machine the assertion could run against the pre-failure render. Poll
+ * for the state the test is actually about instead of guessing a tick count.
+ */
+async function waitFor(predicate: () => boolean, description: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    flushSync(() => {});
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+/**
  * Unmount and drain the one-shot tasks the runtime leaves behind.
  *
  * The `execCommand` copy fallback selects a textarea, and jsdom queues that
@@ -351,7 +370,10 @@ describe("CodeBlock clipboard integration", () => {
       assert(button, "copy control renders");
 
       button.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
-      await settle();
+      await waitFor(
+        () => button.dataset.failed === "true",
+        "both clipboard mechanisms to fail",
+      );
 
       assertEquals(button.dataset.copied, "false");
       assertEquals(button.dataset.failed, "true");
@@ -383,7 +405,10 @@ describe("CodeBlock clipboard integration", () => {
       assert(button, "copy control renders");
 
       button.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
-      await settle();
+      await waitFor(
+        () => button.getAttribute("aria-label") === "Unable to copy code",
+        "the copy control to report failure",
+      );
 
       assertEquals(button.getAttribute("aria-label"), "Unable to copy code");
       assertEquals(


### PR DESCRIPTION
`code-block.test.tsx › exposes failed copy feedback to assistive technology` failed once in CI on #3474 — a branch that changes one line of CSP caching and no React code — and passed on re-run.

**The race.** `settle` spends a fixed budget of one microtask and one macrotask:

```ts
await Promise.resolve();
await new Promise((resolve) => setTimeout(resolve, 0));
flushSync(() => {});
```

That covers the success path, where the clipboard promise resolves and React re-renders. The failure path is longer: a rejected `clipboard.writeText` falls back to `execCommand`, and only once *that* returns false is the failed state set. On a loaded machine the assertion can run against the pre-failure render. It explains the shape of the flake exactly — only the two failure-path tests are exposed, and the success-path ones never flake.

**The change.** Both failure-path tests poll for the state they are actually about instead of guessing a tick count. The helper throws a named timeout, so a genuine regression still fails loudly rather than being waited out — I checked that by pointing the predicate at a sentinel that is never true and confirming it reports `Timed out waiting for the copy control to report failure` rather than passing.

**What I cannot claim.** I could not reproduce the flake locally: not in isolation (5/5 green), not with the whole `ui/` directory in one process, not under `--coverage`, and not on a pristine `origin/main` worktree. So this removes a race that is visible in the code, not one I was able to observe. If it recurs, the timeout message will now say which condition was never reached, which is more than the previous failure gave us.

Separate from #3474 on purpose — an unrelated test-harness change does not belong in a one-line behavioural fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved clipboard failure test reliability by waiting for asynchronous state updates.
  * Added timeout handling with clearer error feedback when expected updates do not occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->