### PR TITLE
test(platform): diagnose Bun abort reason flake

### DIFF
--- a/src/agent/child-run/execution-support.test.ts
+++ b/src/agent/child-run/execution-support.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { isNativeErrorWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { assertEquals, assertStrictEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
@@ -63,8 +64,12 @@ describe("child-run-execution-support", () => {
     });
 
     it("throws the signal Error reason when present", () => {
+      const reason = new Error("custom reason");
       const controller = new AbortController();
-      controller.abort(new Error("custom reason"));
+      controller.abort(reason);
+
+      assertStrictEquals(controller.signal.reason, reason);
+      assertEquals(isNativeErrorWithoutHooks(controller.signal.reason), true);
 
       assertThrows(() => throwIfChildRunAborted(controller.signal), Error, "custom reason");
     });

--- a/src/agent/child-run/execution-support.test.ts
+++ b/src/agent/child-run/execution-support.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { isNativeErrorWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { assertEquals, assertStrictEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isNativeError } from "node:util/types";
 import {
   formatChildRunStreamPartError,
   isChildRunAbortError,
@@ -68,8 +68,16 @@ describe("child-run-execution-support", () => {
       const controller = new AbortController();
       controller.abort(reason);
 
-      assertStrictEquals(controller.signal.reason, reason);
-      assertEquals(isNativeErrorWithoutHooks(controller.signal.reason), true);
+      assertStrictEquals(
+        controller.signal.reason,
+        reason,
+        "AbortSignal must retain the supplied Error reason by identity",
+      );
+      assertEquals(
+        isNativeError(controller.signal.reason),
+        true,
+        "node:util/types must retain the supplied Error brand",
+      );
 
       assertThrows(() => throwIfChildRunAborted(controller.signal), Error, "custom reason");
     });

--- a/src/platform/compat/native-brand-checks.test.ts
+++ b/src/platform/compat/native-brand-checks.test.ts
@@ -1,0 +1,19 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { snapshotNativeBrandChecks } from "./native-brand-checks.ts";
+
+describe("native brand checks", () => {
+  it("falls back to the captured Error.isError brand when the host check misses", () => {
+    const checks = snapshotNativeBrandChecks({
+      isAsyncFunction: () => false,
+      isNativeError: () => false,
+      isPromise: () => false,
+      isProxy: () => false,
+      isUint8Array: () => false,
+    });
+
+    assertEquals(checks?.isNativeError(new Error("native")), true);
+    assertEquals(checks?.isNativeError({ name: "Error", message: "shaped" }), false);
+  });
+});

--- a/src/platform/compat/native-brand-checks.test.ts
+++ b/src/platform/compat/native-brand-checks.test.ts
@@ -1,19 +1,78 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isProxy } from "node:util/types";
+import { runInNewContext } from "node:vm";
 import { snapshotNativeBrandChecks } from "./native-brand-checks.ts";
 
 describe("native brand checks", () => {
-  it("falls back to the captured Error.isError brand when the host check misses", () => {
+  it("falls back to an unspoofed built-in Error tag when the host check misses", () => {
+    let tagReads = 0;
+    let proxyTrapCalls = 0;
+    const tagged = Object.defineProperty({}, Symbol.toStringTag, {
+      get() {
+        tagReads++;
+        return "Error";
+      },
+    });
+    const proxied = new Proxy(new Error("proxied"), {
+      getOwnPropertyDescriptor(target, key) {
+        proxyTrapCalls++;
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+      getPrototypeOf(target) {
+        proxyTrapCalls++;
+        return Reflect.getPrototypeOf(target);
+      },
+    });
     const checks = snapshotNativeBrandChecks({
       isAsyncFunction: () => false,
       isNativeError: () => false,
       isPromise: () => false,
-      isProxy: () => false,
+      isProxy,
       isUint8Array: () => false,
     });
 
     assertEquals(checks?.isNativeError(new Error("native")), true);
+    assertEquals(checks?.isNativeError(runInNewContext("new Error('cross realm')")), true);
     assertEquals(checks?.isNativeError({ name: "Error", message: "shaped" }), false);
+    assertEquals(checks?.isNativeError(Object.create(Error.prototype)), false);
+    assertEquals(checks?.isNativeError(tagged), false);
+    assertEquals(checks?.isNativeError(proxied), false);
+    assertEquals(tagReads, 0);
+    assertEquals(proxyTrapCalls, 0);
+  });
+
+  it("does not consult a replaced Error.isError hook", () => {
+    const previous = Object.getOwnPropertyDescriptor(Error, "isError");
+    let hookCalls = 0;
+    Object.defineProperty(Error, "isError", {
+      configurable: true,
+      value: () => {
+        hookCalls++;
+        return true;
+      },
+      writable: true,
+    });
+
+    try {
+      const checks = snapshotNativeBrandChecks({
+        isAsyncFunction: () => false,
+        isNativeError: () => false,
+        isPromise: () => false,
+        isProxy,
+        isUint8Array: () => false,
+      });
+
+      assertEquals(checks?.isNativeError(new Error("native")), true);
+      assertEquals(checks?.isNativeError({ name: "Error", message: "shaped" }), false);
+      assertEquals(hookCalls, 0);
+    } finally {
+      if (previous) {
+        Object.defineProperty(Error, "isError", previous);
+      } else {
+        Reflect.deleteProperty(Error, "isError");
+      }
+    }
   });
 });

--- a/src/platform/compat/native-brand-checks.test.ts
+++ b/src/platform/compat/native-brand-checks.test.ts
@@ -1,11 +1,43 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { isProxy } from "node:util/types";
-import { runInNewContext } from "node:vm";
-import { snapshotNativeBrandChecks } from "./native-brand-checks.ts";
 
 describe("native brand checks", () => {
+  it("does not invoke a replaced node:vm export during initialization", async () => {
+    const hostProcess = (globalThis as typeof globalThis & {
+      process?: { getBuiltinModule?: (specifier: string) => unknown };
+    }).process;
+    const vmModule = hostProcess?.getBuiltinModule?.("node:vm") as
+      | Record<string, unknown>
+      | undefined;
+    const previous = vmModule && Object.getOwnPropertyDescriptor(vmModule, "runInNewContext");
+    let hookCalls = 0;
+    let isolated: typeof import("./native-brand-checks.ts") | undefined;
+    let failure: unknown;
+
+    if (!vmModule || !previous) throw new Error("node:vm must be available in host tests");
+    Object.defineProperty(vmModule, "runInNewContext", {
+      configurable: true,
+      value: () => {
+        hookCalls++;
+        return () => true;
+      },
+      writable: true,
+    });
+
+    try {
+      isolated = await import("./native-brand-checks.ts?poisoned-node-vm-export");
+    } catch (error) {
+      failure = error;
+    } finally {
+      Object.defineProperty(vmModule, "runInNewContext", previous);
+    }
+
+    assertEquals(failure, undefined);
+    assertEquals(isolated?.nativeBrandChecks?.isNativeError({}), false);
+    assertEquals(hookCalls, 0);
+  });
+
   it("does not capture replaced primary-realm Error brand hooks", async () => {
     const previousIsError = Object.getOwnPropertyDescriptor(Error, "isError");
     const previousToString = Object.getOwnPropertyDescriptor(Object.prototype, "toString");
@@ -46,75 +78,5 @@ describe("native brand checks", () => {
     assertEquals(isolated?.nativeBrandChecks?.isNativeError({}), false);
     assertEquals(isErrorHookCalls, 0);
     assertEquals(toStringHookCalls, 0);
-  });
-
-  it("falls back to an isolated Error brand check when the host check misses", () => {
-    let tagReads = 0;
-    let proxyTrapCalls = 0;
-    const tagged = Object.defineProperty({}, Symbol.toStringTag, {
-      get() {
-        tagReads++;
-        return "Error";
-      },
-    });
-    const proxied = new Proxy(new Error("proxied"), {
-      getOwnPropertyDescriptor(target, key) {
-        proxyTrapCalls++;
-        return Reflect.getOwnPropertyDescriptor(target, key);
-      },
-      getPrototypeOf(target) {
-        proxyTrapCalls++;
-        return Reflect.getPrototypeOf(target);
-      },
-    });
-    const checks = snapshotNativeBrandChecks({
-      isAsyncFunction: () => false,
-      isNativeError: () => false,
-      isPromise: () => false,
-      isProxy,
-      isUint8Array: () => false,
-    });
-
-    assertEquals(checks?.isNativeError(new Error("native")), true);
-    assertEquals(checks?.isNativeError(runInNewContext("new Error('cross realm')")), true);
-    assertEquals(checks?.isNativeError({ name: "Error", message: "shaped" }), false);
-    assertEquals(checks?.isNativeError(Object.create(Error.prototype)), false);
-    assertEquals(checks?.isNativeError(tagged), false);
-    assertEquals(checks?.isNativeError(proxied), false);
-    assertEquals(tagReads, 0);
-    assertEquals(proxyTrapCalls, 0);
-  });
-
-  it("does not consult a replaced Error.isError hook", () => {
-    const previous = Object.getOwnPropertyDescriptor(Error, "isError");
-    let hookCalls = 0;
-    Object.defineProperty(Error, "isError", {
-      configurable: true,
-      value: () => {
-        hookCalls++;
-        return true;
-      },
-      writable: true,
-    });
-
-    try {
-      const checks = snapshotNativeBrandChecks({
-        isAsyncFunction: () => false,
-        isNativeError: () => false,
-        isPromise: () => false,
-        isProxy,
-        isUint8Array: () => false,
-      });
-
-      assertEquals(checks?.isNativeError(new Error("native")), true);
-      assertEquals(checks?.isNativeError({ name: "Error", message: "shaped" }), false);
-      assertEquals(hookCalls, 0);
-    } finally {
-      if (previous) {
-        Object.defineProperty(Error, "isError", previous);
-      } else {
-        Reflect.deleteProperty(Error, "isError");
-      }
-    }
   });
 });

--- a/src/platform/compat/native-brand-checks.test.ts
+++ b/src/platform/compat/native-brand-checks.test.ts
@@ -6,7 +6,49 @@ import { runInNewContext } from "node:vm";
 import { snapshotNativeBrandChecks } from "./native-brand-checks.ts";
 
 describe("native brand checks", () => {
-  it("falls back to an unspoofed built-in Error tag when the host check misses", () => {
+  it("does not capture replaced primary-realm Error brand hooks", async () => {
+    const previousIsError = Object.getOwnPropertyDescriptor(Error, "isError");
+    const previousToString = Object.getOwnPropertyDescriptor(Object.prototype, "toString");
+    let isErrorHookCalls = 0;
+    let toStringHookCalls = 0;
+    let isolated: typeof import("./native-brand-checks.ts") | undefined;
+    Object.defineProperty(Error, "isError", {
+      configurable: true,
+      value: () => {
+        isErrorHookCalls++;
+        return true;
+      },
+      writable: true,
+    });
+    Object.defineProperty(Object.prototype, "toString", {
+      configurable: true,
+      value: () => {
+        toStringHookCalls++;
+        return "[object Error]";
+      },
+      writable: true,
+    });
+
+    try {
+      isolated = await import("./native-brand-checks.ts?poisoned-primary-realm-error-hooks");
+    } finally {
+      if (previousToString) {
+        Object.defineProperty(Object.prototype, "toString", previousToString);
+      }
+      if (previousIsError) {
+        Object.defineProperty(Error, "isError", previousIsError);
+      } else {
+        Reflect.deleteProperty(Error, "isError");
+      }
+    }
+
+    assertEquals(isolated?.nativeBrandChecks?.isNativeError(new Error("native")), true);
+    assertEquals(isolated?.nativeBrandChecks?.isNativeError({}), false);
+    assertEquals(isErrorHookCalls, 0);
+    assertEquals(toStringHookCalls, 0);
+  });
+
+  it("falls back to an isolated Error brand check when the host check misses", () => {
     let tagReads = 0;
     let proxyTrapCalls = 0;
     const tagged = Object.defineProperty({}, Symbol.toStringTag, {

--- a/src/platform/compat/native-brand-checks.ts
+++ b/src/platform/compat/native-brand-checks.ts
@@ -37,67 +37,41 @@ function readOwnDataFunction(
   return typeof descriptor.value === "function" ? descriptor.value : undefined;
 }
 
-function createErrorBrandCheck(
-  hostCheck: (...args: unknown[]) => unknown,
-) {
-  return (value: unknown): boolean => {
-    try {
-      if (apply(hostCheck, undefined, [value]) === true) return true;
-    } catch (_) {
-      // Fall through to the independent realm's Error brand check.
-    }
-
-    if (!isolatedErrorBrandCheck) return false;
-    try {
-      return apply(isolatedErrorBrandCheck, undefined, [value]) === true;
-    } catch (_) {
-      return false;
-    }
-  };
-}
-
-export function snapshotNativeBrandChecks(value: unknown): NativeBrandChecks | undefined {
+function snapshotNativeBrandChecks(value: unknown): NativeBrandChecks | undefined {
   if ((typeof value !== "object" && typeof value !== "function") || value === null) {
     return undefined;
   }
 
-  const keys = [
-    "isAsyncFunction",
-    "isNativeError",
-    "isPromise",
-    "isProxy",
-    "isUint8Array",
-  ] as const;
-  const checks = createObject(null) as Record<
-    (typeof keys)[number],
-    (...args: unknown[]) => unknown
-  >;
-  for (const key of keys) {
+  const snapshot = createObject(null) as NativeBrandChecks;
+  for (
+    const key of [
+      "isAsyncFunction",
+      "isNativeError",
+      "isPromise",
+      "isProxy",
+      "isUint8Array",
+    ] as const
+  ) {
     const check = readOwnDataFunction(value, key);
     if (!check) return undefined;
-    checks[key] = check;
-  }
-
-  const snapshot = createObject(null) as NativeBrandChecks;
-  for (const key of keys) {
     defineProperty(snapshot, key, {
       configurable: false,
       enumerable: true,
-      value: key === "isNativeError" ? createErrorBrandCheck(checks.isNativeError) : checks[key],
+      value: check,
       writable: false,
     });
   }
   return freeze(snapshot);
 }
 
-function loadHostBuiltinModule(specifier: string): unknown {
+function loadNativeBrandCheckModule(): unknown {
   if (!isBun && !isDeno && !isNode) return undefined;
 
   const hostProcess = (globalThis as typeof globalThis & { process?: HostProcess }).process;
   if (hostProcess) {
     const getBuiltinModule = readOwnDataFunction(hostProcess as object, "getBuiltinModule");
     if (getBuiltinModule) {
-      return apply(getBuiltinModule, hostProcess, [specifier]);
+      return apply(getBuiltinModule, hostProcess, ["node:util/types"]);
     }
   }
 
@@ -105,35 +79,11 @@ function loadHostBuiltinModule(specifier: string): unknown {
   // Bun releases that predate process.getBuiltinModule without adding a Node
   // builtin to browser module graphs.
   if (isBun && typeof require === "function") {
-    return apply(require, undefined, [specifier]);
+    return apply(require, undefined, ["node:util/types"]);
   }
 
   return undefined;
 }
-
-function loadIsolatedErrorBrandCheck(): ((...args: unknown[]) => unknown) | undefined {
-  const vmModule = loadHostBuiltinModule("node:vm");
-  if (
-    (typeof vmModule !== "object" && typeof vmModule !== "function") ||
-    vmModule === null
-  ) {
-    return undefined;
-  }
-
-  const runInNewContext = readOwnDataFunction(vmModule, "runInNewContext");
-  if (!runInNewContext) return undefined;
-
-  try {
-    const check = apply(runInNewContext, vmModule, ["Error.isError"]);
-    return typeof check === "function" ? check as (...args: unknown[]) => unknown : undefined;
-  } catch (_) {
-    return undefined;
-  }
-}
-
-// The fresh realm is not affected by application changes to Error.isError or
-// Object.prototype.toString in the runtime's primary realm.
-const isolatedErrorBrandCheck = loadIsolatedErrorBrandCheck();
 
 /**
  * Immutable host brand checks captured once at the runtime trust boundary.
@@ -141,7 +91,7 @@ const isolatedErrorBrandCheck = loadIsolatedErrorBrandCheck();
  * and use the conservative callers in error-introspection.ts.
  */
 export const nativeBrandChecks = snapshotNativeBrandChecks(
-  loadHostBuiltinModule("node:util/types"),
+  loadNativeBrandCheckModule(),
 );
 
 if ((isBun || isDeno || isNode) && !nativeBrandChecks) {

--- a/src/platform/compat/native-brand-checks.ts
+++ b/src/platform/compat/native-brand-checks.ts
@@ -22,8 +22,10 @@ const createObject = Object.create;
 const defineProperty = Object.defineProperty;
 const freeze = Object.freeze;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const getPrototypeOf = Object.getPrototypeOf;
 const objectHasOwnProperty = Object.prototype.hasOwnProperty;
-const NativeError = Error;
+const objectToString = Object.prototype.toString;
+const toStringTagSymbol = Symbol.toStringTag;
 
 function hasOwn(object: object, key: PropertyKey): boolean {
   return apply(objectHasOwnProperty, object, [key]) as boolean;
@@ -38,19 +40,50 @@ function readOwnDataFunction(
   return typeof descriptor.value === "function" ? descriptor.value : undefined;
 }
 
-const capturedErrorIsError = readOwnDataFunction(NativeError, "isError");
+const MAX_BRAND_PROTOTYPE_CHAIN_DEPTH = 100;
 
-function createErrorBrandCheck(hostCheck: (...args: unknown[]) => unknown) {
+function canReadBuiltinTagWithoutHooks(
+  value: unknown,
+  isProxy: (...args: unknown[]) => unknown,
+): boolean {
+  if ((typeof value !== "object" && typeof value !== "function") || value === null) {
+    return false;
+  }
+
+  let current: object | null = value;
+  for (
+    let depth = 0;
+    current !== null && depth < MAX_BRAND_PROTOTYPE_CHAIN_DEPTH;
+    depth++
+  ) {
+    try {
+      if (apply(isProxy, undefined, [current]) === true) return false;
+      if (getOwnPropertyDescriptor(current, toStringTagSymbol) !== undefined) return false;
+      current = getPrototypeOf(current);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  return current === null;
+}
+
+function createErrorBrandCheck(
+  hostCheck: (...args: unknown[]) => unknown,
+  isProxy: (...args: unknown[]) => unknown,
+) {
   return (value: unknown): boolean => {
     try {
       if (apply(hostCheck, undefined, [value]) === true) return true;
     } catch (_) {
-      // Fall through to the independent Error.isError brand primitive.
+      // Fall through to the independent built-in tag check.
     }
 
-    if (!capturedErrorIsError) return false;
+    // Object.prototype.toString only exposes the internal Error tag safely
+    // after every Proxy and Symbol.toStringTag override has been rejected.
+    if (!canReadBuiltinTagWithoutHooks(value, isProxy)) return false;
     try {
-      return apply(capturedErrorIsError, NativeError, [value]) === true;
+      return apply(objectToString, value, []) === "[object Error]";
     } catch (_) {
       return false;
     }
@@ -62,22 +95,31 @@ export function snapshotNativeBrandChecks(value: unknown): NativeBrandChecks | u
     return undefined;
   }
 
-  const snapshot = createObject(null) as NativeBrandChecks;
-  for (
-    const key of [
-      "isAsyncFunction",
-      "isNativeError",
-      "isPromise",
-      "isProxy",
-      "isUint8Array",
-    ] as const
-  ) {
+  const keys = [
+    "isAsyncFunction",
+    "isNativeError",
+    "isPromise",
+    "isProxy",
+    "isUint8Array",
+  ] as const;
+  const checks = createObject(null) as Record<
+    (typeof keys)[number],
+    (...args: unknown[]) => unknown
+  >;
+  for (const key of keys) {
     const check = readOwnDataFunction(value, key);
     if (!check) return undefined;
+    checks[key] = check;
+  }
+
+  const snapshot = createObject(null) as NativeBrandChecks;
+  for (const key of keys) {
     defineProperty(snapshot, key, {
       configurable: false,
       enumerable: true,
-      value: key === "isNativeError" ? createErrorBrandCheck(check) : check,
+      value: key === "isNativeError"
+        ? createErrorBrandCheck(checks.isNativeError, checks.isProxy)
+        : checks[key],
       writable: false,
     });
   }

--- a/src/platform/compat/native-brand-checks.ts
+++ b/src/platform/compat/native-brand-checks.ts
@@ -22,10 +22,7 @@ const createObject = Object.create;
 const defineProperty = Object.defineProperty;
 const freeze = Object.freeze;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
-const getPrototypeOf = Object.getPrototypeOf;
 const objectHasOwnProperty = Object.prototype.hasOwnProperty;
-const objectToString = Object.prototype.toString;
-const toStringTagSymbol = Symbol.toStringTag;
 
 function hasOwn(object: object, key: PropertyKey): boolean {
   return apply(objectHasOwnProperty, object, [key]) as boolean;
@@ -40,50 +37,19 @@ function readOwnDataFunction(
   return typeof descriptor.value === "function" ? descriptor.value : undefined;
 }
 
-const MAX_BRAND_PROTOTYPE_CHAIN_DEPTH = 100;
-
-function canReadBuiltinTagWithoutHooks(
-  value: unknown,
-  isProxy: (...args: unknown[]) => unknown,
-): boolean {
-  if ((typeof value !== "object" && typeof value !== "function") || value === null) {
-    return false;
-  }
-
-  let current: object | null = value;
-  for (
-    let depth = 0;
-    current !== null && depth < MAX_BRAND_PROTOTYPE_CHAIN_DEPTH;
-    depth++
-  ) {
-    try {
-      if (apply(isProxy, undefined, [current]) === true) return false;
-      if (getOwnPropertyDescriptor(current, toStringTagSymbol) !== undefined) return false;
-      current = getPrototypeOf(current);
-    } catch (_) {
-      return false;
-    }
-  }
-
-  return current === null;
-}
-
 function createErrorBrandCheck(
   hostCheck: (...args: unknown[]) => unknown,
-  isProxy: (...args: unknown[]) => unknown,
 ) {
   return (value: unknown): boolean => {
     try {
       if (apply(hostCheck, undefined, [value]) === true) return true;
     } catch (_) {
-      // Fall through to the independent built-in tag check.
+      // Fall through to the independent realm's Error brand check.
     }
 
-    // Object.prototype.toString only exposes the internal Error tag safely
-    // after every Proxy and Symbol.toStringTag override has been rejected.
-    if (!canReadBuiltinTagWithoutHooks(value, isProxy)) return false;
+    if (!isolatedErrorBrandCheck) return false;
     try {
-      return apply(objectToString, value, []) === "[object Error]";
+      return apply(isolatedErrorBrandCheck, undefined, [value]) === true;
     } catch (_) {
       return false;
     }
@@ -117,23 +83,21 @@ export function snapshotNativeBrandChecks(value: unknown): NativeBrandChecks | u
     defineProperty(snapshot, key, {
       configurable: false,
       enumerable: true,
-      value: key === "isNativeError"
-        ? createErrorBrandCheck(checks.isNativeError, checks.isProxy)
-        : checks[key],
+      value: key === "isNativeError" ? createErrorBrandCheck(checks.isNativeError) : checks[key],
       writable: false,
     });
   }
   return freeze(snapshot);
 }
 
-function loadNativeBrandCheckModule(): unknown {
+function loadHostBuiltinModule(specifier: string): unknown {
   if (!isBun && !isDeno && !isNode) return undefined;
 
   const hostProcess = (globalThis as typeof globalThis & { process?: HostProcess }).process;
   if (hostProcess) {
     const getBuiltinModule = readOwnDataFunction(hostProcess as object, "getBuiltinModule");
     if (getBuiltinModule) {
-      return apply(getBuiltinModule, hostProcess, ["node:util/types"]);
+      return apply(getBuiltinModule, hostProcess, [specifier]);
     }
   }
 
@@ -141,11 +105,35 @@ function loadNativeBrandCheckModule(): unknown {
   // Bun releases that predate process.getBuiltinModule without adding a Node
   // builtin to browser module graphs.
   if (isBun && typeof require === "function") {
-    return apply(require, undefined, ["node:util/types"]);
+    return apply(require, undefined, [specifier]);
   }
 
   return undefined;
 }
+
+function loadIsolatedErrorBrandCheck(): ((...args: unknown[]) => unknown) | undefined {
+  const vmModule = loadHostBuiltinModule("node:vm");
+  if (
+    (typeof vmModule !== "object" && typeof vmModule !== "function") ||
+    vmModule === null
+  ) {
+    return undefined;
+  }
+
+  const runInNewContext = readOwnDataFunction(vmModule, "runInNewContext");
+  if (!runInNewContext) return undefined;
+
+  try {
+    const check = apply(runInNewContext, vmModule, ["Error.isError"]);
+    return typeof check === "function" ? check as (...args: unknown[]) => unknown : undefined;
+  } catch (_) {
+    return undefined;
+  }
+}
+
+// The fresh realm is not affected by application changes to Error.isError or
+// Object.prototype.toString in the runtime's primary realm.
+const isolatedErrorBrandCheck = loadIsolatedErrorBrandCheck();
 
 /**
  * Immutable host brand checks captured once at the runtime trust boundary.
@@ -153,7 +141,7 @@ function loadNativeBrandCheckModule(): unknown {
  * and use the conservative callers in error-introspection.ts.
  */
 export const nativeBrandChecks = snapshotNativeBrandChecks(
-  loadNativeBrandCheckModule(),
+  loadHostBuiltinModule("node:util/types"),
 );
 
 if ((isBun || isDeno || isNode) && !nativeBrandChecks) {

--- a/src/platform/compat/native-brand-checks.ts
+++ b/src/platform/compat/native-brand-checks.ts
@@ -23,6 +23,7 @@ const defineProperty = Object.defineProperty;
 const freeze = Object.freeze;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const objectHasOwnProperty = Object.prototype.hasOwnProperty;
+const NativeError = Error;
 
 function hasOwn(object: object, key: PropertyKey): boolean {
   return apply(objectHasOwnProperty, object, [key]) as boolean;
@@ -37,7 +38,26 @@ function readOwnDataFunction(
   return typeof descriptor.value === "function" ? descriptor.value : undefined;
 }
 
-function snapshotNativeBrandChecks(value: unknown): NativeBrandChecks | undefined {
+const capturedErrorIsError = readOwnDataFunction(NativeError, "isError");
+
+function createErrorBrandCheck(hostCheck: (...args: unknown[]) => unknown) {
+  return (value: unknown): boolean => {
+    try {
+      if (apply(hostCheck, undefined, [value]) === true) return true;
+    } catch (_) {
+      // Fall through to the independent Error.isError brand primitive.
+    }
+
+    if (!capturedErrorIsError) return false;
+    try {
+      return apply(capturedErrorIsError, NativeError, [value]) === true;
+    } catch (_) {
+      return false;
+    }
+  };
+}
+
+export function snapshotNativeBrandChecks(value: unknown): NativeBrandChecks | undefined {
   if ((typeof value !== "object" && typeof value !== "function") || value === null) {
     return undefined;
   }
@@ -57,7 +77,7 @@ function snapshotNativeBrandChecks(value: unknown): NativeBrandChecks | undefine
     defineProperty(snapshot, key, {
       configurable: false,
       enumerable: true,
-      value: check,
+      value: key === "isNativeError" ? createErrorBrandCheck(check) : check,
       writable: false,
     });
   }


### PR DESCRIPTION
Refs veryfront/veryfront-issue-inbox#492

## Summary

- preserve the original host-only native Error brand trust boundary with no production behavior change
- make the intermittent Bun regression identify whether `AbortController.abort(reason)` loses strict reason identity or `node:util/types.isNativeError` loses the Error brand
- add hostile initialization regressions that prevent future fallbacks from invoking mutable `Error.isError`, `Object.prototype.toString`, or `node:vm` hooks
- keep issue #492 open until the failure recurs with evidence that identifies the failing primitive

## Why this is diagnostic, not a speculative fix

The failure remains intermittent and has not reproduced in focused or stress runs. The original assertion only proved that the final abort normalizer produced its generic `DOMException`; it did not prove whether Bun changed `signal.reason` or whether its native Error check returned false.

Two attempted production fallbacks were rejected during exact-head review because they weakened the no-hook security contract. The built-in-tag version could capture a replaced `Object.prototype.toString`; the fresh-realm version had to invoke the writable `node:vm.runInNewContext` export. Both could execute project code and classify plain objects as native Errors. Those production changes are fully removed from the final diff.

## Red-green TDD

Review-driven hostile tests made each unsafe design fail deterministically:

1. replacing application-realm `Error.isError` exposed the first writable fallback
2. replacing `Object.prototype.toString` before module evaluation executed the hook and made `{}` look like an Error
3. replacing `node:vm.runInNewContext` before module evaluation executed arbitrary code and returned a forged always-true brand check

The final green state restores the original host-only implementation and retains security regressions for the mutable initialization hooks. The Bun abort test now asserts reason identity and the direct `node:util/types` brand separately before exercising the existing product behavior.

## Verification

- focused Deno tests: 3 files, 31 steps passed
- focused Bun harness: 2 files passed
- focused Node harness: 2 files, 13 tests passed
- isolated Bun diagnostic stress: 100/100 processes passed
- npm cross-runtime build passed
- targeted `deno check` passed
- `deno task lint:ci` passed
- `deno fmt --check` and `git diff --check` passed