### PR TITLE
fix(extensions): install ext-db-sqlite on current Node releases

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -60,7 +60,7 @@
     "npm:ajv-formats@3.0.1": "3.0.1_ajv@8.18.0",
     "npm:ajv@8.18.0": "8.18.0",
     "npm:bash-tool@1.3.18": "1.3.18_ai@7.0.41__zod@3.25.76_just-bash@3.0.1",
-    "npm:better-sqlite3@9.6.0": "9.6.0",
+    "npm:better-sqlite3@13.0.3": "13.0.3",
     "npm:brace-expansion@5.0.9": "5.0.9",
     "npm:browserslist@4.28.7": "4.28.7",
     "npm:daisyui@5.5.14": "5.5.14",
@@ -2925,13 +2925,11 @@
         "just-bash"
       ]
     },
-    "better-sqlite3@9.6.0": {
-      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+    "better-sqlite3@13.0.3": {
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "dependencies": [
-        "bindings",
-        "prebuild-install"
-      ],
-      "scripts": true
+        "node-addon-api"
+      ]
     },
     "bidi-js@1.0.3": {
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
@@ -2941,12 +2939,6 @@
     },
     "bignumber.js@9.3.1": {
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
-    },
-    "bindings@1.5.0": {
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": [
-        "file-uri-to-path"
-      ]
     },
     "bl@4.1.0": {
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
@@ -3368,9 +3360,6 @@
         "token-types",
         "uint8array-extras"
       ]
-    },
-    "file-uri-to-path@1.0.0": {
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range@7.1.1": {
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
@@ -6427,7 +6416,7 @@
       "extensions/ext-db-sqlite": {
         "dependencies": [
           "npm:@types/better-sqlite3@7.6.13",
-          "npm:better-sqlite3@9.6.0"
+          "npm:better-sqlite3@13.0.3"
         ]
       },
       "extensions/ext-dev-ui-react": {

--- a/extensions/ext-db-sqlite/deno.json
+++ b/extensions/ext-db-sqlite/deno.json
@@ -13,7 +13,7 @@
     ]
   },
   "imports": {
-    "better-sqlite3": "npm:better-sqlite3@9.6.0",
+    "better-sqlite3": "npm:better-sqlite3@13.0.3",
     "@types/better-sqlite3": "npm:@types/better-sqlite3@7.6.13"
   },
   "tasks": {

--- a/scripts/build/npm-dependency-sources.test.ts
+++ b/scripts/build/npm-dependency-sources.test.ts
@@ -48,7 +48,7 @@ describe("npm dependency source helpers", () => {
 		assertEquals(npmDependencyRange(configs, "@types/react"), "19.2.14");
 		assertEquals(npmDependencyRange(configs, "@types/react-dom"), "19.2.3");
 		assertEquals(npmDependencyRange(configs, "@kreuzberg/node"), "4.4.2");
-		assertEquals(npmDependencyRange(configs, "better-sqlite3", ""), "9.6.0");
+		assertEquals(npmDependencyRange(configs, "better-sqlite3", ""), "13.0.3");
 	});
 
 	it("fails when an explicit npm dependency has no config source", () => {

--- a/scripts/build/npm-extension-package-metadata.test.ts
+++ b/scripts/build/npm-extension-package-metadata.test.ts
@@ -70,6 +70,31 @@ describe("manifestDependencies", () => {
     assertEquals(manifestDependencies(manifest), { sharp: "0.35.3" });
   });
 
+  it("pins SQLite to a release that ships prebuilt binaries", async () => {
+    const manifest = JSON.parse(
+      await Deno.readTextFile("extensions/ext-db-sqlite/deno.json"),
+    ) as ExtensionManifest;
+
+    assertEquals(manifestDependencies(manifest)["better-sqlite3"], "13.0.3");
+  });
+
+  it("rejects native dependencies pinned below their prebuilt-binary floor", () => {
+    const manifest: ExtensionManifest = {
+      name: "@veryfront/ext-db-sqlite",
+      exports: "./src/index.ts",
+      veryfront: { extension: true },
+      imports: {
+        "better-sqlite3": "npm:better-sqlite3@9.6.0",
+      },
+    };
+
+    assertThrows(
+      () => manifestDependencies(manifest),
+      Error,
+      "better-sqlite3@9.6.0 predates 13.0.0",
+    );
+  });
+
   it("pins bash-tool's required AI SDK peer in the sandbox extension", async () => {
     const manifest = JSON.parse(
       await Deno.readTextFile(

--- a/scripts/build/npm-extension-package-metadata.ts
+++ b/scripts/build/npm-extension-package-metadata.ts
@@ -80,6 +80,19 @@ const TEST_ONLY_IMPORTS = new Set([
 
 const NODE_ENGINE_PATTERN = /^>=(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/;
 
+/**
+ * Native npm dependencies must be pinned to a release that ships prebuilt
+ * binaries for every supported Node release. Extension imports become exact
+ * pins in the published package, so an older pin never resolves forward: it
+ * falls back to `node-gyp rebuild`, which cannot compile against the V8
+ * headers of newer Node majors and leaves the extension uninstallable.
+ */
+const PREBUILT_NATIVE_DEPENDENCY_FLOORS: Record<string, string> = {
+  // 13.0.0 is the first release whose npm tarball carries Node-API prebuilds
+  // for every platform, so installs never invoke node-gyp.
+  "better-sqlite3": "13.0.0",
+};
+
 function compareVersions(left: string, right: string): number {
   const leftParts = left.split(".").map(Number);
   const rightParts = right.split(".").map(Number);
@@ -123,6 +136,16 @@ export function extensionNameFromPackageName(packageName: string): string {
   return packageName.replace(/^@veryfront\//, "");
 }
 
+function assertPrebuiltNativeDependency(name: string, version: string): void {
+  const floor = PREBUILT_NATIVE_DEPENDENCY_FLOORS[name];
+  if (!floor || compareVersions(version, floor) >= 0) return;
+
+  throw new Error(
+    `${name}@${version} predates ${floor}, the first release that ships prebuilt binaries. ` +
+      `Older pins fall back to node-gyp and cannot install on every supported Node release.`,
+  );
+}
+
 export function manifestDependencies(
   manifest: ExtensionManifest,
 ): Record<string, string> {
@@ -134,6 +157,7 @@ export function manifestDependencies(
     const parsed = parseNpmImport(target);
     if (!parsed) continue;
 
+    assertPrebuiltNativeDependency(parsed.name, parsed.version);
     dependencies[parsed.name] = parsed.version;
   }
 

--- a/scripts/build/proxy-deno.lock
+++ b/scripts/build/proxy-deno.lock
@@ -1597,7 +1597,7 @@
       "extensions/ext-db-sqlite": {
         "dependencies": [
           "npm:@types/better-sqlite3@7.6.13",
-          "npm:better-sqlite3@9.6.0"
+          "npm:better-sqlite3@13.0.3"
         ]
       },
       "extensions/ext-dev-ui-react": {


### PR DESCRIPTION
## Symptom

Found on a DX dogfood walk against the published 0.1.1228 artifacts, on Node 25.2.1 / npm 11.6.2 / macOS arm64.

`veryfront dev` on a fresh `--template minimal --runtime node` app stops with:

```
✗ [unknown-error] Detail: Could not find package '@veryfront/ext-db-sqlite' from referrer
  .../node_modules/veryfront/esm/src/extensions/first-party-import.js
```

and installing the package the CLI names is impossible:

```
$ npm install @veryfront/ext-db-sqlite
npm error command sh -c prebuild-install || node-gyp rebuild --release
npm error .../node-gyp/25.2.1/include/node/v8-memory-span.h:45:28:
          error: no member named 'ranges' in namespace 'std'
npm error 20 errors generated.
npm error make: *** [Release/obj.target/better_sqlite3/src/better_sqlite3.o] Error 1
npm error gyp ERR! not ok
```

The same dead end appears without the CLI: on plain Node, `createKVStore({ path })` throws
`"Could not open a durable KV store for explicit path ... install @veryfront/ext-db-sqlite"` — the
runtime's own remediation points at a package that cannot be installed.

The machine has a working toolchain (clang and make both ran). The compile itself is impossible
against Node 25's V8 headers.

## Root cause

`extensions/ext-db-sqlite/deno.json` pinned `better-sqlite3` at the exact version `9.6.0`, and
extension imports become **exact** pins in the generated package.json
(`manifestDependencies` copies the version verbatim), so the published
`@veryfront/ext-db-sqlite` declared `"better-sqlite3": "9.6.0"` with no range.

better-sqlite3 9.6.0 has no binary in its npm tarball; its install script is
`prebuild-install || node-gyp rebuild`, and the per-ABI prebuilds it fetches stop before Node 23.
On any newer Node it falls through to a source build that cannot succeed. Node 25 is not the
blocker — the pin is: `npm install better-sqlite3@13.0.3` on the same machine finishes in ~1s with
no node-gyp at all.

better-sqlite3 13.0.0 is the first release built on Node-API with per-platform prebuilds shipped
**inside the npm tarball** (`prebuilds/darwin-arm64.node`, `linux-x64.node`, …). Being ABI-independent,
it keeps installing on Node majors that do not exist yet — visible in the lockfile diff, where
`"scripts": true` and the `prebuild-install`/`bindings` chain disappear and only `node-addon-api`
remains.

## Fix

- Pin `better-sqlite3` to `13.0.3` in the extension manifest (`@types/better-sqlite3` is unchanged;
  it was already a major behind the runtime and nothing type-checks through it — the extension
  loads the module dynamically).
- Guard the class of defect in `manifestDependencies`: a native dependency pinned below its
  prebuilt-binary floor now fails the extension package build with an explanatory error instead of
  publishing an uninstallable pin.

The API surface the extension consumes (`exec` / `prepare` / `run` / `get` / `all` / `close`, via
`SqliteDatabase`) is unchanged between 9.x and 13.x and was exercised against the installed 13.0.3
binary.

## Regression test

`scripts/build/npm-extension-package-metadata.test.ts` — the module that turns extension manifests
into published package.json dependencies is where the exact pin is minted, so that is where the
invariant belongs, next to the existing "pins the audit-clean Sharp release" / "pins S3 to the first
audit-clean fix-forward AWS SDK pair" cases:

- `pins SQLite to a release that ships prebuilt binaries` — reads the real
  `extensions/ext-db-sqlite/deno.json` and asserts the dependency the published package will carry.
  Fails on the parent commit with `9.6.0 !== 13.0.3`.
- `rejects native dependencies pinned below their prebuilt-binary floor` — a synthetic manifest
  re-pinning `better-sqlite3@9.6.0` must now throw. Fails on the parent commit with
  `Expected function to throw`.

`scripts/build/npm-dependency-sources.test.ts` reads the same manifest for its workspace-range
assertion and moves to `13.0.3` with it.

Verification beyond the unit tests, on the same Node 25.2.1 that produced the report: installing the
exact dependency set the fixed extension will publish (`better-sqlite3@13.0.3` +
`@types/better-sqlite3@7.6.13`) succeeds in 2s with no node-gyp invocation, and the resulting binary
opens a database and round-trips a `prepare`/`run`/`get`/`all` cycle.

## Notes

Two `deno task test:scripts` steps fail locally on this machine and are unrelated to this change —
`keeps npm CLI agent workflow paths off the DNT Deno shim in real Deno` needs a built `npm/`
directory, and `documents alias re-exports from Deno doc reference declarations` fails identically
with the change stashed (local Deno 2.7.12 vs the 2.7.7 CI pins).
