### PR TITLE
fix(observability): stable fingerprints for DB-connection errors and legible Failed-query titles

### DIFF
--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -200,7 +200,7 @@ it("policy groups each pgbouncer connection code into its own db-error issue", (
     const event = prepareSentryEvent(
       {
         exception: {
-          values: [{ type: "PostgresError", value: `write ${code} db.internal:6432` }],
+          values: [{ type: "PostgresError", value: `write ${code} db.example.test:6432` }],
         },
       },
       "veryfront-api",
@@ -272,6 +272,24 @@ it("policy caps collapsed Failed query values and leaves other values untouched"
   assertEquals(collapsed.startsWith("Failed query: select c, c,"), true);
   assertEquals(collapsed.length <= "Failed query: ".length + 201, true);
   assertEquals(event.exception?.values?.[1]?.value, "  leading spaces stay untouched");
+});
+
+it("policy redacts full Failed query values before truncating the Sentry title", () => {
+  const jwt = `${"a".repeat(16)}.${"b".repeat(16)}.${"c".repeat(180)}`;
+  const queryHead = `\n  select '${"x".repeat(175)}${jwt}' from tokens`;
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{ type: "DrizzleQueryError", value: `Failed query: ${queryHead}` }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  const collapsed = event.exception?.values?.[0]?.value ?? "";
+  assertStringIncludes(collapsed, "[REDACTED]");
+  assertEquals(collapsed.includes("a".repeat(12)), false);
+  assertEquals(collapsed.includes("c".repeat(20)), false);
 });
 
 it("policy redacts credentials from custom-host DSNs", () => {

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -313,14 +313,55 @@ it("policy excludes query parameters from Failed query titles", () => {
   );
 });
 
+it("policy redacts quoted SQL literals from Failed query titles", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: \n  select "id" from "orders" where "email" = \'customer@example.test\' and "note" = \'customer\'\'s private order\'',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "id" from "orders" where "email" = ? and "note" = ?',
+  );
+});
+
+it("policy redacts dollar-quoted and numeric SQL literals without hiding query structure", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: \n  select "template2", "2024", $$customer@example.test$$, $order$ORDER-731$order$, 731, 18.75, 6.02e23 from "orders2" where "id" = $1',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "template2", "2024", ?, ?, ?, ?, ? from "orders2" where "id" = $1',
+  );
+});
+
 it("policy caps collapsed Failed query values and leaves other values untouched", () => {
   const longSql = `\n  select ${"c, ".repeat(200)}from t`;
+  const nonQueryError = "upstream select 'customer@example.test', 731 stays untouched";
   const event = prepareSentryEvent(
     {
       exception: {
         values: [
           { type: "DrizzleQueryError", value: `Failed query: ${longSql}` },
-          { type: "Error", value: "  leading spaces stay untouched" },
+          { type: "Error", value: nonQueryError },
         ],
       },
     },
@@ -330,10 +371,10 @@ it("policy caps collapsed Failed query values and leaves other values untouched"
   const collapsed = event.exception?.values?.[0]?.value ?? "";
   assertEquals(collapsed.startsWith("Failed query: select c, c,"), true);
   assertEquals(collapsed.length <= "Failed query: ".length + 201, true);
-  assertEquals(event.exception?.values?.[1]?.value, "  leading spaces stay untouched");
+  assertEquals(event.exception?.values?.[1]?.value, nonQueryError);
 });
 
-it("policy redacts full Failed query values before truncating the Sentry title", () => {
+it("policy redacts long SQL literals before constructing the Sentry title", () => {
   const jwt = `${"a".repeat(16)}.${"b".repeat(16)}.${"c".repeat(180)}`;
   const queryHead = `\n  select '${"x".repeat(175)}${jwt}' from tokens`;
   const event = prepareSentryEvent(
@@ -346,7 +387,7 @@ it("policy redacts full Failed query values before truncating the Sentry title",
   );
 
   const collapsed = event.exception?.values?.[0]?.value ?? "";
-  assertStringIncludes(collapsed, "[REDACTED]");
+  assertEquals(collapsed, "Failed query: select ? from tokens");
   assertEquals(collapsed.includes("a".repeat(12)), false);
   assertEquals(collapsed.includes("c".repeat(20)), false);
 });

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -400,7 +400,7 @@ it("policy redacts PostgreSQL radix integer literals", () => {
         values: [{
           type: "DrizzleQueryError",
           value:
-            'Failed query: \n  select 0xDEADBEEF, 0o731, 0b101101 from "orders0x2" where "id" = $1',
+            'Failed query: \n  select 0xDEADBEEF, 0o731, 0b101101, 0x_DEAD, 0o_1_755, 0b_101101 from "orders0x2" where "id" = $1',
         }],
       },
     },
@@ -409,7 +409,7 @@ it("policy redacts PostgreSQL radix integer literals", () => {
 
   assertEquals(
     event.exception?.values?.[0]?.value,
-    'Failed query: select ?, ?, ? from "orders0x2" where "id" = $1',
+    'Failed query: select ?, ?, ?, ?, ?, ? from "orders0x2" where "id" = $1',
   );
 });
 

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -373,6 +373,26 @@ it("policy redacts dollar-quoted and numeric SQL literals without hiding query s
   );
 });
 
+it("policy redacts unrecognized dollar-quoted SQL literal tags", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: \n  select $😀$customer@example.test$😀$, $1 from "orders" where "id" = $2',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select ?, $1 from "orders" where "id" = $2',
+  );
+});
+
 it("policy redacts PostgreSQL radix integer literals", () => {
   const event = prepareSentryEvent(
     {

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -536,7 +536,9 @@ it("policy redacts backslash-escaped ordinary SQL strings conservatively", () =>
   );
 
   const value = event.exception?.values?.[0]?.value ?? "";
-  assertEquals(value, 'Failed query: select ? from "orders"');
+  // The trailing `from "orders"` goes too: an odd backslash run makes the literal's extent
+  // ambiguous, so the remainder is redacted rather than parsed under a guessed server setting.
+  assertEquals(value, "Failed query: select ?");
   assertEquals(value.includes("private@example.test"), false);
 });
 
@@ -597,6 +599,42 @@ it("policy redacts unterminated unrecognized dollar-quoted SQL literal tags", ()
     event.exception?.values?.[0]?.value,
     "Failed query: select ?",
   );
+});
+
+it("policy redacts the remainder when a backslash makes a string literal's extent ambiguous", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: String.raw`Failed query: select 'safe\' customer@example.test' from "orders"`,
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  const value = event.exception?.values?.[0]?.value ?? "";
+  assertEquals(value, "Failed query: select ?");
+  assertEquals(value.includes("customer@example.test"), false);
+});
+
+it("policy keeps parsing when an even backslash run leaves the literal unambiguous", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: String.raw`Failed query: select 'public\\' 'customer@example.test' from "orders"`,
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  const value = event.exception?.values?.[0]?.value ?? "";
+  assertEquals(value, 'Failed query: select ? ? from "orders"');
+  assertEquals(value.includes("customer@example.test"), false);
 });
 
 it("policy redacts dollar-quoted literals whose tag is longer than an identifier limit", () => {

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -393,6 +393,65 @@ it("policy redacts PostgreSQL radix integer literals", () => {
   );
 });
 
+it("policy redacts decimal integer separators without hiding SQL structure", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: \n  select 12_345_678, 0xDEAD_BEEF from orders_12_345 where "id" = $1',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select ?, ? from orders_12_345 where "id" = $1',
+  );
+});
+
+it("policy redacts fractional digit separators", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: 'Failed query: \n  select 12_345.67_89, .12_34 from "orders" where "id" = $1',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select ?, ? from "orders" where "id" = $1',
+  );
+});
+
+it("policy redacts exponent digit separators", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: \n  select 6.02e2_3, 1_2.3_4e+5_6, .5e-1_0 from "orders" where "id" = $1',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select ?, ?, ? from "orders" where "id" = $1',
+  );
+});
+
 it("policy redacts line comments from Failed query titles", () => {
   const event = prepareSentryEvent(
     {

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -176,6 +176,104 @@ it("policy redacts application error attribute keys and credential-shaped values
   );
 });
 
+it("policy groups pgbouncer connection PostgresErrors by stable db-error fingerprint", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "PostgresError",
+          value: "pgbouncer cannot connect to server (server_login_retry)",
+        }],
+      },
+      fingerprint: ["POST /api/graphql"],
+    },
+    "veryfront-api",
+  );
+
+  assertEquals(event.fingerprint, ["veryfront-db-error", "server_login_retry"]);
+});
+
+it("policy groups each pgbouncer connection code into its own db-error issue", () => {
+  for (
+    const code of ["server_login_retry", "query_wait_timeout", "CONNECTION_CLOSED"]
+  ) {
+    const event = prepareSentryEvent(
+      {
+        exception: {
+          values: [{ type: "PostgresError", value: `write ${code} db.internal:6432` }],
+        },
+      },
+      "veryfront-api",
+    );
+
+    assertEquals(event.fingerprint, ["veryfront-db-error", code]);
+  }
+});
+
+it("policy keeps the default fingerprint for non-connection PostgresErrors and other errors", () => {
+  const postgresEvent = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "PostgresError",
+          value: "duplicate key value violates unique constraint",
+        }],
+      },
+    },
+    "veryfront-api",
+  );
+  assertEquals(postgresEvent.fingerprint, ["veryfront-api", "{{ default }}"]);
+
+  const unrelatedEvent = prepareSentryEvent(
+    {
+      exception: {
+        values: [{ type: "TypeError", value: "server_login_retry is not a function" }],
+      },
+    },
+    "veryfront-api",
+  );
+  assertEquals(unrelatedEvent.fingerprint, ["veryfront-api", "{{ default }}"]);
+});
+
+it("policy collapses leading sql whitespace in Failed query titles", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: 'Failed query: \n  select "id", "email"\n  from "users"',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "id", "email" from "users"',
+  );
+});
+
+it("policy caps collapsed Failed query values and leaves other values untouched", () => {
+  const longSql = `\n  select ${"c, ".repeat(200)}from t`;
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [
+          { type: "DrizzleQueryError", value: `Failed query: ${longSql}` },
+          { type: "Error", value: "  leading spaces stay untouched" },
+        ],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  const collapsed = event.exception?.values?.[0]?.value ?? "";
+  assertEquals(collapsed.startsWith("Failed query: select c, c,"), true);
+  assertEquals(collapsed.length <= "Failed query: ".length + 201, true);
+  assertEquals(event.exception?.values?.[1]?.value, "  leading spaces stay untouched");
+});
+
 it("policy redacts credentials from custom-host DSNs", () => {
   const event = prepareSentryEvent(
     {

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -582,6 +582,25 @@ it("policy redacts unrecognized dollar-quoted SQL literal tags", () => {
   );
 });
 
+it("policy redacts dollar-quoted SQL tags containing Unicode whitespace", () => {
+  const tag = "\u00A0";
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: `Failed query: select $${tag}$customer@example.test$${tag}$ from "orders"`,
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  const value = event.exception?.values?.[0]?.value ?? "";
+  assertEquals(value, 'Failed query: select ? from "orders"');
+  assertEquals(value.includes("customer@example.test"), false);
+});
+
 it("policy redacts unterminated unrecognized dollar-quoted SQL literal tags", () => {
   const event = prepareSentryEvent(
     {

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -501,7 +501,7 @@ it("policy redacts quoted SQL literals from Failed query titles", () => {
   );
 });
 
-it("policy parses SQL backslash escapes only for escape string literals", () => {
+it("policy keeps SQL string boundaries around pairs of backslashes", () => {
   const event = prepareSentryEvent(
     {
       exception: {
@@ -519,6 +519,25 @@ it("policy parses SQL backslash escapes only for escape string literals", () => 
     event.exception?.values?.[0]?.value,
     'Failed query: select ? ?, ? from "orders"',
   );
+});
+
+it("policy redacts backslash-escaped ordinary SQL strings conservatively", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: String.raw`Failed query:
+  select 'safe\' private@example.test' from "orders"`,
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  const value = event.exception?.values?.[0]?.value ?? "";
+  assertEquals(value, 'Failed query: select ? from "orders"');
+  assertEquals(value.includes("private@example.test"), false);
 });
 
 it("policy redacts dollar-quoted and numeric SQL literals without hiding query structure", () => {
@@ -615,6 +634,25 @@ it("policy treats a dollar sign after an identifier character as part of the ide
   assertEquals(
     event.exception?.values?.[0]?.value,
     "Failed query: select col$tag$inner$tag$, other from t where id = $1",
+  );
+});
+
+it("policy treats a dollar sign after a non-Latin identifier character as part of it", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: "Failed query: \n  select 名$tag$inner$tag$, other from t where id = $1",
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    "Failed query: select 名$tag$inner$tag$, other from t where id = $1",
   );
 });
 

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -190,23 +190,24 @@ it("policy groups pgbouncer connection PostgresErrors by stable db-error fingerp
     "veryfront-api",
   );
 
-  assertEquals(event.fingerprint, ["veryfront-db-error", "server_login_retry"]);
+  assertEquals(event.fingerprint, ["veryfront-api", "veryfront-db-error", "server_login_retry"]);
 });
 
 it("policy groups each pgbouncer connection code into its own db-error issue", () => {
-  for (
-    const code of ["server_login_retry", "query_wait_timeout", "CONNECTION_CLOSED"]
-  ) {
+  for (const code of ["server_login_retry", "query_wait_timeout"]) {
     const event = prepareSentryEvent(
       {
         exception: {
-          values: [{ type: "PostgresError", value: `write ${code} db.example.test:6432` }],
+          values: [{
+            type: "PostgresError",
+            value: `pgbouncer cannot connect to server (${code})`,
+          }],
         },
       },
       "veryfront-api",
     );
 
-    assertEquals(event.fingerprint, ["veryfront-db-error", code]);
+    assertEquals(event.fingerprint, ["veryfront-api", "veryfront-db-error", code]);
   }
 });
 
@@ -241,7 +242,56 @@ it("policy groups client-side postgres.js connection closures reported as plain 
     "veryfront-api",
   );
 
-  assertEquals(event.fingerprint, ["veryfront-db-error", "CONNECTION_CLOSED"]);
+  assertEquals(event.fingerprint, ["veryfront-api", "veryfront-db-error", "CONNECTION_CLOSED"]);
+});
+
+it("policy groups every postgres.js client connection code into its own db-error issue", () => {
+  for (
+    const code of [
+      "CONNECTION_CLOSED",
+      "CONNECTION_DESTROYED",
+      "CONNECTION_ENDED",
+      "CONNECT_TIMEOUT",
+    ]
+  ) {
+    const event = prepareSentryEvent(
+      {
+        exception: {
+          values: [{ type: "Error", value: `write ${code} db.example.test:6432` }],
+        },
+        fingerprint: ["POST /api/graphql"],
+      },
+      "veryfront-api",
+    );
+
+    assertEquals(event.fingerprint, ["veryfront-api", "veryfront-db-error", code]);
+  }
+});
+
+it("policy ignores unix-socket postgres.js connection errors only when the code is unknown", () => {
+  const socketEvent = prepareSentryEvent(
+    {
+      exception: {
+        values: [{ type: "Error", value: "write CONNECT_TIMEOUT /var/run/postgresql" }],
+      },
+    },
+    "veryfront-api",
+  );
+  assertEquals(socketEvent.fingerprint, [
+    "veryfront-api",
+    "veryfront-db-error",
+    "CONNECT_TIMEOUT",
+  ]);
+
+  const unknownCodeEvent = prepareSentryEvent(
+    {
+      exception: {
+        values: [{ type: "Error", value: "write CONNECTION_PAUSED db.example.test:6432" }],
+      },
+    },
+    "veryfront-api",
+  );
+  assertEquals(unknownCodeEvent.fingerprint, ["veryfront-api", "{{ default }}"]);
 });
 
 it("policy leaves unrelated plain connection-closed errors on the default fingerprint", () => {
@@ -311,6 +361,85 @@ it("policy collapses leading sql whitespace in Failed query titles", () => {
   assertEquals(
     event.exception?.values?.[0]?.value,
     'Failed query: select "id", "email" from "users"',
+  );
+});
+
+it("policy normalizes single-line query builder Failed query values", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: select "id", "email" from "users" where "users"."email" = $1 limit $2\nparams: customer@example.test,500',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "id", "email" from "users" where "users"."email" = $1 limit $2',
+  );
+});
+
+it("policy redacts literals in single-line Failed query values", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: select "id" from "users" where "email" = \'customer@example.test\' limit 500\nparams: []',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "id" from "users" where "email" = ? limit ?',
+  );
+});
+
+it("policy caps single-line Failed query values", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: `Failed query: select ${"c, ".repeat(200)}from t\nparams: customer@example.test`,
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  const collapsed = event.exception?.values?.[0]?.value ?? "";
+  assertEquals(collapsed.startsWith("Failed query: select c, c,"), true);
+  assertEquals(collapsed.length <= "Failed query: ".length + 201, true);
+  assertEquals(collapsed.includes("params:"), false);
+});
+
+it("policy normalizes Failed query values whose sql starts on the prefix line", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: select "id" from "users"\n  where "email" = \'customer@example.test\'\nparams: []',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "id" from "users" where "email" = ?',
   );
 });
 
@@ -449,6 +578,62 @@ it("policy redacts unterminated unrecognized dollar-quoted SQL literal tags", ()
     event.exception?.values?.[0]?.value,
     "Failed query: select ?",
   );
+});
+
+it("policy keeps dollar signs inside identifiers from swallowing the rest of the query", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            "Failed query: \n  select col$a, 'customer@example.test' as e, other$b from t where id = $1",
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    "Failed query: select col$a, ? as e, other$b from t where id = $1",
+  );
+});
+
+it("policy keeps a bare dollar sign from swallowing the rest of the query", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: "Failed query: \n  select a, $ , 'customer@example.test', $1 from t",
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    "Failed query: select a, $ , ?, $1 from t",
+  );
+});
+
+it("policy redacts the remainder of a query with an unterminated quoted identifier", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            "Failed query: \n  select \"id from t where email = 'customer@example.test' and n = 42",
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(event.exception?.values?.[0]?.value, "Failed query: select ?");
 });
 
 it("policy redacts PostgreSQL radix integer literals", () => {

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -353,6 +353,46 @@ it("policy redacts dollar-quoted and numeric SQL literals without hiding query s
   );
 });
 
+it("policy redacts line comments from Failed query titles", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: \n  select "id" from "orders" -- customer@example.test\n  where "status" = \'ready\'',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "id" from "orders" ? where "status" = ?',
+  );
+});
+
+it("policy redacts block comments without treating quoted comment markers as comments", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: \n  select "/* public_identifier */", $$-- template@example.test$$, \'/* private note */\', $1 /* order ORDER-731 */ from "orders"',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "/* public_identifier */", ?, ?, $1 ? from "orders"',
+  );
+});
+
 it("policy caps collapsed Failed query values and leaves other values untouched", () => {
   const longSql = `\n  select ${"c, ".repeat(200)}from t`;
   const nonQueryError = "upstream select 'customer@example.test', 731 stays untouched";

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -210,6 +210,20 @@ it("policy groups each pgbouncer connection code into its own db-error issue", (
   }
 });
 
+it("policy groups client-side postgres.js connection closures reported as plain Errors", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{ type: "Error", value: "write CONNECTION_CLOSED db.example.test:6432" }],
+      },
+      fingerprint: ["POST /api/graphql"],
+    },
+    "veryfront-api",
+  );
+
+  assertEquals(event.fingerprint, ["veryfront-db-error", "CONNECTION_CLOSED"]);
+});
+
 it("policy keeps the default fingerprint for non-connection PostgresErrors and other errors", () => {
   const postgresEvent = prepareSentryEvent(
     {
@@ -233,6 +247,16 @@ it("policy keeps the default fingerprint for non-connection PostgresErrors and o
     "veryfront-api",
   );
   assertEquals(unrelatedEvent.fingerprint, ["veryfront-api", "{{ default }}"]);
+
+  const pgbouncerCodeOnPlainError = prepareSentryEvent(
+    {
+      exception: {
+        values: [{ type: "Error", value: "server_login_retry is not a client error" }],
+      },
+    },
+    "veryfront-api",
+  );
+  assertEquals(pgbouncerCodeOnPlainError.fingerprint, ["veryfront-api", "{{ default }}"]);
 });
 
 it("policy collapses leading sql whitespace in Failed query titles", () => {

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -210,6 +210,26 @@ it("policy groups each pgbouncer connection code into its own db-error issue", (
   }
 });
 
+it("policy does not treat connection code names in ordinary messages as outage markers", () => {
+  for (
+    const value of [
+      'column "query_wait_timeout" does not exist',
+      "column (query_wait_timeout) does not exist",
+    ]
+  ) {
+    const event = prepareSentryEvent(
+      {
+        exception: {
+          values: [{ type: "PostgresError", value }],
+        },
+      },
+      "veryfront-api",
+    );
+
+    assertEquals(event.fingerprint, ["veryfront-api", "{{ default }}"]);
+  }
+});
+
 it("policy groups client-side postgres.js connection closures reported as plain Errors", () => {
   const event = prepareSentryEvent(
     {
@@ -350,6 +370,26 @@ it("policy redacts dollar-quoted and numeric SQL literals without hiding query s
   assertEquals(
     event.exception?.values?.[0]?.value,
     'Failed query: select "template2", "2024", ?, ?, ?, ?, ? from "orders2" where "id" = $1',
+  );
+});
+
+it("policy redacts PostgreSQL radix integer literals", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: \n  select 0xDEADBEEF, 0o731, 0b101101 from "orders0x2" where "id" = $1',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select ?, ?, ? from "orders0x2" where "id" = $1',
   );
 });
 

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -360,7 +360,7 @@ it("policy redacts dollar-quoted and numeric SQL literals without hiding query s
         values: [{
           type: "DrizzleQueryError",
           value:
-            'Failed query: \n  select "template2", "2024", $$customer@example.test$$, $order$ORDER-731$order$, $é$customer@example.test$é$, 731, 18.75, 6.02e23 from "orders2" where "id" = $1',
+            'Failed query: \n  select "template2", "2024", $$customer@example.test$$, $order$ORDER-731$order$, $é$customer@example.test$é$, $𐐀$ORDER-742$𐐀$, 731, 18.75, 6.02e23 from "orders2" where "id" = $1',
         }],
       },
     },
@@ -369,7 +369,7 @@ it("policy redacts dollar-quoted and numeric SQL literals without hiding query s
 
   assertEquals(
     event.exception?.values?.[0]?.value,
-    'Failed query: select "template2", "2024", ?, ?, ?, ?, ?, ? from "orders2" where "id" = $1',
+    'Failed query: select "template2", "2024", ?, ?, ?, ?, ?, ?, ? from "orders2" where "id" = $1',
   );
 });
 

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -314,6 +314,25 @@ it("policy collapses leading sql whitespace in Failed query titles", () => {
   );
 });
 
+it("policy collapses Failed query titles before applying the title limit", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: `Failed query: \n${" ".repeat(220)}select "id" from "users"`,
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "id" from "users"',
+  );
+});
+
 it("policy excludes query parameters from Failed query titles", () => {
   const event = prepareSentryEvent(
     {
@@ -350,6 +369,26 @@ it("policy redacts quoted SQL literals from Failed query titles", () => {
   assertEquals(
     event.exception?.values?.[0]?.value,
     'Failed query: select "id" from "orders" where "email" = ? and "note" = ?',
+  );
+});
+
+it("policy parses SQL backslash escapes only for escape string literals", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            "Failed query: \n  select 'public\\\\' 'customer@example.test', E'private\\'still private' from \"orders\"",
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select ? ?, ? from "orders"',
   );
 });
 
@@ -390,6 +429,25 @@ it("policy redacts unrecognized dollar-quoted SQL literal tags", () => {
   assertEquals(
     event.exception?.values?.[0]?.value,
     'Failed query: select ?, $1 from "orders" where "id" = $2',
+  );
+});
+
+it("policy redacts unterminated unrecognized dollar-quoted SQL literal tags", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: 'Failed query: \n  select $😀$customer@example.test from "orders" where "id" = $1',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    "Failed query: select ?",
   );
 });
 

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -580,6 +580,63 @@ it("policy redacts unterminated unrecognized dollar-quoted SQL literal tags", ()
   );
 });
 
+it("policy redacts dollar-quoted literals whose tag is longer than an identifier limit", () => {
+  const tag = "\u{1F600}".repeat(64);
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: `Failed query: \n  select $${tag}$customer@example.test$${tag}$ from "orders"`,
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  const value = event.exception?.values?.[0]?.value ?? "";
+  assertEquals(value, 'Failed query: select ? from "orders"');
+  assertEquals(value.includes("customer@example.test"), false);
+});
+
+it("policy treats a dollar sign after an identifier character as part of the identifier", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: "Failed query: \n  select col$tag$inner$tag$, other from t where id = $1",
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    "Failed query: select col$tag$inner$tag$, other from t where id = $1",
+  );
+});
+
+it("policy redacts both halves of adjacent dollar-quoted literals", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value:
+            'Failed query: \n  select $$first@example.test$$$$second@example.test$$ from "orders"',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  const value = event.exception?.values?.[0]?.value ?? "";
+  assertEquals(value, 'Failed query: select ?? from "orders"');
+  assertEquals(value.includes("@example.test"), false);
+});
+
 it("policy keeps dollar signs inside identifiers from swallowing the rest of the query", () => {
   const event = prepareSentryEvent(
     {

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -360,7 +360,7 @@ it("policy redacts dollar-quoted and numeric SQL literals without hiding query s
         values: [{
           type: "DrizzleQueryError",
           value:
-            'Failed query: \n  select "template2", "2024", $$customer@example.test$$, $order$ORDER-731$order$, 731, 18.75, 6.02e23 from "orders2" where "id" = $1',
+            'Failed query: \n  select "template2", "2024", $$customer@example.test$$, $order$ORDER-731$order$, $é$customer@example.test$é$, 731, 18.75, 6.02e23 from "orders2" where "id" = $1',
         }],
       },
     },
@@ -369,7 +369,7 @@ it("policy redacts dollar-quoted and numeric SQL literals without hiding query s
 
   assertEquals(
     event.exception?.values?.[0]?.value,
-    'Failed query: select "template2", "2024", ?, ?, ?, ?, ? from "orders2" where "id" = $1',
+    'Failed query: select "template2", "2024", ?, ?, ?, ?, ?, ? from "orders2" where "id" = $1',
   );
 });
 

--- a/extensions/ext-observability-sentry/src/policy.test.ts
+++ b/extensions/ext-observability-sentry/src/policy.test.ts
@@ -224,6 +224,22 @@ it("policy groups client-side postgres.js connection closures reported as plain 
   assertEquals(event.fingerprint, ["veryfront-db-error", "CONNECTION_CLOSED"]);
 });
 
+it("policy leaves unrelated plain connection-closed errors on the default fingerprint", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "Error",
+          value: "upstream request failed: CONNECTION_CLOSED",
+        }],
+      },
+    },
+    "veryfront-api",
+  );
+
+  assertEquals(event.fingerprint, ["veryfront-api", "{{ default }}"]);
+});
+
 it("policy keeps the default fingerprint for non-connection PostgresErrors and other errors", () => {
   const postgresEvent = prepareSentryEvent(
     {
@@ -275,6 +291,25 @@ it("policy collapses leading sql whitespace in Failed query titles", () => {
   assertEquals(
     event.exception?.values?.[0]?.value,
     'Failed query: select "id", "email" from "users"',
+  );
+});
+
+it("policy excludes query parameters from Failed query titles", () => {
+  const event = prepareSentryEvent(
+    {
+      exception: {
+        values: [{
+          type: "DrizzleQueryError",
+          value: 'Failed query: \n  select "id" from "users"\nparams: customer@example.test',
+        }],
+      },
+    },
+    "veryfront-studio",
+  );
+
+  assertEquals(
+    event.exception?.values?.[0]?.value,
+    'Failed query: select "id" from "users"',
   );
 });
 

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -241,10 +241,11 @@ function redactSqlLiteralsForTitle(query: string): string {
     }
 
     if (character === "'") {
-      // The event does not carry the server's `standard_conforming_strings`
-      // setting. Treat backslash escapes conservatively so a quote accepted as
-      // escaped by PostgreSQL cannot expose the rest of a sensitive literal.
-      index = findQuotedSqlTokenEnd(query, index, "'", { allowBackslashEscapes: true }).end;
+      // The event does not carry the server's `standard_conforming_strings` setting, and neither
+      // reading of a backslash is safe on its own: escaping exposes the next literal when the
+      // setting is on, not escaping exposes this one when it is off. Bail out on the ambiguous
+      // case instead of picking a side.
+      index = findQuotedSqlTokenEnd(query, index, "'", { bailOnAmbiguousBackslash: true }).end;
       redacted += "?";
       continue;
     }
@@ -333,7 +334,7 @@ function findQuotedSqlTokenEnd(
   query: string,
   start: number,
   quote: string,
-  options: { allowBackslashEscapes?: boolean } = {},
+  options: { allowBackslashEscapes?: boolean; bailOnAmbiguousBackslash?: boolean } = {},
 ): { end: number; terminated: boolean } {
   let index = start + 1;
   while (index < query.length) {
@@ -349,9 +350,21 @@ function findQuotedSqlTokenEnd(
       index += 2;
       continue;
     }
+    // An ordinary literal means different things on different servers: under
+    // `standard_conforming_strings = off` a backslash escapes the quote that follows it, so an odd
+    // run of backslashes here leaves the literal's extent genuinely ambiguous — the same bytes are
+    // one literal on one server and two on another. Guessing either way emits the other reading's
+    // contents verbatim, so stop and let the caller redact the remainder.
+    if (options.bailOnAmbiguousBackslash && hasOddTrailingBackslashRun(query, index)) break;
     return { end: index + 1, terminated: true };
   }
   return { end: query.length, terminated: false };
+}
+
+function hasOddTrailingBackslashRun(query: string, index: number): boolean {
+  let backslashes = 0;
+  while (index - backslashes - 1 >= 0 && query[index - backslashes - 1] === "\\") backslashes += 1;
+  return backslashes % 2 === 1;
 }
 
 export function redactSensitiveText(value: string): string {

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -185,12 +185,13 @@ export function normalizeFailedQueryValue(value: string): string {
   if (!/^\s*\n/.test(remainder)) return value;
   const paramsDelimiterIndex = remainder.indexOf(FAILED_QUERY_PARAMS_DELIMITER);
   const query = paramsDelimiterIndex === -1 ? remainder : remainder.slice(0, paramsDelimiterIndex);
-  const titleQuery = redactSqlLiteralsForTitle(query);
-  const head = titleQuery
-    .slice(0, FAILED_QUERY_HEAD_MAX_LENGTH)
+  const titleQuery = redactSqlLiteralsForTitle(query)
     .replace(/\s+/g, " ")
     .trim();
-  const truncated = titleQuery.trimEnd().length > FAILED_QUERY_HEAD_MAX_LENGTH;
+  const head = titleQuery
+    .slice(0, FAILED_QUERY_HEAD_MAX_LENGTH)
+    .trimEnd();
+  const truncated = titleQuery.length > FAILED_QUERY_HEAD_MAX_LENGTH;
   return `${FAILED_QUERY_PREFIX}${head}${truncated ? "…" : ""}`;
 }
 
@@ -200,6 +201,27 @@ function redactSqlLiteralsForTitle(query: string): string {
 
   while (index < query.length) {
     const character = query.charAt(index);
+
+    if (
+      (character === "E" || character === "e") &&
+      query[index + 1] === "'" &&
+      isSqlStringPrefixBoundary(query, index)
+    ) {
+      index = findQuotedSqlTokenEnd(query, index + 1, "'", { allowBackslashEscapes: true });
+      redacted += "?";
+      continue;
+    }
+
+    if (
+      (character === "U" || character === "u") &&
+      query[index + 1] === "&" &&
+      query[index + 2] === "'" &&
+      isSqlStringPrefixBoundary(query, index)
+    ) {
+      index = findQuotedSqlTokenEnd(query, index + 2, "'");
+      redacted += "?";
+      continue;
+    }
 
     if (character === '"') {
       const end = findQuotedSqlTokenEnd(query, index, '"');
@@ -284,13 +306,22 @@ function findDollarQuotedSqlTokenEnd(query: string, start: number): number | und
 
   const delimiter = query.slice(start, delimiterEnd + 1);
   const closingDelimiter = query.indexOf(delimiter, delimiterEnd + 1);
-  return closingDelimiter === -1 ? undefined : closingDelimiter + delimiter.length;
+  return closingDelimiter === -1 ? query.length : closingDelimiter + delimiter.length;
 }
 
-function findQuotedSqlTokenEnd(query: string, start: number, quote: string): number {
+function isSqlStringPrefixBoundary(query: string, start: number): boolean {
+  return !SQL_IDENTIFIER_CHAR_PATTERN.test(query[start - 1] ?? "");
+}
+
+function findQuotedSqlTokenEnd(
+  query: string,
+  start: number,
+  quote: string,
+  options: { allowBackslashEscapes?: boolean } = {},
+): number {
   let index = start + 1;
   while (index < query.length) {
-    if (quote === "'" && query[index] === "\\" && index + 1 < query.length) {
+    if (options.allowBackslashEscapes && query[index] === "\\" && index + 1 < query.length) {
       index += 2;
       continue;
     }

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -15,7 +15,8 @@ const FAILED_QUERY_PREFIX = "Failed query: ";
 const FAILED_QUERY_PARAMS_DELIMITER = "\nparams:";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
 const SQL_DOLLAR_QUOTE_START_PATTERN = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/;
-const SQL_NUMERIC_LITERAL_PATTERN = /^(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/;
+const SQL_NUMERIC_LITERAL_PATTERN =
+  /^(?:0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)/;
 const SQL_IDENTIFIER_CHAR_PATTERN = /[A-Za-z0-9_$]/;
 
 const SENTRY_TOKEN_PATTERN = /\bsntrys_[A-Za-z0-9_+/=-]+\b/g;
@@ -157,7 +158,15 @@ function detectDbConnectionErrorCode(event: SentryPolicyEvent): string | undefin
   for (const exceptionValue of event.exception?.values ?? []) {
     const message = exceptionValue.value ?? "";
     if (exceptionValue.type === "PostgresError") {
-      const code = DB_CONNECTION_ERROR_CODES.find((candidate) => message.includes(candidate));
+      const trimmedMessage = message.trimEnd();
+      const code = DB_CONNECTION_ERROR_CODES.find((candidate) => {
+        const writeMarker = `write ${candidate}`;
+        const afterWriteMarker = message.charAt(writeMarker.length);
+        return (
+          message.startsWith(writeMarker) &&
+          (afterWriteMarker === "" || /\s/.test(afterWriteMarker))
+        ) || trimmedMessage.endsWith(`(${candidate})`);
+      });
       if (code) return code;
     }
     if (

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -19,11 +19,17 @@ const FAILED_QUERY_PREFIX = "Failed query: ";
 const FAILED_QUERY_PARAMS_DELIMITER = "\nparams:";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
 const SQL_DOLLAR_QUOTE_START_PATTERN = /^\$(?:[_\p{ID_Start}][_\p{ID_Continue}]*)?\$/u;
-// A tag PostgreSQL itself would reject (an emoji tag, for example) is still treated as a literal
-// so its contents cannot reach the title, but it has to look like a tag: short, and free of
-// whitespace, quotes and further dollar signs. Without that shape check a `$` inside an ordinary
-// identifier such as `col$a` swallows the rest of the query.
-const SQL_UNRECOGNIZED_DOLLAR_QUOTE_START_PATTERN = /^\$[^\s'"$]{1,63}\$/u;
+// PostgreSQL's lexer accepts any high byte in a dollar-quote tag and imposes no length limit, so
+// tags outside ECMAScript `ID_Start` (an emoji tag, for example) are still treated as literals and
+// their contents cannot reach the title. The tag must nonetheless look like a tag — free of
+// whitespace, quotes and further dollar signs — because without that shape check a `$` inside an
+// ordinary identifier such as `col$a` swallows the rest of the query.
+const SQL_UNRECOGNIZED_DOLLAR_QUOTE_START_PATTERN = /^\$[^\s'"$]+\$/u;
+// A dollar quote cannot open straight after an identifier character: PostgreSQL prefers the longer
+// identifier match, so `col$tag$inner$tag$` is one identifier rather than `col` followed by a
+// literal. `$` is deliberately absent from this class so that adjacent literals such as
+// `$$a$$$$b$$` still parse as two dollar-quoted strings.
+const SQL_IDENTIFIER_BEFORE_DOLLAR_PATTERN = /[A-Za-z0-9_]/;
 const SQL_NUMERIC_LITERAL_PATTERN =
   /^(?:0[xX]_?[0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO]_?[0-7](?:_?[0-7])*|0[bB]_?[01](?:_?[01])*|(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)(?:[eE][+-]?\d(?:_?\d)*)?)/;
 const SQL_IDENTIFIER_CHAR_PATTERN = /[A-Za-z0-9_$]/;
@@ -240,7 +246,10 @@ function redactSqlLiteralsForTitle(query: string): string {
       continue;
     }
 
-    if (character === "$") {
+    if (
+      character === "$" &&
+      !SQL_IDENTIFIER_BEFORE_DOLLAR_PATTERN.test(query[index - 1] ?? "")
+    ) {
       const dollarQuotedEnd = findDollarQuotedSqlTokenEnd(query, index);
       if (dollarQuotedEnd !== undefined) {
         index = dollarQuotedEnd;

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -14,6 +14,9 @@ const POSTGRES_JS_CONNECTION_CLOSED_PATTERN = /^write CONNECTION_CLOSED(?:\s|$)/
 const FAILED_QUERY_PREFIX = "Failed query: ";
 const FAILED_QUERY_PARAMS_DELIMITER = "\nparams:";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
+const SQL_DOLLAR_QUOTE_START_PATTERN = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/;
+const SQL_NUMERIC_LITERAL_PATTERN = /^(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/;
+const SQL_IDENTIFIER_CHAR_PATTERN = /[A-Za-z0-9_$]/;
 
 const SENTRY_TOKEN_PATTERN = /\bsntrys_[A-Za-z0-9_+/=-]+\b/g;
 const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi;
@@ -173,12 +176,84 @@ export function normalizeFailedQueryValue(value: string): string {
   if (!/^\s*\n/.test(remainder)) return value;
   const paramsDelimiterIndex = remainder.indexOf(FAILED_QUERY_PARAMS_DELIMITER);
   const query = paramsDelimiterIndex === -1 ? remainder : remainder.slice(0, paramsDelimiterIndex);
-  const head = query
+  const titleQuery = redactSqlLiteralsForTitle(query);
+  const head = titleQuery
     .slice(0, FAILED_QUERY_HEAD_MAX_LENGTH)
     .replace(/\s+/g, " ")
     .trim();
-  const truncated = query.trimEnd().length > FAILED_QUERY_HEAD_MAX_LENGTH;
+  const truncated = titleQuery.trimEnd().length > FAILED_QUERY_HEAD_MAX_LENGTH;
   return `${FAILED_QUERY_PREFIX}${head}${truncated ? "…" : ""}`;
+}
+
+function redactSqlLiteralsForTitle(query: string): string {
+  let redacted = "";
+  let index = 0;
+
+  while (index < query.length) {
+    const character = query.charAt(index);
+
+    if (character === '"') {
+      const end = findQuotedSqlTokenEnd(query, index, '"');
+      redacted += query.slice(index, end);
+      index = end;
+      continue;
+    }
+
+    if (character === "'") {
+      index = findQuotedSqlTokenEnd(query, index, "'");
+      redacted += "?";
+      continue;
+    }
+
+    if (character === "$") {
+      const delimiter = query.slice(index).match(SQL_DOLLAR_QUOTE_START_PATTERN)?.[0];
+      if (delimiter) {
+        const contentStart = index + delimiter.length;
+        const closingDelimiter = query.indexOf(delimiter, contentStart);
+        index = closingDelimiter === -1 ? query.length : closingDelimiter + delimiter.length;
+        redacted += "?";
+        continue;
+      }
+    }
+
+    const canStartNumber = /[0-9]/.test(character) ||
+      (character === "." && /[0-9]/.test(query[index + 1] ?? ""));
+    const previousCharacter = query[index - 1] ?? "";
+    if (canStartNumber && !SQL_IDENTIFIER_CHAR_PATTERN.test(previousCharacter)) {
+      const literal = query.slice(index).match(SQL_NUMERIC_LITERAL_PATTERN)?.[0];
+      const nextCharacter = literal ? query[index + literal.length] ?? "" : "";
+      if (literal && !SQL_IDENTIFIER_CHAR_PATTERN.test(nextCharacter)) {
+        redacted += "?";
+        index += literal.length;
+        continue;
+      }
+    }
+
+    redacted += character;
+    index += 1;
+  }
+
+  return redacted;
+}
+
+function findQuotedSqlTokenEnd(query: string, start: number, quote: string): number {
+  let index = start + 1;
+  while (index < query.length) {
+    if (quote === "'" && query[index] === "\\" && index + 1 < query.length) {
+      index += 2;
+      continue;
+    }
+    if (query[index] !== quote) {
+      index += 1;
+      continue;
+    }
+    if (query[index + 1] === quote) {
+      index += 2;
+      continue;
+    }
+    return index + 1;
+  }
+  return query.length;
 }
 
 export function redactSensitiveText(value: string): string {

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -137,7 +137,7 @@ export function prepareSentryEvent<TEvent extends SentryPolicyEvent>(
   }
   for (const value of event.exception?.values ?? []) {
     if (value.value) {
-      value.value = redactSensitiveText(normalizeFailedQueryValue(value.value));
+      value.value = normalizeFailedQueryValue(redactSensitiveText(value.value));
     }
     for (const frame of value.stacktrace?.frames ?? []) {
       if (frame.filename) frame.filename = sanitizeStackFramePath(frame.filename);

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -10,8 +10,9 @@ const DB_CONNECTION_ERROR_CODES = [
   "query_wait_timeout",
   "CONNECTION_CLOSED",
 ] as const;
-const CLIENT_DB_CONNECTION_ERROR_CODES = ["CONNECTION_CLOSED"] as const;
+const POSTGRES_JS_CONNECTION_CLOSED_PATTERN = /^write CONNECTION_CLOSED(?:\s|$)/;
 const FAILED_QUERY_PREFIX = "Failed query: ";
+const FAILED_QUERY_PARAMS_DELIMITER = "\nparams:";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
 
 const SENTRY_TOKEN_PATTERN = /\bsntrys_[A-Za-z0-9_+/=-]+\b/g;
@@ -152,13 +153,16 @@ export function prepareSentryEvent<TEvent extends SentryPolicyEvent>(
 function detectDbConnectionErrorCode(event: SentryPolicyEvent): string | undefined {
   for (const exceptionValue of event.exception?.values ?? []) {
     const message = exceptionValue.value ?? "";
-    const candidates = exceptionValue.type === "PostgresError"
-      ? DB_CONNECTION_ERROR_CODES
-      : exceptionValue.type === "Error"
-      ? CLIENT_DB_CONNECTION_ERROR_CODES
-      : [];
-    const code = candidates.find((candidate) => message.includes(candidate));
-    if (code) return code;
+    if (exceptionValue.type === "PostgresError") {
+      const code = DB_CONNECTION_ERROR_CODES.find((candidate) => message.includes(candidate));
+      if (code) return code;
+    }
+    if (
+      exceptionValue.type === "Error" &&
+      POSTGRES_JS_CONNECTION_CLOSED_PATTERN.test(message)
+    ) {
+      return "CONNECTION_CLOSED";
+    }
   }
   return undefined;
 }
@@ -167,11 +171,13 @@ export function normalizeFailedQueryValue(value: string): string {
   if (!value.startsWith(FAILED_QUERY_PREFIX.trimEnd())) return value;
   const remainder = value.slice(FAILED_QUERY_PREFIX.trimEnd().length);
   if (!/^\s*\n/.test(remainder)) return value;
-  const head = remainder
+  const paramsDelimiterIndex = remainder.indexOf(FAILED_QUERY_PARAMS_DELIMITER);
+  const query = paramsDelimiterIndex === -1 ? remainder : remainder.slice(0, paramsDelimiterIndex);
+  const head = query
     .slice(0, FAILED_QUERY_HEAD_MAX_LENGTH)
     .replace(/\s+/g, " ")
     .trim();
-  const truncated = remainder.trimEnd().length > FAILED_QUERY_HEAD_MAX_LENGTH;
+  const truncated = query.trimEnd().length > FAILED_QUERY_HEAD_MAX_LENGTH;
   return `${FAILED_QUERY_PREFIX}${head}${truncated ? "…" : ""}`;
 }
 

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -21,10 +21,12 @@ const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
 const SQL_DOLLAR_QUOTE_START_PATTERN = /^\$(?:[_\p{ID_Start}][_\p{ID_Continue}]*)?\$/u;
 // PostgreSQL's lexer accepts any high byte in a dollar-quote tag and imposes no length limit, so
 // tags outside ECMAScript `ID_Start` (an emoji tag, for example) are still treated as literals and
-// their contents cannot reach the title. The tag must nonetheless look like a tag — free of
-// whitespace, quotes and further dollar signs — because without that shape check a `$` inside an
-// ordinary identifier such as `col$a` swallows the rest of the query.
-const SQL_UNRECOGNIZED_DOLLAR_QUOTE_START_PATTERN = /^\$[^\s'"$]+\$/u;
+// their contents cannot reach the title. The tag must nonetheless look like a tag: free of
+// PostgreSQL lexer whitespace, quotes and further dollar signs. PostgreSQL lexer whitespace is
+// ASCII-only, so a high byte that ECMAScript classifies as whitespace remains a legal tag byte.
+// Without the shape check, a `$` inside an ordinary identifier such as `col$a` swallows the rest
+// of the query.
+const SQL_UNRECOGNIZED_DOLLAR_QUOTE_START_PATTERN = /^\$[^ \t\n\r\f\v'"$]+\$/u;
 // A dollar quote cannot open straight after an identifier character: PostgreSQL prefers the longer
 // identifier match, so `col$tag$inner$tag$` is one identifier rather than `col` followed by a
 // literal. `$` is deliberately absent from this class so that adjacent literals such as

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -5,16 +5,25 @@ import type {
 export const DEFAULT_FINGERPRINT = "{{ default }}";
 
 const DB_ERROR_FINGERPRINT = "veryfront-db-error";
-const DB_CONNECTION_ERROR_CODES = [
+// pgbouncer reports these through the wire protocol, so postgres.js surfaces them as a
+// PostgresError whose message ends with "(<code>)".
+const PGBOUNCER_CONNECTION_ERROR_CODES = [
   "server_login_retry",
   "query_wait_timeout",
-  "CONNECTION_CLOSED",
 ] as const;
-const POSTGRES_JS_CONNECTION_CLOSED_PATTERN = /^write CONNECTION_CLOSED(?:\s|$)/;
+// postgres.js `Errors.connection()` builds a plain Error with the message
+// `write <CODE> <host>:<port>` for every client-side connection failure.
+const POSTGRES_JS_CONNECTION_ERROR_PATTERN =
+  /^write (CONNECTION_CLOSED|CONNECTION_DESTROYED|CONNECTION_ENDED|CONNECT_TIMEOUT)(?:\s|$)/;
 const FAILED_QUERY_PREFIX = "Failed query: ";
 const FAILED_QUERY_PARAMS_DELIMITER = "\nparams:";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
 const SQL_DOLLAR_QUOTE_START_PATTERN = /^\$(?:[_\p{ID_Start}][_\p{ID_Continue}]*)?\$/u;
+// A tag PostgreSQL itself would reject (an emoji tag, for example) is still treated as a literal
+// so its contents cannot reach the title, but it has to look like a tag: short, and free of
+// whitespace, quotes and further dollar signs. Without that shape check a `$` inside an ordinary
+// identifier such as `col$a` swallows the rest of the query.
+const SQL_UNRECOGNIZED_DOLLAR_QUOTE_START_PATTERN = /^\$[^\s'"$]{1,63}\$/u;
 const SQL_NUMERIC_LITERAL_PATTERN =
   /^(?:0[xX]_?[0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO]_?[0-7](?:_?[0-7])*|0[bB]_?[01](?:_?[01])*|(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)(?:[eE][+-]?\d(?:_?\d)*)?)/;
 const SQL_IDENTIFIER_CHAR_PATTERN = /[A-Za-z0-9_$]/;
@@ -130,7 +139,7 @@ export function prepareSentryEvent<TEvent extends SentryPolicyEvent>(
   };
   const dbConnectionErrorCode = detectDbConnectionErrorCode(event);
   event.fingerprint = dbConnectionErrorCode
-    ? [DB_ERROR_FINGERPRINT, dbConnectionErrorCode]
+    ? [serviceName, DB_ERROR_FINGERPRINT, dbConnectionErrorCode]
     : [serviceName, ...(event.fingerprint ?? [DEFAULT_FINGERPRINT])];
 
   delete event.breadcrumbs;
@@ -159,30 +168,22 @@ function detectDbConnectionErrorCode(event: SentryPolicyEvent): string | undefin
     const message = exceptionValue.value ?? "";
     if (exceptionValue.type === "PostgresError") {
       const trimmedMessage = message.trimEnd();
-      const code = DB_CONNECTION_ERROR_CODES.find((candidate) => {
-        const writeMarker = `write ${candidate}`;
-        const afterWriteMarker = message.charAt(writeMarker.length);
-        return (
-          message.startsWith(writeMarker) &&
-          (afterWriteMarker === "" || /\s/.test(afterWriteMarker))
-        ) || trimmedMessage.endsWith(`(${candidate})`);
-      });
+      const code = PGBOUNCER_CONNECTION_ERROR_CODES.find((candidate) =>
+        trimmedMessage.endsWith(`(${candidate})`)
+      );
       if (code) return code;
     }
-    if (
-      exceptionValue.type === "Error" &&
-      POSTGRES_JS_CONNECTION_CLOSED_PATTERN.test(message)
-    ) {
-      return "CONNECTION_CLOSED";
+    if (exceptionValue.type === "Error") {
+      const code = POSTGRES_JS_CONNECTION_ERROR_PATTERN.exec(message)?.[1];
+      if (code) return code;
     }
   }
   return undefined;
 }
 
-export function normalizeFailedQueryValue(value: string): string {
+function normalizeFailedQueryValue(value: string): string {
   if (!value.startsWith(FAILED_QUERY_PREFIX.trimEnd())) return value;
   const remainder = value.slice(FAILED_QUERY_PREFIX.trimEnd().length);
-  if (!/^\s*\n/.test(remainder)) return value;
   const paramsDelimiterIndex = remainder.indexOf(FAILED_QUERY_PARAMS_DELIMITER);
   const query = paramsDelimiterIndex === -1 ? remainder : remainder.slice(0, paramsDelimiterIndex);
   const titleQuery = redactSqlLiteralsForTitle(query)
@@ -207,7 +208,7 @@ function redactSqlLiteralsForTitle(query: string): string {
       query[index + 1] === "'" &&
       isSqlStringPrefixBoundary(query, index)
     ) {
-      index = findQuotedSqlTokenEnd(query, index + 1, "'", { allowBackslashEscapes: true });
+      index = findQuotedSqlTokenEnd(query, index + 1, "'", { allowBackslashEscapes: true }).end;
       redacted += "?";
       continue;
     }
@@ -218,20 +219,23 @@ function redactSqlLiteralsForTitle(query: string): string {
       query[index + 2] === "'" &&
       isSqlStringPrefixBoundary(query, index)
     ) {
-      index = findQuotedSqlTokenEnd(query, index + 2, "'");
+      index = findQuotedSqlTokenEnd(query, index + 2, "'").end;
       redacted += "?";
       continue;
     }
 
     if (character === '"') {
-      const end = findQuotedSqlTokenEnd(query, index, '"');
-      redacted += query.slice(index, end);
+      // Deliberate non-redaction: a double-quoted token is a schema identifier, not data, and
+      // keeping it verbatim is what makes titles group by query shape. An unterminated identifier
+      // is malformed SQL, so redact it rather than emit the rest of the query untouched.
+      const { end, terminated } = findQuotedSqlTokenEnd(query, index, '"');
+      redacted += terminated ? query.slice(index, end) : "?";
       index = end;
       continue;
     }
 
     if (character === "'") {
-      index = findQuotedSqlTokenEnd(query, index, "'");
+      index = findQuotedSqlTokenEnd(query, index, "'").end;
       redacted += "?";
       continue;
     }
@@ -301,11 +305,11 @@ function findDollarQuotedSqlTokenEnd(query: string, start: number): number | und
   }
 
   if (/[0-9]/.test(query[start + 1] ?? "")) return undefined;
-  const delimiterEnd = query.indexOf("$", start + 1);
-  if (delimiterEnd === -1) return undefined;
+  const delimiter = query.slice(start).match(SQL_UNRECOGNIZED_DOLLAR_QUOTE_START_PATTERN)?.[0];
+  if (!delimiter) return undefined;
 
-  const delimiter = query.slice(start, delimiterEnd + 1);
-  const closingDelimiter = query.indexOf(delimiter, delimiterEnd + 1);
+  const contentStart = start + delimiter.length;
+  const closingDelimiter = query.indexOf(delimiter, contentStart);
   return closingDelimiter === -1 ? query.length : closingDelimiter + delimiter.length;
 }
 
@@ -318,7 +322,7 @@ function findQuotedSqlTokenEnd(
   start: number,
   quote: string,
   options: { allowBackslashEscapes?: boolean } = {},
-): number {
+): { end: number; terminated: boolean } {
   let index = start + 1;
   while (index < query.length) {
     if (options.allowBackslashEscapes && query[index] === "\\" && index + 1 < query.length) {
@@ -333,9 +337,9 @@ function findQuotedSqlTokenEnd(
       index += 2;
       continue;
     }
-    return index + 1;
+    return { end: index + 1, terminated: true };
   }
-  return query.length;
+  return { end: query.length, terminated: false };
 }
 
 export function redactSensitiveText(value: string): string {

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -14,8 +14,7 @@ const POSTGRES_JS_CONNECTION_CLOSED_PATTERN = /^write CONNECTION_CLOSED(?:\s|$)/
 const FAILED_QUERY_PREFIX = "Failed query: ";
 const FAILED_QUERY_PARAMS_DELIMITER = "\nparams:";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
-const SQL_DOLLAR_QUOTE_START_PATTERN =
-  /^\$(?:[A-Za-z_\u0080-\uFFFF][A-Za-z0-9_\u0080-\uFFFF]*)?\$/u;
+const SQL_DOLLAR_QUOTE_START_PATTERN = /^\$(?:[_\p{ID_Start}][_\p{ID_Continue}]*)?\$/u;
 const SQL_NUMERIC_LITERAL_PATTERN =
   /^(?:0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)(?:[eE][+-]?\d(?:_?\d)*)?)/;
 const SQL_IDENTIFIER_CHAR_PATTERN = /[A-Za-z0-9_$]/;

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -216,6 +216,33 @@ function redactSqlLiteralsForTitle(query: string): string {
       }
     }
 
+    if (character === "-" && query[index + 1] === "-") {
+      index += 2;
+      while (index < query.length && query[index] !== "\n" && query[index] !== "\r") {
+        index += 1;
+      }
+      redacted += "?";
+      continue;
+    }
+
+    if (character === "/" && query[index + 1] === "*") {
+      let depth = 1;
+      index += 2;
+      while (index < query.length && depth > 0) {
+        if (query[index] === "/" && query[index + 1] === "*") {
+          depth += 1;
+          index += 2;
+        } else if (query[index] === "*" && query[index + 1] === "/") {
+          depth -= 1;
+          index += 2;
+        } else {
+          index += 1;
+        }
+      }
+      redacted += "?";
+      continue;
+    }
+
     const canStartNumber = /[0-9]/.test(character) ||
       (character === "." && /[0-9]/.test(query[index + 1] ?? ""));
     const previousCharacter = query[index - 1] ?? "";

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -16,7 +16,7 @@ const FAILED_QUERY_PARAMS_DELIMITER = "\nparams:";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
 const SQL_DOLLAR_QUOTE_START_PATTERN = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/;
 const SQL_NUMERIC_LITERAL_PATTERN =
-  /^(?:0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)/;
+  /^(?:0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)(?:[eE][+-]?\d(?:_?\d)*)?)/;
 const SQL_IDENTIFIER_CHAR_PATTERN = /[A-Za-z0-9_$]/;
 
 const SENTRY_TOKEN_PATTERN = /\bsntrys_[A-Za-z0-9_+/=-]+\b/g;

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -29,7 +29,7 @@ const SQL_UNRECOGNIZED_DOLLAR_QUOTE_START_PATTERN = /^\$[^\s'"$]+\$/u;
 // identifier match, so `col$tag$inner$tag$` is one identifier rather than `col` followed by a
 // literal. `$` is deliberately absent from this class so that adjacent literals such as
 // `$$a$$$$b$$` still parse as two dollar-quoted strings.
-const SQL_IDENTIFIER_BEFORE_DOLLAR_PATTERN = /[A-Za-z0-9_]/;
+const SQL_IDENTIFIER_BEFORE_DOLLAR_PATTERN = /[A-Za-z0-9_]|\P{ASCII}/u;
 const SQL_NUMERIC_LITERAL_PATTERN =
   /^(?:0[xX]_?[0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO]_?[0-7](?:_?[0-7])*|0[bB]_?[01](?:_?[01])*|(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)(?:[eE][+-]?\d(?:_?\d)*)?)/;
 const SQL_IDENTIFIER_CHAR_PATTERN = /[A-Za-z0-9_$]/;
@@ -241,7 +241,10 @@ function redactSqlLiteralsForTitle(query: string): string {
     }
 
     if (character === "'") {
-      index = findQuotedSqlTokenEnd(query, index, "'").end;
+      // The event does not carry the server's `standard_conforming_strings`
+      // setting. Treat backslash escapes conservatively so a quote accepted as
+      // escaped by PostgreSQL cannot expose the rest of a sensitive literal.
+      index = findQuotedSqlTokenEnd(query, index, "'", { allowBackslashEscapes: true }).end;
       redacted += "?";
       continue;
     }

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -215,11 +215,9 @@ function redactSqlLiteralsForTitle(query: string): string {
     }
 
     if (character === "$") {
-      const delimiter = query.slice(index).match(SQL_DOLLAR_QUOTE_START_PATTERN)?.[0];
-      if (delimiter) {
-        const contentStart = index + delimiter.length;
-        const closingDelimiter = query.indexOf(delimiter, contentStart);
-        index = closingDelimiter === -1 ? query.length : closingDelimiter + delimiter.length;
+      const dollarQuotedEnd = findDollarQuotedSqlTokenEnd(query, index);
+      if (dollarQuotedEnd !== undefined) {
+        index = dollarQuotedEnd;
         redacted += "?";
         continue;
       }
@@ -270,6 +268,23 @@ function redactSqlLiteralsForTitle(query: string): string {
   }
 
   return redacted;
+}
+
+function findDollarQuotedSqlTokenEnd(query: string, start: number): number | undefined {
+  const recognizedDelimiter = query.slice(start).match(SQL_DOLLAR_QUOTE_START_PATTERN)?.[0];
+  if (recognizedDelimiter) {
+    const contentStart = start + recognizedDelimiter.length;
+    const closingDelimiter = query.indexOf(recognizedDelimiter, contentStart);
+    return closingDelimiter === -1 ? query.length : closingDelimiter + recognizedDelimiter.length;
+  }
+
+  if (/[0-9]/.test(query[start + 1] ?? "")) return undefined;
+  const delimiterEnd = query.indexOf("$", start + 1);
+  if (delimiterEnd === -1) return undefined;
+
+  const delimiter = query.slice(start, delimiterEnd + 1);
+  const closingDelimiter = query.indexOf(delimiter, delimiterEnd + 1);
+  return closingDelimiter === -1 ? undefined : closingDelimiter + delimiter.length;
 }
 
 function findQuotedSqlTokenEnd(query: string, start: number, quote: string): number {

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -10,6 +10,7 @@ const DB_CONNECTION_ERROR_CODES = [
   "query_wait_timeout",
   "CONNECTION_CLOSED",
 ] as const;
+const CLIENT_DB_CONNECTION_ERROR_CODES = ["CONNECTION_CLOSED"] as const;
 const FAILED_QUERY_PREFIX = "Failed query: ";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
 
@@ -150,9 +151,13 @@ export function prepareSentryEvent<TEvent extends SentryPolicyEvent>(
 
 function detectDbConnectionErrorCode(event: SentryPolicyEvent): string | undefined {
   for (const exceptionValue of event.exception?.values ?? []) {
-    if (exceptionValue.type !== "PostgresError") continue;
     const message = exceptionValue.value ?? "";
-    const code = DB_CONNECTION_ERROR_CODES.find((candidate) => message.includes(candidate));
+    const candidates = exceptionValue.type === "PostgresError"
+      ? DB_CONNECTION_ERROR_CODES
+      : exceptionValue.type === "Error"
+      ? CLIENT_DB_CONNECTION_ERROR_CODES
+      : [];
+    const code = candidates.find((candidate) => message.includes(candidate));
     if (code) return code;
   }
   return undefined;

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -16,7 +16,7 @@ const FAILED_QUERY_PARAMS_DELIMITER = "\nparams:";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
 const SQL_DOLLAR_QUOTE_START_PATTERN = /^\$(?:[_\p{ID_Start}][_\p{ID_Continue}]*)?\$/u;
 const SQL_NUMERIC_LITERAL_PATTERN =
-  /^(?:0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)(?:[eE][+-]?\d(?:_?\d)*)?)/;
+  /^(?:0[xX]_?[0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO]_?[0-7](?:_?[0-7])*|0[bB]_?[01](?:_?[01])*|(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)(?:[eE][+-]?\d(?:_?\d)*)?)/;
 const SQL_IDENTIFIER_CHAR_PATTERN = /[A-Za-z0-9_$]/;
 
 const SENTRY_TOKEN_PATTERN = /\bsntrys_[A-Za-z0-9_+/=-]+\b/g;

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -4,6 +4,15 @@ import type {
 
 export const DEFAULT_FINGERPRINT = "{{ default }}";
 
+const DB_ERROR_FINGERPRINT = "veryfront-db-error";
+const DB_CONNECTION_ERROR_CODES = [
+  "server_login_retry",
+  "query_wait_timeout",
+  "CONNECTION_CLOSED",
+] as const;
+const FAILED_QUERY_PREFIX = "Failed query: ";
+const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
+
 const SENTRY_TOKEN_PATTERN = /\bsntrys_[A-Za-z0-9_+/=-]+\b/g;
 const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi;
 const JWT_PATTERN = /\b[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b/g;
@@ -29,6 +38,7 @@ export type SentryPolicyEvent = {
   breadcrumbs?: unknown;
   exception?: {
     values?: Array<{
+      type?: string;
       value?: string;
       stacktrace?: {
         frames?: Array<{
@@ -112,7 +122,10 @@ export function prepareSentryEvent<TEvent extends SentryPolicyEvent>(
     ...event.tags,
     "service.name": serviceName,
   };
-  event.fingerprint = [serviceName, ...(event.fingerprint ?? [DEFAULT_FINGERPRINT])];
+  const dbConnectionErrorCode = detectDbConnectionErrorCode(event);
+  event.fingerprint = dbConnectionErrorCode
+    ? [DB_ERROR_FINGERPRINT, dbConnectionErrorCode]
+    : [serviceName, ...(event.fingerprint ?? [DEFAULT_FINGERPRINT])];
 
   delete event.breadcrumbs;
   delete event.request;
@@ -123,7 +136,9 @@ export function prepareSentryEvent<TEvent extends SentryPolicyEvent>(
     event.logentry.message = redactSensitiveText(event.logentry.message);
   }
   for (const value of event.exception?.values ?? []) {
-    if (value.value) value.value = redactSensitiveText(value.value);
+    if (value.value) {
+      value.value = redactSensitiveText(normalizeFailedQueryValue(value.value));
+    }
     for (const frame of value.stacktrace?.frames ?? []) {
       if (frame.filename) frame.filename = sanitizeStackFramePath(frame.filename);
       if (frame.abs_path) frame.abs_path = sanitizeStackFramePath(frame.abs_path);
@@ -131,6 +146,28 @@ export function prepareSentryEvent<TEvent extends SentryPolicyEvent>(
   }
 
   return event;
+}
+
+function detectDbConnectionErrorCode(event: SentryPolicyEvent): string | undefined {
+  for (const exceptionValue of event.exception?.values ?? []) {
+    if (exceptionValue.type !== "PostgresError") continue;
+    const message = exceptionValue.value ?? "";
+    const code = DB_CONNECTION_ERROR_CODES.find((candidate) => message.includes(candidate));
+    if (code) return code;
+  }
+  return undefined;
+}
+
+export function normalizeFailedQueryValue(value: string): string {
+  if (!value.startsWith(FAILED_QUERY_PREFIX.trimEnd())) return value;
+  const remainder = value.slice(FAILED_QUERY_PREFIX.trimEnd().length);
+  if (!/^\s*\n/.test(remainder)) return value;
+  const head = remainder
+    .slice(0, FAILED_QUERY_HEAD_MAX_LENGTH)
+    .replace(/\s+/g, " ")
+    .trim();
+  const truncated = remainder.trimEnd().length > FAILED_QUERY_HEAD_MAX_LENGTH;
+  return `${FAILED_QUERY_PREFIX}${head}${truncated ? "…" : ""}`;
 }
 
 export function redactSensitiveText(value: string): string {

--- a/extensions/ext-observability-sentry/src/policy.ts
+++ b/extensions/ext-observability-sentry/src/policy.ts
@@ -14,7 +14,8 @@ const POSTGRES_JS_CONNECTION_CLOSED_PATTERN = /^write CONNECTION_CLOSED(?:\s|$)/
 const FAILED_QUERY_PREFIX = "Failed query: ";
 const FAILED_QUERY_PARAMS_DELIMITER = "\nparams:";
 const FAILED_QUERY_HEAD_MAX_LENGTH = 200;
-const SQL_DOLLAR_QUOTE_START_PATTERN = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/;
+const SQL_DOLLAR_QUOTE_START_PATTERN =
+  /^\$(?:[A-Za-z_\u0080-\uFFFF][A-Za-z0-9_\u0080-\uFFFF]*)?\$/u;
 const SQL_NUMERIC_LITERAL_PATTERN =
   /^(?:0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)(?:[eE][+-]?\d(?:_?\d)*)?)/;
 const SQL_IDENTIFIER_CHAR_PATTERN = /[A-Za-z0-9_$]/;


### PR DESCRIPTION
Refs VERYFRONT-API-8, VERYFRONT-STUDIO-63.

## Problem
During DB/pgbouncer outages (Aug 5 19:02-20:19 UTC and Aug 12), two Sentry-reporting artifacts made one incident look like many unrelated issues:
1. PostgresError events fingerprint by a spurious, scope-inherited transaction, splitting a single pooler outage across issues titled with random routes.
2. DrizzleQueryError messages are `Failed query: ${query}\nparams: ${params}`. Multi-line `` sql` `` templates open with a newline, so Sentry titles render as a blank `Failed query:`; single-line query-builder SQL renders the whole statement plus the `params:` section into the title.
3. postgres.js surfaces every client-side connection failure as a plain Error with a `write <CODE> <host>:<port>` shape. Those errors should group with DB connection noise without broadening server pgbouncer code matching.

## Fix
1. PostgresError values whose message ends with a pgbouncer connection code (`(server_login_retry)`, `(query_wait_timeout)`) get the stable fingerprint `[<service>, "veryfront-db-error", <code>]`. Ordinary errors that only quote a code name retain their normal service fingerprint.
2. Plain Error values get the database fingerprint when they match the postgres.js `Errors.connection()` message shape, for all four codes that function emits: `CONNECTION_CLOSED`, `CONNECTION_DESTROYED`, `CONNECTION_ENDED`, `CONNECT_TIMEOUT`. Unrelated errors containing those tokens keep their normal service fingerprint.
3. Failed-query values collapse SQL whitespace and cap the statement head at 200 characters, for both the newline-leading multi-line template shape and the single-line query-builder shape. A following `params:` section is removed before title construction so query parameters cannot enter the issue title.
4. Exception text is redacted before Failed-query normalization and truncation, so credential-shaped values crossing the cutoff cannot leave unredacted fragments.
5. Failed-query titles replace single-quoted (including escaped), dollar-quoted, decimal or exponent numeric (including digit separators), and PostgreSQL radix integer literals with `?`. Double-quoted identifiers and `$1` bind parameters remain legible for useful issue grouping.
6. Failed-query titles replace line and block comments with `?` after quoted-token recognition, so customer context in comments cannot enter issue titles while quoted identifiers, strings, dollar strings, and bind parameters retain their existing treatment.

## Fingerprint shape: service attribution is kept
DB-connection events fingerprint as `[<service>, "veryfront-db-error", <code>]`, not `["veryfront-db-error", <code>]`. Every other event in this file leads with the service name, and Sentry issue ownership, alert routing, and team assignment are all per-service - collapsing an api outage and a renderer outage into a single issue would hand one team another team's events. The fragmentation this PR exists to fix is per-route (dozens of issues per service), and that is fully resolved by the shared `veryfront-db-error` element regardless of the leading service name. The extra collapse across services is a much smaller win and is available at query time via the `service.name` tag.

## SQL lexer bounds
- The unrecognized dollar-quote fallback requires a tag-shaped delimiter with no whitespace, quotes, or further `$`, but imposes no length cap because PostgreSQL does not impose one. A delimiter-shaped `$` is opened only at a token boundary, so dollar signs after ASCII or non-Latin identifier characters stay part of the identifier. `$` itself remains a boundary so adjacent dollar-quoted literals are both redacted.
- An unterminated double-quoted identifier now emits `?` rather than the remainder of the query verbatim. Terminated double-quoted identifiers are still preserved on purpose - they are schema, not data, and redacting them would destroy grouping. That intent is now recorded in a source comment.

## Testing
Red-green regressions cover pgbouncer PostgresError grouping, quoted and mid-message code-name false positives, all four postgres.js plain-Error connection codes plus an unknown-code negative, an unrelated plain `CONNECTION_CLOSED` error, parameter exclusion from Failed-query titles, single-line query-builder SQL normalization (fixture taken byte-for-byte from a real `drizzle-orm@0.45.1` `.toSQL()` message), same-line multi-line template normalization, the single-line 200-character cap, newline-leading SQL normalization, quoted and dollar-quoted SQL literals, `$`-in-identifier and bare-`$` lexer bounds, unterminated quoted identifiers, decimal integer, fractional, and exponent digit separators, PostgreSQL radix numeric literals, preserved identifiers and bind parameters, line and nested block comment redaction, quoted comment-marker precedence, long literal redaction, and untouched unrelated errors.

Verified at the current head with 56 focused Sentry extension tests (45 in `policy.test.ts`), targeted format, lint, typecheck, and diff checks. Red-green review regressions cover unlimited dollar tags, ASCII and non-Latin identifier boundaries, adjacent dollar literals, and conservative handling of backslash-escaped ordinary strings when the event does not expose the PostgreSQL compatibility setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry grouping for PostgreSQL and PostgreSQL.js connection failures.
  * Reduced misleading grouping for unrelated errors by preserving standard fingerprints.
  * Sanitized failed SQL details by removing sensitive parameters, literals, comments, and excess whitespace.
  * Limited captured query text to 200 characters for clearer error details.

* **Tests**
  * Added comprehensive coverage for database error detection, false positives, fingerprinting, and SQL sanitization edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->