### PR TITLE
test(agent): pin the Gemini 3.x tool-result replay to the live wire shape

### DIFF
--- a/src/agent/runtime/provider-metadata-continuation.test.ts
+++ b/src/agent/runtime/provider-metadata-continuation.test.ts
@@ -658,4 +658,113 @@ describe("agent provider metadata continuation", () => {
       },
     });
   });
+
+  // Wire shape modelled on a real gemini-3.1-pro-preview streamGenerateContent
+  // response: the signature rides the functionCall part in the first chunk, and
+  // a trailing empty-text part arrives in a separate chunk alongside the finish
+  // reason. Gemini 3.x rejects the tool-result leg with HTTP 400 "Function call
+  // is missing a thought_signature in functionCall parts" unless that exact
+  // model turn is replayed, while 2.5 accepts an unsigned replay. The signature
+  // itself is opaque to the replay path, so this fixture carries a fabricated
+  // placeholder rather than a captured provider value.
+  it("replays a Gemini 3.x signed tool call in the live wire shape", async () => {
+    const encoder = new TextEncoder();
+    const signedFunctionCallPart = {
+      functionCall: {
+        name: "lookup",
+        args: { query: "Veryfront" },
+        id: "call_2874307",
+      },
+      thoughtSignature: "dGVzdC1nZW1pbmktMy10aG91Z2h0LXNpZ25hdHVyZS1wbGFjZWhvbGRlcg==",
+    };
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const googleRuntime = createGoogleModelRuntime({
+      apiKey: "test-google-key",
+      baseURL: "https://example.google.test/v1beta",
+      fetch: (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        const responseParts = requestBodies.length === 1
+          ? [
+            encoder.encode(
+              `data: ${
+                JSON.stringify({
+                  candidates: [{
+                    content: { parts: [signedFunctionCallPart], role: "model" },
+                    index: 0,
+                  }],
+                  usageMetadata: {
+                    promptTokenCount: 57,
+                    candidatesTokenCount: 16,
+                    totalTokenCount: 165,
+                    thoughtsTokenCount: 92,
+                  },
+                  modelVersion: "gemini-3.1-pro-preview",
+                })
+              }\n\n`,
+            ),
+            encoder.encode(
+              `data: ${
+                JSON.stringify({
+                  candidates: [{
+                    content: { parts: [{ text: "" }], role: "model" },
+                    finishReason: "STOP",
+                    index: 0,
+                  }],
+                  usageMetadata: {
+                    promptTokenCount: 57,
+                    candidatesTokenCount: 16,
+                    totalTokenCount: 165,
+                  },
+                })
+              }\n\n`,
+            ),
+          ]
+          : [
+            encoder.encode(
+              'data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Done"}]}}]}\n\n',
+            ),
+            encoder.encode(
+              'data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":1,"totalTokenCount":3}}\n\n',
+            ),
+          ];
+        return Promise.resolve(
+          new Response(
+            ReadableStream.from([...responseParts, encoder.encode("data: [DONE]\n\n")]),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        );
+      },
+    }, "gemini-3.1-pro-preview");
+    const assistant = agent({
+      model: "google/gemini-3.1-pro-preview",
+      system: "Use the lookup tool.",
+      tools: { lookup: createLookupTool() },
+      maxSteps: 2,
+      resolveModelTransport: () => ({ model: googleRuntime }),
+    });
+
+    const body = await (await assistant.stream({ input: "Look up Veryfront" }))
+      .toDataStreamResponse().text();
+
+    assertStringIncludes(body, "Done");
+    assertEquals(requestBodies.length, 2);
+    // The signature must never surface in the client-facing stream.
+    assertEquals(body.includes(signedFunctionCallPart.thoughtSignature), false);
+    // The tool-result leg must carry the signed model turn verbatim, trailing
+    // empty-text part included, which is what the live API accepts.
+    const continuationContents = requestBodies[1]?.contents as unknown[] | undefined;
+    assertEquals(continuationContents?.slice(-2), [
+      { role: "model", parts: [signedFunctionCallPart, { text: "" }] },
+      {
+        role: "user",
+        parts: [{
+          functionResponse: {
+            id: "call_2874307",
+            name: "lookup",
+            response: { result: { value: "Veryfront" } },
+          },
+        }],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## What this is

A regression test, not a fix. The fix for the reported bug already landed on `main` in #3820. This pins the behaviour to the shape the live API actually returns, and records the verification.

## The bug (veryfront-issue-inbox#549)

`google-ai-studio/gemini-3.1-pro-preview` and `google-ai-studio/gemini-3.5-flash` passed text runs but failed every tool call. The tool call itself succeeded; the run died on the next provider request — the one carrying the tool result back.

Captured verbatim from the provider:

```json
{"error": {"code": 400,
 "message": "Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, and missing thought_signature may lead to degraded model performance. Additional data, function call `default_api:get_weather` , position 2. Please refer to https://ai.google.dev/gemini-api/docs/thought-signatures for more details.",
 "status": "INVALID_ARGUMENT"}}
```

Replaying the model turn four ways against the live gateway isolates the cause to exactly one field:

| replayed model turn | 3.1-pro | 3.5-flash | 2.5-pro |
|---|---|---|---|
| verbatim, all parts | 200 | 200 | 200 |
| functionCall parts only, signature kept | 200 | 200 | 200 |
| trailing empty-text part dropped | 200 | 200 | 200 |
| functionCall only, signature stripped | **400** | **400** | 200 |

Not the `functionResponse` shape, not part ordering, not the trailing `{"text":""}` part 3.x emits. Only `thoughtSignature`. 2.5 tolerates its absence, which is why the same round trip passed there and made this look 3.x-specific rather than replay-specific.

## Why it is already fixed

`ext-llm-google` was correct on both ends the whole time: `google-stream.ts` retains the signed raw part and emits it as `providerMetadata.google.rawAssistantParts`, and `google-request-builder.ts` replays those parts verbatim. The metadata never reached the replay path, because the agent loop rebuilds the prompt from framework messages on every step and had no field to carry it. #3820 plumbed `providerMetadata` through that boundary.

## What this test adds

The existing continuation tests drive a synthetic single-part stream. A real `gemini-3.1-pro-preview` response splits differently: the signature rides the `functionCall` part in the first chunk, and a trailing empty-text part arrives in a separate chunk alongside `finishReason: STOP`. Both parts are retained, and the verbatim two-part replay is what the live API accepts. This test uses that captured shape, so a future change that drops the trailing part or the signature fails here instead of in production against one model generation.

## Verification

- Red against `5887da120` (the commit before #3820), green on `main`.
- Live tool round trip through the staging AI gateway using the real agent runtime, `main` vs pre-fix:

```
main:     [OK  ] gemini-3.1-pro-preview | requests=2 | 2nd request has thoughtSignature=true
          [OK  ] gemini-3.5-flash       | requests=2 | 2nd request has thoughtSignature=true
          [OK  ] gemini-2.5-pro         | requests=2 | 2nd request has thoughtSignature=true
          [OK  ] gemini-2.5-flash       | requests=2 | 2nd request has thoughtSignature=true

pre-fix:  [FAIL] gemini-3.1-pro-preview | Provider request failed with status 400
          [FAIL] gemini-3.5-flash       | Provider request failed with status 400
          [OK  ] gemini-2.5-pro
          [OK  ] gemini-2.5-flash
```

- `deno test --allow-all extensions/ext-llm-google/` — 4 passed (106 steps).
- `deno test --allow-all src/agent/runtime/provider-metadata-continuation.test.ts` — 6 steps, all pass.
- `text-generation-runtime-message-converter.test.ts` and `runtime-bridge.test.ts` — 2 passed (78 steps).

## Still open: the fix is unreleased

#3820 merged after `v0.1.1240` and is in no published release. Staging runs `veryfront@0.1.1231`. Until a release ships and is deployed, #549 still reproduces in staging and production regardless of this PR. That release is the remaining action, not more code.

Also checked and clear: reloaded multi-turn history (unsigned tool calls from earlier turns) returns 200 on 3.x. Gemini only enforces the signature on the tool call immediately preceding the tool result, so conversations resumed from persistence are unaffected by the metadata being in-memory only.

Refs veryfront-issue-inbox#549

https://claude.ai/code/session_01J2e7P4tmqYjYZQ1paDomg5