### PR TITLE
test(ui): contain deferred jsdom timers in harnesses

### DIFF
--- a/src/react/components/ui/adapter/popover.conformance.test.tsx
+++ b/src/react/components/ui/adapter/popover.conformance.test.tsx
@@ -20,7 +20,7 @@ import { createPortal, flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { Popover, PopoverContent, PopoverTrigger } from "../popover.tsx";
 import { composeRefs, Slot } from "../slot.tsx";
 import { UIAdapterProvider } from "./context.tsx";
@@ -119,6 +119,12 @@ export function runPopoverConformance(
   Wrap: React.FC<{ children: React.ReactNode }>,
 ): void {
   describe(`Popover adapter conformance - ${label}`, () => {
+    afterEach(async () => {
+      // jsdom defers selection updates after focus. Drain that timer before
+      // Deno's leak sanitizer closes the surrounding conformance group.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
+
     it("open trigger reveals content with role=dialog, portalled into the token scope", () => {
       const { scope, clickTrigger, cleanup } = mountInScope(
         <Wrap>

--- a/src/react/components/ui/field.test.tsx
+++ b/src/react/components/ui/field.test.tsx
@@ -10,7 +10,7 @@ import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 
 import { Field, FieldControl, FieldDescription, FieldError, FieldLabel } from "./field.tsx";
 
@@ -95,6 +95,12 @@ function render(element: React.ReactElement): {
 }
 
 describe("Field", () => {
+  afterEach(async () => {
+    // React defers scheduler cleanup after unmount. Drain that timer before
+    // Deno's leak sanitizer closes the surrounding behaviour group.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  });
+
   it("wires label htmlFor and control id, and aria-describedby → description", () => {
     const { host, unmount } = render(
       <Field>


### PR DESCRIPTION
## Summary

- Drain jsdom deferred selection work after each Popover conformance case.
- Drain React scheduler cleanup after each Field behavior case.
- Keep production component behavior and Deno leak sanitization unchanged.

## Why

Deno leak sanitization could observe timers that jsdom 28 or React 19 scheduled during synchronous test cleanup after the owning BDD group had already finished. This made the full pre-push suite fail nondeterministically while validating #3723.

The drains stay local to the two independently reproduced jsdom harnesses. This PR does not weaken leak detection or alter runtime code.

## Red evidence

- Exact main Popover trace-leak run: 0 groups passed, 27 steps, 3 timer-leak failures from jsdom selection updates after focus.
- Exact main Field trace-leak run: 0 groups passed, 8 steps, 1 timer-leak failure from the React scheduler after unmount.

## Green evidence

- Deno 2.7.7 Popover trace-leak run: 27 of 27 steps.
- Four repeated Popover trace-leak runs: 108 of 108 steps.
- Ten repeated Field trace-leak runs: 80 of 80 steps.
- Popover, Field, and Floating trace-leak matrix: 42 of 42 steps.
- Targeted Bun tests: 2 files passed.
- Formatting, lint, typecheck, and diff checks passed.
- Two correctly pinned full pre-push hooks passed at exact head: 3887 tests and 29290 steps, plus cwd and cwd-exclusion suites.

## Scope

Test harness only. Unblocks renewed validation of #3723 after this baseline fix is reviewed and merged.