### PR TITLE
fix(server): serve generated pages at clean route URLs

### DIFF
--- a/src/server/services/static/static-file.service.test.ts
+++ b/src/server/services/static/static-file.service.test.ts
@@ -342,6 +342,29 @@ describe("server/services/static/static-file.service", () => {
       }
     });
 
+    it("serves built index pages when a clean route segment contains a dot", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const fileData = new TextEncoder().encode("<html>Blog post</html>");
+      const files = new Map<string, Uint8Array>([
+        ["/project/dist/blog.post/index.html", fileData],
+      ]);
+      const service = new StaticFileService(createMockFsRepo(files));
+      const options = makeOptions();
+
+      for (const route of ["/blog.post", "/blog.post/"]) {
+        const result = await service.resolveFile(route, options);
+
+        assertExists(result);
+        assertEquals(result.path, "/project/dist/blog.post/index.html");
+        assertEquals(result.contentType.includes("text/html"), true);
+        assertEquals(result.data, fileData);
+      }
+    });
+
     it("should resolve file from public directory", async () => {
       __injectDepsForTests({
         manifestCache: new Map(),

--- a/src/server/services/static/static-file.service.test.ts
+++ b/src/server/services/static/static-file.service.test.ts
@@ -319,6 +319,29 @@ describe("server/services/static/static-file.service", () => {
       }
     });
 
+    it("serves built nested index pages through clean route URLs", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const fileData = new TextEncoder().encode("<html>About</html>");
+      const files = new Map<string, Uint8Array>([
+        ["/project/dist/about/index.html", fileData],
+      ]);
+      const service = new StaticFileService(createMockFsRepo(files));
+      const options = makeOptions();
+
+      for (const route of ["/about", "/about/"]) {
+        const result = await service.resolveFile(route, options);
+
+        assertExists(result);
+        assertEquals(result.path, "/project/dist/about/index.html");
+        assertEquals(result.contentType.includes("text/html"), true);
+        assertEquals(result.data, fileData);
+      }
+    });
+
     it("should resolve file from public directory", async () => {
       __injectDepsForTests({
         manifestCache: new Map(),

--- a/src/server/services/static/static-file.service.ts
+++ b/src/server/services/static/static-file.service.ts
@@ -26,7 +26,10 @@ import {
 } from "#veryfront/utils/path-utils.ts";
 import { normalizeChunkPath } from "../../utils/chunk-utils.ts";
 import { computeEtag } from "../../handlers/utils/etag.ts";
-import { getContentType as getContentTypeFromExt } from "../../handlers/utils/content-types.ts";
+import {
+  CONTENT_TYPES,
+  getContentType as getContentTypeFromExt,
+} from "../../handlers/utils/content-types.ts";
 
 const logger = serverLogger.component("static-file-service");
 
@@ -200,7 +203,7 @@ export class StaticFileService {
       if (isWithinDirectory(root, absPath)) addCandidate(absPath, dir);
     }
 
-    if (!this.isAssetRequest(normalizedPath) && normalizedPath !== "/index.html") {
+    if (this.shouldProbeIndexPage(normalizedPath)) {
       const indexPath = `${normalizedPath.replace(/\/$/, "")}/index.html`;
       for (const dir of dirs) {
         const root = joinPath(options.projectDir, dir);
@@ -381,6 +384,13 @@ export class StaticFileService {
     if (this.isDeniedDotfile(pathname)) return false;
     return pathname.includes(".") || pathname.startsWith("/_veryfront/") ||
       pathname.startsWith("/_vf/assets/");
+  }
+
+  private shouldProbeIndexPage(pathname: string): boolean {
+    if (pathname === "/index.html") return false;
+    if (pathname.startsWith("/_veryfront/") || pathname.startsWith("/_vf/assets/")) return false;
+    if (!this.isAssetRequest(pathname)) return true;
+    return !Object.hasOwn(CONTENT_TYPES, getExtension(pathname).toLowerCase());
   }
 
   private isDeniedDotfile(pathname: string): boolean {

--- a/src/server/services/static/static-file.service.ts
+++ b/src/server/services/static/static-file.service.ts
@@ -200,6 +200,15 @@ export class StaticFileService {
       if (isWithinDirectory(root, absPath)) addCandidate(absPath, dir);
     }
 
+    if (!this.isAssetRequest(normalizedPath) && normalizedPath !== "/index.html") {
+      const indexPath = `${normalizedPath.replace(/\/$/, "")}/index.html`;
+      for (const dir of dirs) {
+        const root = joinPath(options.projectDir, dir);
+        const absPath = normalizePath(joinPath(root, indexPath));
+        if (isWithinDirectory(root, absPath)) addCandidate(absPath, dir);
+      }
+    }
+
     return candidates;
   }
 

--- a/tests/integration/server/production/static.test.ts
+++ b/tests/integration/server/production/static.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert";
 import { afterAll, describe, it } from "#veryfront/testing/bdd";
-import { writeTextFile } from "#veryfront/compat/fs.ts";
+import { mkdir, writeTextFile } from "#veryfront/compat/fs.ts";
+import { join } from "#veryfront/compat/path";
 import { type TestContext, withTestContext } from "../../../_helpers/context.ts";
 import "../../../_helpers/log-guard.ts";
 import { cleanupBundler } from "../../../../src/rendering/cleanup.ts";
@@ -52,6 +53,23 @@ describe(
           await m.text();
         },
       );
+    });
+
+    it("serves generated nested pages through clean route URLs", async () => {
+      await withTestContext("production-server-clean-route", async (context: TestContext) => {
+        const pageDir = join(context.projectDir, "dist", "about");
+        await mkdir(pageDir, { recursive: true });
+        await writeTextFile(join(pageDir, "index.html"), "<html>About</html>");
+
+        const server = await context.createProductionServer();
+        const baseUrl = `http://127.0.0.1:${server.port}`;
+
+        for (const route of ["/about", "/about/"]) {
+          const response = await fetch(`${baseUrl}${route}`);
+          assertEquals(response.status, 200);
+          assertEquals(await response.text(), "<html>About</html>");
+        }
+      });
     });
   },
 );

--- a/tests/integration/server/production/static.test.ts
+++ b/tests/integration/server/production/static.test.ts
@@ -57,17 +57,22 @@ describe(
 
     it("serves generated nested pages through clean route URLs", async () => {
       await withTestContext("production-server-clean-route", async (context: TestContext) => {
-        const pageDir = join(context.projectDir, "dist", "about");
-        await mkdir(pageDir, { recursive: true });
-        await writeTextFile(join(pageDir, "index.html"), "<html>About</html>");
+        for (const page of ["about", "blog.post"]) {
+          const pageDir = join(context.projectDir, "dist", page);
+          await mkdir(pageDir, { recursive: true });
+          await writeTextFile(join(pageDir, "index.html"), `<html>${page}</html>`);
+        }
 
         const server = await context.createProductionServer();
         const baseUrl = `http://127.0.0.1:${server.port}`;
 
-        for (const route of ["/about", "/about/"]) {
+        for (const route of ["/about", "/about/", "/blog.post", "/blog.post/"]) {
           const response = await fetch(`${baseUrl}${route}`);
           assertEquals(response.status, 200);
-          assertEquals(await response.text(), "<html>About</html>");
+          assertEquals(
+            await response.text(),
+            route.startsWith("/about") ? "<html>about</html>" : "<html>blog.post</html>",
+          );
         }
       });
     });


### PR DESCRIPTION
## Summary

- resolve generated nested `index.html` pages for clean production URLs
- keep exact static-file candidates ahead of directory-index fallbacks
- add service-level and production HTTP regressions for `/about` and `/about/`

## Root cause

`veryfront build` emits a nested route such as `/about` at `dist/about/index.html`. `veryfront serve` only probed `dist/about`, missed the generated page, and fell through to live SSR. For an MDX page that fallback produced hydration data pointing at raw `page.mdx`, and the browser module request returned 404.

The module endpoint was not the correct fix. The generated static page should be served before SSR fallback.

## Validation

- `deno test --preload=src/testing/preload.ts --no-check --allow-all src/server/services/static/static-file.service.test.ts`
- `deno test --preload=src/testing/preload.ts --no-check --allow-all src/server/handlers/request/static.handler.test.ts`
- `deno test --preload=src/testing/preload.ts --no-check --allow-all --unstable-worker-options --unstable-net tests/integration/server/production/static.test.ts`
- full pre-push formatting, lint, typecheck, and unit suite: 3,774 parallel tests plus isolated CWD suites passed
- generated Node minimal template: scaffold, install, build, production serve, HTTP `/` and `/about`, browser `/` and `/about`, clean shutdown all passed

## Follow-up journey

The full seven-template by three-runtime production journey will continue independently. Any additional defect will use its own test-first PR.