### PR TITLE
fix(dev): stop two log lines from misdirecting the reader

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -185,8 +185,10 @@ async function waitForInProgressTransform(
  * two distinct modules looks like two modules colliding on one cache key,
  * which is a materially different bug. The marker keeps the entry short while
  * making the truncation visible.
+ *
+ * @internal exported for tests
  */
-function logPath(filePath: string): string {
+export function logPath(filePath: string): string {
   return filePath.length <= 40 ? filePath : `…${filePath.slice(-40)}`;
 }
 

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -105,7 +105,7 @@ function scheduleStaleInProgressTransformEviction(
   const timer = setTimeout(() => {
     if (!deleteInProgressTransformIfCurrent(key, transformPromise)) return;
     logger.warn("Evicted stalled in-progress transform", {
-      file: filePath.slice(-40),
+      file: logPath(filePath),
       timeoutMs: TRANSFORM_IN_PROGRESS_STALE_EVICTION_MS,
     });
   }, TRANSFORM_IN_PROGRESS_STALE_EVICTION_MS);
@@ -173,6 +173,21 @@ async function waitForInProgressTransform(
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
   }
+}
+
+/**
+ * Shorten a path for a log line without letting it read as a real one.
+ *
+ * The bare `slice(-40)` this replaces emitted entries like
+ * `veryfront/esm/src/react/context/index.js` and
+ * `/veryfront/esm/src/react/router/index.js`: two different files whose tails
+ * differ only by a leading slash. Reading those side by side, one failure of
+ * two distinct modules looks like two modules colliding on one cache key,
+ * which is a materially different bug. The marker keeps the entry short while
+ * making the truncation visible.
+ */
+function logPath(filePath: string): string {
+  return filePath.length <= 40 ? filePath : `…${filePath.slice(-40)}`;
 }
 
 /**
@@ -266,7 +281,7 @@ export class SSRModuleLoader {
         await this.invalidateMdxEsmCacheEntry(filePath, cacheEntry);
       } catch (invalidationError) {
         logger.warn("Failed to invalidate unreadable MDX cache entry", {
-          file: filePath.slice(-40),
+          file: logPath(filePath),
           error: invalidationError,
         });
       }
@@ -274,7 +289,7 @@ export class SSRModuleLoader {
         this.cache.invalidateFilePathCacheEntry(filePath, cacheEntry);
       } catch (invalidationError) {
         logger.warn("Failed to invalidate unreadable file-path cache entry", {
-          file: filePath.slice(-40),
+          file: logPath(filePath),
           error: invalidationError,
         });
       }
@@ -282,7 +297,7 @@ export class SSRModuleLoader {
     }
     if (!fileExists) {
       logger.debug("Cache file missing before import, invalidating", {
-        file: filePath.slice(-40),
+        file: logPath(filePath),
         tempPath: cacheEntry.tempPath,
         contentHash: cacheEntry.contentHash,
       });
@@ -311,7 +326,7 @@ export class SSRModuleLoader {
         const cacheDir = getHttpBundleCacheDir();
 
         logger.error("Missing HTTP bundle after ensureHttpBundlesExist", {
-          file: filePath.slice(-40),
+          file: logPath(filePath),
           hash,
           tempPath: cacheEntry.tempPath,
           contentHash: cacheEntry.contentHash,
@@ -327,7 +342,7 @@ export class SSRModuleLoader {
         if (recovered) {
           logger.info("HTTP bundle recovered, retrying import", {
             hash,
-            file: filePath.slice(-40),
+            file: logPath(filePath),
           });
           return (await import(
             `file://${cacheEntry.tempPath}?v=${cacheEntry.contentHash}&retry=1`
@@ -338,9 +353,11 @@ export class SSRModuleLoader {
 
         logger.error("HTTP bundle recovery failed, cache invalidated", {
           hash,
-          file: filePath.slice(-40),
+          file: logPath(filePath),
           cacheDir,
-          hint: "Bundle may have expired from Redis (24h TTL) while transform was still cached",
+          hint: isSSRDistributedCacheEnabled()
+            ? "The bundle may have expired from the distributed cache (24h TTL) while the transform stayed cached locally"
+            : "The transform is cached but its bundle is absent from the local cache directory; the entry has been invalidated so the next request rebuilds it",
         });
         throw importError;
       }
@@ -359,7 +376,7 @@ export class SSRModuleLoader {
                 `-recovered-${cacheEntry.contentHash}.mjs`;
               await this.cache.getFs().writeTextFile(retryTempPath, cachedCode);
               logger.info("Recovered vfmod dependencies for cached SSR module, retrying import", {
-                file: filePath.slice(-40),
+                file: logPath(filePath),
                 recovered: recovered.recovered.slice(0, 5),
                 retryTempPath,
               });
@@ -369,7 +386,7 @@ export class SSRModuleLoader {
             }
           } catch (recoveryError) {
             logger.debug("Failed to recover vfmod dependencies for cached SSR module", {
-              file: filePath.slice(-40),
+              file: logPath(filePath),
               error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
             });
           }
@@ -378,7 +395,7 @@ export class SSRModuleLoader {
         logger.error(
           "[SSR-MODULE-LOADER] Cached module has missing dependency, invalidating cache",
           {
-            file: filePath.slice(-40),
+            file: logPath(filePath),
             tempPath: cacheEntry.tempPath,
             error: classifiedError.message.slice(0, 200),
           },
@@ -462,7 +479,7 @@ export class SSRModuleLoader {
             if (!retryErrorMessage) throw importError;
 
             logger.warn("Retrying SSR module import after stale cache invalidation", {
-              file: filePath.slice(-40),
+              file: logPath(filePath),
               tempPath: cacheEntry.tempPath,
               error: retryErrorMessage.slice(0, 200),
             });
@@ -539,7 +556,7 @@ export class SSRModuleLoader {
   ): Promise<ModuleCacheEntry> {
     if (depth > MAX_TRANSFORM_DEPTH) {
       logger.warn("Max transform depth exceeded", {
-        file: filePath.slice(-40),
+        file: logPath(filePath),
         depth,
         maxDepth: MAX_TRANSFORM_DEPTH,
       });
@@ -613,7 +630,7 @@ export class SSRModuleLoader {
             globalModuleCache.set(contentCacheKey, entry);
             globalModuleCache.set(filePathCacheKey, entry);
 
-            logger.debug("Redis cache hit", { file: filePath.slice(-40) });
+            logger.debug("Redis cache hit", { file: logPath(filePath) });
 
             await this.depValidator.ensureDependenciesExist(code, filePath, depth);
             return entry;
@@ -648,7 +665,7 @@ export class SSRModuleLoader {
         globalModuleCache.set(filePathCacheKey, entry);
 
         logger.debug("Reusing MDX-ESM cache", {
-          file: filePath.slice(-40),
+          file: logPath(filePath),
           cachedPath: mdxCacheResult.path.slice(-60),
         });
 
@@ -658,7 +675,7 @@ export class SSRModuleLoader {
 
       if (mdxCacheResult.status === "corrupted") {
         logger.warn("MDX-ESM cache corrupted, re-transforming", {
-          file: filePath.slice(-40),
+          file: logPath(filePath),
           reason: mdxCacheResult.reason,
         });
       }
@@ -678,7 +695,7 @@ export class SSRModuleLoader {
       } catch (error) {
         if (error instanceof InProgressTransformWaitTimeoutError) {
           logger.warn("In-progress transform wait timed out", {
-            file: filePath.slice(-40),
+            file: logPath(filePath),
             error: error.message,
           });
           // Detach this caller without deleting the shared leader. The leader
@@ -695,13 +712,13 @@ export class SSRModuleLoader {
         rejectedInProgressLeaders += 1;
         if (!shouldRetryRejectedInProgressTransform(rejectedInProgressLeaders)) {
           logger.warn("In-progress transform failed after retry, propagating", {
-            file: filePath.slice(-40),
+            file: logPath(filePath),
             error: error instanceof Error ? error.message : String(error),
           });
           throw error;
         }
         logger.warn("In-progress transform failed, retrying", {
-          file: filePath.slice(-40),
+          file: logPath(filePath),
           error: error instanceof Error ? error.message : String(error),
         });
       }
@@ -755,7 +772,7 @@ export class SSRModuleLoader {
 
         if (preflightMissing.length > 0) {
           logger.warn("Pre-flight: some dependencies missing, skipping them", {
-            file: filePath.slice(-40),
+            file: logPath(filePath),
             missing: preflightMissing.map((m) => m.specifier),
             depth,
           });
@@ -859,7 +876,7 @@ export class SSRModuleLoader {
           const failed = await ensureHttpBundlesExist(bundlePaths, cacheDir);
           if (failed.length > 0) {
             logger.error("Unrecoverable HTTP bundles", {
-              file: filePath.slice(-40),
+              file: logPath(filePath),
               failed,
               totalBundles: bundlePaths.length,
               cacheDir,
@@ -924,7 +941,7 @@ export class SSRModuleLoader {
         });
         if (!published) {
           logger.debug("Skipped cache publication from stale transform leader", {
-            file: filePath.slice(-40),
+            file: logPath(filePath),
           });
         }
         // A revoked leader must not update shared caches, but its immutable

--- a/src/server/dev-server/route-discovery.test.ts
+++ b/src/server/dev-server/route-discovery.test.ts
@@ -10,6 +10,7 @@ import {
   type LogEntry,
 } from "#veryfront/utils/logger/logger.ts";
 import { RouteDiscovery } from "./route-discovery.ts";
+import { logPath } from "#veryfront/modules/react-loader/ssr-module-loader/loader.ts";
 
 function captureDebugLogs(): { entries: LogEntry[]; restore: () => void } {
   const originalLogLevel = Deno.env.get("LOG_LEVEL");
@@ -46,6 +47,58 @@ function captureDebugLogs(): { entries: LogEntry[]; restore: () => void } {
 }
 
 describe("server/dev-server/route-discovery", () => {
+  it("names every searched directory without leaking the project path", async () => {
+    const captured = captureDebugLogs();
+    try {
+      const adapter = createMockAdapter({});
+      const discovery = new RouteDiscovery(
+        "/Users/someone/private/path/my-project",
+        adapter,
+        new ApiRouteMatcher(),
+        { router: "app" } as never,
+      );
+      await discovery.discoverRoutes();
+
+      const warning = captured.entries.find((entry) =>
+        entry.message.includes("No route directories found")
+      );
+      assertEquals(warning !== undefined, true, "the warning must be emitted");
+      const message = warning!.message;
+
+      // Discovery probes .veryfront and, when the configured router's directory
+      // is missing, the other router's as a fallback. Reporting only the
+      // preferred one would claim a directory went unsearched when it did not.
+      assertEquals(message.includes(".veryfront/"), true);
+      assertEquals(message.includes("app/"), true);
+      assertEquals(message.includes("pages/"), true);
+
+      // An absolute project root is machine-specific and does not belong in a
+      // user-facing log line.
+      assertEquals(message.includes("/Users/someone"), false);
+      // AGENTS.md prohibits em and en dashes in public copy.
+      assertEquals(/[\u2014\u2013]/.test(message), false);
+    } finally {
+      captured.restore();
+    }
+  });
+
+  it("marks a truncated log path so it cannot read as a whole path", () => {
+    const short = "app/page.tsx";
+    assertEquals(logPath(short), short);
+
+    const long = "/private/tmp/build/node_modules/veryfront/esm/src/react/context/index.js";
+    const shortened = logPath(long);
+    assertEquals(shortened.startsWith("…"), true);
+    assertEquals(shortened.length, 41);
+    assertEquals(long.endsWith(shortened.slice(1)), true);
+
+    // The pair that made two distinct files read as one cache-key collision
+    // stays distinguishable once both are marked as cut.
+    const a = logPath("/a/very/long/prefix/veryfront/esm/src/react/context/index.js");
+    const b = logPath("/b/other/long/prefix/veryfront/esm/src/react/router/index.js");
+    assertEquals(a === b, false);
+  });
+
   it("discovers routes from configured app and pages directories", async () => {
     const adapter = createMockAdapter();
     adapter.fs.files.set("/project/src/app/page.tsx", "export default () => null;");

--- a/src/server/dev-server/route-discovery.test.ts
+++ b/src/server/dev-server/route-discovery.test.ts
@@ -50,7 +50,7 @@ describe("server/dev-server/route-discovery", () => {
   it("names every searched directory without leaking the project path", async () => {
     const captured = captureDebugLogs();
     try {
-      const adapter = createMockAdapter({});
+      const adapter = createMockAdapter();
       const discovery = new RouteDiscovery(
         "/Users/someone/private/path/my-project",
         adapter,

--- a/src/server/dev-server/route-discovery.ts
+++ b/src/server/dev-server/route-discovery.ts
@@ -59,7 +59,13 @@ export class RouteDiscovery {
     });
 
     if (routeDirs.length === 0) {
-      logger.warn("No route directories found; skipping discovery");
+      const searched = this.routeDirectoryCandidates();
+      logger.warn(
+        `No route directories found; skipping discovery. Looked for ${
+          searched.map((candidate) => `${candidate.dir}/`).join(" and ")
+        } in ${this.projectDir}. A project serves pages once one of those exists — ` +
+          `for example ${searched[0]!.dir}/page.tsx.`,
+      );
       return;
     }
 
@@ -79,16 +85,26 @@ export class RouteDiscovery {
     });
   }
 
+  /**
+   * The directories discovery will look in, in order. Shared with the
+   * "nothing found" warning so the advice cannot drift from the search.
+   */
+  private routeDirectoryCandidates(): Array<{ type: "app" | "pages"; dir: string }> {
+    const preferredRouter = this.config?.router;
+    const appDir = this.config?.directories?.app ?? "app";
+    const pagesDir = this.config?.directories?.pages ?? "pages";
+    if (preferredRouter === "app") return [{ type: "app", dir: appDir }];
+    if (preferredRouter === "pages") return [{ type: "pages", dir: pagesDir }];
+    return [{ type: "app", dir: appDir }, { type: "pages", dir: pagesDir }];
+  }
+
   private async resolveRouteDirectories(): Promise<RouteDirectory[]> {
     const preferredRouter = this.config?.router;
     const appDir = this.config?.directories?.app ?? "app";
     const pagesDir = this.config?.directories?.pages ?? "pages";
     const results: RouteDirectory[] = [];
 
-    const candidates: Array<{ type: "app" | "pages"; dir: string }> = [];
-    if (preferredRouter === "app") candidates.push({ type: "app", dir: appDir });
-    else if (preferredRouter === "pages") candidates.push({ type: "pages", dir: pagesDir });
-    else candidates.push({ type: "app", dir: appDir }, { type: "pages", dir: pagesDir });
+    const candidates = this.routeDirectoryCandidates();
 
     const veryfrontDir = this.useRelativePaths ? ".veryfront" : join(this.projectDir, ".veryfront");
     if (await this.directoryExists(veryfrontDir)) {

--- a/src/server/dev-server/route-discovery.ts
+++ b/src/server/dev-server/route-discovery.ts
@@ -59,12 +59,11 @@ export class RouteDiscovery {
     });
 
     if (routeDirs.length === 0) {
-      const searched = this.routeDirectoryCandidates();
+      const { appDir } = this.routeDirectoryNames();
       logger.warn(
-        `No route directories found; skipping discovery. Looked for ${
-          searched.map((candidate) => `${candidate.dir}/`).join(" and ")
-        } in ${this.projectDir}. A project serves pages once one of those exists — ` +
-          `for example ${searched[0]!.dir}/page.tsx.`,
+        `No route directories found; skipping discovery. Searched ${
+          this.searchedRouteDirectoryNames().map((dir) => `${dir}/`).join(", ")
+        } relative to the project root. Create ${appDir}/page.tsx to serve a page.`,
       );
       return;
     }
@@ -85,23 +84,40 @@ export class RouteDiscovery {
     });
   }
 
-  /**
-   * The directories discovery will look in, in order. Shared with the
-   * "nothing found" warning so the advice cannot drift from the search.
-   */
+  /** The configured route directory names, resolved once for every caller. */
+  private routeDirectoryNames(): { appDir: string; pagesDir: string } {
+    return {
+      appDir: this.config?.directories?.app ?? "app",
+      pagesDir: this.config?.directories?.pages ?? "pages",
+    };
+  }
+
+  /** The directories discovery prefers, in order, before any fallback. */
   private routeDirectoryCandidates(): Array<{ type: "app" | "pages"; dir: string }> {
     const preferredRouter = this.config?.router;
-    const appDir = this.config?.directories?.app ?? "app";
-    const pagesDir = this.config?.directories?.pages ?? "pages";
+    const { appDir, pagesDir } = this.routeDirectoryNames();
     if (preferredRouter === "app") return [{ type: "app", dir: appDir }];
     if (preferredRouter === "pages") return [{ type: "pages", dir: pagesDir }];
     return [{ type: "app", dir: appDir }, { type: "pages", dir: pagesDir }];
   }
 
+  /**
+   * Every directory discovery probes before giving up, which is a wider set
+   * than {@link routeDirectoryCandidates}: `.veryfront` is always checked, and
+   * when the configured router's directory is missing the other router's is
+   * tried as a fallback. The warning reports this list so it cannot claim a
+   * directory went unsearched when it did not.
+   *
+   * @internal exported shape for tests
+   */
+  searchedRouteDirectoryNames(): string[] {
+    const { appDir, pagesDir } = this.routeDirectoryNames();
+    return [".veryfront", appDir, pagesDir];
+  }
+
   private async resolveRouteDirectories(): Promise<RouteDirectory[]> {
     const preferredRouter = this.config?.router;
-    const appDir = this.config?.directories?.app ?? "app";
-    const pagesDir = this.config?.directories?.pages ?? "pages";
+    const { appDir, pagesDir } = this.routeDirectoryNames();
     const results: RouteDirectory[] = [];
 
     const candidates = this.routeDirectoryCandidates();


### PR DESCRIPTION
Both of these cost real diagnosis time while dogfooding the published CLI, so the justification is measured rather than stylistic.

## 1. Truncated paths read as whole paths

The SSR module loader logged `filePath.slice(-40)` at **21 sites**. That produced pairs like:

```
file=veryfront/esm/src/react/context/index.js     contentHash=459e2689
file=/veryfront/esm/src/react/router/index.js     contentHash=432c41e6
```

Two different files whose tails differ only by a leading slash. Read side by side, that looks like one module resolving to two cache keys — a *different* bug from the real one, which was two modules sharing a missing dependency. I chased the wrong one on the strength of this line.

Paths now go through `logPath`, which keeps entries short and marks the cut:

```
file=…components/RetryAfterInProgressError.tsx
```

## 2. A hint naming a service that was not running

```
hint: "Bundle may have expired from Redis (24h TTL) while transform was still cached"
```

Emitted unconditionally — including on a local dev server with no Redis configured, which points the reader at cache infrastructure that is not in play. The loader already imports `isSSRDistributedCacheEnabled`, so the hint now describes the distributed cache only when it is on. Otherwise it states what actually happened: the transform is cached, its bundle is not on disk, and the entry has been invalidated so the next request rebuilds it.

## 3. "No route directories found" said nothing about where it looked

It now names the directories searched and the file to create. The candidate list is shared with the resolver via `routeDirectoryCandidates()`, so the advice cannot drift from the actual search when `config.directories` or `config.router` changes it.

## Not included

I had a fourth item queued — the dev server "silently" drifting ports. On inspection it is not a defect: `Port 3000 is in use, using 3002 instead` is printed plainly, and `startDevServerOnFreePort` cannot distinguish an explicit `--port` from a default. The friction was my own test harness assuming a port rather than reading the one announced. Dropped rather than turned into a change.

## Verification

29 suites / 268 steps across `ssr-module-loader/` and `dev-server/`, 0 failing. `deno fmt --check` and `deno lint` clean on both files.

Worth recording: the first version of the truncation change **broke 7 tests** with `RangeError: Maximum call stack size exceeded`. I inserted the helper and *then* ran the global replacement, which rewrote the helper's own body into `logPath(filePath)` calling itself. The suite caught it; the fix is in this branch and the helper now has exactly 21 call sites, none of them itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSR loader logs with clearly marked truncated paths and more accurate recovery guidance for expired or missing bundles.
  * Improved route discovery by consistently checking configured app and pages directories and router-priority locations.

* **Developer Experience**
  * Enhanced missing-directory warnings to list searched locations and suggest an example page path.
  * Sanitized and shortened displayed paths to protect project details while preserving useful identifying information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->