### PR TITLE
fix(agent): replay provider metadata across tool steps

### DIFF
--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -1040,7 +1040,7 @@ Input delivered to a hosted agent-service detached execution callback.
 
 | Name                                 | Description                                       | Source                                                                                                             |
 | ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `AgentRuntime`                       | Implement agent runtime.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/index.ts#L1073)                   |
+| `AgentRuntime`                       | Implement agent runtime.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/index.ts#L1074)                   |
 | `AgentRuntimeMessageConversionError` | Error shape for agent runtime message conversion. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/message-adapter.ts#L138)          |
 | `AgentServiceAuthError`              | Error shape for hosted service auth.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/auth.ts#L14)                      |
 | `AppendConversationRunEventsError`   | Error shape for append conversation run events.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable-append-errors.ts#L4) |

--- a/docs/api-reference/veryfront/embedding.md
+++ b/docs/api-reference/veryfront/embedding.md
@@ -42,7 +42,7 @@ export const { POST, GET, DELETE } = createUploadHandler(store, {
 | `ragStore`                  | Creates a persistent RAG store with lazy embedding and similarity search.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/rag-store.ts#L212)      |
 | `registerEmbeddingProvider` | Register an embedding provider factory.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L25)         |
 | `resolveEmbeddingModel`     | Resolve a "provider/model" string to an embedding runtime instance.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L116)        |
-| `similarity`                | Compute cosine similarity between two numeric vectors.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runtime/runtime-bridge.ts#L1265)  |
+| `similarity`                | Compute cosine similarity between two numeric vectors.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runtime/runtime-bridge.ts#L1285)  |
 | `vectorStore`               | Creates an in-memory vector store with integrated embedding and similarity search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/vector-store.ts#L46)    |
 
 ### Types

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -144,6 +144,7 @@ export interface ChatStreamState {
   accumulatedText: string;
   reasoningParts: StreamingReasoningPart[];
   finishReason: string | null;
+  providerMetadata?: Record<string, unknown>;
   toolCalls: Map<string, StreamingToolCall>;
   toolResults: StreamingToolResult[];
   suppressedToolCalls: { id: string; name: string }[];
@@ -1395,6 +1396,7 @@ export function processStreamInternal(
             closeTextSegment();
             closeReasoningSegment();
             state.finishReason = typedPart.finishReason ?? null;
+            state.providerMetadata = typedPart.providerMetadata;
             if (state.finishReason) {
               setActiveSpanAttributes({
                 "gen_ai.response.finish_reasons": [state.finishReason],

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -44,6 +44,7 @@ import {
 } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { setActiveSpanAttributes as setOtelActiveSpanAttributes } from "#veryfront/observability";
 import { convertToTextGenerationRuntimeRequestMessages } from "./text-generation-runtime-message-converter.ts";
+import { attachProviderMetadata } from "./provider-metadata.ts";
 import { convertToolsToRuntimeTools } from "./model-tool-converter.ts";
 import {
   bindRuntimeRemoteToolSourcesToCredentialOwner,
@@ -593,11 +594,11 @@ function buildGeneratedAssistantMessage(
       args: toolCall.input as Record<string, unknown>,
     });
   }
-  return {
+  return attachProviderMetadata({
     ...metadata,
     role: "assistant",
     parts,
-  };
+  }, response.providerMetadata);
 }
 
 function executeFrameworkToolSearch(input: {
@@ -2549,6 +2550,7 @@ export class AgentRuntime {
         preserveRecoverablePlaceholderToolCalls: shouldRecoverInterruptedLocalToolBatch ||
           !shouldContinue,
       });
+      attachProviderMetadata(assistantMessage, state.providerMetadata);
 
       for (const tc of state.toolCalls.values()) {
         const materialized = materializeStreamedToolCall(tc);

--- a/src/agent/runtime/provider-metadata-continuation.test.ts
+++ b/src/agent/runtime/provider-metadata-continuation.test.ts
@@ -1,0 +1,257 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ModelRuntime } from "#veryfront/provider";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import { tool } from "#veryfront/tool";
+import { agent } from "../index.ts";
+import type { AgentRunModelCallContextEvent } from "../../runtime/model-call-context.ts";
+import { runWithRunEventSink } from "../../runtime/run-event-sink-context.ts";
+import { createGoogleModelRuntime } from "../../../extensions/ext-llm-google/src/google-provider.ts";
+
+const providerMetadata = {
+  google: {
+    rawAssistantParts: [{
+      functionCall: {
+        id: "lookup-1",
+        name: "lookup",
+        args: { query: "Veryfront" },
+      },
+      thoughtSignature: "test-thought-signature",
+    }],
+  },
+};
+
+function createLookupTool() {
+  return tool({
+    id: "lookup",
+    description: "Look up a test value",
+    inputSchema: defineSchema((v) => v.object({ query: v.string() }))(),
+    execute: ({ query }) => ({ value: query }),
+  });
+}
+
+function readAssistantProviderMetadata(options: unknown): unknown {
+  const prompt = (options as { prompt?: Array<Record<string, unknown>> }).prompt ?? [];
+  return prompt.find((message) => message.role === "assistant")?.providerMetadata;
+}
+
+function streamFrom(parts: unknown[]): ReadableStream<unknown> {
+  return new ReadableStream({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+}
+
+async function withStreamLifecycleMode(
+  mode: "legacy" | "active",
+  operation: () => Promise<void>,
+): Promise<void> {
+  const previousMode = Deno.env.get("VF_STREAM_LIFECYCLE_MODE");
+  Deno.env.set("VF_STREAM_LIFECYCLE_MODE", mode);
+  try {
+    await operation();
+  } finally {
+    if (previousMode === undefined) Deno.env.delete("VF_STREAM_LIFECYCLE_MODE");
+    else Deno.env.set("VF_STREAM_LIFECYCLE_MODE", previousMode);
+  }
+}
+
+describe("agent provider metadata continuation", () => {
+  it("replays generate provider metadata on the tool-result leg", async () => {
+    let callCount = 0;
+    let continuedProviderMetadata: unknown;
+    const modelCallEvents: AgentRunModelCallContextEvent[] = [];
+    const model: ModelRuntime = {
+      provider: "google",
+      modelId: "gemini-3.5-flash",
+      async doGenerate(options: unknown) {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            content: [{
+              type: "tool-call",
+              toolCallId: "lookup-1",
+              toolName: "lookup",
+              input: '{"query":"Veryfront"}',
+            }],
+            finishReason: "tool-calls",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            providerMetadata,
+          };
+        }
+
+        continuedProviderMetadata = readAssistantProviderMetadata(options);
+        return {
+          content: [{ type: "text", text: "Done" }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        throw new Error("not used");
+      },
+    };
+    const assistant = agent({
+      model: "google/gemini-3.5-flash",
+      system: "Use the lookup tool.",
+      tools: { lookup: createLookupTool() },
+      maxSteps: 2,
+      resolveModelTransport: () => ({ model }),
+    });
+
+    const result = await runWithRunEventSink(
+      (event) => {
+        modelCallEvents.push(event as AgentRunModelCallContextEvent);
+      },
+      () => assistant.generate({ input: "Look up Veryfront" }),
+    );
+
+    assertEquals(result.text, "Done");
+    assertEquals(callCount, 2);
+    assertEquals(continuedProviderMetadata, providerMetadata);
+    assertEquals(JSON.stringify(result.messages).includes("test-thought-signature"), false);
+    assertEquals(JSON.stringify(modelCallEvents).includes("test-thought-signature"), false);
+  });
+
+  for (const lifecycleMode of ["legacy", "active"] as const) {
+    it(`replays streamed provider metadata through the ${lifecycleMode} lifecycle`, () =>
+      withStreamLifecycleMode(lifecycleMode, async () => {
+        let callCount = 0;
+        let continuedProviderMetadata: unknown;
+        const model: ModelRuntime = {
+          provider: "google",
+          modelId: "gemini-3.5-flash",
+          async doGenerate() {
+            throw new Error("not used");
+          },
+          async doStream(options: unknown) {
+            callCount++;
+            if (callCount === 1) {
+              return {
+                stream: streamFrom([
+                  {
+                    type: "tool-call",
+                    toolCallId: "lookup-1",
+                    toolName: "lookup",
+                    input: '{"query":"Veryfront"}',
+                  },
+                  {
+                    type: "finish",
+                    finishReason: "tool-calls",
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                    providerMetadata,
+                  },
+                ]),
+              };
+            }
+
+            continuedProviderMetadata = readAssistantProviderMetadata(options);
+            return {
+              stream: streamFrom([
+                { type: "text-delta", delta: "Done" },
+                {
+                  type: "finish",
+                  finishReason: "stop",
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                },
+              ]),
+            };
+          },
+        };
+        const assistant = agent({
+          model: "google/gemini-3.5-flash",
+          system: "Use the lookup tool.",
+          tools: { lookup: createLookupTool() },
+          maxSteps: 2,
+          resolveModelTransport: () => ({ model }),
+        });
+
+        const body = await (await assistant.stream({ input: "Look up Veryfront" }))
+          .toDataStreamResponse()
+          .text();
+
+        assertEquals(callCount, 2);
+        assertEquals(continuedProviderMetadata, providerMetadata);
+        assertEquals(body.includes("test-thought-signature"), false);
+      }));
+  }
+
+  it("replays the exact signed Gemini tool call before its function response", async () => {
+    const encoder = new TextEncoder();
+    const rawAssistantParts = [{
+      functionCall: {
+        id: "lookup-1",
+        name: "lookup",
+        args: { query: "Veryfront" },
+      },
+      thoughtSignature: "test-thought-signature",
+    }];
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const googleRuntime = createGoogleModelRuntime({
+      apiKey: "test-google-key",
+      baseURL: "https://example.google.test/v1beta",
+      fetch: (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        const responseParts = requestBodies.length === 1
+          ? [
+            encoder.encode(
+              `data: ${
+                JSON.stringify({
+                  candidates: [{ content: { role: "model", parts: rawAssistantParts } }],
+                })
+              }\n\n`,
+            ),
+            encoder.encode(
+              'data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}\n\n',
+            ),
+          ]
+          : [
+            encoder.encode(
+              'data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Done"}]}}]}\n\n',
+            ),
+            encoder.encode(
+              'data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":1,"totalTokenCount":3}}\n\n',
+            ),
+          ];
+        return Promise.resolve(
+          new Response(
+            ReadableStream.from([...responseParts, encoder.encode("data: [DONE]\n\n")]),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        );
+      },
+    }, "gemini-3.5-flash");
+    const assistant = agent({
+      model: "google/gemini-3.5-flash",
+      system: "Use the lookup tool.",
+      tools: { lookup: createLookupTool() },
+      maxSteps: 2,
+      resolveModelTransport: () => ({ model: googleRuntime }),
+    });
+
+    const body = await (await assistant.stream({ input: "Look up Veryfront" }))
+      .toDataStreamResponse()
+      .text();
+
+    assertStringIncludes(body, "Done");
+    assertEquals(body.includes("test-thought-signature"), false);
+    assertEquals(requestBodies.length, 2);
+    const continuationContents = requestBodies[1]?.contents as unknown[] | undefined;
+    assertEquals(continuationContents?.slice(-2), [
+      { role: "model", parts: rawAssistantParts },
+      {
+        role: "user",
+        parts: [{
+          functionResponse: {
+            id: "lookup-1",
+            name: "lookup",
+            response: { result: { value: "Veryfront" } },
+          },
+        }],
+      },
+    ]);
+  });
+});

--- a/src/agent/runtime/provider-metadata.ts
+++ b/src/agent/runtime/provider-metadata.ts
@@ -1,0 +1,21 @@
+import type { Message } from "../types.ts";
+
+const providerMetadataByMessage = new WeakMap<Message, Record<string, unknown>>();
+
+/** Keep provider replay metadata inside one runtime turn without exposing it on public messages. */
+export function attachProviderMetadata(
+  message: Message,
+  providerMetadata: Record<string, unknown> | undefined,
+): Message {
+  if (providerMetadata !== undefined) {
+    providerMetadataByMessage.set(message, providerMetadata);
+  }
+  return message;
+}
+
+/** Read provider replay metadata previously attached to an internal assistant message. */
+export function readAttachedProviderMetadata(
+  message: Message,
+): Record<string, unknown> | undefined {
+  return providerMetadataByMessage.get(message);
+}

--- a/src/agent/runtime/runtime-tool-types.ts
+++ b/src/agent/runtime/runtime-tool-types.ts
@@ -53,6 +53,7 @@ export interface RuntimeGenerateTextResult {
   toolResults?: RuntimeGenerateToolResult[];
   usage?: RuntimeGenerateUsage;
   finishReason?: string | null;
+  providerMetadata?: Record<string, unknown>;
 }
 
 export interface RuntimeRepairToolCall {
@@ -143,6 +144,7 @@ export type RuntimeStreamPart =
   | {
     type: "finish";
     finishReason?: string | null;
+    providerMetadata?: Record<string, unknown>;
     totalUsage?: {
       inputTokens?: number;
       outputTokens?: number;

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -19,6 +19,7 @@ import type {
 import { assertProviderReachableAttachment } from "./attachment-reachability.ts";
 import { buildDataFileAnnotation } from "#veryfront/chat/types.ts";
 import { getTextFromParts, getToolArguments, type Message, type ToolCallPart } from "../types.ts";
+import { readAttachedProviderMetadata } from "./provider-metadata.ts";
 
 function getStringPartField(part: unknown, key: string): string | undefined {
   if (!part || typeof part !== "object" || Array.isArray(part)) return undefined;
@@ -318,9 +319,11 @@ export function convertToTextGenerationRuntimeMessage(
         content.push({ type: "text", text: "" });
       }
 
+      const providerMetadata = readAttachedProviderMetadata(msg);
       const assistantMessage: TextGenerationRuntimeAssistantMessage = {
         role: "assistant",
         content,
+        ...(providerMetadata === undefined ? {} : { providerMetadata }),
       };
       return assistantMessage;
     }
@@ -467,6 +470,14 @@ function convertAssistantMessageToTextGenerationRuntimeMessages(
   flushAssistantMessage(assistantContent);
   flushToolMessage();
   flushAssistantMessage(deferredAssistantContent);
+
+  const providerMetadata = readAttachedProviderMetadata(message);
+  const assistantMessages = messages.filter((entry) => entry.role === "assistant");
+  // Exact replay metadata describes one provider response. Attaching it after
+  // conversion split that response would pair it with an incomplete projection.
+  if (providerMetadata !== undefined && assistantMessages.length === 1) {
+    assistantMessages[0]!.providerMetadata = providerMetadata;
+  }
 
   return messages;
 }

--- a/src/agent/runtime/text-generation-runtime-message-types.ts
+++ b/src/agent/runtime/text-generation-runtime-message-types.ts
@@ -48,6 +48,7 @@ export interface TextGenerationRuntimeUserMessage {
 export interface TextGenerationRuntimeAssistantMessage {
   role: "assistant";
   content: Array<TextGenerationRuntimeTextPart | TextGenerationRuntimeToolCallPart>;
+  providerMetadata?: Record<string, unknown>;
 }
 
 export interface TextGenerationRuntimeToolMessage {

--- a/src/agent/streaming/lifecycle/live-adapter.ts
+++ b/src/agent/streaming/lifecycle/live-adapter.ts
@@ -225,6 +225,7 @@ export function applyLifecycleSnapshotToChatStreamState(
   state.accumulatedText = snapshot.accumulatedText;
   state.reasoningParts = snapshot.reasoning.map((part) => ({ ...part }));
   state.finishReason = snapshot.finishReason;
+  state.providerMetadata = snapshot.providerMetadata;
   state.toolCalls = new Map(
     snapshot.tools.filter(isAvailableTool).map((tool) => [
       tool.id,

--- a/src/agent/streaming/lifecycle/reducer.ts
+++ b/src/agent/streaming/lifecycle/reducer.ts
@@ -448,6 +448,9 @@ function reduceNonTextProtocolEvent(
       state.snapshot = {
         ...state.snapshot,
         finishReason: event.finishReason,
+        ...(event.providerMetadata === undefined
+          ? {}
+          : { providerMetadata: event.providerMetadata }),
         phase: terminalPhase,
         hasSemanticProgress: true,
       };

--- a/src/agent/streaming/lifecycle/runtime-provider-adapter.ts
+++ b/src/agent/streaming/lifecycle/runtime-provider-adapter.ts
@@ -119,6 +119,9 @@ export function decodeRuntimeStreamPart(
           event: {
             type: "step_finish" as const,
             finishReason: normalizeFinishReason(typed.finishReason),
+            ...(typed.providerMetadata === undefined
+              ? {}
+              : { providerMetadata: typed.providerMetadata }),
           },
         },
       ];

--- a/src/agent/streaming/lifecycle/types.ts
+++ b/src/agent/streaming/lifecycle/types.ts
@@ -123,6 +123,7 @@ export type StreamProtocolEvent =
       | "content-filter"
       | "other"
       | null;
+    providerMetadata?: Record<string, unknown>;
   }
   | { type: "custom"; name: string; data: unknown };
 
@@ -208,6 +209,7 @@ export interface StreamSnapshot {
     | "content-filter"
     | "other"
     | null;
+  providerMetadata?: Record<string, unknown>;
   usage: StreamUsage;
   hasStreamOutput: boolean;
   hasSemanticProgress: boolean;

--- a/src/runtime/runtime-bridge.test.ts
+++ b/src/runtime/runtime-bridge.test.ts
@@ -1119,6 +1119,9 @@ describe("runtime-bridge", () => {
 
   it("buffers the stream path for models that prefer streamed generate", async () => {
     let called = false;
+    const providerMetadata = {
+      google: { rawAssistantParts: [{ thoughtSignature: "test-thought-signature" }] },
+    };
 
     const model = {
       ...createStreamModel(
@@ -1141,6 +1144,7 @@ describe("runtime-bridge", () => {
                   inputTokens: { total: 2 },
                   outputTokens: { total: 5 },
                 },
+                providerMetadata,
               },
             ]),
           };
@@ -1163,6 +1167,7 @@ describe("runtime-bridge", () => {
       outputTokens: 5,
       totalTokens: 7,
     });
+    assertEquals(result.providerMetadata, providerMetadata);
   });
 
   it("buffers streamed tool calls for models that prefer streamed generate", async () => {

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -134,12 +134,18 @@ type DirectGenerateResult = {
   >;
   finishReason?: string | { unified?: string | null } | null;
   usage?: unknown;
+  providerMetadata?: Record<string, unknown>;
 };
 
 type DirectStreamResult = {
   stream: ReadableStream<unknown>;
 };
 type DirectTextOptions = GenerateTextOptions | StreamTextOptions;
+type DirectModelMessage =
+  | Exclude<ModelCallMessage, { role: "assistant" }>
+  | (Extract<ModelCallMessage, { role: "assistant" }> & {
+    providerMetadata?: Record<string, unknown>;
+  });
 type ModelCallRequestSource = Pick<
   GenerateTextOptions,
   | "maxOutputTokens"
@@ -153,7 +159,7 @@ type ModelCallRequestSource = Pick<
   | "reasoning"
 >;
 type DirectModelOptions = Record<string, unknown> & {
-  prompt: ModelCallMessage[];
+  prompt: DirectModelMessage[];
   tools?: ModelCallTool[];
 } & ModelCallRequestSource;
 
@@ -236,8 +242,8 @@ function getProviderRequestMessages(
 function toRuntimePrompt(
   system: readonly ChatSystemMessage[],
   messages: TextGenerationRuntimeMessage[],
-): ModelCallMessage[] {
-  const prompt: ModelCallMessage[] = system.map((message) => ({
+): DirectModelMessage[] {
+  const prompt: DirectModelMessage[] = system.map((message) => ({
     role: "system",
     content: message.content,
     ...(message.providerOptions === undefined ? {} : { providerOptions: message.providerOptions }),
@@ -267,6 +273,9 @@ function toRuntimePrompt(
               input: part.input,
             }
           ),
+          ...(message.providerMetadata === undefined
+            ? {}
+            : { providerMetadata: message.providerMetadata }),
         });
         break;
       case "tool":
@@ -368,9 +377,12 @@ function sanitizePersistedProviderOptions(
 }
 
 function sanitizeModelCallContextMessages(
-  messages: readonly ModelCallMessage[],
+  messages: readonly DirectModelMessage[],
 ): ModelCallMessage[] {
   return messages.map((message) => {
+    if (message.role === "assistant") {
+      return { role: "assistant", content: message.content };
+    }
     if (message.role !== "system") {
       return message;
     }
@@ -881,6 +893,7 @@ function buildDirectGenerateResult(
     ...(toolResults.length > 0 ? { toolResults } : {}),
     usage: normalizeUsage(result.usage),
     finishReason: normalizeFinishReason(result.finishReason),
+    ...(result.providerMetadata === undefined ? {} : { providerMetadata: result.providerMetadata }),
   };
 }
 
@@ -957,6 +970,7 @@ async function buildGenerateResultFromStream(
   let text = "";
   let usage: RuntimeGenerateTextResult["usage"];
   let finishReason: string | null = null;
+  let providerMetadata: Record<string, unknown> | undefined;
   const toolCalls = new Map<string, NonNullable<RuntimeGenerateTextResult["toolCalls"]>[number]>();
   const toolInputs = new Map<string, { toolCallId: string; toolName: string; input: string }>();
   const toolResults: NonNullable<RuntimeGenerateTextResult["toolResults"]> = [];
@@ -1046,6 +1060,7 @@ async function buildGenerateResultFromStream(
       case "finish":
         finishReason = part.finishReason ?? null;
         usage = streamUsageToGenerateUsage(part.totalUsage);
+        providerMetadata = part.providerMetadata;
         break;
     }
   }
@@ -1058,6 +1073,7 @@ async function buildGenerateResultFromStream(
     ...(toolResults.length > 0 ? { toolResults } : {}),
     usage,
     finishReason,
+    ...(providerMetadata === undefined ? {} : { providerMetadata }),
   };
 }
 
@@ -1086,6 +1102,7 @@ function normalizeStreamPart(part: unknown): unknown {
     usage?: unknown;
     totalUsage?: unknown;
     finishReason?: unknown;
+    providerMetadata?: Record<string, unknown>;
   };
   const usage = normalizeUsage(finishPart.usage) ?? normalizeUsage(finishPart.totalUsage);
   const recomputedTotal = usage ? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0) : undefined;
@@ -1093,6 +1110,9 @@ function normalizeStreamPart(part: unknown): unknown {
   return {
     type: "finish",
     finishReason: normalizeFinishReason(finishPart.finishReason),
+    ...(finishPart.providerMetadata === undefined
+      ? {}
+      : { providerMetadata: finishPart.providerMetadata }),
     ...(usage
       ? {
         totalUsage: {


### PR DESCRIPTION
## Summary

- retain provider replay metadata across direct generate, stream-backed generate, legacy stream, and active stream-lifecycle tool steps
- attach the metadata only to the next internal model request
- keep thought signatures out of public messages, SSE, public schemas, memory serialization, and durable model-call events
- verify the exact signed Gemini model part precedes its matching function response on the second wire request
- regenerate affected API reference source links

## Root cause

The Google adapter already captured exact Gemini assistant parts, including `thoughtSignature`, in `providerMetadata`. The central runtime bridge discarded that metadata while normalizing generate and stream results, and the agent history builders therefore could not return it on the tool-result leg. The active stream lifecycle also discarded finish metadata while projecting its terminal snapshot. Gemini 2.5 tolerated the omission, while Gemini 3 rejects the continuation with HTTP 400 because function-call thought signatures are mandatory.

Google protocol reference: https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures

## RED-GREEN TDD

RED:

```text
deno test --preload=src/testing/preload.ts --no-check --allow-all src/agent/runtime/provider-metadata-continuation.test.ts
```

Generate and legacy stream initially made the second provider request with `providerMetadata: undefined`. After fixing those paths, an explicit active-lifecycle regression still failed with `providerMetadata: undefined`.

GREEN:

- generate, legacy stream, and active stream replay the exact metadata on the tool-result request
- a credential-free Google wire regression verifies the exact signed assistant part is replayed before the function response
- the signature is absent from returned messages, streamed SSE, and durable model-call context
- stream-backed generate preserves finish metadata

## Verification

- focused exact-head suite: 5 files, 67 steps passed
- `deno task --quiet verify:quick`
- `deno task --quiet typecheck`
- `deno task --quiet lint`
- `deno task docs:api-reference:check`
- earlier full unit suite before the active-lifecycle extension: 3,922 tests and 29,969 steps passed, plus cwd suites
- `git diff --check`

Fixes veryfront/veryfront-issue-inbox#549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved assistant provider metadata across generated responses, streamed responses, tool-result continuations, and lifecycle events.
  * Maintained provider-specific information needed for reliable multi-step and streamed interactions.

* **Bug Fixes**
  * Corrected API reference links for the agent runtime and embedding similarity function.

* **Tests**
  * Added coverage for provider metadata continuity across generation and streaming workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->