### PR TITLE
perf(platform): await the file-list warmup instead of per-file API probing

### DIFF
--- a/src/cache/request-cache-batcher.ts
+++ b/src/cache/request-cache-batcher.ts
@@ -16,6 +16,7 @@ interface PendingRequest {
 interface RequestCacheContext {
   cache: Map<string, string | null>;
   pending: Map<string, Promise<string | null>>;
+  mutationVersions: Map<string, number>;
   batchQueue: PendingRequest[];
   batchTimer: ReturnType<typeof setTimeout> | null;
 }
@@ -28,6 +29,7 @@ export function runWithCacheBatching<T>(fn: () => Promise<T>): Promise<T> {
   const context: RequestCacheContext = {
     cache: new Map(),
     pending: new Map(),
+    mutationVersions: new Map(),
     batchQueue: [],
     batchTimer: null,
   };
@@ -57,7 +59,8 @@ export async function getCachedWithBatching(
   const existingPending = ctx.pending.get(key);
   if (existingPending) return existingPending;
 
-  const promise = new Promise<string | null>((resolve, reject) => {
+  const mutationVersion = ctx.mutationVersions.get(key) ?? 0;
+  const backendPromise = new Promise<string | null>((resolve, reject) => {
     ctx.batchQueue.push({ key, resolve, reject });
 
     if (ctx.batchQueue.length >= MAX_BATCH_SIZE) {
@@ -73,14 +76,23 @@ export async function getCachedWithBatching(
     }, BATCH_DELAY_MS);
   });
 
+  // An explicit request-local set or delete supersedes a backend read that was
+  // already in flight. Return that newer local view instead of letting the
+  // pending result overwrite it when the backend eventually responds.
+  const promise = backendPromise.then((result) => {
+    if ((ctx.mutationVersions.get(key) ?? 0) !== mutationVersion) {
+      return ctx.cache.get(key) ?? null;
+    }
+    ctx.cache.set(key, result);
+    return result;
+  });
+
   ctx.pending.set(key, promise);
 
   try {
-    const result = await promise;
-    ctx.cache.set(key, result);
-    return result;
+    return await promise;
   } finally {
-    ctx.pending.delete(key);
+    if (ctx.pending.get(key) === promise) ctx.pending.delete(key);
   }
 }
 
@@ -110,7 +122,6 @@ async function flushBatch(ctx: RequestCacheContext, backend: CacheBackend): Prom
 
     for (const request of requests) {
       const value = results.get(request.key) ?? null;
-      ctx.cache.set(request.key, value);
       request.resolve(value);
     }
   } catch (error) {
@@ -131,7 +142,10 @@ async function getIndividually(
 }
 
 export function setInRequestCache(key: string, value: string | null): void {
-  asyncLocalStorage.getStore()?.cache.set(key, value);
+  const ctx = asyncLocalStorage.getStore();
+  if (!ctx) return;
+  ctx.mutationVersions.set(key, (ctx.mutationVersions.get(key) ?? 0) + 1);
+  ctx.cache.set(key, value);
 }
 
 export function getRequestCacheStats(): { hits: number; stored: number } | null {

--- a/src/platform/adapters/fs/cache/file-cache.test.ts
+++ b/src/platform/adapters/fs/cache/file-cache.test.ts
@@ -7,6 +7,7 @@ import {
   isFileCacheDistributedEnabled,
 } from "./file-cache.ts";
 import { CacheBackends } from "#veryfront/cache/backend.ts";
+import { runWithCacheBatching } from "#veryfront/cache/request-cache-batcher.ts";
 
 describe("FileCache", () => {
   let cache: FileCache;
@@ -373,6 +374,53 @@ describe("Distributed cache functions", () => {
       // vacuously passing because the backend was never wired up.
       distributedCache.set("serializable", { ok: true });
       assertEquals(backendWrites, 1);
+    });
+
+    it("deleteAsync() invalidates the request-scoped value in distributed mode", async () => {
+      const distributedModule = await import(
+        "./file-cache.ts?distributed-request-cache-invalidation-regression"
+      );
+      const descriptor = Object.getOwnPropertyDescriptor(CacheBackends, "file");
+      assertExists(descriptor);
+      const values = new Map<string, string>();
+      Object.defineProperty(CacheBackends, "file", {
+        ...descriptor,
+        value: () =>
+          Promise.resolve({
+            type: "redis",
+            size: 0,
+            get: (key: string) => Promise.resolve(values.get(key) ?? null),
+            set: (key: string, value: string) => {
+              values.set(key, value);
+              return Promise.resolve();
+            },
+            del: (key: string) => {
+              values.delete(key);
+              return Promise.resolve();
+            },
+            clear: () => Promise.resolve(),
+          } as never),
+      });
+
+      try {
+        assertEquals(await distributedModule.initializeFileCacheBackend(), true);
+      } finally {
+        Object.defineProperty(CacheBackends, "file", descriptor);
+      }
+
+      const distributedCache = new distributedModule.FileCache();
+      await runWithCacheBatching(async () => {
+        await distributedCache.setAsync("listing", "stale");
+        assertEquals(await distributedCache.getAsync("listing"), "stale");
+
+        await distributedCache.deleteAsync("listing");
+
+        assertEquals(
+          await distributedCache.getAsync("listing"),
+          undefined,
+          "the current request must not retain the deleted distributed value",
+        );
+      });
     });
 
     it("should return boolean", async () => {

--- a/src/platform/adapters/fs/cache/file-cache.test.ts
+++ b/src/platform/adapters/fs/cache/file-cache.test.ts
@@ -423,6 +423,78 @@ describe("Distributed cache functions", () => {
       });
     });
 
+    it("deleteAsync() prevents a pending distributed read from restoring stale data", async () => {
+      const distributedModule = await import(
+        "./file-cache.ts?distributed-pending-read-invalidation-regression"
+      );
+      const descriptor = Object.getOwnPropertyDescriptor(CacheBackends, "file");
+      assertExists(descriptor);
+      const values = new Map<string, string>();
+      let delayReads = false;
+      let markReadStarted: (() => void) | undefined;
+      const readStarted = new Promise<void>((resolve) => {
+        markReadStarted = resolve;
+      });
+      let releaseRead: (() => void) | undefined;
+      const readReleased = new Promise<void>((resolve) => {
+        releaseRead = resolve;
+      });
+      Object.defineProperty(CacheBackends, "file", {
+        ...descriptor,
+        value: () =>
+          Promise.resolve({
+            type: "redis",
+            size: 0,
+            get: async (key: string) => {
+              const captured = values.get(key) ?? null;
+              if (delayReads) {
+                markReadStarted?.();
+                await readReleased;
+              }
+              return captured;
+            },
+            set: (key: string, value: string) => {
+              values.set(key, value);
+              return Promise.resolve();
+            },
+            del: (key: string) => {
+              values.delete(key);
+              return Promise.resolve();
+            },
+            clear: () => Promise.resolve(),
+          } as never),
+      });
+
+      try {
+        assertEquals(await distributedModule.initializeFileCacheBackend(), true);
+      } finally {
+        Object.defineProperty(CacheBackends, "file", descriptor);
+      }
+
+      const distributedCache = new distributedModule.FileCache();
+      await distributedCache.setAsync("listing", "stale");
+      delayReads = true;
+
+      await runWithCacheBatching(async () => {
+        const pendingRead = distributedCache.getAsync("listing");
+        await readStarted;
+
+        await distributedCache.deleteAsync("listing");
+        releaseRead?.();
+
+        assertEquals(
+          await pendingRead,
+          undefined,
+          "a read invalidated while pending must not return its captured value",
+        );
+        assertEquals(
+          await distributedCache.getAsync("listing"),
+          undefined,
+          "the pending read must not restore its stale value for later reads",
+        );
+      });
+    });
+
     it("should return boolean", async () => {
       assertEquals(typeof (await initializeFileCacheBackend()), "boolean");
     });

--- a/src/platform/adapters/fs/cache/file-cache.ts
+++ b/src/platform/adapters/fs/cache/file-cache.ts
@@ -297,6 +297,11 @@ export class FileCache {
       "platform.fs.cache.deleteAsync",
       async () => {
         const deletedFromFallback = this.delete(key);
+        // setAsync() publishes distributed writes into the request-scoped
+        // cache before awaiting the backend. Invalidate that view as part of
+        // the same delete, or this request can keep reading a value that the
+        // backend no longer contains.
+        setInRequestCache(key, null);
         const backend = this.getBackend();
         if (backend) {
           await backend.del(key);

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -1007,6 +1007,70 @@ describe("VeryfrontFSAdapter", () => {
       });
     });
 
+    it("discards initialization files when the request branch changes during cache write", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+      const internals = adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          getContext: () => { type: string; name?: string };
+          listAllFiles: () => Promise<Array<{ path: string; content: string }>>;
+        };
+        cache: {
+          setAsync: (key: string, value: unknown) => Promise<void>;
+        };
+        wsManager: { connect: (_projectId: string) => void };
+      };
+
+      internals.client.initialize = () => Promise.resolve();
+      internals.client.getProjectSlug = () => "test-project";
+      internals.client.getProjectId = () => "project-123";
+      internals.client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+
+      let listAllFilesCalls = 0;
+      internals.client.listAllFiles = () => {
+        listAllFilesCalls++;
+        const branch = internals.client.getContext().name ?? "main";
+        return Promise.resolve([{
+          path: "pages/index.tsx",
+          content: branch,
+        }]);
+      };
+      internals.wsManager.connect = () => {};
+
+      const setStarted = Promise.withResolvers<void>();
+      const releaseSet = Promise.withResolvers<void>();
+      const setAsync = internals.cache.setAsync.bind(internals.cache);
+      let setCalls = 0;
+      internals.cache.setAsync = async (key, value) => {
+        setCalls++;
+        if (setCalls === 1) {
+          setStarted.resolve();
+          await releaseSet.promise;
+        }
+        await setAsync(key, value);
+      };
+
+      const initialization = adapter.initialize();
+      await setStarted.promise;
+      adapter.setRequestBranch("draft");
+      releaseSet.resolve();
+      await initialization;
+
+      assertEquals(await adapter.readTextFile("pages/index.tsx"), "draft");
+      assertEquals(listAllFilesCalls, 2);
+    });
+
     it("does not reuse a freshness lease after the request branch changes", async () => {
       const adapter = createAdapter({
         veryfront: {

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -1824,6 +1824,8 @@ describe("VeryfrontFSAdapter", () => {
       }).cache;
 
       assertEquals(cache.delete(cacheKey), true);
+      // Simulate the retained listing expiring with the cache entry.
+      (adapter as unknown as { clearRetainedFileList: () => void }).clearRetainedFileList();
       assertEquals(await adapter.getAllSourceFiles(), []);
 
       await waitFor(async () => {
@@ -2029,6 +2031,7 @@ describe("VeryfrontFSAdapter", () => {
       }).cache;
 
       assertEquals(cache.delete(cacheKey), true);
+      (adapter as unknown as { clearRetainedFileList: () => void }).clearRetainedFileList();
       assertEquals(await adapter.getAllSourceFiles(), []);
 
       await waitFor(async () => {
@@ -2096,6 +2099,7 @@ describe("VeryfrontFSAdapter", () => {
       }).cache;
 
       assertEquals(cache.delete(cacheKey), true);
+      (adapter as unknown as { clearRetainedFileList: () => void }).clearRetainedFileList();
 
       await Promise.all([
         adapter.getAllSourceFiles(),

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -549,30 +549,55 @@ export class VeryfrontFSAdapter implements FSAdapter {
     });
 
     const cacheKey = buildFileListCacheKey(contentContext);
+    const initializationIdentity = this.getCurrentSourceSnapshotIdentity();
+    const initializationSnapshotVersion = this.sourceSnapshotVersion;
     logger.debug("Step 4: fetchFileList START", { projectSlug, cacheKey });
 
     try {
       const files = await fetchFileListForContext(this.client, contentContext);
       const fileSummary = summarizeFileList(files);
 
-      await this.cache.setAsync(cacheKey, files);
-      this.markSourceSnapshotChanged(files);
+      const initialSnapshotApplied = await this.runSourceSnapshotMutation(async () => {
+        const isSnapshotSuperseded = () =>
+          this.contentContext !== contentContext ||
+          this.getCurrentSourceSnapshotIdentity() !== initializationIdentity ||
+          this.sourceSnapshotVersion !== initializationSnapshotVersion;
+        if (isSnapshotSuperseded()) return false;
+
+        await this.cache.setAsync(cacheKey, files);
+        if (isSnapshotSuperseded()) {
+          await this.cache.deleteAsync(cacheKey);
+          return false;
+        }
+
+        this.markSourceSnapshotChanged(files, initializationIdentity);
+        return true;
+      });
 
       this.fileListReadyResolve?.();
       this.fileListReadyResolve = null;
 
-      logger.debug("Fetched files during initialization", {
-        cacheKey,
-        totalFiles: fileSummary.totalFiles,
-        filesWithContent: fileSummary.filesWithContent,
-        sourceFiles: fileSummary.sourceFiles,
-        sourceFilesWithContent: fileSummary.sourceFilesWithContent,
-      });
+      logger.debug(
+        initialSnapshotApplied
+          ? "Fetched files during initialization"
+          : "Discarded initialization files superseded by a newer source snapshot",
+        {
+          cacheKey,
+          totalFiles: fileSummary.totalFiles,
+          filesWithContent: fileSummary.filesWithContent,
+          sourceFiles: fileSummary.sourceFiles,
+          sourceFilesWithContent: fileSummary.sourceFilesWithContent,
+        },
+      );
 
       // Trigger CSS pre-generation after the initial file snapshot is ready for
       // published contexts. Branch previews should first try remote metadata
       // recovery on cold starts instead of repopulating the prepared cache here.
-      if (fileSummary.sourceFilesWithContent > 0 && this.shouldBackgroundPregenerateStyles()) {
+      if (
+        initialSnapshotApplied &&
+        fileSummary.sourceFilesWithContent > 0 &&
+        this.shouldBackgroundPregenerateStyles()
+      ) {
         this.triggerCSSPregeneration(files).catch(() => {
           // Error already logged in triggerCSSPregeneration
         });
@@ -582,15 +607,16 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
       logger.debug("initialize COMPLETE", {
         projectSlug,
-        fileCount: files.length,
+        fileCount: initialSnapshotApplied ? files.length : 0,
         totalDuration: `${(performance.now() - initStartTime).toFixed(2)}ms`,
       });
 
-      if (contentContext.sourceType === "branch") {
+      const initializedContext = this.contentContext;
+      if (initializedContext?.sourceType === "branch") {
         logger.debug("Initialized (branch mode)", {
           projectId: this.client.getProjectId(),
-          files: files.length,
-          branch: contentContext.branch,
+          files: initialSnapshotApplied ? files.length : 0,
+          branch: initializedContext.branch,
           proxyMode: this.proxyMode,
         });
         this.wsManager.connect(projectId);
@@ -599,15 +625,15 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
       logger.debug("Initialized (published mode)", {
         projectId: this.client.getProjectId(),
-        files: files.length,
-        sourceType: contentContext.sourceType,
-        environmentName: contentContext.environmentName,
-        releaseId: contentContext.releaseId,
+        files: initialSnapshotApplied ? files.length : 0,
+        sourceType: initializedContext?.sourceType,
+        environmentName: initializedContext?.environmentName,
+        releaseId: initializedContext?.releaseId,
       });
 
       // Keep a WebSocket connection in environment mode to receive deployment pokes.
       // Release mode is immutable, so no need to keep a live connection.
-      if (contentContext.sourceType === "environment") {
+      if (initializedContext?.sourceType === "environment") {
         this.wsManager.connect(projectId);
       }
     } catch (error) {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -920,7 +920,18 @@ export class VeryfrontFSAdapter implements FSAdapter {
         return;
       }
 
+      const snapshotVersion = this.sourceSnapshotVersion;
       await this.cache.setAsync(cacheKey, files);
+      if (
+        this.contentContext !== context ||
+        this.sourceSnapshotVersion !== snapshotVersion
+      ) {
+        // A newer poke invalidated this replacement while its distributed
+        // cache write was pending. Remove the value that just landed and leave
+        // memory empty so the next read derives the newer snapshot.
+        await this.cache.deleteAsync(cacheKey);
+        return;
+      }
       this.readOps.clearFileListIndex();
       this.markSourceSnapshotChanged(files);
       // Retain after the version bump so the poked listing -- not the one it

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -394,7 +394,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
           "hasCachedFileList miss",
           { waitForWarmup: true },
         );
-        return Array.isArray(cached?.files) && cached.files.length > 0;
+        return Array.isArray(cached?.files);
       },
       isPersistentCacheInvalidated: (prefix: string) => this.isPersistentCacheInvalidated(prefix),
       isReleaseBeingInvalidated: (releaseId: string) =>

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -571,6 +571,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
         }
 
         this.markSourceSnapshotChanged(files, initializationIdentity);
+        // Retain after the generation bump so the first read can reuse the
+        // initialized snapshot even when the configured cache keeps nothing.
+        this.retainFileList(cacheKey, files);
         return true;
       });
 

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -989,11 +989,11 @@ export class VeryfrontFSAdapter implements FSAdapter {
     const previousVersion = this.sourceSnapshotVersion;
     const files = await fetchFileListForContext(this.client, refreshContext);
     const result = await this.runSourceSnapshotMutation(async () => {
-      if (
+      const isSnapshotSuperseded = () =>
         this.contentContext !== refreshContext ||
         this.getCurrentSourceSnapshotIdentity() !== refreshIdentity ||
-        this.sourceSnapshotVersion !== previousVersion
-      ) {
+        this.sourceSnapshotVersion !== previousVersion;
+      if (isSnapshotSuperseded()) {
         return { applied: false, sourceChanged: false };
       }
 
@@ -1012,13 +1012,23 @@ export class VeryfrontFSAdapter implements FSAdapter {
           this.cache.deleteByPrefixAsync(buildDirCacheKeyPrefix(refreshContext)),
           this.cache.deleteAsync(cacheKey),
         ]);
+        if (isSnapshotSuperseded()) {
+          return { applied: false, sourceChanged: false };
+        }
       }
 
       await this.cache.setAsync(cacheKey, files);
-      this.branchMissRecoveryFailures.clear();
+      if (isSnapshotSuperseded()) {
+        await this.cache.deleteAsync(cacheKey);
+        return { applied: false, sourceChanged: false };
+      }
 
       if (sourceChanged) {
         await this.invalidateDerivedSourceCaches();
+        if (isSnapshotSuperseded()) {
+          await this.cache.deleteAsync(cacheKey);
+          return { applied: false, sourceChanged: false };
+        }
         // Publish freshness only after every cache derived from the previous
         // snapshot has been invalidated. Concurrent followers remain attached
         // to the refresh singleflight until this point.
@@ -1029,6 +1039,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
         this.sourceSnapshotCheckedAt = Date.now();
       }
 
+      this.branchMissRecoveryFailures.clear();
       this.retainFileList(cacheKey, files);
 
       return { applied: true, sourceChanged };

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -250,11 +250,11 @@ export class VeryfrontFSAdapter implements FSAdapter {
       )?.length ?? 0,
     });
 
-    if (!files?.length) {
+    if (files === undefined) {
       files = this.readRetainedFileList<T>(cacheKey);
     }
 
-    if (!files?.length) {
+    if (files === undefined) {
       this.scheduleFileListWarmup(missReason, cacheKey);
       if (options.waitForWarmup) {
         files = await this.awaitFileListWarmup<T>(cacheKey) ?? files;
@@ -307,7 +307,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       return undefined;
     }
 
-    return retained.files.length ? (retained.files as T[]) : undefined;
+    return retained.files as T[];
   }
 
   /**
@@ -327,7 +327,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     if (!warmupPromise || this.fileListWarmupKey !== cacheKey) return undefined;
 
     const fetched = await warmupPromise;
-    return fetched?.length ? (fetched as T[]) : undefined;
+    return fetched === null ? undefined : (fetched as T[]);
   }
 
   constructor(config: FSAdapterConfig) {
@@ -797,7 +797,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
           effectiveCacheKey,
         );
 
-        if (existing?.length) {
+        if (existing !== undefined) {
           logger.debug("Skipping file list warmup because cache is already populated", {
             reason,
             cacheKey: effectiveCacheKey,
@@ -1295,12 +1295,12 @@ export class VeryfrontFSAdapter implements FSAdapter {
     // populates it for a release-backed context, so returning early meant the
     // list was empty on every request for the life of the process. Wait for the
     // fetch this read just started, then look again.
-    if (options.waitForWarmup && cacheKey && !files?.length && this.fileListWarmupPromise) {
+    if (options.waitForWarmup && cacheKey && files === undefined && this.fileListWarmupPromise) {
       // Take what the fetch returned rather than re-reading the cache: with
       // caching disabled, or a failed backend write, the cache keeps nothing
       // and correctness would depend on a write that never happened.
       const fetched = await this.fileListWarmupPromise;
-      files = fetched?.length
+      files = fetched !== null
         ? fetched
         : await this.cache.getAsync<{ path: string; content?: string }[]>(cacheKey);
     }

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -802,6 +802,16 @@ export class VeryfrontFSAdapter implements FSAdapter {
           }
 
           await this.cache.setAsync(effectiveCacheKey, files);
+          // A poke can advance the generation while a distributed cache write
+          // is pending. Remove the value that just landed before releasing the
+          // mutation lock, so neither this waiter nor a later read sees it.
+          if (
+            this.contentContext !== warmupContext ||
+            this.sourceSnapshotVersion !== warmupSnapshotVersion
+          ) {
+            await this.cache.deleteAsync(effectiveCacheKey);
+            return false;
+          }
           this.retainFileList(effectiveCacheKey, files);
           return true;
         });

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -212,6 +212,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     noContextMessage: string,
     lookupLabel: string,
     missReason: string,
+    options: { waitForWarmup?: boolean } = {},
   ): Promise<{ cacheKey: string; files: T[] | undefined } | undefined> {
     const cacheKey = this.getCurrentFileListCacheKey();
     if (!cacheKey) {
@@ -219,7 +220,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       return undefined;
     }
 
-    const files = await this.cache.getAsync<T[]>(cacheKey);
+    let files = await this.cache.getAsync<T[]>(cacheKey);
     logger.debug(`${lookupLabel} lookup`, {
       cacheKey,
       hasResult: !!files,
@@ -231,9 +232,32 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
     if (!files?.length) {
       this.scheduleFileListWarmup(missReason, cacheKey);
+      if (options.waitForWarmup) {
+        files = await this.awaitFileListWarmup<T>(cacheKey) ?? files;
+      }
     }
 
     return { cacheKey, files };
+  }
+
+  /**
+   * Wait for the in-flight file-list warmup for `cacheKey` and return the
+   * fetched listing. SSR module resolution reads this list for every module of
+   * a page; when the cached listing has expired, answering "no list" makes each
+   * module fall back to its own per-file/per-extension API probing (dozens of
+   * sequential fetches per render). Paying for one awaited listing fetch keeps
+   * that fan-out at a single API call while staying exactly as fresh: the
+   * listing is fetched from the API at request time. Warmup failures resolve to
+   * undefined so callers keep the legacy per-file fallback.
+   */
+  private async awaitFileListWarmup<T extends { path: string }>(
+    cacheKey: string,
+  ): Promise<T[] | undefined> {
+    const warmupPromise = this.fileListWarmupPromise;
+    if (!warmupPromise || this.fileListWarmupKey !== cacheKey) return undefined;
+
+    const fetched = await warmupPromise;
+    return fetched?.length ? (fetched as T[]) : undefined;
   }
 
   constructor(config: FSAdapterConfig) {
@@ -287,7 +311,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
           type?: string;
           size?: number;
           updated_at?: string;
-        }>("getFileList: no contentContext", "getFileList", "getFileList miss");
+        }>("getFileList: no contentContext", "getFileList", "getFileList miss", {
+          waitForWarmup: true,
+        });
         return cached?.files;
       },
       hasCachedFileList: async () => {
@@ -295,6 +321,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
           "hasCachedFileList: no contentContext",
           "hasCachedFileList",
           "hasCachedFileList miss",
+          { waitForWarmup: true },
         );
         return Array.isArray(cached?.files) && cached.files.length > 0;
       },
@@ -327,6 +354,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
           "getFileListCache: no contentContext",
           "getFileListCache",
           "getFileListCache miss",
+          { waitForWarmup: true },
         );
         return cached?.files;
       },

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -449,7 +449,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
       getContentSource: () => this.contentSource,
       getProjectDir: () => this.normalizer.getProjectDir(),
       clearMemoryCaches: () => this.clearMemoryCaches(),
-      replaceSourceSnapshot: (cacheKey, files) => this.replaceSourceSnapshot(cacheKey, files),
+      getSourceSnapshotVersion: () => this.sourceSnapshotVersion,
+      replaceSourceSnapshot: (cacheKey, files, expectedSnapshotVersion) =>
+        this.replaceSourceSnapshot(cacheKey, files, expectedSnapshotVersion),
       pregenerateStyles: (files) => this.triggerCSSPregeneration(files),
     });
 
@@ -909,22 +911,27 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private replaceSourceSnapshot(
     cacheKey: string,
     files: SourceSnapshotFile[],
+    expectedSnapshotVersion = this.sourceSnapshotVersion,
   ): Promise<void> {
+    const expectedContext = this.contentContext;
     return this.runSourceSnapshotMutation(async () => {
-      const context = this.contentContext;
-      if (!context || buildFileListCacheKey(context) !== cacheKey) {
-        logger.debug("Discarding source snapshot for superseded content context", {
+      if (
+        !expectedContext ||
+        this.contentContext !== expectedContext ||
+        this.sourceSnapshotVersion !== expectedSnapshotVersion ||
+        buildFileListCacheKey(expectedContext) !== cacheKey
+      ) {
+        logger.debug("Discarding superseded source snapshot", {
           cacheKey,
           projectSlug: this.projectSlug,
         });
         return;
       }
 
-      const snapshotVersion = this.sourceSnapshotVersion;
       await this.cache.setAsync(cacheKey, files);
       if (
-        this.contentContext !== context ||
-        this.sourceSnapshotVersion !== snapshotVersion
+        this.contentContext !== expectedContext ||
+        this.sourceSnapshotVersion !== expectedSnapshotVersion
       ) {
         // A newer poke invalidated this replacement while its distributed
         // cache write was pending. Remove the value that just landed and leave

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -37,6 +37,7 @@ import {
 import {
   buildFileCacheOptions,
   buildRetryConfig,
+  DEFAULT_CACHE_TTL_MS,
   shouldBackgroundPregenerateStyles,
 } from "./adapter-helpers.ts";
 import { isNotFoundLikeError } from "./read-operations-helpers.ts";
@@ -136,6 +137,25 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private fileListWarmupPromise: Promise<Array<{ path: string; content?: string }> | null> | null =
     null;
   private fileListWarmupKey: string | null = null;
+  /**
+   * Last listing this adapter fetched or was poked with, kept in memory because
+   * a cache write is not guaranteed to retain it: writes are skipped entirely
+   * when caching is disabled, oversized listings are dropped by the memory
+   * cache, and backend writes can fail. Without this, every module lookup of a
+   * render would miss the cache and await its own full listing fetch -- more
+   * API traffic than the per-file probing this replaced. It expires with the
+   * same TTL as the cache entry it stands in for and is dropped by every
+   * invalidation, so it is never fresher or staler than a retained cache write.
+   */
+  private retainedFileList:
+    | {
+      cacheKey: string;
+      files: Array<{ path: string; content?: string }>;
+      snapshotVersion: number;
+      retainedAt: number;
+    }
+    | null = null;
+  private readonly fileListRetentionMs: number;
   /** Single-flight foreground refresh when a branch preview read misses a newly pushed file. */
   private branchMissRecoveryPromise: Promise<void> | null = null;
   private branchMissRecoveryGeneration = 0;
@@ -231,6 +251,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
     });
 
     if (!files?.length) {
+      files = this.readRetainedFileList<T>(cacheKey);
+    }
+
+    if (!files?.length) {
       this.scheduleFileListWarmup(missReason, cacheKey);
       if (options.waitForWarmup) {
         files = await this.awaitFileListWarmup<T>(cacheKey) ?? files;
@@ -238,6 +262,52 @@ export class VeryfrontFSAdapter implements FSAdapter {
     }
 
     return { cacheKey, files };
+  }
+
+  /** Keep `files` answerable from memory for as long as a cache write would. */
+  private retainFileList(
+    cacheKey: string,
+    files: Array<{ path: string; content?: string }>,
+  ): void {
+    this.retainedFileList = {
+      cacheKey,
+      files,
+      snapshotVersion: this.sourceSnapshotVersion,
+      retainedAt: Date.now(),
+    };
+  }
+
+  private clearRetainedFileList(): void {
+    this.retainedFileList = null;
+  }
+
+  /**
+   * The retained listing, if it still describes the snapshot the caller is
+   * reading. Anything that supersedes the snapshot -- a poke, a refresh, a
+   * branch or token change -- either drops it outright or moves the snapshot
+   * version past it, so a superseded listing can never answer a read.
+   */
+  private readRetainedFileList<T extends { path: string }>(
+    cacheKey: string,
+  ): T[] | undefined {
+    const retained = this.retainedFileList;
+    if (!retained) return undefined;
+
+    if (
+      retained.cacheKey !== cacheKey ||
+      retained.snapshotVersion !== this.sourceSnapshotVersion
+    ) {
+      this.clearRetainedFileList();
+      return undefined;
+    }
+
+    if (Date.now() - retained.retainedAt > this.fileListRetentionMs) {
+      logger.debug("Retained file list expired", { cacheKey });
+      this.clearRetainedFileList();
+      return undefined;
+    }
+
+    return retained.files.length ? (retained.files as T[]) : undefined;
   }
 
   /**
@@ -295,6 +365,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     const cacheConfig = buildFileCacheOptions(vf.cache);
 
     this.cache = new FileCache(cacheConfig);
+    this.fileListRetentionMs = cacheConfig.ttl ?? DEFAULT_CACHE_TTL_MS;
     this.normalizer = new PathNormalizer(config.projectDir);
     // Per-releaseId fetcher registration is done in setContentContext when a
     // release context is resolved, ensuring the correct project-scoped token.
@@ -377,12 +448,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       getContentContext: () => this.contentContext,
       getContentSource: () => this.contentSource,
       getProjectDir: () => this.normalizer.getProjectDir(),
-      clearMemoryCaches: () => {
-        clearCachedReleaseAssetManifests();
-        this.readOps.clearFileListIndex();
-        this.statOps.clearIndex();
-        this.dirOps.clearTree();
-      },
+      clearMemoryCaches: () => this.clearMemoryCaches(),
       replaceSourceSnapshot: (cacheKey, files) => this.replaceSourceSnapshot(cacheKey, files),
       pregenerateStyles: (files) => this.triggerCSSPregeneration(files),
     });
@@ -695,6 +761,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     }
 
     const warmupContext = this.contentContext;
+    const warmupSnapshotVersion = this.sourceSnapshotVersion;
     let warmupPromise: Promise<Array<{ path: string; content?: string }> | null> | null = null;
     warmupPromise = (async () => {
       try {
@@ -721,7 +788,38 @@ export class VeryfrontFSAdapter implements FSAdapter {
         });
 
         const files = await fetchFileListForContext(this.client, warmupContext);
-        await this.cache.setAsync(effectiveCacheKey, files);
+
+        // A WebSocket snapshot can land while this fetch is open. Publishing
+        // the pre-poke listing would roll both the cache and this caller's
+        // answer back to the older draft, so the write is serialized against
+        // snapshot mutations and stands down when one won the race.
+        const applied = await this.runSourceSnapshotMutation(async () => {
+          if (
+            this.contentContext !== warmupContext ||
+            this.sourceSnapshotVersion !== warmupSnapshotVersion
+          ) {
+            return false;
+          }
+
+          await this.cache.setAsync(effectiveCacheKey, files);
+          this.retainFileList(effectiveCacheKey, files);
+          return true;
+        });
+
+        if (!applied) {
+          logger.debug("Discarding file list warmup superseded by a newer source snapshot", {
+            reason,
+            cacheKey: effectiveCacheKey,
+          });
+
+          // Answer with the snapshot that superseded this fetch rather than
+          // the listing it carries, so the caller stays as fresh as the poke.
+          return await this.cache.getAsync<Array<{ path: string; content?: string }>>(
+            effectiveCacheKey,
+          ) ?? this.readRetainedFileList<{ path: string; content?: string }>(effectiveCacheKey) ??
+            null;
+        }
+
         const fileSummary = summarizeFileList(files);
 
         if (fileSummary.sourceFilesWithContent > 0 && this.shouldBackgroundPregenerateStyles()) {
@@ -758,6 +856,19 @@ export class VeryfrontFSAdapter implements FSAdapter {
     this.fileListWarmupKey = effectiveCacheKey;
     // That collaborator only needs completion, not the payload.
     this.readOps.setFileListReadyPromise(warmupPromise.then(() => {}));
+  }
+
+  /**
+   * Drop every in-memory view of the current source snapshot. Used by pokes
+   * that invalidate without carrying replacement files inline, so the next read
+   * re-derives everything from the API rather than from a superseded listing.
+   */
+  private clearMemoryCaches(): void {
+    clearCachedReleaseAssetManifests();
+    this.clearRetainedFileList();
+    this.readOps.clearFileListIndex();
+    this.statOps.clearIndex();
+    this.dirOps.clearTree();
   }
 
   private markSourceSnapshotChanged(
@@ -798,6 +909,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
       await this.cache.setAsync(cacheKey, files);
       this.readOps.clearFileListIndex();
       this.markSourceSnapshotChanged(files);
+      // Retain after the version bump so the poked listing -- not the one it
+      // replaced -- is what later reads see when the cache keeps nothing.
+      this.retainFileList(cacheKey, files);
     });
   }
 
@@ -862,6 +976,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       if (sourceChanged) {
         this.fileListWarmupPromise = null;
         this.fileListWarmupKey = null;
+        this.clearRetainedFileList();
         this.readOps.clearFileListIndex();
         this.statOps.clearIndex();
         this.dirOps.clearTree();
@@ -888,6 +1003,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
         this.sourceSnapshotIdentity = refreshIdentity;
         this.sourceSnapshotCheckedAt = Date.now();
       }
+
+      this.retainFileList(cacheKey, files);
 
       return { applied: true, sourceChanged };
     });
@@ -1062,6 +1179,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     this.exactReadInitializationGeneration++;
     this.fileListWarmupPromise = null;
     this.fileListWarmupKey = null;
+    this.clearRetainedFileList();
     this.branchMissRecoveryPromise = null;
     this.branchMissRecoveryGeneration++;
     this.branchMissRecoveryFailures.clear();
@@ -1202,6 +1320,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   private invalidateRequestAuthoritySnapshot(): void {
     this.cache.clear();
+    this.clearRetainedFileList();
     this.readOps.clearFileListIndex();
     this.statOps.clearIndex();
     this.dirOps.clearTree();
@@ -1277,6 +1396,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       this.dirOps.clearTree();
       this.fileListWarmupPromise = null;
       this.fileListWarmupKey = null;
+      this.clearRetainedFileList();
       this.branchMissRecoveryPromise = null;
       this.branchMissRecoveryGeneration++;
       this.branchMissRecoveryFailures.clear();

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -938,7 +938,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     cacheKey: string,
     files: SourceSnapshotFile[],
     expectedSnapshotVersion = this.sourceSnapshotVersion,
-  ): Promise<boolean> {
+  ): Promise<number | undefined> {
     const expectedContext = this.contentContext;
     return this.runSourceSnapshotMutation(async () => {
       if (
@@ -951,7 +951,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
           cacheKey,
           projectSlug: this.projectSlug,
         });
-        return false;
+        return undefined;
       }
 
       await this.cache.setAsync(cacheKey, files);
@@ -963,14 +963,14 @@ export class VeryfrontFSAdapter implements FSAdapter {
         // cache write was pending. Remove the value that just landed and leave
         // memory empty so the next read derives the newer snapshot.
         await this.cache.deleteAsync(cacheKey);
-        return false;
+        return undefined;
       }
       this.readOps.clearFileListIndex();
       this.markSourceSnapshotChanged(files);
       // Retain after the version bump so the poked listing -- not the one it
       // replaced -- is what later reads see when the cache keeps nothing.
       this.retainFileList(cacheKey, files);
-      return true;
+      return this.sourceSnapshotVersion;
     });
   }
 

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -865,6 +865,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
    */
   private clearMemoryCaches(): void {
     clearCachedReleaseAssetManifests();
+    // An accepted poke may clear memory before its debounced replacement
+    // listing arrives. Advance the generation immediately so an older warmup
+    // cannot repopulate the cache or answer a waiting read in that window.
+    this.sourceSnapshotVersion = nextSourceSnapshotGeneration();
     this.clearRetainedFileList();
     this.readOps.clearFileListIndex();
     this.statOps.clearIndex();

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -938,7 +938,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     cacheKey: string,
     files: SourceSnapshotFile[],
     expectedSnapshotVersion = this.sourceSnapshotVersion,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const expectedContext = this.contentContext;
     return this.runSourceSnapshotMutation(async () => {
       if (
@@ -951,7 +951,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
           cacheKey,
           projectSlug: this.projectSlug,
         });
-        return;
+        return false;
       }
 
       await this.cache.setAsync(cacheKey, files);
@@ -963,13 +963,14 @@ export class VeryfrontFSAdapter implements FSAdapter {
         // cache write was pending. Remove the value that just landed and leave
         // memory empty so the next read derives the newer snapshot.
         await this.cache.deleteAsync(cacheKey);
-        return;
+        return false;
       }
       this.readOps.clearFileListIndex();
       this.markSourceSnapshotChanged(files);
       // Retain after the version bump so the poked listing -- not the one it
       // replaced -- is what later reads see when the cache keeps nothing.
       this.retainFileList(cacheKey, files);
+      return true;
     });
   }
 

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -1,0 +1,227 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { VeryfrontFSAdapter } from "./adapter.ts";
+import { buildFileListCacheKey } from "./cache-keys.ts";
+import { createAdapter } from "./adapter.test-helpers.ts";
+
+interface StubFile {
+  path: string;
+  content: string;
+}
+
+interface ClientCallCounts {
+  listAllFiles: number;
+  getFileContent: number;
+  listFiles: number;
+}
+
+/**
+ * Wires the adapter's API client so every network operation is counted.
+ * `files` is mutable: tests can edit entries to simulate draft updates.
+ */
+function stubClient(
+  adapter: VeryfrontFSAdapter,
+  files: StubFile[],
+): ClientCallCounts {
+  const counts: ClientCallCounts = {
+    listAllFiles: 0,
+    getFileContent: 0,
+    listFiles: 0,
+  };
+
+  const client = adapter.getClient() as unknown as {
+    listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+    getFileContent: (path: string) => Promise<string>;
+    getFileContentBytesWithinLimit: (path: string) => Promise<Uint8Array>;
+    listFiles: (options?: { pattern?: string }) => Promise<{ files: Array<{ path: string }> }>;
+  };
+
+  client.listAllFiles = () => {
+    counts.listAllFiles++;
+    return Promise.resolve(files.map((file) => ({ ...file })));
+  };
+  client.getFileContent = (path: string) => {
+    counts.getFileContent++;
+    const file = files.find((candidate) => candidate.path === path);
+    if (!file) return Promise.reject(new Error(`404 Not Found: ${path}`));
+    return Promise.resolve(file.content);
+  };
+  client.getFileContentBytesWithinLimit = (path: string) => {
+    counts.getFileContent++;
+    const file = files.find((candidate) => candidate.path === path);
+    if (!file) return Promise.reject(new Error(`404 Not Found: ${path}`));
+    return Promise.resolve(new TextEncoder().encode(file.content));
+  };
+  client.listFiles = () => {
+    counts.listFiles++;
+    return Promise.resolve({ files: [] });
+  };
+
+  return counts;
+}
+
+function createDraftAdapter(files: StubFile[]): {
+  adapter: VeryfrontFSAdapter;
+  counts: ClientCallCounts;
+} {
+  const adapter = createAdapter({
+    veryfront: {
+      apiBaseUrl: "https://api.example.com",
+      apiToken: "test-token",
+      projectSlug: "test-project",
+      cache: { enabled: true },
+    },
+  });
+  const counts = stubClient(adapter, files);
+
+  adapter.setContentContext({
+    sourceType: "branch",
+    projectSlug: "test-project",
+    branch: "main",
+  });
+  // Simulate a warmed-up server whose file-list cache entry expired (the
+  // preview steady state after the 60s TTL): initialized, but no cached list.
+  (adapter as unknown as { initialized: boolean }).initialized = true;
+
+  return { adapter, counts };
+}
+
+describe("file list fan-out (issue inbox#32)", () => {
+  it("serves N draft module reads from one listing fetch instead of per-file probes", async () => {
+    const moduleCount = 8;
+    const files: StubFile[] = Array.from({ length: moduleCount }, (_, index) => ({
+      path: `components/mod${index}.tsx`,
+      content: `export const mod${index} = ${index};`,
+    }));
+    const { adapter, counts } = createDraftAdapter(files);
+
+    const contents = await Promise.all(
+      files.map((file) => adapter.readTextFile(file.path)),
+    );
+
+    assertEquals(
+      contents,
+      files.map((file) => file.content),
+      "every module must be served with its draft content",
+    );
+    assertEquals(
+      counts.listAllFiles,
+      1,
+      "an SSR render with a cold file-list cache must fetch the listing exactly once",
+    );
+    assertEquals(
+      counts.getFileContent,
+      0,
+      "module reads must come from the single listing fetch, not per-file API probes",
+    );
+    assertEquals(
+      counts.listFiles,
+      0,
+      "module resolution must not issue per-extension pattern searches",
+    );
+  });
+
+  it("resolves extensionless module paths via the listing without pattern searches", async () => {
+    const files: StubFile[] = [
+      { path: "app/layout.tsx", content: "export default function Layout() {}" },
+      { path: "components/app.tsx", content: "export const app = 1;" },
+    ];
+    const { adapter, counts } = createDraftAdapter(files);
+
+    const resolvedLayout = await adapter.resolveFile("app/layout");
+    const resolvedComponent = await adapter.resolveFile("components/app");
+
+    assertEquals(resolvedLayout, "app/layout.tsx", "layout must resolve from the listing");
+    assertEquals(
+      resolvedComponent,
+      "components/app.tsx",
+      "component must resolve from the listing",
+    );
+    assertEquals(
+      counts.listFiles,
+      0,
+      "extension resolution must not fan out into per-pattern API searches",
+    );
+    assertEquals(
+      counts.listAllFiles,
+      1,
+      "extension resolution must reuse the single listing fetch",
+    );
+  });
+
+  it("still serves fresh draft content after a file update poke", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'v1';" },
+    ];
+    const { adapter, counts } = createDraftAdapter(files);
+
+    const first = await adapter.readTextFile("pages/index.tsx");
+    assertEquals(first, "export default 'v1';", "first read must see the initial draft");
+
+    // Simulate an edit: the API now returns new content, and the WebSocket
+    // poke replaces the source snapshot exactly as websocket-manager does.
+    files[0] = { path: "pages/index.tsx", content: "export default 'v2';" };
+    const context = adapter.getContentContext();
+    if (!context) throw new Error("content context required");
+    const internals = adapter as unknown as {
+      replaceSourceSnapshot: (
+        cacheKey: string,
+        snapshotFiles: Array<{ path: string; content?: string }>,
+      ) => Promise<void>;
+    };
+    await internals.replaceSourceSnapshot(
+      buildFileListCacheKey(context),
+      files.map((file) => ({ ...file })),
+    );
+
+    const second = await adapter.readTextFile("pages/index.tsx");
+    assertEquals(
+      second,
+      "export default 'v2';",
+      "an edited draft file must invalidate any file-list caching",
+    );
+    assertEquals(
+      counts.getFileContent,
+      0,
+      "updated content must be served from the poked snapshot without per-file probes",
+    );
+  });
+
+  it("fetches a fresh listing when the cached one is cleared by an invalidation", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'v1';" },
+    ];
+    const { adapter, counts } = createDraftAdapter(files);
+
+    const first = await adapter.readTextFile("pages/index.tsx");
+    assertEquals(first, "export default 'v1';", "first read must see the initial draft");
+    assertEquals(counts.listAllFiles, 1, "first read warms the listing once");
+
+    // Simulate the invalidation path that clears caches without replacing the
+    // snapshot (e.g. a poke that could not fetch files inline).
+    files[0] = { path: "pages/index.tsx", content: "export default 'v2';" };
+    const context = adapter.getContentContext();
+    if (!context) throw new Error("content context required");
+    const internals = adapter as unknown as {
+      cache: { delete: (key: string) => void };
+      readOps: { clearFileListIndex: () => void };
+      statOps: { clearIndex: () => void };
+    };
+    internals.cache.delete(buildFileListCacheKey(context));
+    internals.readOps.clearFileListIndex();
+    internals.statOps.clearIndex();
+
+    const second = await adapter.readTextFile("pages/index.tsx");
+    assertEquals(
+      second,
+      "export default 'v2';",
+      "a cleared file-list cache must trigger a fresh listing, never stale content",
+    );
+    assertEquals(
+      counts.listAllFiles,
+      2,
+      "the invalidated listing must be refetched exactly once",
+    );
+  });
+});

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -206,6 +206,11 @@ describe("file list fan-out (issue inbox#32)", () => {
       1,
       "an empty branch listing must be fetched only once",
     );
+    assertEquals(
+      counts.listFiles,
+      0,
+      "an authoritative empty listing must not fall back to per-extension searches",
+    );
   });
 
   it("still serves fresh draft content after a file update poke", async () => {

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -366,4 +366,46 @@ describe("file list fan-out (issue inbox#32)", () => {
       "the obsolete warmup must not overwrite the newer snapshot in the cache",
     );
   });
+
+  it("discards a warmup that resolves after a poke clears memory caches", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'v1';" },
+    ];
+    const { adapter, counts } = createDraftAdapter(files);
+
+    let releaseFetch: (() => void) | undefined;
+    const fetchReleased = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const client = adapter.getClient() as unknown as {
+      listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+    };
+    const staleListing = files.map((file) => ({ ...file }));
+    client.listAllFiles = async () => {
+      counts.listAllFiles++;
+      await fetchReleased;
+      return staleListing;
+    };
+
+    const readPromise = adapter.readTextFile("pages/index.tsx");
+    await waitFor(() => Promise.resolve(counts.listAllFiles === 1));
+
+    files[0] = { path: "pages/index.tsx", content: "export default 'v2';" };
+    const internals = adapter as unknown as {
+      clearMemoryCaches: () => void;
+    };
+    internals.clearMemoryCaches();
+    releaseFetch?.();
+
+    assertEquals(
+      await readPromise,
+      "export default 'v2';",
+      "a pre-poke warmup must not answer after the poke invalidates memory caches",
+    );
+    assertEquals(
+      counts.getFileContent,
+      1,
+      "the invalidated warmup must fall back to a fresh exact-file read",
+    );
+  });
 });

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -88,6 +88,51 @@ function createDraftAdapter(files: StubFile[], cacheEnabled = true): {
 }
 
 describe("file list fan-out (issue inbox#32)", () => {
+  it("reuses the listing fetched during initialization when cache storage retains nothing", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'initialized';" },
+    ];
+    const adapter = createAdapter({
+      veryfront: {
+        apiBaseUrl: "https://api.example.com",
+        apiToken: "test-token",
+        projectSlug: "test-project",
+        cache: { enabled: false },
+      },
+    });
+    const counts = stubClient(adapter, files);
+    const internals = adapter as unknown as {
+      client: {
+        initialize: () => Promise<void>;
+        getProjectSlug: () => string;
+        getProjectId: () => string;
+        getCachedProject: () => { provider: string; layout: string };
+      };
+      wsManager: { connect: (_projectId: string) => void };
+    };
+    internals.client.initialize = () => Promise.resolve();
+    internals.client.getProjectSlug = () => "test-project";
+    internals.client.getProjectId = () => "project-123";
+    internals.client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+    internals.wsManager.connect = () => {};
+    adapter.setContentContext({
+      sourceType: "branch",
+      projectSlug: "test-project",
+      branch: "main",
+    });
+
+    await adapter.initialize();
+    assertEquals(counts.listAllFiles, 1, "initialization must fetch the listing once");
+
+    assertEquals(await adapter.readTextFile("pages/index.tsx"), "export default 'initialized';");
+    assertEquals(
+      counts.listAllFiles,
+      1,
+      "the first read after initialization must reuse the fetched listing",
+    );
+    assertEquals(counts.getFileContent, 0, "the initialized listing must answer the read");
+  });
+
   it("serves N draft module reads from one listing fetch instead of per-file probes", async () => {
     const moduleCount = 8;
     const files: StubFile[] = Array.from({ length: moduleCount }, (_, index) => ({

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -506,4 +506,47 @@ describe("file list fan-out (issue inbox#32)", () => {
       "a replacement invalidated during its write must not retain the older draft",
     );
   });
+
+  it("discards a source refresh invalidated during its cache write", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'v1';" },
+    ];
+    const { adapter } = createDraftAdapter(files);
+    (adapter.getClient() as unknown as { getProjectId: () => string | undefined }).getProjectId =
+      () => undefined;
+    let markSetStarted: (() => void) | undefined;
+    const setStarted = new Promise<void>((resolve) => {
+      markSetStarted = resolve;
+    });
+    let releaseSet: (() => void) | undefined;
+    const setReleased = new Promise<void>((resolve) => {
+      releaseSet = resolve;
+    });
+    const internals = adapter as unknown as {
+      cache: {
+        setAsync: (key: string, value: unknown) => Promise<void>;
+      };
+      clearMemoryCaches: () => void;
+    };
+    const setAsync = internals.cache.setAsync.bind(internals.cache);
+    internals.cache.setAsync = async (key, value) => {
+      markSetStarted?.();
+      await setReleased;
+      await setAsync(key, value);
+    };
+
+    const refresh = adapter.refreshSourceSnapshot("poll");
+    await setStarted;
+
+    files[0] = { path: "pages/index.tsx", content: "export default 'v2';" };
+    internals.clearMemoryCaches();
+    releaseSet?.();
+    await refresh;
+
+    assertEquals(
+      await adapter.readTextFile("pages/index.tsx"),
+      "export default 'v2';",
+      "a refresh invalidated during its write must not retain the older draft",
+    );
+  });
 });

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -454,4 +454,56 @@ describe("file list fan-out (issue inbox#32)", () => {
       "the superseded cache write must fall back to a fresh exact-file read",
     );
   });
+
+  it("discards a replacement snapshot invalidated during its cache write", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'v2';" },
+    ];
+    const { adapter } = createDraftAdapter(files);
+    const context = adapter.getContentContext();
+    if (!context) throw new Error("content context required");
+
+    let markSetStarted: (() => void) | undefined;
+    const setStarted = new Promise<void>((resolve) => {
+      markSetStarted = resolve;
+    });
+    let releaseSet: (() => void) | undefined;
+    const setReleased = new Promise<void>((resolve) => {
+      releaseSet = resolve;
+    });
+    const internals = adapter as unknown as {
+      cache: {
+        setAsync: (key: string, value: unknown) => Promise<void>;
+      };
+      clearMemoryCaches: () => void;
+      replaceSourceSnapshot: (
+        key: string,
+        snapshotFiles: Array<{ path: string; content?: string }>,
+      ) => Promise<void>;
+    };
+    const setAsync = internals.cache.setAsync.bind(internals.cache);
+    internals.cache.setAsync = async (key, value) => {
+      markSetStarted?.();
+      await setReleased;
+      await setAsync(key, value);
+    };
+
+    const replacement = internals.replaceSourceSnapshot(
+      buildFileListCacheKey(context),
+      [{ path: "pages/index.tsx", content: "export default 'v1';" }],
+    );
+    await setStarted;
+
+    // A second poke clears memory immediately, then its selective refresh can
+    // fail. The first poke's delayed write must not become the retained answer.
+    internals.clearMemoryCaches();
+    releaseSet?.();
+    await replacement;
+
+    assertEquals(
+      await adapter.readTextFile("pages/index.tsx"),
+      "export default 'v2';",
+      "a replacement invalidated during its write must not retain the older draft",
+    );
+  });
 });

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -549,4 +549,60 @@ describe("file list fan-out (issue inbox#32)", () => {
       "a refresh invalidated during its write must not retain the older draft",
     );
   });
+
+  it("discards a replacement invalidated while waiting for the mutation queue", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'v2';" },
+    ];
+    const { adapter } = createDraftAdapter(files);
+    const context = adapter.getContentContext();
+    if (!context) throw new Error("content context required");
+    const cacheKey = buildFileListCacheKey(context);
+    let markSetStarted: (() => void) | undefined;
+    const setStarted = new Promise<void>((resolve) => {
+      markSetStarted = resolve;
+    });
+    let releaseSet: (() => void) | undefined;
+    const setReleased = new Promise<void>((resolve) => {
+      releaseSet = resolve;
+    });
+    const internals = adapter as unknown as {
+      cache: {
+        setAsync: (key: string, value: unknown) => Promise<void>;
+      };
+      clearMemoryCaches: () => void;
+      replaceSourceSnapshot: (
+        key: string,
+        snapshotFiles: Array<{ path: string; content?: string }>,
+      ) => Promise<void>;
+    };
+    const setAsync = internals.cache.setAsync.bind(internals.cache);
+    let setCalls = 0;
+    internals.cache.setAsync = async (key, value) => {
+      setCalls++;
+      if (setCalls === 1) {
+        markSetStarted?.();
+        await setReleased;
+      }
+      await setAsync(key, value);
+    };
+
+    const blockingReplacement = internals.replaceSourceSnapshot(cacheKey, [
+      { path: "pages/index.tsx", content: "export default 'v0';" },
+    ]);
+    await setStarted;
+    const queuedReplacement = internals.replaceSourceSnapshot(cacheKey, [
+      { path: "pages/index.tsx", content: "export default 'v1';" },
+    ]);
+
+    internals.clearMemoryCaches();
+    releaseSet?.();
+    await Promise.all([blockingReplacement, queuedReplacement]);
+
+    assertEquals(
+      await adapter.readTextFile("pages/index.tsx"),
+      "export default 'v2';",
+      "a queued replacement must keep the generation from when it was requested",
+    );
+  });
 });

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -150,6 +150,19 @@ describe("file list fan-out (issue inbox#32)", () => {
     );
   });
 
+  it("reuses an authoritative empty listing across sequential resolutions", async () => {
+    const { adapter, counts } = createDraftAdapter([], false);
+
+    assertEquals(await adapter.resolveFile("components/missing-one"), null);
+    assertEquals(await adapter.resolveFile("components/missing-two"), null);
+
+    assertEquals(
+      counts.listAllFiles,
+      1,
+      "an empty branch listing must be fetched only once",
+    );
+  });
+
   it("still serves fresh draft content after a file update poke", async () => {
     const files: StubFile[] = [
       { path: "pages/index.tsx", content: "export default 'v1';" },

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -408,4 +408,50 @@ describe("file list fan-out (issue inbox#32)", () => {
       "the invalidated warmup must fall back to a fresh exact-file read",
     );
   });
+
+  it("discards a warmup when a poke lands during its cache write", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'v1';" },
+    ];
+    const { adapter, counts } = createDraftAdapter(files);
+
+    let markSetStarted: (() => void) | undefined;
+    const setStarted = new Promise<void>((resolve) => {
+      markSetStarted = resolve;
+    });
+    let releaseSet: (() => void) | undefined;
+    const setReleased = new Promise<void>((resolve) => {
+      releaseSet = resolve;
+    });
+    const internals = adapter as unknown as {
+      cache: {
+        setAsync: (key: string, value: unknown) => Promise<void>;
+      };
+      clearMemoryCaches: () => void;
+    };
+    const setAsync = internals.cache.setAsync.bind(internals.cache);
+    internals.cache.setAsync = async (key, value) => {
+      markSetStarted?.();
+      await setReleased;
+      await setAsync(key, value);
+    };
+
+    const readPromise = adapter.readTextFile("pages/index.tsx");
+    await setStarted;
+
+    files[0] = { path: "pages/index.tsx", content: "export default 'v2';" };
+    internals.clearMemoryCaches();
+    releaseSet?.();
+
+    assertEquals(
+      await readPromise,
+      "export default 'v2';",
+      "a cache write that finishes after the poke must not publish its old listing",
+    );
+    assertEquals(
+      counts.getFileContent,
+      1,
+      "the superseded cache write must fall back to a fresh exact-file read",
+    );
+  });
 });

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { VeryfrontFSAdapter } from "./adapter.ts";
 import { buildFileListCacheKey } from "./cache-keys.ts";
-import { createAdapter } from "./adapter.test-helpers.ts";
+import { createAdapter, waitFor } from "./adapter.test-helpers.ts";
 
 interface StubFile {
   path: string;
@@ -61,7 +61,7 @@ function stubClient(
   return counts;
 }
 
-function createDraftAdapter(files: StubFile[]): {
+function createDraftAdapter(files: StubFile[], cacheEnabled = true): {
   adapter: VeryfrontFSAdapter;
   counts: ClientCallCounts;
 } {
@@ -70,7 +70,7 @@ function createDraftAdapter(files: StubFile[]): {
       apiBaseUrl: "https://api.example.com",
       apiToken: "test-token",
       projectSlug: "test-project",
-      cache: { enabled: true },
+      cache: { enabled: cacheEnabled },
     },
   });
   const counts = stubClient(adapter, files);
@@ -198,19 +198,17 @@ describe("file list fan-out (issue inbox#32)", () => {
     assertEquals(first, "export default 'v1';", "first read must see the initial draft");
     assertEquals(counts.listAllFiles, 1, "first read warms the listing once");
 
-    // Simulate the invalidation path that clears caches without replacing the
-    // snapshot (e.g. a poke that could not fetch files inline).
+    // Drive the real invalidation path that clears caches without replacing the
+    // snapshot (a poke that could not fetch files inline).
     files[0] = { path: "pages/index.tsx", content: "export default 'v2';" };
     const context = adapter.getContentContext();
     if (!context) throw new Error("content context required");
     const internals = adapter as unknown as {
       cache: { delete: (key: string) => void };
-      readOps: { clearFileListIndex: () => void };
-      statOps: { clearIndex: () => void };
+      clearMemoryCaches: () => void;
     };
     internals.cache.delete(buildFileListCacheKey(context));
-    internals.readOps.clearFileListIndex();
-    internals.statOps.clearIndex();
+    internals.clearMemoryCaches();
 
     const second = await adapter.readTextFile("pages/index.tsx");
     assertEquals(
@@ -222,6 +220,150 @@ describe("file list fan-out (issue inbox#32)", () => {
       counts.listAllFiles,
       2,
       "the invalidated listing must be refetched exactly once",
+    );
+  });
+
+  it("serves later module reads from the warmed listing when cache storage retains nothing", async () => {
+    // Caching disabled is the sharpest form of "the cache write did not
+    // retain": setAsync is a no-op, exactly like an oversized listing dropped
+    // by the memory cache or a failed backend write. Without in-adapter
+    // retention every module lookup would start and await its own full
+    // listing fetch -- more API traffic than the per-file probing this
+    // change replaced.
+    const files: StubFile[] = Array.from({ length: 8 }, (_, index) => ({
+      path: `components/mod${index}.tsx`,
+      content: `export const mod${index} = ${index};`,
+    }));
+    const { adapter, counts } = createDraftAdapter(files, false);
+
+    const contents: string[] = [];
+    for (const file of files) {
+      contents.push(await adapter.readTextFile(file.path));
+    }
+
+    assertEquals(
+      contents,
+      files.map((file) => file.content),
+      "every module must be served with its draft content",
+    );
+    assertEquals(
+      counts.listAllFiles,
+      1,
+      "a non-retaining cache must not turn each module lookup into its own listing fetch",
+    );
+    assertEquals(
+      counts.getFileContent,
+      0,
+      "module reads must come from the warmed listing, not per-file API probes",
+    );
+  });
+
+  it("drops the retained listing on a poke so a non-retaining cache never serves stale drafts", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'v1';" },
+    ];
+    const { adapter, counts } = createDraftAdapter(files, false);
+
+    assertEquals(
+      await adapter.readTextFile("pages/index.tsx"),
+      "export default 'v1';",
+      "first read must see the initial draft",
+    );
+
+    files[0] = { path: "pages/index.tsx", content: "export default 'v2';" };
+    const context = adapter.getContentContext();
+    if (!context) throw new Error("content context required");
+    const internals = adapter as unknown as {
+      replaceSourceSnapshot: (
+        cacheKey: string,
+        snapshotFiles: Array<{ path: string; content?: string }>,
+      ) => Promise<void>;
+      clearMemoryCaches: () => void;
+    };
+
+    await internals.replaceSourceSnapshot(
+      buildFileListCacheKey(context),
+      files.map((file) => ({ ...file })),
+    );
+
+    assertEquals(
+      await adapter.readTextFile("pages/index.tsx"),
+      "export default 'v2';",
+      "a poked snapshot must win over the retained listing",
+    );
+
+    // A poke that could not carry files inline only clears memory caches. The
+    // retained listing must go with them, or the next read serves the old draft.
+    files[0] = { path: "pages/index.tsx", content: "export default 'v3';" };
+    internals.clearMemoryCaches();
+
+    assertEquals(
+      await adapter.readTextFile("pages/index.tsx"),
+      "export default 'v3';",
+      "clearing memory caches must invalidate the retained listing",
+    );
+    assertEquals(
+      counts.listAllFiles,
+      2,
+      "only the memory-cache invalidation may cost a refetch; the poked snapshot must not",
+    );
+  });
+
+  it("discards a warmup that resolves after a newer snapshot replaced it", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default 'v1';" },
+    ];
+    const { adapter, counts } = createDraftAdapter(files);
+
+    // Hold the listing fetch open so a WebSocket snapshot can land while it is
+    // in flight. The fetch resolves with the listing as it was *before* the
+    // snapshot -- writing that through would roll the cache back to v1.
+    let releaseFetch: (() => void) | undefined;
+    const fetchReleased = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const client = adapter.getClient() as unknown as {
+      listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+    };
+    const staleListing = files.map((file) => ({ ...file }));
+    client.listAllFiles = async () => {
+      counts.listAllFiles++;
+      await fetchReleased;
+      return staleListing;
+    };
+
+    const readPromise = adapter.readTextFile("pages/index.tsx");
+    await waitFor(() => Promise.resolve(counts.listAllFiles === 1));
+
+    const context = adapter.getContentContext();
+    if (!context) throw new Error("content context required");
+    const cacheKey = buildFileListCacheKey(context);
+    const internals = adapter as unknown as {
+      replaceSourceSnapshot: (
+        key: string,
+        snapshotFiles: Array<{ path: string; content?: string }>,
+      ) => Promise<void>;
+      cache: { getAsync: <T>(key: string) => Promise<T | undefined> };
+    };
+    await internals.replaceSourceSnapshot(cacheKey, [
+      { path: "pages/index.tsx", content: "export default 'v2';" },
+    ]);
+
+    releaseFetch?.();
+
+    assertEquals(
+      await readPromise,
+      "export default 'v2';",
+      "a warmup that started before the poke must not answer with its pre-poke listing",
+    );
+
+    const cached = await internals.cache.getAsync<Array<{ path: string; content?: string }>>(
+      cacheKey,
+    );
+    assertEquals(
+      cached?.[0]?.content,
+      "export default 'v2';",
+      "the obsolete warmup must not overwrite the newer snapshot in the cache",
     );
   });
 });

--- a/src/platform/adapters/fs/veryfront/stat-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.test.ts
@@ -405,6 +405,22 @@ describe("StatOperations", () => {
       assertEquals(searchCallCount, 4);
     });
 
+    it("should treat an empty provided file list as authoritative", async () => {
+      let searchCallCount = 0;
+      const client = createMockClient({
+        searchFiles: () => {
+          searchCallCount++;
+          return Promise.resolve([]);
+        },
+      });
+      const contextProvider = createBranchContextWithFiles([]);
+      contextProvider.hasCachedFileList = undefined;
+      const statOps = createStatOps(client, new PathNormalizer(), contextProvider);
+
+      assertEquals(await statOps.resolveFile("missing/component"), null);
+      assertEquals(searchCallCount, 0);
+    });
+
     it("should resolve via API search without building the full index", async () => {
       let listAllFilesCallCount = 0;
       let searchCallCount = 0;

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -393,7 +393,7 @@ export class StatOperations extends VeryfrontOperationsBase {
     }
 
     const files = await this.contextProvider?.getFileList?.();
-    return Array.isArray(files) && files.length > 0;
+    return Array.isArray(files);
   }
 
   private resolveFromIndex(
@@ -536,6 +536,15 @@ export class StatOperations extends VeryfrontOperationsBase {
     );
     if (indexedResolution) {
       return indexedResolution;
+    }
+
+    if (hasCachedFileList && fileIdx.size === 0) {
+      logger.debug("resolveFile not found in authoritative empty file list", {
+        normalizedPath,
+        indexMs,
+      });
+      this.cache.set(cacheKey, NOT_FOUND_SENTINEL);
+      return null;
     }
 
     if (attemptedApiResolve) {

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -95,6 +95,13 @@ function createWebSocketManager(options: {
   pregenerateStyles?: (
     files: Array<{ path: string; content?: string }>,
   ) => Promise<{ hash: string; assetPath: string } | undefined>;
+  clearMemoryCaches?: () => void;
+  getSourceSnapshotVersion?: () => number;
+  replaceSourceSnapshot?: (
+    cacheKey: string,
+    files: Array<{ path: string; content?: string }>,
+    expectedSnapshotVersion?: number,
+  ) => Promise<void>;
 } = {}): WebSocketManager {
   const cache = {
     deleteByPrefixAsync: async () => 0,
@@ -123,8 +130,9 @@ function createWebSocketManager(options: {
     }),
     getContentSource: () => ({ type: "branch", branch: "main" }),
     getProjectDir: () => undefined,
-    clearMemoryCaches: () => {},
-    replaceSourceSnapshot: async () => {},
+    clearMemoryCaches: options.clearMemoryCaches ?? (() => {}),
+    getSourceSnapshotVersion: options.getSourceSnapshotVersion,
+    replaceSourceSnapshot: options.replaceSourceSnapshot ?? (async () => {}),
     pregenerateStyles: options.pregenerateStyles,
   });
 }
@@ -901,6 +909,108 @@ describe("WebSocketManager", () => {
     assertEquals(capturedProject?.styleArtifactHash, "hash-1");
     assertEquals(capturedProject?.styleAssetPath, "/_vf/css/hash-1.css");
 
+    manager.dispose();
+  });
+
+  it("passes the pre-fetch source generation to selective snapshot replacement", async () => {
+    const fetchStarted = Promise.withResolvers<void>();
+    const releaseFetch = Promise.withResolvers<
+      Array<{ path: string; content?: string }>
+    >();
+    let sourceSnapshotVersion = 1;
+    let replacementVersion: number | undefined;
+    const manager = createWebSocketManager({
+      client: {
+        listAllFiles: () => {
+          fetchStarted.resolve();
+          return releaseFetch.promise;
+        },
+      },
+      clearMemoryCaches: () => {
+        sourceSnapshotVersion++;
+      },
+      getSourceSnapshotVersion: () => sourceSnapshotVersion,
+      replaceSourceSnapshot: (_cacheKey, _files, expectedSnapshotVersion) => {
+        replacementVersion = expectedSnapshotVersion;
+        return Promise.resolve();
+      },
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+    socket.onmessage?.call(
+      socket as unknown as WebSocket,
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "poke",
+          data: { changedPaths: ["app/page.tsx"], branchName: "main" },
+        }),
+      }),
+    );
+
+    assertEquals(runOnlyScheduledTimer(), 100);
+    await fetchStarted.promise;
+    sourceSnapshotVersion++;
+    releaseFetch.resolve([{ path: "app/page.tsx", content: "v1" }]);
+    await flushMicrotasks();
+
+    assertEquals(
+      replacementVersion,
+      2,
+      "replacement must receive the generation captured before the file-list fetch",
+    );
+    manager.dispose();
+  });
+
+  it("passes the post-clear source generation to full snapshot replacement", async () => {
+    const fetchStarted = Promise.withResolvers<void>();
+    const releaseFetch = Promise.withResolvers<
+      Array<{ path: string; content?: string }>
+    >();
+    let sourceSnapshotVersion = 1;
+    let replacementVersion: number | undefined;
+    const manager = createWebSocketManager({
+      client: {
+        listAllFiles: () => {
+          fetchStarted.resolve();
+          return releaseFetch.promise;
+        },
+      },
+      clearMemoryCaches: () => {
+        sourceSnapshotVersion++;
+      },
+      getSourceSnapshotVersion: () => sourceSnapshotVersion,
+      replaceSourceSnapshot: (_cacheKey, _files, expectedSnapshotVersion) => {
+        replacementVersion = expectedSnapshotVersion;
+        return Promise.resolve();
+      },
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+    socket.onmessage?.call(
+      socket as unknown as WebSocket,
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "poke",
+          data: { branchName: "main" },
+        }),
+      }),
+    );
+
+    assertEquals(runOnlyScheduledTimer(), 100);
+    await fetchStarted.promise;
+    sourceSnapshotVersion++;
+    releaseFetch.resolve([{ path: "app/page.tsx", content: "v1" }]);
+    await flushMicrotasks();
+
+    assertEquals(
+      replacementVersion,
+      3,
+      "replacement must receive the generation captured after the full invalidation clear",
+    );
     manager.dispose();
   });
 

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -101,7 +101,7 @@ function createWebSocketManager(options: {
     cacheKey: string,
     files: Array<{ path: string; content?: string }>,
     expectedSnapshotVersion?: number,
-  ) => Promise<boolean>;
+  ) => Promise<number | undefined>;
 } = {}): WebSocketManager {
   const cache = {
     deleteByPrefixAsync: async () => 0,
@@ -132,7 +132,7 @@ function createWebSocketManager(options: {
     getProjectDir: () => undefined,
     clearMemoryCaches: options.clearMemoryCaches ?? (() => {}),
     getSourceSnapshotVersion: options.getSourceSnapshotVersion,
-    replaceSourceSnapshot: options.replaceSourceSnapshot ?? (async () => true),
+    replaceSourceSnapshot: options.replaceSourceSnapshot ?? (async () => 0),
     pregenerateStyles: options.pregenerateStyles,
   });
 }
@@ -664,7 +664,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => true,
+      replaceSourceSnapshot: async () => 0,
     });
 
     manager.connect("project-1");
@@ -726,7 +726,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => true,
+      replaceSourceSnapshot: async () => 0,
     });
 
     manager.connect("project-1");
@@ -765,7 +765,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => true,
+      replaceSourceSnapshot: async () => 0,
     });
 
     manager.connect("project-1");
@@ -804,7 +804,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => true,
+      replaceSourceSnapshot: async () => 0,
     });
 
     manager.connect("project-1");
@@ -843,7 +843,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => true,
+      replaceSourceSnapshot: async () => 0,
     });
 
     manager.connect("project-1");
@@ -932,7 +932,9 @@ describe("WebSocketManager", () => {
       getSourceSnapshotVersion: () => sourceSnapshotVersion,
       replaceSourceSnapshot: (_cacheKey, _files, expectedSnapshotVersion) => {
         replacementVersion = expectedSnapshotVersion;
-        return Promise.resolve(true);
+        return Promise.resolve(
+          expectedSnapshotVersion === sourceSnapshotVersion ? sourceSnapshotVersion : undefined,
+        );
       },
     });
 
@@ -983,7 +985,9 @@ describe("WebSocketManager", () => {
       },
       getSourceSnapshotVersion: () => sourceSnapshotVersion,
       replaceSourceSnapshot: (_cacheKey, _files, expectedSnapshotVersion) =>
-        Promise.resolve(expectedSnapshotVersion === sourceSnapshotVersion),
+        Promise.resolve(
+          expectedSnapshotVersion === sourceSnapshotVersion ? sourceSnapshotVersion : undefined,
+        ),
       pregenerateStyles: () => {
         pregenerateCalls++;
         return Promise.resolve({
@@ -1024,11 +1028,75 @@ describe("WebSocketManager", () => {
     manager.dispose();
   });
 
-  it("passes the post-clear source generation to full snapshot replacement", async () => {
+  it("does not publish styles superseded during selective pregeneration", async () => {
+    const pregenerationStarted = Promise.withResolvers<void>();
+    const releasePregeneration = Promise.withResolvers<{
+      hash: string;
+      assetPath: string;
+    }>();
+    let sourceSnapshotVersion = 1;
+    let publishedStyleHash: string | undefined;
+    const manager = createWebSocketManager({
+      client: {
+        listAllFiles: () => Promise.resolve([{ path: "app/page.tsx", content: "v1" }]),
+      },
+      clearMemoryCaches: () => {
+        sourceSnapshotVersion++;
+      },
+      getSourceSnapshotVersion: () => sourceSnapshotVersion,
+      replaceSourceSnapshot: () => {
+        sourceSnapshotVersion++;
+        return Promise.resolve(sourceSnapshotVersion);
+      },
+      pregenerateStyles: () => {
+        pregenerationStarted.resolve();
+        return releasePregeneration.promise;
+      },
+      invalidationCallbacks: {
+        triggerReload: (_changedPaths, project) => {
+          publishedStyleHash = project?.styleArtifactHash;
+        },
+      },
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+    const poke = () =>
+      socket.onmessage?.call(
+        socket as unknown as WebSocket,
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "poke",
+            data: { changedPaths: ["app/page.tsx"], branchName: "main" },
+          }),
+        }),
+      );
+
+    poke();
+    assertEquals(runOnlyScheduledTimer(), 100);
+    await pregenerationStarted.promise;
+    poke();
+    releasePregeneration.resolve({
+      hash: "stale-hash",
+      assetPath: "/_vf/css/stale-hash.css",
+    });
+    await flushMicrotasks();
+
+    assertEquals(publishedStyleHash, undefined);
+    manager.dispose();
+  });
+
+  it("discards full styles superseded during pregeneration", async () => {
     const fetchStarted = Promise.withResolvers<void>();
     const releaseFetch = Promise.withResolvers<
       Array<{ path: string; content?: string }>
     >();
+    const pregenerationStarted = Promise.withResolvers<void>();
+    const releasePregeneration = Promise.withResolvers<{
+      hash: string;
+      assetPath: string;
+    }>();
     let sourceSnapshotVersion = 1;
     let replacementVersion: number | undefined;
     let pregenerateCalls = 0;
@@ -1046,14 +1114,16 @@ describe("WebSocketManager", () => {
       getSourceSnapshotVersion: () => sourceSnapshotVersion,
       replaceSourceSnapshot: (_cacheKey, _files, expectedSnapshotVersion) => {
         replacementVersion = expectedSnapshotVersion;
-        return Promise.resolve(expectedSnapshotVersion === sourceSnapshotVersion);
+        if (expectedSnapshotVersion !== sourceSnapshotVersion) {
+          return Promise.resolve(undefined);
+        }
+        sourceSnapshotVersion++;
+        return Promise.resolve(sourceSnapshotVersion);
       },
       pregenerateStyles: () => {
         pregenerateCalls++;
-        return Promise.resolve({
-          hash: "stale-hash",
-          assetPath: "/_vf/css/stale-hash.css",
-        });
+        pregenerationStarted.resolve();
+        return releasePregeneration.promise;
       },
       invalidationCallbacks: {
         triggerReload: (_changedPaths, project) => {
@@ -1077,8 +1147,21 @@ describe("WebSocketManager", () => {
 
     assertEquals(runOnlyScheduledTimer(), 100);
     await fetchStarted.promise;
-    sourceSnapshotVersion++;
     releaseFetch.resolve([{ path: "app/page.tsx", content: "v1" }]);
+    await pregenerationStarted.promise;
+    socket.onmessage?.call(
+      socket as unknown as WebSocket,
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "poke",
+          data: { branchName: "main" },
+        }),
+      }),
+    );
+    releasePregeneration.resolve({
+      hash: "stale-hash",
+      assetPath: "/_vf/css/stale-hash.css",
+    });
     await flushMicrotasks();
 
     assertEquals(
@@ -1086,7 +1169,7 @@ describe("WebSocketManager", () => {
       3,
       "replacement must receive the generation captured after the full invalidation clear",
     );
-    assertEquals(pregenerateCalls, 0);
+    assertEquals(pregenerateCalls, 1);
     assertEquals(publishedStyleHash, undefined);
     manager.dispose();
   });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
-import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
+import type { ProjectFile, VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import type { FileCache } from "../cache/file-cache.ts";
 import type { InvalidationCallbacks } from "./types.ts";
 import { WebSocketManager } from "./websocket-manager.ts";
@@ -15,6 +15,16 @@ import { __resetLoggerConfigForTests } from "#veryfront/utils/logger/logger.ts";
 interface TimerEntry {
   delay: number;
   callback: () => void;
+}
+
+function makeProjectFile(path: string, content: string): ProjectFile {
+  return {
+    path,
+    content,
+    type: "page",
+    size: content.length,
+    updated_at: "2026-08-17T00:00:00.000Z",
+  };
 }
 
 class MockWebSocket {
@@ -914,9 +924,7 @@ describe("WebSocketManager", () => {
 
   it("passes the pre-fetch source generation to selective snapshot replacement", async () => {
     const fetchStarted = Promise.withResolvers<void>();
-    const releaseFetch = Promise.withResolvers<
-      Array<{ path: string; content?: string }>
-    >();
+    const releaseFetch = Promise.withResolvers<ProjectFile[]>();
     let sourceSnapshotVersion = 1;
     let replacementVersion: number | undefined;
     const manager = createWebSocketManager({
@@ -954,7 +962,7 @@ describe("WebSocketManager", () => {
     assertEquals(runOnlyScheduledTimer(), 100);
     await fetchStarted.promise;
     sourceSnapshotVersion++;
-    releaseFetch.resolve([{ path: "app/page.tsx", content: "v1" }]);
+    releaseFetch.resolve([makeProjectFile("app/page.tsx", "v1")]);
     await flushMicrotasks();
 
     assertEquals(
@@ -967,9 +975,7 @@ describe("WebSocketManager", () => {
 
   it("does not pregenerate styles for a superseded selective snapshot", async () => {
     const fetchStarted = Promise.withResolvers<void>();
-    const releaseFetch = Promise.withResolvers<
-      Array<{ path: string; content?: string }>
-    >();
+    const releaseFetch = Promise.withResolvers<ProjectFile[]>();
     let sourceSnapshotVersion = 1;
     let pregenerateCalls = 0;
     let publishedStyleHash: string | undefined;
@@ -1020,7 +1026,7 @@ describe("WebSocketManager", () => {
     assertEquals(runOnlyScheduledTimer(), 100);
     await fetchStarted.promise;
     poke();
-    releaseFetch.resolve([{ path: "app/page.tsx", content: "v1" }]);
+    releaseFetch.resolve([makeProjectFile("app/page.tsx", "v1")]);
     await flushMicrotasks();
 
     assertEquals(pregenerateCalls, 0);
@@ -1038,7 +1044,7 @@ describe("WebSocketManager", () => {
     let publishedStyleHash: string | undefined;
     const manager = createWebSocketManager({
       client: {
-        listAllFiles: () => Promise.resolve([{ path: "app/page.tsx", content: "v1" }]),
+        listAllFiles: () => Promise.resolve([makeProjectFile("app/page.tsx", "v1")]),
       },
       clearMemoryCaches: () => {
         sourceSnapshotVersion++;
@@ -1089,9 +1095,7 @@ describe("WebSocketManager", () => {
 
   it("discards full styles superseded during pregeneration", async () => {
     const fetchStarted = Promise.withResolvers<void>();
-    const releaseFetch = Promise.withResolvers<
-      Array<{ path: string; content?: string }>
-    >();
+    const releaseFetch = Promise.withResolvers<ProjectFile[]>();
     const pregenerationStarted = Promise.withResolvers<void>();
     const releasePregeneration = Promise.withResolvers<{
       hash: string;
@@ -1147,7 +1151,7 @@ describe("WebSocketManager", () => {
 
     assertEquals(runOnlyScheduledTimer(), 100);
     await fetchStarted.promise;
-    releaseFetch.resolve([{ path: "app/page.tsx", content: "v1" }]);
+    releaseFetch.resolve([makeProjectFile("app/page.tsx", "v1")]);
     await pregenerationStarted.promise;
     socket.onmessage?.call(
       socket as unknown as WebSocket,

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -979,6 +979,7 @@ describe("WebSocketManager", () => {
     let sourceSnapshotVersion = 1;
     let pregenerateCalls = 0;
     let publishedStyleHash: string | undefined;
+    let reloadCalls = 0;
     const manager = createWebSocketManager({
       client: {
         listAllFiles: () => {
@@ -1003,6 +1004,7 @@ describe("WebSocketManager", () => {
       },
       invalidationCallbacks: {
         triggerReload: (_changedPaths, project) => {
+          reloadCalls++;
           publishedStyleHash = project?.styleArtifactHash;
         },
       },
@@ -1031,6 +1033,7 @@ describe("WebSocketManager", () => {
 
     assertEquals(pregenerateCalls, 0);
     assertEquals(publishedStyleHash, undefined);
+    assertEquals(reloadCalls, 0, "a rejected selective snapshot must not publish a reload");
     manager.dispose();
   });
 
@@ -1042,6 +1045,7 @@ describe("WebSocketManager", () => {
     }>();
     let sourceSnapshotVersion = 1;
     let publishedStyleHash: string | undefined;
+    let reloadCalls = 0;
     const manager = createWebSocketManager({
       client: {
         listAllFiles: () => Promise.resolve([makeProjectFile("app/page.tsx", "v1")]),
@@ -1060,6 +1064,7 @@ describe("WebSocketManager", () => {
       },
       invalidationCallbacks: {
         triggerReload: (_changedPaths, project) => {
+          reloadCalls++;
           publishedStyleHash = project?.styleArtifactHash;
         },
       },
@@ -1090,6 +1095,7 @@ describe("WebSocketManager", () => {
     await flushMicrotasks();
 
     assertEquals(publishedStyleHash, undefined);
+    assertEquals(reloadCalls, 0, "a superseded selective invalidation must not publish a reload");
     manager.dispose();
   });
 
@@ -1105,6 +1111,7 @@ describe("WebSocketManager", () => {
     let replacementVersion: number | undefined;
     let pregenerateCalls = 0;
     let publishedStyleHash: string | undefined;
+    let reloadCalls = 0;
     const manager = createWebSocketManager({
       client: {
         listAllFiles: () => {
@@ -1131,6 +1138,7 @@ describe("WebSocketManager", () => {
       },
       invalidationCallbacks: {
         triggerReload: (_changedPaths, project) => {
+          reloadCalls++;
           publishedStyleHash = project?.styleArtifactHash;
         },
       },
@@ -1175,6 +1183,7 @@ describe("WebSocketManager", () => {
     );
     assertEquals(pregenerateCalls, 1);
     assertEquals(publishedStyleHash, undefined);
+    assertEquals(reloadCalls, 0, "a superseded full invalidation must not publish a reload");
     manager.dispose();
   });
 

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -1046,6 +1046,7 @@ describe("WebSocketManager", () => {
     let sourceSnapshotVersion = 1;
     let publishedStyleHash: string | undefined;
     let reloadCalls = 0;
+    let evictCalls = 0;
     const manager = createWebSocketManager({
       client: {
         listAllFiles: () => Promise.resolve([makeProjectFile("app/page.tsx", "v1")]),
@@ -1066,6 +1067,10 @@ describe("WebSocketManager", () => {
         triggerReload: (_changedPaths, project) => {
           reloadCalls++;
           publishedStyleHash = project?.styleArtifactHash;
+        },
+        evictCurrentAdapter: () => {
+          evictCalls++;
+          manager.dispose();
         },
       },
     });
@@ -1096,7 +1101,16 @@ describe("WebSocketManager", () => {
 
     assertEquals(publishedStyleHash, undefined);
     assertEquals(reloadCalls, 0, "a superseded selective invalidation must not publish a reload");
-    manager.dispose();
+    assertEquals(evictCalls, 0, "a superseded invalidation must not cancel the newer poke");
+
+    assertEquals(
+      runOnlyScheduledTimer(),
+      100,
+      "the newer selective invalidation must remain queued",
+    );
+    await flushMicrotasks();
+    assertEquals(reloadCalls, 1, "the newer selective invalidation must publish its reload");
+    assertEquals(evictCalls, 1, "the adapter may be evicted after the newer invalidation succeeds");
   });
 
   it("discards full styles superseded during pregeneration", async () => {
@@ -1112,6 +1126,7 @@ describe("WebSocketManager", () => {
     let pregenerateCalls = 0;
     let publishedStyleHash: string | undefined;
     let reloadCalls = 0;
+    let evictCalls = 0;
     const manager = createWebSocketManager({
       client: {
         listAllFiles: () => {
@@ -1140,6 +1155,9 @@ describe("WebSocketManager", () => {
         triggerReload: (_changedPaths, project) => {
           reloadCalls++;
           publishedStyleHash = project?.styleArtifactHash;
+        },
+        evictCurrentAdapter: () => {
+          evictCalls++;
         },
       },
     });
@@ -1184,6 +1202,7 @@ describe("WebSocketManager", () => {
     assertEquals(pregenerateCalls, 1);
     assertEquals(publishedStyleHash, undefined);
     assertEquals(reloadCalls, 0, "a superseded full invalidation must not publish a reload");
+    assertEquals(evictCalls, 0, "a superseded full invalidation must preserve the newer poke");
     manager.dispose();
   });
 

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -101,7 +101,7 @@ function createWebSocketManager(options: {
     cacheKey: string,
     files: Array<{ path: string; content?: string }>,
     expectedSnapshotVersion?: number,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
 } = {}): WebSocketManager {
   const cache = {
     deleteByPrefixAsync: async () => 0,
@@ -132,7 +132,7 @@ function createWebSocketManager(options: {
     getProjectDir: () => undefined,
     clearMemoryCaches: options.clearMemoryCaches ?? (() => {}),
     getSourceSnapshotVersion: options.getSourceSnapshotVersion,
-    replaceSourceSnapshot: options.replaceSourceSnapshot ?? (async () => {}),
+    replaceSourceSnapshot: options.replaceSourceSnapshot ?? (async () => true),
     pregenerateStyles: options.pregenerateStyles,
   });
 }
@@ -664,7 +664,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => {},
+      replaceSourceSnapshot: async () => true,
     });
 
     manager.connect("project-1");
@@ -726,7 +726,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => {},
+      replaceSourceSnapshot: async () => true,
     });
 
     manager.connect("project-1");
@@ -765,7 +765,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => {},
+      replaceSourceSnapshot: async () => true,
     });
 
     manager.connect("project-1");
@@ -804,7 +804,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => {},
+      replaceSourceSnapshot: async () => true,
     });
 
     manager.connect("project-1");
@@ -843,7 +843,7 @@ describe("WebSocketManager", () => {
       getContentSource: () => ({ type: "branch", branch: "main" }),
       getProjectDir: () => undefined,
       clearMemoryCaches: () => {},
-      replaceSourceSnapshot: async () => {},
+      replaceSourceSnapshot: async () => true,
     });
 
     manager.connect("project-1");
@@ -932,7 +932,7 @@ describe("WebSocketManager", () => {
       getSourceSnapshotVersion: () => sourceSnapshotVersion,
       replaceSourceSnapshot: (_cacheKey, _files, expectedSnapshotVersion) => {
         replacementVersion = expectedSnapshotVersion;
-        return Promise.resolve();
+        return Promise.resolve(true);
       },
     });
 
@@ -963,6 +963,67 @@ describe("WebSocketManager", () => {
     manager.dispose();
   });
 
+  it("does not pregenerate styles for a superseded selective snapshot", async () => {
+    const fetchStarted = Promise.withResolvers<void>();
+    const releaseFetch = Promise.withResolvers<
+      Array<{ path: string; content?: string }>
+    >();
+    let sourceSnapshotVersion = 1;
+    let pregenerateCalls = 0;
+    let publishedStyleHash: string | undefined;
+    const manager = createWebSocketManager({
+      client: {
+        listAllFiles: () => {
+          fetchStarted.resolve();
+          return releaseFetch.promise;
+        },
+      },
+      clearMemoryCaches: () => {
+        sourceSnapshotVersion++;
+      },
+      getSourceSnapshotVersion: () => sourceSnapshotVersion,
+      replaceSourceSnapshot: (_cacheKey, _files, expectedSnapshotVersion) =>
+        Promise.resolve(expectedSnapshotVersion === sourceSnapshotVersion),
+      pregenerateStyles: () => {
+        pregenerateCalls++;
+        return Promise.resolve({
+          hash: "stale-hash",
+          assetPath: "/_vf/css/stale-hash.css",
+        });
+      },
+      invalidationCallbacks: {
+        triggerReload: (_changedPaths, project) => {
+          publishedStyleHash = project?.styleArtifactHash;
+        },
+      },
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+    const poke = () =>
+      socket.onmessage?.call(
+        socket as unknown as WebSocket,
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "poke",
+            data: { changedPaths: ["app/page.tsx"], branchName: "main" },
+          }),
+        }),
+      );
+
+    poke();
+    assertEquals(runOnlyScheduledTimer(), 100);
+    await fetchStarted.promise;
+    poke();
+    releaseFetch.resolve([{ path: "app/page.tsx", content: "v1" }]);
+    await flushMicrotasks();
+
+    assertEquals(pregenerateCalls, 0);
+    assertEquals(publishedStyleHash, undefined);
+    manager.dispose();
+  });
+
   it("passes the post-clear source generation to full snapshot replacement", async () => {
     const fetchStarted = Promise.withResolvers<void>();
     const releaseFetch = Promise.withResolvers<
@@ -970,6 +1031,8 @@ describe("WebSocketManager", () => {
     >();
     let sourceSnapshotVersion = 1;
     let replacementVersion: number | undefined;
+    let pregenerateCalls = 0;
+    let publishedStyleHash: string | undefined;
     const manager = createWebSocketManager({
       client: {
         listAllFiles: () => {
@@ -983,7 +1046,19 @@ describe("WebSocketManager", () => {
       getSourceSnapshotVersion: () => sourceSnapshotVersion,
       replaceSourceSnapshot: (_cacheKey, _files, expectedSnapshotVersion) => {
         replacementVersion = expectedSnapshotVersion;
-        return Promise.resolve();
+        return Promise.resolve(expectedSnapshotVersion === sourceSnapshotVersion);
+      },
+      pregenerateStyles: () => {
+        pregenerateCalls++;
+        return Promise.resolve({
+          hash: "stale-hash",
+          assetPath: "/_vf/css/stale-hash.css",
+        });
+      },
+      invalidationCallbacks: {
+        triggerReload: (_changedPaths, project) => {
+          publishedStyleHash = project?.styleArtifactHash;
+        },
       },
     });
 
@@ -1011,6 +1086,8 @@ describe("WebSocketManager", () => {
       3,
       "replacement must receive the generation captured after the full invalidation clear",
     );
+    assertEquals(pregenerateCalls, 0);
+    assertEquals(publishedStyleHash, undefined);
     manager.dispose();
   });
 

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -804,7 +804,9 @@ export class WebSocketManager {
           previewInvalidationPrefixes,
           previewInvalidationVersion,
         );
-        this.deps.invalidationCallbacks.evictCurrentAdapter?.();
+        if (!reloadSuperseded) {
+          this.deps.invalidationCallbacks.evictCurrentAdapter?.();
+        }
       }
     }
   }
@@ -991,7 +993,9 @@ export class WebSocketManager {
           previewInvalidationPrefixes,
           previewInvalidationVersion,
         );
-        this.deps.invalidationCallbacks.evictCurrentAdapter?.();
+        if (!reloadSuperseded) {
+          this.deps.invalidationCallbacks.evictCurrentAdapter?.();
+        }
       }
     }
   }

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -633,6 +633,7 @@ export class WebSocketManager {
     const previewInvalidationPrefixes = this.getPreviewInvalidationPrefixes(contentContext);
     const previewInvalidationVersion = this.previewInvalidationVersion;
     let preparedStyleArtifact: PreviewStyleArtifactInfo | undefined;
+    let reloadSuperseded = false;
     let succeeded = false;
 
     try {
@@ -734,7 +735,9 @@ export class WebSocketManager {
             files,
             sourceSnapshotVersion,
           );
-          if (appliedSnapshotVersion !== undefined) {
+          if (appliedSnapshotVersion === undefined) {
+            reloadSuperseded = true;
+          } else {
             preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
             const currentSnapshotVersion = this.deps.getSourceSnapshotVersion?.();
             if (
@@ -742,6 +745,7 @@ export class WebSocketManager {
               currentSnapshotVersion !== appliedSnapshotVersion
             ) {
               preparedStyleArtifact = undefined;
+              reloadSuperseded = true;
             }
 
             logger.debug("Fresh files cached (memory + Redis)", {
@@ -759,29 +763,37 @@ export class WebSocketManager {
 
       this.pokeMetrics.invalidationsTriggered++;
 
-      logger.info(
-        "[WebSocketManager] TRIGGERING HMR RELOAD via invalidationCallbacks.triggerReload",
-        {
+      if (reloadSuperseded) {
+        logger.debug("Skipping reload for superseded selective invalidation", {
           changedPathsCount: changedPaths.length,
           projectSlug: this.deps.projectSlug,
-          projectId: this.deps.client.getProjectId(),
-          hasTriggerReloadCallback: !!this.deps.invalidationCallbacks.triggerReload,
-        },
-      );
+        });
+      } else {
+        logger.info(
+          "[WebSocketManager] TRIGGERING HMR RELOAD via invalidationCallbacks.triggerReload",
+          {
+            changedPathsCount: changedPaths.length,
+            projectSlug: this.deps.projectSlug,
+            projectId: this.deps.client.getProjectId(),
+            hasTriggerReloadCallback: !!this.deps.invalidationCallbacks.triggerReload,
+          },
+        );
 
-      const projectContext = buildReloadProjectContext(
-        contentContext,
-        this.deps.projectSlug,
-        this.deps.client.getProjectId(),
-        preparedStyleArtifact,
-      );
+        const projectContext = buildReloadProjectContext(
+          contentContext,
+          this.deps.projectSlug,
+          this.deps.client.getProjectId(),
+          preparedStyleArtifact,
+        );
 
-      this.deps.invalidationCallbacks.triggerReload?.(changedPaths, projectContext);
+        this.deps.invalidationCallbacks.triggerReload?.(changedPaths, projectContext);
+      }
 
-      logger.info("Selective invalidation complete - HMR triggered", {
+      logger.info("Selective invalidation complete", {
         changedPathsCount: changedPaths.length,
         durationMs: Date.now() - startTime,
         totalInvalidations: this.pokeMetrics.invalidationsTriggered,
+        reloadTriggered: !reloadSuperseded,
       });
 
       this.sendPokeAck("selective", changedPaths);
@@ -803,6 +815,7 @@ export class WebSocketManager {
     const previewInvalidationPrefixes = this.getPreviewInvalidationPrefixes(contentContext);
     const previewInvalidationVersion = this.previewInvalidationVersion;
     let preparedStyleArtifact: PreviewStyleArtifactInfo | undefined;
+    let reloadSuperseded = false;
     let succeeded = false;
 
     try {
@@ -914,7 +927,9 @@ export class WebSocketManager {
             files,
             sourceSnapshotVersion,
           );
-          if (appliedSnapshotVersion !== undefined) {
+          if (appliedSnapshotVersion === undefined) {
+            reloadSuperseded = true;
+          } else {
             preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
             const currentSnapshotVersion = this.deps.getSourceSnapshotVersion?.();
             if (
@@ -922,6 +937,7 @@ export class WebSocketManager {
               currentSnapshotVersion !== appliedSnapshotVersion
             ) {
               preparedStyleArtifact = undefined;
+              reloadSuperseded = true;
             }
 
             logger.debug("FRESH FILES FETCHED", {
@@ -937,20 +953,26 @@ export class WebSocketManager {
 
       this.pokeMetrics.invalidationsTriggered++;
 
-      logger.info("TRIGGERING FULL BROWSER RELOAD via ReloadNotifier", {
-        projectSlug: this.deps.projectSlug,
-        projectId: this.deps.client.getProjectId(),
-        hasTriggerReloadCallback: !!this.deps.invalidationCallbacks.triggerReload,
-      });
+      if (reloadSuperseded) {
+        logger.debug("Skipping reload for superseded full invalidation", {
+          projectSlug: this.deps.projectSlug,
+        });
+      } else {
+        logger.info("TRIGGERING FULL BROWSER RELOAD via ReloadNotifier", {
+          projectSlug: this.deps.projectSlug,
+          projectId: this.deps.client.getProjectId(),
+          hasTriggerReloadCallback: !!this.deps.invalidationCallbacks.triggerReload,
+        });
 
-      const projectContext = buildReloadProjectContext(
-        contentContext,
-        this.deps.projectSlug,
-        this.deps.client.getProjectId(),
-        preparedStyleArtifact,
-      );
+        const projectContext = buildReloadProjectContext(
+          contentContext,
+          this.deps.projectSlug,
+          this.deps.client.getProjectId(),
+          preparedStyleArtifact,
+        );
 
-      this.deps.invalidationCallbacks.triggerReload?.(undefined, projectContext);
+        this.deps.invalidationCallbacks.triggerReload?.(undefined, projectContext);
+      }
 
       logger.debug("CACHE INVALIDATION COMPLETE", {
         fileCacheCleared: totalFileCount,

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -65,7 +65,7 @@ interface WebSocketDeps {
     cacheKey: string,
     files: ProjectFile[],
     expectedSnapshotVersion?: number,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   pregenerateStyles?: (
     files: ProjectFile[],
   ) => Promise<PreviewStyleArtifactInfo | undefined>;
@@ -729,14 +729,20 @@ export class WebSocketManager {
         try {
           const files = await this.deps.client.listAllFiles();
           const cacheKey = buildFileListCacheKey(contentContext);
-          await this.deps.replaceSourceSnapshot(cacheKey, files, sourceSnapshotVersion);
-          preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
-
-          logger.debug("Fresh files cached (memory + Redis)", {
+          const snapshotApplied = await this.deps.replaceSourceSnapshot(
             cacheKey,
-            fileCount: files.length,
-            styleAssetPath: preparedStyleArtifact?.assetPath,
-          });
+            files,
+            sourceSnapshotVersion,
+          );
+          if (snapshotApplied) {
+            preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
+
+            logger.debug("Fresh files cached (memory + Redis)", {
+              cacheKey,
+              fileCount: files.length,
+              styleAssetPath: preparedStyleArtifact?.assetPath,
+            });
+          }
         } catch (error) {
           logger.warn("Failed to fetch files during selective invalidation", {
             error,
@@ -896,14 +902,20 @@ export class WebSocketManager {
         try {
           const files = await this.deps.client.listAllFiles();
           const cacheKey = buildFileListCacheKey(contentContext);
-          await this.deps.replaceSourceSnapshot(cacheKey, files, sourceSnapshotVersion);
-          preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
-
-          logger.debug("FRESH FILES FETCHED", {
+          const snapshotApplied = await this.deps.replaceSourceSnapshot(
             cacheKey,
-            fileCount: files.length,
-            styleAssetPath: preparedStyleArtifact?.assetPath,
-          });
+            files,
+            sourceSnapshotVersion,
+          );
+          if (snapshotApplied) {
+            preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
+
+            logger.debug("FRESH FILES FETCHED", {
+              cacheKey,
+              fileCount: files.length,
+              styleAssetPath: preparedStyleArtifact?.assetPath,
+            });
+          }
         } catch (error) {
           logger.warn("Failed to fetch files during invalidation", { error });
         }

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -65,7 +65,7 @@ interface WebSocketDeps {
     cacheKey: string,
     files: ProjectFile[],
     expectedSnapshotVersion?: number,
-  ) => Promise<boolean>;
+  ) => Promise<number | undefined>;
   pregenerateStyles?: (
     files: ProjectFile[],
   ) => Promise<PreviewStyleArtifactInfo | undefined>;
@@ -729,13 +729,20 @@ export class WebSocketManager {
         try {
           const files = await this.deps.client.listAllFiles();
           const cacheKey = buildFileListCacheKey(contentContext);
-          const snapshotApplied = await this.deps.replaceSourceSnapshot(
+          const appliedSnapshotVersion = await this.deps.replaceSourceSnapshot(
             cacheKey,
             files,
             sourceSnapshotVersion,
           );
-          if (snapshotApplied) {
+          if (appliedSnapshotVersion !== undefined) {
             preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
+            const currentSnapshotVersion = this.deps.getSourceSnapshotVersion?.();
+            if (
+              currentSnapshotVersion !== undefined &&
+              currentSnapshotVersion !== appliedSnapshotVersion
+            ) {
+              preparedStyleArtifact = undefined;
+            }
 
             logger.debug("Fresh files cached (memory + Redis)", {
               cacheKey,
@@ -902,13 +909,20 @@ export class WebSocketManager {
         try {
           const files = await this.deps.client.listAllFiles();
           const cacheKey = buildFileListCacheKey(contentContext);
-          const snapshotApplied = await this.deps.replaceSourceSnapshot(
+          const appliedSnapshotVersion = await this.deps.replaceSourceSnapshot(
             cacheKey,
             files,
             sourceSnapshotVersion,
           );
-          if (snapshotApplied) {
+          if (appliedSnapshotVersion !== undefined) {
             preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
+            const currentSnapshotVersion = this.deps.getSourceSnapshotVersion?.();
+            if (
+              currentSnapshotVersion !== undefined &&
+              currentSnapshotVersion !== appliedSnapshotVersion
+            ) {
+              preparedStyleArtifact = undefined;
+            }
 
             logger.debug("FRESH FILES FETCHED", {
               cacheKey,

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -60,9 +60,11 @@ interface WebSocketDeps {
   getContentSource: () => ContentSource;
   getProjectDir: () => string | undefined;
   clearMemoryCaches: () => void;
+  getSourceSnapshotVersion?: () => number;
   replaceSourceSnapshot: (
     cacheKey: string,
     files: ProjectFile[],
+    expectedSnapshotVersion?: number,
   ) => Promise<void>;
   pregenerateStyles?: (
     files: ProjectFile[],
@@ -627,6 +629,7 @@ export class WebSocketManager {
     this.pendingChangedPaths.clear();
 
     const contentContext = this.deps.getContentContext();
+    const sourceSnapshotVersion = this.deps.getSourceSnapshotVersion?.();
     const previewInvalidationPrefixes = this.getPreviewInvalidationPrefixes(contentContext);
     const previewInvalidationVersion = this.previewInvalidationVersion;
     let preparedStyleArtifact: PreviewStyleArtifactInfo | undefined;
@@ -726,7 +729,7 @@ export class WebSocketManager {
         try {
           const files = await this.deps.client.listAllFiles();
           const cacheKey = buildFileListCacheKey(contentContext);
-          await this.deps.replaceSourceSnapshot(cacheKey, files);
+          await this.deps.replaceSourceSnapshot(cacheKey, files, sourceSnapshotVersion);
           preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
 
           logger.debug("Fresh files cached (memory + Redis)", {
@@ -823,6 +826,7 @@ export class WebSocketManager {
       // These caches are also cleared immediately on POKE receipt (before debounce).
       // These calls are redundant safety nets for the full invalidation flow.
       this.deps.clearMemoryCaches();
+      const sourceSnapshotVersion = this.deps.getSourceSnapshotVersion?.();
       this.deps.invalidationCallbacks.clearDomainCache?.();
 
       const projectId = this.deps.client.getProjectId();
@@ -892,7 +896,7 @@ export class WebSocketManager {
         try {
           const files = await this.deps.client.listAllFiles();
           const cacheKey = buildFileListCacheKey(contentContext);
-          await this.deps.replaceSourceSnapshot(cacheKey, files);
+          await this.deps.replaceSourceSnapshot(cacheKey, files, sourceSnapshotVersion);
           preparedStyleArtifact = await this.deps.pregenerateStyles?.(files);
 
           logger.debug("FRESH FILES FETCHED", {


### PR DESCRIPTION
## Problem

When the cached draft file listing expires (60s TTL), SSR module resolution answers "no list" and every module on the page falls back to its own per-file content fetch plus per-extension pattern search. On a representative preview `GET /` this fans out to ~57 sequential-ish API calls (~5.7s render), all triggered from `mdx.fetch_module` under `layout.preloadModules`.

The cache miss already scheduled a single-flight file-list warmup — but returned without waiting for it, so the render raced ahead on the slow per-file path while the one fetch that would have answered everything completed in the background.

## Fix

`VeryfrontFSAdapter` now awaits the in-flight warmup on the content-provider read paths (`getFileList`, `hasCachedFileList`, `getFileListCache`) via a new `waitForWarmup` option on the shared cached-listing lookup:

- A cold render pays **one** awaited listing fetch instead of O(modules × extensions) probes.
- Freshness is unchanged: the listing is still fetched from the API at request time, WebSocket pokes still replace the snapshot and clear the indexes.
- A failed or empty warmup resolves to `undefined`, so callers keep the legacy per-file fallback.
- The warmup stays single-flight (`fileListWarmupPromise` / `fileListWarmupKey`), so concurrent reads during the same miss share one fetch.

## Tests

New `src/platform/adapters/fs/veryfront/file-list-fanout.test.ts` (4 steps) drives the adapter read paths against a counting API stub and asserts the call-count fingerprints of the regression: a cold read resolves with `listAllFiles = 1`, `getFileContent = 0`, `listFiles = 0` (previously the miss path answered without a listing and probing began). 3 of the 4 steps fail with `adapter.ts` reverted to `origin/main`.

## Verification

- `deno task verify:quick` (fmt, lint suite, docs checks, typecheck) — pass
- `deno task test` (full unit suite, `--no-check --parallel`) — pass
- `deno check` / `deno lint` clean on both changed files

Ref: veryfront-issue-inbox#32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-list retrieval during cache warmups and when cache writes are unavailable.
  * Prevented stale asynchronous results from replacing newer snapshots or triggering unnecessary browser reloads.
  * Ensured deleted files and authoritative empty listings are handled correctly without stale fallback results.

* **Performance**
  * Reduced redundant file-list requests during concurrent reads and extensionless file resolution.

* **Tests**
  * Added coverage for cache invalidation, concurrent reads, updated content, refreshed listings, and stale fetch prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->