### PR TITLE
fix(platform): client-safe request-context seam — client-bundle baseline to zero

### DIFF
--- a/scripts/lint/client-bundle-baseline.json
+++ b/scripts/lint/client-bundle-baseline.json
@@ -1,8 +1,6 @@
 {
   "note": "Known server modules reachable from a browser entrypoint (#3670). Burn down, never grow. Regenerate with: deno run --allow-read --allow-write scripts/lint/audit-client-bundle.ts --update",
   "entrypoints": {
-    "src/index.client.ts": [
-      "src/platform/adapters/fs/veryfront/request-context.ts"
-    ]
+    "src/index.client.ts": []
   }
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -29,7 +29,7 @@ import { getHostEnv } from "#veryfront/platform/compat/process/env.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache/registry.ts";
 import { VERYFRONT_CONFIG_FILES } from "./config-files.ts";
-import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { currentRequestContext } from "#veryfront/platform/request-context-access.ts";
 import type { ModuleLexer } from "#veryfront/extensions/bundler/module-lexer.ts";
 import { tryResolve as tryResolveContract } from "#veryfront/extensions/contracts.ts";
 import { importFirstPartyExtensionModule } from "#veryfront/extensions/first-party-import.ts";
@@ -1935,7 +1935,7 @@ interface InternalGetConfigOptions extends GetConfigOptions {
 }
 
 function getVirtualConfigSourceContext(): VirtualConfigSourceContext | undefined {
-  const source = getCurrentRequestContext();
+  const source = currentRequestContext();
   if (!source) return undefined;
 
   return {
@@ -2026,7 +2026,7 @@ function assertMatchingVirtualConfigSource(
 
 function assertMatchingHostedProjectIdentity(
   cacheKey: string,
-  actual: ReturnType<typeof getCurrentRequestContext>,
+  actual: ReturnType<typeof currentRequestContext>,
 ): void {
   if (!actual) {
     throw CACHE_INVARIANT_VIOLATION.create({
@@ -2144,7 +2144,7 @@ function getConfigInternal(
         assertMatchingVirtualConfigSource(options.sourceContext, ambientSourceContext);
       }
       if (hostedMultiProjectFilesystem) {
-        assertMatchingHostedProjectIdentity(options!.cacheKey!, getCurrentRequestContext());
+        assertMatchingHostedProjectIdentity(options!.cacheKey!, currentRequestContext());
       }
       const sourceContext = hasQualifiedCacheIdentity
         ? options.sourceContext ?? ambientSourceContext

--- a/src/platform/adapters/fs/veryfront/request-context.ts
+++ b/src/platform/adapters/fs/veryfront/request-context.ts
@@ -1,5 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
+import { registerRequestContextAccessor } from "#veryfront/platform/request-context-access.ts";
+
 export interface RequestContext {
   projectSlug: string;
   projectId?: string;
@@ -24,6 +26,10 @@ export const asyncLocalStorage = new AsyncLocalStorage<RequestContext>();
 export function getCurrentRequestContext(): RequestContext | null {
   return asyncLocalStorage.getStore() ?? null;
 }
+
+// Shared client/server code reads the context through the client-safe holder;
+// loading this module is what makes the real accessor available there.
+registerRequestContextAccessor(getCurrentRequestContext);
 
 /**
  * Wraps a callback to preserve the current AsyncLocalStorage context.

--- a/src/platform/request-context-access.ts
+++ b/src/platform/request-context-access.ts
@@ -1,0 +1,35 @@
+/**
+ * Client-safe access to the hosted request context.
+ *
+ * The real context lives in an AsyncLocalStorage inside
+ * `adapters/fs/veryfront/request-context.ts`, whose module-scope
+ * `node:async_hooks` import must stay out of browser bundles. Shared
+ * client/server code (the config loader's hosted-identity assertions) reads
+ * the context through this holder instead: the server module registers its
+ * accessor when it loads, and in the browser nothing ever registers, so
+ * `currentRequestContext()` returns null — the correct answer there, since a
+ * hosted request context only exists while the server VFS adapter runs a
+ * request.
+ *
+ * Registration cannot be observed "too early": the only writer of the
+ * context (`multi-project-adapter.ts`'s `asyncLocalStorage.run`) imports the
+ * server module, so any populated context implies the accessor is in place.
+ */
+
+import type { RequestContext } from "./adapters/fs/veryfront/request-context.ts";
+
+export type { RequestContext };
+
+let accessor: (() => RequestContext | null) | undefined;
+
+/** Called by the server request-context module when it loads. */
+export function registerRequestContextAccessor(
+  fn: () => RequestContext | null,
+): void {
+  accessor = fn;
+}
+
+/** The current hosted request context, or null outside a server request. */
+export function currentRequestContext(): RequestContext | null {
+  return accessor?.() ?? null;
+}

--- a/src/platform/request-context-access.ts
+++ b/src/platform/request-context-access.ts
@@ -16,7 +16,7 @@
  * server module, so any populated context implies the accessor is in place.
  */
 
-import type { RequestContext } from "./adapters/fs/veryfront/request-context.ts";
+import type { RequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 
 export type { RequestContext };
 


### PR DESCRIPTION
## What

Retires the last entry in the client-bundle server-leak baseline. After #3760 took it from 39 to 1, this takes it to **0** — the boundary gate stops being a burn-down ratchet and becomes a hard invariant: any server module reaching the browser entrypoint now fails CI immediately, with no grandfathered exceptions.

## The last leak and its seam

`src/platform/adapters/fs/veryfront/request-context.ts` holds the hosted request context in an `AsyncLocalStorage`, with `node:async_hooks` imported at module scope. It stayed reachable from `src/index.client.ts` because the config loader's hosted-identity assertions call `getCurrentRequestContext()` **synchronously** — no dynamic-import escape.

The fix is inversion of control, not async-ification:

- **`src/platform/request-context-access.ts`** (new, ~35 lines, no `async_hooks` anywhere): a holder exposing `currentRequestContext(): RequestContext | null` plus `registerRequestContextAccessor()`. Its only tie to the server module is a type import, which bundles erase.
- **`request-context.ts`** registers its real ALS-backed accessor at module scope. Ordering is safe by construction: the only writer of the context (`multi-project-adapter.ts`'s `asyncLocalStorage.run`) imports this module, so a populated context always implies the accessor is registered.
- **`config/loader.ts`**'s three call sites read through the holder. In the browser the server module never loads, nothing registers, and the holder returns `null` — exactly the semantic that environment already had, since a hosted request context only exists inside a server request.

The other seven importers of `request-context.ts` are server-only and unchanged.

## Verification

- `lint:client-bundle`: green against the now-empty baseline; 320 modules / 1904 KiB client graph, 0 known leaks.
- VFS adapter + config suites (the identity-assertion consumers): 75 files / 958 steps, all green.
- Full suite: 4,441 passed, zero regressions (only the documented pre-existing local environmental failures).
- All 9 typecheck entry points, module boundaries, anti-slop audit, formatting: green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading for hosted projects and virtual sources by handling request information consistently.
  * Enhanced behavior when request information is unavailable, helping prevent configuration-related issues in client environments.
  * Improved reliability when identifying hosted project settings during configuration loading.

* **Refactor**
  * Standardized request-context access across supported platform environments without changing public functionality.
  * Improved compatibility between server-side and client-side configuration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->