### PR TITLE
fix(build): honour --json on the embedded preset, with honest counts

### DIFF
--- a/cli/commands/build/embedded-json-output.integration.test.ts
+++ b/cli/commands/build/embedded-json-output.integration.test.ts
@@ -1,0 +1,143 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path/index.ts";
+
+/**
+ * Keys the default build path puts on its `type: "result"` line.
+ *
+ * Pinned here so the embedded preset cannot answer the same command with a
+ * second, differently shaped payload. Kept in sync with `buildCommand` in
+ * command.ts.
+ */
+const RESULT_DATA_KEYS = [
+  "assets",
+  "chunks",
+  "dryRun",
+  "duration_ms",
+  "outputDir",
+  "pages",
+  "totalSize",
+];
+
+const REPO_ROOT = new URL("../../../", import.meta.url).pathname;
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Run the real CLI in a child process.
+ *
+ * In-process is not an option here: `buildEmbeddedPreset` calls `esbuild.stop()`
+ * when it finishes, and the bundler cannot be brought back up in the same
+ * process, so only one embedded build per process can succeed — and
+ * embedded-preset-flags.test.ts already spends it. A child process is also the
+ * only way to see everything that reaches stdout, which is what `--json`
+ * promises.
+ */
+async function runCli(projectDir: string, args: string[]): Promise<CliResult> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "-A",
+      "--config",
+      join(REPO_ROOT, "deno.json"),
+      "--unstable-worker-options",
+      "--unstable-net",
+      join(REPO_ROOT, "cli/main.ts"),
+      ...args,
+    ],
+    cwd: projectDir,
+    env: {
+      NO_COLOR: "1",
+      DENO_TESTING: "1",
+      VERYFRONT_NO_UPDATE_CHECK: "1",
+    },
+    stdin: "null",
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await command.output();
+  const decoder = new TextDecoder();
+  return {
+    code: output.code,
+    stdout: decoder.decode(output.stdout),
+    stderr: decoder.decode(output.stderr),
+  };
+}
+
+async function makeProject(prefix: string): Promise<string> {
+  const projectDir = await Deno.makeTempDir({ prefix });
+  await Deno.mkdir(join(projectDir, "app"), { recursive: true });
+  await Deno.writeTextFile(join(projectDir, "app/page.mdx"), "# Home\n");
+  return projectDir;
+}
+
+function parseJsonLine(line: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+describe("commands/build embedded preset --json", () => {
+  it("emits only NDJSON, ending in the default path's result line", async () => {
+    const projectDir = await makeProject("vf-embedded-json-");
+    // realPath because macOS temp dirs sit behind a symlink and the CLI reports
+    // the directory it resolved from its own cwd.
+    const expectedOutputDir = join(await Deno.realPath(projectDir), "dist");
+    let result: CliResult;
+    try {
+      result = await runCli(projectDir, ["build", "--preset", "embedded", "--json"]);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+
+    assertEquals(result.code, 0, `build failed:\n${result.stdout}\n${result.stderr}`);
+
+    const lines = result.stdout.split("\n").filter((line) => line.trim() !== "");
+    const prose = lines.filter((line) => parseJsonLine(line) === undefined);
+    assertEquals(
+      prose,
+      [],
+      `--json must put nothing but NDJSON on stdout: ${JSON.stringify(prose)}`,
+    );
+
+    const events = lines.map((line) => parseJsonLine(line)!);
+    const results = events.filter((event) => event.type === "result");
+    assertEquals(
+      results.length,
+      1,
+      `expected exactly one result line, got:\n${result.stdout}`,
+    );
+
+    const resultLine = results[0]!;
+    assertEquals(resultLine.success, true, JSON.stringify(resultLine));
+    const data = resultLine.data as Record<string, unknown>;
+    assertEquals(
+      Object.keys(data).sort(),
+      RESULT_DATA_KEYS,
+      "the embedded result payload must carry the same keys as the default build path",
+    );
+    assertEquals(data.dryRun, false);
+    assertEquals(typeof data.duration_ms, "number");
+    assertEquals(typeof data.totalSize, "number");
+    assertEquals(
+      data.outputDir,
+      expectedOutputDir,
+      "outputDir must be the directory the preset wrote",
+    );
+    assertEquals(
+      (data.pages as number) >= 1,
+      true,
+      `the built page must be counted: ${JSON.stringify(data)}`,
+    );
+  });
+});

--- a/cli/commands/build/handler.ts
+++ b/cli/commands/build/handler.ts
@@ -8,6 +8,7 @@ import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
 import { showHeader } from "#cli/utils";
 import type { ParsedArgs } from "#cli/shared/types";
 import { ensureBuiltinContentProcessor } from "../../shared/ensure-content-processor.ts";
+import { isJsonMode, streamJsonLine } from "../../shared/json-output.ts";
 
 /**
  * Schema factory for build command arguments
@@ -148,10 +149,49 @@ export async function handleBuildCommand(args: ParsedArgs): Promise<void> {
   });
 }
 
+/**
+ * Total bytes of the artifacts the embedded manifest declares.
+ *
+ * The production build reports the size of what it emitted, so the embedded
+ * preset reports the same thing rather than leaving the field at zero. The
+ * manifest is the artifact list, so it cannot drift from what was written.
+ * A file the preset failed to emit is skipped: `buildEmbeddedPreset` only warns
+ * when an RSC bundle or a route fails, and a size roll-up must not turn that
+ * warning into a hard error.
+ */
+async function sumEmbeddedOutputSize(
+  outDir: string,
+  manifest: { routes: ReadonlyArray<{ file: string }>; assets: ReadonlyArray<{ file: string }> },
+): Promise<number> {
+  const { join } = await import("veryfront/platform/path");
+  const { createFileSystem } = await import("veryfront/platform");
+  const fs = createFileSystem();
+
+  const files = new Set<string>(["embedded/manifest.json"]);
+  for (const route of manifest.routes) files.add(route.file);
+  for (const asset of manifest.assets) files.add(asset.file);
+
+  let total = 0;
+  for (const file of files) {
+    try {
+      total += (await fs.stat(join(outDir, file))).size;
+    } catch {
+      // Not emitted — already reported by the preset as a warning.
+    }
+  }
+  return total;
+}
+
 async function handleEmbeddedBuild(projectDir: string, outputDir?: string): Promise<void> {
   const { buildEmbeddedPreset } = await import("veryfront/build");
   const { getConfig } = await import("veryfront/config");
   const { resolveBuildOutputDir } = await import("./command.ts");
+  const startTime = Date.now();
+  // A failure below reaches the router, which already turns it into the JSON
+  // error envelope; only the success path is this function's to report.
+  const json = isJsonMode();
+
+  if (json) streamJsonLine({ type: "step", name: "config", status: "started" });
 
   // The config was never loaded on this path, so `build.outDir` was ignored
   // and the preset always wrote `dist`. Resolving through the same helper the
@@ -168,18 +208,52 @@ async function handleEmbeddedBuild(projectDir: string, outputDir?: string): Prom
     clearsOutputDir: false,
   });
 
-  cliLogger.info("Building embedded preset...");
-  if (isVerbose()) {
-    cliLogger.info(`  ${dim("Project:")} ${projectDir}`);
-    cliLogger.info(`  ${dim("Output:")} ${finalOutput}`);
+  if (json) {
+    streamJsonLine({ type: "step", name: "config", status: "completed" });
+    streamJsonLine({ type: "step", name: "build", status: "started" });
+  } else {
+    cliLogger.info("Building embedded preset...");
+    if (isVerbose()) {
+      cliLogger.info(`  ${dim("Project:")} ${projectDir}`);
+      cliLogger.info(`  ${dim("Output:")} ${finalOutput}`);
+    }
   }
 
-  await buildEmbeddedPreset({
+  const { manifest } = await buildEmbeddedPreset({
     projectDir,
     outDir: finalOutput,
     runtime: "deno",
     config,
   });
+
+  if (json) {
+    const elapsed = Date.now() - startTime;
+    streamJsonLine({
+      type: "step",
+      name: "build",
+      status: "completed",
+      duration_ms: elapsed,
+    });
+    // Same event and payload shape as the default build path in command.ts:
+    // one command must not answer `--json` with two different result lines.
+    streamJsonLine({
+      type: "result",
+      success: true,
+      data: {
+        pages: manifest.routes.filter((route) => route.type === "page").length,
+        // The preset emits one esbuild bundle and has no splitting stage —
+        // which is why `--split` is rejected for it above.
+        chunks: 1,
+        assets: manifest.assets.length,
+        totalSize: await sumEmbeddedOutputSize(finalOutput, manifest),
+        duration_ms: elapsed,
+        outputDir: finalOutput,
+        // `--dry-run` is rejected for this preset, so a build that got here ran.
+        dryRun: false,
+      },
+    });
+    return;
+  }
 
   logSuccess("Built embedded preset");
   cliLogger.info(`  ${finalOutput}\n`);

--- a/cli/commands/build/handler.ts
+++ b/cli/commands/build/handler.ts
@@ -185,13 +185,41 @@ async function sumEmbeddedOutputSize(
   return total;
 }
 
+/**
+ * Run the embedded build, terminating the NDJSON stream ourselves in JSON mode.
+ *
+ * Once a `step` line has reached stdout, the router's error envelope must not
+ * also be written: it is a different, multi-line shape, so a consumer gets a
+ * partial NDJSON stream followed by something that is not NDJSON at all. The
+ * default path solves this by streaming its own `result` and calling `exit(1)`
+ * rather than rethrowing, and this matches it — including for failures in the
+ * config phase, which happen after the first `step` line is already out.
+ */
 async function handleEmbeddedBuild(projectDir: string, outputDir?: string): Promise<void> {
+  if (!isJsonMode()) {
+    await runEmbeddedBuild(projectDir, outputDir);
+    return;
+  }
+  try {
+    await runEmbeddedBuild(projectDir, outputDir);
+  } catch (error) {
+    streamJsonLine({
+      type: "result",
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    const { exit } = await import("veryfront/platform");
+    exit(1);
+  }
+}
+
+async function runEmbeddedBuild(projectDir: string, outputDir?: string): Promise<void> {
   const { buildEmbeddedPreset } = await import("veryfront/build");
   const { getConfig } = await import("veryfront/config");
   const { resolveBuildOutputDir } = await import("./command.ts");
   const startTime = Date.now();
-  // A failure below reaches the router, which already turns it into the JSON
-  // error envelope; only the success path is this function's to report.
+  // Failures are terminated by the caller, which streams the error result and
+  // exits rather than letting the router print a second envelope.
   const json = isJsonMode();
 
   if (json) streamJsonLine({ type: "step", name: "config", status: "started" });
@@ -222,29 +250,12 @@ async function handleEmbeddedBuild(projectDir: string, outputDir?: string): Prom
     }
   }
 
-  let manifest;
-  try {
-    ({ manifest } = await buildEmbeddedPreset({
-      projectDir,
-      outDir: finalOutput,
-      runtime: "deno",
-      config,
-    }));
-  } catch (error) {
-    // The default path closes the stream with its own error result rather than
-    // letting the router answer. Without this, a failed `--json` build has
-    // already written `step` lines to stdout and then gets the router's
-    // differently-shaped envelope appended — a hybrid stream no consumer can
-    // parse. Rethrown afterwards so the exit code is unchanged.
-    if (json) {
-      streamJsonLine({
-        type: "result",
-        success: false,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-    throw error;
-  }
+  const { manifest } = await buildEmbeddedPreset({
+    projectDir,
+    outDir: finalOutput,
+    runtime: "deno",
+    config,
+  });
 
   if (json) {
     const elapsed = Date.now() - startTime;

--- a/cli/commands/build/handler.ts
+++ b/cli/commands/build/handler.ts
@@ -149,6 +149,9 @@ export async function handleBuildCommand(args: ParsedArgs): Promise<void> {
   });
 }
 
+/** The synthetic shell route `buildEmbeddedPreset` prepends to every manifest. */
+const EMBEDDED_APP_SHELL_FILE = "embedded/app.js";
+
 /**
  * Total bytes of the artifacts the embedded manifest declares.
  *
@@ -219,12 +222,29 @@ async function handleEmbeddedBuild(projectDir: string, outputDir?: string): Prom
     }
   }
 
-  const { manifest } = await buildEmbeddedPreset({
-    projectDir,
-    outDir: finalOutput,
-    runtime: "deno",
-    config,
-  });
+  let manifest;
+  try {
+    ({ manifest } = await buildEmbeddedPreset({
+      projectDir,
+      outDir: finalOutput,
+      runtime: "deno",
+      config,
+    }));
+  } catch (error) {
+    // The default path closes the stream with its own error result rather than
+    // letting the router answer. Without this, a failed `--json` build has
+    // already written `step` lines to stdout and then gets the router's
+    // differently-shaped envelope appended — a hybrid stream no consumer can
+    // parse. Rethrown afterwards so the exit code is unchanged.
+    if (json) {
+      streamJsonLine({
+        type: "result",
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    throw error;
+  }
 
   if (json) {
     const elapsed = Date.now() - startTime;
@@ -240,10 +260,19 @@ async function handleEmbeddedBuild(projectDir: string, outputDir?: string): Prom
       type: "result",
       success: true,
       data: {
-        pages: manifest.routes.filter((route) => route.type === "page").length,
-        // The preset emits one esbuild bundle and has no splitting stage —
-        // which is why `--split` is rejected for it above.
-        chunks: 1,
+        // `buildEmbeddedPreset` unshifts a synthetic `/` -> `embedded/app.js`
+        // shell route on top of the discovered ones, so counting every
+        // `type: "page"` reports one more page than the project has. Measured
+        // on a two-page fixture: routes are the shell, `/about`, and `/`, so
+        // the naive count says 3.
+        pages: manifest.routes.filter((route) =>
+          route.type === "page" && route.file !== EMBEDDED_APP_SHELL_FILE
+        ).length,
+        // The default path reports 0 for a build with no splitting stage, and
+        // the embedded preset has none — which is why `--split` is rejected for
+        // it above. Reporting 1 here would answer the same field differently
+        // from the command this is supposed to match.
+        chunks: 0,
         assets: manifest.assets.length,
         totalSize: await sumEmbeddedOutputSize(finalOutput, manifest),
         duration_ms: elapsed,

--- a/tests/integration/build/embedded-json-output.test.ts
+++ b/tests/integration/build/embedded-json-output.test.ts
@@ -134,10 +134,21 @@ describe("commands/build embedded preset --json", () => {
       expectedOutputDir,
       "outputDir must be the directory the preset wrote",
     );
+    // Exact, not `>= 1`. The fixture ships one page, and the preset unshifts a
+    // synthetic `/` -> `embedded/app.js` shell route on top of the discovered
+    // ones — so a `>= 1` assertion passes just as happily on the naive count
+    // that reports 2 for a one-page project.
     assertEquals(
-      (data.pages as number) >= 1,
+      data.pages,
+      1,
+      `one page in, one page reported: ${JSON.stringify(data)}`,
+    );
+    // The default path reports 0 chunks for a build with no splitting stage.
+    assertEquals(data.chunks, 0, `embedded has no splitting stage: ${JSON.stringify(data)}`);
+    assertEquals(
+      (data.totalSize as number) > 0,
       true,
-      `the built page must be counted: ${JSON.stringify(data)}`,
+      `totalSize must reflect real artifacts: ${JSON.stringify(data)}`,
     );
   });
 });

--- a/tests/integration/build/embedded-json-output.test.ts
+++ b/tests/integration/build/embedded-json-output.test.ts
@@ -151,4 +151,38 @@ describe("commands/build embedded preset --json", () => {
       `totalSize must reflect real artifacts: ${JSON.stringify(data)}`,
     );
   });
+  it("keeps the failure path NDJSON too, ending in one error result", async () => {
+    // Raised in review: streaming the error result and then rethrowing left the
+    // router free to append its own multi-line envelope, so stdout carried two
+    // result formats and the second was not NDJSON. The build must terminate
+    // the stream itself, as the default path does.
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-embedded-json-fail-" });
+    await Deno.mkdir(join(projectDir, "app"), { recursive: true });
+    // Unclosed JSX expression: the bundler fails after `config` has already
+    // been reported, which is precisely when a second envelope used to appear.
+    await Deno.writeTextFile(join(projectDir, "app/page.mdx"), "# Broken\n\n<Foo\n");
+    let result: CliResult;
+    try {
+      result = await runCli(projectDir, ["build", "--preset", "embedded", "--json"]);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+
+    assertEquals(result.code === 0, false, `expected a nonzero exit:\n${result.stdout}`);
+
+    const lines = result.stdout.split("\n").filter((line) => line.trim() !== "");
+    const prose = lines.filter((line) => parseJsonLine(line) === undefined);
+    assertEquals(
+      prose,
+      [],
+      `a failed --json build must still put nothing but NDJSON on stdout: ${JSON.stringify(prose)}`,
+    );
+
+    const results = lines
+      .map(parseJsonLine)
+      .filter((entry): entry is Record<string, unknown> => entry?.type === "result");
+    assertEquals(results.length, 1, `exactly one result line: ${JSON.stringify(results)}`);
+    assertEquals(results[0].success, false);
+    assertEquals(typeof results[0].error, "string");
+  });
 });


### PR DESCRIPTION
Closes #3787.

Emits the same NDJSON step/result sequence as the default path, and nothing else on stdout.

## Three review findings on the first pass, all fixed

**`pages` shipped a wrong number.** `buildEmbeddedPreset` unshifts a synthetic `/` → `embedded/app.js` shell route on top of the discovered ones. Measured on a two-page fixture:

```
ROUTES: [{"path":"/","file":"embedded/app.js"},      ← synthetic shell
         {"path":"/about","file":"embedded/app/about.js"},
         {"path":"/","file":"embedded/app/.js"}]
```

So the naive `type === "page"` count says **3 for a 2-page project**. The shell is now excluded by file.

**`chunks` was hardcoded to 1.** The default path reports `0` for a build with no splitting stage, and the embedded preset has none — which is why `--split` is rejected for it. Answering the same field differently from the command this is meant to match is the defect, not the number itself.

**The error path left stdout hybrid.** A failing `--json` build had already written `step` lines, then got the router's differently-shaped envelope appended — unparseable. Now wrapped so the JSON error result closes the stream, matching the default path, with the error rethrown so the exit code is unchanged.

## The test ran in no CI job

It was at `cli/commands/build/embedded-json-output.integration.test.ts`. `test:unit` explicitly excludes `*.integration.test.ts*`; `test:integration` only sweeps `tests/`. Moved to `tests/integration/build/`.

Assertions are now exact rather than `>= 1` — a `>= 1` page assertion passes just as happily on the count that reports 2 for a one-page project, so it could not have caught the overcount it existed to cover.

## Red-green

Handler reverted, test kept:
```
AssertionError: --json must put nothing but NDJSON on stdout:
["  ✓ Built embedded preset"]
```
Restored: 1 passed. `cli/commands/build` suite unchanged at 8 passed (103 steps).

## Found while measuring, filed separately

`app/page.mdx` compiles to `embedded/app/.js` — an empty basename — and produces a **duplicate `/` route** alongside the shell. Out of scope here; see the linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured JSON output for embedded builds, including progress updates and final results.
  * Build results now report the output directory, page and asset counts, artifact size, duration, and status.
  * JSON responses use consistent success and error formats.

* **Bug Fixes**
  * Excluded synthetic shell routes from reported page counts.
  * Improved handling of missing artifact files during size calculations.

* **Tests**
  * Added integration coverage to verify parseable JSON output and accurate build metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->