### PR TITLE
fix(cli): make `veryfront up --dry-run` report the plan it would apply

### DIFF
--- a/cli/commands/up/command.test.ts
+++ b/cli/commands/up/command.test.ts
@@ -14,7 +14,9 @@ import { capitalizeSeparatedWords } from "veryfront/utils/case-utils";
 import { resetInteractiveMode, setNonInteractive } from "../../shared/interactive.ts";
 import { setJsonMode } from "../../shared/json-output.ts";
 import { stripAnsi } from "../../ui/ansi.ts";
+import { setLoggerPreset } from "veryfront/utils/logger";
 import type {
+  DeployEvent,
   DeployPlan,
   DeployProject,
   DeployProjectOutcome,
@@ -78,17 +80,48 @@ async function captureLog<T>(run: () => Promise<T>): Promise<{ result: T; output
   }
 }
 
+/**
+ * Everything a human sees, in order, across both console streams.
+ *
+ * Spinner frames land on stderr and results on stdout, so a test that reads
+ * only `console.log` cannot tell whether the run narrated something it never
+ * did. The logger runs under the same "cli" preset `cli/main.ts` installs, so
+ * a captured line is byte-for-byte the line a user reads.
+ */
+async function captureConsole<T>(
+  run: () => Promise<T>,
+): Promise<{ result: T; lines: string[] }> {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  const record = (...args: unknown[]) => {
+    lines.push(stripAnsi(args.map(String).join(" ")));
+  };
+  console.log = record;
+  console.error = record;
+  setLoggerPreset("cli");
+  try {
+    return { result: await run(), lines };
+  } finally {
+    setLoggerPreset("server");
+    console.log = originalLog;
+    console.error = originalError;
+  }
+}
+
 /** Deploy Execution recorded, never executed: what did `up` ask deploy to do? */
 function recordingDeployProject(
   outcome: DeployProjectOutcome,
+  events: DeployEvent[] = [],
 ): { deployProject: DeployProject; requests: DeployProjectRequest[] } {
   const requests: DeployProjectRequest[] = [];
   return {
     requests,
     deployProject: {
-      execute(request) {
+      async execute(request, observer) {
         requests.push(request);
-        return Promise.resolve(outcome);
+        for (const event of events) await observer?.onEvent(event);
+        return outcome;
       },
     },
   };
@@ -396,6 +429,80 @@ describe("Up Command", () => {
         });
       } finally {
         setJsonMode(false);
+        resetInteractiveMode();
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("tells a human what the dry run would do, and never renders an empty status line", async () => {
+      const projectDir = await createLinkedProjectDir();
+      const { deployProject } = recordingDeployProject(dryRunOutcome(), [
+        { kind: "step", step: "resolve-config", phase: "started" },
+        // A dry run reaches the environment lookup, whose non-verbose progress
+        // text is "Building release..." — a build no dry run performs.
+        { kind: "step", step: "resolve-target", phase: "started" },
+      ]);
+
+      try {
+        setNonInteractive(true);
+        const { lines } = await captureConsole(() =>
+          withMockFetch(
+            authCheckOnlyFetch(),
+            () =>
+              upCommand({ projectDir, dryRun: true }, authenticatedEnv(projectDir), {
+                deployProject,
+              }),
+          )
+        );
+
+        // A status glyph with no message is a rendered line that says nothing.
+        assertEquals(lines.some((line) => line.trim() === "●"), false);
+        assertEquals(lines.some((line) => line.includes("Building release")), false);
+        assertEquals(
+          lines.includes(
+            '  › Would push source to "main", create release, and deploy to "preview" for project linked-up',
+          ),
+          true,
+        );
+        assertEquals(lines.includes("  ✓ Dry run complete"), true);
+      } finally {
+        resetInteractiveMode();
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("names the project a human dry run would create", async () => {
+      const projectDir = await Deno.makeTempDir();
+      const expectedSlug = normalizeProjectSlug(projectDir.split(/[/\\]/).pop() ?? "");
+      const { deployProject } = recordingDeployProject(
+        dryRunOutcome({
+          projectId: null,
+          environmentId: null,
+          plannedActions: ["create-project", "push-source", "create-release", "deploy"],
+        }),
+      );
+
+      try {
+        await Deno.writeTextFile(join(projectDir, "package.json"), "{}");
+        setNonInteractive(true);
+        const { lines } = await captureConsole(() =>
+          withMockFetch(
+            authCheckOnlyFetch(),
+            () =>
+              upCommand({ projectDir, dryRun: true }, authenticatedEnv(projectDir), {
+                deployProject,
+              }),
+          )
+        );
+
+        assertEquals(lines.some((line) => line.trim() === "●"), false);
+        assertEquals(
+          lines.includes(
+            `  › Would create the project, push source to "main", create release, and deploy to "preview" for project ${expectedSlug}`,
+          ),
+          true,
+        );
+      } finally {
         resetInteractiveMode();
         await Deno.remove(projectDir, { recursive: true });
       }

--- a/cli/commands/up/command.test.ts
+++ b/cli/commands/up/command.test.ts
@@ -458,9 +458,12 @@ describe("Up Command", () => {
         // A status glyph with no message is a rendered line that says nothing.
         assertEquals(lines.some((line) => line.trim() === "●"), false);
         assertEquals(lines.some((line) => line.includes("Building release")), false);
+        // The name comes from the plan ("verified-slug"), not from the local
+        // link ("linked-up"): a project renamed after linking still resolves by
+        // id, and the apply would target the plan's slug.
         assertEquals(
           lines.includes(
-            '  › Would push source to "main", create release, and deploy to "preview" for project linked-up',
+            '  › Would push source to "main", create release, and deploy to "preview" for project verified-slug',
           ),
           true,
         );
@@ -477,6 +480,8 @@ describe("Up Command", () => {
       const { deployProject } = recordingDeployProject(
         dryRunOutcome({
           projectId: null,
+          // No project exists yet, so the plan carries the slug it would create.
+          projectSlug: expectedSlug,
           environmentId: null,
           plannedActions: ["create-project", "push-source", "create-release", "deploy"],
         }),

--- a/cli/commands/up/command.ts
+++ b/cli/commands/up/command.ts
@@ -8,7 +8,7 @@ import { ensureAuthenticated } from "../../auth/index.ts";
 import { type EnvironmentConfig, getEnvironmentConfig } from "veryfront/config";
 import { createSpinner } from "#cli/ui";
 import { isTTY, promptUser } from "#cli/utils";
-import { logSuccess, logWarning } from "#cli/utils";
+import { logInfo, logSuccess, logWarning } from "#cli/utils";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
 import {
   createApiClient,
@@ -117,6 +117,26 @@ function plannedUpActions(plan: DeployPlan): string[] {
   ];
 }
 
+/**
+ * The same plan in prose, for the humans `--dry-run` exists to inform.
+ *
+ * A dry run that only says it finished cannot be read before the real run, so
+ * it names the project it resolved and every action the apply would take.
+ * It never predicts a preview URL: `up` prints URLs it has verified, and the
+ * hostname of a deployment that does not exist yet is not one of them.
+ */
+function formatUpDryRunPlan(plan: DeployPlan, projectSlug: string): string {
+  const actions = [
+    ...(plan.plannedActions.includes("create-project") ? ["create the project"] : []),
+    ...(plan.plannedActions.includes("push-source") ? [`push source to "${plan.branch}"`] : []),
+    "create release",
+    `deploy to "${plan.environment}"`,
+  ];
+  const last = actions[actions.length - 1];
+  const phrase = `${actions.slice(0, -1).join(", ")}, and ${last}`;
+  return `Would ${phrase} for project ${projectSlug}`;
+}
+
 export async function upCommand(
   options: Partial<UpOptions> = {},
   env: EnvironmentConfig = getEnvironmentConfig(),
@@ -159,10 +179,10 @@ export async function upCommand(
       );
     } else {
       logWarning("This folder is empty.");
-      cliLogger.info("");
+      console.log();
       cliLogger.info("To get started, create your app files or run:");
       cliLogger.info(`  ${brand("veryfront init")}`);
-      cliLogger.info("");
+      console.log();
     }
     exitProcess(1);
     return;
@@ -238,7 +258,9 @@ export async function upCommand(
     projectSlug = slug;
   }
 
-  if (!jsonOutput) cliLogger.info("");
+  // A blank separator is written straight to stdout: routed through the logger
+  // it renders as a status glyph with no message.
+  if (!jsonOutput) console.log();
 
   // Deploy Execution owns the rest: the bootstrap push, the release, the
   // deployment, and the readiness probe behind the URL printed below.
@@ -257,6 +279,9 @@ export async function upCommand(
     }, {
       onEvent(event) {
         if (event.kind !== "step") return;
+        // A dry run resolves the target and stops. Narrating the steps of an
+        // apply it never performs told users it was "Building release...".
+        if (dryRun) return;
         const next = deployProgressText(event, "preview", verbose);
         if (!next || next === progressText) return;
         progressText = next;
@@ -282,6 +307,7 @@ export async function upCommand(
         },
       });
     } else {
+      logInfo(formatUpDryRunPlan(outcome.plan, projectSlug));
       logSuccess("Dry run complete");
     }
     return;

--- a/cli/commands/up/command.ts
+++ b/cli/commands/up/command.ts
@@ -122,10 +122,13 @@ function plannedUpActions(plan: DeployPlan): string[] {
  *
  * A dry run that only says it finished cannot be read before the real run, so
  * it names the project it resolved and every action the apply would take.
+ * The name comes from the plan, not from the local link: a project renamed
+ * after it was linked still resolves by id, and the plan carries the slug the
+ * apply would actually target.
  * It never predicts a preview URL: `up` prints URLs it has verified, and the
  * hostname of a deployment that does not exist yet is not one of them.
  */
-function formatUpDryRunPlan(plan: DeployPlan, projectSlug: string): string {
+function formatUpDryRunPlan(plan: DeployPlan): string {
   const actions = [
     ...(plan.plannedActions.includes("create-project") ? ["create the project"] : []),
     ...(plan.plannedActions.includes("push-source") ? [`push source to "${plan.branch}"`] : []),
@@ -134,7 +137,7 @@ function formatUpDryRunPlan(plan: DeployPlan, projectSlug: string): string {
   ];
   const last = actions[actions.length - 1];
   const phrase = `${actions.slice(0, -1).join(", ")}, and ${last}`;
-  return `Would ${phrase} for project ${projectSlug}`;
+  return `Would ${phrase} for project ${plan.projectSlug}`;
 }
 
 export async function upCommand(
@@ -307,7 +310,7 @@ export async function upCommand(
         },
       });
     } else {
-      logInfo(formatUpDryRunPlan(outcome.plan, projectSlug));
+      logInfo(formatUpDryRunPlan(outcome.plan));
       logSuccess("Dry run complete");
     }
     return;


### PR DESCRIPTION
Found on a DX dogfood walk of the published docs (`veryfront up --dry-run` from a
linked project directory).

## Symptom

```
  ○ Analyzing project...
  ●
  ○ Linking project...
  ○ Building release...
  ✓ Dry run complete
```

Three problems in five lines:

1. Line 2 is a status glyph with no message — a rendered line that says nothing.
2. The dry run never names the project it resolved or any action it would take,
   so the flag cannot serve its purpose: reading the plan before committing to
   it. `veryfront deploy --dry-run` already prints exactly that line; `up` did
   not.
3. It narrates `Building release...` during a run that builds nothing.

## Root cause

- `cli/commands/up/command.ts` wrote its blank separator with
  `cliLogger.info("")`. The CLI logger preset renders every record as
  `  <glyph> <message>`, so an empty message renders as a bare bullet.
- The dry-run branch only called `logSuccess("Dry run complete")`. The plan was
  computed (`plannedUpActions`) but reached the `--json` result only.
- `up` fed every Deploy Execution step event to the spinner regardless of mode.
  A dry run still runs `resolve-target`, whose non-verbose progress text is
  `Building release...` — accurate for an apply, a lie for a dry run.

## Fix

- Blank separators go straight to stdout (`console.log()`), so nothing renders a
  contentless status line.
- The dry-run branch prints the plan in prose, phrased like the existing
  `veryfront deploy --dry-run` line:
  `› Would push source to "main", create release, and deploy to "preview" for project linked-up`
  (with `create the project` prepended when the project does not exist yet).
- Step events no longer drive the spinner in dry-run mode; the run shows
  `Linking project...` and then reports its plan.
- The project it names comes from the plan (`plan.projectSlug`), not from the
  local link: a project renamed after linking still resolves by id, and the plan
  carries the slug the apply would target. The `--json` payload still reports the
  locally analyzed slug — pre-existing, with its own asserted contract, and not
  something a presentation fix should change.

Deliberately *not* included: a predicted preview URL. `up` prints only URLs it
has verified from a real deployment — an existing test asserts it never rebuilds
a preview hostname from the local slug — and a dry run has no deployment to
verify.

After:

```
  ○ Analyzing project...
  ○ Linking project...
  › Would push source to "main", create release, and deploy to "preview" for project linked-up
  ✓ Dry run complete
```

## Regression test

`cli/commands/up/command.test.ts` — two BDD cases next to the existing `up`
dry-run coverage, because this is `up`'s presentation of a plan Deploy Execution
hands it, and the file already injects a stub `DeployProject`:

- *tells a human what the dry run would do, and never renders an empty status
  line* — the linked-project case.
- *names the project a human dry run would create* — the not-yet-created case.

Both assert against a new `captureConsole` helper that records **both** console
streams (spinner frames go to stderr, results to stdout) under the same `"cli"`
logger preset `cli/main.ts` installs, so a captured line is byte-for-byte the
line a user reads. The pre-existing `captureLog` reads stdout only under the
server preset, which is why it could not see either defect.

The stub `DeployProject` now replays step events, so the test can assert the dry
run never narrates `Building release...`.

Both tests fail on `main` — the first on the empty-glyph assertion, the second
on the missing plan line.

## Not touched

`cliLogger.info("")` is used as a blank line in six other CLI commands
(`pull`, `lock`, `analyze-chunks`, `workflow`, `task`, `build/config-display`)
and renders the same empty bullet there. Out of scope for this fix.

