### PR TITLE
fix(chat): point the missing-renderer warning at a real docs page

### DIFF
--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -14,7 +14,7 @@
  * <Markdown># Hello{"\n\n"}Some **bold** text with `code`.</Markdown>
  * ```
  *
- * @see https://veryfront.com/docs/guides/chat-ui
+ * @see https://veryfront.com/docs/code/guides/chat-ui
  */
 
 export {

--- a/src/react/components/chat/missing-renderer-warning.test.ts
+++ b/src/react/components/chat/missing-renderer-warning.test.ts
@@ -4,16 +4,18 @@ import { MISSING_MARKDOWN_RENDERER_WARNING } from "./missing-renderer-warning.ts
 
 /**
  * The warning's only escape hatch is the documentation link, so the link has to
- * resolve. The published guide lives under `/docs/code/guides/chat-ui` and the
- * Markdown section on that page is "Render Markdown directly"
- * (`#render-markdown-directly`); `/docs/guides/chat-ui` is a 404.
+ * resolve. The published guide lives under `/docs/code/guides/chat-ui`
+ * (`/docs/guides/chat-ui` is a 404), and the fragment has to track the heading
+ * in this repo's `docs/guides/chat-ui.md`, which is the source the published
+ * site is generated from: "## Render Markdown in chat" slugs to
+ * `#render-markdown-in-chat`.
  */
 describe("missing Markdown renderer warning — documentation link", () => {
   it("carries exactly one link, and it is the published chat-ui guide", () => {
     const links = MISSING_MARKDOWN_RENDERER_WARNING.match(/https:\/\/\S+/g) ?? [];
 
     assertEquals(links, [
-      "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-directly",
+      "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-in-chat",
     ]);
   });
 });

--- a/src/react/components/chat/missing-renderer-warning.test.ts
+++ b/src/react/components/chat/missing-renderer-warning.test.ts
@@ -1,0 +1,22 @@
+import { assert, assertStringIncludes } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import { MISSING_MARKDOWN_RENDERER_WARNING } from "./missing-renderer-warning.ts";
+
+/**
+ * The warning's only escape hatch is the documentation link, so the link has to
+ * resolve. The published guide lives under `/docs/code/guides/chat-ui` and the
+ * Markdown section on that page is "Render Markdown directly"
+ * (`#render-markdown-directly`); `/docs/guides/chat-ui` is a 404.
+ */
+describe("missing Markdown renderer warning — documentation link", () => {
+  it("points at the published chat-ui guide, not the legacy 404 path", () => {
+    assertStringIncludes(
+      MISSING_MARKDOWN_RENDERER_WARNING,
+      "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-directly",
+    );
+    assert(
+      !MISSING_MARKDOWN_RENDERER_WARNING.includes("https://veryfront.com/docs/guides/"),
+      "the warning must not link under /docs/, which 404s; guides live under /docs/code/",
+    );
+  });
+});

--- a/src/react/components/chat/missing-renderer-warning.test.ts
+++ b/src/react/components/chat/missing-renderer-warning.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertStringIncludes } from "#veryfront/testing/assert";
+import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { MISSING_MARKDOWN_RENDERER_WARNING } from "./missing-renderer-warning.ts";
 
@@ -9,14 +9,11 @@ import { MISSING_MARKDOWN_RENDERER_WARNING } from "./missing-renderer-warning.ts
  * (`#render-markdown-directly`); `/docs/guides/chat-ui` is a 404.
  */
 describe("missing Markdown renderer warning — documentation link", () => {
-  it("points at the published chat-ui guide, not the legacy 404 path", () => {
-    assertStringIncludes(
-      MISSING_MARKDOWN_RENDERER_WARNING,
+  it("carries exactly one link, and it is the published chat-ui guide", () => {
+    const links = MISSING_MARKDOWN_RENDERER_WARNING.match(/https:\/\/\S+/g) ?? [];
+
+    assertEquals(links, [
       "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-directly",
-    );
-    assert(
-      !MISSING_MARKDOWN_RENDERER_WARNING.includes("https://veryfront.com/docs/guides/"),
-      "the warning must not link under /docs/, which 404s; guides live under /docs/code/",
-    );
+    ]);
   });
 });

--- a/src/react/components/chat/missing-renderer-warning.ts
+++ b/src/react/components/chat/missing-renderer-warning.ts
@@ -26,7 +26,7 @@ export const MISSING_MARKDOWN_RENDERER_WARNING =
   '  import { MarkdownRendererProvider } from "veryfront/markdown";\n' +
   "  <MarkdownRendererProvider renderer={MarkdownRenderer}><Chat /></MarkdownRendererProvider>\n" +
   "New projects scaffold this in app/markdown-renderer.tsx. See " +
-  "https://veryfront.com/docs/guides/chat-ui#render-markdown-in-chat";
+  "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-directly";
 
 let warnedMissingMarkdownRenderer = false;
 

--- a/src/react/components/chat/missing-renderer-warning.ts
+++ b/src/react/components/chat/missing-renderer-warning.ts
@@ -26,7 +26,7 @@ export const MISSING_MARKDOWN_RENDERER_WARNING =
   '  import { MarkdownRendererProvider } from "veryfront/markdown";\n' +
   "  <MarkdownRendererProvider renderer={MarkdownRenderer}><Chat /></MarkdownRendererProvider>\n" +
   "New projects scaffold this in app/markdown-renderer.tsx. See " +
-  "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-directly";
+  "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-in-chat";
 
 let warnedMissingMarkdownRenderer = false;
 

--- a/src/server/handlers/dev/framework-candidates.generated.ts
+++ b/src/server/handlers/dev/framework-candidates.generated.ts
@@ -11710,7 +11710,7 @@ export const FRAMEWORK_CANDIDATES: readonly string[] = [
   "https://models.dev/logos/${key}.svg",
   "https://ui.shadcn.com/blocks).",
   "https://upload.invalid/",
-  "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-directly",
+  "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-in-chat",
   "hue",
   "hydration",
   "i)",

--- a/src/server/handlers/dev/framework-candidates.generated.ts
+++ b/src/server/handlers/dev/framework-candidates.generated.ts
@@ -11710,7 +11710,7 @@ export const FRAMEWORK_CANDIDATES: readonly string[] = [
   "https://models.dev/logos/${key}.svg",
   "https://ui.shadcn.com/blocks).",
   "https://upload.invalid/",
-  "https://veryfront.com/docs/guides/chat-ui#render-markdown-in-chat",
+  "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-directly",
   "hue",
   "hydration",
   "i)",


### PR DESCRIPTION
Found during a DX dogfood walk of the public docs (veryfront.com/docs/code), following them literally as a new developer.

## Symptom

A chat surface with no Markdown renderer installed renders raw `## Heading` source and the framework warns in the browser console:

```
[Veryfront] Chat is showing raw Markdown source because no Markdown renderer is installed. Install one for the chat subtree:
  import { MarkdownRendererProvider } from "veryfront/markdown";
  <MarkdownRendererProvider renderer={MarkdownRenderer}><Chat /></MarkdownRendererProvider>
New projects scaffold this in app/markdown-renderer.tsx. See https://veryfront.com/docs/guides/chat-ui#render-markdown-in-chat
```

The link is the only escape hatch the warning offers, and it 404s:

```
$ curl -s -o /dev/null -w '%{http_code}\n' -L https://veryfront.com/docs/guides/chat-ui
404
$ curl -s -o /dev/null -w '%{http_code}\n' -L https://veryfront.com/docs/code/guides/chat-ui
200
```

## Root cause

`MISSING_MARKDOWN_RENDERER_WARNING` in `src/react/components/chat/missing-renderer-warning.ts` hard-codes a docs URL that predates the published information architecture: the `/code` path segment is missing. The `@see` tag on the `veryfront/markdown` module carried the same stale `/docs/guides/` path.

## Fix

Point both at the page that actually serves:

```
https://veryfront.com/docs/code/guides/chat-ui#render-markdown-in-chat
```

No behaviour change beyond the string.

## Which fragment (review follow-up)

The first pass of this PR also rewrote the fragment to `#render-markdown-directly`, because that is what the live page serves today. That was wrong, and review caught it.

The published site is a **generated mirror** of this repo's `docs/`, and the mirror is behind:

```
$ gh api 'repos/veryfront/veryfront-docs/commits?path=docs/code/guides/chat-ui.md&per_page=1' \
    --jq '.[]|"\(.commit.author.date) \(.commit.message|split("\n")[0])"'
2026-08-02T16:44:04Z  docs: update code docs from veryfront-code@11b070d
```

That snapshot predates `1da0dd044` (#3358, 2026-08-04), which renamed the section to "Render Markdown in chat" and added the "Present Markdown source safely" / "Install a semantic renderer" sections the live page still lacks. So `#render-markdown-directly` is a stale artifact, not the target — and this PR is what ends the staleness: it touches `src/markdown/index.ts`, which matches `src/**/index.ts` in `.github/workflows/sync-docs.yml`, so merging it dispatches the sync that republishes the current heading.

The fragment therefore tracks the canonical source heading, `#render-markdown-in-chat`. Until the sync runs, the link loads the guide but does not scroll to the section; that resolves on merge.

## Regression test

`src/react/components/chat/missing-renderer-warning.test.ts` — a new colocated test next to the module that owns the constant, rather than in `chat-markdown.test.tsx`, which tests *when* the warning fires. The existing assertion there only checked the substring `guides/chat-ui`, which is exactly why the broken path survived. The new test extracts every `https://` link out of the message and compares the whole list, so it pins both that there is exactly one link and that it is the right one — a substring check could not have caught either half of this bug. Its docstring records that the fragment tracks the heading in `docs/guides/chat-ui.md`, so the next rename fails the test rather than silently rotting the link.

(Extraction rather than `String.includes` of a URL prefix is also what CodeQL wants: a literal URL prefix passed to `includes` trips `js/incomplete-url-substring-sanitization` even in a test.)

Confirmed failing before the fix for the right reason, and passing after.

## Regenerated artifact

`src/server/handlers/dev/framework-candidates.generated.ts` carries the warning string as an extracted Tailwind candidate, so `deno task generate:manifests:check` (run by `ci (typecheck)`) goes stale on a string edit. Regenerated with `deno run -A scripts/build/prebundle-client-scripts.ts`; the diff is the one line.
