### PR TITLE
test(e2e): avoid wildcard localhost DNS for API requests

### DIFF
--- a/tests/e2e/helpers/runtime.test.ts
+++ b/tests/e2e/helpers/runtime.test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getRuntimeForPlaywrightProject } from "./runtime.ts";
+
+describe("Playwright runtime requests", () => {
+  it("uses loopback transport while preserving the production virtual host", () => {
+    const runtime = getRuntimeForPlaywrightProject("production-host");
+
+    assertEquals(runtime.getApiRequest("alpha", "/api/status"), {
+      url: "http://127.0.0.1:8080/api/status",
+      headers: { host: "alpha.localhost:8080" },
+    });
+  });
+
+  it("uses loopback transport while preserving the preview virtual host", () => {
+    const runtime = getRuntimeForPlaywrightProject("preview-host");
+
+    assertEquals(runtime.getApiRequest("alpha", "/api/status"), {
+      url: "http://127.0.0.1:8080/api/status",
+      headers: { host: "alpha.preview.localhost:8080" },
+    });
+  });
+});

--- a/tests/e2e/helpers/runtime.ts
+++ b/tests/e2e/helpers/runtime.ts
@@ -1,13 +1,28 @@
+const PLAYWRIGHT_RUNTIME_PORT = 8080;
+const PLAYWRIGHT_RUNTIME_ORIGIN = `http://127.0.0.1:${PLAYWRIGHT_RUNTIME_PORT}`;
+
+function createApiRequest(hostname: string, path: string) {
+  return {
+    url: `${PLAYWRIGHT_RUNTIME_ORIGIN}${path}`,
+    headers: { host: `${hostname}:${PLAYWRIGHT_RUNTIME_PORT}` },
+  };
+}
+
 export const PLAYWRIGHT_RUNTIME_CONFIGS = [
   {
     name: "production-host",
     modeName: "production",
-    getUrl: (subdomain: string) => `http://${subdomain}.localhost:8080`,
+    getUrl: (subdomain: string) => `http://${subdomain}.localhost:${PLAYWRIGHT_RUNTIME_PORT}`,
+    getApiRequest: (subdomain: string, path: string) =>
+      createApiRequest(`${subdomain}.localhost`, path),
   },
   {
     name: "preview-host",
     modeName: "preview",
-    getUrl: (subdomain: string) => `http://${subdomain}.preview.localhost:8080`,
+    getUrl: (subdomain: string) =>
+      `http://${subdomain}.preview.localhost:${PLAYWRIGHT_RUNTIME_PORT}`,
+    getApiRequest: (subdomain: string, path: string) =>
+      createApiRequest(`${subdomain}.preview.localhost`, path),
   },
 ] as const;
 

--- a/tests/e2e/multi-project.playwright.ts
+++ b/tests/e2e/multi-project.playwright.ts
@@ -32,7 +32,8 @@ test(
     const runtime = getRuntimeForPlaywrightProject(testInfo.project.name);
 
     for (const subdomain of PROJECTS) {
-      const response = await request.get(`${runtime.getUrl(subdomain)}/api/status`);
+      const apiRequest = runtime.getApiRequest(subdomain, "/api/status");
+      const response = await request.get(apiRequest.url, { headers: apiRequest.headers });
 
       expect(response.ok()).toBeTruthy();
       expect(await response.json()).toEqual({ ok: true, project: subdomain });

--- a/tests/e2e/smoke.playwright.ts
+++ b/tests/e2e/smoke.playwright.ts
@@ -65,7 +65,8 @@ for (const subdomain of PROJECTS) {
 
     test("API routes respond with JSON", async ({ request }, testInfo) => {
       const runtime = getRuntimeForPlaywrightProject(testInfo.project.name);
-      const response = await request.get(`${runtime.getUrl(subdomain)}/api/status`);
+      const apiRequest = runtime.getApiRequest(subdomain, "/api/status");
+      const response = await request.get(apiRequest.url, { headers: apiRequest.headers });
 
       expect(response.ok()).toBeTruthy();
       expect(response.headers()["content-type"]).toContain("application/json");


### PR DESCRIPTION
## Summary

- route Playwright API request fixtures through `127.0.0.1:8080` so Node does not need to resolve wildcard `*.localhost` hostnames
- preserve the original production or preview virtual host in the `Host` header
- keep browser navigation unchanged and add focused coverage for both runtime modes

This is a scoped residual from veryfront/veryfront-issue-inbox#497. The umbrella issue remains open for its other work items.

## Red-green TDD

Red:
- `deno test --no-check --allow-all tests/e2e/helpers/runtime.test.ts`
- failed in both cases because `runtime.getApiRequest` did not exist

Green:
- the same command passes, 1 test with 2 steps

## Verification

- focused runtime helper test: passed
- live Veryfront server probe using Playwright APIRequestContext: passed for both provisioned projects in production and preview modes, 4 request cases total
- `deno fmt --check tests/e2e/helpers/runtime.ts tests/e2e/helpers/runtime.test.ts tests/e2e/smoke.playwright.ts tests/e2e/multi-project.playwright.ts`: passed
- `deno lint tests/e2e/helpers/runtime.ts tests/e2e/helpers/runtime.test.ts tests/e2e/smoke.playwright.ts tests/e2e/multi-project.playwright.ts`: passed
- `deno check tests/e2e/helpers/runtime.test.ts tests/e2e/smoke.playwright.ts tests/e2e/multi-project.playwright.ts`: passed
- `deno task verify:quick`: passed
- `git diff --check`: passed

The full `deno task test:e2e:playwright` wrapper currently stops before test discovery with `ReferenceError: exports is not defined` in unchanged `tests/e2e/setup/server.ts`. The same failure reproduces from an untouched clean worktree, so it is unrelated to this change.
