### PR TITLE
build: define the verify:dist task the release script already calls

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -463,6 +463,7 @@
     "build": "deno task build:prepare && deno run -A scripts/build/compile-binary.ts --output ./bin/veryfront",
     "build:proxy-lock": "deno cache --node-modules-dir=none --lock scripts/build/proxy-deno.lock cli/proxy-main.ts",
     "build:npm": "deno run -A scripts/build/generate-integrations-module.ts && deno task generate && deno run --config=scripts/test.deno.json --frozen -A scripts/build/build-npm-dnt.ts",
+    "verify:dist": "deno task build && deno task build:npm",
     "release": "deno run -A scripts/release.ts",
     "test": "deno task generate && DENO_TESTING=1 VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/testing/preload.ts --no-check --parallel --allow-all '--ignore=tests/e2e,tests/integration/compiled-binary-e2e.test.ts,scripts' --unstable-worker-options --unstable-net",
     "test:unit": "deno task generate && DENO_TESTING=1 VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/testing/preload.ts --no-check --parallel --allow-all --v8-flags=--max-old-space-size=8192 '--ignore=tests,src/workflow/__tests__' --unstable-worker-options --unstable-net $(find src cli -name '*.test.ts*' ! -name '*.integration.test.ts*')",


### PR DESCRIPTION
Closes veryfront-issue-inbox#435.

## Problem

`scripts/release.ts` runs `deno task verify:dist` whenever `--no-build` is not passed:

```ts
// 3. Verify distributable artifacts locally (CI will rebuild on publish)
if (!args["no-build"]) {
  console.log("\n📦 Verifying distribution artifacts (binary + npm package)...");
  await runCommand(["deno", "task", "verify:dist"]);
}
```

No such task existed. Running it printed `Task not found: verify:dist` followed by the task list, so **any release cut without `--no-build` failed at that step**.

Together with #3505 — which fixed `deno task test` dying on an orphaned `#dnt` import since #3212 — this is why recent releases were all cut as `--no-test --no-build`: both of the release script's own gates were unrunnable, for two unrelated reasons. With both fixed, releases can run their own gates again.

## Fix

Defined as the two tasks the script's own comment names — binary and npm package:

```json
"verify:dist": "deno task build && deno task build:npm"
```

## Verified before proposing

Ran end to end on this branch:

```
$ deno task verify:dist
...
📦 Output: ./npm/
📦 Extension packages: ./npm/extensions/
exit=0
```

Both artifacts produced, and no build output leaks into git (`git status` shows only `deno.json`). Defining a task that does not work would only relocate the breakage, so it was executed rather than assumed.

## Note on cost

It is not free — `verify:dist` compiles the binary and builds the npm package locally, so an ungated `deno task release` becomes substantially slower. That is presumably part of why the skip flags became habitual. If that tradeoff is unwanted, the alternative is to drop the call from `release.ts` rather than leave it referencing a task that does not exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a distribution verification task that runs both build processes to validate generated packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->