### PR TITLE
fix(security): reject worker read-scope symlink escapes

### DIFF
--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -1738,59 +1738,40 @@ testSuite("ProjectWorker - real worker request isolation", () => {
     }
   });
 
-  it("revalidates scoped read roots before executing project code", async () => {
+  it("revalidates changed read roots when a replacement source generation starts", async () => {
     const projectDir = await Deno.makeTempDir();
     const outsideDir = await Deno.makeTempDir();
     const outsidePath = join(outsideDir, "secret.txt");
     const linkedPath = join(projectDir, "linked-secret.txt");
-    const modulePath = join(projectDir, "route.mjs");
     await Deno.writeTextFile(outsidePath, "outside secret");
-    await Deno.writeTextFile(
-      modulePath,
-      `
-        export async function GET() {
-          const leaked = await Deno.readTextFile(${JSON.stringify(linkedPath)});
-          return Response.json({ leaked });
-        }
-      `,
-    );
-    const module = await prepareModulePath(modulePath);
 
-    const worker = new ProjectWorker({
-      projectId: "test-post-start-symlink-denied",
+    const currentGeneration = new ProjectWorker({
+      projectId: "test-current-symlink-generation",
+      permissions: buildWorkerPermissions([projectDir]),
+      requestTimeoutMs: 10_000,
+      allowInternalEgress: false,
+    });
+    const replacementGeneration = new ProjectWorker({
+      projectId: "test-replacement-symlink-generation",
       permissions: buildWorkerPermissions([projectDir]),
       requestTimeoutMs: 10_000,
       allowInternalEgress: false,
     });
 
-    worker.start();
+    currentGeneration.start();
     try {
-      await assertWorkerReady(worker);
+      await assertWorkerReady(currentGeneration);
+      currentGeneration.terminate();
       await Deno.symlink(outsidePath, linkedPath);
 
-      await assertRejects(
-        () =>
-          worker.execute({
-            type: "execute-app-route",
-            id: "post-start-symlink",
-            module,
-            modulePath,
-            method: "GET",
-            request: {
-              url: "http://localhost/api/read",
-              method: "GET",
-              headers: [],
-              body: null,
-            },
-            params: {},
-            projectDir,
-            sourceIntegrationPolicy: TEST_SOURCE_INTEGRATION_POLICY,
-          }),
+      assertThrows(
+        () => replacementGeneration.start(),
         VeryfrontError,
         "Worker read scope contains a symlink outside its allowed roots",
       );
     } finally {
-      worker.terminate();
+      currentGeneration.terminate();
+      replacementGeneration.terminate();
       await Deno.remove(projectDir, { recursive: true });
       await Deno.remove(outsideDir, { recursive: true });
     }
@@ -2404,31 +2385,40 @@ testSuite("ProjectWorker - executeStream", () => {
     assert(threw, "should throw when worker is not available");
   });
 
-  it("revalidates scoped read roots before streaming execution", async () => {
+  it("revalidates changed stream roots when a replacement source generation starts", async () => {
     const projectDir = await Deno.makeTempDir();
     const outsideDir = await Deno.makeTempDir();
     const outsidePath = join(outsideDir, "secret.txt");
     await Deno.writeTextFile(outsidePath, "outside secret");
 
-    const worker = new ProjectWorker({
-      projectId: "test-post-start-stream-symlink-denied",
+    const currentGeneration = new ProjectWorker({
+      projectId: "test-current-stream-symlink-generation",
+      permissions: { ...buildWorkerPermissions([projectDir]), net: false },
+      requestTimeoutMs: 5_000,
+      allowInternalEgress: false,
+      workerScriptUrl: TEST_WORKER_SCRIPT_URL,
+    });
+    const replacementGeneration = new ProjectWorker({
+      projectId: "test-replacement-stream-symlink-generation",
       permissions: { ...buildWorkerPermissions([projectDir]), net: false },
       requestTimeoutMs: 5_000,
       allowInternalEgress: false,
       workerScriptUrl: TEST_WORKER_SCRIPT_URL,
     });
 
-    worker.start();
+    currentGeneration.start();
     try {
+      currentGeneration.terminate();
       await Deno.symlink(outsidePath, join(projectDir, "linked-secret.txt"));
 
       assertThrows(
-        () => worker.executeStream(makeScriptedSSRRequest("post-start-stream-symlink")),
+        () => replacementGeneration.start(),
         VeryfrontError,
         "Worker read scope contains a symlink outside its allowed roots",
       );
     } finally {
-      worker.terminate();
+      currentGeneration.terminate();
+      replacementGeneration.terminate();
       await Deno.remove(projectDir, { recursive: true });
       await Deno.remove(outsideDir, { recursive: true });
     }

--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -22,7 +22,7 @@ import type { WorkerEgressBroker } from "./worker-egress-guard.ts";
 import { computeHash } from "#veryfront/utils";
 import { SERVICE_OVERLOADED, VeryfrontError } from "#veryfront/errors";
 import { validateDataResult } from "#veryfront/data/helpers.ts";
-import { fromFileUrl, toFileUrl } from "#veryfront/compat/path";
+import { fromFileUrl, join, toFileUrl } from "#veryfront/compat/path";
 
 const testSuite = isDeno ? describe : describe.skip;
 const TEST_SOURCE_INTEGRATION_POLICY = { schemaVersion: 1, mode: "unrestricted" } as const;
@@ -1702,6 +1702,34 @@ testSuite("ProjectWorker - real worker request isolation", () => {
       assert(
         response.error.message.includes("Requires read access"),
         `expected permission denial, got: ${response.error.message}`,
+      );
+    } finally {
+      worker.terminate();
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(outsideDir, { recursive: true });
+    }
+  });
+
+  it("rejects a scoped read root containing a symlink to an outside file", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const outsideDir = await Deno.makeTempDir();
+    const outsidePath = join(outsideDir, "secret.txt");
+    const linkedPath = join(projectDir, "linked-secret.txt");
+    await Deno.writeTextFile(outsidePath, "outside secret");
+    await Deno.symlink(outsidePath, linkedPath);
+
+    const worker = new ProjectWorker({
+      projectId: "test-preexisting-symlink-denied",
+      permissions: buildWorkerPermissions([projectDir]),
+      requestTimeoutMs: 10_000,
+      allowInternalEgress: false,
+    });
+
+    try {
+      assertThrows(
+        () => worker.start(),
+        VeryfrontError,
+        "Worker read scope contains a symlink outside its allowed roots",
       );
     } finally {
       worker.terminate();

--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -1738,6 +1738,64 @@ testSuite("ProjectWorker - real worker request isolation", () => {
     }
   });
 
+  it("revalidates scoped read roots before executing project code", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const outsideDir = await Deno.makeTempDir();
+    const outsidePath = join(outsideDir, "secret.txt");
+    const linkedPath = join(projectDir, "linked-secret.txt");
+    const modulePath = join(projectDir, "route.mjs");
+    await Deno.writeTextFile(outsidePath, "outside secret");
+    await Deno.writeTextFile(
+      modulePath,
+      `
+        export async function GET() {
+          const leaked = await Deno.readTextFile(${JSON.stringify(linkedPath)});
+          return Response.json({ leaked });
+        }
+      `,
+    );
+    const module = await prepareModulePath(modulePath);
+
+    const worker = new ProjectWorker({
+      projectId: "test-post-start-symlink-denied",
+      permissions: buildWorkerPermissions([projectDir]),
+      requestTimeoutMs: 10_000,
+      allowInternalEgress: false,
+    });
+
+    worker.start();
+    try {
+      await assertWorkerReady(worker);
+      await Deno.symlink(outsidePath, linkedPath);
+
+      await assertRejects(
+        () =>
+          worker.execute({
+            type: "execute-app-route",
+            id: "post-start-symlink",
+            module,
+            modulePath,
+            method: "GET",
+            request: {
+              url: "http://localhost/api/read",
+              method: "GET",
+              headers: [],
+              body: null,
+            },
+            params: {},
+            projectDir,
+            sourceIntegrationPolicy: TEST_SOURCE_INTEGRATION_POLICY,
+          }),
+        VeryfrontError,
+        "Worker read scope contains a symlink outside its allowed roots",
+      );
+    } finally {
+      worker.terminate();
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(outsideDir, { recursive: true });
+    }
+  });
+
   it("blocks project fetches to loopback network targets", async () => {
     const projectDir = await Deno.makeTempDir();
     const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });
@@ -2344,6 +2402,36 @@ testSuite("ProjectWorker - executeStream", () => {
       threw = true;
     }
     assert(threw, "should throw when worker is not available");
+  });
+
+  it("revalidates scoped read roots before streaming execution", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const outsideDir = await Deno.makeTempDir();
+    const outsidePath = join(outsideDir, "secret.txt");
+    await Deno.writeTextFile(outsidePath, "outside secret");
+
+    const worker = new ProjectWorker({
+      projectId: "test-post-start-stream-symlink-denied",
+      permissions: { ...buildWorkerPermissions([projectDir]), net: false },
+      requestTimeoutMs: 5_000,
+      allowInternalEgress: false,
+      workerScriptUrl: TEST_WORKER_SCRIPT_URL,
+    });
+
+    worker.start();
+    try {
+      await Deno.symlink(outsidePath, join(projectDir, "linked-secret.txt"));
+
+      assertThrows(
+        () => worker.executeStream(makeScriptedSSRRequest("post-start-stream-symlink")),
+        VeryfrontError,
+        "Worker read scope contains a symlink outside its allowed roots",
+      );
+    } finally {
+      worker.terminate();
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(outsideDir, { recursive: true });
+    }
   });
 
   it("returns a ReadableStream when worker is started", async () => {

--- a/src/security/sandbox/project-worker.ts
+++ b/src/security/sandbox/project-worker.ts
@@ -655,6 +655,7 @@ export class ProjectWorker {
             UNKNOWN_ERROR.create({ detail: `Worker not available (status: ${this._status})` }),
           );
         }
+        assertWorkerReadScopeConfined(this.permissions.read);
         if (this.pending.has(requestId)) {
           return Promise.reject(UNKNOWN_ERROR.create({ detail: "Duplicate worker request id" }));
         }
@@ -725,6 +726,7 @@ export class ProjectWorker {
     if (!this.worker || this._status === "crashed" || this._status === "terminated") {
       throw UNKNOWN_ERROR.create({ detail: `Worker not available (status: ${this._status})` });
     }
+    assertWorkerReadScopeConfined(this.permissions.read);
 
     if (this.pending.has(requestId) || this.streamHandlers.has(requestId)) {
       throw UNKNOWN_ERROR.create({ detail: "Duplicate worker request id" });

--- a/src/security/sandbox/project-worker.ts
+++ b/src/security/sandbox/project-worker.ts
@@ -24,6 +24,7 @@ import {
   type WorkerEgressBroker,
 } from "./worker-egress-guard.ts";
 import type { WorkerPermissions } from "./worker-permissions.ts";
+import { assertWorkerReadScopeConfined } from "./worker-read-scope.ts";
 import { deserializeWorkerError } from "./worker-error-boundary.ts";
 import type {
   SerializedError,
@@ -543,6 +544,8 @@ export class ProjectWorker {
         message: "Custom project worker scripts cannot use unrestricted network permissions",
       });
     }
+
+    assertWorkerReadScopeConfined(this.permissions.read);
 
     const allowInternalEgress = this.allowInternalEgress;
     let workerPermissions: Readonly<ScopedWorkerPermissions> = this.permissions;

--- a/src/security/sandbox/project-worker.ts
+++ b/src/security/sandbox/project-worker.ts
@@ -24,7 +24,7 @@ import {
   type WorkerEgressBroker,
 } from "./worker-egress-guard.ts";
 import type { WorkerPermissions } from "./worker-permissions.ts";
-import { assertWorkerReadScopeConfined } from "./worker-read-scope.ts";
+import { createWorkerReadScopeGenerationAudit } from "./worker-read-scope.ts";
 import { deserializeWorkerError } from "./worker-error-boundary.ts";
 import type {
   SerializedError,
@@ -477,6 +477,7 @@ export class ProjectWorker {
   private suppressIdleNotifications = false;
   private requestTimeoutMs: number;
   private readonly permissions: Readonly<WorkerPermissions>;
+  private readonly assertReadScopeGenerationConfined: () => void;
   private workerScriptUrl?: string;
   private readonly isolatedSsrRendererModuleUrl?: string;
   private egressResolveHost?: ResolveWorkerHost;
@@ -490,6 +491,9 @@ export class ProjectWorker {
   constructor(options: ProjectWorkerOptions) {
     this.projectId = options.projectId;
     this.permissions = snapshotWorkerPermissions(options.permissions);
+    this.assertReadScopeGenerationConfined = createWorkerReadScopeGenerationAudit(
+      this.permissions.read,
+    );
     this.requestTimeoutMs = requireRequestTimeoutMs(options.requestTimeoutMs);
     this.workerScriptUrl = options.workerScriptUrl;
     this.isolatedSsrRendererModuleUrl = options.isolatedSsrRendererModuleUrl === undefined
@@ -545,7 +549,7 @@ export class ProjectWorker {
       });
     }
 
-    assertWorkerReadScopeConfined(this.permissions.read);
+    this.assertReadScopeGenerationConfined();
 
     const allowInternalEgress = this.allowInternalEgress;
     let workerPermissions: Readonly<ScopedWorkerPermissions> = this.permissions;
@@ -655,7 +659,7 @@ export class ProjectWorker {
             UNKNOWN_ERROR.create({ detail: `Worker not available (status: ${this._status})` }),
           );
         }
-        assertWorkerReadScopeConfined(this.permissions.read);
+        this.assertReadScopeGenerationConfined();
         if (this.pending.has(requestId)) {
           return Promise.reject(UNKNOWN_ERROR.create({ detail: "Duplicate worker request id" }));
         }
@@ -726,7 +730,7 @@ export class ProjectWorker {
     if (!this.worker || this._status === "crashed" || this._status === "terminated") {
       throw UNKNOWN_ERROR.create({ detail: `Worker not available (status: ${this._status})` });
     }
-    assertWorkerReadScopeConfined(this.permissions.read);
+    this.assertReadScopeGenerationConfined();
 
     if (this.pending.has(requestId) || this.streamHandlers.has(requestId)) {
       throw UNKNOWN_ERROR.create({ detail: "Duplicate worker request id" });

--- a/src/security/sandbox/worker-read-scope.test.ts
+++ b/src/security/sandbox/worker-read-scope.test.ts
@@ -21,6 +21,38 @@ describe("worker read scope", () => {
     }
   });
 
+  it("rejects a directory symlink that can escape through parent traversal", async () => {
+    const sandbox = await Deno.makeTempDir();
+    const root = join(sandbox, "project");
+    const nested = join(root, "nested");
+    await Deno.mkdir(nested, { recursive: true });
+    await Deno.writeTextFile(join(sandbox, "secret.txt"), "outside secret");
+    await Deno.symlink(root, join(nested, "project-root"), { type: "dir" });
+
+    try {
+      assertThrows(
+        () => assertWorkerReadScopeConfined([root]),
+        VeryfrontError,
+        "Worker read scope contains a symlink outside its allowed roots",
+      );
+    } finally {
+      await Deno.remove(sandbox, { recursive: true });
+    }
+  });
+
+  it("allows a directory symlink whose parent traversal stays in scope", async () => {
+    const root = await Deno.makeTempDir();
+    const target = join(root, "packages", "shared");
+    await Deno.mkdir(target, { recursive: true });
+    await Deno.symlink(target, join(root, "shared"), { type: "dir" });
+
+    try {
+      assertWorkerReadScopeConfined([root]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
   it("rejects dangling symlinks", async () => {
     const root = await Deno.makeTempDir();
     await Deno.symlink(join(root, "missing.txt"), join(root, "dangling.txt"));

--- a/src/security/sandbox/worker-read-scope.test.ts
+++ b/src/security/sandbox/worker-read-scope.test.ts
@@ -50,6 +50,25 @@ describe("worker read scope", () => {
     }
   });
 
+  it("rejects a read root that is itself a symlink", async () => {
+    const sandbox = await Deno.makeTempDir();
+    const targetRoot = join(sandbox, "target", "project");
+    const linkedRoot = join(sandbox, "linked-project");
+    await Deno.mkdir(targetRoot, { recursive: true });
+    await Deno.writeTextFile(join(sandbox, "target", "secret.txt"), "outside secret");
+    await Deno.symlink(targetRoot, linkedRoot, { type: "dir" });
+
+    try {
+      assertThrows(
+        () => assertWorkerReadScopeConfined([linkedRoot]),
+        VeryfrontError,
+        "Worker read scope contains a symlink outside its allowed roots",
+      );
+    } finally {
+      await Deno.remove(sandbox, { recursive: true });
+    }
+  });
+
   it("rejects a directory symlink that can escape through parent traversal", async () => {
     const sandbox = await Deno.makeTempDir();
     const root = join(sandbox, "project");

--- a/src/security/sandbox/worker-read-scope.test.ts
+++ b/src/security/sandbox/worker-read-scope.test.ts
@@ -1,0 +1,46 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path";
+import { VeryfrontError } from "#veryfront/errors";
+import { assertWorkerReadScopeConfined } from "./worker-read-scope.ts";
+
+describe("worker read scope", () => {
+  it("allows a symlink whose target is inside another allowed root", async () => {
+    const firstRoot = await Deno.makeTempDir();
+    const secondRoot = await Deno.makeTempDir();
+    const target = join(secondRoot, "shared.txt");
+    await Deno.writeTextFile(target, "shared");
+    await Deno.symlink(target, join(firstRoot, "shared.txt"));
+
+    try {
+      assertWorkerReadScopeConfined([firstRoot, secondRoot]);
+    } finally {
+      await Deno.remove(firstRoot, { recursive: true });
+      await Deno.remove(secondRoot, { recursive: true });
+    }
+  });
+
+  it("rejects dangling symlinks", async () => {
+    const root = await Deno.makeTempDir();
+    await Deno.symlink(join(root, "missing.txt"), join(root, "dangling.txt"));
+
+    try {
+      assertThrows(
+        () => assertWorkerReadScopeConfined([root]),
+        VeryfrontError,
+        "Worker read scope contains a symlink outside its allowed roots",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("ignores an optional read root that does not exist at startup", () => {
+    const missingRoot = join(
+      Deno.cwd(),
+      `.veryfront-missing-worker-root-${crypto.randomUUID()}`,
+    );
+    assertWorkerReadScopeConfined([missingRoot]);
+  });
+});

--- a/src/security/sandbox/worker-read-scope.test.ts
+++ b/src/security/sandbox/worker-read-scope.test.ts
@@ -3,9 +3,38 @@ import { assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import { VeryfrontError } from "#veryfront/errors";
-import { assertWorkerReadScopeConfined } from "./worker-read-scope.ts";
+import {
+  assertWorkerReadScopeConfined,
+  createWorkerReadScopeGenerationAudit,
+} from "./worker-read-scope.ts";
 
 describe("worker read scope", () => {
+  it("audits each immutable source generation once", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const outsideDir = await Deno.makeTempDir();
+    const outsidePath = join(outsideDir, "secret.txt");
+    const linkedPath = join(projectDir, "linked-secret.txt");
+    await Deno.writeTextFile(outsidePath, "outside secret");
+
+    try {
+      const currentGeneration = createWorkerReadScopeGenerationAudit([projectDir]);
+      currentGeneration();
+      await Deno.symlink(outsidePath, linkedPath);
+
+      currentGeneration();
+
+      const replacementGeneration = createWorkerReadScopeGenerationAudit([projectDir]);
+      assertThrows(
+        replacementGeneration,
+        VeryfrontError,
+        "Worker read scope contains a symlink outside its allowed roots",
+      );
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(outsideDir, { recursive: true });
+    }
+  });
+
   it("allows a symlink whose target is inside another allowed root", async () => {
     const firstRoot = await Deno.makeTempDir();
     const secondRoot = await Deno.makeTempDir();

--- a/src/security/sandbox/worker-read-scope.ts
+++ b/src/security/sandbox/worker-read-scope.ts
@@ -56,9 +56,8 @@ function assertSymlinkConfined(
  *
  * Deno authorizes reads using the symlink location rather than its resolved
  * target. Project workers cannot create new symlinks because write access is
- * denied, but the host can change a source tree. Call this before startup and
- * again at every execution boundary so a pooled worker cannot use a link added
- * between requests.
+ * denied. Use {@link createWorkerReadScopeGenerationAudit} for pooled workers
+ * so this full-tree scan runs once per immutable source generation.
  */
 export function assertWorkerReadScopeConfined(
   readScope: readonly string[] | boolean,
@@ -111,4 +110,25 @@ export function assertWorkerReadScopeConfined(
       rejectUnconfinedReadScope();
     }
   }
+}
+
+/**
+ * Create a successful-once read-scope audit for one immutable worker source
+ * generation.
+ *
+ * Host source changes must rotate the worker generation identity or evict its
+ * pool scope. The replacement worker receives a new audit and scans the new
+ * tree before startup. Reusing this closure across mutable source generations
+ * would violate that host-owned lifecycle contract.
+ */
+export function createWorkerReadScopeGenerationAudit(
+  readScope: readonly string[] | boolean,
+): () => void {
+  const generationReadScope = Array.isArray(readScope) ? [...readScope] : readScope;
+  let complete = false;
+  return () => {
+    if (complete) return;
+    assertWorkerReadScopeConfined(generationReadScope);
+    complete = true;
+  };
 }

--- a/src/security/sandbox/worker-read-scope.ts
+++ b/src/security/sandbox/worker-read-scope.ts
@@ -1,0 +1,86 @@
+import { join } from "#veryfront/compat/path";
+import { SECURITY_VIOLATION } from "#veryfront/errors";
+import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
+import { isWithinDirectory } from "#veryfront/security/path-validation.ts";
+
+function rejectUnconfinedReadScope(): never {
+  throw SECURITY_VIOLATION.create({
+    detail: "Worker read scope contains a symlink outside its allowed roots",
+  });
+}
+
+/**
+ * Reject scoped worker roots that contain a pre-existing symlink escape.
+ *
+ * Deno authorizes reads using the symlink location rather than its resolved
+ * target. Project workers cannot create new symlinks because write access is
+ * denied, so auditing the host-owned tree before startup closes that gap.
+ */
+export function assertWorkerReadScopeConfined(
+  readScope: readonly string[] | boolean,
+): void {
+  if (!Array.isArray(readScope) || readScope.length === 0) return;
+
+  const physicalRoots: string[] = [];
+  for (const root of readScope) {
+    try {
+      physicalRoots.push(Deno.realPathSync(root));
+    } catch (error) {
+      // A missing optional support path grants nothing at startup. Project
+      // workers cannot create it because their write permission is denied.
+      if (isNotFoundError(error)) continue;
+      rejectUnconfinedReadScope();
+    }
+  }
+
+  const pending = [...new Set(physicalRoots)];
+  const visitedDirectories = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) continue;
+
+    let metadata: Deno.FileInfo;
+    try {
+      metadata = Deno.lstatSync(current);
+    } catch {
+      rejectUnconfinedReadScope();
+    }
+    if (metadata.isSymlink) {
+      let target: string;
+      try {
+        target = Deno.realPathSync(current);
+      } catch {
+        rejectUnconfinedReadScope();
+      }
+      if (!physicalRoots.some((root) => isWithinDirectory(root, target))) {
+        rejectUnconfinedReadScope();
+      }
+      continue;
+    }
+    if (!metadata.isDirectory) continue;
+
+    if (visitedDirectories.has(current)) continue;
+    visitedDirectories.add(current);
+
+    try {
+      for (const entry of Deno.readDirSync(current)) {
+        const entryPath = join(current, entry.name);
+        if (entry.isSymlink) {
+          let target: string;
+          try {
+            target = Deno.realPathSync(entryPath);
+          } catch {
+            rejectUnconfinedReadScope();
+          }
+          if (!physicalRoots.some((root) => isWithinDirectory(root, target))) {
+            rejectUnconfinedReadScope();
+          }
+        } else if (entry.isDirectory) {
+          pending.push(entryPath);
+        }
+      }
+    } catch {
+      rejectUnconfinedReadScope();
+    }
+  }
+}

--- a/src/security/sandbox/worker-read-scope.ts
+++ b/src/security/sandbox/worker-read-scope.ts
@@ -67,6 +67,9 @@ export function assertWorkerReadScopeConfined(
   const physicalRoots: string[] = [];
   for (const root of readScope) {
     try {
+      if (Deno.lstatSync(root).isSymlink) {
+        rejectUnconfinedReadScope();
+      }
       physicalRoots.push(Deno.realPathSync(root));
     } catch (error) {
       // A missing optional support path grants nothing at startup. Project

--- a/src/security/sandbox/worker-read-scope.ts
+++ b/src/security/sandbox/worker-read-scope.ts
@@ -1,4 +1,4 @@
-import { join } from "#veryfront/compat/path";
+import { dirname, join, relative } from "#veryfront/compat/path";
 import { SECURITY_VIOLATION } from "#veryfront/errors";
 import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import { isWithinDirectory } from "#veryfront/security/path-validation.ts";
@@ -7,6 +7,48 @@ function rejectUnconfinedReadScope(): never {
   throw SECURITY_VIOLATION.create({
     detail: "Worker read scope contains a symlink outside its allowed roots",
   });
+}
+
+function directorySymlinkCanEscape(
+  linkPath: string,
+  targetPath: string,
+  physicalRoots: readonly string[],
+): boolean {
+  for (const sourceRoot of physicalRoots) {
+    if (!isWithinDirectory(sourceRoot, linkPath)) continue;
+    const sourceRelativePath = relative(sourceRoot, linkPath);
+    const parentSteps = sourceRelativePath === "."
+      ? 0
+      : sourceRelativePath.split("/").filter(Boolean).length;
+    let targetAncestor = targetPath;
+    for (let index = 0; index < parentSteps; index += 1) {
+      targetAncestor = dirname(targetAncestor);
+    }
+    if (!physicalRoots.some((root) => isWithinDirectory(root, targetAncestor))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function assertSymlinkConfined(
+  linkPath: string,
+  physicalRoots: readonly string[],
+): void {
+  let target: string;
+  let targetMetadata: Deno.FileInfo;
+  try {
+    target = Deno.realPathSync(linkPath);
+    targetMetadata = Deno.statSync(target);
+  } catch {
+    rejectUnconfinedReadScope();
+  }
+  if (
+    !physicalRoots.some((root) => isWithinDirectory(root, target)) ||
+    (targetMetadata.isDirectory && directorySymlinkCanEscape(linkPath, target, physicalRoots))
+  ) {
+    rejectUnconfinedReadScope();
+  }
 }
 
 /**
@@ -46,15 +88,7 @@ export function assertWorkerReadScopeConfined(
       rejectUnconfinedReadScope();
     }
     if (metadata.isSymlink) {
-      let target: string;
-      try {
-        target = Deno.realPathSync(current);
-      } catch {
-        rejectUnconfinedReadScope();
-      }
-      if (!physicalRoots.some((root) => isWithinDirectory(root, target))) {
-        rejectUnconfinedReadScope();
-      }
+      assertSymlinkConfined(current, physicalRoots);
       continue;
     }
     if (!metadata.isDirectory) continue;
@@ -66,15 +100,7 @@ export function assertWorkerReadScopeConfined(
       for (const entry of Deno.readDirSync(current)) {
         const entryPath = join(current, entry.name);
         if (entry.isSymlink) {
-          let target: string;
-          try {
-            target = Deno.realPathSync(entryPath);
-          } catch {
-            rejectUnconfinedReadScope();
-          }
-          if (!physicalRoots.some((root) => isWithinDirectory(root, target))) {
-            rejectUnconfinedReadScope();
-          }
+          assertSymlinkConfined(entryPath, physicalRoots);
         } else if (entry.isDirectory) {
           pending.push(entryPath);
         }

--- a/src/security/sandbox/worker-read-scope.ts
+++ b/src/security/sandbox/worker-read-scope.ts
@@ -52,11 +52,13 @@ function assertSymlinkConfined(
 }
 
 /**
- * Reject scoped worker roots that contain a pre-existing symlink escape.
+ * Reject scoped worker roots that contain a symlink escape.
  *
  * Deno authorizes reads using the symlink location rather than its resolved
  * target. Project workers cannot create new symlinks because write access is
- * denied, so auditing the host-owned tree before startup closes that gap.
+ * denied, but the host can change a source tree. Call this before startup and
+ * again at every execution boundary so a pooled worker cannot use a link added
+ * between requests.
  */
 export function assertWorkerReadScopeConfined(
   readScope: readonly string[] | boolean,


### PR DESCRIPTION
## Summary

- audit scoped worker read roots before starting project code
- revalidate the read scope before every normal and streaming execution
- reject dangling symlinks, targets outside allowed physical roots, and directory links whose parent traversal can escape
- allow links whose resolved access remains inside an explicitly allowed root
- return a sanitized `SECURITY_VIOLATION` without exposing filesystem paths

Deno path-scoped read permissions authorize a symlink by its link location, not its resolved target. Denied worker writes prevent project code from adding a link, while execution-boundary revalidation catches host-side source changes before a pooled worker runs further project code. Existing generation invalidation still retires workers when API or data source generations change. See the [Deno permissions reference](https://docs.deno.com/runtime/reference/permissions/#file-system-access).

## Red-green TDD

Red:

- a preexisting external symlink allowed `ProjectWorker.start()` to continue
- after a clean start, replacing a project entry with an external symlink allowed the next request to read the outside file

Green:

- startup rejects an already unsafe scope
- normal and streaming execution revalidate the scope and reject a link added after startup
- focused coverage also exercises cross-root links, directory parent traversal, dangling links, and optional missing roots

## Verification

- worker read-scope and full ProjectWorker suites: 76 steps passed
- `deno task verify:quick`
- `git diff --check`

Refs veryfront/veryfront-issue-inbox#105

@codex review