### PR TITLE
fix(extensions): keep optional Deno imports optional

### DIFF
--- a/src/extensions/first-party-import.test.ts
+++ b/src/extensions/first-party-import.test.ts
@@ -308,6 +308,16 @@ describe("first-party extension imports", () => {
         ]),
         true,
       );
+
+      const denoMissingDependency = new Error(
+        `Import "@veryfront/ext-auth-jwt" not a dependency`,
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(denoMissingDependency, [
+          "@veryfront/ext-auth-jwt",
+        ]),
+        true,
+      );
     });
 
     it("parses Bun relative, package, and object-shaped missing-module errors", () => {

--- a/src/extensions/first-party-import.ts
+++ b/src/extensions/first-party-import.ts
@@ -318,7 +318,7 @@ function reportedMissingSpecifier(message: string): string | undefined {
     const pattern of [
       /^Cannot find module\s+["']([^"']+)["']\nRequire stack:(?:\n- [^\r\n]+)+$/,
       /^(?:Cannot find package|Cannot find module|Module not found)\s+["']([^"']+)["'](?:(?:\s+imported from\s+.+)|\.)?$/,
-      /^Import\s+["']([^"']+)["']\s+not a dependency and not in import map(?:\s+from\s+.+)?$/,
+      /^Import\s+["']([^"']+)["']\s+not a dependency(?: and not in import map)?(?:\s+from\s+.+)?$/,
       /^Unable to resolve\s+["']([^"']+)["'](?:\s+from\s+.+)?$/,
     ]
   ) {


### PR DESCRIPTION
## Summary

Deno 2.7.7 can report an unavailable optional first-party extension as:

```text
Import "@veryfront/ext-auth-jwt" not a dependency
```

The classifier accepted only the older wording, `not a dependency and not in import map`, so build orchestration treated an absent optional builtin as a hard error for Deno scaffolds. The missing-extension regex now accepts both exact forms while still matching only the explicitly probed first-party specifier.

PR #3541 is the independent SSG fix needed for the `ai-agent` case in the combined 21-case template matrix. This PR is the optional-extension classifier fix and does not depend on that change.

## Regression test

- Added a focused classifier regression for Deno's shortened `not a dependency` wording.

## Verification

- Focused RED then GREEN: 1 test, 29 steps
- `src/extensions` suite: 78 tests, 510 steps
- Full unit suite: 3786 tests, 28100 steps, 1 ignored
- `deno fmt --check`: 4980 files
- `deno lint`: 4905 files
- `deno check src/index.ts`
- 21/21 scaffold, install, and production build matrix passes when paired with PR #3541


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing dependency errors reported in Bun-style formats.
  * Correctly identifies missing first-party packages when no import-map details are included.

* **Tests**
  * Added coverage for missing-dependency error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->