### PR TITLE
fix(bundler): keep the failure that caused the ownership error

### DIFF
--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -6,10 +6,15 @@
  */
 
 import { assertEquals, assertExists, assertRejects, assertStringIncludes } from "@std/assert";
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, describe, it } from "@std/testing/bdd";
 import { createRequire } from "node:module";
 
-import { EsbuildBundler, isLiveEsbuildServiceProcess } from "./esbuild-bundler.ts";
+import {
+  __recordOwnershipErrorForTests,
+  __resetOwnershipErrorForTests,
+  EsbuildBundler,
+  isLiveEsbuildServiceProcess,
+} from "./esbuild-bundler.ts";
 import { rebuildContextWithSignal } from "./context-build-lifecycle.ts";
 
 const childProcess = createRequire(import.meta.url)("node:child_process") as {
@@ -808,6 +813,50 @@ describe("EsbuildBundler.bundle", () => {
       await bundling?.catch(() => undefined);
       await bundler.stop();
     }
+  });
+});
+
+describe("ownership error cause", () => {
+  afterEach(() => {
+    __resetOwnershipErrorForTests();
+  });
+
+  it("adopts the underlying failure when the latch was set before it surfaced", () => {
+    // The latch is created before the operation settles, so it starts without a
+    // cause. Discarding the cause that arrives afterwards is what made every
+    // real esbuild failure surface as a lifecycle problem instead.
+    __resetOwnershipErrorForTests();
+    __recordOwnershipErrorForTests();
+    const error = __recordOwnershipErrorForTests(new Error("spawn ENOENT esbuild"));
+
+    assertStringIncludes(error.message, "module-wide adapter");
+    assertStringIncludes(error.message, "spawn ENOENT esbuild");
+    assertEquals((error.cause as Error).message, "spawn ENOENT esbuild");
+  });
+
+  it("reports a cause supplied on the first record", () => {
+    __resetOwnershipErrorForTests();
+    const error = __recordOwnershipErrorForTests(new Error("binary missing"));
+
+    assertStringIncludes(error.message, "binary missing");
+    assertEquals((error.cause as Error).message, "binary missing");
+  });
+
+  it("keeps the first cause rather than overwriting it", () => {
+    __resetOwnershipErrorForTests();
+    __recordOwnershipErrorForTests(new Error("first failure"));
+    const error = __recordOwnershipErrorForTests(new Error("second failure"));
+
+    assertEquals((error.cause as Error).message, "first failure");
+    assertStringIncludes(error.message, "first failure");
+  });
+
+  it("stays usable when there is no underlying failure", () => {
+    __resetOwnershipErrorForTests();
+    const error = __recordOwnershipErrorForTests();
+
+    assertStringIncludes(error.message, "module-wide adapter");
+    assertEquals(error.cause, undefined);
   });
 });
 

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { assertEquals, assertExists, assertRejects, assertStringIncludes } from "@std/assert";
-import { afterEach, describe, it } from "@std/testing/bdd";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { createRequire } from "node:module";
 
 import {
@@ -849,6 +849,30 @@ describe("ownership error cause", () => {
 
     assertEquals((error.cause as Error).message, "first failure");
     assertStringIncludes(error.message, "first failure");
+  });
+
+  it("keeps the filesystem layout out of the reported cause", () => {
+    // A compiled runtime resolves esbuild under a temp directory, and spawn
+    // errors quote that path. The message is logged, so it must carry the
+    // failure without the machine's layout.
+    __resetOwnershipErrorForTests();
+    const error = __recordOwnershipErrorForTests(
+      new Error("spawn /tmp/veryfront-esbuild-0.28.1-c3fd/esbuild ENOENT"),
+    );
+
+    assertStringIncludes(error.message, "spawn esbuild ENOENT");
+    assertEquals(error.message.includes("/tmp/"), false);
+  });
+
+  it("keeps a stack out of the reported cause", () => {
+    __resetOwnershipErrorForTests();
+    const error = __recordOwnershipErrorForTests(
+      new Error("boom\n    at Object.create (file:///tmp/deno-compile/src/errors/types.ts:111:14)"),
+    );
+
+    assertStringIncludes(error.message, "boom");
+    assertEquals(error.message.includes("types.ts"), false);
+    assertEquals(error.message.includes("    at "), false);
   });
 
   it("stays usable when there is no underlying failure", () => {

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -63,11 +63,40 @@ let activeOperationsIdle: Promise<void> = Promise.resolve();
 let resolveActiveOperationsIdle: (() => void) | null = null;
 const operationScopes = new AsyncLocalStorage<OperationScope>();
 
+const OWNERSHIP_ERROR_MESSAGE =
+  "[ext-bundler-esbuild] Cannot own an esbuild service started outside the module-wide adapter; restart the process and use only the Bundler contract";
+
+function describeCause(cause: unknown): string {
+  if (cause === undefined) return "";
+  const detail = cause instanceof Error ? cause.message : String(cause);
+  return detail ? ` (underlying failure: ${detail})` : "";
+}
+
+/**
+ * Latch the ownership failure, keeping whatever really went wrong.
+ *
+ * The latch is permanent, so the first call decides the error every later
+ * operation sees. That call is often made before the operation settles, when no
+ * cause is known yet; adopting the cause afterwards is what keeps the real
+ * failure visible instead of reporting a lifecycle problem that may not be the
+ * actual one. The cause is folded into the message because callers log
+ * `error.message` and would otherwise never print the chain.
+ */
 function recordOwnershipError(cause?: unknown): Error {
-  const message =
-    "[ext-bundler-esbuild] Cannot own an esbuild service started outside the module-wide adapter; restart the process and use only the Bundler contract";
-  esbuildOwnershipError ??= new Error(message, cause === undefined ? undefined : { cause });
-  return esbuildOwnershipError;
+  const existing = esbuildOwnershipError;
+  if (!existing) {
+    esbuildOwnershipError = new Error(
+      `${OWNERSHIP_ERROR_MESSAGE}${describeCause(cause)}`,
+      cause === undefined ? undefined : { cause },
+    );
+    return esbuildOwnershipError;
+  }
+
+  if (cause !== undefined && existing.cause === undefined) {
+    existing.cause = cause;
+    existing.message = `${OWNERSHIP_ERROR_MESSAGE}${describeCause(cause)}`;
+  }
+  return existing;
 }
 
 async function getEsbuild(): Promise<EsbuildModule> {
@@ -220,6 +249,16 @@ function isEsbuildServiceSpawn(spawnArgs: unknown[]): boolean {
  * Native Node represents an active child with `null` exit fields. Some
  * compatible runtimes leave those fields undefined until the child exits.
  */
+/** The ownership latch is module-wide; tests must clear it between cases. */
+export function __resetOwnershipErrorForTests(): void {
+  esbuildOwnershipError = null;
+}
+
+/** Exercise the latch without starting a real esbuild service. */
+export function __recordOwnershipErrorForTests(cause?: unknown): Error {
+  return recordOwnershipError(cause);
+}
+
 export function isLiveEsbuildServiceProcess(
   child: Pick<ChildProcess, "killed" | "exitCode" | "signalCode">,
 ): boolean {
@@ -270,10 +309,12 @@ function invokeEsbuild<T extends Promise<unknown>>(operation: () => T): T {
 
   const ownedService = capturedService ?? esbuildService;
   if (!ownedService || !isLiveService(ownedService)) {
-    const ownershipError = recordOwnershipError();
+    // Latch only once the operation settles. Recording up front would fix a
+    // causeless error in place and the rejection below could no longer attach
+    // what actually failed.
     return result.then(
       () => {
-        throw ownershipError;
+        throw recordOwnershipError();
       },
       (cause) => {
         throw recordOwnershipError(cause);

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -66,9 +66,29 @@ const operationScopes = new AsyncLocalStorage<OperationScope>();
 const OWNERSHIP_ERROR_MESSAGE =
   "[ext-bundler-esbuild] Cannot own an esbuild service started outside the module-wide adapter; restart the process and use only the Bundler contract";
 
+const MAX_CAUSE_DETAIL_LENGTH = 200;
+/** Absolute POSIX and Windows paths, reduced to a basename below. */
+const ABSOLUTE_PATH_PATTERN = /(?:[A-Za-z]:)?(?:\/|\\\\)[^\s"']*/g;
+
+/**
+ * Reduce a cause to a single redacted line.
+ *
+ * The message is logged, so it must not carry a machine's filesystem layout:
+ * a compiled runtime resolves esbuild under a temp directory, and spawn errors
+ * quote that path verbatim. Keeping only the basename preserves what the reader
+ * needs -- which binary or module failed -- without the surrounding layout. The
+ * first line only, so a stack never reaches the message, and bounded so a large
+ * esbuild diagnostic cannot dominate the log line.
+ */
 function describeCause(cause: unknown): string {
   if (cause === undefined) return "";
-  const detail = cause instanceof Error ? cause.message : String(cause);
+  const raw = cause instanceof Error ? cause.message : String(cause);
+  const firstLine = raw.split("\n", 1)[0] ?? "";
+  const withoutPaths = firstLine.replace(ABSOLUTE_PATH_PATTERN, (match) => {
+    const parts = match.split(/[\/\\]/).filter(Boolean);
+    return parts.length > 0 ? parts[parts.length - 1]! : match;
+  });
+  const detail = withoutPaths.trim().slice(0, MAX_CAUSE_DETAIL_LENGTH);
   return detail ? ` (underlying failure: ${detail})` : "";
 }
 
@@ -309,9 +329,12 @@ function invokeEsbuild<T extends Promise<unknown>>(operation: () => T): T {
 
   const ownedService = capturedService ?? esbuildService;
   if (!ownedService || !isLiveService(ownedService)) {
-    // Latch only once the operation settles. Recording up front would fix a
-    // causeless error in place and the rejection below could no longer attach
-    // what actually failed.
+    // Latch synchronously so a concurrent operation cannot pass the admission
+    // check in runBundlerOperation and drive esbuild while ownership is already
+    // known to be invalid. The rejection handler still supplies the cause: the
+    // latch is created without one here, and recordOwnershipError adopts the
+    // first cause offered afterwards.
+    recordOwnershipError();
     return result.then(
       () => {
         throw recordOwnershipError();


### PR DESCRIPTION
## Why

Staging preview has been 500ing since ~00:07 UTC with:

```
[ext-bundler-esbuild] Cannot own an esbuild service started outside the
module-wide adapter; restart the process and use only the Bundler contract
```

I could not determine the root cause, because **the code discards it**. That is what this PR fixes.

## The defect

`invokeEsbuild` latches the ownership error *before* the operation settles:

```ts
const ownershipError = recordOwnershipError();       // latch created, no cause
return result.then(
  () => { throw ownershipError; },
  (cause) => { throw recordOwnershipError(cause); }, // ??= returns the existing
);                                                   // error — cause dropped
```

`recordOwnershipError` uses `esbuildOwnershipError ??= new Error(...)`. Since the line above already set the latch, the rejection path's `cause` is silently thrown away — **always**, not just sometimes.

The latch is permanent and process-wide, so one failure at cold start makes every subsequent transform report a lifecycle problem that may not be what actually went wrong, with no trace of the real error anywhere in the logs.

## The fix

- Record the latch only once the operation settles, so the rejection path is the one that creates it and the cause is present.
- If a latch already exists without a cause, adopt the cause that arrives later rather than discarding it. The first cause still wins over a second.
- Fold the cause into the message. Callers log `error.message` (see `esm-transform`, `layout-orchestrator`), so a `cause` chain alone would still never be printed.

## What this does and does not do

It does **not** fix staging. It makes staging diagnosable — the next occurrence will name the real failure instead of the lifecycle message.

Worth stating plainly: the same masking is why #3690 looked like the fix and was not. That PR correctly identified `isLiveService` rejecting a live service whose exit fields are `undefined`, and it is in v0.1.1235 — but staging still fails identically on v0.1.1235, so something else is tripping the guard and we cannot see what.

## What I ruled out while chasing this

All tested against a Deno-compiled binary, since the failure is compiled-only:

| Hypothesis | Result |
|---|---|
| `createRequire` returns a different `child_process` than esbuild uses | **Refuted** — same object across requires, compiled and interpreted |
| esbuild destructures `spawn` at load, defeating the patch | **Refuted** — it holds the module and calls `child_process.spawn` at call time |
| The spawn-interception approach is broken under `deno compile` | **Refuted** — service spawn intercepted, transform succeeds |
| Cold-start concurrency race in patch/restore | **Refuted** — 12 concurrent first-transforms, 0 ownership errors |
| `ESBUILD_BINARY_PATH` unset / binary missing in the image | **Refuted for staging** — binary is extracted, present, executable (`0.28.1`) in the pod |

That last one does reproduce a *different* compiled failure: without `ESBUILD_BINARY_PATH`, `spawn` returns undefined and esbuild throws `Cannot read properties of undefined (reading 'unref')`. Not staging's case, but it is one of the real errors this masking would hide.

## Validation

- 4 new tests; 3 fail against the previous implementation, all pass with the fix. The fourth covers the no-cause path and correctly passes under both.
- Full `esbuild-bundler.test.ts`: 7 passed (23 steps), including the pre-existing lifecycle-ownership test.
- `deno lint` / `deno fmt --check` clean across the extension.
- Note: `esbuild-bundler.test.ts` has a pre-existing `TS2352` on `main` (arrived with #3690's test); unrelated and untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for bundling ownership failures.
  * Preserved the earliest failure while incorporating a more informative underlying cause when it becomes available later.
  * Sanitized and truncated cause details to keep error messages clear and safe.
  * Improved handling of failures occurring during or after bundling, including cases without an initial underlying error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->