### PR TITLE
fix: omit temperature for Opus 5

### DIFF
--- a/src/agent/runtime/model-capabilities.test.ts
+++ b/src/agent/runtime/model-capabilities.test.ts
@@ -38,6 +38,9 @@ describe("runtime model capabilities", () => {
   it("applies the temperature policy to the full current model matrix", () => {
     const temperatureMatrix = [
       ["anthropic/claude-opus-4-8", undefined],
+      ["anthropic/claude-opus-5", undefined],
+      ["anthropic/claude-opus-5-20260801", undefined],
+      ["anthropic/claude-opus-5.1", undefined],
       ["anthropic/claude-opus-4-6", 0.2],
       ["anthropic/claude-sonnet-4-6", 0.2],
       ["anthropic/claude-haiku-4-5-20251001", 0.2],

--- a/src/agent/runtime/model-capabilities.test.ts
+++ b/src/agent/runtime/model-capabilities.test.ts
@@ -22,10 +22,47 @@ describe("runtime model capabilities", () => {
   it("omits temperature for Anthropic Opus models that reject sampling parameters", () => {
     assertEquals(supportsTemperatureParameter("anthropic/claude-opus-4-7"), false);
     assertEquals(supportsTemperatureParameter("anthropic/claude-opus-4-8"), false);
+    assertEquals(supportsTemperatureParameter("anthropic/claude-opus-5"), false);
+    assertEquals(supportsTemperatureParameter("anthropic/claude-opus-5-20260801"), false);
+    assertEquals(supportsTemperatureParameter("anthropic/claude-opus-5.1"), false);
     assertEquals(
       supportsTemperatureParameter("veryfront-cloud/anthropic/claude-opus-4-8"),
       false,
     );
+    assertEquals(
+      supportsTemperatureParameter("veryfront-cloud/anthropic/claude-opus-5"),
+      false,
+    );
+  });
+
+  it("applies the temperature policy to the full current model matrix", () => {
+    const temperatureMatrix = [
+      ["anthropic/claude-opus-4-8", undefined],
+      ["anthropic/claude-opus-4-6", 0.2],
+      ["anthropic/claude-sonnet-4-6", 0.2],
+      ["anthropic/claude-haiku-4-5-20251001", 0.2],
+      ["openai/gpt-5.5", 0.2],
+      ["openai/gpt-5.4-mini", 0.2],
+      ["openai/gpt-5.4", 0.2],
+      ["openai/gpt-5.4-nano", 0.2],
+      ["openai/gpt-5.2", 0.2],
+      ["google-ai-studio/gemini-3.1-pro-preview", 0.2],
+      ["google-ai-studio/gemini-3.5-flash", 0.2],
+      ["google-ai-studio/gemini-2.5-pro", 0.2],
+      ["google-ai-studio/gemini-2.5-flash", 0.2],
+      ["mistral/mistral-large-2512", 0.2],
+      ["moonshotai/kimi-k2.6", 1],
+      ["moonshotai/kimi-k2.5", 0.2],
+    ] as const;
+
+    for (const [modelId, expectedTemperature] of temperatureMatrix) {
+      assertEquals(resolveTemperatureParameter(modelId, 0.2, 0), expectedTemperature, modelId);
+      assertEquals(
+        resolveTemperatureParameter(`veryfront-cloud/${modelId}`, 0.2, 0),
+        expectedTemperature,
+        `hosted ${modelId}`,
+      );
+    }
   });
 
   it("keeps temperature for other current hosted models", () => {

--- a/src/agent/runtime/model-capabilities.ts
+++ b/src/agent/runtime/model-capabilities.ts
@@ -1,9 +1,9 @@
 const VERYFRONT_CLOUD_MODEL_PREFIX = "veryfront-cloud/";
 
-// MAINTENANCE: Update this set whenever a new model is released that does not
-// accept a temperature parameter. Models absent from this set are assumed to
-// support temperature; the consequence of a missing entry is an ignored parameter,
-// not a hard error.
+// MAINTENANCE: Update this set or family predicate whenever a new model is released
+// that does not accept a temperature parameter. Models absent from this policy are
+// assumed to support temperature; the consequence of a missing entry is an ignored
+// parameter, not a hard error.
 const MODELS_WITHOUT_TEMPERATURE_PARAMETER = new Set([
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-8",
@@ -57,7 +57,10 @@ export function normalizeModelCapabilityId(modelString?: string): string | undef
 export function supportsTemperatureParameter(modelString?: string): boolean {
   const normalizedModel = normalizeModelCapabilityId(modelString);
   if (!normalizedModel) return true;
-  return !MODELS_WITHOUT_TEMPERATURE_PARAMETER.has(normalizedModel);
+  return (
+    !MODELS_WITHOUT_TEMPERATURE_PARAMETER.has(normalizedModel) &&
+    !/^anthropic\/claude-opus-5(?:[.-]|$)/.test(normalizedModel)
+  );
 }
 
 export function getFixedTemperatureParameter(


### PR DESCRIPTION
## Summary

- omit `temperature` for the Claude Opus 5 model family, including dated and minor-version IDs
- apply the policy to direct and `veryfront-cloud/` model identifiers
- add a temperature-policy matrix for all current catalog models

## Root cause

The runtime assumed models not listed in its capability exceptions supported `temperature`. Opus 5 was not covered, so the unsupported parameter was forwarded.

## Validation

- standalone model matrix passed: 16 catalog models in direct and hosted forms, plus four Opus 5 IDs
- targeted type check, formatting, lint, and whitespace diff checks passed
- repository pre-push typecheck remains blocked by unrelated existing React type export and timer-type errors; bypassed with explicit user approval

Closes veryfront/veryfront-issue-inbox#489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model capability detection for Anthropic Claude Opus 5 variants.
  * Correctly handles temperature settings for hosted model IDs and Kimi 2.6.
  * Expanded coverage for Anthropic Opus aliases and hosted model variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->