### PR TITLE
test(chat): check the renderer warning's anchor against the guide it links to

### DIFF
--- a/src/react/components/chat/missing-renderer-warning.test.ts
+++ b/src/react/components/chat/missing-renderer-warning.test.ts
@@ -1,21 +1,87 @@
-import { assertEquals } from "#veryfront/testing/assert";
+import { assert, assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
+import { fromFileUrl } from "@std/path";
 import { MISSING_MARKDOWN_RENDERER_WARNING } from "./missing-renderer-warning.ts";
 
 /**
- * The warning's only escape hatch is the documentation link, so the link has to
- * resolve. The published guide lives under `/docs/code/guides/chat-ui`
- * (`/docs/guides/chat-ui` is a 404), and the fragment has to track the heading
- * in this repo's `docs/guides/chat-ui.md`, which is the source the published
- * site is generated from: "## Render Markdown in chat" slugs to
- * `#render-markdown-in-chat`.
+ * The warning's only escape hatch is the documentation link, so the whole link
+ * has to resolve: the page and the fragment.
+ *
+ * The page is published from this repository's `docs/` tree under
+ * `/docs/code/`, so the URL also names the file that has to carry the anchor.
+ * Asserting the fragment against that file's headings -- rather than against a
+ * second copy of the string -- means renaming the section fails here instead of
+ * shipping a link that lands readers at the top of the article.
  */
-describe("missing Markdown renderer warning — documentation link", () => {
-  it("carries exactly one link, and it is the published chat-ui guide", () => {
-    const links = MISSING_MARKDOWN_RENDERER_WARNING.match(/https:\/\/\S+/g) ?? [];
 
-    assertEquals(links, [
-      "https://veryfront.com/docs/code/guides/chat-ui#render-markdown-in-chat",
-    ]);
+/** Prefix under which veryfront-code's docs/ tree is published. */
+const PUBLISHED_DOCS_PREFIX = "https://veryfront.com/docs/code/";
+
+/** Repository root, resolved from this module so the process cwd cannot move it. */
+const REPO_ROOT = fromFileUrl(new URL("../../../../", import.meta.url));
+
+/**
+ * Resolve a published docs URL back to the repository file behind it.
+ * Deriving the path keeps the two in step: moving the guide without moving the
+ * link fails this test.
+ */
+function localFileForDocsUrl(url: URL): string {
+  const withoutFragment = `${url.origin}${url.pathname}`;
+  assert(
+    withoutFragment.startsWith(PUBLISHED_DOCS_PREFIX),
+    `the warning must link into the published veryfront-code docs tree ` +
+      `(${PUBLISHED_DOCS_PREFIX}...), got: ${withoutFragment}`,
+  );
+  return `${REPO_ROOT}docs/${withoutFragment.slice(PUBLISHED_DOCS_PREFIX.length)}.md`;
+}
+
+/**
+ * Anchor ids the published page exposes. Headings are slugified to lowercase
+ * hyphenated text.
+ */
+function anchorsIn(markdown: string): Set<string> {
+  const anchors = new Set<string>();
+  for (const line of markdown.split("\n")) {
+    const heading = /^#{2,6}\s+(.+?)\s*$/.exec(line)?.[1];
+    if (heading) anchors.add(heading.toLowerCase().replace(/\s+/g, "-"));
+  }
+  return anchors;
+}
+
+/** The single link the warning ships. */
+function warningLink(): URL {
+  const links = MISSING_MARKDOWN_RENDERER_WARNING.match(/https:\/\/\S+/g) ?? [];
+  assertEquals(
+    links.length,
+    1,
+    `the warning must carry exactly one link, got: ${links.join(", ")}`,
+  );
+  return new URL(links[0] as string);
+}
+
+describe("missing Markdown renderer warning — documentation link", () => {
+  it("points at the published chat-ui guide", () => {
+    const link = warningLink();
+
+    assertEquals(
+      `${link.origin}${link.pathname}`,
+      "https://veryfront.com/docs/code/guides/chat-ui",
+      "`/docs/guides/chat-ui` is a 404; the guide is published under `/docs/code/`",
+    );
+  });
+
+  it("names a section that exists in the guide it links to", async () => {
+    const link = warningLink();
+    const docFile = localFileForDocsUrl(link);
+    const anchors = anchorsIn(await Deno.readTextFile(docFile));
+    const fragment = decodeURIComponent(link.hash.replace(/^#/, ""));
+
+    assert(fragment !== "", "the warning must deep-link to the renderer section, not the page top");
+    assert(
+      anchors.has(fragment),
+      `no "#${fragment}" heading in ${docFile}. A reader following the warning lands at the ` +
+        `top of the article instead of the section. Headings present: ` +
+        `${[...anchors].join(", ")}`,
+    );
   });
 });


### PR DESCRIPTION
Companion to veryfront/veryfront-docs#371. Dogfooding round 2, finding 8.

## The finding, and why the previous fix did not close it

A chat surface without a Markdown renderer logs a warning whose only escape hatch is a deep link. Round 1 fixed the path half of that link -- `/docs/guides/chat-ui` was a genuine 404, and `/docs/code/guides/chat-ui` is not. Verification against published `0.1.1229` showed the symptom had only half moved:

```
$ curl -s https://veryfront.com/docs/code/guides/chat-ui | grep -c render-markdown-in-chat
0
```

The fragment names no heading on the published page. Unlike a bad path, a bad fragment does not 404 -- the browser silently leaves the reader at the top of the article -- so nothing surfaced it.

The framework's string is not wrong. `docs/guides/chat-ui.md`, the file that page is published from, has carried `## Render Markdown in chat` since #3358. The published page is a 2026-08-02 snapshot that predates it, because veryfront-docs' sync workflow has failed on every run since (details in the docs PR). **The content fix belongs in veryfront-docs, and is there.** Nothing about the emitted URL needs to change here.

## What this changes

The test guarding that link, only.

It asserted the whole URL against a second copy of the same string:

```ts
assertEquals(links, ["https://veryfront.com/docs/code/guides/chat-ui#render-markdown-in-chat"]);
```

That can catch someone editing the constant. It cannot catch someone renaming the heading the fragment names -- the exact drift this finding is about -- because the heading is not part of what it compares. Its doc comment claimed the fragment "has to track the heading in this repo's `docs/guides/chat-ui.md`", but nothing enforced it.

So resolve the published URL back to the repository file it is published from, and assert the fragment against that file's headings. Same shape as the check #3589 added for error docs links.

Confirmed it fails for the right reason by renaming the heading to what the published page currently has:

```
AssertionError: no "#render-markdown-in-chat" heading in .../docs/guides/chat-ui.md.
A reader following the warning lands at the top of the article instead of the section.
Headings present: prerequisites, add-the-preset-ui, ..., render-markdown-directly, ...
```

The doc path resolves from `import.meta.url`, not the process cwd: test files share one process under `--parallel` and `src/testing/cwd.ts` chdirs it. `lint:cwd-relative-test-reads` passes with no new baseline entry.

## Scope

No runtime change, so nothing to verify against a build. The published-artifact proof for this finding is the live page, and it is recorded on the docs PR:

**https://veryfront.com/docs/code/guides/chat-ui#render-markdown-in-chat** must scroll to a "Render Markdown in chat" heading once veryfront/veryfront-docs#371 is live.

## Not fixed here

veryfront-docs' `update-reference` sync has failed on every run since 2026-08-02, so no code doc merged since then has reached the site. Its quality gate runs after the copy and before the PR, so one non-compliant file blocks delivery of all of them, and the 13 issues it reports live in `docs/**` in this repository. That is very likely why several round-1 doc fixes never appeared live. It needs its own issue; the offending files are other findings' territory.
