### PR TITLE
fix(rendering): make cycle imports generation-safe

### DIFF
--- a/src/rendering/orchestrator/module-loader/cycle-manifest.test.ts
+++ b/src/rendering/orchestrator/module-loader/cycle-manifest.test.ts
@@ -1,0 +1,338 @@
+import "#veryfront/schemas/_test-setup.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertNotEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { basename, join } from "#veryfront/compat/path/index.ts";
+import {
+  getCycleManifestCacheDir,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import {
+  advanceCycleManifestGeneration,
+  getCycleManifestGeneration,
+} from "#veryfront/transforms/mdx/esm-module-loader/cycle-manifest-lifecycle.ts";
+import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import {
+  CYCLE_MANIFEST_SIDECAR_SUFFIX,
+  cycleArtifactBelongsToGraph,
+  CycleManifestTransaction,
+  inspectCycleManifestCache,
+} from "./cycle-manifest.ts";
+
+async function removeFixture(tmpDir: string): Promise<void> {
+  await Promise.all([
+    Deno.remove(tmpDir, { recursive: true }).catch(() => undefined),
+    Deno.remove(getCycleManifestCacheDir(tmpDir), { recursive: true }).catch(() => undefined),
+  ]);
+}
+
+describe("module-loader/cycle-manifest", () => {
+  it("adopts a persisted generation before the first local invalidation", async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-cycle-persisted-generation-" });
+    const manifestDir = getCycleManifestCacheDir(tmpDir);
+    const artifactPath = join(
+      manifestDir,
+      "42-snapshot/artifacts/0.snapshot.js",
+    );
+
+    try {
+      assertEquals(
+        cycleArtifactBelongsToGraph(artifactPath, tmpDir, "snapshot"),
+        true,
+      );
+      advanceCycleManifestGeneration(manifestDir);
+      assertEquals(
+        cycleArtifactBelongsToGraph(artifactPath, tmpDir, "snapshot"),
+        false,
+      );
+    } finally {
+      await removeFixture(tmpDir);
+    }
+  });
+
+  it("rejects an artifact from an invalidated manifest generation", async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-cycle-generation-" });
+    const manifestDir = getCycleManifestCacheDir(tmpDir);
+    const generation = getCycleManifestGeneration(manifestDir);
+    const artifactPath = join(
+      manifestDir,
+      `${generation}-snapshot/artifacts/0.snapshot.js`,
+    );
+
+    try {
+      assertEquals(
+        cycleArtifactBelongsToGraph(artifactPath, tmpDir, "snapshot"),
+        true,
+      );
+      advanceCycleManifestGeneration(manifestDir);
+      assertEquals(
+        cycleArtifactBelongsToGraph(artifactPath, tmpDir, "snapshot"),
+        false,
+      );
+    } finally {
+      await removeFixture(tmpDir);
+    }
+  });
+
+  it("rejects an edge count that its cache evidence cannot represent", () => {
+    const transaction = new CycleManifestTransaction("/tmp/cycle-limit", "bounded");
+    for (let index = 0; index < 5_000; index++) {
+      transaction.registerEdge(`/project/target-${index}.ts`, "/project/importer.ts", true);
+    }
+
+    const error = assertThrows(
+      () => transaction.registerEdge("/project/overflow.ts", "/project/importer.ts", true),
+      VeryfrontError,
+    );
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(error.slug, "cache-error");
+  });
+
+  it("publishes colliding targets only after every entry is durable", async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-cycle-manifest-" });
+    const localAdapter = await getLocalAdapter();
+    const tsSourcePath = "/project/app/page.ts";
+    const tsxSourcePath = "/project/app/page.tsx";
+    const transaction = new CycleManifestTransaction(
+      tmpDir,
+      "snapshot-a",
+      new Map([
+        [tsSourcePath, "0"],
+        [tsxSourcePath, "1"],
+      ]),
+    );
+    const manifestRoot = getCycleManifestCacheDir(tmpDir);
+    const tsEntryPath = transaction.registerEdge(tsSourcePath, tsSourcePath, true);
+    const tsxArtifactPath = transaction.registerEdge(tsxSourcePath, tsxSourcePath, false);
+    const tsArtifactPath = transaction.reserveArtifactPath(tsSourcePath);
+
+    try {
+      await Deno.mkdir(join(manifestRoot, "0-snapshot-a/artifacts"), {
+        recursive: true,
+      });
+      await Deno.writeTextFile(tsxArtifactPath, `export default "tsx";`);
+      transaction.recordArtifact(tsxSourcePath, tsxArtifactPath, true);
+      await Deno.writeTextFile(
+        tsArtifactPath,
+        await transaction.sealRootArtifactCode(
+          `export const kind = "ts";`,
+          tsSourcePath,
+          false,
+          localAdapter,
+        ),
+      );
+      transaction.recordArtifact(tsSourcePath, tsArtifactPath, false, true);
+
+      let published = false;
+      transaction.deferCachePublication(async () => {
+        assertEquals(await localAdapter.fs.exists(tsEntryPath), true);
+        assertEquals(await localAdapter.fs.exists(tsxArtifactPath), true);
+        published = true;
+      });
+
+      await transaction.commit(localAdapter);
+
+      assertNotEquals(tsEntryPath, tsxArtifactPath);
+      assertStringIncludes(await Deno.readTextFile(tsEntryPath), basename(tsArtifactPath));
+      assertEquals(await Deno.readTextFile(tsxArtifactPath), `export default "tsx";`);
+      assertStringIncludes(await Deno.readTextFile(tsEntryPath), `export function then`);
+      assertEquals(await localAdapter.fs.exists(join(tmpDir, "app/page.js")), false);
+      assertEquals(published, true);
+    } finally {
+      await removeFixture(tmpDir);
+    }
+  });
+
+  it("fails closed before publication when its manifest directory cannot persist", async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-cycle-manifest-" });
+    const localAdapter = await getLocalAdapter();
+    const transaction = new CycleManifestTransaction(tmpDir, "mkdir-failure");
+    const sourcePath = join(tmpDir, "project/app/page.ts");
+    const manifestRoot = getCycleManifestCacheDir(tmpDir);
+    const artifactPath = join(manifestRoot, "0-mkdir-failure/artifacts/0.aaaa1111.js");
+    transaction.registerEdge(sourcePath, sourcePath, true);
+    await Deno.mkdir(join(manifestRoot, "0-mkdir-failure/artifacts"), {
+      recursive: true,
+    });
+    await Deno.writeTextFile(
+      artifactPath,
+      await transaction.sealRootArtifactCode(
+        `export const value = true;`,
+        sourcePath,
+        false,
+        localAdapter,
+      ),
+    );
+    transaction.recordArtifact(sourcePath, artifactPath, false, true);
+    let published = false;
+    transaction.deferCachePublication(() => {
+      published = true;
+      return Promise.resolve();
+    });
+
+    const stubFs = Object.create(localAdapter.fs) as typeof localAdapter.fs;
+    stubFs.mkdir = () => Promise.reject(new Error("ENOSPC: manifest directory"));
+    const stubAdapter = Object.create(localAdapter) as typeof localAdapter;
+    Object.defineProperty(stubAdapter, "fs", { value: stubFs });
+
+    try {
+      const error = await assertRejects(() => transaction.commit(stubAdapter), VeryfrontError);
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "cache-error");
+      assertEquals(published, false);
+    } finally {
+      await removeFixture(tmpDir);
+    }
+  });
+
+  it("binds the complete entry set to the root artifact", async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-cycle-manifest-complete-" });
+    const localAdapter = await getLocalAdapter();
+    const transaction = new CycleManifestTransaction(tmpDir, "complete");
+    const rootSource = "/project/root.ts";
+    const otherSource = "/project/other.ts";
+    const manifestRoot = getCycleManifestCacheDir(tmpDir);
+    const rootArtifact = join(manifestRoot, "0-complete/artifacts/0.aaaa1111.js");
+    const otherArtifact = join(manifestRoot, "0-complete/artifacts/1.bbbb2222.js");
+    const firstEntry = transaction.registerEdge(rootSource, rootSource, true);
+    transaction.registerEdge(otherSource, otherSource, true);
+
+    try {
+      await Deno.mkdir(join(manifestRoot, "0-complete/artifacts"), {
+        recursive: true,
+      });
+      await Deno.writeTextFile(otherArtifact, `export const other = true;`);
+      transaction.recordArtifact(otherSource, otherArtifact, false);
+      await Deno.writeTextFile(
+        rootArtifact,
+        await transaction.sealRootArtifactCode(
+          `export const root = true;`,
+          rootSource,
+          false,
+          localAdapter,
+        ),
+      );
+      transaction.recordArtifact(rootSource, rootArtifact, false, true);
+      await transaction.commit(localAdapter);
+
+      const sidecarPath = `${rootArtifact}${CYCLE_MANIFEST_SIDECAR_SUFFIX}`;
+      const sidecar = JSON.parse(await Deno.readTextFile(sidecarPath));
+      sidecar.entries = sidecar.entries.slice(1);
+      await Deno.writeTextFile(sidecarPath, JSON.stringify(sidecar));
+      await Deno.remove(firstEntry);
+
+      assertEquals(
+        await inspectCycleManifestCache(rootArtifact, tmpDir, localAdapter),
+        "invalid",
+      );
+    } finally {
+      await removeFixture(tmpDir);
+    }
+  });
+
+  it("rejects a sidecar whose entry is coherently retargeted", async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-cycle-manifest-retarget-" });
+    const localAdapter = await getLocalAdapter();
+    const transaction = new CycleManifestTransaction(tmpDir, "retarget");
+    const rootSource = "/project/root.ts";
+    const otherSource = "/project/other.ts";
+    const manifestRoot = getCycleManifestCacheDir(tmpDir);
+    const rootArtifact = join(manifestRoot, "0-retarget/artifacts/0.aaaa1111.js");
+    const otherArtifact = join(manifestRoot, "0-retarget/artifacts/1.bbbb2222.js");
+    const entryPath = transaction.registerEdge(otherSource, rootSource, true);
+    transaction.markCycleBound(otherSource);
+
+    try {
+      await Deno.mkdir(join(manifestRoot, "0-retarget/artifacts"), {
+        recursive: true,
+      });
+      await Deno.writeTextFile(otherArtifact, `export const other = true;`);
+      transaction.recordArtifact(otherSource, otherArtifact, false);
+      await Deno.writeTextFile(
+        rootArtifact,
+        await transaction.sealRootArtifactCode(
+          `export const root = true;`,
+          rootSource,
+          false,
+          localAdapter,
+        ),
+      );
+      transaction.recordArtifact(rootSource, rootArtifact, false, true);
+      await transaction.commit(localAdapter);
+
+      const sidecarPath = `${rootArtifact}${CYCLE_MANIFEST_SIDECAR_SUFFIX}`;
+      const sidecar = JSON.parse(await Deno.readTextFile(sidecarPath));
+      sidecar.entries[0][1] = sidecar.root;
+      await Deno.writeTextFile(sidecarPath, JSON.stringify(sidecar));
+      await Deno.writeTextFile(
+        entryPath,
+        [
+          "export function then(resolve, reject) {",
+          '  return import("./artifacts/0.aaaa1111.js").then(resolve, reject);',
+          "}",
+        ].join("\n"),
+      );
+
+      assertEquals(
+        await inspectCycleManifestCache(rootArtifact, tmpDir, localAdapter),
+        "invalid",
+      );
+    } finally {
+      await removeFixture(tmpDir);
+    }
+  });
+
+  it("persists one canonical manifest instead of duplicating it per member", async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-cycle-manifest-linear-" });
+    const localAdapter = await getLocalAdapter();
+    const transaction = new CycleManifestTransaction(tmpDir, "linear");
+    const artifactPaths: string[] = [];
+
+    try {
+      const manifestRoot = getCycleManifestCacheDir(tmpDir);
+      await Deno.mkdir(join(manifestRoot, "0-linear/artifacts"), {
+        recursive: true,
+      });
+      for (let index = 0; index < 40; index++) {
+        const sourcePath = `/project/module-${index}.ts`;
+        const artifactPath = join(
+          manifestRoot,
+          `0-linear/artifacts/${index.toString(36)}.deadbeef.js`,
+        );
+        transaction.registerEdge(sourcePath, sourcePath, true);
+        await Deno.writeTextFile(
+          artifactPath,
+          transaction.markMemberArtifactCode(`export const value = ${index};`),
+        );
+        transaction.recordArtifact(sourcePath, artifactPath, false, index === 0);
+        artifactPaths.push(artifactPath);
+      }
+      await Deno.writeTextFile(
+        artifactPaths[0]!,
+        await transaction.sealRootArtifactCode(
+          `export const value = 0;`,
+          "/project/module-0.ts",
+          false,
+          localAdapter,
+        ),
+      );
+      await transaction.commit(localAdapter);
+
+      let sidecarCount = 0;
+      for (const artifactPath of artifactPaths) {
+        if (await localAdapter.fs.exists(`${artifactPath}${CYCLE_MANIFEST_SIDECAR_SUFFIX}`)) {
+          sidecarCount++;
+        }
+      }
+      assertEquals(sidecarCount, 1);
+    } finally {
+      await removeFixture(tmpDir);
+    }
+  });
+});

--- a/src/rendering/orchestrator/module-loader/cycle-manifest.ts
+++ b/src/rendering/orchestrator/module-loader/cycle-manifest.ts
@@ -1,0 +1,708 @@
+/**
+ * Immutable indirection for module-graph cycle edges.
+ *
+ * @module rendering/orchestrator/module-loader/cycle-manifest
+ */
+
+import { CACHE_ERROR } from "#veryfront/errors";
+import { dirname, isAbsolute, join, relative } from "#veryfront/compat/path/index.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
+import {
+  CYCLE_MANIFEST_SIDECAR_SUFFIX,
+  getCycleManifestCacheDir,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import {
+  getCycleManifestGeneration,
+  isCurrentCycleManifestGeneration,
+  parseCycleManifestGeneration,
+} from "#veryfront/transforms/mdx/esm-module-loader/cycle-manifest-lifecycle.ts";
+import { computeHash } from "#veryfront/utils/hash-utils.ts";
+
+interface CycleManifestEntry {
+  path: string;
+  targetFilePath: string;
+  isDynamic: boolean;
+}
+
+interface PersistedArtifact {
+  path: string;
+  exposesDefault: boolean;
+  cycleBound: boolean;
+}
+
+type CachePublication = () => Promise<void>;
+
+const CYCLE_MANIFEST_FORMAT_VERSION = 2;
+const MAX_CYCLE_MANIFEST_ENTRIES = 5_000;
+const JSONParse = JSON.parse;
+const JSONStringify = JSON.stringify;
+export { CYCLE_MANIFEST_SIDECAR_SUFFIX };
+const CYCLE_MANIFEST_ROOT_MARKER = "//# veryfront-cycle-manifest:v2:";
+const CYCLE_MANIFEST_MEMBER_MARKER = "//# veryfront-cycle-member:v2:";
+const ROOT_TARGET_DESCRIPTOR = "$root";
+const CYCLE_MANIFEST_EVIDENCE = /^[a-f0-9]{64}:[0-9]{1,5}:[1-9][0-9]{0,4}$/;
+const CYCLE_MANIFEST_MEMBER_EVIDENCE = /^[A-Za-z0-9_-]{1,128}$/;
+const CYCLE_BOUND_MODULE_RELATIVE_PATH =
+  /^(?:0|[1-9][0-9]*)-[A-Za-z0-9_-]+\/artifacts\/[0-9a-z]+\.[A-Za-z0-9_-]{1,8}\.js$/;
+const GRAPH_ID = /^[A-Za-z0-9_-]{1,128}$/;
+
+function isWithinDirectory(path: string, directory: string): boolean {
+  const relativePath = relative(directory, path);
+  return relativePath !== ".." &&
+    !relativePath.startsWith("../") &&
+    !relativePath.startsWith("..\\") &&
+    !isAbsolute(relativePath);
+}
+
+function asModuleSpecifier(path: string): string {
+  const normalized = path.replaceAll("\\", "/");
+  return normalized.startsWith(".") ? normalized : `./${normalized}`;
+}
+
+function isCycleArtifactPath(path: string, tmpDir: string): boolean {
+  const relativePath = relative(getCycleManifestCacheDir(tmpDir), path).replaceAll("\\", "/");
+  return CYCLE_BOUND_MODULE_RELATIVE_PATH.test(relativePath);
+}
+
+/** Whether an immutable artifact belongs to the current source-graph snapshot. */
+export function cycleArtifactBelongsToGraph(
+  path: string,
+  tmpDir: string,
+  graphId: string,
+): boolean {
+  const manifestRoot = getCycleManifestCacheDir(tmpDir);
+  const relativePath = relative(manifestRoot, path).replaceAll("\\", "/");
+  const separator = relativePath.indexOf("/");
+  if (separator === -1) return false;
+  const graphDirectory = relativePath.slice(0, separator);
+  const generationSeparator = graphDirectory.indexOf("-");
+  const generation = parseCycleManifestGeneration(graphDirectory);
+  return generation !== undefined &&
+    isCurrentCycleManifestGeneration(manifestRoot, generation) &&
+    graphDirectory.slice(generationSeparator + 1) === graphId &&
+    CYCLE_BOUND_MODULE_RELATIVE_PATH.test(relativePath);
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function cycleManifestEntrySource(
+  targetSpecifier: string,
+  isDynamic: boolean,
+  exposesDefault: boolean,
+): string {
+  if (isDynamic) {
+    return [
+      "export function then(resolve, reject) {",
+      `  return import(${JSONStringify(targetSpecifier)}).then(resolve, reject);`,
+      "}",
+    ].join("\n");
+  }
+
+  const lines = [`export * from ${JSONStringify(targetSpecifier)};`];
+  if (exposesDefault) {
+    lines.push(`export { default } from ${JSONStringify(targetSpecifier)};`);
+  }
+  return lines.join("\n");
+}
+
+/** One transform graph's cycle entries and delayed cache publications. */
+export class CycleManifestTransaction {
+  readonly #tmpDir: string;
+  readonly #evidenceBaseDir: string;
+  readonly #manifestRootDir: string;
+  readonly #generation: number;
+  readonly #graphId: string;
+  readonly #manifestDir: string;
+  readonly #entries: CycleManifestEntry[] = [];
+  readonly #artifacts = new Map<string, PersistedArtifact>();
+  readonly #artifactPaths = new Map<string, string>();
+  readonly #artifactIds: ReadonlyMap<string, string>;
+  readonly #entryIds = new Map<string, string>();
+  readonly #cycleBoundSources: Set<string>;
+  readonly #dependencyWaits = new Map<string, Set<string>>();
+  readonly #cachePublications: CachePublication[] = [];
+  #rootArtifactPath: string | undefined;
+  #rootSourcePath: string | undefined;
+  #rootExposesDefault = false;
+  #rootIsCycleBound = false;
+  #rootEvidence: { digest: string; entryCount: number; artifactCount: number } | undefined;
+  #sealedArtifactDescriptors: [string, string][] | undefined;
+  #committed = false;
+
+  constructor(
+    tmpDir: string,
+    graphId = crypto.randomUUID().replaceAll("-", ""),
+    artifactIds: ReadonlyMap<string, string> = new Map(),
+  ) {
+    if (!GRAPH_ID.test(graphId)) {
+      throw CACHE_ERROR.create({ detail: "Cycle manifest graph identity is invalid" });
+    }
+    this.#tmpDir = tmpDir;
+    this.#evidenceBaseDir = dirname(tmpDir);
+    this.#graphId = graphId;
+    this.#manifestRootDir = getCycleManifestCacheDir(tmpDir);
+    this.#generation = getCycleManifestGeneration(this.#manifestRootDir);
+    this.#manifestDir = join(this.#manifestRootDir, `${this.#generation}-${graphId}`);
+    this.#artifactIds = artifactIds;
+    this.#cycleBoundSources = new Set();
+  }
+
+  /** Reserve an immutable module path for one edge before its target hash exists. */
+  registerEdge(
+    targetFilePath: string,
+    importerFilePath: string,
+    isDynamic: boolean,
+    plannedId?: string,
+  ): string {
+    if (this.#committed) {
+      throw CACHE_ERROR.create({ detail: "Cannot extend a committed cycle manifest" });
+    }
+    this.#cycleBoundSources.add(importerFilePath);
+    this.#cycleBoundSources.add(targetFilePath);
+    if (!isDynamic) return this.reserveArtifactPath(targetFilePath);
+
+    const edgeKey = JSONStringify([importerFilePath, targetFilePath, true]);
+    const existingPath = this.#entryIds.get(edgeKey);
+    if (existingPath) return existingPath;
+    if (this.#entries.length >= MAX_CYCLE_MANIFEST_ENTRIES) {
+      throw CACHE_ERROR.create({ detail: "Cycle manifest entry limit exceeded" });
+    }
+
+    const entryId = plannedId ?? this.#entries.length.toString(36);
+    if (!/^[0-9a-z-]{1,128}$/.test(entryId)) {
+      throw CACHE_ERROR.create({ detail: "Cycle manifest entry identity is invalid" });
+    }
+    const entryPath = join(this.#manifestDir, `${entryId}.js`);
+    this.#entryIds.set(edgeKey, entryPath);
+    this.#entries.push({ path: entryPath, targetFilePath, isDynamic });
+    return entryPath;
+  }
+
+  /** Mark an importer whose persisted artifact depends on a cycle-bound child. */
+  markCycleBound(filePath: string): void {
+    this.#cycleBoundSources.add(filePath);
+  }
+
+  /** Whether this source belongs to the ancestry of a cycle-closing edge. */
+  isCycleBound(filePath: string): boolean {
+    return this.#cycleBoundSources.has(filePath);
+  }
+
+  /** Track one recursive wait, or decline it when it would deadlock the graph. */
+  beginDependencyWait(importerFilePath: string, targetFilePath: string): (() => void) | null {
+    if (this.#hasDependencyPath(targetFilePath, importerFilePath)) return null;
+    let targets = this.#dependencyWaits.get(importerFilePath);
+    if (!targets) {
+      targets = new Set();
+      this.#dependencyWaits.set(importerFilePath, targets);
+    }
+    targets.add(targetFilePath);
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      targets!.delete(targetFilePath);
+      if (targets!.size === 0) this.#dependencyWaits.delete(importerFilePath);
+    };
+  }
+
+  #hasDependencyPath(startFilePath: string, targetFilePath: string): boolean {
+    if (startFilePath === targetFilePath) return true;
+    const visited = new Set([startFilePath]);
+    const pending = [startFilePath];
+    for (let index = 0; index < pending.length; index++) {
+      for (const dependency of this.#dependencyWaits.get(pending[index]!) ?? []) {
+        if (dependency === targetFilePath) return true;
+        if (visited.has(dependency)) continue;
+        visited.add(dependency);
+        pending.push(dependency);
+      }
+    }
+    return false;
+  }
+
+  /** Allocate one graph-content-addressed artifact path outside authored paths. */
+  reserveArtifactPath(filePath: string): string {
+    if (!this.#cycleBoundSources.has(filePath)) {
+      throw CACHE_ERROR.create({ detail: "Cannot reserve an artifact outside a cycle closure" });
+    }
+    const existing = this.#artifactPaths.get(filePath);
+    if (existing) return existing;
+
+    const artifactId = this.#artifactIds.get(filePath) ??
+      this.#artifactPaths.size.toString(36);
+    const path = join(
+      this.#manifestDir,
+      "artifacts",
+      `${artifactId}.${this.#graphId.slice(0, 8)}.js`,
+    );
+    this.#artifactPaths.set(filePath, path);
+    return path;
+  }
+
+  /** Record the content-addressed artifact produced for a source module. */
+  recordArtifact(
+    filePath: string,
+    path: string,
+    exposesDefault: boolean,
+    isGraphRoot = false,
+  ): void {
+    this.#artifacts.set(filePath, {
+      path,
+      exposesDefault,
+      cycleBound: this.#cycleBoundSources.has(filePath),
+    });
+    if (isGraphRoot) {
+      this.#rootArtifactPath = path;
+      this.#rootIsCycleBound = this.#cycleBoundSources.has(filePath);
+    }
+  }
+
+  /** Whether this graph needs export metadata for the source module. */
+  referencesStaticTarget(filePath: string): boolean {
+    return this.#entries.some((entry) => !entry.isDynamic && entry.targetFilePath === filePath);
+  }
+
+  /** Whether a cycle-closing edge addresses this source through the manifest. */
+  referencesTarget(filePath: string): boolean {
+    return this.#entries.some((entry) => entry.targetFilePath === filePath);
+  }
+
+  /** Delay publication until every cycle entry is durable. */
+  deferCachePublication(publication: CachePublication): void {
+    this.#cachePublications.push(publication);
+  }
+
+  /** Mark a cycle member so a later root lookup fails closed without a sidecar. */
+  markMemberArtifactCode(code: string): string {
+    return `${code}\n${CYCLE_MANIFEST_MEMBER_MARKER}${this.#graphId}\n`;
+  }
+
+  /** Bind the complete manifest entry set to the graph root's immutable bytes. */
+  async sealRootArtifactCode(
+    code: string,
+    rootSourcePath: string,
+    rootExposesDefault: boolean,
+    localAdapter: RuntimeAdapter,
+  ): Promise<string> {
+    this.#rootSourcePath = rootSourcePath;
+    this.#rootExposesDefault = rootExposesDefault;
+    const entryDescriptors = this.#entryDescriptors();
+    const artifactDescriptors = await this.#artifactDescriptors(localAdapter, code);
+    const digest = await computeHash(JSONStringify({
+      entries: entryDescriptors,
+      artifacts: artifactDescriptors,
+    }));
+    this.#sealedArtifactDescriptors = artifactDescriptors;
+    this.#rootEvidence = {
+      digest,
+      entryCount: entryDescriptors.length,
+      artifactCount: artifactDescriptors.length,
+    };
+    return `${code}\n${CYCLE_MANIFEST_ROOT_MARKER}${digest}:` +
+      `${entryDescriptors.length}:${artifactDescriptors.length}\n`;
+  }
+
+  async #artifactDescriptors(
+    localAdapter: RuntimeAdapter,
+    rootCode?: string,
+  ): Promise<[string, string][]> {
+    if (!this.#rootSourcePath) {
+      throw CACHE_ERROR.create({ detail: "Cycle manifest graph root is not initialized" });
+    }
+    const descriptors: [string, string][] = [];
+    for (const [sourcePath, artifact] of this.#artifacts) {
+      if (!artifact.cycleBound || sourcePath === this.#rootSourcePath) continue;
+      let raw: string | Uint8Array;
+      try {
+        raw = await localAdapter.fs.readFile(artifact.path);
+      } catch (error) {
+        throw CACHE_ERROR.create({
+          detail: "Failed to read a cycle manifest artifact",
+          cause: error,
+        });
+      }
+      const code = typeof raw === "string" ? raw : new TextDecoder().decode(raw);
+      descriptors.push([
+        relative(this.#evidenceBaseDir, artifact.path).replaceAll("\\", "/"),
+        await computeHash(code),
+      ]);
+    }
+    if (rootCode === undefined) {
+      throw CACHE_ERROR.create({ detail: "Cycle manifest root bytes are not initialized" });
+    }
+    descriptors.push([ROOT_TARGET_DESCRIPTOR, await computeHash(rootCode)]);
+    return descriptors.sort(([left], [right]) => compareText(left, right));
+  }
+
+  #entryDescriptors(): [string, string, boolean, boolean][] {
+    if (!this.#rootSourcePath) {
+      throw CACHE_ERROR.create({ detail: "Cycle manifest graph root is not initialized" });
+    }
+    return this.#entries
+      .map((entry): [string, string, boolean, boolean] => {
+        if (entry.targetFilePath === this.#rootSourcePath) {
+          return [
+            relative(this.#evidenceBaseDir, entry.path).replaceAll("\\", "/"),
+            ROOT_TARGET_DESCRIPTOR,
+            entry.isDynamic,
+            this.#rootExposesDefault,
+          ];
+        }
+        const target = this.#artifacts.get(entry.targetFilePath);
+        if (!target) {
+          throw CACHE_ERROR.create({ detail: "Cycle manifest target metadata is incomplete" });
+        }
+        return [
+          relative(this.#evidenceBaseDir, entry.path).replaceAll("\\", "/"),
+          relative(this.#evidenceBaseDir, target.path).replaceAll("\\", "/"),
+          entry.isDynamic,
+          target.exposesDefault,
+        ];
+      })
+      .sort(([left], [right]) => compareText(left, right));
+  }
+
+  /** Persist all entries, then make the graph's caches visible. */
+  async commit(localAdapter: RuntimeAdapter): Promise<void> {
+    if (this.#committed) {
+      throw CACHE_ERROR.create({ detail: "Cycle manifest transaction was already committed" });
+    }
+    this.#committed = true;
+
+    if (getCycleManifestGeneration(this.#manifestRootDir) !== this.#generation) {
+      throw CACHE_ERROR.create({ detail: "Cycle manifest generation was invalidated" });
+    }
+
+    if (this.#rootIsCycleBound) {
+      if (
+        !this.#rootArtifactPath ||
+        !this.#rootIsCycleBound ||
+        !this.#rootEvidence ||
+        this.#rootEvidence.entryCount !== this.#entries.length ||
+        !isWithinDirectory(this.#rootArtifactPath, this.#tmpDir) &&
+          !isCycleArtifactPath(this.#rootArtifactPath, this.#tmpDir)
+      ) {
+        throw CACHE_ERROR.create({
+          detail: "Cycle manifest has no durable graph root artifact",
+        });
+      }
+      let rootExists: boolean;
+      try {
+        rootExists = await localAdapter.fs.exists(this.#rootArtifactPath);
+      } catch (error) {
+        throw CACHE_ERROR.create({
+          detail: "Failed to validate cycle manifest graph root",
+          cause: error,
+        });
+      }
+      if (!rootExists) {
+        throw CACHE_ERROR.create({
+          detail: "Cycle manifest has no durable graph root artifact",
+        });
+      }
+      try {
+        await localAdapter.fs.mkdir(this.#manifestDir, { recursive: true });
+      } catch (error) {
+        throw CACHE_ERROR.create({
+          detail: "Failed to persist cycle manifest directory",
+          cause: error,
+        });
+      }
+
+      for (const entry of this.#entries) {
+        const target = this.#artifacts.get(entry.targetFilePath);
+        let targetExists = false;
+        if (target) {
+          try {
+            targetExists = await localAdapter.fs.exists(target.path);
+          } catch (error) {
+            throw CACHE_ERROR.create({
+              detail: "Failed to validate cycle manifest target",
+              cause: error,
+            });
+          }
+        }
+        if (
+          !target ||
+          !target.cycleBound ||
+          !isWithinDirectory(target.path, this.#manifestRootDir) ||
+          !isCycleArtifactPath(target.path, this.#tmpDir) ||
+          !targetExists
+        ) {
+          throw CACHE_ERROR.create({
+            detail: "Cycle manifest target is not a durable content-hashed module artifact",
+          });
+        }
+
+        const targetSpecifier = asModuleSpecifier(relative(dirname(entry.path), target.path));
+
+        try {
+          await localAdapter.fs.writeFile(
+            entry.path,
+            cycleManifestEntrySource(
+              targetSpecifier,
+              entry.isDynamic,
+              target.exposesDefault,
+            ),
+          );
+        } catch (error) {
+          throw CACHE_ERROR.create({
+            detail: "Failed to persist cycle manifest entry",
+            cause: error,
+          });
+        }
+      }
+
+      const serializedEntries = this.#entries.map((entry) => {
+        const target = this.#artifacts.get(entry.targetFilePath)!;
+        return [
+          relative(this.#evidenceBaseDir, entry.path).replaceAll("\\", "/"),
+          relative(this.#evidenceBaseDir, target.path).replaceAll("\\", "/"),
+          entry.isDynamic,
+          target.exposesDefault,
+        ];
+      }).sort(([left], [right]) => compareText(String(left), String(right)));
+      const rootArtifact = await localAdapter.fs.readFile(this.#rootArtifactPath);
+      const decodedRoot = typeof rootArtifact === "string"
+        ? rootArtifact
+        : new TextDecoder().decode(rootArtifact);
+      const rootCode = rootCodeWithoutEvidence(decodedRoot);
+      if (rootCode === undefined) {
+        throw CACHE_ERROR.create({ detail: "Cycle manifest root evidence is missing" });
+      }
+      const artifactDescriptors = await this.#artifactDescriptors(localAdapter, rootCode);
+      const digest = await computeHash(JSONStringify({
+        entries: this.#entryDescriptors(),
+        artifacts: artifactDescriptors,
+      }));
+      if (
+        digest !== this.#rootEvidence.digest ||
+        artifactDescriptors.length !== this.#rootEvidence.artifactCount ||
+        JSONStringify(artifactDescriptors) !== JSONStringify(this.#sealedArtifactDescriptors)
+      ) {
+        throw CACHE_ERROR.create({ detail: "Cycle manifest changed after its root was sealed" });
+      }
+      const serializedArtifacts = artifactDescriptors.map(([path, contentDigest]) => [
+        path === ROOT_TARGET_DESCRIPTOR
+          ? relative(this.#evidenceBaseDir, this.#rootArtifactPath!).replaceAll("\\", "/")
+          : path,
+        contentDigest,
+        path === ROOT_TARGET_DESCRIPTOR,
+      ]);
+      const serializedManifest = JSONStringify({
+        version: CYCLE_MANIFEST_FORMAT_VERSION,
+        root: relative(this.#evidenceBaseDir, this.#rootArtifactPath).replaceAll("\\", "/"),
+        digest: this.#rootEvidence.digest,
+        entryCount: this.#rootEvidence.entryCount,
+        artifactCount: this.#rootEvidence.artifactCount,
+        entries: serializedEntries,
+        artifacts: serializedArtifacts,
+      });
+      try {
+        await localAdapter.fs.writeFile(
+          `${this.#rootArtifactPath}${CYCLE_MANIFEST_SIDECAR_SUFFIX}`,
+          serializedManifest,
+        );
+      } catch (error) {
+        throw CACHE_ERROR.create({
+          detail: "Failed to persist cycle manifest cache evidence",
+          cause: error,
+        });
+      }
+    }
+
+    if (getCycleManifestGeneration(this.#manifestRootDir) !== this.#generation) {
+      throw CACHE_ERROR.create({ detail: "Cycle manifest generation was invalidated" });
+    }
+    for (const publish of this.#cachePublications) await publish();
+  }
+}
+
+export type CycleManifestCacheState = "none" | "valid-root" | "invalid";
+
+function rootEvidenceFromCode(
+  code: string,
+): { digest: string; entryCount: number; artifactCount: number } | undefined {
+  const markerIndex = code.lastIndexOf(`\n${CYCLE_MANIFEST_ROOT_MARKER}`);
+  if (markerIndex === -1) return undefined;
+  const evidence = code.slice(markerIndex + 1 + CYCLE_MANIFEST_ROOT_MARKER.length).trimEnd();
+  if (!CYCLE_MANIFEST_EVIDENCE.test(evidence)) return undefined;
+  const parts = evidence.split(":");
+  return {
+    digest: parts[0]!,
+    entryCount: Number(parts[1]),
+    artifactCount: Number(parts[2]),
+  };
+}
+
+function rootCodeWithoutEvidence(code: string): string | undefined {
+  const markerIndex = code.lastIndexOf(`\n${CYCLE_MANIFEST_ROOT_MARKER}`);
+  return markerIndex === -1 ? undefined : code.slice(0, markerIndex);
+}
+
+function hasCycleMarker(code: string): boolean {
+  if (rootEvidenceFromCode(code) !== undefined) return true;
+  const markerIndex = code.lastIndexOf(`\n${CYCLE_MANIFEST_MEMBER_MARKER}`);
+  if (markerIndex === -1) return false;
+  const evidence = code.slice(markerIndex + 1 + CYCLE_MANIFEST_MEMBER_MARKER.length).trimEnd();
+  return CYCLE_MANIFEST_MEMBER_EVIDENCE.test(evidence);
+}
+
+/** Validate the immutable cycle closure associated with a cached artifact. */
+export async function inspectCycleManifestCache(
+  modulePath: string,
+  tmpDir: string,
+  localAdapter: RuntimeAdapter,
+): Promise<CycleManifestCacheState> {
+  const evidenceBaseDir = dirname(tmpDir);
+  const manifestRootDir = getCycleManifestCacheDir(tmpDir);
+  let raw: string | Uint8Array;
+  try {
+    raw = await localAdapter.fs.readFile(`${modulePath}${CYCLE_MANIFEST_SIDECAR_SUFFIX}`);
+  } catch (error) {
+    if (!isNotFoundError(error)) return "invalid";
+    if (isCycleArtifactPath(modulePath, tmpDir)) return "invalid";
+    try {
+      const module = await localAdapter.fs.readFile(modulePath);
+      const decodedModule = typeof module === "string" ? module : new TextDecoder().decode(module);
+      return hasCycleMarker(decodedModule) ? "invalid" : "none";
+    } catch {
+      return "invalid";
+    }
+  }
+
+  try {
+    const decoded = typeof raw === "string" ? raw : new TextDecoder().decode(raw);
+    const parsed: unknown = JSONParse(decoded);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return "invalid";
+    const record = parsed as Record<string, unknown>;
+    if (
+      record.version !== CYCLE_MANIFEST_FORMAT_VERSION ||
+      typeof record.root !== "string" ||
+      typeof record.digest !== "string" ||
+      typeof record.entryCount !== "number" ||
+      typeof record.artifactCount !== "number" ||
+      !Array.isArray(record.entries) ||
+      !Array.isArray(record.artifacts) ||
+      record.entries.length > MAX_CYCLE_MANIFEST_ENTRIES ||
+      record.artifacts.length === 0 ||
+      record.artifacts.length > MAX_CYCLE_MANIFEST_ENTRIES
+    ) {
+      return "invalid";
+    }
+
+    const rootPath = join(evidenceBaseDir, record.root);
+    if (
+      !isWithinDirectory(rootPath, tmpDir) && !isCycleArtifactPath(rootPath, tmpDir) ||
+      !await localAdapter.fs.exists(rootPath)
+    ) {
+      return "invalid";
+    }
+    const rootArtifact = await localAdapter.fs.readFile(rootPath);
+    const decodedRoot = typeof rootArtifact === "string"
+      ? rootArtifact
+      : new TextDecoder().decode(rootArtifact);
+    const rootEvidence = rootEvidenceFromCode(decodedRoot);
+    if (
+      !rootEvidence ||
+      rootEvidence.digest !== record.digest ||
+      rootEvidence.entryCount !== record.entryCount ||
+      rootEvidence.artifactCount !== record.artifactCount ||
+      record.entryCount !== record.entries.length ||
+      record.artifactCount !== record.artifacts.length
+    ) {
+      return "invalid";
+    }
+
+    const descriptors: [string, string, boolean, boolean][] = [];
+    for (const value of record.entries) {
+      if (
+        !Array.isArray(value) || value.length !== 4 ||
+        typeof value[0] !== "string" || typeof value[1] !== "string" ||
+        typeof value[2] !== "boolean" || typeof value[3] !== "boolean"
+      ) {
+        return "invalid";
+      }
+      const entryPath = join(evidenceBaseDir, value[0]);
+      const targetPath = join(evidenceBaseDir, value[1]);
+      const targetSpecifier = asModuleSpecifier(relative(dirname(entryPath), targetPath));
+      if (
+        !isWithinDirectory(entryPath, manifestRootDir) ||
+        !isWithinDirectory(targetPath, manifestRootDir) ||
+        !isCycleArtifactPath(targetPath, tmpDir) ||
+        !await localAdapter.fs.exists(targetPath)
+      ) {
+        return "invalid";
+      }
+      const entry = await localAdapter.fs.readFile(entryPath);
+      const decodedEntry = typeof entry === "string" ? entry : new TextDecoder().decode(entry);
+      if (decodedEntry !== cycleManifestEntrySource(targetSpecifier, value[2], value[3])) {
+        return "invalid";
+      }
+      descriptors.push([
+        relative(evidenceBaseDir, entryPath).replaceAll("\\", "/"),
+        targetPath === rootPath
+          ? ROOT_TARGET_DESCRIPTOR
+          : relative(evidenceBaseDir, targetPath).replaceAll("\\", "/"),
+        value[2],
+        value[3],
+      ]);
+    }
+    descriptors.sort(([left], [right]) => compareText(left, right));
+    const artifactDescriptors: [string, string][] = [];
+    let foundRootArtifact = false;
+    for (const value of record.artifacts) {
+      if (
+        !Array.isArray(value) || value.length !== 3 ||
+        typeof value[0] !== "string" || typeof value[1] !== "string" ||
+        typeof value[2] !== "boolean" || !/^[a-f0-9]{64}$/.test(value[1])
+      ) {
+        return "invalid";
+      }
+      const artifactPath = join(evidenceBaseDir, value[0]);
+      const isRoot = value[2];
+      if (
+        isRoot && foundRootArtifact ||
+        isRoot && artifactPath !== rootPath ||
+        !isRoot && !isCycleArtifactPath(artifactPath, tmpDir) ||
+        !await localAdapter.fs.exists(artifactPath)
+      ) {
+        return "invalid";
+      }
+      const artifact = await localAdapter.fs.readFile(artifactPath);
+      const decodedArtifact = typeof artifact === "string"
+        ? artifact
+        : new TextDecoder().decode(artifact);
+      const artifactCode = isRoot ? rootCodeWithoutEvidence(decodedArtifact) : decodedArtifact;
+      if (artifactCode === undefined || await computeHash(artifactCode) !== value[1]) {
+        return "invalid";
+      }
+      if (isRoot) foundRootArtifact = true;
+      artifactDescriptors.push([
+        isRoot
+          ? ROOT_TARGET_DESCRIPTOR
+          : relative(evidenceBaseDir, artifactPath).replaceAll("\\", "/"),
+        value[1],
+      ]);
+    }
+    if (!foundRootArtifact) return "invalid";
+    artifactDescriptors.sort(([left], [right]) => compareText(left, right));
+    const digest = await computeHash(JSONStringify({
+      entries: descriptors,
+      artifacts: artifactDescriptors,
+    }));
+    if (digest !== record.digest) return "invalid";
+    return rootPath === modulePath ? "valid-root" : "invalid";
+  } catch {
+    return "invalid";
+  }
+}
+
+/** Whether persistence changes the authored extension to a hashed JavaScript artifact. */
+export function needsCycleManifest(filePath: string): boolean {
+  return /\.(?:tsx?|jsx?|mdx)$/.test(filePath);
+}

--- a/src/rendering/orchestrator/module-loader/index.test.ts
+++ b/src/rendering/orchestrator/module-loader/index.test.ts
@@ -9,9 +9,20 @@ import {
 } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
-import { basename, dirname, join } from "#veryfront/compat/path/index.ts";
+import { dirname, fromFileUrl, join, toFileUrl } from "#veryfront/compat/path/index.ts";
 import { getMdxEsmCacheDir, runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
-import { buildMdxEsmPathCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import {
+  buildMdxEsmPathCacheKey,
+  getCycleManifestCacheDir,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import {
+  clearModulePathCache,
+  getLocalFs,
+  getModulePathCache,
+  invalidateModulePaths,
+  saveModulePathCache,
+  waitForDiskCleanup,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 import {
   isMissingModuleError,
   isUnresolvedTenantImport,
@@ -20,6 +31,7 @@ import {
   transformModuleWithDeps,
 } from "./index.ts";
 import { buildModuleTransformCacheVariant, getModuleCacheKey } from "./module-cache-lookup.ts";
+import { CYCLE_MANIFEST_SIDECAR_SUFFIX, inspectCycleManifestCache } from "./cycle-manifest.ts";
 import {
   isBuildFailure,
   isTenantBuildFailure,
@@ -56,6 +68,7 @@ async function withModuleLoaderFixture<T>(
   } finally {
     await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
     await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+    await Deno.remove(getCycleManifestCacheDir(tmpDir), { recursive: true }).catch(() => undefined);
   }
 }
 
@@ -204,26 +217,23 @@ describe("module-loader/transformModuleWithDeps", () => {
     );
   });
 
-  // The `.ts` counterpart of the cycle case, which the `.json` shape above does
-  // not exercise: a `.ts` module is persisted as a *content-hashed* `.js`
-  // artifact (`app/page.<hash>.js`), and the cycle edge — left un-transformed to
-  // break the recursion — is normalised by esbuild to a relative `../app/page.js`
-  // that does not match the hashed name. To make that edge resolvable, the cycle
-  // target persists a stable non-hashed alias (`app/page.js`) that re-exports
-  // its hashed artifact. This test pins both halves: the edge shape and the
-  // alias that backs it. (The alias is not yet runtime-verified end to end; if
-  // it does not resolve in a real runtime the branch stays broken, no worse than
-  // before.)
-  it("writes a resolvable alias when a dynamic import closes a .ts cycle", async () => {
+  it("resolves a lazy .ts cycle to its hashed artifact without a mutable alias", async () => {
     await withModuleLoaderFixture(
       {
         "app/page.ts": [
-          `import { a } from "../lib/a.ts";`,
+          `import { a, later } from "../lib/a.ts";`,
           `export const pageValue = a;`,
+          `export const moduleUrl = import.meta.url;`,
+          `export let count = 0;`,
+          `export function increment() { count += 1; }`,
+          `export { later };`,
+          `export default "default-cycle";`,
         ].join("\n"),
         "lib/a.ts": [
           `export const a = "cycle";`,
-          `export async function later() { return await import("../app/page.ts"); }`,
+          "export async function later() {",
+          "  return await import(/* cycle */ `../app/page.ts` /* deferred */);",
+          "}",
         ].join("\n"),
       },
       async ({ projectDir, tmpDir, config }) => {
@@ -243,22 +253,1202 @@ describe("module-loader/transformModuleWithDeps", () => {
         // The static import to lib/a resolves to its content-hashed artifact.
         const depArtifactPath = assertTransformedImportPath(
           await Deno.readTextFile(transformed),
-          "/lib/a.",
+          "/veryfront-cycle-manifests/",
         );
-        assert(/\/lib\/a\.[0-9a-f]{1,8}\.js$/.test(depArtifactPath), depArtifactPath);
+        assert(
+          /\/veryfront-cycle-manifests\/[^/]+\/[^/]+\/artifacts\/[0-9a-z]+\.[0-9a-f]{1,8}\.js$/
+            .test(
+              depArtifactPath,
+            ),
+          depArtifactPath,
+        );
+        assert(
+          /\/veryfront-cycle-manifests\/[^/]+\/[^/]+\/artifacts\/[0-9a-z]+\.[0-9a-f]{1,8}\.js$/
+            .test(
+              transformed,
+            ),
+          transformed,
+        );
 
-        // The cycle edge survives as the relative `.js` specifier esbuild leaves.
+        // The deferred edge resolves at runtime to the same content-hashed root
+        // artifact, without publishing the old logical `app/page.js` alias.
         const depCode = await Deno.readTextFile(depArtifactPath);
-        assertStringIncludes(depCode, `import("../app/page.js")`);
-
-        // The alias the edge points at exists next to the hashed artifact and
-        // re-exports it, so `../app/page.js` resolves to the real module.
-        const aliasPath = join(tmpDir, "app/page.js");
-        const aliasCode = await Deno.readTextFile(aliasPath);
-        assertStringIncludes(
-          aliasCode,
-          `export * from "./${basename(transformed)}";`,
+        const rootNamespace = await import(toFileUrl(transformed).href);
+        const cycleNamespace = await rootNamespace.later();
+        const cachedTransform = await transformModuleWithDeps(
+          join(projectDir, "app/page.ts"),
+          tmpDir,
+          config.adapter,
+          config,
         );
+        assertStrictEquals(cachedTransform, transformed);
+        assertStrictEquals(cycleNamespace, rootNamespace);
+        assertEquals(cycleNamespace.pageValue, "cycle");
+        assertEquals(cycleNamespace.default, "default-cycle");
+        assertEquals(cycleNamespace.moduleUrl, toFileUrl(transformed).href);
+        rootNamespace.increment();
+        assertEquals(cycleNamespace.count, 1);
+        assertEquals(await config.adapter.fs.exists(join(tmpDir, "app/page.js")), false);
+        assert(!depCode.includes(`import("../app/page.js")`), depCode);
+      },
+    );
+  });
+
+  it("preserves the root module namespace across a static cycle edge", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import * as branch from "../lib/b.ts";`,
+          `export { branch };`,
+          `export default "root-default";`,
+          `export let count = 0;`,
+          `export function increment() { count += 1; }`,
+        ].join("\n"),
+        "lib/b.ts": [
+          `import * as root from "../app/page.ts";`,
+          `export { root };`,
+          `export function read() { return [root.default, root.count]; }`,
+        ].join("\n"),
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const transformed = await transformModuleWithDeps(
+          join(projectDir, "app/page.ts"),
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const root = await import(toFileUrl(transformed).href);
+        assertEquals(
+          await inspectCycleManifestCache(transformed, tmpDir, config.adapter),
+          "valid-root",
+        );
+        const cached = await transformModuleWithDeps(
+          join(projectDir, "app/page.ts"),
+          tmpDir,
+          config.adapter,
+          config,
+        );
+
+        assertStrictEquals(cached, transformed);
+        assertStrictEquals(root.branch.root, root);
+        assertEquals(root.branch.read(), ["root-default", 0]);
+        root.increment();
+        assertEquals(root.branch.read(), ["root-default", 1]);
+      },
+    );
+  });
+
+  it("does not reuse a cached cycle member across root generations", async () => {
+    const pageSource = (version: string) =>
+      [
+        `import { later } from "../lib/a.ts";`,
+        `export const version = ${JSON.stringify(version)};`,
+        `export { later };`,
+      ].join("\n");
+
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": pageSource("first"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const firstPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+
+        config.moduleCache.delete(
+          getModuleCacheKey(
+            pagePath,
+            config.projectId,
+            config.projectDir,
+            config.contentSourceId,
+            config.reactVersion,
+            config.mode,
+          ),
+        );
+        await Deno.writeTextFile(pagePath, pageSource("second"));
+
+        const secondPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const secondNamespace = await import(toFileUrl(secondPath).href);
+        const cycleNamespace = await secondNamespace.later();
+
+        assertNotStrictEquals(secondPath, firstPath);
+        assertEquals(secondNamespace.version, "second");
+        assertEquals(cycleNamespace.version, "second");
+      },
+    );
+  });
+
+  it("rebuilds a cached cycle root when only a member source changes", async () => {
+    const memberSource = (version: string) =>
+      [
+        `export const version = ${JSON.stringify(version)};`,
+        `export async function later() { return await import("../app/page.ts"); }`,
+      ].join("\n");
+
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import { later, version as memberVersion } from "../lib/a.ts";`,
+          `export { later, memberVersion };`,
+        ].join("\n"),
+        "lib/a.ts": memberSource("old"),
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        await runWithCacheDir(tmpDir, async () => {
+          const pagePath = join(projectDir, "app/page.ts");
+          const memberPath = join(projectDir, "lib/a.ts");
+          const diskConfig = {
+            ...config,
+            projectId: "cycle-member-edit",
+            contentSourceId: "main",
+          };
+          const cacheDir = join(
+            getMdxEsmCacheDir(),
+            encodeURIComponent(diskConfig.projectId),
+            encodeURIComponent(diskConfig.contentSourceId),
+          );
+          await Deno.mkdir(cacheDir, { recursive: true });
+          const firstPath = await transformModuleWithDeps(
+            pagePath,
+            cacheDir,
+            diskConfig.adapter,
+            diskConfig,
+          );
+          await saveModulePathCache(cacheDir);
+          clearModulePathCache();
+          await getModulePathCache(cacheDir);
+
+          await Deno.writeTextFile(memberPath, memberSource("new"));
+          invalidateModulePaths(["lib/a.ts"]);
+          await waitForDiskCleanup();
+
+          const secondPath = await transformModuleWithDeps(
+            pagePath,
+            cacheDir,
+            diskConfig.adapter,
+            { ...diskConfig, moduleCache: new Map() },
+          );
+          const second = await import(toFileUrl(secondPath).href);
+
+          assertNotStrictEquals(secondPath, firstPath);
+          assertEquals(second.memberVersion, "new");
+          assertStrictEquals(await second.later(), second);
+
+          await waitForDiskCleanup();
+          const graphDirectories: string[] = [];
+          for await (const entry of Deno.readDir(getCycleManifestCacheDir(cacheDir))) {
+            if (entry.isDirectory) graphDirectories.push(entry.name);
+          }
+          assertEquals(
+            graphDirectories.length,
+            1,
+            `expected one current cycle graph, found ${graphDirectories.join(", ")}`,
+          );
+        });
+      },
+    );
+  });
+
+  it("does not return a cycle artifact queued for invalidation cleanup", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import { later } from "../lib/a.ts";`,
+          `export { later };`,
+        ].join("\n"),
+        "lib/a.ts": `export async function later() { return import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        await runWithCacheDir(tmpDir, async () => {
+          const pagePath = join(projectDir, "app/page.ts");
+          const diskConfig = {
+            ...config,
+            projectId: "cycle-invalidation-race",
+            contentSourceId: "main",
+          };
+          const cacheDir = join(
+            getMdxEsmCacheDir(),
+            encodeURIComponent(diskConfig.projectId),
+            encodeURIComponent(diskConfig.contentSourceId),
+          );
+          await Deno.mkdir(cacheDir, { recursive: true });
+          const firstPath = await transformModuleWithDeps(
+            pagePath,
+            cacheDir,
+            diskConfig.adapter,
+            diskConfig,
+          );
+          const localFs = getLocalFs();
+          const originalRemove = localFs.remove.bind(localFs);
+          let releaseRemoval!: () => void;
+          const removalReleased = new Promise<void>((resolve) => {
+            releaseRemoval = resolve;
+          });
+          let reportRemovalStarted!: () => void;
+          const removalStarted = new Promise<void>((resolve) => {
+            reportRemovalStarted = resolve;
+          });
+
+          try {
+            localFs.remove = async (path, options) => {
+              if (path === firstPath) {
+                reportRemovalStarted();
+                await removalReleased;
+              }
+              await originalRemove(path, options);
+            };
+
+            invalidateModulePaths(["app/page.ts"]);
+            await removalStarted;
+            const secondPath = await transformModuleWithDeps(
+              pagePath,
+              cacheDir,
+              diskConfig.adapter,
+              diskConfig,
+            );
+            releaseRemoval();
+            await waitForDiskCleanup();
+
+            assertNotStrictEquals(secondPath, firstPath);
+            assertEquals(await diskConfig.adapter.fs.exists(secondPath), true);
+          } finally {
+            releaseRemoval();
+            localFs.remove = originalRemove;
+          }
+        });
+      },
+    );
+  });
+
+  it("re-resolves an ordinary cached dependency that becomes a cycle member", async () => {
+    const pageSource = (version: string, importsCycle: boolean) =>
+      importsCycle
+        ? [
+          `import { later } from "../lib/a.ts";`,
+          `export const version = ${JSON.stringify(version)};`,
+          `export { later };`,
+        ].join("\n")
+        : `export const version = ${JSON.stringify(version)};`;
+
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": pageSource("old", false),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const memberPath = join(projectDir, "lib/a.ts");
+        await transformModuleWithDeps(memberPath, tmpDir, config.adapter, config);
+
+        config.moduleCache.delete(
+          getModuleCacheKey(
+            pagePath,
+            config.projectId,
+            config.projectDir,
+            config.contentSourceId,
+            config.reactVersion,
+            config.mode,
+          ),
+        );
+        await Deno.writeTextFile(pagePath, pageSource("new", true));
+
+        const currentPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const currentNamespace = await import(toFileUrl(currentPath).href);
+        const cycleNamespace = await currentNamespace.later();
+
+        assertStrictEquals(cycleNamespace, currentNamespace);
+        assertEquals(cycleNamespace.version, "new");
+      },
+    );
+  });
+
+  it("isolates concurrent cycle closures with immutable JavaScript identity", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import {`,
+          `  aliasUrl, assetUrl, bracketUrl, filename, later,`,
+          `  readSelf, resolvedAssetUrl, wrapperUrl,`,
+          `} from "../lib/wrapper.js";`,
+          `export {`,
+          `  aliasUrl, assetUrl, bracketUrl, filename, later,`,
+          `  readSelf, resolvedAssetUrl, wrapperUrl,`,
+          `};`,
+          `export const version = "current";`,
+        ].join("\n"),
+        "lib/wrapper.js": [
+          `import { later } from "./a.ts";`,
+          `export { later };`,
+          `const meta = import.meta;`,
+          `export const wrapperUrl = import.meta.url;`,
+          `export const bracketUrl = import.meta["url"];`,
+          `export const aliasUrl = meta.url;`,
+          `export const filename = import.meta.filename;`,
+          `export const assetUrl = new URL("./asset.txt", meta.url).href;`,
+          `export const resolvedAssetUrl = import.meta.resolve("./asset.txt");`,
+          `export function readSelf() { return Deno.readTextFile(new URL(import.meta.url)); }`,
+        ].join("\n"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const [firstPath, secondPath] = await Promise.all([
+          transformModuleWithDeps(
+            pagePath,
+            tmpDir,
+            config.adapter,
+            { ...config, moduleCache: new Map() },
+          ),
+          transformModuleWithDeps(
+            pagePath,
+            tmpDir,
+            config.adapter,
+            { ...config, moduleCache: new Map() },
+          ),
+        ]);
+        assertStrictEquals(firstPath, secondPath);
+
+        const [firstNamespace, secondNamespace] = await Promise.all([
+          import(toFileUrl(firstPath).href),
+          import(toFileUrl(secondPath).href),
+        ]);
+        const [firstCycleNamespace, secondCycleNamespace] = await Promise.all([
+          firstNamespace.later(),
+          secondNamespace.later(),
+        ]);
+
+        assertStrictEquals(firstNamespace, secondNamespace);
+        assertStrictEquals(firstCycleNamespace, firstNamespace);
+        assertStrictEquals(secondCycleNamespace, secondNamespace);
+        for (const namespace of [firstNamespace, secondNamespace]) {
+          const wrapperUrl = namespace.wrapperUrl as string;
+          const wrapperPath = fromFileUrl(wrapperUrl);
+          assertStringIncludes(wrapperUrl, "/veryfront-cycle-manifests/");
+          assertEquals(namespace.wrapperUrl, wrapperUrl);
+          assertEquals(namespace.bracketUrl, wrapperUrl);
+          assertEquals(namespace.aliasUrl, wrapperUrl);
+          assertEquals(namespace.filename, wrapperPath);
+          assertEquals(
+            namespace.assetUrl,
+            toFileUrl(join(dirname(wrapperPath), "asset.txt")).href,
+          );
+          assertEquals(
+            namespace.resolvedAssetUrl,
+            toFileUrl(join(dirname(wrapperPath), "asset.txt")).href,
+          );
+          assertStringIncludes(await namespace.readSelf(), `veryfront-cycle-member`);
+        }
+      },
+    );
+  });
+
+  it("isolates concurrent source generations across a JavaScript cycle ancestor", async () => {
+    const pageSource = (version: string) =>
+      [
+        `import { later, readSelf, wrapperVersion } from "../lib/wrapper.js";`,
+        `export { later, readSelf, wrapperVersion };`,
+        `export const version = ${JSON.stringify(version)};`,
+      ].join("\n");
+    const wrapperSource = (version: string) =>
+      [
+        `export { later } from "./a.ts";`,
+        `export const wrapperVersion = ${JSON.stringify(version)};`,
+        `export function readSelf() { return Deno.readTextFile(new URL(import.meta.url)); }`,
+      ].join("\n");
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": pageSource("disk"),
+        "lib/wrapper.js": wrapperSource("disk"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const wrapperPath = join(projectDir, "lib/wrapper.js");
+        const adapterFor = (version: string) => {
+          const fs = Object.assign(Object.create(config.adapter.fs), {
+            readFile(path: string): Promise<string | Uint8Array> {
+              if (path === pagePath) return Promise.resolve(pageSource(version));
+              if (path === wrapperPath) return Promise.resolve(wrapperSource(version));
+              return config.adapter.fs.readFile(path);
+            },
+          });
+          return { ...config.adapter, fs };
+        };
+        const firstAdapter = adapterFor("one");
+        const secondAdapter = adapterFor("two");
+        const [firstPath, secondPath] = await Promise.all([
+          transformModuleWithDeps(pagePath, tmpDir, firstAdapter, {
+            ...config,
+            adapter: firstAdapter,
+            moduleCache: new Map(),
+          }),
+          transformModuleWithDeps(pagePath, tmpDir, secondAdapter, {
+            ...config,
+            adapter: secondAdapter,
+            moduleCache: new Map(),
+          }),
+        ]);
+        const [first, second] = await Promise.all([
+          import(toFileUrl(firstPath).href),
+          import(toFileUrl(secondPath).href),
+        ]);
+        const [firstCycle, secondCycle] = await Promise.all([
+          first.later(),
+          second.later(),
+        ]);
+
+        assertNotStrictEquals(firstPath, secondPath);
+        assertStrictEquals(firstCycle, first);
+        assertStrictEquals(secondCycle, second);
+        assertEquals(firstCycle.version, "one");
+        assertEquals(secondCycle.version, "two");
+        assertEquals(first.wrapperVersion, "one");
+        assertEquals(second.wrapperVersion, "two");
+        assertStringIncludes(await first.readSelf(), `wrapperVersion = "one"`);
+        assertStringIncludes(await second.readSelf(), `wrapperVersion = "two"`);
+      },
+    );
+  });
+
+  it("reuses the matching source generation from a shared disk path cache", async () => {
+    const pageSource = (version: string) =>
+      [
+        `import { later } from "../lib/a.ts";`,
+        `export { later };`,
+        `export const version = ${JSON.stringify(version)};`,
+      ].join("\n");
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": pageSource("disk"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        await runWithCacheDir(tmpDir, async () => {
+          const pagePath = join(projectDir, "app/page.ts");
+          const adapterFor = (version: string) => {
+            const fs = Object.assign(Object.create(config.adapter.fs), {
+              readFile(path: string): Promise<string | Uint8Array> {
+                if (path === pagePath) return Promise.resolve(pageSource(version));
+                return config.adapter.fs.readFile(path);
+              },
+            });
+            return { ...config.adapter, fs };
+          };
+          const firstAdapter = adapterFor("one");
+          const secondAdapter = adapterFor("two");
+          const sharedConfig = {
+            ...config,
+            projectId: "cycle-snapshots",
+            contentSourceId: "main",
+          };
+          const cacheDir = join(
+            getMdxEsmCacheDir(),
+            encodeURIComponent(sharedConfig.projectId),
+            encodeURIComponent(sharedConfig.contentSourceId),
+          );
+          await Deno.mkdir(cacheDir, { recursive: true });
+          const [firstPath, secondPath] = await Promise.all([
+            transformModuleWithDeps(pagePath, cacheDir, firstAdapter, {
+              ...sharedConfig,
+              adapter: firstAdapter,
+              moduleCache: new Map(),
+            }),
+            transformModuleWithDeps(pagePath, cacheDir, secondAdapter, {
+              ...sharedConfig,
+              adapter: secondAdapter,
+              moduleCache: new Map(),
+            }),
+          ]);
+
+          const againFirstPath = await transformModuleWithDeps(
+            pagePath,
+            cacheDir,
+            firstAdapter,
+            {
+              ...sharedConfig,
+              adapter: firstAdapter,
+              moduleCache: new Map(),
+            },
+          );
+          const againSecondPath = await transformModuleWithDeps(
+            pagePath,
+            cacheDir,
+            secondAdapter,
+            {
+              ...sharedConfig,
+              adapter: secondAdapter,
+              moduleCache: new Map(),
+            },
+          );
+
+          assertStrictEquals(againFirstPath, firstPath);
+          assertStrictEquals(againSecondPath, secondPath);
+          assertEquals((await import(toFileUrl(againFirstPath).href)).version, "one");
+          assertEquals((await import(toFileUrl(againSecondPath).href)).version, "two");
+        });
+      },
+    );
+  });
+
+  it("bounds source reads linearly when cached siblings share a dependency closure", async () => {
+    const width = 12;
+    const files: Record<string, string> = {};
+    for (let index = 0; index < width; index++) {
+      files[`lib/chain-${index}.ts`] = index + 1 < width
+        ? `import "./chain-${index + 1}.ts"; export const value${index} = ${index};`
+        : `export const value${index} = ${index};`;
+      files[`lib/sibling-${index}.ts`] =
+        `import "./chain-0.ts"; export const sibling${index} = ${index};`;
+    }
+    files["app/page.ts"] = Array.from(
+      { length: width },
+      (_, index) => `import "../lib/sibling-${index}.ts";`,
+    ).join("\n") + `\nexport const ready = true;`;
+
+    await withModuleLoaderFixture(
+      files,
+      async ({ projectDir, tmpDir, config }) => {
+        for (let index = 0; index < width; index++) {
+          await transformModuleWithDeps(
+            join(projectDir, `lib/sibling-${index}.ts`),
+            tmpDir,
+            config.adapter,
+            config,
+          );
+        }
+
+        let projectSourceReads = 0;
+        const readsByPath = new Map<string, number>();
+        const countingFs = Object.assign(Object.create(config.adapter.fs), {
+          async readFile(path: string): Promise<string | Uint8Array> {
+            if (path.startsWith(projectDir) && path.endsWith(".ts")) {
+              projectSourceReads++;
+              readsByPath.set(path, (readsByPath.get(path) ?? 0) + 1);
+            }
+            return await config.adapter.fs.readFile(path);
+          },
+        });
+        const countingAdapter = { ...config.adapter, fs: countingFs };
+        await transformModuleWithDeps(
+          join(projectDir, "app/page.ts"),
+          tmpDir,
+          countingAdapter,
+          { ...config, adapter: countingAdapter },
+        );
+
+        assert(
+          projectSourceReads <= width * 2 + 2,
+          `expected linear reads for ${width * 2 + 1} sources, got ${projectSourceReads}: ${
+            JSON.stringify([...readsByPath])
+          }`,
+        );
+      },
+    );
+  });
+
+  it("transforms a cold converging cycle graph once per source", async () => {
+    const layerCount = 10;
+    const files: Record<string, string> = {};
+    for (let layer = 0; layer < layerCount; layer++) {
+      for (const branch of ["a", "b"]) {
+        files[`lib/${branch}-${layer}.ts`] = layer + 1 < layerCount
+          ? [
+            `import "./a-${layer + 1}.ts";`,
+            `import "./b-${layer + 1}.ts";`,
+            `export const value = "${branch}-${layer}";`,
+          ].join("\n")
+          : [
+            `export async function later() { return await import("../app/page.ts"); }`,
+            `export const value = "${branch}-${layer}";`,
+          ].join("\n");
+      }
+    }
+    files["app/page.ts"] = [
+      `import "../lib/a-0.ts";`,
+      `import "../lib/b-0.ts";`,
+      `export const ready = true;`,
+    ].join("\n");
+
+    await withModuleLoaderFixture(
+      files,
+      async ({ projectDir, tmpDir, config }) => {
+        const phaseCounts = new Map<string, number>();
+        await transformModuleWithDeps(
+          join(projectDir, "app/page.ts"),
+          tmpDir,
+          config.adapter,
+          {
+            ...config,
+            onProgress: (progress) => {
+              phaseCounts.set(progress.phase, (phaseCounts.get(progress.phase) ?? 0) + 1);
+            },
+          },
+        );
+
+        const sourceCount = layerCount * 2 + 1;
+        assertEquals(phaseCounts.get("module:source-read"), sourceCount);
+        assertEquals(phaseCounts.get("module:dependencies-transformed"), sourceCount);
+        assertEquals(phaseCounts.get("module:persisted"), sourceCount);
+      },
+    );
+  });
+
+  it("shares one live namespace across converging cycle branches", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import * as a from "../lib/a.ts";`,
+          `import * as b from "../lib/b.ts";`,
+          `export { a, b };`,
+        ].join("\n"),
+        "lib/a.ts": [
+          `import { later } from "./c.ts";`,
+          `export let count = 0;`,
+          `export function increment() { count += 1; }`,
+          `export { later };`,
+        ].join("\n"),
+        "lib/b.ts": [
+          `import { later } from "./c.ts";`,
+          `export { later };`,
+        ].join("\n"),
+        "lib/c.ts": `export async function later() { return await import("./a.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const rootPath = await transformModuleWithDeps(
+          join(projectDir, "app/page.ts"),
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const root = await import(toFileUrl(rootPath).href);
+        const [fromA, fromB] = await Promise.all([root.a.later(), root.b.later()]);
+
+        assertStrictEquals(fromA, root.a);
+        assertStrictEquals(fromB, root.a);
+        root.a.increment();
+        assertEquals(fromB.count, 1);
+      },
+    );
+  });
+
+  it("breaks a cycle formed through a converging in-flight dependency", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import * as a from "../lib/a.ts";`,
+          `import * as b from "../lib/b.ts";`,
+          `export { a, b };`,
+        ].join("\n"),
+        "lib/a.ts": `export { later } from "./c.ts";`,
+        "lib/b.ts": `export { later } from "./c.ts"; export const branch = "b";`,
+        "lib/c.ts": `export async function later() { return await import("./b.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        let timer = 0;
+        const rootPath = await Promise.race([
+          transformModuleWithDeps(
+            join(projectDir, "app/page.ts"),
+            tmpDir,
+            config.adapter,
+            config,
+          ),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error("converging cycle deadlocked")), 2_000);
+          }),
+        ]).finally(() => clearTimeout(timer));
+        const root = await import(toFileUrl(rootPath).href);
+        const [fromA, fromB] = await Promise.all([root.a.later(), root.b.later()]);
+
+        assertStrictEquals(fromA, root.b);
+        assertStrictEquals(fromB, root.b);
+      },
+    );
+  });
+
+  it("loads a TypeScript cycle below an authored JavaScript root", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.js": [
+          `import { later } from "../lib/b.ts";`,
+          `export { later };`,
+          `export const rootUrl = import.meta.url;`,
+        ].join("\n"),
+        "lib/b.ts": [
+          `import { later } from "./c.ts";`,
+          `export { later };`,
+          `export const member = "b";`,
+        ].join("\n"),
+        "lib/c.ts": `export async function later() { return await import("./b.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const rootPath = await transformModuleWithDeps(
+          join(projectDir, "app/page.js"),
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const rootNamespace = await import(toFileUrl(rootPath).href);
+        const cycleNamespace = await rootNamespace.later();
+
+        assertStringIncludes(rootPath, "/veryfront-cycle-manifests/");
+        assertEquals(rootNamespace.rootUrl, toFileUrl(rootPath).href);
+        assertEquals(cycleNamespace.member, "b");
+      },
+    );
+  });
+
+  it("isolates concurrent JavaScript roots above a TypeScript cycle", async () => {
+    const pageSource = (version: string) =>
+      [
+        `import { later } from "../lib/b.ts";`,
+        `export { later };`,
+        `export const version = ${JSON.stringify(version)};`,
+        `export function readSelf() { return Deno.readTextFile(new URL(import.meta.url)); }`,
+      ].join("\n");
+    await withModuleLoaderFixture(
+      {
+        "app/page.js": pageSource("disk"),
+        "lib/b.ts": `export { later } from "./c.ts";`,
+        "lib/c.ts": `export async function later() { return await import("./b.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.js");
+        const adapterFor = (version: string) => {
+          const fs = Object.assign(Object.create(config.adapter.fs), {
+            readFile(path: string): Promise<string | Uint8Array> {
+              return path === pagePath
+                ? Promise.resolve(pageSource(version))
+                : config.adapter.fs.readFile(path);
+            },
+          });
+          return { ...config.adapter, fs };
+        };
+        const firstAdapter = adapterFor("one");
+        const secondAdapter = adapterFor("two");
+
+        const [firstPath, secondPath] = await Promise.all([
+          transformModuleWithDeps(pagePath, tmpDir, firstAdapter, {
+            ...config,
+            adapter: firstAdapter,
+            moduleCache: new Map(),
+          }),
+          transformModuleWithDeps(pagePath, tmpDir, secondAdapter, {
+            ...config,
+            adapter: secondAdapter,
+            moduleCache: new Map(),
+          }),
+        ]);
+        const [first, second] = await Promise.all([
+          import(toFileUrl(firstPath).href),
+          import(toFileUrl(secondPath).href),
+        ]);
+
+        assertNotStrictEquals(firstPath, secondPath);
+        assertEquals(first.version, "one");
+        assertEquals(second.version, "two");
+        assertStringIncludes(await first.readSelf(), `version = "one"`);
+        assertStringIncludes(await second.readSelf(), `version = "two"`);
+      },
+    );
+  });
+
+  it("does not reuse a former cycle member when it becomes the graph root", async () => {
+    const pageSource = (version: string) =>
+      [
+        `import later from "../lib/a.ts";`,
+        `export const version = ${JSON.stringify(version)};`,
+        `export { later };`,
+      ].join("\n");
+
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": pageSource("first"),
+        "lib/a.ts": [
+          `export async function later() { return await import("../app/page.ts"); }`,
+          `export default later;`,
+        ].join("\n"),
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const memberPath = join(projectDir, "lib/a.ts");
+        await transformModuleWithDeps(pagePath, tmpDir, config.adapter, config);
+
+        config.moduleCache.delete(
+          getModuleCacheKey(
+            pagePath,
+            config.projectId,
+            config.projectDir,
+            config.contentSourceId,
+            config.reactVersion,
+            config.mode,
+          ),
+        );
+        await Deno.writeTextFile(pagePath, pageSource("second"));
+
+        const newRootPath = await transformModuleWithDeps(
+          memberPath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const memberNamespace = await import(toFileUrl(newRootPath).href);
+        const pageNamespace = await memberNamespace.later();
+
+        assertEquals(pageNamespace.version, "second");
+      },
+    );
+  });
+
+  it("does not mistake authored marker text for cycle cache evidence", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": `export const authored = "//# veryfront-cycle-manifest:v1";`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        let sourceReads = 0;
+        config.onProgress = (event) => {
+          if (event.phase === "module:source-read" && event.filePath === pagePath) {
+            sourceReads++;
+          }
+        };
+
+        const firstPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const secondPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+
+        assertStrictEquals(secondPath, firstPath);
+        assertEquals(sourceReads, 1);
+      },
+    );
+  });
+
+  it("keeps authored JavaScript reusable when its path resembles manifest storage", async () => {
+    const relativePath = "_cycle-manifests/authored/artifacts/0.deadbeef.js";
+    await withModuleLoaderFixture(
+      { [relativePath]: `export const authored = true;` },
+      async ({ projectDir, tmpDir, config }) => {
+        let sourceReads = 0;
+        const countingConfig: ModuleLoaderConfig = {
+          ...config,
+          onProgress: (progress) => {
+            if (progress.phase === "module:source-read") sourceReads++;
+          },
+        };
+        const sourcePath = join(projectDir, relativePath);
+        const firstPath = await transformModuleWithDeps(
+          sourcePath,
+          tmpDir,
+          config.adapter,
+          countingConfig,
+        );
+        const secondPath = await transformModuleWithDeps(
+          sourcePath,
+          tmpDir,
+          config.adapter,
+          countingConfig,
+        );
+
+        assertStrictEquals(secondPath, firstPath);
+        assertEquals(sourceReads, 1);
+      },
+    );
+  });
+
+  it("reuses an authored filename that resembles the retired cycle suffix", async () => {
+    await withModuleLoaderFixture(
+      {
+        "lib/authored.cycle.deadbeef.js": `export const owner = "authored";`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const filePath = join(projectDir, "lib/authored.cycle.deadbeef.js");
+        let sourceReads = 0;
+        config.onProgress = (event) => {
+          if (event.phase === "module:source-read" && event.filePath === filePath) {
+            sourceReads++;
+          }
+        };
+
+        const firstPath = await transformModuleWithDeps(
+          filePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const secondPath = await transformModuleWithDeps(
+          filePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+
+        assertStrictEquals(secondPath, firstPath);
+        assertEquals(sourceReads, 1);
+      },
+    );
+  });
+
+  it("rebuilds a cached cycle closure when its manifest entry disappears", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import { later } from "../lib/a.ts";`,
+          `export const value = "recovered";`,
+          `export { later };`,
+        ].join("\n"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const firstPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const depPath = assertTransformedImportPath(
+          await Deno.readTextFile(firstPath),
+          "/veryfront-cycle-manifests/",
+        );
+        const depCode = await Deno.readTextFile(depPath);
+        const manifestUrl = depCode.match(
+          /import\("(file:\/\/[^"\n]+\/veryfront-cycle-manifests\/[^"\n]+)"\)/,
+        )
+          ?.[1];
+        assert(manifestUrl, depCode);
+        await Deno.remove(fromFileUrl(manifestUrl));
+
+        const rebuiltPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const rebuiltNamespace = await import(toFileUrl(rebuiltPath).href);
+        const cycleNamespace = await rebuiltNamespace.later();
+
+        assertNotStrictEquals(rebuiltPath, firstPath);
+        assertEquals(cycleNamespace.value, "recovered");
+      },
+    );
+  });
+
+  it("rebuilds a cached cycle closure when a static member artifact disappears", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import { later } from "../lib/a.ts";`,
+          `export const value = "recovered";`,
+          `export { later };`,
+        ].join("\n"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const firstPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const memberPath = assertTransformedImportPath(
+          await Deno.readTextFile(firstPath),
+          "/veryfront-cycle-manifests/",
+        );
+        await Deno.remove(memberPath);
+
+        const rebuiltPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const rebuilt = await import(toFileUrl(rebuiltPath).href);
+
+        assertNotStrictEquals(rebuiltPath, firstPath);
+        assertStrictEquals(await rebuilt.later(), rebuilt);
+      },
+    );
+  });
+
+  it("rejects a cached cycle closure whose member bytes are corrupted", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import { later } from "../lib/a.ts";`,
+          `export const value = "original";`,
+          `export { later };`,
+        ].join("\n"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const rootPath = await transformModuleWithDeps(
+          join(projectDir, "app/page.ts"),
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const memberPath = assertTransformedImportPath(
+          await Deno.readTextFile(rootPath),
+          "/veryfront-cycle-manifests/",
+        );
+        await Deno.writeTextFile(memberPath, `export const corrupted = true;`);
+
+        assertEquals(
+          await inspectCycleManifestCache(rootPath, tmpDir, config.adapter),
+          "invalid",
+        );
+      },
+    );
+  });
+
+  it("rebuilds when both a cycle entry and its cache evidence disappear", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import { later } from "../lib/a.ts";`,
+          `export const value = "recovered";`,
+          `export { later };`,
+        ].join("\n"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const firstPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const depPath = assertTransformedImportPath(
+          await Deno.readTextFile(firstPath),
+          "/veryfront-cycle-manifests/",
+        );
+        const depCode = await Deno.readTextFile(depPath);
+        const manifestUrl = depCode.match(
+          /import\("(file:\/\/[^"\n]+\/veryfront-cycle-manifests\/[^"\n]+)"\)/,
+        )
+          ?.[1];
+        assert(manifestUrl, depCode);
+        await Deno.remove(fromFileUrl(manifestUrl));
+        await Deno.remove(`${firstPath}${CYCLE_MANIFEST_SIDECAR_SUFFIX}`);
+
+        const rebuiltPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const rebuiltNamespace = await import(toFileUrl(rebuiltPath).href);
+        const cycleNamespace = await rebuiltNamespace.later();
+
+        assertNotStrictEquals(rebuiltPath, firstPath);
+        assertStrictEquals(cycleNamespace, rebuiltNamespace);
+        assertEquals(cycleNamespace.value, "recovered");
+      },
+    );
+  });
+
+  it("rebuilds a cached cycle closure when its manifest entry is corrupted", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import { later } from "../lib/a.ts";`,
+          `export const value = "original";`,
+          `export { later };`,
+        ].join("\n"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const firstPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const depPath = assertTransformedImportPath(
+          await Deno.readTextFile(firstPath),
+          "/veryfront-cycle-manifests/",
+        );
+        const depCode = await Deno.readTextFile(depPath);
+        const manifestUrl = depCode.match(
+          /import\("(file:\/\/[^"\n]+\/veryfront-cycle-manifests\/[^"\n]+)"\)/,
+        )
+          ?.[1];
+        assert(manifestUrl, depCode);
+        await Deno.writeTextFile(
+          fromFileUrl(manifestUrl),
+          `export const value = "corrupted"; export default "wrong";`,
+        );
+
+        const rebuiltPath = await transformModuleWithDeps(
+          pagePath,
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const rebuiltNamespace = await import(toFileUrl(rebuiltPath).href);
+        const cycleNamespace = await rebuiltNamespace.later();
+
+        assertNotStrictEquals(rebuiltPath, firstPath);
+        assertStrictEquals(cycleNamespace, rebuiltNamespace);
+        assertEquals(cycleNamespace.value, "original");
+      },
+    );
+  });
+
+  it("keeps an unrelated cached leaf reusable after a cyclic graph", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.ts": [
+          `import { later } from "../lib/a.ts";`,
+          `import { shared } from "../lib/shared.ts";`,
+          `export const value = shared;`,
+          `export { later };`,
+        ].join("\n"),
+        "lib/a.ts": `export async function later() { return await import("../app/page.ts"); }`,
+        "lib/shared.ts": `export const shared = "shared";`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const pagePath = join(projectDir, "app/page.ts");
+        const sharedPath = join(projectDir, "lib/shared.ts");
+        await transformModuleWithDeps(pagePath, tmpDir, config.adapter, config);
+
+        let sharedSourceReads = 0;
+        config.onProgress = (event) => {
+          if (event.phase === "module:source-read" && event.filePath === sharedPath) {
+            sharedSourceReads++;
+          }
+        };
+        await transformModuleWithDeps(sharedPath, tmpDir, config.adapter, config);
+        await transformModuleWithDeps(sharedPath, tmpDir, config.adapter, config);
+
+        assertEquals(sharedSourceReads, 0);
       },
     );
   });
@@ -955,10 +2145,8 @@ describe("module-loader/isUnresolvedTenantImport", () => {
     assertEquals(isUnresolvedTenantImport(unrelated, new Set(["./missing"]), REBUILT), false);
   });
 
-  // The cycle-breaking branch leaves a resolved target's specifier as authored
-  // and relies on an alias the code itself marks as not runtime-verified. That
-  // target resolved, so it is never recorded as dropped — and a framework path
-  // the repo openly marks unverified must not page as a tenant warning.
+  // A resolved cycle target is never recorded as dropped. A later framework
+  // failure on that branch must therefore not be reported as a tenant warning.
   it("does not classify a failure when the resolver dropped nothing", () => {
     assertEquals(isUnresolvedTenantImport(missing(), new Set()), false);
   });

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -7,14 +7,34 @@
  * @module rendering/orchestrator/module-loader
  */
 
-import { rendererLogger } from "#veryfront/utils";
+import { join, relative, toFileUrl } from "#veryfront/compat/path/index.ts";
+import { CACHE_ERROR } from "#veryfront/errors";
+import { isTenantSourceBuildError } from "#veryfront/errors/tenant-classification.ts";
+import { getProjectTmpDir } from "#veryfront/modules/react-loader/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
-import { getProjectTmpDir } from "#veryfront/modules/react-loader/index.ts";
-import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
-import { join, toFileUrl } from "#veryfront/compat/path/index.ts";
-import { invalidateMdxEsmModule } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import type { DependencyPinningSourceInput } from "#veryfront/transforms/esm/package-registry.ts";
 import {
+  rewriteSsrProjectAliasSpecifier,
+} from "#veryfront/transforms/import-rewriter/strategies/alias-strategy.ts";
+import {
+  invalidateMdxEsmModule,
+  registerCycleManifestSources,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import type { TransformProgressListener } from "#veryfront/transforms/progress.ts";
+import { rendererLogger } from "#veryfront/utils";
+import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { MODULE_CACHE_MAX_ENTRIES } from "#veryfront/utils/constants/cache.ts";
+import { computeHash } from "#veryfront/utils/hash-utils.ts";
+import { markBuildFailure, markTenantBuildFailure } from "./build-failure.ts";
+import {
+  cycleArtifactBelongsToGraph,
+  CycleManifestTransaction,
+  inspectCycleManifestCache,
+  needsCycleManifest,
+} from "./cycle-manifest.ts";
+import {
+  type ResolvedModuleDependency,
   resolveModuleDependencies,
   rewriteResolvedDependencyImports,
   type TransformedModuleDependency,
@@ -22,6 +42,7 @@ import {
 import {
   persistTransformedModule,
   readPersistedUnresolvedSpecifiers,
+  transformedModuleHasDefaultExport,
 } from "./module-persistence.ts";
 import { transformModuleCodeWithCache } from "./module-transform-cache.ts";
 import {
@@ -29,16 +50,11 @@ import {
   getModuleCacheKey,
   resolveCachedModulePath,
 } from "./module-cache-lookup.ts";
-import { markBuildFailure, markTenantBuildFailure } from "./build-failure.ts";
-import type { TransformProgressListener } from "#veryfront/transforms/progress.ts";
-import type { DependencyPinningSourceInput } from "#veryfront/transforms/esm/package-registry.ts";
-import { MODULE_CACHE_MAX_ENTRIES } from "#veryfront/utils/constants/cache.ts";
-import { isTenantSourceBuildError } from "#veryfront/errors/tenant-classification.ts";
-import { rewriteSsrProjectAliasSpecifier } from "#veryfront/transforms/import-rewriter/strategies/alias-strategy.ts";
 
 export { isBuildFailure } from "./build-failure.ts";
 
 const logger = rendererLogger.component("module-loader");
+const JSONStringify = JSON.stringify;
 
 /**
  * Specifiers each transformed module subtree left as authored, keyed by the
@@ -51,6 +67,7 @@ const logger = rendererLogger.component("module-loader");
  * order on reads, while holding only specifier strings.
  */
 const unresolvedSpecifiersByCacheKey = new Map<string, readonly string[]>();
+const MAX_SOURCE_GRAPH_MODULES = 5_000;
 
 function cacheUnresolvedSpecifiers(cacheKey: string, specifiers: readonly string[]): void {
   unresolvedSpecifiersByCacheKey.delete(cacheKey);
@@ -89,6 +106,201 @@ function decodeFileContent(fileContent: string | Uint8Array): string {
   return new TextDecoder().decode(fileContent);
 }
 
+type SourceGraphNode =
+  | {
+    status: "ready";
+    fileContent: string;
+    resolvedDeps: readonly ResolvedModuleDependency[];
+  }
+  | { status: "failed"; fileContent?: string; error: unknown };
+
+interface SourceGraphPlan {
+  graphId: string;
+  nodes: ReadonlyMap<string, SourceGraphNode>;
+  cycleBoundSources: ReadonlySet<string>;
+  artifactIds: ReadonlyMap<string, string>;
+  transforms: Map<string, Promise<string>>;
+  unresolvedBySource: Map<string, readonly string[]>;
+}
+
+const sourceGraphByCycleManifest = new WeakMap<CycleManifestTransaction, SourceGraphPlan>();
+
+function computeCycleBoundSources(
+  nodes: ReadonlyMap<string, SourceGraphNode>,
+): ReadonlySet<string> {
+  const adjacency = new Map<string, string[]>();
+  const reverseAdjacency = new Map<string, string[]>();
+  const uniqueTargets = new Map<string, Set<string>>();
+  for (const path of nodes.keys()) {
+    adjacency.set(path, []);
+    reverseAdjacency.set(path, []);
+    uniqueTargets.set(path, new Set());
+  }
+  for (const [path, node] of nodes) {
+    const targets = adjacency.get(path)!;
+    const seenTargets = uniqueTargets.get(path)!;
+    if (node.status === "failed") continue;
+    for (const dependency of node.resolvedDeps) {
+      const target = dependency.depFilePath;
+      if (!target || !nodes.has(target) || seenTargets.has(target)) continue;
+      seenTargets.add(target);
+      targets.push(target);
+      reverseAdjacency.get(target)!.push(path);
+    }
+  }
+
+  const visited = new Set<string>();
+  const finishOrder: string[] = [];
+  for (const start of adjacency.keys()) {
+    if (visited.has(start)) continue;
+    visited.add(start);
+    const stack: Array<{ path: string; next: number }> = [{ path: start, next: 0 }];
+    while (stack.length > 0) {
+      const frame = stack.at(-1)!;
+      const targets = adjacency.get(frame.path)!;
+      const target = targets[frame.next];
+      if (target !== undefined) {
+        frame.next++;
+        if (!visited.has(target)) {
+          visited.add(target);
+          stack.push({ path: target, next: 0 });
+        }
+        continue;
+      }
+      finishOrder.push(frame.path);
+      stack.pop();
+    }
+  }
+
+  const componentByPath = new Map<string, number>();
+  const componentSizes: number[] = [];
+  for (let orderIndex = finishOrder.length - 1; orderIndex >= 0; orderIndex--) {
+    const start = finishOrder[orderIndex]!;
+    if (componentByPath.has(start)) continue;
+    const componentId = componentSizes.length;
+    let size = 0;
+    const pending = [start];
+    componentByPath.set(start, componentId);
+    while (pending.length > 0) {
+      const path = pending.pop()!;
+      size++;
+      for (const importer of reverseAdjacency.get(path)!) {
+        if (componentByPath.has(importer)) continue;
+        componentByPath.set(importer, componentId);
+        pending.push(importer);
+      }
+    }
+    componentSizes.push(size);
+  }
+
+  const cycleBoundSources = new Set<string>();
+  const pending: string[] = [];
+  for (const [path, targets] of adjacency) {
+    const componentId = componentByPath.get(path)!;
+    if (componentSizes[componentId]! === 1 && !targets.includes(path)) continue;
+    cycleBoundSources.add(path);
+    pending.push(path);
+  }
+  for (let index = 0; index < pending.length; index++) {
+    for (const importer of reverseAdjacency.get(pending[index]!)!) {
+      if (cycleBoundSources.has(importer)) continue;
+      cycleBoundSources.add(importer);
+      pending.push(importer);
+    }
+  }
+  return cycleBoundSources;
+}
+
+async function createSourceGraphPlan(
+  rootFilePath: string,
+  rootCacheKey: string,
+  localAdapter: RuntimeAdapter,
+  config: ModuleLoaderConfig,
+  rootUsesLocalAdapter: boolean,
+  recoveryNonce?: string,
+): Promise<SourceGraphPlan> {
+  const nodes = new Map<string, SourceGraphNode>();
+  const pending = [{ filePath: rootFilePath, useLocalAdapter: rootUsesLocalAdapter }];
+  const queued = new Set([rootFilePath]);
+
+  for (let index = 0; index < pending.length; index++) {
+    if (nodes.size >= MAX_SOURCE_GRAPH_MODULES) {
+      throw CACHE_ERROR.create({ detail: "Module source graph limit exceeded" });
+    }
+    throwIfModuleLoadAborted(config);
+    const current = pending[index]!;
+    const readAdapter = current.useLocalAdapter ? localAdapter : config.adapter;
+    let fileContent: string;
+    try {
+      fileContent = decodeFileContent(await readAdapter.fs.readFile(current.filePath));
+      markModuleLoadProgress(config, "module:source-read", current.filePath);
+    } catch (error) {
+      nodes.set(current.filePath, { status: "failed", error });
+      continue;
+    }
+
+    try {
+      const resolvedDeps = await resolveModuleDependencies({
+        adapter: config.adapter,
+        fileContent,
+        filePath: current.filePath,
+        projectDir: config.projectDir,
+      });
+      nodes.set(current.filePath, { status: "ready", fileContent, resolvedDeps });
+      markModuleLoadProgress(config, "module:dependencies-resolved", current.filePath);
+      for (const dependency of resolvedDeps) {
+        if (!dependency.depFilePath || queued.has(dependency.depFilePath)) continue;
+        queued.add(dependency.depFilePath);
+        pending.push({
+          filePath: dependency.depFilePath,
+          useLocalAdapter: dependency.isLocalLib,
+        });
+      }
+    } catch (error) {
+      nodes.set(current.filePath, { status: "failed", fileContent, error });
+    }
+  }
+
+  const sortedPaths = [...nodes.keys()].sort();
+  const artifactIds = new Map(
+    sortedPaths.map((path, index) => [path, index.toString(36)]),
+  );
+  const identity = sortedPaths.map((path) => {
+    const node = nodes.get(path)!;
+    return [
+      relative(config.projectDir, path).replaceAll("\\", "/"),
+      node.fileContent ?? null,
+      (node.status === "ready" ? node.resolvedDeps : []).map((dependency) => [
+        dependency.path,
+        dependency.depFilePath
+          ? relative(config.projectDir, dependency.depFilePath).replaceAll("\\", "/")
+          : null,
+        dependency.isDynamic,
+      ]),
+    ];
+  });
+  const graphId = (await computeHash(
+    JSONStringify([rootCacheKey, recoveryNonce ?? null, identity]),
+  )).slice(0, 32);
+  return {
+    graphId,
+    nodes,
+    cycleBoundSources: computeCycleBoundSources(nodes),
+    artifactIds,
+    transforms: new Map(),
+    unresolvedBySource: new Map(),
+  };
+}
+
+function plannedEntryId(
+  sourceGraph: SourceGraphPlan,
+  importerFilePath: string,
+  dependency: ResolvedModuleDependency,
+): string {
+  const artifactId = sourceGraph.artifactIds.get(importerFilePath) ?? "0";
+  return `${artifactId}-${dependency.start.toString(36)}-${dependency.end.toString(36)}`;
+}
+
 /**
  * Transform a module and all its local dependencies (@/ alias and relative imports).
  *
@@ -99,18 +311,17 @@ function decodeFileContent(fileContent: string | Uint8Array): string {
  * @param useLocalAdapter - Whether to use local adapter for reading
  * @returns Path to the transformed module file
  */
-export async function transformModuleWithDeps(
+async function transformModuleWithDepsUnmemoized(
   filePath: string,
   tmpDir: string,
   localAdapter: RuntimeAdapter,
   config: ModuleLoaderConfig,
   useLocalAdapter = false,
   lineage: ReadonlySet<string> = new Set(),
-  // Shared by reference across the whole transform tree (unlike `lineage`, which
-  // is copied per level): a descendant records a cycle target here, and the
-  // ancestor that eventually persists that target reads it to write a stable
-  // alias the left-as-authored cycle edge can resolve to.
-  cycleTargets: Set<string> = new Set(),
+  // Shared by reference across the whole transform tree. It reserves immutable
+  // graph-local paths for cycle edges before their target hashes are known, then
+  // publishes caches only after those manifest entries are durable.
+  cycleManifest?: CycleManifestTransaction,
   // Also shared by reference across the whole transform tree: every specifier
   // the dependency resolver could not resolve and therefore left as authored.
   // Those are the only specifiers that can survive into the built module and
@@ -125,6 +336,9 @@ export async function transformModuleWithDeps(
   // cache-hit branch therefore replays what the first resolution found.
   unresolvedSpecifiers: Set<string> = new Set(),
 ): Promise<string> {
+  const ownsCycleManifest = cycleManifest === undefined;
+  let sourceGraph = cycleManifest ? sourceGraphByCycleManifest.get(cycleManifest) : undefined;
+  let recoveryNonce: string | undefined;
   throwIfModuleLoadAborted(config);
   const { moduleCache, projectDir, projectId, contentSourceId, adapter, mode } = config;
   const cacheKey = getModuleCacheKey(
@@ -152,19 +366,69 @@ export async function transformModuleWithDeps(
     serverExternalPackages: config.serverExternalPackages,
   });
   if (cachedPath) {
-    // Replay the evidence this module produced when it was last resolved. A
-    // cache hit skips `resolveModuleDependencies`, so without this a dependency
-    // that was already transformed contributes nothing and its tenant-authored
-    // dangling import silently loses attribution.
-    const memoizedUnresolvedSpecifiers = unresolvedSpecifiersByCacheKey.get(cacheKey);
-    const cachedUnresolvedSpecifiers = memoizedUnresolvedSpecifiers ??
-      await readPersistedUnresolvedSpecifiers(cachedPath, localAdapter);
-    cacheUnresolvedSpecifiers(cacheKey, cachedUnresolvedSpecifiers);
-    for (const specifier of cachedUnresolvedSpecifiers) {
-      unresolvedSpecifiers.add(specifier);
+    const cycleManifestState = await inspectCycleManifestCache(
+      cachedPath,
+      tmpDir,
+      localAdapter,
+    );
+    let shouldRebuild = cycleManifestState === "invalid" ||
+      cycleManifestState === "valid-root" && lineage.size > 0 ||
+      sourceGraph?.cycleBoundSources.has(filePath) === true;
+    if (!shouldRebuild && ownsCycleManifest && cycleManifestState === "valid-root") {
+      sourceGraph = await createSourceGraphPlan(
+        filePath,
+        cacheKey,
+        localAdapter,
+        config,
+        useLocalAdapter,
+      );
+      shouldRebuild = !cycleArtifactBelongsToGraph(
+        cachedPath,
+        tmpDir,
+        sourceGraph.graphId,
+      );
     }
-    markModuleLoadProgress(config, "module:cache-hit", filePath);
-    return cachedPath;
+    if (shouldRebuild) {
+      if (ownsCycleManifest && cycleManifestState === "invalid") {
+        recoveryNonce = crypto.randomUUID();
+      }
+      moduleCache.delete(cacheKey);
+    } else {
+      // Replay the evidence this module produced when it was last resolved. A
+      // cache hit skips `resolveModuleDependencies`, so without this a dependency
+      // that was already transformed contributes nothing and its tenant-authored
+      // dangling import silently loses attribution.
+      const memoizedUnresolvedSpecifiers = unresolvedSpecifiersByCacheKey.get(cacheKey);
+      const cachedUnresolvedSpecifiers = memoizedUnresolvedSpecifiers ??
+        await readPersistedUnresolvedSpecifiers(cachedPath, localAdapter);
+      cacheUnresolvedSpecifiers(cacheKey, cachedUnresolvedSpecifiers);
+      for (const specifier of cachedUnresolvedSpecifiers) {
+        unresolvedSpecifiers.add(specifier);
+      }
+      sourceGraph?.unresolvedBySource.set(filePath, cachedUnresolvedSpecifiers);
+      markModuleLoadProgress(config, "module:cache-hit", filePath);
+      return cachedPath;
+    }
+  }
+
+  if (ownsCycleManifest) {
+    sourceGraph ??= await createSourceGraphPlan(
+      filePath,
+      cacheKey,
+      localAdapter,
+      config,
+      useLocalAdapter,
+      recoveryNonce,
+    );
+    cycleManifest = new CycleManifestTransaction(
+      tmpDir,
+      sourceGraph.graphId,
+      sourceGraph.artifactIds,
+    );
+    sourceGraphByCycleManifest.set(cycleManifest, sourceGraph);
+  }
+  if (!cycleManifest || !sourceGraph) {
+    throw CACHE_ERROR.create({ detail: "Module source graph was not initialized" });
   }
 
   // Collect this module and every recursively transformed descendant into an
@@ -172,17 +436,13 @@ export async function transformModuleWithDeps(
   // merge it into the caller's aggregate evidence.
   const moduleUnresolvedSpecifiers = new Set<string>();
 
-  const readAdapter = useLocalAdapter ? localAdapter : adapter;
-  let fileContent = decodeFileContent(await readAdapter.fs.readFile(filePath));
-  markModuleLoadProgress(config, "module:source-read", filePath);
-
-  const resolvedDeps = await resolveModuleDependencies({
-    adapter,
-    fileContent,
-    filePath,
-    projectDir,
-  });
-  markModuleLoadProgress(config, "module:dependencies-resolved", filePath);
+  const sourceNode = sourceGraph.nodes.get(filePath);
+  if (!sourceNode) {
+    throw CACHE_ERROR.create({ detail: "Module source graph is incomplete" });
+  }
+  if (sourceNode.status === "failed") throw sourceNode.error;
+  let fileContent = sourceNode.fileContent;
+  const resolvedDeps = sourceNode.resolvedDeps;
 
   // The module cache is only written once a transform completes, so it cannot
   // break a cycle that is still in progress. Carry the chain instead.
@@ -190,27 +450,28 @@ export async function transformModuleWithDeps(
 
   const transformedDeps = (await Promise.all(
     resolvedDeps.filter((d) => d.depFilePath).map(async (dep) => {
+      const manifestDependency = (): TransformedModuleDependency | null => {
+        if (!needsCycleManifest(dep.depFilePath!)) return null;
+        return {
+          ...dep,
+          depTempPath: cycleManifest.registerEdge(
+            dep.depFilePath!,
+            filePath,
+            dep.isDynamic,
+            plannedEntryId(sourceGraph, filePath, dep),
+          ),
+        };
+      };
       // `await import()` is how a module graph legitimately breaks an import
       // cycle, so following one eagerly can lead straight back to a module
-      // further up this chain and recurse until the worker dies. Leave the
-      // specifier as authored so the recursion terminates.
-      //
-      // The cycle target is persisted as a content-hashed artifact whose hash
-      // is derived from transformed output we do not produce here (producing it
-      // is the recursion we are breaking), so the edge cannot be rewritten to
-      // that hashed path. Instead we record the target: when its ancestor
-      // persists it, a stable non-hashed alias is written next to the hashed
-      // artifact so the relative `.js` specifier esbuild leaves behind resolves.
-      // NOTE: this alias path is not yet runtime-verified end to end; if it does
-      // not resolve in a real runtime the cycle branch stays broken, which is no
-      // worse than before (and still a strict improvement over hanging).
+      // further up this chain and recurse until the worker dies. Route that
+      // edge through graph-scoped indirection while the target hash is pending.
       if (nextLineage.has(dep.depFilePath!)) {
-        cycleTargets.add(dep.depFilePath!);
         logger.debug("Skipping dependency already in the transform chain:", {
           path: dep.path,
           depFilePath: dep.depFilePath,
         });
-        return null;
+        return manifestDependency();
       }
 
       logger.debug("Found dependency:", {
@@ -219,6 +480,8 @@ export async function transformModuleWithDeps(
         isLocalLib: dep.isLocalLib,
       });
 
+      const finishWait = cycleManifest.beginDependencyWait(filePath, dep.depFilePath!);
+      if (!finishWait) return manifestDependency();
       try {
         const depTempPath = await transformModuleWithDeps(
           dep.depFilePath!,
@@ -227,7 +490,7 @@ export async function transformModuleWithDeps(
           config,
           dep.isLocalLib,
           nextLineage,
-          cycleTargets,
+          cycleManifest,
           moduleUnresolvedSpecifiers,
         );
 
@@ -252,9 +515,18 @@ export async function transformModuleWithDeps(
           reason: error instanceof Error ? error.message : String(error),
         });
         return null;
+      } finally {
+        finishWait();
       }
     }),
   )).filter((dep): dep is TransformedModuleDependency => dep !== null);
+  if (
+    transformedDeps.some((dep) =>
+      dep.depFilePath !== null && cycleManifest.isCycleBound(dep.depFilePath)
+    )
+  ) {
+    cycleManifest.markCycleBound(filePath);
+  }
   markModuleLoadProgress(config, "module:dependencies-transformed", filePath);
 
   fileContent = rewriteResolvedDependencyImports(fileContent, transformedDeps);
@@ -274,8 +546,10 @@ export async function transformModuleWithDeps(
       projectDir,
     });
   }
+  const cycleBound = cycleManifest.isCycleBound(filePath);
+  const useCycleArtifact = cycleBound;
   const effectiveProjectId = projectId ?? projectDir;
-  const { code: transformedCode } = await transformModuleCodeWithCache({
+  let { code: transformedCode } = await transformModuleCodeWithCache({
     fileContent,
     filePath,
     projectDir,
@@ -291,6 +565,19 @@ export async function transformModuleWithDeps(
     onProgress: config.onProgress,
     signal: config.signal,
   });
+  const exposesDefault = (cycleManifest.referencesStaticTarget(filePath) ||
+    cycleBound && ownsCycleManifest) &&
+    transformedModuleHasDefaultExport(transformedCode);
+  if (cycleBound) {
+    transformedCode = ownsCycleManifest
+      ? await cycleManifest.sealRootArtifactCode(
+        transformedCode,
+        filePath,
+        exposesDefault,
+        localAdapter,
+      )
+      : cycleManifest.markMemberArtifactCode(transformedCode);
+  }
   markModuleLoadProgress(config, "module:source-transformed", filePath);
 
   const persistedPath = await persistTransformedModule({
@@ -306,13 +593,88 @@ export async function transformModuleWithDeps(
     moduleServerOrigin: config.moduleServerOrigin,
     dependencyPinningCacheKey: config.dependencyPinningCacheKey,
     serverExternalPackages: config.serverExternalPackages,
-    isCycleTarget: cycleTargets.has(filePath),
     unresolvedSpecifiers: [...moduleUnresolvedSpecifiers],
+    cycleArtifactPath: useCycleArtifact ? cycleManifest.reserveArtifactPath(filePath) : undefined,
+    deferCachePublication: (publication) => {
+      if (cycleBound && !ownsCycleManifest) return;
+      cycleManifest.deferCachePublication(async () => {
+        if (cycleBound && contentSourceId) {
+          await registerCycleManifestSources(
+            tmpDir,
+            projectDir,
+            sourceGraph.cycleBoundSources,
+          );
+        }
+        await publication();
+      });
+    },
   });
+  cycleManifest.recordArtifact(
+    filePath,
+    persistedPath,
+    exposesDefault,
+    ownsCycleManifest,
+  );
+  if (ownsCycleManifest) await cycleManifest.commit(localAdapter);
   cacheUnresolvedSpecifiers(cacheKey, [...moduleUnresolvedSpecifiers]);
+  sourceGraph.unresolvedBySource.set(filePath, [...moduleUnresolvedSpecifiers]);
   for (const specifier of moduleUnresolvedSpecifiers) unresolvedSpecifiers.add(specifier);
   markModuleLoadProgress(config, "module:persisted", filePath);
   return persistedPath;
+}
+
+/** Transform a module graph while sharing each planned source's in-flight result. */
+export function transformModuleWithDeps(
+  filePath: string,
+  tmpDir: string,
+  localAdapter: RuntimeAdapter,
+  config: ModuleLoaderConfig,
+  useLocalAdapter = false,
+  lineage: ReadonlySet<string> = new Set(),
+  cycleManifest?: CycleManifestTransaction,
+  unresolvedSpecifiers: Set<string> = new Set(),
+): Promise<string> {
+  const sourceGraph = cycleManifest ? sourceGraphByCycleManifest.get(cycleManifest) : undefined;
+  if (!sourceGraph) {
+    return transformModuleWithDepsUnmemoized(
+      filePath,
+      tmpDir,
+      localAdapter,
+      config,
+      useLocalAdapter,
+      lineage,
+      cycleManifest,
+      unresolvedSpecifiers,
+    );
+  }
+
+  const pending = sourceGraph.transforms.get(filePath);
+  if (pending) {
+    return pending.then((path) => {
+      for (const specifier of sourceGraph.unresolvedBySource.get(filePath) ?? []) {
+        unresolvedSpecifiers.add(specifier);
+      }
+      return path;
+    });
+  }
+
+  const transform = transformModuleWithDepsUnmemoized(
+    filePath,
+    tmpDir,
+    localAdapter,
+    config,
+    useLocalAdapter,
+    lineage,
+    cycleManifest,
+    unresolvedSpecifiers,
+  );
+  sourceGraph.transforms.set(filePath, transform);
+  void transform.catch(() => {
+    if (sourceGraph.transforms.get(filePath) === transform) {
+      sourceGraph.transforms.delete(filePath);
+    }
+  });
+  return transform;
 }
 
 export interface ModuleLoaderConfig {

--- a/src/rendering/orchestrator/module-loader/module-persistence.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertNotEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { basename, dirname, join } from "#veryfront/compat/path/index.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
@@ -12,6 +12,7 @@ import {
 import {
   persistTransformedModule,
   readPersistedUnresolvedSpecifiers,
+  transformedModuleHasDefaultExport,
 } from "./module-persistence.ts";
 
 describe("module-loader/module-persistence", () => {
@@ -63,7 +64,46 @@ describe("module-loader/module-persistence", () => {
     }
   });
 
-  it("isolates dynamic-cycle artifacts and aliases across dependency snapshots", async () => {
+  it("defers memory and path-cache publication until the graph commits", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const filePath = join(projectDir, "app/page.ts");
+    const moduleCache = new Map<string, string>();
+    let publication: (() => Promise<void>) | undefined;
+
+    try {
+      const result = await persistTransformedModule({
+        filePath,
+        projectDir,
+        tmpDir,
+        transformedCode: "export const page = 1;",
+        localAdapter,
+        moduleCache,
+        cacheKey: "deferred",
+        contentSourceId: "preview-main",
+        reactVersion: "19.1.1",
+        deferCachePublication: (publish) => {
+          publication = publish;
+        },
+      });
+
+      const pathCache = await getModulePathCache(tmpDir);
+      const mdxCacheKey = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+      assertEquals(moduleCache.has("deferred"), false);
+      assertEquals(pathCache.has(mdxCacheKey), false);
+
+      await publication?.();
+
+      assertEquals(moduleCache.get("deferred"), result);
+      assertEquals(pathCache.get(mdxCacheKey), result);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
+  it("isolates artifacts across dependency snapshots", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
     const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
     const localAdapter = await getLocalAdapter();
@@ -81,7 +121,6 @@ describe("module-loader/module-persistence", () => {
         cacheKey: "snapshot-a",
         dependencyPinningCacheKey: "on:34n9smy47dk9",
         moduleServerOrigin: "https://app.example.test",
-        isCycleTarget: true,
       });
       const snapshotBPath = await persistTransformedModule({
         filePath,
@@ -93,28 +132,18 @@ describe("module-loader/module-persistence", () => {
         cacheKey: "snapshot-b",
         dependencyPinningCacheKey: "on:34n8mjmdp7io",
         moduleServerOrigin: "https://app.example.test",
-        isCycleTarget: true,
       });
 
       assertNotEquals(dirname(snapshotAPath), dirname(snapshotBPath));
-
-      const snapshotAAlias = await Deno.readTextFile(join(dirname(snapshotAPath), "page.js"));
-      const snapshotBAlias = await Deno.readTextFile(join(dirname(snapshotBPath), "page.js"));
-      assertStringIncludes(
-        snapshotAAlias,
-        `export * from "./${basename(snapshotAPath)}";`,
-      );
-      assertStringIncludes(
-        snapshotBAlias,
-        `export * from "./${basename(snapshotBPath)}";`,
-      );
+      assertEquals(await Deno.readTextFile(snapshotAPath), `export const snapshot = "A";`);
+      assertEquals(await Deno.readTextFile(snapshotBPath), `export const snapshot = "B";`);
     } finally {
       await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
       await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
     }
   });
 
-  it("writes a JavaScript cycle target at the authored stable path", async () => {
+  it("writes JavaScript at its authored path", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
     const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
     const localAdapter = await getLocalAdapter();
@@ -128,8 +157,7 @@ describe("module-loader/module-persistence", () => {
         transformedCode,
         localAdapter,
         moduleCache: new Map<string, string>(),
-        cacheKey: "javascript-cycle-target",
-        isCycleTarget: true,
+        cacheKey: "javascript-module",
       });
 
       assertEquals(result, join(tmpDir, "app/page.js"));
@@ -140,38 +168,56 @@ describe("module-loader/module-persistence", () => {
     }
   });
 
-  it("does not infer a default cycle alias from string contents", async () => {
+  it("keeps cycle artifacts outside the authored source namespace", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
     const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
     const localAdapter = await getLocalAdapter();
-    const filePath = join(projectDir, "app/page.ts");
-    const moduleCache = new Map<string, string>();
+    const cycleCode = `export const owner = "cycle";`;
 
     try {
-      const result = await persistTransformedModule({
-        filePath,
+      const cyclePath = await persistTransformedModule({
+        filePath: join(projectDir, "lib/widget.js"),
         projectDir,
         tmpDir,
-        transformedCode: `export const label = "Set as default";`,
+        transformedCode: cycleCode,
         localAdapter,
-        moduleCache,
-        cacheKey: "string-default",
-        isCycleTarget: true,
+        moduleCache: new Map<string, string>(),
+        cacheKey: "cycle-artifact",
+        cycleArtifactPath: join(
+          tmpDir,
+          "_cycle-manifests/snapshot-a/artifacts/0.deadbeef.js",
+        ),
+      });
+      const authoredPath = await persistTransformedModule({
+        filePath: join(projectDir, "lib", basename(cyclePath)),
+        projectDir,
+        tmpDir,
+        transformedCode: `export const owner = "authored";`,
+        localAdapter,
+        moduleCache: new Map<string, string>(),
+        cacheKey: "authored-artifact",
       });
 
-      const aliasCode = await Deno.readTextFile(join(dirname(result), "page.js"));
-      assertEquals(aliasCode, `export * from "./${basename(result)}";`);
+      assertNotEquals(authoredPath, cyclePath);
+      assertEquals(await Deno.readTextFile(cyclePath), cycleCode);
+      assertEquals(
+        authoredPath,
+        join(tmpDir, "lib", basename(cyclePath)),
+      );
     } finally {
       await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
       await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
     }
   });
 
-  it("does not infer a default cycle alias from regex contents", async () => {
-    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
-    const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
-    const localAdapter = await getLocalAdapter();
+  it("does not infer a default export from string contents", () => {
+    assertEquals(
+      transformedModuleHasDefaultExport(`export const label = "Set as default";`),
+      false,
+    );
+  });
 
+  it("does not infer a default export from regex contents", () => {
     const cases = [
       `export const pattern = /export default/;`,
       `if (enabled) /export default/.test(source); export const value = 1;`,
@@ -184,87 +230,40 @@ describe("module-loader/module-persistence", () => {
       `function read() { return // keep the comment\n/export default/.source; }`,
     ] as const;
 
-    try {
-      for (const [index, transformedCode] of cases.entries()) {
-        const filePath = join(projectDir, `app/page-${index}.ts`);
-        const result = await persistTransformedModule({
-          filePath,
-          projectDir,
-          tmpDir,
-          transformedCode,
-          localAdapter,
-          moduleCache: new Map<string, string>(),
-          cacheKey: `regex-default-${index}`,
-          isCycleTarget: true,
-        });
-
-        const aliasCode = await Deno.readTextFile(join(dirname(result), `page-${index}.js`));
-        assertEquals(aliasCode, `export * from "./${basename(result)}";`);
-      }
-    } finally {
-      await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
-      await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+    for (const transformedCode of cases) {
+      assertEquals(transformedModuleHasDefaultExport(transformedCode), false);
     }
   });
 
-  it("writes default cycle aliases only when an export exposes default", async () => {
-    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
-    const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
-    const localAdapter = await getLocalAdapter();
-    const moduleCache = new Map<string, string>();
-
+  it("detects whether transformed code exposes a default export", () => {
     const cases = [
       {
-        path: "app/default-declaration.ts",
         transformedCode: `export default function Page() { return null; }`,
         exposesDefault: true,
       },
       {
-        path: "app/division-before-default.ts",
         transformedCode: `const ratio = total / count; export default ratio;`,
         exposesDefault: true,
       },
       {
-        path: "app/member-keyword-division-before-default.ts",
         transformedCode: `const ratio = mod.typeof / 2; export { default } from "./component.js";`,
         exposesDefault: true,
       },
       {
-        path: "app/named-as-default.ts",
         transformedCode: `const Page = () => null;\nexport { Page as default };`,
         exposesDefault: true,
       },
       {
-        path: "app/default-as-named.ts",
         transformedCode: `export { default as Page } from "./component.js";`,
         exposesDefault: false,
       },
     ] as const;
 
-    try {
-      for (const testCase of cases) {
-        const result = await persistTransformedModule({
-          filePath: join(projectDir, testCase.path),
-          projectDir,
-          tmpDir,
-          transformedCode: testCase.transformedCode,
-          localAdapter,
-          moduleCache,
-          cacheKey: testCase.path,
-          isCycleTarget: true,
-        });
-
-        const aliasCode = await Deno.readTextFile(
-          join(dirname(result), basename(testCase.path).replace(/\.ts$/, ".js")),
-        );
-        assertEquals(
-          aliasCode.includes(`export { default } from "./${basename(result)}";`),
-          testCase.exposesDefault,
-        );
-      }
-    } finally {
-      await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
-      await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+    for (const testCase of cases) {
+      assertEquals(
+        transformedModuleHasDefaultExport(testCase.transformedCode),
+        testCase.exposesDefault,
+      );
     }
   });
 
@@ -481,12 +480,9 @@ describe("module-loader/module-persistence", () => {
         contentSourceId: "preview-main",
         reactVersion: "19.1.1",
         unresolvedSpecifiers: ["./missing"],
-        isCycleTarget: true,
       });
 
       assertEquals(await Deno.readTextFile(result), transformedCode);
-      const aliasCode = await Deno.readTextFile(join(tmpDir, "lib/evidence.js"));
-      assertStringIncludes(aliasCode, `export * from "./${basename(result)}";`);
       assertEquals(moduleCache.has("evidence"), false);
       assertEquals(await readPersistedUnresolvedSpecifiers(result, stubAdapter), []);
 

--- a/src/rendering/orchestrator/module-loader/module-persistence.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.ts
@@ -80,12 +80,34 @@ export interface PersistTransformedModuleInput {
   serverExternalPackages?: readonly string[];
   /** Tenant-authored imports left unresolved in this module subtree. */
   unresolvedSpecifiers?: readonly string[];
-  /**
-   * True when a dynamic import elsewhere closes a cycle back onto this module.
-   * Such an edge is left as authored (`import("../app/page.js")`), so it needs a
-   * stable, non-hashed alias next to the content-hashed artifact to resolve to.
-   */
-  isCycleTarget?: boolean;
+  /** Exact graph-content-addressed path for a cycle-dependent artifact. */
+  cycleArtifactPath?: string;
+  /** Delay cache visibility until the caller commits its full module graph. */
+  deferCachePublication?: (publication: () => Promise<void>) => void;
+}
+
+type ModuleOutputInput = Pick<
+  PersistTransformedModuleInput,
+  | "filePath"
+  | "projectDir"
+  | "tmpDir"
+  | "dependencyPinningCacheKey"
+  | "moduleServerOrigin"
+  | "serverExternalPackages"
+>;
+
+function getOutputRelativePath(input: ModuleOutputInput): string {
+  const relativePath = input.filePath.startsWith(input.projectDir)
+    ? input.filePath.slice(input.projectDir.length).replace(/^\/+/, "")
+    : input.filePath.replace(/^\/+/, "");
+  const cacheVariant = buildModuleTransformCacheVariant(
+    input.dependencyPinningCacheKey,
+    input.moduleServerOrigin,
+    input.serverExternalPackages,
+  );
+  return cacheVariant
+    ? join("_pins", encodeURIComponent(cacheVariant), relativePath)
+    : relativePath;
 }
 
 /** Read unresolved-import evidence stored beside a transformed artifact. */
@@ -114,11 +136,11 @@ export async function readPersistedUnresolvedSpecifiers(
 }
 
 /**
- * Whether transformed output exposes a default export, so a cycle alias knows
- * to re-export it. Covers esbuild's `export default …`, `… as default`, and
- * `export { default } from …` forms.
+ * Whether transformed output exposes a default export, so a cycle-manifest
+ * entry can re-export it. Covers esbuild's `export default …`, `… as default`,
+ * and `export { default } from …` forms.
  */
-function hasDefaultExport(code: string): boolean {
+export function transformedModuleHasDefaultExport(code: string): boolean {
   let previousTokenIndex = -1;
   const controlConditionCloseParens = new Set<number>();
   const statementBlockCloseBraces = new Set<number>();
@@ -483,46 +505,6 @@ function isIdentifierPart(char: string | undefined): boolean {
   return isIdentifierStart(char) || (char !== undefined && char >= "0" && char <= "9");
 }
 
-/**
- * Write a stable, non-hashed alias next to a cycle target's hashed artifact.
- *
- * A dynamic import that closes an import cycle is left as the author wrote it
- * (see the module loader), so esbuild normalises it to a relative `.js` path
- * (`../app/page.js`) that does not match the content-hashed artifact
- * (`../app/page.<hash>.js`). The alias sits at that relative path and re-exports
- * the real artifact, so the edge resolves if the branch runs. Best-effort: a
- * failed alias just leaves the pre-existing (unresolved) cycle edge in place.
- */
-async function writeCycleTargetAlias(
-  input: PersistTransformedModuleInput,
-  outputRelativePath: string,
-  hashedFileName: string,
-): Promise<void> {
-  const aliasRelativePath = outputRelativePath.replace(/\.(tsx?|jsx|mdx)$/, ".js");
-  // Same extension in and out means nothing was renamed (already `.js`): the
-  // authored edge already points at the real artifact, so no alias is needed.
-  if (aliasRelativePath === outputRelativePath) return;
-
-  const aliasPath = join(input.tmpDir, aliasRelativePath);
-  const lines = [`export * from "./${hashedFileName}";`];
-  if (hasDefaultExport(input.transformedCode)) {
-    lines.push(`export { default } from "./${hashedFileName}";`);
-  }
-
-  try {
-    await input.localAdapter.fs.writeFile(aliasPath, lines.join("\n"));
-    logger.debug("Wrote cycle-target alias", {
-      alias: aliasRelativePath,
-      target: hashedFileName,
-    });
-  } catch (error) {
-    logger.warn("Failed to write cycle-target alias", {
-      filePath: input.filePath.slice(-40),
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
-
 /** Write a transformed module artifact and register cache pointers. */
 export async function persistTransformedModule(
   input: PersistTransformedModuleInput,
@@ -540,17 +522,11 @@ export async function persistTransformedModule(
   const relativePath = input.filePath.startsWith(input.projectDir)
     ? input.filePath.slice(input.projectDir.length).replace(/^\/+/, "")
     : input.filePath.replace(/^\/+/, "");
-
-  const cacheVariant = buildModuleTransformCacheVariant(
-    input.dependencyPinningCacheKey,
-    input.moduleServerOrigin,
-    input.serverExternalPackages,
-  );
-  const outputRelativePath = cacheVariant
-    ? join("_pins", encodeURIComponent(cacheVariant), relativePath)
-    : relativePath;
+  const outputRelativePath = getOutputRelativePath(input);
   const jsPath = outputRelativePath.replace(/\.(tsx?|jsx|mdx)$/, `.${transformedHash}.js`);
-  const tempFilePath = join(input.tmpDir, jsPath);
+  const tempFilePath = input.cycleArtifactPath
+    ? input.cycleArtifactPath
+    : join(input.tmpDir, jsPath);
 
   const tempDir = tempFilePath.substring(0, tempFilePath.lastIndexOf("/"));
   await ensureDir(input.localAdapter, tempDir).catch(() => {
@@ -605,38 +581,38 @@ export async function persistTransformedModule(
     }
   }
 
-  if (shouldPublishReusableCache && input.contentSourceId) {
-    const normalizedPath = `_vf_modules/${relativePath.replace(/\.(tsx?|jsx|mdx)$/, ".js")}`;
-    const mdxCacheKey = buildMdxEsmPathCacheKey(
-      normalizedPath,
-      input.reactVersion,
-      buildModuleTransformCacheVariant(
-        input.dependencyPinningCacheKey,
-        input.moduleServerOrigin,
-        input.serverExternalPackages,
-      ),
-    );
-    const cache = await getModulePathCache(input.tmpDir);
-    cache.set(mdxCacheKey, tempFilePath);
-
-    saveModulePathCache(input.tmpDir).catch((err) => {
-      logger.debug("Failed to save module cache", { error: String(err) });
-    });
-
-    logger.debug("Registered module in MDX-ESM cache", {
-      file: input.filePath.slice(-40),
-      mdxCacheKey,
-      tempFilePath: tempFilePath.slice(-60),
-    });
-  }
-
   if (shouldPublishReusableCache) {
-    input.moduleCache.set(input.cacheKey, tempFilePath);
-  }
+    const publish = async () => {
+      if (input.contentSourceId) {
+        const normalizedPath = `_vf_modules/${relativePath.replace(/\.(tsx?|jsx|mdx)$/, ".js")}`;
+        const mdxCacheKey = buildMdxEsmPathCacheKey(
+          normalizedPath,
+          input.reactVersion,
+          buildModuleTransformCacheVariant(
+            input.dependencyPinningCacheKey,
+            input.moduleServerOrigin,
+            input.serverExternalPackages,
+          ),
+        );
+        const cache = await getModulePathCache(input.tmpDir);
+        cache.set(mdxCacheKey, tempFilePath);
 
-  if (input.isCycleTarget) {
-    const hashedFileName = jsPath.slice(jsPath.lastIndexOf("/") + 1);
-    await writeCycleTargetAlias(input, outputRelativePath, hashedFileName);
+        saveModulePathCache(input.tmpDir).catch((err) => {
+          logger.debug("Failed to save module cache", { error: String(err) });
+        });
+
+        logger.debug("Registered module in MDX-ESM cache", {
+          file: input.filePath.slice(-40),
+          mdxCacheKey,
+          tempFilePath: tempFilePath.slice(-60),
+        });
+      }
+
+      input.moduleCache.set(input.cacheKey, tempFilePath);
+    };
+
+    if (input.deferCachePublication) input.deferCachePublication(publish);
+    else await publish();
   }
 
   return tempFilePath;

--- a/src/transforms/mdx/esm-module-loader/cache-format.ts
+++ b/src/transforms/mdx/esm-module-loader/cache-format.ts
@@ -1,5 +1,8 @@
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import { hashString as hashCachePath } from "#veryfront/cache/hash.ts";
+import { join } from "#veryfront/compat/path/index.ts";
 import { createCacheNamespace } from "#veryfront/utils/cache-namespace.ts";
+import { getCacheBaseDir } from "#veryfront/utils/cache-dir.ts";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 import {
@@ -13,6 +16,18 @@ const ALL_FILE_URL_PATTERN_SOURCE = /file:\/\/([^"'\s]+)/.source;
 const MJS_FILE_URL_PATTERN_SOURCE = /file:\/\/([^"'\s]+\.mjs)/.source;
 const CACHE_NAMESPACE_SENTINEL = "__vf_cache_namespace__";
 export const UNRESOLVED_IMPORTS_SIDECAR_SUFFIX = ".unresolved-imports.json";
+const CYCLE_MANIFEST_CACHE_DIR = "veryfront-cycle-manifests";
+export const CYCLE_MANIFEST_SIDECAR_SUFFIX = ".cycle-manifest.json";
+
+/** Cache-wide storage that no project or content-source namespace can occupy. */
+export function getCycleManifestCacheRootDir(): string {
+  return join(getCacheBaseDir(), CYCLE_MANIFEST_CACHE_DIR);
+}
+
+/** Storage outside the project-relative artifact namespace for one cache dir. */
+export function getCycleManifestCacheDir(cacheDir: string): string {
+  return join(getCycleManifestCacheRootDir(), hashCachePath(cacheDir));
+}
 const MDX_ESM_PATH_CACHE_ATTRIBUTION_SCHEMA = "unresolved-import-sidecars-v1";
 const PUBLIC_RUNTIME_SPECIFIERS = [
   "veryfront/head",

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join, toFileUrl } from "#veryfront/compat/path";
 import {
   clearAllLocalCaches,
+  clearESMDiskCache,
   clearMdxEsmCacheNamespace,
   clearModulePathCache,
   getLocalFs,
@@ -20,12 +21,15 @@ import {
 } from "./index.ts";
 import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 import { exists, readTextFile, remove, writeTextFile } from "#veryfront/compat/fs.ts";
-import { runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { getMdxEsmCacheDir, runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { getCycleManifestGeneration } from "../cycle-manifest-lifecycle.ts";
 import { cacheModule } from "../module-fetcher/module-cache.ts";
 import { rendererLogger as log } from "#veryfront/utils";
 import {
   buildMdxEsmModuleFileName,
   buildMdxEsmPathCacheKey,
+  CYCLE_MANIFEST_SIDECAR_SUFFIX,
+  getCycleManifestCacheDir,
   UNRESOLVED_IMPORTS_SIDECAR_SUFFIX,
 } from "../cache-format.ts";
 import { getCacheStats } from "#veryfront/utils/memory/index.ts";
@@ -83,11 +87,17 @@ describe("MDX module path cache", () => {
         const ssrCacheDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
         const cachedPath = join(cacheDir, "stale.mjs");
         const ssrCachedPath = join(ssrCacheDir, "stale-ssr.mjs");
+        const cycleArtifactPath = join(
+          getCycleManifestCacheDir(cacheDir),
+          "0-stale/artifacts/0.deadbeef.js",
+        );
 
         await getLocalFs().mkdir(cacheDir, { recursive: true });
         await getLocalFs().mkdir(ssrCacheDir, { recursive: true });
         await writeTextFile(cachedPath, "export default function Stale() {}");
         await writeTextFile(ssrCachedPath, "export default function StaleSSR() {}");
+        await getLocalFs().mkdir(join(cycleArtifactPath, ".."), { recursive: true });
+        await writeTextFile(cycleArtifactPath, "export default 'cycle';");
 
         const cache = await getModulePathCache(cacheDir);
         cache.set(cacheKey, cachedPath);
@@ -100,6 +110,7 @@ describe("MDX module path cache", () => {
 
         assertEquals(await exists(cachedPath), false);
         assertEquals(await exists(ssrCachedPath), false);
+        assertEquals(await exists(cycleArtifactPath), false);
         assertEquals((await getModulePathCache(cacheDir)).get(cacheKey), undefined);
         assertEquals((await getModulePathCache(ssrCacheDir)).get(cacheKey), undefined);
         assertEquals(verifiedModuleDeps.get(`${cachedPath}:${cacheKey}`), undefined);
@@ -175,6 +186,14 @@ describe("MDX module path cache", () => {
         const legacyParentPath = join(legacyParentDir, "parent.mjs");
         const legacyChildPath = join(legacyChildDir, "child-legacy.mjs");
         const currentChildPath = join(currentChildDir, "child-current.mjs");
+        const legacyChildCyclePath = join(
+          getCycleManifestCacheDir(legacyChildDir),
+          "0-stale/artifacts/0.deadbeef.js",
+        );
+        const currentChildCyclePath = join(
+          getCycleManifestCacheDir(currentChildDir),
+          "0-current/artifacts/0.cafebabe.js",
+        );
 
         await getLocalFs().mkdir(legacyParentDir, { recursive: true });
         await getLocalFs().mkdir(legacyChildDir, { recursive: true });
@@ -182,6 +201,10 @@ describe("MDX module path cache", () => {
         await writeTextFile(legacyParentPath, "export default 'legacy-parent';");
         await writeTextFile(legacyChildPath, "export default 'legacy-child';");
         await writeTextFile(currentChildPath, "export default 'current-child';");
+        await getLocalFs().mkdir(join(legacyChildCyclePath, ".."), { recursive: true });
+        await getLocalFs().mkdir(join(currentChildCyclePath, ".."), { recursive: true });
+        await writeTextFile(legacyChildCyclePath, "export default 'legacy-cycle';");
+        await writeTextFile(currentChildCyclePath, "export default 'current-cycle';");
 
         const legacyParentCache = await getModulePathCache(legacyParentDir);
         legacyParentCache.set(cacheKey, legacyParentPath);
@@ -198,6 +221,8 @@ describe("MDX module path cache", () => {
         assertEquals(await exists(legacyParentPath), false);
         assertEquals(await exists(legacyChildPath), false);
         assertEquals(await exists(currentChildPath), true);
+        assertEquals(await exists(legacyChildCyclePath), false);
+        assertEquals(await exists(currentChildCyclePath), true);
         assertEquals((await getModulePathCache(legacyParentDir)).get(cacheKey), undefined);
         assertEquals((await getModulePathCache(legacyChildDir)).get(cacheKey), undefined);
         assertEquals((await getModulePathCache(currentChildDir)).get(cacheKey), currentChildPath);
@@ -242,6 +267,52 @@ describe("MDX module path cache", () => {
         remove(cacheDirA, { recursive: true }),
         remove(cacheDirB, { recursive: true }),
       ]);
+      clearModulePathCache();
+    }
+  });
+
+  it("keeps cycle storage outside every content-source namespace", async () => {
+    const cacheBase = await makeTempDir({ prefix: "vf-cycle-namespace-isolation-" });
+
+    try {
+      await runWithCacheDir(cacheBase, () => {
+        const projectDir = join(cacheBase, "veryfront-mdx-esm", "project");
+        const mainCacheDir = join(projectDir, "main");
+        const collidingSourceDir = join(projectDir, "main.veryfront-cycle-manifests");
+
+        assertEquals(getCycleManifestCacheDir(mainCacheDir) === collidingSourceDir, false);
+      });
+    } finally {
+      await remove(cacheBase, { recursive: true });
+    }
+  });
+
+  it("removes persisted generations that predate a fresh-process full clear", async () => {
+    const cacheBase = await makeTempDir({ prefix: "vf-cycle-fresh-clear-" });
+
+    try {
+      await runWithCacheDir(cacheBase, async () => {
+        const cacheDir = join(getMdxEsmCacheDir(), "project", "source");
+        const staleArtifact = join(
+          getCycleManifestCacheDir(cacheDir),
+          "7-stale/artifacts/0.deadbeef.js",
+        );
+        const futureDatedArtifact = join(
+          getCycleManifestCacheDir(cacheDir),
+          `${Number.MAX_SAFE_INTEGER}-stale/artifacts/0.cafebabe.js`,
+        );
+        await getLocalFs().mkdir(join(staleArtifact, ".."), { recursive: true });
+        await getLocalFs().mkdir(join(futureDatedArtifact, ".."), { recursive: true });
+        await writeTextFile(staleArtifact, `export default "stale";`);
+        await writeTextFile(futureDatedArtifact, `export default "future-stale";`);
+
+        await clearESMDiskCache();
+
+        assertEquals(await exists(staleArtifact), false);
+        assertEquals(await exists(futureDatedArtifact), false);
+      });
+    } finally {
+      await remove(cacheBase, { recursive: true }).catch(() => {});
       clearModulePathCache();
     }
   });
@@ -462,10 +533,12 @@ describe("invalidateModulePaths — disk persistence", () => {
     const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
     const staleMjsPath = join(cacheDir, buildMdxEsmModuleFileName("stale-evidence"));
     const evidencePath = `${staleMjsPath}${UNRESOLVED_IMPORTS_SIDECAR_SUFFIX}`;
+    const cycleEvidencePath = `${staleMjsPath}${CYCLE_MANIFEST_SIDECAR_SUFFIX}`;
 
     try {
       await writeTextFile(staleMjsPath, `export default "stale";`);
       await writeTextFile(evidencePath, JSON.stringify(["./missing"]));
+      await writeTextFile(cycleEvidencePath, `{}`);
       await writeTextFile(
         join(cacheDir, "_index.json"),
         JSON.stringify({ [versionedKey]: staleMjsPath }),
@@ -477,7 +550,185 @@ describe("invalidateModulePaths — disk persistence", () => {
 
       assertEquals(await exists(staleMjsPath), false);
       assertEquals(await exists(evidencePath), false);
+      assertEquals(await exists(cycleEvidencePath), false);
     } finally {
+      await remove(cacheDir, { recursive: true }).catch(() => {});
+      clearModulePathCache();
+    }
+  });
+
+  it("deletes every cycle generation for an affected cache directory", async () => {
+    clearModulePathCache();
+
+    const cacheDir = await makeTempDir({ prefix: "vf-mdx-invalidate-cycle-" });
+    const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
+    const manifestDir = getCycleManifestCacheDir(cacheDir);
+    const oldGraphDir = join(manifestDir, "0-graph-a");
+    const currentGraphDir = join(manifestDir, "0-graph-b");
+    const staleModulePath = join(currentGraphDir, "artifacts", "0.deadbeef.js");
+
+    try {
+      await Deno.mkdir(join(oldGraphDir, "artifacts"), { recursive: true });
+      await Deno.writeTextFile(
+        join(oldGraphDir, "artifacts", "0.cafebabe.js"),
+        `export default "orphaned";`,
+      );
+      await Deno.mkdir(join(currentGraphDir, "artifacts"), { recursive: true });
+      await writeTextFile(staleModulePath, `export default "stale";`);
+      await writeTextFile(`${staleModulePath}.cycle-manifest.json`, `{}`);
+      await writeTextFile(
+        join(cacheDir, "_index.json"),
+        JSON.stringify({ [versionedKey]: staleModulePath }),
+      );
+      await getModulePathCache(cacheDir);
+
+      invalidateModulePaths(["components/EmptyState.tsx"]);
+      await waitForDiskCleanup();
+
+      assertEquals(await exists(manifestDir), false);
+    } finally {
+      await remove(manifestDir, { recursive: true }).catch(() => {});
+      await remove(cacheDir, { recursive: true }).catch(() => {});
+      clearModulePathCache();
+    }
+  });
+
+  it("does not delete a graph published after invalidation begins", async () => {
+    clearModulePathCache();
+
+    const cacheDir = await makeTempDir({ prefix: "vf-mdx-invalidate-cycle-race-" });
+    const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
+    const manifestDir = getCycleManifestCacheDir(cacheDir);
+    const staleGeneration = getCycleManifestGeneration(manifestDir);
+    const staleGraphDir = join(manifestDir, `${staleGeneration}-stale`);
+    const freshGraphDir = join(manifestDir, `${staleGeneration + 1}-fresh`);
+    const staleModulePath = join(staleGraphDir, "artifacts", "0.deadbeef.js");
+    const freshModulePath = join(freshGraphDir, "artifacts", "0.cafebabe.js");
+    const localFs = getLocalFs();
+    const originalReadDir = localFs.readDir.bind(localFs);
+    let releaseRead!: () => void;
+    const readReleased = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    let reportReadStarted!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      reportReadStarted = resolve;
+    });
+
+    try {
+      await Deno.mkdir(join(staleGraphDir, "artifacts"), { recursive: true });
+      await writeTextFile(staleModulePath, `export default "stale";`);
+      await writeTextFile(
+        join(cacheDir, "_index.json"),
+        JSON.stringify({ [versionedKey]: staleModulePath }),
+      );
+      const cache = await getModulePathCache(cacheDir);
+
+      localFs.readDir = (path: string): ReturnType<typeof originalReadDir> => {
+        if (path !== manifestDir) return originalReadDir(path);
+        return (async function* () {
+          reportReadStarted();
+          await readReleased;
+          yield* originalReadDir(path);
+        })();
+      };
+
+      invalidateModulePaths(["components/EmptyState.tsx"]);
+      await readStarted;
+      await Deno.mkdir(join(freshGraphDir, "artifacts"), { recursive: true });
+      await writeTextFile(freshModulePath, `export default "fresh";`);
+      cache.set(versionedKey, freshModulePath);
+      releaseRead();
+      await waitForDiskCleanup();
+
+      assertEquals(await exists(staleGraphDir), false);
+      assertEquals(await exists(freshModulePath), true);
+      assertEquals(cache.get(versionedKey), freshModulePath);
+    } finally {
+      releaseRead();
+      localFs.readDir = originalReadDir;
+      await remove(manifestDir, { recursive: true }).catch(() => {});
+      await remove(cacheDir, { recursive: true }).catch(() => {});
+      clearModulePathCache();
+    }
+  });
+
+  it("does not delete the latest graph after rapid invalidations", async () => {
+    clearModulePathCache();
+
+    const cacheDir = await makeTempDir({ prefix: "vf-mdx-invalidate-cycle-rapid-" });
+    const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
+    const manifestDir = getCycleManifestCacheDir(cacheDir);
+    const initialGeneration = getCycleManifestGeneration(manifestDir);
+    const initialGraphDir = join(manifestDir, `${initialGeneration}-initial`);
+    const initialModulePath = join(initialGraphDir, "artifacts", "0.deadbeef.js");
+    const localFs = getLocalFs();
+    const originalReadDir = localFs.readDir.bind(localFs);
+    let releaseRead!: () => void;
+    const readReleased = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    let reportReadStarted!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      reportReadStarted = resolve;
+    });
+
+    try {
+      await Deno.mkdir(join(initialGraphDir, "artifacts"), { recursive: true });
+      await writeTextFile(initialModulePath, `export default "initial";`);
+      await writeTextFile(
+        join(cacheDir, "_index.json"),
+        JSON.stringify({ [versionedKey]: initialModulePath }),
+      );
+      const cache = await getModulePathCache(cacheDir);
+
+      let intercepted = false;
+      localFs.readDir = (path: string): ReturnType<typeof originalReadDir> => {
+        if (path !== manifestDir || intercepted) return originalReadDir(path);
+        intercepted = true;
+        return (async function* () {
+          reportReadStarted();
+          await readReleased;
+          yield* originalReadDir(path);
+        })();
+      };
+
+      invalidateModulePaths(["components/EmptyState.tsx"]);
+      await readStarted;
+
+      const intermediateGeneration = getCycleManifestGeneration(manifestDir);
+      const intermediateGraphDir = join(
+        manifestDir,
+        `${intermediateGeneration}-intermediate`,
+      );
+      const intermediateModulePath = join(
+        intermediateGraphDir,
+        "artifacts",
+        "0.cafebabe.js",
+      );
+      await Deno.mkdir(join(intermediateGraphDir, "artifacts"), { recursive: true });
+      await writeTextFile(intermediateModulePath, `export default "intermediate";`);
+      cache.set(versionedKey, intermediateModulePath);
+
+      invalidateModulePaths(["components/EmptyState.tsx"]);
+      const latestGeneration = getCycleManifestGeneration(manifestDir);
+      const latestGraphDir = join(manifestDir, `${latestGeneration}-latest`);
+      const latestModulePath = join(latestGraphDir, "artifacts", "0.8badf00d.js");
+      await Deno.mkdir(join(latestGraphDir, "artifacts"), { recursive: true });
+      await writeTextFile(latestModulePath, `export default "latest";`);
+      cache.set(versionedKey, latestModulePath);
+
+      releaseRead();
+      await waitForDiskCleanup();
+
+      assertEquals(await exists(initialGraphDir), false);
+      assertEquals(await exists(intermediateGraphDir), false);
+      assertEquals(await exists(latestModulePath), true);
+      assertEquals(cache.get(versionedKey), latestModulePath);
+    } finally {
+      releaseRead();
+      localFs.readDir = originalReadDir;
+      await remove(manifestDir, { recursive: true }).catch(() => {});
       await remove(cacheDir, { recursive: true }).catch(() => {});
       clearModulePathCache();
     }
@@ -1300,7 +1551,14 @@ describe("local cache root version-control hygiene", () => {
 
     try {
       await runWithCacheDir(cacheBase, async () => {
+        const cycleArtifactPath = join(
+          getCycleManifestCacheDir(join(cacheBase, "veryfront-mdx-esm/project/source")),
+          "0-stale/artifacts/0.deadbeef.js",
+        );
+        await getLocalFs().mkdir(join(cycleArtifactPath, ".."), { recursive: true });
+        await writeTextFile(cycleArtifactPath, "export default 'stale-cycle';");
         await clearAllLocalCaches();
+        assertEquals(await exists(cycleArtifactPath), false);
       });
 
       const ignorePath = join(cacheBase, ".gitignore");

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -6,7 +6,7 @@
  * @module build/transforms/mdx/esm-module-loader/cache
  */
 
-import { fromFileUrl, join } from "#veryfront/compat/path";
+import { fromFileUrl, join, relative } from "#veryfront/compat/path";
 import { rendererLogger as logger } from "#veryfront/utils";
 import {
   ensureCacheDirIgnored,
@@ -22,9 +22,18 @@ import { registerCache } from "#veryfront/utils/memory/index.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import {
   buildMdxEsmPathCacheKey,
+  CYCLE_MANIFEST_SIDECAR_SUFFIX,
+  getCycleManifestCacheDir,
+  getCycleManifestCacheRootDir,
   MDX_ESM_ALL_FILE_URL_PATTERN_SOURCE,
   UNRESOLVED_IMPORTS_SIDECAR_SUFFIX,
 } from "../cache-format.ts";
+import {
+  advanceAllCycleManifestGenerations,
+  advanceCycleManifestGeneration,
+  getCycleManifestGeneration,
+  parseCycleManifestGeneration,
+} from "../cycle-manifest-lifecycle.ts";
 import { ensureMdxModuleDependencies } from "../module-fetcher/dependency-recovery.ts";
 import { findStaticImportFromSpans } from "../utils/source-spans.ts";
 import {
@@ -42,6 +51,13 @@ export type CacheLookupResult =
 
 const MAX_VERIFIED_MODULE_DEPS = 2_000;
 const MAX_MODULE_PATH_CACHE_ENTRIES = 500;
+const MAX_CYCLE_MANIFEST_SOURCE_ENTRIES = 5_000;
+const CYCLE_MANIFEST_SOURCES_INDEX_KEY = "__veryfront_cycle_manifest_sources_v1__";
+
+interface CycleManifestSourceIndex {
+  readonly sources: Set<string>;
+  saturated: boolean;
+}
 
 export const verifiedModuleDeps = new LRUCache<string, true>({
   maxEntries: MAX_VERIFIED_MODULE_DEPS,
@@ -172,6 +188,64 @@ function hasUnresolvedVfModules(code: string): boolean {
 
 const modulePathCaches = new Map<string, Map<string, string>>();
 const modulePathCacheLoaded = new Set<string>();
+const cycleManifestSources = new Map<string, CycleManifestSourceIndex>();
+
+function normalizeModuleSourcePath(path: string, projectDir?: string): string {
+  const relativePath = projectDir ? relative(projectDir, path) : path;
+  return relativePath
+    .replaceAll("\\", "/")
+    .replace(/^\/+/, "")
+    .replace(/\.(tsx?|jsx?|mdx)$/, "");
+}
+
+function loadCycleManifestSources(cacheDir: string, serialized: unknown): void {
+  if (serialized === "*") {
+    cycleManifestSources.set(cacheDir, { sources: new Set(), saturated: true });
+    return;
+  }
+  if (typeof serialized !== "string") return;
+
+  try {
+    const parsed = JSON.parse(serialized);
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length > MAX_CYCLE_MANIFEST_SOURCE_ENTRIES ||
+      parsed.some((path) => typeof path !== "string")
+    ) {
+      cycleManifestSources.set(cacheDir, { sources: new Set(), saturated: true });
+      return;
+    }
+    cycleManifestSources.set(cacheDir, {
+      sources: new Set(parsed),
+      saturated: false,
+    });
+  } catch (_) {
+    cycleManifestSources.set(cacheDir, { sources: new Set(), saturated: true });
+  }
+}
+
+/** Record cycle members without exposing them as reusable graph roots. */
+export async function registerCycleManifestSources(
+  cacheDir: string,
+  projectDir: string,
+  sourcePaths: Iterable<string>,
+): Promise<void> {
+  await getModulePathCache(cacheDir);
+  const index = cycleManifestSources.get(cacheDir) ?? {
+    sources: new Set<string>(),
+    saturated: false,
+  };
+  cycleManifestSources.set(cacheDir, index);
+  if (index.saturated) return;
+
+  for (const sourcePath of sourcePaths) {
+    index.sources.add(normalizeModuleSourcePath(sourcePath, projectDir));
+    if (index.sources.size <= MAX_CYCLE_MANIFEST_SOURCE_ENTRIES) continue;
+    index.sources.clear();
+    index.saturated = true;
+    return;
+  }
+}
 
 export function getMdxEsmSsrCacheDir(projectId: string, contentSourceId: string): string {
   return join(
@@ -230,6 +304,10 @@ export async function getModulePathCache(cacheDir: string): Promise<Map<string, 
     const content = await getLocalFs().readTextFile(indexPath);
     const index = JSON.parse(content) as Record<string, string>;
     for (const [path, cachePath] of Object.entries(index)) {
+      if (path === CYCLE_MANIFEST_SOURCES_INDEX_KEY) {
+        loadCycleManifestSources(cacheDir, cachePath);
+        continue;
+      }
       cache.set(path, cachePath);
     }
     logger.debug(`${LOG_PREFIX_MDX_LOADER} Loaded module index: ${cache.size} entries`);
@@ -250,6 +328,12 @@ export async function saveModulePathCache(cacheDir: string): Promise<void> {
   for (const [path, cachePath] of cache.entries()) {
     index[path] = cachePath;
   }
+  const sourceIndex = cycleManifestSources.get(cacheDir);
+  if (sourceIndex) {
+    index[CYCLE_MANIFEST_SOURCES_INDEX_KEY] = sourceIndex.saturated
+      ? "*"
+      : JSON.stringify([...sourceIndex.sources].sort());
+  }
 
   try {
     await getLocalFs().writeTextFile(indexPath, JSON.stringify(index));
@@ -261,6 +345,7 @@ export async function saveModulePathCache(cacheDir: string): Promise<void> {
 export function clearModulePathCache(): void {
   modulePathCaches.clear();
   modulePathCacheLoaded.clear();
+  cycleManifestSources.clear();
   verifiedModuleDeps.clear();
   logger.debug(`${LOG_PREFIX_MDX_LOADER} Cleared module path cache`);
 }
@@ -297,26 +382,83 @@ function queueIndexPersist(cacheDirs: string[]): void {
   });
 }
 
+async function deleteStaleCycleManifestGenerations(
+  localFs: ReturnType<typeof getLocalFs>,
+  manifestDir: string,
+  currentGeneration: number,
+): Promise<void> {
+  try {
+    for await (const entry of localFs.readDir(manifestDir)) {
+      if (!entry.isDirectory) continue;
+      const generation = parseCycleManifestGeneration(entry.name);
+      const liveGeneration = Math.max(
+        currentGeneration,
+        getCycleManifestGeneration(manifestDir),
+      );
+      if (generation === liveGeneration) continue;
+      await localFs.remove(join(manifestDir, entry.name), { recursive: true });
+    }
+    try {
+      await localFs.remove(manifestDir);
+    } catch (_) {
+      /* expected: a current generation keeps the namespace non-empty */
+    }
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error;
+  }
+}
+
+function moduleSourcePathsMatch(left: string, right: string): boolean {
+  return left === right || left.endsWith(`/${right}`) || right.endsWith(`/${left}`);
+}
+
+function cycleManifestSourceMatches(
+  index: CycleManifestSourceIndex | undefined,
+  changedPath: string,
+): boolean {
+  if (index?.saturated === true) return true;
+  if (!index) return false;
+  for (const sourcePath of index.sources) {
+    if (moduleSourcePathsMatch(sourcePath, changedPath)) return true;
+  }
+  return false;
+}
+
 export function invalidateModulePaths(changedPaths: string[]): void {
   if (modulePathCaches.size === 0) return;
 
   let invalidatedCount = 0;
   const staleMjsFiles: string[] = [];
+  const staleCycleManifestGenerations = new Map<string, number>();
   const affectedCacheDirs = new Set<string>();
 
+  const invalidateCycleManifest = (cacheDir: string): boolean => {
+    const manifestDir = getCycleManifestCacheDir(cacheDir);
+    if (staleCycleManifestGenerations.has(manifestDir)) return false;
+    staleCycleManifestGenerations.set(
+      manifestDir,
+      advanceCycleManifestGeneration(manifestDir),
+    );
+    affectedCacheDirs.add(cacheDir);
+    cycleManifestSources.delete(cacheDir);
+    return true;
+  };
+
   for (const changedPath of changedPaths) {
-    const normalizedChanged = changedPath.replace(/^\/+/, "").replace(/\.(tsx?|jsx?|mdx)$/, "");
+    const normalizedChanged = normalizeModuleSourcePath(changedPath);
 
     for (const [cacheDir, cache] of modulePathCaches.entries()) {
+      const sourceIndex = cycleManifestSources.get(cacheDir);
+      if (cycleManifestSourceMatches(sourceIndex, normalizedChanged)) {
+        if (invalidateCycleManifest(cacheDir)) invalidatedCount++;
+      }
+
       for (const [cachedKey, cachedFilePath] of cache.entries()) {
         const normalizedCached = extractNormalizedCachedModulePath(cachedKey);
 
-        if (
-          normalizedCached === normalizedChanged ||
-          normalizedCached.endsWith(`/${normalizedChanged}`) ||
-          normalizedChanged.endsWith(`/${normalizedCached}`)
-        ) {
+        if (moduleSourcePathsMatch(normalizedCached, normalizedChanged)) {
           staleMjsFiles.push(cachedFilePath);
+          invalidateCycleManifest(cacheDir);
           affectedCacheDirs.add(cacheDir);
           cache.delete(cachedKey);
           // Clear the verified-deps fast-path so lookupMdxEsmCache won't
@@ -334,6 +476,17 @@ export function invalidateModulePaths(changedPaths: string[]): void {
   );
 
   if (invalidatedCount === 0) return;
+
+  for (const [cacheDir, cache] of modulePathCaches.entries()) {
+    const manifestDir = getCycleManifestCacheDir(cacheDir);
+    if (!staleCycleManifestGenerations.has(manifestDir)) continue;
+    const normalizedPrefix = `${manifestDir.replaceAll("\\", "/").replace(/\/$/, "")}/`;
+    for (const [cachedKey, cachedFilePath] of cache.entries()) {
+      if (!cachedFilePath.replaceAll("\\", "/").startsWith(normalizedPrefix)) continue;
+      cache.delete(cachedKey);
+      verifiedModuleDeps.delete(`${cachedFilePath}:${cachedKey}`);
+    }
+  }
 
   // Persist invalidation to disk: update _index.json and delete stale .mjs files.
   // Fire-and-forget so callers aren't blocked, but disk state is eventually consistent.
@@ -368,6 +521,32 @@ export function invalidateModulePaths(changedPaths: string[]): void {
         await localFs.remove(`${mjsPath}${UNRESOLVED_IMPORTS_SIDECAR_SUFFIX}`);
       } catch (_) {
         /* expected: most modules have no unresolved-import evidence */
+      }
+      try {
+        await localFs.remove(`${mjsPath}${CYCLE_MANIFEST_SIDECAR_SUFFIX}`);
+      } catch (_) {
+        /* expected: only cycle graph roots have manifest evidence */
+      }
+    }
+
+    for (const [manifestDir, currentGeneration] of staleCycleManifestGenerations) {
+      try {
+        await deleteStaleCycleManifestGenerations(
+          localFs,
+          manifestDir,
+          currentGeneration,
+        );
+        logger.debug(`${LOG_PREFIX_MDX_LOADER} Deleted stale cycle manifest generations`, {
+          manifestDir,
+          currentGeneration,
+        });
+      } catch (error) {
+        if (!isNotFoundError(error)) {
+          logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to delete stale cycle manifests`, {
+            manifestDir,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
     }
   };
@@ -515,19 +694,47 @@ function extractNormalizedCachedModulePath(cachedKey: string): string {
 }
 
 export async function clearESMDiskCache(): Promise<void> {
+  const currentCycleGeneration = advanceAllCycleManifestGenerations();
   const cacheDir = getMdxEsmCacheDir();
+  const cycleManifestCacheDir = getCycleManifestCacheRootDir();
   const fs = getLocalFs();
+  cycleManifestSources.clear();
 
   try {
     // Remove entire cache directory and recreate it
     // This handles nested project directories such as customer/local-main/
     await fs.remove(cacheDir, { recursive: true });
-    await fs.mkdir(cacheDir, { recursive: true });
-    logger.debug(`${LOG_PREFIX_MDX_LOADER} Cleared ESM disk cache`);
   } catch (error) {
     if (!isNotFoundError(error)) {
       logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to clear ESM disk cache`, error);
     }
+  }
+
+  try {
+    for await (const entry of fs.readDir(cycleManifestCacheDir)) {
+      if (!entry.isDirectory) continue;
+      await deleteStaleCycleManifestGenerations(
+        fs,
+        join(cycleManifestCacheDir, entry.name),
+        currentCycleGeneration,
+      );
+    }
+    try {
+      await fs.remove(cycleManifestCacheDir);
+    } catch (_) {
+      /* expected: a post-clear generation keeps the cache root non-empty */
+    }
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to clear cycle manifest cache`, error);
+    }
+  }
+
+  try {
+    await fs.mkdir(cacheDir, { recursive: true });
+    logger.debug(`${LOG_PREFIX_MDX_LOADER} Cleared ESM disk cache`);
+  } catch (error) {
+    logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to recreate ESM disk cache`, error);
   }
 }
 
@@ -558,9 +765,17 @@ export async function clearMdxEsmCacheNamespace(
     }
   }
 
+  const manifestGenerations = new Map(
+    [...affectedCacheDirs].map((cacheDir) => {
+      const manifestDir = getCycleManifestCacheDir(cacheDir);
+      return [manifestDir, advanceCycleManifestGeneration(manifestDir)] as const;
+    }),
+  );
+
   for (const cacheDir of affectedCacheDirs) {
     modulePathCaches.delete(cacheDir);
     modulePathCacheLoaded.delete(cacheDir);
+    cycleManifestSources.delete(cacheDir);
   }
 
   for (const key of Array.from(verifiedModuleDeps.keys())) {
@@ -598,6 +813,23 @@ export async function clearMdxEsmCacheNamespace(
         cacheDir,
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+  }
+
+  for (const [manifestDir, currentGeneration] of manifestGenerations) {
+    try {
+      await deleteStaleCycleManifestGenerations(
+        getLocalFs(),
+        manifestDir,
+        currentGeneration,
+      );
+    } catch (error) {
+      if (!isNotFoundError(error)) {
+        logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to remove cycle manifest namespace`, {
+          manifestDir,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 }

--- a/src/transforms/mdx/esm-module-loader/cycle-manifest-lifecycle.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cycle-manifest-lifecycle.test.ts
@@ -1,0 +1,24 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  advanceAllCycleManifestGenerations,
+  advanceCycleManifestGeneration,
+  getCycleManifestGeneration,
+} from "./cycle-manifest-lifecycle.ts";
+
+describe("cycle-manifest lifecycle", () => {
+  it("advances a full clear beyond every selectively invalidated namespace", () => {
+    const firstDir = `/cache/${crypto.randomUUID()}/first`;
+    const secondDir = `/cache/${crypto.randomUUID()}/second`;
+    advanceCycleManifestGeneration(firstDir);
+    const highestSelectiveGeneration = advanceCycleManifestGeneration(firstDir);
+    advanceCycleManifestGeneration(secondDir);
+
+    const fullClearGeneration = advanceAllCycleManifestGenerations();
+
+    assertEquals(fullClearGeneration > highestSelectiveGeneration, true);
+    assertEquals(getCycleManifestGeneration(firstDir), fullClearGeneration);
+    assertEquals(getCycleManifestGeneration(secondDir), fullClearGeneration);
+  });
+});

--- a/src/transforms/mdx/esm-module-loader/cycle-manifest-lifecycle.ts
+++ b/src/transforms/mdx/esm-module-loader/cycle-manifest-lifecycle.ts
@@ -1,0 +1,56 @@
+const generations = new Map<string, number>();
+let globalGeneration = 0;
+const dateNow = Date.now;
+
+function freshGenerationAfter(generation: number): number {
+  return Math.max(generation + 1, dateNow() * 1_000);
+}
+
+/** Current in-process invalidation generation for one manifest namespace. */
+export function getCycleManifestGeneration(manifestDir: string): number {
+  const existing = generations.get(manifestDir);
+  if (existing !== undefined) return existing;
+  generations.set(manifestDir, globalGeneration);
+  return globalGeneration;
+}
+
+/** Adopt persisted state once, then reject artifacts invalidated in this process. */
+export function isCurrentCycleManifestGeneration(
+  manifestDir: string,
+  artifactGeneration: number,
+): boolean {
+  const existing = generations.get(manifestDir);
+  if (existing !== undefined) return artifactGeneration === existing;
+
+  const currentGeneration = Math.max(globalGeneration, artifactGeneration);
+  generations.set(manifestDir, currentGeneration);
+  return artifactGeneration === currentGeneration;
+}
+
+/** Advance synchronously so transforms started after invalidation get a new generation. */
+export function advanceCycleManifestGeneration(manifestDir: string): number {
+  const existing = generations.get(manifestDir);
+  const generation = existing === undefined ? freshGenerationAfter(globalGeneration) : existing + 1;
+  generations.set(manifestDir, generation);
+  return generation;
+}
+
+/** Invalidate every manifest transaction created before a full cache clear. */
+export function advanceAllCycleManifestGenerations(): number {
+  for (const generation of generations.values()) {
+    if (generation > globalGeneration) globalGeneration = generation;
+  }
+  globalGeneration = freshGenerationAfter(globalGeneration);
+  for (const manifestDir of generations.keys()) generations.set(manifestDir, globalGeneration);
+  return globalGeneration;
+}
+
+/** Extract the generation prefix from a graph directory name. */
+export function parseCycleManifestGeneration(name: string): number | undefined {
+  const separator = name.indexOf("-");
+  if (separator <= 0) return undefined;
+  const prefix = name.slice(0, separator);
+  if (!/^(?:0|[1-9][0-9]*)$/.test(prefix)) return undefined;
+  const generation = Number(prefix);
+  return Number.isSafeInteger(generation) ? generation : undefined;
+}


### PR DESCRIPTION
## Description

- resolves static and dynamic module-cycle edges through immutable, graph-scoped artifacts instead of mutable authored-path aliases
- validates manifest entries and every bound artifact before cache reuse, rebuilding on missing or corrupt evidence
- plans and memoizes the dependency graph so converging SCCs preserve namespace/live-binding identity without exponential work or deadlock
- tracks cycle members and lifecycle generations so watcher invalidation and cache clears retire stale graphs without deleting fresh publications

Static closing edges resolve directly to the immutable target namespace. Dynamic closing edges use a manifest entry that resolves the same target namespace. Cycle-bound JavaScript keeps native artifact-relative import.meta behavior.

## Related Issue(s)

- Relates to https://github.com/veryfront/veryfront-issue-inbox/issues/114
- Investigation start: https://github.com/veryfront/veryfront-issue-inbox/issues/114#issuecomment-5318857606

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [x] Test update

## Red-Green TDD Evidence

Regression tests were added before each implementation correction for concurrent generation cross-wiring, exact namespace/default/live-binding behavior, corrupt and incomplete manifests, cache-member invalidation, converging SCC deadlocks and duplicate work, full/namespace clear races, and rapid sequential invalidation cleanup.

## Verification

- focused cycle/cache matrix: 15 tests, 126 steps, 0 failures
- adjacent module-loader matrix: 56 tests, 867 steps, 0 failures
- pre-push unit suite: 3,924 tests, 30,037 steps, 0 failures, 1 existing ignored test
- pinned Deno 2.7.7 lint:ci: green
- pinned Deno 2.7.7 CI-equivalent typecheck and generated-artifact checks: green
- independent exact-tree review: approved with no actionable findings

## Checklist

- [x] Documentation is not required because this changes internal module-cache behavior without changing public APIs
- [x] I have added tests that prove my fix is effective or that my feature works