### PR TITLE
fix(cli): surface --runtime in `veryfront init --help`

### DIFF
--- a/cli/commands/init/command-help.test.ts
+++ b/cli/commands/init/command-help.test.ts
@@ -1,0 +1,42 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { showCommandHelp } from "../../help/command-help.ts";
+import { initHelp } from "./command-help.ts";
+import { parseRuntime } from "./runtime.ts";
+
+function captureConsoleLog(run: () => void): string {
+  const output: string[] = [];
+  const originalLog = console.log;
+  try {
+    console.log = (msg?: unknown, ...rest: unknown[]) => {
+      output.push(String(msg), ...rest.map(String));
+    };
+    run();
+  } finally {
+    console.log = originalLog;
+  }
+  return output.join("\n");
+}
+
+describe("cli/commands/init/command-help", () => {
+  it("documents --runtime, which the handler accepts and the docs advertise", () => {
+    // `veryfront init --runtime <node|bun|deno>` works and is documented on
+    // the public create-project page, but was missing from `init --help`,
+    // hiding a supported flag from the CLI's own discovery surface.
+    const runtimeOption = initHelp.options?.find((opt) => opt.flag.includes("--runtime"));
+    assertExists(runtimeOption, "init help must document the --runtime flag");
+    // Takes a value, so the arg parser classifies it as a value flag.
+    assertEquals(runtimeOption.flag.includes("<"), true);
+    for (const runtime of ["node", "bun", "deno"]) {
+      // Every value parseRuntime accepts must be discoverable from --help.
+      assertEquals(parseRuntime(runtime), runtime);
+      assertStringIncludes(runtimeOption.description, runtime);
+    }
+  });
+
+  it("renders --runtime in `veryfront init --help` output", () => {
+    const output = captureConsoleLog(() => showCommandHelp("init"));
+    assertStringIncludes(output, "--runtime");
+  });
+});

--- a/cli/commands/init/command-help.ts
+++ b/cli/commands/init/command-help.ts
@@ -12,6 +12,11 @@ export const initHelp: CommandHelp = {
         "Project template (minimal | ai-agent | docs-agent | agentic-workflow | multi-agent-system | coding-agent | saas-starter)",
     },
     {
+      flag: "--runtime <name>",
+      description: "Target JavaScript runtime (node | bun | deno)",
+      default: "node",
+    },
+    {
       flag: "--integrations <list>",
       description: "Service integrations for chat template (gmail,slack,github,calendar)",
     },
@@ -49,6 +54,6 @@ export const initHelp: CommandHelp = {
     "Run without arguments for interactive wizard",
     "Interactive mode prompts for: location, template, and git initialization",
     "Use --deploy to create, push, and deploy in one step",
-    "Config file supports: name, template, integrations, skipInstall, skipEnvPrompt, env",
+    "Config file supports: name, template, runtime, integrations, skipInstall, skipEnvPrompt, env",
   ],
 };

--- a/cli/help/tips.test.ts
+++ b/cli/help/tips.test.ts
@@ -59,6 +59,19 @@ describe("cli/help/tips", () => {
         assertEquals(templates.includes(template), true);
       }
     });
+
+    it("aligns every template description in the same column", () => {
+      // The list is a table: ragged padding made `docs-agent` and `minimal`
+      // hang their descriptions in different columns from the rest.
+      // deno-lint-ignore no-control-regex
+      const plain = getInitTemplates().replace(/\x1b\[[0-9;]*m/g, "");
+      const columns = plain
+        .split("\n")
+        .filter((line) => line.includes("•"))
+        .map((line) => line.indexOf("- "));
+      assertEquals(columns.length, 7);
+      assertEquals(new Set(columns).size, 1, `misaligned columns: ${columns.join(", ")}`);
+    });
   });
 
   describe("getPostDeployTips", () => {

--- a/cli/help/tips.ts
+++ b/cli/help/tips.ts
@@ -17,13 +17,13 @@ export function getBuildTips(): string {
 
 export function getInitTemplates(): string {
   return `${yellow("Available Templates:")}\n` +
-    `  • ${green("ai-agent")}              - AI chatbot with tools and streaming\n` +
-    `  • ${green("docs-agent")}         - Document Q&A with source citations\n` +
+    `  • ${green("ai-agent")}            - AI chatbot with tools and streaming\n` +
+    `  • ${green("docs-agent")}          - Document Q&A with source citations\n` +
     `  • ${green("multi-agent-system")}  - Agents that delegate to each other\n` +
     `  • ${green("agentic-workflow")}    - AI pipeline with approvals\n` +
     `  • ${green("coding-agent")}        - AI code assistant with file tools\n` +
     `  • ${green("saas-starter")}        - AI SaaS with auth + per-user memory\n` +
-    `  • ${green("minimal")}       - Blank canvas\n`;
+    `  • ${green("minimal")}             - Blank canvas\n`;
 }
 
 export function getPostDeployTips(): string {


### PR DESCRIPTION
## Problem

`veryfront init --runtime <node|bun|deno>` has worked since #1894 and is documented
on the public getting-started page
(https://veryfront.com/docs/code/getting-started/create-project — "Choose a runtime"),
but the flag was never added to the init help entry. Against the published
**0.1.1229** binary:

```
$ veryfront init --help | grep -i runtime
(no output)
```

The help output lists `-t/--template`, `--integrations`, `--deploy`, `-f/--force`,
`-c/--config`, `--skip-install`, `--skip-env-prompt` — and nothing else. Meanwhile
`veryfront init x --template minimal --runtime bun` scaffolds correctly and prints
`bun install` / `bun dev`. The CLI's own discovery surface hid a supported,
documented flag. The `Notes:` line listing the `--config` keys omitted `runtime`
for the same reason, even though `handler.ts` reads `config.runtime`.

Same output, cosmetic: the `Available Templates` block padded template names to
three different widths, so descriptions hung in three different columns
(`ai-agent` at col 26, `docs-agent` at 23, `minimal` at 18).

## Fix

Help text only, no behaviour change:

- `cli/commands/init/command-help.ts` — document `--runtime <name>` (default `node`),
  add `runtime` to the config-file note.
- `cli/help/tips.ts` — pad every template name to the same width.

`--runtime` already parsed as a value flag (it is absent from `BOOLEAN_FLAGS` in
`cli/shared/args.ts`); documenting it with a `<name>` placeholder makes
`getDocumentedFlagKind` classify it as `"value"`, which is the same answer.

## Tests

`cli/commands/init/command-help.test.ts` (new) asserts the flag is documented, that
every value `parseRuntime` accepts appears in the description, and that
`showCommandHelp("init")` renders it. `cli/help/tips.test.ts` gains a column-alignment
assertion. Both fail on the pre-fix tree:

```
cli/commands/init/command-help ... documents --runtime ... => AssertionError
cli/help/tips ... aligns every template description ... => misaligned columns: 26, 23, 24, 24, 24, 24, 18
```

## Verified against the published repro

Published 0.1.1229 (installed via `install.sh --version 0.1.1229` into a sandbox
outside the platform checkout): `veryfront init --help | grep -i runtime` → no output.

This branch:

```
$ deno run -A cli/main.ts init --help | grep -i runtime
    --runtime <name>        Target JavaScript runtime (node | bun | deno) (default: node)
    Config file supports: name, template, runtime, integrations, skipInstall, skipEnvPrompt, env
```

and the flag still works end to end:

```
$ deno run -A cli/main.ts init vf31-bun --template minimal --runtime bun --skip-install --skip-env-prompt
  ✓ vf31-bun ready
  cd vf31-bun
  bun install
  bun dev
```

Template list on this branch:

```
Available Templates:
  • ai-agent            - AI chatbot with tools and streaming
  • docs-agent          - Document Q&A with source citations
  • multi-agent-system  - Agents that delegate to each other
  • agentic-workflow    - AI pipeline with approvals
  • coding-agent        - AI code assistant with file tools
  • saas-starter        - AI SaaS with auth + per-user memory
  • minimal             - Blank canvas
```

## Docs

No docs change needed — the public page already documents `--runtime`; the CLI was
the side that was out of date. Nothing to re-verify on the live site.
