### PR TITLE
fix(cli): open the Environments panel instead of a 404 for `open --env`

### DIFF
--- a/cli/commands/open/command-help.ts
+++ b/cli/commands/open/command-help.ts
@@ -12,7 +12,7 @@ export const openHelp: CommandHelp = {
     },
     {
       flag: "--env <name>",
-      description: "Open a specific environment's dashboard page",
+      description: "Open the project's Environments panel",
     },
     { flag: "--studio", description: "Open Veryfront Studio" },
     { flag: "--json", description: "Output URL as JSON instead of opening" },

--- a/cli/commands/open/command.ts
+++ b/cli/commands/open/command.ts
@@ -26,8 +26,13 @@ export function buildUrl(projectSlug: string, options: OpenOptions): string {
   if (options.studio) {
     return `${DASHBOARD_BASE}/studio/${projectSlug}`;
   }
+  // Environments are a panel on the project page, not a route of their own —
+  // `/projects/<slug>/environments/<name>` is a hard 404. The panel is opened
+  // with `?panels=<panelId>`. The panel's own deep link seeds a selection by
+  // environment *id* (`?environments=edit:<id>`), which `open` cannot resolve
+  // from a name without an API token, so the env name selects the panel only.
   if (options.env) {
-    return `${DASHBOARD_BASE}/projects/${projectSlug}/environments/${options.env}`;
+    return `${DASHBOARD_BASE}/projects/${projectSlug}?panels=environments`;
   }
   return `${DASHBOARD_BASE}/projects/${projectSlug}`;
 }

--- a/cli/commands/open/handler.test.ts
+++ b/cli/commands/open/handler.test.ts
@@ -93,12 +93,24 @@ describe("Open Command", () => {
       assertEquals(url, "https://veryfront.com/studio/my-app");
     });
 
-    it("builds environment URL", () => {
+    it("builds environment URL that opens the Environments panel", () => {
+      // `/projects/<slug>/environments/<name>` is not a Studio route — it is a
+      // hard 404. Environments are a panel on the project page, addressed by the
+      // `?panels=` query param.
       const url = buildUrl("my-app", { env: "staging", studio: false });
       assertEquals(
         url,
-        "https://veryfront.com/projects/my-app/environments/staging",
+        "https://veryfront.com/projects/my-app?panels=environments",
       );
+    });
+
+    it("never builds an /environments/ path segment for any env name", () => {
+      // Regression guard: the dashboard has no `/environments/` route at all,
+      // so no env name may produce one.
+      for (const env of ["production", "staging", "preview"]) {
+        const url = buildUrl("my-app", { env, studio: false });
+        assertEquals(url.includes("/environments/"), false, `env=${env}`);
+      }
     });
 
     it("studio flag takes precedence over env", () => {

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -111,8 +111,8 @@ curl -sSf -N -X POST <environment-url>/api/ag-ui \
 ```
 
 `veryfront open` opens the project in the Cloud dashboard, where the deployment
-is listed; `veryfront open --env production` opens that environment's dashboard
-page. Neither opens the deployed site, so use the environment URL Deploy printed
+is listed; `veryfront open --env production` opens the project's Environments
+panel. Neither opens the deployed site, so use the environment URL Deploy printed
 to check the running deployment.
 
 For an automated production workflow, see


### PR DESCRIPTION
## Problem

`veryfront open --env <name>` reported `success: true` while handing the user a dead link.

```console
$ veryfront open --env production --json     # published 0.1.1229
{
  "success": true,
  "command": "open",
  "data": { "url": "https://veryfront.com/projects/<slug>/environments/production" }
}

$ curl -s -o /dev/null -w '%{http_code}' https://veryfront.com/projects/<slug>/environments/production
404
```

The dashboard has no `/environments/` route. Studio's page tree only serves
`pages/projects/[projectSlug]` — there is no nested `environments` route, so *every*
`--env` invocation produced a hard 404 ("This page could not be found").

This is newly reachable ground: before #3576, `open` could not resolve a project slug from a
local link at all and errored `No project found` here, so no URL was ever produced. #3576 fixed
the resolution and exposed the broken `--env` route behind it.

## Fix

Environments are a **panel** on the project page, addressed with `?panels=environments`:

```
https://veryfront.com/projects/<slug>?panels=environments
```

The env name selects the panel, not a specific row. That is deliberate: the panel's own deep
link seeds a selection by environment **id** (`?environments=edit:<id>`, matched in
`EnvironmentsPanelContainer` with `environments.find(env => env.id === selectedEnvironmentId)`).
`open` only has the env *name* and has no token to resolve it to an id, so emitting
`?environments=edit:production` would open a detail drawer bound to an id that never matches —
strictly worse than landing on the panel list. Resolving the id would mean an authenticated API
call, which `open` deliberately does not make.

Also corrects the two places that described the old behaviour (`--env` help text and the
deploy-project guide sentence).

## Verification against the published repro

Re-ran the finding's own command against this build:

| URL | before | after |
| --- | --- | --- |
| `/projects/<slug>/environments/production` (0.1.1229) | **404** | — |
| `/projects/<slug>?panels=environments` (this build) | — | **302** |

302 is the signed-out redirect to `/sign-in` that every real Studio page returns for an
anonymous request — i.e. a route that exists — versus the 404 body the old URL rendered.

```console
$ deno run -A cli/main.ts open --env production --project <slug> --json
{ "success": true, "command": "open",
  "data": { "url": "https://veryfront.com/projects/<slug>?panels=environments" } }
```

## Tests

`cli/commands/open/handler.test.ts` — both fail on `main` for the right reason (asserted before
writing the fix):

- `builds environment URL that opens the Environments panel` — pins the exact corrected URL.
- `never builds an /environments/ path segment for any env name` — regression guard over
  `production` / `staging` / `preview`, since the dashboard has no `/environments/` route at all.

## Scope

Deliberately narrow. `veryfront open`'s broader "opens Studio, never the deployed app" behaviour
and the deploy-project Verification step are separate findings owned by other agents; this PR
only stops `--env` from emitting a 404 and fixes the one clause that its behaviour change
invalidates.

## Live docs

No published-docs change is required — `veryfront-docs` does not carry the
"environment's dashboard page" claim (verified by grep). The only doc edit is the in-repo
`docs/getting-started/deploy-project.md`.
