### PR TITLE
fix(agent): let elapsedMs reach the wire through the AG-UI SSE schemas

### DIFF
--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -376,6 +376,45 @@ describe("internal-agents/ag-ui-sse", () => {
     );
   });
 
+  it("carries elapsedMs through to the wire without widening the allow-list", () => {
+    // These payload schemas are an allow-list and `parse` returns only what
+    // they declare, so a stamped field missing from a schema is dropped
+    // silently between the encoder and the wire. That is how elapsedMs went
+    // missing through two releases after it was already being stamped, so
+    // both halves are pinned: the field survives, and nothing else does.
+    const stamped = new TextDecoder().decode(
+      formatAgUiEvent("StepStarted", { stepName: "step-1", elapsedMs: 42 }),
+    );
+    assertEquals(
+      stamped.includes('"elapsedMs":42'),
+      true,
+      `elapsedMs must reach the wire, got ${JSON.stringify(stamped)}`,
+    );
+
+    const leaked = new TextDecoder().decode(
+      formatAgUiEvent("StepStarted", { stepName: "step-1", unexpected: "x" }),
+    );
+    assertEquals(
+      leaked.includes("unexpected"),
+      false,
+      `the allow-list must still drop undeclared fields, got ${JSON.stringify(leaked)}`,
+    );
+  });
+
+  it("stamps elapsedMs end to end from the runtime encoder root", () => {
+    const state = createStreamTransformState();
+    mapRuntimeEventToAgUi(state, { type: "message-start", messageId: "assistant-1" });
+    const events = mapRuntimeEventToAgUi(state, { type: "start-step" });
+    const frame = new TextDecoder().decode(
+      formatAgUiEvent(events[0]!.event, events[0]!.payload),
+    );
+    assertEquals(
+      /"elapsedMs":\d+/.test(frame),
+      true,
+      `the production encoder root must emit elapsedMs, got ${JSON.stringify(frame)}`,
+    );
+  });
+
   it("accepts extension event tokens without weakening SSE framing", () => {
     const payload = formatAgUiEvent("Done.custom-v1", { ok: true });
 

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -30,14 +30,26 @@ export function createStreamTransformState(
 
 function buildAgUiEventPayloadSchemas(): Record<string, Schema<Record<string, unknown>>> {
   const v = resolveSchemaValidator();
+  // Every encoded event carries a run-relative `elapsedMs` (see browser-encoder).
+  // These payload schemas are an allow-list and `parse` returns only what they
+  // declare, so a field missing from one is silently dropped before it reaches
+  // the wire -- which is exactly how `elapsedMs` went missing after it was
+  // stamped. Declaring it here once keeps that from recurring per event type.
+  const withElapsed = (
+    shape: Record<string, unknown>,
+  ): Schema<Record<string, unknown>> =>
+    // deno-lint-ignore no-explicit-any
+    (v.object({ ...shape, elapsedMs: v.number().optional() } as any) as unknown) as Schema<
+      Record<string, unknown>
+    >;
   const schemas: Record<string, Schema<Record<string, unknown>>> = {
-    RunStarted: v.object({
+    RunStarted: withElapsed({
       runId: v.string().min(1),
       threadId: v.string().min(1),
       agentId: v.string().min(1),
     }),
-    StateSnapshot: v.object({ snapshot: v.record(v.string(), v.unknown()) }),
-    MessagesSnapshot: v.object({
+    StateSnapshot: withElapsed({ snapshot: v.record(v.string(), v.unknown()) }),
+    MessagesSnapshot: withElapsed({
       messages: v.array(v.object({
         id: v.string().min(1),
         role: v.enum(["user", "assistant", "system", "tool"]),
@@ -46,36 +58,39 @@ function buildAgUiEventPayloadSchemas(): Record<string, Schema<Record<string, un
         createdAt: v.string().optional(),
       })),
     }),
-    TextMessageStart: v.object({
+    TextMessageStart: withElapsed({
       messageId: v.string().min(1),
       contentId: v.string().min(1),
       role: v.literal("assistant"),
     }),
-    TextMessageContent: v.object({
+    TextMessageContent: withElapsed({
       messageId: v.string().min(1),
       contentId: v.string().min(1),
       delta: v.string(),
     }),
-    TextMessageEnd: v.object({
+    TextMessageEnd: withElapsed({
       messageId: v.string().min(1),
       contentId: v.string().min(1),
     }),
-    ReasoningMessageStart: v.object({ messageId: v.string().min(1), role: v.literal("reasoning") }),
-    ReasoningMessageContent: v.object({ messageId: v.string().min(1), delta: v.string() }),
-    ReasoningMessageEnd: v.object({ messageId: v.string().min(1) }),
-    StepStarted: v.object({ stepName: v.string().min(1) }),
-    StepFinished: v.object({ stepName: v.string().min(1) }),
-    ToolCallStart: v.object({ toolCallId: v.string().min(1), toolCallName: v.string().min(1) }),
-    ToolCallArgs: v.object({ toolCallId: v.string().min(1), delta: v.string() }),
-    ToolCallEnd: v.object({ toolCallId: v.string().min(1) }),
-    ToolCallResult: v.object({
+    ReasoningMessageStart: withElapsed({
+      messageId: v.string().min(1),
+      role: v.literal("reasoning"),
+    }),
+    ReasoningMessageContent: withElapsed({ messageId: v.string().min(1), delta: v.string() }),
+    ReasoningMessageEnd: withElapsed({ messageId: v.string().min(1) }),
+    StepStarted: withElapsed({ stepName: v.string().min(1) }),
+    StepFinished: withElapsed({ stepName: v.string().min(1) }),
+    ToolCallStart: withElapsed({ toolCallId: v.string().min(1), toolCallName: v.string().min(1) }),
+    ToolCallArgs: withElapsed({ toolCallId: v.string().min(1), delta: v.string() }),
+    ToolCallEnd: withElapsed({ toolCallId: v.string().min(1) }),
+    ToolCallResult: withElapsed({
       toolCallId: v.string().min(1),
       result: v.unknown(),
       isError: v.boolean().optional(),
     }),
-    Custom: v.object({ name: v.string().min(1), value: v.unknown() }),
-    RunError: v.object({ code: v.string().min(1).optional(), message: v.string().min(1) }),
-    RunFinished: v.object({
+    Custom: withElapsed({ name: v.string().min(1), value: v.unknown() }),
+    RunError: withElapsed({ code: v.string().min(1).optional(), message: v.string().min(1) }),
+    RunFinished: withElapsed({
       metadata: v.object({
         provider: v.string().optional(),
         model: v.string().optional(),


### PR DESCRIPTION
`elapsedMs` has been stamped since #3502 but still never reached storage. This is why.

## Root cause, with a reproduction

The AG-UI SSE payload schemas in `src/internal-agents/ag-ui-sse.ts` are an **allow-list**, and `formatAgUiEvent` serializes `schema.parse(payload)` — the parse *result*, not the input. Anything the schema does not declare is dropped between the encoder and the wire:

```
formatAgUiEvent("StepStarted", { stepName: "step-1", elapsedMs: 42 })
→ 'event: StepStarted\ndata: {"stepName":"step-1"}\n\n'
```

That also explains the evidence that made this so confusing to chase: `stepName` survived because it is on the allow-list; `elapsedMs` never was. Both symptoms had the same single cause.

Measured on production **v0.1.1222**: the 14:00 tick still showed no `elapsedMs` on any event, on pods verified to report `0.1.1222` (`10.192.9.132`, `10.192.6.137`, artifact `20260809132722-48ee1f3b77bb`). So this was not a rollout-timing artifact.

## Fix

Declare `elapsedMs` once through a `withElapsed` helper applied to all 18 event schemas, rather than widening them to passthrough. The allow-list is a deliberate wire contract — this stream is persisted verbatim into `agent_run_event` — so it stays closed to everything else.

## Tests

Two, both verified to fail without the change:

- `elapsedMs` reaches the wire, **and** an undeclared field still does not — pinning both halves, so a future "fix" that just makes the schemas passthrough would not satisfy it.
- End-to-end from the real production composition root: `createStreamTransformState()` → `mapRuntimeEventToAgUi` → `formatAgUiEvent`.

Reverting the fix reproduces the exact production symptom:

```
AssertionError: elapsedMs must reach the wire, got
"event: StepStarted\ndata: {\"stepName\":\"step-1\"}\n\n"
```

**The gap that let this through:** `browser-encoder` and `ag-ui-sse` were each well covered in isolation, so a field vanishing *between* them was invisible to both suites. The second test exists specifically to cover that boundary.

## Follow-up, agreed separately

Add an absolute `emittedAt` as the durable primitive and derive elapsed on read. `elapsedMs` is measured from encoder construction, so its meaning depends on which encoder instance produced it and when — the anchor ambiguity behind #3483, #3497 and #3502 each landing in the wrong place. An absolute timestamp has no anchor to get wrong, and additionally makes ingest lag measurable as `created_at − emittedAt`, which is the gap that misled the original trace analysis.

## Note on the pre-push gate

Two pushes were rejected by timing-sensitive tests before this landed — `string-renderer` (5ms SSR deadline) and `project-env/fetcher` (timeout fallback). Both pass in isolation and are unrelated to SSE schemas; the machine was loaded by concurrent suites. Flagging rather than hiding it.