### PR TITLE
test(agent-runs): stop a success-path assertion racing a 10ms deadline

### DIFF
--- a/src/agent/runtime/project-files-client.test.ts
+++ b/src/agent/runtime/project-files-client.test.ts
@@ -1662,8 +1662,14 @@ Deno.test("successful strict project file calls dispose cancellation listeners a
   const observedSignals: AbortSignal[] = [];
   const client = createStrictRuntimeProjectFilesClient({
     apiUrl: baseOptions.apiUrl,
-    operationTimeoutMs: 10,
-    timeoutMs: 10,
+    // Deadlines only need to be larger than this call, which resolves from a
+    // stub. A 10ms budget made a success-path assertion depend on wall clock:
+    // under a loaded parallel run the deadline can elapse before the call
+    // settles, the timeout path runs, and the listener counts below stop being
+    // 1/1. Nothing here tests timeout behaviour -- the tests that do set their
+    // own short deadlines deliberately.
+    operationTimeoutMs: 30_000,
+    timeoutMs: 30_000,
     fetch: (_url, init) => {
       observedSignals.push(init.signal as AbortSignal);
       return Promise.resolve(


### PR DESCRIPTION
## What

`"successful strict project file calls dispose cancellation listeners and timers"` built its client with `operationTimeoutMs: 10` / `timeoutMs: 10` around a stubbed fetch, then asserted the abort listener was added once and removed once.

Nothing in that test is about timeouts. The deadline was incidental config that made a **success-path** assertion depend on wall clock: under a loaded parallel run the 10ms can elapse before the call settles, the timeout path runs, and the counts stop being 1/1.

Raised to 30s, with the reasoning in a comment so it is not "tidied" back down.

## What this deliberately does not change

The other 12 short deadlines in this file stay. Tests named *"bounds a stalled terminal response"* or *"enforces its deadline after trace"* **need** a 1ms budget — that is the behaviour under test, and contention only makes those fire more reliably, which is the outcome they assert.

That distinction matters: sweeping every short deadline in the suite would break a dozen legitimate timeout tests to chase a handful of real ones.

## Honest status

This is a plausible fix for one instance, not a proven fix for the suite:

- I could **not** reproduce the failure in isolation, even under 12 saturating busy-loops (0/6). The mechanism fits the evidence but is unproven.
- The suite's failing test **varies between runs** — three earlier failures today were a different test entirely — so one fix cannot be expected to make the suite green.
- Four full-suite runs passed afterwards. Against a ~1-in-3 baseline, four clean runs occur by chance about 20% of the time, so that is a regression check that passed, **not** evidence of improvement.

What it does establish: this test no longer depends on wall clock for an assertion that has nothing to do with time. That is correct regardless of whether it was the cause.

`deno lint` and `deno fmt --check` clean; the file passes 75/75.

Background, including a correction to my own earlier over-count of the affected sites: veryfront-issue-inbox#506.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cancellation cleanup test reliability by using longer operation and request timeouts.
  * Preserved validation that cancellation listeners are properly removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->