### PR TITLE
fix(css): give the unminified-CSS warning a remedy that works

### DIFF
--- a/src/html/styles-builder/css-provider-session.test.ts
+++ b/src/html/styles-builder/css-provider-session.test.ts
@@ -239,7 +239,7 @@ describe("styles-builder CSS provider sessions", () => {
       __resetLogRecordEmitterForTests();
     }
 
-    const reports = records.filter((entry) => entry.message.includes("not minified"));
+    const reports = records.filter((entry) => entry.message.includes("unminified CSS"));
     assertEquals(reports.length, 1);
     const report = reports[0]?.message ?? "";
     assertEquals(reports[0]?.level, "warn");

--- a/src/html/styles-builder/css-provider-session.test.ts
+++ b/src/html/styles-builder/css-provider-session.test.ts
@@ -208,12 +208,15 @@ describe("styles-builder CSS provider sessions", () => {
     assertEquals(generated.css, "missing-optimizer|sheet|alpha");
   });
 
-  it("reports a missing optimizer once, with the package that provides one", () => {
+  it("reports a missing optimizer once, with the steps that actually enable one", () => {
     // `regenerateCSSByHash` acquires a session per request, so warning on every
     // acquisition made this line the most frequent entry in a hosted project's
-    // logs -- once per render, at warn level, naming a registration hook with no
-    // documented way to act on it. State the package that registers an engine,
-    // and say it once while the engine stays absent.
+    // logs -- once per render, at warn level. Say it once while the engine stays
+    // absent, and give the whole recipe: `@veryfront/ext-css-lightning` declares
+    // `activation: "explicit"`, so installing the package registers nothing on
+    // its own. Only a `veryfront.config.ts` `extensions` entry activates it, and
+    // advice that stops at the install leaves the developer with unminified CSS
+    // and no next step.
     installProcessor(createProcessor("warn-rearm"));
     register(CSSOptimizationEngineName, createOptimizer("warn-rearm"));
     // Observing an engine re-arms the warning, so this test does not depend on
@@ -236,10 +239,19 @@ describe("styles-builder CSS provider sessions", () => {
       __resetLogRecordEmitterForTests();
     }
 
-    const reports = records.filter((entry) => entry.message.includes("CSSOptimizationEngine"));
+    const reports = records.filter((entry) => entry.message.includes("not minified"));
     assertEquals(reports.length, 1);
+    const report = reports[0]?.message ?? "";
     assertEquals(reports[0]?.level, "warn");
-    assertEquals(reports[0]?.message.includes("@veryfront/ext-css-lightning"), true);
+    assertEquals(report.includes("@veryfront/ext-css-lightning"), true);
+    assertEquals(report.includes("veryfront.config.ts"), true);
+    assertEquals(report.includes("extensions"), true);
+    // `deno add` is wrong twice over: scaffolded projects are npm projects, and
+    // no package manager can activate an explicit-activation extension.
+    assertEquals(report.includes("deno add"), false);
+    // The contract name is an internal registration hook the guides never
+    // mention, so it cannot appear as the developer-facing instruction.
+    assertEquals(report.includes("CSSOptimizationEngine"), false);
   });
 
   it("keeps minified and unminified output in separate cache identities", async () => {

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -165,8 +165,8 @@ export function acquireCSSGenerationSession(minify: boolean): CSSGenerationSessi
     const recommendation = getRecommendation(CSSOptimizationEngineName);
     logger.warn(
       recommendation === undefined
-        ? "CSS is not minified: no CSS optimizer is active"
-        : `CSS is not minified: no CSS optimizer is active. Install ${recommendation}, then add it to "extensions" in veryfront.config.ts`,
+        ? "Veryfront emits unminified CSS because no CSS optimizer is active"
+        : `Veryfront emits unminified CSS because no CSS optimizer is active. Install ${recommendation}, then add it to "extensions" in veryfront.config.ts`,
     );
   }
   const optimizationEngine = optimizationProvider === undefined

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -149,14 +149,24 @@ export function acquireCSSGenerationSession(minify: boolean): CSSGenerationSessi
     //
     // Once per process, not once per acquisition: regenerateCSSByHash acquires
     // a session on every cold-cache request, which made this the single most
-    // frequent line in a hosted project's logs. Name the package that registers
-    // an engine, or the message asks for a hook with no way to reach it.
+    // frequent line in a hosted project's logs.
+    //
+    // State the effect and the whole remedy. An earlier revision borrowed
+    // `resolve()`'s "install it with: deno add <package>" hint, which is only
+    // true for an auto-activating extension: `@veryfront/ext-css-lightning`
+    // declares `activation: "explicit"`, so installing it registers nothing
+    // until a `veryfront.config.ts` `extensions` entry activates it, and
+    // scaffolded projects are npm projects where `deno add` is the wrong
+    // command besides. Advice that stops at the install reads as actionable and
+    // leaves the CSS exactly as unminified as before. The contract name stays
+    // out of the instruction: it is an internal registration hook the guides
+    // never mention, and `component=css-compiler` already identifies the source.
     reportedMissingOptimizationEngine = true;
     const recommendation = getRecommendation(CSSOptimizationEngineName);
     logger.warn(
       recommendation === undefined
-        ? "No CSSOptimizationEngine registered; emitting unminified CSS"
-        : `No CSSOptimizationEngine registered; emitting unminified CSS. Install one with: deno add ${recommendation}`,
+        ? "CSS is not minified: no CSS optimizer is active"
+        : `CSS is not minified: no CSS optimizer is active. Install ${recommendation}, then add it to "extensions" in veryfront.config.ts`,
     );
   }
   const optimizationEngine = optimizationProvider === undefined


### PR DESCRIPTION
Round-2 verification finding [9]: *"Production builds emit unminified CSS behind an internal-sounding warning."* Marked `still-broken-after-fix` against published `0.1.1229`.

## Why the previous fix missed

#3575 changed two things: it reported the missing optimizer once per process instead of once per session acquisition, and it appended `Install one with: deno add @veryfront/ext-css-lightning`.

The frequency half worked. The actionability half did not, because the hint was borrowed from `resolve()`, where it is correct — the contracts `resolve()` guards are satisfied by `builtin-deferred` extensions, which `builtin-extensions.ts` auto-imports the moment the package is installed.

`@veryfront/ext-css-lightning` is not one of those. Its manifest declares `activation: "explicit"`, and `discoverBoundProjectExtensions` skips explicit-activation extensions outright: *"only a materialized `config.extensions` entry may activate them."* Installing the package therefore registers nothing. `deno add` is also the wrong command for a scaffolded project, which is an npm project with a `package.json`.

So the diagnosis in #3575 was right about the noise and wrong about the remedy: it made a dead end read as a next step.

## Reproduction against published 0.1.1229

`veryfront init support-agent --template ai-agent`, then `veryfront build`:

| step | CSS bytes | warning |
| --- | --- | --- |
| untouched scaffold | 90,684 | shown |
| after `npm install @veryfront/ext-css-lightning` (the message's advice) | 90,684 | still shown |
| after also adding `extCssLightning()` to `extensions` in `veryfront.config.ts` | 71,466 | gone |

The middle row is the defect: the framework's own instruction, carried out, changes nothing.

## The change

```
- No CSSOptimizationEngine registered; emitting unminified CSS. Install one with: deno add @veryfront/ext-css-lightning
+ Veryfront emits unminified CSS because no CSS optimizer is active. Install @veryfront/ext-css-lightning, then add it to "extensions" in veryfront.config.ts
```

Effect first, package named, second step named, package manager left to the project. The contract name leaves the instruction — it is an internal registration hook no guide mentions, and the record already carries `component=css-compiler`. Once-per-process reporting and the re-arm on observing an engine are unchanged.

This aligns the styles-builder path with `src/build/asset-pipeline/index.ts`, which already said "Install **and explicitly compose** @veryfront/ext-css-lightning".

## Verification against the finding's own command

`veryfront build ; veryfront serve` on the same scaffold, run against this branch's `cli/main.ts`:

- no config entry → `! Veryfront emits unminified CSS because no CSS optimizer is active. Install @veryfront/ext-css-lightning, then add it to "extensions" in veryfront.config.ts`, CSS 90,740 bytes.
- following that message exactly → no warning, CSS **71,506 bytes**, minified.
- `veryfront serve` prints it once before `✓ Ready`; two HTTP renders add no further occurrences (`grep -c` = 1), so #3575's once-per-process behaviour is preserved.

The regression test was written first and failed for the right reason (no emitted record contained the expected phrase).

`aabf75f45` reworded the message into active voice per AGENTS.md § Public copy rules, after review; the byte counts above are from that build.

## Scope

Not addressed here, deliberately: the default production build still emits unminified CSS, because `ext-css-lightning` is `rootNpm: false` in `first-party-defaults.ts` — a documented policy that keeps native-FFI and output-changing extensions out of the root install. Shipping a minifier by default is a product decision, not a bug fix. What this PR fixes is that a developer who wants minification can now reach it by following the message.

No doc change is required: the message points at the `extensions` array in `veryfront.config.ts`, which `docs/guides/extensions.md` § "Enable an extension" already documents.
