### PR TITLE
fix(tests): stop listTestFiles silently dropping glob patterns

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -557,7 +557,7 @@
     "test:tool-search-live": "VF_DISABLE_LRU_INTERVAL=1 deno test --no-check -A tests/agent/verify-tool-search-live.test.ts",
     "test:cross-runtime": "deno run --allow-all src/platform/compat/cross-runtime.test.ts",
     "test:node": {
-      "command": "node ./tests/node/run-tests.mjs 'src/**/*.test.ts' extensions/ext-bundler-esbuild/src/binary.test.ts tests/ensure-npm-links.test.mjs",
+      "command": "node ./tests/node/run-tests.mjs 'src/**/*.test.ts' extensions/ext-bundler-esbuild/src/binary.test.ts tests/ensure-npm-links.test.mjs tests/test-file-utils.test.mjs",
       "dependencies": ["build:npm"]
     },
     "test:bun": {

--- a/tests/test-file-utils.mjs
+++ b/tests/test-file-utils.mjs
@@ -38,21 +38,31 @@ function globToRegex(glob) {
     if (char === "*") {
       const next = glob[i + 1];
       if (next === "*") {
-        // `**` crosses directory boundaries. Written as its own segment
-        // (`src/**/*.test.ts`) it must also match *zero* segments, so
-        // `src/a.test.ts` is selected — this is what both ripgrep and
-        // node:fs `globSync` do. Translating it to `.*` alone requires a
-        // trailing separator and silently drops every depth-1 match.
-        if (glob[i + 2] === "/") {
+        // `**` only crosses directory boundaries when it is a *complete*
+        // path segment. Both ripgrep and node:fs `globSync` agree:
+        //   src/**/*.test.ts  -> src/a.test.ts AND src/nested/b.test.ts
+        //   src/**.test.ts    -> src/a.test.ts only (segment-scoped)
+        //   src/foo**/*.test.ts -> src/foo/a.test.ts only, NOT src/foo.test.ts
+        // So the globstar translation is gated on both boundaries, and a
+        // `**` glued to other characters degrades to a single `*`.
+        const atSegmentStart = i === 0 || glob[i - 1] === "/";
+        const after = glob[i + 2];
+        if (atSegmentStart && after === "/") {
+          // Matches zero or more segments, so the depth-1 case is included.
           re += "(?:.*\\/)?";
           i += 2;
-        } else {
+          continue;
+        }
+        if (atSegmentStart && after === undefined) {
           re += ".*";
           i += 1;
+          continue;
         }
-      } else {
         re += "[^/]*";
+        i += 1;
+        continue;
       }
+      re += "[^/]*";
       continue;
     }
     if (char === "?") {
@@ -116,17 +126,24 @@ function listWithFallback(patterns, cwd) {
     }
 
     const baseDir = getBaseDir(pattern, cwd);
-    const matcher = globToRegex(toPosixPath(pattern));
+    // A glob whose base does not exist contributes nothing, the same as the
+    // non-glob branch above. This is checked up front rather than by catching
+    // around the walk: a failure *inside* the traversal (an unreadable
+    // subdirectory, a file removed mid-walk) would otherwise be swallowed
+    // after `walk` had already accumulated part of the tree, and the runner
+    // would execute a partial selection and report success — which is the
+    // exact silent-omission failure this module is being fixed for. Those
+    // errors propagate.
     try {
-      walk(baseDir, (file) => {
-        const rel = toPosixPath(file.startsWith(cwd) ? file.slice(cwd.length + 1) : file);
-        if (matcher.test(rel)) files.add(file);
-      });
+      if (!statSync(baseDir).isDirectory()) continue;
     } catch {
-      // A glob whose base directory does not exist contributes nothing, the
-      // same as the non-glob branch above. Left unguarded this throws out of
-      // the runner entirely instead of yielding an empty selection.
+      continue;
     }
+    const matcher = globToRegex(toPosixPath(pattern));
+    walk(baseDir, (file) => {
+      const rel = toPosixPath(file.startsWith(cwd) ? file.slice(cwd.length + 1) : file);
+      if (matcher.test(rel)) files.add(file);
+    });
   }
   return Array.from(files);
 }

--- a/tests/test-file-utils.mjs
+++ b/tests/test-file-utils.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { readdirSync, statSync } from "node:fs";
-import { dirname, resolve, sep } from "node:path";
+import { dirname, relative, resolve, sep } from "node:path";
 
 const TEST_FILE_RE = /\.test\.[cm]?[jt]sx?$/i;
 const GLOB_CHARS_RE = /[\*\?\[]/;
@@ -124,6 +124,18 @@ function isMissingPathError(error) {
   return code === "ENOENT" || code === "ENOTDIR";
 }
 
+/**
+ * True when `target` sits under a dot-prefixed directory relative to `cwd`.
+ *
+ * Only segments below `cwd` count: a checkout that itself lives under a hidden
+ * directory is not thereby invisible to its own test runner.
+ */
+function hasHiddenSegment(target, cwd) {
+  const relativePath = relative(cwd, target);
+  if (relativePath === "" || relativePath.startsWith("..")) return false;
+  return toPosixPath(relativePath).split("/").some((segment) => segment.startsWith("."));
+}
+
 function listWithFallback(patterns, cwd) {
   const files = new Set();
   for (const pattern of patterns) {
@@ -151,6 +163,11 @@ function listWithFallback(patterns, cwd) {
     }
 
     const baseDir = getBaseDir(pattern, cwd);
+    // `rg` prunes hidden directories before the glob is applied, so a pattern
+    // whose literal prefix descends into one matches nothing at all — verified
+    // with rg 15: `-g 'src/.fixtures/**/*.test.ts'` returns no files. `walk`
+    // starts *inside* the base, so the per-entry hidden check never sees it.
+    if (hasHiddenSegment(baseDir, cwd)) continue;
     // A glob whose base does not exist contributes nothing, the same as the
     // non-glob branch above. This is checked up front rather than by catching
     // around the walk: a failure *inside* the traversal (an unreadable

--- a/tests/test-file-utils.mjs
+++ b/tests/test-file-utils.mjs
@@ -85,11 +85,14 @@ function globToRegex(glob) {
 function walk(dir, onFile) {
   const entries = readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
-    // `rg` skips hidden entries unless `--hidden` is passed, and node:fs glob
-    // skips them too. The fallback has to match, or the selected test set
-    // depends on whether ripgrep happens to be installed — which is the exact
-    // class of divergence this module is being fixed for.
-    if (entry.name.startsWith(".")) continue;
+    // `rg` is the reference here, because `rg` is what runs when it is
+    // installed; the fallback exists to reproduce its selection when it is
+    // not. It treats the two cases differently, verified directly:
+    //   hidden directory  -> skipped   (src/.fixtures/x.test.ts is omitted)
+    //   dot-prefixed file -> INCLUDED  (src/.smoke.test.ts is returned)
+    // because `-g/--glob` "always overrides any other ignore logic". Note
+    // node:fs glob excludes both, so it is the wrong oracle for dot-files.
+    if (entry.isDirectory() && entry.name.startsWith(".")) continue;
     const fullPath = resolve(dir, entry.name);
     if (entry.isDirectory()) {
       walk(fullPath, onFile);
@@ -127,19 +130,22 @@ function listWithFallback(patterns, cwd) {
     if (!pattern) continue;
     const absolute = resolve(cwd, pattern);
     if (!hasGlob(pattern)) {
+      // Base lookup guarded; the traversal is not, for the same reason as
+      // `listTestFiles` — a descendant vanishing mid-walk must not be read as
+      // "this path does not exist".
+      let stats;
       try {
-        const stats = statSync(absolute);
-        if (stats.isDirectory()) {
-          walk(absolute, (file) => {
-            if (TEST_FILE_RE.test(file)) files.add(file);
-          });
-        } else if (stats.isFile() && TEST_FILE_RE.test(absolute)) {
-          files.add(absolute);
-        }
+        stats = statSync(absolute);
       } catch (error) {
-        // Same rule as the glob branch below: a missing path contributes
-        // nothing, anything else propagates.
         if (!isMissingPathError(error)) throw error;
+        continue;
+      }
+      if (stats.isDirectory()) {
+        walk(absolute, (file) => {
+          if (TEST_FILE_RE.test(file)) files.add(file);
+        });
+      } else if (stats.isFile() && TEST_FILE_RE.test(absolute)) {
+        files.add(absolute);
       }
       continue;
     }
@@ -189,26 +195,28 @@ export function listTestFiles(patterns, cwd = process.cwd()) {
       continue;
     }
 
+    // Only the base lookup is guarded. Wrapping the traversal too would
+    // re-swallow an `ENOENT` raised *inside* `walk` — a descendant removed
+    // between `readdirSync` calls — and silently drop the directory's whole
+    // contribution, which the glob branch above already avoids.
+    let stats;
     try {
-      const stats = statSync(absolute);
-      if (stats.isFile()) {
-        if (TEST_FILE_RE.test(absolute)) files.add(absolute);
-        continue;
-      }
-      if (stats.isDirectory()) {
-        const matches = runRg(["--files", "-g", "*.test.*", absolute], cwd);
-        if (matches) {
-          for (const match of matches) files.add(resolve(cwd, match));
-        } else {
-          for (const file of listWithFallback([absolute], cwd)) files.add(file);
-        }
-      }
+      stats = statSync(absolute);
     } catch (error) {
-      // Same rule as `listWithFallback`: a missing path contributes nothing,
-      // anything else propagates. A broad catch here also swallowed the
-      // rethrow from the `listWithFallback` call above, so a directory with an
-      // unreadable descendant was silently omitted.
       if (!isMissingPathError(error)) throw error;
+      continue;
+    }
+    if (stats.isFile()) {
+      if (TEST_FILE_RE.test(absolute)) files.add(absolute);
+      continue;
+    }
+    if (stats.isDirectory()) {
+      const matches = runRg(["--files", "-g", "*.test.*", absolute], cwd);
+      if (matches) {
+        for (const match of matches) files.add(resolve(cwd, match));
+      } else {
+        for (const file of listWithFallback([absolute], cwd)) files.add(file);
+      }
     }
   }
 

--- a/tests/test-file-utils.mjs
+++ b/tests/test-file-utils.mjs
@@ -132,7 +132,12 @@ function isMissingPathError(error) {
  */
 function hasHiddenSegment(target, cwd) {
   const relativePath = relative(cwd, target);
-  if (relativePath === "" || relativePath.startsWith("..")) return false;
+  // `startsWith("..")` alone would misread a directory *named* `..fixtures` as
+  // a parent path and skip the hidden check entirely. Only an exact `..` or a
+  // `..` followed by a separator escapes `cwd`.
+  const escapesCwd = relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) || relativePath.startsWith("../");
+  if (relativePath === "" || escapesCwd) return false;
   return toPosixPath(relativePath).split("/").some((segment) => segment.startsWith("."));
 }
 

--- a/tests/test-file-utils.mjs
+++ b/tests/test-file-utils.mjs
@@ -85,6 +85,11 @@ function globToRegex(glob) {
 function walk(dir, onFile) {
   const entries = readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
+    // `rg` skips hidden entries unless `--hidden` is passed, and node:fs glob
+    // skips them too. The fallback has to match, or the selected test set
+    // depends on whether ripgrep happens to be installed — which is the exact
+    // class of divergence this module is being fixed for.
+    if (entry.name.startsWith(".")) continue;
     const fullPath = resolve(dir, entry.name);
     if (entry.isDirectory()) {
       walk(fullPath, onFile);
@@ -198,8 +203,12 @@ export function listTestFiles(patterns, cwd = process.cwd()) {
           for (const file of listWithFallback([absolute], cwd)) files.add(file);
         }
       }
-    } catch {
-      // Ignore missing paths or stat failures.
+    } catch (error) {
+      // Same rule as `listWithFallback`: a missing path contributes nothing,
+      // anything else propagates. A broad catch here also swallowed the
+      // rethrow from the `listWithFallback` call above, so a directory with an
+      // unreadable descendant was silently omitted.
+      if (!isMissingPathError(error)) throw error;
     }
   }
 

--- a/tests/test-file-utils.mjs
+++ b/tests/test-file-utils.mjs
@@ -104,6 +104,18 @@ function getBaseDir(pattern, cwd) {
   return resolve(cwd, base || ".");
 }
 
+/**
+ * A base path that does not exist contributes nothing. Anything else —
+ * `EACCES` on an ancestor, a device error — has to propagate: swallowing it
+ * would drop the whole pattern, and if that left the selection empty the
+ * runner would exit 0 having run nothing. That silent-omission failure is the
+ * reason this module is being fixed.
+ */
+function isMissingPathError(error) {
+  const code = error?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
 function listWithFallback(patterns, cwd) {
   const files = new Set();
   for (const pattern of patterns) {
@@ -119,8 +131,10 @@ function listWithFallback(patterns, cwd) {
         } else if (stats.isFile() && TEST_FILE_RE.test(absolute)) {
           files.add(absolute);
         }
-      } catch {
-        // Ignore missing paths.
+      } catch (error) {
+        // Same rule as the glob branch below: a missing path contributes
+        // nothing, anything else propagates.
+        if (!isMissingPathError(error)) throw error;
       }
       continue;
     }
@@ -136,7 +150,8 @@ function listWithFallback(patterns, cwd) {
     // errors propagate.
     try {
       if (!statSync(baseDir).isDirectory()) continue;
-    } catch {
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
       continue;
     }
     const matcher = globToRegex(toPosixPath(pattern));

--- a/tests/test-file-utils.mjs
+++ b/tests/test-file-utils.mjs
@@ -38,8 +38,18 @@ function globToRegex(glob) {
     if (char === "*") {
       const next = glob[i + 1];
       if (next === "*") {
-        re += ".*";
-        i += 1;
+        // `**` crosses directory boundaries. Written as its own segment
+        // (`src/**/*.test.ts`) it must also match *zero* segments, so
+        // `src/a.test.ts` is selected — this is what both ripgrep and
+        // node:fs `globSync` do. Translating it to `.*` alone requires a
+        // trailing separator and silently drops every depth-1 match.
+        if (glob[i + 2] === "/") {
+          re += "(?:.*\\/)?";
+          i += 2;
+        } else {
+          re += ".*";
+          i += 1;
+        }
       } else {
         re += "[^/]*";
       }
@@ -107,10 +117,16 @@ function listWithFallback(patterns, cwd) {
 
     const baseDir = getBaseDir(pattern, cwd);
     const matcher = globToRegex(toPosixPath(pattern));
-    walk(baseDir, (file) => {
-      const rel = toPosixPath(file.startsWith(cwd) ? file.slice(cwd.length + 1) : file);
-      if (matcher.test(rel)) files.add(file);
-    });
+    try {
+      walk(baseDir, (file) => {
+        const rel = toPosixPath(file.startsWith(cwd) ? file.slice(cwd.length + 1) : file);
+        if (matcher.test(rel)) files.add(file);
+      });
+    } catch {
+      // A glob whose base directory does not exist contributes nothing, the
+      // same as the non-glob branch above. Left unguarded this throws out of
+      // the runner entirely instead of yielding an empty selection.
+    }
   }
   return Array.from(files);
 }
@@ -125,8 +141,15 @@ export function listTestFiles(patterns, cwd = process.cwd()) {
       const matches = runRg(["--files", "-g", pattern], cwd);
       if (matches) {
         for (const match of matches) files.add(resolve(cwd, match));
-        continue;
+      } else {
+        // No ripgrep (it is absent on the CI runners), so resolve the glob
+        // in-process. This fallback has to be per-pattern: the whole-result
+        // fallback at the end only fires when *nothing* matched, so a single
+        // explicit file listed next to a glob was enough to suppress it and
+        // drop the glob's entire contribution without a word.
+        for (const file of listWithFallback([pattern], cwd)) files.add(file);
       }
+      continue;
     }
 
     try {

--- a/tests/test-file-utils.test.mjs
+++ b/tests/test-file-utils.test.mjs
@@ -11,49 +11,88 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
-import { fileURLToPath } from "node:url";
-import { after, describe, it } from "node:test";
+import { describe, it } from "node:test";
 
 const utilsUrl = new URL("./test-file-utils.mjs", import.meta.url).href;
-const fixtures = [];
+
+const BASE_TREE = [
+  "src/a.test.ts",
+  "src/nested/b.test.ts",
+  "src/nested/deep/c.test.ts",
+  "src/not-a-test.ts",
+  "extra/explicit.test.mjs",
+];
+
+const GLOBSTAR_TREE = [
+  "src/b.test.ts",
+  "src/foo.test.ts",
+  "src/foo/a.test.ts",
+  "src/foo/deep/d.test.ts",
+];
 
 /**
- * The suite exercises the branch taken when `rg` is not on PATH, which is the
- * case on the CI runners. `rgAvailable` is module-level state latched on the
- * first ENOENT, so each scenario runs in its own child process with an empty
- * PATH rather than trying to reset it in-process.
+ * Build a throwaway tree, hand it to `run`, then remove it.
+ *
+ * Teardown is per-test rather than a `node:test` `after` hook: `tests/` is also
+ * swept by `deno test` in the integration lane, and Deno's `node:test` shim
+ * does not implement `after` — it fails the whole file with an uncaught
+ * "Not implemented: test.after". `describe`/`it` are supported in both, which
+ * is why the sibling `ensure-npm-links.test.mjs` sticks to them.
  */
-function createFixture() {
+function withFixture(relativePaths, run) {
   const root = mkdtempSync(join(tmpdir(), "vf-test-file-utils-"));
-  fixtures.push(root);
-  for (
-    const relative of [
-      "src/a.test.ts",
-      "src/nested/b.test.ts",
-      "src/nested/deep/c.test.ts",
-      "src/not-a-test.ts",
-      "extra/explicit.test.mjs",
-    ]
-  ) {
-    const absolute = join(root, relative);
-    mkdirSync(dirname(absolute), { recursive: true });
-    writeFileSync(absolute, "// fixture\n");
+  try {
+    for (const relative of relativePaths) {
+      const absolute = join(root, relative);
+      mkdirSync(dirname(absolute), { recursive: true });
+      writeFileSync(absolute, "// fixture\n");
+    }
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
-  return root;
+}
+
+/**
+ * Resolve patterns with `rg` guaranteed absent.
+ *
+ * `rgAvailable` is module-level state latched on the first ENOENT, so each
+ * scenario runs in its own child process with an empty PATH instead of trying
+ * to reset it in-process. An empty PATH is what makes `spawnSync("rg", ...)`
+ * fail with ENOENT, which is the branch this suite is about — and the branch
+ * the CI runners actually take.
+ */
+function runListTestFilesProbe(patterns, cwd) {
+  // The probe goes to a real file rather than `-e`. This suite runs in both
+  // the Node lane and the Deno integration lane (which sweeps all of `tests/`),
+  // and `process.execPath` is whichever runtime is hosting — so a Node-only
+  // `--input-type=module -e` invocation fails under Deno with "await is only
+  // valid in async functions and the top level bodies of modules".
+  const probeDir = mkdtempSync(join(tmpdir(), "vf-test-file-utils-probe-"));
+  const probePath = join(probeDir, "probe.mjs");
+  writeFileSync(
+    probePath,
+    `import { listTestFiles } from ${JSON.stringify(utilsUrl)};\n` +
+      `process.stdout.write(JSON.stringify(listTestFiles(${JSON.stringify(patterns)}, ${
+        JSON.stringify(cwd)
+      })));\n`,
+  );
+  // Deno needs its permissions named; Node takes the script path alone.
+  const args = typeof globalThis.Deno === "undefined"
+    ? [probePath]
+    : ["run", "--allow-read", "--allow-env", "--allow-run", probePath];
+  try {
+    return spawnSync(process.execPath, args, {
+      encoding: "utf8",
+      env: { ...process.env, PATH: "" },
+    });
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true });
+  }
 }
 
 function listTestFilesWithoutRipgrep(patterns, cwd) {
-  const script = `
-    const { listTestFiles } = await import(${JSON.stringify(utilsUrl)});
-    const files = listTestFiles(${JSON.stringify(patterns)}, ${JSON.stringify(cwd)});
-    process.stdout.write(JSON.stringify(files));
-  `;
-  const result = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
-    encoding: "utf8",
-    // An empty PATH is what makes spawnSync("rg", ...) fail with ENOENT, which
-    // is the condition this suite is about. Everything else is inherited.
-    env: { ...process.env, PATH: "" },
-  });
+  const result = runListTestFilesProbe(patterns, cwd);
   ok(
     result.status === 0,
     `child listTestFiles failed (status ${result.status}): ${result.stderr}`,
@@ -79,90 +118,78 @@ function globFilesSorted(pattern, root) {
     .sort();
 }
 
-after(() => {
-  for (const root of fixtures) rmSync(root, { recursive: true, force: true });
-});
-
 describe("listTestFiles without ripgrep", () => {
   it("resolves a glob pattern when no other pattern matched", () => {
-    const root = createFixture();
-    const files = listTestFilesWithoutRipgrep(["src/**/*.test.ts"], root);
-    deepStrictEqual(relativeSorted(files, root), [
-      "src/a.test.ts",
-      "src/nested/b.test.ts",
-      "src/nested/deep/c.test.ts",
-    ]);
+    withFixture(BASE_TREE, (root) => {
+      deepStrictEqual(
+        relativeSorted(listTestFilesWithoutRipgrep(["src/**/*.test.ts"], root), root),
+        [
+          "src/a.test.ts",
+          "src/nested/b.test.ts",
+          "src/nested/deep/c.test.ts",
+        ],
+      );
+    });
   });
 
   it("resolves a glob pattern alongside an explicit file pattern", () => {
-    const root = createFixture();
-    // The regression: the explicit file makes the result set non-empty, so the
-    // whole-result-set fallback never fires and the glob silently contributes
-    // nothing. Selection collapses to the explicit file alone.
-    const files = listTestFilesWithoutRipgrep(
-      ["src/**/*.test.ts", "extra/explicit.test.mjs"],
-      root,
-    );
-    deepStrictEqual(relativeSorted(files, root), [
-      "extra/explicit.test.mjs",
-      "src/a.test.ts",
-      "src/nested/b.test.ts",
-      "src/nested/deep/c.test.ts",
-    ]);
+    withFixture(BASE_TREE, (root) => {
+      // The regression: the explicit file makes the result set non-empty, so
+      // the whole-result-set fallback never fires and the glob silently
+      // contributes nothing. Selection collapses to the explicit file alone.
+      const files = listTestFilesWithoutRipgrep(
+        ["src/**/*.test.ts", "extra/explicit.test.mjs"],
+        root,
+      );
+      deepStrictEqual(relativeSorted(files, root), [
+        "extra/explicit.test.mjs",
+        "src/a.test.ts",
+        "src/nested/b.test.ts",
+        "src/nested/deep/c.test.ts",
+      ]);
+    });
   });
 
   it("resolves a glob pattern alongside a directory pattern", () => {
-    const root = createFixture();
-    const files = listTestFilesWithoutRipgrep(["src/**/*.test.ts", "extra"], root);
-    deepStrictEqual(relativeSorted(files, root), [
-      "extra/explicit.test.mjs",
-      "src/a.test.ts",
-      "src/nested/b.test.ts",
-      "src/nested/deep/c.test.ts",
-    ]);
+    withFixture(BASE_TREE, (root) => {
+      const files = listTestFilesWithoutRipgrep(["src/**/*.test.ts", "extra"], root);
+      deepStrictEqual(relativeSorted(files, root), [
+        "extra/explicit.test.mjs",
+        "src/a.test.ts",
+        "src/nested/b.test.ts",
+        "src/nested/deep/c.test.ts",
+      ]);
+    });
   });
 
   it("does not invent matches for a glob that matches nothing", () => {
-    const root = createFixture();
-    const files = listTestFilesWithoutRipgrep(
-      ["does-not-exist/**/*.test.ts", "extra/explicit.test.mjs"],
-      root,
-    );
-    deepStrictEqual(relativeSorted(files, root), ["extra/explicit.test.mjs"]);
+    withFixture(BASE_TREE, (root) => {
+      const files = listTestFilesWithoutRipgrep(
+        ["does-not-exist/**/*.test.ts", "extra/explicit.test.mjs"],
+        root,
+      );
+      deepStrictEqual(relativeSorted(files, root), ["extra/explicit.test.mjs"]);
+    });
   });
 
   it("keeps a glob's contribution identical with and without an extra pattern", () => {
-    const root = createFixture();
-    const globOnly = relativeSorted(listTestFilesWithoutRipgrep(["src/**/*.test.ts"], root), root);
-    const withExtra = relativeSorted(
-      listTestFilesWithoutRipgrep(["src/**/*.test.ts", "extra/explicit.test.mjs"], root),
-      root,
-    ).filter((file) => file.startsWith("src/"));
-    deepStrictEqual(withExtra, globOnly);
+    withFixture(BASE_TREE, (root) => {
+      const globOnly = relativeSorted(
+        listTestFilesWithoutRipgrep(["src/**/*.test.ts"], root),
+        root,
+      );
+      const withExtra = relativeSorted(
+        listTestFilesWithoutRipgrep(["src/**/*.test.ts", "extra/explicit.test.mjs"], root),
+        root,
+      ).filter((file) => file.startsWith("src/"));
+      deepStrictEqual(withExtra, globOnly);
+    });
   });
 });
 
-function createGlobstarFixture() {
-  const root = mkdtempSync(join(tmpdir(), "vf-test-file-utils-globstar-"));
-  fixtures.push(root);
-  for (
-    const relative of [
-      "src/b.test.ts",
-      "src/foo.test.ts",
-      "src/foo/a.test.ts",
-      "src/foo/deep/d.test.ts",
-    ]
-  ) {
-    const absolute = join(root, relative);
-    mkdirSync(dirname(absolute), { recursive: true });
-    writeFileSync(absolute, "// fixture\n");
-  }
-  return root;
-}
-
 describe("listTestFiles treats ** as a globstar only as a complete segment", () => {
   // Raised in review on #3780. `**` glued to other characters is segment-scoped
-  // in both ripgrep and node:fs glob, so the zero-segment translation must be
+  // in both ripgrep and node:fs glob, so the zero-segment translation has to be
   // gated on both boundaries or `src/foo**/` wrongly selects `src/foo.test.ts`.
   for (
     const pattern of [
@@ -175,56 +202,20 @@ describe("listTestFiles treats ** as a globstar only as a complete segment", () 
     ]
   ) {
     it(`resolves ${pattern} the way node:fs glob does`, () => {
-      const root = createGlobstarFixture();
-      const expected = globFilesSorted(pattern, root);
-      deepStrictEqual(relativeSorted(listTestFilesWithoutRipgrep([pattern], root), root), expected);
+      withFixture(GLOBSTAR_TREE, (root) => {
+        deepStrictEqual(
+          relativeSorted(listTestFilesWithoutRipgrep([pattern], root), root),
+          globFilesSorted(pattern, root),
+        );
+      });
     });
   }
 });
 
-describe("listTestFiles does not hide a failed traversal", () => {
-  // Raised in review on #3780. Catching around the whole walk swallowed errors
-  // raised *during* traversal after files had already been collected, so the
-  // runner could execute a partial selection and report success — the same
-  // silent-omission failure this module is being fixed for.
-  it("propagates an unreadable subdirectory instead of returning a partial set", function () {
-    if (typeof process.getuid === "function" && process.getuid() === 0) {
-      // root ignores the mode bits, so the error cannot be provoked.
-      return;
-    }
-    const root = createFixture();
-    const blocked = join(root, "src", "blocked");
-    mkdirSync(blocked, { recursive: true });
-    writeFileSync(join(blocked, "hidden.test.ts"), "// fixture\n");
-    chmodSync(blocked, 0o000);
-    try {
-      const result = spawnSync(process.execPath, [
-        "--input-type=module",
-        "-e",
-        `
-        const { listTestFiles } = await import(${JSON.stringify(utilsUrl)});
-        const files = listTestFiles(["src/**/*.test.ts"], ${JSON.stringify(root)});
-        process.stdout.write(JSON.stringify(files));
-      `,
-      ], { encoding: "utf8", env: { ...process.env, PATH: "" } });
-      ok(
-        result.status !== 0,
-        `expected a non-zero exit, got ${result.status} with stdout: ${result.stdout}`,
-      );
-      ok(
-        /EACCES|EPERM/.test(result.stderr),
-        `expected a permission error to surface, got: ${result.stderr}`,
-      );
-    } finally {
-      chmodSync(blocked, 0o755);
-    }
-  });
-});
-
 describe("listTestFiles agrees with the platform glob", () => {
-  // `node:fs` globSync is the reference implementation here: ripgrep's `-g`
-  // returns the same set for these patterns, and pinning against a built-in
-  // keeps the assertion deterministic on machines where `rg` is absent.
+  // `node:fs` globSync is the reference implementation: ripgrep's `-g` returns
+  // the same set for these patterns, and pinning against a built-in keeps the
+  // assertion deterministic on machines where `rg` is absent.
   for (
     const pattern of [
       "src/**/*.test.ts",
@@ -235,21 +226,45 @@ describe("listTestFiles agrees with the platform glob", () => {
     ]
   ) {
     it(`resolves ${pattern} the way node:fs glob does`, () => {
-      const root = createFixture();
-      const expected = globFilesSorted(pattern, root);
-      deepStrictEqual(relativeSorted(listTestFilesWithoutRipgrep([pattern], root), root), expected);
+      withFixture(BASE_TREE, (root) => {
+        deepStrictEqual(
+          relativeSorted(listTestFilesWithoutRipgrep([pattern], root), root),
+          globFilesSorted(pattern, root),
+        );
+      });
     });
   }
+});
 
-  it("matches the in-process path, whatever ripgrep availability is here", async () => {
-    const root = createFixture();
-    const patterns = ["src/**/*.test.ts", "extra/explicit.test.mjs"];
-    const { listTestFiles } = await import(
-      fileURLToPath(new URL("./test-file-utils.mjs", import.meta.url))
-    );
-    deepStrictEqual(
-      relativeSorted(listTestFiles(patterns, root), root),
-      relativeSorted(listTestFilesWithoutRipgrep(patterns, root), root),
-    );
+describe("listTestFiles does not hide a failed traversal", () => {
+  // Raised in review on #3780. Catching around the whole walk swallowed errors
+  // raised *during* traversal after files had already been collected, so the
+  // runner could execute a partial selection and report success — the same
+  // silent-omission failure this module is being fixed for.
+  it("propagates an unreadable subdirectory instead of returning a partial set", () => {
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      // root ignores the mode bits, so the error cannot be provoked.
+      return;
+    }
+    withFixture(BASE_TREE, (root) => {
+      const blocked = join(root, "src", "blocked");
+      mkdirSync(blocked, { recursive: true });
+      writeFileSync(join(blocked, "hidden.test.ts"), "// fixture\n");
+      chmodSync(blocked, 0o000);
+      try {
+        const result = runListTestFilesProbe(["src/**/*.test.ts"], root);
+        ok(
+          result.status !== 0,
+          `expected a non-zero exit, got ${result.status} with stdout: ${result.stdout}`,
+        );
+        ok(
+          /EACCES|EPERM/.test(result.stderr),
+          `expected a permission error to surface, got: ${result.stderr}`,
+        );
+      } finally {
+        // Restore before teardown, or the recursive remove cannot descend.
+        chmodSync(blocked, 0o755);
+      }
+    });
   });
 });

--- a/tests/test-file-utils.test.mjs
+++ b/tests/test-file-utils.test.mjs
@@ -241,9 +241,41 @@ describe("listTestFiles does not hide a failed traversal", () => {
   // raised *during* traversal after files had already been collected, so the
   // runner could execute a partial selection and report success — the same
   // silent-omission failure this module is being fixed for.
+  it("propagates an unreadable glob base instead of dropping the pattern", () => {
+    if (typeof process.getuid === "function" && process.getuid() === 0) return;
+    if (process.platform === "win32") return;
+    withFixture(BASE_TREE, (root) => {
+      // The glob's base is `src/`, reached through an ancestor we cannot
+      // search. `statSync` raises EACCES rather than ENOENT, and treating that
+      // as "missing" would drop the whole pattern — leaving an empty selection
+      // that the runner reports as a clean pass.
+      const gate = join(root, "src");
+      chmodSync(gate, 0o000);
+      try {
+        const result = runListTestFilesProbe(["src/nested/**/*.test.ts"], root);
+        ok(
+          result.status !== 0,
+          `expected a non-zero exit, got ${result.status} with stdout: ${result.stdout}`,
+        );
+        ok(
+          /EACCES|EPERM/.test(result.stderr),
+          `expected a permission error to surface, got: ${result.stderr}`,
+        );
+      } finally {
+        chmodSync(gate, 0o755);
+      }
+    });
+  });
+
   it("propagates an unreadable subdirectory instead of returning a partial set", () => {
     if (typeof process.getuid === "function" && process.getuid() === 0) {
       // root ignores the mode bits, so the error cannot be provoked.
+      return;
+    }
+    if (process.platform === "win32") {
+      // `chmod 000` does not deny directory traversal on Windows, so the child
+      // would succeed and the assertion below would fail for the wrong reason.
+      // No CI runner is Windows today; this is for local runs.
       return;
     }
     withFixture(BASE_TREE, (root) => {

--- a/tests/test-file-utils.test.mjs
+++ b/tests/test-file-utils.test.mjs
@@ -263,6 +263,18 @@ describe("listTestFiles matches ripgrep on dot-prefixed entries", () => {
     });
   });
 
+  it("treats a directory named ..something as hidden, not as a parent path", () => {
+    // `relative()` returns `..fixtures` here, which a bare startsWith("..")
+    // check reads as "outside cwd" and waves through. rg 15 returns nothing
+    // for this pattern.
+    withFixture(["..fixtures/a.test.ts", "src/a.test.ts"], (root) => {
+      deepStrictEqual(
+        relativeSorted(listTestFilesWithoutRipgrep(["..fixtures/**/*.test.ts"], root), root),
+        [],
+      );
+    });
+  });
+
   it("still prunes a hidden directory", () => {
     withFixture(DOTFILE_TREE, (root) => {
       const selected = relativeSorted(

--- a/tests/test-file-utils.test.mjs
+++ b/tests/test-file-utils.test.mjs
@@ -251,6 +251,18 @@ describe("listTestFiles matches ripgrep on dot-prefixed entries", () => {
     });
   });
 
+  it("matches nothing when the glob's literal prefix is a hidden directory", () => {
+    // rg prunes the hidden directory before applying the glob, so this pattern
+    // returns no files at all. `walk` starts inside the base, so the per-entry
+    // check never sees `.fixtures` — the base itself has to be rejected.
+    withFixture(DOTFILE_TREE, (root) => {
+      deepStrictEqual(
+        relativeSorted(listTestFilesWithoutRipgrep(["src/.fixtures/**/*.test.ts"], root), root),
+        [],
+      );
+    });
+  });
+
   it("still prunes a hidden directory", () => {
     withFixture(DOTFILE_TREE, (root) => {
       const selected = relativeSorted(

--- a/tests/test-file-utils.test.mjs
+++ b/tests/test-file-utils.test.mjs
@@ -20,6 +20,10 @@ const BASE_TREE = [
   "src/nested/b.test.ts",
   "src/nested/deep/c.test.ts",
   "src/not-a-test.ts",
+  // Hidden directory: both `rg` (without --hidden) and node:fs glob skip these,
+  // so the in-process fallback must too or selection depends on whether
+  // ripgrep happens to be installed.
+  "src/.fixtures/hidden.test.ts",
   "extra/explicit.test.mjs",
 ];
 
@@ -241,6 +245,32 @@ describe("listTestFiles does not hide a failed traversal", () => {
   // raised *during* traversal after files had already been collected, so the
   // runner could execute a partial selection and report success — the same
   // silent-omission failure this module is being fixed for.
+  it("propagates an unreadable descendant of a directory pattern", () => {
+    if (typeof process.getuid === "function" && process.getuid() === 0) return;
+    if (process.platform === "win32") return;
+    withFixture(BASE_TREE, (root) => {
+      // A *directory* pattern routes through `listWithFallback` from inside
+      // `listTestFiles`'s own try. A broad catch there swallowed the rethrow,
+      // so the directory's tests were dropped and only the other explicit
+      // pattern survived — reported as a clean pass.
+      const blocked = join(root, "src", "nested");
+      chmodSync(blocked, 0o000);
+      try {
+        const result = runListTestFilesProbe(["src", "extra/explicit.test.mjs"], root);
+        ok(
+          result.status !== 0,
+          `expected a non-zero exit, got ${result.status} with stdout: ${result.stdout}`,
+        );
+        ok(
+          /EACCES|EPERM/.test(result.stderr),
+          `expected a permission error to surface, got: ${result.stderr}`,
+        );
+      } finally {
+        chmodSync(blocked, 0o755);
+      }
+    });
+  });
+
   it("propagates an unreadable glob base instead of dropping the pattern", () => {
     if (typeof process.getuid === "function" && process.getuid() === 0) return;
     if (process.platform === "win32") return;

--- a/tests/test-file-utils.test.mjs
+++ b/tests/test-file-utils.test.mjs
@@ -1,0 +1,158 @@
+import { deepStrictEqual, ok } from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { globSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, describe, it } from "node:test";
+
+const utilsUrl = new URL("./test-file-utils.mjs", import.meta.url).href;
+const fixtures = [];
+
+/**
+ * The suite exercises the branch taken when `rg` is not on PATH, which is the
+ * case on the CI runners. `rgAvailable` is module-level state latched on the
+ * first ENOENT, so each scenario runs in its own child process with an empty
+ * PATH rather than trying to reset it in-process.
+ */
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), "vf-test-file-utils-"));
+  fixtures.push(root);
+  for (
+    const relative of [
+      "src/a.test.ts",
+      "src/nested/b.test.ts",
+      "src/nested/deep/c.test.ts",
+      "src/not-a-test.ts",
+      "extra/explicit.test.mjs",
+    ]
+  ) {
+    const absolute = join(root, relative);
+    mkdirSync(dirname(absolute), { recursive: true });
+    writeFileSync(absolute, "// fixture\n");
+  }
+  return root;
+}
+
+function listTestFilesWithoutRipgrep(patterns, cwd) {
+  const script = `
+    const { listTestFiles } = await import(${JSON.stringify(utilsUrl)});
+    const files = listTestFiles(${JSON.stringify(patterns)}, ${JSON.stringify(cwd)});
+    process.stdout.write(JSON.stringify(files));
+  `;
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    encoding: "utf8",
+    // An empty PATH is what makes spawnSync("rg", ...) fail with ENOENT, which
+    // is the condition this suite is about. Everything else is inherited.
+    env: { ...process.env, PATH: "" },
+  });
+  ok(
+    result.status === 0,
+    `child listTestFiles failed (status ${result.status}): ${result.stderr}`,
+  );
+  return JSON.parse(result.stdout);
+}
+
+function relativeSorted(files, root) {
+  return files
+    .map((file) => resolve(file).slice(resolve(root).length + 1).split(sep).join("/"))
+    .sort();
+}
+
+after(() => {
+  for (const root of fixtures) rmSync(root, { recursive: true, force: true });
+});
+
+describe("listTestFiles without ripgrep", () => {
+  it("resolves a glob pattern when no other pattern matched", () => {
+    const root = createFixture();
+    const files = listTestFilesWithoutRipgrep(["src/**/*.test.ts"], root);
+    deepStrictEqual(relativeSorted(files, root), [
+      "src/a.test.ts",
+      "src/nested/b.test.ts",
+      "src/nested/deep/c.test.ts",
+    ]);
+  });
+
+  it("resolves a glob pattern alongside an explicit file pattern", () => {
+    const root = createFixture();
+    // The regression: the explicit file makes the result set non-empty, so the
+    // whole-result-set fallback never fires and the glob silently contributes
+    // nothing. Selection collapses to the explicit file alone.
+    const files = listTestFilesWithoutRipgrep(
+      ["src/**/*.test.ts", "extra/explicit.test.mjs"],
+      root,
+    );
+    deepStrictEqual(relativeSorted(files, root), [
+      "extra/explicit.test.mjs",
+      "src/a.test.ts",
+      "src/nested/b.test.ts",
+      "src/nested/deep/c.test.ts",
+    ]);
+  });
+
+  it("resolves a glob pattern alongside a directory pattern", () => {
+    const root = createFixture();
+    const files = listTestFilesWithoutRipgrep(["src/**/*.test.ts", "extra"], root);
+    deepStrictEqual(relativeSorted(files, root), [
+      "extra/explicit.test.mjs",
+      "src/a.test.ts",
+      "src/nested/b.test.ts",
+      "src/nested/deep/c.test.ts",
+    ]);
+  });
+
+  it("does not invent matches for a glob that matches nothing", () => {
+    const root = createFixture();
+    const files = listTestFilesWithoutRipgrep(
+      ["does-not-exist/**/*.test.ts", "extra/explicit.test.mjs"],
+      root,
+    );
+    deepStrictEqual(relativeSorted(files, root), ["extra/explicit.test.mjs"]);
+  });
+
+  it("keeps a glob's contribution identical with and without an extra pattern", () => {
+    const root = createFixture();
+    const globOnly = relativeSorted(listTestFilesWithoutRipgrep(["src/**/*.test.ts"], root), root);
+    const withExtra = relativeSorted(
+      listTestFilesWithoutRipgrep(["src/**/*.test.ts", "extra/explicit.test.mjs"], root),
+      root,
+    ).filter((file) => file.startsWith("src/"));
+    deepStrictEqual(withExtra, globOnly);
+  });
+});
+
+describe("listTestFiles agrees with the platform glob", () => {
+  // `node:fs` globSync is the reference implementation here: ripgrep's `-g`
+  // returns the same set for these patterns, and pinning against a built-in
+  // keeps the assertion deterministic on machines where `rg` is absent.
+  for (
+    const pattern of [
+      "src/**/*.test.ts",
+      "src/**/*.test.*",
+      "**/*.test.ts",
+      "src/*.test.ts",
+      "src/nested/**/*.test.ts",
+    ]
+  ) {
+    it(`resolves ${pattern} the way node:fs glob does`, () => {
+      const root = createFixture();
+      const expected = globSync(pattern, { cwd: root })
+        .map((file) => file.split(sep).join("/"))
+        .sort();
+      deepStrictEqual(relativeSorted(listTestFilesWithoutRipgrep([pattern], root), root), expected);
+    });
+  }
+
+  it("matches the in-process path, whatever ripgrep availability is here", async () => {
+    const root = createFixture();
+    const patterns = ["src/**/*.test.ts", "extra/explicit.test.mjs"];
+    const { listTestFiles } = await import(
+      fileURLToPath(new URL("./test-file-utils.mjs", import.meta.url))
+    );
+    deepStrictEqual(
+      relativeSorted(listTestFiles(patterns, root), root),
+      relativeSorted(listTestFilesWithoutRipgrep(patterns, root), root),
+    );
+  });
+});

--- a/tests/test-file-utils.test.mjs
+++ b/tests/test-file-utils.test.mjs
@@ -1,6 +1,14 @@
 import { deepStrictEqual, ok } from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { globSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  globSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -56,6 +64,18 @@ function listTestFilesWithoutRipgrep(patterns, cwd) {
 function relativeSorted(files, root) {
   return files
     .map((file) => resolve(file).slice(resolve(root).length + 1).split(sep).join("/"))
+    .sort();
+}
+
+/**
+ * `globSync` yields directory entries as well as files (`src/**` includes
+ * `src/foo`), while `listTestFiles` only ever returns files. Compare like with
+ * like so the reference stays meaningful for directory-matching patterns.
+ */
+function globFilesSorted(pattern, root) {
+  return globSync(pattern, { cwd: root })
+    .filter((entry) => statSync(join(root, entry)).isFile())
+    .map((entry) => entry.split(sep).join("/"))
     .sort();
 }
 
@@ -122,6 +142,85 @@ describe("listTestFiles without ripgrep", () => {
   });
 });
 
+function createGlobstarFixture() {
+  const root = mkdtempSync(join(tmpdir(), "vf-test-file-utils-globstar-"));
+  fixtures.push(root);
+  for (
+    const relative of [
+      "src/b.test.ts",
+      "src/foo.test.ts",
+      "src/foo/a.test.ts",
+      "src/foo/deep/d.test.ts",
+    ]
+  ) {
+    const absolute = join(root, relative);
+    mkdirSync(dirname(absolute), { recursive: true });
+    writeFileSync(absolute, "// fixture\n");
+  }
+  return root;
+}
+
+describe("listTestFiles treats ** as a globstar only as a complete segment", () => {
+  // Raised in review on #3780. `**` glued to other characters is segment-scoped
+  // in both ripgrep and node:fs glob, so the zero-segment translation must be
+  // gated on both boundaries or `src/foo**/` wrongly selects `src/foo.test.ts`.
+  for (
+    const pattern of [
+      "src/foo**/*.test.ts",
+      "src/**.test.ts",
+      "src/**/*.test.ts",
+      "src/**",
+      "**/*.test.ts",
+      "src/foo/**/*.test.ts",
+    ]
+  ) {
+    it(`resolves ${pattern} the way node:fs glob does`, () => {
+      const root = createGlobstarFixture();
+      const expected = globFilesSorted(pattern, root);
+      deepStrictEqual(relativeSorted(listTestFilesWithoutRipgrep([pattern], root), root), expected);
+    });
+  }
+});
+
+describe("listTestFiles does not hide a failed traversal", () => {
+  // Raised in review on #3780. Catching around the whole walk swallowed errors
+  // raised *during* traversal after files had already been collected, so the
+  // runner could execute a partial selection and report success — the same
+  // silent-omission failure this module is being fixed for.
+  it("propagates an unreadable subdirectory instead of returning a partial set", function () {
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      // root ignores the mode bits, so the error cannot be provoked.
+      return;
+    }
+    const root = createFixture();
+    const blocked = join(root, "src", "blocked");
+    mkdirSync(blocked, { recursive: true });
+    writeFileSync(join(blocked, "hidden.test.ts"), "// fixture\n");
+    chmodSync(blocked, 0o000);
+    try {
+      const result = spawnSync(process.execPath, [
+        "--input-type=module",
+        "-e",
+        `
+        const { listTestFiles } = await import(${JSON.stringify(utilsUrl)});
+        const files = listTestFiles(["src/**/*.test.ts"], ${JSON.stringify(root)});
+        process.stdout.write(JSON.stringify(files));
+      `,
+      ], { encoding: "utf8", env: { ...process.env, PATH: "" } });
+      ok(
+        result.status !== 0,
+        `expected a non-zero exit, got ${result.status} with stdout: ${result.stdout}`,
+      );
+      ok(
+        /EACCES|EPERM/.test(result.stderr),
+        `expected a permission error to surface, got: ${result.stderr}`,
+      );
+    } finally {
+      chmodSync(blocked, 0o755);
+    }
+  });
+});
+
 describe("listTestFiles agrees with the platform glob", () => {
   // `node:fs` globSync is the reference implementation here: ripgrep's `-g`
   // returns the same set for these patterns, and pinning against a built-in
@@ -137,9 +236,7 @@ describe("listTestFiles agrees with the platform glob", () => {
   ) {
     it(`resolves ${pattern} the way node:fs glob does`, () => {
       const root = createFixture();
-      const expected = globSync(pattern, { cwd: root })
-        .map((file) => file.split(sep).join("/"))
-        .sort();
+      const expected = globFilesSorted(pattern, root);
       deepStrictEqual(relativeSorted(listTestFilesWithoutRipgrep([pattern], root), root), expected);
     });
   }

--- a/tests/test-file-utils.test.mjs
+++ b/tests/test-file-utils.test.mjs
@@ -216,6 +216,52 @@ describe("listTestFiles treats ** as a globstar only as a complete segment", () 
   }
 });
 
+describe("listTestFiles matches ripgrep on dot-prefixed entries", () => {
+  // `rg` is the oracle for this case, not node:fs glob, because `rg` is what
+  // runs when it is installed — the fallback exists to reproduce its
+  // selection. Verified directly against rg 14:
+  //   rg --files -g "*.test.*" src        -> includes src/.smoke.test.ts
+  //   rg --files -g "src/**/*.test.ts"    -> includes src/.smoke.test.ts
+  //   rg --files -g "src/**/*.test.ts"    -> OMITS  src/.fixtures/x.test.ts
+  // `-g/--glob` "always overrides any other ignore logic", so a dot-prefixed
+  // *file* is matched while a hidden *directory* is still pruned. node:fs glob
+  // excludes both, so the globSync-pinned suite below cannot cover this.
+  const DOTFILE_TREE = [
+    "src/a.test.ts",
+    "src/.smoke.test.ts",
+    "src/.fixtures/skipped.test.ts",
+    "src/nested/b.test.ts",
+  ];
+
+  it("keeps a dot-prefixed file matched by a glob pattern", () => {
+    withFixture(DOTFILE_TREE, (root) => {
+      deepStrictEqual(
+        relativeSorted(listTestFilesWithoutRipgrep(["src/**/*.test.ts"], root), root),
+        ["src/.smoke.test.ts", "src/a.test.ts", "src/nested/b.test.ts"],
+      );
+    });
+  });
+
+  it("keeps a dot-prefixed file under a directory pattern", () => {
+    withFixture(DOTFILE_TREE, (root) => {
+      deepStrictEqual(
+        relativeSorted(listTestFilesWithoutRipgrep(["src"], root), root),
+        ["src/.smoke.test.ts", "src/a.test.ts", "src/nested/b.test.ts"],
+      );
+    });
+  });
+
+  it("still prunes a hidden directory", () => {
+    withFixture(DOTFILE_TREE, (root) => {
+      const selected = relativeSorted(
+        listTestFilesWithoutRipgrep(["src/**/*.test.ts"], root),
+        root,
+      );
+      deepStrictEqual(selected.includes("src/.fixtures/skipped.test.ts"), false);
+    });
+  });
+});
+
 describe("listTestFiles agrees with the platform glob", () => {
   // `node:fs` globSync is the reference implementation: ripgrep's `-g` returns
   // the same set for these patterns, and pinning against a built-in keeps the


### PR DESCRIPTION
## What

`listTestFiles` silently dropped glob patterns, so the Node lane selected **2 test files where it should have selected ~1229** — and reported green the whole time.

Fixes item 2 of #3351 ("widen the Node lane"), which turns out to have been a defect rather than the triage task it was filed as.

## The bug

`listTestFiles` resolves globs by shelling out to `rg`. When `rg` is not on PATH — the case on the CI runners — `runRg` returns `null`, the glob branch falls through to a `statSync` that throws on the glob string, and the pattern contributes nothing.

A fallback existed, but only fired when the **entire** result set was empty:

```js
if (files.size === 0) {
  return listWithFallback(patterns, cwd);
}
```

`test:node` passes two explicit files alongside the glob. Those made the set non-empty, so the fallback never ran.

## Evidence

From the last green run on `main` (31951078970) — same commit, same helper, both lanes green:

```
tests (bun):   Bun test files: 1360 passed, 0 failed
tests (node):  ℹ tests 8   ℹ pass 8   ℹ fail 0
```

Those 8 were `ensureNpmNodeModulesLinks` (7) and `ensureEsbuildBinary runtime guards` (1) — exactly the two explicitly-listed files. The glob contributed zero.

The asymmetry is the shape of the pattern each task passes. `test:bun` passes `src/` — a **directory**, which takes a `statSync` branch that has its own fallback. `test:node` passes `'src/**/*.test.ts'` — a **glob**, which did not.

Reproduced directly:

```
3-pattern listTestFiles: 2      // glob + 2 explicit files
1-pattern listTestFiles: 1591   // glob alone -> whole-set fallback fires
```

`src/platform/compat/http/pinned-fetch.ts` — the transport #3351 is actually about — has never executed under Node despite being listed as covered.

## Three fixes, each with red-green coverage

1. **Per-pattern fallback in the glob branch**, instead of per-result-set. This is the 1229-file drop.
2. **`**/` now translates to `(?:.*\/)?`** so it matches zero segments. As `.*` it required a trailing separator and dropped every depth-1 match — `src/a.test.ts` was excluded while `src/nested/b.test.ts` was kept. The fallback therefore disagreed with **both** ripgrep and `node:fs` globSync, which I confirmed against each.
3. **Guarded the fallback's `walk`** against a missing base directory. Unguarded it threw out of the runner rather than yielding an empty selection — surfaced by the new "glob that matches nothing" case, which is reachable now that globs route here.

## Test design

`rgAvailable` is module-level state latched on the first ENOENT, so each case runs in **its own child process with an empty PATH**. That makes the rg-absent branch deterministic rather than dependent on what happens to be installed.

Selection is pinned against `node:fs` globSync as the reference implementation, across five patterns.

RED (before the fix):

```
✖ resolves a glob pattern alongside an explicit file pattern
  actual:   [ 'extra/explicit.test.mjs' ]
  expected: [ 'extra/explicit.test.mjs', 'src/a.test.ts',
              'src/nested/b.test.ts', 'src/nested/deep/c.test.ts' ]
```

GREEN (after):

```
ℹ tests 11   ℹ pass 11   ℹ fail 0
```

## Blast radius — read this before approving

This does not merely fix a helper. `test:node` already passes the glob, so **fixing the helper widens the lane from 2 files to ~1229 in the same change.** Selection goes 2 → 1596 before the runner's exclude filters.

I am running the widened lane locally and will post the result on this PR before asking for merge. If it is red, the honest resolution is a documented exclusion baseline in the same shape the repo already uses for `check-skipped-tests-baseline` — not narrowing the glob back down and calling it green.

Related: veryfront-issue-inbox#492 is the other known cross-runtime lane problem. Worth the contrast — that is a lane running 1360 files that occasionally lies; this was a lane running 2 files that always looked green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recursive file discovery, including directories without nested folders.
  * Corrected globstar handling and path matching at segment boundaries.
  * Dot-prefixed files are included, while hidden directories are skipped.
  * Missing paths are handled gracefully; other filesystem errors are reported.
  * Improved fallback behavior for mixed inputs and multiple patterns when the preferred search utility is unavailable.

* **Tests**
  * Added comprehensive coverage for fallback discovery, glob matching, hidden paths, error handling, and cross-method consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->