### PR TITLE
fix(dev): treat a wildcard listener as holding the port

### DIFF
--- a/cli/commands/dev/port-fallback.test.ts
+++ b/cli/commands/dev/port-fallback.test.ts
@@ -32,14 +32,14 @@ function probeBusyOn(busy: number[]): {
 const FREE_PORT_ATTEMPTS = 25;
 
 /**
- * Binds an ephemeral loopback port on one family, or returns null when the host
- * has no address in that family at all (CI containers are routinely IPv4-only).
+ * Binds an ephemeral port on one address, or returns null when the host has no
+ * address in that family at all (CI containers are routinely IPv4-only).
  *
  * Only a missing address family is worth skipping for. Every other bind failure
  * - a permission error, a resource limit - is rethrown, so it fails the test
  * that called this rather than quietly turning it into a no-op.
  */
-function listenOnLoopback(hostname: string): Deno.Listener | null {
+function listenOn(hostname: string): Deno.Listener | null {
   try {
     return Deno.listen({ hostname, port: 0 });
   } catch (error) {
@@ -147,7 +147,7 @@ describe("cli/commands/dev/port-fallback", () => {
       // ::1 wherever IPv6 is available - so a second dev server's port scan sees
       // an IPv4-only probe succeed on a port the first instance already holds,
       // and hands out a port that is not actually free.
-      const held = listenOnLoopback("::1");
+      const held = listenOn("::1");
       if (!held) return; // no IPv6 on this host - nothing to collide with
 
       const heldPort = (held.addr as Deno.NetAddr).port;
@@ -155,6 +155,27 @@ describe("cli/commands/dev/port-fallback", () => {
         assertEquals(await isPortAvailable(heldPort), false);
       } finally {
         held.close();
+      }
+    });
+
+    it("skips a port held on a wildcard address", async () => {
+      // BSD and macOS let a more specific address bind over a wildcard holder,
+      // so loopback-only probes call a bare `listen(port)` port free and the
+      // dev server lands beside that listener instead of falling forward.
+      for (const wildcard of ["::", "0.0.0.0"]) {
+        const held = listenOn(wildcard);
+        if (!held) continue; // no address in that family on this host
+
+        const heldPort = (held.addr as Deno.NetAddr).port;
+        try {
+          assertEquals(
+            await isPortAvailable(heldPort),
+            false,
+            `a listener on ${wildcard}:${heldPort} must count as holding that port`,
+          );
+        } finally {
+          held.close();
+        }
       }
     });
 

--- a/cli/commands/dev/port-fallback.ts
+++ b/cli/commands/dev/port-fallback.ts
@@ -54,26 +54,31 @@ export function isAddressFamilyUnavailableError(error: unknown): boolean {
     message.includes("address family not supported");
 }
 
+/** The wildcards a listener binds when it names no host. */
+const ANY_ADDRESS = Object.freeze({ IPV4: "0.0.0.0", IPV6: "::" } as const);
+
 /**
- * The loopback addresses a `veryfront dev` listener can land on.
+ * The addresses a port has to be free on before `veryfront dev` can have it.
  *
- * Which family a listener gets is decided by the runtime, not by the CLI: the
- * Deno HTTP adapter defaults to `LOCALHOST.IPV4`, while the Node adapter that
- * the published npm build runs defaults to the *name* `localhost`, which
- * resolves to `::1` first on any dual-stack host. That is why one `veryfront
- * dev` serves the app on `127.0.0.1:3000` but its MCP server - `--port + 2` -
- * on `[::1]:3002`.
+ * Both loopback families are probed because the runtime, not the CLI, picks
+ * which one a listener lands on: the Deno adapter defaults to `LOCALHOST.IPV4`,
+ * the published npm build's Node adapter to the name `localhost`, which
+ * resolves to `::1` first on a dual-stack host.
  *
- * A probe that bound only IPv4 therefore reported IPv6-held ports as free, and
- * a second `veryfront dev` announced "Port 3000 is in use, using 3002 instead"
- * while 3002 was already reserved by the first instance's MCP server. Nothing
- * hard-failed only because the two listeners landed on different families.
+ * Both wildcards are probed because a bare `listen(port)` binds `::` or
+ * `0.0.0.0`, and BSD and macOS let a more specific address bind over a wildcard
+ * holder - so loopback-only probes call such a port free and the dev server
+ * silently lands beside the existing listener instead of falling forward.
  *
- * The literal addresses are probed rather than the name `localhost` because a
- * listen on a name binds just the first address it resolves to, which would
- * leave the other family unchecked exactly as before.
+ * Literal addresses rather than the name `localhost`: a listen on a name binds
+ * only the first address it resolves to, leaving the other family unchecked.
  */
-const PROBE_HOSTNAMES: readonly string[] = [LOCALHOST.IPV4, LOCALHOST.IPV6];
+const PROBE_HOSTNAMES: readonly string[] = [
+  LOCALHOST.IPV4,
+  LOCALHOST.IPV6,
+  ANY_ADDRESS.IPV4,
+  ANY_ADDRESS.IPV6,
+];
 
 /** What one bind-and-release attempt learned about a port on one address. */
 type ProbeOutcome = "free" | "in-use" | "no-such-family";


### PR DESCRIPTION
## Problem

`veryfront dev` prints `Ready — http://localhost:3000` and then serves a *different process's* app on that URL.

Reproduced on macOS with an unrelated dev server already running:

| Process | Bind | Result |
|---|---|---|
| other dev server (bare `listen(3000)`) | `*:3000` (`::`, dual-stack) | holds the port |
| `veryfront dev` | `127.0.0.1:3000` | binds anyway, no warning |

`http://localhost:3000` resolves to `::1` first, so the browser reaches the *other* process. `http://127.0.0.1:3000` reaches the veryfront app. Neither the port fall-forward nor the `Port N is in use` warning fired.

## Cause

`PROBE_HOSTNAMES` checks only the two *specific* loopback addresses. BSD and macOS permit binding a more specific address over a wildcard holder, so both probes report free:

```
holder bound on :::3999
probe 127.0.0.1:3999 -> free      ← miss
probe ::1:3999       -> free      ← miss
probe 0.0.0.0:3999   -> in-use
probe :::3999        -> in-use
```

#3562 added fall-forward; #3650 widened the probe from IPv4-only to both loopback families. Both addresses #3650 added are specific, so a *wildcard* holder — which is what any bare `listen(port)` creates — is still invisible.

## Fix

Probe the two wildcards alongside the two loopback addresses. A port counts as available only when nothing holds it on any of them.

## Testing

Test first, and it failed for the right reason before the change:

```
skips a port held on a wildcard address ... FAILED
  AssertionError: a listener on :::61774 must count as holding that port
  -   true
  +   false
```

After: `ok | 1 passed (24 steps) | 0 failed`. Full CLI suite: `ok | 324 passed (3284 steps) | 0 failed`. `deno lint` and `deno check` clean.

Verified against the live collision that prompted this, with the real listeners still up:

```
isPortAvailable(3000)   = false
findAvailablePort(3000) = 3001
```

## Notes for review

- **Deliberate over-trigger.** Probing the wildcards can also report a port busy when a listener holds an unrelated non-loopback address (e.g. `192.168.1.5:3000`). That falls forward and prints `Port 3000 is in use, using 3001 instead`, which is the safe direction — the alternative is the silent collision above.
- **Other consumer.** `clearLocalCachesIfPortFree` (`cli/commands/dev/command.ts:148`) shares this probe. The broadening only makes it skip clearing caches while another server holds the port — also the safe direction.
- **Not fixed here.** `cli/commands/dev/command.ts:258` hardcodes `http://localhost:${boundPort}` rather than deriving the URL from the bound address. It stops being user-visible once fall-forward works; worth a separate change.
- The `PROBE_HOSTNAMES` doc comment is condensed rather than extended; the rationale from #3650 is preserved in shorter form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development server port availability checks.
  * Ports occupied on IPv4 or IPv6 wildcard addresses are now correctly reported as unavailable.
  * Added graceful handling for environments without IPv4 or IPv6 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->