### PR TITLE
docs(getting-started): document adding Veryfront to an existing project

### DIFF
--- a/docs/getting-started/add-to-existing-project.md
+++ b/docs/getting-started/add-to-existing-project.md
@@ -29,37 +29,58 @@ variants.
 
 ## Configure TypeScript
 
-Veryfront routes are `.tsx` files, so the compiler needs the React JSX
-transform. Add both options to your `compilerOptions`:
+The package ships a base config with everything Veryfront needs. Extending it is
+the shortest correct route:
+
+```json
+{
+  "extends": "veryfront/tsconfig.json",
+  "include": ["src", "app"]
+}
+```
+
+Make sure `include` covers wherever you keep your own source as well as your
+routes.
+
+### Setting the options yourself
+
+If your project cannot extend that config, three settings matter:
 
 ```json
 {
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "skipLibCheck": true
   }
 }
 ```
 
-`skipLibCheck` is required, not merely recommended. Veryfront's MDX support
+**`moduleResolution`** must understand package exports. Veryfront's entry points
+are subpaths such as `veryfront/agent`, which the older `node` and `classic`
+modes cannot resolve:
+
+```text
+app/a.ts(1,23): error TS2307: Cannot find module 'veryfront/agent' or its corresponding type declarations.
+  There are types at 'node_modules/veryfront/esm/src/agent/index.d.ts', but this result could not be
+  resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.
+```
+
+`bundler`, `node16`, and `nodenext` all work.
+
+**`jsx`** is needed because Veryfront routes are `.tsx` files.
+
+**`skipLibCheck`** is required, not merely recommended. Veryfront's MDX support
 depends on `@types/mdx`, which refers to a global `JSX` namespace that React 19
-no longer declares globally. Without `skipLibCheck`, `tsc` fails on a
-dependency you do not import:
+no longer declares globally. Without it, `tsc` fails on a dependency you do not
+import:
 
 ```text
 node_modules/@types/mdx/types.d.ts(23,38): error TS2503: Cannot find namespace 'JSX'.
 ```
 
-Scaffolded projects set `skipLibCheck` already, which is why the error only
-appears when adding Veryfront to a project you already have.
-
-Make sure `include` covers wherever you put routes:
-
-```json
-{
-  "include": ["src", "app"]
-}
-```
+Scaffolded projects set all three already, which is why these only surface when
+adding Veryfront to a project you already have.
 
 ## Add an entry route
 
@@ -91,11 +112,14 @@ forward and prints the port it actually used, so open the URL the CLI prints.
 
 ## Verify it worked
 
-Open the URL the CLI printed. The page renders `Hello from Veryfront`. To check
-it without a browser, using that same port:
+Open the URL the CLI printed. The page renders `Hello from Veryfront`.
+
+To check it without a browser, use the port from that URL rather than assuming
+3000. If the port fell forward, 3000 still belongs to whatever took it, so
+curling it verifies the wrong server:
 
 ```bash
-curl -s http://localhost:3000/
+curl -s http://localhost:<PORT>/
 ```
 
 The response contains `Hello from Veryfront`.

--- a/docs/getting-started/add-to-existing-project.md
+++ b/docs/getting-started/add-to-existing-project.md
@@ -1,0 +1,117 @@
+---
+title: "Add to an existing project"
+description: "Install Veryfront Code into a TypeScript project you already have."
+order: 5
+---
+
+Use this page to add Veryfront to a codebase that already exists. To start from
+a scaffold instead, see [Create project](./create-project.md).
+
+Veryfront installs as a normal dependency. It does not rewrite your
+`package.json` scripts, your `tsconfig.json`, or any source file you already
+have.
+
+## Prerequisites
+
+- Node.js 22.3 or later.
+- An existing TypeScript project.
+
+## Install the framework
+
+```bash
+npm install veryfront
+```
+
+The package ships the framework and the `veryfront` CLI, so you can run
+commands with `npx veryfront <command>` without a global install. See
+[Installation](./installation.md) for pnpm, yarn, bun, Deno, and global-CLI
+variants.
+
+## Configure TypeScript
+
+Veryfront routes are `.tsx` files, so the compiler needs the React JSX
+transform. Add both options to your `compilerOptions`:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "skipLibCheck": true
+  }
+}
+```
+
+`skipLibCheck` is required, not merely recommended. Veryfront's MDX support
+depends on `@types/mdx`, which refers to a global `JSX` namespace that React 19
+no longer declares globally. Without `skipLibCheck`, `tsc` fails on a
+dependency you do not import:
+
+```text
+node_modules/@types/mdx/types.d.ts(23,38): error TS2503: Cannot find namespace 'JSX'.
+```
+
+Scaffolded projects set `skipLibCheck` already, which is why the error only
+appears when adding Veryfront to a project you already have.
+
+Make sure `include` covers wherever you put routes:
+
+```json
+{
+  "include": ["src", "app"]
+}
+```
+
+## Add an entry route
+
+Veryfront serves the `app/` directory. Without it the dev server still starts,
+but reports that it found no route directories. Create one page:
+
+```tsx
+// app/page.tsx
+export default function Home() {
+  return <h1>Hello from Veryfront</h1>;
+}
+```
+
+## Run it
+
+```bash
+npx veryfront dev
+```
+
+The CLI prints the URL it bound:
+
+```text
+✓ Ready in 2.1s
+http://localhost:3000
+```
+
+The dev server uses port 3000 by default. When that port is taken it falls
+forward and prints the port it actually used, so open the URL the CLI prints.
+
+## Verify it worked
+
+Open the URL the CLI printed. The page renders `Hello from Veryfront`. To check
+it without a browser, using that same port:
+
+```bash
+curl -s http://localhost:3000/
+```
+
+The response contains `Hello from Veryfront`.
+
+Your existing scripts are untouched. Confirm the build you had before still
+runs:
+
+```bash
+npm run build
+```
+
+## Next steps
+
+| Goal                    | Page                                    |
+| ----------------------- | --------------------------------------- |
+| Define an agent         | [Create agent](./create-agent.md)       |
+| Expose an agent route   | [Create API](./create-api.md)           |
+| Add a chat UI           | [Create frontend](./create-frontend.md) |
+| Choose where models run | [Providers](../guides/providers.md)     |

--- a/docs/getting-started/create-agent.md
+++ b/docs/getting-started/create-agent.md
@@ -1,7 +1,7 @@
 ---
 title: "Create agent"
 description: "Define an AI agent."
-order: 5
+order: 6
 ---
 
 ## Prerequisites

--- a/docs/getting-started/create-api.md
+++ b/docs/getting-started/create-api.md
@@ -1,7 +1,7 @@
 ---
 title: "Create API"
 description: "Expose a Veryfront agent through a streaming AG-UI route."
-order: 6
+order: 7
 ---
 
 ## Prerequisites

--- a/docs/getting-started/create-frontend.md
+++ b/docs/getting-started/create-frontend.md
@@ -1,7 +1,7 @@
 ---
 title: "Create frontend"
 description: "Add a chat page that streams responses from a Veryfront agent."
-order: 7
+order: 8
 ---
 
 ## Prerequisites

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy with Veryfront Cloud"
 description: "Push and deploy an existing Veryfront project."
-order: 8
+order: 9
 ---
 
 Deploy a project that already works locally. For a guided first project that

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -23,12 +23,13 @@ you develop or deploy the app.
 
 Use these pages when you want to work on one part of an existing project:
 
-| Goal                                            | Page                                        |
-| ----------------------------------------------- | ------------------------------------------- |
-| Install the CLI or framework                    | [Installation](./installation.md)           |
-| Scaffold a project                              | [Create project](./create-project.md)       |
-| Define an agent                                 | [Create agent](./create-agent.md)           |
-| Expose an agent route                           | [Create API](./create-api.md)               |
-| Add a chat UI                                   | [Create frontend](./create-frontend.md)     |
-| Deploy an existing project with Veryfront Cloud | [Deploy project](./deploy-project.md)       |
-| Connect a coding agent to the dev server        | [Coding agents](../guides/coding-agents.md) |
+| Goal                                            | Page                                                       |
+| ----------------------------------------------- | ---------------------------------------------------------- |
+| Install the CLI or framework                    | [Installation](./installation.md)                          |
+| Scaffold a project                              | [Create project](./create-project.md)                      |
+| Add Veryfront to a project you already have     | [Add to an existing project](./add-to-existing-project.md) |
+| Define an agent                                 | [Create agent](./create-agent.md)                          |
+| Expose an agent route                           | [Create API](./create-api.md)                              |
+| Add a chat UI                                   | [Create frontend](./create-frontend.md)                    |
+| Deploy an existing project with Veryfront Cloud | [Deploy project](./deploy-project.md)                      |
+| Connect a coding agent to the dev server        | [Coding agents](../guides/coding-agents.md)                |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -144,8 +144,8 @@ Install the CLI globally when you use Veryfront commands often.
 
 | Method            | Use when                                          | Approximate size                            |
 | ----------------- | ------------------------------------------------- | ------------------------------------------- |
-| npm package       | You use Node.js, Deno, Bun, or another npm client | 6 MB download, 28 MB before dependencies   |
-| Standalone binary | You need one executable with an included runtime | 0.9 to 1.2 GB for the downloaded executable |
+| npm package       | You use Node.js, Deno, Bun, or another npm client | 6 MB download, 28 MB before dependencies    |
+| Standalone binary | You need one executable with an included runtime  | 0.9 to 1.2 GB for the downloaded executable |
 
 These measurements describe recent releases and vary by platform and package
 manager. A clean global npm installation used approximately 145 MB in one

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -1011,7 +1011,7 @@ describe("Guide: add-to-existing-project.md", () => {
   it("documents the compiler options the scaffold actually sets", async () => {
     const guide = await readGuide("add-to-existing-project.md");
 
-    // The page tells an existing-project reader to add by hand what the
+    // The page tells an existing-project reader to set by hand what the
     // scaffolded template already carries. If the template ever drops one of
     // these, the guidance is wrong and this fails.
     const template = await getTemplate("ai-agent");
@@ -1023,6 +1023,32 @@ describe("Guide: add-to-existing-project.md", () => {
       assertStringIncludes(guide, option);
       assertStringIncludes(tsconfig.content, option);
     }
+  });
+
+  it("documents a package-exports-aware moduleResolution", async () => {
+    const guide = await readGuide("add-to-existing-project.md");
+
+    // Veryfront's entry points are subpath exports (`veryfront/agent`), which
+    // the older `node`/`classic` modes cannot resolve. The scaffold sets
+    // `bundler`; an adopting project must pick an equivalent mode or the
+    // linked next steps fail to typecheck.
+    assertStringIncludes(guide, '"moduleResolution": "bundler"');
+
+    const template = await getTemplate("ai-agent");
+    assertExists(template);
+    const tsconfig = template.find((file) => file.path === "tsconfig.json");
+    assertExists(tsconfig);
+    assertStringIncludes(tsconfig.content.toLowerCase(), '"moduleresolution": "bundler"');
+  });
+
+  it("points at the base config the package actually publishes", async () => {
+    const guide = await readGuide("add-to-existing-project.md");
+    assertStringIncludes(guide, '"extends": "veryfront/tsconfig.json"');
+
+    // The page's shortest path is extending the shipped config, so the npm
+    // build must keep publishing it under that exact export key.
+    const dnt = await Deno.readTextFile("scripts/build/build-npm-dnt.ts");
+    assertStringIncludes(dnt, './tsconfig.json"] = "./tsconfig.json"');
   });
 
   it("documents the install command and the entry route the server needs", async () => {

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -1046,8 +1046,12 @@ describe("Guide: add-to-existing-project.md", () => {
     assertStringIncludes(guide, '"extends": "veryfront/tsconfig.json"');
 
     // The page's shortest path is extending the shipped config, so the npm
-    // build must keep publishing it under that exact export key.
-    const dnt = await Deno.readTextFile("scripts/build/build-npm-dnt.ts");
+    // build must keep publishing it under that exact export key. Resolved from
+    // import.meta.url, not the process cwd: test files share one process under
+    // --parallel and a sibling isolate can hold `withCwd` while this runs.
+    const dnt = await Deno.readTextFile(
+      new URL("../../scripts/build/build-npm-dnt.ts", import.meta.url),
+    );
     assertStringIncludes(dnt, './tsconfig.json"] = "./tsconfig.json"');
   });
 

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -103,6 +103,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "installation.md",
   "create-frontend.md",
   "create-project.md",
+  "add-to-existing-project.md",
   "create-api.md",
   "deploy-project.md",
   "integrations.md",
@@ -1002,6 +1003,39 @@ describe("Guide: create-project.md", () => {
     for (const templateId of templateIds) {
       assertStringIncludes(guide, `\`${templateId}\``);
       assertExists(await getTemplate(templateId));
+    }
+  });
+});
+
+describe("Guide: add-to-existing-project.md", () => {
+  it("documents the compiler options the scaffold actually sets", async () => {
+    const guide = await readGuide("add-to-existing-project.md");
+
+    // The page tells an existing-project reader to add by hand what the
+    // scaffolded template already carries. If the template ever drops one of
+    // these, the guidance is wrong and this fails.
+    const template = await getTemplate("ai-agent");
+    assertExists(template);
+    const tsconfig = template.find((file) => file.path === "tsconfig.json");
+    assertExists(tsconfig, "expected the ai-agent template to ship a tsconfig.json");
+
+    for (const option of ['"jsx": "react-jsx"', '"skipLibCheck": true']) {
+      assertStringIncludes(guide, option);
+      assertStringIncludes(tsconfig.content, option);
+    }
+  });
+
+  it("documents the install command and the entry route the server needs", async () => {
+    const guide = await readGuide("add-to-existing-project.md");
+
+    for (
+      const snippet of [
+        "npm install veryfront",
+        "// app/page.tsx",
+        "npx veryfront dev",
+      ]
+    ) {
+      assertStringIncludes(guide, snippet);
     }
   });
 });

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -749,6 +749,8 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     ],
     snippets: [
       "npm install veryfront",
+      '"extends": "veryfront/tsconfig.json"',
+      '"moduleResolution": "bundler"',
       '"jsx": "react-jsx"',
       '"skipLibCheck": true',
       "@types/mdx",

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -738,6 +738,24 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     ],
     snippets: ["provider/model", "OPENAI_API_KEY", "registerModelProvider"],
   },
+  "getting-started/add-to-existing-project.md": {
+    references: [
+      "./create-project.md",
+      "./installation.md",
+      "./create-agent.md",
+      "./create-api.md",
+      "./create-frontend.md",
+      "../guides/providers.md",
+    ],
+    snippets: [
+      "npm install veryfront",
+      '"jsx": "react-jsx"',
+      '"skipLibCheck": true',
+      "@types/mdx",
+      "// app/page.tsx",
+      "npx veryfront dev",
+    ],
+  },
   "getting-started/create-project.md": {
     references: ["./installation.md", "./create-agent.md"],
     snippets: [


### PR DESCRIPTION
Found while dogfooding the documented journeys against published **v0.1.1237**.

## Problem

There is no documented path for adopting Veryfront into a codebase that already exists.
`installation.md` stops at `npm install veryfront`; nothing says what comes next — no entry
route, no tsconfig requirements, no way to confirm it worked. A scan of the full page index
at `/docs/llms.txt` turns up no page covering it.

Every developer with an existing project — most of the addressable audience — has to guess.

## The part that actually bites

`skipLibCheck` is **required**, not stylistic. Veryfront pulls `@types/mdx` transitively via
`@mdx-js/mdx`, and it refers to a global `JSX` namespace React 19 no longer declares. A strict
project that typechecked clean before installing fails afterwards on a dependency it never
imports:

```
node_modules/@types/mdx/types.d.ts(23,38): error TS2503: Cannot find namespace JSX.
```

Scaffolded projects set `skipLibCheck` already, so this only ever surfaces on the
existing-project path — exactly the path that had no page. That is why it has gone unnoticed.

I tested the obvious alternative fix and it does not work: removing `@types/react` from the
consumer tree leaves the same four errors and adds new ones. Only `skipLibCheck` or
`types: []` resolves it, so documenting the requirement is the correct move here. Making
`ext-content-mdx` opt-in for library consumers would remove the requirement entirely, but
that changes what a bare `npm install veryfront` gives you and wants a separate decision.

## Verification

Every step was walked end to end before it was written down:

1. plain strict TS project builds clean
2. `npm install veryfront` breaks the typecheck (above)
3. the documented tsconfig fixes it
4. `app/page.tsx` + `npx veryfront dev` serves it (`curl` returns `Hello from Veryfront`)
5. the pre-existing `npm run build` still passes

## Tests

The repo enforces a contract and executable code-example coverage for every published guide,
so the page ships with both. The code-example test pins the two documented compiler options
to what the `ai-agent` template actually ships — if the template ever drops one, the guidance
is wrong and this fails rather than drifting silently.

`tests/docs/` — 56 passed, 0 failed. `validate-public-docs` clean across 124 files.

## Note on placement

This is authored in `veryfront-code/docs/`, not `veryfront-docs`, because `sync-docs.yml`
publishes one into the other. Sibling `order:` values shift by one to seat the page between
"Create project" and "Create agent".