### PR TITLE
docs: name the dev server port flag in getting started

### DIFF
--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -104,6 +104,24 @@ veryfront dev
 Open [http://localhost:3000](http://localhost:3000). File changes reload the
 browser.
 
+### Change the port
+
+The dev server binds port 3000. Pass `--port` to bind a different one:
+
+```bash
+veryfront dev --port 4000
+```
+
+When the requested port is already taken, `veryfront dev` does not fail. It
+scans forward for the first free port, reports the switch, and serves there:
+
+```text
+! Port 3000 is in use, using 3001 instead
+```
+
+Open the URL the CLI prints, not the one in the examples above. The development
+MCP server follows the port the dev server bound, plus 2.
+
 ## Inspect the scaffold
 
 The `minimal` template creates:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -93,13 +93,14 @@ Use [Coding agents](../guides/coding-agents.md) for setup details.
 
 ## Verify it worked
 
-Open `http://localhost:3000` and ask:
+Open the URL `veryfront dev` printed — `http://localhost:3000` unless the port
+moved — and ask:
 
 ```text
 What is 128 divided by 8?
 ```
 
-To test the route without the UI:
+To test the route without the UI, using that same port:
 
 ```bash
 curl -N -X POST http://localhost:3000/api/ag-ui \

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -93,8 +93,8 @@ Use [Coding agents](../guides/coding-agents.md) for setup details.
 
 ## Verify it worked
 
-Open the URL `veryfront dev` printed — `http://localhost:3000` unless the port
-moved — and ask:
+Open the URL `veryfront dev` printed. Unless the port moved, that is
+`http://localhost:3000`. Ask:
 
 ```text
 What is 128 divided by 8?

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -77,6 +77,15 @@ also set `VERYFRONT_API_TOKEN` directly. Direct provider keys such as
 veryfront dev
 ```
 
+The dev server binds port 3000. When that port is already taken, `veryfront dev`
+prints `! Port 3000 is in use, using 3001 instead` and serves on the first free
+port after 3000, so open the URL the CLI prints. Pass `--port` to pin one
+yourself:
+
+```bash
+veryfront dev --port 4000
+```
+
 `veryfront dev` also starts the development MCP server on the app port plus 2.
 With the default app port, coding agents can connect to
 `http://localhost:3002/mcp` and call `vf_bootstrap` once at session start.

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -507,6 +507,36 @@ describe("guide content contracts", () => {
       "agents guide samples must guard the getAgent() result before using it",
     );
   });
+
+  it("tells getting-started readers how to choose the dev server port", async () => {
+    // Port 3000 is the most contended port on a developer machine. `veryfront
+    // dev` no longer hard-fails on it: it falls forward to the next free port
+    // and announces the switch. Both halves are invisible to a doc-only
+    // reader, who then opens the 3000 the page prints and reaches whatever
+    // process took it. `--port` exists but lives only in `veryfront dev
+    // --help`, so the getting-started pages that start the dev server have to
+    // name it and describe the fallback.
+    const help = await Deno.readTextFile("cli/commands/dev/command-help.ts");
+    const portFlag = help.match(/flag: "(--port [^"]*)"/)?.[1];
+    assert(
+      portFlag !== undefined,
+      "veryfront dev must declare a --port flag in its command help",
+    );
+
+    for (
+      const path of [
+        "docs/getting-started/create-project.md",
+        "docs/getting-started/quickstart.md",
+      ]
+    ) {
+      const page = await Deno.readTextFile(path);
+
+      assertStringIncludes(page, "veryfront dev --port");
+      // The exact notice `veryfront dev` prints, so a reader who lands on a
+      // different port than the page's examples recognizes what happened.
+      assertStringIncludes(page, "is in use, using");
+    }
+  });
 });
 
 /**

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -516,7 +516,10 @@ describe("guide content contracts", () => {
     // process took it. `--port` exists but lives only in `veryfront dev
     // --help`, so the getting-started pages that start the dev server have to
     // name it and describe the fallback.
-    const help = await Deno.readTextFile("cli/commands/dev/command-help.ts");
+    const repoRoot = new URL("../../", import.meta.url);
+    const help = await Deno.readTextFile(
+      new URL("cli/commands/dev/command-help.ts", repoRoot),
+    );
     const portFlag = help.match(/flag: "(--port [^"]*)"/)?.[1];
     assert(
       portFlag !== undefined,
@@ -529,7 +532,7 @@ describe("guide content contracts", () => {
         "docs/getting-started/quickstart.md",
       ]
     ) {
-      const page = await Deno.readTextFile(path);
+      const page = await Deno.readTextFile(new URL(path, repoRoot));
 
       assertStringIncludes(page, "veryfront dev --port");
       // The exact notice `veryfront dev` prints, so a reader who lands on a


### PR DESCRIPTION
## Symptom

Round-2 verification finding [7], doc half. Against published `0.1.1229`, with
`127.0.0.1:3000` held by another process:

```
  Veryfront (v0.1.1229)

  ! Port 3000 is in use, using 3001 instead

  ✓ Ready in 925ms
  http://veryfront.me:3001
```

The CLI half of that finding is fixed and shipped (#3562): no hard fail, no
`[initialization-error]`, the server binds 3001 and the dev MCP server moves to
3003. The doc half is not. Neither getting-started page mentions `--port`, and
neither warns the reader that the printed port can differ from the one in the
page's own examples. A reader whose 3000 is busy follows the page to
`http://localhost:3000` and reaches whatever process took it.

`--port` is documented only in `veryfront dev --help`.

## Why the earlier fix did not cover this

#3562 changed CLI behaviour only. Its own commit message named the doc gap
("the getting-started docs ... never mention `--port`") as the motivation, but
the change never touched `docs/`. Nothing regressed; the doc half was simply
never in scope.

## Change

- `docs/getting-started/create-project.md`: a `### Change the port` subsection
  under "Run the dev server" with the `--port` flag, the fallback behaviour, and
  the notice line the CLI actually prints.
- `docs/getting-started/quickstart.md`: the same facts in one paragraph plus a
  `--port` example, ahead of the existing dev-MCP paragraph (whose "app port
  plus 2" is relative to the port the server bound, which the new paragraph now
  makes visible).
- `tests/docs/guide-content.test.ts`: a contract test that reads the `--port`
  declaration out of `cli/commands/dev/command-help.ts` and requires both pages
  to name the flag and the fallback notice.

No source behaviour changes.

## Verification

Repro built against the published artifact, in a sandbox outside the platform
checkout: `npm install veryfront@0.1.1229`, `veryfront init test-app --template
minimal`, blocker on `127.0.0.1:3000`, then `veryfront dev`. Output above;
`lsof` confirmed `127.0.0.1:3001` and `[::1]:3003`. `veryfront dev --port 4000`
binds 4000 with MCP on 4002. Every documented string is copied from that run.

Test is red before the doc change (`docs/getting-started/create-project.md` does
not contain "veryfront dev --port") and green after:

```
deno test -A tests/docs/guide-content.test.ts   # 28 steps, 0 failed
```

## Live URLs that must show this

This repo's `docs/` is not what `veryfront.com` serves. The published copy is
`veryfront-docs/docs/code/**`, which has drifted from this tree, so the same
change goes there in a companion PR. The pages to check after both land:

- https://veryfront.com/docs/code/getting-started/create-project
- https://veryfront.com/docs/code/getting-started/quickstart

Both must contain the string `veryfront dev --port`. Today they contain "port"
zero times in rendered text.
