### PR TITLE
Prevent Anthropic cache mutation during request serialization

### DIFF
--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -600,6 +600,92 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
     });
   });
 
+  it("rejects raw provider bucket accessors before cache budgeting", () => {
+    let hookCalls = 0;
+    const tools = Array.from({ length: 5 }, (_, index) => ({
+      name: `bucket-hook-${index}`,
+      input_schema: { type: "object", properties: {} },
+      cache_control: () => "omitted",
+    })) as Array<Record<string, unknown>>;
+    const anthropic = { tools } as Record<string, unknown>;
+    Object.defineProperty(anthropic, "model", {
+      enumerable: true,
+      get() {
+        hookCalls += 1;
+        for (const tool of tools) {
+          tool.cache_control = { type: "ephemeral" };
+        }
+        return "mutated-model";
+      },
+    });
+
+    let thrown: unknown;
+    try {
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+          providerOptions: { anthropic },
+        },
+        false,
+        createWarningCollector(),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    assertEquals(hookCalls, 0);
+    assertEquals(thrown instanceof TypeError, true);
+    assertEquals(
+      (thrown as Error).message,
+      "Anthropic provider options could not be inspected",
+    );
+  });
+
+  it("rejects raw provider thinking accessors before cache budgeting", () => {
+    let hookCalls = 0;
+    const tools = Array.from({ length: 5 }, (_, index) => ({
+      name: `thinking-hook-${index}`,
+      input_schema: { type: "object", properties: {} },
+      cache_control: () => "omitted",
+    })) as Array<Record<string, unknown>>;
+    const thinking = { budget_tokens: 1024 } as Record<string, unknown>;
+    Object.defineProperty(thinking, "type", {
+      enumerable: true,
+      get() {
+        hookCalls += 1;
+        for (const tool of tools) {
+          tool.cache_control = { type: "ephemeral" };
+        }
+        return "enabled";
+      },
+    });
+
+    let thrown: unknown;
+    try {
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+          providerOptions: { anthropic: { thinking, tools } },
+        },
+        false,
+        createWarningCollector(),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    assertEquals(hookCalls, 0);
+    assertEquals(thrown instanceof TypeError, true);
+    assertEquals(
+      (thrown as Error).message,
+      "Anthropic provider thinking.type must be a non-empty string",
+    );
+  });
+
   it("uses descriptor snapshots during TTL normalization", async () => {
     const result = await runNoBrandEval(`
       const { buildAnthropicMessagesRequest } = await import(

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -502,6 +502,104 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
     });
   });
 
+  it("uses the captured array constructor for cache snapshots", async () => {
+    const result = await runNoBrandEval(`
+      const NativeArray = Array;
+      const { buildAnthropicMessagesRequest } = await import(
+        "./extensions/ext-llm-anthropic/src/anthropic-request-builder.ts"
+      );
+      function MutableArray() {
+        return {};
+      }
+      Object.defineProperty(MutableArray, "isArray", {
+        value: NativeArray.isArray,
+      });
+      Object.defineProperty(globalThis, "Array", {
+        configurable: true,
+        value: MutableArray,
+      });
+
+      let body;
+      try {
+        body = buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+          },
+          false,
+          { push() {}, drain() { return []; } },
+        );
+      } finally {
+        Object.defineProperty(globalThis, "Array", {
+          configurable: true,
+          value: NativeArray,
+          writable: true,
+        });
+      }
+      console.log(JSON.stringify({
+        isArray: NativeArray.isArray(body.messages),
+        messages: body.messages,
+      }));
+    `);
+
+    assertEquals(result, {
+      isArray: true,
+      messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+    });
+  });
+
+  it("uses captured assignment when merging raw provider options", async () => {
+    const result = await runNoBrandEval(`
+      const { buildAnthropicMessagesRequest } = await import(
+        "./extensions/ext-llm-anthropic/src/anthropic-request-builder.ts"
+      );
+      const originalAssign = Object.assign;
+      let mutableAssignCalls = 0;
+      Object.assign = function(target) {
+        mutableAssignCalls += 1;
+        return target;
+      };
+
+      let body;
+      try {
+        body = buildAnthropicMessagesRequest(
+          "claude-sonnet-4-6",
+          "anthropic",
+          {
+            prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+            providerOptions: {
+              anthropic: {
+                tools: [{
+                  name: "cached-tool",
+                  input_schema: { type: "object", properties: {} },
+                  cache_control: { type: "ephemeral" },
+                }],
+              },
+            },
+          },
+          false,
+          { push() {}, drain() { return []; } },
+        );
+      } finally {
+        Object.assign = originalAssign;
+      }
+      console.log(JSON.stringify({
+        mutableAssignCalls,
+        tools: body.tools,
+      }));
+    `);
+
+    assertEquals(result, {
+      mutableAssignCalls: 0,
+      tools: [{
+        name: "cached-tool",
+        input_schema: { type: "object", properties: {} },
+        cache_control: { type: "ephemeral" },
+      }],
+    });
+  });
+
   it("uses descriptor snapshots during TTL normalization", async () => {
     const result = await runNoBrandEval(`
       const { buildAnthropicMessagesRequest } = await import(
@@ -1832,6 +1930,47 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
       "Anthropic cache inputs must not define toJSON hooks",
     );
     assertEquals(hookCalls, 0);
+  });
+
+  it("rejects earlier request-field hooks before budgeting tool breakpoints", () => {
+    let hookCalls = 0;
+    const tools = Array.from({ length: 5 }, (_, index) => ({
+      name: `body-hook-${index}`,
+      input_schema: { type: "object", properties: {} },
+      cache_control: () => "omitted",
+    })) as Array<Record<string, unknown>>;
+    const model = {
+      toJSON() {
+        hookCalls += 1;
+        for (const tool of tools) {
+          tool.cache_control = { type: "ephemeral" };
+        }
+        return "mutated-model";
+      },
+    };
+
+    let thrown: unknown;
+    try {
+      buildAnthropicMessagesRequest(
+        "claude-sonnet-4-6",
+        "anthropic",
+        {
+          prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+          providerOptions: { anthropic: { model, tools } },
+        },
+        false,
+        createWarningCollector(),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    assertEquals(hookCalls, 0);
+    assertEquals(thrown instanceof TypeError, true);
+    assertEquals(
+      (thrown as Error).message,
+      "Anthropic cache inputs must not define toJSON hooks",
+    );
   });
 
   it("rejects boxed primitive coercion before budgeting tool breakpoints", () => {

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -48,6 +48,7 @@ const objectGetPrototypeOf = Object.getPrototypeOf;
 const objectHasOwn = Object.hasOwn;
 const objectKeys = Object.keys;
 const reflectDeleteProperty = Reflect.deleteProperty;
+const reflectOwnKeys = Reflect.ownKeys;
 const setAdd = Set.prototype.add;
 const setDelete = Set.prototype.delete;
 const setHas = Set.prototype.has;
@@ -1773,14 +1774,70 @@ function readJsonSerializedAnthropicString(value: unknown): string | undefined {
   throw new TypeError("Anthropic cache strings must use primitive string values");
 }
 
-function prepareAnthropicProviderOptions(
-  providerOptions: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
-  if (providerOptions === undefined || canIdentifyProxyWithoutHooks) {
-    return providerOptions;
+function snapshotAnthropicProviderBucket(
+  bucket: object,
+): Record<string, unknown> {
+  if (isProxyWithoutHooks(bucket)) {
+    throw new TypeError("Anthropic provider options could not be inspected");
   }
 
+  const snapshot: Record<string, unknown> = {};
+  let keys: PropertyKey[];
   try {
+    keys = apply(reflectOwnKeys, Reflect, [bucket]) as PropertyKey[];
+  } catch {
+    throw new TypeError("Anthropic provider options could not be inspected");
+  }
+  for (let index = 0; index < keys.length; index += 1) {
+    const key = keys[index]!;
+    if (typeof key !== "string") continue;
+
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = objectGetOwnPropertyDescriptor(bucket, key);
+    } catch {
+      throw new TypeError("Anthropic provider options could not be inspected");
+    }
+    if (descriptor?.enumerable !== true) continue;
+    if (!objectHasOwn(descriptor, "value")) {
+      throw new TypeError("Anthropic provider options could not be inspected");
+    }
+    defineOwnEnumerableDataProperty(snapshot, key, descriptor.value);
+  }
+  return snapshot;
+}
+
+function prepareAnthropicProviderOptions(
+  providerOptions: Record<string, unknown> | undefined,
+  ...providerNames: string[]
+): Record<string, unknown> | undefined {
+  if (providerOptions === undefined) return undefined;
+
+  try {
+    if (canIdentifyProxyWithoutHooks) {
+      if (isProxyWithoutHooks(providerOptions)) {
+        throw new TypeError("Anthropic provider options could not be inspected");
+      }
+      const snapshot: Record<string, unknown> = {};
+      for (let index = 0; index < providerNames.length; index += 1) {
+        const providerName = providerNames[index]!;
+        const descriptor = objectGetOwnPropertyDescriptor(providerOptions, providerName);
+        if (descriptor === undefined) continue;
+        if (!objectHasOwn(descriptor, "value")) {
+          throw new TypeError("Anthropic provider options could not be inspected");
+        }
+        const value = descriptor.value;
+        defineOwnEnumerableDataProperty(
+          snapshot,
+          providerName,
+          value !== null && typeof value === "object" && !ArrayIsArray(value)
+            ? snapshotAnthropicProviderBucket(value)
+            : value,
+        );
+      }
+      return snapshot;
+    }
+
     const snapshot = snapshotProviderJsonValue(providerOptions, {
       dropUndefinedMembers: true,
       sortObjectKeys: false,
@@ -2195,18 +2252,31 @@ function resolveAnthropicThinkingBudget(
 function resolveAnthropicProviderThinkingBudget(
   options: Record<string, unknown>,
 ): number | undefined {
-  const thinking = options.thinking;
+  const thinkingProperty = readOwnEnumerableDataProperty(options, "thinking");
+  if (!thinkingProperty) {
+    throw new TypeError("Anthropic provider thinking must be an object");
+  }
+  const thinking = thinkingProperty.present ? thinkingProperty.value : undefined;
   if (thinking === undefined) {
     return undefined;
   }
-  if (thinking === null || typeof thinking !== "object" || Array.isArray(thinking)) {
+  if (
+    thinking === null || typeof thinking !== "object" || ArrayIsArray(thinking) ||
+    isProxyWithoutHooks(thinking)
+  ) {
     throw new TypeError("Anthropic provider thinking must be an object");
   }
-  const record = thinking as Record<string, unknown>;
-  if (typeof record.type !== "string" || record.type.length === 0) {
+  const type = readOwnEnumerableDataProperty(thinking, "type");
+  if (!type?.present || typeof type.value !== "string" || type.value.length === 0) {
     throw new TypeError("Anthropic provider thinking.type must be a non-empty string");
   }
-  const budgetTokens = record.budget_tokens;
+  const budgetTokensProperty = readOwnEnumerableDataProperty(thinking, "budget_tokens");
+  if (!budgetTokensProperty) {
+    throw new TypeError(
+      "Anthropic provider thinking.budget_tokens must be a safe integer of at least 1024",
+    );
+  }
+  const budgetTokens = budgetTokensProperty.present ? budgetTokensProperty.value : undefined;
   if (
     budgetTokens !== undefined &&
     (!Number.isSafeInteger(budgetTokens) || (budgetTokens as number) < 1024)
@@ -2215,7 +2285,7 @@ function resolveAnthropicProviderThinkingBudget(
       "Anthropic provider thinking.budget_tokens must be a safe integer of at least 1024",
     );
   }
-  if (record.type !== "enabled") {
+  if (type.value !== "enabled") {
     return undefined;
   }
   if (budgetTokens === undefined) {
@@ -2255,7 +2325,7 @@ export function buildAnthropicMessagesRequestWithCorrelationState(
     toolsCacheControl,
   );
   const rawProviderOptions = readProviderOptions(
-    prepareAnthropicProviderOptions(options.providerOptions),
+    prepareAnthropicProviderOptions(options.providerOptions, "anthropic", providerName),
     "anthropic",
     providerName,
   );

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -36,10 +36,12 @@ import {
 type ProviderCacheTtl = boolean | "5m" | "1h";
 
 const apply = Reflect.apply;
+const NativeArray = Array;
 const ArrayIsArray = Array.isArray;
 const booleanValueOf = Boolean.prototype.valueOf;
 const NativeSet = Set;
 const numberValueOf = Number.prototype.valueOf;
+const objectAssign = Object.assign;
 const objectDefineProperty = Object.defineProperty;
 const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const objectGetPrototypeOf = Object.getPrototypeOf;
@@ -1554,7 +1556,7 @@ function snapshotAnthropicCacheArray<T>(
   label: string,
 ): T[] {
   assertNoAnthropicCacheJsonHook(value);
-  const snapshot = new Array<T>(value.length);
+  const snapshot = new NativeArray<T>(value.length);
   for (let index = 0; index < value.length; index += 1) {
     let descriptor: PropertyDescriptor | undefined;
     try {
@@ -1671,7 +1673,7 @@ function retainLatestAnthropicMessageCacheBreakpoints(
     return messages;
   }
 
-  const normalizedMessages = new Array<AnthropicCompatibleMessage>(messages.length);
+  const normalizedMessages = new NativeArray<AnthropicCompatibleMessage>(messages.length);
   for (let messageIndex = 0; messageIndex < messages.length; messageIndex += 1) {
     const message = readAnthropicArrayDataElement(
       messages,
@@ -1955,7 +1957,7 @@ function retainLatestAnthropicCacheBreakpoints(
   values: Array<Record<string, unknown>>,
   maximum: number,
 ): Array<Record<string, unknown>> {
-  const breakpointIndexes = new Array<number>(values.length);
+  const breakpointIndexes = new NativeArray<number>(values.length);
   let breakpointCount = 0;
   for (let index = 0; index < values.length; index += 1) {
     const descriptor = objectGetOwnPropertyDescriptor(values, `${index}`);
@@ -1973,7 +1975,7 @@ function retainLatestAnthropicCacheBreakpoints(
     return values;
   }
 
-  const retained = new Array<Record<string, unknown>>(values.length);
+  const retained = new NativeArray<Record<string, unknown>>(values.length);
   for (let index = 0; index < values.length; index += 1) {
     const descriptor = objectGetOwnPropertyDescriptor(values, `${index}`);
     if (descriptor !== undefined) {
@@ -2081,6 +2083,32 @@ function assertAnthropicCacheableRequestFields(
   }
   if (body.tools !== undefined && !ArrayIsArray(body.tools)) {
     throw new TypeError("Anthropic tools must be an array");
+  }
+
+  const keys = objectKeys(body);
+  let lastCacheFieldIndex = -1;
+  for (let index = 0; index < keys.length; index += 1) {
+    const key = keys[index];
+    if (key === "messages" || key === "system" || key === "tools") {
+      lastCacheFieldIndex = index;
+    }
+  }
+  for (let index = 0; index <= lastCacheFieldIndex; index += 1) {
+    const key = keys[index]!;
+    if (key === "messages" || key === "system" || key === "tools") {
+      continue;
+    }
+    const descriptor = objectGetOwnPropertyDescriptor(body, key);
+    if (!descriptor || !objectHasOwn(descriptor, "value")) {
+      throw new TypeError("Anthropic request fields must use enumerable data properties");
+    }
+    const value = descriptor.value;
+    if (
+      value !== null &&
+      (typeof value === "object" || typeof value === "function")
+    ) {
+      assertNoNestedAnthropicCacheJsonHooks(value, "Anthropic request fields");
+    }
   }
 }
 
@@ -2357,7 +2385,7 @@ export function buildAnthropicMessagesRequestWithCorrelationState(
     ...(options.anthropicContainer !== undefined ? { container: options.anthropicContainer } : {}),
   };
 
-  Object.assign(body, rawProviderOptions);
+  apply(objectAssign, Object, [body, rawProviderOptions]);
   if (thinkingBudget !== undefined || providerThinkingBudget !== undefined) {
     body.thinking = { type: "enabled", budget_tokens: effectiveThinkingBudget };
   }


### PR DESCRIPTION
## Summary

- Snapshot selected raw Anthropic provider buckets through captured property descriptors before `readProviderOptions` can enumerate or read them.
- Reject serialization-visible bucket accessors and the early nested `thinking` accessors without invoking them, so cache controls cannot change before breakpoint budgeting.
- Preserve normal raw provider values, including JSON-omitted extension values, while retaining the existing edge-runtime deep snapshot and Proxy rejection.
- Capture the native `Array` constructor and `Object.assign` so application code cannot corrupt cache snapshots or raw provider-option merging after module import.
- Preserve existing cache-control semantics, breakpoint ordering, and conversation history shaping.

## Context

This is a follow-up to #3437, which merged before its final review findings could land.

It addresses the remaining [`Array` constructor review finding](https://github.com/veryfront/veryfront-code/pull/3437#discussion_r3790346678) and the related raw-provider-options serialization cases. An earlier field such as `model.toJSON` could mutate five initially omitted tool `cache_control` values after the builder counted zero breakpoints, causing native `JSON.stringify` to emit five.

A subsequent review found that an enumerable raw provider bucket accessor was even earlier: `readProviderOptions` used `Object.entries` before the cache assertion, invoking a `model` getter twice when the canonical provider name and alias matched. The regression reproduced two getter calls, while a sibling `thinking.type` accessor reproduced three. Both now fail closed with zero hook calls.

## Validation

Validated with pinned Deno 2.7.7:

- Request builder: 1 passed, 88 steps
- Full Anthropic extension: 6 passed, 241 steps
- Touched format check: 2 files
- Touched lint: 2 files
- Builder typecheck: passed
- `git diff --check`: passed
- Full repository pre-push hook:
  - Repository format: 5,047 files
  - Repository lint: 4,972 files
  - `deno check src/index.ts`: passed
  - Unit suite: 3,849 passed, 28,671 steps, 0 failed, 1 ignored
  - Cwd suite: 10 passed, 197 steps
  - Cwd exclusion suite: 2 passed

## Risk

The change is limited to Anthropic request construction. The Node-compatible path snapshots only the selected provider buckets and retains nested raw values, avoiding the compatibility expansion of deep-snapshotting every raw option. It fails closed only when raw request behavior would execute before cache budgeting. Live Anthropic transport serialization was not exercised.
