### PR TITLE
fix(bundler): keep compiled renderer service live

### DIFF
--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -9,7 +9,7 @@ import { assertEquals, assertExists, assertRejects, assertStringIncludes } from 
 import { describe, it } from "@std/testing/bdd";
 import { createRequire } from "node:module";
 
-import { EsbuildBundler } from "./esbuild-bundler.ts";
+import { EsbuildBundler, isLiveEsbuildServiceProcess } from "./esbuild-bundler.ts";
 import { rebuildContextWithSignal } from "./context-build-lifecycle.ts";
 
 const childProcess = createRequire(import.meta.url)("node:child_process") as {
@@ -87,6 +87,19 @@ describe("EsbuildBundler.transform", () => {
     } finally {
       await bundler.stop();
     }
+  });
+});
+
+describe("esbuild service lifecycle", () => {
+  it("treats a Node-compatible child with unset exit fields as live", () => {
+    assertEquals(
+      isLiveEsbuildServiceProcess({
+        killed: false,
+        exitCode: undefined,
+        signalCode: undefined,
+      } as Pick<ReturnType<typeof childProcess.spawn>, "killed" | "exitCode" | "signalCode">),
+      true,
+    );
   });
 });
 

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -214,10 +214,22 @@ function isEsbuildServiceSpawn(spawnArgs: unknown[]): boolean {
     args.includes("--ping");
 }
 
+/**
+ * Keep lifecycle tracking tolerant of Node-compatible child-process shims.
+ *
+ * Native Node represents an active child with `null` exit fields. Some
+ * compatible runtimes leave those fields undefined until the child exits.
+ */
+export function isLiveEsbuildServiceProcess(
+  child: Pick<ChildProcess, "killed" | "exitCode" | "signalCode">,
+): boolean {
+  return !child.killed &&
+    (child.exitCode === null || child.exitCode === undefined) &&
+    (child.signalCode === null || child.signalCode === undefined);
+}
+
 function isLiveService(service: EsbuildService): boolean {
-  return !service.child.killed &&
-    service.child.exitCode === null &&
-    service.child.signalCode === null;
+  return isLiveEsbuildServiceProcess(service.child);
 }
 
 function invokeEsbuild<T extends Promise<unknown>>(operation: () => T): T {


### PR DESCRIPTION
## Summary

Fixes compiled renderer startup when the Node-compatible `ChildProcess` reports `exitCode` and `signalCode` as `undefined` before exit. The esbuild adapter previously treated that live service as externally owned, permanently rejecting TSX transforms and returning preview HTTP 500s.

## Root cause

Staging renderer logs from strict E2E run #31756302514 show project TSX transforms failing with `[ext-bundler-esbuild] Cannot own an esbuild service started outside the module-wide adapter`. The production Deno-compiled runtime exposes unset exit fields during service startup; the adapter accepted only `null`.

## Validation

- Added a regression test for Node-compatible unset exit fields.
- `deno test --no-check --allow-all extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts` — 6 tests / 19 steps passed.
- `deno fmt --check` and `git diff --check` passed.

## Validation gap

The local compiled-binary test and repository typecheck are blocked before test execution by the local Deno 2.9.4 runtime lacking the repository-required `node:util/types` brand checks; CI runs in the supported environment and is the release gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of active esbuild processes across runtimes that report missing exit or signal information.
  * Prevented active bundler services from being incorrectly treated as stopped.

* **Tests**
  * Added coverage for identifying a running child process with undefined exit details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->