### PR TITLE
fix(test): close remaining Bun review gaps

### DIFF
--- a/tests/bun/npm-protocol-imports.ts
+++ b/tests/bun/npm-protocol-imports.ts
@@ -3,6 +3,10 @@ type Token = {
   value: string;
 };
 
+/** Module paths whose imports need Bun-specific rewriting before resolution. */
+export const BUN_REWRITE_MODULE_FILTER =
+  /(\.test\.[cm]?[jt]sx?|[/\\]extensions[/\\]ext-[^/\\]+[/\\]src[/\\].*\.[cm]?[jt]sx?)$/;
+
 function bareNpmSpecifier(specifier: string): string {
   const value = specifier.slice("npm:".length);
   const match = /^((?:@[^/]+\/)?[^@/]+)(?:@[^/]+)?(\/.*)?$/.exec(value);
@@ -95,4 +99,20 @@ export function rewriteNpmProtocolImports(source: string): string | null {
     source,
     (specifier) => specifier.startsWith("npm:") ? bareNpmSpecifier(specifier) : null,
   );
+}
+
+/** Rewrite imports selected by the Bun preload hook on every path style. */
+export function rewriteBunPreloadedModuleContents(
+  modulePath: string,
+  source: string,
+  resolveWorkspaceSpecifier: (specifier: string) => string | null,
+): string {
+  const posixPath = modulePath.replaceAll("\\", "/");
+  let contents = posixPath.includes("/extensions/")
+    ? rewriteModuleSpecifiers(source, resolveWorkspaceSpecifier) ?? source
+    : source;
+  if (/\.test\.[cm]?[jt]sx?$/.test(posixPath)) {
+    contents = rewriteNpmProtocolImports(contents) ?? contents;
+  }
+  return contents;
 }

--- a/tests/bun/npm-protocol-resolution.test.ts
+++ b/tests/bun/npm-protocol-resolution.test.ts
@@ -2,7 +2,11 @@ import { BasicTracerProvider } from "npm:@opentelemetry/sdk-trace-base@2.9.0";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { rewriteNpmProtocolImports } from "./npm-protocol-imports.ts";
+import {
+  BUN_REWRITE_MODULE_FILTER,
+  rewriteBunPreloadedModuleContents,
+  rewriteNpmProtocolImports,
+} from "./npm-protocol-imports.ts";
 
 describe("Bun npm protocol resolution", () => {
   it("loads versioned scoped and unscoped npm imports", () => {
@@ -29,5 +33,40 @@ describe("Bun npm protocol resolution", () => {
         'const load = () => import("@scope/package/subpath");',
       ].join("\n"),
     );
+  });
+
+  it("rewrites extension and test paths with either path separator", () => {
+    const extensionSource = 'import value from "workspace-alias";';
+    const testSource = 'import value from "npm:fixture@1.0.0";';
+
+    for (
+      const modulePath of [
+        "/repo/extensions/ext-example/src/index.ts",
+        "C:\\repo\\extensions\\ext-example\\src\\index.ts",
+      ]
+    ) {
+      assertEquals(BUN_REWRITE_MODULE_FILTER.test(modulePath), true);
+      assertEquals(
+        rewriteBunPreloadedModuleContents(
+          modulePath,
+          extensionSource,
+          (specifier) => specifier === "workspace-alias" ? "./resolved.ts" : null,
+        ),
+        'import value from "./resolved.ts";',
+      );
+    }
+
+    for (
+      const modulePath of [
+        "/repo/src/example.test.ts",
+        "C:\\repo\\src\\example.test.ts",
+      ]
+    ) {
+      assertEquals(BUN_REWRITE_MODULE_FILTER.test(modulePath), true);
+      assertEquals(
+        rewriteBunPreloadedModuleContents(modulePath, testSource, () => null),
+        'import value from "fixture";',
+      );
+    }
   });
 });

--- a/tests/bun/preload.ts
+++ b/tests/bun/preload.ts
@@ -12,7 +12,10 @@ import { plugin } from "bun";
 import { existsSync, readFileSync, statSync } from "fs";
 import { dirname, extname, relative, resolve, sep } from "path";
 import { fileURLToPath } from "url";
-import { rewriteModuleSpecifiers, rewriteNpmProtocolImports } from "./npm-protocol-imports.ts";
+import {
+  BUN_REWRITE_MODULE_FILTER,
+  rewriteBunPreloadedModuleContents,
+} from "./npm-protocol-imports.ts";
 
 const projectRoot = resolve(import.meta.dir, "../..");
 
@@ -144,21 +147,15 @@ plugin({
     // import-looking fixture strings and comments untouched.
     build.onLoad(
       {
-        filter:
-          /(\.test\.[cm]?[jt]sx?|[/\\]extensions[/\\]ext-[^/\\]+[/\\]src[/\\].*\.[cm]?[jt]sx?)$/,
+        filter: BUN_REWRITE_MODULE_FILTER,
       },
       (args) => {
-        const posixPath = args.path.split(sep).join("/");
         const source = readFileSync(args.path, "utf8");
-        let contents = posixPath.includes("/extensions/")
-          ? rewriteModuleSpecifiers(
-            source,
-            (specifier) => workspaceModuleSpecifier(args.path, specifier),
-          ) ?? source
-          : source;
-        if (/\.test\.[cm]?[jt]sx?$/.test(posixPath)) {
-          contents = rewriteNpmProtocolImports(contents) ?? contents;
-        }
+        const contents = rewriteBunPreloadedModuleContents(
+          args.path,
+          source,
+          (specifier) => workspaceModuleSpecifier(args.path, specifier),
+        );
         const extension = extname(args.path).toLowerCase();
         const loader = extension === ".tsx"
           ? "tsx"

--- a/tests/bun/runner-args.test.mjs
+++ b/tests/bun/runner-args.test.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   buildBunTestArgs,
   buildIsolatedBunTestRuns,
@@ -50,7 +51,7 @@ test("the Bun runner drains child output and exits naturally", () => {
 test("the Bun runner fails loudly when filters select no files", () => {
   const result = spawnSync(
     process.execPath,
-    [new URL("./run-tests.mjs", import.meta.url).pathname],
+    [fileURLToPath(new URL("./run-tests.mjs", import.meta.url))],
     {
       env: { ...process.env, BUN_TEST_INCLUDE: "missing-bun-fixture.test.ts" },
       encoding: "utf8",

--- a/tests/bun/workspace-packages.mjs
+++ b/tests/bun/workspace-packages.mjs
@@ -1,4 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, rmdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { randomUUID } from "node:crypto";
 import { ensureDirectoryLink } from "../ensure-npm-links.mjs";
@@ -7,6 +16,7 @@ const MARKER_NAME = ".veryfront-bun-workspace-package.json";
 const LOCK_NAME = ".veryfront-bun-workspace-packages.lock";
 const RECLAIMER_NAME = ".veryfront-bun-workspace-packages.reclaim";
 const LOCK_OWNER = "veryfront-bun-tests";
+const INCOMPLETE_RECLAIMER_GRACE_MS = 30_000;
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
@@ -45,12 +55,8 @@ function acquirePreparationLock(nodeModulesPath) {
 
 export function reclaimStalePreparationLock(lockPath, runtimeProcess = process) {
   const reclaimerPath = join(dirname(lockPath), RECLAIMER_NAME);
-  try {
-    mkdirSync(reclaimerPath);
-  } catch (error) {
-    if (error?.code === "EEXIST") return null;
-    throw error;
-  }
+  const reclaimerToken = acquireReclaimerLock(reclaimerPath);
+  if (reclaimerToken === null) return null;
 
   try {
     let marker;
@@ -76,8 +82,82 @@ export function reclaimStalePreparationLock(lockPath, runtimeProcess = process) 
     );
     return token;
   } finally {
-    rmSync(reclaimerPath, { recursive: true, force: true });
+    releaseReclaimerLock(reclaimerPath, reclaimerToken);
   }
+}
+
+function acquireReclaimerLock(reclaimerPath) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const token = randomUUID();
+    try {
+      mkdirSync(reclaimerPath);
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (!discardAbandonedReclaimerLock(reclaimerPath)) return null;
+      continue;
+    }
+
+    try {
+      writeFileSync(
+        join(reclaimerPath, MARKER_NAME),
+        `${JSON.stringify({ owner: LOCK_OWNER, pid: process.pid, token })}\n`,
+      );
+      return token;
+    } catch (error) {
+      rmSync(reclaimerPath, { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  return null;
+}
+
+function discardAbandonedReclaimerLock(reclaimerPath) {
+  let marker;
+  try {
+    marker = readJson(join(reclaimerPath, MARKER_NAME));
+  } catch {
+    try {
+      if (Date.now() - statSync(reclaimerPath).mtimeMs < INCOMPLETE_RECLAIMER_GRACE_MS) {
+        return false;
+      }
+    } catch (error) {
+      if (error?.code === "ENOENT") return true;
+      throw error;
+    }
+  }
+
+  if (marker !== undefined) {
+    if (marker?.owner !== LOCK_OWNER) return false;
+    if (!Number.isSafeInteger(marker.pid) || marker.pid < 1) return false;
+    try {
+      process.kill(marker.pid, 0);
+      return false;
+    } catch (error) {
+      if (error?.code !== "ESRCH") return false;
+    }
+  }
+
+  const discardedPath = `${reclaimerPath}.${randomUUID()}.stale`;
+  try {
+    renameSync(reclaimerPath, discardedPath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return true;
+    throw error;
+  }
+  rmSync(discardedPath, { recursive: true, force: true });
+  return true;
+}
+
+function releaseReclaimerLock(reclaimerPath, token) {
+  let marker;
+  try {
+    marker = readJson(join(reclaimerPath, MARKER_NAME));
+  } catch {
+    return;
+  }
+  if (marker.owner !== LOCK_OWNER || marker.token !== token) return;
+  rmSync(reclaimerPath, { recursive: true, force: true });
 }
 
 function releasePreparationLock(lockPath, token) {

--- a/tests/bun/workspace-packages.mjs
+++ b/tests/bun/workspace-packages.mjs
@@ -5,6 +5,7 @@ import { ensureDirectoryLink } from "../ensure-npm-links.mjs";
 
 const MARKER_NAME = ".veryfront-bun-workspace-package.json";
 const LOCK_NAME = ".veryfront-bun-workspace-packages.lock";
+const RECLAIMER_NAME = ".veryfront-bun-workspace-packages.reclaim";
 const LOCK_OWNER = "veryfront-bun-tests";
 
 function readJson(path) {
@@ -14,27 +15,21 @@ function readJson(path) {
 function acquirePreparationLock(nodeModulesPath) {
   mkdirSync(nodeModulesPath, { recursive: true });
   const lockPath = join(nodeModulesPath, LOCK_NAME);
+  const token = randomUUID();
   try {
     mkdirSync(lockPath);
   } catch (error) {
     if (error?.code === "EEXIST") {
-      if (!reclaimStalePreparationLock(lockPath)) {
+      const reclaimedToken = reclaimStalePreparationLock(lockPath);
+      if (reclaimedToken === null) {
         throw new Error("Bun workspace package preparation is already active");
       }
-      try {
-        mkdirSync(lockPath);
-      } catch (retryError) {
-        if (retryError?.code === "EEXIST") {
-          throw new Error("Bun workspace package preparation is already active");
-        }
-        throw retryError;
-      }
+      return { lockPath, token: reclaimedToken };
     } else {
       throw error;
     }
   }
 
-  const token = randomUUID();
   try {
     writeFileSync(
       join(lockPath, MARKER_NAME),
@@ -49,26 +44,39 @@ function acquirePreparationLock(nodeModulesPath) {
 }
 
 export function reclaimStalePreparationLock(lockPath, runtimeProcess = process) {
-  let marker;
+  const reclaimerPath = join(dirname(lockPath), RECLAIMER_NAME);
   try {
-    marker = readJson(join(lockPath, MARKER_NAME));
-  } catch {
-    return false;
+    mkdirSync(reclaimerPath);
+  } catch (error) {
+    if (error?.code === "EEXIST") return null;
+    throw error;
   }
 
-  if (marker?.owner !== LOCK_OWNER) {
-    return false;
-  }
-  if (!Number.isSafeInteger(marker.pid) || marker.pid < 1) {
-    return false;
-  }
   try {
-    runtimeProcess.kill(marker.pid, 0);
-    return false;
-  } catch (error) {
-    if (error?.code !== "ESRCH") return false;
-    rmSync(lockPath, { recursive: true, force: true });
-    return true;
+    let marker;
+    try {
+      marker = readJson(join(lockPath, MARKER_NAME));
+    } catch {
+      return null;
+    }
+
+    if (marker?.owner !== LOCK_OWNER) return null;
+    if (!Number.isSafeInteger(marker.pid) || marker.pid < 1) return null;
+    try {
+      runtimeProcess.kill(marker.pid, 0);
+      return null;
+    } catch (error) {
+      if (error?.code !== "ESRCH") return null;
+    }
+
+    const token = randomUUID();
+    writeFileSync(
+      join(lockPath, MARKER_NAME),
+      `${JSON.stringify({ owner: LOCK_OWNER, pid: process.pid, token })}\n`,
+    );
+    return token;
+  } finally {
+    rmSync(reclaimerPath, { recursive: true, force: true });
   }
 }
 

--- a/tests/bun/workspace-packages.test.mjs
+++ b/tests/bun/workspace-packages.test.mjs
@@ -1,6 +1,17 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import { prepareBunWorkspacePackages } from "./workspace-packages.mjs";
@@ -9,6 +20,71 @@ const projectRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
+}
+
+async function waitForFiles(paths, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!paths.every((path) => existsSync(path))) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${paths.join(", ")}`);
+    }
+    await delay(10);
+  }
+}
+
+function spawnLockReclaimer(lockPath, coordinationRoot, id) {
+  const childSource = String.raw`
+    import { existsSync, writeFileSync } from "node:fs";
+    const { reclaimStalePreparationLock } = await import(process.env.VF_LOCK_MODULE_URL);
+    const lockPath = process.env.VF_LOCK_PATH;
+    const coordinationRoot = process.env.VF_COORDINATION_ROOT;
+    const id = process.env.VF_RECLAIMER_ID;
+    const otherId = id === "0" ? "1" : "0";
+    const waitBuffer = new Int32Array(new SharedArrayBuffer(4));
+    const wait = () => Atomics.wait(waitBuffer, 0, 0, 10);
+    writeFileSync(coordinationRoot + "/" + id + ".ready", "ready\n");
+    while (!existsSync(coordinationRoot + "/start")) wait();
+    const runtimeProcess = {
+      kill() {
+        writeFileSync(coordinationRoot + "/" + id + ".checked", "checked\n");
+        const deadline = Date.now() + 500;
+        while (
+          !existsSync(coordinationRoot + "/" + otherId + ".checked") &&
+          Date.now() < deadline
+        ) wait();
+        const error = new Error("dead lock owner");
+        error.code = "ESRCH";
+        throw error;
+      },
+    };
+    const token = reclaimStalePreparationLock(lockPath, runtimeProcess);
+    writeFileSync(
+      coordinationRoot + "/" + id + ".result.json",
+      JSON.stringify({ id, pid: process.pid, token }),
+    );
+    if (token !== null) {
+      while (!existsSync(coordinationRoot + "/release")) wait();
+    }
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "--eval", childSource], {
+    env: {
+      ...process.env,
+      VF_COORDINATION_ROOT: coordinationRoot,
+      VF_LOCK_MODULE_URL: new URL("./workspace-packages.mjs", import.meta.url).href,
+      VF_LOCK_PATH: lockPath,
+      VF_RECLAIMER_ID: String(id),
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  const completion = new Promise((resolveCompletion) => {
+    child.on("close", (code, signal) => resolveCompletion({ code, signal, stderr }));
+  });
+  return { child, completion };
 }
 
 test("prepareBunWorkspacePackages derives native packages from every workspace export", () => {
@@ -130,6 +206,57 @@ test("workspace package preparation reclaims a stale lock with a dead owner", ()
     );
   } finally {
     prepared.cleanup();
+  }
+});
+
+test("concurrent stale-lock reclaimers preserve the live replacement owner", async () => {
+  const coordinationRoot = mkdtempSync(join(tmpdir(), "veryfront-bun-lock-race-"));
+  const lockPath = join(coordinationRoot, ".veryfront-bun-workspace-packages.lock");
+  mkdirSync(lockPath);
+  writeFileSync(
+    join(lockPath, ".veryfront-bun-workspace-package.json"),
+    `${JSON.stringify({ owner: "veryfront-bun-tests", pid: 9_999_999, token: "stale" })}\n`,
+  );
+  const reclaimers = [
+    spawnLockReclaimer(lockPath, coordinationRoot, 0),
+    spawnLockReclaimer(lockPath, coordinationRoot, 1),
+  ];
+  const releasePath = join(coordinationRoot, "release");
+
+  try {
+    await waitForFiles([
+      join(coordinationRoot, "0.ready"),
+      join(coordinationRoot, "1.ready"),
+    ]);
+    writeFileSync(join(coordinationRoot, "start"), "start\n");
+    const resultPaths = [
+      join(coordinationRoot, "0.result.json"),
+      join(coordinationRoot, "1.result.json"),
+    ];
+    await waitForFiles(resultPaths);
+
+    const results = resultPaths.map(readJson);
+    const winners = results.filter((result) => result.token !== null);
+    assert.equal(winners.length, 1);
+    const winner = winners[0];
+    const marker = readJson(join(lockPath, ".veryfront-bun-workspace-package.json"));
+    assert.equal(marker.token, winner.token);
+    assert.equal(marker.pid, winner.pid);
+    assert.doesNotThrow(() => process.kill(winner.pid, 0));
+    assert.equal(existsSync(lockPath), true);
+
+    writeFileSync(releasePath, "release\n");
+    const completions = await Promise.all(reclaimers.map(({ completion }) => completion));
+    for (const completion of completions) {
+      assert.deepEqual(completion, { code: 0, signal: null, stderr: "" });
+    }
+  } finally {
+    if (!existsSync(releasePath)) writeFileSync(releasePath, "release\n");
+    for (const { child } of reclaimers) {
+      if (child.exitCode === null && child.signalCode === null) child.kill();
+    }
+    await Promise.allSettled(reclaimers.map(({ completion }) => completion));
+    rmSync(coordinationRoot, { recursive: true, force: true });
   }
 });
 

--- a/tests/bun/workspace-packages.test.mjs
+++ b/tests/bun/workspace-packages.test.mjs
@@ -14,7 +14,7 @@ import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
-import { prepareBunWorkspacePackages } from "./workspace-packages.mjs";
+import { prepareBunWorkspacePackages, reclaimStalePreparationLock } from "./workspace-packages.mjs";
 
 const projectRoot = fileURLToPath(new URL("../..", import.meta.url));
 
@@ -206,6 +206,38 @@ test("workspace package preparation reclaims a stale lock with a dead owner", ()
     );
   } finally {
     prepared.cleanup();
+  }
+});
+
+test("stale-lock recovery reclaims an abandoned reclaimer directory", () => {
+  const coordinationRoot = mkdtempSync(join(tmpdir(), "veryfront-bun-lock-interrupted-"));
+  const lockPath = join(coordinationRoot, ".veryfront-bun-workspace-packages.lock");
+  const reclaimerPath = join(coordinationRoot, ".veryfront-bun-workspace-packages.reclaim");
+  mkdirSync(lockPath);
+  mkdirSync(reclaimerPath);
+  writeFileSync(
+    join(lockPath, ".veryfront-bun-workspace-package.json"),
+    `${JSON.stringify({ owner: "veryfront-bun-tests", pid: 9_999_999, token: "stale" })}\n`,
+  );
+  writeFileSync(
+    join(reclaimerPath, ".veryfront-bun-workspace-package.json"),
+    `${
+      JSON.stringify({
+        owner: "veryfront-bun-tests",
+        pid: 9_999_998,
+        token: "abandoned-reclaimer",
+      })
+    }\n`,
+  );
+
+  try {
+    const token = reclaimStalePreparationLock(lockPath);
+
+    assert.equal(typeof token, "string");
+    assert.equal(readJson(join(lockPath, ".veryfront-bun-workspace-package.json")).token, token);
+    assert.equal(existsSync(reclaimerPath), false);
+  } finally {
+    rmSync(coordinationRoot, { recursive: true, force: true });
   }
 });
 

--- a/tests/bun/workspace-packages.test.mjs
+++ b/tests/bun/workspace-packages.test.mjs
@@ -22,6 +22,14 @@ function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
 }
 
+function signalRelease(path) {
+  try {
+    writeFileSync(path, "release\n", { flag: "wx" });
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+  }
+}
+
 async function waitForFiles(paths, timeoutMs = 5_000) {
   const deadline = Date.now() + timeoutMs;
   while (!paths.every((path) => existsSync(path))) {
@@ -277,13 +285,13 @@ test("concurrent stale-lock reclaimers preserve the live replacement owner", asy
     assert.doesNotThrow(() => process.kill(winner.pid, 0));
     assert.equal(existsSync(lockPath), true);
 
-    writeFileSync(releasePath, "release\n");
+    signalRelease(releasePath);
     const completions = await Promise.all(reclaimers.map(({ completion }) => completion));
     for (const completion of completions) {
       assert.deepEqual(completion, { code: 0, signal: null, stderr: "" });
     }
   } finally {
-    if (!existsSync(releasePath)) writeFileSync(releasePath, "release\n");
+    signalRelease(releasePath);
     for (const { child } of reclaimers) {
       if (child.exitCode === null && child.signalCode === null) child.kill();
     }


### PR DESCRIPTION
## Summary

- serialize stale Bun workspace-lock reclamation without deleting the canonical lock directory
- add a two-process regression proving a concurrent reclaimer cannot remove the live replacement owner
- normalize Bun preload paths across slash styles and cover extension and test rewrites
- convert the Bun runner test URL with `fileURLToPath` for Windows

This follow-up addresses all three review threads that completed as PR #3543 entered the merge queue.

## Verification

- `node --test tests/bun/runner-args.test.mjs tests/bun/workspace-packages.test.mjs`, 14 passed
- concurrent stale-lock regression, 20/20 isolated runs passed
- Bun 1.3.6 npm-protocol focused suite, 3 passed
- full Bun isolation runner, 1296 files passed; one pre-existing macOS native watcher assertion fails locally and is unchanged by this diff
- `deno lint` on all six changed files
- `deno fmt --check` on all six changed files
- `git diff --check`