### PR TITLE
fix(cli): stop veryfront routes printing a bare bullet and a flush-left API heading

### DIFF
--- a/cli/commands/routes/command.ts
+++ b/cli/commands/routes/command.ts
@@ -69,7 +69,10 @@ export async function routesCommand(
     cliLogger.info(`  ${p.pattern} -> ${p.file}`);
   }
 
-  cliLogger.info("\nAPI:");
+  // Emit the section break directly: a leading "\n" inside the message would be
+  // prefixed by the CLI logger, printing a bare glyph line and a flush-left heading.
+  console.log("");
+  cliLogger.info("API:");
   for (const a of apis) {
     cliLogger.info(`  ${a.pattern} -> ${a.file}`);
   }

--- a/cli/commands/routes/routes.integration.test.ts
+++ b/cli/commands/routes/routes.integration.test.ts
@@ -142,8 +142,11 @@ describe("CLI routes command", () => {
 
       const glyphLine = /^ {2}\S /;
 
-      const pagesHeading = lines.find((line) => line.includes("Pages:"));
-      const apiHeading = lines.find((line) => line.includes("API:"));
+      const pagesIndex = lines.findIndex((line) => line.includes("Pages:"));
+      const apiIndex = lines.findIndex((line) => line.includes("API:"));
+
+      const pagesHeading = lines[pagesIndex];
+      const apiHeading = lines[apiIndex];
 
       assert(pagesHeading !== undefined, "expected a Pages: heading");
       assert(apiHeading !== undefined, "expected an API: heading");
@@ -154,6 +157,15 @@ describe("CLI routes command", () => {
       assert(
         glyphLine.test(apiHeading),
         `API heading is not indented/prefixed: ${JSON.stringify(apiHeading)}`,
+      );
+
+      // The blank separator is the other half of the fix: without it the two
+      // sections run together. Assert it explicitly so removing the
+      // `console.log("")` fails here rather than passing silently.
+      assert(apiIndex > pagesIndex, "expected the API section to follow the Pages section");
+      assert(
+        lines[apiIndex - 1] === "",
+        `expected a blank line before the API heading, got ${JSON.stringify(lines[apiIndex - 1])}`,
       );
 
       for (const line of lines) {

--- a/cli/commands/routes/routes.integration.test.ts
+++ b/cli/commands/routes/routes.integration.test.ts
@@ -1,10 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertStringIncludes } from "#veryfront/testing/assert";
+import { assert, assertStringIncludes } from "#veryfront/testing/assert";
 import { join } from "#veryfront/compat/path";
 import { describe, it } from "#veryfront/testing/bdd";
 import { mkdir, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { routesCommand } from "./index.ts";
 import { setJsonMode } from "../../shared/json-output.ts";
+import { setLoggerPreset } from "veryfront/utils/logger";
 import { type TestContext, withTestContext } from "../../../tests/_helpers/context.ts";
 
 async function setupPagesRouter(context: TestContext): Promise<void> {
@@ -54,6 +55,20 @@ async function captureConsoleLog(run: () => Promise<void>): Promise<string> {
   }
 
   return output.join("\n");
+}
+
+/** Strips SGR colour codes so assertions can look at the raw layout. */
+const ANSI_SGR = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+/** Renders the command through the real CLI logger preset and returns each printed line. */
+async function captureCliPresetLines(run: () => Promise<void>): Promise<string[]> {
+  setLoggerPreset("cli");
+  try {
+    const raw = await captureConsoleLog(run);
+    return raw.replace(ANSI_SGR, "").split("\n");
+  } finally {
+    setLoggerPreset("server");
+  }
 }
 
 describe("CLI routes command", () => {
@@ -111,6 +126,43 @@ describe("CLI routes command", () => {
       assertStringIncludes(text, "/blog/[slug] -> app/blog/[slug]/page.tsx");
       assertStringIncludes(text, "API:");
       assertStringIncludes(text, "/api/ag-ui -> app/api/ag-ui/route.ts");
+    });
+  });
+
+  // Regression: the section break used to be baked into the heading string as
+  // "\nAPI:", so the CLI logger prefixed the leading newline instead of the
+  // heading. That printed a bare "  ● " line followed by a flush-left "API:".
+  it("separates sections without a bare glyph line or an unprefixed heading", async () => {
+    await withTestContext("routes-section-layout", async (context: TestContext) => {
+      await setupAppRouter(context);
+
+      const lines = await captureCliPresetLines(async () => {
+        await routesCommand(context.projectDir);
+      });
+
+      const glyphLine = /^ {2}\S /;
+
+      const pagesHeading = lines.find((line) => line.includes("Pages:"));
+      const apiHeading = lines.find((line) => line.includes("API:"));
+
+      assert(pagesHeading !== undefined, "expected a Pages: heading");
+      assert(apiHeading !== undefined, "expected an API: heading");
+      assert(
+        glyphLine.test(pagesHeading),
+        `Pages heading is not indented/prefixed: ${JSON.stringify(pagesHeading)}`,
+      );
+      assert(
+        glyphLine.test(apiHeading),
+        `API heading is not indented/prefixed: ${JSON.stringify(apiHeading)}`,
+      );
+
+      for (const line of lines) {
+        if (line.trim() === "") continue;
+        assert(
+          !(glyphLine.test(line) && line.replace(glyphLine, "").trim() === ""),
+          `emitted a glyph-only line with no content: ${JSON.stringify(line)}`,
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
## Symptom

`veryfront routes` renders its two sections incorrectly — a bare bullet on an
otherwise empty line, then the `API:` heading printed flush-left with no bullet
while `Pages:` has one:

```
Veryfront (v0.1.1228)

  ● Pages:
  ●   / -> app/page.tsx
  ● 
API:
  ●   /api/ag-ui -> app/api/ag-ui/route.ts
```

Exit code is 0 — the routes are all discovered correctly, only the rendering is
broken. The scaffold's own `AGENTS.md` developer loop tells new developers to
run this command ("4. Verify discovered routes with `veryfront routes`"), so it
is one of the first commands a new user sees.

## Root cause

`cli/commands/routes/command.ts` emitted the second heading as:

```ts
cliLogger.info("\nAPI:");
```

In the CLI logger preset (`setLoggerPreset("cli")`, set in `cli/main.ts`), every
message is rendered as `  <glyph> <message>` — see `formatTextLine` in
`src/utils/logger/logger.ts`. The leading `\n` is inside the message, so the
single rendered line is `  ● \nAPI:`: the glyph ends up prefixing an empty
message, and the real heading lands on the next line outside the prefixing
wrapper.

## Fix

Emit the section break as its own blank line and hand the heading to the logger
by itself. This matches the "blank line between logical sections" rule in the
CLI output conventions and leaves both headings identically prefixed:

```
  ● Pages:
  ●   / -> app/page.tsx

  ● API:
  ●   /api/ag-ui -> app/api/ag-ui/route.ts
```

## Regression test

`cli/commands/routes/routes.integration.test.ts` —
`"separates sections without a bare glyph line or an unprefixed heading"`.

It lives there rather than in `veryfront-e2e` because the bug is fully
reproducible in-process: no browser, no deployment, no credentials. It runs in
the pre-push gate alongside the existing routes integration tests.

The three pre-existing tests in that file could not catch this: they capture
`console.log` while the logger is in the default `server` preset and assert with
`assertStringIncludes`, so both the bare glyph line and the lost indentation are
invisible to them. The new test drives the command through the real `cli`
preset, strips SGR colour codes, and asserts on line structure — that both
headings carry the `  <glyph> ` prefix, and that no emitted line is a glyph with
no content.

Confirmed failing before the fix, for the right reason:

```
error: AssertionError: API heading is not indented/prefixed: "API:"
```

## Verification

Original symptom reproduced against this tree before the change and gone after,
running the worktree CLI against a scaffold-shaped project:

```
# before
  ● Pages:
  ●   / -> app/page.tsx
  ● $
API:$
  ●   /api/ag-ui -> app/api/ag-ui/route.ts

# after
  ● Pages:
  ●   / -> app/page.tsx
$
  ● API:$
  ●   /api/ag-ui -> app/api/ag-ui/route.ts
```

`deno fmt --check`, `deno lint`, `deno check`, the `cli/commands/routes` and
`cli/utils` suites, and the full pre-push gate all pass.

## Provenance

Found by a DX dogfood walk of
https://veryfront.com/docs/code/getting-started/quickstart against published CLI
0.1.1228, following the `vf-dx-dogfood` skill.

## Out of scope

`cli/commands/lock/command.ts` has the same `cliLogger.info("\n…")` shape in two
places. Left alone deliberately — this PR is scoped to the one confirmed
finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route command output formatting by separating the `Pages:` and `API:` sections with a clean blank line.
  * Ensured section headings consistently include the expected CLI logger formatting.
  * Removed an unnecessary glyph-only line from route output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->