### PR TITLE
fix(cli): probe dev ports without the dnt Deno shim

### DIFF
--- a/cli/commands/dev/port-fallback.test.ts
+++ b/cli/commands/dev/port-fallback.test.ts
@@ -127,13 +127,9 @@ describe("cli/commands/dev/port-fallback", () => {
     });
 
     it("probes without going through the ambient Deno namespace", async () => {
-      // The npm build runs this file with dnt's @deno/shim-deno standing in for
-      // the `Deno` namespace, even under Deno itself. That shim's Node-backed
-      // `listen()` reads `server._handle.fd` synchronously, which is null on
-      // Deno, so a probe routed through the ambient namespace dies with
-      // "Cannot read properties of null (reading 'fd')" and `veryfront dev`
-      // never binds a port. Standing in a throwing `Deno.listen` reproduces
-      // that shim here: the probe must not depend on it.
+      // Stand in the failure the npm build hits under Deno: dnt swaps the
+      // ambient namespace for @deno/shim-deno, whose `listen` throws on a null
+      // `server._handle`. The probe must answer correctly without it.
       const nativeListen = Deno.listen;
       const held = nativeListen({ hostname: "127.0.0.1", port: 0 });
       const heldPort = (held.addr as Deno.NetAddr).port;

--- a/cli/commands/dev/port-fallback.test.ts
+++ b/cli/commands/dev/port-fallback.test.ts
@@ -125,6 +125,42 @@ describe("cli/commands/dev/port-fallback", () => {
 
       assertEquals(await isPortAvailable(freePort), true);
     });
+
+    it("probes without going through the ambient Deno namespace", async () => {
+      // The npm build runs this file with dnt's @deno/shim-deno standing in for
+      // the `Deno` namespace, even under Deno itself. That shim's Node-backed
+      // `listen()` reads `server._handle.fd` synchronously, which is null on
+      // Deno, so a probe routed through the ambient namespace dies with
+      // "Cannot read properties of null (reading 'fd')" and `veryfront dev`
+      // never binds a port. Standing in a throwing `Deno.listen` reproduces
+      // that shim here: the probe must not depend on it.
+      const nativeListen = Deno.listen;
+      const held = nativeListen({ hostname: "127.0.0.1", port: 0 });
+      const heldPort = (held.addr as Deno.NetAddr).port;
+      const freeListener = nativeListen({ hostname: "127.0.0.1", port: 0 });
+      const freePort = (freeListener.addr as Deno.NetAddr).port;
+      freeListener.close();
+
+      Object.defineProperty(Deno, "listen", {
+        configurable: true,
+        writable: true,
+        value: () => {
+          throw new TypeError("Cannot read properties of null (reading 'fd')");
+        },
+      });
+
+      try {
+        assertEquals(await isPortAvailable(heldPort), false);
+        assertEquals(await isPortAvailable(freePort), true);
+      } finally {
+        Object.defineProperty(Deno, "listen", {
+          configurable: true,
+          writable: true,
+          value: nativeListen,
+        });
+        held.close();
+      }
+    });
   });
 
   describe("isPortInUseError", () => {

--- a/cli/commands/dev/port-fallback.test.ts
+++ b/cli/commands/dev/port-fallback.test.ts
@@ -163,6 +163,41 @@ describe("cli/commands/dev/port-fallback", () => {
     });
   });
 
+  describe("npm build safety", () => {
+    it("never reaches the runtime through the binding dnt rewrites", async () => {
+      // dnt rewrites every bare `Deno.<member>` access in the npm build to
+      // `dntShim.Deno.<member>`, i.e. `@deno/shim-deno`. That shim implements
+      // its TCP listen as `net.createServer()` followed by an immediate read of
+      // `server._handle.fd`, and Deno's own `node:net` compat leaves `_handle`
+      // null at that point. So under a Deno-installed CLI the probe threw
+      // `TypeError: Cannot read properties of null (reading 'fd')` and
+      // `veryfront dev` died before the dev server could bind - while the very
+      // same package ran fine under Node, where the shim is not used.
+      //
+      // The test above proves the probe survives a poisoned ambient namespace.
+      // This one guards the whole file, including paths that test never runs:
+      // any bare `Deno.` member access reintroduced anywhere here is a rewrite
+      // target. Reach the runtime through `getDenoRuntime()` instead, whose
+      // `Reflect.get(globalThis, "Deno")` dnt leaves alone.
+      const source = await Deno.readTextFile(new URL("./port-fallback.ts", import.meta.url));
+      // dnt rewrites code, not prose, and the fix's own doc comment has to be
+      // free to name `Deno.listen` as the thing it stopped calling. Strip
+      // comments first - `(?<![:\\])` keeps the `//` of a `https://` inside one
+      // from ending it early. String literals are left in, so a `"Deno.foo"`
+      // would be a false positive: it fails towards rewording, never silence.
+      const code = source
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/(?<![:\\])\/\/.*$/gm, "");
+      const rewrittenByDnt = code.match(/(?<![.\w$])Deno\.\w+/g) ?? [];
+
+      assertEquals(
+        rewrittenByDnt,
+        [],
+        `dnt would rewrite ${rewrittenByDnt.join(", ")} to the broken @deno/shim-deno namespace`,
+      );
+    });
+  });
+
   describe("isPortInUseError", () => {
     it("recognises the address-in-use error the runtime actually throws", () => {
       const held = Deno.listen({ hostname: "127.0.0.1", port: 0 });

--- a/cli/commands/dev/port-fallback.ts
+++ b/cli/commands/dev/port-fallback.ts
@@ -35,13 +35,10 @@ export function isPortInUseError(error: unknown): boolean {
 /**
  * Binds `port` and releases it again, to see whether the dev server could have it.
  *
- * `node:net` probes on every runtime rather than `Deno.listen` under Deno: the
- * npm build resolves a bare `Deno` to dnt's @deno/shim-deno even when the CLI
- * is running on Deno (`deno install -g npm:veryfront`), and that shim's
- * Node-backed `listen()` reads `server._handle.fd` synchronously - null on
- * Deno - so the probe died with "Cannot read properties of null (reading
- * 'fd')" before the dev server ever bound a port. One `node:net` path works on
- * Deno, on Node, and inside a compiled binary, and cannot reach the shim.
+ * One `node:net` path serves every runtime. A bare `Deno.listen` cannot: the
+ * npm build resolves bare `Deno` to dnt's @deno/shim-deno even when the CLI
+ * runs on Deno, and that shim reads `server._handle.fd` synchronously, which
+ * Deno leaves null - the crash that stopped `veryfront dev` binding at all.
  */
 export async function isPortAvailable(port: number): Promise<boolean> {
   const net = await import("node:net");

--- a/cli/commands/dev/port-fallback.ts
+++ b/cli/commands/dev/port-fallback.ts
@@ -14,7 +14,6 @@
 
 import { LOCALHOST } from "veryfront/config";
 import { PORT_IN_USE } from "veryfront/errors";
-import { isDeno } from "veryfront/platform";
 
 /** How many consecutive ports to try before giving up. */
 export const MAX_PORT_FALLBACK_ATTEMPTS = 10;
@@ -33,19 +32,18 @@ export function isPortInUseError(error: unknown): boolean {
     message.includes("eaddrinuse") || message.includes("address already in use");
 }
 
-/** Binds `port` and releases it again, to see whether the dev server could have it. */
+/**
+ * Binds `port` and releases it again, to see whether the dev server could have it.
+ *
+ * `node:net` probes on every runtime rather than `Deno.listen` under Deno: the
+ * npm build resolves a bare `Deno` to dnt's @deno/shim-deno even when the CLI
+ * is running on Deno (`deno install -g npm:veryfront`), and that shim's
+ * Node-backed `listen()` reads `server._handle.fd` synchronously - null on
+ * Deno - so the probe died with "Cannot read properties of null (reading
+ * 'fd')" before the dev server ever bound a port. One `node:net` path works on
+ * Deno, on Node, and inside a compiled binary, and cannot reach the shim.
+ */
 export async function isPortAvailable(port: number): Promise<boolean> {
-  if (isDeno) {
-    try {
-      // @ts-ignore - Deno global
-      Deno.listen({ hostname: LOCALHOST.IPV4, port }).close();
-      return true;
-    } catch (error) {
-      if (isPortInUseError(error)) return false;
-      throw error;
-    }
-  }
-
   const net = await import("node:net");
   return await new Promise<boolean>((resolve, reject) => {
     const server = net.createServer();


### PR DESCRIPTION
## The symptom

On published `0.1.1229`, `veryfront dev` never binds a port when the CLI runs on Deno — the Deno-global install (`deno install -gArf npm:veryfront`), `deno run -A npm:veryfront dev`, and the `deno task dev` that a `--runtime deno` scaffold prints as its own next step:

```
Veryfront (v0.1.1229)

✗ [unknown-error] Unknown/unclassified error

  Detail: Cannot read properties of null (reading 'fd')
  Suggestion: Check logs for more details
```

`build`, `serve`, `routes` and `doctor` all succeed under the same install. `dev` was the only command that reached the broken code, and the npm-global (Node) install of the identical version runs `dev` fine.

## Root cause

The real stack, recovered by calling `handleDevCommand` directly under Deno against the published tarball:

```
TypeError: Cannot read properties of null (reading 'fd')
    at Object.listen (node_modules/@deno/shim-deno/dist/deno/stable/functions/listen.js:44:64)
    at isPortAvailable (node_modules/veryfront/esm/cli/commands/dev/port-fallback.js:38:26)
    at clearLocalCachesIfPortFree (node_modules/veryfront/esm/cli/commands/dev/command.js:95:16)
```

`isPortAvailable` branched on `isDeno` and then called the bare `Deno.listen`. In the npm build dnt rewrites every bare `Deno` to `@deno/shim-deno` — `esm/_dnt.shims.js` re-exports the shim unconditionally, so the shim wins even when a genuine `Deno` global is right there. That shim's Node-backed `listen()` does:

```js
const waitFor = new Promise((resolve) => server.listen(port, hostname, resolve));
// @ts-expect-error undocumented socket._handle property
const listener = new Listener(server._handle.fd, …);
```

`server._handle` is assigned synchronously by Node's `listen()`, but not by Deno's node-compat layer, so it is still `null` on that line. The one branch written for Deno was the one branch Deno could not execute.

The repo already knows this hazard — `cli/auth/callback-server.ts` reaches the real namespace via `self` ("Access native Deno.serve via `self` to bypass dnt shim transform"), and `getNativeDeno()` in `src/platform/compat/http/native-response.ts` documents it. `port-fallback.ts`, which was written to copy that callback server's fallback, missed it.

## The fix

Probe with `node:net` on every runtime and delete the Deno branch. This function already used `node:net` on Node; it is one path now, it behaves identically on Deno, and it cannot reach the shim. Verified on all four runtime shapes the CLI ships in: Deno source, `deno compile` binary, npm-on-Node, npm-on-Deno.

## Regression test

`cli/commands/dev/port-fallback.test.ts` stands a throwing `Deno.listen` into the ambient namespace — the shim reproduced in-process, same `TypeError: Cannot read properties of null (reading 'fd')` — and asserts the probe still reports a held port busy and a free port free. It fails on `main` at `port-fallback.ts:41` with exactly the published error, and passes with this change.

## Proof against the published artifact, not just the tests

The finding's own command, re-run against `veryfront@0.1.1229` with only this function transplanted into the installed tree:

| | before | after |
|---|---|---|
| `deno run -A ./node_modules/veryfront/bin/veryfront.js dev --port 3772` | `✗ [unknown-error] … reading 'fd'`, nothing listening | `✓ Ready in 1.6s` / `http://veryfront.me:3772`, `lsof` confirms `TCP 127.0.0.1:3772 (LISTEN)` |
| same, port already taken | — | `! Port 3772 is in use, using 3773 instead` → `✓ Ready` |
| `node ./node_modules/veryfront/bin/veryfront.js dev --port 3774` (control) | `✓ Ready`, `curl` 200 | `✓ Ready`, `curl` 200 |

## What this does *not* fix

With the port crash gone, `veryfront dev` under Deno binds and reports Ready, but page renders still fail with a **separate** Deno defect: the SSR module loader dynamic-importing generated `.cache/veryfront-http-bundle/http-*.mjs` throws `TypeError: Loading unprepared module: …`, so `/` returns 500 (Node returns 200 on the identical project). That is a different failure in a different subsystem and belongs to the open "CLI is entirely non-functional under the Deno runtime" reports — deliberately out of scope here rather than folded into this change.

Also from the originating finding, and deliberately unchanged: the published package declaring 7 of the 20 `@veryfront/ext-*` specifiers its runtime references is **policy, not a packaging bug** — `rootNpm` in `src/extensions/first-party-defaults.ts` keeps credentialed, native and output-changing integrations out of the root dependency set, and `first-party-import.ts` now degrades with an install hint instead of dying. No live doc page needs to change for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development server port detection across supported runtimes.
  * Port availability checks now reliably identify occupied and available ports without depending on ambient runtime behavior.

* **Tests**
  * Added regression coverage for port detection when the runtime’s default listener is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->