### PR TITLE
fix(build): let the published package use Deno's own Deno global

### DIFF
--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -24,7 +24,7 @@ import {
 	readDenoConfigSet,
 } from "./npm-dependency-sources.ts";
 import { buildExtensionPackages } from "./build-npm-extension-packages.ts";
-import { patchDntArgvPolyfill } from "./dnt-polyfill.ts";
+import { patchDntArgvPolyfill, patchDntDenoShim } from "./dnt-polyfill.ts";
 import { normalizeNpmPackageMetadata } from "./npm-package-metadata.ts";
 import { assertNpmRuntimeHelperContract } from "./npm-runtime-helper-contract.ts";
 import { normalizeEsmShReactNpmShims } from "./npm-react-shims.ts";
@@ -229,6 +229,16 @@ await build({
 		// Fix dnt polyfill bug: process.argv[1] can be undefined in dynamic imports
 		await patchDntArgvPolyfill(
 			"./npm/esm/_dnt.polyfills.js",
+			{ required: true },
+		);
+
+		// dnt re-exports `@deno/shim-deno` unconditionally, so `deno run -A
+		// npm:veryfront` ran the Node reimplementations of Deno APIs instead of
+		// the runtime's own. Deno.listen in particular reads `server._handle.fd`
+		// off a node:net server, which is null under Deno's node compatibility
+		// layer, so every command that binds a port died before starting.
+		await patchDntDenoShim(
+			"./npm/esm/_dnt.shims.js",
 			{ required: true },
 		);
 

--- a/scripts/build/build-npm-extension-packages.ts
+++ b/scripts/build/build-npm-extension-packages.ts
@@ -1,6 +1,6 @@
 import { build, emptyDir } from "#dnt";
 import { basename, dirname, join, relative, toFileUrl } from "#std/path";
-import { patchDntArgvPolyfill } from "./dnt-polyfill.ts";
+import { patchDntArgvPolyfill, patchDntDenoShim } from "./dnt-polyfill.ts";
 import {
   bareImportPackageNames,
   createExtensionPackageSpecs,
@@ -90,6 +90,7 @@ async function buildExtensionPackage(
           rootConfig: options.rootConfig,
         });
         await patchDntArgvPolyfill(`${outDir}/esm/_dnt.polyfills.js`);
+        await patchDntDenoShim(`${outDir}/esm/_dnt.shims.js`);
 
         await Deno.copyFile(`${options.rootDir}/LICENSE`, `${outDir}/LICENSE`);
         await Deno.copyFile(`${options.rootDir}/NOTICE`, `${outDir}/NOTICE`);

--- a/scripts/build/dnt-polyfill.test.ts
+++ b/scripts/build/dnt-polyfill.test.ts
@@ -1,5 +1,17 @@
 import { assertEquals, assertRejects } from "#std/assert";
-import { patchDntArgvPolyfill } from "./dnt-polyfill.ts";
+import { patchDntArgvPolyfill, patchDntDenoShim } from "./dnt-polyfill.ts";
+
+/** Verbatim shape of the `_dnt.shims.js` DNT emits for `shims: { deno: true, crypto: true }`. */
+const GENERATED_SHIMS = `import { Deno } from "@deno/shim-deno";
+export { Deno } from "@deno/shim-deno";
+import { crypto } from "@deno/shim-crypto";
+export { crypto } from "@deno/shim-crypto";
+const dntGlobals = {
+    Deno,
+    crypto,
+};
+export const dntGlobalThis = globalThis;
+`;
 
 Deno.test("patchDntArgvPolyfill guards missing process argv entries", async () => {
   const directory = await Deno.makeTempDir();
@@ -46,6 +58,140 @@ Deno.test("patchDntArgvPolyfill fails closed when required DNT output changes", 
       Error,
       "does not contain the expected process.argv[1] expression",
     );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+/**
+ * Load the patched `_dnt.shims.js` the way the published package loads it, with
+ * `@deno/shim-deno` swapped for a local stub so the test can tell which `Deno`
+ * the module actually hands back.
+ */
+async function importPatchedShims(
+  directory: string,
+  source: string,
+): Promise<{ Deno: typeof Deno }> {
+  await Deno.writeTextFile(
+    `${directory}/stub-shim-deno.js`,
+    'export const Deno = { __stub: "deno" };\n',
+  );
+  await Deno.writeTextFile(
+    `${directory}/stub-shim-crypto.js`,
+    'export const crypto = { __stub: "crypto" };\n',
+  );
+  const path = `${directory}/_dnt.shims.js`;
+  await Deno.writeTextFile(
+    path,
+    source
+      .replaceAll('"@deno/shim-deno"', '"./stub-shim-deno.js"')
+      .replaceAll('"@deno/shim-crypto"', '"./stub-shim-crypto.js"'),
+  );
+  return await import(
+    `${import.meta.resolve(`file://${path}`)}?t=${Date.now()}`
+  );
+}
+
+Deno.test("unpatched DNT shims shadow the real Deno global (the bug being fixed)", async () => {
+  const directory = await Deno.makeTempDir();
+
+  try {
+    // DNT re-exports `@deno/shim-deno` unconditionally, so the published
+    // package used the Node reimplementation even when running under Deno.
+    const unpatched = await importPatchedShims(directory, GENERATED_SHIMS);
+    assertEquals(unpatched.Deno, { __stub: "deno" });
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("patchDntDenoShim makes the published shims prefer the real Deno global", async () => {
+  const directory = await Deno.makeTempDir();
+  const path = `${directory}/_dnt.shims.js`;
+
+  try {
+    await Deno.writeTextFile(path, GENERATED_SHIMS);
+    assertEquals(await patchDntDenoShim(path, { required: true }), true);
+
+    // Running under Deno, the module must resolve to the runtime's own Deno.
+    // The `@deno/shim-deno` fallback reimplements Deno.listen on top of
+    // node:net and reads `server._handle.fd`, which is null under Deno's node
+    // compatibility layer — every `veryfront dev` under Deno died there.
+    const patched = await importPatchedShims(
+      directory,
+      await Deno.readTextFile(path),
+    );
+    assertEquals(patched.Deno, globalThis.Deno);
+    assertEquals(typeof patched.Deno.listen, "function");
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("patchDntDenoShim keeps the shim fallback for runtimes without Deno", async () => {
+  const directory = await Deno.makeTempDir();
+  const path = `${directory}/_dnt.shims.js`;
+
+  try {
+    await Deno.writeTextFile(path, GENERATED_SHIMS);
+    await patchDntDenoShim(path, { required: true });
+    const patchedSource = await Deno.readTextFile(path);
+
+    // Simulate Node/Bun, where `globalThis.Deno` is absent, by pinning the
+    // native lookup to undefined before re-evaluating the module.
+    const nodeShaped = patchedSource.replace(
+      "globalThis.Deno",
+      "/* node */ undefined",
+    );
+    const patched = await importPatchedShims(directory, nodeShaped);
+    assertEquals(patched.Deno, { __stub: "deno" });
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("patchDntDenoShim is idempotent", async () => {
+  const directory = await Deno.makeTempDir();
+  const path = `${directory}/_dnt.shims.js`;
+
+  try {
+    await Deno.writeTextFile(path, GENERATED_SHIMS);
+    assertEquals(await patchDntDenoShim(path, { required: true }), true);
+    const once = await Deno.readTextFile(path);
+    assertEquals(await patchDntDenoShim(path, { required: true }), false);
+    assertEquals(await Deno.readTextFile(path), once);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("patchDntDenoShim fails closed when required DNT shim output changes", async () => {
+  const directory = await Deno.makeTempDir();
+  const path = `${directory}/_dnt.shims.js`;
+
+  try {
+    await Deno.writeTextFile(
+      path,
+      'export { Deno } from "@deno/shim-deno-next";\n',
+    );
+    await assertRejects(
+      () => patchDntDenoShim(path, { required: true }),
+      Error,
+      "does not contain the expected @deno/shim-deno re-export",
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("patchDntDenoShim skips packages without the DNT Deno shim", async () => {
+  const directory = await Deno.makeTempDir();
+  const path = `${directory}/_dnt.shims.js`;
+
+  try {
+    await Deno.writeTextFile(path, "export {};\n");
+    assertEquals(await patchDntDenoShim(path), false);
+    assertEquals(await Deno.readTextFile(path), "export {};\n");
   } finally {
     await Deno.remove(directory, { recursive: true });
   }

--- a/scripts/build/dnt-polyfill.test.ts
+++ b/scripts/build/dnt-polyfill.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals, assertRejects } from "#std/assert";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import { patchDntArgvPolyfill, patchDntDenoShim } from "./dnt-polyfill.ts";
 
 /** Verbatim shape of the `_dnt.shims.js` DNT emits for `shims: { deno: true, crypto: true }`. */
@@ -13,54 +14,56 @@ const dntGlobals = {
 export const dntGlobalThis = globalThis;
 `;
 
-Deno.test("patchDntArgvPolyfill guards missing process argv entries", async () => {
-  const directory = await Deno.makeTempDir();
-  const path = `${directory}/_dnt.polyfills.js`;
+describe("patchDntArgvPolyfill", () => {
+  it("guards missing process argv entries", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.polyfills.js`;
 
-  try {
-    await Deno.writeTextFile(
-      path,
-      'const mainUrl = "file:///" + process.argv[1].replace(/\\\\/g, "/");\n',
-    );
+    try {
+      await Deno.writeTextFile(
+        path,
+        'const mainUrl = "file:///" + process.argv[1].replace(/\\\\/g, "/");\n',
+      );
 
-    assertEquals(await patchDntArgvPolyfill(path, { required: true }), true);
-    assertEquals(
-      await Deno.readTextFile(path),
-      'const mainUrl = "file:///" + (process.argv[1] ?? "").replace(/\\\\/g, "/");\n',
-    );
-    assertEquals(await patchDntArgvPolyfill(path, { required: true }), false);
-  } finally {
-    await Deno.remove(directory, { recursive: true });
-  }
-});
+      assertEquals(await patchDntArgvPolyfill(path, { required: true }), true);
+      assertEquals(
+        await Deno.readTextFile(path),
+        'const mainUrl = "file:///" + (process.argv[1] ?? "").replace(/\\\\/g, "/");\n',
+      );
+      assertEquals(await patchDntArgvPolyfill(path, { required: true }), false);
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
 
-Deno.test("patchDntArgvPolyfill skips packages without the DNT import-meta shim", async () => {
-  const directory = await Deno.makeTempDir();
-  const path = `${directory}/_dnt.polyfills.js`;
+  it("skips packages without the DNT import-meta shim", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.polyfills.js`;
 
-  try {
-    await Deno.writeTextFile(path, "export {};\n");
-    assertEquals(await patchDntArgvPolyfill(path), false);
-    assertEquals(await Deno.readTextFile(path), "export {};\n");
-  } finally {
-    await Deno.remove(directory, { recursive: true });
-  }
-});
+    try {
+      await Deno.writeTextFile(path, "export {};\n");
+      assertEquals(await patchDntArgvPolyfill(path), false);
+      assertEquals(await Deno.readTextFile(path), "export {};\n");
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
 
-Deno.test("patchDntArgvPolyfill fails closed when required DNT output changes", async () => {
-  const directory = await Deno.makeTempDir();
-  const path = `${directory}/_dnt.polyfills.js`;
+  it("fails closed when required DNT output changes", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.polyfills.js`;
 
-  try {
-    await Deno.writeTextFile(path, "export {};\n");
-    await assertRejects(
-      () => patchDntArgvPolyfill(path, { required: true }),
-      Error,
-      "does not contain the expected process.argv[1] expression",
-    );
-  } finally {
-    await Deno.remove(directory, { recursive: true });
-  }
+    try {
+      await Deno.writeTextFile(path, "export {};\n");
+      await assertRejects(
+        () => patchDntArgvPolyfill(path, { required: true }),
+        Error,
+        "does not contain the expected process.argv[1] expression",
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
 });
 
 /**
@@ -92,107 +95,109 @@ async function importPatchedShims(
   );
 }
 
-Deno.test("unpatched DNT shims shadow the real Deno global (the bug being fixed)", async () => {
-  const directory = await Deno.makeTempDir();
+describe("patchDntDenoShim", () => {
+  it("pins the bug being fixed: unpatched DNT shims shadow the real Deno global", async () => {
+    const directory = await Deno.makeTempDir();
 
-  try {
-    // DNT re-exports `@deno/shim-deno` unconditionally, so the published
-    // package used the Node reimplementation even when running under Deno.
-    const unpatched = await importPatchedShims(directory, GENERATED_SHIMS);
-    assertEquals(unpatched.Deno, { __stub: "deno" });
-  } finally {
-    await Deno.remove(directory, { recursive: true });
-  }
-});
+    try {
+      // DNT re-exports `@deno/shim-deno` unconditionally, so the published
+      // package used the Node reimplementation even when running under Deno.
+      const unpatched = await importPatchedShims(directory, GENERATED_SHIMS);
+      assertEquals(unpatched.Deno, { __stub: "deno" });
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
 
-Deno.test("patchDntDenoShim makes the published shims prefer the real Deno global", async () => {
-  const directory = await Deno.makeTempDir();
-  const path = `${directory}/_dnt.shims.js`;
+  it("makes the published shims prefer the real Deno global", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
 
-  try {
-    await Deno.writeTextFile(path, GENERATED_SHIMS);
-    assertEquals(await patchDntDenoShim(path, { required: true }), true);
+    try {
+      await Deno.writeTextFile(path, GENERATED_SHIMS);
+      assertEquals(await patchDntDenoShim(path, { required: true }), true);
 
-    // Running under Deno, the module must resolve to the runtime's own Deno.
-    // The `@deno/shim-deno` fallback reimplements Deno.listen on top of
-    // node:net and reads `server._handle.fd`, which is null under Deno's node
-    // compatibility layer — every `veryfront dev` under Deno died there.
-    const patched = await importPatchedShims(
-      directory,
-      await Deno.readTextFile(path),
-    );
-    assertEquals(patched.Deno, globalThis.Deno);
-    assertEquals(typeof patched.Deno.listen, "function");
-  } finally {
-    await Deno.remove(directory, { recursive: true });
-  }
-});
+      // Running under Deno, the module must resolve to the runtime's own Deno.
+      // The `@deno/shim-deno` fallback reimplements Deno.listen on top of
+      // node:net and reads `server._handle.fd`, which is null under Deno's node
+      // compatibility layer — every `veryfront dev` under Deno died there.
+      const patched = await importPatchedShims(
+        directory,
+        await Deno.readTextFile(path),
+      );
+      assertEquals(patched.Deno, globalThis.Deno);
+      assertEquals(typeof patched.Deno.listen, "function");
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
 
-Deno.test("patchDntDenoShim keeps the shim fallback for runtimes without Deno", async () => {
-  const directory = await Deno.makeTempDir();
-  const path = `${directory}/_dnt.shims.js`;
+  it("keeps the shim fallback for runtimes without Deno", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
 
-  try {
-    await Deno.writeTextFile(path, GENERATED_SHIMS);
-    await patchDntDenoShim(path, { required: true });
-    const patchedSource = await Deno.readTextFile(path);
+    try {
+      await Deno.writeTextFile(path, GENERATED_SHIMS);
+      await patchDntDenoShim(path, { required: true });
+      const patchedSource = await Deno.readTextFile(path);
 
-    // Simulate Node/Bun, where `globalThis.Deno` is absent, by pinning the
-    // native lookup to undefined before re-evaluating the module.
-    const nodeShaped = patchedSource.replace(
-      "globalThis.Deno",
-      "/* node */ undefined",
-    );
-    const patched = await importPatchedShims(directory, nodeShaped);
-    assertEquals(patched.Deno, { __stub: "deno" });
-  } finally {
-    await Deno.remove(directory, { recursive: true });
-  }
-});
+      // Simulate Node/Bun, where `globalThis.Deno` is absent, by pinning the
+      // native lookup to undefined before re-evaluating the module.
+      const nodeShaped = patchedSource.replace(
+        "globalThis.Deno",
+        "/* node */ undefined",
+      );
+      const patched = await importPatchedShims(directory, nodeShaped);
+      assertEquals(patched.Deno, { __stub: "deno" });
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
 
-Deno.test("patchDntDenoShim is idempotent", async () => {
-  const directory = await Deno.makeTempDir();
-  const path = `${directory}/_dnt.shims.js`;
+  it("is idempotent", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
 
-  try {
-    await Deno.writeTextFile(path, GENERATED_SHIMS);
-    assertEquals(await patchDntDenoShim(path, { required: true }), true);
-    const once = await Deno.readTextFile(path);
-    assertEquals(await patchDntDenoShim(path, { required: true }), false);
-    assertEquals(await Deno.readTextFile(path), once);
-  } finally {
-    await Deno.remove(directory, { recursive: true });
-  }
-});
+    try {
+      await Deno.writeTextFile(path, GENERATED_SHIMS);
+      assertEquals(await patchDntDenoShim(path, { required: true }), true);
+      const once = await Deno.readTextFile(path);
+      assertEquals(await patchDntDenoShim(path, { required: true }), false);
+      assertEquals(await Deno.readTextFile(path), once);
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
 
-Deno.test("patchDntDenoShim fails closed when required DNT shim output changes", async () => {
-  const directory = await Deno.makeTempDir();
-  const path = `${directory}/_dnt.shims.js`;
+  it("fails closed when required DNT shim output changes", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
 
-  try {
-    await Deno.writeTextFile(
-      path,
-      'export { Deno } from "@deno/shim-deno-next";\n',
-    );
-    await assertRejects(
-      () => patchDntDenoShim(path, { required: true }),
-      Error,
-      "does not contain the expected @deno/shim-deno re-export",
-    );
-  } finally {
-    await Deno.remove(directory, { recursive: true });
-  }
-});
+    try {
+      await Deno.writeTextFile(
+        path,
+        'export { Deno } from "@deno/shim-deno-next";\n',
+      );
+      await assertRejects(
+        () => patchDntDenoShim(path, { required: true }),
+        Error,
+        "does not contain the expected @deno/shim-deno re-export",
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
 
-Deno.test("patchDntDenoShim skips packages without the DNT Deno shim", async () => {
-  const directory = await Deno.makeTempDir();
-  const path = `${directory}/_dnt.shims.js`;
+  it("skips packages without the DNT Deno shim", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
 
-  try {
-    await Deno.writeTextFile(path, "export {};\n");
-    assertEquals(await patchDntDenoShim(path), false);
-    assertEquals(await Deno.readTextFile(path), "export {};\n");
-  } finally {
-    await Deno.remove(directory, { recursive: true });
-  }
+    try {
+      await Deno.writeTextFile(path, "export {};\n");
+      assertEquals(await patchDntDenoShim(path), false);
+      assertEquals(await Deno.readTextFile(path), "export {};\n");
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
 });

--- a/scripts/build/dnt-polyfill.ts
+++ b/scripts/build/dnt-polyfill.ts
@@ -1,6 +1,23 @@
 const UNSAFE_ARGV_EXPRESSION = "process.argv[1].replace";
 const SAFE_ARGV_EXPRESSION = '(process.argv[1] ?? "").replace';
 
+const SHIM_DENO_REEXPORT = 'import { Deno } from "@deno/shim-deno";\n' +
+  'export { Deno } from "@deno/shim-deno";\n';
+
+/** Marker proving the Deno-global preference is already in place. */
+const NATIVE_DENO_MARKER = "dntNativeDeno";
+
+const NATIVE_DENO_PREFERENCE =
+  'import { Deno as dntShimDeno } from "@deno/shim-deno";\n' +
+  "const dntNativeDeno = globalThis.Deno;\n" +
+  "// Prefer the host runtime's own Deno. The `@deno/shim-deno` fallback exists\n" +
+  "// for Node and Bun; under Deno it shadows working native APIs with node:net\n" +
+  "// reimplementations that throw (e.g. Deno.listen reads `server._handle.fd`,\n" +
+  "// which is null on Deno's node compatibility layer).\n" +
+  'export const Deno = typeof dntNativeDeno?.version?.deno === "string"\n' +
+  "    ? dntNativeDeno\n" +
+  "    : dntShimDeno;\n";
+
 export type PatchDntArgvPolyfillOptions = {
   required?: boolean;
 };
@@ -50,6 +67,61 @@ export async function patchDntArgvPolyfill(
     throw new Error(
       `${path} contains an unrecognized process.argv[1] expression. ` +
         "Update the generated polyfill normalizer before publishing.",
+    );
+  }
+
+  return false;
+}
+
+export type PatchDntDenoShimOptions = {
+  required?: boolean;
+};
+
+/**
+ * Make DNT's generated `_dnt.shims.js` defer to the host runtime's own `Deno`.
+ *
+ * DNT re-exports `@deno/shim-deno` unconditionally, so every framework module
+ * that touches `Deno.*` got the Node reimplementation even when the published
+ * package was executed by Deno itself (`deno run -A npm:veryfront dev`). Those
+ * reimplementations are not runnable on Deno: `Deno.listen` builds a node:net
+ * server and immediately reads `server._handle.fd`, which is null on Deno's
+ * node compatibility layer, so the CLI aborted with
+ * "Cannot read properties of null (reading 'fd')" before the dev server bound.
+ *
+ * The shim stays in place for Node and Bun, which have no `Deno` global.
+ */
+export async function patchDntDenoShim(
+  path: string,
+  options: PatchDntDenoShimOptions = {},
+): Promise<boolean> {
+  let source: string;
+  try {
+    source = await Deno.readTextFile(path);
+  } catch (error) {
+    if (!options.required && error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+
+  if (source.includes(NATIVE_DENO_MARKER)) {
+    return false;
+  }
+
+  if (source.includes(SHIM_DENO_REEXPORT)) {
+    await Deno.writeTextFile(
+      path,
+      source.replace(SHIM_DENO_REEXPORT, NATIVE_DENO_PREFERENCE),
+    );
+    console.log("Patched DNT Deno shim to prefer the native Deno global");
+    return true;
+  }
+
+  if (options.required || source.includes("@deno/shim-deno")) {
+    throw new Error(
+      `${path} does not contain the expected @deno/shim-deno re-export. ` +
+        "DNT output may have changed; update the generated shim normalizer " +
+        "before publishing.",
     );
   }
 


### PR DESCRIPTION
## Symptom

The CLI was entirely non-functional under Deno, even though
https://veryfront.com/docs/code/getting-started/installation documents
`deno add npm:veryfront` as a supported install path.

```
$ deno run -A npm:veryfront@0.1.1229 dev --port 3795

✗ [unknown-error] Unknown/unclassified error
  Detail: Cannot read properties of null (reading 'fd')
  Suggestion: Check logs for more details
```

The same project ran fine under Node. Not a regression — 0.1.1228 was also
broken under Deno, with a different message.

## Root cause

The boundary reported `unknown-error` and dropped the original stack. Logging
the raw throwable in the published package gives the real one:

```
TypeError: Cannot read properties of null (reading 'fd')
    at Object.listen (node_modules/@deno/shim-deno/dist/deno/stable/functions/listen.js:44:64)
    at isPortAvailable (node_modules/veryfront/esm/cli/commands/dev/port-fallback.js:38:26)
    at clearLocalCachesIfPortFree (node_modules/veryfront/esm/cli/commands/dev/command.js:95:16)
```

dnt emits `npm/esm/_dnt.shims.js` as an *unconditional* re-export:

```js
import { Deno } from "@deno/shim-deno";
export { Deno } from "@deno/shim-deno";
```

So every framework module that touches `Deno.*` got the Node
reimplementation — including when Deno itself was executing the package. The
shim's `Deno.listen` builds a `node:net` server and immediately reads
`server._handle.fd`:

```js
const server = createServer();
const waitFor = new Promise((resolve) => server.listen(port, hostname, resolve));
// server._handle.fd is assigned immediately on .listen()
const listener = new Listener(server._handle.fd, /* … */);
```

That assumption does not hold on Deno's node compatibility layer, where
`_handle` is null. `isPortAvailable` is the first thing `dev` does, so the
process died before the server bound. Any port-binding command (`dev`,
`start`, …) hit the same wall.

## Fix

Patch the generated shim in `postBuild`, right beside the existing
`process.argv[1]` fix, so it defers to the host runtime's own `Deno` and keeps
`@deno/shim-deno` as the fallback for Node and Bun:

```js
import { Deno as dntShimDeno } from "@deno/shim-deno";
const dntNativeDeno = globalThis.Deno;
export const Deno = typeof dntNativeDeno?.version?.deno === "string"
    ? dntNativeDeno
    : dntShimDeno;
```

The first-party extension packages build through dnt with the same
`shims: { deno: true }` config and carry an identical shim file, so they get
the same patch.

`patchDntDenoShim` fails closed: if dnt's output shape ever changes, the root
build throws rather than silently shipping the broken shim again.

## Verification against the published repro

Negative control, published 0.1.1229 — `deno run -A npm:veryfront@0.1.1229 dev
--port 3795` in a `veryfront init` project outside the monorepo:

```
✗ [unknown-error] Unknown/unclassified error
  Detail: Cannot read properties of null (reading 'fd')
```

Same project, same command, with `node_modules/veryfront` replaced by this
branch's `deno task build:npm` output:

```
=== shim head of the package under test ===
import { Deno as dntShimDeno } from "@deno/shim-deno";
const dntNativeDeno = globalThis.Deno;

Veryfront (v0.1.1229)

  ✓ Ready in 1.0s
  http://veryfront.me:3795
```

`--verbose` confirms it now walks all the way through route discovery and
binds the port instead of aborting after "Using local filesystem (no proxy
mode)".

## Tests

`scripts/build/dnt-polyfill.test.ts` (already in `deno task test:scripts`).
The tests evaluate the shim module for real, with `@deno/shim-deno` swapped
for a local stub, so they assert which `Deno` the module actually hands back
rather than matching on source text:

- `unpatched DNT shims shadow the real Deno global (the bug being fixed)` —
  pins the pre-fix behaviour; fails if the patch is ever dropped
- `patchDntDenoShim makes the published shims prefer the real Deno global`
- `patchDntDenoShim keeps the shim fallback for runtimes without Deno`
- idempotency, fail-closed, and no-op-when-absent cases

Confirmed red before the fix (`does not provide an export named
'patchDntDenoShim'`), green after.

## Scope

Build-script only; no `src/` or docs changes, so nothing needs to be checked
on the live docs site for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for generated packages running in environments with native Deno APIs.
  * Prevented generated compatibility shims from overriding available native functionality.
  * Added safer handling for missing, already-patched, or unexpected generated files.

* **Tests**
  * Expanded coverage for compatibility behavior, fallback handling, idempotent patching, and missing-output scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->