### PR TITLE
fix(server): read the environment's active release from its deployment

### DIFF
--- a/src/server/project-env/production-environment-resolver.test.ts
+++ b/src/server/project-env/production-environment-resolver.test.ts
@@ -126,6 +126,57 @@ describe("ProductionEnvironmentResolver", () => {
     );
   });
 
+  // The API returns the active release nested under `deployment.release.id`, not
+  // as a top-level `active_release_id`. Reading only the flat key resolved every
+  // lookup to null, so every release-bound run was denied with "Signed release
+  // identity does not match the environment active release" while the signed
+  // release and the deployed release were in fact identical.
+  it("binds a named environment to the release nested under its deployment", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(Response.json({
+        data: [{
+          id: "env-staging",
+          name: "staging",
+          deployment: {
+            id: "deployment-1",
+            release: { id: "release-staging-42", deploy_status: "deployed" },
+          },
+        }],
+      }))) as typeof fetch;
+
+    const resolver = new ProjectEnvironmentIdentityResolver();
+    assertEquals(
+      await resolver.resolveNamedForActiveRelease({
+        ...scope(),
+        environmentName: "staging",
+        expectedEnvironmentId: "env-staging",
+        expectedReleaseId: "release-staging-42",
+      }),
+      "env-staging",
+    );
+  });
+
+  it("still denies a nested release that does not match the signed identity", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(Response.json({
+        data: [{
+          id: "env-staging",
+          name: "staging",
+          deployment: { release: { id: "release-other" } },
+        }],
+      }))) as typeof fetch;
+
+    const error = await assertRejects(() =>
+      new ProjectEnvironmentIdentityResolver().resolveNamedForActiveRelease({
+        ...scope(),
+        environmentName: "staging",
+        expectedEnvironmentId: "env-staging",
+        expectedReleaseId: "release-staging-42",
+      })
+    );
+    assertEquals((error as { slug?: string }).slug, "permission-denied");
+  });
+
   it("fails closed when active release metadata is missing or does not match", async () => {
     const activeReleaseIds: unknown[] = [undefined, null, "release-other"];
     globalThis.fetch = (() =>

--- a/src/server/project-env/production-environment-resolver.ts
+++ b/src/server/project-env/production-environment-resolver.ts
@@ -170,7 +170,12 @@ function parseNamedEnvironmentIdentity(
         detail: "Project environment lookup returned an invalid environment entry",
       });
     }
-    const rawActiveReleaseId = (entry as { active_release_id?: unknown }).active_release_id;
+    // The environments endpoint carries the active release nested under the
+    // environment's deployment. `active_release_id` is read first so a flat
+    // response keeps working, but the nested path is what production returns.
+    const deployment = (entry as { deployment?: { release?: { id?: unknown } } | null }).deployment;
+    const rawActiveReleaseId = (entry as { active_release_id?: unknown }).active_release_id ??
+      deployment?.release?.id;
     if (
       rawActiveReleaseId !== undefined &&
       rawActiveReleaseId !== null &&


### PR DESCRIPTION
Every release-bound run against a named environment is denied with HTTP 403 before doing any work:

```
Runtime stream returned HTTP 403 on /api/control-plane/runs/{runId}/stream
"Signed release identity does not match the environment active release"
```

Nothing is stale and no release has moved. The resolver is comparing against `null`.

## Root cause

`production-environment-resolver.ts:173` read the active release from the top level of each environment entry:

```ts
const rawActiveReleaseId = (entry as { active_release_id?: unknown }).active_release_id
```

`GET /projects/{slug}/environments` does not return that field. Verified live against production, the entry carries:

```
created_at, deployment, domains, environment_variables,
id, name, project_id, protected, updated_at
```

No key matching `/release/` at all. The release is nested one level down:

```json
"deployment": { "release": { "id": "87a43e4c-...", "deploy_status": "deployed" } }
```

A missing value is tolerated at parse time and stored as `null`, so nothing fails where the field is read. It fails later in `resolveNamedForActiveRelease`, where `null !== expectedReleaseId` holds for every run. A shape mismatch surfaces as a permission denial, which is why the message misleads about staleness.

## The data was always correct

| Source | Release |
| --- | --- |
| Run signed `expectedReleaseId` | `87a43e4c-c72d-4b0c-9acb-26a77bf6394c` |
| Latest `deployment` row for the production environment | `87a43e4c-c72d-4b0c-9acb-26a77bf6394c` |
| `activeReleaseId` as parsed | `null` |

The project has had no release since 2026-07-27, so this was never release churn.

## Impact

Not project-specific. The resolver is generic, so any project with a schedule or other release-bound run against a named environment has been failing.

Observed on `agentic-job-submission-processing`: **61** `RUNTIME_HTTP_ERROR` events between 2026-08-05 02:00 and 2026-08-08 10:00, with completion collapsing from 51/51 runs finishing on 2026-08-04 to 3/14 on 2026-08-08. The schedule is paused because of it. Re-enabling it today reproduced the 403 within one second on current production, API `20260809055131-e71b31df00c6` and framework v0.1.1218.

## Fix

Read the nested path, keeping the flat one first so a flat response keeps working and the existing tests covering it are untouched.

## Why CI did not catch it

`production-environment-resolver.test.ts:130` builds its fixture with `active_release_id` — the shape the resolver expects, not the shape the API sends. The test and the parser agreed with each other and both disagreed with production. The new tests use the real response shape.

## Tests

Red-first:

- a named environment binds to the release nested under its deployment — failed before the fix
- a nested release that does **not** match the signed identity is still denied — passed throughout, so the fix cannot over-permit

Verified the guard has teeth: removing the `?? deployment?.release?.id` fallback re-breaks the first test.

`src/server/project-env`: **8 passed**. Full `src/server`: 191 passed, 1 pre-existing failure in `agent-stream.handler` which I baselined by stashing this change — identical 6 failing steps without it. Typecheck, `deno fmt --check`, `deno lint` clean.

## After merge

Framework release, then a server promote, then the schedule can be re-enabled. That should clear the 403 and, in the same tick, produce the first run carrying `elapsedMs` from veryfront-code#3483 — which has never been observed end to end because no run has completed since it shipped.

Closes veryfront-issue-inbox#417.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production environment detection to recognize active release information from nested deployment responses.
  * Preserved compatibility with existing response formats.
  * Continued rejecting deployments when the active release does not match the expected release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->