### PR TITLE
fix(ssr): preserve terminal cross-project fetch errors

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -1,13 +1,19 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "../../../transforms/plugins/__tests__/code-parser-setup.ts";
-import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { BUILD_FAILED, VeryfrontError } from "#veryfront/errors";
 import { FakeTime } from "#std/testing/time";
 import { join } from "#veryfront/compat/path";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 import { clearSSRModuleCache, clearSSRModuleCacheForProject, SSRModuleLoader } from "./index.ts";
 import { __ssrModuleLoaderInternals } from "./loader.ts";
-import { globalInProgress, globalModuleCache } from "./cache/memory.ts";
+import { globalCrossProjectCache, globalInProgress, globalModuleCache } from "./cache/memory.ts";
 import {
   TRANSFORM_IN_PROGRESS_STALE_EVICTION_MS,
   TRANSFORM_IN_PROGRESS_WAIT_TIMEOUT_MS,
@@ -1311,6 +1317,64 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       globalInProgress.delete(inProgressKey);
       globalModuleCache.delete(contentCacheKey);
       globalModuleCache.delete(filePathCacheKey);
+    }
+  });
+
+  it("preserves a terminal cross-project fetch failure on a cold load", async () => {
+    clearSSRModuleCache();
+    globalCrossProjectCache.clear();
+
+    const projectDir = "/app";
+    const filePath = "/app/app/page.tsx";
+    const projectId = "project-cold-cross-project-terminal";
+    const specifier = "acme-ui@1.2.3/@/components/Button.tsx";
+    const source = [
+      `import Button from "${specifier}";`,
+      `export default function Page() {`,
+      `  return Button;`,
+      `}`,
+    ].join("\n");
+
+    // The failure http-cache.ts raises once its retries are exhausted. The
+    // registry fetch is the only network boundary the loader crosses on this
+    // path, so raising it there reproduces a cold cross-project fetch failure.
+    const fetchError = BUILD_FAILED.create({
+      detail: "Failed to fetch https://esm.sh/marked: AbortError",
+      context: { phase: "http-module-fetch" },
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.includes("acme-ui@1.2.3")) return Promise.reject(fetchError);
+      return originalFetch(input, init);
+    }) as typeof fetch;
+
+    const loader = new SSRModuleLoader({
+      projectDir,
+      projectId,
+      contentSourceId: "release-1",
+      adapter: createProxyProjectAdapter({ "app/page.tsx": source }),
+      apiBaseUrl: "https://registry.example.test/api",
+      dev: true,
+    });
+
+    try {
+      const error = await assertRejects(
+        () => loader.loadRawModule(filePath, source),
+        VeryfrontError,
+        "Failed to fetch https://esm.sh/marked: AbortError",
+      );
+
+      assertStrictEquals(error, fetchError);
+      // The cold path used to swallow this into `missingDependencies`, finish
+      // the transform, and publish a module whose cross-project specifier was
+      // never rewritten. Nothing may reach the cache when the fetch is terminal.
+      assertEquals(globalModuleCache.size, 0);
+      assertEquals(globalCrossProjectCache.size, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      clearSSRModuleCache();
+      globalCrossProjectCache.clear();
     }
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -19,7 +19,7 @@ import {
   TRANSFORM_IN_PROGRESS_WAIT_TIMEOUT_MS,
 } from "./constants.ts";
 import { verifiedHttpBundlePaths } from "./http-bundle-helpers.ts";
-import { buildSSRModuleCacheKey } from "../../../cache/keys.ts";
+import { buildSSRModuleCacheKey, isKeyForProject } from "../../../cache/keys.ts";
 import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 import { computeConfigHashSync } from "../../../cache/config-hash.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
@@ -1335,9 +1335,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       `}`,
     ].join("\n");
 
-    // The failure http-cache.ts raises once its retries are exhausted. The
-    // registry fetch is the only network boundary the loader crosses on this
-    // path, so raising it there reproduces a cold cross-project fetch failure.
+    // The failure `http-cache.ts` raises once its retries are exhausted. In
+    // production it originates deeper — inside `transformToESM` on the fetched
+    // cross-project source — but that call is not injectable from here, so it
+    // is injected synthetically at the registry fetch, the nearest stubbable
+    // boundary. What matters for this test is that a terminal failure escapes
+    // `transformCrossProjectImportFlow`, which rethrows untouched either way.
     const fetchError = BUILD_FAILED.create({
       detail: "Failed to fetch https://esm.sh/marked: AbortError",
       context: { phase: "http-module-fetch" },
@@ -1369,8 +1372,16 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       // The cold path used to swallow this into `missingDependencies`, finish
       // the transform, and publish a module whose cross-project specifier was
       // never rewritten. Nothing may reach the cache when the fetch is terminal.
-      assertEquals(globalModuleCache.size, 0);
-      assertEquals(globalCrossProjectCache.size, 0);
+      // Scoped to this project's keys rather than asserting on total cache size,
+      // so a late write from an earlier test cannot turn this into a flake.
+      assertEquals(
+        [...globalModuleCache.keys()].filter((key) => isKeyForProject(key, projectId)),
+        [],
+      );
+      assertEquals(
+        [...globalCrossProjectCache.keys()].filter((key) => key.includes(projectId)),
+        [],
+      );
     } finally {
       globalThis.fetch = originalFetch;
       clearSSRModuleCache();

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -30,7 +30,6 @@ import {
   getMaxConcurrentTransforms,
   MAX_TRANSFORM_DEPTH,
   TRANSFORM_ACQUIRE_TIMEOUT_MS,
-  TRANSFORM_BATCH_SIZE,
   TRANSFORM_IN_PROGRESS_STALE_EVICTION_MS,
   TRANSFORM_IN_PROGRESS_WAIT_TIMEOUT_MS,
 } from "./constants.ts";
@@ -787,7 +786,6 @@ export class SSRModuleLoader {
       // Each recursive child acquires its own slot for its own transform only.
       // This prevents hierarchical deadlock where parent holds a slot while
       // children also need slots (10 batch x 2 depth = 21 slots, but limit is 17).
-      const crossProjectPaths = new Map<string, string>();
       const localFs = createFileSystem();
 
       const localImportPaths = await this.depValidator.processLocalImports(
@@ -798,25 +796,10 @@ export class SSRModuleLoader {
         dependencyHashCache,
       );
 
-      for (let i = 0; i < parseResult.crossProjectImports.length; i += TRANSFORM_BATCH_SIZE) {
-        const batch = parseResult.crossProjectImports.slice(i, i + TRANSFORM_BATCH_SIZE);
-        await Promise.all(
-          batch.map(async (crossImport) => {
-            try {
-              const tempPath = await this.transformCrossProjectImport(crossImport);
-              crossProjectPaths.set(crossImport.specifier, tempPath);
-            } catch (error) {
-              this.depValidator.missingDependencies.push({
-                specifier: crossImport.specifier,
-                fromFile: filePath,
-                reason: `Failed to fetch cross-project import: ${
-                  error instanceof Error ? error.message : String(error)
-                }`,
-              });
-            }
-          }),
-        );
-      }
+      const crossProjectPaths = await this.depValidator.processCrossProjectImports(
+        parseResult.crossProjectImports,
+        filePath,
+      );
 
       // Hold project slots only around the actual transform and file write.
       const entry = await this.withTransformCapacity(filePath, "build", async () => {

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
@@ -1,15 +1,20 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import { BUILD_FAILED, VeryfrontError } from "#veryfront/errors";
 import { createDependencyHashCache } from "#veryfront/cache/dependency-graph.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 import { makeTempDir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
 import { SSRDependencyValidator } from "./ssr-dependency-validator.ts";
 
 describe("SSRDependencyValidator", () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
   it("preserves terminal HTTP fetch failures from local dependencies", async () => {
     const tempDir = await makeTempDir({ prefix: "vf-ssr-dependency-validator-" });
     const projectDir = join(tempDir, "project");
@@ -103,6 +108,86 @@ describe("SSRDependencyValidator", () => {
     } finally {
       releaseSibling.resolve();
       await remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("preserves terminal HTTP fetch failures from cross-project imports", async () => {
+    const projectDir = "/project";
+    const fetchError = BUILD_FAILED.create({
+      detail: "Failed to fetch https://esm.sh/marked: AbortError",
+      context: { phase: "http-module-fetch" },
+    });
+    const validator = new SSRDependencyValidator(
+      () => Promise.resolve({ tempPath: "/tmp/unused.mjs", contentHash: "unused" }),
+      () => Promise.reject(fetchError),
+      denoAdapter,
+      projectDir,
+    );
+
+    const error = await assertRejects(
+      () =>
+        validator.ensureDependenciesExist(
+          `import "acme-ui@1.2.3/@/components/Button.tsx";`,
+          "/project/page.tsx",
+        ),
+      VeryfrontError,
+      "Failed to fetch https://esm.sh/marked: AbortError",
+    );
+
+    assertEquals(error, fetchError);
+    assertEquals(validator.missingDependencies, []);
+  });
+
+  it("waits for sibling cross-project transforms before propagating a terminal HTTP fetch failure", async () => {
+    const projectDir = "/project";
+    const siblingStarted = Promise.withResolvers<void>();
+    const releaseSibling = Promise.withResolvers<void>();
+    const fetchError = BUILD_FAILED.create({
+      detail: "Failed to fetch https://esm.sh/marked: AbortError",
+      context: { phase: "http-module-fetch" },
+    });
+    const validator = new SSRDependencyValidator(
+      () => Promise.resolve({ tempPath: "/tmp/unused.mjs", contentHash: "unused" }),
+      async (crossProjectImport) => {
+        if (crossProjectImport.specifier === "terminal-ui@1.0.0/@/broken.tsx") {
+          await siblingStarted.promise;
+          throw fetchError;
+        }
+        siblingStarted.resolve();
+        await releaseSibling.promise;
+        throw new Error("Sibling transform failed");
+      },
+      denoAdapter,
+      projectDir,
+    );
+
+    try {
+      let loadSettled = false;
+      const load = validator.ensureDependenciesExist(
+        `
+          import "terminal-ui@1.0.0/@/broken.tsx";
+          import "sibling-ui@1.0.0/@/also-broken.tsx";
+        `,
+        "/project/page.tsx",
+      );
+      void load.catch(() => {
+        loadSettled = true;
+      });
+
+      await siblingStarted.promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assertEquals(loadSettled, false);
+
+      releaseSibling.resolve();
+      const error = await assertRejects(() => load, VeryfrontError);
+      assertEquals(error, fetchError);
+      assertEquals(validator.missingDependencies.length, 1);
+      assertEquals(
+        validator.missingDependencies[0]?.specifier,
+        "sibling-ui@1.0.0/@/also-broken.tsx",
+      );
+    } finally {
+      releaseSibling.resolve();
     }
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import { BUILD_FAILED, VeryfrontError } from "#veryfront/errors";
@@ -46,7 +46,7 @@ describe("SSRDependencyValidator", () => {
         "Failed to fetch https://esm.sh/marked: AbortError",
       );
 
-      assertEquals(error, fetchError);
+      assertStrictEquals(error, fetchError);
       assertEquals(validator.missingDependencies, []);
     } finally {
       await remove(tempDir, { recursive: true });
@@ -104,7 +104,7 @@ describe("SSRDependencyValidator", () => {
 
       releaseSibling.resolve();
       const error = await assertRejects(() => load, VeryfrontError);
-      assertEquals(error, fetchError);
+      assertStrictEquals(error, fetchError);
     } finally {
       releaseSibling.resolve();
       await remove(tempDir, { recursive: true });
@@ -134,7 +134,7 @@ describe("SSRDependencyValidator", () => {
       "Failed to fetch https://esm.sh/marked: AbortError",
     );
 
-    assertEquals(error, fetchError);
+    assertStrictEquals(error, fetchError);
     assertEquals(validator.missingDependencies, []);
   });
 
@@ -180,7 +180,7 @@ describe("SSRDependencyValidator", () => {
 
       releaseSibling.resolve();
       const error = await assertRejects(() => load, VeryfrontError);
-      assertEquals(error, fetchError);
+      assertStrictEquals(error, fetchError);
       assertEquals(validator.missingDependencies.length, 1);
       assertEquals(
         validator.missingDependencies[0]?.specifier,

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -31,6 +31,25 @@ function isTerminalHttpModuleFetchFailure(error: unknown): error is VeryfrontErr
 }
 
 /**
+ * Pick the rejection a settled dependency batch should propagate.
+ *
+ * Both batch loops catch everything except a terminal HTTP module fetch
+ * failure, so today every rejection is that failure. Select on the predicate
+ * rather than on "first rejection" so a throw added outside either try block
+ * later cannot be mistaken for the terminal failure — and fall back to the
+ * first rejection so such a throw is still propagated rather than dropped.
+ */
+function selectPropagatedFailure(
+  results: PromiseSettledResult<unknown>[],
+): PromiseRejectedResult | undefined {
+  const rejections = results.filter((result): result is PromiseRejectedResult =>
+    result.status === "rejected"
+  );
+  return rejections.find((rejection) => isTerminalHttpModuleFetchFailure(rejection.reason)) ??
+    rejections[0];
+}
+
+/**
  * Manages dependency validation for SSR module loading:
  * - Pre-flight checks for local file existence
  * - Recursive dependency resolution
@@ -160,17 +179,7 @@ export class SSRDependencyValidator {
           }
         }),
       );
-      // Only the guarded rethrow above can reject today, but select on the
-      // predicate rather than on "first rejection" so a throw added outside the
-      // try block later cannot be mistaken for the terminal failure. Any other
-      // rejection is still propagated rather than dropped.
-      const rejections = results.filter((result): result is PromiseRejectedResult =>
-        result.status === "rejected"
-      );
-      const terminalFailure = rejections.find((rejection) =>
-        isTerminalHttpModuleFetchFailure(rejection.reason)
-      );
-      const failure = terminalFailure ?? rejections[0];
+      const failure = selectPropagatedFailure(results);
       if (failure) throw failure.reason;
     }
 
@@ -218,8 +227,8 @@ export class SSRDependencyValidator {
           }
         }),
       );
-      const terminalFailure = results.find((result) => result.status === "rejected");
-      if (terminalFailure?.status === "rejected") throw terminalFailure.reason;
+      const failure = selectPropagatedFailure(results);
+      if (failure) throw failure.reason;
     }
 
     return importPathMap;

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -124,11 +124,12 @@ export class SSRDependencyValidator {
 
     for (let i = 0; i < parseResult.crossProjectImports.length; i += TRANSFORM_BATCH_SIZE) {
       const batch = parseResult.crossProjectImports.slice(i, i + TRANSFORM_BATCH_SIZE);
-      await Promise.all(
+      const results = await Promise.allSettled(
         batch.map(async (crossImport) => {
           try {
             await this.transformCrossProjectImport(crossImport);
           } catch (error) {
+            if (isTerminalHttpModuleFetchFailure(error)) throw error;
             this.missingDependencies.push({
               specifier: crossImport.specifier,
               fromFile: filePath,
@@ -139,6 +140,8 @@ export class SSRDependencyValidator {
           }
         }),
       );
+      const terminalFailure = results.find((result) => result.status === "rejected");
+      if (terminalFailure?.status === "rejected") throw terminalFailure.reason;
     }
   }
 

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -122,12 +122,32 @@ export class SSRDependencyValidator {
       createDependencyHashCache(),
     );
 
-    for (let i = 0; i < parseResult.crossProjectImports.length; i += TRANSFORM_BATCH_SIZE) {
-      const batch = parseResult.crossProjectImports.slice(i, i + TRANSFORM_BATCH_SIZE);
+    await this.processCrossProjectImports(parseResult.crossProjectImports, filePath);
+  }
+
+  /**
+   * Process cross-project imports in batches, building a map of
+   * specifier -> temp file path.
+   *
+   * Non-terminal failures are aggregated into {@link missingDependencies} so the
+   * caller can report every unresolved specifier at once. A terminal HTTP module
+   * fetch failure is rethrown untouched instead: it means the source could not be
+   * retrieved at all, so reporting it as a missing dependency would mislabel a
+   * transient network failure as a broken component.
+   */
+  async processCrossProjectImports(
+    crossProjectImports: CrossProjectImport[],
+    filePath: string,
+  ): Promise<Map<string, string>> {
+    const crossProjectPaths = new Map<string, string>();
+
+    for (let i = 0; i < crossProjectImports.length; i += TRANSFORM_BATCH_SIZE) {
+      const batch = crossProjectImports.slice(i, i + TRANSFORM_BATCH_SIZE);
       const results = await Promise.allSettled(
         batch.map(async (crossImport) => {
           try {
-            await this.transformCrossProjectImport(crossImport);
+            const tempPath = await this.transformCrossProjectImport(crossImport);
+            crossProjectPaths.set(crossImport.specifier, tempPath);
           } catch (error) {
             if (isTerminalHttpModuleFetchFailure(error)) throw error;
             this.missingDependencies.push({
@@ -140,9 +160,21 @@ export class SSRDependencyValidator {
           }
         }),
       );
-      const terminalFailure = results.find((result) => result.status === "rejected");
-      if (terminalFailure?.status === "rejected") throw terminalFailure.reason;
+      // Only the guarded rethrow above can reject today, but select on the
+      // predicate rather than on "first rejection" so a throw added outside the
+      // try block later cannot be mistaken for the terminal failure. Any other
+      // rejection is still propagated rather than dropped.
+      const rejections = results.filter((result): result is PromiseRejectedResult =>
+        result.status === "rejected"
+      );
+      const terminalFailure = rejections.find((rejection) =>
+        isTerminalHttpModuleFetchFailure(rejection.reason)
+      );
+      const failure = terminalFailure ?? rejections[0];
+      if (failure) throw failure.reason;
     }
+
+    return crossProjectPaths;
   }
 
   /**


### PR DESCRIPTION
## Summary

Preserve terminal HTTP module fetch failures across cross-project dependency validation, on every path that transforms a cross-project import — including the cold one, where a first-time fetch failure actually happens.

A terminal `BUILD_FAILED` with `context.phase === "http-module-fetch"` means the source could not be retrieved at all. Reporting it as a missing dependency mislabels a transient network failure as a broken component. #3730 fixed that for local imports; this PR completes it for cross-project imports.

## The cold path

The first commit guarded only `ensureDependenciesExist`, which is reached from three cache-validation sites (`loader.ts:602`, `:637`, `:674`). The fresh-transform path ran its **own** duplicate batch loop with no terminal check, so a cold load still converted the terminal error into a generic `missingDependencies` entry.

Because that loop swallowed the failure instead of throwing, the transform also continued. `crossProjectPaths` got no entry, so `rewriteCrossProjectImport` never ran for that specifier, and the module was still written to disk and published to memory and Redis with the raw specifier unrewritten. A transient network blip poisoned the cache, and the un-rewritten specifier was then fetched from esm.sh as if it were an npm package. The throw only happened afterwards, at `loader.ts:472`.

## Changes

- Extract the batch loop into `SSRDependencyValidator.processCrossProjectImports(crossProjectImports, filePath): Promise<Map<string, string>>`, holding the terminal check, the rethrow, and the specifier → tempPath map. `ensureDependenciesExist` calls it and discards the map; the fresh-transform loop in `loader.ts` is a single call that consumes it. The duplicate loop is deleted, not supplemented — `loader.ts` is +4 / −21.
- Extract `selectPropagatedFailure` and use it from both `processCrossProjectImports` and `processLocalImports`, so the two batch loops agree. It selects the rethrown rejection on the terminal predicate rather than on "first rejection", so a `throw` added outside either `try` block later cannot be mistaken for the terminal failure — with a fallback to the first rejection, so such a throw is still propagated rather than dropped.
- Keep sibling transforms in a batch settling before propagating, via `Promise.allSettled`.

## Tests

- `loader.test.ts` — **"preserves a terminal cross-project fetch failure on a cold load"**. This is where the load-bearing regression lives: it drives the real `SSRModuleLoader` with memory, Redis and MDX caches all cold, a stubbed registry fetch raising the terminal error, and asserts `loadRawModule` rejects with **that exact error object** (`assertStrictEquals`) rather than `Component has missing dependencies`. It also asserts nothing is published to the module or cross-project caches, covering the cache-poisoning half.

  Red against the pre-fix source:

  ```
  error: AssertionError: Expected error message to include
    "Failed to fetch https://esm.sh/marked: AbortError",
  but got
    "Failed to fetch https://esm.sh/acme-ui@1.2.3/@/components/Button.tsx: AbortError".
  ```

  That message is the bug in one line — the swallowed error let the transform continue, so the un-rewritten specifier went to esm.sh. Three real outbound retries, 30 seconds, wrong error. After the fix: 1 ms, no outbound request.

- `ssr-dependency-validator.test.ts` — four cases covering terminal propagation and retained sibling diagnostics for both local and cross-project imports, asserting error identity with `assertStrictEquals` (deep equality would accept a re-created error with identical fields).

```
deno test src/modules/react-loader/ssr-module-loader/loader.test.ts                       ok | 24 steps
deno test src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts     ok |  4 steps
deno test src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts  ok |  6 steps
deno fmt --check / deno lint / deno check   clean on all changed files
pre-push hook: format, lint, typecheck, full unit suite
```

## Related

- Follow-up to #3730
