### PR TITLE
docs: document CSS-in-JS SSR limitation

### DIFF
--- a/docs/getting-started/create-frontend.md
+++ b/docs/getting-started/create-frontend.md
@@ -72,6 +72,21 @@ time. Your renderer owns parsing, sanitization, and link policy. See
 [Render Markdown in chat](../guides/chat-ui.md#render-markdown-in-chat) to swap
 in a different renderer.
 
+## Choose SSR-safe styles
+
+Use build-time CSS when the initial server-rendered page must be styled. Good
+options include Tailwind CSS, CSS Modules, and other tools that emit CSS during
+the build.
+
+Veryfront does not currently collect styles from runtime CSS-in-JS libraries
+such as Emotion or styled-components during server rendering. A generated class
+name can appear in the server HTML without its CSS rule because styles inserted
+through `document.head` are not added to the response. This can leave the page
+unstyled or cause a flash of unstyled content before client hydration.
+
+Do not rely on runtime CSS-in-JS for SSR styling until Veryfront provides a
+server style-collection and insertion API.
+
 ## Verify it worked
 
 Open [http://localhost:3000](http://localhost:3000), send a message, and confirm:

--- a/docs/getting-started/create-frontend.md
+++ b/docs/getting-started/create-frontend.md
@@ -80,8 +80,8 @@ the build.
 
 Veryfront does not currently collect styles from runtime CSS-in-JS libraries
 such as Emotion or styled-components during server rendering. A generated class
-name can appear in the server HTML without its CSS rule because styles inserted
-through `document.head` are not added to the response. This can leave the page
+name may appear in the server HTML without its CSS rule because styles inserted
+through `document.head` are not added to the response. This may leave the page
 unstyled or cause a flash of unstyled content before client hydration.
 
 Do not rely on runtime CSS-in-JS for SSR styling until Veryfront provides a


### PR DESCRIPTION
## Summary

- document that runtime CSS-in-JS styles are not collected during server rendering
- explain the unstyled-content and hydration risks
- recommend build-time CSS until Veryfront provides a server style-collection and insertion API

This implements the recorded docs-only decision on the issue. It does not change runtime behavior.

## Verification

- deno fmt --check docs/getting-started/create-frontend.md
- git diff --check
- deno task docs:validate (all validators and tests passed; two pre-existing guide warnings remain)

Closes veryfront/veryfront-issue-inbox#215