### PR TITLE
docs: tell quickstart readers the setup wizard exists

### DIFF
--- a/cli/commands/init/interactive-wizard.test.ts
+++ b/cli/commands/init/interactive-wizard.test.ts
@@ -4,9 +4,15 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module cli/commands/init/interactive-wizard.test
  */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { formatWizardIntro, SETUP_COPY, shouldRunWizard } from "./interactive-wizard.ts";
+
+const GETTING_STARTED_DIR = new URL("../../../docs/getting-started/", import.meta.url);
+
+function readGettingStartedDoc(name: string): Promise<string> {
+  return Deno.readTextFile(new URL(name, GETTING_STARTED_DIR));
+}
 
 describe("interactive-wizard", () => {
   it("starts directly with the setup task", () => {
@@ -35,6 +41,29 @@ describe("interactive-wizard", () => {
 
     it("should return false when template is minimal", () => {
       assertEquals(shouldRunWizard({ template: "minimal" }), false);
+    });
+  });
+
+  describe("getting-started docs match wizard behaviour", () => {
+    it("keeps the quickstart create command out of the wizard", async () => {
+      const quickstart = await readGettingStartedDoc("quickstart.md");
+      const createCommand = quickstart
+        .split("\n")
+        .find((line) => line.includes("create veryfront"));
+      assertExists(createCommand, "quickstart.md must show a create command");
+
+      // shouldRunWizard() is the gate. Without --template the documented command
+      // opens a blocking template/runtime/git wizard in a real terminal, which
+      // the quickstart presents as a single automatic step.
+      const template = /--template\s+([a-z0-9-]+)/.exec(createCommand)?.[1];
+      assertEquals(shouldRunWizard({ template }), false);
+    });
+
+    it("names every wizard prompt on the create-project page", async () => {
+      const createProject = await readGettingStartedDoc("create-project.md");
+      for (const prompt of [SETUP_COPY.template, SETUP_COPY.runtime, SETUP_COPY.git]) {
+        assertStringIncludes(createProject, prompt);
+      }
     });
   });
 

--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -18,9 +18,21 @@ veryfront init test-app
 cd test-app
 ```
 
-The wizard preselects the `ai-agent` template. Choose another template when you
-want a different starting point. In non-interactive environments, `ai-agent` is
-used automatically.
+The wizard asks three questions in order and waits for an answer on each:
+
+```text
+Choose a starter template:   preselects ai-agent
+Select runtime:              preselects Node.js
+Initialize Git?              preselects Yes
+```
+
+Press Enter three times to accept the preselected answers, or use the arrow keys
+to change one first.
+
+The wizard needs a terminal. In non-interactive environments — CI, piped stdin,
+scripts — `veryfront init` skips every prompt and uses `ai-agent` on Node.js
+without initializing Git. Passing `--template` also skips the whole wizard,
+including the runtime and Git questions.
 
 Choose a starting point directly when you already know what you want to build,
 or when running the command from a non-interactive script:

--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -29,8 +29,8 @@ Initialize Git?              preselects Yes
 Press Enter three times to accept the preselected answers, or use the arrow keys
 to change one first.
 
-The wizard needs a terminal. In non-interactive environments — CI, piped stdin,
-scripts — `veryfront init` skips every prompt and uses `ai-agent` on Node.js
+The wizard needs a terminal. In non-interactive environments (CI, piped stdin,
+scripts), `veryfront init` skips every prompt and uses `ai-agent` on Node.js
 without initializing Git. Passing `--template` also skips the whole wizard,
 including the runtime and Git questions.
 

--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -27,7 +27,7 @@ Initialize Git?              preselects Yes
 ```
 
 Press Enter three times to accept the preselected answers, or use the arrow keys
-to change one first.
+to change an answer first.
 
 The wizard needs a terminal. In non-interactive environments (CI, piped stdin,
 scripts), `veryfront init` skips every prompt and uses `ai-agent` on Node.js

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,8 +20,8 @@ cd support-agent
 
 Passing `-- --template <template>` scaffolds straight away and is what the rest
 of this page assumes. Omit it and the command opens an interactive setup wizard
-that waits for three answers — starter template, runtime, and whether to
-initialize Git — before it writes anything. See
+that waits for three answers (starter template, runtime, and whether to
+initialize Git) before it writes anything. See
 [Create project](./create-project.md) for the wizard. The wizard only appears in
 a terminal; in CI, scripts, and other non-interactive shells the command falls
 back to `ai-agent` on Node.js without Git.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -14,12 +14,17 @@ globally, run them with `npx veryfront@latest ...`.
 ## Create the app
 
 ```bash
-npm create veryfront@latest support-agent
+npm create veryfront@latest support-agent -- --template ai-agent
 cd support-agent
 ```
 
-The `ai-agent` starter is the default. Pass `-- --template <template>` when you
-want a different starting point.
+Passing `-- --template <template>` scaffolds straight away and is what the rest
+of this page assumes. Omit it and the command opens an interactive setup wizard
+that waits for three answers — starter template, runtime, and whether to
+initialize Git — before it writes anything. See
+[Create project](./create-project.md) for the wizard. The wizard only appears in
+a terminal; in CI, scripts, and other non-interactive shells the command falls
+back to `ai-agent` on Node.js without Git.
 
 The `ai-agent` template creates a runnable chat app:
 


### PR DESCRIPTION
Found during a DX dogfood walk of the published getting-started flow.

## Symptom

The quickstart told readers to run:

```bash
npm create veryfront@latest support-agent
```

and then said only: "The `ai-agent` starter is the default. Pass `-- --template <template>` when you want a different starting point." The page presents scaffolding as one automatic step.

In a real terminal that command does not scaffold anything. It stops and waits:

```
Let's set up your project.
Choose a starter template:
  ● AI Agent
    Minimal
    ...
```

and blocks indefinitely — there is no timeout and no non-interactive fallback once a tty is present. Answering that prompt reveals the wizard is not one question but three: `Choose a starter template:`, then `Select runtime:`, then `Initialize Git?`. None of "wizard", "Select runtime", or "Initialize Git" appeared anywhere in the published docs for `npm create`.

Reproduced against this tree with a pty driver on `cli/main.ts init probe-app`: blocked on the template prompt until the harness killed it; with two Enters it walked template -> runtime -> git and stalled on git.

## Root cause

Doc drift, not a CLI defect. `shouldRunWizard()` (cli/commands/init/interactive-wizard.ts) returns true whenever `--template` is absent, and `runInteractiveWizard()` then prompts for template (line 129), runtime (line 155) and git (line 184). The quickstart documented the one invocation that trips this gate while describing the outcome of the invocation that does not.

## Fix

- `docs/getting-started/quickstart.md`: the documented command now passes `-- --template ai-agent`, and the prose says what omitting it does (three-question wizard) and what happens in non-interactive shells (`ai-agent`, Node.js, no git).
- `docs/getting-started/create-project.md`: replaces "The wizard preselects the `ai-agent` template" with all three questions and their preselected answers, plus the two ways to skip the wizard.

No CLI behaviour changes.

## Regression test

`cli/commands/init/interactive-wizard.test.ts` — it lives next to the gate it protects, so the doc claim and the code that makes it true fail together:

- reads the quickstart's create command, extracts `--template`, and asserts `shouldRunWizard()` returns `false` for it. Drop the flag from the doc and the test fails.
- asserts create-project.md contains every `SETUP_COPY` prompt string verbatim. Add or rename a wizard prompt and the test fails until the page is updated.

Both failed before the doc edits (`shouldRunWizard` returned `true`; the page did not contain "Choose a starter template:") and pass after.

## Verification

Doc claims checked against real CLI output, not just source:

- `init probe-app` in a pty: blocks on `Choose a starter template:` with AI Agent preselected; two Enters expose `Select runtime:` (Node.js preselected) and `Initialize Git?` (Yes preselected).
- `init probe-app --template ai-agent` in a pty: no prompt at all, straight to install, `✓ probe-app ready`, and no `.git` in the scaffold — confirming `--template` skips the runtime and git questions too.
- `scripts/docs/validate-guides.ts` passes (one pre-existing unrelated warning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the quickstart guide with the recommended `ai-agent` template and clarified interactive and non-interactive setup behavior.
  - Expanded project creation guidance to explain wizard prompts, default selections, and how to bypass the wizard.
- **Tests**
  - Added validation to ensure getting-started documentation stays aligned with the interactive project creation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->