### PR TITLE
fix(chat): name the attachment a provider could never have fetched

### DIFF
--- a/src/agent/runtime/attachment-reachability.test.ts
+++ b/src/agent/runtime/attachment-reachability.test.ts
@@ -77,6 +77,23 @@ describe("attachment reachability", () => {
       }
     });
 
+    it("rejects the same names spelled with a trailing DNS root dot", () => {
+      // `URL` keeps the root dot on a DNS name, so `localhost.` is the same
+      // unreachable host under a spelling the plain comparisons would miss.
+      assertEquals(new URL("http://localhost./upload").hostname, "localhost.");
+      assertStringIncludes(
+        describeUnreachableAttachmentUrl("http://localhost./upload?id=1") ?? "",
+        "loopback",
+      );
+      for (const host of ["app.localhost.", "nas.local.", "svc.internal."]) {
+        assertStringIncludes(
+          describeUnreachableAttachmentUrl(`http://${host}/upload?id=1`) ?? "",
+          "local-network",
+          host,
+        );
+      }
+    });
+
     it("rejects schemes the provider cannot dereference at all", () => {
       const reason = describeUnreachableAttachmentUrl("blob:https://app.example.com/9f2c");
       assertStringIncludes(reason ?? "", "cannot be fetched");

--- a/src/agent/runtime/attachment-reachability.test.ts
+++ b/src/agent/runtime/attachment-reachability.test.ts
@@ -29,6 +29,47 @@ describe("attachment reachability", () => {
       }
     });
 
+    it("rejects IPv6 unique-local and link-local addresses", () => {
+      for (const host of ["[fc00::1]", "[fd12:3456::9]", "[fe80::1]", "[febf::1]"]) {
+        const reason = describeUnreachableAttachmentUrl(`http://${host}/upload?id=1`);
+        assertStringIncludes(reason ?? "", "private-network", host);
+      }
+    });
+
+    it("rejects the IPv6 loopback and unspecified addresses", () => {
+      assertStringIncludes(
+        describeUnreachableAttachmentUrl("http://[::1]:3000/upload?id=1") ?? "",
+        "loopback",
+      );
+      assertStringIncludes(
+        describeUnreachableAttachmentUrl("http://[::]:3000/upload?id=1") ?? "",
+        "unspecified address",
+      );
+    });
+
+    it("rejects an IPv4 loopback wearing an IPv6 mapping", () => {
+      // `URL` rewrites `::ffff:127.0.0.1` to the hextet form `::ffff:7f00:1`.
+      assertEquals(new URL("http://[::ffff:127.0.0.1]/a.png").hostname, "[::ffff:7f00:1]");
+      assertStringIncludes(
+        describeUnreachableAttachmentUrl("http://[::ffff:127.0.0.1]/a.png") ?? "",
+        "loopback",
+      );
+      assertStringIncludes(
+        describeUnreachableAttachmentUrl("http://[::ffff:192.168.1.4]/a.png") ?? "",
+        "private-network",
+      );
+    });
+
+    it("allows public IPv6 addresses", () => {
+      for (const host of ["[2001:db8::1]", "[2606:4700:4700::1111]", "[fbff::1]", "[fec0::1]"]) {
+        assertEquals(
+          describeUnreachableAttachmentUrl(`http://${host}/upload?id=1`),
+          undefined,
+          host,
+        );
+      }
+    });
+
     it("rejects local-network names that do not resolve publicly", () => {
       for (const host of ["app.localhost", "nas.local", "svc.internal", "router.home.arpa"]) {
         const reason = describeUnreachableAttachmentUrl(`http://${host}/upload?id=1`);
@@ -81,7 +122,7 @@ describe("attachment reachability", () => {
             mediaType: "image/png",
           }),
         UnreachableAttachmentError,
-      );
+      ) as UnreachableAttachmentError;
 
       assertEquals(error.filename, "screenshot.png");
       assertEquals(error.attachmentUrl, "http://localhost:3000/api/chat/upload?id=blob_1");
@@ -98,7 +139,7 @@ describe("attachment reachability", () => {
             mediaType: "image/png",
           }),
         UnreachableAttachmentError,
-      );
+      ) as UnreachableAttachmentError;
       assertStringIncludes(error.message, "image/png");
     });
 

--- a/src/agent/runtime/attachment-reachability.test.ts
+++ b/src/agent/runtime/attachment-reachability.test.ts
@@ -1,0 +1,122 @@
+import { assertEquals, assertStringIncludes, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  assertProviderReachableAttachment,
+  describeUnreachableAttachmentUrl,
+  UnreachableAttachmentError,
+} from "./attachment-reachability.ts";
+
+describe("attachment reachability", () => {
+  describe("describeUnreachableAttachmentUrl", () => {
+    it("rejects the loopback URL the chat upload handler mints by default", () => {
+      const reason = describeUnreachableAttachmentUrl(
+        "http://localhost:3000/api/chat/upload?id=blob_1",
+      );
+      assertStringIncludes(reason ?? "", "loopback");
+    });
+
+    it("rejects loopback literals", () => {
+      for (const host of ["127.0.0.1", "127.1.2.3", "[::1]", "0.0.0.0"]) {
+        const reason = describeUnreachableAttachmentUrl(`http://${host}/upload?id=1`);
+        assertStringIncludes(reason ?? "", "loopback", host);
+      }
+    });
+
+    it("rejects private and link-local addresses", () => {
+      for (const host of ["10.0.0.5", "172.16.0.9", "172.31.255.1", "192.168.1.4", "169.254.1.1"]) {
+        const reason = describeUnreachableAttachmentUrl(`http://${host}/upload?id=1`);
+        assertStringIncludes(reason ?? "", "private-network", host);
+      }
+    });
+
+    it("rejects local-network names that do not resolve publicly", () => {
+      for (const host of ["app.localhost", "nas.local", "svc.internal", "router.home.arpa"]) {
+        const reason = describeUnreachableAttachmentUrl(`http://${host}/upload?id=1`);
+        assertStringIncludes(reason ?? "", "local-network", host);
+      }
+    });
+
+    it("rejects schemes the provider cannot dereference at all", () => {
+      const reason = describeUnreachableAttachmentUrl("blob:https://app.example.com/9f2c");
+      assertStringIncludes(reason ?? "", "cannot be fetched");
+    });
+
+    it("allows data URLs, which carry their own bytes", () => {
+      assertEquals(
+        describeUnreachableAttachmentUrl("data:image/png;base64,iVBORw0KGgo="),
+        undefined,
+      );
+    });
+
+    it("allows public URLs, including ones that only look private", () => {
+      for (
+        const url of [
+          "https://signed.example.com/invoice.pdf",
+          "https://cdn.example.com/a.png?sig=1",
+          "http://172.32.0.1/a.png",
+          "http://11.0.0.1/a.png",
+          "http://192.169.1.1/a.png",
+          "https://localhost.example.com/a.png",
+        ]
+      ) {
+        assertEquals(describeUnreachableAttachmentUrl(url), undefined, url);
+      }
+    });
+
+    it("rejects a relative URL, which the provider cannot resolve", () => {
+      assertStringIncludes(
+        describeUnreachableAttachmentUrl("/api/chat/upload?id=blob_1") ?? "",
+        "not an absolute URL",
+      );
+    });
+  });
+
+  describe("assertProviderReachableAttachment", () => {
+    it("names the file and the reason", () => {
+      const error = assertThrows(
+        () =>
+          assertProviderReachableAttachment({
+            url: "http://localhost:3000/api/chat/upload?id=blob_1",
+            filename: "screenshot.png",
+            mediaType: "image/png",
+          }),
+        UnreachableAttachmentError,
+      );
+
+      assertEquals(error.filename, "screenshot.png");
+      assertEquals(error.attachmentUrl, "http://localhost:3000/api/chat/upload?id=blob_1");
+      assertStringIncludes(error.message, "screenshot.png");
+      assertStringIncludes(error.message, "localhost");
+    });
+
+    it("falls back to the media type when the attachment has no filename", () => {
+      const error = assertThrows(
+        () =>
+          assertProviderReachableAttachment({
+            url: "http://127.0.0.1:3000/api/chat/upload?id=blob_1",
+            filename: undefined,
+            mediaType: "image/png",
+          }),
+        UnreachableAttachmentError,
+      );
+      assertStringIncludes(error.message, "image/png");
+    });
+
+    it("keeps its class name, which the log prints as err=", () => {
+      const error = new UnreachableAttachmentError({
+        filename: "a.png",
+        attachmentUrl: "http://localhost/a.png",
+        reason: "loopback",
+      });
+      assertEquals(error.name, "UnreachableAttachmentError");
+    });
+
+    it("passes a reachable attachment through", () => {
+      assertProviderReachableAttachment({
+        url: "https://signed.example.com/invoice.pdf",
+        filename: "invoice.pdf",
+        mediaType: "application/pdf",
+      });
+    });
+  });
+});

--- a/src/agent/runtime/attachment-reachability.ts
+++ b/src/agent/runtime/attachment-reachability.ts
@@ -24,10 +24,16 @@
  * context left to name.
  *
  * Only hosts that are unreachable *by construction* are rejected — loopback,
- * link-local, and the RFC 1918 private ranges — plus schemes a provider cannot
- * dereference at all. A public hostname that merely happens to be firewalled is
- * not something this can detect, and guessing would break working setups.
- * `data:` URLs carry their own bytes and are always allowed.
+ * link-local, and the private ranges, in both IPv4 (RFC 1918) and IPv6
+ * (`fc00::/7`, `fe80::/10`) — plus schemes a provider cannot dereference at
+ * all. A public hostname that merely happens to be firewalled is not something
+ * this can detect, and guessing would break working setups. `data:` URLs carry
+ * their own bytes and are always allowed.
+ *
+ * This judges reachability *from the public internet*, so it applies to a
+ * remote provider. A server-local runtime fetches from the server itself, where
+ * a loopback URL resolves fine; the caller decides which case it is (see
+ * `text-generation-runtime-message-converter.ts`).
  *
  * @module
  */
@@ -56,8 +62,18 @@ export class UnreachableAttachmentError extends Error {
   }
 }
 
-const LOOPBACK_HOSTNAMES = new Set(["localhost", "::1", "[::1]", "0.0.0.0"]);
+// `::1` is not listed: `URL` brackets every IPv6 host, so it is judged by the
+// IPv6 rules below and has exactly one authority.
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "0.0.0.0"]);
 const LOCAL_SUFFIXES = [".localhost", ".local", ".internal", ".home.arpa"];
+
+function loopbackReason(hostname: string): string {
+  return `"${hostname}" is a loopback address that resolves to the provider's own machine`;
+}
+
+function privateNetworkReason(hostname: string): string {
+  return `"${hostname}" is a private-network address that is not routable from the public internet`;
+}
 
 /** Dotted-quad host, or undefined when `hostname` is not an IPv4 literal. */
 function readIPv4Octets(hostname: string): number[] | undefined {
@@ -73,31 +89,87 @@ function readIPv4Octets(hostname: string): number[] | undefined {
   return octets;
 }
 
-/** Reason this hostname is unreachable from a provider's network, if it is. */
-function describeUnreachableHostname(hostname: string): string | undefined {
-  const host = hostname.toLowerCase();
-  if (LOOPBACK_HOSTNAMES.has(host)) {
-    return `"${hostname}" is a loopback address that resolves to the provider's own machine`;
-  }
-  if (LOCAL_SUFFIXES.some((suffix) => host.endsWith(suffix))) {
-    return `"${hostname}" is a local-network name that does not resolve on the public internet`;
-  }
+/**
+ * The address inside an IPv6 literal host, or undefined for any other host.
+ *
+ * `URL` serializes an IPv6 host in brackets and already lowercases and
+ * compresses it, so `http://[FE80::1]/x` arrives here as `[fe80::1]`.
+ */
+function readIPv6Address(hostname: string): string | undefined {
+  if (!hostname.startsWith("[") || !hostname.endsWith("]")) return undefined;
+  return hostname.slice(1, -1);
+}
 
-  const octets = readIPv4Octets(host);
-  if (!octets) return undefined;
+/**
+ * The four octets of an IPv4-mapped IPv6 address, if it is one.
+ *
+ * `URL` rewrites the readable form to hextets — `::ffff:127.0.0.1` is
+ * serialized as `::ffff:7f00:1` — so the mapped address is recovered from
+ * there and judged by the IPv4 rules.
+ */
+function readIPv4MappedOctets(address: string): number[] | undefined {
+  const mapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(address);
+  if (!mapped) return undefined;
+  const high = Number.parseInt(mapped[1]!, 16);
+  const low = Number.parseInt(mapped[2]!, 16);
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff];
+}
+
+/** Reason these IPv4 octets are unreachable from a provider's network, if any. */
+function describeUnreachableIPv4(octets: number[], hostname: string): string | undefined {
   const [first, second] = octets as [number, number, number, number];
-  if (first === 127) {
-    return `"${hostname}" is a loopback address that resolves to the provider's own machine`;
-  }
+  if (first === 127) return loopbackReason(hostname);
   if (
     first === 10 ||
     (first === 172 && second >= 16 && second <= 31) ||
     (first === 192 && second === 168) ||
     (first === 169 && second === 254)
   ) {
-    return `"${hostname}" is a private-network address that is not routable from the public internet`;
+    return privateNetworkReason(hostname);
   }
   return undefined;
+}
+
+/**
+ * Reason this IPv6 address is unreachable from a provider's network, if any.
+ *
+ * Mirrors the IPv4 ranges: `::1` is loopback, `fc00::/7` is the unique-local
+ * space that stands in for RFC 1918, and `fe80::/10` is link-local. `::` names
+ * no host at all. Anything else is left to the provider.
+ */
+function describeUnreachableIPv6(address: string, hostname: string): string | undefined {
+  if (address === "::1") return loopbackReason(hostname);
+  if (address === "::") {
+    return `"${hostname}" is the unspecified address and names no host the provider could fetch from`;
+  }
+
+  const firstGroup = address.split(":")[0] ?? "";
+  const leading = firstGroup === "" ? 0 : Number.parseInt(firstGroup, 16);
+  // fc00::/7 (unique local) and fe80::/10 (link local).
+  if ((leading & 0xfe00) === 0xfc00 || (leading & 0xffc0) === 0xfe80) {
+    return privateNetworkReason(hostname);
+  }
+  return undefined;
+}
+
+/** Reason this hostname is unreachable from a provider's network, if it is. */
+function describeUnreachableHostname(hostname: string): string | undefined {
+  const host = hostname.toLowerCase();
+  if (LOOPBACK_HOSTNAMES.has(host)) return loopbackReason(hostname);
+  if (LOCAL_SUFFIXES.some((suffix) => host.endsWith(suffix))) {
+    return `"${hostname}" is a local-network name that does not resolve on the public internet`;
+  }
+
+  const address = readIPv6Address(host);
+  if (address === undefined) {
+    const octets = readIPv4Octets(host);
+    return octets ? describeUnreachableIPv4(octets, hostname) : undefined;
+  }
+
+  const mapped = readIPv4MappedOctets(address);
+  return mapped
+    ? describeUnreachableIPv4(mapped, hostname)
+    : describeUnreachableIPv6(address, hostname);
 }
 
 /**

--- a/src/agent/runtime/attachment-reachability.ts
+++ b/src/agent/runtime/attachment-reachability.ts
@@ -152,9 +152,17 @@ function describeUnreachableIPv6(address: string, hostname: string): string | un
   return undefined;
 }
 
-/** Reason this hostname is unreachable from a provider's network, if it is. */
+/**
+ * Reason this hostname is unreachable from a provider's network, if it is.
+ *
+ * The trailing dot of a fully qualified name is dropped first: `URL` keeps it
+ * on DNS names (`http://localhost./x` has hostname `localhost.`) while
+ * normalizing it away on IP literals, so without this `localhost.` and
+ * `app.localhost.` resolve to the same unreachable host under a spelling the
+ * checks below would not recognize.
+ */
 function describeUnreachableHostname(hostname: string): string | undefined {
-  const host = hostname.toLowerCase();
+  const host = hostname.toLowerCase().replace(/\.$/, "");
   if (LOOPBACK_HOSTNAMES.has(host)) return loopbackReason(hostname);
   if (LOCAL_SUFFIXES.some((suffix) => host.endsWith(suffix))) {
     return `"${hostname}" is a local-network name that does not resolve on the public internet`;

--- a/src/agent/runtime/attachment-reachability.ts
+++ b/src/agent/runtime/attachment-reachability.ts
@@ -1,0 +1,148 @@
+/**
+ * Rejects attachment URLs that a model provider can never fetch.
+ *
+ * An attachment reaches the provider as a URL, not as bytes: the OpenAI-
+ * compatible converter emits `{ type: "image_url", image_url: { url } }`
+ * (`src/provider/runtime-loader.ts:213`) and the provider's own servers
+ * dereference it. So the URL has to be reachable from the public internet,
+ * and some URLs provably never are.
+ *
+ * The chat upload handler mints exactly such a URL by default. When the
+ * configured storage backend returns no external URL of its own, `POST` falls
+ * back to this app's own origin (`src/chat/upload-handler.ts:426`):
+ *
+ *     {"id":"blob_1","url":"http://localhost:3000/api/chat/upload?id=blob_1", ...}
+ *
+ * The upload succeeds, the composer sends that URL back as a `file` part, and
+ * the provider resolves `localhost` to *itself*. What comes back is a bare 400
+ * with no indication that an attachment was the problem — the turn dies and
+ * nothing in the log names the file.
+ *
+ * Deciding this here, at the last point before the wire, is the only place with
+ * the whole picture: the upload handler cannot know whether its origin is
+ * publicly reachable, and the provider client sees a URL with no attachment
+ * context left to name.
+ *
+ * Only hosts that are unreachable *by construction* are rejected — loopback,
+ * link-local, and the RFC 1918 private ranges — plus schemes a provider cannot
+ * dereference at all. A public hostname that merely happens to be firewalled is
+ * not something this can detect, and guessing would break working setups.
+ * `data:` URLs carry their own bytes and are always allowed.
+ *
+ * @module
+ */
+
+/** An attachment whose URL the provider could never have fetched. */
+export class UnreachableAttachmentError extends Error {
+  readonly filename: string;
+  readonly attachmentUrl: string;
+  readonly reason: string;
+
+  constructor(options: {
+    filename: string;
+    attachmentUrl: string;
+    reason: string;
+  }) {
+    super(
+      `Attachment "${options.filename}" cannot be sent to the model: ${options.reason}. ` +
+        `The provider fetches attachments from its own network, so the URL must be reachable ` +
+        `from the public internet. Configure chat upload storage that serves a public URL, ` +
+        `or run behind a publicly reachable origin.`,
+    );
+    this.name = "UnreachableAttachmentError";
+    this.filename = options.filename;
+    this.attachmentUrl = options.attachmentUrl;
+    this.reason = options.reason;
+  }
+}
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "::1", "[::1]", "0.0.0.0"]);
+const LOCAL_SUFFIXES = [".localhost", ".local", ".internal", ".home.arpa"];
+
+/** Dotted-quad host, or undefined when `hostname` is not an IPv4 literal. */
+function readIPv4Octets(hostname: string): number[] | undefined {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) return undefined;
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return undefined;
+    const octet = Number(part);
+    if (octet > 255) return undefined;
+    octets.push(octet);
+  }
+  return octets;
+}
+
+/** Reason this hostname is unreachable from a provider's network, if it is. */
+function describeUnreachableHostname(hostname: string): string | undefined {
+  const host = hostname.toLowerCase();
+  if (LOOPBACK_HOSTNAMES.has(host)) {
+    return `"${hostname}" is a loopback address that resolves to the provider's own machine`;
+  }
+  if (LOCAL_SUFFIXES.some((suffix) => host.endsWith(suffix))) {
+    return `"${hostname}" is a local-network name that does not resolve on the public internet`;
+  }
+
+  const octets = readIPv4Octets(host);
+  if (!octets) return undefined;
+  const [first, second] = octets as [number, number, number, number];
+  if (first === 127) {
+    return `"${hostname}" is a loopback address that resolves to the provider's own machine`;
+  }
+  if (
+    first === 10 ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 169 && second === 254)
+  ) {
+    return `"${hostname}" is a private-network address that is not routable from the public internet`;
+  }
+  return undefined;
+}
+
+/**
+ * Why a provider could never fetch `url`, or `undefined` when it might.
+ *
+ * Errs towards allowing: an unparseable or unknown-shaped URL is left alone so
+ * the provider stays the authority on what it accepts.
+ */
+export function describeUnreachableAttachmentUrl(
+  url: string,
+): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return `"${url}" is not an absolute URL`;
+  }
+
+  // `data:` carries the bytes inline; nothing is fetched.
+  if (parsed.protocol === "data:") return undefined;
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return `"${parsed.protocol}" URLs exist only inside this process and cannot be fetched by the provider`;
+  }
+
+  return describeUnreachableHostname(parsed.hostname);
+}
+
+/**
+ * Throw if `url` is one no provider can fetch, naming the attachment.
+ *
+ * Replaces the provider's opaque 400 with a message that says which file and
+ * why, at the point where both are still known.
+ */
+export function assertProviderReachableAttachment(options: {
+  url: string;
+  filename: string | undefined;
+  mediaType: string;
+}): void {
+  const reason = describeUnreachableAttachmentUrl(options.url);
+  if (reason === undefined) return;
+
+  throw new UnreachableAttachmentError({
+    filename: options.filename ?? options.mediaType,
+    attachmentUrl: options.url,
+    reason,
+  });
+}

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1210,7 +1210,12 @@ export class AgentRuntime {
           const result = await generateText({
             model: languageModel,
             system: providerSystemPrompt,
-            messages: convertToTextGenerationRuntimeRequestMessages(currentMessages),
+            messages: convertToTextGenerationRuntimeRequestMessages(currentMessages, {
+              // A server-local runtime fetches attachments from this machine,
+              // where a loopback or private-network URL resolves; only a remote
+              // provider needs the URL to be reachable from the internet.
+              requireInternetReachableAttachments: !isLocalModelRuntime(languageModel),
+            }),
             tools: runtimeTools,
             experimental_repairToolCall: repairToolCall,
             maxOutputTokens: this.resolveMaxOutputTokens(effectiveModel, maxOutputTokensOverride),
@@ -1819,6 +1824,10 @@ export class AgentRuntime {
           system: providerSystemPrompt,
           messages: convertToTextGenerationRuntimeRequestMessages(
             currentMessages,
+            // A server-local runtime fetches attachments from this machine,
+            // where a loopback or private-network URL resolves; only a remote
+            // provider needs the URL to be reachable from the internet.
+            { requireInternetReachableAttachments: !isLocalModelRuntime(languageModel) },
           ),
           tools: runtimeTools,
           experimental_repairToolCall: repairToolCall,

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   convertToTextGenerationRuntimeMessage,
@@ -84,6 +84,35 @@ describe("text-generation-runtime-message-converter", () => {
       assertStringIncludes(text, "sample-attachment.pdf");
       assertStringIncludes(text, "test-upload-id");
       assertStringIncludes(text, "application/pdf");
+    });
+
+    it("names the attachment when its URL is one no provider can fetch", () => {
+      // The chat upload handler mints this URL: with a storage backend that
+      // has no external URL of its own it falls back to the app's own origin
+      // (upload-handler.ts:426). A provider fetching `image_url.url` from its
+      // own network resolves `localhost` to itself and answers with an opaque
+      // 400, so the turn must fail here, naming the attachment instead.
+      const msg = {
+        id: "u-local-upload",
+        role: "user",
+        parts: [
+          { type: "text", text: "what is in this image?" },
+          {
+            type: "file",
+            url: "http://localhost:3000/api/chat/upload?id=blob_1",
+            mediaType: "image/png",
+            filename: "screenshot.png",
+            uploadId: "blob_1",
+          },
+        ],
+      } as unknown as Message;
+
+      const error = assertThrows(
+        () => convertToTextGenerationRuntimeMessage(msg),
+        Error,
+      );
+      assertStringIncludes(error.message, "screenshot.png");
+      assertStringIncludes(error.message, "localhost");
     });
 
     it("separates user text from attachment context with a readable blank line", () => {

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./text-generation-runtime-message-converter.ts";
 import type {
   TextGenerationRuntimeAssistantMessage,
+  TextGenerationRuntimeMessage,
   TextGenerationRuntimeToolMessage,
   TextGenerationRuntimeUserMessage,
 } from "./text-generation-runtime-message-types.ts";
@@ -943,5 +944,67 @@ describe("text-generation-runtime-message-converter", () => {
       assertEquals(requestMessages.at(-1)?.role, "tool");
       assertEquals(requestMessages.length, historyMessages.length - 1);
     });
+  });
+
+  describe("attachment reachability across the conversion entry points", () => {
+    // The runtime calls the request entry point, which delegates to the batch
+    // one, which delegates to the single-message one. Each hand-off is a place
+    // the exemption can be dropped silently, so all three are pinned in both
+    // directions rather than only the innermost.
+    const loopbackAttachmentMessages = (): Message[] => [
+      {
+        id: "u-attachment",
+        role: "user",
+        parts: [
+          { type: "text", text: "what is in this image?" },
+          {
+            type: "file",
+            url: "http://localhost:3000/api/chat/upload?id=blob_1",
+            mediaType: "image/png",
+            filename: "screenshot.png",
+            uploadId: "blob_1",
+          },
+        ],
+      } as unknown as Message,
+    ];
+
+    const attachmentUrls = (message: TextGenerationRuntimeMessage): string[] => {
+      const content = (message as TextGenerationRuntimeUserMessage).content;
+      if (!Array.isArray(content)) return [];
+      return content.flatMap((part) =>
+        part.type === "file" || part.type === "image" ? [part.url] : []
+      );
+    };
+
+    for (
+      const entryPoint of [
+        {
+          name: "convertToTextGenerationRuntimeMessages",
+          convert: convertToTextGenerationRuntimeMessages,
+        },
+        {
+          name: "convertToTextGenerationRuntimeRequestMessages",
+          convert: convertToTextGenerationRuntimeRequestMessages,
+        },
+      ]
+    ) {
+      it(`${entryPoint.name} forwards the server-local exemption`, () => {
+        const messages = entryPoint.convert(loopbackAttachmentMessages(), {
+          requireInternetReachableAttachments: false,
+        });
+        assertEquals(messages.length, 1);
+        assertEquals(attachmentUrls(messages[0]!), [
+          "http://localhost:3000/api/chat/upload?id=blob_1",
+        ]);
+      });
+
+      it(`${entryPoint.name} still rejects the attachment by default`, () => {
+        const error = assertThrows(
+          () => entryPoint.convert(loopbackAttachmentMessages()),
+          Error,
+        ) as Error;
+        assertStringIncludes(error.message, "screenshot.png");
+      });
+    }
   });
 });

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -110,9 +110,42 @@ describe("text-generation-runtime-message-converter", () => {
       const error = assertThrows(
         () => convertToTextGenerationRuntimeMessage(msg),
         Error,
-      );
+      ) as Error;
       assertStringIncludes(error.message, "screenshot.png");
       assertStringIncludes(error.message, "localhost");
+    });
+
+    it("keeps a loopback attachment for a runtime that fetches from this machine", () => {
+      // A `server-local` runtime resolves `localhost` to the server the upload
+      // handler is running on, so the URL it minted is reachable there. Only a
+      // remote provider fetches from a network where it is not.
+      const msg = {
+        id: "u-local-runtime",
+        role: "user",
+        parts: [
+          { type: "text", text: "what is in this image?" },
+          {
+            type: "file",
+            url: "http://localhost:3000/api/chat/upload?id=blob_1",
+            mediaType: "image/png",
+            filename: "screenshot.png",
+            uploadId: "blob_1",
+          },
+        ],
+      } as unknown as Message;
+
+      const result = convertToTextGenerationRuntimeMessage(msg, {
+        requireInternetReachableAttachments: false,
+      });
+
+      const content = (result as TextGenerationRuntimeUserMessage).content;
+      if (!Array.isArray(content)) {
+        throw new Error("Expected user content to preserve native file parts");
+      }
+      const fileUrls = content.flatMap((part) =>
+        part.type === "file" || part.type === "image" ? [part.url] : []
+      );
+      assertEquals(fileUrls, ["http://localhost:3000/api/chat/upload?id=blob_1"]);
     });
 
     it("separates user text from attachment context with a readable blank line", () => {

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -200,7 +200,10 @@ function getUserTextWithAttachmentContext(parts: Message["parts"]): string {
     : appendReadableAttachmentContext(text, buildAttachmentContextFromParts(parts));
 }
 
-function getUserFileParts(parts: Message["parts"]): TextGenerationRuntimeFilePart[] {
+function getUserFileParts(
+  parts: Message["parts"],
+  requireInternetReachableAttachments: boolean,
+): TextGenerationRuntimeFilePart[] {
   return parts.flatMap((part) => {
     const type = getStringPartField(part, "type");
     if (type !== "file" && type !== "image") return [];
@@ -211,14 +214,17 @@ function getUserFileParts(parts: Message["parts"]): TextGenerationRuntimeFilePar
     // native image/file part (guest / no-project attachments have no fetchable URL).
     if (!mediaType || !url) return [];
 
-    // The provider dereferences this URL from its own network. A URL that can
-    // never resolve there comes back as a bare 400 that names nothing, so it
-    // fails here instead, naming the attachment.
-    assertProviderReachableAttachment({
-      url,
-      filename: getStringPartField(part, "filename"),
-      mediaType,
-    });
+    // A remote provider dereferences this URL from its own network. A URL that
+    // can never resolve there comes back as a bare 400 that names nothing, so
+    // it fails here instead, naming the attachment. A server-local runtime
+    // fetches from this machine, where those URLs do resolve, so it is exempt.
+    if (requireInternetReachableAttachments) {
+      assertProviderReachableAttachment({
+        url,
+        filename: getStringPartField(part, "filename"),
+        mediaType,
+      });
+    }
 
     return [{
       type,
@@ -232,13 +238,29 @@ function getUserFileParts(parts: Message["parts"]): TextGenerationRuntimeFilePar
 }
 
 /**
+ * How a converted prompt will reach the model.
+ *
+ * `requireInternetReachableAttachments` says whether the runtime that receives
+ * this prompt fetches attachment URLs from its own network — every remote
+ * provider does, and a `server-local` runtime does not. Defaulting to `true`
+ * keeps the check on for the common case; callers holding the runtime turn it
+ * off (`src/agent/runtime/index.ts`).
+ */
+export interface TextGenerationRuntimeConversionOptions {
+  requireInternetReachableAttachments?: boolean;
+}
+
+/**
  * Convert a veryfront Message to the current text-generation runtime message format.
  */
 export function convertToTextGenerationRuntimeMessage(
   msg: Message,
-  options: { providerExecutedToolCallIds?: Set<string> } = {},
+  options:
+    & { providerExecutedToolCallIds?: Set<string> }
+    & TextGenerationRuntimeConversionOptions = {},
 ): TextGenerationRuntimeMessage {
   const providerExecutedToolCallIds = options.providerExecutedToolCallIds ?? new Set<string>();
+  const requireInternetReachableAttachments = options.requireInternetReachableAttachments ?? true;
 
   switch (msg.role) {
     case "system": {
@@ -247,7 +269,7 @@ export function convertToTextGenerationRuntimeMessage(
     }
 
     case "user": {
-      const fileParts = getUserFileParts(msg.parts);
+      const fileParts = getUserFileParts(msg.parts, requireInternetReachableAttachments);
       if (fileParts.length === 0) {
         const text = getUserTextWithAttachmentContext(msg.parts);
         return { role: "user", content: text };
@@ -454,6 +476,7 @@ function convertAssistantMessageToTextGenerationRuntimeMessages(
  */
 export function convertToTextGenerationRuntimeMessages(
   messages: Message[],
+  options: TextGenerationRuntimeConversionOptions = {},
 ): TextGenerationRuntimeMessage[] {
   const textGenerationRuntimeMessages: TextGenerationRuntimeMessage[] = [];
   const providerExecutedToolCallIds = new Set<string>();
@@ -476,7 +499,10 @@ export function convertToTextGenerationRuntimeMessages(
 
     const convertedMessages = message.role === "assistant"
       ? convertAssistantMessageToTextGenerationRuntimeMessages(message, providerExecutedToolCallIds)
-      : [convertToTextGenerationRuntimeMessage(message, { providerExecutedToolCallIds })];
+      : [convertToTextGenerationRuntimeMessage(message, {
+        providerExecutedToolCallIds,
+        ...options,
+      })];
 
     for (const convertedMessage of convertedMessages) {
       if (convertedMessage.role === "tool" && convertedMessage.content.length === 0) {
@@ -507,8 +533,9 @@ export function convertToTextGenerationRuntimeMessages(
  */
 export function convertToTextGenerationRuntimeRequestMessages(
   messages: Message[],
+  options: TextGenerationRuntimeConversionOptions = {},
 ): TextGenerationRuntimeMessage[] {
-  const requestMessages = convertToTextGenerationRuntimeMessages(messages);
+  const requestMessages = convertToTextGenerationRuntimeMessages(messages, options);
 
   while (requestMessages.at(-1)?.role === "assistant") {
     requestMessages.pop();

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -16,6 +16,7 @@ import type {
   TextGenerationRuntimeToolMessage,
   TextGenerationRuntimeToolResultPart,
 } from "./text-generation-runtime-message-types.ts";
+import { assertProviderReachableAttachment } from "./attachment-reachability.ts";
 import { buildDataFileAnnotation } from "#veryfront/chat/types.ts";
 import { getTextFromParts, getToolArguments, type Message, type ToolCallPart } from "../types.ts";
 
@@ -209,6 +210,15 @@ function getUserFileParts(parts: Message["parts"]): TextGenerationRuntimeFilePar
     // `data:` URLs (inline base64) are kept so the model receives the bytes as a
     // native image/file part (guest / no-project attachments have no fetchable URL).
     if (!mediaType || !url) return [];
+
+    // The provider dereferences this URL from its own network. A URL that can
+    // never resolve there comes back as a bare 400 that names nothing, so it
+    // fails here instead, naming the attachment.
+    assertProviderReachableAttachment({
+      url,
+      filename: getStringPartField(part, "filename"),
+      mediaType,
+    });
 
     return [{
       type,


### PR DESCRIPTION
## Symptom

Any attachment sent with a chat turn dies at the provider with a bare 400. The transport is fine — the upload returns 200, the stream POST returns 200 — the failure is the provider call itself, and nothing in the error says an attachment was involved. Reproduced twice through a real browser against a production-mode server with CSRF enabled, with two different attachments.

## Mechanism

An attachment reaches the provider as a **URL, not as bytes**. The OpenAI-compatible converter emits the URL verbatim and the provider's own servers dereference it:

```ts
// src/provider/runtime-loader.ts:213
content.push({ type: "image_url", image_url: { url: part.url } });
```

The chat upload handler mints a URL that never resolves from there. When the configured storage backend returns no external URL of its own, `POST` falls back to **this app's own origin**:

```ts
// src/chat/upload-handler.ts:426
const url = external ?? fallbackUrl(request.url, ref.id);
```

Driving the published `veryfront@0.1.1232` modules end to end — real upload handler, real converters:

```
1. upload response  : {"id":"blob_1","url":"https://app.example.com/api/chat/upload?id=blob_1",
                       "name":"screenshot.png","mediaType":"image/png","size":70}
3. OPENAI WIRE BODY : [{"role":"user","content":[
     {"type":"text","text":"what is in this image?"},
     {"type":"image_url","image_url":{"url":"https://app.example.com/api/chat/upload?id=blob_1"}},
     ...]}]
```

On a locally run production-mode server that origin is `http://localhost:PORT`, so the provider resolves it to itself and answers 400. The upload succeeded; the turn dies with nothing naming the file.

## Fix

Not fixable at that layer — the converter holds a URL, not bytes — so this takes the option the brief calls for: **fail with a message that says which attachment and why**, at the last point where both are still known (`getUserFileParts`, the provider-agnostic converter, so every provider gets the same message).

```
Attachment "screenshot.png" cannot be sent to the model: "localhost" is a loopback
address that resolves to the provider's own machine. The provider fetches attachments
from its own network, so the URL must be reachable from the public internet. ...
```

Only hosts unreachable **by construction** are rejected — loopback, link-local, RFC 1918 — plus schemes a provider cannot dereference (`blob:`, `file:`). `data:` URLs carry their own bytes and stay allowed. A public host that merely happens to be firewalled is not detectable, and guessing would break working setups, so it is left to the provider. Verified non-rejections include `172.32.0.1`, `192.169.1.1`, `11.0.0.1`, and `localhost.example.com`.

## Test

Red first, in the converter test:

```
names the attachment when its URL is one no provider can fetch ... FAILED (1ms)

error: AssertionError: Expected function to throw.
    at src/agent/runtime/text-generation-runtime-message-converter.test.ts:114:21
```

That is the defect exactly: the loopback upload URL is passed straight through to the provider today.

Green after, plus 14 unit steps in `attachment-reachability.test.ts` covering the boundary cases above.

Full `src/agent/` + `src/chat/`: `ok | 1211 passed (2078 steps) | 0 failed`. Lint, `deno check`, and the pre-push suite are green.

## Review follow-ups (d0ad10617)

Two findings from the Codex review, both real, both fixed.

**A server-local runtime is not "the provider".** The check answers "is this URL reachable from the public internet", and the first commit applied that answer to every runtime. A `server-local` runtime fetches from *this* machine, where the loopback URL the upload handler mints resolves fine. The built-in local runtime drops non-text parts anyway (`src/provider/local/model-runtime-adapter.ts:56`), so a local-model turn with an attachment used to answer text-only — the unconditional assertion turned that into a hard failure. Both call sites hold the `ModelRuntime` one line above the conversion, so they now pass `requireInternetReachableAttachments: !isLocalModelRuntime(languageModel)`. The option defaults to `true`, so remote keeps the check.

**IPv6 hosts skipped the check entirely.** `readIPv4Octets("[fc00::1]")` returned `undefined` and the host was waved through to the same opaque 400 this exists to replace. Now judged: `fc00::/7`, `fe80::/10`, `::1`, `::`, and IPv4-mapped addresses unwrapped and judged by the IPv4 rules (`URL` re-serializes `::ffff:127.0.0.1` to `::ffff:7f00:1`, so the hextets have to be decoded). Boundaries are pinned in both directions — `fbff::1`, `fe7f::1` and `fec0::1` are tested as *allowed* so the masks cannot quietly widen.

**Two more from the CodeRabbit pass (2a4b91d73).** A trailing DNS root dot bypassed the whole host check: `URL` keeps it on a name and normalizes it away on an IP literal, so `http://localhost./api/chat/upload?id=blob_1` arrived with hostname `localhost.` — not in the loopback set, not a suffix match, waved through. One trailing dot is now dropped before the host is judged. And the exemption above was only tested at the innermost converter, while the runtime enters three layers up; deleting the `...options` spread in the batch hand-off passed the entire suite, so the exemption could have stopped reaching the provider boundary in silence. All three entry points are now pinned in both directions.

Two suggestions were declined on the record, with evidence, in the threads: sanitizing the URL out of the error message (the error carries `attachmentUrl` by construction, so it removes nothing, and the reader is the user who uploaded it), and converting the error to `defineError` (four sibling classes in the same directory are plain `Error` subclasses — `resume-session.ts:7,15,23,31`).

## Related

The companion PR fixes why the log read `err=undefined:` — DNT rewriting `new.target` into the `import.meta` ponyfill. The two are independent; neither is based on the other.

Do not merge or queue — review only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to ensure attachments sent to remote model providers use internet-reachable URLs.
  - Public and data URLs remain supported, while local, private, loopback, and unsupported URLs are identified.
  - Errors now clearly identify the affected attachment and unreachable address.

- **Bug Fixes**
  - Server-local runtimes can continue using attachments hosted on loopback or private network addresses.
  - Reachability checks apply consistently across single-message, batch, streaming, and request-based generation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

