### PR TITLE
fix(dev): report the Cloud gateway when a login token can reach it

### DIFF
--- a/cli/commands/dev/command.ts
+++ b/cli/commands/dev/command.ts
@@ -26,7 +26,7 @@ import { createStagedPushOptions, pushCommand, type PushOptions } from "../push/
 import { createProjectSelector } from "./project-selector.ts";
 import { createDevLogController } from "./log-controller.ts";
 import { findAvailablePort, isPortAvailable, isPortInUseError } from "./port-fallback.ts";
-import { listInferenceOptions } from "./inference-status.ts";
+import { advertisesCloudGateway, listInferenceOptions } from "./inference-status.ts";
 
 export interface DevOptions {
   port: number;
@@ -356,6 +356,22 @@ export function devCommand(options: DevOptions): Promise<DevCommandResult> {
       });
       if (inferenceOptions.length > 0) {
         console.log(`  ${dim("Inference")} ${brand(inferenceOptions.join(", "))}`);
+      }
+      // The banner reports configured paths, and it must not block Ready on a
+      // network round-trip (see `void authReady` above). But an expired stored
+      // session still has a nonempty token, so the gateway would be advertised
+      // and then fail on first request. The validation is already in flight —
+      // let it correct the record rather than delay the banner.
+      if (advertisesCloudGateway(inferenceOptions)) {
+        void authReady.then(() => {
+          if (identity) return;
+          console.log(
+            `  ${
+              warning("!")
+            } Veryfront Cloud session is not valid; gateway inference will fail. ` +
+              `Run ${brand("veryfront login")} to renew it.`,
+          );
+        });
       }
       if (mcpServer && isVerbose()) {
         console.log(`  ${dim("MCP")} ${brand(`http://localhost:${mcpPort}/mcp`)}`);

--- a/cli/commands/dev/inference-status.test.ts
+++ b/cli/commands/dev/inference-status.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { listInferenceOptions } from "./inference-status.ts";
 
 describe("commands/dev/inference-status", () => {
-  it("reports the Veryfront Cloud AI Gateway only with project context", () => {
+  it("reports the Veryfront Cloud AI Gateway whenever a token can reach it", () => {
     assertEquals(
       listInferenceOptions({
         apiToken: "<TOKEN>",
@@ -12,7 +12,22 @@ describe("commands/dev/inference-status", () => {
       }),
       ["Veryfront Cloud AI Gateway"],
     );
-    assertEquals(listInferenceOptions({ apiToken: "<TOKEN>" }), []);
+  });
+
+  it("reports the gateway for a logged-in developer whose project is not linked yet", () => {
+    // `veryfront login` alone is enough to serve inference through the gateway:
+    // a freshly scaffolded project has no linked slug, and its chat route still
+    // answers. Requiring a slug here left the banner silent on exactly the path
+    // the quickstart tells a developer to use.
+    assertEquals(
+      listInferenceOptions({ apiToken: "<TOKEN>" }),
+      ["Veryfront Cloud AI Gateway"],
+    );
+  });
+
+  it("reports nothing when no credential can reach any provider", () => {
+    assertEquals(listInferenceOptions({}), []);
+    assertEquals(listInferenceOptions({ projectSlug: "support-agent" }), []);
   });
 
   it("reports direct provider credentials without exposing their values", () => {

--- a/cli/commands/dev/inference-status.test.ts
+++ b/cli/commands/dev/inference-status.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { listInferenceOptions } from "./inference-status.ts";
+import { advertisesCloudGateway, listInferenceOptions } from "./inference-status.ts";
 
 describe("commands/dev/inference-status", () => {
   it("reports the Veryfront Cloud AI Gateway whenever a token can reach it", () => {
@@ -28,6 +28,17 @@ describe("commands/dev/inference-status", () => {
   it("reports nothing when no credential can reach any provider", () => {
     assertEquals(listInferenceOptions({}), []);
     assertEquals(listInferenceOptions({ projectSlug: "support-agent" }), []);
+  });
+
+  it("flags option lists that claim the gateway, so callers can validate the session", () => {
+    // The banner cannot block Ready on a network round-trip, so dev uses this
+    // to decide whether the already-running session check is worth reporting.
+    assertEquals(advertisesCloudGateway(listInferenceOptions({ apiToken: "<TOKEN>" })), true);
+    assertEquals(
+      advertisesCloudGateway(listInferenceOptions({ openaiApiKey: "<API_KEY>" })),
+      false,
+    );
+    assertEquals(advertisesCloudGateway(listInferenceOptions({})), false);
   });
 
   it("reports direct provider credentials without exposing their values", () => {

--- a/cli/commands/dev/inference-status.ts
+++ b/cli/commands/dev/inference-status.ts
@@ -16,7 +16,10 @@ function isSet(value: string | undefined): boolean {
 export function listInferenceOptions(environment: InferenceEnvironment): string[] {
   const options: string[] = [];
 
-  if (isSet(environment.apiToken) && isSet(environment.projectSlug)) {
+  // The gateway authenticates on the token alone. A freshly scaffolded project
+  // has no linked slug yet and its chat route still answers, so gating this on
+  // `projectSlug` hid the one inference path `veryfront login` sets up.
+  if (isSet(environment.apiToken)) {
     options.push("Veryfront Cloud AI Gateway");
   }
   if (isSet(environment.openaiApiKey)) {

--- a/cli/commands/dev/inference-status.ts
+++ b/cli/commands/dev/inference-status.ts
@@ -8,8 +8,19 @@ export interface InferenceEnvironment {
   mistralApiKey?: string;
 }
 
+const CLOUD_GATEWAY_LABEL = "Veryfront Cloud AI Gateway";
+
 function isSet(value: string | undefined): boolean {
   return Boolean(value?.trim());
+}
+
+/**
+ * Whether a rendered option list claims the Cloud gateway. Callers use this to
+ * decide if a stored session still needs validating — the gateway is the only
+ * option whose credential the CLI can check itself.
+ */
+export function advertisesCloudGateway(options: readonly string[]): boolean {
+  return options.includes(CLOUD_GATEWAY_LABEL);
 }
 
 /** Return the inference paths the current dev process can use without exposing credentials. */
@@ -20,7 +31,7 @@ export function listInferenceOptions(environment: InferenceEnvironment): string[
   // has no linked slug yet and its chat route still answers, so gating this on
   // `projectSlug` hid the one inference path `veryfront login` sets up.
   if (isSet(environment.apiToken)) {
-    options.push("Veryfront Cloud AI Gateway");
+    options.push(CLOUD_GATEWAY_LABEL);
   }
   if (isSet(environment.openaiApiKey)) {
     options.push(


### PR DESCRIPTION
Found while dogfooding the documented quickstart against published **v0.1.1237**.

## Problem

`veryfront dev` printed no inference line at all for a developer who ran `veryfront login`
and started a freshly scaffolded project:

```
  ✓ Ready in 3.2s
  http://localhost:3000
```

Inference was working the whole time — the chat route answered `128 / 8 = 16` with no
provider key set — but nothing told the developer which path served it.

## Root cause

The gateway option was gated on `apiToken && projectSlug`:

```ts
if (isSet(environment.apiToken) && isSet(environment.projectSlug)) {
  options.push("Veryfront Cloud AI Gateway");
}
```

A newly scaffolded project has no linked slug yet, and the gateway does not need one — it
authenticates on the token alone. So the gate hid the exact inference path that
`veryfront login` sets up, which is the path the Cloud quickstart tells you to use.

## Reproduction (on `main`)

Logged in via the stored token, project never pushed or linked, `OPENAI_API_KEY` and
`VERYFRONT_API_TOKEN` both unset:

- `POST /api/ag-ui` streams a correct answer through the gateway
- the ready banner prints no `Inference` line

## Change

Report the gateway whenever a token is present. The banner now prints:

```
  ✓ Ready in 1.6s
  http://localhost:3005
  Inference Veryfront Cloud AI Gateway
```

Verified end to end under the same conditions as the repro.

## Note on the test change

`inference-status.test.ts` asserted `listInferenceOptions({ apiToken }) === []` under the
name "reports the Veryfront Cloud AI Gateway only with project context". That assertion
encoded the assumption this PR disproves, so it is replaced rather than kept. Added in its
place: an explicit unlinked-project case, and a case pinning that *no* credential still
yields `[]`, so the gate cannot loosen into reporting a path that does not exist.

`cli/commands/dev/` — 9 passed, 0 failed. `tests/docs/` — 55 passed, 0 failed.