### PR TITLE
fix(bundler): bind the esbuild binary path outside project scope

### DIFF
--- a/src/platform/compat/esbuild-init.ts
+++ b/src/platform/compat/esbuild-init.ts
@@ -81,14 +81,45 @@ async function extractEsbuildBinary(): Promise<string | null> {
   }
 }
 
-if (isDenoCompiled && !Deno.env.get("ESBUILD_BINARY_PATH")) {
+/**
+ * Load esbuild while the host environment is still the one on `process.env`.
+ *
+ * esbuild resolves its binary once, when its module first evaluates:
+ * `var ESBUILD_BINARY_PATH = process.env.ESBUILD_BINARY_PATH || ...`. The
+ * bundler adapter imports esbuild lazily, so in the hosted runtime that
+ * evaluation happens on the first transform -- inside a project environment
+ * scope, which serves the project's variables and not the host's. esbuild then
+ * reads `undefined`, falls back to a binary a compiled build does not ship,
+ * `spawn` returns undefined, and no service ever starts. Every transform in the
+ * process fails from then on.
+ *
+ * Importing here binds the path at startup, outside any project scope, so the
+ * scope keeps hiding the host environment from project code and esbuild still
+ * finds its binary. Only the module is loaded: the service itself starts lazily
+ * on the first transform.
+ */
+async function primeEsbuildModule(): Promise<void> {
   try {
-    const binaryPath = await extractEsbuildBinary();
-    if (binaryPath) {
-      Deno.env.set("ESBUILD_BINARY_PATH", binaryPath);
-      process.env.ESBUILD_BINARY_PATH = binaryPath;
-    }
+    await import("npm:esbuild@0.28.1");
   } catch (error) {
-    serverLogger.error("[esbuild] Binary extraction failed", error);
+    serverLogger.error("[esbuild] Failed to load esbuild during startup", error);
   }
+}
+
+if (isDenoCompiled) {
+  if (!Deno.env.get("ESBUILD_BINARY_PATH")) {
+    try {
+      const binaryPath = await extractEsbuildBinary();
+      if (binaryPath) {
+        Deno.env.set("ESBUILD_BINARY_PATH", binaryPath);
+        process.env.ESBUILD_BINARY_PATH = binaryPath;
+      }
+    } catch (error) {
+      serverLogger.error("[esbuild] Binary extraction failed", error);
+    }
+  }
+
+  // Runs even when the path was already set in the environment: the binding
+  // esbuild makes at module load is what matters, not who set the variable.
+  await primeEsbuildModule();
 }


### PR DESCRIPTION
## Root cause of the staging preview outage

Staging preview has returned **500 for every TSX transform since v0.1.1233**, surfacing as:

```
[ext-bundler-esbuild] Cannot own an esbuild service started outside the module-wide adapter
```

That message is a symptom. **No esbuild service is ever spawned** — confirmed by inspecting the staging pod, where no esbuild process exists at all. esbuild cannot find its binary.

esbuild resolves the binary exactly once, when its module first evaluates (`lib/main.js:1889`):

```js
var ESBUILD_BINARY_PATH = process.env.ESBUILD_BINARY_PATH || ...
```

The bundler adapter imports esbuild **lazily**, so in the hosted runtime that evaluation happens on the first transform — inside a project environment scope, which serves the project's variables and not the host's. esbuild reads `undefined`, falls back to a binary a compiled build does not ship, `spawn` returns undefined, `child.unref()` throws, and the process never recovers.

## The fix

Import esbuild during startup, while the host environment is still the one on `process.env`. Only the module is loaded — the service still starts lazily on the first transform.

**One file. No change to project env isolation. No test rewrites.**

## Verified in a compiled binary

| condition | result |
|---|---|
| `ESBUILD_BINARY_PATH` visible | `transform ok` |
| hidden behind an active project scope | `Cannot read properties of undefined (reading 'unref')` |
| **imported at startup, then enter the scope** | **`transform ok`, and the scope still hides the host env** |

That last row is the fix: the transform succeeds *and* isolation is intact.

## What changed since the first revision

The first revision made the scoped `process.env` view fall back to the host record. A reviewer flagged that as a P1, and they were right — `runtime-handler/index.ts:619-622` activates the scope *specifically* for multi-tenant proxy mode:

```ts
// Only activate env isolation in proxy mode (multi-tenant).
const shouldIsolateEnv = !adapterRes.isLocalProject && !!reqCtx.token
```

so the fallback would have let a tenant route read host credentials such as `VERYFRONT_API_TOKEN`. My justification — that same-isolate code could reach the host env anyway — did not hold: the isolation is deliberate and multi-tenant, not incidental consistency. That approach is fully reverted; `scoped-process-env.ts` and its tests are untouched on this branch.

## Ruled out along the way

Each tested against a Deno-compiled binary, not argued:

| hypothesis | result |
|---|---|
| `createRequire` returns a different `child_process` than esbuild uses | refuted — same object, compiled and interpreted |
| esbuild destructures `spawn` at load, defeating the patch | refuted — it calls `child_process.spawn` at call time |
| the spawn-interception approach is broken under `deno compile` | refuted — service spawn intercepted, transform succeeds |
| cold-start concurrency race in patch/restore | refuted — 12 concurrent first-transforms, 0 ownership errors |

## Validation

- `deno check` / `lint` / `fmt` clean; full pre-push suite passed.
- `src/server/project-env/` + `src/platform/compat/process/`: 11 passed (128 steps) — the isolation tests pass **unmodified**, which is the evidence that nothing was weakened.

## Sequencing

Needs a release and staging deploy before Remote E2E Health goes green. Pairs with #3697, which stops the ownership latch discarding the underlying cause — that masking is what made this take a day to find.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved esbuild startup behavior in compiled Deno environments.
  * Ensured required initialization occurs reliably when configuring or extracting the esbuild binary.
  * Improved resilience by logging module-loading issues without interrupting startup.
  * Preserved existing error handling and logging for binary extraction failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->