### PR TITLE
fix(security): initialize the adapter before deriving CSP origins

### DIFF
--- a/src/server/runtime-handler/derive-project-csp.test.ts
+++ b/src/server/runtime-handler/derive-project-csp.test.ts
@@ -1,0 +1,116 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { deriveProjectCspOrigins } from "./project-runtime-context.ts";
+import { __clearDerivedCspCacheForTests } from "#veryfront/security/http/derived-csp-cache.ts";
+import type { RuntimeAdapter } from "#veryfront/types";
+
+const SOURCE = [{
+  path: "pages/index.tsx",
+  content: '<img src="https://images.unsplash.com/photo.jpg" />',
+}];
+
+/**
+ * Adapter shaped like the hosted one.
+ *
+ * The behaviour under test is the initialization requirement: the real adapter
+ * answers `getAllSourceFiles` with an empty list until it has a content
+ * context, and the only thing that establishes one is `ensureSourceSnapshotFresh`
+ * (which awaits `ensureInitialized`). Its file-list warmup is itself gated on
+ * being initialized, so an uninitialized read never fills in afterwards.
+ */
+function createHostedAdapter(options: { requireInitialization: boolean }) {
+  let initialized = false;
+  const calls = { ensureFresh: 0, listSource: 0, ranInContext: 0 };
+
+  const underlying = {
+    ensureSourceSnapshotFresh: (_reason?: string) => {
+      calls.ensureFresh += 1;
+      initialized = true;
+      return Promise.resolve();
+    },
+    getAllSourceFiles: () => {
+      calls.listSource += 1;
+      if (options.requireInitialization && !initialized) return Promise.resolve([]);
+      return Promise.resolve(SOURCE);
+    },
+    getContentContext: () => null,
+    getSourceSnapshotVersion: () => 7,
+  };
+
+  const fs = {
+    isVeryfrontAdapter: true,
+    isMultiProjectMode: true,
+    getUnderlyingAdapter: () => underlying,
+    ensureSourceSnapshotFresh: underlying.ensureSourceSnapshotFresh,
+    runWithContext: (
+      _slug: string,
+      _token: string,
+      run: () => Promise<unknown>,
+    ) => {
+      calls.ranInContext += 1;
+      return run();
+    },
+  };
+
+  return { adapter: { fs } as unknown as RuntimeAdapter, calls };
+}
+
+const PRODUCTION = {
+  projectSlug: "acme",
+  projectId: "proj_acme",
+  token: "tok",
+  releaseId: "rel_1",
+  branch: null,
+  environmentName: "production",
+};
+
+describe("server/runtime-handler/deriveProjectCspOrigins", () => {
+  it("derives origins for a hosted production release", async () => {
+    // The case that was broken in production: a release-backed adapter that has
+    // not been initialized for this request yet.
+    __clearDerivedCspCacheForTests();
+    const { adapter, calls } = createHostedAdapter({ requireInitialization: true });
+
+    const derived = await deriveProjectCspOrigins({ adapter, ...PRODUCTION });
+
+    assertEquals(derived?.["img-src"], ["https://images.unsplash.com"]);
+    assert(calls.ensureFresh > 0, "the adapter must be initialized before its source is read");
+    assertEquals(calls.ranInContext, 1, "the read stays inside the tenant context");
+  });
+
+  it("still derives when the adapter needs no initializing", async () => {
+    __clearDerivedCspCacheForTests();
+    const { adapter } = createHostedAdapter({ requireInitialization: false });
+
+    const derived = await deriveProjectCspOrigins({
+      adapter,
+      ...PRODUCTION,
+      releaseId: undefined,
+      environmentName: "preview",
+    });
+
+    assertEquals(derived?.["img-src"], ["https://images.unsplash.com"]);
+  });
+
+  it("returns nothing rather than throwing when the adapter cannot host a tenant", async () => {
+    __clearDerivedCspCacheForTests();
+    const derived = await deriveProjectCspOrigins({
+      adapter: { fs: {} } as unknown as RuntimeAdapter,
+      ...PRODUCTION,
+    });
+
+    assertEquals(derived, undefined);
+  });
+
+  it("never fails a response when the read throws", async () => {
+    __clearDerivedCspCacheForTests();
+    const { adapter } = createHostedAdapter({ requireInitialization: false });
+    const fs = (adapter as unknown as { fs: Record<string, unknown> }).fs;
+    fs.runWithContext = () => Promise.reject(new Error("tenant unavailable"));
+
+    const derived = await deriveProjectCspOrigins({ adapter, ...PRODUCTION });
+
+    assertEquals(derived, undefined);
+  });
+});

--- a/src/server/runtime-handler/derive-project-csp.test.ts
+++ b/src/server/runtime-handler/derive-project-csp.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { deriveProjectCspOrigins } from "./project-runtime-context.ts";
 import { __clearDerivedCspCacheForTests } from "#veryfront/security/http/derived-csp-cache.ts";
-import type { RuntimeAdapter } from "#veryfront/types";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
 const SOURCE = [{
   path: "pages/index.tsx",

--- a/src/server/runtime-handler/project-runtime-context.ts
+++ b/src/server/runtime-handler/project-runtime-context.ts
@@ -553,7 +553,15 @@ function createProxyGuard(
  * AsyncLocalStorage and silently yields nothing -- or the wrong project --
  * without it.
  */
-async function deriveProjectCspOrigins(args: {
+/**
+ * Derive a project's CSP origins from the source its release pins.
+ *
+ * Exported because this seam had no test at all: the extractor was covered and
+ * the header merge was covered, but nothing exercised the part that actually
+ * reads an adapter -- which is where it was broken in production for every
+ * hosted project while both neighbours stayed green.
+ */
+export async function deriveProjectCspOrigins(args: {
   adapter: RuntimeAdapter;
   projectSlug: string;
   projectId: string | undefined;
@@ -566,14 +574,30 @@ async function deriveProjectCspOrigins(args: {
   const fs = args.adapter.fs;
 
   const run = async (): Promise<SecurityConfig["derivedCsp"]> => {
+    // Read through the same door the config load uses. `getAllSourceFiles`
+    // needs a content context, and `ensureSourceSnapshotFresh` is what
+    // establishes one -- it awaits `ensureInitialized` before deciding whether
+    // a refresh is due. Without it the adapter answers with an empty list and,
+    // because its warmup is itself gated on being initialized, never fills in
+    // afterwards. That is not a cold cache that warms a moment later; it never
+    // warms, which is why hosted production projects derived nothing on every
+    // request while preview, whose adapter was already initialized by then,
+    // looked correct.
+    await fs.ensureSourceSnapshotFresh?.("csp-derivation");
+
     const underlying = typeof fs.getUnderlyingAdapter === "function"
       ? fs.getUnderlyingAdapter() as {
         getAllSourceFiles?: () => Promise<Array<{ path: string; content?: string }>>;
         getContentContext?: () => ResolvedContentContext | null;
         getSourceSnapshotVersion?: () => number;
+        ensureSourceSnapshotFresh?: (reason?: string) => Promise<void>;
       }
       : undefined;
     if (!underlying || typeof underlying.getAllSourceFiles !== "function") return undefined;
+
+    // The wrapper may delegate without exposing the hook, so ask the adapter
+    // that actually owns the file list too.
+    await underlying.ensureSourceSnapshotFresh?.("csp-derivation");
 
     // Branch and environment content versions are stable while the content
     // under them changes, so the adapter's snapshot generation is what actually


### PR DESCRIPTION
This is the actual cause of derived origins never working for hosted production projects. **#3474 was not it**, and I said it was — the promotion notes on veryfront-server#304 are wrong about that.

**The bug.** `getAllSourceFiles` answers `[]` until the adapter has a content context, and the only thing that establishes one is `ensureSourceSnapshotFresh`, which awaits `ensureInitialized` first (`adapter.ts:917-919`). The config load calls it before reading (`adapter-factory.ts:298`); the derivation path never did. Compounding it, the adapter's file-list warmup is itself gated on `this.initialized`, so the empty read never filled in afterwards. Not a cold cache that warms a moment later — one that never warms.

**Why #3474 didn't help, and how that pointed here.** #3474 stopped an empty read being cached forever, so after it shipped every request re-read the source. Production still derived nothing. That is what proved the emptiness was persistent rather than a cold-start race, and sent me looking for something structural instead. #3474 was still a real bug worth fixing; it just wasn't this one.

**Why preview looked fine.** Its adapter had already been initialized by the time derivation asked, so the same code read a working adapter. Same release, same source, different answer — which is what the probe project showed.

**Hypotheses I falsified along the way**, so the next person doesn't re-run them: release files carry no content (they do — verified against the real API through the client's own `listPublishedFiles` path), and the file-list warmup is failing (no warmup failures in production, and `Refreshed source snapshot` shows the adapter reading source).

**The fix.** Derivation reads through the same door the config load uses — on the wrapper and on the adapter that owns the file list, since the wrapper may delegate without exposing the hook.

**Why this was never caught.** `deriveProjectCspOrigins` had *no test at all*. The extractor was covered and the header merge was covered, so both neighbours stayed green while the seam between them was broken in production. It is exported and tested here: the hosted-release case fails without this change and passes with it, which I verified by removing the fix rather than trusting a green run, plus the no-tenant and read-throws paths.

Lint, typecheck, fmt, docs and the full unit suite green by exit code.

Still needs a release and promotion to confirm in production, and the check is one curl: `vf-csp-probe.production.veryfront.com` should gain `https://images.unsplash.com` and `https://cdn.jsdelivr.net` in `img-src`. Pairs well with #3482, which makes every derivation outcome say which one it was, so the next failure of this kind is visible in logs instead of needing a live probe.