### PR TITLE
fix(bundler): restart the esbuild service after an unexpected child death instead of poisoning the process

### DIFF
--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -932,6 +932,48 @@ describe("EsbuildBundler service crash recovery", () => {
     }
   });
 
+  it("treats an operation launched after service exit but before close as recoverable", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+    const exitTransform = Promise.withResolvers<
+      Awaited<ReturnType<EsbuildBundler["transform"]>>
+    >();
+
+    try {
+      await bundler.transform({ code: "export const managed = true;", loader: "ts" });
+      assertEquals(services.length, 1);
+
+      const managedService = services[0]!;
+      managedService.child.once("exit", () => {
+        void bundler.transform({
+          code: "export const duringExit: number = 1;",
+          loader: "ts",
+        }).then(exitTransform.resolve, exitTransform.reject);
+      });
+      managedService.child.ref();
+      managedService.child.kill("SIGKILL");
+
+      const exitResult = await exitTransform.promise;
+      assertStringIncludes(exitResult.code, "duringExit = 1");
+      await managedService.close;
+
+      const later = await bundler.transform({
+        code: "export const later: number = 2;",
+        loader: "ts",
+      });
+      assertStringIncludes(later.code, "later = 2");
+    } finally {
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
   it("does not let stop complete before an operation waiting for recovery", async () => {
     const observation = observeEsbuildServices();
     const { services } = observation;
@@ -1064,6 +1106,65 @@ describe("EsbuildBundler service crash recovery", () => {
     }
   });
 
+  it("disposes stale plugin resources before recreating a crashed context", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+    let ctx: BuildContext | undefined;
+    let activeResources = 0;
+    let setupCount = 0;
+    let disposeCount = 0;
+
+    try {
+      ctx = await bundler.context({
+        stdin: {
+          contents: "export const pluginContext: number = 1;",
+          sourcefile: "entry.ts",
+          loader: "ts",
+        },
+        bundle: false,
+        format: "esm",
+        write: false,
+        plugins: [{
+          name: "exclusive-plugin-resource",
+          setup(build) {
+            setupCount += 1;
+            activeResources += 1;
+            build.onDispose(() => {
+              activeResources -= 1;
+              disposeCount += 1;
+            });
+          },
+        }],
+      });
+      await ctx.rebuild();
+      assertEquals(activeResources, 1);
+      assertEquals(setupCount, 1);
+      assertEquals(disposeCount, 0);
+
+      const managedService = services[0]!;
+      managedService.child.ref();
+      managedService.child.kill("SIGKILL");
+      await managedService.close;
+
+      await bundler.transform({ code: "export const recovered = true;", loader: "ts" });
+      await ctx.rebuild();
+
+      assertEquals(setupCount, 2);
+      assertEquals(disposeCount, 1);
+      assertEquals(activeResources, 1);
+    } finally {
+      await ctx?.dispose().catch(() => undefined);
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
   it("latches the ownership error once the restart budget is exhausted", async () => {
     const observation = observeEsbuildServices();
     const { services } = observation;
@@ -1100,6 +1201,50 @@ describe("EsbuildBundler service crash recovery", () => {
       // The latch is sticky: later operations keep rejecting without respawns.
       await assertRejects(() =>
         bundler.transform({ code: "export const still = true;", loader: "ts" })
+      );
+      assertEquals(services.length, MAX_SERVICE_RESTARTS + 1);
+    } finally {
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
+  it("latches exhaustion when stop observes a closed lost service", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+
+    try {
+      await bundler.transform({ code: "export const seed: number = 0;", loader: "ts" });
+
+      for (let restart = 1; restart <= MAX_SERVICE_RESTARTS; restart++) {
+        const current = services[services.length - 1]!;
+        current.child.ref();
+        current.child.kill("SIGKILL");
+        await current.close;
+
+        await bundler.transform({
+          code: `export const retry${restart}: number = ${restart};`,
+          loader: "ts",
+        });
+      }
+
+      const exhausted = services[services.length - 1]!;
+      exhausted.child.ref();
+      exhausted.child.kill("SIGKILL");
+      await exhausted.close;
+
+      const stopError = await assertRejects(() => bundler.stop());
+      assertStringIncludes((stopError as Error).message, "module-wide adapter");
+      assertStringIncludes((stopError as Error).message, "exited unexpectedly");
+
+      await assertRejects(() =>
+        bundler.transform({ code: "export const afterStop = true;", loader: "ts" })
       );
       assertEquals(services.length, MAX_SERVICE_RESTARTS + 1);
     } finally {

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -104,7 +104,10 @@ describe("esbuild service lifecycle", () => {
         killed: false,
         exitCode: undefined,
         signalCode: undefined,
-      } as Pick<ReturnType<typeof childProcess.spawn>, "killed" | "exitCode" | "signalCode">),
+      } as unknown as Pick<
+        ReturnType<typeof childProcess.spawn>,
+        "killed" | "exitCode" | "signalCode"
+      >),
       true,
     );
   });
@@ -983,7 +986,7 @@ describe("EsbuildBundler unsupported lifecycle ownership", () => {
     __resetServiceRecoveryForTests();
   });
 
-  it("recovers after a raw service generation replaces the managed one", async () => {
+  it("rejects recovery when a raw service replaces a killed managed service", async () => {
     const observation = observeEsbuildServices();
     const { services } = observation;
     const rawEsbuild = await import("esbuild");
@@ -991,20 +994,65 @@ describe("EsbuildBundler unsupported lifecycle ownership", () => {
 
     try {
       await bundler.transform({ code: "export const managed = true;", loader: "ts" });
+      assertEquals(services.length, 1);
+
+      const managedService = services[0]!;
+      managedService.child.ref();
+      managedService.child.kill("SIGKILL");
+      await managedService.close;
+
+      await rawEsbuild.stop();
+      await rawEsbuild.transform("export const foreign = true;");
+      assertEquals(services.length, 2);
+      const foreignService = services[1]!;
+
+      const error = await assertRejects(() =>
+        bundler.transform({ code: "export const takeover = true;", loader: "ts" })
+      );
+      assertStringIncludes((error as Error).message, "module-wide adapter");
+
+      assertEquals(foreignService.closed, false);
+    } finally {
+      __resetServiceRecoveryForTests();
+      await bundler.stop().catch(() => undefined);
+      for (const service of services) service.child.ref();
+      try {
+        await rawEsbuild.stop();
+        await Promise.all(services.map((service) => service.close));
+      } finally {
+        for (const service of services) service.child.unref();
+        observation.restore();
+      }
+    }
+  });
+
+  it("rejects shutdown when a raw service replaces a killed managed service", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const rawEsbuild = await import("esbuild");
+    const bundler = new EsbuildBundler();
+
+    try {
+      await bundler.transform({ code: "export const managed = true;", loader: "ts" });
+      const managedService = services[0]!;
+      managedService.child.ref();
+      managedService.child.kill("SIGKILL");
+      await managedService.close;
+
       await rawEsbuild.stop();
       await rawEsbuild.transform("export const external = true;");
+      const foreignService = services[services.length - 1]!;
 
-      // The raw stop() killed the managed child, which is the recoverable
-      // crash case: shutdown stays clean instead of rejecting...
-      await bundler.stop();
+      const error = await assertRejects(() => bundler.stop());
+      assertStringIncludes((error as Error).message, "module-wide adapter");
+      assertEquals(foreignService.closed, false);
 
-      // ...and the next operation regains ownership with a fresh service.
-      const result = await bundler.transform({
-        code: "export const recovered: number = 1;",
-        loader: "ts",
-      });
-      assertStringIncludes(result.code, "recovered = 1");
-      assertEquals(services.length >= 3, true);
+      await assertRejects(() =>
+        bundler.transform({
+          code: "export const stillForeign = true;",
+          loader: "ts",
+        })
+      );
     } finally {
       await bundler.stop().catch(() => undefined);
       for (const service of services) service.child.ref();

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -6,14 +6,16 @@
  */
 
 import { assertEquals, assertExists, assertRejects, assertStringIncludes } from "@std/assert";
-import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { createRequire } from "node:module";
 
 import {
   __recordOwnershipErrorForTests,
   __resetOwnershipErrorForTests,
+  __resetServiceRecoveryForTests,
   EsbuildBundler,
   isLiveEsbuildServiceProcess,
+  MAX_SERVICE_RESTARTS,
 } from "./esbuild-bundler.ts";
 import { rebuildContextWithSignal } from "./context-build-lifecycle.ts";
 
@@ -884,37 +886,160 @@ describe("ownership error cause", () => {
   });
 });
 
+describe("EsbuildBundler service crash recovery", () => {
+  beforeEach(() => {
+    __resetServiceRecoveryForTests();
+  });
+
+  it("recovers with a fresh service after the managed service is killed externally", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+
+    try {
+      const first = await bundler.transform({
+        code: "export const before: number = 1;",
+        loader: "ts",
+      });
+      assertStringIncludes(first.code, "before = 1");
+      assertEquals(services.length, 1);
+
+      // The container runtime kills the service child (OOM/SIGKILL); the
+      // adapter never receives an error from esbuild first. The child is
+      // unref'd, so ref it to keep the loop alive for the close event.
+      services[0]!.child.ref();
+      services[0]!.child.kill("SIGKILL");
+      await services[0]!.close;
+
+      const second = await bundler.transform({
+        code: "export const after: number = 2;",
+        loader: "ts",
+      });
+      assertStringIncludes(second.code, "after = 2");
+      assertEquals(services.length, 2);
+    } finally {
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
+  it("latches the ownership error once the restart budget is exhausted", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+
+    try {
+      await bundler.transform({ code: "export const seed: number = 0;", loader: "ts" });
+
+      for (let restart = 1; restart <= MAX_SERVICE_RESTARTS; restart++) {
+        const current = services[services.length - 1]!;
+        current.child.ref();
+        current.child.kill("SIGKILL");
+        await current.close;
+
+        const result = await bundler.transform({
+          code: `export const retry${restart}: number = ${restart};`,
+          loader: "ts",
+        });
+        assertStringIncludes(result.code, `retry${restart} = ${restart}`);
+      }
+      assertEquals(services.length, MAX_SERVICE_RESTARTS + 1);
+
+      const last = services[services.length - 1]!;
+      last.child.ref();
+      last.child.kill("SIGKILL");
+      await last.close;
+
+      const error = await assertRejects(() =>
+        bundler.transform({ code: "export const exhausted = true;", loader: "ts" })
+      );
+      assertStringIncludes((error as Error).message, "module-wide adapter");
+      assertStringIncludes((error as Error).message, "exited unexpectedly");
+
+      // The latch is sticky: later operations keep rejecting without respawns.
+      await assertRejects(() =>
+        bundler.transform({ code: "export const still = true;", loader: "ts" })
+      );
+      assertEquals(services.length, MAX_SERVICE_RESTARTS + 1);
+    } finally {
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+});
+
 describe("EsbuildBundler unsupported lifecycle ownership", () => {
-  it("rejects shutdown after a raw service generation replaces the managed one", async () => {
+  beforeEach(() => {
+    __resetServiceRecoveryForTests();
+  });
+
+  it("recovers after a raw service generation replaces the managed one", async () => {
     const observation = observeEsbuildServices();
     const { services } = observation;
     const rawEsbuild = await import("esbuild");
     const bundler = new EsbuildBundler();
-    let ownershipError: unknown;
-    let stopError: unknown;
 
     try {
       await bundler.transform({ code: "export const managed = true;", loader: "ts" });
       await rawEsbuild.stop();
       await rawEsbuild.transform("export const external = true;");
 
+      // The raw stop() killed the managed child, which is the recoverable
+      // crash case: shutdown stays clean instead of rejecting...
+      await bundler.stop();
+
+      // ...and the next operation regains ownership with a fresh service.
+      const result = await bundler.transform({
+        code: "export const recovered: number = 1;",
+        loader: "ts",
+      });
+      assertStringIncludes(result.code, "recovered = 1");
+      assertEquals(services.length >= 3, true);
+    } finally {
+      await bundler.stop().catch(() => undefined);
+      for (const service of services) service.child.ref();
       try {
-        await bundler.stop();
-      } catch (error) {
-        stopError = error;
+        await rawEsbuild.stop();
+        await Promise.all(services.map((service) => service.close));
+      } finally {
+        for (const service of services) service.child.unref();
+        observation.restore();
       }
-      assertEquals(stopError instanceof Error, true);
-      assertStringIncludes((stopError as Error).message, "Cannot verify closure");
+    }
+  });
+
+  it("still rejects operations that reuse a service started before the adapter", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const rawEsbuild = await import("esbuild");
+    const bundler = new EsbuildBundler();
+    let ownershipError: unknown;
+
+    try {
+      // A foreign service the adapter never captured: it was started while
+      // the spawn interceptor was not installed, so it can never be owned.
+      await rawEsbuild.transform("export const external = true;");
 
       try {
-        await bundler.transform({ code: "export const rejected = true;", loader: "ts" });
+        await bundler.transform({ code: "export const mine = true;", loader: "ts" });
       } catch (error) {
         ownershipError = error;
       }
       assertEquals(ownershipError instanceof Error, true);
       assertStringIncludes((ownershipError as Error).message, "module-wide adapter");
-      assertEquals(services.length >= 2, true);
     } finally {
+      __resetServiceRecoveryForTests();
+      await bundler.stop().catch(() => undefined);
       for (const service of services) service.child.ref();
       try {
         await rawEsbuild.stop();

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -1011,6 +1011,8 @@ describe("EsbuildBundler unsupported lifecycle ownership", () => {
       );
       assertStringIncludes((error as Error).message, "module-wide adapter");
 
+      const stopError = await assertRejects(() => bundler.stop());
+      assertStringIncludes((stopError as Error).message, "module-wide adapter");
       assertEquals(foreignService.closed, false);
     } finally {
       __resetServiceRecoveryForTests();

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -1,5 +1,5 @@
 /**
- * EsbuildBundler smoke tests — verifies the adapter correctly invokes
+ * EsbuildBundler smoke tests verify the adapter correctly invokes
  * esbuild and maps its results into the Bundler contract shape.
  *
  * @module extensions/ext-bundler-esbuild/esbuild-bundler.test
@@ -1209,6 +1209,170 @@ describe("EsbuildBundler service crash recovery", () => {
       assertEquals(disposeCount, 1);
       assertEquals(activeResources, 0);
     } finally {
+      await ctx?.dispose().catch(() => undefined);
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
+  it("does not surface stale plugin disposal errors while cleaning up a later crashed context", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+    let crashingContext: BuildContext | undefined;
+    let disposeCount = 0;
+    const releaseFailedDisposal = Promise.withResolvers<void>();
+    const staleDisposalRecorded = Promise.withResolvers<void>();
+
+    try {
+      await bundler.bundle({
+        stdin: { contents: "export const failingDispose = true;", loader: "ts" },
+        bundle: true,
+        format: "esm",
+        write: false,
+        plugins: [{
+          name: "failing-dispose-resource",
+          setup(build) {
+            build.onDispose(async () => {
+              await releaseFailedDisposal.promise;
+              try {
+                throw new Error("first disposal failed");
+              } finally {
+                staleDisposalRecorded.resolve();
+              }
+            });
+          },
+        }],
+      });
+      releaseFailedDisposal.resolve();
+      await staleDisposalRecorded.promise;
+      await Promise.resolve();
+
+      crashingContext = await bundler.context({
+        stdin: {
+          contents: "export const laterCrashedContext: number = 1;",
+          sourcefile: "later.ts",
+          loader: "ts",
+        },
+        bundle: false,
+        format: "esm",
+        write: false,
+        plugins: [{
+          name: "later-dispose-resource",
+          setup(build) {
+            build.onDispose(() => {
+              disposeCount += 1;
+            });
+          },
+        }],
+      });
+      await crashingContext.rebuild();
+
+      const managedService = services[services.length - 1]!;
+      managedService.child.ref();
+      managedService.child.kill("SIGKILL");
+      await managedService.close;
+
+      await crashingContext.dispose();
+      crashingContext = undefined;
+
+      assertEquals(disposeCount, 1);
+    } finally {
+      releaseFailedDisposal.resolve();
+      await crashingContext?.dispose().catch(() => undefined);
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
+  it("waits for plugin cleanup after a context refresh fails and a later retry succeeds", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+    let ctx: BuildContext | undefined;
+    let setupCount = 0;
+    let disposeCount = 0;
+    let rejectNextSetup = false;
+    const retryDisposalStarted = Promise.withResolvers<void>();
+    let finishRetryDisposal: (() => void) | undefined;
+
+    try {
+      ctx = await bundler.context({
+        stdin: {
+          contents: "export const retryContext: number = 1;",
+          sourcefile: "retry.ts",
+          loader: "ts",
+        },
+        bundle: false,
+        format: "esm",
+        write: false,
+        plugins: [{
+          name: "refresh-retry-dispose-resource",
+          setup(build) {
+            setupCount += 1;
+            const generation = setupCount;
+            if (rejectNextSetup) {
+              rejectNextSetup = false;
+              throw new Error("refresh setup failed");
+            }
+            build.onDispose(() => {
+              if (generation !== 3) {
+                disposeCount += 1;
+                return;
+              }
+              retryDisposalStarted.resolve();
+              return new Promise<void>((resolve) => {
+                finishRetryDisposal = () => {
+                  disposeCount += 1;
+                  resolve();
+                };
+              });
+            });
+          },
+        }],
+      });
+      await ctx.rebuild();
+      assertEquals(setupCount, 1);
+
+      const firstService = services[0]!;
+      firstService.child.ref();
+      firstService.child.kill("SIGKILL");
+      await firstService.close;
+      await bundler.transform({ code: "export const afterFirstCrash = true;", loader: "ts" });
+
+      rejectNextSetup = true;
+      await assertRejects(() => ctx!.rebuild(), Error, "refresh setup failed");
+      assertEquals(disposeCount, 1);
+
+      const secondService = services[services.length - 1]!;
+      secondService.child.ref();
+      secondService.child.kill("SIGKILL");
+      await secondService.close;
+      await bundler.transform({ code: "export const afterSecondCrash = true;", loader: "ts" });
+
+      const rebuilt = await ctx.rebuild();
+      assertStringIncludes(rebuilt.outputFiles[0]!.text, "retryContext = 1");
+      assertEquals(setupCount, 3);
+
+      const disposing = ctx.dispose();
+      ctx = undefined;
+      await retryDisposalStarted.promise;
+      assertEquals(disposeCount, 1);
+      finishRetryDisposal?.();
+      await disposing;
+      assertEquals(disposeCount, 2);
+    } finally {
+      finishRetryDisposal?.();
       await ctx?.dispose().catch(() => undefined);
       await bundler.stop().catch(() => undefined);
       __resetServiceRecoveryForTests();

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -8,6 +8,7 @@
 import { assertEquals, assertExists, assertRejects, assertStringIncludes } from "@std/assert";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { createRequire } from "node:module";
+import type { BuildContext } from "veryfront/extensions/bundler";
 
 import {
   __recordOwnershipErrorForTests,
@@ -921,6 +922,138 @@ describe("EsbuildBundler service crash recovery", () => {
       assertStringIncludes(second.code, "after = 2");
       assertEquals(services.length, 2);
     } finally {
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
+  it("does not let stop complete before an operation waiting for recovery", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const loadStarted = Promise.withResolvers<void>();
+    const releaseLoad = Promise.withResolvers<void>();
+    const bundler = new EsbuildBundler();
+    let bundling: Promise<Awaited<ReturnType<EsbuildBundler["bundle"]>>> | undefined;
+    let recovering: Promise<Awaited<ReturnType<EsbuildBundler["transform"]>>> | undefined;
+    let stopping: Promise<void> | undefined;
+    const keepAlive = setInterval(() => {}, 1_000);
+
+    try {
+      await bundler.transform({ code: "export const managed = true;", loader: "ts" });
+      assertEquals(services.length, 1);
+
+      bundling = bundler.bundle({
+        entryPoints: ["hold:entry"],
+        bundle: true,
+        format: "esm",
+        write: false,
+        plugins: [{
+          name: "hold-recovery",
+          setup(build) {
+            build.onResolve({ filter: /^hold:/ }, () => ({
+              path: "entry",
+              namespace: "hold",
+            }));
+            build.onLoad({ filter: /.*/, namespace: "hold" }, async () => {
+              loadStarted.resolve();
+              await releaseLoad.promise;
+              return { contents: "export const held = true;", loader: "ts" };
+            });
+          },
+        }],
+      });
+      void bundling.catch(() => undefined);
+      await loadStarted.promise;
+
+      const managedService = services[0]!;
+      managedService.child.ref();
+      managedService.child.kill("SIGKILL");
+      await managedService.close;
+
+      recovering = bundler.transform({
+        code: "export const recovered: number = 1;",
+        loader: "ts",
+      });
+
+      let stopSettled = false;
+      stopping = bundler.stop();
+      void stopping.then(
+        () => {
+          stopSettled = true;
+        },
+        () => {
+          stopSettled = true;
+        },
+      );
+      await Promise.resolve();
+      assertEquals(stopSettled, false);
+
+      releaseLoad.resolve();
+      await bundling.catch(() => undefined);
+      const result = await recovering;
+      assertStringIncludes(result.code, "recovered = 1");
+      await stopping;
+
+      assertEquals(services.length, 2);
+      assertEquals(services[1]!.closed, true);
+    } finally {
+      clearInterval(keepAlive);
+      releaseLoad.resolve();
+      await bundling?.catch(() => undefined);
+      await recovering?.catch(() => undefined);
+      await stopping?.catch(() => undefined);
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
+  it("recreates a captured build context after managed service crash recovery", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+    let ctx: BuildContext | undefined;
+
+    try {
+      ctx = await bundler.context({
+        stdin: {
+          contents: "export const fromContext: number = 1;",
+          sourcefile: "entry.ts",
+          loader: "ts",
+        },
+        bundle: false,
+        format: "esm",
+        write: false,
+      });
+      const first = await ctx.rebuild();
+      assertStringIncludes(first.outputFiles[0]!.text, "fromContext = 1");
+      assertEquals(services.length, 1);
+
+      const managedService = services[0]!;
+      managedService.child.ref();
+      managedService.child.kill("SIGKILL");
+      await managedService.close;
+
+      const recovered = await bundler.transform({
+        code: "export const recovered: number = 2;",
+        loader: "ts",
+      });
+      assertStringIncludes(recovered.code, "recovered = 2");
+
+      const rebuilt = await ctx.rebuild();
+      assertStringIncludes(rebuilt.outputFiles[0]!.text, "fromContext = 1");
+      assertEquals(services.length, 2);
+    } finally {
+      await ctx?.dispose().catch(() => undefined);
       await bundler.stop().catch(() => undefined);
       __resetServiceRecoveryForTests();
       try {

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -1220,56 +1220,6 @@ describe("EsbuildBundler service crash recovery", () => {
     }
   });
 
-  it("disposes plugin resources when the service crashes during initial context setup", async () => {
-    const observation = observeEsbuildServices();
-    const { services } = observation;
-    const bundler = new EsbuildBundler();
-    let activeResources = 0;
-    let disposeCount = 0;
-
-    try {
-      const error = await assertRejects(() =>
-        bundler.context({
-          entryPoints: ["crash:entry"],
-          bundle: true,
-          format: "esm",
-          write: false,
-          plugins: [{
-            name: "in-flight-crash-plugin-resource",
-            setup(build) {
-              activeResources += 1;
-              build.onDispose(() => {
-                activeResources -= 1;
-                disposeCount += 1;
-              });
-              const managedService = services[0]!;
-              managedService.child.ref();
-              managedService.child.kill("SIGKILL");
-            },
-          }],
-        })
-      );
-      assertStringIncludes((error as Error).message, "The service");
-      await services[0]!.close;
-      assertEquals(disposeCount, 1);
-      assertEquals(activeResources, 0);
-
-      const recovered = await bundler.transform({
-        code: "export const recoveredAfterBundleCrash: number = 1;",
-        loader: "ts",
-      });
-      assertStringIncludes(recovered.code, "recoveredAfterBundleCrash = 1");
-    } finally {
-      await bundler.stop().catch(() => undefined);
-      __resetServiceRecoveryForTests();
-      try {
-        await bundler.stop();
-      } finally {
-        observation.restore();
-      }
-    }
-  });
-
   it("latches the ownership error once the restart budget is exhausted", async () => {
     const observation = observeEsbuildServices();
     const { services } = observation;

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -1165,6 +1165,111 @@ describe("EsbuildBundler service crash recovery", () => {
     }
   });
 
+  it("disposes stale plugin resources when disposing a crashed context without rebuilding", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+    let ctx: BuildContext | undefined;
+    let activeResources = 0;
+    let disposeCount = 0;
+
+    try {
+      ctx = await bundler.context({
+        stdin: {
+          contents: "export const disposeOnlyContext: number = 1;",
+          sourcefile: "entry.ts",
+          loader: "ts",
+        },
+        bundle: false,
+        format: "esm",
+        write: false,
+        plugins: [{
+          name: "dispose-only-plugin-resource",
+          setup(build) {
+            activeResources += 1;
+            build.onDispose(() => {
+              activeResources -= 1;
+              disposeCount += 1;
+            });
+          },
+        }],
+      });
+      await ctx.rebuild();
+      assertEquals(activeResources, 1);
+      assertEquals(disposeCount, 0);
+
+      const managedService = services[0]!;
+      managedService.child.ref();
+      managedService.child.kill("SIGKILL");
+      await managedService.close;
+
+      await ctx.dispose();
+      ctx = undefined;
+
+      assertEquals(disposeCount, 1);
+      assertEquals(activeResources, 0);
+    } finally {
+      await ctx?.dispose().catch(() => undefined);
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
+  it("disposes plugin resources when the service crashes during initial context setup", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+    let activeResources = 0;
+    let disposeCount = 0;
+
+    try {
+      const error = await assertRejects(() =>
+        bundler.context({
+          entryPoints: ["crash:entry"],
+          bundle: true,
+          format: "esm",
+          write: false,
+          plugins: [{
+            name: "in-flight-crash-plugin-resource",
+            setup(build) {
+              activeResources += 1;
+              build.onDispose(() => {
+                activeResources -= 1;
+                disposeCount += 1;
+              });
+              const managedService = services[0]!;
+              managedService.child.ref();
+              managedService.child.kill("SIGKILL");
+            },
+          }],
+        })
+      );
+      assertStringIncludes((error as Error).message, "The service");
+      await services[0]!.close;
+      assertEquals(disposeCount, 1);
+      assertEquals(activeResources, 0);
+
+      const recovered = await bundler.transform({
+        code: "export const recoveredAfterBundleCrash: number = 1;",
+        loader: "ts",
+      });
+      assertStringIncludes(recovered.code, "recoveredAfterBundleCrash = 1");
+    } finally {
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
   it("latches the ownership error once the restart budget is exhausted", async () => {
     const observation = observeEsbuildServices();
     const { services } = observation;
@@ -1201,6 +1306,52 @@ describe("EsbuildBundler service crash recovery", () => {
       // The latch is sticky: later operations keep rejecting without respawns.
       await assertRejects(() =>
         bundler.transform({ code: "export const still = true;", loader: "ts" })
+      );
+      assertEquals(services.length, MAX_SERVICE_RESTARTS + 1);
+    } finally {
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
+  it("charges losses cleared by stop against the restart budget", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+
+    try {
+      await bundler.transform({ code: "export const seed: number = 0;", loader: "ts" });
+
+      for (let restart = 1; restart <= MAX_SERVICE_RESTARTS; restart++) {
+        const current = services[services.length - 1]!;
+        current.child.ref();
+        current.child.kill("SIGKILL");
+        await current.close;
+
+        await bundler.stop();
+        const recovered = await bundler.transform({
+          code: `export const stopReset${restart}: number = ${restart};`,
+          loader: "ts",
+        });
+        assertStringIncludes(recovered.code, `stopReset${restart} = ${restart}`);
+      }
+
+      const exhausted = services[services.length - 1]!;
+      exhausted.child.ref();
+      exhausted.child.kill("SIGKILL");
+      await exhausted.close;
+
+      const stopError = await assertRejects(() => bundler.stop());
+      assertStringIncludes((stopError as Error).message, "module-wide adapter");
+      assertStringIncludes((stopError as Error).message, "exited unexpectedly");
+
+      await assertRejects(() =>
+        bundler.transform({ code: "export const afterStopBudget = true;", loader: "ts" })
       );
       assertEquals(services.length, MAX_SERVICE_RESTARTS + 1);
     } finally {

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -77,6 +77,7 @@ let serviceLossSpawnGuard: {
   previous: typeof childProcess.spawn;
   foreignService: EsbuildService | null;
 } | null = null;
+let esbuildServiceForeignReplacement: EsbuildService | null = null;
 let activeOperationCount = 0;
 let activeOperationsIdle: Promise<void> = Promise.resolve();
 let resolveActiveOperationsIdle: (() => void) | null = null;
@@ -263,7 +264,8 @@ function recoverLostService(): Promise<void> {
   esbuildServiceRecovery ??= (async () => {
     await activeOperationsIdle;
     if (!esbuildServiceLost) return;
-    const foreignService = serviceLossSpawnGuard?.foreignService;
+    const foreignService = esbuildServiceForeignReplacement ??
+      serviceLossSpawnGuard?.foreignService;
     if (foreignService) {
       const error = recordOwnershipError(
         new Error("esbuild service was replaced outside the module-wide adapter"),
@@ -378,7 +380,9 @@ function installServiceLossSpawnGuard(): void {
   const guard = ((...spawnArgs: unknown[]) => {
     const child = Reflect.apply(previous, childProcess, spawnArgs) as ChildProcess;
     if (isEsbuildServiceSpawn(spawnArgs)) {
-      serviceLossSpawnGuard!.foreignService = observeForeignServiceChild(child);
+      const foreignService = observeForeignServiceChild(child);
+      esbuildServiceForeignReplacement = foreignService;
+      serviceLossSpawnGuard!.foreignService = foreignService;
     }
     return child;
   }) as typeof childProcess.spawn;
@@ -409,6 +413,7 @@ export function __resetServiceRecoveryForTests(): void {
   esbuildOwnershipError = null;
   esbuildServiceLost = false;
   esbuildServiceLostDetail = "";
+  esbuildServiceForeignReplacement = null;
   remainingServiceRestarts = MAX_SERVICE_RESTARTS;
   uninstallServiceLossSpawnGuard();
 }
@@ -655,7 +660,10 @@ export class EsbuildBundler implements Bundler {
     const stopping = (async () => {
       await activeOperationsIdle;
 
-      if (esbuildServiceLost && serviceLossSpawnGuard?.foreignService) {
+      if (
+        esbuildServiceLost &&
+        (esbuildServiceForeignReplacement ?? serviceLossSpawnGuard?.foreignService)
+      ) {
         const error = recordOwnershipError(
           new Error("esbuild service was replaced outside the module-wide adapter"),
         );

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -37,8 +37,8 @@ const ESBUILD_STOP_TIMEOUT_MS = 5_000;
  * Unexpected service-child deaths tolerated before the adapter gives up.
  *
  * The child can be killed by something outside the process (OOM-kill, a
- * container runtime signal). That is recoverable — esbuild respawns the
- * service once its module state is reset — so it must not poison the process
+ * container runtime signal). That is recoverable: esbuild respawns the
+ * service once its module state is reset, so it must not poison the process
  * the way foreign ownership does. The budget keeps a crash-looping binary
  * from respawning forever.
  */
@@ -60,6 +60,7 @@ interface OperationScope {
 interface MappedBundleOptions {
   options: Record<string, unknown>;
   activatePluginDisposals: () => void;
+  disposePluginGeneration: () => Promise<void>;
 }
 
 let esbuildModule: EsbuildModule | null = null;
@@ -191,8 +192,15 @@ function leaveStopBarrier(): void {
 function createPluginDisposalBarrier(scope: OperationScope): {
   wrap: (callback: () => unknown) => () => void;
   activate: () => void;
+  dispose: () => Promise<void>;
 } {
-  const callbacks: Array<{ started: boolean; settled: boolean }> = [];
+  const callbacks: Array<{
+    callback: () => unknown;
+    started: boolean;
+    settled: boolean;
+    settledPromise: Promise<void>;
+    resolveSettled: () => void;
+  }> = [];
   let activated = false;
   let holdingOperation = false;
 
@@ -203,14 +211,15 @@ function createPluginDisposalBarrier(scope: OperationScope): {
     endOperation();
   };
 
-  const settle = (callback: { started: boolean; settled: boolean }): void => {
+  const settle = (callback: { settled: boolean; resolveSettled: () => void }): void => {
     if (callback.settled) return;
     callback.settled = true;
+    callback.resolveSettled();
     releaseIfSettled();
   };
 
   const fail = (
-    callback: { started: boolean; settled: boolean },
+    callback: { settled: boolean; resolveSettled: () => void },
     error: unknown,
   ): void => {
     if (!pluginDisposalError) {
@@ -222,31 +231,50 @@ function createPluginDisposalBarrier(scope: OperationScope): {
     settle(callback);
   };
 
+  const start = (state: {
+    callback: () => unknown;
+    started: boolean;
+    settled: boolean;
+    resolveSettled: () => void;
+  }): void => {
+    if (state.started || state.settled) return;
+    state.started = true;
+    try {
+      const result = state.callback();
+      if (
+        result !== null &&
+        (typeof result === "object" || typeof result === "function") &&
+        typeof (result as PromiseLike<unknown>).then === "function"
+      ) {
+        void Promise.resolve(result).then(
+          () => settle(state),
+          (error) => fail(state, error),
+        );
+      } else {
+        settle(state);
+      }
+    } catch (error) {
+      fail(state, error);
+    }
+  };
+
   return {
     wrap(callback) {
-      const state = { started: false, settled: false };
+      let resolveSettled: () => void = () => {};
+      const settledPromise = new Promise<void>((resolve) => {
+        resolveSettled = resolve;
+      });
+      const state = {
+        callback,
+        started: false,
+        settled: false,
+        settledPromise,
+        resolveSettled,
+      };
       callbacks.push(state);
 
       return () => {
-        if (state.settled) return;
-        state.started = true;
-        try {
-          const result = callback();
-          if (
-            result !== null &&
-            (typeof result === "object" || typeof result === "function") &&
-            typeof (result as PromiseLike<unknown>).then === "function"
-          ) {
-            void Promise.resolve(result).then(
-              () => settle(state),
-              (error) => fail(state, error),
-            );
-          } else {
-            settle(state);
-          }
-        } catch (error) {
-          fail(state, error);
-        }
+        start(state);
       };
     },
     activate() {
@@ -268,6 +296,12 @@ function createPluginDisposalBarrier(scope: OperationScope): {
         }
         releaseIfSettled();
       }, 0);
+    },
+    async dispose() {
+      const pending = callbacks.filter((callback) => !callback.settled);
+      for (const callback of pending) start(callback);
+      await Promise.all(pending.map((callback) => callback.settledPromise));
+      if (pluginDisposalError) throw pluginDisposalError;
     },
   };
 }
@@ -382,15 +416,20 @@ function trackServiceChild(child: ChildProcess): EsbuildService {
     resolveClosed = resolve;
   });
   const service = { child, closed, expectedClose: false };
-  child.once("close", (exitCode, signalCode) => {
+  let lossRecorded = false;
+  const recordUnexpectedLoss = (exitCode: unknown, signalCode: unknown): void => {
     // An unexpected close of a child the adapter owns is a crash, not a
     // lifecycle violation; mark it recoverable instead of latching the
     // permanent ownership error.
-    if (!service.expectedClose) {
-      esbuildServiceLost = true;
-      esbuildServiceLostDetail = `exit code ${exitCode}, signal ${signalCode}`;
-      installServiceLossSpawnGuard();
-    }
+    if (service.expectedClose || lossRecorded) return;
+    lossRecorded = true;
+    esbuildServiceLost = true;
+    esbuildServiceLostDetail = `exit code ${exitCode}, signal ${signalCode}`;
+    installServiceLossSpawnGuard();
+  };
+  child.once("exit", recordUnexpectedLoss);
+  child.once("close", (exitCode, signalCode) => {
+    recordUnexpectedLoss(exitCode, signalCode);
     resolveClosed();
     if (esbuildService === service) esbuildService = null;
   });
@@ -584,6 +623,7 @@ function mapOptions(options: BundleOptions, scope: OperationScope): MappedBundle
   return {
     options: mapped,
     activatePluginDisposals: pluginDisposals.activate,
+    disposePluginGeneration: pluginDisposals.dispose,
   };
 }
 
@@ -661,6 +701,7 @@ export class EsbuildBundler implements Bundler {
         if (contextGeneration === esbuildServiceGeneration) return ctx;
         contextRefresh ??= (async () => {
           if (contextGeneration === esbuildServiceGeneration) return;
+          await mapped.disposePluginGeneration();
           const currentEsbuild = await getEsbuild();
           ctx = await invokeEsbuild(() => currentEsbuild.context(mapped.options)).catch(
             (error: unknown) => {
@@ -724,6 +765,17 @@ export class EsbuildBundler implements Bundler {
       ) {
         const error = recordOwnershipError(
           new Error("esbuild service was replaced outside the module-wide adapter"),
+        );
+        uninstallServiceLossSpawnGuard();
+        throw error;
+      }
+      if (esbuildServiceLost && remainingServiceRestarts <= 0) {
+        const error = recordOwnershipError(
+          new Error(
+            `esbuild service exited unexpectedly ${
+              MAX_SERVICE_RESTARTS + 1
+            } times (last: ${esbuildServiceLostDetail})`,
+          ),
         );
         uninstallServiceLossSpawnGuard();
         throw error;

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -72,6 +72,11 @@ let esbuildServiceLost = false;
 let esbuildServiceLostDetail = "";
 let remainingServiceRestarts = MAX_SERVICE_RESTARTS;
 let esbuildServiceRecovery: Promise<void> | null = null;
+let serviceLossSpawnGuard: {
+  guard: typeof childProcess.spawn;
+  previous: typeof childProcess.spawn;
+  foreignService: EsbuildService | null;
+} | null = null;
 let activeOperationCount = 0;
 let activeOperationsIdle: Promise<void> = Promise.resolve();
 let resolveActiveOperationsIdle: (() => void) | null = null;
@@ -258,6 +263,15 @@ function recoverLostService(): Promise<void> {
   esbuildServiceRecovery ??= (async () => {
     await activeOperationsIdle;
     if (!esbuildServiceLost) return;
+    const foreignService = serviceLossSpawnGuard?.foreignService;
+    if (foreignService) {
+      const error = recordOwnershipError(
+        new Error("esbuild service was replaced outside the module-wide adapter"),
+      );
+      uninstallServiceLossSpawnGuard();
+      throw error;
+    }
+    uninstallServiceLossSpawnGuard();
     if (remainingServiceRestarts <= 0) {
       throw recordOwnershipError(
         new Error(
@@ -324,6 +338,61 @@ function isEsbuildServiceSpawn(spawnArgs: unknown[]): boolean {
     args.includes("--ping");
 }
 
+function trackServiceChild(child: ChildProcess): EsbuildService {
+  let resolveClosed: () => void = () => {};
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const service = { child, closed, expectedClose: false };
+  child.once("close", (exitCode, signalCode) => {
+    // An unexpected close of a child the adapter owns is a crash, not a
+    // lifecycle violation; mark it recoverable instead of latching the
+    // permanent ownership error.
+    if (!service.expectedClose) {
+      esbuildServiceLost = true;
+      esbuildServiceLostDetail = `exit code ${exitCode}, signal ${signalCode}`;
+      installServiceLossSpawnGuard();
+    }
+    resolveClosed();
+    if (esbuildService === service) esbuildService = null;
+  });
+  return service;
+}
+
+function observeForeignServiceChild(child: ChildProcess): EsbuildService {
+  let resolveClosed: () => void = () => {};
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const service = { child, closed, expectedClose: false };
+  child.once("close", () => {
+    resolveClosed();
+  });
+  return service;
+}
+
+function installServiceLossSpawnGuard(): void {
+  if (serviceLossSpawnGuard) return;
+
+  const previous = childProcess.spawn;
+  const guard = ((...spawnArgs: unknown[]) => {
+    const child = Reflect.apply(previous, childProcess, spawnArgs) as ChildProcess;
+    if (isEsbuildServiceSpawn(spawnArgs)) {
+      serviceLossSpawnGuard!.foreignService = observeForeignServiceChild(child);
+    }
+    return child;
+  }) as typeof childProcess.spawn;
+
+  serviceLossSpawnGuard = { guard, previous, foreignService: null };
+  childProcess.spawn = guard;
+}
+
+function uninstallServiceLossSpawnGuard(): void {
+  const guard = serviceLossSpawnGuard;
+  serviceLossSpawnGuard = null;
+  if (guard && childProcess.spawn === guard.guard) childProcess.spawn = guard.previous;
+}
+
 /**
  * Keep lifecycle tracking tolerant of Node-compatible child-process shims.
  *
@@ -341,6 +410,7 @@ export function __resetServiceRecoveryForTests(): void {
   esbuildServiceLost = false;
   esbuildServiceLostDetail = "";
   remainingServiceRestarts = MAX_SERVICE_RESTARTS;
+  uninstallServiceLossSpawnGuard();
 }
 
 /** Exercise the latch without starting a real esbuild service. */
@@ -372,22 +442,7 @@ function invokeEsbuild<T extends Promise<unknown>>(operation: () => T): T {
   const trackedSpawn = ((...spawnArgs: unknown[]) => {
     const child = Reflect.apply(originalSpawn, childProcess, spawnArgs) as ChildProcess;
     if (isEsbuildServiceSpawn(spawnArgs)) {
-      let resolveClosed: () => void = () => {};
-      const closed = new Promise<void>((resolve) => {
-        resolveClosed = resolve;
-      });
-      const service = { child, closed, expectedClose: false };
-      child.once("close", (exitCode, signalCode) => {
-        // An unexpected close of a child the adapter owns is a crash, not a
-        // lifecycle violation; mark it recoverable instead of latching the
-        // permanent ownership error.
-        if (!service.expectedClose) {
-          esbuildServiceLost = true;
-          esbuildServiceLostDetail = `exit code ${exitCode}, signal ${signalCode}`;
-        }
-        resolveClosed();
-        if (esbuildService === service) esbuildService = null;
-      });
+      const service = trackServiceChild(child);
       capturedService = service;
       esbuildService = service;
       if (childProcess.spawn === trackedSpawn) childProcess.spawn = originalSpawn;
@@ -599,6 +654,15 @@ export class EsbuildBundler implements Bundler {
 
     const stopping = (async () => {
       await activeOperationsIdle;
+
+      if (esbuildServiceLost && serviceLossSpawnGuard?.foreignService) {
+        const error = recordOwnershipError(
+          new Error("esbuild service was replaced outside the module-wide adapter"),
+        );
+        uninstallServiceLossSpawnGuard();
+        throw error;
+      }
+      if (esbuildServiceLost) uninstallServiceLossSpawnGuard();
 
       const m = esbuildModule;
       const trackedService = esbuildService;

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -33,6 +33,16 @@ import { toEsbuildPlugin } from "./plugin-adapter.ts";
 type EsbuildModule = any;
 
 const ESBUILD_STOP_TIMEOUT_MS = 5_000;
+/**
+ * Unexpected service-child deaths tolerated before the adapter gives up.
+ *
+ * The child can be killed by something outside the process (OOM-kill, a
+ * container runtime signal). That is recoverable — esbuild respawns the
+ * service once its module state is reset — so it must not poison the process
+ * the way foreign ownership does. The budget keeps a crash-looping binary
+ * from respawning forever.
+ */
+export const MAX_SERVICE_RESTARTS = 3;
 const childProcess = createRequire(import.meta.url)("node:child_process") as {
   spawn: typeof import("node:child_process").spawn;
 };
@@ -58,6 +68,10 @@ let esbuildOwnershipError: Error | null = null;
 let esbuildShutdownError: Error | null = null;
 let pluginDisposalError: Error | null = null;
 let esbuildStopPromise: Promise<void> | null = null;
+let esbuildServiceLost = false;
+let esbuildServiceLostDetail = "";
+let remainingServiceRestarts = MAX_SERVICE_RESTARTS;
+let esbuildServiceRecovery: Promise<void> | null = null;
 let activeOperationCount = 0;
 let activeOperationsIdle: Promise<void> = Promise.resolve();
 let resolveActiveOperationsIdle: (() => void) | null = null;
@@ -229,6 +243,50 @@ function createPluginDisposalBarrier(scope: OperationScope): {
   };
 }
 
+/**
+ * Recover after the managed service child died unexpectedly (crash, OOM-kill).
+ *
+ * esbuild 0.28 keeps a dead service cached in its module state and rejects
+ * every later call, so the reset must go through its `stop()`, which clears
+ * that state and lets the next API call spawn a fresh child. This path only
+ * runs for a child the adapter itself captured; a service started outside the
+ * adapter is still latched permanently by {@link invokeEsbuild}. Recovery is
+ * single-flight and waits for in-flight operations to drain: they fail with
+ * esbuild's own error for the dead child and must not race the reset.
+ */
+function recoverLostService(): Promise<void> {
+  esbuildServiceRecovery ??= (async () => {
+    await activeOperationsIdle;
+    if (!esbuildServiceLost) return;
+    if (remainingServiceRestarts <= 0) {
+      throw recordOwnershipError(
+        new Error(
+          `esbuild service exited unexpectedly ${
+            MAX_SERVICE_RESTARTS + 1
+          } times (last: ${esbuildServiceLostDetail})`,
+        ),
+      );
+    }
+    remainingServiceRestarts -= 1;
+    const detail = esbuildServiceLostDetail;
+    const m = esbuildModule;
+    esbuildModule = null;
+    esbuildService = null;
+    esbuildServiceLost = false;
+    try {
+      await m?.stop();
+    } catch {
+      // Best effort: the child is already gone; stop() only resets state.
+    }
+    console.warn(
+      `[ext-bundler-esbuild] esbuild service exited unexpectedly (${detail}); restarting it (${remainingServiceRestarts} restart(s) left)`,
+    );
+  })().finally(() => {
+    esbuildServiceRecovery = null;
+  });
+  return esbuildServiceRecovery;
+}
+
 async function runBundlerOperation<T>(
   operation: (scope: OperationScope) => Promise<T>,
   preferredScope?: OperationScope,
@@ -240,6 +298,9 @@ async function runBundlerOperation<T>(
   const isReentrant = inheritedScope !== undefined && inheritedScope.activeCount > 0;
   if (!isReentrant) {
     while (esbuildStopPromise) await esbuildStopPromise;
+    // A lost service is recovered before admission, so one child death costs
+    // one restart instead of poisoning every later operation.
+    while (esbuildServiceLost) await recoverLostService();
   }
 
   // Admission is synchronous after the stop barrier check. This makes a stop
@@ -272,6 +333,14 @@ function isEsbuildServiceSpawn(spawnArgs: unknown[]): boolean {
 /** The ownership latch is module-wide; tests must clear it between cases. */
 export function __resetOwnershipErrorForTests(): void {
   esbuildOwnershipError = null;
+}
+
+/** Crash-recovery state is module-wide; tests must reset it between cases. */
+export function __resetServiceRecoveryForTests(): void {
+  esbuildOwnershipError = null;
+  esbuildServiceLost = false;
+  esbuildServiceLostDetail = "";
+  remainingServiceRestarts = MAX_SERVICE_RESTARTS;
 }
 
 /** Exercise the latch without starting a real esbuild service. */
@@ -308,8 +377,14 @@ function invokeEsbuild<T extends Promise<unknown>>(operation: () => T): T {
         resolveClosed = resolve;
       });
       const service = { child, closed, expectedClose: false };
-      child.once("close", () => {
-        if (!service.expectedClose) recordOwnershipError();
+      child.once("close", (exitCode, signalCode) => {
+        // An unexpected close of a child the adapter owns is a crash, not a
+        // lifecycle violation; mark it recoverable instead of latching the
+        // permanent ownership error.
+        if (!service.expectedClose) {
+          esbuildServiceLost = true;
+          esbuildServiceLostDetail = `exit code ${exitCode}, signal ${signalCode}`;
+        }
         resolveClosed();
         if (esbuildService === service) esbuildService = null;
       });
@@ -329,6 +404,11 @@ function invokeEsbuild<T extends Promise<unknown>>(operation: () => T): T {
 
   const ownedService = capturedService ?? esbuildService;
   if (!ownedService || !isLiveService(ownedService)) {
+    // A managed child that died out from under this operation is the
+    // recoverable crash case handled by runBundlerOperation, not foreign
+    // ownership; the operation surfaces esbuild's own error for the dead
+    // child instead of latching the permanent one.
+    if (esbuildServiceLost) return result;
     // Latch synchronously so a concurrent operation cannot pass the admission
     // check in runBundlerOperation and drive esbuild while ownership is already
     // known to be invalid. The rejection handler still supplies the cause: the
@@ -522,7 +602,12 @@ export class EsbuildBundler implements Bundler {
 
       const m = esbuildModule;
       const trackedService = esbuildService;
-      if (trackedService && !trackedService.expectedClose && !isLiveService(trackedService)) {
+      if (
+        trackedService && !trackedService.expectedClose && !isLiveService(trackedService) &&
+        remainingServiceRestarts <= 0
+      ) {
+        // A dead managed child within the restart budget is a crash, which a
+        // stop resets anyway; only an exhausted budget still means giving up.
         recordOwnershipError();
       }
       const ownershipError = esbuildOwnershipError;
@@ -572,6 +657,9 @@ export class EsbuildBundler implements Bundler {
       if (esbuildModule === m) esbuildModule = null;
       if (esbuildService === service) esbuildService = null;
       esbuildShutdownError = null;
+      // A clean stop resets esbuild's module state, so a pending crash needs
+      // no recovery pass anymore.
+      esbuildServiceLost = false;
 
       if (disposalError) {
         if (pluginDisposalError === disposalError) pluginDisposalError = null;

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -72,6 +72,7 @@ let esbuildServiceLost = false;
 let esbuildServiceLostDetail = "";
 let remainingServiceRestarts = MAX_SERVICE_RESTARTS;
 let esbuildServiceRecovery: Promise<void> | null = null;
+let esbuildServiceGeneration = 0;
 let serviceLossSpawnGuard: {
   guard: typeof childProcess.spawn;
   previous: typeof childProcess.spawn;
@@ -81,6 +82,9 @@ let esbuildServiceForeignReplacement: EsbuildService | null = null;
 let activeOperationCount = 0;
 let activeOperationsIdle: Promise<void> = Promise.resolve();
 let resolveActiveOperationsIdle: (() => void) | null = null;
+let stopBarrierCount = 0;
+let stopBarrierIdle: Promise<void> = Promise.resolve();
+let resolveStopBarrierIdle: (() => void) | null = null;
 const operationScopes = new AsyncLocalStorage<OperationScope>();
 
 const OWNERSHIP_ERROR_MESSAGE =
@@ -162,6 +166,25 @@ function endOperation(): void {
   const resolve = resolveActiveOperationsIdle;
   resolveActiveOperationsIdle = null;
   activeOperationsIdle = Promise.resolve();
+  resolve?.();
+}
+
+function enterStopBarrier(): void {
+  if (stopBarrierCount === 0) {
+    stopBarrierIdle = new Promise<void>((resolve) => {
+      resolveStopBarrierIdle = resolve;
+    });
+  }
+  stopBarrierCount += 1;
+}
+
+function leaveStopBarrier(): void {
+  stopBarrierCount -= 1;
+  if (stopBarrierCount !== 0) return;
+
+  const resolve = resolveStopBarrierIdle;
+  resolveStopBarrierIdle = null;
+  stopBarrierIdle = Promise.resolve();
   resolve?.();
 }
 
@@ -294,6 +317,7 @@ function recoverLostService(): Promise<void> {
     } catch {
       // Best effort: the child is already gone; stop() only resets state.
     }
+    esbuildServiceGeneration += 1;
     console.warn(
       `[ext-bundler-esbuild] esbuild service exited unexpectedly (${detail}); restarting it (${remainingServiceRestarts} restart(s) left)`,
     );
@@ -312,24 +336,36 @@ async function runBundlerOperation<T>(
 
   const inheritedScope = operationScopes.getStore();
   const isReentrant = inheritedScope !== undefined && inheritedScope.activeCount > 0;
+  let stopBarrierEntered = false;
   if (!isReentrant) {
     while (esbuildStopPromise) await esbuildStopPromise;
-    // A lost service is recovered before admission, so one child death costs
-    // one restart instead of poisoning every later operation.
-    while (esbuildServiceLost) await recoverLostService();
+    enterStopBarrier();
+    stopBarrierEntered = true;
   }
 
-  // Admission is synchronous after the stop barrier check. This makes a stop
-  // exclusive without serializing independent operations. Work re-entered by
-  // an active plugin shares its live scope so shutdown cannot deadlock on it.
-  const scope = preferredScope ?? (isReentrant ? inheritedScope : { activeCount: 0 });
-  beginOperation();
-  scope.activeCount += 1;
   try {
-    return await operationScopes.run(scope, () => operation(scope));
+    if (!isReentrant) {
+      // A lost service is recovered before admission, so one child death costs
+      // one restart instead of poisoning every later operation. The operation
+      // already holds the stop barrier, so shutdown cannot complete in this
+      // recovery gap and then leave the operation to spawn a new service.
+      while (esbuildServiceLost) await recoverLostService();
+    }
+
+    // Admission is synchronous after the stop barrier check. This makes a stop
+    // exclusive without serializing independent operations. Work re-entered by
+    // an active plugin shares its live scope so shutdown cannot deadlock on it.
+    const scope = preferredScope ?? (isReentrant ? inheritedScope : { activeCount: 0 });
+    beginOperation();
+    scope.activeCount += 1;
+    try {
+      return await operationScopes.run(scope, () => operation(scope));
+    } finally {
+      scope.activeCount -= 1;
+      endOperation();
+    }
   } finally {
-    scope.activeCount -= 1;
-    endOperation();
+    if (stopBarrierEntered) leaveStopBarrier();
   }
 }
 
@@ -414,6 +450,7 @@ export function __resetServiceRecoveryForTests(): void {
   esbuildServiceLost = false;
   esbuildServiceLostDetail = "";
   esbuildServiceForeignReplacement = null;
+  esbuildServiceGeneration = 0;
   remainingServiceRestarts = MAX_SERVICE_RESTARTS;
   uninstallServiceLossSpawnGuard();
 }
@@ -612,16 +649,36 @@ export class EsbuildBundler implements Bundler {
     return runBundlerOperation(async (contextScope) => {
       const esbuild = await getEsbuild();
       const mapped = mapOptions(options, contextScope);
-      const ctx = await invokeEsbuild(() => esbuild.context(mapped.options)).catch(
+      let ctx = await invokeEsbuild(() => esbuild.context(mapped.options)).catch(
         (error: unknown) => {
           mapped.activatePluginDisposals();
           throw error;
         },
       );
+      let contextGeneration = esbuildServiceGeneration;
+      let contextRefresh: Promise<void> | null = null;
+      const currentContext = async () => {
+        if (contextGeneration === esbuildServiceGeneration) return ctx;
+        contextRefresh ??= (async () => {
+          if (contextGeneration === esbuildServiceGeneration) return;
+          const currentEsbuild = await getEsbuild();
+          ctx = await invokeEsbuild(() => currentEsbuild.context(mapped.options)).catch(
+            (error: unknown) => {
+              mapped.activatePluginDisposals();
+              throw error;
+            },
+          );
+          contextGeneration = esbuildServiceGeneration;
+        })().finally(() => {
+          contextRefresh = null;
+        });
+        await contextRefresh;
+        return ctx;
+      };
       return {
         rebuild: () =>
           runBundlerOperation(async () => {
-            const result = await ctx.rebuild();
+            const result = await (await currentContext()).rebuild();
             return {
               outputFiles: (result.outputFiles ?? []).map(toOutput),
               warnings: toMessages(result.warnings),
@@ -631,12 +688,12 @@ export class EsbuildBundler implements Bundler {
           }, contextScope),
         cancel: () =>
           runBundlerOperation(async () => {
-            await ctx.cancel();
+            await (await currentContext()).cancel();
           }, contextScope),
         dispose: () =>
           runBundlerOperation(async () => {
             try {
-              await ctx.dispose();
+              if (contextGeneration === esbuildServiceGeneration) await ctx.dispose();
             } finally {
               mapped.activatePluginDisposals();
             }
@@ -658,6 +715,7 @@ export class EsbuildBundler implements Bundler {
     }
 
     const stopping = (async () => {
+      await stopBarrierIdle;
       await activeOperationsIdle;
 
       if (

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -51,6 +51,7 @@ interface EsbuildService {
   child: ChildProcess;
   closed: Promise<void>;
   expectedClose: boolean;
+  lossRecorded?: boolean;
 }
 
 interface OperationScope {
@@ -416,17 +417,8 @@ function trackServiceChild(child: ChildProcess): EsbuildService {
     resolveClosed = resolve;
   });
   const service = { child, closed, expectedClose: false };
-  let lossRecorded = false;
-  const recordUnexpectedLoss = (exitCode: unknown, signalCode: unknown): void => {
-    // An unexpected close of a child the adapter owns is a crash, not a
-    // lifecycle violation; mark it recoverable instead of latching the
-    // permanent ownership error.
-    if (service.expectedClose || lossRecorded) return;
-    lossRecorded = true;
-    esbuildServiceLost = true;
-    esbuildServiceLostDetail = `exit code ${exitCode}, signal ${signalCode}`;
-    installServiceLossSpawnGuard();
-  };
+  const recordUnexpectedLoss = (exitCode: unknown, signalCode: unknown): void =>
+    recordUnexpectedManagedServiceLoss(service, exitCode, signalCode);
   child.once("exit", recordUnexpectedLoss);
   child.once("close", (exitCode, signalCode) => {
     recordUnexpectedLoss(exitCode, signalCode);
@@ -434,6 +426,21 @@ function trackServiceChild(child: ChildProcess): EsbuildService {
     if (esbuildService === service) esbuildService = null;
   });
   return service;
+}
+
+function recordUnexpectedManagedServiceLoss(
+  service: EsbuildService,
+  exitCode: unknown,
+  signalCode: unknown,
+): void {
+  // An unexpected close of a child the adapter owns is a crash, not a
+  // lifecycle violation; mark it recoverable instead of latching the
+  // permanent ownership error.
+  if (service.expectedClose || service.lossRecorded) return;
+  service.lossRecorded = true;
+  esbuildServiceLost = true;
+  esbuildServiceLostDetail = `exit code ${exitCode}, signal ${signalCode}`;
+  installServiceLossSpawnGuard();
 }
 
 function observeForeignServiceChild(child: ChildProcess): EsbuildService {
@@ -545,6 +552,14 @@ function invokeEsbuild<T extends Promise<unknown>>(operation: () => T): T {
     // ownership; the operation surfaces esbuild's own error for the dead
     // child instead of latching the permanent one.
     if (esbuildServiceLost) return result;
+    if (ownedService && ownedService === esbuildService) {
+      recordUnexpectedManagedServiceLoss(
+        ownedService,
+        ownedService.child.exitCode,
+        ownedService.child.signalCode,
+      );
+      return result;
+    }
     // Latch synchronously so a concurrent operation cannot pass the admission
     // check in runBundlerOperation and drive esbuild while ownership is already
     // known to be invalid. The rejection handler still supplies the cause: the
@@ -627,6 +642,18 @@ function mapOptions(options: BundleOptions, scope: OperationScope): MappedBundle
   };
 }
 
+async function finalizePluginDisposals(mapped: MappedBundleOptions): Promise<void> {
+  const service = esbuildService;
+  if (
+    esbuildServiceLost ||
+    (service && !service.expectedClose && !isLiveService(service))
+  ) {
+    await mapped.disposePluginGeneration();
+    return;
+  }
+  mapped.activatePluginDisposals();
+}
+
 /**
  * esbuild-backed {@link Bundler} implementation.
  *
@@ -667,7 +694,7 @@ export class EsbuildBundler implements Bundler {
           metafile: result.metafile as Metafile | undefined,
         };
       } finally {
-        mapped.activatePluginDisposals();
+        await finalizePluginDisposals(mapped);
       }
     });
   }
@@ -690,8 +717,8 @@ export class EsbuildBundler implements Bundler {
       const esbuild = await getEsbuild();
       const mapped = mapOptions(options, contextScope);
       let ctx = await invokeEsbuild(() => esbuild.context(mapped.options)).catch(
-        (error: unknown) => {
-          mapped.activatePluginDisposals();
+        async (error: unknown) => {
+          await finalizePluginDisposals(mapped);
           throw error;
         },
       );
@@ -704,8 +731,8 @@ export class EsbuildBundler implements Bundler {
           await mapped.disposePluginGeneration();
           const currentEsbuild = await getEsbuild();
           ctx = await invokeEsbuild(() => currentEsbuild.context(mapped.options)).catch(
-            (error: unknown) => {
-              mapped.activatePluginDisposals();
+            async (error: unknown) => {
+              await finalizePluginDisposals(mapped);
               throw error;
             },
           );
@@ -736,7 +763,11 @@ export class EsbuildBundler implements Bundler {
             try {
               if (contextGeneration === esbuildServiceGeneration) await ctx.dispose();
             } finally {
-              mapped.activatePluginDisposals();
+              if (contextGeneration === esbuildServiceGeneration) {
+                mapped.activatePluginDisposals();
+              } else {
+                await mapped.disposePluginGeneration();
+              }
             }
           }, contextScope),
       };
@@ -780,7 +811,10 @@ export class EsbuildBundler implements Bundler {
         uninstallServiceLossSpawnGuard();
         throw error;
       }
-      if (esbuildServiceLost) uninstallServiceLossSpawnGuard();
+      if (esbuildServiceLost) {
+        remainingServiceRestarts -= 1;
+        uninstallServiceLossSpawnGuard();
+      }
 
       const m = esbuildModule;
       const trackedService = esbuildService;

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -204,6 +204,7 @@ function createPluginDisposalBarrier(scope: OperationScope): {
   }> = [];
   let activated = false;
   let holdingOperation = false;
+  let disposalError: Error | null = null;
 
   const releaseIfSettled = (): void => {
     if (!holdingOperation || callbacks.some((callback) => !callback.settled)) return;
@@ -223,12 +224,13 @@ function createPluginDisposalBarrier(scope: OperationScope): {
     callback: { settled: boolean; resolveSettled: () => void },
     error: unknown,
   ): void => {
-    if (!pluginDisposalError) {
-      pluginDisposalError = new Error(
+    if (!disposalError) {
+      disposalError = new Error(
         "[ext-bundler-esbuild] Plugin disposal failed",
         { cause: error },
       );
     }
+    if (!pluginDisposalError) pluginDisposalError = disposalError;
     settle(callback);
   };
 
@@ -302,7 +304,7 @@ function createPluginDisposalBarrier(scope: OperationScope): {
       const pending = callbacks.filter((callback) => !callback.settled);
       for (const callback of pending) start(callback);
       await Promise.all(pending.map((callback) => callback.settledPromise));
-      if (pluginDisposalError) throw pluginDisposalError;
+      if (disposalError) throw disposalError;
     },
   };
 }
@@ -715,7 +717,7 @@ export class EsbuildBundler implements Bundler {
   async context(options: BundleOptions): Promise<BuildContext> {
     return runBundlerOperation(async (contextScope) => {
       const esbuild = await getEsbuild();
-      const mapped = mapOptions(options, contextScope);
+      let mapped = mapOptions(options, contextScope);
       let ctx = await invokeEsbuild(() => esbuild.context(mapped.options)).catch(
         async (error: unknown) => {
           await finalizePluginDisposals(mapped);
@@ -729,13 +731,16 @@ export class EsbuildBundler implements Bundler {
         contextRefresh ??= (async () => {
           if (contextGeneration === esbuildServiceGeneration) return;
           await mapped.disposePluginGeneration();
+          const nextMapped = mapOptions(options, contextScope);
           const currentEsbuild = await getEsbuild();
-          ctx = await invokeEsbuild(() => currentEsbuild.context(mapped.options)).catch(
+          ctx = await invokeEsbuild(() => currentEsbuild.context(nextMapped.options)).catch(
             async (error: unknown) => {
-              await finalizePluginDisposals(mapped);
+              await finalizePluginDisposals(nextMapped);
+              mapped = mapOptions(options, contextScope);
               throw error;
             },
           );
+          mapped = nextMapped;
           contextGeneration = esbuildServiceGeneration;
         })().finally(() => {
           contextRefresh = null;


### PR DESCRIPTION
Fixes [VERYFRONT-SERVER-V](https://veryfront.sentry.io/issues/VERYFRONT-SERVER-V) (160 events, staging, escalating).

## Root cause
The immediate staging trigger (esbuild's module evaluating inside a project env scope and losing `ESBUILD_BINARY_PATH`) was fixed on main by #3698/#3697. This PR fixes the amplifier those left in place: when the managed esbuild service child dies unexpectedly (OOM-kill, SIGKILL, or the #3698-class spawn failure), the adapter latched a permanent process-wide ownership error. Every subsequent transform in the pod failed until restart, so one child death poisoned the whole process for its lifetime.

## Fix
The bundler adapter now recovers with a fresh esbuild service after an unexpected managed child death, bounded by a restart budget (`MAX_SERVICE_RESTARTS = 3`) to preserve the original guard's protection against genuinely foreign service ownership. Operations in flight during a crash surface esbuild's raw transient error once; the next operation recovers.

The recovery path also preserves the module-wide ownership guardrails:

- Raw esbuild services that replace a killed managed child remain rejected. Recovery and later shutdown calls fail closed without touching the foreign service.
- Shutdown waits for operations that are already waiting on lost-service recovery, so `stop()` cannot complete and then leave that operation to spawn a new service afterward.
- Build contexts captured before a managed service crash refresh themselves after recovery from the saved mapped options, so callers can keep using the existing `BuildContext` wrapper.
- Managed child `exit` marks the service loss recoverable immediately, while `close` remains the completion signal, so operations launched in the exit-to-close window do not latch a permanent ownership error.
- Stale plugin `onDispose` callbacks run before recreating a crashed context, preserving exactly one active plugin generation during context recovery.
- Plugin generations are force-disposed when a crashed context is abandoned without rebuild, so abandoned esbuild services cannot strand plugin resources.
- Forced cleanup reports only errors from the plugin generation being disposed while preserving the module-wide async disposal error for shutdown, so an unrelated stale disposal failure cannot poison later crashed-context cleanup.
- Failed context refresh attempts dispose their attempted plugin generation and replace the abandoned mapped options with a fresh barrier, so a later successful retry can still await cleanup.
- Restart-budget exhaustion stays latched even when `stop()` observes the lost service after the dead child has already closed and been cleared from module state.
- `stop()` spends restart budget when it clears a managed crash, so crash plus stop loops cannot bypass the restart limit.

## Testing (red-green TDD)
Regression coverage was added for managed child crash recovery, foreign raw-service replacement, repeated foreign shutdown, shutdown during pre-admission recovery, captured `BuildContext` reuse after recovery, the managed child exit-to-close window, stale plugin disposal before context recreation, abandoned crashed context disposal, stale disposal errors from unrelated plugin barriers, context refresh failure followed by a successful retry, and restart-budget exhaustion when losses are cleared by `stop()`.

The new regressions fail on the pre-fix code: shutdown settles too early, stale context rebuild throws `The service is no longer running`, exit-to-close work latches the permanent module-wide ownership error, stale plugin disposal remains at 0 while a second setup runs, abandoned crashed contexts leave plugin disposal at 0, unrelated stale plugin disposal errors escape later crashed-context cleanup, failed refresh reuses an activated disposal barrier so later cleanup is not awaited, and crash plus stop loops let `stop()` resolve after the restart budget is exhausted.

Local verification at the pushed head (`0efec7681e42b635a0fb897357941bd89f7c3d92`):

- `deno test --preload=src/testing/preload.ts --no-check --allow-all extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts` -> 8 passed, 38 steps.
- `deno test --preload=src/testing/preload.ts --no-check --allow-all extensions/ext-bundler-esbuild/src` -> 12 passed, 46 steps.
- `deno fmt --check extensions/ext-bundler-esbuild/src/esbuild-bundler.ts extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts` -> passed.
- `deno lint extensions/ext-bundler-esbuild/src/esbuild-bundler.ts extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts` -> passed.
- `deno check extensions/ext-bundler-esbuild/src/esbuild-bundler.ts extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts` -> passed.
- `perl -CSD -ne 'print if /\\x{2014}|\\x{2013}/' extensions/ext-bundler-esbuild/src/esbuild-bundler.ts extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts` -> no matches.
- `git diff --check HEAD~1..HEAD` -> passed.
- Full pre-push hook at `0efec7681e42b635a0fb897357941bd89f7c3d92` -> passed: repo format, lint, typecheck, unit suite (3814 passed, 28499 steps, 0 failed, 1 ignored), cwd tests (10 passed, 193 steps), and cwd-exclusion tests (2 passed, 2 steps).

## Reviewer notes
- The restart budget never replenishes after successful recovery; 4 unexpected managed-child deaths over a long process lifetime re-latch the permanent error. A time-windowed budget would be more robust, but this PR keeps the guard simple and bounded.
