### PR TITLE
Clarify README opening copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 Veryfront Code is a full-stack framework for building AI-powered applications and agents with TypeScript and React.
 
-It gives you agents, tools, workflows, and a complete React rendering stack in a single framework. Veryfront Code runs on Node.js, Deno, and Bun, and can be deployed anywhere or shipped through the Veryfront platform with built-in preview environments and production hosting.
+It combines agents, tools, workflows, and a complete React rendering stack, and runs on Node.js, Deno, and Bun.
 
-Veryfront Code is an Apache-2.0 open-source framework that works standalone.
-Develop and evaluate locally, self-host in your own cloud or on-premises
-environment, or use Veryfront Cloud for managed platform services. A Veryfront
-account is not required for local development or self-hosting.
+Veryfront Code is open source under Apache-2.0. Develop locally, self-host in
+your own cloud or on-premises environment, or use the Veryfront platform for
+managed preview environments and production hosting. You do not need a
+Veryfront account for local development or self-hosting.
 
 <p align="center">
   <img src="./assets/banner.svg" alt="Veryfront" width="100%">


### PR DESCRIPTION
## Summary
- Remove repeated standalone and deploy-anywhere positioning from the README opening.
- Keep runtime support, Apache-2.0 licensing, local development, self-hosting, Veryfront platform hosting, and account requirements stated once.

## Verification
- git diff --check
- deno fmt --check README.md
- pre-push hook: formatting, lint, type check, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the framework’s components and runtime support.
  * Added details about open-source licensing and local or self-hosted usage.
  * Documented managed hosting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->