### PR TITLE
fix(cli): exit non-zero from whoami and login when unauthenticated

### DIFF
--- a/cli/auth/exit-code.integration.test.ts
+++ b/cli/auth/exit-code.integration.test.ts
@@ -9,7 +9,7 @@ import { makeTempDir, remove } from "#veryfront/platform/compat/fs.ts";
  * shell scripts, and agents gate on them. These tests drive the real CLI entry
  * point in a subprocess so the assertion is on the process exit code itself.
  */
-describe("cli/auth exit codes", { sanitizeOps: false, sanitizeResources: false }, () => {
+describe("cli/auth exit codes", () => {
   const cliPath = fromFileUrl(new URL("../main.ts", import.meta.url));
   const configPath = fromFileUrl(new URL("../../deno.json", import.meta.url));
 
@@ -69,6 +69,11 @@ describe("cli/auth exit codes", { sanitizeOps: false, sanitizeResources: false }
 
     assertEquals(result.code, 1);
   });
+
+  // `login --provider anthropic|openai` also exits 1 on failure (see cli/router.ts),
+  // but it cannot be driven from here: `promptPassword` calls `Deno.stdin.setRaw()`,
+  // which throws ENODEV on a non-TTY stdin. A subprocess test would exit 1 from that
+  // crash rather than from the failure path, and would pass with the fix reverted.
 
   it("whoami still exits zero when a credential validates", async () => {
     const server = Deno.serve(

--- a/cli/auth/exit-code.integration.test.ts
+++ b/cli/auth/exit-code.integration.test.ts
@@ -1,0 +1,105 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { fromFileUrl } from "#veryfront/compat/path/index.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { makeTempDir, remove } from "#veryfront/platform/compat/fs.ts";
+
+/**
+ * Exit codes are the machine-readable contract for the auth commands: CI steps,
+ * shell scripts, and agents gate on them. These tests drive the real CLI entry
+ * point in a subprocess so the assertion is on the process exit code itself.
+ */
+describe("cli/auth exit codes", { sanitizeOps: false, sanitizeResources: false }, () => {
+  const cliPath = fromFileUrl(new URL("../main.ts", import.meta.url));
+  const configPath = fromFileUrl(new URL("../../deno.json", import.meta.url));
+
+  /**
+   * Runs the CLI with no usable credential: an empty `VERYFRONT_API_TOKEN` and a
+   * throwaway `XDG_CONFIG_HOME` so the developer's stored token is never read.
+   * The cwd is a temp directory so a repository `.env` cannot supply a token.
+   */
+  async function runUnauthenticated(
+    args: string[],
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
+    const tempDir = await makeTempDir({ prefix: "cli-auth-exit-code-" });
+    try {
+      const result = await new Deno.Command(Deno.execPath(), {
+        args: ["run", "-A", "--config", configPath, cliPath, ...args],
+        cwd: tempDir,
+        env: {
+          VERYFRONT_API_TOKEN: "",
+          XDG_CONFIG_HOME: `${tempDir}/config`,
+          VERYFRONT_NO_UPDATE_CHECK: "1",
+          NO_COLOR: "1",
+          CI: "1",
+        },
+        stdin: "null",
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      const decoder = new TextDecoder();
+
+      return {
+        code: result.code,
+        stdout: decoder.decode(result.stdout),
+        stderr: decoder.decode(result.stderr),
+      };
+    } finally {
+      await remove(tempDir, { recursive: true });
+    }
+  }
+
+  it("whoami exits non-zero when no credential is available", async () => {
+    const result = await runUnauthenticated(["whoami"]);
+
+    assertEquals(result.code, 1);
+    assertStringIncludes(result.stdout, "Not logged in");
+    assertStringIncludes(result.stdout, "veryfront login");
+  });
+
+  it("whoami --json exits non-zero and still reports authenticated: false", async () => {
+    const result = await runUnauthenticated(["whoami", "--json"]);
+
+    assertEquals(result.code, 1);
+    assertEquals(JSON.parse(result.stdout).data, { authenticated: false });
+  });
+
+  it("login exits non-zero when it cannot obtain a credential", async () => {
+    const result = await runUnauthenticated(["login"]);
+
+    assertEquals(result.code, 1);
+  });
+
+  it("whoami still exits zero when a credential validates", async () => {
+    const server = Deno.serve(
+      { port: 0, onListen: () => {} },
+      () => Response.json({ id: "user-123", email: "cli@example.test" }),
+    );
+    const baseUrl = `http://127.0.0.1:${(server.addr as Deno.NetAddr).port}`;
+    const tempDir = await makeTempDir({ prefix: "cli-auth-exit-code-ok-" });
+
+    try {
+      const result = await new Deno.Command(Deno.execPath(), {
+        args: ["run", "-A", "--config", configPath, cliPath, "whoami"],
+        cwd: tempDir,
+        env: {
+          VERYFRONT_API_TOKEN: "user-session-token",
+          VERYFRONT_API_BASE_URL: baseUrl,
+          XDG_CONFIG_HOME: `${tempDir}/config`,
+          VERYFRONT_NO_UPDATE_CHECK: "1",
+          NO_COLOR: "1",
+          CI: "1",
+        },
+        stdin: "null",
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+
+      assertEquals(result.code, 0);
+      assertStringIncludes(new TextDecoder().decode(result.stdout), "cli@example.test");
+    } finally {
+      await server.shutdown();
+      await remove(tempDir, { recursive: true });
+    }
+  });
+});

--- a/cli/commands/login/command-help.ts
+++ b/cli/commands/login/command-help.ts
@@ -34,5 +34,6 @@ export const loginHelp: CommandHelp = {
     "Without options, prompts for authentication method",
     "OAuth methods open browser for authentication",
     "Token is stored in ~/.config/veryfront/token",
+    "Exits 1 when no credential was obtained, so scripts can gate on it",
   ],
 };

--- a/cli/commands/whoami/command-help.ts
+++ b/cli/commands/whoami/command-help.ts
@@ -10,5 +10,6 @@ export const whoamiHelp: CommandHelp = {
   notes: [
     "Shows the authenticated user or API-key credential type",
     "Checks both environment variable and stored token",
+    "Exits 0 when a credential validates and 1 when none does, so scripts can gate on it",
   ],
 };

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -71,7 +71,8 @@ const commands: Record<string, CommandLoader> = {
       return;
     }
     const { login } = await import("./auth/index.ts");
-    await login(parseLoginMethod(args));
+    // Exit non-zero so scripts can tell a failed login from a successful one.
+    if (!await login(parseLoginMethod(args))) exitProcess(1);
   },
   "logout": async () => async (args) => {
     const { parseProvider } = await import("./auth/utils.ts");
@@ -90,7 +91,8 @@ const commands: Record<string, CommandLoader> = {
   },
   "whoami": async () => async () => {
     const { whoami } = await import("./auth/index.ts");
-    await whoami();
+    // The exit code is the machine-readable answer: 0 authenticated, 1 not.
+    if (!await whoami()) exitProcess(1);
   },
   "install": async () => (await import("./commands/install/handler.ts")).handleInstallCommand,
   "uninstall": async () => (await import("./commands/install/handler.ts")).handleUninstallCommand,

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -60,18 +60,19 @@ const commands: Record<string, CommandLoader> = {
   "login": async () => async (args) => {
     const { parseLoginMethod, parseProvider } = await import("./auth/utils.ts");
     const provider = parseProvider(args);
+    // Every branch reports failure the same way: exit non-zero so scripts can
+    // tell a failed login from a successful one, whichever credential was asked for.
     if (provider === "anthropic") {
       const { loginAnthropic } = await import("./auth/providers/anthropic.ts");
-      await loginAnthropic();
+      if (!await loginAnthropic()) exitProcess(1);
       return;
     }
     if (provider === "openai") {
       const { loginOpenAI } = await import("./auth/providers/openai.ts");
-      await loginOpenAI(args["base-url"] as string | undefined);
+      if (!await loginOpenAI(args["base-url"] as string | undefined)) exitProcess(1);
       return;
     }
     const { login } = await import("./auth/index.ts");
-    // Exit non-zero so scripts can tell a failed login from a successful one.
     if (!await login(parseLoginMethod(args))) exitProcess(1);
   },
   "logout": async () => async (args) => {


### PR DESCRIPTION
## The lie

`veryfront whoami` prints `✗ Not logged in` and exits **0**.

Reproduced against the published npm artifact `veryfront@0.1.1232`, in a sandbox outside the monorepo, with the exit code captured directly (no pipe, which would mask it):

```
$ env -u VERYFRONT_API_TOKEN ./node_modules/.bin/veryfront whoami

  ✗ Not logged in
  Run 'veryfront login' to authenticate
EXIT=0

$ env -u VERYFRONT_API_TOKEN ./node_modules/.bin/veryfront whoami --json
{
  "success": true,
  "command": "whoami",
  "data": { "authenticated": false }
}
EXIT=0
```

The exit code is the machine-readable contract. Any CI step, shell script, or agent that gates on `veryfront whoami` believes it is authenticated when it is not, then fails later somewhere unrelated and much harder to diagnose. A human used `veryfront whoami` exactly this way — to confirm auth before starting a task — during the dogfood session that found this.

## Sibling check

Swept the neighbouring commands for the same class of defect:

| Command | Unauthenticated / failing behaviour | Verdict |
| --- | --- | --- |
| `whoami` | prints "Not logged in", exits 0 | **bug — fixed here** |
| `login` (non-interactive, no token) | prints "Not logged in. Set VERYFRONT_API_TOKEN…", exits 0 | **bug — fixed here** |
| `logout` | exits 0 | correct |
| `doctor` | a `fail` check throws and exits 1; warnings exit 0 unless `--strict` | correct |
| `routes` (no route dirs) | exits 0 — nothing failed | correct |
| unknown command | exits 1 / 2 in JSON mode | correct |

`login` is the same shape as `whoami` and lives in the same router entry group and auth module, so it is fixed here. `doctor`'s warning-exits-0 behaviour is deliberate and opt-in via `--strict`; left alone.

## Cause

`cli/router.ts` awaited the auth functions and discarded their return values:

```ts
"whoami": async () => async () => {
  const { whoami } = await import("./auth/index.ts");
  await whoami();          // returns AuthIdentity | null — null was dropped
},
```

`whoami()` already reports "no usable credential" by returning `null`. That signal simply never reached the process exit code. Same for `login()`.

## Fix

Both handlers now exit 1 when no credential was obtained.

**Exit code: 1, not 2.** The CLI output style guide's exit-code table reserves `2` for *invalid usage* (wrong args, missing required) and `1` for a general error; `130` is interrupt. `veryfront whoami` with no credential is well-formed usage that answers "no", so it is 1. This also matches the precedent of tools like `grep` and `git diff --quiet`, where 1 means "the answer is no" rather than "you called me wrong".

Human-readable output is unchanged — it still names the problem plainly and points at `veryfront login`. `--json` still emits the `authenticated: false` envelope, now alongside the non-zero exit. Both `whoami` and `login` help text now document the exit codes.

## Tests

`cli/auth/exit-code.integration.test.ts` drives the real CLI entry point in a subprocess and asserts on the process exit code itself — the thing that was wrong. Each run gets a throwaway `XDG_CONFIG_HOME` and a temp cwd so neither a developer's stored token nor a repository `.env` can leak in.

Red, before the fix:

```
running 1 test from ./cli/auth/exit-code.integration.test.ts
cli/auth exit codes ...
  whoami exits non-zero when no credential is available ... FAILED
error: AssertionError: Values are not equal.
    [Diff] Actual / Expected
-   0
+   1

  whoami --json exits non-zero and still reports authenticated: false ... FAILED
  login exits non-zero when it cannot obtain a credential ... FAILED

FAILED | 0 passed | 1 failed (3 steps) (6s)
```

Green, after:

```
running 1 test from ./cli/auth/exit-code.integration.test.ts
cli/auth exit codes ...
  whoami exits non-zero when no credential is available ... ok (2s)
  whoami --json exits non-zero and still reports authenticated: false ... ok (2s)
  login exits non-zero when it cannot obtain a credential ... ok (2s)
  whoami still exits zero when a credential validates ... ok (2s)

ok | 1 passed (4 steps) | 0 failed (8s)
```

The fourth case points the CLI at a stub `/me` server and asserts exit **0** plus the identity in the output, so the fix cannot degenerate into always exiting 1.

Also run clean: `deno fmt --check`, `deno lint`, `deno check` on the changed files, and `deno test cli/router.test.ts cli/auth/ cli/help/` (17 passed, 226 steps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear exit-code behavior for authentication commands.
  * `login` returns exit code 1 when authentication fails.
  * `whoami` returns exit code 1 when no valid credentials are available and 0 when authentication succeeds.
* **Documentation**
  * Updated command help text to explain authentication-related exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->