### PR TITLE
docs: document the Deno install path for the CLI

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -61,6 +61,10 @@ yarn create veryfront
 bun create veryfront
 ```
 
+```bash deno
+deno init --npm veryfront
+```
+
 </CodeGroup>
 
 ## Install the CLI
@@ -93,6 +97,18 @@ yarn global add veryfront
 ```bash
 bun add -g veryfront
 ```
+
+### deno
+
+```bash
+deno install -gArf npm:veryfront
+```
+
+The CLI is published to npm only, so install it through Deno's `npm:`
+specifier. Deno resolves that specifier from the current working directory, so
+inside a project that depends on `veryfront` the global binary runs that
+project's version instead. Run `veryfront --version` outside any project
+directory to see the globally installed version.
 
 ## One-shot CLI usage
 

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -436,6 +436,22 @@ describe("guide content contracts", () => {
       );
     }
   });
+
+  it("gives Deno an install path on every surface the installation guide offers", async () => {
+    const installation = await Deno.readTextFile(
+      "docs/getting-started/installation.md",
+    );
+
+    // The page lists Deno as a supported runtime floor, so each install
+    // surface it documents for npm needs a Deno counterpart that works.
+    assertStringIncludes(installation, "### deno");
+    assertStringIncludes(installation, "deno install -gArf npm:veryfront");
+    assertStringIncludes(installation, "deno init --npm veryfront");
+
+    // The CLI is published to npm only. `jsr:@veryfront/veryfront` has never
+    // existed and resolves to a JSR 404, so it must not be advertised.
+    assertEquals(installation.includes("jsr:@veryfront/veryfront"), false);
+  });
 });
 
 /**


### PR DESCRIPTION
Found during a DX dogfood walk of the public getting-started docs.

## Symptom

`docs/getting-started/installation.md` lists **Deno 2.2 or later** as a
supported runtime and offers `deno add npm:veryfront` for project installs,
but Deno then disappears from the rest of the page:

- **New scaffolded project** — `npm` / `pnpm` / `yarn` / `bun` tabs, no `deno`
  tab (even though `create-project.md` already documents `deno init --npm
  veryfront`).
- **Install the CLI** — `### npm` / `### pnpm` / `### yarn` / `### bun`, no
  `### deno`.

So a Deno user following the page literally has no documented way to get a
global `veryfront` binary. The only Deno CLI-install instruction anywhere in
the workspace pointed at `jsr:@veryfront/veryfront`, which does not exist:

```
$ curl -s -o /dev/null -w '%{http_code}' https://jsr.io/@veryfront/veryfront
404
$ deno install -gArf jsr:@veryfront/veryfront
Download https://jsr.io/@veryfront/veryfront/meta.json
error: JSR package not found: @veryfront/veryfront
```

## Root cause

The CLI is published to npm only — `deno.json` declares the unscoped name
`veryfront`, so no `@veryfront/veryfront` JSR package exists or could exist.
The working Deno install path goes through Deno's `npm:` specifier, and that
one line was simply never added to the installation guide when the Deno tab
was added to the "Blank or existing project" CodeGroup.

Verified against the published 0.1.1228 release, in a sandbox outside the
repo with `DENO_INSTALL_ROOT` pointed at a scratch directory:

```
$ deno install -gArf npm:veryfront
+ npm:veryfront 0.1.1228
✅ Successfully installed veryfront
$ veryfront --version
  ● Veryfront CLI v0.1.1228
```

The caveat in the new subsection is also reproduced, not inferred. `deno
install -g` writes a shim that runs `deno run npm:veryfront`, and Deno
resolves that bare specifier against the nearest `package.json` /
`node_modules` walking up from the **current working directory** — so the
shim's own pinned version is bypassed inside a project that depends on
`veryfront`:

```
$ cd /tmp/sb/empty  && veryfront --version   # ● Veryfront CLI v0.1.1228
$ cd /tmp/sb/pinned && veryfront --version   # ● Veryfront CLI v0.1.1226
```

(`/tmp/sb/pinned` pins `veryfront@0.1.1226` in `package.json`; the binary
invoked is the same absolute path in both runs.) Without that note, a Deno
user reasonably concludes the global install silently failed.

## Fix

Two additions to `docs/getting-started/installation.md`:

1. `deno init --npm veryfront` in the "New scaffolded project" CodeGroup,
   matching the Deno tab already documented in `create-project.md`.
2. A `### deno` subsection with `deno install -gArf npm:veryfront` and the
   cwd-resolution caveat.

No code changes. The related half of this report — the CLI's own update
banner telling users to run `deno install -gArf jsr:@veryfront/veryfront` —
was already fixed by #3524 (`cli/shared/update-check.ts` now points at
`https://registry.npmjs.org/veryfront/latest` and prints
`npm install -g veryfront@latest`), which shipped in 0.1.1228. The walker
saw the old banner from a stale 0.1.1019 binary resolved out of a
`node_modules` tree above its cwd — the same cwd-resolution mechanism
described above.

## Regression test

`tests/docs/guide-content.test.ts` — "gives Deno an install path on every
surface the installation guide offers".

It lives there because that file already owns the installation guide's
runtime-support contract: the adjacent test ("states the supported runtime
floors in the getting-started docs") is what asserts the page's `Deno 2.2 or
later` claim in the first place. Asserting that the claim comes with a usable
install path belongs directly beside the claim itself, and the file is
filesystem-only so it stays cheap. The test also asserts the page never
reintroduces `jsr:@veryfront/veryfront`.

Confirmed failing before the fix, for the right reason:

```
guide content contracts ... gives Deno an install path on every surface the installation guide offers => FAILED
  ... to contain: "### deno".
FAILED | 0 passed (21 steps) | 1 failed (1 step)
```

Green after: `deno task docs:validate` passes end to end (48 guide-contract
tests, 1226 doc links OK), and the full pre-push suite passed.

Note: `docs/getting-started/**` is the source of truth — `.github/workflows/sync-docs.yml`
dispatches to `veryfront/veryfront-docs` on merge, so the public page picks
this up automatically. No change was made in `veryfront-docs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Deno installation instructions for creating a scaffolded project and installing the Veryfront CLI.
  - Clarified npm-only publication, Deno’s `npm:` package resolution, and checking the globally installed CLI version.

- **Tests**
  - Added documentation checks to verify Deno installation guidance remains complete and avoids referencing an unavailable JSR package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->