### PR TITLE
fix(cache): keep the local .cache root out of the user's git history

### DIFF
--- a/cli/utils/env-prompt.test.ts
+++ b/cli/utils/env-prompt.test.ts
@@ -26,7 +26,7 @@ describe("env-prompt", () => {
       assertStringIncludes(result, "# Dependencies");
       assertStringIncludes(result, "# Environment files");
       assertStringIncludes(result, "# Build output");
-      assertStringIncludes(result, "# Local AI model cache");
+      assertStringIncludes(result, "# Local build cache");
       assertStringIncludes(result, ".cache/");
       assertStringIncludes(result, "# IDE");
     });

--- a/cli/utils/env-prompt.ts
+++ b/cli/utils/env-prompt.ts
@@ -178,7 +178,7 @@ export function generateGitignoreContent(existingContent?: string): string {
       "dist/",
       ".veryfront/",
       "",
-      "# Local AI model cache",
+      "# Local build cache",
       ".cache/",
       "",
       "# IDE",

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join, toFileUrl } from "#veryfront/compat/path";
 import {
+  clearAllLocalCaches,
   clearMdxEsmCacheNamespace,
   clearModulePathCache,
   getLocalFs,
@@ -18,7 +19,7 @@ import {
   waitForDiskCleanup,
 } from "./index.ts";
 import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
-import { exists, remove, writeTextFile } from "#veryfront/compat/fs.ts";
+import { exists, readTextFile, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { cacheModule } from "../module-fetcher/module-cache.ts";
 import { rendererLogger as log } from "#veryfront/utils";
@@ -1251,6 +1252,33 @@ describe("invalidateModulePaths — edge cases", () => {
       );
     } finally {
       await remove(cacheDir, { recursive: true }).catch(() => {});
+      clearModulePathCache();
+    }
+  });
+});
+
+describe("local cache root version-control hygiene", () => {
+  // Regression: `veryfront dev` writes its ESM/bundle caches into
+  // `<project>/.cache`. Projects that adopted Veryfront without scaffolding
+  // (their .gitignore predates `veryfront init`) have no `.cache/` entry, so
+  // the generated .mjs bundles showed up as untracked files and a `git add -A`
+  // committed them. Server startup must leave the cache root ignoring itself.
+  it("marks the local cache root as ignored on startup", async () => {
+    const cacheBase = await makeTempDir({ prefix: "vf-cache-root-ignore-" });
+
+    try {
+      await runWithCacheDir(cacheBase, async () => {
+        await clearAllLocalCaches();
+      });
+
+      const ignorePath = join(cacheBase, ".gitignore");
+      assertEquals(await exists(ignorePath), true);
+      assertEquals(
+        (await readTextFile(ignorePath)).split(/\r?\n/).includes("*"),
+        true,
+      );
+    } finally {
+      await remove(cacheBase, { recursive: true });
       clearModulePathCache();
     }
   });

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -9,6 +9,7 @@
 import { fromFileUrl, join } from "#veryfront/compat/path";
 import { rendererLogger as logger } from "#veryfront/utils";
 import {
+  ensureCacheDirIgnored,
   getCacheBaseDir,
   getHttpBundleCacheDir,
   getMdxEsmCacheDir,
@@ -615,6 +616,9 @@ export async function clearHttpBundleCache(): Promise<void> {
 export async function clearAllLocalCaches(): Promise<void> {
   clearModulePathCache();
   await Promise.all([clearESMDiskCache(), clearHttpBundleCache()]);
+  // The cache root lives inside the user's project outside production, so keep
+  // the generated bundles out of their version control before writing more.
+  await ensureCacheDirIgnored();
   logger.debug(`${LOG_PREFIX_MDX_LOADER} Cleared all local caches`);
 }
 

--- a/src/utils/cache-dir.test.ts
+++ b/src/utils/cache-dir.test.ts
@@ -22,6 +22,7 @@ import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   __cacheDirInternals,
+  ensureCacheDirIgnored,
   ensureCacheNodeModules,
   getCacheBaseDir,
   getCacheDirFromContext,
@@ -259,6 +260,27 @@ describe("cache-dir", () => {
       const result = runWithCacheDir("/tmp/test", getHttpBundleCacheDir);
       assert(result.startsWith("/tmp/test"));
       assert(result.endsWith("veryfront-http-bundle"));
+    });
+  });
+
+  describe("ensureCacheDirIgnored", () => {
+    it("creates a self-ignoring .gitignore inside the cache root", async () => {
+      const cacheRoot = makeNodeCacheRoot();
+
+      await runWithCacheDir(cacheRoot, ensureCacheDirIgnored);
+
+      const contents = readFileSync(join(cacheRoot, ".gitignore"), "utf8");
+      assert(contents.split(/\r?\n/).includes("*"));
+    });
+
+    it("never overwrites a .gitignore the user already put there", async () => {
+      const cacheRoot = makeNodeCacheRoot();
+      const ignorePath = join(cacheRoot, ".gitignore");
+      writeFileSync(ignorePath, "!keep-me\n");
+
+      await runWithCacheDir(cacheRoot, ensureCacheDirIgnored);
+
+      assertEquals(readFileSync(ignorePath, "utf8"), "!keep-me\n");
     });
   });
 

--- a/src/utils/cache-dir.ts
+++ b/src/utils/cache-dir.ts
@@ -1,7 +1,11 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { join } from "#veryfront/compat/path/index.ts";
 import { cwd, getHostEnv } from "#veryfront/platform/compat/process.ts";
-import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import {
+  createFileSystem,
+  type FileSystem,
+  isAlreadyExistsError,
+} from "#veryfront/platform/compat/fs.ts";
 import { isNode } from "#veryfront/platform/compat/runtime.ts";
 import { hashString } from "#veryfront/cache/hash.ts";
 import { serverLogger } from "./logger/index.ts";
@@ -107,10 +111,40 @@ export function getHttpBundleCacheDir(): string {
 }
 
 const CACHE_DIR_IGNORE_CONTENT = [
-  "# Created by Veryfront. Holds generated bundles only — safe to delete.",
+  "# Created by Veryfront. Holds generated bundles only, safe to delete.",
   "*",
   "",
 ].join("\n");
+
+/**
+ * Write the ignore marker without clobbering a file that already exists.
+ *
+ * Adapters that expose an exclusive create use it, so a `.gitignore` another
+ * process writes between the caller's `exists()` check and this write survives.
+ * Adapters without that capability fall back to a plain write.
+ */
+async function createIgnoreMarker(
+  fs: FileSystem,
+  ignorePath: string,
+): Promise<void> {
+  const createExclusive = fs.createFileBytesExclusive?.bind(fs);
+  if (createExclusive === undefined) {
+    await fs.writeTextFile(ignorePath, CACHE_DIR_IGNORE_CONTENT);
+    return;
+  }
+
+  try {
+    // Exclusive create so a `.gitignore` that appears between the exists()
+    // check and this write is left intact rather than truncated.
+    await createExclusive(
+      ignorePath,
+      new TextEncoder().encode(CACHE_DIR_IGNORE_CONTENT),
+    );
+  } catch (error) {
+    if (isAlreadyExistsError(error)) return;
+    throw error;
+  }
+}
 
 /**
  * Mark the cache base directory as ignored by version control.
@@ -119,7 +153,7 @@ const CACHE_DIR_IGNORE_CONTENT = [
  * run drops generated `.mjs` bundles into the user's project. `veryfront init`
  * scaffolds a `.gitignore` with a `.cache/` entry, but a project that adopted
  * Veryfront into an existing tree keeps its own `.gitignore` and never gets
- * one — the bundles then show up as untracked files and `git add -A` commits
+ * one, so the bundles show up as untracked files and `git add -A` commits
  * them. A `.gitignore` written *inside* the cache root ignores its contents
  * (and itself) no matter what the project's own `.gitignore` says.
  *
@@ -134,7 +168,7 @@ export async function ensureCacheDirIgnored(): Promise<void> {
     const ignorePath = join(cacheBase, ".gitignore");
     if (await fs.exists(ignorePath)) return;
     await fs.mkdir(cacheBase, { recursive: true });
-    await fs.writeTextFile(ignorePath, CACHE_DIR_IGNORE_CONTENT);
+    await createIgnoreMarker(fs, ignorePath);
   } catch (error) {
     logger.debug("Cache dir ignore marker not written", {
       cacheRoot: describeCacheRoot(cacheBase),

--- a/src/utils/cache-dir.ts
+++ b/src/utils/cache-dir.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { join } from "#veryfront/compat/path/index.ts";
 import { cwd, getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { isNode } from "#veryfront/platform/compat/runtime.ts";
 import { hashString } from "#veryfront/cache/hash.ts";
 import { serverLogger } from "./logger/index.ts";
@@ -103,6 +104,46 @@ export function getMdxEsmCacheDir(): string {
 
 export function getHttpBundleCacheDir(): string {
   return join(getCacheBaseDir(), "veryfront-http-bundle");
+}
+
+const CACHE_DIR_IGNORE_CONTENT = [
+  "# Created by Veryfront. Holds generated bundles only — safe to delete.",
+  "*",
+  "",
+].join("\n");
+
+/**
+ * Mark the cache base directory as ignored by version control.
+ *
+ * Outside production the cache root is `<project>/.cache`, so every dev server
+ * run drops generated `.mjs` bundles into the user's project. `veryfront init`
+ * scaffolds a `.gitignore` with a `.cache/` entry, but a project that adopted
+ * Veryfront into an existing tree keeps its own `.gitignore` and never gets
+ * one — the bundles then show up as untracked files and `git add -A` commits
+ * them. A `.gitignore` written *inside* the cache root ignores its contents
+ * (and itself) no matter what the project's own `.gitignore` says.
+ *
+ * Best-effort: an unwritable cache root must not fail server startup, and an
+ * existing `.gitignore` is never overwritten.
+ */
+export async function ensureCacheDirIgnored(): Promise<void> {
+  const cacheBase = getCacheBaseDir();
+
+  try {
+    const fs = createFileSystem();
+    const ignorePath = join(cacheBase, ".gitignore");
+    if (await fs.exists(ignorePath)) return;
+    await fs.mkdir(cacheBase, { recursive: true });
+    await fs.writeTextFile(ignorePath, CACHE_DIR_IGNORE_CONTENT);
+  } catch (error) {
+    logger.debug("Cache dir ignore marker not written", {
+      cacheRoot: describeCacheRoot(cacheBase),
+      reason: redactCachePathDetails(
+        error instanceof Error ? error.message : String(error),
+        cacheBase,
+      ),
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Found during a DX dogfood walk of the public docs (install → adopt into an existing project → `veryfront dev`).

## Symptom

`veryfront dev` writes generated bundles into `<project>/.cache` and, on the "blank or existing project" adoption path documented in `docs/getting-started/installation.md`, nothing ever tells git to ignore them.

Reproduced against this tree with the real CLI: scaffold an app, replace its `.gitignore` with a typical pre-existing one (`node_modules/`, `dist/`, `.env`), `git init`, `veryfront dev`, load one page:

```
?? .cache/veryfront-mdx-esm/framework/vfmod-vf-framework-69317ee3-54d458af-7fb5feaf-761acd69.mjs
?? .cache/veryfront-mdx-esm/myapp/local-main/app/layout.13a96ac5.js
... (and the rest of .cache/)
```

`git add -A` there commits generated bundle artifacts.

## Root cause

`getDefaultCacheBaseDir()` (`src/utils/cache-dir.ts`) resolves to `join(cwd(), ".cache")` outside production, so the cache root lives inside the user's repo. The only thing that ever ignores it is the `.gitignore` that `veryfront init` scaffolds (`generateGitignoreContent`, `cli/utils/env-prompt.ts`). That function's amend branch — the one used when a `.gitignore` already exists — adds only `.env*` and `.veryfront/`, never `.cache/`, and it is near-unreachable from `init` anyway (`veryfront init .` is rejected, and `init` over an existing directory refuses without `--force`). A project that adopts Veryfront never runs the scaffold path at all, so it gets no entry from anywhere. The published package has no install scripts either.

## Fix

Write a `.gitignore` containing `*` **inside** the cache root, the way `.vercel/` and `.nx/cache/` do. That ignores the directory's contents and the marker itself no matter what the project's own `.gitignore` says, so it covers the scaffold path, the adopt path, and a custom `VERYFRONT_CACHE_DIR` with one mechanism instead of trying to edit a file the framework does not own.

- `ensureCacheDirIgnored()` in `src/utils/cache-dir.ts` — best-effort (an unwritable cache root must not fail server startup) and it never overwrites an existing `.gitignore`.
- Called from `clearAllLocalCaches()`, the documented "call this on server startup" hook, which is what `dev`, `start`, and `serve` all run before the first cache write.
- Also relabels the scaffolded comment: `.cache/` holds `veryfront-mdx-esm/` and `veryfront-http-bundle/`, not the "Local AI model cache" it claimed.

## Regression test

- `src/transforms/mdx/esm-module-loader/cache/index.test.ts` — "marks the local cache root as ignored on startup". It lives next to `clearAllLocalCaches` because that is the startup seam the bug went through: the test drives the same function the dev server calls and asserts the cache root ends up self-ignoring. Confirmed failing before the fix (`.gitignore` absent), passing after.
- `src/utils/cache-dir.test.ts` — two unit cases for `ensureCacheDirIgnored`: it writes the `*` marker, and it leaves a user-authored `.gitignore` alone.

Deno BDD throughout; no browser needed.

## Verification

Reran the finding's command against the fixed tree in the same adopt-path sandbox. `.cache/.gitignore` is now present with `*`, and `git status --porcelain -uall` lists zero entries under `.cache`:

```
?? .gitignore
?? AGENTS.md
?? README.md
?? app/about/page.mdx
?? app/layout.tsx
?? app/page.tsx
?? package-lock.json
?? package.json
?? public/favicon.svg
```

`deno test` over `src/utils`, `src/cache`, `src/transforms`, `cli/utils`, `src/modules/react-loader`: 395 passed, 0 failed. The pre-push gate (fmt check + full unit suite) passed.
