### PR TITLE
fix(security): derive CSP origins on release-backed content

### DIFF
--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -130,7 +130,11 @@ export class VeryfrontFSAdapter implements FSAdapter {
   /** Resolves when file list initialization is complete (for coordinating reads) */
   private fileListReadyResolve: (() => void) | null = null;
   /** Single-flight background rewarm when the file list cache disappears */
-  private fileListWarmupPromise: Promise<void> | null = null;
+  // Resolves with the files it fetched, so a caller that waited does not have
+  // to depend on the cache write having succeeded -- writes are skipped
+  // entirely when caching is disabled, and can fail on a backend cache.
+  private fileListWarmupPromise: Promise<Array<{ path: string; content?: string }> | null> | null =
+    null;
   private fileListWarmupKey: string | null = null;
   /** Single-flight foreground refresh when a branch preview read misses a newly pushed file. */
   private branchMissRecoveryPromise: Promise<void> | null = null;
@@ -663,7 +667,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     }
 
     const warmupContext = this.contentContext;
-    let warmupPromise: Promise<void> | null = null;
+    let warmupPromise: Promise<Array<{ path: string; content?: string }> | null> | null = null;
     warmupPromise = (async () => {
       try {
         const existing = await this.cache.getAsync<Array<{ path: string; content?: string }>>(
@@ -676,7 +680,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
             cacheKey: effectiveCacheKey,
             fileCount: existing.length,
           });
-          return;
+          return existing;
         }
 
         logger.debug("Starting file list warmup", {
@@ -704,12 +708,16 @@ export class VeryfrontFSAdapter implements FSAdapter {
           totalFiles: files.length,
           filesWithContent: files.filter((file) => file.content).length,
         });
+
+        return files;
       } catch (error) {
         logger.warn("File list warmup failed", {
           reason,
           cacheKey: effectiveCacheKey,
           error: error instanceof Error ? error.message : String(error),
         });
+
+        return null;
       } finally {
         if (warmupPromise && this.fileListWarmupPromise === warmupPromise) {
           this.fileListWarmupPromise = null;
@@ -720,7 +728,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
     this.fileListWarmupPromise = warmupPromise;
     this.fileListWarmupKey = effectiveCacheKey;
-    this.readOps.setFileListReadyPromise(warmupPromise);
+    // That collaborator only needs completion, not the payload.
+    this.readOps.setFileListReadyPromise(warmupPromise.then(() => {}));
   }
 
   private markSourceSnapshotChanged(
@@ -1072,8 +1081,13 @@ export class VeryfrontFSAdapter implements FSAdapter {
     // list was empty on every request for the life of the process. Wait for the
     // fetch this read just started, then look again.
     if (options.waitForWarmup && cacheKey && !files?.length && this.fileListWarmupPromise) {
-      await this.fileListWarmupPromise;
-      files = await this.cache.getAsync<{ path: string; content?: string }[]>(cacheKey);
+      // Take what the fetch returned rather than re-reading the cache: with
+      // caching disabled, or a failed backend write, the cache keeps nothing
+      // and correctness would depend on a write that never happened.
+      const fetched = await this.fileListWarmupPromise;
+      files = fetched?.length
+        ? fetched
+        : await this.cache.getAsync<{ path: string; content?: string }[]>(cacheKey);
     }
 
     if (!cacheKey || !files?.length) {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -1040,7 +1040,16 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return this.projectData;
   }
 
-  async getAllSourceFiles(): Promise<Array<{ path: string; content?: string }>> {
+  /**
+   * @param options.waitForWarmup wait for an in-flight file-list fetch instead
+   * of answering empty. Off by default: most callers can proceed without the
+   * list and must not pay for the fetch, but a caller that has no other way to
+   * obtain it -- CSP derivation on a release-backed context, where nothing else
+   * populates the cache -- would otherwise read empty on every request forever.
+   */
+  async getAllSourceFiles(
+    options: { waitForWarmup?: boolean } = {},
+  ): Promise<Array<{ path: string; content?: string }>> {
     if (!this.contentContext) {
       logger.debug("getAllSourceFiles called without contentContext", {
         initialized: this.initialized,
@@ -1055,7 +1064,17 @@ export class VeryfrontFSAdapter implements FSAdapter {
       "getAllSourceFiles miss",
     );
     const cacheKey = cached?.cacheKey;
-    const files = cached?.files;
+    let files = cached?.files;
+
+    // A miss schedules a warmup and returns immediately, which is right for
+    // callers that can proceed without the list. This one cannot: nothing else
+    // populates it for a release-backed context, so returning early meant the
+    // list was empty on every request for the life of the process. Wait for the
+    // fetch this read just started, then look again.
+    if (options.waitForWarmup && cacheKey && !files?.length && this.fileListWarmupPromise) {
+      await this.fileListWarmupPromise;
+      files = await this.cache.getAsync<{ path: string; content?: string }[]>(cacheKey);
+    }
 
     if (!cacheKey || !files?.length) {
       logger.debug("getAllSourceFiles cache miss or empty", {

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -316,10 +316,12 @@ export class MultiProjectFSAdapter implements FSAdapter {
     }
   }
 
-  async getAllSourceFiles(): Promise<Array<{ path: string; content?: string }>> {
+  async getAllSourceFiles(
+    options: { waitForWarmup?: boolean } = {},
+  ): Promise<Array<{ path: string; content?: string }>> {
     try {
       const adapter = await this.getAdapter();
-      const files = (await adapter.getAllSourceFiles?.()) ?? [];
+      const files = (await adapter.getAllSourceFiles?.(options)) ?? [];
 
       if (files.length === 0) {
         logger.debug("getAllSourceFiles returned empty", {

--- a/src/server/runtime-handler/derive-project-csp.test.ts
+++ b/src/server/runtime-handler/derive-project-csp.test.ts
@@ -35,7 +35,8 @@ function createHostedAdapter(options: { requireInitialization: boolean }) {
       return Promise.resolve(SOURCE);
     },
     getContentContext: () => null,
-    getSourceSnapshotVersion: () => 7,
+    // Async, like MultiProjectFSAdapter's.
+    getSourceSnapshotVersion: () => Promise.resolve(7),
   };
 
   const fs = {
@@ -91,6 +92,21 @@ describe("server/runtime-handler/deriveProjectCspOrigins", () => {
     });
 
     assertEquals(derived?.["img-src"], ["https://images.unsplash.com"]);
+  });
+
+  it("awaits an async snapshot version instead of keying on a promise", async () => {
+    // The wrapper's `getSourceSnapshotVersion` is async. Template-stringifying
+    // it put the literal "[object Promise]" into every cache key, so two
+    // different content versions of a project shared one entry.
+    __clearDerivedCspCacheForTests();
+    const seen: string[] = [];
+    const { adapter } = createHostedAdapter({ requireInitialization: true });
+
+    // Two releases of the same project must not collide.
+    await deriveProjectCspOrigins({ ...PRODUCTION, adapter, releaseId: "rel_1" });
+    await deriveProjectCspOrigins({ ...PRODUCTION, adapter, releaseId: "rel_2" });
+
+    for (const key of seen) assert(!key.includes("[object Promise]"));
   });
 
   it("returns nothing rather than throwing when the adapter cannot host a tenant", async () => {

--- a/src/server/runtime-handler/derive-project-csp.test.ts
+++ b/src/server/runtime-handler/derive-project-csp.test.ts
@@ -94,19 +94,47 @@ describe("server/runtime-handler/deriveProjectCspOrigins", () => {
     assertEquals(derived?.["img-src"], ["https://images.unsplash.com"]);
   });
 
-  it("awaits an async snapshot version instead of keying on a promise", async () => {
-    // The wrapper's `getSourceSnapshotVersion` is async. Template-stringifying
-    // it put the literal "[object Promise]" into every cache key, so two
-    // different content versions of a project shared one entry.
+  it("re-derives when the snapshot moves under a fixed release", async () => {
+    // The wrapper's `getSourceSnapshotVersion` is async, and template-stringifying
+    // it wrote the literal "[object Promise]" into every key. Two releases would
+    // still differ by their id prefix, so only a moving snapshot under one fixed
+    // identity can see this: with the promise stringified, both calls share a key
+    // and the second is served from cache instead of re-reading the source.
     __clearDerivedCspCacheForTests();
-    const seen: string[] = [];
-    const { adapter } = createHostedAdapter({ requireInitialization: true });
 
-    // Two releases of the same project must not collide.
-    await deriveProjectCspOrigins({ ...PRODUCTION, adapter, releaseId: "rel_1" });
-    await deriveProjectCspOrigins({ ...PRODUCTION, adapter, releaseId: "rel_2" });
+    let snapshot = 1;
+    let reads = 0;
+    let source = SOURCE;
+    const underlying = {
+      ensureSourceSnapshotFresh: () => Promise.resolve(),
+      getAllSourceFiles: () => {
+        reads += 1;
+        return Promise.resolve(source);
+      },
+      getContentContext: () => null,
+      getSourceSnapshotVersion: () => Promise.resolve(snapshot),
+    };
+    const adapter = {
+      fs: {
+        isVeryfrontAdapter: true,
+        isMultiProjectMode: true,
+        getUnderlyingAdapter: () => underlying,
+        ensureSourceSnapshotFresh: () => Promise.resolve(),
+        runWithContext: (_s: string, _t: string, run: () => Promise<unknown>) => run(),
+      },
+    } as unknown as RuntimeAdapter;
 
-    for (const key of seen) assert(!key.includes("[object Promise]"));
+    const first = await deriveProjectCspOrigins({ ...PRODUCTION, adapter });
+    assertEquals(first?.["img-src"], ["https://images.unsplash.com"]);
+    assertEquals(reads, 1);
+
+    // Same release, new content pushed under it.
+    snapshot = 2;
+    source = [{ path: "pages/index.tsx", content: '<img src="https://cdn.example.com/a.png" />' }];
+
+    const second = await deriveProjectCspOrigins({ ...PRODUCTION, adapter });
+    assertEquals(reads, 2, "a moved snapshot must not be served from the previous key");
+    assertEquals(second?.["img-src"], ["https://cdn.example.com"]);
   });
 
   it("returns nothing rather than throwing when the adapter cannot host a tenant", async () => {

--- a/src/server/runtime-handler/project-runtime-context.ts
+++ b/src/server/runtime-handler/project-runtime-context.ts
@@ -595,9 +595,11 @@ export async function deriveProjectCspOrigins(args: {
 
     const underlying = typeof fs.getUnderlyingAdapter === "function"
       ? fs.getUnderlyingAdapter() as {
-        getAllSourceFiles?: () => Promise<Array<{ path: string; content?: string }>>;
+        getAllSourceFiles?: (
+          options?: { waitForWarmup?: boolean },
+        ) => Promise<Array<{ path: string; content?: string }>>;
         getContentContext?: () => ResolvedContentContext | null;
-        getSourceSnapshotVersion?: () => number;
+        getSourceSnapshotVersion?: () => number | Promise<number | undefined>;
         ensureSourceSnapshotFresh?: (reason?: string) => Promise<void>;
       }
       : undefined;
@@ -617,8 +619,11 @@ export async function deriveProjectCspOrigins(args: {
     // under them changes, so the adapter's snapshot generation is what actually
     // moves when a preview is pushed to. Without it a preview would serve a
     // derivation from before the push until the entry is evicted.
+    // Awaited: the multi-project wrapper's version of this is async, and
+    // template-stringifying the promise put the literal "[object Promise]" in
+    // every key, collapsing all snapshots to one value.
     const snapshot = typeof underlying.getSourceSnapshotVersion === "function"
-      ? underlying.getSourceSnapshotVersion()
+      ? await underlying.getSourceSnapshotVersion()
       : 0;
     const contentVersion = `${
       resolveStyleContentVersion(underlying.getContentContext?.() ?? null, {
@@ -631,7 +636,9 @@ export async function deriveProjectCspOrigins(args: {
     return await getDerivedCspOrigins({
       projectScope: args.projectSlug,
       contentVersion,
-      loadSourceFiles: () => underlying.getAllSourceFiles!(),
+      // Nothing else populates the file list for a release-backed context, so
+      // this read must wait for the fetch rather than answer empty forever.
+      loadSourceFiles: () => underlying.getAllSourceFiles!({ waitForWarmup: true }),
     });
   };
 


### PR DESCRIPTION
The diagnostics from #3482 named this on the first request after deploy:

```
info  Derived CSP origins   contentVersion "environment:preview@…"        fileCount 2  originCount 2
warn  read no project sources  contentVersion "release:f6749fdf…@…"
```

Never once a success for a `release:` context — same for codersociety and tomcode. The failure is specific to release-backed content, not to derivation.

**Cause 1 — the read never waits.** `getAllSourceFiles` answers empty on a cache miss and schedules the fetch in the background. Correct for callers that can proceed without the list; fatal here, because nothing else populates it for a release-backed context, so the read was empty on every request for the life of the process. It now waits for the fetch it just started.

Made **opt-in** rather than changing it for everyone: waiting unconditionally also pulls CSS pregeneration into the request. A test (`does not pregenerate CSS during branch cache warmup`) caught that when I first did it the blunt way, so only CSP derivation opts in.

**Cause 2 — the cache key contained `[object Promise]`.** The multi-project wrapper's `getSourceSnapshotVersion` is async and was being template-stringified. Every content version of every project collapsed to one key, so a push to a preview would have served the previous derivation. Now awaited, and the test wrapper is async like the real one.

**This is the third attempt.** #3474 fixed real negative caching, #3484 fixed a real missing initialization, and I claimed each would close this out. Neither was the cause. What changed is where the answer came from: production logs, not me reasoning about which layer looked suspicious. That is what #3482 was for, and it worked.

Gate green by exit code: lint, `lint:test-typecheck`, typecheck, fmt, docs, full unit suite.

Verification is still one curl after promotion — `vf-csp-probe.production.veryfront.com` gaining `images.unsplash.com` and `cdn.jsdelivr.net` in `img-src` — and if it fails again the logs will say why without another guess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated runtime security policy generation to detect source changes made within the same release, preventing stale cached results.
  * Improved source file loading during startup and refresh operations, including cases where caching is temporarily unavailable.
* **Improvements**
  * Added an option to wait for source files to finish loading before they are read, providing more reliable project data and runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->