### PR TITLE
fix(rsc): serve app-router page modules in local dev under experimental.rsc (#3662)

### DIFF
--- a/src/modules/server/browser-module-admission.ts
+++ b/src/modules/server/browser-module-admission.ts
@@ -29,6 +29,13 @@ export interface BrowserModuleSourcePolicy {
 export interface BrowserModuleSourcePolicyOptions {
   config?: VeryfrontConfig;
   rscEnabled?: boolean;
+  /**
+   * A real on-disk project served by `veryfront dev`. Client boundaries are a
+   * hosted-transport concern: the browser hydrates a local project by importing
+   * the whole page module (as the non-RSC path does), so local dev must not
+   * require an RSC `use client` directive to serve an app-router page (#3662).
+   */
+  isLocalProject?: boolean;
 }
 
 /**
@@ -201,7 +208,9 @@ export function classifyBrowserModuleSourcePath(
   return {
     canonicalPath: path,
     protectionReason: null,
-    requiresClientBoundary: options.rscEnabled === true && appRelative !== null,
+    requiresClientBoundary: options.rscEnabled === true &&
+      appRelative !== null &&
+      options.isLocalProject !== true,
   };
 }
 

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -536,6 +536,61 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     }
   });
 
+  it("serves RSC app-router page and layout modules in local dev so they hydrate", async () => {
+    // Regression #3662: with `experimental.rsc`, `veryfront dev` (isLocalProject)
+    // 404'd every app-router client module because RSC client-boundary admission
+    // — a hosted-transport concern — was applied to local dev, where the browser
+    // hydrates by importing the whole page module (as the non-RSC path does).
+    // The hosted contract stays pinned by the sibling test above.
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-browser-module-rsc-local-" });
+
+    try {
+      await Deno.mkdir(`${projectDir}/app/api`, { recursive: true });
+      for (const name of ["page", "layout"]) {
+        await Deno.writeTextFile(
+          `${projectDir}/app/${name}.tsx`,
+          `export const marker = "server-${name}"; export default function View() { return null; }`,
+        );
+      }
+      await Deno.writeTextFile(
+        `${projectDir}/app/api/save.ts`,
+        `export function GET() { return new Response("secret-route"); }`,
+      );
+
+      const { serveModule } = await import("./module-server.ts");
+      const options = {
+        projectId: "test",
+        projectDir,
+        adapter: denoAdapter,
+        isLocalProject: true,
+        isProxyMode: false,
+        mode: "development",
+        config: { experimental: { rsc: true } },
+      } as const;
+
+      for (const prefix of ["/_vf_modules", "/_veryfront/modules"]) {
+        for (const name of ["page", "layout"]) {
+          const response = await serveModule(
+            new Request(`http://localhost:3000${prefix}/app/${name}.js`),
+            options,
+          );
+          assertEquals(response.status, 200, `${prefix}/app/${name}.js should serve in local dev`);
+          assertStringIncludes(await response.text(), `server-${name}`);
+        }
+
+        // Server surfaces (api/actions) stay protected in local dev regardless of RSC.
+        const apiRoute = await serveModule(
+          new Request(`http://localhost:3000${prefix}/app/api/save.js`),
+          options,
+        );
+        assertEquals(apiRoute.status, 404, `${prefix}/app/api/save.js must stay protected`);
+        assertEquals((await apiRoute.text()).includes("secret-route"), false);
+      }
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("rejects server-directed source from browser module requests", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-browser-module-boundary-" });
 

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -926,6 +926,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           : classifyBrowserModuleAbsoluteSourcePath(sourceFile, projectDir, {
             config: options.config,
             rscEnabled: isRSCEnabled(options.config),
+            isLocalProject: options.isLocalProject,
           });
         const exactSourceKey = sourcePolicy?.canonicalPath ?? null;
 


### PR DESCRIPTION
## Bug

With `experimental: { rsc: true }`, `veryfront dev` returns **404 for every app-router client module** (`/_vf_modules/app/page.js`, `/_vf_modules/app/layout.js`, `/_vf_modules/app/<route>/page.js`), the client throws `Failed to fetch dynamically imported module`, and **nothing hydrates** (it then also probes non-existent `/_vf_modules/pages/*`). Green on `0.1.1123`, red on `0.1.1231`, and specific to the `experimental.rsc` path — without the flag the same app-router routes hydrate fine.

## Root cause (a regression from #3290)

#3290 introduced RSC-aware browser-module admission: `browser-module-admission.ts` sets `requiresClientBoundary: rscEnabled && appRelative`, and the bundler 404s an app-relative module with no `use client` directive. But it wired `rscEnabled: isRSCEnabled(config)` **unconditionally** (`module-server.ts`) — not scoped to hosted — and did **not** touch the hydration pipeline.

RSC client boundaries are a **hosted-transport** concern: hosted/preview/production ship only `use client` islands and render server components via the `/_veryfront/rsc/` endpoint, so refusing a plain server-component page as a browser module is correct there. A local `veryfront dev` project has **no client flight consumer** — the browser hydrates by importing the whole page module, exactly as the non-RSC path does (which still works because `isRSCEnabled` is false there). So the hosted admission refused the very module the local hydration pipeline requests → 404 → dead hydration.

*(Flipping the client-module strategy to `rsc-module` was ruled out: the RSC module endpoint also enforces `requireClientBoundary`, so it 404s server components too. The break is purely in module admission.)*

## Fix

Scope `requiresClientBoundary` to non-local projects via a new `isLocalProject` input on `BrowserModuleSourcePolicyOptions`:

```ts
requiresClientBoundary: options.rscEnabled === true
  && appRelative !== null
  && options.isLocalProject !== true,
```

`module-server.ts` passes `isLocalProject: options.isLocalProject` into the classifier. Local dev now serves app-router pages/layouts through the **same plain-serve branch the non-RSC path already uses**, so they hydrate. Keeping `rscEnabled` truthful (rather than forcing it false in local dev) means any future `rscEnabled`-dependent behavior can't silently regress local dev.

Non-regressing:
- **Hosted contract unchanged** — `isLocalProject: false` ⇒ `requiresClientBoundary` stays true ⇒ server components still 404. Pinned by the existing `requires an explicit client boundary for RSC app modules` test.
- **Server surfaces still protected in local dev** — `api`/`actions`/server-route/middleware/metadata protections are independent of `rscEnabled`.

## Tests (red→green)

Added `serves RSC app-router page and layout modules in local dev so they hydrate` to `module-server.test.ts` (mirrors the hosted pinned test, `isLocalProject: true`): asserts `app/page.js` + `app/layout.js` serve **200** with their server markers, and that `app/api/save.js` **stays 404**. Fails on `main` (404), passes with the fix. Full `module-server` + `browser-module-admission` + `client-module-strategy` + `endpoint-router` suites green; `deno check`/`lint`/`fmt` + `docs:api-reference:check` clean.

Closes #3662.