### PR TITLE
docs: use --target for the documented veryfront install commands

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -109,10 +109,10 @@ Use `npm create veryfront` when you want to scaffold a new project.
 ## Coding-agent setup
 
 Starter templates include `AGENTS.md`. For older projects, install the shared
-project guide:
+project guide with `--target agents`:
 
 ```bash
-veryfront install agents
+veryfront install --target agents
 ```
 
 Then run `veryfront dev` and connect your MCP-aware coding agent to the printed

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -26,17 +26,20 @@ bootstrap step, inference setup, and when to use https://veryfront.com/docs.
 For older projects, add the same guide with:
 
 ```bash
-veryfront install agents
+veryfront install --target agents
 ```
 
 Tool-specific files are still available:
 
 ```bash
-veryfront install claude-code
-veryfront install cursor
-veryfront install copilot
-veryfront install windsurf
+veryfront install --target claude-code
+veryfront install --target cursor
+veryfront install --target copilot
+veryfront install --target windsurf
 ```
+
+Running `veryfront install` without `--target` opens an interactive picker
+instead, preselecting the tools it detects in the project.
 
 Use `AGENTS.md` as the shared source of truth when multiple coding agents work
 in the same project.

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -39,7 +39,10 @@ veryfront install --target windsurf
 ```
 
 Running `veryfront install` without `--target` opens an interactive picker
-instead, preselecting the tools it detects in the project.
+instead, preselecting the tools it detects in the project. Without a TTY (in CI,
+behind a pipe, or from a coding agent) there is no prompt: the detected tools
+are installed immediately, and a project with nothing to detect gets `SKILL.md`.
+Always pass `--target` in non-interactive environments.
 
 Use `AGENTS.md` as the shared source of truth when multiple coding agents work
 in the same project.

--- a/tests/docs/cli-install-commands.test.ts
+++ b/tests/docs/cli-install-commands.test.ts
@@ -1,6 +1,11 @@
 /**
  * Docs contract: every `veryfront install ...` command printed in the published
- * docs must actually select the AI-tool target the surrounding prose promises.
+ * guide set must actually select the AI-tool target the surrounding prose
+ * promises. "Published" means the same three directories the sibling docs
+ * contracts scan (`guide-contracts.test.ts`, `guide-code-examples.test.ts`):
+ * getting-started, guides, concepts. Generated pages (`docs/api-reference`) and
+ * unpublished notes (`docs/internal`, `docs/rfcs`, `docs/evidence`) are out of
+ * scope — they may quote a broken invocation deliberately.
  *
  * The install command reads its target from `--target` only. A bare positional
  * (`veryfront install agents`) is silently ignored and the command falls back to

--- a/tests/docs/cli-install-commands.test.ts
+++ b/tests/docs/cli-install-commands.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Docs contract: every `veryfront install ...` command printed in the published
+ * docs must actually select the AI-tool target the surrounding prose promises.
+ *
+ * The install command reads its target from `--target` only. A bare positional
+ * (`veryfront install agents`) is silently ignored and the command falls back to
+ * auto-detection, which in a fresh project writes `SKILL.md` instead of the
+ * `AGENTS.md` the docs describe.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { parseCliArgs } from "../../cli/shared/args.ts";
+import { parseInstallArgs } from "../../cli/commands/install/handler.ts";
+import { parseTargetFlag } from "../../cli/commands/install/install.ts";
+import { getToolById } from "../../cli/commands/install/registry.ts";
+
+const DOC_DIRS = ["docs/getting-started", "docs/guides", "docs/concepts"] as const;
+
+interface DocumentedInstall {
+  file: string;
+  command: string;
+}
+
+async function listDocFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isDirectory) {
+      files.push(...await listDocFiles(path));
+    } else if (entry.isFile && entry.name.endsWith(".md")) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+/** Collect `veryfront install ...` lines from fenced shell blocks. */
+function extractInstallCommands(file: string, source: string): DocumentedInstall[] {
+  const found: DocumentedInstall[] = [];
+  let inShellFence = false;
+
+  for (const rawLine of source.split("\n")) {
+    const line = rawLine.trim();
+
+    if (line.startsWith("```")) {
+      const lang = line.slice(3).trim().toLowerCase();
+      inShellFence = inShellFence ? false : lang === "bash" || lang === "sh" || lang === "shell";
+      continue;
+    }
+
+    if (!inShellFence) continue;
+    if (!line.startsWith("veryfront install")) continue;
+
+    found.push({ file, command: line });
+  }
+
+  return found;
+}
+
+async function collectDocumentedInstalls(): Promise<DocumentedInstall[]> {
+  const commands: DocumentedInstall[] = [];
+  for (const dir of DOC_DIRS) {
+    for (const file of await listDocFiles(dir)) {
+      commands.push(...extractInstallCommands(file, await Deno.readTextFile(file)));
+    }
+  }
+  return commands.sort((a, b) => a.command.localeCompare(b.command));
+}
+
+/** Run a documented command line through the real CLI parsing pipeline. */
+function resolveTargets(command: string): string[] {
+  const argv = command.replace(/^veryfront\s+/, "").split(/\s+/).filter(Boolean);
+  const parsed = parseInstallArgs(parseCliArgs(argv));
+
+  assert(parsed.success, `\`${command}\` failed argument validation`);
+  if (parsed.data.target === undefined) return [];
+
+  return parseTargetFlag(parsed.data.target);
+}
+
+describe("docs: veryfront install commands", () => {
+  it("every documented install command selects a target non-interactively", async () => {
+    const documented = await collectDocumentedInstalls();
+    assert(documented.length > 0, "expected the docs to document `veryfront install`");
+
+    const ignored = documented.filter(({ command }) => resolveTargets(command).length === 0);
+
+    assertEquals(
+      ignored.map(({ file, command }) => `${file}: ${command}`),
+      [],
+      "these documented commands pass a target the CLI ignores; use `--target <id>`",
+    );
+  });
+
+  it("the pages that promise AGENTS.md document a command that writes AGENTS.md", async () => {
+    const pages = ["docs/getting-started/installation.md", "docs/guides/coding-agents.md"];
+
+    for (const page of pages) {
+      const source = await Deno.readTextFile(page);
+      assert(source.includes("AGENTS.md"), `${page} should describe AGENTS.md`);
+
+      const files = extractInstallCommands(page, source)
+        .flatMap(({ command }) => resolveTargets(command))
+        .map((id) => getToolById(id).file);
+
+      assert(
+        files.includes("AGENTS.md"),
+        `${page} promises AGENTS.md but documents no install command that writes it (writes: ${
+          files.join(", ") || "nothing"
+        })`,
+      );
+    }
+  });
+});

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -925,7 +925,7 @@ describe("Guide: installation.md", () => {
       "yarn global add veryfront",
       "bun add -g veryfront",
       "npx veryfront@latest",
-      "veryfront install agents",
+      "veryfront install --target agents",
       "veryfront --version",
     ];
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -635,7 +635,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "npm create veryfront",
       "npm install -g veryfront",
       "npx veryfront@latest",
-      "veryfront install agents",
+      "veryfront install --target agents",
     ],
   },
   "getting-started/create-agent.md": {


### PR DESCRIPTION
## Symptom

Found by a DX dogfood walk of https://veryfront.com/docs/code/getting-started/installation against published CLI **0.1.1228**.

The "Coding-agent setup" section says starter templates include `AGENTS.md` and that older projects can install the same guide with:

```bash
veryfront install agents
```

Running that in a fresh project writes a different file:

```
$ veryfront install agents

  Installing AI integrations...

  ✓ SKILL.md

  ✓ Your AI assistants now know Veryfront!
```

Exit 0, no warning. The reader is told they are getting `AGENTS.md` and ends up with `SKILL.md` — a file the surrounding docs never mention. The same wrong command form appears in `docs/guides/coding-agents.md`, including the four tool-specific one-liners (`veryfront install claude-code`, `cursor`, `copilot`, `windsurf`).

Reproduced against this tree at `fe5d5b895` (the v0.1.1228 release commit), so it is not already fixed.

## Root cause

`install` takes its tool target from `--target` only:

```ts
// cli/commands/install/handler.ts
export const parseInstallArgs = createArgParser(InstallArgsSchema, {
  target: { keys: ["target", "t"], type: "string" },
  ...
});
```

There is no `positional` spec, so the bare `agents` token lands in `args._` and is dropped. `installCommand` then sees `target === undefined` and falls through to the interactive picker; in a non-TTY it returns the auto-detected defaults, and `detect.ts` marks `skill` as always-suggested and `agents` as never auto-detected — hence `SKILL.md`.

`veryfront install --target agents` writes `AGENTS.md` exactly as the prose describes, so the CLI behaviour is intact and the documented invocation was wrong. This is filed as a doc bug per the dogfood classification. Making the positional an alias for `--target` would be the alternative fix; that is a CLI behaviour change and is deliberately out of scope here.

## Fix

Corrects the documented invocations to the supported `--target` form in `docs/getting-started/installation.md` and `docs/guides/coding-agents.md`, and adds one sentence noting that the flagless form opens the interactive picker. No CLI code changed.

## Regression test

`tests/docs/cli-install-commands.test.ts` (Deno BDD).

It lives in `tests/docs/` because that is where this repo already keeps docs-contract tests that read `docs/**` (`guide-contracts.test.ts`, `guide-code-examples.test.ts`), and because the bug is fully reproducible in-process — no browser, no deployment, no credentials — so it runs in the pre-push gate.

The test does not hard-code the corrected string. It extracts every `veryfront install ...` line from shell fences under `docs/getting-started`, `docs/guides` and `docs/concepts`, feeds each through the real `parseCliArgs` → `parseInstallArgs` → `parseTargetFlag` pipeline, and asserts:

1. every documented install command actually selects a target instead of being silently ignored, and
2. the pages that promise `AGENTS.md` document a command whose resolved target maps to `AGENTS.md` in the install registry.

Confirmed failing before the doc change, for the right reason:

```
- [
-   "docs/getting-started/installation.md: veryfront install agents",
-   "docs/guides/coding-agents.md: veryfront install agents",
-   "docs/guides/coding-agents.md: veryfront install claude-code",
-   "docs/guides/coding-agents.md: veryfront install copilot",
-   "docs/guides/coding-agents.md: veryfront install cursor",
-   "docs/guides/coding-agents.md: veryfront install windsurf",
- ]
+ []

AssertionError: docs/getting-started/installation.md promises AGENTS.md but
documents no install command that writes it (writes: nothing)
```

Two existing contracts pinned the old snippet (`tests/docs/guide-contracts.test.ts`, `tests/docs/guide-code-examples.test.ts`); both are updated to the corrected form.

## Verification

- `deno test tests/docs/` — 51 passed, 0 failed
- `deno test cli/commands/install/` — 15 passed, 0 failed
- `deno task docs:validate` — all 1226 doc links OK
- Original symptom rerun against this worktree's build: `veryfront install --target agents` → `✓ AGENTS.md`
- Full pre-push suite passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use the `veryfront install --target <agent>` command format.
  * Added guidance for interactive target selection when running `veryfront install` without a target.
  * Clarified setup steps for tools that generate `AGENTS.md`.

* **Tests**
  * Added automated checks to ensure documented installation commands specify valid targets.
  * Updated documentation tests for the new command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->