### PR TITLE
fix(cli): make deploy honour --project instead of silently ignoring it

### DIFF
--- a/cli/commands/deploy/command-help.ts
+++ b/cli/commands/deploy/command-help.ts
@@ -7,6 +7,14 @@ export const deployHelp: CommandHelp = {
   usage: "veryfront deploy [options]",
   options: [
     {
+      flag: "-p, --project <slug>",
+      description: "Project to deploy (default: the project this directory is linked to)",
+    },
+    {
+      flag: "-d, --dir <path>",
+      description: "Project directory (default: current directory)",
+    },
+    {
       flag: "-b, --branch <name>",
       description: "Branch to release from (default: main)",
     },
@@ -33,12 +41,14 @@ export const deployHelp: CommandHelp = {
     "veryfront deploy --branch feature-x --environment staging",
     "veryfront deploy --release-name v1.2.0",
     "veryfront deploy --dry-run",
+    "veryfront deploy --project my-app --environment production",
   ],
   notes: [
     "Requires VERYFRONT_API_TOKEN or an authenticated Veryfront login",
     "Creates or links a project when veryfront.json is not present",
     "Promotes main when --branch is omitted",
     "Pushes main before the first deploy when no verified push exists",
+    "With --project, promotes only: the working directory is never pushed, so this directory's push receipt must already name that project",
     "Creates a new release from the resolved branch",
     "Verifies the target environment points to the created deployment before succeeding",
   ],

--- a/cli/commands/deploy/command-help.ts
+++ b/cli/commands/deploy/command-help.ts
@@ -48,7 +48,7 @@ export const deployHelp: CommandHelp = {
     "Creates or links a project when veryfront.json is not present",
     "Promotes main when --branch is omitted",
     "Pushes main before the first deploy when no verified push exists",
-    "With --project, promotes only: the working directory is never pushed, so this directory's push receipt must already name that project",
+    "With --project, promotes only: the working directory is never pushed, so the selected project directory's push receipt must already name that project",
     "Creates a new release from the resolved branch",
     "Verifies the target environment points to the created deployment before succeeding",
   ],

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -27,6 +27,9 @@ function boundedDeployProject(): DeployProject {
 
 const PROJECT_ID = "550e8400-e29b-41d4-a716-446655440000";
 const ENVIRONMENT_ID = "660e8400-e29b-41d4-a716-446655440000";
+/** A project this directory never pushed, resolvable so only the receipt refuses. */
+const OTHER_PROJECT_SLUG = "other-project";
+const OTHER_PROJECT_ID = "770e8400-e29b-41d4-a716-446655440000";
 const RELEASE_ID = "770e8400-e29b-41d4-a716-446655440000";
 const DEPLOYMENT_ID = "880e8400-e29b-41d4-a716-446655440000";
 const PUSHED_SOURCE = "export const value = 1;\n";
@@ -128,6 +131,26 @@ function createDeployFetchHandler(options: {
     }
     if (request.method === "GET" && url.pathname === "/api/projects/my-project") {
       return Response.json({ id: PROJECT_ID, slug: "my-project" });
+    }
+    // Resolves cleanly on purpose. Without it a test naming another project
+    // fails on this lookup, which looks like the refusal it was written to
+    // prove and is not.
+    if (request.method === "GET" && url.pathname === `/api/projects/${OTHER_PROJECT_SLUG}`) {
+      return Response.json({ id: OTHER_PROJECT_ID, slug: OTHER_PROJECT_SLUG });
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname === `/api/projects/${OTHER_PROJECT_ID}/environments`
+    ) {
+      return Response.json({
+        data: [{
+          id: ENVIRONMENT_ID,
+          name: "production",
+          project_id: OTHER_PROJECT_ID,
+          protected: false,
+          domains: [],
+        }],
+      });
     }
     if (request.method === "GET" && url.pathname === "/api/projects/my-project/files") {
       return Response.json({ data: [], page_info: {} });
@@ -661,17 +684,20 @@ it("refuses to deploy a project this directory did not push", async () => {
     await withMockFetch(
       createDeployFetchHandler({ requests, sourceDigest, uploadedPaths }),
       () =>
-        assertRejects(() =>
-          deployCommand({
-            projectSlug: "other-project",
-            projectDir,
-            branch: "main",
-            env: "production",
-            dryRun: false,
-            force: false,
-            quiet: true,
-            deployProject: boundedDeployProject(),
-          })
+        assertRejects(
+          () =>
+            deployCommand({
+              projectSlug: OTHER_PROJECT_SLUG,
+              projectDir,
+              branch: "main",
+              env: "production",
+              dryRun: false,
+              force: false,
+              quiet: true,
+              deployProject: boundedDeployProject(),
+            }),
+          Error,
+          "The latest push targeted a different project.",
         ),
     );
 

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -605,6 +605,82 @@ it("bootstraps exactly one quiet push when no verified push receipt exists", asy
   });
 });
 
+it("never uploads the working directory when deploy names a project", async () => {
+  const projectDir = await Deno.makeTempDir();
+  await withDeployEnv(projectDir, async ({ sourceDigest }) => {
+    const requests: string[] = [];
+    const uploadedPaths: string[] = [];
+
+    await withMockFetch(
+      createDeployFetchHandler({ requests, sourceDigest, uploadedPaths }),
+      () =>
+        assertRejects(
+          () =>
+            deployCommand({
+              projectSlug: "my-project",
+              projectDir,
+              branch: "main",
+              env: "production",
+              dryRun: false,
+              force: false,
+              quiet: true,
+              deployProject: boundedDeployProject(),
+            }),
+          Error,
+          'No verified push found for branch "main"',
+        ),
+    );
+
+    assertEquals(uploadedPaths, []);
+    assertEquals(requests.some((request) => request.startsWith("PUT ")), false);
+    assertEquals(requests.includes(`POST /api/projects/${PROJECT_ID}/deployments`), false);
+  });
+});
+
+it("refuses to deploy a project this directory did not push", async () => {
+  // The incident this flag exists for: standing in one project's directory and
+  // naming another. The receipt here is valid -- for `my-project` -- so nothing
+  // but the slug mismatch can stop the deploy, and nothing may be uploaded on
+  // the way to stopping it.
+  const projectDir = await Deno.makeTempDir();
+  await withDeployEnv(projectDir, async ({ sourceDigest }) => {
+    await writePushReceipt(projectDir, {
+      controlPlane: "https://control.example.test/api",
+      projectId: PROJECT_ID,
+      projectSlug: "my-project",
+      branch: "main",
+      commitSha: `${"2".repeat(40)}`,
+      sourceDigest,
+      clean: true,
+      pushedAt: "2026-07-10T09:20:00.000Z",
+    });
+
+    const requests: string[] = [];
+    const uploadedPaths: string[] = [];
+
+    await withMockFetch(
+      createDeployFetchHandler({ requests, sourceDigest, uploadedPaths }),
+      () =>
+        assertRejects(() =>
+          deployCommand({
+            projectSlug: "other-project",
+            projectDir,
+            branch: "main",
+            env: "production",
+            dryRun: false,
+            force: false,
+            quiet: true,
+            deployProject: boundedDeployProject(),
+          })
+        ),
+    );
+
+    assertEquals(uploadedPaths, [], "a named project must never receive this directory");
+    assertEquals(requests.some((request) => request.startsWith("PUT ")), false);
+    assertEquals(requests.includes(`POST /api/projects/${PROJECT_ID}/deployments`), false);
+  });
+});
+
 it("fails on a stale verified push receipt instead of replacing it", async () => {
   const projectDir = await Deno.makeTempDir();
   await withDeployEnv(projectDir, async ({ sourceDigest }) => {

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -707,6 +707,50 @@ it("refuses to deploy a project this directory did not push", async () => {
   });
 });
 
+it("refuses the same mismatch in a dry run as in an apply", async () => {
+  // A dry run is read in order to trust the apply that follows. Naming a
+  // project makes the source already-pushed, which used to skip the receipt
+  // check here -- so the dry run reported a deploy the identical apply refused.
+  const projectDir = await Deno.makeTempDir();
+  await withDeployEnv(projectDir, async ({ sourceDigest }) => {
+    await writePushReceipt(projectDir, {
+      controlPlane: "https://control.example.test/api",
+      projectId: PROJECT_ID,
+      projectSlug: "my-project",
+      branch: "main",
+      commitSha: `${"3".repeat(40)}`,
+      sourceDigest,
+      clean: true,
+      pushedAt: "2026-07-10T09:20:00.000Z",
+    });
+
+    const requests: string[] = [];
+    const uploadedPaths: string[] = [];
+
+    await withMockFetch(
+      createDeployFetchHandler({ requests, sourceDigest, uploadedPaths }),
+      () =>
+        assertRejects(
+          () =>
+            deployCommand({
+              projectSlug: OTHER_PROJECT_SLUG,
+              projectDir,
+              branch: "main",
+              env: "production",
+              dryRun: true,
+              force: false,
+              quiet: true,
+              deployProject: boundedDeployProject(),
+            }),
+          Error,
+          "The latest push targeted a different project.",
+        ),
+    );
+
+    assertEquals(uploadedPaths, [], "a dry run must not upload either");
+  });
+});
+
 it("fails on a stale verified push receipt instead of replacing it", async () => {
   const projectDir = await Deno.makeTempDir();
   await withDeployEnv(projectDir, async ({ sourceDigest }) => {

--- a/cli/commands/deploy/command.test.ts
+++ b/cli/commands/deploy/command.test.ts
@@ -20,6 +20,10 @@ import { deployCommand } from "./command.ts";
 import { parseCliArgs } from "#cli/shared/args";
 import type { ParsedArgs } from "#cli/shared/types";
 
+// Never touched: the fake executor records the request without reading it.
+// Named rather than inlined so it cannot be mistaken for a real checkout.
+const UNRELATED_PROJECT_DIR = "fixtures/unrelated-checkout";
+
 async function captureConsole<T>(fn: () => Promise<T>): Promise<{ result: T; output: string[] }> {
   const output: string[] = [];
   const originalLog = console.log;
@@ -288,7 +292,7 @@ describe("deploy --project", () => {
     const { output } = await captureConsole(() =>
       deployCommand({
         ...parsed.data,
-        projectDir: "/tmp/an-unrelated-checkout",
+        projectDir: UNRELATED_PROJECT_DIR,
         dryRun: true,
         deployProject: fakeDeployment,
       })

--- a/cli/commands/deploy/command.test.ts
+++ b/cli/commands/deploy/command.test.ts
@@ -17,6 +17,7 @@ import type { DeployResult } from "../../shared/deployment/result.ts";
 import { stripAnsi } from "../../ui/ansi.ts";
 import { DeployArgsSchema, parseDeployArgs } from "./index.ts";
 import { deployCommand } from "./command.ts";
+import { parseCliArgs } from "#cli/shared/args";
 import type { ParsedArgs } from "#cli/shared/types";
 
 async function captureConsole<T>(fn: () => Promise<T>): Promise<{ result: T; output: string[] }> {
@@ -249,6 +250,65 @@ describe("parseDeployArgs", () => {
     if (!result.success) return;
 
     assertEquals(result.data.force, true);
+  });
+});
+
+describe("deploy --project", () => {
+  it("targets the named project and never pushes the working directory", async () => {
+    const observedRequests: DeployProjectRequest[] = [];
+    const fakeDeployment: DeployProject = {
+      execute(request) {
+        observedRequests.push(request);
+        return Promise.resolve({
+          kind: "dry-run",
+          plan: {
+            branch: request.branch ?? "main",
+            projectId: "project-codersociety",
+            // The control plane answers for the requested project; a run that
+            // ignored --project would ask about the working directory instead.
+            projectSlug: request.projectSlug ?? "veryfront-code",
+            environment: request.environment,
+            environmentId: "environment-production",
+            controlPlane: "https://control.example.test/api",
+            plannedActions: request.source.kind === "ensure-pushed"
+              ? ["push-source", "create-release", "deploy"]
+              : ["create-release", "deploy"],
+          },
+        });
+      },
+    };
+
+    const parsed = parseDeployArgs(
+      parseCliArgs(["deploy", "--project", "codersociety", "--environment", "production"]),
+    );
+    assertEquals(parsed.success, true);
+    if (!parsed.success) return;
+    assertEquals(parsed.data.projectSlug, "codersociety");
+
+    const { output } = await captureConsole(() =>
+      deployCommand({
+        ...parsed.data,
+        projectDir: "/tmp/an-unrelated-checkout",
+        dryRun: true,
+        deployProject: fakeDeployment,
+      })
+    );
+
+    assertEquals(observedRequests.length, 1);
+    const [request] = observedRequests;
+    assertEquals(request?.projectSlug, "codersociety");
+    assertEquals(request?.source, { kind: "already-pushed" });
+
+    const humanOutput = stripAnsi(output.join("\n"));
+    assertEquals(humanOutput.includes("for project codersociety"), true);
+    assertEquals(humanOutput.includes("push source"), false);
+  });
+
+  it("parses -p as the project slug", () => {
+    const parsed = parseDeployArgs(parseCliArgs(["deploy", "-p", "codersociety"]));
+    assertEquals(parsed.success, true);
+    if (!parsed.success) return;
+    assertEquals(parsed.data.projectSlug, "codersociety");
   });
 });
 

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -30,6 +30,7 @@ import type { DeployResult } from "../../shared/deployment/result.ts";
  */
 export const getDeployArgsSchema = defineSchema((v) =>
   v.object({
+    projectSlug: v.string().min(1).optional(),
     projectDir: v.string().optional(),
     branch: v.string().min(1).optional(),
     env: v.string().min(1).default("production"),
@@ -60,6 +61,7 @@ export type DeployOptions = Omit<ParsedDeployOptions, "skipSourcePush"> & {
  * Parse CLI arguments into validated DeployOptions
  */
 export const parseDeployArgs = createArgParser(DeployArgsSchema, {
+  projectSlug: CommonArgs.projectSlug,
   projectDir: CommonArgs.projectDir,
   branch: CommonArgs.branch,
   env: CommonArgs.env,
@@ -87,15 +89,18 @@ function deployRunner(options: DeployOptions): DeployProject {
 }
 
 function toDeployRequest(options: DeployOptions) {
+  // Naming a project promotes what that project already has. Deploy must never
+  // upload the working directory into a project the caller only named by slug:
+  // the directory is unrelated to that project by construction.
+  const promoteOnly = options.skipSourcePush || options.projectSlug !== undefined;
   return {
     projectDir: options.projectDir ?? cwd(),
+    ...(options.projectSlug === undefined ? {} : { projectSlug: options.projectSlug }),
     branch: options.branch,
     environment: options.env,
     releaseName: options.releaseName,
     mode: options.dryRun ? "dry-run" as const : "apply" as const,
-    source: options.skipSourcePush
-      ? { kind: "already-pushed" as const }
-      : { kind: "ensure-pushed" as const },
+    source: promoteOnly ? { kind: "already-pushed" as const } : { kind: "ensure-pushed" as const },
   };
 }
 
@@ -107,8 +112,9 @@ function formatDryRunActions(plan: DeployPlan): string {
 
 function logDryRunPlan(plan: DeployPlan, quiet: boolean): void {
   if (quiet) return;
-  const suffix = plan.projectId ? "" : ` for project ${plan.projectSlug}`;
-  logInfo(`Would ${formatDryRunActions(plan)}${suffix}`);
+  // A dry run exists to be read before the real one, so it always names the
+  // project it resolved: which project is what an operator gets wrong.
+  logInfo(`Would ${formatDryRunActions(plan)} for project ${plan.projectSlug}`);
 }
 
 function commandStepName(stepName: DeployStepName): string {

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -1123,7 +1123,15 @@ export function createDeployProject(options: {
       });
 
       if (request.mode === "dry-run") {
-        if (!bootstrapPush && request.source.kind === "ensure-pushed") {
+        // Naming a project also makes the source already-pushed, which would
+        // otherwise skip this check: the dry run then reported a deploy that
+        // the byte-identical apply refused, because the apply compares the
+        // receipt against the named project. `--skip-source-push` keeps its
+        // existing dry-run behaviour; the caller has said the source is handled.
+        if (
+          !bootstrapPush &&
+          (request.source.kind === "ensure-pushed" || request.projectSlug !== undefined)
+        ) {
           await resolvePushedSource({
             projectDir: request.projectDir,
             controlPlane: config.apiUrl,


### PR DESCRIPTION
`veryfront deploy --project X` accepted the flag and threw it away, resolving the project from the working directory instead:

```
$ deno run -A cli/main.ts deploy --project codersociety --environment production --dry-run
  › Would push source to "main", create release, and deploy to "production" for project veryfront-code
```

Worse than a no-op. `deploy` does not merely promote — it **pushes the working directory as project source first**. Combined with the ignored flag, one command can upload an unrelated directory into a project and promote the result. This nearly put a framework repository live on a customer's site; only the dry-run's project name caught it.

## Cause

The plumbing already existed: `cli/shared/deployment/deploy-project.ts:226-237` handles `request.projectSlug` and labels it `{ kind: "argument", name: "--project" }`. Only `parseDeployArgs`' map was missing the field, so `createArgParser` — which copies only mapped fields — discarded it.

Naming a project now also makes the deploy **promote-only**. That is what stops the upload: a working directory is unrelated to a project the caller named by slug.

## Dry run and apply now agree

Making the source `already-pushed` exposed a second problem, and it matters because the reported incident *was* a dry run. The dry-run branch validated the push receipt only for an `ensure-pushed` source, so a named project skipped the check entirely and reported a deploy that the byte-identical apply refused.

It now validates for a named project too. `--skip-source-push` keeps its existing dry-run behaviour — that caller has explicitly said the source is handled — so this does not tighten an unrelated path.

## Test

`refuses to deploy a project this directory did not push` writes a *valid* receipt for `my-project` and then deploys `--project other-project`, so nothing but the mismatch can stop it, and nothing may be uploaded on the way.

Checked against the mutation that matters — dropping the `projectSlug` forwarding — and it **fails**. A test using the already-linked slug passes either way, which is why this one names a different project.

## Both modes are covered

`refuses to deploy a project this directory did not push` writes a *valid* receipt for `my-project`, resolves `other-project` so nothing but the mismatch can refuse, and asserts the refusal by message. `refuses the same mismatch in a dry run as in an apply` pins the two modes together.

Each was checked in the direction that matters:

| Mutation | Result |
|---|---|
| drop the `projectSlug` forwarding | **fails** |
| revert the dry-run receipt check | **fails** |
| as written | passes |

The dry-run case took two attempts. The first passed with the fix reverted and was deleted rather than shipped; the cause was the fixture resolving only one project, so the dry run died on a lookup either way. Resolving `other-project` for the mismatch test removed that blocker and the case could then be written honestly.

Found via veryfront-issue-inbox#430. The promote-only behaviour change is worth a reviewer's attention: anyone who relied on `deploy --project X` bootstrapping the first push must now run `veryfront push` first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for targeting a specific project during deployment with `--project`/`-p`.
  * Added the `--dir` option for specifying the deployment directory.
  * Updated deployment help with project-specific examples and promotion requirements.
  * Dry-run output now identifies the selected project.

* **Bug Fixes**
  * Prevented named-project deployments and dry runs from proceeding without a verified source push or with a mismatched source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
