### PR TITLE
fix(cli): prime build extension contracts

### DIFF
--- a/cli/shared/build-extensions.test.ts
+++ b/cli/shared/build-extensions.test.ts
@@ -1,6 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { EvalReportExporterRegistryName } from "veryfront/extensions/eval";
+import { LLMProviderRegistryName } from "veryfront/extensions/llm";
 import { setupBuildCliExtensions } from "./build-extensions.ts";
 
 /** Minimal stand-in for the loader; the build path only needs it to resolve. */
@@ -59,6 +61,18 @@ describe("cli/shared/build-extensions", () => {
     const names = extensionNames(builtins);
     assertEquals(names.has("ext-bundler-esbuild"), true);
     assertEquals(names.has("ext-content-mdx"), true);
+  });
+
+  it("primes the contracts required by built-in providers and exporters", async () => {
+    let primeContracts: Record<string, unknown> = {};
+
+    await setupBuildCliExtensions("/projects/app", {}, (options) => {
+      primeContracts = options.primeContracts ?? {};
+      return Promise.resolve(loaderStub);
+    });
+
+    assertExists(primeContracts[LLMProviderRegistryName]);
+    assertExists(primeContracts[EvalReportExporterRegistryName]);
   });
 
   it("hands orchestration a logger it can actually log through", async () => {

--- a/cli/shared/build-extensions.ts
+++ b/cli/shared/build-extensions.ts
@@ -26,6 +26,11 @@
  */
 
 import { orchestrateExtensions } from "veryfront/extensions";
+import {
+  createEvalReportExporterRegistry,
+  EvalReportExporterRegistryName,
+} from "veryfront/extensions/eval";
+import { createLLMProviderRegistry, LLMProviderRegistryName } from "veryfront/extensions/llm";
 import { cliLogger } from "#cli/utils";
 import { createBuiltinExtensions } from "../../src/extensions/builtin-extensions.ts";
 
@@ -46,6 +51,10 @@ export async function setupBuildCliExtensions(
     projectDir,
     config,
     logger: cliLogger.component("build-extensions"),
+    primeContracts: {
+      [LLMProviderRegistryName]: createLLMProviderRegistry(),
+      [EvalReportExporterRegistryName]: createEvalReportExporterRegistry(),
+    },
     builtinExtensions: createBuiltinExtensions(),
   });
 }


### PR DESCRIPTION
## Summary

Related to veryfront/veryfront-issue-inbox#456: "veryfront build fails for every project since 0.1.1206: build path is the only orchestrateExtensions caller that omits primeContracts". The inbox issue identifies 0.1.1206 as first bad, introduced by 59fe62c4c / PR #3417, with all local `veryfront build` runs affected.

This fixes the build-only extension orchestration path by priming the same host-owned registries that dev/serve and eval already seed:

- `LLMProviderRegistry` for the built-in OpenAI, Anthropic, and Google LLM extensions.
- `EvalReportExporterRegistry` for the built-in MLflow eval report extension.

The extensions were present and activated. The missing part was the build caller's host registry contract setup, not an optional install.

## Root cause

`cli/shared/build-extensions.ts` was the only `orchestrateExtensions` caller that activated built-in LLM and eval extensions without `primeContracts`. Those extensions correctly fail closed when their required registries are neither provided by another extension nor primed by the host.

## TDD

- Red: added a regression test in `cli/shared/build-extensions.test.ts` that asserts `setupBuildCliExtensions` primes both required contracts.
- Green: `setupBuildCliExtensions` now passes fresh `LLMProviderRegistry` and `EvalReportExporterRegistry` instances into orchestration.
- Refactor: kept the change scoped to the build extension setup and its colocated test.

## Verification

- `deno test --preload=src/testing/preload.ts --no-check --allow-all cli/shared/build-extensions.test.ts` passed after transplant onto `origin/main` (6 steps).
- Focused 30-step regression suite passed during the TDD reproduction/fix cycle.
- `git diff --check` passed.
- `deno task fmt:check` passed.
- `deno task lint` passed.
- `deno check cli/shared/build-extensions.ts cli/shared/build-extensions.test.ts` passed.
- `deno task build:npm` passed during the TDD reproduction/fix cycle.
- Fresh packed-npm consumer build passed during the TDD reproduction/fix cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build extension setup by ensuring required language model and evaluation reporting capabilities are available during orchestration.

* **Tests**
  * Added coverage confirming both capabilities are initialized before build orchestration begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->