### PR TITLE
test: make link observer delay assertion deterministic

### DIFF
--- a/src/rendering/client/prefetch/link-observer.test.ts
+++ b/src/rendering/client/prefetch/link-observer.test.ts
@@ -2,7 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { delay } from "#std/async.ts";
-import { scaleMs } from "#veryfront/testing/timing.ts";
+import { FakeTime } from "#std/testing/time";
 import { LinkObserver } from "./link-observer.ts";
 import type { LinkObserverOptions } from "./link-observer.ts";
 
@@ -455,6 +455,7 @@ describe("LinkObserver", () => {
 
     it("should respect delay option before calling onLinkVisible", async () => {
       await withMocksAsync(async (mocks) => {
+        using time = new FakeTime();
         const link = createLink();
 
         mocks.setDocument({
@@ -462,7 +463,8 @@ describe("LinkObserver", () => {
           body: {},
         });
 
-        const delayMs = scaleMs(50);
+        const delayMs = 50;
+        let callbackCalled = false;
         let callbackTime = 0;
 
         await withObserverAsync(
@@ -470,6 +472,7 @@ describe("LinkObserver", () => {
           createOptions({
             delay: delayMs,
             onLinkVisible: () => {
+              callbackCalled = true;
               callbackTime = Date.now();
             },
           }),
@@ -480,9 +483,12 @@ describe("LinkObserver", () => {
             const startTime = Date.now();
             mocks.getMockIntersectionObserver().triggerIntersection(link as any, true);
 
-            await delay(100);
+            await time.tickAsync(delayMs - 1);
+            assertEquals(callbackCalled, false);
 
-            assertEquals(callbackTime - startTime >= delayMs, true);
+            await time.tickAsync(1);
+            assertEquals(callbackCalled, true);
+            assertEquals(callbackTime - startTime, delayMs);
           },
         );
       });


### PR DESCRIPTION
## Summary

- Replace the link observer delay test wall-clock boundary with deterministic fake time.
- Assert that the callback has not fired at 49 ms and fires at exactly 50 ms.
- Remove the fixed 100 ms wait that intermittently failed under Node CI scheduling pressure.

## RED

`VF_TEST_TIME_SCALE=3 deno test --preload=src/testing/preload.ts --no-check --allow-all src/rendering/client/prefetch/link-observer.test.ts`

The old test failed because it configured a 150 ms timer but waited a fixed 100 ms. The same boundary assumption also failed intermittently in the Node jobs for #3813 and #3815.

## GREEN

- `VF_TEST_TIME_SCALE=3 deno test --preload=src/testing/preload.ts --no-check --allow-all src/rendering/client/prefetch/link-observer.test.ts`
- `deno test --preload=src/testing/preload.ts --no-check --allow-all src/rendering/client/prefetch/link-observer.test.ts`
- `deno task build:npm`
- `VF_TEST_TIME_SCALE=3 VF_TEST_SHARDS=1 VF_TEST_CONCURRENCY=1 node ./tests/node/run-tests.mjs src/rendering/client/prefetch/link-observer.test.ts`
- `VF_TEST_SHARDS=1 VF_TEST_CONCURRENCY=1 node ./tests/node/run-tests.mjs src/rendering/client/prefetch/link-observer.test.ts`
- `deno fmt --check src/rendering/client/prefetch/link-observer.test.ts`
- `deno lint src/rendering/client/prefetch/link-observer.test.ts`
- `git diff --check`

## Risk

Test-only change. Production behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timing test reliability by using controlled simulated time.
  * Added precise checks to confirm callbacks run only at the configured delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->