### PR TITLE
fix(dev): hide secret files from dashboard

### DIFF
--- a/src/server/handlers/dev/dashboard/api.test.ts
+++ b/src/server/handlers/dev/dashboard/api.test.ts
@@ -307,6 +307,24 @@ describe("Dashboard API - GET endpoints", () => {
     assertEquals(body.isBinary, true);
   });
 
+  it("/_dev/api/file-content keeps .env.example visible", async () => {
+    let readFileCalled = false;
+    const ctx = createMockCtxWithFs({
+      readFile: async () => {
+        readFileCalled = true;
+        return "API_KEY=<API_KEY>\n";
+      },
+    });
+    const req = new Request("http://localhost/_dev/api/file-content?path=.env.example");
+
+    const res = await handleDashboardAPI(req, ctx);
+
+    assertEquals(res?.status, 200);
+    assertEquals(readFileCalled, true);
+    const body = await res!.json();
+    assertEquals(body.content, "API_KEY=<API_KEY>\n");
+  });
+
   for (
     const path of [
       ".env",
@@ -372,6 +390,44 @@ describe("Dashboard API - GET endpoints", () => {
       { name: "README.md", type: "file", path: "README.md" },
     ]);
     assertEquals(body.count, 3);
+  });
+
+  it("/_dev/api/files keeps .env.example files and env directories visible", async () => {
+    const entries = [
+      { name: "env", isDirectory: true },
+      { name: ".env.example", isDirectory: false },
+    ];
+    const ctx = createMockCtxWithFs({
+      readDir: async function* () {
+        yield* entries;
+      },
+    });
+    const req = new Request("http://localhost/_dev/api/files");
+
+    const res = await handleDashboardAPI(req, ctx);
+
+    assertEquals(res?.status, 200);
+    const body = await res!.json();
+    assertEquals(body.files, [
+      { name: "env", type: "directory", path: "env" },
+      { name: ".env.example", type: "file", path: ".env.example" },
+    ]);
+  });
+
+  it("/_dev/api/files permits direct listing of an env directory", async () => {
+    let readDirCalled = false;
+    const ctx = createMockCtxWithFs({
+      readDir: async function* () {
+        readDirCalled = true;
+        yield { name: "example.ts", isDirectory: false };
+      },
+    });
+    const req = new Request("http://localhost/_dev/api/files?path=examples/env");
+
+    const res = await handleDashboardAPI(req, ctx);
+
+    assertEquals(res?.status, 200);
+    assertEquals(readDirCalled, true);
   });
 
   it("/_dev/api/files blocks direct listing of sensitive directories", async () => {

--- a/src/server/handlers/dev/dashboard/api.test.ts
+++ b/src/server/handlers/dev/dashboard/api.test.ts
@@ -307,6 +307,90 @@ describe("Dashboard API - GET endpoints", () => {
     assertEquals(body.isBinary, true);
   });
 
+  for (
+    const path of [
+      ".env",
+      ".env.local",
+      ".ENV.production",
+      "config/production.env",
+      "env",
+      ".envrc",
+      ".npmrc",
+      ".pypirc",
+      ".netrc",
+      "credentials.json",
+      "secrets.json",
+      "certs/private.pem",
+      ".git/config",
+    ]
+  ) {
+    it(`/_dev/api/file-content blocks sensitive file ${path}`, async () => {
+      let readFileCalled = false;
+      const ctx = createMockCtxWithFs({
+        readFile: async () => {
+          readFileCalled = true;
+          return "must not be returned";
+        },
+      });
+      const req = new Request(
+        `http://localhost/_dev/api/file-content?path=${encodeURIComponent(path)}`,
+      );
+
+      const res = await handleDashboardAPI(req, ctx);
+
+      assertEquals(res?.status, 403);
+      assertEquals(await res!.json(), { error: "File content is not available" });
+      assertEquals(readFileCalled, false);
+    });
+  }
+
+  it("/_dev/api/files omits sensitive files and directories", async () => {
+    const entries = [
+      { name: "src", isDirectory: true },
+      { name: ".git", isDirectory: true },
+      { name: "README.md", isDirectory: false },
+      { name: ".gitignore", isDirectory: false },
+      { name: ".env", isDirectory: false },
+      { name: ".env.local", isDirectory: false },
+      { name: ".npmrc", isDirectory: false },
+      { name: "private.pem", isDirectory: false },
+    ];
+    const ctx = createMockCtxWithFs({
+      readDir: async function* () {
+        yield* entries;
+      },
+    });
+    const req = new Request("http://localhost/_dev/api/files");
+
+    const res = await handleDashboardAPI(req, ctx);
+
+    assertEquals(res?.status, 200);
+    const body = await res!.json();
+    assertEquals(body.files, [
+      { name: "src", type: "directory", path: "src" },
+      { name: ".gitignore", type: "file", path: ".gitignore" },
+      { name: "README.md", type: "file", path: "README.md" },
+    ]);
+    assertEquals(body.count, 3);
+  });
+
+  it("/_dev/api/files blocks direct listing of sensitive directories", async () => {
+    let readDirCalled = false;
+    const ctx = createMockCtxWithFs({
+      // deno-lint-ignore require-yield
+      readDir: async function* () {
+        readDirCalled = true;
+      },
+    });
+    const req = new Request("http://localhost/_dev/api/files?path=.git");
+
+    const res = await handleDashboardAPI(req, ctx);
+
+    assertEquals(res?.status, 403);
+    assertEquals(await res!.json(), { error: "File content is not available" });
+    assertEquals(readDirCalled, false);
+  });
+
   it("/_dev/api/files with readDir error returns empty list", async () => {
     const ctx = createMockCtxWithFs({
       // deno-lint-ignore require-yield

--- a/src/server/handlers/dev/dashboard/api.test.ts
+++ b/src/server/handlers/dev/dashboard/api.test.ts
@@ -340,6 +340,10 @@ describe("Dashboard API - GET endpoints", () => {
       "secrets.json",
       "certs/private.pem",
       ".git/config",
+      ".env ",
+      ".env... ",
+      ".aws /credentials",
+      ".ssh./id_rsa",
     ]
   ) {
     it(`/_dev/api/file-content blocks sensitive file ${path}`, async () => {

--- a/src/server/handlers/dev/dashboard/api.test.ts
+++ b/src/server/handlers/dev/dashboard/api.test.ts
@@ -342,6 +342,7 @@ describe("Dashboard API - GET endpoints", () => {
       ".git/config",
       ".env ",
       ".env... ",
+      ".env::$DATA",
       ".aws /credentials",
       ".ssh./id_rsa",
     ]
@@ -374,6 +375,7 @@ describe("Dashboard API - GET endpoints", () => {
       { name: ".gitignore", isDirectory: false },
       { name: ".env", isDirectory: false },
       { name: ".env.local", isDirectory: false },
+      { name: ".env::$DATA", isDirectory: false },
       { name: ".npmrc", isDirectory: false },
       { name: "private.pem", isDirectory: false },
     ];

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -106,16 +106,26 @@ const SENSITIVE_DASHBOARD_DIRECTORY_NAMES = new Set([
   ".kube",
   ".ssh",
 ]);
+const SAFE_ENV_TEMPLATE_NAMES = new Set([
+  ".env.example",
+  ".env.sample",
+  ".env.template",
+]);
 const UNAVAILABLE_FILE_MESSAGE = "File content is not available";
 
-function isSensitiveDashboardPath(path: string): boolean {
+function isSensitiveDashboardPath(
+  path: string,
+  kind: "file" | "directory",
+): boolean {
   const segments = path.replaceAll("\\", "/").split("/").filter(Boolean).map((segment) =>
     segment.toLowerCase()
   );
   if (segments.some((segment) => SENSITIVE_DASHBOARD_DIRECTORY_NAMES.has(segment))) return true;
+  if (kind === "directory") return false;
 
   const fileName = segments.at(-1);
   if (!fileName) return false;
+  if (SAFE_ENV_TEMPLATE_NAMES.has(fileName)) return false;
   if (fileName === ".env" || fileName.startsWith(".env.")) return true;
   if (SENSITIVE_DASHBOARD_FILE_NAMES.has(fileName)) return true;
 
@@ -456,7 +466,7 @@ async function handleListFiles(req: Request, ctx: HandlerContext): Promise<Respo
   } else {
     const canonical = await validateRelativePath(relativePath, projectDir, adapter);
     if (canonical === null) return errorResponse("Invalid path", 400);
-    if (isSensitiveDashboardPath(relativePath)) {
+    if (isSensitiveDashboardPath(relativePath, "directory")) {
       return errorResponse(UNAVAILABLE_FILE_MESSAGE, 403);
     }
     fullPath = canonical;
@@ -466,7 +476,7 @@ async function handleListFiles(req: Request, ctx: HandlerContext): Promise<Respo
     const files: Array<{ name: string; type: "file" | "directory"; path: string }> = [];
     for await (const entry of adapter.fs.readDir(fullPath)) {
       const entryPath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
-      if (isSensitiveDashboardPath(entryPath)) continue;
+      if (isSensitiveDashboardPath(entryPath, entry.isDirectory ? "directory" : "file")) continue;
       files.push({
         name: entry.name,
         type: entry.isDirectory ? "directory" : "file",
@@ -499,15 +509,16 @@ async function handleReadFileContent(req: Request, ctx: HandlerContext): Promise
 
   const canonical = await validateRelativePath(relativePath, projectDir, adapter);
   if (canonical === null) return errorResponse("Invalid path", 400);
-  if (isSensitiveDashboardPath(relativePath)) {
+  if (isSensitiveDashboardPath(relativePath, "file")) {
     return errorResponse(UNAVAILABLE_FILE_MESSAGE, 403);
   }
 
   try {
     const content = await adapter.fs.readFile(canonical);
-    const extension = relativePath.split(".").pop() ?? "";
+    const fileName = relativePath.replaceAll("\\", "/").split("/").at(-1)?.toLowerCase() ?? "";
+    const extension = fileName.split(".").pop() ?? "";
 
-    if (!TEXT_EXTENSIONS.has(extension.toLowerCase())) {
+    if (!TEXT_EXTENSIONS.has(extension) && !SAFE_ENV_TEMPLATE_NAMES.has(fileName)) {
       return jsonResponse({
         path: relativePath,
         extension,

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -118,7 +118,7 @@ function isSensitiveDashboardPath(
   kind: "file" | "directory",
 ): boolean {
   const segments = path.replaceAll("\\", "/").split("/").filter(Boolean).map((segment) =>
-    segment.toLowerCase()
+    segment.toLowerCase().replace(/[ .]+$/g, "")
   );
   if (segments.some((segment) => SENSITIVE_DASHBOARD_DIRECTORY_NAMES.has(segment))) return true;
   if (kind === "directory") return false;

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -120,6 +120,10 @@ function isSensitiveDashboardPath(
   const segments = path.replaceAll("\\", "/").split("/").filter(Boolean).map((segment) =>
     segment.toLowerCase().replace(/[ .]+$/g, "")
   );
+  // A colon addresses an alternate data stream on NTFS. Treat stream paths as
+  // unavailable so a sensitive file cannot be reached through an alias such as
+  // `.env::$DATA`.
+  if (segments.some((segment) => segment.includes(":"))) return true;
   if (segments.some((segment) => SENSITIVE_DASHBOARD_DIRECTORY_NAMES.has(segment))) return true;
   if (kind === "directory") return false;
 

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -78,6 +78,51 @@ const TEXT_EXTENSIONS = new Set([
   "dockerignore",
 ]);
 
+const SENSITIVE_DASHBOARD_FILE_NAMES = new Set([
+  ".envrc",
+  ".netrc",
+  ".npmrc",
+  ".pypirc",
+  "application_default_credentials.json",
+  "credentials.json",
+  "env",
+  "id_ed25519",
+  "id_rsa",
+  "secrets.json",
+  "service-account.json",
+]);
+const SENSITIVE_DASHBOARD_FILE_EXTENSIONS = new Set([
+  "env",
+  "key",
+  "p12",
+  "pem",
+  "pfx",
+]);
+const SENSITIVE_DASHBOARD_DIRECTORY_NAMES = new Set([
+  ".aws",
+  ".docker",
+  ".git",
+  ".gnupg",
+  ".kube",
+  ".ssh",
+]);
+const UNAVAILABLE_FILE_MESSAGE = "File content is not available";
+
+function isSensitiveDashboardPath(path: string): boolean {
+  const segments = path.replaceAll("\\", "/").split("/").filter(Boolean).map((segment) =>
+    segment.toLowerCase()
+  );
+  if (segments.some((segment) => SENSITIVE_DASHBOARD_DIRECTORY_NAMES.has(segment))) return true;
+
+  const fileName = segments.at(-1);
+  if (!fileName) return false;
+  if (fileName === ".env" || fileName.startsWith(".env.")) return true;
+  if (SENSITIVE_DASHBOARD_FILE_NAMES.has(fileName)) return true;
+
+  const extension = fileName.includes(".") ? fileName.slice(fileName.lastIndexOf(".") + 1) : "";
+  return SENSITIVE_DASHBOARD_FILE_EXTENSIONS.has(extension);
+}
+
 type DashboardApiMethod = "GET" | "POST";
 type DashboardApiRouteHandler = (
   req: Request,
@@ -411,16 +456,21 @@ async function handleListFiles(req: Request, ctx: HandlerContext): Promise<Respo
   } else {
     const canonical = await validateRelativePath(relativePath, projectDir, adapter);
     if (canonical === null) return errorResponse("Invalid path", 400);
+    if (isSensitiveDashboardPath(relativePath)) {
+      return errorResponse(UNAVAILABLE_FILE_MESSAGE, 403);
+    }
     fullPath = canonical;
   }
 
   try {
     const files: Array<{ name: string; type: "file" | "directory"; path: string }> = [];
     for await (const entry of adapter.fs.readDir(fullPath)) {
+      const entryPath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
+      if (isSensitiveDashboardPath(entryPath)) continue;
       files.push({
         name: entry.name,
         type: entry.isDirectory ? "directory" : "file",
-        path: relativePath ? `${relativePath}/${entry.name}` : entry.name,
+        path: entryPath,
       });
     }
 
@@ -449,6 +499,9 @@ async function handleReadFileContent(req: Request, ctx: HandlerContext): Promise
 
   const canonical = await validateRelativePath(relativePath, projectDir, adapter);
   if (canonical === null) return errorResponse("Invalid path", 400);
+  if (isSensitiveDashboardPath(relativePath)) {
+    return errorResponse(UNAVAILABLE_FILE_MESSAGE, 403);
+  }
 
   try {
     const content = await adapter.fs.readFile(canonical);


### PR DESCRIPTION
## Summary

- deny dashboard content reads for environment files, credential stores, private-key formats, and common credential directories
- omit the same sensitive paths from dashboard file listings
- reject blocked paths before calling the filesystem adapter and return a generic 403 response

This is the first scoped fix from veryfront/veryfront-issue-inbox#105. That issue remains open for the public `veryfront/fs` trust-model documentation and the isolated-worker symlink boundary follow-up.

## Red-green TDD

Red: the new endpoint cases returned HTTP 200 for every representative sensitive path, and the listing included the sensitive entries.

Green:

- `deno test --preload=src/testing/preload.ts --no-check --allow-all src/server/handlers/dev/dashboard/api.test.ts src/server/handlers/dev/dashboard/index.test.ts src/server/handlers/dev/dashboard/access-policy.test.ts` (111 steps passed)
- `deno task verify:quick` (passed)
- `git diff --check` (passed)

## Preview

No visual Studio or dashboard component changed, so a screenshot is not applicable. To preview the functional behavior, request `/_dev/api/file-content?path=.env`; it now returns a generic 403 response. Ordinary source files remain readable, and sensitive entries are absent from `/_dev/api/files`.