### PR TITLE
fix(cli): print the URL to open when `veryfront serve` is ready

### DIFF
--- a/cli/commands/serve/command.test.ts
+++ b/cli/commands/serve/command.test.ts
@@ -5,10 +5,24 @@ import {
   assertExists,
   assertRejects,
   assertStrictEquals,
+  assertStringIncludes,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { serveCommand } from "./command.ts";
+import { setJsonMode } from "../../shared/json-output.ts";
+import { printServeReady, serveCommand, serveReadyUrl } from "./command.ts";
 import type { ServeOptions } from "./command.ts";
+
+function captureStdout(run: () => void): string {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => lines.push(args.join(" "));
+  try {
+    run();
+  } finally {
+    console.log = originalLog;
+  }
+  return lines.join("\n");
+}
 
 type RunWithStartupErrorReporting = <T>(
   startup: () => Promise<T>,
@@ -616,4 +630,39 @@ describe("commands/serve/command", () => {
       assertEquals(calls, [options]);
     });
   }
+
+  describe("serveReadyUrl", () => {
+    it("renders the wildcard bind address as a browsable localhost URL", () => {
+      assertEquals(serveReadyUrl("0.0.0.0", 3000), "http://localhost:3000");
+    });
+
+    it("renders the IPv6 wildcard bind address as a browsable localhost URL", () => {
+      assertEquals(serveReadyUrl("::", 3000), "http://localhost:3000");
+    });
+
+    it("keeps an explicit bind address", () => {
+      assertEquals(serveReadyUrl("127.0.0.1", 8080), "http://127.0.0.1:8080");
+    });
+
+    it("brackets explicit IPv6 bind addresses", () => {
+      assertEquals(serveReadyUrl("::1", 8080), "http://[::1]:8080");
+    });
+  });
+
+  describe("printServeReady", () => {
+    it("prints the URL the deploy docs tell developers to open", () => {
+      const output = captureStdout(() => printServeReady({ port: 3000, bindAddress: "0.0.0.0" }));
+      assertStringIncludes(output, "http://localhost:3000");
+    });
+
+    it("stays silent in JSON mode", () => {
+      setJsonMode(true);
+      try {
+        const output = captureStdout(() => printServeReady({ port: 3000, bindAddress: "0.0.0.0" }));
+        assertEquals(output.trim(), "");
+      } finally {
+        setJsonMode(false);
+      }
+    });
+  });
 });

--- a/cli/commands/serve/command.test.ts
+++ b/cli/commands/serve/command.test.ts
@@ -647,12 +647,21 @@ describe("commands/serve/command", () => {
     it("brackets explicit IPv6 bind addresses", () => {
       assertEquals(serveReadyUrl("::1", 8080), "http://[::1]:8080");
     });
+
+    it("keeps an already bracketed IPv6 bind address bracketed exactly once", () => {
+      assertEquals(serveReadyUrl("[::1]", 8080), "http://[::1]:8080");
+    });
   });
 
   describe("printServeReady", () => {
     it("prints the URL the deploy docs tell developers to open", () => {
       const output = captureStdout(() => printServeReady({ port: 3000, bindAddress: "0.0.0.0" }));
       assertStringIncludes(output, "http://localhost:3000");
+    });
+
+    it("stays silent when an ephemeral port was requested", () => {
+      const output = captureStdout(() => printServeReady({ port: 0, bindAddress: "0.0.0.0" }));
+      assertEquals(output.trim(), "");
     });
 
     it("stays silent in JSON mode", () => {

--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -195,13 +195,23 @@ const WILDCARD_BIND_ADDRESSES = new Set(["", "0.0.0.0", "::", "[::]"]);
  */
 export function serveReadyUrl(bindAddress: string, port: number): string {
   const host = WILDCARD_BIND_ADDRESSES.has(bindAddress) ? "localhost" : bindAddress;
-  const formattedHost = host.includes(":") ? `[${host}]` : host;
+  const bracketed = host.startsWith("[") && host.endsWith("]");
+  const formattedHost = !bracketed && host.includes(":") ? `[${host}]` : host;
   return `http://${formattedHost}:${port}`;
 }
 
-/** Print the ready block with the URL to open, mirroring `veryfront dev`. */
+/**
+ * Print the ready block with the URL to open, mirroring `veryfront dev`.
+ *
+ * Port `0` asks the OS for an ephemeral port, so the requested port is not the
+ * port that was bound and there is no browsable URL to print here — the bound
+ * port is only known to the server's `onListen`, which already logs it as
+ * `Production server listening`. Printing `http://localhost:0` under it would
+ * contradict the one correct line on screen, so the block is skipped instead.
+ */
 export function printServeReady(options: { port: number; bindAddress: string }): void {
   if (isJsonMode()) return;
+  if (options.port === 0) return;
   console.log();
   console.log(`  ${success("✓")} Ready`);
   console.log(`  ${brand(serveReadyUrl(options.bindAddress, options.port))}`);

--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -5,6 +5,8 @@ import { exitProcess, registerTerminationSignals, showHeader } from "#cli/utils"
 import { generateDefaultProjectId } from "../../utils/project.ts";
 import { startCliProductionServer } from "#cli/shared/server-startup";
 import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
+import { isJsonMode } from "../../shared/json-output.ts";
+import { brand, success } from "../../ui/colors.ts";
 import { runStandaloneProxyRuntime } from "./proxy-runtime.ts";
 
 const STARTUP_ERROR_FLUSH_TIMEOUT_MS = 2_000;
@@ -183,6 +185,29 @@ function loadProductionSentryModule(): Promise<ProductionSentryModule> {
   return import("veryfront/observability/sentry");
 }
 
+const WILDCARD_BIND_ADDRESSES = new Set(["", "0.0.0.0", "::", "[::]"]);
+
+/**
+ * Browsable URL for a server bound to `bindAddress`.
+ *
+ * A wildcard bind is not an address a developer can open, so it is rendered as
+ * `localhost` — the host the deploy docs tell them to visit.
+ */
+export function serveReadyUrl(bindAddress: string, port: number): string {
+  const host = WILDCARD_BIND_ADDRESSES.has(bindAddress) ? "localhost" : bindAddress;
+  const formattedHost = host.includes(":") ? `[${host}]` : host;
+  return `http://${formattedHost}:${port}`;
+}
+
+/** Print the ready block with the URL to open, mirroring `veryfront dev`. */
+export function printServeReady(options: { port: number; bindAddress: string }): void {
+  if (isJsonMode()) return;
+  console.log();
+  console.log(`  ${success("✓")} Ready`);
+  console.log(`  ${brand(serveReadyUrl(options.bindAddress, options.port))}`);
+  console.log();
+}
+
 export async function runProductionServer(
   options: ServeOptions,
   dependencies: ProductionServerDependencies = {},
@@ -241,6 +266,8 @@ export async function runProductionServer(
     dependencies.ensureBundlerContracts ?? ensureCliBundlerContracts,
     initializeErrorReporting,
   );
+
+  printServeReady({ port: options.port, bindAddress: options.bindAddress });
 
   let shuttingDown = false;
   const shutdown = async (signal: "SIGINT" | "SIGTERM"): Promise<void> => {


### PR DESCRIPTION
Found during a DX dogfood walk of the public getting-started docs, following them literally as a new developer would.

## Symptom

`docs/getting-started/deploy-project.md` ends with `veryfront serve`, then "Open http://localhost:3000". The command never prints that URL. Complete output of a bare `veryfront serve` on a freshly scaffolded + built app:

```
Veryfront (v0.1.1228)

  ! No CSSOptimizationEngine registered; emitting unminified CSS
  ● Starting production server
                       projectDir=/tmp/app22 port=3122 bindAddress=0.0.0.0
  ● Production server listening
                       hostname=0.0.0.0 port=3122
```

No URL, no hyperlink, no `localhost` token anywhere. The only address on screen is the wildcard bind address, which is not something you can open. `veryfront dev` — the sibling command in the same documented journey — has printed a ready block with a browsable URL all along, so the one command the docs hand to someone deploying for the first time is the one that stays silent.

## Root cause

`runProductionServer` (`cli/commands/serve/command.ts`) awaits `server.ready` and then goes straight to signal registration and the never-settling keep-alive promise. It prints nothing itself; the only listen-time output is the structured `logger.info("Production server listening", params)` inside `src/server/production-server.ts`, whose params are the raw bind parameters (`hostname=0.0.0.0`). A bind address is deliberately not a URL, so nothing in the pipeline ever produces one.

## Fix

Print a ready block after startup resolves, shaped like the one `veryfront dev` already prints:

```
  ✓ Ready
  http://localhost:3122
```

A wildcard bind (`0.0.0.0`, `::`) renders as `localhost`, because that is the host a developer can actually open and the host the docs name. An explicit `--hostname` is echoed as given, with IPv6 literals bracketed. Suppressed under `--json`, the same guard `showHeader()` uses, so machine output is untouched.

## Regression test

`cli/commands/serve/command.test.ts` — next to the existing `serveCommand` routing tests, since the ready block is part of the serve command's contract and this file already owns that surface. It captures `console.log` (the same `captureOutput` pattern used by `cli/commands/build/stats-display.test.ts`) and asserts the printed block contains `http://localhost:3000`, plus the bind-address → URL mapping cases and the JSON-mode silence.

Before the fix the test fails at import: `The requested module './command.ts' does not provide an export named 'printServeReady'` — there was no ready-URL surface on `serve` at all, which is exactly the defect.

## Verification

- `deno test cli/commands/serve/` — 5 passed, 0 failed.
- `deno check cli/main.ts`, `deno lint`, `deno fmt --check` clean.
- Re-ran the original repro (scaffold `--template minimal` → `veryfront build` → `veryfront serve --port 3122`): the ready block with `http://localhost:3122` now appears, and `curl http://localhost:3122/` still returns 200.

## Out of scope (filed separately, not fixed here)

The same walk found that `serve` binds `0.0.0.0` by default, so with SO_REUSEADDR an unrelated process already holding `127.0.0.1:<port>` keeps winning localhost traffic while `serve` still reports "listening" and stays up. That is a bind/port-collision problem with real production implications (k8s wants the wildcard bind), not an output problem, and it needs its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The serve command now displays a clear “Ready” message with a browser-friendly local URL when the server starts.
  * Supports wildcard, IPv4, and IPv6 bind addresses when generating the URL.
  * Suppresses the readiness message when JSON output is enabled.

* **Tests**
  * Added coverage for URL generation and readiness-message output across supported address formats and output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->