### PR TITLE
fix(cli): probe the dev port through the native Deno runtime

### DIFF
--- a/cli/commands/dev/port-fallback.test.ts
+++ b/cli/commands/dev/port-fallback.test.ts
@@ -127,6 +127,30 @@ describe("cli/commands/dev/port-fallback", () => {
     });
   });
 
+  describe("npm build safety", () => {
+    it("never reaches the runtime through the binding dnt rewrites", async () => {
+      // dnt rewrites every bare `Deno.<member>` access in the npm build to
+      // `dntShim.Deno.<member>`, i.e. `@deno/shim-deno`. That shim implements
+      // its TCP listen as `net.createServer()` followed by an immediate read of
+      // `server._handle.fd`, and Deno's own `node:net` compat leaves `_handle`
+      // null at that point. So under a Deno-installed CLI the probe threw
+      // `TypeError: Cannot read properties of null (reading 'fd')` and
+      // `veryfront dev` died before the dev server could bind - while the very
+      // same package ran fine under Node, where the shim is not used.
+      //
+      // The runtime has to be reached through `getDenoRuntime()`, whose
+      // `Reflect.get(globalThis, "Deno")` dnt leaves alone.
+      const source = await Deno.readTextFile(new URL("./port-fallback.ts", import.meta.url));
+      const rewrittenByDnt = source.match(/(?<![.\w$])Deno\.\w+/g) ?? [];
+
+      assertEquals(
+        rewrittenByDnt,
+        [],
+        `dnt would rewrite ${rewrittenByDnt.join(", ")} to the broken @deno/shim-deno namespace`,
+      );
+    });
+  });
+
   describe("isPortInUseError", () => {
     it("recognises the address-in-use error the runtime actually throws", () => {
       const held = Deno.listen({ hostname: "127.0.0.1", port: 0 });

--- a/cli/commands/dev/port-fallback.ts
+++ b/cli/commands/dev/port-fallback.ts
@@ -14,7 +14,7 @@
 
 import { LOCALHOST } from "veryfront/config";
 import { PORT_IN_USE } from "veryfront/errors";
-import { isDeno } from "veryfront/platform";
+import { getDenoRuntime, isDeno } from "veryfront/platform";
 
 /** How many consecutive ports to try before giving up. */
 export const MAX_PORT_FALLBACK_ATTEMPTS = 10;
@@ -33,12 +33,22 @@ export function isPortInUseError(error: unknown): boolean {
     message.includes("eaddrinuse") || message.includes("address already in use");
 }
 
-/** Binds `port` and releases it again, to see whether the dev server could have it. */
+/**
+ * Binds `port` and releases it again, to see whether the dev server could have it.
+ *
+ * The Deno namespace comes from `getDenoRuntime()` rather than the bare global:
+ * in the npm build dnt rewrites every bare `Deno` member access to
+ * `@deno/shim-deno`, whose TCP listen reads `server._handle.fd` straight after
+ * `net.createServer().listen()`. Deno's own `node:net` compat has not populated
+ * `_handle` by then, so a Deno-installed CLI crashed here with
+ * `Cannot read properties of null (reading 'fd')` before the dev server could
+ * bind. `getDenoRuntime()` reads the global reflectively, which dnt leaves alone.
+ */
 export async function isPortAvailable(port: number): Promise<boolean> {
-  if (isDeno) {
+  const denoRuntime = isDeno ? getDenoRuntime() : undefined;
+  if (denoRuntime) {
     try {
-      // @ts-ignore - Deno global
-      Deno.listen({ hostname: LOCALHOST.IPV4, port }).close();
+      denoRuntime.listen({ hostname: LOCALHOST.IPV4, port }).close();
       return true;
     } catch (error) {
       if (isPortInUseError(error)) return false;


### PR DESCRIPTION
## Symptom

Under a Deno-installed CLI, `veryfront dev` dies before it binds anything:

```
$ cd deno-app && deno task dev --port 3730
Task dev deno run -A npm:veryfront@0.1.1229 dev "--port" "3730"
Veryfront (v0.1.1229)

✗ [unknown-error] Unknown/unclassified error
  Detail: Cannot read properties of null (reading 'fd')
  Suggestion: Check logs for more details
$ curl -o /dev/null -w '%{http_code}' 127.0.0.1:3730   # -> 000, nothing listening
```

Reproduced against the **published** `veryfront@0.1.1229` in a sandbox outside this
repo, on a project scaffolded by that same published CLI
(`veryfront init deno-app --template ai-agent --runtime deno --yes`). It is specific
to `dev` under Deno — `build`, `serve`, `routes` and `doctor` all succeed under the
same Deno-global install, and `node ./node_modules/veryfront/bin/veryfront.js dev`
on the identical project serves HTTP 200.

This blocks `--runtime deno`, which
`/docs/code/getting-started/installation` advertises as a supported install path.

## Root cause

The finding said the `.fd` access was not in the framework's own `esm/src` but in a
dependency only reachable on the Deno dev path. It is `@deno/shim-deno`. Raw stack,
recovered by instrumenting the CLI error boundary in the published tarball:

```
TypeError: Cannot read properties of null (reading 'fd')
    at Object.listen (.../@deno/shim-deno/dist/deno/stable/functions/listen.js:44:64)
    at isPortAvailable (.../veryfront/esm/cli/commands/dev/port-fallback.js:38:26)
    at clearLocalCachesIfPortFree (.../veryfront/esm/cli/commands/dev/command.js:95:16)
```

`cli/commands/dev/port-fallback.ts` probed the port with a bare `Deno` listen call.
In the npm build dnt rewrites every bare `Deno` member access to `dntShim.Deno`
(`@deno/shim-deno`) — the published `port-fallback.js` line 38 really reads
`dntShim.Deno.listen(...)`. That shim implements listen as

```js
const server = createServer();
server.listen(port, hostname, resolve);
const listener = new Listener(server._handle.fd, ...);   // <- line 44
```

Under Node `_handle` is populated synchronously; under Deno's `node:net` compat it is
still `null` at that point, so the probe throws. The port scan runs unconditionally on
every `dev` start, so `dev` was dead on arrival for every Deno user.

## Fix

Resolve the namespace through `getDenoRuntime()`, the existing platform helper that
reads the global with `Reflect.get(globalThis, "Deno")` — a form dnt does not rewrite,
which is exactly why `src/platform/compat/http/native-response.ts` already uses the
same trick for `Deno.serve`/`Deno.upgradeWebSocket`. One-line behaviour change; the
Node `node:net` fallback is untouched.

## Test

`cli/commands/dev/port-fallback.test.ts` gains a guard that fails if the module reaches
the runtime through the binding dnt rewrites. It fails on the pre-fix source with
`dnt would rewrite Deno.listen to the broken @deno/shim-deno namespace` and passes
after. A plain unit test cannot catch this: in a Deno test run the bare `Deno` *is* the
native namespace, so the defect only exists in the built artifact.

## Verified against the published repro

1. Baseline, published 0.1.1229, fresh `--runtime deno` scaffold, the finding's own
   command `deno task dev`: `Cannot read properties of null (reading 'fd')`,
   `curl` → **000**.
2. `deno task build:npm` on this branch → `npm pack` → installed the tarball into a
   clean tree outside this repo → `deno run -A .../veryfront/bin/veryfront.js dev`
   in the **same unmodified** scaffold: `✓ Ready in 576ms`, `curl` → **500**, and
   `grep -c "reading 'fd'"` over the whole dev log → **0**.

## Not fixed here — a second, separate Deno-only defect

That 500 is not this bug. With the crash gone, the dev server binds and serves, but SSR
of the first page fails under Deno with

```
✗ Missing HTTP bundle after ensureHttpBundlesExist
    hash=0141fa6c…  expectedPath=.cache/veryfront-http-bundle/http-0141fa6c….mjs
✗ Render failed  error="Loading unprepared module: file://….cache/veryfront-http-bundle/http-0141fa6c….mjs,
    imported from: ….cache/veryfront-mdx-esm/…/veryfront/esm/_dnt.shims.js"
```

The bundle file **does exist on disk** (380 bytes, and so do its three transitive
`http-*.mjs` imports); Deno still rejects the dynamic import as an unprepared module, and
`recoverHttpBundleByHash` reports failure because there was nothing to recover. It is
deterministic across restarts and warm caches, and does not occur under Node on the same
project. That belongs to `src/modules/react-loader/ssr-module-loader` +
`src/transforms/esm/http-cache.ts`, not to the port probe, and is filed separately rather
than smuggled into this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development server port detection when running through npm-compatible builds.
  - Preserved existing port availability behavior in Node environments.

- **Documentation**
  - Clarified port availability behavior and runtime compatibility considerations.

- **Tests**
  - Added automated coverage to prevent regressions in npm build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->