### PR TITLE
fix(deps): bump nanoid and fast-uri past their advisories

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3317,8 +3317,8 @@
         "micromatch"
       ]
     },
-    "fast-uri@3.1.4": {
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="
+    "fast-uri@3.1.5": {
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
     },
     "fast-xml-builder@1.3.0": {
       "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
@@ -4491,8 +4491,8 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "nanoid@3.3.16": {
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+    "nanoid@3.3.18": {
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "bin": true
     },
     "napi-build-utils@2.0.0": {


### PR DESCRIPTION
Closes both open high-severity Dependabot alerts on `main`.

## What they are

Both resolve into the root `deno.lock` as transitive npm dependencies of extensions:

| Package | Was | Now | Reached via | Advisory |
| --- | --- | --- | --- | --- |
| `nanoid` | 3.3.16 | **3.3.18** | `purgecss@8.0.0` → `postcss` (ext-css-purgecss) | GHSA-2v37-7h3g-55p8 — custom generators can loop indefinitely when size is 0 |
| `fast-uri` | 3.1.4 | **3.1.5** | `ajv@8.18.0` (ext-schema-zod) | host confusion via a backslash in the authority |

#3466 already bumped nanoid, but in `storybook/package-lock.json` — a separate surface. The `deno.lock` copy was never moved, which is why the alert stayed open. The integrity hash for 3.3.18 here matches the one that PR landed, which is an independent check that this is the right tarball.

## Why the lock alone

Both dependents reference the bare package name in `deno.lock`, so bumping the key and integrity is sufficient — neither extension's `deno.json` pins a range that needed to move.

## Verification

- `deno check` passes on both `extensions/ext-css-purgecss/src/index.ts` and `extensions/ext-schema-zod/src/index.ts`, so Deno re-resolved and integrity-verified both new tarballs
- The lock did not drift: the diff is exactly the four intended lines
- Extension tests: **6 passed / 3 failed both with and without this bump.** The three failures (GCS blob storage, S3 blob storage, ws package boundary) are pre-existing and unrelated — I stashed the change and re-ran to confirm, since the ws test is a package-boundary check that could plausibly have been affected
