### PR TITLE
fix(css): degrade files rejected by candidate extraction instead of failing every render

### DIFF
--- a/src/rendering/orchestrator/css-candidate-manifest.test.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.test.ts
@@ -3,11 +3,27 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import {
+  __registerLogRecordEmitter,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+} from "#veryfront/utils/logger/logger.ts";
+import {
   getCandidateManifestCacheStats,
   getProjectCandidates,
   getRouteCandidates,
   invalidateProjectCandidateManifests,
 } from "./css-candidate-manifest.ts";
+
+function captureLogs(): { entries: LogEntry[]; restore: () => void } {
+  const entries: LogEntry[] = [];
+  __registerLogRecordEmitter((entry) => entries.push(entry));
+  return {
+    entries,
+    restore: () => {
+      __resetLogRecordEmitterForTests();
+    },
+  };
+}
 
 describe("rendering/orchestrator/css-candidate-manifest", () => {
   describe("invalidateProjectCandidateManifests", () => {
@@ -259,6 +275,36 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
       assertEquals(statsAfterFirst.manifests.entries, 1);
       const second = getProjectCandidates(options);
       assertEquals(second.has("text-red-500"), true);
+    });
+
+    it("logs rejected source files without exposing absolute project paths", () => {
+      invalidateProjectCandidateManifests();
+      const captured = captureLogs();
+      try {
+        const projectDir = "/Users/someone/private/path/my-project";
+        const absoluteSourcePath = `${projectDir}/vendor/minified.js`;
+        const poisonContent = Array.from({ length: 100_001 }, (_, i) => `tok-${i}`).join(" ");
+
+        getProjectCandidates({
+          projectScope: "project-poison-log-redaction",
+          projectVersion: "v1",
+          projectDir,
+          files: [
+            { path: absoluteSourcePath, content: poisonContent },
+          ],
+          developmentMode: false,
+        });
+
+        const warning = captured.entries.find((entry) =>
+          entry.message === "Skipping file rejected by candidate extraction"
+        );
+        assertEquals(warning !== undefined, true, "the warning must be emitted");
+        assertEquals(warning!.context?.path, "vendor/minified.js");
+        assertEquals(JSON.stringify(warning!.context).includes(projectDir), false);
+        assertEquals(JSON.stringify(warning!.context).includes(absoluteSourcePath), false);
+      } finally {
+        captured.restore();
+      }
     });
 
     it("degrades a file that exceeds the byte-size admission cap instead of throwing", () => {

--- a/src/rendering/orchestrator/css-candidate-manifest.test.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.test.ts
@@ -283,6 +283,7 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
       try {
         const projectDir = "/Users/someone/private/path/my-project";
         const absoluteSourcePath = `${projectDir}/vendor/minified.js`;
+        const outsideSourcePath = "/Users/someone/other-parent/minified.js";
         const poisonContent = Array.from({ length: 100_001 }, (_, i) => `tok-${i}`).join(" ");
 
         getProjectCandidates({
@@ -291,17 +292,33 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
           projectDir,
           files: [
             { path: absoluteSourcePath, content: poisonContent },
+            { path: outsideSourcePath, content: poisonContent },
           ],
           developmentMode: false,
         });
 
-        const warning = captured.entries.find((entry) =>
-          entry.message === "Skipping file rejected by candidate extraction"
+        const projectWarning = captured.entries.find((entry) =>
+          entry.message === "Skipping file rejected by candidate extraction" &&
+          entry.context?.path === "vendor/minified.js"
         );
-        assertEquals(warning !== undefined, true, "the warning must be emitted");
-        assertEquals(warning!.context?.path, "vendor/minified.js");
-        assertEquals(JSON.stringify(warning!.context).includes(projectDir), false);
-        assertEquals(JSON.stringify(warning!.context).includes(absoluteSourcePath), false);
+        assertEquals(projectWarning !== undefined, true, "the in-project warning must be emitted");
+        assertEquals(JSON.stringify(projectWarning!.context).includes(projectDir), false);
+        assertEquals(JSON.stringify(projectWarning!.context).includes(absoluteSourcePath), false);
+
+        const outsideWarning = captured.entries.find((entry) =>
+          entry.message === "Skipping file rejected by candidate extraction" &&
+          entry.context?.path === "[outside-project]/minified.js"
+        );
+        assertEquals(
+          outsideWarning !== undefined,
+          true,
+          "the outside-project warning must be emitted",
+        );
+        assertEquals(outsideWarning!.context?.path, "[outside-project]/minified.js");
+        const outsideContext = JSON.stringify(outsideWarning!.context);
+        assertEquals(outsideContext.includes(outsideSourcePath), false);
+        assertEquals(outsideContext.includes("/Users/someone"), false);
+        assertEquals(outsideContext.includes("other-parent"), false);
       } finally {
         captured.restore();
       }
@@ -310,7 +327,9 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
     it("degrades a file that exceeds the byte-size admission cap instead of throwing", () => {
       invalidateProjectCandidateManifests();
       // >MAX_CSS_FILE_BYTES (16MB) — e.g. a giant generated asset in sources.
-      const oversized = "x".repeat(16 * 1024 * 1024 + 1);
+      const oversized = "text-blue-500 ".repeat(
+        Math.ceil((16 * 1024 * 1024 + 1) / "text-blue-500 ".length),
+      );
       const result = getProjectCandidates({
         projectScope: "project-poison-bytes",
         projectVersion: "v1",
@@ -326,6 +345,7 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
       });
 
       assertEquals(result.has("text-red-500"), true);
+      assertEquals(result.has("text-blue-500"), false);
     });
 
     it("keeps configured runtime roots in the candidate graph", () => {

--- a/src/rendering/orchestrator/css-candidate-manifest.test.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.test.ts
@@ -229,6 +229,59 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
       assertEquals(result.has("text-blue-500"), false);
     });
 
+    it("degrades a file that exceeds the candidate-count admission cap instead of throwing", () => {
+      invalidateProjectCandidateManifests();
+      // >MAX_CSS_SELECTOR_TOKENS (100_000) distinct candidates in one file —
+      // the shape of a large minified vendor bundle in project sources.
+      const poisonContent = Array.from({ length: 100_001 }, (_, i) => `tok-${i}`).join(" ");
+      const options = {
+        projectScope: "project-poison-count",
+        projectVersion: "v1",
+        projectDir: "/project",
+        files: [
+          { path: "/project/vendor/minified.js", content: poisonContent },
+          {
+            path: "/project/pages/index.tsx",
+            content: '<div className="text-red-500">Home</div>',
+          },
+        ],
+        developmentMode: false,
+      };
+
+      const result = getProjectCandidates(options);
+
+      assertEquals(result.has("text-red-500"), true);
+      assertEquals(result.has("tok-0"), false);
+
+      // The completed manifest must be cached so the pathological file is not
+      // re-scanned (and cannot re-fail) on every request.
+      const statsAfterFirst = getCandidateManifestCacheStats();
+      assertEquals(statsAfterFirst.manifests.entries, 1);
+      const second = getProjectCandidates(options);
+      assertEquals(second.has("text-red-500"), true);
+    });
+
+    it("degrades a file that exceeds the byte-size admission cap instead of throwing", () => {
+      invalidateProjectCandidateManifests();
+      // >MAX_CSS_FILE_BYTES (16MB) — e.g. a giant generated asset in sources.
+      const oversized = "x".repeat(16 * 1024 * 1024 + 1);
+      const result = getProjectCandidates({
+        projectScope: "project-poison-bytes",
+        projectVersion: "v1",
+        projectDir: "/project",
+        files: [
+          { path: "/project/generated/blob.js", content: oversized },
+          {
+            path: "/project/pages/index.tsx",
+            content: '<div className="text-red-500">Home</div>',
+          },
+        ],
+        developmentMode: false,
+      });
+
+      assertEquals(result.has("text-red-500"), true);
+    });
+
     it("keeps configured runtime roots in the candidate graph", () => {
       invalidateProjectCandidateManifests();
       const result = getProjectCandidates({

--- a/src/rendering/orchestrator/css-candidate-manifest.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.ts
@@ -85,6 +85,19 @@ function toRelativeProjectPath(path: string, projectDir: string): string {
   return normalized.replace(/^\/+/, "");
 }
 
+function toDiagnosticProjectPath(path: string, projectDir: string): string {
+  const normalized = normalizePath(path);
+  const normalizedProjectDir = normalizePath(projectDir).replace(/\/+$/, "");
+  if (normalized === normalizedProjectDir) return ".";
+  if (normalized.startsWith(`${normalizedProjectDir}/`)) {
+    return normalized.slice(normalizedProjectDir.length + 1);
+  }
+  if (/^(?:[A-Za-z]:)?\//.test(normalized)) {
+    return `[outside-project]/${normalized.split("/").pop() ?? "unknown"}`;
+  }
+  return normalized.replace(/^\/+/, "");
+}
+
 function buildManifestCacheKey(
   projectScope: string,
   projectVersion: string,
@@ -133,7 +146,7 @@ function buildCandidateManifest(files: SourceFileLike[], projectDir: string): Ca
       extracted = extractCandidates(file.content);
     } catch (error) {
       logger.warn("Skipping file rejected by candidate extraction", {
-        path: file.path,
+        path: toDiagnosticProjectPath(file.path, projectDir),
         error: error instanceof Error ? error.message : String(error),
       });
       continue;

--- a/src/rendering/orchestrator/css-candidate-manifest.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.ts
@@ -123,7 +123,23 @@ function buildCandidateManifest(files: SourceFileLike[], projectDir: string): Ca
     if (!file.content) continue;
     if (!SOURCE_EXTENSIONS.some((ext) => file.path.endsWith(ext))) continue;
 
-    const candidates = new Set(extractCandidates(file.content));
+    // A file the tokenizer refuses to admit (over the byte or candidate-count
+    // cap) must degrade to "contributes no candidates", not abort the manifest:
+    // an escaping throw here propagates to the SSR boundary and, because it
+    // happens before manifestCache.set, is rebuilt and re-thrown on every
+    // request to the project (VERYFRONT-SERVER-F).
+    let extracted: string[];
+    try {
+      extracted = extractCandidates(file.content);
+    } catch (error) {
+      logger.warn("Skipping file rejected by candidate extraction", {
+        path: file.path,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    const candidates = new Set(extracted);
     const relativePath = toRelativeProjectPath(file.path, projectDir);
     const absolutePath = normalizePath(file.path);
 


### PR DESCRIPTION
Follow-up hardening for [VERYFRONT-SERVER-F](https://veryfront.sentry.io/issues/VERYFRONT-SERVER-F) (975 events in ~90 min on Aug 6; the literal 1024-char-token throw was already fixed by d60537f49 / v0.1.1205 the same day — Sentry issue resolved with evidence).

## Remaining defect
Two sibling crash-on-user-content throws stayed live on the exact same per-request, no-negative-caching SSR path that produced the original storm:
- `candidate-tokenizer.ts`: TypeError when one file yields >100,000 distinct candidates (reachable with a large minified vendor `.js` in project sources)
- `assertCSSFileContent`: TypeError for any scanned source file >16MB

Either throw escapes `buildCandidateManifest` **before** `manifestCache.set`, so the failure re-runs the full project scan and re-throws on every request — one oversized tenant file takes down every render for the project, indefinitely.

## Fix
`buildCandidateManifest` now degrades per-file: a file rejected by the admission caps is logged (warn) and skipped, the manifest still builds and caches, and the rest of the project renders with styles from its remaining files.

## Testing (red-green TDD)
Two new tests in `css-candidate-manifest.test.ts` (per-cap degradation) fail on pre-fix src with the exact TypeErrors (adversarial revert-check), pass at HEAD (19 steps).

## Reviewer notes (from adversarial verification)
- The catch is broad: any `extractCandidates` error (including a future tokenizer bug) downgrades to warn+skip for that file — availability tradeoff at this seam; a real defect would show as silently-missing styles plus the warn log.
- The sandboxed `candidate-extractor.ts` aggregate cap remains live on other paths — out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSS candidate manifest generation now continues gracefully when individual files exceed candidate-count or size limits.
  * Valid CSS candidates remain available even when other files are rejected.
  * Rejected files are skipped without interrupting the overall process.
  * Diagnostic messages now use safer project-relative paths and avoid exposing absolute project locations.
  * Completed manifests are cached for consistent reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->