### PR TITLE
fix(config): keep the env-ordering diagnostic off the user's console

### DIFF
--- a/src/config/environment-config.test.ts
+++ b/src/config/environment-config.test.ts
@@ -90,7 +90,7 @@ describe("EnvironmentConfig", () => {
           expect(second).not.toBe(first);
           expect(Object.isFrozen(second)).toBe(true);
           expect(isEnvironmentConfigInitialized()).toBe(false);
-          expect(warnings).toHaveLength(1);
+          expect(warnings).toHaveLength(0);
 
           const earlyInit = initEnvironmentConfig();
           expect(earlyInit.apiToken).toBe("after-mutation");
@@ -107,6 +107,55 @@ describe("EnvironmentConfig", () => {
       } finally {
         logger.warn = originalWarn;
       }
+    });
+
+    // Regression: a second copy of the framework can be loaded from the
+    // project's own node_modules mid-request (globally installed CLI + local
+    // `veryfront` dependency). That copy never runs loadEnv, so the early
+    // access diagnostic fired on the user's first agent request. The advice it
+    // carries ("ensure loadEnv runs before environment config access") is only
+    // actionable by framework code, so it must not reach the user's console.
+    it("keeps the early-access ordering diagnostic off the user-facing warn channel", async () => {
+      __resetEnvLoaderForTests();
+      const originalWarn = logger.warn;
+      const originalDebug = logger.debug;
+      const warnings: string[] = [];
+      const debugMessages: string[] = [];
+      logger.warn = (message: string) => warnings.push(message);
+      logger.debug = (message: string) => debugMessages.push(message);
+
+      try {
+        await withEnv({ VERYFRONT_DEBUG_RUNTIME_ENV: "0" }, async () => {
+          getEnvironmentConfig();
+          getEnvironmentConfig();
+        });
+      } finally {
+        logger.warn = originalWarn;
+        logger.debug = originalDebug;
+      }
+
+      expect(warnings).toHaveLength(0);
+      expect(debugMessages.filter((m) => m.includes("[EnvironmentConfig]"))).toHaveLength(1);
+    });
+
+    it("keeps the early-access diagnostic on warn with a stack under VERYFRONT_DEBUG_RUNTIME_ENV", async () => {
+      __resetEnvLoaderForTests();
+      const originalWarn = logger.warn;
+      const warnings: unknown[][] = [];
+      logger.warn = (...args: unknown[]) => warnings.push(args);
+
+      try {
+        await withEnv({ VERYFRONT_DEBUG_RUNTIME_ENV: "1" }, async () => {
+          getEnvironmentConfig();
+        });
+      } finally {
+        logger.warn = originalWarn;
+      }
+
+      expect(warnings).toHaveLength(1);
+      const [message, details] = warnings[0] ?? [];
+      expect(String(message)).toContain("[EnvironmentConfig]");
+      expect(details).toHaveProperty("stack");
     });
   });
 

--- a/src/config/environment-config.ts
+++ b/src/config/environment-config.ts
@@ -264,6 +264,18 @@ export function refreshEnvironmentConfig(): EnvironmentConfig {
   return _environmentConfig;
 }
 
+/**
+ * Record the "config read before .env load" ordering diagnostic.
+ *
+ * This is a framework-internal signal: the only fix it names — run `loadEnv`
+ * first — belongs to framework code, never to the application developer. It can
+ * fire in a perfectly healthy user session because a second copy of the
+ * framework may be loaded from the project's own `node_modules` mid-request
+ * (globally installed CLI plus a local `veryfront` dependency), and that copy
+ * never runs `loadEnv`. The returned snapshot is still correct there, so the
+ * message stays on the debug channel and only escalates to `warn` — with a
+ * stack — when someone opts in via `VERYFRONT_DEBUG_RUNTIME_ENV`.
+ */
 function warnEarlyAccess(): void {
   if (warnedEarlyEnvConfig) return;
   warnedEarlyEnvConfig = true;
@@ -273,9 +285,9 @@ function warnEarlyAccess(): void {
   const debugStack = getEnv("VERYFRONT_DEBUG_RUNTIME_ENV");
   if (debugStack === "1" || debugStack === "true") {
     logger.warn(message, { stack: new Error().stack });
-  } else {
-    logger.warn(message);
+    return;
   }
+  logger.debug(message);
 }
 
 export function getEnvironmentConfig(): EnvironmentConfig {
@@ -283,7 +295,7 @@ export function getEnvironmentConfig(): EnvironmentConfig {
     return _environmentConfig;
   }
 
-  // Env not loaded yet - return uncached snapshot with warning
+  // Env not loaded yet - return uncached snapshot, recording the ordering diagnostic
   if (!hasEnvLoaded()) {
     warnEarlyAccess();
     return Object.freeze(readEnvSnapshot());


### PR DESCRIPTION
## Symptom

Found on a DX dogfood walk of the published `veryfront@0.1.1228`.

A freshly scaffolded project (`npm create veryfront@latest support-agent -- --yes`, untouched)
prints a framework-internal diagnostic on the user's **first agent request** — the first chat
message in the default `ai-agent` template:

```
10:17:55  VERYFRONT  ▲ [EnvironmentConfig] getEnvironmentConfig called before .env load. Returning uncached snapshot; ensure loadEnv runs before environment config access.
10:17:56  VERYFRONT  ✖ Failed to fetch remote integration tool definitions
                       error="Integration tools API returned 400 Bad Request"
```

The advice the line carries — "ensure loadEnv runs before environment config access" — is only
actionable by framework code. An application developer has no `loadEnv` to reorder, so the line
reads as an unexplained framework warning sitting next to real errors.

## Root cause

Two things combine:

1. `warnEarlyAccess()` in `src/config/environment-config.ts` logged at `warn`, i.e. on a channel the
   user sees at the default log level.
2. The condition it reports is reachable in a perfectly healthy session. Captured with
   `VERYFRONT_DEBUG_RUNTIME_ENV=1`, the stack is:

   ```
   warnEarlyAccess  <- getEnvironmentConfig <- getApiBaseUrlEnv
     <- getRemoteIntegrationToolDiscovery <- getRemoteToolDefinitions
     <- getAvailableTools <- prepareAgentRuntimeStep <- executeAgentLoopStreaming
   ```

   and every frame resolves to **`support-agent/node_modules/veryfront/esm/…`** while the CLI
   process itself is running out of the globally installed copy. A second copy of the framework is
   loaded from the project's own `node_modules` mid-request. In that copy `loadEnv` has never run
   and never will, so `hasEnvLoaded()` is permanently `false` and the diagnostic fires on the first
   call that reads env config.

The snapshot returned in that state is still correct — process env is shared between the two copies
and the early path deliberately returns an uncached snapshot. Only the message is wrong to show.

This PR fixes the leak. The underlying split module graph (global CLI + project-local `veryfront`
loading two framework copies in one process) is the same root cause behind the separately tracked
"globally-installed CLI never registers the project's `tools/` directory" finding, and is left to
that change.

## Fix

`warnEarlyAccess()` now logs the message at `debug`. The `warn`-with-stack path is unchanged and
still available behind the existing `VERYFRONT_DEBUG_RUNTIME_ENV` opt-in, so framework work on env
ordering keeps the loud signal, and `LOG_LEVEL=debug` / `VERYFRONT_DEBUG=1` still surfaces the
message for everyone else. Nothing about when the diagnostic is computed, or about the snapshot it
guards, changed.

## Regression test

`src/config/environment-config.test.ts` — next to the existing early-snapshot tests, because the
behaviour under test is a property of `getEnvironmentConfig()`'s pre-`loadEnv` branch, and that file
already owns the stubbing pattern for it. No browser or deployment is involved, so this is a Deno
BDD unit test rather than an e2e.

Two cases:

- `keeps the early-access ordering diagnostic off the user-facing warn channel` — with
  `VERYFRONT_DEBUG_RUNTIME_ENV` off, two early `getEnvironmentConfig()` calls produce **zero** warn
  records and exactly one debug record (also pinning the once-per-process dedupe). Fails on `main`
  with `Expected value to have length 0, but it does not: the value has length 1`.
- `keeps the early-access diagnostic on warn with a stack under VERYFRONT_DEBUG_RUNTIME_ENV` — pins
  the opt-in escalation path so a future cleanup cannot quietly delete the diagnostic.

The existing `keeps early snapshots immutable and uncached until environment loading completes` test
asserted `warnings).toHaveLength(1)`; that assertion moved to the new tests and now reads `0`.

## Verification

- New test fails on `main` for the right reason, passes with the fix.
- `src/config/`, `src/utils/env-loader.test.ts`, `src/utils/logger/logger.test.ts`: 48 passed, 0 failed.
- Original symptom: re-ran the exact repro (published 0.1.1228 scaffold, globally installed CLI,
  `POST /api/ag-ui` with UUID thread/run/message ids) with this change applied to the installed
  package. `[EnvironmentConfig]` occurrences in the server log went from 1 to 0; the rest of the log
  is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary warning messages when environment configuration is accessed early.
  - Early-access diagnostics are now logged quietly by default while still being recorded for troubleshooting.
  - Runtime debug mode continues to provide warning messages with stack details for easier investigation.

- **Documentation**
  - Added guidance explaining early environment-configuration access diagnostics and debug behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->