### PR TITLE
fix(proxy): keep config workers out of binary graph

### DIFF
--- a/scripts/build/compile-binary.test.ts
+++ b/scripts/build/compile-binary.test.ts
@@ -1,5 +1,5 @@
 import { walk } from "#std/fs/walk";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { it } from "#veryfront/testing/bdd.ts";
 import { FIRST_PARTY_DEFERRED_BUILTIN_EXTENSION_POLICIES } from "#veryfront/extensions/first-party-defaults.ts";
 import {
@@ -7,6 +7,79 @@ import {
   DEFAULT_INCLUDES,
   PROXY_INCLUDES,
 } from "./compile-binary.ts";
+
+interface DenoInfoDependency {
+  code?: { specifier: string };
+  type?: { specifier: string };
+}
+
+interface DenoInfoModule {
+  dependencies?: DenoInfoDependency[] | null;
+  specifier: string;
+}
+
+interface DenoInfoGraph {
+  roots: string[];
+  modules: DenoInfoModule[];
+}
+
+function isResolvedDependency(value: unknown): value is DenoInfoDependency {
+  if (!value || typeof value !== "object") return false;
+  const dependency = value as Record<string, unknown>;
+  if (
+    typeof dependency.specifier !== "string" ||
+    dependency.specifier.length === 0
+  ) {
+    return false;
+  }
+
+  const targets = [dependency.code, dependency.type].filter((target) =>
+    target != null
+  );
+  return targets.length > 0 &&
+    targets.every((target) =>
+      typeof target === "object" &&
+      target !== null &&
+      typeof (target as Record<string, unknown>).specifier === "string" &&
+      ((target as Record<string, unknown>).specifier as string).length > 0
+    );
+}
+
+function parseDenoInfoGraph(value: unknown): DenoInfoGraph {
+  if (!value || typeof value !== "object") {
+    throw new TypeError("Invalid deno info graph");
+  }
+  const graph = value as Record<string, unknown>;
+  if (
+    !Array.isArray(graph.roots) ||
+    graph.roots.length === 0 ||
+    !graph.roots.every((root) => typeof root === "string" && root.length > 0) ||
+    !Array.isArray(graph.modules) ||
+    graph.modules.length === 0
+  ) {
+    throw new TypeError("Invalid deno info graph");
+  }
+
+  for (const module of graph.modules) {
+    if (!module || typeof module !== "object") {
+      throw new TypeError("Invalid deno info module");
+    }
+    const record = module as Record<string, unknown>;
+    if (typeof record.specifier !== "string" || record.specifier.length === 0) {
+      throw new TypeError("Invalid deno info module specifier");
+    }
+    if (
+      record.dependencies !== undefined &&
+      record.dependencies !== null &&
+      (!Array.isArray(record.dependencies) ||
+        !record.dependencies.every(isResolvedDependency))
+    ) {
+      throw new TypeError("Invalid deno info dependency");
+    }
+  }
+
+  return graph as unknown as DenoInfoGraph;
+}
 
 it("compiled CLI embeds the default Node WebSocket extension for HMR", () => {
   const args = createCompileArgs({
@@ -197,17 +270,18 @@ it("proxy binary cannot reach declarative config worker modules", async () => {
     new TextDecoder().decode(output.stderr),
   );
 
-  const info = JSON.parse(new TextDecoder().decode(output.stdout)) as {
-    roots?: string[];
-    modules?: Array<{
-      dependencies?: Array<{ code?: { specifier?: string } }>;
-      specifier?: string;
-    }>;
-  };
-  const modules = new Map(
-    (info.modules ?? []).map((module) => [module.specifier ?? "", module]),
+  const info = parseDenoInfoGraph(
+    JSON.parse(new TextDecoder().decode(output.stdout)),
   );
-  const reachable = new Set(info.roots ?? []);
+  const modules = new Map(
+    info.modules.map((module) => [module.specifier, module]),
+  );
+  for (const root of info.roots) {
+    if (!modules.has(root)) {
+      throw new TypeError("Deno info root is missing from the module graph");
+    }
+  }
+  const reachable = new Set(info.roots);
   const pending = [...reachable];
   while (pending.length > 0) {
     const specifier = pending.shift()!;
@@ -226,6 +300,22 @@ it("proxy binary cannot reach declarative config worker modules", async () => {
     [],
     "the proxy must not reach project config evaluation; it only forwards requests to the production server",
   );
+});
+
+it("proxy graph validation rejects incomplete metadata", () => {
+  for (
+    const graph of [
+      {},
+      { roots: [], modules: [] },
+      { roots: ["proxy"], modules: [{}] },
+      {
+        roots: ["proxy"],
+        modules: [{ specifier: "proxy", dependencies: [{}] }],
+      },
+    ]
+  ) {
+    assertThrows(() => parseDenoInfoGraph(graph), TypeError);
+  }
 });
 
 it("proxy release verifies lock freshness and publishes an exact SBOM", async () => {

--- a/scripts/build/compile-binary.test.ts
+++ b/scripts/build/compile-binary.test.ts
@@ -184,6 +184,50 @@ it("proxy binary embeds only the runtime-resolved proxy entrypoint", async () =>
   }
 });
 
+it("proxy binary cannot reach declarative config worker modules", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["info", "--json", "cli/proxy-main.ts"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  assertEquals(
+    output.success,
+    true,
+    new TextDecoder().decode(output.stderr),
+  );
+
+  const info = JSON.parse(new TextDecoder().decode(output.stdout)) as {
+    roots?: string[];
+    modules?: Array<{
+      dependencies?: Array<{ code?: { specifier?: string } }>;
+      specifier?: string;
+    }>;
+  };
+  const modules = new Map(
+    (info.modules ?? []).map((module) => [module.specifier ?? "", module]),
+  );
+  const reachable = new Set(info.roots ?? []);
+  const pending = [...reachable];
+  while (pending.length > 0) {
+    const specifier = pending.shift()!;
+    for (const dependency of modules.get(specifier)?.dependencies ?? []) {
+      const dependencySpecifier = dependency.code?.specifier;
+      if (!dependencySpecifier || reachable.has(dependencySpecifier)) continue;
+      reachable.add(dependencySpecifier);
+      pending.push(dependencySpecifier);
+    }
+  }
+  const evaluatorWorkerModules = [...reachable]
+    .filter((specifier) => specifier.includes("declarative-evaluator-worker"));
+
+  assertEquals(
+    evaluatorWorkerModules,
+    [],
+    "the proxy must not reach project config evaluation; it only forwards requests to the production server",
+  );
+});
+
 it("proxy release verifies lock freshness and publishes an exact SBOM", async () => {
   const workflow = await Deno.readTextFile(".github/workflows/cicd.yml");
   const denoConfig = JSON.parse(await Deno.readTextFile("deno.json")) as {

--- a/scripts/build/compile-binary.ts
+++ b/scripts/build/compile-binary.ts
@@ -69,19 +69,12 @@ export const DEFAULT_INCLUDES = [
 ];
 
 export const PROXY_INCLUDES = [
-  // Deliberately omits UNTRACEABLE_WORKER_INCLUDES, on build grounds only.
-  // Adding them fails the compile outright: the worker entry's graph wants
-  // @babel/types@7.29.8 plus @babel/helper-string-parser and
-  // @babel/helper-validator-identifier, while proxy-deno.lock pins
-  // @babel/types@7.29.0, and --frozen refuses to update the lock.
-  //
-  // This is NOT evidence that the proxy is safe. The lock already carries a
-  // babel parse toolchain (parser, generator, traverse, types), so "the deps
-  // are absent, therefore the worker never runs here" does not follow --
-  // the conflict is a version skew, not an absence. `cli/proxy-main.ts` does
-  // pull the evaluator's runner into its graph, so whether the proxy can reach
-  // a spawn at runtime is an open question, tracked in veryfront-issue-inbox#382.
-  // If it can, this list and the proxy lock have to be regenerated together.
+  // Deliberately omits UNTRACEABLE_WORKER_INCLUDES. The standalone proxy
+  // forwards project requests to the production server and never evaluates
+  // project config. Its entry graph must therefore remain unable to reach the
+  // declarative evaluator worker. compile-binary.test.ts enforces that runtime
+  // boundary. If project config evaluation is added to the proxy, embed every
+  // reachable worker here and regenerate the proxy lock in the same change.
   //
   // The proxy runtime is loaded after provider activation. Providers are
   // statically referenced by cli/proxy-main.ts so --include does not embed the

--- a/src/proxy/control-plane-signature.ts
+++ b/src/proxy/control-plane-signature.ts
@@ -32,7 +32,10 @@ import {
   verifyControlPlaneJwsSignature,
   verifyDispatchJwsSignature,
 } from "#veryfront/channels/control-plane.ts";
-import { isRequestBodyTooLargeError, readBodyWithLimit } from "#veryfront/security/index.ts";
+import {
+  isRequestBodyTooLargeError,
+  readBodyWithLimit,
+} from "#veryfront/security/input-validation/limits.ts";
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 import { isWellFormedString } from "#veryfront/utils/is-well-formed-string.ts";
 import { isCanonicalOpaqueProjectIdentifier } from "#veryfront/utils/project-identity.ts";


### PR DESCRIPTION
## Summary

- narrow the proxy control-plane body reader import so the security barrel cannot pull project config evaluation into the runtime graph
- document the runtime boundary that lets the proxy profile omit worker entrypoints
- add a graph-level regression test that follows executable dependencies from the proxy entrypoint

Closes veryfront/veryfront-issue-inbox#382

## Verification

- `deno fmt --check scripts/build/compile-binary.ts scripts/build/compile-binary.test.ts src/proxy/control-plane-signature.ts`
- `deno lint --config=scripts/test.deno.json scripts/build/compile-binary.ts scripts/build/compile-binary.test.ts`
- `deno lint src/proxy/control-plane-signature.ts`
- `deno check --config=scripts/test.deno.json scripts/build/compile-binary.test.ts`
- `deno check src/proxy/control-plane-signature.ts`
- `deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/build/compile-binary.test.ts`
- `deno test --preload=src/testing/preload.ts --no-check --allow-all src/proxy/control-plane-signature.test.ts src/proxy/control-plane-signature.api-contract.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened proxy runtime boundaries to prevent unintended access to configuration evaluation components.
  * Improved request body-size validation by using dedicated security limits.
* **Tests**
  * Added coverage verifying that the proxy does not load declarative evaluator workers through its dependency graph.
* **Documentation**
  * Clarified proxy runtime isolation and requirements for future behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->