### PR TITLE
docs(chat): wire a Markdown renderer into the chat page samples

### DIFF
--- a/docs/getting-started/create-frontend.md
+++ b/docs/getting-started/create-frontend.md
@@ -19,20 +19,65 @@ Replace `app/page.tsx` with a client page:
 "use client";
 
 import { Chat, useChat } from "veryfront/chat";
+import { MarkdownRendererProvider } from "veryfront/markdown";
+import { MarkdownRenderer } from "./markdown-renderer.tsx";
 
 export default function Home() {
   const chat = useChat();
 
-  return <Chat chat={chat} placeholder="Ask me anything..." />;
+  return (
+    <MarkdownRendererProvider renderer={MarkdownRenderer}>
+      <Chat chat={chat} placeholder="Ask me anything..." />
+    </MarkdownRendererProvider>
+  );
 }
 ```
 
 `useChat()` uses `/api/ag-ui` by default. `Chat` renders the composer,
 messages, loading state, and streamed assistant response.
 
+Keep the `MarkdownRendererProvider` wrapper. Assistants answer in Markdown, and
+`veryfront/markdown` presents plain escaped source until a renderer is
+installed, so a `<Chat>` without one shows `- **Static type checking**` instead
+of a bulleted list.
+
+## Supply the Markdown renderer
+
+`veryfront init` already scaffolds `app/markdown-renderer.tsx`, so a project
+created with [Create project](./create-project.md) has this file. Create it
+yourself if you added Veryfront to an existing project:
+
+```bash
+npm install react-markdown@9.0.3 remark-gfm@4.0.1
+```
+
+```tsx
+// app/markdown-renderer.tsx
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { MarkdownRendererProps } from "veryfront/markdown";
+
+export function MarkdownRenderer({ source }: MarkdownRendererProps): React.JSX.Element {
+  return <ReactMarkdown remarkPlugins={[remarkGfm]}>{source}</ReactMarkdown>;
+}
+```
+
+Pin the parser to an exact version: these packages reach the browser through the
+module pipeline, where a floating range resolves to whatever is latest at
+request time. Your renderer owns parsing, sanitization, and link policy. See
+[Render Markdown in chat](../guides/chat-ui.md#render-markdown-in-chat) to swap
+in a different renderer.
+
 ## Verify it worked
 
-Open [http://localhost:3000](http://localhost:3000), send a message, and ensure
-the assistant response streams into the chat.
+Open [http://localhost:3000](http://localhost:3000), send a message, and confirm:
+
+- The assistant response streams into the chat.
+- Ask for a bulleted list. The reply renders as formatted Markdown, not raw
+  Markdown source: bullets and bold text, with no literal `-` or `**` markers
+  and no `` ``` `` fences.
+- The browser console reports no missing-Markdown-renderer warning.
 
 For custom layouts, see [Chat UI](../guides/chat-ui.md).

--- a/docs/getting-started/create-frontend.md
+++ b/docs/getting-started/create-frontend.md
@@ -43,12 +43,14 @@ of a bulleted list.
 
 ## Supply the Markdown renderer
 
-`veryfront init` already scaffolds `app/markdown-renderer.tsx`, so a project
-created with [Create project](./create-project.md) has this file. Create it
-yourself if you added Veryfront to an existing project:
+[Create project](./create-project.md) preselects the `ai-agent` template, and
+that starter, like the other chat starters, scaffolds
+`app/markdown-renderer.tsx`, so those projects already have this file. Create it
+yourself if yours does not: the `minimal` and `agentic-workflow` templates ship
+without a renderer, as does a project you added Veryfront to.
 
 ```bash
-npm install react-markdown@9.0.3 remark-gfm@4.0.1
+npm install --save-exact react-markdown@9.0.3 remark-gfm@4.0.1
 ```
 
 ```tsx
@@ -64,9 +66,9 @@ export function MarkdownRenderer({ source }: MarkdownRendererProps): React.JSX.E
 }
 ```
 
-Pin the parser to an exact version: these packages reach the browser through the
-module pipeline, where a floating range resolves to whatever is latest at
-request time. Your renderer owns parsing, sanitization, and link policy. See
+`--save-exact` matters: these packages reach the browser through the module
+pipeline, where a floating `^` range resolves to whatever is latest at request
+time. Your renderer owns parsing, sanitization, and link policy. See
 [Render Markdown in chat](../guides/chat-ui.md#render-markdown-in-chat) to swap
 in a different renderer.
 

--- a/docs/guides/chat-ui.md
+++ b/docs/guides/chat-ui.md
@@ -42,9 +42,10 @@ message list, loading state, and scroll behavior.
 The `MarkdownRendererProvider` wrapper is required for readable answers.
 Assistants reply in Markdown, and `veryfront/markdown` presents plain escaped
 source until a renderer is installed, so a `<Chat>` without one shows
-`## Heading` rather than a heading. Every starter scaffolds the
-`app/markdown-renderer.tsx` this sample imports; if you added Veryfront to an
-existing project, create it first. See
+`## Heading` rather than a heading. The chat starters scaffold the
+`app/markdown-renderer.tsx` this sample imports; the `minimal` and
+`agentic-workflow` templates do not. Create the file first if your project does
+not already have it. See
 [Render Markdown in chat](#render-markdown-in-chat). Wrap the other samples on
 this page the same way.
 
@@ -326,10 +327,12 @@ installed, so `<Chat>` shows raw Markdown on its own. Every chat starter
 scaffolds a renderer in `app/markdown-renderer.tsx` and installs it around
 `<Chat>`, so a new project renders assistant answers with no extra setup.
 
-Add the same two pieces to an existing project. Install the parser:
+Add the same two pieces to a project without one. Install the parser, pinned to
+an exact version: these packages reach the browser through the module pipeline,
+where a floating `^` range resolves to whatever is latest at request time.
 
 ```bash
-npm install react-markdown@9.0.3 remark-gfm@4.0.1
+npm install --save-exact react-markdown@9.0.3 remark-gfm@4.0.1
 ```
 
 Then create the renderer and install it for the chat subtree:

--- a/docs/guides/chat-ui.md
+++ b/docs/guides/chat-ui.md
@@ -23,15 +23,30 @@ Create a client page:
 // app/page.tsx
 "use client";
 import { Chat, useChat } from "veryfront/chat";
+import { MarkdownRendererProvider } from "veryfront/markdown";
+import { MarkdownRenderer } from "./markdown-renderer.tsx";
 
 export default function ChatPage() {
   const chat = useChat();
-  return <Chat chat={chat} placeholder="Ask me anything..." />;
+  return (
+    <MarkdownRendererProvider renderer={MarkdownRenderer}>
+      <Chat chat={chat} placeholder="Ask me anything..." />
+    </MarkdownRendererProvider>
+  );
 }
 ```
 
 `useChat()` connects to `/api/ag-ui` by default. `Chat` renders the composer,
 message list, loading state, and scroll behavior.
+
+The `MarkdownRendererProvider` wrapper is required for readable answers.
+Assistants reply in Markdown, and `veryfront/markdown` presents plain escaped
+source until a renderer is installed, so a `<Chat>` without one shows
+`## Heading` rather than a heading. Every starter scaffolds the
+`app/markdown-renderer.tsx` this sample imports; if you added Veryfront to an
+existing project, create it first. See
+[Render Markdown in chat](#render-markdown-in-chat). Wrap the other samples on
+this page the same way.
 
 ## Add request preprocessing
 
@@ -468,6 +483,9 @@ Run `veryfront dev` and open the page that renders the chat UI:
 - A chat using `memoryConversationStore()` starts empty after a page reload.
 - Standalone Markdown source is escaped and readable in the initial server
   HTML; an injected renderer is used only in the subtree where it is installed.
+- An assistant answer containing a list or a heading renders as formatted
+  Markdown, not raw Markdown source, and the browser console reports no
+  missing-Markdown-renderer warning.
 
 If the assistant response is empty, check the dev-server log for provider or
 agent errors and confirm the AG-UI route is mounted.

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -358,4 +358,64 @@ describe("guide content contracts", () => {
     );
     assertEquals(installation.includes("Deno 1.45"), false);
   });
+
+  it("wires a Markdown renderer into every chat page the docs tell you to write", async () => {
+    // `veryfront/markdown` presents plain escaped source until a renderer is
+    // installed, so a `<Chat>` built without one shows the assistant's raw
+    // Markdown. Every starter scaffolds `app/markdown-renderer.tsx` and the
+    // provider around `<Chat>`; a copy-paste sample that drops them is a
+    // silent downgrade from the scaffold the reader already has.
+    for (
+      const path of [
+        "docs/getting-started/create-frontend.md",
+        "docs/guides/chat-ui.md",
+      ]
+    ) {
+      const guide = await Deno.readTextFile(path);
+      const pageSample = firstFencedBlockContaining(guide, "// app/page.tsx");
+
+      assert(
+        pageSample !== undefined,
+        `${path}: expected an app/page.tsx sample`,
+      );
+      assertStringIncludes(pageSample, "MarkdownRendererProvider");
+      assertStringIncludes(pageSample, 'from "veryfront/markdown"');
+      assertStringIncludes(pageSample, "./markdown-renderer.tsx");
+
+      // The reader must be able to create the file the sample imports.
+      assertStringIncludes(guide, "app/markdown-renderer.tsx");
+      assertStringIncludes(guide, "MarkdownRendererProps");
+
+      // "Verify it worked" must fail when the chat renders raw source,
+      // otherwise the checklist passes on a visibly broken chat.
+      assertStringIncludes(
+        verifyItWorkedSection(guide),
+        "not raw Markdown source",
+      );
+    }
+  });
 });
+
+/**
+ * Body of the guide's "Verify it worked" section, up to the next heading, with
+ * whitespace collapsed so assertions do not depend on prose line wrapping.
+ */
+function verifyItWorkedSection(guide: string): string {
+  const start = guide.indexOf("## Verify it worked");
+  if (start === -1) return "";
+  const rest = guide.slice(start + "## Verify it worked".length);
+  const end = rest.indexOf("\n## ");
+  return (end === -1 ? rest : rest.slice(0, end)).replace(/\s+/g, " ");
+}
+
+/** First fenced code block whose body contains `needle`. */
+function firstFencedBlockContaining(
+  guide: string,
+  needle: string,
+): string | undefined {
+  for (const match of guide.matchAll(/^(`{3,})[^\n]*\n([\s\S]*?)^\1\s*$/gm)) {
+    const body = match[2] ?? "";
+    if (body.includes(needle)) return body;
+  }
+  return undefined;
+}


### PR DESCRIPTION
Found during a DX dogfood walk of the published docs (veryfront 0.1.1228). Two backlog findings, one root cause, so they are fixed together.

## Symptom

Following either chat page verbatim produces a chat that renders the assistant's **raw Markdown source** instead of formatted text.

- **[getting-started/create-frontend](https://veryfront.com/docs/code/getting-started/create-frontend)** — asked for "three benefits of TypeScript as a markdown bulleted list with bold headings"; the page showed literal `- **Static Type Checking**: ...`. Even a plain answer rendered inside a `code` node.
- **[guides/chat-ui](https://veryfront.com/docs/code/guides/chat-ui)**, "Add the preset UI" — every assistant reply rendered as a raw fenced block with literal ``` fences and `**` markers visible.

Both emitted the framework's own warning in the browser console:

```
[Veryfront] Chat is showing raw Markdown source because no Markdown renderer is
installed. Install one for the chat subtree: ...
New projects scaffold this in app/markdown-renderer.tsx.
```

## Root cause

`veryfront/markdown` presents plain escaped source until a renderer is installed — the right default for a standalone `<Markdown>`, but wrong for chat, where the assistant writes Markdown. `src/react/components/chat/missing-renderer-warning.ts` says so directly: "In chat it is almost always a mistake."

Every starter scaffolds `app/markdown-renderer.tsx` and wraps `<Chat>` in `MarkdownRendererProvider` (`cli/templates/files/ai-agent/app/page.tsx`). Both doc samples dropped that wrapper:

- `create-frontend.md` said "Replace `app/page.tsx`" with a sample that has no provider — so the doc **actively deleted** working setup the reader already had, and never mentioned a renderer anywhere (0 hits for "markdown" in the whole page).
- `chat-ui.md`'s primary "Add the preset UI" sample also dropped it. The guide does have a "Render Markdown in chat" section, but it is ~280 lines below the sample with no pointer from it, so a reader copy-pasting the first block never reaches it.

Neither page's "Verify it worked" checklist had an item that would catch the degradation: `create-frontend` only checked that the response *streams*, and `chat-ui`'s only Markdown item covered *standalone* `<Markdown>`, not chat answers. Both checklists passed on a visibly broken chat.

## Fix

Minimal and doc-only:

- Wrap both `app/page.tsx` samples in `MarkdownRendererProvider`, matching the scaffold.
- Say why the wrapper is required, and note that the other samples on the chat-ui page need it too.
- Give `create-frontend` a short "Supply the Markdown renderer" section for readers who added Veryfront to an existing project rather than scaffolding, with the exact-pinned parser install.
- Add a verification item to both pages that fails when the answer renders as raw source.

No source or template changes — the framework and the scaffold were already correct; only the prose disagreed with them.

## Regression test

`tests/docs/guide-content.test.ts` — `"wires a Markdown renderer into every chat page the docs tell you to write"`.

It lives there because this is a doc-content contract, which is exactly what that suite holds (runtime floors, guide wording, CLI-flag accuracy), and because it is in the `deno task docs:validate` gate that CI already runs on every docs change. A code-level test could not catch it: the framework behaves correctly here — only the prose was wrong.

The test extracts the first `// app/page.tsx` fenced block from each page and requires the provider, the `veryfront/markdown` import, and the `./markdown-renderer.tsx` import; it also requires each page to show how to create that file, and requires the "Verify it worked" section to check for rendered rather than raw Markdown.

Confirmed red before the fix, for the right reason, and independently for each page:

```
to contain: "MarkdownRendererProvider"
Expected actual: "// app/page.tsx ... return <Chat chat={chat} placeholder="Ask me anything..." />;"
```

Reverting only `chat-ui.md` reproduces the same failure on its own, so the test pins both halves rather than one.

## Verification

- `deno task docs:validate` passes end to end: 42 reference pages, 68 guides, 48 guide-example suites (94 steps), and all 1228 doc links — so the new `#render-markdown-in-chat` anchor and the cross-page link resolve.
- `deno fmt --check` and `deno lint` clean on all three files.
- Pre-existing, untouched: `tests/docs/guide-examples.test.ts` has 3 `TS2532` errors under type-check; the `docs:validate` task runs that file with `--no-check`, and I did not modify it.

## Related, deliberately not touched

`MISSING_MARKDOWN_RENDERER_WARNING` (`src/react/components/chat/missing-renderer-warning.ts:29`) points at `https://veryfront.com/docs/guides/chat-ui#render-markdown-in-chat` — missing the `/code` segment, so it 404s. That is a separate backlog finding owned by another agent; left alone here. The anchor half of it is now correct, since this PR keeps that heading and links to it.
