### PR TITLE
Fix omitted hosted tool selector loading mode

### DIFF
--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -146,8 +146,31 @@ Deno.test("prepareHostedChatRuntimeToolAssembly keeps empty allowed tools as exp
     preloadLatestConversationUserText: false,
   });
 
+  assertEquals(toolAssembly.toolLoadingMode, "eager");
   assertEquals(toolAssembly.localToolNames, []);
   assertEquals(taskContext.availableToolNames, []);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly defers an omitted allowed tools catalog", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    sourceIntegrationPolicy: unrestrictedSourceIntegrationPolicy,
+    taskContext,
+    instructions: "Base instructions",
+    localTools: { sleep: localTool("Sleep") },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.toolLoadingMode, "deferred");
+  assertEquals(taskContext.availableToolNames, ["tool_search"]);
 });
 
 Deno.test("prepareHostedChatRuntimeToolAssembly defers an unrestricted tools true catalog", async () => {

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -268,8 +268,11 @@ export async function prepareHostedChatRuntimeToolAssembly<
     agentId: input.taskContext.agentId,
     localTools: authorizedLocalTools,
   });
+  const normalizedAllowedToolNames = normalizeHostedRuntimeAllowedToolNames(
+    ownerScopedAllowedToolNames,
+  );
   const allowedToolNames = resolveHostedRuntimeAllowedToolNames({
-    allowedToolNames: ownerScopedAllowedToolNames,
+    allowedToolNames: normalizedAllowedToolNames,
     localToolNames: Object.keys(authorizedLocalTools),
     availableSkillIds: input.taskContext.availableSkillIds,
     includeRuntimeEssentialToolsWhenEmpty: input.includeRuntimeEssentialToolsWhenEmpty,
@@ -359,7 +362,7 @@ export async function prepareHostedChatRuntimeToolAssembly<
     input.sourceIntegrationPolicy,
   );
   const localToolNames = Object.keys(localHostTools);
-  const toolLoadingMode: RuntimeToolLoadingMode = input.allowedToolNames === null
+  const toolLoadingMode: RuntimeToolLoadingMode = normalizedAllowedToolNames === null
     ? "deferred"
     : "eager";
   const authorizedToolNames = [


### PR DESCRIPTION
Closes veryfront/veryfront-issue-inbox#437

## Summary

- select hosted runtime tool-loading mode from the normalized owner-scoped selector
- treat omitted `allowedToolNames` like explicit `null` and use deferred loading
- preserve empty arrays as eager, explicit deny-all selectors

## Verification

- `deno test --no-check --allow-all src/agent/hosted/default-chat-runtime.test.ts src/agent/hosted/runtime-essential-tools.test.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts`
- `deno check src/agent/hosted/chat-runtime-tool-assembly.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts`
- `deno task verify:quick`
- `git diff --check`