### PR TITLE
fix(api): resolve Veryfront imports in Deno temp modules

### DIFF
--- a/src/routing/api/module-loader/external-import-rewriter.test.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { FileInfo } from "#veryfront/platform/adapters/base.ts";
 import type { FileSystem } from "#veryfront/platform/compat/fs.ts";
@@ -8,10 +13,12 @@ import {
   getNodeExternalPackagesToResolve,
   NODE_BUILTINS,
   resolveEsmUserDependencies,
+  resolveVeryfrontPackageExport,
   rewriteCompiledBinaryUserDependencyImports,
   rewriteCompiledBinaryVeryfrontImports,
   rewriteDenoNodeBuiltinImports,
   rewriteDenoNpmDependencyImports,
+  rewriteExternalImports,
 } from "./external-import-rewriter.ts";
 
 function createFakeFileSystem(files: Record<string, string>): FileSystem {
@@ -291,6 +298,50 @@ describe("external-import-rewriter", () => {
 
       assertStringIncludes(out, `from "npm:lodash@4.17.21"`);
       assertStringIncludes(out, `from "npm:lodash@4.17.21/merge"`);
+    });
+  });
+
+  describe("rewriteExternalImports", () => {
+    it("resolves packaged Veryfront exports inside the running package", () => {
+      const runningPackage = {
+        packageUrl: new URL("file:///opt/veryfront/package.json"),
+        exports: {
+          "./embedding": { import: "./esm/src/embedding/index.js" },
+          "./escape": { import: "../escape.js" },
+        },
+      };
+
+      assertEquals(
+        resolveVeryfrontPackageExport("veryfront/embedding", runningPackage),
+        "file:///opt/veryfront/esm/src/embedding/index.js",
+      );
+      assertThrows(
+        () => resolveVeryfrontPackageExport("veryfront/escape", runningPackage),
+        TypeError,
+        "escapes its package root",
+      );
+    });
+
+    it("resolves Veryfront imports from the running package for Deno temp modules", async () => {
+      const source = [
+        `import { createUploadHandler } from "veryfront/embedding";`,
+        `const agentModule = import("veryfront/agent");`,
+      ].join("\n");
+
+      const out = await rewriteExternalImports(
+        source,
+        "/srv/app",
+        createFakeFileSystem({}),
+      );
+
+      assertStringIncludes(
+        out,
+        `from "${import.meta.resolve("veryfront/embedding")}"`,
+      );
+      assertStringIncludes(
+        out,
+        `import("${import.meta.resolve("veryfront/agent")}")`,
+      );
     });
   });
 

--- a/src/routing/api/module-loader/external-import-rewriter.test.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.test.ts
@@ -18,7 +18,7 @@ import {
   rewriteCompiledBinaryVeryfrontImports,
   rewriteDenoNodeBuiltinImports,
   rewriteDenoNpmDependencyImports,
-  rewriteExternalImports,
+  rewriteDenoVeryfrontImports,
 } from "./external-import-rewriter.ts";
 
 function createFakeFileSystem(files: Record<string, string>): FileSystem {
@@ -301,7 +301,7 @@ describe("external-import-rewriter", () => {
     });
   });
 
-  describe("rewriteExternalImports", () => {
+  describe("Deno Veryfront package imports", () => {
     it("resolves packaged Veryfront exports inside the running package", () => {
       const runningPackage = {
         packageUrl: new URL("file:///opt/veryfront/package.json"),
@@ -328,11 +328,7 @@ describe("external-import-rewriter", () => {
         `const agentModule = import("veryfront/agent");`,
       ].join("\n");
 
-      const out = await rewriteExternalImports(
-        source,
-        "/srv/app",
-        createFakeFileSystem({}),
-      );
+      const out = await rewriteDenoVeryfrontImports(source);
 
       assertStringIncludes(
         out,

--- a/src/routing/api/module-loader/external-import-rewriter.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.ts
@@ -284,6 +284,77 @@ export function rewriteDenoNodeBuiltinImports(code: string): string {
   return rewriteDenoNodeBuiltinsForRoute(code);
 }
 
+interface RunningVeryfrontPackage {
+  packageUrl: URL;
+  exports: Record<string, unknown>;
+}
+
+let runningVeryfrontPackage: Promise<RunningVeryfrontPackage | null> | null = null;
+
+function loadRunningVeryfrontPackage(): Promise<RunningVeryfrontPackage | null> {
+  runningVeryfrontPackage ??= (async () => {
+    const packageUrl = new URL("../../../../../package.json", import.meta.url);
+    try {
+      const raw = await Deno.readTextFile(packageUrl);
+      const pkg = JSON.parse(raw) as { name?: unknown; exports?: unknown };
+      if (pkg.name !== "veryfront" || !pkg.exports || typeof pkg.exports !== "object") {
+        return null;
+      }
+      return {
+        packageUrl,
+        exports: pkg.exports as Record<string, unknown>,
+      };
+    } catch {
+      return null;
+    }
+  })();
+  return runningVeryfrontPackage;
+}
+
+async function resolveDenoVeryfrontImport(specifier: string): Promise<string> {
+  const runningPackage = await loadRunningVeryfrontPackage();
+  if (!runningPackage) return import.meta.resolve(specifier);
+
+  return resolveVeryfrontPackageExport(specifier, runningPackage);
+}
+
+export function resolveVeryfrontPackageExport(
+  specifier: string,
+  runningPackage: RunningVeryfrontPackage,
+): string {
+  const exportKey = specifier === "veryfront" ? "." : `./${specifier.slice("veryfront/".length)}`;
+  const exportPath = resolveExportEntry(runningPackage.exports[exportKey]);
+  if (!exportPath) {
+    throw new TypeError(`Veryfront package does not export ${exportKey}`);
+  }
+
+  const packageRoot = new URL("./", runningPackage.packageUrl);
+  const resolved = new URL(exportPath, packageRoot);
+  if (!resolved.href.startsWith(packageRoot.href)) {
+    throw new TypeError(`Veryfront package export escapes its package root: ${exportKey}`);
+  }
+  return resolved.href;
+}
+
+async function rewriteDenoVeryfrontImports(code: string): Promise<string> {
+  const replacements = new Map<string, string>();
+
+  for (const imported of await parseImports(code)) {
+    const specifier = imported.n;
+    if (
+      typeof specifier !== "string" ||
+      (specifier !== "veryfront" && !specifier.startsWith("veryfront/"))
+    ) {
+      continue;
+    }
+
+    replacements.set(specifier, await resolveDenoVeryfrontImport(specifier));
+  }
+
+  if (replacements.size === 0) return code;
+  return await replaceSpecifiers(code, (specifier) => replacements.get(specifier));
+}
+
 export async function rewriteExternalImports(
   code: string,
   projectDir: string,
@@ -304,6 +375,10 @@ export async function rewriteExternalImports(
   if (isDeno) {
     transformed = rewriteNpmImports(transformed, projectDir);
     transformed = rewriteDenoNodeBuiltinImports(transformed);
+
+    if (!isCompiledBinary()) {
+      transformed = await rewriteDenoVeryfrontImports(transformed);
+    }
 
     // Rewrite user-installed npm dependencies.
     // In non-compiled Deno: use npm: specifiers (resolved by Deno's npm support).

--- a/src/routing/api/module-loader/external-import-rewriter.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.ts
@@ -336,7 +336,7 @@ export function resolveVeryfrontPackageExport(
   return resolved.href;
 }
 
-async function rewriteDenoVeryfrontImports(code: string): Promise<string> {
+export async function rewriteDenoVeryfrontImports(code: string): Promise<string> {
   const replacements = new Map<string, string>();
 
   for (const imported of await parseImports(code)) {


### PR DESCRIPTION
## Summary

- resolve noncompiled Deno `veryfront` imports through the running package export map
- preserve the existing compiled Deno shims and Node/Bun behavior
- reject package export targets that escape the installed package root
- add focused regressions for static and dynamic subpath imports

## Root cause

Fresh Deno projects do not inherit this repository's import map. When a generated API route had to use the bundled temporary-module path, bare imports such as `veryfront/embedding` remained external. Deno then evaluated the temporary file outside the installed package context and could not resolve the framework import.

Using `import.meta.resolve` alone was insufficient because the packed npm build uses a DNT resolver ponyfill that loses package self-resolution. This change reads the active package export map and converts framework imports to contained file URLs before Deno evaluates the temporary module.

## Verification

- focused rewriter regression captured red, then passed green
- module-loader suites: 5 passed, 97 steps, 0 failed
- formatting, lint, and typecheck passed
- full pre-push checks passed, including parallel unit tests and isolated CWD suites
- generated docs-agent Deno project passed scaffold, install, build, production serve, `/`, `/uploads`, browser checks, and `/api/uploads` with a clean network log

Related: veryfront/veryfront-issue-inbox#456