### PR TITLE
fix(cli): explain an unsupported Node version instead of crashing

### DIFF
--- a/cli/node-engine-precondition.test.ts
+++ b/cli/node-engine-precondition.test.ts
@@ -1,0 +1,101 @@
+import { assert, assertEquals, assertStringIncludes } from "#std/assert";
+import { describe, it } from "#std/testing/bdd";
+
+import { MINIMUM_NODE_VERSION } from "../scripts/build/runtime-support.ts";
+import {
+  formatUnsupportedNodeMessage,
+  meetsMinimumNodeVersion,
+  MINIMUM_NODE_VERSION as SHIM_MINIMUM_NODE_VERSION,
+} from "../scripts/build/node-engine-precondition.js";
+
+const wrapperSource = await Deno.readTextFile(
+  new URL("../scripts/build/bin-wrapper.js", import.meta.url),
+);
+
+describe("node engine precondition", () => {
+  it("keeps the shim floor locked to the single runtime-version contract", () => {
+    assertEquals(SHIM_MINIMUM_NODE_VERSION, MINIMUM_NODE_VERSION);
+  });
+
+  it("rejects Node releases below the floor", () => {
+    // 18.18.0 is the release dogfooded in the report: it predates
+    // process.getBuiltinModule (Node 22.3.0), which the compat layer requires.
+    assertEquals(meetsMinimumNodeVersion("18.18.0"), false);
+    assertEquals(meetsMinimumNodeVersion("20.11.1"), false);
+    assertEquals(meetsMinimumNodeVersion("22.2.0"), false);
+    assertEquals(meetsMinimumNodeVersion("22.2.99"), false);
+  });
+
+  it("accepts the floor and newer Node releases", () => {
+    assertEquals(meetsMinimumNodeVersion("22.3.0"), true);
+    assertEquals(meetsMinimumNodeVersion("22.10.0"), true);
+    assertEquals(meetsMinimumNodeVersion("24.0.0"), true);
+    assertEquals(meetsMinimumNodeVersion("25.2.1"), true);
+  });
+
+  it("compares version segments numerically, not lexicographically", () => {
+    assertEquals(meetsMinimumNodeVersion("9.0.0"), false);
+    assertEquals(meetsMinimumNodeVersion("100.0.0"), true);
+  });
+
+  it("fails open when the version is not a plain release triple", () => {
+    // The gate only exists to explain a crash. It must never be the reason a
+    // runtime that would have worked is refused, so anything it cannot parse
+    // with confidence is allowed through to the normal startup path.
+    assertEquals(meetsMinimumNodeVersion(undefined), true);
+    assertEquals(meetsMinimumNodeVersion(""), true);
+    assertEquals(meetsMinimumNodeVersion("not-a-version"), true);
+    assertEquals(meetsMinimumNodeVersion("22.3.0-nightly20240604"), true);
+  });
+
+  it("classifies the failure with the required version, the actual version, a fix and docs", () => {
+    const message = formatUnsupportedNodeMessage("18.18.0");
+
+    assertStringIncludes(message, "✗");
+    assertStringIncludes(message, `Veryfront requires Node.js ${MINIMUM_NODE_VERSION} or later`);
+    assertStringIncludes(message, "18.18.0");
+    assertStringIncludes(message, "Suggestion:");
+    assertStringIncludes(
+      message,
+      "https://veryfront.com/docs/code/getting-started/installation",
+    );
+  });
+
+  it("never leaks the raw compat assertion users cannot act on", () => {
+    const message = formatUnsupportedNodeMessage("18.18.0");
+    assertEquals(message.includes("node:util/types"), false);
+    assertEquals(message.includes("ModuleJob"), false);
+  });
+});
+
+describe("bin wrapper", () => {
+  const gateIndex = wrapperSource.indexOf("if (!meetsMinimumNodeVersion(");
+  const fallbackIndex = wrapperSource.indexOf("async function runJsFallback");
+  const cliImportIndex = wrapperSource.indexOf("../esm/cli/main.js");
+  const nativeSpawnIndex = wrapperSource.indexOf("spawn(nativeBinary");
+
+  it("gates before the bundled JS CLI loads", () => {
+    assert(gateIndex >= 0, "bin-wrapper.js must run the Node engine precondition");
+    assert(cliImportIndex >= 0, "bin-wrapper.js must still import the bundled CLI");
+    assert(
+      gateIndex < cliImportIndex,
+      "the engine gate must run before the framework module graph loads, " +
+        "otherwise the compat assertion throws first",
+    );
+  });
+
+  it("keeps the gate inside the JS fallback so the native binary stays ungated", () => {
+    // The postinstall-downloaded native binary is self-contained and runs fine
+    // on Node releases below the floor. Hoisting this gate to module scope
+    // would refuse those installs for no reason.
+    assert(nativeSpawnIndex >= 0, "bin-wrapper.js must still spawn the native binary");
+    assert(
+      fallbackIndex >= 0 && gateIndex > fallbackIndex,
+      "the engine gate must live inside runJsFallback, not at module scope",
+    );
+  });
+
+  it("exits non-zero on an unsupported runtime", () => {
+    assertStringIncludes(wrapperSource, "process.exit(1)");
+  });
+});

--- a/scripts/build/bin-wrapper.js
+++ b/scripts/build/bin-wrapper.js
@@ -3,6 +3,10 @@ import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  formatUnsupportedNodeMessage,
+  meetsMinimumNodeVersion,
+} from "./node-engine-precondition.js";
 
 await import("../esm/_dnt.polyfills.js");
 
@@ -13,6 +17,14 @@ const nativeBinary = join(
 );
 
 async function runJsFallback() {
+  // Only the bundled JS CLI needs a modern Node: the compat layer reads
+  // process.getBuiltinModule (Node 22.3.0+) while its module graph loads and
+  // otherwise throws an internal assertion with no version, fix or docs link.
+  // The native binary above is self-contained, so it stays ungated.
+  if (!meetsMinimumNodeVersion(process.versions.node)) {
+    console.error(formatUnsupportedNodeMessage(process.versions.node));
+    process.exit(1);
+  }
   await import("../esm/cli/main.js");
 }
 

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -285,6 +285,12 @@ await build({
 		await Deno.mkdir("./npm/bin", { recursive: true });
 		await Deno.copyFile("./scripts/build/bin-wrapper.js", "./npm/bin/veryfront.js");
 		await Deno.chmod("./npm/bin/veryfront.js", 0o755);
+		// The shim imports this before any framework module, so it has to sit
+		// beside it and stay loadable on Node releases below the supported floor.
+		await Deno.copyFile(
+			"./scripts/build/node-engine-precondition.js",
+			"./npm/bin/node-engine-precondition.js",
+		);
 
 		// Copy package documentation files (must exist at repo root)
 		await Deno.mkdir("./npm/assets", { recursive: true });

--- a/scripts/build/node-engine-precondition.js
+++ b/scripts/build/node-engine-precondition.js
@@ -1,0 +1,80 @@
+/**
+ * Node.js engine precondition for the published `veryfront` bin shim.
+ *
+ * This module is copied verbatim next to `bin/veryfront.js` in the npm package
+ * and is imported before any framework module. It therefore has to run on every
+ * Node release a user might have installed, including ones far below the
+ * supported floor:
+ *
+ *   - no dependencies, no framework imports, no polyfills
+ *   - nothing newer than ES2020 syntax
+ *
+ * Without this gate the first framework module to load is
+ * `src/platform/compat/native-brand-checks`, which needs
+ * `process.getBuiltinModule` (added in Node 22.3.0). On older Node it throws
+ * "The current server runtime does not expose complete node:util/types brand
+ * checks" — an internal assertion with no version, no fix and no docs link.
+ *
+ * Keep MINIMUM_NODE_VERSION in sync with `runtime-support.ts`; a test locks the
+ * two together.
+ */
+
+/** Minimum Node.js release supported by the published npm package. */
+export const MINIMUM_NODE_VERSION = "22.3.0";
+
+const DOCS_URL = "https://veryfront.com/docs/code/getting-started/installation";
+const RELEASE_TRIPLE = /^(\d+)\.(\d+)\.(\d+)$/;
+
+function parseReleaseTriple(version) {
+  if (typeof version !== "string") return undefined;
+  const match = RELEASE_TRIPLE.exec(version.trim());
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * Whether `version` is at or above `minimum`.
+ *
+ * Fails open: a version this cannot parse as a plain `major.minor.patch`
+ * release is allowed through. The gate exists to explain a crash, so it must
+ * never become the reason a runtime that would have worked is refused.
+ *
+ * @param {string | undefined} version e.g. `process.versions.node`
+ * @param {string} [minimum]
+ * @returns {boolean}
+ */
+export function meetsMinimumNodeVersion(version, minimum = MINIMUM_NODE_VERSION) {
+  const actual = parseReleaseTriple(version);
+  const floor = parseReleaseTriple(minimum);
+  if (!actual || !floor) return true;
+
+  for (let index = 0; index < 3; index++) {
+    if (actual[index] !== floor[index]) return actual[index] > floor[index];
+  }
+  return true;
+}
+
+/**
+ * Human-readable, actionable message for an unsupported Node release.
+ *
+ * Mirrors the CLI error shape (`✗` headline, indented Detail / Suggestion /
+ * Docs) so an engine failure reads like every other classified Veryfront
+ * error rather than a raw stack trace.
+ *
+ * @param {string | undefined} version e.g. `process.versions.node`
+ * @param {string} [minimum]
+ * @returns {string}
+ */
+export function formatUnsupportedNodeMessage(version, minimum = MINIMUM_NODE_VERSION) {
+  const detected = typeof version === "string" && version.trim() !== ""
+    ? `Node.js ${version.trim()}`
+    : "an unknown Node.js version";
+
+  return [
+    `  ✗ Veryfront requires Node.js ${minimum} or later`,
+    `    Detail: This shell is running ${detected}.`,
+    "    Suggestion: Upgrade Node.js, then run the command again. With nvm:" +
+    ` nvm install ${minimum} && nvm use ${minimum}`,
+    `    Docs: ${DOCS_URL}`,
+  ].join("\n");
+}


### PR DESCRIPTION
Round-2 dogfooding finding [18] (`new`, confirmed against published `0.1.1229`).

## Symptom

Running the CLI on an unsupported Node produced a raw unhandled stack trace instead of a classified error:

```console
$ npx -y -p node@18.18.0 node ./node_modules/veryfront/bin/veryfront.js dev --port 3781
Error: The current server runtime does not expose complete node:util/types brand checks
    at .../node_modules/veryfront/esm/src/platform/compat/native-brand-checks.js:67:11
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
```

No error code, no version, no suggestion, no docs link — while every other CLI failure renders detail/suggestion/docs.

## Root cause

`src/platform/compat/native-brand-checks.ts` needs `process.getBuiltinModule`, which landed in Node **22.3.0** — exactly `MINIMUM_NODE_VERSION` in `scripts/build/runtime-support.ts`. It reads it *while its module graph loads*, so on older Node the throw happens during import of `esm/cli/main.js`, before any CLI code exists to classify it. `bin/veryfront.js` had no engine precondition, so the shim's generic `catch` just dumped the raw `Error`.

The docs are not at fault — `docs/getting-started/installation.md` already states the floor, and `tests/docs/guide-content.test.ts` enforces it. This is purely a missing runtime precondition.

## Fix

- New dependency-free `scripts/build/node-engine-precondition.js`, copied next to `bin/veryfront.js`, loadable on Node releases far below the floor.
- The shim reports the failure in the usual CLI shape.

```
  ✗ Veryfront requires Node.js 22.3.0 or later
    Detail: This shell is running Node.js 18.18.0.
    Suggestion: Upgrade Node.js, then run the command again. With nvm: nvm install 22.3.0 && nvm use 22.3.0
    Docs: https://veryfront.com/docs/code/getting-started/installation
```

Two deliberate scoping decisions:

- **The gate guards only the JS fallback.** `scripts/postinstall.js` downloads a self-contained native binary into `bin/`, which runs fine on older Node. I verified the published shim + a native binary works on Node 18.18, so hoisting the gate to module scope would have refused those installs for no reason. A test locks the gate inside `runJsFallback`.
- **Unparseable versions fail open.** The gate exists to explain a crash; it must never be the reason a runtime that would have worked is turned away.

`MINIMUM_NODE_VERSION` is duplicated in the shim (it cannot import framework code) and a test locks it to `runtime-support.ts`.

## Verification against the published repro

The finding's own command, run against installed `veryfront@0.1.1229` with only its shim replaced by this branch's:

| Scenario | Before | After |
|---|---|---|
| Node 18.18.0, JS fallback | raw `Error:` + `ModuleJob` frame | classified message, exit 1 |
| Node 18.18.0, native binary present | works | works (no regression) |
| Node 22.3.0 (the exact floor) | works | works |

The Node 22.3.0 row confirms the floor is right: the first release with `process.getBuiltinModule` is the first that passes the gate.

## Tests

`cli/node-engine-precondition.test.ts` (10 steps). Confirmed red before the fix, and the anti-regression case was independently confirmed red by temporarily hoisting the gate to module scope.

CI's `scripts/test/npm-install-smoke.sh` runs `node node_modules/veryfront/bin/veryfront.js --version` against the real packed tarball, which covers the new file actually shipping (`pkg.files` already includes `bin`).

No live-docs change is needed for this PR.
