### PR TITLE
fix(api): reuse authenticated config snapshot

### DIFF
--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -155,9 +155,15 @@ export class APIRouteHandler {
   constructor(
     private projectDir: string,
     adapter?: RuntimeAdapter,
+    config?: Awaited<ReturnType<typeof getConfig>>,
   ) {
     this.adapter = adapter ?? null;
     this.adapterPromise = adapter ? Promise.resolve(adapter) : null;
+    this.config = config ?? null;
+    if (config !== undefined) {
+      this.corsConfig = config.security?.cors ?? null;
+      this.corsConfigLoaded = true;
+    }
   }
 
   initialize(): Promise<void> {

--- a/src/server/handlers/request/api/pages-api-handler.test.ts
+++ b/src/server/handlers/request/api/pages-api-handler.test.ts
@@ -65,6 +65,8 @@ function createHandlerContext(
     projectSlug?: string;
     mode?: "preview" | "production";
     releaseId?: string;
+    environmentId?: string;
+    environmentName?: string;
   },
 ): HandlerContext {
   return {
@@ -75,6 +77,8 @@ function createHandlerContext(
     projectId: input.projectSlug ? `${input.projectSlug}-id` : undefined,
     resolvedEnvironment: input.mode ?? "preview",
     releaseId: input.releaseId,
+    environmentId: input.environmentId,
+    environmentName: input.environmentName,
     requestContext: {
       token: "test-token",
       slug: input.projectSlug ?? "test-project",
@@ -121,6 +125,82 @@ describe("server/handlers/request/api/pages-api-handler", () => {
       assertExists(response);
       assertEquals(response.headers.get("access-control-allow-origin"), "https://app.example.test");
       assertEquals(configLoads, 0);
+    });
+
+    it("isolates cached handlers by environment and config snapshot", async () => {
+      const cache = createMockCache();
+      const adapter = createMockAdapter();
+      __injectCacheForTests(cache as any);
+
+      const createEnvironmentContext = (
+        environmentId: string,
+        origin: string,
+      ): HandlerContext => {
+        const ctx = createHandlerContext({
+          adapter,
+          projectSlug: "hosted-project",
+          mode: "production",
+          releaseId: "shared-release",
+          environmentId,
+          environmentName: environmentId,
+        });
+        ctx.config = {
+          security: { cors: { origin: [origin] } },
+        } as HandlerContext["config"];
+        return ctx;
+      };
+
+      const staging = createEnvironmentContext(
+        "staging",
+        "https://staging.example.test",
+      );
+      const production = createEnvironmentContext(
+        "production",
+        "https://production.example.test",
+      );
+
+      const stagingHandler = await getApiHandler(staging);
+      const productionHandler = await getApiHandler(production);
+      const productionResponse = await productionHandler.handle(
+        new Request("https://project.example.test/api/test", {
+          method: "OPTIONS",
+          headers: { origin: "https://production.example.test" },
+        }),
+        production,
+      );
+
+      assertExists(productionResponse);
+      assertEquals(
+        productionResponse.headers.get("access-control-allow-origin"),
+        "https://production.example.test",
+      );
+      assertEquals(cache.store.size, 2);
+      assertEquals(stagingHandler === productionHandler, false);
+
+      const reusedProductionHandler = await getApiHandler(production);
+      assertEquals(reusedProductionHandler === productionHandler, true);
+      assertEquals(cache.store.size, 2);
+
+      const updatedProduction = createEnvironmentContext(
+        "production",
+        "https://updated.example.test",
+      );
+      const updatedProductionHandler = await getApiHandler(updatedProduction);
+      const updatedProductionResponse = await updatedProductionHandler.handle(
+        new Request("https://project.example.test/api/test", {
+          method: "OPTIONS",
+          headers: { origin: "https://updated.example.test" },
+        }),
+        updatedProduction,
+      );
+
+      assertExists(updatedProductionResponse);
+      assertEquals(
+        updatedProductionResponse.headers.get("access-control-allow-origin"),
+        "https://updated.example.test",
+      );
+      assertEquals(cache.store.size, 3);
+      assertEquals(productionHandler === updatedProductionHandler, false);
     });
   });
 

--- a/src/server/handlers/request/api/pages-api-handler.test.ts
+++ b/src/server/handlers/request/api/pages-api-handler.test.ts
@@ -88,6 +88,42 @@ function createHandlerContext(
 }
 
 describe("server/handlers/request/api/pages-api-handler", () => {
+  describe("request config snapshot", () => {
+    it("does not reload hosted config while creating the API route handler", async () => {
+      const adapter = createMockAdapter();
+      let configLoads = 0;
+      __injectApiRouteDepsForTests({
+        getConfig: () => {
+          configLoads++;
+          return Promise.reject(new Error("hosted config must use the authenticated snapshot"));
+        },
+      });
+      const ctx = createHandlerContext({
+        adapter,
+        projectSlug: "hosted-project",
+      });
+      ctx.config = {
+        security: {
+          cors: { origin: ["https://app.example.test"] },
+          remoteHosts: ["assets.example.test"],
+        },
+      } as HandlerContext["config"];
+
+      const handler = await getApiHandler(ctx);
+      const response = await handler.handle(
+        new Request("https://project.example.test/api/test", {
+          method: "OPTIONS",
+          headers: { origin: "https://app.example.test" },
+        }),
+        ctx,
+      );
+
+      assertExists(response);
+      assertEquals(response.headers.get("access-control-allow-origin"), "https://app.example.test");
+      assertEquals(configLoads, 0);
+    });
+  });
+
   describe("LRUHandlerCache", () => {
     it("should clean up automatically evicted handlers without cleaning up manual removals", async () => {
       const evicted: MockHandler[] = [];

--- a/src/server/handlers/request/api/pages-api-handler.ts
+++ b/src/server/handlers/request/api/pages-api-handler.ts
@@ -161,7 +161,7 @@ async function createApiHandler(
     await ensurePreviewSourceSnapshotFresh(ctx);
   }
 
-  const handler = new APIRouteHandler(ctx.projectDir, ctx.adapter);
+  const handler = new APIRouteHandler(ctx.projectDir, ctx.adapter, ctx.config);
   await handler.initialize();
   return handler;
 }

--- a/src/server/handlers/request/api/pages-api-handler.ts
+++ b/src/server/handlers/request/api/pages-api-handler.ts
@@ -93,6 +93,11 @@ interface HandlerLeaseState {
 }
 
 const handlerLeaseStates = new WeakMap<Promise<APIRouteHandler>, HandlerLeaseState>();
+// Hosted config snapshots are deeply frozen and cached by their source and
+// environment fingerprint. Keep that exact process-local identity in the
+// handler key so changed environment values cannot reuse a stale handler.
+const configSnapshotIds = new WeakMap<object, number>();
+let nextConfigSnapshotId = 1;
 
 function getCache(): HandlerCache<Promise<APIRouteHandler>> {
   return injectedCache ?? apiHandlerCache;
@@ -108,6 +113,15 @@ function getApiHandlerCacheContext(ctx: HandlerContext) {
   return tryGetCacheKeyContext() ?? extractCacheKeyContext(ctx);
 }
 
+function getConfigSnapshotId(config: NonNullable<HandlerContext["config"]>): number {
+  let id = configSnapshotIds.get(config);
+  if (id === undefined) {
+    id = nextConfigSnapshotId++;
+    configSnapshotIds.set(config, id);
+  }
+  return id;
+}
+
 function getCacheKey(ctx: HandlerContext): string {
   if (!ctx.projectSlug) return ctx.projectDir;
 
@@ -115,7 +129,12 @@ function getCacheKey(ctx: HandlerContext): string {
   // No safe scoped key (e.g. production without a releaseId): fall back to the
   // project-specific dir key rather than a shared bucket.
   if (!cacheContext) return ctx.projectDir;
-  return `${ctx.projectDir}:${ctx.projectSlug}:${cacheContext.mode}:${cacheContext.versionId}`;
+  const environmentIdentity = ctx.environmentId ?? ctx.environmentName;
+  const environmentKey = environmentIdentity
+    ? `:environment:${encodeURIComponent(environmentIdentity)}`
+    : "";
+  const configKey = ctx.config ? `:config:${getConfigSnapshotId(ctx.config)}` : "";
+  return `${ctx.projectDir}:${ctx.projectSlug}:${cacheContext.mode}:${cacheContext.versionId}${environmentKey}${configKey}`;
 }
 
 function shouldCacheApiHandler(ctx: HandlerContext): boolean {


### PR DESCRIPTION
Addresses veryfront/veryfront-issue-inbox#253

## What changed

- Pass the request-scoped `VeryfrontConfig` snapshot into `APIRouteHandler`.
- Seed API route discovery and CORS from that snapshot.
- Reuse the same snapshot for module loading and `security.remoteHosts` policy.
- Scope cached handlers to the environment identity and exact config snapshot.
- Keep the existing trusted local config load when no request snapshot exists.

## Root cause

The `Object.create` fingerprint is a shared stack frame, not one error type. Pulling complete current events shows that the dominant source is a specific hosted routing invariant:

`Hosted multi-project config requires an authenticated declarative evaluation context`

In a current 48-hour sample capped at 5,000 matching events, production contained:

- 4,239 `Failed to load config` warnings
- 371 `Failed to load security.remoteHosts` warnings
- 247 `Failed to load CORS configuration` warnings

These appear on ordinary project API routes. The outer authenticated request boundary already loaded `ctx.config`, but `createApiHandler` discarded it. `APIRouteHandler` then called the plain trusted `getConfig` path against the hosted multi-project filesystem, which correctly rejected the contextless reload. Route handling continued with defaults and emitted two or three warnings per handler.

This change keeps the authenticated snapshot authoritative across API route discovery, CORS, and module security policy. It does not weaken the hosted config invariant or evaluate tenant config in the host realm.

## Red-green TDD

Red 1: creating a hosted API handler with an authenticated config snapshot still called the plain config loader twice, once for route config and once for CORS.

Green 1: the regression proves zero reloads and verifies that the supplied CORS policy is active on an OPTIONS response.

Red 2: two production environments on the same release reused one handler. The second environment inherited the first environment's CORS allowlist.

Green 2: the cache key now includes the authenticated environment identity and process-local identity of the deeply frozen config snapshot. The regression proves separate environments and updated environment values get separate handlers, while the same snapshot still reuses its handler.

## Verification

- Related API routing suite: 120/120 steps pass across four test files.
- Focused request snapshot suite: 18/18 steps pass.
- `deno fmt --check` passes for all three changed files.
- `deno lint` passes for all three changed files.
- `deno check` passes for all three changed files.
- `git diff --check` passes.

## Follow-up

After deployment, remeasure #253 by structured `message` and `error.message`. Other low-volume sources that happen to contain the same `Object.create` frame should stay separate from this hosted config fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API requests now consistently use the correct environment and configuration settings.
  * Prevented configuration from being incorrectly reused across different environments or configuration snapshots.
  * Improved handling of hosted configurations by avoiding unnecessary reloads when the authenticated configuration is already available.

* **Performance**
  * Reuses compatible API handlers more reliably, reducing redundant initialization for identical production configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->