### PR TITLE
fix(client): keep the server runtime adapters out of the index.client barrel (#3661)

### DIFF
--- a/src/index.client.boundary.test.ts
+++ b/src/index.client.boundary.test.ts
@@ -1,4 +1,7 @@
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { readTextFile } from "#veryfront/platform/compat/fs.ts";
+import { fromFileUrl } from "#veryfront/platform/compat/path/index.ts";
 
 /**
  * `src/index.client.ts` is the browser/SSR-safe mirror of the `veryfront` root
@@ -12,10 +15,18 @@ import { assert, assertEquals } from "#veryfront/testing/assert.ts";
  * that actually ships — dynamic `import()` is lazy and legitimately used by the
  * adapter registry, and `import type` is erased) and fails if it reaches any
  * server-only runtime module. Paths are resolved through `import.meta.url`, not
- * the cwd, so the check is location-independent.
+ * the cwd, so the check is location-independent, and read through
+ * `#veryfront/platform/compat/fs.ts` rather than a runtime global so the guard
+ * runs on all three runtimes — the Node and Bun runners skip any test file whose
+ * source names a runtime-global member of `Deno` (see `isDenoDependentTest` in
+ * `tests/node/run-tests.mjs`), so a direct global read here would silently
+ * narrow this regression to Deno alone.
  */
 
 const REPO_ROOT = new URL("../", import.meta.url);
+
+const readRepoFile = (path: string): Promise<string> =>
+  readTextFile(fromFileUrl(new URL(path, REPO_ROOT)));
 
 /**
  * The runtime adapter graph behind the #3661 crash: constructing any of these
@@ -40,7 +51,7 @@ let cachedImportMap: Record<string, string> | null = null;
 
 async function loadImportMap(): Promise<Record<string, string>> {
   if (cachedImportMap) return cachedImportMap;
-  const denoJson = JSON.parse(await Deno.readTextFile(new URL("deno.json", REPO_ROOT)));
+  const denoJson = JSON.parse(await readRepoFile("deno.json"));
   cachedImportMap = (denoJson.imports ?? {}) as Record<string, string>;
   return cachedImportMap;
 }
@@ -71,7 +82,18 @@ function resolveToRepoPath(
       if (matches && key.length > bestKey.length) bestKey = key;
     }
     const mapped = map[bestKey];
-    if (!mapped) return null;
+    // A `#` specifier no import-map key covers cannot be walked. Returning null
+    // here would drop the edge *and* everything behind it, so a key rename would
+    // quietly turn this guard green while the leak survived — fail instead.
+    if (!mapped) {
+      throw new Error(
+        `unresolved import-map specifier "${spec}" (imported by ${fromPath}): ` +
+          `the client import graph cannot be verified`,
+      );
+    }
+    // Keys that map to an external target (`#std/*` → `jsr:@std/*`) have no
+    // source-tree path to walk.
+    if (/^(?:npm|jsr|node|https?):/.test(mapped)) return null;
     const target = mapped.replace(/^\.\//, "");
     return normalize(target + spec.slice(bestKey.length));
   }
@@ -95,7 +117,7 @@ async function readModule(repoPath: string): Promise<{ path: string; source: str
     : [repoPath + ".ts", repoPath + ".tsx", repoPath + "/index.ts", repoPath + "/index.tsx"];
   for (const candidate of candidates) {
     try {
-      const source = await Deno.readTextFile(new URL(candidate, REPO_ROOT));
+      const source = await readRepoFile(candidate);
       return { path: candidate, source };
     } catch {
       // try the next extension form
@@ -129,32 +151,34 @@ async function collectStaticGraph(entry: string): Promise<Map<string, string | n
   return reached;
 }
 
-Deno.test("index.client barrel never statically reaches a server runtime adapter (#3661)", async () => {
-  const graph = await collectStaticGraph("src/index.client.ts");
+describe("index.client static import boundary", () => {
+  it("never statically reaches a server runtime adapter (#3661)", async () => {
+    const graph = await collectStaticGraph("src/index.client.ts");
 
-  // Sanity: the walk actually resolved the barrel and its neighbourhood.
-  assert(graph.has("src/index.client.ts"), "entry module was not read");
-  assert(graph.size > 10, `expected a non-trivial graph, got ${graph.size} modules`);
+    // Sanity: the walk actually resolved the barrel and its neighbourhood.
+    assert(graph.has("src/index.client.ts"), "entry module was not read");
+    assert(graph.size > 10, `expected a non-trivial graph, got ${graph.size} modules`);
 
-  const leaks = [...graph.keys()].filter((path) =>
-    SERVER_ONLY_PATTERNS.some((pattern) => pattern.test("/" + path))
-  );
-
-  if (leaks.length > 0) {
-    const trace = (leak: string): string => {
-      const chain = [leak];
-      let cursor: string | null | undefined = graph.get(leak);
-      while (cursor) {
-        chain.push(cursor);
-        cursor = graph.get(cursor);
-      }
-      return chain.reverse().join("\n   → ");
-    };
-    throw new Error(
-      `index.client.ts statically reaches ${leaks.length} server-only module(s):\n` +
-        leaks.map(trace).join("\n\n"),
+    const leaks = [...graph.keys()].filter((path) =>
+      SERVER_ONLY_PATTERNS.some((pattern) => pattern.test("/" + path))
     );
-  }
 
-  assertEquals(leaks, []);
+    if (leaks.length > 0) {
+      const trace = (leak: string): string => {
+        const chain = [leak];
+        let cursor: string | null | undefined = graph.get(leak);
+        while (cursor) {
+          chain.push(cursor);
+          cursor = graph.get(cursor);
+        }
+        return chain.reverse().join("\n   → ");
+      };
+      throw new Error(
+        `index.client.ts statically reaches ${leaks.length} server-only module(s):\n` +
+          leaks.map(trace).join("\n\n"),
+      );
+    }
+
+    assertEquals(leaks, []);
+  });
 });

--- a/src/index.client.boundary.test.ts
+++ b/src/index.client.boundary.test.ts
@@ -60,9 +60,14 @@ function resolveToRepoPath(
     return normalize(fromDir + spec);
   }
   if (spec.startsWith("#")) {
+    // Deno import-map semantics: a bare key (`#veryfront/security`) maps only the
+    // exact specifier — it points at a *file*. Only a trailing-slash key
+    // (`#veryfront/`) maps sub-paths. Matching sub-paths against a bare key would
+    // mis-resolve `#veryfront/security/sandbox/x.ts` onto the security barrel file
+    // and silently drop the edge — hiding real leaks.
     let bestKey = "";
     for (const key of Object.keys(map)) {
-      const matches = spec === key || spec.startsWith(key.endsWith("/") ? key : key + "/");
+      const matches = key.endsWith("/") ? spec.startsWith(key) : spec === key;
       if (matches && key.length > bestKey.length) bestKey = key;
     }
     const mapped = map[bestKey];

--- a/src/index.client.boundary.test.ts
+++ b/src/index.client.boundary.test.ts
@@ -1,0 +1,155 @@
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+
+/**
+ * `src/index.client.ts` is the browser/SSR-safe mirror of the `veryfront` root
+ * barrel — the module the import rewriter redirects `veryfront` to for a browser
+ * target. It must never statically pull the server runtime adapters into the
+ * client graph: constructing `DenoAdapter → DenoFileSystemAdapter →
+ * NodeCompatibleFileSystemAdapter` in a browser dereferences a Node-absent
+ * `fs.constants.O_NOFOLLOW` and kills hydration (#3661).
+ *
+ * This walks the *static* value-import graph from `index.client.ts` (the graph
+ * that actually ships — dynamic `import()` is lazy and legitimately used by the
+ * adapter registry, and `import type` is erased) and fails if it reaches any
+ * server-only runtime module. Paths are resolved through `import.meta.url`, not
+ * the cwd, so the check is location-independent.
+ */
+
+const REPO_ROOT = new URL("../", import.meta.url);
+
+/**
+ * The runtime adapter graph behind the #3661 crash: constructing any of these
+ * in a browser reaches `NodeCompatibleFileSystemAdapter`'s `O_NOFOLLOW` read.
+ * (The broader server→client leak surface — `adapters/fs/veryfront/*`,
+ * `compat/process/command`, `production-server` — is the subject of the
+ * fail-loud CI gate in #3670, not this focused regression.)
+ */
+const SERVER_ONLY_PATTERNS: readonly RegExp[] = [
+  /\/platform\/adapters\/runtime\/(deno|node|bun|cloudflare)\/adapter\.ts$/,
+  /\/platform\/adapters\/runtime\/(deno|node|bun|cloudflare)\/filesystem-adapter\.ts$/,
+  /\/platform\/adapters\/runtime\/shared\/node-filesystem-adapter\.ts$/,
+];
+
+// Only follow value imports/exports with a `from` clause. Skipping `import type`
+// / `export type` keeps erased type edges out, and requiring `from` skips bare
+// side-effect and dynamic `import(...)` forms.
+const STATIC_FROM_RE =
+  /(?:^|\n)\s*(?:import|export)\s+(?!type\b)[^;'"]*?\sfrom\s+["']([^"']+)["']/g;
+
+let cachedImportMap: Record<string, string> | null = null;
+
+async function loadImportMap(): Promise<Record<string, string>> {
+  if (cachedImportMap) return cachedImportMap;
+  const denoJson = JSON.parse(await Deno.readTextFile(new URL("deno.json", REPO_ROOT)));
+  cachedImportMap = (denoJson.imports ?? {}) as Record<string, string>;
+  return cachedImportMap;
+}
+
+/**
+ * Resolve a specifier to a repo-relative `src/...` path, or `null` when it is
+ * external (npm/jsr/node/`react`) or a runtime-provided `veryfront/*` bare
+ * specifier the browser loads from the import map rather than the source tree.
+ */
+function resolveToRepoPath(
+  spec: string,
+  fromPath: string,
+  map: Record<string, string>,
+): string | null {
+  if (spec.startsWith("./") || spec.startsWith("../")) {
+    const fromDir = fromPath.slice(0, fromPath.lastIndexOf("/") + 1);
+    return normalize(fromDir + spec);
+  }
+  if (spec.startsWith("#")) {
+    let bestKey = "";
+    for (const key of Object.keys(map)) {
+      const matches = spec === key || spec.startsWith(key.endsWith("/") ? key : key + "/");
+      if (matches && key.length > bestKey.length) bestKey = key;
+    }
+    const mapped = map[bestKey];
+    if (!mapped) return null;
+    const target = mapped.replace(/^\.\//, "");
+    return normalize(target + spec.slice(bestKey.length));
+  }
+  // Bare specifier: react, node:*, npm:*, jsr:*, veryfront/* → external.
+  return null;
+}
+
+function normalize(path: string): string {
+  const parts: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") parts.pop();
+    else parts.push(segment);
+  }
+  return parts.join("/");
+}
+
+async function readModule(repoPath: string): Promise<{ path: string; source: string } | null> {
+  const candidates = /\.[cm]?[jt]sx?$/.test(repoPath)
+    ? [repoPath]
+    : [repoPath + ".ts", repoPath + ".tsx", repoPath + "/index.ts", repoPath + "/index.tsx"];
+  for (const candidate of candidates) {
+    try {
+      const source = await Deno.readTextFile(new URL(candidate, REPO_ROOT));
+      return { path: candidate, source };
+    } catch {
+      // try the next extension form
+    }
+  }
+  return null;
+}
+
+/** Walk the static value-import graph, returning every reached source path and the edge into it. */
+async function collectStaticGraph(entry: string): Promise<Map<string, string | null>> {
+  const map = await loadImportMap();
+  const reached = new Map<string, string | null>();
+  const queue: Array<{ repoPath: string; via: string | null }> = [{ repoPath: entry, via: null }];
+
+  while (queue.length > 0) {
+    const { repoPath, via } = queue.shift()!;
+    const mod = await readModule(repoPath);
+    if (!mod) continue;
+    if (reached.has(mod.path)) continue;
+    reached.set(mod.path, via);
+
+    STATIC_FROM_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = STATIC_FROM_RE.exec(mod.source)) !== null) {
+      const specifier = match[1];
+      if (!specifier) continue;
+      const next = resolveToRepoPath(specifier, mod.path, map);
+      if (next) queue.push({ repoPath: next, via: mod.path });
+    }
+  }
+  return reached;
+}
+
+Deno.test("index.client barrel never statically reaches a server runtime adapter (#3661)", async () => {
+  const graph = await collectStaticGraph("src/index.client.ts");
+
+  // Sanity: the walk actually resolved the barrel and its neighbourhood.
+  assert(graph.has("src/index.client.ts"), "entry module was not read");
+  assert(graph.size > 10, `expected a non-trivial graph, got ${graph.size} modules`);
+
+  const leaks = [...graph.keys()].filter((path) =>
+    SERVER_ONLY_PATTERNS.some((pattern) => pattern.test("/" + path))
+  );
+
+  if (leaks.length > 0) {
+    const trace = (leak: string): string => {
+      const chain = [leak];
+      let cursor: string | null | undefined = graph.get(leak);
+      while (cursor) {
+        chain.push(cursor);
+        cursor = graph.get(cursor);
+      }
+      return chain.reverse().join("\n   → ");
+    };
+    throw new Error(
+      `index.client.ts statically reaches ${leaks.length} server-only module(s):\n` +
+        leaks.map(trace).join("\n\n"),
+    );
+  }
+
+  assertEquals(leaks, []);
+});

--- a/src/index.client.ts
+++ b/src/index.client.ts
@@ -22,7 +22,12 @@
 export { defineConfig, defineConfigWithEnv, mergeConfigs } from "#veryfront/config";
 export type { VeryfrontConfig } from "#veryfront/config";
 
-export { getEnv } from "#veryfront/platform";
+// Source `getEnv` from its browser-safe leaf, not the `#veryfront/platform`
+// barrel: that barrel statically re-exports the eager runtime-adapter singletons
+// (`detect.ts` → Deno/Node/Bun adapters), which drags the server filesystem
+// adapter graph into the client bundle and crashes hydration on a browser-absent
+// `fs.constants.O_NOFOLLOW` (#3661).
+export { getEnv } from "#veryfront/platform/compat/process/env.ts";
 
 // NOTE: the server bootstrap value export (`createHandler`, `startServer`,
 // `toNodeHandler` from the public server entrypoint) is intentionally omitted


### PR DESCRIPTION
## Bug

On `veryfront dev`, a client-tree route that reaches the `veryfront` root barrel drags the **server/Deno runtime adapters** into the browser bundle. During hydration the browser constructs `DenoAdapter → DenoFileSystemAdapter → NodeCompatibleFileSystemAdapter`, which dereferences a browser-absent `fs.constants.O_NOFOLLOW` and throws, aborting hydration (#3661). Green on `0.1.1123`, red on `0.1.1231` — a regression of the leak class #3025 sealed.

## Root cause

`src/index.client.ts` is the browser/SSR-safe mirror the import rewriter redirects `veryfront` to for a browser target. It re-exported `getEnv` from the **broad** `#veryfront/platform` barrel:

```ts
export { getEnv } from "#veryfront/platform";
```

`src/platform/index.ts` statically re-exports `getAdapter` from `adapters/detect.ts`, which in turn statically re-exports the **eager singletons** `denoAdapter` / `nodeAdapter` / `bunAdapter` (`new DenoAdapter()` at module top level). So pulling one leaf helper (`getEnv`) through the barrel pulls the whole runtime-adapter graph — including `NodeCompatibleFileSystemAdapter` and its `O_NOFOLLOW` read — into the client chunk. A static import-graph walk from `index.client.ts` confirms this is the sole path to the adapters.

## Fix

Source `getEnv` from its adapter-free leaf, `#veryfront/platform/compat/process/env.ts` (where it is defined, and already the canonical import for 12 other modules). Behaviour-identical, and it removes the only static edge from the client barrel into the platform barrel — so the runtime adapters are no longer statically reachable from the client graph.

## Tests (red→green)

`src/index.client.boundary.test.ts` walks the **static value-import graph** from `index.client.ts` (skipping erased `import type` and lazy dynamic `import()`, resolving `#veryfront/*` via the import map) and fails if it reaches any `platform/adapters/runtime/*/adapter.ts`, `*/filesystem-adapter.ts`, or `node-filesystem-adapter.ts`. On `main` it fails with a 7-module leak trace through `platform/index.ts → detect.ts`; with the fix it passes. `deno check` / `deno lint` / `deno fmt` clean; platform env + detect suites green.

## Scope

This fixes the O_NOFOLLOW hydration crash. The broader server→client surface the leak also exposed (`adapters/fs/veryfront/*`, `compat/process/command`) is real but separate — it is the target of the fail-loud CI gate in #3670, which will catch it comprehensively. The defensive `O_NOFOLLOW` optional-chain guard in #3672 remains valuable defense-in-depth.

Closes #3661.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser and server-rendered compatibility by preventing server-only runtime code from being included in client bundles.
  * Preserved the existing `getEnv` API while ensuring it uses a browser-safe implementation.

* **Tests**
  * Added regression coverage to detect browser bundles that accidentally import server-only functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->