### PR TITLE
Place README banner beneath tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 **Put your agents to work.**
 
+<p align="center">
+  <img src="./assets/banner.svg" alt="Veryfront" width="100%">
+</p>
+
 Veryfront Code is a full-stack framework for building AI-powered applications and agents with TypeScript and React.
 
 It combines agents, tools, workflows, and a complete React rendering stack, and runs on Node.js, Deno, and Bun.
@@ -14,10 +18,6 @@ Veryfront Code is open source under Apache-2.0. Develop locally, self-host in
 your own cloud or on-premises environment, or use the Veryfront platform for
 managed preview environments and production hosting. You do not need a
 Veryfront account for local development or self-hosting.
-
-<p align="center">
-  <img src="./assets/banner.svg" alt="Veryfront" width="100%">
-</p>
 
 ## Get started
 


### PR DESCRIPTION
## Summary

- Move the existing banner directly below “Put your agents to work.”
- Keep the banner asset and introductory copy unchanged.
- Create a clearer title, message, visual, and explanation sequence.

## Verification

- `git diff --check`
- `deno fmt --check README.md`
- Confirmed the banner appears once and follows the tagline
- Pre-push formatting, lint, and type checks passed
- Unit tests reached 3,813 passing tests, then failed on the existing `chat attachment CSRF` timer leak. The same leak reproduces when that test file runs alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Moved the project banner image to a more prominent position near the top of the README.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->