### PR TITLE
fix(cli): stop veryfront build printing a bare bullet line

### DIFF
--- a/cli/commands/build/config-display.test.ts
+++ b/cli/commands/build/config-display.test.ts
@@ -3,9 +3,47 @@ import "#veryfront/schemas/_test-setup.ts";
  * Tests for build config display
  */
 
+import { assert } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { setLoggerPreset } from "veryfront/utils/logger";
+import { setVerboseMode } from "#cli/utils";
 import { displayBuildConfig, displayBuildStart } from "./config-display.ts";
 import type { BuildOptions } from "./types.ts";
+
+/** Strips SGR colour codes so assertions can look at the raw layout. */
+const ANSI_SGR = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+/** Matches the CLI logger's `  <glyph> ` prefix. */
+const GLYPH_LINE = /^ {2}\S /;
+
+/** Renders through the real CLI logger preset and returns each printed line. */
+function captureCliPresetLines(run: () => void): string[] {
+  const output: string[] = [];
+  const origLog = console.log;
+
+  setLoggerPreset("cli");
+  try {
+    console.log = (msg?: unknown, ...rest: unknown[]) => {
+      output.push(String(msg ?? ""), ...rest.map(String));
+    };
+    run();
+  } finally {
+    console.log = origLog;
+    setLoggerPreset("server");
+  }
+
+  return output.join("\n").replace(ANSI_SGR, "").split("\n");
+}
+
+function assertNoGlyphOnlyLine(lines: string[]): void {
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    assert(
+      !(GLYPH_LINE.test(line) && line.replace(GLYPH_LINE, "").trim() === ""),
+      `emitted a glyph-only line with no content: ${JSON.stringify(line)}`,
+    );
+  }
+}
 
 describe("build/config-display", () => {
   describe("displayBuildConfig", () => {
@@ -90,6 +128,50 @@ describe("build/config-display", () => {
       };
 
       displayBuildConfig(options);
+    });
+  });
+
+  // Regression: the section break after the dry-run notice was emitted as
+  // `cliLogger.info("")`. The CLI logger preset renders every message as
+  // `  <glyph> <message>`, so an empty message printed a bare "  ● " line
+  // between the notice and "Building...". Same defect the routes command had.
+  describe("section separators under the CLI logger preset", () => {
+    it("separates the dry-run notice without a bare glyph line", () => {
+      const lines = captureCliPresetLines(() => {
+        displayBuildConfig({ projectDir: "/project", dryRun: true });
+        displayBuildStart();
+      });
+
+      assertNoGlyphOnlyLine(lines);
+
+      const buildingIndex = lines.findIndex((line) => line.includes("Building..."));
+      assert(buildingIndex > 0, "expected a Building... line after the dry-run notice");
+      assert(
+        lines[buildingIndex - 1] === "",
+        `expected a blank line before Building..., got ${JSON.stringify(lines[buildingIndex - 1])}`,
+      );
+    });
+
+    it("separates the verbose config block without a bare glyph line", () => {
+      setVerboseMode(true);
+      let lines: string[];
+      try {
+        lines = captureCliPresetLines(() => {
+          displayBuildConfig({ projectDir: "/project", outputDir: "dist" });
+          displayBuildStart();
+        });
+      } finally {
+        setVerboseMode(false);
+      }
+
+      assertNoGlyphOnlyLine(lines);
+
+      const buildingIndex = lines.findIndex((line) => line.includes("Building..."));
+      assert(buildingIndex > 0, "expected a Building... line after the verbose config block");
+      assert(
+        lines[buildingIndex - 1] === "",
+        `expected a blank line before Building..., got ${JSON.stringify(lines[buildingIndex - 1])}`,
+      );
     });
   });
 

--- a/cli/commands/build/config-display.ts
+++ b/cli/commands/build/config-display.ts
@@ -28,12 +28,15 @@ export function displayBuildConfig(options: BuildOptions): void {
     cliLogger.info(`  ${dim("Features:")} ${features}`);
     if (include?.length) cliLogger.info(`  ${dim("Include:")} ${include.join(", ")}`);
     if (exclude?.length) cliLogger.info(`  ${dim("Exclude:")} ${exclude.join(", ")}`);
-    cliLogger.info("");
+    // Emit the section break directly: the CLI logger preset renders every
+    // message as `  <glyph> <message>`, so an empty message prints a bare
+    // glyph line instead of a blank one.
+    console.log("");
   }
 
   if (dryRun) {
     cliLogger.info(`  ${warning("!")} Dry run: no files will be written`);
-    cliLogger.info("");
+    console.log("");
   }
 }
 


### PR DESCRIPTION
## Symptom

`veryfront build --dry-run` prints a glyph-only line — `  ● ` with no text — between the dry-run notice and `Building...`.

Reproduced against **published 0.1.1229** in a sandbox outside the platform checkout (`npm i veryfront@0.1.1229`, scaffolded with `veryfront init`):

```
$ veryfront build --dry-run
Veryfront (v0.1.1229)

  ● ! Dry run: no files will be written
  ●                                        <-- bare bullet
  ● Building...
```

`--verbose --dry-run` on 0.1.1229 emits **two** of them (lines 23 and 25 — one after the config block, one after the dry-run notice).

## Root cause

The CLI logger preset renders every message as `  <glyph> <message>`. `cli/commands/build/config-display.ts` used `cliLogger.info("")` as a section break, so the glyph was emitted with an empty message instead of a blank line.

This is the **same defect** commit 7b25cb7bd (#3556) fixed for `veryfront routes` in this release — the build path had two more instances of it that the earlier fix did not touch.

## Fix

Emit both section breaks directly with `console.log("")`, matching the routes fix and the "blank line between logical sections" rule in the CLI output conventions. No behaviour change beyond the layout.

## Verification against the published repro

Same sandbox project, same command, run against this branch:

```
Veryfront (v0.1.1229)

  ● ! Dry run: no files will be written
                                           <-- real blank line
  ● Building...
```

`--verbose --dry-run` grep for `^  ● $`: **2 matches on 0.1.1229, 0 matches on this branch.**

Dry-run behaviour is unchanged — seeded `dist/keepme.txt` survives the dry run intact and nothing is written.

## Test

`cli/commands/build/config-display.test.ts` gains a `section separators under the CLI logger preset` block that renders `displayBuildConfig` through the real `cli` logger preset and asserts:

- no glyph-only line is emitted (dry-run path and verbose path), and
- the line immediately before `Building...` is blank — so deleting the separator fails here rather than passing silently.

Both cases were confirmed to fail before the fix with `AssertionError: emitted a glyph-only line with no content: "  ● "`.

## Scope

`cli/commands/build/config-display.ts` only. Other `cliLogger.info("")` callers (`pull`, `lock`, `analyze-chunks`, `task`, `workflow`, `env-prompt`) have the same latent issue but are out of scope for this finding.