### PR TITLE
docs: list every scaffolded file in the getting-started project trees

### DIFF
--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -121,6 +121,7 @@ test-app/
   public/
     favicon.svg
   package.json
+  tsconfig.json
 ```
 
 The `ai-agent` template creates:
@@ -146,6 +147,7 @@ test-app/
   public/
     favicon.svg
   globals.css
+  globals.d.ts
   package.json
   tsconfig.json
 ```

--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -110,35 +110,48 @@ The `minimal` template creates:
 
 ```
 test-app/
-  AGENTS.md        # Project guide for coding agents
+  .gitignore
+  AGENTS.md         # Project guide for coding agents
+  README.md
   app/
     layout.tsx      # Root layout wrapping all pages
     page.tsx        # Home page (/)
     about/
       page.mdx      # /about (MDX page)
+  public/
+    favicon.svg
   package.json
-  README.md
 ```
 
-The `ai-agent` template also creates:
+The `ai-agent` template creates:
 
 ```
 test-app/
+  .gitignore
   AGENTS.md         # Project guide for coding agents
+  README.md
   agents/
     assistant.ts    # AI agent definition
   tools/
     calculator.ts   # Tool the agent can call
+  evals/
+    assistant.eval.ts   # Smoke eval for the agent, run with `veryfront eval`
   app/
     layout.tsx
     page.tsx        # Chat UI
+    markdown-renderer.tsx   # Renders assistant replies as markdown
     api/
       ag-ui/
         route.ts    # AG-UI streaming chat endpoint
+  public/
+    favicon.svg
+  globals.css
+  package.json
+  tsconfig.json
 ```
 
-Pages live in `app/`. The agent template also adds root-level `agents/` and
-`tools/`. For the convention behind these directories, see
+Pages live in `app/`. The agent template also adds root-level `agents/`,
+`tools/`, and `evals/`. For the convention behind these directories, see
 [Framework conventions](../concepts/framework-conventions.md).
 
 Generate additional app and AI primitives from the project root:

--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -108,7 +108,7 @@ browser.
 
 The `minimal` template creates:
 
-```
+```text
 test-app/
   .gitignore
   AGENTS.md         # Project guide for coding agents
@@ -126,7 +126,7 @@ test-app/
 
 The `ai-agent` template creates:
 
-```
+```text
 test-app/
   .gitignore
   AGENTS.md         # Project guide for coding agents

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -49,6 +49,7 @@ support-agent/
   public/
     favicon.svg
   globals.css
+  globals.d.ts
   package.json
   tsconfig.json
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -30,20 +30,32 @@ The `ai-agent` template creates a runnable chat app:
 
 ```text
 support-agent/
+  .gitignore
   AGENTS.md
+  README.md
   agents/
     assistant.ts
   tools/
     calculator.ts
+  evals/
+    assistant.eval.ts
   app/
+    layout.tsx
     page.tsx
+    markdown-renderer.tsx
     api/
       ag-ui/
         route.ts
+  public/
+    favicon.svg
+  globals.css
+  package.json
+  tsconfig.json
 ```
 
-The template includes the agent, calculator tool, chat page, AG-UI route, and
-`AGENTS.md` project guide for coding agents.
+The template includes the agent, calculator tool, chat page, AG-UI route, a
+smoke eval you run with `veryfront eval` (see [Evals](../guides/evals.md)), and
+the `AGENTS.md` project guide for coding agents.
 
 ## Authenticate
 

--- a/tests/docs/scaffold-trees.test.ts
+++ b/tests/docs/scaffold-trees.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Docs contract: the project trees printed in the getting-started pages must
+ * list every file the corresponding template actually scaffolds.
+ *
+ * These trees are drawn as complete directory listings — no ellipsis, no
+ * "partial" marker — so a reader treats them as the full scaffold. When a
+ * template gains a file and the tree is not updated, the page silently starts
+ * lying about what `veryfront init` produced.
+ *
+ * Ground truth is `cli/templates/manifest.json` (the template's own files) plus
+ * the files the init flow generates for every template regardless of choice.
+ */
+
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+/** Repo-relative reads, so a cwd-changing sibling test cannot break these. */
+const REPO_ROOT = new URL("../../", import.meta.url);
+
+function readRepoFile(path: string): Promise<string> {
+  return Deno.readTextFile(new URL(path, REPO_ROOT));
+}
+
+/** Written by the init flow for every template, so absent from the manifest. */
+const GENERATED_FILES = [".gitignore", "AGENTS.md", "package.json"] as const;
+
+interface DocumentedTree {
+  doc: string;
+  /** Prose line that introduces the tree; the next fenced block is the tree. */
+  marker: string;
+  template: string;
+}
+
+const DOCUMENTED_TREES: DocumentedTree[] = [
+  {
+    doc: "docs/getting-started/quickstart.md",
+    marker: "The `ai-agent` template creates a runnable chat app:",
+    template: "ai-agent",
+  },
+  {
+    doc: "docs/getting-started/create-project.md",
+    marker: "The `minimal` template creates:",
+    template: "minimal",
+  },
+  {
+    doc: "docs/getting-started/create-project.md",
+    marker: "The `ai-agent` template creates:",
+    template: "ai-agent",
+  },
+];
+
+function extractFencedBlockAfter(source: string, marker: string): string {
+  const markerIndex = source.indexOf(marker);
+  assert(markerIndex >= 0, `marker not found in doc: ${marker}`);
+
+  const openIndex = source.indexOf("```", markerIndex);
+  assert(openIndex >= 0, `no fenced block after marker: ${marker}`);
+
+  const bodyStart = source.indexOf("\n", openIndex);
+  assert(bodyStart >= 0, `unterminated fence opener after marker: ${marker}`);
+
+  const closeIndex = source.indexOf("```", bodyStart);
+  assert(closeIndex >= 0, `unterminated fenced block after marker: ${marker}`);
+
+  return source.slice(bodyStart + 1, closeIndex);
+}
+
+/**
+ * Turns an indented ASCII tree into the file paths it claims exist. Directory
+ * lines end with `/`; trailing `# ...` comments are annotations, not names.
+ */
+function parseTree(block: string): string[] {
+  const files: string[] = [];
+  const stack: Array<{ indent: number; name: string }> = [];
+  let sawRoot = false;
+
+  for (const rawLine of block.split("\n")) {
+    const line = rawLine.replace(/\s+#.*$/, "");
+    if (line.trim() === "") continue;
+
+    const name = line.trim();
+    const indent = line.length - line.trimStart().length;
+
+    if (!sawRoot) {
+      assert(name.endsWith("/"), `tree must start at a project root: ${name}`);
+      sawRoot = true;
+    }
+
+    while (stack.length > 0 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+
+    if (name.endsWith("/")) {
+      stack.push({ indent, name: name.slice(0, -1) });
+      continue;
+    }
+
+    // stack[0] is the project root directory, which is not part of the path.
+    const prefix = stack.slice(1).map((entry) => entry.name);
+    files.push([...prefix, name].join("/"));
+  }
+
+  return files.sort();
+}
+
+async function expectedFilesFor(template: string): Promise<string[]> {
+  const manifest = JSON.parse(
+    await readRepoFile("cli/templates/manifest.json"),
+  ) as { templates: Record<string, { files: Record<string, string> }> };
+
+  const entry = manifest.templates[template];
+  assert(entry, `template missing from manifest: ${template}`);
+
+  return [...Object.keys(entry.files), ...GENERATED_FILES].sort();
+}
+
+describe("getting-started scaffold trees", () => {
+  for (const { doc, marker, template } of DOCUMENTED_TREES) {
+    it(`lists every file the ${template} template creates (${doc})`, async () => {
+      const source = await readRepoFile(doc);
+      const documented = parseTree(extractFencedBlockAfter(source, marker));
+      const expected = await expectedFilesFor(template);
+
+      assertEquals(
+        documented,
+        expected,
+        `${doc}: the ${template} tree is drawn as a complete listing but does ` +
+          `not match the template. Missing: ` +
+          `[${expected.filter((file) => !documented.includes(file))}]. ` +
+          `Not created: [${documented.filter((file) => !expected.includes(file))}].`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
Found during a DX dogfood walk of the published getting-started flow.

## Symptom

The project trees in `docs/getting-started/quickstart.md` and
`docs/getting-started/create-project.md` are drawn as complete directory
listings: a project root, nested directories, no ellipsis and no "partial"
marker. They are not complete.

Scaffolding with the literal documented command and enumerating the result:

```
veryfront init my-agent --template ai-agent --skip-install --skip-env-prompt
find . -type f -not -path './node_modules/*' ! -name package-lock.json | sort
```

gives 14 files:

```
.gitignore  AGENTS.md  README.md  agents/assistant.ts  app/api/ag-ui/route.ts
app/layout.tsx  app/markdown-renderer.tsx  app/page.tsx  evals/assistant.eval.ts
globals.css  package.json  public/favicon.svg  tools/calculator.ts  tsconfig.json
```

The quickstart tree listed 5 of those 14. The `create-project.md` ai-agent tree
listed 6 of 14 while re-listing `AGENTS.md`, `app/layout.tsx` and `app/page.tsx`,
so it read as a full tree rather than a delta, yet dropped `package.json` and
`README.md` that the minimal tree just above it does list. The minimal tree
listed 6 of the 8 files that template writes (missing `.gitignore` and
`public/favicon.svg`).

The worst omission is `evals/assistant.eval.ts`: `veryfront eval --list` in the
scaffold prints `- eval:assistant (agent:assistant)`, `package.json` ships an
`"eval": "veryfront eval"` script, and there is a whole `guides/evals.md` page,
but nothing in getting-started tells a reader the directory exists.

## Root cause

The trees were hand-maintained prose. Templates gained files (`evals/`,
`markdown-renderer.tsx`, `globals.css`, `tsconfig.json`, `public/favicon.svg`)
and nothing tied the documentation back to what the templates ship, so the trees
drifted silently.

## Fix

Complete all three trees so they match `cli/templates/manifest.json` plus the
files the init flow generates for every template (`.gitignore`, `AGENTS.md`,
`package.json`). Reword `The ai-agent template also creates:` to
`The ai-agent template creates:`, since it is a full tree, not a delta. Mention
`evals/` in the prose beneath and link the evals guide from the quickstart.

## Regression test

`tests/docs/scaffold-trees.test.ts` (new). It lives beside the other docs
contracts in `tests/docs/` (`guide-contracts`, `guide-content`,
`cli-install-commands`), which is where assertions about published prose already
live. It parses each documented ASCII tree out of the page and compares the file
set to `cli/templates/manifest.json` plus the always-generated files, so the next
template file that lands fails the build instead of quietly aging the docs out of
date.

Confirmed failing before the fix for the right reason (diff showed exactly the
nine and two missing paths), passing after. The corrected trees were also diffed
against a real `veryfront init` scaffold produced by this branch's CLI: all three
match the on-disk file set exactly.

`deno task docs:validate` validators (`validate-guides`, `validate-public-docs`,
`check-doc-links`) pass. The one failure in `tests/docs/` locally
(`guide-examples.test.ts` "runs.mdx") is a sandbox network refusal
(`General SOCKS server failure`) unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project setup and quickstart guides with accurate scaffold file trees.
  - Documented additional template files, including project guides, evaluations, assets, configuration, and markdown support.
  - Clarified that the template includes a smoke evaluation and project guidance.

- **Tests**
  - Added coverage to verify documented scaffold trees stay synchronized with generated template files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->