### PR TITLE
fix(agent): emit a reasoning start when a v2 delta finds no span open

### DIFF
--- a/src/agent/ag-ui/lifecycle-browser-adapter.test.ts
+++ b/src/agent/ag-ui/lifecycle-browser-adapter.test.ts
@@ -290,4 +290,29 @@ describe("lifecycle AG-UI browser adapter", () => {
       payload: { messageId: "message-unmatched-end:reasoning:0", role: "reasoning" },
     }]);
   });
+
+  it("opens a reasoning span visibly when a delta arrives with none open", () => {
+    const adapter = createLifecycleAgUiBrowserAdapter({
+      messageId: "message-orphan-delta",
+    });
+    const events = frames([
+      { event: { type: "reasoning_content", id: "reasoning-0", delta: "thinking" } },
+      { event: { type: "reasoning_end", id: "reasoning-0" } },
+    ]).flatMap((frame) => adapter.encode(frame));
+
+    assertEquals(events, [
+      {
+        event: "ReasoningMessageStart",
+        payload: { messageId: "message-orphan-delta:reasoning:0", role: "reasoning" },
+      },
+      {
+        event: "ReasoningMessageContent",
+        payload: { messageId: "message-orphan-delta:reasoning:0", delta: "thinking" },
+      },
+      {
+        event: "ReasoningMessageEnd",
+        payload: { messageId: "message-orphan-delta:reasoning:0" },
+      },
+    ]);
+  });
 });

--- a/src/agent/ag-ui/lifecycle-browser-adapter.ts
+++ b/src/agent/ag-ui/lifecycle-browser-adapter.ts
@@ -192,15 +192,27 @@ export function createLifecycleAgUiBrowserAdapter(input: {
             role: "reasoning",
           },
         }];
-      case "reasoning_content":
+      case "reasoning_content": {
         state.sawVisibleOutput = true;
-        return [{
+        // A delta with no span open still opens one, so emit its start too.
+        // Consumers key on ReasoningMessageStart to create the block and drop
+        // content for a messageId they never saw begin. Matches browser-encoder.
+        const events: AgUiBrowserEncodedEvent[] = [];
+        if (activeReasoningMessageId === null) {
+          events.push({
+            event: "ReasoningMessageStart",
+            payload: { messageId: startReasoning(), role: "reasoning" },
+          });
+        }
+        events.push({
           event: "ReasoningMessageContent",
           payload: {
             messageId: continueReasoning(),
             delta: event.delta,
           },
-        }];
+        });
+        return events;
+      }
       case "reasoning_end": {
         const messageId = endReasoning();
         return messageId === null ? [] : [{


### PR DESCRIPTION
Closes veryfront/veryfront-issue-inbox#408.

## Bug

On the v2 stream-lifecycle path (`VF_STREAM_LIFECYCLE_MODE`), a `reasoning_content` arriving with no span open mints a span id but emits only Content:

```ts
const continueReasoning = (): string => activeReasoningMessageId ?? startReasoning();
```

No `ReasoningMessageStart` is ever emitted for that id. Per veryfront/veryfront-issue-inbox#152, the API canonicalizer and Studio stream decoder key strictly on the reasoning lifecycle, so content whose start never arrived is dropped — silently missing reasoning text.

`browser-encoder.ts` (v1) already synthesizes the missing start. This makes v2 match.

## Fix

One case in `lifecycle-browser-adapter.ts`: emit the start first when a delta finds no span open. No other paths touched.

## Tests

One test, `opens a reasoning span visibly when a delta arrives with none open`, asserting the full `Start → Content → End` sequence on one id. Confirmed red before the fix, green after.

`src/agent/ag-ui/` 29 passed / 158 steps. `deno check` / `fmt` / `lint` / docs check clean.

## Note

Needs a provider that emits reasoning content without a preceding start; I have not confirmed one does. This fixes a real v1/v2 divergence, not a proven live incident.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reasoning content received without an active reasoning span now starts one automatically.
  * Reasoning messages consistently emit start, content, and end events with a stable message identifier.
  * Automatically opened reasoning spans close correctly when the corresponding end event arrives.

* **Tests**
  * Added coverage for orphan reasoning content events and their complete lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->