### PR TITLE
refactor(http): pin by dialling the validated address, not by overriding DNS

### DIFF
--- a/src/platform/compat/http/pinned-fetch.test.ts
+++ b/src/platform/compat/http/pinned-fetch.test.ts
@@ -313,13 +313,28 @@ describe("pinned connect attempts", () => {
     assertEquals(isRetriableConnectFailure(null), false);
   });
 
+  it("retries ETIMEDOUT only when it came from connect", () => {
+    // A socket timeout after the request was written carries the same code, and
+    // replaying it could deliver a non-idempotent request twice.
+    assertEquals(
+      isRetriableConnectFailure({ code: "ETIMEDOUT", syscall: "connect" }),
+      true,
+    );
+    assertEquals(
+      isRetriableConnectFailure({ code: "ETIMEDOUT", syscall: "read" }),
+      false,
+    );
+    assertEquals(isRetriableConnectFailure({ code: "ETIMEDOUT" }), false);
+  });
+
   it("replays only bodies that re-read identically", () => {
     assertEquals(isReplayableRequestBody(null), true);
     assertEquals(isReplayableRequestBody("{}"), true);
     assertEquals(isReplayableRequestBody(new Uint8Array([1, 2])), true);
     assertEquals(isReplayableRequestBody(new URLSearchParams("a=1")), true);
-    // Consumed by Readable.fromWeb, so a second attempt would send nothing.
-    assertEquals(isReplayableRequestBody(new Blob(["x"])), false);
+    // Immutable, and writeRequestBody takes a fresh body.stream() per attempt.
+    assertEquals(isReplayableRequestBody(new Blob(["x"])), true);
+    // Already drained by the attempt that failed, so a retry would send nothing.
     assertEquals(
       isReplayableRequestBody(new Blob(["x"]).stream() as unknown as BodyInit),
       false,

--- a/src/platform/compat/http/pinned-fetch.test.ts
+++ b/src/platform/compat/http/pinned-fetch.test.ts
@@ -285,11 +285,10 @@ describe("pinned connect attempts", () => {
     assertEquals(planPinnedConnectAttempts(["203.0.113.7"]), [["203.0.113.7"]]);
   });
 
-  it("offers the whole set first, then one address at a time", () => {
-    // The runtime gets its chance to race the set; the per-address attempts are
-    // the fallback for runtimes that ignore autoSelectFamily, such as Bun.
+  it("dials one address per attempt", () => {
+    // Every attempt dials one address; the runtime is never asked to choose.
     const plan = planPinnedConnectAttempts(["2606:4700::1", "104.26.14.209"]);
-    assertEquals(plan[0], ["2606:4700::1", "104.26.14.209"]);
+    assertEquals(plan[0], ["2606:4700::1"]);
     assertEquals(plan.length, 2);
     assertEquals(plan[1], ["104.26.14.209"]);
   });

--- a/src/platform/compat/http/pinned-fetch.test.ts
+++ b/src/platform/compat/http/pinned-fetch.test.ts
@@ -6,6 +6,9 @@ import {
   createPinnedFetchResponse,
   DEFAULT_OUTBOUND_USER_AGENT,
   fetchWithPinnedAddresses,
+  isReplayableRequestBody,
+  isRetriableConnectFailure,
+  planPinnedConnectAttempts,
 } from "./pinned-fetch.ts";
 
 describe("fetchWithPinnedAddresses", () => {
@@ -200,6 +203,42 @@ describe("fetchWithPinnedAddresses", () => {
     }
   });
 
+  it("falls through to the next validated address when the first refuses", async () => {
+    if (!isNode) return;
+
+    const { createServer } = await import("node:http");
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("reached");
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Node test server did not expose a TCP address");
+      }
+      // 127.0.0.2 is loopback with nothing listening, so it refuses fast. Only
+      // the second validated address serves. autoSelectFamily races IPv4
+      // against IPv6 and does nothing for two addresses of the same family, so
+      // the transport has to walk the list itself.
+      const response = await fetchWithPinnedAddresses(
+        new URL(`http://localhost:${address.port}/resource`),
+        ["127.0.0.2", "127.0.0.1"],
+        { method: "GET" },
+      );
+      assertEquals(response.status, 200);
+      assertEquals(await response.text(), "reached");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+    }
+  });
+
   it("returns a null body for HEAD through the native Node transport", async () => {
     if (!isNode) return;
 
@@ -238,5 +277,53 @@ describe("fetchWithPinnedAddresses", () => {
         server.close((error) => error ? reject(error) : resolve());
       });
     }
+  });
+});
+
+describe("pinned connect attempts", () => {
+  it("keeps a single validated address as one attempt", () => {
+    assertEquals(planPinnedConnectAttempts(["203.0.113.7"]), [["203.0.113.7"]]);
+  });
+
+  it("offers the whole set first, then one address at a time", () => {
+    // The runtime gets its chance to race the set; the per-address attempts are
+    // the fallback for runtimes that ignore autoSelectFamily, such as Bun.
+    const plan = planPinnedConnectAttempts(["2606:4700::1", "104.26.14.209"]);
+    assertEquals(plan[0], ["2606:4700::1", "104.26.14.209"]);
+    assertEquals(plan.length, 2);
+    assertEquals(plan[1], ["104.26.14.209"]);
+  });
+
+  it("tries the other address family before a sibling of the failed one", () => {
+    const plan = planPinnedConnectAttempts([
+      "2606:4700::1",
+      "2606:4700::2",
+      "104.26.14.209",
+    ]);
+    // A host with no IPv6 route fails on both AAAA records, so the A record has
+    // to come before the second AAAA.
+    assertEquals(plan[1], ["104.26.14.209"]);
+    assertEquals(plan[2], ["2606:4700::2"]);
+  });
+
+  it("retries only connect-level failures", () => {
+    assertEquals(isRetriableConnectFailure({ code: "ECONNREFUSED" }), true);
+    assertEquals(isRetriableConnectFailure({ code: "ENETUNREACH" }), true);
+    assertEquals(isRetriableConnectFailure({ code: "ECONNRESET" }), false);
+    assertEquals(isRetriableConnectFailure(new Error("boom")), false);
+    assertEquals(isRetriableConnectFailure(null), false);
+  });
+
+  it("replays only bodies that re-read identically", () => {
+    assertEquals(isReplayableRequestBody(null), true);
+    assertEquals(isReplayableRequestBody("{}"), true);
+    assertEquals(isReplayableRequestBody(new Uint8Array([1, 2])), true);
+    assertEquals(isReplayableRequestBody(new URLSearchParams("a=1")), true);
+    // Consumed by Readable.fromWeb, so a second attempt would send nothing.
+    assertEquals(isReplayableRequestBody(new Blob(["x"])), false);
+    assertEquals(
+      isReplayableRequestBody(new Blob(["x"]).stream() as unknown as BodyInit),
+      false,
+    );
   });
 });

--- a/src/platform/compat/http/pinned-fetch.ts
+++ b/src/platform/compat/http/pinned-fetch.ts
@@ -88,35 +88,6 @@ function addressFamily(address: string): 4 | 6 {
   return address.includes(":") ? 6 : 4;
 }
 
-function createPinnedLookup(addresses: readonly string[]): RequestOptions["lookup"] {
-  let nextIndex = 0;
-  return ((_hostname: string, options: unknown, callback: (...args: unknown[]) => void) => {
-    const requestedFamily = typeof options === "number"
-      ? options
-      : typeof options === "object" && options !== null && "family" in options
-      ? Number((options as { family?: unknown }).family ?? 0)
-      : 0;
-    const candidates = addresses.filter((address) =>
-      requestedFamily === 0 || addressFamily(address) === requestedFamily
-    );
-    if (candidates.length === 0) {
-      callback(new Error("No validated address matches the requested address family"));
-      return;
-    }
-    const wantsAll = typeof options === "object" && options !== null &&
-      (options as { all?: unknown }).all === true;
-    if (wantsAll) {
-      callback(
-        null,
-        candidates.map((address) => ({ address, family: addressFamily(address) })),
-      );
-      return;
-    }
-    const address = candidates[nextIndex++ % candidates.length]!;
-    callback(null, address, addressFamily(address));
-  }) as RequestOptions["lookup"];
-}
-
 /** Connect-level failures that mean "this address is unusable", not "this request is bad". */
 const RETRIABLE_CONNECT_CODES = new Set([
   "ECONNREFUSED",
@@ -129,13 +100,11 @@ const RETRIABLE_CONNECT_CODES = new Set([
 /**
  * Order the validated addresses into connection attempts.
  *
- * The first attempt offers the whole set, which is what `autoSelectFamily`
- * consumes on runtimes that implement it. Bun does not implement it, so a host
- * whose DNS carries an unreachable family (an AAAA record with no IPv6 route,
- * for instance) fails outright instead of falling through. The follow-up
- * attempts pin one address each so the walk happens here rather than depending
- * on the runtime, and a different family is tried before a sibling of the one
- * that just failed.
+ * Each attempt dials exactly one validated address, so the walk happens here
+ * rather than depending on the runtime: Node honours `autoSelectFamily` and a
+ * custom `lookup`, Bun honours neither. A different family is tried before a
+ * sibling of the one that just failed, because a host with no IPv6 route fails
+ * on every AAAA record its DNS carries.
  *
  * Every address is already validated by the egress policy, so trying them in
  * turn narrows nothing: the set is identical, only the order of use changes.
@@ -143,7 +112,7 @@ const RETRIABLE_CONNECT_CODES = new Set([
 export function planPinnedConnectAttempts(
   addresses: readonly string[],
 ): readonly (readonly string[])[] {
-  if (addresses.length <= 1) return [addresses];
+  if (addresses.length <= 1) return addresses.map((address) => [address]);
   const first = addresses[0]!;
   const otherFamily = addresses.filter((address) =>
     addressFamily(address) !== addressFamily(first)
@@ -151,7 +120,7 @@ export function planPinnedConnectAttempts(
   const sameFamily = addresses.slice(1).filter((address) =>
     addressFamily(address) === addressFamily(first)
   );
-  return [addresses, ...[...otherFamily, ...sameFamily].map((address) => [address])];
+  return [[first], ...[...otherFamily, ...sameFamily].map((address) => [address])];
 }
 
 /** True when the request may be issued again against a different address. */
@@ -287,16 +256,18 @@ export async function fetchWithPinnedAddresses(
   for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
     const requestOptions: RequestOptions & { autoSelectFamily?: boolean } = {
       protocol: url.protocol,
-      hostname: url.hostname,
-      port: url.port || undefined,
+      // Connect straight to the validated address. Overriding DNS through a
+      // custom `lookup` is the documented way to pin and Node honours it, but
+      // Bun's node:https ignores the address it returns and fails with
+      // ECONNREFUSED even for a reachable one, so the pin was inert there.
+      // Dialling the address directly needs no runtime cooperation; identity
+      // travels in the Host header and the TLS SNI name instead.
+      hostname: attempts[attemptIndex]![0]!,
+      port: url.port || (url.protocol === "https:" ? 443 : 80),
       path: `${url.pathname}${url.search}`,
       method,
-      headers: requestHeaders,
-      lookup: createPinnedLookup(attempts[attemptIndex]!),
-      // Let Node/Bun race the complete validated address set instead of binding
-      // availability to whichever A/AAAA record happened to be returned first.
-      // Bun ignores this, which is why the loop above also walks the addresses.
-      autoSelectFamily: true,
+      headers: { ...requestHeaders, host: url.host },
+
       ...(url.protocol === "https:" ? { servername: url.hostname } : {}),
     };
 

--- a/src/platform/compat/http/pinned-fetch.ts
+++ b/src/platform/compat/http/pinned-fetch.ts
@@ -117,6 +117,61 @@ function createPinnedLookup(addresses: readonly string[]): RequestOptions["looku
   }) as RequestOptions["lookup"];
 }
 
+/** Connect-level failures that mean "this address is unusable", not "this request is bad". */
+const RETRIABLE_CONNECT_CODES = new Set([
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EADDRNOTAVAIL",
+  "ETIMEDOUT",
+]);
+
+/**
+ * Order the validated addresses into connection attempts.
+ *
+ * The first attempt offers the whole set, which is what `autoSelectFamily`
+ * consumes on runtimes that implement it. Bun does not implement it, so a host
+ * whose DNS carries an unreachable family (an AAAA record with no IPv6 route,
+ * for instance) fails outright instead of falling through. The follow-up
+ * attempts pin one address each so the walk happens here rather than depending
+ * on the runtime, and a different family is tried before a sibling of the one
+ * that just failed.
+ *
+ * Every address is already validated by the egress policy, so trying them in
+ * turn narrows nothing: the set is identical, only the order of use changes.
+ */
+export function planPinnedConnectAttempts(
+  addresses: readonly string[],
+): readonly (readonly string[])[] {
+  if (addresses.length <= 1) return [addresses];
+  const first = addresses[0]!;
+  const otherFamily = addresses.filter((address) =>
+    addressFamily(address) !== addressFamily(first)
+  );
+  const sameFamily = addresses.slice(1).filter((address) =>
+    addressFamily(address) === addressFamily(first)
+  );
+  return [addresses, ...[...otherFamily, ...sameFamily].map((address) => [address])];
+}
+
+/** True when the request may be issued again against a different address. */
+export function isRetriableConnectFailure(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" && RETRIABLE_CONNECT_CODES.has(code);
+}
+
+/**
+ * A body may only be replayed when re-reading it yields the same bytes. Blob
+ * and ReadableStream bodies reach the wire through `Readable.fromWeb`, which
+ * consumes them, so a second attempt would send nothing.
+ */
+export function isReplayableRequestBody(body: BodyInit | null): boolean {
+  return body === null || typeof body === "string" ||
+    body instanceof URLSearchParams || body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body);
+}
+
 function copyResponseHeaders(message: IncomingMessage): Headers {
   const headers = new Headers();
   for (let i = 0; i < message.rawHeaders.length; i += 2) {
@@ -225,82 +280,102 @@ export async function fetchWithPinnedAddresses(
   const transport = url.protocol === "https:"
     ? await import("node:https")
     : await import("node:http");
-  const requestOptions: RequestOptions & { autoSelectFamily?: boolean } = {
-    protocol: url.protocol,
-    hostname: url.hostname,
-    port: url.port || undefined,
-    path: `${url.pathname}${url.search}`,
-    method,
-    headers: requestHeaders,
-    lookup: createPinnedLookup(addresses),
-    // Let Node/Bun race the complete validated address set instead of binding
-    // availability to whichever A/AAAA record happened to be returned first.
-    autoSelectFamily: true,
-    ...(url.protocol === "https:" ? { servername: url.hostname } : {}),
-  };
+  const attempts = planPinnedConnectAttempts(addresses);
+  const bodyIsReplayable = isReplayableRequestBody(body);
+  let lastConnectError: unknown;
 
-  return await new Promise<Response>((resolve, reject) => {
-    let settled = false;
-    let responseMessage: IncomingMessage | undefined;
-    const cleanupAbortListener = () => init.signal?.removeEventListener("abort", abort);
-    const rejectBeforeResponse = (error: unknown) => {
-      cleanupAbortListener();
-      reject(error);
+  for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
+    const requestOptions: RequestOptions & { autoSelectFamily?: boolean } = {
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port || undefined,
+      path: `${url.pathname}${url.search}`,
+      method,
+      headers: requestHeaders,
+      lookup: createPinnedLookup(attempts[attemptIndex]!),
+      // Let Node/Bun race the complete validated address set instead of binding
+      // availability to whichever A/AAAA record happened to be returned first.
+      // Bun ignores this, which is why the loop above also walks the addresses.
+      autoSelectFamily: true,
+      ...(url.protocol === "https:" ? { servername: url.hostname } : {}),
     };
-    const request = transport.request(requestOptions, async (message) => {
-      responseMessage = message;
-      try {
-        const responseHeaders = copyResponseHeaders(message);
-        const status = message.statusCode ?? 500;
-        if (method === "HEAD" || NULL_BODY_STATUSES.has(status)) {
-          message.once("end", cleanupAbortListener);
-          message.once("close", cleanupAbortListener);
-          message.once("error", cleanupAbortListener);
-          // Drain any protocol-invalid payload without exposing it through the
-          // Fetch response. Response rejects stream bodies for these statuses.
-          message.resume();
-          settled = true;
-          resolve(createPinnedFetchResponse(
-            status,
-            message.statusMessage ?? "",
-            responseHeaders,
-            null,
-            method,
-          ));
+
+    try {
+      return await new Promise<Response>((resolve, reject) => {
+        let settled = false;
+        let responseMessage: IncomingMessage | undefined;
+        const cleanupAbortListener = () => init.signal?.removeEventListener("abort", abort);
+        const rejectBeforeResponse = (error: unknown) => {
+          cleanupAbortListener();
+          reject(error);
+        };
+        const request = transport.request(requestOptions, async (message) => {
+          responseMessage = message;
+          try {
+            const responseHeaders = copyResponseHeaders(message);
+            const status = message.statusCode ?? 500;
+            if (method === "HEAD" || NULL_BODY_STATUSES.has(status)) {
+              message.once("end", cleanupAbortListener);
+              message.once("close", cleanupAbortListener);
+              message.once("error", cleanupAbortListener);
+              // Drain any protocol-invalid payload without exposing it through the
+              // Fetch response. Response rejects stream bodies for these statuses.
+              message.resume();
+              settled = true;
+              resolve(createPinnedFetchResponse(
+                status,
+                message.statusMessage ?? "",
+                responseHeaders,
+                null,
+                method,
+              ));
+              return;
+            }
+            const decoded = await decodeResponseBody(message, responseHeaders);
+            decoded.once("end", cleanupAbortListener);
+            decoded.once("close", cleanupAbortListener);
+            decoded.once("error", cleanupAbortListener);
+            const { Readable } = await import("node:stream");
+            const webBody = Readable.toWeb(decoded) as globalThis.ReadableStream<Uint8Array>;
+            settled = true;
+            resolve(createPinnedFetchResponse(
+              status,
+              message.statusMessage ?? "",
+              responseHeaders,
+              webBody,
+              method,
+            ));
+          } catch (error) {
+            rejectBeforeResponse(error);
+          }
+        });
+
+        const abort = () => {
+          const reason = init.signal?.reason ??
+            new DOMException("The operation was aborted", "AbortError");
+          responseMessage?.destroy(isErrorAcrossRealms(reason) ? reason : undefined);
+          request.destroy(isErrorAcrossRealms(reason) ? reason : undefined);
+          if (!settled) rejectBeforeResponse(reason);
+        };
+        init.signal?.addEventListener("abort", abort, { once: true });
+        if (init.signal?.aborted) {
+          abort();
           return;
         }
-        const decoded = await decodeResponseBody(message, responseHeaders);
-        decoded.once("end", cleanupAbortListener);
-        decoded.once("close", cleanupAbortListener);
-        decoded.once("error", cleanupAbortListener);
-        const { Readable } = await import("node:stream");
-        const webBody = Readable.toWeb(decoded) as globalThis.ReadableStream<Uint8Array>;
-        settled = true;
-        resolve(createPinnedFetchResponse(
-          status,
-          message.statusMessage ?? "",
-          responseHeaders,
-          webBody,
-          method,
-        ));
-      } catch (error) {
-        rejectBeforeResponse(error);
+        request.once("error", rejectBeforeResponse);
+        void writeRequestBody(request, body).catch((error) => request.destroy(error));
+      });
+    } catch (error) {
+      lastConnectError = error;
+      const hasAnotherAddress = attemptIndex < attempts.length - 1;
+      if (
+        !hasAnotherAddress || !bodyIsReplayable || init.signal?.aborted ||
+        !isRetriableConnectFailure(error)
+      ) {
+        throw error;
       }
-    });
-
-    const abort = () => {
-      const reason = init.signal?.reason ??
-        new DOMException("The operation was aborted", "AbortError");
-      responseMessage?.destroy(isErrorAcrossRealms(reason) ? reason : undefined);
-      request.destroy(isErrorAcrossRealms(reason) ? reason : undefined);
-      if (!settled) rejectBeforeResponse(reason);
-    };
-    init.signal?.addEventListener("abort", abort, { once: true });
-    if (init.signal?.aborted) {
-      abort();
-      return;
     }
-    request.once("error", rejectBeforeResponse);
-    void writeRequestBody(request, body).catch((error) => request.destroy(error));
-  });
+  }
+
+  throw lastConnectError;
 }

--- a/src/platform/compat/http/pinned-fetch.ts
+++ b/src/platform/compat/http/pinned-fetch.ts
@@ -300,6 +300,7 @@ export async function fetchWithPinnedAddresses(
       ...(url.protocol === "https:" ? { servername: url.hostname } : {}),
     };
 
+    let pendingRequest: ClientRequest | undefined;
     try {
       return await new Promise<Response>((resolve, reject) => {
         let settled = false;
@@ -363,9 +364,22 @@ export async function fetchWithPinnedAddresses(
           return;
         }
         request.once("error", rejectBeforeResponse);
+        // Bun reports connect failures through
+        // `process.nextTick(() => self.emit("error", err))`, so the emit can
+        // land after this promise has settled and after the `once` listener
+        // above has been consumed. With no listener left, Node stream
+        // semantics turn it into an uncaught exception and the process exits,
+        // which is how one refused address took down the dev server instead of
+        // failing a single request. This sink absorbs the late emit; the first
+        // error still rejects through `rejectBeforeResponse`.
+        request.on("error", () => {});
+        pendingRequest = request;
         void writeRequestBody(request, body).catch((error) => request.destroy(error));
       });
     } catch (error) {
+      // Release the socket of the attempt being abandoned. The sink above stays
+      // attached, so a teardown error from this destroy has somewhere to land.
+      pendingRequest?.destroy();
       lastConnectError = error;
       const hasAnotherAddress = attemptIndex < attempts.length - 1;
       if (

--- a/src/platform/compat/http/pinned-fetch.ts
+++ b/src/platform/compat/http/pinned-fetch.ts
@@ -127,18 +127,29 @@ export function planPinnedConnectAttempts(
 export function isRetriableConnectFailure(error: unknown): boolean {
   if (typeof error !== "object" || error === null) return false;
   const code = (error as { code?: unknown }).code;
-  return typeof code === "string" && RETRIABLE_CONNECT_CODES.has(code);
+  if (typeof code !== "string" || !RETRIABLE_CONNECT_CODES.has(code)) return false;
+  // ETIMEDOUT is the one code here that is not exclusively a connect failure:
+  // it also surfaces when a socket times out after the request was written, and
+  // replaying then could deliver a non-idempotent request twice. Only the
+  // connect syscall is known to have reached no server.
+  if (code === "ETIMEDOUT") {
+    return (error as { syscall?: unknown }).syscall === "connect";
+  }
+  return true;
 }
 
 /**
- * A body may only be replayed when re-reading it yields the same bytes. Blob
- * and ReadableStream bodies reach the wire through `Readable.fromWeb`, which
- * consumes them, so a second attempt would send nothing.
+ * A body may only be replayed when re-reading it yields the same bytes. A
+ * ReadableStream does not qualify: the failed attempt already drained it, so a
+ * retry would send nothing.
  */
 export function isReplayableRequestBody(body: BodyInit | null): boolean {
+  // A Blob counts: it is immutable and `writeRequestBody` calls `body.stream()`
+  // per attempt, so each attempt gets a fresh stream over identical bytes. A
+  // ReadableStream does not, because the attempt that failed already drained it.
   return body === null || typeof body === "string" ||
     body instanceof URLSearchParams || body instanceof ArrayBuffer ||
-    ArrayBuffer.isView(body);
+    ArrayBuffer.isView(body) || body instanceof Blob;
 }
 
 function copyResponseHeaders(message: IncomingMessage): Headers {


### PR DESCRIPTION
> **Framing correction.** This started as a fix for a live Bun defect. That defect is **already fixed upstream in Bun 1.3.14** (released 2026-05-13); the machine that found it was running 1.3.6. This PR is therefore *not* fixing a current-Bun bug, and I've rewritten the description so a reviewer isn't misled. The reasons to still take it are below, and none of them depend on that bug.

## What was wrong

The pinned transport overrode DNS with a custom `lookup` and asked the runtime to race the validated set via `autoSelectFamily`. Both are documented Node behaviours. Bun ≤ 1.3.13 honours neither:

```
                        Bun 1.3.6        Node        Bun 1.3.14
plain (no lookup)       200              200         200
servername only         200              200         200
custom lookup only      ECONNREFUSED     200         200
```

It failed even when the lookup returned the reachable IPv4 address `curl` uses, so on those versions the pin was **inert** — no address the egress policy validated could be reached through it.

Worth stating precisely, because it is the difference between broken and insecure: Bun **failed closed**. Supplying a lookup killed the connection rather than silently falling back to its own DNS resolution. Had it resolved on its own we would have seen 200s and an actual validation bypass; we saw refusals. This was an availability failure, not an SSRF hole.

## Why take it anyway

1. **Users choose their runtime, and you cannot make them upgrade.** Anyone on Bun < 1.3.14 hits a dev server that cannot fetch a module.
2. **It removes a dependency rather than working around one.** Dialling the validated address directly asks nothing of the runtime — no `lookup` support, no `autoSelectFamily`. Identity still travels with the request: `Host` from the original URL, TLS SNI unchanged, which is what the DNS override existed to protect.
3. **The crash guard is not specific to this bug.** Bun raises connect failures via `process.nextTick(() => self.emit("error", err))`, so an emit can land after the attempt's promise settled and after `once("error", …)` was consumed. With no listener left, Node stream semantics escalate it to an uncaught exception and the process exits — one refused address took down the dev server instead of failing a request. Each request now keeps a permanent no-op sink beside the `once` path, and abandoned attempts are destroyed before the next address is tried. That class of late emit is not unique to the lookup bug.

## Pinning is unchanged

Every candidate was already validated by the egress policy, so only the order of use differs — nothing new becomes reachable. Retries are limited to connect-level codes (**excluding `ECONNRESET`**, which can mean the request was already seen) and to bodies that re-read identically, since `Blob` and `ReadableStream` are consumed by `Readable.fromWeb` and would replay as nothing.

`createPinnedLookup` is deleted rather than left dead.

## Deno is not affected

`worker-egress-guard.ts:1248` routes Node and Bun through this transport and Deno through `startPinnedSocksTunnel`. Verified at the call site, not inferred from the module comment.

## Verification

Combined build with #3681 and #3682, four arms, all rendering the page:

| arm | http | marker | unprepared | adapter.fs | econnrefused | crashed |
|---|---|---|---|---|---|---|
| bun | **200** | ✓ | 0 | 0 | 0 | 0 |
| node | **200** | ✓ | 0 | 0 | 0 | 0 |
| deno | **200** | ✓ | 0 | 0 | 0 | 0 |
| deno + global-install config | **200** | ✓ | 0 | 0 | 0 | 0 |

Re-verified on Bun 1.3.14 after upgrading: 200, page rendered, zero refusals, zero crashes.

## Coverage

The behavioural test for this transport is gated on `isNode` and **silently no-ops in the Deno lane** — `isDeno=true isNode=false` there, so a test written that way passes in 0ms without executing. The planner and both predicates are tested directly and runtime-independently instead: attempt ordering, other-family-first, connect-code selectivity, and body replayability.