### PR TITLE
fix(deploy): stop failing deploys on a probe an API key cannot pass

### DIFF
--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -700,6 +700,66 @@ describe("environment URL readiness", () => {
     }]);
   });
 
+  it("does not send an opaque credential that merely contains dots", async () => {
+    const requests: Array<{ url: string; cookie: string | null }> = [];
+
+    await withMockFetch(
+      (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        requests.push({ url: request.url, cookie: request.headers.get("cookie") });
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://veryfront.com/sign-in" },
+          }),
+        );
+      },
+      () =>
+        waitForEnvironmentReady({
+          ...hostedTarget,
+          protected: true,
+          // Three non-empty segments, but no decodable JWT payload behind them.
+          apiToken: "opaque.segment.value",
+        }),
+    );
+
+    assertEquals(requests, [{
+      url: "https://my-project.production.veryfront.com/",
+      cookie: null,
+    }]);
+  });
+
+  it("does not send a JWT-shaped credential whose payload carries no userId", async () => {
+    const requests: Array<{ url: string; cookie: string | null }> = [];
+    // {"alg":"HS256"} . {"sub":"u_1"} . sig — decodes cleanly, but the gate
+    // reads userId, so this could never resolve to a member.
+    const withoutUserId = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1XzEifQ.test-signature";
+
+    await withMockFetch(
+      (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        requests.push({ url: request.url, cookie: request.headers.get("cookie") });
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://veryfront.com/sign-in" },
+          }),
+        );
+      },
+      () =>
+        waitForEnvironmentReady({
+          ...hostedTarget,
+          protected: true,
+          apiToken: withoutUserId,
+        }),
+    );
+
+    assertEquals(requests, [{
+      url: "https://my-project.production.veryfront.com/",
+      cookie: null,
+    }]);
+  });
+
   it("treats a sign-in redirect as ready when the credential is an API key", async () => {
     // The deployment is already committed by the time this probe runs. A
     // redirect proves routing resolves and the gate is serving the

--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -582,12 +582,17 @@ describe("pushed source provenance", () => {
 });
 
 describe("environment URL readiness", () => {
+  // The protected-environment gate only accepts a session JWT, so the probe
+  // credential has to be JWT-shaped for the authenticated path to be exercised.
+  const sessionToken = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJ1XzEifQ.test-signature";
+  const apiKeyToken = "vf_d157f0000000000000000000000000000000000";
+
   const hostedTarget = {
     projectSlug: "my-project",
     environmentName: "production",
     url: "https://my-project.production.veryfront.com",
     protected: false,
-    apiToken: "test-token",
+    apiToken: sessionToken,
   };
 
   it("retries a transient 404 before accepting the environment URL", async () => {
@@ -662,7 +667,81 @@ describe("environment URL readiness", () => {
         }),
     );
 
-    assertEquals(cookie, "authToken=test-token");
+    assertEquals(cookie, `authToken=${sessionToken}`);
+  });
+
+  it("does not send an API key to the protected environment gate", async () => {
+    const requests: Array<{ url: string; cookie: string | null }> = [];
+
+    await withMockFetch(
+      (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        requests.push({ url: request.url, cookie: request.headers.get("cookie") });
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://veryfront.com/sign-in" },
+          }),
+        );
+      },
+      () =>
+        waitForEnvironmentReady({
+          ...hostedTarget,
+          protected: true,
+          apiToken: apiKeyToken,
+        }),
+    );
+
+    // The gate only resolves session JWTs, so an API key is rejected exactly
+    // like no credential at all. Sending it leaks the key for no benefit.
+    assertEquals(requests, [{
+      url: "https://my-project.production.veryfront.com/",
+      cookie: null,
+    }]);
+  });
+
+  it("treats a sign-in redirect as ready when the credential is an API key", async () => {
+    // The deployment is already committed by the time this probe runs. A
+    // redirect proves routing resolves and the gate is serving the
+    // environment, which is all this probe can establish without a session.
+    await withMockFetch(
+      () =>
+        Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://veryfront.com/sign-in" },
+          }),
+        ),
+      () =>
+        waitForEnvironmentReady({
+          ...hostedTarget,
+          protected: true,
+          apiToken: apiKeyToken,
+        }),
+    );
+  });
+
+  it("classifies a rejected session credential as a deployment error", async () => {
+    const error = await assertRejects(() =>
+      withMockFetch(
+        () =>
+          Promise.resolve(
+            new Response(null, {
+              status: 302,
+              headers: { location: "https://veryfront.com/sign-in" },
+            }),
+          ),
+        () =>
+          waitForEnvironmentReady({
+            ...hostedTarget,
+            protected: true,
+          }),
+      )
+    );
+
+    // A bare Error here surfaces to the operator as `unknown-error`.
+    assertStrictEquals(error instanceof VeryfrontError, true);
+    assertEquals((error as VeryfrontError).slug, DEPLOYMENT_ERROR.slug);
   });
 
   it("upgrades authenticated Veryfront environment probes to HTTPS", async () => {
@@ -685,7 +764,7 @@ describe("environment URL readiness", () => {
     );
 
     assertEquals(requestedUrl, "https://my-project.production.veryfront.com/");
-    assertEquals(cookie, "authToken=test-token");
+    assertEquals(cookie, `authToken=${sessionToken}`);
   });
 
   it("does not send credentials to a mismatched Veryfront project host", async () => {
@@ -722,7 +801,7 @@ describe("environment URL readiness", () => {
       },
       {
         url: "https://my-project.production.veryfront.com/",
-        cookie: "authToken=test-token",
+        cookie: `authToken=${sessionToken}`,
       },
     ]);
   });
@@ -749,7 +828,7 @@ describe("environment URL readiness", () => {
 
     assertEquals(requests, [{
       url: "https://my-project.production.veryfront.org/",
-      cookie: "authToken=test-token",
+      cookie: `authToken=${sessionToken}`,
     }]);
   });
 
@@ -784,7 +863,7 @@ describe("environment URL readiness", () => {
       { url: "https://app.example.com/", cookie: null },
       {
         url: "https://my-project.production.veryfront.com/",
-        cookie: "authToken=test-token",
+        cookie: `authToken=${sessionToken}`,
       },
     ]);
   });

--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -997,6 +997,18 @@ describe("environment URL readiness", () => {
     );
   });
 
+  it("names the status when a challenge was not a sign-in redirect", async () => {
+    const message = await withMockFetch(
+      () => Promise.resolve(new Response(null, { status: 403 })),
+      () =>
+        expectErrorMessage(() => waitForEnvironmentReady({ ...hostedTarget, protected: false })),
+    );
+
+    // A 403 performs no redirect. Reporting one sends the operator looking for
+    // a hop that never happened.
+    assertMatch(message ?? "", /returned HTTP 403/);
+  });
+
   it("reports the URL and last status when readiness times out", async () => {
     const error = await withMockFetch(
       () => Promise.resolve(new Response("not ready", { status: 404 })),

--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -582,8 +582,7 @@ describe("pushed source provenance", () => {
 });
 
 describe("environment URL readiness", () => {
-  // The protected-environment gate only accepts a session JWT, so the probe
-  // credential has to be JWT-shaped for the authenticated path to be exercised.
+  // Must be JWT-shaped, or the authenticated path stops being exercised.
   const sessionToken = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJ1XzEifQ.test-signature";
   const apiKeyToken = "vf_d157f0000000000000000000000000000000000";
 
@@ -692,8 +691,6 @@ describe("environment URL readiness", () => {
         }),
     );
 
-    // The gate only resolves session JWTs, so an API key is rejected exactly
-    // like no credential at all. Sending it leaks the key for no benefit.
     assertEquals(requests, [{
       url: "https://my-project.production.veryfront.com/",
       cookie: null,
@@ -718,7 +715,6 @@ describe("environment URL readiness", () => {
         waitForEnvironmentReady({
           ...hostedTarget,
           protected: true,
-          // Three non-empty segments, but no decodable JWT payload behind them.
           apiToken: "opaque.segment.value",
         }),
     );
@@ -731,8 +727,7 @@ describe("environment URL readiness", () => {
 
   it("does not send a JWT-shaped credential whose payload carries no userId", async () => {
     const requests: Array<{ url: string; cookie: string | null }> = [];
-    // {"alg":"HS256"} . {"sub":"u_1"} . sig — decodes cleanly, but the gate
-    // reads userId, so this could never resolve to a member.
+    // {"alg":"HS256"} . {"sub":"u_1"} . sig — decodes, but carries no userId.
     const withoutUserId = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1XzEifQ.test-signature";
 
     await withMockFetch(
@@ -761,9 +756,6 @@ describe("environment URL readiness", () => {
   });
 
   it("treats a sign-in redirect as ready when the credential is an API key", async () => {
-    // The deployment is already committed by the time this probe runs. A
-    // redirect proves routing resolves and the gate is serving the
-    // environment, which is all this probe can establish without a session.
     await withMockFetch(
       () =>
         Promise.resolve(
@@ -1004,8 +996,6 @@ describe("environment URL readiness", () => {
         expectErrorMessage(() => waitForEnvironmentReady({ ...hostedTarget, protected: false })),
     );
 
-    // A 403 performs no redirect. Reporting one sends the operator looking for
-    // a hop that never happened.
     assertMatch(message ?? "", /returned HTTP 403/);
   });
 

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -829,11 +829,32 @@ function isMatchingVeryfrontHostedUrl(
     parsed.environment === target.environmentName.toLowerCase();
 }
 
+/**
+ * Whether a stored credential could satisfy the protected-environment gate.
+ *
+ * The gate resolves the `authToken` cookie by decoding it as a JWT and reading
+ * `userId` from the verified payload; it has no API-key branch. An opaque
+ * `vf_…` API key therefore fails the same way an absent cookie does, so
+ * presenting one only leaks the key. This is a shape check, not verification —
+ * the CLI cannot verify the signature and does not need to. It only needs to
+ * know whether the gate could possibly accept the credential.
+ */
+function isSessionCredential(apiToken: string): boolean {
+  const segments = apiToken.split(".");
+  return segments.length === 3 && segments.every((segment) => segment.length > 0);
+}
+
 function buildEnvironmentReadinessProbes(
   target: EnvironmentReadinessTarget,
 ): EnvironmentReadinessProbe[] {
   const route = target.route === undefined ? "/" : target.route;
   if (route === null) return [];
+
+  // Without a session credential the probe cannot get past the gate. A sign-in
+  // redirect still proves routing resolves and the proxy is serving this
+  // environment, which is the most this step can establish — and the
+  // deployment it would otherwise fail is already committed and verified.
+  const canAuthenticate = isSessionCredential(target.apiToken);
 
   const targetUrl = buildEnvironmentProbeUrl(target.url, route);
   if (target.protected && !isMatchingVeryfrontHostedUrl(new URL(targetUrl), target)) {
@@ -848,15 +869,15 @@ function buildEnvironmentReadinessProbes(
           buildCanonicalEnvironmentUrl(target.projectSlug, target.environmentName),
           route,
         ),
-        authenticate: true,
-        acceptAuthenticationChallenge: false,
+        authenticate: canAuthenticate,
+        acceptAuthenticationChallenge: !canAuthenticate,
       },
     ];
   }
   return [{
     url: target.protected ? secureEnvironmentProbeUrl(targetUrl) : targetUrl,
-    authenticate: target.protected,
-    acceptAuthenticationChallenge: false,
+    authenticate: target.protected && canAuthenticate,
+    acceptAuthenticationChallenge: target.protected && !canAuthenticate,
   }];
 }
 
@@ -935,25 +956,33 @@ export async function waitForEnvironmentReady(
 
         if (ready) break;
         if (authenticationChallenge) {
-          const message = probe.authenticate
-            ? `Could not authenticate the protected environment URL ${probe.url}. Run veryfront login and deploy again.`
-            : `Environment URL ${probe.url} redirected to sign-in. Check its protection settings and deploy again.`;
-          throw new Error(message);
+          // These are diagnosed conditions, so they must carry the deployment
+          // slug. A bare Error reaches the operator as `unknown-error` with
+          // "Check logs for more details", which describes nothing.
+          throw DEPLOYMENT_ERROR.create({
+            detail: probe.authenticate
+              ? `Could not authenticate the protected environment URL ${probe.url}. Run veryfront login and deploy again.`
+              : `Environment URL ${probe.url} redirected to sign-in. Check its protection settings and deploy again.`,
+            context: { url: probe.url },
+          });
         }
         if (!isTransientEnvironmentStatus(response.status)) {
-          throw new Error(
-            `Environment URL ${probe.url} returned HTTP ${response.status}. Check the environment configuration and deploy again.`,
-          );
+          throw DEPLOYMENT_ERROR.create({
+            detail:
+              `Environment URL ${probe.url} returned HTTP ${response.status}. Check the environment configuration and deploy again.`,
+            context: { url: probe.url, status: response.status },
+          });
         }
       }
 
       const remainingMs = deadline - Date.now();
       if (remainingMs <= 0) {
-        throw new Error(
-          `Environment URL ${probe.url} did not become ready within ${
+        throw DEPLOYMENT_ERROR.create({
+          detail: `Environment URL ${probe.url} did not become ready within ${
             Math.ceil(timeoutMs / 1000)
           }s (last response: ${lastResponse}). Check the deployment and run deploy again.`,
-        );
+          context: { url: probe.url, timeoutMs },
+        });
       }
       await wait(Math.min(pollIntervalMs, remainingMs));
     }

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -849,24 +849,9 @@ function decodeJwtSegment(segment: string | undefined): object | null {
 /**
  * Whether a stored credential could satisfy the protected-environment gate.
  *
- * The gate resolves the `authToken` cookie by decoding it as a JWT and reading
- * `userId` from the verified payload; it has no API-key branch. An opaque
- * `vf_…` API key therefore fails the same way an absent cookie does, so
- * presenting one only leaks the key.
- *
- * This mirrors what the gate reads rather than merely counting dots, so an
- * opaque credential that happens to contain dots is withheld too. It is still
- * a shape check, not verification — the CLI cannot verify the signature and
- * does not need to. It only needs to know whether the gate could possibly
- * accept the credential.
- *
- * The counterpart is `isApiKeyToken` in `cli/auth/login.ts`, which asks what
- * the operator logged in with; this asks what the proxy gate can resolve. They
- * must never both be true for one credential, and this one is deliberately
- * fail-closed: a credential it cannot recognise is withheld, not sent. An
- * earlier revision of this check was loose enough to leak `a.b.c`, so the
- * invariant is held by a test — `does not send an API key to the protected
- * environment gate` fails the moment a key becomes presentable again.
+ * The gate reads `userId` from the verified JWT payload and has no API-key
+ * branch, so presenting an opaque key only leaks it. Reads what the gate
+ * reads, and withholds anything it cannot recognise.
  */
 function isSessionCredential(apiToken: string): boolean {
   const segments = apiToken.split(".");
@@ -890,16 +875,10 @@ function buildEnvironmentReadinessProbes(
   if (route === null) return [];
 
   // Without a session credential the probe cannot get past the gate. Its
-  // challenge — a sign-in redirect, 401, or 403 — still proves routing
-  // resolves and the proxy is serving this environment, which is the most this
-  // step can establish, and the deployment it would otherwise fail is already
-  // committed and verified.
-  //
-  // Accepting the whole challenge rather than only the redirect is the same
-  // allowance the protected custom-domain probe below already makes, not a new
-  // one. Narrowing it would buy nothing here either: the gate answers before
-  // the app does, so for a protected environment with no session this probe is
-  // blind to application health whichever challenge it accepts.
+  // challenge still proves routing resolves and the proxy is serving this
+  // environment — the most this step can establish, and the deployment it
+  // would otherwise fail is already committed and verified. Same allowance the
+  // protected custom-domain probe below already makes.
   const canAuthenticate = isSessionCredential(target.apiToken);
 
   const targetUrl = buildEnvironmentProbeUrl(target.url, route);
@@ -945,13 +924,7 @@ function isSignInRedirect(response: Response, requestUrl: string): boolean {
   }
 }
 
-/**
- * Describe why a probe was turned away at the gate.
- *
- * A challenge is a sign-in redirect, a 401, or a 403, so the message has to
- * name which one arrived. Reporting every challenge as "redirected to sign-in"
- * sent operators looking for a redirect that a 403 never performed.
- */
+/** A challenge is a sign-in redirect, a 401, or a 403; say which one arrived. */
 function describeAuthenticationChallenge(
   probe: EnvironmentReadinessProbe,
   status: number,
@@ -1023,9 +996,7 @@ export async function waitForEnvironmentReady(
 
         if (ready) break;
         if (authenticationChallenge) {
-          // These are diagnosed conditions, so they must carry the deployment
-          // slug. A bare Error reaches the operator as `unknown-error` with
-          // "Check logs for more details", which describes nothing.
+          // A bare Error here reaches the operator as `unknown-error`.
           throw DEPLOYMENT_ERROR.create({
             detail: describeAuthenticationChallenge(probe, response.status, signInRedirect),
             context: { url: probe.url, status: response.status },

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -829,19 +829,50 @@ function isMatchingVeryfrontHostedUrl(
     parsed.environment === target.environmentName.toLowerCase();
 }
 
+const MAX_JWT_SEGMENT_CODE_UNITS = 8 * 1024;
+
+/** Decode one base64url JWT segment into a plain object, or null if it is not one. */
+function decodeJwtSegment(segment: string | undefined): object | null {
+  if (segment === undefined) return null;
+  if (segment.length === 0 || segment.length > MAX_JWT_SEGMENT_CODE_UNITS) return null;
+  try {
+    const base64 = segment.replaceAll("-", "+").replaceAll("_", "/");
+    const binary = atob(base64 + "=".repeat((4 - base64.length % 4) % 4));
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    const parsed = JSON.parse(new TextDecoder().decode(bytes));
+    return typeof parsed === "object" && parsed !== null ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Whether a stored credential could satisfy the protected-environment gate.
  *
  * The gate resolves the `authToken` cookie by decoding it as a JWT and reading
  * `userId` from the verified payload; it has no API-key branch. An opaque
  * `vf_…` API key therefore fails the same way an absent cookie does, so
- * presenting one only leaks the key. This is a shape check, not verification —
- * the CLI cannot verify the signature and does not need to. It only needs to
- * know whether the gate could possibly accept the credential.
+ * presenting one only leaks the key.
+ *
+ * This mirrors what the gate reads rather than merely counting dots, so an
+ * opaque credential that happens to contain dots is withheld too. It is still
+ * a shape check, not verification — the CLI cannot verify the signature and
+ * does not need to. It only needs to know whether the gate could possibly
+ * accept the credential.
  */
 function isSessionCredential(apiToken: string): boolean {
   const segments = apiToken.split(".");
-  return segments.length === 3 && segments.every((segment) => segment.length > 0);
+  if (segments.length !== 3) return false;
+
+  const header = decodeJwtSegment(segments[0]);
+  if (header === null || typeof readUntrustedOwnDataProperty(header, "alg") !== "string") {
+    return false;
+  }
+
+  const payload = decodeJwtSegment(segments[1]);
+  if (payload === null) return false;
+  const userId = readUntrustedOwnDataProperty(payload, "userId");
+  return typeof userId === "string" && userId.length > 0;
 }
 
 function buildEnvironmentReadinessProbes(

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -859,6 +859,14 @@ function decodeJwtSegment(segment: string | undefined): object | null {
  * a shape check, not verification — the CLI cannot verify the signature and
  * does not need to. It only needs to know whether the gate could possibly
  * accept the credential.
+ *
+ * The counterpart is `isApiKeyToken` in `cli/auth/login.ts`, which asks what
+ * the operator logged in with; this asks what the proxy gate can resolve. They
+ * must never both be true for one credential, and this one is deliberately
+ * fail-closed: a credential it cannot recognise is withheld, not sent. An
+ * earlier revision of this check was loose enough to leak `a.b.c`, so the
+ * invariant is held by a test — `does not send an API key to the protected
+ * environment gate` fails the moment a key becomes presentable again.
  */
 function isSessionCredential(apiToken: string): boolean {
   const segments = apiToken.split(".");
@@ -881,10 +889,17 @@ function buildEnvironmentReadinessProbes(
   const route = target.route === undefined ? "/" : target.route;
   if (route === null) return [];
 
-  // Without a session credential the probe cannot get past the gate. A sign-in
-  // redirect still proves routing resolves and the proxy is serving this
-  // environment, which is the most this step can establish — and the
-  // deployment it would otherwise fail is already committed and verified.
+  // Without a session credential the probe cannot get past the gate. Its
+  // challenge — a sign-in redirect, 401, or 403 — still proves routing
+  // resolves and the proxy is serving this environment, which is the most this
+  // step can establish, and the deployment it would otherwise fail is already
+  // committed and verified.
+  //
+  // Accepting the whole challenge rather than only the redirect is the same
+  // allowance the protected custom-domain probe below already makes, not a new
+  // one. Narrowing it would buy nothing here either: the gate answers before
+  // the app does, so for a protected environment with no session this probe is
+  // blind to application health whichever challenge it accepts.
   const canAuthenticate = isSessionCredential(target.apiToken);
 
   const targetUrl = buildEnvironmentProbeUrl(target.url, route);
@@ -928,6 +943,27 @@ function isSignInRedirect(response: Response, requestUrl: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Describe why a probe was turned away at the gate.
+ *
+ * A challenge is a sign-in redirect, a 401, or a 403, so the message has to
+ * name which one arrived. Reporting every challenge as "redirected to sign-in"
+ * sent operators looking for a redirect that a 403 never performed.
+ */
+function describeAuthenticationChallenge(
+  probe: EnvironmentReadinessProbe,
+  status: number,
+  signInRedirect: boolean,
+): string {
+  if (probe.authenticate) {
+    return `Could not authenticate the protected environment URL ${probe.url}. Run veryfront login and deploy again.`;
+  }
+  if (signInRedirect) {
+    return `Environment URL ${probe.url} redirected to sign-in. Check its protection settings and deploy again.`;
+  }
+  return `Environment URL ${probe.url} returned HTTP ${status}. Check its protection settings and deploy again.`;
 }
 
 function isTransientEnvironmentStatus(status: number): boolean {
@@ -991,10 +1027,8 @@ export async function waitForEnvironmentReady(
           // slug. A bare Error reaches the operator as `unknown-error` with
           // "Check logs for more details", which describes nothing.
           throw DEPLOYMENT_ERROR.create({
-            detail: probe.authenticate
-              ? `Could not authenticate the protected environment URL ${probe.url}. Run veryfront login and deploy again.`
-              : `Environment URL ${probe.url} redirected to sign-in. Check its protection settings and deploy again.`,
-            context: { url: probe.url },
+            detail: describeAuthenticationChallenge(probe, response.status, signInRedirect),
+            context: { url: probe.url, status: response.status },
           });
         }
         if (!isTransientEnvironmentStatus(response.status)) {


### PR DESCRIPTION
## Problem

Deploying to a protected environment from an API-key-authenticated CLI always failed on the last step — reported as `unknown-error`, after the deployment had already been committed and verified.

```
$ npx veryfront@latest whoami
  ✓ Authenticated with an API key

$ npx veryfront@latest deploy
✗ [unknown-error] Unknown/unclassified error
  Detail: Could not authenticate the protected environment URL https://…production.veryfront.com/. Run veryfront login and deploy again.
  Suggestion: Check logs for more details
```

The suggested remedy is a dead end: `veryfront login` is what produced the API key.

## Root cause

The readiness probe sent the stored credential as an `authToken` cookie (`deploy-project.ts:908`). The gate reading that cookie resolves it by decoding a JWT and reading `userId` from the verified payload (`src/proxy/proxy-access-control.ts:104-166`) — RS256 or HS256 only, no API-key branch. An opaque `vf_…` key was rejected exactly like no credential at all.

Verified against production — all three return the same sign-in redirect:

```
302  # no auth
302  # Cookie: authToken=<api key>   ← what the CLI sent
302  # Authorization: Bearer <api key>
```

So the probe could never succeed, and sending the key leaked it for no benefit.

The probe is also the *last* step. `create-deployment` (line 1193) and `verify-deployment` (line 1203) both complete before it runs — the deploy had already landed when the CLI reported failure.

Separately, every throw in the readiness loop was a bare `Error`, so the boundary wrapped these fully-diagnosed conditions in the catch-all `unknown-error` slug with "Check logs for more details".

## Fix

**1. Don't present a credential the gate cannot accept.** `isSessionCredential` decodes the header and payload as base64url JSON and requires a string `userId` in the payload — the same value the gate reads before testing project membership. Anything else probes unauthenticated.

The check is deliberately fail-closed: a credential the CLI cannot positively recognise is withheld, never sent. Counting dot-separated segments would not have been enough, because an opaque `a.b.c` credential would still have been presented — and presenting it is the leak this check exists to prevent.

**2. Accept the gate's challenge as ready when there is no session.** A challenge — sign-in redirect, 401, or 403 — still proves routing resolves and the proxy is serving the environment, which is all this step can establish without a session. This reuses the existing `acceptAuthenticationChallenge` path already used for protected custom domains; no new semantics.

Accepting the whole challenge rather than only the redirect is the same allowance that path already makes. Narrowing it would buy nothing here either: the gate answers before the app does, so for a protected environment with no session this probe is blind to application health whichever challenge it accepts.

**3. Classify the errors.** The throws in the readiness loop now carry `DEPLOYMENT_ERROR` instead of a bare `Error`, so the slug, suggestion, and docs URL match the actual condition.

**4. Name the challenge that actually arrived.** Every challenge was reported as "redirected to sign-in", including a 401 or 403. A public environment answering 403 sent the operator looking for a redirect that never happened. The message now names the status when there was no redirect, and the error context carries it.

A JWT session that is genuinely rejected still fails the deploy, with the same message — that path is unchanged, and there "Run veryfront login" is correct advice.

## Verification

**End-to-end, against the reported failure** — same URL, same API key, calling the real `waitForEnvironmentReady`:

```
before:  RESULT: probe failed — Could not authenticate the protected environment URL …
after:   RESULT: probe passed — deploy would complete
```

Checked against real credentials: the session JWT is still sent, the API key is still withheld.

**Tests** — 6 added. Each was confirmed to fail on the unfixed code and pass with the fix:

- `does not send an API key to the protected environment gate`
- `does not send an opaque credential that merely contains dots`
- `does not send a JWT-shaped credential whose payload carries no userId`
- `treats a sign-in redirect as ready when the credential is an API key`
- `classifies a rejected session credential as a deployment error`
- `names the status when a challenge was not a sign-in redirect`

The first of these also holds the invariant against `isApiKeyToken` in `cli/auth/login.ts`: it goes red the moment an API key becomes presentable to the gate again.

The existing fixture token `test-token` was not JWT-shaped, so it would have silently taken the new unauthenticated path and stopped covering the authenticated one. It is now a JWT-shaped `sessionToken`, keeping those assertions meaningful.

`cli/shared/deployment/` — 12 files, 87 steps, all passing. `deno check`, `deno lint`, `deno fmt --check` clean.

## Scope

This does not make API keys work against protected environments — whether an API key *should* grant browser access to a protected environment is a product decision with real security implications, and belongs in the proxy, not the CLI. This PR stops a probe from failing a deploy that succeeded.

It also does not change the broader shape of the last step: a readiness failure still fails a deploy that has already been committed and verified. That is fixed here only for the case that could never have succeeded. Making readiness a warning rather than a failure affects every credential type and every failure mode, so it belongs in its own change.

Closes veryfront/veryfront-issue-inbox#444


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment environment readiness checks for session-based and API-key authentication.
  * Prevented API keys and invalid session credentials from being sent to protected environment gates.
  * Accepted sign-in redirects and authentication challenges as valid readiness responses for API-key probes.
  * Added clearer deployment errors for rejected credentials, HTTP status failures, unavailable environments, and timeouts.
  * Improved session credential validation so only authenticated sessions are used during deployment checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->