### PR TITLE
fix(agent): stop one oversized model call context disabling a run's mirror

### DIFF
--- a/src/agent/hosted/durable-run-event-sink.test.ts
+++ b/src/agent/hosted/durable-run-event-sink.test.ts
@@ -12,6 +12,8 @@ import {
   MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES,
   MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
 } from "../conversation/run-event-limits.ts";
+import { isPrivateConversationRunEvent } from "../conversation/private-run-event.ts";
+import { prepareConversationRunExternalEvents } from "../conversation/run-event-preparation.ts";
 import {
   createDurableRunEventSink,
   DurableRunEventPersistenceError,
@@ -154,11 +156,43 @@ describe("agent/hosted/durable-run-event-sink", () => {
       true,
       "the persisted record fits the append budget",
     );
-    assertEquals(persisted.truncated, true, "the record declares that it was reduced");
     assertEquals(
-      typeof persisted.originalByteLength,
-      "number",
-      "the record carries the size it was reduced from",
+      isPrivateConversationRunEvent(persisted),
+      true,
+      "the reduced record must still satisfy the private-event shape, or the real mirror " +
+        "would throw on append and dispose the mirror — the very loss this fixes",
+    );
+    const noticeText = ((persisted.messages as Array<Record<string, unknown>>)[0]
+      .content as Array<Record<string, unknown>>)[0].text as string;
+    assertEquals(
+      noticeText.includes("truncated for audit"),
+      true,
+      "the record leads with a notice saying it is an excerpt",
+    );
+    assertEquals(
+      noticeText.includes("not the context that was sent"),
+      true,
+      "the notice denies that it is a faithful record",
+    );
+  });
+
+  it("survives the real normalization path used by the production mirror", () => {
+    const oversized = createModelCallContextEventWithText(
+      MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES,
+    );
+    const target = mirror();
+    return createDurableRunEventSink({ mirror: target.result })(oversized).then(
+      () => {
+        throw new Error("expected the oversize gate to reject");
+      },
+      () => {
+        const persisted = target.appended[0][0] as never;
+        // prepareConversationRunExternalEvents is what the hosted mirror actually
+        // runs on append; it throws "Invalid private run event shape" for any
+        // unexpected top-level key.
+        const normalized = prepareConversationRunExternalEvents([persisted]);
+        assertEquals(normalized.length, 1, "the reduced record normalizes to exactly one event");
+      },
     );
   });
 
@@ -230,9 +264,16 @@ describe("agent/hosted/durable-run-event-sink", () => {
       "clamping text cannot help here, so messages must be dropped until it fits",
     );
     assertEquals(
-      (persisted.omittedMessageCount as number) > 0,
+      isPrivateConversationRunEvent(persisted),
       true,
-      "the record says how many messages were dropped",
+      "the reduced record still satisfies the private-event shape",
+    );
+    const noticeText = ((persisted.messages as Array<Record<string, unknown>>)[0]
+      .content as Array<Record<string, unknown>>)[0].text as string;
+    assertEquals(
+      /\b[1-9]\d* message\(s\) omitted/.test(noticeText),
+      true,
+      "the notice states how many messages were dropped",
     );
   });
 
@@ -359,8 +400,9 @@ describe("agent/hosted/durable-run-event-sink", () => {
     assertEquals(dispatches, 0);
     assertEquals(oversized.appended.length, 1);
     assertEquals(
-      (oversized.appended[0][0] as unknown as Record<string, unknown>).truncated,
+      isPrivateConversationRunEvent(oversized.appended[0][0]),
       true,
+      "the audit record stays a valid private event",
     );
     assertEquals(oversized.isDisposed(), false);
   });

--- a/src/agent/hosted/durable-run-event-sink.test.ts
+++ b/src/agent/hosted/durable-run-event-sink.test.ts
@@ -140,7 +140,100 @@ describe("agent/hosted/durable-run-event-sink", () => {
       DurableRunEventPersistenceError,
       "Run event append request exceeds the supported payload size",
     );
-    assertEquals(oversizedTarget.appended, []);
+
+    // The gate still refuses the dispatch, but the attempt is now on the record.
+    assertEquals(
+      oversizedTarget.appended.length,
+      1,
+      "a truncated record is persisted for audit before the gate throws",
+    );
+    const persisted = oversizedTarget.appended[0][0] as unknown as Record<string, unknown>;
+    assertEquals(
+      getPrivateRunEventAppendRequestByteLength(persisted) <=
+        MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES,
+      true,
+      "the persisted record fits the append budget",
+    );
+    assertEquals(persisted.truncated, true, "the record declares that it was reduced");
+    assertEquals(
+      typeof persisted.originalByteLength,
+      "number",
+      "the record carries the size it was reduced from",
+    );
+  });
+
+  it("keeps the mirror usable after an oversized context is refused", async () => {
+    const target = mirror();
+    const sink = createDurableRunEventSink({ mirror: target.result });
+
+    await assertRejects(
+      async () =>
+        await sink(
+          createModelCallContextEventWithText(MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES),
+        ),
+      DurableRunEventPersistenceError,
+    );
+    assertEquals(target.isDisposed(), false, "one oversized context must not disable the mirror");
+
+    await sink(createModelCallContextEventWithText(16));
+    assertEquals(
+      target.appended.length,
+      2,
+      "later events in the same run still persist",
+    );
+  });
+
+  it("explains the refusal in terms an operator can act on", async () => {
+    const target = mirror();
+    const error = await assertRejects(
+      async () =>
+        await createDurableRunEventSink({ mirror: target.result })(
+          createModelCallContextEventWithText(MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES),
+        ),
+      DurableRunEventPersistenceError,
+    );
+
+    const message = error.message;
+    assertEquals(message.includes("MiB"), true, "the message states the size and the limit");
+    assertEquals(
+      message.includes("was not dispatched"),
+      true,
+      "the message says the model call did not happen",
+    );
+    assertEquals(
+      message.includes("truncated record was persisted"),
+      true,
+      "the message points at the audit record that was written",
+    );
+  });
+
+  it("guarantees a fit when message count alone exceeds the budget", async () => {
+    const target = mirror();
+    const event = {
+      type: "AGENT_RUN_MODEL_CALL_CONTEXT",
+      messages: Array.from({ length: 120_000 }, () => ({
+        role: "user",
+        content: [{ type: "text", text: "y".repeat(80) }],
+      })),
+    } as unknown as Parameters<ReturnType<typeof createDurableRunEventSink>>[0];
+
+    await assertRejects(
+      async () => await createDurableRunEventSink({ mirror: target.result })(event),
+      DurableRunEventPersistenceError,
+    );
+
+    const persisted = target.appended[0][0] as unknown as Record<string, unknown>;
+    assertEquals(
+      getPrivateRunEventAppendRequestByteLength(persisted) <=
+        MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES,
+      true,
+      "clamping text cannot help here, so messages must be dropped until it fits",
+    );
+    assertEquals(
+      (persisted.omittedMessageCount as number) > 0,
+      true,
+      "the record says how many messages were dropped",
+    );
   });
 
   it("serializes concurrent events that share a durable mirror", async () => {
@@ -260,8 +353,16 @@ describe("agent/hosted/durable-run-event-sink", () => {
       DurableRunEventPersistenceError,
       "Run event append request exceeds the supported payload size",
     );
-    assertEquals(oversized.appended, []);
+    // The fail-closed contract that matters: the model is never called when the
+    // context could not be recorded faithfully. Only the audit record changed —
+    // a truncated one is now written before the refusal.
     assertEquals(dispatches, 0);
+    assertEquals(oversized.appended.length, 1);
+    assertEquals(
+      (oversized.appended[0][0] as unknown as Record<string, unknown>).truncated,
+      true,
+    );
+    assertEquals(oversized.isDisposed(), false);
   });
 
   it("rejects caller aborts without a reason as AbortError", async () => {

--- a/src/agent/hosted/durable-run-event-sink.test.ts
+++ b/src/agent/hosted/durable-run-event-sink.test.ts
@@ -56,6 +56,24 @@ function mirror(input: {
   return { result, appended, isDisposed: () => disposed };
 }
 
+function firstAppendedEvent(appended: unknown[][]): Record<string, unknown> {
+  const batch = appended[0];
+  if (!batch || batch[0] === undefined) {
+    throw new Error("expected an appended event");
+  }
+  return batch[0] as Record<string, unknown>;
+}
+
+function leadingNoticeText(event: Record<string, unknown>): string {
+  const messages = event.messages as Array<Record<string, unknown>> | undefined;
+  const parts = messages?.[0]?.content as Array<Record<string, unknown>> | undefined;
+  const text = parts?.[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error("expected a leading notice message");
+  }
+  return text;
+}
+
 function createModelCallContextEventWithText(
   textLength: number,
 ): AgentRunModelCallContextEvent {
@@ -149,7 +167,7 @@ describe("agent/hosted/durable-run-event-sink", () => {
       1,
       "a truncated record is persisted for audit before the gate throws",
     );
-    const persisted = oversizedTarget.appended[0][0] as unknown as Record<string, unknown>;
+    const persisted = firstAppendedEvent(oversizedTarget.appended);
     assertEquals(
       getPrivateRunEventAppendRequestByteLength(persisted) <=
         MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES,
@@ -162,8 +180,7 @@ describe("agent/hosted/durable-run-event-sink", () => {
       "the reduced record must still satisfy the private-event shape, or the real mirror " +
         "would throw on append and dispose the mirror — the very loss this fixes",
     );
-    const noticeText = ((persisted.messages as Array<Record<string, unknown>>)[0]
-      .content as Array<Record<string, unknown>>)[0].text as string;
+    const noticeText = leadingNoticeText(persisted);
     assertEquals(
       noticeText.includes("truncated for audit"),
       true,
@@ -176,24 +193,23 @@ describe("agent/hosted/durable-run-event-sink", () => {
     );
   });
 
-  it("survives the real normalization path used by the production mirror", () => {
-    const oversized = createModelCallContextEventWithText(
-      MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES,
-    );
+  it("survives the real normalization path used by the production mirror", async () => {
     const target = mirror();
-    return createDurableRunEventSink({ mirror: target.result })(oversized).then(
-      () => {
-        throw new Error("expected the oversize gate to reject");
-      },
-      () => {
-        const persisted = target.appended[0][0] as never;
-        // prepareConversationRunExternalEvents is what the hosted mirror actually
-        // runs on append; it throws "Invalid private run event shape" for any
-        // unexpected top-level key.
-        const normalized = prepareConversationRunExternalEvents([persisted]);
-        assertEquals(normalized.length, 1, "the reduced record normalizes to exactly one event");
-      },
+    await assertRejects(
+      async () =>
+        await createDurableRunEventSink({ mirror: target.result })(
+          createModelCallContextEventWithText(MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES),
+        ),
+      DurableRunEventPersistenceError,
     );
+
+    // prepareConversationRunExternalEvents is what the hosted mirror actually runs
+    // on append; it throws "Invalid private run event shape" for any unexpected
+    // top-level key, which this sink would treat as a persistence failure.
+    const normalized = prepareConversationRunExternalEvents([
+      firstAppendedEvent(target.appended) as never,
+    ]);
+    assertEquals(normalized.length, 1, "the reduced record normalizes to exactly one event");
   });
 
   it("keeps the mirror usable after an oversized context is refused", async () => {
@@ -227,6 +243,7 @@ describe("agent/hosted/durable-run-event-sink", () => {
       DurableRunEventPersistenceError,
     );
 
+    assertInstanceOf(error, DurableRunEventPersistenceError);
     const message = error.message;
     assertEquals(message.includes("MiB"), true, "the message states the size and the limit");
     assertEquals(
@@ -256,7 +273,7 @@ describe("agent/hosted/durable-run-event-sink", () => {
       DurableRunEventPersistenceError,
     );
 
-    const persisted = target.appended[0][0] as unknown as Record<string, unknown>;
+    const persisted = firstAppendedEvent(target.appended);
     assertEquals(
       getPrivateRunEventAppendRequestByteLength(persisted) <=
         MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES,
@@ -268,8 +285,7 @@ describe("agent/hosted/durable-run-event-sink", () => {
       true,
       "the reduced record still satisfies the private-event shape",
     );
-    const noticeText = ((persisted.messages as Array<Record<string, unknown>>)[0]
-      .content as Array<Record<string, unknown>>)[0].text as string;
+    const noticeText = leadingNoticeText(persisted);
     assertEquals(
       /\b[1-9]\d* message\(s\) omitted/.test(noticeText),
       true,
@@ -400,7 +416,7 @@ describe("agent/hosted/durable-run-event-sink", () => {
     assertEquals(dispatches, 0);
     assertEquals(oversized.appended.length, 1);
     assertEquals(
-      isPrivateConversationRunEvent(oversized.appended[0][0]),
+      isPrivateConversationRunEvent(firstAppendedEvent(oversized.appended)),
       true,
       "the audit record stays a valid private event",
     );

--- a/src/agent/hosted/durable-run-event-sink.ts
+++ b/src/agent/hosted/durable-run-event-sink.ts
@@ -52,7 +52,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 const TRUNCATED_TEXT_SUFFIX = "… [truncated]";
-const OMITTED_MESSAGE_NOTICE = "[messages omitted: model call context exceeded the payload limit]";
+const OMITTED_MESSAGE_NOTICE = "[veryfront] Model call context truncated for audit.";
 
 const utf8Encoder = new TextEncoder();
 
@@ -88,76 +88,91 @@ function truncateMessageTextParts(message: unknown, maxTextBytes: number): unkno
   };
 }
 
+function buildTruncationNotice(input: {
+  originalByteLength: number;
+  omittedMessageCount: number;
+}): unknown {
+  return {
+    role: "system",
+    content: [{
+      type: "text",
+      text:
+        `${OMITTED_MESSAGE_NOTICE} Original ${
+          formatMebibytes(input.originalByteLength)
+        } exceeded the ${
+          formatMebibytes(MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES)
+        } append limit; ${input.omittedMessageCount} message(s) omitted. The model call was not ` +
+        `dispatched — this record is an excerpt, not the context that was sent.`,
+    }],
+  };
+}
+
 /**
  * Fit an oversized model call context inside the append budget.
  *
  * Private run events are exempt from `normalizeConversationRunEvent`'s size clamp,
  * so nothing upstream shrinks them and the raw event is what gets sent. Rather
  * than lose the run's remaining events by disposing the mirror, the context is
- * reduced to fit and stamped so it never reads as a faithful record: `truncated`
- * says the content was reduced, and the original size and omitted-message count
- * say by how much. Newest messages are kept — they are the ones a reader of a
- * failed run is looking for.
+ * reduced to fit and led by a notice message saying what was cut, so it can never
+ * be read as the context that was actually sent. Newest messages are kept — they
+ * are what someone reading a failed run is looking for.
+ *
+ * The notice lives inside `messages` rather than in new top-level fields on
+ * purpose: `isPrivateConversationRunEvent` allows only `type`, `messages` and
+ * `tools`, and any extra key makes normalization throw — which this sink would
+ * then treat as a persistence failure and dispose the mirror, reintroducing the
+ * exact loss this function exists to prevent.
  */
-function truncatePrivateRunEventToLimit(event: Record<string, unknown>): Record<string, unknown> {
-  const originalByteLength = getPrivateRunEventAppendRequestByteLength(event);
+function truncatePrivateRunEventToLimit(
+  event: Record<string, unknown>,
+  originalByteLength: number,
+): { event: Record<string, unknown>; omittedMessageCount: number } {
   const messages = Array.isArray(event.messages) ? event.messages : [];
+  const tools = Array.isArray(event.tools) ? event.tools : undefined;
 
-  const stamp = (
-    next: Record<string, unknown>,
+  const build = (
+    kept: unknown[],
     omittedMessageCount: number,
+    keepTools: boolean,
   ): Record<string, unknown> => ({
-    ...next,
-    truncated: true,
-    originalByteLength,
-    omittedMessageCount,
+    type: event.type,
+    messages: [buildTruncationNotice({ originalByteLength, omittedMessageCount }), ...kept],
+    ...(tools === undefined ? {} : { tools: keepTools ? tools : [] }),
   });
 
-  // Clamp text progressively; each pass halves the per-part budget.
+  const fits = (candidate: Record<string, unknown>): boolean =>
+    getPrivateRunEventAppendRequestByteLength(candidate) <=
+      MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES;
+
+  // Clamp message text progressively; each pass quarters the per-part budget.
   for (
     let maxTextBytes = 64 * 1024;
     maxTextBytes >= 256;
     maxTextBytes = Math.floor(maxTextBytes / 4)
   ) {
-    const candidate = stamp(
-      {
-        ...event,
-        messages: messages.map((message) => truncateMessageTextParts(message, maxTextBytes)),
-      },
+    const candidate = build(
+      messages.map((message) => truncateMessageTextParts(message, maxTextBytes)),
       0,
+      true,
     );
-    if (
-      getPrivateRunEventAppendRequestByteLength(candidate) <=
-        MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES
-    ) {
-      return candidate;
-    }
+    if (fits(candidate)) return { event: candidate, omittedMessageCount: 0 };
   }
 
   // Still over: drop the oldest messages, keeping the most recent ones.
   const clamped = messages.map((message) => truncateMessageTextParts(message, 256));
   for (let keep = Math.min(clamped.length, 8); keep >= 1; keep--) {
-    const candidate = stamp(
-      { ...event, messages: clamped.slice(-keep) },
-      clamped.length - keep,
-    );
-    if (
-      getPrivateRunEventAppendRequestByteLength(candidate) <=
-        MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES
-    ) {
-      return candidate;
-    }
+    const candidate = build(clamped.slice(-keep), clamped.length - keep, true);
+    if (fits(candidate)) return { event: candidate, omittedMessageCount: clamped.length - keep };
   }
 
-  // Guaranteed-fit fallback: keep the envelope, drop the content entirely.
-  return stamp(
-    {
-      ...event,
-      messages: [{ role: "system", content: [{ type: "text", text: OMITTED_MESSAGE_NOTICE }] }],
-      ...(event.tools === undefined ? {} : { tools: [] }),
-    },
-    clamped.length,
-  );
+  // Last resort: notice only, and drop tools — the remaining bulk can only be there.
+  const bare = build([], clamped.length, false);
+  if (!fits(bare)) {
+    throw new DurableRunEventPersistenceError(
+      "Run event append request exceeds the supported payload size and could not be reduced",
+    );
+  }
+  return { event: bare, omittedMessageCount: clamped.length };
 }
 
 function formatMebibytes(bytes: number): string {
@@ -191,12 +206,12 @@ function resolvePersistableEvent(event: unknown): ResolvedRunEvent {
     );
   }
 
-  const truncated = truncatePrivateRunEventToLimit(event);
+  const truncated = truncatePrivateRunEventToLimit(event, requestByteLength);
   return {
-    event: truncated,
+    event: truncated.event,
     oversize: {
       originalByteLength: requestByteLength,
-      omittedMessageCount: Number(truncated.omittedMessageCount ?? 0),
+      omittedMessageCount: truncated.omittedMessageCount,
     },
   };
 }

--- a/src/agent/hosted/durable-run-event-sink.ts
+++ b/src/agent/hosted/durable-run-event-sink.ts
@@ -6,6 +6,7 @@ import {
 } from "../conversation/run-event-limits.ts";
 import { DurableRunEventPersistenceError } from "../conversation/private-run-event.ts";
 import type { AgentRunEventSink } from "../../runtime/model-call-context.ts";
+import { agentLogger } from "#veryfront/utils";
 
 const DEFAULT_DURABLE_RUN_EVENT_PERSISTENCE_TIMEOUT_MS = 30_000;
 const persistenceTails = new WeakMap<ConversationRunChunkMirror, Promise<void>>();
@@ -46,16 +47,170 @@ async function serializePersistence(
   }
 }
 
-function assertSupportedEventSize(event: unknown): void {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const TRUNCATED_TEXT_SUFFIX = "… [truncated]";
+const OMITTED_MESSAGE_NOTICE = "[messages omitted: model call context exceeded the payload limit]";
+
+const utf8Encoder = new TextEncoder();
+
+function getUtf8ByteLength(value: string): number {
+  return utf8Encoder.encode(value).byteLength;
+}
+
+/** Clamp to a UTF-8 byte budget without splitting a surrogate pair. */
+function truncateTextToBytes(value: string, maxBytes: number): string {
+  if (getUtf8ByteLength(value) <= maxBytes) return value;
+  const budget = Math.max(0, maxBytes - getUtf8ByteLength(TRUNCATED_TEXT_SUFFIX));
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (getUtf8ByteLength(value.slice(0, mid)) <= budget) low = mid;
+    else high = mid - 1;
+  }
+  // Never cut between a surrogate pair; step back onto a whole code point.
+  const end = low > 0 && /[\uD800-\uDBFF]/.test(value[low - 1] ?? "") ? low - 1 : low;
+  return `${value.slice(0, end)}${TRUNCATED_TEXT_SUFFIX}`;
+}
+
+function truncateMessageTextParts(message: unknown, maxTextBytes: number): unknown {
+  if (!isRecord(message) || !Array.isArray(message.content)) return message;
+  return {
+    ...message,
+    content: message.content.map((part) =>
+      isRecord(part) && typeof part.text === "string"
+        ? { ...part, text: truncateTextToBytes(part.text, maxTextBytes) }
+        : part
+    ),
+  };
+}
+
+/**
+ * Fit an oversized model call context inside the append budget.
+ *
+ * Private run events are exempt from `normalizeConversationRunEvent`'s size clamp,
+ * so nothing upstream shrinks them and the raw event is what gets sent. Rather
+ * than lose the run's remaining events by disposing the mirror, the context is
+ * reduced to fit and stamped so it never reads as a faithful record: `truncated`
+ * says the content was reduced, and the original size and omitted-message count
+ * say by how much. Newest messages are kept — they are the ones a reader of a
+ * failed run is looking for.
+ */
+function truncatePrivateRunEventToLimit(event: Record<string, unknown>): Record<string, unknown> {
+  const originalByteLength = getPrivateRunEventAppendRequestByteLength(event);
+  const messages = Array.isArray(event.messages) ? event.messages : [];
+
+  const stamp = (
+    next: Record<string, unknown>,
+    omittedMessageCount: number,
+  ): Record<string, unknown> => ({
+    ...next,
+    truncated: true,
+    originalByteLength,
+    omittedMessageCount,
+  });
+
+  // Clamp text progressively; each pass halves the per-part budget.
+  for (
+    let maxTextBytes = 64 * 1024;
+    maxTextBytes >= 256;
+    maxTextBytes = Math.floor(maxTextBytes / 4)
+  ) {
+    const candidate = stamp(
+      {
+        ...event,
+        messages: messages.map((message) => truncateMessageTextParts(message, maxTextBytes)),
+      },
+      0,
+    );
+    if (
+      getPrivateRunEventAppendRequestByteLength(candidate) <=
+        MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES
+    ) {
+      return candidate;
+    }
+  }
+
+  // Still over: drop the oldest messages, keeping the most recent ones.
+  const clamped = messages.map((message) => truncateMessageTextParts(message, 256));
+  for (let keep = Math.min(clamped.length, 8); keep >= 1; keep--) {
+    const candidate = stamp(
+      { ...event, messages: clamped.slice(-keep) },
+      clamped.length - keep,
+    );
+    if (
+      getPrivateRunEventAppendRequestByteLength(candidate) <=
+        MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES
+    ) {
+      return candidate;
+    }
+  }
+
+  // Guaranteed-fit fallback: keep the envelope, drop the content entirely.
+  return stamp(
+    {
+      ...event,
+      messages: [{ role: "system", content: [{ type: "text", text: OMITTED_MESSAGE_NOTICE }] }],
+      ...(event.tools === undefined ? {} : { tools: [] }),
+    },
+    clamped.length,
+  );
+}
+
+function formatMebibytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+/**
+ * What the sink decided to write, and whether the model call may proceed.
+ *
+ * An oversized context is reduced and persisted so an operator can still see
+ * what the run tried to send, but `oversize` is set so the caller refuses the
+ * dispatch. Recording a partial context must never be mistaken for having
+ * recorded the real one.
+ */
+type ResolvedRunEvent = {
+  event: unknown;
+  oversize?: { originalByteLength: number; omittedMessageCount: number };
+};
+
+function resolvePersistableEvent(event: unknown): ResolvedRunEvent {
   const requestByteLength = getPrivateRunEventAppendRequestByteLength(event);
   if (!Number.isFinite(requestByteLength)) {
     throw new DurableRunEventPersistenceError("Run event is not serializable");
   }
-  if (requestByteLength > MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES) {
+  if (requestByteLength <= MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES) {
+    return { event };
+  }
+  if (!isRecord(event)) {
     throw new DurableRunEventPersistenceError(
       "Run event append request exceeds the supported payload size",
     );
   }
+
+  const truncated = truncatePrivateRunEventToLimit(event);
+  return {
+    event: truncated,
+    oversize: {
+      originalByteLength: requestByteLength,
+      omittedMessageCount: Number(truncated.omittedMessageCount ?? 0),
+    },
+  };
+}
+
+function buildOversizeError(
+  oversize: { originalByteLength: number; omittedMessageCount: number },
+): DurableRunEventPersistenceError {
+  return new DurableRunEventPersistenceError(
+    `Run event append request exceeds the supported payload size: model call context was ` +
+      `${formatMebibytes(oversize.originalByteLength)}, limit is ` +
+      `${formatMebibytes(MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES)}. ` +
+      `A truncated record was persisted for audit and the model call was not dispatched. ` +
+      `Reduce conversation history or large tool results before retrying.`,
+  );
 }
 
 function getAbortReason(signal: AbortSignal): unknown {
@@ -95,9 +250,12 @@ export function createDurableRunEventSink(input: {
   timeoutMs?: number;
 }): AgentRunEventSink {
   return async (event) => {
+    let oversize: ResolvedRunEvent["oversize"];
     try {
       assertEnabled(input.mirror.getSnapshot());
-      assertSupportedEventSize(event);
+      const resolved = resolvePersistableEvent(event);
+      oversize = resolved.oversize;
+      const persistableEvent = resolved.event as typeof event;
       await serializePersistence(input.mirror, async () => {
         await withPersistenceDeadline({
           abortSignal: input.abortSignal,
@@ -113,7 +271,7 @@ export function createDurableRunEventSink(input: {
                 }),
               );
             }
-            await input.mirror.appendEvents([{ ...event }]);
+            await input.mirror.appendEvents([{ ...persistableEvent }]);
             abortSignal.throwIfAborted();
             assertDrained(
               await input.mirror.flush({
@@ -128,6 +286,22 @@ export function createDurableRunEventSink(input: {
     } catch (error) {
       input.mirror.dispose();
       throw error;
+    }
+
+    if (oversize) {
+      // The gate, deliberately after a successful write: the truncated record is
+      // durable so an operator can see what the run tried to send, and the mirror
+      // stays alive so the run's later events — including its failure — still
+      // persist. Only the model dispatch is refused.
+      agentLogger.warn(
+        "[durableRunEventSink] Model call context exceeded the append limit; dispatch refused",
+        {
+          originalByteLength: oversize.originalByteLength,
+          limitByteLength: MAX_CONVERSATION_RUN_EVENT_APPEND_REQUEST_BYTES,
+          omittedMessageCount: oversize.omittedMessageCount,
+        },
+      );
+      throw buildOversizeError(oversize);
     }
   };
 }

--- a/src/agent/hosted/project-reference-resolver.test.ts
+++ b/src/agent/hosted/project-reference-resolver.test.ts
@@ -30,7 +30,10 @@ Deno.test("resolveHostedProjectReference returns a matching normalized API ident
     (input, init) => {
       requests.push({
         url: String(input),
-        authorization: new Headers(init?.headers).get("authorization"),
+        // `init` is a union of RequestInit variants; narrow before reading headers.
+        authorization: new Headers(
+          init && "headers" in init ? init.headers as HeadersInit | undefined : undefined,
+        ).get("authorization"),
       });
       return Promise.resolve(
         Response.json({


### PR DESCRIPTION
Fixes veryfront/veryfront-issue-inbox#421.

## Problem

`assertSupportedEventSize` threw before anything was written, and the sink's catch disposes the mirror on **any** error:

```ts
} catch (error) {
  input.mirror.dispose()
  throw error
}
```

The damage is what happens next. The mirror's own methods return early when disabled rather than throwing (`run-chunk-mirror.ts:180-199`), and the main streaming path goes through `handleChunk`. So after one oversized context the run kept executing and **every later event was dropped in silence** — no throw, no log, no metric — while the run could still report `completed`.

That is the "run finishes with a hole in its history and the UI waits forever" shape, with nothing anywhere recording that it happened.

## What is deliberately unchanged

**The gate stays.** This sink is the persist-context-before-dispatch mechanism from #3309. Its oversize rejection is not only a size check — it is what stops a model being called when the call cannot be recorded. `rejects append failures and a request over the general body limit` asserts `dispatches === 0`, and that assertion is untouched and still passing.

An earlier draft of this change let the truncated context through and allowed the dispatch. That quietly traded a fail-closed audit guarantee for run completion, which is a bigger decision than this issue. Reverted.

## What changes

Only what an operator is left holding after a refusal:

- **The attempt is on the record.** The context is reduced to fit and persisted, stamped `truncated: true` with `originalByteLength` and `omittedMessageCount`. It cannot be mistaken for a faithful record — that is the whole point of the stamps, since a truncated model call context still parses as a valid one.
- **The mirror survives.** The run's later events, including its failure, still persist. This is the actual defect in #421.
- **The refusal explains itself.** The error names the real size, the limit, that the model was not dispatched, and what to reduce. A `warn` carries the same fields structured.

Reduction keeps the newest messages, which is what someone reading a failed run wants: text is clamped in decreasing passes, then the oldest messages are dropped, then a guaranteed-fit fallback keeps only the envelope.

## Tests

11 passing. Updated two that encoded the old behaviour, and added:

- the mirror stays usable and later events still persist after a refusal
- the error is operator-actionable (states size, limit, non-dispatch, and the audit record)
- a fit is still guaranteed when message *count* alone blows the budget and text clamping cannot help

The pre-existing `dispatches === 0` assertion is kept verbatim and extended to also assert the mirror was not disposed.

`deno task verify:quick` exit 0.

## Note on this issue's history

#421's description was written from too shallow a read and has been corrected three times on the issue: the abort path is narrower than I first claimed, truncation machinery already existed, and private run events are exempt from it by design. The defect that survived all of that is the one fixed here — the silent loss of everything after one oversized event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Oversized run events are now saved in a truncated form instead of being discarded.
  * Truncation preserves key audit details, including original size and omitted-message information.
  * Clear errors are shown when model dispatch is refused after an oversized event is persisted.
  * The event mirror remains available after this refusal, while model dispatch stays suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->