### PR TITLE
docs: narrow the getAgent() result in the agents guide samples

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -347,10 +347,16 @@ its `id` matches the value passed to `createAgUiHandler()`.
 
 For server-side generation (e.g., in `getServerData`), use `generate()`:
 
+`getAgent()` returns `Agent | undefined`, so narrow the result before calling
+it. Without the guard, the sample fails typecheck under the `"strict": true`
+tsconfig that `veryfront init` writes.
+
 ```ts
 import { getAgent } from "veryfront/agent";
 
 const agent = getAgent("assistant");
+if (!agent) throw new Error("Agent not found: assistant");
+
 const result = await agent.generate({
   input: "Summarize the latest news about AI.",
 });
@@ -451,6 +457,8 @@ Save the agent file, restart `veryfront dev`, and invoke it from server code:
 import { getAgent } from "veryfront/agent";
 
 const agent = getAgent("assistant");
+if (!agent) throw new Error("Agent not found: assistant");
+
 const result = await agent.generate({ input: "Hello" });
 console.log(result.text);
 ```

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -345,8 +345,7 @@ its `id` matches the value passed to `createAgUiHandler()`.
 
 ## Non-streaming response
 
-For server-side generation (e.g., in `getServerData`), use `generate()`:
-
+For server-side generation (e.g., in `getServerData`), use `generate()`.
 `getAgent()` returns `Agent | undefined`, so narrow the result before calling
 it. Without the guard, the sample fails typecheck under the `"strict": true`
 tsconfig that `veryfront init` writes.

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -462,8 +462,10 @@ describe("guide content contracts", () => {
     const unnarrowed: string[] = [];
     for (const fence of guide.matchAll(/```(?:ts|tsx)\n([\s\S]*?)```/g)) {
       const code = fence[1];
+      if (code === undefined) continue;
       for (const binding of code.matchAll(/const (\w+) = getAgent\(/g)) {
         const name = binding[1];
+        if (name === undefined) continue;
         const body = code.slice((binding.index ?? 0) + binding[0].length);
         const firstUse = body.search(new RegExp(`\\b${name}\\s*[.?]`));
         if (firstUse === -1) continue;

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -452,6 +452,32 @@ describe("guide content contracts", () => {
     // existed and resolves to a JSR 404, so it must not be advertised.
     assertEquals(installation.includes("jsr:@veryfront/veryfront"), false);
   });
+
+  it("narrows the possibly-undefined getAgent() result in agents guide samples", async () => {
+    const guide = await Deno.readTextFile("docs/guides/agents.md");
+
+    // `getAgent()` returns `Agent | undefined`, and `veryfront init` writes a
+    // tsconfig with `"strict": true`, so any sample that touches the result
+    // without narrowing it fails typecheck (TS18048) when pasted verbatim.
+    const unnarrowed: string[] = [];
+    for (const fence of guide.matchAll(/```(?:ts|tsx)\n([\s\S]*?)```/g)) {
+      const code = fence[1];
+      for (const binding of code.matchAll(/const (\w+) = getAgent\(/g)) {
+        const name = binding[1];
+        const body = code.slice((binding.index ?? 0) + binding[0].length);
+        const firstUse = body.search(new RegExp(`\\b${name}\\s*[.?]`));
+        if (firstUse === -1) continue;
+        const guardAt = body.search(new RegExp(`if\\s*\\(\\s*!${name}\\b`));
+        if (guardAt === -1 || guardAt > firstUse) unnarrowed.push(name);
+      }
+    }
+
+    assertEquals(
+      unnarrowed,
+      [],
+      "agents guide samples must guard the getAgent() result before using it",
+    );
+  });
 });
 
 /**


### PR DESCRIPTION
Found during a DX dogfood walk of https://veryfront.com/docs/code/guides/agents, following the published docs literally as a new developer would.

## Symptom

Both `getAgent()` samples in the agents guide (the "Non-streaming response" one and the "Verify it worked" one) are given verbatim as:

```ts
const agent = getAgent("assistant");
const result = await agent.generate({ input: "Hello" });
```

Paste either into a project created by `veryfront init` and run the typechecker:

```
app/api/ask/route.ts(8,24): error TS18048: 'agent' is possibly 'undefined'.
```

The samples work at runtime, so the failure only shows up once the developer runs the typechecker the scaffolder configured for them. The guide never mentions the narrowing and offers no guard.

## Root cause

`getAgent()` returns `Agent | undefined` (`src/agent/composition/composition.ts:216`) because the id may not be registered. The scaffolder writes `"strict": true` into the project tsconfig (`cli/commands/init/config-generator.ts:106`, and every `cli/templates/files/*/tsconfig.json`). Under `strictNullChecks`, calling a method on the result without narrowing is an error. The samples predate that and were never updated.

Reproduced against this tree, not just the published build:

```
$ deno check sample.ts
TS18048 [ERROR]: 'agent' is possibly 'undefined'.
const result = await agent.generate({ input: "Hello" });
                     ~~~~~
```

## Fix

Add `if (!agent) throw new Error("Agent not found: assistant");` to both samples, plus one sentence saying `getAgent()` returns `Agent | undefined` and why the guard is there. No API change.

## Regression test

`tests/docs/guide-content.test.ts` — "narrows the possibly-undefined getAgent() result in agents guide samples".

It lives there because `docs/guides/agents.md` in this repo is the source of truth for the published page (`veryfront-docs` `docs/code/guides/agents.md` is synced from it and hand edits there are overwritten), and `tests/docs/guide-content.test.ts` is the existing home for guide-content contracts. It is also already wired into `deno task docs:validate`, so it runs in the `ci (lint)` lane.

The test parses the `ts`/`tsx` fences in the guide, finds every `const X = getAgent(...)` binding that is later dereferenced, and fails unless an `if (!X)` guard appears before the first use. That is a structural check on the actual defect, not a magic-string assertion, so a future sample that drops the guard fails too.

Confirmed it fails before the fix for the right reason:

```
AssertionError: Values are not equal: agents guide samples must guard the getAgent() result before using it
-   [ "agent", "agent" ]
+   []
```

and passes after. `deno task docs:validate`'s guide validators, `check-doc-links.ts`, `deno fmt --check` and `deno lint` are clean on the touched files.

## Noted, not fixed here

The same unguarded pattern exists in `docs/guides/memory-and-streaming.md` (3 samples) and `docs/guides/multi-agent.md` (`agentAsTool(researcher, ...)` passes a possibly-undefined value into an `Agent` parameter). Those are outside this finding's scope and are left for a separate change; the test added here is deliberately scoped to the agents guide so it does not silently claim coverage it does not have.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated agent usage examples to handle missing agents safely.
  - Added a clear “Agent not found” error when an agent is unavailable.

- **Tests**
  - Added validation to ensure documentation examples check agent availability before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->