### PR TITLE
fix(ssr): preserve terminal HTTP fetch errors

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
@@ -1,0 +1,49 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path";
+import { BUILD_FAILED, VeryfrontError } from "#veryfront/errors";
+import { createDependencyHashCache } from "#veryfront/cache/dependency-graph.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
+import { makeTempDir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
+import { SSRDependencyValidator } from "./ssr-dependency-validator.ts";
+
+describe("SSRDependencyValidator", () => {
+  it("preserves terminal HTTP fetch failures from local dependencies", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-dependency-validator-" });
+    const dependencyPath = join(projectDir, "markdown-renderer.tsx");
+    const fetchError = BUILD_FAILED.create({
+      detail: "Failed to fetch https://esm.sh/marked: AbortError",
+      context: { phase: "http-module-fetch" },
+    });
+    const validator = new SSRDependencyValidator(
+      () => Promise.reject(fetchError),
+      () => Promise.resolve(""),
+      denoAdapter,
+      projectDir,
+    );
+
+    try {
+      await writeTextFile(dependencyPath, "export const marked = true;");
+
+      const error = await assertRejects(
+        () =>
+          validator.processLocalImports(
+            [{ absolutePath: dependencyPath, specifier: "./markdown-renderer.tsx" }],
+            join(projectDir, "page.tsx"),
+            0,
+            createFileSystem(),
+            createDependencyHashCache(),
+          ),
+        VeryfrontError,
+        "Failed to fetch https://esm.sh/marked: AbortError",
+      );
+
+      assertEquals(error, fetchError);
+      assertEquals(validator.missingDependencies, []);
+    } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+});

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
@@ -11,8 +11,9 @@ import { SSRDependencyValidator } from "./ssr-dependency-validator.ts";
 
 describe("SSRDependencyValidator", () => {
   it("preserves terminal HTTP fetch failures from local dependencies", async () => {
-    const projectDir = await makeTempDir({ prefix: "vf-ssr-dependency-validator-" });
-    const dependencyPath = join(projectDir, "markdown-renderer.tsx");
+    const tempDir = await makeTempDir({ prefix: "vf-ssr-dependency-validator-" });
+    const projectDir = join(tempDir, "project");
+    const dependencyPath = join(tempDir, "markdown-renderer.tsx");
     const fetchError = BUILD_FAILED.create({
       detail: "Failed to fetch https://esm.sh/marked: AbortError",
       context: { phase: "http-module-fetch" },
@@ -43,14 +44,15 @@ describe("SSRDependencyValidator", () => {
       assertEquals(error, fetchError);
       assertEquals(validator.missingDependencies, []);
     } finally {
-      await remove(projectDir, { recursive: true });
+      await remove(tempDir, { recursive: true });
     }
   });
 
   it("waits for sibling transforms before propagating a terminal HTTP fetch failure", async () => {
-    const projectDir = await makeTempDir({ prefix: "vf-ssr-dependency-validator-" });
-    const terminalPath = join(projectDir, "terminal.ts");
-    const siblingPath = join(projectDir, "sibling.ts");
+    const tempDir = await makeTempDir({ prefix: "vf-ssr-dependency-validator-" });
+    const projectDir = join(tempDir, "project");
+    const terminalPath = join(tempDir, "terminal.ts");
+    const siblingPath = join(tempDir, "sibling.ts");
     const siblingStarted = Promise.withResolvers<void>();
     const releaseSibling = Promise.withResolvers<void>();
     const fetchError = BUILD_FAILED.create({
@@ -100,7 +102,7 @@ describe("SSRDependencyValidator", () => {
       assertEquals(error, fetchError);
     } finally {
       releaseSibling.resolve();
-      await remove(projectDir, { recursive: true });
+      await remove(tempDir, { recursive: true });
     }
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
@@ -46,4 +46,61 @@ describe("SSRDependencyValidator", () => {
       await remove(projectDir, { recursive: true });
     }
   });
+
+  it("waits for sibling transforms before propagating a terminal HTTP fetch failure", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-dependency-validator-" });
+    const terminalPath = join(projectDir, "terminal.ts");
+    const siblingPath = join(projectDir, "sibling.ts");
+    const siblingStarted = Promise.withResolvers<void>();
+    const releaseSibling = Promise.withResolvers<void>();
+    const fetchError = BUILD_FAILED.create({
+      detail: "Failed to fetch https://esm.sh/marked: AbortError",
+      context: { phase: "http-module-fetch" },
+    });
+    const validator = new SSRDependencyValidator(
+      async (filePath) => {
+        if (filePath === terminalPath) {
+          await siblingStarted.promise;
+          throw fetchError;
+        }
+        siblingStarted.resolve();
+        await releaseSibling.promise;
+        throw new Error("Sibling transform failed");
+      },
+      () => Promise.resolve(""),
+      denoAdapter,
+      projectDir,
+    );
+
+    try {
+      await writeTextFile(terminalPath, "export const terminal = true;");
+      await writeTextFile(siblingPath, "export const sibling = true;");
+
+      let loadSettled = false;
+      const load = validator.processLocalImports(
+        [
+          { absolutePath: terminalPath, specifier: "./terminal.ts" },
+          { absolutePath: siblingPath, specifier: "./sibling.ts" },
+        ],
+        join(projectDir, "page.tsx"),
+        0,
+        createFileSystem(),
+        createDependencyHashCache(),
+      );
+      void load.catch(() => {
+        loadSettled = true;
+      });
+
+      await siblingStarted.promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assertEquals(loadSettled, false);
+
+      releaseSibling.resolve();
+      const error = await assertRejects(() => load, VeryfrontError);
+      assertEquals(error, fetchError);
+    } finally {
+      releaseSibling.resolve();
+      await remove(projectDir, { recursive: true });
+    }
+  });
 });

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -11,7 +11,7 @@ import type { CrossProjectImport, MissingImport } from "#veryfront/transforms/es
 import { parseLocalImports } from "#veryfront/transforms/esm/import-parser.ts";
 import { registerCSSImport } from "../css-import-collector.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
-import { createError, toError } from "#veryfront/errors";
+import { BUILD_FAILED, createError, toError, VeryfrontError } from "#veryfront/errors";
 import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { MAX_TRANSFORM_DEPTH, TRANSFORM_BATCH_SIZE } from "./constants.ts";
@@ -22,6 +22,13 @@ import {
 } from "#veryfront/cache/dependency-graph.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
+
+function isTerminalHttpModuleFetchFailure(error: unknown): error is VeryfrontError {
+  if (!(error instanceof VeryfrontError) || error.slug !== BUILD_FAILED.slug) return false;
+  const context = error.context;
+  return typeof context === "object" && context !== null &&
+    (context as { phase?: unknown }).phase === "http-module-fetch";
+}
 
 /**
  * Manages dependency validation for SSR module loading:
@@ -165,6 +172,7 @@ export class SSRDependencyValidator {
             importPathMap.set(imp.specifier, depEntry.tempPath);
             importPathMap.set(imp.absolutePath, depEntry.tempPath);
           } catch (error) {
+            if (isTerminalHttpModuleFetchFailure(error)) throw error;
             this.missingDependencies.push({
               specifier: imp.specifier,
               fromFile: fromFilePath,

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -157,7 +157,7 @@ export class SSRDependencyValidator {
 
     for (let i = 0; i < imports.length; i += TRANSFORM_BATCH_SIZE) {
       const batch = imports.slice(i, i + TRANSFORM_BATCH_SIZE);
-      await Promise.all(
+      const results = await Promise.allSettled(
         batch.map(async (imp) => {
           try {
             const depSource = await this.readLocalImportSource(imp.absolutePath, localFs);
@@ -183,6 +183,8 @@ export class SSRDependencyValidator {
           }
         }),
       );
+      const terminalFailure = results.find((result) => result.status === "rejected");
+      if (terminalFailure?.status === "rejected") throw terminalFailure.reason;
     }
 
     return importPathMap;

--- a/src/transforms/esm/http-cache.test.ts
+++ b/src/transforms/esm/http-cache.test.ts
@@ -36,6 +36,7 @@ import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { MAX_BUNDLE_CHUNK_SIZE_BYTES } from "#veryfront/utils/constants/buffers.ts";
 import { HTTP_MODULE_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
 import { OutboundRequestBlockedError } from "#veryfront/security/http/outbound-fetch.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import { MODULE_LOAD_TIMEOUT_MS } from "#veryfront/rendering/orchestrator/module-collection.ts";
 import { FakeTime } from "#std/testing/time";
 import {
@@ -1340,6 +1341,27 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
       assertEquals(fetchCount, 3);
       assertInstanceOf(error, Error);
       assert(!error.message.includes("super-secret"));
+    });
+  });
+
+  it("labels exhausted AbortError retries as HTTP module fetch failures", async () => {
+    let fetchCount = 0;
+    const mockFetch = (() => {
+      fetchCount += 1;
+      return Promise.reject(new DOMException("request aborted", "AbortError"));
+    }) as typeof fetch;
+
+    await withIsolatedHttpCache("vf-esm-abort-failure-", mockFetch, async (tempDir) => {
+      const error = await assertRejects(
+        () => cacheModuleToLocal("https://esm.sh/aborted-package", tempDir),
+        VeryfrontError,
+        "Failed to fetch https://esm.sh/aborted-package: AbortError",
+      );
+
+      assertEquals(fetchCount, 3);
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "build-failed");
+      assertEquals(error.context, { phase: "http-module-fetch" });
     });
   });
 

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -180,6 +180,13 @@ interface HttpModuleFetchResult {
   contentType: string;
 }
 
+function terminalHttpModuleFetchError(detail: string): VeryfrontError {
+  return BUILD_FAILED.create({
+    detail,
+    context: { phase: "http-module-fetch" },
+  });
+}
+
 class HttpModuleResponseError extends Error {
   constructor(readonly status: number) {
     super(`HTTP module response returned status ${status}`);
@@ -308,17 +315,15 @@ async function fetchHttpModule(
     );
   } catch (error) {
     if (error instanceof HttpModuleResponseError) {
-      throw BUILD_FAILED.create({ detail: `Failed to fetch ${safeUrl}: ${error.status}` });
+      throw terminalHttpModuleFetchError(`Failed to fetch ${safeUrl}: ${error.status}`);
     }
     if (error instanceof HttpModuleRequestError) {
-      throw BUILD_FAILED.create({
-        detail: `Failed to fetch ${safeUrl}: ${error.requestErrorType}`,
-      });
+      throw terminalHttpModuleFetchError(
+        `Failed to fetch ${safeUrl}: ${error.requestErrorType}`,
+      );
     }
     if (error instanceof HttpModuleBodyError) {
-      throw BUILD_FAILED.create({
-        detail: `Failed to fetch ${safeUrl}: ${error.message}`,
-      });
+      throw terminalHttpModuleFetchError(`Failed to fetch ${safeUrl}: ${error.message}`);
     }
     if (error instanceof OutboundRequestBlockedError) {
       // Preserve the policy-denial type so downstream specifier resolution can


### PR DESCRIPTION
## Summary

- keep the existing bounded three-attempt HTTP module retry policy
- mark exhausted HTTP module request, response, and body failures with a structured fetch phase
- propagate that exact terminal fetch error through local SSR dependency validation
- wait for every transform in the dependency batch before propagating a terminal fetch error
- keep ordinary missing and failed local dependency aggregation unchanged

## Why

The HTTP cache already retries transient request failures, including `AbortError`, up to three times. After those attempts were exhausted, recursive SSR dependency validation caught the structured build error and reclassified the importing local file as missing. That hid the network cause behind `Component has missing dependencies`.

The terminal error now carries a non-sensitive `http-module-fetch` phase. The dependency validator rethrows only a `build-failed` error with that exact phase, so users receive the sanitized fetch failure and the local module is not mislabeled as absent.

## Red-green TDD

- Red: an exhausted `AbortError` test confirmed three fetch attempts but found no terminal fetch phase
- Red: a validator test showed a marked fetch failure was swallowed and converted into a missing local dependency
- Green: exhausted fetch failures carry the phase marker, and local dependency validation preserves that exact error
- Review red-green: a terminal fetch failure rejected the batch while a sibling transform was still running; the validator now settles the full batch before propagating the terminal error
- Existing transient retry, permanent response, cancellation, cache, and loader regressions remain green

## Verification

- HTTP cache, SSR dependency validator, and SSR loader suite (100 steps passed)
- `deno check` for the four touched source and test modules
- `deno fmt --check` for the four touched source and test modules
- `deno task lint:ci`

Closes veryfront/veryfront-issue-inbox#460
