### PR TITLE
fix(deno): recognize Deno's npm-referrer missing-package error

### DIFF
--- a/src/extensions/first-party-import.test.ts
+++ b/src/extensions/first-party-import.test.ts
@@ -320,6 +320,39 @@ describe("first-party extension imports", () => {
       );
     });
 
+    it("parses the Deno npm-referrer missing-package shape", () => {
+      // Deno reports an unresolvable npm package differently when the importer
+      // itself lives inside the npm cache, which is exactly what a scaffolded
+      // `deno task dev` hits while probing optional first-party extensions.
+      const denoNpmReferrer = Object.assign(
+        new Error(
+          `Could not find package '@veryfront/ext-auth-jwt' from referrer 'file:///app/node_modules/.deno/veryfront@0.1.0/node_modules/veryfront/esm/src/extensions/first-party-import.js'.`,
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(denoNpmReferrer, [
+          "@veryfront/ext-auth-jwt",
+        ]),
+        true,
+      );
+
+      // A broken transitive dependency of an installed extension must still be
+      // surfaced rather than swallowed as "extension not installed".
+      const transitiveFailure = Object.assign(
+        new Error(
+          `Could not find package 'jose' from referrer 'file:///app/node_modules/@veryfront/ext-auth-jwt/esm/src/index.js'.`,
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(transitiveFailure, [
+          "@veryfront/ext-auth-jwt",
+        ]),
+        false,
+      );
+    });
+
     it("parses Bun relative, package, and object-shaped missing-module errors", () => {
       const relativeError = Object.assign(
         new Error(

--- a/src/extensions/first-party-import.ts
+++ b/src/extensions/first-party-import.ts
@@ -318,6 +318,8 @@ function reportedMissingSpecifier(message: string): string | undefined {
     const pattern of [
       /^Cannot find module\s+["']([^"']+)["']\nRequire stack:(?:\n- [^\r\n]+)+$/,
       /^(?:Cannot find package|Cannot find module|Module not found)\s+["']([^"']+)["'](?:(?:\s+imported from\s+.+)|\.)?$/,
+      // Deno, when the importer itself resolves out of the npm cache.
+      /^Could not find package\s+["']([^"']+)["']\s+from referrer\s+["'][^"']+["']\.?$/,
       /^Import\s+["']([^"']+)["']\s+not a dependency(?: and not in import map)?(?:\s+from\s+.+)?$/,
       /^Unable to resolve\s+["']([^"']+)["'](?:\s+from\s+.+)?$/,
     ]


### PR DESCRIPTION
Found by a DX dogfood walk of https://veryfront.com/docs/code/getting-started/create-project against published CLI **0.1.1228**.

## Symptom

The documented Deno path is dead on arrival. Scaffold succeeds and prints `cd test-app` / `deno task dev`, but the very next documented command never binds a port:

```
$ veryfront init test-app --template ai-agent --runtime deno
  ✓ test-app ready
  cd test-app
  deno task dev

$ deno task dev
Task dev deno run -A npm:veryfront@0.1.1228 dev
Veryfront (v0.1.1228)

✗ [unknown-error] Unknown/unclassified error

  Detail: Could not find package '@veryfront/ext-auth-jwt' from referrer
  'file:///.../test-app/node_modules/.deno/veryfront@0.1.1228/node_modules/veryfront/esm/src/extensions/first-party-import.js'.
  Suggestion: Check logs for more details
```

`curl` → 000, the server never starts. Reproduced twice. The equivalent `--runtime bun` scaffold works, so this is Deno-specific.

## Root cause

`@veryfront/ext-auth-jwt` is `builtin-deferred` with `rootNpm: false` (`src/extensions/first-party-defaults.ts`) — it is deliberately *not* a dependency of the root npm package. Failing to import it is the expected path, and `createOptionalBuiltinExtension` is supposed to swallow that failure via `isMissingFirstPartyExtensionModule`.

The classifier never got the chance. A `--runtime deno` scaffold runs its tasks as `deno run -A npm:veryfront@<version>`, so the extension probe is issued from a referrer *inside the npm cache*. In that configuration Deno words the resolution failure as:

```
Could not find package 'X' from referrer 'file:///...'.
```

`reportedMissingSpecifier` recognized `Cannot find package …`, `Cannot find module … from …`, `Import "…" not a dependency`, and `Unable to resolve …`, but not `Could not find package … from referrer …`. `error.code` is `ERR_MODULE_NOT_FOUND`, so `isMissingModuleError` said yes, but the anchored specifier could not be extracted — and the function fails closed, returning `false`. The optional-builtin handler then rethrew, and boot died.

Fix: add the referrer shape to the recognized resolver messages. One anchored pattern, no behaviour change anywhere else.

## Regression test

`src/extensions/first-party-import.test.ts` — Deno BDD, alongside the existing per-runtime message-shape cases (`parses exact Deno and Node package-subpath error shapes`, `parses Bun relative, package, and object-shaped missing-module errors`). It lives there rather than in `veryfront-e2e` because the defect is a pure string-classification bug: it needs no browser, no deployment, and no credentials, and it runs in the pre-push gate.

The new case asserts both directions, which is the point of this classifier:

- `Could not find package '@veryfront/ext-auth-jwt' from referrer '…/node_modules/.deno/veryfront@…/…/first-party-import.js'.` anchored on `@veryfront/ext-auth-jwt` → `true` (tolerate: extension genuinely not installed).
- `Could not find package 'jose' from referrer '…/node_modules/@veryfront/ext-auth-jwt/esm/src/index.js'.` anchored on `@veryfront/ext-auth-jwt` → `false` (surface: a broken transitive dependency of an *installed* extension must not be misread as "not installed").

The test was written first and confirmed failing on the first assertion (`Values are not equal: false / true`) before the one-line fix landed.

## Verification of the original symptom

Reproduced end to end in a sandbox outside the repo with the published CLI pinned at 0.1.1228, then re-ran the exact documented command with the same pattern applied to the scaffold's resolved copy of `first-party-import.js`:

```
$ deno task dev
Veryfront (v0.1.1228)
  ✓ Ready in 509ms
  http://veryfront.me:3000

$ curl -o /dev/null -w '%{http_code}' http://veryfront.me:3000/
200
```

Before: no bind, `000`. After: `200`.

Full pre-push suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of missing first-party extensions in Deno npm cache error messages.
  * Prevented missing transitive dependencies from being incorrectly classified as absent extensions.

* **Tests**
  * Added coverage for Deno npm-referrer missing-package error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->