### PR TITLE
docs: use verified Node container recipe

### DIFF
--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -50,15 +50,21 @@ node_modules
 Add this `Dockerfile`:
 
 ```dockerfile
-FROM denoland/deno:2.6.0
+FROM node:22-slim
 
 WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
 COPY . .
-RUN deno task build
+RUN npm run build
 
 EXPOSE 3000
-CMD ["deno", "task", "start"]
+CMD ["npm", "start"]
 ```
+
+`npm ci` installs the project-local Veryfront CLI from the lockfile before the
+image builds the app. Copying the package files first also lets Docker reuse the
+dependency layer when only application code changes.
 
 Build and run it:
 

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -1087,6 +1087,11 @@ describe("Guide: self-hosting.md", () => {
       const command of [
         "veryfront build",
         "veryfront serve",
+        "FROM node:22-slim",
+        "COPY package.json package-lock.json ./",
+        "RUN npm ci",
+        "RUN npm run build",
+        'CMD ["npm", "start"]',
         "docker build -t veryfront-app .",
         "docker run --rm -p 3000:3000 --env-file .env veryfront-app",
       ]
@@ -1094,6 +1099,7 @@ describe("Guide: self-hosting.md", () => {
       assertStringIncludes(guide, command);
     }
     assertEquals(guide.includes("veryfront login"), false);
+    assertEquals(guide.includes("FROM denoland/deno"), false);
   });
 });
 


### PR DESCRIPTION
## Summary

- install dependencies inside the self-hosted container with `npm ci`
- build and serve the npm quickstart through its package scripts
- add a docs contract that rejects the unverified Deno container recipe

The previous Dockerfile excluded `node_modules` but did not install dependencies, so `deno task build` failed with `veryfront: command not found`. The replacement was verified from a fresh `npm create veryfront@latest` project using public `veryfront@0.1.1233`, then built and served in Docker with an HTTP 200 response.

## Verification

- failing focused docs test before the guide change
- `deno test --preload=src/testing/preload.ts --no-check --allow-all tests/docs/guide-content.test.ts tests/docs/guide-contracts.test.ts tests/docs/guide-code-examples.test.ts`
- `deno task docs:validate`
- `deno fmt --check docs/guides/self-hosting.md tests/docs/guide-code-examples.test.ts`
- `git diff --check`
- `docker build -t veryfront-public-smoke-01233 .`
- container returned HTTP 200 on port 3100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the self-hosting Docker setup to use Node.js 22.
  - Added instructions for installing locked dependencies, building, and starting the application.
  - Improved Docker build caching by separating dependency files from application code.
  - Removed obsolete Deno-based setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->