### PR TITLE
fix(server): exempt run execution from stuck alarms

### DIFF
--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -359,9 +359,6 @@ describe("server/runtime-handler/request-tracker", () => {
         requestTracker.start("slow-req", "proj", "/slow", "GET");
         requestTracker.complete("slow-req", 200);
       } finally {
-        requestTracker.complete("expected-long-run", 500);
-        requestTracker.complete("non-execute-method", 500);
-        requestTracker.complete("lookalike-path", 500);
         globalThis.setTimeout = originalSetTimeout;
       }
 
@@ -402,6 +399,9 @@ describe("server/runtime-handler/request-tracker", () => {
         assertEquals(scheduledDelays.includes(10_000), true);
         requestTracker.complete("lookalike-path", 404);
       } finally {
+        requestTracker.complete("expected-long-run", 500);
+        requestTracker.complete("non-execute-method", 500);
+        requestTracker.complete("lookalike-path", 500);
         globalThis.setTimeout = originalSetTimeout;
       }
     });

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -359,6 +359,9 @@ describe("server/runtime-handler/request-tracker", () => {
         requestTracker.start("slow-req", "proj", "/slow", "GET");
         requestTracker.complete("slow-req", 200);
       } finally {
+        requestTracker.complete("expected-long-run", 500);
+        requestTracker.complete("non-execute-method", 500);
+        requestTracker.complete("lookalike-path", 500);
         globalThis.setTimeout = originalSetTimeout;
       }
 

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -371,6 +371,38 @@ describe("server/runtime-handler/request-tracker", () => {
       assertEquals(verySlowEntry?.level, "error");
     });
 
+    it("skips generic stuck timers for expected long-running run execution", () => {
+      const scheduledDelays: number[] = [];
+      const originalSetTimeout = globalThis.setTimeout;
+
+      globalThis.setTimeout = ((callback: TimerHandler, delay?: number, ...args: unknown[]) => {
+        if (delay !== undefined) scheduledDelays.push(delay);
+        return originalSetTimeout(callback, delay, ...args);
+      }) as typeof setTimeout;
+
+      try {
+        const path = "/api/control-plane/runs/run_scheduled_1/execute";
+        const beforeCount = requestTracker.getInFlightCount();
+
+        requestTracker.start("expected-long-run", "proj", path, "POST");
+        assertEquals(scheduledDelays.includes(10_000), false);
+        assertEquals(requestTracker.getInFlightCount(), beforeCount + 1);
+        requestTracker.complete("expected-long-run", 200);
+
+        scheduledDelays.length = 0;
+        requestTracker.start("non-execute-method", "proj", path, "GET");
+        assertEquals(scheduledDelays.includes(10_000), true);
+        requestTracker.complete("non-execute-method", 405);
+
+        scheduledDelays.length = 0;
+        requestTracker.start("lookalike-path", "proj", `${path}/extra`, "POST");
+        assertEquals(scheduledDelays.includes(10_000), true);
+        requestTracker.complete("lookalike-path", 404);
+      } finally {
+        globalThis.setTimeout = originalSetTimeout;
+      }
+    });
+
     it("handles module request with short duration (no debug log)", () => {
       requestTracker.start("fast-mod", "proj", "/_vf_modules/fast.js", "GET");
       requestTracker.complete("fast-mod", 200);

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -45,6 +45,13 @@ const MODULE_REQUEST_LOG_THRESHOLD_MS = 100;
 /** Attach request-profiler details to completion logs at or above this duration. */
 const DEFAULT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS = 2_000;
 
+/** Control-plane execution can legitimately run until the configured request timeout. */
+const RUN_EXECUTION_PATH_PATTERN = /^\/api\/control-plane\/runs\/[^/]+\/execute$/u;
+
+function isExpectedLongRunningRequest(path: string, method: string): boolean {
+  return method === "POST" && RUN_EXECUTION_PATH_PATTERN.test(path);
+}
+
 function getSlowRequestProfileLogThresholdMs(): number {
   const raw = getEnv("VERYFRONT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS");
   if (!raw) return DEFAULT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS;
@@ -163,9 +170,13 @@ class RequestTracker {
       productionRuntime,
     };
 
-    // WebSocket connections are long-lived by design and lightweight internal
-    // asset/module requests can be noisy under CI jitter — don't flag them as stuck.
-    if (!isWebSocketPath(path) && !isLightweightPath(path)) {
+    // WebSocket connections and control-plane execution are long-lived by design.
+    // Lightweight internal asset/module requests can be noisy under CI jitter.
+    if (
+      !isExpectedLongRunningRequest(path, method) &&
+      !isWebSocketPath(path) &&
+      !isLightweightPath(path)
+    ) {
       tracked.slowTimer = setTimeout(() => {
         const elapsedMs = Math.round(performance.now() - startTime);
         logger.warn("Slow request detected", {


### PR DESCRIPTION
## Summary

- Treat only exact `POST /api/control-plane/runs/<RUN_ID>/execute` requests as expected long-running work in the generic request tracker.
- Keep those requests in the in-flight set so 30-second status diagnostics, graceful drain, tracing, and configured request timeouts still apply.
- Preserve the existing slow/stuck timers for other methods and lookalike paths.

## Production diagnosis

The issue reported 35 generic stuck alarms in seven days. Sanitized Loki and Tempo correlation showed:

- 30 were exact scheduled-run execute requests for one project. All 30 corresponding traces completed successfully.
- Completion duration was 39 to 651 seconds, with a median near 147 seconds.
- Every trace contained agent generation/execution spans, and 29 contained tool execution spans.
- The execute handler intentionally supports workflows for up to 15 minutes, while the generic tracker reports likely stuck at 25 seconds.
- The remaining four page warnings and one sourcing warning are outside this exact-route change and remain observable.

## Red-green TDD

Red:

- Added a regression proving the exact POST execute route schedules no generic 10-second stuck timer while remaining in flight.
- The new assertion failed on the previous implementation because the timer was scheduled.

Green:

- Added an exact method-and-path classifier.
- Added negative coverage proving GET and a POST path lookalike still schedule normal diagnostics.

## Verification

- Focused request-tracker test: 51 steps passed.
- Request tracker, request lifecycle, and runtime-handler tests: 83 steps passed.
- `deno task verify:quick`: passed, including formatting, lint, dependency boundaries, docs checks, and typecheck.
- `git diff --check`: passed.
- `deno task test`: 4,439 tests passed. Four unrelated main-baseline failures remained: three CLI fixture conflict tests reproduce in isolation in untouched CLI files, and one parallel fixed-port collision passed on serial rerun.
- Brooks PR review: 98/100, no findings.

Fixes veryfront/veryfront-issue-inbox#532.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of run execution requests to prevent incorrect slow-request warnings.
  * Preserved request monitoring for other request types and similar-looking paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->