### PR TITLE
fix(deno): recognize the npm-referrer miss that names the owning package

### DIFF
--- a/src/extensions/first-party-import.test.ts
+++ b/src/extensions/first-party-import.test.ts
@@ -353,6 +353,40 @@ describe("first-party extension imports", () => {
       );
     });
 
+    it("parses the Deno npm-referrer shape when it names the owning package", () => {
+      // `deno add npm:veryfront` / `deno install -g npm:veryfront` resolve the
+      // CLI out of the global Deno npm cache, and from that referrer Deno
+      // appends the owning package identifier to the message. Home directory
+      // redacted; only the trailing ` (pkg@version)` suffix is under test.
+      const denoCacheReferrer = Object.assign(
+        new Error(
+          `Could not find package '@veryfront/ext-db-sqlite' from referrer 'file:///home/<redacted>/.cache/deno/npm/registry.npmjs.org/veryfront/0.1.1228/esm/src/extensions/first-party-import.js' (veryfront@0.1.1228).`,
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(denoCacheReferrer, [
+          "@veryfront/ext-db-sqlite",
+        ]),
+        true,
+      );
+
+      // The owning-package suffix must not turn a transitive dependency
+      // failure inside an installed extension into a tolerated skip.
+      const transitiveFromCache = Object.assign(
+        new Error(
+          `Could not find package 'jose' from referrer 'file:///home/<redacted>/.cache/deno/npm/registry.npmjs.org/@veryfront/ext-auth-jwt/0.1.1228/esm/src/index.js' (@veryfront/ext-auth-jwt@0.1.1228).`,
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(transitiveFromCache, [
+          "@veryfront/ext-auth-jwt",
+        ]),
+        false,
+      );
+    });
+
     it("parses Bun relative, package, and object-shaped missing-module errors", () => {
       const relativeError = Object.assign(
         new Error(

--- a/src/extensions/first-party-import.ts
+++ b/src/extensions/first-party-import.ts
@@ -318,8 +318,10 @@ function reportedMissingSpecifier(message: string): string | undefined {
     const pattern of [
       /^Cannot find module\s+["']([^"']+)["']\nRequire stack:(?:\n- [^\r\n]+)+$/,
       /^(?:Cannot find package|Cannot find module|Module not found)\s+["']([^"']+)["'](?:(?:\s+imported from\s+.+)|\.)?$/,
-      // Deno, when the importer itself resolves out of the npm cache.
-      /^Could not find package\s+["']([^"']+)["']\s+from referrer\s+["'][^"']+["']\.?$/,
+      // Deno, when the importer itself resolves out of the npm cache. The
+      // trailing parenthetical names the owning package when the referrer
+      // lives in the global Deno npm cache (`deno add npm:veryfront`).
+      /^Could not find package\s+["']([^"']+)["']\s+from referrer\s+["'][^"']+["'](?:\s+\([^()]*\))?\.?$/,
       /^Import\s+["']([^"']+)["']\s+not a dependency(?: and not in import map)?(?:\s+from\s+.+)?$/,
       /^Unable to resolve\s+["']([^"']+)["'](?:\s+from\s+.+)?$/,
     ]


### PR DESCRIPTION
Found during a DX dogfood walk of https://veryfront.com/docs/code/getting-started/installation, which advertises Deno as a first-class runtime (`deno add npm:veryfront`, "Deno 1.45 or later").

## Symptom

The published `veryfront` CLI was dead on arrival under Deno. Every command exited 1 before anything bound:

```
$ deno install -g -A -f -n veryfront npm:veryfront
$ veryfront dev
  Veryfront (v0.1.1228)
  ✗ [unknown-error] Unknown/unclassified error
    Detail: Could not find package '@veryfront/ext-auth-jwt' from referrer
    '…/esm/src/extensions/first-party-import.js' (veryfront@0.1.1228).
```

Installing the named package only advanced the chain to the next one (`@veryfront/ext-db-sqlite`, …). The same node_modules tree started fine under Node.

## Root cause

Not a missing dependency. The root npm package depends only on `STANDARD_ROOT_NPM_EXTENSION_DIRECTORIES` **by design** (`src/extensions/first-party-defaults.ts`) — the other first-party extensions are `builtin-deferred`/`builtin-direct` and are meant to degrade to "not installed" when absent. `loadOptionalBuiltinExtension` already implements that skip, gated on `isMissingFirstPartyExtensionModule`, which classifies a failed dynamic import by parsing the runtime's message.

#3560 landed the bare Deno npm-resolver shape while this branch was open:

```
Could not find package 'X' from referrer 'Y'.
```

That covers `deno task dev` in a scaffolded project, where the referrer sits in a local `node_modules/.deno/…` tree. It does **not** cover the documented global install path. When the referrer resolves out of the *global* Deno npm cache — `deno add npm:veryfront`, `deno install -g npm:veryfront` — Deno appends the owning package identifier:

```
Could not find package 'X' from referrer 'Y' (veryfront@0.1.1228).
```

The trailing parenthetical leaves the message unparsed, `reportedMissingSpecifier` returns `undefined`, the error is not recognised as "extension not installed", and it is rethrown as fatal. So on the documented install path the intentional optional-extension split still turned into a hard startup crash on the first optional extension.

## Fix

One optional group on the pattern #3560 added: ` (pkg@version)`. Nothing else changes.

## Regression test

`src/extensions/first-party-import.test.ts`, beside the existing per-runtime message-shape cases where this classifier's runtime-message contract is already pinned. It covers the global-cache referrer with the trailing package identifier, plus a negative case proving the suffix does not let a genuinely broken transitive dependency inside an *installed* extension (`Could not find package 'jose' from referrer '…/@veryfront/ext-auth-jwt/…' (@veryfront/ext-auth-jwt@0.1.1228).`) be swallowed as "not installed".

Confirmed failing before the fix (`false` where `true` is expected) and passing after. Home directory in the fixture referrer is a redacted placeholder; only the message shape is under test.
