### PR TITLE
fix(css): report a missing CSS optimizer once, and say how to add one

### DIFF
--- a/src/html/styles-builder/css-provider-session.test.ts
+++ b/src/html/styles-builder/css-provider-session.test.ts
@@ -6,6 +6,11 @@ import {
   type CSSProcessor,
   CSSProcessorName,
 } from "#veryfront/extensions/css/index.ts";
+import {
+  __resetLogRecordEmitterForTests,
+  __subscribeLogRecordEmitter,
+  type LogEntry,
+} from "#veryfront/utils/logger/index.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
@@ -201,6 +206,40 @@ describe("styles-builder CSS provider sessions", () => {
 
     const generated = await generateTailwindCSS("sheet", ["alpha"], { minify: true });
     assertEquals(generated.css, "missing-optimizer|sheet|alpha");
+  });
+
+  it("reports a missing optimizer once, with the package that provides one", () => {
+    // `regenerateCSSByHash` acquires a session per request, so warning on every
+    // acquisition made this line the most frequent entry in a hosted project's
+    // logs -- once per render, at warn level, naming a registration hook with no
+    // documented way to act on it. State the package that registers an engine,
+    // and say it once while the engine stays absent.
+    installProcessor(createProcessor("warn-rearm"));
+    register(CSSOptimizationEngineName, createOptimizer("warn-rearm"));
+    // Observing an engine re-arms the warning, so this test does not depend on
+    // whether an earlier test in this file already reported the absence.
+    acquireCSSGenerationSession(true);
+    resetContracts();
+    installProcessor(createProcessor("warn-once"));
+
+    const records: LogEntry[] = [];
+    __resetLogRecordEmitterForTests();
+    const unsubscribe = __subscribeLogRecordEmitter((entry) => {
+      records.push(entry);
+    });
+    try {
+      acquireCSSGenerationSession(true);
+      acquireCSSGenerationSession(true);
+      acquireCSSGenerationSession(true);
+    } finally {
+      unsubscribe();
+      __resetLogRecordEmitterForTests();
+    }
+
+    const reports = records.filter((entry) => entry.message.includes("CSSOptimizationEngine"));
+    assertEquals(reports.length, 1);
+    assertEquals(reports[0]?.level, "warn");
+    assertEquals(reports[0]?.message.includes("@veryfront/ext-css-lightning"), true);
   });
 
   it("keeps minified and unminified output in separate cache identities", async () => {

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -7,6 +7,7 @@
  */
 
 import { tryResolve } from "#veryfront/extensions/contracts.ts";
+import { getRecommendation } from "#veryfront/extensions/recommendations.ts";
 import {
   captureCSSOptimizationEngine,
   type CSSOptimizationEngine,
@@ -70,6 +71,7 @@ const weakSetAdd = WeakSet.prototype.add;
 const weakSetHas = WeakSet.prototype.has;
 const CSS_PIPELINE_IDENTITY_SCHEMA = "veryfront.css-pipeline.v2";
 const cssGenerationSessions = new WeakSet<object>();
+let reportedMissingOptimizationEngine = false;
 const inFlightProjectCSS = new Map<
   string,
   Promise<{ css: string; hash: string; fromCache: boolean }>
@@ -137,11 +139,25 @@ export function acquireCSSGenerationSession(minify: boolean): CSSGenerationSessi
   // an engine the CSS is emitted unminified and the identity below records it
   // as such, so no cache can serve a stale minified entry in its place.
   const optimizationProvider = minify ? tryResolve<unknown>(CSSOptimizationEngineName) : undefined;
-  if (minify && optimizationProvider === undefined) {
+  if (optimizationProvider !== undefined) {
+    // Re-arm: an engine that disappears later is a new regression to report.
+    reportedMissingOptimizationEngine = false;
+  } else if (minify && !reportedMissingOptimizationEngine) {
     // Warn, not debug: this is a silent quality regression for a project that
     // did select an optimizer and whose registration failed. It must not be
     // indistinguishable from a project that never wanted one.
-    logger.warn("No CSSOptimizationEngine registered; emitting unminified CSS");
+    //
+    // Once per process, not once per acquisition: regenerateCSSByHash acquires
+    // a session on every cold-cache request, which made this the single most
+    // frequent line in a hosted project's logs. Name the package that registers
+    // an engine, or the message asks for a hook with no way to reach it.
+    reportedMissingOptimizationEngine = true;
+    const recommendation = getRecommendation(CSSOptimizationEngineName);
+    logger.warn(
+      recommendation === undefined
+        ? "No CSSOptimizationEngine registered; emitting unminified CSS"
+        : `No CSSOptimizationEngine registered; emitting unminified CSS. Install one with: deno add ${recommendation}`,
+    );
   }
   const optimizationEngine = optimizationProvider === undefined
     ? undefined


### PR DESCRIPTION
Found during a DX dogfood walk of the published docs (`docs/code/getting-started/deploy-project`), following them literally as a new developer.

## Symptom

`veryfront build` on a freshly scaffolded project prints:

```
  ● Building...
  ! No CSSOptimizationEngine registered; emitting unminified CSS
  ✓ Built in 3.03s
```

`veryfront serve` repeats it at startup, and the hosted runtime emits it at
`level=warn component=css-compiler` **once per render** — it was the single most
frequent line in the dogfood project's cloud logs (4+ entries in the first four
seconds of the deployment's stream).

Two problems, one line:

1. **Volume.** `regenerateCSSByHash` acquires a generation session on every
   cold-cache request, before the in-flight map is even consulted, so every
   render that misses the local CSS cache logs the warning again. A default
   project floods its own observability with a message about a condition that
   has not changed since boot.
2. **No action.** The message names `CSSOptimizationEngine`, an internal
   contract name. Nothing in the docs says how to register one, so a developer
   reading it has no next step.

## Root cause

`acquireCSSGenerationSession` in `src/html/styles-builder/tailwind-compiler.ts`
logged unconditionally whenever `minify` was requested and no engine resolved.
The absence is a process-level fact, but the log was per-acquisition.

## Fix

Report the absence once while it holds, and name the package that fixes it:

```
! No CSSOptimizationEngine registered; emitting unminified CSS. Install one with: deno add @veryfront/ext-css-lightning
```

The package name comes from the existing `getRecommendation` map, which already
maps `CSSOptimizationEngine` → `@veryfront/ext-css-lightning`, and the phrasing
matches how `resolve()` reports a missing extension.

The flag re-arms whenever an engine *is* observed, so a project whose engine
registration later breaks gets a fresh warning rather than permanent silence —
which is the case the warn level exists for.

Behaviour is otherwise unchanged: an absent engine still degrades to unminified
CSS and is still recorded in the pipeline cache identity, so no minified entry
can be served from an unminified one.

## Regression test

`src/html/styles-builder/css-provider-session.test.ts` — "reports a missing
optimizer once, with the package that provides one". It lives beside the other
provider-session tests because the behaviour under test is a property of
`acquireCSSGenerationSession`, the same seam those tests already drive; nothing
about it needs a browser or a deployment.

The test acquires three sessions with no engine registered and asserts exactly
one `warn` record naming `@veryfront/ext-css-lightning`. It first registers and
acquires with an engine so it re-arms the flag itself and does not depend on
test ordering within the file.

Confirmed failing before the fix for the right reason (`3` records, expected
`1`), passing after.

## Verification

- `deno test src/html/styles-builder src/extensions src/release-assets src/build src/server/handlers/dev/styles-css.handler.test.ts` — 174 passed, 0 failed.
- Re-ran the finding's command against a scaffolded project with the local tree:
  the build now prints the actionable message once.
- `deno fmt --check`, `deno lint`, `deno check`, `lint:module-boundaries`,
  `lint:dependency-boundaries` all clean.
