### PR TITLE
fix(cli): resolve the local project link in veryfront open

### DIFF
--- a/cli/commands/open/command-help.ts
+++ b/cli/commands/open/command-help.ts
@@ -10,7 +10,10 @@ export const openHelp: CommandHelp = {
       flag: "-p, --project <slug>",
       description: "Project slug to open (overrides inferred project)",
     },
-    { flag: "--env <name>", description: "Open a specific environment URL" },
+    {
+      flag: "--env <name>",
+      description: "Open a specific environment's dashboard page",
+    },
     { flag: "--studio", description: "Open Veryfront Studio" },
     { flag: "--json", description: "Output URL as JSON instead of opening" },
   ],

--- a/cli/commands/open/handler.test.ts
+++ b/cli/commands/open/handler.test.ts
@@ -1,14 +1,84 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "veryfront/platform/path";
 import { parseCliArgs } from "#cli/shared/args";
 import { buildUrl, parseOpenArgs } from "./command.ts";
-import { createSuccessEnvelope } from "../../shared/json-output.ts";
+import { createSuccessEnvelope, setJsonMode } from "../../shared/json-output.ts";
+import { reportProjectNotFound, resolveOpenProjectSlug } from "./handler.ts";
 
 function assertSuccess<T extends { success: boolean; data?: unknown }>(
   result: T,
 ): asserts result is T & { success: true; data: NonNullable<T["data"]> } {
   assertEquals(result.success, true);
+}
+
+const PROJECT_REFERENCE_ENV_KEYS = [
+  "VERYFRONT_PROJECT_SLUG",
+  "TENANT_PROJECT_SLUG",
+  "VERYFRONT_PROJECT_ID",
+  "TENANT_PROJECT_ID",
+  "VERYFRONT_API_URL",
+  "VERYFRONT_API_BASE_URL",
+] as const;
+
+async function withSavedEnv(fn: () => Promise<void> | void): Promise<void> {
+  const saved = new Map(
+    PROJECT_REFERENCE_ENV_KEYS.map((key) => [key, Deno.env.get(key)]),
+  );
+  try {
+    for (const key of PROJECT_REFERENCE_ENV_KEYS) Deno.env.delete(key);
+    await fn();
+  } finally {
+    for (const key of PROJECT_REFERENCE_ENV_KEYS) {
+      const value = saved.get(key);
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  }
+}
+
+async function withTempProject(
+  fn: (projectDir: string) => Promise<void>,
+): Promise<void> {
+  const projectDir = await Deno.makeTempDir();
+  try {
+    await fn(projectDir);
+  } finally {
+    await Deno.remove(projectDir, { recursive: true });
+  }
+}
+
+/** The link `push`/`deploy` write into a project directory. */
+async function writeProjectLink(
+  projectDir: string,
+  projectSlug: string,
+  controlPlane = "https://api.veryfront.com",
+): Promise<void> {
+  await Deno.mkdir(join(projectDir, ".veryfront"), { recursive: true });
+  await Deno.writeTextFile(
+    join(projectDir, ".veryfront", "project.json"),
+    JSON.stringify({
+      version: 1,
+      controlPlane,
+      projectId: "linked-project-id",
+      projectSlug,
+    }),
+  );
+}
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map((value) => String(value)).join(" "));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return lines.join("\n");
 }
 
 describe("Open Command", () => {
@@ -63,6 +133,108 @@ describe("Open Command", () => {
       const result = parseOpenArgs(parseCliArgs(["open", "--project-slug", "my-project"]));
       assertSuccess(result);
       assertEquals(result.data.projectSlug, "my-project");
+    });
+  });
+
+  describe("resolveOpenProjectSlug", () => {
+    it("resolves the project push and deploy linked in this directory", async () => {
+      await withSavedEnv(async () => {
+        await withTempProject(async (projectDir) => {
+          await writeProjectLink(projectDir, "dx-dogfood-deploy");
+
+          assertEquals(
+            await resolveOpenProjectSlug(projectDir),
+            "dx-dogfood-deploy",
+          );
+        });
+      });
+    });
+
+    it("returns undefined for a directory with no project reference", async () => {
+      await withSavedEnv(async () => {
+        await withTempProject(async (projectDir) => {
+          assertEquals(await resolveOpenProjectSlug(projectDir), undefined);
+        });
+      });
+    });
+
+    it("prefers --project over the local link", async () => {
+      await withSavedEnv(async () => {
+        await withTempProject(async (projectDir) => {
+          await writeProjectLink(projectDir, "linked-project");
+
+          assertEquals(
+            await resolveOpenProjectSlug(projectDir, "flag-project"),
+            "flag-project",
+          );
+        });
+      });
+    });
+
+    it("prefers veryfront.json over the local link", async () => {
+      await withSavedEnv(async () => {
+        await withTempProject(async (projectDir) => {
+          await writeProjectLink(projectDir, "linked-project");
+          await Deno.writeTextFile(
+            join(projectDir, "veryfront.json"),
+            JSON.stringify({ projectSlug: "json-config-project" }),
+          );
+
+          assertEquals(
+            await resolveOpenProjectSlug(projectDir),
+            "json-config-project",
+          );
+        });
+      });
+    });
+
+    it("prefers a tenant project reference over the local link", async () => {
+      await withSavedEnv(async () => {
+        Deno.env.set("TENANT_PROJECT_SLUG", "tenant-project");
+        await withTempProject(async (projectDir) => {
+          await writeProjectLink(projectDir, "linked-project");
+
+          assertEquals(
+            await resolveOpenProjectSlug(projectDir),
+            "tenant-project",
+          );
+        });
+      });
+    });
+
+    it("rejects a local link that targets a different control plane", async () => {
+      await withSavedEnv(async () => {
+        await withTempProject(async (projectDir) => {
+          await writeProjectLink(
+            projectDir,
+            "linked-project",
+            "https://api.other.veryfront.com",
+          );
+
+          await assertRejects(
+            () => resolveOpenProjectSlug(projectDir),
+            Error,
+            ".veryfront/project.json",
+          );
+        });
+      });
+    });
+  });
+
+  describe("reportProjectNotFound", () => {
+    it("emits a JSON error envelope in --json mode", async () => {
+      setJsonMode(true);
+      try {
+        const output = await captureStdout(() => reportProjectNotFound());
+        const parsed = JSON.parse(output);
+
+        assertEquals(parsed.success, false);
+        assertEquals(parsed.command, "open");
+        assertEquals(parsed.error.code, "PROJECT_NOT_FOUND");
+        assertEquals(parsed.error.message, "No project found.");
+      } finally {
+        setJsonMode(false);
+      }
     });
   });
 });

--- a/cli/commands/open/handler.test.ts
+++ b/cli/commands/open/handler.test.ts
@@ -202,6 +202,32 @@ describe("Open Command", () => {
       });
     });
 
+    it("skips an ID-only reference rather than opening /projects/<id>", async () => {
+      // `buildUrl` pastes what it is given into the dashboard path, and the
+      // dashboard wants the canonical slug — `push` calls the API to turn a
+      // project ID into one. `open` has no token, so the ID must not be used.
+      await withSavedEnv(async () => {
+        Deno.env.set("VERYFRONT_PROJECT_ID", "project-123");
+        await withTempProject(async (projectDir) => {
+          await writeProjectLink(projectDir, "linked-project");
+
+          assertEquals(
+            await resolveOpenProjectSlug(projectDir),
+            "linked-project",
+          );
+        });
+      });
+    });
+
+    it("reports no project when only a project ID is set", async () => {
+      await withSavedEnv(async () => {
+        Deno.env.set("TENANT_PROJECT_ID", "project-123");
+        await withTempProject(async (projectDir) => {
+          assertEquals(await resolveOpenProjectSlug(projectDir), undefined);
+        });
+      });
+    });
+
     it("rejects a local link that targets a different control plane", async () => {
       await withSavedEnv(async () => {
         await withTempProject(async (projectDir) => {

--- a/cli/commands/open/handler.ts
+++ b/cli/commands/open/handler.ts
@@ -23,11 +23,24 @@ export const PROJECT_NOT_FOUND_ERROR: ErrorEnvelope["error"] = {
 };
 
 /**
+ * Environment references that name a project by slug. `VERYFRONT_PROJECT_ID`
+ * and `TENANT_PROJECT_ID` name it by ID instead, and `buildUrl` produces
+ * `https://veryfront.com/projects/<slug>` — `push` resolves an ID through the
+ * API before printing that URL, which `open` cannot do without a token. So an
+ * ID-only reference is skipped rather than pasted in as a slug, and resolution
+ * keeps walking to the local link `push`/`deploy` wrote for that same project.
+ */
+const SLUG_ENVIRONMENT_REFERENCE_NAMES: ReadonlySet<string> = new Set([
+  "VERYFRONT_PROJECT_SLUG",
+  "TENANT_PROJECT_SLUG",
+]);
+
+/**
  * The project `open` targets, in the precedence the deploy docs publish:
  * `--project`, then `VERYFRONT_PROJECT_SLUG` or environment configuration,
  * then `veryfront.config.ts`, then legacy `veryfront.json`, then lower-level
- * tenant or project-ID environment references, then the local project link
- * `push` and `deploy` write into the directory.
+ * tenant slug environment references, then the local project link `push` and
+ * `deploy` write into the directory.
  */
 export async function resolveOpenProjectSlug(
   projectDir: string,
@@ -40,8 +53,11 @@ export async function resolveOpenProjectSlug(
 
   const env = getEnvironmentConfig();
   const fileConfig = await readConfigFile(projectDir);
+  const environmentReference = resolveEnvironmentProjectReference();
   const referenced = env.projectSlug ?? fileConfig?.projectSlug ??
-    resolveEnvironmentProjectReference()?.reference;
+    (environmentReference && SLUG_ENVIRONMENT_REFERENCE_NAMES.has(environmentReference.name)
+      ? environmentReference.reference
+      : undefined);
   if (referenced) return referenced;
 
   const { resolveCliApiUrl } = await import("../../shared/constants.ts");

--- a/cli/commands/open/handler.ts
+++ b/cli/commands/open/handler.ts
@@ -2,27 +2,75 @@ import type { ParsedArgs } from "#cli/shared/types";
 import { parseArgsOrThrow } from "#cli/shared/args";
 import { exitProcess, logUsageError } from "#cli/utils";
 import { brand } from "../../ui/colors.ts";
-import { createSuccessEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
+import {
+  createErrorEnvelope,
+  createSuccessEnvelope,
+  type ErrorEnvelope,
+  isJsonMode,
+  outputJson,
+} from "../../shared/json-output.ts";
 import { buildUrl, parseOpenArgs } from "./command.ts";
+
+const PROJECT_NOT_FOUND_HINT =
+  "Run from a project directory or set --project / VERYFRONT_PROJECT_SLUG";
+
+/** The one failure `open` can report, in the machine-readable shape. */
+export const PROJECT_NOT_FOUND_ERROR: ErrorEnvelope["error"] = {
+  code: "PROJECT_NOT_FOUND",
+  slug: "project-not-found",
+  message: "No project found.",
+  context: { suggestion: PROJECT_NOT_FOUND_HINT },
+};
+
+/**
+ * The project `open` targets, in the precedence the deploy docs publish:
+ * `--project`, then `VERYFRONT_PROJECT_SLUG` or environment configuration,
+ * then `veryfront.config.ts`, then legacy `veryfront.json`, then lower-level
+ * tenant or project-ID environment references, then the local project link
+ * `push` and `deploy` write into the directory.
+ */
+export async function resolveOpenProjectSlug(
+  projectDir: string,
+  explicitSlug?: string,
+): Promise<string | undefined> {
+  if (explicitSlug) return explicitSlug;
+
+  const { getEnvironmentConfig } = await import("veryfront/config");
+  const { readConfigFile, resolveEnvironmentProjectReference } = await import("#cli/shared/config");
+
+  const env = getEnvironmentConfig();
+  const fileConfig = await readConfigFile(projectDir);
+  const referenced = env.projectSlug ?? fileConfig?.projectSlug ??
+    resolveEnvironmentProjectReference()?.reference;
+  if (referenced) return referenced;
+
+  const { resolveCliApiUrl } = await import("../../shared/constants.ts");
+  const { readProjectLinkForControlPlane } = await import("../../shared/project-link.ts");
+
+  const link = await readProjectLinkForControlPlane(
+    projectDir,
+    resolveCliApiUrl(env, fileConfig?.apiUrl),
+  );
+  return link?.projectSlug;
+}
+
+/** Report the one failure `open` can hit, honoring `--json`. */
+export async function reportProjectNotFound(): Promise<void> {
+  if (isJsonMode()) {
+    await outputJson(createErrorEnvelope("open", PROJECT_NOT_FOUND_ERROR));
+    return;
+  }
+  logUsageError(PROJECT_NOT_FOUND_ERROR.message, PROJECT_NOT_FOUND_HINT);
+}
 
 export async function handleOpenCommand(args: ParsedArgs): Promise<void> {
   const opts = parseArgsOrThrow(parseOpenArgs, "open", args);
 
-  let projectSlug = opts.projectSlug;
-  if (!projectSlug) {
-    const { cwd } = await import("veryfront/platform");
-    const { getEnvironmentConfig } = await import("veryfront/config");
-    const { readConfigFile } = await import("#cli/shared/config");
-    projectSlug = getEnvironmentConfig().projectSlug ??
-      (await readConfigFile(cwd()))?.projectSlug ??
-      undefined;
-  }
+  const { cwd } = await import("veryfront/platform");
+  const projectSlug = await resolveOpenProjectSlug(cwd(), opts.projectSlug);
 
   if (!projectSlug) {
-    logUsageError(
-      "No project found.",
-      "Run from a project directory or set --project / VERYFRONT_PROJECT_SLUG",
-    );
+    await reportProjectNotFound();
     exitProcess(1);
     return;
   }

--- a/cli/help/tips.test.ts
+++ b/cli/help/tips.test.ts
@@ -67,6 +67,12 @@ describe("cli/help/tips", () => {
       assertEquals(getPostDeployTips().includes("npx"), false);
     });
 
+    it("labels veryfront open as the dashboard, not the deployed site", () => {
+      // `open` builds https://veryfront.com/projects/<slug> URLs, so a bare
+      // "Open:" label reads as an offer to open the deployment itself.
+      assertEquals(getPostDeployTips().includes("Dashboard:"), true);
+    });
+
     it("does not add a generic next-steps block", () => {
       assertEquals(getPostDeployTips().includes("Next steps"), false);
     });

--- a/cli/help/tips.ts
+++ b/cli/help/tips.ts
@@ -27,7 +27,7 @@ export function getInitTemplates(): string {
 }
 
 export function getPostDeployTips(): string {
-  return `\n  ${dim("Open:")} ${cyan("veryfront open")}\n`;
+  return `\n  ${dim("Dashboard:")} ${cyan("veryfront open")}\n`;
 }
 
 const COMMAND_TIPS: Record<string, () => string> = {

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -83,10 +83,19 @@ For a non-Cloud target, run `veryfront build` and ship the `dist/` output. See
 ## Verify it worked
 
 Deploy prints the environment URL. Request that URL and confirm the deployed
-page and API routes respond:
+page responds:
 
 ```bash
 curl -sSf <environment-url>
+```
+
+Then request an API route the project serves. For the agent route from
+[Create API](./create-api.md):
+
+```bash
+curl -sSf -N -X POST <environment-url>/api/ag-ui \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"What is Veryfront in one sentence?"}]}]}'
 ```
 
 `veryfront open` opens the project in the Cloud dashboard, where the deployment

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -82,13 +82,17 @@ For a non-Cloud target, run `veryfront build` and ship the `dist/` output. See
 
 ## Verify it worked
 
-After Deploy completes, run:
+Deploy prints the environment URL. Request that URL and confirm the deployed
+page and API routes respond:
 
 ```bash
-veryfront open
+curl -sSf <environment-url>
 ```
 
-The deployed page and API routes respond.
+`veryfront open` opens the project in the Cloud dashboard, where the deployment
+is listed; `veryfront open --env production` opens that environment's dashboard
+page. Neither opens the deployed site, so use the environment URL Deploy printed
+to check the running deployment.
 
 For an automated production workflow, see
 [Deploy from CI](../guides/deploy-from-ci.md).

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -87,9 +87,12 @@ npx veryfront@latest deploy --branch feature-x --env staging
 Deploy uses the last verified Push receipt and verifies the release was built
 from that exact source digest before assigning it to the environment. If no Push
 receipt exists, Deploy first runs a quiet Push so the first deployment still
-works as one command. Use `npx veryfront@latest open` after deployment to open
-the project. Deploy prints the environment URL; use
-`npx veryfront@latest open --json` when automation needs the same URL later.
+works as one command. Deploy prints the environment URL; record it when
+automation needs the deployed URL later. Use `npx veryfront@latest open` after
+deployment to open the project in the Cloud dashboard, and
+`npx veryfront@latest open --json` to print that dashboard URL. `open` resolves
+the same project reference Push and Deploy use, including the local
+`.veryfront/project.json` link.
 
 Project reference precedence is `VERYFRONT_PROJECT_SLUG` or environment
 configuration, then `veryfront.config.ts`, then legacy `veryfront.json`, then
@@ -141,7 +144,9 @@ After `veryfront deploy`:
 - The CLI reports whether every shared proxy acknowledged the active release. An
   unconfirmed data-plane update is a warning after commit, not a failed deploy;
   do not retry solely because of that warning.
-- `veryfront open` opens the deployed project.
+- The environment URL Deploy printed serves the deployed page and API routes.
+- `veryfront open` opens the project in the Cloud dashboard, not the deployed
+  site.
 - The same page, API route, agent, workflow, task, or run path works in
   production.
 - The Cloud dashboard lists the deployment under the project.

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -92,7 +92,9 @@ automation needs the deployed URL later. Use `npx veryfront@latest open` after
 deployment to open the project in the Cloud dashboard, and
 `npx veryfront@latest open --json` to print that dashboard URL. `open` resolves
 the same project reference Push and Deploy use, including the local
-`.veryfront/project.json` link.
+`.veryfront/project.json` link. Dashboard URLs are built from the project slug,
+so `open` skips an ID-only `VERYFRONT_PROJECT_ID` or `TENANT_PROJECT_ID`
+reference and uses the link instead.
 
 Project reference precedence is `VERYFRONT_PROJECT_SLUG` or environment
 configuration, then `veryfront.config.ts`, then legacy `veryfront.json`, then

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -162,6 +162,33 @@ describe("guide content contracts", () => {
     assertStringIncludes(guide, "npx veryfront@latest open");
   });
 
+  it("points post-deploy verification at the environment URL, not at open", async () => {
+    // `veryfront open` builds Cloud dashboard URLs
+    // (https://veryfront.com/projects/<slug>[/environments/<env>]). It never
+    // resolves the deployed site, so the deploy docs must not send readers to
+    // it to confirm the deployment responds.
+    const docs = [
+      "docs/getting-started/deploy-project.md",
+      "docs/guides/deploying.md",
+    ];
+
+    for (const path of docs) {
+      const text = await Deno.readTextFile(path);
+
+      assertStringIncludes(text, "open` opens the project in the Cloud dashboard");
+      assertEquals(text.includes("open` opens the deployed"), false);
+    }
+
+    const gettingStarted = await Deno.readTextFile(
+      "docs/getting-started/deploy-project.md",
+    );
+    assertStringIncludes(gettingStarted, "Deploy prints the environment URL");
+    assertEquals(
+      gettingStarted.includes("The deployed page and API routes respond."),
+      false,
+    );
+  });
+
   it("uses serve for local production builds", async () => {
     const docs = [
       "docs/getting-started/deploy-project.md",


### PR DESCRIPTION
Found during a DX dogfood walk of
[getting-started/deploy-project](https://veryfront.com/docs/code/getting-started/deploy-project)
and [guides/deploying](https://veryfront.com/docs/code/guides/deploying), following
the published pages literally. Two findings, one root cause: `veryfront open` does
not behave the way the deploy journey's final step assumes.

## Symptom

Run from the project root seconds after a successful `npx veryfront deploy --env production`
in that same directory:

```
$ veryfront open ; echo EXIT=$?
  ✗ No project found.
  Run from a project directory or set --project / VERYFRONT_PROJECT_SLUG
EXIT=1
```

The directory contains the `.veryfront/project.json` link that `push` and `deploy`
had just written and both had resolved the project from without any flag.
`veryfront open --project <slug>` and `VERYFRONT_PROJECT_SLUG=<slug> veryfront open`
both exit 0, isolating the failure to directory-based resolution. `--json` made it
worse: the failure printed the human banner, so scripted verification could not
parse it.

Separately, no `open` invocation reaches the deployment:

```
$ veryfront open --project <slug> --env production --json
{"data":{"url":"https://veryfront.com/projects/<slug>/environments/production"}}
```

That is the Studio environment page, not the environment URL `deploy` itself
printed — so "the deployed page and API routes respond" could not be checked via
`open` at all.

## Root cause

`cli/commands/open/handler.ts` resolved the project with only
`getEnvironmentConfig().projectSlug ?? (await readConfigFile(cwd()))?.projectSlug`.
That stops two tiers short of the precedence the same docs publish
("… then lower-level tenant or project-ID environment references, then the ignored
local link"): it never consults `resolveEnvironmentProjectReference()` and never
reads `.veryfront/project.json`. `cli/commands/config/handler.ts` already resolves
the full chain; `open` was the outlier.

The failure branch also called `logUsageError` unconditionally, ignoring `isJsonMode()`.

`buildUrl` has only ever produced `https://veryfront.com/projects/…` dashboard URLs.
That is the intended behavior of the command; the docs describing it as the way to
reach the running deployment were wrong.

## Change

- `resolveOpenProjectSlug` now walks the documented precedence and ends at
  `readProjectLinkForControlPlane`, the same reader `config`/`push`/`deploy` use —
  including its loud error when the link targets a different control plane, so a
  stale link can never silently open someone else's project.
- `reportProjectNotFound` emits a `PROJECT_NOT_FOUND` error envelope under `--json`
  and keeps the existing banner otherwise.
- Deploy docs point verification at the environment URL Deploy prints and describe
  `open` as the Cloud dashboard shortcut it is; the post-deploy CLI tip is relabeled
  `Dashboard:` for the same reason. No behavior claim was invented — the docs now say
  exactly what the command does.

## Regression tests

- `cli/commands/open/handler.test.ts` — Deno BDD, next to the handler it guards.
  Covers the linked-directory case that failed, each precedence tier above the link,
  the control-plane mismatch, and the `--json` error envelope (captured from the real
  `outputJson` call, not asserted on a constructed value). Before the fix these fail
  with `undefined` instead of the linked slug, `undefined` instead of the tenant
  reference, and `SyntaxError: Unexpected end of JSON input` because nothing was
  written to stdout.
- `tests/docs/guide-content.test.ts` — the doc claim is a doc contract, and this file
  is where the repo already pins deploy-doc wording. It fails against the previous
  text on "`open` opens the deployed project."
- `cli/help/tips.test.ts` — pins the post-deploy tip label.

Verified after the fix by rerunning the finding's command against the local tree:
`veryfront open` from the linked directory exits 0 and prints the project URL, and
`veryfront open --json` with no project anywhere emits a parseable
`{"success":false,…,"code":"PROJECT_NOT_FOUND"}` envelope with exit 1.

`deno task docs:validate` passes; the full CLI unit suite and the pre-push gate are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `open` to consistently resolve the intended project across command-line, configuration, and local project references.
  * Added clearer project-not-found errors, including JSON-formatted output.
  * Clarified that `open` opens the Cloud dashboard rather than the deployed site.

* **Documentation**
  * Updated deployment guidance to use the printed environment URL for verification.
  * Documented dashboard links, JSON output, and production-environment options.
  * Relabeled post-deployment guidance from “Open” to “Dashboard.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->