### PR TITLE
docs(guides): anchor the agents verify snippet in a debug route

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -457,17 +457,28 @@ export default agent({
 
 ## Verify it worked
 
-Save the agent file, restart `veryfront dev`, and invoke it from server code:
+Save the agent file and restart `veryfront dev`. The quickest server-side
+check is a throwaway debug route:
 
 ```ts
+// app/api/debug/agent/route.ts
 import { getAgent } from "veryfront/agent";
 
-const agent = getAgent("assistant");
-if (!agent) throw new Error("Agent not found: assistant");
+export async function GET() {
+  const agent = getAgent("assistant");
+  if (!agent) throw new Error("Agent not found: assistant");
 
-const result = await agent.generate({ input: "Hello" });
-console.log(result.text);
+  const result = await agent.generate({ input: "Hello" });
+  return Response.json({ text: result.text });
+}
 ```
+
+```bash
+curl http://localhost:3000/api/debug/agent
+```
+
+The response carries the model's reply. Remove the debug route before
+deploying.
 
 If generation fails, check the dev-server log for agent registration or provider
 errors. If AG-UI routing fails, use the route verification in

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -75,7 +75,13 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   },
   "guides/agents.md": {
     references: ["../api-reference/veryfront/agent.md"],
-    snippets: ["createAgUiHandler", "load_skill_reference", "RunFinished"],
+    snippets: [
+      "createAgUiHandler",
+      "load_skill_reference",
+      "RunFinished",
+      "// app/api/debug/agent/route.ts",
+      "curl http://localhost:3000/api/debug/agent",
+    ],
   },
   "guides/build-a-rag-app.md": {
     references: [


### PR DESCRIPTION
## Problem

DX dogfood of the published agents guide (**veryfront@0.1.1239**) found the "Verify it worked" step says *invoke it from server code* and then shows a bare `getAgent`/`generate` snippet with no stated home. A first-time reader doesn't know whether it belongs in a route, a script, or a task. The tools guide next door already solves this with a throwaway debug route.

## Fix

Mirror the tools guide's shape: the snippet becomes `app/api/debug/agent/route.ts` plus the `curl` to hit it, with the same "remove before deploying" note. This exact route was walked during the dogfood run against 0.1.1239 and answered end-to-end on the first try.

## Regression coverage

`guide-contracts.test.ts`: the page contract now requires the route path and the curl command (written first, failed for the right reason). Full `tests/docs/` 56/56 and `validate-public-docs.ts` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent verification instructions with a temporary debug endpoint example.
  * Added a `curl` command for testing agent responses.
  * Clarified that the debug endpoint should be removed before deployment.

* **Tests**
  * Updated documentation checks to validate the new verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->