### PR TITLE
ci: stop unrelated apt repos from gating the Chromium install

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -227,7 +227,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-deno
         timeout-minutes: 5
-      - name: Configure apt retries and mirrors
+      - name: Configure apt sources, retries, and mirrors
         run: |
           sudo sed -i \
             -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
@@ -239,6 +239,29 @@ jobs:
             echo 'Acquire::http::Timeout "30";'
             echo 'Acquire::https::Timeout "30";'
           } | sudo tee /etc/apt/apt.conf.d/99veryfront-ci-retries
+
+          # `playwright install --with-deps` shells out to `apt-get update`, which
+          # consults every repository configured on the runner image and fails the
+          # whole install when any single one of them is unreachable. The image
+          # ships third-party repositories (packages.microsoft.com/repos/azure-cli,
+          # packages.microsoft.com/ubuntu/24.04/prod, dl.google.com, ...) that
+          # Chromium's system libraries never come from, so an outage there is pure
+          # noise -- and because it is a persistent 403 rather than a blip, retrying
+          # cannot clear it. Park every non-Ubuntu source for the life of this job so
+          # only the archive that actually serves the dependencies can gate us.
+          if grep -rqE '\.ubuntu\.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+            sudo mkdir -p /etc/apt/sources.list.d.disabled
+            for source_file in /etc/apt/sources.list.d/*; do
+              [ -f "${source_file}" ] || continue
+              if grep -qE '\.ubuntu\.com' "${source_file}"; then
+                continue
+              fi
+              sudo mv "${source_file}" /etc/apt/sources.list.d.disabled/
+              echo "Disabled apt source unrelated to Chromium deps: ${source_file}"
+            done
+          else
+            echo "::warning::No Ubuntu archive apt source detected; leaving apt sources untouched"
+          fi
       - name: Install Chromium
         timeout-minutes: 15
         run: |
@@ -296,7 +319,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-deno
         timeout-minutes: 5
-      - name: Configure apt retries and mirrors
+      - name: Configure apt sources, retries, and mirrors
         run: |
           sudo sed -i \
             -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
@@ -308,6 +331,29 @@ jobs:
             echo 'Acquire::http::Timeout "30";'
             echo 'Acquire::https::Timeout "30";'
           } | sudo tee /etc/apt/apt.conf.d/99veryfront-ci-retries
+
+          # `playwright install --with-deps` shells out to `apt-get update`, which
+          # consults every repository configured on the runner image and fails the
+          # whole install when any single one of them is unreachable. The image
+          # ships third-party repositories (packages.microsoft.com/repos/azure-cli,
+          # packages.microsoft.com/ubuntu/24.04/prod, dl.google.com, ...) that
+          # Chromium's system libraries never come from, so an outage there is pure
+          # noise -- and because it is a persistent 403 rather than a blip, retrying
+          # cannot clear it. Park every non-Ubuntu source for the life of this job so
+          # only the archive that actually serves the dependencies can gate us.
+          if grep -rqE '\.ubuntu\.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+            sudo mkdir -p /etc/apt/sources.list.d.disabled
+            for source_file in /etc/apt/sources.list.d/*; do
+              [ -f "${source_file}" ] || continue
+              if grep -qE '\.ubuntu\.com' "${source_file}"; then
+                continue
+              fi
+              sudo mv "${source_file}" /etc/apt/sources.list.d.disabled/
+              echo "Disabled apt source unrelated to Chromium deps: ${source_file}"
+            done
+          else
+            echo "::warning::No Ubuntu archive apt source detected; leaving apt sources untouched"
+          fi
       - name: Install Chromium
         timeout-minutes: 15
         run: |


### PR DESCRIPTION
## Why this is worth fixing

This is not a flake. The merge queue has been ejecting healthy PRs all day on
infrastructure noise, and every ejection teaches reviewers to re-queue without
reading the log. That habit is the actual risk: it is how a genuine failure
eventually gets waved through. Removing the noise source is what keeps the
signal trustworthy.

## The failure

merge_group run `31574851781`, job `tests (binary e2e)`, ejected #3626:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
E: Failed to fetch https://packages.microsoft.com/ubuntu/24.04/prod/dists/noble/InRelease  403  Forbidden
Failed to install browsers
Error: Installation process exited with code: 100
```

## Root cause

`playwright install --with-deps chromium` shells out to `apt-get update`, which
consults **every** repository configured on the runner image and fails the whole
command if any single one is unreachable. The `ubuntu-24.04` image ships
third-party repos — `packages.microsoft.com/repos/azure-cli`,
`packages.microsoft.com/ubuntu/24.04/prod`, `dl.google.com`, ... — that have
nothing whatsoever to do with Chromium. When Microsoft's CDN returns 403, apt
exits non-zero, so the browser install fails, so the job fails.

### Why the existing hardening did not help

The step already has a `wait_for_apt_locks` loop, a 2-attempt retry with
`retry_backoff_seconds`, and a `timeout` wrapper. None of it can help here: a
403 is a persistent server-side state, not a transient blip. Both attempts
failed identically, 21 seconds apart. Retrying a 403 just produces a second 403.

## The fix

Option (a), generalised from "unbreak Microsoft" to "close the whole failure
class": before installing, park every apt source that is **not** an Ubuntu
archive. Chromium's system libraries come only from the Ubuntu archive, so
that is the only repo allowed to gate the job. A transient failure of any
unrelated third-party repo now cannot fail this step — today's Microsoft 403,
and equally a future `dl.google.com` or `download.docker.com` outage.

Fail-safe: if no Ubuntu archive source is detected, sources are left untouched
and a warning is emitted, so a future image layout change degrades to today's
behaviour rather than deleting the archive out from under apt.

### Why not option (b), dropping `--with-deps`

That would mean betting that the runner image happens to carry all ~21 Chromium
libraries, forever. I could not verify that claim without asserting it on a
runner, and even a verified snapshot would be verified only against
`ubuntu24/20260720.247` — a later image that drops a library would resurface as
a cryptic "browser failed to launch" instead of a legible apt error. Keeping
`--with-deps` keeps the dependency set correct by construction; scoping apt's
sources removes the noise without giving that up.

### Scaffolding kept

The lock-wait / retry / timeout scaffolding is retained and is still load
bearing — it now covers what it was actually good for: dpkg lock contention and
genuine transient failures of the Ubuntu archive itself. Nothing was removed.

## Both call sites

Applied to both browser-installing jobs, since fixing one leaves the other
flaky:

- `tests (rsc browser e2e)` — `.github/workflows/cicd.yml`
- `tests (binary e2e)` — `.github/workflows/cicd.yml`

## Verification

- Step logic exercised locally under GitHub's `bash -e` semantics against a
  reproduction of the real runner source set (`ubuntu.sources` +
  `azure-cli.list` + `microsoft-prod.list` + `google-chrome.list` +
  `docker.list`): the four third-party sources are parked, `ubuntu.sources` is
  kept, step exits 0.
- Edge cases confirmed: no-Ubuntu-source (warns, touches nothing), empty
  `sources.list.d` (glob does not expand literally), and re-run idempotency.
- Confirmed no later step in either job depends on a parked repository.

## Not weakened

No `continue-on-error`, no skipped tests, no relaxed assertions. A real browser
failure or test failure still fails the build.
