### PR TITLE
fix(proxy): record upstream status on failed-closed metadata lookups

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -484,7 +484,8 @@ describe("Proxy Handler", () => {
         );
         assertEquals(failedClosed?.level, "error");
         assertEquals(failedClosed?.extra?.upstreamStatus, 503);
-        assertEquals(failedClosed?.extra?.upstreamBodySnippet, "Unavailable");
+        assertEquals(failedClosed?.extra?.upstreamBodySnippet, undefined);
+        assertEquals(JSON.stringify(failedClosed).includes("Unavailable"), false);
         await handler.close();
       } finally {
         await server.shutdown();

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -442,6 +442,7 @@ describe("Proxy Handler", () => {
     });
 
     it("fails closed when routing metadata has an operational failure", async () => {
+      const { entries, logger } = createRecordingLogger();
       let fullProjectLookups = 0;
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
@@ -467,7 +468,7 @@ describe("Proxy Handler", () => {
       });
 
       try {
-        const handler = createHandler(port);
+        const handler = createHandler(port, "", logger);
         const ctx = await handler.processRequest(
           new Request("http://example.com/page", {
             headers: { host: "example.com" },
@@ -477,6 +478,13 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error?.status, 502);
         assertEquals(ctx.error?.message, "Proxy routing metadata request was rejected");
         assertEquals(fullProjectLookups, 0);
+
+        const failedClosed = entries.find((entry) =>
+          entry.message === "Proxy metadata lookup failed closed"
+        );
+        assertEquals(failedClosed?.level, "error");
+        assertEquals(failedClosed?.extra?.upstreamStatus, 503);
+        assertEquals(failedClosed?.extra?.upstreamBodySnippet, "Unavailable");
         await handler.close();
       } finally {
         await server.shutdown();

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -910,7 +910,6 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
             lookupType: error.lookupType,
             status: error.publicStatus,
             upstreamStatus: error.upstreamStatus,
-            upstreamBodySnippet: error.upstreamBodySnippet,
           });
           return {
             error: {
@@ -978,7 +977,6 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
               lookupType: retryError.lookupType,
               status: retryError.publicStatus,
               upstreamStatus: retryError.upstreamStatus,
-              upstreamBodySnippet: retryError.upstreamBodySnippet,
             });
             return {
               error: {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -909,6 +909,8 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
             scope,
             lookupType: error.lookupType,
             status: error.publicStatus,
+            upstreamStatus: error.upstreamStatus,
+            upstreamBodySnippet: error.upstreamBodySnippet,
           });
           return {
             error: {
@@ -975,6 +977,8 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
               scope,
               lookupType: retryError.lookupType,
               status: retryError.publicStatus,
+              upstreamStatus: retryError.upstreamStatus,
+              upstreamBodySnippet: retryError.upstreamBodySnippet,
             });
             return {
               error: {

--- a/src/proxy/project-metadata-client.test.ts
+++ b/src/proxy/project-metadata-client.test.ts
@@ -77,7 +77,7 @@ describe("proxy project metadata client", () => {
     assertEquals((failure as ProxyLookupFailure).upstreamStatus, 500);
   });
 
-  it("records upstream diagnostics without changing the public failure message", async () => {
+  it("records only non-sensitive upstream diagnostics", async () => {
     const rejected = createProjectMetadataClient({
       apiBaseUrl: "https://api.example.com",
       fetchImpl: makeFetch(() =>
@@ -91,10 +91,7 @@ describe("proxy project metadata client", () => {
     ) as ProxyLookupFailure;
     assertEquals(failure.publicStatus, 502);
     assertEquals(failure.upstreamStatus, 500);
-    assertEquals(
-      failure.upstreamBodySnippet,
-      `{"error":"database unavailable"}${"x".repeat(512)}`.slice(0, 256),
-    );
+    assertEquals("upstreamBodySnippet" in failure, false);
     assertEquals(failure.message.includes("500"), false);
 
     const wrongContentType = createProjectMetadataClient({
@@ -111,7 +108,7 @@ describe("proxy project metadata client", () => {
       "content type",
     ) as ProxyLookupFailure;
     assertEquals(contentTypeFailure.upstreamStatus, 200);
-    assertEquals(contentTypeFailure.upstreamBodySnippet, "<html>maintenance</html>");
+    assertEquals("upstreamBodySnippet" in contentTypeFailure, false);
 
     const invalidJson = createProjectMetadataClient({
       apiBaseUrl: "https://api.example.com",
@@ -127,7 +124,7 @@ describe("proxy project metadata client", () => {
       "invalid response",
     ) as ProxyLookupFailure;
     assertEquals(invalidFailure.upstreamStatus, 200);
-    assertEquals(invalidFailure.upstreamBodySnippet, "not json");
+    assertEquals("upstreamBodySnippet" in invalidFailure, false);
   });
 
   it("requires bounded JSON with the expected response schema", async () => {

--- a/src/proxy/project-metadata-client.test.ts
+++ b/src/proxy/project-metadata-client.test.ts
@@ -74,6 +74,60 @@ describe("proxy project metadata client", () => {
       ProxyLookupFailure,
     );
     assertEquals((failure as ProxyLookupFailure).publicStatus, 502);
+    assertEquals((failure as ProxyLookupFailure).upstreamStatus, 500);
+  });
+
+  it("records upstream diagnostics without changing the public failure message", async () => {
+    const rejected = createProjectMetadataClient({
+      apiBaseUrl: "https://api.example.com",
+      fetchImpl: makeFetch(() =>
+        new Response(`{"error":"database unavailable"}${"x".repeat(512)}`, { status: 500 })
+      ),
+    });
+    const failure = await assertRejects(
+      () => rejected.lookupAccess("storefront", "token", false),
+      ProxyLookupFailure,
+      "Proxy access metadata request was rejected",
+    ) as ProxyLookupFailure;
+    assertEquals(failure.publicStatus, 502);
+    assertEquals(failure.upstreamStatus, 500);
+    assertEquals(
+      failure.upstreamBodySnippet,
+      `{"error":"database unavailable"}${"x".repeat(512)}`.slice(0, 256),
+    );
+    assertEquals(failure.message.includes("500"), false);
+
+    const wrongContentType = createProjectMetadataClient({
+      apiBaseUrl: "https://api.example.com",
+      fetchImpl: makeFetch(() =>
+        new Response("<html>maintenance</html>", {
+          headers: { "Content-Type": "text/html" },
+        })
+      ),
+    });
+    const contentTypeFailure = await assertRejects(
+      () => wrongContentType.lookupRouting("storefront", "token"),
+      ProxyLookupFailure,
+      "content type",
+    ) as ProxyLookupFailure;
+    assertEquals(contentTypeFailure.upstreamStatus, 200);
+    assertEquals(contentTypeFailure.upstreamBodySnippet, "<html>maintenance</html>");
+
+    const invalidJson = createProjectMetadataClient({
+      apiBaseUrl: "https://api.example.com",
+      fetchImpl: makeFetch(() =>
+        new Response("not json", {
+          headers: { "Content-Type": "application/json" },
+        })
+      ),
+    });
+    const invalidFailure = await assertRejects(
+      () => invalidJson.lookupRouting("storefront", "token"),
+      ProxyLookupFailure,
+      "invalid response",
+    ) as ProxyLookupFailure;
+    assertEquals(invalidFailure.upstreamStatus, 200);
+    assertEquals(invalidFailure.upstreamBodySnippet, "not json");
   });
 
   it("requires bounded JSON with the expected response schema", async () => {

--- a/src/proxy/project-metadata-client.ts
+++ b/src/proxy/project-metadata-client.ts
@@ -5,15 +5,13 @@ import {
 import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
 import { isErrorAcrossRealms } from "#veryfront/platform/compat/error-introspection.ts";
 import { injectContext, ProxySpanNames, withSpan } from "./tracing.ts";
-import { readProxyResponseText, settleProxyResponseBody } from "./response-body.ts";
+import { readProxyResponseJson, settleProxyResponseBody } from "./response-body.ts";
 
 const DEFAULT_LOOKUP_TIMEOUT_MS = 10_000;
 const MAX_LOOKUP_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_INFLIGHT_LOOKUPS = 200;
 const MAX_CONFIGURED_INFLIGHT_LOOKUPS = 10_000;
 const MAX_METADATA_RESPONSE_BYTES = 512 * 1024;
-const MAX_UPSTREAM_BODY_SNIPPET_BYTES = 256;
-const MAX_UPSTREAM_BODY_SNIPPET_READS = 64;
 const MAX_API_BASE_URL_CODE_UNITS = 2_048;
 const MAX_LOOKUP_KEY_CODE_UNITS = 256;
 const MAX_ENVIRONMENTS = 1_000;
@@ -98,13 +96,10 @@ export class ProxyLookupAuthError extends Error {
 export interface ProxyLookupFailureUpstreamContext {
   /** HTTP status returned by the metadata API for the failed lookup. */
   upstreamStatus?: number;
-  /** Bounded UTF-8 snippet of the upstream response body, for diagnostics only. */
-  upstreamBodySnippet?: string;
 }
 
 export class ProxyLookupFailure extends Error {
   readonly upstreamStatus?: number;
-  readonly upstreamBodySnippet?: string;
 
   constructor(
     readonly lookupType: ProxyLookupType,
@@ -115,7 +110,6 @@ export class ProxyLookupFailure extends Error {
     super(message, options);
     this.name = "ProxyLookupFailure";
     this.upstreamStatus = options?.upstreamStatus;
-    this.upstreamBodySnippet = options?.upstreamBodySnippet;
   }
 }
 
@@ -450,60 +444,6 @@ async function awaitAbortable<T>(
   });
 }
 
-const snippetDecoder = new TextDecoder("utf-8", { fatal: false });
-const snippetEncoder = new TextEncoder();
-
-function truncateBodySnippet(text: string): string | undefined {
-  if (text.length === 0) return undefined;
-  return snippetDecoder.decode(
-    snippetEncoder.encode(text).subarray(0, MAX_UPSTREAM_BODY_SNIPPET_BYTES),
-  );
-}
-
-/**
- * Best-effort read of a bounded upstream body prefix for diagnostics.
- *
- * Never throws: abort, stream errors, and adversarial chunking all degrade to
- * `undefined`. The reader is cancelled before returning so callers keep the
- * same body-settlement guarantees as `settleProxyResponseBody`.
- */
-async function readUpstreamBodySnippet(
-  response: Response,
-  signal: AbortSignal,
-): Promise<string | undefined> {
-  const body = response.body;
-  if (!body || signal.aborted) return undefined;
-  const reader = body.getReader();
-  const bytes = new Uint8Array(MAX_UPSTREAM_BODY_SNIPPET_BYTES);
-  let totalBytes = 0;
-  try {
-    for (let reads = 0; reads < MAX_UPSTREAM_BODY_SNIPPET_READS; reads++) {
-      if (signal.aborted || totalBytes >= MAX_UPSTREAM_BODY_SNIPPET_BYTES) break;
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (!value || value.byteLength === 0) continue;
-      const take = Math.min(value.byteLength, MAX_UPSTREAM_BODY_SNIPPET_BYTES - totalBytes);
-      bytes.set(value.subarray(0, take), totalBytes);
-      totalBytes += take;
-    }
-  } catch {
-    // Diagnostics stay best-effort: the lookup failure itself is authoritative.
-  } finally {
-    try {
-      await reader.cancel();
-    } catch {
-      // Cancellation reached a terminal state; ownership may be released.
-    }
-    try {
-      reader.releaseLock();
-    } catch {
-      // The stream may already have released the reader after cancellation.
-    }
-  }
-  if (totalBytes === 0) return undefined;
-  return snippetDecoder.decode(bytes.subarray(0, totalBytes));
-}
-
 export function createProjectMetadataClient(
   options: ProjectMetadataClientOptions,
 ): ProjectMetadataClient {
@@ -580,38 +520,36 @@ export function createProjectMetadataClient(
           throw new ProxyLookupAuthError(lookupType, response.status);
         }
         if (!response.ok) {
-          const upstreamBodySnippet = await readUpstreamBodySnippet(response, controller.signal);
           await settleProxyResponseBody(response);
           const publicStatus = response.status === 429 ? 503 : 502;
           throw new ProxyLookupFailure(
             lookupType,
             publicStatus,
             `Proxy ${lookupType} metadata request was rejected`,
-            { upstreamStatus: response.status, upstreamBodySnippet },
+            { upstreamStatus: response.status },
           );
         }
 
         const contentType = response.headers.get("content-type")?.split(";")[0]?.trim()
           .toLowerCase();
         if (contentType !== "application/json") {
-          const upstreamBodySnippet = await readUpstreamBodySnippet(response, controller.signal);
           await settleProxyResponseBody(response);
           throw new ProxyLookupFailure(
             lookupType,
             502,
             `Proxy ${lookupType} metadata returned an invalid content type`,
-            { upstreamStatus: response.status, upstreamBodySnippet },
+            { upstreamStatus: response.status },
           );
         }
 
-        let responseText: string | undefined;
         try {
-          responseText = await readProxyResponseText(
-            response,
-            MAX_METADATA_RESPONSE_BYTES,
-            controller.signal,
+          return parse(
+            await readProxyResponseJson(
+              response,
+              MAX_METADATA_RESPONSE_BYTES,
+              controller.signal,
+            ),
           );
-          return parse(JSON.parse(responseText) as unknown);
         } catch (error) {
           if (controller.signal.aborted) throw abortReason(controller.signal);
           if (error instanceof ProxyLookupFailure) throw error;
@@ -622,9 +560,6 @@ export function createProjectMetadataClient(
             {
               cause: error,
               upstreamStatus: response.status,
-              upstreamBodySnippet: responseText === undefined
-                ? undefined
-                : truncateBodySnippet(responseText),
             },
           );
         }

--- a/src/proxy/project-metadata-client.ts
+++ b/src/proxy/project-metadata-client.ts
@@ -5,13 +5,15 @@ import {
 import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
 import { isErrorAcrossRealms } from "#veryfront/platform/compat/error-introspection.ts";
 import { injectContext, ProxySpanNames, withSpan } from "./tracing.ts";
-import { readProxyResponseJson, settleProxyResponseBody } from "./response-body.ts";
+import { readProxyResponseText, settleProxyResponseBody } from "./response-body.ts";
 
 const DEFAULT_LOOKUP_TIMEOUT_MS = 10_000;
 const MAX_LOOKUP_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_INFLIGHT_LOOKUPS = 200;
 const MAX_CONFIGURED_INFLIGHT_LOOKUPS = 10_000;
 const MAX_METADATA_RESPONSE_BYTES = 512 * 1024;
+const MAX_UPSTREAM_BODY_SNIPPET_BYTES = 256;
+const MAX_UPSTREAM_BODY_SNIPPET_READS = 64;
 const MAX_API_BASE_URL_CODE_UNITS = 2_048;
 const MAX_LOOKUP_KEY_CODE_UNITS = 256;
 const MAX_ENVIRONMENTS = 1_000;
@@ -93,15 +95,27 @@ export class ProxyLookupAuthError extends Error {
   }
 }
 
+export interface ProxyLookupFailureUpstreamContext {
+  /** HTTP status returned by the metadata API for the failed lookup. */
+  upstreamStatus?: number;
+  /** Bounded UTF-8 snippet of the upstream response body, for diagnostics only. */
+  upstreamBodySnippet?: string;
+}
+
 export class ProxyLookupFailure extends Error {
+  readonly upstreamStatus?: number;
+  readonly upstreamBodySnippet?: string;
+
   constructor(
     readonly lookupType: ProxyLookupType,
     readonly publicStatus: 502 | 503 | 504,
     message: string,
-    options?: ErrorOptions,
+    options?: ErrorOptions & ProxyLookupFailureUpstreamContext,
   ) {
     super(message, options);
     this.name = "ProxyLookupFailure";
+    this.upstreamStatus = options?.upstreamStatus;
+    this.upstreamBodySnippet = options?.upstreamBodySnippet;
   }
 }
 
@@ -436,6 +450,60 @@ async function awaitAbortable<T>(
   });
 }
 
+const snippetDecoder = new TextDecoder("utf-8", { fatal: false });
+const snippetEncoder = new TextEncoder();
+
+function truncateBodySnippet(text: string): string | undefined {
+  if (text.length === 0) return undefined;
+  return snippetDecoder.decode(
+    snippetEncoder.encode(text).subarray(0, MAX_UPSTREAM_BODY_SNIPPET_BYTES),
+  );
+}
+
+/**
+ * Best-effort read of a bounded upstream body prefix for diagnostics.
+ *
+ * Never throws: abort, stream errors, and adversarial chunking all degrade to
+ * `undefined`. The reader is cancelled before returning so callers keep the
+ * same body-settlement guarantees as `settleProxyResponseBody`.
+ */
+async function readUpstreamBodySnippet(
+  response: Response,
+  signal: AbortSignal,
+): Promise<string | undefined> {
+  const body = response.body;
+  if (!body || signal.aborted) return undefined;
+  const reader = body.getReader();
+  const bytes = new Uint8Array(MAX_UPSTREAM_BODY_SNIPPET_BYTES);
+  let totalBytes = 0;
+  try {
+    for (let reads = 0; reads < MAX_UPSTREAM_BODY_SNIPPET_READS; reads++) {
+      if (signal.aborted || totalBytes >= MAX_UPSTREAM_BODY_SNIPPET_BYTES) break;
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      const take = Math.min(value.byteLength, MAX_UPSTREAM_BODY_SNIPPET_BYTES - totalBytes);
+      bytes.set(value.subarray(0, take), totalBytes);
+      totalBytes += take;
+    }
+  } catch {
+    // Diagnostics stay best-effort: the lookup failure itself is authoritative.
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Cancellation reached a terminal state; ownership may be released.
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // The stream may already have released the reader after cancellation.
+    }
+  }
+  if (totalBytes === 0) return undefined;
+  return snippetDecoder.decode(bytes.subarray(0, totalBytes));
+}
+
 export function createProjectMetadataClient(
   options: ProjectMetadataClientOptions,
 ): ProjectMetadataClient {
@@ -512,34 +580,38 @@ export function createProjectMetadataClient(
           throw new ProxyLookupAuthError(lookupType, response.status);
         }
         if (!response.ok) {
+          const upstreamBodySnippet = await readUpstreamBodySnippet(response, controller.signal);
           await settleProxyResponseBody(response);
           const publicStatus = response.status === 429 ? 503 : 502;
           throw new ProxyLookupFailure(
             lookupType,
             publicStatus,
             `Proxy ${lookupType} metadata request was rejected`,
+            { upstreamStatus: response.status, upstreamBodySnippet },
           );
         }
 
         const contentType = response.headers.get("content-type")?.split(";")[0]?.trim()
           .toLowerCase();
         if (contentType !== "application/json") {
+          const upstreamBodySnippet = await readUpstreamBodySnippet(response, controller.signal);
           await settleProxyResponseBody(response);
           throw new ProxyLookupFailure(
             lookupType,
             502,
             `Proxy ${lookupType} metadata returned an invalid content type`,
+            { upstreamStatus: response.status, upstreamBodySnippet },
           );
         }
 
+        let responseText: string | undefined;
         try {
-          return parse(
-            await readProxyResponseJson(
-              response,
-              MAX_METADATA_RESPONSE_BYTES,
-              controller.signal,
-            ),
+          responseText = await readProxyResponseText(
+            response,
+            MAX_METADATA_RESPONSE_BYTES,
+            controller.signal,
           );
+          return parse(JSON.parse(responseText) as unknown);
         } catch (error) {
           if (controller.signal.aborted) throw abortReason(controller.signal);
           if (error instanceof ProxyLookupFailure) throw error;
@@ -547,7 +619,13 @@ export function createProjectMetadataClient(
             lookupType,
             502,
             `Proxy ${lookupType} metadata returned an invalid response`,
-            { cause: error },
+            {
+              cause: error,
+              upstreamStatus: response.status,
+              upstreamBodySnippet: responseText === undefined
+                ? undefined
+                : truncateBodySnippet(responseText),
+            },
           );
         }
       } catch (error) {


### PR DESCRIPTION
## Summary

The proxy now records the upstream HTTP status when a routing or access metadata lookup fails closed. Public status codes and response messages remain unchanged.

## Root cause

A non-success metadata response was converted to a public 502 or 503 without retaining the upstream status, which made transient API failures difficult to distinguish in proxy logs.

## What changed

- `ProxyLookupFailure` carries an optional `upstreamStatus`.
- Rejected, invalid-content-type, and invalid-response paths populate that status.
- Both failed-closed handler logs include the status.
- Upstream response bodies are never retained or logged. The initial body-snippet implementation was removed after review because error payloads can contain sensitive or internal data.
- Removing the diagnostic body reader also preserves the original failed-closed timeout and capacity behavior.

## Testing

- RED: regression assertions failed while the failure and log objects still exposed the upstream body.
- GREEN: `deno test --preload=src/testing/preload.ts --no-check --allow-all src/proxy/project-metadata-client.test.ts src/proxy/handler.test.ts`, 2 tests, 82 steps.
- Broader: same command with `--unstable-net src/proxy/`, 51 tests, 502 steps.
- `deno check`, changed-file lint and format checks, and `git diff --check` pass.

## Risk

Low. This adds one numeric internal diagnostic field. Client-facing behavior is unchanged, and no upstream payload is logged.

Refs VERYFRONT-STUDIO-60