### PR TITLE
fix(config): keep hosted config filenames exact

### DIFF
--- a/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
@@ -101,6 +101,11 @@ export function splitKnownFileExtension(
   };
 }
 
+/** Config discovery depends on each candidate name matching the source that is returned. */
+export function requiresExactPublishedPath(apiPath: string): boolean {
+  return /(?:^|\/)veryfront\.config\.(?:js|ts|mjs)$/.test(apiPath);
+}
+
 export function isNotFoundLikeError(error: unknown): boolean {
   if (typeof error === "object" && error !== null) {
     const status = Object.getOwnPropertyDescriptor(error, "status");

--- a/src/platform/adapters/fs/veryfront/read-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.test.ts
@@ -760,7 +760,9 @@ describe("ReadOperations", () => {
         getPublishedFileContent: (path: string) => {
           publishedFetchPaths.push(path);
           if (path === "veryfront.config.ts") return Promise.resolve("typescript config");
-          return Promise.reject(new Error("404 Not Found"));
+          return Promise.reject(
+            API_CLIENT_ERROR.create({ detail: "not found", status: 404 }),
+          );
         },
         resolveFileWithExtension: () => {
           resolveCallCount++;
@@ -777,11 +779,11 @@ describe("ReadOperations", () => {
         createReleaseContext("release-config"),
       );
 
-      await assertRejects(
+      const error = await assertRejects(
         () => readOps.readTextFile("veryfront.config.js"),
         Error,
-        "404 Not Found",
       );
+      assertEquals((error as Error & { code?: string }).code, "ENOENT");
       assertEquals(publishedFetchPaths, ["veryfront.config.js"]);
       assertEquals(resolveCallCount, 0);
     });

--- a/src/platform/adapters/fs/veryfront/read-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.test.ts
@@ -250,6 +250,30 @@ describe("ReadOperations", () => {
         ["pages/home.tsx", true],
       ]);
     });
+
+    it("does not substitute another extension for a published config candidate", async () => {
+      const exactCalls: string[] = [];
+      const readOps = createReadyReadOps(
+        createMockClient({
+          getPublishedFileContentBytesWithinLimit: (path: string) => {
+            exactCalls.push(path);
+            if (path === "veryfront.config.ts") {
+              return Promise.resolve(new Uint8Array([7]));
+            }
+            return Promise.reject(API_CLIENT_ERROR.create({ detail: "not found", status: 404 }));
+          },
+        }),
+        false,
+        createReleaseContext("release-config"),
+      );
+
+      await assertRejects(
+        () => readOps.readFileBytesWithinLimit("veryfront.config.js", 1),
+        Error,
+        "404 Not Found: veryfront.config.js",
+      );
+      assertEquals(exactCalls, ["veryfront.config.js"]);
+    });
   });
 
   describe("readTextFile", () => {
@@ -727,6 +751,39 @@ describe("ReadOperations", () => {
       assertEquals(resolveBasePath, "pages/landing");
       assertEquals(resolveExtensions, [".tsx", ".ts", ".jsx", ".js", ".mdx", ".md"]);
       assertEquals(publishedFetchPaths, ["pages/landing.tsx"]);
+    });
+
+    it("does not substitute another extension for a published config candidate", async () => {
+      const publishedFetchPaths: string[] = [];
+      let resolveCallCount = 0;
+      const client = createMockClient({
+        getPublishedFileContent: (path: string) => {
+          publishedFetchPaths.push(path);
+          if (path === "veryfront.config.ts") return Promise.resolve("typescript config");
+          return Promise.reject(new Error("404 Not Found"));
+        },
+        resolveFileWithExtension: () => {
+          resolveCallCount++;
+          return Promise.resolve({
+            path: "veryfront.config.ts",
+            content: "typescript config",
+          });
+        },
+      });
+
+      const readOps = createReadyReadOps(
+        client,
+        false,
+        createReleaseContext("release-config"),
+      );
+
+      await assertRejects(
+        () => readOps.readTextFile("veryfront.config.js"),
+        Error,
+        "404 Not Found",
+      );
+      assertEquals(publishedFetchPaths, ["veryfront.config.js"]);
+      assertEquals(resolveCallCount, 0);
     });
 
     it("should fall back in parallel when pattern search fails for published 404", async () => {

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -737,7 +737,9 @@ export class ReadOperations {
         throw error;
       }
 
-      if (requiresExactPublishedPath(apiPath)) throw error;
+      if (requiresExactPublishedPath(apiPath)) {
+        throw createNotFoundLikeError(normalizedPath);
+      }
 
       const fallbackContent = await this.tryFallbackExtensions(
         apiPath,

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -17,6 +17,7 @@ import {
   getResolvedCacheKey,
   isNotFoundLikeError,
   READ_OPERATION_EXTENSION_PRIORITY as EXTENSION_PRIORITY,
+  requiresExactPublishedPath,
   splitKnownFileExtension,
 } from "./read-operations-helpers.ts";
 import type { ResolvedContentContext } from "./types.ts";
@@ -119,6 +120,7 @@ export class ReadOperations {
             return await this.readExactApiPath(apiPath, admittedLimit, isPublished, context);
           } catch (error) {
             if (!isPublished || !isNotFoundLikeError(error)) throw error;
+            if (requiresExactPublishedPath(apiPath)) throw error;
             const split = splitKnownFileExtension(apiPath);
             if (!split) throw error;
             for (const extension of EXTENSION_PRIORITY) {
@@ -734,6 +736,8 @@ export class ReadOperations {
         });
         throw error;
       }
+
+      if (requiresExactPublishedPath(apiPath)) throw error;
 
       const fallbackContent = await this.tryFallbackExtensions(
         apiPath,


### PR DESCRIPTION
## Summary

- require exact published reads for `veryfront.config.js`, `veryfront.config.ts`, and `veryfront.config.mjs`
- preserve published extension fallback for ordinary source modules
- cover both text and bounded-byte filesystem reads

## Verification

- `deno test --no-check --allow-all src/platform/adapters/fs/veryfront/read-operations.test.ts`
- `deno test --no-check --allow-all --unstable-worker-options src/config/loader.test.ts`
- `deno task verify:quick`
- `git diff --check`

Fixes veryfront/veryfront-issue-inbox#383