### PR TITLE
Allow agent authoring tools to be reloaded after writes

### DIFF
--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -1040,7 +1040,7 @@ Input delivered to a hosted agent-service detached execution callback.
 
 | Name                                 | Description                                       | Source                                                                                                             |
 | ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `AgentRuntime`                       | Implement agent runtime.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/index.ts#L718)                    |
+| `AgentRuntime`                       | Implement agent runtime.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/index.ts#L724)                    |
 | `AgentRuntimeMessageConversionError` | Error shape for agent runtime message conversion. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/message-adapter.ts#L138)          |
 | `AgentServiceAuthError`              | Error shape for hosted service auth.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/auth.ts#L14)                      |
 | `AppendConversationRunEventsError`   | Error shape for append conversation run events.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable-append-errors.ts#L4) |

--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -1040,7 +1040,7 @@ Input delivered to a hosted agent-service detached execution callback.
 
 | Name                                 | Description                                       | Source                                                                                                             |
 | ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `AgentRuntime`                       | Implement agent runtime.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/index.ts#L686)                    |
+| `AgentRuntime`                       | Implement agent runtime.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/index.ts#L718)                    |
 | `AgentRuntimeMessageConversionError` | Error shape for agent runtime message conversion. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/message-adapter.ts#L138)          |
 | `AgentServiceAuthError`              | Error shape for hosted service auth.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/auth.ts#L14)                      |
 | `AppendConversationRunEventsError`   | Error shape for append conversation run events.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable-append-errors.ts#L4) |

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1240,7 +1240,7 @@ export class AgentRuntime {
           synchronizeRuntimeToolInventory(
             currentSystemPrompt,
             runtimeTools,
-            effectiveToolExposurePlan.deferred,
+            agentWriteFinalResponseToolGuardEnabled ? effectiveToolExposurePlan.deferred : [],
           ),
           preparedStep.integrationToolDiscovery,
         );
@@ -1858,7 +1858,7 @@ export class AgentRuntime {
         synchronizeRuntimeToolInventory(
           currentSystemPrompt,
           runtimeTools,
-          effectiveToolExposurePlan.deferred,
+          agentWriteFinalResponseToolGuardEnabled ? effectiveToolExposurePlan.deferred : [],
         ),
         preparedStep.integrationToolDiscovery,
       );

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1240,7 +1240,11 @@ export class AgentRuntime {
           synchronizeRuntimeToolInventory(
             currentSystemPrompt,
             runtimeTools,
-            agentWriteFinalResponseToolGuardEnabled ? effectiveToolExposurePlan.deferred : [],
+            agentWriteFinalResponseToolGuardEnabled
+              ? effectiveToolExposurePlan.deferred.filter((tool) =>
+                shouldHideProjectToolAfterAgentWriteSuccess(tool.name)
+              )
+              : [],
           ),
           preparedStep.integrationToolDiscovery,
         );
@@ -1858,7 +1862,11 @@ export class AgentRuntime {
         synchronizeRuntimeToolInventory(
           currentSystemPrompt,
           runtimeTools,
-          agentWriteFinalResponseToolGuardEnabled ? effectiveToolExposurePlan.deferred : [],
+          agentWriteFinalResponseToolGuardEnabled
+            ? effectiveToolExposurePlan.deferred.filter((tool) =>
+              shouldHideProjectToolAfterAgentWriteSuccess(tool.name)
+            )
+            : [],
         ),
         preparedStep.integrationToolDiscovery,
       );

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -103,6 +103,7 @@ import {
 } from "./agent-runtime-step.ts";
 import { buildStreamedAssistantMessage } from "./streamed-assistant-message.ts";
 import {
+  type DeferredToolSummary,
   flattenSystemInstructions,
   hasRuntimeToolInventory,
   withRuntimeToolInventory,
@@ -436,12 +437,17 @@ function applyAgentWriteFinalResponseGuard(
 function synchronizeRuntimeToolInventory(
   systemPrompt: string,
   runtimeTools: Record<string, unknown> | undefined,
+  deferredTools: readonly DeferredToolSummary[] = [],
 ): string {
   if (!hasRuntimeToolInventory(systemPrompt)) {
     return systemPrompt;
   }
   return flattenSystemInstructions(
-    withRuntimeToolInventory(systemPrompt, Object.keys(runtimeTools ?? {}).sort()),
+    withRuntimeToolInventory(
+      systemPrompt,
+      Object.keys(runtimeTools ?? {}).sort(),
+      deferredTools,
+    ),
   );
 }
 
@@ -1136,6 +1142,7 @@ export class AgentRuntime {
           sandbox: undefined,
         }
         : runConfig;
+      const runtimeStepToolLoading = resolveRuntimeToolLoading(runtimeStepConfig);
       const allowedRemoteToolNames = hasToolReplacements
         ? undefined
         : getRuntimeAllowedRemoteTools(this.config);
@@ -1176,7 +1183,7 @@ export class AgentRuntime {
           config: runtimeStepConfig,
           effectiveModel,
           excludedToolNames: agentWriteFinalResponseToolGuardEnabled &&
-              toolLoadingResolution.mode === "eager"
+              runtimeStepToolLoading.mode === "eager"
             ? AGENT_WRITE_FINAL_RESPONSE_EXCLUDED_TOOL_NAMES
             : undefined,
           forwardedRemoteToolDefinitions,
@@ -1204,12 +1211,12 @@ export class AgentRuntime {
         const toolContext = preparedStep.toolContext;
         const effectiveToolExposurePlan = agentWriteFinalResponseToolGuardEnabled
           ? applyAgentWriteFinalResponseGuard(preparedStep.toolExposurePlan, {
-            reloadable: toolLoadingResolution.mode === "deferred",
+            reloadable: runtimeStepToolLoading.mode === "deferred",
           })
           : preparedStep.toolExposurePlan;
         const tools = effectiveToolExposurePlan.visible;
         setSpanAttributes(loopSpan, {
-          "tool.loading.mode": resolveRuntimeToolLoading(runtimeStepConfig).mode,
+          "tool.loading.mode": runtimeStepToolLoading.mode,
           "tool.loading.provenance": toolLoadingResolution.provenance,
           "tool.catalog.authorized_count": preparedStep.toolExposurePlan.authorized.length,
           "tool.catalog.visible_count": tools.length,
@@ -1230,7 +1237,11 @@ export class AgentRuntime {
           providerTools: stepProviderTools,
         });
         currentSystemPrompt = withIntegrationToolDiscoveryStatus(
-          synchronizeRuntimeToolInventory(currentSystemPrompt, runtimeTools),
+          synchronizeRuntimeToolInventory(
+            currentSystemPrompt,
+            runtimeTools,
+            effectiveToolExposurePlan.deferred,
+          ),
           preparedStep.integrationToolDiscovery,
         );
         const response = await withSpan("agent.generate_text", async (span) => {
@@ -1844,7 +1855,11 @@ export class AgentRuntime {
         providerTools: stepProviderTools,
       });
       currentSystemPrompt = withIntegrationToolDiscoveryStatus(
-        synchronizeRuntimeToolInventory(currentSystemPrompt, runtimeTools),
+        synchronizeRuntimeToolInventory(
+          currentSystemPrompt,
+          runtimeTools,
+          effectiveToolExposurePlan.deferred,
+        ),
         preparedStep.integrationToolDiscovery,
       );
       const runtimeToolNames = Object.keys(runtimeTools ?? {}).sort();

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -216,6 +216,7 @@ import { buildRuntimeUsageTraceAttributes } from "./trace-usage.ts";
 import {
   createToolExposureCheckpoint,
   createToolExposureState,
+  createToolSearchDefinition,
   searchToolExposure,
   TOOL_SEARCH_TOOL_NAME,
   type ToolExposureCheckpoint,
@@ -386,12 +387,43 @@ function shouldHideProjectToolAfterAgentWriteSuccess(toolName: string): boolean 
   return AGENT_WRITE_FINAL_RESPONSE_EXCLUDED_TOOL_NAMES.has(toolName);
 }
 
-function applyAgentWriteFinalResponseGuard(plan: ToolExposurePlan): ToolExposurePlan {
+function didReloadProjectAgentWriteTool(result: ToolSearchResult): boolean {
+  return result.matches.some((match) =>
+    match.status === "loaded" && shouldHideProjectToolAfterAgentWriteSuccess(match.name)
+  );
+}
+
+function compareToolNames(left: { name: string }, right: { name: string }): number {
+  return left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+}
+
+function applyAgentWriteFinalResponseGuard(
+  plan: ToolExposurePlan,
+  options: { reloadable: boolean },
+): ToolExposurePlan {
   const keep = (tool: { name: string }) => !shouldHideProjectToolAfterAgentWriteSuccess(tool.name);
   for (const toolName of plan.loadedToolNames) {
     if (shouldHideProjectToolAfterAgentWriteSuccess(toolName)) {
       plan.loadedToolNames.delete(toolName);
     }
+  }
+  if (options.reloadable) {
+    const guardedTools = plan.authorized.filter((tool) => !keep(tool));
+    const visible = plan.visible.filter(keep);
+    const deferredByName = new Map(
+      [...plan.deferred, ...guardedTools].map((tool) => [tool.name, tool]),
+    );
+    if (
+      guardedTools.length > 0 &&
+      !visible.some((tool) => tool.name === TOOL_SEARCH_TOOL_NAME)
+    ) {
+      visible.push(createToolSearchDefinition());
+    }
+    return {
+      ...plan,
+      visible: visible.sort(compareToolNames),
+      deferred: [...deferredByName.values()].sort(compareToolNames),
+    };
   }
   return {
     ...plan,
@@ -1143,7 +1175,8 @@ export class AgentRuntime {
           allowedRemoteToolNames,
           config: runtimeStepConfig,
           effectiveModel,
-          excludedToolNames: agentWriteFinalResponseToolGuardEnabled
+          excludedToolNames: agentWriteFinalResponseToolGuardEnabled &&
+              toolLoadingResolution.mode === "eager"
             ? AGENT_WRITE_FINAL_RESPONSE_EXCLUDED_TOOL_NAMES
             : undefined,
           forwardedRemoteToolDefinitions,
@@ -1170,7 +1203,9 @@ export class AgentRuntime {
         currentRuntimeContext = preparedStep.runtimeContext;
         const toolContext = preparedStep.toolContext;
         const effectiveToolExposurePlan = agentWriteFinalResponseToolGuardEnabled
-          ? applyAgentWriteFinalResponseGuard(preparedStep.toolExposurePlan)
+          ? applyAgentWriteFinalResponseGuard(preparedStep.toolExposurePlan, {
+            reloadable: toolLoadingResolution.mode === "deferred",
+          })
           : preparedStep.toolExposurePlan;
         const tools = effectiveToolExposurePlan.visible;
         setSpanAttributes(loopSpan, {
@@ -1404,6 +1439,9 @@ export class AgentRuntime {
                   plan: effectiveToolExposurePlan,
                   state: toolExposureState,
                 });
+                if (didReloadProjectAgentWriteTool(search.result)) {
+                  agentWriteFinalResponseToolGuardEnabled = false;
+                }
                 toolCall.status = "completed";
                 toolCall.result = search.result;
                 setSpanAttributes(toolSpan, {
@@ -1757,7 +1795,8 @@ export class AgentRuntime {
         allowedRemoteToolNames,
         config: runtimeStepConfig,
         effectiveModel,
-        excludedToolNames: agentWriteFinalResponseToolGuardEnabled
+        excludedToolNames: agentWriteFinalResponseToolGuardEnabled &&
+            toolLoadingResolution.mode === "eager"
           ? AGENT_WRITE_FINAL_RESPONSE_EXCLUDED_TOOL_NAMES
           : undefined,
         forwardedRemoteToolDefinitions,
@@ -1782,7 +1821,9 @@ export class AgentRuntime {
       currentRuntimeContext = preparedStep.runtimeContext;
       const toolContext = preparedStep.toolContext;
       const effectiveToolExposurePlan = agentWriteFinalResponseToolGuardEnabled
-        ? applyAgentWriteFinalResponseGuard(preparedStep.toolExposurePlan)
+        ? applyAgentWriteFinalResponseGuard(preparedStep.toolExposurePlan, {
+          reloadable: toolLoadingResolution.mode === "deferred",
+        })
         : preparedStep.toolExposurePlan;
       const tools = effectiveToolExposurePlan.visible;
       setOtelActiveSpanAttributes({
@@ -2098,6 +2139,9 @@ export class AgentRuntime {
               plan: effectiveToolExposurePlan,
               state: toolExposureState,
             });
+            if (didReloadProjectAgentWriteTool(search.result)) {
+              agentWriteFinalResponseToolGuardEnabled = false;
+            }
             toolCall.status = "completed";
             toolCall.result = search.result;
             toolCalls.push(toolCall);

--- a/src/agent/runtime/request-scoped-tool-replacement.test.ts
+++ b/src/agent/runtime/request-scoped-tool-replacement.test.ts
@@ -6,6 +6,7 @@ import { type ModelRuntime } from "#veryfront/provider";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { tool, toolRegistry } from "#veryfront/tool";
 import { agent } from "../index.ts";
+import type { RuntimeToolFilterConfig } from "./runtime-tool-config.ts";
 
 function toolNamesFromGenerateOptions(options: unknown): string[] {
   const tools = (options as { tools?: Record<string, unknown> | Array<{ name?: string }> })
@@ -152,6 +153,64 @@ describe("request-scoped tool replacement for generate()", () => {
       source: "replacement",
       query: "current",
     });
+  });
+
+  it("keeps request replacement agent-write tools eager after a successful write", async () => {
+    const observedToolNames: string[][] = [];
+    let step = 0;
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/request-agent-write-tools",
+      async doGenerate(options: unknown) {
+        observedToolNames.push(toolNamesFromGenerateOptions(options));
+        step++;
+        if (step === 1) {
+          return {
+            content: [{
+              type: "tool-call",
+              toolCallId: "create-agent-replacement",
+              toolName: "create_agent",
+              input: '{"id":"replacement-agent"}',
+            }],
+            finishReason: "tool-calls",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          };
+        }
+        return {
+          content: [{ type: "text", text: "done" }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        return { stream: new ReadableStream() };
+      },
+    };
+
+    const assistant = agent(
+      {
+        model: "hosted/request-agent-write-tools",
+        system: "Create the replacement agent.",
+        maxSteps: 2,
+        resolveModelTransport: async () => ({ model }),
+        __vfToolLoadingMode: "deferred",
+      } as Parameters<typeof agent>[0] & RuntimeToolFilterConfig,
+    );
+
+    const result = await assistant.generate({
+      input: "Create an agent",
+      tools: {
+        create_agent: tool({
+          id: "create_agent",
+          description: "Create a project agent",
+          inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+          execute: async ({ id }) => ({ id }),
+        }),
+      },
+    });
+
+    assertEquals(observedToolNames, [["create_agent"], []]);
+    assertEquals(result.toolCalls[0]?.status, "completed");
   });
 
   it("does not fall through to configured, registry, remote, integration, or provider-native tools", async () => {

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -22,6 +22,15 @@ function toolNames(options: unknown): string[] {
     : Object.keys((value as Record<string, unknown> | undefined) ?? {}).sort();
 }
 
+function createRuntimeStream(parts: unknown[]): ReadableStream<unknown> {
+  return new ReadableStream({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+}
+
 function systemPrompt(options: unknown): string {
   const prompt = (options as { prompt?: Array<{ role?: string; content?: unknown }> }).prompt;
   if (!Array.isArray(prompt)) return "";
@@ -124,6 +133,189 @@ it("deferred generate searches, exposes on the next step, and executes once", as
   assertEquals((observedSystems[1] ?? "").includes("read_release_marker"), false);
   assertEquals(executionCount, 1);
   assertEquals(response.text, "Release marker marker-1");
+});
+
+it("deferred generate can reload create_agent after a successful agent write", async () => {
+  const observedTools: string[][] = [];
+  let step = 0;
+  const model: ModelRuntime = {
+    provider: "hosted",
+    modelId: "hosted/deferred-agent-authoring",
+    async doGenerate(options: unknown) {
+      observedTools.push(toolNames(options));
+      step++;
+      if (step === 1 || step === 3) {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: `search-create-agent-${step}`,
+            toolName: "tool_search",
+            input: JSON.stringify({ query: "create_agent" }),
+          }],
+          finishReason: "tool-calls",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      }
+      if (step === 2 || step === 4) {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: `create-agent-${step}`,
+            toolName: "create_agent",
+            input: JSON.stringify({ id: `agent-${step}` }),
+          }],
+          finishReason: "tool-calls",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      }
+      return {
+        content: [{ type: "text", text: "Created both agents." }],
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      };
+    },
+    async doStream() {
+      return { stream: new ReadableStream() };
+    },
+  };
+  let executionCount = 0;
+  const assistant = agent(
+    {
+      id: "deferred-agent-authoring-test",
+      model: "hosted/deferred-agent-authoring",
+      system: "Create both requested agents, loading create_agent when needed.",
+      tools: {
+        load_skill: tool({
+          id: "load_skill",
+          description: "Load a skill",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+        create_agent: tool({
+          id: "create_agent",
+          description: "Create a project agent",
+          inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+          execute: ({ id }) => {
+            executionCount++;
+            return { id, source_path: `agents/${id}.ts` };
+          },
+        }),
+      },
+      maxSteps: 5,
+      resolveModelTransport: () => ({ model }),
+      __vfToolLoadingMode: "deferred",
+    } as AgentConfig & RuntimeToolFilterConfig,
+  );
+
+  const response = await assistant.generate({ input: "Create two project agents" });
+
+  assertEquals(observedTools, [
+    ["load_skill", "tool_search"],
+    ["create_agent", "load_skill"],
+    ["load_skill", "tool_search"],
+    ["create_agent", "load_skill"],
+    ["load_skill", "tool_search"],
+  ]);
+  assertEquals(executionCount, 2);
+  assertEquals(response.text, "Created both agents.");
+});
+
+it("deferred stream can reload another agent write tool after a successful write", async () => {
+  const observedTools: string[][] = [];
+  let step = 0;
+  const model: ModelRuntime = {
+    provider: "hosted",
+    modelId: "hosted/deferred-agent-authoring-stream",
+    async doGenerate() {
+      return { content: [{ type: "text", text: "unused" }] };
+    },
+    async doStream(options: unknown) {
+      observedTools.push(toolNames(options));
+      step++;
+      if (step === 1 || step === 3) {
+        return {
+          stream: createRuntimeStream([
+            {
+              type: "tool-call",
+              toolCallId: `search-create-agent-${step}`,
+              toolName: "tool_search",
+              input: { query: step === 1 ? "create_agent" : "update_agent" },
+            },
+            { type: "finish", finishReason: "tool-calls" },
+          ]),
+        };
+      }
+      if (step === 2 || step === 4) {
+        return {
+          stream: createRuntimeStream([
+            {
+              type: "tool-call",
+              toolCallId: `create-agent-${step}`,
+              toolName: step === 2 ? "create_agent" : "update_agent",
+              input: { id: `agent-${step}` },
+            },
+            { type: "finish", finishReason: "tool-calls" },
+          ]),
+        };
+      }
+      return {
+        stream: createRuntimeStream([
+          { type: "text-delta", text: "Created both agents." },
+          { type: "finish", finishReason: "stop" },
+        ]),
+      };
+    },
+  };
+  const executionCounts = { create: 0, update: 0 };
+  const assistant = agent(
+    {
+      id: "deferred-agent-authoring-stream-test",
+      model: "hosted/deferred-agent-authoring-stream",
+      system: "Create both requested agents, loading create_agent when needed.",
+      tools: {
+        load_skill: tool({
+          id: "load_skill",
+          description: "Load a skill",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({}),
+        }),
+        create_agent: tool({
+          id: "create_agent",
+          description: "Create a project agent",
+          inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+          execute: ({ id }) => {
+            executionCounts.create++;
+            return { id, source_path: `agents/${id}.ts` };
+          },
+        }),
+        update_agent: tool({
+          id: "update_agent",
+          description: "Update a project agent",
+          inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+          execute: ({ id }) => {
+            executionCounts.update++;
+            return { id, source_path: `agents/${id}.ts` };
+          },
+        }),
+      },
+      maxSteps: 5,
+      resolveModelTransport: () => ({ model }),
+      __vfToolLoadingMode: "deferred",
+    } as AgentConfig & RuntimeToolFilterConfig,
+  );
+
+  const response = await assistant.stream({ input: "Create two project agents" });
+  const body = await response.toDataStreamResponse().text();
+
+  assertEquals(observedTools, [
+    ["load_skill", "tool_search"],
+    ["create_agent", "load_skill", "tool_search"],
+    ["load_skill", "tool_search"],
+    ["load_skill", "tool_search", "update_agent"],
+    ["load_skill", "tool_search"],
+  ]);
+  assertEquals(executionCounts, { create: 1, update: 1 });
+  assertEquals(body.includes("Created both agents."), true);
 });
 
 it("deferred generate activates and executes provider-native web search on demand", async () => {

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -11,6 +11,7 @@ import {
 import { agent } from "../index.ts";
 import type { AgentConfig } from "../types.ts";
 import type { RuntimeToolFilterConfig } from "./runtime-tool-config.ts";
+import { flattenSystemInstructions, withRuntimeToolInventory } from "./tool-inventory.ts";
 
 function toolNames(options: unknown): string[] {
   const value = (options as { tools?: unknown }).tools;
@@ -137,12 +138,14 @@ it("deferred generate searches, exposes on the next step, and executes once", as
 
 it("deferred generate can reload create_agent after a successful agent write", async () => {
   const observedTools: string[][] = [];
+  const observedSystems: string[] = [];
   let step = 0;
   const model: ModelRuntime = {
     provider: "hosted",
     modelId: "hosted/deferred-agent-authoring",
     async doGenerate(options: unknown) {
       observedTools.push(toolNames(options));
+      observedSystems.push(systemPrompt(options));
       step++;
       if (step === 1 || step === 3) {
         return {
@@ -183,7 +186,12 @@ it("deferred generate can reload create_agent after a successful agent write", a
     {
       id: "deferred-agent-authoring-test",
       model: "hosted/deferred-agent-authoring",
-      system: "Create both requested agents, loading create_agent when needed.",
+      system: flattenSystemInstructions(
+        withRuntimeToolInventory(
+          "Create both requested agents, loading create_agent when needed.",
+          [],
+        ),
+      ),
       tools: {
         load_skill: tool({
           id: "load_skill",
@@ -216,6 +224,10 @@ it("deferred generate can reload create_agent after a successful agent write", a
     ["create_agent", "load_skill"],
     ["load_skill", "tool_search"],
   ]);
+  assertEquals(
+    observedSystems[2]?.includes("- create_agent: Create a project agent"),
+    true,
+  );
   assertEquals(executionCount, 2);
   assertEquals(response.text, "Created both agents.");
 });

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -208,6 +208,12 @@ it("deferred generate can reload create_agent after a successful agent write", a
             return { id, source_path: `agents/${id}.ts` };
           },
         }),
+        read_project_secret: tool({
+          id: "read_project_secret",
+          description: "Read a private project secret",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({ value: "redacted" }),
+        }),
       },
       maxSteps: 5,
       resolveModelTransport: () => ({ model }),
@@ -219,14 +225,18 @@ it("deferred generate can reload create_agent after a successful agent write", a
 
   assertEquals(observedTools, [
     ["load_skill", "tool_search"],
-    ["create_agent", "load_skill"],
+    ["create_agent", "load_skill", "tool_search"],
     ["load_skill", "tool_search"],
-    ["create_agent", "load_skill"],
+    ["create_agent", "load_skill", "tool_search"],
     ["load_skill", "tool_search"],
   ]);
   assertEquals(
     observedSystems[2]?.includes("- create_agent: Create a project agent"),
     true,
+  );
+  assertEquals(
+    observedSystems[2]?.includes("- read_project_secret: Read a private project secret"),
+    false,
   );
   assertEquals(executionCount, 2);
   assertEquals(response.text, "Created both agents.");
@@ -234,6 +244,7 @@ it("deferred generate can reload create_agent after a successful agent write", a
 
 it("deferred stream can reload another agent write tool after a successful write", async () => {
   const observedTools: string[][] = [];
+  const observedSystems: string[] = [];
   let step = 0;
   const model: ModelRuntime = {
     provider: "hosted",
@@ -243,6 +254,7 @@ it("deferred stream can reload another agent write tool after a successful write
     },
     async doStream(options: unknown) {
       observedTools.push(toolNames(options));
+      observedSystems.push(systemPrompt(options));
       step++;
       if (step === 1 || step === 3) {
         return {
@@ -283,7 +295,12 @@ it("deferred stream can reload another agent write tool after a successful write
     {
       id: "deferred-agent-authoring-stream-test",
       model: "hosted/deferred-agent-authoring-stream",
-      system: "Create both requested agents, loading create_agent when needed.",
+      system: flattenSystemInstructions(
+        withRuntimeToolInventory(
+          "Create both requested agents, loading create_agent when needed.",
+          [],
+        ),
+      ),
       tools: {
         load_skill: tool({
           id: "load_skill",
@@ -309,6 +326,12 @@ it("deferred stream can reload another agent write tool after a successful write
             return { id, source_path: `agents/${id}.ts` };
           },
         }),
+        read_project_secret: tool({
+          id: "read_project_secret",
+          description: "Read a private project secret",
+          inputSchema: defineSchema((v) => v.object({}))(),
+          execute: () => ({ value: "redacted" }),
+        }),
       },
       maxSteps: 5,
       resolveModelTransport: () => ({ model }),
@@ -326,6 +349,14 @@ it("deferred stream can reload another agent write tool after a successful write
     ["load_skill", "tool_search", "update_agent"],
     ["load_skill", "tool_search"],
   ]);
+  assertEquals(
+    observedSystems[2]?.includes("- update_agent: Update a project agent"),
+    true,
+  );
+  assertEquals(
+    observedSystems[2]?.includes("- read_project_secret: Read a private project secret"),
+    false,
+  );
   assertEquals(executionCounts, { create: 1, update: 1 });
   assertEquals(body.includes("Created both agents."), true);
 });


### PR DESCRIPTION
## Summary

- keep `create_agent` and `update_agent` unavailable immediately after a successful agent write
- keep those authorized tools in the deferred search catalog instead of removing them from the run
- let an explicit `tool_search` reload an agent authoring tool for the next step
- preserve the existing eager-mode final-response guard

## Root cause

The post-write guard passed both tool names as excluded tools and then removed them from the visible, deferred, and authorized exposure sets. In deferred mode, `tool_search` searches only the deferred set, so the model could not recover either authoring tool after the first successful write.

## Red-green evidence

- generate and stream regressions first failed after the first successful write because the second `tool_search` could not expose the requested authoring tool
- the generate regression also covers a catalog with no other deferred tool, which requires the runtime to restore `tool_search` itself
- the stream regression reloads `update_agent` after `create_agent`, covering both guarded authoring tools

## Verification

- focused tool exposure, durability, and runtime refresh suites: 51 tests and 27 BDD steps passed
- `deno task lint:ci`
- generated API reference check
- `git diff --check`

Closes veryfront/veryfront-issue-inbox#463


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent workflows can now defer loading certain tools until they are needed, while keeping tool search available.
  * Repeated discovery and execution of agent creation and update tools now work reliably in both standard and streaming responses.

* **Bug Fixes**
  * Improved tool visibility and execution handling when deferred tools are reloaded.

* **Documentation**
  * Updated the Agent Runtime source reference link in the API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->