### PR TITLE
fix(build): bake --max-old-space-size=4096 into compiled full binaries

### DIFF
--- a/scripts/build/compile-binary.test.ts
+++ b/scripts/build/compile-binary.test.ts
@@ -5,6 +5,7 @@ import { FIRST_PARTY_DEFERRED_BUILTIN_EXTENSION_POLICIES } from "#veryfront/exte
 import {
   createCompileArgs,
   DEFAULT_INCLUDES,
+  findMissingBakedV8Flags,
   PROXY_INCLUDES,
 } from "./compile-binary.ts";
 
@@ -527,6 +528,139 @@ it("proxy binary smoke runs only for same-repository pull requests", async () =>
     true,
     "the pull-request proxy job must not retain checkout credentials",
   );
+});
+
+it("full binary bakes the production heap limit as compile-time V8 flags", () => {
+  // Compiled binaries ignore DENO_V8_FLAGS at runtime, so the production
+  // chart's `--max-old-space-size=4096` never reached the release binary:
+  // every heap OOM in 30 days died at V8's ~2 GiB default while the manifest
+  // verifiably set 4096 (veryfront-issue-inbox#269). `deno compile --v8-flags`
+  // is the only channel through which a compiled artifact gets the flag.
+  // 4096 pins the deployment contract: production pods are sized (5 Gi limit)
+  // around a 4 GiB heap ceiling.
+  const args = createCompileArgs({
+    entrypoint: "cli/main.ts",
+    extraIncludes: [],
+    output: "veryfront",
+  });
+
+  assertEquals(
+    args.includes("--v8-flags=--max-old-space-size=4096"),
+    true,
+    `full profile must bake --max-old-space-size=4096 at compile time, got v8 flag args: ${
+      JSON.stringify(args.filter((arg) => arg.startsWith("--v8-flags")))
+    }`,
+  );
+});
+
+it("proxy binary keeps V8's default heap ceiling", () => {
+  // Proxy pods run under a 1536 MiB memory limit (smoke-proxy-memory.sh pins
+  // it). A baked 4 GiB old-space ceiling would let the heap grow past the
+  // cgroup limit and turn GC back-pressure into OOMKills.
+  const args = createCompileArgs({
+    extraIncludes: [],
+    output: "veryfront-proxy",
+    profile: "proxy",
+  });
+
+  assertEquals(
+    args.some((arg) => arg.startsWith("--v8-flags")),
+    false,
+    "the proxy profile must not inherit the full binary's baked heap ceiling",
+  );
+});
+
+it("compile-time V8 flags govern the compiled binary's real heap limit", async () => {
+  // Two legs, both needed for an honest claim:
+  //
+  // Leg 1 (mechanism): compile a probe with a 3000 MB sentinel old-space and
+  // run it. V8 defaults land near ~2 GiB (small hosts) or ~4 GiB (large
+  // hosts), never ~3 GiB, so the observed limit can only come from the baked
+  // flag -- and the DENO_V8_FLAGS in the child env documents that a runtime
+  // override cannot move it.
+  //
+  // Leg 2 (wiring): compile the same probe with exactly the `--v8-flags`
+  // arguments createCompileArgs emits for the release profile and assert the
+  // flag is serialized into the binary's trailer (`"v8_flags":[...]`). This
+  // is the check that can also run against real release artifacts CI cannot
+  // execute (cross-target), and it fails when the build invocation stops
+  // passing the flag.
+  const dir = await Deno.makeTempDir({ prefix: "veryfront-v8-flags-" });
+  try {
+    const probe = `${dir}/heap-probe.ts`;
+    await Deno.writeTextFile(
+      probe,
+      'const v8 = process.getBuiltinModule("node:v8");\n' +
+        "console.log(Math.round(v8.getHeapStatistics().heap_size_limit / (1024 * 1024)));\n",
+    );
+    const suffix = Deno.build.os === "windows" ? ".exe" : "";
+
+    const compileProbe = async (name: string, v8FlagArgs: string[]) => {
+      const output = `${dir}/${name}`;
+      const result = await new Deno.Command(Deno.execPath(), {
+        args: [
+          "compile",
+          "--no-config",
+          "--quiet",
+          "--allow-all",
+          ...v8FlagArgs,
+          "--output",
+          output,
+          probe,
+        ],
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      assertEquals(
+        result.success,
+        true,
+        new TextDecoder().decode(result.stderr),
+      );
+      return `${output}${suffix}`;
+    };
+
+    const sentinelBinary = await compileProbe("heap-sentinel", [
+      "--v8-flags=--max-old-space-size=3000",
+    ]);
+    const run = await new Deno.Command(sentinelBinary, {
+      env: { DENO_V8_FLAGS: "--max-old-space-size=8192" },
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    assertEquals(run.success, true, new TextDecoder().decode(run.stderr));
+    const limitMb = Number(new TextDecoder().decode(run.stdout).trim());
+    assertEquals(
+      limitMb >= 3000 && limitMb <= 3256,
+      true,
+      `expected heap_size_limit near the 3000 MB sentinel (old space plus young-generation overhead), got ${limitMb} MB -- baked v8-flags do not govern the compiled runtime`,
+    );
+
+    const releaseV8FlagArgs = createCompileArgs({
+      entrypoint: "cli/main.ts",
+      extraIncludes: [],
+      output: "veryfront",
+    }).filter((arg) => arg.startsWith("--v8-flags"));
+    const wiredBinary = await compileProbe(
+      "heap-release-flags",
+      releaseV8FlagArgs,
+    );
+    // The trailer serializes baked flags at the tail of a compact JSON
+    // array, after Deno's own defaults; the guard matches the joined baked
+    // flags plus the closing `]`, so an embedded source file containing the
+    // bare quoted flag cannot satisfy it. This assertion doubles as the
+    // empirical proof that the tail anchor matches a real artifact on the
+    // pinned Deno line.
+    const content = new TextDecoder("latin1").decode(
+      await Deno.readFile(wiredBinary),
+    );
+    assertEquals(
+      findMissingBakedV8Flags(content, ["--max-old-space-size=4096"]),
+      [],
+      "the release compile invocation must serialize --max-old-space-size=4096 into the binary trailer; without it production runs at V8's ~2 GiB default (veryfront-issue-inbox#269)",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 it("full binary remains the default compile profile", () => {

--- a/scripts/build/compile-binary.ts
+++ b/scripts/build/compile-binary.ts
@@ -328,8 +328,7 @@ async function assertArtifactContracts(
     failures.push(
       `Compiled binary was not built with V8 flag(s): ${missingV8Flags.join(", ")}.\n` +
         "Compiled binaries ignore DENO_V8_FLAGS at runtime, so without the baked flag " +
-        "production runs at V8's ~2 GiB default heap limit and dies there " +
-        "(veryfront-issue-inbox#269).",
+        "production runs at V8's ~2 GiB default heap limit and dies there.",
     );
   }
   if (failures.length > 0) {

--- a/scripts/build/compile-binary.ts
+++ b/scripts/build/compile-binary.ts
@@ -68,6 +68,27 @@ export const DEFAULT_INCLUDES = [
   "dist/framework-src",
 ];
 
+/**
+ * V8 flags baked into the full binary at compile time.
+ *
+ * Compiled binaries ignore the DENO_V8_FLAGS environment variable at runtime,
+ * so the production chart's `--max-old-space-size=4096` never reached the
+ * release binary: every heap OOM over 30 days died at V8's ~2 GiB default
+ * while the manifest verifiably set 4096 (veryfront-issue-inbox#269).
+ * `deno compile --v8-flags` serializes the flags into the binary's trailer
+ * (`"v8_flags":[...]`), which is the only channel through which a compiled
+ * artifact gets them. The baked value is final -- a runtime DENO_V8_FLAGS
+ * cannot override it -- so 4096 here IS the production heap ceiling, and the
+ * chart's env var is documentation only. Production pods are sized (5 Gi
+ * limit) around this 4 GiB ceiling; change both together.
+ *
+ * The proxy profile deliberately does not carry these: proxy pods run under a
+ * 1536 MiB memory limit (smoke-proxy-memory.sh pins it), and a 4 GiB
+ * old-space ceiling would let the heap grow past the cgroup limit and turn GC
+ * back-pressure into OOMKills.
+ */
+export const FULL_PROFILE_V8_FLAGS = ["--max-old-space-size=4096"];
+
 export const PROXY_INCLUDES = [
   // Deliberately omits UNTRACEABLE_WORKER_INCLUDES. The standalone proxy
   // forwards project requests to the production server and never evaluates
@@ -104,6 +125,12 @@ export function createCompileArgs(options: CompileBinaryOptions): string[] {
     "--unstable-net",
     "--unstable-worker-options",
   ];
+
+  if (profile === "full") {
+    // See FULL_PROFILE_V8_FLAGS: runtime DENO_V8_FLAGS is ignored by compiled
+    // binaries, so compile time is the only place the heap limit can be set.
+    args.push(`--v8-flags=${FULL_PROFILE_V8_FLAGS.join(",")}`);
+  }
 
   if (profile === "proxy") {
     // Why a dedicated proxy binary exists at all.
@@ -173,14 +200,49 @@ export function findMissingEmbeddedWorkers(
   binaryContent: string,
   workerIncludes: readonly string[],
 ): string[] {
-  return workerIncludes.filter((include) => {
-    const fileName = include.slice(include.lastIndexOf("/") + 1);
-    return !binaryContent.includes(`"n":"${fileName}"`);
-  });
+  return workerIncludes.filter((include) =>
+    !binaryContent.includes(workerVfsMarker(include))
+  );
+}
+
+function workerVfsMarker(include: string): string {
+  const fileName = include.slice(include.lastIndexOf("/") + 1);
+  return `"n":"${fileName}"`;
 }
 
 /**
- * Streams the binary looking for each worker's VFS entry.
+ * Names the V8 flags a compiled binary was NOT built with.
+ *
+ * Baked flags are serialized into the binary's trailer as a compact JSON
+ * array whose tail is the compile invocation's flags, appended after Deno's
+ * own defaults (observed on the pinned line:
+ * `"v8_flags":["UNUSED_BUT_NECESSARY_ARG0","--stack-size=1024",
+ * "--inspector-live-edit","--max-old-space-size=4096"]`). The marker is the
+ * joined baked flags plus the array's closing `]` rather than one bare
+ * quoted flag, so a future embedded source file or asset that merely
+ * contains the quoted literal cannot make this check pass vacuously; the
+ * mechanism test's wiring leg verifies the tail anchor against a real
+ * compiled artifact, so a Deno release that reordered the trailer would fail
+ * loudly there and here, never silently pass. Absence of the marker means
+ * the compile invocation dropped the flags and the artifact runs at V8's
+ * defaults (veryfront-issue-inbox#269: ~2 GiB instead of the configured
+ * 4 GiB). Checked on the artifact rather than by running it because release
+ * builds cross-compile targets the CI host cannot execute.
+ */
+export function findMissingBakedV8Flags(
+  binaryContent: string,
+  v8Flags: readonly string[],
+): string[] {
+  if (v8Flags.length === 0) return [];
+  return binaryContent.includes(v8FlagsMarker(v8Flags)) ? [] : [...v8Flags];
+}
+
+function v8FlagsMarker(v8Flags: readonly string[]): string {
+  return `${v8Flags.map((flag) => `"${flag}"`).join(",")}]`;
+}
+
+/**
+ * Streams the binary looking for each named marker.
  *
  * Reads in chunks rather than decoding the file at once: these binaries embed
  * hundreds of megabytes, and a single decode throws "buffer exceeds maximum
@@ -189,15 +251,16 @@ export function findMissingEmbeddedWorkers(
  * and carries the tail of each chunk forward so a marker split across a
  * boundary is still found.
  */
-async function findMissingEmbeddedWorkersInFile(
+async function findMissingMarkersInFile(
   path: string,
-  workerIncludes: readonly string[],
+  markers: ReadonlyMap<string, string>,
 ): Promise<string[]> {
   const CHUNK_BYTES = 8 * 1024 * 1024;
-  const markerLength = (include: string) => include.length - include.lastIndexOf("/") + 6;
-  const carryLength = Math.max(...workerIncludes.map(markerLength));
+  const carryLength = Math.max(
+    ...[...markers.values()].map((marker) => marker.length),
+  );
 
-  const remaining = new Set(workerIncludes);
+  const remaining = new Map(markers);
   const decoder = new TextDecoder("latin1");
   const buffer = new Uint8Array(CHUNK_BYTES);
   const file = await Deno.open(path, { read: true });
@@ -209,9 +272,9 @@ async function findMissingEmbeddedWorkersInFile(
       if (bytesRead === null) break;
 
       const text = carry + decoder.decode(buffer.subarray(0, bytesRead));
-      for (const include of [...remaining]) {
-        if (findMissingEmbeddedWorkers(text, [include]).length === 0) {
-          remaining.delete(include);
+      for (const [name, marker] of [...remaining]) {
+        if (text.includes(marker)) {
+          remaining.delete(name);
         }
       }
       carry = text.slice(-carryLength);
@@ -220,33 +283,57 @@ async function findMissingEmbeddedWorkersInFile(
     file.close();
   }
 
-  return [...remaining];
+  return [...remaining.keys()];
 }
 
-async function assertWorkersEmbedded(
+async function assertArtifactContracts(
   outputPath: string,
   profile: CompileBinaryProfile,
 ): Promise<void> {
-  // Expectations come from the declared constant, NOT from the resolved include
-  // list. Deriving them from the include list makes this tautological: dropping
-  // a worker from the list would also drop it from what is checked, so the one
-  // regression this exists to catch would pass. The proxy profile is the sole
-  // exemption, for the build reason documented on PROXY_INCLUDES.
-  const expected = profile === "proxy" ? [] : UNTRACEABLE_WORKER_INCLUDES;
-  if (expected.length === 0) {
+  // Expectations come from the declared constants, NOT from the resolved
+  // compile args. Deriving them from the args makes this tautological:
+  // dropping a worker or flag from the args would also drop it from what is
+  // checked, so the one regression this exists to catch would pass. The proxy
+  // profile is the sole exemption, for the build reason documented on
+  // PROXY_INCLUDES and FULL_PROFILE_V8_FLAGS.
+  const expectedWorkers = profile === "proxy" ? [] : UNTRACEABLE_WORKER_INCLUDES;
+  const expectedV8Flags = profile === "proxy" ? [] : FULL_PROFILE_V8_FLAGS;
+  // All expected flags share the one anchored trailer marker: the compile
+  // invocation bakes exactly this set, so either the whole serialized array
+  // is present or none of the flags reached the artifact.
+  const markers = new Map([
+    ...expectedWorkers.map((include) => [include, workerVfsMarker(include)] as const),
+    ...expectedV8Flags.map((flag) => [flag, v8FlagsMarker(expectedV8Flags)] as const),
+  ]);
+  if (markers.size === 0) {
     return;
   }
 
-  const missing = await findMissingEmbeddedWorkersInFile(
+  const missing = await findMissingMarkersInFile(
     normalizeOutputPath(outputPath),
-    expected,
+    markers,
   );
-  if (missing.length > 0) {
-    throw new Error(
-      `Compiled binary is missing ${missing.length} worker entrypoint(s): ${
-        missing.join(", ")
+  const missingWorkers = missing.filter((name) => expectedWorkers.includes(name));
+  const missingV8Flags = missing.filter((name) => expectedV8Flags.includes(name));
+
+  const failures: string[] = [];
+  if (missingWorkers.length > 0) {
+    failures.push(
+      `Compiled binary is missing ${missingWorkers.length} worker entrypoint(s): ${
+        missingWorkers.join(", ")
       }.\nThe binary would start, serve traffic, and crash the first time one is spawned.`,
     );
+  }
+  if (missingV8Flags.length > 0) {
+    failures.push(
+      `Compiled binary was not built with V8 flag(s): ${missingV8Flags.join(", ")}.\n` +
+        "Compiled binaries ignore DENO_V8_FLAGS at runtime, so without the baked flag " +
+        "production runs at V8's ~2 GiB default heap limit and dies there " +
+        "(veryfront-issue-inbox#269).",
+    );
+  }
+  if (failures.length > 0) {
+    throw new Error(failures.join("\n"));
   }
 }
 
@@ -262,7 +349,7 @@ export async function compileBinary(options: CompileBinaryOptions): Promise<void
     throw new Error(`deno compile failed with exit code ${result.code}`);
   }
 
-  await assertWorkersEmbedded(options.output, options.profile ?? "full");
+  await assertArtifactContracts(options.output, options.profile ?? "full");
 }
 
 function normalizeOutputPath(path: string): string {


### PR DESCRIPTION
## Problem

Compiled binaries ignore the `DENO_V8_FLAGS` environment variable at runtime, so setting `--max-old-space-size=4096` in the deployment environment never reaches a compiled release binary. A deployment can verifiably set the env var while the process still runs at V8's ~2 GiB default old-space limit and OOMs there.

`deno compile --v8-flags` is the only channel through which a compiled artifact receives V8 flags: they are serialized into the binary's trailer at compile time and are final (a runtime `DENO_V8_FLAGS` cannot override them).

## Fix

- Bake `--max-old-space-size=4096` into the **full** profile via `--v8-flags` in `createCompileArgs` (`scripts/build/compile-binary.ts`). The baked value is the real production heap ceiling; production pods are sized (5 Gi limit) around it.
- The **proxy** profile deliberately keeps V8's defaults: proxy pods run under a 1536 MiB cgroup limit (pinned by `smoke-proxy-memory.sh`), and a 4 GiB old-space ceiling would turn GC back-pressure into OOMKills.
- Extend the post-compile artifact assertion to fail the build when the baked flags are missing from the trailer. The marker is anchored to the tail of the trailer's `"v8_flags":[...]` array (joined baked flags plus the closing `]`), so an embedded source file that merely contains the quoted flag literal cannot satisfy the check vacuously. Checked on the artifact bytes because release builds cross-compile targets CI cannot execute.

## Tests

`scripts/build/compile-binary.test.ts`:

- Full profile emits `--v8-flags=--max-old-space-size=4096`; proxy profile emits no `--v8-flags`.
- Mechanism leg: a probe compiled with a 3000 MB sentinel reports `heap_size_limit` in the 3000–3256 MB window even with a conflicting runtime `DENO_V8_FLAGS` — V8 defaults land near ~2 GiB or ~4 GiB, never ~3 GiB, so the observed limit can only come from the baked flag.
- Wiring leg: a probe compiled with exactly the release profile's `--v8-flags` args serializes the flag into the trailer, verified through the same guard the build uses; this doubles as the empirical proof that the tail-anchored marker matches a real artifact on the pinned Deno line.

Verified locally on Deno 2.7.12 (CI pins the same 2.7 line).

Ref: veryfront-issue-inbox#269
