### PR TITLE
fix(css): tell the reader to create the config file, and what to put in it

### DIFF
--- a/src/extensions/setup-hint.test.ts
+++ b/src/extensions/setup-hint.test.ts
@@ -1,0 +1,115 @@
+import { withTempDir } from "#veryfront/testing/index.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { writeTextFile } from "#veryfront/platform/compat/fs.ts";
+import { join } from "#veryfront/platform/compat/path/index.ts";
+import { formatExtensionSetupHint } from "./setup-hint.ts";
+
+describe("extensions/setup-hint", () => {
+  it("tells a project with no config file to create one, and what to put in it", async () => {
+    // `veryfront init --template minimal` writes package.json, app/, public/,
+    // tsconfig.json and no veryfront.config.ts. Verified against published
+    // 0.1.1232. Telling that reader to "add it to the extensions in
+    // veryfront.config.ts" names a file that does not exist.
+    await withTempDir(async (directory) => {
+      await writeTextFile(join(directory, "package.json"), `{"name":"scaffold"}`);
+
+      const hint = formatExtensionSetupHint("@veryfront/ext-css-lightning", {
+        projectDirectory: directory,
+      });
+
+      assertEquals(
+        hint.includes("create veryfront.config.ts"),
+        true,
+        `hint must name the file as one to create, got: ${hint}`,
+      );
+      // The whole file, pasteable as one line. Spelled out rather than derived
+      // from the formatter so a formatter that regressed cannot satisfy this
+      // by agreeing with itself.
+      assertEquals(
+        hint.includes(
+          `import { defineConfig } from "veryfront"; ` +
+            `import extCssLightning from "@veryfront/ext-css-lightning"; ` +
+            `export default defineConfig({ extensions: [extCssLightning()] });`,
+        ),
+        true,
+        `hint must carry the complete config file, got: ${hint}`,
+      );
+      assertEquals(
+        hint.includes("npm install @veryfront/ext-css-lightning"),
+        true,
+        `hint must carry the install command for this project, got: ${hint}`,
+      );
+    });
+  });
+
+  it("never names `veryfront/config`, which is not an exported subpath", async () => {
+    // The obvious guess when the hint stays silent. `veryfront`'s package
+    // exports map has no `./config` entry, so Node rejects it with
+    // ERR_PACKAGE_PATH_NOT_EXPORTED and the config never loads.
+    await withTempDir(async (directory) => {
+      await writeTextFile(join(directory, "package.json"), `{"name":"scaffold"}`);
+      const hint = formatExtensionSetupHint("@veryfront/ext-css-lightning", {
+        projectDirectory: directory,
+      });
+      assertEquals(hint.includes(`"veryfront/config"`), false, hint);
+    });
+  });
+
+  it("edits the config file the project already has, without re-declaring it", async () => {
+    await withTempDir(async (directory) => {
+      await writeTextFile(join(directory, "package.json"), `{"name":"configured"}`);
+      await writeTextFile(join(directory, "veryfront.config.ts"), "export default {};\n");
+
+      const hint = formatExtensionSetupHint("@veryfront/ext-css-lightning", {
+        projectDirectory: directory,
+      });
+
+      assertEquals(
+        hint.includes("create veryfront.config.ts"),
+        false,
+        `the file exists; the hint must not ask for a second one, got: ${hint}`,
+      );
+      assertEquals(
+        hint.includes(`import extCssLightning from "@veryfront/ext-css-lightning"`),
+        true,
+        `hint must still show the import line, got: ${hint}`,
+      );
+      assertEquals(
+        hint.includes(`"extensions"`) && hint.includes("extCssLightning()"),
+        true,
+        `hint must name the array entry to add, got: ${hint}`,
+      );
+    });
+  });
+
+  it("names the config file the project actually keeps", async () => {
+    // The loader accepts .js and .mjs too. A hint that hard-codes .ts sends a
+    // reader with veryfront.config.js to a second, shadowed file.
+    await withTempDir(async (directory) => {
+      await writeTextFile(join(directory, "package.json"), `{"name":"js-config"}`);
+      await writeTextFile(join(directory, "veryfront.config.js"), "export default {};\n");
+
+      const hint = formatExtensionSetupHint("@veryfront/ext-css-lightning", {
+        projectDirectory: directory,
+      });
+
+      assertEquals(hint.includes("veryfront.config.js"), true, hint);
+      assertEquals(hint.includes("veryfront.config.ts"), false, hint);
+    });
+  });
+
+  it("derives a binding that is a valid identifier for any recommendation", async () => {
+    // Every first-party extension exports its factory as the module default,
+    // so the local binding is the hint's to choose; it only has to be a legal
+    // identifier. `npm:`-prefixed recommendations must not leak the prefix.
+    await withTempDir(async (directory) => {
+      await writeTextFile(join(directory, "package.json"), `{"name":"identifiers"}`);
+      const hint = formatExtensionSetupHint("npm:@veryfront/ext-redis", {
+        projectDirectory: directory,
+      });
+      assertEquals(hint.includes(`import extRedis from "@veryfront/ext-redis"`), true, hint);
+      assertEquals(hint.includes("npm:@veryfront/ext-redis"), false, hint);
+    });
+  });
+});

--- a/src/extensions/setup-hint.test.ts
+++ b/src/extensions/setup-hint.test.ts
@@ -99,6 +99,28 @@ describe("extensions/setup-hint", () => {
     });
   });
 
+  it("names a .mjs config file too, which the loader also accepts", async () => {
+    // Third and last entry in VERYFRONT_CONFIG_FILES, and the one a lookup
+    // that stopped early would drop. Spelled out rather than iterated over the
+    // constant: a regression that removed `.mjs` from the loader's list would
+    // make an iterating test check one case fewer and still pass.
+    await withTempDir(async (directory) => {
+      await writeTextFile(join(directory, "package.json"), `{"name":"mjs-config"}`);
+      await writeTextFile(join(directory, "veryfront.config.mjs"), "export default {};\n");
+
+      const hint = formatExtensionSetupHint("@veryfront/ext-css-lightning", {
+        projectDirectory: directory,
+      });
+
+      assertEquals(hint.includes("veryfront.config.mjs"), true, hint);
+      assertEquals(
+        hint.includes("create veryfront.config.ts"),
+        false,
+        `the project has a config file; the hint must not ask for a second one, got: ${hint}`,
+      );
+    });
+  });
+
   it("derives a binding that is a valid identifier for any recommendation", async () => {
     // Every first-party extension exports its factory as the module default,
     // so the local binding is the hint's to choose; it only has to be a legal

--- a/src/extensions/setup-hint.ts
+++ b/src/extensions/setup-hint.ts
@@ -1,0 +1,136 @@
+/**
+ * Formats the whole remedy for a missing explicit-activation extension.
+ *
+ * A first-party `@veryfront/ext-*` package is inert until a project composes
+ * it, so a hint that stops at the install command reads as actionable and
+ * changes nothing. The composition step is a `veryfront.config.ts` `extensions`
+ * entry -- and naming that file is only useful to a reader who has one.
+ * `veryfront init --template minimal` writes `package.json`, `app/`, `public/`,
+ * and `tsconfig.json`; no config file at all. Verified against published
+ * 0.1.1232. So the hint must know whether the file exists, and say "create" or
+ * "add to" accordingly.
+ *
+ * Naming the file is still not enough to act on, because the first line of the
+ * file it asks for is exactly the line a reader cannot guess. The obvious
+ * guess, `import { defineConfig } from "veryfront/config"`, is not an exported
+ * subpath: `defineConfig` lives on the package root. Node rejects the guess
+ * with ERR_PACKAGE_PATH_NOT_EXPORTED, which the config loader reports as a
+ * bare "Failed to load veryfront.config.ts". So the hint carries the import
+ * lines verbatim, and in the create case the complete file, on one line, ready
+ * to paste.
+ *
+ * The local binding is this module's to choose: every first-party extension
+ * exports its factory as the module default. It is derived from the package
+ * name so the reader can see which import belongs to which entry.
+ *
+ * @module extensions/setup-hint
+ */
+
+import { join } from "#veryfront/platform/compat/path/index.ts";
+import { cwd } from "#veryfront/platform/compat/process.ts";
+import { existsSync } from "#veryfront/platform/compat/std/fs.ts";
+import {
+  VERYFRONT_CONFIG_FILES,
+  type VeryfrontConfigFileName,
+} from "#veryfront/config/config-files.ts";
+import {
+  detectProjectInstallTarget,
+  formatInstallCommand,
+  type InstallTarget,
+  runtimeInstallTarget,
+} from "./install-command.ts";
+
+const NPM_SPECIFIER_PREFIX = "npm:";
+
+/** Config file a project is told to create when it has none. */
+const DEFAULT_CONFIG_FILE: VeryfrontConfigFileName = "veryfront.config.ts";
+
+export interface ExtensionSetupHintOptions {
+  /** Project root to inspect; defaults to the working directory. */
+  readonly projectDirectory?: string;
+  /** Package client to format the install command for; detected by default. */
+  readonly installTarget?: InstallTarget;
+}
+
+/** Strip the registry prefix some recommendations record. */
+function barePackageName(packageName: string): string {
+  return packageName.startsWith(NPM_SPECIFIER_PREFIX)
+    ? packageName.slice(NPM_SPECIFIER_PREFIX.length)
+    : packageName;
+}
+
+/**
+ * Return a legal JavaScript identifier for `packageName`'s default export.
+ *
+ * `@veryfront/ext-css-lightning` becomes `extCssLightning`. The scope is
+ * dropped because it repeats on every first-party package, and every remaining
+ * separator starts a new word.
+ */
+export function defaultImportBinding(packageName: string): string {
+  const unscoped = barePackageName(packageName).replace(/^@[^/]+\//, "");
+  const words = unscoped.split(/[^A-Za-z0-9]+/).filter((word) => word.length > 0);
+  const binding = words
+    .map((word, index) => (index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)))
+    .join("");
+  // A package whose name is only separators, or that starts with a digit,
+  // cannot name a binding. Nothing first-party looks like that, but the
+  // fallback keeps the emitted snippet parseable rather than plausible.
+  return /^[A-Za-z_$]/.test(binding) ? binding : "extension";
+}
+
+/**
+ * Return the config file the project keeps, or `undefined` when it has none.
+ *
+ * The loader accepts `.js`, `.ts`, and `.mjs` in that precedence, so a hint
+ * that hard-codes `.ts` would send a reader who has `veryfront.config.js` to a
+ * second file the loader never reaches.
+ */
+export function findExistingConfigFile(
+  projectDirectory?: string,
+): VeryfrontConfigFileName | undefined {
+  let directory = projectDirectory;
+  if (directory === undefined) {
+    try {
+      directory = cwd();
+    } catch (_) {
+      /* expected: cwd() is unavailable in runtimes without a process */
+      return undefined;
+    }
+  }
+  try {
+    for (const fileName of VERYFRONT_CONFIG_FILES) {
+      if (existsSync(join(directory, fileName))) return fileName;
+    }
+  } catch (_) {
+    /* expected: no synchronous filesystem, or the path is unreadable */
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Return the install-and-compose instruction for `packageName`.
+ *
+ * Phrased as the tail of a sentence that has already stated the effect, so a
+ * caller supplies its own "X is not active." lead.
+ */
+export function formatExtensionSetupHint(
+  packageName: string,
+  options?: ExtensionSetupHintOptions,
+): string {
+  const bareName = barePackageName(packageName);
+  const binding = defaultImportBinding(bareName);
+  const installTarget = options?.installTarget ??
+    detectProjectInstallTarget(options?.projectDirectory) ?? runtimeInstallTarget();
+  const install = formatInstallCommand(bareName, installTarget);
+  const existingConfigFile = findExistingConfigFile(options?.projectDirectory);
+  const importLine = `import ${binding} from "${bareName}";`;
+
+  if (existingConfigFile === undefined) {
+    return `Install one with: ${install}, then create ${DEFAULT_CONFIG_FILE} containing: ` +
+      `import { defineConfig } from "veryfront"; ${importLine} ` +
+      `export default defineConfig({ extensions: [${binding}()] });`;
+  }
+  return `Install one with: ${install}, then activate it in ${existingConfigFile}: ` +
+    `add ${importLine} and list ${binding}() in "extensions".`;
+}

--- a/src/html/styles-builder/css-provider-session.test.ts
+++ b/src/html/styles-builder/css-provider-session.test.ts
@@ -323,6 +323,52 @@ describe("styles-builder CSS provider sessions", () => {
     );
   });
 
+  it("shows the import line, so the config edit needs no guessing", () => {
+    // The shipped hint ends at `then add it to "extensions" in
+    // veryfront.config.ts`. Verified against published 0.1.1232: `veryfront
+    // init --template minimal` writes no veryfront.config.ts at all, so the
+    // reader has to author the file, and the sentence never says what to write
+    // in it. The natural first guess, `import { defineConfig } from
+    // "veryfront/config"`, is not an exported subpath -- the build then dies
+    // with a bare "Failed to load veryfront.config.ts".
+    //
+    // Whether the file already exists depends on the working directory, which
+    // a unit test must not depend on (setup-hint.test.ts pins that mapping
+    // against explicit directories). What holds either way is the import line
+    // for the package being recommended: without it the reader is guessing at
+    // both the specifier and the binding.
+    installProcessor(createProcessor("import-line-rearm"));
+    register(CSSOptimizationEngineName, createOptimizer("import-line-rearm"));
+    acquireCSSGenerationSession(true);
+    resetContracts();
+    installProcessor(createProcessor("import-line"));
+
+    const records: LogEntry[] = [];
+    __resetLogRecordEmitterForTests();
+    const unsubscribe = __subscribeLogRecordEmitter((entry) => {
+      records.push(entry);
+    });
+    try {
+      acquireCSSGenerationSession(true);
+    } finally {
+      unsubscribe();
+      __resetLogRecordEmitterForTests();
+    }
+
+    const message = records.find((entry) => entry.message.includes("unminified CSS"))
+      ?.message ?? "";
+    assertEquals(
+      message.includes(`import extCssLightning from "@veryfront/ext-css-lightning"`),
+      true,
+      `hint must show the import line for the extension, got: ${message}`,
+    );
+    assertEquals(
+      message.includes("extCssLightning()"),
+      true,
+      `hint must show the extension being composed, got: ${message}`,
+    );
+  });
+
   it("keeps minified and unminified output in separate cache identities", async () => {
     // The reversal above is only safe because an absent optimizer is recorded
     // in the pipeline identity, so an unminified entry can never be served in

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -7,7 +7,7 @@
  */
 
 import { tryResolve } from "#veryfront/extensions/contracts.ts";
-import { formatInstallCommand } from "#veryfront/extensions/install-command.ts";
+import { formatExtensionSetupHint } from "#veryfront/extensions/setup-hint.ts";
 import { getRecommendation } from "#veryfront/extensions/recommendations.ts";
 import {
   captureCSSOptimizationEngine,
@@ -162,21 +162,22 @@ export function acquireCSSGenerationSession(minify: boolean): CSSGenerationSessi
     // it is an internal registration hook the guides never mention, and
     // `component=css-compiler` already identifies the source.
     //
-    // Naming the package is likewise not enough to act on, so the install step
-    // is a command the reader can paste. `formatInstallCommand` derives it from
-    // the manifest that owns the project's dependencies rather than hard-coding
-    // one client: a bare `deno add @veryfront/ext-css-lightning` resolves
-    // against JSR, which hosts no `@veryfront` package, and the compiled Deno
-    // binary builds `--runtime node` scaffolds whose own `npm ci` would ignore
-    // any deno.json a `deno add` wrote.
+    // Naming the package is likewise not enough to act on, so the remedy is
+    // steps the reader can paste. `formatExtensionSetupHint` owns both: an
+    // install command derived from the manifest that owns the project's
+    // dependencies rather than one hard-coded client, and the config edit --
+    // "create" or "add to", with the import lines, depending on whether the
+    // project has a config file. `veryfront init --template minimal` writes
+    // none, so the earlier "add it to the extensions in veryfront.config.ts"
+    // named a file that did not exist and never said what to put in it.
     reportedMissingOptimizationEngine = true;
     const recommendation = getRecommendation(CSSOptimizationEngineName);
     logger.warn(
       recommendation === undefined
         ? "Veryfront emits unminified CSS because no CSS optimizer is active"
-        : `Veryfront emits unminified CSS because no CSS optimizer is active. Install one with: ${
-          formatInstallCommand(recommendation)
-        }, then add it to "extensions" in veryfront.config.ts`,
+        : `Veryfront emits unminified CSS because no CSS optimizer is active. ${
+          formatExtensionSetupHint(recommendation)
+        }`,
     );
   }
   const optimizationEngine = optimizationProvider === undefined


### PR DESCRIPTION
Follow-up to #3597. That PR fixed the install command in the CSS-optimizer hint; the sentence's second half still fails.

## Reproduction (published 0.1.1232, sandbox outside the monorepo)

```
$ npm i veryfront@0.1.1232 && npx veryfront init myapp --template minimal --runtime node
$ ls -a myapp
.gitignore  AGENTS.md  README.md  app  package.json  public  tsconfig.json
$ cd myapp && npm i && npm run build
  ! Veryfront emits unminified CSS because no CSS optimizer is active. Install one with:
    npm install @veryfront/ext-css-lightning, then add it to "extensions" in veryfront.config.ts
```

There is no `veryfront.config.ts`. The hint names a file the scaffold does not create — the exact defect #3597 set out to fix, surviving in the second clause.

Following it then fails on the first natural attempt. The reader has to author the file, and its first line is the one line the hint never gives. The obvious guess:

```ts
import { defineConfig } from "veryfront/config";
```

is not an exported subpath — `defineConfig` is on the package root — so Node raises `ERR_PACKAGE_PATH_NOT_EXPORTED`:

```
  ! Failed to load config file
                       configFile=veryfront.config.ts
✗ [config-parse-error] Failed to parse configuration
  Detail: Failed to load veryfront.config.ts
```

(The loader swallowing that cause is a separate defect, fixed in its own PR.)

## Change

`src/extensions/setup-hint.ts` now composes the whole remedy and inspects the project first:

*No config file:*
> Install one with: `npm install @veryfront/ext-css-lightning`, then create veryfront.config.ts containing: `import { defineConfig } from "veryfront"; import extCssLightning from "@veryfront/ext-css-lightning"; export default defineConfig({ extensions: [extCssLightning()] });`

*Config file present:*
> Install one with: `npm install @veryfront/ext-css-lightning`, then activate it in veryfront.config.ts: add `import extCssLightning from "@veryfront/ext-css-lightning";` and list `extCssLightning()` in "extensions".

The create form is the whole file on one line, pasteable as-is. The existing form names the file the project actually keeps — the loader accepts `.js`, `.ts` and `.mjs`, so a hardcoded `.ts` would send a reader with `veryfront.config.js` to a second file the loader never reaches.

The local binding is the hint's to choose (every first-party extension exports its factory as the module default), so it is derived from the package name.

It lives beside `install-command.ts`, whose detector it reuses, rather than in the CSS pipeline that prints it: the same "installing it registers nothing" hole applies to every explicit-activation entry in `recommendations.ts`.

## Tests

Red first. `css-provider-session.test.ts` — "shows the import line, so the config edit needs no guessing":

```
error: AssertionError: Values are not equal: hint must show the import line for the extension,
got: Veryfront emits unminified CSS because no CSS optimizer is active. Install one with:
deno add npm:@veryfront/ext-css-lightning, then add it to "extensions" in veryfront.config.ts
-   false
+   true
```

`src/extensions/setup-hint.test.ts` pins the create/edit branches, the `.js`/`.ts` filename, the absence of `"veryfront/config"`, and binding derivation against explicit temp directories rather than the working directory.

## End-to-end verification

Scratch npm project scaffolded by published 0.1.1232, built with this branch's CLI. Following the printed sentence literally and nothing else:

```
before:  110,606 bytes  dist/_vf/css/397cc85c….css   (warning printed)
after:    89,489 bytes  dist/_vf/css/0a452ee2….css   (no warning)
```

Also confirmed the edit branch fires when a `veryfront.config.ts` exists without the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added setup guidance for configuring extensions, including installation commands and configuration examples.
  * Detects existing JavaScript, TypeScript, and module configuration files and provides tailored update instructions.
  * Generates valid import bindings for recommended packages.
  * Supports customized project locations and installation targets when generating setup guidance.

* **Bug Fixes**
  * Improved missing CSS optimizer warnings with actionable installation and configuration instructions.
  * Preserved the existing fallback warning when no extension recommendation is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->