### PR TITLE
fix(runtime): keep dispatch alive when model context is not cloneable

### DIFF
--- a/docs/api-reference/veryfront/embedding.md
+++ b/docs/api-reference/veryfront/embedding.md
@@ -42,7 +42,7 @@ export const { POST, GET, DELETE } = createUploadHandler(store, {
 | `ragStore`                  | Creates a persistent RAG store with lazy embedding and similarity search.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/rag-store.ts#L212)      |
 | `registerEmbeddingProvider` | Register an embedding provider factory.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L25)         |
 | `resolveEmbeddingModel`     | Resolve a "provider/model" string to an embedding runtime instance.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L116)        |
-| `similarity`                | Compute cosine similarity between two numeric vectors.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runtime/runtime-bridge.ts#L975)   |
+| `similarity`                | Compute cosine similarity between two numeric vectors.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runtime/runtime-bridge.ts#L987)   |
 | `vectorStore`               | Creates an in-memory vector store with integrated embedding and similarity search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/vector-store.ts#L46)    |
 
 ### Types

--- a/src/runtime/runtime-bridge.test.ts
+++ b/src/runtime/runtime-bridge.test.ts
@@ -1,6 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { VeryfrontError } from "#veryfront/errors";
-import { assertEquals, assertInstanceOf, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { type AgentRunEvent, runWithRunEventSink } from "../agent/index.ts";
 import { runWithMandatoryRunEventSink } from "./run-event-sink-context.ts";
@@ -12,7 +11,7 @@ import {
 } from "./runtime-bridge.test-helpers.ts";
 
 describe("runtime-bridge", () => {
-  it("rejects non-cloneable model context with a stable registered error", async () => {
+  it("skips non-cloneable model context without failing model dispatch", async () => {
     const sensitiveValue = "CUSTOMER_SECRET_123";
     for (
       const testCase of [
@@ -47,41 +46,26 @@ describe("runtime-bridge", () => {
       const model = createGenerateModel("test", `test/${testCase.name}`, async () => {
         dispatches += 1;
         return {
-          content: [{ type: "text", text: "must not dispatch" }],
+          content: [{ type: "text", text: "dispatched" }],
           finishReason: "stop",
           usage: {},
         };
       });
 
-      const error = await assertRejects(async () =>
-        await runWithRunEventSink(
-          () => {
-            sinkCalls += 1;
-          },
-          () =>
-            generateText({
-              model,
-              messages: testCase.messages,
-              tools: testCase.tools as never,
-            }),
-        )
+      const result = await runWithRunEventSink(
+        () => {
+          sinkCalls += 1;
+        },
+        () =>
+          generateText({
+            model,
+            messages: testCase.messages,
+            tools: testCase.tools as never,
+          }),
       );
-
-      assertInstanceOf(error, VeryfrontError);
-      assertEquals(error.slug, "durable-run-event-persistence-failed");
-      assertEquals(
-        error.message,
-        "Model call context contains data that cannot be persisted safely",
-      );
-      assertEquals(error.cause, undefined);
-      assertEquals(
-        JSON.stringify(error, Object.getOwnPropertyNames(error)).includes(
-          sensitiveValue,
-        ),
-        false,
-      );
+      assertEquals(result.text, "dispatched");
       assertEquals(sinkCalls, 0);
-      assertEquals(dispatches, 0);
+      assertEquals(dispatches, 1);
     }
   });
 

--- a/src/runtime/runtime-bridge.test.ts
+++ b/src/runtime/runtime-bridge.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { metricsManager } from "#veryfront/observability/metrics/index.ts";
 import { type AgentRunEvent, runWithRunEventSink } from "../agent/index.ts";
 import { runWithMandatoryRunEventSink } from "./run-event-sink-context.ts";
 import { generateText, streamText } from "./runtime-bridge.ts";
@@ -393,6 +394,78 @@ describe("runtime-bridge", () => {
     );
 
     assertEquals(order, ["mandatory", "public", "dispatch"]);
+  });
+
+  it("delivers a successful sink clone and sanitizes another clone failure", async () => {
+    const sensitiveFailureClass = "CUSTOMER_SECRET_FAILURE_CLASS";
+    const cloneError = new Error("clone failed");
+    cloneError.name = sensitiveFailureClass;
+    let cloneReads = 0;
+    const statefulInput = {};
+    Object.defineProperty(statefulInput, "value", {
+      enumerable: true,
+      get() {
+        cloneReads += 1;
+        if (cloneReads === 1) throw cloneError;
+        return "safe";
+      },
+    });
+
+    const recorder = metricsManager.getRecorder();
+    const originalRecordError = recorder?.recordError;
+    const failureClasses: string[] = [];
+    if (recorder) {
+      recorder.recordError = (attributes) => {
+        if (
+          attributes?.slug === "model-call-context-clone-failed" &&
+          typeof attributes.failure_class === "string"
+        ) {
+          failureClasses.push(attributes.failure_class);
+        }
+      };
+    }
+
+    let mandatoryCalls = 0;
+    let publicEvent: AgentRunEvent | undefined;
+    let dispatches = 0;
+    const model = createGenerateModel("test", "test/partial-clone", async () => {
+      dispatches += 1;
+      return { content: [], finishReason: "stop", usage: {} };
+    });
+
+    try {
+      await runWithMandatoryRunEventSink(
+        () => {
+          mandatoryCalls += 1;
+        },
+        () =>
+          runWithRunEventSink(
+            (event) => {
+              publicEvent = event;
+            },
+            () =>
+              generateText({
+                model,
+                messages: [{
+                  role: "assistant",
+                  content: [{
+                    type: "tool-call",
+                    toolCallId: "call-1",
+                    toolName: "stateful",
+                    input: statefulInput,
+                  }],
+                }, { role: "user", content: "Continue" }],
+              }),
+          ),
+      );
+    } finally {
+      if (recorder && originalRecordError) recorder.recordError = originalRecordError;
+    }
+
+    assertEquals(mandatoryCalls, 0);
+    assertEquals(publicEvent?.type, "AGENT_RUN_MODEL_CALL_CONTEXT");
+    assertEquals(dispatches, 1);
+    assertEquals(failureClasses, ["unknown"]);
   });
 
   it("calls a sink shared by both lanes only once", async () => {

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -6,7 +6,8 @@
  * types and calls into this bridge at the edge.
  */
 import type { TextGenerationRuntimeMessage } from "#veryfront/agent/runtime/text-generation-runtime-message-types.ts";
-import { DURABLE_RUN_EVENT_PERSISTENCE_FAILED } from "#veryfront/errors";
+import { recordErrorCount } from "#veryfront/observability/metrics/index.ts";
+import { serverLogger } from "#veryfront/utils";
 import type {
   RuntimeGenerateTextResult,
   RuntimeStreamPart,
@@ -28,6 +29,7 @@ import type {
 import { getActiveRunEventSinks } from "./run-event-sink-context.ts";
 
 const cloneStructuredValue = globalThis.structuredClone;
+const logger = serverLogger.component("runtime-bridge");
 
 type GenerateTextOptions = {
   model: ModelRuntime;
@@ -493,20 +495,29 @@ async function emitModelCallContextEvent(directOptions: DirectModelOptions): Pro
     ...(directOptions.tools ? { tools: directOptions.tools } : {}),
   };
 
-  const cloneEvent = (): AgentRunModelCallContextEvent => {
+  const cloneEvent = (): AgentRunModelCallContextEvent | null => {
     try {
       return cloneStructuredValue(event);
-    } catch {
-      throw DURABLE_RUN_EVENT_PERSISTENCE_FAILED.create({
-        detail: "Model call context contains data that cannot be persisted safely",
+    } catch (error) {
+      const failureClass = error instanceof Error ? error.name : typeof error;
+      recordErrorCount({
+        slug: "model-call-context-clone-failed",
+        failure_class: failureClass,
       });
+      logger.warn("Model call context event was not persisted because it is not cloneable", {
+        failureClass,
+      });
+      return null;
     }
   };
-  if (sinks.mandatory) {
-    await sinks.mandatory(cloneEvent());
+  const mandatoryEvent = sinks.mandatory ? cloneEvent() : undefined;
+  const publicEvent = sinks.public && sinks.public !== sinks.mandatory ? cloneEvent() : undefined;
+  if (mandatoryEvent === null || publicEvent === null) return;
+  if (sinks.mandatory && mandatoryEvent) {
+    await sinks.mandatory(mandatoryEvent);
   }
-  if (sinks.public && sinks.public !== sinks.mandatory) {
-    await sinks.public(cloneEvent());
+  if (sinks.public && sinks.public !== sinks.mandatory && publicEvent) {
+    await sinks.public(publicEvent);
   }
 }
 

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -499,7 +499,9 @@ async function emitModelCallContextEvent(directOptions: DirectModelOptions): Pro
     try {
       return cloneStructuredValue(event);
     } catch (error) {
-      const failureClass = error instanceof Error ? error.name : typeof error;
+      const failureClass = error instanceof DOMException && error.name === "DataCloneError"
+        ? "DataCloneError"
+        : "unknown";
       recordErrorCount({
         slug: "model-call-context-clone-failed",
         failure_class: failureClass,
@@ -512,7 +514,6 @@ async function emitModelCallContextEvent(directOptions: DirectModelOptions): Pro
   };
   const mandatoryEvent = sinks.mandatory ? cloneEvent() : undefined;
   const publicEvent = sinks.public && sinks.public !== sinks.mandatory ? cloneEvent() : undefined;
-  if (mandatoryEvent === null || publicEvent === null) return;
   if (sinks.mandatory && mandatoryEvent) {
     await sinks.mandatory(mandatoryEvent);
   }


### PR DESCRIPTION
Closes veryfront/veryfront-issue-inbox#375.\n\n## Summary\n\n- drop a model-call context event when its payload cannot be structured-cloned\n- count and log the sanitized failure class without including tool output\n- continue model dispatch while preserving fail-closed behavior for actual sink failures\n\n## Verification\n\n- \n- \n- \n- running 1 test from ./src/runtime/runtime-bridge.test.ts
runtime-bridge ...
  skips non-cloneable model context without failing model dispatch ...
------- output -------
12:17:28  SERVER     ▲ [runtime-bridge] Model call context event was not persisted because it is not cloneable
                       failureClass=DataCloneError
12:17:28  SERVER     ▲ [runtime-bridge] Model call context event was not persisted because it is not cloneable
                       failureClass=DataCloneError
----- output end -----
  skips non-cloneable model context without failing model dispatch ... ok (1ms)
  emits one exact run event with normalized messages and resolved tools before direct generate ... ok (0ms)
  records exactly one ordered context for each evolving skill-backed dispatch ... ok (0ms)
  emits before stream-backed generate and direct stream dispatch ... ok (1ms)
  propagates sink failures without dispatching ... ok (0ms)
  awaits the mandatory sink before the public sink and provider dispatch ... ok (0ms)
  calls a sink shared by both lanes only once ... ok (0ms)
  fails closed in either sink lane ... ok (1ms)
  isolates nested sink mutations from generate and stream provider inputs ... ok (0ms)
  uses the direct generate path for models without tools ... ok (0ms)
  forwards reasoning options to direct generate models ... ok (0ms)
  buffers the stream path for models that prefer streamed generate ... ok (0ms)
  buffers streamed tool calls for models that prefer streamed generate ... ok (1ms)
  uses the direct stream path for models without tools ... ok (0ms)
  rejects a second stream view started after direct consumption ... ok (0ms)
  cancels a sole stream consumer without waiting for an unused branch ... ok (0ms)
  handles an abandoned stream request rejection ... ok (0ms)
  forwards reasoning options to direct stream models ... ok (0ms)
  uses the direct generate path for ordinary function tools ... ok (0ms)
  uses the direct stream path for ordinary function tools ... ok (0ms)
  uses the direct stream path for provider-native tools ... ok (0ms)
  uses the direct generate path for provider-native tools ... ok (0ms)
  keeps providerExecuted on direct generate provider tool results ... ok (0ms)
  uses the direct stream path for provider-native web_fetch ... ok (1ms)
  uses the direct generate path for provider-native web_fetch ... ok (0ms)
  drops trailing assistant prefill messages before direct stream requests ... ok (0ms)
  drops trailing assistant prefill messages before direct generate requests ... ok (0ms)
runtime-bridge ... ok (7ms)

ok | 1 passed (27 steps) | 0 failed (10ms)\n- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime dispatch now succeeds when model context contains data that cannot be cloned.
  * Uncloneable context is skipped for event delivery instead of causing the model call to fail.
  * Successfully cloneable events continue to be delivered independently.
  * Improved logging and metrics capture when event data cannot be cloned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->