### PR TITLE
fix(cli): keep the shared ESM cache when another dev server holds the port

### DIFF
--- a/cli/commands/dev/command.ts
+++ b/cli/commands/dev/command.ts
@@ -9,6 +9,7 @@ import { runtime } from "veryfront/platform";
 import { getConfig } from "veryfront/config";
 import { getEnvironmentConfig } from "veryfront/config";
 import { startDevServer } from "veryfront/server";
+import { clearAllLocalCaches } from "veryfront/transforms/mdx-cache";
 import { validateProviderConfig } from "veryfront/discovery";
 import { brand, devShortcuts, dim, error as errorColor, formatDuration, warning } from "#cli/ui";
 import { exitProcess, isTTY, isVerbose, registerTerminationSignals } from "#cli/utils";
@@ -24,7 +25,7 @@ import { pullCommand } from "../pull/index.ts";
 import { createStagedPushOptions, pushCommand, type PushOptions } from "../push/index.ts";
 import { createProjectSelector } from "./project-selector.ts";
 import { createDevLogController } from "./log-controller.ts";
-import { findAvailablePort, isPortInUseError } from "./port-fallback.ts";
+import { findAvailablePort, isPortAvailable, isPortInUseError } from "./port-fallback.ts";
 
 export interface DevOptions {
   port: number;
@@ -33,6 +34,12 @@ export interface DevOptions {
   open?: boolean;
   /** Demo mode: don't exit process on shutdown, resolve done promise instead */
   demoMode?: boolean;
+  /**
+   * Clear the shared on-disk ESM caches before starting. Only honoured once the
+   * requested dev port is confirmed free, because the cache directory is shared
+   * with any dev server already serving this project.
+   */
+  clearLocalCaches?: boolean;
 }
 
 export type DevCommandOptions = DevOptions;
@@ -115,11 +122,42 @@ export async function startDevServerOnFreePort<T>(
   }
 }
 
+/**
+ * Clears the shared on-disk ESM caches, but only if `requestedPort` is free.
+ *
+ * The caches live under the project's `.cache` directory, which every dev
+ * server rooted at that project shares. A taken dev port is the signal that one
+ * of them is already running and still serving modules it compiled, so the
+ * clear is skipped rather than wiping that server's work out from under it -
+ * the second `veryfront dev` falls forward to a free port and starts on a cache
+ * it did not just destroy.
+ *
+ * Returns whether the clear ran. Takes `clear` and `probe` as parameters so the
+ * decision can be tested without booting a dev server, the same seam
+ * `startDevServerOnFreePort` uses.
+ */
+export async function clearLocalCachesIfPortFree(
+  requestedPort: number,
+  clear: () => Promise<void> = clearAllLocalCaches,
+  probe: (port: number) => Promise<boolean> = isPortAvailable,
+): Promise<boolean> {
+  if (!await probe(requestedPort)) return false;
+  await clear();
+  return true;
+}
+
 export function devCommand(options: DevOptions): Promise<DevCommandResult> {
   return withSpan(
     "cli.command.dev",
     async () => {
-      const { port, projectDir, hmr = true, open = false, demoMode = false } = options;
+      const {
+        port,
+        projectDir,
+        hmr = true,
+        open = false,
+        demoMode = false,
+        clearLocalCaches = false,
+      } = options;
       const startTime = Date.now();
 
       let doneResolve: (() => void) | undefined;
@@ -145,6 +183,8 @@ export function devCommand(options: DevOptions): Promise<DevCommandResult> {
       const DEFAULT_DEV_PORT = 3000;
       const finalPort = port !== DEFAULT_DEV_PORT ? port : (config?.dev?.port ?? port);
       const enableHMR = config?.dev?.hmr !== false && hmr;
+
+      if (clearLocalCaches) await clearLocalCachesIfPortFree(finalPort);
 
       const env = getEnvironmentConfig();
       const isProxyMode = config?.fs?.veryfront?.proxyMode === true;

--- a/cli/commands/dev/dev-cache-guard.integration.test.ts
+++ b/cli/commands/dev/dev-cache-guard.integration.test.ts
@@ -1,0 +1,167 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createServer } from "node:net";
+import { join } from "#veryfront/compat/path";
+import { exists, mkdir, writeTextFile } from "#veryfront/platform/compat/fs.ts";
+import { runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { clearConfigCache } from "#veryfront/config";
+import { TEST_TIMEOUTS } from "../../../tests/_helpers/constants.ts";
+import { withTestContext } from "../../../tests/_helpers/context.ts";
+import { clearLocalCachesIfPortFree } from "./command.ts";
+import { handleDevCommand } from "./handler.ts";
+
+/**
+ * The on-disk ESM caches live under the project's `.cache` directory, which
+ * every dev server rooted at that project shares. Clearing them before the dev
+ * port has been resolved and probed means a second `veryfront dev` destroys the
+ * running server's compiled modules - the surviving server then has to
+ * recompile everything on its next request.
+ */
+
+interface SeededCache {
+  cacheDir: string;
+  mdxEsmEntry: string;
+  httpBundleEntry: string;
+}
+
+/** Writes the cache entries a dev server that is already running would own. */
+async function seedRunningServerCache(projectDir: string): Promise<SeededCache> {
+  const cacheDir = join(projectDir, ".cache");
+  const mdxEsmDir = join(cacheDir, "veryfront-mdx-esm");
+  const httpBundleDir = join(cacheDir, "veryfront-http-bundle");
+  await mkdir(mdxEsmDir, { recursive: true });
+  await mkdir(httpBundleDir, { recursive: true });
+
+  const mdxEsmEntry = join(mdxEsmDir, "running-server-module.mjs");
+  const httpBundleEntry = join(httpBundleDir, "running-server-bundle.mjs");
+  await writeTextFile(mdxEsmEntry, "export const compiledByRunningServer = true;\n");
+  await writeTextFile(httpBundleEntry, "export const bundledByRunningServer = true;\n");
+
+  return { cacheDir, mdxEsmEntry, httpBundleEntry };
+}
+
+/** Stands in for the dev server that is already listening on this project's port. */
+async function holdPort(): Promise<{ port: number; release: () => Promise<void> }> {
+  const held = createServer();
+  const port = await new Promise<number>((resolve, reject) => {
+    held.once("error", reject);
+    held.listen(0, "127.0.0.1", () => {
+      const address = held.address();
+      resolve(typeof address === "object" && address !== null ? address.port : 0);
+    });
+  });
+  return {
+    port,
+    release: () => new Promise<void>((done) => held.close(() => done())),
+  };
+}
+
+describe("veryfront dev cache guard", () => {
+  it(
+    "keeps the shared ESM cache when another dev server holds the port",
+    { timeout: TEST_TIMEOUTS.INTEGRATION },
+    async () => {
+      await withTestContext("dev-cache-guard-port-taken", async (context) => {
+        const cache = await seedRunningServerCache(context.projectDir);
+        const { port, release } = await holdPort();
+
+        try {
+          const cleared = await runWithCacheDir(
+            cache.cacheDir,
+            () => clearLocalCachesIfPortFree(port),
+          );
+
+          assertEquals(cleared, false, "a taken dev port must not clear the shared cache");
+          assert(
+            await exists(cache.mdxEsmEntry),
+            "the running server's MDX-ESM cache entry must survive a second `veryfront dev`",
+          );
+          assert(
+            await exists(cache.httpBundleEntry),
+            "the running server's HTTP bundle cache entry must survive a second `veryfront dev`",
+          );
+        } finally {
+          await release();
+        }
+      });
+    },
+  );
+
+  it(
+    "still clears the shared ESM cache when the dev port is free",
+    { timeout: TEST_TIMEOUTS.INTEGRATION },
+    async () => {
+      await withTestContext("dev-cache-guard-port-free", async (context) => {
+        const cache = await seedRunningServerCache(context.projectDir);
+        const { port, release } = await holdPort();
+        // Release immediately: the port is known-unused, not merely unprobed.
+        await release();
+
+        const cleared = await runWithCacheDir(
+          cache.cacheDir,
+          () => clearLocalCachesIfPortFree(port),
+        );
+
+        assertEquals(cleared, true, "a free dev port must still clear stale caches");
+        assertEquals(
+          await exists(cache.mdxEsmEntry),
+          false,
+          "a stale MDX-ESM cache entry must be cleared when no server holds the port",
+        );
+        assertEquals(
+          await exists(cache.httpBundleEntry),
+          false,
+          "a stale HTTP bundle cache entry must be cleared when no server holds the port",
+        );
+      });
+    },
+  );
+
+  it(
+    "does not clear the shared ESM cache before the dev command owns the port",
+    { timeout: TEST_TIMEOUTS.INTEGRATION },
+    async () => {
+      await withTestContext("dev-cache-guard-handler-ordering", async (context) => {
+        clearConfigCache();
+
+        await writeTextFile(
+          join(context.projectDir, "veryfront.config.js"),
+          `export default { title: "Cache Guard" };\n`,
+        );
+        const cache = await seedRunningServerCache(context.projectDir);
+
+        // 70000 is not a bindable TCP port, so the probe inside devCommand
+        // fails and the command aborts. Anything that clears the caches ahead
+        // of that probe - as the handler itself used to - has already destroyed
+        // the running server's modules by the time the command gives up.
+        await assertRejects(
+          () =>
+            runWithCacheDir(
+              cache.cacheDir,
+              () =>
+                handleDevCommand({
+                  _: ["dev"],
+                  port: 70000,
+                  project: context.projectDir,
+                  "no-hmr": true,
+                }),
+            ),
+          Error,
+          undefined,
+          "an unbindable dev port must fail the command",
+        );
+
+        assert(
+          await exists(cache.mdxEsmEntry),
+          "the MDX-ESM cache entry must survive a `veryfront dev` that never took a port",
+        );
+        assert(
+          await exists(cache.httpBundleEntry),
+          "the HTTP bundle cache entry must survive a `veryfront dev` that never took a port",
+        );
+      });
+    },
+  );
+});

--- a/cli/commands/dev/handler.ts
+++ b/cli/commands/dev/handler.ts
@@ -8,7 +8,6 @@ import { cwd, setEnv } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import { cliLogger, DEFAULT_DEV_SERVER_PORT, showHeader } from "#cli/utils";
 import { refreshLoggerConfig } from "veryfront/utils";
-import { clearAllLocalCaches } from "veryfront/transforms/mdx-cache";
 import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
 import type { ParsedArgs } from "#cli/shared/types";
@@ -70,15 +69,17 @@ export async function handleDevCommand(args: ParsedArgs): Promise<void> {
     refreshLoggerConfig();
   }
 
-  // Clear stale ESM caches to prevent module resolution issues from previous runs
-  await clearAllLocalCaches();
-
   const { devCommand } = await import("./index.ts");
   const { done } = await devCommand({
     port: opts.port,
     projectDir,
     hmr: opts.hmr && !opts.noHmr,
     open: opts.open,
+    // Clear stale ESM caches to prevent module resolution issues from previous
+    // runs. devCommand does this only once it has resolved the dev port and
+    // found it free — the caches are shared with any dev server already running
+    // against this project.
+    clearLocalCaches: true,
   });
 
   // Block until the dev server shuts down.


### PR DESCRIPTION
Found during a DX dogfood walk of the developer journey.

## Symptom

Running `veryfront dev` a second time in the same project, while the first
server is still up, destroys the shared `.cache`.

Measured on the parent commit with a seeded cache directory:

```
--- cache BEFORE second dev ---   6
--- cache AFTER second dev ---    0
```

The second command took the still-running server's compiled modules with it.
The surviving server then has to recompile everything on the next request; the
original walk saw 432 `.mjs` files go to 0.

## Root cause

`cli/commands/dev/handler.ts` cleared the caches unconditionally, before it even
called `devCommand`:

```ts
// Clear stale ESM caches to prevent module resolution issues from previous runs
await clearAllLocalCaches();

const { devCommand } = await import("./index.ts");
```

The dev port is not resolved until `devCommand` merges `config.dev.port`, and
not bound until `startDevServer` runs — several steps later. The cache directory
(`getCacheBaseDir()`, i.e. `<project>/.cache`) is shared by every dev server
rooted at the same project, so the destructive step ran for a process that had
no claim on the port.

## Fix

Move the clear into `devCommand`, behind a probe on the resolved port:

```ts
if (clearLocalCaches) await clearLocalCachesIfPortFree(finalPort);
```

A taken dev port is the signal that another dev server is already serving this
project and still needs the modules it compiled, so the clear is skipped: the
second `veryfront dev` falls forward to a free port (#3562) and starts on a
cache it did not just destroy. A free port still clears, so the stale-module
behaviour the clear exists for is unchanged.

`clearLocalCachesIfPortFree` takes its clear and its probe as parameters — the
same seam `startDevServerOnFreePort` uses — so the decision is testable without
booting a dev server. The probe itself is `isPortAvailable` from
`cli/commands/dev/port-fallback.ts`, already used by the port fall-forward and
already cross-runtime.

One other consequence, intended: `clearLocalCaches` is opt-in, so `veryfront
demo`'s programmatic `devCommand` call keeps its current behaviour of never
clearing.

## Regression tests

`cli/commands/dev/dev-cache-guard.integration.test.ts`, all three confirmed red
first against an unconditional clear:

- a real held socket makes the probe report taken, and the seeded MDX-ESM and
  HTTP bundle entries survive;
- a released port still clears them, so the guard did not simply disable the
  clear;
- `handleDevCommand` driven against an unbindable port aborts inside
  `devCommand` with the seeded entries intact. That one locks the handler
  ordering that caused the bug — anything clearing ahead of the port probe has
  already destroyed the running server's modules by the time the command gives
  up.

## Verification

- `deno test cli/commands/dev cli/commands/demo` — 14 passed, 0 failed.
- `deno check cli/main.ts`, `deno lint`, `deno fmt` clean.

## Rebase note

Rebased onto current `main`, which now carries #3562 (`veryfront dev` falls
forward to a free port instead of hard-failing). The first cut of this PR added
its own `cli/commands/dev/port-guard.ts` probe and made a busy port a hard
failure. Both are gone: the hard failure would have reverted #3562, and
`port-fallback.ts` already ships the same bind-and-release probe. What survives
is the part #3562 does not address — the shared cache must not be wiped by a
process that does not own the port. Without this change the fall-forward makes
the bug quieter, not smaller: the second `veryfront dev` now succeeds on the
next port and still clears the first server's cache.
