### PR TITLE
fix(proxy): carry proxy identity on the renderer WebSocket bridge

### DIFF
--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -33,11 +33,13 @@ import {
 } from "./retry.ts";
 import {
   authorizeWebSocketRequest,
+  buildRendererBridgeRequest,
   closeBridgePeer,
   createProxyClientWebSocketUpgradeOptions,
   getClientWebSocketErrorLogLevel,
   getServerWebSocketErrorLogLevel,
 } from "./websocket-bridge.ts";
+import { connectUpstreamWebSocket, type UpstreamWebSocket } from "./websocket-client.ts";
 import { register } from "../extensions/contracts.ts";
 import { importFirstPartyExtensionModule } from "#veryfront/extensions/first-party-import.ts";
 import { ENV_VAR_MISSING, INITIALIZATION_ERROR } from "#veryfront/errors";
@@ -282,11 +284,12 @@ async function handleWebSocketUpgrade(req: Request, url: URL): Promise<Response>
   const scope = context.environment;
   const projectSlug = context.projectSlug;
 
-  const serverWsUrl = PRODUCTION_SERVER_URL.replace(/^http/, "ws");
-  const safePath = url.pathname.replace(/^\/\/+/, "/");
-  const targetUrl = new URL(`${serverWsUrl}${safePath}${url.search}`);
-  targetUrl.searchParams.set("x-project-slug", projectSlug || "");
-  targetUrl.searchParams.set("x-environment", scope);
+  const { url: targetUrl, headers: bridgeHeaders } = buildRendererBridgeRequest(
+    req,
+    url,
+    context,
+    PRODUCTION_SERVER_URL,
+  );
 
   proxyLogger.info("[WebSocket] Upgrade request received", {
     host,
@@ -302,7 +305,7 @@ async function handleWebSocketUpgrade(req: Request, url: URL): Promise<Response>
     createProxyClientWebSocketUpgradeOptions(),
   );
 
-  let serverSocket: WebSocket | null = null;
+  let serverSocket: UpstreamWebSocket | null = null;
   let connectTimeoutId: ReturnType<typeof setTimeout> | null = null;
   let timedOut = false;
 
@@ -318,7 +321,10 @@ async function handleWebSocketUpgrade(req: Request, url: URL): Promise<Response>
     });
 
     try {
-      serverSocket = new WebSocket(targetUrl.toString());
+      // Headered hop: the renderer's proxy guard requires the same identity
+      // every other forwarded request carries, and a bare WebSocket cannot
+      // send it.
+      serverSocket = connectUpstreamWebSocket(targetUrl, bridgeHeaders);
     } catch (error) {
       proxyLogger.error("[WebSocket] Failed to create server WebSocket", {
         error: error instanceof Error ? error.message : String(error),

--- a/src/proxy/websocket-bridge-identity.test.ts
+++ b/src/proxy/websocket-bridge-identity.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The proxy's own WebSocket bridge hop, judged by the renderer gate that
+ * actually answers it.
+ *
+ * `handleWebSocketUpgrade` terminates the browser socket and opens a second
+ * socket to the shared renderer. That second request is the one the renderer's
+ * `createProxyGuard` inspects, so these tests build it with the production
+ * builder and hand it to the production guard rather than asserting on a
+ * header list that could drift from what the guard demands.
+ */
+import "#veryfront/schemas/_test-setup.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { prepareProjectRequest } from "#veryfront/server/runtime-handler/project-runtime-context.ts";
+import type { ProxyContext } from "./handler.ts";
+import { buildRendererBridgeRequest } from "./websocket-bridge.ts";
+import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
+
+/** The internal renderer service. It is not a project domain and carries no slug. */
+const RENDERER_SERVER_URL = "http://veryfront-server";
+
+/** Headers a browser sends to the proxy for `wss://<slug>.preview.veryfront.com/_ws`. */
+function browserUpgradeHeaders(host: string): Headers {
+  return new Headers({
+    host,
+    upgrade: "websocket",
+    connection: "Upgrade",
+    "sec-websocket-version": "13",
+    "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+  });
+}
+
+/** The context the proxy resolved for the browser socket before bridging. */
+function previewContext(overrides: Partial<ProxyContext> = {}): ProxyContext {
+  const host = "support-agent-agodnc.preview.veryfront.com";
+  return {
+    token: "vf_proxy_minted_project_token",
+    projectSlug: "support-agent-agodnc",
+    projectId: "prj_01hzzz",
+    environment: "preview",
+    contentSourceId: "src_01hzzz",
+    host,
+    parsedDomain: parseProjectDomain(host),
+    isLocalProject: false,
+    ...overrides,
+  };
+}
+
+/** Replay the bridge hop as the renderer receives it. */
+function bridgeHopRequest(
+  browserRequest: Request,
+  context: ProxyContext,
+): Request {
+  const bridge = buildRendererBridgeRequest(
+    browserRequest,
+    new URL(browserRequest.url),
+    context,
+    RENDERER_SERVER_URL,
+  );
+  const headers = new Headers(bridge.headers);
+  // Deno's client adds the handshake fields itself; the identity must survive.
+  headers.set("host", new URL(bridge.url).host);
+  headers.set("upgrade", "websocket");
+  headers.set("connection", "Upgrade");
+  headers.set("sec-websocket-version", "13");
+  headers.set("sec-websocket-key", "AQIDBAUGBwgJCgsMDQ4PEC==");
+  return new Request(bridge.url.toString().replace(/^ws/, "http"), { headers });
+}
+
+async function guardVerdict(
+  request: Request,
+  trusted: boolean,
+): Promise<{ detail: string | null; projectSlug: string | undefined }> {
+  const prepared = await prepareProjectRequest({
+    req: request,
+    url: new URL(request.url),
+    isProxyMode: true,
+    trustProxy: () => Promise.resolve(trusted),
+  });
+  return {
+    detail: prepared.proxyGuard?.detail ?? null,
+    projectSlug: prepared.headers.projectSlug,
+  };
+}
+
+describe("proxy renderer WebSocket bridge identity", () => {
+  it("is admitted by the renderer proxy guard", async () => {
+    const browserRequest = new Request(
+      "https://support-agent-agodnc.preview.veryfront.com/_ws",
+      { headers: browserUpgradeHeaders("support-agent-agodnc.preview.veryfront.com") },
+    );
+
+    const verdict = await guardVerdict(
+      bridgeHopRequest(browserRequest, previewContext()),
+      true,
+    );
+
+    assertEquals(
+      verdict.detail,
+      null,
+      "the platform's own preview HMR bridge is answered 502 by the renderer",
+    );
+    assertEquals(verdict.projectSlug, "support-agent-agodnc");
+  });
+
+  it("carries the proxy-minted project token the renderer needs upstream", () => {
+    const browserRequest = new Request(
+      "https://support-agent-agodnc.preview.veryfront.com/_ws",
+      { headers: browserUpgradeHeaders("support-agent-agodnc.preview.veryfront.com") },
+    );
+
+    const bridge = buildRendererBridgeRequest(
+      browserRequest,
+      new URL(browserRequest.url),
+      previewContext(),
+      RENDERER_SERVER_URL,
+    );
+
+    assertEquals(bridge.headers.get("x-token"), "vf_proxy_minted_project_token");
+    assertEquals(bridge.headers.get("x-project-slug"), "support-agent-agodnc");
+    assertEquals(bridge.headers.get("x-environment"), "preview");
+  });
+
+  it("never lets the browser's query string name the tenant", async () => {
+    // The browser chooses the whole query string of `/_ws`, and the bridge
+    // forwards it. Identity must come from the proxy-resolved context only.
+    const browserRequest = new Request(
+      "https://support-agent-agodnc.preview.veryfront.com/_ws" +
+        "?x-project-slug=victim-project&x-environment=production",
+      { headers: browserUpgradeHeaders("support-agent-agodnc.preview.veryfront.com") },
+    );
+
+    const bridge = buildRendererBridgeRequest(
+      browserRequest,
+      new URL(browserRequest.url),
+      previewContext(),
+      RENDERER_SERVER_URL,
+    );
+    const verdict = await guardVerdict(bridgeHopRequest(browserRequest, previewContext()), true);
+
+    assertEquals(bridge.url.searchParams.get("x-project-slug"), null);
+    assertEquals(bridge.url.searchParams.get("x-environment"), null);
+    assertEquals(verdict.projectSlug, "support-agent-agodnc");
+    assertEquals(verdict.detail, null);
+  });
+
+  it("still rejects an unsigned look-alike hop that names itself in the query", async () => {
+    // Anything that reaches the renderer directly and mimics the bridge URL
+    // without the proxy-supplied identity headers must stay rejected.
+    const forged = new Request(
+      "http://veryfront-server/_ws?x-project-slug=support-agent-agodnc&x-environment=preview",
+      { headers: browserUpgradeHeaders("veryfront-server") },
+    );
+
+    const verdict = await guardVerdict(forged, true);
+
+    assertEquals(verdict.detail, "x-project-slug header is required in proxy mode");
+    assertEquals(verdict.projectSlug, undefined);
+  });
+
+  it("still rejects a bridge-shaped hop with no upstream token", async () => {
+    const browserRequest = new Request(
+      "https://support-agent-agodnc.preview.veryfront.com/_ws",
+      { headers: browserUpgradeHeaders("support-agent-agodnc.preview.veryfront.com") },
+    );
+
+    const verdict = await guardVerdict(
+      bridgeHopRequest(browserRequest, previewContext({ token: undefined })),
+      true,
+    );
+
+    assertEquals(verdict.detail, "x-token header is required in proxy mode");
+  });
+
+  it("still rejects the bridge hop when the proxy boundary is not operator-trusted", async () => {
+    const browserRequest = new Request(
+      "https://support-agent-agodnc.preview.veryfront.com/_ws",
+      { headers: browserUpgradeHeaders("support-agent-agodnc.preview.veryfront.com") },
+    );
+
+    const verdict = await guardVerdict(
+      bridgeHopRequest(browserRequest, previewContext({ projectId: "prj_01hzzz" })),
+      false,
+    );
+
+    assert(verdict.detail !== null, "an untrusted boundary must not be admitted");
+    assertEquals(
+      verdict.detail,
+      "project, environment, and branch identity headers require an operator-authenticated proxy boundary",
+    );
+  });
+});

--- a/src/proxy/websocket-bridge.ts
+++ b/src/proxy/websocket-bridge.ts
@@ -1,4 +1,5 @@
 import type { WebSocketUpgradeOptions } from "#veryfront/platform/compat/http/index.ts";
+import { createProxyContextHeaders } from "./handler.ts";
 import type { ProxyContext, ProxyRequestOptions } from "./handler.ts";
 
 type BridgePeer = Pick<WebSocket, "close" | "readyState">;
@@ -15,6 +16,61 @@ export async function authorizeWebSocketRequest(
 ): Promise<WebSocketAuthorization> {
   const context = await resolveContext(req, { url });
   return context.error ? { allowed: false, error: context.error } : { allowed: true, context };
+}
+
+/** The upstream hop the proxy opens to the renderer for a browser WebSocket. */
+export interface RendererBridgeRequest {
+  readonly url: URL;
+  readonly headers: Headers;
+}
+
+/**
+ * Identity the browser may name in the `/_ws` query string. The proxy owns both
+ * values, so a client-supplied copy is always discarded rather than forwarded.
+ */
+const BROWSER_CONTROLLED_IDENTITY_PARAMS = ["x-project-slug", "x-environment"] as const;
+
+/**
+ * Handshake fields that belong to the browser's socket, not the upstream one.
+ * The upstream client mints its own key, version and extension list.
+ */
+const CLIENT_HANDSHAKE_HEADERS = [
+  "sec-websocket-key",
+  "sec-websocket-version",
+  "sec-websocket-extensions",
+  "sec-websocket-accept",
+] as const;
+
+/**
+ * Build the renderer hop for a browser WebSocket.
+ *
+ * The bridge hop carries the same proxy-resolved identity headers as every
+ * other forwarded request -- including the `x-token` the proxy minted for this
+ * project from its own API client credentials. That is what positively
+ * identifies the proxy to the renderer's `createProxyGuard`; the guard demands
+ * exactly this and nothing about a WebSocket makes it optional.
+ *
+ * Identity is never taken from the query string: the browser chooses the whole
+ * query of `/_ws` and the bridge forwards it, so any tenant identity read from
+ * there would be caller-chosen. The two params the proxy used to write are
+ * deleted for the same reason.
+ */
+export function buildRendererBridgeRequest(
+  req: Request,
+  url: URL,
+  context: ProxyContext,
+  serverUrl: string,
+): RendererBridgeRequest {
+  const serverWsUrl = serverUrl.replace(/^http/, "ws");
+  const safePath = url.pathname.replace(/^\/\/+/, "/");
+  const target = new URL(`${serverWsUrl}${safePath}${url.search}`);
+  for (const param of BROWSER_CONTROLLED_IDENTITY_PARAMS) target.searchParams.delete(param);
+
+  const headers = createProxyContextHeaders(req.headers, context);
+  for (const header of CLIENT_HANDSHAKE_HEADERS) headers.delete(header);
+  headers.delete("sec-websocket-protocol");
+
+  return { url: target, headers };
 }
 
 export type ServerWebSocketErrorLogLevel = "warn" | "error";

--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -10,8 +10,6 @@ import {
 import { buildRendererBridgeRequest } from "./websocket-bridge.ts";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
 
-const TEST_PORT = 45913;
-
 interface UpstreamServer {
   readonly url: URL;
   readonly seenHeaders: Promise<Record<string, string | null>>;
@@ -27,8 +25,11 @@ function startUpstreamServer(options: { rejectWith?: number } = {}): UpstreamSer
   });
   const sockets = new Set<WebSocket>();
 
+  // Bind ephemerally (port 0) so parallel test modules never collide on a fixed
+  // port, and to 127.0.0.1 to avoid IPv6 flakiness — same shape as the other
+  // proxy tests (see server-resolver.test.ts, token-manager.test.ts).
   const server = Deno.serve(
-    { port: TEST_PORT, signal: controller.signal, onListen: () => {} },
+    { hostname: "127.0.0.1", port: 0, signal: controller.signal, onListen: () => {} },
     (req) => {
       resolveHeaders({
         "x-token": req.headers.get("x-token"),
@@ -51,8 +52,10 @@ function startUpstreamServer(options: { rejectWith?: number } = {}): UpstreamSer
     },
   );
 
+  const addr = server.addr as Deno.NetAddr;
+
   return {
-    url: new URL(`ws://127.0.0.1:${TEST_PORT}/_ws`),
+    url: new URL(`ws://${addr.hostname}:${addr.port}/_ws`),
     seenHeaders,
     async close() {
       for (const socket of sockets) {
@@ -133,7 +136,7 @@ describe("upstream WebSocket client", () => {
           parsedDomain: parseProjectDomain("support-agent-agodnc.preview.veryfront.com"),
           isLocalProject: false,
         },
-        "http://127.0.0.1:" + TEST_PORT,
+        `http://${server.url.host}`,
       );
 
       const socket = connectUpstreamWebSocket(server.url, bridge.headers);

--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -1,0 +1,258 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assert, assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  connectUpstreamWebSocket,
+  resolveUpstreamWebSocketStreamFactory,
+  UpstreamWebSocket,
+  type UpstreamWebSocketStream,
+} from "./websocket-client.ts";
+import { buildRendererBridgeRequest } from "./websocket-bridge.ts";
+import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
+
+const TEST_PORT = 45913;
+
+interface UpstreamServer {
+  readonly url: URL;
+  readonly seenHeaders: Promise<Record<string, string | null>>;
+  close(): Promise<void>;
+}
+
+/** A renderer stand-in that reports the handshake headers it received. */
+function startUpstreamServer(options: { rejectWith?: number } = {}): UpstreamServer {
+  const controller = new AbortController();
+  let resolveHeaders: (value: Record<string, string | null>) => void = () => {};
+  const seenHeaders = new Promise<Record<string, string | null>>((resolve) => {
+    resolveHeaders = resolve;
+  });
+  const sockets = new Set<WebSocket>();
+
+  const server = Deno.serve(
+    { port: TEST_PORT, signal: controller.signal, onListen: () => {} },
+    (req) => {
+      resolveHeaders({
+        "x-token": req.headers.get("x-token"),
+        "x-project-slug": req.headers.get("x-project-slug"),
+        "x-environment": req.headers.get("x-environment"),
+        "sec-websocket-key": req.headers.get("sec-websocket-key"),
+      });
+      if (options.rejectWith) {
+        return new Response(JSON.stringify({ error: "Missing project context" }), {
+          status: options.rejectWith,
+        });
+      }
+      const { socket, response } = Deno.upgradeWebSocket(req);
+      sockets.add(socket);
+      socket.onmessage = (event) => {
+        if (socket.readyState === WebSocket.OPEN) socket.send(`echo:${event.data}`);
+      };
+      socket.onclose = () => sockets.delete(socket);
+      return response;
+    },
+  );
+
+  return {
+    url: new URL(`ws://127.0.0.1:${TEST_PORT}/_ws`),
+    seenHeaders,
+    async close() {
+      for (const socket of sockets) {
+        if (socket.readyState === WebSocket.OPEN) socket.close();
+      }
+      controller.abort();
+      await server.finished;
+    },
+  };
+}
+
+function identityHeaders(): Headers {
+  return new Headers({
+    "x-token": "vf_proxy_minted_project_token",
+    "x-project-slug": "support-agent-agodnc",
+    "x-environment": "preview",
+  });
+}
+
+describe("upstream WebSocket client", () => {
+  it("presents the proxy identity headers on the handshake", async () => {
+    const server = startUpstreamServer();
+    try {
+      const socket = connectUpstreamWebSocket(server.url, identityHeaders());
+      const opened = new Promise<void>((resolve) => {
+        socket.onopen = () => resolve();
+      });
+      await opened;
+
+      const seen = await server.seenHeaders;
+      assertEquals(seen["x-token"], "vf_proxy_minted_project_token");
+      assertEquals(seen["x-project-slug"], "support-agent-agodnc");
+      assertEquals(seen["x-environment"], "preview");
+      assert(seen["sec-websocket-key"], "the client still performs a real handshake");
+
+      const closed = new Promise<void>((resolve) => {
+        socket.onclose = () => resolve();
+      });
+      socket.close(1000, "done");
+      await closed;
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("carries a full browser-derived bridge header set through the handshake", async () => {
+    // The forwarded set is whatever the browser sent minus hop-by-hop fields,
+    // so the handshake must survive cookies, origin and friends riding along.
+    const server = startUpstreamServer();
+    try {
+      const browserRequest = new Request(
+        "https://support-agent-agodnc.preview.veryfront.com/_ws",
+        {
+          headers: {
+            host: "support-agent-agodnc.preview.veryfront.com",
+            upgrade: "websocket",
+            connection: "Upgrade",
+            "sec-websocket-version": "13",
+            "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "sec-websocket-extensions": "permessage-deflate",
+            origin: "https://support-agent-agodnc.preview.veryfront.com",
+            cookie: "authToken=browser-session",
+            "user-agent": "Mozilla/5.0",
+            "accept-language": "en-GB",
+          },
+        },
+      );
+      const bridge = buildRendererBridgeRequest(
+        browserRequest,
+        new URL(browserRequest.url),
+        {
+          token: "vf_proxy_minted_project_token",
+          projectSlug: "support-agent-agodnc",
+          projectId: "prj_01hzzz",
+          environment: "preview",
+          contentSourceId: "src_01hzzz",
+          host: "support-agent-agodnc.preview.veryfront.com",
+          parsedDomain: parseProjectDomain("support-agent-agodnc.preview.veryfront.com"),
+          isLocalProject: false,
+        },
+        "http://127.0.0.1:" + TEST_PORT,
+      );
+
+      const socket = connectUpstreamWebSocket(server.url, bridge.headers);
+      await new Promise<void>((resolve, reject) => {
+        socket.onopen = () => resolve();
+        socket.onerror = () => reject(new Error("the bridge handshake was rejected"));
+      });
+
+      const seen = await server.seenHeaders;
+      assertEquals(seen["x-token"], "vf_proxy_minted_project_token");
+      assertEquals(seen["x-project-slug"], "support-agent-agodnc");
+
+      const closed = new Promise<void>((resolve) => {
+        socket.onclose = () => resolve();
+      });
+      socket.close(1000, "done");
+      await closed;
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("bridges frames in both directions", async () => {
+    const server = startUpstreamServer();
+    try {
+      const socket = connectUpstreamWebSocket(server.url, identityHeaders());
+      const message = new Promise<string>((resolve) => {
+        socket.onmessage = (event) => resolve(String(event.data));
+      });
+      await new Promise<void>((resolve) => {
+        socket.onopen = () => resolve();
+      });
+
+      socket.send("ping");
+      assertEquals(await message, "echo:ping");
+
+      const closed = new Promise<void>((resolve) => {
+        socket.onclose = () => resolve();
+      });
+      socket.close(1000, "done");
+      await closed;
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("surfaces a rejected handshake as an error and a close", async () => {
+    // Exactly what production sees today when the renderer answers 502.
+    const server = startUpstreamServer({ rejectWith: 502 });
+    try {
+      const socket = connectUpstreamWebSocket(server.url, new Headers());
+      const events: string[] = [];
+      const settled = new Promise<void>((resolve) => {
+        socket.onerror = () => events.push("error");
+        socket.onclose = () => {
+          events.push("close");
+          resolve();
+        };
+      });
+      await settled;
+
+      assertEquals(events, ["error", "close"]);
+      assertEquals(socket.readyState, WebSocket.CLOSED);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("never falls back to a headerless socket when WebSocketStream is missing", () => {
+    const scope = globalThis as { WebSocketStream?: unknown };
+    const original = scope.WebSocketStream;
+    delete scope.WebSocketStream;
+    try {
+      assertThrows(
+        () => resolveUpstreamWebSocketStreamFactory(),
+        TypeError,
+        "WebSocketStream is unavailable",
+      );
+    } finally {
+      if (original !== undefined) scope.WebSocketStream = original;
+    }
+  });
+
+  it("tears the stream down when the close code is rejected by the client API", () => {
+    const closeCalls: (undefined | { closeCode?: number; reason?: string })[] = [];
+    const stream: UpstreamWebSocketStream = {
+      opened: new Promise(() => {}),
+      closed: new Promise(() => {}),
+      close(closeInfo) {
+        closeCalls.push(closeInfo);
+        if (closeInfo) throw new TypeError("The close code must be 1000 or 3000-4999");
+      },
+    };
+
+    const socket = new UpstreamWebSocket("ws://renderer/_ws", new Headers(), () => stream);
+    socket.close(1011, "Server connection error");
+
+    assertEquals(closeCalls.length, 2);
+    assertEquals(closeCalls[0], { closeCode: 1011, reason: "Server connection error" });
+    assertEquals(closeCalls[1], undefined);
+    assertEquals(socket.readyState, WebSocket.CLOSING);
+  });
+
+  it("passes the headers straight through to the stream factory", () => {
+    let seen: [string, string][] = [];
+    const stream: UpstreamWebSocketStream = {
+      opened: new Promise(() => {}),
+      closed: new Promise(() => {}),
+      close() {},
+    };
+
+    new UpstreamWebSocket("ws://renderer/_ws", identityHeaders(), (_url, init) => {
+      seen = init.headers;
+      return stream;
+    });
+
+    assert(
+      seen.some(([name, value]) => name === "x-token" && value === "vf_proxy_minted_project_token"),
+      `expected the upstream token header, got ${JSON.stringify(seen)}`,
+    );
+  });
+});

--- a/src/proxy/websocket-client.ts
+++ b/src/proxy/websocket-client.ts
@@ -1,0 +1,174 @@
+/**
+ * Upstream WebSocket client for the proxy's renderer bridge.
+ *
+ * `new WebSocket(url)` cannot set request headers, so the bridge used to move
+ * the tenant identity into the query string -- where the renderer, correctly,
+ * refuses to read it. This client speaks the same handshake through
+ * `WebSocketStream`, which does accept headers, so the bridge hop can carry the
+ * exact identity headers every other proxied request carries.
+ *
+ * The surface is deliberately `WebSocket`-shaped (`readyState`, `send`,
+ * `close`, `onopen`/`onmessage`/`onerror`/`onclose` receiving real DOM events)
+ * so the bridge wiring in `main.ts` is unchanged by the transport swap.
+ *
+ * @module proxy/websocket-client
+ */
+
+/** The `opened` value of a WebSocketStream. */
+export interface UpstreamWebSocketConnection {
+  readonly readable: ReadableStream<string | Uint8Array>;
+  readonly writable: WritableStream<string | Uint8Array>;
+}
+
+/** The subset of `WebSocketStream` this client depends on. */
+export interface UpstreamWebSocketStream {
+  readonly opened: Promise<UpstreamWebSocketConnection>;
+  readonly closed: Promise<{ closeCode?: number; reason?: string }>;
+  close(closeInfo?: { closeCode?: number; reason?: string }): void;
+}
+
+export type UpstreamWebSocketStreamFactory = (
+  url: string,
+  init: { headers: [string, string][] },
+) => UpstreamWebSocketStream;
+
+type WebSocketStreamGlobal = {
+  WebSocketStream?: new (
+    url: string,
+    init: { headers: [string, string][] },
+  ) => UpstreamWebSocketStream;
+};
+
+/**
+ * Resolve the runtime's `WebSocketStream`.
+ *
+ * Fails loudly rather than falling back to `new WebSocket(url)`: a silent
+ * fallback would drop the identity headers again and reproduce the 502 this
+ * client exists to fix. The proxy binary is compiled with `--unstable-net`.
+ */
+export function resolveUpstreamWebSocketStreamFactory(): UpstreamWebSocketStreamFactory {
+  const constructor = (globalThis as WebSocketStreamGlobal).WebSocketStream;
+  if (typeof constructor !== "function") {
+    throw new TypeError(
+      "WebSocketStream is unavailable; the proxy requires --unstable-net to bridge WebSockets",
+    );
+  }
+  return (url, init) => new constructor(url, init);
+}
+
+async function toChunk(
+  data: string | ArrayBufferLike | ArrayBufferView | Blob,
+): Promise<string | Uint8Array> {
+  if (typeof data === "string") return data;
+  if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer());
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+  return new Uint8Array(data as ArrayBuffer);
+}
+
+/** A `WebSocket`-shaped client that presents request headers on connect. */
+export class UpstreamWebSocket {
+  #stream: UpstreamWebSocketStream;
+  #writer: WritableStreamDefaultWriter<string | Uint8Array> | null = null;
+  #readyState: number = WebSocket.CONNECTING;
+  #writes: Promise<void> = Promise.resolve();
+  #settled = false;
+
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string | Uint8Array>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  constructor(url: URL | string, headers: Headers, factory: UpstreamWebSocketStreamFactory) {
+    this.#stream = factory(url.toString(), { headers: [...headers] });
+    this.#stream.opened.then(
+      (connection) => this.#open(connection),
+      (error: unknown) => this.#fail(error),
+    );
+    this.#stream.closed.then(
+      (info) => this.#close(info.closeCode ?? 1005, info.reason ?? "", true),
+      (error: unknown) => this.#fail(error),
+    );
+  }
+
+  get readyState(): number {
+    return this.#readyState;
+  }
+
+  send(data: string | ArrayBufferLike | ArrayBufferView | Blob): void {
+    const writer = this.#writer;
+    if (!writer || this.#readyState !== WebSocket.OPEN) return;
+    // Chained so an awaited Blob conversion cannot reorder frames.
+    this.#writes = this.#writes
+      .then(async () => {
+        await writer.write(await toChunk(data));
+      })
+      .catch((error: unknown) => this.#fail(error));
+  }
+
+  close(code?: number, reason?: string): void {
+    if (this.#readyState === WebSocket.CLOSING || this.#readyState === WebSocket.CLOSED) return;
+    this.#readyState = WebSocket.CLOSING;
+    try {
+      this.#stream.close(code === undefined ? undefined : { closeCode: code, reason });
+    } catch {
+      // Codes such as 1011 are reserved for endpoints and rejected by the
+      // client close API. The bridge only wants the connection torn down.
+      try {
+        this.#stream.close();
+      } catch {
+        // Already closed by the peer.
+      }
+    }
+  }
+
+  #open(connection: UpstreamWebSocketConnection): void {
+    if (this.#readyState !== WebSocket.CONNECTING) {
+      // Closed while connecting; drop the connection we just inherited.
+      connection.readable.cancel().catch(() => {});
+      return;
+    }
+    this.#writer = connection.writable.getWriter();
+    this.#readyState = WebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+    this.#pump(connection.readable);
+  }
+
+  async #pump(readable: ReadableStream<string | Uint8Array>): Promise<void> {
+    const reader = readable.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return;
+        this.onmessage?.(new MessageEvent("message", { data: value }));
+      }
+    } catch (error) {
+      this.#fail(error);
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  #fail(error: unknown): void {
+    if (this.#settled) return;
+    const message = error instanceof Error ? error.message : String(error);
+    this.onerror?.(new ErrorEvent("error", { message }));
+    this.#close(1006, message, false);
+  }
+
+  #close(code: number, reason: string, wasClean: boolean): void {
+    if (this.#settled) return;
+    this.#settled = true;
+    this.#readyState = WebSocket.CLOSED;
+    this.onclose?.(new CloseEvent("close", { code, reason, wasClean }));
+  }
+}
+
+export function connectUpstreamWebSocket(
+  url: URL | string,
+  headers: Headers,
+  factory: UpstreamWebSocketStreamFactory = resolveUpstreamWebSocketStreamFactory(),
+): UpstreamWebSocket {
+  return new UpstreamWebSocket(url, headers, factory);
+}


### PR DESCRIPTION
## The hole

`createProxyGuard` (`src/server/runtime-handler/project-runtime-context.ts:477`) rejects the platform's own proxy → renderer WebSocket bridge (`src/proxy/main.ts:272-322`).

**Mechanism.** The bridge terminates the browser socket and opens a second socket to the shared renderer with `new WebSocket(targetUrl)`. That API cannot set request headers, so the bridge put the tenant identity in the query string:

```ts
targetUrl.searchParams.set("x-project-slug", projectSlug || "");
targetUrl.searchParams.set("x-environment", scope);
```

The renderer deliberately does not read tenant identity from a WebSocket query — `wsSlugOverride` was pinned to `undefined` in #3290 because those params are browser-controlled. So the hop arrives with **no** `x-project-slug` and **no** `x-token`, the bridge target host (`veryfront-server`) carries no slug, and `createProxyGuard` answers 502 before any handler runs.

Locally this never shows up: the combined dev server runs the renderer with `PROXY_MODE=0`, and `createProxyGuard` returns `undefined` when `!isProxyMode`.

## It is firing in production right now

Loki, `veryfront-production`, last 24h — the guard warn and the proxy's matching failure, one pair per reconnect:

```
{"level":"warn","service":"server","message":"x-project-slug header is required in proxy mode",
 "component":"runtime-handler","context":{"pathname":"/_ws","host":"veryfront-server","forwardedHost":null}}

{"level":"error","service":"proxy","message":"[WebSocket] Server connection error",
 "context":{"projectSlug":"support-agent-agodnc","environment":"preview",
 "targetUrl":"ws://veryfront-server/_ws?x-project-slug=support-agent-agodnc&x-environment=preview",
 "error":"NetworkError: failed to connect to WebSocket: Invalid status code: 502"}}
```

`sum(count_over_time(... [1h]))` holds between **1,000 and 5,000 rejections per hour for the entire window** — never zero.

**User-visible symptom:** preview HMR / live-reload is dead on `*.preview.veryfront.com`. The browser's socket to the proxy succeeds (101), the upstream hop 502s, the client is closed `1011 "Server connection error"`, and the HMR script reconnects on backoff — roughly once a second, forever. Silently retried, never surfaced: no error names the guard, the header, or the proxy.

## The fix

The proxy already holds the identity the guard demands. Its `x-token` is a project-scoped bearer it minted from its own API client credentials (`VERYFRONT_PROXY_API_CLIENT_ID/SECRET`), and it attaches that plus the resolved project/environment/branch identity to **every other** forwarded request via `createProxyContextHeaders`. The bridge hop was the only request that dropped it, because of a transport limitation.

So the hop now carries that same header set, over a `WebSocketStream`-backed client that can present headers:

- **`buildRendererBridgeRequest`** builds the hop with `createProxyContextHeaders(req.headers, context)` and **deletes** the browser-supplied `x-project-slug` / `x-environment` query params rather than overwriting them. Identity travels only in proxy-owned headers.
- **`UpstreamWebSocket`** (`src/proxy/websocket-client.ts`) presents headers on the handshake behind a `WebSocket`-shaped surface (`readyState`/`send`/`close`/`onopen`/`onmessage`/`onerror`/`onclose` with real DOM events), so the bridge wiring in `main.ts` is otherwise unchanged. It **fails loudly** if `WebSocketStream` is unavailable instead of falling back to a headerless socket, which would silently reproduce this bug. `--unstable-net` is already baked into the compiled proxy binary (`scripts/build/compile-binary.ts:104`).

**No security control is weakened.** `createProxyGuard` is not touched: no route is exempted, no header presence is trusted, no new credential is invented. The caller now holds the credential the gate always demanded. A prefix/path-keyed exemption was never on the table for exactly the reason recorded in #3641.

### Existing shared identity: what was looked for

Before inventing a credential I checked what the proxy and renderer actually share. `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` is public-key-only on both sides — neither can mint with it. `VERYFRONT_PROXY_ROUTING_INVALIDATION_SECRET` is proxy-only (`veryfront-server-proxy-secret`; the renderer's `envFrom` is `veryfront-server-secret`, disjoint). There is no shared symmetric secret, and there does not need to be: the proxy's `x-token` is the existing, API-minted identity, and it now rides the hop.

## Tests

TDD. The red test failed with the exact production message:

```
proxy renderer WebSocket bridge identity ... is admitted by the renderer proxy guard
error: AssertionError: Values are not equal: the platform's own preview HMR bridge is answered 502 by the renderer
    [Diff] Actual / Expected
-   "x-project-slug header is required in proxy mode"
+   null
```

The identity tests build the hop with the production builder and hand it to the **production guard** (`prepareProjectRequest`), not to a hand-written header list. Adversarial coverage — all three must stay rejected:

- a look-alike hop that names itself only in the query string (`?x-project-slug=…&x-environment=…`, no headers) → still `x-project-slug header is required in proxy mode`
- a bridge-shaped hop with no upstream token → still `x-token header is required in proxy mode`
- a bridge hop at a boundary that is not operator-trusted → still `project, environment, and branch identity headers require an operator-authenticated proxy boundary`
- and: a browser that puts `x-project-slug=victim-project` in the `/_ws` query still resolves as its own tenant, because the bridge deletes those params

Transport tests run a real `Deno.serve` + `Deno.upgradeWebSocket` renderer stand-in and assert the headers arrive on the wire, including the full browser-derived set (cookie/origin/user-agent riding along), plus the 502-rejection path and the no-silent-fallback guarantee.

```
src/proxy/           51 passed (497 steps) | 0 failed
runtime-handler +
handlers/preview     28 passed (450 steps) | 0 failed
deno lint / fmt / check  clean
module boundaries    exit 0 (debt -1)
```

No existing test was weakened or deleted.

## Risk

The transport swap is the substantive risk: `WebSocketStream` is Deno-unstable and this path carries all preview HMR. It is compiled in, verified end-to-end against a real Deno WS server here, and the adapter keeps the bridge's event wiring identical. Worth watching after deploy: `[WebSocket] Server connection error` should go to zero and `[WebSocket] Server connected, bridge established` should appear for preview projects.