### PR TITLE
test: type runtime test filters

### DIFF
--- a/tests/test-file-utils.mjs
+++ b/tests/test-file-utils.mjs
@@ -165,6 +165,12 @@ export function splitIntoShards(files, shardCount) {
   return shards;
 }
 
+/**
+ * @param {string[]} files
+ * @param {{ include?: string[]; exclude?: string[] }} [filters]
+ * @param {string} [cwd]
+ * @returns {string[]}
+ */
 export function filterTestFiles(files, { include = [], exclude = [] } = {}, cwd = process.cwd()) {
   if (files.length === 0) return [];
   const includeMatchers = include.map((pattern) => globToRegex(toPosixPath(pattern)));


### PR DESCRIPTION
## Summary

- Adds a JSDoc contract to `filterTestFiles` so TypeScript callers see `include` and `exclude` as `string[]` filters.
- Fixes the standalone `deno check tests/runtime-test-filters.test.ts` diagnostic that PR #3743 missed because it merged before the type-only helper commit landed.
- Preserves runtime behavior; this is a JSDoc-only follow-up.

## Verification

- Red before fix: Deno 2.7.7 `deno check tests/runtime-test-filters.test.ts` failed at `tests/runtime-test-filters.test.ts:39:53` and `:45:52` with `string[]` not assignable to `never[]`.
- Green after fix: `Deno 2.7.7 deno check tests/runtime-test-filters.test.ts`.
- Green after fix: pinned Deno focused runtime filter test, `1 passed (4 steps), 0 failed`.
- Green after fix: pinned Deno `deno task fmt:check`, `deno task lint:ci`, `deno task typecheck`.
- Full pre-push: first run exposed unrelated timing failures in `src/agent/runtime/project-files-client.test.ts` and `src/react/compat/ssr-adapter/stream-renderer.test.ts`; both exact files passed on direct rerun. Second full `.husky/pre-push` run passed with `All pre-push checks passed!`.


## Final readiness

- Exact head: `d23d0694eaf58693bc5a502dde3ac087c2e8e4c8`.
- Exact-head GitHub CI is green with no pending or failed checks.
- Review threads: 0 unresolved.
- Fresh independent Standards and Spec reviews both approved at 98% confidence.
- Aggregate merge confidence: 98%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing the test file filtering utility, including its inputs, working directory, and return value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->