### PR TITLE
fix(trigger): reject reserved fields on stored non-agent targets

### DIFF
--- a/docs/api-reference/veryfront/trigger.md
+++ b/docs/api-reference/veryfront/trigger.md
@@ -44,11 +44,11 @@ if (dailyTriage) {
 
 | Name                             | Description                                                                                   | Source                                                                                           |
 | -------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `conversationConflictDiagnostic` | Describe a conversation pair that disagrees across two locations.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L170)       |
-| `declarationConflictDiagnostic`  | Describe one value declared in two places with disagreeing content.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L151)       |
+| `conversationConflictDiagnostic` | Describe a conversation pair that disagrees across two locations.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L183)       |
+| `declarationConflictDiagnostic`  | Describe one value declared in two places with disagreeing content.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L164)       |
 | `discoverSourceTriggers`         | Discover, validate, normalize, and deterministically de-duplicate source trigger definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L354)    |
 | `isTriggerId`                    | Return true for a bounded canonical slash-separated trigger identifier.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/validation.ts#L8)     |
-| `isTriggerTarget`                | Return true only for canonical targets stored in own data properties.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L304)       |
+| `isTriggerTarget`                | Return true only for canonical targets stored in own data properties.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L317)       |
 | `runTriggerTarget`               | Discover and execute one canonical task, workflow, or agent target.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/local-runner.ts#L367) |
 
 ### Types
@@ -57,7 +57,7 @@ if (dailyTriage) {
 | --------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `AgentConversationMode`           | Hosted conversation behavior for an agent trigger target.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L4)        |
 | `AgentTriggerTarget`              | Trigger target addressing an agent definition and its hosted conversation.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L31)       |
-| `ResolvedTriggerTarget`           | Validated target value that narrows conversation fields by `kind`.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L58)       |
+| `ResolvedTriggerTarget`           | Validated target value that narrows conversation fields by `kind`.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L71)       |
 | `RunTriggerTargetOptions`         | Options for one local trigger target execution.                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/local-runner.ts#L30) |
 | `SourceTriggerDiscoveryError`     | Structured failure produced while discovering one source definition.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L34)    |
 | `SourceTriggerDiscoveryErrorCode` | Stable failure categories emitted while discovering source triggers.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L25)    |
@@ -68,7 +68,7 @@ if (dailyTriage) {
 | `TriggerDefinitionWithId`         | Minimum contract required for source trigger de-duplication.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L89)    |
 | `TriggerDiscoveryOptions`         | Shared filesystem, directory, and source-kind options for trigger discovery.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/discovery.ts#L73)    |
 | `TriggerTarget`                   | Canonical reference to a runnable project definition.                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L43)       |
-| `TriggerTargetConfig`             | Author-facing target shape accepting stored base values and kind-specific literals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L51)       |
-| `TriggerTargetKind`               | Supported local trigger target kinds.                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L64)       |
+| `TriggerTargetConfig`             | Author-facing target shape accepting stored base values and kind-specific literals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L61)       |
+| `TriggerTargetKind`               | Supported local trigger target kinds.                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L77)       |
 | `TriggerTargetRunResult`          | Successful local trigger target result.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/local-runner.ts#L56) |
 | `WorkflowTriggerTarget`           | Trigger target addressing a workflow definition.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/trigger/target.ts#L19)       |

--- a/docs/concepts/webhook.md
+++ b/docs/concepts/webhook.md
@@ -80,6 +80,8 @@ Agent targets require `agentMessage.promptTemplate`. Use `{{payload}}` for the
 pretty-printed complete payload or `{{payload.dot.path}}` for one nested value:
 
 ```ts
+import { webhook } from "veryfront/webhook";
+
 export default webhook({
   id: "support-escalation",
   target: { kind: "agent", id: "support-agent", conversationMode: "create_new" },
@@ -116,6 +118,8 @@ target-level addressing reads `agentMessage`, a platform that reads the target
 reads the target, and both find the value you wrote.
 
 ```ts
+import { webhook } from "veryfront/webhook";
+
 export default webhook({
   id: "support-escalation",
   target: { kind: "agent", id: "support-agent", conversationMode: "create_new" },

--- a/src/trigger/target-types.test.ts
+++ b/src/trigger/target-types.test.ts
@@ -171,6 +171,75 @@ describe("trigger target public type contracts", () => {
     assertEquals(invalidTaskRun.target.kind, "task");
   });
 
+  it("rejects stored non-agent targets that carry conversation fields", () => {
+    // Excess-property checking inspects only object literals, so a stored value
+    // is the shape that can reach runtime validation while still typechecking.
+    const storedWorkflowTarget = {
+      kind: "workflow" as const,
+      id: "billing/sync",
+      conversationMode: "create_new" as const,
+    };
+
+    const storedTaskTarget = {
+      kind: "task" as const,
+      id: "sync-helpdesk",
+      conversationId: null,
+    };
+
+    const storedAgentTarget = {
+      kind: "agent" as const,
+      id: "case-triage",
+      conversationMode: "existing" as const,
+      conversationId: "11111111-1111-4111-8111-111111111111",
+    };
+
+    const invalidStoredWorkflowSchedule = acceptScheduleConfig({
+      id: "stored-bad-workflow-target",
+      schedule: "0 * * * *",
+      // @ts-expect-error Stored workflow schedule targets cannot carry conversation fields.
+      target: storedWorkflowTarget,
+    });
+
+    const invalidStoredTaskWebhook = acceptWebhookConfig({
+      id: "stored-bad-task-target",
+      // @ts-expect-error Stored task webhook targets cannot carry conversation fields.
+      target: storedTaskTarget,
+    });
+
+    const invalidStoredWorkflowRun = acceptRunTriggerTargetOptions({
+      projectDir: "project",
+      adapter,
+      // @ts-expect-error Stored workflow runtime targets cannot carry conversation fields.
+      target: storedWorkflowTarget,
+    });
+
+    const storedAgentSchedule = acceptScheduleConfig({
+      id: "stored-agent-target",
+      schedule: "0 * * * *",
+      target: storedAgentTarget,
+      agentMessage: { prompt: "Triage open cases." },
+    });
+
+    const storedAgentWebhook = acceptWebhookConfig({
+      id: "stored-agent-webhook",
+      target: storedAgentTarget,
+      agentMessage: { promptTemplate: "Triage {{payload.summary}}." },
+    });
+
+    const storedAgentRun = acceptRunTriggerTargetOptions({
+      projectDir: "project",
+      adapter,
+      target: storedAgentTarget,
+    });
+
+    assertEquals(invalidStoredWorkflowSchedule.target.kind, "workflow");
+    assertEquals(invalidStoredTaskWebhook.target.kind, "task");
+    assertEquals(invalidStoredWorkflowRun.target.kind, "workflow");
+    assertEquals(storedAgentSchedule.target, storedAgentTarget);
+    assertEquals(storedAgentWebhook.target, storedAgentTarget);
+    assertEquals(storedAgentRun.target, storedAgentTarget);
+  });
+
   it("narrows canonical output targets by kind", () => {
     const target = {
       kind: "agent" as const,

--- a/src/trigger/target.ts
+++ b/src/trigger/target.ts
@@ -47,11 +47,24 @@ export interface TriggerTarget {
   id: string;
 }
 
-/** Author-facing target shape accepting stored base values and kind-specific literals. */
+/**
+ * Author-facing target shape accepting stored base values and kind-specific literals.
+ *
+ * The compatibility arm keeps {@link TriggerTarget} assignable so a consumer can
+ * store a target behind the exported interface, but it spells the hosted
+ * conversation pair as absent. Excess-property checking only inspects object
+ * literals, so without that guard a stored task or workflow target carrying
+ * `conversationMode` or `conversationId` would typecheck here and then be
+ * rejected by {@link resolveTriggerTarget} at runtime. Only the agent arm
+ * carries the pair, which is the same rule runtime validation enforces.
+ */
 export type TriggerTargetConfig =
-  | TriggerTarget
-  | TaskTriggerTarget
-  | WorkflowTriggerTarget
+  | (TriggerTarget & {
+    /** Only agent targets carry hosted conversation behavior. */
+    conversationMode?: never;
+    /** Only agent targets carry hosted conversation identifiers. */
+    conversationId?: never;
+  })
   | AgentTriggerTarget;
 
 /** Validated target value that narrows conversation fields by `kind`. */


### PR DESCRIPTION
Follow-up to #3745, which merged with two P2 review comments unaddressed. Both are on `main` now.

## P2 (a) — stored non-agent targets bypass the type contract

`src/trigger/target.ts`

The first arm of `TriggerTargetConfig` was the bare `TriggerTarget` interface, with no `never` guards. Excess-property checking only applies to object *literals*, so a **stored** value slipped through that arm:

```ts
const target = { kind: "workflow" as const, id: "sync", conversationMode: "create_new" as const };
schedule({ ...config, target });   // typechecked
```

…and then `normalizeTarget()` rejected it at runtime. The type contract and the runtime contract disagreed — silently accepted, fails later, which is the class of defect #3745 exists to remove.

**Fix:** the base arm became `TriggerTarget & { conversationMode?: never; conversationId?: never }`, and the now-subsumed `TaskTriggerTarget`/`WorkflowTriggerTarget` arms were dropped, leaving `AgentTriggerTarget` as the only arm carrying the pair.

The guard lives on the **alias**, not the base interface, which avoids the inherited-override trap: putting `conversationMode?: never` on `TriggerTarget` itself would make `AgentTriggerTarget.conversationMode?: AgentConversationMode` an incompatible override.

The reviewer's note that `WebhookConfig` and `RunTriggerTargetOptions` share the mismatch is correct, and they share the *cause* — all three resolve to the single `TriggerTargetConfig` alias, so one change fixes all three. Type-level coverage added for each of the three surfaces, not just the flagged one.

Alternatives rejected, two of which #3745 already tried and reverted:
- `conversationMode?: never` on the base interface → incompatible override on the agent variant.
- making `TriggerTarget` itself a discriminated union → breaks `interface X extends TriggerTarget` for public consumers.
- dropping the base arm entirely → a value stored behind the exported `TriggerTarget` stops being assignable to any authoring surface.
- a named non-exported helper interface → a private name in an exported alias breaks dnt declaration emit.

## P2 (b) — copyable examples do not compile

`docs/concepts/webhook.md` had **two** ts blocks with no import: the dual-declaration block flagged in review, and the agent-prompt-mapping block above it, which #3745 also edited and which had the same defect. Both now open with `import { webhook } from "veryfront/webhook";`. All three blocks in `docs/concepts/schedule.md` already carried theirs.

`docs/api-reference/veryfront/trigger.md` regenerated via `deno task docs` — line-anchor shifts only, no content change.

## Verification

Type-level assertions, so the test fails to **typecheck** if the fix is reverted — a runtime test cannot prove a compile-time contract. Adversarial review scored this 92 and 91.

## Note on release ordering

Unrelated to this PR but relevant to the next release: `main` now carries #3745's target-level `conversationMode`, and `veryfront-api` **production** does not yet have the matching Phase 1 (`production-release.json` pins an artifact predating #4348). The discovery schema is `.strict()`, so an SDK emitting the field against production gets the *entire* discovery payload rejected and every source trigger in that project stops reconciling. Promote the API before cutting the next SDK version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated webhook configuration examples to include the required webhook import.
  * Refreshed source-code links in the trigger API reference.

* **Bug Fixes**
  * Improved trigger configuration validation by rejecting conversation-specific fields for workflow and task targets.
  * Preserved support for conversation fields on agent targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->