### PR TITLE
fix(server): do not read the adapter back from a cache that can drop it

### DIFF
--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -522,6 +522,53 @@ describe("adapter-factory", () => {
     assertEquals("isLocalProject" in result, true);
   });
 
+  it("survives an adapter cache that drops the entry it was just given", async () => {
+    Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
+    const cache = new ProjectDiscoveryCache();
+    const adapter = createMockAdapter({
+      "/trusted/project": { isDirectory: true },
+      "/trusted/project/app": { isDirectory: true },
+    });
+
+    // The adapter LRU estimates a RuntimeAdapter's size and evicts it again
+    // when it exceeds the byte budget, so set() can silently store nothing.
+    // Observed under Bun 1.3.6, where the same adapter object that caches
+    // fine on Node is dropped: set() then has()===false and size===0.
+    // resolveAdapter must not depend on reading back what it just wrote.
+    cache.adapters.set = () => {};
+
+    const result = await resolveAdapter({
+      req: await makeReq({ projectPath: "/trusted/project", trusted: true }),
+      projectDir: "/base/project",
+      adapter,
+      config: undefined,
+      projectSlug: "myproject",
+      projectId: "proj_123",
+      proxyToken: undefined,
+      releaseId: undefined,
+      proxyEnv: "preview",
+      branch: null,
+      environmentName: undefined,
+      parsedDomain: {
+        slug: null,
+        branch: null,
+        environment: null,
+        isVeryfrontDomain: false,
+        isDraft: false,
+        allowIframeEmbed: false,
+      },
+      isProxyMode: true,
+      cache,
+      prepareHostedConfigContext: preparePreviewHostedConfigContext,
+    });
+
+    assertEquals(
+      result.adapter === undefined || result.adapter === null,
+      false,
+      "resolveAdapter must hand on a real adapter even when the cache drops it",
+    );
+  });
+
   it("uses injected cache instead of default singleton", async () => {
     Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
     const cache = new ProjectDiscoveryCache();

--- a/src/server/runtime-handler/adapter-factory.ts
+++ b/src/server/runtime-handler/adapter-factory.ts
@@ -222,17 +222,27 @@ export async function resolveAdapter(
       projectDir: effectiveProjectDir,
     });
 
-    // Get or create local adapter
-    if (!cache.adapters.has(effectiveProjectDir)) {
-      const baseAdapter = await runtime.get();
-      cache.adapters.set(effectiveProjectDir, baseAdapter);
+    // Get or create local adapter.
+    //
+    // Hold the adapter rather than reading it back: the cache is an LRU that
+    // estimates each value's size and can evict an oversized entry as part of
+    // the same set(), so a write is not guaranteed to be readable afterwards.
+    // A RuntimeAdapter crosses that budget under Bun, where set() then leaves
+    // has() === false and size === 0, and the non-null assertion this replaces
+    // turned that miss into an undefined adapter that reached getConfig and
+    // threw "undefined is not an object (evaluating 'adapter.fs')" on every
+    // request. Caching stays best effort; correctness no longer depends on it.
+    let localAdapter = cache.adapters.get(effectiveProjectDir);
+    if (!localAdapter) {
+      localAdapter = await runtime.get();
+      cache.adapters.set(effectiveProjectDir, localAdapter);
       logger.debug("Created local adapter for project", {
         projectSlug: opts.projectSlug,
         projectDir: effectiveProjectDir,
       });
     }
 
-    effectiveAdapter = cache.adapters.get(effectiveProjectDir)!;
+    effectiveAdapter = localAdapter;
 
     if (shouldDeferConfigLoad(opts)) {
       effectiveConfig = undefined;


### PR DESCRIPTION
`resolveAdapter` wrote the adapter into an LRU and read it back with a non-null assertion:

```ts
if (!cache.adapters.has(dir)) {
  const baseAdapter = await runtime.get();
  cache.adapters.set(dir, baseAdapter);
}
effectiveAdapter = cache.adapters.get(dir)!;   // ← may be undefined
```

`LRUCacheAdapter.set()` inserts the entry and then runs `enforceMemoryLimits`, which can evict what it just added when the estimated size exceeds the byte budget. So `set()` is allowed to store nothing, and the `!` turned that miss into an `undefined` adapter that reached `getConfig` and threw on **every request**:

```
undefined is not an object (evaluating 'adapter.fs')
```

## Evidence

Same adapter object, same cache, measured directly:

| | result |
|---|---|
| Bun — `set(adapter)` | `has=false size=0` — **dropped** |
| Node — `set(adapter)` | `has=true size=1` |
| Bun — `set(smallObject)` | `has=true size=1` — small values fine |

A probe inside `resolveAdapter` under Bun confirmed the caller's view: `has=false get=undefined size=0`, measured *after* the `if (!has) { … set() }` block ran.

**This is not Bun-specific.** Bun exposed it first because a `RuntimeAdapter` crosses the byte budget there, but any oversized adapter — or ordinary eviction once the 50-entry cache fills under load — produces the same `undefined` on Node and Deno.

## Fix

Hold the adapter already obtained rather than re-reading it. Correctness stops depending on a cache round-trip, and the non-null assertion goes away. Caching remains best-effort, which is all an LRU promises.

## Verification

Built a package and ran it under Bun: the `adapter.fs` crash is **gone (0 occurrences)** and the dev server now boots and proceeds past it.

Bun still cannot render a page, on a **separate defect this does not touch**: Bun's `node:_http_client` fails to connect to `esm.sh` where `curl` reaches it (200), and the uncaught error kills the process. The stack contains no framework frames. Reproducible across runs. Filed separately in the summary rather than conflated here.

## Note on the test

The regression test simulates the drop by making `cache.adapters.set` a no-op. It fails before this change and passes after.

An earlier version of it **passed against the unfixed code** — it took the non-local-project branch and never reached the assertion. Corrected to the proxy-trusted local path, where the failure actually lives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where adapter cache eviction could cause valid runtime adapters to be unavailable.
  * Adapter resolution now reliably returns the adapter obtained from the runtime, even when cache writes are disabled or entries are evicted.

* **Tests**
  * Added regression coverage for adapter resolution during cache eviction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->