### PR TITLE
fix: expose authenticated HTTP module redirects

### DIFF
--- a/src/security/http/outbound-fetch.test.ts
+++ b/src/security/http/outbound-fetch.test.ts
@@ -151,6 +151,103 @@ describe("guardedOutboundFetch", () => {
     ]);
   });
 
+  it("reports followed redirect hops to the host caller", async () => {
+    const redirects: Array<{ status: number; fromUrl: string; toUrl: string }> = [];
+    const fetchImpl: typeof fetch = (input) => {
+      const url = String(input);
+      if (url.endsWith("/start")) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://93.184.216.35/auth" },
+          }),
+        );
+      }
+      if (url.endsWith("/auth")) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 307,
+            headers: { location: "https://93.184.216.36/sign-in" },
+          }),
+        );
+      }
+      return Promise.resolve(new Response("sign in"));
+    };
+    const boundary = createTestBoundary(fetchImpl);
+
+    const response = await boundary.guardedFetch(
+      "https://93.184.216.34/start",
+      undefined,
+      {
+        onRedirect({ status, fromUrl, toUrl }) {
+          redirects.push({
+            status,
+            fromUrl: fromUrl.href,
+            toUrl: toUrl.href,
+          });
+        },
+      },
+    );
+
+    assertEquals(await response.text(), "sign in");
+    assertEquals(redirects, [
+      {
+        status: 302,
+        fromUrl: "https://93.184.216.34/start",
+        toUrl: "https://93.184.216.35/auth",
+      },
+      {
+        status: 307,
+        fromUrl: "https://93.184.216.35/auth",
+        toUrl: "https://93.184.216.36/sign-in",
+      },
+    ]);
+  });
+
+  it("does not report a redirect that the egress guard blocks", async () => {
+    const redirects: string[] = [];
+    let fetchCalls = 0;
+
+    await assertRejects(
+      () =>
+        guardedEgressFetch("https://public.example/start", undefined, {
+          fetchImpl: () => {
+            fetchCalls++;
+            return Promise.resolve(
+              new Response(null, {
+                status: 302,
+                headers: { location: "https://private.example/sign-in" },
+              }),
+            );
+          },
+          pinnedFetch: (_url, _addresses, _init) => {
+            fetchCalls++;
+            return Promise.resolve(
+              new Response(null, {
+                status: 302,
+                headers: { location: "https://private.example/sign-in" },
+              }),
+            );
+          },
+          onRedirect({ toUrl }) {
+            redirects.push(toUrl.href);
+          },
+          options: {
+            resolveHost(hostname) {
+              return Promise.resolve([
+                hostname === "private.example" ? "10.0.0.8" : "93.184.216.34",
+              ]);
+            },
+          },
+        }),
+      WorkerEgressBlockedError,
+      "blocked for host: private.example",
+    );
+
+    assertEquals(fetchCalls, 1);
+    assertEquals(redirects, []);
+  });
+
   it("preserves Request input semantics for origin-bound provider transports", async () => {
     let captured: Request | undefined;
     const fetchImpl: typeof fetch = async (input, init) => {

--- a/src/security/http/outbound-fetch.test.ts
+++ b/src/security/http/outbound-fetch.test.ts
@@ -248,6 +248,45 @@ describe("guardedOutboundFetch", () => {
     assertEquals(redirects, []);
   });
 
+  it("cancels the destination response when a redirect observer fails", async () => {
+    let cancelledBodies = 0;
+    let fetchCalls = 0;
+    const boundary = createTestBoundary((input) => {
+      fetchCalls++;
+      if (String(input).endsWith("/start")) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://93.184.216.35/final" },
+          }),
+        );
+      }
+      return Promise.resolve(
+        new Response(
+          new ReadableStream({
+            cancel() {
+              cancelledBodies++;
+            },
+          }),
+        ),
+      );
+    });
+
+    await assertRejects(
+      () =>
+        boundary.guardedFetch("https://93.184.216.34/start", undefined, {
+          onRedirect() {
+            throw new Error("observer failed");
+          },
+        }),
+      Error,
+      "observer failed",
+    );
+
+    assertEquals(fetchCalls, 2);
+    assertEquals(cancelledBodies, 1);
+  });
+
   it("preserves Request input semantics for origin-bound provider transports", async () => {
     let captured: Request | undefined;
     const fetchImpl: typeof fetch = async (input, init) => {

--- a/src/security/http/outbound-fetch.ts
+++ b/src/security/http/outbound-fetch.ts
@@ -13,6 +13,7 @@ import {
   WorkerEgressBlockedError,
   type WorkerEgressFetch,
   type WorkerEgressPinnedFetch,
+  type WorkerEgressRedirect,
 } from "#veryfront/security/sandbox/worker-egress-guard.ts";
 
 export const HOST_INTERNAL_EGRESS_OVERRIDE_ENV = "VERYFRONT_HOST_ALLOW_INTERNAL_EGRESS";
@@ -26,6 +27,8 @@ export class OutboundRequestBlockedError extends Error {
 export interface GuardedOutboundFetchOptions {
   /** Additional operator-owned URL policy, applied to every redirect hop. */
   authorizeUrl?: (url: URL) => void | Promise<void>;
+  /** Observe each redirect after its guarded destination request succeeds. */
+  onRedirect?: (redirect: WorkerEgressRedirect) => void | Promise<void>;
 }
 
 /** Host-owned transport primitives used after outbound policy validation. */
@@ -92,6 +95,7 @@ async function fetchWithHostTransport(
       }
       await options.authorizeUrl?.(url);
     },
+    onRedirect: options.onRedirect,
     options: {
       allowInternalEgress: allowInternalEgress ||
         isInternalEgressOverrideEnabled(getHostEnv(HOST_INTERNAL_EGRESS_OVERRIDE_ENV)),

--- a/src/security/sandbox/worker-egress-guard.ts
+++ b/src/security/sandbox/worker-egress-guard.ts
@@ -1114,6 +1114,13 @@ export type WorkerEgressPinnedFetch = (
   init: RequestInit,
 ) => Promise<Response>;
 
+/** Redirect hop whose guarded destination request returned a response. */
+export interface WorkerEgressRedirect {
+  status: number;
+  fromUrl: URL;
+  toUrl: URL;
+}
+
 /** Dependencies for {@link guardedEgressFetch} (injectable for tests). */
 export interface GuardedEgressFetchDeps {
   /** Underlying fetch implementation (defaults to the global `fetch`). */
@@ -1130,6 +1137,8 @@ export interface GuardedEgressFetchDeps {
    * redirect destination before a connection is opened.
    */
   authorizeUrl?: (url: URL) => void | Promise<void>;
+  /** Observe each redirect after its guarded destination request succeeds. */
+  onRedirect?: (redirect: WorkerEgressRedirect) => void | Promise<void>;
   /** Captured runtime primitives used to establish the DNS-pinned tunnel. */
   runtime?: Partial<PinnedEgressRuntime>;
 }
@@ -1163,6 +1172,7 @@ export async function guardedEgressFetch(
   let resolvedRuntime: PinnedEgressRuntime | undefined;
   const getRuntime = () => resolvedRuntime ??= getPinnedEgressRuntime(deps.runtime);
   let didRedirect = false;
+  let pendingRedirect: WorkerEgressRedirect | undefined;
 
   const requestedRedirect: RequestRedirect = init?.redirect ??
     (input instanceof Request ? input.redirect : "follow");
@@ -1283,6 +1293,17 @@ export async function guardedEgressFetch(
       }
     }
 
+    if (pendingRedirect) {
+      const followedRedirect = pendingRedirect;
+      pendingRedirect = undefined;
+      try {
+        await deps.onRedirect?.(followedRedirect);
+      } catch (error) {
+        await response.body?.cancel().catch(() => undefined);
+        throw error;
+      }
+    }
+
     if (!REDIRECT_STATUSES.has(response.status)) {
       Object.defineProperties(response, {
         url: { configurable: true, enumerable: true, value: url },
@@ -1319,6 +1340,11 @@ export async function guardedEgressFetch(
         `Worker network egress blocked: redirect to non-http(s) scheme ${nextUrl.protocol}`,
       );
     }
+    pendingRedirect = {
+      status: response.status,
+      fromUrl: parsedUrl,
+      toUrl: nextUrl,
+    };
     // Cross-origin redirect: strip credential-bearing headers, matching the
     // platform fetch this guard replaces, so a redirect target cannot receive
     // the caller's Authorization/Cookie.

--- a/src/transforms/esm/http-cache-helpers.ts
+++ b/src/transforms/esm/http-cache-helpers.ts
@@ -48,6 +48,7 @@ const URLHostnameGet = ObjectGetOwnPropertyDescriptor(
   IntrinsicURL.prototype,
   "hostname",
 )!.get!;
+const URLOriginGet = ObjectGetOwnPropertyDescriptor(IntrinsicURL.prototype, "origin")!.get!;
 const URLPathnameGet = ObjectGetOwnPropertyDescriptor(
   IntrinsicURL.prototype,
   "pathname",
@@ -73,6 +74,10 @@ const queryTextEncoder = new TextEncoder();
 
 function getURLHostname(url: URL): string {
   return ReflectApply(URLHostnameGet, url, []);
+}
+
+function getURLOrigin(url: URL): string {
+  return ReflectApply(URLOriginGet, url, []);
 }
 
 function getURLPathname(url: URL): string {
@@ -554,6 +559,30 @@ export function isCanonicalReactEsmUrl(rawUrl: string): boolean {
 }
 
 /**
+ * Build a bounded redirect destination for HTTP module diagnostics.
+ *
+ * Arbitrary paths can contain credentials, so neutral redirects expose only
+ * their origin. The known interactive sign-in route is reduced to its
+ * canonical first segment before it is retained.
+ */
+export function sanitizeHttpModuleRedirectDestination(
+  rawUrl: string,
+): { url: string; isAuthentication: boolean } {
+  try {
+    const parsed = new IntrinsicURL(rawUrl);
+    const origin = getURLOrigin(parsed);
+    const pathname = getURLPathname(parsed);
+    const isAuthentication = pathname === "/sign-in" || stringStartsWith(pathname, "/sign-in/");
+    return {
+      url: isAuthentication ? `${origin}/sign-in` : origin,
+      isAuthentication,
+    };
+  } catch (_) {
+    return { url: "[invalid-url]", isAuthentication: false };
+  }
+}
+
+/**
  * Diagnostic for an HTTP module fetch that answered with HTML.
  *
  * A followed redirect takes precedence because the final HTML belongs to the
@@ -565,7 +594,7 @@ export function isCanonicalReactEsmUrl(rawUrl: string): boolean {
  */
 export function describeHtmlModuleResponse(
   rawUrl: string,
-  redirect?: { status: number; url: string },
+  redirect?: { status: number; url: string; isAuthentication: boolean },
 ): string {
   let hostname = "";
   let pathname = "";
@@ -579,9 +608,12 @@ export function describeHtmlModuleResponse(
 
   const received = `Received HTML instead of JavaScript from ${rawUrl}.`;
   if (redirect) {
+    const instruction = redirect.isAuthentication
+      ? "Verify that the module endpoint is accessible without interactive authentication."
+      : "Verify that the redirect destination serves a JavaScript module.";
     return `${received} The upstream redirected the module request with HTTP ${redirect.status} ` +
       `to ${redirect.url} before returning HTML. ` +
-      "Verify that the module endpoint is accessible without interactive authentication.";
+      instruction;
   }
   if (hostname === "esm.sh") {
     return `${received} The package may not exist or failed to build on esm.sh.`;

--- a/src/transforms/esm/http-cache-helpers.ts
+++ b/src/transforms/esm/http-cache-helpers.ts
@@ -556,12 +556,17 @@ export function isCanonicalReactEsmUrl(rawUrl: string): boolean {
 /**
  * Diagnostic for an HTTP module fetch that answered with HTML.
  *
- * Only esm.sh gets the "package failed to build" explanation. For any other
- * host, direct the reader to verify that the import resolves to JavaScript.
- * A path starting with "/@/" is the "@/" project alias in absolute form, so it
- * gets a specific alias-resolution instruction.
+ * A followed redirect takes precedence because the final HTML belongs to the
+ * redirect destination, not the authored module URL. Otherwise, only esm.sh
+ * gets the "package failed to build" explanation. For any other host, direct
+ * the reader to verify that the import resolves to JavaScript. A path starting
+ * with "/@/" is the "@/" project alias in absolute form, so it gets a specific
+ * alias-resolution instruction.
  */
-export function describeHtmlModuleResponse(rawUrl: string): string {
+export function describeHtmlModuleResponse(
+  rawUrl: string,
+  redirect?: { status: number; url: string },
+): string {
   let hostname = "";
   let pathname = "";
   try {
@@ -573,6 +578,11 @@ export function describeHtmlModuleResponse(rawUrl: string): string {
   }
 
   const received = `Received HTML instead of JavaScript from ${rawUrl}.`;
+  if (redirect) {
+    return `${received} The upstream redirected the module request with HTTP ${redirect.status} ` +
+      `to ${redirect.url} before returning HTML. ` +
+      "Verify that the module endpoint is accessible without interactive authentication.";
+  }
   if (hostname === "esm.sh") {
     return `${received} The package may not exist or failed to build on esm.sh.`;
   }

--- a/src/transforms/esm/http-cache.test.ts
+++ b/src/transforms/esm/http-cache.test.ts
@@ -1555,7 +1555,7 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
 
   it("reports an authentication redirect before an HTTP module returns HTML", async () => {
     const moduleUrl = "https://93.184.216.34/@/components/ResponsiveImage";
-    const signInUrl = "https://93.184.216.35/sign-in?access_token=super-secret";
+    const signInUrl = "https://93.184.216.35/sign-in/ONE_TIME_CODE?access_token=super-secret";
     const fetchedUrls: string[] = [];
     const mockFetch = ((input: RequestInfo | URL) => {
       const url = input instanceof Request
@@ -1592,6 +1592,7 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
       assertEquals(fetchedUrls, [moduleUrl, signInUrl]);
       assertInstanceOf(error, Error);
       assert(!error.message.includes("super-secret"));
+      assert(!error.message.includes("ONE_TIME_CODE"));
       assertEquals(
         error.message,
         `Received HTML instead of JavaScript from ${moduleUrl}. ` +
@@ -1600,6 +1601,74 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
           "Verify that the module endpoint is accessible without interactive authentication.",
       );
     });
+  });
+
+  it("redacts redirect paths and reserves authentication wording for sign-in", async () => {
+    const moduleUrl = "https://93.184.216.34/components/RedirectedModule";
+    const cases = [
+      {
+        name: "moved module",
+        status: 301,
+        redirectUrl: "https://93.184.216.35/moved/module.js",
+        secrets: [] as string[],
+      },
+      {
+        name: "path credential",
+        status: 302,
+        redirectUrl: "https://93.184.216.35/magic/ONE_TIME_CODE?access_token=query-secret",
+        secrets: ["ONE_TIME_CODE", "query-secret"],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const mockFetch = ((input: RequestInfo | URL) => {
+        const url = input instanceof Request
+          ? input.url
+          : input instanceof URL
+          ? input.href
+          : String(input);
+        if (url === moduleUrl) {
+          return Promise.resolve(
+            new Response(null, {
+              status: testCase.status,
+              headers: { location: testCase.redirectUrl },
+            }),
+          );
+        }
+        if (url === testCase.redirectUrl) {
+          return Promise.resolve(
+            new Response("<!doctype html><title>Not a module</title>", {
+              headers: { "content-type": "text/html;charset=utf-8" },
+            }),
+          );
+        }
+        throw new Error(`Unexpected fetch to ${url}`);
+      }) as typeof fetch;
+
+      await withIsolatedHttpCache(
+        `vf-esm-neutral-redirect-${testCase.name}-`,
+        mockFetch,
+        async (tempDir) => {
+          const error = await assertRejects(
+            () => cacheModuleToLocal(moduleUrl, tempDir),
+            Error,
+          );
+
+          assertInstanceOf(error, Error);
+          for (const secret of testCase.secrets) {
+            assert(!error.message.includes(secret));
+          }
+          assert(!error.message.includes("interactive authentication"));
+          assertEquals(
+            error.message,
+            `Received HTML instead of JavaScript from ${moduleUrl}. ` +
+              `The upstream redirected the module request with HTTP ${testCase.status} to ` +
+              "https://93.184.216.35 before returning HTML. " +
+              "Verify that the redirect destination serves a JavaScript module.",
+          );
+        },
+      );
+    }
   });
 
   it("bounds transient failure attempts and cancels every response body", async () => {

--- a/src/transforms/esm/http-cache.test.ts
+++ b/src/transforms/esm/http-cache.test.ts
@@ -1553,6 +1553,55 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
     });
   });
 
+  it("reports an authentication redirect before an HTTP module returns HTML", async () => {
+    const moduleUrl = "https://93.184.216.34/@/components/ResponsiveImage";
+    const signInUrl = "https://93.184.216.35/sign-in?access_token=super-secret";
+    const fetchedUrls: string[] = [];
+    const mockFetch = ((input: RequestInfo | URL) => {
+      const url = input instanceof Request
+        ? input.url
+        : input instanceof URL
+        ? input.href
+        : String(input);
+      fetchedUrls.push(url);
+
+      if (url === moduleUrl) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: signInUrl },
+          }),
+        );
+      }
+      if (url === signInUrl) {
+        return Promise.resolve(
+          new Response("<!doctype html><title>Sign in</title>", {
+            headers: { "content-type": "text/html;charset=utf-8" },
+          }),
+        );
+      }
+      throw new Error(`Unexpected fetch to ${url}`);
+    }) as typeof fetch;
+
+    await withIsolatedHttpCache("vf-esm-auth-redirect-", mockFetch, async (tempDir) => {
+      const error = await assertRejects(
+        () => cacheModuleToLocal(moduleUrl, tempDir),
+        Error,
+      );
+
+      assertEquals(fetchedUrls, [moduleUrl, signInUrl]);
+      assertInstanceOf(error, Error);
+      assert(!error.message.includes("super-secret"));
+      assertEquals(
+        error.message,
+        `Received HTML instead of JavaScript from ${moduleUrl}. ` +
+          "The upstream redirected the module request with HTTP 302 to " +
+          "https://93.184.216.35/sign-in before returning HTML. " +
+          "Verify that the module endpoint is accessible without interactive authentication.",
+      );
+    });
+  });
+
   it("bounds transient failure attempts and cancels every response body", async () => {
     let fetchCount = 0;
     let cancelledBodies = 0;

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -180,6 +180,7 @@ async function publishHttpBundleGeneration<T>(
 interface HttpModuleFetchResult {
   code: string;
   contentType: string;
+  redirect?: { status: number; url: string };
 }
 
 function terminalHttpModuleFetchError(
@@ -230,6 +231,7 @@ async function fetchHttpModuleAttempt(
   attempt: number,
 ): Promise<HttpModuleFetchResult> {
   let response: Response | undefined;
+  let redirect: HttpModuleFetchResult["redirect"];
 
   try {
     const startedAt = performance.now();
@@ -237,6 +239,13 @@ async function fetchHttpModuleAttempt(
       headers: { "user-agent": "Mozilla/5.0 Veryfront/1.0" },
       signal,
       redirect: "follow",
+    }, {
+      onRedirect(hop) {
+        redirect = {
+          status: hop.status,
+          url: sanitizeUrlForSpan(hop.toUrl.href),
+        };
+      },
     });
 
     const duration = Math.round(performance.now() - startedAt);
@@ -262,6 +271,7 @@ async function fetchHttpModuleAttempt(
         signal,
       ),
       contentType: response.headers.get("content-type") ?? "",
+      redirect,
     };
   } catch (error) {
     if (
@@ -593,10 +603,12 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
         {
           url: safeUrl,
           contentType,
+          redirectStatus: fetchedModule.redirect?.status,
+          redirectUrl: fetchedModule.redirect?.url,
         },
       );
       throw BUNDLE_ERROR.create({
-        detail: describeHtmlModuleResponse(safeUrl),
+        detail: describeHtmlModuleResponse(safeUrl, fetchedModule.redirect),
       });
     }
 

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -62,6 +62,7 @@ import {
   isHttpUrl,
   normalizeHttpUrl,
   prepareHttpCacheRequestOptions,
+  sanitizeHttpModuleRedirectDestination,
   type SetLike,
 } from "./http-cache-helpers.ts";
 import { extractBundleDeps, validateBundleDepsExist } from "./bundle-deps-validator.ts";
@@ -180,7 +181,7 @@ async function publishHttpBundleGeneration<T>(
 interface HttpModuleFetchResult {
   code: string;
   contentType: string;
-  redirect?: { status: number; url: string };
+  redirect?: { status: number; url: string; isAuthentication: boolean };
 }
 
 function terminalHttpModuleFetchError(
@@ -241,9 +242,10 @@ async function fetchHttpModuleAttempt(
       redirect: "follow",
     }, {
       onRedirect(hop) {
+        const destination = sanitizeHttpModuleRedirectDestination(hop.toUrl.href);
         redirect = {
           status: hop.status,
-          url: sanitizeUrlForSpan(hop.toUrl.href),
+          ...destination,
         };
       },
     });


### PR DESCRIPTION
## Outcome

Surface the deterministic authentication redirect that precedes an HTTP module HTML response. The loader now reports the last fully admitted redirect status and a bounded destination instead of misclassifying this failure as an esm.sh build or alias-resolution problem.

This is intentionally diagnostic-only. It does not retry the redirect, weaken endpoint authentication, or claim to restore the affected project render.

## RED → GREEN

- RED: a module request returning 302 to a sign-in URL and then HTML produced the old generic alias diagnostic.
- GREEN: the error now identifies HTTP 302 and the canonical sign-in destination, with arbitrary path, query, fragment, and userinfo data removed.
- RED: ordinary redirects were mislabeled as interactive authentication and credential-bearing path segments reached diagnostics.
- GREEN: only canonical /sign-in routes receive authentication guidance; all other destinations reduce to their origin and receive neutral JavaScript-module guidance.
- RED: a public redirect into a private DNS address notified the observer before the egress guard blocked it.
- GREEN: observers see only redirects whose guarded destination request returned a response.
- Regression: a throwing observer preserves its error and cancels the destination response body exactly once.

## Safety

- Redirect following and retry policy are unchanged.
- Every destination still passes caller authorization and egress validation.
- Cross-origin credentials are still stripped before following.
- Logged and public redirect metadata omits untrusted path, query, fragment, and userinfo data.

## Verification

- Focused redirect, egress, and HTTP-cache matrix: 5 tests / 136 steps.
- Full pre-push unit suite: 3,929 tests / 30,094 steps, plus cwd suites.
- Deno check, lint, format, diff, anti-slop, and test-typecheck baselines pass.
- CI-pinned Deno 2.7.7 API docs: 44 files current.
- Public docs, error docs, generated artifact, release, and CI workflow checks pass.
- Independent Spec and Standards reviews approve exact head b19240c8e.

## Follow-up

The project owner still needs to replace the public-domain ResponsiveImage import with an authenticated/content-addressed registry source. Issue #240 remains the structural product fix.

Related: veryfront/veryfront-issue-inbox#177
Related: veryfront/veryfront-issue-inbox#240