### PR TITLE
fix(security): close the cross-cutting gaps in the signed-dispatch exemptions

### DIFF
--- a/docs/api-reference/veryfront/security.md
+++ b/docs/api-reference/veryfront/security.md
@@ -94,7 +94,7 @@ applySecurityHeaders(response.headers, false, generateNonce(), null);
 
 | Name                   | Description | Source                                                                                                     |
 | ---------------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
-| `AuthHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/auth.ts#L157)             |
+| `AuthHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/auth.ts#L160)             |
 | `BaseHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/base-handler.ts#L45)      |
 | `CsrfHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/csrf/csrf-handler.ts#L60) |
 | `ResponseBuilder`      |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/response/builder.ts#L9)   |

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -214,6 +214,8 @@ The signature-keyed bypass is narrow. It applies only to a request that both add
 
 Three run-lifecycle routes are a longstanding exception and bypass middleware whether or not they are signed: `POST /api/control-plane/runs/{runId}/stream`, `POST /api/control-plane/runs/{runId}/resume`, and `DELETE /api/control-plane/runs/{runId}`. Do not rely on middleware to gate those three paths.
 
+A signed channel dispatch bypasses root middleware on the same terms. This is the request the platform sends to `POST /channels/invoke` to run one of your agents on a message from Slack or Discord, and it carries its own envelope under its own header, verified by the channel handler rather than by the control-plane signature check. Your middleware does not run for your project's channel traffic. An unsigned request to `POST /channels/invoke` still runs your middleware.
+
 Production loading is fail-closed. If a declared middleware file cannot be read, compiled, or validated as a middleware export, a dedicated server does not start and a shared server returns an error only for the affected project request. Failed shared loads are not cached, so a corrected deployment can recover without restarting unrelated projects. Development loading remains nonfatal and reports the loading error in the server log.
 
 ## Verify it worked

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -88,11 +88,30 @@ export function isControlPlaneSurfaceRoute(
  * cannot be replayed against another.
  *
  * Callers use this to keep gates that assume a browser client, such as CSRF
- * double-submit validation, from standing in front of platform dispatch. A
- * browser cannot attach the signature header to a cross-origin request without
- * a preflight the runtime does not grant, so a forged cross-site request never
- * satisfies this predicate. Neither does a project route that merely sits at a
- * look-alike path.
+ * double-submit validation, from standing in front of platform dispatch.
+ *
+ * Do not read a true result as evidence that the caller is the platform, and do
+ * not argue the exemption is safe because the header is hard to attach. It is
+ * not hard to attach. A project can configure a permissive `security.cors`, and
+ * on the default path `resolveNormalizedCORSPreflightPolicy` reflects whatever
+ * `Access-Control-Request-Headers` asked for, so the runtime will advertise this
+ * header to a cross-origin caller. The proxy likewise forwards an unverified
+ * `x-veryfront-*-jws` from a public request rather than stripping it. Assume an
+ * attacker can set this header at will.
+ *
+ * The exemption is safe for a narrower reason that does not depend on who can
+ * set the header. Skipping the gate concedes only the browser-credential check;
+ * authority still comes from the signature the receiving handler verifies, which
+ * an attacker cannot forge. And every route this predicate admits is owned by a
+ * handler registered ahead of `ApiHandlerWrapper` and instantiated
+ * unconditionally, so an admitted request always terminates at that verification
+ * and can never fall through to project code. A forged header buys a different
+ * rejection, nothing more. That ordering is the load-bearing part; it is pinned
+ * by `server/runtime-handler/dispatch-exemption-ordering.test.ts`, and the
+ * behaviour it protects by `security/http/dispatch-exemption-matrix.test.ts`.
+ *
+ * A project route that merely sits at a look-alike path is not a registered
+ * surface and does not satisfy this predicate at all.
  *
  * This is not authentication. It only reports that authority for the request
  * comes from a signature the handler checks, never from ambient credentials.
@@ -140,9 +159,16 @@ export function isChannelDispatchRoute(
  * double-submit validation, from standing in front of platform dispatch. The
  * channel dispatcher and the runtime-owner re-dispatch in
  * `resolveRuntimeOwnerInvokeUrl` hold no `__Host-vf_csrf` cookie to echo and
- * derive no authority from one. A browser cannot attach the signature header to
- * a cross-origin request without a preflight the runtime does not grant, so a
- * forged cross-site request never satisfies this predicate.
+ * derive no authority from one.
+ *
+ * As with {@link isSignedControlPlaneDispatch}, assume an attacker can set this
+ * header: a permissive project `security.cors` makes the runtime advertise it on
+ * a preflight, and the proxy forwards an unverified one. The exemption is safe
+ * because it concedes only the browser-credential check (authority still comes
+ * from the envelope `ChannelInvokeHandler` verifies, which an attacker cannot
+ * forge), and because `ChannelInvokeHandler` is registered ahead of
+ * `ApiHandlerWrapper` and instantiated unconditionally, so an admitted request
+ * always terminates at that verification rather than at project code.
  *
  * This is not authentication. It only reports that authority for the request
  * comes from a signature the handler checks, never from ambient credentials.

--- a/src/security/http/auth.ts
+++ b/src/security/http/auth.ts
@@ -1,5 +1,8 @@
 import { isCspReportRequest } from "#veryfront/security/http/csp-report-endpoint.ts";
-import { isSignedControlPlaneDispatch } from "#veryfront/channels/control-plane.ts";
+import {
+  isSignedChannelDispatch,
+  isSignedControlPlaneDispatch,
+} from "#veryfront/channels/control-plane.ts";
 import { BaseHandler } from "./base-handler.ts";
 import type {
   HandlerContext,
@@ -182,19 +185,41 @@ export class AuthHandler extends BaseHandler {
     // 120s deadline naming neither auth nor config. Studio's agent listing 401s
     // the same way, on a call that sends no `Authorization` header at all.
     //
-    // The exemption is keyed on the request being a real dispatch, not on it
-    // being path-shaped like one: `isSignedControlPlaneDispatch` requires both a
-    // method/path pair that a control-plane handler owns and the signature
-    // header that handler verifies. The `/api/control-plane/` namespace is
-    // reserved but not exclusively routed, so a project App or Pages API route
-    // can sit under it in a custom runtime; such a route is not a registered
-    // surface and keeps its auth gate.
+    // The exemption is keyed on a registered surface, not on a path shape:
+    // `isSignedControlPlaneDispatch` requires both a method/path pair that a
+    // control-plane handler owns and the signature header that handler
+    // verifies. The `/api/control-plane/` namespace is reserved but not
+    // exclusively routed, so a project App or Pages API route can sit under it
+    // in a custom runtime; such a route is not a registered surface and keeps
+    // its auth gate.
+    //
+    // The predicate cannot tell a genuine dispatch from a set header, and it
+    // does not try to. Assume an attacker can set it. What bounds the
+    // exemption is that the routes it admits terminate at a handler that
+    // verifies the envelope, ahead of `ApiHandlerWrapper`, so a forged header
+    // reaches a 401 rather than project code.
     //
     // This sits ahead of `resolveAuth` for the same reason the CSP report
     // exemption does: an auth config the runtime cannot resolve still fails
     // closed for every browser request, but a project's config typo must not
     // brick the platform's own dispatch, which authenticates itself downstream.
     if (isSignedControlPlaneDispatch(req)) return Promise.resolve(this.continue());
+
+    // A platform channel dispatch is not a site visitor either, for the same
+    // reasons and with the same consequence. The channel dispatcher POSTs
+    // `/channels/invoke` carrying a signed dispatch envelope, and the runtime
+    // re-dispatches to the same route when another instance owns the run;
+    // neither caller can hold a Basic credential or a Bearer secret the project
+    // authored. A 401 here does not protect the site, it takes the project's
+    // Slack and Discord agents offline with a silence that names no gate.
+    //
+    // Two predicates, not one. A channel dispatch carries a different envelope
+    // under a different header, verified by `verifyDispatchJws` against the
+    // dispatch id, platform, project id and body hash rather than by
+    // `verifyControlPlaneJws` against a method and path, so neither header may
+    // stand in for the other. What must be shared is the set of gates each is
+    // exempt from. See `security/http/dispatch-exemption-matrix.test.ts`.
+    if (isSignedChannelDispatch(req)) return Promise.resolve(this.continue());
 
     const auth = this.resolveAuth(ctx);
     if (!auth) return Promise.resolve(this.continue());

--- a/src/security/http/csrf/csrf-handler.ts
+++ b/src/security/http/csrf/csrf-handler.ts
@@ -91,13 +91,19 @@ export class CsrfHandler extends BaseHandler {
     // building the project's own release asset manifest, which surfaces only as
     // `deploy` timing out with `last state: missing`.
     //
-    // The exemption is keyed on the request being a real dispatch, not on it
-    // being path-shaped like one: `isSignedControlPlaneDispatch` requires both a
-    // method/path pair that a control-plane handler owns and the signature
-    // header that handler verifies. The `/api/control-plane/` namespace is
-    // reserved but not exclusively routed, so a project App or Pages API route
-    // can sit under it in a custom runtime; such a route is cookie
-    // authenticated, is not a registered surface, and keeps CSRF enforced.
+    // The exemption is keyed on a registered surface, not on a path shape:
+    // `isSignedControlPlaneDispatch` requires both a method/path pair that a
+    // control-plane handler owns and the signature header that handler
+    // verifies. The `/api/control-plane/` namespace is reserved but not
+    // exclusively routed, so a project App or Pages API route can sit under it
+    // in a custom runtime; such a route is cookie authenticated, is not a
+    // registered surface, and keeps CSRF enforced.
+    //
+    // The predicate cannot tell a genuine dispatch from a set header, and it
+    // does not try to. Assume an attacker can set it. What bounds the
+    // exemption is that the routes it admits terminate at a handler that
+    // verifies the envelope, ahead of `ApiHandlerWrapper`, so a forged header
+    // reaches a 401 rather than project code.
     if (isSignedControlPlaneDispatch(req)) return this.continue();
 
     // A platform channel dispatch is not a browser request either. A Slack or

--- a/src/security/http/dispatch-exemption-matrix.test.ts
+++ b/src/security/http/dispatch-exemption-matrix.test.ts
@@ -1,0 +1,484 @@
+/**
+ * The full matrix of signed-dispatch exemptions: every dispatch kind against
+ * every gate that can stand in front of it.
+ *
+ * The runtime serves two kinds of caller that are structurally incapable of
+ * satisfying a browser-credential gate, each with its own envelope:
+ *
+ * - a control-plane dispatch, `x-veryfront-control-plane-jws`, verified by
+ *   `verifyControlPlaneJws` against the request method and path;
+ * - a channel dispatch, `x-veryfront-dispatch-jws`, verified by
+ *   `verifyDispatchJws` against the dispatch id, platform, project id and a
+ *   hash of the body.
+ *
+ * Three gates can stand in front of either one, and each was added to the
+ * runtime separately: `security.auth`, `security.csrf`, and the project's root
+ * `middleware.ts`. Exempting one gate for one caller is what the individual
+ * fixes did, and it leaves the caller blocked by the gates nobody looked at:
+ * before this matrix existed, a channel dispatch was exempt from CSRF and was
+ * still 401'd by `security.auth` and still 403'd by a gating `middleware.ts`,
+ * so the caller the CSRF fix set out to unblock was still blocked twice.
+ *
+ * This file is the artifact that stops the next gate — or the next dispatch
+ * kind — from landing with a partial exemption. Adding either means adding a
+ * row or a column here, and the empty cells fail.
+ *
+ * Every cell asserts three directions.
+ *
+ * Admitted when validly signed, because a gate that blocks the platform's own
+ * dispatch takes the project's channels or deploys offline with an error that
+ * names neither the gate nor the config.
+ *
+ * Rejected when unsigned, because the exemption is keyed on the envelope and
+ * never on the path: an unsigned request to the very same route is ordinary
+ * traffic and must still meet every gate the project configured.
+ *
+ * Rejected downstream when forged, which is the direction that carries the real
+ * security argument. The signature header is attacker-settable — see
+ * `a project's CORS policy can make the signature header attachable` below —
+ * so a forged one does match the predicate and does skip the gate. That is safe
+ * only because the route terminates at a handler that verifies the envelope,
+ * never at project code. These cells are what makes that load-bearing.
+ *
+ * @module security/http/dispatch-exemption-matrix.test
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { RouteRegistry } from "#veryfront/routing/registry/index.ts";
+import { AuthHandler } from "#veryfront/security/http/auth.ts";
+import { CsrfHandler } from "#veryfront/security/http/csrf/csrf-handler.ts";
+import { deriveSecurityContext } from "#veryfront/security/http/config.ts";
+import { createEmptyDiscoveryResult } from "#veryfront/discovery";
+import { ProjectMiddlewareRuntime } from "#veryfront/server/runtime-handler/project-middleware.ts";
+import type { MiddlewareFunction } from "#veryfront/server/dev-server/middleware.ts";
+import type { Agent, AgentMessage, AgentResponse } from "#veryfront/agent";
+import type { VeryfrontConfig } from "#veryfront/config";
+import type { HandlerContext } from "#veryfront/types";
+import type { Handler } from "#veryfront/routing/registry/types.ts";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { ChannelInvokeHandler } from "#veryfront/server/handlers/request/channel-invoke.handler.ts";
+import { handleCORSPreflight } from "#veryfront/security/http/cors/preflight.ts";
+import {
+  ProjectRunExecuteHandler,
+  type ProjectRunExecuteHandlerDeps,
+} from "#veryfront/server/handlers/request/project-run-execute.handler.ts";
+import {
+  createControlPlaneSignature,
+  createCtx as createControlPlaneCtx,
+} from "#veryfront/server/handlers/request/internal-agent-run.test-helpers.ts";
+
+const encoder = new TextEncoder();
+
+const RUN_ID = "run_matrix_1";
+const EXECUTE_PATH = `/api/control-plane/runs/${RUN_ID}/execute`;
+const INVOKE_PATH = "/channels/invoke";
+
+/** What a prepared dispatch needs before a gate is put in front of it. */
+interface PreparedDispatch {
+  readonly request: Request;
+  readonly ctx: HandlerContext;
+  /** The handler that owns the dispatch's route. */
+  readonly terminal: Handler;
+  /** Whether the work behind the route actually ran. */
+  readonly reached: () => boolean;
+}
+
+/**
+ * How the request presents its signature header.
+ *
+ * `forged` is the case the exemptions actually have to survive. The header is
+ * attacker-settable — a permissive project `security.cors` makes the runtime
+ * advertise it on a preflight, and the proxy forwards an unverified
+ * `x-veryfront-*-jws` from a public request rather than stripping it — so the
+ * predicates match on a value nobody has checked yet. Safety comes from what
+ * happens next, not from who can set the header.
+ */
+type SignaturePresentation = "valid" | "absent" | "forged";
+
+const FORGED_JWS = "eyJhbGciOiJFZERTQSJ9.eyJzdWIiOiJmb3JnZWQifQ.not-a-signature";
+
+interface DispatchKind {
+  readonly name: string;
+  /** Prepare a dispatch presenting its signature header in a given way. */
+  readonly prepare: (
+    options: { readonly signature: SignaturePresentation },
+  ) => Promise<PreparedDispatch>;
+}
+
+// --- control-plane dispatch --------------------------------------------------
+
+async function prepareControlPlaneDispatch(
+  { signature }: { readonly signature: SignaturePresentation },
+): Promise<PreparedDispatch> {
+  const body = JSON.stringify({
+    runId: RUN_ID,
+    kind: "task",
+    target: "task:release-asset-build",
+    projectId: "proj-1",
+    config: { release_id: "rel-1", release_version: 1 },
+  });
+  const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+    requestId: RUN_ID,
+    projectId: "proj-1",
+    requestMethod: "POST",
+    requestPath: EXECUTE_PATH,
+  });
+
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (signature === "valid") headers["x-veryfront-control-plane-jws"] = jws;
+  if (signature === "forged") headers["x-veryfront-control-plane-jws"] = FORGED_JWS;
+
+  const request = new Request(`https://demo-project.example.test${EXECUTE_PATH}`, {
+    method: "POST",
+    headers,
+    body,
+  });
+
+  let reached = false;
+  const deps = {
+    executeReleaseAssetBuild: () => {
+      reached = true;
+      return Promise.resolve({
+        success: true,
+        result: { state: "ready", moduleCount: 1, cssCount: 1, routeCount: 1 },
+        logs: null,
+        duration_ms: 10,
+      });
+    },
+    now: () => 0,
+  } as unknown as ProjectRunExecuteHandlerDeps;
+
+  return {
+    request,
+    ctx: createControlPlaneCtx(publicKeyPem),
+    terminal: new ProjectRunExecuteHandler(deps),
+    reached: () => reached,
+  };
+}
+
+// --- channel dispatch --------------------------------------------------------
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+async function createDispatchSignature(
+  body: string,
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey("Ed25519", true, [
+    "sign",
+    "verify",
+  ]) as CryptoKeyPair;
+  const publicKeyPem = encodePem(
+    "PUBLIC KEY",
+    await crypto.subtle.exportKey("spki", keyPair.publicKey),
+  );
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: "demo-project",
+    sub: "dispatch-1",
+    project_id: "proj-1",
+    platform: "slack",
+    body_sha256: await sha256Base64url(body),
+    iat: now,
+    exp: now + 60,
+  }));
+  const signature = await crypto.subtle.sign(
+    "Ed25519",
+    keyPair.privateKey,
+    encoder.encode(`${header}.${payload}`),
+  );
+
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createAgent(generate: () => Promise<AgentResponse>): Agent {
+  return {
+    id: "agent-1",
+    config: {} as Agent["config"],
+    generate: generate as unknown as Agent["generate"],
+    stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
+    respond: async () => new Response(),
+    getMemory: () => ({} as never),
+    getMemoryStats: async () => ({ totalMessages: 0, estimatedTokens: 0, type: "conversation" }),
+    clearMemory: async () => {},
+  };
+}
+
+function createChannelCtx(publicKeyPem: string): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: {
+        get: (key: string) =>
+          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+      },
+      fs: {},
+    },
+    securityConfig: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+async function prepareChannelDispatch(
+  { signature }: { readonly signature: SignaturePresentation },
+): Promise<PreparedDispatch> {
+  const body = JSON.stringify({
+    dispatchId: "dispatch-1",
+    conversationId: "conversation-1",
+    projectId: "proj-1",
+    assistantId: "agent-1",
+    platform: "slack",
+    inboundMessage: {
+      text: "Hello from Slack",
+      userId: "U123",
+      userName: "Alice",
+      isDirectMessage: false,
+    },
+    conversationHistory: [
+      { id: "user-1", role: "user", parts: [{ type: "text", text: "Hello from Slack" }] },
+    ],
+  });
+  const { jws, publicKeyPem } = await createDispatchSignature(body);
+
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (signature === "valid") headers["x-veryfront-dispatch-jws"] = jws;
+  if (signature === "forged") headers["x-veryfront-dispatch-jws"] = FORGED_JWS;
+
+  const request = new Request(`https://demo-project.example.test${INVOKE_PATH}`, {
+    method: "POST",
+    headers,
+    body,
+  });
+
+  let reached = false;
+  const assistantMessage: AgentMessage = {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [{ type: "text", text: "Hello from the agent" }],
+  };
+  const terminal = new ChannelInvokeHandler({
+    ensureProjectDiscovery: async () => createEmptyDiscoveryResult(),
+    getAgent: () =>
+      createAgent(() => {
+        reached = true;
+        return Promise.resolve({
+          text: "Hello from the agent",
+          messages: [assistantMessage],
+          toolCalls: [],
+          status: "completed",
+          usage: { promptTokens: 5, completionTokens: 7, totalTokens: 12 },
+        });
+      }),
+    getAllAgentIds: () => ["agent-1"],
+  });
+
+  return {
+    request,
+    ctx: createChannelCtx(publicKeyPem),
+    terminal,
+    reached: () => reached,
+  };
+}
+
+const DISPATCH_KINDS: readonly DispatchKind[] = [
+  { name: "control-plane dispatch", prepare: prepareControlPlaneDispatch },
+  { name: "channel dispatch", prepare: prepareChannelDispatch },
+];
+
+// --- gates -------------------------------------------------------------------
+
+interface GateOutcome {
+  readonly status: number;
+  readonly reached: boolean;
+}
+
+interface Gate {
+  readonly name: string;
+  /** The status this gate answers with when it turns a request away. */
+  readonly rejectedStatus: number;
+  readonly run: (prepared: PreparedDispatch) => Promise<GateOutcome>;
+}
+
+function applySecurity(prepared: PreparedDispatch, security: Record<string, unknown>): void {
+  const { securityConfig } = deriveSecurityContext(
+    { security } as VeryfrontConfig,
+    // The runtime that serves a dispatch resolves as a preview environment, so
+    // production defaults are off and only explicit config turns a gate on.
+    { productionDefaults: false },
+  );
+  prepared.ctx.securityConfig = securityConfig;
+}
+
+async function runChain(
+  prepared: PreparedDispatch,
+  front: Handler,
+): Promise<GateOutcome> {
+  const registry = new RouteRegistry();
+  registry.registerAll([front, prepared.terminal]);
+  const response = await registry.execute(prepared.request, prepared.ctx);
+  return { status: response?.status ?? 0, reached: prepared.reached() };
+}
+
+const GATES: readonly Gate[] = [
+  {
+    name: "security.csrf",
+    rejectedStatus: 403,
+    run: (prepared) => {
+      applySecurity(prepared, { csrf: true });
+      return runChain(prepared, new CsrfHandler());
+    },
+  },
+  {
+    name: "security.auth",
+    rejectedStatus: 401,
+    run: (prepared) => {
+      applySecurity(prepared, { auth: { basic: { username: "admin", password: "secret" } } });
+      return runChain(prepared, new AuthHandler());
+    },
+  },
+  {
+    name: "project middleware.ts",
+    rejectedStatus: 401,
+    run: async (prepared) => {
+      applySecurity(prepared, {});
+      // Ordinary project code: a root middleware that authorizes every request.
+      // It cannot recognise a dispatch, because `createApplicationRequest`
+      // withholds every `x-veryfront-*` header from project code.
+      const gating: MiddlewareFunction[] = [
+        (c, next) =>
+          c.req.headers.get("authorization")
+            ? next()
+            : Promise.resolve(new Response("Unauthorized", { status: 401 })),
+      ];
+      const registry = new RouteRegistry();
+      registry.registerAll([prepared.terminal]);
+      const runtime = new ProjectMiddlewareRuntime({
+        loadMiddleware: () => Promise.resolve(gating),
+      });
+      const response = await runtime.execute({
+        request: prepared.request,
+        handlerContext: prepared.ctx,
+        isSharedProxy: false,
+        next: async () => (await registry.execute(prepared.request, prepared.ctx)) ?? undefined,
+      });
+      return { status: response?.status ?? 0, reached: prepared.reached() };
+    },
+  },
+];
+
+describe("signed dispatch exemptions: every dispatch kind against every gate", () => {
+  for (const kind of DISPATCH_KINDS) {
+    for (const gate of GATES) {
+      it(`admits a signed ${kind.name} through ${gate.name}`, async () => {
+        const prepared = await kind.prepare({ signature: "valid" });
+        const outcome = await gate.run(prepared);
+        assertEquals(
+          outcome.reached,
+          true,
+          `${gate.name} blocked a signed ${kind.name}: the runtime answered ${outcome.status}. ` +
+            `Every gate must exempt every signed dispatch kind; a partial exemption leaves the ` +
+            `caller blocked by whichever gate nobody looked at.`,
+        );
+        assertEquals(outcome.status, 200);
+      });
+
+      it(`rejects a forged ${kind.name} downstream of ${gate.name}`, async () => {
+        // The premise this replaces: earlier docstrings argued the exemption was
+        // safe because "a browser cannot attach the signature header to a
+        // cross-origin request without a preflight the runtime does not grant".
+        // The runtime does grant it — see the preflight test alongside this one.
+        // The header is attacker-settable, the predicate matches, and the gate
+        // is skipped. That is fine, and this is why: the route terminates at a
+        // handler that verifies the envelope, so the forgery buys a different
+        // rejection and never project code.
+        const prepared = await kind.prepare({ signature: "forged" });
+        const outcome = await gate.run(prepared);
+        assertEquals(
+          outcome.reached,
+          false,
+          `a forged signature header reached the work behind a ${kind.name}. The exemption ` +
+            `relies entirely on the owning handler verifying the envelope; if that check is ` +
+            `gone, skipping ${gate.name} is a bypass rather than a shortcut.`,
+        );
+        assertEquals(
+          outcome.status,
+          401,
+          `a forged ${kind.name} was answered with ${outcome.status} rather than 401 by the ` +
+            `handler that owns the route.`,
+        );
+      });
+
+      it(`rejects an unsigned ${kind.name} at ${gate.name}`, async () => {
+        const prepared = await kind.prepare({ signature: "absent" });
+        const outcome = await gate.run(prepared);
+        assertEquals(
+          outcome.status,
+          gate.rejectedStatus,
+          `${gate.name} let an unsigned request through on the dispatch route for a ` +
+            `${kind.name}. The exemption is keyed on the signature envelope, never on the ` +
+            `method and path, so the same route without a signature is ordinary project ` +
+            `traffic and must still meet the gate.`,
+        );
+        assertEquals(outcome.reached, false);
+      });
+    }
+  }
+});
+
+describe("signed dispatch exemptions: what the safety argument may not rest on", () => {
+  it("a project's CORS policy can make the signature header attachable", async () => {
+    // #3641's docstring, and the copy of it #3647 inherited, argued the
+    // exemption was safe because "a browser cannot attach the signature header
+    // to a cross-origin request without a preflight the runtime does not
+    // grant". The runtime grants it. With no configured `allowedHeaders`,
+    // `resolveNormalizedCORSPreflightPolicy` reflects whatever
+    // `Access-Control-Request-Headers` asked for, so any project whose CORS
+    // policy admits an origin also advertises the signature header to it.
+    //
+    // This test exists so the claim cannot be reinstated. If it ever starts
+    // failing, the runtime has become stricter and the docstrings may be
+    // revisited — but the argument must still be made from the downstream
+    // signature check, which is the thing an attacker cannot forge.
+    for (const config of [true, { origin: "*" }, { origin: "https://attacker.example" }]) {
+      const preflight = await handleCORSPreflight({
+        request: new Request(`https://demo-project.example.test${EXECUTE_PATH}`, {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://attacker.example",
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "x-veryfront-control-plane-jws",
+          },
+        }),
+        config,
+      } as never);
+
+      assertEquals(preflight.status, 204, `preflight rejected under ${JSON.stringify(config)}`);
+      assertEquals(
+        preflight.headers.get("Access-Control-Allow-Headers"),
+        "x-veryfront-control-plane-jws",
+        `The runtime declined to advertise the dispatch signature header under ` +
+          `${JSON.stringify(config)}. That is stricter than when this was written; do not ` +
+          `take it as licence to argue the exemption is safe because the header is ` +
+          `unattachable. Safety comes from the downstream signature verification.`,
+      );
+    }
+  });
+});

--- a/src/server/runtime-handler/dispatch-exemption-ordering.test.ts
+++ b/src/server/runtime-handler/dispatch-exemption-ordering.test.ts
@@ -1,0 +1,228 @@
+/**
+ * The invariant every signed-dispatch exemption rests on.
+ *
+ * `isSignedControlPlaneDispatch` and `isSignedChannelDispatch` let a request
+ * skip `security.auth`, `security.csrf` and the project's root `middleware.ts`.
+ * That is only safe because of a fact about the handler chain, not about the
+ * predicates: every route either predicate admits is owned by a platform
+ * handler that is registered ahead of `ApiHandlerWrapper` and is instantiated
+ * unconditionally. The exempted request therefore always terminates at a
+ * handler that verifies its envelope, and can never fall through to a project's
+ * App Router or Pages API route.
+ *
+ * That fact lives in the ordering of `HANDLER_NAMES`, and nothing else records
+ * it. All seven handlers involved share `PRIORITY_MEDIUM_API`, so
+ * `RouteRegistry`'s priority sort is a no-op between them and the chain order
+ * is exactly the list order. Move `ApiHandlerWrapper` up the list, move one of
+ * the owners down, or give an owner an `enabled` predicate, and each exemption
+ * silently turns from "skip the browser-credential gate on the way to a
+ * signature check" into "skip the browser-credential gate on the way to project
+ * code" — an unauthenticated bypass of the project's own auth, CSRF and
+ * middleware, reachable by anyone who sets a header.
+ *
+ * @module server/runtime-handler/dispatch-exemption-ordering.test
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { Handler, RoutePattern } from "#veryfront/types";
+import { createHandlerRegistry } from "#veryfront/server/runtime-handler/index.ts";
+import {
+  CHANNEL_INVOKE_PATH,
+  isChannelDispatchRoute,
+  isControlPlaneSurfaceRoute,
+} from "#veryfront/channels/control-plane.ts";
+
+const RUN_ID = "run_ordering_1";
+
+/**
+ * Every route either dispatch predicate admits, and the handler that owns it.
+ *
+ * The owner column is what makes the exemption safe. It is checked below
+ * against the handler's own declared patterns, so a route that quietly moves to
+ * a different handler fails here rather than being taken on trust.
+ */
+const ADMITTED_ROUTES: ReadonlyArray<{
+  readonly method: string;
+  readonly path: string;
+  readonly owner: string;
+}> = [
+  {
+    method: "POST",
+    path: "/api/control-plane/agents/list",
+    owner: "InternalAgentsListHandler",
+  },
+  {
+    method: "POST",
+    path: `/api/control-plane/runs/${RUN_ID}/execute`,
+    owner: "ProjectRunExecuteHandler",
+  },
+  {
+    method: "POST",
+    path: `/api/control-plane/runs/${RUN_ID}/stream`,
+    owner: "AgentStreamHandler",
+  },
+  {
+    method: "POST",
+    path: `/api/control-plane/runs/${RUN_ID}/resume`,
+    owner: "AgentRunResumeHandler",
+  },
+  {
+    method: "DELETE",
+    path: `/api/control-plane/runs/${RUN_ID}`,
+    owner: "AgentRunCancelHandler",
+  },
+  {
+    method: "POST",
+    path: CHANNEL_INVOKE_PATH,
+    owner: "ChannelInvokeHandler",
+  },
+];
+
+const CONSEQUENCE =
+  "Reordering HANDLER_NAMES turns the signed-dispatch exemptions into bypasses. " +
+  "A request carrying only a header would skip the project's security.auth, " +
+  "security.csrf and middleware.ts and reach project code, because nothing " +
+  "downstream of ApiHandlerWrapper verifies a dispatch envelope. If you need to " +
+  "move a handler, move it and keep every owner listed here ahead of " +
+  "ApiHandlerWrapper.";
+
+function createAdapter(): RuntimeAdapter {
+  return {
+    env: { get: () => undefined },
+    fs: {},
+  } as unknown as RuntimeAdapter;
+}
+
+function patternClaims(pattern: RoutePattern, method: string, path: string): boolean {
+  const methods = pattern.method === undefined
+    ? undefined
+    : Array.isArray(pattern.method)
+    ? pattern.method
+    : [pattern.method];
+  if (methods && !methods.some((value) => value.toUpperCase() === method)) return false;
+
+  if (pattern.pattern instanceof RegExp) return pattern.pattern.test(path);
+  if (pattern.exact) return path === pattern.pattern;
+  if (pattern.prefix) return path.startsWith(pattern.pattern);
+  return path === pattern.pattern;
+}
+
+function claimsRoute(handler: Handler, method: string, path: string): boolean {
+  return (handler.metadata.patterns ?? []).some((pattern) => patternClaims(pattern, method, path));
+}
+
+describe("signed-dispatch exemptions: handler ordering invariant", () => {
+  const { registry } = createHandlerRegistry("/project", createAdapter());
+  const order = registry.getHandlers().map((handler) => handler.metadata.name);
+  const apiIndex = order.indexOf("ApiHandlerWrapper");
+
+  /**
+   * Resolve an owner, failing with the consequence rather than vacuously.
+   *
+   * Every assertion below reads a property off the owning handler. Reached
+   * through an optional chain, a missing owner yields `undefined`, which is
+   * also the value the `enabled` check expects, so the test would pass while
+   * the invariant it names went unverified. A bare `!` instead throws a
+   * `TypeError` that says nothing about why the chain matters. Fail here, once,
+   * with the reason.
+   */
+  function requireOwner(owner: string, method: string, path: string): Handler {
+    const handler = registry.getHandlers().find((h) => h.metadata.name === owner);
+    assertEquals(
+      handler !== undefined,
+      true,
+      `${owner} owns ${method} ${path}, which the signed-dispatch predicates admit, but it ` +
+        `is not registered in the handler chain. ${CONSEQUENCE}`,
+    );
+    return handler as Handler;
+  }
+
+  it("registers ApiHandlerWrapper in the chain", () => {
+    assertEquals(apiIndex >= 0, true, "ApiHandlerWrapper is not in the handler chain at all");
+  });
+
+  for (const route of ADMITTED_ROUTES) {
+    it(`keeps ${route.owner} ahead of ApiHandlerWrapper for ${route.method} ${route.path}`, () => {
+      const ownerIndex = order.indexOf(route.owner);
+      assertEquals(
+        ownerIndex >= 0,
+        true,
+        `${route.owner} owns ${route.method} ${route.path}, which the signed-dispatch ` +
+          `predicates admit, but it is not registered in the handler chain. ${CONSEQUENCE}`,
+      );
+      assertEquals(
+        ownerIndex < apiIndex,
+        true,
+        `${route.owner} (chain position ${ownerIndex}) now runs AFTER ApiHandlerWrapper ` +
+          `(position ${apiIndex}), so an exempted ${route.method} ${route.path} reaches ` +
+          `project code before it reaches the handler that verifies its signature. ` +
+          CONSEQUENCE,
+      );
+    });
+
+    it(`instantiates ${route.owner} unconditionally`, () => {
+      const handler = requireOwner(route.owner, route.method, route.path);
+      assertEquals(
+        handler.metadata.enabled,
+        undefined,
+        `${route.owner} now declares an \`enabled\` predicate, so the runtime can skip it ` +
+          `for some requests while the exemption in front of it still applies. On a request ` +
+          `where it is skipped, ${route.method} ${route.path} falls through to ` +
+          `ApiHandlerWrapper. ${CONSEQUENCE}`,
+      );
+    });
+
+    it(`routes ${route.method} ${route.path} to ${route.owner} by its own patterns`, () => {
+      assertEquals(
+        claimsRoute(
+          requireOwner(route.owner, route.method, route.path),
+          route.method,
+          route.path,
+        ),
+        true,
+        `${route.owner} no longer declares a pattern covering ${route.method} ${route.path}. ` +
+          `The route may have moved to another handler; check that its new owner is also ` +
+          `ahead of ApiHandlerWrapper. ${CONSEQUENCE}`,
+      );
+    });
+  }
+
+  it("lists every route the dispatch predicates admit", () => {
+    // The predicates are the source of truth for what is exempt. If either one
+    // learns a new route, this catches the omission rather than leaving the new
+    // route's ordering unchecked.
+    const probes: ReadonlyArray<{ method: string; path: string }> = [
+      { method: "POST", path: "/api/control-plane/agents/list" },
+      { method: "POST", path: `/api/control-plane/runs/${RUN_ID}/execute` },
+      { method: "POST", path: `/api/control-plane/runs/${RUN_ID}/stream` },
+      { method: "POST", path: `/api/control-plane/runs/${RUN_ID}/resume` },
+      { method: "DELETE", path: `/api/control-plane/runs/${RUN_ID}` },
+      { method: "POST", path: CHANNEL_INVOKE_PATH },
+      // Shapes the predicates must keep rejecting, so a widened predicate that
+      // starts admitting them shows up as a missing row here.
+      { method: "POST", path: "/api/control-plane/runs" },
+      { method: "GET", path: `/api/control-plane/runs/${RUN_ID}/execute` },
+      { method: "POST", path: "/api/control-plane/anything-else" },
+      { method: "POST", path: `${CHANNEL_INVOKE_PATH}/application-route` },
+      { method: "PUT", path: CHANNEL_INVOKE_PATH },
+    ];
+
+    const admitted = probes
+      .filter(({ method, path }) =>
+        isControlPlaneSurfaceRoute(method, path) || isChannelDispatchRoute(method, path)
+      )
+      .map(({ method, path }) => `${method} ${path}`);
+    const listed = ADMITTED_ROUTES.map((route) => `${route.method} ${route.path}`);
+
+    assertEquals(
+      admitted,
+      listed,
+      `The set of routes the dispatch predicates admit no longer matches the table in this ` +
+        `file. Add the new route and its owning handler to ADMITTED_ROUTES so its position ` +
+        `relative to ApiHandlerWrapper is checked. ${CONSEQUENCE}`,
+    );
+  });
+});

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -3,6 +3,7 @@ import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts"
 import { registerLRUCache } from "#veryfront/cache";
 import {
   isConfigOptionalControlPlaneRunRequest,
+  isSignedChannelDispatch,
   isSignedControlPlaneDispatch,
 } from "#veryfront/channels/control-plane.ts";
 import { MiddlewareContext } from "#veryfront/middleware/core/context.ts";
@@ -120,15 +121,41 @@ export class ProjectMiddlewareRuntime {
     // therefore has no choice but to reject its own deploy, which surfaces
     // only as `deploy` timing out with `last state: missing`.
     //
-    // The bypass is keyed on the request being a real dispatch, not on it
-    // being path-shaped like one: `isSignedControlPlaneDispatch` requires both
-    // a method/path pair a control-plane handler owns and the signature header
-    // that handler verifies. It concedes nothing to an unauthenticated caller,
-    // because the only routes it can reach answer 401 without a valid envelope
+    // The bypass is keyed on a registered surface, not on a path shape:
+    // `isSignedControlPlaneDispatch` requires both a method/path pair a
+    // control-plane handler owns and the signature header that handler
+    // verifies. The predicate cannot tell a genuine dispatch from a set header
+    // and does not try to; it concedes nothing to an unauthenticated caller
+    // because the only routes it can reach are owned by handlers registered
+    // ahead of `ApiHandlerWrapper`, which answer 401 without a valid envelope
     // and never fall through to project code. Every other request, including
     // an unsigned one to the same path and a project route that merely sits
     // inside the reserved namespace, still traverses project middleware.
     if (isSignedControlPlaneDispatch(request)) {
+      return next();
+    }
+
+    // A platform channel dispatch is not the project's traffic either. It
+    // addresses `ChannelInvokeHandler`, carries a signed dispatch envelope
+    // rather than a user session, and asks the runtime to run one of the
+    // project's own agents on a message that arrived from Slack, Discord or a
+    // sibling runtime instance that owns the run.
+    //
+    // The same impossibility applies: `createApplicationRequest` withholds
+    // every `x-veryfront-*` header from project code, so the dispatch signature
+    // is invisible to middleware, and a root `middleware.ts` that gates
+    // requests has no choice but to reject the project's own channels. The
+    // symptom is that the channel simply goes quiet.
+    //
+    // Two predicates, not one: a channel dispatch is verified by
+    // `verifyDispatchJws` against the dispatch id, platform, project id and
+    // body hash, not by `verifyControlPlaneJws` against a method and path. What
+    // is shared is the set of gates each dispatch kind is exempt from. See
+    // `security/http/dispatch-exemption-matrix.test.ts`. The bypass concedes
+    // nothing: `POST /channels/invoke` without a valid envelope answers 401 at
+    // the handler and never falls through to project code, and an unsigned
+    // request to the same path still traverses project middleware.
+    if (isSignedChannelDispatch(request)) {
       return next();
     }
 


### PR DESCRIPTION
Three defects that only exist across #3645, #3646 and #3647 read together. No single PR author could see any of them.

> **No longer stacked.** #3645, #3646 and #3647 have all landed on `main`. This branch was rebuilt from current `main` as three commits carrying only this PR's own payload, so the merge commits and the squash-vs-merge conflicts they caused are gone. The tree is unchanged from the previously reviewed version.
>
> The fourth defect, a silent bad merge between #3645 and #3646, was fixed on those two branches and is already on `main`; nothing here re-applies it. The deploy failure-message work that used to appear in this diff landed with #3646 and has been dropped from this branch rather than re-added.

## 1. A channel dispatch was exempt from one gate out of three

#3647 exempted `POST /channels/invoke` from CSRF. On the merged tree a channel dispatch carrying its envelope was **still 401'd** by a project's `security.auth` and **still turned away** by a gating root `middleware.ts`. The caller that fix set out to unblock was still blocked, twice, by the two gates nobody had reason to look at — a project's Slack and Discord agents would simply have gone quiet.

Red, before the fix:

```
  admits a signed channel dispatch through security.auth ... FAILED (1ms)
  admits a signed channel dispatch through project middleware.ts ... FAILED (1ms)

error: AssertionError: security.auth blocked a signed channel dispatch: the
runtime answered 401. Every gate must exempt every signed dispatch kind; a
partial exemption leaves the caller blocked by whichever gate nobody looked at.
```

`isSignedChannelDispatch` now applies at `AuthHandler` and `ProjectMiddlewareRuntime` too. The two predicate families stay **separate** — a channel dispatch carries a different envelope under a different header, verified by `verifyDispatchJws` against the dispatch id, platform, project id and body hash, not by `verifyControlPlaneJws` against a method and path. What must be shared is the *set of gates* each is exempt from, and that is now under test.

**`src/security/http/dispatch-exemption-matrix.test.ts`** is the artifact: `{control-plane dispatch, channel dispatch}` × `{security.auth, security.csrf, project middleware.ts}`, each cell asserting three directions.

| | admitted when signed | rejected at the gate when unsigned | rejected downstream when forged |
|---|---|---|---|
| control-plane dispatch | ✔ | ✔ | ✔ |
| channel dispatch | ✔ | ✔ | ✔ |

Adding a fourth gate, or a third dispatch kind, means adding a row or a column — and the empty cells fail.

## 2. The load-bearing invariant was unasserted

Every one of these exemptions is safe **only** because each route it admits is owned by a handler registered ahead of `ApiHandlerWrapper` in `HANDLER_NAMES` and instantiated unconditionally. All seven handlers share `PRIORITY_MEDIUM_API`, so `RouteRegistry`'s priority sort is a no-op between them and the chain order *is* the list order.

Nothing recorded that. Moving one line turns every exemption into an unauthenticated bypass of the project's own auth, CSRF and middleware, reachable by anyone who sets a header.

**`src/server/runtime-handler/dispatch-exemption-ordering.test.ts`** asserts it, including that no owner has grown an `enabled` predicate and that the route table still matches what the predicates admit. Moving `ApiHandlerWrapper` up the list produces:

```
error: AssertionError: InternalAgentsListHandler (chain position 26) now runs
AFTER ApiHandlerWrapper (position 25), so an exempted POST
/api/control-plane/agents/list reaches project code before it reaches the
handler that verifies its signature. Reordering HANDLER_NAMES turns the
signed-dispatch exemptions into bypasses. A request carrying only a header would
skip the project's security.auth, security.csrf and middleware.ts and reach
project code, because nothing downstream of ApiHandlerWrapper verifies a
dispatch envelope. If you need to move a handler, move it and keep every owner
listed here ahead of ApiHandlerWrapper.
```

## 3. The docstring's security argument was false

#3641's docstring, repeated verbatim by #3647:

> A browser cannot attach the signature header to a cross-origin request without a preflight the runtime does not grant.

The runtime grants it. With no configured `allowedHeaders`, `resolveNormalizedCORSPreflightPolicy` reflects whatever `Access-Control-Request-Headers` asked for:

```
origin: true (reflect any)      -> 204 | allow-headers: x-veryfront-control-plane-jws
origin: '*'                     -> 204 | allow-headers: x-veryfront-control-plane-jws
origin: 'https://evil.example'  -> 204 | allow-headers: x-veryfront-control-plane-jws
```

So any project whose CORS policy admits an origin advertises the signature header to it. The proxy also forwards an unverified `x-veryfront-*-jws` from a public request rather than stripping it. **Assume an attacker can set this header.**

The docstrings now state the actual basis: the exemption skips only the browser-credential gate, authority still comes from the downstream signature verification an attacker cannot forge, and every admitted route terminates at a handler doing that verification ahead of `ApiHandlerWrapper`. The same overstatement in three gate comments — that the exemption is keyed on "the request being a real dispatch" — is corrected; no predicate can know that from a header.

Two tests replace the premise rather than just deleting it:

- the **forged column** of the matrix, asserting a garbage signature skips the gate and is then answered 401 by the owning handler, never reaching project code;
- a test that pins the CORS behaviour so the false claim cannot be reinstated, and that says in its failure message what to do if the runtime ever becomes stricter.

## Verification

- `src/security/http/dispatch-exemption-matrix.test.ts` — 18 steps, red→green demonstrated on the two channel/auth and channel/middleware cells
- `src/server/runtime-handler/dispatch-exemption-ordering.test.ts` — 20 steps, red demonstrated by mutating `HANDLER_NAMES`
- `deno test src/security/http/ src/channels/ src/release-assets/ src/server/runtime-handler/ src/server/handlers/request/` — 118 passed (1633 steps), 0 failed
- `deno fmt --check`, `deno lint`, `deno check src/index.ts`, `deno task test:unit` — clean
- `docs/api-reference/veryfront/security.md` regenerated (line pin only)

No existing test was weakened.

## Follow-up, not in this PR

`createProxyContextHeaders` (`src/proxy/handler.ts:1349`) strips every `INTERNAL_PROXY_HEADERS` entry and re-sets the proxy's own, but deliberately does **not** strip client-supplied `x-veryfront-*-jws`. An attacker-set header on an anchored public route therefore does reach the renderer and does disable these gates — harmless today only because the crypto check downstream rejects, which is now asserted rather than assumed.

The proxy should strip a jws header it did not itself verify, but that is not a change to make blind: verification needs `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` on the proxy, so stripping would couple renderer authentication to proxy key configuration, and the flag has to be threaded through `createProxyContextHeaders`/`injectContextHeaders` including the new WebSocket bridge path from #3648. Details in the review thread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Signed platform control-plane and channel dispatches now pass through the appropriate handlers without being blocked by project authentication, CSRF, or root middleware.
  * Unsigned, forged, unsupported, and look-alike requests remain protected by existing security checks.

* **Deployment**
  * Release asset timeouts now distinguish builds that never started from builds still unresolved and provide clearer troubleshooting details.

* **Documentation**
  * Clarified middleware bypass rules and updated API source references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
