### PR TITLE
fix(platform): construct NodeCompatibleFileSystemAdapter safely when node:fs constants are absent

### DIFF
--- a/src/platform/adapters/runtime/shared/node-filesystem-adapter.test.ts
+++ b/src/platform/adapters/runtime/shared/node-filesystem-adapter.test.ts
@@ -12,6 +12,7 @@ import {
   hasUsableWindowsSnapshotIdentity,
   NodeCompatibleFileSystemAdapter,
   readNodeFileSnapshotWithinLimit,
+  resolveNoFollowFlag,
 } from "./node-filesystem-adapter.ts";
 import { setupNodeFsWatcher } from "./shared-watcher.ts";
 
@@ -39,7 +40,40 @@ function requireExclusiveCreator(adapter: NodeCompatibleFileSystemAdapter) {
   return adapter.createFileBytesExclusive;
 }
 
+describe("resolveNoFollowFlag", () => {
+  it("does not throw when node:fs constants are unavailable (#3661)", () => {
+    // In a browser bundle `nodeFsConstants` is `undefined`. Reading `.O_NOFOLLOW`
+    // off it must degrade to "unavailable", not throw at construction. Passing
+    // `undefined` for `constants` reproduces the non-Node runtime directly.
+    assertEquals(resolveNoFollowFlag({}, undefined), undefined);
+  });
+
+  it("returns the runtime O_NOFOLLOW when the constants are present", () => {
+    assertEquals(resolveNoFollowFlag({}, { O_NOFOLLOW: 0x20000 }), 0x20000);
+  });
+
+  it("lets an own noFollow option win over the runtime constants (test seam)", () => {
+    assertEquals(resolveNoFollowFlag({ noFollow: 7 }, { O_NOFOLLOW: 0x20000 }), 7);
+    // An own `undefined` means "unavailable" even when constants exist.
+    assertEquals(resolveNoFollowFlag({ noFollow: undefined }, { O_NOFOLLOW: 0x20000 }), undefined);
+  });
+});
+
 describe("NodeCompatibleFileSystemAdapter", () => {
+  it("constructs without exact-snapshot support when node:fs constants are absent (#3661)", () => {
+    // Reproduce the browser path end to end: no runtime O_NOFOLLOW available, so
+    // the adapter must construct (not throw) and simply cannot bind an exact
+    // inode snapshot. `noFollow: undefined` is the documented "unavailable" seam.
+    const adapter = new NodeCompatibleFileSystemAdapter(undefined, {
+      noFollow: undefined,
+      platform: "posix",
+    });
+    assertEquals(
+      (adapter as { readFileSnapshotWithinLimit?: unknown }).readFileSnapshotWithinLimit,
+      undefined,
+    );
+  });
+
   it("reads empty and exact-limit snapshots and rejects invalid or oversized inputs", async () => {
     const root = await Deno.makeTempDir({ prefix: "veryfront-node-snapshot-" });
     try {

--- a/src/platform/adapters/runtime/shared/node-filesystem-adapter.ts
+++ b/src/platform/adapters/runtime/shared/node-filesystem-adapter.ts
@@ -409,7 +409,12 @@ export class NodeCompatibleFileSystemAdapter implements FileSystemAdapter {
       ...nodeFileSystemOperations,
       ...options.operations,
     } as NodeFileSystemOperations;
-    const noFollow = hasOwn(options, "noFollow") ? options.noFollow : nodeFsConstants.O_NOFOLLOW;
+    // `node:fs` constants are absent in non-Node runtimes (e.g. a browser bundle
+    // that transitively pulls this adapter in). Treat that as "unavailable" —
+    // matching NodeFileSystemCapabilityOptions.noFollow's documented contract —
+    // instead of throwing `Cannot read properties of undefined (reading 'O_NOFOLLOW')`
+    // at construction, which kills client hydration (#3661).
+    const noFollow = hasOwn(options, "noFollow") ? options.noFollow : nodeFsConstants?.O_NOFOLLOW;
     const platform = options.platform ?? (runtimeUsesWindowsPaths() ? "windows" : "posix");
     const canOpenExactSnapshot = platform === "windows"
       ? hasUsableWindowsSnapshotIdentity(detectNodeCompatibleRuntime())

--- a/src/platform/adapters/runtime/shared/node-filesystem-adapter.ts
+++ b/src/platform/adapters/runtime/shared/node-filesystem-adapter.ts
@@ -397,6 +397,25 @@ async function createNodeFileBytesExclusive(
 }
 
 /**
+ * Resolve the `O_NOFOLLOW` open flag that binds an exact-inode snapshot read.
+ *
+ * `constants` is `undefined` in a runtime without `node:fs` — e.g. a browser
+ * bundle that transitively imports this adapter. Dereferencing `.O_NOFOLLOW` on
+ * it unconditionally threw `Cannot read properties of undefined (reading
+ * 'O_NOFOLLOW')` during construction and aborted client hydration (#3661).
+ * Treat the missing constants as "unavailable" (`undefined`) — the same meaning
+ * {@link NodeFileSystemCapabilityOptions.noFollow} already documents for an own
+ * `undefined` — so `canOpenExactSnapshot` degrades to `false` instead of the
+ * constructor exploding. An own `noFollow` on `options` still wins (the test seam).
+ */
+export function resolveNoFollowFlag(
+  options: NodeFileSystemCapabilityOptions,
+  constants: { readonly O_NOFOLLOW?: number } | undefined,
+): number | undefined {
+  return hasOwn(options, "noFollow") ? options.noFollow : constants?.O_NOFOLLOW;
+}
+
+/**
  * Filesystem implementation shared by runtimes that provide Node-compatible
  * `node:fs` APIs (currently Node.js and Bun).
  */
@@ -409,12 +428,7 @@ export class NodeCompatibleFileSystemAdapter implements FileSystemAdapter {
       ...nodeFileSystemOperations,
       ...options.operations,
     } as NodeFileSystemOperations;
-    // `node:fs` constants are absent in non-Node runtimes (e.g. a browser bundle
-    // that transitively pulls this adapter in). Treat that as "unavailable" —
-    // matching NodeFileSystemCapabilityOptions.noFollow's documented contract —
-    // instead of throwing `Cannot read properties of undefined (reading 'O_NOFOLLOW')`
-    // at construction, which kills client hydration (#3661).
-    const noFollow = hasOwn(options, "noFollow") ? options.noFollow : nodeFsConstants?.O_NOFOLLOW;
+    const noFollow = resolveNoFollowFlag(options, nodeFsConstants);
     const platform = options.platform ?? (runtimeUsesWindowsPaths() ? "windows" : "posix");
     const canOpenExactSnapshot = platform === "windows"
       ? hasUsableWindowsSnapshotIdentity(detectNodeCompatibleRuntime())


### PR DESCRIPTION
## Bug

`NodeCompatibleFileSystemAdapter`'s constructor reads a `node:fs` constant unconditionally:

```ts
const noFollow = hasOwn(options, "noFollow") ? options.noFollow : nodeFsConstants.O_NOFOLLOW;
```

In a non-Node runtime (e.g. a **browser** bundle that transitively imports this adapter), `nodeFsConstants` is `undefined`, so **construction throws**:

```
TypeError: Cannot read properties of undefined (reading 'O_NOFOLLOW')
    at new NodeCompatibleFileSystemAdapter (…/node-filesystem-adapter.js)
    at new DenoFileSystemAdapter (…/deno/filesystem-adapter.js)
    at new DenoAdapter (…/deno/adapter.js)
```

…which aborts client hydration.

## Issue

Surfaced by #3661 (a client-tree route that value-imports a server helper drags the runtime adapter graph into the browser bundle). Whether or not that leak should happen, the adapter constructor should not *crash* when `node:fs` constants are unavailable — the code already models this: `NodeFileSystemCapabilityOptions.noFollow` is documented as *"An own undefined value means unavailable."*

## Reproduction

Against this repo's source via LOCALDEV, `pages-server-import-leak/vector-a` in [mattboon/veryfront-router-testing](https://github.com/mattboon/veryfront-router-testing):

```bash
cd pages-server-import-leak
deno run --allow-all <veryfront-code>/cli/main.ts dev --port 3025
# open http://127.0.0.1:3025/vector-a → console shows the O_NOFOLLOW TypeError, hydration aborts
```

## Fix

Optional-chain the constant deref, matching the documented "undefined means unavailable" contract. When absent, `noFollow` is `undefined` → `canOpenExactSnapshot` is `false` (correct in a browser), and the constructor no longer throws.

```diff
-    const noFollow = hasOwn(options, "noFollow") ? options.noFollow : nodeFsConstants.O_NOFOLLOW;
+    const noFollow = hasOwn(options, "noFollow")
+      ? options.noFollow
+      : nodeFsConstants?.O_NOFOLLOW;
```

## Validation

`deno test src/platform/adapters/runtime/shared/node-filesystem-adapter.test.ts` → **1 passed (37 steps), 0 failed.**

Defense-in-depth only: the deeper server→client leak that pulls this adapter into the browser at all is tracked separately in #3661.

Refs #3661.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with runtimes where certain filesystem options are unavailable.
  * Prevented initialization errors in environments that do not provide the optional filesystem constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->