### PR TITLE
fix(cli): use public config exports for deploy

### DIFF
--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -1,9 +1,11 @@
-import { type EnvironmentConfig, getConfig, getEnvironmentConfig } from "veryfront/config";
-import { findVeryfrontConfigFile } from "#veryfront/config/config-files.ts";
 import {
+  type EnvironmentConfig,
   findHostedConfigIncompatibility,
+  findVeryfrontConfigFile,
   formatHostedConfigIncompatibility,
-} from "#veryfront/config/hosted-compatibility.ts";
+  getConfig,
+  getEnvironmentConfig,
+} from "veryfront/config";
 import { createFileSystem, isNotFoundError, runtime } from "veryfront/platform";
 import { join, relative, resolve } from "veryfront/platform/path";
 import { isWithinDirectory, normalizePath } from "veryfront/utils";

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -1,0 +1,20 @@
+import {
+  findHostedConfigIncompatibility,
+  formatHostedConfigIncompatibility,
+} from "./hosted-compatibility.ts";
+import * as publicConfig from "./index.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+describe("veryfront/config public exports", () => {
+  it("exposes hosted compatibility checks to CLI consumers", () => {
+    assertEquals(
+      publicConfig.findHostedConfigIncompatibility,
+      findHostedConfigIncompatibility,
+    );
+    assertEquals(
+      publicConfig.formatHostedConfigIncompatibility,
+      formatHostedConfigIncompatibility,
+    );
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -18,6 +18,11 @@ export {
   type VeryfrontConfigFile,
   type VeryfrontConfigFileName,
 } from "./config-files.ts";
+export {
+  findHostedConfigIncompatibility,
+  formatHostedConfigIncompatibility,
+  type HostedConfigIncompatibility,
+} from "./hosted-compatibility.ts";
 export { defineConfig, defineConfigWithEnv, mergeConfigs } from "./define-config.ts";
 export { getApiTokenEnv, isCiEnv, isDenoTestingEnv, isRscExperimentalEnabled } from "./env.ts";
 


### PR DESCRIPTION
## Summary

- expose hosted config compatibility helpers through `veryfront/config`
- use the public config boundary from the deploy helper
- add a focused public-export test

This fixes the CLI boundary regression detected by `deno task verify:quick`.

## Verification

- `deno test --preload=src/testing/preload.ts --no-check --allow-all src/config/index.test.ts cli/shared/deployment/deploy-project.test.ts`
- `deno task lint:cli-boundary`
- `deno check cli/shared/deployment/deploy-project.ts src/config/index.ts`
- `deno task verify:quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public configuration helpers for detecting and formatting hosted configuration incompatibilities.
  * Exposed hosted configuration incompatibility details for broader configuration workflows.

* **Bug Fixes**
  * Improved deployment configuration compatibility by using the public configuration interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->