### PR TITLE
fix(security): keep platform liveness probes out of the project auth gate

### DIFF
--- a/cli/commands/deploy/command-help.ts
+++ b/cli/commands/deploy/command-help.ts
@@ -51,5 +51,6 @@ export const deployHelp: CommandHelp = {
     "With --project, promotes only: the working directory is never pushed, so the selected project directory's push receipt must already name that project",
     "Creates a new release from the resolved branch",
     "Verifies the target environment points to the created deployment before succeeding",
+    "Warns when only the environment's access gate answered the readiness probe, so the app itself was never observed serving",
   ],
 };

--- a/cli/commands/deploy/command.test.ts
+++ b/cli/commands/deploy/command.test.ts
@@ -56,6 +56,7 @@ describe("deploy command adapters", () => {
       environmentId: "environment-sentinel",
       deploymentId: "deployment-sentinel",
       url: "https://sentinel.example.test/dashboard",
+      urlVerification: "gated",
       protected: true,
       routingConvergence: { status: "converged", acknowledged: 3, recipients: 3 },
       commitSha: "f".repeat(40),
@@ -72,6 +73,11 @@ describe("deploy command adapters", () => {
           { kind: "step", step: "resolve-config", phase: "completed" },
           { kind: "step", step: "create-deployment", phase: "started" },
           { kind: "step", step: "create-deployment", phase: "completed" },
+          {
+            kind: "warning",
+            code: "environment-url-unverified",
+            message: "sentinel url warning",
+          },
           {
             kind: "warning",
             code: "routing-convergence-unconfirmed",
@@ -135,6 +141,8 @@ describe("deploy command adapters", () => {
       expectedUrlLine,
     );
     assertEquals(humanOutput.includes("Release 2026.07.30-1"), true);
+    // Both warnings, not just the last: an operator needs the URL one most.
+    assertEquals(humanOutput.includes("sentinel url warning"), true);
     assertEquals(humanOutput.includes("sentinel warning"), true);
 
     const jsonRecords = json.output.map((line) => JSON.parse(line));
@@ -149,6 +157,11 @@ describe("deploy command adapters", () => {
         "deploy:completed",
       ],
     );
+    assertEquals(jsonRecords.at(-3), {
+      type: "warning",
+      code: "environment-url-unverified",
+      message: "sentinel url warning",
+    });
     assertEquals(jsonRecords.at(-2), {
       type: "warning",
       code: "routing-convergence-unconfirmed",

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -133,13 +133,15 @@ async function deployCommandHuman(options: DeployOptions): Promise<DeployResult 
     progressText = next;
     spinner.update(next);
   };
-  let warning: string | null = null;
+  // Collected, not overwritten: a deploy can raise more than one warning, and
+  // the one an operator most needs is not reliably the last.
+  const warnings: string[] = [];
   let outcome: DeployProjectOutcome;
   try {
     outcome = await deployRunner(options).execute(toDeployRequest(options), {
       onEvent(event) {
         if (event.kind === "warning") {
-          warning = event.message;
+          warnings.push(event.message);
           return;
         }
         updateProgress(deployProgressText(event, env, verbose));
@@ -195,7 +197,7 @@ async function deployCommandHuman(options: DeployOptions): Promise<DeployResult 
     logInfo(`  Control plane: ${result.controlPlane}`);
   }
 
-  if (warning) logWarning(warning);
+  for (const message of warnings) logWarning(message);
 
   if (verbose) {
     const { getPostDeployTips } = await import("../../help/tips.ts");

--- a/cli/commands/up/command.test.ts
+++ b/cli/commands/up/command.test.ts
@@ -139,6 +139,7 @@ const VERIFIED_RESULT: DeployResult = {
   environmentId: "environment-1",
   deploymentId: "deployment-1",
   url: "https://verified.example.test/dashboard",
+  urlVerification: "served",
   protected: false,
   routingConvergence: null,
   commitSha: "a".repeat(40),

--- a/cli/mcp/tools/deploy-tool.ts
+++ b/cli/mcp/tools/deploy-tool.ts
@@ -4,7 +4,8 @@
  * Creates a release from a branch and deploys it to an environment through
  * Deploy Execution (`DeployProject.execute`), the same module behind the
  * `vf deploy` CLI command. Success means the deployment is verified and the
- * environment URL is reachable.
+ * environment URL resolves. Read `urlVerification` to tell whether the app
+ * itself answered (`served`) or only its access gate did (`gated`).
  */
 
 import { defineSchema, lazySchema } from "veryfront/schemas";
@@ -113,7 +114,10 @@ export const vfTriggerDeploy: MCPTool<TriggerDeployInput, TriggerDeployResult> =
     "Requires a successful vf push from the current project, then creates and verifies a release " +
     "from the specified branch, deploys it to the target environment, waits for release assets " +
     "and environment readiness, and returns the deployment evidence including the live URL. " +
-    "Success means the environment is verified and reachable. " +
+    "Success means the deployment is verified and the environment URL resolves. " +
+    "Check the returned urlVerification field to tell what the readiness probe established: " +
+    "'served' means the app itself answered, 'gated' means only its access gate answered so the " +
+    "app was never observed, and 'unprobed' means the project has no static page route to check. " +
     "Requires a valid API token (set VERYFRONT_API_TOKEN or run 'veryfront login'). " +
     "Do not use for local builds; use vf_build instead. " +
     "Do not use for running tests before deploy; use vf_run_tests instead.",

--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -487,7 +487,7 @@ describe("DeployProject", () => {
    * The readiness probe cannot get past a protected environment's access gate
    * without a session credential, so a gate challenge is all it ever sees. The
    * app behind the gate can be answering 503 to every signed-in visitor and
-   * this step still completes — which is correct, because the deployment is
+   * this step still completes, which is correct, because the deployment is
    * already committed and verified, and wrong to report as a verified URL.
    * Deploy has to say which of the two it established.
    */
@@ -529,6 +529,14 @@ describe("DeployProject", () => {
         assertStringIncludes(
           warning?.kind === "warning" ? warning.message : "",
           "https://my-project.production.veryfront.com/",
+        );
+        // The remedy has to be one the caller can act on. This deploy resolved
+        // VERYFRONT_API_TOKEN from the shell, which outranks the token store,
+        // so "run veryfront login" alone would leave the next deploy gated the
+        // same way.
+        assertStringIncludes(
+          warning?.kind === "warning" ? warning.message : "",
+          "VERYFRONT_API_TOKEN is set in this shell",
         );
         assertEquals(
           outcome.kind === "deployed" ? outcome.result.urlVerification : undefined,

--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -483,6 +483,92 @@ describe("DeployProject", () => {
     });
   });
 
+  /**
+   * The readiness probe cannot get past a protected environment's access gate
+   * without a session credential, so a gate challenge is all it ever sees. The
+   * app behind the gate can be answering 503 to every signed-in visitor and
+   * this step still completes — which is correct, because the deployment is
+   * already committed and verified, and wrong to report as a verified URL.
+   * Deploy has to say which of the two it established.
+   */
+  it("warns that the environment URL was never observed serving behind its gate", async () => {
+    await withDeployEnv(async () => {
+      const { projectDir } = await createPushedProject();
+      const controlPlane = new InMemoryDeployControlPlane();
+      controlPlane.environmentProtected = true;
+      const events: DeployEvent[] = [];
+      try {
+        const outcome = await withFetchStub(
+          // What a signed-out caller gets: the gate, never the dead app.
+          () =>
+            new Response(null, {
+              status: 302,
+              headers: { location: "https://veryfront.com/sign-in" },
+            }),
+          () =>
+            createDeployment(controlPlane).execute({
+              projectDir,
+              environment: "production",
+              mode: "apply",
+              source: { kind: "already-pushed" },
+            }, {
+              onEvent(event) {
+                events.push(event);
+              },
+            }),
+        );
+
+        assertEquals(outcome.kind, "deployed");
+        const warning = events.find((event) =>
+          event.kind === "warning" && event.code === "environment-url-unverified"
+        );
+        assertEquals(
+          warning?.kind === "warning" ? warning.code : "no warning emitted",
+          "environment-url-unverified",
+        );
+        assertStringIncludes(
+          warning?.kind === "warning" ? warning.message : "",
+          "https://my-project.production.veryfront.com/",
+        );
+        assertEquals(
+          outcome.kind === "deployed" ? outcome.result.urlVerification : undefined,
+          "gated",
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+  });
+
+  it("records the environment URL as served when the probe sees the app answer", async () => {
+    await withDeployEnv(async () => {
+      const { projectDir } = await createPushedProject();
+      const controlPlane = new InMemoryDeployControlPlane();
+      const events: DeployEvent[] = [];
+      try {
+        const outcome = await executeApply(projectDir, controlPlane, {
+          onEvent(event) {
+            events.push(event);
+          },
+        });
+
+        assertEquals(outcome.kind, "deployed");
+        assertEquals(
+          events.some((event) =>
+            event.kind === "warning" && event.code === "environment-url-unverified"
+          ),
+          false,
+        );
+        assertEquals(
+          outcome.kind === "deployed" ? outcome.result.urlVerification : undefined,
+          "served",
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+  });
+
   it("awaits async observer events before starting the next deployment step", async () => {
     await withDeployEnv(async () => {
       const { projectDir } = await createPushedProject();
@@ -772,6 +858,48 @@ describe("environment URL readiness", () => {
           apiToken: apiKeyToken,
         }),
     );
+  });
+
+  it("reports a gate challenge as gated, not as the app serving", async () => {
+    const readiness = await withMockFetch(
+      () =>
+        Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://veryfront.com/sign-in" },
+          }),
+        ),
+      () =>
+        waitForEnvironmentReady({
+          ...hostedTarget,
+          protected: true,
+          apiToken: apiKeyToken,
+        }),
+    );
+
+    assertEquals(readiness, {
+      kind: "gated",
+      url: "https://my-project.production.veryfront.com/",
+      status: 302,
+    });
+  });
+
+  it("reports a served response when the probe reaches the app itself", async () => {
+    const readiness = await withMockFetch(
+      () => Promise.resolve(new Response("ready")),
+      () => waitForEnvironmentReady(hostedTarget),
+    );
+
+    assertEquals(readiness, { kind: "served" });
+  });
+
+  it("reports an unprobed environment when there is no page route to check", async () => {
+    const readiness = await withMockFetch(
+      () => Promise.reject(new Error("readiness must not fetch without a route")),
+      () => waitForEnvironmentReady({ ...hostedTarget, route: null }),
+    );
+
+    assertEquals(readiness, { kind: "unprobed" });
   });
 
   it("classifies a rejected session credential as a deployment error", async () => {

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -102,7 +102,7 @@ export type DeployEvent =
   }
   | {
     kind: "warning";
-    code: "routing-convergence-unconfirmed";
+    code: "routing-convergence-unconfirmed" | "environment-url-unverified";
     message: string;
   };
 
@@ -987,10 +987,25 @@ async function cancelResponseBody(response: Response): Promise<void> {
   }
 }
 
+/**
+ * What the readiness step actually established about the environment URL.
+ *
+ * `served` is the only outcome in which the app itself was observed answering.
+ * A protected environment challenges an unauthenticated probe at the access
+ * gate, and this CLI cannot get past that gate holding an API key rather than a
+ * session, so `gated` means routing resolves and nothing more — the app behind
+ * it may be answering 503 to every signed-in visitor. Reporting the two the
+ * same way is what lets a broken deployment finish with a green tick.
+ */
+export type EnvironmentReadiness =
+  | Readonly<{ kind: "served" }>
+  | Readonly<{ kind: "unprobed" }>
+  | Readonly<{ kind: "gated"; url: string; status: number }>;
+
 export async function waitForEnvironmentReady(
   target: EnvironmentReadinessTarget,
   options: { pollIntervalMs?: number; timeoutMs?: number } = {},
-): Promise<void> {
+): Promise<EnvironmentReadiness> {
   const pollIntervalMs = options.pollIntervalMs === undefined ||
       !Number.isFinite(options.pollIntervalMs)
     ? DEFAULT_ENVIRONMENT_POLL_INTERVAL_MS
@@ -999,7 +1014,11 @@ export async function waitForEnvironmentReady(
     ? DEFAULT_ENVIRONMENT_TIMEOUT_MS
     : Math.max(1, Math.trunc(options.timeoutMs));
   const deadline = Date.now() + timeoutMs;
-  for (const probe of buildEnvironmentReadinessProbes(target)) {
+  const probes = buildEnvironmentReadinessProbes(target);
+  let servedBy: EnvironmentReadiness | null = null;
+  let gatedBy: EnvironmentReadiness | null = null;
+
+  for (const probe of probes) {
     const headers = new Headers({ "Cache-Control": "no-cache" });
     if (probe.authenticate) {
       headers.set("Cookie", `authToken=${target.apiToken}`);
@@ -1025,12 +1044,19 @@ export async function waitForEnvironmentReady(
         const authenticationChallenge = signInRedirect ||
           response.status === 401 ||
           response.status === 403;
-        const ready = response.status >= 200 && response.status < 300 ||
-          response.status >= 300 && response.status < 400 && !signInRedirect ||
-          probe.acceptAuthenticationChallenge && authenticationChallenge;
+        const served = response.status >= 200 && response.status < 300 ||
+          response.status >= 300 && response.status < 400 && !signInRedirect;
+        const gated = !served && probe.acceptAuthenticationChallenge && authenticationChallenge;
+        const ready = served || gated;
         await cancelResponseBody(response);
 
-        if (ready) break;
+        if (ready) {
+          if (served) servedBy = { kind: "served" };
+          else if (gated && !gatedBy) {
+            gatedBy = { kind: "gated", url: probe.url, status: response.status };
+          }
+          break;
+        }
         if (authenticationChallenge) {
           // A bare Error here reaches the operator as `unknown-error`.
           throw DEPLOYMENT_ERROR.create({
@@ -1059,6 +1085,27 @@ export async function waitForEnvironmentReady(
       await wait(Math.min(pollIntervalMs, remainingMs));
     }
   }
+
+  // Order matters: one probe seeing the app answer outweighs another that only
+  // reached the gate. With no probe at all — or, unreachably, a loop that
+  // neither broke nor threw — the honest answer is that nothing was checked,
+  // never that the app served.
+  if (servedBy) return servedBy;
+  if (gatedBy) return gatedBy;
+  return { kind: "unprobed" };
+}
+
+/**
+ * The signal a deploy owes an operator when it never saw the app answer.
+ *
+ * Failing here is wrong — the deployment is committed and verified, and a
+ * protected environment challenging an API key is the expected case for CI —
+ * but reporting it as a verified URL is what let a permanently-503 app deploy
+ * with a green tick and no signal at all.
+ */
+function getEnvironmentUrlWarning(readiness: EnvironmentReadiness): string | null {
+  if (readiness.kind !== "gated") return null;
+  return `Deployment committed, but ${readiness.url} was never observed serving this app: the access gate answered HTTP ${readiness.status} and this CLI has no session credential to probe past it. Open the URL signed in, or run veryfront login and deploy again, to confirm the app responds.`;
 }
 
 function getDeploymentRoutingConvergenceWarning(deployment: DeployDeployment): string | null {
@@ -1082,6 +1129,7 @@ function createDeployResult({
   environment,
   deployment,
   environmentUrl,
+  readiness,
   config,
   branch,
 }: {
@@ -1090,6 +1138,7 @@ function createDeployResult({
   environment: DeployEnvironment;
   deployment: DeployDeployment;
   environmentUrl: string;
+  readiness: EnvironmentReadiness;
   config: ResolvedConfig;
   branch: string;
 }): DeployResult {
@@ -1105,6 +1154,7 @@ function createDeployResult({
     environmentId: verification.environmentId,
     deploymentId: verification.deploymentId,
     url: environmentUrl,
+    urlVerification: readiness.kind,
     protected: environment.protected,
     routingConvergence: deployment.routingConvergence as DeploymentRoutingConvergence | undefined ??
       null,
@@ -1331,18 +1381,31 @@ export function createDeployProject(options: {
         buildEnvironmentUrl(verification.projectSlug, environment),
         readinessRoute,
       );
-      await step(observer, "wait-environment-url", async () =>
-        waitForEnvironmentReady({
-          projectSlug: verification.projectSlug,
-          environmentName: environment.name,
-          url: environmentUrl,
-          route: readinessRoute,
-          protected: environment.protected,
-          apiToken: config.apiToken,
-        }, {
-          pollIntervalMs: polling.environmentPollIntervalMs,
-          timeoutMs: polling.environmentTimeoutMs,
-        }));
+      const readiness = await step(
+        observer,
+        "wait-environment-url",
+        async () =>
+          waitForEnvironmentReady({
+            projectSlug: verification.projectSlug,
+            environmentName: environment.name,
+            url: environmentUrl,
+            route: readinessRoute,
+            protected: environment.protected,
+            apiToken: config.apiToken,
+          }, {
+            pollIntervalMs: polling.environmentPollIntervalMs,
+            timeoutMs: polling.environmentTimeoutMs,
+          }),
+      );
+
+      const urlWarning = getEnvironmentUrlWarning(readiness);
+      if (urlWarning) {
+        await emit(observer, {
+          kind: "warning",
+          code: "environment-url-unverified",
+          message: urlWarning,
+        });
+      }
 
       const warning = getDeploymentRoutingConvergenceWarning(deployment);
       if (warning) {
@@ -1361,6 +1424,7 @@ export function createDeployProject(options: {
           environment,
           deployment,
           environmentUrl,
+          readiness,
           config,
           branch,
         }),

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -993,7 +993,7 @@ async function cancelResponseBody(response: Response): Promise<void> {
  * `served` is the only outcome in which the app itself was observed answering.
  * A protected environment challenges an unauthenticated probe at the access
  * gate, and this CLI cannot get past that gate holding an API key rather than a
- * session, so `gated` means routing resolves and nothing more — the app behind
+ * session, so `gated` means routing resolves and nothing more: the app behind
  * it may be answering 503 to every signed-in visitor. Reporting the two the
  * same way is what lets a broken deployment finish with a green tick.
  */
@@ -1087,25 +1087,49 @@ export async function waitForEnvironmentReady(
   }
 
   // Order matters: one probe seeing the app answer outweighs another that only
-  // reached the gate. With no probe at all — or, unreachably, a loop that
-  // neither broke nor threw — the honest answer is that nothing was checked,
-  // never that the app served.
+  // reached the gate. With no probe at all, or, unreachably, a loop that neither
+  // broke nor threw, the honest answer is that nothing was checked, never that
+  // the app served.
   if (servedBy) return servedBy;
   if (gatedBy) return gatedBy;
   return { kind: "unprobed" };
 }
 
 /**
+ * The remedy that actually changes the probe credential for this token source.
+ *
+ * `veryfront login` only helps when nothing outranks the stored session.
+ * `resolveApiTokenForMode` in `cli/shared/config.ts` resolves a shell
+ * `VERYFRONT_API_TOKEN` and a `veryfront.json` `apiToken` ahead of the token
+ * store, so for those two sources signing in leaves the next deploy gated the
+ * same way. Naming the overriding key is the only step an operator can act on.
+ */
+function getProbeCredentialRemedy(source: ResolvedConfig["apiTokenSource"]): string {
+  if (source === "env") {
+    return "VERYFRONT_API_TOKEN is set in this shell and is resolved ahead of any stored session, so veryfront login does not change what the probe sends. Open the URL signed in, or unset that variable, run veryfront login, and deploy again, to confirm the app responds.";
+  }
+  if (source === "config-file") {
+    return "The apiToken in veryfront.json is resolved ahead of any stored session, so veryfront login does not change what the probe sends. Open the URL signed in, or remove that token, run veryfront login, and deploy again, to confirm the app responds.";
+  }
+  return "Open the URL signed in, or run veryfront login and deploy again, to confirm the app responds.";
+}
+
+/**
  * The signal a deploy owes an operator when it never saw the app answer.
  *
- * Failing here is wrong — the deployment is committed and verified, and a
- * protected environment challenging an API key is the expected case for CI —
- * but reporting it as a verified URL is what let a permanently-503 app deploy
- * with a green tick and no signal at all.
+ * Failing here is wrong, because the deployment is committed and verified, and
+ * a protected environment challenging an API key is the expected case for CI.
+ * Reporting it as a verified URL is what let a permanently-503 app deploy with
+ * a green tick and no signal at all.
  */
-function getEnvironmentUrlWarning(readiness: EnvironmentReadiness): string | null {
+function getEnvironmentUrlWarning(
+  readiness: EnvironmentReadiness,
+  apiTokenSource: ResolvedConfig["apiTokenSource"],
+): string | null {
   if (readiness.kind !== "gated") return null;
-  return `Deployment committed, but ${readiness.url} was never observed serving this app: the access gate answered HTTP ${readiness.status} and this CLI has no session credential to probe past it. Open the URL signed in, or run veryfront login and deploy again, to confirm the app responds.`;
+  return `Deployment committed, but ${readiness.url} was never observed serving this app: the access gate answered HTTP ${readiness.status} and this CLI has no session credential to probe past it. ${
+    getProbeCredentialRemedy(apiTokenSource)
+  }`;
 }
 
 function getDeploymentRoutingConvergenceWarning(deployment: DeployDeployment): string | null {
@@ -1398,7 +1422,7 @@ export function createDeployProject(options: {
           }),
       );
 
-      const urlWarning = getEnvironmentUrlWarning(readiness);
+      const urlWarning = getEnvironmentUrlWarning(readiness, config.apiTokenSource);
       if (urlWarning) {
         await emit(observer, {
           kind: "warning",

--- a/cli/shared/deployment/result.ts
+++ b/cli/shared/deployment/result.ts
@@ -12,6 +12,15 @@ export interface DeployResult {
   environmentId: string;
   deploymentId: string;
   url: string;
+  /**
+   * What the readiness step established about {@link DeployResult.url}.
+   *
+   * `served` means the probe saw the app answer. `gated` means only the access
+   * gate answered, so the app behind it was never observed — a machine-readable
+   * form of the `environment-url-unverified` warning, for CI that needs to fail
+   * on it. `unprobed` means the project has no page route to check.
+   */
+  urlVerification: "served" | "gated" | "unprobed";
   protected: boolean;
   routingConvergence: DeploymentRoutingConvergence | null;
   commitSha: string | null;

--- a/cli/shared/deployment/result.ts
+++ b/cli/shared/deployment/result.ts
@@ -16,9 +16,10 @@ export interface DeployResult {
    * What the readiness step established about {@link DeployResult.url}.
    *
    * `served` means the probe saw the app answer. `gated` means only the access
-   * gate answered, so the app behind it was never observed — a machine-readable
-   * form of the `environment-url-unverified` warning, for CI that needs to fail
-   * on it. `unprobed` means the project has no page route to check.
+   * gate answered, so the app behind it was never observed. That value is the
+   * machine-readable form of the `environment-url-unverified` warning, for CI
+   * that needs to fail on it. `unprobed` means the project has no page route to
+   * check.
    */
   urlVerification: "served" | "gated" | "unprobed";
   protected: boolean;

--- a/cli/test-utils/deploy-test-support.ts
+++ b/cli/test-utils/deploy-test-support.ts
@@ -201,6 +201,8 @@ export class InMemoryDeployControlPlane implements DeployControlPlane {
   readonly projectLookups: string[] = [];
   getProjectError: unknown;
   environment: DeployEnvironment | null | undefined;
+  /** Whether the default environment sits behind the platform access gate. */
+  environmentProtected = false;
   releaseVersion: string | null = "2026.07.30-1";
   releaseProjectId = PROJECT_ID;
   releaseFiles: DeployReleaseFile[] = [
@@ -227,7 +229,7 @@ export class InMemoryDeployControlPlane implements DeployControlPlane {
     return {
       id: ENVIRONMENT_ID,
       name,
-      protected: false,
+      protected: this.environmentProtected,
       projectId: PROJECT_ID,
       deployment: this.deploymentReadCount > 0 && this.deployment && this.release
         ? {

--- a/docs/api-reference/veryfront/security.md
+++ b/docs/api-reference/veryfront/security.md
@@ -94,7 +94,7 @@ applySecurityHeaders(response.headers, false, generateNonce(), null);
 
 | Name                   | Description | Source                                                                                                     |
 | ---------------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
-| `AuthHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/auth.ts#L160)             |
+| `AuthHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/auth.ts#L161)             |
 | `BaseHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/base-handler.ts#L45)      |
 | `CsrfHandler`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/csrf/csrf-handler.ts#L60) |
 | `ResponseBuilder`      |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/http/response/builder.ts#L9)   |

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -97,9 +97,28 @@ session token and has no API-key branch, so an API key presented to it resolves
 to no user and draws the same sign-in redirect an anonymous request gets.
 `veryfront deploy` acts on that distinction instead of leaking the key: it sends
 the stored credential to a protected environment only when that credential is a
-session token, and otherwise probes anonymously and accepts the challenge as
-proof the environment is serving. Its readiness probe counts a sign-in redirect,
-a `401`, and a `403` alike as that challenge.
+session token, and otherwise probes anonymously. Its readiness probe counts a
+sign-in redirect, a `401`, and a `403` alike as that challenge.
+
+A challenge proves routing resolves to the environment and nothing about the app
+behind the gate, so deploy does not report it as proof the app is serving. The
+deploy still succeeds, because the deployment is already committed and verified,
+and it prints a warning naming the URL it never observed serving. In `--json`
+mode that warning arrives as
+`{"type":"warning","code":"environment-url-unverified"}`, and the result carries
+a `urlVerification` field:
+
+| Value      | Meaning                                                     |
+| ---------- | ----------------------------------------------------------- |
+| `served`   | The probe saw the app itself answer.                        |
+| `gated`    | Only the access gate answered, so the app was not observed. |
+| `unprobed` | The project has no static page route to check.              |
+
+A CI job that must fail on an unverified URL can key on `gated`. Signing in
+changes what the probe sends only when nothing outranks the stored session: a
+`VERYFRONT_API_TOKEN` in the shell and an `apiToken` in `veryfront.json` are both
+resolved ahead of it, so remove the overriding key before running
+`veryfront login`.
 
 A non-browser client can still authenticate. The gate inspects the cookie, not
 the client, so `curl`, a CI smoke test, or an uptime monitor reaches a protected

--- a/src/security/http/auth.ts
+++ b/src/security/http/auth.ts
@@ -1,4 +1,5 @@
 import { isCspReportRequest } from "#veryfront/security/http/csp-report-endpoint.ts";
+import { isPlatformLivenessProbe } from "#veryfront/security/http/platform-liveness-probe.ts";
 import {
   isSignedChannelDispatch,
   isSignedControlPlaneDispatch,
@@ -167,10 +168,23 @@ export class AuthHandler extends BaseHandler {
   handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     if (req.method.toUpperCase() === "OPTIONS") return Promise.resolve(this.continue());
 
+    const pathname = new URL(req.url).pathname;
+
+    // The orchestrator's own liveness and readiness probes are not site
+    // visitors, and a project that gates them takes its site offline rather
+    // than protecting it. See `isPlatformLivenessProbe` for why exempting them
+    // discloses nothing.
+    //
+    // This sits ahead of `resolveAuth` for the same reason the CSP report
+    // exemption does: an auth config the runtime cannot resolve still fails
+    // closed for every browser request, but a project's config typo must not
+    // fail the readiness probe and pull the pod out of service.
+    if (isPlatformLivenessProbe(req.method, pathname)) return Promise.resolve(this.continue());
+
     // Same reasoning as the CSRF gate: a browser reports a violation without
     // credentials, so a protected project would collect nothing. See
     // `isCspReportRequest` for why exempting it discloses nothing.
-    if (isCspReportRequest(req.method, new URL(req.url).pathname)) {
+    if (isCspReportRequest(req.method, pathname)) {
       return Promise.resolve(this.continue());
     }
 

--- a/src/security/http/platform-liveness-probe.ts
+++ b/src/security/http/platform-liveness-probe.ts
@@ -25,7 +25,7 @@ const PROBE_PATHS = new Set(PLATFORM_LIVENESS_PROBE_PATHS);
  * sends no `Authorization` header and there is nowhere to hand it a per-project
  * secret. Left alone, a project that sets `security.auth` fails its own
  * readiness probe, the Service drops its only endpoint, and the ingress answers
- * every visitor with a bodiless 503 — while the liveness failures restart the
+ * every visitor with a bodiless 503, while the liveness failures restart the
  * container underneath. The gate the project asked for takes its site offline
  * instead of protecting it, and nothing in the response names auth. Local
  * `veryfront dev` never shows it: the dev server answers both paths ahead of
@@ -33,7 +33,7 @@ const PROBE_PATHS = new Set(PLATFORM_LIVENESS_PROBE_PATHS);
  *
  * Exempting them discloses nothing the gate exists to protect. `HealthHandler`
  * owns both paths as exact patterns, so a project route can never be what
- * answers here, and what it returns is fixed platform text — `{"service":
+ * answers here, and what it returns is fixed platform text: `{"service":
  * "veryfront-server","status":"ok"}` and `ready`/`not-ready`. No project
  * content, no configuration, no credential. `/_health`, which reports the
  * runtime version and build mode and which nothing in the platform probes,

--- a/src/security/http/platform-liveness-probe.ts
+++ b/src/security/http/platform-liveness-probe.ts
@@ -1,0 +1,48 @@
+/**
+ * The platform's own liveness and readiness probes.
+ *
+ * The paths are declared here, on the side both the security gates and the
+ * monitoring handler can depend on, because the two have to agree. The
+ * orchestrator's HTTP probes are the only caller: the operator gives every
+ * project server a `readinessProbe` on `/readyz` and a `livenessProbe` plus
+ * `startupProbe` on `/healthz`.
+ *
+ * @module security/http/platform-liveness-probe
+ */
+
+/** Paths the orchestrator probes over HTTP, exactly as the operator declares them. */
+export const PLATFORM_LIVENESS_PROBE_PATHS: readonly string[] = Object.freeze([
+  "/healthz",
+  "/readyz",
+]);
+
+const PROBE_PATHS = new Set(PLATFORM_LIVENESS_PROBE_PATHS);
+
+/**
+ * Whether a request is one of the orchestrator's HTTP probes.
+ *
+ * The auth gate runs ahead of every handler and refuses these: a kubelet probe
+ * sends no `Authorization` header and there is nowhere to hand it a per-project
+ * secret. Left alone, a project that sets `security.auth` fails its own
+ * readiness probe, the Service drops its only endpoint, and the ingress answers
+ * every visitor with a bodiless 503 — while the liveness failures restart the
+ * container underneath. The gate the project asked for takes its site offline
+ * instead of protecting it, and nothing in the response names auth. Local
+ * `veryfront dev` never shows it: the dev server answers both paths ahead of
+ * the handler registry.
+ *
+ * Exempting them discloses nothing the gate exists to protect. `HealthHandler`
+ * owns both paths as exact patterns, so a project route can never be what
+ * answers here, and what it returns is fixed platform text — `{"service":
+ * "veryfront-server","status":"ok"}` and `ready`/`not-ready`. No project
+ * content, no configuration, no credential. `/_health`, which reports the
+ * runtime version and build mode and which nothing in the platform probes,
+ * keeps its gate.
+ *
+ * Only GET and HEAD are exempt, the methods a probe uses; any other method on
+ * these paths is a site visitor and stays gated.
+ */
+export function isPlatformLivenessProbe(method: string, pathname: string): boolean {
+  const verb = method.toUpperCase();
+  return (verb === "GET" || verb === "HEAD") && PROBE_PATHS.has(pathname);
+}

--- a/src/server/runtime-handler/monitoring-probe-auth.test.ts
+++ b/src/server/runtime-handler/monitoring-probe-auth.test.ts
@@ -1,0 +1,140 @@
+import "#veryfront/schemas/_test-setup.ts";
+/**
+ * The platform's own liveness/readiness probes must survive a project's
+ * `security.auth` gate.
+ *
+ * `AuthHandler` runs at priority 0 with `patterns: []`, so it sees every
+ * request the registry executes — including the monitoring fast path in
+ * `runtime-handler/index.ts`, which calls `registry.execute` with a context
+ * carrying the project's `securityConfig`. The caller on that path is a kubelet
+ * HTTP probe (operator `k8s-resources.ts`: readinessProbe GET /readyz,
+ * livenessProbe + startupProbe GET /healthz). A kubelet probe sends no
+ * `Authorization` header and cannot be handed a per-project secret.
+ *
+ * If the gate answers those probes with 401, the pod never becomes Ready, the
+ * Service drops its only endpoint and the ingress answers every visitor request
+ * with a bodiless 503 — while the liveness failures restart the container in a
+ * loop. Local `veryfront dev` never shows this because the dev server answers
+ * /healthz and /readyz ahead of the handler registry.
+ *
+ * @module server/runtime-handler/monitoring-probe-auth.test
+ */
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { SecurityConfig } from "#veryfront/types";
+import { createHandlerRegistry } from "./index.ts";
+import { buildMinimalContext } from "./handler-context-builder.ts";
+import { setServerInitialized } from "#veryfront/server/handlers/monitoring/health.handler.ts";
+import { isMonitoringPath } from "./request-utils.ts";
+
+/** Kubelet probe paths, exactly as the operator manifest declares them. */
+const KUBELET_PROBE_PATHS = ["/healthz", "/readyz"] as const;
+
+/** Adapter whose project dir exists, so /readyz can answer "ready". */
+function createAdapter(env: Record<string, string> = {}): RuntimeAdapter {
+  return {
+    id: "test",
+    name: "test",
+    capabilities: {},
+    fs: {
+      stat: (_path: string) => Promise.resolve({ isDirectory: true, isFile: false }),
+    },
+    env: {
+      get: (key: string) => env[key],
+      set: () => {},
+      delete: () => {},
+      has: (key: string) => key in env,
+      toObject: () => ({ ...env }),
+    },
+    server: {},
+    serve: () => Promise.resolve({ close: () => Promise.resolve() }),
+  } as unknown as RuntimeAdapter;
+}
+
+/** Replays the monitoring fast path from `runtime-handler/index.ts`. */
+async function probe(
+  pathname: string,
+  securityConfig: SecurityConfig | null,
+  env: Record<string, string> = {},
+): Promise<Response> {
+  assertEquals(isMonitoringPath(pathname), true, `${pathname} must take the monitoring fast path`);
+
+  const projectDir = "/tmp/monitoring-probe-auth";
+  const adapter = createAdapter(env);
+  const { registry } = createHandlerRegistry(projectDir, adapter);
+  const ctx = buildMinimalContext(projectDir, adapter, securityConfig, false, undefined);
+
+  // A kubelet probe: bare GET, no Authorization header, no cookies.
+  const req = new Request(`http://10.42.0.17:3001${pathname}`, { method: "GET" });
+  const response = await registry.execute(req, ctx);
+  return response ?? new Response("Not Found", { status: 404 });
+}
+
+async function assertProbesAnswerOk(
+  securityConfig: SecurityConfig | null,
+  env: Record<string, string> = {},
+): Promise<void> {
+  setServerInitialized(true);
+  try {
+    for (const path of KUBELET_PROBE_PATHS) {
+      const res = await probe(path, securityConfig, env);
+      const challenge = res.headers.get("WWW-Authenticate") ?? "";
+      await res.body?.cancel();
+      assertEquals(
+        res.status,
+        200,
+        `${path} must stay reachable for the kubelet probe (got ${res.status}${
+          challenge ? ` WWW-Authenticate: ${challenge}` : ""
+        })`,
+      );
+    }
+  } finally {
+    setServerInitialized(false);
+  }
+}
+
+const BASIC_AUTH = { auth: { basic: { username: "admin", password: "s3cret" } } } as SecurityConfig;
+const BEARER_AUTH = { auth: { bearer: { token: "project-secret" } } } as SecurityConfig;
+const MALFORMED_AUTH = { auth: { basic: {} } } as unknown as SecurityConfig;
+
+describe("kubelet probes vs the project auth gate", () => {
+  it("answer 200 with no auth configured", async () => {
+    await assertProbesAnswerOk(null);
+  });
+
+  it("answer 200 when the project configures security.auth.basic", async () => {
+    await assertProbesAnswerOk(BASIC_AUTH);
+  });
+
+  it("answer 200 when the project configures security.auth.bearer", async () => {
+    await assertProbesAnswerOk(BEARER_AUTH);
+  });
+
+  it("answer 200 when security.auth is malformed and fails closed", async () => {
+    await assertProbesAnswerOk(MALFORMED_AUTH);
+  });
+
+  it("answer 200 when the auth gate comes from VERYFRONT_BASIC_USER/PASS", async () => {
+    await assertProbesAnswerOk(null, {
+      VERYFRONT_BASIC_USER: "ops",
+      VERYFRONT_BASIC_PASS: "s3cret",
+    });
+  });
+
+  it("answer 200 when the auth gate comes from VERYFRONT_BEARER_TOKEN", async () => {
+    await assertProbesAnswerOk(null, { VERYFRONT_BEARER_TOKEN: "vf_probe_token" });
+  });
+
+  it("keeps gating a project page while basic auth is configured", async () => {
+    const projectDir = "/tmp/monitoring-probe-auth";
+    const adapter = createAdapter();
+    const ctx = buildMinimalContext(projectDir, adapter, BASIC_AUTH, false, undefined);
+    const { registry } = createHandlerRegistry(projectDir, adapter);
+    const res = await registry.execute(new Request("http://site.example/"), ctx);
+    await res?.body?.cancel();
+    assertEquals(res?.status, 401);
+    assertEquals(res?.headers.get("WWW-Authenticate"), 'Basic realm="Secure Area"');
+  });
+});

--- a/src/server/runtime-handler/monitoring-probe-auth.test.ts
+++ b/src/server/runtime-handler/monitoring-probe-auth.test.ts
@@ -4,7 +4,7 @@ import "#veryfront/schemas/_test-setup.ts";
  * `security.auth` gate.
  *
  * `AuthHandler` runs at priority 0 with `patterns: []`, so it sees every
- * request the registry executes — including the monitoring fast path in
+ * request the registry executes, including the monitoring fast path in
  * `runtime-handler/index.ts`, which calls `registry.execute` with a context
  * carrying the project's `securityConfig`. The caller on that path is a kubelet
  * HTTP probe (operator `k8s-resources.ts`: readinessProbe GET /readyz,
@@ -13,7 +13,7 @@ import "#veryfront/schemas/_test-setup.ts";
  *
  * If the gate answers those probes with 401, the pod never becomes Ready, the
  * Service drops its only endpoint and the ingress answers every visitor request
- * with a bodiless 503 — while the liveness failures restart the container in a
+ * with a bodiless 503, while the liveness failures restart the container in a
  * loop. Local `veryfront dev` never shows this because the dev server answers
  * /healthz and /readyz ahead of the handler registry.
  *


### PR DESCRIPTION
## What broke

A project that sets `security.auth` (basic or bearer) deploys successfully and then answers **503 to every request**, root document included, in both production and preview. No body, no `401` challenge. The same config serves correctly under local `veryfront dev`.

## Why

`AuthHandler` is registered at priority 0 with `patterns: []`, so it sees every request the handler registry executes. That includes the monitoring fast path in `server/runtime-handler/index.ts`, which calls `registry.execute` with a context carrying the project's `securityConfig` — and `AuthHandler` sorts ahead of `HealthHandler`.

The caller on that path is a kubelet HTTP probe. The operator gives every project server a `readinessProbe` on `/readyz` and a `livenessProbe` plus `startupProbe` on `/healthz`. A kubelet probe sends no `Authorization` header and there is nowhere to hand it a per-project secret, so the gate answered all three with `401`:

- readiness fails → the pod never becomes Ready → the Service drops its only endpoint → the ingress answers every visitor with a bodiless `503`;
- liveness fails → the container restarts underneath, indefinitely.

The gate the project asked for takes its site offline instead of protecting it, and nothing in the response names auth.

Local `veryfront dev` never shows this: `server/dev-server/request-handler.ts` answers `/healthz` and `/readyz` ahead of the handler registry, so the probes there never meet the gate. That is the whole of the local-vs-deployed divergence.

This is a framework defect, not an environment one.

## Fix 1 — the runtime

New `security/http/platform-liveness-probe.ts`, mirroring the existing `csp-report-endpoint.ts` exemption seam, exempts `GET`/`HEAD` on `/healthz` and `/readyz` — exactly the paths the operator probes.

It discloses nothing the gate exists to protect. `HealthHandler` owns both paths as **exact** patterns, so a project route can never be what answers there, and what it returns is fixed platform text (`{"service":"veryfront-server","status":"ok"}` and `ready`/`not-ready`) — no project content, no configuration, no credential. `/_health`, which reports the runtime version and build mode and which nothing in the platform probes, keeps its gate. Any method other than GET/HEAD on those paths is a site visitor and stays gated.

The auth gate was the only one blocking the probes: CSRF already exempts safe methods, and project `middleware.ts` runs well past the monitoring fast path.

## Fix 2 — the deploy verification blind spot

Independent defect, and the reason the operator got no signal at all: `veryfront deploy` reported SUCCESS, and its "Verifying production URL" step passed, against the permanently-503 app.

A protected environment challenges an unauthenticated probe at the platform access gate, and the CLI deliberately withholds an API key from that gate (it reads a session JWT's `userId` and has no API-key branch). So the readiness step saw only the gate's `302` and treated it as a verified URL — the app behind the gate was never observed at all.

Failing the step outright would break every protected deploy from CI, where an API key is the norm, and the deployment at that point is already committed and verified. So instead the step now reports **what it established**:

- `waitForEnvironmentReady` returns `served` | `gated` | `unprobed`;
- `gated` raises an `environment-url-unverified` warning naming the URL and the gate status;
- `urlVerification` lands in the deploy result, so JSON consumers and CI can fail on it.

The human renderer also **collects** warnings rather than overwriting a single slot — otherwise the new URL warning would be silently clobbered by the routing-convergence one.

## Tests

TDD, red first.

`src/server/runtime-handler/monitoring-probe-auth.test.ts` replays the monitoring fast path over the full registry. Before the fix:

```
kubelet probes vs the project auth gate ... answer 200 when the project configures security.auth.basic
error: AssertionError: /healthz must stay reachable for the kubelet probe
       (got 401 WWW-Authenticate: Basic realm="Secure Area")
-   401
+   200

FAILED | 0 passed (2 steps) | 1 failed (5 steps)
```

Covers `security.auth.basic`, `security.auth.bearer`, a malformed auth config that fails closed, and the `VERYFRONT_BASIC_USER`/`PASS` and `VERYFRONT_BEARER_TOKEN` env forms — plus an assertion that an ordinary project page still gets its `401` challenge.

`cli/shared/deployment/deploy-project.test.ts` covers fix 2. Before:

```
DeployProject ... warns that the environment URL was never observed serving behind its gate
-   no warning emitted
+   environment-url-unverified

environment URL readiness ... reports a gate challenge as gated, not as the app serving
+   { kind: "gated", status: 302, url: "https://my-project.production.veryfront.com/" }
-   undefined
```

After: green, and the full unit suite passes — `ok | 3805 passed (28411 steps) | 0 failed`.

## Not covered here

The cloud A/B/A was reproduced by the reporter, not re-run here; this branch reproduces the mechanism in-process instead. Confirming the deployed fix still wants one A/B/A against a cloud project once a build carrying this lands.
