### PR TITLE
fix(config): report why the config module failed, not only which file

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -722,7 +722,7 @@ export default config as const;
           const error = await assertRejects(
             () => getConfig(projectDir, adapter),
             VeryfrontError,
-          );
+          ) as VeryfrontError;
 
           assert(
             error.message.includes("veryfront.config.js"),
@@ -755,7 +755,7 @@ export default config as const;
           const error = await assertRejects(
             () => getConfig(projectDir, adapter),
             VeryfrontError,
-          );
+          ) as VeryfrontError;
 
           assert(
             error.message.includes("DATABASE_URL is required"),
@@ -785,7 +785,7 @@ export default config as const;
           const error = await assertRejects(
             () => getConfig(projectDir, adapter),
             VeryfrontError,
-          );
+          ) as VeryfrontError;
 
           assert(
             error.message.includes("first line"),
@@ -798,6 +798,49 @@ export default config as const;
           assert(
             error.message.length < 512,
             `error must stay bounded, got ${error.message.length} characters`,
+          );
+        } finally {
+          await Deno.remove(projectDir, { recursive: true });
+        }
+      });
+
+      it("redacts a credential the bound would otherwise cut in half", async () => {
+        // Order matters, not just presence: the redactor recognizes userinfo by
+        // the trailing `@host`. Cutting the message to 200 characters first can
+        // drop that `@host` and leave the password prefix behind in a detail
+        // that a 400 response carries all the way to the caller, so redaction
+        // has to see the complete message. The padding is sized so the password
+        // straddles the 200-character bound: `https://svc:` ends at character
+        // 190 and the `@` sits at 209, so an unredacted cut keeps nine
+        // characters of the secret and loses the marker that identifies it.
+        const adapter = setup();
+        const projectDir = await Deno.makeTempDir({
+          prefix: "vf-config-cause-credential-",
+        });
+        const configPath = `${projectDir}/veryfront.config.js`;
+        const padding = "B".repeat(160);
+        const password = "sup3rsecretpassword";
+        const source =
+          `throw new Error("upstream refused ${padding} https://svc:${password}@registry.internal/pkg");\n`;
+
+        try {
+          await Deno.writeTextFile(configPath, source);
+          adapter.fs.files.set(configPath, source);
+
+          const error = await assertRejects(
+            () => getConfig(projectDir, adapter),
+            VeryfrontError,
+          ) as VeryfrontError;
+
+          assert(
+            !error.message.includes(password),
+            `error must not carry the password, got: ${error.message}`,
+          );
+          // A prefix of the secret is still the secret: pin the exact cut the
+          // 200-character bound produces when redaction runs too late.
+          assert(
+            !error.message.includes(password.slice(0, 9)),
+            `error must not carry a prefix of the password, got: ${error.message}`,
           );
         } finally {
           await Deno.remove(projectDir, { recursive: true });

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -683,6 +683,127 @@ export default config as const;
         }
       });
 
+      it("names why the config module failed, not just which file failed", async () => {
+        // Reproduced against published 0.1.1232 in a `veryfront init --template
+        // minimal` scaffold. A reader following the CSS-optimizer hint writes
+        // the natural first guess, `import { defineConfig } from
+        // "veryfront/config"` -- a subpath the package does not export. The
+        // build reports:
+        //
+        //   ! Failed to load config file  configFile=veryfront.config.ts
+        //   ✗ [config-parse-error] Failed to parse configuration
+        //     Detail: Failed to load veryfront.config.ts
+        //     Suggestion: Ensure your configuration file contains valid
+        //                 JavaScript or TypeScript
+        //
+        // The runtime said exactly what was wrong -- "Package subpath './config'
+        // is not defined by exports" -- and the loader dropped it, then advised
+        // checking syntax that was never the problem. `cause` is attached but
+        // nothing on the way to the terminal reads it, at any log level.
+        const adapter = setup();
+        const projectDir = await Deno.makeTempDir({
+          prefix: "vf-config-load-cause-",
+        });
+        const configPath = `${projectDir}/veryfront.config.js`;
+        // Not the literal `veryfront/config` from the field report: this
+        // repository's own deno.json maps that specifier to src/config/index.ts
+        // for internal callers, so inside the test process it resolves. That
+        // asymmetry is why the guess is natural in the first place -- the
+        // subpath is real in the monorepo and absent from the package's exports
+        // map. A specifier no map claims reproduces the same class of failure
+        // and needs no network.
+        const source = 'import { defineConfig } from "veryfront/not-an-export";\n' +
+          "export default defineConfig({});\n";
+
+        try {
+          await Deno.writeTextFile(configPath, source);
+          adapter.fs.files.set(configPath, source);
+
+          const error = await assertRejects(
+            () => getConfig(projectDir, adapter),
+            VeryfrontError,
+          );
+
+          assert(
+            error.message.includes("veryfront.config.js"),
+            `error must still name the file, got: ${error.message}`,
+          );
+          // Both runtimes name the subpath rather than the joined specifier:
+          // Deno says "Unknown export './not-an-export' for 'veryfront'", Node
+          // says "Package subpath './config' is not defined by exports".
+          assert(
+            error.message.includes("not-an-export"),
+            `error must name the subpath that failed to resolve, got: ${error.message}`,
+          );
+        } finally {
+          await Deno.remove(projectDir, { recursive: true });
+        }
+      });
+
+      it("carries a thrown config's own message through to the reader", async () => {
+        const adapter = setup();
+        const projectDir = await Deno.makeTempDir({
+          prefix: "vf-config-throw-cause-",
+        });
+        const configPath = `${projectDir}/veryfront.config.js`;
+        const source = 'throw new Error("DATABASE_URL is required");\n';
+
+        try {
+          await Deno.writeTextFile(configPath, source);
+          adapter.fs.files.set(configPath, source);
+
+          const error = await assertRejects(
+            () => getConfig(projectDir, adapter),
+            VeryfrontError,
+          );
+
+          assert(
+            error.message.includes("DATABASE_URL is required"),
+            `error must repeat what the config threw, got: ${error.message}`,
+          );
+        } finally {
+          await Deno.remove(projectDir, { recursive: true });
+        }
+      });
+
+      it("bounds a hostile cause instead of pasting it into the report", async () => {
+        // The cause is authored by the project being loaded. A hosted build log
+        // must not become a paste surface for an arbitrarily long, arbitrarily
+        // formatted string, so the summary is one line and bounded.
+        const adapter = setup();
+        const projectDir = await Deno.makeTempDir({
+          prefix: "vf-config-cause-bound-",
+        });
+        const configPath = `${projectDir}/veryfront.config.js`;
+        const noise = "A".repeat(4096);
+        const source = `throw new Error("first line\\nsecond line ${noise}");\n`;
+
+        try {
+          await Deno.writeTextFile(configPath, source);
+          adapter.fs.files.set(configPath, source);
+
+          const error = await assertRejects(
+            () => getConfig(projectDir, adapter),
+            VeryfrontError,
+          );
+
+          assert(
+            error.message.includes("first line"),
+            `error must keep the first line, got: ${error.message}`,
+          );
+          assert(
+            !error.message.includes("second line"),
+            `error must stop at the first line, got: ${error.message}`,
+          );
+          assert(
+            error.message.length < 512,
+            `error must stay bounded, got ${error.message.length} characters`,
+          );
+        } finally {
+          await Deno.remove(projectDir, { recursive: true });
+        }
+      });
+
       it("bounds distinct concurrent loads and recovers capacity after they drain", async () => {
         const adapter = setup();
         const gate = Promise.withResolvers<void>();

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -768,7 +768,7 @@ async function readHostedConfigSource(
       if (isPreservedConfigLoadError(error)) throw error;
       logger.warn("Failed to load config file", { configFile });
       throw CONFIG_PARSE_ERROR.create({
-        detail: `Failed to load ${configFile}`,
+        detail: configLoadFailureDetail(configFile, error),
         cause: error,
         context: { configFile },
       });
@@ -1488,6 +1488,50 @@ function isPreservedConfigLoadError(error: unknown): boolean {
   return error instanceof VeryfrontError;
 }
 
+/**
+ * How much of a config module's own failure the report repeats.
+ *
+ * The cause is authored by the project being loaded, so a hosted build log must
+ * not become a paste surface for it. One line, bounded, control characters
+ * removed.
+ */
+const MAX_CONFIG_LOAD_CAUSE_CHARACTERS = 200;
+
+// deno-lint-ignore no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
+
+/** Return the one-line summary of `error`, or `undefined` when it has none. */
+function summarizeConfigLoadCause(error: unknown): string | undefined {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === "string"
+    ? error
+    : undefined;
+  if (message === undefined) return undefined;
+  const firstLine = message.split("\n", 1)[0]?.replace(CONTROL_CHARACTERS, " ").trim() ?? "";
+  if (firstLine.length === 0) return undefined;
+  return firstLine.length > MAX_CONFIG_LOAD_CAUSE_CHARACTERS
+    ? `${firstLine.slice(0, MAX_CONFIG_LOAD_CAUSE_CHARACTERS - 1)}…`
+    : firstLine;
+}
+
+/**
+ * Report why the config module failed, not only which file did.
+ *
+ * `cause` is attached to the error, but nothing between here and the terminal
+ * reads it, at any log level. A reader whose config imports a subpath the
+ * package does not export got "Failed to load veryfront.config.ts" and a
+ * suggestion to check their syntax -- while the runtime had already said
+ * "Package subpath './config' is not defined by exports". Repeating that line
+ * is the difference between a build the reader can fix and one they cannot.
+ */
+function configLoadFailureDetail(configFile: string, error: unknown): string {
+  const summary = summarizeConfigLoadCause(error);
+  return summary === undefined
+    ? `Failed to load ${configFile}`
+    : `Failed to load ${configFile}: ${summary}`;
+}
+
 async function loadConfigFromTempFile(
   source: string,
   configPath: string,
@@ -2145,7 +2189,7 @@ function getConfigInternal(
                 if (isPreservedConfigLoadError(error)) throw error;
                 logger.warn("Failed to load config file", { configFile });
                 throw CONFIG_PARSE_ERROR.create({
-                  detail: `Failed to load ${configFile}`,
+                  detail: configLoadFailureDetail(configFile, error),
                   cause: error,
                   context: { configFile },
                 });
@@ -2215,7 +2259,7 @@ function getConfigInternal(
             if (isPreservedConfigLoadError(error)) throw error;
             logger.warn("Failed to load config file", { configFile });
             throw CONFIG_PARSE_ERROR.create({
-              detail: `Failed to load ${configFile}`,
+              detail: configLoadFailureDetail(configFile, error),
               cause: error,
               context: { configFile },
             });
@@ -2345,7 +2389,7 @@ export async function evaluateHostedConfigSource(
     }
     if (isPreservedConfigLoadError(error)) throw error;
     throw CONFIG_PARSE_ERROR.create({
-      detail: `Failed to load ${options.source.fileName}`,
+      detail: configLoadFailureDetail(options.source.fileName, error),
       cause: error,
       context: { configFile: options.source.fileName },
     });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -9,6 +9,7 @@ import {
 import { isBun, isDenoCompiled } from "#veryfront/platform/compat/runtime.ts";
 import { ESBUILD_WASM_URL } from "#veryfront/platform/compat/esbuild-shared.ts";
 import { serverLogger } from "#veryfront/utils/logger/logger.ts";
+import { sanitizeUrlCredentials } from "#veryfront/utils/logger/redact.ts";
 import { getReactImportMap, REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { DEFAULT_CACHE_DIR } from "#veryfront/utils/constants/server.ts";
 import { buildConfigCacheKey, type VirtualConfigSourceContext } from "#veryfront/cache/keys.ts";
@@ -767,8 +768,15 @@ async function readHostedConfigSource(
       }
       if (isPreservedConfigLoadError(error)) throw error;
       logger.warn("Failed to load config file", { configFile });
+      // Deliberately generic, unlike the three evaluation sites. Everything
+      // reaching here came out of `adapter.fs.readFile`, so the cause describes
+      // the storage backend -- internal hostnames, paths, account identifiers --
+      // not the project's own config module. CONFIG_PARSE_ERROR is a 400, and
+      // the HTTP boundary strips `detail` only at 5xx
+      // (src/errors/middleware/http-error-boundary.ts:113-116), so a cause
+      // repeated here would reach the tenant. It stays on `cause` for the logs.
       throw CONFIG_PARSE_ERROR.create({
-        detail: configLoadFailureDetail(configFile, error),
+        detail: `Failed to load ${configFile}`,
         cause: error,
         context: { configFile },
       });
@@ -1500,7 +1508,15 @@ const MAX_CONFIG_LOAD_CAUSE_CHARACTERS = 200;
 // deno-lint-ignore no-control-regex
 const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
 
-/** Return the one-line summary of `error`, or `undefined` when it has none. */
+/**
+ * Return the one-line summary of `error`, or `undefined` when it has none.
+ *
+ * Redaction runs over the complete message before anything is cut away, the
+ * order `sanitizeBoundedDiagnosticText` documents: taking the first line or the
+ * first 200 characters can split `scheme://user:password@host` before the
+ * trailing `@host` the redactor matches on, which would leave the password
+ * prefix in a status-400 detail.
+ */
 function summarizeConfigLoadCause(error: unknown): string | undefined {
   const message = error instanceof Error
     ? error.message
@@ -1508,7 +1524,8 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
     ? error
     : undefined;
   if (message === undefined) return undefined;
-  const firstLine = message.split("\n", 1)[0]?.replace(CONTROL_CHARACTERS, " ").trim() ?? "";
+  const redacted = sanitizeUrlCredentials(message);
+  const firstLine = redacted.split("\n", 1)[0]?.replace(CONTROL_CHARACTERS, " ").trim() ?? "";
   if (firstLine.length === 0) return undefined;
   return firstLine.length > MAX_CONFIG_LOAD_CAUSE_CHARACTERS
     ? `${firstLine.slice(0, MAX_CONFIG_LOAD_CAUSE_CHARACTERS - 1)}…`


### PR DESCRIPTION
Second defect found while following #3597's CSS-optimizer hint literally in a scratch project built from published `veryfront@0.1.1232`. (The hint itself is fixed in a separate PR.)

## Reproduction

A reader told to put the extension in `veryfront.config.ts` writes the natural first guess:

```ts
import { defineConfig } from "veryfront/config";
import extCSSLightning from "@veryfront/ext-css-lightning";
export default defineConfig({ extensions: [extCSSLightning()] });
```

`veryfront` exports no `./config` subpath — `defineConfig` is on the package root — so Node raises `ERR_PACKAGE_PATH_NOT_EXPORTED` with a message that says exactly what is wrong:

```
Package subpath './config' is not defined by "exports" in .../veryfront/package.json
```

The loader drops it:

```
  ! Failed to load config file
                       configFile=veryfront.config.ts
  ✗ Failed to load veryfront.config.ts
✗ [config-parse-error] Failed to parse configuration
  Detail: Failed to load veryfront.config.ts
  Suggestion: Ensure your configuration file contains valid JavaScript or TypeScript
```

The file's syntax was never the problem, so the suggestion sends the reader looking in the wrong place. `cause` is attached to the error, but nothing between the loader and the terminal reads it — including at `LOG_LEVEL=debug`, which adds only `loadAndMergeConfig called` and then the same bare line.

## Change

The three `Failed to load <file>` sites in `src/config/loader.ts` that wrap evaluation of the project's config module append a summary of the cause. The summary is redacted with `sanitizeUrlCredentials`, then reduced to one line, bounded to 200 characters, and stripped of control characters: the cause is authored by the project being loaded, and a hosted build log must not become a paste surface for it. Redaction runs before the bound because `sanitizeUrlCredentials` recognizes userinfo by its trailing `@host`, and a cut that drops the `@host` would leave a password prefix behind -- the ordering `sanitizeBoundedDiagnosticText` already documents at `src/errors/diagnostic-policy.ts:63-72`.

The fourth site, in `readHostedConfigSource`, keeps the generic detail. Everything reaching that catch came out of `adapter.fs.readFile`, so the cause describes the storage backend rather than the project's config module, and `CONFIG_PARSE_ERROR` is a 400 whose `detail` the HTTP boundary does not strip (`src/errors/middleware/http-error-boundary.ts:113-116`). The cause stays attached for the logs.

## Tests

Red first, three new cases in `src/config/loader.test.ts`:

```
error: AssertionError: error must name the subpath that failed to resolve,
       got: Failed to load veryfront.config.js
error: AssertionError: error must repeat what the config threw,
       got: Failed to load veryfront.config.js
error: AssertionError: error must keep the first line,
       got: Failed to load veryfront.config.js
```

The third pins the bound: a cause with `"first line\nsecond line " + "A".repeat(4096)` must keep the first line, drop the rest, and leave the report under 512 characters.

A fourth case, added after review, pins the redaction *order* rather than the presence of a call. Its padding is sized so `https://svc:` ends at character 190 and the `@` sits at 209, putting the marker the redactor matches on past the bound. With `sanitizeUrlCredentials` moved back after the bound it fails:

```
error: AssertionError: error must not carry a prefix of the password, got:
  Failed to load veryfront.config.js: upstream refused BBBB...BBBB https://svc:sup3rsecr...
```

The unresolvable specifier in the test is `veryfront/not-an-export`, not the `veryfront/config` from the field report, because this repository's own `deno.json` maps `veryfront/config` to `src/config/index.ts` for internal callers, so it resolves inside the test process. That asymmetry — a subpath that is real in the monorepo and absent from the published exports map — is why the guess is natural in the first place, and it is called out in the test comment.

## End-to-end verification

The published 0.1.1232 npm package with only `esm/src/config/` replaced by this branch's `deno task build:npm` output, same scratch project, same wrong import:

```
  Detail: Failed to load veryfront.config.ts: Package subpath './config' is not
          defined by "exports" in /private/tmp/…
```

## Not changed

The `config-parse-error` suggestion still reads "Ensure your configuration file contains valid JavaScript or TypeScript", which remains wrong for a resolution failure. Narrowing the suggestion per cause class is a larger change to the error registry and is left out of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
