### PR TITLE
feat(integrations): opt safe connector defaults into model schemas

### DIFF
--- a/docs/api-reference/veryfront/integrations.md
+++ b/docs/api-reference/veryfront/integrations.md
@@ -42,11 +42,11 @@ const runtimeTools = await getRemoteIntegrationToolDefinitions();
 | Name                                         | Description                        | Source                                                                                          |
 | -------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `EnvVarSchema`                               | Zod schema for env var.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L235) |
-| `IntegrationConfigSchema`                    | Zod schema for integration config. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L477) |
-| `IntegrationEndpointHistoricalSummarySchema` |                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L376) |
+| `IntegrationConfigSchema`                    | Zod schema for integration config. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L480) |
+| `IntegrationEndpointHistoricalSummarySchema` |                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L379) |
 | `IntegrationNameSchema`                      | Zod schema for integration name.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L214) |
-| `IntegrationPromptSchema`                    | Zod schema for integration prompt. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L450) |
-| `IntegrationToolSchema`                      | Zod schema for integration tool.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L418) |
+| `IntegrationPromptSchema`                    | Zod schema for integration prompt. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L453) |
+| `IntegrationToolSchema`                      | Zod schema for integration tool.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L421) |
 | `OAuthConfigSchema`                          | Zod schema for oauth config.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L300) |
 | `OAuthFieldSchema`                           | Zod schema for oauth field.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L248) |
 
@@ -67,14 +67,14 @@ const runtimeTools = await getRemoteIntegrationToolDefinitions();
 
 | Name                                   | Description                                                                           | Source                                                                                               |
 | -------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `EnvVarConfig`                         | Configuration used by env var.                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L482)      |
-| `IntegrationConfig`                    | Configuration used by integration.                                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L496)      |
-| `IntegrationConnector`                 | Public API contract for integration connector.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L75)        |
-| `IntegrationEndpointHistoricalSummary` | Provider-declared summary contract for old tool outputs kept actionable across turns. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L490)      |
-| `IntegrationName`                      | Public API contract for integration name.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L480)      |
-| `IntegrationPrompt`                    | Public API contract for integration prompt.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L494)      |
-| `IntegrationTool`                      | Public API contract for integration tool.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L66)        |
-| `IntegrationToolMeta`                  | Public API contract for integration tool meta.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L488)      |
-| `OAuthConfig`                          | Configuration used by oauth.                                                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L486)      |
-| `OAuthField`                           | Public API contract for oauth field.                                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L484)      |
+| `EnvVarConfig`                         | Configuration used by env var.                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L485)      |
+| `IntegrationConfig`                    | Configuration used by integration.                                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L499)      |
+| `IntegrationConnector`                 | Public API contract for integration connector.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L77)        |
+| `IntegrationEndpointHistoricalSummary` | Provider-declared summary contract for old tool outputs kept actionable across turns. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L493)      |
+| `IntegrationName`                      | Public API contract for integration name.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L483)      |
+| `IntegrationPrompt`                    | Public API contract for integration prompt.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L497)      |
+| `IntegrationTool`                      | Public API contract for integration tool.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/types.ts#L68)        |
+| `IntegrationToolMeta`                  | Public API contract for integration tool meta.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L491)      |
+| `OAuthConfig`                          | Configuration used by oauth.                                                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L489)      |
+| `OAuthField`                           | Public API contract for oauth field.                                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/schema.ts#L487)      |
 | `RemoteIntegrationToolDiscoveryResult` | Result of listing the integration tools available to the current run.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/integrations/remote-tools.ts#L84) |

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -449,6 +449,7 @@ describe("integration endpoint specs", () => {
         true,
         `Expected ${tool.id} to expose its safe SOQL default`,
       );
+      assertExists(tool.id, "Expected exposed Salesforce tools to declare an id");
       exposedToolIds.push(tool.id);
       exposedDefaults += 1;
     }

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -426,13 +426,22 @@ describe("integration endpoint specs", () => {
     );
   });
 
-  it("opts every curated Salesforce SOQL default into model-facing schemas", () => {
+  it("opts only scoped Salesforce SOQL defaults into model-facing schemas", () => {
     const connector = getConnector("salesforce");
     let exposedDefaults = 0;
 
     for (const tool of connector.tools) {
       const query = tool.endpoint?.params?.q;
       if (query?.default === undefined) continue;
+
+      if (tool.id === "salesforce__list_case_activity") {
+        assertEquals(
+          query.exposeDefault,
+          undefined,
+          "Expected unscoped CaseComment query to stay out of model-facing schemas",
+        );
+        continue;
+      }
 
       assertEquals(
         query.exposeDefault,
@@ -442,7 +451,7 @@ describe("integration endpoint specs", () => {
       exposedDefaults += 1;
     }
 
-    assertEquals(exposedDefaults, 7);
+    assertEquals(exposedDefaults, 6);
   });
 
   it("declares Service Cloud support tools", () => {

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -426,6 +426,25 @@ describe("integration endpoint specs", () => {
     );
   });
 
+  it("opts every curated Salesforce SOQL default into model-facing schemas", () => {
+    const connector = getConnector("salesforce");
+    let exposedDefaults = 0;
+
+    for (const tool of connector.tools) {
+      const query = tool.endpoint?.params?.q;
+      if (query?.default === undefined) continue;
+
+      assertEquals(
+        query.exposeDefault,
+        true,
+        `Expected ${tool.id} to expose its safe SOQL default`,
+      );
+      exposedDefaults += 1;
+    }
+
+    assertEquals(exposedDefaults, 7);
+  });
+
   it("declares Service Cloud support tools", () => {
     const expected = [
       "find_customer",

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -428,6 +428,7 @@ describe("integration endpoint specs", () => {
 
   it("opts only scoped Salesforce SOQL defaults into model-facing schemas", () => {
     const connector = getConnector("salesforce");
+    const exposedToolIds: string[] = [];
     let exposedDefaults = 0;
 
     for (const tool of connector.tools) {
@@ -448,9 +449,18 @@ describe("integration endpoint specs", () => {
         true,
         `Expected ${tool.id} to expose its safe SOQL default`,
       );
+      exposedToolIds.push(tool.id);
       exposedDefaults += 1;
     }
 
+    assertEquals(exposedToolIds, [
+      "salesforce__find_customer",
+      "salesforce__search_accounts",
+      "salesforce__search_contacts",
+      "salesforce__list_cases",
+      "salesforce__search_knowledge_articles",
+      "salesforce__list_opportunities",
+    ]);
     assertEquals(exposedDefaults, 6);
   });
 

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -47525,6 +47525,7 @@ export const connectors: IntegrationConfig[] = [
               "SOQL Contact query. Include Account fields when the agent needs customer context.",
             "default":
               "SELECT Id, FirstName, LastName, Email, Phone, Title, AccountId, Account.Name, Account.Type, Account.Industry FROM Contact ORDER BY LastModifiedDate DESC LIMIT 25",
+            "exposeDefault": true,
           },
         },
         "response": { "transform": "records" },
@@ -47544,6 +47545,7 @@ export const connectors: IntegrationConfig[] = [
             "description": "SOQL Account query",
             "default":
               "SELECT Id, Name, Type, Industry, Phone, Website, OwnerId, LastModifiedDate FROM Account ORDER BY LastModifiedDate DESC LIMIT 50",
+            "exposeDefault": true,
           },
         },
         "response": { "transform": "records" },
@@ -47580,6 +47582,7 @@ export const connectors: IntegrationConfig[] = [
             "description": "SOQL query for contacts",
             "default":
               "SELECT Id, FirstName, LastName, Email, Phone, Title, AccountId, Account.Name FROM Contact ORDER BY LastModifiedDate DESC LIMIT 50",
+            "exposeDefault": true,
           },
         },
         "response": { "transform": "records" },
@@ -47617,6 +47620,7 @@ export const connectors: IntegrationConfig[] = [
               "SOQL Case query. Filter by ContactId, AccountId, Status, OwnerId, Priority, or CreatedDate as needed.",
             "default":
               "SELECT Id, CaseNumber, Subject, Status, Priority, Origin, ContactId, AccountId, OwnerId, CreatedDate, LastModifiedDate FROM Case ORDER BY LastModifiedDate DESC LIMIT 50",
+            "exposeDefault": true,
           },
         },
         "response": { "transform": "records" },
@@ -47655,6 +47659,7 @@ export const connectors: IntegrationConfig[] = [
               "SOQL CaseComment query. Add WHERE ParentId = '<caseId>' to inspect one case.",
             "default":
               "SELECT Id, ParentId, CommentBody, CreatedDate, CreatedById, IsPublished FROM CaseComment ORDER BY CreatedDate DESC LIMIT 50",
+            "exposeDefault": true,
           },
         },
         "response": { "transform": "records" },
@@ -47676,6 +47681,7 @@ export const connectors: IntegrationConfig[] = [
               "SOQL KnowledgeArticleVersion query. Filter by Title, Summary, DataCategory, or language when needed.",
             "default":
               "SELECT Id, KnowledgeArticleId, Title, Summary, UrlName, Language, LastPublishedDate FROM KnowledgeArticleVersion WHERE PublishStatus = 'Online' ORDER BY LastPublishedDate DESC LIMIT 25",
+            "exposeDefault": true,
           },
         },
         "response": { "transform": "records" },
@@ -47695,6 +47701,7 @@ export const connectors: IntegrationConfig[] = [
             "description": "SOQL query for opportunities",
             "default":
               "SELECT Id, Name, StageName, Amount, CloseDate, AccountId, OwnerId, LastModifiedDate FROM Opportunity ORDER BY CloseDate DESC LIMIT 50",
+            "exposeDefault": true,
           },
         },
         "response": { "transform": "records" },

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -47659,7 +47659,6 @@ export const connectors: IntegrationConfig[] = [
               "SOQL CaseComment query. Add WHERE ParentId = '<caseId>' to inspect one case.",
             "default":
               "SELECT Id, ParentId, CommentBody, CreatedDate, CreatedById, IsPublished FROM CaseComment ORDER BY CreatedDate DESC LIMIT 50",
-            "exposeDefault": true,
           },
         },
         "response": { "transform": "records" },

--- a/src/integrations/schema.test.ts
+++ b/src/integrations/schema.test.ts
@@ -1,0 +1,17 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getIntegrationEndpointParamSchema } from "./schema.ts";
+
+describe("IntegrationEndpointParamSchema", () => {
+  it("preserves an explicit model-facing default opt-in", () => {
+    const parsed = getIntegrationEndpointParamSchema().parse({
+      type: "string",
+      in: "query",
+      description: "SOQL query",
+      default: "SELECT Id FROM Case LIMIT 50",
+      exposeDefault: true,
+    });
+
+    assertEquals(parsed.exposeDefault, true);
+  });
+});

--- a/src/integrations/schema.test.ts
+++ b/src/integrations/schema.test.ts
@@ -1,3 +1,4 @@
+import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { getIntegrationEndpointParamSchema } from "./schema.ts";

--- a/src/integrations/schema.ts
+++ b/src/integrations/schema.ts
@@ -306,6 +306,9 @@ export const getIntegrationEndpointParamSchema = defineSchema((v) =>
     description: v.string(),
     required: v.boolean().optional(),
     default: v.unknown().optional(),
+    // Opts this execution default into the model-facing tool input schema.
+    // Use only when the value is safe and useful as model guidance.
+    exposeDefault: v.boolean().optional(),
     // For query params only: the HTTP query parameter name to send when it differs
     // from the agent-facing parameter key (e.g. input query -> query param $search).
     queryName: v.string().optional(),

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -10,6 +10,8 @@ export interface IntegrationEndpointParam {
   description: string;
   required?: boolean;
   default?: unknown;
+  /** Expose this safe execution default in the model-facing tool input schema. */
+  exposeDefault?: boolean;
   queryName?: string;
   queryValueFormat?: "microsoft-graph-search";
   headerName?: string;

--- a/templates/integrations/salesforce/connector.json
+++ b/templates/integrations/salesforce/connector.json
@@ -194,8 +194,7 @@
             "type": "string",
             "in": "query",
             "description": "SOQL CaseComment query. Add WHERE ParentId = '<caseId>' to inspect one case.",
-            "default": "SELECT Id, ParentId, CommentBody, CreatedDate, CreatedById, IsPublished FROM CaseComment ORDER BY CreatedDate DESC LIMIT 50",
-            "exposeDefault": true
+            "default": "SELECT Id, ParentId, CommentBody, CreatedDate, CreatedById, IsPublished FROM CaseComment ORDER BY CreatedDate DESC LIMIT 50"
           }
         },
         "response": {

--- a/templates/integrations/salesforce/connector.json
+++ b/templates/integrations/salesforce/connector.json
@@ -52,7 +52,8 @@
             "type": "string",
             "in": "query",
             "description": "SOQL Contact query. Include Account fields when the agent needs customer context.",
-            "default": "SELECT Id, FirstName, LastName, Email, Phone, Title, AccountId, Account.Name, Account.Type, Account.Industry FROM Contact ORDER BY LastModifiedDate DESC LIMIT 25"
+            "default": "SELECT Id, FirstName, LastName, Email, Phone, Title, AccountId, Account.Name, Account.Type, Account.Industry FROM Contact ORDER BY LastModifiedDate DESC LIMIT 25",
+            "exposeDefault": true
           }
         },
         "response": {
@@ -73,7 +74,8 @@
             "type": "string",
             "in": "query",
             "description": "SOQL Account query",
-            "default": "SELECT Id, Name, Type, Industry, Phone, Website, OwnerId, LastModifiedDate FROM Account ORDER BY LastModifiedDate DESC LIMIT 50"
+            "default": "SELECT Id, Name, Type, Industry, Phone, Website, OwnerId, LastModifiedDate FROM Account ORDER BY LastModifiedDate DESC LIMIT 50",
+            "exposeDefault": true
           }
         },
         "response": {
@@ -112,7 +114,8 @@
             "type": "string",
             "in": "query",
             "description": "SOQL query for contacts",
-            "default": "SELECT Id, FirstName, LastName, Email, Phone, Title, AccountId, Account.Name FROM Contact ORDER BY LastModifiedDate DESC LIMIT 50"
+            "default": "SELECT Id, FirstName, LastName, Email, Phone, Title, AccountId, Account.Name FROM Contact ORDER BY LastModifiedDate DESC LIMIT 50",
+            "exposeDefault": true
           }
         },
         "response": {
@@ -151,7 +154,8 @@
             "type": "string",
             "in": "query",
             "description": "SOQL Case query. Filter by ContactId, AccountId, Status, OwnerId, Priority, or CreatedDate as needed.",
-            "default": "SELECT Id, CaseNumber, Subject, Status, Priority, Origin, ContactId, AccountId, OwnerId, CreatedDate, LastModifiedDate FROM Case ORDER BY LastModifiedDate DESC LIMIT 50"
+            "default": "SELECT Id, CaseNumber, Subject, Status, Priority, Origin, ContactId, AccountId, OwnerId, CreatedDate, LastModifiedDate FROM Case ORDER BY LastModifiedDate DESC LIMIT 50",
+            "exposeDefault": true
           }
         },
         "response": {
@@ -190,7 +194,8 @@
             "type": "string",
             "in": "query",
             "description": "SOQL CaseComment query. Add WHERE ParentId = '<caseId>' to inspect one case.",
-            "default": "SELECT Id, ParentId, CommentBody, CreatedDate, CreatedById, IsPublished FROM CaseComment ORDER BY CreatedDate DESC LIMIT 50"
+            "default": "SELECT Id, ParentId, CommentBody, CreatedDate, CreatedById, IsPublished FROM CaseComment ORDER BY CreatedDate DESC LIMIT 50",
+            "exposeDefault": true
           }
         },
         "response": {
@@ -211,7 +216,8 @@
             "type": "string",
             "in": "query",
             "description": "SOQL KnowledgeArticleVersion query. Filter by Title, Summary, DataCategory, or language when needed.",
-            "default": "SELECT Id, KnowledgeArticleId, Title, Summary, UrlName, Language, LastPublishedDate FROM KnowledgeArticleVersion WHERE PublishStatus = 'Online' ORDER BY LastPublishedDate DESC LIMIT 25"
+            "default": "SELECT Id, KnowledgeArticleId, Title, Summary, UrlName, Language, LastPublishedDate FROM KnowledgeArticleVersion WHERE PublishStatus = 'Online' ORDER BY LastPublishedDate DESC LIMIT 25",
+            "exposeDefault": true
           }
         },
         "response": {
@@ -232,7 +238,8 @@
             "type": "string",
             "in": "query",
             "description": "SOQL query for opportunities",
-            "default": "SELECT Id, Name, StageName, Amount, CloseDate, AccountId, OwnerId, LastModifiedDate FROM Opportunity ORDER BY CloseDate DESC LIMIT 50"
+            "default": "SELECT Id, Name, StageName, Amount, CloseDate, AccountId, OwnerId, LastModifiedDate FROM Opportunity ORDER BY CloseDate DESC LIMIT 50",
+            "exposeDefault": true
           }
         },
         "response": {


### PR DESCRIPTION
## Summary

- add an explicit `exposeDefault` opt-in to integration endpoint parameters
- mark six scoped Salesforce SOQL defaults as safe model guidance and keep the unscoped CaseComment query hidden
- regenerate the integration catalog and public reference

This is additive package metadata. It does not expose any default by itself; the coordinated API change controls the model-facing schema.

## Red-green TDD

The schema regression failed first because it stripped `exposeDefault`. A later red-first safety regression proved the unscoped CaseComment default was model-visible. The final catalog exposes only the six scoped query defaults and keeps CaseComment opt-in.

## Verification

- exact-head focused integration schema/catalog tests: 42 steps passed
- exact-head format, lint, and type checks: passed
- exact-head GitHub CI: 28 passed, 6 expected skips, 0 failures
- generated integration data and API reference checks: passed
- `git diff --check`: passed

No Studio UI is changed. No screenshot is applicable.

Tracks veryfront/veryfront-issue-inbox#455.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Salesforce integration tools now expose curated default queries in their tool input schemas for customer, account, contact, case, knowledge article, and opportunity workflows.
  - Integration parameters can indicate whether safe default values should appear in model-facing tool schemas.

- **Documentation**
  - Updated API reference source links to accurately point to the relevant integration schema and type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
