### PR TITLE
fix(cli): point the token prompt at the current API keys page

### DIFF
--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -7,7 +7,12 @@ import { isTTY, promptUser } from "../utils/index.ts";
 import { brand, dim, error, warning } from "../ui/colors.ts";
 import { createSpinner, type SpinnerController } from "../ui/progress.ts";
 import { PromptInterruptedError, select } from "../utils/terminal-select.ts";
-import { DEFAULT_CALLBACK_PORT, DEFAULT_LOGIN_TIMEOUT_MS, getApiUrl } from "../shared/constants.ts";
+import {
+  API_KEYS_URL,
+  DEFAULT_CALLBACK_PORT,
+  DEFAULT_LOGIN_TIMEOUT_MS,
+  getApiUrl,
+} from "../shared/constants.ts";
 import { createSuccessEnvelope, isJsonMode, outputJson } from "../shared/json-output.ts";
 import { isInteractive } from "../shared/interactive.ts";
 
@@ -242,7 +247,7 @@ async function loginWithOAuth(
 async function loginWithToken(): Promise<string | null> {
   console.log();
   console.log("  " + brand("Enter your API token"));
-  console.log("  " + dim("You can get a token from veryfront.com/settings/api-keys"));
+  console.log("  " + dim(`You can get a token from ${API_KEYS_URL}`));
   console.log();
 
   const token = (await promptUser("  API token: ")).trim();

--- a/cli/commands/demo/demo.ts
+++ b/cli/commands/demo/demo.ts
@@ -32,6 +32,7 @@ import {
 import { canOpenBrowser, openBrowser } from "../../auth/browser.ts";
 import { getCallbackUrl, startCallbackServer } from "../../auth/callback-server.ts";
 import {
+  API_KEYS_URL,
   DEFAULT_CALLBACK_PORT,
   DEFAULT_LOGIN_TIMEOUT_MS,
   resolveCliApiUrl,
@@ -165,7 +166,7 @@ async function demoLogin(preselectedMethod?: AuthMethod): Promise<boolean> {
 
   if (method === "token") {
     console.log(`  ${brand("Enter your API token")}`);
-    console.log(`  ${dim("You can get a token from veryfront.com/settings/api-keys")}`);
+    console.log(`  ${dim(`You can get a token from ${API_KEYS_URL}`)}`);
     console.log();
 
     const tokenInput = promptSync("  API token:") ?? "";

--- a/cli/shared/constants.test.ts
+++ b/cli/shared/constants.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  API_KEYS_URL,
   CONFIG_DIR_NAME,
   DEFAULT_API_URL,
   DEFAULT_CALLBACK_PORT,
@@ -11,6 +12,7 @@ import {
   TOKEN_FILE_NAME,
   TOKEN_FILE_PERMISSIONS,
 } from "./constants.ts";
+import { readTextFile } from "#veryfront/platform/compat/fs.ts";
 import type { EnvironmentConfig } from "#veryfront/config/environment-config.ts";
 
 describe("cli/shared/constants", () => {
@@ -42,6 +44,35 @@ describe("cli/shared/constants", () => {
 
     it("should have TOKEN_FILE_NAME", () => {
       assertEquals(TOKEN_FILE_NAME, "token");
+    });
+  });
+
+  describe("API_KEYS_URL", () => {
+    // Regression: the token prompts printed veryfront.com/settings/api-keys,
+    // which 301-redirects to veryfront.com/account/api-keys.
+    it("points at the current dashboard API keys page", () => {
+      assertEquals(API_KEYS_URL, "veryfront.com/account/api-keys");
+    });
+
+    it("is the only API keys URL cited by the interactive token prompts", async () => {
+      const promptSources = ["../auth/login.ts", "../commands/demo/demo.ts"];
+
+      for (const source of promptSources) {
+        const contents = await readTextFile(
+          new URL(source, import.meta.url).pathname,
+        );
+
+        assertStringIncludes(
+          contents,
+          "You can get a token from ",
+          `${source} should still print the API token hint`,
+        );
+        assertEquals(
+          contents.includes("veryfront.com/settings/api-keys"),
+          false,
+          `${source} must not cite the redirecting veryfront.com/settings/api-keys path`,
+        );
+      }
     });
   });
 

--- a/cli/shared/constants.ts
+++ b/cli/shared/constants.ts
@@ -43,6 +43,12 @@ export const DEFAULT_LOGIN_TIMEOUT_MS = 120_000;
 export const SHUTDOWN_TIMEOUT_MS = 3_000;
 export const REQUEST_TIMEOUT_MS = 3_000;
 
+/**
+ * Dashboard page where users mint a Veryfront API token.
+ * `/settings/api-keys` is a legacy path that 301-redirects here.
+ */
+export const API_KEYS_URL = "veryfront.com/account/api-keys";
+
 export const CONFIG_DIR_NAME = "veryfront";
 export const TOKEN_FILE_NAME = "token";
 export const TOKEN_FILE_PERMISSIONS = 0o600;


### PR DESCRIPTION
## Problem

Round-2 DX verification finding [20]. The interactive token prompt in `veryfront login` (and the same prompt inside `veryfront demo`) tells you:

```
  Enter your API token
  You can get a token from veryfront.com/settings/api-keys
```

That path has moved:

```
$ curl -sS -o /dev/null -w '%{http_code} -> %{redirect_url}' https://veryfront.com/settings/api-keys
301 -> https://veryfront.com/account/api-keys
```

A browser still lands on the right page, but the CLI is citing a stale path, and anyone typing it by hand from the terminal gets a redirect instead of the canonical URL.

Reproduced against **published 0.1.1229** (npm `veryfront@0.1.1229`, installed in a sandbox outside the monorepo so Deno import maps could not resolve to local source), driven through the auth-method menu on a real pty:

```
  ✓ API Token

  Enter your API token
  You can get a token from veryfront.com/settings/api-keys
```

## Fix

Add `API_KEYS_URL` to `cli/shared/constants.ts` set to `veryfront.com/account/api-keys`, and render it from both prompt sites (`cli/auth/login.ts`, `cli/commands/demo/demo.ts`) so the two copies cannot drift apart again. No behaviour change beyond the printed string.

## Tests

`cli/shared/constants.test.ts` gains two cases:

1. `API_KEYS_URL` equals `veryfront.com/account/api-keys`.
2. Neither prompt source cites the redirecting `veryfront.com/settings/api-keys` path (while still printing the hint at all).

Both fail on the pre-fix tree — confirmed by first landing the constant with the old value:

```
FAILED | 0 passed (14 steps) | 1 failed (3 steps)
AssertionError: ../auth/login.ts must not cite the redirecting veryfront.com/settings/api-keys path
```

## Verified against the original repro

Same pty driver, this branch's build (`deno run -A cli/main.ts login`):

```
  ✓ API Token

  Enter your API token
  You can get a token from veryfront.com/account/api-keys
```

`https://veryfront.com/account/api-keys` returns `302 -> /sign-in?from=%2Faccount%2Fapi-keys` when signed out — i.e. it is the real page behind auth, not another moved path.

## Scope

Framework-only. No docs change is needed: `docs/code/**` in veryfront-docs contains no reference to this URL, and `docs/api-reference` does not cover `cli/`, so no `deno task docs` regeneration.