### PR TITLE
fix(agent): withhold replay metadata when a tool call was suppressed

### DIFF
--- a/extensions/ext-llm-google/src/google-provider.ts
+++ b/extensions/ext-llm-google/src/google-provider.ts
@@ -54,6 +54,7 @@ import { readGoogleGroundingMetadata } from "./google-grounding-metadata.ts";
 import {
   createGoogleProviderMetadata,
   readGoogleThoughtSignature,
+  reconcileGoogleProviderMetadata,
 } from "./google-thought-signatures.ts";
 import {
   extractGoogleCandidateParts,
@@ -563,6 +564,17 @@ export function createGoogleModelRuntime(
     modelId,
     specificationVersion: "v3",
     supportedUrls: {},
+    _reconcileProviderMetadata(
+      input: {
+        providerMetadata: Record<string, unknown>;
+        suppressedToolCalls: readonly { id: string; name: string }[];
+      },
+    ) {
+      return reconcileGoogleProviderMetadata(
+        input.providerMetadata,
+        input.suppressedToolCalls,
+      );
+    },
     doGenerate(options: OpenAICompatibleLanguageOptions) {
       const url = getGoogleGenerateContentUrl(config.baseURL, modelId);
       const warnings = createWarningCollector();

--- a/extensions/ext-llm-google/src/google-request-builder.test.ts
+++ b/extensions/ext-llm-google/src/google-request-builder.test.ts
@@ -58,6 +58,19 @@ function buildGoogleAssistantReplay(
   );
 }
 
+function buildGoogleAssistantReplayFromMetadata(
+  providerMetadata: Record<string, unknown>,
+  content: readonly RuntimeAssistantContentPart[],
+) {
+  return buildGoogleGenerateContentRequest(
+    "google",
+    {
+      prompt: [{ role: "assistant", content, providerMetadata }],
+    },
+    createWarningCollector(),
+  );
+}
+
 function nestedGoogleArguments(wrappers: number): Record<string, unknown> {
   let value: Record<string, unknown> = { leaf: true };
   for (let index = 0; index < wrappers; index += 1) {
@@ -515,7 +528,12 @@ describe("ext-llm-google/google-request-builder", () => {
 
     assertJsonEquals(
       reconcileGoogleProviderMetadata(metadata, [{ id: "stale-1", name: "missing_tool" }]),
-      { google: { rawAssistantParts: [survivingPart] } },
+      {
+        google: {
+          rawAssistantParts: [survivingPart],
+          rawAssistantPartIndexes: [1],
+        },
+      },
     );
     assertEquals(
       reconcileGoogleProviderMetadata(metadata, [{ id: "absent", name: "missing_tool" }]),
@@ -545,6 +563,37 @@ describe("ext-llm-google/google-request-builder", () => {
       TypeError,
       "could not preserve a surviving signed tool call",
     );
+  });
+
+  it("keeps anonymous raw-position ids stable after suppressing an earlier call", () => {
+    const suppressedPart = {
+      functionCall: { name: "missing_tool", args: {} },
+      thoughtSignature: "stale-signature",
+    };
+    const survivingPart = {
+      functionCall: { name: "lookup", args: { query: "Veryfront" } },
+      thoughtSignature: "surviving-signature",
+    };
+    const metadata = createGoogleProviderMetadata([suppressedPart, survivingPart]);
+    if (metadata === undefined) {
+      throw new Error("Expected signed Google provider metadata");
+    }
+    const reconciled = reconcileGoogleProviderMetadata(metadata, [{
+      id: "tool-0",
+      name: "missing_tool",
+    }]);
+    if (reconciled === undefined) {
+      throw new Error("Expected surviving Google provider metadata");
+    }
+
+    const body = buildGoogleAssistantReplayFromMetadata(reconciled, [{
+      type: "tool-call",
+      toolCallId: "tool-1",
+      toolName: "lookup",
+      input: { query: "Veryfront" },
+    }]);
+
+    assertJsonEquals(body.contents, [{ role: "model", parts: [survivingPart] }]);
   });
 
   it("accepts raw-position and legacy occurrence ids while preserving exact correlation", () => {

--- a/extensions/ext-llm-google/src/google-request-builder.test.ts
+++ b/extensions/ext-llm-google/src/google-request-builder.test.ts
@@ -5,7 +5,10 @@ import {
   buildGoogleGenerateContentRequest,
   type RuntimeToolDefinition,
 } from "./google-request-builder.ts";
-import { createGoogleProviderMetadata } from "./google-thought-signatures.ts";
+import {
+  createGoogleProviderMetadata,
+  reconcileGoogleProviderMetadata,
+} from "./google-thought-signatures.ts";
 
 function createWarningCollector() {
   const warnings: Array<{
@@ -494,6 +497,54 @@ describe("ext-llm-google/google-request-builder", () => {
       role: "model",
       parts: rawAssistantParts,
     }]);
+  });
+
+  it("reconciles suppressed calls without stripping surviving signatures", () => {
+    const suppressedPart = {
+      functionCall: { id: "stale-1", name: "missing_tool", args: {} },
+      thoughtSignature: "stale-signature",
+    };
+    const survivingPart = {
+      functionCall: { id: "lookup-1", name: "lookup", args: { query: "Veryfront" } },
+      thoughtSignature: "surviving-signature",
+    };
+    const metadata = createGoogleProviderMetadata([suppressedPart, survivingPart]);
+    if (metadata === undefined) {
+      throw new Error("Expected signed Google provider metadata");
+    }
+
+    assertJsonEquals(
+      reconcileGoogleProviderMetadata(metadata, [{ id: "stale-1", name: "missing_tool" }]),
+      { google: { rawAssistantParts: [survivingPart] } },
+    );
+    assertEquals(
+      reconcileGoogleProviderMetadata(metadata, [{ id: "absent", name: "missing_tool" }]),
+      metadata,
+    );
+    assertEquals(
+      reconcileGoogleProviderMetadata(metadata, [
+        { id: "stale-1", name: "missing_tool" },
+        { id: "lookup-1", name: "lookup" },
+      ]),
+      undefined,
+    );
+
+    const unsignedSurvivor = createGoogleProviderMetadata([
+      suppressedPart,
+      { functionCall: { id: "lookup-1", name: "lookup", args: {} } },
+    ]);
+    if (unsignedSurvivor === undefined) {
+      throw new Error("Expected mixed Google provider metadata");
+    }
+    assertThrows(
+      () =>
+        reconcileGoogleProviderMetadata(unsignedSurvivor, [{
+          id: "stale-1",
+          name: "missing_tool",
+        }]),
+      TypeError,
+      "could not preserve a surviving signed tool call",
+    );
   });
 
   it("accepts raw-position and legacy occurrence ids while preserving exact correlation", () => {

--- a/extensions/ext-llm-google/src/google-request-builder.ts
+++ b/extensions/ext-llm-google/src/google-request-builder.ts
@@ -19,7 +19,7 @@ import {
   readGoogleExecutableCode,
   readGooglePartDataField,
 } from "./google-content-parts.ts";
-import { readGoogleRawAssistantParts } from "./google-thought-signatures.ts";
+import { readGoogleRawAssistantReplay } from "./google-thought-signatures.ts";
 
 export interface OpenAICompatibleLanguageOptions extends ModelRuntimeCallOptions {
   requestLabels?: Record<string, string>;
@@ -106,6 +106,7 @@ function invalidGoogleProviderHistory(): TypeError {
 
 function readGoogleRawToolHistory(
   rawAssistantParts: readonly Record<string, unknown>[],
+  rawAssistantPartIndexes: readonly number[],
 ): GoogleRawToolHistory {
   const registry = createGoogleToolCallCorrelationRegistry();
   const ordinaryCalls: CanonicalProviderCall[] = [];
@@ -135,7 +136,10 @@ function readGoogleRawToolHistory(
         throw invalidGoogleProviderHistory();
       }
       const providerId = typeof functionCall.id === "string" ? functionCall.id : undefined;
-      const id = registry.registerFunctionCall(partIndex, providerId);
+      const id = registry.registerFunctionCall(
+        rawAssistantPartIndexes[partIndex] ?? partIndex,
+        providerId,
+      );
       // Histories persisted before raw-position ids used the anonymous-call
       // occurrence instead. Build both complete projections so validation
       // cannot accept a mixture that no implementation ever emitted.
@@ -257,6 +261,7 @@ function survivingToolEvents(
 function validateGoogleToolReplay(
   message: Extract<ModelRuntimePromptMessage, { readonly role: "assistant" }>,
   rawAssistantParts: readonly Record<string, unknown>[],
+  rawAssistantPartIndexes: readonly number[],
 ): void {
   const providerToolCalls = (message.providerToolCalls ?? []).map((call) => ({
     id: call.toolCallId,
@@ -329,7 +334,7 @@ function validateGoogleToolReplay(
 
   let rawHistory: GoogleRawToolHistory;
   try {
-    rawHistory = readGoogleRawToolHistory(rawAssistantParts);
+    rawHistory = readGoogleRawToolHistory(rawAssistantParts, rawAssistantPartIndexes);
   } catch {
     throw invalidGoogleProviderHistory();
   }
@@ -430,10 +435,14 @@ function toGoogleContents(
         });
         break;
       case "assistant": {
-        const rawAssistantParts = readGoogleRawAssistantParts(message.providerMetadata);
-        if (rawAssistantParts) {
-          validateGoogleToolReplay(message, rawAssistantParts);
-          contents.push({ role: "model", parts: rawAssistantParts });
+        const rawAssistantReplay = readGoogleRawAssistantReplay(message.providerMetadata);
+        if (rawAssistantReplay) {
+          validateGoogleToolReplay(
+            message,
+            rawAssistantReplay.parts,
+            rawAssistantReplay.partIndexes,
+          );
+          contents.push({ role: "model", parts: rawAssistantReplay.parts });
           break;
         }
 

--- a/extensions/ext-llm-google/src/google-thought-signatures.ts
+++ b/extensions/ext-llm-google/src/google-thought-signatures.ts
@@ -368,3 +368,74 @@ export function readGoogleRawAssistantParts(
     rawPartsSnapshot as readonly JsonSnapshotValue[],
   );
 }
+
+/**
+ * Remove provider tool parts that the runtime deliberately suppressed while
+ * preserving the exact signed parts for every surviving Google tool call.
+ */
+export function reconcileGoogleProviderMetadata(
+  providerMetadata: Record<string, unknown>,
+  suppressedToolCalls: readonly { id: string; name: string }[],
+): Record<string, unknown> | undefined {
+  if (suppressedToolCalls.length === 0) {
+    return providerMetadata;
+  }
+
+  const rawAssistantParts = readGoogleRawAssistantParts(providerMetadata);
+  if (rawAssistantParts === undefined) {
+    return providerMetadata;
+  }
+
+  const suppressedIds = new Set(suppressedToolCalls.map((toolCall) => toolCall.id));
+  const matchedSuppressedIds = new Set<string>();
+  const retainedParts: Record<string, unknown>[] = [];
+  const registry = createGoogleToolCallCorrelationRegistry();
+  let retainedToolPart = false;
+
+  for (let partIndex = 0; partIndex < rawAssistantParts.length; partIndex += 1) {
+    const part = rawAssistantParts[partIndex];
+    if (part === undefined) {
+      throw new TypeError("Google raw assistant parts must be dense");
+    }
+
+    const dataField = readGooglePartDataField(part);
+    let toolCallId: string | undefined;
+    if (dataField === "functionCall") {
+      const functionCall = readRecord(part.functionCall);
+      const providerId = typeof functionCall?.id === "string" ? functionCall.id : undefined;
+      toolCallId = registry.registerFunctionCall(partIndex, providerId);
+    } else if (dataField === "executableCode") {
+      const executableCode = readGoogleExecutableCode(part.executableCode);
+      toolCallId = registry.registerCodeExecution(executableCode.providerId);
+    } else if (dataField === "codeExecutionResult") {
+      const result = readGoogleCodeExecutionResult(part.codeExecutionResult);
+      toolCallId = registry.resolveCodeExecutionResult(result.providerId);
+    }
+
+    if (toolCallId !== undefined && suppressedIds.has(toolCallId)) {
+      matchedSuppressedIds.add(toolCallId);
+      continue;
+    }
+
+    retainedParts.push(part);
+    retainedToolPart ||= dataField === "functionCall" ||
+      dataField === "executableCode" ||
+      dataField === "codeExecutionResult";
+  }
+
+  registry.assertSettled();
+  if (matchedSuppressedIds.size === 0) {
+    return providerMetadata;
+  }
+  if (retainedParts.length === 0) {
+    return undefined;
+  }
+
+  const reconciled = createGoogleProviderMetadata(retainedParts);
+  if (reconciled === undefined && retainedToolPart) {
+    throw new TypeError(
+      "Google provider metadata could not preserve a surviving signed tool call",
+    );
+  }
+  return reconciled;
+}

--- a/extensions/ext-llm-google/src/google-thought-signatures.ts
+++ b/extensions/ext-llm-google/src/google-thought-signatures.ts
@@ -13,6 +13,7 @@ import {
 
 const GOOGLE_METADATA_KEY = "google";
 const RAW_ASSISTANT_PARTS_KEY = "rawAssistantParts";
+const RAW_ASSISTANT_PART_INDEXES_KEY = "rawAssistantPartIndexes";
 const GROUNDING_METADATA_KEY = "groundingMetadata";
 const MAX_GOOGLE_RAW_ASSISTANT_PARTS = 4_096;
 export const MAX_GOOGLE_PROVIDER_METADATA_BYTES = 8 * 1024 * 1024;
@@ -86,6 +87,39 @@ function readGoogleRawPartsValue(
   ) {
     throw new TypeError(
       "Google raw assistant parts must be an enumerable data property",
+    );
+  }
+  return descriptor.value;
+}
+
+function readGoogleRawPartIndexesValue(
+  googleMetadata: unknown,
+): unknown {
+  if (
+    googleMetadata === null ||
+    typeof googleMetadata !== "object" ||
+    Array.isArray(googleMetadata)
+  ) {
+    throw new TypeError("Google provider metadata must be an object");
+  }
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(
+      googleMetadata,
+      RAW_ASSISTANT_PART_INDEXES_KEY,
+    );
+  } catch {
+    throw new TypeError("Google provider metadata could not be inspected");
+  }
+  if (descriptor === undefined) {
+    return undefined;
+  }
+  if (
+    descriptor.enumerable !== true ||
+    !Object.hasOwn(descriptor, "value")
+  ) {
+    throw new TypeError(
+      "Google raw assistant part indexes must be an enumerable data property",
     );
   }
   return descriptor.value;
@@ -235,6 +269,7 @@ export function readGoogleThoughtSignature(
 export function createGoogleProviderMetadata(
   parts: Array<Record<string, unknown>>,
   groundingMetadata?: Record<string, unknown>,
+  rawAssistantPartIndexes?: readonly number[],
 ): Record<string, unknown> | undefined {
   const needsExactReplay = needsGoogleExactReplay(parts);
   if (!needsExactReplay && groundingMetadata === undefined) {
@@ -251,14 +286,25 @@ export function createGoogleProviderMetadata(
         `Google raw assistant parts exceeded ${MAX_GOOGLE_RAW_ASSISTANT_PARTS} entries`,
       );
     }
+    const ownedPartIndexes = rawAssistantPartIndexes === undefined
+      ? undefined
+      : validateGoogleRawAssistantPartIndexes(
+        snapshotGoogleProviderMetadata(rawAssistantPartIndexes),
+        partsSnapshot.length,
+      );
     ownedParts = validateGoogleRawAssistantParts(
       partsSnapshot as readonly JsonSnapshotValue[],
+      ownedPartIndexes,
     );
+    rawAssistantPartIndexes = ownedPartIndexes;
   }
 
   const metadata = snapshotGoogleProviderMetadata({
     [GOOGLE_METADATA_KEY]: {
       ...(needsExactReplay ? { [RAW_ASSISTANT_PARTS_KEY]: ownedParts } : {}),
+      ...(needsExactReplay && rawAssistantPartIndexes !== undefined
+        ? { [RAW_ASSISTANT_PART_INDEXES_KEY]: rawAssistantPartIndexes }
+        : {}),
       ...(groundingMetadata !== undefined ? { [GROUNDING_METADATA_KEY]: groundingMetadata } : {}),
     },
   });
@@ -271,6 +317,7 @@ export function createGoogleProviderMetadata(
 
 function validateGoogleRawAssistantParts(
   rawParts: readonly JsonSnapshotValue[],
+  rawPartIndexes?: readonly number[],
 ): readonly Record<string, unknown>[] {
   if (rawParts.length === 0) {
     throw new TypeError("Google raw assistant parts must be a non-empty array");
@@ -301,7 +348,10 @@ function validateGoogleRawAssistantParts(
       const functionCall = readRecord(part.functionCall);
       const functionCallId = typeof functionCall?.id === "string" ? functionCall.id : undefined;
       try {
-        toolCallRegistry.registerFunctionCall(partIndex, functionCallId);
+        toolCallRegistry.registerFunctionCall(
+          rawPartIndexes?.[partIndex] ?? partIndex,
+          functionCallId,
+        );
       } catch {
         throw new TypeError("Google raw assistant tool call id was duplicated");
       }
@@ -343,9 +393,37 @@ function validateGoogleRawAssistantParts(
   return rawParts as readonly Record<string, unknown>[];
 }
 
-export function readGoogleRawAssistantParts(
+function validateGoogleRawAssistantPartIndexes(
+  value: JsonSnapshotValue,
+  partCount: number,
+): readonly number[] {
+  if (!Array.isArray(value) || value.length !== partCount) {
+    throw new TypeError("Google raw assistant part indexes must match the raw parts");
+  }
+  let previous = -1;
+  for (const index of value) {
+    if (
+      typeof index !== "number" ||
+      !Number.isSafeInteger(index) ||
+      index <= previous ||
+      index < 0 ||
+      index >= MAX_GOOGLE_RAW_ASSISTANT_PARTS
+    ) {
+      throw new TypeError("Google raw assistant part indexes must be increasing safe integers");
+    }
+    previous = index;
+  }
+  return value as readonly number[];
+}
+
+export type GoogleRawAssistantReplay = {
+  parts: readonly Record<string, unknown>[];
+  partIndexes: readonly number[];
+};
+
+export function readGoogleRawAssistantReplay(
   providerMetadata: Record<string, unknown> | undefined,
-): readonly Record<string, unknown>[] | undefined {
+): GoogleRawAssistantReplay | undefined {
   if (providerMetadata === undefined) {
     return undefined;
   }
@@ -354,19 +432,36 @@ export function readGoogleRawAssistantParts(
     return undefined;
   }
   const rawParts = readGoogleRawPartsValue(rawGoogleMetadata);
+  const rawPartIndexes = readGoogleRawPartIndexesValue(rawGoogleMetadata);
   if (rawParts === undefined) {
+    if (rawPartIndexes !== undefined) {
+      throw new TypeError("Google raw assistant part indexes require raw parts");
+    }
     return undefined;
   }
-  // Grounding and future Google metadata fields are not replayed. Snapshot
-  // only the exact wire value that will be validated and transmitted so those
-  // independent fields cannot consume replay budgets or invoke accessors.
   const rawPartsSnapshot = snapshotGoogleProviderMetadata(rawParts);
   if (!Array.isArray(rawPartsSnapshot)) {
     throw new TypeError("Google raw assistant parts must be a non-empty array");
   }
-  return validateGoogleRawAssistantParts(
-    rawPartsSnapshot as readonly JsonSnapshotValue[],
-  );
+  const partIndexes = rawPartIndexes === undefined
+    ? rawPartsSnapshot.map((_part, index) => index)
+    : validateGoogleRawAssistantPartIndexes(
+      snapshotGoogleProviderMetadata(rawPartIndexes),
+      rawPartsSnapshot.length,
+    );
+  return {
+    parts: validateGoogleRawAssistantParts(
+      rawPartsSnapshot as readonly JsonSnapshotValue[],
+      partIndexes,
+    ),
+    partIndexes,
+  };
+}
+
+export function readGoogleRawAssistantParts(
+  providerMetadata: Record<string, unknown> | undefined,
+): readonly Record<string, unknown>[] | undefined {
+  return readGoogleRawAssistantReplay(providerMetadata)?.parts;
 }
 
 /**
@@ -381,14 +476,16 @@ export function reconcileGoogleProviderMetadata(
     return providerMetadata;
   }
 
-  const rawAssistantParts = readGoogleRawAssistantParts(providerMetadata);
-  if (rawAssistantParts === undefined) {
+  const replay = readGoogleRawAssistantReplay(providerMetadata);
+  if (replay === undefined) {
     return providerMetadata;
   }
+  const { partIndexes, parts: rawAssistantParts } = replay;
 
   const suppressedIds = new Set(suppressedToolCalls.map((toolCall) => toolCall.id));
   const matchedSuppressedIds = new Set<string>();
   const retainedParts: Record<string, unknown>[] = [];
+  const retainedPartIndexes: number[] = [];
   const registry = createGoogleToolCallCorrelationRegistry();
   let retainedToolPart = false;
 
@@ -403,7 +500,7 @@ export function reconcileGoogleProviderMetadata(
     if (dataField === "functionCall") {
       const functionCall = readRecord(part.functionCall);
       const providerId = typeof functionCall?.id === "string" ? functionCall.id : undefined;
-      toolCallId = registry.registerFunctionCall(partIndex, providerId);
+      toolCallId = registry.registerFunctionCall(partIndexes[partIndex] ?? partIndex, providerId);
     } else if (dataField === "executableCode") {
       const executableCode = readGoogleExecutableCode(part.executableCode);
       toolCallId = registry.registerCodeExecution(executableCode.providerId);
@@ -418,6 +515,7 @@ export function reconcileGoogleProviderMetadata(
     }
 
     retainedParts.push(part);
+    retainedPartIndexes.push(partIndexes[partIndex] ?? partIndex);
     retainedToolPart ||= dataField === "functionCall" ||
       dataField === "executableCode" ||
       dataField === "codeExecutionResult";
@@ -431,7 +529,11 @@ export function reconcileGoogleProviderMetadata(
     return undefined;
   }
 
-  const reconciled = createGoogleProviderMetadata(retainedParts);
+  const reconciled = createGoogleProviderMetadata(
+    retainedParts,
+    undefined,
+    retainedPartIndexes,
+  );
   if (reconciled === undefined && retainedToolPart) {
     throw new TypeError(
       "Google provider metadata could not preserve a surviving signed tool call",

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -2550,13 +2550,15 @@ export class AgentRuntime {
         preserveRecoverablePlaceholderToolCalls: shouldRecoverInterruptedLocalToolBatch ||
           !shouldContinue,
       });
-      // A suppressed tool call means the persisted parts no longer mirror the
-      // raw model turn, so replaying provider metadata would fail the
-      // provider's exact-history validation (e.g. Google's signed tool
-      // replay); the continuation falls back to synthesized parts instead.
-      if (state.suppressedToolCalls.length === 0) {
-        attachProviderMetadata(assistantMessage, state.providerMetadata);
-      }
+      attachProviderMetadata(
+        assistantMessage,
+        reconcileSuppressedProviderMetadata(
+          languageModel,
+          state.providerMetadata,
+          state.suppressedToolCalls,
+          state.toolCalls.size > 0,
+        ),
+      );
 
       for (const tc of state.toolCalls.values()) {
         const materialized = materializeStreamedToolCall(tc);
@@ -3206,4 +3208,46 @@ export class AgentRuntime {
   async clearMemory(): Promise<void> {
     await this.memory.clear();
   }
+}
+
+type ProviderMetadataReconciler = (input: {
+  providerMetadata: Record<string, unknown>;
+  suppressedToolCalls: readonly { id: string; name: string }[];
+}) => Record<string, unknown> | undefined;
+
+function reconcileSuppressedProviderMetadata(
+  modelRuntime: ModelRuntime,
+  providerMetadata: Record<string, unknown> | undefined,
+  suppressedToolCalls: readonly { id: string; name: string }[],
+  hasSurvivingToolCalls: boolean,
+): Record<string, unknown> | undefined {
+  if (providerMetadata === undefined || suppressedToolCalls.length === 0) {
+    return providerMetadata;
+  }
+  if (!hasSurvivingToolCalls) {
+    return undefined;
+  }
+
+  const reconcile = modelRuntime._reconcileProviderMetadata;
+  if (typeof reconcile !== "function") {
+    throw new TypeError(
+      "Model runtime cannot reconcile provider metadata after suppressing a tool call",
+    );
+  }
+
+  const reconciled = (reconcile as ProviderMetadataReconciler).call(modelRuntime, {
+    providerMetadata,
+    suppressedToolCalls,
+  });
+  if (
+    reconciled === undefined ||
+    reconciled === null ||
+    typeof reconciled !== "object" ||
+    Array.isArray(reconciled)
+  ) {
+    throw new TypeError(
+      "Model runtime did not preserve provider metadata for surviving tool calls",
+    );
+  }
+  return reconciled;
 }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -2550,7 +2550,13 @@ export class AgentRuntime {
         preserveRecoverablePlaceholderToolCalls: shouldRecoverInterruptedLocalToolBatch ||
           !shouldContinue,
       });
-      attachProviderMetadata(assistantMessage, state.providerMetadata);
+      // A suppressed tool call means the persisted parts no longer mirror the
+      // raw model turn, so replaying provider metadata would fail the
+      // provider's exact-history validation (e.g. Google's signed tool
+      // replay); the continuation falls back to synthesized parts instead.
+      if (state.suppressedToolCalls.length === 0) {
+        attachProviderMetadata(assistantMessage, state.providerMetadata);
+      }
 
       for (const tc of state.toolCalls.values()) {
         const materialized = materializeStreamedToolCall(tc);

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -3224,29 +3224,31 @@ function reconcileSuppressedProviderMetadata(
   if (providerMetadata === undefined || suppressedToolCalls.length === 0) {
     return providerMetadata;
   }
-  if (!hasSurvivingToolCalls) {
-    return undefined;
-  }
 
   const reconcile = modelRuntime._reconcileProviderMetadata;
   if (typeof reconcile !== "function") {
-    throw new TypeError(
-      "Model runtime cannot reconcile provider metadata after suppressing a tool call",
-    );
+    return undefined;
   }
 
   const reconciled = (reconcile as ProviderMetadataReconciler).call(modelRuntime, {
     providerMetadata,
     suppressedToolCalls,
   });
+  if (reconciled === undefined) {
+    if (!hasSurvivingToolCalls) {
+      return undefined;
+    }
+    throw new TypeError(
+      "Model runtime did not preserve provider metadata for surviving tool calls",
+    );
+  }
   if (
-    reconciled === undefined ||
     reconciled === null ||
     typeof reconciled !== "object" ||
     Array.isArray(reconciled)
   ) {
     throw new TypeError(
-      "Model runtime did not preserve provider metadata for surviving tool calls",
+      "Model runtime returned invalid provider metadata after suppressing a tool call",
     );
   }
   return reconciled;

--- a/src/agent/runtime/provider-metadata-continuation.test.ts
+++ b/src/agent/runtime/provider-metadata-continuation.test.ts
@@ -339,12 +339,20 @@ describe("agent provider metadata continuation", () => {
     ]);
   });
 
-  it("withholds replay metadata when a streamed tool call was suppressed", async () => {
+  it("asks the model runtime to reconcile metadata after suppressing a tool call", async () => {
     let callCount = 0;
     let continuedProviderMetadata: unknown = "unread";
+    let reconciledSuppressions: unknown;
     const model: ModelRuntime = {
       provider: "google",
       modelId: "gemini-3.5-flash",
+      _reconcileProviderMetadata({ providerMetadata: metadata, suppressedToolCalls }: {
+        providerMetadata: Record<string, unknown>;
+        suppressedToolCalls: readonly { id: string; name: string }[];
+      }) {
+        reconciledSuppressions = suppressedToolCalls;
+        return metadata;
+      },
       async doGenerate() {
         throw new Error("not used");
       },
@@ -401,10 +409,88 @@ describe("agent provider metadata continuation", () => {
       .text();
 
     assertEquals(callCount, 2);
-    // The suppressed call diverges the persisted parts from the raw model
-    // turn, so the continuation must rebuild the assistant message without
-    // replay metadata instead of failing Google's exact-history validation.
-    assertEquals(continuedProviderMetadata, undefined);
+    assertEquals(reconciledSuppressions, [{ id: "stale-1", name: "missing_tool" }]);
+    assertEquals(continuedProviderMetadata, providerMetadata);
     assertEquals(body.includes("test-thought-signature"), false);
+  });
+
+  it("preserves the signed surviving Gemini call after suppressing an unavailable call", async () => {
+    const encoder = new TextEncoder();
+    const staleRawPart = {
+      functionCall: {
+        id: "stale-1",
+        name: "missing_tool",
+        args: { query: "stale" },
+      },
+      thoughtSignature: "stale-thought-signature",
+    };
+    const survivingRawPart = {
+      functionCall: {
+        id: "lookup-1",
+        name: "lookup",
+        args: { query: "Veryfront" },
+      },
+      thoughtSignature: "surviving-thought-signature",
+    };
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const googleRuntime = createGoogleModelRuntime({
+      apiKey: "test-google-key",
+      baseURL: "https://example.google.test/v1beta",
+      fetch: (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        const responseParts = requestBodies.length === 1
+          ? [
+            encoder.encode(
+              `data: ${
+                JSON.stringify({
+                  candidates: [{
+                    content: { role: "model", parts: [staleRawPart, survivingRawPart] },
+                  }],
+                })
+              }\n\n`,
+            ),
+            encoder.encode(
+              'data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}\n\n',
+            ),
+          ]
+          : [
+            encoder.encode(
+              'data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Done"}]}}]}\n\n',
+            ),
+            encoder.encode(
+              'data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":1,"totalTokenCount":3}}\n\n',
+            ),
+          ];
+        return Promise.resolve(
+          new Response(
+            ReadableStream.from([...responseParts, encoder.encode("data: [DONE]\n\n")]),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        );
+      },
+    }, "gemini-3.5-flash");
+    const assistant = agent({
+      model: "google/gemini-3.5-flash",
+      system: "Use the lookup tool.",
+      tools: { lookup: createLookupTool() },
+      maxSteps: 2,
+      resolveModelTransport: () => ({ model: googleRuntime }),
+    });
+
+    const body = await (await assistant.stream({ input: "Look up Veryfront" }))
+      .toDataStreamResponse()
+      .text();
+
+    assertStringIncludes(body, "Done");
+    assertEquals(requestBodies.length, 2);
+    const continuationContents = requestBodies[1]?.contents as Array<{
+      role?: string;
+      parts?: unknown[];
+    }>;
+    const replayedAssistant = continuationContents.find((content) =>
+      content.role === "model" && JSON.stringify(content.parts).includes("lookup-1")
+    );
+    assertEquals(replayedAssistant?.parts, [survivingRawPart]);
+    assertEquals(JSON.stringify(continuationContents).includes("stale-1"), false);
   });
 });

--- a/src/agent/runtime/provider-metadata-continuation.test.ts
+++ b/src/agent/runtime/provider-metadata-continuation.test.ts
@@ -338,4 +338,73 @@ describe("agent provider metadata continuation", () => {
       },
     ]);
   });
+
+  it("withholds replay metadata when a streamed tool call was suppressed", async () => {
+    let callCount = 0;
+    let continuedProviderMetadata: unknown = "unread";
+    const model: ModelRuntime = {
+      provider: "google",
+      modelId: "gemini-3.5-flash",
+      async doGenerate() {
+        throw new Error("not used");
+      },
+      async doStream(options: unknown) {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            stream: streamFrom([
+              {
+                type: "tool-call",
+                toolCallId: "stale-1",
+                toolName: "missing_tool",
+                input: '{"query":"stale"}',
+              },
+              {
+                type: "tool-call",
+                toolCallId: "lookup-1",
+                toolName: "lookup",
+                input: '{"query":"Veryfront"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                providerMetadata,
+              },
+            ]),
+          };
+        }
+
+        continuedProviderMetadata = readAssistantProviderMetadata(options);
+        return {
+          stream: streamFrom([
+            { type: "text-delta", delta: "Done" },
+            {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            },
+          ]),
+        };
+      },
+    };
+    const assistant = agent({
+      model: "google/gemini-3.5-flash",
+      system: "Use the lookup tool.",
+      tools: { lookup: createLookupTool() },
+      maxSteps: 2,
+      resolveModelTransport: () => ({ model }),
+    });
+
+    const body = await (await assistant.stream({ input: "Look up Veryfront" }))
+      .toDataStreamResponse()
+      .text();
+
+    assertEquals(callCount, 2);
+    // The suppressed call diverges the persisted parts from the raw model
+    // turn, so the continuation must rebuild the assistant message without
+    // replay metadata instead of failing Google's exact-history validation.
+    assertEquals(continuedProviderMetadata, undefined);
+    assertEquals(body.includes("test-thought-signature"), false);
+  });
 });

--- a/src/agent/runtime/provider-metadata-continuation.test.ts
+++ b/src/agent/runtime/provider-metadata-continuation.test.ts
@@ -8,6 +8,7 @@ import { agent } from "../index.ts";
 import type { AgentRunModelCallContextEvent } from "../../runtime/model-call-context.ts";
 import { runWithRunEventSink } from "../../runtime/run-event-sink-context.ts";
 import { createGoogleModelRuntime } from "../../../extensions/ext-llm-google/src/google-provider.ts";
+import { reconcileGoogleProviderMetadata } from "../../../extensions/ext-llm-google/src/google-thought-signatures.ts";
 
 const providerMetadata = {
   google: {
@@ -414,6 +415,72 @@ describe("agent provider metadata continuation", () => {
     assertEquals(body.includes("test-thought-signature"), false);
   });
 
+  it("falls back to synthesized replay for runtimes without a metadata reconciler", async () => {
+    let callCount = 0;
+    let continuedProviderMetadata: unknown = "unread";
+    const model: ModelRuntime = {
+      provider: "custom",
+      modelId: "custom-model",
+      async doGenerate() {
+        throw new Error("not used");
+      },
+      async doStream(options: unknown) {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            stream: streamFrom([
+              {
+                type: "tool-call",
+                toolCallId: "stale-1",
+                toolName: "missing_tool",
+                input: '{"query":"stale"}',
+              },
+              {
+                type: "tool-call",
+                toolCallId: "lookup-1",
+                toolName: "lookup",
+                input: '{"query":"Veryfront"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                providerMetadata,
+              },
+            ]),
+          };
+        }
+
+        continuedProviderMetadata = readAssistantProviderMetadata(options);
+        return {
+          stream: streamFrom([
+            { type: "text-delta", delta: "Done" },
+            {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            },
+          ]),
+        };
+      },
+    };
+    const assistant = agent({
+      model: "custom/custom-model",
+      system: "Use the lookup tool.",
+      tools: { lookup: createLookupTool() },
+      maxSteps: 2,
+      resolveModelTransport: () => ({ model }),
+    });
+
+    const body = await (await assistant.stream({ input: "Look up Veryfront" }))
+      .toDataStreamResponse()
+      .text();
+
+    assertStringIncludes(body, "Done");
+    assertEquals(callCount, 2);
+    assertEquals(continuedProviderMetadata, undefined);
+  });
+
   it("preserves the signed surviving Gemini call after suppressing an unavailable call", async () => {
     const encoder = new TextEncoder();
     const staleRawPart = {
@@ -492,5 +559,103 @@ describe("agent provider metadata continuation", () => {
     );
     assertEquals(replayedAssistant?.parts, [survivingRawPart]);
     assertEquals(JSON.stringify(continuationContents).includes("stale-1"), false);
+  });
+
+  it("preserves signed Gemini reasoning when every tool call is suppressed", async () => {
+    const signedThoughtPart = {
+      text: "Private reasoning.",
+      thought: true,
+      thoughtSignature: "surviving-thought-signature",
+    };
+    const staleRawPart = {
+      functionCall: {
+        id: "stale-1",
+        name: "missing_tool",
+        args: { query: "stale" },
+      },
+      thoughtSignature: "stale-thought-signature",
+    };
+    const signedProviderMetadata = {
+      google: { rawAssistantParts: [signedThoughtPart, staleRawPart] },
+    };
+    let callCount = 0;
+    let continuedProviderMetadata: unknown = "unread";
+    const model: ModelRuntime = {
+      provider: "google",
+      modelId: "gemini-3.5-flash",
+      _reconcileProviderMetadata({ providerMetadata, suppressedToolCalls }: {
+        providerMetadata: Record<string, unknown>;
+        suppressedToolCalls: readonly { id: string; name: string }[];
+      }) {
+        return reconcileGoogleProviderMetadata(providerMetadata, suppressedToolCalls);
+      },
+      async doGenerate() {
+        throw new Error("not used");
+      },
+      async doStream(options: unknown) {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            stream: streamFrom([
+              { type: "reasoning-start", id: "reasoning-0" },
+              {
+                type: "reasoning-delta",
+                id: "reasoning-0",
+                delta: "Private reasoning.",
+              },
+              {
+                type: "reasoning-end",
+                id: "reasoning-0",
+                signature: "surviving-thought-signature",
+              },
+              {
+                type: "tool-call",
+                toolCallId: "stale-1",
+                toolName: "missing_tool",
+                input: '{"query":"stale"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                providerMetadata: signedProviderMetadata,
+              },
+            ]),
+          };
+        }
+
+        continuedProviderMetadata = readAssistantProviderMetadata(options);
+        return {
+          stream: streamFrom([
+            { type: "text-delta", delta: "Done" },
+            {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            },
+          ]),
+        };
+      },
+    };
+    const assistant = agent({
+      model: "google/gemini-3.5-flash",
+      system: "Use the lookup tool.",
+      tools: { lookup: createLookupTool() },
+      maxSteps: 2,
+      resolveModelTransport: () => ({ model }),
+    });
+
+    const body = await (await assistant.stream({ input: "Look up Veryfront" }))
+      .toDataStreamResponse()
+      .text();
+
+    assertStringIncludes(body, "Done");
+    assertEquals(callCount, 2);
+    assertEquals(continuedProviderMetadata, {
+      google: {
+        rawAssistantParts: [signedThoughtPart],
+        rawAssistantPartIndexes: [0],
+      },
+    });
   });
 });

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -13,6 +13,7 @@ import type {
   TextGenerationRuntimeUserMessage,
 } from "./text-generation-runtime-message-types.ts";
 import type { Message } from "../types.ts";
+import { attachProviderMetadata } from "./provider-metadata.ts";
 
 describe("text-generation-runtime-message-converter", () => {
   describe("convertToTextGenerationRuntimeMessage", () => {
@@ -438,6 +439,33 @@ describe("text-generation-runtime-message-converter", () => {
         { role: "user", content: "list my repos" },
         { role: "user", content: "try again" },
       ]);
+    });
+
+    it("keeps an exact-replay assistant turn that has only canonical reasoning", () => {
+      const providerMetadata = {
+        google: {
+          rawAssistantParts: [{
+            text: "Private reasoning.",
+            thought: true,
+            thoughtSignature: "thought-signature",
+          }],
+        },
+      };
+      const message = attachProviderMetadata({
+        id: "a-reasoning",
+        role: "assistant",
+        parts: [{
+          type: "reasoning",
+          text: "Private reasoning.",
+          signature: "thought-signature",
+        }],
+      }, providerMetadata);
+
+      assertEquals(convertToTextGenerationRuntimeMessages([message]), [{
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+        providerMetadata,
+      }]);
     });
 
     it("omits provider-executed tool-only assistant messages from replay", () => {

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -359,6 +359,7 @@ export function convertToTextGenerationRuntimeMessage(
 
 function hasProviderSendableAssistantContent(message: Message): boolean {
   if (message.role !== "assistant") return true;
+  if (readAttachedProviderMetadata(message) !== undefined) return true;
 
   return message.parts.some((part) => {
     if (part.type === "text" && "text" in part) {
@@ -477,6 +478,12 @@ function convertAssistantMessageToTextGenerationRuntimeMessages(
   // conversion split that response would pair it with an incomplete projection.
   if (providerMetadata !== undefined && assistantMessages.length === 1) {
     assistantMessages[0]!.providerMetadata = providerMetadata;
+  } else if (providerMetadata !== undefined && messages.length === 0) {
+    messages.push({
+      role: "assistant",
+      content: [{ type: "text", text: "" }],
+      providerMetadata,
+    });
   }
 
   return messages;


### PR DESCRIPTION
## Summary

Follow-up to #3820, closing the residual replay failure found in review.

When a streamed Gemini turn contained an unavailable call alongside signed replay content, the runtime removed the unavailable call from canonical history. Replaying the original raw metadata then failed exact-history validation, but removing all metadata also stripped signatures from valid surviving calls and reasoning.

## Change

- Ask the model runtime to reconcile opaque provider metadata after a tool call is suppressed, including when no tool call survives.
- Fall back to synthesized replay for public custom runtimes that do not expose the private reconciliation hook.
- Fail closed when surviving calls cannot retain reconciled replay metadata.
- Let Google remove only suppressed raw tool parts while preserving exact signed surviving calls and non-tool reasoning.
- Keep a reasoning-only assistant turn provider-sendable when exact replay metadata is attached.
- Preserve validated original raw-part indexes so filtering cannot renumber anonymous surviving calls.
- Reject reconciliation when a remaining Google tool call has no replay signature.
- Keep provider-specific wire knowledge out of the core agent loop.

## Testing

- RED: the mixed-call continuation synthesized a valid Gemini call without its thought signature.
- RED: filtering an earlier anonymous call renumbered the surviving `tool-1` call to `tool-0` and failed exact replay validation.
- RED: a custom public runtime without the private hook aborted before its continuation.
- RED: an all-suppressed Gemini tool turn dropped the signed non-tool reasoning metadata.
- GREEN: the Google runtime replays signed surviving content and omits unavailable calls.
- GREEN: custom runtimes fall back to synthesized replay without an API-breaking hook requirement.
- Direct reconciliation tests cover unchanged metadata, all calls suppressed, and unsigned-survivor rejection.
- Google request, provider, stream-handler, continuation, and message-converter suites pass: 224 steps.
- Changed-file format, lint, typecheck, and diff checks pass.
- The branch is based on main commit `2c2091a3975eb9ec8005f62dc56643cf31ac8e9c`.

## Risk

Moderate and contained. The core runtime treats metadata as opaque. Google owns validation and reconstruction. Unsupported custom runtimes retain the synthesized-replay behavior from the first fix, while unsafe provider-specific reconciliation paths fail closed.

Refs VERYFRONT-AGENT-9
