### PR TITLE
fix(dev): probe ports through the real Deno runtime, not the dnt shim

### DIFF
--- a/cli/commands/dev/port-fallback.test.ts
+++ b/cli/commands/dev/port-fallback.test.ts
@@ -127,6 +127,31 @@ describe("cli/commands/dev/port-fallback", () => {
     });
   });
 
+  describe("published npm build", () => {
+    // dnt rewrites every bare `Deno.` call site in the published npm package
+    // into `@deno/shim-deno`, whose Node-backed `listen()` reads
+    // `server._handle.fd` - null under Deno's `node:net`. A CLI installed with
+    // `deno install -gArf npm:veryfront` runs that package on a real Deno, so
+    // the runtime check passed while the call reached the shim, and
+    // `veryfront dev` died on "Cannot read properties of null (reading 'fd')"
+    // before printing a URL. Deno and the shim are the same object in-repo, so
+    // the invariant has to be asserted over the source dnt actually rewrites.
+    it("probes ports through getDenoRuntime(), not the bare global dnt rewrites", async () => {
+      const source = await Deno.readTextFile(new URL("./port-fallback.ts", import.meta.url));
+      const code = source
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/(["'`])(?:\\.|(?!\1)[^\\])*\1/g, '""')
+        .replace(/\/\/[^\n]*/g, "");
+
+      assertEquals(
+        code.match(/(^|[^.\w$])Deno\s*\./g) ?? [],
+        [],
+        "reach the runtime via getDenoRuntime() - dnt rewrites bare Deno calls to @deno/shim-deno",
+      );
+      assertStringIncludes(code, "getDenoRuntime()");
+    });
+  });
+
   describe("isPortInUseError", () => {
     it("recognises the address-in-use error the runtime actually throws", () => {
       const held = Deno.listen({ hostname: "127.0.0.1", port: 0 });

--- a/cli/commands/dev/port-fallback.ts
+++ b/cli/commands/dev/port-fallback.ts
@@ -14,7 +14,7 @@
 
 import { LOCALHOST } from "veryfront/config";
 import { PORT_IN_USE } from "veryfront/errors";
-import { isDeno } from "veryfront/platform";
+import { getDenoRuntime } from "veryfront/platform";
 
 /** How many consecutive ports to try before giving up. */
 export const MAX_PORT_FALLBACK_ATTEMPTS = 10;
@@ -33,12 +33,22 @@ export function isPortInUseError(error: unknown): boolean {
     message.includes("eaddrinuse") || message.includes("address already in use");
 }
 
-/** Binds `port` and releases it again, to see whether the dev server could have it. */
+/**
+ * Binds `port` and releases it again, to see whether the dev server could have it.
+ *
+ * The Deno runtime is read through `getDenoRuntime()` rather than through the
+ * `Deno` global directly: dnt rewrites every bare `Deno.` reference in the
+ * published npm build into `@deno/shim-deno`, whose Node-backed `listen()`
+ * reads `server._handle.fd` - null under Deno's `node:net`. A CLI installed
+ * with `deno install -gArf npm:veryfront` runs that build on a real Deno, so
+ * the shim was reached and `veryfront dev` died on "Cannot read properties of
+ * null (reading 'fd')" before it ever printed a URL.
+ */
 export async function isPortAvailable(port: number): Promise<boolean> {
-  if (isDeno) {
+  const deno = getDenoRuntime();
+  if (deno) {
     try {
-      // @ts-ignore - Deno global
-      Deno.listen({ hostname: LOCALHOST.IPV4, port }).close();
+      deno.listen({ hostname: LOCALHOST.IPV4, port }).close();
       return true;
     } catch (error) {
       if (isPortInUseError(error)) return false;


### PR DESCRIPTION
## Symptom

A CLI installed the way the installation guide now tells people to install it —
`deno install -gArf npm:veryfront` (added by 0d3697648 / #3569) — produces a
working `veryfront`, but `veryfront dev` dies before printing a URL:

```
✗ [unknown-error] Unknown/unclassified error

  Detail: Cannot read properties of null (reading 'fd')
  Suggestion: Check logs for more details
```

`build`, `serve`, `routes` and `doctor` all succeed under the same install. The
npm-global install of the identical version (`npm i -g veryfront@0.1.1229`) runs
`dev` fine, so the defect is specific to running the published package on Deno.

## Root cause

Recovered by unwrapping the boundary error against published `0.1.1229`:

```
TypeError: Cannot read properties of null (reading 'fd')
    at Object.listen (node_modules/@deno/shim-deno/dist/deno/stable/functions/listen.js:44:64)
    at isPortAvailable (node_modules/veryfront/esm/cli/commands/dev/port-fallback.js:38:26)
    at clearLocalCachesIfPortFree (node_modules/veryfront/esm/cli/commands/dev/command.js:95:16)
```

`isPortAvailable` branched on `isDeno` and then called `Deno.listen`. dnt
rewrites every bare `Deno.` call site in the published npm package into
`@deno/shim-deno` — the emitted line really is `dntShim.Deno.listen(...)` — and
that shim's Node-backed `listen()` reads `server._handle.fd`, which is null
under Deno's `node:net`.

The two halves therefore disagreed on a Deno-global install:

- `isDeno` is computed from the **real** global (`Reflect.get(globalThis, "Deno")`),
  so it was `true`;
- the `Deno` identifier in the same function had been rewritten to the **shim**.

`runtime.ts` even documents `isDeno` as "true if running in the real Deno runtime
rather than a dnt shim" — the constant was right, the call site was not. The
resulting `TypeError` carries nothing the error registry can match, which is why
the user got `unknown-error` rather than anything actionable.

`port-fallback.js` was the only `dntShim.Deno` reference in the whole `dev`
command tree, which is exactly why only `dev` was affected.

## Fix

Read the runtime with `getDenoRuntime()` — the accessor that already exists for
this, used the same way in `cli/commands/serve/split-mode.ts` and elsewhere. It
resolves the real global through `Reflect.get`, which dnt leaves alone. Under
Node it returns `undefined` and the existing `node:net` path still runs.

## Regression test

Deno and the shim are the same object in-repo, so no in-process test can tell
`Deno.listen` from `getDenoRuntime().listen` here — the divergence only exists in
the dnt output. The test therefore asserts the invariant over the source dnt
actually rewrites: comment- and string-stripped `port-fallback.ts` must contain
no bare `Deno.` call site, and must reach the runtime via `getDenoRuntime()`.

Verified red before the fix, for the right reason (1 offender: `Deno.listen`),
and green after.

## Verified against the published repro

Reproduced first against published `0.1.1229` outside the platform checkout:

```
DENO_INSTALL_ROOT=/tmp/r2-25-sandbox/d deno install -gArf -n vf25 npm:veryfront@0.1.1229
vf25 init app25 --template minimal
cd app25 && vf25 dev
# -> ✗ [unknown-error] ... Cannot read properties of null (reading 'fd')
```

Then re-ran the finding's own command with only this change applied to the
published artifact's emitted `port-fallback.js`:

```
  ✓ Ready in 834ms
  http://veryfront.me:3000
```

## Notes

No doc change is needed here; the installation guide's `deno install -gArf
npm:veryfront` instruction is correct and this makes it true for `dev` too.
Separately, #3569 is merged but the live installation page still does not show
the Deno section — that deployment gap is tracked by another finding, not this PR.
