### PR TITLE
fix(agent): preserve resumed text segments

### DIFF
--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -404,7 +404,7 @@ describe("chat-stream-handler", () => {
           output: { submitted: false },
           providerExecuted: true,
         },
-        { type: "text-delta", text: " After tool." },
+        { type: "text-delta", text: "I've opened the panel." },
         { type: "finish", finishReason: "stop", totalUsage: null },
       ]);
 
@@ -428,9 +428,9 @@ describe("chat-stream-handler", () => {
           output: { submitted: false },
           providerExecuted: true,
         },
-        { type: "text-start", id: "text-1" },
-        { type: "text-delta", id: "text-1", delta: " After tool." },
-        { type: "text-end", id: "text-1" },
+        { type: "text-start", id: "text-1:1" },
+        { type: "text-delta", id: "text-1:1", delta: "I've opened the panel." },
+        { type: "text-end", id: "text-1:1" },
       ]);
     });
 
@@ -2023,6 +2023,39 @@ describe("processStream active mode", () => {
       { type: "text-delta", text: "answer" },
       { type: "finish", finishReason: "stop", totalUsage: null },
     ]);
+  });
+
+  it("matches legacy SSE and preserves resumed text after a tool interruption", async () => {
+    const { active } = await assertModeParity([
+      { type: "text-delta", text: "Before tool." },
+      { type: "tool-input-start", id: "native-1", toolName: "web_search" },
+      {
+        type: "tool-input-available",
+        toolCallId: "native-1",
+        toolName: "web_search",
+        input: { query: "x" },
+      },
+      {
+        type: "tool-result",
+        toolCallId: "native-1",
+        toolName: "web_search",
+        result: { answer: 42 },
+      },
+      { type: "text-delta", text: "I've opened the panel." },
+      { type: "finish", finishReason: "stop", totalUsage: null },
+    ]);
+
+    assertEquals(
+      active.events.filter((event) => event.type.startsWith("text-")),
+      [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "Before tool." },
+        { type: "text-end", id: "text-1" },
+        { type: "text-start", id: "text-1:1" },
+        { type: "text-delta", id: "text-1:1", delta: "I've opened the panel." },
+        { type: "text-end", id: "text-1:1" },
+      ],
+    );
   });
 
   it("matches legacy SSE and state for a committed local tool call", async () => {

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -2046,7 +2046,9 @@ describe("processStream active mode", () => {
     ]);
 
     assertEquals(
-      active.events.filter((event) => event.type.startsWith("text-")),
+      active.events.filter((event) =>
+        typeof event.type === "string" && event.type.startsWith("text-")
+      ),
       [
         { type: "text-start", id: "text-1" },
         { type: "text-delta", id: "text-1", delta: "Before tool." },

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -561,6 +561,8 @@ export function processStreamInternal(
       : null;
     let shadowLifecycleFailed = false;
     let textOpen = false;
+    let activeTextPartId: string | undefined;
+    let nextTextSegmentIndex = 0;
     let activeReasoningId: string | null = null;
     const reasoningParts = new Map<string, StreamingReasoningPart>();
     let shouldStopForCommittedLocalToolCall = false;
@@ -670,9 +672,13 @@ export function processStreamInternal(
       }
 
       textOpen = true;
+      activeTextPartId = textPartId === undefined || nextTextSegmentIndex === 0
+        ? textPartId
+        : `${textPartId}:${nextTextSegmentIndex}`;
+      nextTextSegmentIndex += 1;
       sendSSE(controller, encoder, {
         type: "text-start",
-        id: textPartId,
+        id: activeTextPartId,
       });
     };
 
@@ -684,8 +690,9 @@ export function processStreamInternal(
       textOpen = false;
       sendSSE(controller, encoder, {
         type: "text-end",
-        id: textPartId,
+        id: activeTextPartId,
       });
+      activeTextPartId = undefined;
     };
 
     const openReasoningSegment = (reasoningId: string) => {
@@ -956,7 +963,7 @@ export function processStreamInternal(
             state.accumulatedText += typedPart.text;
             sendSSE(controller, encoder, {
               type: "text-delta",
-              id: textPartId,
+              id: activeTextPartId,
               delta: typedPart.text,
             });
             callbacks?.onChunk?.(typedPart.text);

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1826,7 +1826,10 @@ export class AgentRuntime {
       );
 
       const state = createStreamState();
-      await processStream(streamSource, state, controller, encoder, textPartId, {
+      const stepTextPartId = textPartId === undefined || step === 0
+        ? textPartId
+        : `${textPartId}:step:${step}`;
+      await processStream(streamSource, state, controller, encoder, stepTextPartId, {
         onChunk: callbacks?.onChunk,
         onUsage: (usage) => accumulateUsage(totalUsage, usage),
         providerExecutedToolNames: getProviderExecutedToolNames(runtimeTools),

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -1563,9 +1563,10 @@ describe("agent runtime refresh hooks", () => {
       context: { projectId: "project-stream" },
     })).toDataStreamResponse();
 
-    await response.text();
+    const body = await response.text();
 
     assertEquals(toolResults.length, 1);
+    assertEquals(/"type":"text-start","id":"[^"]+:step:1"/.test(body), true);
     assertEquals(toolResults[0]?.toolName, "write_report");
     assertEquals(toolResults[0]?.toolCallId, "write-stream-1");
     assertEquals(toolResults[0]?.input, { path: "research/stream-report.md" });

--- a/src/agent/streaming/lifecycle/live-adapter.ts
+++ b/src/agent/streaming/lifecycle/live-adapter.ts
@@ -22,6 +22,17 @@ export function createStreamLifecycleLiveAdapter(
   input: { textPartId?: string },
 ) {
   const tools = new Map<string, LiveAdapterToolState>();
+  let activeTextPartId: string | undefined;
+  let nextTextSegmentIndex = 0;
+  const openTextPartId = (eventId: string | undefined): string => {
+    activeTextPartId = input.textPartId === undefined
+      ? eventId ?? "text"
+      : nextTextSegmentIndex === 0
+      ? input.textPartId
+      : `${input.textPartId}:${nextTextSegmentIndex}`;
+    nextTextSegmentIndex += 1;
+    return activeTextPartId;
+  };
   return {
     encode(frame: StreamLifecycleFrame): ChatStreamEvent[] {
       if (frame.class === "diagnostic") return [];
@@ -41,19 +52,22 @@ export function createStreamLifecycleLiveAdapter(
         case "text_start":
           return [{
             type: "text-start",
-            id: input.textPartId ?? event.id ?? "text",
+            id: openTextPartId(event.id),
           }];
         case "text_content":
           return [{
             type: "text-delta",
-            id: input.textPartId ?? event.id ?? "text",
+            id: activeTextPartId ?? openTextPartId(event.id),
             delta: event.delta,
           }];
-        case "text_end":
+        case "text_end": {
+          const id = activeTextPartId ?? input.textPartId ?? event.id ?? "text";
+          activeTextPartId = undefined;
           return [{
             type: "text-end",
-            id: input.textPartId ?? event.id ?? "text",
+            id,
           }];
+        }
         case "reasoning_start":
           return [{ type: "reasoning-start", id: event.id }];
         case "reasoning_content":


### PR DESCRIPTION
## Summary

- assign a fresh content ID when assistant text resumes after tool activity
- keep active and legacy lifecycle adapters aligned
- namespace text IDs across later model steps
- add production-shaped regression coverage for the missing first character

## Verification

- deno test --no-check --allow-all src/agent/runtime/chat-stream-handler.test.ts src/agent/streaming/lifecycle/live-adapter.test.ts src/agent/runtime/refresh.test.ts
- deno fmt --check src/agent/runtime/chat-stream-handler.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/index.ts src/agent/runtime/refresh.test.ts src/agent/streaming/lifecycle/live-adapter.ts
- deno task verify:quick
- deno task test:unit
- deno task audit

Closes veryfront/veryfront-issue-inbox#337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed assistant responses after tool activity, preserving resumed text in distinct segments.
  * Prevented text segments from reusing identifiers across agent steps or interruptions.
  * Ensured text-start, text-delta, and text-end events consistently reference the correct segment for smoother streaming.
* **Tests**
  * Added coverage for resumed text and step-specific streaming events across supported streaming lifecycles.
  * Verified consistent behavior for live and legacy streaming flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->