### PR TITLE
docs: stop telling self-hosters to ship dist/ alone

### DIFF
--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -84,10 +84,13 @@ the project to the host and run `veryfront build` there (or ship the `dist/` you
 built locally alongside the source), then run `veryfront serve` from the project
 directory.
 
-A host that receives only `dist/` serves the pages and returns 404 for every API
-route, so the chat UI from the default scaffold loads with a dead `/api/ag-ui`
-backend. See [Building and deploying](../guides/deploying.md) for a container
-example.
+A host that receives only `dist/` has no backend. The pages load, but every API
+route is absent, and the response depends on the host: running
+`veryfront serve` over a `dist/`-only directory returns 404, while a static host
+that honors the generated `_redirects` file returns the SPA `index.html` with a
+200. Either way the chat UI from the default scaffold loads with a dead
+`/api/ag-ui` backend. See [Building and deploying](../guides/deploying.md) for a
+container example.
 
 ## Verify it worked
 

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -10,8 +10,8 @@ order: 7
   [Create project](./create-project.md)).
 - For Veryfront Cloud: run `veryfront login` or set `VERYFRONT_API_TOKEN`. See
   [Configuration](../guides/configuration.md).
-- For another host: any container or Node-compatible runtime that can serve the
-  build output.
+- For another host: any container or Node-compatible runtime that can run
+  `veryfront serve` from the project directory.
 
 ## Build
 
@@ -21,7 +21,9 @@ Create a production build:
 veryfront build
 ```
 
-This writes the production output to `dist/`.
+This writes the browser build to `dist/`: HTML, client bundles, CSS, and static
+assets. API routes, agents, workflows, and tasks are not compiled into `dist/`.
+`veryfront serve` loads them from the project source at request time.
 
 ## Run the production build locally
 
@@ -77,8 +79,15 @@ link.
 
 ## Deploy somewhere else
 
-For a non-Cloud target, run `veryfront build` and ship the `dist/` output. See
-[Building and deploying](../guides/deploying.md).
+For a non-Cloud target, ship the whole project directory, not just `dist/`. Copy
+the project to the host and run `veryfront build` there (or ship the `dist/` you
+built locally alongside the source), then run `veryfront serve` from the project
+directory.
+
+A host that receives only `dist/` serves the pages and returns 404 for every API
+route, so the chat UI from the default scaffold loads with a dead `/api/ag-ui`
+backend. See [Building and deploying](../guides/deploying.md) for a container
+example.
 
 ## Verify it worked
 

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -12,8 +12,8 @@ Keep the first production path narrow: one route, one check, one deploy.
 - A Veryfront project that runs with `veryfront dev`.
 - Production credentials for providers, integrations, and deployment targets.
 - For Veryfront Cloud: run `veryfront login` or set `VERYFRONT_API_TOKEN`.
-- For self-hosting: the current Node.js LTS or a container host that can serve
-  the build output.
+- For self-hosting: the current Node.js LTS or a container host that can run
+  `veryfront serve` from the project directory.
 
 ## Pick one production path
 
@@ -111,7 +111,9 @@ deploying.
 
 ## Deploy somewhere else
 
-Self-hosted deployments can use the build output or a container:
+Self-hosted deployments ship the whole project directory, not just `dist/`. The
+container below copies the project, builds it in place, and serves it from the
+project directory:
 
 ```dockerfile
 FROM denoland/deno:2.6.0
@@ -124,8 +126,8 @@ EXPOSE 3000
 CMD ["deno", "task", "start"]
 ```
 
-Use infrastructure that supports your chosen runtime and can serve the build
-output.
+Use infrastructure that supports your chosen runtime and can run
+`veryfront serve` from the project directory.
 
 ## Verify it worked
 

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -199,6 +199,25 @@ describe("guide content contracts", () => {
     );
   });
 
+  it("does not offer the build output as a self-hosting target", async () => {
+    // The sibling guide is what the Getting Started page links to for a
+    // non-Cloud target, so it has to carry the same model: the host runs
+    // `veryfront serve` over the project, it does not serve `dist/` alone.
+    const guide = await Deno.readTextFile("docs/guides/deploying.md");
+    const prose = guide.replace(/\s+/g, " ");
+
+    assertEquals(prose.includes("can serve the build output"), false);
+    assertEquals(prose.includes("use the build output or a container"), false);
+    assertStringIncludes(
+      prose,
+      "ship the whole project directory, not just `dist/`",
+    );
+    assertStringIncludes(
+      prose,
+      "run `veryfront serve` from the project directory",
+    );
+  });
+
   it("documents single-command Deploy for interactive Veryfront Cloud paths", async () => {
     const docs = [
       "docs/getting-started/deploy-project.md",

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -176,6 +176,29 @@ describe("guide content contracts", () => {
     }
   });
 
+  it("does not present dist/ as a self-contained self-hosted deployment", async () => {
+    const doc = await Deno.readTextFile(
+      "docs/getting-started/deploy-project.md",
+    );
+    const prose = doc.replace(/\s+/g, " ");
+
+    // `veryfront build` emits browser assets only. API routes, agents,
+    // workflows, and tasks are served from the project source by
+    // `veryfront serve`, so a host that receives `dist/` alone answers pages
+    // and 404s every API route.
+    assertEquals(prose.includes("ship the `dist/` output"), false);
+    assertStringIncludes(prose, "browser build to `dist/`");
+    assertStringIncludes(prose, "not compiled into `dist/`");
+    assertStringIncludes(
+      prose,
+      "ship the whole project directory, not just `dist/`",
+    );
+    assertStringIncludes(
+      prose,
+      "run `veryfront serve` from the project directory",
+    );
+  });
+
   it("documents single-command Deploy for interactive Veryfront Cloud paths", async () => {
     const docs = [
       "docs/getting-started/deploy-project.md",


### PR DESCRIPTION
Found during a DX dogfood walk of https://veryfront.com/docs/code/getting-started/deploy-project.

## Symptom

The Deploy project page's "Deploy somewhere else" section said:

> For a non-Cloud target, run `veryfront build` and ship the `dist/` output.

Follow that literally and you ship a dead backend. The page's own default
scaffold (`veryfront init`, ai-agent template) contains
`app/api/ag-ui/route.ts` and `agents/assistant.ts`, and neither survives the
build:

```
$ veryfront build
  ✓ Built in 6.41s
    1 page, 0 chunks, 1 asset
    14.51 KB in dist

$ find dist -type f
dist/_redirects
dist/_veryfront/app.js
dist/_veryfront/client.js
dist/_veryfront/hydration-runtime.22f7158e.js
dist/_veryfront/hydration-runtime.js
dist/_veryfront/manifest.json
dist/_veryfront/prefetch.js
dist/_veryfront/router.js
dist/_vf/css/ef279860....css
dist/favicon.svg
dist/index.html
dist/sw.js
```

Every file is a client-side artifact. Serving a directory that contains only
that `dist/` confirms it:

| serve cwd                   | `GET /api/ag-ui` |
| --------------------------- | ---------------- |
| project root (source + dist) | `405` (route exists, POST-only) |
| a directory holding only `dist/` | `404` (route absent) |

So a developer who ships `dist/` to a static host or a container gets the chat
UI rendering fine and `/api/ag-ui` 404ing, with nothing in the output
explaining why. The Prerequisites bullet ("any container or Node-compatible
runtime that can serve the build output") reinforced the same wrong model.

## Root cause

Documentation only. `veryfront build` producing browser assets and
`veryfront serve` loading routes, agents, workflows, and tasks from the project
source at request time is the intended design - the sibling guide
`docs/guides/deploying.md` already ships the whole project via `COPY . .` plus
`deno task start`. The Getting Started page contradicted it.

This page is the upstream source for the published site:
`veryfront-docs/.github/workflows/update-reference.yml` copies
`veryfront-code/docs/getting-started/` into `veryfront-docs/docs/code/getting-started/`,
so editing `veryfront-docs` directly would be overwritten on the next sync.
The fix belongs here.

## The change

- Prerequisites: another host needs a runtime that can *run `veryfront serve`
  from the project directory*, not one that can "serve the build output".
- Build: say what `dist/` actually holds, and that API routes, agents,
  workflows, and tasks are not compiled into it.
- Deploy somewhere else: ship the whole project directory, build on the host or
  ship `dist/` alongside the source, then run `veryfront serve`. States the
  failure mode a `dist/`-only host produces so the symptom is searchable.

## Regression test

`tests/docs/guide-content.test.ts` - "does not present dist/ as a
self-contained self-hosted deployment".

That file is where this repo already pins doc claims that drift against real
behavior (runtime floors, Deploy/Push wording, the `veryfront serve` vs
`veryfront start` contract), and it runs under `deno task docs:validate` in CI.
The assertion is a content contract rather than a runtime test because the
defect is a false claim in prose, not a code path: it forbids the exact old
sentence and requires the corrected framing. Whitespace is normalized so the
test pins wording, not line wrapping.

Confirmed failing before the doc edit for the right reason
(`ship the \`dist/\` output` still present), passing after.
