### PR TITLE
fix(server): serve only the current content address on the versioned hydration path

### DIFF
--- a/src/server/handlers/request/prod-hydration-module.handler.test.ts
+++ b/src/server/handlers/request/prod-hydration-module.handler.test.ts
@@ -53,6 +53,14 @@ function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   };
 }
 
+function staleVersionedPath(): string {
+  const currentPath = getProdHydrationModulePath();
+  const currentHash = currentPath.match(/hydration-runtime\.([0-9a-f]{8})\.js$/)?.[1];
+  assertExists(currentHash);
+  const staleHash = currentHash === "00000000" ? "11111111" : "00000000";
+  return `/_veryfront/hydration-runtime.${staleHash}.js`;
+}
+
 describe("server/handlers/request/prod-hydration-module.handler", () => {
   it("serves the versioned production hydration runtime module with immutable caching", async () => {
     const handler = new ProdHydrationModuleHandler();
@@ -111,5 +119,67 @@ describe("server/handlers/request/prod-hydration-module.handler", () => {
     assertEquals(second.response?.headers.get("cache-control"), IMMUTABLE_CACHE_CONTROL);
     assertEquals(second.response?.headers.get("pragma"), null);
     assertEquals(second.response?.headers.get("expires"), null);
+  });
+
+  it("rejects a versioned path whose hash does not match the current runtime", async () => {
+    const handler = new ProdHydrationModuleHandler();
+    const result = await handler.handle(
+      new Request(`http://localhost${staleVersionedPath()}`),
+      makeCtx(),
+    );
+
+    assertEquals(result.continue, false, "the handler owns the versioned path space");
+    assertExists(result.response);
+    assertEquals(
+      result.response.status,
+      404,
+      "an unknown hash must be rejected, not served current-runtime bytes",
+    );
+    assertEquals(
+      result.response.headers.get("cache-control"),
+      NO_CACHE_CONTROL,
+      "a rejection must never be cached as immutable",
+    );
+
+    const body = await result.response.text();
+    assertEquals(
+      body.includes("renderPage"),
+      false,
+      "a stale content address must not resolve to unrelated runtime bytes",
+    );
+  });
+
+  it("does not answer 304 for a stale hash even when the current ETag matches", async () => {
+    const handler = new ProdHydrationModuleHandler();
+    const current = await handler.handle(
+      new Request(`http://localhost${getProdHydrationModulePath()}`),
+      makeCtx(),
+    );
+    const etag = current.response?.headers.get("etag");
+    assertExists(etag);
+
+    const stale = await handler.handle(
+      new Request(`http://localhost${staleVersionedPath()}`, {
+        headers: { "if-none-match": etag },
+      }),
+      makeCtx(),
+    );
+
+    assertEquals(
+      stale.response?.status,
+      404,
+      "the hash invariant is checked before ETag revalidation",
+    );
+  });
+
+  it("rejects a stale hash on HEAD requests without a body", async () => {
+    const handler = new ProdHydrationModuleHandler();
+    const result = await handler.handle(
+      new Request(`http://localhost${staleVersionedPath()}`, { method: "HEAD" }),
+      makeCtx(),
+    );
+
+    assertEquals(result.response?.status, 404, "HEAD must agree with GET on rejection");
+    assertEquals(await result.response?.text(), "", "HEAD responses carry no body");
   });
 });

--- a/src/server/handlers/request/prod-hydration-module.handler.test.ts
+++ b/src/server/handlers/request/prod-hydration-module.handler.test.ts
@@ -2,8 +2,10 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ProdHydrationModuleHandler } from "./prod-hydration-module.handler.ts";
+import { StaticHandler } from "./static.handler.ts";
 import type { HandlerContext } from "../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { RouteRegistry } from "#veryfront/routing/registry/index.ts";
 import {
   getProdHydrationModulePath,
   PROD_HYDRATION_MODULE_PATH,
@@ -59,6 +61,25 @@ function staleVersionedPath(): string {
   assertExists(currentHash);
   const staleHash = currentHash === "00000000" ? "11111111" : "00000000";
   return `/_veryfront/hydration-runtime.${staleHash}.js`;
+}
+
+function makeStaticHandler(content: string | null): StaticHandler {
+  const handler = new StaticHandler();
+  (handler as any).staticService = {
+    resolveFile: (pathname: string) =>
+      Promise.resolve(
+        content === null ? null : {
+          path: `/tmp/test-project/dist${pathname}`,
+          data: new TextEncoder().encode(content),
+          etag: '"release-runtime"',
+          contentType: "application/javascript; charset=utf-8",
+          cacheStrategy: "immutable",
+          source: "dist",
+        },
+      ),
+    isAssetRequest: () => true,
+  };
+  return handler;
 }
 
 describe("server/handlers/request/prod-hydration-module.handler", () => {
@@ -121,65 +142,83 @@ describe("server/handlers/request/prod-hydration-module.handler", () => {
     assertEquals(second.response?.headers.get("expires"), null);
   });
 
-  it("rejects a versioned path whose hash does not match the current runtime", async () => {
+  it("lets a non-current versioned path fall through to release static assets", async () => {
     const handler = new ProdHydrationModuleHandler();
     const result = await handler.handle(
       new Request(`http://localhost${staleVersionedPath()}`),
       makeCtx(),
     );
 
-    assertEquals(result.continue, false, "the handler owns the versioned path space");
-    assertExists(result.response);
-    assertEquals(
-      result.response.status,
-      404,
-      "an unknown hash must be rejected, not served current-runtime bytes",
-    );
-    assertEquals(
-      result.response.headers.get("cache-control"),
-      NO_CACHE_CONTROL,
-      "a rejection must never be cached as immutable",
-    );
-
-    const body = await result.response.text();
-    assertEquals(
-      body.includes("renderPage"),
-      false,
-      "a stale content address must not resolve to unrelated runtime bytes",
-    );
+    assertEquals(result.continue, true);
+    assertEquals(result.response, undefined);
   });
 
-  it("does not answer 304 for a stale hash even when the current ETag matches", async () => {
-    const handler = new ProdHydrationModuleHandler();
-    const current = await handler.handle(
+  it("serves a release-baked versioned runtime through the handler chain", async () => {
+    const releasePath = staleVersionedPath();
+    const registry = new RouteRegistry()
+      .register(new ProdHydrationModuleHandler())
+      .register(makeStaticHandler("export const releaseRuntime = true;"));
+    const response = await registry.execute(
+      new Request(`http://localhost${releasePath}`),
+      makeCtx(),
+    );
+
+    assertExists(response);
+    assertEquals(response.status, 200);
+    assertEquals(response.headers.get("cache-control"), IMMUTABLE_CACHE_CONTROL);
+    assertEquals(await response.text(), "export const releaseRuntime = true;");
+  });
+
+  it("returns a non-cacheable 404 after a versioned release asset misses", async () => {
+    const registry = new RouteRegistry()
+      .register(new ProdHydrationModuleHandler())
+      .register(makeStaticHandler(null));
+    const response = await registry.execute(
+      new Request(`http://localhost${staleVersionedPath()}`),
+      makeCtx(),
+    );
+
+    assertExists(response);
+    assertEquals(response.status, 404);
+    assertEquals(response.headers.get("cache-control"), NO_CACHE_CONTROL);
+    assertEquals(await response.text(), "Not Found");
+  });
+
+  it("does not answer 304 for a release runtime when the current ETag matches", async () => {
+    const currentHandler = new ProdHydrationModuleHandler();
+    const current = await currentHandler.handle(
       new Request(`http://localhost${getProdHydrationModulePath()}`),
       makeCtx(),
     );
     const etag = current.response?.headers.get("etag");
     assertExists(etag);
 
-    const stale = await handler.handle(
+    const registry = new RouteRegistry()
+      .register(currentHandler)
+      .register(makeStaticHandler("export const releaseRuntime = true;"));
+    const response = await registry.execute(
       new Request(`http://localhost${staleVersionedPath()}`, {
         headers: { "if-none-match": etag },
       }),
       makeCtx(),
     );
 
-    assertEquals(
-      stale.response?.status,
-      404,
-      "the hash invariant is checked before ETag revalidation",
-    );
+    assertExists(response);
+    assertEquals(response.status, 200);
+    assertEquals(await response.text(), "export const releaseRuntime = true;");
   });
 
-  it("rejects a stale hash on HEAD requests without a body", async () => {
-    const handler = new ProdHydrationModuleHandler();
-    const result = await handler.handle(
+  it("serves a release-baked runtime on HEAD requests without a body", async () => {
+    const registry = new RouteRegistry()
+      .register(new ProdHydrationModuleHandler())
+      .register(makeStaticHandler("export const releaseRuntime = true;"));
+    const response = await registry.execute(
       new Request(`http://localhost${staleVersionedPath()}`, { method: "HEAD" }),
       makeCtx(),
     );
 
-    assertEquals(result.response?.status, 404, "HEAD must agree with GET on rejection");
-    assertEquals(await result.response?.text(), "", "HEAD responses carry no body");
+    assertExists(response);
+    assertEquals(response.status, 200);
+    assertEquals(await response.text(), "", "HEAD responses carry no body");
   });
 });

--- a/src/server/handlers/request/prod-hydration-module.handler.ts
+++ b/src/server/handlers/request/prod-hydration-module.handler.ts
@@ -2,12 +2,13 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import {
   generateProdHydrationModule,
+  getProdHydrationModulePath,
   isVersionedProdHydrationModulePath,
   PROD_HYDRATION_MODULE_PATH,
   PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN,
 } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 import { computeStrongEtag, hasMatchingEtag } from "../utils/etag.ts";
-import { HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
+import { HTTP_NOT_FOUND, HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
 
 let cachedModule: { js: string; etag: string } | null = null;
 
@@ -41,9 +42,33 @@ export class ProdHydrationModuleHandler extends BaseHandler {
 
     const method = req.method.toUpperCase();
     const pathname = new URL(req.url).pathname;
-    const cacheStrategy = isVersionedProdHydrationModulePath(pathname) ? "immutable" : "no-cache";
+    const isVersioned = isVersionedProdHydrationModulePath(pathname);
+    const cacheStrategy = isVersioned ? "immutable" : "no-cache";
     const { js, etag } = getProdHydrationModuleBundle();
     const builder = this.createResponseBuilder(ctx).withCORS(req, ctx.securityConfig?.cors);
+
+    // The versioned path is content-addressed: its hash segment is derived from
+    // the bytes of the current runtime and cached as immutable. A hash that does
+    // not match the current runtime must be rejected rather than answered with
+    // unrelated current-runtime bytes — otherwise a previously issued URL would
+    // silently change content after a runtime upgrade. Callers recover via the
+    // canonical unversioned path (`PROD_HYDRATION_MODULE_PATH`, always current,
+    // revalidated) or by re-fetching the document, whose SSR output always
+    // embeds the current hash. Release-scoped hydration runtimes baked per
+    // release by `output-generator.ts` are owned separately (issue #277); this
+    // handler owns only the globally served current-runtime paths.
+    if (isVersioned && pathname !== getProdHydrationModulePath()) {
+      return this.respond(
+        builder
+          .withSecurity(ctx.securityConfig ?? undefined, req)
+          .withCache("no-cache")
+          .withContentType(
+            "text/plain; charset=utf-8",
+            method === "HEAD" ? null : "Not Found",
+            HTTP_NOT_FOUND,
+          ),
+      );
+    }
 
     if (hasMatchingEtag(req, etag)) {
       return this.respond(

--- a/src/server/handlers/request/prod-hydration-module.handler.ts
+++ b/src/server/handlers/request/prod-hydration-module.handler.ts
@@ -8,7 +8,7 @@ import {
   PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN,
 } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 import { computeStrongEtag, hasMatchingEtag } from "../utils/etag.ts";
-import { HTTP_NOT_FOUND, HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
+import { HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
 
 let cachedModule: { js: string; etag: string } | null = null;
 
@@ -40,35 +40,20 @@ export class ProdHydrationModuleHandler extends BaseHandler {
       return this.continue();
     }
 
-    const method = req.method.toUpperCase();
     const pathname = new URL(req.url).pathname;
     const isVersioned = isVersionedProdHydrationModulePath(pathname);
+
+    // Serve only the current content address dynamically. Non-current hashes
+    // may name valid release-baked assets, so StaticHandler owns their lookup
+    // and returns the final non-cacheable 404 when no stored asset matches.
+    if (isVersioned && pathname !== getProdHydrationModulePath()) {
+      return this.continue();
+    }
+
+    const method = req.method.toUpperCase();
     const cacheStrategy = isVersioned ? "immutable" : "no-cache";
     const { js, etag } = getProdHydrationModuleBundle();
     const builder = this.createResponseBuilder(ctx).withCORS(req, ctx.securityConfig?.cors);
-
-    // The versioned path is content-addressed: its hash segment is derived from
-    // the bytes of the current runtime and cached as immutable. A hash that does
-    // not match the current runtime must be rejected rather than answered with
-    // unrelated current-runtime bytes — otherwise a previously issued URL would
-    // silently change content after a runtime upgrade. Callers recover via the
-    // canonical unversioned path (`PROD_HYDRATION_MODULE_PATH`, always current,
-    // revalidated) or by re-fetching the document, whose SSR output always
-    // embeds the current hash. Release-scoped hydration runtimes baked per
-    // release by `output-generator.ts` are owned separately (issue #277); this
-    // handler owns only the globally served current-runtime paths.
-    if (isVersioned && pathname !== getProdHydrationModulePath()) {
-      return this.respond(
-        builder
-          .withSecurity(ctx.securityConfig ?? undefined, req)
-          .withCache("no-cache")
-          .withContentType(
-            "text/plain; charset=utf-8",
-            method === "HEAD" ? null : "Not Found",
-            HTTP_NOT_FOUND,
-          ),
-      );
-    }
 
     if (hasMatchingEtag(req, etag)) {
       return this.respond(


### PR DESCRIPTION
## Problem

The versioned hydration runtime URL (`/_veryfront/hydration-runtime.<hash>.js`) uses immutable caching, but the dynamic handler accepted any well-formed hash and returned the current runtime bytes. That broke the content-addressing contract. A first attempt rejected every non-current hash before release-baked assets could be served.

## Fix

The dynamic handler serves only the current content address. Non-current hashes fall through to `StaticHandler`, which serves the exact release-baked asset from `dist` when present. If the stored asset is absent, the static layer returns the final non-cacheable 404. GET, HEAD, and ETag behavior follow the same ownership boundary.

## Testing

- RED: four focused tests failed because the priority-300 handler returned 404 before the priority-500 static handler.
- GREEN: the current runtime, release-baked runtime, missing asset, ETag, GET, and HEAD cases all pass.
- `deno test --preload=src/testing/preload.ts --no-check --allow-all src/server/handlers/request/prod-hydration-module.handler.test.ts src/server/handlers/request/static.handler.test.ts src/server/services/static/static-file.service.test.ts`, 3 tests with 53 steps.
- `deno fmt --check src/server/handlers/request/prod-hydration-module.handler.ts src/server/handlers/request/prod-hydration-module.handler.test.ts`
- `deno lint src/server/handlers/request/prod-hydration-module.handler.ts src/server/handlers/request/prod-hydration-module.handler.test.ts`
- `deno check src/server/handlers/request/prod-hydration-module.handler.ts src/server/handlers/request/prod-hydration-module.handler.test.ts`
- `git diff --check`

Closes veryfront/veryfront-issue-inbox#276