### PR TITLE
docs: remove provider guide next links

### DIFF
--- a/docs/guides/integrations/github.md
+++ b/docs/guides/integrations/github.md
@@ -47,12 +47,6 @@ prompts, project files, tickets, or client-side environment variables.
 1. Start a new agent run that uses a read-only GitHub tool.
 2. Confirm the tool returns the connected user's GitHub data.
 
-## Next
-
-- [Integrations](../integrations.md): Declare GitHub tools and apply source or project policy.
-- [Set up Jira](./jira.md): Connect a Jira provider.
-- [Set up Salesforce](./salesforce.md): Connect a Salesforce provider.
-
 ## Related
 
 - [veryfront/integrations](../../api-reference/veryfront/integrations.md): Connector catalog and helper API.

--- a/docs/guides/integrations/jira.md
+++ b/docs/guides/integrations/jira.md
@@ -49,12 +49,6 @@ prompts, project files, tickets, or client-side environment variables.
 1. Start a new agent run that uses a read-only Jira tool.
 2. Confirm the tool returns the expected Atlassian site or Jira project data.
 
-## Next
-
-- [Integrations](../integrations.md): Declare Jira tools and apply source or project policy.
-- [Set up GitHub](./github.md): Connect a GitHub provider.
-- [Set up Salesforce](./salesforce.md): Connect a Salesforce provider.
-
 ## Related
 
 - [veryfront/integrations](../../api-reference/veryfront/integrations.md): Connector catalog and helper API.

--- a/docs/guides/integrations/salesforce.md
+++ b/docs/guides/integrations/salesforce.md
@@ -85,12 +85,6 @@ project environment variable through the approved secret-management workflow.
 2. Confirm the tool returns data from the target Salesforce org.
 3. For a service account, confirm the Salesforce audit trail attributes the request to the configured integration user.
 
-## Next
-
-- [Integrations](../integrations.md): Declare Salesforce tools and apply source or project policy.
-- [Set up GitHub](./github.md): Connect a GitHub provider.
-- [Set up Jira](./jira.md): Connect a Jira provider.
-
 ## Related
 
 - [veryfront/integrations](../../api-reference/veryfront/integrations.md): Connector catalog and helper API.


### PR DESCRIPTION
## Summary
- remove the redundant Next sections from the Salesforce, GitHub, and Jira setup guides
- retain each page’s related API and concept references

## Validation
- `deno fmt --check docs/guides/integrations/{salesforce,github,jira}.md`
- `git diff --check`
- pre-push formatting and lint passed; its repository-wide type check has existing unrelated errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed redundant “Next” navigation sections from the GitHub, Jira, and Salesforce integration guides.
  * Existing “Related” links remain available for navigating between relevant documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->