### PR TITLE
fix(discovery): bind project discovery to the running framework install

### DIFF
--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -471,6 +471,86 @@ describe("discovery/import-rewriter", () => {
     }
   });
 
+  it("binds discovery imports to the running framework install when the CLI runs from another install", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    await Deno.mkdir(`${veryfrontDir}/local`, { recursive: true });
+    await Deno.writeTextFile(
+      `${veryfrontDir}/package.json`,
+      JSON.stringify({
+        name: "veryfront",
+        version: "0.0.0-project-local",
+        exports: {
+          "./schemas": "./local/schemas.js",
+          "./tool": "./local/tool.js",
+        },
+      }),
+    );
+    await Deno.writeTextFile(`${veryfrontDir}/local/schemas.js`, "");
+    await Deno.writeTextFile(`${veryfrontDir}/local/tool.js`, "");
+
+    const globalInstall = "file:///opt/npm/lib/node_modules/veryfront";
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        [
+          'import { defineSchema } from "veryfront/schemas";',
+          'import { tool } from "veryfront/tool";',
+        ].join("\n"),
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/tools`,
+        {
+          resolveSpecifier: (specifier) =>
+            `${globalInstall}/esm/src/${specifier.replace("veryfront/", "")}/index.js`,
+        },
+      );
+
+      // The project copy is a *second* framework instance: nothing bootstraps
+      // its extension contracts, so `defineSchema()` there throws
+      // `Missing extension for contract "SchemaValidator"` and the project's
+      // tools never register.
+      assertStringIncludes(transformed, `${globalInstall}/esm/src/schemas/index.js`);
+      assertStringIncludes(transformed, `${globalInstall}/esm/src/tool/index.js`);
+      assertEquals(transformed.includes("node_modules/veryfront/local/"), false);
+      assertEquals(transformed.includes('from "veryfront/'), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("keeps project-local veryfront exports when the running install is the project's own", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const veryfrontDir = `${projectDir}/node_modules/veryfront`;
+    await Deno.mkdir(`${veryfrontDir}/local`, { recursive: true });
+    await Deno.writeTextFile(
+      `${veryfrontDir}/package.json`,
+      JSON.stringify({
+        name: "veryfront",
+        version: "0.0.0-project-local",
+        exports: { "./schemas": "./local/schemas.js" },
+      }),
+    );
+    await Deno.writeTextFile(`${veryfrontDir}/local/schemas.js`, "");
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        'import { defineSchema } from "veryfront/schemas";',
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/tools`,
+        {
+          resolveSpecifier: () => `file://${veryfrontDir}/esm/src/schemas/index.js`,
+        },
+      );
+
+      assertStringIncludes(transformed, `${projectDir}/node_modules/veryfront/local/schemas.js`);
+      assertEquals(transformed.includes("esm/src/schemas/index.js"), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("resolves project-local veryfront exports when projectDir is relative", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
     const veryfrontDir = `${projectDir}/node_modules/veryfront`;

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -214,6 +214,28 @@ const resolvedSpecifierCache = new LRUCache<string, string>({
   maxEntries: RESOLVED_SPECIFIER_CACHE_MAX_ENTRIES,
 });
 
+const NODE_MODULES_VERYFRONT_SEGMENT = "/node_modules/veryfront/";
+
+/**
+ * The installed `veryfront` package a resolved framework module belongs to, or
+ * `null` when the running framework is not an npm install (source checkouts,
+ * `jsr:`/`https:` specifiers).
+ */
+function getInstalledVeryfrontPackageUrl(moduleUrl: string): string | null {
+  if (!moduleUrl.startsWith("file://")) return null;
+  const index = moduleUrl.lastIndexOf(NODE_MODULES_VERYFRONT_SEGMENT);
+  if (index === -1) return null;
+  return moduleUrl.slice(0, index + NODE_MODULES_VERYFRONT_SEGMENT.length - 1);
+}
+
+interface DiscoveryRewriteOptions {
+  /**
+   * Resolves a bare specifier against the framework instance executing this
+   * process. Defaults to `import.meta.resolve`; injectable for tests.
+   */
+  resolveSpecifier?: (specifier: string) => string;
+}
+
 /**
  * Rewrite imports for Node.js runtime
  * - Resolves relative imports to file:// URLs
@@ -225,6 +247,7 @@ export async function rewriteDiscoveryImports(
   projectDir: string,
   fs: ReturnType<typeof createFileSystem>,
   fileDir: string,
+  options: DiscoveryRewriteOptions = {},
 ): Promise<string> {
   let transformed = code;
 
@@ -362,9 +385,12 @@ export async function rewriteDiscoveryImports(
       transformed = rewritePackageImports(transformed, pkg, resolvedUrl);
     }
 
+    const resolveSpecifier = options.resolveSpecifier ??
+      ((specifier: string) => import.meta.resolve(specifier));
+
     const resolveRuntimeSpecifierToFileUrl = (specifier: string): string | null => {
       try {
-        const resolved = import.meta.resolve(specifier);
+        const resolved = resolveSpecifier(specifier);
         return resolved && resolved !== specifier ? resolved : null;
       } catch (_) {
         return null;
@@ -468,8 +494,37 @@ export async function rewriteDiscoveryImports(
       return { kind: "resolved", url: pathToFileURL(resolvedPath).href };
     };
 
+    // Discovery modules are emitted outside the project tree, so they must be
+    // bound to the framework instance that is actually executing: registries
+    // that discovered primitives land in (extension contracts, tool registry)
+    // are module-local to that instance. The project's own package is normally
+    // that instance — a project-local CLI launch — and stays preferred.
+    //
+    // A globally installed CLI runs from a *different* npm install. Binding
+    // there would load a second framework instance whose extension contracts
+    // were never bootstrapped, so `defineSchema()` throws
+    // `Missing extension for contract "SchemaValidator"`, tool discovery aborts
+    // for that file, and the project's tools silently never register.
+    const projectVeryfrontPackageUrl = veryfrontExportSource.kind === "present"
+      ? pathToFileURL(veryfrontExportSource.packagePath).href.replace(/\/$/, "")
+      : null;
+
     for (const specifier of veryfrontSpecifiers) {
       if (veryfrontExportSource.kind === "absent") continue;
+
+      const runtimeUrl = resolveRuntimeSpecifierToFileUrl(specifier);
+      const runningPackageUrl = runtimeUrl === null
+        ? null
+        : getInstalledVeryfrontPackageUrl(runtimeUrl);
+      if (
+        runtimeUrl !== null &&
+        runningPackageUrl !== null &&
+        runningPackageUrl !== projectVeryfrontPackageUrl
+      ) {
+        transformed = rewriteResolvedSpecifierImports(transformed, specifier, runtimeUrl);
+        continue;
+      }
+
       const result = resolveVeryfrontExportToFileUrl(specifier);
       if (result.kind === "resolved") {
         transformed = rewriteResolvedSpecifierImports(transformed, specifier, result.url);


### PR DESCRIPTION
Found by a DX dogfood walk of https://veryfront.com/docs/code/getting-started/create-project against published CLI **0.1.1228**, installed the way the installation page tells you to (`npm install -g veryfront`).

## Symptom

```
veryfront init clean-app --template ai-agent
cd clean-app
veryfront dev --port 3222      # then click the template's "Run the numbers" suggestion
```

The app boots and renders with a clean browser console, but **every** chat message fails — including the template's own built-in suggestion buttons:

```
event: RunError
data: {"message":"Unknown tool reference: calculator. Tool names must exactly match
tool({ id: \"...\" }). Available tools: execute_skill_script, load_skill, load_skill_reference"}
```

`tools/calculator.ts` in the scaffold declares `id: "calculator"` exactly. With `VERYFRONT_DEBUG=1` the real failure is visible at boot:

```
● Found 1 tool files in /…/clean-app/tools
✗ Error loading file:///…/clean-app/tools/calculator.ts:
    err=VeryfrontError: Missing extension for contract "SchemaValidator".
        Install it with: deno add @veryfront/ext-schema-zod
● Found 1 agent files in /…/clean-app/agents
· [Discovery] Registered 0 tools, 1 agents, …
```

It is specific to the launcher. Same project, same 0.1.1228, cache cleared:

| Launcher | Result |
|---|---|
| `veryfront dev` (global npm install) | broken — `agents/` loads, `tools/` does not |
| `npm run dev` (`node_modules/.bin/veryfront`) | works |
| `bun run dev` (`--runtime bun` scaffold) | works |

## Root cause

`rewriteDiscoveryImports` rewrites bare `veryfront/*` imports in discovered project files to the project's own `node_modules/veryfront` package (#3037 — discovery modules are emitted outside the project tree, so they must not resolve by chance).

That is correct when the CLI *is* the project's install. A globally installed CLI runs from a different install, so the project copy becomes a **second framework instance** in the same process — and nothing ever bootstraps its extension contracts. `defineSchema()` in that instance resolves `SchemaValidator` against an empty contract registry and throws. Tool discovery catches the error per file, so the project registers 0 tools; `agents/assistant.ts` imports only `veryfront/agent`, which needs no contract, so agents keep loading and the failure only surfaces later as `Unknown tool reference`.

`ext-schema-zod` is bundled in the package and *is* loaded — just into the CLI's instance, not the project copy's. Hence the misleading "install it with `deno add`" advice.

## Fix

Prefer the framework install that is actually executing when it is a different npm install than the project's. The project-local preference from #3037 is unchanged everywhere it was already right:

* project-local CLI launch — running install *is* the project's copy, no change;
* source checkouts and `jsr:` / `https:` runtimes — not an npm install, so the rule never triggers and the existing fail-closed behaviour for a present-but-unreadable project package is preserved.

## Regression test

`src/discovery/import-rewriter.test.ts` — Deno BDD, alongside the eight existing tests that pin this exact resolution decision.

* `binds discovery imports to the running framework install when the CLI runs from another install` — fails before the fix, resolving to `<project>/node_modules/veryfront/local/schemas.js` instead of the running install.
* `keeps project-local veryfront exports when the running install is the project's own` — pins the #3037 behaviour that must not regress.

It lives in `veryfront-code` rather than `veryfront-e2e` because the defect is pure module resolution: reproducible in-process, no browser, no deployment, no credentials — so it runs in the pre-push gate. The runtime resolver is injected through a new optional `resolveSpecifier` option (mirroring `rewriteForDeno`'s existing seam) so a test can stand in for a globally installed CLI deterministically.

## Verification

Beyond the unit test, the same change was applied to the published 0.1.1228 artifact and the finding's command re-run against a freshly scaffolded `ai-agent` project:

```
● Found 1 tool files in /…/clean-app/tools
· [tool] Registered "calculator" for scope __default__
· [Discovery] Registered 1 tools, 1 agents, …
… /api/ag-ui … agents=1 tools=1 errors=0
```

Zero occurrences of `Unknown tool reference` (was one per message). Full pre-push suite passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery import resolution when the CLI runs from a different framework installation.
  * Ensured imports use the active framework installation when appropriate, while preserving project-local exports when installations match.

* **Tests**
  * Added coverage for matching and differing framework installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->