### PR TITLE
fix(dev): print the address the dev server bound, not `localhost`

### DIFF
--- a/cli/commands/demo/dev-step.test.ts
+++ b/cli/commands/demo/dev-step.test.ts
@@ -5,7 +5,10 @@ import type { DevCommandResult } from "../dev/index.ts";
 import { runDemoDevStep } from "./dev-step.ts";
 
 /** A dev server that fell forward off the requested 3000 onto `port`. */
-function devServerOn(port: number): { result: DevCommandResult; stopped: () => boolean } {
+function devServerOn(
+  port: number,
+  bindAddress = "127.0.0.1",
+): { result: DevCommandResult; stopped: () => boolean } {
   let stopped = false;
   return {
     stopped: () => stopped,
@@ -13,6 +16,7 @@ function devServerOn(port: number): { result: DevCommandResult; stopped: () => b
       ready: Promise.resolve(),
       done: Promise.resolve(),
       port,
+      bindAddress,
       stop: () => {
         stopped = true;
         return Promise.resolve();
@@ -37,11 +41,11 @@ describe("cli/commands/demo/dev-step", () => {
       log: (line) => lines.push(line),
     });
 
-    assertEquals(opened, ["http://localhost:3007"]);
+    assertEquals(opened, ["http://127.0.0.1:3007"]);
 
-    const shown = lines.find((line) => line.includes("http://localhost:"));
+    const shown = lines.find((line) => line.includes("http://127.0.0.1:"));
     assert(shown !== undefined, "the demo must print the dev server address");
-    assertStringIncludes(shown, "http://localhost:3007/");
+    assertStringIncludes(shown, "http://127.0.0.1:3007/");
 
     // The requested port belongs to whatever caused the collision.
     assertEquals(lines.some((line) => line.includes(":3000")), false);
@@ -61,7 +65,26 @@ describe("cli/commands/demo/dev-step", () => {
       log: () => {},
     });
 
-    assertEquals(opened, ["http://localhost:3000"]);
+    assertEquals(opened, ["http://127.0.0.1:3000"]);
+  });
+
+  it("shows the address the server bound, not the name `localhost`", async () => {
+    // `localhost` resolves to ::1 first on a dual-stack host, so the name can
+    // point at a process other than the demo's own dev server.
+    const server = devServerOn(3000, "::1");
+    const opened: string[] = [];
+
+    await runDemoDevStep({
+      start: () => Promise.resolve(server.result),
+      open: (url) => {
+        opened.push(url);
+        return Promise.resolve();
+      },
+      waitForStop: () => Promise.resolve(true),
+      log: () => {},
+    });
+
+    assertEquals(opened, ["http://[::1]:3000"]);
   });
 
   it("stops the server once the viewer asks to move on", async () => {

--- a/cli/commands/demo/dev-step.ts
+++ b/cli/commands/demo/dev-step.ts
@@ -9,6 +9,7 @@
 
 import { brand, dim, success } from "#cli/ui";
 import type { DevCommandResult } from "../dev/index.ts";
+import { serverDisplayUrl } from "../dev/server-url.ts";
 
 export interface DemoDevStepDeps {
   /** Starts the dev server. */
@@ -24,16 +25,17 @@ export interface DemoDevStepDeps {
 /**
  * Shows the running dev server, opens it, then stops it on request.
  *
- * Both the printed URL and the opened URL come from `result.port` - the port
- * the server actually bound. `veryfront dev` asks for 3000 but falls forward
- * when that is taken, so keying off the requested port would send the viewer to
- * whatever process caused the collision instead of to the demo.
+ * Both the printed URL and the opened URL come from the address and port the
+ * server actually bound. `veryfront dev` asks for 3000 but falls forward when
+ * that is taken, and it binds a literal address rather than the name
+ * `localhost` - so keying off either the requested port or the name would send
+ * the viewer to whatever process caused the collision instead of to the demo.
  */
 export async function runDemoDevStep(deps: DemoDevStepDeps): Promise<void> {
   const result = await deps.start();
   await result.ready;
 
-  const serverUrl = `http://localhost:${result.port}`;
+  const serverUrl = serverDisplayUrl(result.bindAddress, result.port);
 
   deps.log(`  ${success("●")} ${brand(`${serverUrl}/`)}`);
   deps.log("");

--- a/cli/commands/dev/command.ts
+++ b/cli/commands/dev/command.ts
@@ -26,6 +26,7 @@ import { createStagedPushOptions, pushCommand, type PushOptions } from "../push/
 import { createProjectSelector } from "./project-selector.ts";
 import { createDevLogController } from "./log-controller.ts";
 import { findAvailablePort, isPortAvailable, isPortInUseError } from "./port-fallback.ts";
+import { serverDisplayUrl } from "./server-url.ts";
 import { listInferenceOptions } from "./inference-status.ts";
 
 export interface DevOptions {
@@ -63,6 +64,12 @@ export interface DevCommandResult {
    * the collision.
    */
   port: number;
+  /**
+   * The address the server bound. Embedded callers must build URLs from this
+   * rather than from the name `localhost`, which resolves to `::1` first on a
+   * dual-stack host and so can name an address the server is not listening on.
+   */
+  bindAddress: string;
   /** Stop the dev server programmatically (for demo mode) */
   stop: () => Promise<void>;
 }
@@ -335,11 +342,12 @@ export function devCommand(options: DevOptions): Promise<DevCommandResult> {
           ready: devServer.ready,
           done,
           port: boundPort,
+          bindAddress: devServer.bindAddress,
           stop: shutdown,
         };
       }
 
-      const serverUrl = `http://localhost:${boundPort}`;
+      const serverUrl = serverDisplayUrl(devServer.bindAddress, boundPort);
       const elapsed = Date.now() - startTime;
 
       console.log();
@@ -446,6 +454,7 @@ export function devCommand(options: DevOptions): Promise<DevCommandResult> {
         ready: devServer.ready,
         done,
         port: boundPort,
+        bindAddress: devServer.bindAddress,
         stop: shutdown,
       };
     },

--- a/cli/commands/dev/dev.test.ts
+++ b/cli/commands/dev/dev.test.ts
@@ -82,6 +82,7 @@ describe("cli/commands/dev", () => {
         ready: Promise.resolve(),
         done: Promise.resolve(),
         port: 3000,
+        bindAddress: "127.0.0.1",
         stop: async () => {},
       };
 
@@ -96,6 +97,7 @@ describe("cli/commands/dev", () => {
         ready: Promise.resolve(),
         done: new Promise(() => {}), // never resolves
         port: 3000,
+        bindAddress: "127.0.0.1",
         stop: async () => {},
       };
 
@@ -109,6 +111,7 @@ describe("cli/commands/dev", () => {
         ready: Promise.resolve(),
         done: Promise.resolve(),
         port: 3000,
+        bindAddress: "127.0.0.1",
         stop: () => {
           stopped = true;
           return Promise.resolve();
@@ -197,6 +200,7 @@ describe("cli/commands/dev", () => {
           ready: Promise.resolve(),
           done: Promise.resolve(),
           port: started.port,
+          bindAddress: "127.0.0.1",
           stop: () => Promise.resolve(),
         };
 

--- a/cli/commands/dev/server-url.test.ts
+++ b/cli/commands/dev/server-url.test.ts
@@ -1,0 +1,29 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { serverDisplayUrl } from "./server-url.ts";
+
+describe("cli/commands/dev/server-url", () => {
+  describe("serverDisplayUrl", () => {
+    it("names the address the server actually bound, not `localhost`", () => {
+      // The dev server binds LOCALHOST.IPV4. `localhost` resolves to ::1 first
+      // on a dual-stack host, so printing the name points at an address the
+      // server is not listening on.
+      assertEquals(serverDisplayUrl("127.0.0.1", 3000), "http://127.0.0.1:3000");
+    });
+
+    it("brackets an IPv6 address so the URL is valid", () => {
+      assertEquals(serverDisplayUrl("::1", 3000), "http://[::1]:3000");
+    });
+
+    it("shows a loopback address when the server bound a wildcard", () => {
+      // A wildcard is a bind target, not somewhere to browse to.
+      assertEquals(serverDisplayUrl("0.0.0.0", 3000), "http://127.0.0.1:3000");
+      assertEquals(serverDisplayUrl("::", 3000), "http://[::1]:3000");
+    });
+
+    it("keeps a specific non-loopback address", () => {
+      assertEquals(serverDisplayUrl("192.168.1.5", 3000), "http://192.168.1.5:3000");
+    });
+  });
+});

--- a/cli/commands/dev/server-url.ts
+++ b/cli/commands/dev/server-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Turns the address a dev server bound into the URL to show for it.
+ *
+ * The name `localhost` is deliberately not used. It resolves to `::1` first on
+ * a dual-stack host, while the dev server binds `LOCALHOST.IPV4` - so the
+ * printed URL named an address the server was not listening on, and any process
+ * that did hold `[::1]:port` answered in its place.
+ */
+
+import { LOCALHOST } from "veryfront/config";
+
+/** Wildcards are bind targets, not somewhere to browse to. */
+const LOOPBACK_FOR_WILDCARD: Readonly<Record<string, string>> = Object.freeze({
+  "0.0.0.0": LOCALHOST.IPV4,
+  "::": LOCALHOST.IPV6,
+});
+
+export function serverDisplayUrl(bindAddress: string, port: number): string {
+  const host = LOOPBACK_FOR_WILDCARD[bindAddress] ?? bindAddress;
+  // A literal IPv6 address needs brackets to be a valid URL authority.
+  return `http://${host.includes(":") ? `[${host}]` : host}:${port}`;
+}

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -34,7 +34,8 @@ import {
   ToolsCallParamsSchema,
 } from "./jsonrpc.ts";
 
-// Exact loopback origins only. `localhost` is the hostname the CLI prints.
+// Exact loopback origins only. All three forms are reachable: the CLI prints the
+// address the dev server bound, and a browser may send either name or literal.
 // Project subdomains were never admitted here and still are not.
 const ALLOWED_HTTP_ORIGIN_HOSTS = new Set([
   "localhost",

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -155,7 +155,7 @@ export class DevServer {
 
     logger.debug("Starting dev server", {
       port: this.options.port,
-      bindAddress: this.options.bindAddress ?? LOCALHOST.IPV4,
+      bindAddress: this.bindAddress,
       projectDir: this.options.projectDir,
       hmr: this.options.enableHMR,
       fastRefresh: this.options.enableFastRefresh,
@@ -291,7 +291,7 @@ export class DevServer {
 
     this.server = await this.adapter.serve(handler, {
       port: this.options.port,
-      hostname: this.options.bindAddress ?? LOCALHOST.IPV4,
+      hostname: this.bindAddress,
       signal: this.options.signal,
       nodeWebSocketServerProvider: this._nodeWebSocketServerProvider,
       onListen: ({ port }: { hostname: string; port: number }) => {
@@ -310,6 +310,11 @@ export class DevServer {
         }
       },
     });
+  }
+
+  /** The address this server listens on. Callers must not re-derive it. */
+  get bindAddress(): string {
+    return this.options.bindAddress ?? LOCALHOST.IPV4;
   }
 
   /** Return the request handler for use with external HTTP servers. */


### PR DESCRIPTION
Follow-up to #3704, which fixed the port probe. This fixes the *host* half of the same bug. Independent of #3704 — different files, either order merges.

## Problem

`DevServer` binds `this.options.bindAddress ?? LOCALHOST.IPV4` (`server.ts:294`). The CLI printed `http://localhost:${boundPort}` (`command.ts:342`).

Those are different hosts. `localhost` resolves to `::1` first on a dual-stack machine, so the URL the CLI printed named an address the server was not listening on. Browsers usually paper over it via Happy Eyeballs — but when some other process holds `[::1]:port`, it answers instead, which is exactly the failure reported against #3704: `veryfront dev` printed `Ready — http://localhost:3000` and that URL served an unrelated app's 500.

## Fix

`serverDisplayUrl(bindAddress, port)` builds the URL from the address actually bound:

| Bound | Shown |
|---|---|
| `127.0.0.1` | `http://127.0.0.1:3000` |
| `::1` | `http://[::1]:3000` (bracketed — a bare literal is not a valid authority) |
| `0.0.0.0` / `::` | loopback — a wildcard is a bind target, not somewhere to browse |
| `192.168.1.5` | unchanged |

`DevServer` now exposes `bindAddress` as one source of truth; the two places that re-derived it inline route through it, so they cannot drift. `DevCommandResult` carries `bindAddress` alongside `port`, mirroring how `port` is already threaded to embedded callers.

## Same defect in the demo path

`cli/commands/demo/dev-step.ts` had it too. Its doc comment already promised the printed and opened URLs "come from the port the server actually bound … or the viewer is sent to whatever process caused the collision" — correct about the port, silent about the host. Same helper now.

## MCP origin allowlist

`cli/mcp/server.ts` gates HTTP origins and its comment said "`localhost` is the hostname the CLI prints". The set already contained `127.0.0.1` and `[::1]`, so the new URL passes unchanged — only the comment moved. Checked before changing the printed URL, not after.

## Testing

Test-first throughout. New `serverDisplayUrl` tests were stubbed against the *old* behavior so the assertions did the failing, not a module-not-found error:

```
names the address the server actually bound, not `localhost` ... FAILED
brackets an IPv6 address so the URL is valid ... FAILED
shows a loopback address when the server bound a wildcard ... FAILED
keeps a specific non-loopback address ... FAILED
```

Demo path, before the change: 3 URL tests RED, the 2 unrelated lifecycle tests still green.

After: `ok | 11 passed (112 steps) | 0 failed` across `cli/commands/dev/` + the demo step, green on 3 consecutive runs. `deno lint` (56 files) and `deno check` clean.

## Local test-run noise (not from this change, flagged for honesty)

The full `cli/` + `src/server/dev-server/` parallel run is not clean on my machine, in a way I verified is unrelated:

- **2 constant failures** in `cli/commands/push/command.test.ts` (`.vfignore` is covered by a `.gitignore`, so `git add` refuses it). Reproduced identically with my changes stashed on clean `origin/main`.
- **1 varying failure** — `dev-output.integration.test.ts` in one run, `start/command` MCP boundary in another, neither in a third. Different test each run under full-tree parallel load; `dev-output` passes in isolation and `cli/commands/dev/` is 3/3 green in parallel.

CI is the arbiter here — flagging it rather than presenting a clean local run I did not get.

## Not in scope

`command.ts:362` still prints `http://localhost:${mcpPort}/mcp`. The MCP server calls `serve(handler, { port })` with **no** hostname, so it takes the adapter default rather than `LOCALHOST.IPV4` — a genuinely different situation that deserves its own change, not a blind rename. The `onListen` debug log in `server.ts` also still uses `buildLocalhostUrl`; `serverDisplayUrl` lives under `cli/`, and `src/` importing from `cli/` would invert the layering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development server URLs now reflect the actual bound address instead of always displaying `localhost`.
  * Added proper URL formatting for IPv6 addresses, including required brackets.
  * Wildcard bind addresses now resolve to usable loopback URLs for browser access.
  * Server startup messages consistently display the address where the server is listening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->