### PR TITLE
fix(ci): keep bundle report comments best-effort

### DIFF
--- a/.github/workflows/client-bundle-report.yml
+++ b/.github/workflows/client-bundle-report.yml
@@ -31,8 +31,10 @@ jobs:
       - name: Compute client bundle report
         run: deno task client-bundle:report > client-bundle-report.md
       - name: Post sticky PR comment
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          retries: 3
           script: |
             const fs = require("fs");
             const marker = "<!-- client-bundle-report -->";

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -36,7 +36,27 @@ function jobBlock(workflow: string, jobName: string): string {
   return nextJob === -1 ? rest : rest.slice(0, nextJob);
 }
 
+function workflowStepBlock(workflow: string, stepName: string): string {
+  const marker = `      - name: ${stepName}\n`;
+  const start = workflow.indexOf(marker);
+  assert(start >= 0, `expected ${stepName} step to exist`);
+
+  const nextStep = workflow.indexOf("\n      - ", start + marker.length);
+  return nextStep === -1 ? workflow.slice(start) : workflow.slice(start, nextStep);
+}
+
 describe("repository hardening", () => {
+  it("keeps the client bundle report authoritative and its comment best-effort", async () => {
+    const workflow = await readText(".github/workflows/client-bundle-report.yml");
+    const compute = workflowStepBlock(workflow, "Compute client bundle report");
+    const comment = workflowStepBlock(workflow, "Post sticky PR comment");
+
+    assert(compute.includes("deno task client-bundle:report"));
+    assert(!compute.includes("continue-on-error"));
+    assert(comment.includes("continue-on-error: true"));
+    assert(comment.includes("retries: 3"));
+  });
+
   it("keeps CODEOWNERS in force for public governance files", async () => {
     const codeowners = await readText(".github/CODEOWNERS");
 


### PR DESCRIPTION
## Summary

- retry sticky client bundle report comment requests up to three times
- treat the informational PR comment as best-effort
- keep the bundle computation and leak detection as the authoritative hard gate

## Root cause

The report computation completed successfully, but intermittent GitHub API 503 responses while updating the sticky PR comment failed the entire job. This produced false-red checks on otherwise valid changes.

## RED-GREEN TDD

- RED: added a repository hardening contract that failed because the comment step had no best-effort policy
- GREEN: added retries and step-level continue-on-error while asserting that the compute step remains strict

## Verification

- `deno fmt --check .github/workflows/client-bundle-report.yml src/security/repository-hardening.test.ts`
- `deno lint src/security/repository-hardening.test.ts`
- `deno check src/security/repository-hardening.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/testing/preload.ts --no-check --allow-all src/security/repository-hardening.test.ts`
- `git diff --check`

All commands pass. This is a CI-only change with no product or UI behavior change.

Unblocks reliable validation for #3825 and #3829.