### PR TITLE
test(cli): stop the skills CLI tests reading the module cache as CLI output

### DIFF
--- a/cli/commands/skills/handler.test.ts
+++ b/cli/commands/skills/handler.test.ts
@@ -7,12 +7,33 @@ import { getSkillInfo, listSkills } from "./command.ts";
 describe("Skills Command", () => {
   const repositoryRoot = fromFileUrl(new URL("../../../", import.meta.url));
 
+  /**
+   * Run the CLI the way these tests mean to read it: `--quiet` so the child's
+   * stderr carries the command's output and nothing else.
+   *
+   * Without it the stderr assertions below are not only about the CLI. A child
+   * whose dependencies are not all present locally first resolves them --
+   * `nodeModulesDir` is `auto`, so it reconciles `node_modules/` against
+   * `cli/main.ts`'s graph -- and it narrates that work on stderr: `Download
+   * https://registry.npmjs.org/yaml`. Nothing in this repository's CI puts
+   * `yaml` where the child would find it. The cache is warmed from
+   * `src/index.ts`, and `yaml` reaches the CLI only through `cli/main.ts` (via
+   * `@opentelemetry/configuration` and `bash-tool`), so it is in neither the
+   * warmed blob nor the test process's own graph; whether a shard paid for the
+   * fetch came down to which cache entry the runner happened to restore. That
+   * is why this file failed on pull requests that cannot reach this code.
+   *
+   * `--quiet` suppresses only the runtime's own diagnostics. Anything the CLI
+   * writes to stderr still arrives -- `veryfront skills info` with no name and
+   * no `--json` still reports `✗ Usage: veryfront skills info <name>` under it
+   * -- so the assertions still hold the command to a silent stderr.
+   */
   async function runSkillsInfo(
     args: string[],
   ): Promise<{ code: number; stdout: string; stderr: string }> {
     const cliPath = fromFileUrl(new URL("../../main.ts", import.meta.url));
     const result = await new Deno.Command(Deno.execPath(), {
-      args: ["run", "-A", cliPath, "skills", "info", ...args, "--json"],
+      args: ["run", "-A", "--quiet", cliPath, "skills", "info", ...args, "--json"],
       cwd: repositoryRoot,
       env: { VERYFRONT_NO_UPDATE_CHECK: "1", NO_COLOR: "1" },
       stdin: "null",


### PR DESCRIPTION
## The flake

`cli/commands/skills/handler.test.ts` has been failing on coverage shard 7/8 for pull
requests that cannot reach the code it tests — #3648 (proxy WebSocket bridge identity) and
#3651 (a release PR touching three version files), both with the same two steps under
`info JSON output`, both `412 passed / 1 failed`.

## Root cause

The failing assertions are `handler.test.ts:36` and `handler.test.ts:52`, both
`assertEquals(result.stderr, "")` against a child `deno run -A cli/main.ts skills info
--json`. The diff in the CI log (run 31642742785, job `coverage shard 7/8`) says what
landed there:

```
    [Diff] Actual / Expected

-   Download https://registry.npmjs.org/yaml\n
```

That is the Deno runtime narrating its own work, not the CLI writing output. `deno.json`
sets `nodeModulesDir` to `auto`, so a child whose dependencies are not all present first
reconciles `node_modules/` against `cli/main.ts`'s graph, and it reports each fetch that
costs on stderr.

Nothing puts `yaml` where the child would find it. `.github/actions/setup-deno` warms the
Deno cache from `src/index.ts`, and `npm:yaml@2.9.0` reaches the CLI only through
`cli/main.ts` — via `@opentelemetry/configuration`, `bash-tool` and `just-bash` — so it is
in neither the warmed blob nor the test process's own graph. `actions/cache/restore` falls
back through `restore-keys`, so which packages a shard actually has is decided by which
cache entry the runner happened to restore. That is the whole of the flakiness: the file
was asserting on the machine's module cache alongside the CLI's stderr.

This is a test defect, not a product one. The CLI writes nothing to stderr here; every
environment variable that any file in shard 7 mutates was probed against the command and
none of them change its stdout, stderr or exit code.

## The fix

One line: `--quiet` on the child.

It suppresses the runtime's diagnostics and nothing else. What the CLI writes still
arrives — `veryfront skills info` with no name and no `--json` still reports
`✗ Usage: veryfront skills info <name>` on stderr underneath `--quiet` — so the assertions
still hold the command to a silent stderr. They just no longer hold the module cache to it
as well. No retry, no tolerance, no skip.

## Verification

The failure reproduces deterministically by putting the machine in the state a partially
restored CI cache puts it in — evicting the `yaml` packument from `DENO_DIR` before each
run:

```
rm -rf "$DENO_DIR/npm/registry.npmjs.org/yaml"
deno test --preload=src/testing/preload.ts --no-check --parallel --allow-all \
  --v8-flags=--max-old-space-size=8192 --ignore=tests --ignore=src/workflow/__tests__ \
  --unstable-worker-options --unstable-net <the 232 shard-7 files>
```

It produces the CI diff byte for byte.

| condition | before | after |
| --- | --- | --- |
| this file alone, trigger armed each run | 0 / 25 passed | 25 / 25 passed |
| full shard-7 file set under `--parallel`, trigger armed each run | 1 / 20 passed (19 skills failures) | 55 / 55 passed (0 skills failures, 0 other failures) |

Deno 2.7.7 throughout, matching CI.

## Noticed while investigating, not fixed here

- `src/extensions/factory-loader.test.ts:201` reads `const repositoryRoot = Deno.cwd()`
  inside a test while `cli/commands/schedule/handler.test.ts` may hold the process
  directory through `withCwd`. It failed once in 25 baseline shard-7 runs with
  `Module not found "file:///.../vf-schedule-local-timeout-.../src/platform/compat/path/index.ts"`
  — a live flake of the class `src/testing/cwd.ts` exists to prevent, and one that file has
  not opted into. Deriving the root from `import.meta.url` fixes it.
- With `LOG_LEVEL=DEBUG` in the environment, `veryfront <cmd> --json` writes ~35 lines of
  debug logs to **stdout** ahead of the JSON envelope, which breaks `JSON.parse` for any
  machine consumer. `setJsonMode()` (`cli/shared/json-output.ts:20`) lowers the level only
  after flag parsing, so module-load-time logs escape it. That one is a product bug and
  deserves its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CLI test output by suppressing unrelated runtime dependency-resolution diagnostics.
  * Added documentation clarifying expected stderr behavior for CLI assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->