### PR TITLE
Keep the cache root out of git on the build path, and document it

### DIFF
--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -215,9 +215,10 @@ The cache root keeps itself out of version control. When the file is absent,
 both commands create a `.gitignore` in the cache root containing `*`, which
 ignores the directory's contents and the file itself, so a project that adopted
 Veryfront into an existing tree does not have to edit its own `.gitignore`. A
-`.cache/.gitignore` you wrote yourself is never overwritten, so keep the
-generated bundles ignored there if you replace it. `veryfront init` also lists
-`.cache/` in the `.gitignore` it scaffolds.
+marker you wrote yourself — a `.cache/.gitignore` of your own, say — is never
+overwritten in either root, so keep the generated bundles ignored there if you
+replace it. `veryfront init` also lists `.cache/` in the `.gitignore` it
+scaffolds.
 
 Deleting the cache root costs only time. The next run recompiles the pages and
 refetches the remote dependencies it needs.

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -182,31 +182,44 @@ These directories are not auto-discovered. They are common project conventions.
 
 ## Generated directories
 
-The CLI writes these directories into the project root. They hold derived
-output only, so deleting them is safe: the next command regenerates whatever it
-needs.
+These directories hold derived output only, so deleting them is safe: the next
+command regenerates whatever it needs. `dist/` is always written into the
+project root. `.cache/` is too during development, but not under a production
+runtime — see "Where the cache root lives" below.
 
 | Directory | Written by                         | Contents                                                                                                  |
 | --------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `.cache/` | `veryfront dev`, `veryfront build` | Compiled page modules in `veryfront-mdx-esm/` and bundled remote dependencies in `veryfront-http-bundle/` |
 | `dist/`   | `veryfront build`                  | The build output. `-o/--output` and `build.outDir` change the location                                    |
 
-`.cache/` keeps itself out of version control. When the file is absent, both
-commands create a `.cache/.gitignore` containing `*`, which ignores the
-directory's contents and the file itself, so a project that adopted Veryfront
-into an existing tree does not have to edit its own `.gitignore`. A
-`.cache/.gitignore` you wrote yourself is never overwritten, so keep the
-generated bundles ignored there if you replace it. `veryfront init` also lists
-`.cache/` in the `.gitignore` it scaffolds.
+### Where the cache root lives
 
-Set `VERYFRONT_CACHE_DIR` to keep generated bundles out of the project tree
-entirely:
+The cache root is `.cache/` in the project directory during development. Under
+a production runtime it is not in the project at all: when `NODE_ENV` or
+`VERYFRONT_MODE` is `production` and `HOME` is set, the cache root is
+`.cache/veryfront` inside the home directory instead, so a deployed project
+directory that is read-only still has somewhere to write. Both roots hold the
+same `veryfront-mdx-esm/` and `veryfront-http-bundle/` subdirectories.
+
+Set `VERYFRONT_CACHE_DIR` (or `VF_CACHE_DIR`) to choose the location yourself.
+It wins in both modes, so it is also how you keep generated bundles out of the
+project tree during development:
 
 ```bash
 VERYFRONT_CACHE_DIR=/tmp/veryfront-cache veryfront dev
 ```
 
-Deleting `.cache/` costs only time. The next run recompiles the pages and
+### Keeping the cache out of version control
+
+The cache root keeps itself out of version control. When the file is absent,
+both commands create a `.gitignore` in the cache root containing `*`, which
+ignores the directory's contents and the file itself, so a project that adopted
+Veryfront into an existing tree does not have to edit its own `.gitignore`. A
+`.cache/.gitignore` you wrote yourself is never overwritten, so keep the
+generated bundles ignored there if you replace it. `veryfront init` also lists
+`.cache/` in the `.gitignore` it scaffolds.
+
+Deleting the cache root costs only time. The next run recompiles the pages and
 refetches the remote dependencies it needs.
 
 ## Special files

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -191,11 +191,13 @@ needs.
 | `.cache/` | `veryfront dev`, `veryfront build` | Compiled page modules in `veryfront-mdx-esm/` and bundled remote dependencies in `veryfront-http-bundle/` |
 | `dist/`   | `veryfront build`                  | The build output. `-o/--output` and `build.outDir` change the location                                    |
 
-`.cache/` keeps itself out of version control: both commands write a
-`.cache/.gitignore` that ignores the directory's contents and the file itself,
-so a project that adopted Veryfront into an existing tree does not have to edit
-its own `.gitignore`. `veryfront init` also lists `.cache/` in the `.gitignore`
-it scaffolds.
+`.cache/` keeps itself out of version control. When the file is absent, both
+commands create a `.cache/.gitignore` containing `*`, which ignores the
+directory's contents and the file itself, so a project that adopted Veryfront
+into an existing tree does not have to edit its own `.gitignore`. A
+`.cache/.gitignore` you wrote yourself is never overwritten, so keep the
+generated bundles ignored there if you replace it. `veryfront init` also lists
+`.cache/` in the `.gitignore` it scaffolds.
 
 Set `VERYFRONT_CACHE_DIR` to keep generated bundles out of the project tree
 entirely:

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -68,6 +68,8 @@ my-app/
     globals.css
   veryfront.config.ts   # Framework configuration (optional)
   package.json
+  .cache/               # Generated bundles (written by the CLI, safe to delete)
+  dist/                 # Build output (written by `veryfront build`)
 ```
 
 ## Routing directories
@@ -177,6 +179,33 @@ These directories are not auto-discovered. They are common project conventions.
 | `public/`     | Static assets served at root path   |
 | `styles/`     | Global CSS files                    |
 | `middleware/` | Custom middleware functions         |
+
+## Generated directories
+
+The CLI writes these directories into the project root. They hold derived
+output only, so deleting them is safe: the next command regenerates whatever it
+needs.
+
+| Directory | Written by                         | Contents                                                                                                  |
+| --------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `.cache/` | `veryfront dev`, `veryfront build` | Compiled page modules in `veryfront-mdx-esm/` and bundled remote dependencies in `veryfront-http-bundle/` |
+| `dist/`   | `veryfront build`                  | The build output. `-o/--output` and `build.outDir` change the location                                    |
+
+`.cache/` keeps itself out of version control: both commands write a
+`.cache/.gitignore` that ignores the directory's contents and the file itself,
+so a project that adopted Veryfront into an existing tree does not have to edit
+its own `.gitignore`. `veryfront init` also lists `.cache/` in the `.gitignore`
+it scaffolds.
+
+Set `VERYFRONT_CACHE_DIR` to keep generated bundles out of the project tree
+entirely:
+
+```bash
+VERYFRONT_CACHE_DIR=/tmp/veryfront-cache veryfront dev
+```
+
+Deleting `.cache/` costs only time. The next run recompiles the pages and
+refetches the remote dependencies it needs.
 
 ## Special files
 

--- a/src/build/production-build/build/build-orchestrator.ts
+++ b/src/build/production-build/build/build-orchestrator.ts
@@ -2,6 +2,7 @@ import { serverLogger as logger } from "#veryfront/utils";
 import type { BuildOptions, BuildStats } from "#veryfront/server/build-types.ts";
 import { createError, toError } from "#veryfront/errors";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { ensureCacheDirIgnored } from "#veryfront/utils/cache-dir.ts";
 import {
   cleanupCaches,
   cleanupRenderer,
@@ -83,6 +84,15 @@ export function buildProduction(options: BuildOptions): Promise<BuildStats> {
       }
 
       logger.debug("Starting production build", options);
+
+      // Outside production the cache root is `<project>/.cache`, so a build
+      // drops generated bundles into the user's project. Server startup writes
+      // a self-ignoring `.gitignore` there, but a build never starts a server,
+      // so the bundles showed up as untracked files in a project whose own
+      // .gitignore predates Veryfront. Marked here rather than in
+      // `setupBuildDirectories` because a dry run skips that step and still
+      // populates the cache root.
+      await ensureCacheDirIgnored();
 
       const context = await withSpan(
         "build.initializeContext",

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -1,10 +1,11 @@
 import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { basename } from "#veryfront/compat/path";
+import { deleteEnv, getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import {
+  getCacheBaseDir,
   getHttpBundleCacheDir,
   getMdxEsmCacheDir,
-  runWithCacheDir,
 } from "#veryfront/utils/cache-dir.ts";
 import { MINIMUM_DENO_VERSION, MINIMUM_NODE_VERSION } from "../../scripts/build/runtime-support.ts";
 
@@ -558,29 +559,131 @@ describe("guide content contracts", () => {
     }
   });
 
-  it("documents the .cache root the CLI writes into the project", async () => {
+  it("documents the cache root in both development and production", async () => {
     // Resolved from import.meta.url, not the process cwd: test files share one
     // process under --parallel and a sibling isolate can hold a chdir.
+    const repoRoot = new URL("../../", import.meta.url);
     const guide = await Deno.readTextFile(
-      new URL("../../docs/guides/project-structure.md", import.meta.url),
+      new URL("docs/guides/project-structure.md", repoRoot),
     );
 
-    // `veryfront dev` and `veryfront build` both create `<project>/.cache`.
-    // Before this section existed the only explanation a developer got was the
-    // comment inside the generated `.cache/.gitignore`.
+    // `veryfront dev` and `veryfront build` both create a cache root. Before
+    // this section existed the only explanation a developer got was the
+    // comment inside the generated `.gitignore` marker.
     assertStringIncludes(guide, "## Generated directories");
     assertStringIncludes(guide, "`.cache/`");
     assertStringIncludes(guide, "`.cache/.gitignore`");
     assertStringIncludes(guide, "VERYFRONT_CACHE_DIR");
 
-    // Pinned to the real layout, so renaming a cache subdirectory fails here
-    // instead of leaving the guide describing a tree that no longer exists.
-    runWithCacheDir("/tmp/veryfront-guide-content", () => {
-      assertStringIncludes(guide, basename(getMdxEsmCacheDir()));
-      assertStringIncludes(guide, basename(getHttpBundleCacheDir()));
-    });
+    // The location is not one place. `getDefaultCacheBaseDir()` sends the
+    // cache to `$HOME/.cache/veryfront` under a production runtime and to
+    // `<project>/.cache` otherwise, so a guide that describes only the project
+    // root is wrong for every deployed run. Both branches are resolved here by
+    // calling the real function under each mode rather than by forcing a cache
+    // context, which would answer with the forced path in both modes and pass
+    // no matter what the guide says.
+    const home = "/tmp/veryfront-guide-content-home";
+    const noOverride = { VERYFRONT_CACHE_DIR: undefined, VF_CACHE_DIR: undefined };
+    const resolveRoots = (mode: string | undefined) =>
+      withHostEnv(
+        { ...noOverride, HOME: home, NODE_ENV: mode, VERYFRONT_MODE: mode },
+        () => ({
+          base: getCacheBaseDir(),
+          mdxEsm: basename(getMdxEsmCacheDir()),
+          httpBundle: basename(getHttpBundleCacheDir()),
+        }),
+      );
+
+    const development = resolveRoots("development");
+    const production = resolveRoots("production");
+
+    // Guard the guard: if these ever resolve to the same place, the two
+    // assertions below stop distinguishing anything and this test would keep
+    // passing while the guide describes a mode that no longer exists.
+    assert(
+      development.base !== production.base,
+      "development and production must resolve to different cache roots",
+    );
+    assertEquals(basename(development.base), ".cache");
+    assertStringIncludes(production.base, home);
+
+    // `.cache/veryfront` — the production root with the home prefix removed, so
+    // the guide has to name the real deployed location and not just `.cache/`.
+    const productionUnderHome = production.base
+      .slice(home.length + 1)
+      .replaceAll("\\", "/");
+    assertStringIncludes(guide, productionUnderHome);
+
+    // Every variable the production branch reads has to appear in the guide, so
+    // renaming a trigger fails here instead of leaving readers checking a
+    // variable the code stopped consulting.
+    for (
+      const key of productionCacheTriggerEnvKeys(
+        await Deno.readTextFile(
+          new URL("src/utils/cache-dir.ts", repoRoot),
+        ),
+      )
+    ) {
+      assertStringIncludes(guide, key);
+    }
+
+    // Pinned to the real layout in both modes, so renaming a cache
+    // subdirectory fails here instead of leaving the guide describing a tree
+    // that no longer exists.
+    for (const { mdxEsm, httpBundle } of [development, production]) {
+      assertStringIncludes(guide, mdxEsm);
+      assertStringIncludes(guide, httpBundle);
+    }
   });
 });
+
+/**
+ * Run `fn` with host environment variables set, restoring the previous values
+ * afterwards. `undefined` unsets a variable for the duration of the call.
+ */
+function withHostEnv<T>(
+  vars: Readonly<Record<string, string | undefined>>,
+  fn: () => T,
+): T {
+  const previous = Object.keys(vars).map(
+    (key) => [key, getHostEnv(key)] as const,
+  );
+  const apply = (entries: readonly (readonly [string, string | undefined])[]) => {
+    for (const [key, value] of entries) {
+      if (value === undefined) deleteEnv(key);
+      else setEnv(key, value);
+    }
+  };
+
+  apply(Object.entries(vars));
+  try {
+    return fn();
+  } finally {
+    apply(previous);
+  }
+}
+
+/**
+ * Environment variables `getDefaultCacheBaseDir()` reads to choose between the
+ * project cache root and the home cache root, read out of the source so the
+ * guide's list of triggers cannot drift away from the code's.
+ */
+function productionCacheTriggerEnvKeys(source: string): string[] {
+  const start = source.indexOf("function getDefaultCacheBaseDir(");
+  assert(start !== -1, "cache-dir.ts must define getDefaultCacheBaseDir()");
+  const open = source.indexOf("{", start);
+  let depth = 0;
+  let end = open;
+  for (; end < source.length; end++) {
+    if (source[end] === "{") depth++;
+    else if (source[end] === "}" && --depth === 0) break;
+  }
+
+  const body = source.slice(open, end);
+  const keys = [...body.matchAll(/getHostEnv\("([A-Z_]+)"\)/g)].map((m) => m[1]!);
+  assert(keys.length > 0, "getDefaultCacheBaseDir() must read the host env");
+  return [...new Set(keys)];
+}
 
 /**
  * Body of the guide's "Verify it worked" section, up to the next heading, with

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -1,5 +1,11 @@
 import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { basename } from "#veryfront/compat/path";
+import {
+  getHttpBundleCacheDir,
+  getMdxEsmCacheDir,
+  runWithCacheDir,
+} from "#veryfront/utils/cache-dir.ts";
 import { MINIMUM_DENO_VERSION, MINIMUM_NODE_VERSION } from "../../scripts/build/runtime-support.ts";
 
 describe("guide content contracts", () => {
@@ -550,6 +556,25 @@ describe("guide content contracts", () => {
       // different port than the page's examples recognizes what happened.
       assertStringIncludes(page, "is in use, using");
     }
+  });
+
+  it("documents the .cache root the CLI writes into the project", async () => {
+    const guide = await Deno.readTextFile("docs/guides/project-structure.md");
+
+    // `veryfront dev` and `veryfront build` both create `<project>/.cache`.
+    // Before this section existed the only explanation a developer got was the
+    // comment inside the generated `.cache/.gitignore`.
+    assertStringIncludes(guide, "## Generated directories");
+    assertStringIncludes(guide, "`.cache/`");
+    assertStringIncludes(guide, "`.cache/.gitignore`");
+    assertStringIncludes(guide, "VERYFRONT_CACHE_DIR");
+
+    // Pinned to the real layout, so renaming a cache subdirectory fails here
+    // instead of leaving the guide describing a tree that no longer exists.
+    runWithCacheDir("/tmp/veryfront-guide-content", () => {
+      assertStringIncludes(guide, basename(getMdxEsmCacheDir()));
+      assertStringIncludes(guide, basename(getHttpBundleCacheDir()));
+    });
   });
 });
 

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -559,7 +559,11 @@ describe("guide content contracts", () => {
   });
 
   it("documents the .cache root the CLI writes into the project", async () => {
-    const guide = await Deno.readTextFile("docs/guides/project-structure.md");
+    // Resolved from import.meta.url, not the process cwd: test files share one
+    // process under --parallel and a sibling isolate can hold a chdir.
+    const guide = await Deno.readTextFile(
+      new URL("../../docs/guides/project-structure.md", import.meta.url),
+    );
 
     // `veryfront dev` and `veryfront build` both create `<project>/.cache`.
     // Before this section existed the only explanation a developer got was the

--- a/tests/integration/server/build/build.test.ts
+++ b/tests/integration/server/build/build.test.ts
@@ -13,11 +13,12 @@
 import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert";
 import { join } from "#veryfront/compat/path";
 import { afterAll, describe, it } from "#veryfront/testing/bdd";
-import { mkdir, readTextFile, remove, writeTextFile } from "#veryfront/compat/fs.ts";
+import { exists, mkdir, readTextFile, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { buildProduction } from "../../../../src/build/production-build/index.ts";
 import type { BuildStats } from "../../../../src/server/build-types.ts";
 import { withTestContext } from "../../../_helpers/context.ts";
 import { cleanupBundler } from "../../../../src/rendering/cleanup.ts";
+import { runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
 
 async function removeAppDir(projectDir: string): Promise<void> {
   await remove(join(projectDir, "app"), { recursive: true });
@@ -63,6 +64,41 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
         assertEquals(typeof stats.pages, "number");
         assertEquals(typeof stats.duration, "number");
         assert(stats.duration >= 0);
+      });
+    });
+
+    // Regression: outside production the cache root is `<project>/.cache`, so a
+    // build drops generated bundles into the user's project — a dry run
+    // included. Server startup writes a self-ignoring `.gitignore` there, but
+    // `veryfront build` never starts a server, so a project that adopted
+    // Veryfront (its own .gitignore predates `veryfront init`) saw the bundles
+    // as untracked files and `git add -A` committed them.
+    it("marks the local cache root as ignored so a build cannot dirty the project's git history", async () => {
+      await withTestContext("build-cache-ignore", async (context) => {
+        const outputDir = join(context.projectDir, "dist");
+        const cacheRoot = join(context.projectDir, ".cache");
+
+        await removeAppDir(context.projectDir);
+
+        const pagesDir = await ensurePagesDir(context.projectDir);
+        await writeTextFile(join(pagesDir, "index.mdx"), "# Home Page");
+
+        await runWithCacheDir(cacheRoot, () =>
+          buildProduction({
+            projectDir: context.projectDir,
+            outputDir,
+            enableSplitting: false,
+            enableCompression: false,
+            enablePrefetch: false,
+            dryRun: true,
+          }));
+
+        const ignorePath = join(cacheRoot, ".gitignore");
+        assertEquals(await exists(ignorePath), true);
+        assertEquals(
+          (await readTextFile(ignorePath)).split(/\r?\n/).includes("*"),
+          true,
+        );
       });
     });
 


### PR DESCRIPTION
## What the round-2 verification found

Finding 16 was filed as "`veryfront dev` writes an undocumented `.cache/` tree into the host project root and never adds a `.gitignore` entry" and marked **partially-fixed**: the git-hygiene half looked fixed, the documentation half did not.

Reproducing on the **published 0.1.1229** showed the git-hygiene half is only fixed on the path the verification happened to test.

Adopt-path project (hand-built per the Installation doc, own `.gitignore` listing only `node_modules/`, `dist/`, `.env`, `git init` + commit), published `veryfront@0.1.1229`:

| command | `git status --porcelain -uall` |
| --- | --- |
| `veryfront dev` + one page load | 0 lines (fixed by #3581) |
| `veryfront build` | **10 untracked `.cache/**.mjs` files** |
| `veryfront build --dry-run` | **10 untracked `.cache/**.mjs` files** |

`.cache/.gitignore` is simply absent after a build.

## Why the previous fix missed it

#3581 diagnosed the problem correctly but hooked the repair to the wrong lifecycle. It calls `ensureCacheDirIgnored()` from `clearAllLocalCaches()`, and only `veryfront dev`, `veryfront start`, and `veryfront serve` call that — they are the commands that boot a server. `veryfront build` never boots a server, so it writes `veryfront-mdx-esm/` and `veryfront-http-bundle/` into `<project>/.cache` with no marker in sight. The fix was verified through the dev path only, which is exactly the path it covered.

## The fix

`buildProduction()` marks the cache root itself. That is the single library entry the CLI build, the MCP build tool, and a direct API call all funnel through. It is *not* in `setupBuildDirectories()`, because a dry run returns from that step early and still populates the cache root (verified above).

## Documentation half

The project-structure guide gains a **Generated directories** section: what `.cache/` holds (named after the real subdirectories, pinned by a test), that it ignores itself so an adopted project never has to edit its own `.gitignore`, that deleting it is safe, and `VERYFRONT_CACHE_DIR` for keeping generated bundles out of the project tree entirely. Every claim was checked against published-CLI behaviour, including that `VERYFRONT_CACHE_DIR` relocates the whole root and leaves the project clean.

**Live URL that must show this after the docs sync lands: <https://veryfront.com/code/guides/project-structure>** (section "Generated directories"). `docs/code/guides/` in veryfront-docs is overwritten wholesale from this repo by `.github/workflows/sync-docs.yml` → `update-reference.yml`, so this repo is the source of truth; veryfront-docs#375 carries the same text so the live page does not wait on the sync run.

## Tests

- `tests/integration/server/build/build.test.ts` — new case runs `buildProduction()` inside `runWithCacheDir()` and asserts the cache root ends up with a `.gitignore` containing `*`. Confirmed red before the fix (`AssertionError: Values are not equal`) and green after.
- `tests/docs/guide-content.test.ts` — pins the new guide section to the real cache layout via `basename(getMdxEsmCacheDir())` / `basename(getHttpBundleCacheDir())`, so renaming a cache subdirectory fails here instead of silently stranding the guide.

## Proof the original symptom is gone

Same sandbox project, same commands, this branch's build instead of 0.1.1229:

```
$ veryfront build         -> git status --porcelain -uall: 0 lines
$ veryfront build --dry-run -> git status --porcelain -uall: 0 lines
$ cat .cache/.gitignore
# Created by Veryfront. Holds generated bundles only, safe to delete.
*
$ git check-ignore -v .cache/
.cache/.gitignore:2:*   .cache/
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented generated `.cache/` and `dist/` directories, including their contents, regeneration, safe deletion, and cache-directory configuration.

- **Bug Fixes**
  - Production dry-run builds now ensure generated cache files are ignored by version control, preventing untracked cache bundles.

- **Tests**
  - Added coverage verifying cache-directory documentation and correct `.gitignore` creation during production builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->