### PR TITLE
Give prerendered app routes the head their layout declares

### DIFF
--- a/src/server/build-app-route-renderer.test.ts
+++ b/src/server/build-app-route-renderer.test.ts
@@ -16,6 +16,7 @@ import {
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 import { CLIENT_PAGE_ISLAND_ID } from "#veryfront/rendering/rsc/page-island.ts";
+import { HEAD_SHELL_PROVENANCE_ATTRIBUTE } from "#veryfront/html/managed-head-protocol.ts";
 import { getProjectReact } from "#veryfront/react";
 import { getReactDOMServer } from "#veryfront/react/compat/ssr-adapter/server-loader.ts";
 import {
@@ -561,6 +562,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <Head>
         <title>Assistant</title>
         <meta name="viewport" content="width=device-width, initial-scale=2.0" />
+        <script type="module" src="/analytics.js"></script>
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
       </Head>
       {children}
@@ -586,13 +588,31 @@ export default function Page() {
         contentSourceId: "test-content-source",
       });
 
-      assertStringIncludes(html, "<title>Assistant</title>");
-      assertEquals(html.includes("<title>Veryfront App</title>"), false);
+      // The title carries shell provenance so the client head manager adopts it
+      // instead of appending a second managed title.
+      assertStringIncludes(
+        html,
+        `<title ${HEAD_SHELL_PROVENANCE_ATTRIBUTE}="true">Assistant</title>`,
+      );
+      assertEquals(html.includes("Veryfront App"), false);
       assertStringIncludes(html, 'href="/favicon.svg"');
       // A layout-declared viewport replaces the shell default instead of
       // shipping two competing viewport directives.
       assertEquals(html.match(/name="viewport"/g)?.length, 1);
       assertStringIncludes(html, 'content="width=device-width, initial-scale=2.0"');
+      // Collected head elements close the head, after the project stylesheet,
+      // matching the request-time shell's cascade order.
+      const stylesheetIndex = html.indexOf('rel="stylesheet"');
+      const faviconIndex = html.indexOf('href="/favicon.svg"');
+      const headCloseIndex = html.indexOf("</head>");
+      assertEquals(stylesheetIndex >= 0 && stylesheetIndex < faviconIndex, true);
+      assertEquals(faviconIndex < headCloseIndex, true);
+      // A collected module script resolves bare specifiers only if the framework
+      // import map is already closed above it, and it still precedes the CSS.
+      const importMapEndIndex = html.indexOf("</script>", html.indexOf('type="importmap"'));
+      const collectedScriptIndex = html.indexOf('src="/analytics.js"');
+      assertEquals(importMapEndIndex >= 0 && importMapEndIndex < collectedScriptIndex, true);
+      assertEquals(collectedScriptIndex < stylesheetIndex, true);
     } finally {
       await cleanupProject(projectDir);
     }

--- a/src/server/build-app-route-renderer.test.ts
+++ b/src/server/build-app-route-renderer.test.ts
@@ -542,6 +542,64 @@ export default function Page() {
 });
 
 Deno.test({
+  name:
+    "server/build-app-route-renderer hoists the layout's declared <Head> title into the prerendered document",
+  async fn() {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-app-route-head-" });
+    const appDir = join(projectDir, "app");
+    const pageFile = join(appDir, "page.tsx");
+
+    try {
+      await Deno.mkdir(appDir, { recursive: true });
+      await Deno.writeTextFile(
+        join(appDir, "layout.tsx"),
+        `import { Head } from "veryfront/head";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Head>
+        <title>Assistant</title>
+        <meta name="viewport" content="width=device-width, initial-scale=2.0" />
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+      </Head>
+      {children}
+    </>
+  );
+}
+`,
+      );
+      await Deno.writeTextFile(
+        pageFile,
+        `"use client";
+export default function Page() {
+  return <button id="head-page" type="button">Open</button>;
+}
+`,
+      );
+
+      const html = await renderAppRouteToHTML({
+        adapter: denoAdapter,
+        projectDir,
+        routePath: "/",
+        pageFile,
+        contentSourceId: "test-content-source",
+      });
+
+      assertStringIncludes(html, "<title>Assistant</title>");
+      assertEquals(html.includes("<title>Veryfront App</title>"), false);
+      assertStringIncludes(html, 'href="/favicon.svg"');
+      // A layout-declared viewport replaces the shell default instead of
+      // shipping two competing viewport directives.
+      assertEquals(html.match(/name="viewport"/g)?.length, 1);
+      assertStringIncludes(html, 'content="width=device-width, initial-scale=2.0"');
+    } finally {
+      await cleanupProject(projectDir);
+    }
+  },
+});
+
+Deno.test({
   name: "server/build-app-route-renderer discovers and unwraps JavaScript document layouts",
   async fn() {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-app-route-js-layout-" });

--- a/src/server/build-app-route-renderer.ts
+++ b/src/server/build-app-route-renderer.ts
@@ -5,10 +5,17 @@
 import { dirname, isAbsolute, join, normalize, relative } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { getProjectReact, renderToStringAdapter } from "#veryfront/react";
+import { runWithHeadCollector } from "#veryfront/react/head-collector.ts";
+import {
+  buildHeadElements,
+  resolveCommittedHeadFromHTML,
+} from "#veryfront/rendering/orchestrator/html-head.ts";
 import { loadComponentFromSource } from "#veryfront/modules/react-loader/index.ts";
 import { COMPILATION_ERROR } from "#veryfront/errors";
 import { generateHydrationData, getProdScripts } from "#veryfront/html";
 import { buildImportMapJson } from "#veryfront/html/utils.ts";
+import { escapeHTML } from "#veryfront/html/html-escape.ts";
+import { headMetaSingletonKeyFromRecord } from "#veryfront/html/managed-head-protocol.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { getPreviewStylesheetLink } from "#veryfront/html/dev-scripts.ts";
 import {
@@ -271,8 +278,16 @@ async function renderAppRouteToHTMLWithInternals(
     }
   }
 
-  const htmlInner = await renderToStringAdapter(element, { reactVersion });
-  const title = "Veryfront App";
+  // Prerendered documents must carry the same identity the request-time SSR
+  // shell gives them: a layout's `<Head>` owns the title and the head links,
+  // and without a render context the Head instances never commit, leaving the
+  // built page on the framework's placeholder title.
+  const { result: htmlInner, head: requestHead } = await runWithHeadCollector(
+    (renderContext) => renderToStringAdapter(element, { reactVersion, renderContext }),
+  );
+  const committedHead = resolveCommittedHeadFromHTML(htmlInner, requestHead);
+  const title = committedHead?.title ?? "Veryfront App";
+  const headElements = buildHeadElements(committedHead);
   const slug = routePathToSlug(routePath);
   const importMapJson = await buildImportMapJson({
     projectDir,
@@ -318,12 +333,20 @@ async function renderAppRouteToHTMLWithInternals(
     ? getPreviewStylesheetLink()
     : "";
 
+  const headScripts = headElements.scripts ? `\n  ${headElements.scripts}` : "";
+  const headOther = headElements.other ? `\n  ${headElements.other}` : "";
+  // The shell owns the viewport only until a layout declares its own; emitting
+  // both would ship two competing viewport directives in one document.
+  const viewportMeta =
+    committedHead?.metas.some((meta) => headMetaSingletonKeyFromRecord(meta) === "meta:viewport")
+      ? ""
+      : `\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">`;
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${title}</title>
+  <meta charset="UTF-8">${viewportMeta}${headScripts}
+  <title>${escapeHTML(title)}</title>${headOther}
 
   <!-- Import map for React dependencies -->
   <script type="importmap">

--- a/src/server/build-app-route-renderer.ts
+++ b/src/server/build-app-route-renderer.ts
@@ -15,7 +15,10 @@ import { COMPILATION_ERROR } from "#veryfront/errors";
 import { generateHydrationData, getProdScripts } from "#veryfront/html";
 import { buildImportMapJson } from "#veryfront/html/utils.ts";
 import { escapeHTML } from "#veryfront/html/html-escape.ts";
-import { headMetaSingletonKeyFromRecord } from "#veryfront/html/managed-head-protocol.ts";
+import {
+  HEAD_SHELL_PROVENANCE_ATTRIBUTE,
+  headMetaSingletonKeyFromRecord,
+} from "#veryfront/html/managed-head-protocol.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { getPreviewStylesheetLink } from "#veryfront/html/dev-scripts.ts";
 import {
@@ -333,6 +336,10 @@ async function renderAppRouteToHTMLWithInternals(
     ? getPreviewStylesheetLink()
     : "";
 
+  // Mirror the request-time shell's head order exactly: the framework import
+  // map precedes every collected module script, and the remaining collected
+  // elements close the head so a layout's styles win the cascade over the
+  // generated project stylesheet.
   const headScripts = headElements.scripts ? `\n  ${headElements.scripts}` : "";
   const headOther = headElements.other ? `\n  ${headElements.other}` : "";
   // The shell owns the viewport only until a layout declares its own; emitting
@@ -345,15 +352,15 @@ async function renderAppRouteToHTMLWithInternals(
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">${viewportMeta}${headScripts}
-  <title>${escapeHTML(title)}</title>${headOther}
+  <meta charset="UTF-8">${viewportMeta}
+  <title ${HEAD_SHELL_PROVENANCE_ATTRIBUTE}="true">${escapeHTML(title)}</title>
 
   <!-- Import map for React dependencies -->
   <script type="importmap">
   ${importMapJson}
-  </script>
+  </script>${headScripts}
 
-  ${stylesheetLink}
+  ${stylesheetLink}${headOther}
 </head>
 <body>
 ${hydrationDataScript}


### PR DESCRIPTION
## What broke

A locally built project and the same project deployed rendered two different documents.

```
veryfront init x --template ai-agent   # app/layout.tsx declares <Head><title>Assistant</title></Head>
veryfront build
veryfront serve                        # -> agent-browser get title => "Veryfront App"
                                       # deployed origin (and `veryfront dev`) => "Assistant"
```

`deploy-project` tells the reader to run `veryfront serve` to "confirm functionality" before pushing, so the pre-deploy check is the one view that shows a placeholder identity the deployment never has.

Reproduced on published `0.1.1229` in a sandbox outside the monorepo: the prerendered `dist/index.html` contains `<title>Veryfront App</title>` and no favicon link.

## Why

`veryfront build` prerenders app-router routes through `renderAppRouteToHTML`, which hardcoded

```ts
const title = "Veryfront App";
```

and rendered with `renderToStringAdapter(element, { reactVersion })` — no `renderContext`. Without a render context, `Head` gets `serverCommitToken === undefined`, so its payload rides along as an inert `data-vf-ssr-head` attribute on a hidden div inside `#root` and nothing ever hoists it into `<head>`. The layout's `Head` also renders outside `#veryfront-page-island`, so hydration never re-runs it and the placeholder survives into the browser too.

Request-time SSR does this correctly (`ssr-orchestrator` → `runWithHeadCollector` → `resolveCommittedHeadFromHTML`); only the build path skipped it.

## The fix

`src/server/build-app-route-renderer.ts`:

- render inside `runWithHeadCollector` and pass the `renderContext` through to `renderToStringAdapter`, so `Head` instances commit
- resolve the committed payload out of the returned markup with `resolveCommittedHeadFromHTML`, the same helper the SSR shell uses
- emit the committed title plus the committed links / metas / blocking scripts into the document head via `buildHeadElements`
- a layout-declared viewport replaces the shell default instead of shipping two competing viewport directives
- the title is `escapeHTML`-escaped, matching `html-shell-generator`

No change to the fallback: a project with no `<Head>` still gets `Veryfront App`.

## Tests

New BDD case in `src/server/build-app-route-renderer.test.ts` — "hoists the layout's declared `<Head>` title into the prerendered document". It renders a real layout that imports `Head` from `veryfront/head` and asserts the built document carries `<title>Assistant</title>`, the declared favicon link, and exactly one viewport meta (the layout's).

Confirmed red before the fix for the right reason (document contained `<title>Veryfront App</title>` and no favicon link), green after. All 8 tests in the file pass, as do `src/build/production-build/`, `src/rendering/orchestrator/`, and the full pre-push suite.

## Verified against the original repro

Not "tests pass" — the finding's own command, against a build of this branch:

```
veryfront build && veryfront serve
agent-browser open http://localhost:3000 && agent-browser get title
=> Assistant          # was: Veryfront App on published 0.1.1229
```

`curl http://localhost:3000/` returns `<title>Assistant</title>` and the favicon link is now in `<head>`. The accessibility snapshot is also clean — no raw stylesheet text node, which the finding reported as a second symptom under `veryfront serve`.

## Live URL to check

None — this is framework behaviour, no doc change.

## Review follow-up (11cd1ea27)

Three divergences from the shell this was meant to mirror, all confirmed against `src/rendering/orchestrator/html.ts` and `src/html/html-shell-generator.ts` and fixed:

- the hoisted `<title>` now carries `data-vf-shell-head`, so the client head manager adopts it instead of appending a second managed title
- collected scripts now follow the closed framework import map (matching `injectHeadScriptsAfterImportMap`) instead of preceding it, so a layout's module script can resolve bare specifiers
- the remaining collected elements now close the head, after the project stylesheet, so a layout's `<Head>` styles win the cascade as they do at request time

The regression test grew assertions for all three, and the layout fixture declares a module script so the import-map ordering is exercised rather than assumed.
