### PR TITLE
chore(release): v0.1.1228

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1227",
+  "version": "0.1.1228",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1227";
+export const VERSION = "0.1.1228";


### PR DESCRIPTION
Cuts **v0.1.1228**, the release that unblocks `veryfront build`.

Merging this publishes: `version-check` (cicd.yml:469) compares `deno.json` against the previous commit, and a changed stable version gates the `release` job.

## Why this release matters

`veryfront build` has been broken for **every project since 0.1.1206** — 22 releases. An external report surfaced it on 0.1.1227 (veryfront-issue-inbox#456).

There is no earlier version to pin to. 0.1.1205 fails the same templates with the `CSSProcessor` error that #3417 was fixing. A release is the only fix path.

## What ships

| PR | Fix |
|---|---|
| #3538 | Prime host contracts in the build extension path |
| #3541 | Resolve server-side esm.sh modules with a server target |
| #3542 | Keep optional Deno imports optional |
| #3540 | Isolate cwd-mutating unit tests |

## Verification on merged main (`48cd2d5c7`)

All 7 scaffold templates, each `veryfront init` + `veryfront build` from scratch:

| Template | Result | Pages |
|---|---|---|
| `minimal` | ✓ 4.87s | 2 |
| `ai-agent` *(default)* | ✓ 7.04s | 1 |
| `docs-agent` | ✓ 6.83s | 2 |
| `agentic-workflow` | ✓ 2.50s | 1 |
| `multi-agent-system` | ✓ 3.26s | 1 |
| `coding-agent` | ✓ 4.24s | 1 |
| `saas-starter` | ✓ 4.72s | 3 |

Before these fixes, 5 of the 7 failed. Page counts are included because `veryfront build` can exit 0 with zero pages, so "built" alone is not evidence.

Hydration checked in a real browser on the `docs-agent` build served via `veryfront serve`: 428 requests all 200, zero console messages, React fibers attached. That matters because #3541 makes SSR evaluate esm.sh's `node` build while the browser still gets `es2022`, and a parity break there would be invisible to CI.

## Diff

Two lines. `deno.json` and `src/utils/version-constant.ts` must move together; `src/utils/version.test.ts:25` enforces it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to **0.1.1228**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->