### PR TITLE
fix(cli): report the stored login token in `veryfront config`

### DIFF
--- a/cli/commands/config/handler.test.ts
+++ b/cli/commands/config/handler.test.ts
@@ -17,6 +17,28 @@ const CONFIG_ENV_KEYS = [
   "VERYFRONT_DEBUG",
 ] as const;
 
+const TOKEN_STORE_ENV_KEYS = [
+  ...CONFIG_ENV_KEYS,
+  "XDG_CONFIG_HOME",
+] as const;
+
+async function withTokenStore(
+  storedToken: string | null,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const configHome = await Deno.makeTempDir();
+  try {
+    if (storedToken !== null) {
+      await Deno.mkdir(join(configHome, "veryfront"), { recursive: true });
+      await Deno.writeTextFile(join(configHome, "veryfront", "token"), `${storedToken}\n`);
+    }
+    Deno.env.set("XDG_CONFIG_HOME", configHome);
+    await fn();
+  } finally {
+    await Deno.remove(configHome, { recursive: true });
+  }
+}
+
 async function withSavedEnv(
   keys: readonly string[],
   fn: () => Promise<void> | void,
@@ -215,6 +237,49 @@ describe("Config Command", () => {
 
           assertEquals(data.projectSlug, "tenant-project-id-from-env");
           assertEquals(data.configSource, null);
+        });
+      });
+    });
+
+    it("reports a stored login token as authenticated", async () => {
+      await withSavedEnv(TOKEN_STORE_ENV_KEYS, async () => {
+        await withTokenStore("stored-session-token", async () => {
+          await withTempConfigProject({}, async (projectDir) => {
+            const data = await getConfigCommandData(projectDir);
+
+            assertEquals(data.hasStoredToken, true);
+            assertEquals(data.hasApiToken, false);
+            assertEquals(data.authenticated, true);
+          });
+        });
+      });
+    });
+
+    it("reports VERYFRONT_API_TOKEN as authenticated without a stored token", async () => {
+      await withSavedEnv(TOKEN_STORE_ENV_KEYS, async () => {
+        await withTokenStore(null, async () => {
+          Deno.env.set("VERYFRONT_API_TOKEN", "vf_env_token");
+          await withTempConfigProject({}, async (projectDir) => {
+            const data = await getConfigCommandData(projectDir);
+
+            assertEquals(data.hasStoredToken, false);
+            assertEquals(data.hasApiToken, true);
+            assertEquals(data.authenticated, true);
+          });
+        });
+      });
+    });
+
+    it("reports no authentication when neither a token store nor an env token exists", async () => {
+      await withSavedEnv(TOKEN_STORE_ENV_KEYS, async () => {
+        await withTokenStore(null, async () => {
+          await withTempConfigProject({}, async (projectDir) => {
+            const data = await getConfigCommandData(projectDir);
+
+            assertEquals(data.hasStoredToken, false);
+            assertEquals(data.hasApiToken, false);
+            assertEquals(data.authenticated, false);
+          });
         });
       });
     });

--- a/cli/commands/config/handler.ts
+++ b/cli/commands/config/handler.ts
@@ -56,6 +56,8 @@ export type ConfigCommandData = {
   debug: boolean;
   ci: boolean;
   hasApiToken: boolean;
+  hasStoredToken: boolean;
+  authenticated: boolean;
   configSource: string | null;
   envOverrides: string[];
 };
@@ -69,6 +71,7 @@ export async function getConfigCommandData(projectDir: string): Promise<ConfigCo
     PROJECT_LINK_RELATIVE_PATH,
     readProjectLinkForControlPlane,
   } = await import("../../shared/project-link.ts");
+  const { hasToken } = await import("../../auth/token-store.ts");
 
   const detectedConfigSource = await detectConfigSource(projectDir);
   const envOverrides = getEnvOverrides();
@@ -82,6 +85,12 @@ export async function getConfigCommandData(projectDir: string): Promise<ConfigCo
     ))?.projectSlug
     : undefined;
 
+  // `whoami` authenticates from the CLI token store as well as the environment
+  // token, so `config` has to consult both or it reports "Authenticated: no"
+  // for a developer who is logged in.
+  const hasApiToken = !!(config.apiToken ?? fileConfig?.apiToken);
+  const hasStoredToken = await hasToken(config);
+
   return {
     projectSlug: config.projectSlug ?? fileConfig?.projectSlug ?? environmentProjectReference ??
       linkedProjectSlug ?? null,
@@ -90,7 +99,9 @@ export async function getConfigCommandData(projectDir: string): Promise<ConfigCo
     apiBaseUrl: config.apiBaseUrl,
     debug: config.debug,
     ci: config.ci,
-    hasApiToken: !!(config.apiToken ?? fileConfig?.apiToken),
+    hasApiToken,
+    hasStoredToken,
+    authenticated: hasApiToken || hasStoredToken,
     configSource: linkedProjectSlug
       ? PROJECT_LINK_RELATIVE_PATH
       : detectedConfigSource === ".veryfront/project.json"
@@ -124,7 +135,7 @@ export async function handleConfigCommand(_args: ParsedArgs): Promise<void> {
   console.log(`  ${dim("Debug:")}         ${configData.debug}`);
   console.log(`  ${dim("CI:")}            ${configData.ci}`);
   console.log(
-    `  ${dim("Authenticated:")} ${configData.hasApiToken ? "yes" : "no"}`,
+    `  ${dim("Authenticated:")} ${configData.authenticated ? "yes" : "no"}`,
   );
   console.log(
     `  ${dim("Config file:")}   ${configData.configSource ?? "(none)"}`,


### PR DESCRIPTION
## Symptom

`veryfront config` and `veryfront whoami` disagreed about whether the developer was logged in, in the same directory, on the same stored credential:

```
$ veryfront whoami
  ✓ Logged in as koji@codersociety.com
  Token stored at: /Users/<u>/.config/veryfront/token

$ veryfront config
  ...
  Authenticated: no
```

`push` and `deploy` both succeeded in that directory, so `config` was simply wrong. Anyone debugging a push failure gets sent after an auth problem that does not exist.

Reproduced against the published **0.1.1229** (`npm i veryfront@0.1.1229`, run outside the monorepo so import maps do not resolve to local source). Present on 0.1.1228 too — not a regression, and not fixed by anything merged after the release cut.

## Root cause

`getConfigCommandData` derived the whole `Authenticated` line from `hasApiToken`:

```ts
hasApiToken: !!(config.apiToken ?? fileConfig?.apiToken),
```

That covers only `VERYFRONT_API_TOKEN` and an `apiToken` in the project config file. A developer who ran `veryfront login` has neither — the credential lives in the CLI token store (`~/.config/veryfront/token`), which is exactly what `whoami`, `push`, and `deploy` read via `readToken()`. `config` never consulted it.

## Fix

Consult the token store as well, and stop overloading one field with two meanings:

- `hasApiToken` keeps its narrow meaning — an API token from the environment or the config file.
- `hasStoredToken` reports the CLI token store.
- `authenticated` is the union, and is what the human line and JSON consumers should read.

The lookup stays offline. `config` is a local inspection command, so it reports credential *presence*; validating the credential against the API remains `whoami`'s job.

## Verification

Regression tests were written first and confirmed failing for the right reason (`data.authenticated` / `data.hasStoredToken` were `undefined`) before the fix, in `cli/commands/config/handler.test.ts`:

- a stored login token alone reports `authenticated: true`
- `VERYFRONT_API_TOKEN` alone reports `authenticated: true` with `hasStoredToken: false`
- neither present reports `authenticated: false`

The original symptom, re-run against this build from a directory outside the monorepo:

```
$ whoami  ->  ✓ Logged in as koji@codersociety.com
$ config  ->  Authenticated: yes
```

and `config --json` now returns `"hasApiToken": false, "hasStoredToken": true, "authenticated": true`.

Full local pre-push suite (fmt, lint, `deno check`, `test:unit`) green.

## Scope

Framework-only; no documentation change is needed. No page in `veryfront-docs` documents the `config` command's fields (`grep` for `hasApiToken` / `Authenticated:` across `docs/code/**` returns nothing), so there is no live URL to check for this one.
