### PR TITLE
fix(extensions): allow final esbuild stop loss before close

### DIFF
--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -1479,6 +1479,68 @@ describe("EsbuildBundler service crash recovery", () => {
     }
   });
 
+  it("allows the final budgeted stop loss before the child close event clears tracking", async () => {
+    const observation = observeEsbuildServices();
+    const { services } = observation;
+    const bundler = new EsbuildBundler();
+    let finalStop: Promise<void> | undefined;
+    const finalStopStarted = Promise.withResolvers<void>();
+
+    try {
+      await bundler.transform({ code: "export const seed: number = 0;", loader: "ts" });
+
+      for (let restart = 1; restart < MAX_SERVICE_RESTARTS; restart++) {
+        const current = services[services.length - 1]!;
+        current.child.ref();
+        current.child.kill("SIGKILL");
+        await current.close;
+
+        await bundler.stop();
+        const recovered = await bundler.transform({
+          code: `export const stopReset${restart}: number = ${restart};`,
+          loader: "ts",
+        });
+        assertStringIncludes(recovered.code, `stopReset${restart} = ${restart}`);
+      }
+
+      const finalBudgeted = services[services.length - 1]!;
+      finalBudgeted.child.once("exit", () => {
+        finalStop = bundler.stop();
+        finalStopStarted.resolve();
+      });
+      finalBudgeted.child.ref();
+      finalBudgeted.child.kill("SIGKILL");
+
+      await finalStopStarted.promise;
+      await finalStop;
+      await finalBudgeted.close;
+
+      const recovered = await bundler.transform({
+        code: "export const afterFinalStopLoss: number = 3;",
+        loader: "ts",
+      });
+      assertStringIncludes(recovered.code, "afterFinalStopLoss = 3");
+
+      const exhausted = services[services.length - 1]!;
+      exhausted.child.ref();
+      exhausted.child.kill("SIGKILL");
+      await exhausted.close;
+
+      const stopError = await assertRejects(() => bundler.stop());
+      assertStringIncludes((stopError as Error).message, "module-wide adapter");
+      assertStringIncludes((stopError as Error).message, "exited unexpectedly");
+    } finally {
+      await finalStop?.catch(() => undefined);
+      await bundler.stop().catch(() => undefined);
+      __resetServiceRecoveryForTests();
+      try {
+        await bundler.stop();
+      } finally {
+        observation.restore();
+      }
+    }
+  });
+
   it("latches exhaustion when stop observes a closed lost service", async () => {
     const observation = observeEsbuildServices();
     const { services } = observation;

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts
@@ -5,7 +5,12 @@
  * @module extensions/ext-bundler-esbuild/esbuild-bundler.test
  */
 
-import { assertEquals, assertExists, assertRejects, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { createRequire } from "node:module";
 import type { BuildContext } from "veryfront/extensions/bundler";

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -816,8 +816,10 @@ export class EsbuildBundler implements Bundler {
         uninstallServiceLossSpawnGuard();
         throw error;
       }
+      let chargedLostService = false;
       if (esbuildServiceLost) {
         remainingServiceRestarts -= 1;
+        chargedLostService = true;
         uninstallServiceLossSpawnGuard();
       }
 
@@ -825,7 +827,7 @@ export class EsbuildBundler implements Bundler {
       const trackedService = esbuildService;
       if (
         trackedService && !trackedService.expectedClose && !isLiveService(trackedService) &&
-        remainingServiceRestarts <= 0
+        remainingServiceRestarts <= 0 && !chargedLostService
       ) {
         // A dead managed child within the restart budget is a crash, which a
         // stop resets anyway; only an exhausted budget still means giving up.


### PR DESCRIPTION
## Summary

Follow-up to merged #3718. The original PR was merged and its source branch was deleted before the tested repair for the exit-before-close recovery race could be pushed.

This PR fixes the remaining esbuild child lifecycle race where a managed service can emit `exit` before `close`, leaving the dead child tracked while `stop()` consumes the final restart budget. The stop path now remembers whether the current stop call already charged the observed loss, so the final permitted loss is not converted into a permanent ownership failure before `close` clears tracking.

## Verification

Red evidence on fresh `origin/main` before the fix:

- Applied only the new regression test, then ran `deno test --preload=src/testing/preload.ts --no-check --allow-all extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts`
- The new test failed with: `Cannot verify closure of an externally owned esbuild service; restart the process`

Green evidence on this branch:

- `deno test --preload=src/testing/preload.ts --no-check --allow-all extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts` -> `8 passed (39 steps), 0 failed`
- `deno test --preload=src/testing/preload.ts --no-check --allow-all extensions/ext-bundler-esbuild/src/binary.test.ts extensions/ext-bundler-esbuild/src/es-module-lexer.test.ts extensions/ext-bundler-esbuild/src/index.test.ts` -> `4 passed (8 steps), 0 failed`
- `deno check extensions/ext-bundler-esbuild/src/esbuild-bundler.ts extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts`
- `deno lint extensions/ext-bundler-esbuild/src/esbuild-bundler.ts extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts`
- `deno fmt --check extensions/ext-bundler-esbuild/src/esbuild-bundler.ts extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts`
- `git diff --check`
- Full local pre-push hook passed before push: format check, lint, root typecheck, unit suite (`3816 passed (28529 steps), 0 failed, 1 ignored`), cwd tests (`10 passed`), cwd-exclusion tests (`2 passed`)

Note: the globbed command `deno test --preload=src/testing/preload.ts --no-check --allow-all extensions/ext-bundler-esbuild/src/*.test.ts` showed the tests passing but exited with Deno's pending-promise warning when those extension test files were run together. The same coverage passed when split as above.

## Risk

Narrow lifecycle accounting change in the esbuild extension. PR is intentionally draft while remote CI runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when the bundling service stops unexpectedly during shutdown.
  * Prevented valid final recovery attempts from being rejected prematurely.
  * Ensured subsequent service failures correctly stop processing once the recovery limit has been reached.
  * Improved error handling and reliability for transformations following service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->