### PR TITLE
fix(build): load the DNT shims lazily so a global Deno install can render

### DIFF
--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -24,7 +24,11 @@ import {
 	readDenoConfigSet,
 } from "./npm-dependency-sources.ts";
 import { buildExtensionPackages } from "./build-npm-extension-packages.ts";
-import { patchDntArgvPolyfill, patchDntDenoShim } from "./dnt-polyfill.ts";
+import {
+	patchDntArgvPolyfill,
+	patchDntCryptoShim,
+	patchDntDenoShim,
+} from "./dnt-polyfill.ts";
 import { normalizeNpmPackageMetadata } from "./npm-package-metadata.ts";
 import { assertNpmRuntimeHelperContract } from "./npm-runtime-helper-contract.ts";
 import { normalizeEsmShReactNpmShims } from "./npm-react-shims.ts";
@@ -238,6 +242,17 @@ await build({
 		// off a node:net server, which is null under Deno's node compatibility
 		// layer, so every command that binds a port died before starting.
 		await patchDntDenoShim(
+			"./npm/esm/_dnt.shims.js",
+			{ required: true },
+		);
+
+		// Both shims must be lazy, not just the Deno one. The esm transform
+		// rewrites each bare specifier into an absolute file:// bundle, and Deno
+		// cannot prepare that graph node when node_modules is unmanaged, which is
+		// what `deno install -g` writes (`nodeModulesDir: "manual"`). A single
+		// remaining static shim import keeps a globally installed CLI failing
+		// every request with "Loading unprepared module".
+		await patchDntCryptoShim(
 			"./npm/esm/_dnt.shims.js",
 			{ required: true },
 		);

--- a/scripts/build/build-npm-extension-packages.ts
+++ b/scripts/build/build-npm-extension-packages.ts
@@ -1,6 +1,10 @@
 import { build, emptyDir } from "#dnt";
 import { basename, dirname, join, relative, toFileUrl } from "#std/path";
-import { patchDntArgvPolyfill, patchDntDenoShim } from "./dnt-polyfill.ts";
+import {
+  patchDntArgvPolyfill,
+  patchDntCryptoShim,
+  patchDntDenoShim,
+} from "./dnt-polyfill.ts";
 import {
   bareImportPackageNames,
   createExtensionPackageSpecs,
@@ -91,6 +95,7 @@ async function buildExtensionPackage(
         });
         await patchDntArgvPolyfill(`${outDir}/esm/_dnt.polyfills.js`);
         await patchDntDenoShim(`${outDir}/esm/_dnt.shims.js`);
+        await patchDntCryptoShim(`${outDir}/esm/_dnt.shims.js`);
 
         await Deno.copyFile(`${options.rootDir}/LICENSE`, `${outDir}/LICENSE`);
         await Deno.copyFile(`${options.rootDir}/NOTICE`, `${outDir}/NOTICE`);

--- a/scripts/build/dnt-polyfill.test.ts
+++ b/scripts/build/dnt-polyfill.test.ts
@@ -357,6 +357,27 @@ describe("patchDntCryptoShim", () => {
     }
   });
 
+  it("fails closed on unrecognized crypto output without being asked to", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
+
+    try {
+      // build-npm-extension-packages.ts calls this without `required`, so the
+      // default path is the one that guards the extension packages.
+      await Deno.writeTextFile(
+        path,
+        'export { crypto } from "@deno/shim-crypto-next";\n',
+      );
+      await assertRejects(
+        () => patchDntCryptoShim(path),
+        Error,
+        "does not contain the expected @deno/shim-crypto re-export",
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
   it("skips packages without the DNT crypto shim", async () => {
     const directory = await Deno.makeTempDir();
     const path = `${directory}/_dnt.shims.js`;

--- a/scripts/build/dnt-polyfill.test.ts
+++ b/scripts/build/dnt-polyfill.test.ts
@@ -1,6 +1,10 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { patchDntArgvPolyfill, patchDntDenoShim } from "./dnt-polyfill.ts";
+import {
+  patchDntArgvPolyfill,
+  patchDntCryptoShim,
+  patchDntDenoShim,
+} from "./dnt-polyfill.ts";
 
 /** Verbatim shape of the `_dnt.shims.js` DNT emits for `shims: { deno: true, crypto: true }`. */
 const GENERATED_SHIMS = `import { Deno } from "@deno/shim-deno";
@@ -74,7 +78,7 @@ describe("patchDntArgvPolyfill", () => {
 async function importPatchedShims(
   directory: string,
   source: string,
-): Promise<{ Deno: typeof Deno }> {
+): Promise<{ Deno: typeof Deno; crypto: typeof crypto }> {
   await Deno.writeTextFile(
     `${directory}/stub-shim-deno.js`,
     'export const Deno = { __stub: "deno" };\n',
@@ -154,6 +158,37 @@ describe("patchDntDenoShim", () => {
     }
   });
 
+  it("never makes Deno resolve the Node/Bun fallback", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
+
+    try {
+      await Deno.writeTextFile(path, GENERATED_SHIMS);
+      await patchDntDenoShim(path, { required: true });
+      const patchedSource = await Deno.readTextFile(path);
+
+      // A static import makes every runtime resolve `@deno/shim-deno`, including
+      // Deno, which discards the value. The esm transform rewrites that bare
+      // specifier to an absolute file:// bundle, and Deno refuses to prepare
+      // that graph node when node_modules is unmanaged — `deno install -g`
+      // writes `nodeModulesDir: "manual"` — so a globally installed CLI failed
+      // every request with "Loading unprepared module" while the bundle it
+      // named was present on disk.
+      assertEquals(
+        /(^|\n)\s*import\s[^\n]*from\s*"@deno\/shim-deno"/.test(patchedSource),
+        false,
+        "the Node/Bun fallback must not be imported statically",
+      );
+      assertEquals(
+        patchedSource.includes('await import("@deno/shim-deno")'),
+        true,
+        "the fallback must load lazily, only on runtimes that use it",
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
   it("is idempotent", async () => {
     const directory = await Deno.makeTempDir();
     const path = `${directory}/_dnt.shims.js`;
@@ -188,6 +223,25 @@ describe("patchDntDenoShim", () => {
     }
   });
 
+  it("leaves the crypto shim to patchDntCryptoShim", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
+
+    try {
+      await Deno.writeTextFile(path, GENERATED_SHIMS);
+      await patchDntDenoShim(path, { required: true });
+      const patchedSource = await Deno.readTextFile(path);
+
+      assertEquals(
+        patchedSource.includes('from "@deno/shim-crypto"'),
+        true,
+        "the Deno patcher must not silently take over the crypto shim",
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
   it("skips packages without the DNT Deno shim", async () => {
     const directory = await Deno.makeTempDir();
     const path = `${directory}/_dnt.shims.js`;
@@ -195,6 +249,121 @@ describe("patchDntDenoShim", () => {
     try {
       await Deno.writeTextFile(path, "export {};\n");
       assertEquals(await patchDntDenoShim(path), false);
+      assertEquals(await Deno.readTextFile(path), "export {};\n");
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+});
+
+describe("patchDntCryptoShim", () => {
+  it("never makes a runtime with native crypto resolve the fallback", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
+
+    try {
+      await Deno.writeTextFile(path, GENERATED_SHIMS);
+      assertEquals(await patchDntCryptoShim(path, { required: true }), true);
+      const patchedSource = await Deno.readTextFile(path);
+
+      // The esm transform rewrites this bare specifier to an absolute file://
+      // bundle exactly as it does for the Deno shim, and a static import of it
+      // is unpreparable when node_modules is unmanaged. Web Crypto is a global
+      // on Deno, Node 19+ and Bun, so the fallback is dead weight everywhere
+      // the framework runs.
+      assertEquals(
+        /(^|\n)\s*import\s[^\n]*from\s*"@deno\/shim-crypto"/.test(
+          patchedSource,
+        ),
+        false,
+        "the crypto fallback must not be imported statically",
+      );
+      assertEquals(
+        patchedSource.includes('await import("@deno/shim-crypto")'),
+        true,
+        "the crypto fallback must load lazily",
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
+  it("prefers the runtime's own crypto global", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
+
+    try {
+      await Deno.writeTextFile(path, GENERATED_SHIMS);
+      await patchDntCryptoShim(path, { required: true });
+      const patched = await importPatchedShims(
+        directory,
+        await Deno.readTextFile(path),
+      );
+      assertEquals(patched.crypto, globalThis.crypto);
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
+  it("keeps the fallback for runtimes without a crypto global", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
+
+    try {
+      await Deno.writeTextFile(path, GENERATED_SHIMS);
+      await patchDntCryptoShim(path, { required: true });
+      const nodeShaped = (await Deno.readTextFile(path)).replace(
+        "globalThis.crypto",
+        "/* no crypto */ undefined",
+      );
+      const patched = await importPatchedShims(directory, nodeShaped);
+      assertEquals(patched.crypto, { __stub: "crypto" });
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
+  it("is idempotent", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
+
+    try {
+      await Deno.writeTextFile(path, GENERATED_SHIMS);
+      assertEquals(await patchDntCryptoShim(path, { required: true }), true);
+      const once = await Deno.readTextFile(path);
+      assertEquals(await patchDntCryptoShim(path, { required: true }), false);
+      assertEquals(await Deno.readTextFile(path), once);
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
+  it("fails closed when required DNT crypto output changes", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
+
+    try {
+      await Deno.writeTextFile(
+        path,
+        'export { crypto } from "@deno/shim-crypto-next";\n',
+      );
+      await assertRejects(
+        () => patchDntCryptoShim(path, { required: true }),
+        Error,
+        "does not contain the expected @deno/shim-crypto re-export",
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
+  it("skips packages without the DNT crypto shim", async () => {
+    const directory = await Deno.makeTempDir();
+    const path = `${directory}/_dnt.shims.js`;
+
+    try {
+      await Deno.writeTextFile(path, "export {};\n");
+      assertEquals(await patchDntCryptoShim(path), false);
       assertEquals(await Deno.readTextFile(path), "export {};\n");
     } finally {
       await Deno.remove(directory, { recursive: true });

--- a/scripts/build/dnt-polyfill.ts
+++ b/scripts/build/dnt-polyfill.ts
@@ -4,19 +4,43 @@ const SAFE_ARGV_EXPRESSION = '(process.argv[1] ?? "").replace';
 const SHIM_DENO_REEXPORT = 'import { Deno } from "@deno/shim-deno";\n' +
   'export { Deno } from "@deno/shim-deno";\n';
 
+const SHIM_CRYPTO_REEXPORT = 'import { crypto } from "@deno/shim-crypto";\n' +
+  'export { crypto } from "@deno/shim-crypto";\n';
+
 /** Marker proving the Deno-global preference is already in place. */
 const NATIVE_DENO_MARKER = "dntNativeDeno";
 
-const NATIVE_DENO_PREFERENCE =
-  'import { Deno as dntShimDeno } from "@deno/shim-deno";\n' +
-  "const dntNativeDeno = globalThis.Deno;\n" +
+/** Marker proving the crypto-global preference is already in place. */
+const NATIVE_CRYPTO_MARKER = "dntNativeCrypto";
+
+const NATIVE_CRYPTO_PREFERENCE =
+  "const dntNativeCrypto = globalThis.crypto;\n" +
+  "// Web Crypto is a global on every runtime the framework supports (Deno,\n" +
+  "// Node 19+, Bun), so `@deno/shim-crypto` is a fallback for runtimes that no\n" +
+  "// longer exist in practice. It loads lazily for the same reason the Deno\n" +
+  "// shim does: the esm transform rewrites the bare specifier to an absolute\n" +
+  "// file:// bundle, and Deno cannot prepare that graph node when node_modules\n" +
+  "// is unmanaged.\n" +
+  "export const crypto = dntNativeCrypto !== undefined\n" +
+  "    ? dntNativeCrypto\n" +
+  '    : (await import("@deno/shim-crypto")).crypto;\n';
+
+const NATIVE_DENO_PREFERENCE = "const dntNativeDeno = globalThis.Deno;\n" +
   "// Prefer the host runtime's own Deno. The `@deno/shim-deno` fallback exists\n" +
   "// for Node and Bun; under Deno it shadows working native APIs with node:net\n" +
   "// reimplementations that throw (e.g. Deno.listen reads `server._handle.fd`,\n" +
   "// which is null on Deno's node compatibility layer).\n" +
+  "//\n" +
+  "// It loads lazily so Deno never resolves it at all. The esm transform\n" +
+  "// rewrites the bare specifier to an absolute file:// bundle, and Deno\n" +
+  "// refuses to prepare that graph node when node_modules is unmanaged, which\n" +
+  '// is what `deno install -g` produces (`nodeModulesDir: "manual"`). A static\n' +
+  '// import therefore failed every request with "Loading unprepared module"\n' +
+  "// naming a bundle that was present on disk, on the one runtime that never\n" +
+  "// reads the value.\n" +
   'export const Deno = typeof dntNativeDeno?.version?.deno === "string"\n' +
   "    ? dntNativeDeno\n" +
-  "    : dntShimDeno;\n";
+  '    : (await import("@deno/shim-deno")).Deno;\n';
 
 export type PatchDntArgvPolyfillOptions = {
   required?: boolean;
@@ -120,6 +144,64 @@ export async function patchDntDenoShim(
   if (options.required || source.includes("@deno/shim-deno")) {
     throw new Error(
       `${path} does not contain the expected @deno/shim-deno re-export. ` +
+        "DNT output may have changed; update the generated shim normalizer " +
+        "before publishing.",
+    );
+  }
+
+  return false;
+}
+
+export type PatchDntCryptoShimOptions = {
+  required?: boolean;
+};
+
+/**
+ * Make DNT's generated `_dnt.shims.js` defer to the host runtime's own
+ * `crypto`, and load `@deno/shim-crypto` only where that global is absent.
+ *
+ * This is the crypto half of the same defect {@link patchDntDenoShim} fixes.
+ * DNT imports both shims statically, so every runtime resolves them. The esm
+ * transform rewrites those bare specifiers into absolute `file://` bundles,
+ * and Deno refuses to prepare such a graph node when `node_modules` is
+ * unmanaged — which is exactly what `deno install -g` produces, since it
+ * writes `nodeModulesDir: "manual"`. A globally installed CLI therefore failed
+ * every request with "Loading unprepared module", naming a bundle that was
+ * present on disk.
+ *
+ * Fixing only the Deno shim is not enough: the crypto import alone keeps the
+ * graph unpreparable.
+ */
+export async function patchDntCryptoShim(
+  path: string,
+  options: PatchDntCryptoShimOptions = {},
+): Promise<boolean> {
+  let source: string;
+  try {
+    source = await Deno.readTextFile(path);
+  } catch (error) {
+    if (!options.required && error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+
+  if (source.includes(NATIVE_CRYPTO_MARKER)) {
+    return false;
+  }
+
+  if (source.includes(SHIM_CRYPTO_REEXPORT)) {
+    await Deno.writeTextFile(
+      path,
+      source.replace(SHIM_CRYPTO_REEXPORT, NATIVE_CRYPTO_PREFERENCE),
+    );
+    console.log("Patched DNT crypto shim to prefer the native crypto global");
+    return true;
+  }
+
+  if (options.required || source.includes("@deno/shim-crypto")) {
+    throw new Error(
+      `${path} does not contain the expected @deno/shim-crypto re-export. ` +
         "DNT output may have changed; update the generated shim normalizer " +
         "before publishing.",
     );


### PR DESCRIPTION
A globally installed CLI returns 500 on **every** request, on any project including a fresh `npm create veryfront` scaffold.

```
deno install -gArf npm:veryfront   →  500  "Loading unprepared module"
npm install -g veryfront           →  200
```

Found by walking the documented install page as a new developer would.

## Why it was hard to see

The error names an http bundle that is **present on disk** — all 171 of them were — and its hint blames `Bundle may have expired from Redis (24h TTL)` on a local dev run with no Redis anywhere. The message points away from the cause in two directions at once.

## Cause

`deno install -g` writes its own config beside the shim:

```json
{ "workspace": [], "nodeModulesDir": "manual" }
```

Deno generates that file for **any** global npm install — `npm:cowsay` produces a byte-identical one — so it isn't something this package controls or can opt out of.

DNT imports `@deno/shim-deno` and `@deno/shim-crypto` **statically**. The esm transform rewrites both bare specifiers into absolute `file://` bundles, and Deno will not prepare such a graph node when `node_modules` is unmanaged.

Both shims exist only for runtimes lacking the corresponding global. `patchDntDenoShim` already documented its fallback as being "for Node and Bun", and Web Crypto is a global on Deno, Node 19+ and Bun alike. The imports are now lazy, which is what the code already said it wanted.

**Fixing one shim is not enough.** A single remaining static import keeps the graph unpreparable — the Deno-only change measured identically to no change at all, which is how the crypto half surfaced.

## Verification

Built and packed a tarball, then ran both arms with the same config and the same project shape:

| | http | unprepared | marker rendered |
|---|---|---|---|
| published `0.1.1232` | **500** | 1 | no |
| this build | **200** | 0 | yes |

Cross-runtime, same build:

| runtime | before | after |
|---|---|---|
| Deno + global-install config | 500 | **200** |
| Deno, plain | 200 | 200 |
| Node 25.2.1 | 200 | 200 |
| Bun 1.3.6 | 500 | 500 |

Bun fails identically before and after, on an unrelated defect — `undefined is not an object (evaluating 'adapter.fs')`, not the module graph. Untouched here; it needs its own fix and I did not want to conflate the two.

Also gated: `deno task fmt:check` (4806 files), `dnt-polyfill` and `dnt-meta-property-safety` suites, `deno lint`.

## Tests

`patchDntCryptoShim` mirrors the Deno patcher — same idempotency marker, same fail-closed check if DNT's output shape changes. New cases cover lazy-not-static for both shims, native preference, fallback retention when the global is absent, idempotency, and fail-closed. A separate case pins that the Deno patcher does not silently take over the crypto shim.

Wired into `build-npm-extension-packages.ts` as well — extensions emit their own `_dnt.shims.js` and would otherwise keep the static imports.

## Note on scope

This does not re-document the Deno global install; the docs currently list it and it has never worked. Worth a follow-up once this ships, along with a startup guard so a future regression here fails fast with an instruction instead of a per-request 500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when using generated packages across different runtimes.
  * Native runtime support is now preferred, with fallback shims loaded only when needed.
  * Added safer handling for unavailable or changed generated shim files.
* **Build Improvements**
  * Package builds now consistently apply both runtime and cryptography compatibility updates.
* **Tests**
  * Expanded coverage for fallback behavior, native runtime preference, repeated processing, and invalid build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->