### PR TITLE
docs(fs): document runtime trust boundary

### DIFF
--- a/docs/api-reference/veryfront/fs.md
+++ b/docs/api-reference/veryfront/fs.md
@@ -21,11 +21,12 @@ supplied through request-owned environment data rather than `.env` files.
 Isolated Pages route `ctx.fs` is a separate, read-only, project-confined
 capability. Those protections do not change the contract of `veryfront/fs`.
 
-Use `validatePath` from `veryfront/security` with a trusted `baseDir` before
-reading a user-influenced path. Physical validation follows symlinks when
-the adapter you pass exposes physical path semantics.
+Canonicalize a trusted root and candidate with `realPath`, then use
+`validateLexicalPath` from `veryfront/security` before reading a
+user-influenced path. Canonicalization follows existing symlinks before the
+containment check.
 
-`validatePath` is a path-admission check, not an operating-system sandbox.
+Path admission is not an operating-system sandbox.
 The trusted root must not be writable by untrusted or project code while a
 validated path is in use. Otherwise, concurrent filesystem changes can
 create a time-of-check/time-of-use race between validation and reading.
@@ -68,24 +69,22 @@ const configPath = resolve(cwd(), "veryfront.config.ts");
 ### Confine an untrusted path
 
 ```ts
-import { cwd, resolve } from "veryfront/fs";
-import { runtime } from "veryfront/platform";
-import { validatePath } from "veryfront/security";
+import { cwd, readTextFile, realPath, resolve } from "veryfront/fs";
+import { validateLexicalPath } from "veryfront/security";
 
-const publicFilesDir = resolve(cwd(), "public-data");
-const adapter = await runtime.get();
+const publicFilesDir = await realPath(resolve(cwd(), "public-data"));
 
 export async function readPublicFile(requestedPath: string): Promise<string> {
-  const admitted = await validatePath(requestedPath, {
-    adapter,
+  const candidate = resolve(publicFilesDir, requestedPath);
+  const canonicalPath = await realPath(candidate);
+  const admitted = validateLexicalPath(canonicalPath, {
     baseDir: publicFilesDir,
-    allowAbsolute: false,
-    level: "strict",
+    allowAbsolute: true,
   });
   if (!admitted.valid || !admitted.canonicalPath) {
     throw new Error("Invalid path");
   }
-  return await adapter.fs.readFile(admitted.canonicalPath);
+  return await readTextFile(admitted.canonicalPath);
 }
 ```
 

--- a/docs/api-reference/veryfront/fs.md
+++ b/docs/api-reference/veryfront/fs.md
@@ -1,8 +1,24 @@
 ---
 title: "veryfront/fs"
-description: "Public filesystem, path, and cwd utilities."
+description: "Runtime-native filesystem, path, and cwd utilities."
 order: 11
 ---
+
+## Runtime boundary
+
+`veryfront/fs` delegates to the active runtime filesystem. It does not add a
+project-root sandbox, block `.env` or other secret-file names, or validate
+paths from untrusted input. Relative paths resolve from `cwd()`. Absolute
+paths and `..` segments can reach any location that the runtime permits.
+
+Runtime permissions remain the outer boundary. Hosted project secrets are
+supplied through request-owned environment data rather than `.env` files.
+Isolated Pages route `ctx.fs` is a separate, read-only, project-confined
+capability. Those protections do not change the contract of `veryfront/fs`.
+
+Use `validatePath` from `veryfront/security` with a trusted `baseDir` before
+reading a user-influenced path. Physical validation follows symlinks when
+the active filesystem exposes physical path semantics.
 
 ## Import
 
@@ -37,6 +53,27 @@ const dir = dirname(filePath); // "src/pages"
 import { cwd, resolve } from "veryfront/fs";
 
 const configPath = resolve(cwd(), "veryfront.config.ts");
+```
+
+### Confine an untrusted path
+
+```ts
+import { cwd, readTextFile, resolve } from "veryfront/fs";
+import { validatePath } from "veryfront/security";
+
+const publicFilesDir = resolve(cwd(), "public-data");
+
+export async function readPublicFile(requestedPath: string): Promise<string> {
+  const admitted = await validatePath(requestedPath, {
+    baseDir: publicFilesDir,
+    allowAbsolute: false,
+    level: "strict",
+  });
+  if (!admitted.valid || !admitted.canonicalPath) {
+    throw new Error("Invalid path");
+  }
+  return await readTextFile(admitted.canonicalPath);
+}
 ```
 
 ## Exports

--- a/docs/api-reference/veryfront/fs.md
+++ b/docs/api-reference/veryfront/fs.md
@@ -6,7 +6,7 @@ order: 11
 
 ## Runtime boundary
 
-`veryfront/fs` uses the native process filesystem selected for Deno or Node.
+`veryfront/fs` uses the native process filesystem selected for Deno, Node, or Bun.
 It does not delegate to the `runtime.get().fs` adapter. Custom adapters
 configured with `runtime.set()` affect adapter-consuming APIs, not these
 compatibility functions.

--- a/docs/api-reference/veryfront/fs.md
+++ b/docs/api-reference/veryfront/fs.md
@@ -6,10 +6,15 @@ order: 11
 
 ## Runtime boundary
 
-`veryfront/fs` delegates to the active runtime filesystem. It does not add a
-project-root sandbox, block `.env` or other secret-file names, or validate
-paths from untrusted input. Relative paths resolve from `cwd()`. Absolute
-paths and `..` segments can reach any location that the runtime permits.
+`veryfront/fs` uses the native process filesystem selected for Deno or Node.
+It does not delegate to the `runtime.get().fs` adapter. Custom adapters
+configured with `runtime.set()` affect adapter-consuming APIs, not these
+compatibility functions.
+
+`veryfront/fs` does not add a project-root sandbox, block `.env` or other
+secret-file names, or validate paths from untrusted input. Relative paths
+resolve from `cwd()`. Absolute paths and `..` segments can reach any location
+that the runtime permits.
 
 Runtime permissions remain the outer boundary. Hosted project secrets are
 supplied through request-owned environment data rather than `.env` files.
@@ -18,7 +23,7 @@ capability. Those protections do not change the contract of `veryfront/fs`.
 
 Use `validatePath` from `veryfront/security` with a trusted `baseDir` before
 reading a user-influenced path. Physical validation follows symlinks when
-the active filesystem exposes physical path semantics.
+the adapter you pass exposes physical path semantics.
 
 ## Import
 

--- a/docs/api-reference/veryfront/fs.md
+++ b/docs/api-reference/veryfront/fs.md
@@ -58,7 +58,7 @@ const configPath = resolve(cwd(), "veryfront.config.ts");
 ### Confine an untrusted path
 
 ```ts
-import { cwd, readTextFile, resolve } from "veryfront/fs";
+import { cwd, resolve } from "veryfront/fs";
 import { runtime } from "veryfront/platform";
 import { validatePath } from "veryfront/security";
 
@@ -75,7 +75,7 @@ export async function readPublicFile(requestedPath: string): Promise<string> {
   if (!admitted.valid || !admitted.canonicalPath) {
     throw new Error("Invalid path");
   }
-  return await readTextFile(admitted.canonicalPath);
+  return await adapter.fs.readFile(admitted.canonicalPath);
 }
 ```
 

--- a/docs/api-reference/veryfront/fs.md
+++ b/docs/api-reference/veryfront/fs.md
@@ -59,12 +59,15 @@ const configPath = resolve(cwd(), "veryfront.config.ts");
 
 ```ts
 import { cwd, readTextFile, resolve } from "veryfront/fs";
+import { runtime } from "veryfront/platform";
 import { validatePath } from "veryfront/security";
 
 const publicFilesDir = resolve(cwd(), "public-data");
+const adapter = await runtime.get();
 
 export async function readPublicFile(requestedPath: string): Promise<string> {
   const admitted = await validatePath(requestedPath, {
+    adapter,
     baseDir: publicFilesDir,
     allowAbsolute: false,
     level: "strict",

--- a/docs/api-reference/veryfront/fs.md
+++ b/docs/api-reference/veryfront/fs.md
@@ -25,6 +25,11 @@ Use `validatePath` from `veryfront/security` with a trusted `baseDir` before
 reading a user-influenced path. Physical validation follows symlinks when
 the adapter you pass exposes physical path semantics.
 
+`validatePath` is a path-admission check, not an operating-system sandbox.
+The trusted root must not be writable by untrusted or project code while a
+validated path is in use. Otherwise, concurrent filesystem changes can
+create a time-of-check/time-of-use race between validation and reading.
+
 ## Import
 
 ```ts

--- a/scripts/docs/barrel-jsdoc.ts
+++ b/scripts/docs/barrel-jsdoc.ts
@@ -1,0 +1,124 @@
+export interface BarrelJSDoc {
+  description: string;
+  moduleName: string;
+  remarks: string;
+  examples: Array<{ title: string; code: string }>;
+}
+
+const EMPTY_BARREL_JSDOC: BarrelJSDoc = {
+  description: "",
+  moduleName: "",
+  remarks: "",
+  examples: [],
+};
+
+export function parseBarrelJSDoc(content: string): BarrelJSDoc {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith("/**")) {
+    return EMPTY_BARREL_JSDOC;
+  }
+
+  const endIdx = trimmed.indexOf("*/");
+  if (endIdx === -1) {
+    return EMPTY_BARREL_JSDOC;
+  }
+
+  const block = trimmed.slice(3, endIdx);
+  const lines = block.split("\n").map((line) => line.replace(/^\s*\*\s?/, ""));
+
+  let moduleName = "";
+  const descLines: string[] = [];
+  const remarkLines: string[] = [];
+  const examples: Array<{ title: string; code: string }> = [];
+  let inExample = false;
+  let inRemarks = false;
+  let exampleTitle = "";
+  let exampleLines: string[] = [];
+  let inCodeBlock = false;
+
+  const finishExample = (): void => {
+    if (exampleLines.length > 0) {
+      examples.push({ title: exampleTitle, code: exampleLines.join("\n") });
+    }
+    exampleTitle = "";
+    exampleLines = [];
+  };
+
+  for (const line of lines) {
+    if (!inCodeBlock && line.startsWith("@module")) {
+      moduleName = line.replace("@module", "").trim();
+      inRemarks = false;
+      continue;
+    }
+
+    if (!inCodeBlock && line.startsWith("@remarks")) {
+      finishExample();
+      inExample = false;
+      inRemarks = true;
+      const inlineRemarks = line.replace("@remarks", "").trim();
+      if (inlineRemarks) remarkLines.push(inlineRemarks);
+      continue;
+    }
+
+    if (!inCodeBlock && line.startsWith("@example")) {
+      finishExample();
+      exampleTitle = line.replace("@example", "").trim();
+      exampleLines = [];
+      inExample = true;
+      inRemarks = false;
+      inCodeBlock = false;
+      continue;
+    }
+
+    if (!inCodeBlock && line.startsWith("@")) {
+      finishExample();
+      inExample = false;
+      inRemarks = false;
+      continue;
+    }
+
+    if (inExample) {
+      if (line.startsWith("```")) {
+        inCodeBlock = !inCodeBlock;
+      }
+      exampleLines.push(line);
+    } else if (inRemarks) {
+      remarkLines.push(line);
+    } else if (!moduleName || descLines.length > 0 || line.trim()) {
+      if (!line.startsWith("@")) {
+        descLines.push(line);
+      }
+    }
+  }
+
+  finishExample();
+
+  const description = normalizePublicDocText(
+    descLines.join(" ").replace(/\s+/g, " ").trim(),
+  );
+  const remarks = remarkLines.join("\n").trim();
+  return { description, moduleName, remarks, examples };
+}
+
+export function normalizePublicDocText(text: string): string {
+  const withoutInlineJsDocLinks = text.replace(
+    /\{@(?:link|linkcode|linkplain)\s+([^}]+)\}/g,
+    (_match, rawTarget: string) => {
+      const target = rawTarget.trim();
+      const pipeIndex = target.indexOf("|");
+      const display = pipeIndex >= 0
+        ? target.slice(pipeIndex + 1).trim()
+        : target.match(/^\S+\s+(.+)$/)?.[1]?.trim() || target;
+      return `\`${display.replace(/`/g, "\\`")}\``;
+    },
+  );
+
+  return withoutInlineJsDocLinks
+    .replace(/`[^`]*`|[<>]/g, (token) => {
+      if (token.startsWith("`")) return token;
+      return token === "<" ? "&lt;" : "&gt;";
+    })
+    .replace(/[\u2013\u2014]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/scripts/docs/barrel-jsdoc.ts
+++ b/scripts/docs/barrel-jsdoc.ts
@@ -109,7 +109,15 @@ export function normalizePublicDocText(text: string): string {
       const display = pipeIndex >= 0
         ? target.slice(pipeIndex + 1).trim()
         : target.match(/^\S+\s+(.+)$/)?.[1]?.trim() || target;
-      return `\`${display.replace(/`/g, "\\`")}\``;
+      const longestBacktickRun = Math.max(
+        0,
+        ...(display.match(/`+/g) ?? []).map((run) => run.length),
+      );
+      const delimiter = "`".repeat(longestBacktickRun + 1);
+      const needsPadding = display.startsWith("`") || display.endsWith("`");
+      return `${delimiter}${
+        needsPadding ? ` ${display} ` : display
+      }${delimiter}`;
     },
   );
 

--- a/scripts/docs/barrel-jsdoc.ts
+++ b/scripts/docs/barrel-jsdoc.ts
@@ -45,7 +45,25 @@ export function parseBarrelJSDoc(content: string): BarrelJSDoc {
     codeFence = null;
   };
 
+  const updateCodeFence = (line: string): void => {
+    const fenceMatch = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/);
+    if (!fenceMatch) return;
+    const fence = fenceMatch[2];
+    const marker = fence[0] as "`" | "~";
+    if (codeFence === null) {
+      codeFence = { marker, length: fence.length };
+    } else if (
+      marker === codeFence.marker &&
+      fence.length >= codeFence.length &&
+      fenceMatch[3].trim() === ""
+    ) {
+      codeFence = null;
+    }
+  };
+
   for (const line of lines) {
+    if (inExample || inRemarks) updateCodeFence(line);
+
     if (codeFence === null && line.startsWith("@module")) {
       moduleName = line.replace("@module", "").trim();
       inRemarks = false;
@@ -79,20 +97,6 @@ export function parseBarrelJSDoc(content: string): BarrelJSDoc {
     }
 
     if (inExample) {
-      const fenceMatch = line.trimStart().match(/^(`{3,}|~{3,})(.*)$/);
-      if (fenceMatch) {
-        const fence = fenceMatch[1];
-        const marker = fence[0] as "`" | "~";
-        if (codeFence === null) {
-          codeFence = { marker, length: fence.length };
-        } else if (
-          marker === codeFence.marker &&
-          fence.length >= codeFence.length &&
-          fenceMatch[2].trim() === ""
-        ) {
-          codeFence = null;
-        }
-      }
       exampleLines.push(line);
     } else if (inRemarks) {
       remarkLines.push(line);

--- a/scripts/docs/barrel-jsdoc.ts
+++ b/scripts/docs/barrel-jsdoc.ts
@@ -34,7 +34,7 @@ export function parseBarrelJSDoc(content: string): BarrelJSDoc {
   let inRemarks = false;
   let exampleTitle = "";
   let exampleLines: string[] = [];
-  let inCodeBlock = false;
+  let codeFence: { marker: "`" | "~"; length: number } | null = null;
 
   const finishExample = (): void => {
     if (exampleLines.length > 0) {
@@ -42,16 +42,17 @@ export function parseBarrelJSDoc(content: string): BarrelJSDoc {
     }
     exampleTitle = "";
     exampleLines = [];
+    codeFence = null;
   };
 
   for (const line of lines) {
-    if (!inCodeBlock && line.startsWith("@module")) {
+    if (codeFence === null && line.startsWith("@module")) {
       moduleName = line.replace("@module", "").trim();
       inRemarks = false;
       continue;
     }
 
-    if (!inCodeBlock && line.startsWith("@remarks")) {
+    if (codeFence === null && line.startsWith("@remarks")) {
       finishExample();
       inExample = false;
       inRemarks = true;
@@ -60,17 +61,17 @@ export function parseBarrelJSDoc(content: string): BarrelJSDoc {
       continue;
     }
 
-    if (!inCodeBlock && line.startsWith("@example")) {
+    if (codeFence === null && line.startsWith("@example")) {
       finishExample();
       exampleTitle = line.replace("@example", "").trim();
       exampleLines = [];
       inExample = true;
       inRemarks = false;
-      inCodeBlock = false;
+      codeFence = null;
       continue;
     }
 
-    if (!inCodeBlock && line.startsWith("@")) {
+    if (codeFence === null && line.startsWith("@")) {
       finishExample();
       inExample = false;
       inRemarks = false;
@@ -78,8 +79,19 @@ export function parseBarrelJSDoc(content: string): BarrelJSDoc {
     }
 
     if (inExample) {
-      if (line.startsWith("```")) {
-        inCodeBlock = !inCodeBlock;
+      const fenceMatch = line.trimStart().match(/^(`{3,}|~{3,})(.*)$/);
+      if (fenceMatch) {
+        const fence = fenceMatch[1];
+        const marker = fence[0] as "`" | "~";
+        if (codeFence === null) {
+          codeFence = { marker, length: fence.length };
+        } else if (
+          marker === codeFence.marker &&
+          fence.length >= codeFence.length &&
+          fenceMatch[2].trim() === ""
+        ) {
+          codeFence = null;
+        }
       }
       exampleLines.push(line);
     } else if (inRemarks) {
@@ -122,7 +134,7 @@ export function normalizePublicDocText(text: string): string {
   );
 
   return withoutInlineJsDocLinks
-    .replace(/`[^`]*`|[<>]/g, (token) => {
+    .replace(/(`+)[\s\S]*?\1|[<>]/g, (token) => {
       if (token.startsWith("`")) return token;
       return token === "<" ? "&lt;" : "&gt;";
     })

--- a/scripts/docs/generate-api-reference.test.ts
+++ b/scripts/docs/generate-api-reference.test.ts
@@ -106,12 +106,31 @@ describe("generate-api-reference", () => {
     assertEquals(parsed.remarks, "The example remains intact.");
   });
 
+  it("preserves JSDoc tags inside tilde-fenced examples", () => {
+    const parsed = parseBarrelJSDoc(`/**
+ * @module example
+ * @example Decorated class
+ * ~~~ts
+ * @sealed
+ * class Example {}
+ * ~~~
+ * @remarks
+ * The example remains intact.
+ */`);
+
+    assertEquals(parsed.examples, [{
+      title: "Decorated class",
+      code: "~~~ts\n@sealed\nclass Example {}\n~~~",
+    }]);
+    assertEquals(parsed.remarks, "The example remains intact.");
+  });
+
   it("uses a safe Markdown code span for linked labels containing backticks", () => {
     const parsed = parseBarrelJSDoc(
-      "/**\n * Uses {@link Example|C:\\path`name}.\n */",
+      "/**\n * Uses {@link Example|C:\\path<T>`name}.\n */",
     );
 
-    assertEquals(parsed.description, "Uses ``C:\\path`name``.");
+    assertEquals(parsed.description, "Uses ``C:\\path<T>`name``.");
   });
 
   it("removes check output when generation fails", async () => {
@@ -218,9 +237,17 @@ describe("generate-api-reference", () => {
         "generated client reference must not expose internal import specifiers",
       );
       assertStringIncludes(fsReference, "## Runtime boundary");
+      assertStringIncludes(
+        fsReference,
+        "uses the native process filesystem selected for Deno or Node",
+      );
+      assertStringIncludes(
+        fsReference,
+        "does not delegate to the `runtime.get().fs` adapter",
+      );
       assertMatch(
         fsReference,
-        /does not add a\s+project-root sandbox, block `\.env` or other secret-file names/,
+        /does not add a\s+project-root sandbox, block `\.env` or other\s+secret-file names/,
       );
       assertMatch(
         fsReference,

--- a/scripts/docs/generate-api-reference.test.ts
+++ b/scripts/docs/generate-api-reference.test.ts
@@ -106,6 +106,14 @@ describe("generate-api-reference", () => {
     assertEquals(parsed.remarks, "The example remains intact.");
   });
 
+  it("uses a safe Markdown code span for linked labels containing backticks", () => {
+    const parsed = parseBarrelJSDoc(
+      "/**\n * Uses {@link Example|C:\\path`name}.\n */",
+    );
+
+    assertEquals(parsed.description, "Uses ``C:\\path`name``.");
+  });
+
   it("removes check output when generation fails", async () => {
     const sandboxRoot = await Deno.makeTempDir();
     const emptyRoot = `${sandboxRoot}/cwd`;

--- a/scripts/docs/generate-api-reference.test.ts
+++ b/scripts/docs/generate-api-reference.test.ts
@@ -125,6 +125,48 @@ describe("generate-api-reference", () => {
     assertEquals(parsed.remarks, "The example remains intact.");
   });
 
+  it("preserves JSDoc tags inside fenced remarks", () => {
+    const parsed = parseBarrelJSDoc(`/**
+ * @module example
+ * @remarks
+ * The literal tag stays in this example:
+ * ~~~md
+ * @example This is Markdown content
+ * ~~~
+ * @example Actual example
+ * ~~~ts
+ * export const value = true;
+ * ~~~
+ * @returns Nothing.
+ */`);
+
+    assertEquals(
+      parsed.remarks,
+      "The literal tag stays in this example:\n~~~md\n@example This is Markdown content\n~~~",
+    );
+    assertEquals(parsed.examples, [{
+      title: "Actual example",
+      code: "~~~ts\nexport const value = true;\n~~~",
+    }]);
+  });
+
+  it("does not close a fence on a delimiter indented by four spaces", () => {
+    const parsed = parseBarrelJSDoc(`/**
+ * @module example
+ * @example Nested Markdown
+ * ~~~md
+ *     ~~~
+ * @literal
+ * ~~~
+ * @returns Nothing.
+ */`);
+
+    assertEquals(parsed.examples, [{
+      title: "Nested Markdown",
+      code: "~~~md\n    ~~~\n@literal\n~~~",
+    }]);
+  });
+
   it("uses a safe Markdown code span for linked labels containing backticks", () => {
     const parsed = parseBarrelJSDoc(
       "/**\n * Uses {@link Example|C:\\path<T>`name}.\n */",

--- a/scripts/docs/generate-api-reference.test.ts
+++ b/scripts/docs/generate-api-reference.test.ts
@@ -228,6 +228,11 @@ describe("generate-api-reference", () => {
         /validatePath\(requestedPath, \{[\s\S]*?adapter,[\s\S]*?baseDir: publicFilesDir/,
         "the confinement example must pass the active adapter to validatePath",
       );
+      assertStringIncludes(
+        fsReference,
+        "return await adapter.fs.readFile(admitted.canonicalPath);",
+        "the confinement example must read through the adapter that validated the path",
+      );
       assertEquals(
         fsReference.indexOf("## Runtime boundary") <
           fsReference.indexOf("## Import"),

--- a/scripts/docs/generate-api-reference.test.ts
+++ b/scripts/docs/generate-api-reference.test.ts
@@ -160,6 +160,9 @@ describe("generate-api-reference", () => {
       const chatReference = await Deno.readTextFile(
         `${outputDir}/veryfront/chat.md`,
       );
+      const fsReference = await Deno.readTextFile(
+        `${outputDir}/veryfront/fs.md`,
+      );
       const agentReference = await Deno.readTextFile(
         `${outputDir}/veryfront/agent.md`,
       );
@@ -182,13 +185,22 @@ describe("generate-api-reference", () => {
         false,
         "generated client reference must not expose internal import specifiers",
       );
+      assertStringIncludes(fsReference, "## Runtime boundary");
+      assertMatch(
+        fsReference,
+        /does not add a\s+project-root sandbox, block `\.env` or other secret-file names/,
+      );
+      assertMatch(
+        fsReference,
+        /Isolated Pages route `ctx\.fs` is a separate, read-only, project-confined\s+capability/,
+      );
       assertMatch(
         uiReference,
         /^\|\s*`AppShellProps`\s*\|\s*Props accepted by `AppShell`\.\s*\|/m,
       );
       assertMatch(
         uiReference,
-        /import type \{\s*DisclosureParts,\s*DisclosureProps,\s*MultipleToggleGroupRootProps,?\s*\} from "veryfront\/ui\/adapter";/m,
+        /import type \{\s*[A-Za-z][A-Za-z0-9]*(?:,\s*[A-Za-z][A-Za-z0-9]*){0,2},?\s*\} from "veryfront\/ui\/adapter";/m,
         "type-only deep exports must use a copyable type import",
       );
       for (

--- a/scripts/docs/generate-api-reference.test.ts
+++ b/scripts/docs/generate-api-reference.test.ts
@@ -297,18 +297,30 @@ describe("generate-api-reference", () => {
       );
       assertStringIncludes(
         fsReference,
-        'import { runtime } from "veryfront/platform";',
-      );
-      assertStringIncludes(fsReference, "const adapter = await runtime.get();");
-      assertMatch(
-        fsReference,
-        /validatePath\(requestedPath, \{[\s\S]*?adapter,[\s\S]*?baseDir: publicFilesDir/,
-        "the confinement example must pass the active adapter to validatePath",
+        'import { cwd, readTextFile, realPath, resolve } from "veryfront/fs";',
       );
       assertStringIncludes(
         fsReference,
-        "return await adapter.fs.readFile(admitted.canonicalPath);",
-        "the confinement example must read through the adapter that validated the path",
+        'import { validateLexicalPath } from "veryfront/security";',
+      );
+      assertEquals(
+        fsReference.includes('from "veryfront/platform"'),
+        false,
+        "the copyable example must use only published package exports",
+      );
+      assertStringIncludes(
+        fsReference,
+        'const publicFilesDir = await realPath(resolve(cwd(), "public-data"));',
+      );
+      assertMatch(
+        fsReference,
+        /const candidate = resolve\(publicFilesDir, requestedPath\);[\s\S]*?const canonicalPath = await realPath\(candidate\);[\s\S]*?validateLexicalPath\(canonicalPath, \{[\s\S]*?baseDir: publicFilesDir/,
+        "the confinement example must validate the physically resolved path",
+      );
+      assertStringIncludes(
+        fsReference,
+        "return await readTextFile(admitted.canonicalPath);",
+        "the confinement example must read the admitted canonical path",
       );
       assertEquals(
         fsReference.indexOf("## Runtime boundary") <

--- a/scripts/docs/generate-api-reference.test.ts
+++ b/scripts/docs/generate-api-reference.test.ts
@@ -5,6 +5,7 @@ import {
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#std/testing/bdd";
 import { compile } from "npm:@mdx-js/mdx@3.1.1";
+import { parseBarrelJSDoc } from "./barrel-jsdoc.ts";
 
 const CHECK_TEMP_PREFIX = "veryfront-api-reference-check-";
 
@@ -82,6 +83,29 @@ async function assertGeneratedReferenceIsFormatted(
 }
 
 describe("generate-api-reference", () => {
+  it("preserves JSDoc tags inside fenced examples", () => {
+    const parsed = parseBarrelJSDoc(`/**
+ * Example module.
+ *
+ * @module example
+ *
+ * @example Decorated class
+ * \`\`\`ts
+ * @sealed
+ * class Example {}
+ * \`\`\`
+ *
+ * @remarks
+ * The example remains intact.
+ */`);
+
+    assertEquals(parsed.examples, [{
+      title: "Decorated class",
+      code: "```ts\n@sealed\nclass Example {}\n```\n",
+    }]);
+    assertEquals(parsed.remarks, "The example remains intact.");
+  });
+
   it("removes check output when generation fails", async () => {
     const sandboxRoot = await Deno.makeTempDir();
     const emptyRoot = `${sandboxRoot}/cwd`;
@@ -193,6 +217,22 @@ describe("generate-api-reference", () => {
       assertMatch(
         fsReference,
         /Isolated Pages route `ctx\.fs` is a separate, read-only, project-confined\s+capability/,
+      );
+      assertStringIncludes(
+        fsReference,
+        'import { runtime } from "veryfront/platform";',
+      );
+      assertStringIncludes(fsReference, "const adapter = await runtime.get();");
+      assertMatch(
+        fsReference,
+        /validatePath\(requestedPath, \{[\s\S]*?adapter,[\s\S]*?baseDir: publicFilesDir/,
+        "the confinement example must pass the active adapter to validatePath",
+      );
+      assertEquals(
+        fsReference.indexOf("## Runtime boundary") <
+          fsReference.indexOf("## Import"),
+        true,
+        "runtime boundary guidance must precede imports",
       );
       assertMatch(
         uiReference,

--- a/scripts/docs/generate-api-reference.test.ts
+++ b/scripts/docs/generate-api-reference.test.ts
@@ -281,7 +281,7 @@ describe("generate-api-reference", () => {
       assertStringIncludes(fsReference, "## Runtime boundary");
       assertStringIncludes(
         fsReference,
-        "uses the native process filesystem selected for Deno or Node",
+        "uses the native process filesystem selected for Deno, Node, or Bun",
       );
       assertStringIncludes(
         fsReference,

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -15,6 +15,11 @@ import { parseArgs } from "#std/flags";
 import { ensureDir } from "#std/fs/ensure-dir";
 import { COMMANDS } from "../../cli/help/command-definitions.ts";
 import type { CommandCategory, CommandHelp } from "../../cli/help/types.ts";
+import {
+  type BarrelJSDoc,
+  normalizePublicDocText,
+  parseBarrelJSDoc,
+} from "./barrel-jsdoc.ts";
 
 const ROOT = Deno.cwd();
 
@@ -75,13 +80,6 @@ interface DeepImport {
 interface ModuleGroup {
   parent: ExportEntry;
   deepImports: DeepImport[];
-}
-
-interface BarrelJSDoc {
-  description: string;
-  moduleName: string;
-  remarks: string;
-  examples: Array<{ title: string; code: string }>;
 }
 
 interface TsType {
@@ -240,13 +238,6 @@ interface SourceDocStats {
   documented: number;
   missing: number;
 }
-
-const EMPTY_BARREL_JSDOC: BarrelJSDoc = {
-  description: "",
-  moduleName: "",
-  remarks: "",
-  examples: [],
-};
 
 // ---------------------------------------------------------------------------
 // Curated import snippets: show the most representative imports per module
@@ -924,131 +915,6 @@ function getModuleGroups(): ModuleGroup[] {
     .map((slug) => groups.get(slug)!)
     .filter(Boolean)
     .sort((a, b) => a.parent.importPath.localeCompare(b.parent.importPath));
-}
-
-// ---------------------------------------------------------------------------
-// 2. Parse barrel JSDoc
-// ---------------------------------------------------------------------------
-
-function parseBarrelJSDoc(content: string): BarrelJSDoc {
-  const trimmed = content.trimStart();
-  if (!trimmed.startsWith("/**")) {
-    return EMPTY_BARREL_JSDOC;
-  }
-
-  const endIdx = trimmed.indexOf("*/");
-  if (endIdx === -1) {
-    return EMPTY_BARREL_JSDOC;
-  }
-
-  const block = trimmed.slice(3, endIdx);
-  const lines = block.split("\n").map((l) => l.replace(/^\s*\*\s?/, ""));
-
-  let moduleName = "";
-  const descLines: string[] = [];
-  const remarkLines: string[] = [];
-  const examples: Array<{ title: string; code: string }> = [];
-  let inExample = false;
-  let inRemarks = false;
-  let exampleTitle = "";
-  let exampleLines: string[] = [];
-  let inCodeBlock = false;
-
-  const finishExample = (): void => {
-    finalizeExample(examples, exampleTitle, exampleLines);
-    exampleTitle = "";
-    exampleLines = [];
-  };
-
-  for (const line of lines) {
-    if (line.startsWith("@module")) {
-      moduleName = line.replace("@module", "").trim();
-      inRemarks = false;
-      continue;
-    }
-
-    if (line.startsWith("@remarks")) {
-      finishExample();
-      inExample = false;
-      inRemarks = true;
-      const inlineRemarks = line.replace("@remarks", "").trim();
-      if (inlineRemarks) remarkLines.push(inlineRemarks);
-      continue;
-    }
-
-    if (line.startsWith("@example")) {
-      finishExample();
-      exampleTitle = line.replace("@example", "").trim();
-      exampleLines = [];
-      inExample = true;
-      inRemarks = false;
-      inCodeBlock = false;
-      continue;
-    }
-
-    if (line.startsWith("@")) {
-      finishExample();
-      inExample = false;
-      inRemarks = false;
-      continue;
-    }
-
-    if (inExample) {
-      if (line.startsWith("```")) {
-        inCodeBlock = !inCodeBlock;
-      }
-      exampleLines.push(line);
-    } else if (inRemarks) {
-      remarkLines.push(line);
-    } else if (!moduleName || descLines.length > 0 || line.trim()) {
-      if (!line.startsWith("@")) {
-        descLines.push(line);
-      }
-    }
-  }
-
-  finishExample();
-
-  const description = normalizePublicDocText(
-    descLines.join(" ").replace(/\s+/g, " ").trim(),
-  );
-  const remarks = remarkLines.join("\n").trim();
-  return { description, moduleName, remarks, examples };
-}
-
-function normalizePublicDocText(text: string): string {
-  const withoutInlineJsDocLinks = text.replace(
-    /\{@(?:link|linkcode|linkplain)\s+([^}]+)\}/g,
-    (_match, rawTarget: string) => {
-      const target = rawTarget.trim();
-      const pipeIndex = target.indexOf("|");
-      const display = pipeIndex >= 0
-        ? target.slice(pipeIndex + 1).trim()
-        : target.match(/^\S+\s+(.+)$/)?.[1]?.trim() || target;
-      return `\`${display.replace(/`/g, "\\`")}\``;
-    },
-  );
-
-  return withoutInlineJsDocLinks
-    .replace(/`[^`]*`|[<>]/g, (token) => {
-      if (token.startsWith("`")) return token;
-      return token === "<" ? "&lt;" : "&gt;";
-    })
-    .replace(/[\u2013\u2014]/g, "-")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function finalizeExample(
-  examples: Array<{ title: string; code: string }>,
-  title: string,
-  lines: string[],
-): void {
-  if (lines.length === 0) {
-    return;
-  }
-
-  examples.push({ title, code: lines.join("\n") });
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -80,6 +80,7 @@ interface ModuleGroup {
 interface BarrelJSDoc {
   description: string;
   moduleName: string;
+  remarks: string;
   examples: Array<{ title: string; code: string }>;
 }
 
@@ -243,6 +244,7 @@ interface SourceDocStats {
 const EMPTY_BARREL_JSDOC: BarrelJSDoc = {
   description: "",
   moduleName: "",
+  remarks: "",
   examples: [],
 };
 
@@ -944,8 +946,10 @@ function parseBarrelJSDoc(content: string): BarrelJSDoc {
 
   let moduleName = "";
   const descLines: string[] = [];
+  const remarkLines: string[] = [];
   const examples: Array<{ title: string; code: string }> = [];
   let inExample = false;
+  let inRemarks = false;
   let exampleTitle = "";
   let exampleLines: string[] = [];
   let inCodeBlock = false;
@@ -959,6 +963,16 @@ function parseBarrelJSDoc(content: string): BarrelJSDoc {
   for (const line of lines) {
     if (line.startsWith("@module")) {
       moduleName = line.replace("@module", "").trim();
+      inRemarks = false;
+      continue;
+    }
+
+    if (line.startsWith("@remarks")) {
+      finishExample();
+      inExample = false;
+      inRemarks = true;
+      const inlineRemarks = line.replace("@remarks", "").trim();
+      if (inlineRemarks) remarkLines.push(inlineRemarks);
       continue;
     }
 
@@ -967,6 +981,7 @@ function parseBarrelJSDoc(content: string): BarrelJSDoc {
       exampleTitle = line.replace("@example", "").trim();
       exampleLines = [];
       inExample = true;
+      inRemarks = false;
       inCodeBlock = false;
       continue;
     }
@@ -974,6 +989,7 @@ function parseBarrelJSDoc(content: string): BarrelJSDoc {
     if (line.startsWith("@")) {
       finishExample();
       inExample = false;
+      inRemarks = false;
       continue;
     }
 
@@ -982,6 +998,8 @@ function parseBarrelJSDoc(content: string): BarrelJSDoc {
         inCodeBlock = !inCodeBlock;
       }
       exampleLines.push(line);
+    } else if (inRemarks) {
+      remarkLines.push(line);
     } else if (!moduleName || descLines.length > 0 || line.trim()) {
       if (!line.startsWith("@")) {
         descLines.push(line);
@@ -994,7 +1012,8 @@ function parseBarrelJSDoc(content: string): BarrelJSDoc {
   const description = normalizePublicDocText(
     descLines.join(" ").replace(/\s+/g, " ").trim(),
   );
-  return { description, moduleName, examples };
+  const remarks = remarkLines.join("\n").trim();
+  return { description, moduleName, remarks, examples };
 }
 
 function normalizePublicDocText(text: string): string {
@@ -2505,6 +2524,11 @@ function generateMD(
     lines.push("");
   }
 
+  if (jsdoc.remarks) {
+    lines.push(jsdoc.remarks);
+    lines.push("");
+  }
+
   // Import snippet: use curated priority list
   const priorityNames = IMPORT_PRIORITY[entry.importPath];
   const allExportNames = new Set([
@@ -2622,6 +2646,10 @@ function generateMD(
       lines.push("");
       if (di.jsdoc.description) {
         lines.push(di.jsdoc.description);
+        lines.push("");
+      }
+      if (di.jsdoc.remarks) {
+        lines.push(di.jsdoc.remarks);
         lines.push("");
       }
       lines.push("```ts");
@@ -2798,6 +2826,7 @@ async function main() {
       jsdoc = {
         description: entry.syntheticDescription ?? "",
         moduleName: entry.importPath,
+        remarks: "",
         examples: [],
       };
     } else {
@@ -2807,7 +2836,7 @@ async function main() {
         jsdoc = parseBarrelJSDoc(content);
       } catch (err) {
         console.warn(`  Could not read ${entry.filePath}: ${err}`);
-        jsdoc = { description: "", moduleName: "", examples: [] };
+        jsdoc = { description: "", moduleName: "", remarks: "", examples: [] };
       }
       nodes = await getDenoDoc(entry.filePath);
       addSourceDocStats(sourceDocStats, summarizeSourceDocs(nodes));
@@ -2824,7 +2853,12 @@ async function main() {
         const content = await Deno.readTextFile(absFilePath);
         deepJsdoc = parseBarrelJSDoc(content);
       } catch {
-        deepJsdoc = { description: "", moduleName: "", examples: [] };
+        deepJsdoc = {
+          description: "",
+          moduleName: "",
+          remarks: "",
+          examples: [],
+        };
       }
       const deepNodes = await getDenoDoc(deep.filePath);
       addSourceDocStats(sourceDocStats, summarizeSourceDocs(deepNodes));

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -46,7 +46,7 @@
  *
  * @example Confine an untrusted path
  * ```ts
- * import { cwd, readTextFile, resolve } from "veryfront/fs";
+ * import { cwd, resolve } from "veryfront/fs";
  * import { runtime } from "veryfront/platform";
  * import { validatePath } from "veryfront/security";
  *
@@ -63,7 +63,7 @@
  *   if (!admitted.valid || !admitted.canonicalPath) {
  *     throw new Error("Invalid path");
  *   }
- *   return await readTextFile(admitted.canonicalPath);
+ *   return await adapter.fs.readFile(admitted.canonicalPath);
  * }
  * ```
  */

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -1,7 +1,24 @@
 /**
- * Public filesystem, path, and cwd utilities.
+ * Runtime-native filesystem, path, and cwd utilities.
  *
  * @module fs
+ *
+ * @remarks
+ * ## Runtime boundary
+ *
+ * `veryfront/fs` delegates to the active runtime filesystem. It does not add a
+ * project-root sandbox, block `.env` or other secret-file names, or validate
+ * paths from untrusted input. Relative paths resolve from `cwd()`. Absolute
+ * paths and `..` segments can reach any location that the runtime permits.
+ *
+ * Runtime permissions remain the outer boundary. Hosted project secrets are
+ * supplied through request-owned environment data rather than `.env` files.
+ * Isolated Pages route `ctx.fs` is a separate, read-only, project-confined
+ * capability. Those protections do not change the contract of `veryfront/fs`.
+ *
+ * Use `validatePath` from `veryfront/security` with a trusted `baseDir` before
+ * reading a user-influenced path. Physical validation follows symlinks when
+ * the active filesystem exposes physical path semantics.
  *
  * @example File operations
  * ```ts
@@ -25,6 +42,26 @@
  * import { cwd, resolve } from "veryfront/fs";
  *
  * const configPath = resolve(cwd(), "veryfront.config.ts");
+ * ```
+ *
+ * @example Confine an untrusted path
+ * ```ts
+ * import { cwd, readTextFile, resolve } from "veryfront/fs";
+ * import { validatePath } from "veryfront/security";
+ *
+ * const publicFilesDir = resolve(cwd(), "public-data");
+ *
+ * export async function readPublicFile(requestedPath: string): Promise<string> {
+ *   const admitted = await validatePath(requestedPath, {
+ *     baseDir: publicFilesDir,
+ *     allowAbsolute: false,
+ *     level: "strict",
+ *   });
+ *   if (!admitted.valid || !admitted.canonicalPath) {
+ *     throw new Error("Invalid path");
+ *   }
+ *   return await readTextFile(admitted.canonicalPath);
+ * }
  * ```
  */
 

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -25,6 +25,11 @@
  * reading a user-influenced path. Physical validation follows symlinks when
  * the adapter you pass exposes physical path semantics.
  *
+ * `validatePath` is a path-admission check, not an operating-system sandbox.
+ * The trusted root must not be writable by untrusted or project code while a
+ * validated path is in use. Otherwise, concurrent filesystem changes can
+ * create a time-of-check/time-of-use race between validation and reading.
+ *
  * @example File operations
  * ```ts
  * import { exists, mkdir, readTextFile, writeTextFile } from "veryfront/fs";

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -6,10 +6,15 @@
  * @remarks
  * ## Runtime boundary
  *
- * `veryfront/fs` delegates to the active runtime filesystem. It does not add a
- * project-root sandbox, block `.env` or other secret-file names, or validate
- * paths from untrusted input. Relative paths resolve from `cwd()`. Absolute
- * paths and `..` segments can reach any location that the runtime permits.
+ * `veryfront/fs` uses the native process filesystem selected for Deno or Node.
+ * It does not delegate to the `runtime.get().fs` adapter. Custom adapters
+ * configured with `runtime.set()` affect adapter-consuming APIs, not these
+ * compatibility functions.
+ *
+ * `veryfront/fs` does not add a project-root sandbox, block `.env` or other
+ * secret-file names, or validate paths from untrusted input. Relative paths
+ * resolve from `cwd()`. Absolute paths and `..` segments can reach any location
+ * that the runtime permits.
  *
  * Runtime permissions remain the outer boundary. Hosted project secrets are
  * supplied through request-owned environment data rather than `.env` files.
@@ -18,7 +23,7 @@
  *
  * Use `validatePath` from `veryfront/security` with a trusted `baseDir` before
  * reading a user-influenced path. Physical validation follows symlinks when
- * the active filesystem exposes physical path semantics.
+ * the adapter you pass exposes physical path semantics.
  *
  * @example File operations
  * ```ts

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -47,12 +47,15 @@
  * @example Confine an untrusted path
  * ```ts
  * import { cwd, readTextFile, resolve } from "veryfront/fs";
+ * import { runtime } from "veryfront/platform";
  * import { validatePath } from "veryfront/security";
  *
  * const publicFilesDir = resolve(cwd(), "public-data");
+ * const adapter = await runtime.get();
  *
  * export async function readPublicFile(requestedPath: string): Promise<string> {
  *   const admitted = await validatePath(requestedPath, {
+ *     adapter,
  *     baseDir: publicFilesDir,
  *     allowAbsolute: false,
  *     level: "strict",

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -6,7 +6,7 @@
  * @remarks
  * ## Runtime boundary
  *
- * `veryfront/fs` uses the native process filesystem selected for Deno or Node.
+ * `veryfront/fs` uses the native process filesystem selected for Deno, Node, or Bun.
  * It does not delegate to the `runtime.get().fs` adapter. Custom adapters
  * configured with `runtime.set()` affect adapter-consuming APIs, not these
  * compatibility functions.

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -21,11 +21,12 @@
  * Isolated Pages route `ctx.fs` is a separate, read-only, project-confined
  * capability. Those protections do not change the contract of `veryfront/fs`.
  *
- * Use `validatePath` from `veryfront/security` with a trusted `baseDir` before
- * reading a user-influenced path. Physical validation follows symlinks when
- * the adapter you pass exposes physical path semantics.
+ * Canonicalize a trusted root and candidate with `realPath`, then use
+ * `validateLexicalPath` from `veryfront/security` before reading a
+ * user-influenced path. Canonicalization follows existing symlinks before the
+ * containment check.
  *
- * `validatePath` is a path-admission check, not an operating-system sandbox.
+ * Path admission is not an operating-system sandbox.
  * The trusted root must not be writable by untrusted or project code while a
  * validated path is in use. Otherwise, concurrent filesystem changes can
  * create a time-of-check/time-of-use race between validation and reading.
@@ -56,24 +57,22 @@
  *
  * @example Confine an untrusted path
  * ```ts
- * import { cwd, resolve } from "veryfront/fs";
- * import { runtime } from "veryfront/platform";
- * import { validatePath } from "veryfront/security";
+ * import { cwd, readTextFile, realPath, resolve } from "veryfront/fs";
+ * import { validateLexicalPath } from "veryfront/security";
  *
- * const publicFilesDir = resolve(cwd(), "public-data");
- * const adapter = await runtime.get();
+ * const publicFilesDir = await realPath(resolve(cwd(), "public-data"));
  *
  * export async function readPublicFile(requestedPath: string): Promise<string> {
- *   const admitted = await validatePath(requestedPath, {
- *     adapter,
+ *   const candidate = resolve(publicFilesDir, requestedPath);
+ *   const canonicalPath = await realPath(candidate);
+ *   const admitted = validateLexicalPath(canonicalPath, {
  *     baseDir: publicFilesDir,
- *     allowAbsolute: false,
- *     level: "strict",
+ *     allowAbsolute: true,
  *   });
  *   if (!admitted.valid || !admitted.canonicalPath) {
  *     throw new Error("Invalid path");
  *   }
- *   return await adapter.fs.readFile(admitted.canonicalPath);
+ *   return await readTextFile(admitted.canonicalPath);
  * }
  * ```
  */


### PR DESCRIPTION
## Summary

- document that `veryfront/fs` delegates to runtime-native filesystem permissions and does not add a project-root sandbox or secret-file denylist
- distinguish hosted request-owned environment secrets and isolated Pages `ctx.fs` from the public `veryfront/fs` contract
- provide a copyable `validatePath` example for user-influenced paths
- add generated API-reference support for module `@remarks`

This is the Reference-documentation follow-up for veryfront/veryfront-issue-inbox#105. The worker symlink permission boundary remains tracked separately in that issue.

## Red-green verification

Red:
- the API-reference generator regression failed because the runtime-boundary section was absent

Green:
- API-reference generator test: 2 steps passed
- `deno task docs:api-reference:check`: passed, 44 files current
- `deno task docs:validate`: passed, including 1,383 links
- `deno task verify:quick`: passed
- `git diff --check`: passed

## Preview

No UI component changed. Preview the generated page at `docs/api-reference/veryfront/fs.md`; the new **Runtime boundary** section appears before imports and examples.

Refs veryfront/veryfront-issue-inbox#105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded filesystem guidance covering path resolution, runtime permissions, project boundaries, and secret-file behavior.
  * Added examples for safely validating untrusted paths before reading files.
  * Clarified filesystem access differences across runtime environments.

* **Improvements**
  * API reference generation now preserves module and deep-import remarks.
  * Improved formatting for examples, links, code spans, and remarks.
  * Strengthened documentation checks for filesystem guidance and import declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->