### PR TITLE
ci: stop moot merge-queue runs from ejecting healthy PRs from CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,68 @@ jobs:
           languages: javascript-typescript
           queries: security-and-quality
 
-      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+      # A merge-queue batch can dissolve while this job is still running. GitHub
+      # then deletes the ephemeral gh-readonly-queue ref, and the SARIF upload —
+      # which starts ~10 minutes in, after the analysis itself has already
+      # succeeded — fails with "ref ... not found in this repository". Nothing is
+      # being merged at that point, so the run is moot rather than failing, but
+      # the queue reads the red check as the PR's fault and ejects it.
+      #
+      # github/codeql-action offers no supported way to express "this run is
+      # moot" (github/codeql-action#1572, open since March 2023 with no fix), so
+      # the outcome is captured here and re-raised by the guard below. The guard
+      # fails closed: only a target ref that has provably gone away — or moved to
+      # a different SHA, meaning the batch was rebuilt without us — is tolerated.
+      - id: analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        continue-on-error: true
         with:
           category: "/language:javascript-typescript"
+
+      - name: Re-raise CodeQL failure unless the target ref is gone
+        if: ${{ steps.analyze.outcome == 'failure' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_REF: ${{ github.ref }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Only merge-queue refs are ephemeral. Every other event keeps its ref,
+          # so a CodeQL failure there is always the build's problem.
+          if [ "$EVENT_NAME" != "merge_group" ]; then
+            echo "::error::CodeQL failed on a ${EVENT_NAME} run. Failing the build."
+            exit 1
+          fi
+
+          body="$(mktemp)"
+          status="$(curl -sS -o "$body" -w '%{http_code}' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/git/ref/${TARGET_REF#refs/}" \
+            || echo "000")"
+
+          case "$status" in
+            404)
+              echo "::notice::${TARGET_REF} no longer exists: the merge-queue batch dissolved" \
+                "while CodeQL was uploading. Nothing is being merged from this run, so its" \
+                "result cannot gate anything. Treating it as moot."
+              ;;
+            200)
+              current="$(jq -r '.object.sha // empty' "$body")"
+              if [ "$current" = "$TARGET_SHA" ]; then
+                echo "::error::${TARGET_REF} still points at ${TARGET_SHA}, so this run is live." \
+                  "The CodeQL failure is genuine. Failing the build."
+                exit 1
+              fi
+              echo "::notice::${TARGET_REF} has moved from ${TARGET_SHA} to ${current}: the batch" \
+                "was rebuilt without this run. Its result cannot gate the new head. Treating it as moot."
+              ;;
+            *)
+              echo "::error::Could not determine whether ${TARGET_REF} still exists (HTTP ${status})." \
+                "Failing closed."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,11 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Analyze
     runs-on: ubuntu-latest
+    # CodeQL takes ~10 minutes on this repo. Cap the job well under the merge
+    # queue's check_response_timeout (1800s) so that a hung step fails fast and
+    # visibly, rather than stalling until the Actions default of 360 minutes —
+    # which would reproduce the very ejection this workflow exists to prevent.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -38,9 +43,23 @@ jobs:
       #
       # github/codeql-action offers no supported way to express "this run is
       # moot" (github/codeql-action#1572, open since March 2023 with no fix), so
-      # the outcome is captured here and re-raised by the guard below. The guard
-      # fails closed: only a target ref that has provably gone away — or moved to
-      # a different SHA, meaning the batch was rebuilt without us — is tolerated.
+      # the outcome is captured here and re-raised by the guard below.
+      #
+      # What the guard actually tolerates, stated plainly: ANY analyze failure on
+      # a merge_group run whose target ref has provably gone away, or has moved
+      # to a different SHA. That is broader than the upload 404 that motivated it
+      # — an extractor crash or a query failure landing in the same window is
+      # swallowed too. It is safe because check runs are bound to a SHA: if the
+      # queue branch is gone or has moved, nothing can be merged on the strength
+      # of this run, and the rebuilt entry re-runs CodeQL from scratch. Every
+      # other case fails the build — a non-merge_group event, a ref still live at
+      # our SHA, an unparseable response, or any indeterminate API status.
+      #
+      # ASSUMPTION — the merge queue's merge_method is SQUASH, which mints a
+      # fresh SHA for every rebuild, so a moot run's SHA can never recur on a
+      # later live entry. Under REBASE a no-op rebase could reproduce the same
+      # SHA, and this run's moot-green could then satisfy a live entry. If the
+      # queue's merge method ever changes, revisit this guard first.
       - id: analyze
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         continue-on-error: true
@@ -65,21 +84,63 @@ jobs:
           fi
 
           body="$(mktemp)"
-          status="$(curl -sS -o "$body" -w '%{http_code}' \
+          trap 'rm -f "$body"' EXIT
+
+          # This turns a red required check green, so every tolerated path leaves
+          # an auditable line in the job summary, not only in the raw log.
+          summary="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+          # curl already emits 000 through -w on a transport failure, so no
+          # shell-side fallback is wanted: `|| echo 000` would append a second
+          # sentinel and yield the literal string 000000. The explicit assignment
+          # below keeps the sentinel exactly three zeroes.
+          #
+          # The request is bounded and retried. An unbounded hang against
+          # api.github.com would hold the job open past the queue's
+          # check_response_timeout and eject the PR — the exact failure this
+          # guard exists to prevent. Worst case here is ~2 minutes.
+          if ! status="$(curl -sS \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            -o "$body" -w '%{http_code}' \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/git/ref/${TARGET_REF#refs/}" \
-            || echo "000")"
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/git/ref/${TARGET_REF#refs/}")"; then
+            status="000"
+          fi
 
           case "$status" in
             404)
               echo "::notice::${TARGET_REF} no longer exists: the merge-queue batch dissolved" \
                 "while CodeQL was uploading. Nothing is being merged from this run, so its" \
                 "result cannot gate anything. Treating it as moot."
+              {
+                echo "### CodeQL failure tolerated as moot"
+                echo
+                echo "A failing CodeQL run was reported as successful."
+                echo
+                echo "- Target ref: \`${TARGET_REF}\`"
+                echo "- Run SHA: \`${TARGET_SHA}\`"
+                echo "- Reason: the ref returned HTTP 404 — the merge-queue batch dissolved while this job was running, so this run cannot gate any merge."
+              } >> "$summary"
               ;;
             200)
-              current="$(jq -r '.object.sha // empty' "$body")"
+              # A 200 whose body carries no object SHA leaves us unable to tell a
+              # live ref from a dead one. That must fail closed: without this
+              # check an empty value compares unequal to TARGET_SHA and falls
+              # into the tolerant "batch was rebuilt" path below.
+              if ! current="$(jq -r '.object.sha // empty' "$body")"; then
+                current=""
+              fi
+              if [ -z "$current" ]; then
+                echo "::error::${TARGET_REF} returned HTTP 200 but the response carried no object SHA," \
+                  "so whether this run is still live cannot be determined. Failing closed."
+                exit 1
+              fi
               if [ "$current" = "$TARGET_SHA" ]; then
                 echo "::error::${TARGET_REF} still points at ${TARGET_SHA}, so this run is live." \
                   "The CodeQL failure is genuine. Failing the build."
@@ -87,10 +148,20 @@ jobs:
               fi
               echo "::notice::${TARGET_REF} has moved from ${TARGET_SHA} to ${current}: the batch" \
                 "was rebuilt without this run. Its result cannot gate the new head. Treating it as moot."
+              {
+                echo "### CodeQL failure tolerated as moot"
+                echo
+                echo "A failing CodeQL run was reported as successful."
+                echo
+                echo "- Target ref: \`${TARGET_REF}\`"
+                echo "- Run SHA: \`${TARGET_SHA}\`"
+                echo "- Ref now at: \`${current}\`"
+                echo "- Reason: the batch was rebuilt without this run, so this run cannot gate the new head."
+              } >> "$summary"
               ;;
             *)
-              echo "::error::Could not determine whether ${TARGET_REF} still exists (HTTP ${status})." \
-                "Failing closed."
+              echo "::error::Could not determine whether ${TARGET_REF} still exists (HTTP ${status};" \
+                "000 means the request failed at the transport level). Failing closed."
               exit 1
               ;;
           esac


### PR DESCRIPTION
## The defect

The merge queue ejects healthy PRs because CodeQL reports a failure for a run that is no longer attached to anything.

```
##[warning] ref 'refs/heads/gh-readonly-queue/main/pr-3626-2b3a0e096...' not found in this repository
##[error]   ref 'refs/heads/gh-readonly-queue/main/pr-3626-2b3a0e096...' not found in this repository
CodeQL job status was configuration error.
```

## Mechanism, verified

A merge-queue batch dissolves while the CodeQL job is still running. GitHub deletes the ephemeral `gh-readonly-queue/**` branch, and the SARIF upload — which only starts about ten minutes in, *after* the analysis itself has already succeeded — 404s against the ref that no longer exists. The queue reads that red check as the PR's fault and ejects it.

Evidence from run [31573922804](https://github.com/veryfront/veryfront-code/actions/runs/31573922804) (CodeQL, `merge_group`, pr-3626):

| Time (UTC) | Event |
| --- | --- |
| 07:25:21 | #3626 `added_to_merge_queue` |
| 07:25:39 | CodeQL **and** CI/CD start on head SHA `570f612f` |
| 07:31:50 | **CI/CD passes** on that identical head SHA |
| 07:32:52 | queue starts building `pr-3624` on base `2b3a0e096` — the pr-3626 batch is gone |
| 07:35:51 | CodeQL finishes analysis, exports SARIF, begins `Uploading results` |
| 07:36:06 | upload 404s: `ref ... not found in this repository` |
| 07:40:00 | #3626 `removed_from_merge_queue` |

Three things this pins down:

1. **The analysis succeeded.** The log shows `Exported results to SARIF (524ms)` and `CodeQL scanned 5702 out of 5789 TypeScript files`. The only thing that failed is the upload.
2. **The code is fine.** `Analyze` was the *only* failing check of 28 on `570f612f`, and #3626 is a pure 621-line file deletion.
3. **The failure caused the ejection, not the reverse.** The dequeue at 07:40:00 lands after the CodeQL failure at 07:36:11, not before.

Confirmed the deleted ref really is gone, and that a live ref answers normally — this is what the guard keys off:

```
GET /repos/veryfront/veryfront-code/git/ref/heads/gh-readonly-queue/main/pr-3626-2b3a0e096...  -> HTTP 404
GET /repos/veryfront/veryfront-code/git/ref/heads/main                                        -> HTTP 200
```

## How often this actually bites

An earlier draft of this description claimed four healthy runs were ejected today. That number was inflated: it counted every run carrying the ref-404 signature, without checking whether the run had *other* failures that would have ejected it anyway. Corrected against the check-run data for each SHA:

| SHA | PR | Started (UTC) | Other failing checks | Attributable to this bug |
| --- | --- | --- | --- | --- |
| `349c4ec7` | #3606 | 04:48 | `tests (bun)` | no — confounded |
| `aa4ee6cb` | #3626 | 06:28 | `tests (unit)`, `coverage gate`, `coverage shard 4/8` | no — confounded |
| `570f612f` | #3626 | 07:25 | **none** (1 of 28 failed) | **yes** |
| `046ed751` | #3624 | 07:32 | **none** (1 of 28 failed) | **yes** |
| `ff57ccf2` | #3626 | 07:38 | `tests (binary e2e)` | no — confounded |

All five carry the identical `ref ... not found in this repository` signature, so the bug is real and recurrent. But only **two** of them — `570f612f` (#3626) and `046ed751` (#3624) — were otherwise entirely green, and those are the only ejections this change would have prevented. The other three had genuine failures and belonged out of the queue.

`e0cc27da`, an adjacent attempt on the same queue branch, is not in the table at all: its CodeQL run *succeeded*, and it was ejected for `tests (unit)`, `coverage gate` and `coverage shard 4/8`.

Two per day is still worth fixing — CodeQL takes ~10 minutes while CI/CD takes ~6, so CodeQL is structurally the job still in flight when a batch dissolves, and the rate scales with queue churn.

## What `Analyze` actually gates

Worth stating plainly, because it bounds how much this change can cost.

`Analyze` is a required status check on `main`:

```
$ gh api repos/veryfront/veryfront-code/branches/main/protection --jq '.required_status_checks.contexts'
["ci (format)","ci (lint)","ci (typecheck)","tests (unit)","tests (integration)",
 "coverage gate","tests (rsc browser e2e)","tests (binary e2e)","Analyze"]
```

What it gates is **"did the analysis run and upload successfully"** — not "are there findings". On this repo:

- `codeql-action/analyze@v4.37.6` has no fail-on-findings input. Its inputs are `add-snippets, category, check_name, checkout_path, cleanup-level, expect-error, matrix, output, post-processed-sarif-path, ram, ref, sha, skip-queries, threads, token, upload, upload-database, wait-for-processing` — nothing that fails the job on a result.
- Code-scanning merge protection is not enabled (`code-scanning/default-setup` reports `state: not-configured`).
- No code-scanning context appears in the required checks above.
- Alert #278 (`js/incomplete-multi-character-sanitization`, **high**) has been open since 2026-08-11T19:19Z, and 20+ PRs have merged to `main` since. Four alerts are open in total.

So this guard cannot suppress a finding-based block, because no such block exists here. It affects only whether a run that produced no usable upload is allowed to fail the queue.

## On removing the `merge_group` trigger

**The reasoning holds — do not remove it.** The merge queue waits for exactly the required contexts to report on the `merge_group` ref. Drop the trigger and the check never arrives; the queue would sit until `check_response_timeout` (1800s) expires and then eject the PR anyway — the same symptom, six times slower. The comment in the workflow is correct and stays.

## Why not `continue-on-error` on the job

A blanket `continue-on-error: true` on `analyze` would make *every* CodeQL failure non-blocking on every event, including `push` and `schedule`, where a broken analysis means the repo silently stops being scanned. Not done.

## The fix

There is no supported upstream mechanism. [github/codeql-action#1572](https://github.com/github/codeql-action/issues/1572) is this exact error, open since March 2023; a maintainer said they were "discussing internally how best to support merge queue" and nothing shipped. The `analyze` action's inputs offer no way to say "this run is moot". So the guard is hand-rolled, deliberately narrow, and fails closed.

The `analyze` step's outcome is captured rather than failing the job outright, and a guard step re-raises it unless the target ref has provably gone away:

| Condition | Result |
| --- | --- |
| `merge_group`, ref returns **404** — deleted | moot → pass |
| `merge_group`, ref returns **200** but SHA ≠ ours — batch rebuilt without us | moot → pass |
| `merge_group`, ref returns **200** at our SHA — run is live | **fail** |
| `merge_group`, ref returns **200** with no readable SHA | **fail closed** |
| `merge_group`, any other HTTP status or transport error | **fail closed** |
| `pull_request` / `push` / `schedule` | **fail** |

### What the tolerant path really swallows

Stated honestly, because the first draft of the workflow comment overstated it: the guard tolerates **any** analyze failure on a `merge_group` run whose ref has vanished or moved — not only the upload 404. An extractor crash or a query failure landing in the same window is swallowed too.

That is safe for one reason: check runs are bound to a SHA. If the queue branch is gone or has moved, nothing can be merged on the strength of this run, and the rebuilt entry re-runs CodeQL from scratch on a new SHA. A moot pass can never let unreviewed code through; it only stops the queue attributing a dead run to a live PR.

**This rests on the queue's `merge_method` being `SQUASH`**, which mints a fresh SHA for every rebuild, so a moot run's SHA can never recur on a later live entry. Under `REBASE`, a no-op rebase could reproduce the same SHA and let a moot green satisfy a live entry. `rebaseMergeAllowed` is `true` on this repo, so the queue's method is the only thing closing that hole — the assumption is now recorded in the workflow so a future config change does not silently reopen it.

## Verification

The guard script is extracted from the committed YAML and executed by bash against a real local HTTP server and real transport failures, so the actual `curl` invocation — flags, retries, `-w` sentinel — is under test rather than a re-implementation.

```
result exit    tmp  sum  case
----------------------------------------------------------------------------------------
ok        0  clean  yes  merge_group + ref deleted (404)
ok        0  clean  yes  merge_group + ref moved to new SHA
ok        1  clean   no  merge_group + ref live at our SHA
ok        1  clean   no  F1 merge_group + 200 body {}
ok        1  clean   no  F1 merge_group + 200 {"object":null}
ok        1  clean   no  F1 merge_group + 200 {"object":{}} (sha absent)
ok        1  clean   no  F1 merge_group + 200 {"object":{"sha":""}}
ok        1  clean   no  F1 merge_group + 200 unparseable JSON
ok        1  clean   no  F1 merge_group + 200 empty body
ok        1  clean   no  merge_group + API 500
ok        1  clean   no  merge_group + API 403
ok        1  clean   no  F2 merge_group + connection refused
ok        1  clean   no  F2 merge_group + DNS failure
ok        1  clean   no  pull_request failure
ok        1  clean   no  push to main failure
ok        1  clean   no  schedule failure
ok        1  clean   no  F3 merge_group + hung connection (timeout)
----------------------------------------------------------------------------------------
passed=17 failed=0
```

`tmp` asserts the `mktemp` body was removed; `sum` asserts a `$GITHUB_STEP_SUMMARY` record exists on exactly the tolerated paths. Every case also asserts the transport sentinel is three zeroes, never `000000`.

Running the **same** suite against the previous revision of this branch fails 10 of 16, which is what makes the suite worth anything:

```
FAIL      0  clean   no  F1 merge_group + 200 body {}
FAIL      0  clean   no  F1 merge_group + 200 {"object":null}
FAIL      0  clean   no  F1 merge_group + 200 {"object":{}} (sha absent)
FAIL      0  clean   no  F1 merge_group + 200 {"object":{"sha":""}}
FAIL      5  clean   no  F1 merge_group + 200 unparseable JSON
FAIL      0  clean   no  F1 merge_group + 200 empty body
FAIL      1  clean   no  F2 merge_group + connection refused
FAIL      1  clean   no  F2 merge_group + DNS failure
```

Those `exit 0`s are a real fail-open, and they printed:

```
::notice::refs/heads/... has moved from 570f612f8a3c41d9be27fa5d6c18e4b93d72a1ce to : the batch was rebuilt without this run. Treating it as moot.
```

An empty SHA compared unequal to ours and fell into the tolerant path. It now fails closed and says the response was unreadable. The unparseable-JSON case exited 5 — `jq` aborting under `set -e` with no diagnostic at all.

`shellcheck 0.11.0` is clean on the extracted script.

## Trade-off

This is a workaround for a GitHub-side interaction, and it owns two risks:

- **It is hand-rolled**, against the general preference for a supported mechanism. Nothing supported exists; if upstream ever ships one, this should be deleted in favour of it.
- **It narrows the gate in one specific case**: a genuine CodeQL failure that coincides with the batch dissolving is reported as moot. That window is real but harmless for the SHA-binding reason above — that run cannot gate a merge either way, and the rebuilt entry re-runs CodeQL from scratch.

I considered `upload: never` for `merge_group`, which is a documented input and would remove the 404 deterministically. Rejected: it drops the SARIF upload on *every* queue run, not just the broken ones, and would silently break code-scanning merge protection if it is ever enabled here.

## Note

This PR has to survive the very queue it is fixing, on the *old* workflow — the fix only takes effect for runs after it lands. If its own CodeQL check goes red with the ref-not-found signature, that is the bug reproducing itself, not a reason to doubt the change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of automated security analysis by adding a defined execution timeout.
  * Enhanced handling of transient analysis failures and merge-queue conditions.
  * Added safeguards to prevent inconclusive checks from being incorrectly accepted.
  * Tolerated, expected merge-queue failures are now clearly recorded in job summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->