### PR TITLE
Hide agent descriptions from chat empty state

### DIFF
--- a/src/react/components/chat/chat/app-mode-chat.test.tsx
+++ b/src/react/components/chat/chat/app-mode-chat.test.tsx
@@ -91,11 +91,13 @@ describe("ConversationBoundChat — app mode, no ConversationsProvider", () => {
           },
         })),
       )) as typeof fetch;
+    let root: ReturnType<typeof createRoot> | undefined;
     try {
       const rootElement = document.getElementById("root");
       assert(rootElement, "root element exists");
-      const root = createRoot(rootElement);
-      flushSync(() => root.render(<ConversationBoundChat agentId="test-agent" />));
+      const createdRoot = createRoot(rootElement);
+      root = createdRoot;
+      flushSync(() => createdRoot.render(<ConversationBoundChat agentId="test-agent" />));
       await settle();
 
       assertStringIncludes(rootElement.textContent ?? "", "Test Agent");
@@ -105,7 +107,7 @@ describe("ConversationBoundChat — app mode, no ConversationsProvider", () => {
       );
 
       flushSync(() =>
-        root.render(
+        createdRoot.render(
           <ConversationBoundChat
             agentId="test-agent"
             emptyState={{ title: "Custom title", description: "Custom description" }}
@@ -113,8 +115,8 @@ describe("ConversationBoundChat — app mode, no ConversationsProvider", () => {
         )
       );
       assertStringIncludes(rootElement.textContent ?? "", "Custom description");
-      await unmountReactRoot(root);
     } finally {
+      if (root) await unmountReactRoot(root);
       globalThis.fetch = previousFetch;
       restoreDom();
     }

--- a/src/react/components/chat/chat/app-mode-chat.test.tsx
+++ b/src/react/components/chat/chat/app-mode-chat.test.tsx
@@ -17,10 +17,45 @@
  * intentional change alters an output, update the assertion in the same
  * commit and say why.
  */
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
-import { assertStringIncludes } from "#veryfront/testing/assert";
+import { JSDOM } from "npm:jsdom@28.0.0";
+import { unmountReactRoot } from "#veryfront/react/react-root.test-helpers.ts";
+import { assert, assertStringIncludes } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { ConversationBoundChat } from "./app-mode-chat.tsx";
+
+function installDom(): () => void {
+  const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+  const previous = {
+    window: globalThis.window,
+    document: globalThis.document,
+    navigator: globalThis.navigator,
+    self: globalThis.self,
+    Node: globalThis.Node,
+    Element: globalThis.Element,
+    HTMLElement: globalThis.HTMLElement,
+  };
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    navigator: dom.window.navigator,
+    self: dom.window,
+    Node: dom.window.Node,
+    Element: dom.window.Element,
+    HTMLElement: dom.window.HTMLElement,
+  });
+  return () => {
+    Object.assign(globalThis, previous);
+    dom.window.close();
+  };
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 4; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => {});
+}
 
 describe("ConversationBoundChat — app mode, no ConversationsProvider", () => {
   it("renders the initializing skeleton on first render when agentId is set (agent metadata not yet resolved)", () => {
@@ -40,5 +75,48 @@ describe("ConversationBoundChat — app mode, no ConversationsProvider", () => {
       <ConversationBoundChat agentId="test-agent" api="/api/ag-ui" />,
     );
     assertStringIncludes(html, "Type a message...");
+  });
+
+  it("omits agent descriptions but preserves an explicit empty-state description", async () => {
+    const restoreDom = installDom();
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({
+          agent: {
+            id: "test-agent",
+            name: "Test Agent",
+            description: "Metadata description",
+            avatar_url: null,
+          },
+        })),
+      )) as typeof fetch;
+    try {
+      const rootElement = document.getElementById("root");
+      assert(rootElement, "root element exists");
+      const root = createRoot(rootElement);
+      flushSync(() => root.render(<ConversationBoundChat agentId="test-agent" />));
+      await settle();
+
+      assertStringIncludes(rootElement.textContent ?? "", "Test Agent");
+      assert(
+        !rootElement.textContent?.includes("Metadata description"),
+        "agent metadata description is not rendered",
+      );
+
+      flushSync(() =>
+        root.render(
+          <ConversationBoundChat
+            agentId="test-agent"
+            emptyState={{ title: "Custom title", description: "Custom description" }}
+          />,
+        )
+      );
+      assertStringIncludes(rootElement.textContent ?? "", "Custom description");
+      await unmountReactRoot(root);
+    } finally {
+      globalThis.fetch = previousFetch;
+      restoreDom();
+    }
   });
 });

--- a/src/react/components/chat/chat/app-mode-chat.tsx
+++ b/src/react/components/chat/chat/app-mode-chat.tsx
@@ -62,7 +62,7 @@ function UncontrolledChat(
   // box — no `isLoading` wiring from the consumer.
   const agentInitializing = Boolean(resolvedAgentId) && !agent && !agentError;
 
-  // Agent-driven empty state: avatar + name + description, shown once the
+  // Agent-driven empty state: avatar + name, shown once the
   // agent resolves (the skeleton covers the load, so the generic
   // "What can I help with?" placeholder never flashes). A consumer-supplied
   // `emptyState` still wins.
@@ -78,7 +78,6 @@ function UncontrolledChat(
         />
       ),
       title: agent.name,
-      description: agent.description ?? undefined,
     };
   }, [emptyState, agent]);
 


### PR DESCRIPTION
## What changed

- Stop deriving the `<Chat>` empty-state description from agent metadata.
- Keep the agent avatar, name, and prompt suggestions unchanged.
- Preserve explicit `emptyState.description` support for custom chat compositions.

## Why

Agent configuration descriptions should not appear in the default chat hero.

## Validation

- `deno fmt --check src/react/components/chat/chat/app-mode-chat.tsx`
- `deno lint src/react/components/chat/chat/app-mode-chat.tsx`
- `git diff --check`

The repo-wide pre-push typecheck remains blocked by existing React shim export and Node timeout typing errors unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified the chat empty state by removing the agent description.
  * The empty state now displays only the avatar and title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->