### PR TITLE
fix(server): diagnosable masked-env refusal and negative caching for env fetch failures

### DIFF
--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { INVALID_ARGUMENT, SERVICE_OVERLOADED } from "#veryfront/errors";
+import { INVALID_ARGUMENT, NETWORK_ERROR, SERVICE_OVERLOADED } from "#veryfront/errors";
 import {
   __registerLogRecordEmitter,
   __resetLogRecordEmitterForTests,
@@ -44,6 +44,7 @@ import {
   getCurrentRequestContext,
   runWithRequestContext,
 } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { EnvironmentVariableCache } from "../../project-env/cache.ts";
 
 // Literal public addresses exercise guarded egress deterministically without
 // depending on external DNS answers for production or reserved test hosts.
@@ -3546,6 +3547,100 @@ describe("agent stream handler application-error reporting", () => {
     assertEquals(attributes["http.status"], 503);
     assertEquals(attributes["project.id"], "proj-1");
     assertEquals(attributes["project.slug"], "demo-project");
+  });
+
+  it("reports and logs a negative-cached environment failure only on its first response", async () => {
+    const entries: LogEntry[] = [];
+    const previousLogLevel = Deno.env.get("LOG_LEVEL");
+    const failure = NETWORK_ERROR.create({
+      detail: "Internal project environment request failed",
+    });
+    let fetchCount = 0;
+    const cache = new EnvironmentVariableCache(
+      () => {
+        fetchCount += 1;
+        return Promise.reject(failure);
+      },
+      60_000,
+      100,
+      { markFailureReplays: true },
+    );
+    const { captures, restore } = stubApplicationErrorReporter();
+
+    try {
+      Deno.env.set("LOG_LEVEL", "DEBUG");
+      refreshLoggerConfig();
+      __registerLogRecordEmitter((entry) => entries.push(entry));
+
+      const handler = createTestAgentStreamHandler({
+        loadAgentSourceEnvironment: () =>
+          cache.get({
+            projectSlug: "test-project",
+            projectId: "10000000-1000-4000-8000-100000000005",
+            environmentId: "10000000-1000-4000-8000-100000000098",
+            token: "test-token",
+          }),
+        ensureProjectDiscovery: async () => createEmptyDiscoveryResult(),
+        getAgent: () => undefined,
+        getAllAgentIds: () => [],
+        sessionManager: new AgentRunSessionManager(),
+      });
+      const body = createAgentStreamRequestBody({
+        project: {
+          runtimeTargetKind: "environment",
+          runtimeTargetEnvironmentId: "10000000-1000-4000-8000-100000000098",
+        },
+        agentSource: {
+          type: "environment",
+          environmentName: "staging",
+          releaseId: "10000000-1000-4000-8000-100000000099",
+        },
+        credentials: { authToken: "request-scoped-user-token" },
+      });
+      const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+        requestId: "run_1",
+      });
+
+      const responses: Response[] = [];
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const result = await handler.handle(
+          new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "x-veryfront-control-plane-jws": jws,
+            },
+            body,
+          }),
+          createCtx(publicKeyPem),
+        );
+        assertExists(result.response);
+        responses.push(result.response);
+      }
+
+      assertEquals(fetchCount, 1);
+      const firstResponse = responses[0];
+      const replayedResponse = responses[1];
+      assertExists(firstResponse);
+      assertExists(replayedResponse);
+      assertEquals([firstResponse.status, replayedResponse.status], [502, 502]);
+      assertEquals(
+        await firstResponse.clone().json(),
+        await replayedResponse.clone().json(),
+      );
+      assertEquals(captures.length, 1);
+      assertEquals(
+        entries.filter((entry) => entry.message === "Internal agent stream request failed").length,
+        1,
+      );
+      await Promise.all(responses.map((response) => response.body?.cancel()));
+    } finally {
+      restore();
+      __resetLogRecordEmitterForTests();
+      if (previousLogLevel === undefined) Deno.env.delete("LOG_LEVEL");
+      else Deno.env.set("LOG_LEVEL", previousLogLevel);
+      refreshLoggerConfig();
+    }
   });
 
   // A malformed percent escape makes the run-id decode throw. Reporting runs

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -3549,7 +3549,7 @@ describe("agent stream handler application-error reporting", () => {
     assertEquals(attributes["project.slug"], "demo-project");
   });
 
-  it("reports and logs a negative-cached environment failure only on its first response", async () => {
+  it("reports and logs a shared environment failure only once across joiners and replays", async () => {
     const entries: LogEntry[] = [];
     const previousLogLevel = Deno.env.get("LOG_LEVEL");
     const failure = NETWORK_ERROR.create({
@@ -3557,9 +3557,10 @@ describe("agent stream handler application-error reporting", () => {
     });
     let fetchCount = 0;
     const cache = new EnvironmentVariableCache(
-      () => {
+      async () => {
         fetchCount += 1;
-        return Promise.reject(failure);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        throw failure;
       },
       60_000,
       100,
@@ -3601,8 +3602,7 @@ describe("agent stream handler application-error reporting", () => {
         requestId: "run_1",
       });
 
-      const responses: Response[] = [];
-      for (let attempt = 0; attempt < 2; attempt += 1) {
+      const handleRequest = async (): Promise<Response> => {
         const result = await handler.handle(
           new Request("https://example.com/api/control-plane/runs/run_1/stream", {
             method: "POST",
@@ -3615,18 +3615,32 @@ describe("agent stream handler application-error reporting", () => {
           createCtx(publicKeyPem),
         );
         assertExists(result.response);
-        responses.push(result.response);
-      }
+        return result.response;
+      };
+
+      const responses = [
+        ...await Promise.all([handleRequest(), handleRequest()]),
+        await handleRequest(),
+      ];
 
       assertEquals(fetchCount, 1);
       const firstResponse = responses[0];
-      const replayedResponse = responses[1];
+      const joinedResponse = responses[1];
+      const cachedResponse = responses[2];
       assertExists(firstResponse);
-      assertExists(replayedResponse);
-      assertEquals([firstResponse.status, replayedResponse.status], [502, 502]);
+      assertExists(joinedResponse);
+      assertExists(cachedResponse);
+      assertEquals(
+        [firstResponse.status, joinedResponse.status, cachedResponse.status],
+        [502, 502, 502],
+      );
       assertEquals(
         await firstResponse.clone().json(),
-        await replayedResponse.clone().json(),
+        await joinedResponse.clone().json(),
+      );
+      assertEquals(
+        await firstResponse.clone().json(),
+        await cachedResponse.clone().json(),
       );
       assertEquals(captures.length, 1);
       assertEquals(

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -78,6 +78,7 @@ import {
   filterRuntimeProjectEnv,
   ProjectEnvironmentIdentityResolver,
   runWithProjectEnv,
+  unwrapReplayedProjectEnvironmentFailure,
 } from "../../project-env/index.ts";
 import { getHostedConfig, type VeryfrontConfig } from "#veryfront/config/loader.ts";
 import { prepareDeclarativeConfigContext } from "#veryfront/config/declarative-evaluator.ts";
@@ -143,6 +144,9 @@ const _agentEnvVarCache = new EnvironmentVariableCache(
       signal,
     );
   },
+  60_000,
+  100,
+  { markFailureReplays: true },
 );
 
 const _environmentIdentityResolver = new ProjectEnvironmentIdentityResolver();
@@ -935,7 +939,10 @@ export class AgentStreamHandler extends BaseHandler {
         verifiedClaims,
         runWithAgentSourceContext,
       );
-    } catch (error) {
+    } catch (caught) {
+      // The first negative-cache failure owns diagnostics. Replays retain the
+      // original error for response construction but must not repeat reports.
+      const { error, replayed } = unwrapReplayedProjectEnvironmentFailure(caught);
       if (error instanceof InternalAgentRequestBodyTooLargeError) {
         return this.respond(builder.json({ error: error.message }, error.status));
       }
@@ -964,7 +971,7 @@ export class AgentStreamHandler extends BaseHandler {
         const response = errorToResponse(error, new URL(req.url).pathname);
         // errorToResponse strips `detail` from 5xx bodies, so the log and the
         // reported event are the only places it survives.
-        if (response.status >= 500) {
+        if (response.status >= 500 && !replayed) {
           const cause = describeErrorCause(error.cause);
           logger.error("Internal agent stream request failed", {
             projectId: ctx.projectId,
@@ -992,26 +999,28 @@ export class AgentStreamHandler extends BaseHandler {
         return this.respond(applyBuilderHeaders(response, builder.headers));
       }
 
-      this.logWarn("Internal agent stream request failed", {
-        error: error instanceof Error ? error.message : String(error),
-        projectId: ctx.projectId,
-        projectSlug: ctx.projectSlug,
-      });
-      logger.error("Internal agent stream handler failed", {
-        projectId: ctx.projectId,
-        projectSlug: ctx.projectSlug,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      // Unexpected failures have no slug or detail, so the captured stack is
-      // the only real diagnostic.
-      reportHandlerFailure(error, {
-        boundary: "agent.stream.handler",
-        method: req.method,
-        status: HTTP_INTERNAL_SERVER_ERROR,
-        runId: safeRunId(req),
-        projectId: ctx.projectId,
-        projectSlug: ctx.projectSlug,
-      });
+      if (!replayed) {
+        this.logWarn("Internal agent stream request failed", {
+          error: error instanceof Error ? error.message : String(error),
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+        });
+        logger.error("Internal agent stream handler failed", {
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        // Unexpected failures have no slug or detail, so the captured stack is
+        // the only real diagnostic.
+        reportHandlerFailure(error, {
+          boundary: "agent.stream.handler",
+          method: req.method,
+          status: HTTP_INTERNAL_SERVER_ERROR,
+          runId: safeRunId(req),
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+        });
+      }
       return this.respond(builder.json({ error: "Internal agent stream failed" }, 500));
     }
   }

--- a/src/server/project-env/cache.test.ts
+++ b/src/server/project-env/cache.test.ts
@@ -146,6 +146,100 @@ describe("project-env/cache", () => {
     await assertRejects(() => cache.get(scope()), Error, "network error");
   });
 
+  it("does not refetch a failed environment within the failure TTL", async () => {
+    // Mirrors the production incident: a persistent upstream refusal must not
+    // be refetched on every request (223 Sentry events from one misconfig).
+    let fetchCount = 0;
+    const cache = new EnvironmentVariableCache(() => {
+      fetchCount++;
+      return Promise.reject(new Error("Refusing masked environment variable response"));
+    });
+
+    const first = await assertRejects(
+      () => cache.get(scope()),
+      Error,
+      "Refusing masked environment variable response",
+    );
+    // Await the first rejection before the second call so inflight
+    // deduplication cannot mask missing negative caching.
+    const second = await assertRejects(
+      () => cache.get(scope()),
+      Error,
+      "Refusing masked environment variable response",
+    );
+    assertEquals(fetchCount, 1);
+    assertEquals(second, first);
+  });
+
+  it("retries the upstream once the failure TTL has elapsed", async () => {
+    let fetchCount = 0;
+    const cache = new EnvironmentVariableCache(
+      () => {
+        fetchCount++;
+        return Promise.reject(new Error(`refused ${fetchCount}`));
+      },
+      60_000,
+      100,
+      { failureTtlMs: 20 },
+    );
+
+    await assertRejects(() => cache.get(scope()), Error, "refused 1");
+    await assertRejects(() => cache.get(scope()), Error, "refused 1");
+    await delay(30);
+    await assertRejects(() => cache.get(scope()), Error, "refused 2");
+    assertEquals(fetchCount, 2);
+  });
+
+  it("clears a recorded failure once a fetch succeeds", async () => {
+    let fetchCount = 0;
+    const cache = new EnvironmentVariableCache(
+      () => {
+        fetchCount++;
+        if (fetchCount === 1) return Promise.reject(new Error("refused"));
+        return Promise.resolve({ VALUE: "recovered" });
+      },
+      60_000,
+      100,
+      { failureTtlMs: 20 },
+    );
+
+    await assertRejects(() => cache.get(scope()), Error, "refused");
+    await delay(30);
+    assertEquals(await cache.get(scope()), { VALUE: "recovered" });
+    assertEquals(await cache.get(scope()), { VALUE: "recovered" });
+    assertEquals(fetchCount, 2);
+  });
+
+  it("does not record an invalidated fetch as a negative-cache failure", async () => {
+    const oldFetch = deferred<Record<string, string>>();
+    const started = deferred<void>();
+    let fetchCount = 0;
+    const cache = new EnvironmentVariableCache(async () => {
+      fetchCount++;
+      if (fetchCount === 1) {
+        started.resolve();
+        return await oldFetch.promise;
+      }
+      return { VALUE: "fresh" };
+    });
+
+    const oldWaiter = cache.get(scope());
+    await started.promise;
+    cache.invalidate("env-shared");
+    await assertRejects(
+      () => oldWaiter,
+      Error,
+      "Project environment fetch was invalidated",
+    );
+
+    // The invalidation error must not be replayed to the newer epoch.
+    assertEquals(await cache.get(scope()), { VALUE: "fresh" });
+    oldFetch.reject(new Error("stale rejection"));
+    await delay(0);
+    assertEquals(await cache.get(scope()), { VALUE: "fresh" });
+    assertEquals(fetchCount, 2);
+  });
+
   it("does not leak another scope's stale value after a failed fetch", async () => {
     const cache = new EnvironmentVariableCache(async (input) => {
       if (input.projectSlug === "project-a") return { OWNER: "project-a" };
@@ -280,7 +374,8 @@ describe("project-env/cache", () => {
       },
       60_000,
       100,
-      { fetchTimeoutMs: 10, maxInflight: 1 },
+      // This test's subject is in-flight capacity cleanup, not retry pacing.
+      { fetchTimeoutMs: 10, maxInflight: 1, failureTtlMs: 0 },
     );
 
     await assertRejects(
@@ -294,11 +389,18 @@ describe("project-env/cache", () => {
 
   it("clears rejected in-flight work so a retry can succeed", async () => {
     let fetchCount = 0;
-    const cache = new EnvironmentVariableCache(async () => {
-      fetchCount++;
-      if (fetchCount === 1) throw new Error("temporary failure");
-      return { VALUE: "recovered" };
-    });
+    const cache = new EnvironmentVariableCache(
+      async () => {
+        fetchCount++;
+        if (fetchCount === 1) throw new Error("temporary failure");
+        return { VALUE: "recovered" };
+        // failureTtlMs: 0 — this test's subject is in-flight capacity cleanup,
+        // not retry pacing.
+      },
+      60_000,
+      100,
+      { failureTtlMs: 0 },
+    );
 
     await assertRejects(() => cache.get(scope()), Error, "temporary failure");
     assertEquals(await cache.get(scope()), { VALUE: "recovered" });

--- a/src/server/project-env/cache.test.ts
+++ b/src/server/project-env/cache.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
-import { EnvironmentVariableCache, type ProjectEnvironmentScope } from "./cache.ts";
+import {
+  EnvironmentVariableCache,
+  type ProjectEnvironmentScope,
+  unwrapReplayedProjectEnvironmentFailure,
+} from "./cache.ts";
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -169,6 +173,29 @@ describe("project-env/cache", () => {
     );
     assertEquals(fetchCount, 1);
     assertEquals(second, first);
+  });
+
+  it("marks an opted-in failure replay without replacing the original failure", async () => {
+    const failure = new Error("upstream refused the environment request");
+    const cache = new EnvironmentVariableCache(
+      () => Promise.reject(failure),
+      60_000,
+      100,
+      { markFailureReplays: true },
+    );
+
+    const first = await assertRejects(() => cache.get(scope()));
+    const second = await assertRejects(() => cache.get(scope()));
+
+    assertEquals(first, failure);
+    assertEquals(unwrapReplayedProjectEnvironmentFailure(first), {
+      error: failure,
+      replayed: false,
+    });
+    assertEquals(unwrapReplayedProjectEnvironmentFailure(second), {
+      error: failure,
+      replayed: true,
+    });
   });
 
   it("retries the upstream once the failure TTL has elapsed", async () => {

--- a/src/server/project-env/cache.test.ts
+++ b/src/server/project-env/cache.test.ts
@@ -198,6 +198,35 @@ describe("project-env/cache", () => {
     });
   });
 
+  it("marks opted-in in-flight failure joiners as replays", async () => {
+    const failure = new Error("shared upstream failure");
+    let fetchCount = 0;
+    const cache = new EnvironmentVariableCache(
+      async () => {
+        fetchCount += 1;
+        await delay(20);
+        throw failure;
+      },
+      60_000,
+      100,
+      { markFailureReplays: true },
+    );
+
+    const failures = await Promise.all([
+      assertRejects(() => cache.get(scope())),
+      assertRejects(() => cache.get(scope())),
+    ]);
+    const unwrapped = failures
+      .map(unwrapReplayedProjectEnvironmentFailure)
+      .sort((left, right) => Number(left.replayed) - Number(right.replayed));
+
+    assertEquals(fetchCount, 1);
+    assertEquals(unwrapped, [
+      { error: failure, replayed: false },
+      { error: failure, replayed: true },
+    ]);
+  });
+
   it("retries the upstream once the failure TTL has elapsed", async () => {
     let fetchCount = 0;
     const cache = new EnvironmentVariableCache(

--- a/src/server/project-env/cache.ts
+++ b/src/server/project-env/cache.ts
@@ -38,6 +38,31 @@ interface FailureEntry {
   environmentId: string;
 }
 
+const replayedProjectEnvironmentFailures = new WeakMap<object, unknown>();
+
+class ReplayedProjectEnvironmentFailure extends Error {
+  constructor(error: unknown) {
+    super("Project environment request reused a cached failure");
+    this.name = "ReplayedProjectEnvironmentFailure";
+    replayedProjectEnvironmentFailures.set(this, error);
+  }
+}
+
+export function unwrapReplayedProjectEnvironmentFailure(
+  error: unknown,
+): { error: unknown; replayed: boolean } {
+  if (
+    typeof error === "object" && error !== null &&
+    replayedProjectEnvironmentFailures.has(error)
+  ) {
+    return {
+      error: replayedProjectEnvironmentFailures.get(error),
+      replayed: true,
+    };
+  }
+  return { error, replayed: false };
+}
+
 type Fetcher = (
   scope: ProjectEnvironmentScope,
   signal: AbortSignal,
@@ -56,6 +81,8 @@ export interface EnvironmentVariableCacheOptions {
    * without ever serving stale or empty data. Zero disables negative caching.
    */
   failureTtlMs?: number;
+  /** Mark replayed failures so an error boundary can suppress duplicate reporting. */
+  markFailureReplays?: boolean;
 }
 
 /** Max number of scoped environments to cache. Evicts oldest entry when exceeded. */
@@ -170,6 +197,7 @@ export class EnvironmentVariableCache {
   private maxInflight: number;
   private maxInflightPerProject: number;
   private failureTtlMs: number;
+  private markFailureReplays: boolean;
   private globalEpoch = 0;
   private environmentEpochs = new Map<string, number>();
 
@@ -198,6 +226,7 @@ export class EnvironmentVariableCache {
       options.failureTtlMs ?? DEFAULT_FAILURE_TTL_MS,
       "failureTtlMs",
     );
+    this.markFailureReplays = options.markFailureReplays === true;
   }
 
   async get(scope: ProjectEnvironmentScope): Promise<Record<string, string>> {
@@ -228,7 +257,12 @@ export class EnvironmentVariableCache {
     // one per request. Still fails closed: no stale or empty data is served.
     const failure = this.failures.get(key);
     if (failure) {
-      if (now - failure.failedAt < this.failureTtlMs) throw failure.error;
+      if (now - failure.failedAt < this.failureTtlMs) {
+        if (this.markFailureReplays) {
+          throw new ReplayedProjectEnvironmentFailure(failure.error);
+        }
+        throw failure.error;
+      }
       this.failures.delete(key);
     }
 

--- a/src/server/project-env/cache.ts
+++ b/src/server/project-env/cache.ts
@@ -250,7 +250,12 @@ export class EnvironmentVariableCache {
     // Deduplicate only requests with exactly the same canonical identity and
     // credential principal. A shared environment ID is never sufficient.
     const existing = this.inflight.get(key);
-    if (existing) return existing.promise;
+    if (existing) {
+      if (!this.markFailureReplays) return existing.promise;
+      return existing.promise.catch((error) => {
+        throw new ReplayedProjectEnvironmentFailure(error);
+      });
+    }
 
     // Rethrow a recent upstream failure instead of starting another fetch so a
     // persistent refusal produces one upstream fetch per TTL window instead of

--- a/src/server/project-env/cache.ts
+++ b/src/server/project-env/cache.ts
@@ -32,6 +32,12 @@ interface CacheEntry {
   environmentId: string;
 }
 
+interface FailureEntry {
+  error: unknown;
+  failedAt: number;
+  environmentId: string;
+}
+
 type Fetcher = (
   scope: ProjectEnvironmentScope,
   signal: AbortSignal,
@@ -44,11 +50,18 @@ export interface EnvironmentVariableCacheOptions {
   maxInflight?: number;
   /** Maximum number of distinct upstream fetches for one canonical project. */
   maxInflightPerProject?: number;
+  /**
+   * How long a failed fetch is rethrown before the upstream is retried.
+   * Collapses per-request refetch storms during a persistent upstream refusal
+   * without ever serving stale or empty data. Zero disables negative caching.
+   */
+  failureTtlMs?: number;
 }
 
 /** Max number of scoped environments to cache. Evicts oldest entry when exceeded. */
 const DEFAULT_MAX_ENTRIES = 100;
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_FAILURE_TTL_MS = 5_000;
 const DEFAULT_MAX_INFLIGHT = 100;
 const DEFAULT_MAX_INFLIGHT_PER_PROJECT = 10;
 const encodeText = TextEncoder.prototype.encode;
@@ -147,6 +160,7 @@ function invalidatedError(): VeryfrontError {
 
 export class EnvironmentVariableCache {
   private cache = new Map<string, CacheEntry>();
+  private failures = new Map<string, FailureEntry>();
   private inflight = new Map<string, InflightEntry>();
   private inflightByProject = new Map<string, number>();
   private fetcher: Fetcher;
@@ -155,6 +169,7 @@ export class EnvironmentVariableCache {
   private fetchTimeoutMs: number;
   private maxInflight: number;
   private maxInflightPerProject: number;
+  private failureTtlMs: number;
   private globalEpoch = 0;
   private environmentEpochs = new Map<string, number>();
 
@@ -178,6 +193,10 @@ export class EnvironmentVariableCache {
     this.maxInflightPerProject = positiveInteger(
       options.maxInflightPerProject ?? DEFAULT_MAX_INFLIGHT_PER_PROJECT,
       "maxInflightPerProject",
+    );
+    this.failureTtlMs = nonNegativeInteger(
+      options.failureTtlMs ?? DEFAULT_FAILURE_TTL_MS,
+      "failureTtlMs",
     );
   }
 
@@ -203,6 +222,15 @@ export class EnvironmentVariableCache {
     // credential principal. A shared environment ID is never sufficient.
     const existing = this.inflight.get(key);
     if (existing) return existing.promise;
+
+    // Rethrow a recent upstream failure instead of starting another fetch so a
+    // persistent refusal produces one upstream fetch per TTL window instead of
+    // one per request. Still fails closed: no stale or empty data is served.
+    const failure = this.failures.get(key);
+    if (failure) {
+      if (now - failure.failedAt < this.failureTtlMs) throw failure.error;
+      this.failures.delete(key);
+    }
 
     this.assertAdmission(normalizedScope.projectSlug);
 
@@ -230,6 +258,7 @@ export class EnvironmentVariableCache {
       this.globalEpoch++;
       this.environmentEpochs.clear();
       this.cache.clear();
+      this.failures.clear();
       for (const entry of [...this.inflight.values()]) {
         this.invalidateInflight(entry);
       }
@@ -243,6 +272,10 @@ export class EnvironmentVariableCache {
 
     for (const [key, entry] of this.cache) {
       if (entry.environmentId === environmentId) this.cache.delete(key);
+    }
+
+    for (const [key, failure] of this.failures) {
+      if (failure.environmentId === environmentId) this.failures.delete(key);
     }
 
     for (const entry of [...this.inflight.values()]) {
@@ -291,6 +324,7 @@ export class EnvironmentVariableCache {
         throw invalidatedError();
       }
 
+      this.failures.delete(entry.key);
       this.cache.delete(entry.key);
       this.cache.set(entry.key, {
         vars,
@@ -299,6 +333,22 @@ export class EnvironmentVariableCache {
       });
       this.evictIfNeeded();
       return vars;
+    } catch (error) {
+      // Record only failures from the current epoch: invalidated work must not
+      // poison the newer epoch with its cancellation error.
+      if (
+        this.failureTtlMs > 0 &&
+        this.isCurrentEpoch(scope.environmentId, entry.epoch)
+      ) {
+        this.failures.delete(entry.key);
+        this.failures.set(entry.key, {
+          error,
+          failedAt: Date.now(),
+          environmentId: scope.environmentId,
+        });
+        this.evictFailuresIfNeeded();
+      }
+      throw error;
     } finally {
       clearTimeout(timeoutId);
       removeAbortListener();
@@ -351,6 +401,18 @@ export class EnvironmentVariableCache {
   private invalidateInflight(entry: InflightEntry): void {
     this.removeInflight(entry);
     entry.controller.abort(invalidatedError());
+  }
+
+  /** Evict oldest recorded failures when they exceed maxEntries. */
+  private evictFailuresIfNeeded(): void {
+    if (this.failures.size <= this.maxEntries) return;
+    const excess = this.failures.size - this.maxEntries;
+    let removed = 0;
+    for (const key of this.failures.keys()) {
+      if (removed >= excess) break;
+      this.failures.delete(key);
+      removed++;
+    }
   }
 
   /** Evict oldest entries when cache exceeds maxEntries. */

--- a/src/server/project-env/fetcher.test.ts
+++ b/src/server/project-env/fetcher.test.ts
@@ -516,7 +516,7 @@ describe("project-env/fetcher", () => {
     }
   });
 
-  it("rejects masked values returned by the internal endpoint", async () => {
+  it("rejects masked values returned by the internal endpoint and names the offending key", async () => {
     const { server, port } = createMockServer((req: Request) => {
       if (new URL(req.url).pathname === "/projects/my-project/environment-variables") {
         return Response.json({ data: [] });
@@ -525,24 +525,40 @@ describe("project-env/fetcher", () => {
     });
 
     try {
-      await assertRejects(() =>
+      const error = await assertRejects(() =>
         fetchFromMockApi(port, {
           username: "runtime-user",
           password: "runtime-pass",
         })
       );
+      assertEquals((error as { slug?: string }).slug, "network-error");
+      assertEquals((error as Error).message.includes("masked"), true);
+      // Key names are not secret; the offending key makes the refusal diagnosable.
+      assertEquals((error as Error).message.includes("API_KEY"), true);
     } finally {
       await server.shutdown();
     }
   });
 
-  it("rejects masked values returned by the management endpoint", async () => {
+  it("explains the missing internal credentials when the management endpoint returns masked values", async () => {
     const { server, port } = createMockServer(() => {
       return Response.json({ data: [{ key: "API_KEY", value: "********" }] });
     });
 
     try {
-      await assertRejects(() => fetchFromMockApi(port));
+      // No internal credentials configured: the fetcher parsed the management
+      // response, which masks every value by contract. The refusal must state
+      // the operator-actionable cause, not a generic masked-response error.
+      const error = await assertRejects(() => fetchFromMockApi(port));
+      assertEquals((error as { slug?: string }).slug, "network-error");
+      assertEquals(
+        (error as Error).message.includes("VERYFRONT_API_INTERNAL_USER"),
+        true,
+      );
+      assertEquals(
+        (error as Error).message.includes("VERYFRONT_API_INTERNAL_PASS"),
+        true,
+      );
     } finally {
       await server.shutdown();
     }

--- a/src/server/project-env/fetcher.test.ts
+++ b/src/server/project-env/fetcher.test.ts
@@ -516,12 +516,13 @@ describe("project-env/fetcher", () => {
     }
   });
 
-  it("rejects masked values returned by the internal endpoint and names the offending key", async () => {
+  it("rejects masked values without exposing the tenant-defined key", async () => {
+    const tenantDefinedKey = "TENANT_PRIVATE_INVENTORY_KEY";
     const { server, port } = createMockServer((req: Request) => {
       if (new URL(req.url).pathname === "/projects/my-project/environment-variables") {
         return Response.json({ data: [] });
       }
-      return Response.json({ data: [{ key: "API_KEY", value: "********" }] });
+      return Response.json({ data: [{ key: tenantDefinedKey, value: "********" }] });
     });
 
     try {
@@ -532,9 +533,11 @@ describe("project-env/fetcher", () => {
         })
       );
       assertEquals((error as { slug?: string }).slug, "network-error");
-      assertEquals((error as Error).message.includes("masked"), true);
-      // Key names are not secret; the offending key makes the refusal diagnosable.
-      assertEquals((error as Error).message.includes("API_KEY"), true);
+      assertEquals(
+        (error as Error).message,
+        "Refusing masked environment variable response: the internal endpoint returned a masked value",
+      );
+      assertEquals((error as Error).message.includes(tenantDefinedKey), false);
     } finally {
       await server.shutdown();
     }

--- a/src/server/project-env/fetcher.ts
+++ b/src/server/project-env/fetcher.ts
@@ -70,7 +70,29 @@ async function readBoundedEnvironmentResponse(
   return text;
 }
 
-function parseEnvironmentResponse(text: string): Readonly<Record<string, string>> {
+/** Which endpoint produced the parsed body; masked values mean different things per source. */
+type EnvironmentResponseSource = "management" | "internal";
+
+function maskedEnvironmentError(source: EnvironmentResponseSource, key: string): Error {
+  if (source === "management") {
+    // The management endpoint masks every value by contract. Reaching a masked
+    // value here means the host has no internal credentials configured, so the
+    // refusal must state the operator-actionable cause.
+    return invalidEnvironmentResponse(
+      "Refusing masked environment variable response: the management endpoint masks values by contract " +
+        "and VERYFRONT_API_INTERNAL_USER/VERYFRONT_API_INTERNAL_PASS are not configured on this host",
+    );
+  }
+  // Key names are not secret; values are never logged.
+  return invalidEnvironmentResponse(
+    `Refusing masked environment variable response: the internal endpoint returned a masked value for "${key}"`,
+  );
+}
+
+function parseEnvironmentResponse(
+  text: string,
+  source: EnvironmentResponseSource,
+): Readonly<Record<string, string>> {
   let body: unknown;
   try {
     body = JSON.parse(text);
@@ -107,7 +129,7 @@ function parseEnvironmentResponse(text: string): Readonly<Record<string, string>
     }
     keys.add(key);
     if (value === MASKED_ENV_VALUE) {
-      throw invalidEnvironmentResponse("Refusing masked environment variable response");
+      throw maskedEnvironmentError(source, key);
     }
     result[key] = value;
   }
@@ -252,6 +274,7 @@ export async function fetchProjectEnvVars(
   try {
     const result = parseEnvironmentResponse(
       await readBoundedEnvironmentResponse(response, signal),
+      internalAuthorization ? "internal" : "management",
     );
 
     logger.debug("Fetched env vars", {

--- a/src/server/project-env/fetcher.ts
+++ b/src/server/project-env/fetcher.ts
@@ -78,7 +78,7 @@ async function readBoundedEnvironmentResponse(
 /** Which endpoint produced the parsed body; masked values mean different things per source. */
 type EnvironmentResponseSource = "management" | "internal";
 
-function maskedEnvironmentError(source: EnvironmentResponseSource, key: string): Error {
+function maskedEnvironmentError(source: EnvironmentResponseSource): Error {
   if (source === "management") {
     // The management endpoint masks every value by contract. Reaching a masked
     // value here means the host has no internal credentials configured, so the
@@ -88,9 +88,8 @@ function maskedEnvironmentError(source: EnvironmentResponseSource, key: string):
         "and VERYFRONT_API_INTERNAL_USER/VERYFRONT_API_INTERNAL_PASS are not configured on this host",
     );
   }
-  // Key names are not secret; values are never logged.
   return invalidEnvironmentResponse(
-    `Refusing masked environment variable response: the internal endpoint returned a masked value for "${key}"`,
+    "Refusing masked environment variable response: the internal endpoint returned a masked value",
   );
 }
 
@@ -134,7 +133,7 @@ function parseEnvironmentResponse(
     }
     keys.add(key);
     if (value === MASKED_ENV_VALUE) {
-      throw maskedEnvironmentError(source, key);
+      throw maskedEnvironmentError(source);
     }
     result[key] = value;
   }

--- a/src/server/project-env/index.ts
+++ b/src/server/project-env/index.ts
@@ -14,6 +14,7 @@ export {
   EnvironmentVariableCache,
   type EnvironmentVariableCacheOptions,
   type ProjectEnvironmentScope,
+  unwrapReplayedProjectEnvironmentFailure,
 } from "./cache.ts";
 export { filterRuntimeProjectEnv, filterSharedRuntimeProjectEnv } from "./reserved-env.ts";
 export { fetchProjectEnvVars } from "./fetcher.ts";


### PR DESCRIPTION
Fixes [VERYFRONT-SERVER-T](https://veryfront.sentry.io/issues/VERYFRONT-SERVER-T) (223 events / 9 users, escalating until remediated).

## Root cause
The incident itself was a deploy misconfiguration (veryfront-server #316 removed `rendererSecrets.VERYFRONT_API_INTERNAL_USER/PASS`; #318 restored them). But the framework made it needlessly undiagnosable and noisy:
- With no internal credentials, `fetchProjectEnvVars` parsed the management endpoint's **always-masked** authorization-probe response as data and threw the generic "Refusing masked environment variable response" (a 502 NETWORK_ERROR) — the actionable truth ("internal API credentials missing") was never said.
- `EnvironmentVariableCache` caches successes only, so every request re-fetched and re-threw: two upstream calls + one Sentry event per request for ~17 hours.

## Fix
- `parseEnvironmentResponse` now knows its response source (`management` | `internal`): a masked value from the management hop produces an explicit "internal credentials not configured" detail; a masked value from the internal hop keeps the refusal without copying tenant-defined key names into errors or logs.
- `EnvironmentVariableCache` gains short-TTL negative caching (`failureTtlMs`, default 5s): one upstream fetch per TTL window during failure storms, preserving the deliberate fail-closed semantics (never serve stale/empty env).
- `AgentStreamHandler` marks negative-cache replays and returns the same failure response while logging and reporting only the first failure in each TTL window.

## Testing (red-green TDD)
Extended `fetcher.test.ts` masked-value tests with message/source assertions and added a cache test proving a failed fetch is not re-issued within the TTL — all fail on pre-fix src (verified by adversarial revert-check), pass at HEAD.
A handler regression proves concurrent and cached identical 502 responses produce one upstream fetch, one error log, and one application-error report.

## Reviewer notes (from adversarial verification)
- Negative caching applies to **all** failure types at both production call sites, so a one-off transient error also blocks retries for up to 5s per scope — deliberate, documented in the option docstring.