### PR TITLE
fix(doctor): stop warning about healthy scaffolds

### DIFF
--- a/cli/commands/doctor/ai-checks.test.ts
+++ b/cli/commands/doctor/ai-checks.test.ts
@@ -5,9 +5,10 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { withTempDir } from "#veryfront/testing";
+import { withEnv, withTempDir } from "#veryfront/testing";
 import { mkdir, writeTextFile } from "#veryfront/compat/fs.ts";
 import { join } from "#veryfront/compat/path";
+import { clearConfigCache } from "#veryfront/config";
 import { checkAIConfig } from "./ai-checks.ts";
 
 describe("doctor/ai-checks", () => {
@@ -70,6 +71,54 @@ describe("doctor/ai-checks", () => {
         assertStringIncludes(aiFeatureResult.message, "agents/");
         assertStringIncludes(aiFeatureResult.message, "tools/");
       }, { prefix: "doctor-ai-surfaces-" });
+    });
+
+    it("accepts a provider whose API key comes from the environment", async () => {
+      await withTempDir(async (projectDir) => {
+        clearConfigCache();
+        await mkdir(join(projectDir, "agents"), { recursive: true });
+        await writeTextFile(join(projectDir, "agents", "assistant.ts"), "export default {};\n");
+        await writeTextFile(
+          join(projectDir, "veryfront.config.js"),
+          'export default { ai: { providers: { openai: { defaultModel: "gpt-4o-mini" } } } };\n',
+        );
+
+        const results = await withEnv(
+          { OPENAI_API_KEY: "sk-test-doctor" },
+          () => checkAIConfig(projectDir),
+        );
+        const providerResult = results.find((result) => result.name === "AI Provider: openai");
+
+        assertExists(providerResult);
+        assertEquals(
+          providerResult.status,
+          "pass",
+          "a provider whose credential is in the environment is not a doctor failure",
+        );
+        assertStringIncludes(providerResult.message, "OPENAI_API_KEY");
+      }, { prefix: "doctor-ai-env-key-" });
+    });
+
+    it("still fails a provider with no API key in config or environment", async () => {
+      await withTempDir(async (projectDir) => {
+        clearConfigCache();
+        await mkdir(join(projectDir, "agents"), { recursive: true });
+        await writeTextFile(join(projectDir, "agents", "assistant.ts"), "export default {};\n");
+        await writeTextFile(
+          join(projectDir, "veryfront.config.js"),
+          'export default { ai: { providers: { openai: { defaultModel: "gpt-4o-mini" } } } };\n',
+        );
+
+        const results = await withEnv(
+          { OPENAI_API_KEY: "" },
+          () => checkAIConfig(projectDir),
+        );
+        const providerResult = results.find((result) => result.name === "AI Provider: openai");
+
+        assertExists(providerResult);
+        assertEquals(providerResult.status, "fail");
+        assertEquals(providerResult.message, "Missing API Key");
+      }, { prefix: "doctor-ai-no-key-" });
     });
   });
 });

--- a/cli/commands/doctor/ai-checks.test.ts
+++ b/cli/commands/doctor/ai-checks.test.ts
@@ -3,8 +3,11 @@ import "#veryfront/schemas/_test-setup.ts";
  * Tests for doctor AI checks
  */
 
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withTempDir } from "#veryfront/testing";
+import { mkdir, writeTextFile } from "#veryfront/compat/fs.ts";
+import { join } from "#veryfront/compat/path";
 import { checkAIConfig } from "./ai-checks.ts";
 
 describe("doctor/ai-checks", () => {
@@ -39,6 +42,34 @@ describe("doctor/ai-checks", () => {
       assertExists(aiFeatureResult);
       assertEquals(aiFeatureResult.status, "pass");
       assertEquals(aiFeatureResult.message, "Disabled (default)");
+    });
+
+    it("reports AI as in use when the project ships agents and tools", async () => {
+      await withTempDir(async (projectDir) => {
+        await mkdir(join(projectDir, "agents"), { recursive: true });
+        await mkdir(join(projectDir, "tools"), { recursive: true });
+        await writeTextFile(
+          join(projectDir, "agents", "assistant.ts"),
+          "export default {};\n",
+        );
+        await writeTextFile(
+          join(projectDir, "tools", "calculator.ts"),
+          "export default {};\n",
+        );
+
+        const results = await checkAIConfig(projectDir);
+        const aiFeatureResult = results.find((result) => result.name === "AI Features");
+
+        assertExists(aiFeatureResult);
+        assertEquals(aiFeatureResult.status, "pass");
+        assertEquals(
+          aiFeatureResult.message.includes("Disabled"),
+          false,
+          "a project with discoverable agents must not be reported as AI-disabled",
+        );
+        assertStringIncludes(aiFeatureResult.message, "agents/");
+        assertStringIncludes(aiFeatureResult.message, "tools/");
+      }, { prefix: "doctor-ai-surfaces-" });
     });
   });
 });

--- a/cli/commands/doctor/ai-checks.test.ts
+++ b/cli/commands/doctor/ai-checks.test.ts
@@ -104,20 +104,22 @@ describe("doctor/ai-checks", () => {
         clearConfigCache();
         await mkdir(join(projectDir, "agents"), { recursive: true });
         await writeTextFile(join(projectDir, "agents", "assistant.ts"), "export default {};\n");
+        // A provider name no other test's environment touches, so the absence of
+        // its credential is deterministic.
         await writeTextFile(
           join(projectDir, "veryfront.config.js"),
-          'export default { ai: { providers: { openai: { defaultModel: "gpt-4o-mini" } } } };\n',
+          'export default { ai: { providers: { doctorfixture: { defaultModel: "m" } } } };\n',
         );
 
-        const results = await withEnv(
-          { OPENAI_API_KEY: "" },
-          () => checkAIConfig(projectDir),
+        const results = await checkAIConfig(projectDir);
+        const providerResult = results.find((result) =>
+          result.name === "AI Provider: doctorfixture"
         );
-        const providerResult = results.find((result) => result.name === "AI Provider: openai");
 
         assertExists(providerResult);
         assertEquals(providerResult.status, "fail");
         assertEquals(providerResult.message, "Missing API Key");
+        assertStringIncludes(providerResult.details ?? "", "DOCTORFIXTURE_API_KEY");
       }, { prefix: "doctor-ai-no-key-" });
     });
   });

--- a/cli/commands/doctor/ai-checks.ts
+++ b/cli/commands/doctor/ai-checks.ts
@@ -2,12 +2,33 @@ import type { DiagnosticResult } from "./types.ts";
 import { exists } from "#std/fs.ts";
 import { join } from "veryfront/platform/path";
 import type { VeryfrontConfig } from "veryfront/config";
-import { getConfig } from "veryfront/config";
 import { createProjectDiscoveryConfig } from "veryfront/discovery";
-import { createMockAdapter } from "veryfront/platform";
+import { getEnv } from "veryfront/platform";
+import { loadConfigOrNull } from "./project-config.ts";
 
 /** Discovery buckets that make a project's AI surface visible to the runtime. */
 const AI_SURFACE_KEYS = ["agentDirs", "toolDirs", "workflowDirs", "skillDirs"] as const;
+
+/**
+ * Environment variables the built-in providers read their credentials from,
+ * mirroring `autoInitializeFromEnv` in `src/provider/model-registry.ts`.
+ * Anything else follows the documented `<PROVIDER>_API_KEY` convention.
+ */
+const PROVIDER_ENV_KEYS: Record<string, readonly string[]> = {
+  openai: ["OPENAI_API_KEY"],
+  anthropic: ["ANTHROPIC_API_KEY"],
+  google: ["GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"],
+  mistral: ["MISTRAL_API_KEY"],
+};
+
+function providerEnvKeys(name: string): readonly string[] {
+  return PROVIDER_ENV_KEYS[name.toLowerCase()] ?? [`${name.toUpperCase()}_API_KEY`];
+}
+
+/** The env var actually holding this provider's credential, if any. */
+function findProviderEnvKey(name: string): string | undefined {
+  return providerEnvKeys(name).find((key) => (getEnv(key) ?? "").trim() !== "");
+}
 
 /**
  * Lists the AI directories the runtime would actually discover, so doctor
@@ -36,12 +57,11 @@ async function findAISurfaces(
  * Check AI Configuration and API Keys
  */
 export async function checkAIConfig(projectDir: string): Promise<DiagnosticResult[]> {
-  const adapter = createMockAdapter();
+  // The runtime adapter, not a mock one: a mock filesystem never finds the
+  // project's veryfront.config, so every `ai` setting below would read as unset.
+  const config = await loadConfigOrNull(projectDir);
 
-  let config: Awaited<ReturnType<typeof getConfig>>;
-  try {
-    config = await getConfig(projectDir, adapter);
-  } catch {
+  if (!config) {
     return [
       {
         status: "warn",
@@ -89,12 +109,26 @@ export async function checkAIConfig(projectDir: string): Promise<DiagnosticResul
   }
 
   for (const [name, provider] of providerEntries) {
-    const apiKey = provider?.apiKey;
+    if (provider?.apiKey) {
+      results.push({
+        status: "pass",
+        name: `AI Provider: ${name}`,
+        message: "API Key configured",
+      });
+      continue;
+    }
+
+    // Providers normally resolve their credential from the environment, so an
+    // absent `apiKey` in config is only a problem when the env has none either.
+    const envKey = findProviderEnvKey(name);
 
     results.push({
-      status: apiKey ? "pass" : "fail",
+      status: envKey ? "pass" : "fail",
       name: `AI Provider: ${name}`,
-      message: apiKey ? "API Key configured" : "Missing API Key",
+      message: envKey ? `API Key from ${envKey}` : "Missing API Key",
+      details: envKey
+        ? undefined
+        : `Set ${providerEnvKeys(name)[0]} or ai.providers.${name}.apiKey`,
     });
   }
 

--- a/cli/commands/doctor/ai-checks.ts
+++ b/cli/commands/doctor/ai-checks.ts
@@ -1,6 +1,36 @@
 import type { DiagnosticResult } from "./types.ts";
+import { exists } from "#std/fs.ts";
+import { join } from "veryfront/platform/path";
+import type { VeryfrontConfig } from "veryfront/config";
 import { getConfig } from "veryfront/config";
+import { createProjectDiscoveryConfig } from "veryfront/discovery";
 import { createMockAdapter } from "veryfront/platform";
+
+/** Discovery buckets that make a project's AI surface visible to the runtime. */
+const AI_SURFACE_KEYS = ["agentDirs", "toolDirs", "workflowDirs", "skillDirs"] as const;
+
+/**
+ * Lists the AI directories the runtime would actually discover, so doctor
+ * reports what the project ships instead of a config flag nothing reads.
+ */
+async function findAISurfaces(
+  projectDir: string,
+  config: VeryfrontConfig,
+): Promise<string[]> {
+  const discovery = createProjectDiscoveryConfig({ projectDir, config });
+  const surfaces: string[] = [];
+
+  for (const key of AI_SURFACE_KEYS) {
+    for (const dir of discovery[key]) {
+      if (await exists(join(projectDir, dir))) {
+        surfaces.push(`${dir}/`);
+        break;
+      }
+    }
+  }
+
+  return surfaces;
+}
 
 /**
  * Check AI Configuration and API Keys
@@ -21,7 +51,10 @@ export async function checkAIConfig(projectDir: string): Promise<DiagnosticResul
     ];
   }
 
-  if (!config.ai?.enabled) {
+  const surfaces = await findAISurfaces(projectDir, config);
+  const explicitlyEnabled = config.ai?.enabled === true;
+
+  if (!explicitlyEnabled && surfaces.length === 0) {
     return [
       {
         status: "pass",
@@ -35,19 +68,23 @@ export async function checkAIConfig(projectDir: string): Promise<DiagnosticResul
     {
       status: "pass",
       name: "AI Features",
-      message: "Enabled",
+      message: surfaces.length > 0 ? `Enabled (${surfaces.join(", ")})` : "Enabled",
     },
   ];
 
-  const providers = config.ai.providers ?? {};
+  const providers = config.ai?.providers ?? {};
   const providerEntries = Object.entries(providers);
 
   if (providerEntries.length === 0) {
-    results.push({
-      status: "warn",
-      name: "AI Providers",
-      message: "No LLM providers configured",
-    });
+    // Providers are optional: keys usually come from the environment. Only an
+    // explicit `ai.enabled` config with no providers is worth flagging.
+    if (explicitlyEnabled) {
+      results.push({
+        status: "warn",
+        name: "AI Providers",
+        message: "No LLM providers configured",
+      });
+    }
     return results;
   }
 

--- a/cli/commands/doctor/doctor.integration.test.ts
+++ b/cli/commands/doctor/doctor.integration.test.ts
@@ -8,7 +8,8 @@ import {
 } from "#veryfront/testing/assert";
 import { join } from "#veryfront/compat/path";
 import { describe, it } from "#veryfront/testing/bdd";
-import { remove, writeTextFile } from "#veryfront/compat/fs.ts";
+import { mkdir, remove, writeTextFile } from "#veryfront/compat/fs.ts";
+import { withTempDir } from "#veryfront/testing";
 import { doctorCommand, reportDoctorResults, resolveDoctorPort, streamCheck } from "./index.ts";
 import { withTestContext } from "../../../tests/_helpers/context.ts";
 import { clearConfigCache } from "#veryfront/config";
@@ -140,6 +141,59 @@ describe("CLI doctor command", () => {
       assertEquals(await resolveDoctorPort(context.projectDir), 4321);
       assertEquals(await resolveDoctorPort(context.projectDir, 5432), 5432);
     });
+  });
+
+  it("reports no warnings for a freshly scaffolded app-router project", async () => {
+    await withTempDir(async (projectDir) => {
+      clearConfigCache();
+      await mkdir(join(projectDir, "app", "api", "ag-ui"), { recursive: true });
+      await mkdir(join(projectDir, "agents"), { recursive: true });
+      await mkdir(join(projectDir, "tools"), { recursive: true });
+      await writeTextFile(
+        join(projectDir, "app", "page.tsx"),
+        "export default function Page() {\n  return <div />;\n}\n",
+      );
+      await writeTextFile(join(projectDir, "agents", "assistant.ts"), "export default {};\n");
+      await writeTextFile(join(projectDir, "tools", "calculator.ts"), "export default {};\n");
+
+      const output: unknown[][] = [];
+      const originalLog = console.log;
+      console.log = (...args: unknown[]) => output.push(args);
+      setJsonMode(true);
+
+      try {
+        await doctorCommand(projectDir);
+      } finally {
+        setJsonMode(false);
+        console.log = originalLog;
+      }
+
+      const envelope = JSON.parse(String(output[0]?.[0])) as {
+        data: {
+          checks: { name: string; status: string; message: string }[];
+          summary: { warnings: number };
+        };
+      };
+      const checks = envelope.data.checks;
+      const warnings = checks.filter((check) => check.status !== "pass");
+
+      assertEquals(
+        warnings,
+        [],
+        `a healthy scaffold must produce no warnings, got ${JSON.stringify(warnings)}`,
+      );
+      assertEquals(envelope.data.summary.warnings, 0);
+      assertEquals(
+        checks.some((check) => check.name.includes("RSC manifest")),
+        false,
+        "RSC endpoint probes must be skipped while the experimental flag is off",
+      );
+      assertEquals(
+        checks.some((check) => check.message.includes("Disabled")),
+        false,
+        "a project with agents/ and tools/ must not be reported as AI-disabled",
+      );
+    }, { prefix: "doctor-scaffold-" });
   });
 
   it("runs without throwing", async () => {

--- a/cli/commands/doctor/index.ts
+++ b/cli/commands/doctor/index.ts
@@ -8,7 +8,12 @@ import {
   checkConfiguration,
   checkProjectStructure,
 } from "./project-structure.ts";
-import { checkRSCCounters, checkRSCEndpoints, checkRSCFlag } from "./server-checks.ts";
+import {
+  checkRSCCounters,
+  checkRSCEndpoints,
+  checkRSCFlag,
+  isRscDiagnosticsEnabled,
+} from "./server-checks.ts";
 import { checkAIConfig } from "./ai-checks.ts";
 import {
   bold,
@@ -217,6 +222,10 @@ export async function doctorCommand(
   const port = await resolveDoctorPort(projectDir, opts.port);
   const startTime = Date.now();
 
+  // RSC endpoints only exist behind the experimental flag; probing them
+  // otherwise reports unreachable endpoints as project health problems.
+  const rscEnabled = await isRscDiagnosticsEnabled();
+
   if (isJsonMode()) {
     const results: DiagnosticResult[] = [
       await checkDenoVersion(),
@@ -225,8 +234,8 @@ export async function doctorCommand(
       await checkCacheSystem(),
       await checkReactCompatibility(),
       await checkRSCFlag(),
-      ...(await checkRSCEndpoints(port)),
-      await checkRSCCounters(port),
+      ...(rscEnabled ? await checkRSCEndpoints(port) : []),
+      ...(rscEnabled ? [await checkRSCCounters(port)] : []),
       ...(await checkAIConfig(projectDir)),
     ];
     await reportDoctorResults(results, {
@@ -250,8 +259,10 @@ export async function doctorCommand(
   await streamCheck(checkCacheSystem, results);
   await streamCheck(checkReactCompatibility, results);
   await streamCheck(checkRSCFlag, results);
-  await streamCheck(() => checkRSCEndpoints(port), results);
-  await streamCheck(() => checkRSCCounters(port), results);
+  if (rscEnabled) {
+    await streamCheck(() => checkRSCEndpoints(port), results);
+    await streamCheck(() => checkRSCCounters(port), results);
+  }
   await streamCheck(() => checkAIConfig(projectDir), results);
 
   console.log();

--- a/cli/commands/doctor/index.ts
+++ b/cli/commands/doctor/index.ts
@@ -224,7 +224,7 @@ export async function doctorCommand(
 
   // RSC endpoints only exist behind the experimental flag; probing them
   // otherwise reports unreachable endpoints as project health problems.
-  const rscEnabled = await isRscDiagnosticsEnabled();
+  const rscEnabled = await isRscDiagnosticsEnabled(projectDir);
 
   if (isJsonMode()) {
     const results: DiagnosticResult[] = [
@@ -233,7 +233,7 @@ export async function doctorCommand(
       await checkConfiguration(projectDir),
       await checkCacheSystem(),
       await checkReactCompatibility(),
-      await checkRSCFlag(),
+      await checkRSCFlag(projectDir),
       ...(rscEnabled ? await checkRSCEndpoints(port) : []),
       ...(rscEnabled ? [await checkRSCCounters(port)] : []),
       ...(await checkAIConfig(projectDir)),
@@ -258,7 +258,7 @@ export async function doctorCommand(
   await streamCheck(() => checkConfiguration(projectDir), results);
   await streamCheck(checkCacheSystem, results);
   await streamCheck(checkReactCompatibility, results);
-  await streamCheck(checkRSCFlag, results);
+  await streamCheck(() => checkRSCFlag(projectDir), results);
   if (rscEnabled) {
     await streamCheck(() => checkRSCEndpoints(port), results);
     await streamCheck(() => checkRSCCounters(port), results);

--- a/cli/commands/doctor/project-config.ts
+++ b/cli/commands/doctor/project-config.ts
@@ -1,0 +1,19 @@
+import { getConfig } from "veryfront/config";
+import type { VeryfrontConfig } from "veryfront/config";
+
+/**
+ * Loads `veryfront.config` for a project, or `null` when it cannot be read.
+ *
+ * Doctor checks describe a project rather than run it, so a missing or broken
+ * config is reported by the configuration check alone — every other check falls
+ * back to framework defaults instead of failing.
+ */
+export async function loadConfigOrNull(projectDir: string): Promise<VeryfrontConfig | null> {
+  try {
+    const { runtime } = await import("veryfront/platform");
+    const adapter = await runtime.get();
+    return await getConfig(projectDir, adapter);
+  } catch {
+    return null;
+  }
+}

--- a/cli/commands/doctor/project-structure.test.ts
+++ b/cli/commands/doctor/project-structure.test.ts
@@ -5,6 +5,9 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withTempDir } from "#veryfront/testing";
+import { mkdir, writeTextFile } from "#veryfront/compat/fs.ts";
+import { join } from "#veryfront/compat/path";
 import {
   checkCacheSystem,
   checkConfiguration,
@@ -34,12 +37,51 @@ describe("doctor/project-structure", () => {
       }
     });
 
-    it("checks for pages directory", async () => {
+    it("warns when the project has no router directory at all", async () => {
       const results = await checkProjectStructure("/non-existent-path");
-      const pagesCheck = results.find((r) => r.name.includes("pages"));
+      const structureCheck = results.find((r) => r.name.startsWith("Project Structure"));
 
-      assertExists(pagesCheck);
-      assertEquals(pagesCheck.status, "warn"); // Should be warn since path doesn't exist
+      assertExists(structureCheck);
+      assertEquals(structureCheck.status, "warn"); // Should be warn since path doesn't exist
+    });
+
+    it("passes for an app router project without warning about pages/", async () => {
+      await withTempDir(async (projectDir) => {
+        await mkdir(join(projectDir, "app"), { recursive: true });
+        await writeTextFile(
+          join(projectDir, "app", "page.tsx"),
+          "export default function Page() {\n  return <div />;\n}\n",
+        );
+
+        const results = await checkProjectStructure(projectDir);
+
+        assertEquals(
+          results.filter((result) => result.status !== "pass"),
+          [],
+          "app router projects must not be warned about the pages router",
+        );
+        assertEquals(results.length > 0, true, "structure check must report something");
+        assertEquals(
+          results.some((result) => result.message.includes("app")),
+          true,
+          "structure check should name the router it found",
+        );
+      }, { prefix: "doctor-app-router-" });
+    });
+
+    it("passes for a pages router project", async () => {
+      await withTempDir(async (projectDir) => {
+        await mkdir(join(projectDir, "pages"), { recursive: true });
+        await writeTextFile(join(projectDir, "pages", "index.mdx"), "# Hello\n");
+
+        const results = await checkProjectStructure(projectDir);
+
+        assertEquals(
+          results.filter((result) => result.status !== "pass"),
+          [],
+          "pages router projects remain supported",
+        );
+      }, { prefix: "doctor-pages-router-" });
     });
   });
 

--- a/cli/commands/doctor/project-structure.ts
+++ b/cli/commands/doctor/project-structure.ts
@@ -1,27 +1,54 @@
 import { exists } from "#std/fs.ts";
 import { join } from "veryfront/platform/path";
 import { getConfig } from "veryfront/config";
+import type { VeryfrontConfig } from "veryfront/config";
 import type { DiagnosticResult } from "./types.ts";
 
+async function loadConfigOrNull(projectDir: string): Promise<VeryfrontConfig | null> {
+  try {
+    const { runtime } = await import("veryfront/platform");
+    const adapter = await runtime.get();
+    return await getConfig(projectDir, adapter);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reports which router directory the project uses.
+ *
+ * Route discovery accepts either router (`app/` or `pages/`, honoring
+ * `directories` overrides), so the check passes when either one is present and
+ * warns only when the project has no routes at all.
+ */
 export async function checkProjectStructure(projectDir: string): Promise<DiagnosticResult[]> {
-  const requiredFiles = ["pages", "pages/index.mdx"];
-  const results: DiagnosticResult[] = [];
+  const config = await loadConfigOrNull(projectDir);
+  const appDir = config?.directories?.app ?? "app";
+  const pagesDir = config?.directories?.pages ?? "pages";
 
-  for (const file of requiredFiles) {
-    const filePath = join(projectDir, file);
-    const found = await exists(filePath);
+  const [hasApp, hasPages] = await Promise.all([
+    exists(join(projectDir, appDir)),
+    exists(join(projectDir, pagesDir)),
+  ]);
 
-    results.push({
-      name: `Project Structure (${file})`,
-      status: found ? "pass" : "warn",
-      message: found ? "Found" : "Not found",
-      details: !found && file === "pages/index.mdx"
-        ? "Create an index.mdx file in your pages directory"
-        : undefined,
-    });
+  const routers: string[] = [];
+  if (hasApp) routers.push(`${appDir}/`);
+  if (hasPages) routers.push(`${pagesDir}/`);
+
+  if (routers.length === 0) {
+    return [{
+      name: "Project Structure",
+      status: "warn",
+      message: `No ${appDir}/ or ${pagesDir}/ directory found`,
+      details: `Add ${appDir}/page.tsx to create your first route`,
+    }];
   }
 
-  return results;
+  return [{
+    name: "Project Structure",
+    status: "pass",
+    message: `Found ${routers.join(", ")}`,
+  }];
 }
 
 export async function checkConfiguration(projectDir: string): Promise<DiagnosticResult> {

--- a/cli/commands/doctor/project-structure.ts
+++ b/cli/commands/doctor/project-structure.ts
@@ -1,18 +1,8 @@
 import { exists } from "#std/fs.ts";
 import { join } from "veryfront/platform/path";
 import { getConfig } from "veryfront/config";
-import type { VeryfrontConfig } from "veryfront/config";
 import type { DiagnosticResult } from "./types.ts";
-
-async function loadConfigOrNull(projectDir: string): Promise<VeryfrontConfig | null> {
-  try {
-    const { runtime } = await import("veryfront/platform");
-    const adapter = await runtime.get();
-    return await getConfig(projectDir, adapter);
-  } catch {
-    return null;
-  }
-}
+import { loadConfigOrNull } from "./project-config.ts";
 
 /**
  * Reports which router directory the project uses.

--- a/cli/commands/doctor/server-checks.test.ts
+++ b/cli/commands/doctor/server-checks.test.ts
@@ -5,7 +5,16 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { checkRSCCounters, checkRSCEndpoints, checkRSCFlag } from "./server-checks.ts";
+import { withTempDir } from "#veryfront/testing";
+import { writeTextFile } from "#veryfront/compat/fs.ts";
+import { join } from "#veryfront/compat/path";
+import { clearConfigCache } from "#veryfront/config";
+import {
+  checkRSCCounters,
+  checkRSCEndpoints,
+  checkRSCFlag,
+  isRscDiagnosticsEnabled,
+} from "./server-checks.ts";
 
 async function withUnreachableFetch<T>(fn: () => Promise<T>): Promise<T> {
   const originalFetch = globalThis.fetch;
@@ -33,6 +42,33 @@ describe("doctor/server-checks", () => {
       assertExists(result.message);
       assertEquals(result.name, "RSC Flag");
       assertEquals(["pass", "warn", "fail"].includes(result.status), true);
+    });
+
+    it("honors experimental.rsc from the project config, like the server does", async () => {
+      await withTempDir(async (projectDir) => {
+        clearConfigCache();
+        await writeTextFile(
+          join(projectDir, "veryfront.config.js"),
+          "export default { experimental: { rsc: true } };\n",
+        );
+
+        // The env flag is off here; the server would still serve RSC because
+        // `isRSCEnabled` lets an explicit project setting win.
+        assertEquals(await isRscDiagnosticsEnabled(projectDir), true);
+        assertEquals((await checkRSCFlag(projectDir)).message, "enabled");
+      }, { prefix: "doctor-rsc-config-" });
+    });
+
+    it("reports RSC as opt-in when neither config nor env enables it", async () => {
+      await withTempDir(async (projectDir) => {
+        clearConfigCache();
+
+        assertEquals(await isRscDiagnosticsEnabled(projectDir), false);
+        assertEquals(
+          (await checkRSCFlag(projectDir)).message,
+          "disabled (experimental, opt-in)",
+        );
+      }, { prefix: "doctor-rsc-default-" });
     });
   });
 

--- a/cli/commands/doctor/server-checks.ts
+++ b/cli/commands/doctor/server-checks.ts
@@ -35,6 +35,23 @@ function getHashFromManifest(json: unknown): string | null {
   return typeof hash === "string" ? hash : null;
 }
 
+/**
+ * Whether the experimental RSC surface is opted into.
+ *
+ * The RSC endpoint probes only mean something when the flag is on, so doctor
+ * uses this to skip them rather than warn about endpoints the server never
+ * serves.
+ */
+export async function isRscDiagnosticsEnabled(): Promise<boolean> {
+  try {
+    const { isRscExperimentalEnabled } = await import("veryfront/config");
+    return isRscExperimentalEnabled();
+  } catch (error) {
+    cliLogger.debug("Failed to read the RSC experimental flag:", error);
+    return false;
+  }
+}
+
 export async function checkRSCFlag(): Promise<DiagnosticResult> {
   try {
     const { isRscExperimentalEnabled } = await import("veryfront/config");
@@ -42,8 +59,8 @@ export async function checkRSCFlag(): Promise<DiagnosticResult> {
 
     return {
       name: "RSC Flag",
-      status: isEnabled ? "pass" : "warn",
-      message: isEnabled ? "enabled" : "VERYFRONT_EXPERIMENTAL_RSC not set",
+      status: "pass",
+      message: isEnabled ? "enabled" : "disabled (experimental, opt-in)",
     };
   } catch (error) {
     return {

--- a/cli/commands/doctor/server-checks.ts
+++ b/cli/commands/doctor/server-checks.ts
@@ -2,6 +2,7 @@ import type { DiagnosticResult } from "./types.ts";
 import { cliLogger } from "#cli/utils";
 import { DEFAULT_DEV_PORT } from "#cli/shared/constants";
 import { formatError } from "../../utils/string.ts";
+import { loadConfigOrNull } from "./project-config.ts";
 
 const FETCH_TIMEOUT_MS = 2000;
 
@@ -36,26 +37,34 @@ function getHashFromManifest(json: unknown): string | null {
 }
 
 /**
- * Whether the experimental RSC surface is opted into.
- *
- * The RSC endpoint probes only mean something when the flag is on, so doctor
- * uses this to skip them rather than warn about endpoints the server never
- * serves.
+ * Resolves RSC exactly the way the server does: an explicit
+ * `experimental.rsc` in `veryfront.config` wins, and `VERYFRONT_EXPERIMENTAL_RSC`
+ * decides otherwise. Throws if the flag cannot be resolved.
  */
-export async function isRscDiagnosticsEnabled(): Promise<boolean> {
+async function resolveRscEnabled(projectDir?: string): Promise<boolean> {
+  const { isRSCEnabled } = await import("veryfront/utils");
+  const config = projectDir ? await loadConfigOrNull(projectDir) : null;
+  return isRSCEnabled(config ?? undefined);
+}
+
+/**
+ * Whether the experimental RSC surface is opted into for this project.
+ *
+ * The RSC endpoint probes only mean something when RSC is on, so doctor uses
+ * this to skip them rather than warn about endpoints the server never serves.
+ */
+export async function isRscDiagnosticsEnabled(projectDir?: string): Promise<boolean> {
   try {
-    const { isRscExperimentalEnabled } = await import("veryfront/config");
-    return isRscExperimentalEnabled();
+    return await resolveRscEnabled(projectDir);
   } catch (error) {
     cliLogger.debug("Failed to read the RSC experimental flag:", error);
     return false;
   }
 }
 
-export async function checkRSCFlag(): Promise<DiagnosticResult> {
+export async function checkRSCFlag(projectDir?: string): Promise<DiagnosticResult> {
   try {
-    const { isRscExperimentalEnabled } = await import("veryfront/config");
-    const isEnabled = isRscExperimentalEnabled();
+    const isEnabled = await resolveRscEnabled(projectDir);
 
     return {
       name: "RSC Flag",
@@ -66,7 +75,7 @@ export async function checkRSCFlag(): Promise<DiagnosticResult> {
     return {
       name: "RSC Flag",
       status: "warn",
-      message: `env read failed: ${formatError(error)}`,
+      message: `flag read failed: ${formatError(error)}`,
     };
   }
 }


### PR DESCRIPTION
## Symptom

Found while dogfooding the documented developer journey (`veryfront init test-app --template ai-agent --runtime bun`, then `veryfront doctor`).

On a scaffolded project that demonstrably works — routes SSR and client-navigate, AG-UI chat streams with tool calls, `veryfront build` succeeds — `doctor` printed:

```
  ! Project Structure (pages) - Not found
  ! Project Structure (pages/index.mdx) - Not found
  ! RSC Flag - VERYFRONT_EXPERIMENTAL_RSC not set
  ! RSC manifest - unreachable (2ms)
  ! RSC stream - unreachable (0ms)
  ! RSC Counters - unreachable
  ✓ AI Features - Disabled (default)

  ! 6 warnings, 6 passed
```

Every warning was a false alarm, and a new developer running the advertised health check ("Check system requirements and project health") cannot tell which of them matter. `veryfront doctor --strict` was unusable on a healthy project for the same reason.

## Root cause

Three independent checks measured something other than project health:

1. **`checkProjectStructure`** hardcoded `["pages", "pages/index.mdx"]`. Every first-party template scaffolds the app router (`app/page.tsx`, `app/api/*/route.ts`), and `RouteDiscovery.resolveRouteDirectories()` accepts either router plus `directories.app` / `directories.pages` overrides. Doctor was the only place still asserting the pages router.
2. **`checkAIConfig`** keyed off `config.ai.enabled`. That flag is read nowhere else in the framework — `grep` finds exactly one non-test usage, this one. AI surfaces come from discovery (`agents/`, `tools/`, …, see `createProjectDiscoveryConfig`), so a project whose agents and tools are live reported "Disabled (default)".
3. **RSC probes** (`checkRSCEndpoints`, `checkRSCCounters`) fetched `http://127.0.0.1:<port>/_veryfront/rsc/*` unconditionally. Those routes only exist behind `VERYFRONT_EXPERIMENTAL_RSC`, and `doctor` is normally run with no dev server up, so "no server listening" surfaced as three project-health warnings.

## Fix

- Structure check mirrors route discovery: passes on `app/` or `pages/` (honoring `directories` overrides), reports which one it found, and warns once — `No app/ or pages/ directory found` — only when the project has no routes at all.
- AI check reports the discovery directories the runtime would actually load: `AI Features - Enabled (agents/, tools/)`. `Disabled (default)` is kept for projects with no AI surface and no explicit config. The "No LLM providers configured" warning now fires only when `ai.enabled` was set explicitly, since API keys normally come from the environment, not from config.
- RSC endpoint and counter probes run only when the experimental flag is on; the flag line itself becomes informational (`RSC Flag - disabled (experimental, opt-in)`) instead of a warning.

Same project after the fix:

```
  ✓ Runtime Version - Deno 2.7.12
  ✓ Project Structure - Found app/
  ✓ Configuration - Loaded (React auto)
  ✓ Cache System - Managed automatically via Veryfront's built-in LRU cache
  ✓ React Compatibility - React 19.2.4 (14 features)
  ✓ RSC Flag - disabled (experimental, opt-in)
  ✓ AI Features - Enabled (agents/, tools/)

  ✓ All 7 checks passed in 15ms
```

Real problems still surface: a directory with no `app/` and no `pages/` still reports `! 1 warning`, and with `VERYFRONT_EXPERIMENTAL_RSC=1` the endpoint probes still run and still warn when the server is unreachable.

## Regression tests

Deno BDD, colocated with the checks they cover — this is CLI-only logic with no browser or deployment involved, so no e2e was needed:

- `cli/commands/doctor/project-structure.test.ts` — an app-router project produces zero non-pass results (this failed before the fix with the two `Project Structure (pages…) - Not found` warnings); a pages-router project still passes; a project with neither still warns.
- `cli/commands/doctor/ai-checks.test.ts` — a project shipping `agents/` and `tools/` is not reported as AI-disabled and names both directories.
- `cli/commands/doctor/doctor.integration.test.ts` — end-to-end `doctorCommand` over a scaffold-shaped temp project asserts `summary.warnings === 0`, that no RSC endpoint probe ran, and that nothing reports "Disabled". This is the test that pins the finding itself; it lives with the command because it exercises the whole check list in JSON mode.

All three failed before the fix and pass after; the full `cli/commands/` suite (185 tests) is green.


## Review follow-ups

Two defects Codex caught, both the same class as the original finding — doctor describing something other than what the runtime does:

- **RSC resolution** (`52a3c92`). The probe gate read `VERYFRONT_EXPERIMENTAL_RSC` alone, but the runtime's `isRSCEnabled` lets an explicit `experimental.rsc` in `veryfront.config` win. A project that opts in through config would have had its probes skipped and its flag reported as `disabled` while the server served RSC. One resolver now feeds both the flag line and the gate.
- **Provider API keys** (`83901b8`). With AI surfaces now discovered from the project, the provider loop became reachable without `ai.enabled`, and it reported `Missing API Key` — a hard failure — for providers whose credential comes from the environment, which is how the built-in providers resolve keys. It now passes when the provider's env var is set and names it (`API Key from OPENAI_API_KEY`), and fails only when no key exists anywhere.

  Chasing that down surfaced a second defect fixed in the same commit: `checkAIConfig` loaded the config through `createMockAdapter()`, whose filesystem never finds the project's `veryfront.config`, so every `ai` setting in this check read as unset in a real `veryfront doctor` run. It now uses the runtime adapter, like the other doctor checks. The shared loader lives in `cli/commands/doctor/project-config.ts`.

Both are covered by regression tests alongside the originals: a config-enabled RSC project in `server-checks.test.ts`, and env-supplied vs absent provider keys in `ai-checks.test.ts`.
