### PR TITLE
fix(test): let the signal-less follower join the owner's flight instead of racing it

### DIFF
--- a/src/transforms/esm/http-cache.test.ts
+++ b/src/transforms/esm/http-cache.test.ts
@@ -113,23 +113,51 @@ async function runNextFakeTimer(time: FakeTime, tempDir: string): Promise<void> 
   throw new Error("Expected a fake timer to be scheduled");
 }
 
-/** Iterations of {@linkcode runFakeTimersUntil} before it reports a stuck wait. */
+/** Iterations either driving helper takes before it reports a stuck wait. */
 const MAX_FAKE_TIMER_STEPS = 200;
+
+/**
+ * Give pending real filesystem work turns, without moving the clock, until
+ * `isReady` reports done.
+ *
+ * A caller reaches the shared-fetch registry through real filesystem work, so
+ * which of two concurrent callers registers the shared flight is decided by
+ * I/O completion order, not by call order. Draining microtasks once assumes the
+ * first caller already won that race; on a loaded runner it can lose, the two
+ * callers swap roles, and a test written around one of them then exercises the
+ * other. Waiting on the registry itself makes the roles explicit.
+ */
+async function runRealTurnsUntil(
+  time: FakeTime,
+  tempDir: string,
+  isReady: () => boolean,
+  description: string,
+): Promise<void> {
+  for (let step = 0; step < MAX_FAKE_TIMER_STEPS; step++) {
+    if (isReady()) return;
+    await Deno.stat(tempDir);
+    await time.runMicrotasks();
+  }
+  throw new Error(
+    `${description} did not happen within ${MAX_FAKE_TIMER_STEPS} filesystem turns`,
+  );
+}
 
 /**
  * Run scheduled fake timers, one at a time, until `isSettled` reports done.
  *
  * A caller whose only release is its own bounded-wait timer arms that timer
  * once its real I/O reaches the wait. Advancing the fake clock by a fixed span
- * instead assumes the timer already exists: on a loaded runner the caller can
- * arm it after the clock has moved past its due time, and no later advance ever
- * runs it. Awaiting that caller then blocks forever with nothing left on the
+ * instead assumes the timer already exists, and a timer armed after that span
+ * is never run. Awaiting such a caller blocks forever with nothing left on the
  * event loop, which Deno reports as "Promise resolution is still pending but
  * the event loop has already resolved" — a whole test file silently dropped.
  *
  * Stepping from the settled state keeps the wait reachable whenever it is
  * armed, and the step budget turns a genuinely stuck wait into a failure
- * instead of a hang.
+ * instead of a hang. The budget is a stuck detector, not a patience dial: a
+ * caller that re-arms a fresh bounded wait after every timeout exhausts any
+ * budget, and the answer is to stop it re-arming, never to raise the budget.
  */
 async function runFakeTimersUntil(
   time: FakeTime,
@@ -849,7 +877,22 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
         });
         const ownerOutcome = owner.catch((error) => error);
 
-        await time.runMicrotasks();
+        // The follower must join the owner's flight, not start its own. Both
+        // calls reach the registry through real filesystem work, so the owner
+        // owns the flight only once it is registered. Starting the follower
+        // before that lets the roles invert: the signal-less call becomes the
+        // owner and parks on the distributed read that never resolves, while
+        // the signal-bearing call keeps its waiter lease and re-arms a fresh
+        // bounded wait after every timeout — one fake timer per step, forever.
+        await runRealTurnsUntil(
+          time,
+          tempDir,
+          () => inFlightHttpFetches.size === 1,
+          "The owner's shared flight",
+        );
+        assertEquals(inFlightHttpFetches.size, 1);
+        const [ownerFlight] = [...inFlightHttpFetches.values()];
+
         const follower = cacheHttpImportsToLocal(source, options);
         let followerSettled = false;
         const followerOutcome = follower.then(
@@ -864,14 +907,17 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
         );
 
         try {
-          for (let attempt = 0; attempt < 20; attempt++) {
-            if (__getMaxInFlightHttpFetchWaiterCountForTests() >= 2) break;
-            // The follower reaches the shared flight through real filesystem
-            // work, which draining microtasks alone never advances.
-            await Deno.stat(tempDir);
-            await time.runMicrotasks();
-          }
+          // The follower reaches the shared flight through real filesystem
+          // work, which draining microtasks alone never advances.
+          await runRealTurnsUntil(
+            time,
+            tempDir,
+            () => __getMaxInFlightHttpFetchWaiterCountForTests() >= 2,
+            "The follower joining the owner's flight",
+          );
           assertEquals(__getMaxInFlightHttpFetchWaiterCountForTests(), 2);
+          // Both callers share one generation, and it is still the owner's.
+          assertEquals([...inFlightHttpFetches.values()], [ownerFlight]);
 
           await runFakeTimersUntil(
             time,


### PR DESCRIPTION
## The failure

Merge-queue run 31578405141, coverage shard 4/8 (job 94055658155), base `0ee5098b4`:

```
./src/transforms/esm/http-cache.test.ts => HTTP Bundle Cache ... returns a
  signal-less cache follower after its bounded wait ... FAILED (527ms)
error: Error: The signal-less follower's bounded wait did not settle within 200 fake timer steps
```

That message and its budget come from #3631, which replaced a fixed
`time.tickAsync(HTTP_MODULE_FETCH_MAX_WAIT_MS)` advance with `runFakeTimersUntil`
— step fake timers until the wait settles, with a 200-step budget. #3631 did
something valuable: it turned a hang that silently dropped a whole test file into
a named failure. The cause it named is not the cause.

## Root cause

The test starts a cancellable owner and, one `time.runMicrotasks()` later, a
signal-less follower, and assumes the owner registered the shared flight in
between. **Nothing enforces that.** Both calls reach `createInFlightHttpFetch`
through real filesystem work, so I/O completion order — not call order — decides
which one owns the flight.

Probing `inFlightHttpFetches.size` at the moment the follower is created:

| environment | reading |
| --- | --- |
| the file alone, unloaded | `1` in 8 of 8 runs — owner already registered |
| coverage shard 4/8, loaded | `0` — race wide open |

When the follower wins that race the two callers swap roles:

- the **signal-less** call becomes the flight owner and parks on the distributed
  read this test never resolves;
- the **signal-bearing** call becomes the bounded waiter — and
  `waitForSharedInFlightHttpFetch` deliberately keeps a cancellable caller's
  waiter lease across timeouts, re-arming a fresh `HTTP_MODULE_FETCH_MAX_WAIT_MS`
  wait after every one.

So every step of `runFakeTimersUntil` fires a timer and the next step finds a new
one. The budget is *consumed*, never *reached*, and the promise the test is
watching never settles because it is now the owner.
`assertEquals(waiterCount, 2)` passes throughout — two waiters is true of both
role assignments, which is why the test could not tell it was exercising the
wrong caller.

### Evidence

- A reproduced shard failure traces **200 identical steps**, each advancing the
  fake clock by exactly `35300`ms (`HTTP_MODULE_FETCH_MAX_WAIT_MS`) with the
  waiter count pinned at 2 and one flight registered.
- Instrumenting the wait loop records **200 iterations, every one
  `hasSignal=true waitTimeoutMs=35300 same=true waiters=2`** — the looping waiter
  is the *signal-bearing* caller, not the follower the test names.
- Starting the two callers in the reverse order — which is exactly what losing
  the race amounts to — reproduces the identical failure **3 times out of 3**.
- In situ: coverage shard 4/8 with `DENO_JOBS=64` on a saturated machine
  reproduces it on the unpatched parent commit.

### Why #3631's 100 clean runs missed it

They exercised the path; they just always won the race. Run the file alone and
the owner has registered before the follower starts, every time (8/8 above). The
inversion needs the loaded, parallel, coverage-instrumented shard. #3631's own
symptom — `Promise resolution is still pending but the event loop has already
resolved` — is this same inversion seen through the old fixed advance: one tick
fired one re-armed wait, and `await followerOutcome` then blocked forever.

## The fix

Wait for the owner's flight to be registered before creating the follower, so the
follower **joins** that flight instead of racing it, and assert the shared
generation is still the owner's once both callers are on it. The two ad-hoc
"stat and drain microtasks" loops collapse into one `runRealTurnsUntil` helper
that names what it was waiting for when it gives up.

`runFakeTimersUntil` is unchanged and its budget stays at 200. Its comment no
longer attributes this incident to a late-armed timer, and now says plainly that
the budget is a stuck detector, not a patience dial — a caller that re-arms after
every timeout exhausts any budget, and raising it only restores the hang.

**#3631 is not reverted.** Without its step budget this would still be a hang
that drops a whole test file with no name attached to it.

Only `src/transforms/esm/http-cache.test.ts` changes. No production code changes:
the role inversion is legitimate production behaviour (either concurrent render
may win), so the defect was entirely in the test's assumption.

## Verification

| check | result |
| --- | --- |
| `src/transforms/esm/http-cache.test.ts`, 50 consecutive runs | 50 pass / 0 fail |
| coverage shard 4/8, `DENO_JOBS=64`, saturated machine, 16 runs | 16 × `377 passed (3403 steps) \| 0 failed` |
| `deno fmt --check` / `deno lint` / `deno check` (Deno 2.7.7) | clean |

Sibling two-caller tests in the same file (`fetchStarted`, `cacheLookupStarted`,
`renameStarted`, `oldWriteStarted`) already gate on an explicit promise, so this
was the only test in the file relying on `runMicrotasks()` for ordering.
