### PR TITLE
fix(cli): scaffold tools with the id discovery registers

### DIFF
--- a/cli/scaffold/engine.test.ts
+++ b/cli/scaffold/engine.test.ts
@@ -3,6 +3,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#std/path.ts";
+import { filenameToId } from "#veryfront/discovery/discovery-utils.ts";
 import { planScaffold, scaffoldProjectFile } from "./engine.ts";
 
 async function withTempProject(fn: (projectDir: string) => Promise<void>): Promise<void> {
@@ -105,6 +106,21 @@ describe("scaffold engine", () => {
       assertStringIncludes(content, "execute: ({ input }) =>");
       assertEquals(content.includes("execute: async"), false);
     });
+  });
+
+  it("gives a scaffolded tool the same id discovery derives from its filename", () => {
+    const projectDir = "/project";
+
+    for (const name of ["get-weather", "get weather", "search_docs", "searchDocs"]) {
+      const file = planScaffold({ projectDir, type: "tool", name }).files[0]!;
+      const discoveredId = filenameToId(file.path);
+
+      assertStringIncludes(
+        file.content,
+        `id: "${discoveredId}",`,
+        `scaffolded tool "${name}" must declare the id discovery derives from ${file.path}`,
+      );
+    }
   });
 
   it("uses the slug as the generated agent id", async () => {

--- a/cli/scaffold/engine.ts
+++ b/cli/scaffold/engine.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from "veryfront/platform/path";
 import { createFileSystem } from "veryfront/platform";
 import { ensureDir, fileExists } from "../utils/fs.ts";
-import { toComponentName, toSlug } from "../utils/string.ts";
+import { toCamelCaseId, toComponentName, toSlug } from "../utils/string.ts";
 
 export type ScaffoldRouter = "app-router" | "pages-router";
 export const SCAFFOLD_TYPES = [
@@ -94,7 +94,7 @@ const SCAFFOLD_DEFINITIONS: Record<ScaffoldType, ScaffoldDefinition> = {
   },
   tool: {
     getPath: ({ projectDir, slug }) => join(projectDir, "tools", `${slug}.ts`),
-    getContent: ({ name }) => generateToolTemplate(name),
+    getContent: ({ slug }) => generateToolTemplate(toCamelCaseId(slug)),
   },
   agent: {
     getPath: ({ projectDir, slug }) => join(projectDir, "agents", `${slug}.ts`),
@@ -270,7 +270,7 @@ export function ${componentName}({ children }: ${componentName}Props) {
 `;
 }
 
-function generateToolTemplate(name: string): string {
+function generateToolTemplate(id: string): string {
   return `import { defineSchema } from "veryfront/schemas";
 import { tool } from "veryfront/tool";
 
@@ -279,7 +279,7 @@ const inputSchema = defineSchema((v) => v.object({
 }))();
 
 export default tool({
-  id: "${name}",
+  id: "${id}",
   description: "Description of what this tool does",
   inputSchema,
   execute: ({ input }) => {

--- a/cli/scaffold/engine.ts
+++ b/cli/scaffold/engine.ts
@@ -1,7 +1,8 @@
 import { dirname, join } from "veryfront/platform/path";
 import { createFileSystem } from "veryfront/platform";
 import { ensureDir, fileExists } from "../utils/fs.ts";
-import { toCamelCaseId, toComponentName, toSlug } from "../utils/string.ts";
+import { toComponentName, toSlug } from "../utils/string.ts";
+import { filenameToId } from "veryfront/discovery";
 
 export type ScaffoldRouter = "app-router" | "pages-router";
 export const SCAFFOLD_TYPES = [
@@ -94,7 +95,10 @@ const SCAFFOLD_DEFINITIONS: Record<ScaffoldType, ScaffoldDefinition> = {
   },
   tool: {
     getPath: ({ projectDir, slug }) => join(projectDir, "tools", `${slug}.ts`),
-    getContent: ({ slug }) => generateToolTemplate(toCamelCaseId(slug)),
+    // Discovery derives a tool's id from its filename, and an explicit `id`
+    // overrides that. Declare the id discovery would have derived so the
+    // generated tool registers under the name the filename promises.
+    getContent: ({ slug }) => generateToolTemplate(filenameToId(`${slug}.ts`)),
   },
   agent: {
     getPath: ({ projectDir, slug }) => join(projectDir, "agents", `${slug}.ts`),

--- a/cli/utils/string.ts
+++ b/cli/utils/string.ts
@@ -10,6 +10,19 @@ export function toSlug(name: string): string {
     .replace(/\/+/g, "/");
 }
 
+/**
+ * Convert a slug to the camelCase id discovery derives from a filename.
+ *
+ * Kept in sync with `filenameToId` in src/discovery/discovery-utils.ts so a
+ * scaffolded primitive declares the id it will actually register under.
+ */
+export function toCamelCaseId(slug: string): string {
+  const base = slug.split("/").pop() || slug;
+  return base
+    .replace(/[-_](.)/g, (_, char: string) => char.toUpperCase())
+    .replace(/^[A-Z]/, (char) => char.toLowerCase());
+}
+
 /** Convert a slug to a PascalCase component name. */
 export function toComponentName(slug: string): string {
   const base = slug.split("/").pop() || slug;

--- a/cli/utils/string.ts
+++ b/cli/utils/string.ts
@@ -10,19 +10,6 @@ export function toSlug(name: string): string {
     .replace(/\/+/g, "/");
 }
 
-/**
- * Convert a slug to the camelCase id discovery derives from a filename.
- *
- * Kept in sync with `filenameToId` in src/discovery/discovery-utils.ts so a
- * scaffolded primitive declares the id it will actually register under.
- */
-export function toCamelCaseId(slug: string): string {
-  const base = slug.split("/").pop() || slug;
-  return base
-    .replace(/[-_](.)/g, (_, char: string) => char.toUpperCase())
-    .replace(/^[A-Z]/, (char) => char.toLowerCase());
-}
-
 /** Convert a slug to a PascalCase component name. */
 export function toComponentName(slug: string): string {
   const base = slug.split("/").pop() || slug;


### PR DESCRIPTION
Found during a DX dogfood walk of the public docs (`veryfront.com/docs/code`), following the Tools guide literally against the published `veryfront@0.1.1228` CLI.

## Symptom

`veryfront generate tool get-weather` — the exact primitive-generation command from the Create-project page — writes `tools/get-weather.ts` containing:

```ts
export default tool({
  id: "get-weather",
  ...
```

The Tools guide states, at the very same path: *"The filename becomes the tool's ID. `tools/get-weather.ts` registers as `getWeather`."* With the scaffolded file in place that sentence is false, and the guide's own "Verify it worked" curl fails:

- `{"name":"getWeather"}` → HTTP 500
- `{"name":"get-weather"}` → HTTP 200

The A/B control isolates the cause: the guide's hand-written file at the identical path (no `id` field) behaves exactly as documented — `getWeather` succeeds, `get-weather` fails. The only difference is the `id` line the generator inserted on the developer's behalf.

The failure mode is silent. An agent authorizing the documented camelCase name (`tools: { getWeather: true }`) against a scaffolded kebab-id tool boots clean: no warning, no error, no diagnostic — the authorization entry just matches nothing.

## Root cause

`cli/scaffold/engine.ts` echoed the raw `generate` argument straight into the template's `id`, while `toolHandler.getId` (`src/discovery/handlers/tool-handler.ts`) prefers an explicit, non-generated `id` over `filenameToId(file)`. So the generator's own `id` line overrode the filename convention it was supposed to demonstrate.

The same line also produced ids that are not valid tool names at all: `veryfront generate tool "get weather"` wrote `id: "get weather"` (with a space) into `tools/get-weather.ts`.

## Fix

Derive the scaffolded id by calling discovery's own `filenameToId` (via the `veryfront/discovery` package surface) on the filename the scaffold is about to write, so the generated file declares the id it will actually register under:

```ts
tool: {
  getPath: ({ projectDir, slug }) => join(projectDir, "tools", `${slug}.ts`),
  getContent: ({ slug }) => generateToolTemplate(filenameToId(`${slug}.ts`)),
},
```

One expression in the tool definition; no other scaffold type touched. There is deliberately no second copy of the camelCase transform — the generator and discovery now share one function, so they cannot drift.

Verified with the real CLI from this branch:

```
$ veryfront generate tool get-weather
  ● Created .../tools/get-weather.ts

export default tool({
  id: "getWeather",
```

## Regression test

`cli/scaffold/engine.test.ts` — "gives a scaffolded tool the same id discovery derives from its filename". It lives beside the scaffold engine because that is the unit that emits the id, and it asserts the property that actually matters rather than a hardcoded string: for each of `get-weather`, `get weather`, `search_docs`, `searchDocs`, the planned file's `id:` line must equal `filenameToId(path)`. Reverting `getContent` to the raw `name` — the original bug — fails it.

Confirmed failing before the fix (`id: "get-weather"` vs expected `id: "getWeather"`), passing after.

## Not fixed here (out of scope)

Authorization entries in an agent's `tools` map that match no registered tool are still accepted in silence. That is a separate diagnostic gap, not this generator bug.
