### PR TITLE
fix(extensions): distinguish deferred availability

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -116,9 +116,12 @@ the same contract.
 These packages are known to `createBuiltinExtensions()`, but that does not make
 every contract an unconditional global default. Direct built-ins are provided
 by their owning source or service distribution. Deferred candidates load only
-when the matching feature selects their contract and the executing distribution
-contains the package. The standard `veryfront` npm/CLI package installs the
-baseline subset used by ordinary apps and local development.
+when the matching feature selects their contract. Deferred describes activation
+timing, not implementation availability. Most deferred implementations are
+package-backed and skip when the executing distribution does not contain their
+package. The MLflow exporter is root-bundled but remains deferred until selected.
+The standard `veryfront` npm/CLI package installs the baseline package-backed
+subset used by ordinary apps and local development.
 
 | Package                                      | Contract                      | Selection and availability                |
 | -------------------------------------------- | ----------------------------- | ----------------------------------------- |
@@ -137,7 +140,7 @@ baseline subset used by ordinary apps and local development.
 | `@veryfront/ext-observability-opentelemetry` | `TracingExporter`             | Deferred; install when OTLP is configured |
 | `@veryfront/ext-observability-opentelemetry` | `NodeTelemetryProvider`       | Built into the owning agent service       |
 | `@veryfront/ext-eval-report-http`            | Generic HTTP eval exporter    | Deferred; source/service distribution     |
-| `@veryfront/ext-eval-report-mlflow`          | MLflow eval exporter          | Deferred; source/service distribution     |
+| `@veryfront/ext-eval-report-mlflow`          | MLflow eval exporter          | Deferred; root-bundled                    |
 | `@veryfront/ext-llm-openai`                  | `LLMProvider:openai`          | Direct service/source built-in            |
 | `@veryfront/ext-llm-anthropic`               | `LLMProvider:anthropic`       | Direct service/source built-in            |
 | `@veryfront/ext-llm-google`                  | `LLMProvider:google`          | Direct service/source built-in            |

--- a/scripts/test/npm-install-smoke.sh
+++ b/scripts/test/npm-install-smoke.sh
@@ -76,7 +76,7 @@ npm init -y >/dev/null 2>&1
 npm pkg set type=module >/dev/null
 npm install --no-fund --no-audit --silent --ignore-scripts ./veryfront-[0-9]*.tgz ./veryfront-ext-bundler-esbuild-*.tgz ./veryfront-ext-content-mdx-*.tgz ./veryfront-ext-css-tailwind-*.tgz ./veryfront-ext-dev-ui-react-*.tgz ./veryfront-ext-node-websocket-ws-*.tgz ./veryfront-ext-parser-babel-*.tgz ./veryfront-ext-yaml-*.tgz
 
-echo "== 1. root install: CLI and parser extension run under Node"
+echo "== 1. root install: CLI and deferred parser extension run under Node"
 node node_modules/veryfront/bin/veryfront.js --version | grep -q "Veryfront CLI" ||
   fail "CLI --version failed on root install"
 node node_modules/veryfront/bin/veryfront.js schema --json >/dev/null ||
@@ -93,10 +93,11 @@ const m = await import('./node_modules/veryfront/esm/src/extensions/builtin-exte
 const { getDeferredExtensionState } = await import(
   './node_modules/veryfront/esm/src/extensions/deferred-extension.js'
 );
-const resolved = m.createOptionalBuiltinExtension({
+const resolved = m.createDeferredBuiltinExtension({
   name: 'ext-parser-babel',
   origin: 'veryfront/ext-parser-babel',
   sourceDirectory: 'ext-parser-babel',
+  availability: 'package',
   contracts: { provides: ['CodeParser'] },
   capabilities: [],
 });
@@ -120,7 +121,7 @@ const ast = await codeParser.parse({
 });
 if (ast?.type !== 'File') throw new Error('TSX parse failed');
 await extension.teardown?.();
-" || fail "root optional builtin did not register a working CodeParser"
+" || fail "root deferred builtin did not register a working CodeParser"
 
 echo "== 2. root install: transformers optional peer declared"
 node -e "

--- a/src/extensions/builtin-extensions.test.ts
+++ b/src/extensions/builtin-extensions.test.ts
@@ -7,11 +7,11 @@ import type { Extension } from "./types.ts";
 import type { SchemaValidator } from "./schema/index.ts";
 import {
   createBuiltinExtensions,
+  createDeferredBuiltinExtension,
   createEvalCliBuiltinExtensions,
-  createOptionalBuiltinExtension,
+  DEFERRED_BUILTIN_EXTENSIONS,
   ensureBuiltinEvalReportExporterRegistry,
   ensureBuiltinSchemaValidator,
-  OPTIONAL_BUILTIN_EXTENSIONS,
 } from "./builtin-extensions.ts";
 import { mergeExtensions } from "./discovery.ts";
 import { getDeferredExtensionState } from "./deferred-extension.ts";
@@ -98,7 +98,7 @@ describe("ensureBuiltinEvalReportExporterRegistry", () => {
 });
 
 describe("createBuiltinExtensions", () => {
-  async function loadOptionalBuiltin(name: string): Promise<Extension> {
+  async function loadDeferredBuiltin(name: string): Promise<Extension> {
     const candidate = createBuiltinExtensions().find((entry) => entry.extension.name === name);
     assert(candidate);
     const deferred = getDeferredExtensionState(candidate);
@@ -109,7 +109,7 @@ describe("createBuiltinExtensions", () => {
   }
 
   it("uses the loaded AuthProvider extension contract as runtime metadata", async () => {
-    const authExtension = await loadOptionalBuiltin("ext-auth-jwt");
+    const authExtension = await loadDeferredBuiltin("ext-auth-jwt");
 
     assertEquals(
       Object.hasOwn(authExtension.provides ?? {}, "AuthProvider") ||
@@ -119,7 +119,7 @@ describe("createBuiltinExtensions", () => {
   });
 
   it("uses the loaded OpenTelemetry contracts as runtime metadata", async () => {
-    const otelExtension = await loadOptionalBuiltin(
+    const otelExtension = await loadDeferredBuiltin(
       "ext-observability-opentelemetry",
     );
 
@@ -134,7 +134,7 @@ describe("createBuiltinExtensions", () => {
   });
 
   it("loads the generic HTTP eval exporter as a deferred builtin", async () => {
-    const httpExtension = await loadOptionalBuiltin("ext-eval-report-http");
+    const httpExtension = await loadDeferredBuiltin("ext-eval-report-http");
 
     assertEquals(
       httpExtension.contracts?.requires?.includes(EvalReportExporterRegistryName),
@@ -142,7 +142,7 @@ describe("createBuiltinExtensions", () => {
     );
   });
 
-  it("keeps optional candidates deferred until the loader selects them", () => {
+  it("keeps candidates deferred until the loader selects them", () => {
     const authCandidate = createBuiltinExtensions().find((entry) =>
       entry.extension.name === "ext-auth-jwt"
     );
@@ -153,7 +153,7 @@ describe("createBuiltinExtensions", () => {
 
   it("ships baseline CSS and Node WebSocket providers as deferred builtins", () => {
     for (const name of ["ext-css-tailwind", "ext-node-websocket-ws"]) {
-      const definition = OPTIONAL_BUILTIN_EXTENSIONS.find((entry) => entry.name === name);
+      const definition = DEFERRED_BUILTIN_EXTENSIONS.find((entry) => entry.name === name);
       const candidate = createBuiltinExtensions().find((entry) => entry.extension.name === name);
 
       assert(definition, `${name} must be part of the default runtime composition`);
@@ -163,7 +163,7 @@ describe("createBuiltinExtensions", () => {
   });
 
   it("keeps builtin package discovery metadata auto-activated", async () => {
-    for (const definition of OPTIONAL_BUILTIN_EXTENSIONS) {
+    for (const definition of DEFERRED_BUILTIN_EXTENSIONS) {
       const manifest = JSON.parse(
         await Deno.readTextFile(
           new URL(
@@ -257,11 +257,12 @@ describe("createBuiltinExtensions", () => {
     );
   });
 
-  it("skips unavailable optional built-in implementations", async () => {
-    const candidate = createOptionalBuiltinExtension({
+  it("skips unavailable package-backed deferred implementations", async () => {
+    const candidate = createDeferredBuiltinExtension({
       name: "ext-missing",
       origin: "veryfront/ext-missing",
       sourceDirectory: "ext-missing",
+      availability: "package",
     });
 
     const logs: string[] = [];
@@ -278,11 +279,12 @@ describe("createBuiltinExtensions", () => {
     assertEquals(logs.some((message) => message.includes("ext-missing")), true);
   });
 
-  it("rejects an invalid optional built-in factory result", async () => {
-    const candidate = createOptionalBuiltinExtension({
+  it("rejects an invalid root-bundled deferred factory result", async () => {
+    const candidate = createDeferredBuiltinExtension({
       name: "ext-invalid",
       origin: "veryfront/ext-invalid",
       sourceDirectory: "ext-invalid",
+      availability: "root-bundled",
       factory: () => null as unknown as Extension,
     });
 
@@ -293,11 +295,12 @@ describe("createBuiltinExtensions", () => {
     );
   });
 
-  it("rejects optional factory identity drift", async () => {
-    const candidate = createOptionalBuiltinExtension({
+  it("rejects deferred factory identity drift", async () => {
+    const candidate = createDeferredBuiltinExtension({
       name: "ext-expected",
       origin: "veryfront/ext-expected",
       sourceDirectory: "ext-expected",
+      availability: "root-bundled",
       factory: () => ({
         name: "ext-unexpected",
         version: "1.0.0",
@@ -314,10 +317,11 @@ describe("createBuiltinExtensions", () => {
 
   it("does not materialize a builtin hidden by a higher-priority extension", async () => {
     let factoryCalls = 0;
-    const deferred = createOptionalBuiltinExtension({
+    const deferred = createDeferredBuiltinExtension({
       name: "ext-overridden",
       origin: "veryfront/ext-overridden",
       sourceDirectory: "ext-overridden",
+      availability: "root-bundled",
       factory: () => {
         factoryCalls++;
         return {
@@ -348,16 +352,28 @@ describe("createBuiltinExtensions", () => {
     await loader.teardownAll();
   });
 
-  it("declares eval CLI selectors for optional exporter builtins", () => {
-    const http = OPTIONAL_BUILTIN_EXTENSIONS.find((definition) =>
+  it("declares eval CLI selectors for deferred exporter builtins", () => {
+    const http = DEFERRED_BUILTIN_EXTENSIONS.find((definition) =>
       definition.name === "ext-eval-report-http"
     );
-    const mlflow = OPTIONAL_BUILTIN_EXTENSIONS.find((definition) =>
+    const mlflow = DEFERRED_BUILTIN_EXTENSIONS.find((definition) =>
       definition.name === "ext-eval-report-mlflow"
     );
 
     assertEquals(http?.evalExporterSelection, { kind: "any-selected" });
     assertEquals(mlflow?.evalExporterSelection, { kind: "id", id: "mlflow" });
+  });
+
+  it("distinguishes deferred activation from implementation availability", () => {
+    const http = DEFERRED_BUILTIN_EXTENSIONS.find((definition) =>
+      definition.name === "ext-eval-report-http"
+    );
+    const mlflow = DEFERRED_BUILTIN_EXTENSIONS.find((definition) =>
+      definition.name === "ext-eval-report-mlflow"
+    );
+
+    assertEquals(http?.availability, "package");
+    assertEquals(mlflow?.availability, "root-bundled");
   });
 
   it("builds a minimal eval CLI builtin set for selected eval exporters", () => {
@@ -372,7 +388,7 @@ describe("createBuiltinExtensions", () => {
     assertEquals(names.includes("ext-observability-opentelemetry"), false);
   });
 
-  it("does not load optional eval exporter builtins when no exporters are selected", () => {
+  it("does not load deferred eval exporter builtins when no exporters are selected", () => {
     const names = createEvalCliBuiltinExtensions([]).map((entry) => entry.extension.name);
 
     assertEquals(names.includes("ext-eval-report-http"), false);

--- a/src/extensions/builtin-extensions.ts
+++ b/src/extensions/builtin-extensions.ts
@@ -29,13 +29,19 @@ type BuiltinLLMProviderDefinition = {
   provider: () => LLMProvider;
 };
 
-export type OptionalBuiltinExtensionDefinition = {
+type DeferredBuiltinExtensionBase = {
   readonly name: string;
   readonly origin: string;
   readonly sourceDirectory: string;
   readonly evalExporterSelection?: FirstPartyEvalExporterSelection;
-  readonly factory?: ExtensionFactory;
 };
+
+export type DeferredBuiltinExtensionDefinition =
+  & DeferredBuiltinExtensionBase
+  & (
+    | { readonly availability: "package"; readonly factory?: never }
+    | { readonly availability: "root-bundled"; readonly factory: ExtensionFactory }
+  );
 
 const BUILTIN_LLM_PROVIDERS: BuiltinLLMProviderDefinition[] = [
   {
@@ -55,23 +61,30 @@ const BUILTIN_LLM_PROVIDERS: BuiltinLLMProviderDefinition[] = [
   },
 ];
 
-export const OPTIONAL_BUILTIN_EXTENSIONS = Object.freeze(
-  FIRST_PARTY_DEFERRED_BUILTIN_EXTENSION_POLICIES.map((policy) =>
-    Object.freeze({
-      name: policy.name,
-      origin: `veryfront/${policy.sourceDirectory}`,
-      sourceDirectory: policy.sourceDirectory,
-      ...(policy.evalExporterSelection
-        ? { evalExporterSelection: policy.evalExporterSelection }
-        : {}),
-      ...(policy.name === "ext-eval-report-mlflow"
-        ? {
+export const DEFERRED_BUILTIN_EXTENSIONS = Object.freeze(
+  FIRST_PARTY_DEFERRED_BUILTIN_EXTENSION_POLICIES.map(
+    (policy): DeferredBuiltinExtensionDefinition => {
+      const definition = {
+        name: policy.name,
+        origin: `veryfront/${policy.sourceDirectory}`,
+        sourceDirectory: policy.sourceDirectory,
+        ...(policy.evalExporterSelection
+          ? { evalExporterSelection: policy.evalExporterSelection }
+          : {}),
+      } satisfies DeferredBuiltinExtensionBase;
+
+      if (policy.name === "ext-eval-report-mlflow") {
+        return Object.freeze({
+          ...definition,
           // MLflow is deliberately shipped inside the root npm package rather
           // than published as a standalone extension package.
+          availability: "root-bundled",
           factory: extEvalReportMlflow,
-        }
-        : {}),
-    }) satisfies OptionalBuiltinExtensionDefinition
+        });
+      }
+
+      return Object.freeze({ ...definition, availability: "package" });
+    },
   ),
 );
 
@@ -156,33 +169,34 @@ function createBuiltinLLMProviderExtension(
   };
 }
 
-export function createOptionalBuiltinExtension(
-  definition: OptionalBuiltinExtensionDefinition,
+export function createDeferredBuiltinExtension(
+  definition: DeferredBuiltinExtensionDefinition,
 ): ResolvedExtension {
   const capturedDefinition = Object.freeze({ ...definition });
   return createDeferredResolvedExtension({
     name: capturedDefinition.name,
     source: "builtin",
     origin: capturedDefinition.origin,
-    load: (logger) => loadOptionalBuiltinExtension(capturedDefinition, logger),
+    load: (logger) => loadDeferredBuiltinExtension(capturedDefinition, logger),
   });
 }
 
-async function loadOptionalBuiltinExtension(
-  definition: OptionalBuiltinExtensionDefinition,
+async function loadDeferredBuiltinExtension(
+  definition: DeferredBuiltinExtensionDefinition,
   logger: ExtensionLogger,
 ): Promise<Extension | undefined> {
-  const configuredFactory = definition.factory;
   try {
-    const factory = configuredFactory ?? await importOptionalBuiltinFactory(
-      definition.sourceDirectory,
-      getFirstPartyExtensionPackageName(definition),
-    );
+    const factory = definition.availability === "root-bundled"
+      ? definition.factory
+      : await importDeferredBuiltinFactory(
+        definition.sourceDirectory,
+        getFirstPartyExtensionPackageName(definition),
+      );
     const factoryResult = (factory as () => unknown)();
     const issues = validateExtension(factoryResult);
     if (issues.length > 0) {
       throw EXTENSION_VALIDATION_ERROR.create({
-        detail: `Optional builtin factory for "${definition.name}" returned an invalid extension: ${
+        detail: `Deferred builtin factory for "${definition.name}" returned an invalid extension: ${
           issues.join("; ")
         }`,
       });
@@ -191,14 +205,14 @@ async function loadOptionalBuiltinExtension(
     if (extension.name !== definition.name) {
       throw EXTENSION_VALIDATION_ERROR.create({
         detail:
-          `Optional builtin factory for "${definition.name}" returned extension "${extension.name}"`,
+          `Deferred builtin factory for "${definition.name}" returned extension "${extension.name}"`,
       });
     }
     return extension;
   } catch (error) {
     if (
-      configuredFactory !== undefined ||
-      !isMissingOptionalBuiltinImplementation(error, definition)
+      definition.availability === "root-bundled" ||
+      !isMissingDeferredBuiltinImplementation(error, definition)
     ) {
       throw error;
     }
@@ -211,7 +225,7 @@ async function loadOptionalBuiltinExtension(
   }
 }
 
-async function importOptionalBuiltinFactory(
+async function importDeferredBuiltinFactory(
   sourceDirectory: string,
   packageName: string,
 ): Promise<ExtensionFactory> {
@@ -226,9 +240,9 @@ async function importOptionalBuiltinFactory(
   return mod.default as ExtensionFactory;
 }
 
-function isMissingOptionalBuiltinImplementation(
+function isMissingDeferredBuiltinImplementation(
   error: unknown,
-  definition: OptionalBuiltinExtensionDefinition,
+  definition: DeferredBuiltinExtensionDefinition,
 ): boolean {
   return isMissingFirstPartyExtensionModule(error, [
     `extensions/${definition.sourceDirectory}/src/index`,
@@ -237,7 +251,7 @@ function isMissingOptionalBuiltinImplementation(
 }
 
 function getFirstPartyExtensionPackageName(
-  definition: OptionalBuiltinExtensionDefinition,
+  definition: DeferredBuiltinExtensionDefinition,
 ): string {
   return definition.origin.replace("veryfront/", "@veryfront/");
 }
@@ -252,7 +266,7 @@ export function createBuiltinExtensions(): ResolvedExtension[] {
       origin: "veryfront/ext-schema-zod",
       extension: extZod(),
     },
-    ...OPTIONAL_BUILTIN_EXTENSIONS.map(createOptionalBuiltinExtension),
+    ...DEFERRED_BUILTIN_EXTENSIONS.map(createDeferredBuiltinExtension),
     ...BUILTIN_LLM_PROVIDERS.map(createBuiltinLLMProviderExtension),
   ];
 }
@@ -261,7 +275,7 @@ export function createEvalCliBuiltinExtensions(
   selectedExporterIds: string[] = [],
 ): ResolvedExtension[] {
   const selected = new Set(selectedExporterIds);
-  const exporterExtensions = OPTIONAL_BUILTIN_EXTENSIONS.filter((definition) => {
+  const exporterExtensions = DEFERRED_BUILTIN_EXTENSIONS.filter((definition) => {
     const selection = definition.evalExporterSelection;
     if (!selection) return false;
     return selection.kind === "any-selected" ? selected.size > 0 : selected.has(selection.id);
@@ -273,7 +287,7 @@ export function createEvalCliBuiltinExtensions(
       origin: "veryfront/ext-schema-zod",
       extension: extZod(),
     },
-    ...exporterExtensions.map(createOptionalBuiltinExtension),
+    ...exporterExtensions.map(createDeferredBuiltinExtension),
     ...BUILTIN_LLM_PROVIDERS.map(createBuiltinLLMProviderExtension),
   ];
 }

--- a/src/extensions/deferred-extension.ts
+++ b/src/extensions/deferred-extension.ts
@@ -1,10 +1,10 @@
 /**
- * Opaque pre-activation state for optional built-in extensions.
+ * Opaque pre-activation state for deferred built-in extensions.
  *
  * Public extension APIs continue to accept `ResolvedExtension`. A branded
- * resolved value lets the internal loader defer importing optional first-party
- * packages until after merge priority and disable filtering, without exposing
- * a second extension-authoring contract.
+ * resolved value lets the internal loader defer materializing first-party
+ * implementations until after merge priority and disable filtering, without
+ * exposing a second extension-authoring contract.
  */
 
 import type {

--- a/src/extensions/orchestrate.test.ts
+++ b/src/extensions/orchestrate.test.ts
@@ -15,8 +15,8 @@ import type { LLMProvider, LLMProviderRegistry } from "./llm/index.ts";
 import { createLLMProviderRegistry, LLMProviderRegistryName } from "./llm/index.ts";
 import {
   createBuiltinExtensions,
+  createDeferredBuiltinExtension,
   createEvalCliBuiltinExtensions,
-  createOptionalBuiltinExtension,
 } from "./builtin-extensions.ts";
 import { join } from "@std/path";
 
@@ -654,10 +654,11 @@ describe("orchestrateExtensions()", () => {
           discoverPackageExtensions: () => Promise.resolve(packageHits),
         },
         builtinExtensions: [
-          createOptionalBuiltinExtension({
+          createDeferredBuiltinExtension({
             name: "ext-css-tailwind",
             origin: "veryfront/ext-css-tailwind",
             sourceDirectory: "ext-css-tailwind",
+            availability: "root-bundled",
             factory: () => {
               deferredFactoryCalls.push("ext-css-tailwind");
               return stubExt("ext-css-tailwind", {
@@ -666,10 +667,11 @@ describe("orchestrateExtensions()", () => {
               });
             },
           }),
-          createOptionalBuiltinExtension({
+          createDeferredBuiltinExtension({
             name: "ext-node-websocket-ws",
             origin: "veryfront/ext-node-websocket-ws",
             sourceDirectory: "ext-node-websocket-ws",
+            availability: "root-bundled",
             factory: () => {
               deferredFactoryCalls.push("ext-node-websocket-ws");
               return stubExt("ext-node-websocket-ws", {


### PR DESCRIPTION
## Summary

- separate deferred activation from implementation availability
- classify package-backed deferred builtins separately from the root-bundled MLflow exporter
- retain graceful missing-package skips only for package-backed implementations
- rename misleading optional-builtin internals to deferred-builtin terminology
- document that MLflow is bundled with the root package but materialized only when selected

## Why

`builtin-deferred` controls when an extension factory materializes. It does not require every implementation to be physically absent from a distribution. Most deferred builtins are package-backed and can be skipped when their package is unavailable. MLflow is intentionally bundled into the root npm/CLI package and therefore cannot take a missing-package path, but it remains deferred until `mlflow` export is selected.

The prior names and metadata collapsed these two axes into “optional,” making the intentional MLflow behavior look like an unreachable graceful-skip bug. The new discriminated availability field makes the loader invariant explicit and keeps invalid root-bundled factories fail closed.

## Red-green TDD

- Red: a focused metadata test expected HTTP export to be `package` and MLflow to be `root-bundled`; both values were absent
- Green: every deferred builtin now declares one availability mode, and the loader branches on that mode
- Existing loader and orchestration tests continue to prove missing package-backed implementations skip, invalid bundled factories reject, disabled candidates stay lazy, and selected exporters materialize correctly
- Packaging red: the clean-room npm smoke failed because its internal probe still called the renamed optional-builtin helper
- Packaging green: the probe now calls the deferred helper with explicit package availability, and all seven clean-room checks pass

## Verification

- extension builtin, loader, and orchestration suite (147 steps passed)
- `deno check` for the four touched TypeScript modules
- `deno task lint:ci`
- `deno task build:npm`
- `bash scripts/test/npm-install-smoke.sh` (all 7 checks passed)
- public docs validation and API reference checks through `lint:ci`

Closes veryfront/veryfront-issue-inbox#459
