### PR TITLE
fix(agent-runs): classify expected cancellation as lifecycle

### DIFF
--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -2643,6 +2643,62 @@ describe("internal-agents/run-stream", () => {
     assertEquals(sessionManager.getRunStatus(input.runId), null);
   });
 
+  it("logs an expected runtime cancellation as lifecycle info", async () => {
+    const logs = captureConsoleJsonLogs();
+    try {
+      await withJsonDebugLogFormat(async () => {
+        const sessionManager = new AgentRunSessionManager();
+        const agent = {
+          id: "cancelled-agent",
+          config: {
+            id: "cancelled-agent",
+            model: "anthropic/claude-opus-4-6",
+            system: "test",
+          },
+        } as unknown as Agent;
+        const input = {
+          agentId: agent.id,
+          threadId: crypto.randomUUID(),
+          runId: "run_cancelled",
+          messages: [],
+          tools: [],
+          context: [],
+        } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+        const response = await createRuntimeAgentStreamResponse(input, agent, {
+          sessionManager,
+          createRuntime: () => ({
+            stream: async () => {
+              sessionManager.cancelRun(input.runId);
+              return new ReadableStream<Uint8Array>();
+            },
+          }),
+        });
+        await response.text();
+      });
+    } finally {
+      logs.restore();
+    }
+
+    const entries = logs.getEntries();
+    const cancellationEntry = entries.find((entry) =>
+      entry.message === "Internal agent runtime session cancelled"
+    );
+    assertEquals(cancellationEntry?.level, "info");
+    assertEquals(cancellationEntry?.context?.status, "cancelled");
+    assertEquals(cancellationEntry?.context?.error, undefined);
+    assertEquals(
+      entries.find((entry) => entry.message === "Internal agent runtime stream aborted")?.level,
+      "debug",
+    );
+    assertEquals(
+      entries.some((entry) =>
+        entry.level === "warn" && entry.message === "Internal agent runtime stream cancelled"
+      ),
+      false,
+    );
+  });
+
   it("cancels and releases a runtime reader after a non-EOF mapping failure", async () => {
     const sessionManager = new AgentRunSessionManager();
     const agent = {

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -1011,7 +1011,7 @@ export async function createRuntimeAgentStreamResponse(
             aborted = true;
             const cancellationError = new AgentRunCancelledError();
             readerExitReason = cancellationError;
-            logger.warn("Internal agent runtime stream aborted", {
+            logger.debug("Internal agent runtime stream aborted", {
               runId: input.runId,
               threadId: input.threadId,
               agentId: agent.id,
@@ -1142,11 +1142,13 @@ export async function createRuntimeAgentStreamResponse(
                 "error.message": error.message,
               });
               addSpanEvent(runSpan, "agent.run.cancelled");
-              logger.warn("Internal agent runtime stream cancelled", {
+              // The control plane also cancels runtime sessions to park canonical runs for tools.
+              // This is a lifecycle transition, not an execution failure.
+              logger.info("Internal agent runtime session cancelled", {
                 runId: input.runId,
                 threadId: input.threadId,
                 agentId: agent.id,
-                error: error.message,
+                status: "cancelled",
               });
               enqueueIfAttached("RunError", {
                 code: "CANCELLED",


### PR DESCRIPTION
Closes veryfront/veryfront-issue-inbox#115

## What changed

- Log the runtime cancellation signal at debug level instead of warning level.
- Report the completed runtime-session cancellation at info level with `status: cancelled`.
- Name the event as a runtime session cancellation so it is not confused with the canonical agent run becoming terminal.
- Keep real runtime stream failures at error level.

## Root cause

The spike is predominantly intentional control-plane behavior, not project-level run failure. In the same current 48-hour window:

- `veryfront-server` recorded 360 runtime cancellations, 339 on scheduled run IDs.
- `veryfront-api` recorded 345 intentional parks for control-plane tool execution, all for `invoke_agent`.
- 343 cancellation events matched a parking event on the exact environment and run.

Parking cancels the short-lived project runtime session while the canonical API run moves to `waiting_for_tool` and later resumes. The previous warning and `error` field made that normal boundary look like an execution failure.

## Red-green TDD

Red: the new regression failed because cancellation was emitted as `Internal agent runtime stream cancelled` at warning level with `error: Run cancelled`.

Green: the regression now requires a debug cancellation signal, an info-level `Internal agent runtime session cancelled` event, structured `status: cancelled`, and no warning/error-shaped cancellation log.

## Verification

- `deno test --preload=src/testing/preload.ts --no-check --allow-all --unstable-worker-options --unstable-net src/internal-agents/run-stream.test.ts` (48/48 steps pass)
- `deno fmt --check src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts`
- `deno lint src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts`
- `deno check src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation reporting so expected cancellations appear as informational events with a clear cancelled status.
  * Reduced noise by recording stream-aborted messages at debug level and suppressing unnecessary cancellation warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->