### PR TITLE
docs: replace the stale chat README with a contributor map

### DIFF
--- a/src/react/components/chat/README.md
+++ b/src/react/components/chat/README.md
@@ -1,391 +1,79 @@
-# Veryfront Chat Styled Components
+# Chat components — contributor map
 
-**Status**: Phase 6 Complete (Styled Components)
-**Module**: `veryfront/react`
-**Layer**: 3 (Styled - Production-ready)
+Implementation of the chat UI. The public entry point is `veryfront/chat`,
+declared in `deno.json` as [`src/chat/index.ts`](../../../chat/index.ts); the
+components it re-exports live here.
 
-## Overview
-
-Production-ready, fully styled components built on Layer 2 primitives. Get started in seconds with sensible defaults.
-
-**Uses Veryfront's parts-based UI message format** for chat content.
-
-## Philosophy
-
-- **Production-ready** - Fully styled with Tailwind CSS
-- **Customizable** - Theme system and render props
-- **Dark mode** - Built-in dark mode support
-- **Accessible** - ARIA attributes from primitives
-- **Composable** - Composition API for advanced use
-
-## Available Components
-
-### Chat
-
-Complete chat interface with messages, input, and loading states.
-
-```tsx
-import { Chat } from "veryfront/react";
-import { useChat } from "veryfront/agent/react";
-
-export default function ChatPage() {
-  const chat = useChat();
-
-  return (
-    <Chat
-      chat={chat}
-      placeholder="Ask anything..."
-      maxHeight="80vh"
-    />
-  );
-}
-```
-
-The `Chat` component handles the parts-based UI message format internally, extracting text from the `parts` array automatically.
-
-**Customization via theme:**
-
-```tsx
-<Chat
-  chat={chat}
-  theme={{
-    container: "bg-gradient-to-b from-gray-50 to-white",
-    message: {
-      user: "bg-indigo-600 text-white rounded-2xl",
-      assistant: "bg-gray-100 text-gray-900 rounded-2xl",
-    },
-    input: "border-2 border-indigo-500",
-    button: "bg-indigo-600 hover:bg-indigo-700",
-  }}
-/>;
-```
-
-**Customization via render props:**
-
-```tsx
-import type { ChatMessage } from "veryfront/agent/react";
-
-// Helper to extract text from the parts array
-function getTextContent(message: ChatMessage): string {
-  return message.parts
-    .filter((p) => p.type === "text")
-    .map((p) => p.text)
-    .join("");
-}
-
-<Chat
-  chat={chat}
-  renderMessage={(msg) => (
-    <CustomMessage
-      id={msg.id}
-      role={msg.role}
-      content={getTextContent(msg)}
-      parts={msg.parts}
-    />
-  )}
-/>;
-```
-
-**Composition API:**
-
-```tsx
-import { Chat } from "veryfront/react";
-
-<Chat.Root
-  messages={messages}
-  input={input}
-  setInput={setInput}
-  onSubmit={onSubmit}
+> **This file is not the chat API documentation, and must not become it.**
 >
-  <header>
-    <h1>Customer Support</h1>
-    <Status />
-  </header>
+> Every published name, signature, prop, and usage example is already carried by
+> generated or contract-tested files (below). A hand-written fourth copy beside
+> the source is the worst of the four: it looks authoritative because it sits
+> next to the code, and nothing checks it. The previous version of this README
+> was exactly that — it still advertised a `veryfront/react` module that has
+> never existed in `deno.json`'s `exports`, an `AgentCard` `theme` prop that was
+> removed, and a message-part `switch` that silently dropped every real tool
+> call. Keep this file to orientation: where things are, and which check keeps
+> which claim honest. If you want to write an example, put it where a test can
+> run it.
 
-  <Chat.MessageList messages={messages} />
+## Where the chat API is documented — and what keeps each honest
 
-  <Chat.Input.Root
-    input={input}
-    onChange={onChange}
-    onSubmit={onSubmit}
-  >
-    <Chat.Input.Field placeholder="How can we help?" />
-    <Chat.Input.Toolbar>
-      <Chat.Input.Export messages={messages} />
-      <Chat.Input.Send />
-    </Chat.Input.Toolbar>
-  </Chat.Input.Root>
+| Document                                                                                   | Covers                                                       | Enforced by                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`docs/api-reference/veryfront/chat.md`](../../../../docs/api-reference/veryfront/chat.md) | Every export of `veryfront/chat`, with source links          | Generated. `deno task docs` regenerates; `deno task docs:api-reference:check` fails CI when it drifts                                                          |
+| [`docs/guides/chat-ui.md`](../../../../docs/guides/chat-ui.md)                             | Preset → customization → composition, theming, conversations | `tests/docs/guide-*.test.ts` (via `deno task docs:validate`) compile and assert the examples                                                                   |
+| [`docs/guides/chat-hooks.md`](../../../../docs/guides/chat-hooks.md)                       | `useChat`, `useAgent`, persistence, composition hooks        | same guide contract tests                                                                                                                                      |
+| Storybook stories under `storybook/stories/chat`                                           | Rendered anatomy per compound                                | [`scripts/lint/audit-chat-composability.ts`](../../../../scripts/lint/audit-chat-composability.ts) rejects `compositionTree` tokens that aren't real sub-parts |
+| JSDoc on the exports themselves                                                            | Per-prop meaning                                             | Feeds the generated reference above                                                                                                                            |
 
-  <footer>Powered by Veryfront</footer>
-</Chat.Root>;
-```
+Docs changes belong in one of those. Adding an export? Regenerate the reference
+with `deno task docs` (CI pins Deno 2.7.7 — put it first on `PATH`).
 
-### AgentCard
+## Layout
 
-Agent status and tool visualization.
+| Path                                                                                                                                                                                                         | Holds                                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| [`chat/composition/`](./chat/composition)                                                                                                                                                                    | The composition surface — `ChatRoot`, `ChatMessageList`, the composer, `Message`, `ChatEmpty`, `ChatIf`, `ErrorBanner` |
+| [`chat/contexts/`](./chat/contexts)                                                                                                                                                                          | The providers those read from: chat, message, composer, conversations                                                  |
+| [`chat/components/`](./chat/components)                                                                                                                                                                      | Leaf pieces — reasoning, tool calls, sources, attachments, feedback, skeletons                                         |
+| [`chat/hooks/`](./chat/hooks)                                                                                                                                                                                | Headless hooks — composer input, stick-to-bottom, uploads, the `useConversation*` family                               |
+| [`chat/persistence/`](./chat/persistence)                                                                                                                                                                    | Conversation store implementations (local, memory) plus their codec and lock                                           |
+| [`chat/utils/`](./chat/utils)                                                                                                                                                                                | Part grouping, text extraction, Markdown export                                                                        |
+| [`chat/chat-preset.tsx`](./chat/chat-preset.tsx)                                                                                                                                                             | The `<Chat>` preset — app mode and controlled mode assembled from the above                                            |
+| [`theme.ts`](./theme.ts), [`chat-tokens.ts`](./chat-tokens.ts), [`chat-theme-scope.tsx`](./chat-theme-scope.tsx)                                                                                             | Theme contracts and the CSS-variable token scope. Dark mode is tokens, not `dark:` variants                            |
+| [`agent-card.tsx`](./agent-card.tsx), [`agent-picker.tsx`](./agent-picker.tsx), [`model-selector.tsx`](./model-selector.tsx), [`markdown.tsx`](./markdown.tsx), [`error-boundary.tsx`](./error-boundary.tsx) | Standalone components that ship through the same barrel                                                                |
 
-```tsx
-import { AgentCard } from "veryfront/react";
-import { useAgent } from "veryfront/agent/react";
+## Barrels and the parity rule
 
-export default function AgentInterface() {
-  const agent = useAgent({ agent: "support" });
+Three module specifiers reach this code, and they must expose the _same function
+objects_, not merely the same names:
 
-  return (
-    <AgentCard
-      {...agent}
-      theme={{
-        thinking: "bg-amber-50 border-amber-500",
-        tool: "bg-blue-50 border-blue-500",
-      }}
-    />
-  );
-}
-```
+- `veryfront/chat` → [`src/chat/index.ts`](../../../chat/index.ts) — the only
+  one in `deno.json`'s `exports`, so the only one a consumer project can import.
+- `veryfront/react/components/chat` and `veryfront/components/chat` →
+  [`index.ts`](./index.ts) — internal import-map aliases, re-exporting
+  [`chat.tsx`](./chat.tsx), which aggregates the subdirectories above.
 
-### Message
+A new export has to be threaded through all of them.
+[`src/chat/index.test.ts`](../../../chat/index.test.ts) asserts identity across
+the barrels and that each `ChatInput` leaf is the same function as its compound
+sub-part; `deno task lint:chat-ratchets` type-checks
+[`src/react/chat-barrels.check.ts`](../../chat-barrels.check.ts) alongside it.
 
-Message component for the parts-based `ChatMessage` format. Use the default
-anatomy or include only the compound parts your layout needs.
+Sub-parts are attached with `Object.assign` (`Chat.Root`, `Message.Content`,
+`ChatInput.Send`, …). The composability lint and
+`chat/composability.contract.test.tsx` both key off that shape, so keep new
+parts on the same pattern.
 
-```tsx
-import { Message } from "veryfront/react";
+## Working on this directory
 
-<Message.Root message={msg}>
-  <Message.Header />
-  <Message.Content />
-  <Message.Sources />
-  <Message.Actions />
-</Message.Root>;
-```
+`deno task lint:chat-ratchets`, `deno task lint:chat-composability`, and
+`deno task docs:api-reference:check` are the chat-specific gates;
+`deno task docs:check-links` validates the relative links in this file.
 
-### Streaming
+## See also
 
-Pass `isStreaming` to `<Message>` to surface the "Continuing..." shimmer while
-the turn is still generating.
-
-```tsx
-import { Message } from "veryfront/react";
-
-<Message message={message} isStreaming />;
-```
-
-## Theme System
-
-All components support theme customization:
-
-### Chat Theme
-
-```typescript
-interface ChatTheme {
-  container?: string;
-  message?: {
-    user?: string;
-    assistant?: string;
-    system?: string;
-    tool?: string;
-  };
-  input?: string;
-  button?: string;
-  loading?: string;
-}
-```
-
-### Agent Theme
-
-```typescript
-interface AgentTheme {
-  container?: string;
-  status?: string;
-  thinking?: string;
-  tool?: string;
-  toolResult?: string;
-}
-```
-
-## Dark Mode
-
-All components support dark mode automatically via CSS custom properties. Dark mode activates through `prefers-color-scheme: dark`, a `.dark` class, or `[data-theme="dark"]` on a parent element. No `dark:` Tailwind variants are needed. The token system handles it:
-
-```tsx
-<Chat chat={chat} />;
-// Automatically adapts to dark mode via CSS variables
-```
-
-## Accessibility
-
-All components inherit accessibility from Layer 2 primitives:
-
-- Semantic HTML
-- ARIA attributes
-- Keyboard navigation
-- Screen reader support
-
-## Customization Levels
-
-### Level 1: Just Use It
-
-```tsx
-<Chat chat={chat} />;
-```
-
-### Level 2: Theme Customization
-
-```tsx
-<Chat
-  chat={chat}
-  theme={{
-    message: { user: "bg-purple-600 text-white" },
-  }}
-/>;
-```
-
-### Level 3: Render Props
-
-```tsx
-<Chat
-  chat={chat}
-  renderMessage={CustomMessage}
-/>;
-```
-
-### Level 4: Composition API
-
-```tsx
-<Chat.Root
-  messages={chat.messages}
-  input={chat.input}
-  setInput={chat.setInput}
-  onSubmit={chat.handleSubmit}
->
-  <header>Custom Header</header>
-  <Chat.MessageList messages={chat.messages} />
-  <Chat.Input.Root
-    input={chat.input}
-    onChange={chat.handleInputChange}
-    onSubmit={chat.handleSubmit}
-  >
-    <Chat.Input.Field />
-    <Chat.Input.Toolbar>
-      <Chat.Input.Export messages={chat.messages} />
-      <Chat.Input.Send />
-    </Chat.Input.Toolbar>
-  </Chat.Input.Root>
-</Chat.Root>;
-```
-
-### Level 5: Drop to Layer 2 or 1
-
-If you need more control, use primitives (Layer 2) or hooks only (Layer 1).
-
-## Examples
-
-### Quick Start (5 lines)
-
-```tsx
-import { Chat } from "veryfront/react";
-import { useChat } from "veryfront/agent/react";
-
-export default function App() {
-  const chat = useChat();
-  return <Chat chat={chat} />;
-}
-```
-
-### Custom Styling
-
-```tsx
-<Chat
-  chat={chat}
-  className="rounded-xl shadow-lg"
-  theme={{
-    message: {
-      user: "bg-gradient-to-r from-blue-600 to-purple-600 text-white",
-      assistant: "bg-gradient-to-r from-gray-100 to-gray-200",
-    },
-    input: "border-2 border-purple-500 focus:ring-purple-500",
-    button: "bg-purple-600 hover:bg-purple-700",
-  }}
-  placeholder="Ask me anything..."
-/>;
-```
-
-### Integration with Agent
-
-```tsx
-import { AgentCard, Chat } from "veryfront/react";
-import { useAgent } from "veryfront/agent/react";
-
-export default function AgentChat() {
-  const agent = useAgent({ agent: "support" });
-
-  return (
-    <div className="grid grid-cols-2 gap-4">
-      <Chat.Root messages={agent.messages} input="">
-        <Chat.MessageList messages={agent.messages} />
-      </Chat.Root>
-      <AgentCard {...agent} />
-    </div>
-  );
-}
-```
-
-### Working with Chat Message Parts
-
-The built-in message renderer keeps raw message parts available, but assistant answer rendering prefers the final text emitted after tool activity. This prevents pre-tool progress narration from becoming part of the final visible answer while preserving tool calls and results for evidence, sources, and custom UI. Custom renderers should apply the same split when they present a final assistant answer.
-
-```tsx
-import { Chat } from "veryfront/react";
-import { useChat } from "veryfront/agent/react";
-import type { ChatMessage } from "veryfront/agent/react";
-
-// Custom renderer that handles all part types
-function CustomMessage({ message }: { message: ChatMessage }) {
-  return (
-    <div>
-      {message.parts.map((part, i) => {
-        switch (part.type) {
-          case "text":
-            return <p key={i}>{part.text}</p>;
-          case "reasoning":
-            return <blockquote key={i}>{part.text}</blockquote>;
-          case "tool-call":
-            return <div key={i}>Tool: {part.toolName} ({part.state})</div>;
-          case "tool-result":
-            return <div key={i}>Result: {JSON.stringify(part.result)}</div>;
-        }
-      })}
-    </div>
-  );
-}
-
-export default function AdvancedChat() {
-  const chat = useChat();
-
-  return (
-    <Chat
-      chat={chat}
-      renderMessage={(msg) => <CustomMessage message={msg} />}
-    />
-  );
-}
-```
-
-## Status
-
-**Phase 6: Styled Components** **COMPLETE**
-
-**Created:**
-
-- Chat component with theme system (parts-based ChatMessage support)
-- AgentCard component
-- Message component
-- Message streaming state
-- Theme system with defaults
-- Composition API
-- Dark mode support
-- Full customization options
-
-**Total: 4 styled components** + theme system
-
-**Next**: Phase 7 (Developer Experience)
+- [`../README.md`](../README.md) — sibling framework components
+- [`../../README.md`](../../README.md) — the React module as a whole
+- [`docs/rfcs/29-chat-api-shape.md`](../../../../docs/rfcs/29-chat-api-shape.md) — why the composition surface is shaped this way

--- a/src/react/components/chat/README.md
+++ b/src/react/components/chat/README.md
@@ -10,10 +10,11 @@ components it re-exports live here.
 > generated or contract-tested files (below). A hand-written fourth copy beside
 > the source is the worst of the four: it looks authoritative because it sits
 > next to the code, and nothing checks it. The previous version of this README
-> was exactly that — it still advertised a `veryfront/react` module that has
-> never existed in `deno.json`'s `exports`, an `AgentCard` `theme` prop that was
-> removed, and a message-part `switch` that silently dropped every real tool
-> call. Keep this file to orientation: where things are, and which check keeps
+> was exactly that — every one of its examples imported from a path
+> `deno.json`'s `exports` has never published (`veryfront/react`,
+> `veryfront/agent/react`), it showed an `AgentCard` `theme` prop that
+> `AgentCardProps` does not have, and its headline renderer branched on a
+> message-part type that never arrives, silently dropping every real tool call. Keep this file to orientation: where things are, and which check keeps
 > which claim honest. If you want to write an example, put it where a test can
 > run it.
 
@@ -46,20 +47,53 @@ with `deno task docs` (CI pins Deno 2.7.7 — put it first on `PATH`).
 
 ## Barrels and the parity rule
 
-Three module specifiers reach this code, and they must expose the _same function
-objects_, not merely the same names:
+Three barrels re-export this code, and their export sets are deliberately
+_different_. The rule is identity on the shared subset, not one union:
 
 - `veryfront/chat` → [`src/chat/index.ts`](../../../chat/index.ts) — the only
-  one in `deno.json`'s `exports`, so the only one a consumer project can import.
+  one of the three in `deno.json`'s `exports`, so the only one a consumer
+  project can import. A curated public surface: it takes components from
+  [`chat.tsx`](./chat.tsx), adds names that don't live in this directory at all
+  (`useChat`, `useAgent`, `useCompletion`, `useStreaming`, `useVoiceInput` from
+  `src/agent/react/`; `AppShell`, `Tabs`, `CodeBlock` from [`../ui/`](../ui)),
+  and withholds others on purpose — `chatTokens`, `getChatTokensCSS`, and
+  `ColorModeProvider` are asserted _absent_ from it.
 - `veryfront/react/components/chat` and `veryfront/components/chat` →
-  [`index.ts`](./index.ts) — internal import-map aliases, re-exporting
-  [`chat.tsx`](./chat.tsx), which aggregates the subdirectories above.
+  [`index.ts`](./index.ts) — internal import-map aliases over the same
+  [`chat.tsx`](./chat.tsx), plus this directory's theme, token, style-provider
+  and color-mode exports that the public surface withholds.
+- [`../../public.ts`](../../public.ts) — the browser barrel served as
+  `veryfront/react` by the generated import map. Also internal: not in
+  `deno.json`'s `exports`.
 
-A new export has to be threaded through all of them.
-[`src/chat/index.test.ts`](../../../chat/index.test.ts) asserts identity across
-the barrels and that each `ChatInput` leaf is the same function as its compound
-sub-part; `deno task lint:chat-ratchets` type-checks
-[`src/react/chat-barrels.check.ts`](../../chat-barrels.check.ts) alongside it.
+What is actually enforced, and where:
+
+- **Presence in all three**, for one named subset only:
+  `CompoundChatRuntimeExport` in
+  [`../../chat-barrels.check.ts`](../../chat-barrels.check.ts) lists the 32
+  names (the `ChatInput` leaves, `AgentAvatar`, `ChatEmptyState`,
+  `ChatMessagesSkeleton`, `mergeProps`, the headless hooks) that must exist in
+  every barrel; that file also cross-checks `Reasoning`/`ToolCall`, the
+  conversation type family, and `ChatInputRootProps` compatibility.
+  `deno task lint:chat-ratchets` type-checks it.
+- **Identity** — the same function object, not just the same name — for the ten
+  `ChatInput` leaves across `veryfront/chat`, both component aliases and
+  `chat.tsx` (and against the matching `ChatInput.<Part>`), for
+  `useConversationChat` and the canonical hook/context set across both aliases,
+  and for the core re-exports (`Chat`, `useChat`, `useAgent`, `AgentCard`,
+  `ChatErrorBoundary`, …) against their defining modules. All in
+  [`src/chat/index.test.ts`](../../../chat/index.test.ts).
+- **The exact public key list**: the same test asserts `Object.keys` of
+  `veryfront/chat` equals a literal array, so adding or removing a public export
+  fails until that array is updated.
+
+So a new export does not automatically belong in all three — pick the surface.
+Public chat API goes in `src/chat/index.ts` plus its `expectedRuntimeExports`
+entry; something only the React components need belongs in the components
+barrel alone. Either way re-export it from the module that defines it rather
+than re-wrapping — every barrel reading the same source file is what keeps the
+shared names identical — and if it is part of a compound, add it to
+`CompoundChatRuntimeExport` so all three stay in step.
 
 Sub-parts are attached with `Object.assign` (`Chat.Root`, `Message.Content`,
 `ChatInput.Send`, …). The composability lint and


### PR DESCRIPTION
`src/react/components/chat/README.md` was a 391-line consumer tutorial sitting
beside the source with nothing policing it. It declared "Status: Phase 6
Complete" and "Module: `veryfront/react`". A developer reading it would code
against it, because it looks authoritative in a way a `docs/` file doesn't.

## What was actually wrong

Audited against `deno.json`'s `exports`, `src/chat/index.ts`, and the components
under `src/react/components/chat/`:

| Claim | Reality |
| --- | --- |
| 15 import statements, across every example | All 15 name modules absent from `deno.json`'s `exports` — 8x `veryfront/react`, 7x `veryfront/agent/react`. Nothing in the file was copy-pasteable from a consumer project. The real path is `veryfront/chat`, which also exports `useChat`/`useAgent`. |
| `<AgentCard theme={{ thinking, tool }} />` | `AgentCardProps` has no `theme` — it's `name`/`avatarUrl`/`messages`/`toolCalls`/`status`/`thinking`/`className`/`children`/`ref`. |
| The "advanced" renderer's `switch (part.type)`, `case "tool-call"` | No UI `ChatMessagePart` is ever `"tool-call"`. Tool activity arrives as `ChatToolPart` — `` type: `tool-${toolName}` `` with `.state`/`.output`. It type-checks (`"tool-call"` is assignable to the template literal) and then silently drops every real tool call at runtime. The headline example taught a broken renderer. |
| A hand-rolled `getTextContent` helper | `getTextContent` is exported from the barrel. |
| "**Total: 4 styled components**" | `veryfront/chat` exports 354 names (144 of them runtime, per `src/chat/index.test.ts`). |
| 7 composition identifiers shown | The compound also exposes `Chat.Empty`, `Chat.Skeleton`, `Chat.If`, `Chat.ErrorBanner`; `ChatInput` has 10 leaves and `Message` 9+ parts. |
| "Phase 6 Complete", "Next: Phase 7", "Layer 2 primitives", "Level 5: Drop to Layer 2 or 1" | Maps to nothing live. The only other "Phase" reference in `src/` is `src/react/primitives/README.md`; "Layer 2" survives in RFC 29 with an unrelated meaning (opt-in root context). |

Correct and current: the `ChatTheme` and `AgentTheme` interface blocks, the
`<Message isStreaming>` semantics, and the dark-mode paragraph. That's it.

## Why not just fix it

The accurate parts are already policed elsewhere, with tighter guarantees:

- `docs/api-reference/veryfront/chat.md` is **generated** and CI-enforced via
  `docs:api-reference:check`. `ChatTheme` is in it, with a source link.
- `docs/guides/chat-ui.md` and `docs/guides/chat-hooks.md` are **contract-tested**
  by `tests/docs/guide-*.test.ts` — the examples are compiled and asserted.

Rewriting the tutorial in place would have restored the same thing that broke:
a fourth copy of the chat API surface, this one with no check behind it.
There's direct evidence that spot-fixing doesn't hold here: 375b41fb6 ("Complete
chat composition migration") already hand-patched this file in July —
`{...chat}` → `chat={chat}`, `Chat.Header` → `Chat.Root` — and left the import
path wrong and the new composition parts undocumented. It drifted again
immediately, because nothing runs against it.

## Why not delete it either

Two things in this directory are real orientation that neither the generated
reference nor the guides carry, and both are contributor-only:

1. **The three-barrel parity rule.** `veryfront/chat` → `src/chat/index.ts` is
   the only specifier in `exports`; `veryfront/react/components/chat` and
   `veryfront/components/chat` are internal aliases onto
   `src/react/components/chat/index.ts`. They must expose the *same function
   objects*, and a new export has to be threaded through all of them.
   `src/chat/index.test.ts` and `src/react/chat-barrels.check.ts` enforce this,
   but nothing told you it existed.
2. **The layout** of ~40 top-level files plus `chat/{composition,contexts,
   components,hooks,persistence,utils}`.

`src/` modules carry READMEs by convention (29 of them, and
`src/react/README.md` annotates `components/ [has README]`), and these READMEs
are excluded from the published package — they're for contributors.

## What it is now

113 lines, down from 391. **No signatures, no prop lists, no usage examples, no component
catalog** — so there is no API surface left in it to go stale. It carries the
layout, the parity rule, and a table routing each kind of API claim to the doc
that owns it *and the check that keeps that doc true*, with a stated rule at the
top that this file must not become the API documentation again.

Every path in it is a relative markdown link, which makes it partly
self-policing: `scripts/lint/check-doc-links.ts` walks `src/`, so CI now fails
if any directory or file it describes is moved or renamed. Verified locally:
`All 1264 doc links OK`.

No inbound references to the old file existed anywhere in the repo.

## Review follow-up (570f0751a)

The parity section originally said every new export must be threaded through
all three barrels. That was wrong, and the test it cited proves it:
`src/chat/index.test.ts:278-284` asserts `chatTokens`, `getChatTokensCSS` and
`ColorModeProvider` stay *out* of `veryfront/chat` while
`src/react/components/chat/index.ts:25-37` exports exactly those, and
`veryfront/chat` in turn carries hooks (`useChat`, `useAgent`, `useCompletion`,
…) that do not live in this directory at all. The section now states what is
actually enforced — presence across the barrels for the 32 names in
`CompoundChatRuntimeExport` (`src/react/chat-barrels.check.ts:187-230`),
function identity for the `ChatInput` leaves and the canonical hook set, and
the exact public key list asserted by `Object.keys` — and names
`src/react/public.ts`, the third barrel that check actually compares.

---

Docs-only; no source, test, or generated artifact touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the outdated component README with a contributor-oriented guide.
  * Added navigation for API documentation, component structure, exports, development checks, parity rules, and related resources.
  * Clarified that the guide provides orientation, while authoritative API documentation remains the source of truth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
