### PR TITLE
docs(getting-started): warn that the published base tsconfig disables emit

### DIFF
--- a/docs/getting-started/add-to-existing-project.md
+++ b/docs/getting-started/add-to-existing-project.md
@@ -42,9 +42,17 @@ the shortest correct route:
 Make sure `include` covers wherever you keep your own source as well as your
 routes.
 
+The base config sets `"noEmit": true`: Veryfront bundles your routes itself and
+uses `tsc` only for typechecking. If your existing build emits JavaScript with
+`tsc`, do not replace your config with the extends form: the build keeps
+exiting 0 but silently stops emitting, and your output directory goes stale.
+Keep your own config and add the three options below instead, or set
+`"noEmit": false` in the config your build compiles with.
+
 ### Setting the options yourself
 
-If your project cannot extend that config, three settings matter:
+If your project cannot extend that config, including when your build emits
+with `tsc`, three settings matter:
 
 ```json
 {
@@ -130,6 +138,10 @@ runs:
 ```bash
 npm run build
 ```
+
+If that build emits files, check that its output was actually regenerated. A
+`tsc` build that inherited `"noEmit": true` still exits 0 while writing
+nothing.
 
 ## Next steps
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -87,6 +87,12 @@ Veryfront expects, including `"jsx": "react-jsx"` and
 }
 ```
 
+The base config sets `"noEmit": true` because Veryfront bundles your routes. If
+your existing build uses `tsc` to emit JavaScript, do not use this extends form:
+the build exits 0 but stops emitting. Keep your existing config and add the
+required compiler options, or set `"noEmit": false` in the config your build
+uses. See [Add to an existing project](./add-to-existing-project.md).
+
 ### Add a page and run it
 
 Veryfront discovers routes under `app/`. Create a home page:

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -1072,6 +1072,14 @@ describe("Guide: installation.md", () => {
       assertStringIncludes(guide, heading);
     }
   });
+
+  it("warns emitting projects about the inherited noEmit setting", async () => {
+    const guide = await readGuide("installation.md");
+
+    assertStringIncludes(guide, '"noEmit": true');
+    assertStringIncludes(guide, "stops emitting");
+    assertStringIncludes(guide, "./add-to-existing-project.md");
+  });
 });
 
 describe("Guide: create-project.md", () => {

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -1134,6 +1134,21 @@ describe("Guide: add-to-existing-project.md", () => {
     assertStringIncludes(dnt, './tsconfig.json"] = "./tsconfig.json"');
   });
 
+  it("warns that the published base config disables emit", async () => {
+    // The shipped `veryfront/tsconfig.json` sets `noEmit: true`. A host
+    // project whose build is `tsc -p ...` keeps exiting 0 after switching to
+    // `extends` but silently stops emitting to its outDir — the page must
+    // steer emitting projects away from the extends route.
+    const dnt = await Deno.readTextFile(
+      new URL("../../scripts/build/build-npm-dnt.ts", import.meta.url),
+    );
+    assertStringIncludes(dnt, "noEmit: true");
+
+    const guide = await readGuide("add-to-existing-project.md");
+    assertStringIncludes(guide, '"noEmit": true');
+    assertStringIncludes(guide, "stops emitting");
+  });
+
   it("documents the install command and the entry route the server needs", async () => {
     const guide = await readGuide("add-to-existing-project.md");
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -780,6 +780,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       '"moduleResolution": "bundler"',
       '"jsx": "react-jsx"',
       '"skipLibCheck": true',
+      '"noEmit": true',
       "@types/mdx",
       "// app/page.tsx",
       "npx veryfront dev",


### PR DESCRIPTION
## Problem

DX dogfood of the published `add-to-existing-project` page against **veryfront@0.1.1239** found a High-severity doc bug: the page leads with

```json
{ "extends": "veryfront/tsconfig.json", "include": ["src", "app"] }
```

but the shipped base config sets `"noEmit": true`. A host project whose build emits with `tsc` keeps exiting 0 after that swap while silently writing nothing — its `dist/` goes stale with no warning. That directly contradicts the page's own promise ("Your existing scripts are untouched. Confirm the build you had before still runs").

**Repro (published package):** plain TS project building `tsc -p → dist/`; follow the page; edit a source file; `npm run build` exits 0; `node dist/index.js` still runs the old code.

## Fix

- Warn right after the extends snippet that the base config disables emit, and steer emitting projects to the manual three-option route (or an explicit `"noEmit": false"` in the build config).
- Extend "Verify it worked" to check output freshness, not just the exit code.

## Regression coverage

- `guide-code-examples.test.ts`: new test pins `noEmit: true` in `build-npm-dnt.ts` (the artifact that generates the published tsconfig) to the page carrying the warning — written first, failed for the right reason.
- `guide-contracts.test.ts`: page contract now requires the `"noEmit": true` snippet.

Verified: `deno test tests/docs/` 56/56, `validate-public-docs.ts` clean, and the manual-options route empirically re-verified in a sandbox (emit restored while Veryfront serves).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the existing-project setup guide to warn that the recommended TypeScript configuration disables JavaScript emission.
  * Added guidance for projects that generate JavaScript with TypeScript, including configuration overrides and build-output verification.

* **Tests**
  * Added documentation checks to verify the TypeScript setting and ensure the setup guide includes the emission warning and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->