### PR TITLE
fix(trigger): reject stored non-agent conversation targets

### DIFF
--- a/docs/api-reference/veryfront/trigger.md
+++ b/docs/api-reference/veryfront/trigger.md
@@ -44,11 +44,11 @@ if (dailyTriage) {
 
 | Name                             | Description                                                                                   | Source                                                                                           |
 | -------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `conversationConflictDiagnostic` | Describe a conversation pair that disagrees across two locations.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L173)       |
-| `declarationConflictDiagnostic`  | Describe one value declared in two places with disagreeing content.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L154)       |
+| `conversationConflictDiagnostic` | Describe a conversation pair that disagrees across two locations.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L179)       |
+| `declarationConflictDiagnostic`  | Describe one value declared in two places with disagreeing content.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L160)       |
 | `discoverSourceTriggers`         | Discover, validate, normalize, and deterministically de-duplicate source trigger definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L354)    |
 | `isTriggerId`                    | Return true for a bounded canonical slash-separated trigger identifier.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/validation.ts#L8)     |
-| `isTriggerTarget`                | Return true only for canonical targets stored in own data properties.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L307)       |
+| `isTriggerTarget`                | Return true only for canonical targets stored in own data properties.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L313)       |
 | `runTriggerTarget`               | Discover and execute one canonical task, workflow, or agent target.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/local-runner.ts#L367) |
 
 ### Types

--- a/docs/api-reference/veryfront/trigger.md
+++ b/docs/api-reference/veryfront/trigger.md
@@ -44,11 +44,11 @@ if (dailyTriage) {
 
 | Name                             | Description                                                                                   | Source                                                                                           |
 | -------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `conversationConflictDiagnostic` | Describe a conversation pair that disagrees across two locations.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L170)       |
-| `declarationConflictDiagnostic`  | Describe one value declared in two places with disagreeing content.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L151)       |
+| `conversationConflictDiagnostic` | Describe a conversation pair that disagrees across two locations.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L173)       |
+| `declarationConflictDiagnostic`  | Describe one value declared in two places with disagreeing content.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L154)       |
 | `discoverSourceTriggers`         | Discover, validate, normalize, and deterministically de-duplicate source trigger definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L354)    |
 | `isTriggerId`                    | Return true for a bounded canonical slash-separated trigger identifier.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/validation.ts#L8)     |
-| `isTriggerTarget`                | Return true only for canonical targets stored in own data properties.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L304)       |
+| `isTriggerTarget`                | Return true only for canonical targets stored in own data properties.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L307)       |
 | `runTriggerTarget`               | Discover and execute one canonical task, workflow, or agent target.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/local-runner.ts#L367) |
 
 ### Types
@@ -57,7 +57,7 @@ if (dailyTriage) {
 | --------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `AgentConversationMode`           | Hosted conversation behavior for an agent trigger target.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L4)        |
 | `AgentTriggerTarget`              | Trigger target addressing an agent definition and its hosted conversation.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L31)       |
-| `ResolvedTriggerTarget`           | Validated target value that narrows conversation fields by `kind`.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L58)       |
+| `ResolvedTriggerTarget`           | Validated target value that narrows conversation fields by `kind`.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L61)       |
 | `RunTriggerTargetOptions`         | Options for one local trigger target execution.                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/local-runner.ts#L30) |
 | `SourceTriggerDiscoveryError`     | Structured failure produced while discovering one source definition.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L34)    |
 | `SourceTriggerDiscoveryErrorCode` | Stable failure categories emitted while discovering source triggers.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L25)    |
@@ -69,6 +69,6 @@ if (dailyTriage) {
 | `TriggerDiscoveryOptions`         | Shared filesystem, directory, and source-kind options for trigger discovery.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L73)    |
 | `TriggerTarget`                   | Canonical reference to a runnable project definition.                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L43)       |
 | `TriggerTargetConfig`             | Author-facing target shape accepting stored base values and kind-specific literals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L51)       |
-| `TriggerTargetKind`               | Supported local trigger target kinds.                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L64)       |
+| `TriggerTargetKind`               | Supported local trigger target kinds.                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L67)       |
 | `TriggerTargetRunResult`          | Successful local trigger target result.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/local-runner.ts#L56) |
 | `WorkflowTriggerTarget`           | Trigger target addressing a workflow definition.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L19)       |

--- a/docs/concepts/webhook.md
+++ b/docs/concepts/webhook.md
@@ -80,6 +80,8 @@ Agent targets require `agentMessage.promptTemplate`. Use `{{payload}}` for the
 pretty-printed complete payload or `{{payload.dot.path}}` for one nested value:
 
 ```ts
+import { webhook } from "veryfront/webhook";
+
 export default webhook({
   id: "support-escalation",
   target: { kind: "agent", id: "support-agent", conversationMode: "create_new" },
@@ -116,6 +118,8 @@ target-level addressing reads `agentMessage`, a platform that reads the target
 reads the target, and both find the value you wrote.
 
 ```ts
+import { webhook } from "veryfront/webhook";
+
 export default webhook({
   id: "support-escalation",
   target: { kind: "agent", id: "support-agent", conversationMode: "create_new" },

--- a/scripts/typecheck/README.md
+++ b/scripts/typecheck/README.md
@@ -42,6 +42,9 @@ consumer's own `@types/react`. This gate is the regression guard.
 - [`fixtures/trigger-target-config.ts`](./fixtures/trigger-target-config.ts) —
   checks stored trigger targets under `exactOptionalPropertyTypes` across the
   schedule, webhook, and local-run authoring surfaces.
+- [`fixtures/trigger-target-default-optional.ts`](./fixtures/trigger-target-default-optional.ts) —
+  checks that explicit `undefined` fields on stored non-agent targets remain
+  assignable with TypeScript's default optional-property semantics.
 
 Add a fixture whenever a new public compound ships; keep them importing the
 published specifiers (not relative `src` paths) so they exercise the real

--- a/scripts/typecheck/README.md
+++ b/scripts/typecheck/README.md
@@ -1,9 +1,8 @@
 # Consumer typecheck gate
 
-`deno task typecheck:consumer` typechecks the documented `veryfront/ui` and
-`veryfront/chat` composition **the way an external app compiles the published
-package** — real `tsc --noEmit`, real `@types/react`, against the emitted
-`.d.ts` in `npm/`.
+`deno task typecheck:consumer` typechecks documented UI, chat, and trigger
+composition **the way an external app compiles the published package** — real
+`tsc --noEmit`, real `@types/react`, against the emitted `.d.ts` in `npm/`.
 
 ## Why this exists (the gap it closes)
 
@@ -40,6 +39,9 @@ consumer's own `@types/react`. This gate is the regression guard.
 - [`fixtures/chat-composition.tsx`](./fixtures/chat-composition.tsx) — batteries
   `<Chat>`, the `<Chat.Root>` compound, `Message`, `ChatSidebar`, via
   `veryfront/chat`.
+- [`fixtures/trigger-target-config.ts`](./fixtures/trigger-target-config.ts) —
+  checks stored trigger targets under `exactOptionalPropertyTypes` across the
+  schedule, webhook, and local-run authoring surfaces.
 
 Add a fixture whenever a new public compound ships; keep them importing the
 published specifiers (not relative `src` paths) so they exercise the real

--- a/scripts/typecheck/fixtures/trigger-target-config.ts
+++ b/scripts/typecheck/fixtures/trigger-target-config.ts
@@ -1,0 +1,29 @@
+import type { ScheduleConfig } from "veryfront/schedule";
+import type {
+  AgentTriggerTarget,
+  RunTriggerTargetOptions,
+  TriggerTargetConfig,
+} from "veryfront/trigger";
+import type { WebhookConfig } from "veryfront/webhook";
+
+const storedAgentTarget = {
+  kind: "agent" as const,
+  id: "case-triage",
+  conversationMode: undefined,
+  conversationId: undefined,
+};
+
+export const agentTarget: AgentTriggerTarget = storedAgentTarget;
+export const triggerTarget: TriggerTargetConfig = storedAgentTarget;
+export const scheduleTarget: ScheduleConfig["target"] = storedAgentTarget;
+export const webhookTarget: WebhookConfig["target"] = storedAgentTarget;
+export const runTarget: RunTriggerTargetOptions["target"] = storedAgentTarget;
+
+const storedTaskTarget = {
+  kind: "task" as const,
+  id: "sync-helpdesk",
+  conversationMode: undefined,
+};
+
+// @ts-expect-error Non-agent targets cannot declare reserved conversation fields.
+export const invalidTaskTarget: TriggerTargetConfig = storedTaskTarget;

--- a/scripts/typecheck/fixtures/trigger-target-default-optional.ts
+++ b/scripts/typecheck/fixtures/trigger-target-default-optional.ts
@@ -1,0 +1,28 @@
+import type { ScheduleConfig } from "veryfront/schedule";
+import type {
+  RunTriggerTargetOptions,
+  TriggerTargetConfig,
+} from "veryfront/trigger";
+import type { WebhookConfig } from "veryfront/webhook";
+
+const storedWorkflowTarget = {
+  kind: "workflow" as const,
+  id: "billing/sync",
+  conversationMode: undefined,
+};
+const storedTaskTarget = {
+  kind: "task" as const,
+  id: "sync-helpdesk",
+  conversationId: undefined,
+};
+
+export const workflowTrigger: TriggerTargetConfig = storedWorkflowTarget;
+export const workflowSchedule: ScheduleConfig["target"] = storedWorkflowTarget;
+export const workflowWebhook: WebhookConfig["target"] = storedWorkflowTarget;
+export const workflowRun: RunTriggerTargetOptions["target"] =
+  storedWorkflowTarget;
+
+export const taskTrigger: TriggerTargetConfig = storedTaskTarget;
+export const taskSchedule: ScheduleConfig["target"] = storedTaskTarget;
+export const taskWebhook: WebhookConfig["target"] = storedTaskTarget;
+export const taskRun: RunTriggerTargetOptions["target"] = storedTaskTarget;

--- a/scripts/typecheck/run-consumer-typecheck.ts
+++ b/scripts/typecheck/run-consumer-typecheck.ts
@@ -1,8 +1,8 @@
 /**
  * Consumer `tsc --noEmit` gate.
  *
- * Typechecks {@link ./fixtures} — documented `veryfront/ui` / `veryfront/chat`
- * composition — against the BUILT npm package (`npm/esm/**.d.ts`) using a real
+ * Typechecks {@link ./fixtures} — documented UI, chat, and trigger composition
+ * — against the BUILT npm package (`npm/esm/**.d.ts`) using a real
  * `@types/react`, exactly the way an external app compiles the published
  * declarations. This is the gap `deno check` (Deno's own react types + source)
  * and a source-level `tsc` both leave open: it is what caught, and now guards
@@ -20,7 +20,16 @@
 
 const REPO_ROOT = new URL("../../", import.meta.url).pathname;
 const TSC = `${REPO_ROOT}storybook/node_modules/.bin/tsc`;
-const TSCONFIG = "scripts/typecheck/tsconfig.consumer.json";
+const TSCONFIGS = [
+  {
+    label: "exact optional-property semantics",
+    path: "scripts/typecheck/tsconfig.consumer.json",
+  },
+  {
+    label: "default optional-property semantics",
+    path: "scripts/typecheck/tsconfig.consumer-default-optional.json",
+  },
+] as const;
 function exists(path: string): boolean {
   try {
     Deno.statSync(path);
@@ -50,18 +59,22 @@ if (!exists(TSC)) {
   Deno.exit(1);
 }
 
-console.log("Rebuilding npm/ from the current source with deno task build:npm.");
+console.log(
+  "Rebuilding npm/ from the current source with deno task build:npm.",
+);
 const buildCode = await run("deno", ["task", "build:npm"]);
 if (buildCode !== 0) {
   console.error("✖ consumer typecheck: build:npm failed");
   Deno.exit(buildCode);
 }
 
-console.log(
-  "• consumer typecheck: tsc --noEmit over documented composition vs built npm .d.ts",
-);
-const code = await run(TSC, ["--noEmit", "-p", TSCONFIG]);
-if (code === 0) {
-  console.log("✓ consumer typecheck: published composition types are consumer-clean");
+for (const config of TSCONFIGS) {
+  console.log(
+    `• consumer typecheck: ${config.label} vs built npm .d.ts`,
+  );
+  const code = await run(TSC, ["--noEmit", "-p", config.path]);
+  if (code !== 0) Deno.exit(code);
 }
-Deno.exit(code);
+console.log(
+  "✓ consumer typecheck: published composition types are consumer-clean",
+);

--- a/scripts/typecheck/tsconfig.consumer-default-optional.json
+++ b/scripts/typecheck/tsconfig.consumer-default-optional.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.consumer.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false
+  },
+  "include": [
+    "./fixtures/trigger-target-default-optional.ts"
+  ],
+  "exclude": []
+}

--- a/scripts/typecheck/tsconfig.consumer.json
+++ b/scripts/typecheck/tsconfig.consumer.json
@@ -15,6 +15,7 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
     "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
@@ -31,6 +32,9 @@
       "veryfront/chat": ["./npm/esm/src/chat/index.d.ts"],
       "veryfront/chat/types": ["./npm/esm/src/chat/types.d.ts"],
       "veryfront/chat/uploads": ["./npm/esm/src/chat/upload-handler.d.ts"],
+      "veryfront/schedule": ["./npm/esm/src/schedule/index.d.ts"],
+      "veryfront/trigger": ["./npm/esm/src/trigger/index.d.ts"],
+      "veryfront/webhook": ["./npm/esm/src/webhook/index.d.ts"],
       "veryfront/observability/sentry": ["./npm/esm/src/observability/sentry.d.ts"],
       "@veryfront/ext-observability-sentry/node": [
         "./npm/extensions/ext-observability-sentry/esm/node.d.ts"

--- a/scripts/typecheck/tsconfig.consumer.json
+++ b/scripts/typecheck/tsconfig.consumer.json
@@ -44,5 +44,8 @@
   "include": [
     "./fixtures/**/*.ts",
     "./fixtures/**/*.tsx"
+  ],
+  "exclude": [
+    "./fixtures/trigger-target-default-optional.ts"
   ]
 }

--- a/src/schedule/factory.test.ts
+++ b/src/schedule/factory.test.ts
@@ -71,6 +71,30 @@ describe("schedule/factory", () => {
     assertEquals(isScheduleDefinition(definition), true);
   });
 
+  it("treats undefined non-agent conversation fields as omitted", () => {
+    const taskDefinition = schedule({
+      id: "conditional-task",
+      schedule: "0 */6 * * *",
+      target: {
+        kind: "task",
+        id: "run-triage-sweep",
+        conversationMode: undefined,
+      },
+    });
+    const workflowDefinition = schedule({
+      id: "conditional-workflow",
+      schedule: "0 */6 * * *",
+      target: {
+        kind: "workflow",
+        id: "billing/sync",
+        conversationId: undefined,
+      },
+    });
+
+    assertEquals(taskDefinition.target, { kind: "task", id: "run-triage-sweep" });
+    assertEquals(workflowDefinition.target, { kind: "workflow", id: "billing/sync" });
+  });
+
   it("preserves optional execution controls", () => {
     const definition = schedule({
       id: "bounded-sweep",

--- a/src/trigger/target-types.test.ts
+++ b/src/trigger/target-types.test.ts
@@ -116,6 +116,29 @@ describe("trigger target public type contracts", () => {
       agentMessage: { prompt: "Triage open cases." },
     });
 
+    const explicitlyUndefinedAgent = {
+      kind: "agent" as const,
+      id: "conditional-agent",
+      conversationMode: undefined,
+      conversationId: undefined,
+    };
+    const undefinedAgentSchedule = acceptScheduleConfig({
+      id: "conditional-agent-schedule",
+      schedule: "*/10 * * * *",
+      target: explicitlyUndefinedAgent,
+      agentMessage: { prompt: "Triage open cases." },
+    });
+    const undefinedAgentWebhook = acceptWebhookConfig({
+      id: "conditional-agent-webhook",
+      target: explicitlyUndefinedAgent,
+      agentMessage: { promptTemplate: "Triage {{payload}}." },
+    });
+    const undefinedAgentRun = acceptRunTriggerTargetOptions({
+      projectDir: "project",
+      adapter,
+      target: explicitlyUndefinedAgent,
+    });
+
     // @ts-expect-error Task schedules cannot define an agent message.
     const invalidTaskMessage = acceptScheduleConfig({
       id: "bad-task-message",
@@ -167,6 +190,21 @@ describe("trigger target public type contracts", () => {
       id: "billing/sync",
       conversationMode: "create_new" as const,
     };
+    const storedWorkflowConversationId = {
+      kind: "workflow" as const,
+      id: "billing/sync",
+      conversationId: null,
+    };
+    const storedTaskConversation = {
+      kind: "task" as const,
+      id: "sync-helpdesk",
+      conversationMode: "create_new" as const,
+    };
+    const storedTaskConversationId = {
+      kind: "task" as const,
+      id: "sync-helpdesk",
+      conversationId: null,
+    };
 
     acceptScheduleConfig({
       id: "stored-bad-workflow-schedule",
@@ -188,7 +226,64 @@ describe("trigger target public type contracts", () => {
       target: storedWorkflowConversation,
     });
 
+    acceptScheduleConfig({
+      id: "stored-bad-workflow-id-schedule",
+      schedule: "0 * * * *",
+      // @ts-expect-error Stored workflow schedule targets cannot carry conversation fields.
+      target: storedWorkflowConversationId,
+    });
+    acceptWebhookConfig({
+      id: "stored-bad-workflow-id-webhook",
+      // @ts-expect-error Stored workflow webhook targets cannot carry conversation fields.
+      target: storedWorkflowConversationId,
+    });
+    acceptRunTriggerTargetOptions({
+      projectDir: "project",
+      adapter,
+      // @ts-expect-error Stored workflow runtime targets cannot carry conversation fields.
+      target: storedWorkflowConversationId,
+    });
+
+    acceptScheduleConfig({
+      id: "stored-bad-task-mode-schedule",
+      schedule: "0 * * * *",
+      // @ts-expect-error Stored task schedule targets cannot carry conversation fields.
+      target: storedTaskConversation,
+    });
+    acceptWebhookConfig({
+      id: "stored-bad-task-mode-webhook",
+      // @ts-expect-error Stored task webhook targets cannot carry conversation fields.
+      target: storedTaskConversation,
+    });
+    acceptRunTriggerTargetOptions({
+      projectDir: "project",
+      adapter,
+      // @ts-expect-error Stored task runtime targets cannot carry conversation fields.
+      target: storedTaskConversation,
+    });
+
+    acceptScheduleConfig({
+      id: "stored-bad-task-id-schedule",
+      schedule: "0 * * * *",
+      // @ts-expect-error Stored task schedule targets cannot carry conversation fields.
+      target: storedTaskConversationId,
+    });
+    acceptWebhookConfig({
+      id: "stored-bad-task-id-webhook",
+      // @ts-expect-error Stored task webhook targets cannot carry conversation fields.
+      target: storedTaskConversationId,
+    });
+    acceptRunTriggerTargetOptions({
+      projectDir: "project",
+      adapter,
+      // @ts-expect-error Stored task runtime targets cannot carry conversation fields.
+      target: storedTaskConversationId,
+    });
+
     assertEquals(agentSchedule.target.kind, "agent");
+    assertEquals(undefinedAgentSchedule.target.kind, "agent");
+    assertEquals(undefinedAgentWebhook.target.kind, "agent");
+    assertEquals(undefinedAgentRun.target.kind, "agent");
     assertEquals(invalidTaskMessage.target.kind, "task");
     assertEquals(invalidWorkflowMessage.target.kind, "workflow");
     assertEquals(invalidStoredTaskMessage.target.kind, "task");

--- a/src/trigger/target-types.test.ts
+++ b/src/trigger/target-types.test.ts
@@ -162,6 +162,32 @@ describe("trigger target public type contracts", () => {
       target: { kind: "task", id: "sync-helpdesk", conversationMode: "none" },
     });
 
+    const storedWorkflowConversation = {
+      kind: "workflow" as const,
+      id: "billing/sync",
+      conversationMode: "create_new" as const,
+    };
+
+    acceptScheduleConfig({
+      id: "stored-bad-workflow-schedule",
+      schedule: "0 * * * *",
+      // @ts-expect-error Stored workflow schedule targets cannot carry conversation fields.
+      target: storedWorkflowConversation,
+    });
+
+    acceptWebhookConfig({
+      id: "stored-bad-workflow-webhook",
+      // @ts-expect-error Stored workflow webhook targets cannot carry conversation fields.
+      target: storedWorkflowConversation,
+    });
+
+    acceptRunTriggerTargetOptions({
+      projectDir: "project",
+      adapter,
+      // @ts-expect-error Stored workflow runtime targets cannot carry conversation fields.
+      target: storedWorkflowConversation,
+    });
+
     assertEquals(agentSchedule.target.kind, "agent");
     assertEquals(invalidTaskMessage.target.kind, "task");
     assertEquals(invalidWorkflowMessage.target.kind, "workflow");

--- a/src/trigger/target-types.test.ts
+++ b/src/trigger/target-types.test.ts
@@ -139,6 +139,27 @@ describe("trigger target public type contracts", () => {
       target: explicitlyUndefinedAgent,
     });
 
+    const explicitlyUndefinedWorkflow = {
+      kind: "workflow" as const,
+      id: "conditional-workflow",
+      conversationMode: undefined,
+      conversationId: undefined,
+    };
+    const undefinedWorkflowSchedule = acceptScheduleConfig({
+      id: "conditional-workflow-schedule",
+      schedule: "*/10 * * * *",
+      target: explicitlyUndefinedWorkflow,
+    });
+    const undefinedWorkflowWebhook = acceptWebhookConfig({
+      id: "conditional-workflow-webhook",
+      target: explicitlyUndefinedWorkflow,
+    });
+    const undefinedWorkflowRun = acceptRunTriggerTargetOptions({
+      projectDir: "project",
+      adapter,
+      target: explicitlyUndefinedWorkflow,
+    });
+
     // @ts-expect-error Task schedules cannot define an agent message.
     const invalidTaskMessage = acceptScheduleConfig({
       id: "bad-task-message",
@@ -284,6 +305,9 @@ describe("trigger target public type contracts", () => {
     assertEquals(undefinedAgentSchedule.target.kind, "agent");
     assertEquals(undefinedAgentWebhook.target.kind, "agent");
     assertEquals(undefinedAgentRun.target.kind, "agent");
+    assertEquals(undefinedWorkflowSchedule.target.kind, "workflow");
+    assertEquals(undefinedWorkflowWebhook.target.kind, "workflow");
+    assertEquals(undefinedWorkflowRun.target.kind, "workflow");
     assertEquals(invalidTaskMessage.target.kind, "task");
     assertEquals(invalidWorkflowMessage.target.kind, "workflow");
     assertEquals(invalidStoredTaskMessage.target.kind, "task");

--- a/src/trigger/target.ts
+++ b/src/trigger/target.ts
@@ -76,11 +76,10 @@ const CONVERSATION_ID_PATTERN =
 const MAX_DIAGNOSTIC_KEY_LENGTH = 80;
 const SIMPLE_DIAGNOSTIC_KEY_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$-]*$/;
 const TARGET_KEYS = ["kind", "id"] as const;
+const CONVERSATION_TARGET_KEYS = ["conversationMode", "conversationId"] as const;
 const AGENT_TARGET_KEYS = [
-  "kind",
-  "id",
-  "conversationMode",
-  "conversationId",
+  ...TARGET_KEYS,
+  ...CONVERSATION_TARGET_KEYS,
 ] as const;
 
 function readOwnDataProperty(value: object, key: PropertyKey): unknown {
@@ -88,23 +87,30 @@ function readOwnDataProperty(value: object, key: PropertyKey): unknown {
   return descriptor && "value" in descriptor ? descriptor.value : undefined;
 }
 
-function readOwnKind(value: unknown): unknown {
-  if (typeof value !== "object" || value === null) return undefined;
-  try {
-    return readOwnDataProperty(value, "kind");
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * Own keys a trigger target may declare, widened for agent targets.
  *
- * The kind is read as an own data property so an author-defined accessor never
- * runs while the allowed key set is selected.
+ * TypeScript without `exactOptionalPropertyTypes` accepts an explicitly
+ * undefined value for an optional `never` property. Keep that authoring shape
+ * aligned with runtime normalization while still rejecting accessors and every
+ * defined conversation value on non-agent targets.
  */
 export function triggerTargetKeys(value: unknown): readonly string[] {
-  return readOwnKind(value) === "agent" ? AGENT_TARGET_KEYS : TARGET_KEYS;
+  if (typeof value !== "object" || value === null) return TARGET_KEYS;
+  try {
+    if (readOwnDataProperty(value, "kind") === "agent") return AGENT_TARGET_KEYS;
+
+    const keys: string[] = [...TARGET_KEYS];
+    for (const key of CONVERSATION_TARGET_KEYS) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+      if (descriptor !== undefined && "value" in descriptor && descriptor.value === undefined) {
+        keys.push(key);
+      }
+    }
+    return keys;
+  } catch {
+    return TARGET_KEYS;
+  }
 }
 
 /**

--- a/src/trigger/target.ts
+++ b/src/trigger/target.ts
@@ -49,7 +49,10 @@ export interface TriggerTarget {
 
 /** Author-facing target shape accepting stored base values and kind-specific literals. */
 export type TriggerTargetConfig =
-  | TriggerTarget
+  | (TriggerTarget & {
+    conversationMode?: never;
+    conversationId?: never;
+  })
   | TaskTriggerTarget
   | WorkflowTriggerTarget
   | AgentTriggerTarget;

--- a/src/trigger/target.ts
+++ b/src/trigger/target.ts
@@ -34,9 +34,9 @@ export interface AgentTriggerTarget extends TriggerTarget {
   /** Canonical slash-separated definition identifier. */
   id: string;
   /** Hosted conversation behavior; defaults to `none`. */
-  conversationMode?: AgentConversationMode;
+  conversationMode?: AgentConversationMode | undefined;
   /** Existing conversation UUID; required only with `conversationMode: "existing"`. */
-  conversationId?: string | null;
+  conversationId?: string | null | undefined;
 }
 
 /** Canonical reference to a runnable project definition. */

--- a/src/webhook/factory.test.ts
+++ b/src/webhook/factory.test.ts
@@ -33,6 +33,28 @@ describe("webhook/factory", () => {
     assertEquals(isWebhookDefinition(definition), true);
   });
 
+  it("treats undefined non-agent conversation fields as omitted", () => {
+    const taskDefinition = webhook({
+      id: "conditional-task",
+      target: {
+        kind: "task",
+        id: "sync-helpdesk",
+        conversationMode: undefined,
+      },
+    });
+    const workflowDefinition = webhook({
+      id: "conditional-workflow",
+      target: {
+        kind: "workflow",
+        id: "billing/sync",
+        conversationId: undefined,
+      },
+    });
+
+    assertEquals(taskDefinition.target, { kind: "task", id: "sync-helpdesk" });
+    assertEquals(workflowDefinition.target, { kind: "workflow", id: "billing/sync" });
+  });
+
   it("copies caller-owned filter values before retaining a webhook definition", () => {
     const filterValue = { project: { id: "project-1" } };
     const definition = webhook({


### PR DESCRIPTION
## Summary

- reject stored workflow and task trigger targets that carry defined agent-only conversation fields
- normalize explicitly undefined non-agent conversation fields as omitted, matching default TypeScript semantics
- preserve the extendable public `TriggerTarget` compatibility shape
- protect emitted npm declarations under both exact and default optional-property semantics
- make both standalone webhook examples copyable by adding the required import

This follows up on valid late review findings on #3745.

## Red-green TDD

Red:

- source type contracts accepted stored non-agent targets with defined conversation fields
- the emitted-package consumer gate rejected explicit `undefined` agent fields with TS2375 under `exactOptionalPropertyTypes`
- schedule and webhook validators rejected explicit `undefined` non-agent fields that default TypeScript authoring accepts
- forcing the new default-optional consumer fixture into exact mode produces eight TS2322 failures across trigger, schedule, webhook, and run surfaces

Green:

- source type contracts reject workflow and task targets carrying either defined conversation field across schedule, webhook, and run authoring surfaces
- the built npm package accepts stored agent targets with explicit `undefined` under a real `tsc` consumer using `exactOptionalPropertyTypes`
- a separate emitted-package consumer accepts stored non-agent targets with explicit `undefined` under TypeScript's default optional-property semantics across `TriggerTargetConfig`, schedule, webhook, and run surfaces
- schedule and webhook normalization strips only own data conversation fields whose value is exactly `undefined` on non-agent targets
- defined values, accessors, misspellings, and unsupported keys remain rejected

## Final verification

Current exact head: `acbbc74e24f751f77f1e556c00662045c005463c`.

- `deno task typecheck:consumer` rebuilds the npm package once and passes both exact and default optional-property consumer configs against emitted declarations.
- The exact-mode control fails all eight default-optional assignments with TS2322; the default-mode config passes.
- Focused trigger, schedule, webhook, runs, and CLI coverage passes 17 tests (150 steps) with zero failures.
- Source checks, script lint and formatting, generated API reference checks, and `git diff --check` pass.
- The pinned full pre-push gate passes: format 5,048 files, lint 4,973 files, typecheck, 3,853 tests (28,713 steps), 0 failed, 1 ignored (5 steps); cwd suites pass 11 tests (211 steps) and 2 tests (2 steps), both with zero failures.
- A fully paginated exact-head audit found 3 review threads, all resolved, and no actionable review or issue-comment body remains.
- Current `main` is `bdbacef0ef110e242855e94286f3a57e930cdae3`. There are no overlapping changed files and synthetic merge tree `d7a79a360221351716cc47299d2af5cf54f30aaa` is conflict-free.
- Exact-head CI is green, merge state is clean, and Codex found no major issues at the exact head. The PR remains draft for final owner handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated webhook configuration examples to include the required webhook import.
  * Refreshed trigger API references and configuration guidance.

* **Bug Fixes**
  * Prevented conversation-specific fields from being used with non-agent schedule, webhook, and runtime trigger targets.
  * Preserved compatibility when optional conversation fields are explicitly set to `undefined`.
  * Ensured normalized schedule and webhook definitions omit unused conversation fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
