### PR TITLE
fix(security): stop a project's auth policy 401ing the control plane's own dispatch

### DIFF
--- a/docs/api-reference/veryfront/security.md
+++ b/docs/api-reference/veryfront/security.md
@@ -94,7 +94,7 @@ applySecurityHeaders(response.headers, false, generateNonce(), null);
 
 | Name                   | Description | Source                                                                                                     |
 | ---------------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
-| `AuthHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/auth.ts#L156)             |
+| `AuthHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/auth.ts#L157)             |
 | `BaseHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/base-handler.ts#L45)      |
 | `CsrfHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/csrf/csrf-handler.ts#L57) |
 | `ResponseBuilder`      |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/response/builder.ts#L9)   |

--- a/src/release-assets/build-dispatch-security.test.ts
+++ b/src/release-assets/build-dispatch-security.test.ts
@@ -18,6 +18,13 @@
  * Nothing downstream can see it: the run fails before the manifest row is
  * created, and the deploy timeout names neither CSRF nor config.
  *
+ * `security.auth` is the same failure with a different gate. `AuthHandler` runs
+ * at priority 0 — ahead of `CsrfHandler` — and also matches every path, and the
+ * credential it demands is one the platform structurally cannot hold: the
+ * control plane sends a per-run service `Bearer` JWT the Basic branch can never
+ * match and the Bearer branch compares against a project-authored secret. Both
+ * gates are driven here against the real handler chain.
+ *
  * @module release-assets/build-dispatch-security.test
  */
 
@@ -25,9 +32,11 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { RouteRegistry } from "#veryfront/routing/registry/index.ts";
+import { AuthHandler } from "#veryfront/security/http/auth.ts";
 import { CsrfHandler } from "#veryfront/security/http/csrf/csrf-handler.ts";
 import { deriveSecurityContext } from "#veryfront/security/http/config.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
+import type { SecurityConfig } from "#veryfront/types";
 import {
   ProjectRunExecuteHandler,
   type ProjectRunExecuteHandlerDeps,
@@ -57,10 +66,12 @@ interface DispatchOutcome {
  */
 async function dispatchReleaseAssetBuild(
   csrf: CsrfSetting | undefined,
+  auth?: SecurityConfig["auth"],
 ): Promise<DispatchOutcome> {
-  const config = {
-    security: csrf === undefined ? {} : { csrf },
-  } as VeryfrontConfig;
+  const security: Record<string, unknown> = {};
+  if (csrf !== undefined) security.csrf = csrf;
+  if (auth !== undefined) security.auth = auth;
+  const config = { security } as VeryfrontConfig;
   const { securityConfig } = deriveSecurityContext(config, {
     // The task rail dispatches to the project's main-branch runtime, which
     // resolves as a preview environment. Production defaults are therefore off
@@ -112,7 +123,11 @@ async function dispatchReleaseAssetBuild(
   ctx.securityConfig = securityConfig;
 
   const registry = new RouteRegistry();
-  registry.registerAll([new CsrfHandler(), new ProjectRunExecuteHandler(deps)]);
+  registry.registerAll([
+    new AuthHandler(),
+    new CsrfHandler(),
+    new ProjectRunExecuteHandler(deps),
+  ]);
 
   const response = await registry.execute(request, ctx);
   return {
@@ -149,6 +164,46 @@ describe("release assets: control-plane build dispatch", () => {
     // The shape that first surfaced this: keep CSRF enforced everywhere except
     // the agent endpoint the chat client posts to.
     const outcome = await dispatchReleaseAssetBuild({ excludePaths: ["/api/ag-ui"] });
+    assertEquals(
+      outcome.begun,
+      true,
+      `release asset build never started; runtime answered ${outcome.status}: ${outcome.body}`,
+    );
+    assertEquals(outcome.status, 200);
+  });
+
+  it("builds a manifest when the project puts the site behind basic auth", async () => {
+    // The platform cannot hold a project-authored Basic credential. It sends a
+    // per-run service `Bearer` JWT and the signed envelope, so `checkBasicAuth`
+    // could only ever answer 401 — and 401 is not retryable, so the run dies
+    // and the manifest row is never created.
+    const outcome = await dispatchReleaseAssetBuild(undefined, {
+      basic: { username: "admin", password: "secret" },
+    });
+    assertEquals(
+      outcome.begun,
+      true,
+      `release asset build never started; runtime answered ${outcome.status}: ${outcome.body}`,
+    );
+    assertEquals(outcome.status, 200);
+  });
+
+  it("builds a manifest when the project puts the site behind bearer auth", async () => {
+    const outcome = await dispatchReleaseAssetBuild(undefined, {
+      bearer: { token: "project-authored-token" },
+    });
+    assertEquals(
+      outcome.begun,
+      true,
+      `release asset build never started; runtime answered ${outcome.status}: ${outcome.body}`,
+    );
+    assertEquals(outcome.status, 200);
+  });
+
+  it("builds a manifest when the project enables both gates at once", async () => {
+    const outcome = await dispatchReleaseAssetBuild(true, {
+      basic: { username: "admin", password: "secret" },
+    });
     assertEquals(
       outcome.begun,
       true,

--- a/src/release-assets/build-dispatch-security.test.ts
+++ b/src/release-assets/build-dispatch-security.test.ts
@@ -1,6 +1,7 @@
 /**
- * Regression: a project that configures `security.csrf` must still be able to
- * publish a release asset manifest.
+ * Regression: a project's own request gates must not block its release asset
+ * manifest build. Three of them have: `security.auth`, `security.csrf`, and a
+ * root `middleware.ts`.
  *
  * The release asset manifest is built by the project runtime, not by the CLI:
  * the control plane POSTs a signed operation envelope to
@@ -22,8 +23,18 @@
  * at priority 0 — ahead of `CsrfHandler` — and also matches every path, and the
  * credential it demands is one the platform structurally cannot hold: the
  * control plane sends a per-run service `Bearer` JWT the Basic branch can never
- * match and the Bearer branch compares against a project-authored secret. Both
- * gates are driven here against the real handler chain.
+ * match and the Bearer branch compares against a project-authored secret.
+ *
+ * `projectMiddlewareRuntime.execute` wraps the entire handler chain, so a root
+ * `middleware.ts` sits in front of the same dispatch and fails it the same way.
+ * It has no way to pass: `createApplicationRequest` withholds every
+ * `x-veryfront-*` header from project code, so the signature the platform
+ * authenticates with is not visible to the middleware that would have to trust
+ * it.
+ *
+ * All three gates are assembled here in the order the runtime assembles them —
+ * project middleware outermost, then the security handlers, then the run
+ * executor — so that a fix for one gate is exercised with the others standing.
  *
  * @module release-assets/build-dispatch-security.test
  */
@@ -45,6 +56,8 @@ import {
   createControlPlaneSignature,
   createCtx,
 } from "#veryfront/server/handlers/request/internal-agent-run.test-helpers.ts";
+import type { MiddlewareFunction } from "#veryfront/server/dev-server/middleware.ts";
+import { ProjectMiddlewareRuntime } from "#veryfront/server/runtime-handler/project-middleware.ts";
 
 const RUN_ID = "run_release_assets_1";
 const EXECUTE_PATH = `/api/control-plane/runs/${RUN_ID}/execute`;
@@ -61,16 +74,36 @@ interface DispatchOutcome {
 }
 
 /**
- * Drive the real handler chain the runtime uses for a control-plane run
- * dispatch: the security handlers first, then the run executor.
+ * Everything about a dispatch other than the CSRF setting.
+ *
+ * One options bag, not one positional parameter per gate. Every fix that
+ * exempts this dispatch from another gate widens this harness, and positional
+ * parameters grown on separate branches merge into a signature that still
+ * compiles while existing calls bind their argument to the wrong slot: a
+ * `{ projectMiddleware }` argument lands in an `auth` parameter, no middleware
+ * is installed, and the test that proves the middleware bypass works keeps
+ * passing without ever exercising it. A named field cannot merge that way.
+ */
+interface DispatchOptions {
+  /** A `security.auth` policy the project put in front of its own site. */
+  readonly auth?: SecurityConfig["auth"];
+  /** A root `middleware.ts`, which wraps the whole handler chain. */
+  readonly projectMiddleware?: MiddlewareFunction[];
+  /** Send the request without the control-plane signature header. */
+  readonly unsigned?: boolean;
+}
+
+/**
+ * Drive the real chain the runtime uses for a control-plane run dispatch: the
+ * project's root middleware, then the security handlers, then the run executor.
  */
 async function dispatchReleaseAssetBuild(
   csrf: CsrfSetting | undefined,
-  auth?: SecurityConfig["auth"],
+  options: DispatchOptions = {},
 ): Promise<DispatchOutcome> {
   const security: Record<string, unknown> = {};
   if (csrf !== undefined) security.csrf = csrf;
-  if (auth !== undefined) security.auth = auth;
+  if (options.auth !== undefined) security.auth = options.auth;
   const config = { security } as VeryfrontConfig;
   const { securityConfig } = deriveSecurityContext(config, {
     // The task rail dispatches to the project's main-branch runtime, which
@@ -95,7 +128,7 @@ async function dispatchReleaseAssetBuild(
   });
   const request = new Request(`https://example-project.example.test${EXECUTE_PATH}`, {
     method: "POST",
-    headers: {
+    headers: options.unsigned ? { "content-type": "application/json" } : {
       "content-type": "application/json",
       "x-veryfront-control-plane-jws": jws,
     },
@@ -129,11 +162,22 @@ async function dispatchReleaseAssetBuild(
     new ProjectRunExecuteHandler(deps),
   ]);
 
-  const response = await registry.execute(request, ctx);
+  // The runtime wraps the whole handler chain in the project's own root
+  // middleware, so a dispatch meets `middleware.ts` before it meets any
+  // handler.
+  const middlewareRuntime = new ProjectMiddlewareRuntime({
+    loadMiddleware: () => Promise.resolve(options.projectMiddleware ?? []),
+  });
+  const response = await middlewareRuntime.execute({
+    request,
+    handlerContext: ctx,
+    isSharedProxy: false,
+    next: async () => (await registry.execute(request, ctx)) ?? undefined,
+  });
   return {
     begun,
     status: response?.status ?? 0,
-    body: response ? await response.text() : "",
+    body: response === undefined ? "" : await response.text(),
   };
 }
 
@@ -178,7 +222,7 @@ describe("release assets: control-plane build dispatch", () => {
     // could only ever answer 401 — and 401 is not retryable, so the run dies
     // and the manifest row is never created.
     const outcome = await dispatchReleaseAssetBuild(undefined, {
-      basic: { username: "admin", password: "secret" },
+      auth: { basic: { username: "admin", password: "secret" } },
     });
     assertEquals(
       outcome.begun,
@@ -190,7 +234,7 @@ describe("release assets: control-plane build dispatch", () => {
 
   it("builds a manifest when the project puts the site behind bearer auth", async () => {
     const outcome = await dispatchReleaseAssetBuild(undefined, {
-      bearer: { token: "project-authored-token" },
+      auth: { bearer: { token: "project-authored-token" } },
     });
     assertEquals(
       outcome.begun,
@@ -202,7 +246,7 @@ describe("release assets: control-plane build dispatch", () => {
 
   it("builds a manifest when the project enables both gates at once", async () => {
     const outcome = await dispatchReleaseAssetBuild(true, {
-      basic: { username: "admin", password: "secret" },
+      auth: { basic: { username: "admin", password: "secret" } },
     });
     assertEquals(
       outcome.begun,

--- a/src/security/http/auth.test.ts
+++ b/src/security/http/auth.test.ts
@@ -458,3 +458,205 @@ describe("AuthHandler realm sanitization", () => {
     }
   });
 });
+
+/**
+ * Regression: a project that configures `security.auth` must still answer the
+ * control plane's own dispatch.
+ *
+ * `AuthHandler` runs at priority 0 with an empty pattern list, and the registry
+ * never consults `metadata.patterns` — it calls every handler in priority
+ * order — so the gate sits in front of every control-plane surface. The
+ * platform authorizes those calls with a signed operation envelope, not with a
+ * project-authored Basic or Bearer credential it cannot know, so a configured
+ * project answered its own run dispatch with 401.
+ */
+describe("AuthHandler signed control-plane dispatch", () => {
+  const SIGNED = { "x-veryfront-control-plane-jws": "header.payload.signature" };
+
+  const SURFACES = [
+    { method: "POST", path: "/api/control-plane/agents/list" },
+    { method: "POST", path: "/api/control-plane/runs/run_1/execute" },
+    { method: "POST", path: "/api/control-plane/runs/run_1/stream" },
+    { method: "POST", path: "/api/control-plane/runs/run_1/resume" },
+    { method: "DELETE", path: "/api/control-plane/runs/run_1" },
+  ] as const;
+
+  const AUTH_CONFIGS: readonly unknown[] = [
+    { basic: { username: "admin", password: "secret" } },
+    { bearer: { token: "project-token" } },
+  ];
+
+  function createCtx(auth: unknown): HandlerContext {
+    return {
+      projectDir: "/tmp/auth-test",
+      securityConfig: { auth } as unknown as SecurityConfig,
+      adapter: {
+        env: { get: () => undefined },
+      } as unknown as HandlerContext["adapter"],
+      isLocalProject: false,
+    };
+  }
+
+  function createEnvCtx(credentials: Record<string, string>): HandlerContext {
+    return {
+      projectDir: "/tmp/auth-test",
+      securityConfig: null,
+      adapter: {
+        env: { get: (name: string) => credentials[name] },
+      } as unknown as HandlerContext["adapter"],
+      isLocalProject: false,
+    };
+  }
+
+  it("passes every registered surface through for every configured auth shape", async () => {
+    const handler = new AuthHandler();
+
+    for (const auth of AUTH_CONFIGS) {
+      for (const surface of SURFACES) {
+        const result = await handler.handle(
+          new Request(`https://acme.example.test${surface.path}`, {
+            method: surface.method,
+            headers: SIGNED,
+          }),
+          createCtx(auth),
+        );
+
+        expect(
+          [surface.method, surface.path, result.response?.status ?? "continue"],
+        ).toEqual([surface.method, surface.path, "continue"]);
+      }
+    }
+  });
+
+  it("passes a registered surface through for env-configured auth", async () => {
+    // `VERYFRONT_BASIC_USER`/`VERYFRONT_BEARER_TOKEN` reach the same gate as the
+    // config shape, so the deploy breaks identically when they are set.
+    const handler = new AuthHandler();
+
+    for (
+      const credentials of [
+        { VERYFRONT_BASIC_USER: "admin", VERYFRONT_BASIC_PASS: "secret" },
+        { VERYFRONT_BEARER_TOKEN: "project-token" },
+      ]
+    ) {
+      const result = await handler.handle(
+        new Request("https://acme.example.test/api/control-plane/runs/run_1/execute", {
+          method: "POST",
+          headers: SIGNED,
+        }),
+        createEnvCtx(credentials),
+      );
+
+      expect(result.response).toBe(undefined);
+    }
+  });
+
+  it("still challenges a path that merely starts alike", async () => {
+    const handler = new AuthHandler();
+
+    const result = await handler.handle(
+      new Request("https://acme.example.test/api/control-plane-mirror/runs/run_1/execute", {
+        method: "POST",
+        headers: SIGNED,
+      }),
+      createCtx({ basic: { username: "admin", password: "secret" } }),
+    );
+
+    expect(result.response?.status).toBe(401);
+  });
+
+  it("still challenges a project route inside the control-plane namespace", async () => {
+    // The reserved namespace is not exclusively routed: only five method/path
+    // shapes reach a handler that verifies a signed envelope, and anything else
+    // falls through to `ApiHandlerWrapper` and runs project code. Exempting the
+    // prefix would let a project turn its own auth gate off by choosing a path.
+    const handler = new AuthHandler();
+    const projectRoutes = [
+      { method: "POST", path: "/api/control-plane/checkout" },
+      { method: "POST", path: "/api/control-plane/runs" },
+      { method: "POST", path: "/api/control-plane/runs/run_1" },
+      { method: "POST", path: "/api/control-plane/runs/run_1/execute/extra" },
+      { method: "POST", path: "/api/control-plane/agents/list/all" },
+      { method: "PUT", path: "/api/control-plane/runs/run_1/execute" },
+      { method: "DELETE", path: "/api/control-plane/runs/run_1/execute" },
+      { method: "GET", path: "/api/control-plane/runs/run_1/execute" },
+    ];
+
+    for (const route of projectRoutes) {
+      const result = await handler.handle(
+        new Request(`https://acme.example.test${route.path}`, {
+          method: route.method,
+          headers: SIGNED,
+        }),
+        createCtx({ basic: { username: "admin", password: "secret" } }),
+      );
+
+      expect(
+        [route.method, route.path, result.response?.status ?? "continue"],
+      ).toEqual([route.method, route.path, 401]);
+    }
+  });
+
+  it("still challenges a registered surface with no signature header", async () => {
+    // A caller with no envelope has nothing verified downstream, so the gate
+    // must hold. This is what keeps the exemption from being a bypass.
+    const handler = new AuthHandler();
+
+    for (const surface of SURFACES) {
+      const result = await handler.handle(
+        new Request(`https://acme.example.test${surface.path}`, {
+          method: surface.method,
+        }),
+        createCtx({ basic: { username: "admin", password: "secret" } }),
+      );
+
+      expect(
+        [surface.method, surface.path, result.response?.status ?? "continue"],
+      ).toEqual([surface.method, surface.path, 401]);
+    }
+  });
+
+  it("still challenges a registered surface with an empty signature header", async () => {
+    const handler = new AuthHandler();
+
+    const result = await handler.handle(
+      new Request("https://acme.example.test/api/control-plane/runs/run_1/execute", {
+        method: "POST",
+        headers: { "x-veryfront-control-plane-jws": "" },
+      }),
+      createCtx({ basic: { username: "admin", password: "secret" } }),
+    );
+
+    expect(result.response?.status).toBe(401);
+  });
+
+  it("dispatches a signed surface even when the auth config is unresolvable", async () => {
+    // An auth config the runtime cannot resolve fails closed for every browser
+    // request, and that stays true — the two assertions below share one config.
+    // A control-plane dispatch is not browser shaped: the receiving handler
+    // verifies its envelope before acting, so a project typo must not brick the
+    // platform's own run dispatch the way it must brick project content.
+    const handler = new AuthHandler();
+    const unresolvable = {
+      basic: { username: "admin", password: "secret" },
+      bearer: { token: "project-token" },
+    };
+
+    const dispatch = await handler.handle(
+      new Request("https://acme.example.test/api/control-plane/runs/run_1/execute", {
+        method: "POST",
+        headers: SIGNED,
+      }),
+      createCtx(unresolvable),
+    );
+    expect(dispatch.response).toBe(undefined);
+
+    const browser = await handler.handle(
+      new Request("https://acme.example.test/api/control-plane/runs/run_1/execute", {
+        method: "POST",
+      }),
+      createCtx(unresolvable),
+    );
+    expect(browser.response?.status).toBe(401);
+  });
+});

--- a/src/security/http/auth.test.ts
+++ b/src/security/http/auth.test.ts
@@ -533,12 +533,12 @@ describe("AuthHandler signed control-plane dispatch", () => {
     // config shape, so the deploy breaks identically when they are set.
     const handler = new AuthHandler();
 
-    for (
-      const credentials of [
-        { VERYFRONT_BASIC_USER: "admin", VERYFRONT_BASIC_PASS: "secret" },
-        { VERYFRONT_BEARER_TOKEN: "project-token" },
-      ]
-    ) {
+    const credentialShapes: Record<string, string>[] = [
+      { VERYFRONT_BASIC_USER: "admin", VERYFRONT_BASIC_PASS: "secret" },
+      { VERYFRONT_BEARER_TOKEN: "project-token" },
+    ];
+
+    for (const credentials of credentialShapes) {
       const result = await handler.handle(
         new Request("https://acme.example.test/api/control-plane/runs/run_1/execute", {
           method: "POST",

--- a/src/security/http/auth.ts
+++ b/src/security/http/auth.ts
@@ -1,4 +1,5 @@
 import { isCspReportRequest } from "#veryfront/security/http/csp-report-endpoint.ts";
+import { isSignedControlPlaneDispatch } from "#veryfront/channels/control-plane.ts";
 import { BaseHandler } from "./base-handler.ts";
 import type {
   HandlerContext,
@@ -169,6 +170,31 @@ export class AuthHandler extends BaseHandler {
     if (isCspReportRequest(req.method, new URL(req.url).pathname)) {
       return Promise.resolve(this.continue());
     }
+
+    // A control-plane dispatch is not a site visitor. Run execute/stream/resume
+    // /cancel and agent listing arrive from the platform carrying a signed
+    // operation envelope, verified before the receiving handler acts on it. The
+    // platform cannot hold the credential this gate demands: it sends a
+    // per-run service `Bearer` JWT the Basic branch can never match, and the
+    // Bearer branch compares against a secret the project authored. Challenging
+    // it protects nothing and instead kills the run — 401 is not retryable, so
+    // the release asset manifest row is never created and `deploy` fails at its
+    // 120s deadline naming neither auth nor config. Studio's agent listing 401s
+    // the same way, on a call that sends no `Authorization` header at all.
+    //
+    // The exemption is keyed on the request being a real dispatch, not on it
+    // being path-shaped like one: `isSignedControlPlaneDispatch` requires both a
+    // method/path pair that a control-plane handler owns and the signature
+    // header that handler verifies. The `/api/control-plane/` namespace is
+    // reserved but not exclusively routed, so a project App or Pages API route
+    // can sit under it in a custom runtime; such a route is not a registered
+    // surface and keeps its auth gate.
+    //
+    // This sits ahead of `resolveAuth` for the same reason the CSP report
+    // exemption does: an auth config the runtime cannot resolve still fails
+    // closed for every browser request, but a project's config typo must not
+    // brick the platform's own dispatch, which authenticates itself downstream.
+    if (isSignedControlPlaneDispatch(req)) return Promise.resolve(this.continue());
 
     const auth = this.resolveAuth(ctx);
     if (!auth) return Promise.resolve(this.continue());

--- a/src/server/handlers/request/internal-agents-list.handler.test.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.test.ts
@@ -4,6 +4,9 @@ import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/as
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES } from "#veryfront/internal-agents/request-body.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { RouteRegistry } from "#veryfront/routing/registry/index.ts";
+import { AuthHandler } from "#veryfront/security/http/auth.ts";
+import type { HandlerContext, SecurityConfig } from "#veryfront/types";
 import { InternalAgentsListHandler } from "./internal-agents-list.handler.ts";
 import { runWithProjectEnv } from "../../project-env/storage.ts";
 import {
@@ -523,5 +526,94 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
     );
 
     assertEquals(result.response, undefined);
+  });
+});
+
+/**
+ * Regression: Studio's agent listing must survive a project that configures
+ * `security.auth`.
+ *
+ * `AuthHandler` runs at priority 0 with an empty pattern list, and the registry
+ * calls every handler in priority order rather than consulting
+ * `metadata.patterns`, so it stands in front of this surface. The control plane
+ * sends no `Authorization` header on this call at all — it authorizes with the
+ * signed envelope `verifyControlPlaneRequest` checks — so a project that turned
+ * on Basic or Bearer auth answered its own agent listing with 401 and Studio
+ * showed no agents.
+ */
+describe("server/handlers/request/internal-agents-list.handler auth gate", () => {
+  function createListHandler(): InternalAgentsListHandler {
+    return new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => createEmptyDiscoveryResult(),
+      getAgent: (id) => id === "assistant-1" ? createAgentWithConfig("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+    });
+  }
+
+  async function listAgentsThroughChain(
+    auth: SecurityConfig["auth"],
+    options: { readonly signed?: boolean; readonly path?: string } = {},
+  ): Promise<{ status: number }> {
+    const path = options.path ?? "/api/control-plane/agents/list";
+    const body = JSON.stringify({
+      requestId: "agents-1",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-1",
+      requestPath: path,
+    });
+
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    // The control plane sends no `Authorization` header on this call; the
+    // request below carries exactly what `runtime-agent-client` sends.
+    if (options.signed !== false) headers["x-veryfront-control-plane-jws"] = jws;
+
+    const ctx = createCtx(publicKeyPem);
+    ctx.securityConfig = { auth } as HandlerContext["securityConfig"];
+
+    const registry = new RouteRegistry();
+    registry.registerAll([new AuthHandler(), createListHandler()]);
+
+    const response = await registry.execute(
+      new Request(`https://example.com${path}`, { method: "POST", headers, body }),
+      ctx,
+    );
+
+    return { status: response?.status ?? 0 };
+  }
+
+  it("lists agents for a signed dispatch behind basic auth", async () => {
+    const { status } = await listAgentsThroughChain({
+      basic: { username: "admin", password: "secret" },
+    });
+    assertEquals(status, 200);
+  });
+
+  it("lists agents for a signed dispatch behind bearer auth", async () => {
+    const { status } = await listAgentsThroughChain({
+      bearer: { token: "project-authored-token" },
+    });
+    assertEquals(status, 200);
+  });
+
+  it("still challenges the same surface without the signature header", async () => {
+    const { status } = await listAgentsThroughChain(
+      { basic: { username: "admin", password: "secret" } },
+      { signed: false },
+    );
+    assertEquals(status, 401);
+  });
+
+  it("still challenges a project route inside the control-plane namespace", async () => {
+    // `/api/control-plane/agents/list/all` is not a registered surface; it
+    // falls through to project code, which the auth gate must keep protecting
+    // even when the caller attaches a signature header.
+    const { status } = await listAgentsThroughChain(
+      { basic: { username: "admin", password: "secret" } },
+      { path: "/api/control-plane/agents/list/all" },
+    );
+    assertEquals(status, 401);
   });
 });


### PR DESCRIPTION
Second instance of the bug class [#3641](https://github.com/veryfront/veryfront-code/pull/3641) fixed for CSRF: **a gate demands a credential that a legitimate caller structurally cannot hold, and is positioned to run before that caller's handler.**

## The hole

`AuthHandler` (`src/security/http/auth.ts`) declares `priority: 0` and `patterns: []`. The registry never consults `metadata.patterns` — `registry.ts` calls every handler in priority order — so a handler must self-limit, and `AuthHandler.handle` had no path check. It ran on every request, ahead of `CsrfHandler` (priority 5) and `ProjectRunExecuteHandler`, exempting only `OPTIONS` and `isCspReportRequest`.

The platform cannot satisfy it:

- The control plane sends `Authorization: Bearer <platform-minted per-run service JWT>` plus the JWS envelope header (`veryfront-api` `runtime-project-run-client.ts:120-158`). `checkBasicAuth` can never match a `Bearer` header; `checkBearerAuth` compares it against a secret the **project** authored.
- So any project with `security.auth` — or `VERYFRONT_BASIC_USER` / `VERYFRONT_BEARER_TOKEN` — answered its own `task:release-asset-build` dispatch with **401**.
- 401 is not retryable (the client retries only on `>=500` or `429`), so the run died before the manifest row existed, the state stayed `missing`, and `veryfront deploy` failed at its 120s deadline reporting `Release assets were not ready within 120s (last state: missing)` — naming neither auth nor config.

**Second surface:** `POST /api/control-plane/agents/list` fails the same way and worse — `runtime-agent-client.ts:253-269` sends **no `Authorization` header at all**, so Studio's agent listing 401s for any project with `security.auth` set.

## The fix

Reuses the predicate #3641 introduced, in `AuthHandler.handle` alongside the OPTIONS and CSP-report exemptions:

```ts
if (isSignedControlPlaneDispatch(req)) return Promise.resolve(this.continue());
```

`isSignedControlPlaneDispatch` returns true only when **both** hold:

1. `isControlPlaneSurfaceRoute` matches one of five anchored method/path shapes, and
2. the request carries `x-veryfront-control-plane-jws`.

Not a weakening: it exempts nothing that is not authenticated more strongly downstream. Every one of those five surfaces calls `verifyControlPlaneRequest`, and `verifyControlPlaneJws` binds the Ed25519 signature to issuer, audience, project id, request method, request path and body hash, with expiry/skew bounds.

**Why not a prefix match.** `/api/control-plane/` is reserved but not exclusively routed. The run handlers register only the prefix and `return this.continue()` when their anchored regex misses; `ApiHandlerWrapper` declares no patterns and sits after them, so `/api/control-plane/checkout` falls through to project code. Anything keyed on `startsWith`/`includes` would ship a bypass a project could trigger by choosing a path.

**Why ahead of `resolveAuth`.** Same placement as the CSP-report exemption. An unresolvable auth config still fails closed for every browser request, but a project's config typo must not brick the platform's own dispatch, which authenticates itself downstream. A test pins both halves of that with one config.

## Tests (written first, confirmed red)

Red, before the production change:

```
AuthHandler signed control-plane dispatch ...
  passes every registered surface through for every configured auth shape ... FAILED
  passes a registered surface through for env-configured auth ... FAILED
  still challenges a path that merely starts alike ... ok
  still challenges a project route inside the control-plane namespace ... ok
  still challenges a registered surface with no signature header ... ok
  still challenges a registered surface with an empty signature header ... ok
  dispatches a signed surface even when the auth config is unresolvable ... FAILED

error: AssertionError: Values are not equal.
    [ "POST", "/api/control-plane/agents/list", -401 / +"continue" ]
```

```
release assets: control-plane build dispatch ...
  builds a manifest when the project puts the site behind basic auth ... FAILED
  builds a manifest when the project puts the site behind bearer auth ... FAILED
  builds a manifest when the project enables both gates at once ... FAILED

error: AssertionError: release asset build never started; runtime answered 401: Unauthorized
    -false / +true
```

```
internal-agents-list.handler auth gate ...
  lists agents for a signed dispatch behind basic auth ... FAILED   (-401 / +200)
  lists agents for a signed dispatch behind bearer auth ... FAILED   (-401 / +200)
  still challenges the same surface without the signature header ... ok
  still challenges a project route inside the control-plane namespace ... ok
```

Coverage:

- **`src/security/http/auth.test.ts`** — all five surfaces pass for basic, bearer and env-configured auth. **Adversarial:** a look-alike path (`/api/control-plane-mirror/...`), seven project routes inside the namespace *with* the signature header attached, every registered surface with no signature header, and a surface with an empty signature header — all still 401.
- **`src/release-assets/build-dispatch-security.test.ts`** — drives the real chain (`AuthHandler` → `CsrfHandler` → `ProjectRunExecuteHandler`) with a genuine signed Ed25519 envelope and asserts the release asset build executor is reached, under basic auth, bearer auth, and both gates at once. The four pre-existing CSRF cases are unchanged and still pass with `AuthHandler` added to the chain.
- **`src/server/handlers/request/internal-agents-list.handler.test.ts`** — real chain (`AuthHandler` → `InternalAgentsListHandler`) for the second surface, sending exactly what `runtime-agent-client` sends (no `Authorization` header).

No existing test was weakened or deleted.

## Verification

- `deno test src/security/ src/release-assets/ src/channels/ src/server/handlers/` (repo test flags): `ok | 216 passed (2435 steps) | 0 failed`
- `deno task lint:module-boundaries` — exit 0; the import mirrors the one `csrf-handler.ts` already makes. (The "debt decreased by 1" note it prints is pre-existing on clean `origin/main`.)
- `deno lint` / `deno fmt --check` on the changed files, `deno check src/security/http/auth.ts`
- `deno task docs` regenerated the one shifted line pin in `docs/api-reference/veryfront/security.md`

Deno 2.7.7 throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Improved handling of verified control-plane requests so authorized dispatches proceed without unnecessary project authentication prompts.
  * Added coverage for Basic and Bearer authentication, CSRF protection, signed requests, and invalid or unregistered routes.
  * Unauthorized, unsigned, or unmatched requests continue to receive appropriate protection.

* **Documentation**
  * Corrected the `AuthHandler` source reference in the API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->