### PR TITLE
fix(sandbox): keep the default isolation posture off the dev log

### DIFF
--- a/src/security/sandbox/isolation-posture.test.ts
+++ b/src/security/sandbox/isolation-posture.test.ts
@@ -117,6 +117,44 @@ describe("security/sandbox isolation posture reporting", () => {
     assertEquals(posture.inForce, false);
   });
 
+  it("keeps the default posture off the default-verbosity dev log", async () => {
+    // A developer who configured no isolation at all has nothing to act on, so
+    // resolution must not spend the one line a successful dev request prints.
+    await __resetPoolForTests();
+    const entries = captureLogs();
+
+    getIsolationPosture();
+
+    const posture = entries.find((entry) =>
+      entry.message.includes("Worker isolation posture resolved")
+    );
+    assertExists(posture, "expected the posture to still be reported at DEBUG");
+    assertEquals(
+      posture?.level,
+      "debug",
+      "unconfigured posture must not log at info",
+    );
+  });
+
+  it("still reports the posture at info once isolation is actually in force", async () => {
+    await __resetPoolForTests();
+    setEnv("WORKER_ISOLATION_ENABLED", "1");
+    setEnv("WORKER_ISOLATION_SSR", "1");
+    const entries = captureLogs();
+
+    getIsolationPosture();
+
+    const posture = entries.find((entry) =>
+      entry.message.includes("Worker isolation posture resolved")
+    );
+    assertExists(posture, "expected the posture to be reported");
+    assertEquals(
+      posture?.level,
+      "info",
+      "an in-force posture is operator-relevant and stays at info",
+    );
+  });
+
   it("does not warn when a requested surface is genuinely in force", async () => {
     await __resetPoolForTests();
     setEnv("WORKER_ISOLATION_ENABLED", "1");

--- a/src/security/sandbox/worker-pool.ts
+++ b/src/security/sandbox/worker-pool.ts
@@ -1347,7 +1347,12 @@ function resolveFlags(): void {
       },
     );
   } else {
-    logger.info("Worker isolation posture resolved", {
+    // Resolution is operator-relevant only once something is actually
+    // configured. A project that asked for no isolation has nothing to act on,
+    // and this line would otherwise be the only output a successful dev request
+    // produces, so keep the default posture at DEBUG.
+    const report = effectiveSurfaces > 0 ? logger.info : logger.debug;
+    report.call(logger, "Worker isolation posture resolved", {
       master,
       effectiveSurfaces,
       workerIsolationApi: _apiIsolation,


### PR DESCRIPTION
Found while dogfooding the documented quickstart against published **v0.1.1237**.

## What a developer sees today

A fresh `npm create veryfront` project, first request to `veryfront dev`:

```
  ✓ Ready in 925ms
  http://localhost:3000

  ● Worker isolation posture resolved
      requestId=17c528ae-… request_url=http://localhost:3000/api/ag-ui domain=localhost
      pathname=/api/ag-ui master=false effectiveSurfaces=0 workerIsolationApi=false
      workerIsolationData=false workerIsolationSsr=false apiPreparationSupported=true
```

That posture line is the *only* thing a successful request prints, and it is the first
thing a new project shows after `Ready`. Nothing in it is actionable for someone who
configured no isolation at all.

## Change

Report the posture at `DEBUG` when no surface is in force; keep `INFO` once an operator
has actually configured something. The two misconfiguration `warn` branches are
untouched — those are genuinely actionable.

## Tests

Two regression tests in `src/security/sandbox/isolation-posture.test.ts` pin both sides
of the boundary: the unconfigured posture must not log at `info`, and an in-force posture
must still reach `info`. The first fails on `main` (`info` vs `debug`); the second passes
before and after, so it guards against over-correcting into silence.

`src/security/sandbox/` — 40 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced log noise by recording inactive sandbox isolation posture details at debug level.
  - Continued reporting active isolation posture at info level, preserving existing message details.

- **Tests**
  - Added coverage to verify the appropriate logging level for inactive and active isolation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->