### PR TITLE
fix(cli): accept a bare tool name for veryfront install

### DIFF
--- a/cli/commands/install/command-help.ts
+++ b/cli/commands/install/command-help.ts
@@ -4,7 +4,7 @@ export const installHelp: CommandHelp = {
   name: "install",
   category: "project",
   description: "Install AI assistant integrations (Cursor, Claude Code, etc.)",
-  usage: "veryfront install [options]",
+  usage: "veryfront install [tools] [options]",
   options: [
     {
       flag: "--target <tools>",
@@ -22,6 +22,7 @@ export const installHelp: CommandHelp = {
   ],
   examples: [
     "veryfront install                              # Interactive multi-select",
+    "veryfront install agents                       # Same as --target agents",
     "veryfront install --target cursor",
     "veryfront install --target all",
     "veryfront install --target cursor,claude-code --force",
@@ -38,7 +39,7 @@ export const uninstallHelp: CommandHelp = {
   name: "uninstall",
   category: "project",
   description: "Remove AI assistant integrations",
-  usage: "veryfront uninstall [options]",
+  usage: "veryfront uninstall [tools] [options]",
   options: [
     {
       flag: "--target <tools>",

--- a/cli/commands/install/command-help.ts
+++ b/cli/commands/install/command-help.ts
@@ -53,6 +53,7 @@ export const uninstallHelp: CommandHelp = {
   ],
   examples: [
     "veryfront uninstall                            # Interactive multi-select",
+    "veryfront uninstall agents                     # Same as --target agents",
     "veryfront uninstall --target cursor",
     "veryfront uninstall --target all",
     "veryfront uninstall --global",

--- a/cli/commands/install/handler.test.ts
+++ b/cli/commands/install/handler.test.ts
@@ -1,8 +1,15 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { handleInstallCommand, handleUninstallCommand } from "./handler.ts";
+import { handleInstallCommand, handleUninstallCommand, parseInstallArgs } from "./handler.ts";
+import { parseCliArgs } from "#cli/shared/args";
 import type { ParsedArgs } from "#cli/shared/types";
+
+function parseCommandLine(argv: string[]) {
+  const result = parseInstallArgs(parseCliArgs(argv));
+  if (!result.success) throw result.error;
+  return result.data;
+}
 
 function extractInstallArgs(args: ParsedArgs) {
   const target = typeof args.target === "string" ? args.target : undefined;
@@ -115,6 +122,34 @@ describe("commands/install/handler", () => {
     it("does not use -y as force alias (unlike clean/lock)", () => {
       const result = extractInstallArgs({ _: ["install"], y: true });
       assertEquals(result.force, false);
+    });
+  });
+
+  describe("bare positional target", () => {
+    it("reads the target from the first positional argument", () => {
+      assertEquals(parseCommandLine(["install", "agents"]).target, "agents");
+    });
+
+    it("reads a comma-separated positional target", () => {
+      assertEquals(
+        parseCommandLine(["install", "cursor,claude-code"]).target,
+        "cursor,claude-code",
+      );
+    });
+
+    it("lets --target win over the positional", () => {
+      assertEquals(
+        parseCommandLine(["install", "agents", "--target", "cursor"]).target,
+        "cursor",
+      );
+    });
+
+    it("leaves the target unset when no positional is given", () => {
+      assertEquals(parseCommandLine(["install"]).target, undefined);
+    });
+
+    it("reads the positional for uninstall too", () => {
+      assertEquals(parseCommandLine(["uninstall", "agents"]).target, "agents");
     });
   });
 

--- a/cli/commands/install/handler.ts
+++ b/cli/commands/install/handler.ts
@@ -19,7 +19,7 @@ const getInstallArgsSchema = defineSchema((v) =>
 const InstallArgsSchema = lazySchema(getInstallArgsSchema);
 
 export const parseInstallArgs = createArgParser(InstallArgsSchema, {
-  target: { keys: ["target", "t"], type: "string" },
+  target: { keys: ["target", "t"], type: "string", positional: 0 },
   global: { keys: ["global", "g"], type: "boolean" },
   force: CommonArgs.force,
 });

--- a/cli/commands/install/install.integration.test.ts
+++ b/cli/commands/install/install.integration.test.ts
@@ -46,6 +46,22 @@ describe("install command integration", () => {
     };
   }
 
+  async function runInstallArgs(
+    args: string[],
+  ): Promise<{ code: number; output: string }> {
+    const cliPath = new URL("../../main.ts", import.meta.url).pathname;
+    const result = await runCommand("deno", {
+      args: ["run", "--allow-all", cliPath, "install", ...args],
+      cwd: tempDir,
+      capture: true,
+    });
+
+    return {
+      code: result.code,
+      output: (result.stdout ?? "") + (result.stderr ?? ""),
+    };
+  }
+
   async function assertFileExists(path: string): Promise<void> {
     assertEquals(await exists(path), true);
   }
@@ -143,6 +159,38 @@ describe("install command integration", () => {
         "veryfront schema --json",
         "veryfront routes",
       ]);
+    });
+  });
+
+  describe("bare positional target", () => {
+    it("installs AGENTS.md for `veryfront install agents`", async () => {
+      const { code } = await runInstallArgs(["agents", "--force", "--no-input"]);
+      assertEquals(code, 0);
+
+      await assertFileExists(join(tempDir, "AGENTS.md"));
+      await assertFileNotExists(join(tempDir, "SKILL.md"));
+    });
+
+    it("installs the Claude Code integration for `veryfront install claude-code`", async () => {
+      const { code } = await runInstallArgs(["claude-code", "--force", "--no-input"]);
+      assertEquals(code, 0);
+
+      await assertFileExists(join(tempDir, ".claude/CLAUDE.md"));
+      await assertFileNotExists(join(tempDir, "SKILL.md"));
+    });
+
+    it("prefers --target when both a flag and a positional are given", async () => {
+      const { code } = await runInstallArgs([
+        "agents",
+        "--target",
+        "cursor",
+        "--force",
+        "--no-input",
+      ]);
+      assertEquals(code, 0);
+
+      await assertFileExists(join(tempDir, ".cursorrules"));
+      await assertFileNotExists(join(tempDir, "AGENTS.md"));
     });
   });
 

--- a/cli/commands/install/install.integration.test.ts
+++ b/cli/commands/install/install.integration.test.ts
@@ -192,6 +192,14 @@ describe("install command integration", () => {
       await assertFileExists(join(tempDir, ".cursorrules"));
       await assertFileNotExists(join(tempDir, "AGENTS.md"));
     });
+
+    it("fails instead of installing something else for an unknown target", async () => {
+      const { code } = await runInstallArgs(["unknown-tool", "--force", "--no-input"]);
+      assertEquals(code, 1);
+
+      await assertFileNotExists(join(tempDir, "SKILL.md"));
+      await assertFileNotExists(join(tempDir, "AGENTS.md"));
+    });
   });
 
   describe("all targets", () => {

--- a/tests/docs/cli-install-commands.test.ts
+++ b/tests/docs/cli-install-commands.test.ts
@@ -7,10 +7,10 @@
  * unpublished notes (`docs/internal`, `docs/rfcs`, `docs/evidence`) are out of
  * scope — they may quote a broken invocation deliberately.
  *
- * The install command reads its target from `--target` only. A bare positional
- * (`veryfront install agents`) is silently ignored and the command falls back to
- * auto-detection, which in a fresh project writes `SKILL.md` instead of the
- * `AGENTS.md` the docs describe.
+ * The install command takes its target from `--target` or from the first
+ * positional argument (`veryfront install agents`). A command line that selects
+ * neither falls back to auto-detection, which in a fresh project writes
+ * `SKILL.md` instead of the `AGENTS.md` the docs describe.
  */
 
 import "#veryfront/schemas/_test-setup.ts";


### PR DESCRIPTION
## Symptom (reproduced on published 0.1.1229)

```
$ npm i veryfront@0.1.1229
$ mkdir t && cd t && printf '{"name":"t","type":"module"}' > package.json
$ mkdir app && printf 'export default function P(){return <div/>}' > app/page.tsx
$ veryfront install agents --no-input

  Installing AI integrations...

  ✓ SKILL.md          # <- not AGENTS.md

  ✓ Your AI assistants now know Veryfront!
$ echo $?
0
```

`veryfront install` read its target from `--target` only. A bare positional was
dropped on the floor, the command fell through to auto-detection, and in a fresh
project auto-detection resolves to `SKILL.md`. No warning, no error, exit 0. The
same silent drop hit every documented variant (`veryfront install claude-code`,
`... cursor`, ...).

That matters because the **live** docs still print the positional form:

```
$ curl -s -H 'Accept: text/markdown' https://veryfront.com/docs/code/guides/coding-agents.md | grep 'veryfront install'
veryfront install agents
veryfront install claude-code
...
```

## Why the previous doc fix did not make the symptom go away

#3558 (`125f290e2`) rewrote `docs/getting-started/installation.md` and
`docs/guides/coding-agents.md` in **this** repo to use `--target`. That landed
and is correct. But `veryfront.com/docs/code/**` is served from the
`veryfront-docs` repo, which receives these pages through a periodic sync commit
(`docs: update code docs from veryfront-code@<sha>`). The last sync predates
#3558, so the live pages still print the broken form and will keep printing it
until the next sync. A docs-only fix therefore could not close this: readers
follow the deployed page, not the source page.

This PR fixes the CLI instead, so the invocation the live docs print does the
right thing regardless of when the sync lands.

## Fix

`cli/shared/args.ts` already supports positional arg specs; the install spec
simply never declared one. One line:

```ts
target: { keys: ["target", "t"], type: "string", positional: 0 },
```

- `veryfront install agents` now resolves the same target as
  `veryfront install --target agents`.
- `--target` still wins when both a flag and a positional are given.
- An unknown positional (`veryfront install bogus`) now fails validation and
  exits 1 rather than quietly installing something else.
- `uninstall` shares the parser, so `veryfront uninstall cursor` works too.
- Help usage updated to `veryfront install [tools] [options]` with an example.

`docs/**` is left as #3558 wrote it — `--target` is still the form to
recommend for scripts, and the docs contract test in
`tests/docs/cli-install-commands.test.ts` keeps enforcing that every documented
command actually selects a target. Its header comment is updated, since the
"positional is silently ignored" statement it was written against is no longer
true.

## Regression tests (written first, confirmed red)

`cli/commands/install/handler.test.ts` — bare positional resolves to the target,
comma-separated positional, `--target` beats the positional, no positional
leaves it unset, same for `uninstall`.

Before the fix:

```
commands/install/handler ... bare positional target ... reads the target from the first positional argument
error: AssertionError: Values are not equal.
-   undefined
+   "agents"
FAILED | 0 passed (27 steps) | 1 failed (4 steps)
```

`cli/commands/install/install.integration.test.ts` — drives the real CLI binary
in a temp dir and asserts `veryfront install agents --force --no-input` writes
`AGENTS.md` and not `SKILL.md` (plus the `claude-code` and flag-beats-positional
cases). Before the fix both new end-to-end cases failed on the missing
`AGENTS.md` / `.claude/CLAUDE.md`.

## Original symptom, re-run against this build

```
$ cd /tmp/t2   # fresh project, same shape as the repro above
$ deno run --allow-all <worktree>/cli/main.ts install agents --no-input

  Installing AI integrations...

  ✓ AGENTS.md

exit=0
$ ls
AGENTS.md  app  package.json
```

`veryfront install bogus --no-input` now exits 1 instead of writing `SKILL.md`.

## Follow-up owned elsewhere

The `veryfront-docs` sync still needs to run for the live pages to match this
repo's docs. After that sync,
`https://veryfront.com/docs/code/getting-started/installation` and
`https://veryfront.com/docs/code/guides/coding-agents` should show
`veryfront install --target agents`. With this PR shipped, the currently-live
positional form is no longer wrong either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Install and uninstall commands now accept optional positional tool targets.
  * Added support for comma-separated targets.
  * Explicit `--target` options take precedence over positional targets.
  * Updated command help with the new syntax and usage examples.

* **Documentation**
  * Clarified target selection, auto-detection behavior, and possible `SKILL.md` creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->