### PR TITLE
fix(whoami): name the .env file a token came from, not just the variable

### DIFF
--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -501,6 +501,67 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
       }
     });
 
+    // The case above loads its `.env` from a temp directory outside the working
+    // directory, so it exercises the degradation branch — the bare name — and
+    // renders ".env" either way. That cannot distinguish a cwd-relative path
+    // from a leaked absolute one, so the headline behaviour needs its own case:
+    // a file *under* the working directory must render relative to it.
+    it("renders a .env under the working directory as a relative path", async () => {
+      const originalFetch = globalThis.fetch;
+      const originalLog = console.log;
+      const output: string[] = [];
+      const { __resetEnvLoaderForTests, loadEnv } = await import("veryfront/utils/env-loader");
+      const { withCwd } = await import("#veryfront/testing/cwd.ts");
+      // The working directory moves to a temp tree rather than the repository,
+      // and `withCwd` serializes that against every other test in the process.
+      // `realPath` first: a macOS temp dir is reached through /var, a symlink to
+      // /private/var, and `cwd()` reports the resolved form — comparing the
+      // unresolved path would make the fixture look like it sits outside cwd.
+      const root = await Deno.realPath(
+        await Deno.makeTempDir({ prefix: "whoami-env-relative-" }),
+      );
+      const nested = `${root}/config`;
+
+      try {
+        deleteEnv("VERYFRONT_API_TOKEN");
+        __resetEnvLoaderForTests();
+        await Deno.mkdir(nested, { recursive: true });
+        await Deno.writeTextFile(`${nested}/.env`, "VERYFRONT_API_TOKEN=vf_nested\n");
+        await loadEnv({ cwd: nested });
+
+        globalThis.fetch = (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ data: [], page_info: {} }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          )) as typeof fetch;
+        console.log = (message?: unknown) => output.push(String(message));
+
+        const { whoami } = await import("./login.ts");
+        await withCwd(root, () =>
+          whoami({
+            ...testEnv,
+            apiBaseUrl: "https://auth.example.test",
+            apiUrl: undefined,
+            apiToken: "vf_nested",
+          }));
+
+        const printed = output.join("\n");
+        // Relative to the working directory, and therefore never the absolute
+        // path — which is what the bare-name fallback cannot prove.
+        assertStringIncludes(printed, "./config/.env");
+        assertEquals(printed.includes(root), false);
+        assertEquals(printed.includes("vf_nested"), false);
+      } finally {
+        console.log = originalLog;
+        globalThis.fetch = originalFetch;
+        __resetEnvLoaderForTests();
+        deleteEnv("VERYFRONT_API_TOKEN");
+        await Deno.remove(root, { recursive: true });
+      }
+    });
+
     it("still reports a real environment variable without inventing a file", async () => {
       const originalFetch = globalThis.fetch;
       const originalLog = console.log;

--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -17,7 +17,7 @@ import {
   describe,
   it,
 } from "#veryfront/testing/bdd.ts";
-import { deleteEnv, getEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { deleteEnv, getEnv, setEnv } from "veryfront/platform";
 import { deleteToken, readToken, saveToken } from "./token-store.ts";
 import { makeTempDir, remove } from "#veryfront/platform/compat/fs.ts";
 import {
@@ -460,9 +460,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
       const originalFetch = globalThis.fetch;
       const originalLog = console.log;
       const output: string[] = [];
-      const { __resetEnvLoaderForTests, loadEnv } = await import(
-        "#veryfront/utils/env-loader.ts"
-      );
+      const { __resetEnvLoaderForTests, loadEnv } = await import("veryfront/utils/env-loader");
       const envDir = await Deno.makeTempDir({ prefix: "whoami-env-source-" });
 
       try {
@@ -507,7 +505,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
       const originalFetch = globalThis.fetch;
       const originalLog = console.log;
       const output: string[] = [];
-      const { __resetEnvLoaderForTests } = await import("#veryfront/utils/env-loader.ts");
+      const { __resetEnvLoaderForTests } = await import("veryfront/utils/env-loader");
 
       try {
         __resetEnvLoaderForTests();

--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -606,6 +606,51 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
       }
     });
 
+    it("does not attribute an injected API token to a different loaded .env token", async () => {
+      const originalFetch = globalThis.fetch;
+      const originalLog = console.log;
+      const output: string[] = [];
+      const { __resetEnvLoaderForTests, loadEnv } = await import("veryfront/utils/env-loader");
+      const envDir = await Deno.makeTempDir({ prefix: "whoami-env-mismatch-" });
+
+      try {
+        deleteEnv("VERYFRONT_API_TOKEN");
+        __resetEnvLoaderForTests();
+        await Deno.writeTextFile(`${envDir}/.env`, "VERYFRONT_API_TOKEN=vf_from_dotenv\n");
+        await loadEnv({ cwd: envDir });
+
+        globalThis.fetch = (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ data: [], page_info: {} }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          )) as typeof fetch;
+        console.log = (message?: unknown) => output.push(String(message));
+
+        const { whoami } = await import("./login.ts");
+        await whoami({
+          ...testEnv,
+          apiBaseUrl: "https://auth.example.test",
+          apiUrl: undefined,
+          apiToken: "vf_injected",
+        });
+
+        const printed = output.join("\n");
+        assertStringIncludes(printed, "(via VERYFRONT_API_TOKEN)");
+        assertEquals(printed.includes(".env"), false);
+        assertEquals(printed.includes(envDir), false);
+        assertEquals(printed.includes("vf_from_dotenv"), false);
+        assertEquals(printed.includes("vf_injected"), false);
+      } finally {
+        console.log = originalLog;
+        globalThis.fetch = originalFetch;
+        __resetEnvLoaderForTests();
+        deleteEnv("VERYFRONT_API_TOKEN");
+        await Deno.remove(envDir, { recursive: true });
+      }
+    });
+
     it("still reports a real environment variable without inventing a file", async () => {
       const originalFetch = globalThis.fetch;
       const originalLog = console.log;

--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -563,47 +563,15 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
     });
 
     it("falls back to the .env filename for Windows cross-drive paths", async () => {
-      const originalFetch = globalThis.fetch;
-      const originalLog = console.log;
-      const output: string[] = [];
-      const { __resetEnvLoaderForTests, loadEnv } = await import("veryfront/utils/env-loader");
-      const envDir = "D:/whoami-env-cross-drive";
+      const { formatEnvSourcePathForDisplay } = await import("./login.ts");
 
-      try {
-        deleteEnv("VERYFRONT_API_TOKEN");
-        __resetEnvLoaderForTests();
-        await Deno.mkdir(envDir, { recursive: true });
-        await Deno.writeTextFile(`${envDir}/.env`, "VERYFRONT_API_TOKEN=vf_cross_drive\n");
-        await loadEnv({ cwd: envDir });
-
-        globalThis.fetch = (() =>
-          Promise.resolve(
-            new Response(JSON.stringify({ data: [], page_info: {} }), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          )) as typeof fetch;
-        console.log = (message?: unknown) => output.push(String(message));
-
-        const { whoami } = await import("./login.ts");
-        await whoami({
-          ...testEnv,
-          apiBaseUrl: "https://auth.example.test",
-          apiUrl: undefined,
-          apiToken: "vf_cross_drive",
-        });
-
-        const printed = output.join("\n");
-        assertStringIncludes(printed, "from .env");
-        assertEquals(printed.includes("D:/whoami-env-cross-drive"), false);
-        assertEquals(printed.includes("vf_cross_drive"), false);
-      } finally {
-        console.log = originalLog;
-        globalThis.fetch = originalFetch;
-        __resetEnvLoaderForTests();
-        deleteEnv("VERYFRONT_API_TOKEN");
-        await Deno.remove("D:", { recursive: true });
-      }
+      assertEquals(
+        formatEnvSourcePathForDisplay(
+          "D:/whoami-env-cross-drive/.env",
+          "C:/veryfront-project",
+        ),
+        ".env",
+      );
     });
 
     it("does not attribute an injected API token to a different loaded .env token", async () => {

--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -562,6 +562,50 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
       }
     });
 
+    it("falls back to the .env filename for Windows cross-drive paths", async () => {
+      const originalFetch = globalThis.fetch;
+      const originalLog = console.log;
+      const output: string[] = [];
+      const { __resetEnvLoaderForTests, loadEnv } = await import("veryfront/utils/env-loader");
+      const envDir = "D:/whoami-env-cross-drive";
+
+      try {
+        deleteEnv("VERYFRONT_API_TOKEN");
+        __resetEnvLoaderForTests();
+        await Deno.mkdir(envDir, { recursive: true });
+        await Deno.writeTextFile(`${envDir}/.env`, "VERYFRONT_API_TOKEN=vf_cross_drive\n");
+        await loadEnv({ cwd: envDir });
+
+        globalThis.fetch = (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ data: [], page_info: {} }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          )) as typeof fetch;
+        console.log = (message?: unknown) => output.push(String(message));
+
+        const { whoami } = await import("./login.ts");
+        await whoami({
+          ...testEnv,
+          apiBaseUrl: "https://auth.example.test",
+          apiUrl: undefined,
+          apiToken: "vf_cross_drive",
+        });
+
+        const printed = output.join("\n");
+        assertStringIncludes(printed, "from .env");
+        assertEquals(printed.includes("D:/whoami-env-cross-drive"), false);
+        assertEquals(printed.includes("vf_cross_drive"), false);
+      } finally {
+        console.log = originalLog;
+        globalThis.fetch = originalFetch;
+        __resetEnvLoaderForTests();
+        deleteEnv("VERYFRONT_API_TOKEN");
+        await Deno.remove("D:", { recursive: true });
+      }
+    });
+
     it("still reports a real environment variable without inventing a file", async () => {
       const originalFetch = globalThis.fetch;
       const originalLog = console.log;

--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -502,7 +502,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
     });
 
     // The case above loads its `.env` from a temp directory outside the working
-    // directory, so it exercises the degradation branch — the bare name — and
+    // directory, so it exercises the degradation branch, the bare name, and
     // renders ".env" either way. That cannot distinguish a cwd-relative path
     // from a leaked absolute one, so the headline behaviour needs its own case:
     // a file *under* the working directory must render relative to it.
@@ -515,7 +515,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
       // The working directory moves to a temp tree rather than the repository,
       // and `withCwd` serializes that against every other test in the process.
       // `realPath` first: a macOS temp dir is reached through /var, a symlink to
-      // /private/var, and `cwd()` reports the resolved form — comparing the
+      // /private/var, and `cwd()` reports the resolved form. Comparing the
       // unresolved path would make the fixture look like it sits outside cwd.
       const root = await Deno.realPath(
         await Deno.makeTempDir({ prefix: "whoami-env-relative-" }),
@@ -549,7 +549,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
 
         const printed = output.join("\n");
         // Relative to the working directory, and therefore never the absolute
-        // path — which is what the bare-name fallback cannot prove.
+        // path, which is what the bare-name fallback cannot prove.
         assertStringIncludes(printed, "./config/.env");
         assertEquals(printed.includes(root), false);
         assertEquals(printed.includes("vf_nested"), false);

--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -452,6 +452,94 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
         globalThis.fetch = originalFetch;
       }
     });
+
+    it("names the .env file when the token came from one, not just the variable", async () => {
+      // A token loaded from a `.env` in the working directory silently overrides
+      // the stored login. Reporting only "via VERYFRONT_API_TOKEN" sends the
+      // developer to check an environment variable that is genuinely unset.
+      const originalFetch = globalThis.fetch;
+      const originalLog = console.log;
+      const output: string[] = [];
+      const { __resetEnvLoaderForTests, loadEnv } = await import(
+        "#veryfront/utils/env-loader.ts"
+      );
+      const envDir = await Deno.makeTempDir({ prefix: "whoami-env-source-" });
+
+      try {
+        deleteEnv("VERYFRONT_API_TOKEN");
+        __resetEnvLoaderForTests();
+        await Deno.writeTextFile(`${envDir}/.env`, "VERYFRONT_API_TOKEN=vf_from_dotenv\n");
+        await loadEnv({ cwd: envDir });
+
+        globalThis.fetch = (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ data: [], page_info: {} }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          )) as typeof fetch;
+        console.log = (message?: unknown) => output.push(String(message));
+
+        const { whoami } = await import("./login.ts");
+        await whoami({
+          ...testEnv,
+          apiBaseUrl: "https://auth.example.test",
+          apiUrl: undefined,
+          apiToken: "vf_from_dotenv",
+        });
+
+        const printed = output.join("\n");
+        assertStringIncludes(printed, "VERYFRONT_API_TOKEN");
+        assertStringIncludes(printed, ".env");
+        // Never leak the token itself, and never print an absolute machine path.
+        assertEquals(printed.includes("vf_from_dotenv"), false);
+        assertEquals(printed.includes(envDir), false);
+      } finally {
+        console.log = originalLog;
+        globalThis.fetch = originalFetch;
+        __resetEnvLoaderForTests();
+        deleteEnv("VERYFRONT_API_TOKEN");
+        await Deno.remove(envDir, { recursive: true });
+      }
+    });
+
+    it("still reports a real environment variable without inventing a file", async () => {
+      const originalFetch = globalThis.fetch;
+      const originalLog = console.log;
+      const output: string[] = [];
+      const { __resetEnvLoaderForTests } = await import("#veryfront/utils/env-loader.ts");
+
+      try {
+        __resetEnvLoaderForTests();
+        setEnv("VERYFRONT_API_TOKEN", "vf_from_process");
+
+        globalThis.fetch = (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ data: [], page_info: {} }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          )) as typeof fetch;
+        console.log = (message?: unknown) => output.push(String(message));
+
+        const { whoami } = await import("./login.ts");
+        await whoami({
+          ...testEnv,
+          apiBaseUrl: "https://auth.example.test",
+          apiUrl: undefined,
+          apiToken: "vf_from_process",
+        });
+
+        const printed = output.join("\n");
+        assertStringIncludes(printed, "VERYFRONT_API_TOKEN");
+        assertEquals(printed.includes(".env"), false);
+      } finally {
+        console.log = originalLog;
+        globalThis.fetch = originalFetch;
+        __resetEnvLoaderForTests();
+        deleteEnv("VERYFRONT_API_TOKEN");
+      }
+    });
   });
 
   describe("UserInfo type", { sanitizeOps: false, sanitizeResources: false }, () => {

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -17,7 +17,7 @@ import { createSuccessEnvelope, isJsonMode, outputJson } from "../shared/json-ou
 import { isInteractive } from "../shared/interactive.ts";
 import { getEnvSource } from "veryfront/utils/env-loader";
 import { basename, isAbsolute, relative } from "veryfront/platform/path";
-import { cwd } from "veryfront/platform";
+import { cwd, getEnv } from "veryfront/platform";
 
 /**
  * Describe where an API-token credential actually came from.
@@ -29,9 +29,11 @@ import { cwd } from "veryfront/platform";
  * directory-dependent for every command that infers a project from config, so
  * this is worth the extra clause.
  */
-function describeApiTokenSource(): string {
+function describeApiTokenSource(token: string): string {
   const origin = getEnvSource("VERYFRONT_API_TOKEN");
-  if (origin.source !== "env-file") return "(via VERYFRONT_API_TOKEN)";
+  if (origin.source !== "env-file" || getEnv("VERYFRONT_API_TOKEN") !== token) {
+    return "(via VERYFRONT_API_TOKEN)";
+  }
 
   // Repo-relative only: AGENTS.md forbids local absolute paths in user-facing
   // output. A file outside the working directory, including a Windows
@@ -446,7 +448,9 @@ async function reportCredential(
 
   console.log(
     "  " + dim(
-      source === "env" ? describeApiTokenSource() : `Token stored at: ${getTokenLocation(env)}`,
+      source === "env"
+        ? describeApiTokenSource(token)
+        : `Token stored at: ${getTokenLocation(env)}`,
     ),
   );
   return credential;

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -36,12 +36,17 @@ function describeApiTokenSource(): string {
   // Repo-relative only: AGENTS.md forbids local absolute paths in user-facing
   // output. A file outside the working directory degrades to its name rather
   // than exposing the layout above it.
+  // A bare filename stays bare (`.env`); anything nested is prefixed so it
+  // reads unambiguously as a path (`./config/.env`). The test is for a
+  // separator rather than a leading ".", because a dot-*directory* also starts
+  // with one — `.config/.env` would otherwise be the only nested path printed
+  // without the prefix.
   const rel = relative(cwd(), origin.file);
   const shown = !rel || rel.startsWith("..")
     ? basename(origin.file)
-    : rel.startsWith(".")
-    ? rel
-    : `./${rel}`;
+    : /[/\\]/.test(rel) && !rel.startsWith("./")
+    ? `./${rel}`
+    : rel;
   return `(via VERYFRONT_API_TOKEN from ${shown})`;
 }
 

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -15,6 +15,35 @@ import {
 } from "../shared/constants.ts";
 import { createSuccessEnvelope, isJsonMode, outputJson } from "../shared/json-output.ts";
 import { isInteractive } from "../shared/interactive.ts";
+import { getEnvSource } from "#veryfront/utils/env-loader.ts";
+import { relative } from "#veryfront/compat/path";
+import { cwd } from "veryfront/platform";
+
+/**
+ * Describe where an API-token credential actually came from.
+ *
+ * `.env` files in the working directory are loaded into the environment, so a
+ * token can arrive under `VERYFRONT_API_TOKEN` while that variable is unset in
+ * the developer's shell. Reporting only the variable name sends them to check
+ * something they can see is empty; naming the file ends the search. Identity is
+ * directory-dependent for every command that infers a project from config, so
+ * this is worth the extra clause.
+ */
+function describeApiTokenSource(): string {
+  const origin = getEnvSource("VERYFRONT_API_TOKEN");
+  if (origin.source !== "env-file") return "(via VERYFRONT_API_TOKEN)";
+
+  // Repo-relative only: AGENTS.md forbids local absolute paths in user-facing
+  // output. A file outside the working directory degrades to its name rather
+  // than exposing the layout above it.
+  const rel = relative(cwd(), origin.file);
+  const shown = !rel || rel.startsWith("..")
+    ? origin.file.split("/").pop() ?? origin.file
+    : rel.startsWith(".")
+    ? rel
+    : `./${rel}`;
+  return `(via VERYFRONT_API_TOKEN from ${shown})`;
+}
 
 export type AuthMethod = "google" | "github" | "microsoft" | "token";
 
@@ -412,7 +441,7 @@ async function reportCredential(
 
   console.log(
     "  " + dim(
-      source === "env" ? "(via VERYFRONT_API_TOKEN)" : `Token stored at: ${getTokenLocation(env)}`,
+      source === "env" ? describeApiTokenSource() : `Token stored at: ${getTokenLocation(env)}`,
     ),
   );
   return credential;

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -15,8 +15,8 @@ import {
 } from "../shared/constants.ts";
 import { createSuccessEnvelope, isJsonMode, outputJson } from "../shared/json-output.ts";
 import { isInteractive } from "../shared/interactive.ts";
-import { getEnvSource } from "#veryfront/utils/env-loader.ts";
-import { relative } from "#veryfront/compat/path";
+import { getEnvSource } from "veryfront/utils/env-loader";
+import { basename, relative } from "veryfront/platform/path";
 import { cwd } from "veryfront/platform";
 
 /**
@@ -38,7 +38,7 @@ function describeApiTokenSource(): string {
   // than exposing the layout above it.
   const rel = relative(cwd(), origin.file);
   const shown = !rel || rel.startsWith("..")
-    ? origin.file.split("/").pop() ?? origin.file
+    ? basename(origin.file)
     : rel.startsWith(".")
     ? rel
     : `./${rel}`;

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -29,12 +29,7 @@ import { cwd, getEnv } from "veryfront/platform";
  * directory-dependent for every command that infers a project from config, so
  * this is worth the extra clause.
  */
-function describeApiTokenSource(token: string): string {
-  const origin = getEnvSource("VERYFRONT_API_TOKEN");
-  if (origin.source !== "env-file" || getEnv("VERYFRONT_API_TOKEN") !== token) {
-    return "(via VERYFRONT_API_TOKEN)";
-  }
-
+export function formatEnvSourcePathForDisplay(file: string, currentCwd = cwd()): string {
   // Repo-relative only: AGENTS.md forbids local absolute paths in user-facing
   // output. A file outside the working directory, including a Windows
   // cross-drive result, degrades to its name rather than exposing the layout.
@@ -43,13 +38,22 @@ function describeApiTokenSource(token: string): string {
   // separator rather than a leading ".", because a dot-*directory* also starts
   // with one, so `.config/.env` would otherwise be the only nested path printed
   // without the prefix.
-  const rel = relative(cwd(), origin.file);
+  const rel = relative(currentCwd, file);
   const shown = rel === "." || rel.startsWith("..") || isAbsolute(rel)
-    ? basename(origin.file)
+    ? basename(file)
     : /[/\\]/.test(rel) && !rel.startsWith("./")
     ? `./${rel}`
     : rel;
-  return `(via VERYFRONT_API_TOKEN from ${shown})`;
+  return shown;
+}
+
+function describeApiTokenSource(token: string): string {
+  const origin = getEnvSource("VERYFRONT_API_TOKEN");
+  if (origin.source !== "env-file" || getEnv("VERYFRONT_API_TOKEN") !== token) {
+    return "(via VERYFRONT_API_TOKEN)";
+  }
+
+  return `(via VERYFRONT_API_TOKEN from ${formatEnvSourcePathForDisplay(origin.file)})`;
 }
 
 export type AuthMethod = "google" | "github" | "microsoft" | "token";

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -39,7 +39,7 @@ function describeApiTokenSource(): string {
   // A bare filename stays bare (`.env`); anything nested is prefixed so it
   // reads unambiguously as a path (`./config/.env`). The test is for a
   // separator rather than a leading ".", because a dot-*directory* also starts
-  // with one — `.config/.env` would otherwise be the only nested path printed
+  // with one, so `.config/.env` would otherwise be the only nested path printed
   // without the prefix.
   const rel = relative(cwd(), origin.file);
   const shown = !rel || rel.startsWith("..")

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -16,7 +16,7 @@ import {
 import { createSuccessEnvelope, isJsonMode, outputJson } from "../shared/json-output.ts";
 import { isInteractive } from "../shared/interactive.ts";
 import { getEnvSource } from "veryfront/utils/env-loader";
-import { basename, relative } from "veryfront/platform/path";
+import { basename, isAbsolute, relative } from "veryfront/platform/path";
 import { cwd } from "veryfront/platform";
 
 /**
@@ -34,15 +34,15 @@ function describeApiTokenSource(): string {
   if (origin.source !== "env-file") return "(via VERYFRONT_API_TOKEN)";
 
   // Repo-relative only: AGENTS.md forbids local absolute paths in user-facing
-  // output. A file outside the working directory degrades to its name rather
-  // than exposing the layout above it.
+  // output. A file outside the working directory, including a Windows
+  // cross-drive result, degrades to its name rather than exposing the layout.
   // A bare filename stays bare (`.env`); anything nested is prefixed so it
   // reads unambiguously as a path (`./config/.env`). The test is for a
   // separator rather than a leading ".", because a dot-*directory* also starts
   // with one, so `.config/.env` would otherwise be the only nested path printed
   // without the prefix.
   const rel = relative(cwd(), origin.file);
-  const shown = !rel || rel.startsWith("..")
+  const shown = rel === "." || rel.startsWith("..") || isAbsolute(rel)
     ? basename(origin.file)
     : /[/\\]/.test(rel) && !rel.startsWith("./")
     ? `./${rel}`


### PR DESCRIPTION
Found while dogfooding the deploy journey against published v0.1.1237. Recorded as FINDING-007 in that run.

## Problem

`whoami` reports `(via VERYFRONT_API_TOKEN)` for a token loaded out of a `.env` in the working directory, while that variable is genuinely unset in the developer's shell:

```text
$ printenv VERYFRONT_API_TOKEN        # unset

$ cd <REPO_DIR> && veryfront whoami      # this dir has a .env
  ✓ Authenticated with an API key
  (via VERYFRONT_API_TOKEN)

$ cd <OTHER_DIR> && veryfront whoami
  ✓ Logged in as <REDACTED_EMAIL>
  Token stored at: <REDACTED_HOME>/.config/veryfront/token
```

Same shell, same CLI, same user. Identity depends on the working directory, and the message names a variable the developer can verify is empty. Anyone debugging "why am I the wrong user" checks their environment, finds nothing, and is stuck.

This is not only cosmetic. `veryfront project delete` infers its target "from env/config", so which project a destructive command resolves against depends on where it was run from.

## Change

`getEnvSource()` already distinguishes an env-file value from a process one and records the path. `whoami` just never asked it. Now:

```text
  ✓ Authenticated with an API key
  (via VERYFRONT_API_TOKEN from .env)
```

Verified against published 0.1.1238 in the same directory:

| | |
|---|---|
| before | `(via VERYFRONT_API_TOKEN)` |
| after | `(via VERYFRONT_API_TOKEN from .env)` |

The path is cwd-relative. AGENTS.md forbids local absolute paths in user-facing output, and a file outside the working directory degrades to its bare name rather than exposing the layout above it.

Unchanged: the stored-login branch and the JSON envelope. Adding a field there would break its existing deep-equal assertion, and the confusion is in the human output.

## Tests

- env-file case: fails before this change
- control: a real environment variable still reports no file, so the message cannot start inventing paths

Both assert the token itself never appears in output.

## Note on verification

My first reproduction attempt did not reproduce because it used a fake token. `reportCredential` validates against the API and falls through to the token store when the credential is rejected, so the env branch was never reached. The real symptom needs a valid token in a `.env`; the before/after above was captured that way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New features
  * Improved credential status reporting to identify whether API tokens come from environment files or process environment variables.
  * Displays repository-relative or filename-only environment-file paths while protecting token values and sensitive absolute paths.

* Bug fixes
  * Prevented misleading file references for process-environment credentials.
  * Improved handling of relative environment-file paths and cross-drive path scenarios.
  * Added safeguards for mismatched injected tokens and reliable environment cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
