### PR TITLE
fix(dev-server): release watchers and reload subscriptions when the bind fails

### DIFF
--- a/docs/api-reference/veryfront/server.md
+++ b/docs/api-reference/veryfront/server.md
@@ -61,7 +61,7 @@ await server.fetch(new Request("https://example.com/health"));
 
 | Name             | Description           | Source                                                                                                       |
 | ---------------- | --------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `DevServer`      | Implement dev server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/dev-server/server.ts#L57)          |
+| `DevServer`      | Implement dev server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/dev-server/server.ts#L70)          |
 | `RouteDiscovery` |                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/dev-server/route-discovery.ts#L33) |
 
 ### Types

--- a/src/server/dev-server/server-start-failure.integration.test.ts
+++ b/src/server/dev-server/server-start-failure.integration.test.ts
@@ -11,15 +11,19 @@
  * These tests force a real bind failure (a port already held by another
  * listener) after the subscriptions are registered, and assert that the
  * registrations are released rather than merely that `start()` rejects.
+ *
+ * Colocated with the module it covers, but named `*.integration.test.ts`: it
+ * needs a real project directory, a full `bootstrapDev()`, a real OS file
+ * watcher and a real TCP bind, so it is excluded from the unit shard.
  */
 
 import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import type { FileWatcher, WatchOptions } from "#veryfront/platform/adapters/base.ts";
 import { runtime } from "#veryfront/platform/adapters/registry.ts";
-import { ReloadNotifier } from "../../../src/server/reload-notifier.ts";
-import { DevServer } from "../../../src/server/dev-server.ts";
-import { withTestContext } from "../../_helpers/context.ts";
+import { ReloadNotifier } from "../reload-notifier.ts";
+import { DevServer } from "./server.ts";
+import { withTestContext } from "../../../tests/_helpers/context.ts";
 
 type WatchFn = (paths: string | string[], options?: WatchOptions) => FileWatcher;
 

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -42,6 +42,19 @@ function normalizeSlug(value: string | undefined): string | undefined {
   return normalized ? normalized : undefined;
 }
 
+/**
+ * Run one teardown callback, isolating a throw so it cannot strand the teardown
+ * steps that follow it. Callers must clear the handle before calling this.
+ */
+function release(callback: (() => void) | undefined, label: string): void {
+  if (!callback) return;
+  try {
+    callback();
+  } catch (error) {
+    devServerLog.debug(`${label} cleanup error (non-critical)`, error);
+  }
+}
+
 function deriveProjectSlug(projectDir: string): string {
   const dirName = basename(projectDir);
   const slug = dirName
@@ -500,17 +513,22 @@ export class DevServer {
   async stop(): Promise<void> {
     logger.debug("Shutting down dev server");
 
-    // Cleared after release so stop() is safe to call twice — a failed start()
-    // already tore itself down, and a caller holding the instance may still
-    // call stop(). Releasing the broadcast source twice is not harmless: it
-    // decrements a process-wide counter, which would suppress HMR broadcasts
-    // for an unrelated dev server in the same process.
-    this.reloadUnsubscribe?.();
+    // Every handle is cleared *before* anything is invoked, so stop() is safe to
+    // call twice even if a release throws — a failed start() already tore itself
+    // down, and a caller holding the instance may still call stop(). Releasing
+    // the broadcast source twice is not harmless: it decrements a process-wide
+    // counter, which would suppress HMR broadcasts for an unrelated dev server
+    // in the same process.
+    const reloadUnsubscribe = this.reloadUnsubscribe;
+    const invalidateUnsubscribe = this.invalidateUnsubscribe;
+    const releaseExternalBroadcastSource = this.releaseExternalBroadcastSource;
     this.reloadUnsubscribe = undefined;
-    this.invalidateUnsubscribe?.();
     this.invalidateUnsubscribe = undefined;
-    this.releaseExternalBroadcastSource?.();
     this.releaseExternalBroadcastSource = undefined;
+
+    release(reloadUnsubscribe, "ReloadNotifier reload subscription");
+    release(invalidateUnsubscribe, "ReloadNotifier invalidate subscription");
+    release(releaseExternalBroadcastSource, "HMR external broadcast source");
 
     if (this.fileWatchSetup) {
       const metrics = this.fileWatchSetup.getMetrics();

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -96,6 +96,27 @@ export class DevServer {
   }
 
   async start(): Promise<void> {
+    try {
+      await this.startAndBind();
+    } catch (error) {
+      // File watchers and the ReloadNotifier subscriptions are registered
+      // before the port is bound, but callers only ever receive the instance
+      // *after* start() resolves — startDevServer() awaits start() and returns
+      // the server, so a rejection drops the half-built instance with no handle
+      // and nobody left to call stop(). Release here or those registrations
+      // outlive the process. stop() is null-safe at every step, so it tears
+      // down however far start() got, and stays the single teardown path.
+      //
+      // A cleanup failure must never mask the real reason start() failed —
+      // "port already in use" is what the developer needs to see.
+      await this.stop().catch((cleanupError: unknown) => {
+        devServerLog.debug("Cleanup after failed start errored (non-critical)", cleanupError);
+      });
+      throw error;
+    }
+  }
+
+  private async startAndBind(): Promise<void> {
     const baseAdapter = await runtime.get();
     logger.debug(`Using ${baseAdapter.name} runtime adapter`);
 
@@ -479,9 +500,17 @@ export class DevServer {
   async stop(): Promise<void> {
     logger.debug("Shutting down dev server");
 
+    // Cleared after release so stop() is safe to call twice — a failed start()
+    // already tore itself down, and a caller holding the instance may still
+    // call stop(). Releasing the broadcast source twice is not harmless: it
+    // decrements a process-wide counter, which would suppress HMR broadcasts
+    // for an unrelated dev server in the same process.
     this.reloadUnsubscribe?.();
+    this.reloadUnsubscribe = undefined;
     this.invalidateUnsubscribe?.();
+    this.invalidateUnsubscribe = undefined;
     this.releaseExternalBroadcastSource?.();
+    this.releaseExternalBroadcastSource = undefined;
 
     if (this.fileWatchSetup) {
       const metrics = this.fileWatchSetup.getMetrics();

--- a/tests/integration/server/dev-server-start-failure.test.ts
+++ b/tests/integration/server/dev-server-start-failure.test.ts
@@ -1,0 +1,146 @@
+/**
+ * DevServer start-failure cleanup tests.
+ *
+ * `DevServer.start()` registers file watchers and ReloadNotifier subscriptions
+ * *before* it binds the HTTP port. `startDevServer()` constructs the instance,
+ * awaits `start()` and returns it — so when `start()` rejects the half-built
+ * instance is dropped without ever being handed to a caller, and nobody can
+ * call `stop()` on it. Anything registered before the bind would then survive
+ * for the life of the process.
+ *
+ * These tests force a real bind failure (a port already held by another
+ * listener) after the subscriptions are registered, and assert that the
+ * registrations are released rather than merely that `start()` rejects.
+ */
+
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import type { FileWatcher, WatchOptions } from "#veryfront/platform/adapters/base.ts";
+import { runtime } from "#veryfront/platform/adapters/registry.ts";
+import { ReloadNotifier } from "../../../src/server/reload-notifier.ts";
+import { DevServer } from "../../../src/server/dev-server.ts";
+import { withTestContext } from "../../_helpers/context.ts";
+
+type WatchFn = (paths: string | string[], options?: WatchOptions) => FileWatcher;
+
+interface WatchTracker {
+  /** Watchers opened but not yet closed. */
+  readonly open: number;
+  /** Watchers opened over the tracker's lifetime (guards against a vacuous test). */
+  readonly opened: number;
+  restore(): void;
+}
+
+/**
+ * Wrap the runtime adapter's `fs.watch` so the test can count live watchers.
+ * DevServer builds its own adapter from the runtime registry, so patching the
+ * registry singleton is the only seam that observes the watcher it really opens.
+ */
+function trackWatchers(fs: { watch: WatchFn }): WatchTracker {
+  const originalWatch = fs.watch.bind(fs);
+  let open = 0;
+  let opened = 0;
+
+  fs.watch = (paths, options) => {
+    const watcher = originalWatch(paths, options);
+    open++;
+    opened++;
+    let closed = false;
+
+    return {
+      [Symbol.asyncIterator]: () => watcher[Symbol.asyncIterator](),
+      close: () => {
+        if (!closed) {
+          closed = true;
+          open--;
+        }
+        watcher.close();
+      },
+      get ready() {
+        return watcher.ready;
+      },
+      get done() {
+        return watcher.done;
+      },
+    };
+  };
+
+  return {
+    get open() {
+      return open;
+    },
+    get opened() {
+      return opened;
+    },
+    restore: () => {
+      fs.watch = originalWatch;
+    },
+  };
+}
+
+describe("DevServer start failure", () => {
+  it("releases file watchers and ReloadNotifier subscriptions when the HTTP bind fails", async () => {
+    await withTestContext("dev-start-bind-failure", async (context) => {
+      // Hold a port so the dev server's own bind is guaranteed to fail. This is
+      // the real-world path: the probe-then-bind race in `veryfront dev`, or any
+      // other process owning the port between the probe and the bind.
+      const blockerController = new AbortController();
+      const blocker = Deno.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        signal: blockerController.signal,
+        onListen: () => {},
+      }, () => new Response("port already taken"));
+      const occupiedPort = (blocker.addr as Deno.NetAddr).port;
+
+      const adapter = await runtime.get();
+      const watchers = trackWatchers(adapter.fs as unknown as { watch: WatchFn });
+
+      const before = ReloadNotifier.getMetrics();
+
+      try {
+        const server = new DevServer({
+          projectDir: context.projectDir,
+          port: occupiedPort,
+          // HMR must be on: the watchers and both subscriptions are only
+          // registered on this branch.
+          enableHMR: true,
+          enableFastRefresh: false,
+        });
+
+        await assertRejects(
+          () => server.start(),
+          "start() must reject when the port is already bound",
+        );
+
+        // Guard against a vacuous pass: if the dev server never opened a
+        // watcher, the leak assertions below would hold trivially.
+        assert(
+          watchers.opened > 0,
+          "test setup failed — DevServer opened no file watcher, so watcher cleanup is untested",
+        );
+
+        // Compared as one object so a regression reports every leaked
+        // registration at once instead of short-circuiting on the first.
+        const after = ReloadNotifier.getMetrics();
+        assertEquals(
+          {
+            openWatchers: watchers.open,
+            reloadListeners: after.activeReloadListeners,
+            invalidateListeners: after.activeInvalidateListeners,
+          },
+          {
+            openWatchers: 0,
+            reloadListeners: before.activeReloadListeners,
+            invalidateListeners: before.activeInvalidateListeners,
+          },
+          "everything registered before the bind must be released when start() fails",
+        );
+      } finally {
+        watchers.restore();
+        blockerController.abort();
+        await blocker.finished.catch(() => {});
+      }
+    });
+  });
+});


### PR DESCRIPTION
## The defect

`DevServer.start()` registers four things **before** it binds the HTTP port:

| Registration | `server.ts` (pre-fix) |
| --- | --- |
| `setupFileWatchers()` | :164 |
| `ReloadNotifier.subscribeInvalidate` | :167 |
| `HMRHandler.registerExternalBroadcastSource()` | :177 |
| `ReloadNotifier.subscribe` | :178 |
| `adapter.serve()` — the bind | :258 |

All four are released only by `stop()`. But `startDevServer()` (`index.ts:15-20`) constructs the instance, awaits `start()`, and *then* returns it — so when `start()` rejects, the half-built instance is dropped with no handle and **no caller can ever call `stop()`**. All four registrations survive for the life of the process.

The leaked broadcast source is the worst of the three kinds: it decrements a *process-wide* counter, and while it is held `HMRHandler` skips its own broadcast (`hmr.handler.ts:72-78`). So one failed start can silently disable HMR for the dev server that starts next.

Reachable from the probe-then-bind race in `veryfront dev`, and from any `adapter.serve()` failure that is not a port collision (bad bind address, permission denied on a privileged port).

## The fix

`start()` routes failures through `stop()` and rethrows.

Chosen over catching in `startDevServer()` because:

- **`stop()` is already the single teardown path, and already null-safe at every step** (`?.()`, `if (this.fileWatchSetup)`, `if (this.server)`) — it was written to tolerate a partially-built instance. Reusing it means there is no second cleanup list that can drift out of sync when someone adds a new registration to `start()`.
- **It covers every caller.** `DevServer` is exported directly and constructed outside `startDevServer()` (e.g. `tests/integration/server/dev-server-handlers.test.ts:28`); a fix in `startDevServer()` would leave those leaking.
- **It matches existing convention.** `bootstrap.ts` (`orchestrateOrDisposeFS`, and the comment at :482-484) and the Deno `http-server.ts` adapter both release-then-rethrow at the registration site.

Cleanup errors are swallowed to a debug log so they can never mask the real reason `start()` failed — "port already in use" is what the developer needs to see.

`stop()` now clears all three release handles **up front, before any is invoked**, and runs each through a small `release()` helper. This is required, not cosmetic: the reload/invalidate unsubscribes are idempotent (`Set.delete`), but `releaseExternalBroadcastSource` is **not** — it decrements a global counter, so the double-`stop()` this change introduces (failed `start()` cleans up, caller still holds the instance and calls `stop()`) would otherwise corrupt an unrelated dev server's count. Clearing up front rather than per-call means a throwing release cannot leave a later handle set for a second `stop()` to re-invoke.

## Regression test

`src/server/dev-server/server-start-failure.integration.test.ts` forces a **real** bind failure — another listener holds the port — after the subscriptions are registered, and asserts the registrations are released. It does not settle for asserting that `start()` rejects; the rejection already happened before this change.

Watchers are counted by wrapping the runtime registry adapter's `fs.watch`, which is the only seam that observes the watcher `DevServer` really opens (it builds its own adapter internally). The test asserts `watchers.opened > 0` first, so it cannot pass vacuously if that seam ever stops being the one used.

Failing before the fix — all three leaks in one diff:

```
    {
-     invalidateListeners: 1,
-     openWatchers: 1,
-     reloadListeners: 1,
+     invalidateListeners: 0,
+     openWatchers: 0,
+     reloadListeners: 0,
    }
```

Passing after, with **no sanitizer opt-outs** — Deno's own op/resource sanitizers confirm the teardown is complete.

It is colocated with the module it covers per AGENTS.md, and named `*.integration.test.ts` because it needs a real project directory, a full `bootstrapDev()`, a real OS file watcher and a real TCP bind. That suffix is excluded from the unit shard by `deno.json` and follows `src/proxy/routing-invalidation.integration.test.ts`; it still runs in the coverage shards and the pre-push suite.

## Verification

- New test fails before the fix and passes after — re-confirmed after relocating it
- `src/server/dev-server/` + `tests/integration/server/`: 52 passed, 0 failed
- `deno fmt --check`, `deno lint`, `deno check` clean
- Pre-push gate passed; all 27 CI checks green

## Notes

- `docs/api-reference/veryfront/server.md` carries a one-line source-link update: the teardown helper shifted `export class DevServer` from L57 to L70. Regenerated with `deno task docs` under the Deno version CI pins (2.7.7), not hand-edited.
- The known flake `src/transforms/esm/http-cache.test.ts` ("returns a signal-less cache follower after its bounded wait", from #3553) fired once on an earlier push and presented as three red checks (its coverage shard plus the dependent `tests (unit)` and `coverage gate`). Re-run without changes and it went green; it is untouched by this PR.
- Out of scope, noted while working: when `start()` fails, `this.ready` never settles, so anything awaiting it hangs. Pre-existing and independent of this leak — left alone deliberately.

Surfaced by CodeRabbit on #3562 and declined there as out of scope, since that PR touched only `cli/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
