### PR TITLE
feat(rendering): warn on legacy project alias fallback

### DIFF
--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -180,6 +180,16 @@ These directories are not auto-discovered. They are common project conventions.
 | `styles/`     | Global CSS files                    |
 | `middleware/` | Custom middleware functions         |
 
+## Project path aliases
+
+Use `@/` for a project-root-relative import. For example,
+`@/components/Button` resolves to `components/Button` in the project root.
+
+Veryfront temporarily supports legacy imports that add or remove the leading
+`components/` segment during resolution. When this fallback resolves an import,
+Veryfront logs a deprecation warning with the project-root-relative replacement.
+Update the import to the suggested specifier before the fallback is removed.
+
 ## Generated directories
 
 These directories hold derived output only, so deleting them is safe: the next

--- a/src/rendering/orchestrator/file-resolver/index.test.ts
+++ b/src/rendering/orchestrator/file-resolver/index.test.ts
@@ -57,6 +57,42 @@ describe("rendering/orchestrator/file-resolver", () => {
     assertEquals(resolveCalls[0], "/project/components/Welcome.tsx");
   });
 
+  it("reports components-prefix stripping in both filesystem resolution paths", async () => {
+    for (const mode of ["resolveFile", "stat"] as const) {
+      let fallbackCount = 0;
+      const resolveRootFile = (path: string) =>
+        path === "/project/Welcome.tsx" ? "/project/Welcome.tsx" : null;
+      const adapter = {
+        fs: {
+          ...(mode === "resolveFile"
+            ? {
+              resolveFile: async (path: string) => resolveRootFile(path),
+            }
+            : {}),
+          stat: async (path: string) => {
+            if (resolveRootFile(path)) {
+              return {
+                isFile: true,
+                isDirectory: false,
+                isSymlink: false,
+                size: 1,
+                mtime: new Date(),
+              };
+            }
+            throw new Error("File not found");
+          },
+        },
+      } as unknown as RuntimeAdapter;
+
+      const result = await findSourceFile("components/Welcome", "/project", adapter, {
+        onLegacyComponentsFallback: () => fallbackCount++,
+      });
+
+      assertEquals(result, "/project/Welcome.tsx");
+      assertEquals(fallbackCount, 1);
+    }
+  });
+
   it("does not resolve source imports through an implicit pages/ fallback", async () => {
     const resolveCalls: Array<{ basePath: string; allowPagesPrefix?: boolean }> = [];
 

--- a/src/rendering/orchestrator/file-resolver/index.ts
+++ b/src/rendering/orchestrator/file-resolver/index.ts
@@ -55,6 +55,7 @@ export async function findSourceFile(
   basePath: string,
   projectDir: string,
   adapter: RuntimeAdapter,
+  options: { onLegacyComponentsFallback?: () => void } = {},
 ): Promise<string | null> {
   // When the specifier already carries an explicit source extension
   // (e.g. `@/components/Welcome.tsx`), the literal on-disk path must be a
@@ -68,12 +69,14 @@ export async function findSourceFile(
     if (hasExplicitExt) directBases.push(join(projectDir, basePath));
     directBases.push(join(projectDir, stem));
 
+    const legacyBases: string[] = [];
     const stemWithoutComponents = stem.replace(/^components\//, "");
     if (stemWithoutComponents !== stem) {
       if (hasExplicitExt) {
-        directBases.push(join(projectDir, basePath.replace(/^components\//, "")));
+        legacyBases.push(join(projectDir, basePath.replace(/^components\//, "")));
       }
-      directBases.push(join(projectDir, stemWithoutComponents));
+      legacyBases.push(join(projectDir, stemWithoutComponents));
+      directBases.push(...legacyBases);
     }
 
     for (const candidateBase of directBases) {
@@ -81,6 +84,7 @@ export async function findSourceFile(
         allowPagesPrefix: false,
       });
       if (resolved) {
+        if (legacyBases.includes(candidateBase)) options.onLegacyComponentsFallback?.();
         logger.debug("[FileResolver] Found file via resolveFile:", resolved);
         return resolved;
       }
@@ -91,15 +95,20 @@ export async function findSourceFile(
   if (hasExplicitExt) candidates.push(join(projectDir, basePath));
   candidates.push(...buildCandidatePaths(projectDir, stem, SOURCE_EXTENSIONS));
 
+  const legacyCandidates: string[] = [];
   const stemWithoutComponents = stem.replace(/^components\//, "");
   if (stemWithoutComponents !== stem) {
     if (hasExplicitExt) {
-      candidates.push(join(projectDir, basePath.replace(/^components\//, "")));
+      legacyCandidates.push(join(projectDir, basePath.replace(/^components\//, "")));
     }
-    candidates.push(...buildCandidatePaths(projectDir, stemWithoutComponents, SOURCE_EXTENSIONS));
+    legacyCandidates.push(
+      ...buildCandidatePaths(projectDir, stemWithoutComponents, SOURCE_EXTENSIONS),
+    );
+    candidates.push(...legacyCandidates);
   }
 
   const result = await findFirstExisting(candidates, (p) => adapter.fs.stat(p));
+  if (result && legacyCandidates.includes(result)) options.onLegacyComponentsFallback?.();
   logger.debug(
     result ? "[FileResolver] Found file:" : "[FileResolver] File not found:",
     result ?? basePath,

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
@@ -3,6 +3,7 @@ import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/te
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { dirname, join } from "#veryfront/compat/path/index.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
+import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/logger/index.ts";
 import {
   type ResolvedModuleDependency,
   resolveModuleDependencies,
@@ -243,6 +244,65 @@ describe("module-loader/dependency-resolver", () => {
         assertEquals(deps.length, 2);
         assertStringIncludes(deps[0]?.depFilePath ?? "", "/components/Button.tsx");
         assertStringIncludes(deps[1]?.depFilePath ?? "", "/lib/value.ts");
+      },
+    );
+  });
+
+  it("warns only when a deprecated components alias fallback resolves", async () => {
+    await withDependencyFixture(
+      {
+        "app/page.tsx": [
+          `import { Root } from "@/Root";`,
+          `import { LegacyPrefix } from "@/LegacyPrefix";`,
+          `import { LegacyStrip } from "@/components/LegacyStrip";`,
+          `export const page = Root + LegacyPrefix + LegacyStrip;`,
+        ].join("\n"),
+        "Root.ts": `export const Root = "root";`,
+        "components/LegacyPrefix.ts": `export const LegacyPrefix = "prefix";`,
+        "LegacyStrip.ts": `export const LegacyStrip = "strip";`,
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+        const records: LogEntry[] = [];
+        const unsubscribe = __subscribeLogRecordEmitter((entry) => records.push(entry));
+
+        try {
+          const deps = await resolveModuleDependencies({
+            adapter,
+            fileContent,
+            filePath,
+            projectDir,
+          });
+          assertEquals(deps.every((dependency) => dependency.depFilePath !== null), true);
+        } finally {
+          unsubscribe();
+        }
+
+        const warnings = records
+          .filter((entry) =>
+            entry.component === "module-loader" &&
+            entry.level === "warn" &&
+            entry.message ===
+              "The @/ alias resolved through the deprecated components/ fallback. Update the import to match the project-relative file path."
+          )
+          .map((entry) => ({
+            specifier: entry.context?.specifier,
+            suggestedSpecifier: entry.context?.suggestedSpecifier,
+          }))
+          .sort((left, right) => String(left.specifier) < String(right.specifier) ? -1 : 1);
+
+        assertEquals(warnings, [
+          {
+            specifier: "@/LegacyPrefix",
+            suggestedSpecifier: "@/components/LegacyPrefix",
+          },
+          {
+            specifier: "@/components/LegacyStrip",
+            suggestedSpecifier: "@/LegacyStrip",
+          },
+        ]);
       },
     );
   });

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.ts
@@ -155,8 +155,31 @@ async function resolveAliasImport(
 ): Promise<ResolvedModuleDependency> {
   const relativePath = imp.path.substring(2); // Remove @/ prefix.
 
-  const depFilePath = (await findSourceFile(relativePath, projectDir, adapter)) ??
-    (await findSourceFile(`components/${relativePath}`, projectDir, adapter));
+  const warnLegacyFallback = (suggestedSpecifier: string) => {
+    logger.warn(
+      "The @/ alias resolved through the deprecated components/ fallback. Update the import to match the project-relative file path.",
+      { specifier: imp.path, suggestedSpecifier },
+    );
+  };
+
+  const directPath = await findSourceFile(relativePath, projectDir, adapter, {
+    onLegacyComponentsFallback: () => {
+      warnLegacyFallback(`@/${relativePath.replace(/^components\//, "")}`);
+    },
+  });
+  let depFilePath = directPath;
+
+  if (!depFilePath) {
+    let resolvedThroughStripFallback = false;
+    depFilePath = await findSourceFile(`components/${relativePath}`, projectDir, adapter, {
+      onLegacyComponentsFallback: () => {
+        resolvedThroughStripFallback = true;
+      },
+    });
+    if (depFilePath && !resolvedThroughStripFallback) {
+      warnLegacyFallback(`@/components/${relativePath}`);
+    }
+  }
 
   return { ...imp, relativePath, depFilePath, isLocalLib: false };
 }


### PR DESCRIPTION
## Summary

- preserve the legacy components/ project-alias fallback for compatibility, but emit one structured deprecation warning only when that fallback resolves the import
- suggest the equivalent project-relative @/ specifier for both legacy prefix insertion and legacy prefix stripping
- document project alias resolution and the migration path before the fallback is removed

## Behavior

Direct project-relative aliases such as @/Root remain silent. Legacy imports such as @/LegacyPrefix and @/components/LegacyStrip continue to resolve, and the warning identifies the original specifier plus a safe suggested replacement. The warning does not expose local absolute paths.

## RED-GREEN TDD

- RED: focused dependency-resolver coverage expected the two legacy fallback warnings and received none
- GREEN: the focused dependency and file-resolver suite passes (3 modules, 20 steps)
- GREEN: the expanded file-resolver and module-loader surface passes (14 modules, 130 steps)

## Verification

- deno task lint:ci
- targeted typecheck, formatting, and git diff --check
- public documentation validation across 125 files

This is a runtime warning and documentation change, not a Studio UI change. No screenshot is applicable.

Closes veryfront/veryfront-issue-inbox#79