### PR TITLE
fix(rendering): keep release hydration artifacts compatible

### DIFF
--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -34,11 +34,36 @@ veryfront build
 veryfront serve
 ```
 
-`veryfront build` writes browser assets to `dist/`. API routes, agents,
-workflows, and tasks remain in the project source and are loaded by
-`veryfront serve`.
+`veryfront build` writes browser assets to `build.outDir`, which defaults to
+`dist/`. API routes, agents, workflows, and tasks remain in the project source
+and are loaded by `veryfront serve`.
 
-Verify the chosen boundary before uploading source.
+Before uploading source, verify that `build.outDir` contains the browser assets
+and that server-executed API routes, agents, workflows, and tasks remain in the
+project source.
+
+## Keep release browser artifacts together
+
+Each production build writes a content-addressed hydration runtime beside the
+release's router and other browser assets. When Veryfront renders an immutable
+release, the HTML references that release-baked runtime. It does not substitute
+the runtime from the currently serving Veryfront process.
+
+This pairing is a compatibility boundary. Keep the hydration runtime for as
+long as its immutable release can be deployed or served. Retire the release and
+its browser artifacts together; never delete only the hydration runtime or
+redirect its hashed URL to newer bytes. A release that is missing its single
+versioned runtime fails rendering instead of falling back to a potentially
+incompatible runtime.
+
+Veryfront's required browser regression job exercises the current server
+against an aged release artifact set. The build contract test also verifies
+that every promoted artifact set contains exactly one discoverable versioned
+hydration runtime, so an incompatible pairing blocks promotion in CI.
+
+This policy follows [incident #264](https://github.com/veryfront/veryfront-issue-inbox/issues/264)
+and the immediate compatibility fix in
+[veryfront-code PR #3124](https://github.com/veryfront/veryfront-code/pull/3124).
 
 ## Push a preview
 

--- a/src/build/production-build/build/output-generator.test.ts
+++ b/src/build/production-build/build/output-generator.test.ts
@@ -1,8 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { generateClientScripts, generateRedirectsFile } from "./output-generator.ts";
 import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
+import { resolveProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-runtime-selection.ts";
+import { generateClientScripts, generateRedirectsFile } from "./output-generator.ts";
 
 describe("build/production-build/build/output-generator", () => {
   describe("generateClientScripts", () => {
@@ -67,6 +68,30 @@ describe("build/production-build/build/output-generator", () => {
           write.content.includes("RouterProvider")
         ),
         true,
+      );
+      const versionedRuntimeWrites = writes.filter((write) =>
+        /_veryfront\/hydration-runtime\.[0-9a-f]{8}\.js$/.test(write.path)
+      );
+      assertEquals(versionedRuntimeWrites.length, 1);
+      assertEquals(
+        await resolveProdHydrationModulePath({
+          fs: {
+            async *readDir(path: string) {
+              assertEquals(path, "/project/dist/_veryfront");
+              for (const write of versionedRuntimeWrites) {
+                yield {
+                  name: write.path.slice(write.path.lastIndexOf("/") + 1),
+                  isFile: true,
+                  isDirectory: false,
+                  isSymlink: false,
+                };
+              }
+            },
+          },
+          projectDir: "/project",
+          releaseId: "release-built",
+        }),
+        getProdHydrationModulePath(),
       );
     });
   });

--- a/src/html/html-injection.test.ts
+++ b/src/html/html-injection.test.ts
@@ -126,6 +126,23 @@ describe("html/html-injection", () => {
       assertEquals(html.includes("my-slug"), false);
     });
 
+    it("injects a previously selected production hydration runtime", () => {
+      const agedRuntimePath = "/_veryfront/hydration-runtime.1a2b3c4d.js";
+      const html = injectHTMLContent(
+        baseTemplate,
+        "<p>content</p>",
+        minMeta,
+        {
+          mode: "production",
+          slug: "test",
+          prodHydrationModulePath: agedRuntimePath,
+        },
+      );
+
+      assertEquals(html.includes(`src="${agedRuntimePath}"`), true);
+      assertEquals(html.includes("/_veryfront/rsc/client.js"), false);
+    });
+
     it("should escape script-closing sequences in prebuilt import maps", () => {
       const hostileImportMap = JSON.stringify({
         imports: {

--- a/src/html/html-injection.ts
+++ b/src/html/html-injection.ts
@@ -19,6 +19,7 @@ import {
   getProdScripts,
   getStudioScripts,
 } from "./dev-scripts.ts";
+import { getProdScriptsForPath } from "./hydration-script-builder/prod-scripts.ts";
 import { PROJECT_STYLESHEET_IDS } from "./project-stylesheet-ids.ts";
 import { buildReleaseAssetModules } from "#veryfront/release-assets/client-module-map.ts";
 import {
@@ -89,6 +90,8 @@ export interface InjectHTMLContentOptions {
   dependencyPinningCacheKey?: string;
   /** Ready release asset manifest used to hydrate full HTML client pages */
   releaseAssetManifest?: ReleaseAssetManifest | null;
+  /** Production hydration runtime selected from the rendered artifact set */
+  prodHydrationModulePath?: string;
   /** Configured route directories used to map physical page paths to route keys */
   directories?: ConfiguredRouteDirectories;
 }
@@ -246,7 +249,9 @@ export function injectHTMLContent(
     html = html.replace(/{{\s*devScripts\s*}}/gi, "");
     html = html.replace(/{{\s*devStyles\s*}}/gi, "");
 
-    const prodScripts = getProdScripts(options.slug, options.nonce);
+    const prodScripts = options.prodHydrationModulePath
+      ? getProdScriptsForPath(options.prodHydrationModulePath, options.nonce)
+      : getProdScripts(options.slug, options.nonce);
     const hasProdScriptsPlaceholder = /{{\s*prodScripts\s*}}/i.test(html);
 
     if (hasProdScriptsPlaceholder) {

--- a/src/html/html-shell-generator.test.ts
+++ b/src/html/html-shell-generator.test.ts
@@ -1,7 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "./styles-builder/__tests__/css-processor-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import {
   clearAllManifests,
   recordSSRModules,
@@ -86,6 +91,24 @@ describe("html-generation/html-shell-generator", () => {
         result.indexOf('<meta charset="UTF-8">') < result.indexOf("<script"),
         "No production head script may precede the encoding declaration",
       );
+    });
+
+    it("fails closed when a release shell has no selected hydration runtime", async () => {
+      const error = await assertRejects(
+        () =>
+          wrapInHTMLShell(
+            "<h1>Aged release</h1>",
+            createMeta(),
+            createOptions({
+              mode: "production",
+              releaseId: "release-aged",
+              studioEmbed: true,
+            }),
+          ),
+        Error,
+      );
+
+      assertEquals((error as { slug?: unknown }).slug, "render-error");
     });
 
     it("should include content in the body", async () => {

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -1,4 +1,5 @@
 import type { ComponentProps, RenderMetadata } from "#veryfront/types";
+import { RENDER_ERROR } from "#veryfront/errors";
 import { isAbsolute, resolve } from "#veryfront/platform/compat/path/index.ts";
 import { profilePhase, SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
@@ -25,8 +26,8 @@ import {
   generateHydrationData,
   getDevScripts,
   getProdHydrationModulePath,
-  getProdScripts,
 } from "./hydration-script-builder/index.ts";
+import { getProdScriptsForPath } from "./hydration-script-builder/prod-scripts.ts";
 import { getPreviewStylesheetLink, getStudioScripts } from "./dev-scripts.ts";
 import { processMetadata } from "./metadata-builder.ts";
 import {
@@ -294,6 +295,12 @@ async function generateHTMLShellPartsImpl(
   );
 
   const nonce = options.nonce ?? "";
+  const prodHydrationModulePath = options.prodHydrationModulePath;
+  if (!useDevScripts && options.releaseId && !prodHydrationModulePath) {
+    throw RENDER_ERROR.create({
+      detail: "Release hydration runtime must be selected before HTML generation",
+    });
+  }
 
   const modeScripts = useDevScripts
     ? getDevScripts(meta.slug || "", options.config, params, props, nonce, {
@@ -303,7 +310,7 @@ async function generateHTMLShellPartsImpl(
       // development render even though it serves the dev scripts for HMR.
       skipDevFlag: isPreviewMode,
     })
-    : getProdScripts(meta.slug || "", params, props, nonce);
+    : getProdScriptsForPath(prodHydrationModulePath ?? getProdHydrationModulePath(), nonce);
 
   const modeStyles = useDevScripts ? getErrorOverlayStyles(nonce) : "";
 
@@ -319,7 +326,9 @@ async function generateHTMLShellPartsImpl(
     : "";
   const prodHydrationModulePreload = useDevScripts
     ? ""
-    : `<link rel="modulepreload" href="${getProdHydrationModulePath()}">`;
+    : `<link rel="modulepreload" href="${
+      prodHydrationModulePath ?? getProdHydrationModulePath()
+    }">`;
 
   const nonceAttr = buildNonceAttribute(nonce);
 

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -37,6 +37,9 @@ function prodOptions(overrides: Partial<HTMLGenerationOptions> = {}): HTMLGenera
     projectDir: "/proj",
     pagePath: "/proj/pages/index.tsx",
     projectSlug: "demo",
+    prodHydrationModulePath: overrides.releaseId
+      ? "/_veryfront/hydration-runtime.deadbeef.js"
+      : undefined,
     ...overrides,
   };
 }

--- a/src/html/hydration-script-builder/prod-runtime-selection.test.ts
+++ b/src/html/hydration-script-builder/prod-runtime-selection.test.ts
@@ -1,0 +1,200 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertNotStrictEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { DirEntry, FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
+import { getProdHydrationModulePath } from "./prod-scripts.ts";
+import {
+  hasImmutableReleaseHydrationRuntime,
+  resolveProdHydrationModulePath,
+} from "./prod-runtime-selection.ts";
+
+function releaseFileSystem(filenames: readonly string[]): Pick<FileSystemAdapter, "readDir"> {
+  return {
+    async *readDir(path: string): AsyncIterable<DirEntry> {
+      assertEquals(path, "/project/dist/_veryfront");
+      for (const name of filenames) {
+        yield {
+          name,
+          isFile: true,
+          isDirectory: false,
+          isSymlink: false,
+        };
+      }
+    },
+  };
+}
+
+function rejectingFileSystem(
+  error: Error,
+  onRead: () => void = () => {},
+): Pick<FileSystemAdapter, "readDir"> {
+  return {
+    readDir(): AsyncIterable<DirEntry> {
+      onRead();
+      return {
+        [Symbol.asyncIterator](): AsyncIterator<DirEntry> {
+          return { next: () => Promise.reject(error) };
+        },
+      };
+    },
+  };
+}
+
+describe("resolveProdHydrationModulePath", () => {
+  it("classifies only non-empty immutable release IDs as release artifacts", () => {
+    assertEquals(hasImmutableReleaseHydrationRuntime(undefined), false);
+    assertEquals(hasImmutableReleaseHydrationRuntime(""), false);
+    assertEquals(hasImmutableReleaseHydrationRuntime("standalone-dev"), false);
+    assertEquals(hasImmutableReleaseHydrationRuntime("release-aged"), true);
+  });
+
+  it("keeps the serving runtime path outside a release render", async () => {
+    let reads = 0;
+    const fs = {
+      async *readDir(): AsyncIterable<DirEntry> {
+        reads += 1;
+        yield* [];
+      },
+    };
+
+    assertEquals(
+      await resolveProdHydrationModulePath({ fs, projectDir: "/project" }),
+      getProdHydrationModulePath(),
+    );
+    assertEquals(reads, 0);
+  });
+
+  it("keeps standalone source serving independent of stale build artifacts", async () => {
+    let reads = 0;
+    const fs = {
+      async *readDir(): AsyncIterable<DirEntry> {
+        reads += 1;
+        yield {
+          name: "hydration-runtime.1a2b3c4d.js",
+          isFile: true,
+          isDirectory: false,
+          isSymlink: false,
+        };
+      },
+    };
+
+    assertEquals(
+      await resolveProdHydrationModulePath({
+        fs,
+        projectDir: "/project",
+        releaseId: "standalone-dev",
+      }),
+      getProdHydrationModulePath(),
+    );
+    assertEquals(reads, 0);
+  });
+
+  it("selects the content-addressed runtime baked into an aged release", async () => {
+    const agedPath = "/_veryfront/hydration-runtime.1a2b3c4d.js";
+
+    assertEquals(
+      await resolveProdHydrationModulePath({
+        fs: releaseFileSystem([
+          "app.js",
+          "hydration-runtime.js",
+          "hydration-runtime.1a2b3c4d.js",
+          "router.js",
+        ]),
+        projectDir: "/project",
+        releaseId: "release-aged",
+      }),
+      agedPath,
+    );
+    assertEquals(agedPath === getProdHydrationModulePath(), false);
+  });
+
+  it("reads the runtime from the configured build output directory", async () => {
+    const agedPath = "/_veryfront/hydration-runtime.1a2b3c4d.js";
+    const fs = {
+      async *readDir(path: string): AsyncIterable<DirEntry> {
+        assertEquals(path, "/project/custom-output/_veryfront");
+        yield {
+          name: "hydration-runtime.1a2b3c4d.js",
+          isFile: true,
+          isDirectory: false,
+          isSymlink: false,
+        };
+      },
+    };
+
+    assertEquals(
+      await resolveProdHydrationModulePath({
+        fs,
+        projectDir: "/project",
+        buildOutDir: "custom-output",
+        releaseId: "release-aged",
+      }),
+      agedPath,
+    );
+  });
+
+  it("fails closed when a release has no baked content-addressed runtime", async () => {
+    const error = await assertRejects(
+      () =>
+        resolveProdHydrationModulePath({
+          fs: releaseFileSystem(["hydration-runtime.js", "router.js"]),
+          projectDir: "/project",
+          releaseId: "release-incomplete",
+        }),
+      Error,
+    );
+
+    assertEquals((error as { slug?: unknown }).slug, "render-error");
+  });
+
+  it("fails closed when an immutable release directory is missing", async () => {
+    const error = await assertRejects(
+      () =>
+        resolveProdHydrationModulePath({
+          fs: rejectingFileSystem(
+            new Error("missing immutable release"),
+          ),
+          projectDir: "/project",
+          releaseId: "release-missing",
+        }),
+      Error,
+    );
+
+    assertEquals((error as { slug?: unknown }).slug, "render-error");
+  });
+
+  it("wraps filesystem errors that merely expose a render-error slug", async () => {
+    const filesystemError = Object.assign(new Error("filesystem failure"), {
+      slug: "render-error",
+    });
+    const error = await assertRejects(
+      () =>
+        resolveProdHydrationModulePath({
+          fs: rejectingFileSystem(filesystemError),
+          projectDir: "/project",
+          releaseId: "release-unreadable",
+        }),
+      Error,
+    );
+
+    assertEquals((error as { slug?: unknown }).slug, "render-error");
+    assertNotStrictEquals(error, filesystemError);
+  });
+
+  it("fails closed when a release contains ambiguous versioned runtimes", async () => {
+    const error = await assertRejects(
+      () =>
+        resolveProdHydrationModulePath({
+          fs: releaseFileSystem([
+            "hydration-runtime.1a2b3c4d.js",
+            "hydration-runtime.5e6f7a8b.js",
+          ]),
+          projectDir: "/project",
+          releaseId: "release-ambiguous",
+        }),
+      Error,
+    );
+
+    assertEquals((error as { slug?: unknown }).slug, "render-error");
+  });
+});

--- a/src/html/hydration-script-builder/prod-runtime-selection.ts
+++ b/src/html/hydration-script-builder/prod-runtime-selection.ts
@@ -1,0 +1,73 @@
+import { join, resolve } from "#veryfront/compat/path/index.ts";
+import { RENDER_ERROR } from "#veryfront/errors";
+import { getProdHydrationModulePath } from "./prod-scripts.ts";
+import { isVersionedProdHydrationModulePath } from "./prod-path.ts";
+
+export interface ProdHydrationModuleSelectionOptions {
+  fs: {
+    readDir(path: string): AsyncIterable<{ name: string; isFile: boolean }>;
+  };
+  projectDir: string;
+  buildOutDir?: string;
+  releaseId?: string;
+}
+
+/** Whether the release ID names an immutable artifact set rather than local source serving. */
+export function hasImmutableReleaseHydrationRuntime(
+  releaseId: string | undefined,
+): releaseId is string {
+  return releaseId !== undefined && releaseId.length > 0 && releaseId !== "standalone-dev";
+}
+
+/**
+ * Select the hydration runtime owned by the rendered artifact set.
+ *
+ * Non-release renders use the serving runtime. Release renders discover the
+ * single content-addressed runtime baked into that immutable release. Missing
+ * or ambiguous release artifacts fail closed instead of mixing the serving
+ * runtime with release-pinned browser modules.
+ */
+export async function resolveProdHydrationModulePath(
+  options: ProdHydrationModuleSelectionOptions,
+): Promise<string> {
+  if (!hasImmutableReleaseHydrationRuntime(options.releaseId)) {
+    return getProdHydrationModulePath();
+  }
+
+  const configuredOutDir = options.buildOutDir || "dist";
+  const runtimeDirectory = join(resolve(options.projectDir, configuredOutDir), "_veryfront");
+  let selectedPath: string | null = null;
+  let hasMultipleRuntimes = false;
+
+  try {
+    for await (const entry of options.fs.readDir(runtimeDirectory)) {
+      if (!entry.isFile) continue;
+
+      const candidate = `/_veryfront/${entry.name}`;
+      if (!isVersionedProdHydrationModulePath(candidate)) continue;
+      if (selectedPath !== null) {
+        hasMultipleRuntimes = true;
+        break;
+      }
+      selectedPath = candidate;
+    }
+  } catch {
+    throw RENDER_ERROR.create({
+      detail: "Release hydration runtime could not be inspected",
+    });
+  }
+
+  if (hasMultipleRuntimes) {
+    throw RENDER_ERROR.create({
+      detail: "Release contains multiple versioned hydration runtimes",
+    });
+  }
+
+  if (selectedPath === null) {
+    throw RENDER_ERROR.create({
+      detail: "Release is missing its versioned hydration runtime",
+    });
+  }
+
+  return selectedPath;
+}

--- a/src/html/hydration-script-builder/prod-scripts.test.ts
+++ b/src/html/hydration-script-builder/prod-scripts.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import * as esbuild from "veryfront/extensions/bundler";
 import { generateDevClientRendererScript } from "./dev-client-renderer.ts";
@@ -7,6 +7,7 @@ import {
   generateProdHydrationModule,
   getProdHydrationModulePath,
   getProdScripts,
+  getProdScriptsForPath,
   PROD_HYDRATION_MODULE_PATH,
 } from "./prod-scripts.ts";
 
@@ -97,6 +98,23 @@ describe("hydration-script-builder/prod-scripts", () => {
     it("should not include nonce attribute when not provided", () => {
       const result = getProdScripts("page");
       assertEquals(result.includes("nonce="), false);
+    });
+
+    it("should use an explicitly selected release runtime path", () => {
+      const releaseRuntimePath = "/_veryfront/hydration-runtime.1a2b3c4d.js";
+      const result = getProdScriptsForPath(releaseRuntimePath, "nonce-abc");
+
+      assertEquals(result.includes(`src="${releaseRuntimePath}"`), true);
+      assertEquals(result.includes(getProdHydrationModulePath()), false);
+    });
+
+    it("should reject an invalid selected runtime path", () => {
+      const error = assertThrows(
+        () => getProdScriptsForPath('"><script>alert(1)</script>'),
+        Error,
+      );
+
+      assertEquals((error as { slug?: unknown }).slug, "render-error");
     });
   });
 

--- a/src/html/hydration-script-builder/prod-scripts.ts
+++ b/src/html/hydration-script-builder/prod-scripts.ts
@@ -1,6 +1,9 @@
-import { HYDRATION_RUNTIME_BUNDLE } from "./hydration-runtime.generated.ts";
-import { buildNonceAttribute } from "../html-escape.ts";
 import { fnv1aHash } from "#veryfront/utils/hash-utils.ts";
+import { RENDER_ERROR } from "#veryfront/errors";
+import { buildNonceAttribute } from "../html-escape.ts";
+import { HYDRATION_RUNTIME_BUNDLE } from "./hydration-runtime.generated.ts";
+import { isVersionedProdHydrationModulePath } from "./prod-path.ts";
+
 export {
   isVersionedProdHydrationModulePath,
   PROD_HYDRATION_MODULE_PATH,
@@ -33,6 +36,17 @@ export function getProdScripts(
   _props?: Record<string, unknown>,
   nonce?: string,
 ): string {
+  return getProdScriptsForPath(getProdHydrationModulePath(), nonce);
+}
+
+/** Build the production script tag for a previously selected runtime path. */
+export function getProdScriptsForPath(
+  hydrationModulePath: string,
+  nonce?: string,
+): string {
+  if (!isVersionedProdHydrationModulePath(hydrationModulePath)) {
+    throw RENDER_ERROR.create({ detail: "Invalid production hydration runtime path" });
+  }
   const nonceAttr = buildNonceAttribute(nonce);
-  return `\n  <script type="module" src="${getProdHydrationModulePath()}"${nonceAttr}></script>`;
+  return `\n  <script type="module" src="${hydrationModulePath}"${nonceAttr}></script>`;
 }

--- a/src/html/schemas/html.schema.ts
+++ b/src/html/schemas/html.schema.ts
@@ -41,6 +41,8 @@ export const getHTMLGenerationOptionsSchema = defineSchema((v) =>
     projectId: v.string().optional(),
     projectSlug: v.string().optional(),
     releaseId: v.string().optional(),
+    // Release-aware callers must select the runtime from the release build.
+    prodHydrationModulePath: v.string().optional(),
     pageId: v.string().optional(),
     sourceHash: v.string().optional(),
     colorScheme: getColorSchemeSchema().optional(),

--- a/src/rendering/orchestrator/html.test-helpers.ts
+++ b/src/rendering/orchestrator/html.test-helpers.ts
@@ -1,22 +1,29 @@
+import type { DirEntry } from "#veryfront/platform/adapters/base.ts";
 import { type HTMLGenerationContext, HTMLGenerator, type HTMLGeneratorConfig } from "./html.ts";
 
 type MockReadFile = (path: string) => Promise<string>;
+type MockReadDir = (path: string) => AsyncIterable<DirEntry>;
 
 type CreateGeneratorOptions = {
   mode?: HTMLGeneratorConfig["mode"];
   isLocalProject?: boolean;
   readFile?: MockReadFile;
+  readDir?: MockReadDir;
 };
 
 const defaultReadFile: MockReadFile = async () => "";
+const defaultReadDir: MockReadDir = async function* () {};
 
-export function createMockAdapter(readFile: MockReadFile = defaultReadFile) {
+export function createMockAdapter(
+  readFile: MockReadFile = defaultReadFile,
+  readDir: MockReadDir = defaultReadDir,
+) {
   return {
     fs: {
       readFile,
       exists: async () => false,
       stat: async () => ({ isFile: false, isDirectory: false, isSymlink: false }),
-      readDir: async function* () {},
+      readDir,
       mkdir: async () => {},
       writeFile: async () => {},
     },
@@ -27,10 +34,11 @@ export function createHTMLGenerator({
   mode = "production",
   isLocalProject,
   readFile = defaultReadFile,
+  readDir = defaultReadDir,
 }: CreateGeneratorOptions = {}): HTMLGenerator {
   return new HTMLGenerator({
     projectDir: "/project",
-    adapter: createMockAdapter(readFile) as any,
+    adapter: createMockAdapter(readFile, readDir) as any,
     config: {} as any,
     mode,
     isLocalProject,

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -28,6 +28,7 @@ import {
 } from "#veryfront/html/managed-head-protocol.ts";
 import { mergeImportedCSS } from "./html-imported-css.ts";
 import { StreamTimeoutError } from "../utils/stream-utils.ts";
+import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 import {
   createHTMLContext,
   createHTMLGenerator,
@@ -289,6 +290,91 @@ describe("HTMLGenerator helpers", () => {
   });
 
   describe("generateFullHTML", () => {
+    it("uses the hydration runtime baked into an aged release", async () => {
+      const agedRuntimePath = "/_veryfront/hydration-runtime.1a2b3c4d.js";
+      const adapter = createMockAdapter(async (path: string) =>
+        path.endsWith("/app/page.tsx") ? "'use client';" : ""
+      );
+      adapter.fs.readDir = async function* (path: string) {
+        if (path !== "/project/custom-output/_veryfront") return;
+        yield {
+          name: agedRuntimePath.slice("/_veryfront/".length),
+          isFile: true,
+          isDirectory: false,
+          isSymlink: false,
+        };
+      };
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: adapter as any,
+        config: { build: { outDir: "custom-output" } } as any,
+        mode: "production",
+        isLocalProject: false,
+      });
+
+      const html = await generator.generateFullHTML(createHTMLContext({
+        html: "<main>Existing release</main>",
+        options: {
+          environment: "production",
+          releaseId: "release-aged",
+        },
+      }));
+
+      assertStringIncludes(html, `src="${agedRuntimePath}"`);
+      assertStringIncludes(html, `rel="modulepreload" href="${agedRuntimePath}"`);
+      assertEquals(html.includes(getProdHydrationModulePath()), false);
+    });
+
+    it("uses the hydration runtime baked into an aged release for full documents", async () => {
+      const agedRuntimePath = "/_veryfront/hydration-runtime.2b3c4d5e.js";
+      const adapter = createMockAdapter(async (path: string) =>
+        path.endsWith("/app/page.tsx") ? "'use client';" : ""
+      );
+      adapter.fs.readDir = async function* (path: string) {
+        if (path !== "/project/custom-output/_veryfront") return;
+        yield {
+          name: agedRuntimePath.slice("/_veryfront/".length),
+          isFile: true,
+          isDirectory: false,
+          isSymlink: false,
+        };
+      };
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: adapter as any,
+        config: { build: { outDir: "custom-output" } } as any,
+        mode: "production",
+        isLocalProject: false,
+      });
+
+      const html = await generator.generateFullHTML(createHTMLContext({
+        options: {
+          environment: "production",
+          releaseId: "release-aged",
+        },
+      }));
+
+      assertStringIncludes(html, `src="${agedRuntimePath}"`);
+      assertEquals(html.includes(getProdHydrationModulePath()), false);
+    });
+
+    it("keeps the RSC boot script for standalone production full documents", async () => {
+      const generator = createHTMLGenerator({
+        mode: "production",
+        readFile: async (path) => path.endsWith("/app/page.tsx") ? "'use client';" : "",
+      });
+
+      const html = await generator.generateFullHTML(createHTMLContext({
+        options: {
+          environment: "production",
+          releaseId: "standalone-dev",
+        },
+      }));
+
+      assertStringIncludes(html, 'src="/_veryfront/rsc/client.js"');
+      assertEquals(html.includes(getProdHydrationModulePath()), false);
+    });
+
     it("fails closed when a full-document component also declares React Head", async () => {
       const generator = createHTMLGenerator();
 
@@ -461,6 +547,14 @@ describe("HTMLGenerator helpers", () => {
       );
       const generator = createHTMLGenerator({
         readFile: async (path: string) => path.endsWith("/app/page.tsx") ? `'use client';` : "",
+        readDir: async function* () {
+          yield {
+            name: getProdHydrationModulePath().slice("/_veryfront/".length),
+            isFile: true,
+            isDirectory: false,
+            isSymlink: false,
+          };
+        },
       });
 
       const html = await generator.generateFullHTML(createHTMLContext({

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -26,10 +26,15 @@ import { extractRelativePath } from "#veryfront/utils/route-path-utils.ts";
 import { hasUseClientDirective } from "#veryfront/rendering/rsc/page-island.ts";
 import { getReadyManifestForRenderAsync } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
-import { resolveAppComponentPath } from "../layouts/utils/app-resolver.ts";
 import { resolveProjectReactVersion } from "#veryfront/transforms/esm/package-registry.ts";
-import { StreamTimeoutError, streamToString } from "../utils/stream-utils.ts";
 import { profilePhase, profileSyncPhase } from "#veryfront/observability";
+import { NOT_SUPPORTED } from "#veryfront/errors";
+import {
+  hasImmutableReleaseHydrationRuntime,
+  resolveProdHydrationModulePath,
+} from "#veryfront/html/hydration-script-builder/prod-runtime-selection.ts";
+import { resolveAppComponentPath } from "../layouts/utils/app-resolver.ts";
+import { StreamTimeoutError, streamToString } from "../utils/stream-utils.ts";
 import {
   extractProjectClassesForRoute,
   type ProjectCSSResult,
@@ -45,7 +50,7 @@ import {
 } from "./html-head.ts";
 import { mergeImportedCSS as mergeImportedProjectCss } from "./html-imported-css.ts";
 import type { HTMLGenerationContext, HTMLGeneratorConfig } from "./html-types.ts";
-import { NOT_SUPPORTED } from "#veryfront/errors";
+
 export type { HTMLGenerationContext, HTMLGeneratorConfig } from "./html-types.ts";
 
 const logger = rendererLogger.component("html-generator");
@@ -295,7 +300,7 @@ export class HTMLGenerator {
     const mergedFrontmatter = mergeCollectedFrontmatter(fullContext);
     const htmlOptions = await profilePhase(
       "html.build_options",
-      () => this.buildHTMLOptions(fullContext, mergedFrontmatter),
+      () => this.buildHTMLOptions(fullContext, mergedFrontmatter, true),
     );
     const projectCSSPromise = startProjectCSSPreparation(fullContext, htmlOptions);
     startPreparedCSSWarmup(this.config, fullContext, htmlOptions);
@@ -333,9 +338,12 @@ export class HTMLGenerator {
       });
     }
     const mergedFrontmatter = mergeCollectedFrontmatter(context);
+    const hasReleaseIdentity = hasImmutableReleaseHydrationRuntime(
+      resolveReleaseId(context.options),
+    );
     const htmlOptions = await profilePhase(
       "html.build_options",
-      () => this.buildHTMLOptions(context, mergedFrontmatter),
+      () => this.buildHTMLOptions(context, mergedFrontmatter, hasReleaseIdentity),
     );
     const projectCSSPromise = startProjectCSSPreparation(context, htmlOptions);
     const metadata = extractHTMLMetadata(
@@ -392,6 +400,7 @@ export class HTMLGenerator {
       projectStylesheetHref,
       dependencyPinningCacheKey: context.options?.dependencyPinningCacheKey,
       releaseAssetManifest,
+      prodHydrationModulePath: htmlOptions.prodHydrationModulePath,
       directories: this.config.config.directories,
     });
 
@@ -440,7 +449,7 @@ export class HTMLGenerator {
     const mergedFrontmatter = mergeCollectedFrontmatter(context);
     const htmlOptions = await profilePhase(
       "html.build_options",
-      () => this.buildHTMLOptions(context, mergedFrontmatter),
+      () => this.buildHTMLOptions(context, mergedFrontmatter, true),
     );
     const projectCSSPromise = startProjectCSSPreparation(context, htmlOptions);
     startPreparedCSSWarmup(this.config, context, htmlOptions);
@@ -702,6 +711,7 @@ export class HTMLGenerator {
   private async buildHTMLOptions(
     context: HTMLGenerationContext,
     mergedFrontmatter: MDXFrontmatter,
+    includeProdHydrationRuntime: boolean,
   ): Promise<HTMLGenerationOptions> {
     const stylesheetPath = this.config.config?.tailwind?.stylesheet || "globals.css";
     const [appComponentPathOrNull, globalCSS] = await Promise.all([
@@ -769,6 +779,21 @@ export class HTMLGenerator {
     const sourceHash = context.options?.studioEmbed && context.pageInfo.entity.content
       ? computeSourceHash(context.pageInfo.entity.content)
       : undefined;
+    const releaseId = resolveReleaseId(context.options);
+    const usesProductionScripts = context.options?.forceProductionScripts === true ||
+      !(this.config.isLocalProject === true || context.options?.environment === "preview");
+    const prodHydrationModulePath = includeProdHydrationRuntime && usesProductionScripts
+      ? await profilePhase(
+        "html.release_hydration_runtime",
+        () =>
+          resolveProdHydrationModulePath({
+            fs: this.config.adapter.fs,
+            projectDir: this.config.projectDir,
+            buildOutDir: this.config.config?.build?.outDir,
+            releaseId,
+          }),
+      )
+      : undefined;
     return profileSyncPhase("html.build_options.finalize", () => ({
       mode: this.config.mode,
       config: this.config.config,
@@ -793,7 +818,8 @@ export class HTMLGenerator {
       studioEmbed: context.options?.studioEmbed,
       projectId: context.options?.projectId,
       projectSlug: context.options?.projectSlug,
-      releaseId: resolveReleaseId(context.options),
+      releaseId,
+      prodHydrationModulePath,
       pageId: context.options?.pageId,
       sourceHash,
       colorScheme: context.options?.colorScheme,

--- a/src/rendering/page-renderer.ts
+++ b/src/rendering/page-renderer.ts
@@ -29,6 +29,8 @@ interface PageRenderOptions {
   projectSlug?: string;
   /** Content source identifier for cache isolation (branch name or release ID) */
   contentSourceId?: string;
+  /** Release that owns the immutable browser artifacts for this render. */
+  releaseId?: string;
   /** Request-scoped dependency-pinning state used by transform caches. */
   dependencyPinningCacheKey?: string;
   /** Immutable package map paired with dependencyPinningCacheKey. */
@@ -176,6 +178,7 @@ export class PageRenderer {
                 url: options?.url,
                 props: options?.props,
                 nonce: options?.nonce,
+                releaseId: options?.releaseId,
                 dependencyPinningCacheKey: options?.dependencyPinningCacheKey,
                 dependencyPinningDependencies: options?.dependencyPinningDependencies,
               }),

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -644,6 +644,45 @@ describe("Renderer release asset cache isolation", () => {
     clearReleaseAssetManifestCache();
   });
 
+  it("forwards the release identity from context to the render pipeline", async () => {
+    const renderer = new Renderer();
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let observedOptions: RenderOptions | undefined;
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (
+            slug: string,
+            options?: RenderOptions,
+          ) => Promise<RenderResult>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (_slug, options) => {
+          observedOptions = options;
+          return Promise.resolve({
+            html: "<html>release render</html>",
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    try {
+      await renderer.renderPage("/release", makeRenderContext(), {
+        releaseAssetManifest: null,
+      });
+
+      assertEquals(observedOptions?.contentSourceId, "release-rel-1");
+      assertEquals(observedOptions?.releaseId, "rel-1");
+    } finally {
+      await renderer.destroy();
+    }
+  });
+
   it("checks the manifest-versioned cache prefix after awaiting a ready manifest", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     registerManifestFetcherForRelease(

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -1007,6 +1007,7 @@ export class Renderer {
           projectSlug: ctx.projectSlug,
           environment: ctx.environment,
           contentSourceId: ctx.contentSourceId,
+          releaseId: ctx.releaseId,
           skipCacheCheck: true,
           skipCachePersist: true,
         }),

--- a/src/rendering/script-page-handling.test.ts
+++ b/src/rendering/script-page-handling.test.ts
@@ -1,11 +1,14 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { handleScriptPage } from "./script-page-handling.ts";
-import { PageRenderer } from "./page-renderer.ts";
 import { flattenRouteParams } from "#veryfront/routing";
+import type { VeryfrontConfig } from "#veryfront/config";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 import { FakeTime } from "#std/testing/time";
+import { PageRenderer } from "./page-renderer.ts";
+import { handleScriptPage } from "./script-page-handling.ts";
 
 const PIN_KEY_A = "on:z7bg3qnfgtcb";
 const PIN_KEY_B = "on:3w5e11264sgsf";
@@ -117,33 +120,39 @@ function createScriptAdapter(): RuntimeAdapter {
 }
 
 async function renderWithPageRenderer(
-  projectDir: string,
-  pagePath: string,
-  dependencyPinningCacheKey?: string,
-  dependencyPinningDependencies?: Readonly<Record<string, string>>,
+  options: {
+    projectDir: string;
+    pagePath: string;
+    dependencyPinningCacheKey?: string;
+    dependencyPinningDependencies?: Readonly<Record<string, string>>;
+    releaseId?: string;
+    adapter?: RuntimeAdapter;
+    config?: VeryfrontConfig;
+  },
 ): Promise<string> {
+  const adapter = options.adapter ?? createScriptAdapter();
+  const config = options.config ?? { client: { cdn: { provider: "unpkg" } } };
   const renderer = new PageRenderer({
-    projectDir,
+    projectDir: options.projectDir,
     mode: "production",
-    config: {
-      client: { cdn: { provider: "unpkg" } },
-    },
-    adapter: createScriptAdapter(),
+    config,
+    adapter,
     componentRegistry: {} as never,
     compileMDX: () => Promise.reject(new Error("not used for script pages")),
   });
   const result = await renderer.preparePageBundles(
     {
       entity: {
-        path: pagePath,
+        path: options.pagePath,
         frontmatter: {},
       },
     } as never,
     "script-page",
     undefined,
     {
-      dependencyPinningCacheKey,
-      dependencyPinningDependencies,
+      dependencyPinningCacheKey: options.dependencyPinningCacheKey,
+      dependencyPinningDependencies: options.dependencyPinningDependencies,
+      releaseId: options.releaseId,
     },
   );
   if (!result.scriptResult) throw new Error("Expected script page result");
@@ -366,18 +375,18 @@ describe("script-page-handling helpers", () => {
           `export default "<main>Snapshot page</main>";`,
         );
 
-        const snapshotB = await renderWithPageRenderer(
+        const snapshotB = await renderWithPageRenderer({
           projectDir,
           pagePath,
-          PIN_KEY_B,
-          { react: "19.0.0", veryfront: "0.2.0" },
-        );
-        const snapshotA = await renderWithPageRenderer(
+          dependencyPinningCacheKey: PIN_KEY_B,
+          dependencyPinningDependencies: { react: "19.0.0", veryfront: "0.2.0" },
+        });
+        const snapshotA = await renderWithPageRenderer({
           projectDir,
           pagePath,
-          PIN_KEY_A,
-          { react: "18.3.1", veryfront: "0.1.10" },
-        );
+          dependencyPinningCacheKey: PIN_KEY_A,
+          dependencyPinningDependencies: { react: "18.3.1", veryfront: "0.1.10" },
+        });
         const importsB = extractInlineJson(snapshotB, "importmap").imports as
           | Record<string, string>
           | undefined;
@@ -416,12 +425,12 @@ describe("script-page-handling helpers", () => {
           `export default \`<!DOCTYPE html><html><head><title>Script</title></head><body><main>Hello</main></body></html>\`;`,
         );
 
-        const html = await renderWithPageRenderer(
+        const html = await renderWithPageRenderer({
           projectDir,
           pagePath,
-          PIN_KEY_A,
-          { react: "18.3.1", veryfront: "0.1.10" },
-        );
+          dependencyPinningCacheKey: PIN_KEY_A,
+          dependencyPinningDependencies: { react: "18.3.1", veryfront: "0.1.10" },
+        });
         const imports = extractInlineJson(html, "importmap").imports as
           | Record<string, string>
           | undefined;
@@ -440,6 +449,29 @@ describe("script-page-handling helpers", () => {
       }
     });
 
+    it("keeps standalone production full documents on the RSC boot script", async () => {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-script-page-standalone-" });
+
+      try {
+        const pagePath = `${projectDir}/page.js`;
+        await Deno.writeTextFile(
+          pagePath,
+          `export default \`<!DOCTYPE html><html><head><title>Standalone</title></head><body><main>Hello</main></body></html>\`;`,
+        );
+
+        const html = await renderWithPageRenderer({
+          projectDir,
+          pagePath,
+          releaseId: "standalone-dev",
+        });
+
+        assertEquals(html.includes("/_veryfront/rsc/client.js"), true);
+        assertEquals(html.includes(getProdHydrationModulePath()), false);
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
     it("keeps wrapped script-page output byte-identical when pinning is off", async () => {
       using _time = new FakeTime(new Date("2026-07-26T00:00:00.000Z"));
       const projectDir = await Deno.makeTempDir({ prefix: "vf-script-page-off-" });
@@ -451,12 +483,12 @@ describe("script-page-handling helpers", () => {
           `export default "<main>Flag-off page</main>";`,
         );
 
-        const unkeyed = await renderWithPageRenderer(projectDir, pagePath);
-        const flagOff = await renderWithPageRenderer(
+        const unkeyed = await renderWithPageRenderer({ projectDir, pagePath });
+        const flagOff = await renderWithPageRenderer({
           projectDir,
           pagePath,
-          "off",
-        );
+          dependencyPinningCacheKey: "off",
+        });
 
         assertEquals(flagOff, unkeyed);
 
@@ -465,15 +497,83 @@ describe("script-page-handling helpers", () => {
           fullPagePath,
           `export default \`<!DOCTYPE html><html><head><title>Off</title></head><body><main>Flag-off full page</main></body></html>\`;`,
         );
-        const unkeyedFull = await renderWithPageRenderer(projectDir, fullPagePath);
-        const flagOffFull = await renderWithPageRenderer(
+        const unkeyedFull = await renderWithPageRenderer({
           projectDir,
-          fullPagePath,
-          "off",
-        );
+          pagePath: fullPagePath,
+        });
+        const flagOffFull = await renderWithPageRenderer({
+          projectDir,
+          pagePath: fullPagePath,
+          dependencyPinningCacheKey: "off",
+        });
 
         assertEquals(flagOffFull, unkeyedFull);
         assertEquals(flagOffFull.includes('type="importmap"'), false);
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("uses the hydration runtime baked into an aged release", async () => {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-script-page-release-" });
+      const agedRuntimePath = "/_veryfront/hydration-runtime.1a2b3c4d.js";
+
+      try {
+        await Deno.mkdir(`${projectDir}/custom-output/_veryfront`, { recursive: true });
+        await Deno.writeTextFile(
+          `${projectDir}/custom-output${agedRuntimePath}`,
+          "export {};",
+        );
+        const pagePath = `${projectDir}/page.js`;
+        await Deno.writeTextFile(pagePath, `export default "<main>Aged release</main>";`);
+
+        const html = await renderWithPageRenderer({
+          projectDir,
+          pagePath,
+          releaseId: "release-aged",
+          adapter: { fs: createFileSystem() } as unknown as RuntimeAdapter,
+          config: {
+            build: { outDir: "custom-output" },
+            client: { cdn: { provider: "unpkg" } },
+          },
+        });
+
+        assertEquals(html.includes(agedRuntimePath), true);
+        assertEquals(html.includes(getProdHydrationModulePath()), false);
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("uses the hydration runtime baked into an aged release for full documents", async () => {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-script-page-release-full-" });
+      const agedRuntimePath = "/_veryfront/hydration-runtime.2b3c4d5e.js";
+
+      try {
+        await Deno.mkdir(`${projectDir}/custom-output/_veryfront`, { recursive: true });
+        await Deno.writeTextFile(
+          `${projectDir}/custom-output${agedRuntimePath}`,
+          "export {};",
+        );
+        const pagePath = `${projectDir}/page.js`;
+        await Deno.writeTextFile(
+          pagePath,
+          `export default \`<!DOCTYPE html><html><head><title>Aged</title></head><body><main>Aged release</main></body></html>\`;`,
+        );
+
+        const html = await renderWithPageRenderer({
+          projectDir,
+          pagePath,
+          releaseId: "release-aged",
+          adapter: { fs: createFileSystem() } as unknown as RuntimeAdapter,
+          config: {
+            build: { outDir: "custom-output" },
+            client: { cdn: { provider: "unpkg" } },
+          },
+        });
+
+        assertEquals(html.includes(agedRuntimePath), true);
+        assertEquals(html.includes(getProdHydrationModulePath()), false);
       } finally {
         await Deno.remove(projectDir, { recursive: true });
       }

--- a/src/rendering/script-page-handling.ts
+++ b/src/rendering/script-page-handling.ts
@@ -22,11 +22,16 @@ import type {
 } from "#veryfront/types";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
-import { computeHash } from "./utils/index.ts";
 import { buildImportMapJson, type HTMLGenerationOptions, wrapInHTMLShell } from "#veryfront/html";
 import { extractHTMLMetadata, injectHTMLContent, isFullHTMLDocument } from "#veryfront/html";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { getEsbuildLoader } from "#veryfront/utils/path-utils.ts";
+import {
+  hasImmutableReleaseHydrationRuntime,
+  resolveProdHydrationModulePath,
+} from "#veryfront/html/hydration-script-builder/prod-runtime-selection.ts";
+import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
+import { computeHash } from "./utils/index.ts";
 
 const logger = rendererLogger.component("script");
 
@@ -45,6 +50,8 @@ interface ScriptPageOptions {
   url?: URL;
   props?: ComponentProps;
   nonce?: string;
+  /** Release that owns the immutable hydration runtime for wrapped output. */
+  releaseId?: string;
   /** Immutable dependency snapshot that owns all browser work for this document. */
   dependencyPinningCacheKey?: string;
   dependencyPinningDependencies?: Readonly<Record<string, string>>;
@@ -234,6 +241,15 @@ async function generateFullHtml(
   const { mergedFrontmatter, outputMetadata, pageInfo, slug, appComponentPath, options } = context;
   const hasEnabledDependencySnapshot =
     options.dependencyPinningCacheKey?.startsWith("on:") === true;
+  const releaseHydrationModulePath = options.mode === "production" &&
+      hasImmutableReleaseHydrationRuntime(options.releaseId)
+    ? await resolveProdHydrationModulePath({
+      fs: options.adapter.fs,
+      projectDir: options.projectDir,
+      buildOutDir: options.config.build?.outDir,
+      releaseId: options.releaseId,
+    })
+    : undefined;
 
   if (isFullHTMLDocument(htmlBody)) {
     const metadata = extractHTMLMetadata(mergedFrontmatter, undefined);
@@ -255,8 +271,12 @@ async function generateFullHtml(
       nonce: options.nonce,
       importMapJson,
       dependencyPinningCacheKey: options.dependencyPinningCacheKey,
+      prodHydrationModulePath: releaseHydrationModulePath,
     });
   }
+
+  const prodHydrationModulePath = releaseHydrationModulePath ??
+    (options.mode === "production" ? getProdHydrationModulePath() : undefined);
 
   const htmlOptions: HTMLGenerationOptions = {
     mode: options.mode as "development" | "production",
@@ -265,6 +285,8 @@ async function generateFullHtml(
     nestedLayouts: [],
     appPath: appComponentPath,
     nonce: options.nonce,
+    releaseId: options.releaseId,
+    prodHydrationModulePath,
     ...(hasEnabledDependencySnapshot
       ? {
         projectDir: options.projectDir,

--- a/src/rendering/snippet-renderer.test.ts
+++ b/src/rendering/snippet-renderer.test.ts
@@ -1,18 +1,22 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { computeHash } from "#veryfront/utils";
+import { clearReactVersionCache } from "#veryfront/transforms/esm/package-registry.ts";
+import { DEPENDENCY_PINNING_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
+import { deleteEnv, getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 import {
   buildSnippetModuleUrl,
   clearSnippetCache,
   clearSnippetCacheForProject,
   getCompiledSnippet,
   renderSnippet,
+  wrapSnippetInHTMLShell,
 } from "./snippet-renderer.ts";
-import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
-import { computeHash } from "#veryfront/utils";
-import { clearReactVersionCache } from "#veryfront/transforms/esm/package-registry.ts";
-import { DEPENDENCY_PINNING_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
-import { deleteEnv, getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 
 function restoreEnv(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -46,6 +50,42 @@ describe("rendering/snippet-renderer", () => {
         ),
         "https://modules.example/_vf_modules/_snippets/snippet-hash.js?ssr=true&v=123",
       );
+    });
+  });
+
+  describe("wrapSnippetInHTMLShell", () => {
+    it("uses the hydration runtime baked into an aged release", async () => {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-snippet-release-" });
+      const agedRuntimePath = "/_veryfront/hydration-runtime.1a2b3c4d.js";
+      const adapter = { fs: createFileSystem() } as unknown as RuntimeAdapter;
+
+      try {
+        await Deno.mkdir(`${projectDir}/custom-output/_veryfront`, { recursive: true });
+        await Deno.writeTextFile(`${projectDir}/custom-output${agedRuntimePath}`, "export {};");
+
+        const html = await wrapSnippetInHTMLShell(
+          "<main>Aged snippet</main>",
+          { title: "Aged snippet", slug: "aged-snippet" },
+          {
+            mode: "production",
+            projectDir,
+            adapter,
+            releaseId: "release-aged",
+            moduleServerUrl: "http://127.0.0.1:3000",
+            config: { build: { outDir: "custom-output" } },
+          },
+          {
+            hash: "snippet-hash",
+            moduleServerBase: "http://127.0.0.1:3000",
+            dependencyPinningCacheKey: "off",
+          },
+        );
+
+        assertEquals(html.includes(agedRuntimePath), true);
+        assertEquals(html.includes(getProdHydrationModulePath()), false);
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
     });
   });
 

--- a/src/rendering/snippet-renderer.ts
+++ b/src/rendering/snippet-renderer.ts
@@ -2,6 +2,7 @@ import { computeHash, rendererLogger } from "#veryfront/utils";
 import { RENDER_ERROR } from "#veryfront/errors";
 import type { RenderMetadata } from "#veryfront/types";
 import type { VeryfrontConfig } from "#veryfront/config";
+import type { HTMLGenerationOptions } from "#veryfront/html";
 import { wrapInHTMLShell } from "#veryfront/html/html-shell-generator.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerCache } from "#veryfront/utils/memory/index.ts";
@@ -19,6 +20,8 @@ import {
 } from "#veryfront/transforms/esm/package-registry.ts";
 import { appendDependencyPinningKey } from "#veryfront/transforms/import-rewriter/url-builder.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { resolveProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-runtime-selection.ts";
 
 const logger = rendererLogger.component("snippet-renderer");
 
@@ -34,6 +37,8 @@ export interface SnippetRenderOptions {
   isLocalProject?: boolean;
   projectId?: string;
   contentSourceId?: string;
+  /** Release that owns the immutable hydration runtime for this shell. */
+  releaseId?: string;
   /** Canonical request-scoped dependency source supplied by server handlers. */
   dependencyPinningSource?: DependencyPinningSource;
   filePath?: string;
@@ -51,6 +56,52 @@ export interface SnippetRenderOptions {
 export interface SnippetRenderResult {
   html: string;
   frontmatter: Record<string, unknown>;
+}
+
+/** Build the document shell for a compiled snippet. */
+export async function wrapSnippetInHTMLShell(
+  bodyHtml: string,
+  meta: RenderMetadata,
+  options: SnippetRenderOptions,
+  context: {
+    hash: string;
+    moduleServerBase: string;
+    dependencyPinningCacheKey: string;
+    dependencyPinningDependencies?: Readonly<Record<string, string>>;
+  },
+): Promise<string> {
+  const serverPort = getServerPort(options.moduleServerUrl);
+  const snippetConfig = {
+    ...options.config,
+    dev: {
+      ...options.config?.dev,
+      hmr: true,
+      port: serverPort ?? options.config?.dev?.port,
+    },
+  };
+  const prodHydrationModulePath = options.mode === "production"
+    ? await resolveProdHydrationModulePath({
+      fs: options.adapter?.fs ?? createFileSystem(),
+      projectDir: options.projectDir,
+      buildOutDir: options.config?.build?.outDir,
+      releaseId: options.releaseId,
+    })
+    : undefined;
+  const htmlOptions: HTMLGenerationOptions = {
+    mode: options.mode,
+    config: snippetConfig,
+    projectDir: options.projectDir,
+    moduleServerOrigin: new URL(context.moduleServerBase).origin,
+    nonce: options.nonce,
+    studioEmbed: true,
+    pagePath: `_snippets/${context.hash}`,
+    pageId: options.pageId,
+    releaseId: options.releaseId,
+    prodHydrationModulePath,
+    dependencyPinningCacheKey: context.dependencyPinningCacheKey,
+    dependencyPinningDependencies: context.dependencyPinningDependencies,
+  };
+  return await wrapInHTMLShell(bodyHtml, meta, htmlOptions);
 }
 
 export function buildSnippetModuleUrl(
@@ -339,25 +390,9 @@ export function renderSnippet(
           frontmatter: bundle.frontmatter as RenderMetadata["frontmatter"],
         };
 
-        const serverPort = getServerPort(options.moduleServerUrl);
-        const snippetConfig = {
-          ...options.config,
-          dev: {
-            ...options.config?.dev,
-            hmr: true,
-            port: serverPort ?? options.config?.dev?.port,
-          },
-        };
-
-        const html = await wrapInHTMLShell(bodyHtml, meta, {
-          mode: options.mode,
-          config: snippetConfig,
-          projectDir: options.projectDir,
-          moduleServerOrigin: new URL(moduleServerBase).origin,
-          nonce: options.nonce,
-          studioEmbed: true,
-          pagePath: `_snippets/${hash}`,
-          pageId: options.pageId,
+        const html = await wrapSnippetInHTMLShell(bodyHtml, meta, options, {
+          hash,
+          moduleServerBase,
           dependencyPinningCacheKey: dependencySnapshot.cacheKey,
           dependencyPinningDependencies: dependencySnapshot.dependencies,
         });

--- a/src/server/handlers/request/snippet.handler.test.ts
+++ b/src/server/handlers/request/snippet.handler.test.ts
@@ -163,6 +163,53 @@ describe("SnippetHandler host-execution capability", () => {
     );
     assertNotEquals(readPath, undefined, "the granted path must reach the source read");
   });
+
+  it("passes the canonical enriched release identity to snippet rendering", async () => {
+    let renderedReleaseId: string | undefined;
+    const handler = new SnippetHandler({
+      renderSnippet: (_content: string, options: { releaseId?: string }) => {
+        renderedReleaseId = options.releaseId;
+        return Promise.resolve({ html: "<main>Snippet</main>", frontmatter: {} });
+      },
+    });
+    const fs = {
+      symlinkSemantics: "none" as const,
+      isMultiProjectMode: () => false,
+      isContextualMode: () => false,
+      exists: () => Promise.resolve(true),
+      stat: () =>
+        Promise.resolve({
+          isFile: true,
+          isDirectory: false,
+          isSymlink: false,
+          size: 1,
+          mtime: new Date(),
+        }),
+      readFile: () => Promise.resolve("# Snippet"),
+    };
+    const ctx = {
+      projectDir: "/project",
+      projectId: "serving-project",
+      projectSlug: "serving-project",
+      releaseId: "serving-release",
+      enriched: {
+        projectId: "canonical-project",
+        projectSlug: "canonical-project",
+        contentSourceId: "canonical-content",
+        releaseId: "canonical-release",
+      },
+      isLocalProject: true,
+      adapter: { fs },
+    } as unknown as HandlerContext;
+
+    const result = await handler.handle(
+      new Request("http://localhost/@components/button"),
+      ctx,
+    );
+
+    assertEquals(result.response?.status, 200);
+    assertEquals(renderedReleaseId, "canonical-release");
+  });
 });
 
 Deno.test("SnippetHandler preserves dedicated local rendering", async () => {

--- a/src/server/handlers/request/snippet.handler.ts
+++ b/src/server/handlers/request/snippet.handler.ts
@@ -22,12 +22,22 @@ const logger = serverLogger.component("snippet-handler");
 
 const PRIORITY_SNIPPET = 450;
 
+export interface SnippetHandlerDeps {
+  renderSnippet: typeof renderSnippet;
+}
+
+const defaultDeps: SnippetHandlerDeps = { renderSnippet };
+
 export class SnippetHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "SnippetHandler",
     priority: PRIORITY_SNIPPET as HandlerPriority,
     patterns: [{ pattern: /^\/(@\/|@components\/)/, method: "GET" }],
   };
+
+  constructor(private readonly deps: SnippetHandlerDeps = defaultDeps) {
+    super();
+  }
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     const url = new URL(req.url);
@@ -94,13 +104,14 @@ export class SnippetHandler extends BaseHandler {
         const isDev = !!ctx.isLocalProject;
         const dependencyIdentity = getHandlerDependencyPinningIdentity(ctx);
 
-        const result = await renderSnippet(content, {
+        const result = await this.deps.renderSnippet(content, {
           mode: isDev ? "development" : "production",
           projectDir: ctx.projectDir,
           adapter: stableAdapter,
           isLocalProject: ctx.isLocalProject,
           projectId: dependencyIdentity.projectId,
           contentSourceId: dependencyIdentity.contentSourceId,
+          releaseId: dependencyIdentity.releaseId,
           dependencyPinningSource: createHandlerDependencyPinningSource(ctx),
           filePath: admittedPath,
           moduleServerUrl,

--- a/src/server/handlers/request/static.handler.test.ts
+++ b/src/server/handlers/request/static.handler.test.ts
@@ -3,6 +3,8 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { HandlerContext } from "../types.ts";
 import { StaticHandler } from "./static.handler.ts";
+import { getAdapter } from "#veryfront/platform/adapters/detect.ts";
+import { makeTempDir, mkdir, remove, writeTextFile } from "#veryfront/platform/compat/fs.ts";
 
 function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   return {
@@ -53,6 +55,55 @@ describe("server/handlers/request/static.handler", () => {
       "application/javascript; charset=utf-8",
     );
     assertEquals(await result.response.text(), "export const page = true;");
+  });
+
+  it("forwards the configured build output directory to static resolution", async () => {
+    const handler = new StaticHandler();
+    let resolvedBuildOutDir: string | undefined;
+    (handler as any).staticService = {
+      resolveFile: async (_pathname: string, options: { buildOutDir?: string }) => {
+        resolvedBuildOutDir = options.buildOutDir;
+        return null;
+      },
+      isAssetRequest: () => true,
+    };
+
+    await handler.handle(
+      new Request("http://localhost/_veryfront/hydration-runtime.2b3c4d5e.js"),
+      makeCtx({ config: { build: { outDir: "custom-output" } } }),
+    );
+
+    assertEquals(resolvedBuildOutDir, "custom-output");
+  });
+
+  it("serves a release runtime from an absolute build output directory", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-static-project-" });
+    const buildOutDir = await makeTempDir({ prefix: "vf-static-output-" });
+    const runtimePath = "/_veryfront/hydration-runtime.2b3c4d5e.js";
+
+    try {
+      await mkdir(`${buildOutDir}/_veryfront`, { recursive: true });
+      await writeTextFile(
+        `${buildOutDir}${runtimePath}`,
+        "export const releaseRuntime = true;",
+      );
+      const handler = new StaticHandler();
+      const result = await handler.handle(
+        new Request(`http://localhost${runtimePath}`),
+        makeCtx({
+          projectDir,
+          adapter: await getAdapter(),
+          config: { build: { outDir: buildOutDir } },
+        }),
+      );
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+      assertEquals(await result.response.text(), "export const releaseRuntime = true;");
+    } finally {
+      await remove(projectDir, { recursive: true });
+      await remove(buildOutDir, { recursive: true });
+    }
   });
 
   it("serves generated hydration runtime under /_veryfront", async () => {

--- a/src/server/handlers/request/static.handler.ts
+++ b/src/server/handlers/request/static.handler.ts
@@ -92,6 +92,7 @@ export class StaticHandler extends BaseHandler {
           adapter: ctx.adapter,
           isPreviewMode,
           isLocalProject: isLocal,
+          buildOutDir: ctx.config?.build?.outDir,
         };
 
         const result = await this.staticService.resolveFile(pathname, resolveOptions);

--- a/src/server/services/static/static-file.service.test.ts
+++ b/src/server/services/static/static-file.service.test.ts
@@ -57,6 +57,50 @@ function createFsError(message: string, code: string): Error & { code: string } 
   return error;
 }
 
+function createNativeFsAdapter(
+  files: Map<string, Uint8Array>,
+): StaticFileOptions["adapter"] {
+  const ready = Promise.resolve();
+  return {
+    fs: {
+      symlinkSemantics: "none" as const,
+      readFile: async (path: string) => {
+        const data = files.get(path);
+        if (!data) throw createFsError("not found", "ENOENT");
+        return new TextDecoder().decode(data);
+      },
+      readFileBytes: async (path: string) => {
+        const data = files.get(path);
+        if (!data) throw createFsError("not found", "ENOENT");
+        return data;
+      },
+      writeFile: async () => {},
+      exists: async (path: string) => files.has(path),
+      stat: async (path: string) => {
+        const data = files.get(path);
+        if (!data) throw createFsError("not found", "ENOENT");
+        return {
+          isFile: true,
+          isDirectory: false,
+          isSymlink: false,
+          size: data.byteLength,
+          mtime: new Date(0),
+        };
+      },
+      async *readDir() {},
+      mkdir: async () => {},
+      remove: async () => {},
+      makeTempDir: async (prefix: string) => `/tmp/${prefix}`,
+      watch: () => ({
+        ready,
+        done: ready,
+        close() {},
+        async *[Symbol.asyncIterator]() {},
+      }),
+    },
+  } as unknown as StaticFileOptions["adapter"];
+}
+
 afterEach(() => {
   __injectDepsForTests(null);
 });
@@ -317,6 +361,71 @@ describe("server/services/static/static-file.service", () => {
         assertEquals(result.data, fileData);
         assertEquals(typeof result.etag, "string");
       }
+    });
+
+    it("serves production assets from the configured build output directory", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const runtimePath = "/_veryfront/hydration-runtime.2b3c4d5e.js";
+      const fileData = new TextEncoder().encode("export const release = true;");
+      const files = new Map<string, Uint8Array>([
+        [`/project/custom-output${runtimePath}`, fileData],
+      ]);
+      const service = new StaticFileService(createMockFsRepo(files));
+      const options = makeOptions({ buildOutDir: "custom-output" });
+
+      const result = await service.resolveFile(runtimePath, options);
+
+      assertExists(result);
+      assertEquals(result.path, `/project/custom-output${runtimePath}`);
+      assertEquals(result.source, "dist");
+      assertEquals(result.data, fileData);
+      assertEquals(result.cacheStrategy, "immutable");
+    });
+
+    it("serves an absolute build output without widening project access", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const runtimePath = "/_veryfront/hydration-runtime.2b3c4d5e.js";
+      const buildOutDir = "/srv/veryfront-output";
+      const outputPath = `${buildOutDir}${runtimePath}`;
+      const fileData = new TextEncoder().encode("export const release = true;");
+      const files = new Map<string, Uint8Array>([
+        [outputPath, fileData],
+        ["/project/src/private.js", new TextEncoder().encode("private source")],
+      ]);
+      const adapter = createNativeFsAdapter(files);
+      const service = new StaticFileService();
+      const options = makeOptions({ adapter, buildOutDir });
+
+      const result = await service.resolveFile(runtimePath, options);
+
+      assertExists(result);
+      assertEquals(result.path, outputPath);
+      assertEquals(result.source, "dist");
+      assertEquals(result.data, fileData);
+      assertEquals(result.cacheStrategy, "immutable");
+      assertEquals(await service.resolveFile("/src/private.js", options), null);
+    });
+
+    it("does not widen source access when build output contains the project", async () => {
+      const files = new Map<string, Uint8Array>([
+        ["/project/src/private.js", new TextEncoder().encode("private source")],
+      ]);
+      const adapter = createNativeFsAdapter(files);
+      const service = new StaticFileService();
+
+      const malformedRootResult = await service.resolveFile(
+        "/src/private.js",
+        makeOptions({ adapter, buildOutDir: "." }),
+      );
+      assertEquals(malformedRootResult, null);
     });
 
     it("serves built nested index pages through clean route URLs", async () => {

--- a/src/server/services/static/static-file.service.ts
+++ b/src/server/services/static/static-file.service.ts
@@ -72,6 +72,8 @@ export interface StaticFileOptions {
   isPreviewMode: boolean;
   /** Whether this is a local filesystem project */
   isLocalProject: boolean;
+  /** Configured production build output directory */
+  buildOutDir?: string;
 }
 
 /**
@@ -90,6 +92,11 @@ interface FileSystemLike {
   readFile(path: string): Promise<string>;
   readFileBytes(path: string): Promise<Uint8Array>;
   stat(path: string): Promise<{ isFile: boolean; mtime: Date | null }>;
+}
+
+interface StaticFileSystems {
+  buildOutput: FileSystemLike;
+  project: FileSystemLike;
 }
 
 /**
@@ -127,24 +134,52 @@ export class StaticFileService {
     return injectedDeps?.manifestLoading ?? StaticFileService.manifestLoading;
   }
 
-  private getFileSystem(options: StaticFileOptions): FileSystemLike {
-    if (this.fsRepo) return this.fsRepo;
+  private resolveBuildOutputRoot(options: StaticFileOptions): string {
+    return resolve(options.projectDir, options.buildOutDir || "dist");
+  }
+
+  private getFileSystems(options: StaticFileOptions): StaticFileSystems {
+    if (this.fsRepo) return { buildOutput: this.fsRepo, project: this.fsRepo };
 
     const projectRoot = resolve(options.projectDir);
-    const secureFs = createSecureFs({
+    const projectSecureFs = createSecureFs({
       baseDir: projectRoot,
       adapter: options.adapter,
       context: "static-serving",
     });
 
-    // StaticFileService keeps absolute paths in candidates and results, while
-    // SecureFs exposes a base-directory-scoped namespace. Adapt that boundary
-    // explicitly so the static policy can continue rejecting absolute input.
-    const toProjectPath = (path: string): string => relative(projectRoot, resolve(path));
+    const adaptSecureFs = (
+      secureFs: ReturnType<typeof createSecureFs>,
+      root: string,
+    ): FileSystemLike => {
+      const toScopedPath = (path: string): string => relative(root, resolve(path));
+      return {
+        readFile: (path) => secureFs.readFile(toScopedPath(path)),
+        readFileBytes: (path) => secureFs.readFileBytes(toScopedPath(path)),
+        stat: (path) => secureFs.stat(toScopedPath(path)),
+      };
+    };
+
+    // Keep public files under the project policy. A configured build output can
+    // live beside or outside the project, so give that trusted artifact root an
+    // independent boundary instead of expressing it as ../ paths from the project.
+    const project = adaptSecureFs(projectSecureFs, projectRoot);
+    const buildOutputRoot = this.resolveBuildOutputRoot(options);
+    if (isWithinDirectory(buildOutputRoot, projectRoot)) {
+      // Refuse to widen static serving when a malformed output root contains
+      // the project. The project policy still permits only dist and public.
+      return { buildOutput: project, project };
+    }
+
+    const buildOutputSecureFs = createSecureFs({
+      baseDir: buildOutputRoot,
+      adapter: options.adapter,
+      context: "internal",
+      validationOptions: { checkExists: true },
+    });
     return {
-      readFile: (path) => secureFs.readFile(toProjectPath(path)),
-      readFileBytes: (path) => secureFs.readFileBytes(toProjectPath(path)),
-      stat: (path) => secureFs.stat(toProjectPath(path)),
+      buildOutput: adaptSecureFs(buildOutputSecureFs, buildOutputRoot),
+      project,
     };
   }
 
@@ -152,12 +187,13 @@ export class StaticFileService {
     requestPath: string,
     options: StaticFileOptions,
   ): Promise<StaticFileResult | null> {
-    const fs = this.getFileSystem(options);
+    const fileSystems = this.getFileSystems(options);
     const normalizedPath = requestPath === "/" ? "/index.html" : requestPath;
-    const candidates = await this.buildCandidates(normalizedPath, options, fs);
+    const candidates = await this.buildCandidates(normalizedPath, options, fileSystems.buildOutput);
     const unexpectedErrors: unknown[] = [];
 
     for (const candidate of candidates) {
+      const fs = candidate.source === "public" ? fileSystems.project : fileSystems.buildOutput;
       const result = await this.tryResolveCandidate(
         candidate,
         requestPath,
@@ -193,22 +229,28 @@ export class StaticFileService {
       if (manifestPath) addCandidate(manifestPath, "manifest");
     }
 
-    const dirs = options.isLocalProject && !options.isPreviewMode
-      ? ["public"] as const
-      : ["dist", "public"] as const;
+    const buildOutputRoot = this.resolveBuildOutputRoot(options);
+    const publicRoot = resolve(options.projectDir, "public");
+    const dirs: ReadonlyArray<{
+      root: string;
+      source: "dist" | "public";
+    }> = options.isLocalProject && !options.isPreviewMode
+      ? [{ root: publicRoot, source: "public" }]
+      : [
+        { root: buildOutputRoot, source: "dist" },
+        { root: publicRoot, source: "public" },
+      ];
 
-    for (const dir of dirs) {
-      const root = joinPath(options.projectDir, dir);
+    for (const { root, source } of dirs) {
       const absPath = normalizePath(joinPath(root, normalizedPath));
-      if (isWithinDirectory(root, absPath)) addCandidate(absPath, dir);
+      if (isWithinDirectory(root, absPath)) addCandidate(absPath, source);
     }
 
     if (this.shouldProbeIndexPage(normalizedPath)) {
       const indexPath = `${normalizedPath.replace(/\/$/, "")}/index.html`;
-      for (const dir of dirs) {
-        const root = joinPath(options.projectDir, dir);
+      for (const { root, source } of dirs) {
         const absPath = normalizePath(joinPath(root, indexPath));
-        if (isWithinDirectory(root, absPath)) addCandidate(absPath, dir);
+        if (isWithinDirectory(root, absPath)) addCandidate(absPath, source);
       }
     }
 
@@ -294,8 +336,8 @@ export class StaticFileService {
     options: StaticFileOptions,
     fs: FileSystemLike,
   ): Promise<ManifestIndex | null> {
-    const cacheKey = options.projectDir;
-    const distRoot = joinPath(options.projectDir, "dist");
+    const distRoot = this.resolveBuildOutputRoot(options);
+    const cacheKey = distRoot;
     const manifestPath = joinPath(distRoot, "_veryfront/manifest.json");
 
     let stat: { isFile: boolean; mtime: Date | null };

--- a/tests/e2e/regressions/2026-07-27-legacy-router-hydration.test.ts
+++ b/tests/e2e/regressions/2026-07-27-legacy-router-hydration.test.ts
@@ -8,6 +8,8 @@
  *      linking before hydration could run.
  * Fixed: 2026-07-27
  * Related: https://github.com/veryfront/veryfront-issue-inbox/issues/264
+ * Hotfix: https://github.com/veryfront/veryfront-code/pull/3124
+ * Artifact selection: https://github.com/veryfront/veryfront-issue-inbox/issues/277
  *
  * Root Cause:
  *   The shared hydration runtime and project release assets are versioned
@@ -22,7 +24,7 @@
  *   the SPA navigator only when that optional export exists.
  */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   captureBrowserDiagnostics,
@@ -30,7 +32,13 @@ import {
   getBrowserDiagnosticMessages,
   launchChromium,
 } from "../../_helpers/playwright.ts";
-import { generateProdHydrationModule } from "../../../src/html/hydration-script-builder/prod-scripts.ts";
+import {
+  generateProdHydrationModule,
+  getProdHydrationModulePath,
+} from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { PageRenderer } from "#veryfront/rendering/page-renderer.ts";
 
 const HTML = `<!doctype html>
 <html>
@@ -120,6 +128,11 @@ const PAGE_MODULE = `
 export default function ExistingReleasePage() {
   return null;
 }
+`;
+
+const AGED_RELEASE_HYDRATION_MODULE = `
+document.documentElement.dataset.hydrationArtifact = "aged-release";
+document.documentElement.dataset.hydrated = "yes";
 `;
 
 function javascript(source: string): Response {
@@ -215,6 +228,84 @@ describe(
         await closeChromium(browser);
         await server.shutdown();
         await server.finished;
+      }
+    });
+
+    it("loads the aged release runtime instead of the current serving runtime", async () => {
+      const agedRuntimePath = "/_veryfront/hydration-runtime.1a2b3c4d.js";
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-aged-release-browser-" });
+      let server: ReturnType<typeof Deno.serve> | undefined;
+      let browser: Awaited<ReturnType<typeof launchChromium>> = null;
+
+      try {
+        await Deno.mkdir(`${projectDir}/dist/_veryfront`, { recursive: true });
+        await Deno.writeTextFile(`${projectDir}/dist${agedRuntimePath}`, "export {};");
+        const pagePath = `${projectDir}/page.js`;
+        await Deno.writeTextFile(pagePath, `export default "<main>Aged release</main>";`);
+
+        const adapter = { fs: createFileSystem() } as unknown as RuntimeAdapter;
+        const renderer = new PageRenderer({
+          projectDir,
+          mode: "production",
+          config: {},
+          adapter,
+          componentRegistry: {} as never,
+          compileMDX: () => Promise.reject(new Error("not used for script pages")),
+        });
+        const renderResult = await renderer.preparePageBundles(
+          { entity: { path: pagePath, frontmatter: {} } } as never,
+          "aged-release",
+          undefined,
+          { releaseId: "release-aged" },
+        );
+        const html = renderResult.scriptResult?.html;
+        if (!html) throw new Error("Expected the script page renderer to return HTML");
+        assertStringIncludes(html, agedRuntimePath);
+        assertEquals(html.includes(getProdHydrationModulePath()), false);
+
+        let currentRuntimeRequests = 0;
+        server = Deno.serve({
+          hostname: "127.0.0.1",
+          port: 0,
+          onListen() {},
+        }, (request) => {
+          const pathname = new URL(request.url).pathname;
+          if (pathname === "/") {
+            return new Response(html, {
+              headers: { "content-type": "text/html; charset=utf-8" },
+            });
+          }
+          if (pathname === agedRuntimePath) return javascript(AGED_RELEASE_HYDRATION_MODULE);
+          if (pathname === getProdHydrationModulePath()) {
+            currentRuntimeRequests += 1;
+            return new Response("Wrong runtime", { status: 500 });
+          }
+          if (pathname.endsWith(".js")) return javascript("export default {};");
+          return new Response(null, { status: 204 });
+        });
+        browser = await launchChromium();
+        if (!browser) return;
+
+        const page = await browser.newPage();
+        const diagnostics = captureBrowserDiagnostics(page);
+        const { port } = server.addr as Deno.NetAddr;
+        const response = await page.goto(`http://127.0.0.1:${port}/`);
+
+        assertEquals(response?.status(), 200);
+        await waitForHydration(page, diagnostics);
+        assertEquals(
+          await page.evaluate(() => document.documentElement.dataset.hydrationArtifact),
+          "aged-release",
+        );
+        assertEquals(currentRuntimeRequests, 0);
+        assertEquals(getBrowserDiagnosticMessages(diagnostics), []);
+      } finally {
+        await closeChromium(browser);
+        if (server) {
+          await server.shutdown();
+          await server.finished;
+        }
+        await Deno.remove(projectDir, { recursive: true });
       }
     });
   },


### PR DESCRIPTION
## Summary

- select the single content-addressed hydration runtime baked into an immutable release
- propagate release identity through component, script-page, snippet, and full-document HTML shells
- serve configured relative or absolute build outputs through separately scoped secure filesystem roots
- preserve standalone development boot behavior and fail closed for missing or ambiguous immutable-release artifacts
- document the release/runtime compatibility and retirement policy

This implements option 1 selected in veryfront/veryfront-issue-inbox#277 and builds on the content-address ownership fix in #3807. It addresses the artifact skew exposed by incident veryfront/veryfront-issue-inbox#264 and the compatibility hotfix in #3124.

## RED / GREEN

RED coverage reproduced current-runtime leakage from aged release component HTML, wrapped and full-document JavaScript pages, snippet shells, and full-document components. Additional regressions reproduced the missing server release handoff, standalone development misclassification, configured output-directory 404s, and absolute external output rejection.

GREEN coverage verifies:

- aged release runtime selection and typed failure for missing or ambiguous artifacts
- identical selected paths in module preload and script execution
- production build output contains exactly one selectable content-addressed runtime
- component, script-page, snippet, full-document, and server renderer propagation paths
- standalone development retains its synthetic RSC boot path
- relative and absolute configured output directories serve through restrictive independent roots
- real Chromium loads the aged artifact and never requests the current runtime

## Verification

Exact head: `c11ba2e4b61eee04b0f3eb54ba1046e6a128e355`

- focused release/static matrix: 12 tests, 215 steps, 0 failed
- RSC Chromium suite: 4 tests, 9 steps, 0 failed
- full unit gate: 3,921 tests, 29,965 steps, 0 failed, 1 ignored
- cwd suites: 13 tests, 213 steps, 0 failed
- focused Deno release/static/browser matrix: 6 tests, 119 steps, 0 failed
- focused resolver/static coverage passed under Node and Bun
- npm package build passed
- pre-push formatting, lint, typecheck, and diff checks passed
- replacement exact-head GitHub CI is required to be fully green before merge

Closes veryfront/veryfront-issue-inbox#277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production releases now use their matching versioned hydration runtime for reliable rendering, including older releases.
  * Custom build output directories are supported for serving browser assets.
  * Release HTML generation validates that exactly one compatible hydration runtime is available.

* **Bug Fixes**
  * Fixed stale releases loading the current hydration runtime instead of their paired runtime.
  * Improved handling of missing, unreadable, ambiguous, or invalid release assets.

* **Documentation**
  * Updated deployment guidance for build output locations and immutable release artifact pairing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->