### PR TITLE
fix(server): require hosted project env credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,10 +46,11 @@ REDIS_URL=
 # Project environment overlays cannot set this host-owned option.
 # VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION=1
 
-# Optional privileged environment-value retrieval for shared runtimes.
-# Configure both values only when VERYFRONT_API_BASE_URL exposes the canonical
-# /internal/project-environment-variables endpoint. The runtime first verifies
-# the request-scoped bearer token and never falls back if this endpoint fails.
+# Required privileged environment-value retrieval for hosted proxy runtimes.
+# Deploy the canonical /internal/project-environment-variables endpoint before
+# setting both values on the runtime process. The runtime first verifies the
+# request-scoped bearer token and never falls back if this endpoint fails.
+# Leave both values unset for local CLI proxy mode and non-proxy runtimes.
 # VERYFRONT_API_INTERNAL_USER=
 # VERYFRONT_API_INTERNAL_PASS=
 

--- a/src/security/README.md
+++ b/src/security/README.md
@@ -107,14 +107,14 @@ environment ID, and a digest of the request credential. Fetch failure, timeout,
 credential rejection, or explicit invalidation never returns stale or empty
 secret data.
 
-If both `VERYFRONT_API_INTERNAL_USER` and `VERYFRONT_API_INTERNAL_PASS` are
-configured, `VERYFRONT_API_BASE_URL` must provide the canonical
-`/internal/project-environment-variables` endpoint. Before using those host
-credentials, the runtime verifies the request bearer token against the
-project-scoped management endpoint. A missing, redirected, or failed internal
-endpoint is an error; there is no compatibility fallback to masked management
-values. Leave both internal credential variables unset when that endpoint is
-not deployed.
+Hosted proxy mode requires both `VERYFRONT_API_INTERNAL_USER` and
+`VERYFRONT_API_INTERNAL_PASS`, and `VERYFRONT_API_BASE_URL` must provide the
+canonical `/internal/project-environment-variables` endpoint. Before using
+those host credentials, the runtime verifies the request bearer token against
+the project-scoped management endpoint. A missing credential, redirected
+endpoint, or failed internal request is an error. There is no compatibility
+fallback to masked management values. Local CLI proxy mode and non-proxy
+runtimes do not require these host credentials.
 
 #### Trust boundary and residual risk
 
@@ -133,28 +133,37 @@ binding comes from the signed control-plane request body.
 #### Rollout ordering for hosted identity changes
 
 The hosted runtime fails closed at boot without
-`VERYFRONT_TRUST_FORWARDED_HEADERS=1`, and hosted agent runs fail closed
-without the branch identity that only the current proxy derives from the
-signed control-plane body. Upgrading an existing deployment is safe in this
-order:
+`VERYFRONT_TRUST_FORWARDED_HEADERS=1`,
+`VERYFRONT_API_INTERNAL_USER`, and `VERYFRONT_API_INTERNAL_PASS`. Hosted agent
+runs also fail closed without the branch identity that only the current proxy
+derives from the signed control-plane body. Upgrading an existing deployment
+is safe in this order:
 
-1. Set `VERYFRONT_TRUST_FORWARDED_HEADERS=1` (and ensure
+1. Deploy and verify the canonical
+   `/internal/project-environment-variables` endpoint on
+   `VERYFRONT_API_BASE_URL`. Provision the credential pair that the endpoint
+   accepts.
+2. Set `VERYFRONT_API_INTERNAL_USER`, `VERYFRONT_API_INTERNAL_PASS`, and
+   `VERYFRONT_TRUST_FORWARDED_HEADERS=1` (and ensure
    `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` is set) on the runtime environment
    while it still runs the previous version. Earlier runtimes already accept
-   the variable as an explicit operator trust opt-in, so this step is
-   behaviour-preserving inside the required private topology.
-2. Deploy the proxy tier. Earlier runtimes ignore the added
+   the trust variable and internal credentials. Step 1 ensures that their
+   privileged environment reads succeed before the new boot requirement takes
+   effect.
+3. Deploy the proxy tier. Earlier runtimes ignore the added
    `x-default-branch-name` header, and the `vf-utf8:` branch-name encoding is
    applied only to values an earlier proxy could not forward at all.
-3. Deploy the runtime tier. A new runtime booted without step 1 crash-loops
-   intentionally; a new runtime behind an old proxy rejects hosted
+4. Deploy the runtime tier. A new runtime booted without steps 1 and 2
+   crash-loops intentionally. A new runtime behind an old proxy rejects hosted
    preview-branch and non-default-branch agent runs with `PERMISSION_DENIED`
    because branch identity must come from the verified control-plane binding.
 
-Roll back in the reverse order (runtime first, then proxy). The trust variable
-can remain set during rollback. There is deliberately no warn-only
-compatibility mode for a missing trust declaration or missing branch binding:
-either one would let unbound identity select tenant data.
+Roll back the runtime first, then the proxy. Keep the internal endpoint,
+credentials, and trust variable in place throughout rollback. After the older
+runtime is active, operators can unset the internal credentials before removing
+the internal endpoint. There is deliberately no warn-only compatibility mode
+for a missing trust declaration, missing hosted credential, or missing branch
+binding. Any of these gaps can expose or select incorrect tenant data.
 
 ### Input validation
 

--- a/src/server/bootstrap.test.ts
+++ b/src/server/bootstrap.test.ts
@@ -42,6 +42,8 @@ const validationEnvKeys = [
   "DENO_ENV",
   "PROXY_MODE",
   "VERYFRONT_CLI_LOCAL_PROXY_MODE",
+  "VERYFRONT_API_INTERNAL_USER",
+  "VERYFRONT_API_INTERNAL_PASS",
   "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY",
   "VERYFRONT_TRUST_FORWARDED_HEADERS",
 ] as const;
@@ -58,6 +60,11 @@ function restoreValidationEnv(): void {
       Deno.env.set(key, value);
     }
   }
+}
+
+function setHostedInternalCredentials(): void {
+  Deno.env.set("VERYFRONT_API_INTERNAL_USER", "test-internal-user");
+  Deno.env.set("VERYFRONT_API_INTERNAL_PASS", "test-internal-pass");
 }
 
 const noopLogger = {
@@ -294,6 +301,23 @@ describe("validateProductionEnvironmentForTests()", () => {
     );
   });
 
+  it("rejects hosted proxy mode when internal environment credentials are missing", () => {
+    Deno.env.set("PROXY_MODE", "1");
+    Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    Deno.env.set("NODE_ENV", "production");
+    Deno.env.delete("DENO_ENV");
+    Deno.env.set("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
+    Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
+    Deno.env.delete("VERYFRONT_API_INTERNAL_USER");
+    Deno.env.delete("VERYFRONT_API_INTERNAL_PASS");
+
+    assertThrows(
+      () => validateProductionEnvironmentForTests(),
+      Error,
+      "VERYFRONT_API_INTERNAL_USER and VERYFRONT_API_INTERNAL_PASS must be set",
+    );
+  });
+
   it("warns with the actual NODE_ENV value for hosted proxy mode when a signing key exists", () => {
     Deno.env.set("PROXY_MODE", "1");
     Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
@@ -301,6 +325,7 @@ describe("validateProductionEnvironmentForTests()", () => {
     Deno.env.delete("DENO_ENV");
     Deno.env.set("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
     Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
+    setHostedInternalCredentials();
 
     const warnings = captureWarns(() => validateProductionEnvironmentForTests());
 
@@ -318,6 +343,7 @@ describe("validateProductionEnvironmentForTests()", () => {
     Deno.env.delete("DENO_ENV");
     Deno.env.set("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
     Deno.env.delete("VERYFRONT_TRUST_FORWARDED_HEADERS");
+    setHostedInternalCredentials();
 
     assertThrows(
       () => validateProductionEnvironmentForTests(),

--- a/src/server/bootstrap.test.ts
+++ b/src/server/bootstrap.test.ts
@@ -16,6 +16,14 @@ import {
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  deleteEnv,
+  getEnv,
+  makeTempDir,
+  remove,
+  setEnv,
+  writeTextFile,
+} from "#veryfront/testing/deno-compat.ts";
 import { _resetShimForTests } from "#veryfront/observability/tracing/api-shim.ts";
 import { register, reset } from "#veryfront/extensions/contracts.ts";
 import {
@@ -48,23 +56,23 @@ const validationEnvKeys = [
   "VERYFRONT_TRUST_FORWARDED_HEADERS",
 ] as const;
 const originalValidationEnv = new Map(
-  validationEnvKeys.map((key) => [key, Deno.env.get(key)]),
+  validationEnvKeys.map((key) => [key, getEnv(key)]),
 );
 
 function restoreValidationEnv(): void {
   for (const key of validationEnvKeys) {
     const value = originalValidationEnv.get(key);
     if (value === undefined) {
-      Deno.env.delete(key);
+      deleteEnv(key);
     } else {
-      Deno.env.set(key, value);
+      setEnv(key, value);
     }
   }
 }
 
 function setHostedInternalCredentials(): void {
-  Deno.env.set("VERYFRONT_API_INTERNAL_USER", "test-internal-user");
-  Deno.env.set("VERYFRONT_API_INTERNAL_PASS", "test-internal-pass");
+  setEnv("VERYFRONT_API_INTERNAL_USER", "test-internal-user");
+  setEnv("VERYFRONT_API_INTERNAL_PASS", "test-internal-pass");
 }
 
 const noopLogger = {
@@ -76,22 +84,22 @@ const noopLogger = {
 
 function captureWarns(run: () => void): string[] {
   const originalWarn = console.warn;
-  const originalLogLevel = Deno.env.get("LOG_LEVEL");
+  const originalLogLevel = getEnv("LOG_LEVEL");
   const messages: string[] = [];
   console.warn = (...args: unknown[]) => {
     messages.push(args.map(String).join(" "));
   };
 
   try {
-    Deno.env.set("LOG_LEVEL", "DEBUG");
+    setEnv("LOG_LEVEL", "DEBUG");
     __resetLoggerConfigForTests();
     run();
   } finally {
     console.warn = originalWarn;
     if (originalLogLevel === undefined) {
-      Deno.env.delete("LOG_LEVEL");
+      deleteEnv("LOG_LEVEL");
     } else {
-      Deno.env.set("LOG_LEVEL", originalLogLevel);
+      setEnv("LOG_LEVEL", originalLogLevel);
     }
     __resetLoggerConfigForTests();
   }
@@ -236,11 +244,11 @@ describe("validateProductionEnvironmentForTests()", () => {
   });
 
   it("accepts explicit local CLI proxy mode without NODE_ENV production or a signing key", () => {
-    Deno.env.set("PROXY_MODE", "1");
-    Deno.env.set("VERYFRONT_CLI_LOCAL_PROXY_MODE", "1");
-    Deno.env.set("NODE_ENV", "development");
-    Deno.env.delete("DENO_ENV");
-    Deno.env.delete("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+    setEnv("PROXY_MODE", "1");
+    setEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE", "1");
+    setEnv("NODE_ENV", "development");
+    deleteEnv("DENO_ENV");
+    deleteEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
 
     const warnings = captureWarns(() => validateProductionEnvironmentForTests());
 
@@ -248,15 +256,15 @@ describe("validateProductionEnvironmentForTests()", () => {
   });
 
   it("does not trust local CLI proxy mode loaded from a project env file", async () => {
-    const tempDir = await Deno.makeTempDir();
+    const tempDir = await makeTempDir();
 
     try {
-      Deno.env.set("PROXY_MODE", "1");
-      Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-      Deno.env.set("NODE_ENV", "development");
-      Deno.env.delete("DENO_ENV");
-      Deno.env.delete("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
-      await Deno.writeTextFile(
+      setEnv("PROXY_MODE", "1");
+      deleteEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+      setEnv("NODE_ENV", "development");
+      deleteEnv("DENO_ENV");
+      deleteEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+      await writeTextFile(
         `${tempDir}/.env`,
         "VERYFRONT_CLI_LOCAL_PROXY_MODE=1\n",
       );
@@ -269,16 +277,16 @@ describe("validateProductionEnvironmentForTests()", () => {
         "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY must be set",
       );
     } finally {
-      await Deno.remove(tempDir, { recursive: true });
+      await remove(tempDir, { recursive: true });
     }
   });
 
   it("rejects hosted proxy mode when NODE_ENV is missing", () => {
-    Deno.env.set("PROXY_MODE", "1");
-    Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-    Deno.env.delete("NODE_ENV");
-    Deno.env.delete("DENO_ENV");
-    Deno.env.set("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
+    setEnv("PROXY_MODE", "1");
+    deleteEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    deleteEnv("NODE_ENV");
+    deleteEnv("DENO_ENV");
+    setEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
 
     assertThrows(
       () => validateProductionEnvironmentForTests(),
@@ -288,11 +296,11 @@ describe("validateProductionEnvironmentForTests()", () => {
   });
 
   it("rejects hosted proxy mode when the signing key is missing even in development", () => {
-    Deno.env.set("PROXY_MODE", "1");
-    Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-    Deno.env.set("NODE_ENV", "development");
-    Deno.env.delete("DENO_ENV");
-    Deno.env.delete("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+    setEnv("PROXY_MODE", "1");
+    deleteEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    setEnv("NODE_ENV", "development");
+    deleteEnv("DENO_ENV");
+    deleteEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
 
     assertThrows(
       () => validateProductionEnvironmentForTests(),
@@ -302,14 +310,14 @@ describe("validateProductionEnvironmentForTests()", () => {
   });
 
   it("rejects hosted proxy mode when internal environment credentials are missing", () => {
-    Deno.env.set("PROXY_MODE", "1");
-    Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-    Deno.env.set("NODE_ENV", "production");
-    Deno.env.delete("DENO_ENV");
-    Deno.env.set("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
-    Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
-    Deno.env.delete("VERYFRONT_API_INTERNAL_USER");
-    Deno.env.delete("VERYFRONT_API_INTERNAL_PASS");
+    setEnv("PROXY_MODE", "1");
+    deleteEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    setEnv("NODE_ENV", "production");
+    deleteEnv("DENO_ENV");
+    setEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
+    setEnv("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
+    deleteEnv("VERYFRONT_API_INTERNAL_USER");
+    deleteEnv("VERYFRONT_API_INTERNAL_PASS");
 
     assertThrows(
       () => validateProductionEnvironmentForTests(),
@@ -319,12 +327,12 @@ describe("validateProductionEnvironmentForTests()", () => {
   });
 
   it("warns with the actual NODE_ENV value for hosted proxy mode when a signing key exists", () => {
-    Deno.env.set("PROXY_MODE", "1");
-    Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-    Deno.env.set("NODE_ENV", "staging");
-    Deno.env.delete("DENO_ENV");
-    Deno.env.set("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
-    Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
+    setEnv("PROXY_MODE", "1");
+    deleteEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    setEnv("NODE_ENV", "staging");
+    deleteEnv("DENO_ENV");
+    setEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
+    setEnv("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
     setHostedInternalCredentials();
 
     const warnings = captureWarns(() => validateProductionEnvironmentForTests());
@@ -337,12 +345,12 @@ describe("validateProductionEnvironmentForTests()", () => {
   });
 
   it("rejects hosted proxy mode without an explicit trusted topology", () => {
-    Deno.env.set("PROXY_MODE", "1");
-    Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-    Deno.env.set("NODE_ENV", "production");
-    Deno.env.delete("DENO_ENV");
-    Deno.env.set("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
-    Deno.env.delete("VERYFRONT_TRUST_FORWARDED_HEADERS");
+    setEnv("PROXY_MODE", "1");
+    deleteEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    setEnv("NODE_ENV", "production");
+    deleteEnv("DENO_ENV");
+    setEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", "test-public-key");
+    deleteEnv("VERYFRONT_TRUST_FORWARDED_HEADERS");
     setHostedInternalCredentials();
 
     assertThrows(

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -63,6 +63,7 @@ import {
   createServerStyleInvalidationCallbacks,
 } from "./style-callbacks.ts";
 import { clearDomainCache } from "./utils/domain-lookup.ts";
+import { getMissingProjectEnvInternalCredentialDetail } from "./project-env/internal-authorization.ts";
 
 const bootstrapLog = logger.component("bootstrap");
 const bootstrapDevLog = logger.component("bootstrap-dev");
@@ -610,6 +611,14 @@ function validateProductionEnvironment(): void {
         detail:
           "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY must be set when running in proxy mode (PROXY_MODE=1)",
       });
+    }
+
+    const missingInternalCredentials = getMissingProjectEnvInternalCredentialDetail();
+    if (missingInternalCredentials) {
+      logger.error(
+        `[Bootstrap:Prod] CRITICAL: ${missingInternalCredentials}.`,
+      );
+      throw INVALID_ARGUMENT.create({ detail: missingInternalCredentials });
     }
 
     if (!isProxyTopologyTrusted()) {

--- a/src/server/project-env/fetcher.test.ts
+++ b/src/server/project-env/fetcher.test.ts
@@ -129,6 +129,62 @@ describe("project-env/fetcher", () => {
     }
   });
 
+  it("names missing internal credentials in hosted proxy mode", async () => {
+    const previousProxyMode = Deno.env.get("PROXY_MODE");
+    const previousLocalProxyMode = Deno.env.get("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    const paths: string[] = [];
+    const { server, port } = createMockServer((req: Request) => {
+      paths.push(new URL(req.url).pathname);
+      return Response.json({ data: [{ key: "API_KEY", value: "********" }] });
+    });
+
+    try {
+      Deno.env.set("PROXY_MODE", "1");
+      Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+      const error = await assertRejects(() => fetchFromMockApi(port));
+
+      assertEquals((error as { slug?: string }).slug, "config-invalid");
+      assertEquals(
+        error.message,
+        "VERYFRONT_API_INTERNAL_USER and VERYFRONT_API_INTERNAL_PASS must be set in hosted proxy mode",
+      );
+      assertEquals(paths, ["/projects/my-project/environment-variables"]);
+    } finally {
+      if (previousProxyMode === undefined) Deno.env.delete("PROXY_MODE");
+      else Deno.env.set("PROXY_MODE", previousProxyMode);
+      if (previousLocalProxyMode === undefined) {
+        Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+      } else {
+        Deno.env.set("VERYFRONT_CLI_LOCAL_PROXY_MODE", previousLocalProxyMode);
+      }
+      await server.shutdown();
+    }
+  });
+
+  it("keeps local CLI proxy mode on the project-authorized response path", async () => {
+    const previousProxyMode = Deno.env.get("PROXY_MODE");
+    const previousLocalProxyMode = Deno.env.get("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    const { server, port } = createMockServer(() =>
+      Response.json({ data: [{ key: "API_KEY", value: "local-value" }] })
+    );
+
+    try {
+      Deno.env.set("PROXY_MODE", "1");
+      Deno.env.set("VERYFRONT_CLI_LOCAL_PROXY_MODE", "1");
+
+      assertEquals(await fetchFromMockApi(port), { API_KEY: "local-value" });
+    } finally {
+      if (previousProxyMode === undefined) Deno.env.delete("PROXY_MODE");
+      else Deno.env.set("PROXY_MODE", previousProxyMode);
+      if (previousLocalProxyMode === undefined) {
+        Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+      } else {
+        Deno.env.set("VERYFRONT_CLI_LOCAL_PROXY_MODE", previousLocalProxyMode);
+      }
+      await server.shutdown();
+    }
+  });
+
   it("rejects a missing data field instead of substituting an empty environment", async () => {
     const { server, port } = createMockServer(() => {
       return Response.json({});

--- a/src/server/project-env/fetcher.test.ts
+++ b/src/server/project-env/fetcher.test.ts
@@ -129,62 +129,6 @@ describe("project-env/fetcher", () => {
     }
   });
 
-  it("names missing internal credentials in hosted proxy mode", async () => {
-    const previousProxyMode = Deno.env.get("PROXY_MODE");
-    const previousLocalProxyMode = Deno.env.get("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-    const paths: string[] = [];
-    const { server, port } = createMockServer((req: Request) => {
-      paths.push(new URL(req.url).pathname);
-      return Response.json({ data: [{ key: "API_KEY", value: "********" }] });
-    });
-
-    try {
-      Deno.env.set("PROXY_MODE", "1");
-      Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-      const error = await assertRejects(() => fetchFromMockApi(port));
-
-      assertEquals((error as { slug?: string }).slug, "config-invalid");
-      assertEquals(
-        error.message,
-        "VERYFRONT_API_INTERNAL_USER and VERYFRONT_API_INTERNAL_PASS must be set in hosted proxy mode",
-      );
-      assertEquals(paths, ["/projects/my-project/environment-variables"]);
-    } finally {
-      if (previousProxyMode === undefined) Deno.env.delete("PROXY_MODE");
-      else Deno.env.set("PROXY_MODE", previousProxyMode);
-      if (previousLocalProxyMode === undefined) {
-        Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-      } else {
-        Deno.env.set("VERYFRONT_CLI_LOCAL_PROXY_MODE", previousLocalProxyMode);
-      }
-      await server.shutdown();
-    }
-  });
-
-  it("keeps local CLI proxy mode on the project-authorized response path", async () => {
-    const previousProxyMode = Deno.env.get("PROXY_MODE");
-    const previousLocalProxyMode = Deno.env.get("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-    const { server, port } = createMockServer(() =>
-      Response.json({ data: [{ key: "API_KEY", value: "local-value" }] })
-    );
-
-    try {
-      Deno.env.set("PROXY_MODE", "1");
-      Deno.env.set("VERYFRONT_CLI_LOCAL_PROXY_MODE", "1");
-
-      assertEquals(await fetchFromMockApi(port), { API_KEY: "local-value" });
-    } finally {
-      if (previousProxyMode === undefined) Deno.env.delete("PROXY_MODE");
-      else Deno.env.set("PROXY_MODE", previousProxyMode);
-      if (previousLocalProxyMode === undefined) {
-        Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-      } else {
-        Deno.env.set("VERYFRONT_CLI_LOCAL_PROXY_MODE", previousLocalProxyMode);
-      }
-      await server.shutdown();
-    }
-  });
-
   it("rejects a missing data field instead of substituting an empty environment", async () => {
     const { server, port } = createMockServer(() => {
       return Response.json({});

--- a/src/server/project-env/fetcher.ts
+++ b/src/server/project-env/fetcher.ts
@@ -4,17 +4,22 @@
  * @module server/project-env/fetcher
  */
 
-import { encodeBase64, getBaseLogger } from "#veryfront/utils";
+import { getBaseLogger } from "#veryfront/utils";
 import { readResponseTextPrefix } from "#veryfront/utils/response-body.ts";
 import {
   AUTHENTICATION_REQUIRED,
+  CONFIG_INVALID,
   isVeryfrontError,
   NETWORK_ERROR,
   PERMISSION_DENIED,
 } from "#veryfront/errors";
-import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { isErrorAcrossRealms } from "#veryfront/platform/compat/error-introspection.ts";
 import { createProjectEnvSnapshot } from "./snapshot.ts";
+import {
+  getMissingProjectEnvInternalCredentialDetail,
+  getProjectEnvInternalAuthorization,
+  requiresProjectEnvInternalAuthorization,
+} from "./internal-authorization.ts";
 
 const baseLogger = getBaseLogger("PROJECT-ENV");
 
@@ -119,13 +124,6 @@ function parseEnvironmentResponse(text: string): Readonly<Record<string, string>
   }
 }
 
-function getInternalAuthorization(): string | undefined {
-  const username = getHostEnv("VERYFRONT_API_INTERNAL_USER");
-  const password = getHostEnv("VERYFRONT_API_INTERNAL_PASS");
-  if (!username || !password) return undefined;
-  return `Basic ${encodeBase64(`${username}:${password}`)}`;
-}
-
 async function fetchEnvironmentVariables(
   url: string,
   authorization: string,
@@ -226,7 +224,14 @@ export async function fetchProjectEnvVars(
 
   // Do not even materialize the host credential until the tenant credential
   // has proved access to this canonical project/environment pair.
-  const internalAuthorization = getInternalAuthorization();
+  const internalAuthorization = getProjectEnvInternalAuthorization();
+  if (!internalAuthorization && requiresProjectEnvInternalAuthorization()) {
+    discardResponseBody(response);
+    throw CONFIG_INVALID.create({
+      detail: getMissingProjectEnvInternalCredentialDetail() ??
+        "Internal project environment authorization is unavailable in hosted proxy mode",
+    });
+  }
   if (internalAuthorization) {
     discardResponseBody(response);
     response = await fetchEnvironmentVariables(

--- a/src/server/project-env/hosted-authorization.test.ts
+++ b/src/server/project-env/hosted-authorization.test.ts
@@ -1,0 +1,121 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/testing/deno-compat.ts";
+import { fetchProjectEnvVars } from "./fetcher.ts";
+
+const ENV_KEYS = [
+  "PROXY_MODE",
+  "VERYFRONT_CLI_LOCAL_PROXY_MODE",
+  "VERYFRONT_API_INTERNAL_USER",
+  "VERYFRONT_API_INTERNAL_PASS",
+] as const;
+const originalEnv = new Map(ENV_KEYS.map((key) => [key, getEnv(key)]));
+const originalFetch = globalThis.fetch;
+
+function restoreEnvironment(): void {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) deleteEnv(key);
+    else setEnv(key, value);
+  }
+}
+
+describe("hosted project environment authorization", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    restoreEnvironment();
+  });
+
+  it("fails with a configuration error when hosted credentials are missing", async () => {
+    setEnv("PROXY_MODE", "1");
+    deleteEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    deleteEnv("VERYFRONT_API_INTERNAL_USER");
+    deleteEnv("VERYFRONT_API_INTERNAL_PASS");
+    const urls: string[] = [];
+    globalThis.fetch = ((input) => {
+      urls.push(input instanceof Request ? input.url : String(input));
+      return Promise.resolve(
+        Response.json({ data: [{ key: "API_KEY", value: "********" }] }),
+      );
+    }) as typeof fetch;
+
+    const error = await assertRejects(() =>
+      fetchProjectEnvVars(
+        "https://api.veryfront.test",
+        "my-project",
+        "env-123",
+        "test-token",
+      )
+    );
+
+    assertEquals((error as { slug?: string }).slug, "config-invalid");
+    assertEquals(
+      (error as Error).message,
+      "VERYFRONT_API_INTERNAL_USER and VERYFRONT_API_INTERNAL_PASS must be set in hosted proxy mode",
+    );
+    assertEquals(urls.length, 1);
+    assertEquals(new URL(urls[0]!).pathname, "/projects/my-project/environment-variables");
+  });
+
+  it("uses the internal endpoint after project authorization", async () => {
+    setEnv("PROXY_MODE", "1");
+    deleteEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE");
+    setEnv("VERYFRONT_API_INTERNAL_USER", "test-internal-user");
+    setEnv("VERYFRONT_API_INTERNAL_PASS", "test-internal-pass");
+    const requests: Array<{ url: string; authorization: string | null }> = [];
+    globalThis.fetch = ((input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      requests.push({
+        url,
+        authorization: new Headers(init?.headers).get("authorization"),
+      });
+      const data = requests.length === 1
+        ? [{ key: "API_KEY", value: "********" }]
+        : [{ key: "API_KEY", value: "hosted-value" }];
+      return Promise.resolve(Response.json({ data }));
+    }) as typeof fetch;
+
+    assertEquals(
+      await fetchProjectEnvVars(
+        "https://api.veryfront.test",
+        "my-project",
+        "env-123",
+        "test-token",
+      ),
+      { API_KEY: "hosted-value" },
+    );
+    assertEquals(requests.length, 2);
+    assertEquals(
+      new URL(requests[1]!.url).pathname,
+      "/internal/project-environment-variables",
+    );
+    assertEquals(requests[0]!.authorization, "Bearer test-token");
+    assertEquals(requests[1]!.authorization?.startsWith("Basic "), true);
+  });
+
+  it("keeps local CLI proxy mode on the project-authorized response path", async () => {
+    setEnv("PROXY_MODE", "1");
+    setEnv("VERYFRONT_CLI_LOCAL_PROXY_MODE", "1");
+    deleteEnv("VERYFRONT_API_INTERNAL_USER");
+    deleteEnv("VERYFRONT_API_INTERNAL_PASS");
+    let requestCount = 0;
+    globalThis.fetch = (() => {
+      requestCount++;
+      return Promise.resolve(
+        Response.json({ data: [{ key: "API_KEY", value: "local-value" }] }),
+      );
+    }) as typeof fetch;
+
+    assertEquals(
+      await fetchProjectEnvVars(
+        "https://api.veryfront.test",
+        "my-project",
+        "env-123",
+        "test-token",
+      ),
+      { API_KEY: "local-value" },
+    );
+    assertEquals(requestCount, 1);
+  });
+});

--- a/src/server/project-env/internal-authorization.ts
+++ b/src/server/project-env/internal-authorization.ts
@@ -1,0 +1,34 @@
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { encodeBase64 } from "#veryfront/utils";
+import { getEnvSource } from "#veryfront/utils/env-loader.ts";
+
+const INTERNAL_USER_ENV = "VERYFRONT_API_INTERNAL_USER";
+const INTERNAL_PASS_ENV = "VERYFRONT_API_INTERNAL_PASS";
+const LOCAL_CLI_PROXY_MODE_ENV = "VERYFRONT_CLI_LOCAL_PROXY_MODE";
+
+/** Whether project env reads require the hosted runtime's internal API credential. */
+export function requiresProjectEnvInternalAuthorization(): boolean {
+  if (getHostEnv("PROXY_MODE") !== "1") return false;
+  const isLocalCliProxyMode = getHostEnv(LOCAL_CLI_PROXY_MODE_ENV) === "1" &&
+    getEnvSource(LOCAL_CLI_PROXY_MODE_ENV).source === "process";
+  return !isLocalCliProxyMode;
+}
+
+/** Name the missing hosted runtime credentials without exposing their values. */
+export function getMissingProjectEnvInternalCredentialDetail(): string | undefined {
+  const missing = [
+    getHostEnv(INTERNAL_USER_ENV) ? undefined : INTERNAL_USER_ENV,
+    getHostEnv(INTERNAL_PASS_ENV) ? undefined : INTERNAL_PASS_ENV,
+  ].filter((name): name is string => name !== undefined);
+  return missing.length > 0
+    ? `${missing.join(" and ")} must be set in hosted proxy mode`
+    : undefined;
+}
+
+/** Build the internal API authorization header when both credentials are present. */
+export function getProjectEnvInternalAuthorization(): string | undefined {
+  const username = getHostEnv(INTERNAL_USER_ENV);
+  const password = getHostEnv(INTERNAL_PASS_ENV);
+  if (!username || !password) return undefined;
+  return `Basic ${encodeBase64(`${username}:${password}`)}`;
+}

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -3315,6 +3315,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         PRODUCTION_MODE: "1",
         VERYFRONT_TRUST_FORWARDED_HEADERS: "1",
         VERYFRONT_API_BASE_URL: UNREACHABLE_LOCAL_PROXY_API_BASE_URL,
+        VERYFRONT_API_INTERNAL_USER: "test-internal-user",
+        VERYFRONT_API_INTERNAL_PASS: "test-internal-pass",
         VERYFRONT_API_TOKEN: "",
       },
     );
@@ -3386,6 +3388,8 @@ export default function Home() {
         PRODUCTION_MODE: "1",
         VERYFRONT_TRUST_FORWARDED_HEADERS: "1",
         VERYFRONT_API_BASE_URL: UNREACHABLE_LOCAL_PROXY_API_BASE_URL,
+        VERYFRONT_API_INTERNAL_USER: "test-internal-user",
+        VERYFRONT_API_INTERNAL_PASS: "test-internal-pass",
         VERYFRONT_API_TOKEN: "",
       },
     );

--- a/tests/integration/vfs-proxy-mode-e2e.test.ts
+++ b/tests/integration/vfs-proxy-mode-e2e.test.ts
@@ -164,6 +164,8 @@ async function startVFSServer(
     PROXY_MODE: "1",
     VERYFRONT_TRUST_FORWARDED_HEADERS: "1",
     VERYFRONT_API_BASE_URL: "https://api.veryfront.com",
+    VERYFRONT_API_INTERNAL_USER: "test-internal-user",
+    VERYFRONT_API_INTERNAL_PASS: "test-internal-pass",
     LOG_FORMAT: "text",
     VERYFRONT_CACHE_DIR: cacheDir,
     ...extraEnv,


### PR DESCRIPTION
## Description

- Fail hosted proxy startup when either internal project environment credential is missing.
- Return a typed configuration error before a masked management response can hide missing runtime credentials.
- Preserve the explicitly trusted local CLI proxy path without hosted credentials.
- Centralize internal authorization lookup so bootstrap and fetch behavior use one credential contract.
- Document the required endpoint-first upgrade and rollback order for hosted runtimes.
- Exercise the hosted credential contract under Deno, Node, and Bun.

The behavior changes were developed red-green: the new startup and fetch tests failed against the previous behavior, then passed after the implementation changes.

## Related Issue(s)

Fixes veryfront/veryfront-issue-inbox#503

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- `deno fmt --check` on touched code and security guidance
- `deno lint` on touched code
- `deno check src/server/bootstrap.ts src/server/project-env/fetcher.ts src/server/project-env/internal-authorization.ts src/server/project-env/hosted-authorization.test.ts`
- Focused Deno server suites: 40 steps passed
- Focused Node suites: 19 tests passed
- Focused Bun 1.3.6 suites: 2 files passed
- Full parallel unit suite before review follow-ups: 3814 tests passed, 0 failed, 1 ignored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hosted proxy environments now require internal credentials and a canonical internal endpoint.
  * Missing credentials, redirects, or failed internal requests are rejected without fallback.
  * Local CLI proxy mode continues to support its existing authorization flow.

* **Documentation**
  * Updated deployment, startup, rollback, and environment configuration guidance for hosted proxy authorization.

* **Tests**
  * Added coverage for credential validation, authorization headers, local proxy behavior, and fail-closed integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->