### PR TITLE
fix(transforms): drop stale server-hook sourcemaps

### DIFF
--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -7,7 +7,7 @@ import {
   browserServerExportsStripPlugin,
   stripServerOnlyExports,
 } from "./browser-server-exports-strip.ts";
-import { compilePlugin } from "./compile.ts";
+import { COMPILE_SOURCE_MAP_DIRECTIVE_METADATA, compilePlugin } from "./compile.ts";
 import { runPipeline } from "../index.ts";
 import { type TransformContext, TransformStage } from "../types.ts";
 
@@ -1057,12 +1057,15 @@ describe("browser-server-exports-strip", () => {
         `export async function getServerData() { return { props: { key: KEY } }; }`,
         `export default function Page() { return CLIENT_MARKER; }`,
       ].join("\n");
-      const compiled = await compilePlugin.transform({
+      const compileContext = {
         ...ctx(source, "browser"),
         dev: true,
         jsxImportSource: "react",
-      });
-      const match = compiled.match(
+      };
+      const compiled = await compilePlugin.transform(compileContext);
+      const directive = compileContext.metadata.get(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
+      assertEquals(typeof directive, "string");
+      const match = String(directive).match(
         /\/\/[#@]\s*sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/]+={0,2})/,
       );
       assertEquals(match === null, false);
@@ -1074,7 +1077,10 @@ describe("browser-server-exports-strip", () => {
         true,
       );
 
-      const result = await browserServerExportsStripPlugin.transform(ctx(compiled, "browser"));
+      const result = await browserServerExportsStripPlugin.transform({
+        ...compileContext,
+        code: compiled,
+      });
 
       assertNotIncludes(result, "SERVER_VALUE");
       assertNotIncludes(result, "sourceMappingURL=data:application/json;base64,");
@@ -1089,18 +1095,25 @@ describe("browser-server-exports-strip", () => {
         `const MDXLayout = () => CLIENT_MARKER;`,
         `export async function getServerData() { return { props: { key: KEY } }; }`,
       ].join("\n");
-      const compiled = await compilePlugin.transform({
+      const compileContext = {
         ...ctx(source, "browser"),
         filePath: "pages/test.mdx",
         dev: true,
         jsxImportSource: "react",
-      });
-      assertStringIncludes(compiled, "sourceMappingURL=data:application/json;base64,");
+      };
+      const compiled = await compilePlugin.transform(compileContext);
+      assertEquals(
+        String(compileContext.metadata.get(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA)).includes(
+          "sourceMappingURL=data:application/json;base64,",
+        ),
+        true,
+      );
+      assertNotIncludes(compiled, "sourceMappingURL=data:application/json;base64,");
       assertStringIncludes(compiled, "export { MDXLayout };");
 
       const result = await browserServerExportsStripPlugin.transform({
-        ...ctx(compiled, "browser"),
-        filePath: "pages/test.mdx",
+        ...compileContext,
+        code: compiled,
       });
 
       assertNotIncludes(result, "SERVER_VALUE");
@@ -1132,6 +1145,41 @@ describe("browser-server-exports-strip", () => {
 
       assertNotIncludes(result.code, "SERVER_ONLY_HOOK_SOURCE");
       assertNotIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(result.code, "export const APPENDED = true;");
+    });
+
+    it("does not confuse a copied map string with the compile map comment", async () => {
+      const source = [
+        `const KEY = "SERVER_ONLY_HOOK_SOURCE";`,
+        `export async function getServerData() { return { props: { key: KEY } }; }`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const result = await runPipeline(
+        source,
+        "/project/pages/test.tsx",
+        "/project",
+        { projectId: "source-map-duplicate-text", dev: true, ssr: false },
+        {
+          plugins: [{
+            name: "copy-map-before-appending",
+            stage: TransformStage.COMPILE + 0.5,
+            transform: (ctx) => {
+              const directive = ctx.code.match(
+                /\/\/[#@]\s*sourceMappingURL=data:application\/json;base64,[A-Za-z0-9+/]+={0,2}/,
+              )?.[0];
+              const copied = directive
+                ? `export const COPIED_COMPILE_MAP = ${JSON.stringify(directive)};\n`
+                : "";
+              return `${copied}${ctx.code}\nexport const APPENDED = true;`;
+            },
+          }],
+        },
+      );
+
+      assertNotIncludes(result.code, "SERVER_ONLY_HOOK_SOURCE");
+      assertNotIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
+      assertNotIncludes(result.code, "COPIED_COMPILE_MAP");
       assertStringIncludes(result.code, "export const APPENDED = true;");
     });
 

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -1183,23 +1183,41 @@ describe("browser-server-exports-strip", () => {
       assertStringIncludes(result.code, "export const APPENDED = true;");
     });
 
-    it("keeps the compile map when no server hook is rewritten", async () => {
+    it("does not restore a compile map after an intermediate plugin removes the hook", async () => {
+      const source = [
+        `const KEY = "SERVER_ONLY_HOOK_SOURCE";`,
+        `export async function getServerData() { return { props: { key: KEY } }; }`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const result = await runPipeline(
+        source,
+        "/project/pages/test.tsx",
+        "/project",
+        { projectId: "source-map-intermediate-removal", dev: true, ssr: false },
+        {
+          plugins: [{
+            name: "remove-server-hook",
+            stage: TransformStage.COMPILE + 0.5,
+            transform: () => `export default function Page() { return null; }`,
+          }],
+        },
+      );
+
+      assertNotIncludes(result.code, "SERVER_ONLY_HOOK_SOURCE");
+      assertNotIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(result.code, "export default function Page()");
+    });
+
+    it("keeps the compile map when no server hook or intermediate change exists", async () => {
       const result = await runPipeline(
         `export default function Page() { return null; }`,
         "/project/pages/test.tsx",
         "/project",
         { projectId: "source-map-no-server-hook", dev: true, ssr: false },
-        {
-          plugins: [{
-            name: "append-after-compile",
-            stage: TransformStage.COMPILE + 0.5,
-            transform: (ctx) => `${ctx.code}\nexport const APPENDED = true;`,
-          }],
-        },
       );
 
       assertStringIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
-      assertStringIncludes(result.code, "export const APPENDED = true;");
     });
 
     it("removes an external source map reference after stripping", async () => {

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -8,7 +8,8 @@ import {
   stripServerOnlyExports,
 } from "./browser-server-exports-strip.ts";
 import { compilePlugin } from "./compile.ts";
-import type { TransformContext } from "../types.ts";
+import { runPipeline } from "../index.ts";
+import { type TransformContext, TransformStage } from "../types.ts";
 
 function assertNotIncludes(haystack: string, needle: string): void {
   assertEquals(haystack.includes(needle), false, `expected not to find ${needle} in:\n${haystack}`);
@@ -1028,7 +1029,7 @@ describe("browser-server-exports-strip", () => {
 
   describe("plugin", () => {
     function ctx(code: string, target: "browser" | "ssr"): TransformContext {
-      return { code, target, filePath: "pages/test.tsx" } as TransformContext;
+      return { code, target, filePath: "pages/test.tsx", metadata: new Map() } as TransformContext;
     }
 
     it("drops the server-only import chain from the client artifact", async () => {
@@ -1106,6 +1107,51 @@ describe("browser-server-exports-strip", () => {
       assertNotIncludes(result, "sourceMappingURL=data:application/json;base64,");
       assertStringIncludes(result, "sourceMappingURL=data:text/plain;base64,AAAA");
       assertStringIncludes(result, "export { MDXLayout };");
+    });
+
+    it("removes the compile map after an intermediate plugin appends code", async () => {
+      const source = [
+        `const KEY = "SERVER_ONLY_HOOK_SOURCE";`,
+        `export async function getServerData() { return { props: { key: KEY } }; }`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const result = await runPipeline(
+        source,
+        "/project/pages/test.tsx",
+        "/project",
+        { projectId: "source-map-intermediate-plugin", dev: true, ssr: false },
+        {
+          plugins: [{
+            name: "append-after-compile",
+            stage: TransformStage.COMPILE + 0.5,
+            transform: (ctx) => `${ctx.code}\nexport const APPENDED = true;`,
+          }],
+        },
+      );
+
+      assertNotIncludes(result.code, "SERVER_ONLY_HOOK_SOURCE");
+      assertNotIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(result.code, "export const APPENDED = true;");
+    });
+
+    it("keeps the compile map when no server hook is rewritten", async () => {
+      const result = await runPipeline(
+        `export default function Page() { return null; }`,
+        "/project/pages/test.tsx",
+        "/project",
+        { projectId: "source-map-no-server-hook", dev: true, ssr: false },
+        {
+          plugins: [{
+            name: "append-after-compile",
+            stage: TransformStage.COMPILE + 0.5,
+            transform: (ctx) => `${ctx.code}\nexport const APPENDED = true;`,
+          }],
+        },
+      );
+
+      assertStringIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(result.code, "export const APPENDED = true;");
     });
 
     it("removes an external source map reference after stripping", async () => {

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -1,11 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "../../plugins/__tests__/code-parser-setup.ts";
+import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   browserServerExportsStripPlugin,
   stripServerOnlyExports,
 } from "./browser-server-exports-strip.ts";
+import { compilePlugin } from "./compile.ts";
 import type { TransformContext } from "../types.ts";
 
 function assertNotIncludes(haystack: string, needle: string): void {
@@ -18,6 +20,10 @@ function occurrences(haystack: string, name: string): number {
 }
 
 describe("browser-server-exports-strip", () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
   describe("emptying server-only hooks", () => {
     it("empties an exported async function declaration body", async () => {
       const code = [
@@ -1040,6 +1046,51 @@ describe("browser-server-exports-strip", () => {
       assertEquals(occurrences(result, "hashOf"), 0);
       assertNotIncludes(result, "@/lib/uses-crypto");
       assertStringIncludes(result, "TestD as default");
+    });
+
+    it("does not retain a pre-strip inline source map", async () => {
+      const source = [
+        `import { getEnv } from "veryfront";`,
+        `const KEY = getEnv("SERVER_VALUE");`,
+        `const CLIENT_MARKER = "//# sourceMappingURL=data:text/plain;base64,AAAA";`,
+        `export async function getServerData() { return { props: { key: KEY } }; }`,
+        `export default function Page() { return CLIENT_MARKER; }`,
+      ].join("\n");
+      const compiled = await compilePlugin.transform({
+        ...ctx(source, "browser"),
+        dev: true,
+        jsxImportSource: "react",
+      });
+      const match = compiled.match(
+        /\/\/[#@]\s*sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/]+={0,2})/,
+      );
+      assertEquals(match === null, false);
+      const sourceMap = JSON.parse(atob(match?.[1] ?? "")) as {
+        sourcesContent?: string[];
+      };
+      assertEquals(
+        sourceMap.sourcesContent?.some((content) => content.includes("SERVER_VALUE")),
+        true,
+      );
+
+      const result = await browserServerExportsStripPlugin.transform(ctx(compiled, "browser"));
+
+      assertNotIncludes(result, "SERVER_VALUE");
+      assertNotIncludes(result, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(result, "sourceMappingURL=data:text/plain;base64,AAAA");
+    });
+
+    it("removes an external source map reference after stripping", async () => {
+      const code = [
+        `export function getStaticData() { return readSecret(); }`,
+        `export default function Page() { return null; }`,
+        `//# sourceMappingURL=page.js.map`,
+      ].join("\n");
+
+      const result = await browserServerExportsStripPlugin.transform(ctx(code, "browser"));
+
+      assertNotIncludes(result, "readSecret");
+      assertNotIncludes(result, "sourceMappingURL=page.js.map");
     });
 
     it("does not run for the ssr target", () => {

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -1080,6 +1080,34 @@ describe("browser-server-exports-strip", () => {
       assertStringIncludes(result, "sourceMappingURL=data:text/plain;base64,AAAA");
     });
 
+    it("removes a pre-strip inline map before an appended MDX export", async () => {
+      const source = [
+        `import { getEnv } from "veryfront";`,
+        `const KEY = getEnv("SERVER_VALUE");`,
+        `const CLIENT_MARKER = "//# sourceMappingURL=data:text/plain;base64,AAAA";`,
+        `const MDXLayout = () => CLIENT_MARKER;`,
+        `export async function getServerData() { return { props: { key: KEY } }; }`,
+      ].join("\n");
+      const compiled = await compilePlugin.transform({
+        ...ctx(source, "browser"),
+        filePath: "pages/test.mdx",
+        dev: true,
+        jsxImportSource: "react",
+      });
+      assertStringIncludes(compiled, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(compiled, "export { MDXLayout };");
+
+      const result = await browserServerExportsStripPlugin.transform({
+        ...ctx(compiled, "browser"),
+        filePath: "pages/test.mdx",
+      });
+
+      assertNotIncludes(result, "SERVER_VALUE");
+      assertNotIncludes(result, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(result, "sourceMappingURL=data:text/plain;base64,AAAA");
+      assertStringIncludes(result, "export { MDXLayout };");
+    });
+
     it("removes an external source map reference after stripping", async () => {
       const code = [
         `export function getStaticData() { return readSecret(); }`,

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.ts
@@ -59,7 +59,10 @@ import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import type { ASTNode, CodeParser } from "#veryfront/extensions/parser/index.ts";
 import type { TransformContext, TransformPlugin } from "../types.ts";
 import { TransformStage } from "../types.ts";
-import { COMPILE_SOURCE_MAP_DIRECTIVE_METADATA } from "./compile.ts";
+import {
+  COMPILE_SOURCE_MAP_DIRECTIVE_METADATA,
+  COMPILE_SOURCE_MAP_INPUT_METADATA,
+} from "./compile.ts";
 
 /** Exports that only ever execute on the server. */
 const SERVER_ONLY_EXPORTS = ["getServerData", "getStaticData", "getStaticPaths"];
@@ -1116,8 +1119,11 @@ export const browserServerExportsStripPlugin: TransformPlugin = {
   condition: (ctx: TransformContext) => ctx.target === "browser",
   transform: async (ctx: TransformContext) => {
     const directive = ctx.metadata.get(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
+    const compileInput = ctx.metadata.get(COMPILE_SOURCE_MAP_INPUT_METADATA);
+    ctx.metadata.delete(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
+    ctx.metadata.delete(COMPILE_SOURCE_MAP_INPUT_METADATA);
     const result = await stripServerOnlyExports(ctx.code, ctx.filePath);
-    return result === ctx.code && typeof directive === "string"
+    return result === ctx.code && compileInput === ctx.code && typeof directive === "string"
       ? appendSourceMapDirective(result, directive)
       : result;
   },

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.ts
@@ -75,11 +75,9 @@ function dropSourceMapSuffix(code: string): string {
   return code.replace(SOURCE_MAP_SUFFIX, "$1");
 }
 
-function dropRecordedSourceMap(code: string, directive: string | undefined): string {
-  if (!directive) return code;
-  const index = code.indexOf(directive);
-  if (index < 0) return code;
-  return code.slice(0, index) + code.slice(index + directive.length);
+function appendSourceMapDirective(code: string, directive: string): string {
+  const separator = code.length > 0 && !code.endsWith("\n") ? "\n" : "";
+  return `${code}${separator}${directive}\n`;
 }
 
 /** Source the stub nodes are lifted from, so no node shape is hand-built. */
@@ -1061,15 +1059,9 @@ class ServerExportStripError extends Error {
 export async function stripServerOnlyExports(
   code: string,
   filePath?: string,
-  compileSourceMapDirective?: string,
 ): Promise<string> {
   // Cheap pre-check: no mention of a hook means no parse.
   if (!SERVER_ONLY_EXPORTS.some((name) => code.includes(name))) return code;
-
-  // A custom stage may append code after esbuild's map before this pass runs.
-  // Remove the exact compile-generated directive from the analysis input, but
-  // return the original code unchanged when no hook is ultimately rewritten.
-  const analysisCode = dropRecordedSourceMap(code, compileSourceMapDirective);
 
   const parser = tryResolve<CodeParser>("CodeParser");
   if (!parser) {
@@ -1085,7 +1077,7 @@ export async function stripServerOnlyExports(
     if (!parsedStubs) throw new Error("the stub source did not parse");
     stubs = parsedStubs;
 
-    ast = await parser.parse({ code: analysisCode, filePath: filePath ?? "module.tsx" });
+    ast = await parser.parse({ code, filePath: filePath ?? "module.tsx" });
     body = bodyOf(ast);
   } catch (error) {
     throw new ServerExportStripError(
@@ -1122,12 +1114,11 @@ export const browserServerExportsStripPlugin: TransformPlugin = {
   // dropped bindings are never rewritten or pre-fetched.
   stage: TransformStage.COMPILE + 0.6,
   condition: (ctx: TransformContext) => ctx.target === "browser",
-  transform: (ctx: TransformContext) => {
+  transform: async (ctx: TransformContext) => {
     const directive = ctx.metadata.get(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
-    return stripServerOnlyExports(
-      ctx.code,
-      ctx.filePath,
-      typeof directive === "string" ? directive : undefined,
-    );
+    const result = await stripServerOnlyExports(ctx.code, ctx.filePath);
+    return result === ctx.code && typeof directive === "string"
+      ? appendSourceMapDirective(result, directive)
+      : result;
   },
 };

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.ts
@@ -63,6 +63,17 @@ import { TransformStage } from "../types.ts";
 /** Exports that only ever execute on the server. */
 const SERVER_ONLY_EXPORTS = ["getServerData", "getStaticData", "getStaticPaths"];
 
+// The compile stage runs before this pass and embeds its input in a development
+// sourcemap. Once a hook is stripped, any prior map is stale and may contain or
+// point at a verbatim copy of the server-only source. Match only an actual
+// trailing directive so source-map-like text inside authored strings survives.
+const SOURCE_MAP_SUFFIX =
+  /(^|\r?\n)[\t ]*\/\/[#@][\t ]*sourceMappingURL=[^"'`\s]+[\t ]*(?:\r?\n)?$/;
+
+function dropSourceMapSuffix(code: string): string {
+  return code.replace(SOURCE_MAP_SUFFIX, "$1");
+}
+
 /** Source the stub nodes are lifted from, so no node shape is hand-built. */
 const STUB_SOURCE = `function __vfStub() { throw new Error("server-only"); }
 const __vfStubInit = function () { throw new Error("server-only"); };`;
@@ -1085,7 +1096,7 @@ export async function stripServerOnlyExports(code: string, filePath?: string): P
   setBody(ast, dropUnusedImportBindings(pruned, hookClosure));
 
   const generated = await parser.generate(ast);
-  return generated.code;
+  return dropSourceMapSuffix(generated.code);
 }
 
 export const browserServerExportsStripPlugin: TransformPlugin = {

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.ts
@@ -59,6 +59,7 @@ import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import type { ASTNode, CodeParser } from "#veryfront/extensions/parser/index.ts";
 import type { TransformContext, TransformPlugin } from "../types.ts";
 import { TransformStage } from "../types.ts";
+import { COMPILE_SOURCE_MAP_DIRECTIVE_METADATA } from "./compile.ts";
 
 /** Exports that only ever execute on the server. */
 const SERVER_ONLY_EXPORTS = ["getServerData", "getStaticData", "getStaticPaths"];
@@ -72,6 +73,13 @@ const SOURCE_MAP_SUFFIX =
 
 function dropSourceMapSuffix(code: string): string {
   return code.replace(SOURCE_MAP_SUFFIX, "$1");
+}
+
+function dropRecordedSourceMap(code: string, directive: string | undefined): string {
+  if (!directive) return code;
+  const index = code.indexOf(directive);
+  if (index < 0) return code;
+  return code.slice(0, index) + code.slice(index + directive.length);
 }
 
 /** Source the stub nodes are lifted from, so no node shape is hand-built. */
@@ -1050,9 +1058,18 @@ class ServerExportStripError extends Error {
  * in a form with no local declaration to empty. Failing the build is the only
  * safe outcome — the alternative is shipping the loader to the browser.
  */
-export async function stripServerOnlyExports(code: string, filePath?: string): Promise<string> {
+export async function stripServerOnlyExports(
+  code: string,
+  filePath?: string,
+  compileSourceMapDirective?: string,
+): Promise<string> {
   // Cheap pre-check: no mention of a hook means no parse.
   if (!SERVER_ONLY_EXPORTS.some((name) => code.includes(name))) return code;
+
+  // A custom stage may append code after esbuild's map before this pass runs.
+  // Remove the exact compile-generated directive from the analysis input, but
+  // return the original code unchanged when no hook is ultimately rewritten.
+  const analysisCode = dropRecordedSourceMap(code, compileSourceMapDirective);
 
   const parser = tryResolve<CodeParser>("CodeParser");
   if (!parser) {
@@ -1068,7 +1085,7 @@ export async function stripServerOnlyExports(code: string, filePath?: string): P
     if (!parsedStubs) throw new Error("the stub source did not parse");
     stubs = parsedStubs;
 
-    ast = await parser.parse({ code, filePath: filePath ?? "module.tsx" });
+    ast = await parser.parse({ code: analysisCode, filePath: filePath ?? "module.tsx" });
     body = bodyOf(ast);
   } catch (error) {
     throw new ServerExportStripError(
@@ -1105,5 +1122,12 @@ export const browserServerExportsStripPlugin: TransformPlugin = {
   // dropped bindings are never rewritten or pre-fetched.
   stage: TransformStage.COMPILE + 0.6,
   condition: (ctx: TransformContext) => ctx.target === "browser",
-  transform: (ctx: TransformContext) => stripServerOnlyExports(ctx.code, ctx.filePath),
+  transform: (ctx: TransformContext) => {
+    const directive = ctx.metadata.get(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
+    return stripServerOnlyExports(
+      ctx.code,
+      ctx.filePath,
+      typeof directive === "string" ? directive : undefined,
+    );
+  },
 };

--- a/src/transforms/pipeline/stages/compile.ts
+++ b/src/transforms/pipeline/stages/compile.ts
@@ -16,6 +16,7 @@ const ReflectGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
 const SOURCE_MAP_SUFFIX =
   /(^|\r?\n)[\t ]*\/\/[#@][\t ]*sourceMappingURL=[^"'`\s]+[\t ]*(?:\r?\n)?$/;
 export const COMPILE_SOURCE_MAP_DIRECTIVE_METADATA = "compileSourceMapDirective";
+export const COMPILE_SOURCE_MAP_INPUT_METADATA = "compileSourceMapInput";
 
 function trailingSourceMapDirective(code: string): string | undefined {
   const match = SOURCE_MAP_SUFFIX.exec(code);
@@ -116,13 +117,16 @@ export const compilePlugin: TransformPlugin = {
       const sourceMapDirective = trailingSourceMapDirective(code);
       if (ctx.target === "browser" && sourceMapDirective) {
         // Keep the compiler map out of intermediate browser plugins. The
-        // server-export strip stage restores it only when no hook is rewritten.
-        // This makes the real comment unambiguous even if a plugin copies its
-        // text into a string or appends executable code.
+        // server-export strip stage restores it only when the map-free compile
+        // output is unchanged and no hook is rewritten. This makes the real
+        // comment unambiguous even if a plugin copies its text into a string,
+        // appends code, or removes the hook itself.
         ctx.metadata.set(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA, sourceMapDirective);
         code = dropTrailingSourceMapDirective(code);
+        ctx.metadata.set(COMPILE_SOURCE_MAP_INPUT_METADATA, code);
       } else {
         ctx.metadata.delete(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
+        ctx.metadata.delete(COMPILE_SOURCE_MAP_INPUT_METADATA);
       }
 
       return code;

--- a/src/transforms/pipeline/stages/compile.ts
+++ b/src/transforms/pipeline/stages/compile.ts
@@ -15,6 +15,12 @@ const ReflectApply = Reflect.apply;
 const ReflectGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
 const SOURCE_MAP_SUFFIX =
   /(^|\r?\n)[\t ]*\/\/[#@][\t ]*sourceMappingURL=[^"'`\s]+[\t ]*(?:\r?\n)?$/;
+export const COMPILE_SOURCE_MAP_DIRECTIVE_METADATA = "compileSourceMapDirective";
+
+function trailingSourceMapDirective(code: string): string | undefined {
+  const match = SOURCE_MAP_SUFFIX.exec(code);
+  return match?.[0].slice((match[1] ?? "").length).trimEnd();
+}
 
 function appendBeforeSourceMap(code: string, addition: string): string {
   const match = SOURCE_MAP_SUFFIX.exec(code);
@@ -91,6 +97,12 @@ export const compilePlugin: TransformPlugin = {
       // TypeScript, so the output is plain JavaScript the module lexer can
       // anchor to. CSS output is not a module and is left alone.
       let code = loader === "css" ? result.code : await upgradeImportAssertions(result.code);
+      const sourceMapDirective = trailingSourceMapDirective(code);
+      if (sourceMapDirective) {
+        ctx.metadata.set(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA, sourceMapDirective);
+      } else {
+        ctx.metadata.delete(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
+      }
 
       const isMdx = ctx.filePath.endsWith(".mdx");
       if (

--- a/src/transforms/pipeline/stages/compile.ts
+++ b/src/transforms/pipeline/stages/compile.ts
@@ -13,6 +13,14 @@ const ESBUILD_SOURCE_DIAGNOSTIC = Symbol.for(
 const ObjectPrototypeHasOwnProperty = Object.prototype.hasOwnProperty;
 const ReflectApply = Reflect.apply;
 const ReflectGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
+const SOURCE_MAP_SUFFIX =
+  /(^|\r?\n)[\t ]*\/\/[#@][\t ]*sourceMappingURL=[^"'`\s]+[\t ]*(?:\r?\n)?$/;
+
+function appendBeforeSourceMap(code: string, addition: string): string {
+  const match = SOURCE_MAP_SUFFIX.exec(code);
+  if (match?.index === undefined) return code + addition;
+  return code.slice(0, match.index) + addition + match[0].slice((match[1] ?? "").length);
+}
 
 function readOwnDataProperty(value: unknown, key: PropertyKey): unknown {
   if (
@@ -90,7 +98,10 @@ export const compilePlugin: TransformPlugin = {
         /\bconst\s+MDXLayout\b/.test(code) &&
         !/export\s+\{[^}]*MDXLayout/.test(code)
       ) {
-        code += "\nexport { MDXLayout };\n";
+        // Keep esbuild's directive last. Browser server-hook stripping removes
+        // a stale compile map after rewriting, and a framework export appended
+        // after the directive would otherwise hide that suffix.
+        code = appendBeforeSourceMap(code, "\nexport { MDXLayout };\n");
       }
 
       return code;

--- a/src/transforms/pipeline/stages/compile.ts
+++ b/src/transforms/pipeline/stages/compile.ts
@@ -22,6 +22,10 @@ function trailingSourceMapDirective(code: string): string | undefined {
   return match?.[0].slice((match[1] ?? "").length).trimEnd();
 }
 
+function dropTrailingSourceMapDirective(code: string): string {
+  return code.replace(SOURCE_MAP_SUFFIX, "$1");
+}
+
 function appendBeforeSourceMap(code: string, addition: string): string {
   const match = SOURCE_MAP_SUFFIX.exec(code);
   if (match?.index === undefined) return code + addition;
@@ -97,13 +101,6 @@ export const compilePlugin: TransformPlugin = {
       // TypeScript, so the output is plain JavaScript the module lexer can
       // anchor to. CSS output is not a module and is left alone.
       let code = loader === "css" ? result.code : await upgradeImportAssertions(result.code);
-      const sourceMapDirective = trailingSourceMapDirective(code);
-      if (sourceMapDirective) {
-        ctx.metadata.set(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA, sourceMapDirective);
-      } else {
-        ctx.metadata.delete(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
-      }
-
       const isMdx = ctx.filePath.endsWith(".mdx");
       if (
         isMdx &&
@@ -114,6 +111,18 @@ export const compilePlugin: TransformPlugin = {
         // a stale compile map after rewriting, and a framework export appended
         // after the directive would otherwise hide that suffix.
         code = appendBeforeSourceMap(code, "\nexport { MDXLayout };\n");
+      }
+
+      const sourceMapDirective = trailingSourceMapDirective(code);
+      if (ctx.target === "browser" && sourceMapDirective) {
+        // Keep the compiler map out of intermediate browser plugins. The
+        // server-export strip stage restores it only when no hook is rewritten.
+        // This makes the real comment unambiguous even if a plugin copies its
+        // text into a string or appends executable code.
+        ctx.metadata.set(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA, sourceMapDirective);
+        code = dropTrailingSourceMapDirective(code);
+      } else {
+        ctx.metadata.delete(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
       }
 
       return code;


### PR DESCRIPTION
## Summary

- detach the compile-generated browser source map before intermediate plugins run
- restore it only when the map-free compile output remains byte-for-byte unchanged
- omit stale inline and external maps whenever a hook or intermediate stage changes the module
- preserve authored source-map-like strings and untouched-module maps

## Root cause

The development compile stage embeds its input in `sourcesContent` before the browser server-export strip runs. The executable hook and its dependencies were removed, but the stale map still shipped the complete pre-strip source to browser devtools.

Suffix matching was insufficient because MDX and custom pipeline stages can append code after esbuild emits the map. Searching for recorded map text was ambiguous when a plugin copied the same text into a client string. Restoring based only on the strip stage returning its input unchanged was also unsafe when an intermediate plugin had already removed or renamed the hook.

The compile stage now detaches its browser map and records both the directive and the exact map-free compile output. The browser strip stage restores the directive only when its input is still that exact output and it performs no rewrite. Any intermediate change or server-hook rewrite withholds the stale map.

## RED-GREEN TDD

- RED: a real development compile then strip left an inline map whose decoded `sourcesContent` contained the server-only value and hook body
- GREEN: the transformed browser output no longer contains that map or server-only value
- RED: external maps, compiled MDX, a `COMPILE + 0.5` append, a copied-directive string, and an intermediate hook-removal plugin exposed suffix, text-search, and restoration gaps
- GREEN: the map is structurally detached before intermediate plugins and restored only for unchanged hook-free output
- CONTROL: source-map-like authored strings survive, and an untouched no-hook development module keeps its map

## Verification

- focused browser strip suite: 83/83 steps passed
- compile plus browser strip suites: 104/104 steps passed
- full `src/transforms` suite: 157 files and 2,550 steps passed
- changed-file format, lint, type-check, and diff checks passed

This changes no Studio UI.

Closes veryfront/veryfront-issue-inbox#552.