### PR TITLE
fix(fs): redact source content from debug logs

### DIFF
--- a/src/platform/adapters/fs/veryfront/content-log-safety.test.ts
+++ b/src/platform/adapters/fs/veryfront/content-log-safety.test.ts
@@ -1,0 +1,81 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { __resetLoggerConfigForTests } from "#veryfront/utils/logger/logger.ts";
+import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
+import { FileCache } from "../cache/file-cache.ts";
+import { FileListIndex } from "./file-list-index.ts";
+import { PathNormalizer } from "./path-normalizer.ts";
+import { ReadOperations } from "./read-operations.ts";
+
+async function captureDebugOutput(action: () => Promise<void>): Promise<string> {
+  const previousFormat = Deno.env.get("LOG_FORMAT");
+  const previousLevel = Deno.env.get("LOG_LEVEL");
+  const originalDebug = console.debug;
+  const output: string[] = [];
+
+  Deno.env.set("LOG_FORMAT", "json");
+  Deno.env.set("LOG_LEVEL", "DEBUG");
+  __resetLoggerConfigForTests();
+  console.debug = ((...args: unknown[]) => {
+    output.push(args.map((arg) => typeof arg === "string" ? arg : JSON.stringify(arg)).join(" "));
+  }) as typeof console.debug;
+
+  try {
+    await action();
+    return output.join("\n");
+  } finally {
+    console.debug = originalDebug;
+    if (previousFormat === undefined) Deno.env.delete("LOG_FORMAT");
+    else Deno.env.set("LOG_FORMAT", previousFormat);
+    if (previousLevel === undefined) Deno.env.delete("LOG_LEVEL");
+    else Deno.env.set("LOG_LEVEL", previousLevel);
+    __resetLoggerConfigForTests();
+  }
+}
+
+describe("remote filesystem content logging", () => {
+  it("does not log inline source content from the file-list index", async () => {
+    const sentinel = "VF_SOURCE_CONTENT_MUST_NOT_REACH_LOGS_7d4f";
+
+    const output = await captureDebugOutput(async () => {
+      const index = new FileListIndex(async () => [
+        { path: "pages/index.tsx", content: sentinel },
+      ]);
+      assertEquals(await index.lookup("pages/index.tsx"), sentinel);
+    });
+
+    assertEquals(output.includes(sentinel), false);
+  });
+
+  it("does not log source content returned by the remote API", async () => {
+    const sentinel = "VF_REMOTE_SOURCE_MUST_NOT_REACH_LOGS_91ac";
+    const client = {
+      getRequestBranch: () => "main",
+      getFileContent: () => Promise.resolve(sentinel),
+      getPublishedFileContent: () => Promise.resolve(sentinel),
+      resolveFileWithExtension: () => Promise.resolve(null),
+    } as unknown as VeryfrontApiClient;
+    const readOperations = new ReadOperations(
+      client,
+      new FileCache({ enabled: true, ttl: 1_000, maxSize: 100 }),
+      new PathNormalizer(),
+      {
+        isProductionMode: () => false,
+        getReleaseId: () => null,
+        getContentContext: () => ({
+          sourceType: "branch" as const,
+          projectSlug: "test",
+          branch: "main",
+        }),
+      },
+    );
+    readOperations.setFileListReadyPromise(Promise.resolve());
+
+    const output = await captureDebugOutput(async () => {
+      assertEquals(await readOperations.readTextFile("pages/index.tsx"), sentinel);
+    });
+
+    assertEquals(output.includes(sentinel), false);
+  });
+});

--- a/src/platform/adapters/fs/veryfront/file-list-index.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-index.ts
@@ -14,17 +14,6 @@ export interface FileListMatchResult {
   content?: string;
 }
 
-function hashPreview(content: string): number {
-  return content
-    .slice(0, 100)
-    .split("")
-    .reduce((h, c) => ((h << 5) - h + c.charCodeAt(0)) | 0, 0);
-}
-
-function previewText(content: string, max = 80): string {
-  return content.length > max ? `${content.slice(0, max)}...` : content;
-}
-
 const INDEX_STALENESS_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
 
 export class FileListIndex {
@@ -105,8 +94,6 @@ export class FileListIndex {
     logger.debug("FILE_LIST_CACHE_HIT - serving from file list cache", {
       path: normalizedPath,
       contentLength: content.length,
-      contentHash: hashPreview(content),
-      contentPreview: previewText(content, 200).replace(/\n/g, "\\n"),
     });
 
     return {
@@ -210,7 +197,6 @@ export class FileListIndex {
       filesWithContent: fileList.filter((f) => f.content).length,
       sampleFilePath: cacheCheckSample?.path,
       sampleContentLength: cacheCheckSample?.content?.length,
-      sampleContentPreview: cacheCheckSample?.content?.slice(0, 200)?.replace(/\n/g, "\\n"),
     });
 
     const indexKey = `${fileList.length}:${fileList[0]?.path ?? ""}:${
@@ -246,8 +232,6 @@ export class FileListIndex {
       indexedWithContent: index.size,
       sampleFilePath: sampleFile?.path,
       sampleContentLength: sampleContent?.length,
-      sampleContentHash: sampleContent ? hashPreview(sampleContent) : undefined,
-      sampleContentPreview: sampleContent?.slice(0, 200)?.replace(/\n/g, "\\n"),
     });
 
     return {

--- a/src/platform/adapters/fs/veryfront/read-operations-helpers.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations-helpers.test.ts
@@ -4,7 +4,6 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { buildFileCacheKeyPrefix } from "./cache-keys.ts";
 import {
   assertProjectSourcePath,
-  buildContentPreview,
   buildReadFetchState,
   getResolvedCacheKey,
   isNotFoundLikeError,
@@ -98,14 +97,6 @@ describe("read-operations helpers", () => {
         getResolvedCacheKey("file:branch:demo:main", "pages/index.tsx"),
         "file:branch:demo:main:pages/index.tsx",
       );
-    });
-
-    it("builds content previews without changing short strings", () => {
-      assertEquals(buildContentPreview("short text"), "short text");
-    });
-
-    it("truncates long content previews with an ellipsis", () => {
-      assertEquals(buildContentPreview("abcdefghijklmnopqrstuvwxyz", 10), "abcdefghij...");
     });
 
     it("splits known file extensions", () => {

--- a/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
@@ -80,10 +80,6 @@ export function getResolvedCacheKey(
   return `${cacheKeyPrefix}:${normalizedResolvedPath}`;
 }
 
-export function buildContentPreview(content: string, max = 80): string {
-  return content.length > max ? `${content.slice(0, max)}...` : content;
-}
-
 export function buildExtensionCandidatePaths(basePath: string): string[] {
   return READ_OPERATION_EXTENSION_PRIORITY.map((ext) => `${basePath}${ext}`);
 }

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -10,7 +10,6 @@ import { PathNormalizer } from "./path-normalizer.ts";
 import type { ContentContextProvider } from "./file-list-access.ts";
 import {
   assertProjectSourcePath,
-  buildContentPreview,
   buildExtensionCandidatePaths,
   buildReadFetchState,
   createNotFoundLikeError,
@@ -211,7 +210,6 @@ export class ReadOperations {
       path: normalizedPath,
       cacheKey,
       contentLength: requestCached.length,
-      preview: buildContentPreview(requestCached).replace(/\n/g, "\\n"),
     });
     return requestCached;
   }
@@ -252,7 +250,6 @@ export class ReadOperations {
       path: normalizedPath,
       cacheKey,
       contentLength: cached.length,
-      preview: buildContentPreview(cached).replace(/\n/g, "\\n"),
     });
     setRequestScopedFile(cacheKey, cached);
     return cached;
@@ -877,7 +874,6 @@ export class ReadOperations {
     logger.debug("API_FETCH_DONE - got content from API", {
       path: normalizedPath,
       contentLength: content.length,
-      preview: buildContentPreview(content).replace(/\n/g, "\\n"),
       willCache: shouldCache,
     });
 

--- a/src/platform/adapters/fs/veryfront/websocket-manager-helpers.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager-helpers.ts
@@ -81,7 +81,7 @@ export function parsePokeWebSocketMessage(data: string): PokeWebSocketMessage | 
     raw = JSON.parse(data);
   } catch {
     logger.warn("parsePokeWebSocketMessage: malformed JSON in WebSocket message", {
-      preview: data.slice(0, 200),
+      payloadLength: data.length,
     });
     return null;
   }

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -191,6 +191,20 @@ describe("WebSocketManager", () => {
     it("returns null for malformed JSON (parser logs the error at warn)", () => {
       assertEquals(parsePokeWebSocketMessage("{"), null);
     });
+
+    it("does not log malformed WebSocket payload content", () => {
+      const sentinel = "VF_MALFORMED_WS_PAYLOAD_MUST_NOT_REACH_LOGS_4b8e";
+      const warnCapture = captureConsoleMethod("warn");
+
+      try {
+        withJsonLogFormat(() => {
+          assertEquals(parsePokeWebSocketMessage(`{${sentinel}`), null);
+        });
+        assertEquals(warnCapture.getOutput().includes(sentinel), false);
+      } finally {
+        warnCapture.restore();
+      }
+    });
   });
   let originalWebSocket: typeof WebSocket;
   let originalSetTimeout: typeof setTimeout;
@@ -328,6 +342,36 @@ describe("WebSocketManager", () => {
     assertExists(metrics.connectionId);
 
     manager.dispose();
+  });
+
+  it("does not log raw WebSocket message payloads", () => {
+    const sentinel = "VF_WS_PAYLOAD_MUST_NOT_REACH_LOGS_38c1";
+    const originalDebug = console.debug;
+    const output: string[] = [];
+    console.debug = ((...args: unknown[]) => {
+      output.push(args.map((arg) => typeof arg === "string" ? arg : JSON.stringify(arg)).join(" "));
+    }) as typeof console.debug;
+
+    try {
+      withJsonLogFormat(() => {
+        const manager = createWebSocketManager();
+        manager.connect("project-1");
+        const socket = MockWebSocket.instances[0];
+        assertExists(socket);
+
+        socket.onmessage?.call(
+          socket as unknown as WebSocket,
+          new MessageEvent("message", {
+            data: JSON.stringify({ type: "noop", value: sentinel }),
+          }),
+        );
+        manager.dispose();
+      });
+
+      assertEquals(output.join("\n").includes(sentinel), false);
+    } finally {
+      console.debug = originalDebug;
+    }
   });
 
   it("should reset consecutive failures on open", () => {

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -344,13 +344,22 @@ describe("WebSocketManager", () => {
     manager.dispose();
   });
 
-  it("does not log raw WebSocket message payloads", () => {
+  it("does not log fields from valid WebSocket poke payloads", () => {
     const sentinel = "VF_WS_PAYLOAD_MUST_NOT_REACH_LOGS_38c1";
-    const originalDebug = console.debug;
+    const originalMethods = {
+      debug: console.debug,
+      log: console.log,
+      warn: console.warn,
+      error: console.error,
+    };
     const output: string[] = [];
-    console.debug = ((...args: unknown[]) => {
+    const capture = (...args: unknown[]) => {
       output.push(args.map((arg) => typeof arg === "string" ? arg : JSON.stringify(arg)).join(" "));
-    }) as typeof console.debug;
+    };
+    console.debug = capture;
+    console.log = capture;
+    console.warn = capture;
+    console.error = capture;
 
     try {
       withJsonLogFormat(() => {
@@ -362,7 +371,19 @@ describe("WebSocketManager", () => {
         socket.onmessage?.call(
           socket as unknown as WebSocket,
           new MessageEvent("message", {
-            data: JSON.stringify({ type: "noop", value: sentinel }),
+            data: JSON.stringify({
+              type: "poke",
+              data: {
+                changedPaths: [`pages/${sentinel}.tsx`],
+                entityId: sentinel,
+                entityType: sentinel,
+                action: sentinel,
+                branchId: sentinel,
+                branchName: "main",
+                releaseId: sentinel,
+                environmentName: sentinel,
+              },
+            }),
           }),
         );
         manager.dispose();
@@ -370,7 +391,10 @@ describe("WebSocketManager", () => {
 
       assertEquals(output.join("\n").includes(sentinel), false);
     } finally {
-      console.debug = originalDebug;
+      console.debug = originalMethods.debug;
+      console.log = originalMethods.log;
+      console.warn = originalMethods.warn;
+      console.error = originalMethods.error;
     }
   });
 

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -375,14 +375,10 @@ export class WebSocketManager {
 
       logger.debug("POKE RECEIVED - checking environment scope", {
         type: message.type,
-        pokeBranchId: normalizedBranchId,
-        pokeBranchName: normalizedBranchName,
+        hasBranchId: normalizedBranchId !== null,
+        hasBranchName: normalizedBranchName !== null,
         isProductionPoke,
         isProductionMode,
-        currentBranch,
-        entityId: payload.entityId,
-        entityType: payload.entityType,
-        action: payload.action,
         connectionId: this.wsConnectionId,
         totalPokesReceived: this.pokeMetrics.received,
         timeSinceLastPokeMs: timeSinceLastPoke,
@@ -395,8 +391,8 @@ export class WebSocketManager {
         logger.debug(
           "[WebSocketManager] POKE ACCEPTED - branch-scoped poke in production mode",
           {
-            pokeBranchId: normalizedBranchId,
-            pokeBranchName: normalizedBranchName,
+            hasBranchId: normalizedBranchId !== null,
+            hasBranchName: normalizedBranchName !== null,
             sourceType: contentContext?.sourceType,
           },
         );
@@ -406,10 +402,7 @@ export class WebSocketManager {
         if (normalizedBranchName && normalizedBranchName !== currentBranch) {
           logger.debug(
             "[WebSocketManager] POKE SKIPPED - different branch name in preview mode",
-            {
-              pokeBranchName: normalizedBranchName,
-              currentBranch,
-            },
+            { hasCurrentBranch: currentBranch !== null },
           );
           return;
         }
@@ -418,14 +411,14 @@ export class WebSocketManager {
           if (currentBranch === null) {
             logger.debug(
               "[WebSocketManager] POKE SKIPPED - branchId-only poke for main preview",
-              { pokeBranchId: normalizedBranchId },
+              { hasBranchId: true },
             );
             return;
           }
 
           logger.debug(
             "[WebSocketManager] POKE ACCEPTED - branchId-only fallback in preview mode",
-            { pokeBranchId: normalizedBranchId, currentBranch },
+            { hasBranchId: true, hasCurrentBranch: true },
           );
         }
 
@@ -439,7 +432,7 @@ export class WebSocketManager {
           // using a different default branch (e.g., "master", "develop").
           logger.debug(
             "[WebSocketManager] POKE SKIPPED - unscoped poke for named branch preview",
-            { currentBranch, defaultBranchName: this.deps.defaultBranchName ?? "main" },
+            { hasCurrentBranch: true },
           );
           return;
         }
@@ -472,13 +465,9 @@ export class WebSocketManager {
 
       logger.info("POKE ACCEPTED - triggering cache invalidation", {
         changedPathsCount: changedPaths?.length || 0,
-        changedPaths: changedPaths || [],
         projectSlug: this.deps.projectSlug,
-        branch: contentContext?.branch,
         isDeploymentPoke,
         isPublishPoke,
-        pokeReleaseId: normalizedPokeReleaseId,
-        pokeEnvironmentName: normalizedPokeEnvironment,
       });
 
       this.beginPreviewInvalidation(contentContext);
@@ -555,10 +544,8 @@ export class WebSocketManager {
 
     logger.info("PUBLISH POKE - clearing persistent cache", {
       projectSlug: this.deps.projectSlug,
-      releaseId,
-      environmentName,
-      deletionPrefixes: Array.from(deletionPrefixes),
-      pendingPrefixes: Array.from(pendingPrefixes),
+      deletionPrefixCount: deletionPrefixes.size,
+      pendingPrefixCount: pendingPrefixes.size,
       pendingInvalidations: getPendingInvalidationsCount(),
     });
 
@@ -573,15 +560,11 @@ export class WebSocketManager {
 
         logger.info("PUBLISH POKE - persistent cache cleared", {
           projectSlug: this.deps.projectSlug,
-          releaseId,
-          environmentName,
           totalDeleted,
         });
       } catch (error) {
         logger.error("PUBLISH POKE - failed to clear persistent cache (stale data may be served)", {
           projectSlug: this.deps.projectSlug,
-          releaseId,
-          environmentName,
           error: error instanceof Error ? error.message : String(error),
           stack: error instanceof Error ? error.stack : undefined,
         });
@@ -594,7 +577,7 @@ export class WebSocketManager {
             "PUBLISH POKE - keeping pending invalidations active due to deletion failure",
             {
               projectSlug: this.deps.projectSlug,
-              pendingPrefixes: Array.from(pendingPrefixes),
+              pendingPrefixCount: pendingPrefixes.size,
             },
           );
         }
@@ -651,7 +634,6 @@ export class WebSocketManager {
 
     try {
       logger.debug("Performing selective invalidation", {
-        changedPaths,
         count: changedPaths.length,
       });
 
@@ -685,8 +667,8 @@ export class WebSocketManager {
       await Promise.all(deletionPromises);
 
       logger.debug("Cache entries deleted for changed paths", {
-        changedPaths,
-        parentDirs: Array.from(parentDirs),
+        changedPathsCount: changedPaths.length,
+        parentDirsCount: parentDirs.size,
         prefixes: ["file:", "stat:", "dir:"],
       });
 
@@ -695,7 +677,7 @@ export class WebSocketManager {
         this.deps.invalidationCallbacks.invalidateModulePaths?.(changedPaths),
       ];
       logger.debug("Clearing SSR module cache for HMR", {
-        changedPaths,
+        changedPathsCount: changedPaths.length,
         projectId,
         usePerProject: !!this.deps.invalidationCallbacks.clearSSRModuleCacheForProject,
       });
@@ -764,7 +746,7 @@ export class WebSocketManager {
       logger.info(
         "[WebSocketManager] TRIGGERING HMR RELOAD via invalidationCallbacks.triggerReload",
         {
-          changedPaths,
+          changedPathsCount: changedPaths.length,
           projectSlug: this.deps.projectSlug,
           projectId: this.deps.client.getProjectId(),
           hasTriggerReloadCallback: !!this.deps.invalidationCallbacks.triggerReload,
@@ -781,7 +763,7 @@ export class WebSocketManager {
       this.deps.invalidationCallbacks.triggerReload?.(changedPaths, projectContext);
 
       logger.info("Selective invalidation complete - HMR triggered", {
-        changedPaths,
+        changedPathsCount: changedPaths.length,
         durationMs: Date.now() - startTime,
         totalInvalidations: this.pokeMetrics.invalidationsTriggered,
       });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -219,7 +219,10 @@ export class WebSocketManager {
 
       this.ws.onmessage = (event) => {
         this.wsLastPong = Date.now();
-        logger.debug("WebSocket message received:", { data: event.data });
+        logger.debug("WebSocket message received", {
+          payloadType: typeof event.data,
+          payloadLength: typeof event.data === "string" ? event.data.length : undefined,
+        });
         this.handlePokeMessage(event);
       };
 


### PR DESCRIPTION
## Summary

- remove source previews and weak content hashes from remote filesystem debug logs
- log only WebSocket payload type and length, including malformed JSON
- retain operational metadata such as paths, cache keys, lengths, and cache decisions

This is the second scoped fix for veryfront/veryfront-issue-inbox#105. It addresses source and payload disclosure in logs. The broader filesystem contract and documentation work remains tracked in the inbox issue.

## Red-green TDD

Red on the prior implementation:

- inline file-list source sentinel appeared in DEBUG output
- remote API source sentinel appeared in DEBUG output
- malformed WebSocket payload sentinel appeared in WARN output
- ordinary WebSocket payload sentinel appeared in DEBUG output

Green:

- 61 focused filesystem and WebSocket test steps passed
- `deno task verify:quick` passed
- `git diff --check` passed

## Preview

No visual component changes. To verify locally, set `LOG_LEVEL=DEBUG` and `LOG_FORMAT=json`, read a remote project file, and deliver a WebSocket event. Logs retain payload length and filesystem metadata without source or raw payload content.

Refs veryfront/veryfront-issue-inbox#105