### PR TITLE
fix(api-routes): resolve veryfront imports to the running framework copy

### DIFF
--- a/src/routing/api/module-loader/external-import-rewriter.test.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.test.ts
@@ -19,6 +19,7 @@ import {
   rewriteDenoNodeBuiltinImports,
   rewriteDenoNpmDependencyImports,
   rewriteDenoVeryfrontImports,
+  rewriteNodeExternalImports,
 } from "./external-import-rewriter.ts";
 
 function createFakeFileSystem(files: Record<string, string>): FileSystem {
@@ -394,6 +395,57 @@ describe("external-import-rewriter", () => {
       assertStringIncludes(shim, "var require = function(id)");
       assertStringIncludes(shim, "__vf_interopDefault");
       assert(shim.length > 0);
+    });
+  });
+
+  describe("Node Veryfront package imports", () => {
+    // An API route that imports `veryfront/tool` must reach the SAME module
+    // instance the running server uses, or `toolRegistry.get()` looks into a
+    // second, empty registry and every tool reads as "not found" (the Tools
+    // guide's own verify route). That happens whenever the CLI runs from a
+    // different veryfront copy than the project's node_modules — a global
+    // `npm install -g veryfront`, an `npx` cache, or a hoisted monorepo store.
+    it("resolves veryfront route imports against the running package, not the project copy", async () => {
+      const runningPackage = {
+        packageUrl: new URL("file:///opt/cli/node_modules/veryfront/package.json"),
+        exports: {
+          "./tool": { import: "./esm/src/tool/index.js" },
+        },
+      };
+      const fs = createFakeFileSystem({
+        "/srv/app/node_modules/veryfront/package.json": JSON.stringify({
+          exports: { "./tool": { import: "./esm/src/tool/index.js" } },
+        }),
+      });
+
+      const out = await rewriteNodeExternalImports(
+        `import { toolRegistry } from "veryfront/tool";`,
+        "/srv/app",
+        fs,
+        new Map(),
+        { loadRunningPackage: () => Promise.resolve(runningPackage) },
+      );
+
+      assertStringIncludes(out, "file:///opt/cli/node_modules/veryfront/esm/src/tool/index.js");
+      assertEquals(out.includes("/srv/app/node_modules/veryfront"), false);
+    });
+
+    it("falls back to the project copy when no running package is discoverable", async () => {
+      const fs = createFakeFileSystem({
+        "/srv/app/node_modules/veryfront/package.json": JSON.stringify({
+          exports: { "./tool": { import: "./esm/src/tool/index.js" } },
+        }),
+      });
+
+      const out = await rewriteNodeExternalImports(
+        `import { toolRegistry } from "veryfront/tool";`,
+        "/srv/app",
+        fs,
+        new Map(),
+        { loadRunningPackage: () => Promise.resolve(null) },
+      );
+
+      assertStringIncludes(out, "/srv/app/node_modules/veryfront/esm/src/tool/index.js");
     });
   });
 });

--- a/src/routing/api/module-loader/external-import-rewriter.test.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.test.ts
@@ -430,6 +430,41 @@ describe("external-import-rewriter", () => {
       assertEquals(out.includes("/srv/app/node_modules/veryfront"), false);
     });
 
+    it("falls back to the project copy for a subpath the running package lacks", async () => {
+      // An older global CLI against a newer project dependency: the running copy
+      // cannot serve `veryfront/knowledge`, and leaving the bare specifier in the
+      // temp handler module would break a route that used to work.
+      const runningPackage = {
+        packageUrl: new URL("file:///opt/cli/node_modules/veryfront/package.json"),
+        exports: {
+          "./tool": { import: "./esm/src/tool/index.js" },
+        },
+      };
+      const fs = createFakeFileSystem({
+        "/srv/app/node_modules/veryfront/package.json": JSON.stringify({
+          exports: {
+            "./tool": { import: "./esm/src/tool/index.js" },
+            "./knowledge": { import: "./esm/src/knowledge/index.js" },
+          },
+        }),
+      });
+
+      const out = await rewriteNodeExternalImports(
+        [
+          `import { toolRegistry } from "veryfront/tool";`,
+          `import { ingest } from "veryfront/knowledge";`,
+        ].join("\n"),
+        "/srv/app",
+        fs,
+        new Map(),
+        { loadRunningPackage: () => Promise.resolve(runningPackage) },
+      );
+
+      assertStringIncludes(out, "file:///opt/cli/node_modules/veryfront/esm/src/tool/index.js");
+      assertStringIncludes(out, "/srv/app/node_modules/veryfront/esm/src/knowledge/index.js");
+      assertEquals(out.includes(`"veryfront/knowledge"`), false);
+    });
+
     it("falls back to the project copy when no running package is discoverable", async () => {
       const fs = createFakeFileSystem({
         "/srv/app/node_modules/veryfront/package.json": JSON.stringify({

--- a/src/routing/api/module-loader/external-import-rewriter.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.ts
@@ -233,41 +233,51 @@ export async function rewriteNodeExternalImports(
     (specifier) => specifier === "veryfront" || specifier.startsWith("veryfront/"),
   );
 
-  // A route's `veryfront/*` import must land on the SAME module instance the
-  // server is running, or the route gets a second, empty copy of every registry
-  // (`toolRegistry.get()` returns undefined for tools the server has loaded).
-  // The project's node_modules copy is only the same instance by coincidence —
-  // a global install, an npx cache, or a hoisted monorepo store all break it.
-  // The Deno path already resolves against the running package; do the same here.
-  const runningPackage = veryfrontSpecifiers.length > 0
-    ? await (options.loadRunningPackage ?? loadRunningVeryfrontPackage)()
-    : null;
+  if (veryfrontSpecifiers.length > 0) {
+    // A route's `veryfront/*` import must land on the SAME module instance the
+    // server is running, or the route gets a second, empty copy of every
+    // registry (`toolRegistry.get()` returns undefined for tools the server has
+    // loaded). The project's node_modules copy is only the same instance by
+    // coincidence — a global install, an npx cache, or a hoisted monorepo store
+    // all break it. The Deno path already resolves against the running package.
+    const runningPackage = await (options.loadRunningPackage ?? loadRunningVeryfrontPackage)();
+    let projectExports: Record<string, { import?: string }> | undefined;
 
-  if (runningPackage) {
-    for (const specifier of veryfrontSpecifiers) {
-      try {
-        const resolved = resolveVeryfrontPackageExport(specifier, runningPackage);
-        logger.debug(`Resolved ${specifier} -> ${resolved} (running package)`);
-        replacements.set(specifier, resolved);
-      } catch (error) {
-        logger.warn(`No running-package export for ${specifier}: ${String(error)}`);
-      }
-    }
-  } else if (veryfrontSpecifiers.length > 0) {
-    const vfPackagePath = pathHelper.join(projectDir, "node_modules", "veryfront");
-    const exportsMap = await loadVeryfrontExportsMap(projectDir, fs);
-
-    for (const specifier of veryfrontSpecifiers) {
-      const subpath = specifier === "veryfront" ? "." : "./" + specifier.slice("veryfront/".length);
-      const exportEntry = exportsMap[subpath];
+    // Fallback for a subpath the running copy does not export — an older global
+    // CLI against a newer project dependency. A split instance still beats a
+    // bare specifier the temp handler module cannot resolve at all.
+    const resolveFromProjectCopy = async (specifier: string, subpath: string): Promise<void> => {
+      projectExports ??= await loadVeryfrontExportsMap(projectDir, fs);
+      const exportEntry = projectExports[subpath];
       if (!exportEntry?.import) {
         if (subpath !== ".") logger.warn(`No export found for ${subpath}`);
-        continue;
+        return;
       }
 
+      const vfPackagePath = pathHelper.join(projectDir, "node_modules", "veryfront");
       const resolvedPath = pathHelper.join(vfPackagePath, exportEntry.import);
       logger.debug(`Resolved ${specifier} -> ${resolvedPath}`);
       replacements.set(specifier, pathToFileURL(resolvedPath).href);
+    };
+
+    for (const specifier of veryfrontSpecifiers) {
+      const subpath = specifier === "veryfront" ? "." : "./" + specifier.slice("veryfront/".length);
+
+      if (runningPackage) {
+        try {
+          const resolved = resolveVeryfrontPackageExport(specifier, runningPackage);
+          logger.debug(`Resolved ${specifier} -> ${resolved} (running package)`);
+          replacements.set(specifier, resolved);
+          continue;
+        } catch (error) {
+          logger.warn(
+            `Running package does not export ${specifier} (${String(error)}); ` +
+              `falling back to the project copy`,
+          );
+        }
+      }
+
+      await resolveFromProjectCopy(specifier, subpath);
     }
   }
 

--- a/src/routing/api/module-loader/external-import-rewriter.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.ts
@@ -194,6 +194,9 @@ export async function rewriteNodeExternalImports(
   projectDir: string,
   fs: SourceReader,
   userDeps: Map<string, string>,
+  options: {
+    loadRunningPackage?: () => Promise<RunningVeryfrontPackage | null>;
+  } = {},
 ): Promise<string> {
   const { pathToFileURL } = await import("node:url");
   const replacements = new Map<string, string>();
@@ -226,25 +229,39 @@ export async function rewriteNodeExternalImports(
     replacements.set(specifier, resolvedUrl);
   }
 
-  const vfPackagePath = pathHelper.join(projectDir, "node_modules", "veryfront");
-  const exportsMap = await loadVeryfrontExportsMap(projectDir, fs);
+  const veryfrontSpecifiers = [...importedSpecifiers].filter(
+    (specifier) => specifier === "veryfront" || specifier.startsWith("veryfront/"),
+  );
 
-  for (const specifier of importedSpecifiers) {
-    if (specifier === "veryfront") {
-      const exportEntry = exportsMap["."];
-      if (!exportEntry?.import) continue;
+  // A route's `veryfront/*` import must land on the SAME module instance the
+  // server is running, or the route gets a second, empty copy of every registry
+  // (`toolRegistry.get()` returns undefined for tools the server has loaded).
+  // The project's node_modules copy is only the same instance by coincidence —
+  // a global install, an npx cache, or a hoisted monorepo store all break it.
+  // The Deno path already resolves against the running package; do the same here.
+  const runningPackage = veryfrontSpecifiers.length > 0
+    ? await (options.loadRunningPackage ?? loadRunningVeryfrontPackage)()
+    : null;
 
-      const resolvedPath = pathHelper.join(vfPackagePath, exportEntry.import);
-      logger.debug(`Resolved veryfront -> ${resolvedPath}`);
-      replacements.set(specifier, pathToFileURL(resolvedPath).href);
-      continue;
+  if (runningPackage) {
+    for (const specifier of veryfrontSpecifiers) {
+      try {
+        const resolved = resolveVeryfrontPackageExport(specifier, runningPackage);
+        logger.debug(`Resolved ${specifier} -> ${resolved} (running package)`);
+        replacements.set(specifier, resolved);
+      } catch (error) {
+        logger.warn(`No running-package export for ${specifier}: ${String(error)}`);
+      }
     }
+  } else if (veryfrontSpecifiers.length > 0) {
+    const vfPackagePath = pathHelper.join(projectDir, "node_modules", "veryfront");
+    const exportsMap = await loadVeryfrontExportsMap(projectDir, fs);
 
-    if (specifier.startsWith("veryfront/")) {
-      const subpath = "./" + specifier.replace("veryfront/", "");
+    for (const specifier of veryfrontSpecifiers) {
+      const subpath = specifier === "veryfront" ? "." : "./" + specifier.slice("veryfront/".length);
       const exportEntry = exportsMap[subpath];
       if (!exportEntry?.import) {
-        logger.warn(`No export found for ${subpath}`);
+        if (subpath !== ".") logger.warn(`No export found for ${subpath}`);
         continue;
       }
 
@@ -284,18 +301,32 @@ export function rewriteDenoNodeBuiltinImports(code: string): string {
   return rewriteDenoNodeBuiltinsForRoute(code);
 }
 
-interface RunningVeryfrontPackage {
+export interface RunningVeryfrontPackage {
   packageUrl: URL;
   exports: Record<string, unknown>;
 }
 
 let runningVeryfrontPackage: Promise<RunningVeryfrontPackage | null> | null = null;
 
+/**
+ * Read the package.json of the veryfront copy that is currently executing.
+ * Deno reads it directly; Node needs `node:fs`, and Node is exactly where this
+ * matters — the npm CLI falls back to the packaged ESM build.
+ */
+async function readRunningPackageJson(packageUrl: URL): Promise<string> {
+  if (isDeno) return await Deno.readTextFile(packageUrl);
+  const [{ readFile }, { fileURLToPath }] = await Promise.all([
+    import("node:fs/promises"),
+    import("node:url"),
+  ]);
+  return await readFile(fileURLToPath(packageUrl), "utf8");
+}
+
 function loadRunningVeryfrontPackage(): Promise<RunningVeryfrontPackage | null> {
   runningVeryfrontPackage ??= (async () => {
     const packageUrl = new URL("../../../../../package.json", import.meta.url);
     try {
-      const raw = await Deno.readTextFile(packageUrl);
+      const raw = await readRunningPackageJson(packageUrl);
       const pkg = JSON.parse(raw) as { name?: unknown; exports?: unknown };
       if (pkg.name !== "veryfront" || !pkg.exports || typeof pkg.exports !== "object") {
         return null;


### PR DESCRIPTION
## Symptom

The Tools guide ends with a verification step: create `app/api/debug/tools/route.ts`
that calls `toolRegistry.get(name)?.execute(input)`, restart `veryfront dev`, and curl it.
On published **0.1.1229** that step returns "tool not found" for *every* tool — including
`calculator`, the scaffold's own built-in that the server demonstrably loads:

```
$ curl -X POST localhost:3000/api/debug/tools -d '{"name":"getWeather","input":{"input":"Berlin"}}'
{"error":"tool not found","name":"getWeather","allIds":[]}
```

`toolRegistry.getAllIds()` is `[]` and `getStats()` reports `{projectCount: 0, sharedCount: 0}`
— an entirely empty registry, while the server's own registry holds five tools.

## Root cause

`rewriteNodeExternalImports` resolved a route's `veryfront/*` imports against
`<projectDir>/node_modules/veryfront`. That is the copy the *project* has installed,
which is the same module instance as the running server **only by coincidence**.
It stops being the same the moment the CLI comes from somewhere else:

- `npm install -g veryfront` (documented in `getting-started/installation.md`)
- an `npx` cache
- a hoisted monorepo store / pnpm layout

Then the route imports a *second copy of the framework*, gets a second `toolRegistry`
module-level singleton, and that one has never seen discovery run.

The Deno branch of the same function already avoided this: `rewriteDenoVeryfrontImports`
resolves through `loadRunningVeryfrontPackage()` + `resolveVeryfrontPackageExport()`.
The Node branch — which is exactly where this bites, since the npm CLI has no native
binary in `bin/` and falls back to the packaged ESM build under Node — never got that
treatment.

## Fix

Point the Node branch at the same running-package resolution the Deno branch uses,
keeping the project-copy lookup as the fallback for when no running package can be
identified (framework dev checkouts). `loadRunningVeryfrontPackage` also had to learn
to read its own `package.json` under Node, where `Deno.readTextFile` is not available.

## Verification against the published repro

Sandbox outside the platform tree, `npm install veryfront@0.1.1229`, `veryfront init`,
`veryfront generate tool get-weather`, plus the guide's verify route verbatim.
Dev server started from a *different* veryfront copy than the project's `node_modules`
(the failing configuration):

| | before | after |
|---|---|---|
| `{"name":"getWeather"}` | `{"error":"tool not found","allIds":[]}` | `{"result":"Berlin"}` |
| `{"name":"calculator"}` | `{"error":"tool not found","allIds":[]}` | `{"result":3}` |
| route `getStats()` | `{projectCount:0, sharedCount:0}` | `{projectCount:1, sharedCount:3}` |

The ordinary configuration (CLI and project share one copy, `npm run dev`) was
re-checked with the fix applied and still returns `{"result":"Berlin"}`.

## Tests

`src/routing/api/module-loader/external-import-rewriter.test.ts`:

- `resolves veryfront route imports against the running package, not the project copy`
  — confirmed red before the fix with
  `Expected actual: "…file:///srv/app/node_modules/veryfront/esm/src/tool/index.js…" to contain: "file:///opt/cli/node_modules/veryfront/esm/src/tool/index.js"`.
- `falls back to the project copy when no running package is discoverable` — pins the
  fallback so framework dev checkouts keep resolving locally.

## Relation to the earlier "kebab-case tool ID" finding

That finding bundled two defects under one heading. The ID-casing half is genuinely
fixed — `veryfront generate tool get-weather` writes `id: "getWeather"` on 0.1.1229,
matching the guide. The verify-curl half was never a casing problem at all, so the
casing fix could not move it. This PR addresses the actual cause.

## No doc change needed

The guide is correct; the framework was not. `docs/code/guides/tools.md` needs no edit.
