### PR TITLE
fix(ssr): queue concurrent dev transforms instead of failing (issue 113 part 3)

### DIFF
--- a/src/modules/react-loader/component-loader.ts
+++ b/src/modules/react-loader/component-loader.ts
@@ -59,7 +59,6 @@ export async function loadModuleFromSource(
           dependencyPinningDependencies: dependencySnapshot.dependencies,
           dependencyPinningSource,
           mode: options?.mode,
-          signal: options?.signal,
         });
 
         return await loader.loadRawModule(filePath, source);

--- a/src/modules/react-loader/component-loader.ts
+++ b/src/modules/react-loader/component-loader.ts
@@ -59,6 +59,7 @@ export async function loadModuleFromSource(
           dependencyPinningDependencies: dependencySnapshot.dependencies,
           dependencyPinningSource,
           mode: options?.mode,
+          signal: options?.signal,
         });
 
         return await loader.loadRawModule(filePath, source);

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   acquireTransformSlot,
@@ -168,6 +168,33 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         releaseTransformSlot(projectId);
       } finally {
         globalThis.setTimeout = originalSetTimeout;
+        if (previousLimit === undefined) {
+          Deno.env.delete("SSR_TRANSFORM_PER_PROJECT_LIMIT");
+        } else {
+          Deno.env.set("SSR_TRANSFORM_PER_PROJECT_LIMIT", previousLimit);
+        }
+        resetState();
+      }
+    });
+
+    it("should reject and remove a queued acquisition when its signal aborts", async () => {
+      const previousLimit = Deno.env.get("SSR_TRANSFORM_PER_PROJECT_LIMIT");
+      Deno.env.set("SSR_TRANSFORM_PER_PROJECT_LIMIT", "1");
+      resetState();
+
+      try {
+        const projectId = "test-abort-queued-acquire";
+        const controller = new AbortController();
+        assertEquals(acquireTransformSlot(projectId), true);
+
+        const waiter = tryAcquireTransformSlot(projectId, 10_000, false, controller.signal);
+        controller.abort(new DOMException("render cancelled", "AbortError"));
+        releaseTransformSlot(projectId);
+
+        await assertRejects(() => waiter, DOMException, "render cancelled");
+        assertEquals(await tryAcquireTransformSlot(projectId, 0), true);
+        releaseTransformSlot(projectId);
+      } finally {
         if (previousLimit === undefined) {
           Deno.env.delete("SSR_TRANSFORM_PER_PROJECT_LIMIT");
         } else {

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -79,7 +79,10 @@ const projectTransformCounts = new Map<string, number>();
 
 type ProjectTransformWaiter = {
   resolve: (acquired: boolean) => void;
+  reject: (reason?: unknown) => void;
   timeoutId: ReturnType<typeof setTimeout>;
+  signal?: AbortSignal;
+  onAbort?: () => void;
 };
 
 const projectTransformWaiters = new Map<string, ProjectTransformWaiter[]>();
@@ -143,7 +146,24 @@ function settleProjectTransformWaiter(
 ): void {
   removeProjectTransformWaiter(projectId, waiter);
   clearTimeout(waiter.timeoutId);
+  if (waiter.signal && waiter.onAbort) {
+    waiter.signal.removeEventListener("abort", waiter.onAbort);
+  }
   waiter.resolve(acquired);
+}
+
+function abortProjectTransformWaiter(
+  projectId: string,
+  waiter: ProjectTransformWaiter,
+): void {
+  removeProjectTransformWaiter(projectId, waiter);
+  clearTimeout(waiter.timeoutId);
+  if (waiter.signal && waiter.onAbort) {
+    waiter.signal.removeEventListener("abort", waiter.onAbort);
+  }
+  waiter.reject(
+    waiter.signal?.reason ?? new DOMException("The operation was aborted", "AbortError"),
+  );
 }
 
 function wakeNextProjectTransformWaiter(projectId: string): void {
@@ -161,8 +181,7 @@ function wakeNextProjectTransformWaiter(projectId: string): void {
   if (!waiter) return;
 
   projectTransformCounts.set(projectId, current + 1);
-  clearTimeout(waiter.timeoutId);
-  waiter.resolve(true);
+  settleProjectTransformWaiter(projectId, waiter, true);
 }
 
 function rejectProjectTransformWaiters(projectId: string): void {
@@ -171,8 +190,7 @@ function rejectProjectTransformWaiters(projectId: string): void {
 
   projectTransformWaiters.delete(projectId);
   for (const waiter of queue) {
-    clearTimeout(waiter.timeoutId);
-    waiter.resolve(false);
+    settleProjectTransformWaiter(projectId, waiter, false);
   }
 }
 
@@ -184,31 +202,41 @@ function rejectAllProjectTransformWaiters(): void {
 /**
  * Try to acquire a project-level transform slot with retries.
  * Waits up to timeoutMs for a slot to become available.
- * Returns true if acquired, false if timed out.
+ * Returns true if acquired, false if timed out, and rejects with the abort
+ * reason when the caller's signal aborts while queued.
  */
 export async function tryAcquireTransformSlot(
   projectId: string,
   timeoutMs: number,
   bypass = false,
+  signal?: AbortSignal,
 ): Promise<boolean> {
+  signal?.throwIfAborted();
   if (acquireTransformSlot(projectId, bypass)) return true;
   if (timeoutMs <= 0) return false;
 
-  return new Promise<boolean>((resolve) => {
+  return new Promise<boolean>((resolve, reject) => {
     const waiter: ProjectTransformWaiter = {
       resolve,
+      reject,
       timeoutId: setTimeout(() => {
         settleProjectTransformWaiter(projectId, waiter, false);
       }, timeoutMs),
+      signal,
     };
 
     const queue = projectTransformWaiters.get(projectId);
     if (queue) {
       queue.push(waiter);
-      return;
+    } else {
+      projectTransformWaiters.set(projectId, [waiter]);
     }
 
-    projectTransformWaiters.set(projectId, [waiter]);
+    if (signal) {
+      waiter.onAbort = () => abortProjectTransformWaiter(projectId, waiter);
+      signal.addEventListener("abort", waiter.onAbort, { once: true });
+      if (signal.aborted) waiter.onAbort();
+    }
   });
 }
 

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -17,7 +17,7 @@ import { registerCache } from "#veryfront/utils/memory/index.ts";
 import { isKeyForProject, registerMapCache } from "#veryfront/cache/keys.ts";
 import type { CacheStatsSource } from "#veryfront/cache/registry.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
-import { rendererLogger } from "#veryfront/utils";
+import { rendererLogger, throwIfAborted } from "#veryfront/utils";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import {
   getMaxConcurrentTransforms,
@@ -211,7 +211,7 @@ export async function tryAcquireTransformSlot(
   bypass = false,
   signal?: AbortSignal,
 ): Promise<boolean> {
-  signal?.throwIfAborted();
+  throwIfAborted(signal);
   if (acquireTransformSlot(projectId, bypass)) return true;
   if (timeoutMs <= 0) return false;
 

--- a/src/modules/react-loader/ssr-module-loader/concurrency/index.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { Semaphore } from "./semaphore.ts";
+export type { SemaphoreAcquireReport } from "./semaphore.ts";

--- a/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.test.ts
@@ -166,6 +166,35 @@ describe("modules/react-loader/ssr-module-loader/concurrency/semaphore", () => {
       await Promise.all([p1, p2]);
     });
 
+    it("should report the queue depth a timed-out waiter observed", async () => {
+      const sem = new Semaphore(1);
+
+      await sem.tryAcquire();
+      const report = await sem.tryAcquireWithReport(5);
+
+      assertEquals(report.acquired, false);
+      assertEquals(report.waiting, 1, "the waiter that timed out must count itself");
+      assertEquals(sem.waiting, 0, "a timed-out waiter still leaves the queue");
+
+      sem.release();
+      assertEquals(sem.available, 1);
+    });
+
+    it("should report every queued waiter present when an acquire times out", async () => {
+      const sem = new Semaphore(1);
+
+      await sem.tryAcquire();
+      const firstReport = sem.tryAcquireWithReport(5);
+      const secondReport = sem.tryAcquireWithReport(200);
+      assertEquals(sem.waiting, 2);
+
+      assertEquals((await firstReport).waiting, 2, "both queued waiters must be counted");
+
+      sem.release();
+      assertEquals((await secondReport).acquired, true);
+      sem.release();
+    });
+
     it("should remove timed-out waiters from queue", async () => {
       const sem = new Semaphore(1);
 

--- a/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
@@ -1,8 +1,19 @@
 /** Default timeout for acquiring a semaphore permit (ms) */
 const DEFAULT_ACQUIRE_TIMEOUT_MS = 100;
 
+/** Result of an acquire attempt, with the queue depth it observed. */
+export interface SemaphoreAcquireReport {
+  acquired: boolean;
+  /**
+   * Queue depth at the moment the attempt settled, counting the waiter itself.
+   * A timed-out waiter leaves the queue before its caller resumes, so reading
+   * {@link Semaphore.waiting} afterwards understates the real depth.
+   */
+  waiting: number;
+}
+
 interface SemaphoreWaiter {
-  resolve: (acquired: boolean) => void;
+  resolve: (report: SemaphoreAcquireReport) => void;
   reject: (reason?: unknown) => void;
   settled: boolean;
   timeoutId?: ReturnType<typeof setTimeout>;
@@ -24,6 +35,17 @@ export class Semaphore {
     timeoutMs = DEFAULT_ACQUIRE_TIMEOUT_MS,
     options: { signal?: AbortSignal } = {},
   ): Promise<boolean> {
+    return this.tryAcquireWithReport(timeoutMs, options).then((report) => report.acquired);
+  }
+
+  /**
+   * Acquire a permit and report the queue depth the attempt observed. Use this
+   * instead of {@link tryAcquire} when a failure needs an accurate diagnostic.
+   */
+  tryAcquireWithReport(
+    timeoutMs = DEFAULT_ACQUIRE_TIMEOUT_MS,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<SemaphoreAcquireReport> {
     const { signal } = options;
     if (signal?.aborted) {
       return Promise.reject(
@@ -33,18 +55,18 @@ export class Semaphore {
 
     if (this.permits > 0) {
       this.permits--;
-      return Promise.resolve(true);
+      return Promise.resolve({ acquired: true, waiting: this.waitQueue.length });
     }
 
     if (timeoutMs <= 0) {
-      return Promise.resolve(false);
+      return Promise.resolve({ acquired: false, waiting: this.waitQueue.length });
     }
 
     if (this.waitQueue.length >= this.maxQueueSize) {
-      return Promise.resolve(false);
+      return Promise.resolve({ acquired: false, waiting: this.waitQueue.length });
     }
 
-    return new Promise<boolean>((resolve, reject) => {
+    return new Promise<SemaphoreAcquireReport>((resolve, reject) => {
       const waiter: SemaphoreWaiter = {
         resolve,
         reject,
@@ -82,9 +104,12 @@ export class Semaphore {
         waiter.timeoutId = setTimeout(() => {
           if (waiter.settled) return;
           waiter.settled = true;
+          // Read the depth before this waiter leaves the queue, otherwise the
+          // last waiter standing reports an empty queue it was still part of.
+          const waiting = this.waitQueue.length;
           removeWaiter();
           cleanup();
-          resolve(false);
+          resolve({ acquired: false, waiting });
         }, timeoutMs);
       }
 
@@ -101,7 +126,7 @@ export class Semaphore {
       if (next.signal && next.onAbort) {
         next.signal.removeEventListener("abort", next.onAbort);
       }
-      next.resolve(true);
+      next.resolve({ acquired: true, waiting: this.waitQueue.length });
       return;
     }
 

--- a/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
@@ -5,9 +5,10 @@ const DEFAULT_ACQUIRE_TIMEOUT_MS = 100;
 export interface SemaphoreAcquireReport {
   acquired: boolean;
   /**
-   * Queue depth at the moment the attempt settled, counting the waiter itself.
+   * For a timed-out waiter, queue depth at the moment it settled, including
+   * that waiter. Other reports count waiters that remain queued.
    * A timed-out waiter leaves the queue before its caller resumes, so reading
-   * {@link Semaphore.waiting} afterwards understates the real depth.
+   * {@link Semaphore.waiting} afterwards understates the depth it observed.
    */
   waiting: number;
 }

--- a/src/modules/react-loader/ssr-module-loader/constants.ts
+++ b/src/modules/react-loader/ssr-module-loader/constants.ts
@@ -62,6 +62,20 @@ export function resetCachedTransformLimits(): void {
 // dependency; this remains well below the module-load and render hard caps.
 export const TRANSFORM_ACQUIRE_TIMEOUT_MS = 5_000;
 
+// The dev server is single tenant, so shedding load protects nobody: a burst of
+// concurrent refreshes on a cold cache must queue and stay slow instead of
+// failing the render. The wait stays below the module-load hard cap so a wedged
+// transform still surfaces as a load failure.
+export const TRANSFORM_ACQUIRE_TIMEOUT_DEV_MS = 30_000;
+
+/**
+ * Time a transform waits for capacity. Dev queues; production sheds load so one
+ * tenant cannot stall the others.
+ */
+export function getTransformAcquireTimeoutMs(dev: boolean): number {
+  return dev ? TRANSFORM_ACQUIRE_TIMEOUT_DEV_MS : TRANSFORM_ACQUIRE_TIMEOUT_MS;
+}
+
 // Bound waits on a shared cold transform leader. If the leader promise never
 // settles, callers should detach and allow later requests to retry cleanly.
 export const TRANSFORM_IN_PROGRESS_WAIT_TIMEOUT_MS = 45_000;

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -13,7 +13,12 @@ import { join } from "#veryfront/compat/path";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 import { clearSSRModuleCache, clearSSRModuleCacheForProject, SSRModuleLoader } from "./index.ts";
 import { __ssrModuleLoaderInternals } from "./loader.ts";
-import { globalCrossProjectCache, globalInProgress, globalModuleCache } from "./cache/memory.ts";
+import {
+  failedComponents,
+  globalCrossProjectCache,
+  globalInProgress,
+  globalModuleCache,
+} from "./cache/memory.ts";
 import {
   TRANSFORM_IN_PROGRESS_STALE_EVICTION_MS,
   TRANSFORM_IN_PROGRESS_WAIT_TIMEOUT_MS,
@@ -121,6 +126,28 @@ function createProxyProjectAdapter(files: Record<string, string>): RuntimeAdapte
 }
 
 describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, () => {
+  it("does not count request cancellation as a component failure", async () => {
+    clearSSRModuleCache();
+    const controller = new AbortController();
+    const reason = new DOMException("render cancelled", "AbortError");
+    controller.abort(reason);
+    const loader = new SSRModuleLoader({
+      projectDir: "/project",
+      projectId: "cancelled-project",
+      contentSourceId: "local-main",
+      adapter: denoAdapter,
+      dev: true,
+      signal: controller.signal,
+    });
+
+    await assertRejects(
+      () => loader.loadRawModule("/project/Page.tsx", "export default () => null"),
+      Error,
+      "render cancelled",
+    );
+    assertEquals(failedComponents.size, 0);
+  });
+
   it("isolates cache by projectId", async () => {
     clearSSRModuleCache();
 
@@ -1240,6 +1267,43 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       await time.tickAsync(TRANSFORM_IN_PROGRESS_WAIT_TIMEOUT_MS);
       await waitRejected;
       assertEquals(globalInProgress.get(key), pending);
+    } finally {
+      globalInProgress.delete(key);
+    }
+  });
+
+  it("cancels an in-progress transform only after its final observer detaches", async () => {
+    const key = "test:observed-shared-transform";
+    const pending = new Promise<ModuleCacheEntry>(() => {});
+    globalInProgress.set(key, pending);
+    const sharedSignal = __ssrModuleLoaderInternals.registerInProgressTransformObservers(
+      key,
+      pending,
+    );
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+
+    try {
+      const first = __ssrModuleLoaderInternals.waitForInProgressTransform(
+        pending,
+        "/app/SharedLayout.tsx",
+        firstController.signal,
+      );
+      const second = __ssrModuleLoaderInternals.waitForInProgressTransform(
+        pending,
+        "/app/SharedLayout.tsx",
+        secondController.signal,
+      );
+
+      firstController.abort(new DOMException("first render cancelled", "AbortError"));
+      await assertRejects(() => first, Error, "first render cancelled");
+      assertEquals(sharedSignal.aborted, false);
+      assertEquals(globalInProgress.get(key), pending);
+
+      secondController.abort(new DOMException("second render cancelled", "AbortError"));
+      await assertRejects(() => second, Error, "second render cancelled");
+      assertEquals(sharedSignal.aborted, true);
+      assertEquals(globalInProgress.has(key), false);
     } finally {
       globalInProgress.delete(key);
     }

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -148,6 +148,36 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     assertEquals(failedComponents.size, 0);
   });
 
+  it("normalizes an aborted host signal without a reason", async () => {
+    clearSSRModuleCache();
+    const signal = {
+      aborted: true,
+      reason: undefined,
+      throwIfAborted: () => {
+        throw undefined;
+      },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    } as unknown as AbortSignal;
+    const loader = new SSRModuleLoader({
+      projectDir: "/project",
+      projectId: "cancelled-host-project",
+      contentSourceId: "local-main",
+      adapter: denoAdapter,
+      dev: true,
+      signal,
+    });
+
+    const error = await assertRejects(
+      () => loader.loadRawModule("/project/Page.tsx", "export default () => null"),
+      DOMException,
+      "The operation was aborted",
+    );
+    assert(error instanceof DOMException);
+    assertEquals(error.name, "AbortError");
+    assertEquals(failedComponents.size, 0);
+  });
+
   it("isolates cache by projectId", async () => {
     clearSSRModuleCache();
 

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -250,9 +250,7 @@ export class SSRModuleLoader {
 
     try {
       if (semaphore) {
-        const report = await semaphore.tryAcquireWithReport(acquireTimeoutMs, {
-          signal: this.options.signal,
-        });
+        const report = await semaphore.tryAcquireWithReport(acquireTimeoutMs);
         semaphoreAcquired = report.acquired;
         if (!semaphoreAcquired) {
           throw createTransformCapacityError(

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -92,6 +92,46 @@ function deleteInProgressTransformIfCurrent(
   return globalInProgress.delete(key);
 }
 
+interface InProgressTransformObserverState {
+  key: string;
+  transformPromise: Promise<ModuleCacheEntry>;
+  controller: AbortController;
+  observerCount: number;
+  settled: boolean;
+}
+
+const inProgressTransformObservers = new WeakMap<
+  Promise<ModuleCacheEntry>,
+  InProgressTransformObserverState
+>();
+
+function signalAbortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+}
+
+function registerInProgressTransformObservers(
+  key: string,
+  transformPromise: Promise<ModuleCacheEntry>,
+): AbortSignal {
+  const existing = inProgressTransformObservers.get(transformPromise);
+  if (existing) return existing.controller.signal;
+
+  const state: InProgressTransformObserverState = {
+    key,
+    transformPromise,
+    controller: new AbortController(),
+    observerCount: 0,
+    settled: false,
+  };
+  inProgressTransformObservers.set(transformPromise, state);
+  return state.controller.signal;
+}
+
+function markInProgressTransformSettled(transformPromise: Promise<ModuleCacheEntry>): void {
+  const state = inProgressTransformObservers.get(transformPromise);
+  if (state) state.settled = true;
+}
+
 function shouldRetryRejectedInProgressTransform(rejectedLeaderCount: number): boolean {
   return rejectedLeaderCount <= MAX_REJECTED_IN_PROGRESS_RETRIES;
 }
@@ -153,6 +193,7 @@ export const __ssrModuleLoaderInternals = {
   deleteInProgressTransformIfCurrent,
   getMdxEsmCacheVariant,
   publishTransformCacheIfCurrent,
+  registerInProgressTransformObservers,
   scheduleStaleInProgressTransformEviction,
   shouldRetryRejectedInProgressTransform,
   waitForInProgressTransform,
@@ -161,20 +202,56 @@ export const __ssrModuleLoaderInternals = {
 async function waitForInProgressTransform(
   transformPromise: Promise<ModuleCacheEntry>,
   filePath: string,
+  signal?: AbortSignal,
 ): Promise<ModuleCacheEntry> {
+  const observerState = inProgressTransformObservers.get(transformPromise);
+  if (observerState) observerState.observerCount++;
+
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let releaseReason: unknown;
+  let removeAbortListener: (() => void) | undefined;
   try {
-    return await Promise.race([
+    const waits: Promise<ModuleCacheEntry>[] = [
       transformPromise,
       new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new InProgressTransformWaitTimeoutError(filePath)),
-          TRANSFORM_IN_PROGRESS_WAIT_TIMEOUT_MS,
-        );
+        timeoutId = setTimeout(() => {
+          releaseReason = new InProgressTransformWaitTimeoutError(filePath);
+          reject(releaseReason);
+        }, TRANSFORM_IN_PROGRESS_WAIT_TIMEOUT_MS);
       }),
-    ]);
+    ];
+
+    if (signal) {
+      waits.push(
+        new Promise<never>((_, reject) => {
+          const onAbort = (): void => {
+            releaseReason = signalAbortReason(signal);
+            reject(releaseReason);
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+          removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+          if (signal.aborted) onAbort();
+        }),
+      );
+    }
+
+    return await Promise.race(waits);
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
+    removeAbortListener?.();
+    if (observerState) {
+      observerState.observerCount--;
+      if (
+        observerState.observerCount === 0 && !observerState.settled &&
+        !observerState.controller.signal.aborted
+      ) {
+        observerState.controller.abort(releaseReason);
+        deleteInProgressTransformIfCurrent(
+          observerState.key,
+          observerState.transformPromise,
+        );
+      }
+    }
   }
 }
 
@@ -209,9 +286,9 @@ export class SSRModuleLoader {
   constructor(private options: SSRModuleLoaderOptions) {
     this.cache = new SSRCacheManager(options);
     this.depValidator = new SSRDependencyValidator(
-      (filePath, source, depth, dependencyHashCache) =>
-        this.transformWithDependencies(filePath, source, depth, dependencyHashCache),
-      (crossImport) => this.transformCrossProjectImport(crossImport),
+      (filePath, source, depth, dependencyHashCache, signal) =>
+        this.transformWithDependencies(filePath, source, depth, dependencyHashCache, signal),
+      (crossImport, signal) => this.transformCrossProjectImport(crossImport, signal),
       options.adapter,
       options.projectDir,
     );
@@ -221,6 +298,7 @@ export class SSRModuleLoader {
     filePath: string,
     mode: TransformCapacityErrorMode,
     operation: () => Promise<T>,
+    signal?: AbortSignal,
   ): Promise<T> {
     const useSemaphore = getMaxConcurrentTransforms() > 0;
     const projectId = this.options.projectId;
@@ -250,7 +328,7 @@ export class SSRModuleLoader {
 
     try {
       if (semaphore) {
-        const report = await semaphore.tryAcquireWithReport(acquireTimeoutMs);
+        const report = await semaphore.tryAcquireWithReport(acquireTimeoutMs, { signal });
         semaphoreAcquired = report.acquired;
         if (!semaphoreAcquired) {
           throw createTransformCapacityError(
@@ -261,6 +339,7 @@ export class SSRModuleLoader {
         }
       }
 
+      signal?.throwIfAborted();
       return await operation();
     } finally {
       if (semaphore && semaphoreAcquired) {
@@ -476,6 +555,7 @@ export class SSRModuleLoader {
             source,
             0,
             dependencyHashCache,
+            this.options.signal,
           );
           this.throwMissingDependencies(filePath);
 
@@ -500,6 +580,7 @@ export class SSRModuleLoader {
               source,
               0,
               retryDependencyHashCache,
+              this.options.signal,
             );
             this.throwMissingDependencies(filePath);
             const mod = await this.importModuleFromCacheEntry(filePath, fileName, retryCacheEntry);
@@ -508,7 +589,9 @@ export class SSRModuleLoader {
             return mod;
           }
         } catch (error) {
-          this.circuitBreaker.recordFailure(circuitKey);
+          const requestCancelled = this.options.signal?.aborted === true &&
+            error === this.options.signal.reason;
+          if (!requestCancelled) this.circuitBreaker.recordFailure(circuitKey);
           throw error;
         }
       },
@@ -530,13 +613,14 @@ export class SSRModuleLoader {
 
   private async transformCrossProjectImport(
     crossProjectImport: CrossProjectImport,
+    signal?: AbortSignal,
   ): Promise<string> {
     return transformCrossProjectImportFlow({
       crossProjectImport,
       options: this.options,
       cache: this.cache,
       withTransformCapacity: (syntheticFilePath, operation) =>
-        this.withTransformCapacity(syntheticFilePath, "plain", operation),
+        this.withTransformCapacity(syntheticFilePath, "plain", operation, signal),
     });
   }
 
@@ -545,12 +629,13 @@ export class SSRModuleLoader {
     source?: string,
     depth: number = 0,
     dependencyHashCache: DependencyHashCache = createDependencyHashCache(),
+    signal?: AbortSignal,
   ): Promise<ModuleCacheEntry> {
     const fileName = filePath.split("/").pop() || filePath;
 
     return withSpan(
       SpanNames.SSR_TRANSFORM_DEPENDENCIES,
-      () => this.doTransformWithDependencies(filePath, source, depth, dependencyHashCache),
+      () => this.doTransformWithDependencies(filePath, source, depth, dependencyHashCache, signal),
       {
         "ssr.file": fileName,
         "ssr.depth": depth,
@@ -563,7 +648,9 @@ export class SSRModuleLoader {
     source?: string,
     depth: number = 0,
     dependencyHashCache: DependencyHashCache = createDependencyHashCache(),
+    observerSignal?: AbortSignal,
   ): Promise<ModuleCacheEntry> {
+    observerSignal?.throwIfAborted();
     if (depth > MAX_TRANSFORM_DEPTH) {
       logger.warn("Max transform depth exceeded", {
         file: logPath(filePath),
@@ -607,7 +694,7 @@ export class SSRModuleLoader {
         )
       ) {
         globalModuleCache.set(filePathCacheKey, cachedEntry);
-        await this.depValidator.ensureDependenciesExist(code, filePath, depth);
+        await this.depValidator.ensureDependenciesExist(code, filePath, depth, observerSignal);
         return cachedEntry;
       }
     }
@@ -642,7 +729,7 @@ export class SSRModuleLoader {
 
             logger.debug("Redis cache hit", { file: logPath(filePath) });
 
-            await this.depValidator.ensureDependenciesExist(code, filePath, depth);
+            await this.depValidator.ensureDependenciesExist(code, filePath, depth, observerSignal);
             return entry;
           }
           // writeCacheFile returned false — fall through to fresh transform
@@ -679,7 +766,7 @@ export class SSRModuleLoader {
           cachedPath: mdxCacheResult.path.slice(-60),
         });
 
-        await this.depValidator.ensureDependenciesExist(code, filePath, depth);
+        await this.depValidator.ensureDependenciesExist(code, filePath, depth, observerSignal);
         return entry;
       }
 
@@ -699,10 +786,11 @@ export class SSRModuleLoader {
       try {
         return await withSpan(
           SpanNames.SSR_WAIT_IN_PROGRESS,
-          () => waitForInProgressTransform(existingTransform, filePath),
+          () => waitForInProgressTransform(existingTransform, filePath, observerSignal),
           { "ssr.file": filePath.split("/").pop() || filePath },
         );
       } catch (error) {
+        if (observerSignal?.aborted) throw signalAbortReason(observerSignal);
         if (error instanceof InProgressTransformWaitTimeoutError) {
           logger.warn("In-progress transform wait timed out", {
             file: logPath(filePath),
@@ -749,209 +837,225 @@ export class SSRModuleLoader {
       });
     });
     globalInProgress.set(inProgressKey, transformPromise);
+    const sharedSignal = registerInProgressTransformObservers(inProgressKey, transformPromise);
+    const leaderWait = waitForInProgressTransform(
+      transformPromise,
+      filePath,
+      observerSignal,
+    );
     const staleEvictionTimer = scheduleStaleInProgressTransformEviction(
       inProgressKey,
       transformPromise,
       filePath,
     );
 
-    try {
-      let parseResult = await parseLocalImports(
-        code,
-        filePath,
-        this.options.projectDir,
-        this.options.adapter,
-      );
-
-      // Register CSS imports for later inclusion in HTML output.
-      // CSS files are not JS modules — skip them in the dependency graph.
-      for (const cssImport of parseResult.cssImports) {
-        registerCSSImport(cssImport.absolutePath);
-      }
-
-      if (parseResult.missing.length > 0) {
-        this.depValidator.missingDependencies.push(...parseResult.missing);
-      }
-
-      if (parseResult.imports.length > 0) {
-        const { validImports, missingImports: preflightMissing } = await preflightLocalImports(
-          parseResult.imports,
-          filePath,
-          this.options.adapter.fs,
-        );
-
-        if (preflightMissing.length > 0) {
-          logger.warn("Pre-flight: some dependencies missing, skipping them", {
-            file: logPath(filePath),
-            missing: preflightMissing.map((m) => m.specifier),
-            depth,
-          });
-          this.depValidator.missingDependencies.push(...preflightMissing);
-          parseResult = { ...parseResult, imports: validImports };
-        }
-      }
-
-      // Process recursive imports FIRST, without holding a project slot.
-      // Each recursive child acquires its own slot for its own transform only.
-      // This prevents hierarchical deadlock where parent holds a slot while
-      // children also need slots (10 batch x 2 depth = 21 slots, but limit is 17).
-      const localFs = createFileSystem();
-
-      const localImportPaths = await this.depValidator.processLocalImports(
-        parseResult.imports,
-        filePath,
-        depth,
-        localFs,
-        dependencyHashCache,
-      );
-
-      const crossProjectPaths = await this.depValidator.processCrossProjectImports(
-        parseResult.crossProjectImports,
-        filePath,
-      );
-
-      // Hold project slots only around the actual transform and file write.
-      const entry = await this.withTransformCapacity(filePath, "build", async () => {
-        const projectId = this.options.projectId;
-        const transformOpts: TransformOptions = {
-          projectId,
-          dev: this.options.dev,
-          ssr: true,
-          apiBaseUrl: this.options.apiBaseUrl,
-          moduleServerOrigin: this.options.moduleServerOrigin,
-          reactVersion: this.options.reactVersion,
-          serverExternalPackages: this.options.serverExternalPackages,
-          dependencyHashCache,
-          dependencyPinningCacheKey: this.options.dependencyPinningCacheKey,
-          dependencyPinningDependencies: this.options.dependencyPinningDependencies,
-          dependencyPinningSource: this.options.dependencyPinningSource,
-        };
-
-        let transformed = await withSpan(
-          SpanNames.SSR_TRANSFORM_SINGLE,
-          () =>
-            transformToESM(
-              code,
-              filePath,
-              this.options.projectDir,
-              this.options.adapter,
-              transformOpts,
-            ),
-          { "ssr.file": filePath.split("/").pop() || filePath },
-        );
-
-        for (const [specifier, tempPath] of crossProjectPaths.entries()) {
-          transformed = await rewriteCrossProjectImport(transformed, specifier, tempPath);
-        }
-
-        transformed = await rewriteLocalImports(
-          transformed,
-          localImportPaths,
+    const runTransformLeader = async (): Promise<void> => {
+      try {
+        sharedSignal.throwIfAborted();
+        let parseResult = await parseLocalImports(
+          code,
           filePath,
           this.options.projectDir,
+          this.options.adapter,
         );
 
-        transformed = await resolveVfModuleImports(transformed, {
-          filePath,
-          projectId: this.options.projectId,
-          contentSourceId: this.options.contentSourceId!,
-          adapter: this.options.adapter,
-          projectDir: this.options.projectDir,
-          reactVersion: this.options.reactVersion,
-          moduleServerOrigin: this.options.moduleServerOrigin,
-          dependencyPinningCacheKey: this.options.dependencyPinningCacheKey,
-          dependencyPinningDependencies: this.options.dependencyPinningDependencies,
-          dependencyPinningSource: this.options.dependencyPinningSource,
-        });
+        // Register CSS imports for later inclusion in HTML output.
+        // CSS files are not JS modules — skip them in the dependency graph.
+        for (const cssImport of parseResult.cssImports) {
+          registerCSSImport(cssImport.absolutePath);
+        }
 
-        // Ensure HTTP bundles exist for this transform (handles nested bundle deps)
-        const bundlePaths = extractHttpBundlePaths(transformed);
-        if (bundlePaths.length > 0) {
-          const cacheDir = getHttpBundleCacheDir();
-          const failed = await ensureHttpBundlesExist(bundlePaths, cacheDir);
-          if (failed.length > 0) {
-            logger.error("Unrecoverable HTTP bundles", {
+        if (parseResult.missing.length > 0) {
+          this.depValidator.missingDependencies.push(...parseResult.missing);
+        }
+
+        if (parseResult.imports.length > 0) {
+          const { validImports, missingImports: preflightMissing } = await preflightLocalImports(
+            parseResult.imports,
+            filePath,
+            this.options.adapter.fs,
+          );
+
+          if (preflightMissing.length > 0) {
+            logger.warn("Pre-flight: some dependencies missing, skipping them", {
               file: logPath(filePath),
-              failed,
-              totalBundles: bundlePaths.length,
-              cacheDir,
-              source: "fresh-transform",
+              missing: preflightMissing.map((m) => m.specifier),
+              depth,
             });
-            throw toError(
-              createError({
-                type: "build",
-                message: `Missing HTTP bundles after transform (${failed.length}).`,
-                context: {
-                  file: filePath,
-                  phase: "http-bundle-validation",
-                  failed,
-                  cacheDir,
-                },
-              }),
-            );
+            this.depValidator.missingDependencies.push(...preflightMissing);
+            parseResult = { ...parseResult, imports: validImports };
           }
         }
 
-        const transformedHash = await this.cache.hashContentAsync(transformed);
+        // Process recursive imports FIRST, without holding a project slot.
+        // Each recursive child acquires its own slot for its own transform only.
+        // This prevents hierarchical deadlock where parent holds a slot while
+        // children also need slots (10 batch x 2 depth = 21 slots, but limit is 17).
+        const localFs = createFileSystem();
 
-        const tempPath = await this.cache.getTempPath(filePath, transformedHash);
-        const written = await writeCacheFile(
-          this.cache.getFs(),
-          tempPath,
-          transformed,
-          "SSR-MODULE-LOADER",
+        const localImportPaths = await this.depValidator.processLocalImports(
+          parseResult.imports,
+          filePath,
+          depth,
+          localFs,
+          dependencyHashCache,
+          sharedSignal,
         );
-        if (!written) {
-          throw toError(
-            createError({
-              type: "build",
-              message: `Failed to transform module: ${filePath}`,
-              context: { file: filePath, phase: "transform" },
-            }),
+
+        const crossProjectPaths = await this.depValidator.processCrossProjectImports(
+          parseResult.crossProjectImports,
+          filePath,
+          sharedSignal,
+        );
+
+        // Hold project slots only around the actual transform and file write.
+        const entry = await this.withTransformCapacity(filePath, "build", async () => {
+          const projectId = this.options.projectId;
+          const transformOpts: TransformOptions = {
+            projectId,
+            dev: this.options.dev,
+            ssr: true,
+            apiBaseUrl: this.options.apiBaseUrl,
+            moduleServerOrigin: this.options.moduleServerOrigin,
+            reactVersion: this.options.reactVersion,
+            serverExternalPackages: this.options.serverExternalPackages,
+            dependencyHashCache,
+            dependencyPinningCacheKey: this.options.dependencyPinningCacheKey,
+            dependencyPinningDependencies: this.options.dependencyPinningDependencies,
+            dependencyPinningSource: this.options.dependencyPinningSource,
+          };
+
+          let transformed = await withSpan(
+            SpanNames.SSR_TRANSFORM_SINGLE,
+            () =>
+              transformToESM(
+                code,
+                filePath,
+                this.options.projectDir,
+                this.options.adapter,
+                transformOpts,
+              ),
+            { "ssr.file": filePath.split("/").pop() || filePath },
           );
-        }
+          sharedSignal.throwIfAborted();
 
-        const entry: ModuleCacheEntry = { tempPath, contentHash: transformedHash };
-        const published = publishTransformCacheIfCurrent({
-          inProgressKey,
-          transformPromise,
-          staleEvictionTimer,
-          contentCacheKey,
-          filePathCacheKey,
-          entry,
-          ...(isSSRDistributedCacheEnabled()
-            ? {
-              publishDistributed: () => {
-                void setInRedis(contentCacheKey, transformed, {
-                  isProduction: this.cache.isProductionContentSource(),
-                }).catch((error) => {
-                  logger.debug("Distributed cache set failed", {
-                    key: contentCacheKey,
-                    error,
-                  });
-                });
-              },
-            }
-            : {}),
-        });
-        if (!published) {
-          logger.debug("Skipped cache publication from stale transform leader", {
-            file: logPath(filePath),
+          for (const [specifier, tempPath] of crossProjectPaths.entries()) {
+            transformed = await rewriteCrossProjectImport(transformed, specifier, tempPath);
+          }
+
+          transformed = await rewriteLocalImports(
+            transformed,
+            localImportPaths,
+            filePath,
+            this.options.projectDir,
+          );
+
+          transformed = await resolveVfModuleImports(transformed, {
+            filePath,
+            projectId: this.options.projectId,
+            contentSourceId: this.options.contentSourceId!,
+            adapter: this.options.adapter,
+            projectDir: this.options.projectDir,
+            reactVersion: this.options.reactVersion,
+            moduleServerOrigin: this.options.moduleServerOrigin,
+            dependencyPinningCacheKey: this.options.dependencyPinningCacheKey,
+            dependencyPinningDependencies: this.options.dependencyPinningDependencies,
+            dependencyPinningSource: this.options.dependencyPinningSource,
           });
-        }
-        // A revoked leader must not update shared caches, but its immutable
-        // output is still valid for requests that joined this singleflight.
-        return entry;
-      });
 
-      resolveTransform(entry);
-      return entry;
-    } catch (error) {
-      rejectTransform(error instanceof Error ? error : new Error(String(error)));
-      throw error;
-    } finally {
-      clearTimeout(staleEvictionTimer);
-      deleteInProgressTransformIfCurrent(inProgressKey, transformPromise);
-    }
+          // Ensure HTTP bundles exist for this transform (handles nested bundle deps)
+          const bundlePaths = extractHttpBundlePaths(transformed);
+          if (bundlePaths.length > 0) {
+            const cacheDir = getHttpBundleCacheDir();
+            const failed = await ensureHttpBundlesExist(bundlePaths, cacheDir);
+            if (failed.length > 0) {
+              logger.error("Unrecoverable HTTP bundles", {
+                file: logPath(filePath),
+                failed,
+                totalBundles: bundlePaths.length,
+                cacheDir,
+                source: "fresh-transform",
+              });
+              throw toError(
+                createError({
+                  type: "build",
+                  message: `Missing HTTP bundles after transform (${failed.length}).`,
+                  context: {
+                    file: filePath,
+                    phase: "http-bundle-validation",
+                    failed,
+                    cacheDir,
+                  },
+                }),
+              );
+            }
+          }
+
+          const transformedHash = await this.cache.hashContentAsync(transformed);
+
+          const tempPath = await this.cache.getTempPath(filePath, transformedHash);
+          const written = await writeCacheFile(
+            this.cache.getFs(),
+            tempPath,
+            transformed,
+            "SSR-MODULE-LOADER",
+          );
+          if (!written) {
+            throw toError(
+              createError({
+                type: "build",
+                message: `Failed to transform module: ${filePath}`,
+                context: { file: filePath, phase: "transform" },
+              }),
+            );
+          }
+
+          const entry: ModuleCacheEntry = { tempPath, contentHash: transformedHash };
+          sharedSignal.throwIfAborted();
+          const published = publishTransformCacheIfCurrent({
+            inProgressKey,
+            transformPromise,
+            staleEvictionTimer,
+            contentCacheKey,
+            filePathCacheKey,
+            entry,
+            ...(isSSRDistributedCacheEnabled()
+              ? {
+                publishDistributed: () => {
+                  void setInRedis(contentCacheKey, transformed, {
+                    isProduction: this.cache.isProductionContentSource(),
+                  }).catch((error) => {
+                    logger.debug("Distributed cache set failed", {
+                      key: contentCacheKey,
+                      error,
+                    });
+                  });
+                },
+              }
+              : {}),
+          });
+          if (!published) {
+            logger.debug("Skipped cache publication from stale transform leader", {
+              file: logPath(filePath),
+            });
+          }
+          // A revoked leader must not update shared caches, but its immutable
+          // output is still valid for requests that joined this singleflight.
+          return entry;
+        }, sharedSignal);
+
+        markInProgressTransformSettled(transformPromise);
+        resolveTransform(entry);
+      } catch (error) {
+        markInProgressTransformSettled(transformPromise);
+        rejectTransform(error instanceof Error ? error : new Error(String(error)));
+      } finally {
+        clearTimeout(staleEvictionTimer);
+        deleteInProgressTransformIfCurrent(inProgressKey, transformPromise);
+      }
+    };
+
+    void runTransformLeader();
+    return await leaderWait;
   }
 }

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -250,7 +250,9 @@ export class SSRModuleLoader {
 
     try {
       if (semaphore) {
-        const report = await semaphore.tryAcquireWithReport(acquireTimeoutMs);
+        const report = await semaphore.tryAcquireWithReport(acquireTimeoutMs, {
+          signal: this.options.signal,
+        });
         semaphoreAcquired = report.acquired;
         if (!semaphoreAcquired) {
           throw createTransformCapacityError(

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -318,7 +318,9 @@ export class SSRModuleLoader {
     // Production keeps the short deadline as multi-tenant back-pressure.
     const acquireTimeoutMs = getTransformAcquireTimeoutMs(dev);
 
-    if (!await tryAcquireTransformSlot(projectId, acquireTimeoutMs, bypassProjectLimit)) {
+    if (
+      !await tryAcquireTransformSlot(projectId, acquireTimeoutMs, bypassProjectLimit, signal)
+    ) {
       throw createTransformCapacityError(
         mode,
         `Project ${projectId} at transform capacity. Consider reducing page complexity or request rate.`,

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -17,7 +17,7 @@ import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { unrefTimer } from "#veryfront/platform/compat/process.ts";
 import { verifyCacheFileExists, writeCacheFile } from "#veryfront/utils/cache-file-ops.ts";
 import { createError, toError } from "#veryfront/errors";
-import { rendererLogger } from "#veryfront/utils";
+import { rendererLogger, throwIfAborted } from "#veryfront/utils";
 import { SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { extractComponent } from "../extract-component.ts";
@@ -341,7 +341,7 @@ export class SSRModuleLoader {
         }
       }
 
-      signal?.throwIfAborted();
+      throwIfAborted(signal);
       return await operation();
     } finally {
       if (semaphore && semaphoreAcquired) {
@@ -592,7 +592,8 @@ export class SSRModuleLoader {
           }
         } catch (error) {
           const requestCancelled = this.options.signal?.aborted === true &&
-            error === this.options.signal.reason;
+            (error === this.options.signal.reason ||
+              (error instanceof Error && error.name === "AbortError"));
           if (!requestCancelled) this.circuitBreaker.recordFailure(circuitKey);
           throw error;
         }
@@ -652,7 +653,7 @@ export class SSRModuleLoader {
     dependencyHashCache: DependencyHashCache = createDependencyHashCache(),
     observerSignal?: AbortSignal,
   ): Promise<ModuleCacheEntry> {
-    observerSignal?.throwIfAborted();
+    throwIfAborted(observerSignal);
     if (depth > MAX_TRANSFORM_DEPTH) {
       logger.warn("Max transform depth exceeded", {
         file: logPath(filePath),
@@ -853,7 +854,7 @@ export class SSRModuleLoader {
 
     const runTransformLeader = async (): Promise<void> => {
       try {
-        sharedSignal.throwIfAborted();
+        throwIfAborted(sharedSignal);
         let parseResult = await parseLocalImports(
           code,
           filePath,
@@ -939,7 +940,7 @@ export class SSRModuleLoader {
               ),
             { "ssr.file": filePath.split("/").pop() || filePath },
           );
-          sharedSignal.throwIfAborted();
+          throwIfAborted(sharedSignal);
 
           for (const [specifier, tempPath] of crossProjectPaths.entries()) {
             transformed = await rewriteCrossProjectImport(transformed, specifier, tempPath);
@@ -1013,7 +1014,7 @@ export class SSRModuleLoader {
           }
 
           const entry: ModuleCacheEntry = { tempPath, contentHash: transformedHash };
-          sharedSignal.throwIfAborted();
+          throwIfAborted(sharedSignal);
           const published = publishTransformCacheIfCurrent({
             inProgressKey,
             transformPromise,

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -28,8 +28,8 @@ import {
 } from "./loader-helpers.ts";
 import {
   getMaxConcurrentTransforms,
+  getTransformAcquireTimeoutMs,
   MAX_TRANSFORM_DEPTH,
-  TRANSFORM_ACQUIRE_TIMEOUT_MS,
   TRANSFORM_IN_PROGRESS_STALE_EVICTION_MS,
   TRANSFORM_IN_PROGRESS_WAIT_TIMEOUT_MS,
 } from "./constants.ts";
@@ -232,11 +232,15 @@ export class SSRModuleLoader {
     // false "at capacity" failures when a cold-cache render fans out across
     // the framework tree. Bypass it in dev; the global semaphore still bounds
     // total concurrency.
-    const bypassProjectLimit = this.options.dev === true;
+    const dev = this.options.dev === true;
+    const bypassProjectLimit = dev;
 
-    if (
-      !await tryAcquireTransformSlot(projectId, TRANSFORM_ACQUIRE_TIMEOUT_MS, bypassProjectLimit)
-    ) {
+    // Dev queues on the global semaphore instead of failing the render, so a
+    // burst of concurrent refreshes is slower rather than an error page.
+    // Production keeps the short deadline as multi-tenant back-pressure.
+    const acquireTimeoutMs = getTransformAcquireTimeoutMs(dev);
+
+    if (!await tryAcquireTransformSlot(projectId, acquireTimeoutMs, bypassProjectLimit)) {
       throw createTransformCapacityError(
         mode,
         `Project ${projectId} at transform capacity. Consider reducing page complexity or request rate.`,
@@ -246,11 +250,12 @@ export class SSRModuleLoader {
 
     try {
       if (semaphore) {
-        semaphoreAcquired = await semaphore.tryAcquire(TRANSFORM_ACQUIRE_TIMEOUT_MS);
+        const report = await semaphore.tryAcquireWithReport(acquireTimeoutMs);
+        semaphoreAcquired = report.acquired;
         if (!semaphoreAcquired) {
           throw createTransformCapacityError(
             mode,
-            `Transform capacity exceeded (${semaphore.waiting} waiting). Service is overloaded.`,
+            `Transform capacity exceeded (${report.waiting} waiting). Service is overloaded.`,
             filePath,
           );
         }

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -65,9 +65,11 @@ export class SSRDependencyValidator {
       source: string | undefined,
       depth: number,
       dependencyHashCache: DependencyHashCache,
+      signal?: AbortSignal,
     ) => Promise<ModuleCacheEntry>,
     private transformCrossProjectImport: (
       crossProjectImport: CrossProjectImport,
+      signal?: AbortSignal,
     ) => Promise<string>,
     private adapter: RuntimeAdapter,
     private projectDir: string,
@@ -113,7 +115,9 @@ export class SSRDependencyValidator {
     code: string,
     filePath: string,
     depth: number = 0,
+    signal?: AbortSignal,
   ): Promise<void> {
+    signal?.throwIfAborted();
     if (depth > MAX_TRANSFORM_DEPTH) return;
 
     const parseResult = await parseLocalImports(
@@ -139,9 +143,11 @@ export class SSRDependencyValidator {
       depth,
       localFs,
       createDependencyHashCache(),
+      signal,
     );
 
-    await this.processCrossProjectImports(parseResult.crossProjectImports, filePath);
+    await this.processCrossProjectImports(parseResult.crossProjectImports, filePath, signal);
+    signal?.throwIfAborted();
   }
 
   /**
@@ -157,7 +163,9 @@ export class SSRDependencyValidator {
   async processCrossProjectImports(
     crossProjectImports: CrossProjectImport[],
     filePath: string,
+    signal?: AbortSignal,
   ): Promise<Map<string, string>> {
+    signal?.throwIfAborted();
     const crossProjectPaths = new Map<string, string>();
 
     for (let i = 0; i < crossProjectImports.length; i += TRANSFORM_BATCH_SIZE) {
@@ -165,9 +173,10 @@ export class SSRDependencyValidator {
       const results = await Promise.allSettled(
         batch.map(async (crossImport) => {
           try {
-            const tempPath = await this.transformCrossProjectImport(crossImport);
+            const tempPath = await this.transformCrossProjectImport(crossImport, signal);
             crossProjectPaths.set(crossImport.specifier, tempPath);
           } catch (error) {
+            signal?.throwIfAborted();
             if (isTerminalHttpModuleFetchFailure(error)) throw error;
             this.missingDependencies.push({
               specifier: crossImport.specifier,
@@ -181,6 +190,7 @@ export class SSRDependencyValidator {
       );
       const failure = selectPropagatedFailure(results);
       if (failure) throw failure.reason;
+      signal?.throwIfAborted();
     }
 
     return crossProjectPaths;
@@ -196,7 +206,9 @@ export class SSRDependencyValidator {
     depth: number,
     localFs: ReturnType<typeof createFileSystem>,
     dependencyHashCache: DependencyHashCache,
+    signal?: AbortSignal,
   ): Promise<Map<string, string>> {
+    signal?.throwIfAborted();
     const importPathMap = new Map<string, string>();
 
     for (let i = 0; i < imports.length; i += TRANSFORM_BATCH_SIZE) {
@@ -211,11 +223,13 @@ export class SSRDependencyValidator {
               depSource,
               depth + 1,
               dependencyHashCache,
+              signal,
             );
 
             importPathMap.set(imp.specifier, depEntry.tempPath);
             importPathMap.set(imp.absolutePath, depEntry.tempPath);
           } catch (error) {
+            signal?.throwIfAborted();
             if (isTerminalHttpModuleFetchFailure(error)) throw error;
             this.missingDependencies.push({
               specifier: imp.specifier,
@@ -229,6 +243,7 @@ export class SSRDependencyValidator {
       );
       const failure = selectPropagatedFailure(results);
       if (failure) throw failure.reason;
+      signal?.throwIfAborted();
     }
 
     return importPathMap;

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -12,7 +12,7 @@ import { parseLocalImports } from "#veryfront/transforms/esm/import-parser.ts";
 import { registerCSSImport } from "../css-import-collector.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { BUILD_FAILED, createError, toError, VeryfrontError } from "#veryfront/errors";
-import { rendererLogger } from "#veryfront/utils";
+import { rendererLogger, throwIfAborted } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { MAX_TRANSFORM_DEPTH, TRANSFORM_BATCH_SIZE } from "./constants.ts";
 import type { ModuleCacheEntry } from "./types.ts";
@@ -117,7 +117,7 @@ export class SSRDependencyValidator {
     depth: number = 0,
     signal?: AbortSignal,
   ): Promise<void> {
-    signal?.throwIfAborted();
+    throwIfAborted(signal);
     if (depth > MAX_TRANSFORM_DEPTH) return;
 
     const parseResult = await parseLocalImports(
@@ -147,7 +147,7 @@ export class SSRDependencyValidator {
     );
 
     await this.processCrossProjectImports(parseResult.crossProjectImports, filePath, signal);
-    signal?.throwIfAborted();
+    throwIfAborted(signal);
   }
 
   /**
@@ -165,7 +165,7 @@ export class SSRDependencyValidator {
     filePath: string,
     signal?: AbortSignal,
   ): Promise<Map<string, string>> {
-    signal?.throwIfAborted();
+    throwIfAborted(signal);
     const crossProjectPaths = new Map<string, string>();
 
     for (let i = 0; i < crossProjectImports.length; i += TRANSFORM_BATCH_SIZE) {
@@ -176,7 +176,7 @@ export class SSRDependencyValidator {
             const tempPath = await this.transformCrossProjectImport(crossImport, signal);
             crossProjectPaths.set(crossImport.specifier, tempPath);
           } catch (error) {
-            signal?.throwIfAborted();
+            throwIfAborted(signal);
             if (isTerminalHttpModuleFetchFailure(error)) throw error;
             this.missingDependencies.push({
               specifier: crossImport.specifier,
@@ -190,7 +190,7 @@ export class SSRDependencyValidator {
       );
       const failure = selectPropagatedFailure(results);
       if (failure) throw failure.reason;
-      signal?.throwIfAborted();
+      throwIfAborted(signal);
     }
 
     return crossProjectPaths;
@@ -208,7 +208,7 @@ export class SSRDependencyValidator {
     dependencyHashCache: DependencyHashCache,
     signal?: AbortSignal,
   ): Promise<Map<string, string>> {
-    signal?.throwIfAborted();
+    throwIfAborted(signal);
     const importPathMap = new Map<string, string>();
 
     for (let i = 0; i < imports.length; i += TRANSFORM_BATCH_SIZE) {
@@ -229,7 +229,7 @@ export class SSRDependencyValidator {
             importPathMap.set(imp.specifier, depEntry.tempPath);
             importPathMap.set(imp.absolutePath, depEntry.tempPath);
           } catch (error) {
-            signal?.throwIfAborted();
+            throwIfAborted(signal);
             if (isTerminalHttpModuleFetchFailure(error)) throw error;
             this.missingDependencies.push({
               specifier: imp.specifier,
@@ -243,7 +243,7 @@ export class SSRDependencyValidator {
       );
       const failure = selectPropagatedFailure(results);
       if (failure) throw failure.reason;
-      signal?.throwIfAborted();
+      throwIfAborted(signal);
     }
 
     return importPathMap;

--- a/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
@@ -1,0 +1,132 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
+import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
+import { SSRModuleLoader } from "./loader.ts";
+import { clearSSRModuleCache, getTransformSemaphore } from "./cache/index.ts";
+import { TRANSFORM_ACQUIRE_TIMEOUT_MS } from "./constants.ts";
+import type { TransformCapacityErrorMode } from "./loader-helpers.ts";
+
+type TransformCapacityRunner = (
+  filePath: string,
+  mode: TransformCapacityErrorMode,
+  operation: () => Promise<string>,
+) => Promise<string>;
+
+/** Call the private capacity guard directly so the test stays off the transform pipeline. */
+function transformCapacity(loader: SSRModuleLoader): TransformCapacityRunner {
+  const internal = loader as unknown as { withTransformCapacity: TransformCapacityRunner };
+  return internal.withTransformCapacity.bind(loader);
+}
+
+function createLoader(projectId: string, dev: boolean): SSRModuleLoader {
+  return new SSRModuleLoader({
+    projectDir: "/projects/capacity",
+    projectId,
+    adapter: denoAdapter,
+    dev,
+  });
+}
+
+/** Take every free permit so the next acquire has to queue. */
+async function exhaustTransformPermits(): Promise<number> {
+  const semaphore = getTransformSemaphore();
+  let taken = 0;
+  while (semaphore.available > 0) {
+    await semaphore.tryAcquire(0);
+    taken++;
+  }
+  return taken;
+}
+
+function releaseTransformPermits(count: number): void {
+  const semaphore = getTransformSemaphore();
+  for (let i = 0; i < count; i++) semaphore.release();
+}
+
+type Outcome = { ok: true; value: string } | { ok: false; error: Error };
+
+function settle(promise: Promise<string>): Promise<Outcome> {
+  return promise.then(
+    (value): Outcome => ({ ok: true, value }),
+    (error): Outcome => ({
+      ok: false,
+      error: error instanceof Error ? error : new Error(String(error)),
+    }),
+  );
+}
+
+describe("modules/react-loader/ssr-module-loader/transform-capacity", () => {
+  it("should fail fast with the real queue depth when production capacity is exhausted", async () => {
+    clearSSRModuleCache();
+    const loader = createLoader("capacity-production", false);
+    let held = await exhaustTransformPermits();
+    const time = new FakeTime();
+
+    try {
+      const outcome = settle(
+        transformCapacity(loader)(
+          "/projects/capacity/page.tsx",
+          "build",
+          () => Promise.resolve("ran"),
+        ),
+      );
+
+      await time.tickAsync(TRANSFORM_ACQUIRE_TIMEOUT_MS + 1);
+      const result = await outcome;
+
+      assert(!result.ok, "production must shed load instead of queueing past the deadline");
+      assertStringIncludes(
+        result.error.message,
+        "Transform capacity exceeded (1 waiting)",
+        "the diagnostic must count the waiter that timed out",
+      );
+    } finally {
+      time.restore();
+      releaseTransformPermits(held);
+      held = 0;
+      clearSSRModuleCache();
+    }
+  });
+
+  it("should queue a dev burst past the production deadline and succeed once permits free", async () => {
+    clearSSRModuleCache();
+    const loader = createLoader("capacity-dev", true);
+    let held = await exhaustTransformPermits();
+    const semaphore = getTransformSemaphore();
+    const time = new FakeTime();
+
+    try {
+      const burst = Array.from({ length: 4 }, (_, index) =>
+        settle(
+          transformCapacity(loader)(
+            `/projects/capacity/tab-${index}.tsx`,
+            "build",
+            () => Promise.resolve(`tab-${index}`),
+          ),
+        ));
+
+      await time.tickAsync(TRANSFORM_ACQUIRE_TIMEOUT_MS + 1);
+      assertEquals(
+        semaphore.waiting,
+        4,
+        "dev requests must still be queued after the production deadline passes",
+      );
+
+      releaseTransformPermits(held);
+      held = 0;
+
+      const results = await Promise.all(burst);
+      assertEquals(
+        results.map((result) => (result.ok ? result.value : result.error.message)),
+        ["tab-0", "tab-1", "tab-2", "tab-3"],
+        "every queued dev request must run instead of erroring",
+      );
+    } finally {
+      time.restore();
+      releaseTransformPermits(held);
+      clearSSRModuleCache();
+    }
+  });
+});

--- a/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
@@ -12,6 +12,7 @@ type TransformCapacityRunner = (
   filePath: string,
   mode: TransformCapacityErrorMode,
   operation: () => Promise<string>,
+  signal?: AbortSignal,
 ) => Promise<string>;
 
 /** Call the private capacity guard directly so the test stays off the transform pipeline. */
@@ -124,6 +125,48 @@ describe("modules/react-loader/ssr-module-loader/transform-capacity", () => {
       );
     } finally {
       time.restore();
+      releaseTransformPermits(held);
+      clearSSRModuleCache();
+    }
+  });
+
+  it("should remove a queued dev transform when its final observer is cancelled", async () => {
+    clearSSRModuleCache();
+    const controller = new AbortController();
+    const loader = createLoader("capacity-cancelled", true);
+    let held = await exhaustTransformPermits();
+    const semaphore = getTransformSemaphore();
+    let operationRan = false;
+
+    try {
+      const outcome = settle(
+        transformCapacity(loader)(
+          "/projects/capacity/cancelled.tsx",
+          "build",
+          () => {
+            operationRan = true;
+            return Promise.resolve("ran");
+          },
+          controller.signal,
+        ),
+      );
+      await Promise.resolve();
+      assertEquals(semaphore.waiting, 1);
+
+      const reason = new DOMException("render cancelled", "AbortError");
+      controller.abort(reason);
+      await Promise.resolve();
+      const waitingAfterAbort = semaphore.waiting;
+
+      releaseTransformPermits(held);
+      held = 0;
+      const result = await outcome;
+
+      assertEquals(waitingAfterAbort, 0, "the cancelled waiter must leave the queue");
+      assertEquals(operationRan, false, "cancelled transform work must not start");
+      assert(!result.ok, "the render abort must reject the queued acquisition");
+      assertStringIncludes(result.error.message, "render cancelled");
+    } finally {
       releaseTransformPermits(held);
       clearSSRModuleCache();
     }

--- a/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
@@ -20,17 +20,12 @@ function transformCapacity(loader: SSRModuleLoader): TransformCapacityRunner {
   return internal.withTransformCapacity.bind(loader);
 }
 
-function createLoader(
-  projectId: string,
-  dev: boolean,
-  signal?: AbortSignal,
-): SSRModuleLoader {
+function createLoader(projectId: string, dev: boolean): SSRModuleLoader {
   return new SSRModuleLoader({
     projectDir: "/projects/capacity",
     projectId,
     adapter: denoAdapter,
     dev,
-    signal,
   });
 }
 
@@ -129,47 +124,6 @@ describe("modules/react-loader/ssr-module-loader/transform-capacity", () => {
       );
     } finally {
       time.restore();
-      releaseTransformPermits(held);
-      clearSSRModuleCache();
-    }
-  });
-
-  it("should remove a queued dev transform when its render is cancelled", async () => {
-    clearSSRModuleCache();
-    const controller = new AbortController();
-    const loader = createLoader("capacity-cancelled", true, controller.signal);
-    let held = await exhaustTransformPermits();
-    const semaphore = getTransformSemaphore();
-    let operationRan = false;
-
-    try {
-      const outcome = settle(
-        transformCapacity(loader)(
-          "/projects/capacity/cancelled.tsx",
-          "build",
-          () => {
-            operationRan = true;
-            return Promise.resolve("ran");
-          },
-        ),
-      );
-      await Promise.resolve();
-      assertEquals(semaphore.waiting, 1);
-
-      const reason = new DOMException("render cancelled", "AbortError");
-      controller.abort(reason);
-      await Promise.resolve();
-      const waitingAfterAbort = semaphore.waiting;
-
-      releaseTransformPermits(held);
-      held = 0;
-      const result = await outcome;
-
-      assertEquals(waitingAfterAbort, 0, "the cancelled waiter must leave the queue");
-      assertEquals(operationRan, false, "cancelled transform work must not start");
-      assert(!result.ok, "the render abort must reject the queued acquisition");
-      assertStringIncludes(result.error.message, "render cancelled");
-    } finally {
       releaseTransformPermits(held);
       clearSSRModuleCache();
     }

--- a/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
@@ -61,7 +61,7 @@ describe("modules/react-loader/ssr-module-loader/transform-capacity", () => {
   it("should fail fast with the real queue depth when production capacity is exhausted", async () => {
     clearSSRModuleCache();
     const loader = createLoader("capacity-production", false);
-    let held = await exhaustTransformPermits();
+    const held = await exhaustTransformPermits();
     const time = new FakeTime();
 
     try {
@@ -85,7 +85,6 @@ describe("modules/react-loader/ssr-module-loader/transform-capacity", () => {
     } finally {
       time.restore();
       releaseTransformPermits(held);
-      held = 0;
       clearSSRModuleCache();
     }
   });

--- a/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
@@ -20,12 +20,17 @@ function transformCapacity(loader: SSRModuleLoader): TransformCapacityRunner {
   return internal.withTransformCapacity.bind(loader);
 }
 
-function createLoader(projectId: string, dev: boolean): SSRModuleLoader {
+function createLoader(
+  projectId: string,
+  dev: boolean,
+  signal?: AbortSignal,
+): SSRModuleLoader {
   return new SSRModuleLoader({
     projectDir: "/projects/capacity",
     projectId,
     adapter: denoAdapter,
     dev,
+    signal,
   });
 }
 
@@ -124,6 +129,47 @@ describe("modules/react-loader/ssr-module-loader/transform-capacity", () => {
       );
     } finally {
       time.restore();
+      releaseTransformPermits(held);
+      clearSSRModuleCache();
+    }
+  });
+
+  it("should remove a queued dev transform when its render is cancelled", async () => {
+    clearSSRModuleCache();
+    const controller = new AbortController();
+    const loader = createLoader("capacity-cancelled", true, controller.signal);
+    let held = await exhaustTransformPermits();
+    const semaphore = getTransformSemaphore();
+    let operationRan = false;
+
+    try {
+      const outcome = settle(
+        transformCapacity(loader)(
+          "/projects/capacity/cancelled.tsx",
+          "build",
+          () => {
+            operationRan = true;
+            return Promise.resolve("ran");
+          },
+        ),
+      );
+      await Promise.resolve();
+      assertEquals(semaphore.waiting, 1);
+
+      const reason = new DOMException("render cancelled", "AbortError");
+      controller.abort(reason);
+      await Promise.resolve();
+      const waitingAfterAbort = semaphore.waiting;
+
+      releaseTransformPermits(held);
+      held = 0;
+      const result = await outcome;
+
+      assertEquals(waitingAfterAbort, 0, "the cancelled waiter must leave the queue");
+      assertEquals(operationRan, false, "cancelled transform work must not start");
+      assert(!result.ok, "the render abort must reject the queued acquisition");
+      assertStringIncludes(result.error.message, "render cancelled");
+    } finally {
       releaseTransformPermits(held);
       clearSSRModuleCache();
     }

--- a/src/modules/react-loader/ssr-module-loader/types.ts
+++ b/src/modules/react-loader/ssr-module-loader/types.ts
@@ -33,8 +33,6 @@ export interface SSRModuleLoaderOptions {
   dependencyPinningSource?: DependencyPinningSourceInput;
   /** Request mode ("preview" | "production") for studio features */
   mode?: string;
-  /** Cooperative cancellation for request-scoped SSR transforms. */
-  signal?: AbortSignal;
 }
 
 export interface ModuleCacheEntry {

--- a/src/modules/react-loader/ssr-module-loader/types.ts
+++ b/src/modules/react-loader/ssr-module-loader/types.ts
@@ -33,6 +33,8 @@ export interface SSRModuleLoaderOptions {
   dependencyPinningSource?: DependencyPinningSourceInput;
   /** Request mode ("preview" | "production") for studio features */
   mode?: string;
+  /** Cooperative cancellation for request-scoped SSR transforms. */
+  signal?: AbortSignal;
 }
 
 export interface ModuleCacheEntry {

--- a/src/modules/react-loader/types.ts
+++ b/src/modules/react-loader/types.ts
@@ -26,8 +26,6 @@ export interface LoadComponentOptions {
   dependencyPinningSource?: DependencyPinningSourceInput;
   /** Request mode ("preview" | "production") for studio features */
   mode?: string;
-  /** Cooperative cancellation for request-scoped SSR transforms. */
-  signal?: AbortSignal;
 }
 
 export interface ComponentSource {

--- a/src/modules/react-loader/types.ts
+++ b/src/modules/react-loader/types.ts
@@ -26,6 +26,8 @@ export interface LoadComponentOptions {
   dependencyPinningSource?: DependencyPinningSourceInput;
   /** Request mode ("preview" | "production") for studio features */
   mode?: string;
+  /** Cooperative cancellation for request-scoped SSR transforms. */
+  signal?: AbortSignal;
 }
 
 export interface ComponentSource {

--- a/src/rendering/app-reserved.test.ts
+++ b/src/rendering/app-reserved.test.ts
@@ -48,6 +48,38 @@ describe("rendering/app-reserved", () => {
     assertEquals(reads, 0);
   });
 
+  it("normalizes a host signal that has no abort reason", async () => {
+    const signal = {
+      aborted: true,
+      reason: undefined,
+      throwIfAborted: () => {
+        throw undefined;
+      },
+    } as unknown as AbortSignal;
+
+    await assertRejects(
+      () =>
+        loadReservedWithPath(
+          [],
+          "loading",
+          "/project",
+          "development",
+          {} as RuntimeAdapter,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          signal,
+        ),
+      Error,
+      "operation was aborted",
+    );
+  });
+
   describe("RESERVED_COMPONENTS", () => {
     it("should define loading, error, and notFound components", () => {
       assertEquals(RESERVED_COMPONENTS.loading, "loading.tsx");

--- a/src/rendering/app-reserved.test.ts
+++ b/src/rendering/app-reserved.test.ts
@@ -1,10 +1,53 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { collectAncestorDirs, createErrorBoundary, RESERVED_COMPONENTS } from "./app-reserved.ts";
+import {
+  collectAncestorDirs,
+  createErrorBoundary,
+  loadReservedWithPath,
+  RESERVED_COMPONENTS,
+} from "./app-reserved.ts";
 import * as React from "react";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
 describe("rendering/app-reserved", () => {
+  it("does not search reserved component paths after request cancellation", async () => {
+    let reads = 0;
+    const adapter = {
+      fs: {
+        readFile: () => {
+          reads++;
+          return Promise.reject(new Error("not found"));
+        },
+      },
+    } as unknown as RuntimeAdapter;
+    const controller = new AbortController();
+    controller.abort(new DOMException("render cancelled", "AbortError"));
+
+    await assertRejects(
+      () =>
+        loadReservedWithPath(
+          ["/project/app/blog", "/project/app"],
+          "loading",
+          "/project",
+          "development",
+          adapter,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          controller.signal,
+        ),
+      Error,
+      "render cancelled",
+    );
+    assertEquals(reads, 0);
+  });
+
   describe("RESERVED_COMPONENTS", () => {
     it("should define loading, error, and notFound components", () => {
       assertEquals(RESERVED_COMPONENTS.loading, "loading.tsx");

--- a/src/rendering/app-reserved.ts
+++ b/src/rendering/app-reserved.ts
@@ -93,7 +93,9 @@ export async function loadReservedWithPath(
   dependencyPinningSource?: DependencyPinningSourceInput,
   moduleServerOrigin?: string,
   serverExternalPackages?: readonly string[],
+  signal?: AbortSignal,
 ): Promise<{ component: ReservedComponent; filePath: string } | null> {
+  signal?.throwIfAborted();
   const join = (a: string, b: string) => `${a.replace(/\/$/, "")}/${b.replace(/^\//, "")}`;
   const candidateName = RESERVED_COMPONENTS[which];
   const { loadComponentFromSource } = await import(
@@ -115,11 +117,13 @@ export async function loadReservedWithPath(
           dependencyPinningCacheKey,
           dependencyPinningDependencies,
           dependencyPinningSource,
+          signal,
         });
         if (typeof Cmp === "function") {
           return { component: Cmp as ReservedComponent, filePath: file };
         }
       } catch (_) {
+        signal?.throwIfAborted();
         /* expected: component not found in this path, continue to next */
       }
     }
@@ -142,6 +146,7 @@ export async function tryLoadReservedInDirs(
   dependencyPinningSource?: DependencyPinningSourceInput,
   moduleServerOrigin?: string,
   serverExternalPackages?: readonly string[],
+  signal?: AbortSignal,
 ): Promise<ReservedComponent | null> {
   const loaded = await loadReservedWithPath(
     dirs,
@@ -157,6 +162,7 @@ export async function tryLoadReservedInDirs(
     dependencyPinningSource,
     moduleServerOrigin,
     serverExternalPackages,
+    signal,
   );
   return loaded?.component ?? null;
 }

--- a/src/rendering/app-reserved.ts
+++ b/src/rendering/app-reserved.ts
@@ -1,5 +1,5 @@
 import * as BundledReact from "react";
-import { rendererLogger as logger } from "#veryfront/utils";
+import { rendererLogger as logger, throwIfAborted } from "#veryfront/utils";
 import { normalizePath } from "#veryfront/utils/path-utils.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { DependencyPinningSourceInput } from "#veryfront/transforms/esm/package-registry.ts";
@@ -95,7 +95,7 @@ export async function loadReservedWithPath(
   serverExternalPackages?: readonly string[],
   signal?: AbortSignal,
 ): Promise<{ component: ReservedComponent; filePath: string } | null> {
-  signal?.throwIfAborted();
+  throwIfAborted(signal);
   const join = (a: string, b: string) => `${a.replace(/\/$/, "")}/${b.replace(/^\//, "")}`;
   const candidateName = RESERVED_COMPONENTS[which];
   const { loadComponentFromSource } = await import(
@@ -123,7 +123,7 @@ export async function loadReservedWithPath(
           return { component: Cmp as ReservedComponent, filePath: file };
         }
       } catch (_) {
-        signal?.throwIfAborted();
+        throwIfAborted(signal);
         /* expected: component not found in this path, continue to next */
       }
     }

--- a/src/rendering/component-handling.ts
+++ b/src/rendering/component-handling.ts
@@ -121,6 +121,8 @@ export async function handleComponentPage(
     dependencyPinningSource?: DependencyPinningSourceInput;
     /** Bare npm package roots that the runtime resolves without bundling. */
     serverExternalPackages?: readonly string[];
+    /** Cooperative cancellation for this render's SSR transforms. */
+    signal?: AbortSignal;
   },
 ): Promise<ComponentPageResult> {
   try {
@@ -170,6 +172,7 @@ export async function handleComponentPage(
         dependencyPinningDependencies: options?.dependencyPinningDependencies,
         dependencyPinningSource: options?.dependencyPinningSource,
         mode: options?.mode,
+        signal: options?.signal,
       },
     );
 

--- a/src/rendering/component-handling.ts
+++ b/src/rendering/component-handling.ts
@@ -121,8 +121,6 @@ export async function handleComponentPage(
     dependencyPinningSource?: DependencyPinningSourceInput;
     /** Bare npm package roots that the runtime resolves without bundling. */
     serverExternalPackages?: readonly string[];
-    /** Cooperative cancellation for this render's SSR transforms. */
-    signal?: AbortSignal;
   },
 ): Promise<ComponentPageResult> {
   try {
@@ -172,7 +170,6 @@ export async function handleComponentPage(
         dependencyPinningDependencies: options?.dependencyPinningDependencies,
         dependencyPinningSource: options?.dependencyPinningSource,
         mode: options?.mode,
-        signal: options?.signal,
       },
     );
 

--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -58,6 +58,8 @@ export interface LayoutApplicationOptions {
   dependencyPinningSource?: DependencyPinningSourceInput;
   /** Server-trusted local-project identity. */
   isLocalProject?: boolean;
+  /** Cooperative cancellation for request-scoped SSR module loads. */
+  signal?: AbortSignal;
 }
 
 export class LayoutApplicator {
@@ -81,6 +83,7 @@ export class LayoutApplicator {
   private readonly dependencyPinningDependencies?: Readonly<Record<string, string>>;
   private readonly dependencyPinningSource?: DependencyPinningSourceInput;
   private readonly isLocalProject: boolean;
+  private readonly signal?: AbortSignal;
   private reactVersionPromise: Promise<string> | null = null;
   private frameworkProviderModulesPromise?: Promise<{
     PageContextProvider: BundledReact.ComponentType<Record<string, unknown>>;
@@ -108,6 +111,7 @@ export class LayoutApplicator {
     this.dependencyPinningDependencies = options.dependencyPinningDependencies;
     this.dependencyPinningSource = options.dependencyPinningSource;
     this.isLocalProject = options.isLocalProject === true;
+    this.signal = options.signal;
   }
 
   private getReactVersion(): Promise<string> {
@@ -294,6 +298,7 @@ export class LayoutApplicator {
             this.requestUrl?.origin,
             this.config,
             this.isLocalProject,
+            this.signal,
           );
         }
 
@@ -315,6 +320,7 @@ export class LayoutApplicator {
           this.dependencyPinningSource,
           this.requestUrl?.origin,
           this.config,
+          this.signal,
         );
       },
       {
@@ -367,6 +373,7 @@ export class LayoutApplicator {
       dependencyPinningDependencies: this.dependencyPinningDependencies,
       dependencyPinningSource: this.dependencyPinningSource,
       moduleServerOrigin: this.requestUrl?.origin,
+      signal: this.signal,
     } as const;
 
     const [contextModule, routerModule] = await Promise.all([
@@ -440,6 +447,7 @@ export class LayoutApplicator {
                 dependencyPinningDependencies: this.dependencyPinningDependencies,
                 dependencyPinningSource: this.dependencyPinningSource,
                 serverExternalPackages: this.config?.build?.serverExternalPackages,
+                signal: this.signal,
               },
             );
           }
@@ -450,6 +458,7 @@ export class LayoutApplicator {
           logger.debug("Wrapped page with App component");
           return React.createElement(App, { children: pageElement }) as BundledReact.ReactElement;
         } catch (error) {
+          this.signal?.throwIfAborted();
           logger.warn("Failed to load App component:", error);
           return pageElement;
         }
@@ -497,9 +506,11 @@ export class LayoutApplicator {
           dependencyPinningDependencies: this.dependencyPinningDependencies,
           dependencyPinningSource: this.dependencyPinningSource,
           serverExternalPackages: this.config?.build?.serverExternalPackages,
+          signal: this.signal,
         },
       );
     } catch (error) {
+      this.signal?.throwIfAborted();
       logger.error("Failed to compile MDX app component:", error);
       return null;
     }
@@ -537,6 +548,8 @@ export class LayoutApplicator {
               this.dependencyPinningDependencies,
               this.dependencyPinningSource,
               this.requestUrl?.origin,
+              this.config?.build?.serverExternalPackages,
+              this.signal,
             ),
             tryLoadReservedInDirs(
               searchDirs,
@@ -551,6 +564,8 @@ export class LayoutApplicator {
               this.dependencyPinningDependencies,
               this.dependencyPinningSource,
               this.requestUrl?.origin,
+              this.config?.build?.serverExternalPackages,
+              this.signal,
             ),
           ]);
 
@@ -572,6 +587,7 @@ export class LayoutApplicator {
             ) as BundledReact.ReactElement;
           }
         } catch (error) {
+          this.signal?.throwIfAborted();
           logger.warn("Failed applying reserved loading/error components", error);
         }
 

--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from "#veryfront/compat/path";
-import { rendererLogger } from "#veryfront/utils";
+import { rendererLogger, throwIfAborted } from "#veryfront/utils";
 import { flattenRouteParams } from "#veryfront/routing";
 import * as BundledReact from "react";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -458,7 +458,7 @@ export class LayoutApplicator {
           logger.debug("Wrapped page with App component");
           return React.createElement(App, { children: pageElement }) as BundledReact.ReactElement;
         } catch (error) {
-          this.signal?.throwIfAborted();
+          throwIfAborted(this.signal);
           logger.warn("Failed to load App component:", error);
           return pageElement;
         }
@@ -510,7 +510,7 @@ export class LayoutApplicator {
         },
       );
     } catch (error) {
-      this.signal?.throwIfAborted();
+      throwIfAborted(this.signal);
       logger.error("Failed to compile MDX app component:", error);
       return null;
     }
@@ -587,7 +587,7 @@ export class LayoutApplicator {
             ) as BundledReact.ReactElement;
           }
         } catch (error) {
-          this.signal?.throwIfAborted();
+          throwIfAborted(this.signal);
           logger.warn("Failed applying reserved loading/error components", error);
         }
 

--- a/src/rendering/layouts/utils/applicator.ts
+++ b/src/rendering/layouts/utils/applicator.ts
@@ -36,6 +36,7 @@ export function applyLayoutsESM(
   moduleServerOrigin?: string,
   config?: VeryfrontConfig,
   isLocalProject?: boolean,
+  signal?: AbortSignal,
 ): Promise<BundledReact.ReactElement> {
   return withSpan(
     SpanNames.LAYOUT_APPLY_LAYOUTS_ESM,
@@ -116,6 +117,7 @@ export function applyLayoutsESM(
                 dependencyPinningSource,
                 moduleServerOrigin,
                 config?.build?.serverExternalPackages,
+                signal,
               ),
             spanAttrs,
           );
@@ -186,6 +188,7 @@ export async function applyLayoutsFunctionBody(
   dependencyPinningSource?: DependencyPinningSourceInput,
   moduleServerOrigin?: string,
   config?: VeryfrontConfig,
+  signal?: AbortSignal,
 ): Promise<BundledReact.ReactElement> {
   const React = await getProjectReact(reactVersion);
   let element = pageElement;
@@ -235,6 +238,7 @@ export async function applyLayoutsFunctionBody(
         dependencyPinningSource,
         moduleServerOrigin,
         config?.build?.serverExternalPackages,
+        signal,
       );
 
       const child = ensureValidChild(element, React);

--- a/src/rendering/layouts/utils/component-loader.test.ts
+++ b/src/rendering/layouts/utils/component-loader.test.ts
@@ -329,6 +329,48 @@ describe("rendering/layouts/utils/component-loader", () => {
   });
 
   describe("loadTSXComponent", () => {
+    it("threads the request signal into a cold SSR component load", async () => {
+      const cache = createLayoutComponentCache();
+      const controller = new AbortController();
+      let observedSignal: AbortSignal | undefined;
+      const loading = loadTSXComponent(
+        "/project/app/signal-layout.tsx",
+        "/project",
+        cache,
+        layoutAdapter("export default function Layout() { return null; }"),
+        "project-1",
+        "project-slug",
+        "release-1",
+        "19.1.0",
+        {
+          loadComponentFromSource: (_source, _filePath, _projectDir, _adapter, options) => {
+            observedSignal = options?.signal;
+            return new Promise((_resolve, reject) => {
+              options?.signal?.addEventListener(
+                "abort",
+                () => reject(options.signal?.reason),
+                { once: true },
+              );
+            });
+          },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        controller.signal,
+      );
+
+      await waitFor(() => observedSignal !== undefined);
+      const reason = new DOMException("layout render cancelled", "AbortError");
+      controller.abort(reason);
+
+      await assertRejects(() => loading, Error, "layout render cancelled");
+      assertEquals(observedSignal?.aborted, true);
+      assertEquals(observedSignal?.reason, reason);
+    });
+
     it("shares one component load for concurrent cold misses", async () => {
       const cache = createLayoutComponentCache();
       const loaded = Promise.withResolvers<React.ComponentType>();

--- a/src/rendering/layouts/utils/component-loader.ts
+++ b/src/rendering/layouts/utils/component-loader.ts
@@ -1,6 +1,7 @@
 import {
   computeHash,
   rendererLogger as logger,
+  throwIfAborted,
   TSX_LAYOUT_MAX_ENTRIES,
   TSX_LAYOUT_PER_PROJECT_MAX_ENTRIES,
 } from "#veryfront/utils";
@@ -267,7 +268,7 @@ export async function loadTSXComponent(
   serverExternalPackages?: readonly string[],
   signal?: AbortSignal,
 ): Promise<BundledReact.ComponentType> {
-  signal?.throwIfAborted();
+  throwIfAborted(signal);
   const source = await adapter.fs.readFile(componentPath);
   const dependencySnapshot = await resolveDependencyPinningSnapshot(
     dependencyPinningSource ?? projectDir,
@@ -290,14 +291,14 @@ export async function loadTSXComponent(
     cacheKey += `:server-externals:${hashString(serverExternalPackagesIdentity)}`;
   }
 
-  signal?.throwIfAborted();
+  throwIfAborted(signal);
   const cached = cache.get(cacheKey);
   if (cached) return cached;
 
   const loaded = await getTSXComponentFlights(cache).do(
     cacheKey,
     async (control) => {
-      control.signal.throwIfAborted();
+      throwIfAborted(control.signal);
       const cachedDuringFlight = cache.get(cacheKey);
       if (cachedDuringFlight) return cachedDuringFlight;
 

--- a/src/rendering/layouts/utils/component-loader.ts
+++ b/src/rendering/layouts/utils/component-loader.ts
@@ -265,7 +265,9 @@ export async function loadTSXComponent(
   dependencyPinningSource?: DependencyPinningSourceInput,
   moduleServerOrigin?: string,
   serverExternalPackages?: readonly string[],
+  signal?: AbortSignal,
 ): Promise<BundledReact.ComponentType> {
+  signal?.throwIfAborted();
   const source = await adapter.fs.readFile(componentPath);
   const dependencySnapshot = await resolveDependencyPinningSnapshot(
     dependencyPinningSource ?? projectDir,
@@ -288,12 +290,14 @@ export async function loadTSXComponent(
     cacheKey += `:server-externals:${hashString(serverExternalPackagesIdentity)}`;
   }
 
+  signal?.throwIfAborted();
   const cached = cache.get(cacheKey);
   if (cached) return cached;
 
   const loaded = await getTSXComponentFlights(cache).do(
     cacheKey,
     async (control) => {
+      control.signal.throwIfAborted();
       const cachedDuringFlight = cache.get(cacheKey);
       if (cachedDuringFlight) return cachedDuringFlight;
 
@@ -314,6 +318,7 @@ export async function loadTSXComponent(
           dependencyPinningCacheKey: dependencySnapshot.cacheKey,
           dependencyPinningDependencies: dependencySnapshot.dependencies,
           dependencyPinningSource: dependencyPinningSource ?? projectDir,
+          signal: control.signal,
         },
       );
 
@@ -338,6 +343,8 @@ export async function loadTSXComponent(
           componentPath,
         });
       },
+      signal,
+      cancelWhenUnobserved: true,
     },
   );
   return loaded;
@@ -463,6 +470,7 @@ export async function applyTSXLayout(
   dependencyPinningSource?: DependencyPinningSourceInput,
   moduleServerOrigin?: string,
   serverExternalPackages?: readonly string[],
+  signal?: AbortSignal,
 ): Promise<BundledReact.ReactElement> {
   const start = performance.now();
   applyTsxLayoutLog.debug("START", {
@@ -492,6 +500,7 @@ export async function applyTSXLayout(
       dependencyPinningSource,
       moduleServerOrigin,
       serverExternalPackages,
+      signal,
     );
 
     applyTsxLayoutLog.debug("loadTSXComponent DONE", {

--- a/src/rendering/orchestrator/layout.ts
+++ b/src/rendering/orchestrator/layout.ts
@@ -10,7 +10,7 @@ import type { LayoutComponentCache } from "../layouts/utils/component-loader.ts"
 import { loadTSXComponent, preloadMDXLayoutModule } from "../layouts/utils/component-loader.ts";
 import { clearImportMapCache, preloadImportMap } from "#veryfront/modules/import-map/index.ts";
 import { clearSSRModuleCacheForProject } from "#veryfront/modules/react-loader/index.ts";
-import { rendererLogger } from "#veryfront/utils";
+import { rendererLogger, throwIfAborted } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import {
   type DependencyPinningSourceInput,
@@ -139,7 +139,7 @@ export class LayoutOrchestrator {
     return withSpan(
       "layout.preloadModules",
       async () => {
-        signal?.throwIfAborted();
+        throwIfAborted(signal);
         const tsxLayouts = nestedLayouts.filter(
           (layout) => layout.kind === "tsx" && layout.componentPath,
         );
@@ -191,7 +191,7 @@ export class LayoutOrchestrator {
                 this._preloadedImportMap = importMap;
                 return { type: "importMap" as const, success: true };
               } catch (error) {
-                signal?.throwIfAborted();
+                throwIfAborted(signal);
                 const errorMsg = error instanceof Error ? error.message : String(error);
                 logger.error("Failed to preload import map", {
                   error: errorMsg,
@@ -228,7 +228,7 @@ export class LayoutOrchestrator {
                 );
                 return { type: "tsx" as const, path: componentPath, success: true };
               } catch (error) {
-                signal?.throwIfAborted();
+                throwIfAborted(signal);
                 const errorMsg = error instanceof Error ? error.message : String(error);
                 logger.error("Failed to preload TSX layout", {
                   path: componentPath,
@@ -267,7 +267,7 @@ export class LayoutOrchestrator {
                 );
                 return { type: "mdx" as const, path: layout.path, success: true };
               } catch (error) {
-                signal?.throwIfAborted();
+                throwIfAborted(signal);
                 const errorMsg = error instanceof Error ? error.message : String(error);
                 logger.error("Failed to preload MDX layout", {
                   path: layout.path,
@@ -351,7 +351,7 @@ export class LayoutOrchestrator {
     return withSpan(
       "layout.applyLayoutsAndWrappers",
       async () => {
-        signal?.throwIfAborted();
+        throwIfAborted(signal);
         const reactVersion = await this.getReactVersion(
           dependencyPinningCacheKey,
           dependencyPinningDependencies,

--- a/src/rendering/orchestrator/layout.ts
+++ b/src/rendering/orchestrator/layout.ts
@@ -134,10 +134,12 @@ export class LayoutOrchestrator {
     dependencyPinningDependencies?: Readonly<Record<string, string>>,
     dependencyPinningSource?: DependencyPinningSourceInput,
     moduleServerOrigin?: string,
+    signal?: AbortSignal,
   ): Promise<LayoutPreloadSummary> {
     return withSpan(
       "layout.preloadModules",
       async () => {
+        signal?.throwIfAborted();
         const tsxLayouts = nestedLayouts.filter(
           (layout) => layout.kind === "tsx" && layout.componentPath,
         );
@@ -189,6 +191,7 @@ export class LayoutOrchestrator {
                 this._preloadedImportMap = importMap;
                 return { type: "importMap" as const, success: true };
               } catch (error) {
+                signal?.throwIfAborted();
                 const errorMsg = error instanceof Error ? error.message : String(error);
                 logger.error("Failed to preload import map", {
                   error: errorMsg,
@@ -221,9 +224,11 @@ export class LayoutOrchestrator {
                   dependencyPinningSource,
                   moduleServerOrigin,
                   this.config.config.build?.serverExternalPackages,
+                  signal,
                 );
                 return { type: "tsx" as const, path: componentPath, success: true };
               } catch (error) {
+                signal?.throwIfAborted();
                 const errorMsg = error instanceof Error ? error.message : String(error);
                 logger.error("Failed to preload TSX layout", {
                   path: componentPath,
@@ -262,6 +267,7 @@ export class LayoutOrchestrator {
                 );
                 return { type: "mdx" as const, path: layout.path, success: true };
               } catch (error) {
+                signal?.throwIfAborted();
                 const errorMsg = error instanceof Error ? error.message : String(error);
                 logger.error("Failed to preload MDX layout", {
                   path: layout.path,
@@ -340,10 +346,12 @@ export class LayoutOrchestrator {
     dependencyPinningCacheKey?: string,
     dependencyPinningDependencies?: Readonly<Record<string, string>>,
     dependencyPinningSource?: DependencyPinningSourceInput,
+    signal?: AbortSignal,
   ): Promise<React.ReactElement> {
     return withSpan(
       "layout.applyLayoutsAndWrappers",
       async () => {
+        signal?.throwIfAborted();
         const reactVersion = await this.getReactVersion(
           dependencyPinningCacheKey,
           dependencyPinningDependencies,
@@ -388,6 +396,7 @@ export class LayoutOrchestrator {
           dependencyPinningDependencies,
           dependencyPinningSource,
           isLocalProject: this.config.isLocalProject === true,
+          signal,
         });
 
         const pageType = pageElement.type;

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -22,7 +22,7 @@ import {
   registerCycleManifestSources,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 import type { TransformProgressListener } from "#veryfront/transforms/progress.ts";
-import { rendererLogger } from "#veryfront/utils";
+import { rendererLogger, throwIfAborted } from "#veryfront/utils";
 import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { MODULE_CACHE_MAX_ENTRIES } from "#veryfront/utils/constants/cache.ts";
 import { computeHash } from "#veryfront/utils/hash-utils.ts";
@@ -81,7 +81,7 @@ function cacheUnresolvedSpecifiers(cacheKey: string, specifiers: readonly string
 }
 
 function throwIfModuleLoadAborted(config: ModuleLoaderConfig): void {
-  config.signal?.throwIfAborted();
+  throwIfAborted(config.signal);
 }
 
 function markModuleLoadProgress(

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -163,6 +163,53 @@ describe("RenderPipeline behavior", () => {
     clearReleaseAssetManifestCache();
   });
 
+  it("threads render cancellation through layout preload and application", async () => {
+    const controller = new AbortController();
+    let preloadSignal: AbortSignal | undefined;
+    let applySignal: AbortSignal | undefined;
+    const pipeline = createPipeline("/project/pages/cancel-layout.tsx", {
+      layoutOrchestrator: {
+        collectLayouts: async () => ({
+          layoutBundle: undefined,
+          nestedLayouts: [{ kind: "tsx", componentPath: "/project/layout.tsx" }],
+        }),
+        preloadLayoutModules: async (
+          _layouts: unknown,
+          _pinKey: unknown,
+          _dependencies: unknown,
+          _source: unknown,
+          _origin: unknown,
+          signal: AbortSignal | undefined,
+        ) => {
+          preloadSignal = signal;
+          return {
+            tsxTotal: 1,
+            tsxSuccess: 1,
+            tsxFailures: [],
+            mdxTotal: 0,
+            mdxSuccess: 0,
+            mdxFailures: [],
+            importMapSuccess: true,
+            durationMs: 0,
+            allSuccess: true,
+          };
+        },
+        applyLayoutsAndWrappers: async (...args: unknown[]) => {
+          applySignal = args[15] as AbortSignal | undefined;
+          return args[0];
+        },
+      } as any,
+    });
+
+    await pipeline.renderPage("/cancel-layout", {
+      delivery: "string",
+      abortSignal: controller.signal,
+    });
+
+    assertEquals(preloadSignal, controller.signal);
+    assertEquals(applySignal, controller.signal);
+  });
+
   it("resolves request-scoped module loader identity and the configured React version", async () => {
     const pipeline = createPipeline("/project/pages/index.tsx", {
       projectId: "project-config-id",

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -802,6 +802,7 @@ export class RenderPipeline {
                   options?.dependencyPinningDependencies,
                   options?.dependencyPinningSource,
                   options?.url?.origin,
+                  options?.abortSignal,
                 )
                 : Promise.resolve();
 
@@ -972,6 +973,7 @@ export class RenderPipeline {
                         options?.dependencyPinningCacheKey,
                         options?.dependencyPinningDependencies,
                         options?.dependencyPinningSource,
+                        options?.abortSignal,
                       ),
                     {
                       "render.slug": slug,

--- a/src/rendering/orchestrator/ssr-orchestrator.test.ts
+++ b/src/rendering/orchestrator/ssr-orchestrator.test.ts
@@ -294,6 +294,7 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
       let wrappedProjectSlug: string | undefined;
       let wrappedClientPageIsland: unknown;
       let wrappedFrontmatter: Record<string, unknown> | undefined;
+      let wrappedSignal: AbortSignal | undefined;
 
       const config = createMockConfig({
         ssrRenderer: {
@@ -330,6 +331,10 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
             projectSlug: string | undefined,
             clientPageIsland: unknown,
             props: Record<string, unknown> | undefined,
+            _pinKey: unknown,
+            _dependencies: unknown,
+            _source: unknown,
+            abortSignal: AbortSignal | undefined,
           ) => {
             wrappedUrl = url;
             wrappedParams = params;
@@ -337,6 +342,7 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
             wrappedClientPageIsland = clientPageIsland;
             wrappedProps = props;
             wrappedFrontmatter = frontmatter;
+            wrappedSignal = abortSignal;
             return React.createElement("section", null, element as React.ReactNode);
           },
         } as unknown as SSROrchestratorConfig["layoutOrchestrator"],
@@ -345,6 +351,7 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
       const orchestrator = new SSROrchestrator(config);
       const url = new URL("http://localhost/blog/hello?draft=1");
       const clientPageIsland = { mode: "client-page" };
+      const controller = new AbortController();
       let signal: (Error & { errorBoundaryHtml?: string }) | undefined;
 
       try {
@@ -376,6 +383,7 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
               props: { preview: true },
               projectSlug: "docs",
               clientPageIsland: clientPageIsland as any,
+              abortSignal: controller.signal,
             },
           } as any,
         );
@@ -393,6 +401,7 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
       assertEquals(wrappedClientPageIsland, clientPageIsland);
       assertEquals(wrappedProps, { preview: true });
       assertEquals(wrappedFrontmatter, { section: "blog", title: "Hello" });
+      assertEquals(wrappedSignal, controller.signal);
     });
   });
 });

--- a/src/rendering/orchestrator/ssr-orchestrator.ts
+++ b/src/rendering/orchestrator/ssr-orchestrator.ts
@@ -249,6 +249,7 @@ export class SSROrchestrator {
         renderOptions?.dependencyPinningCacheKey,
         renderOptions?.dependencyPinningDependencies,
         renderOptions?.dependencyPinningSource,
+        renderOptions?.abortSignal,
       )
       : errorInfo.element;
 

--- a/src/rendering/page-renderer.ts
+++ b/src/rendering/page-renderer.ts
@@ -37,6 +37,8 @@ interface PageRenderOptions {
   dependencyPinningDependencies?: Readonly<Record<string, string>>;
   /** Exact package source namespace paired with the immutable snapshot. */
   dependencyPinningSource?: DependencyPinningSourceInput;
+  /** Internal signal for the render owner's total deadline. */
+  abortSignal?: AbortSignal;
 }
 
 interface PageBundleResult {
@@ -234,6 +236,7 @@ export class PageRenderer {
                   dependencyPinningDependencies: options?.dependencyPinningDependencies,
                   dependencyPinningSource: options?.dependencyPinningSource,
                   serverExternalPackages: this.config.build?.serverExternalPackages,
+                  signal: options?.abortSignal,
                 },
               ),
             { "render.component_path": pageInfo.entity.path },

--- a/src/rendering/page-renderer.ts
+++ b/src/rendering/page-renderer.ts
@@ -37,8 +37,6 @@ interface PageRenderOptions {
   dependencyPinningDependencies?: Readonly<Record<string, string>>;
   /** Exact package source namespace paired with the immutable snapshot. */
   dependencyPinningSource?: DependencyPinningSourceInput;
-  /** Internal signal for the render owner's total deadline. */
-  abortSignal?: AbortSignal;
 }
 
 interface PageBundleResult {
@@ -236,7 +234,6 @@ export class PageRenderer {
                   dependencyPinningDependencies: options?.dependencyPinningDependencies,
                   dependencyPinningSource: options?.dependencyPinningSource,
                   serverExternalPackages: this.config.build?.serverExternalPackages,
-                  signal: options?.abortSignal,
                 },
               ),
             { "render.component_path": pageInfo.entity.path },

--- a/src/utils/singleflight.test.ts
+++ b/src/utils/singleflight.test.ts
@@ -18,6 +18,47 @@ describe("Singleflight", () => {
     assertEquals(await follower, 42);
   });
 
+  it("cancels shared work only after its final abortable waiter detaches", async () => {
+    const sf = new Singleflight<number>();
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    let operationSignal: AbortSignal | undefined;
+    let operationCalls = 0;
+
+    const operation = (control: { signal: AbortSignal }): Promise<number> => {
+      operationCalls++;
+      operationSignal = control.signal;
+      return new Promise((_resolve, reject) => {
+        control.signal.addEventListener(
+          "abort",
+          () => reject(control.signal.reason),
+          { once: true },
+        );
+      });
+    };
+
+    const first = sf.do("key", operation, {
+      signal: firstController.signal,
+      cancelWhenUnobserved: true,
+    });
+    const second = sf.do("key", operation, {
+      signal: secondController.signal,
+      cancelWhenUnobserved: true,
+    });
+
+    const firstReason = new DOMException("first render cancelled", "AbortError");
+    firstController.abort(firstReason);
+    await assertRejects(() => first, Error, "first render cancelled");
+    assertEquals(operationSignal?.aborted, false);
+
+    const secondReason = new DOMException("second render cancelled", "AbortError");
+    secondController.abort(secondReason);
+    await assertRejects(() => second, Error, "second render cancelled");
+    assertEquals(operationSignal?.aborted, true);
+    assertEquals(operationSignal?.reason, secondReason);
+    assertEquals(operationCalls, 1);
+  });
+
   it("should execute operation and return result", async () => {
     const sf = new Singleflight<number>();
     const result = await sf.do("key", () => Promise.resolve(42));

--- a/src/utils/singleflight.ts
+++ b/src/utils/singleflight.ts
@@ -5,16 +5,30 @@ export interface SingleflightOptions {
   staleAfterMs?: number;
   /** Called after this exact leader is evicted as stale. */
   onStaleEvicted?: () => void;
+  /** Lets this caller detach without cancelling other callers. */
+  signal?: AbortSignal;
+  /** Cancels the shared operation after its final caller detaches. */
+  cancelWhenUnobserved?: boolean;
 }
 
 export interface SingleflightControl {
   /** Whether this operation is still the exact leader registered for its key. */
   isCurrent(): boolean;
+  /** Shared cancellation that fires only after every caller detaches. */
+  signal: AbortSignal;
 }
 
 interface SingleflightEntry<T> {
   promise: Promise<T>;
+  controller: AbortController;
+  waiterCount: number;
+  settled: boolean;
+  cancelWhenUnobserved: boolean;
   staleTimer?: ReturnType<typeof setTimeout>;
+}
+
+function signalAbortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
 }
 
 /**
@@ -27,20 +41,17 @@ export async function waitForSharedPromise<T>(
 ): Promise<T> {
   if (!signal) return await shared;
 
-  const abortReason = (): unknown =>
-    signal.reason ?? new DOMException("The operation was aborted", "AbortError");
-
   if (signal.aborted) {
     // The shared operation can still fail after this caller detaches.
     // Observe that rejection so a sole detached caller cannot leave it unhandled.
     void shared.catch(() => {});
-    throw abortReason();
+    throw signalAbortReason(signal);
   }
 
   return await new Promise<T>((resolve, reject) => {
     const onAbort = (): void => {
       signal.removeEventListener("abort", onAbort);
-      reject(abortReason());
+      reject(signalAbortReason(signal));
     };
 
     signal.addEventListener("abort", onAbort, { once: true });
@@ -60,6 +71,52 @@ export async function waitForSharedPromise<T>(
 export class Singleflight<T> {
   private inflight = new Map<string, SingleflightEntry<T>>();
 
+  private waitForEntry(
+    key: string,
+    entry: SingleflightEntry<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    entry.waiterCount++;
+
+    return new Promise<T>((resolve, reject) => {
+      let finished = false;
+      let released = false;
+
+      const release = (reason?: unknown): void => {
+        if (released) return;
+        released = true;
+        entry.waiterCount--;
+        if (
+          entry.waiterCount === 0 && entry.cancelWhenUnobserved && !entry.settled &&
+          !entry.controller.signal.aborted
+        ) {
+          entry.controller.abort(reason);
+          if (this.inflight.get(key) === entry) this.inflight.delete(key);
+          if (entry.staleTimer !== undefined) clearTimeout(entry.staleTimer);
+        }
+      };
+      const detach = (): void => signal?.removeEventListener("abort", onAbort);
+      const finish = (settle: () => void, reason?: unknown): void => {
+        if (finished) return;
+        finished = true;
+        detach();
+        release(reason);
+        settle();
+      };
+      const onAbort = (): void => {
+        const reason = signal ? signalAbortReason(signal) : undefined;
+        finish(() => reject(reason), reason);
+      };
+
+      signal?.addEventListener("abort", onAbort, { once: true });
+      entry.promise.then(
+        (value) => finish(() => resolve(value)),
+        (error) => finish(() => reject(error)),
+      );
+      if (signal?.aborted) onAbort();
+    });
+  }
+
   async do(
     key: string,
     operation: (control: SingleflightControl) => Promise<T>,
@@ -68,9 +125,13 @@ export class Singleflight<T> {
     if (options.staleAfterMs !== undefined && options.staleAfterMs <= 0) {
       throw new RangeError("Singleflight staleAfterMs must be greater than zero");
     }
+    if (options.signal?.aborted) throw signalAbortReason(options.signal);
 
-    const existing = this.inflight.get(key);
-    if (existing) return existing.promise;
+    const entry = this.inflight.get(key);
+    if (entry) {
+      if (options.cancelWhenUnobserved === true) entry.cancelWhenUnobserved = true;
+      return await this.waitForEntry(key, entry, options.signal);
+    }
 
     let resolvePromise!: (value: T | PromiseLike<T>) => void;
     let rejectPromise!: (reason?: unknown) => void;
@@ -78,21 +139,44 @@ export class Singleflight<T> {
       resolvePromise = resolve;
       rejectPromise = reject;
     });
-    const entry: SingleflightEntry<T> = { promise };
-    const control: SingleflightControl = {
-      isCurrent: () => this.inflight.get(key) === entry,
+    const createdEntry: SingleflightEntry<T> = {
+      promise,
+      controller: new AbortController(),
+      waiterCount: 0,
+      settled: false,
+      cancelWhenUnobserved: options.cancelWhenUnobserved === true,
     };
-    this.inflight.set(key, entry);
+    const control: SingleflightControl = {
+      isCurrent: () => this.inflight.get(key) === createdEntry,
+      signal: createdEntry.controller.signal,
+    };
+    this.inflight.set(key, createdEntry);
 
     try {
-      void operation(control).then(resolvePromise, rejectPromise);
+      void operation(control).then(
+        (value) => {
+          createdEntry.settled = true;
+          resolvePromise(value);
+        },
+        (error) => {
+          createdEntry.settled = true;
+          rejectPromise(error);
+        },
+      );
     } catch (error) {
+      createdEntry.settled = true;
       rejectPromise(error);
     }
 
+    const cleanup = (): void => {
+      if (createdEntry.staleTimer !== undefined) clearTimeout(createdEntry.staleTimer);
+      if (this.inflight.get(key) === createdEntry) this.inflight.delete(key);
+    };
+    void promise.then(cleanup, cleanup);
+
     if (options.staleAfterMs !== undefined) {
-      entry.staleTimer = setTimeout(() => {
-        if (this.inflight.get(key) !== entry) return;
+      createdEntry.staleTimer = setTimeout(() => {
+        if (this.inflight.get(key) !== createdEntry) return;
         this.inflight.delete(key);
         try {
           options.onStaleEvicted?.();
@@ -101,15 +185,10 @@ export class Singleflight<T> {
           // the timer task or interfere with singleflight state cleanup.
         }
       }, options.staleAfterMs);
-      unrefTimer(entry.staleTimer);
+      unrefTimer(createdEntry.staleTimer);
     }
 
-    try {
-      return await promise;
-    } finally {
-      if (entry.staleTimer !== undefined) clearTimeout(entry.staleTimer);
-      if (this.inflight.get(key) === entry) this.inflight.delete(key);
-    }
+    return await this.waitForEntry(key, createdEntry, options.signal);
   }
 
   has(key: string): boolean {


### PR DESCRIPTION
Addresses part 3 of veryfront/veryfront-issue-inbox#113 (concurrent refreshes hard-error). Parts 1, 2 and 4 are out of scope here.

## Problem

On a cold cache, hard-refreshing several tabs at once fails the render with:

```
Failed to load TSX/JSX component: Transform capacity exceeded (0 waiting). Service is overloaded.
```

Two defects behind it:

1. The global transform semaphore uses one acquire deadline for every environment (`TRANSFORM_ACQUIRE_TIMEOUT_MS`, 5s). The dev server already bypasses the per-project cap (`loader.ts`, `options.dev`), but the global semaphore still sheds load on a single-tenant laptop, where shedding protects nobody. A cold fan-out across the framework tree exhausts the 50 permits and the next request fails instead of queueing.
2. The diagnostic understates the queue. A timed-out waiter removes itself from the wait queue before its caller resumes, so the last waiter standing reads `waiting === 0` for a queue it was still part of.

## Fix

- `getTransformAcquireTimeoutMs(dev)` in `src/modules/react-loader/ssr-module-loader/constants.ts` returns `TRANSFORM_ACQUIRE_TIMEOUT_DEV_MS` (30s) in dev and the unchanged 5s deadline otherwise. 30s stays below `MODULE_LOAD_TIMEOUT_MS` (40s) and the 60s render pipeline cap, so a wedged transform still fails as a load error.
- `withTransformCapacity` reuses the existing `this.options.dev` signal (the same one the per-project bypass uses). No new env var.
- `Semaphore.tryAcquireWithReport()` returns `{ acquired, waiting }`, snapshotting the queue depth before the waiter leaves the queue. `tryAcquire()` keeps its boolean contract and delegates.

Production back-pressure is unchanged: same 5s deadline, same permits, same error.

## Evidence

New `src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts`, both red before the fix:

- `should fail fast with the real queue depth when production capacity is exhausted`
  - before: `Expected actual: "Transform capacity exceeded (0 waiting). Service is overloaded." to contain: "Transform capacity exceeded (1 waiting)"`
  - after: passes, and proves production still fails at the 5s deadline.
- `should queue a dev burst past the production deadline and succeed once permits free`
  - before: `Values are not equal: dev requests must still be queued after the production deadline passes` (actual 0, expected 4), that is, the burst had already errored.
  - after: all four queued dev requests run once permits free.

New semaphore cases in `concurrency/semaphore.test.ts`:

- `should report the queue depth a timed-out waiter observed` (a lone waiter reports 1, not 0)
- `should report every queued waiter present when an acquire times out`

Verification commands:

```
deno test --preload=src/testing/preload.ts --no-check --allow-all \
  src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts \
  src/modules/react-loader/ssr-module-loader/concurrency/semaphore.test.ts
# ok | 2 passed (20 steps) | 0 failed

deno test ... --parallel src/modules/react-loader        # ok | 24 passed (216 steps) | 0 failed
deno test ... --parallel src/rendering src/transforms    # ok | 265 passed (4318 steps) | 0 failed
deno fmt / deno lint / deno check on the touched files   # clean
```

The unit sweep also reports pre-existing failures in `src/oauth/**`, `src/cache/backend.test.ts` and the CLI end-to-end suites. Those reproduce on a clean tree with these changes stashed (network-dependent in this environment) and are unrelated to this change.

## Review note: cancellation was tried and reverted

A review suggestion to pass a render `AbortSignal` into the queued acquire was implemented at `ca43fa205` and reverted at `175865512`. `globalInProgress` registers the transform promise before `withTransformCapacity` runs, so aborting a queued acquire rejects the leader every follower is awaiting: those followers drop the shared flight and retransform, and a second rejection propagates because `MAX_REJECTED_IN_PROGRESS_RETRIES` is 1. That makes one closed tab slow or fail the other tabs this PR exists to fix, and the signal was not dev-gated, so it changed production behavior. Cancelling shared singleflighted transforms needs a design against the singleflight contract and belongs in its own change. Full reasoning is on the resolved review threads.
