### PR TITLE
fix(test): type the workflow-start fetch stubs explicitly

### DIFF
--- a/src/workflow/react/use-workflow-start.test.tsx
+++ b/src/workflow/react/use-workflow-start.test.tsx
@@ -50,10 +50,10 @@ describe("useWorkflowStart", () => {
     let hook: UseWorkflowStartResult<{ topic: string }> | null = null;
 
     document.cookie = "__Host-vf_csrf=production-token; Path=/; Secure";
-    globalThis.fetch = (_input, init) => {
+    globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
       requestHeaders = new Headers(init?.headers);
       return Promise.resolve(Response.json({ runId: "run-1" }));
-    };
+    }) as typeof fetch;
 
     function Capture(): null {
       hook = useWorkflowStart<{ topic: string }>({ workflowId: "content-pipeline" });
@@ -83,7 +83,7 @@ describe("useWorkflowStart", () => {
     let workflowHook: UseWorkflowResult | null = null;
 
     document.cookie = "__Host-vf_csrf=shared-token; Path=/; Secure";
-    globalThis.fetch = (input, init) => {
+    globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
       const url = String(input);
       const method = init?.method ?? "GET";
       if (method === "POST") mutationHeaders.set(url, new Headers(init?.headers));
@@ -100,7 +100,7 @@ describe("useWorkflowStart", () => {
         currentNodes: [],
         pendingApprovals: [],
       }));
-    };
+    }) as typeof fetch;
 
     function Capture(): null {
       startHook = useWorkflowStart({ workflowId: "content-pipeline" });
@@ -141,10 +141,10 @@ describe("useWorkflowStart", () => {
     let hook: UseWorkflowStartResult<Record<string, never>> | null = null;
 
     document.cookie = "__Host-vf_csrf=host-token; Path=/; Secure";
-    globalThis.fetch = (_input, init) => {
+    globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
       requestHeaders = new Headers(init?.headers);
       return Promise.resolve(Response.json({ runId: "run-1" }));
-    };
+    }) as typeof fetch;
 
     function Capture(): null {
       hook = useWorkflowStart({


### PR DESCRIPTION
`ci (lint)` started failing on a PR that does not touch the file it fails in. The cause is not that PR.

## What happens

The test-typecheck ratchet runs `deno check --no-lock` (`scripts/lint/check-test-typecheck-baseline.ts:95`), so it resolves dependencies fresh instead of from the lockfile. Upstream drift made `globalThis.fetch` resolve to an ambiguous union:

```
global.RequestInit | RequestInit | (RequestInit & { client?: HttpClient })
```

The three stubs in `use-workflow-start.test.tsx` left `init` to contextual inference, so `init?.headers` and `init?.method` stopped typechecking — with **no change in this repo**.

## Evidence it is not the PR that surfaced it

| Check | Result |
|---|---|
| `deno check --no-lock` on `origin/main` | **fails**, same 4 errors |
| `deno check` (lockfile honoured) on `origin/main` | passes |
| Does the reporting PR touch this file? | no |
| Other open PRs | green — their branches predate the drift |

So `main` is red on this gate right now, and every PR inherits it on the next lint run.

## Fix

Annotate the parameters and cast to `typeof fetch`, following the existing form at `src/metrics/index.test.ts:263`. That removes the dependence on ambient inference, so the stubs typecheck under either resolution.

## Verification

- `deno check --no-lock` — clean (the exact command the gate runs)
- `deno check` with lockfile — clean
- `deno test` — 3 steps, all pass
- `deno fmt --check`, `deno lint` — clean

## Not fixed here

The gate stays unpinned. It resolves dependencies fresh on every run, so future upstream drift can turn `main` red again on an unrelated PR, and the failure will again point at whichever PR happened to run next. Worth deciding separately whether that gate should honour the lockfile — I did not change it, since `--no-lock` may be deliberate for catching drift early, and changing it could surface a batch of unrelated failures.