### PR TITLE
fix(cli): report an unknown install target as an argument error

### DIFF
--- a/cli/commands/install/handler.test.ts
+++ b/cli/commands/install/handler.test.ts
@@ -151,6 +151,17 @@ describe("commands/install/handler", () => {
     it("reads the positional for uninstall too", () => {
       assertEquals(parseCommandLine(["uninstall", "agents"]).target, "agents");
     });
+
+    it("fails argument parsing for an unknown positional tool id", () => {
+      const result = parseInstallArgs(parseCliArgs(["install", "not-a-tool"]));
+      assertEquals(result.success, false);
+      assertEquals(result.error?.message.includes("Valid targets"), true);
+    });
+
+    it("fails argument parsing for an unknown --target too", () => {
+      const result = parseInstallArgs(parseCliArgs(["install", "--target", "not-a-tool"]));
+      assertEquals(result.success, false);
+    });
   });
 
   describe("uninstall argument extraction", () => {

--- a/cli/commands/install/handler.ts
+++ b/cli/commands/install/handler.ts
@@ -3,14 +3,19 @@
  */
 
 import { defineSchema, lazySchema } from "veryfront/schemas";
-import { installCommand } from "./install.ts";
+import { installCommand, isValidTargetSpec, VALID_TARGET_VALUES } from "./install.ts";
 import { uninstallCommand } from "./uninstall.ts";
 import { CommonArgs, createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import type { ParsedArgs } from "#cli/shared/types";
 
 const getInstallArgsSchema = defineSchema((v) =>
   v.object({
-    target: v.string().optional(),
+    // Validated here rather than at install time so an unknown tool id is an
+    // argument error (exit 2), not a runtime failure (exit 1).
+    target: v.string().optional().refine(
+      (value) => value === undefined || isValidTargetSpec(value),
+      { message: `unknown tool. Valid targets: ${VALID_TARGET_VALUES}` },
+    ),
     global: v.boolean().default(false),
     force: v.boolean().default(false),
   })

--- a/cli/commands/install/install.integration.test.ts
+++ b/cli/commands/install/install.integration.test.ts
@@ -194,8 +194,23 @@ describe("install command integration", () => {
     });
 
     it("fails instead of installing something else for an unknown target", async () => {
-      const { code } = await runInstallArgs(["unknown-tool", "--force", "--no-input"]);
-      assertEquals(code, 1);
+      const { code, output } = await runInstallArgs(["unknown-tool", "--force", "--no-input"]);
+      // AGENTS.md reserves exit 2 for usage and argument errors.
+      assertEquals(code, 2);
+      assertEquals(output.includes("Valid targets"), true);
+
+      await assertFileNotExists(join(tempDir, "SKILL.md"));
+      await assertFileNotExists(join(tempDir, "AGENTS.md"));
+    });
+
+    it("fails an unknown --target with the same usage exit code", async () => {
+      const { code } = await runInstallArgs([
+        "--target",
+        "unknown-tool",
+        "--force",
+        "--no-input",
+      ]);
+      assertEquals(code, 2);
 
       await assertFileNotExists(join(tempDir, "SKILL.md"));
       await assertFileNotExists(join(tempDir, "AGENTS.md"));

--- a/cli/commands/install/install.ts
+++ b/cli/commands/install/install.ts
@@ -37,6 +37,14 @@ export function parseTargetFlag(target: string): AIToolId[] {
   return TargetFlagSchema.parse(target);
 }
 
+/** Valid target values, for messages and argument validation. */
+export const VALID_TARGET_VALUES = [...AI_TOOLS.map((t) => t.id), "all"].join(", ");
+
+/** True when the value names at least one known tool (or `all`). */
+export function isValidTargetSpec(target: string): boolean {
+  return TargetFlagSchema.safeParse(target).success;
+}
+
 const getAIToolIdArraySchema = defineSchema((v) => v.array(AIToolIdSchema).min(1));
 
 const AIToolIdArraySchema = lazySchema(getAIToolIdArraySchema);


### PR DESCRIPTION
## Scope after rebase

This branch originally carried two things: the positional tool id for
`veryfront install <tool>`, and the exit code for an unknown tool id. The
positional fix landed on main independently as #3609, so **only the exit-code
correction remains here.** The branch has been rebased onto main and the diff
is now four files in `cli/commands/install/`.

## Symptom

```
$ veryfront install not-a-tool
  ✗ [unknown-error] Unknown/unclassified error
EXIT=1
```

A typo in the tool id exited 1, the code AGENTS.md reserves for a runtime or
command error. A caller — a script, CI, or a person reading the exit status —
could not tell a malformed argument from an installation that genuinely failed
partway through.

## Root cause

`parseInstallArgs` accepted `target` as an arbitrary string. The value was only
checked later, inside `installCommand`, where `parseTargetFlag` throws an
ordinary runtime error. By then the CLI is past argument parsing, so the
router's usage path — the one that produces exit 2 — is no longer in play.

## Fix

`cli/commands/install/handler.ts` — validate `target` while parsing arguments,
via a `refine` on the schema. The failure now goes through `parseArgsOrThrow`
and the router's `Invalid ...` usage path, and the message names the valid
targets:

```
$ veryfront install not-a-tool --force --no-input
  Detail: Invalid install arguments: unknown tool. Valid targets: cursor, claude-code, skill, copilot, windsurf, agents, all
EXIT=2
```

`--target not-a-tool` takes the same path and also exits 2. `uninstall` shares
the parser, so it is covered too.

`cli/commands/install/install.ts` — export `isValidTargetSpec` and
`VALID_TARGET_VALUES` so the check and the message both come from the single
tool registry rather than a second hand-maintained list. `parseTargetFlag`
keeps its own check as a guard for programmatic callers.

## AGENTS.md contract

| Exit code | Meaning                  |
| --------- | ------------------------ |
| `1`       | Runtime or command error |
| `2`       | Usage or argument error  |

## Tests

- `install.integration.test.ts` — the end-to-end case #3609 added for an
  unknown positional asserted exit 1; it now asserts exit 2 and that the output
  names the valid targets. A sibling case covers `--target`. Both still assert
  that no integration file is written.
- `handler.test.ts` — two parser-level cases: an unknown positional and an
  unknown `--target` both fail argument validation.

Changing the existing assertion from 1 to 2 is the behaviour change this PR
owns, so that test is red on main by construction.

## Review

Raised by codex as a P2 on the original branch. The finding was correct and is
fixed rather than argued with.
