### PR TITLE
fix(sandbox): preserve external parser tools

### DIFF
--- a/docs/api-reference/veryfront/sandbox.md
+++ b/docs/api-reference/veryfront/sandbox.md
@@ -179,9 +179,9 @@ Streaming event emitted during command execution.
 | `createAgentServiceSandboxClient`      | Create agent service sandbox client.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L93)  |
 | `createAgentServiceSandboxTools`       | Create agent service sandbox tools.             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L146) |
 | `createProjectScopedExecOptions`       | Options accepted by create project scoped exec. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L61)  |
-| `createSandboxShellTools`              | Create sandbox shell tools.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/shell-tools.ts#L231)         |
-| `normalizeBashToolSet`                 | Normalizes bash tool set.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/shell-tools.ts#L186)         |
-| `renameSandboxFileTools`               | Rename sandbox file tools.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/shell-tools.ts#L195)         |
+| `createSandboxShellTools`              | Create sandbox shell tools.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/shell-tools.ts#L242)         |
+| `normalizeBashToolSet`                 | Normalizes bash tool set.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/shell-tools.ts#L197)         |
+| `renameSandboxFileTools`               | Rename sandbox file tools.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/shell-tools.ts#L206)         |
 | `resolveDefaultSandboxRuntimeEndpoint` | Resolves default sandbox runtime endpoint.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/lazy-sandbox.ts#L79)         |
 | `unwrapSandboxWorkingDirectoryCommand` | Unwrap sandbox working directory command.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L51)  |
 

--- a/src/sandbox/shell-tools.test.ts
+++ b/src/sandbox/shell-tools.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeBashToolSet,
   renameSandboxFileTools,
 } from "./shell-tools.ts";
+import { createToolsFromHostDefinitions } from "#veryfront/tool/host-tools.ts";
 import { toolToProviderDefinition } from "#veryfront/tool/registry.ts";
 
 describe("sandbox/shell-tools", () => {
@@ -183,6 +184,40 @@ describe("sandbox/shell-tools", () => {
       properties: {},
       additionalProperties: true,
     });
+  });
+
+  it("materializes parser schemas with methods named like JSON Schema keywords", () => {
+    class ExternalParserSchema {
+      default = () => this;
+
+      parse(input: unknown) {
+        return input;
+      }
+    }
+
+    const createExternalTool = () => ({
+      description: "Use a sandbox tool",
+      inputSchema: new ExternalParserSchema(),
+      execute: () => ({ ok: true }),
+    });
+    const normalized = renameSandboxFileTools(
+      normalizeBashToolSet({
+        bash: createExternalTool(),
+        readFile: createExternalTool(),
+        writeFile: createExternalTool(),
+      }),
+    );
+
+    assertEquals(normalized.bash?.inputSchemaJson, {
+      type: "object",
+      properties: {},
+      additionalProperties: true,
+    });
+    assertEquals(Object.keys(createToolsFromHostDefinitions(normalized)), [
+      "bash",
+      "sandbox_read_file",
+      "sandbox_write_file",
+    ]);
   });
 
   it("handles invalid definitions gracefully", () => {

--- a/src/sandbox/shell-tools.ts
+++ b/src/sandbox/shell-tools.ts
@@ -6,6 +6,7 @@ import type {
   SandboxShellToolSet,
   SandboxShellToolsProvider,
 } from "#veryfront/extensions/sandbox/index.ts";
+import { snapshotBoundedJsonValue } from "#veryfront/schemas/json-value.ts";
 
 export type {
   SandboxShellClient as BashToolSandboxLike,
@@ -87,6 +88,11 @@ function normalizeJsonSchemaProperties(value: unknown): Record<string, JsonSchem
   return properties;
 }
 
+function normalizeJsonValue(value: unknown) {
+  const snapshot = snapshotBoundedJsonValue(value);
+  return snapshot.success ? snapshot.value : undefined;
+}
+
 function normalizeJsonSchema(value: unknown): JsonSchema | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -100,12 +106,17 @@ function normalizeJsonSchema(value: unknown): JsonSchema | undefined {
   const items = normalizeJsonSchema(value.items);
   const anyOf = normalizeJsonSchemaArray(value.anyOf);
   const prefixItems = normalizeJsonSchemaArray(value.prefixItems);
+  const enumValue = normalizeJsonValue(value.enum);
+  const constValue = Object.hasOwn(value, "const") ? normalizeJsonValue(value.const) : undefined;
+  const defaultValue = Object.hasOwn(value, "default")
+    ? normalizeJsonValue(value.default)
+    : undefined;
 
   if (type !== undefined) schema.type = type;
   if (description !== undefined) schema.description = description;
-  if (Array.isArray(value.enum)) schema.enum = [...value.enum];
-  if ("const" in value) schema.const = value.const;
-  if ("default" in value) schema.default = value.default;
+  if (Array.isArray(enumValue)) schema.enum = enumValue;
+  if (constValue !== undefined) schema.const = constValue;
+  if (defaultValue !== undefined) schema.default = defaultValue;
   if (properties !== undefined) schema.properties = properties;
   if (required !== undefined) schema.required = required;
   if (items !== undefined) schema.items = items;


### PR DESCRIPTION
## Summary

- stop treating parser methods named `default` as JSON Schema keyword data
- validate and snapshot `enum`, `const`, and `default` values through the existing bounded JSON boundary
- preserve the provider-safe fallback for external parser schemas so `bash`, `sandbox_read_file`, and `sandbox_write_file` materialize
- update generated sandbox API-reference source links

Refs veryfront/veryfront-issue-inbox#90. The inbox issue should remain open until the framework release is consumed and the hosted sandbox replay passes.

## Root cause

The sandbox normalizer tries to recognize raw JSON Schema carried by external tool definitions. Zod v3 binds a `.default()` parser method as an own function property. The normalizer copied that method into `inputSchemaJson` as `{ default: [Function] }`; the hardened host-tool materializer then correctly rejected the non-JSON value and dropped all three sandbox tools.

## Red-green TDD

Red:

- `deno test --no-check --allow-all src/sandbox/shell-tools.test.ts`
- the new step received `{ default: [Function] }` instead of the provider-safe object schema
- a real `bash-tool@1.3.18` probe logged schema-conversion failures for all three aliases and materialized `[]`

Green:

- the focused shell-tools suite passes, 10 steps
- the real package probe materializes exactly `bash,sandbox_read_file,sandbox_write_file`

## Verification

- focused host, sandbox, internal-agent, and hosted-root suites: 10 tests, 71 steps passed
- real `bash-tool@1.3.18` materialization probe: passed
- `deno task verify:quick`: passed
- focused format, lint, and type checks: passed
- generated API-reference check: passed
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox tool schema handling for schemas containing keyword-like method names.
  * Added safer validation for schema defaults, constants, and enumerated values, excluding unsupported or oversized values.

* **Documentation**
  * Updated exported function references in the sandbox API documentation.

* **Tests**
  * Added regression coverage for sandbox tool conversion and schema normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->