### PR TITLE
fix(cli): avoid dual-stack dev port collisions

### DIFF
--- a/cli/commands/dev/port-fallback.test.ts
+++ b/cli/commands/dev/port-fallback.test.ts
@@ -125,6 +125,17 @@ describe("cli/commands/dev/port-fallback", () => {
 
       assertEquals(await isPortAvailable(freePort), true);
     });
+
+    it("skips a port held by the IPv6 MCP listener", async () => {
+      const held = Deno.listen({ hostname: "::1", port: 0 });
+      const heldPort = (held.addr as Deno.NetAddr).port;
+
+      try {
+        assertEquals(await isPortAvailable(heldPort), false);
+      } finally {
+        held.close();
+      }
+    });
   });
 
   describe("isPortInUseError", () => {

--- a/cli/commands/dev/port-fallback.ts
+++ b/cli/commands/dev/port-fallback.ts
@@ -33,12 +33,21 @@ export function isPortInUseError(error: unknown): boolean {
     message.includes("eaddrinuse") || message.includes("address already in use");
 }
 
-/** Binds `port` and releases it again, to see whether the dev server could have it. */
-export async function isPortAvailable(port: number): Promise<boolean> {
+/** True when the current machine cannot bind the requested network address. */
+function isAddressUnavailableError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as { code?: string }).code ?? "";
+  const message = error.message.toLowerCase();
+  return error.name === "AddrNotAvailable" || code === "EADDRNOTAVAIL" ||
+    message.includes("eaddrnotavail") || message.includes("address not available");
+}
+
+/** Binds one local address and releases it again. */
+async function isHostPortAvailable(hostname: string, port: number): Promise<boolean> {
   if (isDeno) {
     try {
       // @ts-ignore - Deno global
-      Deno.listen({ hostname: LOCALHOST.IPV4, port }).close();
+      Deno.listen({ hostname, port }).close();
       return true;
     } catch (error) {
       if (isPortInUseError(error)) return false;
@@ -54,10 +63,25 @@ export async function isPortAvailable(port: number): Promise<boolean> {
       if (isPortInUseError(error)) resolve(false);
       else reject(error);
     });
-    server.listen({ port, host: LOCALHOST.IPV4, exclusive: true }, () => {
+    server.listen({ port, host: hostname, exclusive: true }, () => {
       server.close(() => resolve(true));
     });
   });
+}
+
+/** Binds `port` on IPv4 and IPv6 to see whether either local address is busy. */
+export async function isPortAvailable(port: number): Promise<boolean> {
+  for (const hostname of [LOCALHOST.IPV4, LOCALHOST.IPV6]) {
+    try {
+      if (!await isHostPortAvailable(hostname, port)) return false;
+    } catch (error) {
+      // IPv6 may be disabled on the host. In that case only the IPv4 probe is
+      // relevant, but all other unexpected listener failures must still escape.
+      if (hostname === LOCALHOST.IPV6 && isAddressUnavailableError(error)) continue;
+      throw error;
+    }
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## What changed

- Probe both IPv4 and IPv6 loopback addresses before selecting a dev-server port.
- Skip the IPv6 probe only when IPv6 is unavailable on the host.
- Add a regression test for a port held by the MCP listener on `::1`.

## Why

Two simultaneous `veryfront dev` sessions could select the same numeric port on different loopback families. The CLI then printed a `veryfront.me` URL for the second app, but browsers that resolved IPv6 first reached the first session's MCP server instead.

## Impact

Port fallback now avoids ports occupied on either loopback family, so the printed development URL reaches the intended app.

## Validation

- Regression test failed before the implementation and passed after it.
- Focused test: 1 test, 16 steps passed.
- `deno fmt --check`: passed for both changed files.
- `deno lint`: passed for both changed files.
- `deno check cli/commands/dev/port-fallback.ts`: passed.
- Local smoke test: with ports 3000 and 3001 occupied on IPv4 and port 3002 occupied by an IPv6 MCP listener, `veryfront dev` selected port 3003 and served the intended app.
- Repository pre-push checks passed formatting, lint, typecheck, and 3,779 unit tests with zero failures. The hook then exited nonzero because Deno reported one pending promise after the event loop resolved.
